### PR TITLE
Target net8.0 for Hex1b library

### DIFF
--- a/src/Hex1b/Hex1b.csproj
+++ b/src/Hex1b/Hex1b.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Changes the
   main Hex1b library to target net8.0 instead of net10.0, enabling .NET 8.0 LTS
   consumers to use the library.