### PR TITLE
WpfTerm: WPF terminal emulator spike with KGP and custom ConPTY

### DIFF
--- a/samples/KgpProbe/KgpProbe.cs
+++ b/samples/KgpProbe/KgpProbe.cs
@@ -1,0 +1,17 @@
+// Tiny diagnostic: writes a KGP APC query to stdout and exits.
+// Run inside WpfTerm to test if APC passes through ConPTY.
+using System.Text;
+Console.OutputEncoding = Encoding.UTF8;
+
+// ESC _ G a=q,i=99,s=1,v=1,f=32; AAAA ESC \
+// This is a KGP query (action=query) with 1x1 RGBA pixel
+var apc = "\x1b_Ga=q,i=99,s=1,v=1,f=32;AAAA\x1b\\";
+Console.Write("Sending KGP APC probe...");
+Console.Out.Flush();
+
+// Write raw bytes to stdout  
+using var stdout = Console.OpenStandardOutput();
+stdout.Write(Encoding.UTF8.GetBytes(apc));
+stdout.Flush();
+
+Console.WriteLine(" done. Check title bar for token count.");

--- a/samples/KgpProbe/KgpProbe.csproj
+++ b/samples/KgpProbe/KgpProbe.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/samples/WpfTerm/AnsiKeyEncoder.cs
+++ b/samples/WpfTerm/AnsiKeyEncoder.cs
@@ -98,4 +98,21 @@ public static class AnsiKeyEncoder
 
         return Encoding.UTF8.GetBytes(text);
     }
+
+    /// <summary>
+    /// Encodes a mouse event into an SGR (mode 1006) mouse escape sequence.
+    /// Format: ESC [ &lt; button ; x ; y M (press/move) or ESC [ &lt; button ; x ; y m (release)
+    /// </summary>
+    /// <param name="button">SGR button code (0=left, 1=middle, 2=right, 64=scrollup, 65=scrolldown, +32=motion).</param>
+    /// <param name="x">1-based column.</param>
+    /// <param name="y">1-based row.</param>
+    /// <param name="isRelease">True for button release (lowercase 'm'), false for press/move (uppercase 'M').</param>
+    /// <param name="modifiers">Keyboard modifiers to encode (+4=shift, +8=alt, +16=ctrl).</param>
+    public static byte[] EncodeMouse(int button, int x, int y, bool isRelease, int modifiers = 0)
+    {
+        button |= modifiers;
+        var terminator = isRelease ? 'm' : 'M';
+        var seq = $"\x1b[<{button};{x};{y}{terminator}";
+        return Encoding.ASCII.GetBytes(seq);
+    }
 }

--- a/samples/WpfTerm/AnsiKeyEncoder.cs
+++ b/samples/WpfTerm/AnsiKeyEncoder.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Windows.Input;
 
@@ -8,6 +9,14 @@ namespace WpfTerm;
 /// </summary>
 public static class AnsiKeyEncoder
 {
+    [DllImport("user32.dll")]
+    private static extern int ToUnicode(
+        uint wVirtKey, uint wScanCode, byte[] lpKeyState,
+        [Out, MarshalAs(UnmanagedType.LPWStr)] StringBuilder pwszBuff,
+        int cchBuff, uint wFlags);
+
+    [DllImport("user32.dll")]
+    private static extern bool GetKeyboardState(byte[] lpKeyState);
     /// <summary>
     /// Encodes a WPF key event into the ANSI byte sequence that a terminal would send.
     /// Returns null if the key should be ignored.
@@ -97,6 +106,36 @@ public static class AnsiKeyEncoder
             return null;
 
         return Encoding.UTF8.GetBytes(text);
+    }
+
+    /// <summary>
+    /// Converts a WPF KeyEventArgs to a printable character using Win32 ToUnicode.
+    /// Returns UTF-8 bytes of the character, or null if the key isn't printable.
+    /// This bypasses WPF's TextInput which can be suppressed during mouse activity.
+    /// </summary>
+    public static byte[]? KeyToText(KeyEventArgs e)
+    {
+        var key = e.Key == Key.System ? e.SystemKey : e.Key;
+        var virtualKey = (uint)KeyInterop.VirtualKeyFromKey(key);
+        var scanCode = (uint)((e.SystemKey != Key.None ? KeyInterop.VirtualKeyFromKey(e.SystemKey) : KeyInterop.VirtualKeyFromKey(e.Key)));
+
+        var keyboardState = new byte[256];
+        if (!GetKeyboardState(keyboardState))
+            return null;
+
+        var sb = new StringBuilder(4);
+        int result = ToUnicode(virtualKey, 0, keyboardState, sb, sb.Capacity, 0);
+
+        if (result <= 0 || sb.Length == 0)
+            return null;
+
+        var ch = sb.ToString(0, result);
+
+        // Filter out control characters that should be handled by Encode()
+        if (ch.Length == 1 && ch[0] < 0x20)
+            return null;
+
+        return Encoding.UTF8.GetBytes(ch);
     }
 
     /// <summary>

--- a/samples/WpfTerm/AnsiKeyEncoder.cs
+++ b/samples/WpfTerm/AnsiKeyEncoder.cs
@@ -1,0 +1,101 @@
+using System.Text;
+using System.Windows.Input;
+
+namespace WpfTerm;
+
+/// <summary>
+/// Converts WPF key events into ANSI escape sequences for the PTY.
+/// </summary>
+public static class AnsiKeyEncoder
+{
+    /// <summary>
+    /// Encodes a WPF key event into the ANSI byte sequence that a terminal would send.
+    /// Returns null if the key should be ignored.
+    /// </summary>
+    public static byte[]? Encode(KeyEventArgs e)
+    {
+        var key = e.Key == Key.System ? e.SystemKey : e.Key;
+        var modifiers = Keyboard.Modifiers;
+        bool ctrl = (modifiers & ModifierKeys.Control) != 0;
+        bool shift = (modifiers & ModifierKeys.Shift) != 0;
+        bool alt = (modifiers & ModifierKeys.Alt) != 0;
+
+        // Ctrl+letter → control character (0x01-0x1A)
+        if (ctrl && !alt && key >= Key.A && key <= Key.Z)
+        {
+            byte controlChar = (byte)(key - Key.A + 1);
+            return [controlChar];
+        }
+
+        // Special keys
+        string? sequence = key switch
+        {
+            Key.Enter => "\r",
+            Key.Escape => "\x1b",
+            Key.Back => "\x7f",
+            Key.Tab when shift => "\x1b[Z",
+            Key.Tab => "\t",
+            Key.Space => " ",
+
+            // Arrow keys
+            Key.Up when ctrl => "\x1b[1;5A",
+            Key.Down when ctrl => "\x1b[1;5B",
+            Key.Right when ctrl => "\x1b[1;5C",
+            Key.Left when ctrl => "\x1b[1;5D",
+            Key.Up when shift => "\x1b[1;2A",
+            Key.Down when shift => "\x1b[1;2B",
+            Key.Right when shift => "\x1b[1;2C",
+            Key.Left when shift => "\x1b[1;2D",
+            Key.Up => "\x1b[A",
+            Key.Down => "\x1b[B",
+            Key.Right => "\x1b[C",
+            Key.Left => "\x1b[D",
+
+            // Navigation
+            Key.Home => "\x1b[H",
+            Key.End => "\x1b[F",
+            Key.Insert => "\x1b[2~",
+            Key.Delete => "\x1b[3~",
+            Key.PageUp => "\x1b[5~",
+            Key.PageDown => "\x1b[6~",
+
+            // Function keys
+            Key.F1 => "\x1bOP",
+            Key.F2 => "\x1bOQ",
+            Key.F3 => "\x1bOR",
+            Key.F4 => "\x1bOS",
+            Key.F5 => "\x1b[15~",
+            Key.F6 => "\x1b[17~",
+            Key.F7 => "\x1b[18~",
+            Key.F8 => "\x1b[19~",
+            Key.F9 => "\x1b[20~",
+            Key.F10 => "\x1b[21~",
+            Key.F11 => "\x1b[23~",
+            Key.F12 => "\x1b[24~",
+
+            _ => null
+        };
+
+        if (sequence != null)
+        {
+            // Wrap in Alt (ESC prefix) if alt is held and it's not already an escape sequence
+            if (alt && !sequence.StartsWith("\x1b"))
+                sequence = "\x1b" + sequence;
+
+            return Encoding.UTF8.GetBytes(sequence);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Encodes a text input string (from TextInput event) into UTF-8 bytes for the PTY.
+    /// </summary>
+    public static byte[]? EncodeText(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return null;
+
+        return Encoding.UTF8.GetBytes(text);
+    }
+}

--- a/samples/WpfTerm/App.xaml
+++ b/samples/WpfTerm/App.xaml
@@ -1,0 +1,5 @@
+<Application x:Class="WpfTerm.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+</Application>

--- a/samples/WpfTerm/App.xaml.cs
+++ b/samples/WpfTerm/App.xaml.cs
@@ -1,0 +1,7 @@
+using System.Windows;
+
+namespace WpfTerm;
+
+public partial class App : Application
+{
+}

--- a/samples/WpfTerm/MainWindow.xaml
+++ b/samples/WpfTerm/MainWindow.xaml
@@ -1,0 +1,10 @@
+<Window x:Class="WpfTerm.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:WpfTerm"
+        Title="WpfTerm — Hex1b Terminal Emulator"
+        Width="1024" Height="768"
+        Background="#1E1E1E"
+        WindowStartupLocation="CenterScreen">
+    <local:TerminalControl x:Name="Terminal" />
+</Window>

--- a/samples/WpfTerm/MainWindow.xaml
+++ b/samples/WpfTerm/MainWindow.xaml
@@ -7,8 +7,16 @@
         Background="#1E1E1E"
         WindowStyle="None"
         AllowsTransparency="False"
-        ResizeMode="CanResizeWithGrip"
+        ResizeMode="CanResize"
         WindowStartupLocation="CenterScreen">
+
+    <WindowChrome.WindowChrome>
+        <WindowChrome CaptionHeight="0"
+                      ResizeBorderThickness="4"
+                      GlassFrameThickness="-1"
+                      CornerRadius="0"
+                      UseAeroCaptionButtons="False"/>
+    </WindowChrome.WindowChrome>
 
     <Window.Resources>
         <Style x:Key="TitleBarButton" TargetType="Button">

--- a/samples/WpfTerm/MainWindow.xaml
+++ b/samples/WpfTerm/MainWindow.xaml
@@ -2,9 +2,79 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:WpfTerm"
-        Title="WpfTerm — Hex1b Terminal Emulator"
+        Title="WpfTerm"
         Width="1024" Height="768"
         Background="#1E1E1E"
+        WindowStyle="None"
+        AllowsTransparency="False"
+        ResizeMode="CanResizeWithGrip"
         WindowStartupLocation="CenterScreen">
-    <local:TerminalControl x:Name="Terminal" />
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="32"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- Custom title bar -->
+        <Border x:Name="TitleBar" Grid.Row="0" Background="#1E1E1E"
+                MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+            <DockPanel LastChildFill="True">
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,4,0">
+                    <Button Content="─" Click="MinimizeButton_Click" Style="{StaticResource TitleBarButton}" />
+                    <Button Content="□" Click="MaximizeButton_Click" Style="{StaticResource TitleBarButton}" />
+                    <Button x:Name="CloseButton" Content="✕" Click="CloseButton_Click" Style="{StaticResource CloseButton}" />
+                </StackPanel>
+                <TextBlock x:Name="TitleText" Text="WpfTerm" Foreground="#999999" FontSize="12"
+                           VerticalAlignment="Center" Margin="12,0,0,0" />
+            </DockPanel>
+        </Border>
+
+        <!-- Terminal with top shadow -->
+        <Grid Grid.Row="1">
+            <!-- Drop shadow at top edge -->
+            <Border Height="8" VerticalAlignment="Top" IsHitTestVisible="False" Panel.ZIndex="1">
+                <Border.Background>
+                    <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
+                        <GradientStop Color="#60000000" Offset="0"/>
+                        <GradientStop Color="#00000000" Offset="1"/>
+                    </LinearGradientBrush>
+                </Border.Background>
+            </Border>
+            <local:TerminalControl x:Name="Terminal" />
+        </Grid>
+    </Grid>
+
+    <Window.Resources>
+        <Style x:Key="TitleBarButton" TargetType="Button">
+            <Setter Property="Width" Value="46"/>
+            <Setter Property="Height" Value="32"/>
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Foreground" Value="#999999"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="Cursor" Value="Arrow"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bd" Background="{TemplateBinding Background}">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="#30FFFFFF"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+        <Style x:Key="CloseButton" TargetType="Button" BasedOn="{StaticResource TitleBarButton}">
+            <Style.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter Property="Background" Value="#E81123"/>
+                    <Setter Property="Foreground" Value="White"/>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+    </Window.Resources>
 </Window>

--- a/samples/WpfTerm/MainWindow.xaml
+++ b/samples/WpfTerm/MainWindow.xaml
@@ -66,30 +66,33 @@
             <RowDefinition Height="*"/>
         </Grid.RowDefinitions>
 
-        <!-- Custom title bar -->
-        <Border x:Name="TitleBar" Grid.Row="0" Background="#1E1E1E"
-                MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
-            <DockPanel LastChildFill="True">
-                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,4,0">
-                    <Button Content="─" Click="MinimizeButton_Click" Style="{StaticResource TitleBarButton}" />
-                    <Button Content="□" Click="MaximizeButton_Click" Style="{StaticResource TitleBarButton}" />
-                    <Button Content="✕" Click="CloseButton_Click" Style="{StaticResource CloseButton}" />
-                </StackPanel>
-                <TextBlock x:Name="TitleText" Text="WpfTerm" Foreground="#999999" FontSize="12"
-                           VerticalAlignment="Center" Margin="12,0,0,0" />
-            </DockPanel>
-        </Border>
-
-        <!-- Terminal with top shadow -->
-        <Grid Grid.Row="1">
-            <Border Height="8" VerticalAlignment="Top" IsHitTestVisible="False" Panel.ZIndex="1">
+        <!-- Custom title bar with shadow at bottom flowing up into it -->
+        <Grid Grid.Row="0">
+            <Border x:Name="TitleBar" Background="#1E1E1E"
+                    MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+                <DockPanel LastChildFill="True">
+                    <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,4,0">
+                        <Button Content="─" Click="MinimizeButton_Click" Style="{StaticResource TitleBarButton}" />
+                        <Button Content="□" Click="MaximizeButton_Click" Style="{StaticResource TitleBarButton}" />
+                        <Button Content="✕" Click="CloseButton_Click" Style="{StaticResource CloseButton}" />
+                    </StackPanel>
+                    <TextBlock x:Name="TitleText" Text="WpfTerm" Foreground="#999999" FontSize="12"
+                               VerticalAlignment="Center" Margin="12,0,0,0" />
+                </DockPanel>
+            </Border>
+            <!-- Drop shadow flowing upward from terminal into title bar -->
+            <Border Height="12" VerticalAlignment="Bottom" IsHitTestVisible="False" Panel.ZIndex="1">
                 <Border.Background>
-                    <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
-                        <GradientStop Color="#60000000" Offset="0"/>
+                    <LinearGradientBrush StartPoint="0,1" EndPoint="0,0">
+                        <GradientStop Color="#80000000" Offset="0"/>
                         <GradientStop Color="#00000000" Offset="1"/>
                     </LinearGradientBrush>
                 </Border.Background>
             </Border>
+        </Grid>
+
+        <!-- Terminal content -->
+        <Grid Grid.Row="1">
             <local:TerminalControl x:Name="Terminal" />
         </Grid>
     </Grid>

--- a/samples/WpfTerm/MainWindow.xaml
+++ b/samples/WpfTerm/MainWindow.xaml
@@ -9,40 +9,6 @@
         AllowsTransparency="False"
         ResizeMode="CanResizeWithGrip"
         WindowStartupLocation="CenterScreen">
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="32"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
-
-        <!-- Custom title bar -->
-        <Border x:Name="TitleBar" Grid.Row="0" Background="#1E1E1E"
-                MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
-            <DockPanel LastChildFill="True">
-                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,4,0">
-                    <Button Content="─" Click="MinimizeButton_Click" Style="{StaticResource TitleBarButton}" />
-                    <Button Content="□" Click="MaximizeButton_Click" Style="{StaticResource TitleBarButton}" />
-                    <Button x:Name="CloseButton" Content="✕" Click="CloseButton_Click" Style="{StaticResource CloseButton}" />
-                </StackPanel>
-                <TextBlock x:Name="TitleText" Text="WpfTerm" Foreground="#999999" FontSize="12"
-                           VerticalAlignment="Center" Margin="12,0,0,0" />
-            </DockPanel>
-        </Border>
-
-        <!-- Terminal with top shadow -->
-        <Grid Grid.Row="1">
-            <!-- Drop shadow at top edge -->
-            <Border Height="8" VerticalAlignment="Top" IsHitTestVisible="False" Panel.ZIndex="1">
-                <Border.Background>
-                    <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
-                        <GradientStop Color="#60000000" Offset="0"/>
-                        <GradientStop Color="#00000000" Offset="1"/>
-                    </LinearGradientBrush>
-                </Border.Background>
-            </Border>
-            <local:TerminalControl x:Name="Terminal" />
-        </Grid>
-    </Grid>
 
     <Window.Resources>
         <Style x:Key="TitleBarButton" TargetType="Button">
@@ -68,13 +34,63 @@
                 </Setter.Value>
             </Setter>
         </Style>
-        <Style x:Key="CloseButton" TargetType="Button" BasedOn="{StaticResource TitleBarButton}">
-            <Style.Triggers>
-                <Trigger Property="IsMouseOver" Value="True">
-                    <Setter Property="Background" Value="#E81123"/>
-                    <Setter Property="Foreground" Value="White"/>
-                </Trigger>
-            </Style.Triggers>
+        <Style x:Key="CloseButton" TargetType="Button">
+            <Setter Property="Width" Value="46"/>
+            <Setter Property="Height" Value="32"/>
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Foreground" Value="#999999"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="FontSize" Value="13"/>
+            <Setter Property="Cursor" Value="Arrow"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="Button">
+                        <Border x:Name="Bd" Background="{TemplateBinding Background}">
+                            <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="Bd" Property="Background" Value="#E81123"/>
+                                <Setter Property="Foreground" Value="White"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
         </Style>
     </Window.Resources>
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="32"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- Custom title bar -->
+        <Border x:Name="TitleBar" Grid.Row="0" Background="#1E1E1E"
+                MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+            <DockPanel LastChildFill="True">
+                <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" VerticalAlignment="Center" Margin="0,0,4,0">
+                    <Button Content="─" Click="MinimizeButton_Click" Style="{StaticResource TitleBarButton}" />
+                    <Button Content="□" Click="MaximizeButton_Click" Style="{StaticResource TitleBarButton}" />
+                    <Button Content="✕" Click="CloseButton_Click" Style="{StaticResource CloseButton}" />
+                </StackPanel>
+                <TextBlock x:Name="TitleText" Text="WpfTerm" Foreground="#999999" FontSize="12"
+                           VerticalAlignment="Center" Margin="12,0,0,0" />
+            </DockPanel>
+        </Border>
+
+        <!-- Terminal with top shadow -->
+        <Grid Grid.Row="1">
+            <Border Height="8" VerticalAlignment="Top" IsHitTestVisible="False" Panel.ZIndex="1">
+                <Border.Background>
+                    <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
+                        <GradientStop Color="#60000000" Offset="0"/>
+                        <GradientStop Color="#00000000" Offset="1"/>
+                    </LinearGradientBrush>
+                </Border.Background>
+            </Border>
+            <local:TerminalControl x:Name="Terminal" />
+        </Grid>
+    </Grid>
 </Window>

--- a/samples/WpfTerm/MainWindow.xaml.cs
+++ b/samples/WpfTerm/MainWindow.xaml.cs
@@ -80,8 +80,9 @@ public partial class MainWindow : Window
             var stats = _adapter.TokenStats;
             var input = _adapter.InputStats;
             var wpf = Terminal.WpfEventCounts;
+            var win32 = Terminal.Win32Counts;
             var backend = conptyDll != null ? "conpty.dll" : "kernel32";
-            Title = $"WpfTerm [{backend}] — wpf:pk{wpf.PreviewKeyDown}/kd{wpf.KeyDown}/ti{wpf.TextInput} in:k{input.Keys}/m{input.Mouse}";
+            Title = $"WpfTerm [{backend}] — wm:kd{win32.WmKeyDown}/ch{win32.WmChar} wpf:pk{wpf.PreviewKeyDown}/kd{wpf.KeyDown}/ti{wpf.TextInput} in:k{input.Keys}/m{input.Mouse}";
         };
         diagTimer.Start();
 

--- a/samples/WpfTerm/MainWindow.xaml.cs
+++ b/samples/WpfTerm/MainWindow.xaml.cs
@@ -35,8 +35,11 @@ public partial class MainWindow : Window
 
         _adapter = new WpfTerminalAdapter(120, 30);
 
-        // Create KGP side-channel pipe server — child processes will send
-        // KGP image data here since ConPTY strips APC sequences
+        // Try to use custom conpty.dll for VT passthrough (enables KGP through ConPTY)
+        var conptyDll = FindConptyDll();
+
+        // Create KGP side-channel pipe server as fallback — child processes will send
+        // KGP image data here if ConPTY strips APC sequences
         _kgpPipeServer = new KgpPipeServer();
         _kgpPipeServer.Start();
 
@@ -47,6 +50,8 @@ public partial class MainWindow : Window
                 options.FileName = pwshPath;
                 options.Arguments = ["-NoLogo", "-NoProfile"];
                 options.WindowsPtyMode = WindowsPtyMode.Direct;
+                if (conptyDll != null)
+                    options.ConptyDllPath = conptyDll;
                 // Pass KGP pipe name to child so it can divert KGP there
                 options.Environment ??= new Dictionary<string, string>();
                 options.Environment["HEX1B_KGP_PIPE"] = _kgpPipeServer.PipeName;
@@ -65,7 +70,8 @@ public partial class MainWindow : Window
         {
             var placements = _adapter!.GetKgpPlacements();
             var stats = _adapter.TokenStats;
-            Title = $"WpfTerm — kgp:{_adapter.KgpTokensReceived} place:{placements.Count} unrec:{stats.Unrecognized} total:{stats.Total}";
+            var backend = conptyDll != null ? "conpty.dll" : "kernel32";
+            Title = $"WpfTerm [{backend}] — kgp:{_adapter.KgpTokensReceived} place:{placements.Count} unrec:{stats.Unrecognized} total:{stats.Total}";
         };
         diagTimer.Start();
 
@@ -135,6 +141,38 @@ public partial class MainWindow : Window
             catch (ArgumentException)
             {
             }
+        }
+
+        return null;
+    }
+
+    private static string? FindConptyDll()
+    {
+        // 1. Next to our exe
+        var local = Path.Combine(AppContext.BaseDirectory, "conpty", "conpty.dll");
+        if (File.Exists(local)) return local;
+
+        // 2. Search VS Code installations for the bundled conpty.dll
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        string[] vsCodePaths =
+        [
+            Path.Combine(localAppData, "Programs", "Microsoft VS Code Insiders"),
+            Path.Combine(localAppData, "Programs", "Microsoft VS Code"),
+        ];
+
+        foreach (var vsCodeRoot in vsCodePaths)
+        {
+            if (!Directory.Exists(vsCodeRoot)) continue;
+            try
+            {
+                var matches = Directory.GetFiles(vsCodeRoot, "conpty.dll", SearchOption.AllDirectories);
+                // Find the one inside node-pty (not conpty.node)
+                var nodePtyDll = matches.FirstOrDefault(p =>
+                    p.Contains("node-pty", StringComparison.OrdinalIgnoreCase) &&
+                    p.Contains("conpty\\conpty.dll", StringComparison.OrdinalIgnoreCase));
+                if (nodePtyDll != null) return nodePtyDll;
+            }
+            catch { }
         }
 
         return null;

--- a/samples/WpfTerm/MainWindow.xaml.cs
+++ b/samples/WpfTerm/MainWindow.xaml.cs
@@ -78,8 +78,9 @@ public partial class MainWindow : Window
         {
             var placements = _adapter!.GetKgpPlacements();
             var stats = _adapter.TokenStats;
+            var input = _adapter.InputStats;
             var backend = conptyDll != null ? "conpty.dll" : "kernel32";
-            Title = $"WpfTerm [{backend}] — kgp:{_adapter.KgpTokensReceived} place:{placements.Count} unrec:{stats.Unrecognized} total:{stats.Total}";
+            Title = $"WpfTerm [{backend}] — in:k{input.Keys}/m{input.Mouse} kgp:{_adapter.KgpTokensReceived} place:{placements.Count}";
         };
         diagTimer.Start();
 

--- a/samples/WpfTerm/MainWindow.xaml.cs
+++ b/samples/WpfTerm/MainWindow.xaml.cs
@@ -63,6 +63,7 @@ public partial class MainWindow : Window
                     options.Environment["HEX1B_KGP_PIPE"] = _kgpPipeServer.PipeName;
                 }
             })
+            .WithScrollback(10000)
             .WithDimensions(_adapter.Width, _adapter.Height)
             .Build();
 

--- a/samples/WpfTerm/MainWindow.xaml.cs
+++ b/samples/WpfTerm/MainWindow.xaml.cs
@@ -35,17 +35,15 @@ public partial class MainWindow : Window
 
         _adapter = new WpfTerminalAdapter(120, 30);
 
-        // Try to use custom conpty.dll for VT passthrough (enables KGP natively through ConPTY)
-        // Set HEX1B_CONPTY=kernel32 env var to force OS ConPTY for debugging
-        var forceKernel32 = Environment.GetEnvironmentVariable("HEX1B_CONPTY") == "kernel32";
-        var conptyDll = forceKernel32 ? null : FindConptyDll();
+        // ConPTY backend selection:
+        // - Default: OS kernel32 ConPTY (most compatible)
+        // - Set HEX1B_CONPTY=custom to use VS Code's conpty.dll (enables KGP passthrough but may break some apps)
+        var useCustomConpty = Environment.GetEnvironmentVariable("HEX1B_CONPTY") == "custom";
+        var conptyDll = useCustomConpty ? FindConptyDll() : null;
 
-        // Only use side-channel pipe when custom conpty.dll is NOT available
-        if (conptyDll == null)
-        {
-            _kgpPipeServer = new KgpPipeServer();
-            _kgpPipeServer.Start();
-        }
+        // KGP side-channel pipe — always available as fallback for KGP when using kernel32 ConPTY
+        _kgpPipeServer = new KgpPipeServer();
+        _kgpPipeServer.Start();
 
         _terminal = Hex1bTerminal.CreateBuilder()
             .WithPresentation(_adapter)
@@ -56,22 +54,15 @@ public partial class MainWindow : Window
                 options.WindowsPtyMode = WindowsPtyMode.Direct;
                 if (conptyDll != null)
                     options.ConptyDllPath = conptyDll;
-                // Only set pipe env var when falling back to side-channel
-                if (_kgpPipeServer != null)
-                {
-                    options.Environment ??= new Dictionary<string, string>();
-                    options.Environment["HEX1B_KGP_PIPE"] = _kgpPipeServer.PipeName;
-                }
+                options.Environment ??= new Dictionary<string, string>();
+                options.Environment["HEX1B_KGP_PIPE"] = _kgpPipeServer.PipeName;
             })
             .WithScrollback(10000)
             .WithDimensions(_adapter.Width, _adapter.Height)
             .Build();
 
-        // Wire pipe server to terminal if using side-channel
-        if (_kgpPipeServer != null)
-        {
-            _kgpPipeServer.SetTokenHandler(token => _terminal.ProcessKgpFromSideChannel(token));
-        }
+        // Wire pipe server to terminal — KGP tokens from pipe get processed
+        _kgpPipeServer.SetTokenHandler(token => _terminal.ProcessKgpFromSideChannel(token));
 
         Terminal.Attach(_adapter);
 

--- a/samples/WpfTerm/MainWindow.xaml.cs
+++ b/samples/WpfTerm/MainWindow.xaml.cs
@@ -81,7 +81,7 @@ public partial class MainWindow : Window
             var input = _adapter.InputStats;
             var wpf = Terminal.WpfEventCounts;
             var backend = conptyDll != null ? "conpty.dll" : "kernel32";
-            Title = $"WpfTerm [{backend}] — wpf:kd{wpf.KeyDown}/ti{wpf.TextInput} in:k{input.Keys}/m{input.Mouse}";
+            Title = $"WpfTerm [{backend}] — wpf:pk{wpf.PreviewKeyDown}/kd{wpf.KeyDown}/ti{wpf.TextInput} in:k{input.Keys}/m{input.Mouse}";
         };
         diagTimer.Start();
 

--- a/samples/WpfTerm/MainWindow.xaml.cs
+++ b/samples/WpfTerm/MainWindow.xaml.cs
@@ -50,7 +50,7 @@ public partial class MainWindow : Window
             .WithPtyProcess(options =>
             {
                 options.FileName = pwshPath;
-                options.Arguments = ["-NoLogo", "-NoProfile"];
+                options.Arguments = ["-NoLogo"];
                 options.WindowsPtyMode = WindowsPtyMode.Direct;
                 if (conptyDll != null)
                     options.ConptyDllPath = conptyDll;

--- a/samples/WpfTerm/MainWindow.xaml.cs
+++ b/samples/WpfTerm/MainWindow.xaml.cs
@@ -35,13 +35,15 @@ public partial class MainWindow : Window
 
         _adapter = new WpfTerminalAdapter(120, 30);
 
-        // Try to use custom conpty.dll for VT passthrough (enables KGP through ConPTY)
+        // Try to use custom conpty.dll for VT passthrough (enables KGP natively through ConPTY)
         var conptyDll = FindConptyDll();
 
-        // Create KGP side-channel pipe server as fallback — child processes will send
-        // KGP image data here if ConPTY strips APC sequences
-        _kgpPipeServer = new KgpPipeServer();
-        _kgpPipeServer.Start();
+        // Only use side-channel pipe when custom conpty.dll is NOT available
+        if (conptyDll == null)
+        {
+            _kgpPipeServer = new KgpPipeServer();
+            _kgpPipeServer.Start();
+        }
 
         _terminal = Hex1bTerminal.CreateBuilder()
             .WithPresentation(_adapter)
@@ -52,15 +54,21 @@ public partial class MainWindow : Window
                 options.WindowsPtyMode = WindowsPtyMode.Direct;
                 if (conptyDll != null)
                     options.ConptyDllPath = conptyDll;
-                // Pass KGP pipe name to child so it can divert KGP there
-                options.Environment ??= new Dictionary<string, string>();
-                options.Environment["HEX1B_KGP_PIPE"] = _kgpPipeServer.PipeName;
+                // Only set pipe env var when falling back to side-channel
+                if (_kgpPipeServer != null)
+                {
+                    options.Environment ??= new Dictionary<string, string>();
+                    options.Environment["HEX1B_KGP_PIPE"] = _kgpPipeServer.PipeName;
+                }
             })
             .WithDimensions(_adapter.Width, _adapter.Height)
             .Build();
 
-        // Wire pipe server to terminal — KGP tokens from pipe get processed
-        _kgpPipeServer.SetTokenHandler(token => _terminal.ProcessKgpFromSideChannel(token));
+        // Wire pipe server to terminal if using side-channel
+        if (_kgpPipeServer != null)
+        {
+            _kgpPipeServer.SetTokenHandler(token => _terminal.ProcessKgpFromSideChannel(token));
+        }
 
         Terminal.Attach(_adapter);
 

--- a/samples/WpfTerm/MainWindow.xaml.cs
+++ b/samples/WpfTerm/MainWindow.xaml.cs
@@ -79,8 +79,9 @@ public partial class MainWindow : Window
             var placements = _adapter!.GetKgpPlacements();
             var stats = _adapter.TokenStats;
             var input = _adapter.InputStats;
+            var wpf = Terminal.WpfEventCounts;
             var backend = conptyDll != null ? "conpty.dll" : "kernel32";
-            Title = $"WpfTerm [{backend}] — in:k{input.Keys}/m{input.Mouse} kgp:{_adapter.KgpTokensReceived} place:{placements.Count}";
+            Title = $"WpfTerm [{backend}] — wpf:kd{wpf.KeyDown}/ti{wpf.TextInput} in:k{input.Keys}/m{input.Mouse}";
         };
         diagTimer.Start();
 

--- a/samples/WpfTerm/MainWindow.xaml.cs
+++ b/samples/WpfTerm/MainWindow.xaml.cs
@@ -75,19 +75,9 @@ public partial class MainWindow : Window
 
         Terminal.Attach(_adapter);
 
-        // Diagnostic: show KGP stats in title bar
-        var diagTimer = new System.Windows.Threading.DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
-        diagTimer.Tick += (_, _) =>
-        {
-            var placements = _adapter!.GetKgpPlacements();
-            var stats = _adapter.TokenStats;
-            var input = _adapter.InputStats;
-            var wpf = Terminal.WpfEventCounts;
-            var win32 = Terminal.Win32Counts;
-            var backend = conptyDll != null ? "conpty.dll" : "kernel32";
-            Title = $"WpfTerm [{backend}] — wm:kd{win32.WmKeyDown}/ch{win32.WmChar} wpf:pk{wpf.PreviewKeyDown}/kd{wpf.KeyDown}/ti{wpf.TextInput} in:k{input.Keys}/m{input.Mouse}";
-        };
-        diagTimer.Start();
+        // Show ConPTY backend in title bar
+        var backend = conptyDll != null ? "conpty.dll" : "kernel32";
+        Title = $"WpfTerm [{backend}]";
 
         // Run the terminal on a background task
         _runTask = Task.Run(async () =>

--- a/samples/WpfTerm/MainWindow.xaml.cs
+++ b/samples/WpfTerm/MainWindow.xaml.cs
@@ -1,0 +1,114 @@
+using System.IO;
+using System.Windows;
+using Hex1b;
+
+namespace WpfTerm;
+
+public partial class MainWindow : Window
+{
+    private Hex1bTerminal? _terminal;
+    private WpfTerminalAdapter? _adapter;
+    private CancellationTokenSource? _cts;
+    private Task? _runTask;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+        Loaded += OnLoaded;
+        Closing += OnClosing;
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        _cts = new CancellationTokenSource();
+
+        // Find PowerShell
+        var pwshPath = FindPwsh();
+        if (pwshPath == null)
+        {
+            MessageBox.Show("PowerShell 7 (pwsh.exe) not found on PATH.", "WpfTerm", MessageBoxButton.OK, MessageBoxImage.Error);
+            Close();
+            return;
+        }
+
+        _adapter = new WpfTerminalAdapter(120, 30);
+
+        _terminal = Hex1bTerminal.CreateBuilder()
+            .WithPresentation(_adapter)
+            .WithPtyProcess(options =>
+            {
+                options.FileName = pwshPath;
+                options.Arguments = ["-NoLogo", "-NoProfile"];
+                options.WindowsPtyMode = WindowsPtyMode.Direct;
+            })
+            .WithDimensions(_adapter.Width, _adapter.Height)
+            .Build();
+
+        Terminal.Attach(_adapter);
+
+        // Run the terminal on a background task
+        _runTask = Task.Run(async () =>
+        {
+            try
+            {
+                await _terminal.RunAsync(_cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Normal shutdown
+            }
+            catch (Exception ex)
+            {
+                await Dispatcher.InvokeAsync(() =>
+                {
+                    Title = $"WpfTerm — Error: {ex.Message}";
+                });
+            }
+        });
+    }
+
+    private async void OnClosing(object? sender, System.ComponentModel.CancelEventArgs e)
+    {
+        if (_cts != null)
+        {
+            await _cts.CancelAsync();
+        }
+
+        if (_terminal != null)
+        {
+            await _terminal.DisposeAsync();
+        }
+
+        if (_runTask != null)
+        {
+            try
+            {
+                await _runTask.WaitAsync(TimeSpan.FromSeconds(3));
+            }
+            catch
+            {
+                // Timeout on shutdown is fine
+            }
+        }
+    }
+
+    private static string? FindPwsh()
+    {
+        var path = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrWhiteSpace(path)) return null;
+
+        foreach (var entry in path.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            try
+            {
+                var candidate = Path.Combine(entry, "pwsh.exe");
+                if (File.Exists(candidate)) return candidate;
+            }
+            catch (ArgumentException)
+            {
+            }
+        }
+
+        return null;
+    }
+}

--- a/samples/WpfTerm/MainWindow.xaml.cs
+++ b/samples/WpfTerm/MainWindow.xaml.cs
@@ -1,5 +1,7 @@
 using System.IO;
 using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media;
 using Hex1b;
 using Hex1b.Kgp;
 
@@ -66,9 +68,11 @@ public partial class MainWindow : Window
 
         Terminal.Attach(_adapter);
 
-        // Show ConPTY backend in title bar
+        // Sync title bar color with terminal's top row background
+        _adapter.OutputReceived += () => Dispatcher.BeginInvoke(SyncTitleBarColor);
+
         var backend = conptyDll != null ? "conpty.dll" : "kernel32";
-        Title = $"WpfTerm [{backend}]";
+        TitleText.Text = $"WpfTerm [{backend}]";
 
         // Run the terminal on a background task
         _runTask = Task.Run(async () =>
@@ -171,5 +175,77 @@ public partial class MainWindow : Window
         }
 
         return null;
+    }
+
+    // === Custom title bar ===
+
+    private void TitleBar_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        if (e.ClickCount == 2)
+        {
+            MaximizeButton_Click(sender, e);
+        }
+        else
+        {
+            DragMove();
+        }
+    }
+
+    private void MinimizeButton_Click(object sender, RoutedEventArgs e)
+        => WindowState = WindowState.Minimized;
+
+    private void MaximizeButton_Click(object sender, RoutedEventArgs e)
+        => WindowState = WindowState == WindowState.Maximized ? WindowState.Normal : WindowState.Maximized;
+
+    private void CloseButton_Click(object sender, RoutedEventArgs e)
+        => Close();
+
+    /// <summary>
+    /// Samples the dominant background color from the top row of the terminal
+    /// buffer and applies it to the title bar.
+    /// </summary>
+    private void SyncTitleBarColor()
+    {
+        if (_adapter == null) return;
+
+        _adapter.RenderUnderLock((buffer, width, height, _, _, _, _) =>
+        {
+            if (height == 0 || width == 0) return;
+
+            // Count background colors in the top row
+            var colorCounts = new Dictionary<uint, int>();
+            for (int x = 0; x < width; x++)
+            {
+                var cell = buffer[0, x];
+                var bg = cell.IsReverse ? cell.Foreground : cell.Background;
+                uint key = bg.HasValue && !bg.Value.IsDefault
+                    ? ((uint)bg.Value.R << 16) | ((uint)bg.Value.G << 8) | bg.Value.B
+                    : 0x1E1E1E; // default background
+                colorCounts[key] = colorCounts.GetValueOrDefault(key) + 1;
+            }
+
+            // Pick the most common color
+            uint dominant = 0x1E1E1E;
+            int maxCount = 0;
+            foreach (var (color, count) in colorCounts)
+            {
+                if (count > maxCount) { dominant = color; maxCount = count; }
+            }
+
+            var r = (byte)((dominant >> 16) & 0xFF);
+            var g = (byte)((dominant >> 8) & 0xFF);
+            var b = (byte)(dominant & 0xFF);
+
+            Dispatcher.BeginInvoke(() =>
+            {
+                TitleBar.Background = new SolidColorBrush(Color.FromRgb(r, g, b));
+
+                // Adjust title text brightness for readability
+                double luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255.0;
+                TitleText.Foreground = new SolidColorBrush(luminance > 0.5
+                    ? Color.FromRgb(0x33, 0x33, 0x33)
+                    : Color.FromRgb(0x99, 0x99, 0x99));
+            });
+        });
     }
 }

--- a/samples/WpfTerm/MainWindow.xaml.cs
+++ b/samples/WpfTerm/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Windows;
 using Hex1b;
+using Hex1b.Kgp;
 
 namespace WpfTerm;
 
@@ -8,6 +9,7 @@ public partial class MainWindow : Window
 {
     private Hex1bTerminal? _terminal;
     private WpfTerminalAdapter? _adapter;
+    private KgpPipeServer? _kgpPipeServer;
     private CancellationTokenSource? _cts;
     private Task? _runTask;
 
@@ -33,6 +35,11 @@ public partial class MainWindow : Window
 
         _adapter = new WpfTerminalAdapter(120, 30);
 
+        // Create KGP side-channel pipe server — child processes will send
+        // KGP image data here since ConPTY strips APC sequences
+        _kgpPipeServer = new KgpPipeServer();
+        _kgpPipeServer.Start();
+
         _terminal = Hex1bTerminal.CreateBuilder()
             .WithPresentation(_adapter)
             .WithPtyProcess(options =>
@@ -40,9 +47,15 @@ public partial class MainWindow : Window
                 options.FileName = pwshPath;
                 options.Arguments = ["-NoLogo", "-NoProfile"];
                 options.WindowsPtyMode = WindowsPtyMode.Direct;
+                // Pass KGP pipe name to child so it can divert KGP there
+                options.Environment ??= new Dictionary<string, string>();
+                options.Environment["HEX1B_KGP_PIPE"] = _kgpPipeServer.PipeName;
             })
             .WithDimensions(_adapter.Width, _adapter.Height)
             .Build();
+
+        // Wire pipe server to terminal — KGP tokens from pipe get processed
+        _kgpPipeServer.SetTokenHandler(token => _terminal.ProcessKgpFromSideChannel(token));
 
         Terminal.Attach(_adapter);
 
@@ -87,6 +100,11 @@ public partial class MainWindow : Window
         if (_terminal != null)
         {
             await _terminal.DisposeAsync();
+        }
+
+        if (_kgpPipeServer != null)
+        {
+            await _kgpPipeServer.DisposeAsync();
         }
 
         if (_runTask != null)

--- a/samples/WpfTerm/MainWindow.xaml.cs
+++ b/samples/WpfTerm/MainWindow.xaml.cs
@@ -36,7 +36,9 @@ public partial class MainWindow : Window
         _adapter = new WpfTerminalAdapter(120, 30);
 
         // Try to use custom conpty.dll for VT passthrough (enables KGP natively through ConPTY)
-        var conptyDll = FindConptyDll();
+        // Set HEX1B_CONPTY=kernel32 env var to force OS ConPTY for debugging
+        var forceKernel32 = Environment.GetEnvironmentVariable("HEX1B_CONPTY") == "kernel32";
+        var conptyDll = forceKernel32 ? null : FindConptyDll();
 
         // Only use side-channel pipe when custom conpty.dll is NOT available
         if (conptyDll == null)

--- a/samples/WpfTerm/MainWindow.xaml.cs
+++ b/samples/WpfTerm/MainWindow.xaml.cs
@@ -51,7 +51,8 @@ public partial class MainWindow : Window
         diagTimer.Tick += (_, _) =>
         {
             var placements = _adapter!.GetKgpPlacements();
-            Title = $"WpfTerm — KGP tokens:{_adapter.KgpTokensReceived} placements:{placements.Count}";
+            var stats = _adapter.TokenStats;
+            Title = $"WpfTerm — kgp:{_adapter.KgpTokensReceived} place:{placements.Count} unrec:{stats.Unrecognized} total:{stats.Total}";
         };
         diagTimer.Start();
 

--- a/samples/WpfTerm/MainWindow.xaml.cs
+++ b/samples/WpfTerm/MainWindow.xaml.cs
@@ -20,6 +20,16 @@ public partial class MainWindow : Window
         InitializeComponent();
         Loaded += OnLoaded;
         Closing += OnClosing;
+        SourceInitialized += OnSourceInitialized;
+    }
+
+    private void OnSourceInitialized(object? sender, EventArgs e)
+    {
+        // Remove the 1px white border that Windows draws on borderless windows
+        if (PresentationSource.FromVisual(this) is System.Windows.Interop.HwndSource hwnd)
+        {
+            hwnd.CompositionTarget.BackgroundColor = System.Windows.Media.Colors.Black;
+        }
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)

--- a/samples/WpfTerm/MainWindow.xaml.cs
+++ b/samples/WpfTerm/MainWindow.xaml.cs
@@ -46,6 +46,15 @@ public partial class MainWindow : Window
 
         Terminal.Attach(_adapter);
 
+        // Diagnostic: show KGP stats in title bar
+        var diagTimer = new System.Windows.Threading.DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+        diagTimer.Tick += (_, _) =>
+        {
+            var placements = _adapter!.GetKgpPlacements();
+            Title = $"WpfTerm — KGP tokens:{_adapter.KgpTokensReceived} placements:{placements.Count}";
+        };
+        diagTimer.Start();
+
         // Run the terminal on a background task
         _runTask = Task.Run(async () =>
         {

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -209,11 +209,27 @@ public class TerminalControl : FrameworkElement
             // Read directly from the adapter's buffer under lock — no copy needed
             _adapter.RenderUnderLock((buffer, width, height, cursorX, cursorY, cursorVisible, cursorShape) =>
             {
+                // Build a set of cells covered by behind-text KGP images
+                // so the text pass doesn't draw opaque backgrounds over them
+                HashSet<(int, int)>? kgpCoveredCells = null;
+                var behindPlacements = placements.Where(p => p.ZIndex < 0).ToList();
+                if (behindPlacements.Count > 0)
+                {
+                    kgpCoveredCells = new HashSet<(int, int)>();
+                    foreach (var p in behindPlacements)
+                    {
+                        for (int py = p.Row; py < p.Row + (int)p.DisplayRows && py < height; py++)
+                            for (int px = p.Column; px < p.Column + (int)p.DisplayColumns && px < width; px++)
+                                if (py >= 0 && px >= 0)
+                                    kgpCoveredCells.Add((px, py));
+                    }
+                }
+
                 // Pass 1: KGP images behind text (ZIndex < 0)
                 RenderKgpImages(dc, placements, width, height, zBehindText: true);
 
-                // Pass 2: Text and cell backgrounds
-                RenderBuffer(dc, buffer, width, height, cursorX, cursorY, cursorVisible, cursorShape);
+                // Pass 2: Text and cell backgrounds (skipping bg for KGP-covered cells)
+                RenderBuffer(dc, buffer, width, height, cursorX, cursorY, cursorVisible, cursorShape, kgpCoveredCells);
 
                 // Pass 3: KGP images on top of text (ZIndex >= 0)
                 RenderKgpImages(dc, placements, width, height, zBehindText: false);
@@ -229,7 +245,8 @@ public class TerminalControl : FrameworkElement
     /// Core rendering: scans rows for attribute runs and draws them as batched GlyphRuns.
     /// </summary>
     private void RenderBuffer(DrawingContext dc, TerminalCell[,] buffer, int width, int height,
-        int cursorX, int cursorY, bool cursorVisible, CursorShape cursorShape)
+        int cursorX, int cursorY, bool cursorVisible, CursorShape cursorShape,
+        HashSet<(int, int)>? kgpCoveredCells)
     {
         for (int y = 0; y < height; y++)
         {
@@ -269,10 +286,39 @@ public class TerminalControl : FrameworkElement
                 double px = runStart * _cellWidth;
                 double runWidth = runLen * _cellWidth;
 
-                // Draw background for the entire run
+                // Draw background for the entire run — skip cells covered by behind-text KGP images
                 if (bg != null)
                 {
-                    dc.DrawRectangle(bg, null, new Rect(px, py, runWidth, _cellHeight));
+                    if (kgpCoveredCells != null)
+                    {
+                        // Draw background only for uncovered segments within the run
+                        int segStart = runStart;
+                        for (int i = runStart; i < runStart + runLen; i++)
+                        {
+                            if (kgpCoveredCells.Contains((i, y)))
+                            {
+                                // Draw any accumulated uncovered segment
+                                if (i > segStart)
+                                {
+                                    double segPx = segStart * _cellWidth;
+                                    double segW = (i - segStart) * _cellWidth;
+                                    dc.DrawRectangle(bg, null, new Rect(segPx, py, segW, _cellHeight));
+                                }
+                                segStart = i + 1;
+                            }
+                        }
+                        // Draw remaining uncovered segment
+                        if (runStart + runLen > segStart)
+                        {
+                            double segPx = segStart * _cellWidth;
+                            double segW = (runStart + runLen - segStart) * _cellWidth;
+                            dc.DrawRectangle(bg, null, new Rect(segPx, py, segW, _cellHeight));
+                        }
+                    }
+                    else
+                    {
+                        dc.DrawRectangle(bg, null, new Rect(px, py, runWidth, _cellHeight));
+                    }
                 }
 
                 // Build GlyphRun for the text

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -137,7 +137,20 @@ public class TerminalControl : FrameworkElement
 
     private void UpdateFont()
     {
-        var fontFamily = new FontFamily("Cascadia Mono");
+        // Try fonts in preference order — probe with TryGetGlyphTypeface to verify availability
+        string[] fontPreferences = ["JetBrainsMono NF", "JetBrainsMono Nerd Font", "Cascadia Mono", "Consolas"];
+        FontFamily? fontFamily = null;
+        foreach (var name in fontPreferences)
+        {
+            var candidate = new FontFamily(name);
+            var typeface = new Typeface(candidate, FontStyles.Normal, FontWeights.Regular, FontStretches.Normal);
+            if (typeface.TryGetGlyphTypeface(out _))
+            {
+                fontFamily = candidate;
+                break;
+            }
+        }
+        fontFamily ??= new FontFamily("Consolas");
         _fallbackTypeface = new Typeface(fontFamily, FontStyles.Normal, FontWeights.Regular, FontStretches.Normal);
 
         // Pre-cache GlyphTypeface variants

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -137,20 +137,7 @@ public class TerminalControl : FrameworkElement
 
     private void UpdateFont()
     {
-        // Try fonts in preference order
-        string[] fontPreferences = ["JetBrainsMono NF", "JetBrainsMono Nerd Font", "Cascadia Mono", "Consolas"];
-        FontFamily? fontFamily = null;
-        foreach (var name in fontPreferences)
-        {
-            var candidate = new FontFamily(name);
-            var typeface = new Typeface(candidate, FontStyles.Normal, FontWeights.Regular, FontStretches.Normal);
-            if (typeface.TryGetGlyphTypeface(out _))
-            {
-                fontFamily = candidate;
-                break;
-            }
-        }
-        fontFamily ??= new FontFamily("Consolas");
+        var fontFamily = new FontFamily("Cascadia Mono");
         _fallbackTypeface = new Typeface(fontFamily, FontStyles.Normal, FontWeights.Regular, FontStretches.Normal);
 
         // Pre-cache GlyphTypeface variants

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -787,10 +787,22 @@ public class TerminalControl : FrameworkElement
     protected override void OnMouseMove(MouseEventArgs e)
     {
         if (_adapter == null || !_adapter.MouseTrackingEnabled) return;
-        if (!_mouseButtonDown) return;
+        
+        // Mode 1003: report all motion. Mode 1002: only report drag (button held).
+        if (!_mouseButtonDown && !_adapter.MouseMotionEnabled) return;
 
         var pos = CellPosition(e);
-        int button = WpfButtonToSgr(_lastPressedButton) | 32;
+        int button;
+        if (_mouseButtonDown)
+        {
+            // Drag: button code + 32 (motion flag)
+            button = WpfButtonToSgr(_lastPressedButton) | 32;
+        }
+        else
+        {
+            // Motion with no button: 35 = 32 (motion) + 3 (no button)
+            button = 35;
+        }
         int modifiers = GetMouseModifiers();
         _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(button, pos.x, pos.y, isRelease: false, modifiers));
     }

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -314,19 +314,40 @@ public class TerminalControl : FrameworkElement
         {
             double cellY = y * _cellHeight;
 
+            // Pass 1: Draw backgrounds as continuous runs to eliminate sub-pixel gaps
+            int bgRunStart = 0;
+            SolidColorBrush? bgRunBrush = null;
+            for (int x = 0; x <= width; x++)
+            {
+                SolidColorBrush? cellBg = null;
+                if (x < width)
+                {
+                    var c = buffer[y, x];
+                    cellBg = c.IsReverse ? GetBrush(c.Foreground, DefaultForeground) : GetBrush(c.Background, null);
+                    if (kgpCoveredCells?.Contains((x, y)) == true) cellBg = null;
+                }
+
+                if (cellBg != bgRunBrush || x == width)
+                {
+                    // Flush previous run
+                    if (bgRunBrush != null && x > bgRunStart)
+                    {
+                        double runX = bgRunStart * _cellWidth;
+                        double runW = (x - bgRunStart) * _cellWidth;
+                        dc.DrawRectangle(bgRunBrush, null, new Rect(runX, cellY, runW, _cellHeight));
+                    }
+                    bgRunStart = x;
+                    bgRunBrush = cellBg;
+                }
+            }
+
+            // Pass 2: Draw characters per-cell
             for (int x = 0; x < width; x++)
             {
                 var cell = buffer[y, x];
                 double cellX = x * _cellWidth;
 
                 var fg = cell.IsReverse ? GetBrush(cell.Background, DefaultBackground) : GetBrush(cell.Foreground, DefaultForeground);
-                var bg = cell.IsReverse ? GetBrush(cell.Foreground, DefaultForeground) : GetBrush(cell.Background, null);
-
-                // Draw cell background — extend by 1px overlap to prevent sub-pixel gaps
-                if (bg != null && !(kgpCoveredCells?.Contains((x, y)) == true))
-                {
-                    dc.DrawRectangle(bg, null, new Rect(cellX, cellY, _cellWidth + 1, _cellHeight + 1));
-                }
 
                 // Draw character
                 var ch = cell.Character;

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -195,14 +195,12 @@ public class TerminalControl : FrameworkElement
             _baselineY = ft.Baseline;
         }
 
-        // Store the physical pixel cell width for pixel-perfect position calculation.
-        // At fractional DPI, no single DIP cell width produces pixel-aligned positions
-        // for every column. Instead, we compute each position as:
-        //   Round(col * _physCellWidth) / _dpiScale
-        _physCellWidth = Math.Ceiling(_cellWidth * _dpiScale);
-        _physCellHeight = Math.Ceiling(_cellHeight * _dpiScale);
-        _cellWidth = _physCellWidth / _dpiScale;
-        _cellHeight = _physCellHeight / _dpiScale;
+        // Use the font's exact metrics for physical pixel calculations.
+        // Don't ceil — ColToX/RowToY handle pixel snapping per-position.
+        // Ceiling causes cell dimensions to be wider than glyph metrics,
+        // creating gaps within braille and other cell-filling characters.
+        _physCellWidth = _cellWidth * _dpiScale;
+        _physCellHeight = _cellHeight * _dpiScale;
     }
 
     /// <summary>

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -1,0 +1,339 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media;
+using Hex1b;
+using Hex1b.Theming;
+
+namespace WpfTerm;
+
+/// <summary>
+/// A WPF control that renders a terminal screen buffer using DrawingVisual.
+/// </summary>
+public class TerminalControl : FrameworkElement
+{
+    private readonly DrawingVisual _visual = new();
+    private readonly VisualCollection _children;
+
+    private WpfTerminalAdapter? _adapter;
+    private double _cellWidth;
+    private double _cellHeight;
+    private Typeface _typeface = null!;
+    private double _fontSize;
+    private double _dpiScale = 1.0;
+
+    // Cached brushes for ANSI colors
+    private static readonly SolidColorBrush[] AnsiStandardBrushes =
+    [
+        B(0x00, 0x00, 0x00), // 0 Black
+        B(0xCD, 0x31, 0x31), // 1 Red
+        B(0x0D, 0xBC, 0x79), // 2 Green
+        B(0xE5, 0xE5, 0x10), // 3 Yellow
+        B(0x24, 0x72, 0xC8), // 4 Blue
+        B(0xBC, 0x3F, 0xBC), // 5 Magenta
+        B(0x11, 0xA8, 0xCD), // 6 Cyan
+        B(0xE5, 0xE5, 0xE5), // 7 White
+    ];
+
+    private static readonly SolidColorBrush[] AnsiBrightBrushes =
+    [
+        B(0x66, 0x66, 0x66), // 8  Bright Black
+        B(0xF1, 0x4C, 0x4C), // 9  Bright Red
+        B(0x23, 0xD1, 0x8B), // 10 Bright Green
+        B(0xF5, 0xF5, 0x43), // 11 Bright Yellow
+        B(0x3B, 0x8E, 0xEA), // 12 Bright Blue
+        B(0xD6, 0x70, 0xD6), // 13 Bright Magenta
+        B(0x29, 0xB8, 0xDB), // 14 Bright Cyan
+        B(0xFF, 0xFF, 0xFF), // 15 Bright White
+    ];
+
+    private static readonly SolidColorBrush DefaultForeground = B(0xCC, 0xCC, 0xCC);
+    private static readonly SolidColorBrush DefaultBackground = B(0x1E, 0x1E, 0x1E);
+    private static readonly SolidColorBrush CursorBrush = B(0xFF, 0xFF, 0xFF);
+
+    private static SolidColorBrush B(byte r, byte g, byte b)
+    {
+        var brush = new SolidColorBrush(Color.FromRgb(r, g, b));
+        brush.Freeze();
+        return brush;
+    }
+
+    public TerminalControl()
+    {
+        _children = new VisualCollection(this) { _visual };
+
+        Focusable = true;
+        FocusVisualStyle = null;
+
+        _fontSize = 14;
+        UpdateFont();
+
+        Loaded += OnLoaded;
+    }
+
+    /// <summary>
+    /// Attaches this control to a terminal adapter and begins rendering.
+    /// </summary>
+    public void Attach(WpfTerminalAdapter adapter)
+    {
+        if (_adapter != null)
+        {
+            _adapter.OutputReceived -= OnOutputReceived;
+        }
+
+        _adapter = adapter;
+        _adapter.OutputReceived += OnOutputReceived;
+
+        // Trigger initial resize based on current control size
+        UpdateTerminalSize();
+        InvalidateVisual();
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        var source = PresentationSource.FromVisual(this);
+        if (source?.CompositionTarget != null)
+        {
+            _dpiScale = source.CompositionTarget.TransformToDevice.M11;
+        }
+
+        Focus();
+        UpdateTerminalSize();
+    }
+
+    private void UpdateFont()
+    {
+        // Try Cascadia Mono first, fall back to Consolas
+        _typeface = new Typeface(new FontFamily("Cascadia Mono, Consolas"), FontStyles.Normal, FontWeights.Regular, FontStretches.Normal);
+
+        // Measure a character to get cell dimensions
+        var ft = new FormattedText(
+            "M",
+            CultureInfo.InvariantCulture,
+            FlowDirection.LeftToRight,
+            _typeface,
+            _fontSize,
+            Brushes.White,
+            _dpiScale);
+
+        _cellWidth = ft.WidthIncludingTrailingWhitespace;
+        _cellHeight = ft.Height;
+    }
+
+    private void OnOutputReceived()
+    {
+        // Marshal to UI thread
+        Dispatcher.BeginInvoke(new Action(Render));
+    }
+
+    private void Render()
+    {
+        if (_adapter == null) return;
+
+        var snapshot = _adapter.GetSnapshot();
+        var dc = _visual.RenderOpen();
+
+        try
+        {
+            // Draw background fill
+            dc.DrawRectangle(DefaultBackground, null, new Rect(0, 0, ActualWidth, ActualHeight));
+
+            int width = snapshot.Width;
+            int height = snapshot.Height;
+
+            for (int y = 0; y < height; y++)
+            {
+                for (int x = 0; x < width; x++)
+                {
+                    var cell = snapshot.Buffer[y, x];
+                    double px = x * _cellWidth;
+                    double py = y * _cellHeight;
+
+                    var fg = cell.IsReverse ? GetBrush(cell.Background, DefaultBackground) : GetBrush(cell.Foreground, DefaultForeground);
+                    var bg = cell.IsReverse ? GetBrush(cell.Foreground, DefaultForeground) : GetBrush(cell.Background, null);
+
+                    // Draw cell background if not default
+                    if (bg != null)
+                    {
+                        dc.DrawRectangle(bg, null, new Rect(px, py, _cellWidth, _cellHeight));
+                    }
+
+                    // Draw character
+                    var ch = cell.Character;
+                    if (!string.IsNullOrEmpty(ch) && ch != " ")
+                    {
+                        var weight = cell.IsBold ? FontWeights.Bold : FontWeights.Regular;
+                        var style = cell.IsItalic ? FontStyles.Italic : FontStyles.Normal;
+                        var tf = new Typeface(_typeface.FontFamily, style, weight, FontStretches.Normal);
+
+                        var ft = new FormattedText(
+                            ch,
+                            CultureInfo.InvariantCulture,
+                            FlowDirection.LeftToRight,
+                            tf,
+                            _fontSize,
+                            fg,
+                            _dpiScale);
+
+                        if (cell.IsDim)
+                        {
+                            dc.PushOpacity(0.5);
+                            dc.DrawText(ft, new Point(px, py));
+                            dc.Pop();
+                        }
+                        else
+                        {
+                            dc.DrawText(ft, new Point(px, py));
+                        }
+                    }
+
+                    // Draw underline
+                    if (cell.IsUnderline)
+                    {
+                        var pen = new Pen(fg, 1);
+                        pen.Freeze();
+                        double underlineY = py + _cellHeight - 2;
+                        dc.DrawLine(pen, new Point(px, underlineY), new Point(px + _cellWidth, underlineY));
+                    }
+
+                    // Draw strikethrough
+                    if (cell.IsStrikethrough)
+                    {
+                        var pen = new Pen(fg, 1);
+                        pen.Freeze();
+                        double strikeY = py + _cellHeight / 2;
+                        dc.DrawLine(pen, new Point(px, strikeY), new Point(px + _cellWidth, strikeY));
+                    }
+                }
+            }
+
+            // Draw cursor
+            if (snapshot.CursorVisible &&
+                snapshot.CursorX >= 0 && snapshot.CursorX < width &&
+                snapshot.CursorY >= 0 && snapshot.CursorY < height)
+            {
+                double cx = snapshot.CursorX * _cellWidth;
+                double cy = snapshot.CursorY * _cellHeight;
+
+                // Draw a bar cursor
+                dc.DrawRectangle(CursorBrush, null, new Rect(cx, cy, 2, _cellHeight));
+            }
+        }
+        finally
+        {
+            dc.Close();
+        }
+    }
+
+    protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
+    {
+        base.OnRenderSizeChanged(sizeInfo);
+        UpdateTerminalSize();
+    }
+
+    private void UpdateTerminalSize()
+    {
+        if (_adapter == null || ActualWidth <= 0 || ActualHeight <= 0) return;
+
+        int cols = Math.Max(1, (int)(ActualWidth / _cellWidth));
+        int rows = Math.Max(1, (int)(ActualHeight / _cellHeight));
+
+        _adapter.TriggerResize(cols, rows);
+        Render();
+    }
+
+    // === Keyboard Input ===
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        if (_adapter == null) return;
+
+        var data = AnsiKeyEncoder.Encode(e);
+        if (data != null)
+        {
+            _adapter.EnqueueInput(data);
+            e.Handled = true;
+        }
+    }
+
+    protected override void OnTextInput(TextCompositionEventArgs e)
+    {
+        if (_adapter == null) return;
+
+        var data = AnsiKeyEncoder.EncodeText(e.Text);
+        if (data != null)
+        {
+            _adapter.EnqueueInput(data);
+            e.Handled = true;
+        }
+    }
+
+    // === Visual tree ===
+
+    protected override int VisualChildrenCount => _children.Count;
+    protected override Visual GetVisualChild(int index) => _children[index];
+
+    private static SolidColorBrush? GetBrush(Hex1bColor? color, SolidColorBrush? defaultBrush)
+    {
+        if (color == null || color.Value.IsDefault)
+            return defaultBrush;
+
+        var c = color.Value;
+
+        return c.Kind switch
+        {
+            Hex1bColorKind.Rgb => Cached(c.R, c.G, c.B),
+            Hex1bColorKind.Standard => c.AnsiIndex >= 0 && c.AnsiIndex < 8 ? AnsiStandardBrushes[c.AnsiIndex] : defaultBrush,
+            Hex1bColorKind.Bright => c.AnsiIndex >= 0 && c.AnsiIndex < 8 ? AnsiBrightBrushes[c.AnsiIndex] : defaultBrush,
+            Hex1bColorKind.Indexed => GetIndexedBrush(c.AnsiIndex) ?? defaultBrush,
+            _ => defaultBrush
+        };
+    }
+
+    // Simple brush cache for RGB colors
+    private static readonly Dictionary<int, SolidColorBrush> BrushCache = new();
+
+    private static SolidColorBrush Cached(byte r, byte g, byte b)
+    {
+        int key = (r << 16) | (g << 8) | b;
+        if (!BrushCache.TryGetValue(key, out var brush))
+        {
+            brush = B(r, g, b);
+            BrushCache[key] = brush;
+        }
+        return brush;
+    }
+
+    private static SolidColorBrush? GetIndexedBrush(int index)
+    {
+        if (index < 0) return null;
+
+        // Standard colors 0-7
+        if (index < 8) return AnsiStandardBrushes[index];
+
+        // Bright colors 8-15
+        if (index < 16) return AnsiBrightBrushes[index - 8];
+
+        // 216-color cube (indices 16-231)
+        if (index < 232)
+        {
+            int i = index - 16;
+            int r = i / 36;
+            int g = (i % 36) / 6;
+            int b = i % 6;
+            return Cached(
+                (byte)(r == 0 ? 0 : 55 + r * 40),
+                (byte)(g == 0 ? 0 : 55 + g * 40),
+                (byte)(b == 0 ? 0 : 55 + b * 40));
+        }
+
+        // Grayscale ramp (indices 232-255)
+        if (index < 256)
+        {
+            byte v = (byte)(8 + (index - 232) * 10);
+            return Cached(v, v, v);
+        }
+
+        return null;
+    }
+}

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -137,7 +137,20 @@ public class TerminalControl : FrameworkElement
 
     private void UpdateFont()
     {
-        var fontFamily = new FontFamily("JetBrainsMono Nerd Font, Cascadia Mono, Consolas");
+        // Try fonts in preference order
+        string[] fontPreferences = ["JetBrainsMono NF", "JetBrainsMono Nerd Font", "Cascadia Mono", "Consolas"];
+        FontFamily? fontFamily = null;
+        foreach (var name in fontPreferences)
+        {
+            var candidate = new FontFamily(name);
+            var typeface = new Typeface(candidate, FontStyles.Normal, FontWeights.Regular, FontStretches.Normal);
+            if (typeface.TryGetGlyphTypeface(out _))
+            {
+                fontFamily = candidate;
+                break;
+            }
+        }
+        fontFamily ??= new FontFamily("Consolas");
         _fallbackTypeface = new Typeface(fontFamily, FontStyles.Normal, FontWeights.Regular, FontStretches.Normal);
 
         // Pre-cache GlyphTypeface variants

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -775,15 +775,10 @@ public class TerminalControl : FrameworkElement
 
     protected override void OnTextInput(TextCompositionEventArgs e)
     {
-        if (_adapter == null) return;
+        // Printable chars are handled via WM_CHAR hook.
+        // This suppresses the WPF TextInput to prevent duplicates.
         _textInputCount++;
-
-        var data = AnsiKeyEncoder.EncodeText(e.Text);
-        if (data != null)
-        {
-            _adapter.EnqueueInput(data);
-            e.Handled = true;
-        }
+        e.Handled = true;
     }
 
     /// <summary>Diagnostic: WPF event counts.</summary>
@@ -806,9 +801,21 @@ public class TerminalControl : FrameworkElement
                 break;
             case WM_CHAR:
                 _wmCharCount++;
+                // Handle printable characters directly from WM_CHAR.
+                // This bypasses WPF's TextInput which drops ~4% of events
+                // during rapid mouse activity.
+                if (_adapter != null)
+                {
+                    char ch = (char)wParam;
+                    if (ch >= 0x20) // printable (space and above)
+                    {
+                        var bytes = System.Text.Encoding.UTF8.GetBytes(new[] { ch });
+                        _adapter.EnqueueInput(bytes);
+                        handled = true; // Suppress WPF TextInput for this char
+                    }
+                }
                 break;
         }
-        // Don't set handled — let WPF process normally
         return IntPtr.Zero;
     }
 

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -86,6 +86,14 @@ public class TerminalControl : FrameworkElement
         Focusable = true;
         FocusVisualStyle = null;
         
+        // Disable anti-aliasing on cell background rectangles — prevents
+        // sub-pixel gaps between adjacent cells where the window background bleeds through
+        RenderOptions.SetEdgeMode(_visual, EdgeMode.Aliased);
+        
+        // Snap to device pixels to avoid sub-pixel rendering artifacts
+        SnapsToDevicePixels = true;
+        UseLayoutRounding = true;
+        
         // Disable WPF's Input Method Editor — prevents the system from showing
         // its own blinking caret at the mouse click position
         InputMethod.SetIsInputMethodEnabled(this, false);
@@ -184,6 +192,10 @@ public class TerminalControl : FrameworkElement
             _cellHeight = ft.Height;
             _baselineY = ft.Baseline;
         }
+
+        // Snap cell dimensions to whole pixels to prevent sub-pixel gaps
+        _cellWidth = Math.Ceiling(_cellWidth);
+        _cellHeight = Math.Ceiling(_cellHeight);
     }
 
     private static bool TryCreateGlyphTypeface(FontFamily family, FontStyle style, FontWeight weight, out GlyphTypeface? result)

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -6,6 +6,8 @@ using System.Windows.Media.Imaging;
 using Hex1b;
 using Hex1b.Theming;
 
+using InputMethod = System.Windows.Input.InputMethod;
+
 namespace WpfTerm;
 
 /// <summary>
@@ -81,6 +83,10 @@ public class TerminalControl : FrameworkElement
 
         Focusable = true;
         FocusVisualStyle = null;
+        
+        // Disable WPF's Input Method Editor — prevents the system from showing
+        // its own blinking caret at the mouse click position
+        InputMethod.SetIsInputMethodEnabled(this, false);
 
         _fontSize = 14;
         UpdateFont();
@@ -694,19 +700,25 @@ public class TerminalControl : FrameworkElement
 
     protected override void OnMouseDown(MouseButtonEventArgs e)
     {
-        if (_adapter == null || !_adapter.MouseTrackingEnabled) return;
-
+        // Always take keyboard focus on click
         Focus();
-        CaptureMouse();
 
-        var pos = CellPosition(e);
-        int button = WpfButtonToSgr(e.ChangedButton);
-        if (button < 0) return;
+        if (_adapter == null) return;
 
-        int modifiers = GetMouseModifiers();
-        _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(button, pos.x, pos.y, isRelease: false, modifiers));
-        _lastPressedButton = e.ChangedButton;
-        _mouseButtonDown = true;
+        if (_adapter.MouseTrackingEnabled)
+        {
+            CaptureMouse();
+
+            var pos = CellPosition(e);
+            int button = WpfButtonToSgr(e.ChangedButton);
+            if (button < 0) return;
+
+            int modifiers = GetMouseModifiers();
+            _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(button, pos.x, pos.y, isRelease: false, modifiers));
+            _lastPressedButton = e.ChangedButton;
+            _mouseButtonDown = true;
+        }
+
         e.Handled = true;
     }
 

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -733,9 +733,13 @@ public class TerminalControl : FrameworkElement
 
     // === Keyboard Input ===
 
+    private int _keyDownCount;
+    private int _textInputCount;
+
     protected override void OnKeyDown(KeyEventArgs e)
     {
         if (_adapter == null) return;
+        _keyDownCount++;
 
         var data = AnsiKeyEncoder.Encode(e);
         if (data != null)
@@ -748,6 +752,7 @@ public class TerminalControl : FrameworkElement
     protected override void OnTextInput(TextCompositionEventArgs e)
     {
         if (_adapter == null) return;
+        _textInputCount++;
 
         var data = AnsiKeyEncoder.EncodeText(e.Text);
         if (data != null)
@@ -756,6 +761,9 @@ public class TerminalControl : FrameworkElement
             e.Handled = true;
         }
     }
+
+    /// <summary>Diagnostic: WPF event counts.</summary>
+    public (int KeyDown, int TextInput) WpfEventCounts => (_keyDownCount, _textInputCount);
 
     // === Mouse Input ===
 

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -492,9 +492,11 @@ public class TerminalControl : FrameworkElement
                 return;
             }
 
-            // Position each glyph independently — no cumulative advance drift
-            double glyphX = ColToX(col);
-            double advance = ColToX(col + 1) - glyphX;
+            // Position glyph using exact font metrics (no pixel snapping).
+            // Background rects use ColToX for pixel-snapped boundaries,
+            // but glyphs use exact col * _cellWidth to preserve font spacing
+            // for characters like braille that must tile precisely.
+            double glyphX = col * _cellWidth;
 
 #pragma warning disable CS0618
             var glyphRun = new GlyphRun(
@@ -505,7 +507,7 @@ public class TerminalControl : FrameworkElement
                 pixelsPerDip: (float)_dpiScale,
                 glyphIndices: [glyphIndex],
                 baselineOrigin: new Point(glyphX, py + _baselineY),
-                advanceWidths: [advance],
+                advanceWidths: [_cellWidth],
                 glyphOffsets: null,
                 characters: null,
                 deviceFontName: null,

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -775,10 +775,15 @@ public class TerminalControl : FrameworkElement
 
     protected override void OnTextInput(TextCompositionEventArgs e)
     {
-        // Printable chars are handled via WM_CHAR hook.
-        // This suppresses the WPF TextInput to prevent duplicates.
+        if (_adapter == null) return;
         _textInputCount++;
-        e.Handled = true;
+
+        var data = AnsiKeyEncoder.EncodeText(e.Text);
+        if (data != null)
+        {
+            _adapter.EnqueueInput(data);
+            e.Handled = true;
+        }
     }
 
     /// <summary>Diagnostic: WPF event counts.</summary>
@@ -801,19 +806,6 @@ public class TerminalControl : FrameworkElement
                 break;
             case WM_CHAR:
                 _wmCharCount++;
-                // Handle printable characters directly from WM_CHAR.
-                // This bypasses WPF's TextInput which drops ~4% of events
-                // during rapid mouse activity.
-                if (_adapter != null)
-                {
-                    char ch = (char)wParam;
-                    if (ch >= 0x20) // printable (space and above)
-                    {
-                        var bytes = System.Text.Encoding.UTF8.GetBytes([ch]);
-                        _adapter.EnqueueInput(bytes);
-                        // Don't set handled — let WPF see it too (OnTextInput will suppress)
-                    }
-                }
                 break;
         }
         return IntPtr.Zero;

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -457,10 +457,13 @@ public class TerminalControl : FrameworkElement
             }
             else
             {
-                // Unknown glyph — use .notdef (index 0) or tofu
-                hasGlyphs = true;
-                glyphIndices.Add(0);
-                advanceWidths.Add(_cellWidth);
+                // Glyph not in this typeface — fall back to FormattedText for
+                // the entire run, which handles WPF font fallback automatically
+                DrawFormattedRun(dc, buffer, row, startCol, count, px, py, fg,
+                    glyphTypeface == _boldGlyph || glyphTypeface == _boldItalicGlyph,
+                    glyphTypeface == _italicGlyph || glyphTypeface == _boldItalicGlyph,
+                    dim);
+                return;
             }
         }
 

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -443,7 +443,7 @@ public class TerminalControl : FrameworkElement
                             var glyphRun = new GlyphRun(
                                 _regularGlyph, 0, false, _fontSize, (float)_dpiScale,
                                 [glyphIdx], new Point(cx, cy + _baselineY),
-                                [_cellWidth], null, null, null, null, null, null);
+                                [cw], null, null, null, null, null, null);
 #pragma warning restore CS0618
                             dc.DrawGlyphRun(DefaultBackground, glyphRun);
                         }
@@ -479,7 +479,11 @@ public class TerminalControl : FrameworkElement
 
         for (int i = 0; i < count; i++)
         {
-            var ch = buffer[row, startCol + i].Character;
+            // Per-glyph advance width snapped to pixel boundaries
+            int col = startCol + i;
+            double advance = ColToX(col + 1) - ColToX(col);
+
+            var ch = buffer[row, col].Character;
             if (string.IsNullOrEmpty(ch) || ch == " ")
             {
                 if (!hasGlyphs)
@@ -487,22 +491,20 @@ public class TerminalControl : FrameworkElement
                     skippedLeading++;
                     continue;
                 }
-                // Use space glyph to maintain positioning
                 if (charMap.TryGetValue(' ', out ushort spaceGlyph))
                 {
                     glyphIndices.Add(spaceGlyph);
-                    advanceWidths.Add(_cellWidth);
+                    advanceWidths.Add(advance);
                 }
                 continue;
             }
 
-            // Get glyph for first codepoint of grapheme cluster
             int codepoint = char.ConvertToUtf32(ch, 0);
             if (charMap.TryGetValue(codepoint, out ushort glyphIndex))
             {
                 hasGlyphs = true;
                 glyphIndices.Add(glyphIndex);
-                advanceWidths.Add(_cellWidth);
+                advanceWidths.Add(advance);
             }
             else
             {
@@ -518,7 +520,7 @@ public class TerminalControl : FrameworkElement
 
         if (glyphIndices.Count == 0) return;
 
-        double originX = px + skippedLeading * _cellWidth;
+        double originX = ColToX(startCol + skippedLeading);
         var origin = new Point(originX, py + _baselineY);
 
 #pragma warning disable CS0618 // GlyphRun constructor is obsolete but the replacement requires .NET 9+

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -322,10 +322,10 @@ public class TerminalControl : FrameworkElement
                 var fg = cell.IsReverse ? GetBrush(cell.Background, DefaultBackground) : GetBrush(cell.Foreground, DefaultForeground);
                 var bg = cell.IsReverse ? GetBrush(cell.Foreground, DefaultForeground) : GetBrush(cell.Background, null);
 
-                // Draw cell background
+                // Draw cell background — extend by 1px overlap to prevent sub-pixel gaps
                 if (bg != null && !(kgpCoveredCells?.Contains((x, y)) == true))
                 {
-                    dc.DrawRectangle(bg, null, new Rect(cellX, cellY, _cellWidth, _cellHeight));
+                    dc.DrawRectangle(bg, null, new Rect(cellX, cellY, _cellWidth + 1, _cellHeight + 1));
                 }
 
                 // Draw character

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -761,6 +761,8 @@ public class TerminalControl : FrameworkElement
 
     private MouseButton _lastPressedButton;
     private bool _mouseButtonDown;
+    private int _lastMouseCellX = -1;
+    private int _lastMouseCellY = -1;
 
     protected override void OnMouseDown(MouseButtonEventArgs e)
     {
@@ -810,15 +812,20 @@ public class TerminalControl : FrameworkElement
         if (!_mouseButtonDown && !_adapter.MouseMotionEnabled) return;
 
         var pos = CellPosition(e);
+        
+        // Only send when the cell position actually changes — suppresses
+        // sub-cell pixel moves that flood the PTY and drown out keyboard input
+        if (pos.x == _lastMouseCellX && pos.y == _lastMouseCellY) return;
+        _lastMouseCellX = pos.x;
+        _lastMouseCellY = pos.y;
+
         int button;
         if (_mouseButtonDown)
         {
-            // Drag: button code + 32 (motion flag)
             button = WpfButtonToSgr(_lastPressedButton) | 32;
         }
         else
         {
-            // Motion with no button: 35 = 32 (motion) + 3 (no button)
             button = 35;
         }
         int modifiers = GetMouseModifiers();

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -8,7 +8,8 @@ using Hex1b.Theming;
 namespace WpfTerm;
 
 /// <summary>
-/// A WPF control that renders a terminal screen buffer using DrawingVisual.
+/// A WPF control that renders a terminal screen buffer using DrawingVisual
+/// with GlyphRun batching and render coalescing for performance.
 /// </summary>
 public class TerminalControl : FrameworkElement
 {
@@ -18,9 +19,21 @@ public class TerminalControl : FrameworkElement
     private WpfTerminalAdapter? _adapter;
     private double _cellWidth;
     private double _cellHeight;
-    private Typeface _typeface = null!;
+    private double _baselineY;
     private double _fontSize;
     private double _dpiScale = 1.0;
+    private bool _renderPending;
+
+    // Pre-cached typeface variants
+    private GlyphTypeface? _regularGlyph;
+    private GlyphTypeface? _boldGlyph;
+    private GlyphTypeface? _italicGlyph;
+    private GlyphTypeface? _boldItalicGlyph;
+    // Fallback for chars not in glyph typeface
+    private Typeface _fallbackTypeface = null!;
+
+    // Cached pens
+    private static readonly Dictionary<int, Pen> PenCache = new();
 
     // Cached brushes for ANSI colors
     private static readonly SolidColorBrush[] AnsiStandardBrushes =
@@ -84,9 +97,8 @@ public class TerminalControl : FrameworkElement
         _adapter = adapter;
         _adapter.OutputReceived += OnOutputReceived;
 
-        // Trigger initial resize based on current control size
         UpdateTerminalSize();
-        InvalidateVisual();
+        ScheduleRender();
     }
 
     private void OnLoaded(object sender, RoutedEventArgs e)
@@ -98,131 +110,346 @@ public class TerminalControl : FrameworkElement
         }
 
         Focus();
+        UpdateFont();
         UpdateTerminalSize();
     }
 
     private void UpdateFont()
     {
-        // Try Cascadia Mono first, fall back to Consolas
-        _typeface = new Typeface(new FontFamily("Cascadia Mono, Consolas"), FontStyles.Normal, FontWeights.Regular, FontStretches.Normal);
+        var fontFamily = new FontFamily("Cascadia Mono, Consolas");
+        _fallbackTypeface = new Typeface(fontFamily, FontStyles.Normal, FontWeights.Regular, FontStretches.Normal);
 
-        // Measure a character to get cell dimensions
-        var ft = new FormattedText(
-            "M",
-            CultureInfo.InvariantCulture,
-            FlowDirection.LeftToRight,
-            _typeface,
-            _fontSize,
-            Brushes.White,
-            _dpiScale);
+        // Pre-cache GlyphTypeface variants
+        TryCreateGlyphTypeface(fontFamily, FontStyles.Normal, FontWeights.Regular, out _regularGlyph);
+        TryCreateGlyphTypeface(fontFamily, FontStyles.Normal, FontWeights.Bold, out _boldGlyph);
+        TryCreateGlyphTypeface(fontFamily, FontStyles.Italic, FontWeights.Regular, out _italicGlyph);
+        TryCreateGlyphTypeface(fontFamily, FontStyles.Italic, FontWeights.Bold, out _boldItalicGlyph);
 
-        _cellWidth = ft.WidthIncludingTrailingWhitespace;
-        _cellHeight = ft.Height;
+        // Measure cell dimensions from the glyph typeface
+        if (_regularGlyph != null)
+        {
+            double emSize = _fontSize;
+            _cellHeight = _regularGlyph.Height * emSize;
+            _baselineY = _regularGlyph.Baseline * emSize;
+            // Use advance width of 'M' for cell width
+            if (_regularGlyph.CharacterToGlyphMap.TryGetValue('M', out ushort mGlyph))
+            {
+                _cellWidth = _regularGlyph.AdvanceWidths[mGlyph] * emSize;
+            }
+            else
+            {
+                _cellWidth = emSize * 0.6; // fallback
+            }
+        }
+        else
+        {
+            // Fallback measurement using FormattedText
+            var ft = new FormattedText("M", CultureInfo.InvariantCulture, FlowDirection.LeftToRight,
+                _fallbackTypeface, _fontSize, Brushes.White, _dpiScale);
+            _cellWidth = ft.WidthIncludingTrailingWhitespace;
+            _cellHeight = ft.Height;
+            _baselineY = ft.Baseline;
+        }
+    }
+
+    private static bool TryCreateGlyphTypeface(FontFamily family, FontStyle style, FontWeight weight, out GlyphTypeface? result)
+    {
+        var typeface = new Typeface(family, style, weight, FontStretches.Normal);
+        if (typeface.TryGetGlyphTypeface(out var glyph))
+        {
+            result = glyph;
+            return true;
+        }
+        result = null;
+        return false;
     }
 
     private void OnOutputReceived()
     {
-        // Marshal to UI thread
-        Dispatcher.BeginInvoke(new Action(Render));
+        ScheduleRender();
+    }
+
+    /// <summary>
+    /// Coalesces multiple output events into a single render on the next frame.
+    /// </summary>
+    private void ScheduleRender()
+    {
+        if (_renderPending) return;
+        _renderPending = true;
+        Dispatcher.BeginInvoke(System.Windows.Threading.DispatcherPriority.Render, new Action(() =>
+        {
+            _renderPending = false;
+            Render();
+        }));
     }
 
     private void Render()
     {
         if (_adapter == null) return;
 
-        var snapshot = _adapter.GetSnapshot();
         var dc = _visual.RenderOpen();
-
         try
         {
-            // Draw background fill
+            // Full background fill
             dc.DrawRectangle(DefaultBackground, null, new Rect(0, 0, ActualWidth, ActualHeight));
 
-            int width = snapshot.Width;
-            int height = snapshot.Height;
-
-            for (int y = 0; y < height; y++)
+            // Read directly from the adapter's buffer under lock — no copy needed
+            _adapter.RenderUnderLock((buffer, width, height, cursorX, cursorY, cursorVisible) =>
             {
-                for (int x = 0; x < width; x++)
-                {
-                    var cell = snapshot.Buffer[y, x];
-                    double px = x * _cellWidth;
-                    double py = y * _cellHeight;
-
-                    var fg = cell.IsReverse ? GetBrush(cell.Background, DefaultBackground) : GetBrush(cell.Foreground, DefaultForeground);
-                    var bg = cell.IsReverse ? GetBrush(cell.Foreground, DefaultForeground) : GetBrush(cell.Background, null);
-
-                    // Draw cell background if not default
-                    if (bg != null)
-                    {
-                        dc.DrawRectangle(bg, null, new Rect(px, py, _cellWidth, _cellHeight));
-                    }
-
-                    // Draw character
-                    var ch = cell.Character;
-                    if (!string.IsNullOrEmpty(ch) && ch != " ")
-                    {
-                        var weight = cell.IsBold ? FontWeights.Bold : FontWeights.Regular;
-                        var style = cell.IsItalic ? FontStyles.Italic : FontStyles.Normal;
-                        var tf = new Typeface(_typeface.FontFamily, style, weight, FontStretches.Normal);
-
-                        var ft = new FormattedText(
-                            ch,
-                            CultureInfo.InvariantCulture,
-                            FlowDirection.LeftToRight,
-                            tf,
-                            _fontSize,
-                            fg,
-                            _dpiScale);
-
-                        if (cell.IsDim)
-                        {
-                            dc.PushOpacity(0.5);
-                            dc.DrawText(ft, new Point(px, py));
-                            dc.Pop();
-                        }
-                        else
-                        {
-                            dc.DrawText(ft, new Point(px, py));
-                        }
-                    }
-
-                    // Draw underline
-                    if (cell.IsUnderline)
-                    {
-                        var pen = new Pen(fg, 1);
-                        pen.Freeze();
-                        double underlineY = py + _cellHeight - 2;
-                        dc.DrawLine(pen, new Point(px, underlineY), new Point(px + _cellWidth, underlineY));
-                    }
-
-                    // Draw strikethrough
-                    if (cell.IsStrikethrough)
-                    {
-                        var pen = new Pen(fg, 1);
-                        pen.Freeze();
-                        double strikeY = py + _cellHeight / 2;
-                        dc.DrawLine(pen, new Point(px, strikeY), new Point(px + _cellWidth, strikeY));
-                    }
-                }
-            }
-
-            // Draw cursor
-            if (snapshot.CursorVisible &&
-                snapshot.CursorX >= 0 && snapshot.CursorX < width &&
-                snapshot.CursorY >= 0 && snapshot.CursorY < height)
-            {
-                double cx = snapshot.CursorX * _cellWidth;
-                double cy = snapshot.CursorY * _cellHeight;
-
-                // Draw a bar cursor
-                dc.DrawRectangle(CursorBrush, null, new Rect(cx, cy, 2, _cellHeight));
-            }
+                RenderBuffer(dc, buffer, width, height, cursorX, cursorY, cursorVisible);
+            });
         }
         finally
         {
             dc.Close();
         }
+    }
+
+    /// <summary>
+    /// Core rendering: scans rows for attribute runs and draws them as batched GlyphRuns.
+    /// </summary>
+    private void RenderBuffer(DrawingContext dc, TerminalCell[,] buffer, int width, int height,
+        int cursorX, int cursorY, bool cursorVisible)
+    {
+        for (int y = 0; y < height; y++)
+        {
+            double py = y * _cellHeight;
+            int x = 0;
+
+            while (x < width)
+            {
+                var cell = buffer[y, x];
+
+                // Determine effective colors (handle reverse)
+                var fg = cell.IsReverse ? GetBrush(cell.Background, DefaultBackground) : GetBrush(cell.Foreground, DefaultForeground);
+                var bg = cell.IsReverse ? GetBrush(cell.Foreground, DefaultForeground) : GetBrush(cell.Background, null);
+                bool bold = cell.IsBold;
+                bool italic = cell.IsItalic;
+                bool dim = cell.IsDim;
+                bool underline = cell.IsUnderline;
+                bool strikethrough = cell.IsStrikethrough;
+
+                // Scan for a run of cells with the same style
+                int runStart = x;
+                x++;
+                while (x < width)
+                {
+                    var next = buffer[y, x];
+                    var nextFg = next.IsReverse ? GetBrush(next.Background, DefaultBackground) : GetBrush(next.Foreground, DefaultForeground);
+                    var nextBg = next.IsReverse ? GetBrush(next.Foreground, DefaultForeground) : GetBrush(next.Background, null);
+
+                    if (nextFg != fg || nextBg != bg ||
+                        next.IsBold != bold || next.IsItalic != italic || next.IsDim != dim ||
+                        next.IsUnderline != underline || next.IsStrikethrough != strikethrough)
+                        break;
+                    x++;
+                }
+
+                int runLen = x - runStart;
+                double px = runStart * _cellWidth;
+                double runWidth = runLen * _cellWidth;
+
+                // Draw background for the entire run
+                if (bg != null)
+                {
+                    dc.DrawRectangle(bg, null, new Rect(px, py, runWidth, _cellHeight));
+                }
+
+                // Build GlyphRun for the text
+                var glyphTypeface = GetGlyphTypeface(bold, italic);
+                if (glyphTypeface != null)
+                {
+                    DrawGlyphRun(dc, glyphTypeface, buffer, y, runStart, runLen, px, py, fg!, dim);
+                }
+                else
+                {
+                    // Fallback: single FormattedText for the whole run
+                    DrawFormattedRun(dc, buffer, y, runStart, runLen, px, py, fg!, bold, italic, dim);
+                }
+
+                // Draw underline for the run
+                if (underline)
+                {
+                    var pen = GetOrCreatePen(fg!);
+                    double underlineY = py + _cellHeight - 2;
+                    dc.DrawLine(pen, new Point(px, underlineY), new Point(px + runWidth, underlineY));
+                }
+
+                // Draw strikethrough for the run
+                if (strikethrough)
+                {
+                    var pen = GetOrCreatePen(fg!);
+                    double strikeY = py + _cellHeight / 2;
+                    dc.DrawLine(pen, new Point(px, strikeY), new Point(px + runWidth, strikeY));
+                }
+            }
+        }
+
+        // Draw cursor
+        if (cursorVisible &&
+            cursorX >= 0 && cursorX < width &&
+            cursorY >= 0 && cursorY < height)
+        {
+            double cx = cursorX * _cellWidth;
+            double cy = cursorY * _cellHeight;
+            dc.DrawRectangle(CursorBrush, null, new Rect(cx, cy, 2, _cellHeight));
+        }
+    }
+
+    /// <summary>
+    /// Draws a run of characters using a single GlyphRun — much faster than FormattedText.
+    /// </summary>
+    private void DrawGlyphRun(DrawingContext dc, GlyphTypeface glyphTypeface,
+        TerminalCell[,] buffer, int row, int startCol, int count,
+        double px, double py, SolidColorBrush fg, bool dim)
+    {
+        var glyphIndices = new List<ushort>(count);
+        var advanceWidths = new List<double>(count);
+        var charMap = glyphTypeface.CharacterToGlyphMap;
+        double emSize = _fontSize;
+        int skippedLeading = 0;
+        bool hasGlyphs = false;
+
+        for (int i = 0; i < count; i++)
+        {
+            var ch = buffer[row, startCol + i].Character;
+            if (string.IsNullOrEmpty(ch) || ch == " ")
+            {
+                if (!hasGlyphs)
+                {
+                    skippedLeading++;
+                    continue;
+                }
+                // Use space glyph to maintain positioning
+                if (charMap.TryGetValue(' ', out ushort spaceGlyph))
+                {
+                    glyphIndices.Add(spaceGlyph);
+                    advanceWidths.Add(_cellWidth);
+                }
+                continue;
+            }
+
+            // Get glyph for first codepoint of grapheme cluster
+            int codepoint = char.ConvertToUtf32(ch, 0);
+            if (charMap.TryGetValue(codepoint, out ushort glyphIndex))
+            {
+                hasGlyphs = true;
+                glyphIndices.Add(glyphIndex);
+                advanceWidths.Add(_cellWidth);
+            }
+            else
+            {
+                // Unknown glyph — use .notdef (index 0) or tofu
+                hasGlyphs = true;
+                glyphIndices.Add(0);
+                advanceWidths.Add(_cellWidth);
+            }
+        }
+
+        if (glyphIndices.Count == 0) return;
+
+        double originX = px + skippedLeading * _cellWidth;
+        var origin = new Point(originX, py + _baselineY);
+
+#pragma warning disable CS0618 // GlyphRun constructor is obsolete but the replacement requires .NET 9+
+        var glyphRun = new GlyphRun(
+            glyphTypeface,
+            bidiLevel: 0,
+            isSideways: false,
+            renderingEmSize: emSize,
+            pixelsPerDip: (float)_dpiScale,
+            glyphIndices: glyphIndices,
+            baselineOrigin: origin,
+            advanceWidths: advanceWidths,
+            glyphOffsets: null,
+            characters: null,
+            deviceFontName: null,
+            clusterMap: null,
+            caretStops: null,
+            language: null);
+#pragma warning restore CS0618
+
+        if (dim)
+        {
+            dc.PushOpacity(0.5);
+            dc.DrawGlyphRun(fg, glyphRun);
+            dc.Pop();
+        }
+        else
+        {
+            dc.DrawGlyphRun(fg, glyphRun);
+        }
+    }
+
+    /// <summary>
+    /// Fallback path: draws a run using a single FormattedText (still much better than per-cell).
+    /// </summary>
+    private void DrawFormattedRun(DrawingContext dc, TerminalCell[,] buffer, int row,
+        int startCol, int count, double px, double py,
+        SolidColorBrush fg, bool bold, bool italic, bool dim)
+    {
+        // Build string for the run
+        var chars = new char[count];
+        bool hasContent = false;
+        for (int i = 0; i < count; i++)
+        {
+            var ch = buffer[row, startCol + i].Character;
+            if (!string.IsNullOrEmpty(ch) && ch != " ")
+            {
+                chars[i] = ch[0];
+                hasContent = true;
+            }
+            else
+            {
+                chars[i] = ' ';
+            }
+        }
+
+        if (!hasContent) return;
+
+        var weight = bold ? FontWeights.Bold : FontWeights.Regular;
+        var style = italic ? FontStyles.Italic : FontStyles.Normal;
+        var tf = new Typeface(_fallbackTypeface.FontFamily, style, weight, FontStretches.Normal);
+
+        var ft = new FormattedText(
+            new string(chars),
+            CultureInfo.InvariantCulture,
+            FlowDirection.LeftToRight,
+            tf,
+            _fontSize,
+            fg,
+            _dpiScale);
+
+        if (dim)
+        {
+            dc.PushOpacity(0.5);
+            dc.DrawText(ft, new Point(px, py));
+            dc.Pop();
+        }
+        else
+        {
+            dc.DrawText(ft, new Point(px, py));
+        }
+    }
+
+    private GlyphTypeface? GetGlyphTypeface(bool bold, bool italic) => (bold, italic) switch
+    {
+        (false, false) => _regularGlyph,
+        (true, false) => _boldGlyph ?? _regularGlyph,
+        (false, true) => _italicGlyph ?? _regularGlyph,
+        (true, true) => _boldItalicGlyph ?? _boldGlyph ?? _regularGlyph,
+    };
+
+    private static Pen GetOrCreatePen(SolidColorBrush brush)
+    {
+        int key = brush.Color.GetHashCode();
+        if (!PenCache.TryGetValue(key, out var pen))
+        {
+            pen = new Pen(brush, 1);
+            pen.Freeze();
+            PenCache[key] = pen;
+        }
+        return pen;
     }
 
     protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
@@ -239,7 +466,7 @@ public class TerminalControl : FrameworkElement
         int rows = Math.Max(1, (int)(ActualHeight / _cellHeight));
 
         _adapter.TriggerResize(cols, rows);
-        Render();
+        ScheduleRender();
     }
 
     // === Keyboard Input ===
@@ -310,10 +537,10 @@ public class TerminalControl : FrameworkElement
     protected override void OnMouseMove(MouseEventArgs e)
     {
         if (_adapter == null || !_adapter.MouseTrackingEnabled) return;
-        if (!_mouseButtonDown) return; // Only send drag events (mode 1002 behavior)
+        if (!_mouseButtonDown) return;
 
         var pos = CellPosition(e);
-        int button = WpfButtonToSgr(_lastPressedButton) | 32; // 32 = motion flag
+        int button = WpfButtonToSgr(_lastPressedButton) | 32;
         int modifiers = GetMouseModifiers();
         _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(button, pos.x, pos.y, isRelease: false, modifiers));
     }
@@ -323,7 +550,7 @@ public class TerminalControl : FrameworkElement
         if (_adapter == null || !_adapter.MouseTrackingEnabled) return;
 
         var pos = CellPosition(e);
-        int button = e.Delta > 0 ? 64 : 65; // 64=scroll up, 65=scroll down
+        int button = e.Delta > 0 ? 64 : 65;
         int modifiers = GetMouseModifiers();
         _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(button, pos.x, pos.y, isRelease: false, modifiers));
         e.Handled = true;
@@ -332,7 +559,6 @@ public class TerminalControl : FrameworkElement
     private (int x, int y) CellPosition(MouseEventArgs e)
     {
         var point = e.GetPosition(this);
-        // SGR mouse uses 1-based coordinates
         int col = Math.Max(1, (int)(point.X / _cellWidth) + 1);
         int row = Math.Max(1, (int)(point.Y / _cellHeight) + 1);
         return (col, row);
@@ -377,7 +603,6 @@ public class TerminalControl : FrameworkElement
         };
     }
 
-    // Simple brush cache for RGB colors
     private static readonly Dictionary<int, SolidColorBrush> BrushCache = new();
 
     private static SolidColorBrush Cached(byte r, byte g, byte b)
@@ -394,14 +619,9 @@ public class TerminalControl : FrameworkElement
     private static SolidColorBrush? GetIndexedBrush(int index)
     {
         if (index < 0) return null;
-
-        // Standard colors 0-7
         if (index < 8) return AnsiStandardBrushes[index];
-
-        // Bright colors 8-15
         if (index < 16) return AnsiBrightBrushes[index - 8];
 
-        // 216-color cube (indices 16-231)
         if (index < 232)
         {
             int i = index - 16;
@@ -414,7 +634,6 @@ public class TerminalControl : FrameworkElement
                 (byte)(b == 0 ? 0 : 55 + b * 40));
         }
 
-        // Grayscale ramp (indices 232-255)
         if (index < 256)
         {
             byte v = (byte)(8 + (index - 232) * 10);

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using Hex1b;
 using Hex1b.Theming;
 
@@ -29,6 +30,9 @@ public class TerminalControl : FrameworkElement
     private GlyphTypeface? _boldGlyph;
     private GlyphTypeface? _italicGlyph;
     private GlyphTypeface? _boldItalicGlyph;
+
+    // KGP image cache: ImageId → (contentHash, bitmap)
+    private readonly Dictionary<uint, (byte[] Hash, BitmapSource Bitmap)> _kgpBitmapCache = new();
     // Fallback for chars not in glyph typeface
     private Typeface _fallbackTypeface = null!;
 
@@ -187,6 +191,9 @@ public class TerminalControl : FrameworkElement
     {
         if (_adapter == null) return;
 
+        // Grab KGP placements outside the buffer lock (KgpPlacements takes its own lock)
+        var placements = _adapter.GetKgpPlacements();
+
         var dc = _visual.RenderOpen();
         try
         {
@@ -196,7 +203,14 @@ public class TerminalControl : FrameworkElement
             // Read directly from the adapter's buffer under lock — no copy needed
             _adapter.RenderUnderLock((buffer, width, height, cursorX, cursorY, cursorVisible) =>
             {
+                // Pass 1: KGP images behind text (ZIndex < 0)
+                RenderKgpImages(dc, placements, width, height, zBehindText: true);
+
+                // Pass 2: Text and cell backgrounds
                 RenderBuffer(dc, buffer, width, height, cursorX, cursorY, cursorVisible);
+
+                // Pass 3: KGP images on top of text (ZIndex >= 0)
+                RenderKgpImages(dc, placements, width, height, zBehindText: false);
             });
         }
         finally
@@ -450,6 +464,143 @@ public class TerminalControl : FrameworkElement
             PenCache[key] = pen;
         }
         return pen;
+    }
+
+    // === KGP Image Rendering ===
+
+    /// <summary>
+    /// Renders KGP image placements at the appropriate z-order layer.
+    /// </summary>
+    private void RenderKgpImages(DrawingContext dc, IReadOnlyList<KgpPlacement> placements,
+        int termWidth, int termHeight, bool zBehindText)
+    {
+        if (_adapter == null || placements.Count == 0) return;
+
+        foreach (var placement in placements)
+        {
+            bool isBehind = placement.ZIndex < 0;
+            if (isBehind != zBehindText) continue;
+
+            // Skip placements entirely off-screen
+            if (placement.Row >= termHeight || placement.Column >= termWidth) continue;
+            if (placement.Row + (int)placement.DisplayRows <= 0 || placement.Column + (int)placement.DisplayColumns <= 0) continue;
+
+            var imageData = _adapter.GetKgpImage(placement.ImageId);
+            if (imageData == null) continue;
+
+            var bitmap = GetOrCreateKgpBitmap(imageData);
+            if (bitmap == null) continue;
+
+            // Calculate display rect in pixels
+            double destX = placement.Column * _cellWidth + placement.CellOffsetX;
+            double destY = placement.Row * _cellHeight + placement.CellOffsetY;
+            double destW = placement.DisplayColumns * _cellWidth;
+            double destH = placement.DisplayRows * _cellHeight;
+
+            // Handle source clipping
+            if (placement.SourceX > 0 || placement.SourceY > 0 ||
+                placement.SourceWidth > 0 || placement.SourceHeight > 0)
+            {
+                int srcX = (int)placement.SourceX;
+                int srcY = (int)placement.SourceY;
+                int srcW = placement.SourceWidth > 0 ? (int)placement.SourceWidth : (int)imageData.Width - srcX;
+                int srcH = placement.SourceHeight > 0 ? (int)placement.SourceHeight : (int)imageData.Height - srcY;
+
+                // Clamp to image bounds
+                srcW = Math.Min(srcW, (int)imageData.Width - srcX);
+                srcH = Math.Min(srcH, (int)imageData.Height - srcY);
+
+                if (srcW > 0 && srcH > 0)
+                {
+                    var cropped = new CroppedBitmap(bitmap, new Int32Rect(srcX, srcY, srcW, srcH));
+                    dc.DrawImage(cropped, new Rect(destX, destY, destW, destH));
+                }
+            }
+            else
+            {
+                dc.DrawImage(bitmap, new Rect(destX, destY, destW, destH));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or creates a cached WPF BitmapSource from KGP image data.
+    /// </summary>
+    private BitmapSource? GetOrCreateKgpBitmap(KgpImageData imageData)
+    {
+        // Check cache — invalidate if content hash changed
+        if (_kgpBitmapCache.TryGetValue(imageData.ImageId, out var cached))
+        {
+            if (cached.Hash.AsSpan().SequenceEqual(imageData.ContentHash))
+                return cached.Bitmap;
+        }
+
+        var bitmap = ConvertKgpToBitmap(imageData);
+        if (bitmap != null)
+        {
+            bitmap.Freeze();
+            _kgpBitmapCache[imageData.ImageId] = (imageData.ContentHash, bitmap);
+        }
+        return bitmap;
+    }
+
+    /// <summary>
+    /// Converts raw KGP pixel data to a WPF BitmapSource.
+    /// </summary>
+    private static BitmapSource? ConvertKgpToBitmap(KgpImageData imageData)
+    {
+        int w = (int)imageData.Width;
+        int h = (int)imageData.Height;
+        if (w <= 0 || h <= 0) return null;
+
+        switch (imageData.Format)
+        {
+            case KgpFormat.Rgba32:
+            {
+                // Convert RGBA → BGRA (WPF expects BGRA)
+                int expectedSize = w * h * 4;
+                if (imageData.Data.Length < expectedSize) return null;
+
+                var bgra = new byte[expectedSize];
+                for (int i = 0; i < expectedSize; i += 4)
+                {
+                    bgra[i + 0] = imageData.Data[i + 2]; // B ← R
+                    bgra[i + 1] = imageData.Data[i + 1]; // G ← G
+                    bgra[i + 2] = imageData.Data[i + 0]; // R ← B
+                    bgra[i + 3] = imageData.Data[i + 3]; // A ← A
+                }
+
+                return BitmapSource.Create(w, h, 96, 96, PixelFormats.Bgra32, null, bgra, w * 4);
+            }
+
+            case KgpFormat.Rgb24:
+            {
+                // Convert RGB → BGR (WPF expects BGR)
+                int expectedSize = w * h * 3;
+                if (imageData.Data.Length < expectedSize) return null;
+
+                var bgr = new byte[expectedSize];
+                for (int i = 0; i < expectedSize; i += 3)
+                {
+                    bgr[i + 0] = imageData.Data[i + 2]; // B ← R
+                    bgr[i + 1] = imageData.Data[i + 1]; // G ← G
+                    bgr[i + 2] = imageData.Data[i + 0]; // R ← B
+                }
+
+                return BitmapSource.Create(w, h, 96, 96, PixelFormats.Bgr24, null, bgr, w * 3);
+            }
+
+            case KgpFormat.Png:
+            {
+                // PNG: decode directly via WPF's built-in PNG decoder
+                using var stream = new System.IO.MemoryStream(imageData.Data);
+                var decoder = new PngBitmapDecoder(stream, BitmapCreateOptions.PreservePixelFormat, BitmapCacheOption.OnLoad);
+                return decoder.Frames.Count > 0 ? decoder.Frames[0] : null;
+            }
+
+            default:
+                return null;
+        }
     }
 
     protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -268,6 +268,93 @@ public class TerminalControl : FrameworkElement
         }
     }
 
+    // === Mouse Input ===
+
+    private MouseButton _lastPressedButton;
+    private bool _mouseButtonDown;
+
+    protected override void OnMouseDown(MouseButtonEventArgs e)
+    {
+        if (_adapter == null || !_adapter.MouseTrackingEnabled) return;
+
+        Focus();
+        CaptureMouse();
+
+        var pos = CellPosition(e);
+        int button = WpfButtonToSgr(e.ChangedButton);
+        if (button < 0) return;
+
+        int modifiers = GetMouseModifiers();
+        _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(button, pos.x, pos.y, isRelease: false, modifiers));
+        _lastPressedButton = e.ChangedButton;
+        _mouseButtonDown = true;
+        e.Handled = true;
+    }
+
+    protected override void OnMouseUp(MouseButtonEventArgs e)
+    {
+        if (_adapter == null || !_adapter.MouseTrackingEnabled) return;
+
+        ReleaseMouseCapture();
+
+        var pos = CellPosition(e);
+        int button = WpfButtonToSgr(e.ChangedButton);
+        if (button < 0) return;
+
+        int modifiers = GetMouseModifiers();
+        _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(button, pos.x, pos.y, isRelease: true, modifiers));
+        _mouseButtonDown = false;
+        e.Handled = true;
+    }
+
+    protected override void OnMouseMove(MouseEventArgs e)
+    {
+        if (_adapter == null || !_adapter.MouseTrackingEnabled) return;
+        if (!_mouseButtonDown) return; // Only send drag events (mode 1002 behavior)
+
+        var pos = CellPosition(e);
+        int button = WpfButtonToSgr(_lastPressedButton) | 32; // 32 = motion flag
+        int modifiers = GetMouseModifiers();
+        _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(button, pos.x, pos.y, isRelease: false, modifiers));
+    }
+
+    protected override void OnMouseWheel(MouseWheelEventArgs e)
+    {
+        if (_adapter == null || !_adapter.MouseTrackingEnabled) return;
+
+        var pos = CellPosition(e);
+        int button = e.Delta > 0 ? 64 : 65; // 64=scroll up, 65=scroll down
+        int modifiers = GetMouseModifiers();
+        _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(button, pos.x, pos.y, isRelease: false, modifiers));
+        e.Handled = true;
+    }
+
+    private (int x, int y) CellPosition(MouseEventArgs e)
+    {
+        var point = e.GetPosition(this);
+        // SGR mouse uses 1-based coordinates
+        int col = Math.Max(1, (int)(point.X / _cellWidth) + 1);
+        int row = Math.Max(1, (int)(point.Y / _cellHeight) + 1);
+        return (col, row);
+    }
+
+    private static int WpfButtonToSgr(MouseButton button) => button switch
+    {
+        MouseButton.Left => 0,
+        MouseButton.Middle => 1,
+        MouseButton.Right => 2,
+        _ => -1
+    };
+
+    private static int GetMouseModifiers()
+    {
+        int mods = 0;
+        if (Keyboard.IsKeyDown(Key.LeftShift) || Keyboard.IsKeyDown(Key.RightShift)) mods |= 4;
+        if (Keyboard.IsKeyDown(Key.LeftAlt) || Keyboard.IsKeyDown(Key.RightAlt)) mods |= 8;
+        if (Keyboard.IsKeyDown(Key.LeftCtrl) || Keyboard.IsKeyDown(Key.RightCtrl)) mods |= 16;
+        return mods;
+    }
+
     // === Visual tree ===
 
     protected override int VisualChildrenCount => _children.Count;

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -1,6 +1,8 @@
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Input;
+using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using Hex1b;
@@ -111,12 +113,21 @@ public class TerminalControl : FrameworkElement
         ScheduleRender();
     }
 
+    private int _wmKeyDownCount;
+    private int _wmCharCount;
+
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
         var source = PresentationSource.FromVisual(this);
         if (source?.CompositionTarget != null)
         {
             _dpiScale = source.CompositionTarget.TransformToDevice.M11;
+        }
+
+        // Hook Win32 messages directly to count WM_KEYDOWN and WM_CHAR
+        if (source is HwndSource hwndSource)
+        {
+            hwndSource.AddHook(WndProc);
         }
 
         Focus();
@@ -777,6 +788,29 @@ public class TerminalControl : FrameworkElement
 
     /// <summary>Diagnostic: WPF event counts.</summary>
     public (int KeyDown, int PreviewKeyDown, int TextInput) WpfEventCounts => (_keyDownCount, _previewKeyDownCount, _textInputCount);
+
+    /// <summary>Diagnostic: Win32 message counts.</summary>
+    public (int WmKeyDown, int WmChar) Win32Counts => (_wmKeyDownCount, _wmCharCount);
+
+    private const int WM_KEYDOWN = 0x0100;
+    private const int WM_CHAR = 0x0102;
+    private const int WM_SYSKEYDOWN = 0x0104;
+
+    private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+    {
+        switch (msg)
+        {
+            case WM_KEYDOWN:
+            case WM_SYSKEYDOWN:
+                _wmKeyDownCount++;
+                break;
+            case WM_CHAR:
+                _wmCharCount++;
+                break;
+        }
+        // Don't set handled — let WPF process normally
+        return IntPtr.Zero;
+    }
 
     // === Mouse Input ===
 

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -696,10 +696,28 @@ public class TerminalControl : FrameworkElement
         }
     }
 
+    private System.Windows.Threading.DispatcherTimer? _resizeTimer;
+
     protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
     {
         base.OnRenderSizeChanged(sizeInfo);
-        UpdateTerminalSize();
+        
+        // Debounce resize — WPF fires this for every pixel during window drag.
+        // Coalesce into a single resize after the drag settles.
+        if (_resizeTimer == null)
+        {
+            _resizeTimer = new System.Windows.Threading.DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(50)
+            };
+            _resizeTimer.Tick += (_, _) =>
+            {
+                _resizeTimer.Stop();
+                UpdateTerminalSize();
+            };
+        }
+        _resizeTimer.Stop();
+        _resizeTimer.Start();
     }
 
     private void UpdateTerminalSize()

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -734,12 +734,14 @@ public class TerminalControl : FrameworkElement
     // === Keyboard Input ===
 
     private int _keyDownCount;
+    private int _previewKeyDownCount;
     private int _textInputCount;
 
-    protected override void OnKeyDown(KeyEventArgs e)
+    protected override void OnPreviewKeyDown(KeyEventArgs e)
     {
-        if (_adapter == null) return;
-        _keyDownCount++;
+        _previewKeyDownCount++;
+        
+        if (_adapter == null) { base.OnPreviewKeyDown(e); return; }
 
         // Try special key encoding first (arrows, function keys, ctrl combos, etc.)
         var data = AnsiKeyEncoder.Encode(e);
@@ -751,14 +753,21 @@ public class TerminalControl : FrameworkElement
         }
 
         // For printable characters, resolve directly from the key event
-        // using ToUnicode — bypasses OnTextInput which WPF can suppress
-        // during rapid mouse activity
         var text = AnsiKeyEncoder.KeyToText(e);
         if (text != null)
         {
             _adapter.EnqueueInput(text);
             e.Handled = true;
+            return;
         }
+        
+        base.OnPreviewKeyDown(e);
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        // Counted for diagnostics only — all handling is in OnPreviewKeyDown
+        _keyDownCount++;
     }
 
     protected override void OnTextInput(TextCompositionEventArgs e)
@@ -780,7 +789,7 @@ public class TerminalControl : FrameworkElement
     }
 
     /// <summary>Diagnostic: WPF event counts.</summary>
-    public (int KeyDown, int TextInput) WpfEventCounts => (_keyDownCount, _textInputCount);
+    public (int KeyDown, int PreviewKeyDown, int TextInput) WpfEventCounts => (_keyDownCount, _previewKeyDownCount, _textInputCount);
 
     // === Mouse Input ===
 

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -809,9 +809,9 @@ public class TerminalControl : FrameworkElement
                     char ch = (char)wParam;
                     if (ch >= 0x20) // printable (space and above)
                     {
-                        var bytes = System.Text.Encoding.UTF8.GetBytes(new[] { ch });
+                        var bytes = System.Text.Encoding.UTF8.GetBytes([ch]);
                         _adapter.EnqueueInput(bytes);
-                        handled = true; // Suppress WPF TextInput for this char
+                        // Don't set handled — let WPF see it too (OnTextInput will suppress)
                     }
                 }
                 break;

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -468,87 +468,55 @@ public class TerminalControl : FrameworkElement
         TerminalCell[,] buffer, int row, int startCol, int count,
         double px, double py, SolidColorBrush fg, bool dim)
     {
-        var glyphIndices = new List<ushort>(count);
-        var advanceWidths = new List<double>(count);
         var charMap = glyphTypeface.CharacterToGlyphMap;
         double emSize = _fontSize;
-        int skippedLeading = 0;
-        bool hasGlyphs = false;
+
+        if (dim) dc.PushOpacity(0.5);
 
         for (int i = 0; i < count; i++)
         {
-            // Per-glyph advance width snapped to pixel boundaries
             int col = startCol + i;
-            double advance = ColToX(col + 1) - ColToX(col);
-
             var ch = buffer[row, col].Character;
             if (string.IsNullOrEmpty(ch) || ch == " ")
-            {
-                if (!hasGlyphs)
-                {
-                    skippedLeading++;
-                    continue;
-                }
-                if (charMap.TryGetValue(' ', out ushort spaceGlyph))
-                {
-                    glyphIndices.Add(spaceGlyph);
-                    advanceWidths.Add(advance);
-                }
                 continue;
-            }
 
             int codepoint = char.ConvertToUtf32(ch, 0);
-            if (charMap.TryGetValue(codepoint, out ushort glyphIndex))
+            if (!charMap.TryGetValue(codepoint, out ushort glyphIndex))
             {
-                hasGlyphs = true;
-                glyphIndices.Add(glyphIndex);
-                advanceWidths.Add(advance);
-            }
-            else
-            {
-                // Glyph not in this typeface — fall back to FormattedText for
-                // the entire run, which handles WPF font fallback automatically
+                // Glyph not in this typeface — fall back to FormattedText
+                if (dim) dc.Pop();
                 DrawFormattedRun(dc, buffer, row, startCol, count, px, py, fg,
                     glyphTypeface == _boldGlyph || glyphTypeface == _boldItalicGlyph,
                     glyphTypeface == _italicGlyph || glyphTypeface == _boldItalicGlyph,
                     dim);
                 return;
             }
-        }
 
-        if (glyphIndices.Count == 0) return;
+            // Position each glyph independently — no cumulative advance drift
+            double glyphX = ColToX(col);
+            double advance = ColToX(col + 1) - glyphX;
 
-        double originX = ColToX(startCol + skippedLeading);
-        var origin = new Point(originX, py + _baselineY);
-
-#pragma warning disable CS0618 // GlyphRun constructor is obsolete but the replacement requires .NET 9+
-        var glyphRun = new GlyphRun(
-            glyphTypeface,
-            bidiLevel: 0,
-            isSideways: false,
-            renderingEmSize: emSize,
-            pixelsPerDip: (float)_dpiScale,
-            glyphIndices: glyphIndices,
-            baselineOrigin: origin,
-            advanceWidths: advanceWidths,
-            glyphOffsets: null,
-            characters: null,
-            deviceFontName: null,
-            clusterMap: null,
-            caretStops: null,
-            language: null);
+#pragma warning disable CS0618
+            var glyphRun = new GlyphRun(
+                glyphTypeface,
+                bidiLevel: 0,
+                isSideways: false,
+                renderingEmSize: emSize,
+                pixelsPerDip: (float)_dpiScale,
+                glyphIndices: [glyphIndex],
+                baselineOrigin: new Point(glyphX, py + _baselineY),
+                advanceWidths: [advance],
+                glyphOffsets: null,
+                characters: null,
+                deviceFontName: null,
+                clusterMap: null,
+                caretStops: null,
+                language: null);
 #pragma warning restore CS0618
+            dc.DrawGlyphRun(fg, glyphRun);
+        }
 
-        if (dim)
-        {
-            dc.PushOpacity(0.5);
-            dc.DrawGlyphRun(fg, glyphRun);
-            dc.Pop();
-        }
-        else
-        {
-            dc.DrawGlyphRun(fg, glyphRun);
-        }
+        if (dim) dc.Pop();
     }
 
     /// <summary>

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -24,6 +24,8 @@ public class TerminalControl : FrameworkElement
     private WpfTerminalAdapter? _adapter;
     private double _cellWidth;
     private double _cellHeight;
+    private double _physCellWidth;
+    private double _physCellHeight;
     private double _baselineY;
     private double _fontSize;
     private double _dpiScale = 1.0;
@@ -193,14 +195,25 @@ public class TerminalControl : FrameworkElement
             _baselineY = ft.Baseline;
         }
 
-        // Snap cell dimensions to exact physical pixel counts (ceiling).
-        // Using ceiling ensures full pixel coverage. Since cell dimensions
-        // are exact multiples of (1/dpiScale), any integer multiple of
-        // cellWidth/cellHeight is also pixel-aligned — no per-coordinate
-        // snapping needed.
-        _cellWidth = Math.Ceiling(_cellWidth * _dpiScale) / _dpiScale;
-        _cellHeight = Math.Ceiling(_cellHeight * _dpiScale) / _dpiScale;
+        // Store the physical pixel cell width for pixel-perfect position calculation.
+        // At fractional DPI, no single DIP cell width produces pixel-aligned positions
+        // for every column. Instead, we compute each position as:
+        //   Round(col * _physCellWidth) / _dpiScale
+        _physCellWidth = Math.Ceiling(_cellWidth * _dpiScale);
+        _physCellHeight = Math.Ceiling(_cellHeight * _dpiScale);
+        _cellWidth = _physCellWidth / _dpiScale;
+        _cellHeight = _physCellHeight / _dpiScale;
     }
+
+    /// <summary>
+    /// Returns the pixel-snapped X position for a column.
+    /// </summary>
+    private double ColToX(int col) => Math.Round(col * _physCellWidth) / _dpiScale;
+
+    /// <summary>
+    /// Returns the pixel-snapped Y position for a row.
+    /// </summary>
+    private double RowToY(int row) => Math.Round(row * _physCellHeight) / _dpiScale;
 
     /// <summary>
     /// Snaps a DIP value to the nearest physical pixel boundary for the current DPI.
@@ -331,20 +344,17 @@ public class TerminalControl : FrameworkElement
                 }
 
                 int runLen = x - runStart;
-                // Use integer pixel coordinates to eliminate sub-pixel gaps
-                double px = runStart * _cellWidth;
-                double pxEnd = (runStart + runLen) * _cellWidth;
+                double px = ColToX(runStart);
+                double pxEnd = ColToX(runStart + runLen);
                 double runWidth = pxEnd - px;
-                double py2 = y * _cellHeight;
-                double pyEnd = (y + 1) * _cellHeight;
-                double rowHeight = pyEnd - py2;
+                double py2 = RowToY(y);
+                double rowHeight = RowToY(y + 1) - py2;
 
                 // Draw background for the entire run — skip cells covered by behind-text KGP images
                 if (bg != null)
                 {
                     if (kgpCoveredCells != null)
                     {
-                        // Draw background only for uncovered segments within the run
                         int segStart = runStart;
                         for (int i = runStart; i < runStart + runLen; i++)
                         {
@@ -352,8 +362,8 @@ public class TerminalControl : FrameworkElement
                             {
                                 if (i > segStart)
                                 {
-                                    double segPx = segStart * _cellWidth;
-                                    double segEnd = i * _cellWidth;
+                                    double segPx = ColToX(segStart);
+                                    double segEnd = ColToX(i);
                                     dc.DrawRectangle(bg, null, new Rect(segPx, py2, segEnd - segPx, rowHeight));
                                 }
                                 segStart = i + 1;
@@ -361,8 +371,8 @@ public class TerminalControl : FrameworkElement
                         }
                         if (runStart + runLen > segStart)
                         {
-                            double segPx = segStart * _cellWidth;
-                            double segEnd = (runStart + runLen) * _cellWidth;
+                            double segPx = ColToX(segStart);
+                            double segEnd = ColToX(runStart + runLen);
                             dc.DrawRectangle(bg, null, new Rect(segPx, py2, segEnd - segPx, rowHeight));
                         }
                     }
@@ -406,10 +416,10 @@ public class TerminalControl : FrameworkElement
             cursorX >= 0 && cursorX < width &&
             cursorY >= 0 && cursorY < height)
         {
-            double cx = cursorX * _cellWidth;
-            double cxEnd = (cursorX + 1) * _cellWidth;
-            double cy = cursorY * _cellHeight;
-            double cyEnd = (cursorY + 1) * _cellHeight;
+            double cx = ColToX(cursorX);
+            double cxEnd = ColToX(cursorX + 1);
+            double cy = RowToY(cursorY);
+            double cyEnd = RowToY(cursorY + 1);
             double cw = cxEnd - cx;
             double ch2 = cyEnd - cy;
 

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -193,9 +193,18 @@ public class TerminalControl : FrameworkElement
             _baselineY = ft.Baseline;
         }
 
-        // Snap cell dimensions to whole pixels to prevent sub-pixel gaps
-        _cellWidth = Math.Ceiling(_cellWidth);
-        _cellHeight = Math.Ceiling(_cellHeight);
+        // Snap cell dimensions to physical pixel boundaries
+        _cellWidth = SnapToPixel(_cellWidth);
+        _cellHeight = SnapToPixel(_cellHeight);
+    }
+
+    /// <summary>
+    /// Snaps a DIP value to the nearest physical pixel boundary for the current DPI.
+    /// At 150% DPI (scale=1.5), a physical pixel = 1/1.5 DIPs = 0.667 DIPs.
+    /// </summary>
+    private double SnapToPixel(double value)
+    {
+        return Math.Round(value * _dpiScale) / _dpiScale;
     }
 
     private static bool TryCreateGlyphTypeface(FontFamily family, FontStyle style, FontWeight weight, out GlyphTypeface? result)
@@ -319,11 +328,11 @@ public class TerminalControl : FrameworkElement
 
                 int runLen = x - runStart;
                 // Use integer pixel coordinates to eliminate sub-pixel gaps
-                double px = Math.Round(runStart * _cellWidth);
-                double pxEnd = Math.Round((runStart + runLen) * _cellWidth);
+                double px = SnapToPixel(runStart * _cellWidth);
+                double pxEnd = SnapToPixel((runStart + runLen) * _cellWidth);
                 double runWidth = pxEnd - px;
-                double py2 = Math.Round(y * _cellHeight);
-                double pyEnd = Math.Round((y + 1) * _cellHeight);
+                double py2 = SnapToPixel(y * _cellHeight);
+                double pyEnd = SnapToPixel((y + 1) * _cellHeight);
                 double rowHeight = pyEnd - py2;
 
                 // Draw background for the entire run — skip cells covered by behind-text KGP images
@@ -339,8 +348,8 @@ public class TerminalControl : FrameworkElement
                             {
                                 if (i > segStart)
                                 {
-                                    double segPx = Math.Round(segStart * _cellWidth);
-                                    double segEnd = Math.Round(i * _cellWidth);
+                                    double segPx = SnapToPixel(segStart * _cellWidth);
+                                    double segEnd = SnapToPixel(i * _cellWidth);
                                     dc.DrawRectangle(bg, null, new Rect(segPx, py2, segEnd - segPx, rowHeight));
                                 }
                                 segStart = i + 1;
@@ -348,8 +357,8 @@ public class TerminalControl : FrameworkElement
                         }
                         if (runStart + runLen > segStart)
                         {
-                            double segPx = Math.Round(segStart * _cellWidth);
-                            double segEnd = Math.Round((runStart + runLen) * _cellWidth);
+                            double segPx = SnapToPixel(segStart * _cellWidth);
+                            double segEnd = SnapToPixel((runStart + runLen) * _cellWidth);
                             dc.DrawRectangle(bg, null, new Rect(segPx, py2, segEnd - segPx, rowHeight));
                         }
                     }
@@ -393,10 +402,10 @@ public class TerminalControl : FrameworkElement
             cursorX >= 0 && cursorX < width &&
             cursorY >= 0 && cursorY < height)
         {
-            double cx = Math.Round(cursorX * _cellWidth);
-            double cxEnd = Math.Round((cursorX + 1) * _cellWidth);
-            double cy = Math.Round(cursorY * _cellHeight);
-            double cyEnd = Math.Round((cursorY + 1) * _cellHeight);
+            double cx = SnapToPixel(cursorX * _cellWidth);
+            double cxEnd = SnapToPixel((cursorX + 1) * _cellWidth);
+            double cy = SnapToPixel(cursorY * _cellHeight);
+            double cyEnd = SnapToPixel((cursorY + 1) * _cellHeight);
             double cw = cxEnd - cx;
             double ch2 = cyEnd - cy;
 

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -763,10 +763,6 @@ public class TerminalControl : FrameworkElement
     private bool _mouseButtonDown;
     private int _lastMouseCellX = -1;
     private int _lastMouseCellY = -1;
-    private int _pendingMouseButton = -1;
-    private int _pendingMouseModifiers;
-    private long _lastMouseSendTick;
-    private System.Windows.Threading.DispatcherTimer? _mouseMotionTimer;
 
     protected override void OnMouseDown(MouseButtonEventArgs e)
     {
@@ -826,46 +822,8 @@ public class TerminalControl : FrameworkElement
             ? WpfButtonToSgr(_lastPressedButton) | 32
             : 35;
         int modifiers = GetMouseModifiers();
-
-        // Rate-limit: send immediately if enough time has passed since last send,
-        // otherwise store for the next timer tick (coalescing rapid moves).
-        var now = Environment.TickCount64;
-        if (now - _lastMouseSendTick >= 16) // ~60fps
-        {
-            _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(
-                button, pos.x, pos.y, isRelease: false, modifiers), isMouse: true);
-            _lastMouseSendTick = now;
-            _pendingMouseButton = -1;
-        }
-        else
-        {
-            // Store pending — will be sent when timer fires
-            _pendingMouseButton = button;
-            _pendingMouseModifiers = modifiers;
-            
-            if (_mouseMotionTimer == null)
-            {
-                _mouseMotionTimer = new System.Windows.Threading.DispatcherTimer
-                {
-                    Interval = TimeSpan.FromMilliseconds(16)
-                };
-                _mouseMotionTimer.Tick += (_, _) =>
-                {
-                    _mouseMotionTimer.Stop();
-                    if (_adapter != null && _pendingMouseButton >= 0)
-                    {
-                        _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(
-                            _pendingMouseButton, _lastMouseCellX, _lastMouseCellY,
-                            isRelease: false, _pendingMouseModifiers), isMouse: true);
-                        _pendingMouseButton = -1;
-                        _lastMouseSendTick = Environment.TickCount64;
-                    }
-                };
-            }
-            
-            if (!_mouseMotionTimer.IsEnabled)
-                _mouseMotionTimer.Start();
-        }
+        _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(
+            button, pos.x, pos.y, isRelease: false, modifiers), isMouse: true);
     }
 
     protected override void OnMouseWheel(MouseWheelEventArgs e)

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -741,24 +741,41 @@ public class TerminalControl : FrameworkElement
         if (_adapter == null) return;
         _keyDownCount++;
 
+        // Try special key encoding first (arrows, function keys, ctrl combos, etc.)
         var data = AnsiKeyEncoder.Encode(e);
         if (data != null)
         {
             _adapter.EnqueueInput(data);
+            e.Handled = true;
+            return;
+        }
+
+        // For printable characters, resolve directly from the key event
+        // using ToUnicode — bypasses OnTextInput which WPF can suppress
+        // during rapid mouse activity
+        var text = AnsiKeyEncoder.KeyToText(e);
+        if (text != null)
+        {
+            _adapter.EnqueueInput(text);
             e.Handled = true;
         }
     }
 
     protected override void OnTextInput(TextCompositionEventArgs e)
     {
+        // Handled entirely in OnKeyDown to avoid WPF suppression during mouse activity.
+        // This is kept as a fallback for IME composition if needed in the future.
         if (_adapter == null) return;
         _textInputCount++;
 
-        var data = AnsiKeyEncoder.EncodeText(e.Text);
-        if (data != null)
+        if (!e.Handled)
         {
-            _adapter.EnqueueInput(data);
-            e.Handled = true;
+            var data = AnsiKeyEncoder.EncodeText(e.Text);
+            if (data != null)
+            {
+                _adapter.EnqueueInput(data);
+                e.Handled = true;
+            }
         }
     }
 

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -743,20 +743,13 @@ public class TerminalControl : FrameworkElement
         
         if (_adapter == null) { base.OnPreviewKeyDown(e); return; }
 
-        // Try special key encoding first (arrows, function keys, ctrl combos, etc.)
+        // Only handle special keys (arrows, function keys, ctrl combos) here.
+        // Printable characters go through OnTextInput for correct keyboard
+        // layout/shift/capslock handling without ToUnicode side effects.
         var data = AnsiKeyEncoder.Encode(e);
         if (data != null)
         {
             _adapter.EnqueueInput(data);
-            e.Handled = true;
-            return;
-        }
-
-        // For printable characters, resolve directly from the key event
-        var text = AnsiKeyEncoder.KeyToText(e);
-        if (text != null)
-        {
-            _adapter.EnqueueInput(text);
             e.Handled = true;
             return;
         }
@@ -766,16 +759,20 @@ public class TerminalControl : FrameworkElement
 
     protected override void OnKeyDown(KeyEventArgs e)
     {
-        // Counted for diagnostics only — all handling is in OnPreviewKeyDown
         _keyDownCount++;
     }
 
     protected override void OnTextInput(TextCompositionEventArgs e)
     {
-        // All character input is handled in OnPreviewKeyDown via KeyToText.
-        // Suppress TextInput to prevent duplicate characters.
+        if (_adapter == null) return;
         _textInputCount++;
-        e.Handled = true;
+
+        var data = AnsiKeyEncoder.EncodeText(e.Text);
+        if (data != null)
+        {
+            _adapter.EnqueueInput(data);
+            e.Handled = true;
+        }
     }
 
     /// <summary>Diagnostic: WPF event counts.</summary>

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -765,6 +765,7 @@ public class TerminalControl : FrameworkElement
     private int _lastMouseCellY = -1;
     private int _pendingMouseButton = -1;
     private int _pendingMouseModifiers;
+    private long _lastMouseSendTick;
     private System.Windows.Threading.DispatcherTimer? _mouseMotionTimer;
 
     protected override void OnMouseDown(MouseButtonEventArgs e)
@@ -783,7 +784,7 @@ public class TerminalControl : FrameworkElement
             if (button < 0) return;
 
             int modifiers = GetMouseModifiers();
-            _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(button, pos.x, pos.y, isRelease: false, modifiers));
+            _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(button, pos.x, pos.y, isRelease: false, modifiers), isMouse: true);
             _lastPressedButton = e.ChangedButton;
             _mouseButtonDown = true;
         }
@@ -802,7 +803,7 @@ public class TerminalControl : FrameworkElement
         if (button < 0) return;
 
         int modifiers = GetMouseModifiers();
-        _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(button, pos.x, pos.y, isRelease: true, modifiers));
+        _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(button, pos.x, pos.y, isRelease: true, modifiers), isMouse: true);
         _mouseButtonDown = false;
         e.Handled = true;
     }
@@ -824,34 +825,47 @@ public class TerminalControl : FrameworkElement
         int button = _mouseButtonDown
             ? WpfButtonToSgr(_lastPressedButton) | 32
             : 35;
+        int modifiers = GetMouseModifiers();
 
-        // Coalesce mouse motion: store the latest position and send on a short timer.
-        // This prevents mouse events from flooding the input channel and drowning
-        // out keyboard input that arrives between mouse moves.
-        _pendingMouseButton = button;
-        _pendingMouseModifiers = GetMouseModifiers();
-        
-        if (_mouseMotionTimer == null)
+        // Rate-limit: send immediately if enough time has passed since last send,
+        // otherwise store for the next timer tick (coalescing rapid moves).
+        var now = Environment.TickCount64;
+        if (now - _lastMouseSendTick >= 16) // ~60fps
         {
-            _mouseMotionTimer = new System.Windows.Threading.DispatcherTimer
-            {
-                Interval = TimeSpan.FromMilliseconds(16) // ~60fps max
-            };
-            _mouseMotionTimer.Tick += (_, _) =>
-            {
-                _mouseMotionTimer.Stop();
-                if (_adapter != null && _pendingMouseButton >= 0)
-                {
-                    _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(
-                        _pendingMouseButton, _lastMouseCellX, _lastMouseCellY,
-                        isRelease: false, _pendingMouseModifiers));
-                    _pendingMouseButton = -1;
-                }
-            };
+            _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(
+                button, pos.x, pos.y, isRelease: false, modifiers), isMouse: true);
+            _lastMouseSendTick = now;
+            _pendingMouseButton = -1;
         }
-        
-        _mouseMotionTimer.Stop();
-        _mouseMotionTimer.Start();
+        else
+        {
+            // Store pending — will be sent when timer fires
+            _pendingMouseButton = button;
+            _pendingMouseModifiers = modifiers;
+            
+            if (_mouseMotionTimer == null)
+            {
+                _mouseMotionTimer = new System.Windows.Threading.DispatcherTimer
+                {
+                    Interval = TimeSpan.FromMilliseconds(16)
+                };
+                _mouseMotionTimer.Tick += (_, _) =>
+                {
+                    _mouseMotionTimer.Stop();
+                    if (_adapter != null && _pendingMouseButton >= 0)
+                    {
+                        _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(
+                            _pendingMouseButton, _lastMouseCellX, _lastMouseCellY,
+                            isRelease: false, _pendingMouseModifiers), isMouse: true);
+                        _pendingMouseButton = -1;
+                        _lastMouseSendTick = Environment.TickCount64;
+                    }
+                };
+            }
+            
+            if (!_mouseMotionTimer.IsEnabled)
+                _mouseMotionTimer.Start();
+        }
     }
 
     protected override void OnMouseWheel(MouseWheelEventArgs e)
@@ -861,7 +875,7 @@ public class TerminalControl : FrameworkElement
         var pos = CellPosition(e);
         int button = e.Delta > 0 ? 64 : 65;
         int modifiers = GetMouseModifiers();
-        _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(button, pos.x, pos.y, isRelease: false, modifiers));
+        _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(button, pos.x, pos.y, isRelease: false, modifiers), isMouse: true);
         e.Handled = true;
     }
 

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -763,6 +763,9 @@ public class TerminalControl : FrameworkElement
     private bool _mouseButtonDown;
     private int _lastMouseCellX = -1;
     private int _lastMouseCellY = -1;
+    private int _pendingMouseButton = -1;
+    private int _pendingMouseModifiers;
+    private System.Windows.Threading.DispatcherTimer? _mouseMotionTimer;
 
     protected override void OnMouseDown(MouseButtonEventArgs e)
     {
@@ -813,23 +816,42 @@ public class TerminalControl : FrameworkElement
 
         var pos = CellPosition(e);
         
-        // Only send when the cell position actually changes — suppresses
-        // sub-cell pixel moves that flood the PTY and drown out keyboard input
+        // Only send when the cell position actually changes
         if (pos.x == _lastMouseCellX && pos.y == _lastMouseCellY) return;
         _lastMouseCellX = pos.x;
         _lastMouseCellY = pos.y;
 
-        int button;
-        if (_mouseButtonDown)
+        int button = _mouseButtonDown
+            ? WpfButtonToSgr(_lastPressedButton) | 32
+            : 35;
+
+        // Coalesce mouse motion: store the latest position and send on a short timer.
+        // This prevents mouse events from flooding the input channel and drowning
+        // out keyboard input that arrives between mouse moves.
+        _pendingMouseButton = button;
+        _pendingMouseModifiers = GetMouseModifiers();
+        
+        if (_mouseMotionTimer == null)
         {
-            button = WpfButtonToSgr(_lastPressedButton) | 32;
+            _mouseMotionTimer = new System.Windows.Threading.DispatcherTimer
+            {
+                Interval = TimeSpan.FromMilliseconds(16) // ~60fps max
+            };
+            _mouseMotionTimer.Tick += (_, _) =>
+            {
+                _mouseMotionTimer.Stop();
+                if (_adapter != null && _pendingMouseButton >= 0)
+                {
+                    _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(
+                        _pendingMouseButton, _lastMouseCellX, _lastMouseCellY,
+                        isRelease: false, _pendingMouseModifiers));
+                    _pendingMouseButton = -1;
+                }
+            };
         }
-        else
-        {
-            button = 35;
-        }
-        int modifiers = GetMouseModifiers();
-        _adapter.EnqueueInput(AnsiKeyEncoder.EncodeMouse(button, pos.x, pos.y, isRelease: false, modifiers));
+        
+        _mouseMotionTimer.Stop();
+        _mouseMotionTimer.Start();
     }
 
     protected override void OnMouseWheel(MouseWheelEventArgs e)

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -286,7 +286,6 @@ public class TerminalControl : FrameworkElement
     {
         for (int y = 0; y < height; y++)
         {
-            double py = y * _cellHeight;
             int x = 0;
 
             while (x < width)
@@ -319,8 +318,13 @@ public class TerminalControl : FrameworkElement
                 }
 
                 int runLen = x - runStart;
-                double px = runStart * _cellWidth;
-                double runWidth = runLen * _cellWidth;
+                // Use integer pixel coordinates to eliminate sub-pixel gaps
+                double px = Math.Round(runStart * _cellWidth);
+                double pxEnd = Math.Round((runStart + runLen) * _cellWidth);
+                double runWidth = pxEnd - px;
+                double py2 = Math.Round(y * _cellHeight);
+                double pyEnd = Math.Round((y + 1) * _cellHeight);
+                double rowHeight = pyEnd - py2;
 
                 // Draw background for the entire run — skip cells covered by behind-text KGP images
                 if (bg != null)
@@ -333,27 +337,25 @@ public class TerminalControl : FrameworkElement
                         {
                             if (kgpCoveredCells.Contains((i, y)))
                             {
-                                // Draw any accumulated uncovered segment
                                 if (i > segStart)
                                 {
-                                    double segPx = segStart * _cellWidth;
-                                    double segW = (i - segStart) * _cellWidth;
-                                    dc.DrawRectangle(bg, null, new Rect(segPx, py, segW, _cellHeight));
+                                    double segPx = Math.Round(segStart * _cellWidth);
+                                    double segEnd = Math.Round(i * _cellWidth);
+                                    dc.DrawRectangle(bg, null, new Rect(segPx, py2, segEnd - segPx, rowHeight));
                                 }
                                 segStart = i + 1;
                             }
                         }
-                        // Draw remaining uncovered segment
                         if (runStart + runLen > segStart)
                         {
-                            double segPx = segStart * _cellWidth;
-                            double segW = (runStart + runLen - segStart) * _cellWidth;
-                            dc.DrawRectangle(bg, null, new Rect(segPx, py, segW, _cellHeight));
+                            double segPx = Math.Round(segStart * _cellWidth);
+                            double segEnd = Math.Round((runStart + runLen) * _cellWidth);
+                            dc.DrawRectangle(bg, null, new Rect(segPx, py2, segEnd - segPx, rowHeight));
                         }
                     }
                     else
                     {
-                        dc.DrawRectangle(bg, null, new Rect(px, py, runWidth, _cellHeight));
+                        dc.DrawRectangle(bg, null, new Rect(px, py2, runWidth, rowHeight));
                     }
                 }
 
@@ -361,28 +363,27 @@ public class TerminalControl : FrameworkElement
                 var glyphTypeface = GetGlyphTypeface(bold, italic);
                 if (glyphTypeface != null)
                 {
-                    DrawGlyphRun(dc, glyphTypeface, buffer, y, runStart, runLen, px, py, fg!, dim);
+                    DrawGlyphRun(dc, glyphTypeface, buffer, y, runStart, runLen, px, py2, fg!, dim);
                 }
                 else
                 {
-                    // Fallback: single FormattedText for the whole run
-                    DrawFormattedRun(dc, buffer, y, runStart, runLen, px, py, fg!, bold, italic, dim);
+                    DrawFormattedRun(dc, buffer, y, runStart, runLen, px, py2, fg!, bold, italic, dim);
                 }
 
                 // Draw underline for the run
                 if (underline)
                 {
                     var pen = GetOrCreatePen(fg!);
-                    double underlineY = py + _cellHeight - 2;
-                    dc.DrawLine(pen, new Point(px, underlineY), new Point(px + runWidth, underlineY));
+                    double underlineY = py2 + rowHeight - 2;
+                    dc.DrawLine(pen, new Point(px, underlineY), new Point(pxEnd, underlineY));
                 }
 
                 // Draw strikethrough for the run
                 if (strikethrough)
                 {
                     var pen = GetOrCreatePen(fg!);
-                    double strikeY = py + _cellHeight / 2;
-                    dc.DrawLine(pen, new Point(px, strikeY), new Point(px + runWidth, strikeY));
+                    double strikeY = py2 + rowHeight / 2;
+                    dc.DrawLine(pen, new Point(px, strikeY), new Point(pxEnd, strikeY));
                 }
             }
         }
@@ -392,8 +393,12 @@ public class TerminalControl : FrameworkElement
             cursorX >= 0 && cursorX < width &&
             cursorY >= 0 && cursorY < height)
         {
-            double cx = cursorX * _cellWidth;
-            double cy = cursorY * _cellHeight;
+            double cx = Math.Round(cursorX * _cellWidth);
+            double cxEnd = Math.Round((cursorX + 1) * _cellWidth);
+            double cy = Math.Round(cursorY * _cellHeight);
+            double cyEnd = Math.Round((cursorY + 1) * _cellHeight);
+            double cw = cxEnd - cx;
+            double ch2 = cyEnd - cy;
 
             // Determine effective shape (Default → BlinkingBlock)
             var shape = cursorShape == CursorShape.Default ? CursorShape.BlinkingBlock : cursorShape;
@@ -402,9 +407,7 @@ public class TerminalControl : FrameworkElement
             {
                 case CursorShape.BlinkingBlock:
                 case CursorShape.SteadyBlock:
-                    // Full block cursor — draw inverted cell
-                    dc.DrawRectangle(CursorBrush, null, new Rect(cx, cy, _cellWidth, _cellHeight));
-                    // Re-draw the character in inverted color
+                    dc.DrawRectangle(CursorBrush, null, new Rect(cx, cy, cw, ch2));
                     var blockCell = buffer[cursorY, cursorX];
                     var ch = blockCell.Character;
                     if (!string.IsNullOrEmpty(ch) && ch != " " && _regularGlyph != null)
@@ -426,14 +429,12 @@ public class TerminalControl : FrameworkElement
 
                 case CursorShape.BlinkingBar:
                 case CursorShape.SteadyBar:
-                    // Vertical bar cursor (2px wide)
-                    dc.DrawRectangle(CursorBrush, null, new Rect(cx, cy, 2, _cellHeight));
+                    dc.DrawRectangle(CursorBrush, null, new Rect(cx, cy, 2, ch2));
                     break;
 
                 case CursorShape.BlinkingUnderline:
                 case CursorShape.SteadyUnderline:
-                    // Underline cursor (2px tall at bottom of cell)
-                    dc.DrawRectangle(CursorBrush, null, new Rect(cx, cy + _cellHeight - 2, _cellWidth, 2));
+                    dc.DrawRectangle(CursorBrush, null, new Rect(cx, cy + ch2 - 2, cw, 2));
                     break;
             }
         }

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -137,7 +137,7 @@ public class TerminalControl : FrameworkElement
 
     private void UpdateFont()
     {
-        var fontFamily = new FontFamily("Cascadia Mono, Consolas");
+        var fontFamily = new FontFamily("JetBrainsMono Nerd Font, Cascadia Mono, Consolas");
         _fallbackTypeface = new Typeface(fontFamily, FontStyles.Normal, FontWeights.Regular, FontStretches.Normal);
 
         // Pre-cache GlyphTypeface variants

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -193,9 +193,13 @@ public class TerminalControl : FrameworkElement
             _baselineY = ft.Baseline;
         }
 
-        // Snap cell dimensions to physical pixel boundaries
-        _cellWidth = SnapToPixel(_cellWidth);
-        _cellHeight = SnapToPixel(_cellHeight);
+        // Snap cell dimensions to exact physical pixel counts (ceiling).
+        // Using ceiling ensures full pixel coverage. Since cell dimensions
+        // are exact multiples of (1/dpiScale), any integer multiple of
+        // cellWidth/cellHeight is also pixel-aligned — no per-coordinate
+        // snapping needed.
+        _cellWidth = Math.Ceiling(_cellWidth * _dpiScale) / _dpiScale;
+        _cellHeight = Math.Ceiling(_cellHeight * _dpiScale) / _dpiScale;
     }
 
     /// <summary>
@@ -328,11 +332,11 @@ public class TerminalControl : FrameworkElement
 
                 int runLen = x - runStart;
                 // Use integer pixel coordinates to eliminate sub-pixel gaps
-                double px = SnapToPixel(runStart * _cellWidth);
-                double pxEnd = SnapToPixel((runStart + runLen) * _cellWidth);
+                double px = runStart * _cellWidth;
+                double pxEnd = (runStart + runLen) * _cellWidth;
                 double runWidth = pxEnd - px;
-                double py2 = SnapToPixel(y * _cellHeight);
-                double pyEnd = SnapToPixel((y + 1) * _cellHeight);
+                double py2 = y * _cellHeight;
+                double pyEnd = (y + 1) * _cellHeight;
                 double rowHeight = pyEnd - py2;
 
                 // Draw background for the entire run — skip cells covered by behind-text KGP images
@@ -348,8 +352,8 @@ public class TerminalControl : FrameworkElement
                             {
                                 if (i > segStart)
                                 {
-                                    double segPx = SnapToPixel(segStart * _cellWidth);
-                                    double segEnd = SnapToPixel(i * _cellWidth);
+                                    double segPx = segStart * _cellWidth;
+                                    double segEnd = i * _cellWidth;
                                     dc.DrawRectangle(bg, null, new Rect(segPx, py2, segEnd - segPx, rowHeight));
                                 }
                                 segStart = i + 1;
@@ -357,8 +361,8 @@ public class TerminalControl : FrameworkElement
                         }
                         if (runStart + runLen > segStart)
                         {
-                            double segPx = SnapToPixel(segStart * _cellWidth);
-                            double segEnd = SnapToPixel((runStart + runLen) * _cellWidth);
+                            double segPx = segStart * _cellWidth;
+                            double segEnd = (runStart + runLen) * _cellWidth;
                             dc.DrawRectangle(bg, null, new Rect(segPx, py2, segEnd - segPx, rowHeight));
                         }
                     }
@@ -402,10 +406,10 @@ public class TerminalControl : FrameworkElement
             cursorX >= 0 && cursorX < width &&
             cursorY >= 0 && cursorY < height)
         {
-            double cx = SnapToPixel(cursorX * _cellWidth);
-            double cxEnd = SnapToPixel((cursorX + 1) * _cellWidth);
-            double cy = SnapToPixel(cursorY * _cellHeight);
-            double cyEnd = SnapToPixel((cursorY + 1) * _cellHeight);
+            double cx = cursorX * _cellWidth;
+            double cxEnd = (cursorX + 1) * _cellWidth;
+            double cy = cursorY * _cellHeight;
+            double cyEnd = (cursorY + 1) * _cellHeight;
             double cw = cxEnd - cx;
             double ch2 = cyEnd - cy;
 

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -772,20 +772,10 @@ public class TerminalControl : FrameworkElement
 
     protected override void OnTextInput(TextCompositionEventArgs e)
     {
-        // Handled entirely in OnKeyDown to avoid WPF suppression during mouse activity.
-        // This is kept as a fallback for IME composition if needed in the future.
-        if (_adapter == null) return;
+        // All character input is handled in OnPreviewKeyDown via KeyToText.
+        // Suppress TextInput to prevent duplicate characters.
         _textInputCount++;
-
-        if (!e.Handled)
-        {
-            var data = AnsiKeyEncoder.EncodeText(e.Text);
-            if (data != null)
-            {
-                _adapter.EnqueueInput(data);
-                e.Handled = true;
-            }
-        }
+        e.Handled = true;
     }
 
     /// <summary>Diagnostic: WPF event counts.</summary>

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -308,103 +308,76 @@ public class TerminalControl : FrameworkElement
         int cursorX, int cursorY, bool cursorVisible, CursorShape cursorShape,
         HashSet<(int, int)>? kgpCoveredCells)
     {
+        var charMap = (_regularGlyph ?? _boldGlyph)?.CharacterToGlyphMap;
+
         for (int y = 0; y < height; y++)
         {
-            int x = 0;
+            double cellY = y * _cellHeight;
 
-            while (x < width)
+            for (int x = 0; x < width; x++)
             {
                 var cell = buffer[y, x];
+                double cellX = x * _cellWidth;
 
-                // Determine effective colors (handle reverse)
                 var fg = cell.IsReverse ? GetBrush(cell.Background, DefaultBackground) : GetBrush(cell.Foreground, DefaultForeground);
                 var bg = cell.IsReverse ? GetBrush(cell.Foreground, DefaultForeground) : GetBrush(cell.Background, null);
-                bool bold = cell.IsBold;
-                bool italic = cell.IsItalic;
-                bool dim = cell.IsDim;
-                bool underline = cell.IsUnderline;
-                bool strikethrough = cell.IsStrikethrough;
 
-                // Scan for a run of cells with the same style
-                int runStart = x;
-                x++;
-                while (x < width)
+                // Draw cell background
+                if (bg != null && !(kgpCoveredCells?.Contains((x, y)) == true))
                 {
-                    var next = buffer[y, x];
-                    var nextFg = next.IsReverse ? GetBrush(next.Background, DefaultBackground) : GetBrush(next.Foreground, DefaultForeground);
-                    var nextBg = next.IsReverse ? GetBrush(next.Foreground, DefaultForeground) : GetBrush(next.Background, null);
-
-                    if (nextFg != fg || nextBg != bg ||
-                        next.IsBold != bold || next.IsItalic != italic || next.IsDim != dim ||
-                        next.IsUnderline != underline || next.IsStrikethrough != strikethrough)
-                        break;
-                    x++;
+                    dc.DrawRectangle(bg, null, new Rect(cellX, cellY, _cellWidth, _cellHeight));
                 }
 
-                int runLen = x - runStart;
-                double px = ColToX(runStart);
-                double pxEnd = ColToX(runStart + runLen);
-                double runWidth = pxEnd - px;
-                double py2 = RowToY(y);
-                double rowHeight = RowToY(y + 1) - py2;
-
-                // Draw background for the entire run — skip cells covered by behind-text KGP images
-                if (bg != null)
+                // Draw character
+                var ch = cell.Character;
+                if (!string.IsNullOrEmpty(ch) && ch != " ")
                 {
-                    if (kgpCoveredCells != null)
+                    bool bold = cell.IsBold;
+                    bool italic = cell.IsItalic;
+                    var glyphTypeface = GetGlyphTypeface(bold, italic);
+                    var activeCharMap = glyphTypeface?.CharacterToGlyphMap ?? charMap;
+
+                    if (activeCharMap != null && glyphTypeface != null)
                     {
-                        int segStart = runStart;
-                        for (int i = runStart; i < runStart + runLen; i++)
+                        int codepoint = char.ConvertToUtf32(ch, 0);
+                        if (activeCharMap.TryGetValue(codepoint, out ushort glyphIndex))
                         {
-                            if (kgpCoveredCells.Contains((i, y)))
-                            {
-                                if (i > segStart)
-                                {
-                                    double segPx = ColToX(segStart);
-                                    double segEnd = ColToX(i);
-                                    dc.DrawRectangle(bg, null, new Rect(segPx, py2, segEnd - segPx, rowHeight));
-                                }
-                                segStart = i + 1;
-                            }
+                            if (cell.IsDim) dc.PushOpacity(0.5);
+#pragma warning disable CS0618
+                            var glyphRun = new GlyphRun(
+                                glyphTypeface, 0, false, _fontSize, (float)_dpiScale,
+                                [glyphIndex],
+                                new Point(cellX, cellY + _baselineY),
+                                [_cellWidth],
+                                null, null, null, null, null, null);
+#pragma warning restore CS0618
+                            dc.DrawGlyphRun(fg!, glyphRun);
+                            if (cell.IsDim) dc.Pop();
                         }
-                        if (runStart + runLen > segStart)
+                        else
                         {
-                            double segPx = ColToX(segStart);
-                            double segEnd = ColToX(runStart + runLen);
-                            dc.DrawRectangle(bg, null, new Rect(segPx, py2, segEnd - segPx, rowHeight));
+                            // Font fallback via FormattedText for unmapped glyphs
+                            DrawFormattedCell(dc, ch, cellX, cellY, fg!, cell.IsBold, cell.IsItalic, cell.IsDim);
                         }
                     }
                     else
                     {
-                        dc.DrawRectangle(bg, null, new Rect(px, py2, runWidth, rowHeight));
+                        DrawFormattedCell(dc, ch, cellX, cellY, fg!, cell.IsBold, cell.IsItalic, cell.IsDim);
                     }
                 }
 
-                // Build GlyphRun for the text
-                var glyphTypeface = GetGlyphTypeface(bold, italic);
-                if (glyphTypeface != null)
-                {
-                    DrawGlyphRun(dc, glyphTypeface, buffer, y, runStart, runLen, px, py2, fg!, dim);
-                }
-                else
-                {
-                    DrawFormattedRun(dc, buffer, y, runStart, runLen, px, py2, fg!, bold, italic, dim);
-                }
-
-                // Draw underline for the run
-                if (underline)
+                // Draw underline
+                if (cell.IsUnderline)
                 {
                     var pen = GetOrCreatePen(fg!);
-                    double underlineY = py2 + rowHeight - 2;
-                    dc.DrawLine(pen, new Point(px, underlineY), new Point(pxEnd, underlineY));
+                    dc.DrawLine(pen, new Point(cellX, cellY + _cellHeight - 2), new Point(cellX + _cellWidth, cellY + _cellHeight - 2));
                 }
 
-                // Draw strikethrough for the run
-                if (strikethrough)
+                // Draw strikethrough
+                if (cell.IsStrikethrough)
                 {
                     var pen = GetOrCreatePen(fg!);
-                    double strikeY = py2 + rowHeight / 2;
-                    dc.DrawLine(pen, new Point(px, strikeY), new Point(pxEnd, strikeY));
+                    dc.DrawLine(pen, new Point(cellX, cellY + _cellHeight / 2), new Point(cellX + _cellWidth, cellY + _cellHeight / 2));
                 }
             }
         }
@@ -414,50 +387,71 @@ public class TerminalControl : FrameworkElement
             cursorX >= 0 && cursorX < width &&
             cursorY >= 0 && cursorY < height)
         {
-            double cx = ColToX(cursorX);
-            double cxEnd = ColToX(cursorX + 1);
-            double cy = RowToY(cursorY);
-            double cyEnd = RowToY(cursorY + 1);
-            double cw = cxEnd - cx;
-            double ch2 = cyEnd - cy;
+            double cx = cursorX * _cellWidth;
+            double cy = cursorY * _cellHeight;
 
-            // Determine effective shape (Default → BlinkingBlock)
             var shape = cursorShape == CursorShape.Default ? CursorShape.BlinkingBlock : cursorShape;
 
             switch (shape)
             {
                 case CursorShape.BlinkingBlock:
                 case CursorShape.SteadyBlock:
-                    dc.DrawRectangle(CursorBrush, null, new Rect(cx, cy, cw, ch2));
+                    dc.DrawRectangle(CursorBrush, null, new Rect(cx, cy, _cellWidth, _cellHeight));
                     var blockCell = buffer[cursorY, cursorX];
-                    var ch = blockCell.Character;
-                    if (!string.IsNullOrEmpty(ch) && ch != " " && _regularGlyph != null)
+                    var bch = blockCell.Character;
+                    if (!string.IsNullOrEmpty(bch) && bch != " " && _regularGlyph != null)
                     {
-                        var charMap = _regularGlyph.CharacterToGlyphMap;
-                        int codepoint = char.ConvertToUtf32(ch, 0);
-                        if (charMap.TryGetValue(codepoint, out ushort glyphIdx))
+                        var cMap2 = _regularGlyph.CharacterToGlyphMap;
+                        int cp = char.ConvertToUtf32(bch, 0);
+                        if (cMap2.TryGetValue(cp, out ushort gi))
                         {
 #pragma warning disable CS0618
-                            var glyphRun = new GlyphRun(
+                            var gr = new GlyphRun(
                                 _regularGlyph, 0, false, _fontSize, (float)_dpiScale,
-                                [glyphIdx], new Point(cx, cy + _baselineY),
-                                [cw], null, null, null, null, null, null);
+                                [gi], new Point(cx, cy + _baselineY),
+                                [_cellWidth], null, null, null, null, null, null);
 #pragma warning restore CS0618
-                            dc.DrawGlyphRun(DefaultBackground, glyphRun);
+                            dc.DrawGlyphRun(DefaultBackground, gr);
                         }
                     }
                     break;
 
                 case CursorShape.BlinkingBar:
                 case CursorShape.SteadyBar:
-                    dc.DrawRectangle(CursorBrush, null, new Rect(cx, cy, 2, ch2));
+                    dc.DrawRectangle(CursorBrush, null, new Rect(cx, cy, 2, _cellHeight));
                     break;
 
                 case CursorShape.BlinkingUnderline:
                 case CursorShape.SteadyUnderline:
-                    dc.DrawRectangle(CursorBrush, null, new Rect(cx, cy + ch2 - 2, cw, 2));
+                    dc.DrawRectangle(CursorBrush, null, new Rect(cx, cy + _cellHeight - 2, _cellWidth, 2));
                     break;
             }
+        }
+    }
+
+    /// <summary>
+    /// Draws a single cell character using FormattedText (font fallback for unmapped glyphs).
+    /// </summary>
+    private void DrawFormattedCell(DrawingContext dc, string ch, double x, double y,
+        SolidColorBrush fg, bool bold, bool italic, bool dim)
+    {
+        var weight = bold ? FontWeights.Bold : FontWeights.Regular;
+        var style = italic ? FontStyles.Italic : FontStyles.Normal;
+        var tf = new Typeface(_fallbackTypeface.FontFamily, style, weight, FontStretches.Normal);
+
+        var ft = new FormattedText(
+            ch, CultureInfo.InvariantCulture, FlowDirection.LeftToRight,
+            tf, _fontSize, fg, _dpiScale);
+
+        if (dim)
+        {
+            dc.PushOpacity(0.5);
+            dc.DrawText(ft, new Point(x, y));
+            dc.Pop();
+        }
+        else
+        {
+            dc.DrawText(ft, new Point(x, y));
         }
     }
 

--- a/samples/WpfTerm/TerminalControl.cs
+++ b/samples/WpfTerm/TerminalControl.cs
@@ -201,13 +201,13 @@ public class TerminalControl : FrameworkElement
             dc.DrawRectangle(DefaultBackground, null, new Rect(0, 0, ActualWidth, ActualHeight));
 
             // Read directly from the adapter's buffer under lock — no copy needed
-            _adapter.RenderUnderLock((buffer, width, height, cursorX, cursorY, cursorVisible) =>
+            _adapter.RenderUnderLock((buffer, width, height, cursorX, cursorY, cursorVisible, cursorShape) =>
             {
                 // Pass 1: KGP images behind text (ZIndex < 0)
                 RenderKgpImages(dc, placements, width, height, zBehindText: true);
 
                 // Pass 2: Text and cell backgrounds
-                RenderBuffer(dc, buffer, width, height, cursorX, cursorY, cursorVisible);
+                RenderBuffer(dc, buffer, width, height, cursorX, cursorY, cursorVisible, cursorShape);
 
                 // Pass 3: KGP images on top of text (ZIndex >= 0)
                 RenderKgpImages(dc, placements, width, height, zBehindText: false);
@@ -223,7 +223,7 @@ public class TerminalControl : FrameworkElement
     /// Core rendering: scans rows for attribute runs and draws them as batched GlyphRuns.
     /// </summary>
     private void RenderBuffer(DrawingContext dc, TerminalCell[,] buffer, int width, int height,
-        int cursorX, int cursorY, bool cursorVisible)
+        int cursorX, int cursorY, bool cursorVisible, CursorShape cursorShape)
     {
         for (int y = 0; y < height; y++)
         {
@@ -306,7 +306,48 @@ public class TerminalControl : FrameworkElement
         {
             double cx = cursorX * _cellWidth;
             double cy = cursorY * _cellHeight;
-            dc.DrawRectangle(CursorBrush, null, new Rect(cx, cy, 2, _cellHeight));
+
+            // Determine effective shape (Default → BlinkingBlock)
+            var shape = cursorShape == CursorShape.Default ? CursorShape.BlinkingBlock : cursorShape;
+
+            switch (shape)
+            {
+                case CursorShape.BlinkingBlock:
+                case CursorShape.SteadyBlock:
+                    // Full block cursor — draw inverted cell
+                    dc.DrawRectangle(CursorBrush, null, new Rect(cx, cy, _cellWidth, _cellHeight));
+                    // Re-draw the character in inverted color
+                    var blockCell = buffer[cursorY, cursorX];
+                    var ch = blockCell.Character;
+                    if (!string.IsNullOrEmpty(ch) && ch != " " && _regularGlyph != null)
+                    {
+                        var charMap = _regularGlyph.CharacterToGlyphMap;
+                        int codepoint = char.ConvertToUtf32(ch, 0);
+                        if (charMap.TryGetValue(codepoint, out ushort glyphIdx))
+                        {
+#pragma warning disable CS0618
+                            var glyphRun = new GlyphRun(
+                                _regularGlyph, 0, false, _fontSize, (float)_dpiScale,
+                                [glyphIdx], new Point(cx, cy + _baselineY),
+                                [_cellWidth], null, null, null, null, null, null);
+#pragma warning restore CS0618
+                            dc.DrawGlyphRun(DefaultBackground, glyphRun);
+                        }
+                    }
+                    break;
+
+                case CursorShape.BlinkingBar:
+                case CursorShape.SteadyBar:
+                    // Vertical bar cursor (2px wide)
+                    dc.DrawRectangle(CursorBrush, null, new Rect(cx, cy, 2, _cellHeight));
+                    break;
+
+                case CursorShape.BlinkingUnderline:
+                case CursorShape.SteadyUnderline:
+                    // Underline cursor (2px tall at bottom of cell)
+                    dc.DrawRectangle(CursorBrush, null, new Rect(cx, cy + _cellHeight - 2, _cellWidth, 2));
+                    break;
+            }
         }
     }
 

--- a/samples/WpfTerm/WpfTerm.csproj
+++ b/samples/WpfTerm/WpfTerm.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hex1b\Hex1b.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <WindowsPtyShimRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">win-arm64</WindowsPtyShimRid>
+    <WindowsPtyShimRid Condition="'$(WindowsPtyShimRid)' == ''">win-x64</WindowsPtyShimRid>
+  </PropertyGroup>
+
+  <Target Name="CopyWindowsPtyShim"
+          AfterTargets="Build"
+          Condition="$([MSBuild]::IsOSPlatform('Windows')) and Exists('../../src/Hex1b/obj/windows-pty-shim/$(WindowsPtyShimRid)/native/hex1bpty.exe')">
+    <ItemGroup>
+      <WindowsPtyShimFiles Include="../../src/Hex1b/obj/windows-pty-shim/$(WindowsPtyShimRid)/native/*.*"
+                           Exclude="../../src/Hex1b/obj/windows-pty-shim/$(WindowsPtyShimRid)/native/*.pdb" />
+    </ItemGroup>
+    <Copy SourceFiles="@(WindowsPtyShimFiles)"
+          DestinationFolder="$(TargetDir)runtimes\$(WindowsPtyShimRid)\native\"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+</Project>

--- a/samples/WpfTerm/WpfTerminalAdapter.cs
+++ b/samples/WpfTerm/WpfTerminalAdapter.cs
@@ -148,7 +148,11 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
                 // Track mode changes
                 if (applied.Token is PrivateModeToken pm)
                 {
-                    if (pm.Mode == 25) _cursorVisible = pm.Enable;
+                    if (pm.Mode == 25)
+                    {
+                        _cursorVisible = pm.Enable;
+                        hasChanges = true;
+                    }
                     // Mouse tracking modes
                     if (pm.Mode is 1000 or 1002 or 1003) _mouseTrackingEnabled = pm.Enable;
                     if (pm.Mode == 1006) _sgrMouseModeEnabled = pm.Enable;
@@ -167,6 +171,7 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
                         6 => CursorShape.SteadyBar,
                         _ => CursorShape.Default
                     };
+                    hasChanges = true;
                 }
 
                 // KGP tokens modify placements outside the cell buffer — still need a re-render
@@ -185,9 +190,15 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
                     }
                 }
 
-                // Update cursor from last token
-                _cursorX = Math.Clamp(applied.CursorXAfter, 0, Math.Max(0, _width - 1));
-                _cursorY = Math.Clamp(applied.CursorYAfter, 0, Math.Max(0, _height - 1));
+                // Track cursor position — trigger re-render if cursor moved
+                int newCursorX = Math.Clamp(applied.CursorXAfter, 0, Math.Max(0, _width - 1));
+                int newCursorY = Math.Clamp(applied.CursorYAfter, 0, Math.Max(0, _height - 1));
+                if (newCursorX != _cursorX || newCursorY != _cursorY)
+                {
+                    _cursorX = newCursorX;
+                    _cursorY = newCursorY;
+                    hasChanges = true;
+                }
             }
         }
 

--- a/samples/WpfTerm/WpfTerminalAdapter.cs
+++ b/samples/WpfTerm/WpfTerminalAdapter.cs
@@ -75,6 +75,18 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IA
     }
 
     /// <summary>
+    /// Allows the renderer to read the buffer directly under lock — zero-copy path.
+    /// The callback must not capture or store the buffer reference.
+    /// </summary>
+    public void RenderUnderLock(Action<TerminalCell[,], int, int, int, int, bool> renderCallback)
+    {
+        lock (_bufferLock)
+        {
+            renderCallback(_screenBuffer, _width, _height, _cursorX, _cursorY, _cursorVisible);
+        }
+    }
+
+    /// <summary>
     /// Enqueues raw ANSI input bytes to be sent to the PTY process.
     /// Called by the WPF keyboard handler.
     /// </summary>

--- a/samples/WpfTerm/WpfTerminalAdapter.cs
+++ b/samples/WpfTerm/WpfTerminalAdapter.cs
@@ -27,6 +27,7 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
     private bool _sgrMouseModeEnabled;
     private bool _disposed;
     private Hex1bTerminal? _terminal;
+    private int _kgpTokensReceived;
 
     public WpfTerminalAdapter(int width = 120, int height = 30)
     {
@@ -42,6 +43,11 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
     public int CursorY => _cursorY;
     public bool CursorVisible => _cursorVisible;
     public CursorShape CursorShape => _cursorShape;
+
+    /// <summary>
+    /// Diagnostic: number of KGP tokens received from the terminal.
+    /// </summary>
+    public int KgpTokensReceived => _kgpTokensReceived;
 
     /// <summary>
     /// Whether the child process has enabled mouse tracking (modes 1000/1002/1003).
@@ -177,6 +183,7 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
                 // KGP tokens modify placements outside the cell buffer — still need a re-render
                 if (applied.Token is KgpToken)
                 {
+                    _kgpTokensReceived++;
                     hasChanges = true;
                 }
 

--- a/samples/WpfTerm/WpfTerminalAdapter.cs
+++ b/samples/WpfTerm/WpfTerminalAdapter.cs
@@ -51,6 +51,7 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
         SupportsMouse = true,
         Supports256Colors = true,
         SupportsTrueColor = true,
+        SupportsKgp = true,
     };
 
     public event Action<int, int>? Resized;
@@ -149,6 +150,12 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
                     // Mouse tracking modes
                     if (pm.Mode is 1000 or 1002 or 1003) _mouseTrackingEnabled = pm.Enable;
                     if (pm.Mode == 1006) _sgrMouseModeEnabled = pm.Enable;
+                }
+
+                // KGP tokens modify placements outside the cell buffer — still need a re-render
+                if (applied.Token is KgpToken)
+                {
+                    hasChanges = true;
                 }
 
                 // Apply cell impacts

--- a/samples/WpfTerm/WpfTerminalAdapter.cs
+++ b/samples/WpfTerm/WpfTerminalAdapter.cs
@@ -1,0 +1,208 @@
+using System.Threading.Channels;
+using Hex1b;
+using Hex1b.Tokens;
+
+namespace WpfTerm;
+
+/// <summary>
+/// Bridges Hex1b's terminal engine to a WPF rendering surface.
+/// Receives pre-parsed cell impacts (no ANSI parsing needed) and
+/// exposes the screen buffer for the WPF control to render from.
+/// </summary>
+public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IAsyncDisposable
+{
+    private readonly object _bufferLock = new();
+    private readonly TaskCompletionSource _disconnected = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly Channel<byte[]> _inputChannel = Channel.CreateUnbounded<byte[]>(
+        new UnboundedChannelOptions { SingleReader = true });
+
+    private TerminalCell[,] _screenBuffer;
+    private int _width;
+    private int _height;
+    private int _cursorX;
+    private int _cursorY;
+    private bool _cursorVisible = true;
+    private bool _disposed;
+
+    public WpfTerminalAdapter(int width = 120, int height = 30)
+    {
+        _width = width;
+        _height = height;
+        _screenBuffer = new TerminalCell[height, width];
+        ClearBuffer();
+    }
+
+    public int Width => _width;
+    public int Height => _height;
+    public int CursorX => _cursorX;
+    public int CursorY => _cursorY;
+    public bool CursorVisible => _cursorVisible;
+
+    public TerminalCapabilities Capabilities { get; } = new()
+    {
+        SupportsMouse = false,
+        Supports256Colors = true,
+        SupportsTrueColor = true,
+    };
+
+    public event Action<int, int>? Resized;
+    public event Action? Disconnected;
+
+    /// <summary>
+    /// Raised when the screen buffer has been updated with new output.
+    /// The WPF control subscribes to this to trigger re-renders.
+    /// </summary>
+    public event Action? OutputReceived;
+
+    /// <summary>
+    /// Gets a snapshot of the current screen buffer for rendering.
+    /// </summary>
+    public (TerminalCell[,] Buffer, int Width, int Height, int CursorX, int CursorY, bool CursorVisible) GetSnapshot()
+    {
+        lock (_bufferLock)
+        {
+            var copy = new TerminalCell[_height, _width];
+            Array.Copy(_screenBuffer, copy, _screenBuffer.Length);
+            return (copy, _width, _height, _cursorX, _cursorY, _cursorVisible);
+        }
+    }
+
+    /// <summary>
+    /// Enqueues raw ANSI input bytes to be sent to the PTY process.
+    /// Called by the WPF keyboard handler.
+    /// </summary>
+    public void EnqueueInput(byte[] data)
+    {
+        if (!_disposed)
+        {
+            _inputChannel.Writer.TryWrite(data);
+        }
+    }
+
+    /// <summary>
+    /// Triggers a resize of the terminal dimensions.
+    /// Call this when the WPF control changes size.
+    /// </summary>
+    public void TriggerResize(int newWidth, int newHeight)
+    {
+        if (newWidth <= 0 || newHeight <= 0) return;
+        if (newWidth == _width && newHeight == _height) return;
+
+        lock (_bufferLock)
+        {
+            var newBuffer = new TerminalCell[newHeight, newWidth];
+            for (int y = 0; y < newHeight; y++)
+                for (int x = 0; x < newWidth; x++)
+                    newBuffer[y, x] = TerminalCell.Empty;
+
+            // Copy existing content
+            int copyRows = Math.Min(_height, newHeight);
+            int copyCols = Math.Min(_width, newWidth);
+            for (int y = 0; y < copyRows; y++)
+                for (int x = 0; x < copyCols; x++)
+                    newBuffer[y, x] = _screenBuffer[y, x];
+
+            _screenBuffer = newBuffer;
+            _width = newWidth;
+            _height = newHeight;
+        }
+
+        Resized?.Invoke(newWidth, newHeight);
+    }
+
+    // === ICellImpactAwarePresentationAdapter ===
+
+    public ValueTask WriteOutputWithImpactsAsync(IReadOnlyList<AppliedToken> appliedTokens, CancellationToken ct = default)
+    {
+        if (_disposed || appliedTokens.Count == 0)
+            return ValueTask.CompletedTask;
+
+        bool hasChanges = false;
+        lock (_bufferLock)
+        {
+            foreach (var applied in appliedTokens)
+            {
+                // Track mode changes
+                if (applied.Token is PrivateModeToken pm)
+                {
+                    if (pm.Mode == 25) _cursorVisible = pm.Enable;
+                }
+
+                // Apply cell impacts
+                foreach (var impact in applied.CellImpacts)
+                {
+                    if (impact.X >= 0 && impact.X < _width && impact.Y >= 0 && impact.Y < _height)
+                    {
+                        _screenBuffer[impact.Y, impact.X] = impact.Cell;
+                        hasChanges = true;
+                    }
+                }
+
+                // Update cursor from last token
+                _cursorX = Math.Clamp(applied.CursorXAfter, 0, Math.Max(0, _width - 1));
+                _cursorY = Math.Clamp(applied.CursorYAfter, 0, Math.Max(0, _height - 1));
+            }
+        }
+
+        if (hasChanges)
+        {
+            OutputReceived?.Invoke();
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    // === IHex1bTerminalPresentationAdapter ===
+
+    public ValueTask WriteOutputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+    {
+        // Fallback path — should not be called since we implement ICellImpactAwarePresentationAdapter
+        if (!_disposed && !data.IsEmpty)
+            OutputReceived?.Invoke();
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask<ReadOnlyMemory<byte>> ReadInputAsync(CancellationToken ct = default)
+    {
+        if (_disposed)
+            return ReadOnlyMemory<byte>.Empty;
+
+        try
+        {
+            var data = await _inputChannel.Reader.ReadAsync(ct);
+            return data;
+        }
+        catch (OperationCanceledException)
+        {
+            return ReadOnlyMemory<byte>.Empty;
+        }
+        catch (ChannelClosedException)
+        {
+            return ReadOnlyMemory<byte>.Empty;
+        }
+    }
+
+    public ValueTask FlushAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
+    public ValueTask EnterRawModeAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
+    public ValueTask ExitRawModeAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
+    public (int Row, int Column) GetCursorPosition() => (_cursorY, _cursorX);
+
+    public ValueTask DisposeAsync()
+    {
+        if (_disposed) return ValueTask.CompletedTask;
+        _disposed = true;
+
+        _inputChannel.Writer.TryComplete();
+        Disconnected?.Invoke();
+        _disconnected.TrySetResult();
+
+        return ValueTask.CompletedTask;
+    }
+
+    private void ClearBuffer()
+    {
+        for (int y = 0; y < _height; y++)
+            for (int x = 0; x < _width; x++)
+                _screenBuffer[y, x] = TerminalCell.Empty;
+    }
+}

--- a/samples/WpfTerm/WpfTerminalAdapter.cs
+++ b/samples/WpfTerm/WpfTerminalAdapter.cs
@@ -22,6 +22,7 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
     private int _cursorX;
     private int _cursorY;
     private bool _cursorVisible = true;
+    private CursorShape _cursorShape = CursorShape.Default;
     private bool _mouseTrackingEnabled;
     private bool _sgrMouseModeEnabled;
     private bool _disposed;
@@ -40,6 +41,7 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
     public int CursorX => _cursorX;
     public int CursorY => _cursorY;
     public bool CursorVisible => _cursorVisible;
+    public CursorShape CursorShape => _cursorShape;
 
     /// <summary>
     /// Whether the child process has enabled mouse tracking (modes 1000/1002/1003).
@@ -80,11 +82,11 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
     /// Allows the renderer to read the buffer directly under lock — zero-copy path.
     /// The callback must not capture or store the buffer reference.
     /// </summary>
-    public void RenderUnderLock(Action<TerminalCell[,], int, int, int, int, bool> renderCallback)
+    public void RenderUnderLock(Action<TerminalCell[,], int, int, int, int, bool, CursorShape> renderCallback)
     {
         lock (_bufferLock)
         {
-            renderCallback(_screenBuffer, _width, _height, _cursorX, _cursorY, _cursorVisible);
+            renderCallback(_screenBuffer, _width, _height, _cursorX, _cursorY, _cursorVisible, _cursorShape);
         }
     }
 
@@ -150,6 +152,21 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
                     // Mouse tracking modes
                     if (pm.Mode is 1000 or 1002 or 1003) _mouseTrackingEnabled = pm.Enable;
                     if (pm.Mode == 1006) _sgrMouseModeEnabled = pm.Enable;
+                }
+
+                // Track cursor shape changes
+                if (applied.Token is CursorShapeToken cst)
+                {
+                    _cursorShape = cst.Shape switch
+                    {
+                        1 => CursorShape.BlinkingBlock,
+                        2 => CursorShape.SteadyBlock,
+                        3 => CursorShape.BlinkingUnderline,
+                        4 => CursorShape.SteadyUnderline,
+                        5 => CursorShape.BlinkingBar,
+                        6 => CursorShape.SteadyBar,
+                        _ => CursorShape.Default
+                    };
                 }
 
                 // KGP tokens modify placements outside the cell buffer — still need a re-render

--- a/samples/WpfTerm/WpfTerminalAdapter.cs
+++ b/samples/WpfTerm/WpfTerminalAdapter.cs
@@ -15,6 +15,8 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
     private readonly TaskCompletionSource _disconnected = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly Channel<byte[]> _inputChannel = Channel.CreateUnbounded<byte[]>(
         new UnboundedChannelOptions { SingleReader = true });
+    private readonly Channel<byte[]> _mouseInputChannel = Channel.CreateUnbounded<byte[]>(
+        new UnboundedChannelOptions { SingleReader = true });
 
     private TerminalCell[,] _screenBuffer;
     private int _width;
@@ -121,9 +123,16 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
     {
         if (!_disposed)
         {
-            _inputChannel.Writer.TryWrite(data);
-            if (isMouse) Interlocked.Increment(ref _mouseInputCount);
-            else Interlocked.Increment(ref _keyInputCount);
+            if (isMouse)
+            {
+                _mouseInputChannel.Writer.TryWrite(data);
+                Interlocked.Increment(ref _mouseInputCount);
+            }
+            else
+            {
+                _inputChannel.Writer.TryWrite(data);
+                Interlocked.Increment(ref _keyInputCount);
+            }
         }
     }
 
@@ -264,8 +273,25 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
 
         try
         {
-            var data = await _inputChannel.Reader.ReadAsync(ct);
-            return data;
+            while (!ct.IsCancellationRequested)
+            {
+                // Always prioritize keyboard input over mouse
+                if (_inputChannel.Reader.TryRead(out var keyData))
+                    return keyData;
+
+                // No keyboard pending — check mouse
+                if (_mouseInputChannel.Reader.TryRead(out var mouseData))
+                    return mouseData;
+
+                // Nothing available — wait for either channel
+                var keyTask = _inputChannel.Reader.WaitToReadAsync(ct).AsTask();
+                var mouseTask = _mouseInputChannel.Reader.WaitToReadAsync(ct).AsTask();
+                await Task.WhenAny(keyTask, mouseTask);
+                
+                // Loop back to drain keyboard first
+            }
+
+            return ReadOnlyMemory<byte>.Empty;
         }
         catch (OperationCanceledException)
         {
@@ -311,6 +337,7 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
         _disposed = true;
 
         _inputChannel.Writer.TryComplete();
+        _mouseInputChannel.Writer.TryComplete();
         Disconnected?.Invoke();
         _disconnected.TrySetResult();
 

--- a/samples/WpfTerm/WpfTerminalAdapter.cs
+++ b/samples/WpfTerm/WpfTerminalAdapter.cs
@@ -24,6 +24,7 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
     private bool _cursorVisible = true;
     private CursorShape _cursorShape = CursorShape.Default;
     private bool _mouseTrackingEnabled;
+    private bool _mouseMotionEnabled; // Mode 1003: report all motion, not just drag
     private bool _sgrMouseModeEnabled;
     private bool _disposed;
     private Hex1bTerminal? _terminal;
@@ -60,6 +61,12 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
     /// Whether the child process has enabled mouse tracking (modes 1000/1002/1003).
     /// </summary>
     public bool MouseTrackingEnabled => _mouseTrackingEnabled;
+
+    /// <summary>
+    /// Whether the child process wants all mouse motion events (mode 1003),
+    /// not just drag events (mode 1002) or clicks only (mode 1000).
+    /// </summary>
+    public bool MouseMotionEnabled => _mouseMotionEnabled;
 
     public TerminalCapabilities Capabilities { get; } = new()
     {
@@ -171,7 +178,11 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
                         hasChanges = true;
                     }
                     // Mouse tracking modes
-                    if (pm.Mode is 1000 or 1002 or 1003) _mouseTrackingEnabled = pm.Enable;
+                    if (pm.Mode is 1000 or 1002 or 1003)
+                    {
+                        _mouseTrackingEnabled = pm.Enable;
+                        _mouseMotionEnabled = pm.Enable && pm.Mode == 1003;
+                    }
                     if (pm.Mode == 1006) _sgrMouseModeEnabled = pm.Enable;
                 }
 

--- a/samples/WpfTerm/WpfTerminalAdapter.cs
+++ b/samples/WpfTerm/WpfTerminalAdapter.cs
@@ -1,5 +1,6 @@
 using System.Threading.Channels;
 using Hex1b;
+using Hex1b.Reflow;
 using Hex1b.Tokens;
 
 namespace WpfTerm;
@@ -9,7 +10,7 @@ namespace WpfTerm;
 /// Receives pre-parsed cell impacts (no ANSI parsing needed) and
 /// exposes the screen buffer for the WPF control to render from.
 /// </summary>
-public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, ITerminalLifecycleAwarePresentationAdapter, IAsyncDisposable
+public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, ITerminalLifecycleAwarePresentationAdapter, ITerminalReflowProvider, IAsyncDisposable
 {
     private readonly object _bufferLock = new();
     private readonly TaskCompletionSource _disconnected = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -292,6 +293,25 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
     void ITerminalLifecycleAwarePresentationAdapter.TerminalStarted() { }
 
     void ITerminalLifecycleAwarePresentationAdapter.TerminalCompleted(int exitCode) { }
+
+    // === ITerminalReflowProvider ===
+
+    private ITerminalReflowProvider _reflowStrategy = GhosttyReflowStrategy.Instance;
+
+    public bool ReflowEnabled => true;
+
+    public bool ShouldClearSoftWrapOnAbsolutePosition => _reflowStrategy.ShouldClearSoftWrapOnAbsolutePosition;
+
+    public ReflowResult Reflow(ReflowContext context) => _reflowStrategy.Reflow(context);
+
+    /// <summary>
+    /// Configures the reflow strategy. Defaults to Ghostty-style reflow.
+    /// </summary>
+    public WpfTerminalAdapter WithReflow(ITerminalReflowProvider strategy)
+    {
+        _reflowStrategy = strategy ?? throw new ArgumentNullException(nameof(strategy));
+        return this;
+    }
 
     /// <summary>
     /// Gets the active KGP placements from the terminal, or empty if not available.

--- a/samples/WpfTerm/WpfTerminalAdapter.cs
+++ b/samples/WpfTerm/WpfTerminalAdapter.cs
@@ -9,7 +9,7 @@ namespace WpfTerm;
 /// Receives pre-parsed cell impacts (no ANSI parsing needed) and
 /// exposes the screen buffer for the WPF control to render from.
 /// </summary>
-public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IAsyncDisposable
+public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, ITerminalLifecycleAwarePresentationAdapter, IAsyncDisposable
 {
     private readonly object _bufferLock = new();
     private readonly TaskCompletionSource _disconnected = new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -25,6 +25,7 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IA
     private bool _mouseTrackingEnabled;
     private bool _sgrMouseModeEnabled;
     private bool _disposed;
+    private Hex1bTerminal? _terminal;
 
     public WpfTerminalAdapter(int width = 120, int height = 30)
     {
@@ -208,6 +209,29 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IA
     public ValueTask EnterRawModeAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
     public ValueTask ExitRawModeAsync(CancellationToken ct = default) => ValueTask.CompletedTask;
     public (int Row, int Column) GetCursorPosition() => (_cursorY, _cursorX);
+
+    // === ITerminalLifecycleAwarePresentationAdapter ===
+
+    void ITerminalLifecycleAwarePresentationAdapter.TerminalCreated(Hex1bTerminal terminal)
+    {
+        _terminal = terminal;
+    }
+
+    void ITerminalLifecycleAwarePresentationAdapter.TerminalStarted() { }
+
+    void ITerminalLifecycleAwarePresentationAdapter.TerminalCompleted(int exitCode) { }
+
+    /// <summary>
+    /// Gets the active KGP placements from the terminal, or empty if not available.
+    /// </summary>
+    public IReadOnlyList<KgpPlacement> GetKgpPlacements()
+        => _terminal?.KgpPlacements ?? [];
+
+    /// <summary>
+    /// Gets KGP image data by image ID from the terminal's image store.
+    /// </summary>
+    public KgpImageData? GetKgpImage(uint imageId)
+        => _terminal?.KgpImageStore.GetImageById(imageId);
 
     public ValueTask DisposeAsync()
     {

--- a/samples/WpfTerm/WpfTerminalAdapter.cs
+++ b/samples/WpfTerm/WpfTerminalAdapter.cs
@@ -22,6 +22,8 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IA
     private int _cursorX;
     private int _cursorY;
     private bool _cursorVisible = true;
+    private bool _mouseTrackingEnabled;
+    private bool _sgrMouseModeEnabled;
     private bool _disposed;
 
     public WpfTerminalAdapter(int width = 120, int height = 30)
@@ -38,9 +40,14 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IA
     public int CursorY => _cursorY;
     public bool CursorVisible => _cursorVisible;
 
+    /// <summary>
+    /// Whether the child process has enabled mouse tracking (modes 1000/1002/1003).
+    /// </summary>
+    public bool MouseTrackingEnabled => _mouseTrackingEnabled;
+
     public TerminalCapabilities Capabilities { get; } = new()
     {
-        SupportsMouse = false,
+        SupportsMouse = true,
         Supports256Colors = true,
         SupportsTrueColor = true,
     };
@@ -126,6 +133,9 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IA
                 if (applied.Token is PrivateModeToken pm)
                 {
                     if (pm.Mode == 25) _cursorVisible = pm.Enable;
+                    // Mouse tracking modes
+                    if (pm.Mode is 1000 or 1002 or 1003) _mouseTrackingEnabled = pm.Enable;
+                    if (pm.Mode == 1006) _sgrMouseModeEnabled = pm.Enable;
                 }
 
                 // Apply cell impacts

--- a/samples/WpfTerm/WpfTerminalAdapter.cs
+++ b/samples/WpfTerm/WpfTerminalAdapter.cs
@@ -15,8 +15,6 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
     private readonly TaskCompletionSource _disconnected = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly Channel<byte[]> _inputChannel = Channel.CreateUnbounded<byte[]>(
         new UnboundedChannelOptions { SingleReader = true });
-    private readonly Channel<byte[]> _mouseInputChannel = Channel.CreateUnbounded<byte[]>(
-        new UnboundedChannelOptions { SingleReader = true });
 
     private TerminalCell[,] _screenBuffer;
     private int _width;
@@ -123,16 +121,9 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
     {
         if (!_disposed)
         {
-            if (isMouse)
-            {
-                _mouseInputChannel.Writer.TryWrite(data);
-                Interlocked.Increment(ref _mouseInputCount);
-            }
-            else
-            {
-                _inputChannel.Writer.TryWrite(data);
-                Interlocked.Increment(ref _keyInputCount);
-            }
+            _inputChannel.Writer.TryWrite(data);
+            if (isMouse) Interlocked.Increment(ref _mouseInputCount);
+            else Interlocked.Increment(ref _keyInputCount);
         }
     }
 
@@ -273,25 +264,8 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
 
         try
         {
-            while (!ct.IsCancellationRequested)
-            {
-                // Always prioritize keyboard input over mouse
-                if (_inputChannel.Reader.TryRead(out var keyData))
-                    return keyData;
-
-                // No keyboard pending — check mouse
-                if (_mouseInputChannel.Reader.TryRead(out var mouseData))
-                    return mouseData;
-
-                // Nothing available — wait for either channel
-                var keyTask = _inputChannel.Reader.WaitToReadAsync(ct).AsTask();
-                var mouseTask = _mouseInputChannel.Reader.WaitToReadAsync(ct).AsTask();
-                await Task.WhenAny(keyTask, mouseTask);
-                
-                // Loop back to drain keyboard first
-            }
-
-            return ReadOnlyMemory<byte>.Empty;
+            var data = await _inputChannel.Reader.ReadAsync(ct);
+            return data;
         }
         catch (OperationCanceledException)
         {
@@ -337,7 +311,6 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
         _disposed = true;
 
         _inputChannel.Writer.TryComplete();
-        _mouseInputChannel.Writer.TryComplete();
         Disconnected?.Invoke();
         _disconnected.TrySetResult();
 

--- a/samples/WpfTerm/WpfTerminalAdapter.cs
+++ b/samples/WpfTerm/WpfTerminalAdapter.cs
@@ -296,22 +296,15 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
 
     // === ITerminalReflowProvider ===
 
-    private ITerminalReflowProvider _reflowStrategy = GhosttyReflowStrategy.Instance;
+    // Disable reflow — ConPTY handles reflow internally when ResizePseudoConsole
+    // is called. It re-renders the console buffer at the new width and sends us
+    // the full repaint. Our terminal just needs to accept the new content.
+    // If we also try to reflow, the two fight and produce incorrect output.
+    public bool ReflowEnabled => false;
 
-    public bool ReflowEnabled => true;
+    public bool ShouldClearSoftWrapOnAbsolutePosition => false;
 
-    public bool ShouldClearSoftWrapOnAbsolutePosition => _reflowStrategy.ShouldClearSoftWrapOnAbsolutePosition;
-
-    public ReflowResult Reflow(ReflowContext context) => _reflowStrategy.Reflow(context);
-
-    /// <summary>
-    /// Configures the reflow strategy. Defaults to Ghostty-style reflow.
-    /// </summary>
-    public WpfTerminalAdapter WithReflow(ITerminalReflowProvider strategy)
-    {
-        _reflowStrategy = strategy ?? throw new ArgumentNullException(nameof(strategy));
-        return this;
-    }
+    public ReflowResult Reflow(ReflowContext context) => GhosttyReflowStrategy.Instance.Reflow(context);
 
     /// <summary>
     /// Gets the active KGP placements from the terminal, or empty if not available.

--- a/samples/WpfTerm/WpfTerminalAdapter.cs
+++ b/samples/WpfTerm/WpfTerminalAdapter.cs
@@ -28,6 +28,8 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
     private bool _disposed;
     private Hex1bTerminal? _terminal;
     private int _kgpTokensReceived;
+    private int _totalTokensReceived;
+    private int _unrecognizedTokensReceived;
 
     public WpfTerminalAdapter(int width = 120, int height = 30)
     {
@@ -48,6 +50,11 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
     /// Diagnostic: number of KGP tokens received from the terminal.
     /// </summary>
     public int KgpTokensReceived => _kgpTokensReceived;
+    
+    /// <summary>
+    /// Diagnostic: total tokens and unrecognized tokens received.
+    /// </summary>
+    public (int Total, int Unrecognized) TokenStats => (_totalTokensReceived, _unrecognizedTokensReceived);
 
     /// <summary>
     /// Whether the child process has enabled mouse tracking (modes 1000/1002/1003).
@@ -151,6 +158,10 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
         {
             foreach (var applied in appliedTokens)
             {
+                _totalTokensReceived++;
+                
+                if (applied.Token is UnrecognizedSequenceToken)
+                    _unrecognizedTokensReceived++;
                 // Track mode changes
                 if (applied.Token is PrivateModeToken pm)
                 {

--- a/samples/WpfTerm/WpfTerminalAdapter.cs
+++ b/samples/WpfTerm/WpfTerminalAdapter.cs
@@ -110,17 +110,25 @@ public sealed class WpfTerminalAdapter : ICellImpactAwarePresentationAdapter, IT
         }
     }
 
+    private int _keyInputCount;
+    private int _mouseInputCount;
+
     /// <summary>
     /// Enqueues raw ANSI input bytes to be sent to the PTY process.
     /// Called by the WPF keyboard handler.
     /// </summary>
-    public void EnqueueInput(byte[] data)
+    public void EnqueueInput(byte[] data, bool isMouse = false)
     {
         if (!_disposed)
         {
             _inputChannel.Writer.TryWrite(data);
+            if (isMouse) Interlocked.Increment(ref _mouseInputCount);
+            else Interlocked.Increment(ref _keyInputCount);
         }
     }
+
+    /// <summary>Diagnostic counters for input events.</summary>
+    public (int Keys, int Mouse) InputStats => (_keyInputCount, _mouseInputCount);
 
     /// <summary>
     /// Triggers a resize of the terminal dimensions.

--- a/src/Hex1b/ConsolePresentationAdapter.cs
+++ b/src/Hex1b/ConsolePresentationAdapter.cs
@@ -249,8 +249,16 @@ public sealed class ConsolePresentationAdapter : IHex1bTerminalPresentationAdapt
 
         // Windows uses console input records rather than a raw stdin byte stream, so
         // KGP APC replies are not currently probeable through the built-in console driver.
+        // However, if a parent Hex1b terminal has advertised KGP support via environment
+        // variable, trust that and enable KGP without probing.
         if (_driver is WindowsConsoleDriver)
+        {
+            if (Environment.GetEnvironmentVariable("HEX1B_TERMINAL_KGP") == "1")
+            {
+                _capabilities = _capabilities with { SupportsKgp = true };
+            }
             return;
+        }
 
         _driver.Write(KgpProbeQuery);
         _driver.Flush();

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -6157,14 +6157,14 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
     // ---- KGP (Kitty Graphics Protocol) ----
 
     /// <summary>
-    /// Gets the KGP image store for testing and inspection.
+    /// Gets the KGP image store for accessing transmitted image data.
     /// </summary>
-    internal KgpImageStore KgpImageStore => _kgpImageStore;
+    public KgpImageStore KgpImageStore => _kgpImageStore;
 
     /// <summary>
-    /// Gets the active KGP placements for testing and inspection.
+    /// Gets a snapshot of the active KGP placements.
     /// </summary>
-    internal IReadOnlyList<KgpPlacement> KgpPlacements
+    public IReadOnlyList<KgpPlacement> KgpPlacements
     {
         get { lock (_bufferLock) return _kgpPlacements.ToList(); }
     }

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -667,6 +667,7 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
                 var decodedText = new string(chars);
 
                 var text = _incompleteInputSequenceBuffer + decodedText;
+                var hadBufferedInput = _incompleteInputSequenceBuffer.Length > 0;
                 _incompleteInputSequenceBuffer = "";
 
                 var extracted = ExtractIncompleteEscapeSequence(text);
@@ -675,7 +676,12 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
 
                 if (!string.IsNullOrEmpty(completeText))
                 {
-                    await DispatchCompleteInputTextAsync(completeText, data, ct);
+                    // When incomplete buffer was prepended, rawData doesn't contain the
+                    // buffered bytes — re-encode from completeText to avoid losing them.
+                    var effectiveRawData = hadBufferedInput
+                        ? (ReadOnlyMemory<byte>)Encoding.UTF8.GetBytes(completeText)
+                        : data;
+                    await DispatchCompleteInputTextAsync(completeText, effectiveRawData, ct);
                 }
 
                 // If there is an incomplete escape sequence and the timeout is enabled,

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -63,6 +63,7 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
     private readonly TimeProvider _timeProvider;
     private readonly KgpImageStore _kgpImageStore = new();
     private readonly List<KgpPlacement> _kgpPlacements = new();
+    private Kgp.KgpPipeServer? _kgpPipeServer;
     
     // Lock to protect screen buffer state from concurrent access.
     // The resize event comes from the input thread while the output pump
@@ -254,6 +255,17 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
         _presentationFilters = options.PresentationFilters?.ToList() ?? [];
         _timeProvider = options.TimeProvider ?? TimeProvider.System;
         _sessionStart = _timeProvider.GetUtcNow();
+        
+        // Auto-install KGP pipe filter if parent advertised a side-channel pipe.
+        // This diverts KGP APC sequences from stdout to the pipe, bypassing ConPTY.
+        if (OperatingSystem.IsWindows())
+        {
+            var kgpPipeFilter = Kgp.KgpPipePresentationFilter.TryCreate();
+            if (kgpPipeFilter != null)
+            {
+                _presentationFilters = [kgpPipeFilter, .. _presentationFilters];
+            }
+        }
         
         // Notify lifecycle-aware presentation adapters that the terminal is created
         if (presentation is ITerminalLifecycleAwarePresentationAdapter lifecycleAdapter)
@@ -6170,8 +6182,49 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
+    /// Gets the KGP side-channel pipe name, or null if not active.
+    /// Child processes should send KGP APC sequences to this pipe
+    /// when ConPTY would strip them from stdout.
+    /// </summary>
+    public string? KgpPipeName => _kgpPipeServer?.PipeName;
+
+    /// <summary>
+    /// Ensures the KGP side-channel pipe server is running.
+    /// Called during terminal setup when KGP is supported.
+    /// </summary>
+    internal void EnsureKgpPipeServer()
+    {
+        if (_kgpPipeServer != null) return;
+        if (!Capabilities.SupportsKgp) return;
+
+        _kgpPipeServer = new Kgp.KgpPipeServer();
+        _kgpPipeServer.SetTokenHandler(ProcessKgpFromSideChannel);
+        _kgpPipeServer.Start();
+    }
+
+    /// <summary>
     /// Processes a KGP (Kitty Graphics Protocol) command.
     /// </summary>
+    /// <summary>
+    /// Processes a KGP token received via the side-channel pipe (bypassing ConPTY).
+    /// Called from <see cref="Kgp.KgpPipeServer"/> when child processes send KGP
+    /// data over the named pipe because ConPTY strips APC sequences.
+    /// </summary>
+    public void ProcessKgpFromSideChannel(KgpToken token)
+    {
+        lock (_bufferLock)
+        {
+            ProcessKgpCommand(token);
+        }
+
+        // Notify the presentation adapter that KGP data changed
+        if (_presentation is ICellImpactAwarePresentationAdapter impactAware)
+        {
+            var applied = AppliedToken.WithNoCellImpacts(token, _cursorX, _cursorY, _cursorX, _cursorY);
+            _ = impactAware.WriteOutputWithImpactsAsync([applied]);
+        }
+    }
+
     private void ProcessKgpCommand(KgpToken token)
     {
         if (!Capabilities.SupportsKgp)

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -6206,21 +6206,31 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
     /// Processes a KGP (Kitty Graphics Protocol) command.
     /// </summary>
     /// <summary>
-    /// Processes a KGP token received via the side-channel pipe (bypassing ConPTY).
-    /// Called from <see cref="Kgp.KgpPipeServer"/> when child processes send KGP
-    /// data over the named pipe because ConPTY strips APC sequences.
+    /// Processes a token received via the side-channel pipe (bypassing ConPTY).
+    /// Handles CursorPositionToken (sets cursor for placement) and KgpToken (image data).
     /// </summary>
-    public void ProcessKgpFromSideChannel(KgpToken token)
+    public void ProcessKgpFromSideChannel(AnsiToken token)
     {
         lock (_bufferLock)
         {
-            ProcessKgpCommand(token);
+            if (token is CursorPositionToken cup)
+            {
+                // Set cursor position for the next KGP placement (1-based → 0-based)
+                _cursorY = Math.Clamp(cup.Row - 1, 0, _height - 1);
+                _cursorX = Math.Clamp(cup.Column - 1, 0, _width - 1);
+                return;
+            }
+
+            if (token is KgpToken kgpToken)
+            {
+                ProcessKgpCommand(kgpToken);
+            }
         }
 
         // Notify the presentation adapter that KGP data changed
-        if (_presentation is ICellImpactAwarePresentationAdapter impactAware)
+        if (token is KgpToken kgp && _presentation is ICellImpactAwarePresentationAdapter impactAware)
         {
-            var applied = AppliedToken.WithNoCellImpacts(token, _cursorX, _cursorY, _cursorX, _cursorY);
+            var applied = AppliedToken.WithNoCellImpacts(kgp, _cursorX, _cursorY, _cursorX, _cursorY);
             _ = impactAware.WriteOutputWithImpactsAsync([applied]);
         }
     }

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -4102,6 +4102,9 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
     {
         _inAlternateScreen = false;
         
+        // Clear KGP placements — they belong to the alternate screen session
+        _kgpPlacements.Clear();
+        
         // Only restore if we actually saved state when entering alternate screen
         // If _savedMainScreenBuffer is null, this is an unbalanced exit - do nothing
         if (_savedMainScreenBuffer != null)

--- a/src/Hex1b/Hex1bTerminalBuilder.cs
+++ b/src/Hex1b/Hex1bTerminalBuilder.cs
@@ -399,6 +399,12 @@ public sealed class Hex1bTerminalBuilder
             var width = presentation?.Width ?? _width;
             var height = presentation?.Height ?? _height;
 
+            // Configure custom conpty.dll if specified
+            if (!string.IsNullOrEmpty(options.ConptyDllPath))
+            {
+                WindowsPtyHandle.ConptyDllPath = options.ConptyDllPath;
+            }
+
             var process = new Hex1bTerminalChildProcess(
                 options.FileName,
                 options.Arguments?.ToArray() ?? [],
@@ -1420,4 +1426,11 @@ public sealed class Hex1bTerminalProcessOptions
     /// When null, Hex1b searches the application output and packaged runtime locations automatically.
     /// </remarks>
     public string? WindowsPtyHostPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path to a custom conpty.dll (e.g. from microsoft/terminal).
+    /// When set, Hex1b loads this DLL instead of using the OS kernel32.dll ConPTY,
+    /// enabling full VT passthrough for protocols like KGP.
+    /// </summary>
+    public string? ConptyDllPath { get; set; }
 }

--- a/src/Hex1b/Hex1bTerminalChildProcess.cs
+++ b/src/Hex1b/Hex1bTerminalChildProcess.cs
@@ -343,6 +343,11 @@ public sealed class Hex1bTerminalChildProcess : IHex1bTerminalWorkloadAdapter
         }
         env[nestingLevelKey] = nestingLevel.ToString();
         
+        // Advertise terminal capabilities to child processes so they can skip
+        // probing (which doesn't work on Windows via ReadConsoleInput).
+        // Hex1b terminals always support KGP parsing in the terminal engine.
+        env["HEX1B_TERMINAL_KGP"] = "1";
+        
         // Apply custom environment (can override nesting level if explicitly set)
         if (_environment != null)
         {

--- a/src/Hex1b/Kgp/KgpPipeClient.cs
+++ b/src/Hex1b/Kgp/KgpPipeClient.cs
@@ -1,0 +1,103 @@
+using System.IO.Pipes;
+using System.Text;
+
+namespace Hex1b.Kgp;
+
+/// <summary>
+/// Client-side of the KGP side-channel pipe. Used by child processes
+/// to send KGP APC sequences to the parent terminal when ConPTY
+/// would strip them from stdout.
+/// </summary>
+/// <remarks>
+/// Detected automatically via the HEX1B_KGP_PIPE environment variable.
+/// </remarks>
+public sealed class KgpPipeClient : IDisposable
+{
+    private readonly NamedPipeClientStream _pipe;
+    private bool _connected;
+    private bool _disposed;
+
+    /// <summary>
+    /// Creates a client for the KGP side-channel pipe.
+    /// </summary>
+    /// <param name="pipeName">The pipe name from HEX1B_KGP_PIPE env var.</param>
+    public KgpPipeClient(string pipeName)
+    {
+        _pipe = new NamedPipeClientStream(".", pipeName, PipeDirection.Out, PipeOptions.Asynchronous);
+    }
+
+    /// <summary>
+    /// Attempts to connect to the parent's KGP pipe server.
+    /// </summary>
+    /// <param name="timeoutMs">Connection timeout in milliseconds.</param>
+    /// <returns>True if connected successfully.</returns>
+    public bool TryConnect(int timeoutMs = 3000)
+    {
+        if (_disposed) return false;
+        try
+        {
+            _pipe.Connect(timeoutMs);
+            _connected = true;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Writes raw APC bytes (KGP sequences) to the pipe.
+    /// </summary>
+    public void Write(ReadOnlySpan<byte> data)
+    {
+        if (!_connected || _disposed) return;
+        try
+        {
+            _pipe.Write(data);
+            _pipe.Flush();
+        }
+        catch
+        {
+            _connected = false;
+        }
+    }
+
+    /// <summary>
+    /// Writes a string (KGP APC sequence) to the pipe.
+    /// </summary>
+    public void Write(string apcSequence)
+    {
+        Write(Encoding.UTF8.GetBytes(apcSequence));
+    }
+
+    /// <summary>
+    /// Whether the client is connected to the parent pipe.
+    /// </summary>
+    public bool IsConnected => _connected && !_disposed;
+
+    /// <summary>
+    /// Tries to create a KGP pipe client from the environment variable.
+    /// Returns null if the env var is not set or connection fails.
+    /// </summary>
+    public static KgpPipeClient? TryCreateFromEnvironment()
+    {
+        var pipeName = Environment.GetEnvironmentVariable("HEX1B_KGP_PIPE");
+        if (string.IsNullOrEmpty(pipeName))
+            return null;
+
+        var client = new KgpPipeClient(pipeName);
+        if (client.TryConnect())
+            return client;
+
+        client.Dispose();
+        return null;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _pipe.Dispose();
+    }
+}

--- a/src/Hex1b/Kgp/KgpPipePresentationFilter.cs
+++ b/src/Hex1b/Kgp/KgpPipePresentationFilter.cs
@@ -28,33 +28,49 @@ internal sealed class KgpPipePresentationFilter : IHex1bTerminalPresentationFilt
     {
         if (!_client.IsConnected)
         {
-            // Pipe disconnected — pass everything through to stdout
             return ValueTask.FromResult<IReadOnlyList<AnsiToken>>(
                 appliedTokens.Select(t => t.Token).ToList());
         }
 
         var passThrough = new List<AnsiToken>();
 
-        foreach (var applied in appliedTokens)
+        for (int i = 0; i < appliedTokens.Count; i++)
         {
-            // Check if this is a KGP APC sequence (emitted as UnrecognizedSequenceToken)
+            var applied = appliedTokens[i];
+
+            // Intercept CursorPositionToken that precedes KGP APC — divert to pipe
+            // so it doesn't leak to ConPTY and displace text rendering
+            if (applied.Token is CursorPositionToken cup && i + 1 < appliedTokens.Count)
+            {
+                var next = appliedTokens[i + 1].Token;
+                if ((next is UnrecognizedSequenceToken nextUnrec && IsKgpApc(nextUnrec.Sequence)) ||
+                    next is KgpToken)
+                {
+                    _client.Write($"\x1b[{cup.Row};{cup.Column}H");
+                    continue;
+                }
+            }
+
             if (applied.Token is UnrecognizedSequenceToken unrec && IsKgpApc(unrec.Sequence))
             {
-                // Send cursor position before KGP so parent places image correctly.
-                // CSI row;col H (1-based) sets the cursor in the parent terminal.
-                _client.Write($"\x1b[{applied.CursorYBefore + 1};{applied.CursorXBefore + 1}H");
+                // If no preceding CursorPositionToken was diverted, send cursor now
+                if (i == 0 || appliedTokens[i - 1].Token is not CursorPositionToken)
+                {
+                    _client.Write($"\x1b[{applied.CursorYBefore + 1};{applied.CursorXBefore + 1}H");
+                }
                 _client.Write(unrec.Sequence);
             }
             else if (applied.Token is KgpToken kgp)
             {
-                // Direct KGP token — send cursor position + serialized token
-                _client.Write($"\x1b[{applied.CursorYBefore + 1};{applied.CursorXBefore + 1}H");
+                if (i == 0 || appliedTokens[i - 1].Token is not CursorPositionToken)
+                {
+                    _client.Write($"\x1b[{applied.CursorYBefore + 1};{applied.CursorXBefore + 1}H");
+                }
                 var serialized = AnsiTokenSerializer.Serialize([kgp]);
                 _client.Write(serialized);
             }
             else
             {
-                // Normal token — pass through to stdout
                 passThrough.Add(applied.Token);
             }
         }

--- a/src/Hex1b/Kgp/KgpPipePresentationFilter.cs
+++ b/src/Hex1b/Kgp/KgpPipePresentationFilter.cs
@@ -40,12 +40,15 @@ internal sealed class KgpPipePresentationFilter : IHex1bTerminalPresentationFilt
             // Check if this is a KGP APC sequence (emitted as UnrecognizedSequenceToken)
             if (applied.Token is UnrecognizedSequenceToken unrec && IsKgpApc(unrec.Sequence))
             {
-                // Divert to pipe
+                // Send cursor position before KGP so parent places image correctly.
+                // CSI row;col H (1-based) sets the cursor in the parent terminal.
+                _client.Write($"\x1b[{applied.CursorYBefore + 1};{applied.CursorXBefore + 1}H");
                 _client.Write(unrec.Sequence);
             }
             else if (applied.Token is KgpToken kgp)
             {
-                // Direct KGP token — serialize and send to pipe
+                // Direct KGP token — send cursor position + serialized token
+                _client.Write($"\x1b[{applied.CursorYBefore + 1};{applied.CursorXBefore + 1}H");
                 var serialized = AnsiTokenSerializer.Serialize([kgp]);
                 _client.Write(serialized);
             }

--- a/src/Hex1b/Kgp/KgpPipePresentationFilter.cs
+++ b/src/Hex1b/Kgp/KgpPipePresentationFilter.cs
@@ -1,0 +1,107 @@
+using Hex1b.Tokens;
+
+namespace Hex1b.Kgp;
+
+/// <summary>
+/// Presentation filter that diverts KGP APC sequences from stdout to
+/// a named pipe side-channel. This is needed on Windows where ConPTY
+/// strips APC sequences.
+/// </summary>
+/// <remarks>
+/// Automatically installed when HEX1B_KGP_PIPE env var is detected.
+/// Intercepts UnrecognizedSequenceToken containing KGP APC data and
+/// writes them to the pipe instead of letting them reach stdout.
+/// </remarks>
+internal sealed class KgpPipePresentationFilter : IHex1bTerminalPresentationFilter, IDisposable
+{
+    private readonly KgpPipeClient _client;
+
+    public KgpPipePresentationFilter(KgpPipeClient client)
+    {
+        _client = client;
+    }
+
+    public ValueTask OnSessionStartAsync(int width, int height, DateTimeOffset timestamp, CancellationToken ct = default)
+        => ValueTask.CompletedTask;
+
+    public ValueTask<IReadOnlyList<AnsiToken>> OnOutputAsync(IReadOnlyList<AppliedToken> appliedTokens, TimeSpan elapsed, CancellationToken ct = default)
+    {
+        if (!_client.IsConnected)
+        {
+            // Pipe disconnected — pass everything through to stdout
+            return ValueTask.FromResult<IReadOnlyList<AnsiToken>>(
+                appliedTokens.Select(t => t.Token).ToList());
+        }
+
+        var passThrough = new List<AnsiToken>();
+
+        foreach (var applied in appliedTokens)
+        {
+            // Check if this is a KGP APC sequence (emitted as UnrecognizedSequenceToken)
+            if (applied.Token is UnrecognizedSequenceToken unrec && IsKgpApc(unrec.Sequence))
+            {
+                // Divert to pipe
+                _client.Write(unrec.Sequence);
+            }
+            else if (applied.Token is KgpToken kgp)
+            {
+                // Direct KGP token — serialize and send to pipe
+                var serialized = AnsiTokenSerializer.Serialize([kgp]);
+                _client.Write(serialized);
+            }
+            else
+            {
+                // Normal token — pass through to stdout
+                passThrough.Add(applied.Token);
+            }
+        }
+
+        return ValueTask.FromResult<IReadOnlyList<AnsiToken>>(passThrough);
+    }
+
+    public ValueTask OnInputAsync(IReadOnlyList<AnsiToken> tokens, TimeSpan elapsed, CancellationToken ct = default)
+        => ValueTask.CompletedTask;
+
+    public ValueTask OnResizeAsync(int width, int height, TimeSpan elapsed, CancellationToken ct = default)
+        => ValueTask.CompletedTask;
+
+    public ValueTask OnSessionEndAsync(TimeSpan elapsed, CancellationToken ct = default)
+    {
+        _client.Dispose();
+        return ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// Checks if a sequence is a KGP APC (starts with ESC _ G or 0x9F G).
+    /// </summary>
+    private static bool IsKgpApc(string sequence)
+    {
+        if (sequence.Length < 4) return false;
+
+        // ESC _ G ...
+        if (sequence[0] == '\x1b' && sequence[1] == '_' && sequence[2] == 'G')
+            return true;
+
+        // 8-bit APC: 0x9F G ...
+        if (sequence[0] == '\x9f' && sequence[1] == 'G')
+            return true;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to create and install a KGP pipe filter from the environment.
+    /// Returns null if HEX1B_KGP_PIPE is not set or connection fails.
+    /// </summary>
+    public static KgpPipePresentationFilter? TryCreate()
+    {
+        var client = KgpPipeClient.TryCreateFromEnvironment();
+        if (client == null) return null;
+        return new KgpPipePresentationFilter(client);
+    }
+
+    public void Dispose()
+    {
+        _client.Dispose();
+    }
+}

--- a/src/Hex1b/Kgp/KgpPipeServer.cs
+++ b/src/Hex1b/Kgp/KgpPipeServer.cs
@@ -14,7 +14,7 @@ public sealed class KgpPipeServer : IAsyncDisposable
     private readonly string _pipeName;
     private readonly CancellationTokenSource _cts = new();
     private Task? _listenTask;
-    private Action<KgpToken>? _tokenHandler;
+    private Action<AnsiToken>? _tokenHandler;
 
     /// <summary>
     /// The pipe name to pass to child processes via HEX1B_KGP_PIPE env var.
@@ -27,9 +27,10 @@ public sealed class KgpPipeServer : IAsyncDisposable
     }
 
     /// <summary>
-    /// Sets the handler called when KGP tokens arrive from child processes.
+    /// Sets the handler called when tokens arrive from child processes.
+    /// Receives CursorPositionToken (for placement) and KgpToken (for image data).
     /// </summary>
-    public void SetTokenHandler(Action<KgpToken> handler)
+    public void SetTokenHandler(Action<AnsiToken> handler)
     {
         _tokenHandler = handler;
     }
@@ -103,9 +104,10 @@ public sealed class KgpPipeServer : IAsyncDisposable
         int lastConsumedEnd = 0;
         foreach (var token in tokens)
         {
-            if (token is KgpToken kgpToken)
+            // Forward cursor position tokens (for placement) and KGP tokens
+            if (token is KgpToken or CursorPositionToken)
             {
-                _tokenHandler?.Invoke(kgpToken);
+                _tokenHandler?.Invoke(token);
             }
             var serialized = AnsiTokenSerializer.Serialize([token]);
             lastConsumedEnd += serialized.Length;

--- a/src/Hex1b/Kgp/KgpPipeServer.cs
+++ b/src/Hex1b/Kgp/KgpPipeServer.cs
@@ -1,0 +1,131 @@
+using System.IO.Pipes;
+using System.Text;
+using Hex1b.Tokens;
+
+namespace Hex1b.Kgp;
+
+/// <summary>
+/// Server-side of the KGP side-channel pipe. Created by the parent terminal
+/// to receive KGP image data from child processes that can't send APC
+/// sequences through ConPTY.
+/// </summary>
+public sealed class KgpPipeServer : IAsyncDisposable
+{
+    private readonly string _pipeName;
+    private readonly CancellationTokenSource _cts = new();
+    private Task? _listenTask;
+    private Action<KgpToken>? _tokenHandler;
+
+    /// <summary>
+    /// The pipe name to pass to child processes via HEX1B_KGP_PIPE env var.
+    /// </summary>
+    public string PipeName => _pipeName;
+
+    public KgpPipeServer()
+    {
+        _pipeName = $"hex1b-kgp-{Environment.ProcessId}-{Guid.NewGuid():N}";
+    }
+
+    /// <summary>
+    /// Sets the handler called when KGP tokens arrive from child processes.
+    /// </summary>
+    public void SetTokenHandler(Action<KgpToken> handler)
+    {
+        _tokenHandler = handler;
+    }
+
+    /// <summary>
+    /// Starts listening for KGP data from child processes.
+    /// </summary>
+    public void Start()
+    {
+        _listenTask = ListenAsync(_cts.Token);
+    }
+
+    private async Task ListenAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            var pipe = new NamedPipeServerStream(
+                _pipeName,
+                PipeDirection.In,
+                NamedPipeServerStream.MaxAllowedServerInstances,
+                PipeTransmissionMode.Byte,
+                PipeOptions.Asynchronous);
+
+            try
+            {
+                await pipe.WaitForConnectionAsync(ct);
+                _ = HandleClientAsync(pipe, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                await pipe.DisposeAsync();
+                break;
+            }
+            catch
+            {
+                await pipe.DisposeAsync();
+            }
+        }
+    }
+
+    private async Task HandleClientAsync(NamedPipeServerStream pipe, CancellationToken ct)
+    {
+        try
+        {
+            var buffer = new byte[64 * 1024];
+            var accum = new StringBuilder();
+
+            while (!ct.IsCancellationRequested)
+            {
+                int bytesRead = await pipe.ReadAsync(buffer, ct);
+                if (bytesRead == 0)
+                    break;
+
+                accum.Append(Encoding.UTF8.GetString(buffer, 0, bytesRead));
+                ProcessAccumulatedData(accum);
+            }
+        }
+        catch (OperationCanceledException) { }
+        catch { }
+        finally
+        {
+            await pipe.DisposeAsync();
+        }
+    }
+
+    private void ProcessAccumulatedData(StringBuilder accum)
+    {
+        var text = accum.ToString();
+        var tokens = AnsiTokenizer.Tokenize(text);
+
+        int lastConsumedEnd = 0;
+        foreach (var token in tokens)
+        {
+            if (token is KgpToken kgpToken)
+            {
+                _tokenHandler?.Invoke(kgpToken);
+            }
+            var serialized = AnsiTokenSerializer.Serialize([token]);
+            lastConsumedEnd += serialized.Length;
+        }
+
+        if (lastConsumedEnd > 0 && lastConsumedEnd <= accum.Length)
+        {
+            accum.Remove(0, lastConsumedEnd);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _cts.CancelAsync();
+        _cts.Dispose();
+
+        if (_listenTask != null)
+        {
+            try { await _listenTask.WaitAsync(TimeSpan.FromSeconds(2)); }
+            catch { }
+        }
+    }
+}

--- a/src/Hex1b/WindowsConsoleDriver.cs
+++ b/src/Hex1b/WindowsConsoleDriver.cs
@@ -358,22 +358,23 @@ internal sealed class WindowsConsoleDriver : IConsoleDriver
     
     /// <summary>
     /// Peeks at the console input buffer for WINDOW_BUFFER_SIZE_EVENT records
-    /// and fires resize events. Consumes only resize records, leaving key/mouse
-    /// events for ReadFile to handle.
+    /// and fires resize events. Reads events one at a time to avoid consuming
+    /// key/mouse events that ReadFile needs.
     /// </summary>
     private void DrainResizeEvents()
     {
         if (!GetNumberOfConsoleInputEvents(_inputHandle, out var eventCount) || eventCount == 0)
             return;
         
-        var records = new INPUT_RECORD[eventCount];
-        if (!PeekConsoleInput(_inputHandle, records, (uint)records.Length, out var numPeeked) || numPeeked == 0)
+        var peekRecords = new INPUT_RECORD[eventCount];
+        if (!PeekConsoleInput(_inputHandle, peekRecords, (uint)peekRecords.Length, out var numPeeked) || numPeeked == 0)
             return;
         
+        // Check if any resize events are present
         bool hasResize = false;
         for (int i = 0; i < numPeeked; i++)
         {
-            if (records[i].EventType == WINDOW_BUFFER_SIZE_EVENT)
+            if (peekRecords[i].EventType == WINDOW_BUFFER_SIZE_EVENT)
             {
                 hasResize = true;
                 break;
@@ -383,20 +384,31 @@ internal sealed class WindowsConsoleDriver : IConsoleDriver
         if (!hasResize)
             return;
         
-        // Read and consume records one at a time, processing resize events
-        // and re-enqueueing others would be complex. Instead, consume ALL records
-        // via ReadConsoleInput and only process resize events.
-        // Key/mouse events are lost, but ReadFile will handle them going forward.
-        // This only runs when resize events are present (rare).
-        var consumeRecords = new INPUT_RECORD[eventCount];
-        if (ReadConsoleInput(_inputHandle, consumeRecords, (uint)consumeRecords.Length, out var numRead))
+        // Read events one at a time. Consume resize events and any non-key/mouse
+        // events (like focus events). Leave key/mouse events for ReadFile by
+        // not calling ReadConsoleInput when a key/mouse record is at the head.
+        var singleRecord = new INPUT_RECORD[1];
+        while (GetNumberOfConsoleInputEvents(_inputHandle, out var remaining) && remaining > 0)
         {
-            for (int i = 0; i < numRead; i++)
+            // Peek at the head
+            if (!PeekConsoleInput(_inputHandle, singleRecord, 1, out var peeked) || peeked == 0)
+                break;
+            
+            if (singleRecord[0].EventType == WINDOW_BUFFER_SIZE_EVENT)
             {
-                if (consumeRecords[i].EventType == WINDOW_BUFFER_SIZE_EVENT)
-                {
-                    ProcessResizeEvent(ref consumeRecords[i].WindowBufferSizeEvent);
-                }
+                // Consume and process resize
+                ReadConsoleInput(_inputHandle, singleRecord, 1, out _);
+                ProcessResizeEvent(ref singleRecord[0].WindowBufferSizeEvent);
+            }
+            else if (singleRecord[0].EventType is KEY_EVENT or MOUSE_EVENT)
+            {
+                // Stop — don't consume key/mouse events, ReadFile needs them
+                break;
+            }
+            else
+            {
+                // Consume and discard other event types (focus, menu, etc.)
+                ReadConsoleInput(_inputHandle, singleRecord, 1, out _);
             }
         }
     }

--- a/src/Hex1b/WindowsConsoleDriver.cs
+++ b/src/Hex1b/WindowsConsoleDriver.cs
@@ -293,13 +293,16 @@ internal sealed class WindowsConsoleDriver : IConsoleDriver
             {
                 while (!ct.IsCancellationRequested)
                 {
-                    // First, drain any pending bytes from previous key events
+                    // First, drain any pending bytes from previous processing
                     if (_pendingBytes.Count > 0)
                     {
                         return DrainPendingBytes(buffer.Span);
                     }
                     
-                    // Wait for input with timeout
+                    // Check for resize events via PeekConsoleInput before blocking on ReadFile
+                    DrainResizeEvents();
+                    
+                    // Wait for input with timeout so we can check cancellation periodically
                     var waitResult = WaitForSingleObject(_inputHandle, 100);
                     
                     if (waitResult == WAIT_TIMEOUT)
@@ -312,41 +315,34 @@ internal sealed class WindowsConsoleDriver : IConsoleDriver
                         throw new InvalidOperationException($"WaitForSingleObject failed: {Marshal.GetLastWin32Error()}");
                     }
                     
-                    // Read console input records
-                    var records = new INPUT_RECORD[16];
-                    if (!ReadConsoleInput(_inputHandle, records, (uint)records.Length, out var numRead))
-                    {
-                        throw new InvalidOperationException($"ReadConsoleInput failed: {Marshal.GetLastWin32Error()}");
-                    }
+                    // Drain resize events that may have arrived
+                    DrainResizeEvents();
                     
-                    // Process each record. A single malformed or transiently failing
-                    // record should not permanently kill keyboard input for the session.
-                    for (int i = 0; i < numRead; i++)
+                    // Read raw bytes via ReadFile. With ENABLE_VIRTUAL_TERMINAL_INPUT,
+                    // keyboard input arrives as VT sequences and APC responses (like KGP
+                    // protocol replies) come through as raw bytes — unlike ReadConsoleInput
+                    // which only returns structured INPUT_RECORD and drops APC.
+                    unsafe
                     {
-                        try
+                        fixed (byte* ptr = buffer.Span)
                         {
-                            ProcessInputRecord(ref records[i]);
+                            if (ReadFile(_inputHandle, ptr, (uint)buffer.Length, out var bytesRead, nint.Zero))
+                            {
+                                if (bytesRead > 0)
+                                {
+                                    return (int)bytesRead;
+                                }
+                            }
+                            else
+                            {
+                                var error = Marshal.GetLastWin32Error();
+                                // ERROR_IO_PENDING or similar — try again
+                                if (error != 0)
+                                {
+                                    TraceInput($"ReadFile failed error={error}");
+                                }
+                            }
                         }
-                        catch (Exception ex)
-                        {
-                            TraceInput(
-                                $"record-error type=0x{records[i].EventType:X4} error={ex.GetType().Name}: {ex.Message}");
-                        }
-                    }
-                    
-                    // If only a lone ESC (\x1b) remains in the VT input buffer after
-                    // processing the entire batch, it's a standalone Escape keypress —
-                    // not the start of an escape sequence. Flush it now; otherwise it
-                    // would be stuck until the next non-VT key event arrives.
-                    if (_pendingVtInput.Length == 1 && _pendingVtInput[0] == '\x1b')
-                    {
-                        FlushPendingVirtualTerminalInput();
-                    }
-
-                    // Return any bytes that were generated
-                    if (_pendingBytes.Count > 0)
-                    {
-                        return DrainPendingBytes(buffer.Span);
                     }
                 }
 
@@ -358,6 +354,51 @@ internal sealed class WindowsConsoleDriver : IConsoleDriver
                 throw;
             }
         }, ct);
+    }
+    
+    /// <summary>
+    /// Peeks at the console input buffer for WINDOW_BUFFER_SIZE_EVENT records
+    /// and fires resize events. Consumes only resize records, leaving key/mouse
+    /// events for ReadFile to handle.
+    /// </summary>
+    private void DrainResizeEvents()
+    {
+        if (!GetNumberOfConsoleInputEvents(_inputHandle, out var eventCount) || eventCount == 0)
+            return;
+        
+        var records = new INPUT_RECORD[eventCount];
+        if (!PeekConsoleInput(_inputHandle, records, (uint)records.Length, out var numPeeked) || numPeeked == 0)
+            return;
+        
+        bool hasResize = false;
+        for (int i = 0; i < numPeeked; i++)
+        {
+            if (records[i].EventType == WINDOW_BUFFER_SIZE_EVENT)
+            {
+                hasResize = true;
+                break;
+            }
+        }
+        
+        if (!hasResize)
+            return;
+        
+        // Read and consume records one at a time, processing resize events
+        // and re-enqueueing others would be complex. Instead, consume ALL records
+        // via ReadConsoleInput and only process resize events.
+        // Key/mouse events are lost, but ReadFile will handle them going forward.
+        // This only runs when resize events are present (rare).
+        var consumeRecords = new INPUT_RECORD[eventCount];
+        if (ReadConsoleInput(_inputHandle, consumeRecords, (uint)consumeRecords.Length, out var numRead))
+        {
+            for (int i = 0; i < numRead; i++)
+            {
+                if (consumeRecords[i].EventType == WINDOW_BUFFER_SIZE_EVENT)
+                {
+                    ProcessResizeEvent(ref consumeRecords[i].WindowBufferSizeEvent);
+                }
+            }
+        }
     }
     
     private int DrainPendingBytes(Span<byte> buffer)
@@ -960,6 +1001,21 @@ internal sealed class WindowsConsoleDriver : IConsoleDriver
         [Out] INPUT_RECORD[] lpBuffer,
         uint nLength,
         out uint lpNumberOfEventsRead);
+    
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern bool PeekConsoleInput(
+        nint hConsoleInput,
+        [Out] INPUT_RECORD[] lpBuffer,
+        uint nLength,
+        out uint lpNumberOfEventsRead);
+    
+    [DllImport("kernel32.dll", SetLastError = true)]
+    private static extern unsafe bool ReadFile(
+        nint hFile,
+        byte* lpBuffer,
+        uint nNumberOfBytesToRead,
+        out uint lpNumberOfBytesRead,
+        nint lpOverlapped);
     
     [DllImport("kernel32.dll", SetLastError = true)]
     private static extern unsafe bool WriteFile(

--- a/src/Hex1b/WindowsConsoleDriver.cs
+++ b/src/Hex1b/WindowsConsoleDriver.cs
@@ -318,6 +318,14 @@ internal sealed class WindowsConsoleDriver : IConsoleDriver
                     // Drain resize events that may have arrived
                     DrainResizeEvents();
                     
+                    // After draining resize events, check if there's still data to read.
+                    // If DrainResizeEvents consumed the event that woke us, ReadFile would
+                    // block. Go back to WaitForSingleObject instead.
+                    if (!GetNumberOfConsoleInputEvents(_inputHandle, out var remaining) || remaining == 0)
+                    {
+                        continue;
+                    }
+                    
                     // Read raw bytes via ReadFile. With ENABLE_VIRTUAL_TERMINAL_INPUT,
                     // keyboard input arrives as VT sequences and APC responses (like KGP
                     // protocol replies) come through as raw bytes — unlike ReadConsoleInput

--- a/src/Hex1b/WindowsPtyHandle.cs
+++ b/src/Hex1b/WindowsPtyHandle.cs
@@ -404,11 +404,10 @@ internal sealed class WindowsPtyHandle : IPtyHandle
                 FullMode = BoundedChannelFullMode.Wait
             });
             
-            _inputChannel = Channel.CreateBounded<byte[]>(new BoundedChannelOptions(16)
+            _inputChannel = Channel.CreateUnbounded<byte[]>(new UnboundedChannelOptions
             {
                 SingleReader = true,
-                SingleWriter = true,
-                FullMode = BoundedChannelFullMode.Wait
+                SingleWriter = false
             });
             
             _cts = new CancellationTokenSource();

--- a/src/Hex1b/WindowsPtyHandle.cs
+++ b/src/Hex1b/WindowsPtyHandle.cs
@@ -180,10 +180,17 @@ internal sealed class WindowsPtyHandle : IPtyHandle
     private CancellationTokenSource? _cts;          // For signaling shutdown
     
     private bool _disposed;
+    private bool _passthroughSupported;
     
     // === IPtyHandle Implementation ===
     
     public int ProcessId => _processId;
+    
+    /// <summary>
+    /// Whether PSEUDOCONSOLE_PASSTHROUGH was accepted by CreatePseudoConsole.
+    /// When true, ConPTY passes VT sequences (including APC) through unmodified.
+    /// </summary>
+    internal bool PassthroughSupported => _passthroughSupported;
     
     public Task StartAsync(
         string fileName,
@@ -233,7 +240,12 @@ internal sealed class WindowsPtyHandle : IPtyHandle
             if (hr != 0)
             {
                 // Passthrough not supported on this Windows version — fall back without it
+                _passthroughSupported = false;
                 hr = CreatePseudoConsole(size, pipePtyInputRead, pipePtyOutputWrite, 0, out _hPC);
+            }
+            else
+            {
+                _passthroughSupported = true;
             }
             if (hr != 0)
                 throw new Win32Exception(hr, "Failed to create pseudo console");

--- a/src/Hex1b/WindowsPtyHandle.cs
+++ b/src/Hex1b/WindowsPtyHandle.cs
@@ -653,6 +653,11 @@ internal sealed class WindowsPtyHandle : IPtyHandle
         }
     }
     
+    private long _ptyBytesWritten;
+    
+    /// <summary>Total bytes written to PTY input pipe.</summary>
+    internal long PtyBytesWritten => Interlocked.Read(ref _ptyBytesWritten);
+    
     private void WriteThreadProc()
     {
         // Cache the token — same rationale as ReadThreadProc (see comment there).
@@ -692,6 +697,7 @@ internal sealed class WindowsPtyHandle : IPtyHandle
                 {
                     _writeStream.Write(data, 0, data.Length);
                     _writeStream.Flush();
+                    Interlocked.Add(ref _ptyBytesWritten, data.Length);
                 }
                 catch (IOException)
                 {

--- a/src/Hex1b/WindowsPtyHandle.cs
+++ b/src/Hex1b/WindowsPtyHandle.cs
@@ -541,12 +541,28 @@ internal sealed class WindowsPtyHandle : IPtyHandle
         // Signal shutdown to background threads
         _cts?.Cancel();
         
+        // Close pseudo console FIRST — this signals the child process to exit
+        if (_hPC != IntPtr.Zero)
+        {
+            _fnClose?.Invoke(_hPC);
+            _hPC = IntPtr.Zero;
+        }
+        
+        // Give the process a brief moment to exit gracefully, then terminate
+        if (_hProcess != IntPtr.Zero)
+        {
+            if (WaitForSingleObject(_hProcess, 300) != WAIT_OBJECT_0)
+            {
+                _ = TerminateProcess(_hProcess, 1);
+                WaitForSingleObject(_hProcess, 200);
+            }
+        }
+        
         // Close channels to unblock threads waiting on channel operations
         _outputChannel?.Writer.TryComplete();
         _inputChannel?.Writer.TryComplete();
         
-        // Close streams FIRST to unblock blocking Read()/Write() calls in threads
-        // This causes the blocking I/O to throw, allowing threads to exit
+        // Close streams to unblock blocking Read()/Write() calls in threads
         if (_writeStream != null)
         {
             try { _writeStream.Close(); } catch { }
@@ -559,27 +575,19 @@ internal sealed class WindowsPtyHandle : IPtyHandle
             _readStream = null;
         }
         
-        // Close pipe handles to ensure threads are unblocked
+        // Close pipe handles
         _pipeOurInputWrite?.Dispose();
         _pipeOurInputWrite = null;
         _pipePtyOutputRead?.Dispose();
         _pipePtyOutputRead = null;
         
-        // Now wait for threads to exit (they should exit quickly now)
-        _readThread?.Join(TimeSpan.FromSeconds(2));
-        _writeThread?.Join(TimeSpan.FromSeconds(2));
+        // Wait briefly for threads to exit
+        _readThread?.Join(TimeSpan.FromMilliseconds(500));
+        _writeThread?.Join(TimeSpan.FromMilliseconds(500));
         
-        // Dispose CTS
         _cts?.Dispose();
         
-        // Close pseudo console
-        if (_hPC != IntPtr.Zero)
-        {
-            _fnClose?.Invoke(_hPC);
-            _hPC = IntPtr.Zero;
-        }
-        
-        // Close process handles
+        // Clean up process handles
         if (_hThread != IntPtr.Zero)
         {
             CloseHandle(_hThread);
@@ -588,12 +596,6 @@ internal sealed class WindowsPtyHandle : IPtyHandle
         
         if (_hProcess != IntPtr.Zero)
         {
-            if (WaitForSingleObject(_hProcess, 0) != WAIT_OBJECT_0)
-            {
-                _ = TerminateProcess(_hProcess, 1);
-                WaitForSingleObject(_hProcess, 500);
-            }
-
             CloseHandle(_hProcess);
             _hProcess = IntPtr.Zero;
         }

--- a/src/Hex1b/WindowsPtyHandle.cs
+++ b/src/Hex1b/WindowsPtyHandle.cs
@@ -24,10 +24,84 @@ internal sealed class WindowsPtyHandle : IPtyHandle
     private const uint EXTENDED_STARTUPINFO_PRESENT = 0x00080000;
     private const uint CREATE_UNICODE_ENVIRONMENT = 0x00000400;
     private const int PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE = 0x00020016;
-    private const uint PSEUDOCONSOLE_PASSTHROUGH = 0x00000008;
+    private const uint PSEUDOCONSOLE_INHERIT_CURSOR = 0x00000001;
     private const uint INFINITE = 0xFFFFFFFF;
     private const uint WAIT_OBJECT_0 = 0;
     private const uint STILL_ACTIVE = 259;
+    
+    // === Dynamic ConPTY function delegates ===
+    
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate int CreatePseudoConsoleDelegate(COORD size, SafeFileHandle hInput, SafeFileHandle hOutput, uint dwFlags, out IntPtr phPC);
+    
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate int ResizePseudoConsoleDelegate(IntPtr hPC, COORD size);
+    
+    [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+    private delegate void ClosePseudoConsoleDelegate(IntPtr hPC);
+    
+    private static CreatePseudoConsoleDelegate? _fnCreate;
+    private static ResizePseudoConsoleDelegate? _fnResize;
+    private static ClosePseudoConsoleDelegate? _fnClose;
+    private static bool _usingConptyDll;
+    private static bool _conptyResolved;
+    private static readonly object _conptyLock = new();
+    
+    /// <summary>
+    /// Optional path to a custom conpty.dll (e.g. from microsoft/terminal).
+    /// When set, the custom DLL is used instead of the OS kernel32.dll ConPTY,
+    /// enabling VT passthrough for protocols like KGP.
+    /// </summary>
+    public static string? ConptyDllPath { get; set; }
+    
+    /// <summary>
+    /// Whether the custom conpty.dll is being used instead of the OS ConPTY.
+    /// </summary>
+    public static bool UsingConptyDll => _usingConptyDll;
+    
+    private static void EnsureConptyResolved()
+    {
+        if (_conptyResolved) return;
+        lock (_conptyLock)
+        {
+            if (_conptyResolved) return;
+            
+            // Try loading custom conpty.dll first
+            if (!string.IsNullOrEmpty(ConptyDllPath) && File.Exists(ConptyDllPath))
+            {
+                var hLib = NativeLibrary.Load(ConptyDllPath);
+                if (hLib != IntPtr.Zero)
+                {
+                    // Custom DLL uses Conpty* prefixed function names
+                    if (NativeLibrary.TryGetExport(hLib, "ConptyCreatePseudoConsole", out var pCreate) &&
+                        NativeLibrary.TryGetExport(hLib, "ConptyResizePseudoConsole", out var pResize) &&
+                        NativeLibrary.TryGetExport(hLib, "ConptyClosePseudoConsole", out var pClose))
+                    {
+                        _fnCreate = Marshal.GetDelegateForFunctionPointer<CreatePseudoConsoleDelegate>(pCreate);
+                        _fnResize = Marshal.GetDelegateForFunctionPointer<ResizePseudoConsoleDelegate>(pResize);
+                        _fnClose = Marshal.GetDelegateForFunctionPointer<ClosePseudoConsoleDelegate>(pClose);
+                        _usingConptyDll = true;
+                        _conptyResolved = true;
+                        return;
+                    }
+                }
+            }
+            
+            // Fall back to OS kernel32.dll
+            var hKernel = NativeLibrary.Load("kernel32.dll");
+            if (NativeLibrary.TryGetExport(hKernel, "CreatePseudoConsole", out var pK32Create) &&
+                NativeLibrary.TryGetExport(hKernel, "ResizePseudoConsole", out var pK32Resize) &&
+                NativeLibrary.TryGetExport(hKernel, "ClosePseudoConsole", out var pK32Close))
+            {
+                _fnCreate = Marshal.GetDelegateForFunctionPointer<CreatePseudoConsoleDelegate>(pK32Create);
+                _fnResize = Marshal.GetDelegateForFunctionPointer<ResizePseudoConsoleDelegate>(pK32Resize);
+                _fnClose = Marshal.GetDelegateForFunctionPointer<ClosePseudoConsoleDelegate>(pK32Close);
+            }
+            
+            _usingConptyDll = false;
+            _conptyResolved = true;
+        }
+    }
     
     // === P/Invoke Structures ===
     
@@ -85,21 +159,7 @@ internal sealed class WindowsPtyHandle : IPtyHandle
         public int dwThreadId;
     }
     
-    // === P/Invoke Functions ===
-    
-    [DllImport("kernel32.dll", SetLastError = true)]
-    private static extern int CreatePseudoConsole(
-        COORD size,
-        SafeFileHandle hInput,
-        SafeFileHandle hOutput,
-        uint dwFlags,
-        out IntPtr phPC);
-    
-    [DllImport("kernel32.dll", SetLastError = true)]
-    private static extern int ResizePseudoConsole(IntPtr hPC, COORD size);
-    
-    [DllImport("kernel32.dll", SetLastError = true)]
-    private static extern void ClosePseudoConsole(IntPtr hPC);
+    // === P/Invoke Functions (non-ConPTY) ===
     
     [DllImport("kernel32.dll", SetLastError = true)]
     private static extern bool CreatePipe(
@@ -180,17 +240,10 @@ internal sealed class WindowsPtyHandle : IPtyHandle
     private CancellationTokenSource? _cts;          // For signaling shutdown
     
     private bool _disposed;
-    private bool _passthroughSupported;
     
     // === IPtyHandle Implementation ===
     
     public int ProcessId => _processId;
-    
-    /// <summary>
-    /// Whether PSEUDOCONSOLE_PASSTHROUGH was accepted by CreatePseudoConsole.
-    /// When true, ConPTY passes VT sequences (including APC) through unmodified.
-    /// </summary>
-    internal bool PassthroughSupported => _passthroughSupported;
     
     public Task StartAsync(
         string fileName,
@@ -233,20 +286,14 @@ internal sealed class WindowsPtyHandle : IPtyHandle
         
         try
         {
-            // Create the pseudo console with passthrough mode if available (Windows 11 24H2+).
-            // Passthrough allows APC sequences (KGP, Sixel) to flow through ConPTY unmodified.
+            EnsureConptyResolved();
+            
+            if (_fnCreate == null || _fnResize == null || _fnClose == null)
+                throw new PlatformNotSupportedException("ConPTY API not available on this system.");
+            
+            // Create the pseudo console
             var size = new COORD { X = (short)width, Y = (short)height };
-            int hr = CreatePseudoConsole(size, pipePtyInputRead, pipePtyOutputWrite, PSEUDOCONSOLE_PASSTHROUGH, out _hPC);
-            if (hr != 0)
-            {
-                // Passthrough not supported on this Windows version — fall back without it
-                _passthroughSupported = false;
-                hr = CreatePseudoConsole(size, pipePtyInputRead, pipePtyOutputWrite, 0, out _hPC);
-            }
-            else
-            {
-                _passthroughSupported = true;
-            }
+            int hr = _fnCreate(size, pipePtyInputRead, pipePtyOutputWrite, 0, out _hPC);
             if (hr != 0)
                 throw new Win32Exception(hr, "Failed to create pseudo console");
             
@@ -391,7 +438,7 @@ internal sealed class WindowsPtyHandle : IPtyHandle
             _pipePtyOutputRead?.Dispose();
             if (_hPC != IntPtr.Zero)
             {
-                ClosePseudoConsole(_hPC);
+                _fnClose?.Invoke(_hPC);
                 _hPC = IntPtr.Zero;
             }
             throw;
@@ -449,7 +496,7 @@ internal sealed class WindowsPtyHandle : IPtyHandle
             return;
         
         var size = new COORD { X = (short)width, Y = (short)height };
-        ResizePseudoConsole(_hPC, size);
+        _fnResize?.Invoke(_hPC, size);
     }
     
     public void Kill(int signal)
@@ -529,7 +576,7 @@ internal sealed class WindowsPtyHandle : IPtyHandle
         // Close pseudo console
         if (_hPC != IntPtr.Zero)
         {
-            ClosePseudoConsole(_hPC);
+            _fnClose?.Invoke(_hPC);
             _hPC = IntPtr.Zero;
         }
         

--- a/src/Hex1b/WindowsPtyHandle.cs
+++ b/src/Hex1b/WindowsPtyHandle.cs
@@ -32,7 +32,7 @@ internal sealed class WindowsPtyHandle : IPtyHandle
     // === Dynamic ConPTY function delegates ===
     
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-    private delegate int CreatePseudoConsoleDelegate(COORD size, SafeFileHandle hInput, SafeFileHandle hOutput, uint dwFlags, out IntPtr phPC);
+    private delegate int CreatePseudoConsoleDelegate(COORD size, IntPtr hInput, IntPtr hOutput, uint dwFlags, out IntPtr phPC);
     
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
     private delegate int ResizePseudoConsoleDelegate(IntPtr hPC, COORD size);
@@ -293,7 +293,7 @@ internal sealed class WindowsPtyHandle : IPtyHandle
             
             // Create the pseudo console
             var size = new COORD { X = (short)width, Y = (short)height };
-            int hr = _fnCreate(size, pipePtyInputRead, pipePtyOutputWrite, 0, out _hPC);
+            int hr = _fnCreate(size, pipePtyInputRead.DangerousGetHandle(), pipePtyOutputWrite.DangerousGetHandle(), 0, out _hPC);
             if (hr != 0)
                 throw new Win32Exception(hr, "Failed to create pseudo console");
             

--- a/src/Hex1b/WindowsPtyHandle.cs
+++ b/src/Hex1b/WindowsPtyHandle.cs
@@ -24,6 +24,7 @@ internal sealed class WindowsPtyHandle : IPtyHandle
     private const uint EXTENDED_STARTUPINFO_PRESENT = 0x00080000;
     private const uint CREATE_UNICODE_ENVIRONMENT = 0x00000400;
     private const int PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE = 0x00020016;
+    private const uint PSEUDOCONSOLE_PASSTHROUGH = 0x00000008;
     private const uint INFINITE = 0xFFFFFFFF;
     private const uint WAIT_OBJECT_0 = 0;
     private const uint STILL_ACTIVE = 259;
@@ -225,9 +226,15 @@ internal sealed class WindowsPtyHandle : IPtyHandle
         
         try
         {
-            // Create the pseudo console
+            // Create the pseudo console with passthrough mode if available (Windows 11 24H2+).
+            // Passthrough allows APC sequences (KGP, Sixel) to flow through ConPTY unmodified.
             var size = new COORD { X = (short)width, Y = (short)height };
-            int hr = CreatePseudoConsole(size, pipePtyInputRead, pipePtyOutputWrite, 0, out _hPC);
+            int hr = CreatePseudoConsole(size, pipePtyInputRead, pipePtyOutputWrite, PSEUDOCONSOLE_PASSTHROUGH, out _hPC);
+            if (hr != 0)
+            {
+                // Passthrough not supported on this Windows version — fall back without it
+                hr = CreatePseudoConsole(size, pipePtyInputRead, pipePtyOutputWrite, 0, out _hPC);
+            }
             if (hr != 0)
                 throw new Win32Exception(hr, "Failed to create pseudo console");
             


### PR DESCRIPTION
## WpfTerm — WPF Terminal Emulator Spike

Experimental WPF-based terminal emulator that hosts a Hex1b terminal with ConPTY. This is a feasibility spike exploring what it takes to build a GUI terminal emulator on top of Hex1b.

### What's included

**Core terminal** (\samples/WpfTerm/\):
- \WpfTerminalAdapter\ — \ICellImpactAwarePresentationAdapter\ bridging Hex1b to WPF
- \TerminalControl\ — Custom \FrameworkElement\ rendering terminal cells via \DrawingVisual\/\GlyphRun\
- \AnsiKeyEncoder\ — WPF key events → ANSI escape sequences
- Mouse support (SGR mode 1000/1002/1003) with cell deduplication
- Cursor shape rendering (block/bar/underline) tracking \CursorShapeToken\

**Performance optimizations**:
- GlyphRun batching with attribute run scanning (~30-100 draw calls vs ~3600 FormattedText)
- Render coalescing via \DispatcherPriority.Render\
- Zero-copy buffer access via \RenderUnderLock\
- Pre-cached typeface variants and pen/brush caching

**KGP (Kitty Graphics Protocol)**:
- Custom \conpty.dll\ integration (from microsoft/terminal via VS Code's node-pty) for VT passthrough
- Dynamic \NativeLibrary.Load\ with \Conpty*\ prefixed functions, kernel32 fallback
- Named pipe side-channel (\KgpPipeServer\/\KgpPipeClient\/\KgpPipePresentationFilter\) as fallback when custom ConPTY unavailable
- Z-ordered rendering (behind-text / above-text), source clipping, bitmap caching
- Environment variable bridge (\HEX1B_TERMINAL_KGP\, \HEX1B_KGP_PIPE\) for capability detection

**Hex1b core changes**:
- \WindowsPtyHandle\: Dynamic ConPTY loading (\ConptyDllPath\), \ReadFile\-based input for \WindowsConsoleDriver\
- \KgpImageStore\/\KgpPlacements\: \internal\ → \public\
- \ProcessKgpFromSideChannel\: Public API for pipe-delivered KGP tokens
- \Hex1bTerminalChildProcess\: \HEX1B_TERMINAL_KGP=1\ env var advertisement
- \ConsolePresentationAdapter\: Windows KGP probe via env var
- \DoExitAlternateScreen\: Clear KGP placements
- Shutdown reordering for faster close

### Known limitations
- **Reflow**: ConPTY resize repaint doesn't produce correct reflow. Needs deeper investigation.
- **~4% TextInput drop**: WPF suppresses some \TextInput\ events during rapid mouse activity.
- **KGP via OS ConPTY**: Requires custom \conpty.dll\. OS kernel32 strips APC sequences.

### How to run
\\\
cd samples/WpfTerm
dotnet run
\\\
