### PR TITLE
Fix agent init SKILL template and --key help text

### DIFF
--- a/src/Hex1b.Tool/Commands/Agent/AgentInitCommand.cs
+++ b/src/Hex1b.Tool/Commands/Agent/AgentInitCommand.cs
@@ -114,11 +114,13 @@ internal sealed class AgentInitCommand : BaseCommand
         ## Installation
 
         ```bash
-        # Install as a local tool (recommended for repos)
-        dotnet tool install Hex1b.Tool
+        # Install as a global tool
+        dotnet tool install -g Hex1b.Tool
 
-        # Or restore if already in the tool manifest
-        dotnet tool restore
+        # Or as a local tool (requires a tool manifest)
+        dotnet new tool-manifest   # if no manifest exists yet
+        dotnet tool install --local Hex1b.Tool
+        dotnet tool restore        # to restore from an existing manifest
         ```
 
         ## Concepts
@@ -219,7 +221,7 @@ internal sealed class AgentInitCommand : BaseCommand
         dotnet hex1b keys <id> --key Enter
         dotnet hex1b keys <id> --key Tab
         dotnet hex1b keys <id> --key Escape
-        dotnet hex1b keys <id> --key ArrowUp
+        dotnet hex1b keys <id> --key UpArrow
 
         # Send key with modifiers
         dotnet hex1b keys <id> --key C --ctrl          # Ctrl+C
@@ -228,9 +230,17 @@ internal sealed class AgentInitCommand : BaseCommand
         dotnet hex1b keys <id> --key F --ctrl --shift   # Ctrl+Shift+F
         ```
 
-        Available key names: `Enter`, `Tab`, `Escape`, `Backspace`, `Spacebar`, `UpArrow`,
-        `DownArrow`, `LeftArrow`, `RightArrow`, `Home`, `End`, `PageUp`, `PageDown`, `Delete`,
-        `Insert`, `F1`–`F12`, and single letters `A`–`Z`.
+        Available key names (from the `Hex1bKey` enum, case-insensitive):
+
+        - **Letters:** `A`–`Z`
+        - **Digits:** `D0`–`D9`
+        - **Function keys:** `F1`–`F12`
+        - **Navigation:** `UpArrow`, `DownArrow`, `LeftArrow`, `RightArrow`, `Home`, `End`, `PageUp`, `PageDown`
+        - **Editing:** `Backspace`, `Delete`, `Insert`
+        - **Whitespace:** `Tab`, `Enter`, `Spacebar`
+        - **Other:** `Escape`
+        - **Punctuation:** `OemComma`, `OemPeriod`, `OemMinus`, `OemPlus`, `OemQuestion`, `Oem1`, `Oem4`, `Oem5`, `Oem6`, `Oem7`, `OemTilde`
+        - **Numpad:** `NumPad0`–`NumPad9`, `Multiply`, `Add`, `Subtract`, `Decimal`, `Divide`
 
         ## How to Send Mouse Input
 

--- a/src/Hex1b.Tool/Commands/KeysCommand.cs
+++ b/src/Hex1b.Tool/Commands/KeysCommand.cs
@@ -14,7 +14,7 @@ internal sealed class KeysCommand : BaseCommand
     private readonly TerminalClient _client;
 
     private static readonly Argument<string> s_idArgument = new("id") { Description = "Terminal ID (or prefix)" };
-    private static readonly Option<string?> s_keyOption = new("--key") { Description = "Named key (Enter, Tab, Escape, F1, ArrowUp, etc.)" };
+    private static readonly Option<string?> s_keyOption = new("--key") { Description = "Named key (Enter, Tab, Escape, F1, UpArrow, etc.)" };
     private static readonly Option<string?> s_textOption = new("--text") { Description = "Type text as keystrokes" };
     private static readonly Option<bool> s_ctrlOption = new("--ctrl") { Description = "Ctrl modifier" };
     private static readonly Option<bool> s_shiftOption = new("--shift") { Description = "Shift modifier" };


### PR DESCRIPTION
## Summary

Fixes three issues in the generated SKILL.md template from `hex1b agent init` and the `--key` option help text:

### 1. Install command missing scope flag
`dotnet tool install Hex1b.Tool` (without `--global` or `--local`) fails. Updated to show both global and local install options with proper flags.

### 2. Wrong key name in example and help text
The example used `--key ArrowUp` but the `Hex1bKey` enum value is `UpArrow`. Since key names are parsed via `Enum.TryParse<Hex1bKey>(keyName, ignoreCase: true, ...)`, `ArrowUp` would fail at runtime. Fixed in both:
- `AgentInitCommand.cs` template
- `KeysCommand.cs` `--key` option description

### 3. Incomplete key name reference
The key list only mentioned common keys. Expanded to include all `Hex1bKey` enum values: letters, digits (`D0`-`D9`), function keys, navigation, editing, whitespace, punctuation (`OemComma`, etc.), and numpad keys.