### PR TITLE
Add per-side border theming with fallback chains

### DIFF
--- a/src/Hex1b/Nodes/BorderNode.cs
+++ b/src/Hex1b/Nodes/BorderNode.cs
@@ -135,14 +135,19 @@ public sealed class BorderNode : Hex1bNode, ILayoutProvider
     public override void Render(Hex1bRenderContext context)
     {
         var theme = context.Theme;
-        var borderColor = theme.Get(BorderTheme.BorderColor);
         var titleColor = theme.Get(BorderTheme.TitleColor);
         var topLeft = theme.Get(BorderTheme.TopLeftCorner);
         var topRight = theme.Get(BorderTheme.TopRightCorner);
         var bottomLeft = theme.Get(BorderTheme.BottomLeftCorner);
         var bottomRight = theme.Get(BorderTheme.BottomRightCorner);
-        var horizontal = theme.Get(BorderTheme.HorizontalLine);
-        var vertical = theme.Get(BorderTheme.VerticalLine);
+        var topHorizontal = theme.Get(BorderTheme.TopLine);
+        var bottomHorizontal = theme.Get(BorderTheme.BottomLine);
+        var leftVertical = theme.Get(BorderTheme.LeftLine);
+        var rightVertical = theme.Get(BorderTheme.RightLine);
+        var topColor = theme.Get(BorderTheme.TopBorderColor);
+        var bottomColor = theme.Get(BorderTheme.BottomBorderColor);
+        var leftColor = theme.Get(BorderTheme.LeftBorderColor);
+        var rightColor = theme.Get(BorderTheme.RightBorderColor);
 
         var x = Bounds.X;
         var y = Bounds.Y;
@@ -152,7 +157,10 @@ public sealed class BorderNode : Hex1bNode, ILayoutProvider
         // Apply border color with global background
         var globalBg = theme.GetGlobalBackground();
         var globalBgAnsi = globalBg.IsDefault ? "" : globalBg.ToBackgroundAnsi();
-        var colorCode = $"{globalBgAnsi}{borderColor.ToForegroundAnsi()}";
+        var topColorCode = $"{globalBgAnsi}{topColor.ToForegroundAnsi()}";
+        var bottomColorCode = $"{globalBgAnsi}{bottomColor.ToForegroundAnsi()}";
+        var leftColorCode = $"{globalBgAnsi}{leftColor.ToForegroundAnsi()}";
+        var rightColorCode = $"{globalBgAnsi}{rightColor.ToForegroundAnsi()}";
         var resetToGlobal = theme.GetResetToGlobalCodes();
         
         var innerWidth = Math.Max(0, width - 2);
@@ -182,21 +190,21 @@ public sealed class BorderNode : Hex1bNode, ILayoutProvider
             var leftPadding = (innerWidth - titleToShowDisplayWidth) / 2;
             var rightPadding = innerWidth - titleToShowDisplayWidth - leftPadding;
             
-            topLine = $"{colorCode}{topLeft}" +
-                      new string(horizontal[0], leftPadding) +
-                      $"{globalBgAnsi}{titleColor.ToForegroundAnsi()}{titleToShow}{colorCode}" +
-                      new string(horizontal[0], rightPadding) +
+            topLine = $"{topColorCode}{topLeft}" +
+                      new string(topHorizontal[0], leftPadding) +
+                      $"{globalBgAnsi}{titleColor.ToForegroundAnsi()}{titleToShow}{topColorCode}" +
+                      new string(topHorizontal[0], rightPadding) +
                       $"{topRight}{resetToGlobal}";
         }
         else
         {
-            topLine = $"{colorCode}{topLeft}{new string(horizontal[0], innerWidth)}{topRight}{resetToGlobal}";
+            topLine = $"{topColorCode}{topLeft}{new string(topHorizontal[0], innerWidth)}{topRight}{resetToGlobal}";
         }
         WriteLineClipped(context, x, y, topLine);
 
         // Draw left and right borders for each row, filling inner area with background
-        var leftBorder = $"{colorCode}{vertical}{resetToGlobal}";
-        var rightBorder = $"{colorCode}{vertical}{resetToGlobal}";
+        var leftBorder = $"{leftColorCode}{leftVertical}{resetToGlobal}";
+        var rightBorder = $"{rightColorCode}{rightVertical}{resetToGlobal}";
         var innerFill = innerWidth > 0 ? $"{globalBgAnsi}{new string(' ', innerWidth)}{resetToGlobal}" : "";
         for (int row = 1; row < height - 1; row++)
         {
@@ -212,7 +220,7 @@ public sealed class BorderNode : Hex1bNode, ILayoutProvider
         // Draw bottom border
         if (height > 1)
         {
-            var bottomLine = $"{colorCode}{bottomLeft}{new string(horizontal[0], innerWidth)}{bottomRight}{resetToGlobal}";
+            var bottomLine = $"{bottomColorCode}{bottomLeft}{new string(bottomHorizontal[0], innerWidth)}{bottomRight}{resetToGlobal}";
             WriteLineClipped(context, x, y + height - 1, bottomLine);
         }
 

--- a/src/Hex1b/Theming/BorderTheme.cs
+++ b/src/Hex1b/Theming/BorderTheme.cs
@@ -28,4 +28,72 @@ public static class BorderTheme
     
     public static readonly Hex1bThemeElement<string> VerticalLine = 
         new($"{nameof(BorderTheme)}.{nameof(VerticalLine)}", () => "│");
+    
+    #region Per-Side Line Characters
+    
+    /// <summary>
+    /// Line character for the top border. Falls back to <see cref="HorizontalLine"/>.
+    /// </summary>
+    public static readonly Hex1bThemeElement<string> TopLine = 
+        new($"{nameof(BorderTheme)}.{nameof(TopLine)}", () => "─", HorizontalLine);
+    
+    /// <summary>
+    /// Line character for the bottom border. Falls back to <see cref="HorizontalLine"/>.
+    /// </summary>
+    public static readonly Hex1bThemeElement<string> BottomLine = 
+        new($"{nameof(BorderTheme)}.{nameof(BottomLine)}", () => "─", HorizontalLine);
+    
+    /// <summary>
+    /// Line character for the left border. Falls back to <see cref="VerticalLine"/>.
+    /// </summary>
+    public static readonly Hex1bThemeElement<string> LeftLine = 
+        new($"{nameof(BorderTheme)}.{nameof(LeftLine)}", () => "│", VerticalLine);
+    
+    /// <summary>
+    /// Line character for the right border. Falls back to <see cref="VerticalLine"/>.
+    /// </summary>
+    public static readonly Hex1bThemeElement<string> RightLine = 
+        new($"{nameof(BorderTheme)}.{nameof(RightLine)}", () => "│", VerticalLine);
+    
+    #endregion
+    
+    #region Per-Side Border Colors
+    
+    /// <summary>
+    /// Color for horizontal borders (top and bottom). Falls back to <see cref="BorderColor"/>.
+    /// </summary>
+    public static readonly Hex1bThemeElement<Hex1bColor> HorizontalBorderColor = 
+        new($"{nameof(BorderTheme)}.{nameof(HorizontalBorderColor)}", () => Hex1bColor.Gray, BorderColor);
+    
+    /// <summary>
+    /// Color for vertical borders (left and right). Falls back to <see cref="BorderColor"/>.
+    /// </summary>
+    public static readonly Hex1bThemeElement<Hex1bColor> VerticalBorderColor = 
+        new($"{nameof(BorderTheme)}.{nameof(VerticalBorderColor)}", () => Hex1bColor.Gray, BorderColor);
+    
+    /// <summary>
+    /// Color for the top border. Falls back to <see cref="HorizontalBorderColor"/>.
+    /// </summary>
+    public static readonly Hex1bThemeElement<Hex1bColor> TopBorderColor = 
+        new($"{nameof(BorderTheme)}.{nameof(TopBorderColor)}", () => Hex1bColor.Gray, HorizontalBorderColor);
+    
+    /// <summary>
+    /// Color for the bottom border. Falls back to <see cref="HorizontalBorderColor"/>.
+    /// </summary>
+    public static readonly Hex1bThemeElement<Hex1bColor> BottomBorderColor = 
+        new($"{nameof(BorderTheme)}.{nameof(BottomBorderColor)}", () => Hex1bColor.Gray, HorizontalBorderColor);
+    
+    /// <summary>
+    /// Color for the left border. Falls back to <see cref="VerticalBorderColor"/>.
+    /// </summary>
+    public static readonly Hex1bThemeElement<Hex1bColor> LeftBorderColor = 
+        new($"{nameof(BorderTheme)}.{nameof(LeftBorderColor)}", () => Hex1bColor.Gray, VerticalBorderColor);
+    
+    /// <summary>
+    /// Color for the right border. Falls back to <see cref="VerticalBorderColor"/>.
+    /// </summary>
+    public static readonly Hex1bThemeElement<Hex1bColor> RightBorderColor = 
+        new($"{nameof(BorderTheme)}.{nameof(RightBorderColor)}", () => Hex1bColor.Gray, VerticalBorderColor);
+    
+    #endregion
 }

--- a/src/Hex1b/Theming/Hex1bTheme.cs
+++ b/src/Hex1b/Theming/Hex1bTheme.cs
@@ -39,6 +39,10 @@ public class Hex1bTheme
         {
             return typedValue;
         }
+        if (element.Fallback != null)
+        {
+            return Get(element.Fallback);
+        }
         return element.DefaultValue();
     }
 

--- a/src/Hex1b/Theming/Hex1bThemeElement.cs
+++ b/src/Hex1b/Theming/Hex1bThemeElement.cs
@@ -7,11 +7,19 @@ public class Hex1bThemeElement<T>
 {
     public string Name { get; }
     public Func<T> DefaultValue { get; }
+    
+    /// <summary>
+    /// Optional fallback element to check before using DefaultValue.
+    /// Enables cascading theme values (e.g., TopLine falls back to HorizontalLine).
+    /// </summary>
+    public Hex1bThemeElement<T>? Fallback { get; }
 
-    public Hex1bThemeElement(string name, Func<T> defaultValue)
+    public Hex1bThemeElement(string name, Func<T> defaultValue,
+                             Hex1bThemeElement<T>? fallback = null)
     {
         Name = name;
         DefaultValue = defaultValue;
+        Fallback = fallback;
     }
 
     public override string ToString() => Name;


### PR DESCRIPTION
## Summary

Adds fallback chain support to the theming infrastructure and per-side border styling.

### Theme Infrastructure
- `Hex1bThemeElement<T>` gains an optional `Fallback` property
- `Hex1bTheme.Get<T>()` walks the fallback chain before using `DefaultValue()`
- Fully backward-compatible (existing elements have `null` fallback)

### New BorderTheme Elements (10)
**Per-side line characters** (fall back to axis elements):
- `TopLine`, `BottomLine` → `HorizontalLine`
- `LeftLine`, `RightLine` → `VerticalLine`

**Per-axis/side colors** (cascade to `BorderColor`):
- `HorizontalBorderColor`, `VerticalBorderColor` → `BorderColor`
- `TopBorderColor`, `BottomBorderColor` → `HorizontalBorderColor`
- `LeftBorderColor`, `RightBorderColor` → `VerticalBorderColor`

### Rendering
`BorderNode.Render()` reads per-side values with independent ANSI color codes per edge.

### Tests
11 new tests covering fallback chain resolution, precedence, and per-side rendering. All 3255 existing tests continue to pass.