### PR TITLE
Fix #292: Public API for registering prebuilt InputBindings

### DIFF
--- a/samples/QuadTerminalDemo/Program.cs
+++ b/samples/QuadTerminalDemo/Program.cs
@@ -22,12 +22,8 @@ app.UseStaticFiles();
 
 var terminalConfigs = GetTerminalConfigs();
 
-app.MapGet("/terminal-config", () => terminalConfigs.Select(config => new
-{
-    endpoint = config.Endpoint,
-    label = config.Label,
-    windowsPty = config.WindowsPty
-}));
+app.MapGet("/terminal-config", () => terminalConfigs.Select(config =>
+    new TerminalConfigResponse(config.Endpoint, config.Label, config.WindowsPty)));
 
 // Helper to create WebSocket terminal endpoint
 async Task HandleTerminal(HttpContext context, TerminalConfig config)
@@ -176,5 +172,10 @@ internal sealed record TerminalConfig(
     string Label,
     string[] Command,
     WindowsPtyConfig? WindowsPty = null);
+
+internal sealed record TerminalConfigResponse(
+    string Endpoint,
+    string Label,
+    WindowsPtyConfig? WindowsPty);
 
 internal sealed record WindowsPtyConfig(string Backend, int BuildNumber);

--- a/src/Hex1b/Input/CharacterBinding.cs
+++ b/src/Hex1b/Input/CharacterBinding.cs
@@ -32,26 +32,34 @@ public sealed class CharacterBinding
     /// A stable identifier for the action this binding performs.
     /// Used for programmatic rebinding via <see cref="InputBindingsBuilder.Remove(ActionId)"/>.
     /// </summary>
-    public ActionId? ActionId { get; internal set; }
+    /// <remarks>
+    /// When supplied via the constructor (e.g., for a binding registered through
+    /// <see cref="InputBindingsBuilder.Add(CharacterBinding)"/>), this id supports
+    /// <see cref="InputBindingsBuilder.Remove(ActionId)"/> only — it is NOT registered
+    /// in the rebinding registry.
+    /// </remarks>
+    public ActionId? ActionId { get; }
 
     /// <summary>
     /// Creates a text binding with the given predicate and synchronous handler.
     /// </summary>
-    public CharacterBinding(Func<string, bool> predicate, Action<string> handler, string? description = null)
+    public CharacterBinding(Func<string, bool> predicate, Action<string> handler, string? description = null, ActionId? actionId = null)
     {
         Predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
         Handler = handler ?? throw new ArgumentNullException(nameof(handler));
         Description = description;
+        ActionId = actionId;
     }
 
     /// <summary>
     /// Creates a text binding with the given predicate and async handler.
     /// </summary>
-    public CharacterBinding(Func<string, bool> predicate, Func<string, InputBindingActionContext, Task> handler, string? description = null)
+    public CharacterBinding(Func<string, bool> predicate, Func<string, InputBindingActionContext, Task> handler, string? description = null, ActionId? actionId = null)
     {
         Predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
         AsyncHandler = handler ?? throw new ArgumentNullException(nameof(handler));
         Description = description;
+        ActionId = actionId;
     }
 
     /// <summary>

--- a/src/Hex1b/Input/CharacterStepBuilder.cs
+++ b/src/Hex1b/Input/CharacterStepBuilder.cs
@@ -19,7 +19,7 @@ public sealed class CharacterStepBuilder
     /// </summary>
     public void Action(Action<string> handler, string? description = null)
     {
-        _parent.AddCharacterBinding(new CharacterBinding(_predicate, handler, description));
+        _parent.Add(new CharacterBinding(_predicate, handler, description));
     }
 
     /// <summary>
@@ -27,6 +27,6 @@ public sealed class CharacterStepBuilder
     /// </summary>
     public void Action(Func<string, InputBindingActionContext, Task> handler, string? description = null)
     {
-        _parent.AddCharacterBinding(new CharacterBinding(_predicate, handler, description));
+        _parent.Add(new CharacterBinding(_predicate, handler, description));
     }
 }

--- a/src/Hex1b/Input/DragBinding.cs
+++ b/src/Hex1b/Input/DragBinding.cs
@@ -31,14 +31,21 @@ public sealed class DragBinding
     /// A stable identifier for the action this binding performs.
     /// Used for programmatic rebinding via <see cref="InputBindingsBuilder.Remove(ActionId)"/>.
     /// </summary>
-    public ActionId? ActionId { get; internal set; }
+    /// <remarks>
+    /// When supplied via the constructor (e.g., for a binding registered through
+    /// <see cref="InputBindingsBuilder.Add(DragBinding)"/>), this id supports
+    /// <see cref="InputBindingsBuilder.Remove(ActionId)"/> only — it is NOT registered
+    /// in the rebinding registry.
+    /// </remarks>
+    public ActionId? ActionId { get; }
 
-    public DragBinding(MouseButton button, Hex1bModifiers modifiers, Func<int, int, DragHandler> factory, string? description)
+    public DragBinding(MouseButton button, Hex1bModifiers modifiers, Func<int, int, DragHandler> factory, string? description, ActionId? actionId = null)
     {
         Button = button;
         Modifiers = modifiers;
         Factory = factory;
         Description = description;
+        ActionId = actionId;
     }
 
     /// <summary>

--- a/src/Hex1b/Input/DragStepBuilder.cs
+++ b/src/Hex1b/Input/DragStepBuilder.cs
@@ -40,7 +40,7 @@ public sealed class DragStepBuilder
     public InputBindingsBuilder Action(Func<int, int, DragHandler> factory, string? description = null)
     {
         var binding = new DragBinding(_button, _modifiers, factory, description);
-        _parent.AddDragBinding(binding);
+        _parent.Add(binding);
         return _parent;
     }
 }

--- a/src/Hex1b/Input/InputBinding.cs
+++ b/src/Hex1b/Input/InputBinding.cs
@@ -36,7 +36,7 @@ public sealed class InputBinding
     /// When true, this binding is checked even when another node has captured all input.
     /// Use this for menu accelerators and other app-level shortcuts that should always work.
     /// </summary>
-    public bool OverridesCapture { get; internal set; }
+    public bool OverridesCapture { get; }
 
     /// <summary>
     /// The node that owns this binding (for conflict detection and debugging).
@@ -48,13 +48,22 @@ public sealed class InputBinding
     /// Used for programmatic rebinding via <see cref="InputBindingsBuilder.Remove(ActionId)"/>.
     /// Convention: "WidgetName.ActionName" (e.g., "List.MoveUp").
     /// </summary>
-    public ActionId? ActionId { get; internal set; }
+    /// <remarks>
+    /// When supplied via the constructor (e.g., for a binding registered through
+    /// <see cref="InputBindingsBuilder.Add(InputBinding)"/>), this id supports
+    /// <see cref="InputBindingsBuilder.Remove(ActionId)"/> and
+    /// <see cref="InputBindingsBuilder.GetBindings(ActionId)"/> only — it is NOT registered
+    /// in the rebinding registry. Use the fluent
+    /// <see cref="KeyStepBuilder.Triggers(ActionId, Action{InputBindingActionContext}, string?)"/>
+    /// path if you also need <see cref="KeyStepBuilder.Triggers(ActionId)"/> rebinding support.
+    /// </remarks>
+    public ActionId? ActionId { get; }
 
     /// <summary>
     /// Creates an input binding with a simple action handler (no context).
     /// </summary>
-    public InputBinding(IReadOnlyList<KeyStep> steps, Action action, string? description = null, bool isGlobal = false)
-        : this(steps, _ => { action(); return Task.CompletedTask; }, description, isGlobal)
+    public InputBinding(IReadOnlyList<KeyStep> steps, Action action, string? description = null, bool isGlobal = false, ActionId? actionId = null, bool overridesCapture = false)
+        : this(steps, _ => { action(); return Task.CompletedTask; }, description, isGlobal, actionId, overridesCapture)
     {
         ArgumentNullException.ThrowIfNull(action);
     }
@@ -62,8 +71,8 @@ public sealed class InputBinding
     /// <summary>
     /// Creates an input binding with a synchronous context-aware action handler.
     /// </summary>
-    public InputBinding(IReadOnlyList<KeyStep> steps, Action<InputBindingActionContext> action, string? description = null, bool isGlobal = false)
-        : this(steps, ctx => { action(ctx); return Task.CompletedTask; }, description, isGlobal)
+    public InputBinding(IReadOnlyList<KeyStep> steps, Action<InputBindingActionContext> action, string? description = null, bool isGlobal = false, ActionId? actionId = null, bool overridesCapture = false)
+        : this(steps, ctx => { action(ctx); return Task.CompletedTask; }, description, isGlobal, actionId, overridesCapture)
     {
         ArgumentNullException.ThrowIfNull(action);
     }
@@ -71,15 +80,19 @@ public sealed class InputBinding
     /// <summary>
     /// Creates an input binding with an async context-aware action handler.
     /// </summary>
-    public InputBinding(IReadOnlyList<KeyStep> steps, Func<InputBindingActionContext, Task> handler, string? description = null, bool isGlobal = false)
+    public InputBinding(IReadOnlyList<KeyStep> steps, Func<InputBindingActionContext, Task> handler, string? description = null, bool isGlobal = false, ActionId? actionId = null, bool overridesCapture = false)
     {
+        ArgumentNullException.ThrowIfNull(steps);
         if (steps.Count == 0)
             throw new ArgumentException("At least one key step is required.", nameof(steps));
-        
-        Steps = steps;
+
+        // Defensive copy so external mutation of the source list cannot change runtime behavior.
+        Steps = [.. steps];
         Handler = handler ?? throw new ArgumentNullException(nameof(handler));
         Description = description;
         IsGlobal = isGlobal;
+        ActionId = actionId;
+        OverridesCapture = overridesCapture;
     }
 
     /// <summary>

--- a/src/Hex1b/Input/InputBindingsBuilder.cs
+++ b/src/Hex1b/Input/InputBindingsBuilder.cs
@@ -90,34 +90,66 @@ public sealed class InputBindingsBuilder
         => text.Length > 0 && (text.Length > 1 || !char.IsControl(text[0]));
 
     /// <summary>
-    /// Adds a pre-built binding directly.
+    /// Adds a pre-built key binding directly.
+    /// Use this when constructing an <see cref="InputBinding"/> outside the fluent builder
+    /// (for example, when bindings are loaded from configuration or shared across widgets).
     /// </summary>
-    internal void AddBinding(InputBinding binding)
+    /// <param name="binding">The binding to add. Must not be <see langword="null"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="binding"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// Each binding instance should be treated as single-use: <see cref="InputBinding.OwnerNode"/>
+    /// is mutated post-construction by the input router, so reusing the same instance across
+    /// multiple widgets produces ambiguous owner metadata.
+    /// </remarks>
+    public void Add(InputBinding binding)
     {
+        ArgumentNullException.ThrowIfNull(binding);
         _bindings.Add(binding);
     }
 
     /// <summary>
     /// Adds a pre-built character binding directly.
     /// </summary>
-    internal void AddCharacterBinding(CharacterBinding binding)
+    /// <param name="binding">The binding to add. Must not be <see langword="null"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="binding"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// Character bindings are checked only on the focused node — there is no global-style fallback.
+    /// </remarks>
+    public void Add(CharacterBinding binding)
     {
+        ArgumentNullException.ThrowIfNull(binding);
         _characterBindings.Add(binding);
     }
 
     /// <summary>
     /// Adds a pre-built mouse binding directly.
     /// </summary>
-    internal void AddMouseBinding(MouseBinding binding)
+    /// <param name="binding">The binding to add. Must not be <see langword="null"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="binding"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// Mouse Down events route via focus hit-testing, which only considers focusable nodes.
+    /// Mouse bindings on non-focusable container nodes will never fire — wrap such nodes in
+    /// <c>InteractableWidget</c> to make them mouse-routable.
+    /// </remarks>
+    public void Add(MouseBinding binding)
     {
+        ArgumentNullException.ThrowIfNull(binding);
         _mouseBindings.Add(binding);
     }
 
     /// <summary>
     /// Adds a pre-built drag binding directly.
     /// </summary>
-    internal void AddDragBinding(DragBinding binding)
+    /// <param name="binding">The binding to add. Must not be <see langword="null"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="binding"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// Drag initiation routes via focus hit-testing, which only considers focusable nodes.
+    /// Drag bindings on non-focusable container nodes will never fire — wrap such nodes in
+    /// <c>InteractableWidget</c> to make them mouse-routable.
+    /// </remarks>
+    public void Add(DragBinding binding)
     {
+        ArgumentNullException.ThrowIfNull(binding);
         _dragBindings.Add(binding);
     }
 

--- a/src/Hex1b/Input/KeyStepBuilder.cs
+++ b/src/Hex1b/Input/KeyStepBuilder.cs
@@ -96,10 +96,8 @@ public sealed class KeyStepBuilder
     public void Action(Action handler, string? description = null)
     {
         CommitCurrentStep();
-        var binding = new InputBinding([.. _completedSteps], handler, description, _isGlobal);
-        binding.OverridesCapture = _overridesCapture;
-        binding.ActionId = _actionId;
-        _parent.AddBinding(binding);
+        var binding = new InputBinding([.. _completedSteps], handler, description, _isGlobal, _actionId, _overridesCapture);
+        _parent.Add(binding);
     }
 
     /// <summary>
@@ -109,10 +107,8 @@ public sealed class KeyStepBuilder
     public void Action(Action<InputBindingActionContext> handler, string? description = null)
     {
         CommitCurrentStep();
-        var binding = new InputBinding([.. _completedSteps], handler, description, _isGlobal);
-        binding.OverridesCapture = _overridesCapture;
-        binding.ActionId = _actionId;
-        _parent.AddBinding(binding);
+        var binding = new InputBinding([.. _completedSteps], handler, description, _isGlobal, _actionId, _overridesCapture);
+        _parent.Add(binding);
     }
 
     /// <summary>
@@ -121,10 +117,8 @@ public sealed class KeyStepBuilder
     public void Action(Func<InputBindingActionContext, Task> handler, string? description = null)
     {
         CommitCurrentStep();
-        var binding = new InputBinding([.. _completedSteps], handler, description, _isGlobal);
-        binding.OverridesCapture = _overridesCapture;
-        binding.ActionId = _actionId;
-        _parent.AddBinding(binding);
+        var binding = new InputBinding([.. _completedSteps], handler, description, _isGlobal, _actionId, _overridesCapture);
+        _parent.Add(binding);
     }
 
     /// <summary>

--- a/src/Hex1b/Input/MouseBinding.cs
+++ b/src/Hex1b/Input/MouseBinding.cs
@@ -42,13 +42,19 @@ public sealed class MouseBinding
     /// A stable identifier for the action this binding performs.
     /// Used for programmatic rebinding via <see cref="InputBindingsBuilder.Remove(ActionId)"/>.
     /// </summary>
-    public ActionId? ActionId { get; internal set; }
+    /// <remarks>
+    /// When supplied via the constructor (e.g., for a binding registered through
+    /// <see cref="InputBindingsBuilder.Add(MouseBinding)"/>), this id supports
+    /// <see cref="InputBindingsBuilder.Remove(ActionId)"/> only — it is NOT registered
+    /// in the rebinding registry.
+    /// </remarks>
+    public ActionId? ActionId { get; }
 
     /// <summary>
     /// Creates a mouse binding with a simple action handler (no context).
     /// </summary>
-    public MouseBinding(MouseButton button, MouseAction action, Hex1bModifiers modifiers, Action handler, string? description)
-        : this(button, action, modifiers, 1, _ => { handler(); return Task.CompletedTask; }, description)
+    public MouseBinding(MouseButton button, MouseAction action, Hex1bModifiers modifiers, Action handler, string? description, ActionId? actionId = null)
+        : this(button, action, modifiers, 1, _ => { handler(); return Task.CompletedTask; }, description, actionId)
     {
         ArgumentNullException.ThrowIfNull(handler);
     }
@@ -56,8 +62,8 @@ public sealed class MouseBinding
     /// <summary>
     /// Creates a mouse binding with a simple action handler and click count (no context).
     /// </summary>
-    public MouseBinding(MouseButton button, MouseAction action, Hex1bModifiers modifiers, int clickCount, Action handler, string? description)
-        : this(button, action, modifiers, clickCount, _ => { handler(); return Task.CompletedTask; }, description)
+    public MouseBinding(MouseButton button, MouseAction action, Hex1bModifiers modifiers, int clickCount, Action handler, string? description, ActionId? actionId = null)
+        : this(button, action, modifiers, clickCount, _ => { handler(); return Task.CompletedTask; }, description, actionId)
     {
         ArgumentNullException.ThrowIfNull(handler);
     }
@@ -65,8 +71,8 @@ public sealed class MouseBinding
     /// <summary>
     /// Creates a mouse binding with a synchronous context-aware handler.
     /// </summary>
-    public MouseBinding(MouseButton button, MouseAction action, Hex1bModifiers modifiers, int clickCount, Action<InputBindingActionContext> handler, string? description)
-        : this(button, action, modifiers, clickCount, ctx => { handler(ctx); return Task.CompletedTask; }, description)
+    public MouseBinding(MouseButton button, MouseAction action, Hex1bModifiers modifiers, int clickCount, Action<InputBindingActionContext> handler, string? description, ActionId? actionId = null)
+        : this(button, action, modifiers, clickCount, ctx => { handler(ctx); return Task.CompletedTask; }, description, actionId)
     {
         ArgumentNullException.ThrowIfNull(handler);
     }
@@ -74,7 +80,7 @@ public sealed class MouseBinding
     /// <summary>
     /// Creates a mouse binding with an async context-aware handler.
     /// </summary>
-    public MouseBinding(MouseButton button, MouseAction action, Hex1bModifiers modifiers, int clickCount, Func<InputBindingActionContext, Task> handler, string? description)
+    public MouseBinding(MouseButton button, MouseAction action, Hex1bModifiers modifiers, int clickCount, Func<InputBindingActionContext, Task> handler, string? description, ActionId? actionId = null)
     {
         Button = button;
         Action = action;
@@ -82,6 +88,7 @@ public sealed class MouseBinding
         ClickCount = clickCount;
         AsyncHandler = handler ?? throw new ArgumentNullException(nameof(handler));
         Description = description;
+        ActionId = actionId;
     }
 
     /// <summary>

--- a/src/Hex1b/Input/MouseStepBuilder.cs
+++ b/src/Hex1b/Input/MouseStepBuilder.cs
@@ -68,7 +68,7 @@ public sealed class MouseStepBuilder
     public InputBindingsBuilder Action(Action action, string? description = null)
     {
         var binding = new MouseBinding(_button, _action, _modifiers, _clickCount, action, description);
-        _parent.AddMouseBinding(binding);
+        _parent.Add(binding);
         return _parent;
     }
 
@@ -78,7 +78,7 @@ public sealed class MouseStepBuilder
     public InputBindingsBuilder Action(Action<InputBindingActionContext> action, string? description = null)
     {
         var binding = new MouseBinding(_button, _action, _modifiers, _clickCount, action, description);
-        _parent.AddMouseBinding(binding);
+        _parent.Add(binding);
         return _parent;
     }
 
@@ -88,7 +88,7 @@ public sealed class MouseStepBuilder
     public InputBindingsBuilder Action(Func<InputBindingActionContext, Task> action, string? description = null)
     {
         var binding = new MouseBinding(_button, _action, _modifiers, _clickCount, action, description);
-        _parent.AddMouseBinding(binding);
+        _parent.Add(binding);
         return _parent;
     }
 
@@ -99,9 +99,8 @@ public sealed class MouseStepBuilder
     public InputBindingsBuilder Triggers(ActionId actionId, Action action, string? description = null)
     {
         _parent.RegisterAction(actionId, _ => { action(); return Task.CompletedTask; }, description);
-        var binding = new MouseBinding(_button, _action, _modifiers, _clickCount, action, description);
-        binding.ActionId = actionId;
-        _parent.AddMouseBinding(binding);
+        var binding = new MouseBinding(_button, _action, _modifiers, _clickCount, action, description, actionId);
+        _parent.Add(binding);
         return _parent;
     }
 
@@ -112,9 +111,8 @@ public sealed class MouseStepBuilder
     public InputBindingsBuilder Triggers(ActionId actionId, Action<InputBindingActionContext> action, string? description = null)
     {
         _parent.RegisterAction(actionId, ctx => { action(ctx); return Task.CompletedTask; }, description);
-        var binding = new MouseBinding(_button, _action, _modifiers, _clickCount, action, description);
-        binding.ActionId = actionId;
-        _parent.AddMouseBinding(binding);
+        var binding = new MouseBinding(_button, _action, _modifiers, _clickCount, action, description, actionId);
+        _parent.Add(binding);
         return _parent;
     }
 
@@ -124,9 +122,8 @@ public sealed class MouseStepBuilder
     public InputBindingsBuilder Triggers(ActionId actionId, Func<InputBindingActionContext, Task> action, string? description = null)
     {
         _parent.RegisterAction(actionId, action, description);
-        var binding = new MouseBinding(_button, _action, _modifiers, _clickCount, action, description);
-        binding.ActionId = actionId;
-        _parent.AddMouseBinding(binding);
+        var binding = new MouseBinding(_button, _action, _modifiers, _clickCount, action, description, actionId);
+        _parent.Add(binding);
         return _parent;
     }
 }

--- a/src/content/guide/input.md
+++ b/src/content/guide/input.md
@@ -168,6 +168,34 @@ protected override void ConfigureDefaultBindings(InputBindingsBuilder bindings)
 
 This separation — actions declared on widgets, defaults wired in nodes — is what makes the rebinding system work. You reference `ListWidget.MoveUp` to remap it; you never need to know what key it was originally bound to.
 
+## Registering Prebuilt Bindings
+
+Most app code uses the fluent API (`b.Ctrl().Key(Hex1bKey.S).Action(...)`), but you can also construct an `InputBinding`, `MouseBinding`, `CharacterBinding`, or `DragBinding` directly and register it via `InputBindingsBuilder.Add(...)`. This is useful when bindings are loaded from configuration, generated dynamically, or shared across multiple widgets.
+
+```csharp
+// Build the binding outside the WithInputBindings callback.
+var selectWordLeft = new InputBinding(
+    [new KeyStep(Hex1bKey.LeftArrow, Hex1bModifiers.Control | Hex1bModifiers.Shift)],
+    handler: ctx => SelectPreviousWord(ctx),
+    description: "Select previous word",
+    isGlobal: false,
+    actionId: new ActionId("MyApp.SelectWordLeft"),
+    overridesCapture: false);
+
+widget.WithInputBindings(b => b.Add(selectWordLeft));
+```
+
+The same pattern works for `Add(MouseBinding)`, `Add(CharacterBinding)`, and `Add(DragBinding)`. Each overload throws `ArgumentNullException` when given `null`.
+
+### Caveats
+
+A few constraints are worth knowing about before relying on prebuilt bindings:
+
+- **Treat each binding instance as single-use.** The router stamps `OwnerNode` on the binding during input collection, so reusing the same `InputBinding` instance across multiple widgets produces ambiguous owner metadata. Construct a fresh instance per registration.
+- **Mouse and drag bindings on non-focusable nodes never fire.** Mouse routing hit-tests focusable nodes only — bindings on a plain container (e.g., `VStack`, `Border`) won't receive mouse events. Wrap the container in `InteractableWidget` to make it mouse-routable.
+- **Character bindings are checked only on the focused node.** They have no global-style fallback; `Add(CharacterBinding)` on a non-focusable widget will compile and store the binding but it won't ever match.
+- **Constructor-supplied `ActionId` does NOT enable `Triggers(actionId)` rebinding.** It supports `Remove(ActionId)` and `GetBindings(ActionId)` only. If you need apps to re-bind your action by id, register through the fluent `Triggers(actionId, handler, description)` path instead — that path also seeds the rebinding registry.
+
 ## Customizing Keybindings
 
 The `WithInputBindings` API combined with `ActionId` gives you four patterns for customizing widget behavior.

--- a/tests/Hex1b.Tests/PrebuiltBindingTests.cs
+++ b/tests/Hex1b.Tests/PrebuiltBindingTests.cs
@@ -1,0 +1,544 @@
+using Hex1b.Input;
+using Hex1b.Layout;
+using Hex1b.Nodes;
+using Hex1b.Widgets;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Tests for the public <c>InputBindingsBuilder.Add(...)</c> overloads that allow app code
+/// to register prebuilt <see cref="InputBinding"/>, <see cref="MouseBinding"/>,
+/// <see cref="CharacterBinding"/>, and <see cref="DragBinding"/> instances. Covers issue
+/// <see href="https://github.com/mitchdenny/hex1b/issues/292">#292</see>.
+/// </summary>
+public class PrebuiltBindingTests
+{
+    /// <summary>
+    /// Mock focusable node used to drive end-to-end character/key routing without
+    /// pulling in real widgets. Mirrors the pattern in <see cref="InputRouterTests"/>.
+    /// </summary>
+    private sealed class MockFocusableNode : Hex1bNode
+    {
+        public override bool IsFocusable => true;
+        private bool _isFocused;
+        public override bool IsFocused { get => _isFocused; set => _isFocused = value; }
+
+        public Action<InputBindingsBuilder>? BindingsConfig { get; set; }
+
+        public override void ConfigureDefaultBindings(InputBindingsBuilder bindings)
+        {
+            BindingsConfig?.Invoke(bindings);
+        }
+
+        protected override Size MeasureCore(Constraints constraints) => new(10, 1);
+        public override void Render(Hex1bRenderContext context) { }
+    }
+
+    #region 1. Null guards
+
+    [Fact]
+    public void Add_NullInputBinding_ThrowsArgumentNullException()
+    {
+        var builder = new InputBindingsBuilder();
+        Assert.Throws<ArgumentNullException>(() => builder.Add((InputBinding)null!));
+    }
+
+    [Fact]
+    public void Add_NullMouseBinding_ThrowsArgumentNullException()
+    {
+        var builder = new InputBindingsBuilder();
+        Assert.Throws<ArgumentNullException>(() => builder.Add((MouseBinding)null!));
+    }
+
+    [Fact]
+    public void Add_NullCharacterBinding_ThrowsArgumentNullException()
+    {
+        var builder = new InputBindingsBuilder();
+        Assert.Throws<ArgumentNullException>(() => builder.Add((CharacterBinding)null!));
+    }
+
+    [Fact]
+    public void Add_NullDragBinding_ThrowsArgumentNullException()
+    {
+        var builder = new InputBindingsBuilder();
+        Assert.Throws<ArgumentNullException>(() => builder.Add((DragBinding)null!));
+    }
+
+    #endregion
+
+    #region 2. Round-trip via the public Bindings/MouseBindings/etc. lists
+
+    [Fact]
+    public void Add_PrebuiltInputBinding_AppearsInBindingsList()
+    {
+        var builder = new InputBindingsBuilder();
+        var binding = new InputBinding(
+            [new KeyStep(Hex1bKey.LeftArrow, Hex1bModifiers.Control | Hex1bModifiers.Shift)],
+            () => { },
+            "Select word left");
+
+        builder.Add(binding);
+
+        var actual = Assert.Single(builder.Bindings);
+        Assert.Same(binding, actual);
+        Assert.Empty(builder.MouseBindings);
+        Assert.Empty(builder.CharacterBindings);
+        Assert.Empty(builder.DragBindings);
+    }
+
+    [Fact]
+    public void Add_PrebuiltMouseBinding_AppearsInMouseBindingsList()
+    {
+        var builder = new InputBindingsBuilder();
+        var binding = new MouseBinding(MouseButton.Left, MouseAction.Down, Hex1bModifiers.None, () => { }, "click");
+
+        builder.Add(binding);
+
+        var actual = Assert.Single(builder.MouseBindings);
+        Assert.Same(binding, actual);
+    }
+
+    [Fact]
+    public void Add_PrebuiltCharacterBinding_AppearsInCharacterBindingsList()
+    {
+        var builder = new InputBindingsBuilder();
+        var binding = new CharacterBinding(text => text.Length == 1, _ => { }, "any single char");
+
+        builder.Add(binding);
+
+        var actual = Assert.Single(builder.CharacterBindings);
+        Assert.Same(binding, actual);
+    }
+
+    [Fact]
+    public void Add_PrebuiltDragBinding_AppearsInDragBindingsList()
+    {
+        var builder = new InputBindingsBuilder();
+        var binding = new DragBinding(
+            MouseButton.Left,
+            Hex1bModifiers.None,
+            (_, _) => new DragHandler(),
+            "drag");
+
+        builder.Add(binding);
+
+        var actual = Assert.Single(builder.DragBindings);
+        Assert.Same(binding, actual);
+    }
+
+    #endregion
+
+    #region 3. End-to-end routing through Add(prebuilt)
+
+    [Fact]
+    public async Task Add_PrebuiltCtrlShiftInputBinding_FiresEndToEnd()
+    {
+        // RULE: A Ctrl+Shift+Key binding constructed externally and registered via
+        //       InputBindingsBuilder.Add(InputBinding) routes correctly when the
+        //       terminal delivers a Ctrl+Shift+Key event. Mirrors the fluent-path
+        //       coverage in InputBindingPrecedenceTests.CtrlShiftBinding_GlobalBinding_FiresEndToEnd.
+        // SETUP: VStack with a prebuilt Ctrl+Shift+LeftArrow binding added via b.Add(...).
+        // ACTION: Press Ctrl+Shift+LeftArrow.
+        // EXPECTED: Binding fires.
+
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
+        var bindingFired = false;
+        var renderOccurred = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var prebuilt = new InputBinding(
+            [new KeyStep(Hex1bKey.LeftArrow, Hex1bModifiers.Control | Hex1bModifiers.Shift)],
+            (Action<InputBindingActionContext>)(_ => { bindingFired = true; }),
+            "Prebuilt Ctrl+Shift+LeftArrow");
+
+        using var app = new Hex1bApp(
+            ctx => ctx.VStack(v => [
+                v.Test().OnRender(_ => renderOccurred.TrySetResult())
+            ]).WithInputBindings(b => b.Add(prebuilt)),
+            new Hex1bAppOptions { WorkloadAdapter = workload, EnableDefaultCtrlCExit = false }
+        );
+
+        using var cts = new CancellationTokenSource();
+        var runTask = app.RunAsync(cts.Token);
+
+        await renderOccurred.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Ctrl().Shift().Key(Hex1bKey.LeftArrow).Wait(100).Capture("final")
+            .Build()
+            .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
+
+        Assert.True(bindingFired, "Prebuilt Ctrl+Shift+LeftArrow binding should fire end-to-end");
+
+        cts.Cancel();
+        await runTask;
+    }
+
+    #endregion
+
+    #region 4. Constructor parameter flow-through
+
+    [Fact]
+    public void InputBinding_ConstructedWithActionId_ExposesActionId()
+    {
+        var actionId = new ActionId("Test.Foo");
+        var binding = new InputBinding(
+            [new KeyStep(Hex1bKey.A)],
+            () => { },
+            description: "foo",
+            isGlobal: false,
+            actionId: actionId);
+
+        Assert.Equal(actionId, binding.ActionId);
+        Assert.False(binding.OverridesCapture);
+    }
+
+    [Fact]
+    public void InputBinding_ConstructedWithOverridesCapture_ExposesFlag()
+    {
+        var binding = new InputBinding(
+            [new KeyStep(Hex1bKey.A)],
+            () => { },
+            description: "foo",
+            isGlobal: false,
+            actionId: null,
+            overridesCapture: true);
+
+        Assert.True(binding.OverridesCapture);
+        Assert.Null(binding.ActionId);
+    }
+
+    [Fact]
+    public void MouseBinding_ConstructedWithActionId_ExposesActionId()
+    {
+        var actionId = new ActionId("Test.Click");
+        var binding = new MouseBinding(
+            MouseButton.Left,
+            MouseAction.Down,
+            Hex1bModifiers.None,
+            () => { },
+            "click",
+            actionId);
+
+        Assert.Equal(actionId, binding.ActionId);
+    }
+
+    [Fact]
+    public void CharacterBinding_ConstructedWithActionId_ExposesActionId()
+    {
+        var actionId = new ActionId("Test.Type");
+        var binding = new CharacterBinding(
+            _ => true,
+            _ => { },
+            "type",
+            actionId);
+
+        Assert.Equal(actionId, binding.ActionId);
+    }
+
+    [Fact]
+    public void DragBinding_ConstructedWithActionId_ExposesActionId()
+    {
+        var actionId = new ActionId("Test.Drag");
+        var binding = new DragBinding(
+            MouseButton.Left,
+            Hex1bModifiers.None,
+            (_, _) => new DragHandler(),
+            "drag",
+            actionId);
+
+        Assert.Equal(actionId, binding.ActionId);
+    }
+
+    #endregion
+
+    #region 5. ActionId enables Remove(ActionId) for prebuilt bindings
+
+    [Fact]
+    public void Remove_ByActionId_RemovesPrebuiltMouseBinding()
+    {
+        var builder = new InputBindingsBuilder();
+        var actionId = new ActionId("Test.Click");
+        var binding = new MouseBinding(MouseButton.Left, MouseAction.Down, Hex1bModifiers.None, () => { }, "click", actionId);
+
+        builder.Add(binding);
+        Assert.Single(builder.MouseBindings);
+
+        builder.Remove(actionId);
+
+        Assert.Empty(builder.MouseBindings);
+    }
+
+    [Fact]
+    public void Remove_ByActionId_RemovesPrebuiltInputBinding()
+    {
+        var builder = new InputBindingsBuilder();
+        var actionId = new ActionId("Test.Foo");
+        var binding = new InputBinding([new KeyStep(Hex1bKey.A)], () => { }, "foo", false, actionId);
+
+        builder.Add(binding);
+        Assert.Single(builder.Bindings);
+
+        builder.Remove(actionId);
+
+        Assert.Empty(builder.Bindings);
+    }
+
+    #endregion
+
+    #region 6. End-to-end OverridesCapture flag honored
+
+    [Fact]
+    public async Task Add_PrebuiltOverridesCaptureBinding_FiresWhenCaptured()
+    {
+        // RULE: A prebuilt InputBinding constructed with overridesCapture: true must
+        //       fire even when a downstream node (TerminalWidget) has captured input.
+        //       Mirrors the fluent-path coverage in CaptureOverrideChordTests.
+        // SETUP: VStack containing a child terminal that captures input + a prebuilt
+        //        Ctrl+B binding registered via b.Add(...) with overridesCapture: true.
+        // ACTION: Send Ctrl+B while the terminal has capture.
+        // EXPECTED: The prebuilt binding fires.
+
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
+
+        var bindingFired = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var renderOccurred = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await using var childWorkload = StreamWorkloadAdapter.CreateHeadless(40, 10);
+        using var childTerminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(childWorkload).WithHeadless().WithDimensions(40, 10)
+            .WithTerminalWidget(out var handle).Build();
+
+        using var childCts = new CancellationTokenSource();
+        _ = childTerminal.RunAsync(childCts.Token);
+
+        var prebuilt = new InputBinding(
+            [new KeyStep(Hex1bKey.B, Hex1bModifiers.Control)],
+            (Action<InputBindingActionContext>)(_ => bindingFired.TrySetResult()),
+            description: "Prebuilt override capture",
+            isGlobal: false,
+            actionId: null,
+            overridesCapture: true);
+
+        using var app = new Hex1bApp(
+            ctx =>
+            {
+                var widget = ctx.VStack(v => [
+                    v.Terminal(handle).Fill(),
+                    v.Test().OnRender(_ => renderOccurred.TrySetResult())
+                ]).WithInputBindings(b => b.Add(prebuilt));
+
+                return Task.FromResult<Hex1bWidget>(widget);
+            },
+            new Hex1bAppOptions { WorkloadAdapter = workload, EnableDefaultCtrlCExit = false }
+        );
+
+        using var cts = new CancellationTokenSource();
+        var runTask = app.RunAsync(cts.Token);
+
+        await renderOccurred.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Ctrl().Key(Hex1bKey.B).Wait(100)
+            .Build()
+            .ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+        await bindingFired.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
+
+        await childCts.CancelAsync();
+        cts.Cancel();
+        try { await runTask; } catch (OperationCanceledException) { }
+    }
+
+    #endregion
+
+    #region 7. End-to-end character binding via Add(prebuilt)
+
+    [Fact]
+    public async Task Add_PrebuiltCharacterBinding_FiresOnTextInput()
+    {
+        // RULE: A CharacterBinding constructed externally and registered via
+        //       InputBindingsBuilder.Add(CharacterBinding) fires when its predicate
+        //       matches an incoming text input event. Character bindings only route
+        //       to the focused node, so the receiver must be focusable+focused.
+        // SETUP: A focusable mock node with a prebuilt AnyCharacter-style binding.
+        // ACTION: Route a Hex1bKeyEvent carrying the character 'x'.
+        // EXPECTED: The handler receives "x".
+
+        var received = "";
+        var node = new MockFocusableNode
+        {
+            IsFocused = true,
+            BindingsConfig = b => b.Add(new CharacterBinding(
+                text => text.Length > 0 && !char.IsControl(text[0]),
+                text => received = text,
+                "Prebuilt any character"))
+        };
+
+        var result = await InputRouter.RouteInputToNodeAsync(
+            node,
+            new Hex1bKeyEvent(Hex1bKey.X, 'x', Hex1bModifiers.None),
+            null,
+            null,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(InputResult.Handled, result);
+        Assert.Equal("x", received);
+    }
+
+    #endregion
+
+    #region 8. End-to-end drag binding via Add(prebuilt)
+
+    [Fact]
+    public void Add_PrebuiltDragBinding_FactoryInvokedByStartDrag()
+    {
+        // RULE: A DragBinding constructed externally and registered via
+        //       InputBindingsBuilder.Add(DragBinding) participates in drag dispatch
+        //       just like a fluent-built one. We exercise the binding's StartDrag
+        //       contract directly because end-to-end mouse drag wiring is covered
+        //       elsewhere; this test confirms the prebuilt instance round-trips.
+        // SETUP: A drag binding that records the (x, y) it was started at.
+        // ACTION: Add it, look it up, and invoke StartDrag(7, 11).
+        // EXPECTED: The factory was invoked with (7, 11) and the binding matches a
+        //           Mouse Down event for the configured button + modifiers.
+
+        (int x, int y)? startedAt = null;
+        var binding = new DragBinding(
+            MouseButton.Left,
+            Hex1bModifiers.None,
+            (x, y) =>
+            {
+                startedAt = (x, y);
+                return new DragHandler();
+            },
+            "drag");
+
+        var builder = new InputBindingsBuilder();
+        builder.Add(binding);
+
+        var added = Assert.Single(builder.DragBindings);
+        Assert.True(added.Matches(new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 0, 0, Hex1bModifiers.None, ClickCount: 1)));
+        added.StartDrag(7, 11);
+
+        Assert.Equal((7, 11), startedAt);
+    }
+
+    #endregion
+
+    #region 9. Conflict detection still applies to prebuilt globals
+
+    [Fact]
+    public async Task Add_PrebuiltGlobalBinding_ConflictingDefaultGlobal_Throws()
+    {
+        // RULE: When two global bindings claim the same first key step, the input
+        //       router's CollectGlobalBindings must throw an InvalidOperationException.
+        //       The new public Add(InputBinding) path must not bypass this safety net.
+        // SETUP: Two non-focusable VStacks, one nested in the other. Outer registers a
+        //        global binding for 'X' via the fluent .Global() path; inner registers
+        //        another global binding for 'X' via Add(prebuilt with isGlobal: true).
+        // ACTION: Press 'X' to trigger global collection during input routing.
+        // EXPECTED: app.RunAsync surfaces an InvalidOperationException about a global
+        //           binding conflict.
+
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
+        var renderOccurred = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var prebuiltGlobal = new InputBinding(
+            [new KeyStep(Hex1bKey.X)],
+            () => { },
+            description: "Prebuilt global X",
+            isGlobal: true);
+
+        using var app = new Hex1bApp(
+            ctx => ctx.VStack(outer => [
+                outer.VStack(inner => [
+                    inner.Test().OnRender(_ => renderOccurred.TrySetResult())
+                ]).WithInputBindings(b => b.Add(prebuiltGlobal))
+            ]).WithInputBindings(b =>
+            {
+                b.Key(Hex1bKey.X).Global().Action(() => { }, "Fluent global X");
+            }),
+            new Hex1bAppOptions { WorkloadAdapter = workload, EnableDefaultCtrlCExit = false }
+        );
+
+        using var cts = new CancellationTokenSource();
+        var runTask = app.RunAsync(cts.Token);
+
+        await renderOccurred.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
+
+        await new Hex1bTerminalInputSequenceBuilder().Key(Hex1bKey.X).Wait(100).Build()
+            .ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => await runTask);
+        Assert.Contains("Global binding conflict", ex.Message);
+
+        cts.Cancel();
+    }
+
+    #endregion
+
+    #region 10. Defensive copy of Steps
+
+    [Fact]
+    public void InputBinding_StepsListMutatedAfterConstruction_DoesNotAffectBinding()
+    {
+        // RULE: InputBinding must defensively copy its steps list so that callers
+        //       mutating the source list after construction can't change runtime
+        //       behavior of an already-registered binding.
+
+        var steps = new List<KeyStep>
+        {
+            new(Hex1bKey.LeftArrow, Hex1bModifiers.Control | Hex1bModifiers.Shift)
+        };
+
+        var binding = new InputBinding(steps, () => { }, "select word left");
+
+        steps.Clear();
+        steps.Add(new KeyStep(Hex1bKey.RightArrow, Hex1bModifiers.None));
+
+        var step = Assert.Single(binding.Steps);
+        Assert.Equal(Hex1bKey.LeftArrow, step.Key);
+        Assert.Equal(Hex1bModifiers.Control | Hex1bModifiers.Shift, step.Modifiers);
+    }
+
+    #endregion
+
+    #region 11. ActionId via ctor does NOT register for Triggers(actionId) rebinding
+
+    [Fact]
+    public void Triggers_ByActionId_AfterAddPrebuiltOnly_ThrowsInvalidOperation()
+    {
+        // RULE: An ActionId supplied via the InputBinding ctor identifies the binding
+        //       for Remove(ActionId) and GetBindings(ActionId) only — it does NOT
+        //       populate the rebinding registry. Apps that need Triggers(actionId)
+        //       rebinding support must use the fluent Triggers(actionId, handler, ...)
+        //       path, which both registers the binding and seeds the registry.
+        //       This test locks in that documented limitation so a future implementation
+        //       change is a deliberate decision rather than an accident.
+
+        var builder = new InputBindingsBuilder();
+        var actionId = new ActionId("Test.Foo");
+        var prebuilt = new InputBinding(
+            [new KeyStep(Hex1bKey.A)],
+            () => { },
+            description: "foo",
+            isGlobal: false,
+            actionId: actionId);
+
+        builder.Add(prebuilt);
+
+        // Sanity check: the binding is queryable by its ActionId for inspection/removal.
+        Assert.Single(builder.GetBindings(actionId));
+
+        // But the rebinding registry was NOT seeded, so Triggers(actionId) fails predictably.
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            builder.Key(Hex1bKey.B).Triggers(actionId));
+        Assert.Contains(actionId.Value, ex.Message);
+        Assert.Contains("has not been registered", ex.Message);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Closes #292.

## What

Adds public `InputBindingsBuilder.Add(InputBinding|MouseBinding|CharacterBinding|DragBinding)` overloads so app code can construct bindings outside the fluent step-builder API and register them — useful when bindings are loaded from configuration, generated dynamically, or shared across widgets.

Makes `OverridesCapture` and `ActionId` constructor-only on all four binding types (immutable post-construction). The fluent step builders (`KeyStepBuilder`, `MouseStepBuilder`, `CharacterStepBuilder`, `DragStepBuilder`) now construct bindings fully and call `Add(...)` instead of mutating after the fact. `InputBinding.Steps` is defensively copied.

## Why

[Issue #292](https://github.com/mitchdenny/hex1b/issues/292) raised three concerns. The first (`Ctrl()/Shift()` rejecting modifier combinations) was already fixed by #293. The second (`CtrlShift()` convenience helpers) was scoped out. This PR addresses the third: the `AddBinding(...)` method on `InputBindingsBuilder` was `internal`, so app code had no way to register a prebuilt binding.

## Caveats (documented in `src/content/guide/input.md`)

A new "Registering Prebuilt Bindings" section in the input guide covers four constraints:

- **Treat each binding instance as single-use.** The router stamps `OwnerNode` on the binding during input collection — reusing one across widgets produces ambiguous owner metadata.
- **Mouse and drag bindings on non-focusable nodes never fire.** Mouse routing hit-tests focusables only; wrap a container in `InteractableWidget` to receive mouse events.
- **Character bindings are checked only on the focused node.** They have no global-style fallback.
- **A constructor-supplied `ActionId` does NOT enable `Triggers(actionId)` rebinding.** It supports `Remove(ActionId)` and `GetBindings(ActionId)` only. Apps that need rebindable actions should use the fluent `Triggers(actionId, handler, description)` path, which seeds the rebinding registry.

## Tests

22 new tests in `tests/Hex1b.Tests/PrebuiltBindingTests.cs` covering null-guards, round-trip, end-to-end Ctrl+Shift, OverridesCapture, character routing, drag invocation, global-conflict detection, defensive Steps copy, and the documented `Triggers(actionId)` failure path. All pass.

## Drive-by fix: QuadTerminalDemo

While verifying samples still build, I found `samples/QuadTerminalDemo` was failing on `main` (not caused by this PR) due to an anonymous-type response in a `MapGet` handler that the AOT `RequestDelegateGenerator` source generator cannot represent. Second commit replaces the anonymous type with a named `TerminalConfigResponse` record. JSON shape preserved (camelCase via ASP.NET Core web defaults).

## Verification

- `dotnet build src/Hex1b/Hex1b.csproj` — clean (0 warnings, 0 errors).
- `dotnet test` — 7511 pass + 31 skipped + 1 unrelated flake (`EditorNodeRenderingTests.Render_SmallViewport3Lines_Only3RowsRendered`, passes in isolation).
- All 64/64 sample projects build.