### PR TITLE
Add GitHub CLI, Node.js, Python, and uv features to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,14 @@
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/features/powershell:1": {},
-		"ghcr.io/devcontainers/features/sshd:1": {}
+		"ghcr.io/devcontainers/features/sshd:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "latest",
+			"installYarnUsingApt": false
+		},
+		"ghcr.io/devcontainers/features/python:1": {},
+		"ghcr.io/astral-sh/uv:1": {}
 	},
 
 	"hostRequirements": {


### PR DESCRIPTION
Adds the following devcontainer features:
- GitHub CLI
- Node.js (latest, with installYarnUsingApt: false to avoid Yarn GPG issues)
- Python
- uv (Python package manager from Astral)