### PR TITLE
Add ITerminalEmulatorBackend for pluggable terminal emulators

### DIFF
--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -57,6 +57,7 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
     private readonly Func<CancellationToken, Task<int>>? _runCallback;
     private readonly IReadOnlyList<IHex1bTerminalWorkloadFilter> _workloadFilters;
     private readonly IReadOnlyList<IHex1bTerminalPresentationFilter> _presentationFilters;
+    private readonly ITerminalEmulatorBackend? _emulatorBackend;
     private readonly CancellationTokenSource _disposeCts = new();
     private readonly DateTimeOffset _sessionStart;
     private readonly TrackedObjectStore _trackedObjects = new();
@@ -293,6 +294,7 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
         
         _metrics = options.Metrics ?? Diagnostics.Hex1bMetrics.Default;
         _escapeTimeout = options.EscapeSequenceTimeout ?? TimeSpan.FromMilliseconds(50);
+        _emulatorBackend = options.TerminalEmulatorBackend;
 
         // Subscribe to presentation events
         _presentation.Resized += OnPresentationResized;
@@ -1288,12 +1290,33 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
                 {
                     // Channel empty - this is a frame boundary
                     await NotifyWorkloadFiltersFrameCompleteAsync();
-                    
+
                     // Small delay to prevent busy-waiting in headless mode
                     await Task.Delay(10, ct);
                     continue;
                 }
-                
+
+                // When an external emulator backend is set, delegate all output
+                // processing to it and skip the built-in tokenizer/ApplyTokens pipeline.
+                if (_emulatorBackend != null)
+                {
+                    _emulatorBackend.ProcessOutput(data.Span);
+
+                    // Sync state from the backend so Hex1b's APIs see current values
+                    _cursorX = _emulatorBackend.CursorX;
+                    _cursorY = _emulatorBackend.CursorY;
+                    _inAlternateScreen = _emulatorBackend.InAlternateScreen;
+                    _windowTitle = _emulatorBackend.Title ?? "";
+
+                    // Forward raw bytes to presentation
+                    if (_presentation != null)
+                    {
+                        await _presentation.WriteOutputAsync(data, ct);
+                        _metrics.TerminalOutputBytes.Record(data.Length);
+                    }
+                    continue;
+                }
+
                 string? completeText = null;
                 IReadOnlyList<AnsiToken> tokens;
 
@@ -1752,9 +1775,15 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
     {
         lock (_bufferLock)
         {
+            // When an external emulator backend is set, get the buffer from it
+            if (_emulatorBackend != null)
+            {
+                return _emulatorBackend.GetScreenBuffer(_width, _height);
+            }
+
             var copy = new TerminalCell[_height, _width];
             Array.Copy(_screenBuffer, copy, _screenBuffer.Length);
-            
+
             if (addTrackedObjectRefs)
             {
                 for (int y = 0; y < _height; y++)
@@ -1765,7 +1794,7 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
                     }
                 }
             }
-            
+
             return copy;
         }
     }
@@ -1997,6 +2026,9 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
     {
         lock (_bufferLock)
         {
+            // Notify the external emulator backend of the resize
+            _emulatorBackend?.Resize(newWidth, newHeight);
+
             // Check if the presentation adapter supports reflow and has it enabled
             if (_presentation is ITerminalReflowProvider { ReflowEnabled: true } reflowProvider)
             {
@@ -5785,6 +5817,7 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
         }
 
         _workload.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        _emulatorBackend?.Dispose();
 
         _escapeFlushTimer?.Dispose();
 
@@ -5834,6 +5867,7 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
         }
 
         await _workload.DisposeAsync();
+        _emulatorBackend?.Dispose();
 
         _escapeFlushTimer?.Dispose();
 

--- a/src/Hex1b/Hex1bTerminalBuilder.cs
+++ b/src/Hex1b/Hex1bTerminalBuilder.cs
@@ -53,6 +53,7 @@ public sealed class Hex1bTerminalBuilder
     private Action<ScrollbackRowEventArgs>? _scrollbackCallback;
     private Reflow.ITerminalReflowProvider? _reflowStrategy;
     private bool _reflowEnabled;
+    private ITerminalEmulatorBackend? _terminalEmulatorBackend;
 
     /// <summary>
     /// Creates a new terminal builder.
@@ -854,6 +855,19 @@ public sealed class Hex1bTerminalBuilder
     }
 
     /// <summary>
+    /// Replaces Hex1b's built-in terminal emulator with an external backend.
+    /// When set, the backend processes raw workload output instead of the built-in
+    /// AnsiTokenizer + ApplyTokens pipeline.
+    /// </summary>
+    /// <param name="backend">The terminal emulator backend to use.</param>
+    /// <returns>This builder for chaining.</returns>
+    public Hex1bTerminalBuilder WithTerminalEmulator(ITerminalEmulatorBackend backend)
+    {
+        _terminalEmulatorBackend = backend ?? throw new ArgumentNullException(nameof(backend));
+        return this;
+    }
+
+    /// <summary>
     /// Configures the terminal to run a Hex1b Flow — a sequence of inline micro-TUI slices
     /// and optional full-screen TUI applications in the normal terminal buffer.
     /// </summary>
@@ -1324,7 +1338,8 @@ public sealed class Hex1bTerminalBuilder
             RunCallback = runCallback,
             ScrollbackCapacity = _scrollbackCapacity,
             ScrollbackCallback = _scrollbackCallback,
-            Metrics = ResolveMetrics()
+            Metrics = ResolveMetrics(),
+            TerminalEmulatorBackend = _terminalEmulatorBackend
         };
         
         foreach (var filter in _workloadFilters)

--- a/src/Hex1b/Hex1bTerminalOptions.cs
+++ b/src/Hex1b/Hex1bTerminalOptions.cs
@@ -126,6 +126,18 @@ public sealed class Hex1bTerminalOptions
     public TimeSpan? EscapeSequenceTimeout { get; set; }
 
     /// <summary>
+    /// Optional external terminal emulator backend that replaces Hex1b's built-in
+    /// VT parser and screen buffer management.
+    /// </summary>
+    /// <remarks>
+    /// When set, the terminal delegates output processing to this backend instead of
+    /// using the built-in <see cref="Tokens.AnsiTokenizer"/> and token application pipeline.
+    /// The backend owns the terminal state (cursor, screen buffer, modes) and is queried
+    /// by <see cref="Hex1bTerminal.CreateSnapshot()"/> for the current screen content.
+    /// </remarks>
+    public ITerminalEmulatorBackend? TerminalEmulatorBackend { get; set; }
+
+    /// <summary>
     /// Validates the options and throws if invalid.
     /// </summary>
     internal void Validate()

--- a/src/Hex1b/ITerminalEmulatorBackend.cs
+++ b/src/Hex1b/ITerminalEmulatorBackend.cs
@@ -1,0 +1,38 @@
+namespace Hex1b;
+
+/// <summary>
+/// Allows replacing Hex1b's built-in terminal emulator with an external implementation.
+/// When set via <see cref="Hex1bTerminalBuilder.WithTerminalEmulator"/>, the backend
+/// processes raw workload output instead of the built-in AnsiTokenizer + ApplyTokens pipeline.
+/// </summary>
+public interface ITerminalEmulatorBackend : IDisposable
+{
+    /// <summary>
+    /// Process raw output bytes from the workload.
+    /// Called instead of the built-in AnsiTokenizer + ApplyTokens pipeline.
+    /// </summary>
+    void ProcessOutput(ReadOnlySpan<byte> data);
+
+    /// <summary>
+    /// Handle terminal resize.
+    /// </summary>
+    void Resize(int width, int height);
+
+    /// <summary>
+    /// Get the current screen buffer state as a grid of <see cref="TerminalCell"/>.
+    /// Called by <see cref="Hex1bTerminal.CreateSnapshot()"/> and related methods.
+    /// </summary>
+    TerminalCell[,] GetScreenBuffer(int width, int height);
+
+    /// <summary>Current cursor column (0-based).</summary>
+    int CursorX { get; }
+
+    /// <summary>Current cursor row (0-based).</summary>
+    int CursorY { get; }
+
+    /// <summary>Whether the terminal is in alternate screen mode.</summary>
+    bool InAlternateScreen { get; }
+
+    /// <summary>The terminal title (set via OSC 0/2). Null if not set.</summary>
+    string? Title { get; }
+}


### PR DESCRIPTION
## Summary

We're experimenting with using [libghostty](https://libghostty.tip.ghostty.org/) (the terminal emulator engine from [Ghostty](https://ghostty.org/)) as an alternative VT parser backend for Hex1b. To support this cleanly, this PR adds a minimal abstraction that allows external terminal emulators to be plugged in, replacing Hex1b's built-in `AnsiTokenizer` + `ApplyTokens` pipeline while keeping everything else — workloads, presentation adapters, filters, automation, and the snapshot API.

### Changes

- **`ITerminalEmulatorBackend`** — new interface (`ProcessOutput`, `Resize`, `GetScreenBuffer`, cursor/title/alt-screen state)
- **`Hex1bTerminalBuilder.WithTerminalEmulator(backend)`** — builder method to plug in a backend
- **`Hex1bTerminalOptions.TerminalEmulatorBackend`** — option property
- **`Hex1bTerminal`** — when a backend is set:
  - `PumpWorkloadOutputAsync` delegates to `backend.ProcessOutput()` and syncs cursor state, skipping the tokenizer
  - `GetScreenBuffer` delegates to the backend
  - `Resize` also resizes the backend
  - `Dispose`/`DisposeAsync` disposes the backend

### Usage

```csharp
var backend = new MyCustomEmulatorBackend();
await using var terminal = Hex1bTerminal.CreateBuilder()
    .WithProcess("ls", "-la")
    .WithHeadless()
    .WithTerminalEmulator(backend)
    .Build();
```

When no backend is set, behavior is completely unchanged — the existing VT parser continues to work as before.

### Motivation

We're building a .NET wrapper for libghostty and wanted to integrate it with Hex1b idiomatically rather than wrapping around the outside. This abstraction lets libghostty fully replace the VT parsing layer while Hex1b continues to handle process management, I/O pumping, presentation, and the automation/snapshot API. We think this could be useful for other terminal emulator engines too.

We have a working integration ([`GhosttyEmulatorBackend`](https://github.com/slang25/libghostty-dotnet)) with passing comparison tests that demonstrates the approach.

## Test plan

- [ ] Existing Hex1b tests continue to pass (no backend = no behavior change)
- [ ] Integration tested via libghostty backend with 36 VT parsing comparison tests
- [ ] Manual testing with headless terminal + automation API
- [ ] Verified: screen text, cursor position, window title, alt screen, cell attributes all flow through correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)