### PR TITLE
Preserve ANSI color indices through terminal color pipeline

### DIFF
--- a/src/Hex1b/Automation/TerminalRegionAnsiExtensions.cs
+++ b/src/Hex1b/Automation/TerminalRegionAnsiExtensions.cs
@@ -110,7 +110,7 @@ public static class TerminalRegionAnsiExtensions
                 sb.Append($"\x1b[{x + 1}G");
 
                 // Build SGR (Select Graphic Rendition) sequence
-                var sgrParams = new List<int>();
+                var sgrParts = new List<string>();
 
                 // Check if we need to reset attributes
                 var needsReset = false;
@@ -136,7 +136,7 @@ public static class TerminalRegionAnsiExtensions
 
                 if (needsReset || (currentFg.HasValue && !targetFg.HasValue) || (currentBg.HasValue && !targetBg.HasValue))
                 {
-                    sgrParams.Add(0);  // Reset all attributes
+                    sgrParts.Add("0");  // Reset all attributes
                     currentAttrs = CellAttributes.None;
                     currentFg = null;
                     currentBg = null;
@@ -144,54 +144,46 @@ public static class TerminalRegionAnsiExtensions
 
                 // Add text attributes
                 if ((targetAttrs & CellAttributes.Bold) != 0 && (currentAttrs & CellAttributes.Bold) == 0)
-                    sgrParams.Add(1);
+                    sgrParts.Add("1");
                 if ((targetAttrs & CellAttributes.Dim) != 0 && (currentAttrs & CellAttributes.Dim) == 0)
-                    sgrParams.Add(2);
+                    sgrParts.Add("2");
                 if ((targetAttrs & CellAttributes.Italic) != 0 && (currentAttrs & CellAttributes.Italic) == 0)
-                    sgrParams.Add(3);
+                    sgrParts.Add("3");
                 if ((targetAttrs & CellAttributes.Underline) != 0 && (currentAttrs & CellAttributes.Underline) == 0)
-                    sgrParams.Add(4);
+                    sgrParts.Add("4");
                 if ((targetAttrs & CellAttributes.Blink) != 0 && (currentAttrs & CellAttributes.Blink) == 0)
-                    sgrParams.Add(5);
+                    sgrParts.Add("5");
                 if ((targetAttrs & CellAttributes.Hidden) != 0 && (currentAttrs & CellAttributes.Hidden) == 0)
-                    sgrParams.Add(8);
+                    sgrParts.Add("8");
                 if ((targetAttrs & CellAttributes.Strikethrough) != 0 && (currentAttrs & CellAttributes.Strikethrough) == 0)
-                    sgrParams.Add(9);
+                    sgrParts.Add("9");
                 if ((targetAttrs & CellAttributes.Overline) != 0 && (currentAttrs & CellAttributes.Overline) == 0)
-                    sgrParams.Add(53);
+                    sgrParts.Add("53");
 
-                // Add foreground color (24-bit true color)
+                // Add foreground color preserving original encoding
                 if (targetFg.HasValue && !ColorsEqual(targetFg, currentFg))
                 {
-                    sgrParams.Add(38);
-                    sgrParams.Add(2);
-                    sgrParams.Add(targetFg.Value.R);
-                    sgrParams.Add(targetFg.Value.G);
-                    sgrParams.Add(targetFg.Value.B);
+                    sgrParts.Add(FormatColorSgr(targetFg.Value, isForeground: true));
                 }
                 else if (!targetFg.HasValue && currentFg.HasValue)
                 {
-                    sgrParams.Add(39);  // Default foreground
+                    sgrParts.Add("39");  // Default foreground
                 }
 
-                // Add background color (24-bit true color)
+                // Add background color preserving original encoding
                 if (targetBg.HasValue && !ColorsEqual(targetBg, currentBg))
                 {
-                    sgrParams.Add(48);
-                    sgrParams.Add(2);
-                    sgrParams.Add(targetBg.Value.R);
-                    sgrParams.Add(targetBg.Value.G);
-                    sgrParams.Add(targetBg.Value.B);
+                    sgrParts.Add(FormatColorSgr(targetBg.Value, isForeground: false));
                 }
                 else if (!targetBg.HasValue && currentBg.HasValue)
                 {
-                    sgrParams.Add(49);  // Default background
+                    sgrParts.Add("49");  // Default background
                 }
 
                 // Emit SGR sequence if needed
-                if (sgrParams.Count > 0)
+                if (sgrParts.Count > 0)
                 {
-                    sb.Append($"\x1b[{string.Join(";", sgrParams)}m");
+                    sb.Append($"\x1b[{string.Join(";", sgrParts)}m");
                 }
 
                 // Update current state
@@ -252,8 +244,17 @@ public static class TerminalRegionAnsiExtensions
             return true;
         if (!a.HasValue || !b.HasValue)
             return false;
-        return a.Value.R == b.Value.R && a.Value.G == b.Value.G && a.Value.B == b.Value.B;
+        return a.Value.R == b.Value.R && a.Value.G == b.Value.G && a.Value.B == b.Value.B
+            && a.Value.Kind == b.Value.Kind && a.Value.AnsiIndex == b.Value.AnsiIndex;
     }
+
+    private static string FormatColorSgr(Hex1bColor color, bool isForeground) => color.Kind switch
+    {
+        Hex1bColorKind.Standard => (isForeground ? 30 + color.AnsiIndex : 40 + color.AnsiIndex).ToString(),
+        Hex1bColorKind.Bright => (isForeground ? 90 + color.AnsiIndex : 100 + color.AnsiIndex).ToString(),
+        Hex1bColorKind.Indexed => $"{(isForeground ? "38;5" : "48;5")};{color.AnsiIndex}",
+        _ => $"{(isForeground ? "38;2" : "48;2")};{color.R};{color.G};{color.B}"
+    };
 }
 
 /// <summary>

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -5745,27 +5745,27 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
 
     private static Hex1bColor StandardColorFromCode(int code) => code switch
     {
-        0 => Hex1bColor.FromRgb(0, 0, 0),
-        1 => Hex1bColor.FromRgb(128, 0, 0),
-        2 => Hex1bColor.FromRgb(0, 128, 0),
-        3 => Hex1bColor.FromRgb(128, 128, 0),
-        4 => Hex1bColor.FromRgb(0, 0, 128),
-        5 => Hex1bColor.FromRgb(128, 0, 128),
-        6 => Hex1bColor.FromRgb(0, 128, 128),
-        7 => Hex1bColor.FromRgb(192, 192, 192),
+        0 => Hex1bColor.FromStandard(0, 0, 0, 0),
+        1 => Hex1bColor.FromStandard(1, 128, 0, 0),
+        2 => Hex1bColor.FromStandard(2, 0, 128, 0),
+        3 => Hex1bColor.FromStandard(3, 128, 128, 0),
+        4 => Hex1bColor.FromStandard(4, 0, 0, 128),
+        5 => Hex1bColor.FromStandard(5, 128, 0, 128),
+        6 => Hex1bColor.FromStandard(6, 0, 128, 128),
+        7 => Hex1bColor.FromStandard(7, 192, 192, 192),
         _ => Hex1bColor.FromRgb(128, 128, 128)
     };
 
     private static Hex1bColor BrightColorFromCode(int code) => code switch
     {
-        0 => Hex1bColor.FromRgb(128, 128, 128),
-        1 => Hex1bColor.FromRgb(255, 0, 0),
-        2 => Hex1bColor.FromRgb(0, 255, 0),
-        3 => Hex1bColor.FromRgb(255, 255, 0),
-        4 => Hex1bColor.FromRgb(0, 0, 255),
-        5 => Hex1bColor.FromRgb(255, 0, 255),
-        6 => Hex1bColor.FromRgb(0, 255, 255),
-        7 => Hex1bColor.FromRgb(255, 255, 255),
+        0 => Hex1bColor.FromBright(0, 128, 128, 128),
+        1 => Hex1bColor.FromBright(1, 255, 0, 0),
+        2 => Hex1bColor.FromBright(2, 0, 255, 0),
+        3 => Hex1bColor.FromBright(3, 255, 255, 0),
+        4 => Hex1bColor.FromBright(4, 0, 0, 255),
+        5 => Hex1bColor.FromBright(5, 255, 0, 255),
+        6 => Hex1bColor.FromBright(6, 0, 255, 255),
+        7 => Hex1bColor.FromBright(7, 255, 255, 255),
         _ => Hex1bColor.FromRgb(192, 192, 192)
     };
 
@@ -5777,16 +5777,16 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
         }
         else if (index < 232)
         {
-            index -= 16;
-            var r = (index / 36) * 51;
-            var g = ((index / 6) % 6) * 51;
-            var b = (index % 6) * 51;
-            return Hex1bColor.FromRgb((byte)r, (byte)g, (byte)b);
+            var i = index - 16;
+            var r = (i / 36) * 51;
+            var g = ((i / 6) % 6) * 51;
+            var b = (i % 6) * 51;
+            return Hex1bColor.FromIndexed((byte)index, (byte)r, (byte)g, (byte)b);
         }
         else
         {
             var gray = (index - 232) * 10 + 8;
-            return Hex1bColor.FromRgb((byte)gray, (byte)gray, (byte)gray);
+            return Hex1bColor.FromIndexed((byte)index, (byte)gray, (byte)gray, (byte)gray);
         }
     }
 

--- a/src/Hex1b/Surfaces/SurfaceComparer.cs
+++ b/src/Hex1b/Surfaces/SurfaceComparer.cs
@@ -749,7 +749,9 @@ public static class SurfaceComparer
         if (a is null || b is null) return false;
         return a.Value.R == b.Value.R && 
                a.Value.G == b.Value.G && 
-               a.Value.B == b.Value.B;
+               a.Value.B == b.Value.B &&
+               a.Value.Kind == b.Value.Kind &&
+               a.Value.AnsiIndex == b.Value.AnsiIndex;
     }
 
     private static string BuildSgrParameters(

--- a/src/Hex1b/Surfaces/SurfaceComparer.cs
+++ b/src/Hex1b/Surfaces/SurfaceComparer.cs
@@ -867,9 +867,13 @@ public static class SurfaceComparer
 
     private static string BuildColorSgr(Hex1bColor color, bool isForeground)
     {
-        // Use 24-bit color (SGR 38;2;r;g;b for foreground, 48;2;r;g;b for background)
-        var prefix = isForeground ? "38;2" : "48;2";
-        return $"{prefix};{color.R};{color.G};{color.B}";
+        return color.Kind switch
+        {
+            Hex1bColorKind.Standard => (isForeground ? 30 + color.AnsiIndex : 40 + color.AnsiIndex).ToString(),
+            Hex1bColorKind.Bright => (isForeground ? 90 + color.AnsiIndex : 100 + color.AnsiIndex).ToString(),
+            Hex1bColorKind.Indexed => $"{(isForeground ? "38;5" : "48;5")};{color.AnsiIndex}",
+            _ => $"{(isForeground ? "38;2" : "48;2")};{color.R};{color.G};{color.B}"
+        };
     }
 
     #endregion

--- a/src/Hex1b/Surfaces/SurfaceRenderContext.cs
+++ b/src/Hex1b/Surfaces/SurfaceRenderContext.cs
@@ -1505,27 +1505,27 @@ public class SurfaceRenderContext : Hex1bRenderContext
 
     private static Hex1bColor GetBasicColor(int index) => index switch
     {
-        0 => Hex1bColor.FromRgb(0, 0, 0),       // Black
-        1 => Hex1bColor.FromRgb(128, 0, 0),     // Red
-        2 => Hex1bColor.FromRgb(0, 128, 0),     // Green
-        3 => Hex1bColor.FromRgb(128, 128, 0),   // Yellow
-        4 => Hex1bColor.FromRgb(0, 0, 128),     // Blue
-        5 => Hex1bColor.FromRgb(128, 0, 128),   // Magenta
-        6 => Hex1bColor.FromRgb(0, 128, 128),   // Cyan
-        7 => Hex1bColor.FromRgb(192, 192, 192), // White
+        0 => Hex1bColor.FromStandard(0, 0, 0, 0),       // Black
+        1 => Hex1bColor.FromStandard(1, 128, 0, 0),     // Red
+        2 => Hex1bColor.FromStandard(2, 0, 128, 0),     // Green
+        3 => Hex1bColor.FromStandard(3, 128, 128, 0),   // Yellow
+        4 => Hex1bColor.FromStandard(4, 0, 0, 128),     // Blue
+        5 => Hex1bColor.FromStandard(5, 128, 0, 128),   // Magenta
+        6 => Hex1bColor.FromStandard(6, 0, 128, 128),   // Cyan
+        7 => Hex1bColor.FromStandard(7, 192, 192, 192), // White
         _ => Hex1bColor.FromRgb(128, 128, 128)
     };
 
     private static Hex1bColor GetBrightColor(int index) => index switch
     {
-        0 => Hex1bColor.FromRgb(128, 128, 128), // Bright Black (Gray)
-        1 => Hex1bColor.FromRgb(255, 0, 0),     // Bright Red
-        2 => Hex1bColor.FromRgb(0, 255, 0),     // Bright Green
-        3 => Hex1bColor.FromRgb(255, 255, 0),   // Bright Yellow
-        4 => Hex1bColor.FromRgb(0, 0, 255),     // Bright Blue
-        5 => Hex1bColor.FromRgb(255, 0, 255),   // Bright Magenta
-        6 => Hex1bColor.FromRgb(0, 255, 255),   // Bright Cyan
-        7 => Hex1bColor.FromRgb(255, 255, 255), // Bright White
+        0 => Hex1bColor.FromBright(0, 128, 128, 128), // Bright Black (Gray)
+        1 => Hex1bColor.FromBright(1, 255, 0, 0),     // Bright Red
+        2 => Hex1bColor.FromBright(2, 0, 255, 0),     // Bright Green
+        3 => Hex1bColor.FromBright(3, 255, 255, 0),   // Bright Yellow
+        4 => Hex1bColor.FromBright(4, 0, 0, 255),     // Bright Blue
+        5 => Hex1bColor.FromBright(5, 255, 0, 255),   // Bright Magenta
+        6 => Hex1bColor.FromBright(6, 0, 255, 255),   // Bright Cyan
+        7 => Hex1bColor.FromBright(7, 255, 255, 255), // Bright White
         _ => Hex1bColor.FromRgb(255, 255, 255)
     };
 
@@ -1543,13 +1543,13 @@ public class SurfaceRenderContext : Hex1bRenderContext
             var r = (i / 36) * 51;
             var g = ((i / 6) % 6) * 51;
             var b = (i % 6) * 51;
-            return Hex1bColor.FromRgb((byte)r, (byte)g, (byte)b);
+            return Hex1bColor.FromIndexed((byte)index, (byte)r, (byte)g, (byte)b);
         }
         else
         {
             // Grayscale (indices 232-255)
             var gray = (index - 232) * 10 + 8;
-            return Hex1bColor.FromRgb((byte)gray, (byte)gray, (byte)gray);
+            return Hex1bColor.FromIndexed((byte)index, (byte)gray, (byte)gray, (byte)gray);
         }
     }
 

--- a/src/Hex1b/Theming/Hex1bColor.cs
+++ b/src/Hex1b/Theming/Hex1bColor.cs
@@ -1,8 +1,32 @@
 namespace Hex1b.Theming;
 
 /// <summary>
+/// The kind of ANSI color encoding.
+/// </summary>
+public enum Hex1bColorKind : byte
+{
+    /// <summary>24-bit RGB color (SGR 38;2;R;G;B).</summary>
+    Rgb,
+
+    /// <summary>Standard ANSI color index 0–7 (SGR 30–37 / 40–47).</summary>
+    Standard,
+
+    /// <summary>Bright ANSI color index 0–7 (SGR 90–97 / 100–107).</summary>
+    Bright,
+
+    /// <summary>256-color palette index (SGR 38;5;N / 48;5;N).</summary>
+    Indexed
+}
+
+/// <summary>
 /// Represents a color that can be used in the terminal.
 /// </summary>
+/// <remarks>
+/// Colors preserve their original encoding so that when re-serialized
+/// they emit the same SGR code the workload originally sent. This ensures
+/// standard ANSI colors (e.g., SGR 34 = blue) remain palette-relative
+/// instead of being converted to fixed RGB values.
+/// </remarks>
 public readonly struct Hex1bColor
 {
     public byte R { get; }
@@ -10,18 +34,71 @@ public readonly struct Hex1bColor
     public byte B { get; }
     public bool IsDefault { get; }
 
+    /// <summary>
+    /// The color encoding kind.
+    /// </summary>
+    public Hex1bColorKind Kind { get; }
+
+    /// <summary>
+    /// The ANSI color index (0–7 for standard/bright, 0–255 for indexed).
+    /// Only meaningful when <see cref="Kind"/> is not <see cref="Hex1bColorKind.Rgb"/>.
+    /// </summary>
+    public byte AnsiIndex { get; }
+
     private Hex1bColor(byte r, byte g, byte b, bool isDefault = false)
     {
         R = r;
         G = g;
         B = b;
         IsDefault = isDefault;
+        Kind = Hex1bColorKind.Rgb;
+        AnsiIndex = 0;
+    }
+
+    private Hex1bColor(byte r, byte g, byte b, Hex1bColorKind kind, byte ansiIndex)
+    {
+        R = r;
+        G = g;
+        B = b;
+        IsDefault = false;
+        Kind = kind;
+        AnsiIndex = ansiIndex;
     }
 
     /// <summary>
     /// Creates a color from RGB values.
     /// </summary>
     public static Hex1bColor FromRgb(byte r, byte g, byte b) => new(r, g, b);
+
+    /// <summary>
+    /// Creates a standard ANSI color (indices 0–7, corresponding to SGR 30–37).
+    /// </summary>
+    /// <param name="index">Color index 0–7.</param>
+    /// <param name="r">Approximate RGB red component (for rendering when palette is unavailable).</param>
+    /// <param name="g">Approximate RGB green component.</param>
+    /// <param name="b">Approximate RGB blue component.</param>
+    public static Hex1bColor FromStandard(byte index, byte r, byte g, byte b) =>
+        new(r, g, b, Hex1bColorKind.Standard, index);
+
+    /// <summary>
+    /// Creates a bright ANSI color (indices 0–7, corresponding to SGR 90–97).
+    /// </summary>
+    /// <param name="index">Color index 0–7.</param>
+    /// <param name="r">Approximate RGB red component.</param>
+    /// <param name="g">Approximate RGB green component.</param>
+    /// <param name="b">Approximate RGB blue component.</param>
+    public static Hex1bColor FromBright(byte index, byte r, byte g, byte b) =>
+        new(r, g, b, Hex1bColorKind.Bright, index);
+
+    /// <summary>
+    /// Creates a 256-color palette color (SGR 38;5;N).
+    /// </summary>
+    /// <param name="index">Color index 0–255.</param>
+    /// <param name="r">Approximate RGB red component.</param>
+    /// <param name="g">Approximate RGB green component.</param>
+    /// <param name="b">Approximate RGB blue component.</param>
+    public static Hex1bColor FromIndexed(byte index, byte r, byte g, byte b) =>
+        new(r, g, b, Hex1bColorKind.Indexed, index);
 
     /// <summary>
     /// The default terminal foreground/background color.
@@ -44,12 +121,26 @@ public readonly struct Hex1bColor
     /// <summary>
     /// Gets the ANSI escape code for setting this as the foreground color.
     /// </summary>
-    public string ToForegroundAnsi() => IsDefault ? "\x1b[39m" : $"\x1b[38;2;{R};{G};{B}m";
+    public string ToForegroundAnsi() => Kind switch
+    {
+        _ when IsDefault => "\x1b[39m",
+        Hex1bColorKind.Standard => $"\x1b[{30 + AnsiIndex}m",
+        Hex1bColorKind.Bright => $"\x1b[{90 + AnsiIndex}m",
+        Hex1bColorKind.Indexed => $"\x1b[38;5;{AnsiIndex}m",
+        _ => $"\x1b[38;2;{R};{G};{B}m"
+    };
 
     /// <summary>
     /// Gets the ANSI escape code for setting this as the background color.
     /// </summary>
-    public string ToBackgroundAnsi() => IsDefault ? "\x1b[49m" : $"\x1b[48;2;{R};{G};{B}m";
+    public string ToBackgroundAnsi() => Kind switch
+    {
+        _ when IsDefault => "\x1b[49m",
+        Hex1bColorKind.Standard => $"\x1b[{40 + AnsiIndex}m",
+        Hex1bColorKind.Bright => $"\x1b[{100 + AnsiIndex}m",
+        Hex1bColorKind.Indexed => $"\x1b[48;5;{AnsiIndex}m",
+        _ => $"\x1b[48;2;{R};{G};{B}m"
+    };
 
     /// <summary>
     /// Gets the ANSI escape code for setting this as the underline color (SGR 58).

--- a/tests/Hex1b.Tests/AnsiColorPreservationTests.cs
+++ b/tests/Hex1b.Tests/AnsiColorPreservationTests.cs
@@ -1,0 +1,456 @@
+using Hex1b.Automation;
+using Hex1b.Surfaces;
+using Hex1b.Theming;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Tests that ANSI color indices are preserved through the terminal color pipeline.
+/// Standard ANSI colors (SGR 30-37), bright colors (SGR 90-97), and 256-color indices
+/// (SGR 38;5;N) must be stored with their original encoding and re-emitted faithfully
+/// so that the user's terminal palette is respected.
+/// </summary>
+public class AnsiColorPreservationTests
+{
+    #region Hex1bColor Kind Preservation
+
+    [Fact]
+    public void FromStandard_PreservesKindAndIndex()
+    {
+        var color = Hex1bColor.FromStandard(4, 0, 0, 128);
+
+        Assert.Equal(Hex1bColorKind.Standard, color.Kind);
+        Assert.Equal(4, color.AnsiIndex);
+        Assert.Equal(0, color.R);
+        Assert.Equal(0, color.G);
+        Assert.Equal(128, color.B);
+    }
+
+    [Fact]
+    public void FromBright_PreservesKindAndIndex()
+    {
+        var color = Hex1bColor.FromBright(1, 255, 0, 0);
+
+        Assert.Equal(Hex1bColorKind.Bright, color.Kind);
+        Assert.Equal(1, color.AnsiIndex);
+    }
+
+    [Fact]
+    public void FromIndexed_PreservesKindAndIndex()
+    {
+        var color = Hex1bColor.FromIndexed(196, 255, 0, 0);
+
+        Assert.Equal(Hex1bColorKind.Indexed, color.Kind);
+        Assert.Equal(196, color.AnsiIndex);
+    }
+
+    [Fact]
+    public void FromRgb_HasRgbKind()
+    {
+        var color = Hex1bColor.FromRgb(100, 200, 50);
+
+        Assert.Equal(Hex1bColorKind.Rgb, color.Kind);
+        Assert.Equal(0, color.AnsiIndex);
+    }
+
+    #endregion
+
+    #region Hex1bColor ANSI Serialization
+
+    [Theory]
+    [InlineData(0, "\x1b[30m")]  // Black
+    [InlineData(1, "\x1b[31m")]  // Red
+    [InlineData(2, "\x1b[32m")]  // Green
+    [InlineData(3, "\x1b[33m")]  // Yellow
+    [InlineData(4, "\x1b[34m")]  // Blue
+    [InlineData(5, "\x1b[35m")]  // Magenta
+    [InlineData(6, "\x1b[36m")]  // Cyan
+    [InlineData(7, "\x1b[37m")]  // White
+    public void ToForegroundAnsi_StandardColor_EmitsOriginalCode(int index, string expected)
+    {
+        var color = Hex1bColor.FromStandard((byte)index, 0, 0, 0);
+        Assert.Equal(expected, color.ToForegroundAnsi());
+    }
+
+    [Theory]
+    [InlineData(0, "\x1b[40m")]
+    [InlineData(4, "\x1b[44m")]  // Blue background
+    public void ToBackgroundAnsi_StandardColor_EmitsOriginalCode(int index, string expected)
+    {
+        var color = Hex1bColor.FromStandard((byte)index, 0, 0, 0);
+        Assert.Equal(expected, color.ToBackgroundAnsi());
+    }
+
+    [Theory]
+    [InlineData(0, "\x1b[90m")]   // Bright black
+    [InlineData(1, "\x1b[91m")]   // Bright red
+    [InlineData(4, "\x1b[94m")]   // Bright blue
+    [InlineData(7, "\x1b[97m")]   // Bright white
+    public void ToForegroundAnsi_BrightColor_EmitsOriginalCode(int index, string expected)
+    {
+        var color = Hex1bColor.FromBright((byte)index, 0, 0, 0);
+        Assert.Equal(expected, color.ToForegroundAnsi());
+    }
+
+    [Theory]
+    [InlineData(0, "\x1b[100m")]
+    [InlineData(4, "\x1b[104m")]  // Bright blue background
+    public void ToBackgroundAnsi_BrightColor_EmitsOriginalCode(int index, string expected)
+    {
+        var color = Hex1bColor.FromBright((byte)index, 0, 0, 0);
+        Assert.Equal(expected, color.ToBackgroundAnsi());
+    }
+
+    [Fact]
+    public void ToForegroundAnsi_IndexedColor_Emits256Code()
+    {
+        var color = Hex1bColor.FromIndexed(196, 255, 0, 0);
+        Assert.Equal("\x1b[38;5;196m", color.ToForegroundAnsi());
+    }
+
+    [Fact]
+    public void ToBackgroundAnsi_IndexedColor_Emits256Code()
+    {
+        var color = Hex1bColor.FromIndexed(21, 0, 0, 255);
+        Assert.Equal("\x1b[48;5;21m", color.ToBackgroundAnsi());
+    }
+
+    [Fact]
+    public void ToForegroundAnsi_RgbColor_Emits24BitCode()
+    {
+        var color = Hex1bColor.FromRgb(100, 200, 50);
+        Assert.Equal("\x1b[38;2;100;200;50m", color.ToForegroundAnsi());
+    }
+
+    #endregion
+
+    #region Terminal ProcessSgr Preservation
+
+    [Theory]
+    [InlineData("34", Hex1bColorKind.Standard, 4)]     // Blue
+    [InlineData("31", Hex1bColorKind.Standard, 1)]     // Red
+    [InlineData("37", Hex1bColorKind.Standard, 7)]     // White
+    public void ProcessSgr_StandardForeground_PreservesIndex(string sgr, Hex1bColorKind expectedKind, int expectedIndex)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+
+        terminal.ApplyTokens([new SgrToken(sgr), new TextToken("X")]);
+
+        var cell = terminal.CreateSnapshot().GetCell(0, 0);
+        Assert.NotNull(cell.Foreground);
+        Assert.Equal(expectedKind, cell.Foreground.Value.Kind);
+        Assert.Equal(expectedIndex, cell.Foreground.Value.AnsiIndex);
+    }
+
+    [Theory]
+    [InlineData("44", Hex1bColorKind.Standard, 4)]     // Blue bg
+    [InlineData("41", Hex1bColorKind.Standard, 1)]     // Red bg
+    public void ProcessSgr_StandardBackground_PreservesIndex(string sgr, Hex1bColorKind expectedKind, int expectedIndex)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+
+        terminal.ApplyTokens([new SgrToken(sgr), new TextToken("X")]);
+
+        var cell = terminal.CreateSnapshot().GetCell(0, 0);
+        Assert.NotNull(cell.Background);
+        Assert.Equal(expectedKind, cell.Background.Value.Kind);
+        Assert.Equal(expectedIndex, cell.Background.Value.AnsiIndex);
+    }
+
+    [Theory]
+    [InlineData("94", Hex1bColorKind.Bright, 4)]    // Bright blue
+    [InlineData("91", Hex1bColorKind.Bright, 1)]    // Bright red
+    public void ProcessSgr_BrightForeground_PreservesIndex(string sgr, Hex1bColorKind expectedKind, int expectedIndex)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+
+        terminal.ApplyTokens([new SgrToken(sgr), new TextToken("X")]);
+
+        var cell = terminal.CreateSnapshot().GetCell(0, 0);
+        Assert.NotNull(cell.Foreground);
+        Assert.Equal(expectedKind, cell.Foreground.Value.Kind);
+        Assert.Equal(expectedIndex, cell.Foreground.Value.AnsiIndex);
+    }
+
+    [Fact]
+    public void ProcessSgr_256ColorForeground_PreservesIndex()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+
+        terminal.ApplyTokens([new SgrToken("38;5;196"), new TextToken("X")]);
+
+        var cell = terminal.CreateSnapshot().GetCell(0, 0);
+        Assert.NotNull(cell.Foreground);
+        Assert.Equal(Hex1bColorKind.Indexed, cell.Foreground.Value.Kind);
+        Assert.Equal(196, cell.Foreground.Value.AnsiIndex);
+    }
+
+    [Fact]
+    public void ProcessSgr_24BitRgb_StaysRgbKind()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+
+        terminal.ApplyTokens([new SgrToken("38;2;100;200;50"), new TextToken("X")]);
+
+        var cell = terminal.CreateSnapshot().GetCell(0, 0);
+        Assert.NotNull(cell.Foreground);
+        Assert.Equal(Hex1bColorKind.Rgb, cell.Foreground.Value.Kind);
+        Assert.Equal(100, cell.Foreground.Value.R);
+        Assert.Equal(200, cell.Foreground.Value.G);
+        Assert.Equal(50, cell.Foreground.Value.B);
+    }
+
+    #endregion
+
+    #region ToAnsi Round-Trip Preservation
+
+    [Fact]
+    public void ToAnsi_StandardBlue_EmitsOriginalSgrCode()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+
+        // Apply standard blue foreground
+        terminal.ApplyTokens([new SgrToken("34"), new TextToken("X")]);
+
+        var snapshot = terminal.CreateSnapshot();
+        var ansi = snapshot.ToAnsi(new TerminalAnsiOptions { IncludeClearScreen = true });
+
+        // Should contain SGR 34 (standard blue), NOT 38;2;0;0;128 (RGB)
+        Assert.Contains("\x1b[34m", ansi);
+        Assert.DoesNotContain("38;2;0;0;128", ansi);
+    }
+
+    [Fact]
+    public void ToAnsi_BrightRed_EmitsOriginalSgrCode()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+
+        terminal.ApplyTokens([new SgrToken("91"), new TextToken("X")]);
+
+        var snapshot = terminal.CreateSnapshot();
+        var ansi = snapshot.ToAnsi(new TerminalAnsiOptions { IncludeClearScreen = true });
+
+        Assert.Contains("\x1b[91m", ansi);
+        Assert.DoesNotContain("38;2;255;0;0", ansi);
+    }
+
+    [Fact]
+    public void ToAnsi_256Color_Emits256Code()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+
+        terminal.ApplyTokens([new SgrToken("38;5;196"), new TextToken("X")]);
+
+        var snapshot = terminal.CreateSnapshot();
+        var ansi = snapshot.ToAnsi(new TerminalAnsiOptions { IncludeClearScreen = true });
+
+        Assert.Contains("38;5;196", ansi);
+    }
+
+    [Fact]
+    public void ToAnsi_24BitRgb_Emits24BitCode()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
+
+        terminal.ApplyTokens([new SgrToken("38;2;100;200;50"), new TextToken("X")]);
+
+        var snapshot = terminal.CreateSnapshot();
+        var ansi = snapshot.ToAnsi(new TerminalAnsiOptions { IncludeClearScreen = true });
+
+        Assert.Contains("38;2;100;200;50", ansi);
+    }
+
+    #endregion
+
+    #region SurfaceComparer Preservation
+
+    [Fact]
+    public void SurfaceComparer_StandardColor_EmitsOriginalCode()
+    {
+        var previous = new Surface(10, 1);
+        var current = new Surface(10, 1);
+        current[0, 0] = new SurfaceCell("X", Hex1bColor.FromStandard(4, 0, 0, 128), null);
+
+        var diff = SurfaceComparer.Compare(previous, current);
+        var tokens = SurfaceComparer.ToTokens(diff);
+
+        var sgr = tokens.OfType<SgrToken>().FirstOrDefault();
+        Assert.NotNull(sgr);
+        // Should emit "34" (standard blue), not "38;2;0;0;128"
+        Assert.Contains("34", sgr.Parameters.Split(';'));
+        Assert.DoesNotContain("38;2", sgr.Parameters);
+    }
+
+    [Fact]
+    public void SurfaceComparer_BrightColor_EmitsOriginalCode()
+    {
+        var previous = new Surface(10, 1);
+        var current = new Surface(10, 1);
+        current[0, 0] = new SurfaceCell("X", Hex1bColor.FromBright(4, 0, 0, 255), null);
+
+        var diff = SurfaceComparer.Compare(previous, current);
+        var tokens = SurfaceComparer.ToTokens(diff);
+
+        var sgr = tokens.OfType<SgrToken>().FirstOrDefault();
+        Assert.NotNull(sgr);
+        Assert.Contains("94", sgr.Parameters.Split(';'));
+    }
+
+    [Fact]
+    public void SurfaceComparer_IndexedColor_Emits256Code()
+    {
+        var previous = new Surface(10, 1);
+        var current = new Surface(10, 1);
+        current[0, 0] = new SurfaceCell("X", Hex1bColor.FromIndexed(196, 255, 0, 0), null);
+
+        var diff = SurfaceComparer.Compare(previous, current);
+        var tokens = SurfaceComparer.ToTokens(diff);
+
+        var sgr = tokens.OfType<SgrToken>().FirstOrDefault();
+        Assert.NotNull(sgr);
+        Assert.Contains("38;5;196", sgr.Parameters);
+    }
+
+    [Fact]
+    public void SurfaceComparer_RgbColor_Emits24BitCode()
+    {
+        var previous = new Surface(10, 1);
+        var current = new Surface(10, 1);
+        current[0, 0] = new SurfaceCell("X", Hex1bColor.FromRgb(100, 200, 50), null);
+
+        var diff = SurfaceComparer.Compare(previous, current);
+        var tokens = SurfaceComparer.ToTokens(diff);
+
+        var sgr = tokens.OfType<SgrToken>().FirstOrDefault();
+        Assert.NotNull(sgr);
+        Assert.Contains("38;2;100;200;50", sgr.Parameters);
+    }
+
+    [Fact]
+    public void SurfaceComparer_StandardBackground_EmitsOriginalCode()
+    {
+        var previous = new Surface(10, 1);
+        var current = new Surface(10, 1);
+        current[0, 0] = new SurfaceCell("X", null, Hex1bColor.FromStandard(1, 128, 0, 0));
+
+        var diff = SurfaceComparer.Compare(previous, current);
+        var tokens = SurfaceComparer.ToTokens(diff);
+
+        var sgr = tokens.OfType<SgrToken>().FirstOrDefault();
+        Assert.NotNull(sgr);
+        // Background standard red = SGR 41
+        Assert.Contains("41", sgr.Parameters.Split(';'));
+    }
+
+    #endregion
+
+    #region Full Pipeline (Terminal → Surface → ANSI Output)
+
+    [Fact]
+    public async Task EmbeddedTerminal_StandardBlue_PreservedThroughSurface()
+    {
+        // This tests the full rendering pipeline used by EmbeddedTerminalDemo:
+        // 1. Child terminal receives ESC[34m (standard blue)
+        // 2. TerminalNode renders to SurfaceRenderContext via WriteClipped
+        // 3. SurfaceRenderContext parses ANSI and stores Hex1bColor with preserved index
+        // 4. SurfaceComparer diffs and emits final ANSI with original SGR code
+
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var childTerminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithHeadless()
+            .WithDimensions(20, 5)
+            .Build();
+
+        // Apply standard blue to the child terminal
+        childTerminal.ApplyTokens([new SgrToken("34"), new TextToken("Blue!")]);
+
+        // Verify the child terminal stores the color with its index
+        var childSnapshot = childTerminal.CreateSnapshot();
+        var childCell = childSnapshot.GetCell(0, 0);
+        Assert.NotNull(childCell.Foreground);
+        Assert.Equal(Hex1bColorKind.Standard, childCell.Foreground.Value.Kind);
+        Assert.Equal(4, childCell.Foreground.Value.AnsiIndex);
+
+        // Now verify the ToAnsi output preserves it
+        var ansi = childSnapshot.ToAnsi(new TerminalAnsiOptions { IncludeClearScreen = true });
+        Assert.Contains("\x1b[34m", ansi);
+        Assert.DoesNotContain("38;2;0;0;128", ansi);
+    }
+
+    [Fact]
+    public void SurfaceRenderContext_StandardBlue_PreservesColorKind()
+    {
+        // Test that SurfaceRenderContext's ANSI parser preserves color indices
+        // when parsing ANSI codes written by TerminalNode.RenderRow
+
+        var surface = new Surface(20, 1);
+        var context = new SurfaceRenderContext(surface);
+
+        // Simulate what TerminalNode.RenderRow writes: ESC[0m ESC[34m Blue!
+        context.WriteClipped(0, 0, "\x1b[0m\x1b[34mBlue!");
+
+        // The surface cell should preserve the standard blue index
+        var cell = surface[0, 0];
+        Assert.Equal("B", cell.Character);
+        Assert.NotNull(cell.Foreground);
+        Assert.Equal(Hex1bColorKind.Standard, cell.Foreground.Value.Kind);
+        Assert.Equal(4, cell.Foreground.Value.AnsiIndex);
+    }
+
+    [Fact]
+    public void SurfaceRenderContext_BrightRed_PreservesColorKind()
+    {
+        var surface = new Surface(20, 1);
+        var context = new SurfaceRenderContext(surface);
+
+        context.WriteClipped(0, 0, "\x1b[91mRed!");
+
+        var cell = surface[0, 0];
+        Assert.NotNull(cell.Foreground);
+        Assert.Equal(Hex1bColorKind.Bright, cell.Foreground.Value.Kind);
+        Assert.Equal(1, cell.Foreground.Value.AnsiIndex);
+    }
+
+    [Fact]
+    public void SurfaceRenderContext_256Color_PreservesColorKind()
+    {
+        var surface = new Surface(20, 1);
+        var context = new SurfaceRenderContext(surface);
+
+        context.WriteClipped(0, 0, "\x1b[38;5;196mRed!");
+
+        var cell = surface[0, 0];
+        Assert.NotNull(cell.Foreground);
+        Assert.Equal(Hex1bColorKind.Indexed, cell.Foreground.Value.Kind);
+        Assert.Equal(196, cell.Foreground.Value.AnsiIndex);
+    }
+
+    [Fact]
+    public void SurfaceRenderContext_24BitRgb_StaysRgbKind()
+    {
+        var surface = new Surface(20, 1);
+        var context = new SurfaceRenderContext(surface);
+
+        context.WriteClipped(0, 0, "\x1b[38;2;100;200;50mGreen!");
+
+        var cell = surface[0, 0];
+        Assert.NotNull(cell.Foreground);
+        Assert.Equal(Hex1bColorKind.Rgb, cell.Foreground.Value.Kind);
+        Assert.Equal(100, cell.Foreground.Value.R);
+        Assert.Equal(200, cell.Foreground.Value.G);
+        Assert.Equal(50, cell.Foreground.Value.B);
+    }
+
+    #endregion
+}

--- a/tests/Hex1b.Tests/ColorIndexMappingTests.cs
+++ b/tests/Hex1b.Tests/ColorIndexMappingTests.cs
@@ -46,8 +46,11 @@ public class ColorIndexMappingTests
         Assert.NotNull(fg);
 
         // Index 7 (SGR 37) should be light gray (192,192,192), NOT white (255,255,255)
-        Assert.NotEqual(Hex1bColor.FromRgb(255, 255, 255), fg.Value);
-        Assert.Equal(Hex1bColor.FromRgb(192, 192, 192), fg.Value);
+        Assert.Equal(192, fg.Value.R);
+        Assert.Equal(192, fg.Value.G);
+        Assert.Equal(192, fg.Value.B);
+        Assert.Equal(Hex1bColorKind.Standard, fg.Value.Kind);
+        Assert.Equal(7, fg.Value.AnsiIndex);
     }
 
     [Fact]
@@ -61,7 +64,11 @@ public class ColorIndexMappingTests
         Assert.NotNull(fg);
 
         // Index 15 (SGR 97) should be white (255,255,255), NOT gray
-        Assert.Equal(Hex1bColor.FromRgb(255, 255, 255), fg.Value);
+        Assert.Equal(255, fg.Value.R);
+        Assert.Equal(255, fg.Value.G);
+        Assert.Equal(255, fg.Value.B);
+        Assert.Equal(Hex1bColorKind.Bright, fg.Value.Kind);
+        Assert.Equal(7, fg.Value.AnsiIndex);
     }
 
     [Fact]
@@ -96,7 +103,11 @@ public class ColorIndexMappingTests
         var snap = t.Terminal.CreateSnapshot();
         var fg = snap.GetCell(0, 0).Foreground;
         Assert.NotNull(fg);
-        Assert.Equal(Hex1bColor.FromRgb(r, g, b), fg.Value);
+        Assert.Equal(r, fg.Value.R);
+        Assert.Equal(g, fg.Value.G);
+        Assert.Equal(b, fg.Value.B);
+        Assert.Equal(Hex1bColorKind.Standard, fg.Value.Kind);
+        Assert.Equal(sgr - 30, fg.Value.AnsiIndex);
     }
 
     [Theory]
@@ -116,7 +127,11 @@ public class ColorIndexMappingTests
         var snap = t.Terminal.CreateSnapshot();
         var fg = snap.GetCell(0, 0).Foreground;
         Assert.NotNull(fg);
-        Assert.Equal(Hex1bColor.FromRgb(r, g, b), fg.Value);
+        Assert.Equal(r, fg.Value.R);
+        Assert.Equal(g, fg.Value.G);
+        Assert.Equal(b, fg.Value.B);
+        Assert.Equal(Hex1bColorKind.Bright, fg.Value.Kind);
+        Assert.Equal(sgr - 90, fg.Value.AnsiIndex);
     }
 
     [Fact]
@@ -130,7 +145,11 @@ public class ColorIndexMappingTests
         Assert.NotNull(fg);
 
         // Index 196 = 6x6x6 cube: (196-16)=180, r=180/36=5→255, g=0, b=0
-        Assert.Equal(Hex1bColor.FromRgb(255, 0, 0), fg.Value);
+        Assert.Equal(255, fg.Value.R);
+        Assert.Equal(0, fg.Value.G);
+        Assert.Equal(0, fg.Value.B);
+        Assert.Equal(Hex1bColorKind.Indexed, fg.Value.Kind);
+        Assert.Equal(196, fg.Value.AnsiIndex);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

Standard ANSI colors (e.g., `ESC[34m` for blue) were being converted to hardcoded RGB values on input (`0,0,128`), then re-emitted as 24-bit RGB (`ESC[38;2;0;0;128m`) on output. This bypassed the user's terminal color palette, causing standard colors to appear differently than expected — particularly noticeable for blue, which most terminals render much brighter than `(0,0,128)`.

This affects any code path that re-serializes terminal cell colors: `CreateSnapshot().ToAnsi()`, surface comparison diffs, and `Hex1bColor.ToForegroundAnsi()`/`ToBackgroundAnsi()`.

## Fix

Preserve the original ANSI color encoding through the entire pipeline:

### `Hex1bColor` struct changes
- Added `Hex1bColorKind` enum: `Rgb`, `Standard`, `Bright`, `Indexed`
- Added `AnsiIndex` property for palette-relative colors
- Added factory methods: `FromStandard()`, `FromBright()`, `FromIndexed()`
- Updated `ToForegroundAnsi()`/`ToBackgroundAnsi()` to emit the original SGR code

### Terminal color parsing
- `StandardColorFromCode()`: now returns `Hex1bColor.FromStandard(index, r, g, b)`
- `BrightColorFromCode()`: now returns `Hex1bColor.FromBright(index, r, g, b)`
- `Color256FromIndex()`: now returns `Hex1bColor.FromIndexed(index, r, g, b)` for indices 16-255

### Serialization paths
- `SurfaceComparer.BuildColorSgr()`: emits `34` instead of `38;2;0;0;128`
- `TerminalRegionAnsiExtensions`: emits palette-relative SGR codes

## Before/After

| Input | Before (output) | After (output) |
|-------|-----------------|----------------|
| `ESC[34m` (blue fg) | `ESC[38;2;0;0;128m` | `ESC[34m` |
| `ESC[91m` (bright red fg) | `ESC[38;2;255;0;0m` | `ESC[91m` |
| `ESC[38;5;196m` (256-color) | `ESC[38;2;255;0;0m` | `ESC[38;5;196m` |
| `ESC[38;2;100;200;50m` (RGB) | `ESC[38;2;100;200;50m` | `ESC[38;2;100;200;50m` (unchanged) |

## Testing

All 7111 existing tests pass.
