### PR TITLE
Fix devcontainer prebuild failing due to Yarn GPG key expiration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+# Base image for .NET 10.0 development
+FROM mcr.microsoft.com/devcontainers/dotnet:10.0-noble
+
+# Workaround for Yarn APT repo GPG key expiration issue.
+# The base image includes Yarn apt sources which have an expired GPG key,
+# causing apt-get update to fail during devcontainer feature installation.
+# Since this project doesn't need Yarn, we remove the problematic sources.
+# See: https://github.com/devcontainers/features/issues/1543
+USER root
+RUN rm -f /etc/apt/sources.list.d/yarn.list \
+    && rm -f /usr/share/keyrings/yarn.gpg \
+    && apt-get update

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,8 +2,13 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
 {
 	"name": "Aspire",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/dotnet:10.0-noble",
+	// Using a Dockerfile to work around Yarn APT repo GPG key expiration issue.
+	// The base devcontainer image includes Yarn sources with an expired key, which
+	// causes apt-get update to fail during feature installation.
+	// See: https://github.com/devcontainers/features/issues/1543
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/features/powershell:1": {}


### PR DESCRIPTION
The base devcontainer image includes Yarn apt sources with an expired GPG key, which causes apt-get update to fail during devcontainer feature installation (e.g., docker-in-docker).

This PR switches from using the image directly to a custom Dockerfile that removes the unused Yarn apt sources before features are installed.

Fixes: https://github.com/devcontainers/features/issues/1543