### PR TITLE
Fix terminal color rendering to preserve indexed palette colors

### DIFF
--- a/samples/TermPetDemo/Program.cs
+++ b/samples/TermPetDemo/Program.cs
@@ -66,8 +66,13 @@ shellBuilder = OperatingSystem.IsWindows()
     {
         options.FileName = "pwsh.exe";
         options.WindowsPtyMode = WindowsPtyMode.RequireProxy;
+        options.ConfigureEnvironment = env => env["COLORTERM"] = "truecolor";
     })
-    : shellBuilder.WithPtyProcess("/bin/bash");
+    : shellBuilder.WithPtyProcess(options =>
+    {
+        options.FileName = "/bin/bash";
+        options.ConfigureEnvironment = env => env["COLORTERM"] = "truecolor";
+    });
 
 var bash = shellBuilder
     .WithDimensions(ptyWidth, ptyHeight)

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -5745,49 +5745,23 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
 
     private static Hex1bColor StandardColorFromCode(int code) => code switch
     {
-        0 => Hex1bColor.FromRgb(0, 0, 0),
-        1 => Hex1bColor.FromRgb(128, 0, 0),
-        2 => Hex1bColor.FromRgb(0, 128, 0),
-        3 => Hex1bColor.FromRgb(128, 128, 0),
-        4 => Hex1bColor.FromRgb(0, 0, 128),
-        5 => Hex1bColor.FromRgb(128, 0, 128),
-        6 => Hex1bColor.FromRgb(0, 128, 128),
-        7 => Hex1bColor.FromRgb(192, 192, 192),
-        _ => Hex1bColor.FromRgb(128, 128, 128)
+        >= 0 and <= 7 => Hex1bColor.FromIndex((byte)code),
+        _ => Hex1bColor.FromIndex(7)
     };
 
     private static Hex1bColor BrightColorFromCode(int code) => code switch
     {
-        0 => Hex1bColor.FromRgb(128, 128, 128),
-        1 => Hex1bColor.FromRgb(255, 0, 0),
-        2 => Hex1bColor.FromRgb(0, 255, 0),
-        3 => Hex1bColor.FromRgb(255, 255, 0),
-        4 => Hex1bColor.FromRgb(0, 0, 255),
-        5 => Hex1bColor.FromRgb(255, 0, 255),
-        6 => Hex1bColor.FromRgb(0, 255, 255),
-        7 => Hex1bColor.FromRgb(255, 255, 255),
-        _ => Hex1bColor.FromRgb(192, 192, 192)
+        >= 0 and <= 7 => Hex1bColor.FromIndex((byte)(code + 8)),
+        _ => Hex1bColor.FromIndex(7)
     };
 
     private static Hex1bColor Color256FromIndex(int index)
     {
-        if (index < 16)
+        if (index is >= 0 and <= 255)
         {
-            return index < 8 ? StandardColorFromCode(index) : BrightColorFromCode(index - 8);
+            return Hex1bColor.FromIndex((byte)index);
         }
-        else if (index < 232)
-        {
-            index -= 16;
-            var r = (index / 36) * 51;
-            var g = ((index / 6) % 6) * 51;
-            var b = (index % 6) * 51;
-            return Hex1bColor.FromRgb((byte)r, (byte)g, (byte)b);
-        }
-        else
-        {
-            var gray = (index - 232) * 10 + 8;
-            return Hex1bColor.FromRgb((byte)gray, (byte)gray, (byte)gray);
-        }
+        return Hex1bColor.FromRgb(0, 0, 0);
     }
 
     /// <inheritdoc />

--- a/src/Hex1b/Hex1bTerminalBuilder.cs
+++ b/src/Hex1b/Hex1bTerminalBuilder.cs
@@ -409,7 +409,8 @@ public sealed class Hex1bTerminalBuilder
                 initialHeight: height,
                 ptyHandleFactory: () => Hex1bTerminalChildProcess.CreatePtyHandle(
                     options.WindowsPtyMode,
-                    options.WindowsPtyHostPath));
+                    options.WindowsPtyHostPath),
+                configureEnvironment: options.ConfigureEnvironment);
 
             Func<CancellationToken, Task<int>> runCallback = async ct =>
             {
@@ -1399,6 +1400,23 @@ public sealed class Hex1bTerminalProcessOptions
     /// Defaults to true.
     /// </summary>
     public bool InheritEnvironment { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets an optional callback to inspect and modify the final environment dictionary
+    /// before it is passed to the child process. The callback is invoked after the environment
+    /// is constructed (inheriting parent variables, setting TERM/COLORTERM/TERM_PROGRAM/HEX1B_NESTING_LEVEL,
+    /// and applying <see cref="Environment"/> overrides).
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// options.ConfigureEnvironment = env =>
+    /// {
+    ///     env.Remove("SECRET_TOKEN");
+    ///     env["MY_CUSTOM_VAR"] = "value";
+    /// };
+    /// </code>
+    /// </example>
+    public Action<Dictionary<string, string>>? ConfigureEnvironment { get; set; }
 
     /// <summary>
     /// Gets or sets how Hex1b should choose the Windows PTY backend.

--- a/src/Hex1b/Hex1bTerminalChildProcess.cs
+++ b/src/Hex1b/Hex1bTerminalChildProcess.cs
@@ -40,6 +40,7 @@ public sealed class Hex1bTerminalChildProcess : IHex1bTerminalWorkloadAdapter
     private readonly string? _workingDirectory;
     private readonly Dictionary<string, string>? _environment;
     private readonly bool _inheritEnvironment;
+    private readonly Action<Dictionary<string, string>>? _configureEnvironment;
     private readonly Func<IPtyHandle> _ptyHandleFactory;
     
     private int _width;
@@ -102,7 +103,8 @@ public sealed class Hex1bTerminalChildProcess : IHex1bTerminalWorkloadAdapter
         bool inheritEnvironment,
         int initialWidth,
         int initialHeight,
-        Func<IPtyHandle> ptyHandleFactory)
+        Func<IPtyHandle> ptyHandleFactory,
+        Action<Dictionary<string, string>>? configureEnvironment = null)
     {
         _fileName = fileName ?? throw new ArgumentNullException(nameof(fileName));
         _arguments = arguments ?? [];
@@ -110,6 +112,7 @@ public sealed class Hex1bTerminalChildProcess : IHex1bTerminalWorkloadAdapter
         _environment = environment;
         _inheritEnvironment = inheritEnvironment;
         _ptyHandleFactory = ptyHandleFactory ?? throw new ArgumentNullException(nameof(ptyHandleFactory));
+        _configureEnvironment = configureEnvironment;
         _width = initialWidth;
         _height = initialHeight;
     }
@@ -332,6 +335,22 @@ public sealed class Hex1bTerminalChildProcess : IHex1bTerminalWorkloadAdapter
             env["TERM"] = "xterm-256color";
         }
         
+        // Hex1b's terminal emulator supports 24-bit true color. Advertise this so
+        // child shells and TUI tools can use full RGB colors instead of falling back
+        // to 256 or 16 colors. COLORTERM=truecolor is the de facto standard used by
+        // all major terminal emulators (kitty, ghostty, iTerm2, Windows Terminal, etc.).
+        if (!env.ContainsKey("COLORTERM"))
+        {
+            env["COLORTERM"] = "truecolor";
+        }
+        
+        // Identify Hex1b as the hosting terminal emulator so child processes can
+        // detect capabilities (e.g., AutoReflowStrategy) and tools can tailor behavior.
+        if (!env.ContainsKey("TERM_PROGRAM"))
+        {
+            env["TERM_PROGRAM"] = "hex1b";
+        }
+        
         // Set HEX1B_NESTING_LEVEL to track nested terminal depth
         // If already set, increment it; otherwise set to 1
         const string nestingLevelKey = "HEX1B_NESTING_LEVEL";
@@ -351,6 +370,9 @@ public sealed class Hex1bTerminalChildProcess : IHex1bTerminalWorkloadAdapter
                 env[key] = value;
             }
         }
+        
+        // Invoke the optional callback for final customization
+        _configureEnvironment?.Invoke(env);
         
         return env;
     }

--- a/src/Hex1b/Surfaces/SurfaceComparer.cs
+++ b/src/Hex1b/Surfaces/SurfaceComparer.cs
@@ -867,7 +867,22 @@ public static class SurfaceComparer
 
     private static string BuildColorSgr(Hex1bColor color, bool isForeground)
     {
-        // Use 24-bit color (SGR 38;2;r;g;b for foreground, 48;2;r;g;b for background)
+        if (color.IsIndexed)
+        {
+            var idx = color.Index;
+            if (isForeground)
+            {
+                if (idx < 8) return $"{30 + idx}";
+                if (idx < 16) return $"{90 + idx - 8}";
+                return $"38;5;{idx}";
+            }
+            else
+            {
+                if (idx < 8) return $"{40 + idx}";
+                if (idx < 16) return $"{100 + idx - 8}";
+                return $"48;5;{idx}";
+            }
+        }
         var prefix = isForeground ? "38;2" : "48;2";
         return $"{prefix};{color.R};{color.G};{color.B}";
     }

--- a/src/Hex1b/Surfaces/SurfaceRenderContext.cs
+++ b/src/Hex1b/Surfaces/SurfaceRenderContext.cs
@@ -1505,52 +1505,23 @@ public class SurfaceRenderContext : Hex1bRenderContext
 
     private static Hex1bColor GetBasicColor(int index) => index switch
     {
-        0 => Hex1bColor.FromRgb(0, 0, 0),       // Black
-        1 => Hex1bColor.FromRgb(128, 0, 0),     // Red
-        2 => Hex1bColor.FromRgb(0, 128, 0),     // Green
-        3 => Hex1bColor.FromRgb(128, 128, 0),   // Yellow
-        4 => Hex1bColor.FromRgb(0, 0, 128),     // Blue
-        5 => Hex1bColor.FromRgb(128, 0, 128),   // Magenta
-        6 => Hex1bColor.FromRgb(0, 128, 128),   // Cyan
-        7 => Hex1bColor.FromRgb(192, 192, 192), // White
-        _ => Hex1bColor.FromRgb(128, 128, 128)
+        >= 0 and <= 7 => Hex1bColor.FromIndex((byte)index),
+        _ => Hex1bColor.FromIndex(7)
     };
 
     private static Hex1bColor GetBrightColor(int index) => index switch
     {
-        0 => Hex1bColor.FromRgb(128, 128, 128), // Bright Black (Gray)
-        1 => Hex1bColor.FromRgb(255, 0, 0),     // Bright Red
-        2 => Hex1bColor.FromRgb(0, 255, 0),     // Bright Green
-        3 => Hex1bColor.FromRgb(255, 255, 0),   // Bright Yellow
-        4 => Hex1bColor.FromRgb(0, 0, 255),     // Bright Blue
-        5 => Hex1bColor.FromRgb(255, 0, 255),   // Bright Magenta
-        6 => Hex1bColor.FromRgb(0, 255, 255),   // Bright Cyan
-        7 => Hex1bColor.FromRgb(255, 255, 255), // Bright White
-        _ => Hex1bColor.FromRgb(255, 255, 255)
+        >= 0 and <= 7 => Hex1bColor.FromIndex((byte)(index + 8)),
+        _ => Hex1bColor.FromIndex(15)
     };
 
     private static Hex1bColor Get256Color(int index)
     {
-        if (index < 16)
+        if (index is >= 0 and <= 255)
         {
-            // Basic 16 colors
-            return index < 8 ? GetBasicColor(index) : GetBrightColor(index - 8);
+            return Hex1bColor.FromIndex((byte)index);
         }
-        else if (index < 232)
-        {
-            // 6x6x6 color cube (indices 16-231)
-            var i = index - 16;
-            var r = (i / 36) * 51;
-            var g = ((i / 6) % 6) * 51;
-            var b = (i % 6) * 51;
-            return Hex1bColor.FromRgb((byte)r, (byte)g, (byte)b);
-        }
-        else
-        {
-            // Grayscale (indices 232-255)
-            var gray = (index - 232) * 10 + 8;
-            return Hex1bColor.FromRgb((byte)gray, (byte)gray, (byte)gray);
-        }
+        return Hex1bColor.FromRgb(0, 0, 0);
     }
 
     #endregion

--- a/src/Hex1b/Theming/Hex1bColor.cs
+++ b/src/Hex1b/Theming/Hex1bColor.cs
@@ -2,7 +2,19 @@ namespace Hex1b.Theming;
 
 /// <summary>
 /// Represents a color that can be used in the terminal.
+/// Supports RGB, indexed (palette 0-255), and default terminal colors.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Indexed colors (0-15) are re-emitted as standard SGR codes (e.g., <c>\e[32m</c> for green),
+/// allowing the parent terminal to apply its own color scheme. Indices 16-255 use the
+/// <c>38;5;N</c> / <c>48;5;N</c> form. RGB colors always use <c>38;2;R;G;Bm</c>.
+/// </para>
+/// <para>
+/// The <see cref="R"/>, <see cref="G"/>, <see cref="B"/> properties return resolved RGB values
+/// for all color modes, including indexed colors (using the standard VGA/xterm palette as fallback).
+/// </para>
+/// </remarks>
 public readonly struct Hex1bColor
 {
     public byte R { get; }
@@ -10,18 +22,53 @@ public readonly struct Hex1bColor
     public byte B { get; }
     public bool IsDefault { get; }
 
+    private readonly short _index; // -1 = not indexed; 0-255 = palette index
+
+    /// <summary>
+    /// Gets whether this color is an indexed (palette) color rather than an explicit RGB color.
+    /// </summary>
+    public bool IsIndexed => _index >= 0;
+
+    /// <summary>
+    /// Gets the palette index if <see cref="IsIndexed"/> is true, otherwise -1.
+    /// </summary>
+    public short Index => _index;
+
     private Hex1bColor(byte r, byte g, byte b, bool isDefault = false)
     {
         R = r;
         G = g;
         B = b;
         IsDefault = isDefault;
+        _index = -1;
+    }
+
+    private Hex1bColor(byte index, byte r, byte g, byte b)
+    {
+        R = r;
+        G = g;
+        B = b;
+        IsDefault = false;
+        _index = index;
     }
 
     /// <summary>
     /// Creates a color from RGB values.
     /// </summary>
     public static Hex1bColor FromRgb(byte r, byte g, byte b) => new(r, g, b);
+
+    /// <summary>
+    /// Creates an indexed (palette) color. The RGB fallback values are resolved from the
+    /// standard xterm 256-color palette for use in non-ANSI contexts (SVG, HTML, etc.).
+    /// When rendered as ANSI, the original index is preserved so the parent terminal can
+    /// apply its own color scheme.
+    /// </summary>
+    /// <param name="index">The palette index (0-255).</param>
+    public static Hex1bColor FromIndex(byte index)
+    {
+        var (r, g, b) = ResolveIndexRgb(index);
+        return new Hex1bColor(index, r, g, b);
+    }
 
     /// <summary>
     /// The default terminal foreground/background color.
@@ -43,16 +90,91 @@ public readonly struct Hex1bColor
 
     /// <summary>
     /// Gets the ANSI escape code for setting this as the foreground color.
+    /// Indexed colors 0-7 emit <c>\e[30-37m</c>, 8-15 emit <c>\e[90-97m</c>,
+    /// 16-255 emit <c>\e[38;5;Nm</c>, and RGB colors emit <c>\e[38;2;R;G;Bm</c>.
     /// </summary>
-    public string ToForegroundAnsi() => IsDefault ? "\x1b[39m" : $"\x1b[38;2;{R};{G};{B}m";
+    public string ToForegroundAnsi()
+    {
+        if (IsDefault) return "\x1b[39m";
+        if (_index >= 0)
+        {
+            if (_index < 8) return $"\x1b[{30 + _index}m";
+            if (_index < 16) return $"\x1b[{90 + _index - 8}m";
+            return $"\x1b[38;5;{_index}m";
+        }
+        return $"\x1b[38;2;{R};{G};{B}m";
+    }
 
     /// <summary>
     /// Gets the ANSI escape code for setting this as the background color.
+    /// Indexed colors 0-7 emit <c>\e[40-47m</c>, 8-15 emit <c>\e[100-107m</c>,
+    /// 16-255 emit <c>\e[48;5;Nm</c>, and RGB colors emit <c>\e[48;2;R;G;Bm</c>.
     /// </summary>
-    public string ToBackgroundAnsi() => IsDefault ? "\x1b[49m" : $"\x1b[48;2;{R};{G};{B}m";
+    public string ToBackgroundAnsi()
+    {
+        if (IsDefault) return "\x1b[49m";
+        if (_index >= 0)
+        {
+            if (_index < 8) return $"\x1b[{40 + _index}m";
+            if (_index < 16) return $"\x1b[{100 + _index - 8}m";
+            return $"\x1b[48;5;{_index}m";
+        }
+        return $"\x1b[48;2;{R};{G};{B}m";
+    }
 
     /// <summary>
     /// Gets the ANSI escape code for setting this as the underline color (SGR 58).
     /// </summary>
-    public string ToUnderlineColorAnsi() => IsDefault ? "\x1b[59m" : $"\x1b[58;2;{R};{G};{B}m";
+    public string ToUnderlineColorAnsi()
+    {
+        if (IsDefault) return "\x1b[59m";
+        if (_index >= 0) return $"\x1b[58;5;{_index}m";
+        return $"\x1b[58;2;{R};{G};{B}m";
+    }
+
+    /// <summary>
+    /// Resolves an xterm 256-color palette index to its standard RGB values.
+    /// </summary>
+    private static (byte R, byte G, byte B) ResolveIndexRgb(int index) => index switch
+    {
+        // Standard colors (0-7)
+        0 => (0, 0, 0),
+        1 => (128, 0, 0),
+        2 => (0, 128, 0),
+        3 => (128, 128, 0),
+        4 => (0, 0, 128),
+        5 => (128, 0, 128),
+        6 => (0, 128, 128),
+        7 => (192, 192, 192),
+        // Bright colors (8-15)
+        8 => (128, 128, 128),
+        9 => (255, 0, 0),
+        10 => (0, 255, 0),
+        11 => (255, 255, 0),
+        12 => (0, 0, 255),
+        13 => (255, 0, 255),
+        14 => (0, 255, 255),
+        15 => (255, 255, 255),
+        // 6x6x6 color cube (16-231)
+        >= 16 and <= 231 => ResolveColorCube(index - 16),
+        // Grayscale ramp (232-255)
+        >= 232 and <= 255 => ResolveGrayscale(index - 232),
+        _ => (0, 0, 0)
+    };
+
+    private static (byte R, byte G, byte B) ResolveColorCube(int offset)
+    {
+        int b = offset % 6;
+        int g = (offset / 6) % 6;
+        int r = offset / 36;
+        return ((byte)(r == 0 ? 0 : 55 + r * 40),
+                (byte)(g == 0 ? 0 : 55 + g * 40),
+                (byte)(b == 0 ? 0 : 55 + b * 40));
+    }
+
+    private static (byte R, byte G, byte B) ResolveGrayscale(int offset)
+    {
+        byte v = (byte)(8 + offset * 10);
+        return (v, v, v);
+    }
 }

--- a/src/Hex1b/UnixPtyHandle.cs
+++ b/src/Hex1b/UnixPtyHandle.cs
@@ -39,18 +39,18 @@ internal sealed partial class UnixPtyHandle : IPtyHandle
         string resolvedPath = ResolveExecutablePath(fileName);
         
         // The native pty_forkpty functions inherit the parent's environment.
-        // We need to temporarily set HEX1B_NESTING_LEVEL so the child inherits the correct value,
-        // then restore the original value after fork.
-        // Note: This is not thread-safe, but acceptable for this diagnostic variable.
-        const string nestingLevelKey = "HEX1B_NESTING_LEVEL";
-        string? originalNestingLevel = System.Environment.GetEnvironmentVariable(nestingLevelKey);
+        // We need to temporarily set all environment variables from the dictionary
+        // so the child inherits the correct values, then restore the originals after fork.
+        // Note: This is not thread-safe, but acceptable for typical terminal-start scenarios.
+        var savedEnvironment = new Dictionary<string, string?>();
         
         try
         {
-            // Set the nesting level from the environment dictionary (which has the incremented value)
-            if (environment.TryGetValue(nestingLevelKey, out var newNestingLevel))
+            // Apply all environment dictionary entries to the parent process
+            foreach (var (key, value) in environment)
             {
-                System.Environment.SetEnvironmentVariable(nestingLevelKey, newNestingLevel);
+                savedEnvironment[key] = System.Environment.GetEnvironmentVariable(key);
+                System.Environment.SetEnvironmentVariable(key, value);
             }
             
             int result;
@@ -102,8 +102,11 @@ internal sealed partial class UnixPtyHandle : IPtyHandle
         }
         finally
         {
-            // Restore the original nesting level in the parent process
-            System.Environment.SetEnvironmentVariable(nestingLevelKey, originalNestingLevel);
+            // Restore all original environment values in the parent process
+            foreach (var (key, originalValue) in savedEnvironment)
+            {
+                System.Environment.SetEnvironmentVariable(key, originalValue);
+            }
         }
         
         // Small delay to let child process initialize


### PR DESCRIPTION
## Summary

This PR fixes terminal color rendering by preserving indexed palette colors instead of eagerly converting them to RGB. This allows parent terminals (Windows Terminal, iTerm2, etc.) to apply their own color schemes for the standard 16 ANSI colors.

### Changes

**Indexed color support in \Hex1bColor\**
- Added \FromIndex(byte)\ factory method that stores the palette index (0-255) alongside fallback RGB values
- Added \IsIndexed\ / \Index\ properties to distinguish indexed from RGB colors
- \ToForegroundAnsi()\ / \ToBackgroundAnsi()\ now emit compact SGR codes for indexed colors (e.g. \\e[32m\ for green) instead of always using 24-bit \38;2;R;G;B\ sequences
- Consolidated the duplicated xterm 256-color palette lookup tables from \Hex1bTerminal\ and \SurfaceRenderContext\ into a single \ResolveIndexRgb()\ method on \Hex1bColor\

**Surface rendering**
- \SurfaceComparer.BuildColorSgr\ now emits standard SGR codes for indexed colors 0-15 and \38;5;N\/\48;5;N\ for 16-255

**Child process environment**
- PTY child processes now automatically get \COLORTERM=truecolor\ and \TERM_PROGRAM=hex1b\ so shells and TUI apps detect true color support
- Added \ConfigureEnvironment\ callback on \Hex1bTerminalProcessOptions\ for custom environment tweaks before process launch

**Unix PTY fix**
- \UnixPtyHandle\ now propagates **all** environment dictionary entries to the child process (previously only \HEX1B_NESTING_LEVEL\ was forwarded)

### Files changed
- \src/Hex1b/Theming/Hex1bColor.cs\ — core indexed color support
- \src/Hex1b/Surfaces/SurfaceComparer.cs\ — SGR output for indexed colors
- \src/Hex1b/Surfaces/SurfaceRenderContext.cs\ — consolidated color lookups
- \src/Hex1b/Hex1bTerminal.cs\ — consolidated color lookups
- \src/Hex1b/Hex1bTerminalChildProcess.cs\ — COLORTERM/TERM_PROGRAM + ConfigureEnvironment
- \src/Hex1b/Hex1bTerminalBuilder.cs\ — ConfigureEnvironment plumbing
- \src/Hex1b/UnixPtyHandle.cs\ — full environment propagation
- \samples/TermPetDemo/Program.cs\ — demo updated to use ConfigureEnvironment
