### PR TITLE
Fix flaky AutomationException_TotalElapsed_SumsAllSteps test

### DIFF
--- a/tests/Hex1b.Tests/Hex1bTerminalAutomatorTests.cs
+++ b/tests/Hex1b.Tests/Hex1bTerminalAutomatorTests.cs
@@ -379,7 +379,7 @@ public class Hex1bTerminalAutomatorTests
         var runTask = terminal.RunAsync(TestContext.Current.CancellationToken);
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromMilliseconds(250));
 
-        await auto.WaitUntilTextAsync("Hello");
+        await auto.WaitUntilTextAsync("Hello", timeout: TimeSpan.FromSeconds(5));
 
         var ex = await Assert.ThrowsAsync<Hex1bAutomationException>(async () =>
         {


### PR DESCRIPTION
## Problem
The `AutomationException_TotalElapsed_SumsAllSteps` test uses a 250ms default timeout for the `Hex1bTerminalAutomator`. The first `WaitUntilTextAsync("Hello")` call relies on this 250ms timeout for app startup + initial render, which is too tight for slow CI runners.

## Fix
Give the startup `WaitUntilTextAsync("Hello")` an explicit 5-second timeout so it has plenty of headroom for app initialization. The intentionally-failing `WaitUntilTextAsync("Never")` still uses the 250ms default timeout, preserving the test's assertion that `TotalElapsed >= 200ms`.