### PR TITLE
Add HEX1B0006–0009 widget extension naming analyzers and refactor surface to comply

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,8 +83,12 @@ This repo ships a Roslyn analyzer (`src/Hex1b.Analyzers/`) that runs against eve
 | HEX1B0003  | Types deriving from `Hex1bNode` must end with `Node` | |
 | HEX1B0004  | Types deriving from `Hex1bWidget` must be declared as `record` | |
 | HEX1B0005  | Types deriving from `Hex1bNode` must be declared as `class` | |
+| HEX1B0006  | Receiver of widget extension on `WidgetContext<T>` must be named `context` | Flutter-style — keeps the receiver name predictable across every `context.Border(...)`-style call. |
+| HEX1B0007  | Receiver of widget instance extension must be named `widget` | Applies when the receiver is `Hex1bWidget`-derived (or a generic constrained to it). `WidgetContext<T>` receivers are governed by HEX1B0006. |
+| HEX1B0008  | A single widget-builder callback parameter must be named `builder` | "Widget-builder callback" = `Func<…, Hex1bWidget>` (or array / `IEnumerable<>` / derived widget). `On[A-Z]…` event-handler methods are excluded. |
+| HEX1B0009  | A widget extension/instance method should declare at most one widget-builder callback parameter | Multi-builder shapes (e.g. `HSplitter(left, right)`) require explicit `[SuppressMessage("Hex1b.ApiDesign", "HEX1B0009")]`. Same `On*` exclusion as HEX1B0008. |
 
-All five rules default to `Warning` severity and the lib builds under `TreatWarningsAsErrors=true` with zero suppressions. Any new `With*` method on a widget will break the build immediately.
+All nine rules default to `Warning` severity and the lib builds under `TreatWarningsAsErrors=true`. Suppressions exist only where they encode a deliberate API decision (HEX1B0009 on `Splitter`'s two-pane shape).
 
 Tests for the analyzers live in `tests/Hex1b.Analyzers.Tests/`. New rules should follow the existing pattern: implement in `src/Hex1b.Analyzers/`, declare the ID in `Hex1bDiagnosticIds.cs` and `AnalyzerReleases.Unshipped.md`, and add positive + negative tests.
 
@@ -93,6 +97,11 @@ Tests for the analyzers live in `tests/Hex1b.Analyzers.Tests/`. New rules should
 - Nodes: `*Node` (e.g., `TextBlockNode`, `ButtonNode`) — enforced by HEX1B0003/HEX1B0005.
 - State objects: `*State` (e.g., `TextBoxState`) - for widgets requiring user-owned mutable state
 - Widget configuration methods: never `With*` — that prefix is reserved for `Hex1bTerminalBuilder`. Use `On*` for event handlers and verb-noun for properties (e.g., `Title`, `MaxFloating`, `Disabled`). Enforced by HEX1B0001.
+- Widget extension method parameters (Flutter-style):
+  - `WidgetContext<T>` receiver → `context` (HEX1B0006)
+  - Widget instance receiver (`this XxxWidget …` or `where TWidget : Hex1bWidget`) → `widget` (HEX1B0007)
+  - A single widget-builder callback (`Func<…, Hex1bWidget>` etc.) → `builder` (HEX1B0008)
+  - Avoid having two builder callbacks on one method; if genuinely required, suppress HEX1B0009 with a justification (HEX1B0009)
 
 ### Widget Definition Pattern
 ```csharp

--- a/src/Hex1b.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Hex1b.Analyzers/AnalyzerReleases.Unshipped.md
@@ -7,3 +7,7 @@ HEX1B0002  | Hex1b.ApiDesign  | Warning  | Type derived from `Hex1bWidget` must 
 HEX1B0003  | Hex1b.ApiDesign  | Warning  | Type derived from `Hex1bNode` must have a name ending in 'Node'.
 HEX1B0004  | Hex1b.ApiDesign  | Warning  | Type derived from `Hex1bWidget` must be declared as `record`.
 HEX1B0005  | Hex1b.ApiDesign  | Warning  | Type derived from `Hex1bNode` must be declared as `class` (not `record`).
+HEX1B0006  | Hex1b.ApiDesign  | Warning  | Receiver of widget extension method on `WidgetContext<T>` must be named `context`.
+HEX1B0007  | Hex1b.ApiDesign  | Warning  | Receiver of widget instance extension method must be named `widget`.
+HEX1B0008  | Hex1b.ApiDesign  | Warning  | A single widget-builder callback parameter must be named `builder`.
+HEX1B0009  | Hex1b.ApiDesign  | Warning  | A widget extension/instance method should declare at most one widget-builder callback parameter.

--- a/src/Hex1b.Analyzers/Hex1bDiagnosticIds.cs
+++ b/src/Hex1b.Analyzers/Hex1bDiagnosticIds.cs
@@ -12,6 +12,10 @@ internal static class Hex1bDiagnosticIds
     public const string NodeTypeNameMissingSuffix = "HEX1B0003";
     public const string WidgetMustBeRecord = "HEX1B0004";
     public const string NodeMustBeClass = "HEX1B0005";
+    public const string WidgetContextReceiverName = "HEX1B0006";
+    public const string WidgetInstanceReceiverName = "HEX1B0007";
+    public const string WidgetBuilderCallbackName = "HEX1B0008";
+    public const string WidgetMultipleBuilderCallbacks = "HEX1B0009";
 
     /// <summary>
     /// Help link template. Diagnostic-specific suffix is appended.

--- a/src/Hex1b.Analyzers/Hex1bSymbols.cs
+++ b/src/Hex1b.Analyzers/Hex1bSymbols.cs
@@ -10,6 +10,7 @@ internal static class Hex1bSymbols
 {
     public const string WidgetMetadataName = "Hex1b.Widgets.Hex1bWidget";
     public const string NodeMetadataName = "Hex1b.Hex1bNode";
+    public const string WidgetContextMetadataName = "Hex1b.WidgetContext`1";
 
     /// <summary>
     /// Gets the <c>Hex1b.Widgets.Hex1bWidget</c> type symbol from the compilation, or null if not referenced.
@@ -22,6 +23,13 @@ internal static class Hex1bSymbols
     /// </summary>
     public static INamedTypeSymbol? GetNodeType(Compilation compilation)
         => compilation.GetTypeByMetadataName(NodeMetadataName);
+
+    /// <summary>
+    /// Gets the unbound generic <c>Hex1b.WidgetContext&lt;TParentWidget&gt;</c> type symbol from the
+    /// compilation, or null if not referenced.
+    /// </summary>
+    public static INamedTypeSymbol? GetWidgetContextType(Compilation compilation)
+        => compilation.GetTypeByMetadataName(WidgetContextMetadataName);
 
     /// <summary>
     /// Returns true if <paramref name="type"/> is exactly <paramref name="target"/> or transitively
@@ -68,6 +76,125 @@ internal static class Hex1bSymbols
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Returns true if <paramref name="type"/> is a constructed <c>Hex1b.WidgetContext&lt;T&gt;</c>
+    /// (regardless of the specific T argument).
+    /// </summary>
+    public static bool IsWidgetContext(ITypeSymbol? type, INamedTypeSymbol? widgetContextType)
+    {
+        if (type is null || widgetContextType is null)
+        {
+            return false;
+        }
+
+        if (type is not INamedTypeSymbol named || !named.IsGenericType)
+        {
+            return false;
+        }
+
+        var definition = named.OriginalDefinition;
+        return SymbolEqualityComparer.Default.Equals(definition, widgetContextType);
+    }
+
+    /// <summary>
+    /// Returns true if <paramref name="parameter"/> is a "widget-builder callback" — that is,
+    /// a <see cref="System.Func{T, TResult}"/> whose return type is a widget, an array of widgets,
+    /// or an <see cref="System.Collections.Generic.IEnumerable{T}"/> of widgets. Used by HEX1B0008
+    /// (single-builder naming) and HEX1B0009 (at-most-one-builder).
+    /// </summary>
+    public static bool IsWidgetBuilderCallback(IParameterSymbol parameter, INamedTypeSymbol? widgetType)
+    {
+        if (widgetType is null)
+        {
+            return false;
+        }
+
+        if (parameter.Type is not INamedTypeSymbol named || !named.IsGenericType)
+        {
+            return false;
+        }
+
+        // Must be System.Func`N (any arity >= 1) — i.e. delegate type whose name starts with "Func"
+        // and lives in System. We accept Func<T, TResult>, Func<T1, T2, TResult>, etc. so long as
+        // the final type argument is a widget shape.
+        var def = named.ConstructedFrom;
+        if (def.Name != "Func" || def.ContainingNamespace?.ToDisplayString() != "System")
+        {
+            return false;
+        }
+
+        if (named.TypeArguments.Length == 0)
+        {
+            return false;
+        }
+
+        var returnType = named.TypeArguments[named.TypeArguments.Length - 1];
+        return ReturnTypeIsWidgetShape(returnType, widgetType);
+    }
+
+    private static bool ReturnTypeIsWidgetShape(ITypeSymbol returnType, INamedTypeSymbol widgetType)
+    {
+        // Strip nullable annotation: Func<..., Hex1bWidget?> still counts.
+        if (returnType is INamedTypeSymbol nullable
+            && nullable.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T
+            && nullable.TypeArguments.Length == 1)
+        {
+            returnType = nullable.TypeArguments[0];
+        }
+
+        // Direct widget return.
+        if (InheritsFromOrEquals(returnType, widgetType))
+        {
+            return true;
+        }
+
+        // Array of widgets: Hex1bWidget[] (any element subtype).
+        if (returnType is IArrayTypeSymbol array)
+        {
+            return InheritsFromOrEquals(array.ElementType, widgetType)
+                || (array.ElementType is INamedTypeSymbol elemNullable
+                    && elemNullable.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T
+                    && elemNullable.TypeArguments.Length == 1
+                    && InheritsFromOrEquals(elemNullable.TypeArguments[0], widgetType));
+        }
+
+        // IEnumerable<widget> (or any subtype of widget). Accepts IEnumerable<Hex1bWidget?> too.
+        if (returnType is INamedTypeSymbol namedReturn && namedReturn.IsGenericType)
+        {
+            foreach (var iface in EnumerateInterfacesAndSelf(namedReturn))
+            {
+                if (iface.Name == "IEnumerable"
+                    && iface.ContainingNamespace?.ToDisplayString() == "System.Collections.Generic"
+                    && iface.TypeArguments.Length == 1)
+                {
+                    var element = iface.TypeArguments[0];
+                    if (element is INamedTypeSymbol elemNullable
+                        && elemNullable.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T
+                        && elemNullable.TypeArguments.Length == 1)
+                    {
+                        element = elemNullable.TypeArguments[0];
+                    }
+
+                    if (InheritsFromOrEquals(element, widgetType))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<INamedTypeSymbol> EnumerateInterfacesAndSelf(INamedTypeSymbol type)
+    {
+        yield return type;
+        foreach (var iface in type.AllInterfaces)
+        {
+            yield return iface;
+        }
     }
 
     private static bool TypeParameterIsConstrainedToWidget(

--- a/src/Hex1b.Analyzers/WidgetBuilderCallbackNameAnalyzer.cs
+++ b/src/Hex1b.Analyzers/WidgetBuilderCallbackNameAnalyzer.cs
@@ -1,0 +1,181 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Hex1b.Analyzers;
+
+/// <summary>
+/// HEX1B0008: When a widget extension/instance method declares exactly one widget-builder
+/// callback parameter (a <c>Func&lt;TContext, Hex1bWidget&gt;</c>-shaped parameter), it must
+/// be named <c>builder</c>. Methods with two or more such callbacks are governed by HEX1B0009
+/// instead and bypass this check.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class WidgetBuilderCallbackNameAnalyzer : DiagnosticAnalyzer
+{
+    public const string ExpectedName = "builder";
+
+    private static readonly LocalizableString Title =
+        "Widget-builder callback parameter must be named 'builder'";
+
+    private static readonly LocalizableString MessageFormat =
+        "Widget-builder callback parameter '{0}' on method '{1}' should be named 'builder'";
+
+    private static readonly LocalizableString Description =
+        "When a Hex1b widget extension or instance method takes exactly one widget-building callback (Func<TContext, Hex1bWidget> and friends), name it 'builder' for consistency with the rest of the API. Multi-builder methods are governed by HEX1B0009.";
+
+    public static readonly DiagnosticDescriptor Rule = new(
+        id: Hex1bDiagnosticIds.WidgetBuilderCallbackName,
+        title: Title,
+        messageFormat: MessageFormat,
+        category: Hex1bDiagnosticIds.Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: Description,
+        helpLinkUri: Hex1bDiagnosticIds.HelpLink(Hex1bDiagnosticIds.WidgetBuilderCallbackName));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(compilationStart =>
+        {
+            var widgetType = Hex1bSymbols.GetWidgetType(compilationStart.Compilation);
+            if (widgetType is null)
+            {
+                return;
+            }
+
+            var widgetContextType = Hex1bSymbols.GetWidgetContextType(compilationStart.Compilation);
+
+            compilationStart.RegisterSymbolAction(
+                ctx => AnalyzeMethod(ctx, widgetType, widgetContextType),
+                SymbolKind.Method);
+        });
+    }
+
+    private static void AnalyzeMethod(
+        SymbolAnalysisContext context,
+        INamedTypeSymbol widgetType,
+        INamedTypeSymbol? widgetContextType)
+    {
+        var method = (IMethodSymbol)context.Symbol;
+
+        if (method.IsOverride || !method.ExplicitInterfaceImplementations.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        // 'On*' methods are event-handler decorators (e.g. OnBlock, OnExpanding, OnClick).
+        // Their callback parameter is semantically a "handler", not a widget-tree builder,
+        // even when the handler returns a widget shape.
+        if (IsEventHandlerMethodName(method.Name))
+        {
+            return;
+        }
+
+        if (!IsWidgetExtensionOrInstanceMethod(method, widgetType, widgetContextType))
+        {
+            return;
+        }
+
+        // Find all widget-builder callback parameters (skip the receiver of an extension method).
+        var startIndex = method.IsExtensionMethod ? 1 : 0;
+        IParameterSymbol? sole = null;
+        var count = 0;
+        for (var i = startIndex; i < method.Parameters.Length; i++)
+        {
+            var p = method.Parameters[i];
+            if (Hex1bSymbols.IsWidgetBuilderCallback(p, widgetType))
+            {
+                count++;
+                if (count == 1)
+                {
+                    sole = p;
+                }
+                else
+                {
+                    // HEX1B0009 owns multi-builder shape.
+                    return;
+                }
+            }
+        }
+
+        if (count != 1 || sole is null)
+        {
+            return;
+        }
+
+        if (string.Equals(sole.Name, ExpectedName, System.StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var location = sole.Locations.IsDefaultOrEmpty ? Location.None : sole.Locations[0];
+        context.ReportDiagnostic(Diagnostic.Create(Rule, location, sole.Name, method.Name));
+    }
+
+    private static bool IsWidgetExtensionOrInstanceMethod(
+        IMethodSymbol method,
+        INamedTypeSymbol widgetType,
+        INamedTypeSymbol? widgetContextType)
+    {
+        if (method.IsExtensionMethod)
+        {
+            if (method.Parameters.IsDefaultOrEmpty)
+            {
+                return false;
+            }
+
+            var receiverType = method.Parameters[0].Type;
+
+            // WidgetContext<T> extensions are widget-tree builders.
+            if (Hex1bSymbols.IsWidgetContext(receiverType, widgetContextType))
+            {
+                return true;
+            }
+
+            return Hex1bSymbols.IsWidgetTypeOrConstrainedToWidget(receiverType, widgetType);
+        }
+
+        // Instance methods declared on a widget type (e.g. methods on a widget record).
+        if (method.IsStatic)
+        {
+            return false;
+        }
+
+        if (method.DeclaredAccessibility is not (Accessibility.Public or Accessibility.Internal or Accessibility.ProtectedOrInternal))
+        {
+            return false;
+        }
+
+        if (method.MethodKind is MethodKind.Constructor
+            or MethodKind.PropertyGet
+            or MethodKind.PropertySet
+            or MethodKind.EventAdd
+            or MethodKind.EventRemove)
+        {
+            return false;
+        }
+
+        return Hex1bSymbols.InheritsFromOrEquals(method.ContainingType, widgetType);
+    }
+
+    /// <summary>
+    /// Returns true if <paramref name="name"/> matches the Hex1b 'On*' event-handler convention
+    /// (e.g. <c>OnClick</c>, <c>OnBlock</c>, <c>OnExpanding</c>). Such methods take handler
+    /// callbacks rather than widget-tree builders.
+    /// </summary>
+    private static bool IsEventHandlerMethodName(string name)
+    {
+        if (name.Length < 3)
+        {
+            return false;
+        }
+
+        return name[0] == 'O' && name[1] == 'n' && char.IsUpper(name[2]);
+    }
+}

--- a/src/Hex1b.Analyzers/WidgetContextReceiverNameAnalyzer.cs
+++ b/src/Hex1b.Analyzers/WidgetContextReceiverNameAnalyzer.cs
@@ -1,0 +1,84 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Hex1b.Analyzers;
+
+/// <summary>
+/// HEX1B0006: Receiver of an extension method on <c>Hex1b.WidgetContext&lt;T&gt;</c> must
+/// be named <c>context</c>.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class WidgetContextReceiverNameAnalyzer : DiagnosticAnalyzer
+{
+    public const string ExpectedName = "context";
+
+    private static readonly LocalizableString Title =
+        "WidgetContext<T> extension receiver must be named 'context'";
+
+    private static readonly LocalizableString MessageFormat =
+        "Receiver parameter '{0}' of widget extension method '{1}' should be named 'context' (it is a WidgetContext<T>)";
+
+    private static readonly LocalizableString Description =
+        "Hex1b widget extensions on WidgetContext<T> use the receiver name 'context' to align with build-context semantics. Rename the receiver parameter to 'context'.";
+
+    public static readonly DiagnosticDescriptor Rule = new(
+        id: Hex1bDiagnosticIds.WidgetContextReceiverName,
+        title: Title,
+        messageFormat: MessageFormat,
+        category: Hex1bDiagnosticIds.Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: Description,
+        helpLinkUri: Hex1bDiagnosticIds.HelpLink(Hex1bDiagnosticIds.WidgetContextReceiverName));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(compilationStart =>
+        {
+            var widgetContextType = Hex1bSymbols.GetWidgetContextType(compilationStart.Compilation);
+            if (widgetContextType is null)
+            {
+                return;
+            }
+
+            compilationStart.RegisterSymbolAction(
+                ctx => AnalyzeMethod(ctx, widgetContextType),
+                SymbolKind.Method);
+        });
+    }
+
+    private static void AnalyzeMethod(SymbolAnalysisContext context, INamedTypeSymbol widgetContextType)
+    {
+        var method = (IMethodSymbol)context.Symbol;
+
+        if (!method.IsExtensionMethod || method.Parameters.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        if (method.IsOverride || !method.ExplicitInterfaceImplementations.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        var receiver = method.Parameters[0];
+        if (!Hex1bSymbols.IsWidgetContext(receiver.Type, widgetContextType))
+        {
+            return;
+        }
+
+        if (string.Equals(receiver.Name, ExpectedName, System.StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var location = receiver.Locations.IsDefaultOrEmpty ? Location.None : receiver.Locations[0];
+        context.ReportDiagnostic(Diagnostic.Create(Rule, location, receiver.Name, method.Name));
+    }
+}

--- a/src/Hex1b.Analyzers/WidgetInstanceReceiverNameAnalyzer.cs
+++ b/src/Hex1b.Analyzers/WidgetInstanceReceiverNameAnalyzer.cs
@@ -1,0 +1,100 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Hex1b.Analyzers;
+
+/// <summary>
+/// HEX1B0007: Receiver of an extension method whose receiver type is (or is constrained to)
+/// <c>Hex1b.Widgets.Hex1bWidget</c> must be named <c>widget</c>. Extensions on
+/// <c>WidgetContext&lt;T&gt;</c> are owned by HEX1B0006 and are excluded here.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class WidgetInstanceReceiverNameAnalyzer : DiagnosticAnalyzer
+{
+    public const string ExpectedName = "widget";
+
+    private static readonly LocalizableString Title =
+        "Widget instance extension receiver must be named 'widget'";
+
+    private static readonly LocalizableString MessageFormat =
+        "Receiver parameter '{0}' of widget extension method '{1}' should be named 'widget' for consistency with other widget extension methods";
+
+    private static readonly LocalizableString Description =
+        "Hex1b widget instance extensions use the receiver name 'widget' so configuration chains read consistently across the API. Rename role-flavored aliases (e.g. 'editor', 'border', 'panel') to 'widget'.";
+
+    public static readonly DiagnosticDescriptor Rule = new(
+        id: Hex1bDiagnosticIds.WidgetInstanceReceiverName,
+        title: Title,
+        messageFormat: MessageFormat,
+        category: Hex1bDiagnosticIds.Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: Description,
+        helpLinkUri: Hex1bDiagnosticIds.HelpLink(Hex1bDiagnosticIds.WidgetInstanceReceiverName));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(compilationStart =>
+        {
+            var widgetType = Hex1bSymbols.GetWidgetType(compilationStart.Compilation);
+            if (widgetType is null)
+            {
+                return;
+            }
+
+            // WidgetContext<T> may legitimately be absent in downstream compilations; if it's
+            // there we use it to exclude HEX1B0006's territory, otherwise no exclusion needed.
+            var widgetContextType = Hex1bSymbols.GetWidgetContextType(compilationStart.Compilation);
+
+            compilationStart.RegisterSymbolAction(
+                ctx => AnalyzeMethod(ctx, widgetType, widgetContextType),
+                SymbolKind.Method);
+        });
+    }
+
+    private static void AnalyzeMethod(
+        SymbolAnalysisContext context,
+        INamedTypeSymbol widgetType,
+        INamedTypeSymbol? widgetContextType)
+    {
+        var method = (IMethodSymbol)context.Symbol;
+
+        if (!method.IsExtensionMethod || method.Parameters.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        if (method.IsOverride || !method.ExplicitInterfaceImplementations.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        var receiver = method.Parameters[0];
+        var receiverType = receiver.Type;
+
+        // HEX1B0006 owns WidgetContext<T> receivers.
+        if (Hex1bSymbols.IsWidgetContext(receiverType, widgetContextType))
+        {
+            return;
+        }
+
+        if (!Hex1bSymbols.IsWidgetTypeOrConstrainedToWidget(receiverType, widgetType))
+        {
+            return;
+        }
+
+        if (string.Equals(receiver.Name, ExpectedName, System.StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var location = receiver.Locations.IsDefaultOrEmpty ? Location.None : receiver.Locations[0];
+        context.ReportDiagnostic(Diagnostic.Create(Rule, location, receiver.Name, method.Name));
+    }
+}

--- a/src/Hex1b.Analyzers/WidgetMultipleBuilderCallbacksAnalyzer.cs
+++ b/src/Hex1b.Analyzers/WidgetMultipleBuilderCallbacksAnalyzer.cs
@@ -1,0 +1,158 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Hex1b.Analyzers;
+
+/// <summary>
+/// HEX1B0009: A widget extension/instance method should declare at most one widget-builder
+/// callback parameter. Methods that genuinely need multiple builders (e.g. a splitter with
+/// left/right panes) must suppress this rule with an explicit justification, signalling that
+/// the multi-builder shape was a deliberate choice rather than an oversight.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class WidgetMultipleBuilderCallbacksAnalyzer : DiagnosticAnalyzer
+{
+    private static readonly LocalizableString Title =
+        "Widget extension/instance method should declare at most one widget-builder callback";
+
+    private static readonly LocalizableString MessageFormat =
+        "Method '{0}' declares {1} widget-builder callback parameters; prefer a single 'builder' callback or a context type with named slots. Suppress this diagnostic with a justification if the multi-builder shape is intentional.";
+
+    private static readonly LocalizableString Description =
+        "Hex1b widget APIs prefer a single 'builder' callback (or a context type with named slots like SplitterContext) over multiple sibling Func<...> parameters. When a multi-builder shape is genuinely needed, suppress HEX1B0009 explicitly to record the decision.";
+
+    public static readonly DiagnosticDescriptor Rule = new(
+        id: Hex1bDiagnosticIds.WidgetMultipleBuilderCallbacks,
+        title: Title,
+        messageFormat: MessageFormat,
+        category: Hex1bDiagnosticIds.Category,
+        defaultSeverity: DiagnosticSeverity.Warning,
+        isEnabledByDefault: true,
+        description: Description,
+        helpLinkUri: Hex1bDiagnosticIds.HelpLink(Hex1bDiagnosticIds.WidgetMultipleBuilderCallbacks));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(compilationStart =>
+        {
+            var widgetType = Hex1bSymbols.GetWidgetType(compilationStart.Compilation);
+            if (widgetType is null)
+            {
+                return;
+            }
+
+            var widgetContextType = Hex1bSymbols.GetWidgetContextType(compilationStart.Compilation);
+
+            compilationStart.RegisterSymbolAction(
+                ctx => AnalyzeMethod(ctx, widgetType, widgetContextType),
+                SymbolKind.Method);
+        });
+    }
+
+    private static void AnalyzeMethod(
+        SymbolAnalysisContext context,
+        INamedTypeSymbol widgetType,
+        INamedTypeSymbol? widgetContextType)
+    {
+        var method = (IMethodSymbol)context.Symbol;
+
+        if (method.IsOverride || !method.ExplicitInterfaceImplementations.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        // 'On*' methods are event-handler decorators; their multiple Func parameters are
+        // sibling handlers, not multiple widget-tree builders.
+        if (IsEventHandlerMethodName(method.Name))
+        {
+            return;
+        }
+
+        if (!IsWidgetExtensionOrInstanceMethod(method, widgetType, widgetContextType))
+        {
+            return;
+        }
+
+        var startIndex = method.IsExtensionMethod ? 1 : 0;
+        var count = 0;
+        for (var i = startIndex; i < method.Parameters.Length; i++)
+        {
+            if (Hex1bSymbols.IsWidgetBuilderCallback(method.Parameters[i], widgetType))
+            {
+                count++;
+            }
+        }
+
+        if (count < 2)
+        {
+            return;
+        }
+
+        var location = method.Locations.IsDefaultOrEmpty ? Location.None : method.Locations[0];
+        context.ReportDiagnostic(Diagnostic.Create(Rule, location, method.Name, count));
+    }
+
+    private static bool IsWidgetExtensionOrInstanceMethod(
+        IMethodSymbol method,
+        INamedTypeSymbol widgetType,
+        INamedTypeSymbol? widgetContextType)
+    {
+        if (method.IsExtensionMethod)
+        {
+            if (method.Parameters.IsDefaultOrEmpty)
+            {
+                return false;
+            }
+
+            var receiverType = method.Parameters[0].Type;
+
+            if (Hex1bSymbols.IsWidgetContext(receiverType, widgetContextType))
+            {
+                return true;
+            }
+
+            return Hex1bSymbols.IsWidgetTypeOrConstrainedToWidget(receiverType, widgetType);
+        }
+
+        if (method.IsStatic)
+        {
+            return false;
+        }
+
+        if (method.DeclaredAccessibility is not (Accessibility.Public or Accessibility.Internal or Accessibility.ProtectedOrInternal))
+        {
+            return false;
+        }
+
+        if (method.MethodKind is MethodKind.Constructor
+            or MethodKind.PropertyGet
+            or MethodKind.PropertySet
+            or MethodKind.EventAdd
+            or MethodKind.EventRemove)
+        {
+            return false;
+        }
+
+        return Hex1bSymbols.InheritsFromOrEquals(method.ContainingType, widgetType);
+    }
+
+    /// <summary>
+    /// Returns true if <paramref name="name"/> matches the Hex1b 'On*' event-handler convention.
+    /// Such methods host handler callbacks rather than widget-tree builders.
+    /// </summary>
+    private static bool IsEventHandlerMethodName(string name)
+    {
+        if (name.Length < 3)
+        {
+            return false;
+        }
+
+        return name[0] == 'O' && name[1] == 'n' && char.IsUpper(name[2]);
+    }
+}

--- a/src/Hex1b/AccordionExtensions.cs
+++ b/src/Hex1b/AccordionExtensions.cs
@@ -13,12 +13,12 @@ public static class AccordionExtensions
     /// The accordion fills available vertical space by default.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="builder">A function that builds the sections using an AccordionContext.</param>
     /// <returns>An AccordionWidget.</returns>
     /// <example>
     /// <code>
-    /// ctx.Accordion(a => [
+    /// context.Accordion(a => [
     ///     a.Section(s => [s.Text("File list")]).Title("Explorer"),
     ///     a.Section(s => [s.Text("Outline")]).Title("Outline"),
     ///     a.Section(s => [s.Text("Timeline")]).Title("Timeline")
@@ -26,7 +26,7 @@ public static class AccordionExtensions
     /// </code>
     /// </example>
     public static AccordionWidget Accordion<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<AccordionContext, IEnumerable<AccordionSectionWidget>> builder)
         where TParent : Hex1bWidget
     {

--- a/src/Hex1b/AlignExtensions.cs
+++ b/src/Hex1b/AlignExtensions.cs
@@ -19,21 +19,21 @@ public static class AlignExtensions
     /// Aligns a child widget within the available space.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="alignment">The alignment flags (e.g., Alignment.Center, Alignment.TopRight).</param>
     /// <param name="child">The child widget to align.</param>
     /// <returns>An AlignWidget with the specified alignment.</returns>
     /// <example>
     /// <code>
     /// // Right-align a button
-    /// ctx.Align(Alignment.Right, ctx.Button("OK"))
+    /// context.Align(Alignment.Right, context.Button("OK"))
     /// 
     /// // Center a dialog
-    /// ctx.Align(Alignment.Center, ctx.Border(b =&gt; [...]).Title("Dialog"))
+    /// context.Align(Alignment.Center, context.Border(b =&gt; [...]).Title("Dialog"))
     /// </code>
     /// </example>
     public static AlignWidget Align<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Alignment alignment,
         Hex1bWidget child)
         where TParent : Hex1bWidget
@@ -43,12 +43,12 @@ public static class AlignExtensions
     /// Aligns a child widget within the available space using a builder.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="alignment">The alignment flags (e.g., Alignment.Center, Alignment.TopRight).</param>
     /// <param name="builder">A function that builds the child widget.</param>
     /// <returns>An AlignWidget with the specified alignment.</returns>
     public static AlignWidget Align<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Alignment alignment,
         Func<WidgetContext<AlignWidget>, Hex1bWidget> builder)
         where TParent : Hex1bWidget
@@ -62,16 +62,16 @@ public static class AlignExtensions
     /// Centers a child widget both horizontally and vertically.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="child">The child widget to center.</param>
     /// <returns>An AlignWidget centered in both axes.</returns>
     /// <example>
     /// <code>
-    /// ctx.Center(ctx.Text("Welcome!"))
+    /// context.Center(context.Text("Welcome!"))
     /// </code>
     /// </example>
     public static AlignWidget Center<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Hex1bWidget child)
         where TParent : Hex1bWidget
         => new(child, Alignment.Center);
@@ -80,11 +80,11 @@ public static class AlignExtensions
     /// Centers a child widget both horizontally and vertically using a builder.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="builder">A function that builds the child widget.</param>
     /// <returns>An AlignWidget centered in both axes.</returns>
     public static AlignWidget Center<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<WidgetContext<AlignWidget>, Hex1bWidget> builder)
         where TParent : Hex1bWidget
     {

--- a/src/Hex1b/BackdropExtensions.cs
+++ b/src/Hex1b/BackdropExtensions.cs
@@ -12,18 +12,18 @@ public static class BackdropExtensions
     /// Use this to create modal overlays that prevent interaction with layers below.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <returns>A new BackdropWidget.</returns>
     /// <example>
     /// <code>
     /// // Simple backdrop that blocks input
-    /// ctx.ZStack(z => [
+    /// context.ZStack(z => [
     ///     z.VStack(...),  // Base content
     ///     showModal ? z.Backdrop() : null
     /// ])
     /// </code>
     /// </example>
-    public static BackdropWidget Backdrop<TParent>(this WidgetContext<TParent> ctx)
+    public static BackdropWidget Backdrop<TParent>(this WidgetContext<TParent> context)
         where TParent : Hex1bWidget
         => new();
 
@@ -32,13 +32,13 @@ public static class BackdropExtensions
     /// The child is centered within the backdrop.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="child">The child widget to display on top of the backdrop.</param>
     /// <returns>A new BackdropWidget with the child.</returns>
     /// <example>
     /// <code>
     /// // Modal dialog with click-away to dismiss
-    /// ctx.ZStack(z => [
+    /// context.ZStack(z => [
     ///     z.VStack(...),  // Base content
     ///     showModal 
     ///         ? z.Backdrop(z.Border(z.VStack(v => [
@@ -51,7 +51,7 @@ public static class BackdropExtensions
     /// ])
     /// </code>
     /// </example>
-    public static BackdropWidget Backdrop<TParent>(this WidgetContext<TParent> ctx, Hex1bWidget child)
+    public static BackdropWidget Backdrop<TParent>(this WidgetContext<TParent> context, Hex1bWidget child)
         where TParent : Hex1bWidget
         => new(child);
 }

--- a/src/Hex1b/BarChartExtensions.cs
+++ b/src/Hex1b/BarChartExtensions.cs
@@ -11,26 +11,26 @@ public static class BarChartExtensions
     /// <summary>
     /// Creates a bar chart bound to the specified data.
     /// </summary>
-    public static BarChartWidget<T> BarChart<T>(this RootContext ctx, IReadOnlyList<T> data)
+    public static BarChartWidget<T> BarChart<T>(this RootContext context, IReadOnlyList<T> data)
         => new() { Data = data };
 
     /// <summary>
     /// Creates a bar chart with <see cref="ChartItem"/> data (selectors pre-wired).
     /// </summary>
-    public static BarChartWidget<ChartItem> BarChart(this RootContext ctx, IReadOnlyList<ChartItem> data)
+    public static BarChartWidget<ChartItem> BarChart(this RootContext context, IReadOnlyList<ChartItem> data)
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 
     /// <summary>
     /// Creates a bar chart with <see cref="ChartItem"/> data (params overload).
     /// </summary>
-    public static BarChartWidget<ChartItem> BarChart(this RootContext ctx, params ChartItem[] data)
+    public static BarChartWidget<ChartItem> BarChart(this RootContext context, params ChartItem[] data)
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 
     /// <summary>
     /// Creates a bar chart bound to the specified data.
     /// </summary>
     public static BarChartWidget<T> BarChart<T, TParent>(
-        this WidgetContext<TParent> ctx, IReadOnlyList<T> data)
+        this WidgetContext<TParent> context, IReadOnlyList<T> data)
         where TParent : Hex1bWidget
         => new() { Data = data };
 
@@ -38,7 +38,7 @@ public static class BarChartExtensions
     /// Creates a bar chart with <see cref="ChartItem"/> data (selectors pre-wired).
     /// </summary>
     public static BarChartWidget<ChartItem> BarChart<TParent>(
-        this WidgetContext<TParent> ctx, IReadOnlyList<ChartItem> data)
+        this WidgetContext<TParent> context, IReadOnlyList<ChartItem> data)
         where TParent : Hex1bWidget
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 
@@ -46,7 +46,7 @@ public static class BarChartExtensions
     /// Creates a bar chart with <see cref="ChartItem"/> data (params overload).
     /// </summary>
     public static BarChartWidget<ChartItem> BarChart<TParent>(
-        this WidgetContext<TParent> ctx, params ChartItem[] data)
+        this WidgetContext<TParent> context, params ChartItem[] data)
         where TParent : Hex1bWidget
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 }

--- a/src/Hex1b/BorderExtensions.cs
+++ b/src/Hex1b/BorderExtensions.cs
@@ -11,7 +11,7 @@ public static class BorderExtensions
     /// Creates a Border wrapping a single child widget.
     /// </summary>
     public static BorderWidget Border<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Hex1bWidget child)
         where TParent : Hex1bWidget
         => new(child);
@@ -20,7 +20,7 @@ public static class BorderExtensions
     /// Creates a Border with a VStack child.
     /// </summary>
     public static BorderWidget Border<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<WidgetContext<VStackWidget>, Hex1bWidget[]> builder)
         where TParent : Hex1bWidget
     {

--- a/src/Hex1b/BreakdownChartExtensions.cs
+++ b/src/Hex1b/BreakdownChartExtensions.cs
@@ -11,26 +11,26 @@ public static class BreakdownChartExtensions
     /// <summary>
     /// Creates a breakdown chart bound to the specified data.
     /// </summary>
-    public static BreakdownChartWidget<T> BreakdownChart<T>(this RootContext ctx, IReadOnlyList<T> data)
+    public static BreakdownChartWidget<T> BreakdownChart<T>(this RootContext context, IReadOnlyList<T> data)
         => new() { Data = data };
 
     /// <summary>
     /// Creates a breakdown chart with <see cref="ChartItem"/> data (selectors pre-wired).
     /// </summary>
-    public static BreakdownChartWidget<ChartItem> BreakdownChart(this RootContext ctx, IReadOnlyList<ChartItem> data)
+    public static BreakdownChartWidget<ChartItem> BreakdownChart(this RootContext context, IReadOnlyList<ChartItem> data)
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 
     /// <summary>
     /// Creates a breakdown chart with <see cref="ChartItem"/> data (params overload).
     /// </summary>
-    public static BreakdownChartWidget<ChartItem> BreakdownChart(this RootContext ctx, params ChartItem[] data)
+    public static BreakdownChartWidget<ChartItem> BreakdownChart(this RootContext context, params ChartItem[] data)
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 
     /// <summary>
     /// Creates a breakdown chart bound to the specified data.
     /// </summary>
     public static BreakdownChartWidget<T> BreakdownChart<T, TParent>(
-        this WidgetContext<TParent> ctx, IReadOnlyList<T> data)
+        this WidgetContext<TParent> context, IReadOnlyList<T> data)
         where TParent : Hex1bWidget
         => new() { Data = data };
 
@@ -38,7 +38,7 @@ public static class BreakdownChartExtensions
     /// Creates a breakdown chart with <see cref="ChartItem"/> data (selectors pre-wired).
     /// </summary>
     public static BreakdownChartWidget<ChartItem> BreakdownChart<TParent>(
-        this WidgetContext<TParent> ctx, IReadOnlyList<ChartItem> data)
+        this WidgetContext<TParent> context, IReadOnlyList<ChartItem> data)
         where TParent : Hex1bWidget
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 
@@ -46,7 +46,7 @@ public static class BreakdownChartExtensions
     /// Creates a breakdown chart with <see cref="ChartItem"/> data (params overload).
     /// </summary>
     public static BreakdownChartWidget<ChartItem> BreakdownChart<TParent>(
-        this WidgetContext<TParent> ctx, params ChartItem[] data)
+        this WidgetContext<TParent> context, params ChartItem[] data)
         where TParent : Hex1bWidget
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 }

--- a/src/Hex1b/ButtonExtensions.cs
+++ b/src/Hex1b/ButtonExtensions.cs
@@ -12,7 +12,7 @@ public static class ButtonExtensions
     /// Creates a ButtonWidget with the specified label.
     /// </summary>
     public static ButtonWidget Button<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         string label)
         where TParent : Hex1bWidget
         => new(label);

--- a/src/Hex1b/CalendarExtensions.cs
+++ b/src/Hex1b/CalendarExtensions.cs
@@ -11,11 +11,11 @@ public static class CalendarExtensions
     /// <summary>
     /// Creates a calendar widget displaying the specified month.
     /// </summary>
-    /// <param name="ctx">The parent widget context.</param>
+    /// <param name="context">The parent widget context.</param>
     /// <param name="month">The month to display. Only the Year and Month components are used.</param>
     /// <returns>A configured <see cref="CalendarWidget"/>.</returns>
     public static CalendarWidget Calendar<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         DateOnly month)
         where TParent : Hex1bWidget
         => new(month);
@@ -23,22 +23,22 @@ public static class CalendarExtensions
     /// <summary>
     /// Creates a calendar widget displaying the current month.
     /// </summary>
-    /// <param name="ctx">The parent widget context.</param>
+    /// <param name="context">The parent widget context.</param>
     /// <returns>A configured <see cref="CalendarWidget"/>.</returns>
     public static CalendarWidget Calendar<TParent>(
-        this WidgetContext<TParent> ctx)
+        this WidgetContext<TParent> context)
         where TParent : Hex1bWidget
         => new(DateOnly.FromDateTime(DateTime.Today));
 
     /// <summary>
     /// Creates a calendar widget displaying the specified year and month.
     /// </summary>
-    /// <param name="ctx">The parent widget context.</param>
+    /// <param name="context">The parent widget context.</param>
     /// <param name="year">The year.</param>
     /// <param name="month">The month (1-12).</param>
     /// <returns>A configured <see cref="CalendarWidget"/>.</returns>
     public static CalendarWidget Calendar<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         int year, int month)
         where TParent : Hex1bWidget
         => new(new DateOnly(year, month, 1));

--- a/src/Hex1b/CheckboxExtensions.cs
+++ b/src/Hex1b/CheckboxExtensions.cs
@@ -10,21 +10,21 @@ public static class CheckboxExtensions
     /// <summary>
     /// Creates a checkbox with the default unchecked state.
     /// </summary>
-    public static CheckboxWidget Checkbox<TParent>(this WidgetContext<TParent> ctx)
+    public static CheckboxWidget Checkbox<TParent>(this WidgetContext<TParent> context)
         where TParent : Hex1bWidget
         => new();
 
     /// <summary>
     /// Creates a checkbox with the specified state.
     /// </summary>
-    public static CheckboxWidget Checkbox<TParent>(this WidgetContext<TParent> ctx, CheckboxState state)
+    public static CheckboxWidget Checkbox<TParent>(this WidgetContext<TParent> context, CheckboxState state)
         where TParent : Hex1bWidget
         => new(state);
 
     /// <summary>
     /// Creates a checkbox with a label.
     /// </summary>
-    public static CheckboxWidget Checkbox<TParent>(this WidgetContext<TParent> ctx, string label)
+    public static CheckboxWidget Checkbox<TParent>(this WidgetContext<TParent> context, string label)
         where TParent : Hex1bWidget
         => new() { LabelText = label };
 
@@ -32,7 +32,7 @@ public static class CheckboxExtensions
     /// Creates a checkbox with the specified state and label.
     /// </summary>
     public static CheckboxWidget Checkbox<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         CheckboxState state,
         string label)
         where TParent : Hex1bWidget
@@ -42,7 +42,7 @@ public static class CheckboxExtensions
     /// Creates a checkbox with the specified checked state and label.
     /// </summary>
     public static CheckboxWidget Checkbox<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         bool isChecked,
         string? label = null)
         where TParent : Hex1bWidget

--- a/src/Hex1b/ColumnChartExtensions.cs
+++ b/src/Hex1b/ColumnChartExtensions.cs
@@ -12,25 +12,25 @@ public static class ColumnChartExtensions
     /// Creates a column chart bound to the specified data.
     /// </summary>
     /// <typeparam name="T">The data item type.</typeparam>
-    /// <param name="ctx">The root context.</param>
+    /// <param name="context">The root context.</param>
     /// <param name="data">The data source for the chart.</param>
-    public static ColumnChartWidget<T> ColumnChart<T>(this RootContext ctx, IReadOnlyList<T> data)
+    public static ColumnChartWidget<T> ColumnChart<T>(this RootContext context, IReadOnlyList<T> data)
         => new() { Data = data };
 
     /// <summary>
     /// Creates a column chart with <see cref="ChartItem"/> data (selectors pre-wired).
     /// </summary>
-    /// <param name="ctx">The root context.</param>
+    /// <param name="context">The root context.</param>
     /// <param name="data">The chart items.</param>
-    public static ColumnChartWidget<ChartItem> ColumnChart(this RootContext ctx, IReadOnlyList<ChartItem> data)
+    public static ColumnChartWidget<ChartItem> ColumnChart(this RootContext context, IReadOnlyList<ChartItem> data)
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 
     /// <summary>
     /// Creates a column chart with <see cref="ChartItem"/> data (params overload).
     /// </summary>
-    /// <param name="ctx">The root context.</param>
+    /// <param name="context">The root context.</param>
     /// <param name="data">The chart items.</param>
-    public static ColumnChartWidget<ChartItem> ColumnChart(this RootContext ctx, params ChartItem[] data)
+    public static ColumnChartWidget<ChartItem> ColumnChart(this RootContext context, params ChartItem[] data)
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 
     /// <summary>
@@ -38,10 +38,10 @@ public static class ColumnChartExtensions
     /// </summary>
     /// <typeparam name="T">The data item type.</typeparam>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="data">The data source for the chart.</param>
     public static ColumnChartWidget<T> ColumnChart<T, TParent>(
-        this WidgetContext<TParent> ctx, IReadOnlyList<T> data)
+        this WidgetContext<TParent> context, IReadOnlyList<T> data)
         where TParent : Hex1bWidget
         => new() { Data = data };
 
@@ -49,10 +49,10 @@ public static class ColumnChartExtensions
     /// Creates a column chart with <see cref="ChartItem"/> data (selectors pre-wired).
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="data">The chart items.</param>
     public static ColumnChartWidget<ChartItem> ColumnChart<TParent>(
-        this WidgetContext<TParent> ctx, IReadOnlyList<ChartItem> data)
+        this WidgetContext<TParent> context, IReadOnlyList<ChartItem> data)
         where TParent : Hex1bWidget
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 
@@ -60,10 +60,10 @@ public static class ColumnChartExtensions
     /// Creates a column chart with <see cref="ChartItem"/> data (params overload).
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="data">The chart items.</param>
     public static ColumnChartWidget<ChartItem> ColumnChart<TParent>(
-        this WidgetContext<TParent> ctx, params ChartItem[] data)
+        this WidgetContext<TParent> context, params ChartItem[] data)
         where TParent : Hex1bWidget
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 }

--- a/src/Hex1b/DatePickerExtensions.cs
+++ b/src/Hex1b/DatePickerExtensions.cs
@@ -11,7 +11,7 @@ public static class DatePickerExtensions
     /// Creates a date picker widget with no initial date.
     /// </summary>
     public static DatePickerWidget DatePicker<TParent>(
-        this WidgetContext<TParent> ctx)
+        this WidgetContext<TParent> context)
         where TParent : Hex1bWidget
         => new();
 
@@ -19,7 +19,7 @@ public static class DatePickerExtensions
     /// Creates a date picker widget with an initial selected date.
     /// </summary>
     public static DatePickerWidget DatePicker<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         DateOnly initialDate)
         where TParent : Hex1bWidget
         => new() { InitialDate = initialDate };

--- a/src/Hex1b/DocumentDiagnosticPanelExtensions.cs
+++ b/src/Hex1b/DocumentDiagnosticPanelExtensions.cs
@@ -14,7 +14,7 @@ public static class DocumentDiagnosticPanelExtensions
     /// of the given document. Useful for debugging and understanding document state.
     /// </summary>
     public static TreeWidget DocumentDiagnosticPanel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         IHex1bDocument document)
         where TParent : Hex1bWidget
     {

--- a/src/Hex1b/DonutChartExtensions.cs
+++ b/src/Hex1b/DonutChartExtensions.cs
@@ -11,26 +11,26 @@ public static class DonutChartExtensions
     /// <summary>
     /// Creates a donut chart bound to the specified data.
     /// </summary>
-    public static DonutChartWidget<T> DonutChart<T>(this RootContext ctx, IReadOnlyList<T> data)
+    public static DonutChartWidget<T> DonutChart<T>(this RootContext context, IReadOnlyList<T> data)
         => new() { Data = data };
 
     /// <summary>
     /// Creates a donut chart with <see cref="ChartItem"/> data (selectors pre-wired).
     /// </summary>
-    public static DonutChartWidget<ChartItem> DonutChart(this RootContext ctx, IReadOnlyList<ChartItem> data)
+    public static DonutChartWidget<ChartItem> DonutChart(this RootContext context, IReadOnlyList<ChartItem> data)
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 
     /// <summary>
     /// Creates a donut chart with <see cref="ChartItem"/> data (params overload).
     /// </summary>
-    public static DonutChartWidget<ChartItem> DonutChart(this RootContext ctx, params ChartItem[] data)
+    public static DonutChartWidget<ChartItem> DonutChart(this RootContext context, params ChartItem[] data)
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 
     /// <summary>
     /// Creates a donut chart bound to the specified data.
     /// </summary>
     public static DonutChartWidget<T> DonutChart<T, TParent>(
-        this WidgetContext<TParent> ctx, IReadOnlyList<T> data)
+        this WidgetContext<TParent> context, IReadOnlyList<T> data)
         where TParent : Hex1bWidget
         => new() { Data = data };
 
@@ -38,7 +38,7 @@ public static class DonutChartExtensions
     /// Creates a donut chart with <see cref="ChartItem"/> data (selectors pre-wired).
     /// </summary>
     public static DonutChartWidget<ChartItem> DonutChart<TParent>(
-        this WidgetContext<TParent> ctx, IReadOnlyList<ChartItem> data)
+        this WidgetContext<TParent> context, IReadOnlyList<ChartItem> data)
         where TParent : Hex1bWidget
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 
@@ -46,7 +46,7 @@ public static class DonutChartExtensions
     /// Creates a donut chart with <see cref="ChartItem"/> data (params overload).
     /// </summary>
     public static DonutChartWidget<ChartItem> DonutChart<TParent>(
-        this WidgetContext<TParent> ctx, params ChartItem[] data)
+        this WidgetContext<TParent> context, params ChartItem[] data)
         where TParent : Hex1bWidget
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 }

--- a/src/Hex1b/DragBarPanelExtensions.cs
+++ b/src/Hex1b/DragBarPanelExtensions.cs
@@ -11,12 +11,12 @@ public static class DragBarPanelExtensions
     /// Creates a DragBarPanel that wraps content built from a callback.
     /// </summary>
     public static DragBarPanelWidget DragBarPanel<TParent>(
-        this WidgetContext<TParent> ctx,
-        Func<WidgetContext<DragBarPanelWidget>, Hex1bWidget> contentBuilder)
+        this WidgetContext<TParent> context,
+        Func<WidgetContext<DragBarPanelWidget>, Hex1bWidget> builder)
         where TParent : Hex1bWidget
     {
         var contentCtx = new WidgetContext<DragBarPanelWidget>();
-        var content = contentBuilder(contentCtx);
+        var content = builder(contentCtx);
         return new DragBarPanelWidget { Content = content };
     }
     
@@ -24,7 +24,7 @@ public static class DragBarPanelExtensions
     /// Creates a DragBarPanel that wraps a widget directly.
     /// </summary>
     public static DragBarPanelWidget DragBarPanel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Hex1bWidget content)
         where TParent : Hex1bWidget
         => new DragBarPanelWidget { Content = content };

--- a/src/Hex1b/DragDropExtensions.cs
+++ b/src/Hex1b/DragDropExtensions.cs
@@ -12,18 +12,18 @@ public static class DragDropExtensions
     /// The builder lambda receives a <see cref="DraggableContext"/> with
     /// <see cref="DraggableContext.IsDragging"/> to reflect the current drag state.
     /// </summary>
-    /// <param name="ctx">The parent widget context.</param>
+    /// <param name="context">The parent widget context.</param>
     /// <param name="dragData">The reference data that will be passed to the drop target.</param>
     /// <param name="builder">A builder that creates the child widget using drag state.</param>
     /// <example>
     /// <code>
-    /// ctx.Draggable("task-1", dc =>
+    /// context.Draggable("task-1", dc =>
     ///     dc.Border(dc.Text(dc.IsDragging ? "Dragging..." : "Task 1"))
     /// )
     /// </code>
     /// </example>
     public static DraggableWidget Draggable<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         object dragData,
         Func<DraggableContext, Hex1bWidget> builder)
         where TParent : Hex1bWidget
@@ -33,7 +33,7 @@ public static class DragDropExtensions
     /// Creates a draggable wrapper with an implicit VStack for multiple children.
     /// </summary>
     public static DraggableWidget Draggable<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         object dragData,
         Func<DraggableContext, Hex1bWidget[]> builder)
         where TParent : Hex1bWidget
@@ -45,11 +45,11 @@ public static class DragDropExtensions
     /// <see cref="DroppableContext.IsHoveredByDrag"/> and <see cref="DroppableContext.CanAcceptDrag"/>
     /// to reflect the current drag-hover state.
     /// </summary>
-    /// <param name="ctx">The parent widget context.</param>
+    /// <param name="context">The parent widget context.</param>
     /// <param name="builder">A builder that creates the child widget using drop state.</param>
     /// <example>
     /// <code>
-    /// ctx.Droppable(dc =>
+    /// context.Droppable(dc =>
     ///     dc.Text(dc.IsHoveredByDrag ? "Drop here!" : "Target")
     /// )
     /// .Accept(data => data is string)
@@ -57,7 +57,7 @@ public static class DragDropExtensions
     /// </code>
     /// </example>
     public static DroppableWidget Droppable<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<DroppableContext, Hex1bWidget> builder)
         where TParent : Hex1bWidget
         => new(builder);
@@ -66,7 +66,7 @@ public static class DragDropExtensions
     /// Creates a droppable target with an implicit VStack for multiple children.
     /// </summary>
     public static DroppableWidget Droppable<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<DroppableContext, Hex1bWidget[]> builder)
         where TParent : Hex1bWidget
         => new(dc => new VStackWidget(builder(dc)));

--- a/src/Hex1b/DrawerExtensions.cs
+++ b/src/Hex1b/DrawerExtensions.cs
@@ -14,7 +14,7 @@ public static class DrawerExtensions
     /// Use <see cref="DrawerWidget.CollapsedContent"/> and <see cref="DrawerWidget.ExpandedContent"/>
     /// to define the drawer's content for each state.
     /// </remarks>
-    public static DrawerWidget Drawer<TParent>(this WidgetContext<TParent> ctx)
+    public static DrawerWidget Drawer<TParent>(this WidgetContext<TParent> context)
         where TParent : Hex1bWidget
         => new();
 }

--- a/src/Hex1b/EditorExtensions.cs
+++ b/src/Hex1b/EditorExtensions.cs
@@ -14,7 +14,7 @@ public static class EditorExtensions
     /// available vertical space in stack layouts rather than requesting unbounded height.
     /// </summary>
     public static EditorWidget Editor<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         EditorState state)
         where TParent : Hex1bWidget
         => new(state) { HeightHint = SizeHint.Fill };

--- a/src/Hex1b/EffectPanelExtensions.cs
+++ b/src/Hex1b/EffectPanelExtensions.cs
@@ -13,11 +13,11 @@ public static class EffectPanelExtensions
     /// Use <see cref="EffectPanelWidget.Effect"/> to apply a post-processing effect.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="child">The child widget to wrap.</param>
     /// <returns>An <see cref="EffectPanelWidget"/> wrapping the child.</returns>
     public static EffectPanelWidget EffectPanel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Hex1bWidget child)
         where TParent : Hex1bWidget
         => new(child);
@@ -26,12 +26,12 @@ public static class EffectPanelExtensions
     /// Creates an effect panel that wraps the given child widget with an effect applied.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="child">The child widget to wrap.</param>
     /// <param name="effect">A callback that receives the rendered <see cref="Surface"/> for in-place modification.</param>
     /// <returns>An <see cref="EffectPanelWidget"/> with the effect applied.</returns>
     public static EffectPanelWidget EffectPanel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Hex1bWidget child,
         Action<Surface> effect)
         where TParent : Hex1bWidget

--- a/src/Hex1b/FigletTextExtensions.cs
+++ b/src/Hex1b/FigletTextExtensions.cs
@@ -15,7 +15,7 @@ using Hex1b.Widgets;
 /// </remarks>
 /// <example>
 /// <code>
-/// ctx.FigletText("Hello, World")
+/// context.FigletText("Hello, World")
 ///    .Font(FigletFonts.Slant)
 ///    .Layout(FigletLayoutMode.Smushed)
 ///    .HorizontalOverflow(FigletHorizontalOverflow.Wrap);
@@ -27,11 +27,11 @@ public static class FigletTextExtensions
     /// Creates a <see cref="FigletTextWidget"/> with the specified text content.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type in the current context.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="text">The text to render.</param>
     /// <returns>A new <see cref="FigletTextWidget"/> using <see cref="FigletFonts.Standard"/>.</returns>
     public static FigletTextWidget FigletText<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         string text)
         where TParent : Hex1bWidget
         => new(text);

--- a/src/Hex1b/FloatExtensions.cs
+++ b/src/Hex1b/FloatExtensions.cs
@@ -14,14 +14,14 @@ public static class FloatExtensions
     /// </summary>
     /// <example>
     /// <code>
-    /// ctx.VStack(v => [
+    /// context.VStack(v => [
     ///     v.Text("Normal flow"),
     ///     v.Float(v.Icon("📍")).Absolute(10, 5),
     /// ])
     /// </code>
     /// </example>
     public static FloatWidget Float<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Hex1bWidget child)
         where TParent : Hex1bWidget, IFloatWidgetContainer
         => new(child);

--- a/src/Hex1b/FormExtensions.cs
+++ b/src/Hex1b/FormExtensions.cs
@@ -14,7 +14,7 @@ public static class FormExtensions
     /// </summary>
     /// <example>
     /// <code>
-    /// ctx.Form(form =>
+    /// context.Form(form =>
     /// {
     ///     var name = form.TextField("Name");
     ///     return [name, form.SubmitButton("Save", e => { })];
@@ -22,7 +22,7 @@ public static class FormExtensions
     /// </code>
     /// </example>
     public static FormWidget Form<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<FormContext, Hex1bWidget[]> builder)
         where TParent : Hex1bWidget
     {

--- a/src/Hex1b/GridExtensions.cs
+++ b/src/Hex1b/GridExtensions.cs
@@ -19,7 +19,7 @@ public static class GridExtensions
     /// </para>
     /// <example>
     /// <code>
-    /// ctx.Grid(g => [
+    /// context.Grid(g => [
     ///     g.Cell(c => c.Text("Nav")).RowSpan(0, 2).Column(0).Width(20),
     ///     g.Cell(c => c.Text("Header")).Row(0).Column(1),
     ///     g.Cell(c => c.Text("Content")).Row(1).Column(1).FillHeight(),
@@ -27,11 +27,11 @@ public static class GridExtensions
     /// </code>
     /// </example>
     /// </remarks>
-    /// <param name="ctx">The parent widget context.</param>
+    /// <param name="context">The parent widget context.</param>
     /// <param name="builder">A callback that receives a <see cref="GridContext"/> and returns an array of <see cref="GridCellWidget"/>.</param>
     /// <returns>A configured <see cref="GridWidget"/>.</returns>
     public static GridWidget Grid<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<GridContext, GridCellWidget[]> builder)
         where TParent : Hex1bWidget
     {

--- a/src/Hex1b/HStackExtensions.cs
+++ b/src/Hex1b/HStackExtensions.cs
@@ -11,7 +11,7 @@ public static class HStackExtensions
     /// Creates an HStack where the callback returns an array of children.
     /// </summary>
     public static HStackWidget HStack<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<WidgetContext<HStackWidget>, Hex1bWidget[]> builder)
         where TParent : Hex1bWidget
     {

--- a/src/Hex1b/HyperlinkExtensions.cs
+++ b/src/Hex1b/HyperlinkExtensions.cs
@@ -16,7 +16,7 @@ using Hex1b.Widgets;
 /// <example>
 /// <para>Using Hyperlink within a VStack:</para>
 /// <code>
-/// ctx.VStack(v =&gt; [
+/// context.VStack(v =&gt; [
 ///     v.Hyperlink("Click here", "https://example.com"),
 ///     v.Hyperlink("Long link text that wraps", "https://example.com").Wrap()
 /// ])
@@ -30,12 +30,12 @@ public static class HyperlinkExtensions
     /// Creates a <see cref="HyperlinkWidget"/> with the specified text and URI.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type in the current context.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="text">The visible text to display.</param>
     /// <param name="uri">The URI to link to when clicked.</param>
     /// <returns>A new <see cref="HyperlinkWidget"/> with default overflow behavior (Truncate).</returns>
     public static HyperlinkWidget Hyperlink<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         string text,
         string uri)
         where TParent : Hex1bWidget
@@ -45,13 +45,13 @@ public static class HyperlinkExtensions
     /// Creates a <see cref="HyperlinkWidget"/> with the specified text, URI, and click handler.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type in the current context.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="text">The visible text to display.</param>
     /// <param name="uri">The URI to link to when clicked.</param>
     /// <param name="onClick">The click handler to invoke when the hyperlink is activated.</param>
     /// <returns>A new <see cref="HyperlinkWidget"/> configured with the click handler.</returns>
     public static HyperlinkWidget Hyperlink<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         string text,
         string uri,
         Action<HyperlinkClickedEventArgs> onClick)
@@ -62,13 +62,13 @@ public static class HyperlinkExtensions
     /// Creates a <see cref="HyperlinkWidget"/> with the specified text, URI, and async click handler.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type in the current context.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="text">The visible text to display.</param>
     /// <param name="uri">The URI to link to when clicked.</param>
     /// <param name="onClick">The async click handler to invoke when the hyperlink is activated.</param>
     /// <returns>A new <see cref="HyperlinkWidget"/> configured with the async click handler.</returns>
     public static HyperlinkWidget Hyperlink<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         string text,
         string uri,
         Func<HyperlinkClickedEventArgs, Task> onClick)

--- a/src/Hex1b/IconExtensions.cs
+++ b/src/Hex1b/IconExtensions.cs
@@ -10,27 +10,27 @@ public static class IconExtensions
     /// <summary>
     /// Creates an icon widget with the specified icon string.
     /// </summary>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="icon">The icon character or string to display.</param>
     /// <returns>A new IconWidget.</returns>
     /// <example>
     /// <code>
-    /// ctx.Icon("▶")
-    /// ctx.Icon("✓")
-    /// ctx.Icon("🔍")
+    /// context.Icon("▶")
+    /// context.Icon("✓")
+    /// context.Icon("🔍")
     /// </code>
     /// </example>
-    public static IconWidget Icon<TParent>(this WidgetContext<TParent> ctx, string icon)
+    public static IconWidget Icon<TParent>(this WidgetContext<TParent> context, string icon)
         where TParent : Hex1bWidget
         => new(icon);
     
     /// <summary>
     /// Creates an icon widget with the specified icon character.
     /// </summary>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="icon">The icon character to display.</param>
     /// <returns>A new IconWidget.</returns>
-    public static IconWidget Icon<TParent>(this WidgetContext<TParent> ctx, char icon)
+    public static IconWidget Icon<TParent>(this WidgetContext<TParent> context, char icon)
         where TParent : Hex1bWidget
         => new(icon.ToString());
 }

--- a/src/Hex1b/InfoBarExtensions.cs
+++ b/src/Hex1b/InfoBarExtensions.cs
@@ -12,13 +12,13 @@ public static class InfoBarExtensions
     /// Creates an InfoBar widget using a builder pattern.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="builder">A function that builds the info bar children using an InfoBarContext.</param>
     /// <param name="invertColors">Whether to invert foreground/background colors (default: true).</param>
     /// <returns>An InfoBarWidget.</returns>
     /// <example>
     /// <code>
-    /// ctx.InfoBar(s => [
+    /// context.InfoBar(s => [
     ///     s.Section("NORMAL"),
     ///     s.Section("file.cs"),
     ///     s.Section("Ln 42, Col 15")
@@ -26,7 +26,7 @@ public static class InfoBarExtensions
     /// </code>
     /// </example>
     public static InfoBarWidget InfoBar<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<InfoBarContext, IEnumerable<IInfoBarChild>> builder,
         bool invertColors = true)
         where TParent : Hex1bWidget
@@ -39,11 +39,11 @@ public static class InfoBarExtensions
     /// <summary>
     /// Creates an InfoBar widget with legacy InfoBarSection objects.
     /// </summary>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="sections">The sections to display.</param>
     /// <param name="invertColors">Whether to invert foreground/background colors (default: true).</param>
     public static InfoBarWidget InfoBar<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         IReadOnlyList<InfoBarSection> sections,
         bool invertColors = true)
         where TParent : Hex1bWidget
@@ -58,10 +58,10 @@ public static class InfoBarExtensions
     /// <summary>
     /// Creates a simple InfoBar widget with text sections.
     /// </summary>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="texts">The text strings to display as sections.</param>
     public static InfoBarWidget InfoBar<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         params string[] texts)
         where TParent : Hex1bWidget
     {
@@ -73,11 +73,11 @@ public static class InfoBarExtensions
     /// <summary>
     /// Creates an InfoBar widget with a single text section.
     /// </summary>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="text">The text to display.</param>
     /// <param name="invertColors">Whether to invert foreground/background colors (default: true).</param>
     public static InfoBarWidget InfoBar<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         string text,
         bool invertColors = true)
         where TParent : Hex1bWidget
@@ -90,12 +90,12 @@ public static class InfoBarExtensions
     /// Creates an InfoBar widget with pre-built children.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="children">The info bar children.</param>
     /// <param name="invertColors">Whether to invert foreground/background colors (default: true).</param>
     /// <returns>An InfoBarWidget.</returns>
     public static InfoBarWidget InfoBar<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         IEnumerable<IInfoBarChild> children,
         bool invertColors = true)
         where TParent : Hex1bWidget
@@ -109,7 +109,7 @@ public static class InfoBarExtensions
     /// <param name="text">The text content.</param>
     /// <param name="foreground">Optional foreground color.</param>
     /// <param name="background">Optional background color.</param>
-    [Obsolete("Use the builder pattern: ctx.InfoBar(s => [s.Section(...)]) instead.")]
+    [Obsolete("Use the builder pattern: context.InfoBar(s => [s.Section(...)]) instead.")]
     public static InfoBarSection Section(
         string text,
         Hex1bColor? foreground = null,

--- a/src/Hex1b/InputOverrideExtensions.cs
+++ b/src/Hex1b/InputOverrideExtensions.cs
@@ -13,8 +13,8 @@ public static class InputOverrideExtensions
     /// </summary>
     /// <example>
     /// <code>
-    /// ctx.InputOverride(
-    ///     ctx.VStack([list1, list2, textbox1])
+    /// context.InputOverride(
+    ///     context.VStack([list1, list2, textbox1])
     /// )
     /// .Override&lt;ListWidget&gt;(b =&gt;
     /// {
@@ -24,11 +24,11 @@ public static class InputOverrideExtensions
     /// </code>
     /// </example>
     /// <typeparam name="TParent">The parent widget context type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="content">The child widget tree to wrap.</param>
     /// <returns>An <see cref="InputOverrideWidget"/> that can be further configured with <see cref="InputOverrideWidget.Override{TWidget}"/>.</returns>
     public static InputOverrideWidget InputOverride<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Hex1bWidget content)
         where TParent : Hex1bWidget
         => new(content);

--- a/src/Hex1b/InteractableExtensions.cs
+++ b/src/Hex1b/InteractableExtensions.cs
@@ -15,7 +15,7 @@ public static class InteractableExtensions
     /// </summary>
     /// <example>
     /// <code>
-    /// ctx.Interactable(ic =>
+    /// context.Interactable(ic =>
     ///     ic.VStack(v => [
     ///         v.Text("Tile content"),
     ///     ])
@@ -23,7 +23,7 @@ public static class InteractableExtensions
     /// </code>
     /// </example>
     public static InteractableWidget Interactable<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<InteractableContext, Hex1bWidget> builder)
         where TParent : Hex1bWidget
         => new(builder);
@@ -33,14 +33,14 @@ public static class InteractableExtensions
     /// </summary>
     /// <example>
     /// <code>
-    /// ctx.Interactable(ic => [
+    /// context.Interactable(ic => [
     ///     ic.Text("Line 1"),
     ///     ic.Text("Line 2"),
     /// ]).OnClick(args => DoSomething())
     /// </code>
     /// </example>
     public static InteractableWidget Interactable<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<InteractableContext, Hex1bWidget[]> builder)
         where TParent : Hex1bWidget
         => new(ic => new VStackWidget(builder(ic)));

--- a/src/Hex1b/KgpImageExtensions.cs
+++ b/src/Hex1b/KgpImageExtensions.cs
@@ -10,26 +10,26 @@ public static class KgpImageExtensions
     /// <summary>
     /// Creates a <see cref="KgpImageWidget"/> with the specified RGBA32 pixel data and fallback builder.
     /// </summary>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="imageData">Raw RGBA32 pixel data.</param>
     /// <param name="pixelWidth">Width of the image in pixels.</param>
     /// <param name="pixelHeight">Height of the image in pixels.</param>
-    /// <param name="fallbackBuilder">Builds the widget displayed when KGP is not supported.</param>
+    /// <param name="builder">Builds the widget displayed when KGP is not supported.</param>
     /// <param name="width">Optional width in character cells.</param>
     /// <param name="height">Optional height in character cells.</param>
     /// <returns>A new <see cref="KgpImageWidget"/>.</returns>
     public static KgpImageWidget KgpImage<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         byte[] imageData,
         int pixelWidth,
         int pixelHeight,
-        Func<WidgetContext<KgpImageWidget>, Hex1bWidget> fallbackBuilder,
+        Func<WidgetContext<KgpImageWidget>, Hex1bWidget> builder,
         int? width = null,
         int? height = null)
         where TParent : Hex1bWidget
     {
         var fallbackCtx = new WidgetContext<KgpImageWidget>();
-        return new(imageData, pixelWidth, pixelHeight, fallbackBuilder(fallbackCtx), width, height);
+        return new(imageData, pixelWidth, pixelHeight, builder(fallbackCtx), width, height);
     }
 
     /// <summary>

--- a/src/Hex1b/LanguageServer/LanguageServerExtensions.cs
+++ b/src/Hex1b/LanguageServer/LanguageServerExtensions.cs
@@ -22,10 +22,10 @@ public static class LanguageServerExtensions
     /// reuse the same connection. For explicit control, create a
     /// <see cref="LanguageServerDecorationProvider"/> and use <c>.Decorations(provider)</c>.
     /// </remarks>
-    /// <param name="editor">The editor widget to enhance.</param>
+    /// <param name="widget">The editor widget to enhance.</param>
     /// <param name="configure">Configuration callback for the language server connection.</param>
     /// <returns>A new editor widget with the language server decoration provider added.</returns>
-    public static EditorWidget LanguageServer(this EditorWidget editor, Action<LanguageServerConfiguration> configure)
+    public static EditorWidget LanguageServer(this EditorWidget widget, Action<LanguageServerConfiguration> configure)
     {
         var provider = s_providers.GetValue(configure, key =>
         {
@@ -34,7 +34,7 @@ public static class LanguageServerExtensions
             return new LanguageServerDecorationProvider(config);
         });
 
-        return editor.Decorations(provider);
+        return widget.Decorations(provider);
     }
 
     /// <summary>
@@ -42,7 +42,7 @@ public static class LanguageServerExtensions
     /// The workspace handles server lifecycle and connection sharing — multiple
     /// documents of the same language share a single server process.
     /// </summary>
-    /// <param name="editor">The editor widget to enhance.</param>
+    /// <param name="widget">The editor widget to enhance.</param>
     /// <param name="workspace">The workspace that manages server instances.</param>
     /// <param name="documentUri">
     /// The document's URI (e.g., <c>file:///path/to/file.cs</c>).
@@ -57,17 +57,17 @@ public static class LanguageServerExtensions
     /// var workspace = new Hex1bLanguageServerWorkspace("/my/project");
     /// workspace.RegisterServer("csharp", lsp => lsp.WithServerCommand("csharp-ls"));
     ///
-    /// ctx.Editor(state).LanguageServer(workspace, "file:///my/project/Program.cs")
+    /// context.Editor(state).LanguageServer(workspace, "file:///my/project/Program.cs")
     /// </code>
     /// </example>
     public static EditorWidget LanguageServer(
-        this EditorWidget editor,
+        this EditorWidget widget,
         Hex1bLanguageServerWorkspace workspace,
         string documentUri,
         string? languageId = null)
     {
         var provider = workspace.GetProvider(documentUri, languageId);
-        return editor.Decorations(provider);
+        return widget.Decorations(provider);
     }
 
     /// <summary>
@@ -77,14 +77,14 @@ public static class LanguageServerExtensions
     /// or <see cref="Hex1bDocumentWorkspace.MapDecorationProvider"/>.
     /// In-process decoration providers are checked first, then language server providers.
     /// </summary>
-    /// <param name="editor">The editor widget to enhance.</param>
+    /// <param name="widget">The editor widget to enhance.</param>
     /// <param name="workspace">The document workspace that manages servers.</param>
     /// <returns>The editor widget, with a decoration provider if a server matches.</returns>
     public static EditorWidget LanguageServer(
-        this EditorWidget editor,
+        this EditorWidget widget,
         Hex1bDocumentWorkspace workspace)
     {
-        var provider = workspace.GetDecorationProvider(editor.State.Document);
-        return provider != null ? editor.Decorations(provider) : editor;
+        var provider = workspace.GetDecorationProvider(widget.State.Document);
+        return provider != null ? widget.Decorations(provider) : widget;
     }
 }

--- a/src/Hex1b/LayoutExtensions.cs
+++ b/src/Hex1b/LayoutExtensions.cs
@@ -11,7 +11,7 @@ public static class LayoutExtensions
     /// Creates a Layout that wraps a single child widget with clipping enabled.
     /// </summary>
     public static LayoutWidget Layout<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Hex1bWidget child,
         ClipMode clipMode = ClipMode.Clip)
         where TParent : Hex1bWidget
@@ -21,7 +21,7 @@ public static class LayoutExtensions
     /// Creates a Layout with a VStack child.
     /// </summary>
     public static LayoutWidget Layout<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<WidgetContext<VStackWidget>, Hex1bWidget[]> builder,
         ClipMode clipMode = ClipMode.Clip)
         where TParent : Hex1bWidget
@@ -35,7 +35,7 @@ public static class LayoutExtensions
     /// Wraps an existing widget in a Layout with clipping.
     /// </summary>
     public static LayoutWidget WithClipping<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Hex1bWidget child)
         where TParent : Hex1bWidget
         => new(child, ClipMode.Clip);

--- a/src/Hex1b/LegendExtensions.cs
+++ b/src/Hex1b/LegendExtensions.cs
@@ -11,26 +11,26 @@ public static class LegendExtensions
     /// <summary>
     /// Creates a legend bound to the specified data.
     /// </summary>
-    public static LegendWidget<T> Legend<T>(this RootContext ctx, IReadOnlyList<T> data)
+    public static LegendWidget<T> Legend<T>(this RootContext context, IReadOnlyList<T> data)
         => new() { Data = data };
 
     /// <summary>
     /// Creates a legend with <see cref="ChartItem"/> data (selectors pre-wired).
     /// </summary>
-    public static LegendWidget<ChartItem> Legend(this RootContext ctx, IReadOnlyList<ChartItem> data)
+    public static LegendWidget<ChartItem> Legend(this RootContext context, IReadOnlyList<ChartItem> data)
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 
     /// <summary>
     /// Creates a legend with <see cref="ChartItem"/> data (params overload).
     /// </summary>
-    public static LegendWidget<ChartItem> Legend(this RootContext ctx, params ChartItem[] data)
+    public static LegendWidget<ChartItem> Legend(this RootContext context, params ChartItem[] data)
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 
     /// <summary>
     /// Creates a legend bound to the specified data.
     /// </summary>
     public static LegendWidget<T> Legend<T, TParent>(
-        this WidgetContext<TParent> ctx, IReadOnlyList<T> data)
+        this WidgetContext<TParent> context, IReadOnlyList<T> data)
         where TParent : Hex1bWidget
         => new() { Data = data };
 
@@ -38,7 +38,7 @@ public static class LegendExtensions
     /// Creates a legend with <see cref="ChartItem"/> data (selectors pre-wired).
     /// </summary>
     public static LegendWidget<ChartItem> Legend<TParent>(
-        this WidgetContext<TParent> ctx, IReadOnlyList<ChartItem> data)
+        this WidgetContext<TParent> context, IReadOnlyList<ChartItem> data)
         where TParent : Hex1bWidget
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 
@@ -46,7 +46,7 @@ public static class LegendExtensions
     /// Creates a legend with <see cref="ChartItem"/> data (params overload).
     /// </summary>
     public static LegendWidget<ChartItem> Legend<TParent>(
-        this WidgetContext<TParent> ctx, params ChartItem[] data)
+        this WidgetContext<TParent> context, params ChartItem[] data)
         where TParent : Hex1bWidget
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 }

--- a/src/Hex1b/ListExtensions.cs
+++ b/src/Hex1b/ListExtensions.cs
@@ -12,7 +12,7 @@ public static class ListExtensions
     /// Creates a List with the specified items.
     /// </summary>
     public static ListWidget List<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         IReadOnlyList<string> items)
         where TParent : Hex1bWidget
         => new(items);

--- a/src/Hex1b/LoggerPanelExtensions.cs
+++ b/src/Hex1b/LoggerPanelExtensions.cs
@@ -11,10 +11,10 @@ public static class LoggerPanelExtensions
     /// <summary>
     /// Creates a logger panel that displays log entries from the specified log store.
     /// </summary>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="logStore">The log store handle returned by <c>builder.Logging.AddHex1b(out var logStore)</c>.</param>
     public static LoggerPanelWidget LoggerPanel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         IHex1bLogStore logStore)
         where TParent : Hex1bWidget
         => new(logStore);

--- a/src/Hex1b/MarkdownExtensions.cs
+++ b/src/Hex1b/MarkdownExtensions.cs
@@ -11,10 +11,10 @@ public static class MarkdownExtensions
     /// <summary>
     /// Creates a markdown widget that parses and renders the given markdown source.
     /// </summary>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="source">The markdown source text.</param>
     public static MarkdownWidget Markdown<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         string source)
         where TParent : Hex1bWidget
         => new(source);
@@ -22,10 +22,10 @@ public static class MarkdownExtensions
     /// <summary>
     /// Creates a markdown widget from a <see cref="ReadOnlyMemory{T}"/> source.
     /// </summary>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="source">The markdown source memory.</param>
     public static MarkdownWidget Markdown<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         ReadOnlyMemory<char> source)
         where TParent : Hex1bWidget
         => new(source.Span.ToString());
@@ -35,10 +35,10 @@ public static class MarkdownExtensions
     /// The document's <see cref="IHex1bDocument.Version"/> is used for efficient
     /// change detection; re-parsing only occurs when the document version advances.
     /// </summary>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="document">The document to render as markdown.</param>
     public static MarkdownWidget Markdown<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         IHex1bDocument document)
         where TParent : Hex1bWidget
         => new(document);

--- a/src/Hex1b/MenuExtensions.cs
+++ b/src/Hex1b/MenuExtensions.cs
@@ -11,12 +11,12 @@ public static class MenuExtensions
     /// Creates a menu bar with the specified menus.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
-    /// <param name="menuBuilder">A function that builds the menus using a MenuContext.</param>
+    /// <param name="context">The widget context.</param>
+    /// <param name="builder">A function that builds the menus using a MenuContext.</param>
     /// <returns>A MenuBarWidget.</returns>
     /// <example>
     /// <code>
-    /// ctx.MenuBar(m => [
+    /// context.MenuBar(m => [
     ///     m.Menu("File", m => [
     ///         m.MenuItem("New").OnActivated(e => { /* action */ }),
     ///         m.MenuItem("Open").OnActivated(e => { /* action */ }),
@@ -35,12 +35,12 @@ public static class MenuExtensions
     /// </code>
     /// </example>
     public static MenuBarWidget MenuBar<TParent>(
-        this WidgetContext<TParent> ctx,
-        Func<MenuContext, IEnumerable<MenuWidget>> menuBuilder)
+        this WidgetContext<TParent> context,
+        Func<MenuContext, IEnumerable<MenuWidget>> builder)
         where TParent : Hex1bWidget
     {
         var menuContext = new MenuContext();
-        var menus = menuBuilder(menuContext).ToList();
+        var menus = builder(menuContext).ToList();
         return new MenuBarWidget(menus);
     }
 
@@ -48,11 +48,11 @@ public static class MenuExtensions
     /// Creates a menu bar with pre-built menus.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="menus">The menus to include in the bar.</param>
     /// <returns>A MenuBarWidget.</returns>
     public static MenuBarWidget MenuBar<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         IEnumerable<MenuWidget> menus)
         where TParent : Hex1bWidget
     {
@@ -63,11 +63,11 @@ public static class MenuExtensions
     /// Creates a menu bar with pre-built menus.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="menus">The menus to include in the bar.</param>
     /// <returns>A MenuBarWidget.</returns>
     public static MenuBarWidget MenuBar<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         params MenuWidget[] menus)
         where TParent : Hex1bWidget
     {

--- a/src/Hex1b/NavigatorExtensions.cs
+++ b/src/Hex1b/NavigatorExtensions.cs
@@ -14,7 +14,7 @@ public static class NavigatorExtensions
     /// </summary>
     [Experimental("HEX1B001")]
     public static NavigatorWidget Navigator<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         NavigatorState navigatorState)
         where TParent : Hex1bWidget
         => new(navigatorState);

--- a/src/Hex1b/PaddingExtensions.cs
+++ b/src/Hex1b/PaddingExtensions.cs
@@ -11,7 +11,7 @@ public static class PaddingExtensions
     /// Creates a Padding wrapper with per-side values around a single child widget.
     /// </summary>
     public static PaddingWidget Padding<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         int left, int right, int top, int bottom,
         Hex1bWidget child)
         where TParent : Hex1bWidget
@@ -21,7 +21,7 @@ public static class PaddingExtensions
     /// Creates a Padding wrapper with per-side values and a builder for a single child.
     /// </summary>
     public static PaddingWidget Padding<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         int left, int right, int top, int bottom,
         Func<WidgetContext<PaddingWidget>, Hex1bWidget> builder)
         where TParent : Hex1bWidget
@@ -34,7 +34,7 @@ public static class PaddingExtensions
     /// Creates a Padding wrapper with per-side values and an implicit VStack for multiple children.
     /// </summary>
     public static PaddingWidget Padding<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         int left, int right, int top, int bottom,
         Func<WidgetContext<PaddingWidget>, Hex1bWidget[]> builder)
         where TParent : Hex1bWidget
@@ -47,7 +47,7 @@ public static class PaddingExtensions
     /// Creates a Padding wrapper with uniform padding on all sides.
     /// </summary>
     public static PaddingWidget Padding<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         int all,
         Hex1bWidget child)
         where TParent : Hex1bWidget
@@ -57,7 +57,7 @@ public static class PaddingExtensions
     /// Creates a Padding wrapper with uniform horizontal and vertical padding.
     /// </summary>
     public static PaddingWidget Padding<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         int horizontal, int vertical,
         Hex1bWidget child)
         where TParent : Hex1bWidget

--- a/src/Hex1b/PastableExtensions.cs
+++ b/src/Hex1b/PastableExtensions.cs
@@ -12,7 +12,7 @@ public static class PastableExtensions
     /// Creates a Pastable container wrapping a single child widget.
     /// </summary>
     public static PastableWidget Pastable<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Hex1bWidget child)
         where TParent : Hex1bWidget
         => new(child);
@@ -21,7 +21,7 @@ public static class PastableExtensions
     /// Creates a Pastable container with a VStack child.
     /// </summary>
     public static PastableWidget Pastable<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<WidgetContext<VStackWidget>, Hex1bWidget[]> builder)
         where TParent : Hex1bWidget
     {

--- a/src/Hex1b/PickerExtensions.cs
+++ b/src/Hex1b/PickerExtensions.cs
@@ -11,11 +11,11 @@ public static class PickerExtensions
     /// Creates a picker widget with the specified items.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="items">The list of items to choose from.</param>
     /// <returns>A new PickerWidget.</returns>
     public static PickerWidget Picker<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         IReadOnlyList<string> items)
         where TParent : Hex1bWidget
         => new(items);
@@ -24,11 +24,11 @@ public static class PickerExtensions
     /// Creates a picker widget with the specified items.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="items">The items to choose from.</param>
     /// <returns>A new PickerWidget.</returns>
     public static PickerWidget Picker<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         params string[] items)
         where TParent : Hex1bWidget
         => new(items);
@@ -37,12 +37,12 @@ public static class PickerExtensions
     /// Creates a picker widget with the specified items and initial selection.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="items">The list of items to choose from.</param>
     /// <param name="initialSelectedIndex">The initial selected index.</param>
     /// <returns>A new PickerWidget.</returns>
     public static PickerWidget Picker<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         IReadOnlyList<string> items,
         int initialSelectedIndex)
         where TParent : Hex1bWidget

--- a/src/Hex1b/ProgressExtensions.cs
+++ b/src/Hex1b/ProgressExtensions.cs
@@ -27,18 +27,18 @@ using Hex1b.Widgets;
 /// <example>
 /// <para>Determinate progress (0-100):</para>
 /// <code>
-/// ctx.VStack(v => [
+/// context.VStack(v => [
 ///     v.Text("Downloading..."),
 ///     v.Progress(percentComplete)
 /// ])
 /// </code>
 /// <para>Custom range:</para>
 /// <code>
-/// ctx.Progress(current: bytesDownloaded, min: 0, max: totalBytes)
+/// context.Progress(current: bytesDownloaded, min: 0, max: totalBytes)
 /// </code>
 /// <para>Indeterminate (self-animating):</para>
 /// <code>
-/// ctx.ProgressIndeterminate()
+/// context.ProgressIndeterminate()
 /// </code>
 /// </example>
 public static class ProgressExtensions
@@ -47,7 +47,7 @@ public static class ProgressExtensions
     /// Creates a determinate progress bar with a value from 0 to 100.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="current">The current progress value (0-100 by default).</param>
     /// <returns>A new ProgressWidget configured for determinate mode.</returns>
     /// <example>
@@ -56,7 +56,7 @@ public static class ProgressExtensions
     /// </code>
     /// </example>
     public static ProgressWidget Progress<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         double current)
         where TParent : Hex1bWidget
         => new() { Value = current, Minimum = 0, Maximum = 100 };
@@ -65,7 +65,7 @@ public static class ProgressExtensions
     /// Creates a determinate progress bar with a custom range.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="current">The current progress value.</param>
     /// <param name="min">The minimum value of the range.</param>
     /// <param name="max">The maximum value of the range.</param>
@@ -84,7 +84,7 @@ public static class ProgressExtensions
     /// </code>
     /// </example>
     public static ProgressWidget Progress<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         double current,
         double min,
         double max)
@@ -95,7 +95,7 @@ public static class ProgressExtensions
     /// Creates an indeterminate progress bar for operations with unknown completion.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <returns>A new ProgressWidget configured for indeterminate mode with automatic animation.</returns>
     /// <remarks>
     /// <para>
@@ -105,11 +105,11 @@ public static class ProgressExtensions
     /// </remarks>
     /// <example>
     /// <code>
-    /// ctx.ProgressIndeterminate()
+    /// context.ProgressIndeterminate()
     /// </code>
     /// </example>
     public static ProgressWidget ProgressIndeterminate<TParent>(
-        this WidgetContext<TParent> ctx)
+        this WidgetContext<TParent> context)
         where TParent : Hex1bWidget
         => new() { IsIndeterminate = true };
 }

--- a/src/Hex1b/QrCodeExtensions.cs
+++ b/src/Hex1b/QrCodeExtensions.cs
@@ -14,7 +14,7 @@ using Hex1b.Widgets;
 /// <example>
 /// <para>Using QrCode within a VStack:</para>
 /// <code>
-/// ctx.VStack(v => [
+/// context.VStack(v => [
 ///     v.Text("Scan to visit:"),
 ///     v.QrCode("https://github.com/mitchdenny/hex1b"),
 ///     v.Text("GitHub Repository")
@@ -28,16 +28,16 @@ public static class QrCodeExtensions
     /// Creates a <see cref="QrCodeWidget"/> with the specified data to encode.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type in the current context.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="data">The data to encode in the QR code (typically a URL).</param>
     /// <returns>A new <see cref="QrCodeWidget"/> with a default quiet zone of 1.</returns>
     /// <example>
     /// <code>
-    /// ctx.QrCode("https://example.com")
+    /// context.QrCode("https://example.com")
     /// </code>
     /// </example>
     public static QrCodeWidget QrCode<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         string data)
         where TParent : Hex1bWidget
         => new(data);

--- a/src/Hex1b/RescueExtensions.cs
+++ b/src/Hex1b/RescueExtensions.cs
@@ -11,17 +11,17 @@ public static class RescueExtensions
     /// Wraps a widget in a rescue boundary that catches exceptions and displays a fallback.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="child">The child widget to protect.</param>
     /// <returns>A new RescueWidget.</returns>
     /// <example>
     /// <code>
-    /// ctx.Rescue(ctx.SomeWidget())
+    /// context.Rescue(context.SomeWidget())
     ///    .OnRescue(e => logger.LogError(e.Exception, "Error in {Phase}", e.Phase))
     /// </code>
     /// </example>
     public static RescueWidget Rescue<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Hex1bWidget child)
         where TParent : Hex1bWidget
         => new(child);
@@ -30,26 +30,26 @@ public static class RescueExtensions
     /// Wraps a VStack in a rescue boundary that catches exceptions and displays a fallback.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
-    /// <param name="childBuilder">A builder function that creates VStack children.</param>
+    /// <param name="context">The widget context.</param>
+    /// <param name="builder">A builder function that creates VStack children.</param>
     /// <returns>A new RescueWidget containing a VStack.</returns>
     /// <example>
     /// <code>
-    /// ctx.Rescue(v => [
+    /// context.Rescue(v => [
     ///     v.Text("Some content"),
     ///     v.Button("Click me")
     /// ])
     /// </code>
     /// </example>
     public static RescueWidget Rescue<TParent>(
-        this WidgetContext<TParent> ctx,
-        Func<WidgetContext<VStackWidget>, Hex1bWidget[]> childBuilder)
+        this WidgetContext<TParent> context,
+        Func<WidgetContext<VStackWidget>, Hex1bWidget[]> builder)
         where TParent : Hex1bWidget
     {
         try
         {
             var childCtx = new WidgetContext<VStackWidget>();
-            return new RescueWidget(new VStackWidget(childBuilder(childCtx)));
+            return new RescueWidget(new VStackWidget(builder(childCtx)));
         }
         catch (Exception ex)
         {
@@ -63,11 +63,11 @@ public static class RescueExtensions
     /// Useful for production environments where you want a friendly error message.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="child">The child widget to protect.</param>
     /// <returns>A new RescueWidget with ShowDetails set to false.</returns>
     public static RescueWidget RescueFriendly<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Hex1bWidget child)
         where TParent : Hex1bWidget
         => new RescueWidget(child) { ShowDetails = false };

--- a/src/Hex1b/ResponsiveExtensions.cs
+++ b/src/Hex1b/ResponsiveExtensions.cs
@@ -15,7 +15,7 @@ public static class ResponsiveExtensions
     /// Use inside a Responsive() builder to create conditional branches.
     /// </summary>
     public static ConditionalWidget When<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<int, int, bool> condition,
         Func<WidgetContext<ConditionalWidget>, Hex1bWidget> builder)
         where TParent : Hex1bWidget
@@ -30,12 +30,12 @@ public static class ResponsiveExtensions
     /// Convenience overload for common width-based responsive layouts.
     /// </summary>
     public static ConditionalWidget WhenWidth<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<int, bool> widthCondition,
         Func<WidgetContext<ConditionalWidget>, Hex1bWidget> builder)
         where TParent : Hex1bWidget
     {
-        return ctx.When((w, h) => widthCondition(w), builder);
+        return context.When((w, h) => widthCondition(w), builder);
     }
 
     /// <summary>
@@ -43,12 +43,12 @@ public static class ResponsiveExtensions
     /// The content is displayed when availableWidth >= minWidth.
     /// </summary>
     public static ConditionalWidget WhenMinWidth<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         int minWidth,
         Func<WidgetContext<ConditionalWidget>, Hex1bWidget> builder)
         where TParent : Hex1bWidget
     {
-        return ctx.When((w, h) => w >= minWidth, builder);
+        return context.When((w, h) => w >= minWidth, builder);
     }
 
     /// <summary>
@@ -56,21 +56,21 @@ public static class ResponsiveExtensions
     /// Use as the last branch in a Responsive() to provide a fallback.
     /// </summary>
     public static ConditionalWidget Otherwise<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<WidgetContext<ConditionalWidget>, Hex1bWidget> builder)
         where TParent : Hex1bWidget
     {
-        return ctx.When((w, h) => true, builder);
+        return context.When((w, h) => true, builder);
     }
 
     /// <summary>
     /// Creates a Responsive widget that displays the first child whose condition evaluates to true.
     /// Conditions receive (availableWidth, availableHeight) from the parent's layout constraints.
     /// Use collection expression syntax with When()/WhenMinWidth()/Otherwise() to define conditional branches.
-    /// Example: ctx.Responsive(r => [r.WhenMinWidth(100, r => r.Text("Wide")), r.Otherwise(r => r.Text("Narrow"))])
+    /// Example: context.Responsive(r => [r.WhenMinWidth(100, r => r.Text("Wide")), r.Otherwise(r => r.Text("Narrow"))])
     /// </summary>
     public static ResponsiveWidget Responsive<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<WidgetContext<ResponsiveWidget>, ConditionalWidget[]> builder)
         where TParent : Hex1bWidget
     {

--- a/src/Hex1b/ScatterChartExtensions.cs
+++ b/src/Hex1b/ScatterChartExtensions.cs
@@ -12,9 +12,9 @@ public static class ScatterChartExtensions
     /// Creates a scatter chart bound to the specified data.
     /// </summary>
     /// <typeparam name="T">The data item type.</typeparam>
-    /// <param name="ctx">The root context.</param>
+    /// <param name="context">The root context.</param>
     /// <param name="data">The data source for the chart.</param>
-    public static ScatterChartWidget<T> ScatterChart<T>(this RootContext ctx, IReadOnlyList<T> data)
+    public static ScatterChartWidget<T> ScatterChart<T>(this RootContext context, IReadOnlyList<T> data)
         => new() { Data = data };
 
     /// <summary>
@@ -22,10 +22,10 @@ public static class ScatterChartExtensions
     /// </summary>
     /// <typeparam name="T">The data item type.</typeparam>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="data">The data source for the chart.</param>
     public static ScatterChartWidget<T> ScatterChart<T, TParent>(
-        this WidgetContext<TParent> ctx, IReadOnlyList<T> data)
+        this WidgetContext<TParent> context, IReadOnlyList<T> data)
         where TParent : Hex1bWidget
         => new() { Data = data };
 }

--- a/src/Hex1b/ScrollPanelExtensions.cs
+++ b/src/Hex1b/ScrollPanelExtensions.cs
@@ -11,7 +11,7 @@ public static class ScrollPanelExtensions
     /// Creates a vertical scroll panel with the specified child.
     /// </summary>
     public static ScrollPanelWidget VScrollPanel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Hex1bWidget child,
         bool showScrollbar = true)
         where TParent : Hex1bWidget
@@ -21,14 +21,14 @@ public static class ScrollPanelExtensions
     /// Creates a vertical scroll panel with a VStack child built from a callback.
     /// </summary>
     public static ScrollPanelWidget VScrollPanel<TParent>(
-        this WidgetContext<TParent> ctx,
-        Func<WidgetContext<VStackWidget>, Hex1bWidget[]> childBuilder,
+        this WidgetContext<TParent> context,
+        Func<WidgetContext<VStackWidget>, Hex1bWidget[]> builder,
         bool showScrollbar = true)
         where TParent : Hex1bWidget
     {
         var childCtx = new WidgetContext<VStackWidget>();
         return new ScrollPanelWidget(
-            new VStackWidget(childBuilder(childCtx)),
+            new VStackWidget(builder(childCtx)),
             ScrollOrientation.Vertical,
             showScrollbar);
     }
@@ -37,7 +37,7 @@ public static class ScrollPanelExtensions
     /// Creates a horizontal scroll panel with the specified child.
     /// </summary>
     public static ScrollPanelWidget HScrollPanel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Hex1bWidget child,
         bool showScrollbar = true)
         where TParent : Hex1bWidget
@@ -47,14 +47,14 @@ public static class ScrollPanelExtensions
     /// Creates a horizontal scroll panel with an HStack child built from a callback.
     /// </summary>
     public static ScrollPanelWidget HScrollPanel<TParent>(
-        this WidgetContext<TParent> ctx,
-        Func<WidgetContext<HStackWidget>, Hex1bWidget[]> childBuilder,
+        this WidgetContext<TParent> context,
+        Func<WidgetContext<HStackWidget>, Hex1bWidget[]> builder,
         bool showScrollbar = true)
         where TParent : Hex1bWidget
     {
         var childCtx = new WidgetContext<HStackWidget>();
         return new ScrollPanelWidget(
-            new HStackWidget(childBuilder(childCtx)),
+            new HStackWidget(builder(childCtx)),
             ScrollOrientation.Horizontal,
             showScrollbar);
     }
@@ -63,7 +63,7 @@ public static class ScrollPanelExtensions
     /// Creates a scroll panel with the specified orientation.
     /// </summary>
     public static ScrollPanelWidget ScrollPanel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Hex1bWidget child,
         ScrollOrientation orientation,
         bool showScrollbar = true)

--- a/src/Hex1b/ScrollbarExtensions.cs
+++ b/src/Hex1b/ScrollbarExtensions.cs
@@ -11,7 +11,7 @@ public static class ScrollbarExtensions
     /// Creates a vertical scrollbar.
     /// </summary>
     public static ScrollbarWidget VScrollbar<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         int contentSize,
         int viewportSize,
         int offset)
@@ -22,7 +22,7 @@ public static class ScrollbarExtensions
     /// Creates a horizontal scrollbar.
     /// </summary>
     public static ScrollbarWidget HScrollbar<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         int contentSize,
         int viewportSize,
         int offset)
@@ -33,7 +33,7 @@ public static class ScrollbarExtensions
     /// Creates a scrollbar with the specified orientation.
     /// </summary>
     public static ScrollbarWidget Scrollbar<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         ScrollOrientation orientation,
         int contentSize,
         int viewportSize,

--- a/src/Hex1b/SelectionPanelExtensions.cs
+++ b/src/Hex1b/SelectionPanelExtensions.cs
@@ -13,7 +13,7 @@ public static class SelectionPanelExtensions
     /// add a copy/select mode similar to <c>TerminalWidget</c>'s.
     /// </summary>
     public static SelectionPanelWidget SelectionPanel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Hex1bWidget child)
         where TParent : Hex1bWidget
         => new(child);

--- a/src/Hex1b/SeparatorExtensions.cs
+++ b/src/Hex1b/SeparatorExtensions.cs
@@ -19,7 +19,7 @@ using Hex1b.Widgets;
 /// <example>
 /// <para>Using Separator within a VStack:</para>
 /// <code>
-/// ctx.VStack(v =&gt; [
+/// context.VStack(v =&gt; [
 ///     v.Text("Section 1"),
 ///     v.Separator(),
 ///     v.Text("Section 2")
@@ -34,18 +34,18 @@ public static class SeparatorExtensions
     /// The orientation is inferred from the parent container (horizontal in VStack, vertical in HStack).
     /// </summary>
     /// <typeparam name="TParent">The parent widget type in the current context.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <returns>A new <see cref="SeparatorWidget"/>.</returns>
     /// <example>
     /// <code>
-    /// ctx.VStack(v =&gt; [
+    /// context.VStack(v =&gt; [
     ///     v.Text("Above"),
     ///     v.Separator(),
     ///     v.Text("Below")
     /// ])
     /// </code>
     /// </example>
-    public static SeparatorWidget Separator<TParent>(this WidgetContext<TParent> ctx)
+    public static SeparatorWidget Separator<TParent>(this WidgetContext<TParent> context)
         where TParent : Hex1bWidget
         => new();
 
@@ -53,9 +53,9 @@ public static class SeparatorExtensions
     /// Creates a horizontal <see cref="SeparatorWidget"/> regardless of parent container.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type in the current context.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <returns>A new horizontal <see cref="SeparatorWidget"/>.</returns>
-    public static SeparatorWidget HSeparator<TParent>(this WidgetContext<TParent> ctx)
+    public static SeparatorWidget HSeparator<TParent>(this WidgetContext<TParent> context)
         where TParent : Hex1bWidget
         => new() { ExplicitAxis = LayoutAxis.Vertical }; // Horizontal line in vertical layout
 
@@ -63,9 +63,9 @@ public static class SeparatorExtensions
     /// Creates a vertical <see cref="SeparatorWidget"/> regardless of parent container.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type in the current context.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <returns>A new vertical <see cref="SeparatorWidget"/>.</returns>
-    public static SeparatorWidget VSeparator<TParent>(this WidgetContext<TParent> ctx)
+    public static SeparatorWidget VSeparator<TParent>(this WidgetContext<TParent> context)
         where TParent : Hex1bWidget
         => new() { ExplicitAxis = LayoutAxis.Horizontal }; // Vertical line in horizontal layout
 }

--- a/src/Hex1b/SixelExtensions.cs
+++ b/src/Hex1b/SixelExtensions.cs
@@ -13,13 +13,13 @@ public static class SixelExtensions
     /// <summary>
     /// Creates a SixelWidget with the specified image data and fallback widget.
     /// </summary>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="imageData">The Sixel-encoded image data.</param>
     /// <param name="fallback">A widget to display if Sixel is not supported.</param>
     /// <param name="width">Optional width in character cells.</param>
     /// <param name="height">Optional height in character cells.</param>
     public static SixelWidget Sixel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         string imageData,
         Hex1bWidget fallback,
         int? width = null,
@@ -30,13 +30,13 @@ public static class SixelExtensions
     /// <summary>
     /// Creates a SixelWidget with the specified image data and a text fallback.
     /// </summary>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="imageData">The Sixel-encoded image data.</param>
     /// <param name="fallbackText">Text to display if Sixel is not supported.</param>
     /// <param name="width">Optional width in character cells.</param>
     /// <param name="height">Optional height in character cells.</param>
     public static SixelWidget Sixel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         string imageData,
         string fallbackText,
         int? width = null,
@@ -47,15 +47,15 @@ public static class SixelExtensions
     /// <summary>
     /// Creates a SixelWidget with image data and a fallback widget builder.
     /// </summary>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="imageData">The Sixel-encoded image data.</param>
-    /// <param name="fallbackBuilder">Builder for the fallback widget.</param>
+    /// <param name="builder">Builder for the fallback widget.</param>
     /// <param name="width">Optional width in character cells.</param>
     /// <param name="height">Optional height in character cells.</param>
     public static SixelWidget Sixel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         string imageData,
-        Func<WidgetContext<SixelWidget>, Hex1bWidget> fallbackBuilder,
+        Func<WidgetContext<SixelWidget>, Hex1bWidget> builder,
         int? width = null,
         int? height = null)
         where TParent : Hex1bWidget
@@ -63,7 +63,7 @@ public static class SixelExtensions
         var fallbackCtx = new WidgetContext<SixelWidget>();
         return new SixelWidget(
             imageData,
-            fallbackBuilder(fallbackCtx),
+            builder(fallbackCtx),
             width,
             height);
     }
@@ -71,15 +71,15 @@ public static class SixelExtensions
     /// <summary>
     /// Creates a SixelWidget with image data and a VStack fallback.
     /// </summary>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="imageData">The Sixel-encoded image data.</param>
-    /// <param name="fallbackBuilder">Builder for the fallback widgets (wrapped in VStack).</param>
+    /// <param name="builder">Builder for the fallback widgets (wrapped in VStack).</param>
     /// <param name="width">Optional width in character cells.</param>
     /// <param name="height">Optional height in character cells.</param>
     public static SixelWidget Sixel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         string imageData,
-        Func<WidgetContext<VStackWidget>, Hex1bWidget[]> fallbackBuilder,
+        Func<WidgetContext<VStackWidget>, Hex1bWidget[]> builder,
         int? width = null,
         int? height = null)
         where TParent : Hex1bWidget
@@ -87,7 +87,7 @@ public static class SixelExtensions
         var fallbackCtx = new WidgetContext<VStackWidget>();
         return new SixelWidget(
             imageData,
-            new VStackWidget(fallbackBuilder(fallbackCtx)),
+            new VStackWidget(builder(fallbackCtx)),
             width,
             height);
     }

--- a/src/Hex1b/SliderExtensions.cs
+++ b/src/Hex1b/SliderExtensions.cs
@@ -15,15 +15,15 @@ using Hex1b.Widgets;
 /// <example>
 /// <para>Simple slider with default 0-100 range:</para>
 /// <code>
-/// ctx.Slider(50)
+/// context.Slider(50)
 /// </code>
 /// <para>Slider with custom range:</para>
 /// <code>
-/// ctx.Slider(25, min: 0, max: 50)
+/// context.Slider(25, min: 0, max: 50)
 /// </code>
 /// <para>Slider with discrete steps:</para>
 /// <code>
-/// ctx.Slider(0, min: 0, max: 100, step: 10)
+/// context.Slider(0, min: 0, max: 100, step: 10)
 /// </code>
 /// </example>
 /// <seealso cref="SliderWidget"/>
@@ -34,16 +34,16 @@ public static class SliderExtensions
     /// Creates a slider with a 0-100 range.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="initialValue">The initial value (0-100). Default is 0.</param>
     /// <returns>A new SliderWidget.</returns>
     /// <example>
     /// <code>
-    /// ctx.Slider(50) // Slider at 50%
+    /// context.Slider(50) // Slider at 50%
     /// </code>
     /// </example>
     public static SliderWidget Slider<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         double initialValue = 0)
         where TParent : Hex1bWidget
         => new() { InitialValue = initialValue, Minimum = 0, Maximum = 100 };
@@ -52,18 +52,18 @@ public static class SliderExtensions
     /// Creates a slider with a custom range.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="initialValue">The initial value.</param>
     /// <param name="min">The minimum value of the range.</param>
     /// <param name="max">The maximum value of the range.</param>
     /// <returns>A new SliderWidget.</returns>
     /// <example>
     /// <code>
-    /// ctx.Slider(5, min: 0, max: 10)
+    /// context.Slider(5, min: 0, max: 10)
     /// </code>
     /// </example>
     public static SliderWidget Slider<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         double initialValue,
         double min,
         double max)
@@ -74,7 +74,7 @@ public static class SliderExtensions
     /// Creates a slider with a custom range and step increment.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="initialValue">The initial value.</param>
     /// <param name="min">The minimum value of the range.</param>
     /// <param name="max">The maximum value of the range.</param>
@@ -86,11 +86,11 @@ public static class SliderExtensions
     /// </remarks>
     /// <example>
     /// <code>
-    /// ctx.Slider(0, min: 0, max: 100, step: 5)
+    /// context.Slider(0, min: 0, max: 100, step: 5)
     /// </code>
     /// </example>
     public static SliderWidget Slider<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         double initialValue,
         double min,
         double max,

--- a/src/Hex1b/SpinnerExtensions.cs
+++ b/src/Hex1b/SpinnerExtensions.cs
@@ -15,15 +15,15 @@ namespace Hex1b;
 /// <example>
 /// <para>Time-based spinner (recommended, self-animating):</para>
 /// <code>
-/// ctx.Spinner()
+/// context.Spinner()
 /// </code>
 /// <para>Spinner with explicit style:</para>
 /// <code>
-/// ctx.Spinner(SpinnerStyle.Arrow)
+/// context.Spinner(SpinnerStyle.Arrow)
 /// </code>
 /// <para>Manual frame control (no auto-redraw):</para>
 /// <code>
-/// ctx.Spinner(frameIndex: myCounter)
+/// context.Spinner(frameIndex: myCounter)
 /// </code>
 /// </example>
 public static class SpinnerExtensions
@@ -32,15 +32,15 @@ public static class SpinnerExtensions
     /// Creates a self-animating spinner using the theme's default style.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <returns>A new SpinnerWidget with time-based animation and automatic redraws.</returns>
     /// <example>
     /// <code>
-    /// ctx.Spinner()
+    /// context.Spinner()
     /// </code>
     /// </example>
     public static SpinnerWidget Spinner<TParent>(
-        this WidgetContext<TParent> ctx)
+        this WidgetContext<TParent> context)
         where TParent : Hex1bWidget
         => new();
 
@@ -48,16 +48,16 @@ public static class SpinnerExtensions
     /// Creates a self-animating spinner with an explicit style.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="style">The spinner style to use.</param>
     /// <returns>A new SpinnerWidget with time-based animation and automatic redraws.</returns>
     /// <example>
     /// <code>
-    /// ctx.Spinner(SpinnerStyle.Arrow)
+    /// context.Spinner(SpinnerStyle.Arrow)
     /// </code>
     /// </example>
     public static SpinnerWidget Spinner<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         SpinnerStyle style)
         where TParent : Hex1bWidget
         => new() { Style = style };
@@ -66,7 +66,7 @@ public static class SpinnerExtensions
     /// Creates a spinner with manual frame control using the theme's default style.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="frameIndex">The frame index to display (wraps automatically).</param>
     /// <returns>A new SpinnerWidget with manual frame control (no auto-redraw).</returns>
     /// <remarks>
@@ -74,7 +74,7 @@ public static class SpinnerExtensions
     /// and calling <see cref="Hex1bApp.Invalidate"/> or using <see cref="AnimationExtensions.RedrawAfter{TWidget}(TWidget, int)"/>.
     /// </remarks>
     public static SpinnerWidget Spinner<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         int frameIndex)
         where TParent : Hex1bWidget
         => new() { FrameIndex = frameIndex };
@@ -83,7 +83,7 @@ public static class SpinnerExtensions
     /// Creates a spinner with manual frame control and explicit style.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="style">The spinner style to use.</param>
     /// <param name="frameIndex">The frame index to display (wraps automatically).</param>
     /// <returns>A new SpinnerWidget with manual frame control (no auto-redraw).</returns>
@@ -92,7 +92,7 @@ public static class SpinnerExtensions
     /// and calling <see cref="Hex1bApp.Invalidate"/> or using <see cref="AnimationExtensions.RedrawAfter{TWidget}(TWidget, int)"/>.
     /// </remarks>
     public static SpinnerWidget Spinner<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         SpinnerStyle style,
         int frameIndex)
         where TParent : Hex1bWidget

--- a/src/Hex1b/SplitterExtensions.cs
+++ b/src/Hex1b/SplitterExtensions.cs
@@ -1,5 +1,6 @@
 namespace Hex1b;
 
+using System.Diagnostics.CodeAnalysis;
 using Hex1b.Layout;
 using Hex1b.Widgets;
 
@@ -12,7 +13,7 @@ public static class SplitterExtensions
     /// Creates a horizontal Splitter with left and right child widgets.
     /// </summary>
     public static SplitterWidget HSplitter<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Hex1bWidget left,
         Hex1bWidget right,
         int leftWidth = 30)
@@ -23,7 +24,7 @@ public static class SplitterExtensions
     /// Creates a vertical Splitter with top and bottom child widgets.
     /// </summary>
     public static SplitterWidget VSplitter<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Hex1bWidget top,
         Hex1bWidget bottom,
         int topHeight = 10)
@@ -33,8 +34,12 @@ public static class SplitterExtensions
     /// <summary>
     /// Creates a horizontal Splitter where both panes are VStacks built from callbacks.
     /// </summary>
+    [SuppressMessage(
+        "Hex1b.ApiDesign",
+        "HEX1B0009",
+        Justification = "A splitter inherently has two independent panes; each side takes its own builder callback.")]
     public static SplitterWidget HSplitter<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<WidgetContext<VStackWidget>, Hex1bWidget[]> leftBuilder,
         Func<WidgetContext<VStackWidget>, Hex1bWidget[]> rightBuilder,
         int leftWidth = 30)
@@ -52,8 +57,12 @@ public static class SplitterExtensions
     /// <summary>
     /// Creates a vertical Splitter where both panes are VStacks built from callbacks.
     /// </summary>
+    [SuppressMessage(
+        "Hex1b.ApiDesign",
+        "HEX1B0009",
+        Justification = "A splitter inherently has two independent panes; each side takes its own builder callback.")]
     public static SplitterWidget VSplitter<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<WidgetContext<VStackWidget>, Hex1bWidget[]> topBuilder,
         Func<WidgetContext<VStackWidget>, Hex1bWidget[]> bottomBuilder,
         int topHeight = 10)

--- a/src/Hex1b/StatePanelExtensions.cs
+++ b/src/Hex1b/StatePanelExtensions.cs
@@ -14,13 +14,13 @@ public static class StatePanelExtensions
     /// </summary>
     /// <example>
     /// <code>
-    /// ctx.StatePanel(myViewModel, sp =>
+    /// context.StatePanel(myViewModel, sp =>
     ///     sp.Text($"Count: {myViewModel.Count}")
     /// );
     /// </code>
     /// </example>
     public static StatePanelWidget StatePanel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         object stateKey,
         Func<StatePanelContext, Hex1bWidget> builder)
         where TParent : Hex1bWidget

--- a/src/Hex1b/SurfaceExtensions.cs
+++ b/src/Hex1b/SurfaceExtensions.cs
@@ -15,10 +15,10 @@ using Hex1b.Widgets;
 /// <example>
 /// <para>Creating a surface with multiple layers:</para>
 /// <code>
-/// ctx.Surface(s => [
+/// context.Surface(s => [
 ///     s.Layer(backgroundSurface),
 ///     s.Layer(surface => DrawSprite(surface)),
-///     s.Layer(ctx => FogOfWar(ctx, s.MouseX, s.MouseY))
+///     s.Layer(context => FogOfWar(context, s.MouseX, s.MouseY))
 /// ])
 /// </code>
 /// </example>
@@ -30,40 +30,40 @@ public static class SurfaceExtensions
     /// Creates a <see cref="SurfaceWidget"/> with the specified layer builder.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type in the current context.</typeparam>
-    /// <param name="ctx">The widget context.</param>
-    /// <param name="layerBuilder">
+    /// <param name="context">The widget context.</param>
+    /// <param name="builder">
     /// A function that receives a <see cref="SurfaceLayerContext"/> and returns
     /// the layers to composite. Called each render with current mouse position.
     /// </param>
     /// <returns>A new <see cref="SurfaceWidget"/> with the specified layers.</returns>
     /// <example>
     /// <code>
-    /// ctx.Surface(s => [
+    /// context.Surface(s => [
     ///     s.Layer(terrainSurface),
-    ///     s.Layer(ctx => Tint(ctx, Hex1bColor.Blue, 0.3))
+    ///     s.Layer(context => Tint(context, Hex1bColor.Blue, 0.3))
     /// ])
     /// </code>
     /// </example>
     public static SurfaceWidget Surface<TParent>(
-        this WidgetContext<TParent> ctx,
-        Func<SurfaceLayerContext, IEnumerable<SurfaceLayer>> layerBuilder)
+        this WidgetContext<TParent> context,
+        Func<SurfaceLayerContext, IEnumerable<SurfaceLayer>> builder)
         where TParent : Hex1bWidget
-        => new(layerBuilder);
+        => new(builder);
 
     /// <summary>
     /// Creates a <see cref="SurfaceWidget"/> with a single static surface.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type in the current context.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="source">The surface source to display.</param>
     /// <returns>A new <see cref="SurfaceWidget"/> displaying the source.</returns>
     /// <example>
     /// <code>
-    /// ctx.Surface(myPreRenderedSurface)
+    /// context.Surface(myPreRenderedSurface)
     /// </code>
     /// </example>
     public static SurfaceWidget Surface<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         ISurfaceSource source)
         where TParent : Hex1bWidget
         => new(s => [s.Layer(source)]);

--- a/src/Hex1b/TabBarExtensions.cs
+++ b/src/Hex1b/TabBarExtensions.cs
@@ -11,12 +11,12 @@ public static class TabBarExtensions
     /// Creates a TabBar widget using a builder pattern.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="builder">A function that builds the tabs using a TabPanelContext.</param>
     /// <returns>A TabBarWidget.</returns>
     /// <example>
     /// <code>
-    /// ctx.TabBar(tp => [
+    /// context.TabBar(tp => [
     ///     tp.Tab("Tab 1", null).Selected(),
     ///     tp.Tab("Tab 2", null),
     ///     tp.Tab("Tab 3", null)
@@ -24,7 +24,7 @@ public static class TabBarExtensions
     /// </code>
     /// </example>
     public static TabBarWidget TabBar<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<TabPanelContext, IEnumerable<TabItemWidget>> builder)
         where TParent : Hex1bWidget
     {
@@ -37,11 +37,11 @@ public static class TabBarExtensions
     /// Creates a TabBar widget with simple string titles.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="titles">The tab titles.</param>
     /// <returns>A TabBarWidget.</returns>
     public static TabBarWidget TabBar<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         params string[] titles)
         where TParent : Hex1bWidget
     {

--- a/src/Hex1b/TabPanelExtensions.cs
+++ b/src/Hex1b/TabPanelExtensions.cs
@@ -11,12 +11,12 @@ public static class TabPanelExtensions
     /// Creates a TabPanel widget using a builder pattern.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="builder">A function that builds the tabs using a TabPanelContext.</param>
     /// <returns>A TabPanelWidget.</returns>
     /// <example>
     /// <code>
-    /// ctx.TabPanel(tp => [
+    /// context.TabPanel(tp => [
     ///     tp.Tab("Overview", t => [
     ///         t.Text("Overview content")
     ///     ]),
@@ -27,7 +27,7 @@ public static class TabPanelExtensions
     /// </code>
     /// </example>
     public static TabPanelWidget TabPanel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<TabPanelContext, IEnumerable<TabItemWidget>> builder)
         where TParent : Hex1bWidget
     {
@@ -40,11 +40,11 @@ public static class TabPanelExtensions
     /// Creates a TabPanel widget with pre-built tabs.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="tabs">The tabs to display.</param>
     /// <returns>A TabPanelWidget.</returns>
     public static TabPanelWidget TabPanel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         IEnumerable<TabItemWidget> tabs)
         where TParent : Hex1bWidget
     {

--- a/src/Hex1b/TableExtensions.cs
+++ b/src/Hex1b/TableExtensions.cs
@@ -12,10 +12,10 @@ public static class TableExtensions
     /// Creates a new table widget with the specified data.
     /// </summary>
     /// <typeparam name="TRow">The type of data for each row.</typeparam>
-    /// <param name="ctx">The root context.</param>
+    /// <param name="context">The root context.</param>
     /// <param name="data">The data source for table rows. Pass null to show loading state.</param>
     /// <returns>A new TableWidget instance.</returns>
-    public static TableWidget<TRow> Table<TRow>(this RootContext ctx, IReadOnlyList<TRow>? data)
+    public static TableWidget<TRow> Table<TRow>(this RootContext context, IReadOnlyList<TRow>? data)
         => new() { Data = data };
 
     /// <summary>
@@ -23,11 +23,11 @@ public static class TableExtensions
     /// </summary>
     /// <typeparam name="TRow">The type of data for each row.</typeparam>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="data">The data source for table rows. Pass null to show loading state.</param>
     /// <returns>A new TableWidget instance.</returns>
     public static TableWidget<TRow> Table<TRow, TParent>(
-        this WidgetContext<TParent> ctx, 
+        this WidgetContext<TParent> context, 
         IReadOnlyList<TRow>? data)
         where TParent : Hex1bWidget
         => new() { Data = data };
@@ -36,10 +36,10 @@ public static class TableExtensions
     /// Creates a new table widget with an async data source for virtualized tables.
     /// </summary>
     /// <typeparam name="TRow">The type of data for each row.</typeparam>
-    /// <param name="ctx">The root context.</param>
+    /// <param name="context">The root context.</param>
     /// <param name="dataSource">The async data source for virtualized data loading.</param>
     /// <returns>A new TableWidget instance.</returns>
-    public static TableWidget<TRow> Table<TRow>(this RootContext ctx, ITableDataSource<TRow> dataSource)
+    public static TableWidget<TRow> Table<TRow>(this RootContext context, ITableDataSource<TRow> dataSource)
         => new() { DataSource = dataSource };
     
     /// <summary>
@@ -47,11 +47,11 @@ public static class TableExtensions
     /// </summary>
     /// <typeparam name="TRow">The type of data for each row.</typeparam>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="dataSource">The async data source for virtualized data loading.</param>
     /// <returns>A new TableWidget instance.</returns>
     public static TableWidget<TRow> Table<TRow, TParent>(
-        this WidgetContext<TParent> ctx, 
+        this WidgetContext<TParent> context, 
         ITableDataSource<TRow> dataSource)
         where TParent : Hex1bWidget
         => new() { DataSource = dataSource };

--- a/src/Hex1b/TerminalExtensions.cs
+++ b/src/Hex1b/TerminalExtensions.cs
@@ -12,7 +12,7 @@ public static class TerminalExtensions
     /// Creates a TerminalWidget that displays the content of the specified terminal handle.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="handle">The terminal handle to display.</param>
     /// <returns>A new TerminalWidget bound to the handle.</returns>
     /// <example>
@@ -24,11 +24,11 @@ public static class TerminalExtensions
     /// 
     /// _ = terminal.RunAsync(appCt);
     /// 
-    /// ctx.Terminal(bashHandle);
+    /// context.Terminal(bashHandle);
     /// </code>
     /// </example>
     public static TerminalWidget Terminal<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         TerminalWidgetHandle handle)
         where TParent : Hex1bWidget
         => new(handle);
@@ -54,8 +54,8 @@ public static class TerminalExtensions
     /// </remarks>
     /// <example>
     /// <code>
-    /// ctx.Terminal(bashHandle)
-    ///    .WhenNotRunning(args => ctx.VStack(v => [
+    /// context.Terminal(bashHandle)
+    ///    .WhenNotRunning(args => context.VStack(v => [
     ///        v.Text($"Terminal exited with code {args.ExitCode}"),
     ///        v.Button("Restart").OnClick(_ => RestartTerminal())
     ///    ]));
@@ -105,8 +105,8 @@ public static class TerminalExtensions
     /// // Frame the terminal with a panel colour, terminal itself stays opaque black.
     /// var content = new BackgroundPanelWidget(
     ///     panelColor,
-    ///     ctx.Align(Alignment.Center,
-    ///         ctx.Terminal(handle).Background(Hex1bColor.FromRgb(0x0d, 0x11, 0x17))
+    ///     context.Align(Alignment.Center,
+    ///         context.Terminal(handle).Background(Hex1bColor.FromRgb(0x0d, 0x11, 0x17))
     ///             .FixedWidth(80).FixedHeight(24)).Fill());
     /// </code>
     /// </example>
@@ -126,13 +126,13 @@ public static class TerminalExtensions
     /// <example>
     /// <description>Enable copy mode with default vi-style bindings:</description>
     /// <code>
-    /// ctx.Terminal(handle).CopyModeBindings().Fill()
+    /// context.Terminal(handle).CopyModeBindings().Fill()
     /// </code>
     /// </example>
     /// <example>
     /// <description>Customize the entry key:</description>
     /// <code>
-    /// ctx.Terminal(handle).CopyModeBindings(options =>
+    /// context.Terminal(handle).CopyModeBindings(options =>
     /// {
     ///     options.EnterKeys = [Hex1bKey.F5];
     /// }).Fill()

--- a/src/Hex1b/TextBoxExtensions.cs
+++ b/src/Hex1b/TextBoxExtensions.cs
@@ -12,7 +12,7 @@ public static class TextBoxExtensions
     /// Creates a TextBox with default empty text.
     /// </summary>
     public static TextBoxWidget TextBox<TParent>(
-        this WidgetContext<TParent> ctx)
+        this WidgetContext<TParent> context)
         where TParent : Hex1bWidget
         => new();
 
@@ -20,7 +20,7 @@ public static class TextBoxExtensions
     /// Creates a TextBox with the specified text.
     /// </summary>
     public static TextBoxWidget TextBox<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         string text)
         where TParent : Hex1bWidget
         => new(text);

--- a/src/Hex1b/TextExtensions.cs
+++ b/src/Hex1b/TextExtensions.cs
@@ -16,7 +16,7 @@ using Hex1b.Widgets;
 /// <example>
 /// <para>Using Text within a VStack:</para>
 /// <code>
-/// ctx.VStack(v =&gt; [
+/// context.VStack(v =&gt; [
 ///     v.Text("Title"),
 ///     v.Text("Long description that wraps").Wrap(),
 ///     v.Text("Status: OK").FillWidth()
@@ -31,16 +31,16 @@ public static class TextExtensions
     /// Creates a <see cref="TextBlockWidget"/> with the specified text content.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type in the current context.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="text">The text content to display.</param>
     /// <returns>A new <see cref="TextBlockWidget"/> with default overflow behavior (Truncate).</returns>
     /// <example>
     /// <code>
-    /// ctx.Text("Hello, World!")
+    /// context.Text("Hello, World!")
     /// </code>
     /// </example>
     public static TextBlockWidget Text<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         string text)
         where TParent : Hex1bWidget
         => new(text);

--- a/src/Hex1b/ThemePanelExtensions.cs
+++ b/src/Hex1b/ThemePanelExtensions.cs
@@ -13,7 +13,7 @@ public static class ThemePanelExtensions
     /// The theme mutator function receives the current theme and returns the theme to use.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="themeMutator">
     /// A function that receives a clone of the current theme and returns the theme to use.
     /// The theme is already cloned, so you can safely call Set() directly.
@@ -22,14 +22,14 @@ public static class ThemePanelExtensions
     /// <returns>A ThemePanelWidget.</returns>
     /// <example>
     /// <code>
-    /// ctx.ThemePanel(
+    /// context.ThemePanel(
     ///     theme => theme.Set(ButtonTheme.BackgroundColor, Hex1bColor.Blue),
-    ///     ctx.Button("Blue Button")
+    ///     context.Button("Blue Button")
     /// )
     /// </code>
     /// </example>
     public static ThemePanelWidget ThemePanel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<Hex1bTheme, Hex1bTheme> themeMutator,
         Hex1bWidget child)
         where TParent : Hex1bWidget
@@ -39,7 +39,7 @@ public static class ThemePanelExtensions
     /// Creates a ThemePanel with a VStack child that applies theme customizations.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="themeMutator">
     /// A function that receives a clone of the current theme and returns the theme to use.
     /// The theme is already cloned, so you can safely call Set() directly.
@@ -48,7 +48,7 @@ public static class ThemePanelExtensions
     /// <returns>A ThemePanelWidget containing a VStack.</returns>
     /// <example>
     /// <code>
-    /// ctx.ThemePanel(
+    /// context.ThemePanel(
     ///     theme => theme
     ///         .Set(TextTheme.ForegroundColor, Hex1bColor.Green)
     ///         .Set(ButtonTheme.ForegroundColor, Hex1bColor.Yellow),
@@ -60,7 +60,7 @@ public static class ThemePanelExtensions
     /// </code>
     /// </example>
     public static ThemePanelWidget ThemePanel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<Hex1bTheme, Hex1bTheme> themeMutator,
         Func<WidgetContext<VStackWidget>, Hex1bWidget[]> builder)
         where TParent : Hex1bWidget

--- a/src/Hex1b/TilePanelExtensions.cs
+++ b/src/Hex1b/TilePanelExtensions.cs
@@ -13,7 +13,7 @@ public static class TilePanelExtensions
     /// Creates a TilePanel with the specified data source at the default camera position.
     /// </summary>
     public static TilePanelWidget TilePanel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         ITileDataSource dataSource)
         where TParent : Hex1bWidget
         => new() { DataSource = dataSource, HeightHint = SizeHint.Fill };
@@ -22,7 +22,7 @@ public static class TilePanelExtensions
     /// Creates a TilePanel with the specified data source and camera position.
     /// </summary>
     public static TilePanelWidget TilePanel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         ITileDataSource dataSource,
         double cameraX,
         double cameraY,

--- a/src/Hex1b/TimeSeriesChartExtensions.cs
+++ b/src/Hex1b/TimeSeriesChartExtensions.cs
@@ -12,25 +12,25 @@ public static class TimeSeriesChartExtensions
     /// Creates a time series chart bound to the specified data.
     /// </summary>
     /// <typeparam name="T">The data item type.</typeparam>
-    /// <param name="ctx">The root context.</param>
+    /// <param name="context">The root context.</param>
     /// <param name="data">The data source for the chart.</param>
-    public static TimeSeriesChartWidget<T> TimeSeriesChart<T>(this RootContext ctx, IReadOnlyList<T> data)
+    public static TimeSeriesChartWidget<T> TimeSeriesChart<T>(this RootContext context, IReadOnlyList<T> data)
         => new() { Data = data };
 
     /// <summary>
     /// Creates a time series chart with <see cref="ChartItem"/> data (selectors pre-wired).
     /// </summary>
-    /// <param name="ctx">The root context.</param>
+    /// <param name="context">The root context.</param>
     /// <param name="data">The chart items.</param>
-    public static TimeSeriesChartWidget<ChartItem> TimeSeriesChart(this RootContext ctx, IReadOnlyList<ChartItem> data)
+    public static TimeSeriesChartWidget<ChartItem> TimeSeriesChart(this RootContext context, IReadOnlyList<ChartItem> data)
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 
     /// <summary>
     /// Creates a time series chart with <see cref="ChartItem"/> data (params overload).
     /// </summary>
-    /// <param name="ctx">The root context.</param>
+    /// <param name="context">The root context.</param>
     /// <param name="data">The chart items.</param>
-    public static TimeSeriesChartWidget<ChartItem> TimeSeriesChart(this RootContext ctx, params ChartItem[] data)
+    public static TimeSeriesChartWidget<ChartItem> TimeSeriesChart(this RootContext context, params ChartItem[] data)
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 
     /// <summary>
@@ -38,10 +38,10 @@ public static class TimeSeriesChartExtensions
     /// </summary>
     /// <typeparam name="T">The data item type.</typeparam>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="data">The data source for the chart.</param>
     public static TimeSeriesChartWidget<T> TimeSeriesChart<T, TParent>(
-        this WidgetContext<TParent> ctx, IReadOnlyList<T> data)
+        this WidgetContext<TParent> context, IReadOnlyList<T> data)
         where TParent : Hex1bWidget
         => new() { Data = data };
 
@@ -49,10 +49,10 @@ public static class TimeSeriesChartExtensions
     /// Creates a time series chart with <see cref="ChartItem"/> data (selectors pre-wired).
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="data">The chart items.</param>
     public static TimeSeriesChartWidget<ChartItem> TimeSeriesChart<TParent>(
-        this WidgetContext<TParent> ctx, IReadOnlyList<ChartItem> data)
+        this WidgetContext<TParent> context, IReadOnlyList<ChartItem> data)
         where TParent : Hex1bWidget
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 
@@ -60,10 +60,10 @@ public static class TimeSeriesChartExtensions
     /// Creates a time series chart with <see cref="ChartItem"/> data (params overload).
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="data">The chart items.</param>
     public static TimeSeriesChartWidget<ChartItem> TimeSeriesChart<TParent>(
-        this WidgetContext<TParent> ctx, params ChartItem[] data)
+        this WidgetContext<TParent> context, params ChartItem[] data)
         where TParent : Hex1bWidget
         => new() { Data = data, LabelSelector = i => i.Label, ValueSelector = i => i.Value };
 }

--- a/src/Hex1b/ToggleSwitchExtensions.cs
+++ b/src/Hex1b/ToggleSwitchExtensions.cs
@@ -11,12 +11,12 @@ public static class ToggleSwitchExtensions
     /// <summary>
     /// Creates a ToggleSwitchWidget with the provided options.
     /// </summary>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="options">The available options for the toggle switch.</param>
     /// <param name="selectedIndex">The initial selected option index (default is 0).</param>
     /// <returns>A new ToggleSwitchWidget.</returns>
     public static ToggleSwitchWidget ToggleSwitch<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         IReadOnlyList<string> options,
         int selectedIndex = 0)
         where TParent : Hex1bWidget

--- a/src/Hex1b/TreeExtensions.cs
+++ b/src/Hex1b/TreeExtensions.cs
@@ -18,7 +18,7 @@ public static class TreeExtensions
     /// </remarks>
     /// <example>
     /// <code>
-    /// ctx.Tree(t => [
+    /// context.Tree(t => [
     ///     t.Item("Root", root => [
     ///         root.Item("Child 1"),
     ///         root.Item("Child 2")
@@ -27,7 +27,7 @@ public static class TreeExtensions
     /// </code>
     /// </example>
     public static TreeWidget Tree<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<TreeContext, IEnumerable<TreeItemWidget>> builder)
         where TParent : Hex1bWidget
     {
@@ -40,7 +40,7 @@ public static class TreeExtensions
     /// Creates a Tree with the specified root items.
     /// </summary>
     public static TreeWidget Tree<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         params TreeItemWidget[] items)
         where TParent : Hex1bWidget
         => new(items);
@@ -49,7 +49,7 @@ public static class TreeExtensions
     /// Creates a Tree with the specified root items.
     /// </summary>
     public static TreeWidget Tree<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         IReadOnlyList<TreeItemWidget> items)
         where TParent : Hex1bWidget
         => new(items);
@@ -59,14 +59,14 @@ public static class TreeExtensions
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
     /// <typeparam name="T">The data item type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="items">The root data items.</param>
     /// <param name="labelSelector">Function to get the label from a data item.</param>
     /// <param name="childrenSelector">Function to get children from a data item.</param>
     /// <param name="iconSelector">Optional function to get the icon from a data item.</param>
     /// <param name="isExpandedSelector">Optional function to determine if an item is expanded.</param>
     public static TreeWidget Tree<TParent, T>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         IEnumerable<T> items,
         Func<T, string> labelSelector,
         Func<T, IEnumerable<T>> childrenSelector,
@@ -83,14 +83,14 @@ public static class TreeExtensions
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
     /// <typeparam name="T">The data item type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="items">The root data items.</param>
     /// <param name="labelSelector">Function to get the label from a data item.</param>
     /// <param name="hasChildrenSelector">Function to determine if an item has children to load.</param>
     /// <param name="childrenLoader">Async function to load children when an item is expanded.</param>
     /// <param name="iconSelector">Optional function to get the icon from a data item.</param>
     public static TreeWidget Tree<TParent, T>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         IEnumerable<T> items,
         Func<T, string> labelSelector,
         Func<T, bool> hasChildrenSelector,

--- a/src/Hex1b/VStackExtensions.cs
+++ b/src/Hex1b/VStackExtensions.cs
@@ -14,7 +14,7 @@ public static class VStackExtensions
     /// Use collection expression syntax: v => [v.Text("a"), v.Button("b", e => {})]
     /// </summary>
     public static VStackWidget VStack<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<WidgetContext<VStackWidget>, Hex1bWidget[]> builder)
         where TParent : Hex1bWidget
     {

--- a/src/Hex1b/WindowPanelExtensions.cs
+++ b/src/Hex1b/WindowPanelExtensions.cs
@@ -11,17 +11,17 @@ public static class WindowPanelExtensions
     /// Creates a WindowPanel that can host floating windows.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <returns>A new WindowPanelWidget.</returns>
     /// <example>
     /// <code>
-    /// ctx.WindowPanel()
+    /// context.WindowPanel()
     ///    .Background(b => b.Surface(...))
     ///    .Unbounded()
     ///    .Fill()
     /// </code>
     /// </example>
-    public static WindowPanelWidget WindowPanel<TParent>(this WidgetContext<TParent> ctx)
+    public static WindowPanelWidget WindowPanel<TParent>(this WidgetContext<TParent> context)
         where TParent : Hex1bWidget
     {
         return new WindowPanelWidget();
@@ -32,21 +32,21 @@ public static class WindowPanelExtensions
     /// Use named panels when you have multiple WindowPanels in your app.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
+    /// <param name="context">The widget context.</param>
     /// <param name="name">The unique name for this panel.</param>
     /// <returns>A new WindowPanelWidget.</returns>
     /// <example>
     /// <code>
     /// // Create named panels
-    /// ctx.WindowPanel("editor");
-    /// ctx.WindowPanel("preview");
+    /// context.WindowPanel("editor");
+    /// context.WindowPanel("preview");
     /// 
     /// // Access specific panel from event handler
     /// e.Windows["editor"].Open(...);
     /// </code>
     /// </example>
     public static WindowPanelWidget WindowPanel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         string name)
         where TParent : Hex1bWidget
     {
@@ -67,20 +67,20 @@ public static class WindowPanelExtensions
     /// The background does not receive focus or input.
     /// </summary>
     /// <param name="widget">The WindowPanelWidget to configure.</param>
-    /// <param name="backgroundBuilder">A function that builds the background widget using a context.</param>
+    /// <param name="builder">A function that builds the background widget using a context.</param>
     /// <returns>A new WindowPanelWidget with the background configured.</returns>
     /// <example>
     /// <code>
-    /// ctx.WindowPanel()
+    /// context.WindowPanel()
     ///    .Background(b => b.Surface(s => [s.Layer(GradientBackground)]))
     /// </code>
     /// </example>
     public static WindowPanelWidget Background(
         this WindowPanelWidget widget, 
-        Func<WidgetContext<Hex1bWidget>, Hex1bWidget> backgroundBuilder)
+        Func<WidgetContext<Hex1bWidget>, Hex1bWidget> builder)
     {
         var bgContext = new WidgetContext<Hex1bWidget>();
-        var background = backgroundBuilder(bgContext);
+        var background = builder(bgContext);
         return widget with { Background = background };
     }
 }

--- a/src/Hex1b/WrapPanelExtensions.cs
+++ b/src/Hex1b/WrapPanelExtensions.cs
@@ -13,14 +13,14 @@ public static class WrapPanelExtensions
     /// </summary>
     /// <example>
     /// <code>
-    /// ctx.WrapPanel(w => templates.Select(t => w.Border(b => [
+    /// context.WrapPanel(w => templates.Select(t => w.Border(b => [
     ///     b.Text(t.Name),
     ///     b.Text(t.Language),
     /// ]).FixedWidth(30)).ToArray())
     /// </code>
     /// </example>
     public static WrapPanelWidget WrapPanel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<WidgetContext<WrapPanelWidget>, Hex1bWidget[]> builder)
         where TParent : Hex1bWidget
     {
@@ -34,7 +34,7 @@ public static class WrapPanelExtensions
     /// and wrap to the next column when the available height is exceeded.
     /// </summary>
     public static WrapPanelWidget VWrapPanel<TParent>(
-        this WidgetContext<TParent> ctx,
+        this WidgetContext<TParent> context,
         Func<WidgetContext<WrapPanelWidget>, Hex1bWidget[]> builder)
         where TParent : Hex1bWidget
     {

--- a/src/Hex1b/ZStackExtensions.cs
+++ b/src/Hex1b/ZStackExtensions.cs
@@ -13,12 +13,12 @@ public static class ZStackExtensions
     /// All children share the same bounds (the ZStack's bounds).
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="ctx">The widget context.</param>
-    /// <param name="children">A function that returns the child widgets. First = bottom, last = top.</param>
+    /// <param name="context">The widget context.</param>
+    /// <param name="builder">A function that returns the child widgets. First = bottom, last = top.</param>
     /// <returns>A new ZStackWidget.</returns>
     /// <example>
     /// <code>
-    /// ctx.ZStack(z => [
+    /// context.ZStack(z => [
     ///     // Base layer (bottom)
     ///     z.VStack(v => [
     ///         v.Text("Main content here")
@@ -32,12 +32,12 @@ public static class ZStackExtensions
     /// </code>
     /// </example>
     public static ZStackWidget ZStack<TParent>(
-        this WidgetContext<TParent> ctx,
-        Func<WidgetContext<ZStackWidget>, IEnumerable<Hex1bWidget?>> children)
+        this WidgetContext<TParent> context,
+        Func<WidgetContext<ZStackWidget>, IEnumerable<Hex1bWidget?>> builder)
         where TParent : Hex1bWidget
     {
         var childContext = new WidgetContext<ZStackWidget>();
-        var childWidgets = children(childContext)
+        var childWidgets = builder(childContext)
             .Where(c => c != null)
             .Cast<Hex1bWidget>()
             .ToList();

--- a/src/content/.vitepress/config.ts
+++ b/src/content/.vitepress/config.ts
@@ -44,6 +44,7 @@ export default defineConfig({
             { text: 'Your First App', link: '/guide/getting-started' },
             { text: 'Your First Flow App', link: '/guide/building-clis' },
             { text: 'Widgets & Nodes', link: '/guide/widgets-and-nodes' },
+            { text: 'API Design Guidelines', link: '/guide/api-design' },
             { text: 'Layout System', link: '/guide/layout' },
             { text: 'Input Handling', link: '/guide/input' },
             { text: 'Theming', link: '/guide/theming' }

--- a/src/content/guide/api-design.md
+++ b/src/content/guide/api-design.md
@@ -1,0 +1,173 @@
+# API Design Guidelines
+
+These guidelines describe how the public API of Hex1b is shaped — and why the shape is the way it is. They apply both to the library itself and to any third-party packages that ship widgets or extensions on top of it.
+
+The conventions on this page are enforced by Roslyn analyzers (HEX1B0001–HEX1B0009) so that the library and its ecosystem stay consistent over time. Each rule below names the analyzer that polices it.
+
+## Two builders, two patterns
+
+Hex1b has **two distinct fluent surfaces**, and they look different on purpose:
+
+| Surface | Receiver type | Method-name shape | Example |
+|---|---|---|---|
+| **Terminal builder** | `Hex1bTerminalBuilder` | `With*` | `terminal.WithMouse().WithHex1bApp(...)` |
+| **Widget composition** | `WidgetContext<T>` and widget instances | bare verb-noun (no `With*`) | `context.Border(b => [...]).Title("Hi")` |
+
+Both are fluent, but they do different jobs:
+
+- **`Hex1bTerminalBuilder`** wires together the host process — terminal plumbing, presentation/workload adapters, recording, mouse, MCP diagnostics, etc. It is configured **once at startup**, returns the same builder for chaining, and uses `With*` because each call mutates a builder configuration object.
+- **Widget composition** describes the **UI tree on every render pass**. Widgets are immutable `record`s, so a "fluent" call returns a new widget value (or constructs a new one in an extension method) — there is nothing to "be `With`'d into". The `With*` prefix is reserved for the terminal builder so that, when you read a chain of calls, you can tell at a glance which surface you're on.
+
+This is why `HEX1B0001` will reject any `With*` method declared on a widget extension or instance. If you find yourself wanting `WithTitle(...)` on a widget, use `Title(...)` instead.
+
+## Anatomy of a widget
+
+A widget has two halves:
+
+```csharp
+// Configuration — immutable, declarative.
+public record ButtonWidget(string Label) : Hex1bWidget
+{
+    internal Func<ButtonClickedEventArgs, Task>? ClickHandler { get; init; }
+
+    // Event handlers use On*.
+    public ButtonWidget OnClick(Action<ButtonClickedEventArgs> handler)
+        => this with { ClickHandler = args => { handler(args); return Task.CompletedTask; } };
+
+    public ButtonWidget OnClick(Func<ButtonClickedEventArgs, Task> handler)
+        => this with { ClickHandler = handler };
+}
+
+// Behavior — mutable, stateful, owned by the renderer.
+public class ButtonNode : Hex1bNode { /* … */ }
+```
+
+Naming rules:
+
+| Rule | Convention | Analyzer |
+|---|---|---|
+| Widget type names | end in `Widget` | HEX1B0002 |
+| Node type names | end in `Node` | HEX1B0003 |
+| Widget kind | declared as `record` | HEX1B0004 |
+| Node kind | declared as `class` | HEX1B0005 |
+| Event handlers on a widget | `On<Verb>` (`OnClick`, `OnSelectionChanged`) | — |
+| Configuration on a widget | bare verb-noun (`Title`, `MaxFloating`, `Disabled`) | — |
+| Never on a widget | `With*` (reserved for `Hex1bTerminalBuilder`) | HEX1B0001 |
+
+## The `WidgetContext<T>` family
+
+Most widgets are produced by an extension method that takes a `WidgetContext<TParent>` and returns the widget. The context gives child widgets a typed handle to their lexical parent, which the layout system uses to make sensible defaults (e.g. an `HStack` child knows it lives inside a horizontal container).
+
+```csharp
+public static BorderWidget Border<TParent>(
+    this WidgetContext<TParent> context,
+    Func<WidgetContext<BorderWidget>, Hex1bWidget[]> builder,
+    string? title = null)
+    where TParent : Hex1bWidget
+    => /* … */;
+```
+
+Two parameter naming rules apply:
+
+- **`HEX1B0006`** — the `WidgetContext<T>` receiver is always named **`context`**.
+- **`HEX1B0008`** — a single widget-builder callback is always named **`builder`**.
+
+So every call site reads the same way:
+
+```csharp
+context.Border(b => [
+    b.Text("Hello"),
+    b.Button("Click me").OnClick(_ => DoStuff())
+])
+```
+
+Inside the lambda, the parameter is the **child** context (here named `b` for brevity). Lambda variable names are unconstrained — the analyzer only governs the names declared in the extension method signature, so callers can use whatever short alias they like.
+
+## Widget instance extensions
+
+Some operations apply to an existing widget rather than building a new one — for example, decorating an editor with a language server, or adding input bindings to anything. These are extensions on a widget instance, not on a context:
+
+```csharp
+public static EditorWidget LanguageServer(
+    this EditorWidget widget,
+    Action<LanguageServerConfiguration> configure)
+    => /* … */;
+```
+
+- **`HEX1B0007`** — when the receiver is a `Hex1bWidget`-derived type (or a generic constrained to `Hex1bWidget`), it is named **`widget`**, never `editor`, `target`, `self`, or a role-name.
+
+This keeps every widget-on-widget operation reading the same way regardless of which widget it acts on:
+
+```csharp
+context.Editor(state)
+       .LanguageServer(workspace, "file:///app/Program.cs")
+       .Decorations(provider);
+```
+
+## One builder per method
+
+Most widget-builder methods take exactly one builder callback. A handful of widgets — splitters, for example — genuinely need two, one per pane:
+
+```csharp
+[SuppressMessage(
+    "Hex1b.ApiDesign",
+    "HEX1B0009",
+    Justification = "A splitter inherently has two independent panes; each side takes its own builder callback.")]
+public static SplitterWidget HSplitter<TParent>(
+    this WidgetContext<TParent> context,
+    Func<WidgetContext<VStackWidget>, Hex1bWidget[]> leftBuilder,
+    Func<WidgetContext<VStackWidget>, Hex1bWidget[]> rightBuilder,
+    int leftWidth = 30)
+    where TParent : Hex1bWidget
+    => /* … */;
+```
+
+- **`HEX1B0009`** — declaring two or more widget-builder callbacks on the same method is a warning, suppressible with a `Justification`. The suppression is the documentation: it tells the next reader that the multi-builder shape is deliberate, not an oversight.
+
+When you have a choice, prefer a single `builder` that returns multiple children (e.g. `Func<…, Hex1bWidget[]>`) over multiple positional builders. Splitters are the exception because the two panes have different roles, not just different positions.
+
+### `On*` methods are not builders
+
+Both `HEX1B0008` and `HEX1B0009` ignore methods whose name matches `On<Verb>`. These are event-handler decorators — they happen to take a callback that returns a widget, but they fire in response to an event rather than participating in the widget tree's static composition:
+
+```csharp
+// Allowed: OnBlock takes a Func that returns a widget, but it's an event handler.
+public MarkdownWidget OnBlock<TBlock>(
+    Func<MarkdownBlockContext, TBlock, Hex1bWidget> handler) => /* … */;
+```
+
+If you find yourself adding a non-`On*` method that takes more than one widget-producing callback and the suppression message would feel awkward to write, that's a hint to rethink the shape — perhaps the widget itself should expose a child collection, or the method should be split.
+
+## Action callbacks vs. widget builders
+
+Some widgets take an `Action<TWidget>` / `Action<TBuilder>` style configuration callback that mutates a builder rather than returning a widget tree. These are not "widget builders" by the analyzer's definition — they don't return `Hex1bWidget` — and the convention for them is `configure`:
+
+```csharp
+public static FormWidget Form<TParent>(
+    this WidgetContext<TParent> context,
+    Action<FormBuilder> configure)
+    => /* … */;
+```
+
+Use `builder` only when the callback **returns a widget shape** (a widget, an array of widget, or `IEnumerable<Hex1bWidget>`). Use `configure` when the callback mutates a builder object in place.
+
+## Quick reference
+
+| Scenario | Receiver name | Callback name | Method-name prefix |
+|---|---|---|---|
+| Extension on `Hex1bTerminalBuilder` | `builder` (the terminal builder itself) | depends | `With*` (required) |
+| Extension on `WidgetContext<T>` returning a widget | `context` | `builder` (if exactly one) | bare verb-noun |
+| Extension on a widget instance | `widget` | `builder` (if any) | bare verb-noun |
+| Event handler on a widget | n/a | `handler` | `On<Verb>` |
+| Builder-mutating configuration callback | n/a | `configure` | bare verb-noun |
+
+## Why the rules exist
+
+Every rule on this page exists to remove a small daily friction:
+
+- You can read any widget call site without checking the type of the receiver, because `context` and `widget` always mean the same thing.
+- You can spot the boundary between "wiring up the host" and "describing the UI" at a glance, because `With*` only appears on the terminal builder.
+- You don't have to remember whether this widget calls its callback `childBuilder`, `contentBuilder`, or `fallbackBuilder` — it's always `builder`.
+- When a widget genuinely needs a non-default shape (two builders, an Action callback, an `On*` handler), the deviation carries its own justification, so it doesn't read as an inconsistency.
+
+The analyzers turn these conventions into compile-time guarantees rather than style guidelines, which means the rules can evolve without leaving the codebase littered with stragglers — the build will tell you what's left to update.

--- a/src/content/guide/api-design.md
+++ b/src/content/guide/api-design.md
@@ -1,8 +1,6 @@
 # API Design Guidelines
 
-These guidelines describe how the public API of Hex1b is shaped — and why the shape is the way it is. They apply both to the library itself and to any third-party packages that ship widgets or extensions on top of it.
-
-The conventions on this page are enforced by Roslyn analyzers (HEX1B0001–HEX1B0009) so that the library and its ecosystem stay consistent over time. Each rule below names the analyzer that polices it.
+These guidelines describe how the public API of Hex1b is shaped — and why the shape is the way it is. They apply to the library itself and inform any widgets or extensions you build on top of it.
 
 ## Two builders, two patterns
 
@@ -18,7 +16,7 @@ Both are fluent, but they do different jobs:
 - **`Hex1bTerminalBuilder`** wires together the host process — terminal plumbing, presentation/workload adapters, recording, mouse, MCP diagnostics, etc. It is configured **once at startup**, returns the same builder for chaining, and uses `With*` because each call mutates a builder configuration object.
 - **Widget composition** describes the **UI tree on every render pass**. Widgets are immutable `record`s, so a "fluent" call returns a new widget value (or constructs a new one in an extension method) — there is nothing to "be `With`'d into". The `With*` prefix is reserved for the terminal builder so that, when you read a chain of calls, you can tell at a glance which surface you're on.
 
-This is why `HEX1B0001` will reject any `With*` method declared on a widget extension or instance. If you find yourself wanting `WithTitle(...)` on a widget, use `Title(...)` instead.
+If you find yourself wanting `WithTitle(...)` on a widget, use `Title(...)` instead.
 
 ## Anatomy of a widget
 
@@ -44,15 +42,15 @@ public class ButtonNode : Hex1bNode { /* … */ }
 
 Naming rules:
 
-| Rule | Convention | Analyzer |
-|---|---|---|
-| Widget type names | end in `Widget` | HEX1B0002 |
-| Node type names | end in `Node` | HEX1B0003 |
-| Widget kind | declared as `record` | HEX1B0004 |
-| Node kind | declared as `class` | HEX1B0005 |
-| Event handlers on a widget | `On<Verb>` (`OnClick`, `OnSelectionChanged`) | — |
-| Configuration on a widget | bare verb-noun (`Title`, `MaxFloating`, `Disabled`) | — |
-| Never on a widget | `With*` (reserved for `Hex1bTerminalBuilder`) | HEX1B0001 |
+| Rule | Convention |
+|---|---|
+| Widget type names | end in `Widget` |
+| Node type names | end in `Node` |
+| Widget kind | declared as `record` |
+| Node kind | declared as `class` |
+| Event handlers on a widget | `On<Verb>` (`OnClick`, `OnSelectionChanged`) |
+| Configuration on a widget | bare verb-noun (`Title`, `MaxFloating`, `Disabled`) |
+| Never on a widget | `With*` (reserved for `Hex1bTerminalBuilder`) |
 
 ## The `WidgetContext<T>` family
 
@@ -67,10 +65,10 @@ public static BorderWidget Border<TParent>(
     => /* … */;
 ```
 
-Two parameter naming rules apply:
+Two parameter naming conventions apply:
 
-- **`HEX1B0006`** — the `WidgetContext<T>` receiver is always named **`context`**.
-- **`HEX1B0008`** — a single widget-builder callback is always named **`builder`**.
+- The `WidgetContext<T>` receiver is always named **`context`**.
+- A single widget-builder callback is always named **`builder`**.
 
 So every call site reads the same way:
 
@@ -81,7 +79,7 @@ context.Border(b => [
 ])
 ```
 
-Inside the lambda, the parameter is the **child** context (here named `b` for brevity). Lambda variable names are unconstrained — the analyzer only governs the names declared in the extension method signature, so callers can use whatever short alias they like.
+Inside the lambda, the parameter is the **child** context (here named `b` for brevity). Lambda variable names are unconstrained — the convention only governs the names declared in the extension method signature, so callers can use whatever short alias they like.
 
 ## Widget instance extensions
 
@@ -94,9 +92,7 @@ public static EditorWidget LanguageServer(
     => /* … */;
 ```
 
-- **`HEX1B0007`** — when the receiver is a `Hex1bWidget`-derived type (or a generic constrained to `Hex1bWidget`), it is named **`widget`**, never `editor`, `target`, `self`, or a role-name.
-
-This keeps every widget-on-widget operation reading the same way regardless of which widget it acts on:
+When the receiver is a `Hex1bWidget`-derived type (or a generic constrained to `Hex1bWidget`), it is named **`widget`**, never `editor`, `target`, `self`, or a role-name. This keeps every widget-on-widget operation reading the same way regardless of which widget it acts on:
 
 ```csharp
 context.Editor(state)
@@ -109,10 +105,6 @@ context.Editor(state)
 Most widget-builder methods take exactly one builder callback. A handful of widgets — splitters, for example — genuinely need two, one per pane:
 
 ```csharp
-[SuppressMessage(
-    "Hex1b.ApiDesign",
-    "HEX1B0009",
-    Justification = "A splitter inherently has two independent panes; each side takes its own builder callback.")]
 public static SplitterWidget HSplitter<TParent>(
     this WidgetContext<TParent> context,
     Func<WidgetContext<VStackWidget>, Hex1bWidget[]> leftBuilder,
@@ -122,25 +114,23 @@ public static SplitterWidget HSplitter<TParent>(
     => /* … */;
 ```
 
-- **`HEX1B0009`** — declaring two or more widget-builder callbacks on the same method is a warning, suppressible with a `Justification`. The suppression is the documentation: it tells the next reader that the multi-builder shape is deliberate, not an oversight.
-
-When you have a choice, prefer a single `builder` that returns multiple children (e.g. `Func<…, Hex1bWidget[]>`) over multiple positional builders. Splitters are the exception because the two panes have different roles, not just different positions.
+When you have a choice, prefer a single `builder` that returns multiple children (e.g. `Func<…, Hex1bWidget[]>`) over multiple positional builders. Splitters are the exception because the two panes have different roles, not just different positions — so they get role-named builders (`leftBuilder` / `rightBuilder`, `topBuilder` / `bottomBuilder`).
 
 ### `On*` methods are not builders
 
-Both `HEX1B0008` and `HEX1B0009` ignore methods whose name matches `On<Verb>`. These are event-handler decorators — they happen to take a callback that returns a widget, but they fire in response to an event rather than participating in the widget tree's static composition:
+Event-handler decorators sometimes take a callback that returns a widget — they fire in response to an event rather than participating in the widget tree's static composition, so they don't follow the `builder` convention:
 
 ```csharp
-// Allowed: OnBlock takes a Func that returns a widget, but it's an event handler.
+// OnBlock takes a Func that returns a widget, but it's an event handler.
 public MarkdownWidget OnBlock<TBlock>(
     Func<MarkdownBlockContext, TBlock, Hex1bWidget> handler) => /* … */;
 ```
 
-If you find yourself adding a non-`On*` method that takes more than one widget-producing callback and the suppression message would feel awkward to write, that's a hint to rethink the shape — perhaps the widget itself should expose a child collection, or the method should be split.
+If you find yourself adding a non-`On*` method that takes more than one widget-producing callback, that's a hint to rethink the shape — perhaps the widget itself should expose a child collection, or the method should be split.
 
 ## Action callbacks vs. widget builders
 
-Some widgets take an `Action<TWidget>` / `Action<TBuilder>` style configuration callback that mutates a builder rather than returning a widget tree. These are not "widget builders" by the analyzer's definition — they don't return `Hex1bWidget` — and the convention for them is `configure`:
+Some widgets take an `Action<TWidget>` / `Action<TBuilder>` style configuration callback that mutates a builder rather than returning a widget tree. These are not "widget builders" — they don't return `Hex1bWidget` — and the convention for them is `configure`:
 
 ```csharp
 public static FormWidget Form<TParent>(
@@ -168,6 +158,4 @@ Every rule on this page exists to remove a small daily friction:
 - You can read any widget call site without checking the type of the receiver, because `context` and `widget` always mean the same thing.
 - You can spot the boundary between "wiring up the host" and "describing the UI" at a glance, because `With*` only appears on the terminal builder.
 - You don't have to remember whether this widget calls its callback `childBuilder`, `contentBuilder`, or `fallbackBuilder` — it's always `builder`.
-- When a widget genuinely needs a non-default shape (two builders, an Action callback, an `On*` handler), the deviation carries its own justification, so it doesn't read as an inconsistency.
-
-The analyzers turn these conventions into compile-time guarantees rather than style guidelines, which means the rules can evolve without leaving the codebase littered with stragglers — the build will tell you what's left to update.
+- When a widget genuinely needs a non-default shape (two builders, an Action callback, an `On*` handler), the deviation is small enough to read as a deliberate exception rather than an inconsistency.

--- a/tests/Hex1b.Analyzers.Tests/WidgetBuilderCallbackNameAnalyzerTests.cs
+++ b/tests/Hex1b.Analyzers.Tests/WidgetBuilderCallbackNameAnalyzerTests.cs
@@ -1,0 +1,250 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Hex1b.Analyzers.Tests;
+
+public class WidgetBuilderCallbackNameAnalyzerTests
+{
+    private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
+        => AnalyzerTestHelpers<WidgetBuilderCallbackNameAnalyzer>.VerifyAsync(source, expected);
+
+    private static DiagnosticResult Diagnostic()
+        => AnalyzerTestHelpers<WidgetBuilderCallbackNameAnalyzer>.Diagnostic(WidgetBuilderCallbackNameAnalyzer.Rule);
+
+    [Fact]
+    public async Task SingleBuilder_AlternateName_OnWidgetContextExtension_Reports()
+    {
+        const string source = """
+            using System;
+            using Hex1b;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(Hex1bWidget Child) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget Foo<TParent>(
+                    this WidgetContext<TParent> context,
+                    Func<WidgetContext<FooWidget>, Hex1bWidget> {|#0:childBuilder|})
+                    where TParent : Hex1bWidget
+                    => new(childBuilder(new WidgetContext<FooWidget>()));
+            }
+            """;
+
+        await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("childBuilder", "Foo"));
+    }
+
+    [Fact]
+    public async Task SingleBuilder_NamedBuilder_NoDiagnostic()
+    {
+        const string source = """
+            using System;
+            using Hex1b;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(Hex1bWidget Child) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget Foo<TParent>(
+                    this WidgetContext<TParent> context,
+                    Func<WidgetContext<FooWidget>, Hex1bWidget> builder)
+                    where TParent : Hex1bWidget
+                    => new(builder(new WidgetContext<FooWidget>()));
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    [Fact]
+    public async Task SingleBuilder_ReturningArray_AlternateName_Reports()
+    {
+        const string source = """
+            using System;
+            using Hex1b;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(Hex1bWidget[] Children) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget Foo<TParent>(
+                    this WidgetContext<TParent> context,
+                    Func<WidgetContext<FooWidget>, Hex1bWidget[]> {|#0:children|})
+                    where TParent : Hex1bWidget
+                    => new(children(new WidgetContext<FooWidget>()));
+            }
+            """;
+
+        await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("children", "Foo"));
+    }
+
+    [Fact]
+    public async Task SingleBuilder_ReturningIEnumerable_NamedBuilder_NoDiagnostic()
+    {
+        const string source = """
+            using System;
+            using System.Collections.Generic;
+            using Hex1b;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(IEnumerable<Hex1bWidget> Children) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget Foo<TParent>(
+                    this WidgetContext<TParent> context,
+                    Func<WidgetContext<FooWidget>, IEnumerable<Hex1bWidget>> builder)
+                    where TParent : Hex1bWidget
+                    => new(builder(new WidgetContext<FooWidget>()));
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    [Fact]
+    public async Task SingleBuilder_OnWidgetInstanceExtension_Reports()
+    {
+        const string source = """
+            using System;
+            using Hex1b;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(Hex1bWidget? Background) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget Background(
+                    this FooWidget widget,
+                    Func<WidgetContext<Hex1bWidget>, Hex1bWidget> {|#0:backgroundBuilder|})
+                    => widget with { Background = backgroundBuilder(new WidgetContext<Hex1bWidget>()) };
+            }
+            """;
+
+        await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("backgroundBuilder", "Background"));
+    }
+
+    [Fact]
+    public async Task TwoBuilders_NoDiagnostic_FromThisRule()
+    {
+        // HEX1B0009 owns the multi-builder shape; HEX1B0008 must stay silent on it.
+        const string source = """
+            using System;
+            using Hex1b;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(Hex1bWidget Left, Hex1bWidget Right) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget Foo<TParent>(
+                    this WidgetContext<TParent> context,
+                    Func<WidgetContext<FooWidget>, Hex1bWidget> leftBuilder,
+                    Func<WidgetContext<FooWidget>, Hex1bWidget> rightBuilder)
+                    where TParent : Hex1bWidget
+                    => new(leftBuilder(new WidgetContext<FooWidget>()), rightBuilder(new WidgetContext<FooWidget>()));
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    [Fact]
+    public async Task NoBuilder_NoDiagnostic()
+    {
+        const string source = """
+            using Hex1b;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(string Text) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget Foo<TParent>(this WidgetContext<TParent> context, string text)
+                    where TParent : Hex1bWidget => new(text);
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    [Fact]
+    public async Task ActionConfigure_NotABuilder_NoDiagnostic()
+    {
+        // Action<T> configure callbacks aren't widget-builder callbacks; the analyzer must ignore them.
+        const string source = """
+            using System;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(string Text) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget Configure(this FooWidget widget, Action<int> configure) => widget;
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    [Fact]
+    public async Task OnXMethod_HandlerCallback_NoDiagnostic()
+    {
+        // 'OnFoo' methods are event-handler decorators per the Hex1b convention; their callback
+        // is a 'handler', not a widget-tree builder, even when the return type is a widget shape.
+        const string source = """
+            using System;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(string Text) : Hex1bWidget;
+            public abstract record FooBlock { }
+
+            public static class FooExtensions
+            {
+                public static FooWidget OnBlock<TBlock>(
+                    this FooWidget widget,
+                    Func<int, TBlock, Hex1bWidget> handler)
+                    where TBlock : FooBlock => widget;
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    [Fact]
+    public async Task NonWidgetExtension_NoDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            namespace MyApp;
+
+            public static class StringExtensions
+            {
+                public static string Map(this string s, Func<string, string> childBuilder) => childBuilder(s);
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+}

--- a/tests/Hex1b.Analyzers.Tests/WidgetContextReceiverNameAnalyzerTests.cs
+++ b/tests/Hex1b.Analyzers.Tests/WidgetContextReceiverNameAnalyzerTests.cs
@@ -1,0 +1,133 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Hex1b.Analyzers.Tests;
+
+public class WidgetContextReceiverNameAnalyzerTests
+{
+    private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
+        => AnalyzerTestHelpers<WidgetContextReceiverNameAnalyzer>.VerifyAsync(source, expected);
+
+    private static DiagnosticResult Diagnostic()
+        => AnalyzerTestHelpers<WidgetContextReceiverNameAnalyzer>.Diagnostic(WidgetContextReceiverNameAnalyzer.Rule);
+
+    [Fact]
+    public async Task Receiver_NamedCtx_Reports()
+    {
+        const string source = """
+            using Hex1b;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(string Text) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget Foo<TParent>(this WidgetContext<TParent> {|#0:ctx|}, string text)
+                    where TParent : Hex1bWidget => new(text);
+            }
+            """;
+
+        await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("ctx", "Foo"));
+    }
+
+    [Fact]
+    public async Task Receiver_NamedContext_NoDiagnostic()
+    {
+        const string source = """
+            using Hex1b;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(string Text) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget Foo<TParent>(this WidgetContext<TParent> context, string text)
+                    where TParent : Hex1bWidget => new(text);
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    [Fact]
+    public async Task Receiver_AlternateName_Reports()
+    {
+        const string source = """
+            using Hex1b;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(string Text) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget Foo<TParent>(this WidgetContext<TParent> {|#0:builder|}, string text)
+                    where TParent : Hex1bWidget => new(text);
+            }
+            """;
+
+        await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("builder", "Foo"));
+    }
+
+    [Fact]
+    public async Task NonExtensionMethod_NoDiagnostic()
+    {
+        const string source = """
+            using Hex1b;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(string Text) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget Foo<TParent>(WidgetContext<TParent> ctx, string text)
+                    where TParent : Hex1bWidget => new(text);
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    [Fact]
+    public async Task NonWidgetContextReceiver_NoDiagnostic()
+    {
+        const string source = """
+            namespace MyApp;
+
+            public static class StringExtensions
+            {
+                public static string AddPrefix(this string ctx, string prefix) => prefix + ctx;
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    [Fact]
+    public async Task WidgetReceiver_NoDiagnostic()
+    {
+        // Receiver is a widget instance, not WidgetContext<T> — HEX1B0007 territory.
+        const string source = """
+            using Hex1b;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(string Text) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget Title(this FooWidget ctx, string text) => ctx with { Text = text };
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+}

--- a/tests/Hex1b.Analyzers.Tests/WidgetInstanceReceiverNameAnalyzerTests.cs
+++ b/tests/Hex1b.Analyzers.Tests/WidgetInstanceReceiverNameAnalyzerTests.cs
@@ -1,0 +1,145 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Hex1b.Analyzers.Tests;
+
+public class WidgetInstanceReceiverNameAnalyzerTests
+{
+    private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
+        => AnalyzerTestHelpers<WidgetInstanceReceiverNameAnalyzer>.VerifyAsync(source, expected);
+
+    private static DiagnosticResult Diagnostic()
+        => AnalyzerTestHelpers<WidgetInstanceReceiverNameAnalyzer>.Diagnostic(WidgetInstanceReceiverNameAnalyzer.Rule);
+
+    [Fact]
+    public async Task Receiver_RoleNamed_OnConcreteWidget_Reports()
+    {
+        const string source = """
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record EditorWidget(string Text) : Hex1bWidget;
+
+            public static class EditorExtensions
+            {
+                public static EditorWidget LanguageServer(this EditorWidget {|#0:editor|}, string url) => editor;
+            }
+            """;
+
+        await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("editor", "LanguageServer"));
+    }
+
+    [Fact]
+    public async Task Receiver_NamedWidget_OnConcreteWidget_NoDiagnostic()
+    {
+        const string source = """
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record EditorWidget(string Text) : Hex1bWidget;
+
+            public static class EditorExtensions
+            {
+                public static EditorWidget LanguageServer(this EditorWidget widget, string url) => widget;
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    [Fact]
+    public async Task Receiver_GenericWidgetConstrained_NamedNonWidget_Reports()
+    {
+        const string source = """
+            using System;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public static class WidgetExtensions
+            {
+                public static TWidget InputBindings<TWidget>(this TWidget {|#0:w|}, Action<int> configure)
+                    where TWidget : Hex1bWidget => w;
+            }
+            """;
+
+        await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("w", "InputBindings"));
+    }
+
+    [Fact]
+    public async Task Receiver_GenericWidgetConstrained_NamedWidget_NoDiagnostic()
+    {
+        const string source = """
+            using System;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public static class WidgetExtensions
+            {
+                public static TWidget InputBindings<TWidget>(this TWidget widget, Action<int> configure)
+                    where TWidget : Hex1bWidget => widget;
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    [Fact]
+    public async Task WidgetContextReceiver_NoDiagnostic()
+    {
+        // WidgetContext<T> is HEX1B0006 territory; this analyzer must stay silent.
+        const string source = """
+            using Hex1b;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(string Text) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget Foo<TParent>(this WidgetContext<TParent> ctx, string text)
+                    where TParent : Hex1bWidget => new(text);
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    [Fact]
+    public async Task NonWidgetReceiver_NoDiagnostic()
+    {
+        const string source = """
+            namespace MyApp;
+
+            public static class StringExtensions
+            {
+                public static string AddPrefix(this string editor, string prefix) => prefix + editor;
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    [Fact]
+    public async Task NonExtensionMethod_NoDiagnostic()
+    {
+        const string source = """
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record EditorWidget(string Text) : Hex1bWidget;
+
+            public static class EditorExtensions
+            {
+                public static EditorWidget LanguageServer(EditorWidget editor, string url) => editor;
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+}

--- a/tests/Hex1b.Analyzers.Tests/WidgetMultipleBuilderCallbacksAnalyzerTests.cs
+++ b/tests/Hex1b.Analyzers.Tests/WidgetMultipleBuilderCallbacksAnalyzerTests.cs
@@ -1,0 +1,236 @@
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Hex1b.Analyzers.Tests;
+
+public class WidgetMultipleBuilderCallbacksAnalyzerTests
+{
+    private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
+        => AnalyzerTestHelpers<WidgetMultipleBuilderCallbacksAnalyzer>.VerifyAsync(source, expected);
+
+    private static DiagnosticResult Diagnostic()
+        => AnalyzerTestHelpers<WidgetMultipleBuilderCallbacksAnalyzer>.Diagnostic(WidgetMultipleBuilderCallbacksAnalyzer.Rule);
+
+    [Fact]
+    public async Task TwoBuilders_OnWidgetContextExtension_Reports()
+    {
+        const string source = """
+            using System;
+            using Hex1b;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(Hex1bWidget Left, Hex1bWidget Right) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget {|#0:HSplitter|}<TParent>(
+                    this WidgetContext<TParent> context,
+                    Func<WidgetContext<FooWidget>, Hex1bWidget> leftBuilder,
+                    Func<WidgetContext<FooWidget>, Hex1bWidget> rightBuilder)
+                    where TParent : Hex1bWidget
+                    => new(leftBuilder(new WidgetContext<FooWidget>()), rightBuilder(new WidgetContext<FooWidget>()));
+            }
+            """;
+
+        await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("HSplitter", 2));
+    }
+
+    [Fact]
+    public async Task ThreeBuilders_Reports()
+    {
+        const string source = """
+            using System;
+            using Hex1b;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(Hex1bWidget A, Hex1bWidget B, Hex1bWidget C) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget {|#0:Tri|}<TParent>(
+                    this WidgetContext<TParent> context,
+                    Func<WidgetContext<FooWidget>, Hex1bWidget> aBuilder,
+                    Func<WidgetContext<FooWidget>, Hex1bWidget> bBuilder,
+                    Func<WidgetContext<FooWidget>, Hex1bWidget> cBuilder)
+                    where TParent : Hex1bWidget
+                    => new(
+                        aBuilder(new WidgetContext<FooWidget>()),
+                        bBuilder(new WidgetContext<FooWidget>()),
+                        cBuilder(new WidgetContext<FooWidget>()));
+            }
+            """;
+
+        await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("Tri", 3));
+    }
+
+    [Fact]
+    public async Task SingleBuilder_NoDiagnostic()
+    {
+        const string source = """
+            using System;
+            using Hex1b;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(Hex1bWidget Child) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget Foo<TParent>(
+                    this WidgetContext<TParent> context,
+                    Func<WidgetContext<FooWidget>, Hex1bWidget> builder)
+                    where TParent : Hex1bWidget
+                    => new(builder(new WidgetContext<FooWidget>()));
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    [Fact]
+    public async Task NoBuilder_NoDiagnostic()
+    {
+        const string source = """
+            using Hex1b;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(string Text) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget Foo<TParent>(this WidgetContext<TParent> context, string text)
+                    where TParent : Hex1bWidget => new(text);
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    [Fact]
+    public async Task SuppressMessage_OnMultiBuilderMethod_NoDiagnostic()
+    {
+        const string source = """
+            using System;
+            using System.Diagnostics.CodeAnalysis;
+            using Hex1b;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(Hex1bWidget Left, Hex1bWidget Right) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                [SuppressMessage("Hex1b.ApiDesign", "HEX1B0009", Justification = "Splitter genuinely needs two panes.")]
+                public static FooWidget HSplitter<TParent>(
+                    this WidgetContext<TParent> context,
+                    Func<WidgetContext<FooWidget>, Hex1bWidget> leftBuilder,
+                    Func<WidgetContext<FooWidget>, Hex1bWidget> rightBuilder)
+                    where TParent : Hex1bWidget
+                    => new(leftBuilder(new WidgetContext<FooWidget>()), rightBuilder(new WidgetContext<FooWidget>()));
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    [Fact]
+    public async Task TwoBuilders_OnWidgetInstanceExtension_Reports()
+    {
+        const string source = """
+            using System;
+            using Hex1b;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(Hex1bWidget? Header, Hex1bWidget? Footer) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget {|#0:HeaderAndFooter|}(
+                    this FooWidget widget,
+                    Func<WidgetContext<FooWidget>, Hex1bWidget> headerBuilder,
+                    Func<WidgetContext<FooWidget>, Hex1bWidget> footerBuilder)
+                    => widget with
+                    {
+                        Header = headerBuilder(new WidgetContext<FooWidget>()),
+                        Footer = footerBuilder(new WidgetContext<FooWidget>()),
+                    };
+            }
+            """;
+
+        await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("HeaderAndFooter", 2));
+    }
+
+    [Fact]
+    public async Task TwoActionConfigures_NoDiagnostic()
+    {
+        // Two Action<T> callbacks aren't builder callbacks; rule must stay silent.
+        const string source = """
+            using System;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(string Text) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget Configure(this FooWidget widget, Action<int> a, Action<int> b) => widget;
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    [Fact]
+    public async Task OnXMethod_TwoHandlerCallbacks_NoDiagnostic()
+    {
+        // 'On*' methods host handler callbacks, not widget-tree builders, so HEX1B0009 must
+        // stay silent even when an OnFoo method takes multiple handler callbacks.
+        const string source = """
+            using System;
+            using Hex1b.Widgets;
+
+            namespace MyApp;
+
+            public sealed record FooWidget(string Text) : Hex1bWidget;
+
+            public static class FooExtensions
+            {
+                public static FooWidget OnDual(
+                    this FooWidget widget,
+                    Func<int, Hex1bWidget> primary,
+                    Func<int, Hex1bWidget> fallback) => widget;
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+
+    [Fact]
+    public async Task NonWidgetExtension_NoDiagnostic()
+    {
+        const string source = """
+            using System;
+
+            namespace MyApp;
+
+            public static class StringExtensions
+            {
+                public static string Combine(this string s, Func<string, string> a, Func<string, string> b)
+                    => a(s) + b(s);
+            }
+            """;
+
+        await VerifyAsync(source);
+    }
+}

--- a/tests/Hex1b.Tests/TestWidgetExtensions.cs
+++ b/tests/Hex1b.Tests/TestWidgetExtensions.cs
@@ -7,7 +7,7 @@ public static class TestWidgetExtensions
     /// <summary>
     /// Creates a <see cref="TestWidget"/> for witnessing render loop timing.
     /// </summary>
-    public static TestWidget Test<TParent>(this WidgetContext<TParent> ctx)
+    public static TestWidget Test<TParent>(this WidgetContext<TParent> context)
         where TParent : Hex1bWidget
         => new();
 }


### PR DESCRIPTION
## Summary

Audit + standardize widget extension method signatures, then enforce the convention with four new Roslyn analyzers so the API stays consistent over time.

The convention adopted is Flutter-style:

| Receiver / parameter | Name | Analyzer |
|---|---|---|
| `WidgetContext<T>` extension receiver | `context` | HEX1B0006 |
| Widget instance extension receiver (`this XxxWidget …` or `where TWidget : Hex1bWidget`) | `widget` | HEX1B0007 |
| A single widget-builder callback (`Func<…, Hex1bWidget>` etc.) | `builder` | HEX1B0008 |
| Multiple widget-builder callbacks on one method | _avoid; suppress with justification_ | HEX1B0009 |

Before this PR the codebase was inconsistent: receivers were `ctx` ×130, `context` ×3, `editor` ×3; callback names were a mix of `builder`, `childBuilder`, `contentBuilder`, `backgroundBuilder`, `fallbackBuilder`, `menuBuilder`, `layerBuilder`, `children`, `leftBuilder`/`rightBuilder`, etc.

## Analyzers

All four analyzers live in `src/Hex1b.Analyzers/`, default to `Warning` severity, and follow the existing analyzer pattern (compilation start → resolve `Hex1bWidget` / `WidgetContext<T>` → symbol action on `Method`). They skip overrides, explicit interface impls, accessors, and constructors.

- **HEX1B0006** — `WidgetContextReceiverNameAnalyzer`
- **HEX1B0007** — `WidgetInstanceReceiverNameAnalyzer` (excludes `WidgetContext<T>` receivers; HEX1B0006 owns those)
- **HEX1B0008** — `WidgetBuilderCallbackNameAnalyzer`
- **HEX1B0009** — `WidgetMultipleBuilderCallbacksAnalyzer`

A "widget-builder callback" is defined in `Hex1bSymbols.IsWidgetBuilderCallback` as a `System.Func<…, TResult>` where `TResult` is `Hex1bWidget` / a derived widget / `Hex1bWidget?` / an array of widget / an `IEnumerable<>` of widget. It strips one level of `Nullable<T>` and walks `AllInterfaces` to find `IEnumerable<>` regardless of the concrete return type's base class.

### `On*` exclusion (HEX1B0008 + HEX1B0009)

`On[A-Z]…` methods are event-handler decorators, not builders, so both analyzers short-circuit on them. This prevents false positives on shapes like:

- `MarkdownWidget.OnBlock(Func<MarkdownBlockContext, TBlock, Hex1bWidget> handler)`
- `TreeItemWidget.OnExpanding(Func<TreeItemExpandingEventArgs, IEnumerable<TreeItemWidget>> handler)`

The handler returns a widget shape, but it is rendered in response to an event — not part of the widget tree's static composition.

### Suppressing HEX1B0009 (multi-builder)

Some shapes legitimately need two builders. `HSplitter`/`VSplitter` are the only current cases, and they each carry an explicit suppression with justification:

```csharp
[SuppressMessage(
    "Hex1b.ApiDesign",
    "HEX1B0009",
    Justification = "A splitter inherently has two independent panes; each side takes its own builder callback.")]
public static SplitterWidget HSplitter<TParent>(
    this WidgetContext<TParent> context,
    Func<WidgetContext<VStackWidget>, Hex1bWidget[]> leftBuilder,
    Func<WidgetContext<VStackWidget>, Hex1bWidget[]> rightBuilder,
    int leftWidth = 30)
```

## Surface refactor

- Renamed `ctx → context` across ~130 receiver sites in 68 `*Extensions.cs` files (receiver decl, `<param name="ctx">` doc tags, body refs).
- Renamed `editor → widget` receiver in `LanguageServerExtensions.cs` (3 sites).
- Renamed single-callback parameters to `builder` across 9 files: `ScrollPanelExtensions`, `RescueExtensions`, `WindowPanelExtensions`, `DragBarPanelExtensions`, `KgpImageExtensions`, `SixelExtensions`, `MenuExtensions`, `SurfaceExtensions`, `ZStackExtensions`.
- Added `[SuppressMessage("Hex1b.ApiDesign", "HEX1B0009", …)]` to `HSplitter` and `VSplitter` in `SplitterExtensions.cs`.
- Updated `tests/Hex1b.Tests/TestWidgetExtensions.cs` to comply (HEX1B0006 fired on the test helper too — exactly the intended behavior).

## Tests

- 4 new analyzer test files (positive / negative / boundary / suppression / `On*` exclusion):
  - `WidgetContextReceiverNameAnalyzerTests.cs`
  - `WidgetInstanceReceiverNameAnalyzerTests.cs`
  - `WidgetBuilderCallbackNameAnalyzerTests.cs` (incl. `OnXMethod_HandlerCallback_NoDiagnostic`)
  - `WidgetMultipleBuilderCallbacksAnalyzerTests.cs` (incl. `SuppressMessage_OnMultiBuilderMethod_NoDiagnostic` and `OnXMethod_TwoHandlerCallbacks_NoDiagnostic`)
- **All 7638 main tests + 62 analyzer tests pass.**
- Lib builds clean under `TreatWarningsAsErrors=true` with zero unsuppressed warnings.

## Docs

- `AGENTS.md` analyzer table extended with rows for HEX1B0006–HEX1B0009.
- `AGENTS.md` "Naming" section gains explicit guidance on the `context` / `widget` / `builder` parameter convention.
- `AnalyzerReleases.Unshipped.md` updated.

## Out of scope / pre-existing

`samples/WebMuxerDemo/Cli/CliViewerApp.cs` calls a non-existent `WithInputBindings` on a widget. This was introduced in #309 and predates this branch — not addressed here.