### PR TITLE
Fix Docker build deadlock on Windows

### DIFF
--- a/src/Hex1b/DockerContainerExtensions.cs
+++ b/src/Hex1b/DockerContainerExtensions.cs
@@ -127,12 +127,34 @@ public static class DockerContainerExtensions
             startInfo.ArgumentList.Add(arg);
         }
 
-        using var process = Process.Start(startInfo)
-            ?? throw new InvalidOperationException("Failed to start docker build process.");
+        using var process = new System.Diagnostics.Process { StartInfo = startInfo, EnableRaisingEvents = true };
 
-        // Read streams before WaitForExit to avoid deadlock when buffers fill
-        var stdout = process.StandardOutput.ReadToEnd();
-        var stderr = process.StandardError.ReadToEnd();
+        // Use event-based async reading to avoid the classic deadlock where
+        // sequential ReadToEnd() calls block when both pipe buffers fill.
+        // Docker BuildKit sends all build progress to stderr; on Windows
+        // the pipe buffer is only 4 KB and overflows quickly.
+        var stdout = new System.Text.StringBuilder();
+        var stderr = new System.Text.StringBuilder();
+
+        process.OutputDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+            {
+                stdout.AppendLine(e.Data);
+            }
+        };
+
+        process.ErrorDataReceived += (_, e) =>
+        {
+            if (e.Data is not null)
+            {
+                stderr.AppendLine(e.Data);
+            }
+        };
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
         process.WaitForExit();
 
         if (process.ExitCode != 0)


### PR DESCRIPTION
## Problem

Aspire E2E CLI tests hang on Windows when `WithDockerContainer()` builds a Docker image. The root cause is a classic .NET `Process` deadlock in `BuildDockerImage()`.

## Root Cause

```csharp
var stdout = process.StandardOutput.ReadToEnd();  // BLOCKS until stdout EOF
var stderr = process.StandardError.ReadToEnd();    // Never reached if stderr buffer fills
process.WaitForExit();
```

Docker BuildKit (default in modern Docker Desktop) sends **all build progress to stderr**. On Windows, the stderr pipe buffer is only 4 KB. When Docker writes more than 4 KB to stderr:

1. `ReadToEnd()` on stdout blocks waiting for the process to close stdout
2. Docker keeps writing build output to stderr
3. The 4 KB stderr pipe buffer fills up
4. Docker blocks trying to write to stderr
5. **Deadlock**: parent waits on stdout, child blocked on stderr

The Aspire E2E Dockerfile is large (multi-stage with .NET SDK, gh CLI, Node.js, Python) producing enough build output to overflow the buffer quickly.

This works on Linux CI because Linux pipe buffers are 64 KB (16x larger).

## Fix

Replace sequential synchronous `ReadToEnd()` calls with event-based async reading using `BeginOutputReadLine()`/`BeginErrorReadLine()`. This is the same pattern used by Aspire's `ProcessUtil` class for safe process management:

- Attach `OutputDataReceived`/`ErrorDataReceived` event handlers that drain output into `StringBuilder` instances on threadpool threads
- Both streams are drained concurrently, preventing pipe buffer overflow
- `WaitForExit()` is safe because streams are being drained by background threads