### PR TITLE
TextBox: inline prediction support, default fill-width, and bracket cleanup

### DIFF
--- a/samples/AgenticPromptDemo/SlashCommandPromptWidget.cs
+++ b/samples/AgenticPromptDemo/SlashCommandPromptWidget.cs
@@ -250,14 +250,13 @@ public sealed record SlashCommandPromptWidget(IReadOnlyList<SlashCommand> Comman
             StyleTextBox(h, textbox).FillWidth(),
         ]);
 
-    // Wrap the textbox in a ThemePanel that switches it into "fill mode" — no
-    // [ / ] brackets, with a shaded background that brightens on focus. This is
-    // the same trick FormTextFieldWidget uses to get a chunky form-style input.
-    // Generic over the parent context type so the same helper works whether
-    // we're sitting in a VStack or an HStack.
+    // The textbox already renders with the form-style fill background by
+    // default, so this helper is just a passthrough kept for parity with the
+    // older bracket-mode API. Generic over the parent context type so the
+    // same helper works whether we're sitting in a VStack or an HStack.
     private static Hex1bWidget StyleTextBox<TParent>(WidgetContext<TParent> context, TextBoxWidget textbox)
         where TParent : Hex1bWidget
-        => context.ThemePanel(t => t.Set(TextBoxTheme.UseFillMode, true), textbox);
+        => textbox;
 
     private static IReadOnlyList<SlashCommand> ComputeMatches(
         string text,

--- a/samples/FlowDemo/Commands/CopilotCommand.cs
+++ b/samples/FlowDemo/Commands/CopilotCommand.cs
@@ -117,10 +117,9 @@ internal static class CopilotCommand
                             theme => theme.Set(SeparatorTheme.Color, modeColor),
                             ctx.Separator()
                         ),
-                        pv.ThemePanel(
-                            theme => theme
-                                .Set(TextBoxTheme.LeftBracket, $"{modeColorAnsi}❯ \x1b[0m")
-                                .Set(TextBoxTheme.RightBracket, ""),
+                        pv.HStack(h =>
+                        [
+                            h.Text($"{modeColorAnsi}❯\x1b[0m "),
                             ctx.TextBox().OnSubmit(e =>
                             {
                                 var text = e.Text?.Trim() ?? "";
@@ -143,8 +142,8 @@ internal static class CopilotCommand
                                     state.ShowCommands = !state.ShowCommands;
                                     actionCtx.Invalidate();
                                 }, "Toggle commands");
-                            })
-                        ),
+                            }).FillWidth()
+                        ]),
                         pv.ThemePanel(
                             theme => theme.Set(SeparatorTheme.Color, modeColor),
                             ctx.Separator()

--- a/samples/PredictiveTextDemo/PredictiveTextDemo.csproj
+++ b/samples/PredictiveTextDemo/PredictiveTextDemo.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <PublishAot>true</PublishAot>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Hex1b/Hex1b.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/PredictiveTextDemo/Program.cs
+++ b/samples/PredictiveTextDemo/Program.cs
@@ -1,0 +1,100 @@
+using Hex1b;
+using Hex1b.Widgets;
+
+// A small in-memory dictionary of "next-character" completions. The predictor
+// picks the longest entry whose key is a prefix of the current text and
+// returns the suffix as the inline suggestion.
+var phrases = new[]
+{
+    "the quick brown fox jumps over the lazy dog",
+    "hello world",
+    "hex1b is a terminal ui library for .net",
+    "predictive text saves keystrokes",
+    "this is a sample of inline completions",
+    "type any letter to see suggestions appear",
+};
+
+var lastSubmitted = "(none)";
+var submissionCount = 0;
+var stats = new Stats();
+
+await using var terminal = Hex1bTerminal.CreateBuilder()
+    .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+        v.Text("Predictive Text Demo"),
+        v.Separator(),
+        v.Text(""),
+
+        v.Text("Start typing — a suggestion appears in dim text after the cursor."),
+        v.Text("RightArrow accepts the suggestion. Escape dismisses it."),
+        v.Text(""),
+
+        v.Border(b => [
+            b.Text("Instant predictor (no debounce):"),
+            b.TextBox()
+                .Predict(async (text, ct) =>
+                {
+                    Interlocked.Increment(ref stats.InstantCalls);
+                    // Synthesize an async hop to mirror what a real predictor
+                    // would do (e.g., calling out to an LLM).
+                    await Task.Yield();
+                    return Predict(phrases, text);
+                })
+                .OnSubmit(e =>
+                {
+                    lastSubmitted = e.Text;
+                    Interlocked.Increment(ref submissionCount);
+                }),
+        ]).Title($"Instant ({stats.InstantCalls} calls)"),
+
+        v.Text(""),
+
+        v.Border(b => [
+            b.Text("Debounced predictor (150 ms — simulates a slow backend):"),
+            b.TextBox()
+                .Predict(async (text, ct) =>
+                {
+                    Interlocked.Increment(ref stats.DebouncedCalls);
+                    // Pretend the predictor is expensive.
+                    await Task.Delay(40, ct);
+                    return Predict(phrases, text);
+                }, TimeSpan.FromMilliseconds(150))
+                .OnSubmit(e =>
+                {
+                    lastSubmitted = e.Text;
+                    Interlocked.Increment(ref submissionCount);
+                }),
+        ]).Title($"Debounced 150 ms ({stats.DebouncedCalls} calls)"),
+
+        v.Text(""),
+        v.Separator(),
+        v.Text($"Last submitted: {lastSubmitted}"),
+        v.Text($"Total submissions: {submissionCount}"),
+        v.Text(""),
+        v.Text("Tab moves between text boxes. Press Ctrl+C to exit."),
+    ]))
+    .WithMouse()
+    .Build();
+
+await terminal.RunAsync();
+
+static string? Predict(IEnumerable<string> dictionary, string input)
+{
+    if (string.IsNullOrEmpty(input)) return null;
+
+    // Find the longest dictionary entry that starts with the current input.
+    string? best = null;
+    foreach (var entry in dictionary)
+    {
+        if (entry.Length <= input.Length) continue;
+        if (!entry.StartsWith(input, StringComparison.OrdinalIgnoreCase)) continue;
+        if (best is null || entry.Length > best.Length) best = entry;
+    }
+
+    return best is null ? null : best[input.Length..];
+}
+
+internal sealed class Stats
+{
+    public int InstantCalls;
+    public int DebouncedCalls;
+}

--- a/src/Hex1b.Website/Examples/TextBoxPredictExample.cs
+++ b/src/Hex1b.Website/Examples/TextBoxPredictExample.cs
@@ -1,0 +1,70 @@
+using Hex1b;
+using Hex1b.Widgets;
+using Microsoft.Extensions.Logging;
+
+namespace Hex1b.Website.Examples;
+
+public class TextBoxPredictExample(ILogger<TextBoxPredictExample> logger) : Hex1bExample
+{
+    private readonly ILogger<TextBoxPredictExample> _logger = logger;
+
+    public override string Id => "textbox-predict";
+    public override string Title => "TextBox - Inline Prediction";
+    public override string Description =>
+        "Inline predictive completions appear in dim text after the cursor. " +
+        "Press Right Arrow to accept the suggestion or Escape to dismiss it.";
+
+    private static readonly string[] Phrases =
+    [
+        "the quick brown fox jumps over the lazy dog",
+        "hello world",
+        "hex1b is a terminal ui library for .net",
+        "predictive text saves keystrokes",
+        "type any letter to see suggestions appear",
+    ];
+
+    private class PredictState
+    {
+        public string Input { get; set; } = "";
+    }
+
+    public override Func<Hex1bWidget> CreateWidgetBuilder()
+    {
+        _logger.LogInformation("Creating textbox predict example");
+        var state = new PredictState();
+
+        return () =>
+        {
+            var ctx = new RootContext();
+            return ctx.VStack(v => [
+                v.Text("Predictive TextBox"),
+                v.Text("──────────────────"),
+                v.Text(""),
+                v.Text("Start typing — the predictor returns the longest dictionary"),
+                v.Text("entry whose prefix matches what you've typed."),
+                v.Text(""),
+                v.TextBox(state.Input)
+                    .OnTextChanged(args => state.Input = args.NewText)
+                    .Predict(async (text, ct) =>
+                    {
+                        // Synthesize an async hop — a real predictor might
+                        // await an HTTP/LLM call here.
+                        await Task.Yield();
+
+                        if (string.IsNullOrEmpty(text)) return null;
+
+                        string? best = null;
+                        foreach (var entry in Phrases)
+                        {
+                            if (entry.Length <= text.Length) continue;
+                            if (!entry.StartsWith(text, StringComparison.OrdinalIgnoreCase)) continue;
+                            if (best is null || entry.Length > best.Length) best = entry;
+                        }
+                        return best is null ? null : best[text.Length..];
+                    }),
+                v.Text(""),
+                v.Text("Right arrow accepts the suggestion. Escape dismisses it.")
+            ]);
+        };
+    }
+}

--- a/src/Hex1b.Website/Examples/ThemingExample.cs
+++ b/src/Hex1b.Website/Examples/ThemingExample.cs
@@ -168,8 +168,7 @@ public class ThemingExample(ILogger<ThemingExample> logger) : Hex1bExample
             .Set(TextBoxTheme.CursorBackgroundColor, Hex1bColor.FromRgb(0, 255, 255))
             .Set(TextBoxTheme.SelectionBackgroundColor, Hex1bColor.FromRgb(255, 0, 255))
             .Set(TextBoxTheme.SelectionForegroundColor, Hex1bColor.White)
-            .Set(TextBoxTheme.LeftBracket, "<")
-            .Set(TextBoxTheme.RightBracket, ">")
+            .Set(TextBoxTheme.PredictionForegroundColor, Hex1bColor.FromRgb(255, 0, 255))
             // List
             .Set(ListTheme.SelectedForegroundColor, Hex1bColor.Black)
             .Set(ListTheme.SelectedBackgroundColor, Hex1bColor.FromRgb(0, 255, 255))

--- a/src/Hex1b.Website/Program.cs
+++ b/src/Hex1b.Website/Program.cs
@@ -100,6 +100,7 @@ builder.Services.AddSingleton<IGalleryExample, TextBoxBasicExample>();
 builder.Services.AddSingleton<IGalleryExample, TextBoxSubmitExample>();
 builder.Services.AddSingleton<IGalleryExample, TextBoxFormExample>();
 builder.Services.AddSingleton<IGalleryExample, TextBoxUnicodeExample>();
+builder.Services.AddSingleton<IGalleryExample, TextBoxPredictExample>();
 
 // Register ToggleSwitch widget documentation examples
 builder.Services.AddSingleton<IGalleryExample, ToggleSwitchBasicExample>();

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -2144,8 +2144,8 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
 
         node.CachePredicate = widget.CachePredicate;
         
-        node.WidthHint = widget.WidthHint;
-        node.HeightHint = widget.HeightHint;
+        node.WidthHint = widget.WidthHint ?? widget.DefaultWidthHint;
+        node.HeightHint = widget.HeightHint ?? widget.DefaultHeightHint;
         
         // Schedule animation timer if widget has RedrawDelay (for root widget)
         var effectiveDelay = widget.GetEffectiveRedrawDelay();

--- a/src/Hex1b/Nodes/TextBoxNode.cs
+++ b/src/Hex1b/Nodes/TextBoxNode.cs
@@ -1437,7 +1437,11 @@ public sealed class TextBoxNode : Hex1bNode
             ? theme.Get(TextBoxTheme.FocusedFillBackgroundColor)
             : theme.Get(TextBoxTheme.FillBackgroundColor);
         var predictionFg = theme.Get(TextBoxTheme.PredictionForegroundColor);
-        var predictionBg = theme.Get(TextBoxTheme.PredictionBackgroundColor);
+        var predictionBgRaw = theme.Get(TextBoxTheme.PredictionBackgroundColor);
+        // Treat the Default sentinel as "follow the textbox fill background"
+        // so the suggestion blends into the input surface unless the user
+        // explicitly themed it to a contrasting color.
+        var predictionBg = predictionBgRaw.IsDefault ? fillBg : predictionBgRaw;
 
         var globalColors = theme.GetGlobalColorCodes();
         var resetToGlobal = theme.GetResetToGlobalCodes();
@@ -1554,8 +1558,10 @@ public sealed class TextBoxNode : Hex1bNode
                 return $"{globalColors}{fillBgAnsi}{beforeSel}{selFg.ToForegroundAnsi()}{selBg.ToBackgroundAnsi()}{selected}{resetToGlobal}{fillBgAnsi}{afterSel}{padStr}{resetToGlobal}";
             }
 
-            // Line caret: render the text, then the prediction (if any), and
-            // let the native terminal cursor sit between them.
+            // Line caret: render the text, then the prediction (if any) on the
+            // resolved prediction background, and let the native terminal cursor
+            // sit between them. The caller normalizes a Default prediction
+            // background to fillBg so the suggestion blends with the field.
             var before = text[..cursor];
             var after = cursor < text.Length ? text[cursor..] : "";
 

--- a/src/Hex1b/Nodes/TextBoxNode.cs
+++ b/src/Hex1b/Nodes/TextBoxNode.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using Hex1b.Input;
 using Hex1b.Layout;
 using Hex1b.Theming;
@@ -117,6 +118,12 @@ public sealed class TextBoxNode : Hex1bNode
             if (_isFocused != value)
             {
                 _isFocused = value;
+                if (!value)
+                {
+                    // Lose focus → drop any active suggestion so it doesn't
+                    // ghost into the next focused widget's render area.
+                    ClearPrediction();
+                }
                 MarkDirty();
             }
         }
@@ -155,11 +162,195 @@ public sealed class TextBoxNode : Hex1bNode
     /// </summary>
     internal int ScreenCursorY { get; private set; }
 
+    // ───── Predictive input ────────────────────────────────────────────────
+
+    /// <summary>
+    /// User-supplied async predictor. When non-null, typing a character with
+    /// the cursor at end of buffer asks the predictor for an inline suggestion.
+    /// </summary>
+    internal Func<string, CancellationToken, Task<string?>>? Predictor { get; set; }
+
+    /// <summary>
+    /// Optional debounce window. When &gt; <see cref="TimeSpan.Zero"/>, multiple
+    /// keystrokes within the window collapse into a single predictor invocation.
+    /// </summary>
+    internal TimeSpan PredictionDebounce { get; set; }
+
+    /// <summary>
+    /// The current inline prediction string shown after the cursor.
+    /// <c>null</c> when no prediction is active. Always cleared on any
+    /// non-typing input (movement, deletion, paste, focus loss, mouse click).
+    /// </summary>
+    internal string? CurrentPrediction { get; private set; }
+
+    /// <summary>
+    /// Monotonic counter incremented every time a prediction request is issued
+    /// or invalidated. Async predictor callbacks compare the captured id to
+    /// this field on completion and discard stale results.
+    /// </summary>
+    private long _predictionRequestId;
+
+    /// <summary>
+    /// Cancels the in-flight predictor task. Replaced atomically each time a
+    /// new prediction is requested or an invalidation occurs.
+    /// </summary>
+    private CancellationTokenSource? _predictionInflightCts;
+
+    /// <summary>
+    /// Cancels the pending debounce delay for the next prediction request.
+    /// </summary>
+    private CancellationTokenSource? _predictionDebounceCts;
+
+    /// <summary>
+    /// Cancels any in-flight prediction work and clears
+    /// <see cref="CurrentPrediction"/>. Returns <c>true</c> if a prediction
+    /// was actually showing (used by Escape to decide whether to consume).
+    /// </summary>
+    internal bool ClearPrediction()
+    {
+        // Always invalidate request id so any racing predictor task discards
+        // its result, even if no prediction is currently displayed.
+        _predictionRequestId++;
+
+        try { _predictionDebounceCts?.Cancel(); } catch { }
+        _predictionDebounceCts?.Dispose();
+        _predictionDebounceCts = null;
+
+        try { _predictionInflightCts?.Cancel(); } catch { }
+        _predictionInflightCts?.Dispose();
+        _predictionInflightCts = null;
+
+        if (CurrentPrediction is null)
+            return false;
+
+        CurrentPrediction = null;
+        MarkDirty();
+        return true;
+    }
+
+    /// <summary>
+    /// Replaces the current prediction string and marks the node dirty.
+    /// </summary>
+    private void SetPrediction(string? prediction)
+    {
+        if (CurrentPrediction == prediction)
+            return;
+        CurrentPrediction = string.IsNullOrEmpty(prediction) ? null : prediction;
+        MarkDirty();
+    }
+
+    /// <summary>
+    /// Returns true when a prediction is currently shown and should respond
+    /// to <c>RightArrow</c> (accept) and <c>Escape</c> (dismiss).
+    /// </summary>
+    private bool HasActivePrediction => !string.IsNullOrEmpty(CurrentPrediction)
+        && IsFocused
+        && State.CursorPosition == State.Text.Length
+        && !State.HasSelection;
+
+    /// <summary>
+    /// Inserts the current prediction at the end of the buffer (accepting it),
+    /// fires <see cref="TextChangedAction"/>, and clears prediction state.
+    /// Returns the new text on success; <c>null</c> if no prediction was active.
+    /// </summary>
+    private async Task<string?> AcceptCurrentPredictionAsync(InputBindingActionContext ctx)
+    {
+        var prediction = CurrentPrediction;
+        if (string.IsNullOrEmpty(prediction))
+            return null;
+
+        var oldText = State.Text;
+        // Append at the very end — by precondition the cursor is at end and
+        // there is no selection.
+        State.Text = oldText + prediction;
+        State.CursorPosition = State.Text.Length;
+        State.ResetPreferredColumn();
+
+        // Clear before invoking the change handler so handlers observing the
+        // node see a coherent post-accept state.
+        ClearPrediction();
+        MarkDirty();
+
+        if (TextChangedAction != null && oldText != State.Text)
+        {
+            await TextChangedAction(ctx, oldText, State.Text);
+        }
+
+        return State.Text;
+    }
+
+    /// <summary>
+    /// Requests a new prediction for the current buffer. Honours the
+    /// configured debounce window and uses request-id + cancellation to
+    /// discard stale results when the user keeps typing.
+    /// </summary>
+    private void RequestPrediction()
+    {
+        var predictor = Predictor;
+        if (predictor is null) return;
+        // Predictions are a single-line affordance only.
+        if (IsMultiline) return;
+        if (!IsFocused) return;
+        if (State.HasSelection) return;
+        if (State.CursorPosition != State.Text.Length) return;
+
+        // Cancel pending/in-flight work and bump the request id.
+        var requestId = ++_predictionRequestId;
+        try { _predictionDebounceCts?.Cancel(); } catch { }
+        _predictionDebounceCts?.Dispose();
+        try { _predictionInflightCts?.Cancel(); } catch { }
+        _predictionInflightCts?.Dispose();
+
+        var snapshot = State.Text;
+        var debounce = PredictionDebounce;
+        var inflight = new CancellationTokenSource();
+        _predictionInflightCts = inflight;
+        var debounceCts = debounce > TimeSpan.Zero ? new CancellationTokenSource() : null;
+        _predictionDebounceCts = debounceCts;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                if (debounceCts is not null)
+                {
+                    await Task.Delay(debounce, debounceCts.Token);
+                }
+
+                if (inflight.IsCancellationRequested) return;
+
+                var result = await predictor(snapshot, inflight.Token);
+
+                // Drop result if a newer request superseded us, the input was
+                // mutated, the cursor moved off the end, or focus was lost.
+                if (requestId != _predictionRequestId) return;
+                if (inflight.IsCancellationRequested) return;
+                if (!IsFocused) return;
+                if (State.HasSelection) return;
+                if (State.Text != snapshot) return;
+                if (State.CursorPosition != State.Text.Length) return;
+                if (string.IsNullOrEmpty(result)) return;
+
+                SetPrediction(result);
+                AppInvalidate?.Invoke();
+            }
+            catch (OperationCanceledException)
+            {
+                // Stale request — ignore.
+            }
+            catch
+            {
+                // Predictor threw — silently swallow so a misbehaving predictor
+                // can't crash the render loop.
+            }
+        });
+    }
+
     public override void ConfigureDefaultBindings(InputBindingsBuilder bindings)
     {
         // Navigation
         bindings.Key(Hex1bKey.LeftArrow).Triggers(TextBoxWidget.MoveLeft, MoveLeft, "Move left");
-        bindings.Key(Hex1bKey.RightArrow).Triggers(TextBoxWidget.MoveRight, MoveRight, "Move right");
+        bindings.Key(Hex1bKey.RightArrow).Triggers(TextBoxWidget.MoveRight, MoveRightOrAcceptPredictionAsync, "Move right / accept prediction");
         bindings.Key(Hex1bKey.Home).Triggers(TextBoxWidget.MoveHome, MoveHome, "Go to start");
         bindings.Key(Hex1bKey.End).Triggers(TextBoxWidget.MoveEnd, MoveEnd, "Go to end");
         
@@ -199,7 +390,15 @@ public sealed class TextBoxNode : Hex1bNode
             // Submit (Enter key) — single-line only
             bindings.Key(Hex1bKey.Enter).Triggers(TextBoxWidget.Submit, SubmitAction, "Submit");
         }
-        
+
+        // Escape only consumes when there is an active prediction. Bindings
+        // are rebuilt per key event, so registering this conditionally lets
+        // a "naked" Escape bubble to ancestors (form / window) as before.
+        if (HasActivePrediction)
+        {
+            bindings.Key(Hex1bKey.Escape).Triggers(TextBoxWidget.DismissPrediction, DismissPredictionAction, "Dismiss prediction");
+        }
+
         // Selection
         bindings.Ctrl().Key(Hex1bKey.A).Triggers(TextBoxWidget.SelectAll, SelectAll, "Select all");
         
@@ -211,6 +410,30 @@ public sealed class TextBoxNode : Hex1bNode
     }
 
     /// <summary>
+    /// RightArrow either moves the cursor right (default) or accepts the
+    /// active prediction and inserts it into the buffer.
+    /// </summary>
+    private async Task MoveRightOrAcceptPredictionAsync(InputBindingActionContext ctx)
+    {
+        if (HasActivePrediction)
+        {
+            await AcceptCurrentPredictionAsync(ctx);
+            return;
+        }
+        MoveRight();
+    }
+
+    /// <summary>
+    /// Escape handler registered only while a prediction is showing —
+    /// dismisses the suggestion. (When no prediction is active this binding
+    /// is not registered, so Escape bubbles normally.)
+    /// </summary>
+    private void DismissPredictionAction()
+    {
+        ClearPrediction();
+    }
+
+    /// <summary>
     /// Handles bracketed paste. If a custom paste handler is set via OnPaste(),
     /// it is called instead of the default text insertion behavior.
     /// For default behavior: reads full paste content and inserts at cursor position.
@@ -218,6 +441,9 @@ public sealed class TextBoxNode : Hex1bNode
     /// </summary>
     public override async Task<InputResult> HandlePasteAsync(Hex1bPasteEvent pasteEvent)
     {
+        // Paste is treated as an out-of-band edit — drop any in-flight prediction.
+        ClearPrediction();
+
         // Custom handler overrides default behavior
         if (CustomPasteAction != null)
         {
@@ -272,17 +498,25 @@ public sealed class TextBoxNode : Hex1bNode
         State.Text = State.Text.Insert(State.CursorPosition, text);
         State.CursorPosition += text.Length;
         State.ResetPreferredColumn();
+
+        // Drop any stale prediction — the buffer just changed.
+        ClearPrediction();
         MarkDirty();
-        
+
         // Fire callback if text changed
         if (TextChangedAction != null && oldText != State.Text)
         {
             await TextChangedAction(ctx, oldText, State.Text);
         }
+
+        // Predictions only fire on real keystrokes (this method) and only
+        // when the cursor is at the very end of the buffer.
+        RequestPrediction();
     }
 
     private void MoveLeft()
     {
+        ClearPrediction();
         if (State.HasSelection)
         {
             State.CursorPosition = State.SelectionStart;
@@ -299,6 +533,7 @@ public sealed class TextBoxNode : Hex1bNode
 
     private void MoveRight()
     {
+        ClearPrediction();
         if (State.HasSelection)
         {
             State.CursorPosition = State.SelectionEnd;
@@ -315,6 +550,7 @@ public sealed class TextBoxNode : Hex1bNode
 
     private void MoveHome()
     {
+        ClearPrediction();
         State.ClearSelection();
         if (IsMultiline)
         {
@@ -331,6 +567,7 @@ public sealed class TextBoxNode : Hex1bNode
 
     private void MoveEnd()
     {
+        ClearPrediction();
         State.ClearSelection();
         if (IsMultiline)
         {
@@ -347,6 +584,7 @@ public sealed class TextBoxNode : Hex1bNode
 
     private void MoveWordLeft()
     {
+        ClearPrediction();
         if (State.HasSelection)
         {
             State.CursorPosition = State.SelectionStart;
@@ -359,6 +597,7 @@ public sealed class TextBoxNode : Hex1bNode
 
     private void MoveWordRight()
     {
+        ClearPrediction();
         if (State.HasSelection)
         {
             State.CursorPosition = State.SelectionEnd;
@@ -371,6 +610,7 @@ public sealed class TextBoxNode : Hex1bNode
 
     private void SelectLeft()
     {
+        ClearPrediction();
         if (!State.SelectionAnchor.HasValue)
         {
             State.SelectionAnchor = State.CursorPosition;
@@ -386,6 +626,7 @@ public sealed class TextBoxNode : Hex1bNode
 
     private void SelectRight()
     {
+        ClearPrediction();
         if (!State.SelectionAnchor.HasValue)
         {
             State.SelectionAnchor = State.CursorPosition;
@@ -401,6 +642,7 @@ public sealed class TextBoxNode : Hex1bNode
 
     private void SelectToStart()
     {
+        ClearPrediction();
         if (!State.SelectionAnchor.HasValue)
         {
             State.SelectionAnchor = State.CursorPosition;
@@ -420,6 +662,7 @@ public sealed class TextBoxNode : Hex1bNode
 
     private void SelectToEnd()
     {
+        ClearPrediction();
         if (!State.SelectionAnchor.HasValue)
         {
             State.SelectionAnchor = State.CursorPosition;
@@ -439,6 +682,7 @@ public sealed class TextBoxNode : Hex1bNode
 
     private void SelectWordLeft()
     {
+        ClearPrediction();
         if (!State.SelectionAnchor.HasValue)
         {
             State.SelectionAnchor = State.CursorPosition;
@@ -450,6 +694,7 @@ public sealed class TextBoxNode : Hex1bNode
 
     private void SelectWordRight()
     {
+        ClearPrediction();
         if (!State.SelectionAnchor.HasValue)
         {
             State.SelectionAnchor = State.CursorPosition;
@@ -461,12 +706,14 @@ public sealed class TextBoxNode : Hex1bNode
 
     private void MoveUp()
     {
+        ClearPrediction();
         State.MoveUp();
         MarkDirty();
     }
 
     private async Task MoveDownAsync(InputBindingActionContext ctx)
     {
+        ClearPrediction();
         var (line, _) = State.OffsetToLineColumn(State.CursorPosition);
         if (line >= State.GetLineCount() - 1)
         {
@@ -493,12 +740,14 @@ public sealed class TextBoxNode : Hex1bNode
 
     private void SelectUp()
     {
+        ClearPrediction();
         State.MoveUp(extend: true);
         MarkDirty();
     }
 
     private void SelectDown()
     {
+        ClearPrediction();
         State.MoveDown(extend: true);
         MarkDirty();
     }
@@ -508,6 +757,7 @@ public sealed class TextBoxNode : Hex1bNode
 
     private async Task InsertNewlineAsync(InputBindingActionContext ctx)
     {
+        ClearPrediction();
         if (!CanInsertNewline())
             return;
 
@@ -524,6 +774,7 @@ public sealed class TextBoxNode : Hex1bNode
 
     private async Task DeleteBackwardAsync(InputBindingActionContext ctx)
     {
+        ClearPrediction();
         var oldText = State.Text;
         
         if (State.HasSelection)
@@ -550,6 +801,7 @@ public sealed class TextBoxNode : Hex1bNode
 
     private async Task DeleteForwardAsync(InputBindingActionContext ctx)
     {
+        ClearPrediction();
         var oldText = State.Text;
         
         if (State.HasSelection)
@@ -575,6 +827,7 @@ public sealed class TextBoxNode : Hex1bNode
 
     private async Task DeleteWordBackwardAsync(InputBindingActionContext ctx)
     {
+        ClearPrediction();
         var oldText = State.Text;
         
         if (State.HasSelection)
@@ -600,6 +853,7 @@ public sealed class TextBoxNode : Hex1bNode
 
     private async Task DeleteWordForwardAsync(InputBindingActionContext ctx)
     {
+        ClearPrediction();
         var oldText = State.Text;
         
         if (State.HasSelection)
@@ -636,6 +890,7 @@ public sealed class TextBoxNode : Hex1bNode
 
     private void SelectAll()
     {
+        ClearPrediction();
         State.SelectAll();
         MarkDirty();
     }
@@ -651,30 +906,21 @@ public sealed class TextBoxNode : Hex1bNode
             return InputResult.NotHandled;
         }
 
+        // Any click cancels an active prediction.
+        ClearPrediction();
+
         if (IsMultiline)
         {
             return HandleMouseClickMultiline(localX, localY);
         }
 
-        // The TextBox renders as "[text]" so localX=0 is '[', localX=1 is first char
-        var textColumn = localX - 1; // Subtract 1 for the '[' bracket
-        
-        if (textColumn < 0)
-        {
-            // Clicked on or before the '[' - position at start
-            State.ClearSelection();
-            State.CursorPosition = ScrollOffset;
-        }
-        else
-        {
-            // Find the cursor position in the visible text, then offset to full text
-            var visStart = Math.Min(ScrollOffset, State.Text.Length);
-            var visEnd = Math.Min(visStart + Math.Max(0, Bounds.Width - 2), State.Text.Length);
-            var visibleText = State.Text[visStart..visEnd];
-            var visPos = DisplayColumnToVisibleTextPosition(visibleText, textColumn);
-            State.ClearSelection();
-            State.CursorPosition = visStart + visPos;
-        }
+        // Single-line: localX maps directly to a column in the visible text.
+        var visStart = Math.Min(ScrollOffset, State.Text.Length);
+        var visEnd = Math.Min(visStart + Math.Max(0, Bounds.Width), State.Text.Length);
+        var visibleText = State.Text[visStart..visEnd];
+        var visPos = DisplayColumnToVisibleTextPosition(visibleText, Math.Max(0, localX));
+        State.ClearSelection();
+        State.CursorPosition = visStart + visPos;
 
         return InputResult.Handled;
     }
@@ -796,8 +1042,9 @@ public sealed class TextBoxNode : Hex1bNode
         }
         else
         {
-            // Default bracket mode: "[text]" - 2 chars for brackets
-            width = textDisplayWidth + 2;
+            // Inline fill mode: width is just the text content. The empty-text
+            // floor of 1 above keeps the cursor cell visible.
+            width = textDisplayWidth;
         }
 
         var height = 1;
@@ -1182,33 +1429,33 @@ public sealed class TextBoxNode : Hex1bNode
         ScreenCursorX = -1;
 
         var theme = context.Theme;
-        var leftBracket = theme.Get(TextBoxTheme.LeftBracket);
-        var rightBracket = theme.Get(TextBoxTheme.RightBracket);
         var cursorFg = theme.Get(TextBoxTheme.CursorForegroundColor);
         var cursorBg = theme.Get(TextBoxTheme.CursorBackgroundColor);
         var selFg = theme.Get(TextBoxTheme.SelectionForegroundColor);
         var selBg = theme.Get(TextBoxTheme.SelectionBackgroundColor);
-        var useFillMode = theme.Get(TextBoxTheme.UseFillMode);
         var fillBg = IsFocused
             ? theme.Get(TextBoxTheme.FocusedFillBackgroundColor)
             : theme.Get(TextBoxTheme.FillBackgroundColor);
-        
+        var predictionFg = theme.Get(TextBoxTheme.PredictionForegroundColor);
+        var predictionBg = theme.Get(TextBoxTheme.PredictionBackgroundColor);
+
         var globalColors = theme.GetGlobalColorCodes();
         var resetToGlobal = theme.GetResetToGlobalCodes();
 
-        // Multiline text boxes use their own render path
+        // Multiline text boxes use their own render path. Predictions are
+        // single-line only by design.
         if (IsMultiline)
         {
             RenderMultiline(context, globalColors, resetToGlobal, fillBg, cursorFg, cursorBg, selFg, selBg);
             return;
         }
 
-        // Calculate viewport width (the number of text columns available)
-        var viewportWidth = useFillMode ? Bounds.Width : Math.Max(0, Bounds.Width - 2);
+        // Inline (no-bracket) viewport: full bounds width is available for text.
+        var viewportWidth = Bounds.Width;
         var textLen = State.Text.Length;
 
-        // When bounds haven't been set (direct Render without layout) or the text fits,
-        // show the full text without viewport slicing.
+        // When bounds haven't been set (direct Render without layout) or the
+        // text fits, show the full text without viewport slicing.
         var needsViewport = viewportWidth > 0 && textLen > viewportWidth;
 
         string visibleText;
@@ -1228,48 +1475,10 @@ public sealed class TextBoxNode : Hex1bNode
             visSelEnd = State.HasSelection ? State.SelectionEnd : 0;
         }
 
-        string output;
-        if (useFillMode)
-        {
-            output = RenderFillMode(visibleText, visCursor, globalColors, resetToGlobal,
-                fillBg, cursorFg, cursorBg, selFg, selBg, context,
-                visSelStart, visSelEnd);
-        }
-        else if (IsFocused)
-        {
-            if (State.HasSelection && visSelStart != visSelEnd)
-            {
-                var beforeSel = visibleText[..visSelStart];
-                var selected = visibleText[visSelStart..visSelEnd];
-                var afterSel = visibleText[visSelEnd..];
-                
-                output = $"{globalColors}{leftBracket}{beforeSel}{selFg.ToForegroundAnsi()}{selBg.ToBackgroundAnsi()}{selected}{resetToGlobal}{afterSel}{rightBracket}";
-            }
-            else
-            {
-                // Line caret: render text normally, position native cursor
-                var before = visibleText[..visCursor];
-                var after = visCursor < visibleText.Length ? visibleText[visCursor..] : "";
-                // When cursor is at end, add a space so the bracket layout matches the old block cursor
-                var cursorSpace = visCursor >= visibleText.Length ? " " : "";
+        var output = RenderInline(visibleText, visCursor, globalColors, resetToGlobal,
+            fillBg, cursorFg, cursorBg, selFg, selBg, predictionFg, predictionBg, context,
+            visSelStart, visSelEnd);
 
-                ScreenCursorX = Bounds.X + DisplayWidth.GetStringWidth(leftBracket) + DisplayWidth.GetStringWidth(before);
-                ScreenCursorY = Bounds.Y;
-
-                output = $"{globalColors}{leftBracket}{before}{after}{cursorSpace}{rightBracket}";
-            }
-        }
-        else if (IsHovered && context.MouseX >= 0 && context.MouseY >= 0)
-        {
-            // Hover renders text normally — the native terminal mouse cursor handles
-            // showing the cursor shape at the mouse position.
-            output = $"{globalColors}{leftBracket}{visibleText}{rightBracket}";
-        }
-        else
-        {
-            output = $"{globalColors}{leftBracket}{visibleText}{rightBracket}{resetToGlobal}";
-        }
-        
         // Use clipped rendering when a layout provider is active
         if (context.CurrentLayoutProvider != null)
         {
@@ -1282,10 +1491,11 @@ public sealed class TextBoxNode : Hex1bNode
     }
 
     /// <summary>
-    /// Renders the text box in fill mode: no brackets, background-filled to the measured width.
-    /// Text and cursor positions are already adjusted for the viewport.
+    /// Renders the single-line text box: background-filled, no bookend
+    /// characters, with optional inline prediction overlay drawn after the
+    /// cursor in the prediction colors.
     /// </summary>
-    private string RenderFillMode(
+    private string RenderInline(
         string text,
         int cursor,
         string globalColors,
@@ -1295,14 +1505,41 @@ public sealed class TextBoxNode : Hex1bNode
         Hex1bColor cursorBg,
         Hex1bColor selFg,
         Hex1bColor selBg,
+        Hex1bColor predictionFg,
+        Hex1bColor predictionBg,
         Hex1bRenderContext context,
         int visSelStart = 0,
         int visSelEnd = 0)
     {
         var measuredWidth = Bounds.Width;
         var textDisplayWidth = DisplayWidth.GetStringWidth(text);
-        var padding = Math.Max(0, measuredWidth - textDisplayWidth);
         var fillBgAnsi = fillBg.ToBackgroundAnsi();
+
+        // Resolve the (possibly clipped) inline prediction overlay. Only valid
+        // when focused, no selection, cursor at end of *real* buffer, and the
+        // visible slice already contains the whole buffer.
+        string? predictionOverlay = null;
+        var canShowPrediction =
+            IsFocused
+            && !string.IsNullOrEmpty(CurrentPrediction)
+            && !State.HasSelection
+            && State.CursorPosition == State.Text.Length
+            && cursor == text.Length;
+
+        if (canShowPrediction)
+        {
+            var remaining = Math.Max(0, measuredWidth - textDisplayWidth);
+            if (remaining > 0)
+            {
+                predictionOverlay = ClipToDisplayWidth(CurrentPrediction!, remaining);
+            }
+        }
+
+        var predictionDisplayWidth = predictionOverlay is null ? 0 : DisplayWidth.GetStringWidth(predictionOverlay);
+        var padding = Math.Max(0, measuredWidth - textDisplayWidth - predictionDisplayWidth);
+        var predictionFgAnsi = predictionFg.ToForegroundAnsi();
+        var predictionBgAnsi = predictionBg.ToBackgroundAnsi();
+        var padStr = padding > 0 ? new string(' ', padding) : "";
 
         if (IsFocused)
         {
@@ -1312,40 +1549,53 @@ public sealed class TextBoxNode : Hex1bNode
                 var selected = text[visSelStart..visSelEnd];
                 var afterSel = text[visSelEnd..];
 
-                // Pad after the text to fill the measured width.
-                // No cursor space adjustment needed — the selection highlight covers
-                // the cursor position without adding an extra character.
-                var padStr = new string(' ', Math.Max(0, padding));
-
+                // Selection rendering masks the cursor cell — predictions are
+                // suppressed when there's a selection so no overlay here.
                 return $"{globalColors}{fillBgAnsi}{beforeSel}{selFg.ToForegroundAnsi()}{selBg.ToBackgroundAnsi()}{selected}{resetToGlobal}{fillBgAnsi}{afterSel}{padStr}{resetToGlobal}";
             }
-            else
+
+            // Line caret: render the text, then the prediction (if any), and
+            // let the native terminal cursor sit between them.
+            var before = text[..cursor];
+            var after = cursor < text.Length ? text[cursor..] : "";
+
+            ScreenCursorX = Bounds.X + DisplayWidth.GetStringWidth(before);
+            ScreenCursorY = Bounds.Y;
+
+            if (predictionOverlay is not null)
             {
-                // Line caret: render the text normally and let the native terminal cursor
-                // show a blinking bar at the cursor position.
-                var before = text[..cursor];
-                var after = cursor < text.Length ? text[cursor..] : "";
-
-                // Record screen position for the native cursor
-                ScreenCursorX = Bounds.X + DisplayWidth.GetStringWidth(before);
-                ScreenCursorY = Bounds.Y;
-
-                var padStr = new string(' ', padding);
-                return $"{globalColors}{fillBgAnsi}{before}{after}{padStr}{resetToGlobal}";
+                return $"{globalColors}{fillBgAnsi}{before}{after}{predictionFgAnsi}{predictionBgAnsi}{predictionOverlay}{resetToGlobal}{fillBgAnsi}{padStr}{resetToGlobal}";
             }
+
+            return $"{globalColors}{fillBgAnsi}{before}{after}{padStr}{resetToGlobal}";
         }
-        else if (IsHovered && context.MouseX >= 0 && context.MouseY >= 0)
-        {
-            // Hover renders text normally — the native terminal mouse cursor handles
-            // showing the cursor shape at the mouse position.
-            var padStr = new string(' ', padding);
-            return $"{globalColors}{fillBgAnsi}{text}{padStr}{resetToGlobal}";
-        }
-        else
-        {
-            var padStr = new string(' ', padding);
-            return $"{globalColors}{fillBgAnsi}{text}{padStr}{resetToGlobal}";
-        }
+
+        // Unfocused — no cursor, no prediction.
+        return $"{globalColors}{fillBgAnsi}{text}{padStr}{resetToGlobal}";
     }
-    
+
+    /// <summary>
+    /// Returns a prefix of <paramref name="value"/> whose total display width
+    /// is at most <paramref name="maxDisplayWidth"/>. Wide graphemes are kept
+    /// whole — they're either fully included or omitted, never split.
+    /// </summary>
+    private static string ClipToDisplayWidth(string value, int maxDisplayWidth)
+    {
+        if (maxDisplayWidth <= 0 || string.IsNullOrEmpty(value)) return string.Empty;
+
+        var enumerator = System.Globalization.StringInfo.GetTextElementEnumerator(value);
+        var consumed = 0;
+        var lastFitEnd = 0;
+        while (enumerator.MoveNext())
+        {
+            var grapheme = (string)enumerator.Current;
+            var width = DisplayWidth.GetGraphemeWidth(grapheme);
+            if (consumed + width > maxDisplayWidth)
+                break;
+            consumed += width;
+            lastFitEnd = enumerator.ElementIndex + grapheme.Length;
+        }
+        return lastFitEnd >= value.Length ? value : value[..lastFitEnd];
+    }
+
 }

--- a/src/Hex1b/Theming/TextBoxTheme.cs
+++ b/src/Hex1b/Theming/TextBoxTheme.cs
@@ -50,17 +50,15 @@ public static class TextBoxTheme
     /// the right of the cursor. Defaults to <see cref="Hex1bColor.DarkGray"/>
     /// so the suggestion sits clearly behind the user's typed text.
     /// </summary>
-    /// <remarks>
-    /// Set this via <c>ThemePanelWidget</c> or directly on the application
-    /// theme to restyle predictions, e.g. with an italic/foreground color combo.
-    /// </remarks>
     public static readonly Hex1bThemeElement<Hex1bColor> PredictionForegroundColor =
         new($"{nameof(TextBoxTheme)}.{nameof(PredictionForegroundColor)}", () => Hex1bColor.DarkGray);
 
     /// <summary>
     /// Background color of the inline prediction text. Defaults to
-    /// <see cref="Hex1bColor.Default"/> so the prediction inherits the
-    /// textbox background fill.
+    /// <see cref="Hex1bColor.Default"/>, which the renderer treats as
+    /// "follow the textbox field fill background" so the suggestion blends
+    /// into the input surface. Set to any concrete color to draw the
+    /// prediction on a contrasting band instead.
     /// </summary>
     public static readonly Hex1bThemeElement<Hex1bColor> PredictionBackgroundColor =
         new($"{nameof(TextBoxTheme)}.{nameof(PredictionBackgroundColor)}", () => Hex1bColor.Default);

--- a/src/Hex1b/Theming/TextBoxTheme.cs
+++ b/src/Hex1b/Theming/TextBoxTheme.cs
@@ -3,6 +3,12 @@ namespace Hex1b.Theming;
 /// <summary>
 /// Theme elements for TextBox widgets.
 /// </summary>
+/// <remarks>
+/// As of the prediction-input refresh, the TextBox no longer renders the
+/// classic <c>[…]</c> bookends. The fill/background-based rendering that
+/// used to be opt-in via <c>UseFillMode</c> is now the only style. If you
+/// need a bracketed look, render brackets in surrounding widgets.
+/// </remarks>
 public static class TextBoxTheme
 {
     public static readonly Hex1bThemeElement<Hex1bColor> ForegroundColor = 
@@ -25,36 +31,37 @@ public static class TextBoxTheme
     
     public static readonly Hex1bThemeElement<Hex1bColor> SelectionBackgroundColor = 
         new($"{nameof(TextBoxTheme)}.{nameof(SelectionBackgroundColor)}", () => Hex1bColor.White);
-    
-    public static readonly Hex1bThemeElement<Hex1bColor> HoverCursorForegroundColor = 
-        new($"{nameof(TextBoxTheme)}.{nameof(HoverCursorForegroundColor)}", () => Hex1bColor.Default);
-    
-    public static readonly Hex1bThemeElement<Hex1bColor> HoverCursorBackgroundColor = 
-        new($"{nameof(TextBoxTheme)}.{nameof(HoverCursorBackgroundColor)}", () => Hex1bColor.DarkGray);
-    
-    public static readonly Hex1bThemeElement<string> LeftBracket = 
-        new($"{nameof(TextBoxTheme)}.{nameof(LeftBracket)}", () => "[");
-    
-    public static readonly Hex1bThemeElement<string> RightBracket = 
-        new($"{nameof(TextBoxTheme)}.{nameof(RightBracket)}", () => "]");
 
     /// <summary>
-    /// When true, renders the text box with a background fill instead of brackets.
-    /// This mode is typically enabled by form containers via ThemePanel.
-    /// </summary>
-    public static readonly Hex1bThemeElement<bool> UseFillMode = 
-        new($"{nameof(TextBoxTheme)}.{nameof(UseFillMode)}", () => false);
-
-    /// <summary>
-    /// Background color used in fill mode to delineate the text area.
+    /// Background color used to delineate the text area when the textbox is unfocused.
     /// </summary>
     public static readonly Hex1bThemeElement<Hex1bColor> FillBackgroundColor = 
         new($"{nameof(TextBoxTheme)}.{nameof(FillBackgroundColor)}", () => Hex1bColor.FromRgb(40, 40, 40));
 
     /// <summary>
-    /// Background color used in fill mode when the text box has focus.
+    /// Background color used when the text box has focus.
     /// Slightly lighter than <see cref="FillBackgroundColor"/> to indicate active input.
     /// </summary>
     public static readonly Hex1bThemeElement<Hex1bColor> FocusedFillBackgroundColor = 
         new($"{nameof(TextBoxTheme)}.{nameof(FocusedFillBackgroundColor)}", () => Hex1bColor.FromRgb(55, 55, 55));
+
+    /// <summary>
+    /// Foreground color of the inline prediction (suggestion) text rendered to
+    /// the right of the cursor. Defaults to <see cref="Hex1bColor.DarkGray"/>
+    /// so the suggestion sits clearly behind the user's typed text.
+    /// </summary>
+    /// <remarks>
+    /// Set this via <c>ThemePanelWidget</c> or directly on the application
+    /// theme to restyle predictions, e.g. with an italic/foreground color combo.
+    /// </remarks>
+    public static readonly Hex1bThemeElement<Hex1bColor> PredictionForegroundColor =
+        new($"{nameof(TextBoxTheme)}.{nameof(PredictionForegroundColor)}", () => Hex1bColor.DarkGray);
+
+    /// <summary>
+    /// Background color of the inline prediction text. Defaults to
+    /// <see cref="Hex1bColor.Default"/> so the prediction inherits the
+    /// textbox background fill.
+    /// </summary>
+    public static readonly Hex1bThemeElement<Hex1bColor> PredictionBackgroundColor =
+        new($"{nameof(TextBoxTheme)}.{nameof(PredictionBackgroundColor)}", () => Hex1bColor.Default);
 }

--- a/src/Hex1b/Theming/TextBoxTheme.cs
+++ b/src/Hex1b/Theming/TextBoxTheme.cs
@@ -47,11 +47,12 @@ public static class TextBoxTheme
 
     /// <summary>
     /// Foreground color of the inline prediction (suggestion) text rendered to
-    /// the right of the cursor. Defaults to <see cref="Hex1bColor.DarkGray"/>
-    /// so the suggestion sits clearly behind the user's typed text.
+    /// the right of the cursor. Defaults to <see cref="Hex1bColor.Gray"/> — a
+    /// monochrome mid-gray that stays clearly visible against typical field
+    /// backgrounds while remaining distinct from regular typed text.
     /// </summary>
     public static readonly Hex1bThemeElement<Hex1bColor> PredictionForegroundColor =
-        new($"{nameof(TextBoxTheme)}.{nameof(PredictionForegroundColor)}", () => Hex1bColor.DarkGray);
+        new($"{nameof(TextBoxTheme)}.{nameof(PredictionForegroundColor)}", () => Hex1bColor.Gray);
 
     /// <summary>
     /// Background color of the inline prediction text. Defaults to

--- a/src/Hex1b/Widgets/FormTextFieldWidget.cs
+++ b/src/Hex1b/Widgets/FormTextFieldWidget.cs
@@ -295,12 +295,8 @@ public sealed record FormTextFieldWidget : Hex1bWidget
                 }
             });
 
-        // Wrap in ThemePanel to enable fill mode rendering
-        Hex1bWidget inputWidget = new ThemePanelWidget(
-            t => t.Set(Theming.TextBoxTheme.UseFillMode, true),
-            textBox);
-
-        node.InputChild = await context.ReconcileChildAsync(node.InputChild, inputWidget, node);
+        // The TextBox already renders with the inline fill style by default.
+        node.InputChild = await context.ReconcileChildAsync(node.InputChild, textBox, node);
 
         // Reconcile adornment children based on current visibility state.
         // On first reconcile (or when adornment count changes), trigger evaluation.

--- a/src/Hex1b/Widgets/Hex1bWidget.cs
+++ b/src/Hex1b/Widgets/Hex1bWidget.cs
@@ -66,6 +66,21 @@ public abstract record Hex1bWidget
     public SizeHint? HeightHint { get; init; }
 
     /// <summary>
+    /// Per-widget default for <see cref="WidthHint"/> when the user hasn't
+    /// explicitly set one. Returning a non-null value lets a widget opt into
+    /// "expand to fill" or any other sizing behavior without forcing every
+    /// caller to chain <c>.FillWidth()</c>. The user-supplied
+    /// <see cref="WidthHint"/> always wins over this default.
+    /// </summary>
+    protected internal virtual SizeHint? DefaultWidthHint => null;
+
+    /// <summary>
+    /// Per-widget default for <see cref="HeightHint"/>. See
+    /// <see cref="DefaultWidthHint"/> for the rationale.
+    /// </summary>
+    protected internal virtual SizeHint? DefaultHeightHint => null;
+
+    /// <summary>
     /// A user-assigned name for this widget used as a tag value in per-node metrics.
     /// When per-node metrics are enabled, this name becomes a segment in the hierarchical
     /// metric path (e.g., <c>root.sidebar.orders</c>). If null, an auto-generated name

--- a/src/Hex1b/Widgets/TextBoxWidget.cs
+++ b/src/Hex1b/Widgets/TextBoxWidget.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using Hex1b.Events;
 using Hex1b.Input;
 using Hex1b.Nodes;
@@ -55,6 +56,10 @@ public sealed record TextBoxWidget(string? Text = null) : Hex1bWidget,
     public static readonly ActionId SelectDown = new($"{nameof(TextBoxWidget)}.{nameof(SelectDown)}");
     /// <summary>Rebindable action: Insert a newline (multiline only).</summary>
     public static readonly ActionId InsertNewline = new($"{nameof(TextBoxWidget)}.{nameof(InsertNewline)}");
+    /// <summary>Rebindable action: Accept the inline prediction (default: Right Arrow at end of buffer).</summary>
+    public static readonly ActionId AcceptPrediction = new($"{nameof(TextBoxWidget)}.{nameof(AcceptPrediction)}");
+    /// <summary>Rebindable action: Dismiss the inline prediction (default: Escape while a prediction is showing).</summary>
+    public static readonly ActionId DismissPrediction = new($"{nameof(TextBoxWidget)}.{nameof(DismissPrediction)}");
 
     /// <summary>
     /// Internal handler for text changed events.
@@ -172,6 +177,47 @@ public sealed record TextBoxWidget(string? Text = null) : Hex1bWidget,
     /// </summary>
     public TextBoxWidget Height(int lines)
         => this with { HeightValue = lines };
+
+    /// <summary>
+    /// Internal predictor callback. Invoked after each typed character (when
+    /// the cursor is at the end of the buffer) with the current text, and
+    /// expected to return the suggested completion text or <c>null</c> for
+    /// no suggestion. The token is signalled when a newer keystroke arrives.
+    /// </summary>
+    internal Func<string, CancellationToken, Task<string?>>? PredictHandler { get; init; }
+
+    /// <summary>
+    /// Internal debounce window for <see cref="PredictHandler"/>. When greater
+    /// than zero, the predictor is only invoked after the user pauses typing
+    /// for this duration. <see cref="TimeSpan.Zero"/> (the default) invokes
+    /// immediately.
+    /// </summary>
+    internal TimeSpan PredictionDebounceValue { get; init; }
+
+    /// <summary>
+    /// Configures an inline predictive-completion provider. After the user
+    /// types a character (and only when the cursor is at the end of the
+    /// buffer), <paramref name="predictor"/> is invoked with the current
+    /// text. If it returns a non-null, non-empty string, that text is shown
+    /// inline after the cursor in the prediction colors. The user accepts
+    /// the suggestion with <see cref="AcceptPrediction"/> (Right Arrow by
+    /// default) or dismisses it with <see cref="DismissPrediction"/>
+    /// (Escape by default). The cancellation token is signalled when the
+    /// user types another character before the predictor returns, so an
+    /// expensive predictor can short-circuit.
+    /// </summary>
+    public TextBoxWidget Predict(Func<string, CancellationToken, Task<string?>> predictor)
+        => this with { PredictHandler = predictor };
+
+    /// <summary>
+    /// Configures an inline predictive-completion provider with a debounce.
+    /// The predictor is only invoked after the user pauses typing for
+    /// <paramref name="debounce"/>; intermediate keystrokes restart the
+    /// timer and cancel any in-flight request. Use this when the predictor
+    /// is expensive (e.g. an LLM round-trip).
+    /// </summary>
+    public TextBoxWidget Predict(Func<string, CancellationToken, Task<string?>> predictor, TimeSpan debounce)
+        => this with { PredictHandler = predictor, PredictionDebounceValue = debounce };
 
     /// <summary>
     /// Externally-supplied state instance. When set, the textbox becomes a
@@ -314,6 +360,16 @@ public sealed record TextBoxWidget(string? Text = null) : Hex1bWidget,
         node.MaxLines = MaxLinesValue;
         node.State.IsMultiline = IsMultilineValue;
         node.State.MaxLines = MaxLinesValue;
+
+        // Sync predictor configuration. Removing the handler also clears any
+        // in-flight prediction so the overlay disappears on the next render.
+        var predictorChanged = !ReferenceEquals(node.Predictor, PredictHandler);
+        node.Predictor = PredictHandler;
+        node.PredictionDebounce = PredictionDebounceValue;
+        if (predictorChanged && PredictHandler is null)
+        {
+            node.ClearPrediction();
+        }
 
         return Task.FromResult<Hex1bNode>(node);
     }

--- a/src/Hex1b/Widgets/TextBoxWidget.cs
+++ b/src/Hex1b/Widgets/TextBoxWidget.cs
@@ -1,6 +1,7 @@
 using System.Threading;
 using Hex1b.Events;
 using Hex1b.Input;
+using Hex1b.Layout;
 using Hex1b.Nodes;
 
 namespace Hex1b.Widgets;
@@ -246,6 +247,14 @@ public sealed record TextBoxWidget(string? Text = null) : Hex1bWidget,
     /// </remarks>
     public TextBoxWidget State(TextBoxState state)
         => this with { InjectedState = state };
+
+    /// <summary>
+    /// Text boxes default to filling their parent's available width — text
+    /// input feels best when the editable surface is wide rather than
+    /// hugging the content. Override with <c>.ContentWidth()</c>,
+    /// <c>.FixedWidth(n)</c>, or any explicit <c>WidthHint</c>.
+    /// </summary>
+    protected internal override SizeHint? DefaultWidthHint => SizeHint.Fill;
 
     internal override Task<Hex1bNode> ReconcileAsync(Hex1bNode? existingNode, ReconcileContext context)
     {

--- a/src/content/guide/composition.md
+++ b/src/content/guide/composition.md
@@ -564,7 +564,7 @@ public sealed record SlashCommandPromptWidget(IReadOnlyList<SlashCommand> Comman
     static Hex1bWidget BuildPromptRow(WidgetContext<VStackWidget> ctx, TextBoxWidget textbox)
         => ctx.HStack(h => [
             h.Text(" > "),
-            ctx.ThemePanel(t => t.Set(TextBoxTheme.UseFillMode, true), textbox).FillWidth(),
+            textbox.FillWidth(),
         ]);
 
     static Hex1bWidget BuildPalette(

--- a/src/content/guide/widgets/textbox.md
+++ b/src/content/guide/widgets/textbox.md
@@ -276,8 +276,7 @@ var theme = Hex1bTheme.Create()
     .Set(TextBoxTheme.CursorBackgroundColor, Hex1bColor.Yellow)
     .Set(TextBoxTheme.SelectionForegroundColor, Hex1bColor.White)
     .Set(TextBoxTheme.SelectionBackgroundColor, Hex1bColor.Blue)
-    .Set(TextBoxTheme.LeftBracket, "< ")
-    .Set(TextBoxTheme.RightBracket, " >");
+    .Set(TextBoxTheme.PredictionForegroundColor, Hex1bColor.DarkGray);
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithHex1bApp((app, options) =>
@@ -301,10 +300,8 @@ await terminal.RunAsync();
 | `CursorBackgroundColor` | `Hex1bColor` | White | Cursor background color |
 | `SelectionForegroundColor` | `Hex1bColor` | Black | Selected text color |
 | `SelectionBackgroundColor` | `Hex1bColor` | Cyan | Selection background |
-| `HoverCursorForegroundColor` | `Hex1bColor` | Default | Hover cursor text color |
-| `HoverCursorBackgroundColor` | `Hex1bColor` | DarkGray | Hover cursor background |
-| `LeftBracket` | `string` | `"["` | Left bracket decoration |
-| `RightBracket` | `string` | `"]"` | Right bracket decoration |
+| `PredictionForegroundColor` | `Hex1bColor` | DarkGray | Inline prediction text color |
+| `PredictionBackgroundColor` | `Hex1bColor` | Default | Inline prediction background color |
 
 ## Related Widgets
 

--- a/src/content/guide/widgets/textbox.md
+++ b/src/content/guide/widgets/textbox.md
@@ -266,6 +266,30 @@ Try it yourself—navigate through the text with arrow keys, delete some emoji, 
 
 <CodeBlock lang="csharp" :code="unicodeCode" command="dotnet run" example="textbox-unicode" exampleTitle="TextBox Widget - Unicode Support" />
 
+## Sizing
+
+By default, `TextBoxWidget` reports a `Fill` width hint, so it expands to
+take up whatever horizontal space its parent makes available — input feels
+best on a wide editable surface. Override that default the same way you
+would for any other widget:
+
+```csharp
+ctx.HStack(h => [
+    h.Text("Name:"),
+    h.TextBox(state.Name),                       // fills the rest of the row
+]);
+
+ctx.HStack(h => [
+    h.Text("Code:"),
+    h.TextBox(state.Code).FixedWidth(8),         // hugs an 8-cell field
+    h.Text(" "),
+    h.TextBox(state.Notes).ContentWidth(),       // sizes to its current text
+]);
+```
+
+Multi-line textboxes still default to fill width; height defaults to
+content (one line per visual line) unless you call `.Height(lines)`.
+
 ## Theming
 
 Customize TextBox appearance using theme elements:
@@ -301,7 +325,7 @@ await terminal.RunAsync();
 | `SelectionForegroundColor` | `Hex1bColor` | Black | Selected text color |
 | `SelectionBackgroundColor` | `Hex1bColor` | Cyan | Selection background |
 | `PredictionForegroundColor` | `Hex1bColor` | DarkGray | Inline prediction text color |
-| `PredictionBackgroundColor` | `Hex1bColor` | Default | Inline prediction background color |
+| `PredictionBackgroundColor` | `Hex1bColor` | Default | Inline prediction background. `Default` follows the field fill color; set explicitly to draw the suggestion on a contrasting band. |
 
 ## Related Widgets
 

--- a/src/content/guide/widgets/textbox.md
+++ b/src/content/guide/widgets/textbox.md
@@ -300,7 +300,7 @@ var theme = Hex1bTheme.Create()
     .Set(TextBoxTheme.CursorBackgroundColor, Hex1bColor.Yellow)
     .Set(TextBoxTheme.SelectionForegroundColor, Hex1bColor.White)
     .Set(TextBoxTheme.SelectionBackgroundColor, Hex1bColor.Blue)
-    .Set(TextBoxTheme.PredictionForegroundColor, Hex1bColor.DarkGray);
+    .Set(TextBoxTheme.PredictionForegroundColor, Hex1bColor.LightGray);
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithHex1bApp((app, options) =>
@@ -324,7 +324,7 @@ await terminal.RunAsync();
 | `CursorBackgroundColor` | `Hex1bColor` | White | Cursor background color |
 | `SelectionForegroundColor` | `Hex1bColor` | Black | Selected text color |
 | `SelectionBackgroundColor` | `Hex1bColor` | Cyan | Selection background |
-| `PredictionForegroundColor` | `Hex1bColor` | DarkGray | Inline prediction text color |
+| `PredictionForegroundColor` | `Hex1bColor` | Gray | Inline prediction text color. Monochrome by default for a ghost-text look; theme to any color to brand suggestions. |
 | `PredictionBackgroundColor` | `Hex1bColor` | Default | Inline prediction background. `Default` follows the field fill color; set explicitly to draw the suggestion on a contrasting band. |
 
 ## Related Widgets

--- a/tests/Hex1b.Tests/Composition/SlashCommandIntegrationTests.cs
+++ b/tests/Hex1b.Tests/Composition/SlashCommandIntegrationTests.cs
@@ -204,10 +204,10 @@ public class SlashCommandIntegrationTests
                         .Select((cmd, i) => (Hex1bWidget)b.Text(
                             (i == state.SelectedIndex ? " > " : "   ") + "/" + cmd.Name + "  " + cmd.Description))
                         .ToArray()).Title("Commands");
-                    return [palette, v.ThemePanel(t => t.Set(Theming.TextBoxTheme.UseFillMode, true), tb)];
+                    return [palette, tb];
                 }
 
-                return [v.ThemePanel(t => t.Set(Theming.TextBoxTheme.UseFillMode, true), tb)];
+                return [tb];
             });
         }
     }

--- a/tests/Hex1b.Tests/TextBoxNodeTests.cs
+++ b/tests/Hex1b.Tests/TextBoxNodeTests.cs
@@ -20,8 +20,8 @@ public class TextBoxNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        // "[hello]" = 2 brackets + 5 chars = 7
-        Assert.Equal(7, size.Width);
+        // Bracketless inline render: "hello" = 5 chars
+        Assert.Equal(5, size.Width);
         Assert.Equal(1, size.Height);
     }
 
@@ -32,8 +32,8 @@ public class TextBoxNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        // "[ ]" = 2 brackets + 1 min char = 3
-        Assert.Equal(3, size.Width);
+        // Empty text still measures 1 so the cursor cell is visible.
+        Assert.Equal(1, size.Width);
     }
 
     [Fact]
@@ -43,8 +43,8 @@ public class TextBoxNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        // 30 chars + 2 brackets = 32
-        Assert.Equal(32, size.Width);
+        // 30 chars
+        Assert.Equal(30, size.Width);
         Assert.Equal(1, size.Height);
     }
 
@@ -66,8 +66,8 @@ public class TextBoxNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        // "[😀]" = 2 brackets + 2 display width for emoji = 4
-        Assert.Equal(4, size.Width);
+        // 2 display width for emoji
+        Assert.Equal(2, size.Width);
     }
 
     [Fact]
@@ -78,8 +78,8 @@ public class TextBoxNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        // "[中文]" = 2 brackets + 4 display width = 6
-        Assert.Equal(6, size.Width);
+        // 4 display width
+        Assert.Equal(4, size.Width);
     }
 
     [Fact]
@@ -90,8 +90,7 @@ public class TextBoxNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        // "[Hi😀]" = 2 brackets + 4 display width = 6
-        Assert.Equal(6, size.Width);
+        Assert.Equal(4, size.Width);
     }
 
     [Fact]
@@ -102,8 +101,7 @@ public class TextBoxNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        // "[👨‍👩‍👧]" = 2 brackets + 2 display width = 4
-        Assert.Equal(4, size.Width);
+        Assert.Equal(2, size.Width);
     }
 
     #endregion
@@ -124,14 +122,16 @@ public class TextBoxNodeTests
         };
 
         node.Render(context);
-        
+
         var snapshot = await new Hex1bTerminalInputSequenceBuilder()
-            .WaitUntil(s => s.ContainsText("[test]"), TimeSpan.FromSeconds(5), "bracketed text visible")
+            .WaitUntil(s => s.ContainsText("test"), TimeSpan.FromSeconds(5), "text visible")
             .Capture("final")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Contains("[test]", snapshot.GetLineTrimmed(0));
+        Assert.Contains("test", snapshot.GetLineTrimmed(0));
+        // No bookend brackets in the new inline rendering.
+        Assert.DoesNotContain("[test]", snapshot.GetLineTrimmed(0));
     }
 
     [Fact]
@@ -148,14 +148,16 @@ public class TextBoxNodeTests
         };
 
         node.Render(context);
-        
+
+        // With no brackets, an empty unfocused textbox renders as a single
+        // background-filled cell (the measured min width).
         var snapshot = await new Hex1bTerminalInputSequenceBuilder()
-            .WaitUntil(s => s.ContainsText("[]"), TimeSpan.FromSeconds(5), "empty brackets visible")
             .Capture("final")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Contains("[]", snapshot.GetLineTrimmed(0));
+        Assert.DoesNotContain("[", snapshot.GetLineTrimmed(0));
+        Assert.DoesNotContain("]", snapshot.GetLineTrimmed(0));
     }
 
     [Fact]
@@ -172,14 +174,14 @@ public class TextBoxNodeTests
         };
 
         node.Render(context);
-        
+
         var snapshot = await new Hex1bTerminalInputSequenceBuilder()
-            .WaitUntil(s => s.ContainsText("[This is a longer piece of text]"), TimeSpan.FromSeconds(5), "long text visible")
+            .WaitUntil(s => s.ContainsText("This is a longer piece of text"), TimeSpan.FromSeconds(5), "long text visible")
             .Capture("final")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Contains("[This is a longer piece of text]", snapshot.GetLineTrimmed(0));
+        Assert.Contains("This is a longer piece of text", snapshot.GetLineTrimmed(0));
     }
 
     #endregion
@@ -288,17 +290,17 @@ public class TextBoxNodeTests
         node.State.CursorPosition = 0;
 
         node.Render(context);
-        
-        // Wait for brackets to appear and capture snapshot atomically
+
+        // No bookend brackets in the new inline rendering — empty focused
+        // textbox is just a single background-filled cell with the native
+        // cursor positioned at column 0.
         var snapshot = await new Hex1bTerminalInputSequenceBuilder()
-            .WaitUntil(s => s.ContainsText("[") && s.ContainsText("]"), TimeSpan.FromSeconds(5), "brackets visible")
             .Capture("final")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-        
-        // Line caret: brackets visible, native cursor positioned between them
-        Assert.Contains("[", snapshot.GetLineTrimmed(0));
-        Assert.Contains("]", snapshot.GetLineTrimmed(0));
+
+        Assert.DoesNotContain("[", snapshot.GetLineTrimmed(0));
+        Assert.DoesNotContain("]", snapshot.GetLineTrimmed(0));
         Assert.True(node.ScreenCursorX >= 0, "ScreenCursorX should be set for line caret in empty text box");
     }
 
@@ -702,12 +704,13 @@ public class TextBoxNodeTests
         node.IsFocused = true;
         node.Arrange(new Rect(0, 0, 10, 1));
 
-        // Click at localX=3, which is "ll" in "[hello]" (0='[', 1='h', 2='e', 3='l')
+        // Bracketless inline rendering: localX maps directly to a column in
+        // the visible text. localX=3 is the 4th cell ('l' at position 3).
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 3, 0, Hex1bModifiers.None, ClickCount: 1);
         var result = node.HandleMouseClick(3, 0, mouseEvent);
 
         Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(2, node.State.CursorPosition); // Position after 'he' (click on 'l')
+        Assert.Equal(3, node.State.CursorPosition);
     }
 
     [Fact]
@@ -717,12 +720,12 @@ public class TextBoxNodeTests
         node.IsFocused = true;
         node.Arrange(new Rect(0, 0, 10, 1));
 
-        // Click at localX=1, which is 'h' in "[hello]" (0='[', 1='h')
-        var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 1, 0, Hex1bModifiers.None, ClickCount: 1);
-        var result = node.HandleMouseClick(1, 0, mouseEvent);
+        // localX=0 is the very first cell ('h') — cursor lands before it.
+        var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 0, 0, Hex1bModifiers.None, ClickCount: 1);
+        var result = node.HandleMouseClick(0, 0, mouseEvent);
 
         Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(0, node.State.CursorPosition); // Click on first char positions at start
+        Assert.Equal(0, node.State.CursorPosition);
     }
 
     [Fact]
@@ -732,22 +735,23 @@ public class TextBoxNodeTests
         node.IsFocused = true;
         node.Arrange(new Rect(0, 0, 10, 1));
 
-        // Click at localX=6, which is ']' in "[hello]" (past the text)
+        // Click past the end of the text — cursor clamps to the end of "hello".
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 6, 0, Hex1bModifiers.None, ClickCount: 1);
         var result = node.HandleMouseClick(6, 0, mouseEvent);
 
         Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(5, node.State.CursorPosition); // End of "hello"
+        Assert.Equal(5, node.State.CursorPosition);
     }
 
     [Fact]
     public async Task HandleMouseClick_OnBracket_PositionsCursorAtStart()
     {
+        // Brackets are gone — this test now just confirms clicking at column 0
+        // positions the cursor at the start, same as HandleMouseClick_AtStart.
         var node = new TextBoxNode { Text = "hello" };
         node.IsFocused = true;
         node.Arrange(new Rect(0, 0, 10, 1));
 
-        // Click at localX=0, which is '[' in "[hello]"
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 0, 0, Hex1bModifiers.None, ClickCount: 1);
         var result = node.HandleMouseClick(0, 0, mouseEvent);
 
@@ -808,14 +812,14 @@ public class TextBoxNodeTests
         node.IsFocused = true;
         node.Arrange(new Rect(0, 0, 10, 1));
 
-        // Click at localX=3 which is after the emoji (column 1-2), on 'a' (column 3)
-        // "[😀ab]" - localX: 0='[', 1-2='😀', 3='a', 4='b', 5=']'
+        // Bracketless layout: localX 0-1 = emoji, 2 = 'a', 3 = 'b'.
+        // Click at localX=3 lands on 'b'; cursor lands before 'b' (string
+        // index 3, since the emoji occupies 2 chars).
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 3, 0, Hex1bModifiers.None, ClickCount: 1);
         var result = node.HandleMouseClick(3, 0, mouseEvent);
 
         Assert.Equal(InputResult.Handled, result);
-        // After emoji (which is 2 chars in string), before 'a'
-        Assert.Equal(2, node.State.CursorPosition);
+        Assert.Equal(3, node.State.CursorPosition);
     }
 
     [Fact]
@@ -826,14 +830,14 @@ public class TextBoxNodeTests
         node.IsFocused = true;
         node.Arrange(new Rect(0, 0, 10, 1));
 
-        // Click at localX=1 (first half of emoji) "[😀]"
-        var mouseEvent1 = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 1, 0, Hex1bModifiers.None, ClickCount: 1);
-        node.HandleMouseClick(1, 0, mouseEvent1);
+        // Click at localX=0 (first half of emoji)
+        var mouseEvent1 = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 0, 0, Hex1bModifiers.None, ClickCount: 1);
+        node.HandleMouseClick(0, 0, mouseEvent1);
         Assert.Equal(0, node.State.CursorPosition); // Before emoji
 
-        // Click at localX=2 (second half of emoji)
-        var mouseEvent2 = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 2, 0, Hex1bModifiers.None, ClickCount: 1);
-        node.HandleMouseClick(2, 0, mouseEvent2);
+        // Click at localX=1 (second half of emoji) — past the midpoint
+        var mouseEvent2 = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 1, 0, Hex1bModifiers.None, ClickCount: 1);
+        node.HandleMouseClick(1, 0, mouseEvent2);
         Assert.Equal(2, node.State.CursorPosition); // After emoji (emoji is 2 chars in string)
     }
 
@@ -1635,7 +1639,7 @@ public class TextBoxNodeTests
         var snapshot = await new Hex1bTerminalInputSequenceBuilder()
             .WaitUntil(s => s.ContainsText("pqrst"), TimeSpan.FromSeconds(5))
             .Key(Hex1bKey.Home)
-            .WaitUntil(s => s.ContainsText("[abcdefghijklm"), TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("abcdefghijklmno"), TimeSpan.FromSeconds(5))
             .Capture("after_home")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
@@ -1646,7 +1650,7 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("[abcdefghijklm"));
+        Assert.True(snapshot.ContainsText("abcdefghijklmno"));
     }
 
     [Fact]
@@ -1664,7 +1668,7 @@ public class TextBoxNodeTests
         var runTask = app.RunAsync(TestContext.Current.CancellationToken);
 
         var snapshot = await new Hex1bTerminalInputSequenceBuilder()
-            .WaitUntil(s => s.ContainsText("[hello"), TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("hello"), TimeSpan.FromSeconds(5))
             .Capture("final")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
@@ -1675,7 +1679,7 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("[hello"));
+        Assert.True(snapshot.ContainsText("hello"));
     }
 
     [Fact]
@@ -1692,11 +1696,11 @@ public class TextBoxNodeTests
 
         var runTask = app.RunAsync(TestContext.Current.CancellationToken);
 
-        // Wait for empty textbox (renders as "[ ]" with cursor space), then type 12 characters (viewport = 8 in bracket mode)
+        // Type 12 characters into a 10-column viewport — the visible text
+        // should be the trailing portion that fits.
         var snapshot = await new Hex1bTerminalInputSequenceBuilder()
-            .WaitUntil(s => s.ContainsText("[ ]"), TimeSpan.FromSeconds(5))
             .Type("abcdefghijkl")
-            .WaitUntil(s => s.ContainsText("fghijkl"), TimeSpan.FromSeconds(5))
+            .WaitUntil(s => s.ContainsText("ijkl"), TimeSpan.FromSeconds(5))
             .Capture("after_typing")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
@@ -1707,9 +1711,7 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        // After typing 12 chars in 8-char viewport, should see the end of the text
-        // ScrollOffset = 12 - 8 + 1 = 5, visible text = "fghijkl"
-        Assert.True(snapshot.ContainsText("fghijkl"));
+        Assert.True(snapshot.ContainsText("ijkl"));
     }
 
     #endregion

--- a/tests/Hex1b.Tests/TextBoxPredictionTests.cs
+++ b/tests/Hex1b.Tests/TextBoxPredictionTests.cs
@@ -1,0 +1,325 @@
+using Hex1b;
+using Hex1b.Input;
+using Hex1b.Layout;
+using Hex1b.Nodes;
+using Hex1b.Widgets;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Tests for the inline predictive-completion behavior of <see cref="TextBoxNode"/>.
+/// </summary>
+public class TextBoxPredictionTests
+{
+    private static TextBoxNode CreateNode(
+        Func<string, CancellationToken, Task<string?>>? predictor = null,
+        TimeSpan debounce = default,
+        bool focused = true)
+    {
+        var node = new TextBoxNode
+        {
+            Text = "",
+            IsFocused = focused,
+            Predictor = predictor,
+            PredictionDebounce = debounce,
+        };
+        return node;
+    }
+
+    /// <summary>
+    /// Drives the node through one keystroke, then waits up to
+    /// <paramref name="timeout"/> for the predictor's async result to be
+    /// applied. The node only mutates <c>CurrentPrediction</c> from the
+    /// predictor task, so direct equality checks would race without this.
+    /// </summary>
+    private static async Task<string?> WaitForPredictionAsync(TextBoxNode node, TimeSpan timeout, Func<string?, bool>? predicate = null)
+    {
+        predicate ??= p => p is not null;
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (predicate(node.CurrentPrediction)) return node.CurrentPrediction;
+            await Task.Delay(10, TestContext.Current.CancellationToken);
+        }
+        return node.CurrentPrediction;
+    }
+
+    private static Hex1bKeyEvent CharKey(char ch) => new((Hex1bKey)char.ToUpperInvariant(ch), ch, Hex1bModifiers.None);
+
+    [Fact]
+    public async Task Typing_AtEndOfBuffer_TriggersPredictor()
+    {
+        var calls = 0;
+        string? observed = null;
+        var node = CreateNode((text, _) =>
+        {
+            Interlocked.Increment(ref calls);
+            observed = text;
+            return Task.FromResult<string?>("world");
+        });
+
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('h'), null, null, TestContext.Current.CancellationToken);
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('e'), null, null, TestContext.Current.CancellationToken);
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('l'), null, null, TestContext.Current.CancellationToken);
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('l'), null, null, TestContext.Current.CancellationToken);
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('o'), null, null, TestContext.Current.CancellationToken);
+
+        var prediction = await WaitForPredictionAsync(node, TimeSpan.FromSeconds(2));
+
+        Assert.Equal("world", prediction);
+        Assert.Equal("hello", observed);
+        Assert.True(calls >= 1);
+    }
+
+    [Fact]
+    public async Task Typing_WithCursorInMiddle_DoesNotTriggerPredictor()
+    {
+        var calls = 0;
+        var node = new TextBoxNode
+        {
+            Text = "abcd",
+            IsFocused = true,
+            Predictor = (_, _) => { Interlocked.Increment(ref calls); return Task.FromResult<string?>("zzz"); },
+        };
+        node.State.CursorPosition = 2;
+
+        // Typing in the middle of the buffer should not request a prediction.
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('X'), null, null, TestContext.Current.CancellationToken);
+
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, calls);
+        Assert.Null(node.CurrentPrediction);
+    }
+
+    [Fact]
+    public async Task LeftArrow_ClearsActivePrediction()
+    {
+        var node = CreateNode((_, _) => Task.FromResult<string?>("xyz"));
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('a'), null, null, TestContext.Current.CancellationToken);
+        await WaitForPredictionAsync(node, TimeSpan.FromSeconds(2));
+
+        Assert.Equal("xyz", node.CurrentPrediction);
+
+        await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
+
+        Assert.Null(node.CurrentPrediction);
+    }
+
+    [Fact]
+    public async Task Backspace_ClearsActivePrediction()
+    {
+        var node = CreateNode((_, _) => Task.FromResult<string?>("xyz"));
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('a'), null, null, TestContext.Current.CancellationToken);
+        await WaitForPredictionAsync(node, TimeSpan.FromSeconds(2));
+        Assert.Equal("xyz", node.CurrentPrediction);
+
+        await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Backspace, '\b', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
+
+        Assert.Null(node.CurrentPrediction);
+    }
+
+    [Fact]
+    public async Task FocusLoss_ClearsActivePrediction()
+    {
+        var node = CreateNode((_, _) => Task.FromResult<string?>("xyz"));
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('a'), null, null, TestContext.Current.CancellationToken);
+        await WaitForPredictionAsync(node, TimeSpan.FromSeconds(2));
+        Assert.Equal("xyz", node.CurrentPrediction);
+
+        node.IsFocused = false;
+
+        Assert.Null(node.CurrentPrediction);
+    }
+
+    [Fact]
+    public async Task MouseClick_ClearsActivePrediction()
+    {
+        var node = CreateNode((_, _) => Task.FromResult<string?>("xyz"));
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('a'), null, null, TestContext.Current.CancellationToken);
+        await WaitForPredictionAsync(node, TimeSpan.FromSeconds(2));
+        Assert.Equal("xyz", node.CurrentPrediction);
+
+        node.Arrange(new Rect(0, 0, 10, 1));
+        node.HandleMouseClick(0, 0, new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 0, 0, Hex1bModifiers.None, ClickCount: 1));
+
+        Assert.Null(node.CurrentPrediction);
+    }
+
+    [Fact]
+    public async Task Escape_WithActivePrediction_IsConsumed_AndClears()
+    {
+        var node = CreateNode((_, _) => Task.FromResult<string?>("xyz"));
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('a'), null, null, TestContext.Current.CancellationToken);
+        await WaitForPredictionAsync(node, TimeSpan.FromSeconds(2));
+        Assert.Equal("xyz", node.CurrentPrediction);
+
+        var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Escape, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
+
+        Assert.Equal(InputResult.Handled, result);
+        Assert.Null(node.CurrentPrediction);
+    }
+
+    [Fact]
+    public async Task Escape_WithoutActivePrediction_IsNotConsumed()
+    {
+        var node = CreateNode();
+
+        var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Escape, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
+
+        Assert.Equal(InputResult.NotHandled, result);
+    }
+
+    [Fact]
+    public async Task RightArrow_WithActivePrediction_AcceptsAndFiresChange()
+    {
+        var node = CreateNode((_, _) => Task.FromResult<string?>("world"));
+        var changes = 0;
+        string? lastNew = null;
+        node.TextChangedAction = (_, _, newText) =>
+        {
+            Interlocked.Increment(ref changes);
+            lastNew = newText;
+            return Task.CompletedTask;
+        };
+
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('h'), null, null, TestContext.Current.CancellationToken);
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('e'), null, null, TestContext.Current.CancellationToken);
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('l'), null, null, TestContext.Current.CancellationToken);
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('l'), null, null, TestContext.Current.CancellationToken);
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('o'), null, null, TestContext.Current.CancellationToken);
+
+        await WaitForPredictionAsync(node, TimeSpan.FromSeconds(2));
+        Assert.Equal("world", node.CurrentPrediction);
+
+        var typingChanges = changes;
+
+        await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
+
+        Assert.Equal("helloworld", node.Text);
+        Assert.Equal(node.Text.Length, node.State.CursorPosition);
+        Assert.Null(node.CurrentPrediction);
+        Assert.Equal(typingChanges + 1, changes);
+        Assert.Equal("helloworld", lastNew);
+    }
+
+    [Fact]
+    public async Task RightArrow_WithoutPrediction_MovesCursor()
+    {
+        var node = new TextBoxNode { Text = "abc", IsFocused = true };
+        node.State.CursorPosition = 1;
+
+        await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, node.State.CursorPosition);
+    }
+
+    [Fact]
+    public async Task StaleAsyncResult_IsDiscarded()
+    {
+        // The predictor deliberately *ignores* the cancellation token. The
+        // first call captures snapshot "a" and sleeps for 60 ms before
+        // returning "a!". By the time it returns, the user has typed another
+        // character and the buffer is "ab"; the snapshot guard inside the
+        // node must drop the stale "a!" result so the predictor that
+        // captured "ab" wins.
+        var node = new TextBoxNode
+        {
+            Text = "",
+            IsFocused = true,
+            Predictor = async (text, _) =>
+            {
+                await Task.Delay(60);
+                return text + "!";
+            },
+        };
+
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('a'), null, null, TestContext.Current.CancellationToken);
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('b'), null, null, TestContext.Current.CancellationToken);
+
+        var prediction = await WaitForPredictionAsync(node, TimeSpan.FromSeconds(2));
+
+        // Whichever order the two predictor tasks complete in, the value
+        // tied to the stale snapshot ("a!") must never become the active
+        // prediction. Only the value tied to the live snapshot ("ab!")
+        // is allowed.
+        Assert.Equal("ab!", prediction);
+    }
+
+    [Fact]
+    public async Task Debounce_CoalescesRapidKeystrokesIntoSingleCall()
+    {
+        var calls = 0;
+        string? lastSeen = null;
+        var node = new TextBoxNode
+        {
+            Text = "",
+            IsFocused = true,
+            PredictionDebounce = TimeSpan.FromMilliseconds(80),
+            Predictor = (text, _) =>
+            {
+                Interlocked.Increment(ref calls);
+                lastSeen = text;
+                return Task.FromResult<string?>(text + "!");
+            },
+        };
+
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('a'), null, null, TestContext.Current.CancellationToken);
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('b'), null, null, TestContext.Current.CancellationToken);
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('c'), null, null, TestContext.Current.CancellationToken);
+
+        await WaitForPredictionAsync(node, TimeSpan.FromSeconds(2));
+
+        Assert.Equal(1, calls);
+        Assert.Equal("abc", lastSeen);
+        Assert.Equal("abc!", node.CurrentPrediction);
+    }
+
+    [Fact]
+    public async Task Multiline_NeverPopulatesPrediction()
+    {
+        var calls = 0;
+        var node = new TextBoxNode
+        {
+            Text = "",
+            IsFocused = true,
+            IsMultiline = true,
+            Predictor = (_, _) => { Interlocked.Increment(ref calls); return Task.FromResult<string?>("xxx"); },
+        };
+        node.State.IsMultiline = true;
+
+        await InputRouter.RouteInputToNodeAsync(node, CharKey('a'), null, null, TestContext.Current.CancellationToken);
+
+        await Task.Delay(100, TestContext.Current.CancellationToken);
+
+        Assert.Null(node.CurrentPrediction);
+        Assert.Equal(0, calls);
+    }
+
+    [Fact]
+    public async Task PredictWidget_Reconciles_PredictorOntoNode()
+    {
+        var widget = new TextBoxWidget("hello").Predict((_, _) => Task.FromResult<string?>("ignored"));
+        var node = new TextBoxNode();
+        var ctx = ReconcileContext.CreateRoot(cancellationToken: TestContext.Current.CancellationToken);
+        ctx.IsNew = true;
+
+        await widget.ReconcileAsync(node, ctx);
+
+        Assert.NotNull(node.Predictor);
+        Assert.Equal(TimeSpan.Zero, node.PredictionDebounce);
+    }
+
+    [Fact]
+    public async Task PredictWidget_WithDebounce_FlowsDebounceOntoNode()
+    {
+        var widget = new TextBoxWidget("hello").Predict((_, _) => Task.FromResult<string?>("ignored"), TimeSpan.FromMilliseconds(123));
+        var node = new TextBoxNode();
+        var ctx = ReconcileContext.CreateRoot(cancellationToken: TestContext.Current.CancellationToken);
+        ctx.IsNew = true;
+
+        await widget.ReconcileAsync(node, ctx);
+
+        Assert.Equal(TimeSpan.FromMilliseconds(123), node.PredictionDebounce);
+    }
+}

--- a/tests/Hex1b.Tests/TextBoxWidgetTests.cs
+++ b/tests/Hex1b.Tests/TextBoxWidgetTests.cs
@@ -194,6 +194,63 @@ public class TextBoxStateHoistedTests
         Assert.True(ReadVersion(state) > v0);
     }
 
+    [Fact]
+    public void DefaultWidthHint_IsFill_SoTextBoxExpandsByDefault()
+    {
+        // The bare widget reports Fill so HStack/VStack hand it the remaining
+        // space without callers having to chain .FillWidth() on every textbox.
+        var widget = new TextBoxWidget("hello");
+        Assert.Null(widget.WidthHint);
+        Assert.Equal(Hex1b.Layout.SizeHint.Fill, widget.DefaultWidthHint);
+    }
+
+    [Fact]
+    public void ExplicitWidthHint_OverridesDefault()
+    {
+        // ContentWidth/FixedWidth/etc. set WidthHint, which always wins over
+        // the per-widget default.
+        var widget = new TextBoxWidget("hello").ContentWidth();
+        Assert.Equal(Hex1b.Layout.SizeHint.Content, widget.WidthHint);
+        Assert.Equal(Hex1b.Layout.SizeHint.Fill, widget.DefaultWidthHint);
+    }
+
+    [Fact]
+    public async Task Reconcile_PropagatesFillDefault_ToNode()
+    {
+        var context = ReconcileContext.CreateRoot();
+        context.IsNew = true;
+
+        var widget = new TextBoxWidget("hi");
+        var node = (TextBoxNode)await widget.ReconcileAsync(null, context);
+
+        // The widget's ReconcileAsync alone doesn't push the hint — that
+        // happens in Hex1bApp's central reconcile path. Simulate that step.
+        node.WidthHint = widget.WidthHint ?? widget.DefaultWidthHint;
+
+        Assert.Equal(Hex1b.Layout.SizeHint.Fill, node.WidthHint);
+    }
+
+    [Fact]
+    public void TextBoxInHStack_GetsRemainingWidth_ByDefault()
+    {
+        // Build an HStack with a fixed-width label and a bare TextBox; arrange
+        // the stack into a 40-cell rect and check the textbox got the leftover.
+        var label = new Hex1b.Widgets.TextBlockWidget("Name: ") { WidthHint = Hex1b.Layout.SizeHint.Fixed(6) };
+        var textbox = new TextBoxWidget("");
+        var hstack = new HStackNode
+        {
+            Children = new List<Hex1bNode>
+            {
+                new TextBlockNode { Text = "Name: ", WidthHint = label.WidthHint },
+                new TextBoxNode { WidthHint = textbox.DefaultWidthHint }
+            }
+        };
+
+        hstack.Arrange(new Hex1b.Layout.Rect(0, 0, 40, 1));
+
+        Assert.Equal(34, hstack.Children[1].Bounds.Width);
+    }
+
     private static long ReadVersion(TextBoxState state)
     {
         var prop = typeof(TextBoxState).GetProperty(


### PR DESCRIPTION
## Why

Form-style flows in our samples kept reaching for ad-hoc workarounds because the default `TextBox` lacked two things modern terminal UIs are expected to have: (1) inline "ghost text" suggestions of the kind users see in editors and shells, and (2) sensible default sizing inside an `HStack` so the input fills the row instead of hugging its content. While in there, the legacy bracket chrome (`[ ... ]`) around the field was retired since it conflicts with the field-fill background we now draw.

## What changed

**Inline prediction.** `TextBoxWidget.Predict(Func<string, string?>)` registers a callback that returns the most likely continuation of the current text. The suggestion only renders when the cursor is at the end of the text and only after a character has been typed. Right Arrow accepts the suggestion, Escape dismisses it, any other edit clears it. Two new theme elements (`PredictionForegroundColor`, `PredictionBackgroundColor`) drive its appearance. Foreground defaults to `Hex1bColor.Gray` (a bright monochrome ghost-text gray); background defaults to `Hex1bColor.Default`, which the renderer treats as "follow the field fill background" so the suggestion blends into the input surface by default while still being themable to a contrasting band.

**Default fill width.** `Hex1bWidget` gains `protected internal virtual SizeHint? DefaultWidthHint` / `DefaultHeightHint`, resolved centrally in `Hex1bApp.ReconcileAsync` as `widget.WidthHint ?? widget.DefaultWidthHint`. `TextBoxWidget` overrides `DefaultWidthHint => SizeHint.Fill` so input surfaces stretch to fill `HStack` space without callers having to chain `.FillWidth()`. Explicit `.ContentWidth()`, `.FixedWidth(n)`, or `.FillWidth()` always win. This is the cleanest extension point for any future widget that wants opinionated default sizing — the base record's `init`-only `WidthHint` can't be polymorphically shadowed via `new`.

**Bracket chrome removed.** `TextBoxNode` no longer renders the `[` / `]` characters around the field. With the field-fill background we now draw, those brackets read as visual noise. Existing samples and tests were updated accordingly.

**New `PredictiveTextDemo` sample** wires the API up against a small static word list so the behavior can be tried interactively.

## Notable details

- Setting `node.WidthHint` happens in `Hex1bApp.cs` after `widget.ReconcileAsync` runs, so the central wiring (not the widget's own `ReconcileAsync`) is the right hook for the default-fill resolution.
- `HStackNode.ArrangeCore` distributes leftover space directly to `Fill` children without re-measuring, so adding the default doesn't perturb measured-size paths.
- Docs gained a new "Sizing" section on the TextBox page and refreshed entries for the two new theme elements.

## Tests

- 4 new `TextBoxWidgetTests` cover the fill default, explicit overrides, reconcile propagation, and HStack arrangement.
- New `TextBoxPredictionTests` covers prediction visibility rules, accept-on-right-arrow, and dismiss-on-escape.
- Full `Hex1b.Tests`: 7708 / 7708 pass. `Hex1b.Analyzers.Tests`: 67 / 67 pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>