### PR TITLE
Fix #297: restore native cursor after sibling repaint

### DIFF
--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -871,10 +871,11 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
             }
 
             // Render using Surface-based path
+            bool wroteOutput;
             {
                 long renderFrameStart = Stopwatch.GetTimestamp();
                 
-                RenderFrameWithSurface(frameWidth, frameHeight, frameCapabilities);
+                wroteOutput = RenderFrameWithSurface(frameWidth, frameHeight, frameCapabilities);
                 
                 renderTicks = Stopwatch.GetTimestamp() - renderFrameStart;
                 if (_diagnosticTimingEnabled) _diagRenderTicks = renderTicks;
@@ -886,6 +887,18 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
             if (_rootNode != null)
             {
                 ClearDirtyFlags(_rootNode);
+            }
+
+            // Issue #297: When the cursor was intentionally left visible during
+            // render (skipCursorHide for a focused TextBox's native bar cursor),
+            // any cell tokens emitted by RenderFrameWithSurface have moved the
+            // hardware cursor to the last cell write. Invalidate the cached
+            // cursor position so RenderCursor() re-emits a SetCursorPosition for
+            // the focused TextBox even when its desired coordinates are unchanged.
+            if (wroteOutput && skipCursorHide)
+            {
+                _lastRenderedCursorX = -1;
+                _lastRenderedCursorY = -1;
             }
         }
         
@@ -908,7 +921,13 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
     /// <summary>
     /// Renders the frame using Surface-based rendering with efficient diffing.
     /// </summary>
-    private void RenderFrameWithSurface(int width, int height, TerminalCapabilities caps)
+    /// <returns>
+    /// <see langword="true"/> if any output tokens were written to the terminal
+    /// (cell-content diff or KGP placement changes); otherwise <see langword="false"/>.
+    /// Callers use this to know whether the hardware cursor may have been moved by
+    /// the emitted tokens.
+    /// </returns>
+    private bool RenderFrameWithSurface(int width, int height, TerminalCapabilities caps)
     {
         _surfacePool?.NextFrame();
         
@@ -1051,8 +1070,9 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                 $"trackerImages={_kgpTracker.ActivePlacementCount} trackerFragments={_kgpTracker.ActiveFragmentCount}");
         }
         var hasKgpChanges = kgpBefore.Count > 0 || kgpAfter.Count > 0;
+        var wroteOutput = !diff.IsEmpty || hasKgpChanges;
         
-        if (!diff.IsEmpty || hasKgpChanges)
+        if (wroteOutput)
         {
             // Generate text/sixel tokens (KGP emission skipped — handled by tracker above)
             var tokensStart = Stopwatch.GetTimestamp();
@@ -1093,6 +1113,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         }
         
         _isFirstFrame = false;
+        return wroteOutput;
     }
     
     /// <summary>

--- a/tests/Hex1b.Tests/TextBoxNativeCursorRestoreTests.cs
+++ b/tests/Hex1b.Tests/TextBoxNativeCursorRestoreTests.cs
@@ -1,0 +1,75 @@
+using Hex1b.Input;
+using Hex1b.Widgets;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Regression tests for issue #297 — when a focused TextBox uses the native terminal
+/// cursor and a sibling widget repaints in the same frame, the hardware cursor must
+/// still be restored to the TextBox even though the TextBox's own cursor coordinates
+/// did not change since the previous frame.
+/// </summary>
+public class TextBoxNativeCursorRestoreTests
+{
+    [Fact]
+    public async Task FocusedTextBox_AfterSiblingRepaint_NativeCursorReturnsToTextBox()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithHeadless()
+            .WithDimensions(40, 6)
+            .Build();
+
+        // Activity text is mutated between frames. Both values are the same width
+        // so the only cell change between frames is on the activity row — isolating
+        // the cursor-restoration behavior from any layout shift.
+        var activity = "Loading...";
+
+        using var app = new Hex1bApp(
+            ctx => Task.FromResult<Hex1bWidget>(
+                new VStackWidget(new Hex1bWidget[]
+                {
+                    new TextBlockWidget(activity),
+                    new TextBoxWidget("")
+                })),
+            new Hex1bAppOptions { WorkloadAdapter = workload });
+
+        var runTask = app.RunAsync(TestContext.Current.CancellationToken);
+
+        // Initial render: TextBox is focused (only focusable in tree) and has
+        // emitted its native bar cursor.
+        var snapshot1 = await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.ContainsText("Loading..."), TimeSpan.FromSeconds(5), "initial render")
+            .Capture("snapshot1")
+            .Build()
+            .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
+
+        // Sanity: the cursor should be on the TextBox's row (row 1 of the VStack,
+        // i.e. the second visible row), not on the activity row (row 0).
+        // The exact column depends on the default theme's left bracket width but
+        // the row should be 1.
+        Assert.Equal(1, snapshot1.CursorY);
+
+        // Mutate the activity row (same width) and force a re-render.
+        activity = "Loaded....";
+        app.Invalidate();
+
+        var snapshot2 = await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.ContainsText("Loaded...."), TimeSpan.FromSeconds(5), "after activity mutation")
+            .Capture("snapshot2")
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
+
+        await runTask;
+
+        // The TextBox cursor coordinates have not changed between frames, so
+        // RenderCursor()'s early-return optimization kicks in. The bug is that
+        // RenderFrameWithSurface() rewrote cells on the activity row (row 0),
+        // moving the hardware cursor there. Without the fix, snapshot2.CursorY
+        // is 0 (the activity row); with the fix it's still 1 (the TextBox row).
+        Assert.Equal(snapshot1.CursorY, snapshot2.CursorY);
+        Assert.Equal(snapshot1.CursorX, snapshot2.CursorX);
+    }
+}


### PR DESCRIPTION
Fixes #297.

## Problem

A focused `TextBox` uses the native terminal bar cursor. `Hex1bApp` keeps it visible during render to avoid flicker (`skipCursorHide`), but every cell token written by `RenderFrameWithSurface` moves the hardware cursor. `RenderCursor()` then early-returned because the desired TextBox cursor coordinates equalled the cached `_lastRenderedCursorX/Y`, leaving the bar cursor stranded at the last cell write — typically on a sibling activity row.

## Fix

- `RenderFrameWithSurface` now returns `bool wroteOutput = !diff.IsEmpty || hasKgpChanges`.
- When the render emitted tokens **and** `skipCursorHide` was true (the only buggy path — `TerminalNode` and mouse paths already invalidate the cache by hiding the cursor), the caller invalidates `_lastRenderedCursorX/Y = -1` so `RenderCursor()` re-emits `SetCursorPosition` for the focused TextBox even when its coordinates are unchanged.
- Position-only invalidation; shape/visibility/node fields are preserved so the existing flicker-reduction optimization still applies on the unaffected paths.

## Test

New regression test `TextBoxNativeCursorRestoreTests.FocusedTextBox_AfterSiblingRepaint_NativeCursorReturnsToTextBox`:

1. Builds `VStack { TextBlock(activity), TextBox("") }` on a 40x6 headless `Hex1bTerminal`.
2. After initial render, captures `snapshot1` and asserts the cursor sits on the TextBox row (`CursorY == 1`).
3. Mutates `activity` from `""Loading...""` to `""Loaded....""` (same width — isolates cursor restoration from layout shifts), calls `app.Invalidate()`, waits for the new text to appear.
4. Captures `snapshot2` and asserts `snapshot2.CursorX/Y == snapshot1.CursorX/Y`.

Pre-fix: `Expected: 1, Actual: 0` (cursor stranded on activity row).
Post-fix: passes.

## Test results

- `Hex1b.Tests`: 7328 passed, 0 failed (31 skipped, unchanged)
- `Hex1b.McpServer.Tests`: 6 passed
- `Hex1b.Tool.Tests`: 58 passed
