### PR TITLE
Fix flaky issue-driven tests

### DIFF
--- a/tests/Hex1b.Tests/DiagnosticShellIntegrationTests.cs
+++ b/tests/Hex1b.Tests/DiagnosticShellIntegrationTests.cs
@@ -332,9 +332,8 @@ public class DiagnosticShellIntegrationTests
                 catch (OperationCanceledException) { }
             });
             
-            // Give inner terminal time to initialize, then start the diagnostic shell
-            // so it writes the initial greeting and prompt to the output channel.
-            await Task.Delay(100);
+            // The diagnostic shell writes to an unbounded channel, so we can prime the
+            // initial greeting/prompt immediately without relying on a timing delay.
             DiagShell.Start();
             
             Tracer.Log("Test", "Starting outer terminal");
@@ -342,8 +341,12 @@ public class DiagnosticShellIntegrationTests
             // Start the outer terminal (runs the Hex1bApp)
             _runTask = OuterTerminal.RunAsync(_cts.Token);
             
-            // Wait for initial render — should now find "diag>" quickly since Start() was called
-            await WaitForTextAsync("diag>", TimeSpan.FromSeconds(5));
+            var promptVisible = await WaitForTextAsync("diag>", TimeSpan.FromSeconds(5));
+            if (!promptVisible)
+            {
+                throw new TimeoutException(
+                    $"Timed out waiting for diagnostic shell to appear in outer terminal.\nOuter:\n{GetOuterContent()}\nInner:\n{GetInnerContent()}");
+            }
             
             Tracer.Log("Test", "Initial render complete");
         }
@@ -355,21 +358,33 @@ public class DiagnosticShellIntegrationTests
         {
             Tracer.Log("Test", $"Sending command: {command}");
             
-            // Type the command character by character through the workload adapter
-            foreach (var c in command)
-            {
-                await DiagShell.WriteInputAsync(new byte[] { (byte)c });
-                await Task.Delay(5); // Small delay between chars
-            }
-            
-            // Press Enter
-            await DiagShell.WriteInputAsync(new byte[] { 0x0D }); // CR
-            
-            // Small delay after Enter to allow shell to start processing
-            // This helps avoid race conditions when running in parallel with other tests
-            await Task.Delay(50);
+            // Only send a new command once the current prompt is the active bottom line.
+            await WaitForPromptAsync(TimeSpan.FromSeconds(5));
+
+            // Send the whole command in a single write. The workload still processes the
+            // bytes one-by-one, but the test no longer depends on inter-character delays.
+            await DiagShell.WriteInputAsync(Encoding.UTF8.GetBytes(command + "\r"));
             
             Tracer.Log("Test", "Command sent");
+        }
+
+        public async Task WaitForPromptAsync(TimeSpan timeout)
+        {
+            var deadline = DateTimeOffset.Now + timeout;
+            while (DateTimeOffset.Now < deadline)
+            {
+                using var snapshot = InnerTerminal.CreateSnapshot();
+                if (GetLastNonEmptyLine(snapshot) == "diag>")
+                {
+                    Tracer.Log("Test", "Prompt ready");
+                    return;
+                }
+                await Task.Delay(50);
+            }
+
+            Tracer.Log("Test", "Timeout waiting for prompt");
+            throw new TimeoutException(
+                $"Timed out waiting for diagnostic prompt.\nOuter:\n{GetOuterContent()}\nInner:\n{GetInnerContent()}");
         }
         
         /// <summary>
@@ -425,6 +440,17 @@ public class DiagnosticShellIntegrationTests
             }
             return sb.ToString();
         }
+
+        private static string GetLastNonEmptyLine(Hex1bTerminalSnapshot snapshot)
+        {
+            var lastNonEmptyLine = "";
+            foreach (var line in snapshot.GetNonEmptyLines())
+            {
+                lastNonEmptyLine = line.TrimEnd();
+            }
+
+            return lastNonEmptyLine;
+        }
         
         public async ValueTask DisposeAsync()
         {
@@ -456,19 +482,17 @@ public class DiagnosticShellIntegrationTests
         
         // Act - send help command
         await ctx.SendCommandAsync("help");
-        
-        // Wait for help output to appear
-        var foundPing = await ctx.WaitForTextAsync("ping", TimeSpan.FromSeconds(5));
-        var foundCapture = await ctx.WaitForTextAsync("capture", TimeSpan.FromSeconds(1));
-        var foundDump = await ctx.WaitForTextAsync("dump", TimeSpan.FromSeconds(1));
-        
-        // Get final content for assertion
+
+        // Wait for the last expected help entry so assertions observe the full render.
+        var foundDump = await ctx.WaitForTextAsync("dump", TimeSpan.FromSeconds(5));
+        Assert.True(foundDump, $"Should find 'dump' in help output\nOuter:\n{ctx.GetOuterContent()}\nInner:\n{ctx.GetInnerContent()}");
+
         var content = ctx.GetOuterContent();
         
         // Assert - help should show all commands
-        Assert.True(foundPing, "Should find 'ping' in help output");
-        Assert.True(foundCapture, "Should find 'capture' in help output");
-        Assert.True(foundDump, "Should find 'dump' in help output");
+        Assert.Contains("ping", content);
+        Assert.Contains("capture", content);
+        Assert.Contains("dump", content);
     }
     
     [Fact(Skip = "Flaky - timing-sensitive diagnostic shell test")]
@@ -517,28 +541,23 @@ public class DiagnosticShellIntegrationTests
     private static string Truncate(string s, int maxLen) 
         => s.Length <= maxLen ? s.Replace("\n", "\\n").Replace("\r", "\\r") : s[..maxLen].Replace("\n", "\\n").Replace("\r", "\\r") + "...";
     
-    [Fact(Skip = "Flaky in CI - timing-sensitive multi-command test that fails intermittently under load")]
+    [Fact]
     public async Task DiagnosticShell_MultipleCommands_AllRender()
     {
         // Arrange
         await using var ctx = DiagnosticTestContext.Create();
         await ctx.StartAsync();
         
-        // Act - send multiple commands, waiting for prompt between each
-        // to ensure the rendering pipeline has fully processed each command's output
+        // Act - Send commands sequentially. SendCommandAsync waits for the active prompt
+        // before typing, so the next command can't race the previous render.
         await ctx.SendCommandAsync("echo hello");
         var foundHello = await ctx.WaitForTextAsync("hello", TimeSpan.FromSeconds(5));
         Assert.True(foundHello, $"Should find 'hello'\nOuter:\n{ctx.GetOuterContent()}\nInner:\n{ctx.GetInnerContent()}");
-        
-        // Wait for prompt to ensure previous command fully rendered before sending next
-        await ctx.WaitForTextAsync("diag>", TimeSpan.FromSeconds(3));
-        
+
         await ctx.SendCommandAsync("echo world");
         var foundWorld = await ctx.WaitForTextAsync("world", TimeSpan.FromSeconds(5));
         Assert.True(foundWorld, $"Should find 'world'\nOuter:\n{ctx.GetOuterContent()}\nInner:\n{ctx.GetInnerContent()}");
-        
-        await ctx.WaitForTextAsync("diag>", TimeSpan.FromSeconds(3));
-        
+
         await ctx.SendCommandAsync("ping");
         var foundPong = await ctx.WaitForTextAsync("PONG", TimeSpan.FromSeconds(5));
         
@@ -579,7 +598,8 @@ public class DiagnosticShellIntegrationTests
         
         // Act
         await ctx.SendCommandAsync("ping");
-        await Task.Delay(500); // Give time for processing
+        var foundPong = await ctx.WaitForTextAsync("PONG", TimeSpan.FromSeconds(5));
+        Assert.True(foundPong, "Should receive PONG output before checking trace events");
         
         // Get events
         var allEvents = ctx.Tracer.GetEvents();

--- a/tests/Hex1b.Tests/PickerIntegrationTests.cs
+++ b/tests/Hex1b.Tests/PickerIntegrationTests.cs
@@ -154,7 +154,7 @@ public class PickerIntegrationTests
     [Fact]
     public async Task Picker_ClickOnPopupContent_DoesNotDismiss()
     {
-        // Arrange & Act
+        // Arrange
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithHex1bApp((app, options) =>
             {
@@ -168,24 +168,55 @@ public class PickerIntegrationTests
             .Build();
 
         var runTask = terminal.RunAsync(TestContext.Current.CancellationToken);
-        
+
+        // Open the popup and wait for the list content to render.
         await new Hex1bTerminalInputSequenceBuilder()
             .WaitUntil(s => s.ContainsText("Apple"), TimeSpan.FromSeconds(5), "picker to render")
-            .Enter()  // Open the picker popup
+            .Enter()
             .WaitUntil(s => s.ContainsText("Banana") && s.ContainsText("Cherry"), TimeSpan.FromSeconds(5), "popup to open")
-            // Click somewhere on the popup content (we'll click on the first visible item area)
-            // The popup list is rendered somewhere in the middle-ish of the screen
-            // Just click on a middle area where the list would be
-            .ClickAt(5, 5, MouseButton.Left)
-            .Wait(100)  // Wait a bit to make sure click was processed
+            .Build()
+            .ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+        using var popupSnapshot = terminal.CreateSnapshot();
+        (int Line, int Column)? popupApple = null;
+        foreach (var match in popupSnapshot.FindText("Apple"))
+        {
+            if (match.Line > 0)
+            {
+                popupApple = match;
+                break;
+            }
+        }
+
+        Assert.True(
+            popupApple.HasValue,
+            $"Expected to find the popup's selected Apple item.\nScreen:\n{popupSnapshot.GetText()}");
+
+        var popupBorderX = popupApple.Value.Column;
+        var popupBorderY = popupApple.Value.Line - 1;
+        Assert.True(
+            popupBorderY >= 0,
+            $"Expected popup border row above selected item.\nScreen:\n{popupSnapshot.GetText()}");
+
+        // Click the popup border itself. If that click wrongly dismisses the popup, the
+        // subsequent Enter will reopen it instead of selecting the focused item.
+        await new Hex1bTerminalInputSequenceBuilder()
+            .ClickAt(popupBorderX, popupBorderY, MouseButton.Left)
+            .Enter()
+            .WaitUntil(s => s.ContainsText("Apple ▼") && !s.ContainsText("Cherry"), TimeSpan.FromSeconds(5), "popup to close after selecting current item")
+            .Build()
+            .ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+        using var finalSnapshot = terminal.CreateSnapshot();
+
+        await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
             .Build()
-            .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
+            .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        // The popup should still be visible after clicking on its content
-        // (unless the click selected an item, which would close it)
-        // This test verifies that the click-away logic correctly identifies content bounds
+        Assert.True(finalSnapshot.ContainsText("Apple ▼"));
+        Assert.False(finalSnapshot.ContainsText("Cherry"));
     }
 
     [Fact]

--- a/tests/Hex1b.Tests/UnicodeBorderAlignmentTests.cs
+++ b/tests/Hex1b.Tests/UnicodeBorderAlignmentTests.cs
@@ -343,11 +343,34 @@ public class UnicodeBorderAlignmentTests
         
         var runTask = app.RunAsync(cancellationToken);
         
-        // Wait for render, then capture - don't use Capture() to avoid duplicate name issues
+        string? previousFrameText = null;
+        var stableFrameCount = 0;
+
+        // Wait for render to settle before capturing. CI runners can observe the END MARKER
+        // before the full bordered frame has finished flushing to the terminal snapshot.
         await new Hex1bTerminalInputSequenceBuilder()
-            .WaitUntil(s => s.ContainsText("END MARKER"), TimeSpan.FromSeconds(5), "render complete")
-            // CI can capture mid-frame; give the renderer a moment to flush the final diff.
-            .Wait(50)
+            .WaitUntil(s =>
+            {
+                if (!s.ContainsText("END MARKER"))
+                {
+                    previousFrameText = null;
+                    stableFrameCount = 0;
+                    return false;
+                }
+
+                var currentFrameText = s.GetText();
+                if (currentFrameText == previousFrameText)
+                {
+                    stableFrameCount++;
+                }
+                else
+                {
+                    previousFrameText = currentFrameText;
+                    stableFrameCount = 1;
+                }
+
+                return stableFrameCount >= 3;
+            }, TimeSpan.FromSeconds(5), "render to stabilize")
             .Build()
             .ApplyAsync(terminal, cancellationToken);
         


### PR DESCRIPTION
## Summary
- stabilize DiagnosticShell issue-driven tests by removing sleep-based command sequencing and re-enabling the multi-command case
- make the picker popup-content click test deterministic by locating the popup from the snapshot and asserting behavior before exit
- replace the Unicode border helper's fixed post-render sleep with a stable-frame wait

## Validation
- `dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj --no-restore --filter "FullyQualifiedName~Hex1b.Tests.PickerIntegrationTests.Picker_ClickOnPopupContent_DoesNotDismiss|FullyQualifiedName~Hex1b.Tests.UnicodeBorderAlignmentTests.BorderAlignment_CjkCharacters_AlignCorrectly|FullyQualifiedName~Hex1b.Tests.UnicodeBorderAlignmentTests.BorderAlignment_FullWidthCharacters_AlignCorrectly|FullyQualifiedName~Hex1b.Tests.DiagnosticShellIntegrationTests.DiagnosticShell_MultipleCommands_AllRender|FullyQualifiedName~Hex1b.Tests.DiagnosticShellIntegrationTests.DiagnosticShell_HelpCommand_RendersCompletely|FullyQualifiedName~Hex1b.Tests.DiagnosticShellIntegrationTests.InvalidateCallback_IsInvokedOnOutput"`
- issue-driven stress runs: diagnostic multi-command, picker popup-content, CJK alignment, and full-width alignment all passed `20/20`
- broader `Hex1b.Tests` run still shows an unrelated local failure in `Hex1bTerminalBuilderTests.WithProcess_ProcessStartInfo_PreservesWorkingDirectory`

Fixes #141
Fixes #148
Fixes #150