### PR TITLE
Fix mouse cursor flicker via DEC mode 2026 synchronized update

### DIFF
--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -67,6 +67,17 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
     private CursorShape _lastRenderedCursorShape = CursorShape.Default;
     private bool _lastRenderedCursorVisible = false;
     private Hex1bNode? _lastRenderedCursorNode;
+
+    // DEC private mode 2026 (Synchronized Update Mode) sequences. Tells supporting
+    // terminals (Windows Terminal, iTerm2, kitty, etc.) to buffer output until the
+    // matching end sequence and then paint atomically. Used to wrap each render
+    // frame so the user never sees the intermediate hide-cursor / cell-write /
+    // show-cursor states that would otherwise produce visible flicker — most
+    // notably the mouse pointer blinking at high redraw rates (e.g. animated
+    // EffectPanel.RedrawAfter(50)). Terminals that don't recognize mode 2026
+    // simply ignore these sequences.
+    private const string SyncUpdateBegin = "\x1b[?2026h";
+    private const string SyncUpdateEnd = "\x1b[?2026l";
     
     // Click tracking for double/triple click detection
     private DateTime _lastClickTime;
@@ -856,66 +867,91 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         long renderTicks = 0;
         
         // Step 6.5-9: Only do render output if something actually changed
+        //
+        // The entire frame's terminal output (hide cursor → cell writes → cursor restore
+        // via RenderCursor) is wrapped in DEC private mode 2026 (Synchronized Update Mode).
+        // Compatible terminals buffer everything between begin/end and paint atomically,
+        // so the user never sees the intermediate "cursor hidden" or "cursor at last cell
+        // write" states. This is what prevents the mouse pointer from blinking at the
+        // redraw rate during animated content (e.g. EffectPanel.RedrawAfter(50)).
+        // Terminals that don't support mode 2026 ignore the sequences.
         if (needsRender)
         {
-            // Hide cursor during rendering to prevent flicker.
-            // When a TextBoxNode's native cursor is active, skip hiding — the hardware
-            // bar cursor doesn't interfere with cell content rendering, and the
-            // hide/show cycle on every frame causes visible flicker during mouse movement.
-            var skipCursorHide = _lastRenderedCursorVisible && _lastRenderedCursorNode is TextBoxNode;
-            if (!skipCursorHide && (_mouseEnabled || _lastRenderedCursorVisible))
+            _context.Write(SyncUpdateBegin);
+        }
+        try
+        {
+            if (needsRender)
             {
-                _context.Write("\x1b[?25l"); // Hide cursor
-                // Reset so RenderCursor() knows it must re-show the cursor
-                _lastRenderedCursorVisible = false;
-            }
+                // Hide cursor during rendering to prevent flicker.
+                // When a TextBoxNode's native cursor is active, skip hiding — the hardware
+                // bar cursor doesn't interfere with cell content rendering, and the
+                // hide/show cycle on every frame causes visible flicker during mouse movement.
+                var skipCursorHide = _lastRenderedCursorVisible && _lastRenderedCursorNode is TextBoxNode;
+                if (!skipCursorHide && (_mouseEnabled || _lastRenderedCursorVisible))
+                {
+                    _context.Write("\x1b[?25l"); // Hide cursor
+                    // Reset so RenderCursor() knows it must re-show the cursor
+                    _lastRenderedCursorVisible = false;
+                }
 
-            // Render using Surface-based path
-            bool wroteOutput;
-            {
-                long renderFrameStart = Stopwatch.GetTimestamp();
+                // Render using Surface-based path
+                bool wroteOutput;
+                {
+                    long renderFrameStart = Stopwatch.GetTimestamp();
+                    
+                    wroteOutput = RenderFrameWithSurface(frameWidth, frameHeight, frameCapabilities);
+                    
+                    renderTicks = Stopwatch.GetTimestamp() - renderFrameStart;
+                    if (_diagnosticTimingEnabled) _diagRenderTicks = renderTicks;
+                }
                 
-                wroteOutput = RenderFrameWithSurface(frameWidth, frameHeight, frameCapabilities);
-                
-                renderTicks = Stopwatch.GetTimestamp() - renderFrameStart;
-                if (_diagnosticTimingEnabled) _diagRenderTicks = renderTicks;
+                // Clear dirty flags on all nodes (they've been rendered)
+                // Nodes with async content (like TerminalNode) may override ClearDirty()
+                // to keep themselves dirty if new content arrived during the render frame.
+                if (_rootNode != null)
+                {
+                    ClearDirtyFlags(_rootNode);
+                }
+
+                // Issue #297: When the cursor was intentionally left visible during
+                // render (skipCursorHide for a focused TextBox's native bar cursor),
+                // any cell tokens emitted by RenderFrameWithSurface have moved the
+                // hardware cursor to the last cell write. Invalidate the cached
+                // cursor position so RenderCursor() re-emits a SetCursorPosition for
+                // the focused TextBox even when its desired coordinates are unchanged.
+                if (wroteOutput && skipCursorHide)
+                {
+                    _lastRenderedCursorX = -1;
+                    _lastRenderedCursorY = -1;
+                }
             }
             
-            // Clear dirty flags on all nodes (they've been rendered)
-            // Nodes with async content (like TerminalNode) may override ClearDirty()
-            // to keep themselves dirty if new content arrived during the render frame.
-            if (_rootNode != null)
+            // Record metrics for this frame
+            var freq = (double)Stopwatch.Frequency;
+            _metrics.FrameBuildDuration.Record(buildTicks * 1000.0 / freq);
+            _metrics.FrameReconcileDuration.Record(reconcileTicks * 1000.0 / freq);
+            if (needsRender)
             {
-                ClearDirtyFlags(_rootNode);
+                _metrics.FrameRenderDuration.Record(renderTicks * 1000.0 / freq);
             }
-
-            // Issue #297: When the cursor was intentionally left visible during
-            // render (skipCursorHide for a focused TextBox's native bar cursor),
-            // any cell tokens emitted by RenderFrameWithSurface have moved the
-            // hardware cursor to the last cell write. Invalidate the cached
-            // cursor position so RenderCursor() re-emits a SetCursorPosition for
-            // the focused TextBox even when its desired coordinates are unchanged.
-            if (wroteOutput && skipCursorHide)
-            {
-                _lastRenderedCursorX = -1;
-                _lastRenderedCursorY = -1;
-            }
+            _metrics.FrameDuration.Record((Stopwatch.GetTimestamp() - frameStart) * 1000.0 / freq);
+            _metrics.FrameCount.Add(1);
+            
+            // Render hardware cursor - for focused TerminalNode uses child's cursor,
+            // otherwise uses mouse position if mouse cursor is enabled. When inside
+            // a synchronized update (needsRender), the cursor restore is part of the
+            // atomic frame, so the user never sees the cursor at the last cell-write
+            // position.
+            RenderCursor();
         }
-        
-        // Record metrics for this frame
-        var freq = (double)Stopwatch.Frequency;
-        _metrics.FrameBuildDuration.Record(buildTicks * 1000.0 / freq);
-        _metrics.FrameReconcileDuration.Record(reconcileTicks * 1000.0 / freq);
-        if (needsRender)
+        finally
         {
-            _metrics.FrameRenderDuration.Record(renderTicks * 1000.0 / freq);
+            if (needsRender)
+            {
+                _context.Write(SyncUpdateEnd);
+            }
         }
-        _metrics.FrameDuration.Record((Stopwatch.GetTimestamp() - frameStart) * 1000.0 / freq);
-        _metrics.FrameCount.Add(1);
-        
-        // Render hardware cursor - for focused TerminalNode uses child's cursor,
-        // otherwise uses mouse position if mouse cursor is enabled
-        RenderCursor();
     }
     
     /// <summary>

--- a/tests/Hex1b.Tests/KgpOcclusionIntegrationTests.cs
+++ b/tests/Hex1b.Tests/KgpOcclusionIntegrationTests.cs
@@ -904,35 +904,36 @@ public class KgpOcclusionIntegrationTests
 
         await workload.ResizeAsync(60, 19, TestContext.Current.CancellationToken);
 
-        var deleteOutput = await workload.ReadOutputAsync(TestContext.Current.CancellationToken);
-        var clearOutput = await workload.ReadOutputAsync(TestContext.Current.CancellationToken);
-        var postResizeOutput = await ReadNextNonEmptyOutputAsync(workload, TestContext.Current.CancellationToken);
+        // The render frame is now wrapped in DEC mode 2026 (Synchronized Update Mode),
+        // so the first chunks after resize are sync-update / cursor-visibility
+        // sequences. Skip past those and find the chunks that contain the KGP
+        // delete and the text-cell clear. The ordering invariant the test cares
+        // about — KGP delete BEFORE text clear BEFORE post-resize content — is
+        // still preserved within the synchronized region.
+        var deleteOutput = await ReadNextOutputContainingAsync(
+            workload, "\x1b_Ga=d,d=a,q=2\x1b\\", TestContext.Current.CancellationToken);
+        var clearOutput = await ReadNextOutputContainingAsync(
+            workload, "\x1b[0m\x1b[2J", TestContext.Current.CancellationToken);
 
         var deleteText = System.Text.Encoding.UTF8.GetString(deleteOutput.Span);
         var clearText = System.Text.Encoding.UTF8.GetString(clearOutput.Span);
-        var postResizeText = System.Text.Encoding.UTF8.GetString(postResizeOutput.Span);
 
-        string retransmitText;
-        if (postResizeText.Contains("\x1b_Ga=t,", StringComparison.Ordinal))
-        {
-            retransmitText = postResizeText;
-        }
-        else
-        {
-            Assert.DoesNotContain("\x1b_Ga=t,", postResizeText);
-            Assert.DoesNotContain("\x1b_Ga=p,", postResizeText);
-
-            var retransmitOutput = await ReadNextNonEmptyOutputAsync(workload, TestContext.Current.CancellationToken);
-            retransmitText = System.Text.Encoding.UTF8.GetString(retransmitOutput.Span);
-        }
+        // Accumulate everything emitted after the clear until the follow-up
+        // retransmit frame has produced all three KGP markers (transmit, place,
+        // delete-by-id). Sync-update boundaries fragment the output so neither
+        // a single chunk nor a fixed chunk count is reliable here.
+        var afterClearText = await ReadAccumulatedOutputUntilAllPresentAsync(
+            workload,
+            new[] { "\x1b_Ga=t,", "\x1b_Ga=p,", $"\x1b_Ga=d,d=I,i={initialImageId},q=2\x1b\\" },
+            TestContext.Current.CancellationToken);
 
         Assert.Equal("\x1b_Ga=d,d=a,q=2\x1b\\", deleteText);
         Assert.Equal("\x1b[0m\x1b[2J", clearText);
-        Assert.DoesNotContain("\x1b_Ga=d,d=i,", postResizeText);
-        Assert.Contains("\x1b_Ga=t,", retransmitText);
-        Assert.Contains("\x1b_Ga=p,", retransmitText);
-        Assert.Contains($"\x1b_Ga=d,d=I,i={initialImageId},q=2\x1b\\", retransmitText);
-        Assert.NotEqual(initialImageId, ExtractFirstTransmitImageId(retransmitText));
+        Assert.DoesNotContain("\x1b_Ga=d,d=i,", afterClearText);
+        Assert.Contains("\x1b_Ga=t,", afterClearText);
+        Assert.Contains("\x1b_Ga=p,", afterClearText);
+        Assert.Contains($"\x1b_Ga=d,d=I,i={initialImageId},q=2\x1b\\", afterClearText);
+        Assert.NotEqual(initialImageId, ExtractFirstTransmitImageId(afterClearText));
 
         app.RequestStop();
         await runTask;
@@ -961,6 +962,40 @@ public class KgpOcclusionIntegrationTests
             var text = System.Text.Encoding.UTF8.GetString(output.Span);
             if (text.Contains(expectedText, StringComparison.Ordinal))
                 return output;
+        }
+    }
+
+    /// <summary>
+    /// Reads workload output, accumulating chunks into a single string, until
+    /// every text in <paramref name="expectedTexts"/> has been observed in the
+    /// accumulated stream. Use this when an interesting sequence may be split
+    /// across multiple writes (e.g. when a render frame is wrapped in
+    /// synchronized-update sequences that produce extra chunk boundaries).
+    /// </summary>
+    private static async Task<string> ReadAccumulatedOutputUntilAllPresentAsync(
+        Hex1bAppWorkloadAdapter workload,
+        string[] expectedTexts,
+        CancellationToken cancellationToken)
+    {
+        var sb = new System.Text.StringBuilder();
+        while (true)
+        {
+            var output = await workload.ReadOutputAsync(cancellationToken);
+            if (output.IsEmpty) continue;
+
+            sb.Append(System.Text.Encoding.UTF8.GetString(output.Span));
+            var current = sb.ToString();
+            var allPresent = true;
+            for (var i = 0; i < expectedTexts.Length; i++)
+            {
+                if (!current.Contains(expectedTexts[i], StringComparison.Ordinal))
+                {
+                    allPresent = false;
+                    break;
+                }
+            }
+            if (allPresent)
+                return current;
         }
     }
 

--- a/tests/Hex1b.Tests/MouseCursorFlickerTests.cs
+++ b/tests/Hex1b.Tests/MouseCursorFlickerTests.cs
@@ -1,0 +1,208 @@
+using Hex1b.Input;
+using Hex1b.Tokens;
+using Hex1b.Widgets;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Regression tests for mouse cursor flicker during animated redraws.
+///
+/// When mouse support is enabled and an animation drives frequent redraws
+/// (for example <c>EffectPanel.RedrawAfter(50)</c> at 20 fps), each render
+/// frame emits <c>?25l</c> (hide cursor) before cell writes and
+/// <c>SetCursorPosition + ?25h + cursor-shape</c> after. Without atomic frame
+/// commits the terminal renders the intermediate "cursor hidden" / "cursor at
+/// last cell write" states, producing visible blinking of the mouse pointer.
+///
+/// The fix wraps the entire render frame's terminal output in DEC private mode
+/// 2026 (Synchronized Update Mode). Compatible terminals buffer everything
+/// between <c>?2026h</c> and <c>?2026l</c> and paint atomically; non-supporting
+/// terminals ignore the sequences.
+/// </summary>
+public class MouseCursorFlickerTests
+{
+    /// <summary>
+    /// Workload filter that records the order of cursor-related private-mode
+    /// tokens emitted by the workload toward the terminal.
+    /// </summary>
+    private sealed class CursorTokenRecorder : IHex1bTerminalWorkloadFilter
+    {
+        private readonly object _lock = new();
+        private readonly List<PrivateModeToken> _tokens = new();
+
+        public IReadOnlyList<PrivateModeToken> Snapshot()
+        {
+            lock (_lock)
+            {
+                return _tokens.ToArray();
+            }
+        }
+
+        public void Reset()
+        {
+            lock (_lock)
+            {
+                _tokens.Clear();
+            }
+        }
+
+        public ValueTask OnSessionStartAsync(int width, int height, DateTimeOffset timestamp, CancellationToken ct = default) => default;
+        public ValueTask OnFrameCompleteAsync(TimeSpan elapsed, CancellationToken ct = default) => default;
+        public ValueTask OnInputAsync(IReadOnlyList<AnsiToken> tokens, TimeSpan elapsed, CancellationToken ct = default) => default;
+        public ValueTask OnResizeAsync(int width, int height, TimeSpan elapsed, CancellationToken ct = default) => default;
+        public ValueTask OnSessionEndAsync(TimeSpan elapsed, CancellationToken ct = default) => default;
+
+        public ValueTask OnOutputAsync(IReadOnlyList<AnsiToken> tokens, TimeSpan elapsed, CancellationToken ct = default)
+        {
+            lock (_lock)
+            {
+                for (var i = 0; i < tokens.Count; i++)
+                {
+                    if (tokens[i] is PrivateModeToken pm && (pm.Mode == 25 || pm.Mode == 2026))
+                    {
+                        _tokens.Add(pm);
+                    }
+                }
+            }
+            return default;
+        }
+    }
+
+    [Fact]
+    public async Task RenderFrame_WithMouseEnabled_WrapsHideShowInSynchronizedUpdate()
+    {
+        var recorder = new CursorTokenRecorder();
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithHeadless()
+            .WithDimensions(40, 6)
+            .AddWorkloadFilter(recorder)
+            .Build();
+
+        var counter = 0;
+
+        using var app = new Hex1bApp(
+            ctx => Task.FromResult<Hex1bWidget>(
+                new TextBlockWidget($"tick {counter}")),
+            new Hex1bAppOptions { WorkloadAdapter = workload, EnableMouse = true });
+
+        var runTask = app.RunAsync(TestContext.Current.CancellationToken);
+
+        try
+        {
+            // Initial render and put the mouse pointer on-screen so it owns the cursor.
+            await new Hex1bTerminalInputSequenceBuilder()
+                .WaitUntil(s => s.ContainsText("tick 0"), TimeSpan.FromSeconds(5), "initial render")
+                .Build()
+                .ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+            await terminal.SendEventAsync(new Hex1bMouseEvent(MouseButton.None, MouseAction.Move, 12, 3, Hex1bModifiers.None));
+
+            await new Hex1bTerminalInputSequenceBuilder()
+                .WaitUntil(s => s.CursorX == 12 && s.CursorY == 3, TimeSpan.FromSeconds(5), "cursor at mouse position")
+                .Build()
+                .ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+            // Reset the recorder, then drive an invalidate cycle that produces
+            // a render frame.
+            recorder.Reset();
+            counter = 1;
+            app.Invalidate();
+
+            await new Hex1bTerminalInputSequenceBuilder()
+                .WaitUntil(s => s.ContainsText("tick 1"), TimeSpan.FromSeconds(5), "after invalidate")
+                .Build()
+                .ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+            var tokens = recorder.Snapshot();
+
+            // The render frame must be wrapped in synchronized-update sequences.
+            var begin = tokens.Select((t, i) => (t, i)).FirstOrDefault(x => x.t.Mode == 2026 && x.t.Enable);
+            var end = tokens.Select((t, i) => (t, i)).LastOrDefault(x => x.t.Mode == 2026 && !x.t.Enable);
+
+            Assert.NotNull(begin.t);
+            Assert.NotNull(end.t);
+            Assert.True(begin.i < end.i, "Begin sync-update token must precede end token.");
+
+            // Every hide/show cursor token between begin and end must lie inside
+            // the synchronized region — that is what makes the hide → cells →
+            // show cycle invisible to the user.
+            for (var i = 0; i < tokens.Count; i++)
+            {
+                if (tokens[i].Mode != 25) continue;
+                Assert.True(
+                    i > begin.i && i < end.i,
+                    $"Cursor visibility token at index {i} (Enable={tokens[i].Enable}) must be inside the synchronized-update region [{begin.i}..{end.i}], not outside it.");
+            }
+        }
+        finally
+        {
+            await new Hex1bTerminalInputSequenceBuilder()
+                .Ctrl().Key(Hex1bKey.C)
+                .Build()
+                .ApplyAsync(terminal, TestContext.Current.CancellationToken);
+            await runTask;
+        }
+    }
+
+    [Fact]
+    public async Task RenderFrame_SynchronizedUpdate_BeginAndEndAreBalanced()
+    {
+        var recorder = new CursorTokenRecorder();
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithHeadless()
+            .WithDimensions(40, 6)
+            .AddWorkloadFilter(recorder)
+            .Build();
+
+        var counter = 0;
+
+        using var app = new Hex1bApp(
+            ctx => Task.FromResult<Hex1bWidget>(
+                new TextBlockWidget($"tick {counter}")),
+            new Hex1bAppOptions { WorkloadAdapter = workload, EnableMouse = true });
+
+        var runTask = app.RunAsync(TestContext.Current.CancellationToken);
+
+        try
+        {
+            await new Hex1bTerminalInputSequenceBuilder()
+                .WaitUntil(s => s.ContainsText("tick 0"), TimeSpan.FromSeconds(5), "initial render")
+                .Build()
+                .ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+            recorder.Reset();
+
+            // Drive several render frames.
+            for (var i = 1; i <= 3; i++)
+            {
+                counter = i;
+                app.Invalidate();
+                await new Hex1bTerminalInputSequenceBuilder()
+                    .WaitUntil(s => s.ContainsText($"tick {i}"), TimeSpan.FromSeconds(5), $"frame {i}")
+                    .Build()
+                    .ApplyAsync(terminal, TestContext.Current.CancellationToken);
+            }
+
+            var tokens = recorder.Snapshot();
+            var beginCount = tokens.Count(t => t.Mode == 2026 && t.Enable);
+            var endCount = tokens.Count(t => t.Mode == 2026 && !t.Enable);
+
+            // Each render frame must emit a balanced begin/end pair so the
+            // terminal never gets stuck buffering output indefinitely.
+            Assert.Equal(beginCount, endCount);
+            Assert.True(beginCount >= 3, $"Expected at least 3 sync-update frames, got {beginCount}.");
+        }
+        finally
+        {
+            await new Hex1bTerminalInputSequenceBuilder()
+                .Ctrl().Key(Hex1bKey.C)
+                .Build()
+                .ApplyAsync(terminal, TestContext.Current.CancellationToken);
+            await runTask;
+        }
+    }
+}


### PR DESCRIPTION
## Problem

When an animated `EffectPanel` is on screen (e.g. `RedrawAfter(50)` driving a 20 fps redraw), the mouse cursor visibly flickers. Each render frame emits `\x1b[?25l` (hide cursor) → cell writes → `SetCursorPosition + \x1b[?25h + cursor-shape` (re-show), and on a high-redraw-rate frame the terminal renders the intermediate "cursor hidden" state before the cursor is restored — visible blink.

Repro: `samples/FigletTextDemo` (or any sample with `WithMouse()` + an animated `EffectPanel`). Move the mouse over the effect panel; the cursor blinks at the redraw rate.

## Fix

Wrap the entire render-frame commit (including `RenderCursor()`) in DEC private mode 2026 (Synchronized Update Mode):

- `\x1b[?2026h` before the first cell write
- `\x1b[?2026l` after the cursor is repositioned and re-shown
- `try { ... } finally { ... }` so a renderer exception cannot leave the terminal stuck in buffering mode

Compatible terminals (Windows Terminal, iTerm2, kitty, …) buffer everything between begin/end and paint atomically — the user never sees the intermediate "cursor hidden" state. Non-supporting terminals ignore the sequences (no behavioural regression).

The wrap is gated on `if (needsRender)` so non-rendering frames don't pay the cost.

## Why DEC 2026 and not "skip the cursor hide for mouse-pointer mode"

That was tried first. Skipping the pre-render hide leaves the cursor visible during cell writes — and each cell write moves the hardware cursor as a side effect — so the mouse cursor visibly sweeps through every changed cell before `RenderCursor()` snaps it back. DEC 2026 is the right primitive: atomic frame commit at the protocol level.

## Notes

- `Hex1bRenderContext.BeginFrame()`/`EndFrame()` already defined the 2026 sequences (lines 158-181) but **were never called by anything in the codebase**. Sync-update mode was implemented but completely unused. This PR emits the sequences directly from `Hex1bApp` rather than going through `BeginFrame()` to avoid also emitting unwanted APC frame markers.
- `KgpOcclusionIntegrationTests.ResizeFrame_WithKgp_DeletesPlacementsBeforeClear...` was reading exact-positioned chunks via `workload.ReadOutputAsync()` and asserting `Equal` per chunk; the new sync-update sequences shift chunk boundaries. Refactored that test to be order-tolerant via a new `ReadAccumulatedOutputUntilAllPresentAsync` helper. The KGP delete-before-clear ordering invariant is still preserved within the synchronized region.

## Tests

New `tests/Hex1b.Tests/MouseCursorFlickerTests.cs`:
1. `RenderFrame_WithMouseEnabled_WrapsHideShowInSynchronizedUpdate` — every cursor-visibility token sits inside a 2026 begin/end pair.
2. `RenderFrame_SynchronizedUpdate_BeginAndEndAreBalanced` — begin/end pairs balance across multiple invalidate cycles.

Both verified to fail without the fix (stash + rerun).

Full suite: 7,330 passed, 31 skipped, 0 failed on this branch.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
