### PR TITLE
Hmp1 state replay: emit private modes on reconnect

### DIFF
--- a/src/Hex1b/Automation/Hex1bTerminalSnapshot.cs
+++ b/src/Hex1b/Automation/Hex1bTerminalSnapshot.cs
@@ -29,6 +29,20 @@ public sealed class Hex1bTerminalSnapshot : IHex1bTerminalRegion, IDisposable
         CursorX = terminal.CursorX;
         CursorY = terminal.CursorY;
         InAlternateScreen = terminal.InAlternateScreen;
+        CursorVisible = terminal.CursorVisible;
+        BracketedPasteEnabled = terminal.BracketedPasteEnabled;
+        ApplicationCursorKeysEnabled = terminal.ApplicationCursorKeysEnabled;
+        ApplicationKeypadEnabled = terminal.ApplicationKeypadEnabled;
+        FocusEventsEnabled = terminal.FocusEventsEnabled;
+        MouseProtocolX10Enabled = terminal.MouseProtocolX10Enabled;
+        MouseProtocolNormalEnabled = terminal.MouseProtocolNormalEnabled;
+        MouseProtocolHighlightEnabled = terminal.MouseProtocolHighlightEnabled;
+        MouseProtocolButtonEnabled = terminal.MouseProtocolButtonEnabled;
+        MouseProtocolAnyEnabled = terminal.MouseProtocolAnyEnabled;
+        MouseEncodingUtf8Enabled = terminal.MouseEncodingUtf8Enabled;
+        MouseEncodingSgrEnabled = terminal.MouseEncodingSgrEnabled;
+        MouseEncodingUrxvtEnabled = terminal.MouseEncodingUrxvtEnabled;
+        CursorShape = terminal.CursorShape;
         Timestamp = DateTimeOffset.UtcNow;
         CellPixelWidth = terminal.Capabilities.CellPixelWidth;
         CellPixelHeight = terminal.Capabilities.CellPixelHeight;
@@ -152,6 +166,77 @@ public sealed class Hex1bTerminalSnapshot : IHex1bTerminalRegion, IDisposable
     /// Whether the terminal was in alternate screen mode at snapshot time.
     /// </summary>
     public bool InAlternateScreen { get; }
+
+    /// <summary>
+    /// Whether the cursor was visible (DECTCEM, DEC mode 25) at snapshot time.
+    /// </summary>
+    public bool CursorVisible { get; }
+
+    /// <summary>
+    /// Whether bracketed-paste mode (DEC mode 2004) was enabled at snapshot time.
+    /// </summary>
+    public bool BracketedPasteEnabled { get; }
+
+    /// <summary>
+    /// Whether application-cursor-keys mode (DECCKM, DEC mode 1) was enabled at snapshot time.
+    /// </summary>
+    public bool ApplicationCursorKeysEnabled { get; }
+
+    /// <summary>
+    /// Whether application-keypad mode (DECKPAM, ESC =) was enabled at snapshot time.
+    /// </summary>
+    public bool ApplicationKeypadEnabled { get; }
+
+    /// <summary>
+    /// Whether focus-in/focus-out reporting (DEC mode 1004) was enabled at snapshot time.
+    /// </summary>
+    public bool FocusEventsEnabled { get; }
+
+    /// <summary>
+    /// Whether X10-compatibility mouse tracking (DEC mode 9) was enabled at snapshot time.
+    /// </summary>
+    public bool MouseProtocolX10Enabled { get; }
+
+    /// <summary>
+    /// Whether X11 normal mouse tracking (DEC mode 1000) was enabled at snapshot time.
+    /// </summary>
+    public bool MouseProtocolNormalEnabled { get; }
+
+    /// <summary>
+    /// Whether highlight mouse tracking (DEC mode 1001) was enabled at snapshot time.
+    /// </summary>
+    public bool MouseProtocolHighlightEnabled { get; }
+
+    /// <summary>
+    /// Whether button-event mouse tracking (DEC mode 1002) was enabled at snapshot time.
+    /// </summary>
+    public bool MouseProtocolButtonEnabled { get; }
+
+    /// <summary>
+    /// Whether any-event mouse tracking (DEC mode 1003) was enabled at snapshot time.
+    /// </summary>
+    public bool MouseProtocolAnyEnabled { get; }
+
+    /// <summary>
+    /// Whether UTF-8 mouse encoding (DEC mode 1005) was enabled at snapshot time.
+    /// </summary>
+    public bool MouseEncodingUtf8Enabled { get; }
+
+    /// <summary>
+    /// Whether SGR mouse encoding (DEC mode 1006) was enabled at snapshot time.
+    /// </summary>
+    public bool MouseEncodingSgrEnabled { get; }
+
+    /// <summary>
+    /// Whether urxvt mouse encoding (DEC mode 1015) was enabled at snapshot time.
+    /// </summary>
+    public bool MouseEncodingUrxvtEnabled { get; }
+
+    /// <summary>
+    /// DECSCUSR cursor shape value at snapshot time. <c>0</c> means "default";
+    /// values 1–6 follow the standard <c>CSI Ps SP q</c> mapping.
+    /// </summary>
+    public int CursorShape { get; }
     
     /// <summary>
     /// Width of a terminal character cell in pixels.

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -170,6 +170,31 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
     // Default is true — Hex1b always clusters graphemes like modern terminals.
     // Applications can disable with CSI ? 2027 l for per-codepoint handling.
     private bool _graphemeClusterMode = true;
+
+    // Replayable terminal modes that affect input/rendering.
+    //
+    // These are tracked here (in addition to the widget-level handle that some
+    // higher-level Hex1b APIs use) so that presentation adapters consuming the
+    // terminal directly — most notably <see cref="Hmp1PresentationAdapter"/> —
+    // can reproduce the modes for a viewer that connects after the workload
+    // has already configured them. Without this tracking, a TUI app that sets
+    // mouse tracking, hides the cursor, switches to the alt screen, etc.
+    // would lose those settings on every reconnect because the cell-content
+    // replay (ToAnsi) only carries visible state.
+    private bool _cursorVisible = true;            // DECTCEM (mode 25), default on
+    private bool _bracketedPasteMode = false;      // mode 2004
+    private bool _appCursorKeysMode = false;       // DECCKM (mode 1)
+    private bool _appKeypadMode = false;           // DECKPAM (ESC =) / DECKPNM (ESC >)
+    private bool _focusEventReporting = false;     // mode 1004
+    private bool _mouseProtocolX10 = false;        // mode 9
+    private bool _mouseProtocolNormal = false;     // mode 1000
+    private bool _mouseProtocolHighlight = false;  // mode 1001
+    private bool _mouseProtocolButton = false;     // mode 1002 (button-event tracking)
+    private bool _mouseProtocolAny = false;        // mode 1003 (any-event / motion tracking)
+    private bool _mouseEncodingUtf8 = false;       // mode 1005
+    private bool _mouseEncodingSgr = false;        // mode 1006
+    private bool _mouseEncodingUrxvt = false;      // mode 1015
+    private int _cursorShape = 0;                  // 0=default; 1..6 per DECSCUSR
     
     // Last printed character for CSI b (REP - repeat) command
     private TerminalCell _lastPrintedCell = TerminalCell.Empty;
@@ -1732,6 +1757,25 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
     /// <summary>Gets whether the terminal has a pending wrap (for testing).</summary>
     internal bool PendingWrap => _pendingWrap;
 
+    // Replayable terminal mode accessors. See the field declarations near the
+    // top of the file for the rationale. These are exposed as internal so that
+    // Hex1b.Automation.Hex1bTerminalSnapshot (same assembly) can capture them
+    // for presentation-adapter replay.
+    internal bool CursorVisible => _cursorVisible;
+    internal bool BracketedPasteEnabled => _bracketedPasteMode;
+    internal bool ApplicationCursorKeysEnabled => _appCursorKeysMode;
+    internal bool ApplicationKeypadEnabled => _appKeypadMode;
+    internal bool FocusEventsEnabled => _focusEventReporting;
+    internal bool MouseProtocolX10Enabled => _mouseProtocolX10;
+    internal bool MouseProtocolNormalEnabled => _mouseProtocolNormal;
+    internal bool MouseProtocolHighlightEnabled => _mouseProtocolHighlight;
+    internal bool MouseProtocolButtonEnabled => _mouseProtocolButton;
+    internal bool MouseProtocolAnyEnabled => _mouseProtocolAny;
+    internal bool MouseEncodingUtf8Enabled => _mouseEncodingUtf8;
+    internal bool MouseEncodingSgrEnabled => _mouseEncodingSgr;
+    internal bool MouseEncodingUrxvtEnabled => _mouseEncodingUrxvt;
+    internal int CursorShape => _cursorShape;
+
     /// <summary>
     /// The scrollback buffer, if one was configured via <see cref="Hex1bTerminalOptions.ScrollbackCapacity"/>.
     /// </summary>
@@ -2564,6 +2608,66 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
                     // When disabled, each codepoint is treated individually.
                     _graphemeClusterMode = privateModeToken.Enable;
                 }
+                else if (privateModeToken.Mode == 1)
+                {
+                    // DECCKM - Application Cursor Keys Mode
+                    _appCursorKeysMode = privateModeToken.Enable;
+                }
+                else if (privateModeToken.Mode == 9)
+                {
+                    // X10 mouse compatibility tracking
+                    _mouseProtocolX10 = privateModeToken.Enable;
+                }
+                else if (privateModeToken.Mode == 25)
+                {
+                    // DECTCEM - Cursor visibility
+                    _cursorVisible = privateModeToken.Enable;
+                }
+                else if (privateModeToken.Mode == 1000)
+                {
+                    // X11 normal mouse tracking (button press/release)
+                    _mouseProtocolNormal = privateModeToken.Enable;
+                }
+                else if (privateModeToken.Mode == 1001)
+                {
+                    // X11 hilite mouse tracking
+                    _mouseProtocolHighlight = privateModeToken.Enable;
+                }
+                else if (privateModeToken.Mode == 1002)
+                {
+                    // Button-event mouse tracking (press/release/drag)
+                    _mouseProtocolButton = privateModeToken.Enable;
+                }
+                else if (privateModeToken.Mode == 1003)
+                {
+                    // Any-event mouse tracking (also reports motion without buttons)
+                    _mouseProtocolAny = privateModeToken.Enable;
+                }
+                else if (privateModeToken.Mode == 1004)
+                {
+                    // Focus-in/focus-out reporting
+                    _focusEventReporting = privateModeToken.Enable;
+                }
+                else if (privateModeToken.Mode == 1005)
+                {
+                    // UTF-8 mouse encoding
+                    _mouseEncodingUtf8 = privateModeToken.Enable;
+                }
+                else if (privateModeToken.Mode == 1006)
+                {
+                    // SGR mouse encoding
+                    _mouseEncodingSgr = privateModeToken.Enable;
+                }
+                else if (privateModeToken.Mode == 1015)
+                {
+                    // urxvt mouse encoding
+                    _mouseEncodingUrxvt = privateModeToken.Enable;
+                }
+                else if (privateModeToken.Mode == 2004)
+                {
+                    // Bracketed paste mode
+                    _bracketedPasteMode = privateModeToken.Enable;
+                }
                 break;
             
             case StandardModeToken stdModeToken:
@@ -2661,8 +2765,11 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
                 }
                 break;
                 
-            case CursorShapeToken:
-                // Cursor shape is presentation-only, no buffer state to update
+            case CursorShapeToken cursorShapeToken:
+                // DECSCUSR — purely presentational, but tracked so a viewer
+                // attaching after the workload set a non-default shape sees
+                // the same cursor.
+                _cursorShape = cursorShapeToken.Shape;
                 break;
                 
             case CursorMoveToken moveToken:
@@ -2855,8 +2962,11 @@ public sealed class Hex1bTerminal : IDisposable, IAsyncDisposable
                 }
                 break;
             
-            case KeypadModeToken:
-                // Keypad mode - presentation-only, no buffer state
+            case KeypadModeToken kpToken:
+                // ESC = / ESC > — DECKPAM/DECKPNM. Tracked so that a viewer
+                // attaching after the workload entered application-keypad
+                // mode sees the same numeric/application-keypad behaviour.
+                _appKeypadMode = kpToken.Application;
                 break;
                 
             case UnrecognizedSequenceToken:

--- a/src/Hex1b/Hmp1/Hmp1PresentationAdapter.cs
+++ b/src/Hex1b/Hmp1/Hmp1PresentationAdapter.cs
@@ -139,12 +139,14 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
             if (_terminal != null)
             {
                 using var snapshot = _terminal.CreateSnapshot();
+                var prefix = BuildStateReplayPrefix(snapshot);
                 var ansi = snapshot.ToAnsi(new TerminalAnsiOptions
                 {
                     IncludeClearScreen = true,
                     IncludeTrailingNewline = true
                 });
-                syncBytes = Encoding.UTF8.GetBytes(ansi);
+                var suffix = BuildStateReplaySuffix(snapshot);
+                syncBytes = Encoding.UTF8.GetBytes(prefix + ansi + suffix);
             }
             else
             {
@@ -163,6 +165,83 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
         session.ReadTask = Task.Run(() => ReadClientPumpAsync(session), sessionCts.Token);
 
         return new Hmp1ClientHandle(session, this);
+    }
+
+    /// <summary>
+    /// Builds the leading portion of a StateSync replay. Anything that has to
+    /// happen <em>before</em> the cell content is painted (like switching to
+    /// the alternate screen so the painter's clear+home target the right
+    /// buffer) is emitted here.
+    /// </summary>
+    private static string BuildStateReplayPrefix(Hex1bTerminalSnapshot snapshot)
+    {
+        var sb = new StringBuilder();
+
+        // ToAnsi paints onto whichever buffer the viewer is currently on and
+        // does its own \x1b[2J + \x1b[H. If the workload had switched to the
+        // alternate screen, we have to enter alt screen first so the
+        // subsequent clear+home target the alt buffer. DECSET 1049 also saves
+        // and restores the cursor as a side-effect, which lines up with how a
+        // viewer would have observed the original entry.
+        if (snapshot.InAlternateScreen)
+        {
+            sb.Append("\x1b[?1049h");
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Builds the trailing portion of a StateSync replay. Modes are emitted
+    /// here so that any ANSI in the cell-content payload (which conceptually
+    /// targets a freshly-cleared screen) cannot accidentally clobber them.
+    /// Only non-default modes are emitted; the viewer's terminal starts with
+    /// the standard defaults already applied.
+    /// </summary>
+    private static string BuildStateReplaySuffix(Hex1bTerminalSnapshot snapshot)
+    {
+        var sb = new StringBuilder();
+
+        // Mouse-tracking protocols. These flags are independent in xterm — a
+        // workload may legitimately enable more than one — so we mirror that
+        // model on replay rather than picking a single "winning" mode.
+        if (snapshot.MouseProtocolX10Enabled)        { sb.Append("\x1b[?9h"); }
+        if (snapshot.MouseProtocolNormalEnabled)     { sb.Append("\x1b[?1000h"); }
+        if (snapshot.MouseProtocolHighlightEnabled)  { sb.Append("\x1b[?1001h"); }
+        if (snapshot.MouseProtocolButtonEnabled)     { sb.Append("\x1b[?1002h"); }
+        if (snapshot.MouseProtocolAnyEnabled)        { sb.Append("\x1b[?1003h"); }
+
+        // Mouse-encoding modes. Same independence applies.
+        if (snapshot.MouseEncodingUtf8Enabled)       { sb.Append("\x1b[?1005h"); }
+        if (snapshot.MouseEncodingSgrEnabled)        { sb.Append("\x1b[?1006h"); }
+        if (snapshot.MouseEncodingUrxvtEnabled)      { sb.Append("\x1b[?1015h"); }
+
+        // Focus events.
+        if (snapshot.FocusEventsEnabled)             { sb.Append("\x1b[?1004h"); }
+
+        // Bracketed paste.
+        if (snapshot.BracketedPasteEnabled)          { sb.Append("\x1b[?2004h"); }
+
+        // Application cursor keys (DECCKM).
+        if (snapshot.ApplicationCursorKeysEnabled)   { sb.Append("\x1b[?1h"); }
+
+        // Application keypad mode (DECKPAM).
+        if (snapshot.ApplicationKeypadEnabled)       { sb.Append("\x1b="); }
+
+        // Cursor visibility — default is visible, so only emit when hidden.
+        if (!snapshot.CursorVisible)                 { sb.Append("\x1b[?25l"); }
+
+        // Cursor shape (DECSCUSR). 0 means "default"; only emit when
+        // non-default. The space-q trailer is part of the sequence, not a
+        // separator.
+        if (snapshot.CursorShape > 0)
+        {
+            sb.Append("\x1b[");
+            sb.Append(snapshot.CursorShape);
+            sb.Append(" q");
+        }
+
+        return sb.ToString();
     }
 
     /// <inheritdoc />

--- a/tests/Hex1b.Tests/Muxer/MuxerAdapterTests.cs
+++ b/tests/Hex1b.Tests/Muxer/MuxerAdapterTests.cs
@@ -1,6 +1,7 @@
 using System.IO.Pipelines;
 using System.Text;
 using Hex1b;
+using Hex1b.Tokens;
 
 namespace Hex1b.Tests.Muxer;
 
@@ -188,6 +189,139 @@ public class MuxerAdapterTests
     }
 
     [Fact]
+    public async Task StateReplay_EmitsTrackedPrivateModesOnReconnect()
+    {
+        // The presentation adapter rebuilds the screen state for a new viewer
+        // by sending a StateSync frame derived from a Hex1bTerminal snapshot.
+        // ToAnsi only encodes cells + cursor; this test pins down that
+        // private terminal modes (mouse tracking, focus events, bracketed
+        // paste, etc.) are also emitted so that a viewer reconnecting
+        // mid-session sees the same xterm modes as the original viewer did.
+        await using var adapter = new Hmp1PresentationAdapter(80, 24);
+        using var terminal = new Hex1bTerminal(new Hex1bTerminalOptions
+        {
+            Width = 80,
+            Height = 24,
+            WorkloadAdapter = new NoOpWorkloadAdapter(),
+            PresentationAdapter = adapter
+        });
+
+        // Drive the terminal through a representative TUI startup sequence.
+        // Pick at least one mode in each replay-suffix family so a regression
+        // in any single emit branch surfaces here.
+        terminal.ApplyTokens([
+            new PrivateModeToken(1002, true),  // SET_BTN_EVENT_MOUSE
+            new PrivateModeToken(1006, true),  // SET_SGR_EXT_MODE_MOUSE
+            new PrivateModeToken(1004, true),  // SET_FOCUS_EVENT_MOUSE
+            new PrivateModeToken(2004, true),  // SET_BRACKETED_PASTE
+            new PrivateModeToken(25, false),   // RESET_DECTCEM (hide cursor)
+            new PrivateModeToken(1, true),     // SET_DECCKM (app cursor keys)
+            new KeypadModeToken(true),         // DECKPAM
+            new CursorShapeToken(2),           // DECSCUSR steady block
+        ]);
+
+        var (stream1, stream2) = CreateFullDuplexPair();
+        var handle = await adapter.AddClient(stream1);
+
+        var client = new Hmp1WorkloadAdapter(stream2);
+        await client.ConnectAsync(CancellationToken.None);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var stateSyncBytes = await client.ReadOutputAsync(cts.Token);
+        var stateSync = Encoding.UTF8.GetString(stateSyncBytes.Span);
+
+        Assert.Contains("\x1b[?1002h", stateSync);
+        Assert.Contains("\x1b[?1006h", stateSync);
+        Assert.Contains("\x1b[?1004h", stateSync);
+        Assert.Contains("\x1b[?2004h", stateSync);
+        Assert.Contains("\x1b[?25l", stateSync);
+        Assert.Contains("\x1b[?1h", stateSync);
+        Assert.Contains("\x1b=", stateSync);
+        Assert.Contains("\x1b[2 q", stateSync);
+
+        await handle.DisposeAsync();
+        await client.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task StateReplay_OmitsDefaultModes()
+    {
+        // A pristine terminal should produce a StateSync without DECSETs
+        // for any replay-tracked mode, since the viewer's terminal already
+        // starts at those defaults. Otherwise we'd be sending sequences for
+        // every reconnect that have no semantic effect but make the wire
+        // payload larger and the replay slower.
+        await using var adapter = new Hmp1PresentationAdapter(80, 24);
+        using var terminal = new Hex1bTerminal(new Hex1bTerminalOptions
+        {
+            Width = 80,
+            Height = 24,
+            WorkloadAdapter = new NoOpWorkloadAdapter(),
+            PresentationAdapter = adapter
+        });
+
+        var (stream1, stream2) = CreateFullDuplexPair();
+        var handle = await adapter.AddClient(stream1);
+
+        var client = new Hmp1WorkloadAdapter(stream2);
+        await client.ConnectAsync(CancellationToken.None);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var stateSyncBytes = await client.ReadOutputAsync(cts.Token);
+        var stateSync = Encoding.UTF8.GetString(stateSyncBytes.Span);
+
+        // None of the DECSETs covered by BuildStateReplaySuffix should fire.
+        Assert.DoesNotContain("\x1b[?1002h", stateSync);
+        Assert.DoesNotContain("\x1b[?1006h", stateSync);
+        Assert.DoesNotContain("\x1b[?1004h", stateSync);
+        Assert.DoesNotContain("\x1b[?2004h", stateSync);
+        Assert.DoesNotContain("\x1b[?25l", stateSync);
+        Assert.DoesNotContain("\x1b[?1h", stateSync);
+        Assert.DoesNotContain("\x1b=", stateSync);
+
+        await handle.DisposeAsync();
+        await client.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task StateReplay_AlternateScreenIsEnteredBeforeCellRepaint()
+    {
+        // When a workload has switched to the alternate screen (TUI like
+        // htop, vim, less), the viewer reconnecting must enter the alt
+        // screen *before* the painter's clear+home, otherwise the snapshot
+        // will paint into the primary buffer and clobber it.
+        await using var adapter = new Hmp1PresentationAdapter(80, 24);
+        using var terminal = new Hex1bTerminal(new Hex1bTerminalOptions
+        {
+            Width = 80,
+            Height = 24,
+            WorkloadAdapter = new NoOpWorkloadAdapter(),
+            PresentationAdapter = adapter
+        });
+
+        terminal.ApplyTokens([new PrivateModeToken(1049, true)]);
+
+        var (stream1, stream2) = CreateFullDuplexPair();
+        var handle = await adapter.AddClient(stream1);
+
+        var client = new Hmp1WorkloadAdapter(stream2);
+        await client.ConnectAsync(CancellationToken.None);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var stateSyncBytes = await client.ReadOutputAsync(cts.Token);
+        var stateSync = Encoding.UTF8.GetString(stateSyncBytes.Span);
+
+        var altIndex = stateSync.IndexOf("\x1b[?1049h", StringComparison.Ordinal);
+        var clearIndex = stateSync.IndexOf("\x1b[2J", StringComparison.Ordinal);
+
+        Assert.True(altIndex >= 0, "Alt-screen DECSET 1049h must be emitted when the workload is on the alt screen.");
+        Assert.True(clearIndex > altIndex, "Alt-screen DECSET must come before the clear-screen sequence.");
+
+        await handle.DisposeAsync();
+        await client.DisposeAsync();
+    }
+
+    [Fact]
     public async Task Hmp1WorkloadAdapter_Disconnected_FiredOnStreamClose()
     {
         var (stream1, stream2) = CreateFullDuplexPair();
@@ -294,5 +428,31 @@ public class MuxerAdapterTests
             await writeStream.DisposeAsync();
             await base.DisposeAsync();
         }
+    }
+
+    /// <summary>
+    /// A workload adapter that does nothing. Lets us construct a Hex1bTerminal
+    /// for unit tests where we drive state directly via ApplyTokens rather
+    /// than feeding bytes through a pump.
+    /// </summary>
+    private sealed class NoOpWorkloadAdapter : IHex1bTerminalWorkloadAdapter
+    {
+        public event Action? Disconnected
+        {
+            add { }
+            remove { }
+        }
+
+        public ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(CancellationToken ct = default)
+            => ValueTask.FromResult(ReadOnlyMemory<byte>.Empty);
+
+        public ValueTask WriteInputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask ResizeAsync(int width, int height, CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync()
+            => ValueTask.CompletedTask;
     }
 }


### PR DESCRIPTION
## Problem

`Hmp1PresentationAdapter`'s StateSync frame is the protocol's mechanism for bringing a freshly-attached HMP1 viewer up to the same screen state the workload has produced so far. Today, that frame is built from `Hex1bTerminalSnapshot.ToAnsi(...)`, which only emits cell content + cursor position. None of the private terminal modes the workload may have set are replayed.

The practical consequence: a viewer that disconnects and reconnects mid-session for a TUI like `htop`, `vim`, or `less` sees the screen contents but loses mouse tracking, focus events, cursor shape, bracketed paste, app cursor keys, etc. Most TUIs only set those modes at startup, so they never get re-issued and the reconnected viewer is stuck without mouse/etc until the workload is restarted.

This was found while wiring HMP1 into the Aspire dashboard's terminal viewer. Navigating away from a terminal page and back lost mouse mode every single time.

## What changed

`Hex1bTerminal` now tracks the private modes that survive state replay:

- DECTCEM (`?25`) cursor visibility
- DECCKM (`?1`) application cursor keys
- DECKPAM / DECKPNM (`ESC =` / `ESC >`) application keypad
- Mouse tracking protocols `?9` / `?1000` / `?1001` / `?1002` / `?1003` (independent flags so multiple-tracking-mode workloads round-trip faithfully)
- Mouse encodings `?1005` / `?1006` / `?1015`
- Focus-event reporting `?1004`
- Bracketed paste `?2004`
- DECSCUSR cursor shape

`Hex1bTerminalSnapshot` captures all of the above alongside the existing `InAlternateScreen` flag.

`Hmp1PresentationAdapter.AddClient` now wraps the snapshot's `ToAnsi(...)` output with:

- A **prefix** that emits the alt-screen DECSET *before* the painter, so the cell content lands on the alt buffer rather than clobbering primary.
- A **suffix** that emits DECSETs for every non-default tracked mode *after* the painter, as insurance against any sequence in the cell payload accidentally clobbering them.

Default modes are deliberately not emitted — the viewer's terminal already starts at those defaults, and emitting them would just bloat every reconnect with no semantic effect.

## Tests

Three new tests in `MuxerAdapterTests` (`tests/Hex1b.Tests/Muxer/MuxerAdapterTests.cs`) pin down the contract:

- `StateReplay_EmitsTrackedPrivateModesOnReconnect` — the regression test for the bug above. Drives a `Hex1bTerminal` through a representative TUI startup token sequence (mouse, focus, paste, cursor visibility, app-cursor-keys, app-keypad, cursor shape) and asserts every one of those DECSETs ends up in the StateSync bytes a fresh viewer reads.
- `StateReplay_OmitsDefaultModes` — guards against bloating every reconnect with no-op DECSETs. A pristine terminal must produce a StateSync without any of the suffix DECSETs.
- `StateReplay_AlternateScreenIsEnteredBeforeCellRepaint` — pins the prefix/suffix ordering invariant: when the workload is on the alt screen, `?1049h` must appear before the painter's `\x1b[2J`.

`dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj` — `Failed: 0, Passed: 7608, Skipped: 27, Total: 7635`.

## Validation

For reviewers wanting to dogfood this against a real HMP1 viewer:

1. Check out this branch and `dotnet pack src/Hex1b/Hex1b.csproj -c Release -o ./nupkgs -p:PackageVersion=0.144.1-localdev0`.
2. Add `./nupkgs` as a local NuGet source in any consumer that uses `Hex1bTerminal` + `Hmp1PresentationAdapter` (e.g. an Aspire dashboard branch wired to a `WithTerminal` resource), bump the Hex1b version to `0.144.1-localdev0`.
3. Run a TUI that uses mouse mode (`htop`, `btop`, `vim` with `set mouse=a`).
4. Disconnect the viewer and reconnect (in Aspire dashboard: navigate away from the terminal page and back).
5. Without this PR: mouse stops working on the second view. With this PR: mouse, focus events, cursor shape, etc. all persist.

The smaller-scope unit-level validation is `dotnet test --filter "*MuxerAdapterTests*"`.