### PR TITLE
Add AdditionalRunArgs to DockerContainerOptions

### DIFF
--- a/src/Hex1b/DockerContainerArgBuilder.cs
+++ b/src/Hex1b/DockerContainerArgBuilder.cs
@@ -94,6 +94,8 @@ internal static class DockerContainerArgBuilder
             args.Add(options.Network);
         }
 
+        args.AddRange(options.AdditionalRunArgs);
+
         args.Add(options.Image);
         args.Add(options.Shell);
 

--- a/src/Hex1b/DockerContainerOptions.cs
+++ b/src/Hex1b/DockerContainerOptions.cs
@@ -133,4 +133,22 @@ public sealed class DockerContainerOptions
     /// Maps to <c>docker run --network</c>. If null, Docker's default network is used.
     /// </remarks>
     public string? Network { get; set; }
+
+    /// <summary>
+    /// Gets additional arguments passed directly to <c>docker run</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// These arguments are inserted before the image name in the <c>docker run</c>
+    /// command, after all other options. Use this for flags not covered by dedicated
+    /// properties (e.g., <c>--privileged</c>, <c>--cgroupns=host</c>,
+    /// <c>--security-opt</c>, <c>--cap-add</c>).
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// c.AdditionalRunArgs.AddRange(["--privileged", "--cgroupns=host"]);
+    /// </code>
+    /// </example>
+    public List<string> AdditionalRunArgs { get; } = new();
 }

--- a/tests/Hex1b.Tests/DockerContainerArgBuilderTests.cs
+++ b/tests/Hex1b.Tests/DockerContainerArgBuilderTests.cs
@@ -520,4 +520,77 @@ public class DockerContainerArgBuilderTests
 
         Assert.Equal(100, names.Count);
     }
+
+    // --- AdditionalRunArgs tests ---
+
+    [Fact]
+    public void BuildRunArgs_WithAdditionalRunArgs_IncludesArgs()
+    {
+        var options = new DockerContainerOptions();
+        options.AdditionalRunArgs.Add("--privileged");
+        var args = DockerContainerArgBuilder.BuildRunArgs(options, "test");
+
+        Assert.Contains("--privileged", args);
+    }
+
+    [Fact]
+    public void BuildRunArgs_WithMultipleAdditionalRunArgs_IncludesAll()
+    {
+        var options = new DockerContainerOptions();
+        options.AdditionalRunArgs.AddRange(["--privileged", "--cgroupns=host"]);
+        var args = DockerContainerArgBuilder.BuildRunArgs(options, "test");
+
+        Assert.Contains("--privileged", args);
+        Assert.Contains("--cgroupns=host", args);
+    }
+
+    [Fact]
+    public void BuildRunArgs_AdditionalRunArgs_BeforeImage()
+    {
+        var options = new DockerContainerOptions { Image = "alpine:3.21" };
+        options.AdditionalRunArgs.Add("--privileged");
+        var args = DockerContainerArgBuilder.BuildRunArgs(options, "test");
+
+        var privilegedIndex = Array.IndexOf(args, "--privileged");
+        var imageIndex = Array.IndexOf(args, "alpine:3.21");
+        Assert.True(privilegedIndex < imageIndex, "Additional args should come before the image");
+    }
+
+    [Fact]
+    public void BuildRunArgs_EmptyAdditionalRunArgs_NoExtraArgs()
+    {
+        var options = new DockerContainerOptions { Image = "ubuntu:24.04" };
+        var argsWithout = DockerContainerArgBuilder.BuildRunArgs(options, "test");
+
+        // Verify no stray args - count should match a minimal run
+        var optionsWithEmpty = new DockerContainerOptions { Image = "ubuntu:24.04" };
+        var argsWith = DockerContainerArgBuilder.BuildRunArgs(optionsWithEmpty, "test");
+
+        Assert.Equal(argsWithout.Length, argsWith.Length);
+    }
+
+    [Fact]
+    public void BuildRunArgs_AllOptions_IncludesAdditionalRunArgs()
+    {
+        var options = new DockerContainerOptions
+        {
+            Image = "alpine:3.21",
+            WorkingDirectory = "/workspace",
+            Network = "bridge",
+            MountDockerSocket = true,
+            AutoRemove = true,
+            Shell = "/bin/sh",
+            ShellArgs = ["-l"]
+        };
+        options.Environment["A"] = "1";
+        options.Volumes.Add("/tmp:/tmp");
+        options.AdditionalRunArgs.AddRange(["--privileged", "--cgroupns=host"]);
+
+        var args = DockerContainerArgBuilder.BuildRunArgs(options, "full-test");
+
+        Assert.Contains("--privileged", args);
+        Assert.Contains("--cgroupns=host", args);
+        Assert.Contains("alpine:3.21", args);
+        Assert.Contains("/bin/sh", args);
+    }
 }


### PR DESCRIPTION
## Summary

Adds a generic `AdditionalRunArgs` property to `DockerContainerOptions` for passing arbitrary flags to `docker run`, inserted before the image name.

## Motivation

We need to run Podman inside Docker containers for E2E testing of Aspire's Podman container runtime support ([dotnet/aspire#13315](https://github.com/microsoft/aspire/issues/13315)). This requires `--privileged --cgroupns=host` on `docker run`, which isn't covered by existing properties.

Rather than adding dedicated properties for every Docker flag, a generic `List<string>` allows any combination:

```csharp
c.AdditionalRunArgs.AddRange(["--privileged", "--cgroupns=host"]);
```

Other use cases: `--security-opt`, `--cap-add`, `--device`, etc.

## Design note

`AdditionalRunArgs` is a `List<string>` (additive, matching `Volumes` and `Environment`) rather than `string[]` (replace, like `ShellArgs`). The distinction: `AdditionalRunArgs` are `docker run` flags inserted **before** the image name, while `ShellArgs` are arguments to the shell placed **after** the image and shell command. The additive pattern felt more natural for accumulating flags, but happy to switch to `string[]` if you prefer consistency with `ShellArgs`.

## Changes

- **`DockerContainerOptions.cs`** — new `AdditionalRunArgs` property with docs and example
- **`DockerContainerArgBuilder.cs`** — inserts additional args before the image name
- **`DockerContainerArgBuilderTests.cs`** — 5 new tests covering inclusion, ordering, empty case, and combined usage

## Validation

All 7079 existing tests pass, plus 5 new tests.