### PR TITLE
Add EncryptedMuxerDemo sample and stream transform overloads

### DIFF
--- a/samples/EncryptedMuxerDemo/DemoTls.cs
+++ b/samples/EncryptedMuxerDemo/DemoTls.cs
@@ -1,0 +1,83 @@
+using System.Net.Security;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace EncryptedMuxerDemo;
+
+/// <summary>
+/// Provides TLS stream wrapping helpers for the encrypted muxer demo.
+/// Generates an ephemeral self-signed certificate at startup and provides
+/// server/client stream transform functions for use with HMP v1 builder extensions.
+/// </summary>
+internal static class DemoTls
+{
+    private static X509Certificate2? _serverCert;
+
+    /// <summary>
+    /// Gets (or lazily creates) an ephemeral self-signed certificate for the demo server.
+    /// The certificate is generated in-memory and never persisted to disk.
+    /// </summary>
+    public static X509Certificate2 ServerCertificate => _serverCert ??= GenerateSelfSignedCert();
+
+    /// <summary>
+    /// Wraps a raw transport stream with TLS as the server side.
+    /// Performs the TLS handshake asynchronously before returning the encrypted stream.
+    /// </summary>
+    public static async Task<Stream> AuthenticateAsServerAsync(Stream innerStream)
+    {
+        var sslStream = new SslStream(innerStream, leaveInnerStreamOpen: false);
+        await sslStream.AuthenticateAsServerAsync(ServerCertificate);
+        return sslStream;
+    }
+
+    /// <summary>
+    /// Wraps a raw transport stream with TLS as the client side.
+    /// Uses a permissive certificate validation callback since the server
+    /// certificate is ephemeral and self-signed.
+    /// </summary>
+    public static async Task<Stream> AuthenticateAsClientAsync(Stream innerStream)
+    {
+        var sslStream = new SslStream(
+            innerStream,
+            leaveInnerStreamOpen: false,
+            userCertificateValidationCallback: (_, _, _, _) => true);
+
+        await sslStream.AuthenticateAsClientAsync("hex1b-encrypted-muxer-demo");
+        return sslStream;
+    }
+
+    private static X509Certificate2 GenerateSelfSignedCert()
+    {
+        using var rsa = RSA.Create(2048);
+
+        var request = new CertificateRequest(
+            "CN=hex1b-encrypted-muxer-demo",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+
+        request.CertificateExtensions.Add(
+            new X509KeyUsageExtension(
+                X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment,
+                critical: false));
+
+        request.CertificateExtensions.Add(
+            new X509EnhancedKeyUsageExtension(
+                [new Oid("1.3.6.1.5.5.7.3.1")], // serverAuth
+                critical: false));
+
+        var cert = request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddMinutes(-5),
+            DateTimeOffset.UtcNow.AddHours(1));
+
+        // On Windows, export and re-import so the private key is usable with SslStream
+        if (OperatingSystem.IsWindows())
+        {
+            var pfxBytes = cert.Export(X509ContentType.Pfx);
+            cert.Dispose();
+            return X509CertificateLoader.LoadPkcs12(pfxBytes, null, X509KeyStorageFlags.EphemeralKeySet);
+        }
+
+        return cert;
+    }
+}

--- a/samples/EncryptedMuxerDemo/DemoTls.cs
+++ b/samples/EncryptedMuxerDemo/DemoTls.cs
@@ -70,14 +70,10 @@ internal static class DemoTls
             DateTimeOffset.UtcNow.AddMinutes(-5),
             DateTimeOffset.UtcNow.AddHours(1));
 
-        // On Windows, export and re-import so the private key is usable with SslStream
-        if (OperatingSystem.IsWindows())
-        {
-            var pfxBytes = cert.Export(X509ContentType.Pfx);
-            cert.Dispose();
-            return X509CertificateLoader.LoadPkcs12(pfxBytes, null, X509KeyStorageFlags.EphemeralKeySet);
-        }
-
-        return cert;
+        // Export to PFX and re-import so the private key is in a format SslStream can use.
+        // Use MachineKeySet to avoid "ephemeral keys not supported" errors on some Windows versions.
+        var pfxBytes = cert.Export(X509ContentType.Pfx);
+        cert.Dispose();
+        return X509CertificateLoader.LoadPkcs12(pfxBytes, null, X509KeyStorageFlags.MachineKeySet);
     }
 }

--- a/samples/EncryptedMuxerDemo/EncryptedMuxerDemo.csproj
+++ b/samples/EncryptedMuxerDemo/EncryptedMuxerDemo.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <PublishAot>true</PublishAot>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hex1b\Hex1b.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">
+    <WindowsPtyShimRid Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'Arm64'">win-arm64</WindowsPtyShimRid>
+    <WindowsPtyShimRid Condition="'$(WindowsPtyShimRid)' == ''">win-x64</WindowsPtyShimRid>
+  </PropertyGroup>
+
+  <Target Name="CopyWindowsPtyShim"
+          AfterTargets="Build"
+          Condition="$([MSBuild]::IsOSPlatform('Windows')) and Exists('../../src/Hex1b/obj/windows-pty-shim/$(WindowsPtyShimRid)/native/hex1bpty.exe')">
+    <ItemGroup>
+      <WindowsPtyShimFiles Include="../../src/Hex1b/obj/windows-pty-shim/$(WindowsPtyShimRid)/native/*.*"
+                           Exclude="../../src/Hex1b/obj/windows-pty-shim/$(WindowsPtyShimRid)/native/*.pdb" />
+    </ItemGroup>
+    <Copy SourceFiles="@(WindowsPtyShimFiles)"
+          DestinationFolder="$(TargetDir)runtimes\$(WindowsPtyShimRid)\native\"
+          SkipUnchangedFiles="true" />
+  </Target>
+
+</Project>

--- a/samples/EncryptedMuxerDemo/EncryptedMuxerServer.cs
+++ b/samples/EncryptedMuxerDemo/EncryptedMuxerServer.cs
@@ -1,0 +1,38 @@
+using Hex1b;
+
+namespace EncryptedMuxerDemo;
+
+/// <summary>
+/// Runs a headless PTY process and serves it over TLS-encrypted HMP v1 on a Unix domain socket.
+/// </summary>
+internal static class EncryptedMuxerServer
+{
+    public static async Task RunAsync(string socketPath)
+    {
+        // Pre-generate the certificate so it's ready before any client connects
+        _ = DemoTls.ServerCertificate;
+
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithPtyProcess(options =>
+            {
+                options.FileName = GetShell();
+                if (OperatingSystem.IsWindows())
+                    options.WindowsPtyMode = WindowsPtyMode.RequireProxy;
+            })
+            .WithHmp1UdsServer(socketPath, DemoTls.AuthenticateAsServerAsync)
+            .Build();
+
+        await terminal.RunAsync();
+
+        try { File.Delete(socketPath); } catch { }
+    }
+
+    private static string GetShell()
+    {
+        if (OperatingSystem.IsWindows())
+            return "pwsh.exe";
+
+        var shell = Environment.GetEnvironmentVariable("SHELL");
+        return !string.IsNullOrEmpty(shell) ? shell : "bash";
+    }
+}

--- a/samples/EncryptedMuxerDemo/Program.cs
+++ b/samples/EncryptedMuxerDemo/Program.cs
@@ -1,0 +1,15 @@
+using EncryptedMuxerDemo;
+
+var sessionDir = Path.Combine(
+    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+    ".hex1bsamples", "encryptedmuxerdemo");
+
+if (args is ["--server", var socketPath])
+{
+    await EncryptedMuxerServer.RunAsync(socketPath);
+    return;
+}
+
+var sessions = new SessionManager(sessionDir);
+var app = new SessionManagerApp(sessions);
+await app.RunAsync();

--- a/samples/EncryptedMuxerDemo/SessionManager.cs
+++ b/samples/EncryptedMuxerDemo/SessionManager.cs
@@ -1,0 +1,256 @@
+using System.Diagnostics;
+using System.Net.Sockets;
+using Hex1b;
+
+namespace EncryptedMuxerDemo;
+
+/// <summary>
+/// Discovers, creates, connects to, and kills terminal sessions.
+/// Sessions are stored as UDS socket files in a well-known directory.
+/// Connections are wrapped with TLS encryption.
+/// </summary>
+internal sealed class SessionManager
+{
+    private readonly string _sessionDir;
+    private readonly Dictionary<string, Process> _serverProcesses = new();
+
+    public SessionManager(string sessionDir)
+    {
+        _sessionDir = sessionDir;
+        Directory.CreateDirectory(sessionDir);
+    }
+
+    public Hmp1WorkloadAdapter? Adapter { get; private set; }
+    public Hex1bTerminal? EmbeddedTerminal { get; private set; }
+    public TerminalWidgetHandle? Handle { get; private set; }
+    public string? ConnectedSessionName { get; private set; }
+    public string? ConnectedSocketPath { get; private set; }
+    public string? StatusMessage { get; set; }
+    public bool IsConnected => Handle is not null;
+
+    private CancellationTokenSource? _embeddedCts;
+
+    public List<SessionInfo> DiscoverSessions()
+    {
+        var sessions = new List<SessionInfo>();
+
+        if (!Directory.Exists(_sessionDir))
+            return sessions;
+
+        foreach (var file in Directory.GetFiles(_sessionDir, "*.sock"))
+        {
+            var name = Path.GetFileNameWithoutExtension(file);
+            var displayName = name.StartsWith("session_")
+                ? FormatSessionName(name["session_".Length..])
+                : name;
+            sessions.Add(new SessionInfo(displayName, file));
+        }
+
+        sessions.Sort((a, b) => string.Compare(b.SocketPath, a.SocketPath, StringComparison.Ordinal));
+        return sessions;
+    }
+
+    public async Task CreateAndConnectSessionAsync(Action? onStateChanged = null)
+    {
+        var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+        var sockPath = Path.Combine(_sessionDir, $"session_{timestamp}.sock");
+
+        StatusMessage = "Starting new encrypted session...";
+        onStateChanged?.Invoke();
+
+        var exe = Environment.ProcessPath ?? "dotnet";
+        var psi = new ProcessStartInfo
+        {
+            FileName = exe,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        if (!exe.EndsWith("EncryptedMuxerDemo", StringComparison.OrdinalIgnoreCase) &&
+            !exe.EndsWith("EncryptedMuxerDemo.exe", StringComparison.OrdinalIgnoreCase))
+        {
+            psi.FileName = "dotnet";
+            var demoAssembly = Path.Combine(AppContext.BaseDirectory, "EncryptedMuxerDemo.dll");
+            psi.ArgumentList.Add(demoAssembly);
+        }
+
+        psi.ArgumentList.Add("--server");
+        psi.ArgumentList.Add(sockPath);
+
+        var process = Process.Start(psi);
+        if (process is null)
+        {
+            StatusMessage = "Failed to start server process.";
+            onStateChanged?.Invoke();
+            return;
+        }
+
+        _serverProcesses[sockPath] = process;
+
+        for (var i = 0; i < 50; i++)
+        {
+            await Task.Delay(100);
+            if (File.Exists(sockPath))
+                break;
+        }
+
+        if (!File.Exists(sockPath))
+        {
+            StatusMessage = "Server didn't start in time.";
+            onStateChanged?.Invoke();
+            return;
+        }
+
+        await ConnectToSessionAsync(new SessionInfo($"session_{timestamp}", sockPath), onStateChanged);
+    }
+
+    public async Task ConnectToSessionAsync(SessionInfo session, Action? onStateChanged = null)
+    {
+        StatusMessage = $"Connecting to {session.Name} (TLS)...";
+        onStateChanged?.Invoke();
+
+        try
+        {
+            await DisconnectAsync();
+
+            // Connect the raw socket, then wrap with TLS
+            var rawStream = await Hmp1Transports.ConnectUnixSocket(session.SocketPath, CancellationToken.None);
+            var tlsStream = await DemoTls.AuthenticateAsClientAsync(rawStream);
+
+            Adapter = new Hmp1WorkloadAdapter(tlsStream);
+            await Adapter.ConnectAsync(CancellationToken.None);
+
+            _embeddedCts = new CancellationTokenSource();
+
+            EmbeddedTerminal = Hex1bTerminal.CreateBuilder()
+                .WithDimensions(Adapter.RemoteWidth, Adapter.RemoteHeight)
+                .WithWorkload(Adapter)
+                .WithScrollback()
+                .WithTerminalWidget(out var handle)
+                .Build();
+
+            Handle = handle;
+            ConnectedSessionName = session.Name;
+            ConnectedSocketPath = session.SocketPath;
+
+            handle.StateChanged += state =>
+            {
+                if (state == TerminalState.Completed)
+                {
+                    StatusMessage = $"Session '{session.Name}' exited.";
+                    Handle = null;
+                    ConnectedSessionName = null;
+                    ConnectedSocketPath = null;
+                    onStateChanged?.Invoke();
+                }
+            };
+
+            _ = EmbeddedTerminal.RunAsync(_embeddedCts.Token);
+
+            StatusMessage = null;
+            onStateChanged?.Invoke();
+        }
+        catch (SocketException)
+        {
+            try { File.Delete(session.SocketPath); } catch { }
+            StatusMessage = $"Session '{session.Name}' is no longer available (cleaned up).";
+            Adapter = null;
+            onStateChanged?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            StatusMessage = $"Failed to connect: {ex.Message}";
+            Adapter = null;
+            onStateChanged?.Invoke();
+        }
+    }
+
+    public async Task KillCurrentSessionAsync(Action? onStateChanged = null)
+    {
+        if (ConnectedSocketPath is null)
+            return;
+
+        var socketToDelete = ConnectedSocketPath;
+        var sessionName = ConnectedSessionName;
+
+        await DisconnectAsync();
+
+        KillServerProcess(socketToDelete);
+        try { File.Delete(socketToDelete); } catch { }
+
+        StatusMessage = $"Killed session '{sessionName}'.";
+        onStateChanged?.Invoke();
+    }
+
+    public async Task DisconnectAsync()
+    {
+        if (_embeddedCts is not null)
+        {
+            await _embeddedCts.CancelAsync();
+            _embeddedCts.Dispose();
+            _embeddedCts = null;
+        }
+
+        if (EmbeddedTerminal is not null)
+        {
+            await EmbeddedTerminal.DisposeAsync();
+            EmbeddedTerminal = null;
+        }
+
+        if (Adapter is not null)
+        {
+            await Adapter.DisposeAsync();
+            Adapter = null;
+        }
+
+        Handle = null;
+        ConnectedSessionName = null;
+        ConnectedSocketPath = null;
+    }
+
+    public void KillAllServerProcesses()
+    {
+        foreach (var (path, proc) in _serverProcesses)
+        {
+            try
+            {
+                if (!proc.HasExited)
+                    proc.Kill(entireProcessTree: true);
+            }
+            catch { }
+            proc.Dispose();
+            try { File.Delete(path); } catch { }
+        }
+        _serverProcesses.Clear();
+    }
+
+    private void KillServerProcess(string socketPath)
+    {
+        if (_serverProcesses.TryGetValue(socketPath, out var proc))
+        {
+            _serverProcesses.Remove(socketPath);
+            try
+            {
+                if (!proc.HasExited)
+                    proc.Kill(entireProcessTree: true);
+            }
+            catch { }
+            proc.Dispose();
+        }
+    }
+
+    private static string FormatSessionName(string timestamp)
+    {
+        if (DateTime.TryParseExact(timestamp, "yyyyMMdd_HHmmss",
+            System.Globalization.CultureInfo.InvariantCulture,
+            System.Globalization.DateTimeStyles.None, out var dt))
+        {
+            return dt.ToString("yyyy-MM-dd HH:mm:ss");
+        }
+        return timestamp;
+    }
+}
+
+internal sealed record SessionInfo(string Name, string SocketPath);

--- a/samples/EncryptedMuxerDemo/SessionManagerApp.cs
+++ b/samples/EncryptedMuxerDemo/SessionManagerApp.cs
@@ -1,0 +1,128 @@
+using Hex1b;
+using Hex1b.Input;
+using Hex1b.Widgets;
+
+namespace EncryptedMuxerDemo;
+
+/// <summary>
+/// TUI application that provides a session list and terminal view
+/// with tmux-style keyboard chords for navigation.
+/// All connections are TLS-encrypted.
+/// </summary>
+internal sealed class SessionManagerApp
+{
+    private readonly SessionManager _sessions;
+    private Hex1bApp? _app;
+
+    public SessionManagerApp(SessionManager sessions)
+    {
+        _sessions = sessions;
+    }
+
+    public async Task RunAsync()
+    {
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithMouse()
+            .WithHex1bApp((app, _) =>
+            {
+                _app = app;
+                return ctx =>
+                {
+                    Hex1bWidget content;
+                    if (_sessions.IsConnected)
+                        content = BuildTerminalView(ctx, _sessions.Handle!);
+                    else
+                        content = BuildSessionListView(ctx);
+
+                    return content.WithInputBindings(bindings =>
+                    {
+                        bindings.Ctrl().Key(Hex1bKey.B).Then().Key(Hex1bKey.D)
+                            .OverridesCapture()
+                            .Action(_ => _app?.RequestStop(), "Detach");
+
+                        bindings.Ctrl().Key(Hex1bKey.B).Then().Key(Hex1bKey.S)
+                            .OverridesCapture()
+                            .Action(async _ =>
+                            {
+                                await _sessions.DisconnectAsync();
+                                _sessions.StatusMessage = null;
+                                _app?.Invalidate();
+                            }, "Sessions");
+
+                        bindings.Ctrl().Key(Hex1bKey.B).Then().Key(Hex1bKey.X)
+                            .OverridesCapture()
+                            .Action(async _ => await _sessions.KillCurrentSessionAsync(
+                                () => _app?.Invalidate()), "Kill session");
+                    });
+                };
+            })
+            .Build();
+
+        await terminal.RunAsync();
+
+        await _sessions.DisconnectAsync();
+        _sessions.KillAllServerProcesses();
+    }
+
+    private Hex1bWidget BuildSessionListView<TParent>(WidgetContext<TParent> ctx)
+        where TParent : Hex1bWidget
+    {
+        var sessions = _sessions.DiscoverSessions();
+        var items = sessions.Select(s => s.Name).Append("+ New Session").ToList();
+
+        return ctx.VStack(v =>
+        [
+            v.Text(" \U0001f512 Hex1b Encrypted Muxer Demo "),
+            v.Text(""),
+            v.Text(_sessions.StatusMessage ?? "Select a session or create a new one:"),
+            v.Text("  All connections are TLS-encrypted."),
+            v.Text(""),
+            v.List(items)
+                .OnItemActivated(e =>
+                {
+                    if (e.ActivatedIndex == sessions.Count)
+                        _ = _sessions.CreateAndConnectSessionAsync(() => _app?.Invalidate());
+                    else
+                        _ = _sessions.ConnectToSessionAsync(sessions[e.ActivatedIndex],
+                            () => _app?.Invalidate());
+                })
+                .FillHeight(),
+            v.InfoBar(s =>
+            [
+                s.Section("Enter"),
+                s.Section("Select"),
+                s.Spacer(),
+                s.Section("Ctrl+B D"),
+                s.Section("Quit")
+            ]).WithDefaultSeparator(" ")
+        ]);
+    }
+
+    private Hex1bWidget BuildTerminalView<TParent>(WidgetContext<TParent> ctx, TerminalWidgetHandle handle)
+        where TParent : Hex1bWidget
+    {
+        var dims = _sessions.Adapter is not null
+            ? $"{_sessions.Adapter.RemoteWidth}\u00d7{_sessions.Adapter.RemoteHeight}"
+            : "";
+
+        return ctx.VStack(v =>
+        [
+            v.Terminal(handle).CopyModeBindings().Fill(),
+            v.InfoBar(s =>
+            [
+                s.Section("Ctrl+B S"),
+                s.Section("Sessions"),
+                s.Spacer(),
+                s.Section("Ctrl+B X"),
+                s.Section("Kill"),
+                s.Spacer(),
+                s.Section("Ctrl+B D"),
+                s.Section("Detach"),
+                s.Spacer(),
+                s.Section("\U0001f512 TLS"),
+                s.Section(_sessions.ConnectedSessionName ?? ""),
+                s.Section(dims)
+            ]).WithDefaultSeparator(" ")
+        ]);
+    }
+}

--- a/src/Hex1b/Hmp1/Hmp1BuilderExtensions.cs
+++ b/src/Hex1b/Hmp1/Hmp1BuilderExtensions.cs
@@ -69,6 +69,73 @@ public static class Hmp1BuilderExtensions
     }
 
     /// <summary>
+    /// Adds an HMP v1 server listener on a Unix domain socket with a stream transform applied
+    /// to each accepted client connection. Use this to wrap transport streams with encryption,
+    /// compression, or other transformations before HMP v1 framing is applied.
+    /// </summary>
+    /// <param name="builder">The terminal builder.</param>
+    /// <param name="socketPath">Path to the Unix domain socket file.</param>
+    /// <param name="streamTransform">
+    /// A function that wraps the raw transport stream. Called once per client connection.
+    /// The returned stream is used for HMP v1 protocol communication.
+    /// </param>
+    /// <returns>The builder for fluent chaining.</returns>
+    /// <example>
+    /// <code>
+    /// await using var terminal = Hex1bTerminal.CreateBuilder()
+    ///     .WithPtyProcess("bash")
+    ///     .WithHmp1UdsServer("/tmp/my-terminal.sock", stream => WrapWithCompression(stream))
+    ///     .Build();
+    /// </code>
+    /// </example>
+    public static Hex1bTerminalBuilder WithHmp1UdsServer(
+        this Hex1bTerminalBuilder builder,
+        string socketPath,
+        Func<Stream, Stream> streamTransform)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(socketPath);
+        ArgumentNullException.ThrowIfNull(streamTransform);
+        return builder.WithHmp1Server(ct => TransformStreams(
+            Hmp1Transports.ListenUnixSocket(socketPath, ct), streamTransform));
+    }
+
+    /// <summary>
+    /// Adds an HMP v1 server listener on a Unix domain socket with an async stream transform
+    /// applied to each accepted client connection. Use this when the stream wrapping requires
+    /// asynchronous setup, such as a TLS handshake.
+    /// </summary>
+    /// <param name="builder">The terminal builder.</param>
+    /// <param name="socketPath">Path to the Unix domain socket file.</param>
+    /// <param name="streamTransform">
+    /// An async function that wraps the raw transport stream. Called once per client connection.
+    /// The returned stream is used for HMP v1 protocol communication.
+    /// </param>
+    /// <returns>The builder for fluent chaining.</returns>
+    /// <example>
+    /// <code>
+    /// await using var terminal = Hex1bTerminal.CreateBuilder()
+    ///     .WithPtyProcess("bash")
+    ///     .WithHmp1UdsServer("/tmp/my-terminal.sock", async stream =>
+    ///     {
+    ///         var sslStream = new SslStream(stream);
+    ///         await sslStream.AuthenticateAsServerAsync(serverCert);
+    ///         return sslStream;
+    ///     })
+    ///     .Build();
+    /// </code>
+    /// </example>
+    public static Hex1bTerminalBuilder WithHmp1UdsServer(
+        this Hex1bTerminalBuilder builder,
+        string socketPath,
+        Func<Stream, Task<Stream>> streamTransform)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(socketPath);
+        ArgumentNullException.ThrowIfNull(streamTransform);
+        return builder.WithHmp1Server(ct => TransformStreamsAsync(
+            Hmp1Transports.ListenUnixSocket(socketPath, ct), streamTransform));
+    }
+
+    /// <summary>
     /// Configures the terminal as an HMP v1 client. The terminal connects to a remote
     /// server and displays its output locally.
     /// </summary>
@@ -136,6 +203,90 @@ public static class Hmp1BuilderExtensions
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(socketPath);
         return builder.WithHmp1Client(ct => Hmp1Transports.ConnectUnixSocket(socketPath, ct));
+    }
+
+    /// <summary>
+    /// Configures the terminal as an HMP v1 client connecting to a Unix domain socket
+    /// with a stream transform applied after connection. Use this to wrap transport streams
+    /// with encryption, compression, or other transformations before HMP v1 framing is applied.
+    /// </summary>
+    /// <param name="builder">The terminal builder.</param>
+    /// <param name="socketPath">Path to the Unix domain socket to connect to.</param>
+    /// <param name="streamTransform">
+    /// A function that wraps the raw transport stream.
+    /// The returned stream is used for HMP v1 protocol communication.
+    /// </param>
+    /// <returns>The builder for fluent chaining.</returns>
+    public static Hex1bTerminalBuilder WithHmp1UdsClient(
+        this Hex1bTerminalBuilder builder,
+        string socketPath,
+        Func<Stream, Stream> streamTransform)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(socketPath);
+        ArgumentNullException.ThrowIfNull(streamTransform);
+        return builder.WithHmp1Client(async ct =>
+        {
+            var stream = await Hmp1Transports.ConnectUnixSocket(socketPath, ct);
+            return streamTransform(stream);
+        });
+    }
+
+    /// <summary>
+    /// Configures the terminal as an HMP v1 client connecting to a Unix domain socket
+    /// with an async stream transform applied after connection. Use this when the stream
+    /// wrapping requires asynchronous setup, such as a TLS handshake.
+    /// </summary>
+    /// <param name="builder">The terminal builder.</param>
+    /// <param name="socketPath">Path to the Unix domain socket to connect to.</param>
+    /// <param name="streamTransform">
+    /// An async function that wraps the raw transport stream.
+    /// The returned stream is used for HMP v1 protocol communication.
+    /// </param>
+    /// <returns>The builder for fluent chaining.</returns>
+    /// <example>
+    /// <code>
+    /// await using var terminal = Hex1bTerminal.CreateBuilder()
+    ///     .WithHmp1UdsClient("/tmp/my-terminal.sock", async stream =>
+    ///     {
+    ///         var sslStream = new SslStream(stream);
+    ///         await sslStream.AuthenticateAsClientAsync("localhost");
+    ///         return sslStream;
+    ///     })
+    ///     .Build();
+    /// </code>
+    /// </example>
+    public static Hex1bTerminalBuilder WithHmp1UdsClient(
+        this Hex1bTerminalBuilder builder,
+        string socketPath,
+        Func<Stream, Task<Stream>> streamTransform)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(socketPath);
+        ArgumentNullException.ThrowIfNull(streamTransform);
+        return builder.WithHmp1Client(async ct =>
+        {
+            var stream = await Hmp1Transports.ConnectUnixSocket(socketPath, ct);
+            return await streamTransform(stream);
+        });
+    }
+
+    private static async IAsyncEnumerable<Stream> TransformStreams(
+        IAsyncEnumerable<Stream> source,
+        Func<Stream, Stream> transform)
+    {
+        await foreach (var stream in source)
+        {
+            yield return transform(stream);
+        }
+    }
+
+    private static async IAsyncEnumerable<Stream> TransformStreamsAsync(
+        IAsyncEnumerable<Stream> source,
+        Func<Stream, Task<Stream>> transform)
+    {
+        await foreach (var stream in source)
+        {
+            yield return await transform(stream);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Adds stream transform overloads to the HMP1 builder extensions and a new **EncryptedMuxerDemo** sample that demonstrates TLS-encrypted terminal muxing.

### Library changes (`Hmp1BuilderExtensions.cs`)

New overloads for `WithHmp1UdsServer` and `WithHmp1UdsClient` accepting stream transform parameters:

- `Func<Stream, Stream>` (sync) — for simple wraps like compression
- `Func<Stream, Task<Stream>>` (async) — for wraps requiring async setup like TLS handshakes

These allow developers to intercept the transport stream before it reaches the HMP1 protocol layer:

```csharp
// Server: TLS-encrypt each accepted client connection
.WithHmp1UdsServer(socketPath, async stream =>
{
    var ssl = new SslStream(stream);
    await ssl.AuthenticateAsServerAsync(cert);
    return ssl;
})

// Client: TLS-wrap the connection
.WithHmp1UdsClient(socketPath, async stream =>
{
    var ssl = new SslStream(stream, false, (_, _, _, _) => true);
    await ssl.AuthenticateAsClientAsync("localhost");
    return ssl;
})
```

### New sample: EncryptedMuxerDemo

A fork of MuxerDemo that encrypts all HMP1 traffic with TLS 1.3:

| File | Purpose |
|------|---------|
| `DemoTls.cs` | Ephemeral self-signed cert generation + SslStream wrappers |
| `EncryptedMuxerServer.cs` | Headless PTY served over TLS-encrypted HMP1 |
| `SessionManager.cs` | Client session lifecycle with TLS connections |
| `SessionManagerApp.cs` | TUI with lock indicators showing encrypted status |
| `Program.cs` | Entry point with `--server` mode |

### Testing

- Verified TLS 1.3 handshake completes successfully
- Verified HMP1 protocol works over the encrypted stream (80x24 terminal)
- Build passes with 0 warnings, 0 errors
