### PR TITLE
Update README to remove .NET version note

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@
 dotnet add package Hex1b
 ```
 
-> **Note**: Hex1b currently targets .NET 10.0 preview.
-
 ## 🚀 Quick Start
 
 Here's a simple "Hello World" application:


### PR DESCRIPTION
Remove note about Hex1b targeting .NET 10.0 preview.

seeing https://www.nuget.org/packages/Hex1b#dependencies-body-tab
<img width="1132" height="803" alt="image" src="https://github.com/user-attachments/assets/d223a458-18cb-440c-a770-4819725c216b" />
