### PR TITLE
fix: resolve 404 for dotted namespace API reference URLs

### DIFF
--- a/src/Hex1b.Website/Program.cs
+++ b/src/Hex1b.Website/Program.cs
@@ -224,14 +224,25 @@ var rewriteOptions = new RewriteOptions()
         var request = context.HttpContext.Request;
         var path = request.Path.Value ?? "";
         
-        // Skip if it's an API endpoint, WebSocket endpoint, or already has an extension
+        // Skip if it's an API endpoint or WebSocket endpoint
         if (path.StartsWith("/api") || 
             path.StartsWith("/apps") || 
             path.StartsWith("/examples") ||
-            path.StartsWith("/health") ||
-            Path.HasExtension(path))
+            path.StartsWith("/health"))
         {
             return;
+        }
+        
+        // Only skip rewriting if the path has an extension AND the file exists at that
+        // exact path. This prevents dotted namespace paths (e.g., /reference/Hex1b.Widgets)
+        // from being incorrectly treated as having a file extension and skipped.
+        if (Path.HasExtension(path))
+        {
+            var exactFile = app.Environment.WebRootFileProvider.GetFileInfo(path);
+            if (exactFile.Exists)
+            {
+                return;
+            }
         }
         
         // For clean URLs, try to find the corresponding .html file

--- a/src/content/scripts/generate-seo-files.mjs
+++ b/src/content/scripts/generate-seo-files.mjs
@@ -180,7 +180,61 @@ function scanMarkdownFiles(dir) {
     }
     
     scan(dir);
+    
+    // Ensure API reference namespace pages are always included, even when
+    // the DocGenerator hasn't run yet. These pages are listed in the VitePress
+    // sidebar config and are generated at build time by DocGenerator.
+    addSidebarReferencePages(pages, dir);
+    
     return pages;
+}
+
+/**
+ * Adds API reference namespace pages from the VitePress sidebar config
+ * if they weren't already discovered by the filesystem scan.
+ * This ensures llms.txt always includes the namespace pages regardless
+ * of whether the DocGenerator has run.
+ */
+function addSidebarReferencePages(pages, contentDir) {
+    const configPath = path.join(contentDir, '.vitepress', 'config.ts');
+    if (!fs.existsSync(configPath)) {
+        return;
+    }
+    
+    const configContent = fs.readFileSync(configPath, 'utf-8');
+    
+    // Extract sidebar links for /reference/ section
+    // Matches patterns like: { text: 'Hex1b.Widgets', link: '/reference/Hex1b.Widgets' }
+    const linkRegex = /\{\s*text:\s*['"]([^'"]+)['"]\s*,\s*link:\s*['"]\/reference\/([^'"]+)['"]\s*\}/g;
+    let match;
+    
+    // Build a set of existing reference page URLs for deduplication
+    const existingUrls = new Set(
+        pages
+            .filter(p => p.section === 'API Reference')
+            .map(p => p.url)
+    );
+    
+    while ((match = linkRegex.exec(configContent)) !== null) {
+        const title = match[1];
+        const slug = match[2];
+        const url = `${SITE_URL}/reference/${slug}`;
+        
+        if (!existingUrls.has(url)) {
+            // Try to read the generated file for a description
+            const mdPath = path.join(contentDir, 'reference', `${slug}.md`);
+            let description = '';
+            if (fs.existsSync(mdPath)) {
+                const content = fs.readFileSync(mdPath, 'utf-8');
+                description = extractDescription(content);
+            }
+            
+            // Create a synthetic page entry
+            const syntheticPath = mdPath;
+            pages.push(new DocPage(syntheticPath, title, description, 'API Reference'));
+            existingUrls.add(url);
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
## Problem

Coding agents fetching API reference pages like `https://hex1b.dev/reference/Hex1b.Widgets` get a 404.

### Root Cause

`Path.HasExtension("/reference/Hex1b.Widgets")` returns `true` because `.Widgets` is interpreted as a file extension. The URL rewrite middleware skips these paths, so `.html` is never appended → static file middleware returns 404.

This affects **all** dotted namespace reference pages (`Hex1b.Animation`, `Hex1b.Widgets.ButtonWidget`, etc.).

## Fix

### 1. URL Rewrite (`Program.cs`)
Changed the `Path.HasExtension` early-return to also verify the file actually exists on disk via `WebRootFileProvider.GetFileInfo()`. Real static assets (`.css`, `.js`, `.png`) still bypass rewriting, but dotted namespace paths now proceed through the `.html` fallback logic.

### 2. `llms.txt` (`generate-seo-files.mjs`)
The `llms.txt` file (used by agents to discover documentation) was missing all 11 API reference namespace pages. Added `addSidebarReferencePages()` which parses the VitePress sidebar config and includes any `/reference/` entries not already discovered by filesystem scan. This ensures namespace pages always appear in `llms.txt` regardless of whether DocGenerator has run.