### PR TITLE
Add 58 psmux-inspired VT escape sequence tests

### DIFF
--- a/tests/Hex1b.Tests/BracketedPasteEdgeCaseTests.cs
+++ b/tests/Hex1b.Tests/BracketedPasteEdgeCaseTests.cs
@@ -1,0 +1,92 @@
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Tests for bracketed paste tokenization edge cases.
+/// Verifies that CSI 200~ and CSI 201~ are correctly tokenized as SpecialKeyTokens,
+/// and that content between paste markers tokenizes correctly even with unusual content.
+/// Inspired by psmux's test_ssh_vt_paste.rs edge cases.
+/// </summary>
+public class BracketedPasteEdgeCaseTests
+{
+    [Fact]
+    public void Tokenize_PasteStartMarker_ReturnsSpecialKeyToken200()
+    {
+        var result = AnsiTokenizer.Tokenize("\x1b[200~");
+
+        var token = Assert.Single(result);
+        var sk = Assert.IsType<SpecialKeyToken>(token);
+        Assert.Equal(200, sk.KeyCode);
+    }
+
+    [Fact]
+    public void Tokenize_PasteEndMarker_ReturnsSpecialKeyToken201()
+    {
+        var result = AnsiTokenizer.Tokenize("\x1b[201~");
+
+        var token = Assert.Single(result);
+        var sk = Assert.IsType<SpecialKeyToken>(token);
+        Assert.Equal(201, sk.KeyCode);
+    }
+
+    [Fact]
+    public void Tokenize_CompletePasteSequence_ProducesStartContentEnd()
+    {
+        var result = AnsiTokenizer.Tokenize("\x1b[200~hello world\x1b[201~");
+
+        Assert.Equal(3, result.Count);
+        Assert.IsType<SpecialKeyToken>(result[0]);
+        Assert.Equal(200, ((SpecialKeyToken)result[0]).KeyCode);
+
+        Assert.IsType<TextToken>(result[1]);
+        Assert.Equal("hello world", ((TextToken)result[1]).Text);
+
+        Assert.IsType<SpecialKeyToken>(result[2]);
+        Assert.Equal(201, ((SpecialKeyToken)result[2]).KeyCode);
+    }
+
+    [Fact]
+    public void Tokenize_PasteWithEscInsideContent_TokenizesEscSeparately()
+    {
+        // Paste containing ESC followed by a non-CSI character
+        // The ESC should start a new token parse, not be swallowed
+        var result = AnsiTokenizer.Tokenize("\x1b[200~before\x1b[31mred\x1b[201~");
+
+        // Should see: SpecialKey(200), Text("before"), SGR(31), Text("red"), SpecialKey(201)
+        Assert.True(result.Count >= 4, $"Expected at least 4 tokens, got {result.Count}");
+
+        Assert.IsType<SpecialKeyToken>(result[0]);
+        Assert.Equal(200, ((SpecialKeyToken)result[0]).KeyCode);
+
+        Assert.IsType<SpecialKeyToken>(result[^1]);
+        Assert.Equal(201, ((SpecialKeyToken)result[^1]).KeyCode);
+    }
+
+    [Fact]
+    public void Tokenize_ConsecutivePasteSequences_ProducesSeparateMarkers()
+    {
+        var result = AnsiTokenizer.Tokenize(
+            "\x1b[200~first\x1b[201~\x1b[200~second\x1b[201~");
+
+        // Should have: Start, "first", End, Start, "second", End
+        Assert.Equal(6, result.Count);
+
+        Assert.Equal(200, ((SpecialKeyToken)result[0]).KeyCode);
+        Assert.Equal("first", ((TextToken)result[1]).Text);
+        Assert.Equal(201, ((SpecialKeyToken)result[2]).KeyCode);
+        Assert.Equal(200, ((SpecialKeyToken)result[3]).KeyCode);
+        Assert.Equal("second", ((TextToken)result[4]).Text);
+        Assert.Equal(201, ((SpecialKeyToken)result[5]).KeyCode);
+    }
+
+    [Fact]
+    public void Tokenize_EmptyPasteSequence_ProducesStartEnd()
+    {
+        var result = AnsiTokenizer.Tokenize("\x1b[200~\x1b[201~");
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal(200, ((SpecialKeyToken)result[0]).KeyCode);
+        Assert.Equal(201, ((SpecialKeyToken)result[1]).KeyCode);
+    }
+}

--- a/tests/Hex1b.Tests/ColorIndexMappingTests.cs
+++ b/tests/Hex1b.Tests/ColorIndexMappingTests.cs
@@ -1,0 +1,161 @@
+using Hex1b.Theming;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Tests for color index boundary correctness — verifying that SGR 30-37 (standard)
+/// and SGR 90-97 (bright) map to distinct colors, and that 256-color and RGB
+/// pass through correctly. Guards against the index 7/15 swap bug found in psmux.
+/// Inspired by psmux's test_issue155_rendering.rs color mapping tests.
+/// </summary>
+public class ColorIndexMappingTests
+{
+    private sealed class TestTerminal : IDisposable
+    {
+        private readonly StreamWorkloadAdapter _workload;
+        public Hex1bTerminal Terminal { get; }
+
+        public TestTerminal(int width = 80, int height = 24)
+        {
+            _workload = StreamWorkloadAdapter.CreateHeadless(width, height);
+            Terminal = Hex1bTerminal.CreateBuilder()
+                .WithWorkload(_workload).WithHeadless().WithDimensions(width, height).Build();
+        }
+
+        public void Write(string text)
+        {
+            Terminal.ApplyTokens(AnsiTokenizer.Tokenize(text));
+        }
+
+        public void Dispose()
+        {
+            Terminal.Dispose();
+            _workload.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+    }
+
+    [Fact]
+    public void Sgr37_Index7_IsLightGrayNotWhite()
+    {
+        using var t = new TestTerminal();
+        t.Write("\x1b[37mA");
+
+        var snap = t.Terminal.CreateSnapshot();
+        var fg = snap.GetCell(0, 0).Foreground;
+        Assert.NotNull(fg);
+
+        // Index 7 (SGR 37) should be light gray (192,192,192), NOT white (255,255,255)
+        Assert.NotEqual(Hex1bColor.FromRgb(255, 255, 255), fg.Value);
+        Assert.Equal(Hex1bColor.FromRgb(192, 192, 192), fg.Value);
+    }
+
+    [Fact]
+    public void Sgr97_Index15_IsWhiteNotGray()
+    {
+        using var t = new TestTerminal();
+        t.Write("\x1b[97mA");
+
+        var snap = t.Terminal.CreateSnapshot();
+        var fg = snap.GetCell(0, 0).Foreground;
+        Assert.NotNull(fg);
+
+        // Index 15 (SGR 97) should be white (255,255,255), NOT gray
+        Assert.Equal(Hex1bColor.FromRgb(255, 255, 255), fg.Value);
+    }
+
+    [Fact]
+    public void Sgr37_And_Sgr97_ProduceDistinctColors()
+    {
+        using var t = new TestTerminal();
+        t.Write("\x1b[37mA\x1b[97mB");
+
+        var snap = t.Terminal.CreateSnapshot();
+        var fg37 = snap.GetCell(0, 0).Foreground;
+        var fg97 = snap.GetCell(1, 0).Foreground;
+
+        Assert.NotNull(fg37);
+        Assert.NotNull(fg97);
+        Assert.NotEqual(fg37, fg97);
+    }
+
+    [Theory]
+    [InlineData(30, 0, 0, 0)]       // Black
+    [InlineData(31, 128, 0, 0)]     // Red
+    [InlineData(32, 0, 128, 0)]     // Green
+    [InlineData(33, 128, 128, 0)]   // Yellow
+    [InlineData(34, 0, 0, 128)]     // Blue
+    [InlineData(35, 128, 0, 128)]   // Magenta
+    [InlineData(36, 0, 128, 128)]   // Cyan
+    [InlineData(37, 192, 192, 192)] // White/LightGray
+    public void StandardForegroundColors_MapCorrectly(int sgr, byte r, byte g, byte b)
+    {
+        using var t = new TestTerminal();
+        t.Write($"\x1b[{sgr}mX");
+
+        var snap = t.Terminal.CreateSnapshot();
+        var fg = snap.GetCell(0, 0).Foreground;
+        Assert.NotNull(fg);
+        Assert.Equal(Hex1bColor.FromRgb(r, g, b), fg.Value);
+    }
+
+    [Theory]
+    [InlineData(90, 128, 128, 128)]   // Bright Black (Dark Gray)
+    [InlineData(91, 255, 0, 0)]       // Bright Red
+    [InlineData(92, 0, 255, 0)]       // Bright Green
+    [InlineData(93, 255, 255, 0)]     // Bright Yellow
+    [InlineData(94, 0, 0, 255)]       // Bright Blue
+    [InlineData(95, 255, 0, 255)]     // Bright Magenta
+    [InlineData(96, 0, 255, 255)]     // Bright Cyan
+    [InlineData(97, 255, 255, 255)]   // Bright White
+    public void BrightForegroundColors_MapCorrectly(int sgr, byte r, byte g, byte b)
+    {
+        using var t = new TestTerminal();
+        t.Write($"\x1b[{sgr}mX");
+
+        var snap = t.Terminal.CreateSnapshot();
+        var fg = snap.GetCell(0, 0).Foreground;
+        Assert.NotNull(fg);
+        Assert.Equal(Hex1bColor.FromRgb(r, g, b), fg.Value);
+    }
+
+    [Fact]
+    public void Color256_Index196_MapsCorrectly()
+    {
+        using var t = new TestTerminal();
+        t.Write("\x1b[38;5;196mX"); // Index 196 = bright red in 6x6x6 cube
+
+        var snap = t.Terminal.CreateSnapshot();
+        var fg = snap.GetCell(0, 0).Foreground;
+        Assert.NotNull(fg);
+
+        // Index 196 = 6x6x6 cube: (196-16)=180, r=180/36=5→255, g=0, b=0
+        Assert.Equal(Hex1bColor.FromRgb(255, 0, 0), fg.Value);
+    }
+
+    [Fact]
+    public void RgbColor_PassthroughExact()
+    {
+        using var t = new TestTerminal();
+        t.Write("\x1b[38;2;171;205;239mX");
+
+        var snap = t.Terminal.CreateSnapshot();
+        var fg = snap.GetCell(0, 0).Foreground;
+        Assert.NotNull(fg);
+        Assert.Equal(Hex1bColor.FromRgb(171, 205, 239), fg.Value);
+    }
+
+    [Fact]
+    public void Sgr39_ResetsToDefaultForeground()
+    {
+        using var t = new TestTerminal();
+        t.Write("\x1b[31mR\x1b[39mD");
+
+        var snap = t.Terminal.CreateSnapshot();
+        var fgR = snap.GetCell(0, 0).Foreground;
+        var fgD = snap.GetCell(1, 0).Foreground;
+
+        Assert.NotNull(fgR); // Red should be set
+        Assert.Null(fgD);    // Default foreground = null
+    }
+}

--- a/tests/Hex1b.Tests/EraseScrollbackTests.cs
+++ b/tests/Hex1b.Tests/EraseScrollbackTests.cs
@@ -1,0 +1,130 @@
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Tests for ED mode 3 (CSI 3J) — erase scrollback buffer.
+/// Verifies that CSI 3J clears the scrollback without affecting the visible screen,
+/// and that it differs from CSI 2J which only clears the visible screen.
+/// Inspired by psmux's squelch signal tests for CSI 2J/3J discrimination.
+/// </summary>
+public class EraseScrollbackTests
+{
+    private sealed class TestTerminal : IDisposable
+    {
+        private readonly StreamWorkloadAdapter _workload;
+        public Hex1bTerminal Terminal { get; }
+
+        public TestTerminal(int width = 40, int height = 5)
+        {
+            _workload = StreamWorkloadAdapter.CreateHeadless(width, height);
+            Terminal = Hex1bTerminal.CreateBuilder()
+                .WithWorkload(_workload)
+                .WithHeadless()
+                .WithDimensions(width, height)
+                .WithScrollback(100)
+                .Build();
+        }
+
+        public void Write(string text)
+        {
+            // Simulate PTY ONLCR translation
+            var translated = text.Replace("\n", "\r\n");
+            Terminal.ApplyTokens(AnsiTokenizer.Tokenize(translated));
+        }
+
+        public void Dispose()
+        {
+            Terminal.Dispose();
+            _workload.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+    }
+
+    [Fact]
+    public void Ed3_ClearsScrollback()
+    {
+        using var t = new TestTerminal(width: 40, height: 5);
+
+        // Write enough lines to fill screen and push some into scrollback
+        for (int i = 0; i < 10; i++)
+            t.Write($"Line {i}\n");
+
+        // Verify scrollback has content
+        var snapBefore = t.Terminal.CreateSnapshot(scrollbackLines: 100);
+        Assert.True(snapBefore.ScrollbackLineCount > 0,
+            "Should have scrollback lines before CSI 3J");
+
+        // CSI 3J — erase scrollback
+        t.Write("\x1b[3J");
+
+        // Scrollback should be cleared
+        var snapAfter = t.Terminal.CreateSnapshot(scrollbackLines: 100);
+        Assert.Equal(0, snapAfter.ScrollbackLineCount);
+    }
+
+    [Fact]
+    public void Ed2_DoesNotClearScrollback()
+    {
+        using var t = new TestTerminal(width: 40, height: 5);
+
+        // Push content into scrollback
+        for (int i = 0; i < 10; i++)
+            t.Write($"Line {i}\n");
+
+        var snapBefore = t.Terminal.CreateSnapshot(scrollbackLines: 100);
+        var scrollbackBefore = snapBefore.ScrollbackLineCount;
+        Assert.True(scrollbackBefore > 0);
+
+        // CSI 2J — erase visible screen only
+        t.Write("\x1b[2J");
+
+        // Scrollback should NOT be cleared
+        var snapAfter = t.Terminal.CreateSnapshot(scrollbackLines: 100);
+        Assert.True(snapAfter.ScrollbackLineCount > 0,
+            "CSI 2J should not clear scrollback");
+    }
+
+    [Fact]
+    public void Ed3_PreservesCursorPosition()
+    {
+        using var t = new TestTerminal(width: 40, height: 5);
+
+        // Push content into scrollback
+        for (int i = 0; i < 10; i++)
+            t.Write($"Line {i}\n");
+
+        // Position cursor
+        t.Write("\x1b[2;5H");
+
+        // Capture cursor position before
+        var snapBefore = t.Terminal.CreateSnapshot();
+        var cursorXBefore = snapBefore.CursorX;
+        var cursorYBefore = snapBefore.CursorY;
+
+        // CSI 3J
+        t.Write("\x1b[3J");
+
+        // Cursor should be preserved
+        var snapAfter = t.Terminal.CreateSnapshot();
+        Assert.Equal(cursorXBefore, snapAfter.CursorX);
+        Assert.Equal(cursorYBefore, snapAfter.CursorY);
+    }
+
+    [Fact]
+    public void Ed3_CombinedWithEd2_ClearsBothScreenAndScrollback()
+    {
+        using var t = new TestTerminal(width: 40, height: 5);
+
+        // Push content into scrollback
+        for (int i = 0; i < 10; i++)
+            t.Write($"Line {i}\n");
+
+        Assert.True(t.Terminal.CreateSnapshot(scrollbackLines: 100).ScrollbackLineCount > 0);
+
+        // CSI 2J + CSI 3J — clear both visible screen and scrollback
+        t.Write("\x1b[2J\x1b[3J");
+
+        var snap = t.Terminal.CreateSnapshot(scrollbackLines: 100);
+        Assert.Equal(0, snap.ScrollbackLineCount);
+    }
+}

--- a/tests/Hex1b.Tests/MouseProtocolModeTests.cs
+++ b/tests/Hex1b.Tests/MouseProtocolModeTests.cs
@@ -1,0 +1,107 @@
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Tests for mouse protocol mode tokenization (CSI ? 1000/1002/1003/1006 h/l).
+/// Hex1b sends these to the host terminal; these tests verify correct tokenization
+/// of the sequences both for output generation and for parsing terminal output
+/// from child processes.
+/// Inspired by psmux's test_vt100_mouse.rs.
+/// </summary>
+public class MouseProtocolModeTests
+{
+    [Fact]
+    public void Tokenize_MousePressRelease_Enable()
+    {
+        var result = AnsiTokenizer.Tokenize("\x1b[?1000h");
+
+        var token = Assert.Single(result);
+        var pm = Assert.IsType<PrivateModeToken>(token);
+        Assert.Equal(1000, pm.Mode);
+        Assert.True(pm.Enable);
+    }
+
+    [Fact]
+    public void Tokenize_MousePressRelease_Disable()
+    {
+        var result = AnsiTokenizer.Tokenize("\x1b[?1000l");
+
+        var token = Assert.Single(result);
+        var pm = Assert.IsType<PrivateModeToken>(token);
+        Assert.Equal(1000, pm.Mode);
+        Assert.False(pm.Enable);
+    }
+
+    [Fact]
+    public void Tokenize_MouseButtonMotion_Enable()
+    {
+        var result = AnsiTokenizer.Tokenize("\x1b[?1002h");
+
+        var token = Assert.Single(result);
+        var pm = Assert.IsType<PrivateModeToken>(token);
+        Assert.Equal(1002, pm.Mode);
+        Assert.True(pm.Enable);
+    }
+
+    [Fact]
+    public void Tokenize_MouseAnyMotion_Enable()
+    {
+        var result = AnsiTokenizer.Tokenize("\x1b[?1003h");
+
+        var token = Assert.Single(result);
+        var pm = Assert.IsType<PrivateModeToken>(token);
+        Assert.Equal(1003, pm.Mode);
+        Assert.True(pm.Enable);
+    }
+
+    [Fact]
+    public void Tokenize_MouseSgrEncoding_Enable()
+    {
+        var result = AnsiTokenizer.Tokenize("\x1b[?1006h");
+
+        var token = Assert.Single(result);
+        var pm = Assert.IsType<PrivateModeToken>(token);
+        Assert.Equal(1006, pm.Mode);
+        Assert.True(pm.Enable);
+    }
+
+    [Fact]
+    public void Tokenize_MouseSgrEncoding_Disable()
+    {
+        var result = AnsiTokenizer.Tokenize("\x1b[?1006l");
+
+        var token = Assert.Single(result);
+        var pm = Assert.IsType<PrivateModeToken>(token);
+        Assert.Equal(1006, pm.Mode);
+        Assert.False(pm.Enable);
+    }
+
+    [Fact]
+    public void Tokenize_FullMouseEnableSequence_ReturnsAllFourTokens()
+    {
+        // This is the full sequence MouseParser.EnableMouseTracking sends
+        var result = AnsiTokenizer.Tokenize(
+            "\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h");
+
+        Assert.Equal(4, result.Count);
+
+        var modes = result.Cast<PrivateModeToken>().Select(t => t.Mode).ToList();
+        Assert.Equal([1000, 1002, 1003, 1006], modes);
+        Assert.All(result.Cast<PrivateModeToken>(), t => Assert.True(t.Enable));
+    }
+
+    [Fact]
+    public void Tokenize_FullMouseDisableSequence_ReturnsAllFourTokensReversed()
+    {
+        // This is the full sequence MouseParser.DisableMouseTracking sends
+        var result = AnsiTokenizer.Tokenize(
+            "\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l");
+
+        Assert.Equal(4, result.Count);
+
+        var modes = result.Cast<PrivateModeToken>().Select(t => t.Mode).ToList();
+        Assert.Equal([1006, 1003, 1002, 1000], modes);
+        Assert.All(result.Cast<PrivateModeToken>(), t => Assert.False(t.Enable));
+    }
+}

--- a/tests/Hex1b.Tests/Osc7CwdTests.cs
+++ b/tests/Hex1b.Tests/Osc7CwdTests.cs
@@ -1,0 +1,75 @@
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Tests for OSC 7 (Current Working Directory) tokenization.
+/// OSC 7 format: ESC ] 7 ; file://hostname/path ST
+/// Emitted by bash, zsh, fish, and PowerShell to announce the shell's CWD.
+/// Inspired by psmux's test_vt100_screen.rs OSC 7 tests.
+/// </summary>
+public class Osc7CwdTests
+{
+    [Fact]
+    public void Tokenize_Osc7_WithBelTerminator_ReturnsOscToken()
+    {
+        var result = AnsiTokenizer.Tokenize("\x1b]7;file:///home/user/project\x07");
+
+        var token = Assert.Single(result);
+        var oscToken = Assert.IsType<OscToken>(token);
+        Assert.Equal("7", oscToken.Command);
+        Assert.Equal("file:///home/user/project", oscToken.Payload);
+    }
+
+    [Fact]
+    public void Tokenize_Osc7_WithStTerminator_ReturnsOscToken()
+    {
+        var result = AnsiTokenizer.Tokenize("\x1b]7;file:///tmp/test\x1b\\");
+
+        var token = Assert.Single(result);
+        var oscToken = Assert.IsType<OscToken>(token);
+        Assert.Equal("7", oscToken.Command);
+        Assert.Equal("file:///tmp/test", oscToken.Payload);
+    }
+
+    [Fact]
+    public void Tokenize_Osc7_WithHostname_ReturnsFullUri()
+    {
+        var result = AnsiTokenizer.Tokenize("\x1b]7;file://myhost/home/user\x07");
+
+        var token = Assert.Single(result);
+        var oscToken = Assert.IsType<OscToken>(token);
+        Assert.Equal("7", oscToken.Command);
+        Assert.Equal("file://myhost/home/user", oscToken.Payload);
+    }
+
+    [Fact]
+    public void Tokenize_Osc7_WithPercentEncoding_PreservesRawUri()
+    {
+        // Tokenizer should preserve the raw URI; decoding is the consumer's job
+        var result = AnsiTokenizer.Tokenize("\x1b]7;file:///home/user/my%20project\x07");
+
+        var token = Assert.Single(result);
+        var oscToken = Assert.IsType<OscToken>(token);
+        Assert.Equal("7", oscToken.Command);
+        Assert.Equal("file:///home/user/my%20project", oscToken.Payload);
+    }
+
+    [Fact]
+    public void Tokenize_Osc7_DoesNotInterfereWithOsc0()
+    {
+        // OSC 7 followed by OSC 0 — both should parse independently
+        var result = AnsiTokenizer.Tokenize(
+            "\x1b]7;file:///tmp\x07\x1b]0;My Title\x07");
+
+        Assert.Equal(2, result.Count);
+
+        var osc7 = Assert.IsType<OscToken>(result[0]);
+        Assert.Equal("7", osc7.Command);
+        Assert.Equal("file:///tmp", osc7.Payload);
+
+        var osc0 = Assert.IsType<OscToken>(result[1]);
+        Assert.Equal("0", osc0.Command);
+        Assert.Equal("My Title", osc0.Payload);
+    }
+}

--- a/tests/Hex1b.Tests/PasteLineEndingTests.cs
+++ b/tests/Hex1b.Tests/PasteLineEndingTests.cs
@@ -1,0 +1,99 @@
+using Hex1b.Input;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Tests for PasteContext.ReadLinesAsync line-ending handling.
+/// Verifies that \n, \r\n, and \r are all recognized as line separators.
+/// Inspired by psmux's paste line-ending normalization tests.
+/// </summary>
+public class PasteLineEndingTests
+{
+    private static async Task<List<string>> ReadPasteLinesAsync(string pasteContent)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithHeadless()
+            .WithDimensions(80, 24)
+            .Build();
+
+        var tokens = new AnsiToken[]
+        {
+            new SpecialKeyToken(200),
+            new TextToken(pasteContent),
+            new SpecialKeyToken(201),
+        };
+
+        var method = typeof(Hex1bTerminal).GetMethod(
+            "DispatchTokensAsEventsAsync",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+        await (Task)method!.Invoke(terminal, [tokens, workload, CancellationToken.None])!;
+
+        var events = new List<Hex1bEvent>();
+        while (workload.InputEvents.TryRead(out var evt))
+            events.Add(evt);
+
+        var paste = Assert.IsType<Hex1bPasteEvent>(Assert.Single(events));
+        var lines = new List<string>();
+        await foreach (var line in paste.Paste.ReadLinesAsync())
+            lines.Add(line);
+        return lines;
+    }
+
+    [Fact]
+    public async Task ReadLines_LfSeparator_SplitsCorrectly()
+    {
+        var lines = await ReadPasteLinesAsync("line1\nline2\nline3");
+
+        Assert.Equal(3, lines.Count);
+        Assert.Equal("line1", lines[0]);
+        Assert.Equal("line2", lines[1]);
+        Assert.Equal("line3", lines[2]);
+    }
+
+    [Fact]
+    public async Task ReadLines_CrLfSeparator_SplitsCorrectly()
+    {
+        var lines = await ReadPasteLinesAsync("line1\r\nline2\r\nline3");
+
+        Assert.Equal(3, lines.Count);
+        Assert.Equal("line1", lines[0]);
+        Assert.Equal("line2", lines[1]);
+        Assert.Equal("line3", lines[2]);
+    }
+
+    [Fact]
+    public async Task ReadLines_CrSeparator_SplitsCorrectly()
+    {
+        var lines = await ReadPasteLinesAsync("line1\rline2\rline3");
+
+        Assert.Equal(3, lines.Count);
+        Assert.Equal("line1", lines[0]);
+        Assert.Equal("line2", lines[1]);
+        Assert.Equal("line3", lines[2]);
+    }
+
+    [Fact]
+    public async Task ReadLines_MixedLineEndings_SplitsCorrectly()
+    {
+        var lines = await ReadPasteLinesAsync("a\nb\r\nc\rd");
+
+        Assert.Equal(4, lines.Count);
+        Assert.Equal("a", lines[0]);
+        Assert.Equal("b", lines[1]);
+        Assert.Equal("c", lines[2]);
+        Assert.Equal("d", lines[3]);
+    }
+
+    [Fact]
+    public async Task ReadLines_NoLineEndings_ReturnsSingleLine()
+    {
+        var lines = await ReadPasteLinesAsync("no newlines here");
+
+        Assert.Single(lines);
+        Assert.Equal("no newlines here", lines[0]);
+    }
+}

--- a/tests/Hex1b.Tests/SgrHiddenStrikethroughTests.cs
+++ b/tests/Hex1b.Tests/SgrHiddenStrikethroughTests.cs
@@ -1,0 +1,153 @@
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Tests for SGR 8/28 (hidden) and SGR 9/29 (strikethrough) attribute roundtrip behavior.
+/// Validates that these attributes are set, cleared, and interact correctly with SGR 0 reset
+/// and with combined attributes (bold + hidden + strikethrough).
+/// Inspired by psmux's test_issue155_sgr_attrs.rs and test_issue155_rendering.rs.
+/// </summary>
+public class SgrHiddenStrikethroughTests
+{
+    private sealed class TestTerminal : IDisposable
+    {
+        private readonly StreamWorkloadAdapter _workload;
+        public Hex1bTerminal Terminal { get; }
+
+        public TestTerminal(int width = 80, int height = 24)
+        {
+            _workload = StreamWorkloadAdapter.CreateHeadless(width, height);
+            Terminal = Hex1bTerminal.CreateBuilder()
+                .WithWorkload(_workload).WithHeadless().WithDimensions(width, height).Build();
+        }
+
+        public void Write(string text)
+        {
+            Terminal.ApplyTokens(AnsiTokenizer.Tokenize(text));
+        }
+
+        public void Dispose()
+        {
+            Terminal.Dispose();
+            _workload.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
+    }
+
+    [Fact]
+    public void Sgr9_SetsStrikethrough_OnSubsequentCells()
+    {
+        using var t = new TestTerminal();
+        t.Write("\x1b[9mabc");
+
+        var snap = t.Terminal.CreateSnapshot();
+        for (int i = 0; i < 3; i++)
+        {
+            var cell = snap.GetCell(i, 0);
+            Assert.True(cell.Attributes.HasFlag(CellAttributes.Strikethrough),
+                $"Cell {i} should have strikethrough");
+        }
+    }
+
+    [Fact]
+    public void Sgr29_ClearsStrikethrough()
+    {
+        using var t = new TestTerminal();
+        t.Write("\x1b[9mab\x1b[29mcd");
+
+        var snap = t.Terminal.CreateSnapshot();
+        Assert.True(snap.GetCell(0, 0).Attributes.HasFlag(CellAttributes.Strikethrough));
+        Assert.True(snap.GetCell(1, 0).Attributes.HasFlag(CellAttributes.Strikethrough));
+        Assert.False(snap.GetCell(2, 0).Attributes.HasFlag(CellAttributes.Strikethrough));
+        Assert.False(snap.GetCell(3, 0).Attributes.HasFlag(CellAttributes.Strikethrough));
+    }
+
+    [Fact]
+    public void Sgr8_SetsHidden_OnSubsequentCells()
+    {
+        using var t = new TestTerminal();
+        t.Write("\x1b[8mhidden");
+
+        var snap = t.Terminal.CreateSnapshot();
+        for (int i = 0; i < 6; i++)
+        {
+            var cell = snap.GetCell(i, 0);
+            Assert.True(cell.Attributes.HasFlag(CellAttributes.Hidden),
+                $"Cell {i} should have hidden attribute");
+        }
+    }
+
+    [Fact]
+    public void Sgr28_ClearsHidden()
+    {
+        using var t = new TestTerminal();
+        t.Write("\x1b[8mab\x1b[28mcd");
+
+        var snap = t.Terminal.CreateSnapshot();
+        Assert.True(snap.GetCell(0, 0).Attributes.HasFlag(CellAttributes.Hidden));
+        Assert.True(snap.GetCell(1, 0).Attributes.HasFlag(CellAttributes.Hidden));
+        Assert.False(snap.GetCell(2, 0).Attributes.HasFlag(CellAttributes.Hidden));
+        Assert.False(snap.GetCell(3, 0).Attributes.HasFlag(CellAttributes.Hidden));
+    }
+
+    [Fact]
+    public void Sgr0_ResetsBothHiddenAndStrikethrough()
+    {
+        using var t = new TestTerminal();
+        t.Write("\x1b[8;9mab\x1b[0mcd");
+
+        var snap = t.Terminal.CreateSnapshot();
+
+        // First 2 cells: both hidden and strikethrough
+        var cellA = snap.GetCell(0, 0);
+        Assert.True(cellA.Attributes.HasFlag(CellAttributes.Hidden));
+        Assert.True(cellA.Attributes.HasFlag(CellAttributes.Strikethrough));
+
+        // After SGR 0 reset: neither
+        var cellC = snap.GetCell(2, 0);
+        Assert.False(cellC.Attributes.HasFlag(CellAttributes.Hidden));
+        Assert.False(cellC.Attributes.HasFlag(CellAttributes.Strikethrough));
+    }
+
+    [Fact]
+    public void CombinedBoldHiddenStrikethrough_AllActive()
+    {
+        using var t = new TestTerminal();
+        t.Write("\x1b[1;8;9mX");
+
+        var snap = t.Terminal.CreateSnapshot();
+        var cell = snap.GetCell(0, 0);
+
+        Assert.True(cell.Attributes.HasFlag(CellAttributes.Bold));
+        Assert.True(cell.Attributes.HasFlag(CellAttributes.Hidden));
+        Assert.True(cell.Attributes.HasFlag(CellAttributes.Strikethrough));
+    }
+
+    [Fact]
+    public void HiddenCell_PreservesCharacterContent()
+    {
+        using var t = new TestTerminal();
+        t.Write("\x1b[8mABC");
+
+        var snap = t.Terminal.CreateSnapshot();
+
+        // The cell should still store the character even though it's hidden
+        Assert.Equal("A", snap.GetCell(0, 0).Character);
+        Assert.Equal("B", snap.GetCell(1, 0).Character);
+        Assert.Equal("C", snap.GetCell(2, 0).Character);
+    }
+
+    [Fact]
+    public void StrikethroughCell_PreservesCharacterContent()
+    {
+        using var t = new TestTerminal();
+        t.Write("\x1b[9mXYZ");
+
+        var snap = t.Terminal.CreateSnapshot();
+
+        // Strikethrough cells show actual content (unlike hidden which renders as spaces)
+        Assert.Equal("X", snap.GetCell(0, 0).Character);
+        Assert.Equal("Y", snap.GetCell(1, 0).Character);
+        Assert.Equal("Z", snap.GetCell(2, 0).Character);
+    }
+}


### PR DESCRIPTION
## Summary

Adds 58 new cross-platform tests covering VT/ANSI escape sequence edge cases identified by comparing [psmux](https://github.com/psmux/psmux)'s vt100 test suite against Hex1b's existing coverage.

## New test files (7 files, 817 lines)

| File | Tests | Coverage |
|------|-------|----------|
| \Osc7CwdTests.cs\ | 5 | OSC 7 CWD URI tokenization (BEL/ST terminators, hostnames, percent-encoding) |
| \MouseProtocolModeTests.cs\ | 8 | CSI ? 1000/1002/1003/1006 h/l private mode tokenization |
| \BracketedPasteEdgeCaseTests.cs\ | 6 | Paste start/end markers, embedded ESC, consecutive pastes, empty paste |
| \PasteLineEndingTests.cs\ | 5 | \ReadLinesAsync\ handles LF, CRLF, CR, and mixed line endings |
| \SgrHiddenStrikethroughTests.cs\ | 8 | SGR 8/28 hidden, SGR 9/29 strikethrough, SGR 0 reset, combined attributes |
| \ColorIndexMappingTests.cs\ | 22 | All 16 standard/bright colors, index 7≠15 guard, 256-color, RGB passthrough |
| \EraseScrollbackTests.cs\ | 4 | ED mode 3 (CSI 3J) clears scrollback, differs from ED 2, cursor preserved |

## Motivation

psmux's vt100 crate found real bugs around:
- **Color index 7/15 swap** — SGR 37 (light gray) vs SGR 97 (white) getting confused
- **SGR 8/28 hidden attribute** — cells not preserving content or rendering incorrectly
- **ED mode discrimination** — CSI 2J vs CSI 3J behaving identically

These tests guard against the same classes of bugs in Hex1b. All 58 tests pass — no implementation changes were needed (Hex1b already handles all sequences correctly).

## Excluded (Windows-only)

The following psmux patterns were intentionally excluded since Hex1b is cross-platform:
- AltGr / Ctrl+Alt input disambiguation (Windows keyboard layout specific)
- ConPTY Enter key encoding differences
- ConPTY bracketed paste close-sequence stripping
