### PR TITLE
fix: handle missing command in 'terminal start' to avoid IndexOutOfRangeException

### DIFF
--- a/src/Hex1b.Tool/Commands/Terminal/TerminalHostCommand.cs
+++ b/src/Hex1b.Tool/Commands/Terminal/TerminalHostCommand.cs
@@ -37,7 +37,7 @@ internal sealed class TerminalHostCommand : BaseCommand
         var height = parseResult.GetValue(s_heightOption);
         var cwd = parseResult.GetValue(s_cwdOption);
         var record = parseResult.GetValue(s_recordOption);
-        var command = parseResult.GetValue(s_commandArgument) ?? ["/bin/bash"];
+        var command = parseResult.GetValue(s_commandArgument) is { Length: > 0 } cmd ? cmd : ["/bin/bash"];
 
         var config = new TerminalHostConfig
         {

--- a/src/Hex1b.Tool/Commands/Terminal/TerminalStartCommand.cs
+++ b/src/Hex1b.Tool/Commands/Terminal/TerminalStartCommand.cs
@@ -42,7 +42,7 @@ internal sealed class TerminalStartCommand : BaseCommand
         var height = parseResult.GetValue(s_heightOption);
         var cwd = parseResult.GetValue(s_cwdOption);
         var record = parseResult.GetValue(s_recordOption);
-        var command = parseResult.GetValue(s_commandArgument) ?? ["/bin/bash"];
+        var command = parseResult.GetValue(s_commandArgument) is { Length: > 0 } cmd ? cmd : ["/bin/bash"];
 
         // Build args for the host process
         var hostArgs = new List<string> { "terminal", "host", "--width", width.ToString(), "--height", height.ToString() };


### PR DESCRIPTION
## Problem

Running `hex1b terminal start` without `-- [command]` throws an `IndexOutOfRangeException`.

`System.CommandLine` returns an empty `string[]` (not `null`) when no positional argument is provided, so the `?? ["/bin/bash"]` fallback never triggers. When `command[0]` is then accessed on the empty array, it throws.

## Fix

Replace the null-coalescing check with a pattern match (`is { Length: > 0 }`) that correctly handles both null and empty arrays, defaulting to `/bin/bash` in either case.

**Files changed:**
- `src/Hex1b.Tool/Commands/Terminal/TerminalStartCommand.cs`
- `src/Hex1b.Tool/Commands/Terminal/TerminalHostCommand.cs`