### PR TITLE
Fix #296: ScrollPanel global page actions + public scroll API

### DIFF
--- a/samples/ScrollPanelDemo/Program.cs
+++ b/samples/ScrollPanelDemo/Program.cs
@@ -1,0 +1,179 @@
+// ScrollPanelDemo
+//
+// Illustrates the behavioural changes from issue #296:
+//   1. Global PageUp/PageDown can scroll a ScrollPanel even when focus is on
+//      a sibling widget (e.g. a TextBox). Before the fix, the panel's
+//      handlers short-circuited unless the panel itself was focused.
+//   2. PageUp/PageDown bubbles up from a focusable descendant of the panel
+//      (e.g. a Button rendered inside the scrollable content).
+//   3. The new public imperative scroll API on ScrollPanelNode:
+//        node.Offset = N            (settable property, mirrors ListNode.SelectedIndex)
+//        node.ScrollByPage(±1)      (page jump)
+//        node.ScrollBy(±N)          (relative offset, overflow-safe)
+//        node.ScrollToTop() / .ScrollToBottom()
+//      These methods are state mutations and intentionally do not fire OnScroll —
+//      same convention as ListNode.SelectedIndex setter.
+//
+// The OnScroll handler captures the ScrollPanelNode reference on first fire,
+// after which the imperative buttons (Top / Page- / Page+ / Bottom / Offset=25)
+// can call into the public API. Until that first scroll, the buttons display a
+// hint instead.
+//
+// Run with: dotnet run --project samples/ScrollPanelDemo
+
+using Hex1b;
+using Hex1b.Input;
+using Hex1b.Nodes;
+using Hex1b.Widgets;
+
+ScrollPanelNode? panelNode = null;
+var typedText = "Type here while focused…";
+var lastAction = "(none yet)";
+var currentOffset = 0;
+var maxOffset = 0;
+var viewportSize = 0;
+
+var items = Enumerable.Range(1, 60)
+    .Select(i => $"Item {i:00} ─ scroll me with PageUp/PageDown, arrows, or the buttons below")
+    .ToList();
+
+await using var terminal = Hex1bTerminal.CreateBuilder()
+    .WithHex1bApp((app, options) => ctx =>
+    {
+        var status = panelNode is null
+            ? "Status: (scroll the panel once — any arrow or PageUp/Dn — to enable imperative buttons)"
+            : $"Status: Offset={currentOffset}/{maxOffset}   Viewport={viewportSize}   " +
+              $"Progress={(maxOffset > 0 ? currentOffset * 100 / maxOffset : 0),3}%   " +
+              $"AtTop={(currentOffset <= 0).ToString().ToLowerInvariant(),-5}   " +
+              $"AtBottom={(currentOffset >= maxOffset).ToString().ToLowerInvariant(),-5}";
+
+        return ctx.VStack(v => [
+            v.Text("ScrollPanelDemo — issue #296 fixes (global page actions + imperative API)"),
+            v.Separator(),
+
+            v.Text("Scenario A — Global PageUp/PageDown from a focused sibling:"),
+            v.Text("  Focus the textbox below and type. Press PageUp/PageDown — the panel scrolls"),
+            v.Text("  even though the textbox is focused. Before the fix this was a no-op."),
+            v.TextBox(typedText).OnTextChanged(e => typedText = e.NewText),
+            v.Text(""),
+
+            v.Text("Scenario B — Bubble-up from a focusable descendant:"),
+            v.Text("  Tab into a ★ button inside the panel, then press PageUp/PageDown."),
+            v.Text("  The binding bubbles up from the button to the panel (no IsFocused guard)."),
+
+            v.VScrollPanel(p => BuildScrollItems(p, items, label => lastAction = label))
+                .WithInputBindings(b =>
+                {
+                    // Promote PageUp/PageDown to global so they fire from anywhere — issue #296.
+                    b.Remove(ScrollPanelWidget.PageUpAction);
+                    b.Remove(ScrollPanelWidget.PageDownAction);
+                    b.Key(Hex1bKey.PageUp).Global().Triggers(ScrollPanelWidget.PageUpAction);
+                    b.Key(Hex1bKey.PageDown).Global().Triggers(ScrollPanelWidget.PageDownAction);
+                })
+                .OnScroll(e =>
+                {
+                    panelNode = e.Node;
+                    currentOffset = e.Offset;
+                    maxOffset = e.MaxOffset;
+                    viewportSize = e.ViewportSize;
+                    lastAction = $"OnScroll fired: {e.PreviousOffset} → {e.Offset} (binding-driven)";
+                })
+                .FixedHeight(12),
+            v.Text(""),
+
+            v.Text("Scenario C — Imperative scroll API (public ScrollPanelNode methods):"),
+            v.Text("  These click handlers call into the new public API directly. They do NOT"),
+            v.Text("  fire OnScroll (mirrors ListNode.SelectedIndex setter convention)."),
+            v.HStack(h => [
+                h.Button("[ Top ]").OnClick(_ =>
+                {
+                    panelNode?.ScrollToTop();
+                    SyncStatus();
+                    lastAction = "panelNode.ScrollToTop()";
+                }),
+                h.Text(" "),
+                h.Button("[ Page- ]").OnClick(_ =>
+                {
+                    panelNode?.ScrollByPage(-1);
+                    SyncStatus();
+                    lastAction = "panelNode.ScrollByPage(-1)";
+                }),
+                h.Text(" "),
+                h.Button("[ Page+ ]").OnClick(_ =>
+                {
+                    panelNode?.ScrollByPage(+1);
+                    SyncStatus();
+                    lastAction = "panelNode.ScrollByPage(+1)";
+                }),
+                h.Text(" "),
+                h.Button("[ Bottom ]").OnClick(_ =>
+                {
+                    panelNode?.ScrollToBottom();
+                    SyncStatus();
+                    lastAction = "panelNode.ScrollToBottom()";
+                }),
+                h.Text(" "),
+                h.Button("[ Offset=25 ]").OnClick(_ =>
+                {
+                    if (panelNode is not null)
+                    {
+                        panelNode.Offset = 25;
+                        SyncStatus();
+                        lastAction = "panelNode.Offset = 25 (setter)";
+                    }
+                }),
+                h.Text(" "),
+                h.Button("[ Bump +5 ]").OnClick(_ =>
+                {
+                    panelNode?.ScrollBy(+5);
+                    SyncStatus();
+                    lastAction = "panelNode.ScrollBy(+5)";
+                }),
+            ]),
+
+            v.Separator(),
+            v.Text(status),
+            v.Text($"Last action: {lastAction}"),
+            v.Text(""),
+            v.Text("Tab / Shift+Tab to move focus.   Ctrl+Q to quit.")
+        ])
+        .WithInputBindings(b =>
+        {
+            b.Ctrl().Key(Hex1bKey.Q).Action(c => { c.RequestStop(); return Task.CompletedTask; }, "Quit");
+        });
+
+        // Programmatic mutations don't fire OnScroll, so we sync the displayed
+        // status manually after each imperative call.
+        void SyncStatus()
+        {
+            if (panelNode is null) return;
+            currentOffset = panelNode.Offset;
+            maxOffset = panelNode.MaxOffset;
+            viewportSize = panelNode.ViewportSize;
+        }
+    })
+    .WithMouse()
+    .Build();
+
+await terminal.RunAsync();
+
+// Builds the scrollable content: text rows interleaved with focusable ★ buttons
+// at item 10/25/40 to demonstrate Scenario B (bubble-up from descendant).
+static Hex1bWidget[] BuildScrollItems(
+    WidgetContext<VStackWidget> ctx,
+    IReadOnlyList<string> items,
+    Action<string> setLastAction)
+{
+    var widgets = new List<Hex1bWidget>(capacity: items.Count + 4);
+    for (var i = 0; i < items.Count; i++)
+    {
+        widgets.Add(ctx.Text(items[i]));
+        if (i is 9 or 24 or 39)
+        {
+            var captured = i + 1;
+            widgets.Add(ctx.Button($"  ★ Focusable button after item {captured} — Tab here, then PageUp/PageDown")
+                .OnClick(_ => setLastAction($"Clicked ★ button after item {captured}")));
+        }
+    }
+    return widgets.ToArray();
+}

--- a/samples/ScrollPanelDemo/ScrollPanelDemo.csproj
+++ b/samples/ScrollPanelDemo/ScrollPanelDemo.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <PublishAot>true</PublishAot>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Hex1b/Hex1b.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Hex1b/Nodes/ScrollPanelNode.cs
+++ b/src/Hex1b/Nodes/ScrollPanelNode.cs
@@ -92,12 +92,6 @@ public sealed class ScrollPanelNode : Hex1bNode, ILayoutProvider
     /// Set during reconciliation from the ScrollPanelWidget's ScrollHandler.
     /// </summary>
     internal Func<InputBindingActionContext, int, int, int, int, Task>? ScrollAction { get; set; }
-    
-    /// <summary>
-    /// Context for firing scroll events when not triggered by user input.
-    /// </summary>
-    private InputBindingActionContext? _pendingEventContext;
-    
     /// <summary>
     /// Whether follow mode is enabled via the widget configuration.
     /// </summary>
@@ -409,16 +403,13 @@ public sealed class ScrollPanelNode : Hex1bNode, ILayoutProvider
             IsFollowing = _offset >= MaxOffset;
         }
 
-        // Fire scroll event
+        // Fire scroll event when there's an input context. Programmatic mutations
+        // (Offset setter, ScrollByPage, ScrollBy, ScrollToTop, ScrollToBottom) pass
+        // a null context and intentionally skip OnScroll, mirroring ListNode.SelectedIndex.
         if (ScrollAction != null && context != null)
         {
             // Fire async event - we don't await it here as it's fire-and-forget in input handling
             _ = ScrollAction(context, _offset, previousOffset, ContentSize, ViewportSize);
-        }
-        else if (ScrollAction != null)
-        {
-            // Store context for deferred event firing
-            _pendingEventContext = context;
         }
     }
     

--- a/src/Hex1b/Nodes/ScrollPanelNode.cs
+++ b/src/Hex1b/Nodes/ScrollPanelNode.cs
@@ -35,12 +35,26 @@ public sealed class ScrollPanelNode : Hex1bNode, ILayoutProvider
     /// </summary>
     public ScrollPanelWidget? SourceWidget { get; set; }
     
+    private int _offset;
+
     /// <summary>
     /// The current scroll offset (in characters).
     /// For vertical scrolling, this is the row offset.
     /// For horizontal scrolling, this is the column offset.
     /// </summary>
-    public int Offset { get; private set; }
+    /// <remarks>
+    /// Setting this property clamps the value to <c>[0, <see cref="MaxOffset"/>]</c>,
+    /// invalidates layout, and updates follow-mode tracking. Programmatic mutation
+    /// does <b>not</b> fire the <c>OnScroll</c> event because there is no input
+    /// binding context to attach to the event arguments. To observe programmatic
+    /// scroll changes, mirror the value yourself or wrap mutations in your own
+    /// notification.
+    /// </remarks>
+    public int Offset
+    {
+        get => _offset;
+        set => SetOffsetCore(value, context: null);
+    }
     
     /// <summary>
     /// The size of the content being scrolled (in characters).
@@ -67,7 +81,7 @@ public sealed class ScrollPanelNode : Hex1bNode, ILayoutProvider
     /// <summary>
     /// When set, <see cref="EnsureFocusedVisible"/> is suppressed as long as
     /// this node remains the focused descendant. This allows child nodes
-    /// (e.g. markdown headings) to scroll the panel via <see cref="SetOffset"/>
+    /// (e.g. markdown headings) to scroll the panel via <see cref="Offset"/>
     /// without the layout phase immediately scrolling back. Cleared
     /// automatically when focus moves to a different node.
     /// </summary>
@@ -372,27 +386,34 @@ public sealed class ScrollPanelNode : Hex1bNode, ILayoutProvider
     
     /// <summary>
     /// Sets the offset directly and fires the scroll event if changed.
+    /// Internal entry point used by binding-driven scrolling that has an
+    /// <see cref="InputBindingActionContext"/> available for the event payload.
+    /// Public callers should use the <see cref="Offset"/> setter, <see cref="ScrollBy"/>,
+    /// <see cref="ScrollByPage"/>, <see cref="ScrollToTop"/>, or <see cref="ScrollToBottom"/>.
     /// </summary>
     internal void SetOffset(int newOffset, InputBindingActionContext? context = null)
+        => SetOffsetCore(newOffset, context);
+
+    private void SetOffsetCore(int newOffset, InputBindingActionContext? context)
     {
         var clampedOffset = Math.Clamp(newOffset, 0, MaxOffset);
-        if (clampedOffset == Offset) return;
-        
-        var previousOffset = Offset;
-        Offset = clampedOffset;
+        if (clampedOffset == _offset) return;
+
+        var previousOffset = _offset;
+        _offset = clampedOffset;
         MarkDirty();
-        
+
         // Update follow state based on user scroll position
         if (FollowEnabled)
         {
-            IsFollowing = Offset >= MaxOffset;
+            IsFollowing = _offset >= MaxOffset;
         }
-        
+
         // Fire scroll event
         if (ScrollAction != null && context != null)
         {
             // Fire async event - we don't await it here as it's fire-and-forget in input handling
-            _ = ScrollAction(context, Offset, previousOffset, ContentSize, ViewportSize);
+            _ = ScrollAction(context, _offset, previousOffset, ContentSize, ViewportSize);
         }
         else if (ScrollAction != null)
         {
@@ -405,9 +426,7 @@ public sealed class ScrollPanelNode : Hex1bNode, ILayoutProvider
     /// Scrolls by the specified amount (positive = down/right, negative = up/left).
     /// </summary>
     private void ScrollByAmount(int amount, InputBindingActionContext? context = null)
-    {
-        SetOffset(Offset + amount, context);
-    }
+        => SetOffsetCore(_offset + amount, context);
 
     /// <summary>
     /// Adjusts Offset so the focused descendant's bounds are within the viewport.
@@ -484,70 +503,106 @@ public sealed class ScrollPanelNode : Hex1bNode, ILayoutProvider
         }
 
         newOffset = Math.Clamp(newOffset, 0, MaxOffset);
-        if (newOffset == Offset) return false;
+        if (newOffset == _offset) return false;
 
-        Offset = newOffset;
+        _offset = newOffset;
         MarkDirty();
         return true;
     }
     
     /// <summary>
-    /// Scrolls by a full page (viewport size minus 1).
+    /// Scrolls by a full page in the given direction.
     /// </summary>
-    private void ScrollByPage(int direction, InputBindingActionContext? context = null)
+    /// <param name="direction">
+    /// Use <c>+1</c> to scroll forward (down/right) by one viewport, <c>-1</c> to
+    /// scroll backward (up/left) by one viewport. Larger magnitudes multiply the
+    /// step (e.g. <c>2</c> scrolls two pages forward).
+    /// </param>
+    /// <remarks>
+    /// One page is <c>max(1, ViewportSize - 1)</c> — the viewport size minus one
+    /// row/column of overlap so the user keeps a line of context when paging.
+    /// Programmatic mutation does not fire the <c>OnScroll</c> event.
+    /// </remarks>
+    public void ScrollByPage(int direction)
     {
         var pageSize = Math.Max(1, ViewportSize - 1);
-        ScrollByAmount(direction * pageSize, context);
+        SetOffsetCore(_offset + direction * pageSize, context: null);
     }
-    
+
+    /// <summary>
+    /// Scrolls by the specified number of characters relative to the current offset.
+    /// Positive values scroll forward (down/right); negative values scroll backward (up/left).
+    /// The result is clamped to <c>[0, <see cref="MaxOffset"/>]</c>.
+    /// Programmatic mutation does not fire the <c>OnScroll</c> event.
+    /// </summary>
+    public void ScrollBy(int amount)
+    {
+        // Widen to long to avoid overflow when amount is large (e.g., int.MaxValue).
+        long target = (long)_offset + amount;
+        if (target < 0) target = 0;
+        if (target > MaxOffset) target = MaxOffset;
+        SetOffsetCore((int)target, context: null);
+    }
+
+    /// <summary>
+    /// Scrolls to the start of the content (offset <c>0</c>).
+    /// Programmatic mutation does not fire the <c>OnScroll</c> event.
+    /// </summary>
+    public void ScrollToTop() => SetOffsetCore(0, context: null);
+
+    /// <summary>
+    /// Scrolls to the end of the content (offset = <see cref="MaxOffset"/>).
+    /// When follow mode is enabled, this also re-engages following.
+    /// Programmatic mutation does not fire the <c>OnScroll</c> event.
+    /// </summary>
+    public void ScrollToBottom() => SetOffsetCore(MaxOffset, context: null);
+
     #endregion
 
     private void ScrollUp(InputBindingActionContext ctx)
     {
-        if (!IsFocused || Orientation != ScrollOrientation.Vertical) return;
+        if (Orientation != ScrollOrientation.Vertical) return;
         ScrollByAmount(-1, ctx);
     }
 
     private void ScrollDown(InputBindingActionContext ctx)
     {
-        if (!IsFocused || Orientation != ScrollOrientation.Vertical) return;
+        if (Orientation != ScrollOrientation.Vertical) return;
         ScrollByAmount(1, ctx);
     }
 
     private void ScrollLeft(InputBindingActionContext ctx)
     {
-        if (!IsFocused || Orientation != ScrollOrientation.Horizontal) return;
+        if (Orientation != ScrollOrientation.Horizontal) return;
         ScrollByAmount(-1, ctx);
     }
 
     private void ScrollRight(InputBindingActionContext ctx)
     {
-        if (!IsFocused || Orientation != ScrollOrientation.Horizontal) return;
+        if (Orientation != ScrollOrientation.Horizontal) return;
         ScrollByAmount(1, ctx);
     }
 
     private void PageUp(InputBindingActionContext ctx)
     {
-        if (!IsFocused) return;
-        ScrollByPage(-1, ctx);
+        var pageSize = Math.Max(1, ViewportSize - 1);
+        SetOffsetCore(_offset - pageSize, ctx);
     }
 
     private void PageDown(InputBindingActionContext ctx)
     {
-        if (!IsFocused) return;
-        ScrollByPage(1, ctx);
+        var pageSize = Math.Max(1, ViewportSize - 1);
+        SetOffsetCore(_offset + pageSize, ctx);
     }
 
     private void ScrollToStart(InputBindingActionContext ctx)
     {
-        if (!IsFocused) return;
-        SetOffset(0, ctx);
+        SetOffsetCore(0, ctx);
     }
 
     private void ScrollToEnd(InputBindingActionContext ctx)
     {
-        if (!IsFocused) return;
-        SetOffset(MaxOffset, ctx);
+        SetOffsetCore(MaxOffset, ctx);
     }
 
     private void FocusFirst()
@@ -597,7 +652,7 @@ public sealed class ScrollPanelNode : Hex1bNode, ILayoutProvider
         // Follow mode: snap to end when content grows
         if (FollowEnabled && IsFollowing && ContentSize > _previousContentSize)
         {
-            Offset = MaxOffset;
+            _offset = MaxOffset;
         }
         _previousContentSize = ContentSize;
         
@@ -644,13 +699,13 @@ public sealed class ScrollPanelNode : Hex1bNode, ILayoutProvider
         }
         
         // Clamp offset to valid range
-        if (Offset > MaxOffset)
+        if (_offset > MaxOffset)
         {
-            Offset = MaxOffset;
+            _offset = MaxOffset;
         }
-        if (Offset < 0)
+        if (_offset < 0)
         {
-            Offset = 0;
+            _offset = 0;
         }
         
         // Set up viewport rect for clipping

--- a/tests/Hex1b.Tests/ScrollPanelNodeTests.cs
+++ b/tests/Hex1b.Tests/ScrollPanelNodeTests.cs
@@ -760,8 +760,12 @@ public class ScrollPanelNodeTests
     }
 
     [Fact]
-    public async Task HandleInput_NotFocused_DoesNotScroll()
+    public async Task HandleInput_DownArrow_ScrollsRegardlessOfPanelFocus()
     {
+        // The ScrollPanelNode no longer guards its scroll handlers with an IsFocused check.
+        // Real routing already restricts which nodes receive bindings (the focus path), so the
+        // guard was redundant in normal flows and harmful for global / bubble-up scenarios.
+        // This test documents the new behavior: invoking the binding directly scrolls the panel.
         var node = new ScrollPanelNode
         {
             Child = CreateTallContent(20),
@@ -771,9 +775,10 @@ public class ScrollPanelNodeTests
         node.Measure(Constraints.Unbounded);
         node.Arrange(new Rect(0, 0, 40, 10));
 
-        await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.DownArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
+        var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.DownArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(0, node.Offset);
+        Assert.Equal(InputResult.Handled, result);
+        Assert.Equal(1, node.Offset);
     }
 
     #endregion
@@ -1268,5 +1273,322 @@ public class ScrollPanelNodeTests
         Assert.DoesNotContain("<<<END>>>", text);
     }
     
+    #endregion
+
+    #region Issue #296 — Global page actions and public scroll API
+
+    /// <summary>
+    /// Minimal sibling-focusable node used to simulate "focus is on a TextBox in another subtree"
+    /// without dragging in the full TextBox machinery.
+    /// </summary>
+    private sealed class StubFocusableNode : Hex1bNode
+    {
+        public override bool IsFocusable => true;
+        private bool _isFocused;
+        public override bool IsFocused { get => _isFocused; set => _isFocused = value; }
+
+        protected override Size MeasureCore(Constraints constraints) => new(10, 1);
+        public override void Render(Hex1bRenderContext context) { }
+    }
+
+    /// <summary>
+    /// Container that aggregates focusable descendants for FocusRing rebuilding.
+    /// </summary>
+    private sealed class StubContainerNode : Hex1bNode
+    {
+        public List<Hex1bNode> Children { get; } = new();
+
+        protected override Size MeasureCore(Constraints constraints) => new(80, 24);
+        public override void Render(Hex1bRenderContext context) { }
+        public override IEnumerable<Hex1bNode> GetChildren() => Children;
+
+        public override IEnumerable<Hex1bNode> GetFocusableNodes()
+        {
+            foreach (var child in Children)
+            {
+                foreach (var f in child.GetFocusableNodes())
+                {
+                    yield return f;
+                }
+            }
+        }
+    }
+
+    [Fact]
+    public async Task GlobalPageDown_ScrollsPanel_WhenFocusIsOnSibling()
+    {
+        // Arrange: ScrollPanel with a global PageDown binding, plus a sibling focusable that owns focus.
+        var scrollPanel = new ScrollPanelNode
+        {
+            Child = CreateTallContent(50),
+            Orientation = ScrollOrientation.Vertical,
+            // Simulate the user's WithInputBindings: register a global PageDown that triggers PageDownAction.
+            BindingsConfigurator = b => b.Key(Hex1bKey.PageDown).Global().Triggers(ScrollPanelWidget.PageDownAction)
+        };
+        scrollPanel.Measure(Constraints.Unbounded);
+        scrollPanel.Arrange(new Rect(0, 0, 40, 10));
+
+        var sibling = new StubFocusableNode { IsFocused = true };
+
+        var root = new StubContainerNode();
+        root.Children.Add(scrollPanel);
+        root.Children.Add(sibling);
+        scrollPanel.Parent = root;
+        sibling.Parent = root;
+
+        var focusRing = new FocusRing();
+        focusRing.Rebuild(root);
+        focusRing.Focus(sibling);
+
+        // Sanity: focus is on the sibling, not the panel.
+        Assert.False(scrollPanel.IsFocused);
+        Assert.True(sibling.IsFocused);
+
+        var state = new InputRouterState();
+
+        // Act
+        var result = await InputRouter.RouteInputAsync(
+            root,
+            new Hex1bKeyEvent(Hex1bKey.PageDown, '\0', Hex1bModifiers.None),
+            focusRing,
+            state,
+            null,
+            TestContext.Current.CancellationToken);
+
+        // Assert: global binding fired, panel scrolled by ViewportSize - 1.
+        Assert.Equal(InputResult.Handled, result);
+        Assert.Equal(9, scrollPanel.Offset);
+    }
+
+    [Fact]
+    public async Task GlobalPageUp_ScrollsPanel_WhenFocusIsOnSibling()
+    {
+        var scrollPanel = new ScrollPanelNode
+        {
+            Child = CreateTallContent(50),
+            Orientation = ScrollOrientation.Vertical,
+            BindingsConfigurator = b => b.Key(Hex1bKey.PageUp).Global().Triggers(ScrollPanelWidget.PageUpAction)
+        };
+        scrollPanel.Measure(Constraints.Unbounded);
+        scrollPanel.Arrange(new Rect(0, 0, 40, 10));
+        scrollPanel.Offset = 30; // start in the middle so PageUp has room to scroll
+
+        var sibling = new StubFocusableNode { IsFocused = true };
+
+        var root = new StubContainerNode();
+        root.Children.Add(scrollPanel);
+        root.Children.Add(sibling);
+        scrollPanel.Parent = root;
+        sibling.Parent = root;
+
+        var focusRing = new FocusRing();
+        focusRing.Rebuild(root);
+        focusRing.Focus(sibling);
+
+        var state = new InputRouterState();
+
+        var result = await InputRouter.RouteInputAsync(
+            root,
+            new Hex1bKeyEvent(Hex1bKey.PageUp, '\0', Hex1bModifiers.None),
+            focusRing,
+            state,
+            null,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(InputResult.Handled, result);
+        Assert.Equal(21, scrollPanel.Offset); // 30 - (10 - 1)
+    }
+
+    [Fact]
+    public async Task PageDown_BubblesUp_FromFocusableDescendant_ToScrollPanelAncestor()
+    {
+        // Regression for the second symptom of issue #296: when a focusable descendant of a
+        // ScrollPanel has focus and presses PageDown, the binding should bubble up to the panel
+        // and scroll. Before the fix, the IsFocused guard silently swallowed the key.
+        var inner = new StubFocusableNode { IsFocused = true };
+        var scrollPanel = new ScrollPanelNode
+        {
+            Child = inner,
+            Orientation = ScrollOrientation.Vertical
+        };
+        inner.Parent = scrollPanel;
+        scrollPanel.Measure(Constraints.Unbounded);
+        scrollPanel.Arrange(new Rect(0, 0, 40, 10));
+
+        // Add some scrollable content size by faking content via a tall sibling structure: instead,
+        // just give the panel a tall child and re-measure.
+        scrollPanel.Child = CreateTallContent(50);
+        scrollPanel.Measure(Constraints.Unbounded);
+        scrollPanel.Arrange(new Rect(0, 0, 40, 10));
+
+        // Re-attach focus to a real focusable inside the panel for routing.
+        // CreateTallContent returns a VStackNode of TextBlockNodes — none focusable. Add one.
+        var focusableChild = new StubFocusableNode { IsFocused = true };
+        scrollPanel.Child = focusableChild;
+        focusableChild.Parent = scrollPanel;
+        scrollPanel.Measure(Constraints.Unbounded);
+        scrollPanel.Arrange(new Rect(0, 0, 40, 10));
+
+        // The panel needs ContentSize > ViewportSize to have a non-zero MaxOffset. Force it.
+        // Easiest path: build a vertical stack with a focusable header and many text blocks.
+        var children = new List<Hex1bNode> { focusableChild };
+        for (int i = 0; i < 50; i++) children.Add(new TextBlockNode { Text = $"line {i}" });
+        scrollPanel.Child = new VStackNode { Children = children };
+        focusableChild.Parent = scrollPanel.Child;
+        ((VStackNode)scrollPanel.Child).Parent = scrollPanel;
+        scrollPanel.Measure(Constraints.Unbounded);
+        scrollPanel.Arrange(new Rect(0, 0, 40, 10));
+
+        var focusRing = new FocusRing();
+        focusRing.Rebuild(scrollPanel);
+        focusRing.Focus(focusableChild);
+
+        Assert.False(scrollPanel.IsFocused, "Panel should not own focus directly when descendant is focused");
+        Assert.True(focusableChild.IsFocused);
+        Assert.True(scrollPanel.MaxOffset > 0, "Panel must be scrollable for this test to be meaningful");
+
+        var state = new InputRouterState();
+
+        var result = await InputRouter.RouteInputAsync(
+            scrollPanel,
+            new Hex1bKeyEvent(Hex1bKey.PageDown, '\0', Hex1bModifiers.None),
+            focusRing,
+            state,
+            null,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(InputResult.Handled, result);
+        Assert.True(scrollPanel.Offset > 0, $"Expected panel to scroll via bubble-up, but Offset is {scrollPanel.Offset}");
+    }
+
+    [Fact]
+    public void OffsetSetter_ClampsToValidRange()
+    {
+        var node = new ScrollPanelNode
+        {
+            Child = CreateTallContent(50),
+            Orientation = ScrollOrientation.Vertical
+        };
+        node.Measure(Constraints.Unbounded);
+        node.Arrange(new Rect(0, 0, 40, 10));
+
+        node.Offset = -100;
+        Assert.Equal(0, node.Offset);
+
+        node.Offset = 9999;
+        Assert.Equal(node.MaxOffset, node.Offset);
+
+        node.Offset = 5;
+        Assert.Equal(5, node.Offset);
+    }
+
+    [Fact]
+    public void ScrollByPage_AdvancesByViewportMinusOne()
+    {
+        var node = new ScrollPanelNode
+        {
+            Child = CreateTallContent(50),
+            Orientation = ScrollOrientation.Vertical
+        };
+        node.Measure(Constraints.Unbounded);
+        node.Arrange(new Rect(0, 0, 40, 10));
+
+        node.ScrollByPage(1);
+        Assert.Equal(9, node.Offset);  // ViewportSize (10) - 1
+
+        node.ScrollByPage(1);
+        Assert.Equal(18, node.Offset);
+
+        node.ScrollByPage(-1);
+        Assert.Equal(9, node.Offset);
+
+        node.ScrollByPage(2);
+        Assert.Equal(27, node.Offset); // direction can be larger magnitudes
+    }
+
+    [Fact]
+    public void ScrollBy_AppliesRelativeOffset()
+    {
+        var node = new ScrollPanelNode
+        {
+            Child = CreateTallContent(50),
+            Orientation = ScrollOrientation.Vertical
+        };
+        node.Measure(Constraints.Unbounded);
+        node.Arrange(new Rect(0, 0, 40, 10));
+
+        node.ScrollBy(5);
+        Assert.Equal(5, node.Offset);
+
+        node.ScrollBy(-2);
+        Assert.Equal(3, node.Offset);
+
+        // Large positive scroll clamps to MaxOffset; the public API is overflow-safe.
+        node.ScrollBy(int.MaxValue);
+        Assert.Equal(node.MaxOffset, node.Offset);
+
+        node.ScrollBy(int.MinValue);
+        Assert.Equal(0, node.Offset);
+    }
+
+    [Fact]
+    public void ScrollToTop_SetsOffsetToZero()
+    {
+        var node = new ScrollPanelNode
+        {
+            Child = CreateTallContent(50),
+            Orientation = ScrollOrientation.Vertical
+        };
+        node.Measure(Constraints.Unbounded);
+        node.Arrange(new Rect(0, 0, 40, 10));
+        node.Offset = 25;
+
+        node.ScrollToTop();
+
+        Assert.Equal(0, node.Offset);
+    }
+
+    [Fact]
+    public void ScrollToBottom_SetsOffsetToMaxOffset()
+    {
+        var node = new ScrollPanelNode
+        {
+            Child = CreateTallContent(50),
+            Orientation = ScrollOrientation.Vertical
+        };
+        node.Measure(Constraints.Unbounded);
+        node.Arrange(new Rect(0, 0, 40, 10));
+        node.Offset = 5;
+
+        node.ScrollToBottom();
+
+        Assert.Equal(node.MaxOffset, node.Offset);
+        Assert.Equal(40, node.Offset); // 50 content - 10 viewport
+    }
+
+    [Fact]
+    public async Task ProgrammaticScroll_DoesNotFire_OnScrollEvent()
+    {
+        // Public scroll API has no InputBindingActionContext to attach to the event args.
+        // Documented behavior: programmatic mutations do not fire OnScroll.
+        ScrollChangedEventArgs? received = null;
+        var widget = new ScrollPanelWidget(new VStackWidget([new TextBlockWidget("Line 1")]))
+            .OnScroll(e => received = e);
+
+        var context = ReconcileContext.CreateRoot();
+        var node = (ScrollPanelNode)await widget.ReconcileAsync(null, context);
+        node.Child = CreateTallContent(50);
+        node.Measure(Constraints.Unbounded);
+        node.Arrange(new Rect(0, 0, 40, 10));
+
+        node.Offset = 5;
+        node.ScrollBy(3);
+        node.ScrollByPage(1);
+        node.ScrollToTop();
+        node.ScrollToBottom();
+
+        Assert.Null(received);
+    }
+
     #endregion
 }


### PR DESCRIPTION
## Summary

Fixes #296.

A user wanted `PageUp`/`PageDown` to scroll a `ScrollPanelWidget` while focus stayed on a sibling `TextBox`. They opted in via:

```csharp
scrollPanel.WithInputBindings(b =>
{
    b.Key(Hex1bKey.PageUp).Global().Triggers(ScrollPanelWidget.PageUpAction);
    b.Key(Hex1bKey.PageDown).Global().Triggers(ScrollPanelWidget.PageDownAction);
});
```

The global binding correctly resolved to the registered handler on the right panel instance, but the handler short-circuited because every scroll handler began with `if (!IsFocused) return;`.

## Root cause

The `IsFocused` guards in the eight scroll handlers (`ScrollUp`/`ScrollDown`/`ScrollLeft`/`ScrollRight`/`PageUp`/`PageDown`/`ScrollToStart`/`ScrollToEnd`) were redundant for normal routing ╬ô├ç├╢ `InputRouter` only delivers a binding to nodes on the focus path ╬ô├ç├╢ but they had two negative effects:

1. **Defeated user-opted-in `Global()` bindings** (the issue's scenario).
2. **Silently ate keys in the bubble-up case**: when a focusable descendant of the panel was focused and `PageUp`/`PageDown` bubbled up, the binding matched on the panel and the handler returned without scrolling. `ScrollPanelNode.IsFocused` tracks self-focus only; `ManagesChildFocus` doesn't set it.

There was also no public imperative scroll API. `SetOffset` is internal, so programmatic scrolling required reflection.

## Changes

### `src/Hex1b/Nodes/ScrollPanelNode.cs`

- Removed `IsFocused` guards from all eight scroll handlers. Orientation checks on arrow handlers are retained.
- Promoted `Offset` from `{ get; private set; }` to `{ get; set; }` with clamp + `MarkDirty` + follow-mode update, mirroring `ListNode.ScrollOffset`.
- Added public convenience methods:
  - `ScrollByPage(int direction)` ╬ô├ç├╢ scrolls by `direction * (ViewportSize - 1)`.
  - `ScrollBy(int amount)` ╬ô├ç├╢ overflow-safe via `long` widening.
  - `ScrollToTop()` / `ScrollToBottom()`.
- These public surfaces do **not** fire the `OnScroll` event because no `InputBindingActionContext` is available (`WidgetEventArgs.Context` is non-nullable). Documented on each member. Internal `SetOffset(int, ctx)` and binding-driven handlers continue to fire `OnScroll` via a shared `SetOffsetCore` worker.
- Layout-time `Offset` writes go through the backing field directly to avoid invalidating layout during `Measure`/`Arrange`.

### `tests/Hex1b.Tests/ScrollPanelNodeTests.cs`

- Replaced `HandleInput_NotFocused_DoesNotScroll` with `HandleInput_DownArrow_ScrollsRegardlessOfPanelFocus` (inverted expectation matching real routing semantics).
- Added 9 new tests covering: global `PageUp`/`PageDown` without panel focus, bubble-up from a focusable descendant, `Offset` setter clamp, `ScrollByPage` direction, `ScrollBy` (incl. `int.MaxValue`/`int.MinValue` overflow safety), `ScrollToTop`, `ScrollToBottom`, and that programmatic mutations don't fire `OnScroll`.

## Verification

- `dotnet build` ╬ô├ç├╢ 0 warnings, 0 errors.
- `dotnet test tests\Hex1b.Tests\Hex1b.Tests.csproj` ╬ô├ç├╢ **7490 passed, 31 skipped, 0 failed**.

## Notes for reviewer

- `MarkdownScrollHelper` uses the internal `SetOffset(int)` overload, which is preserved.
- `ScrollByPage(int direction)` doesn't widen to `long`; `pageSize` is `ViewportSize - 1` (terminal-bounded), so realistic overflow would require an unrealistic `direction`. `ScrollBy(int amount)` does widen since `amount` comes directly from a caller.
- Programmatic mutations skipping `OnScroll` matches `ListNode.SelectedIndex` semantics ΓÇö that setter likewise updates state, calls `EnsureSelectionVisible`/`MarkDirty`, and does not invoke `SelectionChangedAction`. Only input-binding-driven paths fire change handlers in this codebase. No new subscription surface is needed here.


