### PR TITLE
feat(mcp): add optional asciinema recording to terminal sessions

### DIFF
--- a/src/Hex1b.McpServer/TerminalSessionManager.cs
+++ b/src/Hex1b.McpServer/TerminalSessionManager.cs
@@ -24,6 +24,7 @@ public sealed class TerminalSessionManager : IAsyncDisposable
     /// <param name="environment">Additional environment variables.</param>
     /// <param name="width">Terminal width in columns.</param>
     /// <param name="height">Terminal height in rows.</param>
+    /// <param name="asciinemaFilePath">Optional path to save an asciinema recording.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The created terminal session.</returns>
     public async Task<TerminalSession> StartSessionAsync(
@@ -33,10 +34,11 @@ public sealed class TerminalSessionManager : IAsyncDisposable
         Dictionary<string, string>? environment = null,
         int width = 80,
         int height = 24,
+        string? asciinemaFilePath = null,
         CancellationToken ct = default)
     {
         var id = GenerateSessionId();
-        return await StartSessionAsync(id, command, arguments, workingDirectory, environment, width, height, ct);
+        return await StartSessionAsync(id, command, arguments, workingDirectory, environment, width, height, asciinemaFilePath, ct);
     }
 
     /// <summary>
@@ -49,6 +51,7 @@ public sealed class TerminalSessionManager : IAsyncDisposable
     /// <param name="environment">Additional environment variables.</param>
     /// <param name="width">Terminal width in columns.</param>
     /// <param name="height">Terminal height in rows.</param>
+    /// <param name="asciinemaFilePath">Optional path to save an asciinema recording.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The created terminal session.</returns>
     /// <exception cref="InvalidOperationException">A session with the given ID already exists.</exception>
@@ -60,6 +63,7 @@ public sealed class TerminalSessionManager : IAsyncDisposable
         Dictionary<string, string>? environment = null,
         int width = 80,
         int height = 24,
+        string? asciinemaFilePath = null,
         CancellationToken ct = default)
     {
         if (_disposed)
@@ -73,6 +77,7 @@ public sealed class TerminalSessionManager : IAsyncDisposable
             environment,
             width,
             height,
+            asciinemaFilePath,
             ct);
 
         if (!_sessions.TryAdd(id, session))
@@ -121,7 +126,8 @@ public sealed class TerminalSessionManager : IAsyncDisposable
             StartedAt = s.StartedAt,
             HasExited = s.HasExited,
             ExitCode = s.HasExited ? s.ExitCode : null,
-            ProcessId = s.ProcessId
+            ProcessId = s.ProcessId,
+            AsciinemaFilePath = s.AsciinemaFilePath
         }).ToList();
     }
 
@@ -283,4 +289,9 @@ public class SessionInfo
     /// The process ID of the child process.
     /// </summary>
     public required int ProcessId { get; init; }
+
+    /// <summary>
+    /// The path to the asciinema recording file, if recording is enabled.
+    /// </summary>
+    public string? AsciinemaFilePath { get; init; }
 }

--- a/src/Hex1b.McpServer/Tools/ToolResults.cs
+++ b/src/Hex1b.McpServer/Tools/ToolResults.cs
@@ -30,6 +30,10 @@ public class StartTerminalResult
 
     [JsonPropertyName("height")]
     public required int Height { get; init; }
+
+    [JsonPropertyName("asciinemaFilePath")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AsciinemaFilePath { get; init; }
 }
 
 public class StopTerminalResult
@@ -48,6 +52,10 @@ public class StopTerminalResult
 
     [JsonPropertyName("exitCode")]
     public int? ExitCode { get; init; }
+
+    [JsonPropertyName("asciinemaFilePath")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AsciinemaFilePath { get; init; }
 }
 
 public class RemoveSessionResult
@@ -223,4 +231,8 @@ public class TerminalSessionInfo
     [JsonPropertyName("runningFor")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public TimeSpan? RunningFor { get; init; }
+
+    [JsonPropertyName("asciinemaFilePath")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? AsciinemaFilePath { get; init; }
 }


### PR DESCRIPTION
## Summary

Adds the ability to automatically record terminal sessions to asciinema format (.cast files) when starting a terminal via the MCP server.

## Changes

- Add `asciinemaFilePath` parameter to `StartBashTerminal` and `StartPwshTerminal` MCP tools
- When specified, creates an `AsciinemaRecorder` with AutoFlush enabled
- Recording path is returned in start/stop/list terminal results
- Recording is automatically flushed and saved when session is disposed

## Usage

```
StartBashTerminal(asciinemaFilePath: "/tmp/demo.cast")
```

The recording can then be uploaded with `asciinema upload` or played locally with `asciinema play`.

## Testing

Tested manually by:
1. Starting a terminal session with asciinema recording enabled
2. Running tmux, splitting panes, connecting to Star Wars telnet ASCII art
3. Stopping the session and uploading to asciinema.org

Recording demo: https://asciinema.org/a/S47VG0mArhNylFCE