### PR TITLE
Bump Aspire to 13.3.0 and patch OpenTelemetry CVEs

### DIFF
--- a/apphost.cs
+++ b/apphost.cs
@@ -1,6 +1,6 @@
-#:sdk Aspire.AppHost.Sdk@13.2.0
-#:package Aspire.Hosting.JavaScript@13.2.0
-#:package Aspire.Hosting.Azure.AppContainers@13.2.0
+#:sdk Aspire.AppHost.Sdk@13.3.0
+#:package Aspire.Hosting.JavaScript@13.3.0
+#:package Aspire.Hosting.Azure.AppContainers@13.3.0
 
 using Aspire.Hosting.Pipelines;
 using Microsoft.Extensions.Logging;

--- a/src/Hex1b.ServiceDefaults/Hex1b.ServiceDefaults.csproj
+++ b/src/Hex1b.ServiceDefaults/Hex1b.ServiceDefaults.csproj
@@ -12,11 +12,11 @@
 
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.14.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.14.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Bumps the Aspire AppHost SDK and hosting packages from **13.2.0 → 13.3.0** in `apphost.cs`, then resolves the OpenTelemetry NU1902 vulnerability warnings the website resource started emitting after the bump.

## OpenTelemetry CVEs

The website's build output flagged four GitHub advisories against the `OpenTelemetry.*` 1.14.0 packages referenced by `Hex1b.ServiceDefaults` (transitively used by `Hex1b.Website`):

| Package | Advisory |
|---|---|
| `OpenTelemetry.Api` | [GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j) |
| `OpenTelemetry.Exporter.OpenTelemetryProtocol` | [GHSA-4625-4j76-fww9](https://github.com/advisories/GHSA-4625-4j76-fww9) |
| `OpenTelemetry.Exporter.OpenTelemetryProtocol` | [GHSA-mr8r-92fq-pj8p](https://github.com/advisories/GHSA-mr8r-92fq-pj8p) |
| `OpenTelemetry.Exporter.OpenTelemetryProtocol` | [GHSA-q834-8qmm-v933](https://github.com/advisories/GHSA-q834-8qmm-v933) |

All four are patched in the OpenTelemetry **1.15.x** wave, so every OTEL package in `Hex1b.ServiceDefaults` is bumped to its current latest stable:

| Package | From | To |
|---|---|---|
| `OpenTelemetry.Exporter.OpenTelemetryProtocol` | 1.14.0 | **1.15.3** |
| `OpenTelemetry.Extensions.Hosting` | 1.14.0 | **1.15.3** |
| `OpenTelemetry.Instrumentation.AspNetCore` | 1.14.0 | **1.15.2** |
| `OpenTelemetry.Instrumentation.Http` | 1.14.0 | **1.15.1** |
| `OpenTelemetry.Instrumentation.Runtime` | 1.14.0 | **1.15.1** |

## Verification

- `dotnet build` on `Hex1b.ServiceDefaults` and `Hex1b.Website`: **0 warnings, 0 errors**.
- `aspire start --isolated` cycle: `website` resource reports healthy and `aspire logs website` contains zero `NU1902` entries.