### PR TITLE
Use source-generated JSON serialization for diagnostics protocol

### DIFF
--- a/src/Hex1b.Tool/Commands/Terminal/AttachWebApp.cs
+++ b/src/Hex1b.Tool/Commands/Terminal/AttachWebApp.cs
@@ -120,7 +120,7 @@ internal sealed class AttachWebApp : IAsyncDisposable
         {
             // Send attach request
             var request = new DiagnosticsRequest { Method = "attach" };
-            var requestJson = JsonSerializer.Serialize(request, DiagnosticsJsonOptions.Default);
+            var requestJson = JsonSerializer.Serialize(request, DiagnosticsJsonContext.Default.DiagnosticsRequest);
             await writer.WriteLineAsync(requestJson.AsMemory(), ct);
 
             var responseLine = await reader.ReadLineAsync(ct);
@@ -130,7 +130,7 @@ internal sealed class AttachWebApp : IAsyncDisposable
                 return;
             }
 
-            var response = JsonSerializer.Deserialize<DiagnosticsResponse>(responseLine, DiagnosticsJsonOptions.Default);
+            var response = JsonSerializer.Deserialize(responseLine, DiagnosticsJsonContext.Default.DiagnosticsResponse);
             if (response is not { Success: true })
             {
                 await ws.CloseAsync(WebSocketCloseStatus.InternalServerError, response?.Error ?? "Attach failed", ct);

--- a/src/Hex1b.Tool/Commands/Terminal/UnixSocketAttachTransport.cs
+++ b/src/Hex1b.Tool/Commands/Terminal/UnixSocketAttachTransport.cs
@@ -41,14 +41,14 @@ internal sealed class UnixSocketAttachTransport : IAttachTransport
         _writer = new StreamWriter(_networkStream, Encoding.UTF8) { AutoFlush = true };
 
         var request = new DiagnosticsRequest { Method = "attach" };
-        var requestJson = JsonSerializer.Serialize(request, DiagnosticsJsonOptions.Default);
+        var requestJson = JsonSerializer.Serialize(request, DiagnosticsJsonContext.Default.DiagnosticsRequest);
         await _writer.WriteLineAsync(requestJson.AsMemory(), ct);
 
         var responseLine = await _reader.ReadLineAsync(ct);
         if (string.IsNullOrEmpty(responseLine))
             return new AttachResult(false, 0, 0, false, null, "Empty response from terminal");
 
-        var response = JsonSerializer.Deserialize<DiagnosticsResponse>(responseLine, DiagnosticsJsonOptions.Default);
+        var response = JsonSerializer.Deserialize(responseLine, DiagnosticsJsonContext.Default.DiagnosticsResponse);
         if (response is not { Success: true })
             return new AttachResult(false, 0, 0, false, null, response?.Error ?? "Attach failed");
 

--- a/src/Hex1b.Tool/Infrastructure/TerminalClient.cs
+++ b/src/Hex1b.Tool/Infrastructure/TerminalClient.cs
@@ -23,7 +23,7 @@ internal sealed class TerminalClient
         using var reader = new StreamReader(stream, Encoding.UTF8);
         await using var writer = new StreamWriter(stream, Encoding.UTF8) { AutoFlush = true };
 
-        var requestJson = JsonSerializer.Serialize(request, DiagnosticsJsonOptions.Default);
+        var requestJson = JsonSerializer.Serialize(request, DiagnosticsJsonContext.Default.DiagnosticsRequest);
         await writer.WriteLineAsync(requestJson.AsMemory(), cancellationToken);
 
         var responseLine = await reader.ReadLineAsync(cancellationToken);
@@ -32,7 +32,7 @@ internal sealed class TerminalClient
             return new DiagnosticsResponse { Success = false, Error = "Empty response from terminal" };
         }
 
-        return JsonSerializer.Deserialize<DiagnosticsResponse>(responseLine, DiagnosticsJsonOptions.Default)
+        return JsonSerializer.Deserialize(responseLine, DiagnosticsJsonContext.Default.DiagnosticsResponse)
             ?? new DiagnosticsResponse { Success = false, Error = "Failed to deserialize response" };
     }
 

--- a/src/Hex1b/Diagnostics/DiagnosticTreeProvider.cs
+++ b/src/Hex1b/Diagnostics/DiagnosticTreeProvider.cs
@@ -84,7 +84,7 @@ internal sealed class DiagnosticNode
     /// Key properties of the node for debugging.
     /// </summary>
     [JsonPropertyName("properties")]
-    public Dictionary<string, object?>? Properties { get; set; }
+    public Dictionary<string, JsonElement>? Properties { get; set; }
     
     /// <summary>
     /// Child nodes.
@@ -128,51 +128,68 @@ internal sealed class DiagnosticNode
         return diagNode;
     }
     
-    private static Dictionary<string, object?>? GetNodeProperties(Hex1bNode node)
+    private static Dictionary<string, JsonElement>? GetNodeProperties(Hex1bNode node)
     {
-        var props = new Dictionary<string, object?>();
+        var props = new Dictionary<string, JsonElement>();
         
         // Add type-specific properties for common node types
         switch (node)
         {
             case ButtonNode button:
-                props["label"] = button.Label;
+                props["label"] = ToElement(button.Label);
                 break;
             case TextBlockNode textBlock:
-                props["text"] = textBlock.Text?.Length > 50 
+                props["text"] = ToElement(textBlock.Text?.Length > 50 
                     ? textBlock.Text[..50] + "..." 
-                    : textBlock.Text;
+                    : textBlock.Text);
                 break;
             case ListNode list:
-                props["itemCount"] = list.Items?.Count ?? 0;
-                props["selectedIndex"] = list.SelectedIndex;
+                props["itemCount"] = ToElement(list.Items?.Count ?? 0);
+                props["selectedIndex"] = ToElement(list.SelectedIndex);
                 break;
             case PickerNode picker:
-                props["selectedIndex"] = picker.SelectedIndex;
-                props["selectedText"] = picker.SelectedText;
+                props["selectedIndex"] = ToElement(picker.SelectedIndex);
+                props["selectedText"] = ToElement(picker.SelectedText);
                 break;
             case MenuItemNode menuItem:
-                props["label"] = menuItem.Label;
+                props["label"] = ToElement(menuItem.Label);
                 break;
             case AnchoredNode anchored:
-                props["anchorNodeType"] = anchored.AnchorNode?.GetType().Name;
+                props["anchorNodeType"] = ToElement(anchored.AnchorNode?.GetType().Name);
                 props["anchorBounds"] = anchored.AnchorNode != null 
-                    ? DiagnosticRect.FromRect(anchored.AnchorNode.Bounds) 
-                    : null;
-                props["isAnchorStale"] = anchored.IsAnchorStale;
-                props["position"] = anchored.Position.ToString();
+                    ? JsonSerializer.SerializeToElement(DiagnosticRect.FromRect(anchored.AnchorNode.Bounds), DiagnosticsJsonContext.Default.DiagnosticRect)
+                    : default;
+                props["isAnchorStale"] = ToElement(anchored.IsAnchorStale);
+                props["position"] = ToElement(anchored.Position.ToString());
                 break;
             case BackdropNode backdrop:
-                props["style"] = backdrop.Style.ToString();
-                props["hasClickAwayHandler"] = backdrop.ClickAwayHandler != null || backdrop.ClickAwayEventHandler != null;
+                props["style"] = ToElement(backdrop.Style.ToString());
+                props["hasClickAwayHandler"] = ToElement(backdrop.ClickAwayHandler != null || backdrop.ClickAwayEventHandler != null);
                 break;
             case NotificationPanelNode notificationPanel:
-                props["isDrawerExpanded"] = notificationPanel.IsDrawerExpanded;
-                props["notificationCount"] = notificationPanel.Notifications?.Count ?? 0;
+                props["isDrawerExpanded"] = ToElement(notificationPanel.IsDrawerExpanded);
+                props["notificationCount"] = ToElement(notificationPanel.Notifications?.Count ?? 0);
                 break;
         }
         
         return props.Count > 0 ? props : null;
+    }
+
+    private static JsonElement ToElement(string? value)
+    {
+        return value is null
+            ? default
+            : JsonSerializer.SerializeToElement(value, DiagnosticsJsonContext.Default.String);
+    }
+
+    private static JsonElement ToElement(int value)
+    {
+        return JsonSerializer.SerializeToElement(value, DiagnosticsJsonContext.Default.Int32);
+    }
+
+    private static JsonElement ToElement(bool value)
+    {
+        return JsonSerializer.SerializeToElement(value, DiagnosticsJsonContext.Default.Boolean);
     }
 }
 

--- a/src/Hex1b/Diagnostics/DiagnosticsProtocol.cs
+++ b/src/Hex1b/Diagnostics/DiagnosticsProtocol.cs
@@ -200,9 +200,29 @@ internal sealed class DiagnosticsResponse
 /// </summary>
 internal static class DiagnosticsJsonOptions
 {
-    public static readonly JsonSerializerOptions Default = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-    };
+    public static readonly JsonSerializerOptions Default = DiagnosticsJsonContext.Default.Options;
+}
+
+/// <summary>
+/// Source-generated JSON serializer context for diagnostics protocol types.
+/// Eliminates reflection-based serialization for native AOT compatibility.
+/// </summary>
+[JsonSerializable(typeof(DiagnosticsRequest))]
+[JsonSerializable(typeof(DiagnosticsResponse))]
+[JsonSerializable(typeof(DiagnosticNode))]
+[JsonSerializable(typeof(DiagnosticRect))]
+[JsonSerializable(typeof(DiagnosticPopupEntry))]
+[JsonSerializable(typeof(DiagnosticAnchorInfo))]
+[JsonSerializable(typeof(DiagnosticFocusInfo))]
+[JsonSerializable(typeof(DiagnosticFocusableEntry))]
+[JsonSerializable(typeof(DiagnosticTiming))]
+[JsonSerializable(typeof(DiagnosticFrameInfo))]
+[JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(int))]
+[JsonSerializable(typeof(bool))]
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+internal sealed partial class DiagnosticsJsonContext : JsonSerializerContext
+{
 }

--- a/src/Hex1b/Diagnostics/DiagnosticsSocketListener.cs
+++ b/src/Hex1b/Diagnostics/DiagnosticsSocketListener.cs
@@ -258,7 +258,7 @@ public sealed class McpDiagnosticsPresentationFilter : ITerminalAwarePresentatio
             if (string.IsNullOrEmpty(requestLine))
                 return;
 
-            var request = JsonSerializer.Deserialize<DiagnosticsRequest>(requestLine, DiagnosticsJsonOptions.Default);
+            var request = JsonSerializer.Deserialize(requestLine, DiagnosticsJsonContext.Default.DiagnosticsRequest);
             if (request == null)
             {
                 await WriteErrorAsync(writer, "Invalid request format");
@@ -273,7 +273,7 @@ public sealed class McpDiagnosticsPresentationFilter : ITerminalAwarePresentatio
             }
 
             var response = await HandleRequestAsync(request);
-            var responseJson = JsonSerializer.Serialize(response, DiagnosticsJsonOptions.Default);
+            var responseJson = JsonSerializer.Serialize(response, DiagnosticsJsonContext.Default.DiagnosticsResponse);
             await writer.WriteLineAsync(responseJson);
         }
         catch (Exception ex)
@@ -360,7 +360,7 @@ public sealed class McpDiagnosticsPresentationFilter : ITerminalAwarePresentatio
             Data = session.InitialScreen,
             Leader = session.IsLeader
         };
-        var responseJson = JsonSerializer.Serialize(attachResponse, DiagnosticsJsonOptions.Default);
+        var responseJson = JsonSerializer.Serialize(attachResponse, DiagnosticsJsonContext.Default.DiagnosticsResponse);
         await writer.WriteLineAsync(responseJson.AsMemory(), ct);
 
         // Run two tasks: output streaming and input forwarding
@@ -930,7 +930,7 @@ public sealed class McpDiagnosticsPresentationFilter : ITerminalAwarePresentatio
     private static async Task WriteErrorAsync(StreamWriter writer, string error)
     {
         var response = new DiagnosticsResponse { Success = false, Error = error };
-        var json = JsonSerializer.Serialize(response, DiagnosticsJsonOptions.Default);
+        var json = JsonSerializer.Serialize(response, DiagnosticsJsonContext.Default.DiagnosticsResponse);
         await writer.WriteLineAsync(json);
     }
 


### PR DESCRIPTION
## Summary

Fixes 8 AOT/trim warnings (IL2026/IL3050) in \DiagnosticsSocketListener.cs\ by switching from reflection-based to source-generated JSON serialization.

## Problem

When publishing Hex1b as a native AOT executable, \JsonSerializer.Serialize<T>()\ and \JsonSerializer.Deserialize<T>()\ produce trim/AOT warnings because they rely on reflection that isn't available at runtime.

## Changes

- **\DiagnosticsProtocol.cs\** — Added \DiagnosticsJsonContext\ (\JsonSerializerContext\) with \[JsonSerializable]\ attributes for all diagnostic types; wired \DiagnosticsJsonOptions.Default\ to use the generated context's options
- **\DiagnosticsSocketListener.cs\** — Switched 4 call sites to \JsonTypeInfo<T>\ overloads
- **\DiagnosticTreeProvider.cs\** — Changed \DiagnosticNode.Properties\ from \Dictionary<string, object?>\ to \Dictionary<string, JsonElement>\ for AOT compatibility, with helper methods for type-safe element creation
- **\Hex1b.Tool\** (3 files) — Updated 6 additional call sites in \TerminalClient.cs\, \AttachWebApp.cs\, \UnixSocketAttachTransport.cs\

## Pattern

Follows the existing \AsciinemaJsonContext\ approach used in \AsciinemaRecorder.cs\.