### PR TITLE
Fix AsciinemaRecorder FlushAsync race with concurrent auto-flush

### DIFF
--- a/src/Hex1b/AsciinemaRecorder.cs
+++ b/src/Hex1b/AsciinemaRecorder.cs
@@ -353,6 +353,7 @@ public sealed class AsciinemaRecorder : IHex1bTerminalWorkloadFilter, IAsyncDisp
     {
         List<AsciinemaEvent> eventsToWrite;
         AsciinemaHeader? header = null;
+        bool nothingToWrite;
 
         lock (_lock)
         {
@@ -360,37 +361,50 @@ public sealed class AsciinemaRecorder : IHex1bTerminalWorkloadFilter, IAsyncDisp
             if (_filePath == null)
                 return;
                 
-            if (_pendingEvents.Count == 0 && _headerWritten)
-                return;
+            nothingToWrite = _pendingEvents.Count == 0 && _headerWritten;
 
-            if (!_headerWritten)
+            if (!nothingToWrite)
             {
-                header = new AsciinemaHeader
+                if (!_headerWritten)
                 {
-                    Version = 2,
-                    Width = _width,
-                    Height = _height,
-                    Timestamp = _recordingStartTime.ToUnixTimeSeconds(),
-                    Title = _options.Title,
-                    Command = _options.Command,
-                    IdleTimeLimit = _options.IdleTimeLimit,
-                    Env = _options.CaptureEnvironment ? new Dictionary<string, string>
+                    header = new AsciinemaHeader
                     {
-                        ["TERM"] = Environment.GetEnvironmentVariable("TERM") ?? "xterm-256color",
-                        ["SHELL"] = Environment.GetEnvironmentVariable("SHELL") ?? ""
-                    } : null,
-                    Theme = _options.Theme
-                };
-                _headerWritten = true;
-            }
+                        Version = 2,
+                        Width = _width,
+                        Height = _height,
+                        Timestamp = _recordingStartTime.ToUnixTimeSeconds(),
+                        Title = _options.Title,
+                        Command = _options.Command,
+                        IdleTimeLimit = _options.IdleTimeLimit,
+                        Env = _options.CaptureEnvironment ? new Dictionary<string, string>
+                        {
+                            ["TERM"] = Environment.GetEnvironmentVariable("TERM") ?? "xterm-256color",
+                            ["SHELL"] = Environment.GetEnvironmentVariable("SHELL") ?? ""
+                        } : null,
+                        Theme = _options.Theme
+                    };
+                    _headerWritten = true;
+                }
 
-            eventsToWrite = new List<AsciinemaEvent>(_pendingEvents);
-            _pendingEvents.Clear();
+                eventsToWrite = new List<AsciinemaEvent>(_pendingEvents);
+                _pendingEvents.Clear();
+            }
+            else
+            {
+                eventsToWrite = [];
+            }
         }
 
+        // Always acquire _writeLock so we wait for any in-progress write
+        // (e.g. a concurrent auto-flush) to finish before returning.  Without
+        // this, a caller could read the file before a concurrent flush has
+        // finished creating it on disk.
         await _writeLock.WaitAsync(ct);
         try
         {
+            if (nothingToWrite)
+                return;
+
             await EnsureStreamOpenAsync(overwrite: header != null);
 
             if (header != null)
@@ -410,7 +424,8 @@ public sealed class AsciinemaRecorder : IHex1bTerminalWorkloadFilter, IAsyncDisp
         }
         finally
         {
-            await CloseStreamAsync();
+            if (!nothingToWrite)
+                await CloseStreamAsync();
             _writeLock.Release();
         }
     }


### PR DESCRIPTION
## Summary

Fixes an intermittent test failure tracked in the daily test monitoring:
- Closes #258

## Root Cause

`AsciinemaRecorder.FlushAsync()` had a race condition between the auto-flush (triggered by `OnOutputAsync` when `AutoFlush=true`) and a concurrent manual `FlushAsync()` call.

The auto-flush would:
1. Acquire `_lock`, set `_headerWritten = true`, snapshot events, release `_lock`
2. Wait to acquire `_writeLock`
3. Create the file and write to disk

A concurrent caller's `FlushAsync()` would:
1. Acquire `_lock`, see `_headerWritten == true && _pendingEvents.Count == 0`
2. **Return early** — without acquiring `_writeLock`

The caller would then immediately try to read the file, but the auto-flush hadn't finished writing (or even creating) the file yet, causing:

\\\
System.IO.FileNotFoundException: Could not find file '/tmp/hex1b_test_*.cast'
\\\

## Fix

Always acquire `_writeLock` before returning from `FlushAsync()`, even when there's nothing to write. This ensures the caller is serialized with any in-progress write operation. The actual I/O is skipped when there are no events to flush.

## Testing

- All 12 `AsciinemaRecorderTests` pass locally
- No other tests affected