### PR TITLE
Add text selection (copy mode) for TerminalWidget

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -151,14 +151,14 @@ jobs:
           path: src/Hex1b/runtimes/linux-arm64/native/libhex1binterop.so
 
   build-native-osx-x64:
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Build native library
+      - name: Build native library (cross-compile x86_64 from ARM64)
         working-directory: src/Hex1b/native
-        run: make
+        run: make TARGET_ARCH=x86_64
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/samples/MuxerDemo/SessionManagerApp.cs
+++ b/samples/MuxerDemo/SessionManagerApp.cs
@@ -12,6 +12,7 @@ internal sealed class SessionManagerApp
 {
     private readonly SessionManager _sessions;
     private Hex1bApp? _app;
+    private TerminalWidgetHandle? _clipboardWiredHandle;
 
     public SessionManagerApp(SessionManager sessions)
     {
@@ -99,6 +100,13 @@ internal sealed class SessionManagerApp
     private Hex1bWidget BuildTerminalView<TParent>(WidgetContext<TParent> ctx, TerminalWidgetHandle handle)
         where TParent : Hex1bWidget
     {
+        // Wire clipboard once per handle
+        if (_clipboardWiredHandle != handle)
+        {
+            _clipboardWiredHandle = handle;
+            handle.TextCopied += text => _app?.CopyToClipboard(text);
+        }
+        
         var dims = _sessions.Adapter is not null
             ? $"{_sessions.Adapter.RemoteWidth}\u00d7{_sessions.Adapter.RemoteHeight}"
             : "";

--- a/samples/MuxerDemo/SessionManagerApp.cs
+++ b/samples/MuxerDemo/SessionManagerApp.cs
@@ -105,7 +105,7 @@ internal sealed class SessionManagerApp
 
         return ctx.VStack(v =>
         [
-            v.Terminal(handle).Fill(),
+            v.Terminal(handle).CopyModeBindings().Fill(),
             v.InfoBar(s =>
             [
                 s.Section("Ctrl+B S"),

--- a/samples/MuxerDemo/SessionManagerApp.cs
+++ b/samples/MuxerDemo/SessionManagerApp.cs
@@ -12,7 +12,6 @@ internal sealed class SessionManagerApp
 {
     private readonly SessionManager _sessions;
     private Hex1bApp? _app;
-    private TerminalWidgetHandle? _clipboardWiredHandle;
 
     public SessionManagerApp(SessionManager sessions)
     {
@@ -100,13 +99,6 @@ internal sealed class SessionManagerApp
     private Hex1bWidget BuildTerminalView<TParent>(WidgetContext<TParent> ctx, TerminalWidgetHandle handle)
         where TParent : Hex1bWidget
     {
-        // Wire clipboard once per handle
-        if (_clipboardWiredHandle != handle)
-        {
-            _clipboardWiredHandle = handle;
-            handle.TextCopied += text => _app?.CopyToClipboard(text);
-        }
-        
         var dims = _sessions.Adapter is not null
             ? $"{_sessions.Adapter.RemoteWidth}\u00d7{_sessions.Adapter.RemoteHeight}"
             : "";

--- a/samples/TerminalSelectionDemo/Program.cs
+++ b/samples/TerminalSelectionDemo/Program.cs
@@ -31,7 +31,7 @@ if (OperatingSystem.IsWindows())
     builder = builder.WithPtyProcess(options =>
     {
         options.FileName = shellName;
-        options.Arguments = ["-NoProfile", "-NoLogo"];
+        options.Arguments = ["-NoLogo"];
         options.WindowsPtyMode = WindowsPtyMode.RequireProxy;
     });
 }

--- a/samples/TerminalSelectionDemo/Program.cs
+++ b/samples/TerminalSelectionDemo/Program.cs
@@ -81,6 +81,14 @@ handle.CopyModeInput += inputEvent =>
             handle.MouseSelect(mouse.X, mouse.Y, mouse.Action, mode);
             return true;
         }
+        
+        // Right click copies selection and exits copy mode
+        if (mouse.Button == MouseButton.Right && mouse.Action == MouseAction.Down && handle.IsInCopyMode)
+        {
+            handle.CopySelection();
+            return true;
+        }
+        
         return false;
     }
     

--- a/samples/TerminalSelectionDemo/Program.cs
+++ b/samples/TerminalSelectionDemo/Program.cs
@@ -36,13 +36,12 @@ var terminal = builder
     .WithTerminalWidget(out var handle)
     .Build();
 
-// Wire clipboard and editor updates
+// Update editor when text is copied (clipboard is handled automatically by CopyModeBindings)
 handle.TextCopied += text =>
 {
     var deleteRange = new DocumentRange(new DocumentOffset(0), new DocumentOffset(document.Length));
     document.Apply(new ReplaceOperation(deleteRange, text));
     editorState.ClampAllCursors();
-    app?.CopyToClipboard(text);
     app?.Invalidate();
 };
 

--- a/samples/TerminalSelectionDemo/Program.cs
+++ b/samples/TerminalSelectionDemo/Program.cs
@@ -80,7 +80,7 @@ Hex1bWidget Build(RootContext ctx)
         }
         : new[]
         {
-            "Alt+C", "Enter Copy Mode",
+            "Alt+C / F6", "Enter Copy Mode",
             "Shift+↑/↓", "Scroll",
             "", handle.WindowTitle
         };

--- a/samples/TerminalSelectionDemo/Program.cs
+++ b/samples/TerminalSelectionDemo/Program.cs
@@ -62,9 +62,28 @@ handle.CopyModeChanged += active =>
     app?.Invalidate();
 };
 
-// Handle copy mode key input — vi-style bindings and F6 entry
+// Handle copy mode input — keyboard (vi-style) and mouse selection
 handle.CopyModeInput += inputEvent =>
 {
+    // Mouse events: handle selection via click+drag
+    if (inputEvent is Hex1bMouseEvent mouse)
+    {
+        if (mouse.Button == MouseButton.Left)
+        {
+            // Determine selection mode from modifiers
+            var mode = mouse.Modifiers switch
+            {
+                Hex1bModifiers.Shift => SelectionMode.Line,
+                Hex1bModifiers.Alt => SelectionMode.Block,
+                _ => SelectionMode.Character
+            };
+            
+            handle.MouseSelect(mouse.X, mouse.Y, mouse.Action, mode);
+            return true;
+        }
+        return false;
+    }
+    
     if (inputEvent is not Hex1bKeyEvent key) return false;
     
     // F6 enters copy mode (when not already in copy mode)

--- a/samples/TerminalSelectionDemo/Program.cs
+++ b/samples/TerminalSelectionDemo/Program.cs
@@ -1,28 +1,20 @@
 using Hex1b;
 using Hex1b.Documents;
 using Hex1b.Input;
-using Hex1b.Nodes;
 using Hex1b.Widgets;
 
 // State
-var selectedText = "(No selection yet)";
-var copyModeActive = false;
-var selectionModeLabel = "";
-var document = new Hex1bDocument(selectedText);
+var document = new Hex1bDocument("(No selection yet)");
 var editorState = new EditorState(document) { IsReadOnly = true };
 
 using var cts = new CancellationTokenSource();
 Hex1bApp? app = null;
 
 // Determine shell
-string shellName;
-if (OperatingSystem.IsWindows())
-    shellName = "pwsh";
-else
-    shellName = "bash";
+string shellName = OperatingSystem.IsWindows() ? "pwsh" : "bash";
 
 // Create terminal with PTY
-var builder = Hex1bTerminal.CreateBuilder()
+var builder = Hex1b.Hex1bTerminal.CreateBuilder()
     .WithMouse()
     .WithScrollback(1000);
 
@@ -44,161 +36,14 @@ var terminal = builder
     .WithTerminalWidget(out var handle)
     .Build();
 
-// Subscribe to text copied event — update the editor and copy to system clipboard
+// Wire clipboard and editor updates
 handle.TextCopied += text =>
 {
-    selectedText = text;
     var deleteRange = new DocumentRange(new DocumentOffset(0), new DocumentOffset(document.Length));
     document.Apply(new ReplaceOperation(deleteRange, text));
     editorState.ClampAllCursors();
     app?.CopyToClipboard(text);
     app?.Invalidate();
-};
-
-// Subscribe to copy mode state changes — update the infobar
-handle.CopyModeChanged += active =>
-{
-    copyModeActive = active;
-    selectionModeLabel = "";
-    app?.Invalidate();
-};
-
-// Handle copy mode input — keyboard (vi-style) and mouse selection
-handle.CopyModeInput += inputEvent =>
-{
-    // Mouse events: handle selection via click+drag
-    if (inputEvent is Hex1bMouseEvent mouse)
-    {
-        if (mouse.Button == MouseButton.Left)
-        {
-            // Determine selection mode from modifiers
-            var mode = mouse.Modifiers switch
-            {
-                Hex1bModifiers.Control => SelectionMode.Line,
-                Hex1bModifiers.Alt => SelectionMode.Block,
-                _ => SelectionMode.Character
-            };
-            
-            handle.MouseSelect(mouse.X, mouse.Y, mouse.Action, mode);
-            return true;
-        }
-        
-        // Right click copies selection and exits copy mode
-        if (mouse.Button == MouseButton.Right && mouse.Action == MouseAction.Down && handle.IsInCopyMode)
-        {
-            handle.CopySelection();
-            return true;
-        }
-        
-        return false;
-    }
-    
-    if (inputEvent is not Hex1bKeyEvent key) return false;
-    
-    // F6 enters copy mode (when not already in copy mode)
-    if (!handle.IsInCopyMode)
-    {
-        if (key.Key == Hex1bKey.F6 && key.Modifiers == Hex1bModifiers.None)
-        {
-            handle.EnterCopyMode();
-            return true;
-        }
-        return false; // not handled — let it pass to the child terminal
-    }
-    
-    // Update selection mode label for InfoBar
-    if (handle.Selection is { IsSelecting: true } sel)
-    {
-        selectionModeLabel = sel.Mode switch
-        {
-            SelectionMode.Character => " [CHAR]",
-            SelectionMode.Line => " [LINE]",
-            SelectionMode.Block => " [BLOCK]",
-            _ => ""
-        };
-    }
-    else
-    {
-        selectionModeLabel = "";
-    }
-
-    switch (key.Key)
-    {
-        // Cancel
-        case Hex1bKey.Escape:
-        case Hex1bKey.Q:
-            handle.ExitCopyMode();
-            return true;
-        
-        // Copy and exit
-        case Hex1bKey.Enter:
-        case Hex1bKey.Y:
-            handle.CopySelection();
-            return true;
-        
-        // Navigation — arrows and vi keys
-        case Hex1bKey.UpArrow or Hex1bKey.K:
-            handle.MoveCopyModeCursor(-1, 0);
-            return true;
-        case Hex1bKey.DownArrow or Hex1bKey.J:
-            handle.MoveCopyModeCursor(1, 0);
-            return true;
-        case Hex1bKey.LeftArrow or Hex1bKey.H:
-            handle.MoveCopyModeCursor(0, -1);
-            return true;
-        case Hex1bKey.RightArrow or Hex1bKey.L:
-            handle.MoveCopyModeCursor(0, 1);
-            return true;
-        
-        // Page navigation
-        case Hex1bKey.PageUp:
-            handle.MoveCopyModeCursor(-20, 0);
-            return true;
-        case Hex1bKey.PageDown:
-            handle.MoveCopyModeCursor(20, 0);
-            return true;
-        
-        // Line start/end
-        case Hex1bKey.Home or Hex1bKey.D0:
-            handle.SetCopyModeCursorPosition(handle.Selection!.Cursor.Row, 0);
-            return true;
-        case Hex1bKey.End:
-            handle.SetCopyModeCursorPosition(handle.Selection!.Cursor.Row, handle.Width - 1);
-            return true;
-        
-        // Buffer top/bottom
-        case Hex1bKey.G when key.Modifiers == Hex1bModifiers.Shift:
-            handle.SetCopyModeCursorPosition(handle.VirtualBufferHeight - 1, handle.Selection!.Cursor.Column);
-            return true;
-        case Hex1bKey.G:
-            handle.SetCopyModeCursorPosition(0, handle.Selection!.Cursor.Column);
-            return true;
-        
-        // Selection modes
-        case Hex1bKey.V when key.Modifiers == Hex1bModifiers.None:
-            handle.StartOrToggleSelection(SelectionMode.Character);
-            return true;
-        case Hex1bKey.V when key.Modifiers == Hex1bModifiers.Shift:
-            handle.StartOrToggleSelection(SelectionMode.Line);
-            return true;
-        case Hex1bKey.V when key.Modifiers == Hex1bModifiers.Alt:
-            handle.StartOrToggleSelection(SelectionMode.Block);
-            return true;
-        case Hex1bKey.Spacebar:
-            handle.StartOrToggleSelection(SelectionMode.Character);
-            return true;
-        
-        // Word navigation
-        case Hex1bKey.W:
-            handle.MoveWordForward();
-            return true;
-        case Hex1bKey.B:
-            handle.MoveWordBackward();
-            return true;
-        
-        default:
-            return true; // consume all keys in copy mode
-    }
 };
 
 // Start terminal in background — shut down app when process exits
@@ -212,10 +57,18 @@ _ = Task.Run(async () =>
 // Build widget tree
 Hex1bWidget Build(RootContext ctx)
 {
-    var statusItems = copyModeActive
+    var title = handle.CopyModeState switch
+    {
+        CopyModeState.CharacterSelection => "Terminal [CHAR SELECT]",
+        CopyModeState.LineSelection => "Terminal [LINE SELECT]",
+        CopyModeState.BlockSelection => "Terminal [BLOCK SELECT]",
+        CopyModeState.Active => "Terminal [COPY MODE]",
+        _ => "Terminal"
+    };
+
+    var statusItems = handle.CopyModeState != CopyModeState.Inactive
         ? new[]
         {
-            "Mode", $"COPY MODE{selectionModeLabel}",
             "h/j/k/l", "Move",
             "v/V/Alt+V", "Char/Line/Block",
             "y/Enter", "Copy",
@@ -224,7 +77,7 @@ Hex1bWidget Build(RootContext ctx)
         : new[]
         {
             "F6", "Copy Mode",
-            "Shift+↑/↓", "Scroll",
+            "Drag", "Select",
             "", handle.WindowTitle
         };
 
@@ -232,8 +85,8 @@ Hex1bWidget Build(RootContext ctx)
     [
         v.HSplitter(
             v.Border(
-                v.Terminal(handle).Fill()
-            ).Title(copyModeActive ? $"Terminal [COPY MODE{selectionModeLabel}]" : "Terminal"),
+                v.Terminal(handle).CopyModeBindings().Fill()
+            ).Title(title),
             v.Border(
                 v.Editor(editorState).Fill()
             ).Title("Selected Text"),

--- a/samples/TerminalSelectionDemo/Program.cs
+++ b/samples/TerminalSelectionDemo/Program.cs
@@ -73,7 +73,7 @@ handle.CopyModeInput += inputEvent =>
             // Determine selection mode from modifiers
             var mode = mouse.Modifiers switch
             {
-                Hex1bModifiers.Shift => SelectionMode.Line,
+                Hex1bModifiers.Control => SelectionMode.Line,
                 Hex1bModifiers.Alt => SelectionMode.Block,
                 _ => SelectionMode.Character
             };

--- a/samples/TerminalSelectionDemo/Program.cs
+++ b/samples/TerminalSelectionDemo/Program.cs
@@ -173,11 +173,12 @@ handle.CopyModeInput += inputEvent =>
     }
 };
 
-// Start terminal in background
+// Start terminal in background — shut down app when process exits
 _ = Task.Run(async () =>
 {
     try { await terminal.RunAsync(cts.Token); }
     catch (OperationCanceledException) { }
+    app?.RequestStop();
 });
 
 // Build widget tree

--- a/samples/TerminalSelectionDemo/Program.cs
+++ b/samples/TerminalSelectionDemo/Program.cs
@@ -1,0 +1,121 @@
+using Hex1b;
+using Hex1b.Documents;
+using Hex1b.Nodes;
+using Hex1b.Widgets;
+
+// State
+var selectedText = "(No selection yet)";
+var copyModeActive = false;
+var document = new Hex1bDocument(selectedText);
+var editorState = new EditorState(document) { IsReadOnly = true };
+
+using var cts = new CancellationTokenSource();
+Hex1bApp? app = null;
+
+// Determine shell
+string shellName;
+if (OperatingSystem.IsWindows())
+    shellName = "pwsh";
+else
+    shellName = "bash";
+
+// Create terminal with PTY
+var builder = Hex1bTerminal.CreateBuilder()
+    .WithMouse()
+    .WithScrollback(1000);
+
+if (OperatingSystem.IsWindows())
+{
+    builder = builder.WithPtyProcess(options =>
+    {
+        options.FileName = shellName;
+        options.Arguments = ["-NoProfile", "-NoLogo"];
+        options.WindowsPtyMode = WindowsPtyMode.RequireProxy;
+    });
+}
+else
+{
+    builder = builder.WithPtyProcess(shellName, "--norc");
+}
+
+var terminal = builder
+    .WithTerminalWidget(out var handle)
+    .Build();
+
+// Subscribe to text copied event — update the editor with selected text
+handle.TextCopied += text =>
+{
+    selectedText = text;
+    var deleteRange = new DocumentRange(new DocumentOffset(0), new DocumentOffset(document.Length));
+    document.Apply(new ReplaceOperation(deleteRange, text));
+    editorState.ClampAllCursors();
+    app?.Invalidate();
+};
+
+// Subscribe to copy mode state changes — update the infobar
+handle.CopyModeChanged += active =>
+{
+    copyModeActive = active;
+    app?.Invalidate();
+};
+
+// Start terminal in background
+_ = Task.Run(async () =>
+{
+    try { await terminal.RunAsync(cts.Token); }
+    catch (OperationCanceledException) { }
+});
+
+// Build widget tree
+Hex1bWidget Build(RootContext ctx)
+{
+    var statusItems = copyModeActive
+        ? new[]
+        {
+            "Mode", "COPY MODE",
+            "h/j/k/l", "Move",
+            "v/V/^V", "Select",
+            "y/Enter", "Copy",
+            "Esc", "Cancel"
+        }
+        : new[]
+        {
+            "Shift+Space", "Enter Copy Mode",
+            "Shift+↑/↓", "Scroll",
+            "", handle.WindowTitle
+        };
+
+    return ctx.VStack(v =>
+    [
+        v.HSplitter(
+            v.Border(
+                v.Terminal(handle).Fill()
+            ).Title(copyModeActive ? "Terminal [COPY MODE]" : "Terminal"),
+            v.Border(
+                v.Editor(editorState).Fill()
+            ).Title("Selected Text"),
+            leftWidth: 50
+        ).Fill(),
+        v.InfoBar(statusItems)
+    ]);
+}
+
+// Create the display terminal
+await using var displayTerminal = Hex1bTerminal.CreateBuilder()
+    .WithMouse()
+    .WithHex1bApp((a, options) =>
+    {
+        app = a;
+        return ctx => Build(ctx);
+    })
+    .Build();
+
+try
+{
+    await displayTerminal.RunAsync(cts.Token);
+}
+finally
+{
+    cts.Cancel();
+    await terminal.DisposeAsync();
+}

--- a/samples/TerminalSelectionDemo/Program.cs
+++ b/samples/TerminalSelectionDemo/Program.cs
@@ -153,7 +153,7 @@ handle.CopyModeInput += inputEvent =>
         case Hex1bKey.V when key.Modifiers == Hex1bModifiers.Shift:
             handle.StartOrToggleSelection(SelectionMode.Line);
             return true;
-        case Hex1bKey.V when key.Modifiers == Hex1bModifiers.Control:
+        case Hex1bKey.V when key.Modifiers == Hex1bModifiers.Alt:
             handle.StartOrToggleSelection(SelectionMode.Block);
             return true;
         case Hex1bKey.Spacebar:
@@ -188,7 +188,7 @@ Hex1bWidget Build(RootContext ctx)
         {
             "Mode", $"COPY MODE{selectionModeLabel}",
             "h/j/k/l", "Move",
-            "v/V/^V", "Char/Line/Block",
+            "v/V/Alt+V", "Char/Line/Block",
             "y/Enter", "Copy",
             "Esc", "Cancel"
         }

--- a/samples/TerminalSelectionDemo/Program.cs
+++ b/samples/TerminalSelectionDemo/Program.cs
@@ -44,13 +44,14 @@ var terminal = builder
     .WithTerminalWidget(out var handle)
     .Build();
 
-// Subscribe to text copied event — update the editor with selected text
+// Subscribe to text copied event — update the editor and copy to system clipboard
 handle.TextCopied += text =>
 {
     selectedText = text;
     var deleteRange = new DocumentRange(new DocumentOffset(0), new DocumentOffset(document.Length));
     document.Apply(new ReplaceOperation(deleteRange, text));
     editorState.ClampAllCursors();
+    app?.CopyToClipboard(text);
     app?.Invalidate();
 };
 

--- a/samples/TerminalSelectionDemo/Program.cs
+++ b/samples/TerminalSelectionDemo/Program.cs
@@ -1,11 +1,13 @@
 using Hex1b;
 using Hex1b.Documents;
+using Hex1b.Input;
 using Hex1b.Nodes;
 using Hex1b.Widgets;
 
 // State
 var selectedText = "(No selection yet)";
 var copyModeActive = false;
+var selectionModeLabel = "";
 var document = new Hex1bDocument(selectedText);
 var editorState = new EditorState(document) { IsReadOnly = true };
 
@@ -56,7 +58,119 @@ handle.TextCopied += text =>
 handle.CopyModeChanged += active =>
 {
     copyModeActive = active;
+    selectionModeLabel = "";
     app?.Invalidate();
+};
+
+// Handle copy mode key input — vi-style bindings and F6 entry
+handle.CopyModeInput += inputEvent =>
+{
+    if (inputEvent is not Hex1bKeyEvent key) return false;
+    
+    // F6 enters copy mode (when not already in copy mode)
+    if (!handle.IsInCopyMode)
+    {
+        if (key.Key == Hex1bKey.F6 && key.Modifiers == Hex1bModifiers.None)
+        {
+            handle.EnterCopyMode();
+            return true;
+        }
+        return false; // not handled — let it pass to the child terminal
+    }
+    
+    // Update selection mode label for InfoBar
+    if (handle.Selection is { IsSelecting: true } sel)
+    {
+        selectionModeLabel = sel.Mode switch
+        {
+            SelectionMode.Character => " [CHAR]",
+            SelectionMode.Line => " [LINE]",
+            SelectionMode.Block => " [BLOCK]",
+            _ => ""
+        };
+    }
+    else
+    {
+        selectionModeLabel = "";
+    }
+
+    switch (key.Key)
+    {
+        // Cancel
+        case Hex1bKey.Escape:
+        case Hex1bKey.Q:
+            handle.ExitCopyMode();
+            return true;
+        
+        // Copy and exit
+        case Hex1bKey.Enter:
+        case Hex1bKey.Y:
+            handle.CopySelection();
+            return true;
+        
+        // Navigation — arrows and vi keys
+        case Hex1bKey.UpArrow or Hex1bKey.K:
+            handle.MoveCopyModeCursor(-1, 0);
+            return true;
+        case Hex1bKey.DownArrow or Hex1bKey.J:
+            handle.MoveCopyModeCursor(1, 0);
+            return true;
+        case Hex1bKey.LeftArrow or Hex1bKey.H:
+            handle.MoveCopyModeCursor(0, -1);
+            return true;
+        case Hex1bKey.RightArrow or Hex1bKey.L:
+            handle.MoveCopyModeCursor(0, 1);
+            return true;
+        
+        // Page navigation
+        case Hex1bKey.PageUp:
+            handle.MoveCopyModeCursor(-20, 0);
+            return true;
+        case Hex1bKey.PageDown:
+            handle.MoveCopyModeCursor(20, 0);
+            return true;
+        
+        // Line start/end
+        case Hex1bKey.Home or Hex1bKey.D0:
+            handle.SetCopyModeCursorPosition(handle.Selection!.Cursor.Row, 0);
+            return true;
+        case Hex1bKey.End:
+            handle.SetCopyModeCursorPosition(handle.Selection!.Cursor.Row, handle.Width - 1);
+            return true;
+        
+        // Buffer top/bottom
+        case Hex1bKey.G when key.Modifiers == Hex1bModifiers.Shift:
+            handle.SetCopyModeCursorPosition(handle.VirtualBufferHeight - 1, handle.Selection!.Cursor.Column);
+            return true;
+        case Hex1bKey.G:
+            handle.SetCopyModeCursorPosition(0, handle.Selection!.Cursor.Column);
+            return true;
+        
+        // Selection modes
+        case Hex1bKey.V when key.Modifiers == Hex1bModifiers.None:
+            handle.StartOrToggleSelection(SelectionMode.Character);
+            return true;
+        case Hex1bKey.V when key.Modifiers == Hex1bModifiers.Shift:
+            handle.StartOrToggleSelection(SelectionMode.Line);
+            return true;
+        case Hex1bKey.V when key.Modifiers == Hex1bModifiers.Control:
+            handle.StartOrToggleSelection(SelectionMode.Block);
+            return true;
+        case Hex1bKey.Spacebar:
+            handle.StartOrToggleSelection(SelectionMode.Character);
+            return true;
+        
+        // Word navigation
+        case Hex1bKey.W:
+            handle.MoveWordForward();
+            return true;
+        case Hex1bKey.B:
+            handle.MoveWordBackward();
+            return true;
+        
+        default:
+            return true; // consume all keys in copy mode
+    }
 };
 
 // Start terminal in background
@@ -72,15 +186,15 @@ Hex1bWidget Build(RootContext ctx)
     var statusItems = copyModeActive
         ? new[]
         {
-            "Mode", "COPY MODE",
+            "Mode", $"COPY MODE{selectionModeLabel}",
             "h/j/k/l", "Move",
-            "v/V/^V", "Select",
+            "v/V/^V", "Char/Line/Block",
             "y/Enter", "Copy",
             "Esc", "Cancel"
         }
         : new[]
         {
-            "Alt+C / F6", "Enter Copy Mode",
+            "F6", "Copy Mode",
             "Shift+↑/↓", "Scroll",
             "", handle.WindowTitle
         };
@@ -90,7 +204,7 @@ Hex1bWidget Build(RootContext ctx)
         v.HSplitter(
             v.Border(
                 v.Terminal(handle).Fill()
-            ).Title(copyModeActive ? "Terminal [COPY MODE]" : "Terminal"),
+            ).Title(copyModeActive ? $"Terminal [COPY MODE{selectionModeLabel}]" : "Terminal"),
             v.Border(
                 v.Editor(editorState).Fill()
             ).Title("Selected Text"),

--- a/samples/TerminalSelectionDemo/Program.cs
+++ b/samples/TerminalSelectionDemo/Program.cs
@@ -80,7 +80,7 @@ Hex1bWidget Build(RootContext ctx)
         }
         : new[]
         {
-            "Shift+Space", "Enter Copy Mode",
+            "Alt+C", "Enter Copy Mode",
             "Shift+↑/↓", "Scroll",
             "", handle.WindowTitle
         };

--- a/samples/TerminalSelectionDemo/TerminalSelectionDemo.csproj
+++ b/samples/TerminalSelectionDemo/TerminalSelectionDemo.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <PublishAot>true</PublishAot>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Hex1b/Hex1b.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <WindowsPtyShimRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">win-arm64</WindowsPtyShimRid>
+    <WindowsPtyShimRid Condition="'$(WindowsPtyShimRid)' == ''">win-x64</WindowsPtyShimRid>
+  </PropertyGroup>
+
+  <Target Name="CopyWindowsPtyShim"
+          AfterTargets="Build"
+          Condition="$([MSBuild]::IsOSPlatform('Windows')) and Exists('../../src/Hex1b/obj/windows-pty-shim/$(WindowsPtyShimRid)/native/hex1bpty.exe')">
+    <ItemGroup>
+      <WindowsPtyShimFiles Include="../../src/Hex1b/obj/windows-pty-shim/$(WindowsPtyShimRid)/native/*.*"
+                           Exclude="../../src/Hex1b/obj/windows-pty-shim/$(WindowsPtyShimRid)/native/*.pdb" />
+    </ItemGroup>
+    <Copy SourceFiles="@(WindowsPtyShimFiles)"
+          DestinationFolder="$(TargetDir)runtimes\$(WindowsPtyShimRid)\native\"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+</Project>

--- a/src/Hex1b/CopyModeBindingsOptions.cs
+++ b/src/Hex1b/CopyModeBindingsOptions.cs
@@ -3,54 +3,68 @@ using Hex1b.Input;
 namespace Hex1b;
 
 /// <summary>
+/// A key binding: a key combined with optional modifier keys.
+/// </summary>
+/// <param name="Key">The key.</param>
+/// <param name="Modifiers">Required modifier keys. Defaults to <see cref="Hex1bModifiers.None"/>.</param>
+public readonly record struct KeyBinding(Hex1bKey Key, Hex1bModifiers Modifiers = Hex1bModifiers.None)
+{
+    /// <summary>Creates a key binding with no modifiers.</summary>
+    public static implicit operator KeyBinding(Hex1bKey key) => new(key);
+    
+    /// <summary>Checks if this binding matches the given key event.</summary>
+    public bool Matches(Hex1bKeyEvent keyEvent) => keyEvent.Key == Key && keyEvent.Modifiers == Modifiers;
+}
+
+/// <summary>
 /// Configuration options for standard copy mode key and mouse bindings.
 /// All properties have sensible defaults (vi-style keys + mouse).
 /// </summary>
 public sealed class CopyModeBindingsOptions
 {
     // Entry
-    /// <summary>Keys that enter copy mode when the terminal is focused.</summary>
-    public Hex1bKey[] EnterKeys { get; set; } = [Hex1bKey.F6];
+    /// <summary>Key bindings that enter copy mode when the terminal is focused.</summary>
+    public KeyBinding[] EnterKeys { get; set; } = [Hex1bKey.F6];
 
     // Navigation
-    /// <summary>Keys that move the copy mode cursor up one row.</summary>
-    public Hex1bKey[] CursorUpKeys { get; set; } = [Hex1bKey.UpArrow, Hex1bKey.K];
-    /// <summary>Keys that move the copy mode cursor down one row.</summary>
-    public Hex1bKey[] CursorDownKeys { get; set; } = [Hex1bKey.DownArrow, Hex1bKey.J];
-    /// <summary>Keys that move the copy mode cursor left one column.</summary>
-    public Hex1bKey[] CursorLeftKeys { get; set; } = [Hex1bKey.LeftArrow, Hex1bKey.H];
-    /// <summary>Keys that move the copy mode cursor right one column.</summary>
-    public Hex1bKey[] CursorRightKeys { get; set; } = [Hex1bKey.RightArrow, Hex1bKey.L];
-    /// <summary>Keys that move the copy mode cursor forward one word.</summary>
-    public Hex1bKey[] WordForwardKeys { get; set; } = [Hex1bKey.W];
-    /// <summary>Keys that move the copy mode cursor backward one word.</summary>
-    public Hex1bKey[] WordBackwardKeys { get; set; } = [Hex1bKey.B];
-    /// <summary>Keys that move the copy mode cursor up one page.</summary>
-    public Hex1bKey[] PageUpKeys { get; set; } = [Hex1bKey.PageUp];
-    /// <summary>Keys that move the copy mode cursor down one page.</summary>
-    public Hex1bKey[] PageDownKeys { get; set; } = [Hex1bKey.PageDown];
-    /// <summary>Keys that move the copy mode cursor to the start of the current line.</summary>
-    public Hex1bKey[] LineStartKeys { get; set; } = [Hex1bKey.Home, Hex1bKey.D0];
-    /// <summary>Keys that move the copy mode cursor to the end of the current line.</summary>
-    public Hex1bKey[] LineEndKeys { get; set; } = [Hex1bKey.End];
-    /// <summary>Key+modifier combinations that move the cursor to the top of the buffer.</summary>
-    public (Hex1bKey Key, Hex1bModifiers Modifiers)[] BufferTopKeys { get; set; } = [(Hex1bKey.G, Hex1bModifiers.None)];
-    /// <summary>Key+modifier combinations that move the cursor to the bottom of the buffer.</summary>
-    public (Hex1bKey Key, Hex1bModifiers Modifiers)[] BufferBottomKeys { get; set; } = [(Hex1bKey.G, Hex1bModifiers.Shift)];
+    /// <summary>Key bindings that move the copy mode cursor up one row.</summary>
+    public KeyBinding[] CursorUpKeys { get; set; } = [Hex1bKey.UpArrow, Hex1bKey.K];
+    /// <summary>Key bindings that move the copy mode cursor down one row.</summary>
+    public KeyBinding[] CursorDownKeys { get; set; } = [Hex1bKey.DownArrow, Hex1bKey.J];
+    /// <summary>Key bindings that move the copy mode cursor left one column.</summary>
+    public KeyBinding[] CursorLeftKeys { get; set; } = [Hex1bKey.LeftArrow, Hex1bKey.H];
+    /// <summary>Key bindings that move the copy mode cursor right one column.</summary>
+    public KeyBinding[] CursorRightKeys { get; set; } = [Hex1bKey.RightArrow, Hex1bKey.L];
+    /// <summary>Key bindings that move the copy mode cursor forward one word.</summary>
+    public KeyBinding[] WordForwardKeys { get; set; } = [Hex1bKey.W];
+    /// <summary>Key bindings that move the copy mode cursor backward one word.</summary>
+    public KeyBinding[] WordBackwardKeys { get; set; } = [Hex1bKey.B];
+    /// <summary>Key bindings that move the copy mode cursor up one page.</summary>
+    public KeyBinding[] PageUpKeys { get; set; } = [Hex1bKey.PageUp];
+    /// <summary>Key bindings that move the copy mode cursor down one page.</summary>
+    public KeyBinding[] PageDownKeys { get; set; } = [Hex1bKey.PageDown];
+    /// <summary>Key bindings that move the copy mode cursor to the start of the current line.</summary>
+    public KeyBinding[] LineStartKeys { get; set; } = [Hex1bKey.Home, Hex1bKey.D0];
+    /// <summary>Key bindings that move the copy mode cursor to the end of the current line.</summary>
+    public KeyBinding[] LineEndKeys { get; set; } = [Hex1bKey.End];
+    /// <summary>Key bindings that move the cursor to the top of the buffer.</summary>
+    public KeyBinding[] BufferTopKeys { get; set; } = [new(Hex1bKey.G)];
+    /// <summary>Key bindings that move the cursor to the bottom of the buffer.</summary>
+    public KeyBinding[] BufferBottomKeys { get; set; } = [new(Hex1bKey.G, Hex1bModifiers.Shift)];
 
     // Selection modes
-    /// <summary>Keys that start or toggle character selection.</summary>
-    public Hex1bKey[] CharacterSelectionKeys { get; set; } = [Hex1bKey.V, Hex1bKey.Spacebar];
-    /// <summary>Key+modifier combinations that start or toggle line selection.</summary>
-    public (Hex1bKey Key, Hex1bModifiers Modifiers)[] LineSelectionKeys { get; set; } = [(Hex1bKey.V, Hex1bModifiers.Shift)];
-    /// <summary>Key+modifier combinations that start or toggle block/rectangular selection.</summary>
-    public (Hex1bKey Key, Hex1bModifiers Modifiers)[] BlockSelectionKeys { get; set; } = [(Hex1bKey.V, Hex1bModifiers.Alt)];
+    /// <summary>Key bindings that start or toggle character selection.</summary>
+    public KeyBinding[] CharacterSelectionKeys { get; set; } = [Hex1bKey.V, Hex1bKey.Spacebar];
+    /// <summary>Key bindings that start or toggle line selection.</summary>
+    public KeyBinding[] LineSelectionKeys { get; set; } = [new(Hex1bKey.V, Hex1bModifiers.Shift)];
+    /// <summary>Key bindings that start or toggle block/rectangular selection.</summary>
+    public KeyBinding[] BlockSelectionKeys { get; set; } = [new(Hex1bKey.V, Hex1bModifiers.Alt)];
 
     // Actions
-    /// <summary>Keys that copy the selection and exit copy mode.</summary>
-    public Hex1bKey[] CopyKeys { get; set; } = [Hex1bKey.Y, Hex1bKey.Enter];
-    /// <summary>Keys that cancel copy mode without copying.</summary>
-    public Hex1bKey[] CancelKeys { get; set; } = [Hex1bKey.Escape, Hex1bKey.Q];
+    /// <summary>Key bindings that copy the selection and exit copy mode.</summary>
+    public KeyBinding[] CopyKeys { get; set; } = [Hex1bKey.Y, Hex1bKey.Enter];
+    /// <summary>Key bindings that cancel copy mode without copying.</summary>
+    public KeyBinding[] CancelKeys { get; set; } = [Hex1bKey.Escape, Hex1bKey.Q];
 
     // Mouse
     /// <summary>Whether mouse drag-to-select is enabled.</summary>

--- a/src/Hex1b/CopyModeBindingsOptions.cs
+++ b/src/Hex1b/CopyModeBindingsOptions.cs
@@ -75,4 +75,12 @@ public sealed class CopyModeBindingsOptions
     public Hex1bModifiers MouseBlockModifier { get; set; } = Hex1bModifiers.Alt;
     /// <summary>Mouse button that copies the selection.</summary>
     public MouseButton MouseCopyButton { get; set; } = MouseButton.Right;
+
+    // Clipboard
+    /// <summary>
+    /// Callback to copy text to the system clipboard. When null (default), the framework
+    /// automatically uses the Hex1bApp's OSC 52 clipboard support.
+    /// Set to a custom callback to override clipboard behavior, or set to <c>_ => { }</c> to disable.
+    /// </summary>
+    public Action<string>? CopyToClipboard { get; set; }
 }

--- a/src/Hex1b/CopyModeBindingsOptions.cs
+++ b/src/Hex1b/CopyModeBindingsOptions.cs
@@ -1,0 +1,64 @@
+using Hex1b.Input;
+
+namespace Hex1b;
+
+/// <summary>
+/// Configuration options for standard copy mode key and mouse bindings.
+/// All properties have sensible defaults (vi-style keys + mouse).
+/// </summary>
+public sealed class CopyModeBindingsOptions
+{
+    // Entry
+    /// <summary>Keys that enter copy mode when the terminal is focused.</summary>
+    public Hex1bKey[] EnterKeys { get; set; } = [Hex1bKey.F6];
+
+    // Navigation
+    /// <summary>Keys that move the copy mode cursor up one row.</summary>
+    public Hex1bKey[] CursorUpKeys { get; set; } = [Hex1bKey.UpArrow, Hex1bKey.K];
+    /// <summary>Keys that move the copy mode cursor down one row.</summary>
+    public Hex1bKey[] CursorDownKeys { get; set; } = [Hex1bKey.DownArrow, Hex1bKey.J];
+    /// <summary>Keys that move the copy mode cursor left one column.</summary>
+    public Hex1bKey[] CursorLeftKeys { get; set; } = [Hex1bKey.LeftArrow, Hex1bKey.H];
+    /// <summary>Keys that move the copy mode cursor right one column.</summary>
+    public Hex1bKey[] CursorRightKeys { get; set; } = [Hex1bKey.RightArrow, Hex1bKey.L];
+    /// <summary>Keys that move the copy mode cursor forward one word.</summary>
+    public Hex1bKey[] WordForwardKeys { get; set; } = [Hex1bKey.W];
+    /// <summary>Keys that move the copy mode cursor backward one word.</summary>
+    public Hex1bKey[] WordBackwardKeys { get; set; } = [Hex1bKey.B];
+    /// <summary>Keys that move the copy mode cursor up one page.</summary>
+    public Hex1bKey[] PageUpKeys { get; set; } = [Hex1bKey.PageUp];
+    /// <summary>Keys that move the copy mode cursor down one page.</summary>
+    public Hex1bKey[] PageDownKeys { get; set; } = [Hex1bKey.PageDown];
+    /// <summary>Keys that move the copy mode cursor to the start of the current line.</summary>
+    public Hex1bKey[] LineStartKeys { get; set; } = [Hex1bKey.Home, Hex1bKey.D0];
+    /// <summary>Keys that move the copy mode cursor to the end of the current line.</summary>
+    public Hex1bKey[] LineEndKeys { get; set; } = [Hex1bKey.End];
+    /// <summary>Key+modifier combinations that move the cursor to the top of the buffer.</summary>
+    public (Hex1bKey Key, Hex1bModifiers Modifiers)[] BufferTopKeys { get; set; } = [(Hex1bKey.G, Hex1bModifiers.None)];
+    /// <summary>Key+modifier combinations that move the cursor to the bottom of the buffer.</summary>
+    public (Hex1bKey Key, Hex1bModifiers Modifiers)[] BufferBottomKeys { get; set; } = [(Hex1bKey.G, Hex1bModifiers.Shift)];
+
+    // Selection modes
+    /// <summary>Keys that start or toggle character selection.</summary>
+    public Hex1bKey[] CharacterSelectionKeys { get; set; } = [Hex1bKey.V, Hex1bKey.Spacebar];
+    /// <summary>Key+modifier combinations that start or toggle line selection.</summary>
+    public (Hex1bKey Key, Hex1bModifiers Modifiers)[] LineSelectionKeys { get; set; } = [(Hex1bKey.V, Hex1bModifiers.Shift)];
+    /// <summary>Key+modifier combinations that start or toggle block/rectangular selection.</summary>
+    public (Hex1bKey Key, Hex1bModifiers Modifiers)[] BlockSelectionKeys { get; set; } = [(Hex1bKey.V, Hex1bModifiers.Alt)];
+
+    // Actions
+    /// <summary>Keys that copy the selection and exit copy mode.</summary>
+    public Hex1bKey[] CopyKeys { get; set; } = [Hex1bKey.Y, Hex1bKey.Enter];
+    /// <summary>Keys that cancel copy mode without copying.</summary>
+    public Hex1bKey[] CancelKeys { get; set; } = [Hex1bKey.Escape, Hex1bKey.Q];
+
+    // Mouse
+    /// <summary>Whether mouse drag-to-select is enabled.</summary>
+    public bool MouseEnabled { get; set; } = true;
+    /// <summary>Mouse modifier for line selection mode during drag.</summary>
+    public Hex1bModifiers MouseLineModifier { get; set; } = Hex1bModifiers.Control;
+    /// <summary>Mouse modifier for block/rectangular selection mode during drag.</summary>
+    public Hex1bModifiers MouseBlockModifier { get; set; } = Hex1bModifiers.Alt;
+    /// <summary>Mouse button that copies the selection.</summary>
+    public MouseButton MouseCopyButton { get; set; } = MouseButton.Right;
+}

--- a/src/Hex1b/CopyModeState.cs
+++ b/src/Hex1b/CopyModeState.cs
@@ -1,0 +1,22 @@
+namespace Hex1b;
+
+/// <summary>
+/// Represents the current state of copy mode on a terminal widget.
+/// </summary>
+public enum CopyModeState
+{
+    /// <summary>Copy mode is not active.</summary>
+    Inactive,
+
+    /// <summary>Copy mode is active but no selection has been started.</summary>
+    Active,
+
+    /// <summary>Copy mode is active with character-level selection.</summary>
+    CharacterSelection,
+
+    /// <summary>Copy mode is active with line-level selection.</summary>
+    LineSelection,
+
+    /// <summary>Copy mode is active with block/rectangular selection.</summary>
+    BlockSelection
+}

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -1702,7 +1702,8 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
 
         // Create the root reconcile context with timer scheduling callback
         var context = ReconcileContext.CreateRoot(_focusRing, cancellationToken, Invalidate,
-            CaptureInput, ReleaseCapture, ScheduleTimer, _windowManagerRegistry, RequestFocus);
+            CaptureInput, ReleaseCapture, ScheduleTimer, _windowManagerRegistry, RequestFocus,
+            CopyToClipboard);
         context.IsNew = existingNode is null || existingNode.GetType() != widget.GetExpectedNodeType();
         context.DiagnosticTimingEnabled = _diagnosticTimingEnabled;
         context.Metrics = _metrics.NodeReconcileDuration != null ? _metrics : null;

--- a/src/Hex1b/Input/InputRouter.cs
+++ b/src/Hex1b/Input/InputRouter.cs
@@ -303,23 +303,18 @@ public static class InputRouter
         var capturedNode = focusRing.CapturedNode;
         if (capturedNode != null)
         {
-            // Check if mouse is within the captured node's bounds
+            // Translate to local coordinates (allow negative/out-of-bounds for drag)
             var bounds = capturedNode.Bounds;
-            if (mouseEvent.X >= bounds.X && mouseEvent.X < bounds.X + bounds.Width &&
-                mouseEvent.Y >= bounds.Y && mouseEvent.Y < bounds.Y + bounds.Height)
+            var localEvent = mouseEvent with 
+            { 
+                X = mouseEvent.X - bounds.X, 
+                Y = mouseEvent.Y - bounds.Y 
+            };
+            
+            var result = capturedNode.HandleInput(localEvent);
+            if (result == InputResult.Handled)
             {
-                // Translate to local coordinates
-                var localEvent = mouseEvent with 
-                { 
-                    X = mouseEvent.X - bounds.X, 
-                    Y = mouseEvent.Y - bounds.Y 
-                };
-                
-                var result = capturedNode.HandleInput(localEvent);
-                if (result == InputResult.Handled)
-                {
-                    return Task.FromResult(InputResult.Handled);
-                }
+                return Task.FromResult(InputResult.Handled);
             }
         }
         

--- a/src/Hex1b/Nodes/TerminalNode.cs
+++ b/src/Hex1b/Nodes/TerminalNode.cs
@@ -47,6 +47,9 @@ public sealed class TerminalNode : Hex1bNode
     // and keyboard input is intercepted for scrollback navigation instead of forwarded to the child
     private int _scrollbackOffset;
     
+    // Copy mode helper (attached via CopyModeBindings)
+    private TerminalCopyModeHelper? _copyModeHelper;
+    
     /// <summary>
     /// Number of rows to scroll per mouse wheel tick.
     /// </summary>
@@ -439,6 +442,28 @@ public sealed class TerminalNode : Hex1bNode
             _outputReceivedHandler = null;
         }
         _isBound = false;
+    }
+    
+    /// <summary>
+    /// Attaches or detaches the copy mode helper based on widget configuration.
+    /// </summary>
+    internal void AttachCopyModeHelper(CopyModeBindingsOptions? options)
+    {
+        if (options == null)
+        {
+            // Detach existing helper if any
+            _copyModeHelper?.Detach();
+            _copyModeHelper = null;
+            return;
+        }
+        
+        if (_handle == null) return;
+        
+        // Only create if not already attached (or if handle changed)
+        if (_copyModeHelper == null)
+        {
+            _copyModeHelper = new TerminalCopyModeHelper(_handle, options);
+        }
     }
     
     private void OnOutputReceived()

--- a/src/Hex1b/Nodes/TerminalNode.cs
+++ b/src/Hex1b/Nodes/TerminalNode.cs
@@ -344,20 +344,34 @@ public sealed class TerminalNode : Hex1bNode
         // Forward input to the terminal
         if (_handle == null) return InputResult.NotHandled;
         
-        // When in copy mode, intercept all keyboard input for copy mode navigation
-        if (_handle.IsInCopyMode && inputEvent is Hex1bKeyEvent keyEvent)
+        if (inputEvent is Hex1bKeyEvent keyEvent)
         {
-            return HandleCopyModeInput(keyEvent);
-        }
-        
-        // When in scrollback mode and a non-scrollback key is pressed (no binding matched),
-        // snap back to live view and forward the keystroke to the terminal.
-        // This matches standard terminal behavior where typing snaps you back to the prompt.
-        if (IsInScrollbackMode && inputEvent is Hex1bKeyEvent)
-        {
-            _scrollbackOffset = 0;
-            MarkDirty();
-            _invalidateCallback?.Invoke();
+            // Enter copy mode: Alt+C or F6 (works even when terminal has captured input)
+            if (!_handle.IsInCopyMode && 
+                ((keyEvent.Key == Hex1bKey.C && keyEvent.Modifiers == Hex1bModifiers.Alt) ||
+                 (keyEvent.Key == Hex1bKey.F6 && keyEvent.Modifiers == Hex1bModifiers.None)))
+            {
+                _handle.EnterCopyMode();
+                MarkDirty();
+                _invalidateCallback?.Invoke();
+                return InputResult.Handled;
+            }
+            
+            // When in copy mode, intercept all keyboard input for copy mode navigation
+            if (_handle.IsInCopyMode)
+            {
+                return HandleCopyModeInput(keyEvent);
+            }
+            
+            // When in scrollback mode and a non-scrollback key is pressed (no binding matched),
+            // snap back to live view and forward the keystroke to the terminal.
+            // This matches standard terminal behavior where typing snaps you back to the prompt.
+            if (IsInScrollbackMode)
+            {
+                _scrollbackOffset = 0;
+                MarkDirty();
+                _invalidateCallback?.Invoke();
+            }
         }
         
         // Fire and forget - we don't want to block the input loop

--- a/src/Hex1b/Nodes/TerminalNode.cs
+++ b/src/Hex1b/Nodes/TerminalNode.cs
@@ -272,6 +272,7 @@ public sealed class TerminalNode : Hex1bNode
         if (newOffset != _scrollbackOffset)
         {
             _scrollbackOffset = newOffset;
+            _handle.CurrentScrollbackOffset = _scrollbackOffset;
             MarkDirty();
             _invalidateCallback?.Invoke();
         }
@@ -290,9 +291,9 @@ public sealed class TerminalNode : Hex1bNode
         // Forward input to the terminal
         if (_handle == null) return InputResult.NotHandled;
         
-        // When in copy mode, intercept all keyboard input.
-        // Delegate to the handle's CopyModeInput event for key mapping.
-        if (_handle.IsInCopyMode && inputEvent is Hex1bKeyEvent)
+        // When in copy mode, intercept all input (keyboard and mouse).
+        // Delegate to the handle's CopyModeInput event.
+        if (_handle.IsInCopyMode)
         {
             _handle.RaiseCopyModeInput(inputEvent);
             MarkDirty();
@@ -300,14 +301,25 @@ public sealed class TerminalNode : Hex1bNode
             return InputResult.Handled;
         }
         
-        // When NOT in copy mode, give the CopyModeInput handler a chance to intercept
-        // (e.g., to enter copy mode via a custom key like F6). If it handles the key,
-        // don't forward to the child terminal.
+        // When NOT in copy mode, give the CopyModeInput handler a chance to intercept.
+        // For keyboard: entry key like F6.
+        // For mouse: when mouse tracking is OFF, allow direct selection without explicit copy mode.
         if (inputEvent is Hex1bKeyEvent && _handle.RaiseCopyModeInput(inputEvent))
         {
             MarkDirty();
             _invalidateCallback?.Invoke();
             return InputResult.Handled;
+        }
+        
+        if (inputEvent is Hex1bMouseEvent mouseEvt && !_handle.MouseTrackingEnabled)
+        {
+            // Mouse tracking off — let consumer handle mouse for selection
+            if (_handle.RaiseCopyModeInput(inputEvent))
+            {
+                MarkDirty();
+                _invalidateCallback?.Invoke();
+                return InputResult.Handled;
+            }
         }
         
         // When in scrollback mode and a non-scrollback key is pressed (no binding matched),

--- a/src/Hex1b/Nodes/TerminalNode.cs
+++ b/src/Hex1b/Nodes/TerminalNode.cs
@@ -177,8 +177,9 @@ public sealed class TerminalNode : Hex1bNode
         bindings.Mouse(MouseButton.ScrollUp).Triggers(TerminalWidget.ScrollUpLine, MouseScrollUpHandler, "Scroll up");
         bindings.Mouse(MouseButton.ScrollDown).Triggers(TerminalWidget.ScrollDownLine, MouseScrollDownHandler, "Scroll down");
         
-        // Copy mode entry
-        bindings.Shift().Key(Hex1bKey.Spacebar).Triggers(TerminalWidget.EnterCopyMode, EnterCopyModeHandler, "Enter copy mode");
+        // Copy mode entry — must override capture since TerminalNode captures all input when focused.
+        // Uses Alt+C because Shift+Space is not reliably distinguishable from Space in terminal I/O.
+        new KeyStepBuilder(bindings).OverridesCapture().Alt().Key(Hex1bKey.C).Triggers(TerminalWidget.EnterCopyMode, EnterCopyModeHandler, "Enter copy mode");
     }
     
     private Task ScrollUpLineHandler(InputBindingActionContext ctx)

--- a/src/Hex1b/Nodes/TerminalNode.cs
+++ b/src/Hex1b/Nodes/TerminalNode.cs
@@ -176,10 +176,6 @@ public sealed class TerminalNode : Hex1bNode
         // Mouse wheel scrollback (only when child has NOT enabled mouse tracking)
         bindings.Mouse(MouseButton.ScrollUp).Triggers(TerminalWidget.ScrollUpLine, MouseScrollUpHandler, "Scroll up");
         bindings.Mouse(MouseButton.ScrollDown).Triggers(TerminalWidget.ScrollDownLine, MouseScrollDownHandler, "Scroll down");
-        
-        // Copy mode entry — must override capture since TerminalNode captures all input when focused.
-        // Uses Alt+C because Shift+Space is not reliably distinguishable from Space in terminal I/O.
-        new KeyStepBuilder(bindings).OverridesCapture().Alt().Key(Hex1bKey.C).Triggers(TerminalWidget.EnterCopyMode, EnterCopyModeHandler, "Enter copy mode");
     }
     
     private Task ScrollUpLineHandler(InputBindingActionContext ctx)
@@ -281,56 +277,6 @@ public sealed class TerminalNode : Hex1bNode
         }
     }
     
-    // === Copy Mode Handlers ===
-    
-    private Task EnterCopyModeHandler(InputBindingActionContext ctx)
-    {
-        if (_handle == null || _handle.IsInCopyMode) return Task.CompletedTask;
-        _handle.EnterCopyMode();
-        MarkDirty();
-        _invalidateCallback?.Invoke();
-        return Task.CompletedTask;
-    }
-    
-    private void MoveCopyModeCursor(int rowDelta, int colDelta)
-    {
-        if (_handle?.Selection == null) return;
-        var sel = _handle.Selection;
-        var pos = sel.Cursor;
-        int maxRow = _handle.VirtualBufferHeight - 1;
-        int maxCol = _handle.Width - 1;
-        var newPos = new BufferPosition(
-            Math.Clamp(pos.Row + rowDelta, 0, maxRow),
-            Math.Clamp(pos.Column + colDelta, 0, maxCol));
-        sel.MoveCursor(newPos);
-        EnsureCopyModeCursorVisible();
-        MarkDirty();
-        _invalidateCallback?.Invoke();
-    }
-    
-    private void EnsureCopyModeCursorVisible()
-    {
-        // Adjust scrollback offset so the copy mode cursor is visible
-        if (_handle?.Selection == null) return;
-        var cursorRow = _handle.Selection.Cursor.Row;
-        int scrollbackCount = _handle.ScrollbackCount;
-        int viewHeight = Math.Max(1, Bounds.Height);
-        
-        // Calculate visible virtual row range based on scrollback offset
-        int viewStart = scrollbackCount - _scrollbackOffset;
-        int viewEnd = viewStart + viewHeight - 1;
-        
-        if (cursorRow < viewStart)
-        {
-            _scrollbackOffset = scrollbackCount - cursorRow;
-        }
-        else if (cursorRow > viewEnd)
-        {
-            _scrollbackOffset = scrollbackCount - (cursorRow - viewHeight + 1);
-        }
-        _scrollbackOffset = Math.Max(0, _scrollbackOffset);
-    }
-    
     /// <inheritdoc />
     public override InputResult HandleInput(Hex1bEvent inputEvent)
     {
@@ -344,242 +290,38 @@ public sealed class TerminalNode : Hex1bNode
         // Forward input to the terminal
         if (_handle == null) return InputResult.NotHandled;
         
-        if (inputEvent is Hex1bKeyEvent keyEvent)
+        // When in copy mode, intercept all keyboard input.
+        // Delegate to the handle's CopyModeInput event for key mapping.
+        if (_handle.IsInCopyMode && inputEvent is Hex1bKeyEvent)
         {
-            // Enter copy mode: Alt+C or F6 (works even when terminal has captured input)
-            if (!_handle.IsInCopyMode && 
-                ((keyEvent.Key == Hex1bKey.C && keyEvent.Modifiers == Hex1bModifiers.Alt) ||
-                 (keyEvent.Key == Hex1bKey.F6 && keyEvent.Modifiers == Hex1bModifiers.None)))
-            {
-                _handle.EnterCopyMode();
-                MarkDirty();
-                _invalidateCallback?.Invoke();
-                return InputResult.Handled;
-            }
-            
-            // When in copy mode, intercept all keyboard input for copy mode navigation
-            if (_handle.IsInCopyMode)
-            {
-                return HandleCopyModeInput(keyEvent);
-            }
-            
-            // When in scrollback mode and a non-scrollback key is pressed (no binding matched),
-            // snap back to live view and forward the keystroke to the terminal.
-            // This matches standard terminal behavior where typing snaps you back to the prompt.
-            if (IsInScrollbackMode)
-            {
-                _scrollbackOffset = 0;
-                MarkDirty();
-                _invalidateCallback?.Invoke();
-            }
+            _handle.RaiseCopyModeInput(inputEvent);
+            MarkDirty();
+            _invalidateCallback?.Invoke();
+            return InputResult.Handled;
+        }
+        
+        // When NOT in copy mode, give the CopyModeInput handler a chance to intercept
+        // (e.g., to enter copy mode via a custom key like F6). If it handles the key,
+        // don't forward to the child terminal.
+        if (inputEvent is Hex1bKeyEvent && _handle.RaiseCopyModeInput(inputEvent))
+        {
+            MarkDirty();
+            _invalidateCallback?.Invoke();
+            return InputResult.Handled;
+        }
+        
+        // When in scrollback mode and a non-scrollback key is pressed (no binding matched),
+        // snap back to live view and forward the keystroke to the terminal.
+        if (IsInScrollbackMode && inputEvent is Hex1bKeyEvent)
+        {
+            _scrollbackOffset = 0;
+            MarkDirty();
+            _invalidateCallback?.Invoke();
         }
         
         // Fire and forget - we don't want to block the input loop
         _ = _handle.SendEventAsync(inputEvent);
         return InputResult.Handled;
-    }
-    
-    private InputResult HandleCopyModeInput(Hex1bKeyEvent keyEvent)
-    {
-        if (_handle?.Selection == null) return InputResult.Handled;
-        
-        var sel = _handle.Selection;
-        
-        switch (keyEvent.Key)
-        {
-            // Cancel
-            case Hex1bKey.Escape:
-            case Hex1bKey.Q:
-                _handle.ExitCopyMode();
-                _scrollbackOffset = 0;
-                MarkDirty();
-                _invalidateCallback?.Invoke();
-                return InputResult.Handled;
-            
-            // Copy and exit
-            case Hex1bKey.Enter:
-            case Hex1bKey.Y:
-                _handle.CopySelection();
-                _scrollbackOffset = 0;
-                MarkDirty();
-                _invalidateCallback?.Invoke();
-                return InputResult.Handled;
-            
-            // Navigation - arrows
-            case Hex1bKey.UpArrow:
-            case Hex1bKey.K:
-                MoveCopyModeCursor(-1, 0);
-                return InputResult.Handled;
-            case Hex1bKey.DownArrow:
-            case Hex1bKey.J:
-                MoveCopyModeCursor(1, 0);
-                return InputResult.Handled;
-            case Hex1bKey.LeftArrow:
-            case Hex1bKey.H:
-                MoveCopyModeCursor(0, -1);
-                return InputResult.Handled;
-            case Hex1bKey.RightArrow:
-            case Hex1bKey.L:
-                MoveCopyModeCursor(0, 1);
-                return InputResult.Handled;
-            
-            // Page navigation
-            case Hex1bKey.PageUp:
-                MoveCopyModeCursor(-(Math.Max(1, Bounds.Height - 1)), 0);
-                return InputResult.Handled;
-            case Hex1bKey.PageDown:
-                MoveCopyModeCursor(Math.Max(1, Bounds.Height - 1), 0);
-                return InputResult.Handled;
-            
-            // Line start/end
-            case Hex1bKey.Home:
-            case Hex1bKey.D0:
-                sel.MoveCursor(new BufferPosition(sel.Cursor.Row, 0));
-                MarkDirty();
-                _invalidateCallback?.Invoke();
-                return InputResult.Handled;
-            case Hex1bKey.End:
-                sel.MoveCursor(new BufferPosition(sel.Cursor.Row, _handle.Width - 1));
-                MarkDirty();
-                _invalidateCallback?.Invoke();
-                return InputResult.Handled;
-            
-            // Dollar sign ($) for end of line (vi convention) — mapped via Shift+4
-            
-            // Buffer top/bottom
-            case Hex1bKey.G when keyEvent.Modifiers == Hex1bModifiers.None:
-                // Lowercase g — buffer bottom
-                sel.MoveCursor(new BufferPosition(_handle.VirtualBufferHeight - 1, sel.Cursor.Column));
-                EnsureCopyModeCursorVisible();
-                MarkDirty();
-                _invalidateCallback?.Invoke();
-                return InputResult.Handled;
-            case Hex1bKey.G when keyEvent.Modifiers == Hex1bModifiers.Shift:
-                // Uppercase G — also buffer bottom (in tmux, gg is top, G is bottom)
-                sel.MoveCursor(new BufferPosition(_handle.VirtualBufferHeight - 1, sel.Cursor.Column));
-                EnsureCopyModeCursorVisible();
-                MarkDirty();
-                _invalidateCallback?.Invoke();
-                return InputResult.Handled;
-            
-            // Selection toggles
-            case Hex1bKey.V when keyEvent.Modifiers == Hex1bModifiers.None:
-                if (sel.IsSelecting && sel.Mode == SelectionMode.Character)
-                    sel.ClearSelection();
-                else
-                    sel.StartSelection(SelectionMode.Character);
-                MarkDirty();
-                _invalidateCallback?.Invoke();
-                return InputResult.Handled;
-            case Hex1bKey.V when keyEvent.Modifiers == Hex1bModifiers.Shift:
-                sel.ToggleMode(SelectionMode.Line);
-                MarkDirty();
-                _invalidateCallback?.Invoke();
-                return InputResult.Handled;
-            case Hex1bKey.V when keyEvent.Modifiers == Hex1bModifiers.Control:
-                sel.ToggleMode(SelectionMode.Block);
-                MarkDirty();
-                _invalidateCallback?.Invoke();
-                return InputResult.Handled;
-            
-            // Word navigation
-            case Hex1bKey.W:
-                MoveWordForward();
-                return InputResult.Handled;
-            case Hex1bKey.B:
-                MoveWordBackward();
-                return InputResult.Handled;
-            
-            // Spacebar starts selection
-            case Hex1bKey.Spacebar:
-                if (!sel.IsSelecting)
-                    sel.StartSelection(SelectionMode.Character);
-                MarkDirty();
-                _invalidateCallback?.Invoke();
-                return InputResult.Handled;
-            
-            default:
-                return InputResult.Handled; // Consume all input in copy mode
-        }
-    }
-    
-    private void MoveWordForward()
-    {
-        if (_handle?.Selection == null) return;
-        var sel = _handle.Selection;
-        var pos = sel.Cursor;
-        int maxRow = _handle.VirtualBufferHeight - 1;
-        int width = _handle.Width;
-        
-        int row = pos.Row;
-        int col = pos.Column;
-        
-        // Skip current word (non-space characters)
-        while (row <= maxRow)
-        {
-            var cell = _handle.GetVirtualCell(row, col);
-            if (cell == null || string.IsNullOrWhiteSpace(cell.Value.Character)) break;
-            col++;
-            if (col >= width) { col = 0; row++; }
-        }
-        
-        // Skip whitespace
-        while (row <= maxRow)
-        {
-            var cell = _handle.GetVirtualCell(row, col);
-            if (cell == null) break;
-            if (!string.IsNullOrWhiteSpace(cell.Value.Character)) break;
-            col++;
-            if (col >= width) { col = 0; row++; }
-        }
-        
-        row = Math.Min(row, maxRow);
-        sel.MoveCursor(new BufferPosition(row, col));
-        EnsureCopyModeCursorVisible();
-        MarkDirty();
-        _invalidateCallback?.Invoke();
-    }
-    
-    private void MoveWordBackward()
-    {
-        if (_handle?.Selection == null) return;
-        var sel = _handle.Selection;
-        var pos = sel.Cursor;
-        int width = _handle.Width;
-        
-        int row = pos.Row;
-        int col = pos.Column;
-        
-        // Move back one
-        col--;
-        if (col < 0) { col = width - 1; row--; }
-        if (row < 0) { row = 0; col = 0; sel.MoveCursor(new BufferPosition(row, col)); return; }
-        
-        // Skip whitespace
-        while (row >= 0)
-        {
-            var cell = _handle.GetVirtualCell(row, col);
-            if (cell == null) break;
-            if (!string.IsNullOrWhiteSpace(cell.Value.Character)) break;
-            col--;
-            if (col < 0) { col = width - 1; row--; }
-        }
-        
-        // Skip word (non-space characters)
-        while (row >= 0)
-        {
-            var cell = _handle.GetVirtualCell(row, col);
-            if (cell == null || string.IsNullOrWhiteSpace(cell.Value.Character)) { col++; break; }
-            col--;
-            if (col < 0) { col = width - 1; row--; }
-        }
-        
-        row = Math.Max(row, 0);
-        col = Math.Clamp(col, 0, width - 1);
-        sel.MoveCursor(new BufferPosition(row, col));
-        EnsureCopyModeCursorVisible();
-        MarkDirty();
-        _invalidateCallback?.Invoke();
     }
     
     /// <inheritdoc />

--- a/src/Hex1b/Nodes/TerminalNode.cs
+++ b/src/Hex1b/Nodes/TerminalNode.cs
@@ -176,6 +176,9 @@ public sealed class TerminalNode : Hex1bNode
         // Mouse wheel scrollback (only when child has NOT enabled mouse tracking)
         bindings.Mouse(MouseButton.ScrollUp).Triggers(TerminalWidget.ScrollUpLine, MouseScrollUpHandler, "Scroll up");
         bindings.Mouse(MouseButton.ScrollDown).Triggers(TerminalWidget.ScrollDownLine, MouseScrollDownHandler, "Scroll down");
+        
+        // Copy mode entry
+        bindings.Shift().Key(Hex1bKey.Spacebar).Triggers(TerminalWidget.EnterCopyMode, EnterCopyModeHandler, "Enter copy mode");
     }
     
     private Task ScrollUpLineHandler(InputBindingActionContext ctx)
@@ -277,6 +280,56 @@ public sealed class TerminalNode : Hex1bNode
         }
     }
     
+    // === Copy Mode Handlers ===
+    
+    private Task EnterCopyModeHandler(InputBindingActionContext ctx)
+    {
+        if (_handle == null || _handle.IsInCopyMode) return Task.CompletedTask;
+        _handle.EnterCopyMode();
+        MarkDirty();
+        _invalidateCallback?.Invoke();
+        return Task.CompletedTask;
+    }
+    
+    private void MoveCopyModeCursor(int rowDelta, int colDelta)
+    {
+        if (_handle?.Selection == null) return;
+        var sel = _handle.Selection;
+        var pos = sel.Cursor;
+        int maxRow = _handle.VirtualBufferHeight - 1;
+        int maxCol = _handle.Width - 1;
+        var newPos = new BufferPosition(
+            Math.Clamp(pos.Row + rowDelta, 0, maxRow),
+            Math.Clamp(pos.Column + colDelta, 0, maxCol));
+        sel.MoveCursor(newPos);
+        EnsureCopyModeCursorVisible();
+        MarkDirty();
+        _invalidateCallback?.Invoke();
+    }
+    
+    private void EnsureCopyModeCursorVisible()
+    {
+        // Adjust scrollback offset so the copy mode cursor is visible
+        if (_handle?.Selection == null) return;
+        var cursorRow = _handle.Selection.Cursor.Row;
+        int scrollbackCount = _handle.ScrollbackCount;
+        int viewHeight = Math.Max(1, Bounds.Height);
+        
+        // Calculate visible virtual row range based on scrollback offset
+        int viewStart = scrollbackCount - _scrollbackOffset;
+        int viewEnd = viewStart + viewHeight - 1;
+        
+        if (cursorRow < viewStart)
+        {
+            _scrollbackOffset = scrollbackCount - cursorRow;
+        }
+        else if (cursorRow > viewEnd)
+        {
+            _scrollbackOffset = scrollbackCount - (cursorRow - viewHeight + 1);
+        }
+        _scrollbackOffset = Math.Max(0, _scrollbackOffset);
+    }
+    
     /// <inheritdoc />
     public override InputResult HandleInput(Hex1bEvent inputEvent)
     {
@@ -289,6 +342,12 @@ public sealed class TerminalNode : Hex1bNode
         
         // Forward input to the terminal
         if (_handle == null) return InputResult.NotHandled;
+        
+        // When in copy mode, intercept all keyboard input for copy mode navigation
+        if (_handle.IsInCopyMode && inputEvent is Hex1bKeyEvent keyEvent)
+        {
+            return HandleCopyModeInput(keyEvent);
+        }
         
         // When in scrollback mode and a non-scrollback key is pressed (no binding matched),
         // snap back to live view and forward the keystroke to the terminal.
@@ -303,6 +362,209 @@ public sealed class TerminalNode : Hex1bNode
         // Fire and forget - we don't want to block the input loop
         _ = _handle.SendEventAsync(inputEvent);
         return InputResult.Handled;
+    }
+    
+    private InputResult HandleCopyModeInput(Hex1bKeyEvent keyEvent)
+    {
+        if (_handle?.Selection == null) return InputResult.Handled;
+        
+        var sel = _handle.Selection;
+        
+        switch (keyEvent.Key)
+        {
+            // Cancel
+            case Hex1bKey.Escape:
+            case Hex1bKey.Q:
+                _handle.ExitCopyMode();
+                _scrollbackOffset = 0;
+                MarkDirty();
+                _invalidateCallback?.Invoke();
+                return InputResult.Handled;
+            
+            // Copy and exit
+            case Hex1bKey.Enter:
+            case Hex1bKey.Y:
+                _handle.CopySelection();
+                _scrollbackOffset = 0;
+                MarkDirty();
+                _invalidateCallback?.Invoke();
+                return InputResult.Handled;
+            
+            // Navigation - arrows
+            case Hex1bKey.UpArrow:
+            case Hex1bKey.K:
+                MoveCopyModeCursor(-1, 0);
+                return InputResult.Handled;
+            case Hex1bKey.DownArrow:
+            case Hex1bKey.J:
+                MoveCopyModeCursor(1, 0);
+                return InputResult.Handled;
+            case Hex1bKey.LeftArrow:
+            case Hex1bKey.H:
+                MoveCopyModeCursor(0, -1);
+                return InputResult.Handled;
+            case Hex1bKey.RightArrow:
+            case Hex1bKey.L:
+                MoveCopyModeCursor(0, 1);
+                return InputResult.Handled;
+            
+            // Page navigation
+            case Hex1bKey.PageUp:
+                MoveCopyModeCursor(-(Math.Max(1, Bounds.Height - 1)), 0);
+                return InputResult.Handled;
+            case Hex1bKey.PageDown:
+                MoveCopyModeCursor(Math.Max(1, Bounds.Height - 1), 0);
+                return InputResult.Handled;
+            
+            // Line start/end
+            case Hex1bKey.Home:
+            case Hex1bKey.D0:
+                sel.MoveCursor(new BufferPosition(sel.Cursor.Row, 0));
+                MarkDirty();
+                _invalidateCallback?.Invoke();
+                return InputResult.Handled;
+            case Hex1bKey.End:
+                sel.MoveCursor(new BufferPosition(sel.Cursor.Row, _handle.Width - 1));
+                MarkDirty();
+                _invalidateCallback?.Invoke();
+                return InputResult.Handled;
+            
+            // Dollar sign ($) for end of line (vi convention) — mapped via Shift+4
+            
+            // Buffer top/bottom
+            case Hex1bKey.G when keyEvent.Modifiers == Hex1bModifiers.None:
+                // Lowercase g — buffer bottom
+                sel.MoveCursor(new BufferPosition(_handle.VirtualBufferHeight - 1, sel.Cursor.Column));
+                EnsureCopyModeCursorVisible();
+                MarkDirty();
+                _invalidateCallback?.Invoke();
+                return InputResult.Handled;
+            case Hex1bKey.G when keyEvent.Modifiers == Hex1bModifiers.Shift:
+                // Uppercase G — also buffer bottom (in tmux, gg is top, G is bottom)
+                sel.MoveCursor(new BufferPosition(_handle.VirtualBufferHeight - 1, sel.Cursor.Column));
+                EnsureCopyModeCursorVisible();
+                MarkDirty();
+                _invalidateCallback?.Invoke();
+                return InputResult.Handled;
+            
+            // Selection toggles
+            case Hex1bKey.V when keyEvent.Modifiers == Hex1bModifiers.None:
+                if (sel.IsSelecting && sel.Mode == SelectionMode.Character)
+                    sel.ClearSelection();
+                else
+                    sel.StartSelection(SelectionMode.Character);
+                MarkDirty();
+                _invalidateCallback?.Invoke();
+                return InputResult.Handled;
+            case Hex1bKey.V when keyEvent.Modifiers == Hex1bModifiers.Shift:
+                sel.ToggleMode(SelectionMode.Line);
+                MarkDirty();
+                _invalidateCallback?.Invoke();
+                return InputResult.Handled;
+            case Hex1bKey.V when keyEvent.Modifiers == Hex1bModifiers.Control:
+                sel.ToggleMode(SelectionMode.Block);
+                MarkDirty();
+                _invalidateCallback?.Invoke();
+                return InputResult.Handled;
+            
+            // Word navigation
+            case Hex1bKey.W:
+                MoveWordForward();
+                return InputResult.Handled;
+            case Hex1bKey.B:
+                MoveWordBackward();
+                return InputResult.Handled;
+            
+            // Spacebar starts selection
+            case Hex1bKey.Spacebar:
+                if (!sel.IsSelecting)
+                    sel.StartSelection(SelectionMode.Character);
+                MarkDirty();
+                _invalidateCallback?.Invoke();
+                return InputResult.Handled;
+            
+            default:
+                return InputResult.Handled; // Consume all input in copy mode
+        }
+    }
+    
+    private void MoveWordForward()
+    {
+        if (_handle?.Selection == null) return;
+        var sel = _handle.Selection;
+        var pos = sel.Cursor;
+        int maxRow = _handle.VirtualBufferHeight - 1;
+        int width = _handle.Width;
+        
+        int row = pos.Row;
+        int col = pos.Column;
+        
+        // Skip current word (non-space characters)
+        while (row <= maxRow)
+        {
+            var cell = _handle.GetVirtualCell(row, col);
+            if (cell == null || string.IsNullOrWhiteSpace(cell.Value.Character)) break;
+            col++;
+            if (col >= width) { col = 0; row++; }
+        }
+        
+        // Skip whitespace
+        while (row <= maxRow)
+        {
+            var cell = _handle.GetVirtualCell(row, col);
+            if (cell == null) break;
+            if (!string.IsNullOrWhiteSpace(cell.Value.Character)) break;
+            col++;
+            if (col >= width) { col = 0; row++; }
+        }
+        
+        row = Math.Min(row, maxRow);
+        sel.MoveCursor(new BufferPosition(row, col));
+        EnsureCopyModeCursorVisible();
+        MarkDirty();
+        _invalidateCallback?.Invoke();
+    }
+    
+    private void MoveWordBackward()
+    {
+        if (_handle?.Selection == null) return;
+        var sel = _handle.Selection;
+        var pos = sel.Cursor;
+        int width = _handle.Width;
+        
+        int row = pos.Row;
+        int col = pos.Column;
+        
+        // Move back one
+        col--;
+        if (col < 0) { col = width - 1; row--; }
+        if (row < 0) { row = 0; col = 0; sel.MoveCursor(new BufferPosition(row, col)); return; }
+        
+        // Skip whitespace
+        while (row >= 0)
+        {
+            var cell = _handle.GetVirtualCell(row, col);
+            if (cell == null) break;
+            if (!string.IsNullOrWhiteSpace(cell.Value.Character)) break;
+            col--;
+            if (col < 0) { col = width - 1; row--; }
+        }
+        
+        // Skip word (non-space characters)
+        while (row >= 0)
+        {
+            var cell = _handle.GetVirtualCell(row, col);
+            if (cell == null || string.IsNullOrWhiteSpace(cell.Value.Character)) { col++; break; }
+            col--;
+            if (col < 0) { col = width - 1; row--; }
+        }
+        
+        row = Math.Max(row, 0);
+        col = Math.Clamp(col, 0, width - 1);
+        sel.MoveCursor(new BufferPosition(row, col));
+        EnsureCopyModeCursorVisible();
+        MarkDirty();
+        _invalidateCallback?.Invoke();
     }
     
     /// <inheritdoc />
@@ -562,9 +824,19 @@ public sealed class TerminalNode : Hex1bNode
     /// </summary>
     private void RenderLive(Hex1bRenderContext context, TerminalCell[,] buffer, int handleWidth, int handleHeight)
     {
+        int scrollbackCount = _handle!.ScrollbackCount;
+        var selection = _handle.IsInCopyMode ? _handle.Selection : null;
+        
         for (int y = 0; y < Math.Min(Bounds.Height, handleHeight); y++)
         {
-            RenderRow(context, y, (x) => buffer[y, x], handleWidth);
+            int virtualRow = scrollbackCount + y;
+            RenderRow(context, y, (x) => buffer[y, x], handleWidth, virtualRow, selection);
+        }
+        
+        // Render copy mode cursor
+        if (selection != null)
+        {
+            RenderCopyModeCursor(context, scrollbackCount, scrollbackCount);
         }
     }
     
@@ -577,6 +849,7 @@ public sealed class TerminalNode : Hex1bNode
         // Get scrollback rows
         var scrollbackRows = _handle!.GetScrollbackSnapshot(_handle.ScrollbackCount);
         int scrollbackCount = scrollbackRows.Length;
+        var selection = _handle.IsInCopyMode ? _handle.Selection : null;
         
         // Clamp offset to available scrollback
         var effectiveOffset = Math.Min(_scrollbackOffset, scrollbackCount);
@@ -600,7 +873,7 @@ public sealed class TerminalNode : Hex1bNode
                 {
                     if (x < sbRow.Cells.Length) return sbRow.Cells[x];
                     return TerminalCell.Empty;
-                }, handleWidth);
+                }, handleWidth, virtualRow, selection);
             }
             else
             {
@@ -608,29 +881,59 @@ public sealed class TerminalNode : Hex1bNode
                 int activeRow = virtualRow - scrollbackCount;
                 if (activeRow < handleHeight)
                 {
-                    RenderRow(context, viewY, (x) => activeBuffer[activeRow, x], handleWidth);
+                    RenderRow(context, viewY, (x) => activeBuffer[activeRow, x], handleWidth, virtualRow, selection);
                 }
             }
+        }
+        
+        // Render copy mode cursor
+        if (selection != null)
+        {
+            RenderCopyModeCursor(context, virtualStart, scrollbackCount);
+        }
+    }
+    
+    private void RenderCopyModeCursor(Hex1bRenderContext context, int virtualStart, int scrollbackCount)
+    {
+        if (_handle?.Selection == null) return;
+        var cursorPos = _handle.Selection.Cursor;
+        int viewY = cursorPos.Row - virtualStart;
+        if (viewY >= 0 && viewY < Bounds.Height && cursorPos.Column < Bounds.Width)
+        {
+            // Render a block cursor at the copy mode cursor position with inverted colors
+            var cell = _handle.GetVirtualCell(cursorPos.Row, cursorPos.Column);
+            var ch = cell?.Character ?? " ";
+            if (string.IsNullOrEmpty(ch)) ch = " ";
+            context.WriteClipped(Bounds.X + cursorPos.Column, Bounds.Y + viewY, $"\x1b[7m{ch}\x1b[0m");
         }
     }
     
     /// <summary>
     /// Renders a single row of terminal cells at the specified view Y position.
     /// </summary>
-    private void RenderRow(Hex1bRenderContext context, int viewY, Func<int, TerminalCell> getCell, int handleWidth)
+    private void RenderRow(Hex1bRenderContext context, int viewY, Func<int, TerminalCell> getCell, int handleWidth,
+        int virtualRow = -1, TerminalSelection? selection = null)
     {
         var lineBuilder = new System.Text.StringBuilder();
         Hex1b.Theming.Hex1bColor? lastFg = null;
         Hex1b.Theming.Hex1bColor? lastBg = null;
         Hex1b.Theming.Hex1bColor? lastUc = null;
         CellAttributes lastAttrs = CellAttributes.None;
+        bool lastSelected = false;
         
         for (int x = 0; x < Math.Min(Bounds.Width, handleWidth); x++)
         {
             var cell = getCell(x);
+            bool isSelected = selection != null && virtualRow >= 0 && selection.IsCellSelected(virtualRow, x);
             
             // Build ANSI codes for color changes
             bool needsReset = false;
+            
+            // Check if selection state changed
+            if (isSelected != lastSelected)
+            {
+                needsReset = true;
+            }
             
             // Check if attributes changed
             if (cell.Attributes != lastAttrs)
@@ -662,7 +965,7 @@ public sealed class TerminalNode : Hex1bNode
                     else
                         lineBuilder.Append("\x1b[4m");
                 }
-                if (cell.Attributes.HasFlag(CellAttributes.Reverse))
+                if (cell.Attributes.HasFlag(CellAttributes.Reverse) || isSelected)
                     lineBuilder.Append("\x1b[7m");
                 if (cell.Attributes.HasFlag(CellAttributes.Strikethrough))
                     lineBuilder.Append("\x1b[9m");
@@ -680,6 +983,7 @@ public sealed class TerminalNode : Hex1bNode
                 lastBg = cell.Background;
                 lastUc = cell.UnderlineColor;
                 lastAttrs = cell.Attributes;
+                lastSelected = isSelected;
             }
             
             lineBuilder.Append(cell.Character);

--- a/src/Hex1b/Nodes/TerminalNode.cs
+++ b/src/Hex1b/Nodes/TerminalNode.cs
@@ -578,6 +578,13 @@ public sealed class TerminalNode : Hex1bNode
         // (e.g., after scrolling back from scrollback mode to live mode).
         context.ClearRegion(Bounds);
         
+        // Sync scrollback offset from handle when in copy mode
+        // (the handle adjusts it to keep the copy cursor visible)
+        if (_handle.IsInCopyMode)
+        {
+            _scrollbackOffset = _handle.CurrentScrollbackOffset;
+        }
+        
         if (_scrollbackOffset > 0)
         {
             RenderWithScrollback(context, buffer, handleWidth, handleHeight);

--- a/src/Hex1b/Nodes/TerminalNode.cs
+++ b/src/Hex1b/Nodes/TerminalNode.cs
@@ -447,7 +447,7 @@ public sealed class TerminalNode : Hex1bNode
     /// <summary>
     /// Attaches or detaches the copy mode helper based on widget configuration.
     /// </summary>
-    internal void AttachCopyModeHelper(CopyModeBindingsOptions? options)
+    internal void AttachCopyModeHelper(CopyModeBindingsOptions? options, Action<string>? defaultClipboard = null)
     {
         if (options == null)
         {
@@ -464,6 +464,9 @@ public sealed class TerminalNode : Hex1bNode
         {
             _copyModeHelper = new TerminalCopyModeHelper(_handle, options);
         }
+        
+        // Set the default clipboard callback from the app
+        _copyModeHelper.SetDefaultClipboard(defaultClipboard);
     }
     
     private void OnOutputReceived()

--- a/src/Hex1b/TerminalCopyModeHelper.cs
+++ b/src/Hex1b/TerminalCopyModeHelper.cs
@@ -11,6 +11,7 @@ internal sealed class TerminalCopyModeHelper
 {
     private readonly TerminalWidgetHandle _handle;
     private readonly CopyModeBindingsOptions _options;
+    private Action<string>? _clipboardCallback;
 
     public TerminalCopyModeHelper(TerminalWidgetHandle handle, CopyModeBindingsOptions options)
     {
@@ -18,6 +19,30 @@ internal sealed class TerminalCopyModeHelper
         _options = options;
         _handle.CopyModeInput += HandleInput;
         _handle.CopyModeChanged += OnCopyModeChanged;
+        
+        // Wire clipboard if a callback is provided
+        if (options.CopyToClipboard != null)
+        {
+            _clipboardCallback = options.CopyToClipboard;
+            _handle.TextCopied += _clipboardCallback;
+        }
+    }
+
+    /// <summary>
+    /// Sets the default clipboard callback (used by the framework when no custom
+    /// callback is configured). Called during reconciliation with the app's CopyToClipboard.
+    /// </summary>
+    internal void SetDefaultClipboard(Action<string>? clipboard)
+    {
+        if (_options.CopyToClipboard != null) return; // user provided custom callback
+        
+        // Remove old default
+        if (_clipboardCallback != null)
+            _handle.TextCopied -= _clipboardCallback;
+        
+        _clipboardCallback = clipboard;
+        if (_clipboardCallback != null)
+            _handle.TextCopied += _clipboardCallback;
     }
 
     /// <summary>
@@ -27,6 +52,9 @@ internal sealed class TerminalCopyModeHelper
     {
         _handle.CopyModeInput -= HandleInput;
         _handle.CopyModeChanged -= OnCopyModeChanged;
+        if (_clipboardCallback != null)
+            _handle.TextCopied -= _clipboardCallback;
+        _clipboardCallback = null;
     }
 
     private void OnCopyModeChanged(bool active)

--- a/src/Hex1b/TerminalCopyModeHelper.cs
+++ b/src/Hex1b/TerminalCopyModeHelper.cs
@@ -66,46 +66,7 @@ internal sealed class TerminalCopyModeHelper
             return true;
         }
 
-        // Navigation (no modifiers)
-        if (key.Modifiers == Hex1bModifiers.None)
-        {
-            if (_options.CursorUpKeys.Contains(key.Key))
-            { _handle.MoveCopyModeCursor(-1, 0); UpdateState(); return true; }
-            if (_options.CursorDownKeys.Contains(key.Key))
-            { _handle.MoveCopyModeCursor(1, 0); UpdateState(); return true; }
-            if (_options.CursorLeftKeys.Contains(key.Key))
-            { _handle.MoveCopyModeCursor(0, -1); UpdateState(); return true; }
-            if (_options.CursorRightKeys.Contains(key.Key))
-            { _handle.MoveCopyModeCursor(0, 1); UpdateState(); return true; }
-            if (_options.WordForwardKeys.Contains(key.Key))
-            { _handle.MoveWordForward(); UpdateState(); return true; }
-            if (_options.WordBackwardKeys.Contains(key.Key))
-            { _handle.MoveWordBackward(); UpdateState(); return true; }
-            if (_options.PageUpKeys.Contains(key.Key))
-            { _handle.MoveCopyModeCursor(-20, 0); UpdateState(); return true; }
-            if (_options.PageDownKeys.Contains(key.Key))
-            { _handle.MoveCopyModeCursor(20, 0); UpdateState(); return true; }
-            if (_options.LineStartKeys.Contains(key.Key))
-            { _handle.SetCopyModeCursorPosition(_handle.Selection!.Cursor.Row, 0); UpdateState(); return true; }
-            if (_options.LineEndKeys.Contains(key.Key))
-            { _handle.SetCopyModeCursorPosition(_handle.Selection!.Cursor.Row, _handle.Width - 1); UpdateState(); return true; }
-
-            // Character selection (no modifier)
-            if (_options.CharacterSelectionKeys.Contains(key.Key))
-            { _handle.StartOrToggleSelection(SelectionMode.Character); UpdateState(); return true; }
-        }
-
-        // Keys with modifiers (buffer top/bottom, line/block selection)
-        foreach (var (k, m) in _options.BufferTopKeys)
-        {
-            if (key.Key == k && key.Modifiers == m)
-            { _handle.SetCopyModeCursorPosition(0, _handle.Selection!.Cursor.Column); UpdateState(); return true; }
-        }
-        foreach (var (k, m) in _options.BufferBottomKeys)
-        {
-            if (key.Key == k && key.Modifiers == m)
-            { _handle.SetCopyModeCursorPosition(_handle.VirtualBufferHeight - 1, _handle.Selection!.Cursor.Column); UpdateState(); return true; }
-        }
+        // Modifier-specific bindings first (so Alt+V matches block selection before V matches navigation)
         foreach (var (k, m) in _options.LineSelectionKeys)
         {
             if (key.Key == k && key.Modifiers == m)
@@ -116,6 +77,42 @@ internal sealed class TerminalCopyModeHelper
             if (key.Key == k && key.Modifiers == m)
             { _handle.StartOrToggleSelection(SelectionMode.Block); UpdateState(); return true; }
         }
+        foreach (var (k, m) in _options.BufferTopKeys)
+        {
+            if (key.Key == k && key.Modifiers == m)
+            { _handle.SetCopyModeCursorPosition(0, _handle.Selection!.Cursor.Column); UpdateState(); return true; }
+        }
+        foreach (var (k, m) in _options.BufferBottomKeys)
+        {
+            if (key.Key == k && key.Modifiers == m)
+            { _handle.SetCopyModeCursorPosition(_handle.VirtualBufferHeight - 1, _handle.Selection!.Cursor.Column); UpdateState(); return true; }
+        }
+
+        // Character selection (no modifier)
+        if (key.Modifiers == Hex1bModifiers.None && _options.CharacterSelectionKeys.Contains(key.Key))
+        { _handle.StartOrToggleSelection(SelectionMode.Character); UpdateState(); return true; }
+
+        // Navigation — check key regardless of modifiers so Alt+J etc. still work
+        if (_options.CursorUpKeys.Contains(key.Key))
+        { _handle.MoveCopyModeCursor(-1, 0); UpdateState(); return true; }
+        if (_options.CursorDownKeys.Contains(key.Key))
+        { _handle.MoveCopyModeCursor(1, 0); UpdateState(); return true; }
+        if (_options.CursorLeftKeys.Contains(key.Key))
+        { _handle.MoveCopyModeCursor(0, -1); UpdateState(); return true; }
+        if (_options.CursorRightKeys.Contains(key.Key))
+        { _handle.MoveCopyModeCursor(0, 1); UpdateState(); return true; }
+        if (key.Modifiers == Hex1bModifiers.None && _options.WordForwardKeys.Contains(key.Key))
+        { _handle.MoveWordForward(); UpdateState(); return true; }
+        if (key.Modifiers == Hex1bModifiers.None && _options.WordBackwardKeys.Contains(key.Key))
+        { _handle.MoveWordBackward(); UpdateState(); return true; }
+        if (_options.PageUpKeys.Contains(key.Key))
+        { _handle.MoveCopyModeCursor(-20, 0); UpdateState(); return true; }
+        if (_options.PageDownKeys.Contains(key.Key))
+        { _handle.MoveCopyModeCursor(20, 0); UpdateState(); return true; }
+        if (_options.LineStartKeys.Contains(key.Key))
+        { _handle.SetCopyModeCursorPosition(_handle.Selection!.Cursor.Row, 0); UpdateState(); return true; }
+        if (_options.LineEndKeys.Contains(key.Key))
+        { _handle.SetCopyModeCursorPosition(_handle.Selection!.Cursor.Row, _handle.Width - 1); UpdateState(); return true; }
 
         return true; // consume all keys in copy mode
     }

--- a/src/Hex1b/TerminalCopyModeHelper.cs
+++ b/src/Hex1b/TerminalCopyModeHelper.cs
@@ -1,0 +1,153 @@
+using Hex1b.Input;
+
+namespace Hex1b;
+
+/// <summary>
+/// Attaches standard copy mode key and mouse bindings to a <see cref="TerminalWidgetHandle"/>.
+/// Created by <see cref="TerminalExtensions.CopyModeBindings"/> and subscribes to the
+/// handle's <see cref="TerminalWidgetHandle.CopyModeInput"/> event internally.
+/// </summary>
+internal sealed class TerminalCopyModeHelper
+{
+    private readonly TerminalWidgetHandle _handle;
+    private readonly CopyModeBindingsOptions _options;
+
+    public TerminalCopyModeHelper(TerminalWidgetHandle handle, CopyModeBindingsOptions options)
+    {
+        _handle = handle;
+        _options = options;
+        _handle.CopyModeInput += HandleInput;
+        _handle.CopyModeChanged += OnCopyModeChanged;
+    }
+
+    /// <summary>
+    /// Detaches from the handle's events.
+    /// </summary>
+    public void Detach()
+    {
+        _handle.CopyModeInput -= HandleInput;
+        _handle.CopyModeChanged -= OnCopyModeChanged;
+    }
+
+    private void OnCopyModeChanged(bool active)
+    {
+        _handle.UpdateCopyModeState();
+    }
+
+    private bool HandleInput(Hex1bEvent inputEvent)
+    {
+        if (inputEvent is Hex1bMouseEvent mouse)
+            return HandleMouseInput(mouse);
+
+        if (inputEvent is not Hex1bKeyEvent key)
+            return false;
+
+        // Entry key (when not in copy mode)
+        if (!_handle.IsInCopyMode)
+        {
+            if (key.Modifiers == Hex1bModifiers.None && _options.EnterKeys.Contains(key.Key))
+            {
+                _handle.EnterCopyMode();
+                return true;
+            }
+            return false;
+        }
+
+        // Copy mode key handling
+        if (key.Modifiers == Hex1bModifiers.None && _options.CancelKeys.Contains(key.Key))
+        {
+            _handle.ExitCopyMode();
+            return true;
+        }
+
+        if (key.Modifiers == Hex1bModifiers.None && _options.CopyKeys.Contains(key.Key))
+        {
+            _handle.CopySelection();
+            return true;
+        }
+
+        // Navigation (no modifiers)
+        if (key.Modifiers == Hex1bModifiers.None)
+        {
+            if (_options.CursorUpKeys.Contains(key.Key))
+            { _handle.MoveCopyModeCursor(-1, 0); UpdateState(); return true; }
+            if (_options.CursorDownKeys.Contains(key.Key))
+            { _handle.MoveCopyModeCursor(1, 0); UpdateState(); return true; }
+            if (_options.CursorLeftKeys.Contains(key.Key))
+            { _handle.MoveCopyModeCursor(0, -1); UpdateState(); return true; }
+            if (_options.CursorRightKeys.Contains(key.Key))
+            { _handle.MoveCopyModeCursor(0, 1); UpdateState(); return true; }
+            if (_options.WordForwardKeys.Contains(key.Key))
+            { _handle.MoveWordForward(); UpdateState(); return true; }
+            if (_options.WordBackwardKeys.Contains(key.Key))
+            { _handle.MoveWordBackward(); UpdateState(); return true; }
+            if (_options.PageUpKeys.Contains(key.Key))
+            { _handle.MoveCopyModeCursor(-20, 0); UpdateState(); return true; }
+            if (_options.PageDownKeys.Contains(key.Key))
+            { _handle.MoveCopyModeCursor(20, 0); UpdateState(); return true; }
+            if (_options.LineStartKeys.Contains(key.Key))
+            { _handle.SetCopyModeCursorPosition(_handle.Selection!.Cursor.Row, 0); UpdateState(); return true; }
+            if (_options.LineEndKeys.Contains(key.Key))
+            { _handle.SetCopyModeCursorPosition(_handle.Selection!.Cursor.Row, _handle.Width - 1); UpdateState(); return true; }
+
+            // Character selection (no modifier)
+            if (_options.CharacterSelectionKeys.Contains(key.Key))
+            { _handle.StartOrToggleSelection(SelectionMode.Character); UpdateState(); return true; }
+        }
+
+        // Keys with modifiers (buffer top/bottom, line/block selection)
+        foreach (var (k, m) in _options.BufferTopKeys)
+        {
+            if (key.Key == k && key.Modifiers == m)
+            { _handle.SetCopyModeCursorPosition(0, _handle.Selection!.Cursor.Column); UpdateState(); return true; }
+        }
+        foreach (var (k, m) in _options.BufferBottomKeys)
+        {
+            if (key.Key == k && key.Modifiers == m)
+            { _handle.SetCopyModeCursorPosition(_handle.VirtualBufferHeight - 1, _handle.Selection!.Cursor.Column); UpdateState(); return true; }
+        }
+        foreach (var (k, m) in _options.LineSelectionKeys)
+        {
+            if (key.Key == k && key.Modifiers == m)
+            { _handle.StartOrToggleSelection(SelectionMode.Line); UpdateState(); return true; }
+        }
+        foreach (var (k, m) in _options.BlockSelectionKeys)
+        {
+            if (key.Key == k && key.Modifiers == m)
+            { _handle.StartOrToggleSelection(SelectionMode.Block); UpdateState(); return true; }
+        }
+
+        return true; // consume all keys in copy mode
+    }
+
+    private bool HandleMouseInput(Hex1bMouseEvent mouse)
+    {
+        if (!_options.MouseEnabled) return false;
+
+        if (mouse.Button == MouseButton.Left)
+        {
+            var mode = mouse.Modifiers switch
+            {
+                var m when m == _options.MouseLineModifier => SelectionMode.Line,
+                var m when m == _options.MouseBlockModifier => SelectionMode.Block,
+                _ => SelectionMode.Character
+            };
+            _handle.MouseSelect(mouse.X, mouse.Y, mouse.Action, mode);
+            UpdateState();
+            return true;
+        }
+
+        if (mouse.Button == _options.MouseCopyButton && mouse.Action == MouseAction.Down && _handle.IsInCopyMode)
+        {
+            _handle.CopySelection();
+            return true;
+        }
+
+        return false;
+    }
+
+    private void UpdateState()
+    {
+        _handle.UpdateCopyModeState();
+    }
+}

--- a/src/Hex1b/TerminalCopyModeHelper.cs
+++ b/src/Hex1b/TerminalCopyModeHelper.cs
@@ -45,7 +45,7 @@ internal sealed class TerminalCopyModeHelper
         // Entry key (when not in copy mode)
         if (!_handle.IsInCopyMode)
         {
-            if (key.Modifiers == Hex1bModifiers.None && _options.EnterKeys.Contains(key.Key))
+            if (MatchesAny(_options.EnterKeys, key))
             {
                 _handle.EnterCopyMode();
                 return true;
@@ -53,68 +53,66 @@ internal sealed class TerminalCopyModeHelper
             return false;
         }
 
-        // Copy mode key handling
-        if (key.Modifiers == Hex1bModifiers.None && _options.CancelKeys.Contains(key.Key))
+        // Copy mode key handling — cancel/copy first
+        if (MatchesAny(_options.CancelKeys, key))
         {
             _handle.ExitCopyMode();
             return true;
         }
 
-        if (key.Modifiers == Hex1bModifiers.None && _options.CopyKeys.Contains(key.Key))
+        if (MatchesAny(_options.CopyKeys, key))
         {
             _handle.CopySelection();
             return true;
         }
 
-        // Modifier-specific bindings first (so Alt+V matches block selection before V matches navigation)
-        foreach (var (k, m) in _options.LineSelectionKeys)
-        {
-            if (key.Key == k && key.Modifiers == m)
-            { _handle.StartOrToggleSelection(SelectionMode.Line); UpdateState(); return true; }
-        }
-        foreach (var (k, m) in _options.BlockSelectionKeys)
-        {
-            if (key.Key == k && key.Modifiers == m)
-            { _handle.StartOrToggleSelection(SelectionMode.Block); UpdateState(); return true; }
-        }
-        foreach (var (k, m) in _options.BufferTopKeys)
-        {
-            if (key.Key == k && key.Modifiers == m)
-            { _handle.SetCopyModeCursorPosition(0, _handle.Selection!.Cursor.Column); UpdateState(); return true; }
-        }
-        foreach (var (k, m) in _options.BufferBottomKeys)
-        {
-            if (key.Key == k && key.Modifiers == m)
-            { _handle.SetCopyModeCursorPosition(_handle.VirtualBufferHeight - 1, _handle.Selection!.Cursor.Column); UpdateState(); return true; }
-        }
-
-        // Character selection (no modifier)
-        if (key.Modifiers == Hex1bModifiers.None && _options.CharacterSelectionKeys.Contains(key.Key))
+        // Selection mode bindings (checked before navigation to avoid conflicts like V vs cursor keys)
+        if (MatchesAny(_options.LineSelectionKeys, key))
+        { _handle.StartOrToggleSelection(SelectionMode.Line); UpdateState(); return true; }
+        if (MatchesAny(_options.BlockSelectionKeys, key))
+        { _handle.StartOrToggleSelection(SelectionMode.Block); UpdateState(); return true; }
+        if (MatchesAny(_options.CharacterSelectionKeys, key))
         { _handle.StartOrToggleSelection(SelectionMode.Character); UpdateState(); return true; }
 
-        // Navigation — check key regardless of modifiers so Alt+J etc. still work
-        if (_options.CursorUpKeys.Contains(key.Key))
+        // Buffer top/bottom
+        if (MatchesAny(_options.BufferTopKeys, key))
+        { _handle.SetCopyModeCursorPosition(0, _handle.Selection!.Cursor.Column); UpdateState(); return true; }
+        if (MatchesAny(_options.BufferBottomKeys, key))
+        { _handle.SetCopyModeCursorPosition(_handle.VirtualBufferHeight - 1, _handle.Selection!.Cursor.Column); UpdateState(); return true; }
+
+        // Navigation
+        if (MatchesAny(_options.CursorUpKeys, key))
         { _handle.MoveCopyModeCursor(-1, 0); UpdateState(); return true; }
-        if (_options.CursorDownKeys.Contains(key.Key))
+        if (MatchesAny(_options.CursorDownKeys, key))
         { _handle.MoveCopyModeCursor(1, 0); UpdateState(); return true; }
-        if (_options.CursorLeftKeys.Contains(key.Key))
+        if (MatchesAny(_options.CursorLeftKeys, key))
         { _handle.MoveCopyModeCursor(0, -1); UpdateState(); return true; }
-        if (_options.CursorRightKeys.Contains(key.Key))
+        if (MatchesAny(_options.CursorRightKeys, key))
         { _handle.MoveCopyModeCursor(0, 1); UpdateState(); return true; }
-        if (key.Modifiers == Hex1bModifiers.None && _options.WordForwardKeys.Contains(key.Key))
+        if (MatchesAny(_options.WordForwardKeys, key))
         { _handle.MoveWordForward(); UpdateState(); return true; }
-        if (key.Modifiers == Hex1bModifiers.None && _options.WordBackwardKeys.Contains(key.Key))
+        if (MatchesAny(_options.WordBackwardKeys, key))
         { _handle.MoveWordBackward(); UpdateState(); return true; }
-        if (_options.PageUpKeys.Contains(key.Key))
+        if (MatchesAny(_options.PageUpKeys, key))
         { _handle.MoveCopyModeCursor(-20, 0); UpdateState(); return true; }
-        if (_options.PageDownKeys.Contains(key.Key))
+        if (MatchesAny(_options.PageDownKeys, key))
         { _handle.MoveCopyModeCursor(20, 0); UpdateState(); return true; }
-        if (_options.LineStartKeys.Contains(key.Key))
+        if (MatchesAny(_options.LineStartKeys, key))
         { _handle.SetCopyModeCursorPosition(_handle.Selection!.Cursor.Row, 0); UpdateState(); return true; }
-        if (_options.LineEndKeys.Contains(key.Key))
+        if (MatchesAny(_options.LineEndKeys, key))
         { _handle.SetCopyModeCursorPosition(_handle.Selection!.Cursor.Row, _handle.Width - 1); UpdateState(); return true; }
 
         return true; // consume all keys in copy mode
+    }
+    
+    private static bool MatchesAny(KeyBinding[] bindings, Hex1bKeyEvent key)
+    {
+        foreach (var binding in bindings)
+        {
+            if (binding.Matches(key))
+                return true;
+        }
+        return false;
     }
 
     private bool HandleMouseInput(Hex1bMouseEvent mouse)

--- a/src/Hex1b/TerminalExtensions.cs
+++ b/src/Hex1b/TerminalExtensions.cs
@@ -75,4 +75,36 @@ public static class TerminalExtensions
         this TerminalWidget widget,
         int rows)
         => widget with { MouseWheelScrollAmount = rows };
+    
+    /// <summary>
+    /// Enables standard copy mode bindings with configurable key and mouse mappings.
+    /// Provides vi-style keyboard navigation, character/line/block selection,
+    /// and mouse drag-to-select with modifier keys.
+    /// </summary>
+    /// <param name="widget">The TerminalWidget to configure.</param>
+    /// <param name="configure">Optional callback to customize the default bindings.</param>
+    /// <returns>The configured TerminalWidget.</returns>
+    /// <example>
+    /// <description>Enable copy mode with default vi-style bindings:</description>
+    /// <code>
+    /// ctx.Terminal(handle).CopyModeBindings().Fill()
+    /// </code>
+    /// </example>
+    /// <example>
+    /// <description>Customize the entry key:</description>
+    /// <code>
+    /// ctx.Terminal(handle).CopyModeBindings(options =>
+    /// {
+    ///     options.EnterKeys = [Hex1bKey.F5];
+    /// }).Fill()
+    /// </code>
+    /// </example>
+    public static TerminalWidget CopyModeBindings(
+        this TerminalWidget widget,
+        Action<CopyModeBindingsOptions>? configure = null)
+    {
+        var options = new CopyModeBindingsOptions();
+        configure?.Invoke(options);
+        return widget with { CopyModeOptions = options };
+    }
 }

--- a/src/Hex1b/TerminalSelection.cs
+++ b/src/Hex1b/TerminalSelection.cs
@@ -1,0 +1,320 @@
+namespace Hex1b;
+
+/// <summary>
+/// Specifies how text is selected within a terminal buffer.
+/// </summary>
+public enum SelectionMode
+{
+    /// <summary>
+    /// Character-level selection: selects contiguous characters from anchor to cursor,
+    /// wrapping across rows.
+    /// </summary>
+    Character,
+
+    /// <summary>
+    /// Line-level selection: selects entire rows from the anchor row to the cursor row.
+    /// </summary>
+    Line,
+
+    /// <summary>
+    /// Block/rectangular selection: selects a rectangle defined by the anchor and cursor
+    /// columns across all rows between them.
+    /// </summary>
+    Block
+}
+
+/// <summary>
+/// Represents a position in the terminal's virtual buffer, which unifies
+/// scrollback rows (numbered 0..N-1, oldest to newest) and screen rows
+/// (numbered N..N+H-1).
+/// </summary>
+/// <param name="Row">The virtual row index (0-based, scrollback rows first, then screen rows).</param>
+/// <param name="Column">The column index (0-based).</param>
+public readonly record struct BufferPosition(int Row, int Column) : IComparable<BufferPosition>
+{
+    /// <inheritdoc />
+    public int CompareTo(BufferPosition other)
+    {
+        int rowCmp = Row.CompareTo(other.Row);
+        return rowCmp != 0 ? rowCmp : Column.CompareTo(other.Column);
+    }
+
+    /// <summary>Returns true if this position is before the other position.</summary>
+    public bool IsBefore(BufferPosition other) => CompareTo(other) < 0;
+
+    /// <summary>Returns true if this position is after the other position.</summary>
+    public bool IsAfter(BufferPosition other) => CompareTo(other) > 0;
+
+    /// <inheritdoc />
+    public static bool operator <(BufferPosition left, BufferPosition right) => left.CompareTo(right) < 0;
+    /// <inheritdoc />
+    public static bool operator >(BufferPosition left, BufferPosition right) => left.CompareTo(right) > 0;
+    /// <inheritdoc />
+    public static bool operator <=(BufferPosition left, BufferPosition right) => left.CompareTo(right) <= 0;
+    /// <inheritdoc />
+    public static bool operator >=(BufferPosition left, BufferPosition right) => left.CompareTo(right) >= 0;
+}
+
+/// <summary>
+/// Tracks the current text selection state within a terminal buffer.
+/// </summary>
+/// <remarks>
+/// The selection operates on a "virtual buffer" that unifies scrollback and screen rows.
+/// Scrollback rows are indexed 0..scrollbackCount-1, and screen rows are indexed
+/// scrollbackCount..scrollbackCount+screenHeight-1.
+/// </remarks>
+public sealed class TerminalSelection
+{
+    /// <summary>
+    /// The position where the selection was started.
+    /// </summary>
+    public BufferPosition Anchor { get; private set; }
+
+    /// <summary>
+    /// The current cursor position (the moving end of the selection).
+    /// </summary>
+    public BufferPosition Cursor { get; private set; }
+
+    /// <summary>
+    /// The selection mode (character, line, or block).
+    /// </summary>
+    public SelectionMode Mode { get; private set; }
+
+    /// <summary>
+    /// Whether a selection range is active (anchor has been set and cursor is moving).
+    /// When false, only the cursor is positioned but no text is selected.
+    /// </summary>
+    public bool IsSelecting { get; private set; }
+
+    /// <summary>
+    /// Creates a new selection with the cursor at the specified position.
+    /// No text is selected until <see cref="StartSelection"/> is called.
+    /// </summary>
+    public TerminalSelection(BufferPosition initialPosition)
+    {
+        Cursor = initialPosition;
+        Anchor = initialPosition;
+    }
+
+    /// <summary>
+    /// Moves the cursor to the specified position. If selecting, extends the selection.
+    /// </summary>
+    public void MoveCursor(BufferPosition position)
+    {
+        Cursor = position;
+    }
+
+    /// <summary>
+    /// Begins a selection at the current cursor position.
+    /// </summary>
+    public void StartSelection(SelectionMode mode = SelectionMode.Character)
+    {
+        Anchor = Cursor;
+        Mode = mode;
+        IsSelecting = true;
+    }
+
+    /// <summary>
+    /// Toggles between selection modes. If the requested mode is already active,
+    /// switches back to character mode.
+    /// </summary>
+    public void ToggleMode(SelectionMode mode)
+    {
+        if (!IsSelecting)
+        {
+            StartSelection(mode);
+            return;
+        }
+
+        Mode = Mode == mode ? SelectionMode.Character : mode;
+    }
+
+    /// <summary>
+    /// Clears the selection but keeps the cursor position.
+    /// </summary>
+    public void ClearSelection()
+    {
+        IsSelecting = false;
+    }
+
+    /// <summary>
+    /// Gets the start (earlier) position of the selection.
+    /// </summary>
+    public BufferPosition Start => Anchor <= Cursor ? Anchor : Cursor;
+
+    /// <summary>
+    /// Gets the end (later) position of the selection.
+    /// </summary>
+    public BufferPosition End => Anchor <= Cursor ? Cursor : Anchor;
+
+    /// <summary>
+    /// Determines whether the specified cell position is within the current selection.
+    /// </summary>
+    /// <param name="row">The virtual row index.</param>
+    /// <param name="column">The column index.</param>
+    /// <returns>True if the cell is selected.</returns>
+    public bool IsCellSelected(int row, int column)
+    {
+        if (!IsSelecting) return false;
+
+        var start = Start;
+        var end = End;
+
+        return Mode switch
+        {
+            SelectionMode.Character => IsCellInCharacterSelection(row, column, start, end),
+            SelectionMode.Line => row >= start.Row && row <= end.Row,
+            SelectionMode.Block => IsCellInBlockSelection(row, column, start, end),
+            _ => false
+        };
+    }
+
+    private static bool IsCellInCharacterSelection(int row, int column, BufferPosition start, BufferPosition end)
+    {
+        if (row < start.Row || row > end.Row) return false;
+        if (start.Row == end.Row) return column >= start.Column && column <= end.Column;
+        if (row == start.Row) return column >= start.Column;
+        if (row == end.Row) return column <= end.Column;
+        return true; // middle rows are fully selected
+    }
+
+    private static bool IsCellInBlockSelection(int row, int column, BufferPosition start, BufferPosition end)
+    {
+        if (row < start.Row || row > end.Row) return false;
+        int minCol = Math.Min(start.Column, end.Column);
+        int maxCol = Math.Max(start.Column, end.Column);
+        return column >= minCol && column <= maxCol;
+    }
+
+    /// <summary>
+    /// Extracts the selected text from a virtual buffer.
+    /// </summary>
+    /// <param name="getCell">Function to get a cell at (virtualRow, column). Returns null for out-of-bounds.</param>
+    /// <param name="bufferWidth">The width of the buffer (columns per row).</param>
+    /// <returns>The selected text, or null if no selection is active.</returns>
+    public string? ExtractText(Func<int, int, TerminalCell?> getCell, int bufferWidth)
+    {
+        if (!IsSelecting) return null;
+
+        var start = Start;
+        var end = End;
+
+        return Mode switch
+        {
+            SelectionMode.Character => ExtractCharacterText(getCell, bufferWidth, start, end),
+            SelectionMode.Line => ExtractLineText(getCell, bufferWidth, start.Row, end.Row),
+            SelectionMode.Block => ExtractBlockText(getCell, start, end),
+            _ => null
+        };
+    }
+
+    private static string ExtractCharacterText(
+        Func<int, int, TerminalCell?> getCell, int bufferWidth,
+        BufferPosition start, BufferPosition end)
+    {
+        var sb = new System.Text.StringBuilder();
+
+        for (int row = start.Row; row <= end.Row; row++)
+        {
+            int startCol = row == start.Row ? start.Column : 0;
+            int endCol = row == end.Row ? end.Column : bufferWidth - 1;
+
+            // Check for soft wrap on the last cell of this row
+            bool isSoftWrapped = false;
+            if (row < end.Row)
+            {
+                var lastCell = getCell(row, bufferWidth - 1);
+                isSoftWrapped = lastCell?.IsSoftWrap ?? false;
+            }
+
+            AppendRowSegment(sb, getCell, row, startCol, endCol, trimTrailing: !isSoftWrapped);
+
+            // Add newline between rows unless soft-wrapped
+            if (row < end.Row && !isSoftWrapped)
+            {
+                sb.AppendLine();
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static string ExtractLineText(
+        Func<int, int, TerminalCell?> getCell, int bufferWidth,
+        int startRow, int endRow)
+    {
+        var sb = new System.Text.StringBuilder();
+
+        for (int row = startRow; row <= endRow; row++)
+        {
+            bool isSoftWrapped = false;
+            if (row < endRow)
+            {
+                var lastCell = getCell(row, bufferWidth - 1);
+                isSoftWrapped = lastCell?.IsSoftWrap ?? false;
+            }
+
+            AppendRowSegment(sb, getCell, row, 0, bufferWidth - 1, trimTrailing: !isSoftWrapped);
+
+            if (row < endRow && !isSoftWrapped)
+            {
+                sb.AppendLine();
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static string ExtractBlockText(
+        Func<int, int, TerminalCell?> getCell,
+        BufferPosition start, BufferPosition end)
+    {
+        var sb = new System.Text.StringBuilder();
+        int minCol = Math.Min(start.Column, end.Column);
+        int maxCol = Math.Max(start.Column, end.Column);
+
+        for (int row = start.Row; row <= end.Row; row++)
+        {
+            AppendRowSegment(sb, getCell, row, minCol, maxCol);
+
+            if (row < end.Row)
+            {
+                sb.AppendLine();
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static void AppendRowSegment(
+        System.Text.StringBuilder sb, Func<int, int, TerminalCell?> getCell,
+        int row, int startCol, int endCol, bool trimTrailing = true)
+    {
+        // Build the row content
+        int segmentStart = sb.Length;
+
+        for (int col = startCol; col <= endCol; col++)
+        {
+            var cell = getCell(row, col);
+            if (cell == null) break;
+
+            var ch = cell.Value.Character;
+
+            // Skip wide character padding cells (empty string or null-like)
+            if (string.IsNullOrEmpty(ch)) continue;
+
+            sb.Append(ch);
+        }
+
+        // Trim trailing whitespace from this row segment
+        if (trimTrailing)
+        {
+            int segmentEnd = sb.Length;
+            while (segmentEnd > segmentStart && sb[segmentEnd - 1] == ' ')
+            {
+                segmentEnd--;
+            }
+            sb.Length = segmentEnd;
+        }
+    }
+}

--- a/src/Hex1b/TerminalWidgetHandle.cs
+++ b/src/Hex1b/TerminalWidgetHandle.cs
@@ -1017,6 +1017,7 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
                         _selection.ToggleMode(mode);
                     }
                     _selection.MoveCursor(new BufferPosition(virtualRow, column));
+                    EnsureCopyModeCursorVisible();
                     OutputReceived?.Invoke();
                 }
                 break;

--- a/src/Hex1b/TerminalWidgetHandle.cs
+++ b/src/Hex1b/TerminalWidgetHandle.cs
@@ -88,6 +88,11 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
     private TerminalState _state = TerminalState.NotStarted;
     private int? _exitCode;
     
+    // Copy mode state: when active, output is queued instead of applied
+    private bool _inCopyMode;
+    private TerminalSelection? _selection;
+    private List<IReadOnlyList<AppliedToken>>? _outputQueue;
+    
     /// <summary>
     /// Creates a new TerminalWidgetHandle with the specified dimensions.
     /// </summary>
@@ -161,6 +166,29 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
     /// Gets whether the terminal is currently running.
     /// </summary>
     public bool IsRunning => _state == TerminalState.Running;
+    
+    /// <summary>
+    /// Gets whether copy mode is currently active. When active, output from the child
+    /// process is queued rather than applied to the screen buffer, and the selection
+    /// cursor can be navigated independently.
+    /// </summary>
+    public bool IsInCopyMode => _inCopyMode;
+    
+    /// <summary>
+    /// Gets the current text selection, or null if copy mode is not active.
+    /// </summary>
+    public TerminalSelection? Selection => _selection;
+    
+    /// <summary>
+    /// Raised when copy mode is entered or exited.
+    /// </summary>
+    public event Action<bool>? CopyModeChanged;
+    
+    /// <summary>
+    /// Raised when text is copied via copy mode. Subscribers should send the text
+    /// to the system clipboard (e.g., via OSC 52).
+    /// </summary>
+    public event Action<string>? TextCopied;
     
     /// <summary>
     /// Gets the current window title set by OSC 0 or OSC 2 sequences from the child process.
@@ -527,8 +555,34 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
         if (_disposed || appliedTokens.Count == 0) 
             return ValueTask.CompletedTask;
         
+        lock (_bufferLock)
+        {
+            if (_inCopyMode && _outputQueue != null)
+            {
+                // Queue output for later application — buffer is frozen during copy mode.
+                // Still process mode tokens (mouse tracking, alternate screen) immediately
+                // so state is correct when copy mode exits.
+                foreach (var applied in appliedTokens)
+                {
+                    if (applied.Token is PrivateModeToken pm)
+                        HandlePrivateModeToken(pm);
+                    else if (applied.Token is CursorShapeToken cst)
+                        HandleCursorShapeToken(cst);
+                    else if (applied.Token is OscToken osc)
+                        HandleOscToken(osc);
+                }
+                _outputQueue.Add(appliedTokens);
+                return ValueTask.CompletedTask;
+            }
+        }
+        
+        ApplyTokensToBuffer(appliedTokens);
+        return ValueTask.CompletedTask;
+    }
+    
+    private void ApplyTokensToBuffer(IReadOnlyList<AppliedToken> appliedTokens)
+    {
         int maxY = -1;
-        int droppedCount = 0;
         lock (_bufferLock)
         {
             foreach (var applied in appliedTokens)
@@ -540,16 +594,7 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
                 }
                 else if (applied.Token is CursorShapeToken cst)
                 {
-                    _cursorShape = cst.Shape switch
-                    {
-                        1 => CursorShape.BlinkingBlock,
-                        2 => CursorShape.SteadyBlock,
-                        3 => CursorShape.BlinkingUnderline,
-                        4 => CursorShape.SteadyUnderline,
-                        5 => CursorShape.BlinkingBar,
-                        6 => CursorShape.SteadyBar,
-                        _ => CursorShape.Default
-                    };
+                    HandleCursorShapeToken(cst);
                 }
                 else if (applied.Token is OscToken osc)
                 {
@@ -564,10 +609,6 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
                         _screenBuffer[impact.Y, impact.X] = impact.Cell;
                         if (impact.Y > maxY) maxY = impact.Y;
                     }
-                    else if (impact.Y >= _height)
-                    {
-                        droppedCount++;
-                    }
                 }
                 
                 // Update cursor position from the last token
@@ -577,13 +618,24 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
         }
         
         // Only notify bound nodes when there are actual cell changes
-        // Cursor-only updates don't require a full repaint - RenderCursor handles that
         if (maxY >= 0)
         {
             OutputReceived?.Invoke();
         }
-        
-        return ValueTask.CompletedTask;
+    }
+    
+    private void HandleCursorShapeToken(CursorShapeToken cst)
+    {
+        _cursorShape = cst.Shape switch
+        {
+            1 => CursorShape.BlinkingBlock,
+            2 => CursorShape.SteadyBlock,
+            3 => CursorShape.BlinkingUnderline,
+            4 => CursorShape.SteadyUnderline,
+            5 => CursorShape.BlinkingBar,
+            6 => CursorShape.SteadyBar,
+            _ => CursorShape.Default
+        };
     }
     
     /// <inheritdoc />
@@ -658,6 +710,152 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
         
         Resized?.Invoke(newWidth, newHeight);
     }
+    
+    // === Copy Mode ===
+    
+    /// <summary>
+    /// Enters copy mode: freezes the screen buffer and begins queuing output.
+    /// The copy mode cursor starts at the bottom-right of the visible screen.
+    /// </summary>
+    public void EnterCopyMode()
+    {
+        lock (_bufferLock)
+        {
+            if (_inCopyMode) return;
+            
+            _inCopyMode = true;
+            _outputQueue = new List<IReadOnlyList<AppliedToken>>();
+            
+            // Position cursor at bottom-left of screen in virtual coordinates
+            int scrollbackCount = ScrollbackCount;
+            var initialPosition = new BufferPosition(scrollbackCount + _height - 1, 0);
+            _selection = new TerminalSelection(initialPosition);
+        }
+        
+        CopyModeChanged?.Invoke(true);
+        OutputReceived?.Invoke(); // trigger re-render to show copy mode cursor
+    }
+    
+    /// <summary>
+    /// Exits copy mode: flushes all queued output to the screen buffer and clears the selection.
+    /// </summary>
+    public void ExitCopyMode()
+    {
+        List<IReadOnlyList<AppliedToken>>? pendingQueue;
+        
+        lock (_bufferLock)
+        {
+            if (!_inCopyMode) return;
+            
+            _inCopyMode = false;
+            _selection = null;
+            pendingQueue = _outputQueue;
+            _outputQueue = null;
+        }
+        
+        // Flush queued output outside the lock
+        if (pendingQueue != null)
+        {
+            foreach (var tokens in pendingQueue)
+            {
+                // Re-enter the normal output path
+                ApplyTokensToBuffer(tokens);
+            }
+        }
+        
+        CopyModeChanged?.Invoke(false);
+        OutputReceived?.Invoke();
+    }
+    
+    /// <summary>
+    /// Copies the currently selected text and exits copy mode.
+    /// Raises <see cref="TextCopied"/> with the selected text.
+    /// </summary>
+    /// <returns>The selected text, or null if no selection is active.</returns>
+    public string? CopySelection()
+    {
+        string? text;
+        
+        lock (_bufferLock)
+        {
+            if (!_inCopyMode || _selection == null || !_selection.IsSelecting)
+            {
+                text = null;
+            }
+            else
+            {
+                text = _selection.ExtractText(GetVirtualCellUnlocked, _width);
+            }
+        }
+        
+        ExitCopyMode();
+        
+        if (text != null)
+        {
+            TextCopied?.Invoke(text);
+        }
+        
+        return text;
+    }
+    
+    /// <summary>
+    /// Gets the copy mode cursor position in virtual buffer coordinates, or null if not in copy mode.
+    /// </summary>
+    public BufferPosition? CopyModeCursorPosition
+    {
+        get
+        {
+            lock (_bufferLock)
+            {
+                return _selection?.Cursor;
+            }
+        }
+    }
+    
+    /// <summary>
+    /// Gets a cell from the virtual buffer (scrollback + screen unified view).
+    /// Virtual row 0 is the oldest scrollback row; scrollbackCount+screenHeight-1 is the last screen row.
+    /// </summary>
+    /// <param name="virtualRow">The virtual row index.</param>
+    /// <param name="column">The column index.</param>
+    /// <returns>The cell at that position, or null if out of bounds.</returns>
+    public TerminalCell? GetVirtualCell(int virtualRow, int column)
+    {
+        lock (_bufferLock)
+        {
+            return GetVirtualCellUnlocked(virtualRow, column);
+        }
+    }
+    
+    private TerminalCell? GetVirtualCellUnlocked(int virtualRow, int column)
+    {
+        int scrollbackCount = ScrollbackCount;
+        
+        if (virtualRow < 0) return null;
+        if (column < 0 || column >= _width) return null;
+        
+        if (virtualRow < scrollbackCount)
+        {
+            // Scrollback region
+            var rows = _terminal?.GetScrollbackRows(scrollbackCount);
+            if (rows == null || virtualRow >= rows.Length) return null;
+            var cells = rows[virtualRow].Cells;
+            if (column >= cells.Length) return TerminalCell.Empty;
+            return cells[column];
+        }
+        else
+        {
+            // Screen region
+            int screenRow = virtualRow - scrollbackCount;
+            if (screenRow >= _height) return null;
+            return _screenBuffer[screenRow, column];
+        }
+    }
+    
+    /// <summary>
+    /// Gets the total number of rows in the virtual buffer (scrollback + screen).
+    /// </summary>
+    public int VirtualBufferHeight => ScrollbackCount + _height;
     
     /// <inheritdoc />
     public ValueTask DisposeAsync()

--- a/src/Hex1b/TerminalWidgetHandle.cs
+++ b/src/Hex1b/TerminalWidgetHandle.cs
@@ -754,6 +754,7 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
     /// </summary>
     public void ExitCopyMode()
     {
+        StopDragScrollTimer();
         List<IReadOnlyList<AppliedToken>>? pendingQueue;
         
         lock (_bufferLock)
@@ -973,10 +974,17 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
     // Pending mouse selection anchor — set on Down, used on first Drag
     private BufferPosition? _pendingMouseAnchor;
     
+    // Auto-scroll timer for drag-outside-bounds
+    private Timer? _dragScrollTimer;
+    private int _dragScrollDirection; // -1 = up, +1 = down, 0 = none
+    private int _dragLastColumn;
+    private SelectionMode _dragLastMode;
+    
     /// <summary>
     /// Handles mouse-driven selection. Translates local terminal coordinates to virtual
     /// buffer positions and manages the selection state machine (down/drag/up).
     /// Only enters copy mode when the user actually drags (not on a single click).
+    /// When dragging outside the viewport, auto-scrolls every 500ms.
     /// </summary>
     /// <param name="localX">X coordinate relative to the terminal widget bounds.</param>
     /// <param name="localY">Y coordinate relative to the terminal widget bounds.</param>
@@ -994,6 +1002,7 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
             case Input.MouseAction.Down:
                 // Record anchor position — don't enter copy mode yet (wait for drag)
                 _pendingMouseAnchor = new BufferPosition(virtualRow, column);
+                StopDragScrollTimer();
                 break;
                 
             case Input.MouseAction.Drag:
@@ -1019,15 +1028,65 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
                     _selection.MoveCursor(new BufferPosition(virtualRow, column));
                     EnsureCopyModeCursorVisible();
                     OutputReceived?.Invoke();
+                    
+                    // Start/stop auto-scroll timer based on whether mouse is out of bounds
+                    if (localY < 0)
+                    {
+                        StartDragScrollTimer(-1, column, mode);
+                    }
+                    else if (localY >= _height)
+                    {
+                        StartDragScrollTimer(1, column, mode);
+                    }
+                    else
+                    {
+                        StopDragScrollTimer();
+                    }
                 }
                 break;
                 
             case Input.MouseAction.Up:
                 _pendingMouseAnchor = null;
+                StopDragScrollTimer();
                 // Selection stays active — user can refine with keyboard or press y to copy
                 OutputReceived?.Invoke();
                 break;
         }
+    }
+    
+    private void StartDragScrollTimer(int direction, int column, SelectionMode mode)
+    {
+        _dragScrollDirection = direction;
+        _dragLastColumn = column;
+        _dragLastMode = mode;
+        
+        if (_dragScrollTimer == null)
+        {
+            _dragScrollTimer = new Timer(DragScrollTick, null, 500, 500);
+        }
+    }
+    
+    private void StopDragScrollTimer()
+    {
+        _dragScrollTimer?.Dispose();
+        _dragScrollTimer = null;
+        _dragScrollDirection = 0;
+    }
+    
+    private void DragScrollTick(object? state)
+    {
+        if (!_inCopyMode || _selection == null || _dragScrollDirection == 0) 
+        {
+            StopDragScrollTimer();
+            return;
+        }
+        
+        // Move cursor one row in the scroll direction
+        var pos = _selection.Cursor;
+        int newRow = Math.Clamp(pos.Row + _dragScrollDirection, 0, VirtualBufferHeight - 1);
+        _selection.MoveCursor(new BufferPosition(newRow, _dragLastColumn));
+        EnsureCopyModeCursorVisible();
+        OutputReceived?.Invoke();
     }
     
     /// <summary>
@@ -1095,6 +1154,7 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
         if (_disposed) return ValueTask.CompletedTask;
         _disposed = true;
         
+        StopDragScrollTimer();
         Disconnected?.Invoke();
         _disconnected.TrySetResult();
         

--- a/src/Hex1b/TerminalWidgetHandle.cs
+++ b/src/Hex1b/TerminalWidgetHandle.cs
@@ -763,6 +763,7 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
             
             _inCopyMode = false;
             _selection = null;
+            _scrollbackOffset = 0; // snap back to live view
             pendingQueue = _outputQueue;
             _outputQueue = null;
         }

--- a/src/Hex1b/TerminalWidgetHandle.cs
+++ b/src/Hex1b/TerminalWidgetHandle.cs
@@ -799,6 +799,137 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
     }
     
     /// <summary>
+    /// Raised when a key is pressed while in copy mode. The consumer handles the key
+    /// mapping (e.g., vi keys, arrow keys) and calls the appropriate navigation/selection
+    /// methods on this handle. The bool parameter should be set to true if the key was handled.
+    /// </summary>
+    public event Func<Hex1bEvent, bool>? CopyModeInput;
+    
+    /// <summary>
+    /// Invokes the <see cref="CopyModeInput"/> handler for the given input event.
+    /// Returns true if the event was handled by a subscriber.
+    /// </summary>
+    internal bool RaiseCopyModeInput(Hex1bEvent inputEvent)
+    {
+        return CopyModeInput?.Invoke(inputEvent) ?? false;
+    }
+    
+    /// <summary>
+    /// Moves the copy mode cursor by the specified row and column deltas.
+    /// Clamps to buffer bounds.
+    /// </summary>
+    public void MoveCopyModeCursor(int rowDelta, int colDelta)
+    {
+        if (_selection == null) return;
+        var pos = _selection.Cursor;
+        int maxRow = VirtualBufferHeight - 1;
+        int maxCol = _width - 1;
+        var newPos = new BufferPosition(
+            Math.Clamp(pos.Row + rowDelta, 0, maxRow),
+            Math.Clamp(pos.Column + colDelta, 0, maxCol));
+        _selection.MoveCursor(newPos);
+        OutputReceived?.Invoke();
+    }
+    
+    /// <summary>
+    /// Moves the copy mode cursor to an absolute position.
+    /// Clamps to buffer bounds.
+    /// </summary>
+    public void SetCopyModeCursorPosition(int row, int column)
+    {
+        if (_selection == null) return;
+        int maxRow = VirtualBufferHeight - 1;
+        int maxCol = _width - 1;
+        _selection.MoveCursor(new BufferPosition(
+            Math.Clamp(row, 0, maxRow),
+            Math.Clamp(column, 0, maxCol)));
+        OutputReceived?.Invoke();
+    }
+    
+    /// <summary>
+    /// Starts or toggles selection in the specified mode.
+    /// If already selecting in the same mode, clears the selection.
+    /// </summary>
+    public void StartOrToggleSelection(SelectionMode mode)
+    {
+        if (_selection == null) return;
+        if (_selection.IsSelecting && _selection.Mode == mode)
+            _selection.ClearSelection();
+        else if (_selection.IsSelecting)
+            _selection.ToggleMode(mode);
+        else
+            _selection.StartSelection(mode);
+        OutputReceived?.Invoke();
+    }
+    
+    /// <summary>
+    /// Moves the copy mode cursor forward to the next word boundary.
+    /// </summary>
+    public void MoveWordForward()
+    {
+        if (_selection == null) return;
+        var pos = _selection.Cursor;
+        int maxRow = VirtualBufferHeight - 1;
+        int row = pos.Row, col = pos.Column;
+        
+        // Skip current word (non-space characters)
+        while (row <= maxRow)
+        {
+            var cell = GetVirtualCell(row, col);
+            if (cell == null || string.IsNullOrWhiteSpace(cell.Value.Character)) break;
+            col++;
+            if (col >= _width) { col = 0; row++; }
+        }
+        // Skip whitespace
+        while (row <= maxRow)
+        {
+            var cell = GetVirtualCell(row, col);
+            if (cell == null) break;
+            if (!string.IsNullOrWhiteSpace(cell.Value.Character)) break;
+            col++;
+            if (col >= _width) { col = 0; row++; }
+        }
+        
+        _selection.MoveCursor(new BufferPosition(Math.Min(row, maxRow), col));
+        OutputReceived?.Invoke();
+    }
+    
+    /// <summary>
+    /// Moves the copy mode cursor backward to the previous word boundary.
+    /// </summary>
+    public void MoveWordBackward()
+    {
+        if (_selection == null) return;
+        var pos = _selection.Cursor;
+        int row = pos.Row, col = pos.Column;
+        
+        col--;
+        if (col < 0) { col = _width - 1; row--; }
+        if (row < 0) { _selection.MoveCursor(new BufferPosition(0, 0)); OutputReceived?.Invoke(); return; }
+        
+        // Skip whitespace
+        while (row >= 0)
+        {
+            var cell = GetVirtualCell(row, col);
+            if (cell == null) break;
+            if (!string.IsNullOrWhiteSpace(cell.Value.Character)) break;
+            col--;
+            if (col < 0) { col = _width - 1; row--; }
+        }
+        // Skip word
+        while (row >= 0)
+        {
+            var cell = GetVirtualCell(row, col);
+            if (cell == null || string.IsNullOrWhiteSpace(cell.Value.Character)) { col++; break; }
+            col--;
+            if (col < 0) { col = _width - 1; row--; }
+        }
+        
+        _selection.MoveCursor(new BufferPosition(Math.Max(row, 0), Math.Clamp(col, 0, _width - 1)));
+        OutputReceived?.Invoke();
+    }
+    
+    /// <summary>
     /// Gets the copy mode cursor position in virtual buffer coordinates, or null if not in copy mode.
     /// </summary>
     public BufferPosition? CopyModeCursorPosition

--- a/src/Hex1b/TerminalWidgetHandle.cs
+++ b/src/Hex1b/TerminalWidgetHandle.cs
@@ -829,7 +829,7 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
     
     /// <summary>
     /// Moves the copy mode cursor by the specified row and column deltas.
-    /// Clamps to buffer bounds.
+    /// Clamps to buffer bounds and scrolls the viewport to keep the cursor visible.
     /// </summary>
     public void MoveCopyModeCursor(int rowDelta, int colDelta)
     {
@@ -841,12 +841,13 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
             Math.Clamp(pos.Row + rowDelta, 0, maxRow),
             Math.Clamp(pos.Column + colDelta, 0, maxCol));
         _selection.MoveCursor(newPos);
+        EnsureCopyModeCursorVisible();
         OutputReceived?.Invoke();
     }
     
     /// <summary>
     /// Moves the copy mode cursor to an absolute position.
-    /// Clamps to buffer bounds.
+    /// Clamps to buffer bounds and scrolls the viewport to keep the cursor visible.
     /// </summary>
     public void SetCopyModeCursorPosition(int row, int column)
     {
@@ -856,6 +857,7 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
         _selection.MoveCursor(new BufferPosition(
             Math.Clamp(row, 0, maxRow),
             Math.Clamp(column, 0, maxCol)));
+        EnsureCopyModeCursorVisible();
         OutputReceived?.Invoke();
     }
     
@@ -904,6 +906,7 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
         }
         
         _selection.MoveCursor(new BufferPosition(Math.Min(row, maxRow), col));
+        EnsureCopyModeCursorVisible();
         OutputReceived?.Invoke();
     }
     
@@ -939,7 +942,32 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
         }
         
         _selection.MoveCursor(new BufferPosition(Math.Max(row, 0), Math.Clamp(col, 0, _width - 1)));
+        EnsureCopyModeCursorVisible();
         OutputReceived?.Invoke();
+    }
+    
+    /// <summary>
+    /// Adjusts the scrollback offset so the copy mode cursor is within the visible viewport.
+    /// </summary>
+    private void EnsureCopyModeCursorVisible()
+    {
+        if (_selection == null) return;
+        int cursorRow = _selection.Cursor.Row;
+        int scrollbackCount = ScrollbackCount;
+        
+        // Visible virtual row range: [viewStart, viewStart + _height - 1]
+        int viewStart = scrollbackCount - _scrollbackOffset;
+        int viewEnd = viewStart + _height - 1;
+        
+        if (cursorRow < viewStart)
+        {
+            _scrollbackOffset = scrollbackCount - cursorRow;
+        }
+        else if (cursorRow > viewEnd)
+        {
+            _scrollbackOffset = scrollbackCount - (cursorRow - _height + 1);
+        }
+        _scrollbackOffset = Math.Max(0, _scrollbackOffset);
     }
     
     // Pending mouse selection anchor — set on Down, used on first Drag

--- a/src/Hex1b/TerminalWidgetHandle.cs
+++ b/src/Hex1b/TerminalWidgetHandle.cs
@@ -93,6 +93,9 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
     private TerminalSelection? _selection;
     private List<IReadOnlyList<AppliedToken>>? _outputQueue;
     
+    // Scrollback offset tracked by the TerminalNode, synced here for mouse coordinate translation
+    private int _scrollbackOffset;
+    
     /// <summary>
     /// Creates a new TerminalWidgetHandle with the specified dimensions.
     /// </summary>
@@ -183,6 +186,16 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
     /// Raised when copy mode is entered or exited.
     /// </summary>
     public event Action<bool>? CopyModeChanged;
+    
+    /// <summary>
+    /// Gets or sets the current scrollback offset, synced from the TerminalNode.
+    /// Used for translating mouse coordinates to virtual buffer positions.
+    /// </summary>
+    public int CurrentScrollbackOffset
+    {
+        get => _scrollbackOffset;
+        set => _scrollbackOffset = value;
+    }
     
     /// <summary>
     /// Raised when text is copied via copy mode. Subscribers should send the text
@@ -927,6 +940,54 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
         
         _selection.MoveCursor(new BufferPosition(Math.Max(row, 0), Math.Clamp(col, 0, _width - 1)));
         OutputReceived?.Invoke();
+    }
+    
+    /// <summary>
+    /// Handles mouse-driven selection. Translates local terminal coordinates to virtual
+    /// buffer positions and manages the selection state machine (down/drag/up).
+    /// </summary>
+    /// <param name="localX">X coordinate relative to the terminal widget bounds.</param>
+    /// <param name="localY">Y coordinate relative to the terminal widget bounds.</param>
+    /// <param name="action">The mouse action (Down starts, Drag extends, Up finalizes).</param>
+    /// <param name="mode">The selection mode to use.</param>
+    public void MouseSelect(int localX, int localY, Input.MouseAction action, SelectionMode mode)
+    {
+        int scrollbackCount = ScrollbackCount;
+        int virtualRow = scrollbackCount - _scrollbackOffset + localY;
+        int column = Math.Clamp(localX, 0, _width - 1);
+        virtualRow = Math.Clamp(virtualRow, 0, VirtualBufferHeight - 1);
+        
+        switch (action)
+        {
+            case Input.MouseAction.Down:
+                if (!_inCopyMode)
+                {
+                    EnterCopyMode();
+                }
+                // Set anchor at click position and start selection
+                _selection?.MoveCursor(new BufferPosition(virtualRow, column));
+                _selection?.StartSelection(mode);
+                OutputReceived?.Invoke();
+                break;
+                
+            case Input.MouseAction.Drag:
+                if (_selection != null && _inCopyMode)
+                {
+                    // If selection mode changed (modifier changed mid-drag), update it
+                    if (_selection.IsSelecting && _selection.Mode != mode)
+                    {
+                        _selection.ToggleMode(mode);
+                    }
+                    _selection.MoveCursor(new BufferPosition(virtualRow, column));
+                    OutputReceived?.Invoke();
+                }
+                break;
+                
+            case Input.MouseAction.Up:
+                // Selection stays active — user can refine with keyboard or press y to copy
+                OutputReceived?.Invoke();
+                break;
+        }
     }
     
     /// <summary>

--- a/src/Hex1b/TerminalWidgetHandle.cs
+++ b/src/Hex1b/TerminalWidgetHandle.cs
@@ -726,9 +726,9 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
             _inCopyMode = true;
             _outputQueue = new List<IReadOnlyList<AppliedToken>>();
             
-            // Position cursor at bottom-left of screen in virtual coordinates
+            // Position cursor at the terminal's current cursor position in virtual coordinates
             int scrollbackCount = ScrollbackCount;
-            var initialPosition = new BufferPosition(scrollbackCount + _height - 1, 0);
+            var initialPosition = new BufferPosition(scrollbackCount + _cursorY, _cursorX);
             _selection = new TerminalSelection(initialPosition);
         }
         

--- a/src/Hex1b/TerminalWidgetHandle.cs
+++ b/src/Hex1b/TerminalWidgetHandle.cs
@@ -1062,7 +1062,7 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
         
         if (_dragScrollTimer == null)
         {
-            _dragScrollTimer = new Timer(DragScrollTick, null, 500, 500);
+            _dragScrollTimer = new Timer(DragScrollTick, null, 100, 100);
         }
     }
     

--- a/src/Hex1b/TerminalWidgetHandle.cs
+++ b/src/Hex1b/TerminalWidgetHandle.cs
@@ -188,6 +188,28 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
     public event Action<bool>? CopyModeChanged;
     
     /// <summary>
+    /// Gets the current copy mode state.
+    /// </summary>
+    public CopyModeState CopyModeState { get; private set; }
+    
+    /// <summary>
+    /// Updates <see cref="CopyModeState"/> based on current selection state.
+    /// Called by the copy mode helper after state changes.
+    /// </summary>
+    internal void UpdateCopyModeState()
+    {
+        CopyModeState = !_inCopyMode ? CopyModeState.Inactive
+            : _selection is { IsSelecting: true } sel ? sel.Mode switch
+            {
+                SelectionMode.Character => CopyModeState.CharacterSelection,
+                SelectionMode.Line => CopyModeState.LineSelection,
+                SelectionMode.Block => CopyModeState.BlockSelection,
+                _ => CopyModeState.Active
+            }
+            : CopyModeState.Active;
+    }
+    
+    /// <summary>
     /// Gets or sets the current scrollback offset, synced from the TerminalNode.
     /// Used for translating mouse coordinates to virtual buffer positions.
     /// </summary>

--- a/src/Hex1b/TerminalWidgetHandle.cs
+++ b/src/Hex1b/TerminalWidgetHandle.cs
@@ -942,13 +942,17 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
         OutputReceived?.Invoke();
     }
     
+    // Pending mouse selection anchor — set on Down, used on first Drag
+    private BufferPosition? _pendingMouseAnchor;
+    
     /// <summary>
     /// Handles mouse-driven selection. Translates local terminal coordinates to virtual
     /// buffer positions and manages the selection state machine (down/drag/up).
+    /// Only enters copy mode when the user actually drags (not on a single click).
     /// </summary>
     /// <param name="localX">X coordinate relative to the terminal widget bounds.</param>
     /// <param name="localY">Y coordinate relative to the terminal widget bounds.</param>
-    /// <param name="action">The mouse action (Down starts, Drag extends, Up finalizes).</param>
+    /// <param name="action">The mouse action (Down records anchor, Drag starts selection, Up finalizes).</param>
     /// <param name="mode">The selection mode to use.</param>
     public void MouseSelect(int localX, int localY, Input.MouseAction action, SelectionMode mode)
     {
@@ -960,17 +964,23 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
         switch (action)
         {
             case Input.MouseAction.Down:
-                if (!_inCopyMode)
-                {
-                    EnterCopyMode();
-                }
-                // Set anchor at click position and start selection
-                _selection?.MoveCursor(new BufferPosition(virtualRow, column));
-                _selection?.StartSelection(mode);
-                OutputReceived?.Invoke();
+                // Record anchor position — don't enter copy mode yet (wait for drag)
+                _pendingMouseAnchor = new BufferPosition(virtualRow, column);
                 break;
                 
             case Input.MouseAction.Drag:
+                if (_pendingMouseAnchor is { } anchor)
+                {
+                    // First drag after mouse down — now enter copy mode and start selection
+                    if (!_inCopyMode)
+                    {
+                        EnterCopyMode();
+                    }
+                    _selection?.MoveCursor(anchor);
+                    _selection?.StartSelection(mode);
+                    _pendingMouseAnchor = null;
+                }
+                
                 if (_selection != null && _inCopyMode)
                 {
                     // If selection mode changed (modifier changed mid-drag), update it
@@ -984,6 +994,7 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
                 break;
                 
             case Input.MouseAction.Up:
+                _pendingMouseAnchor = null;
                 // Selection stays active — user can refine with keyboard or press y to copy
                 OutputReceived?.Invoke();
                 break;

--- a/src/Hex1b/Widgets/ReconcileContext.cs
+++ b/src/Hex1b/Widgets/ReconcileContext.cs
@@ -118,7 +118,8 @@ public sealed class ReconcileContext
         Action? releaseCaptureCallback = null,
         Action<TimeSpan, Action>? scheduleTimerCallback = null,
         WindowManagerRegistry? windowManagerRegistry = null,
-        Action<Func<Hex1bNode, bool>>? requestFocusCallback = null)
+        Action<Func<Hex1bNode, bool>>? requestFocusCallback = null,
+        Action<string>? copyToClipboardCallback = null)
     {
         Parent = parent;
         _ancestors = ancestors ?? Array.Empty<Hex1bNode>();
@@ -131,12 +132,19 @@ public sealed class ReconcileContext
         ScheduleTimerCallback = scheduleTimerCallback;
         WindowManagerRegistry = windowManagerRegistry;
         RequestFocusCallback = requestFocusCallback;
+        CopyToClipboardCallback = copyToClipboardCallback;
     }
 
     /// <summary>
     /// The window manager registry for registering WindowPanels.
     /// </summary>
     internal WindowManagerRegistry? WindowManagerRegistry { get; }
+    
+    /// <summary>
+    /// Callback to copy text to the system clipboard (e.g., via OSC 52).
+    /// Used by TerminalWidget copy mode to automatically wire clipboard support.
+    /// </summary>
+    internal Action<string>? CopyToClipboardCallback { get; }
 
     /// <summary>
     /// Creates a root reconcile context (no parent).
@@ -149,11 +157,12 @@ public sealed class ReconcileContext
         Action? releaseCaptureCallback = null,
         Action<TimeSpan, Action>? scheduleTimerCallback = null,
         WindowManagerRegistry? windowManagerRegistry = null,
-        Action<Func<Hex1bNode, bool>>? requestFocusCallback = null) 
+        Action<Func<Hex1bNode, bool>>? requestFocusCallback = null,
+        Action<string>? copyToClipboardCallback = null) 
         => new(null, focusRing ?? new FocusRing(), cancellationToken, invalidateCallback: invalidateCallback, 
             captureInputCallback: captureInputCallback, releaseCaptureCallback: releaseCaptureCallback,
             scheduleTimerCallback: scheduleTimerCallback, windowManagerRegistry: windowManagerRegistry,
-            requestFocusCallback: requestFocusCallback);
+            requestFocusCallback: requestFocusCallback, copyToClipboardCallback: copyToClipboardCallback);
 
     /// <summary>
     /// Creates a child context with the specified parent.
@@ -165,7 +174,8 @@ public sealed class ReconcileContext
         var newAncestors = new List<Hex1bNode>(_ancestors.Count + 1) { parent };
         newAncestors.AddRange(_ancestors);
         return new ReconcileContext(parent, FocusRing, CancellationToken, newAncestors, LayoutAxis, InvalidateCallback, 
-            CaptureInputCallback, ReleaseCaptureCallback, ScheduleTimerCallback, WindowManagerRegistry, RequestFocusCallback)
+            CaptureInputCallback, ReleaseCaptureCallback, ScheduleTimerCallback, WindowManagerRegistry, RequestFocusCallback,
+            CopyToClipboardCallback)
         {
             DiagnosticTimingEnabled = DiagnosticTimingEnabled,
             Metrics = Metrics,
@@ -180,7 +190,8 @@ public sealed class ReconcileContext
     public ReconcileContext WithLayoutAxis(LayoutAxis axis)
     {
         return new ReconcileContext(Parent, FocusRing, CancellationToken, _ancestors.ToList(), axis, InvalidateCallback,
-            CaptureInputCallback, ReleaseCaptureCallback, ScheduleTimerCallback, WindowManagerRegistry, RequestFocusCallback)
+            CaptureInputCallback, ReleaseCaptureCallback, ScheduleTimerCallback, WindowManagerRegistry, RequestFocusCallback,
+            CopyToClipboardCallback)
         { IsNew = IsNew, DiagnosticTimingEnabled = DiagnosticTimingEnabled, Metrics = Metrics, _inputOverrides = _inputOverrides };
     }
     
@@ -191,7 +202,8 @@ public sealed class ReconcileContext
     public ReconcileContext WithChildPosition(int index, int count)
     {
         return new ReconcileContext(Parent, FocusRing, CancellationToken, _ancestors.ToList(), LayoutAxis, InvalidateCallback,
-            CaptureInputCallback, ReleaseCaptureCallback, ScheduleTimerCallback, WindowManagerRegistry, RequestFocusCallback)
+            CaptureInputCallback, ReleaseCaptureCallback, ScheduleTimerCallback, WindowManagerRegistry, RequestFocusCallback,
+            CopyToClipboardCallback)
         { IsNew = IsNew, ChildIndex = index, ChildCount = count, DiagnosticTimingEnabled = DiagnosticTimingEnabled, Metrics = Metrics, _inputOverrides = _inputOverrides };
     }
 
@@ -202,7 +214,8 @@ public sealed class ReconcileContext
     internal ReconcileContext WithInputOverrides(IReadOnlyDictionary<Type, Action<InputBindingsBuilder>> overrides)
     {
         return new ReconcileContext(Parent, FocusRing, CancellationToken, _ancestors.ToList(), LayoutAxis, InvalidateCallback,
-            CaptureInputCallback, ReleaseCaptureCallback, ScheduleTimerCallback, WindowManagerRegistry, RequestFocusCallback)
+            CaptureInputCallback, ReleaseCaptureCallback, ScheduleTimerCallback, WindowManagerRegistry, RequestFocusCallback,
+            CopyToClipboardCallback)
         { IsNew = IsNew, ChildIndex = ChildIndex, ChildCount = ChildCount, DiagnosticTimingEnabled = DiagnosticTimingEnabled, Metrics = Metrics, _inputOverrides = overrides };
     }
 

--- a/src/Hex1b/Widgets/TerminalWidget.cs
+++ b/src/Hex1b/Widgets/TerminalWidget.cs
@@ -58,6 +58,44 @@ public sealed record TerminalWidget(TerminalWidgetHandle Handle) : Hex1bWidget
     /// <summary>Rebindable action: Scroll to the bottom, returning to the live terminal view.</summary>
     public static readonly ActionId ScrollToBottom = new($"{nameof(TerminalWidget)}.{nameof(ScrollToBottom)}");
 
+    // Copy mode actions
+    /// <summary>Rebindable action: Enter copy mode for text selection.</summary>
+    public static readonly ActionId EnterCopyMode = new($"{nameof(TerminalWidget)}.{nameof(EnterCopyMode)}");
+    /// <summary>Rebindable action: Move the copy mode cursor up one row.</summary>
+    public static readonly ActionId CopyModeUp = new($"{nameof(TerminalWidget)}.{nameof(CopyModeUp)}");
+    /// <summary>Rebindable action: Move the copy mode cursor down one row.</summary>
+    public static readonly ActionId CopyModeDown = new($"{nameof(TerminalWidget)}.{nameof(CopyModeDown)}");
+    /// <summary>Rebindable action: Move the copy mode cursor left one column.</summary>
+    public static readonly ActionId CopyModeLeft = new($"{nameof(TerminalWidget)}.{nameof(CopyModeLeft)}");
+    /// <summary>Rebindable action: Move the copy mode cursor right one column.</summary>
+    public static readonly ActionId CopyModeRight = new($"{nameof(TerminalWidget)}.{nameof(CopyModeRight)}");
+    /// <summary>Rebindable action: Move the copy mode cursor forward one word.</summary>
+    public static readonly ActionId CopyModeWordForward = new($"{nameof(TerminalWidget)}.{nameof(CopyModeWordForward)}");
+    /// <summary>Rebindable action: Move the copy mode cursor backward one word.</summary>
+    public static readonly ActionId CopyModeWordBackward = new($"{nameof(TerminalWidget)}.{nameof(CopyModeWordBackward)}");
+    /// <summary>Rebindable action: Move the copy mode cursor up one page.</summary>
+    public static readonly ActionId CopyModePageUp = new($"{nameof(TerminalWidget)}.{nameof(CopyModePageUp)}");
+    /// <summary>Rebindable action: Move the copy mode cursor down one page.</summary>
+    public static readonly ActionId CopyModePageDown = new($"{nameof(TerminalWidget)}.{nameof(CopyModePageDown)}");
+    /// <summary>Rebindable action: Move the copy mode cursor to the start of the current line.</summary>
+    public static readonly ActionId CopyModeLineStart = new($"{nameof(TerminalWidget)}.{nameof(CopyModeLineStart)}");
+    /// <summary>Rebindable action: Move the copy mode cursor to the end of the current line.</summary>
+    public static readonly ActionId CopyModeLineEnd = new($"{nameof(TerminalWidget)}.{nameof(CopyModeLineEnd)}");
+    /// <summary>Rebindable action: Move the copy mode cursor to the top of the buffer.</summary>
+    public static readonly ActionId CopyModeBufferTop = new($"{nameof(TerminalWidget)}.{nameof(CopyModeBufferTop)}");
+    /// <summary>Rebindable action: Move the copy mode cursor to the bottom of the buffer.</summary>
+    public static readonly ActionId CopyModeBufferBottom = new($"{nameof(TerminalWidget)}.{nameof(CopyModeBufferBottom)}");
+    /// <summary>Rebindable action: Start or toggle character selection in copy mode.</summary>
+    public static readonly ActionId CopyModeStartSelection = new($"{nameof(TerminalWidget)}.{nameof(CopyModeStartSelection)}");
+    /// <summary>Rebindable action: Toggle line selection mode in copy mode.</summary>
+    public static readonly ActionId CopyModeToggleLineMode = new($"{nameof(TerminalWidget)}.{nameof(CopyModeToggleLineMode)}");
+    /// <summary>Rebindable action: Toggle block/rectangular selection mode in copy mode.</summary>
+    public static readonly ActionId CopyModeToggleBlockMode = new($"{nameof(TerminalWidget)}.{nameof(CopyModeToggleBlockMode)}");
+    /// <summary>Rebindable action: Copy the selected text and exit copy mode.</summary>
+    public static readonly ActionId CopyModeCopy = new($"{nameof(TerminalWidget)}.{nameof(CopyModeCopy)}");
+    /// <summary>Rebindable action: Cancel copy mode without copying.</summary>
+    public static readonly ActionId CopyModeCancel = new($"{nameof(TerminalWidget)}.{nameof(CopyModeCancel)}");
+
     /// <summary>
     /// Gets the callback that builds a fallback widget when the terminal is not running.
     /// </summary>

--- a/src/Hex1b/Widgets/TerminalWidget.cs
+++ b/src/Hex1b/Widgets/TerminalWidget.cs
@@ -140,7 +140,7 @@ public sealed record TerminalWidget(TerminalWidgetHandle Handle) : Hex1bWidget
         node.Bind();
         
         // Attach copy mode helper if configured
-        node.AttachCopyModeHelper(CopyModeOptions);
+        node.AttachCopyModeHelper(CopyModeOptions, context.CopyToClipboardCallback);
         
         // If terminal is not running and we have a fallback builder, reconcile the fallback widget
         if (Handle.State != TerminalState.Running && NotRunningBuilder != null)

--- a/src/Hex1b/Widgets/TerminalWidget.cs
+++ b/src/Hex1b/Widgets/TerminalWidget.cs
@@ -106,6 +106,12 @@ public sealed record TerminalWidget(TerminalWidgetHandle Handle) : Hex1bWidget
     /// </summary>
     public int MouseWheelScrollAmount { get; init; } = 3;
     
+    /// <summary>
+    /// Gets the copy mode bindings options, or null if copy mode bindings are not configured.
+    /// Set via <see cref="TerminalExtensions.CopyModeBindings"/>.
+    /// </summary>
+    internal CopyModeBindingsOptions? CopyModeOptions { get; init; }
+    
     internal override async Task<Hex1bNode> ReconcileAsync(Hex1bNode? existingNode, ReconcileContext context)
     {
         var node = existingNode as TerminalNode ?? new TerminalNode();
@@ -132,6 +138,9 @@ public sealed record TerminalWidget(TerminalWidgetHandle Handle) : Hex1bWidget
         
         // Bind to the new handle
         node.Bind();
+        
+        // Attach copy mode helper if configured
+        node.AttachCopyModeHelper(CopyModeOptions);
         
         // If terminal is not running and we have a fallback builder, reconcile the fallback widget
         if (Handle.State != TerminalState.Running && NotRunningBuilder != null)

--- a/src/Hex1b/native/Makefile
+++ b/src/Hex1b/native/Makefile
@@ -1,24 +1,29 @@
 # Makefile for libhex1binterop - Native interop library for Hex1b
 #
 # Builds for the current platform:
-#   make           - Build for current platform
-#   make clean     - Remove build artifacts
+#   make                    - Build for current platform
+#   make TARGET_ARCH=x86_64 - Cross-compile for x86_64 (on macOS ARM64)
+#   make clean              - Remove build artifacts
 #
-# Cross-compilation is handled separately via CI/CD
 
 CC = gcc
 CFLAGS = -Wall -Wextra -O2 -fPIC
 LDFLAGS = -shared
 
+# Allow overriding the target architecture for cross-compilation
+TARGET_ARCH ?= $(shell uname -m)
+
 # Detect platform and set library extension and flags
 UNAME_S := $(shell uname -s)
-UNAME_M := $(shell uname -m)
 
 ifeq ($(UNAME_S),Darwin)
     TARGET = libhex1binterop.dylib
     LDFLAGS += -dynamiclib -install_name @rpath/libhex1binterop.dylib
     # macOS needs util library for PTY functions
     LDFLAGS += -lutil
+    # Add arch flag for cross-compilation on macOS
+    CFLAGS += -arch $(TARGET_ARCH)
+    LDFLAGS += -arch $(TARGET_ARCH)
 else
     TARGET = libhex1binterop.so
     LDFLAGS += -lpthread -lutil
@@ -26,13 +31,13 @@ endif
 
 # Determine RID for output directory
 ifeq ($(UNAME_S),Darwin)
-    ifeq ($(UNAME_M),arm64)
+    ifeq ($(TARGET_ARCH),arm64)
         RID = osx-arm64
     else
         RID = osx-x64
     endif
 else
-    ifeq ($(UNAME_M),aarch64)
+    ifeq ($(TARGET_ARCH),aarch64)
         RID = linux-arm64
     else
         RID = linux-x64

--- a/tests/Hex1b.Tests/CopyModeBindingsFunctionalTests.cs
+++ b/tests/Hex1b.Tests/CopyModeBindingsFunctionalTests.cs
@@ -1,0 +1,1360 @@
+using Hex1b;
+using Hex1b.Automation;
+using Hex1b.Input;
+using Hex1b.Tokens;
+using Hex1b.Widgets;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Functional tests for copy mode bindings on the TerminalWidget.
+/// These tests create a headless Hex1bTerminal hosting a TerminalWidget with
+/// <c>.CopyModeBindings()</c>, inject text into the handle, send input via
+/// <see cref="Hex1bTerminalInputSequenceBuilder"/>, and assert on handle state.
+/// </summary>
+public class CopyModeBindingsFunctionalTests
+{
+    /// <summary>
+    /// Test helper that wraps a headless Hex1bTerminal with a TerminalWidget
+    /// configured with copy mode bindings.
+    /// </summary>
+    private sealed class CopyModeTestContext : IAsyncDisposable
+    {
+        private readonly CancellationTokenSource _cts = new();
+
+        public Hex1bTerminal Terminal { get; }
+        public Hex1bApp? App { get; private set; }
+        public TerminalWidgetHandle Handle { get; }
+
+        private Task? _runTask;
+
+        private CopyModeTestContext(Hex1bTerminal terminal, TerminalWidgetHandle handle)
+        {
+            Terminal = terminal;
+            Handle = handle;
+        }
+
+        /// <summary>
+        /// Creates a test context with copy mode bindings and optional configuration.
+        /// </summary>
+        public static CopyModeTestContext Create(
+            Action<CopyModeBindingsOptions>? configure = null,
+            int width = 80,
+            int height = 24,
+            int handleWidth = 60,
+            int handleHeight = 16,
+            bool enableMouse = false)
+        {
+            var handle = new TerminalWidgetHandle(handleWidth, handleHeight);
+            CopyModeTestContext? capturedContext = null;
+
+            var builder = Hex1bTerminal.CreateBuilder()
+                .WithHex1bApp((app, options) =>
+                {
+                    if (capturedContext != null)
+                        capturedContext.App = app;
+
+                    return ctx => ctx.Terminal(handle)
+                        .CopyModeBindings(configure)
+                        .Fill();
+                })
+                .WithHeadless()
+                .WithDimensions(width, height);
+
+            if (enableMouse)
+                builder = builder.WithMouse();
+
+            var terminal = builder.Build();
+            capturedContext = new CopyModeTestContext(terminal, handle);
+            return capturedContext;
+        }
+
+        /// <summary>
+        /// Starts the terminal and waits for initial render.
+        /// </summary>
+        public async Task StartAsync()
+        {
+            _runTask = Terminal.RunAsync(_cts.Token);
+            // Give the app time to start and perform first render
+            await Task.Delay(500);
+        }
+
+        /// <summary>
+        /// Injects text at the given (row, col) in the handle's buffer.
+        /// </summary>
+        public void InjectText(int row, int col, string text)
+        {
+            var impacts = new List<CellImpact>();
+            for (int i = 0; i < text.Length; i++)
+            {
+                impacts.Add(new CellImpact(
+                    col + i,
+                    row,
+                    new TerminalCell(text[i].ToString(), null, null, CellAttributes.None, 0)));
+            }
+
+            var token = new AppliedToken(
+                Token: new TextToken(text),
+                CellImpacts: impacts,
+                CursorXBefore: col,
+                CursorYBefore: row,
+                CursorXAfter: col + text.Length,
+                CursorYAfter: row);
+
+            Handle.WriteOutputWithImpactsAsync([token]).AsTask().Wait();
+        }
+
+        /// <summary>
+        /// Sends a sequence of keys/mouse events to the terminal.
+        /// </summary>
+        public async Task SendKeysAsync(Action<Hex1bTerminalInputSequenceBuilder> build)
+        {
+            var builder = new Hex1bTerminalInputSequenceBuilder();
+            build(builder);
+            await builder.Build().ApplyAsync(Terminal);
+        }
+
+        /// <summary>
+        /// Waits for rendering to settle.
+        /// </summary>
+        public async Task WaitForRenderAsync(int delayMs = 200)
+        {
+            App?.Invalidate();
+            await Task.Delay(delayMs);
+        }
+
+        /// <summary>
+        /// Gets the current screen text.
+        /// </summary>
+        public string GetScreenText() => Terminal.GetScreenText();
+
+        /// <summary>
+        /// Creates a snapshot of the terminal output.
+        /// </summary>
+        public Hex1bTerminalSnapshot CreateSnapshot() => Terminal.CreateSnapshot();
+
+        public async ValueTask DisposeAsync()
+        {
+            _cts.Cancel();
+            if (_runTask != null)
+            {
+                try { await _runTask; }
+                catch { }
+            }
+            await Terminal.DisposeAsync();
+            _cts.Dispose();
+        }
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // 1. Entry Key Tests
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task F6_EntersCopyMode()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Hello World");
+        await ctx.WaitForRenderAsync();
+
+        // Act
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        // Assert
+        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.Equal(CopyModeState.Active, ctx.Handle.CopyModeState);
+    }
+
+    [Fact]
+    public async Task CustomEntryKey_EntersCopyMode()
+    {
+        // Arrange — configure F5 as entry key instead of default F6
+        await using var ctx = CopyModeTestContext.Create(options =>
+        {
+            options.EnterKeys = [Hex1bKey.F5];
+        });
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Hello World");
+        await ctx.WaitForRenderAsync();
+
+        // Act — F5 should enter copy mode
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F5));
+        await ctx.WaitForRenderAsync();
+        Assert.True(ctx.Handle.IsInCopyMode);
+
+        // Exit and verify F6 does NOT enter copy mode
+        ctx.Handle.ExitCopyMode();
+        await ctx.WaitForRenderAsync();
+        Assert.False(ctx.Handle.IsInCopyMode);
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+        Assert.False(ctx.Handle.IsInCopyMode);
+    }
+
+    [Fact]
+    public async Task MultipleEntryKeys_EachWorks()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create(options =>
+        {
+            options.EnterKeys = [Hex1bKey.F5, Hex1bKey.F6];
+        });
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Hello World");
+        await ctx.WaitForRenderAsync();
+
+        // Act — F5 enters copy mode
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F5));
+        await ctx.WaitForRenderAsync();
+        Assert.True(ctx.Handle.IsInCopyMode);
+
+        // Exit and try F6
+        ctx.Handle.ExitCopyMode();
+        await ctx.WaitForRenderAsync();
+        Assert.False(ctx.Handle.IsInCopyMode);
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+        Assert.True(ctx.Handle.IsInCopyMode);
+    }
+
+    [Fact]
+    public async Task EntryKeyWithModifier_Works()
+    {
+        // Arrange — Alt+C as entry key
+        await using var ctx = CopyModeTestContext.Create(options =>
+        {
+            options.EnterKeys = [new KeyBinding(Hex1bKey.C, Hex1bModifiers.Alt)];
+        });
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Hello World");
+        await ctx.WaitForRenderAsync();
+
+        // Act
+        await ctx.SendKeysAsync(b => b.Alt().Key(Hex1bKey.C));
+        await ctx.WaitForRenderAsync();
+
+        // Assert
+        Assert.True(ctx.Handle.IsInCopyMode);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // 2. Cancel / Exit Tests
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Escape_ExitsCopyMode()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Hello");
+        await ctx.WaitForRenderAsync();
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+        Assert.True(ctx.Handle.IsInCopyMode);
+
+        // Act
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Escape));
+        await ctx.WaitForRenderAsync();
+
+        // Assert
+        Assert.False(ctx.Handle.IsInCopyMode);
+        Assert.Equal(CopyModeState.Inactive, ctx.Handle.CopyModeState);
+    }
+
+    [Fact]
+    public async Task Q_ExitsCopyMode()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+        Assert.True(ctx.Handle.IsInCopyMode);
+
+        // Act
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Q));
+        await ctx.WaitForRenderAsync();
+
+        // Assert
+        Assert.False(ctx.Handle.IsInCopyMode);
+    }
+
+    [Fact]
+    public async Task CustomCancelKey_Works()
+    {
+        // Arrange — X as cancel key
+        await using var ctx = CopyModeTestContext.Create(options =>
+        {
+            options.CancelKeys = [Hex1bKey.X];
+        });
+        await ctx.StartAsync();
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+        Assert.True(ctx.Handle.IsInCopyMode);
+
+        // Act — default Escape should NOT exit (replaced)
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Escape));
+        await ctx.WaitForRenderAsync();
+        // Note: all keys are consumed in copy mode, but Escape is no longer a cancel key
+        // The handle should still be in copy mode since Escape is not mapped to cancel
+        Assert.True(ctx.Handle.IsInCopyMode);
+
+        // X should exit
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.X));
+        await ctx.WaitForRenderAsync();
+        Assert.False(ctx.Handle.IsInCopyMode);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // 3. Navigation Tests
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ArrowKeys_MoveCursor()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Line 0");
+        ctx.InjectText(1, 0, "Line 1");
+        ctx.InjectText(2, 0, "Line 2");
+        await ctx.WaitForRenderAsync();
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        var initialPos = ctx.Handle.Selection!.Cursor;
+
+        // Act — move down
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.DownArrow));
+        await ctx.WaitForRenderAsync();
+
+        // Assert — row should have increased
+        var afterDown = ctx.Handle.Selection!.Cursor;
+        Assert.True(afterDown.Row > initialPos.Row || initialPos.Row == ctx.Handle.VirtualBufferHeight - 1,
+            "Down arrow should move cursor down (or cursor was already at bottom)");
+
+        // Move right
+        var beforeRight = ctx.Handle.Selection!.Cursor;
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.RightArrow));
+        await ctx.WaitForRenderAsync();
+        var afterRight = ctx.Handle.Selection!.Cursor;
+        Assert.Equal(beforeRight.Column + 1, afterRight.Column);
+    }
+
+    [Fact]
+    public async Task ViKeys_HJKL_MoveCursor()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "ABCDEF");
+        ctx.InjectText(1, 0, "GHIJKL");
+        await ctx.WaitForRenderAsync();
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        // Move to a known starting position (top-left area)
+        ctx.Handle.SetCopyModeCursorPosition(0, 3);
+        await ctx.WaitForRenderAsync();
+
+        // Act — L (right)
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.L));
+        await ctx.WaitForRenderAsync();
+        Assert.Equal(4, ctx.Handle.Selection!.Cursor.Column);
+
+        // H (left)
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.H));
+        await ctx.WaitForRenderAsync();
+        Assert.Equal(3, ctx.Handle.Selection!.Cursor.Column);
+
+        // J (down)
+        var rowBefore = ctx.Handle.Selection!.Cursor.Row;
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.J));
+        await ctx.WaitForRenderAsync();
+        Assert.Equal(rowBefore + 1, ctx.Handle.Selection!.Cursor.Row);
+
+        // K (up)
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.K));
+        await ctx.WaitForRenderAsync();
+        Assert.Equal(rowBefore, ctx.Handle.Selection!.Cursor.Row);
+    }
+
+    [Fact]
+    public async Task CustomCursorKeys_Work()
+    {
+        // Arrange — WASD navigation, no vi keys
+        await using var ctx = CopyModeTestContext.Create(options =>
+        {
+            options.CursorUpKeys = [Hex1bKey.W];
+            options.CursorDownKeys = [Hex1bKey.S];
+            options.CursorLeftKeys = [Hex1bKey.A];
+            options.CursorRightKeys = [Hex1bKey.D];
+        });
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Row 0 data");
+        ctx.InjectText(1, 0, "Row 1 data");
+        await ctx.WaitForRenderAsync();
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+        ctx.Handle.SetCopyModeCursorPosition(0, 5);
+        await ctx.WaitForRenderAsync();
+
+        // Act — D (right)
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.D));
+        await ctx.WaitForRenderAsync();
+        Assert.Equal(6, ctx.Handle.Selection!.Cursor.Column);
+
+        // Default H (vi-left) should NOT move cursor left — it's not mapped
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.H));
+        await ctx.WaitForRenderAsync();
+        // H is not mapped to any action but all keys are consumed in copy mode
+        // Column should remain unchanged since H is no longer a cursor key
+        Assert.Equal(6, ctx.Handle.Selection!.Cursor.Column);
+    }
+
+    [Fact]
+    public async Task PageUpDown_MovesPage()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        for (int i = 0; i < 16; i++)
+            ctx.InjectText(i, 0, $"Line {i}");
+        await ctx.WaitForRenderAsync();
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        var initial = ctx.Handle.Selection!.Cursor;
+
+        // Act — PageUp should move cursor up significantly
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.PageUp));
+        await ctx.WaitForRenderAsync();
+        var afterPageUp = ctx.Handle.Selection!.Cursor;
+
+        // Assert — row should have decreased (or be at 0 if already near top)
+        Assert.True(afterPageUp.Row <= initial.Row);
+    }
+
+    [Fact]
+    public async Task HomeEnd_MovesToLineStartEnd()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Hello World Test");
+        await ctx.WaitForRenderAsync();
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        // Position cursor in the middle of a row
+        var cursorRow = ctx.Handle.Selection!.Cursor.Row;
+        ctx.Handle.SetCopyModeCursorPosition(cursorRow, 5);
+        await ctx.WaitForRenderAsync();
+
+        // Act — Home should go to column 0
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Home));
+        await ctx.WaitForRenderAsync();
+        Assert.Equal(0, ctx.Handle.Selection!.Cursor.Column);
+
+        // End should go to last column
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.End));
+        await ctx.WaitForRenderAsync();
+        Assert.Equal(ctx.Handle.Width - 1, ctx.Handle.Selection!.Cursor.Column);
+    }
+
+    [Fact]
+    public async Task BufferTopBottom_G_ShiftG()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        for (int i = 0; i < 10; i++)
+            ctx.InjectText(i, 0, $"Row {i}");
+        await ctx.WaitForRenderAsync();
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        // Act — g (lowercase) goes to top
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.G));
+        await ctx.WaitForRenderAsync();
+        Assert.Equal(0, ctx.Handle.Selection!.Cursor.Row);
+
+        // G (Shift+G) goes to bottom
+        await ctx.SendKeysAsync(b => b.Shift().Key(Hex1bKey.G));
+        await ctx.WaitForRenderAsync();
+        Assert.Equal(ctx.Handle.VirtualBufferHeight - 1, ctx.Handle.Selection!.Cursor.Row);
+    }
+
+    [Fact]
+    public async Task WordForwardBackward_W_B()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+
+        // Inject text into the screen buffer
+        ctx.InjectText(0, 0, "hello world test data");
+        await ctx.WaitForRenderAsync();
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        // Position cursor at start of "world" (col=6) on the text row.
+        // This avoids the edge case where B wraps past the buffer top.
+        var scrollbackCount = ctx.Handle.ScrollbackCount;
+        var textVirtualRow = scrollbackCount + 0;
+        ctx.Handle.SetCopyModeCursorPosition(textVirtualRow, 6);
+        ctx.Handle.UpdateCopyModeState();
+        await ctx.WaitForRenderAsync();
+
+        var startPos = ctx.Handle.Selection!.Cursor;
+        Assert.Equal(6, startPos.Column);
+
+        // Act — w (word forward) should advance past "world" to "test"
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.W));
+        await ctx.WaitForRenderAsync();
+        var afterW = ctx.Handle.Selection!.Cursor;
+        Assert.True(afterW.Column > startPos.Column,
+            $"Word forward should advance column (start={startPos}, after={afterW})");
+
+        // b (word backward) should go back toward "world" or "hello"
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.B));
+        await ctx.WaitForRenderAsync();
+        var afterB = ctx.Handle.Selection!.Cursor;
+        Assert.True(afterB.Column < afterW.Column,
+            $"Word backward should move cursor left (afterB={afterB}, afterW={afterW})");
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // 4. Selection Mode Tests
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task V_StartsCharacterSelection()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Hello World");
+        await ctx.WaitForRenderAsync();
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        // Act
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.V));
+        await ctx.WaitForRenderAsync();
+
+        // Assert
+        Assert.Equal(CopyModeState.CharacterSelection, ctx.Handle.CopyModeState);
+        Assert.True(ctx.Handle.Selection!.IsSelecting);
+        Assert.Equal(SelectionMode.Character, ctx.Handle.Selection!.Mode);
+    }
+
+    [Fact]
+    public async Task ShiftV_StartsLineSelection()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Hello");
+        await ctx.WaitForRenderAsync();
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        // Act
+        await ctx.SendKeysAsync(b => b.Shift().Key(Hex1bKey.V));
+        await ctx.WaitForRenderAsync();
+
+        // Assert
+        Assert.Equal(CopyModeState.LineSelection, ctx.Handle.CopyModeState);
+        Assert.Equal(SelectionMode.Line, ctx.Handle.Selection!.Mode);
+    }
+
+    [Fact]
+    public async Task AltV_StartsBlockSelection()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Hello");
+        await ctx.WaitForRenderAsync();
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        // Act
+        await ctx.SendKeysAsync(b => b.Alt().Key(Hex1bKey.V));
+        await ctx.WaitForRenderAsync();
+
+        // Assert
+        Assert.Equal(CopyModeState.BlockSelection, ctx.Handle.CopyModeState);
+        Assert.Equal(SelectionMode.Block, ctx.Handle.Selection!.Mode);
+    }
+
+    [Fact]
+    public async Task V_TogglesCharacterSelection()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Hello");
+        await ctx.WaitForRenderAsync();
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        // First V — starts character selection
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.V));
+        await ctx.WaitForRenderAsync();
+        Assert.True(ctx.Handle.Selection!.IsSelecting);
+
+        // Act — second V — clears selection
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.V));
+        await ctx.WaitForRenderAsync();
+
+        // Assert — selection should be cleared but still in copy mode
+        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.False(ctx.Handle.Selection!.IsSelecting);
+        Assert.Equal(CopyModeState.Active, ctx.Handle.CopyModeState);
+    }
+
+    [Fact]
+    public async Task SelectionModeSwitch_CharacterToLine()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Hello");
+        await ctx.WaitForRenderAsync();
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        // Start character selection
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.V));
+        await ctx.WaitForRenderAsync();
+        Assert.Equal(SelectionMode.Character, ctx.Handle.Selection!.Mode);
+
+        // Act — switch to line selection
+        await ctx.SendKeysAsync(b => b.Shift().Key(Hex1bKey.V));
+        await ctx.WaitForRenderAsync();
+
+        // Assert
+        Assert.Equal(SelectionMode.Line, ctx.Handle.Selection!.Mode);
+        Assert.Equal(CopyModeState.LineSelection, ctx.Handle.CopyModeState);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // 5. Copy Tests
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Y_CopiesAndExits()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Hello World");
+        await ctx.WaitForRenderAsync();
+
+        string? copiedText = null;
+        ctx.Handle.TextCopied += text => copiedText = text;
+
+        // Enter copy mode, position at start of text, start selection, move right
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        var textRow = ctx.Handle.Selection!.Cursor.Row;
+        ctx.Handle.SetCopyModeCursorPosition(textRow, 0);
+        ctx.Handle.StartOrToggleSelection(SelectionMode.Character);
+        ctx.Handle.SetCopyModeCursorPosition(textRow, 4);
+        ctx.Handle.UpdateCopyModeState();
+        await ctx.WaitForRenderAsync();
+
+        // Act
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Y));
+        await ctx.WaitForRenderAsync();
+
+        // Assert
+        Assert.False(ctx.Handle.IsInCopyMode);
+        Assert.NotNull(copiedText);
+        Assert.Contains("Hello", copiedText);
+    }
+
+    [Fact]
+    public async Task Enter_CopiesAndExits()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Test Data");
+        await ctx.WaitForRenderAsync();
+
+        string? copiedText = null;
+        ctx.Handle.TextCopied += text => copiedText = text;
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        var textRow = ctx.Handle.Selection!.Cursor.Row;
+        ctx.Handle.SetCopyModeCursorPosition(textRow, 0);
+        ctx.Handle.StartOrToggleSelection(SelectionMode.Character);
+        ctx.Handle.SetCopyModeCursorPosition(textRow, 3);
+        ctx.Handle.UpdateCopyModeState();
+        await ctx.WaitForRenderAsync();
+
+        // Act — Enter copies
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Enter));
+        await ctx.WaitForRenderAsync();
+
+        // Assert
+        Assert.False(ctx.Handle.IsInCopyMode);
+        Assert.NotNull(copiedText);
+        Assert.Contains("Test", copiedText);
+    }
+
+    [Fact]
+    public async Task CopiedText_TrimsTrailingWhitespace()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Hello   ");  // trailing spaces
+        await ctx.WaitForRenderAsync();
+
+        string? copiedText = null;
+        ctx.Handle.TextCopied += text => copiedText = text;
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        var textRow = ctx.Handle.Selection!.Cursor.Row;
+        ctx.Handle.SetCopyModeCursorPosition(textRow, 0);
+        ctx.Handle.StartOrToggleSelection(SelectionMode.Character);
+        ctx.Handle.SetCopyModeCursorPosition(textRow, 7);
+        ctx.Handle.UpdateCopyModeState();
+
+        // Act
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Y));
+        await ctx.WaitForRenderAsync();
+
+        // Assert — trailing whitespace should be trimmed
+        Assert.NotNull(copiedText);
+        Assert.Equal("Hello", copiedText);
+    }
+
+    [Fact]
+    public async Task CopiedText_CharacterSelection_CorrectContent()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "ABCDEFGHIJ");
+        await ctx.WaitForRenderAsync();
+
+        string? copiedText = null;
+        ctx.Handle.TextCopied += text => copiedText = text;
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        var textRow = ctx.Handle.Selection!.Cursor.Row;
+        ctx.Handle.SetCopyModeCursorPosition(textRow, 2);
+        ctx.Handle.StartOrToggleSelection(SelectionMode.Character);
+        ctx.Handle.SetCopyModeCursorPosition(textRow, 5);
+        ctx.Handle.UpdateCopyModeState();
+
+        // Act
+        ctx.Handle.CopySelection();
+        await ctx.WaitForRenderAsync();
+
+        // Assert — should be characters from col 2 to col 5 inclusive
+        Assert.NotNull(copiedText);
+        Assert.Equal("CDEF", copiedText);
+    }
+
+    [Fact]
+    public async Task CopiedText_LineSelection_FullRows()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "First Row");
+        ctx.InjectText(1, 0, "Second Row");
+        ctx.InjectText(2, 0, "Third Row");
+        await ctx.WaitForRenderAsync();
+
+        string? copiedText = null;
+        ctx.Handle.TextCopied += text => copiedText = text;
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        // Select rows 0 and 1 in line mode — virtual rows include scrollback offset
+        var scrollbackCount = ctx.Handle.ScrollbackCount;
+        ctx.Handle.SetCopyModeCursorPosition(scrollbackCount + 0, 3);
+        ctx.Handle.StartOrToggleSelection(SelectionMode.Line);
+        ctx.Handle.SetCopyModeCursorPosition(scrollbackCount + 1, 5);
+        ctx.Handle.UpdateCopyModeState();
+
+        // Act
+        ctx.Handle.CopySelection();
+        await ctx.WaitForRenderAsync();
+
+        // Assert — line mode copies full rows
+        Assert.NotNull(copiedText);
+        Assert.Contains("First Row", copiedText);
+        Assert.Contains("Second Row", copiedText);
+    }
+
+    [Fact]
+    public async Task CopiedText_BlockSelection_Rectangle()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "ABCDEFGHIJ");
+        ctx.InjectText(1, 0, "KLMNOPQRST");
+        ctx.InjectText(2, 0, "UVWXYZ0123");
+        await ctx.WaitForRenderAsync();
+
+        string? copiedText = null;
+        ctx.Handle.TextCopied += text => copiedText = text;
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        var scrollbackCount = ctx.Handle.ScrollbackCount;
+        ctx.Handle.SetCopyModeCursorPosition(scrollbackCount + 0, 2);
+        ctx.Handle.StartOrToggleSelection(SelectionMode.Block);
+        ctx.Handle.SetCopyModeCursorPosition(scrollbackCount + 2, 4);
+        ctx.Handle.UpdateCopyModeState();
+
+        // Act
+        ctx.Handle.CopySelection();
+        await ctx.WaitForRenderAsync();
+
+        // Assert — block selects cols 2-4 from rows 0-2
+        Assert.NotNull(copiedText);
+        var lines = copiedText.Split(Environment.NewLine);
+        Assert.Equal(3, lines.Length);
+        Assert.Equal("CDE", lines[0]);
+        Assert.Equal("MNO", lines[1]);
+        Assert.Equal("WXY", lines[2]);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // 6. Mouse Selection Tests
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task MouseDrag_EntersCopyModeAndSelects()
+    {
+        // Arrange — test mouse selection via handle's MouseSelect API
+        // which is what the CopyModeHelper calls internally
+        await using var ctx = CopyModeTestContext.Create(enableMouse: true);
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Hello World Test");
+        await ctx.WaitForRenderAsync();
+
+        // Act — simulate mouse drag: down at (2,0), drag to (8,0)
+        ctx.Handle.MouseSelect(2, 0, MouseAction.Down, SelectionMode.Character);
+        ctx.Handle.MouseSelect(8, 0, MouseAction.Drag, SelectionMode.Character);
+        ctx.Handle.MouseSelect(8, 0, MouseAction.Up, SelectionMode.Character);
+        ctx.Handle.UpdateCopyModeState();
+        await ctx.WaitForRenderAsync();
+
+        // Assert — copy mode should be entered and selection active
+        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.NotNull(ctx.Handle.Selection);
+        Assert.True(ctx.Handle.Selection.IsSelecting);
+    }
+
+    [Fact]
+    public async Task MouseClick_WithoutDrag_DoesNotEnterCopyMode()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create(enableMouse: true);
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Hello World");
+        await ctx.WaitForRenderAsync();
+
+        // Act — mouse down + up without drag
+        ctx.Handle.MouseSelect(5, 0, MouseAction.Down, SelectionMode.Character);
+        ctx.Handle.MouseSelect(5, 0, MouseAction.Up, SelectionMode.Character);
+        await ctx.WaitForRenderAsync();
+
+        // Assert — should NOT enter copy mode on click-only
+        Assert.False(ctx.Handle.IsInCopyMode);
+    }
+
+    [Fact]
+    public async Task MouseDrag_CharacterSelection_Default()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create(enableMouse: true);
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "ABCDEFGHIJ");
+        await ctx.WaitForRenderAsync();
+
+        // Act — plain drag defaults to character selection
+        ctx.Handle.MouseSelect(2, 0, MouseAction.Down, SelectionMode.Character);
+        ctx.Handle.MouseSelect(6, 0, MouseAction.Drag, SelectionMode.Character);
+        ctx.Handle.UpdateCopyModeState();
+        await ctx.WaitForRenderAsync();
+
+        // Assert
+        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.NotNull(ctx.Handle.Selection);
+        Assert.Equal(SelectionMode.Character, ctx.Handle.Selection.Mode);
+    }
+
+    [Fact]
+    public async Task MouseDrag_LineSelectionMode()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create(enableMouse: true);
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Line 0");
+        ctx.InjectText(1, 0, "Line 1");
+        await ctx.WaitForRenderAsync();
+
+        // Act — drag with line selection mode
+        ctx.Handle.MouseSelect(2, 0, MouseAction.Down, SelectionMode.Line);
+        ctx.Handle.MouseSelect(6, 1, MouseAction.Drag, SelectionMode.Line);
+        ctx.Handle.UpdateCopyModeState();
+        await ctx.WaitForRenderAsync();
+
+        // Assert
+        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.NotNull(ctx.Handle.Selection);
+        Assert.Equal(SelectionMode.Line, ctx.Handle.Selection.Mode);
+    }
+
+    [Fact]
+    public async Task MouseDrag_BlockSelectionMode()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create(enableMouse: true);
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "ABCDEFGHIJ");
+        ctx.InjectText(1, 0, "KLMNOPQRST");
+        await ctx.WaitForRenderAsync();
+
+        // Act — drag with block selection mode
+        ctx.Handle.MouseSelect(2, 0, MouseAction.Down, SelectionMode.Block);
+        ctx.Handle.MouseSelect(6, 1, MouseAction.Drag, SelectionMode.Block);
+        ctx.Handle.UpdateCopyModeState();
+        await ctx.WaitForRenderAsync();
+
+        // Assert
+        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.NotNull(ctx.Handle.Selection);
+        Assert.Equal(SelectionMode.Block, ctx.Handle.Selection.Mode);
+    }
+
+    [Fact]
+    public async Task RightClick_CopiesSelection()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create(enableMouse: true);
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Hello World");
+        await ctx.WaitForRenderAsync();
+
+        string? copiedText = null;
+        ctx.Handle.TextCopied += text => copiedText = text;
+
+        // Enter copy mode and create selection via keyboard
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        var scrollbackCount = ctx.Handle.ScrollbackCount;
+        ctx.Handle.SetCopyModeCursorPosition(scrollbackCount + 0, 0);
+        ctx.Handle.StartOrToggleSelection(SelectionMode.Character);
+        ctx.Handle.SetCopyModeCursorPosition(scrollbackCount + 0, 4);
+        ctx.Handle.UpdateCopyModeState();
+        await ctx.WaitForRenderAsync();
+
+        // Act — simulate right-click via the CopyModeInput event
+        // (right-click copy is handled by the CopyModeHelper mouse handler)
+        var rightClickEvent = new Hex1bMouseEvent(MouseButton.Right, MouseAction.Down, 3, 0, Hex1bModifiers.None);
+        ctx.Handle.RaiseCopyModeInput(rightClickEvent);
+        await ctx.WaitForRenderAsync();
+
+        // Assert
+        Assert.NotNull(copiedText);
+        Assert.Contains("Hello", copiedText);
+        Assert.False(ctx.Handle.IsInCopyMode);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // 7. CopyModeState Enum Tests
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CopyModeState_Inactive_WhenNotInCopyMode()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+
+        // Assert — should start inactive
+        Assert.Equal(CopyModeState.Inactive, ctx.Handle.CopyModeState);
+        Assert.False(ctx.Handle.IsInCopyMode);
+    }
+
+    [Fact]
+    public async Task CopyModeState_Active_WhenInCopyModeNoSelection()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+
+        // Act
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        // Assert — in copy mode but no selection started yet
+        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.Equal(CopyModeState.Active, ctx.Handle.CopyModeState);
+        Assert.NotNull(ctx.Handle.Selection);
+        Assert.False(ctx.Handle.Selection.IsSelecting);
+    }
+
+    [Fact]
+    public async Task CopyModeState_CharacterSelection_WhenSelecting()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        // Act — press v to start character selection
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.V));
+        await ctx.WaitForRenderAsync();
+
+        // Assert
+        Assert.Equal(CopyModeState.CharacterSelection, ctx.Handle.CopyModeState);
+    }
+
+    [Fact]
+    public async Task CopyModeState_LineSelection_WhenSelectingLines()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        // Act — Shift+V for line selection
+        await ctx.SendKeysAsync(b => b.Shift().Key(Hex1bKey.V));
+        await ctx.WaitForRenderAsync();
+
+        // Assert
+        Assert.Equal(CopyModeState.LineSelection, ctx.Handle.CopyModeState);
+    }
+
+    [Fact]
+    public async Task CopyModeState_BlockSelection_WhenSelectingBlock()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        // Act — Alt+V for block selection
+        await ctx.SendKeysAsync(b => b.Alt().Key(Hex1bKey.V));
+        await ctx.WaitForRenderAsync();
+
+        // Assert
+        Assert.Equal(CopyModeState.BlockSelection, ctx.Handle.CopyModeState);
+    }
+
+    [Fact]
+    public async Task CopyModeState_ReturnsToInactive_AfterExit()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+        Assert.Equal(CopyModeState.Active, ctx.Handle.CopyModeState);
+
+        // Start a selection
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.V));
+        await ctx.WaitForRenderAsync();
+        Assert.Equal(CopyModeState.CharacterSelection, ctx.Handle.CopyModeState);
+
+        // Act — exit copy mode
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Escape));
+        await ctx.WaitForRenderAsync();
+
+        // Assert
+        Assert.Equal(CopyModeState.Inactive, ctx.Handle.CopyModeState);
+        Assert.False(ctx.Handle.IsInCopyMode);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // 8. Output Queuing Tests
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task OutputQueued_DuringCopyMode_NotRendered()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Initial");
+        await ctx.WaitForRenderAsync();
+
+        // Enter copy mode
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+        Assert.True(ctx.Handle.IsInCopyMode);
+
+        // Act — inject new text while in copy mode (should be queued)
+        ctx.InjectText(1, 0, "QUEUED_TEXT");
+        await ctx.WaitForRenderAsync();
+
+        // Assert — the queued text should NOT appear in the screen buffer
+        // because the buffer is frozen during copy mode.
+        // Check via the handle's buffer directly — the cell at row 1 col 0
+        // should still be empty (not updated).
+        var cell = ctx.Handle.GetCell(0, 1);
+        // If queuing is working, the cell character should not be "Q"
+        // (the buffer is frozen, so the queued output hasn't been applied yet)
+        // Note: This depends on the handle's buffer state. The output is queued
+        // but the buffer isn't updated until copy mode exits.
+        Assert.True(ctx.Handle.IsInCopyMode);
+    }
+
+    [Fact]
+    public async Task QueuedOutput_FlushedOnExit()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Before");
+        await ctx.WaitForRenderAsync();
+
+        // Enter copy mode
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+        Assert.True(ctx.Handle.IsInCopyMode);
+
+        // Inject text while in copy mode (queued)
+        ctx.InjectText(1, 0, "AfterExit");
+        await ctx.WaitForRenderAsync();
+
+        // Act — exit copy mode to flush queued output
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Escape));
+        await ctx.WaitForRenderAsync(500);
+
+        // Assert — queued text should now be visible in the handle's buffer
+        Assert.False(ctx.Handle.IsInCopyMode);
+        var cell = ctx.Handle.GetCell(0, 1);
+        Assert.Equal("A", cell.Character);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // 9. Selection Rendering Tests
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SelectedCells_RenderedWithInvertedColors()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Hello World");
+        await ctx.WaitForRenderAsync();
+
+        // Enter copy mode and select text
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        var scrollbackCount = ctx.Handle.ScrollbackCount;
+        ctx.Handle.SetCopyModeCursorPosition(scrollbackCount + 0, 0);
+        ctx.Handle.StartOrToggleSelection(SelectionMode.Character);
+        ctx.Handle.SetCopyModeCursorPosition(scrollbackCount + 0, 4);
+        ctx.Handle.UpdateCopyModeState();
+        await ctx.WaitForRenderAsync(300);
+
+        // Assert — the screen output should contain reverse video escape code (\x1b[7m)
+        // for the selected region
+        var screen = ctx.GetScreenText();
+        var snapshot = ctx.CreateSnapshot();
+
+        // The selection should render cells 0-4 of the text row with inverted colors.
+        // Verify the selection is active and cells are marked as selected.
+        Assert.True(ctx.Handle.Selection!.IsSelecting);
+        Assert.True(ctx.Handle.Selection.IsCellSelected(scrollbackCount + 0, 0));
+        Assert.True(ctx.Handle.Selection.IsCellSelected(scrollbackCount + 0, 4));
+        Assert.False(ctx.Handle.Selection.IsCellSelected(scrollbackCount + 0, 5));
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Additional edge case tests
+    // ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Spacebar_StartsCharacterSelection()
+    {
+        // Arrange — Spacebar is also a default character selection key
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        // Act
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Spacebar));
+        await ctx.WaitForRenderAsync();
+
+        // Assert
+        Assert.Equal(CopyModeState.CharacterSelection, ctx.Handle.CopyModeState);
+    }
+
+    [Fact]
+    public async Task D0_MovesToLineStart()
+    {
+        // Arrange — 0 key is also a default line-start key
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "Hello World");
+        await ctx.WaitForRenderAsync();
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        var row = ctx.Handle.Selection!.Cursor.Row;
+        ctx.Handle.SetCopyModeCursorPosition(row, 5);
+        await ctx.WaitForRenderAsync();
+
+        // Act
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.D0));
+        await ctx.WaitForRenderAsync();
+
+        // Assert
+        Assert.Equal(0, ctx.Handle.Selection!.Cursor.Column);
+    }
+
+    [Fact]
+    public async Task CopyMode_AllKeysConsumed()
+    {
+        // Arrange — when in copy mode, unmapped keys should still be consumed
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+        Assert.True(ctx.Handle.IsInCopyMode);
+
+        // Act — press random keys that aren't mapped to any action
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Z));
+        await ctx.WaitForRenderAsync();
+
+        // Assert — should still be in copy mode (key was consumed but did nothing)
+        Assert.True(ctx.Handle.IsInCopyMode);
+    }
+
+    [Fact]
+    public async Task EnterCopyMode_ExitCopyMode_Roundtrip()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+
+        // Act — enter and exit multiple times
+        for (int i = 0; i < 3; i++)
+        {
+            await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+            await ctx.WaitForRenderAsync();
+            Assert.True(ctx.Handle.IsInCopyMode);
+
+            await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Q));
+            await ctx.WaitForRenderAsync();
+            Assert.False(ctx.Handle.IsInCopyMode);
+        }
+
+        // Assert — state is clean after multiple roundtrips
+        Assert.Equal(CopyModeState.Inactive, ctx.Handle.CopyModeState);
+        Assert.Null(ctx.Handle.Selection);
+    }
+
+    [Fact]
+    public async Task CopyWithNoSelection_DoesNotFireTextCopied()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+
+        string? copiedText = null;
+        ctx.Handle.TextCopied += text => copiedText = text;
+
+        // Enter copy mode but don't start a selection
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.False(ctx.Handle.Selection!.IsSelecting);
+
+        // Act — press Y to copy (but nothing is selected)
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Y));
+        await ctx.WaitForRenderAsync();
+
+        // Assert — TextCopied should not fire, but copy mode should exit
+        Assert.Null(copiedText);
+        Assert.False(ctx.Handle.IsInCopyMode);
+    }
+
+    [Fact]
+    public async Task SelectionPersists_DuringNavigation()
+    {
+        // Arrange
+        await using var ctx = CopyModeTestContext.Create();
+        await ctx.StartAsync();
+        ctx.InjectText(0, 0, "ABCDEFGHIJKLMNOP");
+        ctx.InjectText(1, 0, "QRSTUVWXYZ012345");
+        await ctx.WaitForRenderAsync();
+
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
+        await ctx.WaitForRenderAsync();
+
+        // Start character selection
+        await ctx.SendKeysAsync(b => b.Key(Hex1bKey.V));
+        await ctx.WaitForRenderAsync();
+        Assert.True(ctx.Handle.Selection!.IsSelecting);
+
+        // Act — navigate while selecting
+        await ctx.SendKeysAsync(b => b
+            .Key(Hex1bKey.RightArrow)
+            .Key(Hex1bKey.RightArrow)
+            .Key(Hex1bKey.RightArrow));
+        await ctx.WaitForRenderAsync();
+
+        // Assert — selection should still be active
+        Assert.True(ctx.Handle.Selection!.IsSelecting);
+        Assert.Equal(SelectionMode.Character, ctx.Handle.Selection.Mode);
+    }
+}

--- a/tests/Hex1b.Tests/TerminalCopyModeTests.cs
+++ b/tests/Hex1b.Tests/TerminalCopyModeTests.cs
@@ -1,0 +1,237 @@
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Tests for copy mode on TerminalWidgetHandle — output queuing, enter/exit lifecycle,
+/// selection integration, and text extraction.
+/// </summary>
+public class TerminalCopyModeTests
+{
+    private static TerminalWidgetHandle CreateHandle(int width = 80, int height = 24)
+    {
+        return new TerminalWidgetHandle(width, height);
+    }
+
+    private static IReadOnlyList<AppliedToken> MakeCellImpacts(string text, int row = 0, int startCol = 0)
+    {
+        var impacts = new List<CellImpact>();
+        for (int i = 0; i < text.Length; i++)
+        {
+            impacts.Add(new CellImpact(startCol + i, row,
+                new TerminalCell(text[i].ToString(), null, null)));
+        }
+        
+        return new List<AppliedToken>
+        {
+            new(new TextToken(text), impacts, startCol, row, startCol + text.Length, row)
+        };
+    }
+
+    [Fact]
+    public void EnterCopyMode_SetsIsInCopyMode()
+    {
+        var handle = CreateHandle();
+        Assert.False(handle.IsInCopyMode);
+        
+        handle.EnterCopyMode();
+        Assert.True(handle.IsInCopyMode);
+    }
+
+    [Fact]
+    public void EnterCopyMode_CreatesSelection()
+    {
+        var handle = CreateHandle(80, 24);
+        handle.EnterCopyMode();
+        
+        Assert.NotNull(handle.Selection);
+        // Cursor should be at bottom-left of screen
+        Assert.Equal(23, handle.Selection!.Cursor.Row); // scrollbackCount(0) + height(24) - 1
+        Assert.Equal(0, handle.Selection.Cursor.Column);
+    }
+
+    [Fact]
+    public void ExitCopyMode_ClearsState()
+    {
+        var handle = CreateHandle();
+        handle.EnterCopyMode();
+        handle.ExitCopyMode();
+        
+        Assert.False(handle.IsInCopyMode);
+        Assert.Null(handle.Selection);
+    }
+
+    [Fact]
+    public void EnterCopyMode_DoubleEntry_NoOp()
+    {
+        var handle = CreateHandle();
+        handle.EnterCopyMode();
+        var selection1 = handle.Selection;
+        
+        handle.EnterCopyMode(); // should be no-op
+        Assert.Same(selection1, handle.Selection);
+    }
+
+    [Fact]
+    public async Task OutputQueuing_WhenInCopyMode_DoesNotApplyToBuffer()
+    {
+        var handle = CreateHandle(10, 5);
+        
+        // Write initial content
+        await handle.WriteOutputWithImpactsAsync(MakeCellImpacts("Hello", row: 0));
+        Assert.Equal("H", handle.GetCell(0, 0).Character);
+        
+        // Enter copy mode
+        handle.EnterCopyMode();
+        
+        // Write new content — should be queued, not applied
+        await handle.WriteOutputWithImpactsAsync(MakeCellImpacts("World", row: 0));
+        
+        // Buffer should still show original content
+        Assert.Equal("H", handle.GetCell(0, 0).Character);
+    }
+
+    [Fact]
+    public async Task OutputQueuing_OnExit_FlushesQueuedOutput()
+    {
+        var handle = CreateHandle(10, 5);
+        
+        // Write initial content
+        await handle.WriteOutputWithImpactsAsync(MakeCellImpacts("Hello", row: 0));
+        
+        // Enter copy mode and write new content
+        handle.EnterCopyMode();
+        await handle.WriteOutputWithImpactsAsync(MakeCellImpacts("World", row: 0));
+        
+        // Exit copy mode — queued output should be flushed
+        handle.ExitCopyMode();
+        
+        Assert.Equal("W", handle.GetCell(0, 0).Character);
+        Assert.Equal("o", handle.GetCell(1, 0).Character);
+    }
+
+    [Fact]
+    public async Task OutputQueuing_MultipleChunks_AllFlushedInOrder()
+    {
+        var handle = CreateHandle(10, 5);
+        handle.EnterCopyMode();
+        
+        await handle.WriteOutputWithImpactsAsync(MakeCellImpacts("AA", row: 0));
+        await handle.WriteOutputWithImpactsAsync(MakeCellImpacts("BB", row: 0)); // overwrites
+        
+        handle.ExitCopyMode();
+        
+        // Second write should overwrite first
+        Assert.Equal("B", handle.GetCell(0, 0).Character);
+        Assert.Equal("B", handle.GetCell(1, 0).Character);
+    }
+
+    [Fact]
+    public void CopyModeChanged_FiredOnEnterAndExit()
+    {
+        var handle = CreateHandle();
+        var events = new List<bool>();
+        handle.CopyModeChanged += (value) => events.Add(value);
+        
+        handle.EnterCopyMode();
+        handle.ExitCopyMode();
+        
+        Assert.Equal(2, events.Count);
+        Assert.True(events[0]);   // enter
+        Assert.False(events[1]);  // exit
+    }
+
+    [Fact]
+    public async Task CopySelection_ExtractsTextAndExits()
+    {
+        var handle = CreateHandle(10, 3);
+        
+        // Write content
+        await handle.WriteOutputWithImpactsAsync(MakeCellImpacts("Hello!", row: 0));
+        await handle.WriteOutputWithImpactsAsync(MakeCellImpacts("World!", row: 1));
+        
+        // Enter copy mode
+        handle.EnterCopyMode();
+        
+        // Select "Hello!" on row 0
+        var sel = handle.Selection!;
+        sel.MoveCursor(new BufferPosition(0, 0));
+        sel.StartSelection(SelectionMode.Character);
+        sel.MoveCursor(new BufferPosition(0, 5));
+        
+        string? copiedText = null;
+        handle.TextCopied += (text) => copiedText = text;
+        
+        var result = handle.CopySelection();
+        
+        Assert.Equal("Hello!", result);
+        Assert.Equal("Hello!", copiedText);
+        Assert.False(handle.IsInCopyMode);
+    }
+
+    [Fact]
+    public void CopySelection_NoSelection_ReturnsNull()
+    {
+        var handle = CreateHandle();
+        handle.EnterCopyMode();
+        // Don't start selection
+        
+        var result = handle.CopySelection();
+        Assert.Null(result);
+        Assert.False(handle.IsInCopyMode);
+    }
+
+    [Fact]
+    public void VirtualBufferHeight_ReturnsScrollbackPlusScreen()
+    {
+        var handle = CreateHandle(80, 24);
+        // No scrollback configured (no terminal attached), so scrollback count = 0
+        Assert.Equal(24, handle.VirtualBufferHeight);
+    }
+
+    [Fact]
+    public async Task GetVirtualCell_ScreenRegion_ReturnsCorrectCell()
+    {
+        var handle = CreateHandle(10, 5);
+        await handle.WriteOutputWithImpactsAsync(MakeCellImpacts("ABC", row: 2));
+        
+        // Screen rows start at scrollbackCount (0 when no terminal attached)
+        var cell = handle.GetVirtualCell(2, 0);
+        Assert.NotNull(cell);
+        Assert.Equal("A", cell!.Value.Character);
+        
+        var cell2 = handle.GetVirtualCell(2, 2);
+        Assert.NotNull(cell2);
+        Assert.Equal("C", cell2!.Value.Character);
+    }
+
+    [Fact]
+    public void GetVirtualCell_OutOfBounds_ReturnsNull()
+    {
+        var handle = CreateHandle(10, 5);
+        
+        Assert.Null(handle.GetVirtualCell(-1, 0));
+        Assert.Null(handle.GetVirtualCell(0, -1));
+        Assert.Null(handle.GetVirtualCell(0, 10)); // width = 10
+        Assert.Null(handle.GetVirtualCell(5, 0));  // height = 5
+    }
+
+    [Fact]
+    public void CopyModeCursorPosition_WhenNotInCopyMode_ReturnsNull()
+    {
+        var handle = CreateHandle();
+        Assert.Null(handle.CopyModeCursorPosition);
+    }
+
+    [Fact]
+    public void CopyModeCursorPosition_WhenInCopyMode_ReturnsCursorPos()
+    {
+        var handle = CreateHandle(80, 24);
+        handle.EnterCopyMode();
+        
+        var pos = handle.CopyModeCursorPosition;
+        Assert.NotNull(pos);
+        Assert.Equal(23, pos!.Value.Row);
+        Assert.Equal(0, pos.Value.Column);
+    }
+}

--- a/tests/Hex1b.Tests/TerminalCopyModeTests.cs
+++ b/tests/Hex1b.Tests/TerminalCopyModeTests.cs
@@ -45,8 +45,8 @@ public class TerminalCopyModeTests
         handle.EnterCopyMode();
         
         Assert.NotNull(handle.Selection);
-        // Cursor should be at bottom-left of screen
-        Assert.Equal(23, handle.Selection!.Cursor.Row); // scrollbackCount(0) + height(24) - 1
+        // Cursor should be at terminal's current cursor position (0,0 for fresh handle)
+        Assert.Equal(0, handle.Selection!.Cursor.Row);
         Assert.Equal(0, handle.Selection.Cursor.Column);
     }
 
@@ -231,7 +231,8 @@ public class TerminalCopyModeTests
         
         var pos = handle.CopyModeCursorPosition;
         Assert.NotNull(pos);
-        Assert.Equal(23, pos!.Value.Row);
+        // Fresh handle has cursor at (0,0)
+        Assert.Equal(0, pos!.Value.Row);
         Assert.Equal(0, pos.Value.Column);
     }
 }

--- a/tests/Hex1b.Tests/TerminalMouseSelectionTests.cs
+++ b/tests/Hex1b.Tests/TerminalMouseSelectionTests.cs
@@ -1,0 +1,182 @@
+using Hex1b.Input;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Tests for mouse-driven text selection on TerminalWidgetHandle.
+/// </summary>
+public class TerminalMouseSelectionTests
+{
+    private static TerminalWidgetHandle CreateHandle(int width = 80, int height = 24)
+    {
+        return new TerminalWidgetHandle(width, height);
+    }
+
+    private static async Task WriteText(TerminalWidgetHandle handle, string text, int row, int startCol = 0)
+    {
+        var impacts = new List<CellImpact>();
+        for (int i = 0; i < text.Length; i++)
+        {
+            impacts.Add(new CellImpact(startCol + i, row,
+                new TerminalCell(text[i].ToString(), null, null)));
+        }
+        var tokens = new List<AppliedToken>
+        {
+            new(new TextToken(text), impacts, startCol, row, startCol + text.Length, row)
+        };
+        await handle.WriteOutputWithImpactsAsync(tokens);
+    }
+
+    [Fact]
+    public async Task MouseSelect_Down_EntersCopyModeAndStartsSelection()
+    {
+        var handle = CreateHandle(20, 5);
+        await WriteText(handle, "Hello World", 0);
+        
+        handle.MouseSelect(2, 0, MouseAction.Down, SelectionMode.Character);
+        
+        Assert.True(handle.IsInCopyMode);
+        Assert.NotNull(handle.Selection);
+        Assert.True(handle.Selection!.IsSelecting);
+        Assert.Equal(SelectionMode.Character, handle.Selection.Mode);
+    }
+
+    [Fact]
+    public async Task MouseSelect_Drag_ExtendsSelection()
+    {
+        var handle = CreateHandle(20, 5);
+        await WriteText(handle, "Hello World", 0);
+        
+        handle.MouseSelect(0, 0, MouseAction.Down, SelectionMode.Character);
+        handle.MouseSelect(4, 0, MouseAction.Drag, SelectionMode.Character);
+        
+        var sel = handle.Selection!;
+        // Anchor at (0,0), cursor at (0,4)
+        Assert.Equal(0, sel.Start.Column);
+        Assert.Equal(4, sel.Cursor.Column);
+    }
+
+    [Fact]
+    public async Task MouseSelect_MultiRow_CharacterMode()
+    {
+        var handle = CreateHandle(20, 5);
+        await WriteText(handle, "Line one", 0);
+        await WriteText(handle, "Line two", 1);
+        
+        handle.MouseSelect(5, 0, MouseAction.Down, SelectionMode.Character);
+        handle.MouseSelect(3, 1, MouseAction.Drag, SelectionMode.Character);
+        
+        var sel = handle.Selection!;
+        Assert.Equal(0, sel.Start.Row);
+        Assert.Equal(1, sel.End.Row);
+        
+        // Extract text
+        var text = sel.ExtractText(handle.GetVirtualCell, handle.Width);
+        Assert.Contains("one", text);
+        Assert.Contains("Line", text);
+    }
+
+    [Fact]
+    public async Task MouseSelect_LineMode_SelectsFullRows()
+    {
+        var handle = CreateHandle(20, 5);
+        await WriteText(handle, "AAAA", 0);
+        await WriteText(handle, "BBBB", 1);
+        await WriteText(handle, "CCCC", 2);
+        
+        handle.MouseSelect(2, 0, MouseAction.Down, SelectionMode.Line);
+        handle.MouseSelect(2, 1, MouseAction.Drag, SelectionMode.Line);
+        
+        var sel = handle.Selection!;
+        Assert.Equal(SelectionMode.Line, sel.Mode);
+        // Line mode selects full rows regardless of column
+        Assert.True(sel.IsCellSelected(0, 0));
+        Assert.True(sel.IsCellSelected(0, 3));
+        Assert.True(sel.IsCellSelected(1, 0));
+        Assert.False(sel.IsCellSelected(2, 0));
+    }
+
+    [Fact]
+    public async Task MouseSelect_BlockMode_SelectsRectangle()
+    {
+        var handle = CreateHandle(20, 5);
+        await WriteText(handle, "ABCDEF", 0);
+        await WriteText(handle, "GHIJKL", 1);
+        await WriteText(handle, "MNOPQR", 2);
+        
+        handle.MouseSelect(1, 0, MouseAction.Down, SelectionMode.Block);
+        handle.MouseSelect(3, 2, MouseAction.Drag, SelectionMode.Block);
+        
+        var sel = handle.Selection!;
+        Assert.Equal(SelectionMode.Block, sel.Mode);
+        // Block: columns 1-3, rows 0-2
+        Assert.True(sel.IsCellSelected(0, 1));
+        Assert.True(sel.IsCellSelected(1, 2));
+        Assert.True(sel.IsCellSelected(2, 3));
+        Assert.False(sel.IsCellSelected(0, 0)); // column 0 outside
+        Assert.False(sel.IsCellSelected(0, 4)); // column 4 outside
+    }
+
+    [Fact]
+    public async Task MouseSelect_Up_KeepsSelectionActive()
+    {
+        var handle = CreateHandle(20, 5);
+        await WriteText(handle, "Hello", 0);
+        
+        handle.MouseSelect(0, 0, MouseAction.Down, SelectionMode.Character);
+        handle.MouseSelect(4, 0, MouseAction.Drag, SelectionMode.Character);
+        handle.MouseSelect(4, 0, MouseAction.Up, SelectionMode.Character);
+        
+        // Selection should still be active after mouse up
+        Assert.True(handle.IsInCopyMode);
+        Assert.True(handle.Selection!.IsSelecting);
+    }
+
+    [Fact]
+    public void MouseSelect_Down_WhenAlreadyInCopyMode_ResetsSelection()
+    {
+        var handle = CreateHandle(20, 5);
+        handle.EnterCopyMode();
+        
+        // Click to start new selection
+        handle.MouseSelect(5, 2, MouseAction.Down, SelectionMode.Character);
+        
+        Assert.True(handle.Selection!.IsSelecting);
+        Assert.Equal(2, handle.Selection.Cursor.Row);
+        Assert.Equal(5, handle.Selection.Cursor.Column);
+    }
+
+    [Fact]
+    public async Task MouseSelect_CopySelection_ExtractsCorrectText()
+    {
+        var handle = CreateHandle(20, 5);
+        await WriteText(handle, "Hello World!", 0);
+        
+        string? copiedText = null;
+        handle.TextCopied += text => copiedText = text;
+        
+        // Select "World"
+        handle.MouseSelect(6, 0, MouseAction.Down, SelectionMode.Character);
+        handle.MouseSelect(10, 0, MouseAction.Drag, SelectionMode.Character);
+        
+        var result = handle.CopySelection();
+        
+        Assert.Equal("World", result);
+        Assert.Equal("World", copiedText);
+    }
+
+    [Fact]
+    public void MouseSelect_ClampsToBufferBounds()
+    {
+        var handle = CreateHandle(10, 5);
+        
+        // Click outside bounds
+        handle.MouseSelect(100, 100, MouseAction.Down, SelectionMode.Character);
+        
+        Assert.True(handle.IsInCopyMode);
+        var pos = handle.Selection!.Cursor;
+        Assert.True(pos.Column < handle.Width);
+        Assert.True(pos.Row < handle.VirtualBufferHeight);
+    }
+}

--- a/tests/Hex1b.Tests/TerminalMouseSelectionTests.cs
+++ b/tests/Hex1b.Tests/TerminalMouseSelectionTests.cs
@@ -29,12 +29,25 @@ public class TerminalMouseSelectionTests
     }
 
     [Fact]
-    public async Task MouseSelect_Down_EntersCopyModeAndStartsSelection()
+    public async Task MouseSelect_DownOnly_DoesNotEnterCopyMode()
     {
         var handle = CreateHandle(20, 5);
         await WriteText(handle, "Hello World", 0);
         
         handle.MouseSelect(2, 0, MouseAction.Down, SelectionMode.Character);
+        
+        // Single click without drag should NOT enter copy mode
+        Assert.False(handle.IsInCopyMode);
+    }
+
+    [Fact]
+    public async Task MouseSelect_DownThenDrag_EntersCopyModeAndStartsSelection()
+    {
+        var handle = CreateHandle(20, 5);
+        await WriteText(handle, "Hello World", 0);
+        
+        handle.MouseSelect(2, 0, MouseAction.Down, SelectionMode.Character);
+        handle.MouseSelect(5, 0, MouseAction.Drag, SelectionMode.Character);
         
         Assert.True(handle.IsInCopyMode);
         Assert.NotNull(handle.Selection);
@@ -134,17 +147,18 @@ public class TerminalMouseSelectionTests
     }
 
     [Fact]
-    public void MouseSelect_Down_WhenAlreadyInCopyMode_ResetsSelection()
+    public void MouseSelect_DragWhenAlreadyInCopyMode_SetsNewSelection()
     {
         var handle = CreateHandle(20, 5);
         handle.EnterCopyMode();
         
-        // Click to start new selection
+        // Click and drag to start new selection
         handle.MouseSelect(5, 2, MouseAction.Down, SelectionMode.Character);
+        handle.MouseSelect(8, 2, MouseAction.Drag, SelectionMode.Character);
         
         Assert.True(handle.Selection!.IsSelecting);
-        Assert.Equal(2, handle.Selection.Cursor.Row);
-        Assert.Equal(5, handle.Selection.Cursor.Column);
+        Assert.Equal(2, handle.Selection.Anchor.Row);
+        Assert.Equal(5, handle.Selection.Anchor.Column);
     }
 
     [Fact]
@@ -171,8 +185,9 @@ public class TerminalMouseSelectionTests
     {
         var handle = CreateHandle(10, 5);
         
-        // Click outside bounds
+        // Click and drag outside bounds
         handle.MouseSelect(100, 100, MouseAction.Down, SelectionMode.Character);
+        handle.MouseSelect(100, 100, MouseAction.Drag, SelectionMode.Character);
         
         Assert.True(handle.IsInCopyMode);
         var pos = handle.Selection!.Cursor;

--- a/tests/Hex1b.Tests/TerminalSelectionTests.cs
+++ b/tests/Hex1b.Tests/TerminalSelectionTests.cs
@@ -1,0 +1,303 @@
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Tests for the TerminalSelection model — coordinate math, selection modes,
+/// text extraction with soft wraps and wide characters.
+/// </summary>
+public class TerminalSelectionTests
+{
+    [Fact]
+    public void BufferPosition_CompareTo_OrdersByRowThenColumn()
+    {
+        var a = new BufferPosition(0, 0);
+        var b = new BufferPosition(0, 5);
+        var c = new BufferPosition(1, 0);
+        
+        Assert.True(a < b);
+        Assert.True(b < c);
+        Assert.True(a < c);
+        Assert.False(c < a);
+    }
+
+    [Fact]
+    public void BufferPosition_Equality()
+    {
+        var a = new BufferPosition(3, 7);
+        var b = new BufferPosition(3, 7);
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void Selection_InitialState_NotSelecting()
+    {
+        var sel = new TerminalSelection(new BufferPosition(5, 10));
+        Assert.False(sel.IsSelecting);
+        Assert.Equal(new BufferPosition(5, 10), sel.Cursor);
+    }
+
+    [Fact]
+    public void MoveCursor_UpdatesCursorPosition()
+    {
+        var sel = new TerminalSelection(new BufferPosition(0, 0));
+        sel.MoveCursor(new BufferPosition(3, 5));
+        Assert.Equal(new BufferPosition(3, 5), sel.Cursor);
+    }
+
+    [Fact]
+    public void StartSelection_SetsAnchorAndSelecting()
+    {
+        var sel = new TerminalSelection(new BufferPosition(0, 0));
+        sel.MoveCursor(new BufferPosition(2, 3));
+        sel.StartSelection(SelectionMode.Character);
+        
+        Assert.True(sel.IsSelecting);
+        Assert.Equal(new BufferPosition(2, 3), sel.Anchor);
+        Assert.Equal(SelectionMode.Character, sel.Mode);
+    }
+
+    [Fact]
+    public void ClearSelection_StopsSelecting()
+    {
+        var sel = new TerminalSelection(new BufferPosition(0, 0));
+        sel.StartSelection();
+        Assert.True(sel.IsSelecting);
+        
+        sel.ClearSelection();
+        Assert.False(sel.IsSelecting);
+    }
+
+    [Fact]
+    public void Start_End_NormalizedRegardlessOfDirection()
+    {
+        var sel = new TerminalSelection(new BufferPosition(5, 10));
+        sel.StartSelection();
+        sel.MoveCursor(new BufferPosition(2, 3)); // cursor before anchor
+        
+        Assert.Equal(new BufferPosition(2, 3), sel.Start);
+        Assert.Equal(new BufferPosition(5, 10), sel.End);
+    }
+
+    [Fact]
+    public void ToggleMode_SwitchesBetweenModes()
+    {
+        var sel = new TerminalSelection(new BufferPosition(0, 0));
+        sel.StartSelection(SelectionMode.Character);
+        
+        sel.ToggleMode(SelectionMode.Line);
+        Assert.Equal(SelectionMode.Line, sel.Mode);
+        
+        // Toggle same mode goes back to character
+        sel.ToggleMode(SelectionMode.Line);
+        Assert.Equal(SelectionMode.Character, sel.Mode);
+    }
+
+    // === IsCellSelected tests ===
+
+    [Fact]
+    public void IsCellSelected_Character_SingleRow()
+    {
+        var sel = new TerminalSelection(new BufferPosition(3, 2));
+        sel.StartSelection(SelectionMode.Character);
+        sel.MoveCursor(new BufferPosition(3, 7));
+        
+        Assert.False(sel.IsCellSelected(3, 1));
+        Assert.True(sel.IsCellSelected(3, 2));
+        Assert.True(sel.IsCellSelected(3, 5));
+        Assert.True(sel.IsCellSelected(3, 7));
+        Assert.False(sel.IsCellSelected(3, 8));
+        Assert.False(sel.IsCellSelected(2, 5));
+    }
+
+    [Fact]
+    public void IsCellSelected_Character_MultipleRows()
+    {
+        var sel = new TerminalSelection(new BufferPosition(1, 5));
+        sel.StartSelection(SelectionMode.Character);
+        sel.MoveCursor(new BufferPosition(3, 3));
+        
+        // Row 1: from column 5 to end
+        Assert.False(sel.IsCellSelected(1, 4));
+        Assert.True(sel.IsCellSelected(1, 5));
+        Assert.True(sel.IsCellSelected(1, 79));
+        
+        // Row 2: fully selected
+        Assert.True(sel.IsCellSelected(2, 0));
+        Assert.True(sel.IsCellSelected(2, 79));
+        
+        // Row 3: from start to column 3
+        Assert.True(sel.IsCellSelected(3, 0));
+        Assert.True(sel.IsCellSelected(3, 3));
+        Assert.False(sel.IsCellSelected(3, 4));
+    }
+
+    [Fact]
+    public void IsCellSelected_Line_SelectsEntireRows()
+    {
+        var sel = new TerminalSelection(new BufferPosition(2, 5));
+        sel.StartSelection(SelectionMode.Line);
+        sel.MoveCursor(new BufferPosition(4, 10));
+        
+        Assert.False(sel.IsCellSelected(1, 0));
+        Assert.True(sel.IsCellSelected(2, 0));
+        Assert.True(sel.IsCellSelected(2, 79));
+        Assert.True(sel.IsCellSelected(3, 0));
+        Assert.True(sel.IsCellSelected(4, 0));
+        Assert.True(sel.IsCellSelected(4, 79));
+        Assert.False(sel.IsCellSelected(5, 0));
+    }
+
+    [Fact]
+    public void IsCellSelected_Block_SelectsRectangle()
+    {
+        var sel = new TerminalSelection(new BufferPosition(1, 3));
+        sel.StartSelection(SelectionMode.Block);
+        sel.MoveCursor(new BufferPosition(4, 8));
+        
+        // Inside rectangle
+        Assert.True(sel.IsCellSelected(1, 3));
+        Assert.True(sel.IsCellSelected(2, 5));
+        Assert.True(sel.IsCellSelected(4, 8));
+        
+        // Outside rectangle
+        Assert.False(sel.IsCellSelected(1, 2));
+        Assert.False(sel.IsCellSelected(2, 9));
+        Assert.False(sel.IsCellSelected(0, 5));
+        Assert.False(sel.IsCellSelected(5, 5));
+    }
+
+    [Fact]
+    public void IsCellSelected_WhenNotSelecting_ReturnsFalse()
+    {
+        var sel = new TerminalSelection(new BufferPosition(3, 5));
+        Assert.False(sel.IsCellSelected(3, 5));
+    }
+
+    // === ExtractText tests ===
+
+    private static TerminalCell MakeCell(string ch, bool softWrap = false)
+    {
+        var attrs = softWrap ? CellAttributes.SoftWrap : CellAttributes.None;
+        return new TerminalCell(ch, null, null, attrs);
+    }
+
+    [Fact]
+    public void ExtractText_Character_SingleRow()
+    {
+        // Buffer: "Hello World     " (row 0, 16 wide)
+        var row = "Hello World     ".ToCharArray();
+        TerminalCell? GetCell(int r, int c) => r == 0 && c < 16 ? MakeCell(row[c].ToString()) : null;
+
+        var sel = new TerminalSelection(new BufferPosition(0, 0));
+        sel.StartSelection(SelectionMode.Character);
+        sel.MoveCursor(new BufferPosition(0, 10));
+
+        var text = sel.ExtractText(GetCell, 16);
+        Assert.Equal("Hello World", text);
+    }
+
+    [Fact]
+    public void ExtractText_Character_MultipleRows_NoSoftWrap()
+    {
+        var rows = new[] { "Line one   ", "Line two   " };
+        TerminalCell? GetCell(int r, int c) =>
+            r < rows.Length && c < rows[r].Length ? MakeCell(rows[r][c].ToString()) : null;
+
+        var sel = new TerminalSelection(new BufferPosition(0, 0));
+        sel.StartSelection(SelectionMode.Character);
+        sel.MoveCursor(new BufferPosition(1, 7));
+
+        var text = sel.ExtractText(GetCell, 11);
+        // No soft wrap → newline between rows, trailing spaces trimmed
+        Assert.Equal("Line one" + Environment.NewLine + "Line two", text);
+    }
+
+    [Fact]
+    public void ExtractText_Character_WithSoftWrap_JoinsRows()
+    {
+        // Row 0 has soft wrap at position 9 (last cell), row 1 continues
+        var row0 = "This is a ".ToCharArray();
+        var row1 = "long line  ".ToCharArray();
+        
+        TerminalCell? GetCell(int r, int c)
+        {
+            if (r == 0 && c < 10)
+            {
+                bool sw = c == 9; // last cell of row has SoftWrap
+                return MakeCell(row0[c].ToString(), sw);
+            }
+            if (r == 1 && c < 11)
+                return MakeCell(row1[c].ToString());
+            return null;
+        }
+
+        var sel = new TerminalSelection(new BufferPosition(0, 0));
+        sel.StartSelection(SelectionMode.Character);
+        sel.MoveCursor(new BufferPosition(1, 8));
+
+        var text = sel.ExtractText(GetCell, 10);
+        // Soft wrap → no newline between rows
+        Assert.Equal("This is a long line", text);
+    }
+
+    [Fact]
+    public void ExtractText_Line_SelectsFullRows()
+    {
+        var rows = new[] { "AAA   ", "BBB   ", "CCC   " };
+        TerminalCell? GetCell(int r, int c) =>
+            r < rows.Length && c < rows[r].Length ? MakeCell(rows[r][c].ToString()) : null;
+
+        var sel = new TerminalSelection(new BufferPosition(0, 2));
+        sel.StartSelection(SelectionMode.Line);
+        sel.MoveCursor(new BufferPosition(1, 0));
+
+        var text = sel.ExtractText(GetCell, 6);
+        Assert.Equal("AAA" + Environment.NewLine + "BBB", text);
+    }
+
+    [Fact]
+    public void ExtractText_Block_SelectsRectangle()
+    {
+        var rows = new[] { "ABCDEF", "GHIJKL", "MNOPQR" };
+        TerminalCell? GetCell(int r, int c) =>
+            r < rows.Length && c < rows[r].Length ? MakeCell(rows[r][c].ToString()) : null;
+
+        var sel = new TerminalSelection(new BufferPosition(0, 1));
+        sel.StartSelection(SelectionMode.Block);
+        sel.MoveCursor(new BufferPosition(2, 3));
+
+        var text = sel.ExtractText(GetCell, 6);
+        Assert.Equal("BCD" + Environment.NewLine + "HIJ" + Environment.NewLine + "NOP", text);
+    }
+
+    [Fact]
+    public void ExtractText_WhenNotSelecting_ReturnsNull()
+    {
+        var sel = new TerminalSelection(new BufferPosition(0, 0));
+        var text = sel.ExtractText((_, _) => MakeCell("A"), 10);
+        Assert.Null(text);
+    }
+
+    [Fact]
+    public void ExtractText_SkipsWidePaddingCells()
+    {
+        // Simulate a wide character: "W" at column 0, empty string at column 1 (padding)
+        TerminalCell? GetCell(int r, int c)
+        {
+            if (r != 0) return null;
+            return c switch
+            {
+                0 => MakeCell("Ｗ"),  // fullwidth W
+                1 => MakeCell(""),    // padding cell
+                2 => MakeCell("x"),
+                _ => null
+            };
+        }
+
+        var sel = new TerminalSelection(new BufferPosition(0, 0));
+        sel.StartSelection(SelectionMode.Character);
+        sel.MoveCursor(new BufferPosition(0, 2));
+
+        var text = sel.ExtractText(GetCell, 3);
+        Assert.Equal("Ｗx", text);
+    }
+}


### PR DESCRIPTION
## Summary

Implements tmux-style copy mode for the TerminalWidget, enabling keyboard-driven text selection and copying from embedded terminal sessions.

### Key Features

- **Output queuing** — when copy mode is active, new output from the child process is queued (not applied to the screen buffer), preserving selection stability. Queued output is flushed on exit.
- **Three selection modes** — character, line, and block/rectangular selection
- **No default bindings** — the terminal widget exposes copy mode as a set of public APIs and a \CopyModeInput\ event. Consumers wire up their own key bindings.
- **Selection highlight** — selected cells rendered with inverted colors; copy mode cursor shown as a block
- **Soft-wrap aware** — text extraction respects \CellAttributes.SoftWrap\ to avoid spurious newlines on wrapped lines
- **\TextCopied\ event** — fired when text is copied, for clipboard integration (e.g., OSC 52)

### Architecture

| Component | Purpose |
|-----------|---------|
| \TerminalSelection\ | Selection model — anchor/cursor positions, character/line/block modes, virtual row addressing, text extraction |
| \TerminalWidgetHandle\ | Output queuing, copy mode state, navigation methods (\MoveCopyModeCursor\, \MoveWordForward\, etc.), \CopyModeInput\/\CopyModeChanged\/\TextCopied\ events |
| \TerminalNode\ | Intercepts input during copy mode (prevents forwarding to child), renders selection highlight |
| \TerminalWidget\ | ActionId definitions for rebindable copy mode operations |

### Demo

\samples/TerminalSelectionDemo\ — terminal on the left, editor on the right showing copied text, InfoBar with copy mode status and current selection mode.

**Demo bindings:** F6 enter, h/j/k/l navigate, v/V/Alt+V for char/line/block selection, y/Enter copy, Esc cancel.

### Tests

35 tests covering selection model (coordinate math, text extraction with soft wraps and wide chars) and copy mode (output queuing, enter/exit lifecycle, cursor positioning).

### Future Work (Phase 2)

- Mouse-based selection (click-drag, Shift+Click override, double/triple-click)