### PR TITLE
Add scrollback support to Terminal Widget

### DIFF
--- a/samples/ScrollbackTerminalDemo/Program.cs
+++ b/samples/ScrollbackTerminalDemo/Program.cs
@@ -1,0 +1,118 @@
+using Hex1b;
+using Hex1b.Input;
+using Hex1b.Nodes;
+using Hex1b.Widgets;
+
+// State
+Hex1bApp? displayApp = null;
+TerminalWidgetHandle? activeHandle = null;
+
+using var cts = new CancellationTokenSource();
+
+// Determine shell based on OS
+Hex1bTerminalBuilder ConfigureShell(Hex1bTerminalBuilder builder)
+{
+    if (OperatingSystem.IsWindows())
+    {
+        return builder.WithPtyProcess(options =>
+        {
+            options.FileName = "pwsh";
+            options.Arguments = ["-NoProfile", "-NoLogo"];
+            options.WindowsPtyMode = WindowsPtyMode.RequireProxy;
+        });
+    }
+    return builder.WithPtyProcess("bash", "--norc");
+}
+
+// Create the embedded terminal with scrollback enabled
+var innerBuilder = Hex1bTerminal.CreateBuilder()
+    .WithDimensions(80, 24)
+    .WithScrollback(1000); // Enable 1000-line scrollback buffer
+
+innerBuilder = ConfigureShell(innerBuilder);
+
+var innerTerminal = innerBuilder
+    .WithTerminalWidget(out var handle)
+    .Build();
+
+activeHandle = handle;
+
+// Start the inner terminal in the background
+_ = Task.Run(async () =>
+{
+    try
+    {
+        await innerTerminal.RunAsync(cts.Token);
+        displayApp?.Invalidate();
+    }
+    catch (OperationCanceledException) { }
+});
+
+// Build the widget tree
+Hex1bWidget BuildUI(RootContext ctx)
+{
+    // Get scrollback info for status bar
+    var scrollbackCount = activeHandle?.ScrollbackCount ?? 0;
+    var terminalNode = displayApp?.FocusedNode as TerminalNode;
+    var scrollOffset = terminalNode?.ScrollbackOffset ?? 0;
+    var inScrollback = terminalNode?.IsInScrollbackMode ?? false;
+
+    var scrollStatus = inScrollback
+        ? $"SCROLLBACK [{scrollOffset}/{scrollbackCount}]"
+        : $"LIVE [{scrollbackCount} lines in buffer]";
+
+    var altScreen = activeHandle?.InAlternateScreen == true ? " | ALT SCREEN" : "";
+    var mouseTracking = activeHandle?.MouseTrackingEnabled == true ? " | MOUSE" : "";
+
+    return ctx.VStack(v =>
+    [
+        // Title
+        v.Border(
+            v.Terminal(handle)
+                .WhenNotRunning(args => v.Align(Alignment.Center,
+                    v.VStack(vv =>
+                    [
+                        vv.Text($"Terminal exited with code {args.ExitCode ?? 0}"),
+                        vv.Text(""),
+                        vv.Button("Quit").OnClick(_ => displayApp?.RequestStop())
+                    ])
+                ))
+        ).Title("Scrollback Terminal Demo").Fill(),
+
+        // Keybinding reference
+        v.InfoBar([
+            "Shift+↑/↓", "Scroll Line",
+            "Shift+PgUp/PgDn", "Scroll Page",
+            "Shift+Home/End", "Top/Bottom",
+            "Mouse Wheel", "Scroll"
+        ]),
+
+        // Status bar
+        v.InfoBar([
+            "", $"{scrollStatus}{altScreen}{mouseTracking}"
+        ])
+    ]).WithInputBindings(bindings =>
+    {
+        bindings.Ctrl().Key(Hex1bKey.Q).Action(_ => displayApp?.RequestStop(), "Quit");
+    });
+}
+
+// Create the display terminal
+await using var displayTerminal = Hex1bTerminal.CreateBuilder()
+    .WithMouse()
+    .WithHex1bApp((app, options) =>
+    {
+        displayApp = app;
+        return ctx => BuildUI(ctx);
+    })
+    .Build();
+
+try
+{
+    await displayTerminal.RunAsync(cts.Token);
+}
+finally
+{
+    cts.Cancel();
+    await innerTerminal.DisposeAsync();
+}

--- a/samples/ScrollbackTerminalDemo/ScrollbackTerminalDemo.csproj
+++ b/samples/ScrollbackTerminalDemo/ScrollbackTerminalDemo.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Hex1b/Hex1b.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <WindowsPtyShimRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">win-arm64</WindowsPtyShimRid>
+    <WindowsPtyShimRid Condition="'$(WindowsPtyShimRid)' == ''">win-x64</WindowsPtyShimRid>
+  </PropertyGroup>
+
+  <Target Name="CopyWindowsPtyShim"
+          AfterTargets="Build"
+          Condition="$([MSBuild]::IsOSPlatform('Windows')) and Exists('../../src/Hex1b/obj/windows-pty-shim/$(WindowsPtyShimRid)/native/hex1bpty.exe')">
+    <ItemGroup>
+      <WindowsPtyShimFiles Include="../../src/Hex1b/obj/windows-pty-shim/$(WindowsPtyShimRid)/native/*.*"
+                           Exclude="../../src/Hex1b/obj/windows-pty-shim/$(WindowsPtyShimRid)/native/*.pdb" />
+    </ItemGroup>
+    <Copy SourceFiles="@(WindowsPtyShimFiles)"
+          DestinationFolder="$(TargetDir)runtimes\$(WindowsPtyShimRid)\native\"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+</Project>

--- a/samples/WindowingDemo/Program.cs
+++ b/samples/WindowingDemo/Program.cs
@@ -86,6 +86,7 @@ void OpenTerminalWindow(MenuItemActivatedEventArgs e, TerminalShellKind shellKin
         // terminal content size so the first prompt is laid out correctly.
         .WithDimensions(InitialTerminalColumns, InitialTerminalRows)
         .WithMouse()
+        .WithScrollback(1000)
         .WithPtyProcess(options =>
         {
             options.FileName = launchSpec.FileName;

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -1235,9 +1235,11 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         {
             var handle = terminalNode.Handle;
             
-            // Translate child cursor position to screen coordinates
+            // Translate child cursor position to screen coordinates.
+            // When the terminal is in scrollback mode, the active buffer content is shifted
+            // down by the scrollback offset, so the cursor position must shift accordingly.
             var screenCursorX = terminalNode.Bounds.X + handle.CursorX;
-            var screenCursorY = terminalNode.Bounds.Y + handle.CursorY;
+            var screenCursorY = terminalNode.Bounds.Y + handle.CursorY + terminalNode.ScrollbackOffset;
             var shape = handle.CursorShape;
             var visible = handle.CursorVisible;
             
@@ -1260,7 +1262,8 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
             
             if (visible && 
                 screenCursorX >= 0 && screenCursorX < _context.Width &&
-                screenCursorY >= 0 && screenCursorY < _context.Height)
+                screenCursorY >= 0 && screenCursorY < _context.Height &&
+                screenCursorY < terminalNode.Bounds.Y + terminalNode.Bounds.Height)
             {
                 _context.SetCursorPosition(screenCursorX, screenCursorY);
                 _context.Write("\x1b[?25h"); // Show cursor

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -1752,6 +1752,21 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
+    /// Gets an atomic snapshot of the current screen buffer with its dimensions and cursor position.
+    /// Thread-safe — acquires the buffer lock.
+    /// </summary>
+    /// <returns>A tuple containing the buffer copy, width, height, cursor X, and cursor Y.</returns>
+    internal (TerminalCell[,] Buffer, int Width, int Height, int CursorX, int CursorY) GetScreenBufferSnapshot()
+    {
+        lock (_bufferLock)
+        {
+            var copy = new TerminalCell[_height, _width];
+            Array.Copy(_screenBuffer, copy, _screenBuffer.Length);
+            return (copy, _width, _height, _cursorX, _cursorY);
+        }
+    }
+
+    /// <summary>
     /// Enters alternate screen mode (for testing purposes).
     /// In headless mode, this just sets the flag and clears the buffer.
     /// </summary>

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -1723,6 +1723,35 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
     internal ScrollbackBuffer? Scrollback => _scrollbackBuffer;
 
     /// <summary>
+    /// Gets the number of rows currently stored in the scrollback buffer.
+    /// Returns 0 if scrollback is not enabled.
+    /// </summary>
+    public int ScrollbackCount
+    {
+        get
+        {
+            lock (_bufferLock)
+            {
+                return _scrollbackBuffer?.Count ?? 0;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets a snapshot of up to <paramref name="count"/> most recent scrollback rows,
+    /// ordered oldest to newest. Thread-safe.
+    /// </summary>
+    /// <param name="count">Maximum number of rows to return.</param>
+    /// <returns>Array of scrollback rows, or empty array if scrollback is not enabled.</returns>
+    public ScrollbackRow[] GetScrollbackRows(int count)
+    {
+        lock (_bufferLock)
+        {
+            return _scrollbackBuffer?.GetLines(count) ?? [];
+        }
+    }
+
+    /// <summary>
     /// Enters alternate screen mode (for testing purposes).
     /// In headless mode, this just sets the flag and clears the buffer.
     /// </summary>

--- a/src/Hex1b/Hex1bTerminalChildProcess.cs
+++ b/src/Hex1b/Hex1bTerminalChildProcess.cs
@@ -186,10 +186,24 @@ public sealed class Hex1bTerminalChildProcess : IHex1bTerminalWorkloadAdapter
             ? Environment.CurrentDirectory
             : _workingDirectory;
 
+        // Capture the dimensions we'll create the PTY with. A concurrent ResizeAsync
+        // call may update _width/_height between now and when _started is set to true.
+        var startWidth = _width;
+        var startHeight = _height;
+
         // Start the process
-        await _ptyHandle.StartAsync(_fileName, _arguments, workingDirectory, env, _width, _height, ct);
+        await _ptyHandle.StartAsync(_fileName, _arguments, workingDirectory, env, startWidth, startHeight, ct);
 
         _started = true;
+
+        // If a resize arrived while the PTY was being created (between reading
+        // _width/_height above and setting _started=true), _width/_height will
+        // differ from what the PTY was actually created with. Send a follow-up
+        // resize so the PTY matches the latest requested dimensions.
+        if (_width != startWidth || _height != startHeight)
+        {
+            _ptyHandle.Resize(_width, _height);
+        }
 
         // Signal that the process has started (allows ReadOutputAsync to proceed)
         _startedTcs.TrySetResult();

--- a/src/Hex1b/Nodes/TerminalNode.cs
+++ b/src/Hex1b/Nodes/TerminalNode.cs
@@ -17,6 +17,13 @@ namespace Hex1b.Nodes;
 /// The node is focusable and forwards all keyboard input to the child terminal.
 /// Mouse clicks within the terminal's bounds will focus the terminal.
 /// </para>
+/// <para>
+/// When the terminal has a scrollback buffer configured, the user can scroll up
+/// through previous output using keyboard shortcuts or mouse wheel. Scrollback
+/// viewing is disabled when the child process is using the alternate screen buffer
+/// (mode 1049), and mouse scroll events are forwarded to the child when it has
+/// enabled mouse tracking.
+/// </para>
 /// </remarks>
 public sealed class TerminalNode : Hex1bNode
 {
@@ -34,6 +41,11 @@ public sealed class TerminalNode : Hex1bNode
     // but before ClearDirtyFlags, causing the new content to be lost
     private volatile int _outputVersion;
     private int _lastRenderedVersion;
+    
+    // Scrollback view state
+    // When _scrollbackOffset > 0, the view is scrolled up into the scrollback buffer
+    // and keyboard input is intercepted for scrollback navigation instead of forwarded to the child
+    private int _scrollbackOffset;
     
     /// <summary>
     /// Gets or sets the terminal handle this node renders from.
@@ -133,6 +145,101 @@ public sealed class TerminalNode : Hex1bNode
         _releaseCaptureCallback = releaseCapture;
     }
     
+    /// <summary>
+    /// Gets whether the terminal is currently in scrollback mode (scrolled up from live view).
+    /// </summary>
+    public bool IsInScrollbackMode => _scrollbackOffset > 0;
+    
+    /// <summary>
+    /// Gets the current scrollback offset (number of lines scrolled up from live view).
+    /// </summary>
+    public int ScrollbackOffset => _scrollbackOffset;
+    
+    /// <inheritdoc />
+    public override void ConfigureDefaultBindings(InputBindingsBuilder bindings)
+    {
+        // Keyboard scrollback navigation
+        // Note: Ctrl+Shift combinations are not supported by the input binding system,
+        // so we use Shift+Arrow/PageUp/PageDown/Home/End which matches GNOME Terminal conventions
+        bindings.Shift().Key(Hex1bKey.UpArrow).Triggers(TerminalWidget.ScrollUpLine, ScrollUpLineHandler, "Scroll up one line");
+        bindings.Shift().Key(Hex1bKey.DownArrow).Triggers(TerminalWidget.ScrollDownLine, ScrollDownLineHandler, "Scroll down one line");
+        bindings.Shift().Key(Hex1bKey.PageUp).Triggers(TerminalWidget.ScrollUpPage, ScrollUpPageHandler, "Scroll up one page");
+        bindings.Shift().Key(Hex1bKey.PageDown).Triggers(TerminalWidget.ScrollDownPage, ScrollDownPageHandler, "Scroll down one page");
+        bindings.Shift().Key(Hex1bKey.Home).Triggers(TerminalWidget.ScrollToTop, ScrollToTopHandler, "Scroll to top of scrollback");
+        bindings.Shift().Key(Hex1bKey.End).Triggers(TerminalWidget.ScrollToBottom, ScrollToBottomHandler, "Scroll to bottom (live view)");
+        
+        // Mouse wheel scrollback (only when child has NOT enabled mouse tracking)
+        bindings.Mouse(MouseButton.ScrollUp).Triggers(TerminalWidget.ScrollUpLine, ScrollUpLineHandler, "Scroll up one line");
+        bindings.Mouse(MouseButton.ScrollDown).Triggers(TerminalWidget.ScrollDownLine, ScrollDownLineHandler, "Scroll down one line");
+    }
+    
+    private Task ScrollUpLineHandler(InputBindingActionContext ctx)
+    {
+        AdjustScrollbackOffset(1);
+        return Task.CompletedTask;
+    }
+    
+    private Task ScrollDownLineHandler(InputBindingActionContext ctx)
+    {
+        AdjustScrollbackOffset(-1);
+        return Task.CompletedTask;
+    }
+    
+    private Task ScrollUpPageHandler(InputBindingActionContext ctx)
+    {
+        var pageSize = Math.Max(1, Bounds.Height - 1);
+        AdjustScrollbackOffset(pageSize);
+        return Task.CompletedTask;
+    }
+    
+    private Task ScrollDownPageHandler(InputBindingActionContext ctx)
+    {
+        var pageSize = Math.Max(1, Bounds.Height - 1);
+        AdjustScrollbackOffset(-pageSize);
+        return Task.CompletedTask;
+    }
+    
+    private Task ScrollToTopHandler(InputBindingActionContext ctx)
+    {
+        if (_handle == null) return Task.CompletedTask;
+        var maxOffset = _handle.ScrollbackCount;
+        if (maxOffset > 0)
+        {
+            _scrollbackOffset = maxOffset;
+            MarkDirty();
+            _invalidateCallback?.Invoke();
+        }
+        return Task.CompletedTask;
+    }
+    
+    private Task ScrollToBottomHandler(InputBindingActionContext ctx)
+    {
+        if (_scrollbackOffset > 0)
+        {
+            _scrollbackOffset = 0;
+            MarkDirty();
+            _invalidateCallback?.Invoke();
+        }
+        return Task.CompletedTask;
+    }
+    
+    private void AdjustScrollbackOffset(int delta)
+    {
+        if (_handle == null) return;
+        
+        // Don't allow scrollback when in alternate screen
+        if (_handle.InAlternateScreen) return;
+        
+        var maxOffset = _handle.ScrollbackCount;
+        var newOffset = Math.Clamp(_scrollbackOffset + delta, 0, maxOffset);
+        if (newOffset != _scrollbackOffset)
+        {
+            _scrollbackOffset = newOffset;
+            MarkDirty();
+            _invalidateCallback?.Invoke();
+        }
+    }
+    
     /// <inheritdoc />
     public override InputResult HandleInput(Hex1bEvent inputEvent)
     {
@@ -145,6 +252,16 @@ public sealed class TerminalNode : Hex1bNode
         
         // Forward input to the terminal
         if (_handle == null) return InputResult.NotHandled;
+        
+        // When in scrollback mode, don't forward keyboard input to the child terminal.
+        // The scrollback keybindings are handled by ConfigureDefaultBindings above.
+        // Any non-scrollback key press scrolls back to the live view and is then forwarded.
+        if (IsInScrollbackMode && inputEvent is Hex1bKeyEvent)
+        {
+            // Let the input binding system handle it first (it will match scrollback actions).
+            // If no binding matched, this returns NotHandled and the key is consumed below.
+            return InputResult.NotHandled;
+        }
         
         // Fire and forget - we don't want to block the input loop
         _ = _handle.SendEventAsync(inputEvent);
@@ -161,9 +278,26 @@ public sealed class TerminalNode : Hex1bNode
             return InputResult.NotHandled;
         }
         
-        // Forward click events to the child terminal via unified HandleInput
-        var localEvent = mouseEvent with { X = localX, Y = localY };
-        return HandleInput(localEvent);
+        // When the child has enabled mouse tracking, forward all mouse events to it
+        // (including scroll wheel). The child app manages its own scrolling (e.g., vim).
+        if (_handle != null && _handle.MouseTrackingEnabled)
+        {
+            var localEvent = mouseEvent with { X = localX, Y = localY };
+            return HandleInput(localEvent);
+        }
+        
+        // When the child has NOT enabled mouse tracking, scroll wheel events
+        // control the scrollback view instead of being forwarded.
+        // The scroll bindings are handled by ConfigureDefaultBindings.
+        // Return NotHandled so the input binding system can match them.
+        if (mouseEvent.Button is MouseButton.ScrollUp or MouseButton.ScrollDown)
+        {
+            return InputResult.NotHandled;
+        }
+        
+        // Non-scroll mouse events: forward to the child terminal
+        var evt = mouseEvent with { X = localX, Y = localY };
+        return HandleInput(evt);
     }
     
     /// <inheritdoc />
@@ -365,80 +499,148 @@ public sealed class TerminalNode : Hex1bNode
         // Mark this version as rendered (we'll check if more output arrived after this)
         _lastRenderedVersion = currentVersion;
         
-        // Render each row that fits within our bounds
+        if (_scrollbackOffset > 0)
+        {
+            RenderWithScrollback(context, buffer, handleWidth, handleHeight);
+        }
+        else
+        {
+            RenderLive(context, buffer, handleWidth, handleHeight);
+        }
+    }
+    
+    /// <summary>
+    /// Renders the live terminal buffer (no scrollback offset).
+    /// </summary>
+    private void RenderLive(Hex1bRenderContext context, TerminalCell[,] buffer, int handleWidth, int handleHeight)
+    {
         for (int y = 0; y < Math.Min(Bounds.Height, handleHeight); y++)
         {
-            var lineBuilder = new System.Text.StringBuilder();
-            Hex1b.Theming.Hex1bColor? lastFg = null;
-            Hex1b.Theming.Hex1bColor? lastBg = null;
-            Hex1b.Theming.Hex1bColor? lastUc = null;
-            CellAttributes lastAttrs = CellAttributes.None;
+            RenderRow(context, y, (x) => buffer[y, x], handleWidth);
+        }
+    }
+    
+    /// <summary>
+    /// Renders a composite view of scrollback rows above the active buffer,
+    /// shifted up by _scrollbackOffset lines.
+    /// </summary>
+    private void RenderWithScrollback(Hex1bRenderContext context, TerminalCell[,] activeBuffer, int handleWidth, int handleHeight)
+    {
+        // Get scrollback rows
+        var scrollbackRows = _handle!.GetScrollbackSnapshot(_handle.ScrollbackCount);
+        int scrollbackCount = scrollbackRows.Length;
+        
+        // Clamp offset to available scrollback
+        var effectiveOffset = Math.Min(_scrollbackOffset, scrollbackCount);
+        
+        // The virtual buffer is: [scrollback rows (oldest to newest)] + [active buffer rows]
+        // Total virtual rows = scrollbackCount + handleHeight
+        // The viewport shows handleHeight rows starting from:
+        //   virtualStart = scrollbackCount + handleHeight - handleHeight - effectiveOffset
+        //                = scrollbackCount - effectiveOffset
+        int virtualStart = scrollbackCount - effectiveOffset;
+        
+        for (int viewY = 0; viewY < Math.Min(Bounds.Height, handleHeight); viewY++)
+        {
+            int virtualRow = virtualStart + viewY;
             
-            for (int x = 0; x < Math.Min(Bounds.Width, handleWidth); x++)
+            if (virtualRow < scrollbackCount)
             {
-                var cell = buffer[y, x];
-                
-                // Build ANSI codes for color changes
-                bool needsReset = false;
-                
-                // Check if attributes changed
-                if (cell.Attributes != lastAttrs)
+                // This row comes from scrollback
+                var sbRow = scrollbackRows[virtualRow];
+                RenderRow(context, viewY, (x) =>
                 {
-                    needsReset = true;
-                }
-                
-                // Check if colors changed (nullable struct comparison)
-                if (!Nullable.Equals(cell.Foreground, lastFg) || !Nullable.Equals(cell.Background, lastBg) || !Nullable.Equals(cell.UnderlineColor, lastUc))
+                    if (x < sbRow.Cells.Length) return sbRow.Cells[x];
+                    return TerminalCell.Empty;
+                }, handleWidth);
+            }
+            else
+            {
+                // This row comes from the active buffer
+                int activeRow = virtualRow - scrollbackCount;
+                if (activeRow < handleHeight)
                 {
-                    needsReset = true;
+                    RenderRow(context, viewY, (x) => activeBuffer[activeRow, x], handleWidth);
                 }
-                
-                if (needsReset)
-                {
-                    // Reset and apply new attributes
-                    lineBuilder.Append("\x1b[0m");
-                    
-                    if (cell.Attributes.HasFlag(CellAttributes.Bold))
-                        lineBuilder.Append("\x1b[1m");
-                    if (cell.Attributes.HasFlag(CellAttributes.Dim))
-                        lineBuilder.Append("\x1b[2m");
-                    if (cell.Attributes.HasFlag(CellAttributes.Italic))
-                        lineBuilder.Append("\x1b[3m");
-                    if (cell.Attributes.HasFlag(CellAttributes.Underline))
-                    {
-                        if (cell.UnderlineStyle != UnderlineStyle.None && cell.UnderlineStyle != UnderlineStyle.Single)
-                            lineBuilder.Append($"\x1b[4:{(int)cell.UnderlineStyle}m");
-                        else
-                            lineBuilder.Append("\x1b[4m");
-                    }
-                    if (cell.Attributes.HasFlag(CellAttributes.Reverse))
-                        lineBuilder.Append("\x1b[7m");
-                    if (cell.Attributes.HasFlag(CellAttributes.Strikethrough))
-                        lineBuilder.Append("\x1b[9m");
-                    
-                    if (cell.Foreground != null)
-                        lineBuilder.Append(cell.Foreground.Value.ToForegroundAnsi());
-                    
-                    if (cell.Background != null)
-                        lineBuilder.Append(cell.Background.Value.ToBackgroundAnsi());
-                    
-                    if (cell.UnderlineColor != null)
-                        lineBuilder.Append(cell.UnderlineColor.Value.ToUnderlineColorAnsi());
-                    
-                    lastFg = cell.Foreground;
-                    lastBg = cell.Background;
-                    lastUc = cell.UnderlineColor;
-                    lastAttrs = cell.Attributes;
-                }
-                
-                lineBuilder.Append(cell.Character);
+            }
+        }
+    }
+    
+    /// <summary>
+    /// Renders a single row of terminal cells at the specified view Y position.
+    /// </summary>
+    private void RenderRow(Hex1bRenderContext context, int viewY, Func<int, TerminalCell> getCell, int handleWidth)
+    {
+        var lineBuilder = new System.Text.StringBuilder();
+        Hex1b.Theming.Hex1bColor? lastFg = null;
+        Hex1b.Theming.Hex1bColor? lastBg = null;
+        Hex1b.Theming.Hex1bColor? lastUc = null;
+        CellAttributes lastAttrs = CellAttributes.None;
+        
+        for (int x = 0; x < Math.Min(Bounds.Width, handleWidth); x++)
+        {
+            var cell = getCell(x);
+            
+            // Build ANSI codes for color changes
+            bool needsReset = false;
+            
+            // Check if attributes changed
+            if (cell.Attributes != lastAttrs)
+            {
+                needsReset = true;
             }
             
-            // Reset at end of line
-            lineBuilder.Append("\x1b[0m");
+            // Check if colors changed (nullable struct comparison)
+            if (!Nullable.Equals(cell.Foreground, lastFg) || !Nullable.Equals(cell.Background, lastBg) || !Nullable.Equals(cell.UnderlineColor, lastUc))
+            {
+                needsReset = true;
+            }
             
-            // Write the line at the correct position
-            context.WriteClipped(Bounds.X, Bounds.Y + y, lineBuilder.ToString());
+            if (needsReset)
+            {
+                // Reset and apply new attributes
+                lineBuilder.Append("\x1b[0m");
+                
+                if (cell.Attributes.HasFlag(CellAttributes.Bold))
+                    lineBuilder.Append("\x1b[1m");
+                if (cell.Attributes.HasFlag(CellAttributes.Dim))
+                    lineBuilder.Append("\x1b[2m");
+                if (cell.Attributes.HasFlag(CellAttributes.Italic))
+                    lineBuilder.Append("\x1b[3m");
+                if (cell.Attributes.HasFlag(CellAttributes.Underline))
+                {
+                    if (cell.UnderlineStyle != UnderlineStyle.None && cell.UnderlineStyle != UnderlineStyle.Single)
+                        lineBuilder.Append($"\x1b[4:{(int)cell.UnderlineStyle}m");
+                    else
+                        lineBuilder.Append("\x1b[4m");
+                }
+                if (cell.Attributes.HasFlag(CellAttributes.Reverse))
+                    lineBuilder.Append("\x1b[7m");
+                if (cell.Attributes.HasFlag(CellAttributes.Strikethrough))
+                    lineBuilder.Append("\x1b[9m");
+                
+                if (cell.Foreground != null)
+                    lineBuilder.Append(cell.Foreground.Value.ToForegroundAnsi());
+                
+                if (cell.Background != null)
+                    lineBuilder.Append(cell.Background.Value.ToBackgroundAnsi());
+                
+                if (cell.UnderlineColor != null)
+                    lineBuilder.Append(cell.UnderlineColor.Value.ToUnderlineColorAnsi());
+                
+                lastFg = cell.Foreground;
+                lastBg = cell.Background;
+                lastUc = cell.UnderlineColor;
+                lastAttrs = cell.Attributes;
+            }
+            
+            lineBuilder.Append(cell.Character);
         }
+        
+        // Reset at end of line
+        lineBuilder.Append("\x1b[0m");
+        
+        // Write the line at the correct position
+        context.WriteClipped(Bounds.X, Bounds.Y + viewY, lineBuilder.ToString());
     }
 }

--- a/src/Hex1b/Nodes/TerminalNode.cs
+++ b/src/Hex1b/Nodes/TerminalNode.cs
@@ -48,6 +48,11 @@ public sealed class TerminalNode : Hex1bNode
     private int _scrollbackOffset;
     
     /// <summary>
+    /// Number of rows to scroll per mouse wheel tick.
+    /// </summary>
+    internal int MouseWheelScrollAmount { get; set; } = 3;
+    
+    /// <summary>
     /// Gets or sets the terminal handle this node renders from.
     /// </summary>
     public TerminalWidgetHandle? Handle
@@ -169,8 +174,8 @@ public sealed class TerminalNode : Hex1bNode
         bindings.Shift().Key(Hex1bKey.End).Triggers(TerminalWidget.ScrollToBottom, ScrollToBottomHandler, "Scroll to bottom (live view)");
         
         // Mouse wheel scrollback (only when child has NOT enabled mouse tracking)
-        bindings.Mouse(MouseButton.ScrollUp).Triggers(TerminalWidget.ScrollUpLine, ScrollUpLineHandler, "Scroll up one line");
-        bindings.Mouse(MouseButton.ScrollDown).Triggers(TerminalWidget.ScrollDownLine, ScrollDownLineHandler, "Scroll down one line");
+        bindings.Mouse(MouseButton.ScrollUp).Triggers(TerminalWidget.ScrollUpLine, MouseScrollUpHandler, "Scroll up");
+        bindings.Mouse(MouseButton.ScrollDown).Triggers(TerminalWidget.ScrollDownLine, MouseScrollDownHandler, "Scroll down");
     }
     
     private Task ScrollUpLineHandler(InputBindingActionContext ctx)
@@ -182,6 +187,18 @@ public sealed class TerminalNode : Hex1bNode
     private Task ScrollDownLineHandler(InputBindingActionContext ctx)
     {
         AdjustScrollbackOffset(-1);
+        return Task.CompletedTask;
+    }
+    
+    private Task MouseScrollUpHandler(InputBindingActionContext ctx)
+    {
+        AdjustScrollbackOffset(MouseWheelScrollAmount);
+        return Task.CompletedTask;
+    }
+    
+    private Task MouseScrollDownHandler(InputBindingActionContext ctx)
+    {
+        AdjustScrollbackOffset(-MouseWheelScrollAmount);
         return Task.CompletedTask;
     }
     

--- a/src/Hex1b/Nodes/TerminalNode.cs
+++ b/src/Hex1b/Nodes/TerminalNode.cs
@@ -253,14 +253,14 @@ public sealed class TerminalNode : Hex1bNode
         // Forward input to the terminal
         if (_handle == null) return InputResult.NotHandled;
         
-        // When in scrollback mode, don't forward keyboard input to the child terminal.
-        // The scrollback keybindings are handled by ConfigureDefaultBindings above.
-        // Any non-scrollback key press scrolls back to the live view and is then forwarded.
+        // When in scrollback mode and a non-scrollback key is pressed (no binding matched),
+        // snap back to live view and forward the keystroke to the terminal.
+        // This matches standard terminal behavior where typing snaps you back to the prompt.
         if (IsInScrollbackMode && inputEvent is Hex1bKeyEvent)
         {
-            // Let the input binding system handle it first (it will match scrollback actions).
-            // If no binding matched, this returns NotHandled and the key is consumed below.
-            return InputResult.NotHandled;
+            _scrollbackOffset = 0;
+            MarkDirty();
+            _invalidateCallback?.Invoke();
         }
         
         // Fire and forget - we don't want to block the input loop

--- a/src/Hex1b/Nodes/TerminalNode.cs
+++ b/src/Hex1b/Nodes/TerminalNode.cs
@@ -192,12 +192,32 @@ public sealed class TerminalNode : Hex1bNode
     
     private Task MouseScrollUpHandler(InputBindingActionContext ctx)
     {
+        // When child has enabled mouse tracking, forward scroll to the terminal
+        // instead of controlling the scrollback view
+        if (_handle?.MouseTrackingEnabled == true)
+        {
+            // Convert absolute screen coordinates to terminal-local coordinates
+            var localX = ctx.MouseX - Bounds.X;
+            var localY = ctx.MouseY - Bounds.Y;
+            var scrollEvent = new Hex1bMouseEvent(MouseButton.ScrollUp, MouseAction.Down, localX, localY, Hex1bModifiers.None);
+            _ = _handle.SendEventAsync(scrollEvent);
+            return Task.CompletedTask;
+        }
         AdjustScrollbackOffset(MouseWheelScrollAmount);
         return Task.CompletedTask;
     }
     
     private Task MouseScrollDownHandler(InputBindingActionContext ctx)
     {
+        // When child has enabled mouse tracking, forward scroll to the terminal
+        if (_handle?.MouseTrackingEnabled == true)
+        {
+            var localX = ctx.MouseX - Bounds.X;
+            var localY = ctx.MouseY - Bounds.Y;
+            var scrollEvent = new Hex1bMouseEvent(MouseButton.ScrollDown, MouseAction.Down, localX, localY, Hex1bModifiers.None);
+            _ = _handle.SendEventAsync(scrollEvent);
+            return Task.CompletedTask;
+        }
         AdjustScrollbackOffset(-MouseWheelScrollAmount);
         return Task.CompletedTask;
     }

--- a/src/Hex1b/Nodes/TerminalNode.cs
+++ b/src/Hex1b/Nodes/TerminalNode.cs
@@ -452,7 +452,11 @@ public sealed class TerminalNode : Hex1bNode
         if (_handle != null && _handle.State != TerminalState.Running && FallbackChild != null)
         {
             FallbackChild.Arrange(bounds);
-            return;
+            // Don't return — fall through to resize the handle below.
+            // This ensures the handle (and underlying PTY) gets resized to match the
+            // layout bounds BEFORE the terminal starts running. Without this, the PTY
+            // starts at the initial WithDimensions() size (e.g., 80x24) and the shell's
+            // first output is laid out at the wrong width.
         }
         
         // Safety: clamp unreasonable bounds to handle dimensions

--- a/src/Hex1b/Nodes/TerminalNode.cs
+++ b/src/Hex1b/Nodes/TerminalNode.cs
@@ -499,6 +499,13 @@ public sealed class TerminalNode : Hex1bNode
         // Mark this version as rendered (we'll check if more output arrived after this)
         _lastRenderedVersion = currentVersion;
         
+        // Clear the entire terminal region before rendering rows.
+        // This is necessary because empty terminal cells (TerminalCell.Empty) have null
+        // foreground/background, which produces transparent SurfaceCells. Without clearing,
+        // empty rows below the cursor won't overwrite content from a previous frame
+        // (e.g., after scrolling back from scrollback mode to live mode).
+        context.ClearRegion(Bounds);
+        
         if (_scrollbackOffset > 0)
         {
             RenderWithScrollback(context, buffer, handleWidth, handleHeight);

--- a/src/Hex1b/ScrollbackBuffer.cs
+++ b/src/Hex1b/ScrollbackBuffer.cs
@@ -140,7 +140,7 @@ internal sealed class ScrollbackBuffer
 /// <summary>
 /// A single row stored in the scrollback buffer.
 /// </summary>
-internal readonly record struct ScrollbackRow(
+public readonly record struct ScrollbackRow(
     TerminalCell[] Cells,
     int OriginalWidth,
     DateTimeOffset Timestamp);

--- a/src/Hex1b/TerminalExtensions.cs
+++ b/src/Hex1b/TerminalExtensions.cs
@@ -64,4 +64,15 @@ public static class TerminalExtensions
         this TerminalWidget widget,
         Func<TerminalNotRunningArgs, Hex1bWidget> builder)
         => widget with { NotRunningBuilder = builder };
+    
+    /// <summary>
+    /// Sets the number of rows to scroll per mouse wheel tick.
+    /// </summary>
+    /// <param name="widget">The TerminalWidget to configure.</param>
+    /// <param name="rows">Number of rows per scroll tick. Defaults to 3.</param>
+    /// <returns>The configured TerminalWidget.</returns>
+    public static TerminalWidget WithMouseWheelScrollAmount(
+        this TerminalWidget widget,
+        int rows)
+        => widget with { MouseWheelScrollAmount = rows };
 }

--- a/src/Hex1b/TerminalWidgetHandle.cs
+++ b/src/Hex1b/TerminalWidgetHandle.cs
@@ -390,6 +390,13 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
     /// <returns>A copy of the screen buffer cells.</returns>
     public TerminalCell[,] GetScreenBuffer()
     {
+        // Prefer the terminal's authoritative buffer when available
+        if (_terminal is { } terminal)
+        {
+            var (buffer, _, _, _, _) = terminal.GetScreenBufferSnapshot();
+            return buffer;
+        }
+        
         lock (_bufferLock)
         {
             var copy = new TerminalCell[_height, _width];
@@ -402,9 +409,29 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
     /// Gets a snapshot of the current screen buffer with its dimensions.
     /// This is atomic - the dimensions will always match the buffer.
     /// </summary>
+    /// <remarks>
+    /// When a backing <see cref="Hex1bTerminal"/> is connected, this returns the terminal's
+    /// authoritative buffer rather than the handle's local copy. This ensures the snapshot
+    /// reflects the correct content after resize/reflow operations, where the terminal's
+    /// buffer is reflowed but the handle's local buffer may still have the old layout.
+    /// </remarks>
     /// <returns>A tuple containing the buffer copy, width, and height.</returns>
     public (TerminalCell[,] Buffer, int Width, int Height) GetScreenBufferSnapshot()
     {
+        // Prefer the terminal's authoritative buffer when available.
+        // The handle's local buffer can be stale after resize/reflow because:
+        // 1. Handle.Resize() does a simple copy of old content
+        // 2. Terminal.Resize() does a full reflow
+        // 3. The handle's buffer doesn't get the reflowed content
+        if (_terminal is { } terminal)
+        {
+            var (buffer, width, height, cursorX, cursorY) = terminal.GetScreenBufferSnapshot();
+            // Sync cursor position from the terminal's authoritative state
+            _cursorX = cursorX;
+            _cursorY = cursorY;
+            return (buffer, width, height);
+        }
+        
         lock (_bufferLock)
         {
             var copy = new TerminalCell[_height, _width];

--- a/src/Hex1b/TerminalWidgetHandle.cs
+++ b/src/Hex1b/TerminalWidgetHandle.cs
@@ -68,6 +68,9 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
     private bool _mouseTrackingEnabled;  // Mode 1000, 1002, or 1003
     private bool _sgrMouseModeEnabled;   // Mode 1006
     
+    // Alternate screen tracking - set when child sends mode 1049
+    private bool _inAlternateScreen;
+    
     // Cursor shape (from CursorShapeToken)
     private CursorShape _cursorShape = CursorShape.Default;
     
@@ -136,6 +139,13 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
     /// Mouse events are only forwarded to the child when this is true.
     /// </summary>
     public bool MouseTrackingEnabled => _mouseTrackingEnabled;
+    
+    /// <summary>
+    /// Gets whether the child process is currently using the alternate screen buffer (mode 1049).
+    /// When true, scrollback viewing is disabled because alternate screen programs (vim, less, etc.)
+    /// manage their own scrolling.
+    /// </summary>
+    public bool InAlternateScreen => _inAlternateScreen;
     
     /// <summary>
     /// Gets the current lifecycle state of the terminal session.
@@ -269,6 +279,11 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
             // SGR extended mouse mode (extended coordinates)
             case 1006:
                 _sgrMouseModeEnabled = pm.Enable;
+                break;
+            
+            // Alternate screen buffer
+            case 1049:
+                _inAlternateScreen = pm.Enable;
                 break;
         }
     }
@@ -410,6 +425,23 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
             return _screenBuffer[y, x];
         }
     }
+    
+    /// <summary>
+    /// Gets a snapshot of the scrollback buffer rows from the underlying terminal.
+    /// Returns rows ordered oldest to newest.
+    /// </summary>
+    /// <param name="count">Maximum number of scrollback rows to return.</param>
+    /// <returns>Array of scrollback rows, or empty if scrollback is not enabled.</returns>
+    public ScrollbackRow[] GetScrollbackSnapshot(int count)
+    {
+        return _terminal?.GetScrollbackRows(count) ?? [];
+    }
+    
+    /// <summary>
+    /// Gets the number of rows currently in the scrollback buffer.
+    /// Returns 0 if scrollback is not enabled.
+    /// </summary>
+    public int ScrollbackCount => _terminal?.ScrollbackCount ?? 0;
     
     private void ClearBuffer()
     {

--- a/src/Hex1b/Tokens/AnsiTokenizer.cs
+++ b/src/Hex1b/Tokens/AnsiTokenizer.cs
@@ -310,20 +310,27 @@ public static class AnsiTokenizer
 
             case 'h':
             case 'l':
-                // Set/reset mode
-                if (isPrivateMode && int.TryParse(parameters, out var modeValue))
+                // Set/reset mode — may contain multiple semicolon-separated parameters
+                // e.g., CSI ? 1002;1006;2004 h (sets modes 1002, 1006, and 2004 at once)
+                if (isPrivateMode)
                 {
-                    tokens.Add(new PrivateModeToken(modeValue, command == 'h'));
-                }
-                else if (!isPrivateMode && int.TryParse(parameters, out var stdMode))
-                {
-                    // Standard (non-private) mode: CSI n h / CSI n l
-                    tokens.Add(new StandardModeToken(stdMode, command == 'h'));
+                    foreach (var part in parameters.Split(';'))
+                    {
+                        if (int.TryParse(part, out var modeValue))
+                        {
+                            tokens.Add(new PrivateModeToken(modeValue, command == 'h'));
+                        }
+                    }
                 }
                 else
                 {
-                    // Invalid or unsupported mode
-                    tokens.Add(new UnrecognizedSequenceToken(text[start..(end + 1)]));
+                    foreach (var part in parameters.Split(';'))
+                    {
+                        if (int.TryParse(part, out var stdMode))
+                        {
+                            tokens.Add(new StandardModeToken(stdMode, command == 'h'));
+                        }
+                    }
                 }
                 break;
 

--- a/src/Hex1b/Widgets/TerminalWidget.cs
+++ b/src/Hex1b/Widgets/TerminalWidget.cs
@@ -63,6 +63,11 @@ public sealed record TerminalWidget(TerminalWidgetHandle Handle) : Hex1bWidget
     /// </summary>
     internal Func<TerminalNotRunningArgs, Hex1bWidget>? NotRunningBuilder { get; init; }
     
+    /// <summary>
+    /// Gets the number of rows to scroll per mouse wheel tick. Defaults to 3.
+    /// </summary>
+    public int MouseWheelScrollAmount { get; init; } = 3;
+    
     internal override async Task<Hex1bNode> ReconcileAsync(Hex1bNode? existingNode, ReconcileContext context)
     {
         var node = existingNode as TerminalNode ?? new TerminalNode();
@@ -76,6 +81,7 @@ public sealed record TerminalWidget(TerminalWidgetHandle Handle) : Hex1bWidget
         node.Handle = Handle;
         node.SourceWidget = this;
         node.NotRunningBuilder = NotRunningBuilder;
+        node.MouseWheelScrollAmount = MouseWheelScrollAmount;
         
         // Set the invalidate callback so the node can trigger re-renders when output arrives
         if (context.InvalidateCallback != null)

--- a/src/Hex1b/Widgets/TerminalWidget.cs
+++ b/src/Hex1b/Widgets/TerminalWidget.cs
@@ -1,3 +1,4 @@
+using Hex1b.Input;
 using Hex1b.Nodes;
 
 namespace Hex1b.Widgets;
@@ -44,6 +45,19 @@ public sealed record TerminalNotRunningArgs(
 /// </remarks>
 public sealed record TerminalWidget(TerminalWidgetHandle Handle) : Hex1bWidget
 {
+    /// <summary>Rebindable action: Scroll up one line in the scrollback buffer.</summary>
+    public static readonly ActionId ScrollUpLine = new($"{nameof(TerminalWidget)}.{nameof(ScrollUpLine)}");
+    /// <summary>Rebindable action: Scroll down one line in the scrollback buffer.</summary>
+    public static readonly ActionId ScrollDownLine = new($"{nameof(TerminalWidget)}.{nameof(ScrollDownLine)}");
+    /// <summary>Rebindable action: Scroll up one page in the scrollback buffer.</summary>
+    public static readonly ActionId ScrollUpPage = new($"{nameof(TerminalWidget)}.{nameof(ScrollUpPage)}");
+    /// <summary>Rebindable action: Scroll down one page in the scrollback buffer.</summary>
+    public static readonly ActionId ScrollDownPage = new($"{nameof(TerminalWidget)}.{nameof(ScrollDownPage)}");
+    /// <summary>Rebindable action: Scroll to the top of the scrollback buffer.</summary>
+    public static readonly ActionId ScrollToTop = new($"{nameof(TerminalWidget)}.{nameof(ScrollToTop)}");
+    /// <summary>Rebindable action: Scroll to the bottom, returning to the live terminal view.</summary>
+    public static readonly ActionId ScrollToBottom = new($"{nameof(TerminalWidget)}.{nameof(ScrollToBottom)}");
+
     /// <summary>
     /// Gets the callback that builds a fallback widget when the terminal is not running.
     /// </summary>

--- a/tests/Hex1b.Tests/AnsiTokenizerTests.cs
+++ b/tests/Hex1b.Tests/AnsiTokenizerTests.cs
@@ -360,6 +360,84 @@ public class AnsiTokenizerTests
         Assert.False(pmToken.Enable);
     }
 
+    [Fact]
+    public void Tokenize_MultiplePrivateModesEnable_EmitsTokenPerMode()
+    {
+        // edit.exe sends this to enable mouse tracking + SGR mouse + bracketed paste
+        var result = AnsiTokenizer.Tokenize("\x1b[?1002;1006;2004h");
+
+        Assert.Equal(3, result.Count);
+        var pm0 = Assert.IsType<PrivateModeToken>(result[0]);
+        Assert.Equal(1002, pm0.Mode);
+        Assert.True(pm0.Enable);
+        var pm1 = Assert.IsType<PrivateModeToken>(result[1]);
+        Assert.Equal(1006, pm1.Mode);
+        Assert.True(pm1.Enable);
+        var pm2 = Assert.IsType<PrivateModeToken>(result[2]);
+        Assert.Equal(2004, pm2.Mode);
+        Assert.True(pm2.Enable);
+    }
+
+    [Fact]
+    public void Tokenize_MultiplePrivateModesDisable_EmitsTokenPerMode()
+    {
+        // edit.exe cleanup sequence
+        var result = AnsiTokenizer.Tokenize("\x1b[?1002;1006;2004l");
+
+        Assert.Equal(3, result.Count);
+        var pm0 = Assert.IsType<PrivateModeToken>(result[0]);
+        Assert.Equal(1002, pm0.Mode);
+        Assert.False(pm0.Enable);
+        var pm1 = Assert.IsType<PrivateModeToken>(result[1]);
+        Assert.Equal(1006, pm1.Mode);
+        Assert.False(pm1.Enable);
+        var pm2 = Assert.IsType<PrivateModeToken>(result[2]);
+        Assert.Equal(2004, pm2.Mode);
+        Assert.False(pm2.Enable);
+    }
+
+    [Fact]
+    public void Tokenize_TwoPrivateModesEnable_EmitsTokenPerMode()
+    {
+        // Common pattern: alt screen + cursor hide
+        var result = AnsiTokenizer.Tokenize("\x1b[?1049;25h");
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(1049, Assert.IsType<PrivateModeToken>(result[0]).Mode);
+        Assert.Equal(25, Assert.IsType<PrivateModeToken>(result[1]).Mode);
+    }
+
+    [Fact]
+    public void Tokenize_MultipleStandardModesEnable_EmitsTokenPerMode()
+    {
+        var result = AnsiTokenizer.Tokenize("\x1b[4;20h");
+
+        Assert.Equal(2, result.Count);
+        var sm0 = Assert.IsType<StandardModeToken>(result[0]);
+        Assert.Equal(4, sm0.Mode);
+        Assert.True(sm0.Enable);
+        var sm1 = Assert.IsType<StandardModeToken>(result[1]);
+        Assert.Equal(20, sm1.Mode);
+        Assert.True(sm1.Enable);
+    }
+
+    [Fact]
+    public void Tokenize_MouseTrackingModes_AllRecognized()
+    {
+        // Verify all mouse tracking private modes are correctly tokenized
+        var result1000 = AnsiTokenizer.Tokenize("\x1b[?1000h");
+        Assert.Equal(1000, Assert.IsType<PrivateModeToken>(Assert.Single(result1000)).Mode);
+
+        var result1002 = AnsiTokenizer.Tokenize("\x1b[?1002h");
+        Assert.Equal(1002, Assert.IsType<PrivateModeToken>(Assert.Single(result1002)).Mode);
+
+        var result1003 = AnsiTokenizer.Tokenize("\x1b[?1003h");
+        Assert.Equal(1003, Assert.IsType<PrivateModeToken>(Assert.Single(result1003)).Mode);
+
+        var result1006 = AnsiTokenizer.Tokenize("\x1b[?1006h");
+        Assert.Equal(1006, Assert.IsType<PrivateModeToken>(Assert.Single(result1006)).Mode);
+    }
+
     #endregion
 
     #region Cursor Shape Tests

--- a/tests/Hex1b.Tests/TerminalNodeScrollbackTests.cs
+++ b/tests/Hex1b.Tests/TerminalNodeScrollbackTests.cs
@@ -1,0 +1,386 @@
+using Hex1b.Input;
+using Hex1b.Layout;
+using Hex1b.Nodes;
+using Hex1b.Tokens;
+using Hex1b.Widgets;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Tests for terminal scrollback support in TerminalNode and TerminalWidgetHandle.
+/// </summary>
+public class TerminalNodeScrollbackTests
+{
+    // Helper to create AppliedToken for PrivateMode sequences
+    private static AppliedToken PrivateModeApplied(int mode, bool enable)
+        => AppliedToken.WithNoCellImpacts(new PrivateModeToken(mode, enable), 0, 0, 0, 0);
+
+    #region TerminalWidgetHandle - Alternate Screen Tracking
+
+    [Fact]
+    public void Handle_InAlternateScreen_DefaultsFalse()
+    {
+        var handle = new TerminalWidgetHandle(80, 24);
+        Assert.False(handle.InAlternateScreen);
+    }
+
+    [Fact]
+    public async Task Handle_PrivateMode1049Enable_SetsInAlternateScreen()
+    {
+        var handle = new TerminalWidgetHandle(80, 24);
+
+        await handle.WriteOutputWithImpactsAsync([PrivateModeApplied(1049, true)]);
+
+        Assert.True(handle.InAlternateScreen);
+    }
+
+    [Fact]
+    public async Task Handle_PrivateMode1049Disable_ClearsInAlternateScreen()
+    {
+        var handle = new TerminalWidgetHandle(80, 24);
+
+        await handle.WriteOutputWithImpactsAsync([PrivateModeApplied(1049, true)]);
+        await handle.WriteOutputWithImpactsAsync([PrivateModeApplied(1049, false)]);
+
+        Assert.False(handle.InAlternateScreen);
+    }
+
+    #endregion
+
+    #region TerminalWidgetHandle - Scrollback Access
+
+    [Fact]
+    public void Handle_ScrollbackCount_ReturnsZeroWithoutTerminal()
+    {
+        var handle = new TerminalWidgetHandle(80, 24);
+        Assert.Equal(0, handle.ScrollbackCount);
+    }
+
+    [Fact]
+    public void Handle_GetScrollbackSnapshot_ReturnsEmptyWithoutTerminal()
+    {
+        var handle = new TerminalWidgetHandle(80, 24);
+        var rows = handle.GetScrollbackSnapshot(100);
+        Assert.Empty(rows);
+    }
+
+    [Fact]
+    public void Handle_ScrollbackCount_ReturnsCountWhenTerminalHasScrollback()
+    {
+        var handle = new TerminalWidgetHandle(80, 24);
+        var terminal = CreateTerminalWithScrollback(80, 24, scrollbackCapacity: 100);
+        SetTerminalOnHandle(handle, terminal);
+        PopulateScrollback(terminal, 50);
+
+        Assert.True(handle.ScrollbackCount > 0);
+    }
+
+    [Fact]
+    public void Handle_GetScrollbackSnapshot_ReturnsRowsWhenTerminalHasScrollback()
+    {
+        var handle = new TerminalWidgetHandle(80, 24);
+        var terminal = CreateTerminalWithScrollback(80, 24, scrollbackCapacity: 100);
+        SetTerminalOnHandle(handle, terminal);
+        PopulateScrollback(terminal, 50);
+
+        var rows = handle.GetScrollbackSnapshot(100);
+        Assert.NotEmpty(rows);
+    }
+
+    #endregion
+
+    #region TerminalNode - Scrollback Offset
+
+    [Fact]
+    public void ScrollbackOffset_DefaultsToZero()
+    {
+        var node = new TerminalNode();
+        Assert.Equal(0, node.ScrollbackOffset);
+        Assert.False(node.IsInScrollbackMode);
+    }
+
+    #endregion
+
+    #region TerminalNode - Input Interception
+
+    [Fact]
+    public void HandleInput_WhenInScrollbackMode_DoesNotForwardKeyboard()
+    {
+        var handle = CreateRunningHandle();
+        var node = CreateBoundNode(handle);
+
+        // Manually set scrollback offset to simulate being in scrollback mode
+        SetScrollbackOffset(node, 5);
+
+        var keyEvent = new Hex1bKeyEvent(Hex1bKey.A, "a", Hex1bModifiers.None);
+        var result = node.HandleInput(keyEvent);
+
+        // Should return NotHandled (not forwarded to terminal)
+        Assert.Equal(InputResult.NotHandled, result);
+    }
+
+    [Fact]
+    public void HandleInput_WhenNotInScrollbackMode_ForwardsKeyboard()
+    {
+        var handle = CreateRunningHandle();
+        var node = CreateBoundNode(handle);
+
+        var keyEvent = new Hex1bKeyEvent(Hex1bKey.A, "a", Hex1bModifiers.None);
+        var result = node.HandleInput(keyEvent);
+
+        // Should return Handled (forwarded to terminal)
+        Assert.Equal(InputResult.Handled, result);
+    }
+
+    [Fact]
+    public void HandleInput_MouseEvent_WhenInScrollbackMode_StillForwarded()
+    {
+        var handle = CreateRunningHandle();
+        var node = CreateBoundNode(handle);
+
+        SetScrollbackOffset(node, 5);
+
+        // Non-keyboard events should still be forwarded (scrollback only intercepts keyboard)
+        var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 5, 5, Hex1bModifiers.None);
+        var result = node.HandleInput(mouseEvent);
+
+        Assert.Equal(InputResult.Handled, result);
+    }
+
+    #endregion
+
+    #region TerminalNode - Mouse Scroll Routing
+
+    [Fact]
+    public async Task HandleMouseClick_ScrollWheel_WhenMouseTrackingEnabled_ForwardsToChild()
+    {
+        var handle = CreateRunningHandle();
+        var node = CreateBoundNode(handle);
+
+        // Enable mouse tracking via escape sequence
+        await handle.WriteOutputWithImpactsAsync([PrivateModeApplied(1000, true)]);
+
+        var scrollEvent = new Hex1bMouseEvent(MouseButton.ScrollUp, MouseAction.Down, 5, 5, Hex1bModifiers.None);
+        var result = node.HandleMouseClick(5, 5, scrollEvent);
+
+        // When child has mouse tracking, scroll events are forwarded
+        Assert.Equal(InputResult.Handled, result);
+    }
+
+    [Fact]
+    public void HandleMouseClick_ScrollWheel_WhenNoMouseTracking_ReturnsNotHandled()
+    {
+        var handle = CreateRunningHandle();
+        var node = CreateBoundNode(handle);
+
+        var scrollEvent = new Hex1bMouseEvent(MouseButton.ScrollUp, MouseAction.Down, 5, 5, Hex1bModifiers.None);
+        var result = node.HandleMouseClick(5, 5, scrollEvent);
+
+        // Scroll events should return NotHandled so input binding system handles them
+        Assert.Equal(InputResult.NotHandled, result);
+    }
+
+    [Fact]
+    public void HandleMouseClick_NonScroll_WhenNoMouseTracking_ForwardsToChild()
+    {
+        var handle = CreateRunningHandle();
+        var node = CreateBoundNode(handle);
+
+        var clickEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 5, 5, Hex1bModifiers.None);
+        var result = node.HandleMouseClick(5, 5, clickEvent);
+
+        // Non-scroll mouse events are forwarded
+        Assert.Equal(InputResult.Handled, result);
+    }
+
+    [Fact]
+    public void HandleMouseClick_ScrollDown_WhenNoMouseTracking_ReturnsNotHandled()
+    {
+        var handle = CreateRunningHandle();
+        var node = CreateBoundNode(handle);
+
+        var scrollEvent = new Hex1bMouseEvent(MouseButton.ScrollDown, MouseAction.Down, 5, 5, Hex1bModifiers.None);
+        var result = node.HandleMouseClick(5, 5, scrollEvent);
+
+        Assert.Equal(InputResult.NotHandled, result);
+    }
+
+    #endregion
+
+    #region TerminalNode - ConfigureDefaultBindings
+
+    [Fact]
+    public void ConfigureDefaultBindings_RegistersAllScrollbackActions()
+    {
+        var node = new TerminalNode();
+        var bindings = new InputBindingsBuilder();
+        node.ConfigureDefaultBindings(bindings);
+
+        var actionIds = bindings.GetAllActionIds();
+        Assert.Contains(TerminalWidget.ScrollUpLine, actionIds);
+        Assert.Contains(TerminalWidget.ScrollDownLine, actionIds);
+        Assert.Contains(TerminalWidget.ScrollUpPage, actionIds);
+        Assert.Contains(TerminalWidget.ScrollDownPage, actionIds);
+        Assert.Contains(TerminalWidget.ScrollToTop, actionIds);
+        Assert.Contains(TerminalWidget.ScrollToBottom, actionIds);
+    }
+
+    [Fact]
+    public void ConfigureDefaultBindings_RegistersMouseScrollBindings()
+    {
+        var node = new TerminalNode();
+        var bindings = new InputBindingsBuilder();
+        node.ConfigureDefaultBindings(bindings);
+
+        var mouseBindings = bindings.MouseBindings;
+        Assert.Contains(mouseBindings, b => b.Button == MouseButton.ScrollUp);
+        Assert.Contains(mouseBindings, b => b.Button == MouseButton.ScrollDown);
+    }
+
+    [Fact]
+    public void ConfigureDefaultBindings_HasKeyboardBindingsForScrollback()
+    {
+        var node = new TerminalNode();
+        var bindings = new InputBindingsBuilder();
+        node.ConfigureDefaultBindings(bindings);
+
+        // Should have 6 keyboard bindings (ScrollUpLine, ScrollDownLine, ScrollUpPage, ScrollDownPage, ScrollToTop, ScrollToBottom)
+        Assert.True(bindings.Bindings.Count >= 6, $"Expected at least 6 key bindings, got {bindings.Bindings.Count}");
+    }
+
+    #endregion
+
+    #region TerminalWidget - ActionId Names
+
+    [Fact]
+    public void ActionIds_FollowNamingConvention()
+    {
+        Assert.Equal("TerminalWidget.ScrollUpLine", TerminalWidget.ScrollUpLine.Value);
+        Assert.Equal("TerminalWidget.ScrollDownLine", TerminalWidget.ScrollDownLine.Value);
+        Assert.Equal("TerminalWidget.ScrollUpPage", TerminalWidget.ScrollUpPage.Value);
+        Assert.Equal("TerminalWidget.ScrollDownPage", TerminalWidget.ScrollDownPage.Value);
+        Assert.Equal("TerminalWidget.ScrollToTop", TerminalWidget.ScrollToTop.Value);
+        Assert.Equal("TerminalWidget.ScrollToBottom", TerminalWidget.ScrollToBottom.Value);
+    }
+
+    #endregion
+
+    #region Hex1bTerminal - Scrollback Access
+
+    [Fact]
+    public void Terminal_ScrollbackCount_ReturnsZeroWhenNotEnabled()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithHeadless()
+            .WithDimensions(80, 24)
+            .Build();
+
+        Assert.Equal(0, terminal.ScrollbackCount);
+    }
+
+    [Fact]
+    public void Terminal_ScrollbackCount_ReturnsCountWhenEnabled()
+    {
+        var terminal = CreateTerminalWithScrollback(80, 24, scrollbackCapacity: 100);
+        PopulateScrollback(terminal, 50);
+
+        Assert.True(terminal.ScrollbackCount > 0);
+    }
+
+    [Fact]
+    public void Terminal_GetScrollbackRows_ReturnsEmptyWhenNotEnabled()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithHeadless()
+            .WithDimensions(80, 24)
+            .Build();
+
+        var rows = terminal.GetScrollbackRows(100);
+        Assert.Empty(rows);
+    }
+
+    [Fact]
+    public void Terminal_GetScrollbackRows_ReturnsRowsWhenEnabled()
+    {
+        var terminal = CreateTerminalWithScrollback(80, 24, scrollbackCapacity: 100);
+        PopulateScrollback(terminal, 50);
+
+        var rows = terminal.GetScrollbackRows(100);
+        Assert.NotEmpty(rows);
+    }
+
+    [Fact]
+    public void Terminal_GetScrollbackRows_RespectsCountLimit()
+    {
+        var terminal = CreateTerminalWithScrollback(80, 24, scrollbackCapacity: 100);
+        PopulateScrollback(terminal, 50);
+
+        var rows = terminal.GetScrollbackRows(5);
+        Assert.True(rows.Length <= 5);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static TerminalWidgetHandle CreateRunningHandle()
+    {
+        var handle = new TerminalWidgetHandle(80, 24);
+        var stateField = typeof(TerminalWidgetHandle).GetField("_state",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        stateField!.SetValue(handle, TerminalState.Running);
+        return handle;
+    }
+
+    private static TerminalNode CreateBoundNode(TerminalWidgetHandle handle)
+    {
+        var node = new TerminalNode { Handle = handle };
+        node.SetInvalidateCallback(() => { });
+        node.Bind();
+        node.Arrange(new Rect(0, 0, 80, 24));
+        return node;
+    }
+
+    private static void SetScrollbackOffset(TerminalNode node, int offset)
+    {
+        var field = typeof(TerminalNode).GetField("_scrollbackOffset",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        field!.SetValue(node, offset);
+    }
+
+    private static void SetTerminalOnHandle(TerminalWidgetHandle handle, Hex1bTerminal terminal)
+    {
+        var terminalField = typeof(TerminalWidgetHandle).GetField("_terminal",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        terminalField!.SetValue(handle, terminal);
+    }
+
+    private static Hex1bTerminal CreateTerminalWithScrollback(int width, int height, int scrollbackCapacity)
+    {
+        var workload = new Hex1bAppWorkloadAdapter();
+        return Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithHeadless()
+            .WithDimensions(width, height)
+            .WithScrollback(scrollbackCapacity)
+            .Build();
+    }
+
+    private static void PopulateScrollback(Hex1bTerminal terminal, int lineCount)
+    {
+        // Write enough lines to push content into scrollback
+        var tokens = new List<AnsiToken>();
+        for (int i = 0; i < lineCount; i++)
+        {
+            tokens.Add(new TextToken($"Line {i}"));
+            tokens.Add(ControlCharacterToken.LineFeed);
+        }
+        terminal.ApplyTokens(tokens);
+    }
+
+    #endregion
+}

--- a/tests/Hex1b.Tests/TerminalNodeScrollbackTests.cs
+++ b/tests/Hex1b.Tests/TerminalNodeScrollbackTests.cs
@@ -104,19 +104,22 @@ public class TerminalNodeScrollbackTests
     #region TerminalNode - Input Interception
 
     [Fact]
-    public void HandleInput_WhenInScrollbackMode_DoesNotForwardKeyboard()
+    public void HandleInput_WhenInScrollbackMode_SnapsToLiveAndForwardsKeyboard()
     {
         var handle = CreateRunningHandle();
         var node = CreateBoundNode(handle);
 
         // Manually set scrollback offset to simulate being in scrollback mode
         SetScrollbackOffset(node, 5);
+        Assert.True(node.IsInScrollbackMode);
 
         var keyEvent = new Hex1bKeyEvent(Hex1bKey.A, "a", Hex1bModifiers.None);
         var result = node.HandleInput(keyEvent);
 
-        // Should return NotHandled (not forwarded to terminal)
-        Assert.Equal(InputResult.NotHandled, result);
+        // Should snap back to live view and forward the key
+        Assert.Equal(InputResult.Handled, result);
+        Assert.Equal(0, node.ScrollbackOffset);
+        Assert.False(node.IsInScrollbackMode);
     }
 
     [Fact]

--- a/tests/Hex1b.Tests/TerminalWidgetSizeAlignmentTests.cs
+++ b/tests/Hex1b.Tests/TerminalWidgetSizeAlignmentTests.cs
@@ -1,0 +1,281 @@
+using Hex1b.Input;
+using Hex1b.Layout;
+using Hex1b.Nodes;
+using Hex1b.Widgets;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Tests demonstrating the terminal widget size misalignment issue.
+/// When a TerminalWidget is embedded in a Hex1bApp, the PTY process may start
+/// at the initial WithDimensions() size (e.g., 80x24) instead of the actual
+/// layout bounds (e.g., 120x40), causing rendering glitches for full-screen apps.
+/// </summary>
+public class TerminalWidgetSizeAlignmentTests
+{
+    /// <summary>
+    /// Demonstrates the core problem: after RunAsync starts and ArrangeCore fires,
+    /// all components should agree on dimensions. This test verifies the dimension
+    /// chain: handle → terminal → workload (child process).
+    /// </summary>
+    [Fact]
+    public async Task AllComponents_ShouldAgreeOnDimensions_AfterStartupAndArrange()
+    {
+        // Simulate: terminal created at 80x24, widget laid out at 120x40
+        const int InitialWidth = 80;
+        const int InitialHeight = 24;
+        const int LayoutWidth = 120;
+        const int LayoutHeight = 40;
+        
+        using var cts = new CancellationTokenSource();
+        
+        var builder = Hex1bTerminal.CreateBuilder()
+            .WithDimensions(InitialWidth, InitialHeight)
+            .WithScrollback(100);
+
+        // Use diagnostic shell so we don't need a real PTY
+        builder = builder.WithDiagnosticShell();
+
+        var terminal = builder
+            .WithTerminalWidget(out var handle)
+            .Build();
+
+        // Start RunAsync on a background thread (same pattern as ScrollbackDemo)
+        var runTask = Task.Run(async () =>
+        {
+            try { await terminal.RunAsync(cts.Token); }
+            catch (OperationCanceledException) { }
+        });
+
+        // Wait for terminal to transition to Running
+        var timeout = TimeSpan.FromSeconds(5);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (handle.State != TerminalState.Running && sw.Elapsed < timeout)
+        {
+            await Task.Delay(10);
+        }
+        Assert.Equal(TerminalState.Running, handle.State);
+
+        // Simulate what ArrangeCore does: resize the handle to layout bounds
+        handle.Resize(LayoutWidth, LayoutHeight);
+        
+        // Allow async resize to propagate
+        await Task.Delay(100);
+
+        // Verify ALL components agree on the new dimensions
+        Assert.Equal(LayoutWidth, handle.Width);
+        Assert.Equal(LayoutHeight, handle.Height);
+        Assert.Equal(LayoutWidth, terminal.Width);
+        Assert.Equal(LayoutHeight, terminal.Height);
+
+        // Clean up
+        cts.Cancel();
+        try { await runTask; } catch { }
+        await terminal.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Demonstrates the race condition: when RunAsync starts before the first
+    /// ArrangeCore, the PTY may be created with stale dimensions.
+    /// This test creates a real PTY process to check if the workload's stored
+    /// dimensions match after resize.
+    /// </summary>
+    [Fact]
+    public async Task WorkloadDimensions_ShouldMatchLayout_AfterResize()
+    {
+        const int InitialWidth = 80;
+        const int InitialHeight = 24;
+        const int LayoutWidth = 120;
+        const int LayoutHeight = 40;
+        
+        using var cts = new CancellationTokenSource();
+        
+        var terminal = Hex1bTerminal.CreateBuilder()
+            .WithDimensions(InitialWidth, InitialHeight)
+            .WithDiagnosticShell()
+            .WithTerminalWidget(out var handle)
+            .Build();
+
+        // Start terminal
+        var runTask = Task.Run(async () =>
+        {
+            try { await terminal.RunAsync(cts.Token); }
+            catch (OperationCanceledException) { }
+        });
+
+        // Wait for Running
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (handle.State != TerminalState.Running && sw.Elapsed < TimeSpan.FromSeconds(5))
+            await Task.Delay(10);
+
+        // Resize handle (simulates ArrangeCore)
+        handle.Resize(LayoutWidth, LayoutHeight);
+        await Task.Delay(100);
+
+        // Check the workload's dimension tracking
+        var workload = terminal.Workload;
+        if (workload is Hex1bTerminalChildProcess childProcess)
+        {
+            Assert.Equal(LayoutWidth, childProcess.Width);
+            Assert.Equal(LayoutHeight, childProcess.Height);
+        }
+
+        cts.Cancel();
+        try { await runTask; } catch { }
+        await terminal.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Tests that resizing the handle BEFORE RunAsync starts correctly
+    /// propagates to the terminal and workload dimensions.
+    /// This simulates the case where ArrangeCore runs first (race won by UI thread).
+    /// </summary>
+    [Fact]
+    public async Task ResizeBeforeStart_ShouldPropagateToAllComponents()
+    {
+        const int InitialWidth = 80;
+        const int InitialHeight = 24;
+        const int LayoutWidth = 120;
+        const int LayoutHeight = 40;
+        
+        using var cts = new CancellationTokenSource();
+        
+        var terminal = Hex1bTerminal.CreateBuilder()
+            .WithDimensions(InitialWidth, InitialHeight)
+            .WithDiagnosticShell()
+            .WithTerminalWidget(out var handle)
+            .Build();
+
+        // Resize BEFORE starting (simulates ArrangeCore running before RunAsync)
+        handle.Resize(LayoutWidth, LayoutHeight);
+        
+        // Verify terminal got the resize
+        Assert.Equal(LayoutWidth, terminal.Width);
+        Assert.Equal(LayoutHeight, terminal.Height);
+        
+        // Now start
+        var runTask = Task.Run(async () =>
+        {
+            try { await terminal.RunAsync(cts.Token); }
+            catch (OperationCanceledException) { }
+        });
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (handle.State != TerminalState.Running && sw.Elapsed < TimeSpan.FromSeconds(5))
+            await Task.Delay(10);
+
+        // Dimensions should still match after startup
+        Assert.Equal(LayoutWidth, handle.Width);
+        Assert.Equal(LayoutHeight, handle.Height);
+        Assert.Equal(LayoutWidth, terminal.Width);
+        Assert.Equal(LayoutHeight, terminal.Height);
+
+        cts.Cancel();
+        try { await runTask; } catch { }
+        await terminal.DisposeAsync();
+    }
+
+    /// <summary>
+    /// Tests the TerminalNode arrange → resize flow end-to-end.
+    /// Creates a TerminalNode, arranges it at different bounds than the handle's
+    /// initial size, and verifies the handle gets resized.
+    /// </summary>
+    [Fact]
+    public void ArrangeCore_ResizesHandle_ToMatchLayoutBounds()
+    {
+        var handle = new TerminalWidgetHandle(80, 24);
+        
+        // Set state to Running so ArrangeCore doesn't take the fallback path
+        var stateField = typeof(TerminalWidgetHandle).GetField("_state",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        stateField!.SetValue(handle, TerminalState.Running);
+        
+        var node = new TerminalNode { Handle = handle };
+        node.SetInvalidateCallback(() => { });
+        node.Bind();
+        
+        // First arrange at 120x40 (simulates first layout pass)
+        node.Arrange(new Rect(0, 0, 120, 40));
+        
+        Assert.Equal(120, handle.Width);
+        Assert.Equal(40, handle.Height);
+    }
+    
+    /// <summary>
+    /// Tests that ArrangeCore resizes the handle even when terminal is NotStarted
+    /// and a fallback child exists. This was previously broken (early return skipped resize).
+    /// </summary>
+    [Fact]
+    public void ArrangeCore_ResizesHandle_EvenWhenShowingFallback()
+    {
+        var handle = new TerminalWidgetHandle(80, 24);
+        // State stays NotStarted (default)
+        
+        var node = new TerminalNode
+        {
+            Handle = handle,
+            NotRunningBuilder = args => throw new NotImplementedException("should not be called in arrange"),
+            FallbackChild = new TextBlockNode() // Dummy fallback
+        };
+        node.SetInvalidateCallback(() => { });
+        
+        // Arrange at 120x40
+        node.Arrange(new Rect(0, 0, 120, 40));
+        
+        // Handle should be resized even though fallback is shown
+        Assert.Equal(120, handle.Width);
+        Assert.Equal(40, handle.Height);
+    }
+
+    /// <summary>
+    /// Reproduces the race condition scenario from the ScrollbackDemo:
+    /// - Terminal built at 80x24
+    /// - RunAsync started on background thread 
+    /// - Widget arranged at larger size
+    /// - Verifies that after a brief settle, dimensions are consistent
+    /// </summary>
+    [Fact]
+    public async Task ScrollbackDemoPattern_DimensionsShouldConverge()
+    {
+        const int InitialWidth = 80;
+        const int InitialHeight = 24;
+        const int LayoutWidth = 132;
+        const int LayoutHeight = 43;
+
+        using var cts = new CancellationTokenSource();
+
+        var terminal = Hex1bTerminal.CreateBuilder()
+            .WithDimensions(InitialWidth, InitialHeight)
+            .WithScrollback(1000)
+            .WithDiagnosticShell()
+            .WithTerminalWidget(out var handle)
+            .Build();
+
+        // Pattern from ScrollbackDemo: fire-and-forget RunAsync
+        _ = Task.Run(async () =>
+        {
+            try { await terminal.RunAsync(cts.Token); }
+            catch (OperationCanceledException) { }
+        });
+
+        // Simulate first ArrangeCore (may race with RunAsync)
+        handle.Resize(LayoutWidth, LayoutHeight);
+
+        // Wait for terminal to be running and dimensions to settle
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (handle.State != TerminalState.Running && sw.Elapsed < TimeSpan.FromSeconds(5))
+            await Task.Delay(10);
+        
+        // Give async operations time to complete
+        await Task.Delay(200);
+
+        // ALL dimensions should agree on the layout size
+        Assert.Equal(LayoutWidth, handle.Width);
+        Assert.Equal(LayoutHeight, handle.Height);
+        Assert.Equal(LayoutWidth, terminal.Width);
+        Assert.Equal(LayoutHeight, terminal.Height);
+
+        cts.Cancel();
+        await terminal.DisposeAsync();
+    }
+}


### PR DESCRIPTION
## Summary

Enable interactive scrollback viewing in the TerminalWidget. Users can scroll through previous terminal output using keyboard shortcuts or mouse wheel.

## Changes

### Core library
- **Hex1bTerminal**: Add public \GetScrollbackRows()\, \ScrollbackCount\, and \GetScreenBufferSnapshot()\ for thread-safe buffer access
- **ScrollbackBuffer**: Make \ScrollbackRow\ public (needed for public API)
- **TerminalWidgetHandle**: Track alternate screen mode (1049), expose \InAlternateScreen\, \GetScrollbackSnapshot()\, \ScrollbackCount\. Return terminal's authoritative buffer from \GetScreenBufferSnapshot()\ to avoid post-reflow misalignment.
- **TerminalWidget**: Add 6 \ActionId\ constants for rebindable scrollback actions
- **TerminalNode**: Scrollback view state, composite render, input interception during scrollback, \ConfigureDefaultBindings\ with keyboard and mouse bindings. Snap to live view when typing. Clear region before render to avoid transparent cell compositing artifacts.
- **Hex1bApp**: Adjust cursor Y position by scrollback offset; hide cursor when pushed below terminal bounds

### Bug fixes (pre-existing)
- **ArrangeCore**: Resize handle even when showing fallback widget, so PTY starts at correct layout size instead of initial \WithDimensions()\ size

### Default keybindings (all rebindable)
| Action | Binding |
|--------|---------|
| Scroll line | \Shift+↑/↓\, mouse wheel |
| Scroll page | \Shift+PageUp/PageDown\ |
| Top/bottom | \Shift+Home/End\ |

### Mouse routing
Scroll events go to child when workload has enabled mouse tracking via escape sequences (mode 1000/1002/1003); otherwise they control the scrollback view.

### Samples
- **New \ScrollbackTerminalDemo\**: Dedicated sample with status bar showing scroll position
- **WindowingDemo**: Added \.WithScrollback(1000)\ to enable scrollback on embedded terminals

### Tests
- 24 new tests covering alternate screen tracking, scrollback access, offset behavior, input interception, mouse scroll routing, keybinding registration, ActionId naming, and terminal scrollback access