### PR TITLE
Fix Hex1b Flow resize: soft-wrap tombstones and active step

### DIFF
--- a/samples/FlowDemo/Commands/AgentInitCommand.cs
+++ b/samples/FlowDemo/Commands/AgentInitCommand.cs
@@ -19,7 +19,7 @@ internal static class AgentInitCommand
         new("Windsurf", ".windsurfrules", "Codeium's AI IDE"),
     ];
 
-    public static async Task RunAsync()
+    public static async Task RunAsync(bool softWrap = false)
     {
         var cursorRow = Console.GetCursorPosition().Top;
 
@@ -117,7 +117,11 @@ internal static class AgentInitCommand
                 await Task.Delay(300);
                 await configStep.CompleteAsync(y => y.Text($"  ✓ Configured {configured.Count} agents"));
 
-            }, options => options.InitialCursorRow = cursorRow)
+            }, options =>
+            {
+                options.InitialCursorRow = cursorRow;
+                options.UseSoftWrapTombstones = softWrap;
+            })
             .Build()
             .RunAsync();
 

--- a/samples/FlowDemo/Commands/AgentInitCommand.cs
+++ b/samples/FlowDemo/Commands/AgentInitCommand.cs
@@ -19,124 +19,130 @@ internal static class AgentInitCommand
         new("Windsurf", ".windsurfrules", "Codeium's AI IDE"),
     ];
 
-    public static async Task RunAsync(bool softWrap = false)
+    public static Task RunAsync(bool softWrap = false)
     {
-        var cursorRow = Console.GetCursorPosition().Top;
-
-        var detected = new List<AgentInfo>();
-        var selected = new HashSet<string>();
-        var configured = new List<string>();
-
-        await Hex1bTerminal.CreateBuilder()
-            .WithScrollback()
-            .WithHex1bFlow(async flow =>
-            {
-                // Step 1: Detection spinner
-                var detecting = true;
-                var detectedCount = 0;
-
-                var detectStep = flow.Step(ctx => ctx.HStack(h =>
-                [
-                    detecting ? h.Spinner(SpinnerStyle.Dots) : h.Text("✓"),
-                    h.Text(detecting
-                        ? $" Detecting agents... ({detectedCount} found)"
-                        : $" Found {detected.Count} agents"),
-                ]),
-                    options: opts => opts.MaxHeight = 1
-                );
-
-                // Simulate scanning for agents
-                foreach (var agent in DetectedAgents)
-                {
-                    await Task.Delay(600);
-                    detected.Add(agent);
-                    detectedCount = detected.Count;
-                    detectStep.Invalidate();
-                }
-
-                detecting = false;
-                detectStep.Invalidate();
-                await Task.Delay(300);
-                await detectStep.CompleteAsync(y => y.Text($"  ✓ Detected {detected.Count} agents"));
-
-                // Step 2: Agent selection with checkboxes
-                // Pre-select all agents
-                foreach (var agent in detected)
-                {
-                    selected.Add(agent.Name);
-                }
-
-                var selectStep = flow.Step(ctx => ctx.VStack(v =>
-                [
-                    v.Text("Select agents to configure:"),
-                    .. detected.Select(agent =>
-                        (Hex1bWidget)v.Checkbox(selected.Contains(agent.Name) ? CheckboxValue.Checked : CheckboxValue.Unchecked)
-                            .Label(agent.Name)
-                            .OnToggled(e =>
-                            {
-                                if (selected.Contains(agent.Name))
-                                    selected.Remove(agent.Name);
-                                else
-                                    selected.Add(agent.Name);
-                            })),
-                    v.Text($"  {selected.Count} of {detected.Count} selected"),
-                    v.Button("Configure selected").OnClick(e =>
-                        ctx.Step.Complete(y => y.Text($"  ✓ Selected: {string.Join(", ", selected)}"))),
-                ]),
-                    options: opts => opts.MaxHeight = detected.Count + 5
-                );
-                await selectStep.WaitForCompletionAsync();
-
-                // Step 3: Configuration spinner per agent
-                var configuring = true;
-                var currentAgent = "";
-                var configuredIndex = 0;
-
-                var configStep = flow.Step(ctx => ctx.HStack(h =>
-                [
-                    configuring ? h.Spinner(SpinnerStyle.Dots) : h.Text("✓"),
-                    h.Text(configuring
-                        ? $" Configuring {currentAgent}... ({configuredIndex}/{selected.Count})"
-                        : $" Configured {configured.Count} agents"),
-                ]),
-                    options: opts => opts.MaxHeight = 1
-                );
-
-                var selectedAgents = detected.Where(a => selected.Contains(a.Name)).ToList();
-                foreach (var agent in selectedAgents)
-                {
-                    currentAgent = agent.Name;
-                    configuredIndex++;
-                    configStep.Invalidate();
-                    await Task.Delay(1000);
-                    configured.Add(agent.Name);
-                }
-
-                configuring = false;
-                configStep.Invalidate();
-                await Task.Delay(300);
-                await configStep.CompleteAsync(y => y.Text($"  ✓ Configured {configured.Count} agents"));
-
-            }, options =>
-            {
-                options.InitialCursorRow = cursorRow;
-                options.UseSoftWrapTombstones = softWrap;
-            })
-            .Build()
-            .RunAsync();
-
-        // Summary output
-        Console.WriteLine();
-        Console.WriteLine("Agent configuration complete!");
-        Console.WriteLine();
-
-        var selectedAgents = DetectedAgents.Where(a => configured.Contains(a.Name));
-        foreach (var agent in selectedAgents)
+        return FlowCancellationExtensions.RunAsync(async cancel =>
         {
-            Console.WriteLine($"  ✓ {agent.Name} — {agent.ConfigFile}");
-        }
+            var cursorRow = Console.GetCursorPosition().Top;
 
-        Console.WriteLine();
-        Console.WriteLine("Configuration files have been written to your project.");
+            var detected = new List<AgentInfo>();
+            var selected = new HashSet<string>();
+            var configured = new List<string>();
+
+            await Hex1bTerminal.CreateBuilder()
+                .WithScrollback()
+                .WithHex1bFlow(async flow =>
+                {
+                    // Step 1: Detection spinner
+                    var detecting = true;
+                    var detectedCount = 0;
+
+                    var detectStep = flow.Step(ctx => ctx.HStack(h =>
+                    [
+                        detecting ? h.Spinner(SpinnerStyle.Dots) : h.Text("✓"),
+                        h.Text(detecting
+                            ? $" Detecting agents... ({detectedCount} found)"
+                            : $" Found {detected.Count} agents"),
+                    ]).ExitOnCtrlC(cancel, ctx),
+                        options: opts => opts.MaxHeight = 1
+                    );
+
+                    // Simulate scanning for agents
+                    foreach (var agent in DetectedAgents)
+                    {
+                        await Task.Delay(600, cancel.Token);
+                        detected.Add(agent);
+                        detectedCount = detected.Count;
+                        detectStep.Invalidate();
+                    }
+
+                    detecting = false;
+                    detectStep.Invalidate();
+                    await Task.Delay(300, cancel.Token);
+                    await detectStep.CompleteAsync(y => y.Text($"  ✓ Detected {detected.Count} agents"));
+
+                    // Step 2: Agent selection with checkboxes
+                    // Pre-select all agents
+                    foreach (var agent in detected)
+                    {
+                        selected.Add(agent.Name);
+                    }
+
+                    var selectStep = flow.Step(ctx => ctx.VStack(v =>
+                    [
+                        v.Text("Select agents to configure:"),
+                        .. detected.Select(agent =>
+                            (Hex1bWidget)v.Checkbox(selected.Contains(agent.Name) ? CheckboxValue.Checked : CheckboxValue.Unchecked)
+                                .Label(agent.Name)
+                                .OnToggled(e =>
+                                {
+                                    if (selected.Contains(agent.Name))
+                                        selected.Remove(agent.Name);
+                                    else
+                                        selected.Add(agent.Name);
+                                })),
+                        v.Text($"  {selected.Count} of {detected.Count} selected"),
+                        v.Button("Configure selected").OnClick(e =>
+                            ctx.Step.Complete(y => y.Text($"  ✓ Selected: {string.Join(", ", selected)}"))),
+                    ]).ExitOnCtrlC(cancel, ctx),
+                        options: opts => opts.MaxHeight = detected.Count + 5
+                    );
+                    await selectStep.WaitForCompletionAsync();
+                    cancel.ThrowIfCancelled();
+
+                    // Step 3: Configuration spinner per agent
+                    var configuring = true;
+                    var currentAgent = "";
+                    var configuredIndex = 0;
+
+                    var configStep = flow.Step(ctx => ctx.HStack(h =>
+                    [
+                        configuring ? h.Spinner(SpinnerStyle.Dots) : h.Text("✓"),
+                        h.Text(configuring
+                            ? $" Configuring {currentAgent}... ({configuredIndex}/{selected.Count})"
+                            : $" Configured {configured.Count} agents"),
+                    ]).ExitOnCtrlC(cancel, ctx),
+                        options: opts => opts.MaxHeight = 1
+                    );
+
+                    var selectedAgents = detected.Where(a => selected.Contains(a.Name)).ToList();
+                    foreach (var agent in selectedAgents)
+                    {
+                        currentAgent = agent.Name;
+                        configuredIndex++;
+                        configStep.Invalidate();
+                        await Task.Delay(1000, cancel.Token);
+                        configured.Add(agent.Name);
+                    }
+
+                    configuring = false;
+                    configStep.Invalidate();
+                    await Task.Delay(300, cancel.Token);
+                    await configStep.CompleteAsync(y => y.Text($"  ✓ Configured {configured.Count} agents"));
+
+                }, options =>
+                {
+                    options.InitialCursorRow = cursorRow;
+                    options.UseSoftWrapTombstones = softWrap;
+                })
+                .Build()
+                .RunAsync();
+
+            cancel.ThrowIfCancelled();
+
+            // Summary output
+            Console.WriteLine();
+            Console.WriteLine("Agent configuration complete!");
+            Console.WriteLine();
+
+            var summaryAgents = DetectedAgents.Where(a => configured.Contains(a.Name));
+            foreach (var agent in summaryAgents)
+            {
+                Console.WriteLine($"  ✓ {agent.Name} — {agent.ConfigFile}");
+            }
+
+            Console.WriteLine();
+            Console.WriteLine("Configuration files have been written to your project.");
+        });
     }
 }

--- a/samples/FlowDemo/Commands/CopilotCommand.cs
+++ b/samples/FlowDemo/Commands/CopilotCommand.cs
@@ -42,17 +42,19 @@ internal static class CopilotCommand
         ("/exit", "Exit the Copilot CLI"),
     ];
 
-    public static async Task RunAsync(bool softWrap = false)
+    public static Task RunAsync(bool softWrap = false)
     {
-        var cursorRow = Console.GetCursorPosition().Top;
-        var state = new AppState();
+        return FlowCancellationExtensions.RunAsync(async cancel =>
+        {
+            var cursorRow = Console.GetCursorPosition().Top;
+            var state = new AppState();
 
-        await Hex1bTerminal.CreateBuilder()
-            .WithScrollback()
-            .WithHex1bFlow(async flow =>
-            {
-                var step = flow.Step(ctx =>
+            await Hex1bTerminal.CreateBuilder()
+                .WithScrollback()
+                .WithHex1bFlow(async flow =>
                 {
+                    var step = flow.Step(ctx =>
+                    {
                     var modeColor = GetModeColor(state.CurrentMode);
 
                     // Build the content area (output lines + optional spinner)
@@ -154,13 +156,14 @@ internal static class CopilotCommand
                             : []),
                     ]);
 
-                    return ctx.VStack(v => [mainArea, promptArea]);
+                    return ctx.VStack(v => [mainArea, promptArea]).ExitOnCtrlC(cancel, ctx);
                 },
                     options: opts => opts.EnableMouse = true
                 );
 
                 step.RequestFocus(n => n is TextBoxNode);
                 await step.WaitForCompletionAsync();
+                cancel.ThrowIfCancelled();
 
                 // Cleanup terminal if still running
                 if (state.TerminalCts != null)
@@ -178,6 +181,7 @@ internal static class CopilotCommand
             })
             .Build()
             .RunAsync();
+        });
     }
 
     private static void HandleSubmit(string text, FlowStep step, AppState state)

--- a/samples/FlowDemo/Commands/CopilotCommand.cs
+++ b/samples/FlowDemo/Commands/CopilotCommand.cs
@@ -42,7 +42,7 @@ internal static class CopilotCommand
         ("/exit", "Exit the Copilot CLI"),
     ];
 
-    public static async Task RunAsync()
+    public static async Task RunAsync(bool softWrap = false)
     {
         var cursorRow = Console.GetCursorPosition().Top;
         var state = new AppState();
@@ -171,7 +171,11 @@ internal static class CopilotCommand
                     if (state.ChildTerminal != null)
                         await state.ChildTerminal.DisposeAsync();
                 }
-            }, options => options.InitialCursorRow = cursorRow)
+            }, options =>
+            {
+                options.InitialCursorRow = cursorRow;
+                options.UseSoftWrapTombstones = softWrap;
+            })
             .Build()
             .RunAsync();
     }

--- a/samples/FlowDemo/Commands/NewCommand.cs
+++ b/samples/FlowDemo/Commands/NewCommand.cs
@@ -19,7 +19,7 @@ internal static class NewCommand
 
     private static readonly string[] Languages = ["C#", "TypeScript"];
 
-    public static async Task RunAsync(string? name, string? output)
+    public static async Task RunAsync(string? name, string? output, bool softWrap = false)
     {
         var cursorRow = Console.GetCursorPosition().Top;
 
@@ -145,7 +145,11 @@ internal static class NewCommand
                 await Task.Delay(300);
                 await spinnerStep.CompleteAsync(y => y.Text($"  ✓ Project created at {outputPath}"));
 
-            }, options => options.InitialCursorRow = cursorRow)
+            }, options =>
+            {
+                options.InitialCursorRow = cursorRow;
+                options.UseSoftWrapTombstones = softWrap;
+            })
             .Build()
             .RunAsync();
 

--- a/samples/FlowDemo/Commands/NewCommand.cs
+++ b/samples/FlowDemo/Commands/NewCommand.cs
@@ -19,146 +19,155 @@ internal static class NewCommand
 
     private static readonly string[] Languages = ["C#", "TypeScript"];
 
-    public static async Task RunAsync(string? name, string? output, bool softWrap = false)
+    public static Task RunAsync(string? name, string? output, bool softWrap = false)
     {
-        var cursorRow = Console.GetCursorPosition().Top;
+        return FlowCancellationExtensions.RunAsync(async cancel =>
+        {
+            var cursorRow = Console.GetCursorPosition().Top;
 
-        var selectedTemplate = "";
-        var projectName = name ?? "";
-        var outputPath = output ?? "";
-        var language = "C#";
+            var selectedTemplate = "";
+            var projectName = name ?? "";
+            var outputPath = output ?? "";
+            var language = "C#";
 
-        await Hex1bTerminal.CreateBuilder()
-            .WithScrollback()
-            .WithHex1bFlow(async flow =>
-            {
-                // Step 1: Template picker (skip if subcommand was provided directly)
-                var templateIndex = 0;
-
-                var step = flow.Step(ctx => ctx.VStack(v =>
-                [
-                    v.Text("Select a project template:"),
-                    v.List(Templates.Select(t => t.Name).ToArray())
-                        .OnItemActivated(e =>
-                        {
-                            templateIndex = e.ActivatedIndex;
-                            selectedTemplate = Templates[e.ActivatedIndex].Id;
-                            ctx.Step.Complete(y => y.Text($"  ✓ Template: {Templates[templateIndex].Name}"));
-                        })
-                        .FixedHeight(Templates.Length + 1),
-                ]),
-                    options: opts => opts.MaxHeight = Templates.Length + 3
-                );
-                await step.WaitForCompletionAsync();
-
-                // Step 2: Project name
-                if (string.IsNullOrEmpty(projectName))
+            await Hex1bTerminal.CreateBuilder()
+                .WithScrollback()
+                .WithHex1bFlow(async flow =>
                 {
-                    var nameStep = flow.Step(ctx => ctx.VStack(v =>
-                    [
-                        v.Text("Enter your project name:"),
-                        v.TextBox(projectName)
-                            .OnSubmit(e =>
-                            {
-                                projectName = e.Text;
-                                ctx.Step.Complete(y => y.Text($"  ✓ Project name: {projectName}"));
-                            })
-                            .FillWidth(),
-                    ]),
-                        options: opts => opts.MaxHeight = 4
-                    );
-                    await nameStep.WaitForCompletionAsync();
-                }
+                    // Step 1: Template picker (skip if subcommand was provided directly)
+                    var templateIndex = 0;
 
-                // Step 3: Output directory
-                if (string.IsNullOrEmpty(outputPath))
-                {
-                    var defaultPath = $"./{projectName}";
-                    outputPath = defaultPath;
-
-                    var dirStep = flow.Step(ctx => ctx.VStack(v =>
+                    var step = flow.Step(ctx => ctx.VStack(v =>
                     [
-                        v.Text("Select output directory:"),
-                        v.List(new[]
-                        {
-                            defaultPath,
-                            $"./projects/{projectName}",
-                            $"./src/{projectName}",
-                        })
+                        v.Text("Select a project template:"),
+                        v.List(Templates.Select(t => t.Name).ToArray())
                             .OnItemActivated(e =>
                             {
-                                outputPath = e.ActivatedText;
-                                ctx.Step.Complete(y => y.Text($"  ✓ Output: {outputPath}"));
+                                templateIndex = e.ActivatedIndex;
+                                selectedTemplate = Templates[e.ActivatedIndex].Id;
+                                ctx.Step.Complete(y => y.Text($"  ✓ Template: {Templates[templateIndex].Name}"));
                             })
-                            .FixedHeight(4),
-                    ]),
-                        options: opts => opts.MaxHeight = 6
+                            .FixedHeight(Templates.Length + 1),
+                    ]).ExitOnCtrlC(cancel, ctx),
+                        options: opts => opts.MaxHeight = Templates.Length + 3
                     );
-                    await dirStep.WaitForCompletionAsync();
-                }
+                    await step.WaitForCompletionAsync();
+                    cancel.ThrowIfCancelled();
 
-                // Step 4: Language picker
-                var langStep = flow.Step(ctx => ctx.VStack(v =>
-                [
-                    v.Text("Select AppHost language:"),
-                    v.List(Languages)
-                        .OnItemActivated(e =>
-                        {
-                            language = e.ActivatedText;
-                            ctx.Step.Complete(y => y.Text($"  ✓ Language: {language}"));
-                        })
-                        .FixedHeight(Languages.Length + 1),
-                ]),
-                    options: opts => opts.MaxHeight = Languages.Length + 3
-                );
-                await langStep.WaitForCompletionAsync();
+                    // Step 2: Project name
+                    if (string.IsNullOrEmpty(projectName))
+                    {
+                        var nameStep = flow.Step(ctx => ctx.VStack(v =>
+                        [
+                            v.Text("Enter your project name:"),
+                            v.TextBox(projectName)
+                                .OnSubmit(e =>
+                                {
+                                    projectName = e.Text;
+                                    ctx.Step.Complete(y => y.Text($"  ✓ Project name: {projectName}"));
+                                })
+                                .FillWidth(),
+                        ]).ExitOnCtrlC(cancel, ctx),
+                            options: opts => opts.MaxHeight = 4
+                        );
+                        await nameStep.WaitForCompletionAsync();
+                        cancel.ThrowIfCancelled();
+                    }
 
-                // Step 5: Creation spinner
-                var creating = true;
-                var currentStep = "";
+                    // Step 3: Output directory
+                    if (string.IsNullOrEmpty(outputPath))
+                    {
+                        var defaultPath = $"./{projectName}";
+                        outputPath = defaultPath;
 
-                var spinnerStep = flow.Step(ctx => ctx.HStack(h =>
-                [
-                    creating ? h.Spinner(SpinnerStyle.Dots) : h.Text("✓"),
-                    h.Text(creating ? $" {currentStep}" : " Project created successfully!"),
-                ]),
-                    options: opts => opts.MaxHeight = 1
-                );
+                        var dirStep = flow.Step(ctx => ctx.VStack(v =>
+                        [
+                            v.Text("Select output directory:"),
+                            v.List(new[]
+                            {
+                                defaultPath,
+                                $"./projects/{projectName}",
+                                $"./src/{projectName}",
+                            })
+                                .OnItemActivated(e =>
+                                {
+                                    outputPath = e.ActivatedText;
+                                    ctx.Step.Complete(y => y.Text($"  ✓ Output: {outputPath}"));
+                                })
+                                .FixedHeight(4),
+                        ]).ExitOnCtrlC(cancel, ctx),
+                            options: opts => opts.MaxHeight = 6
+                        );
+                        await dirStep.WaitForCompletionAsync();
+                        cancel.ThrowIfCancelled();
+                    }
 
-                var steps = new[]
-                {
-                    "Creating project structure...",
-                    "Installing NuGet packages...",
-                    "Configuring AppHost...",
-                    "Generating solution file...",
-                };
+                    // Step 4: Language picker
+                    var langStep = flow.Step(ctx => ctx.VStack(v =>
+                    [
+                        v.Text("Select AppHost language:"),
+                        v.List(Languages)
+                            .OnItemActivated(e =>
+                            {
+                                language = e.ActivatedText;
+                                ctx.Step.Complete(y => y.Text($"  ✓ Language: {language}"));
+                            })
+                            .FixedHeight(Languages.Length + 1),
+                    ]).ExitOnCtrlC(cancel, ctx),
+                        options: opts => opts.MaxHeight = Languages.Length + 3
+                    );
+                    await langStep.WaitForCompletionAsync();
+                    cancel.ThrowIfCancelled();
 
-                foreach (var s in steps)
-                {
-                    currentStep = s;
+                    // Step 5: Creation spinner
+                    var creating = true;
+                    var currentStep = "";
+
+                    var spinnerStep = flow.Step(ctx => ctx.HStack(h =>
+                    [
+                        creating ? h.Spinner(SpinnerStyle.Dots) : h.Text("✓"),
+                        h.Text(creating ? $" {currentStep}" : " Project created successfully!"),
+                    ]).ExitOnCtrlC(cancel, ctx),
+                        options: opts => opts.MaxHeight = 1
+                    );
+
+                    var steps = new[]
+                    {
+                        "Creating project structure...",
+                        "Installing NuGet packages...",
+                        "Configuring AppHost...",
+                        "Generating solution file...",
+                    };
+
+                    foreach (var s in steps)
+                    {
+                        currentStep = s;
+                        spinnerStep.Invalidate();
+                        await Task.Delay(800, cancel.Token);
+                    }
+
+                    creating = false;
                     spinnerStep.Invalidate();
-                    await Task.Delay(800);
-                }
+                    await Task.Delay(300, cancel.Token);
+                    await spinnerStep.CompleteAsync(y => y.Text($"  ✓ Project created at {outputPath}"));
 
-                creating = false;
-                spinnerStep.Invalidate();
-                await Task.Delay(300);
-                await spinnerStep.CompleteAsync(y => y.Text($"  ✓ Project created at {outputPath}"));
+                }, options =>
+                {
+                    options.InitialCursorRow = cursorRow;
+                    options.UseSoftWrapTombstones = softWrap;
+                })
+                .Build()
+                .RunAsync();
 
-            }, options =>
-            {
-                options.InitialCursorRow = cursorRow;
-                options.UseSoftWrapTombstones = softWrap;
-            })
-            .Build()
-            .RunAsync();
+            cancel.ThrowIfCancelled();
 
-        // Summary output (normal Console.WriteLine after flow completes)
-        Console.WriteLine();
-        Console.WriteLine($"The project \"{projectName}\" has been created at \"{outputPath}\".");
-        Console.WriteLine();
-        Console.WriteLine("Next steps:");
-        Console.WriteLine($"  cd {outputPath}");
-        Console.WriteLine($"  dotnet run --project {projectName}.AppHost");
+            // Summary output (normal Console.WriteLine after flow completes)
+            Console.WriteLine();
+            Console.WriteLine($"The project \"{projectName}\" has been created at \"{outputPath}\".");
+            Console.WriteLine();
+            Console.WriteLine("Next steps:");
+            Console.WriteLine($"  cd {outputPath}");
+            Console.WriteLine($"  dotnet run --project {projectName}.AppHost");
+        });
     }
 }

--- a/samples/FlowDemo/Commands/SizzleCommand.cs
+++ b/samples/FlowDemo/Commands/SizzleCommand.cs
@@ -14,12 +14,14 @@ namespace FlowDemo.Commands;
 /// </summary>
 internal static class SizzleCommand
 {
-    public static async Task RunAsync(bool softWrap = false)
+    public static Task RunAsync(bool softWrap = false)
     {
-        var cursorRow = Console.GetCursorPosition().Top;
-        string? selectedLocation = null;
+        return FlowCancellationExtensions.RunAsync(async cancel =>
+        {
+            var cursorRow = Console.GetCursorPosition().Top;
+            string? selectedLocation = null;
 
-        await Hex1bTerminal.CreateBuilder()
+            await Hex1bTerminal.CreateBuilder()
             .WithScrollback()
             .WithHex1bFlow(async flow =>
             {
@@ -158,10 +160,11 @@ internal static class SizzleCommand
                         });
                     })
                     .Fill()
-                ]),
+                ]).ExitOnCtrlC(cancel, ctx),
                     options: opts => { opts.MaxHeight = globeHeight; opts.EnableMouse = true; }
                 );
                 await step.WaitForCompletionAsync();
+                cancel.ThrowIfCancelled();
 
             }, options =>
             {
@@ -176,6 +179,7 @@ internal static class SizzleCommand
         {
             Console.WriteLine($"Selected location: {selectedLocation}");
         }
+        });
     }
 
     // Points of interest (lat/lon in degrees, converted to unit sphere positions)

--- a/samples/FlowDemo/Commands/SizzleCommand.cs
+++ b/samples/FlowDemo/Commands/SizzleCommand.cs
@@ -14,7 +14,7 @@ namespace FlowDemo.Commands;
 /// </summary>
 internal static class SizzleCommand
 {
-    public static async Task RunAsync()
+    public static async Task RunAsync(bool softWrap = false)
     {
         var cursorRow = Console.GetCursorPosition().Top;
         string? selectedLocation = null;
@@ -163,7 +163,11 @@ internal static class SizzleCommand
                 );
                 await step.WaitForCompletionAsync();
 
-            }, options => options.InitialCursorRow = cursorRow)
+            }, options =>
+            {
+                options.InitialCursorRow = cursorRow;
+                options.UseSoftWrapTombstones = softWrap;
+            })
             .Build()
             .RunAsync();
 

--- a/samples/FlowDemo/FlowCancellation.cs
+++ b/samples/FlowDemo/FlowCancellation.cs
@@ -1,0 +1,86 @@
+using Hex1b;
+using Hex1b.Flow;
+using Hex1b.Input;
+using Hex1b.Widgets;
+
+namespace FlowDemo;
+
+/// <summary>
+/// Shared cancellation state for a single FlowDemo command run. A Ctrl+C
+/// binding installed on each step's root widget calls <see cref="Cancel"/>
+/// and ends the active step; the flow callback then propagates an
+/// <see cref="OperationCanceledException"/> via <see cref="ThrowIfCancelled"/>
+/// (or via <see cref="Token"/> on Task.Delay/etc.) so the command unwinds
+/// cleanly to the top-level catch in <see cref="FlowCancellationExtensions.RunAsync"/>.
+/// </summary>
+internal sealed class FlowCancellation
+{
+    private readonly CancellationTokenSource _cts = new();
+
+    /// <summary>
+    /// Token that becomes cancelled when the user presses Ctrl+C. Pass to
+    /// <c>Task.Delay</c>, <c>FlowStep.WaitForCompletionAsync</c>, and any
+    /// other awaitable that should bail out on cancellation.
+    /// </summary>
+    public CancellationToken Token => _cts.Token;
+
+    /// <summary>True once the user has pressed Ctrl+C.</summary>
+    public bool IsCancelled => _cts.IsCancellationRequested;
+
+    /// <summary>Signal cancellation. Idempotent.</summary>
+    public void Cancel()
+    {
+        try { _cts.Cancel(); } catch (ObjectDisposedException) { }
+    }
+
+    /// <summary>Throws <see cref="OperationCanceledException"/> if cancelled.</summary>
+    public void ThrowIfCancelled() => _cts.Token.ThrowIfCancellationRequested();
+}
+
+/// <summary>
+/// Helpers that wire a global Ctrl+C exit into a flow.
+/// </summary>
+internal static class FlowCancellationExtensions
+{
+    /// <summary>
+    /// Wraps a step's root widget with a Ctrl+C binding that signals
+    /// cancellation on the supplied <see cref="FlowCancellation"/> and
+    /// exits the current step.
+    /// </summary>
+    /// <remarks>
+    /// The binding overrides the step app's default Ctrl+C-exits-step
+    /// behaviour (added by <c>Hex1bAppOptions.EnableDefaultCtrlCExit</c>)
+    /// because <c>InputBindings</c> on the root widget registers after the
+    /// default binding and wins via the trie's last-write-wins semantics.
+    /// </remarks>
+    public static TWidget ExitOnCtrlC<TWidget>(this TWidget widget, FlowCancellation cancel, FlowStepContext ctx)
+        where TWidget : Hex1bWidget
+    {
+        return widget.InputBindings(b =>
+        {
+            b.Ctrl().Key(Hex1bKey.C).Action(_ =>
+            {
+                cancel.Cancel();
+                ctx.Step.Complete();
+            }, "Cancel and exit");
+        });
+    }
+
+    /// <summary>
+    /// Runs a command body, catching cancellation and printing a friendly
+    /// goodbye message instead of letting the exception escape to the user.
+    /// </summary>
+    public static async Task RunAsync(Func<FlowCancellation, Task> body)
+    {
+        var cancel = new FlowCancellation();
+        try
+        {
+            await body(cancel);
+        }
+        catch (OperationCanceledException) when (cancel.IsCancelled)
+        {
+            Console.WriteLine();
+            Console.WriteLine("✗ Cancelled by user. Goodbye!");
+        }
+    }
+}

--- a/samples/FlowDemo/Program.cs
+++ b/samples/FlowDemo/Program.cs
@@ -4,6 +4,12 @@ using FlowDemo.Commands;
 // FlowDemo — Mock Aspire CLI using Hex1b Flow
 // Demonstrates interactive CLI flows with inline slices and scrollback.
 
+var softWrapOption = new Option<bool>("--soft-wrap", "-s")
+{
+    Description = "Enable experimental soft-wrap tombstones (Hex1bFlowOptions.UseSoftWrapTombstones). When set, completed-step output is emitted as proper logical lines so the host terminal reflows it on resize and scrolls older tombstones into the scrollback buffer naturally.",
+    Recursive = true,
+};
+
 var nameOption = new Option<string?>("--name", "-n") { Description = "The name of the project to create." };
 var outputOption = new Option<string?>("--output", "-o") { Description = "The output path for the project." };
 
@@ -14,13 +20,15 @@ newCommand.SetAction(async (parseResult, ct) =>
 {
     var name = parseResult.GetValue(nameOption);
     var output = parseResult.GetValue(outputOption);
-    await NewCommand.RunAsync(name, output);
+    var softWrap = parseResult.GetValue(softWrapOption);
+    await NewCommand.RunAsync(name, output, softWrap);
 });
 
 var initCommand = new Command("init", "Initialize agent environment configuration for detected agents.");
 initCommand.SetAction(async (parseResult, ct) =>
 {
-    await AgentInitCommand.RunAsync();
+    var softWrap = parseResult.GetValue(softWrapOption);
+    await AgentInitCommand.RunAsync(softWrap);
 });
 
 var agentCommand = new Command("agent", "Manage agent configurations.");
@@ -29,16 +37,19 @@ agentCommand.Subcommands.Add(initCommand);
 var sizzleCommand = new Command("sizzle", "Showcase exotic Hex1b controls.");
 sizzleCommand.SetAction(async (parseResult, ct) =>
 {
-    await SizzleCommand.RunAsync();
+    var softWrap = parseResult.GetValue(softWrapOption);
+    await SizzleCommand.RunAsync(softWrap);
 });
 
 var copilotCommand = new Command("copilot", "Mock Copilot CLI chat interface.");
 copilotCommand.SetAction(async (parseResult, ct) =>
 {
-    await CopilotCommand.RunAsync();
+    var softWrap = parseResult.GetValue(softWrapOption);
+    await CopilotCommand.RunAsync(softWrap);
 });
 
 var rootCommand = new RootCommand("FlowDemo — Mock Aspire CLI powered by Hex1b Flow");
+rootCommand.Options.Add(softWrapOption);
 rootCommand.Subcommands.Add(newCommand);
 rootCommand.Subcommands.Add(agentCommand);
 rootCommand.Subcommands.Add(sizzleCommand);

--- a/samples/FlowReflowProbe/FlowReflowProbe.csproj
+++ b/samples/FlowReflowProbe/FlowReflowProbe.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Hex1b/Hex1b.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/FlowReflowProbe/Program.cs
+++ b/samples/FlowReflowProbe/Program.cs
@@ -152,11 +152,14 @@ void Render()
             return;
         }
 
-        // Total content rows we asked the terminal to display past row 1.
-        // If this exceeds the viewport, the terminal has scrolled and the
-        // YELLOW line has effectively shifted up by that amount.
-        var lastRowOccupied = currentAbsoluteRow - 1;
-        var scrollAmount = Math.Max(0, lastRowOccupied - height);
+        // Scroll trigger: when the cursor moves past the bottom of the
+        // viewport (after a '\n' from row H), the terminal scrolls and the
+        // cursor stays at visual row H. currentAbsoluteRow is where the
+        // cursor would be if no scroll happened, so the amount scrolled is
+        // currentAbsoluteRow - height (clamped at zero). NOTE: deliberately
+        // NOT (currentAbsoluteRow - 1 - height); the trigger is the cursor
+        // overflowing the bottom, not the content occupying the bottom row.
+        var scrollAmount = Math.Max(0, currentAbsoluteRow - height);
         var visibleYellowRow = yellowAbsoluteRow.Value - scrollAmount;
 
         if (visibleYellowRow < 1)

--- a/samples/FlowReflowProbe/Program.cs
+++ b/samples/FlowReflowProbe/Program.cs
@@ -1,0 +1,202 @@
+// Flow Reflow Probe — manual visual test for the host terminal's cursor-and-cell
+// behaviour during horizontal resize. Used to validate whether the proposed
+// "DSR-after-resize anchor" design for Hex1b.Flow is achievable on the user's
+// terminal matrix.
+//
+// Run with:
+//   dotnet run --project samples/FlowReflowProbe
+//
+// What to do:
+//   1. Read the prediction printed at the top.
+//   2. Resize the terminal horizontally — shrink several columns, then expand.
+//   3. Visually check whether the cursor and the cell-positioned 'step'
+//      content end up where the prediction said they should.
+//   4. Press R to redraw at the new size, Q to quit.
+//
+// What this validates:
+//   * Whether the host terminal moves the cursor with reflowed logical lines
+//     (required for DSR-after-resize to recover the post-reflow tombstone
+//     bottom row).
+//   * Whether cell-positioned content stays at its absolute row (required for
+//     the active step's render to land where we expect it to).
+
+using Hex1b.Reflow;
+
+const string Esc = "\x1b";
+const string Reset = Esc + "[0m";
+const string Bold = Esc + "[1m";
+const string Dim = Esc + "[2m";
+const string Cyan = Esc + "[36m";
+const string Yellow = Esc + "[33m";
+const string Green = Esc + "[32m";
+const string Red = Esc + "[31m";
+const string Magenta = Esc + "[35m";
+const string ClearScreen = Esc + "[2J" + Esc + "[H";
+const string ShowCursor = Esc + "[?25h";
+
+var detected = AutoReflowStrategy.Instance.DetectedStrategy;
+var detectedName = detected.GetType().Name;
+var (preserveCursorRow, reflowsCursor, reflowsSavedCursor, comment) = ClassifyStrategy(detected);
+
+Render();
+
+while (true)
+{
+    var key = Console.ReadKey(intercept: true);
+    if (key.Key == ConsoleKey.Q) break;
+    if (key.Key == ConsoleKey.R)
+    {
+        Render();
+    }
+}
+
+Console.Write(ShowCursor);
+Console.WriteLine();
+Console.WriteLine("Probe ended.");
+
+void Render()
+{
+    var width = Console.WindowWidth;
+
+    Console.Write(ClearScreen);
+    Console.Write(ShowCursor);
+
+    PrintHeader();
+    PrintInstructions();
+    PrintTombstone();
+    PrintReferenceLine();
+    PrintStepContent();
+    PositionCursorAtAnchor();
+    Console.Out.Flush();
+
+    void PrintHeader()
+    {
+        Console.WriteLine($"{Bold}{Cyan}=== Hex1b Flow Reflow Probe ==={Reset}");
+        Console.WriteLine();
+        Console.WriteLine($"  {Dim}Terminal:{Reset}        {detectedName}");
+        Console.WriteLine($"  {Dim}Window size:{Reset}     {width} x {Console.WindowHeight}");
+        Console.WriteLine($"  {Dim}TERM:{Reset}            {Environment.GetEnvironmentVariable("TERM") ?? "(unset)"}");
+        Console.WriteLine($"  {Dim}TERM_PROGRAM:{Reset}    {Environment.GetEnvironmentVariable("TERM_PROGRAM") ?? "(unset)"}");
+        Console.WriteLine($"  {Dim}WT_SESSION:{Reset}      {(Environment.GetEnvironmentVariable("WT_SESSION") is not null ? "set" : "(unset)")}");
+        Console.WriteLine();
+        Console.WriteLine($"  {Bold}Prediction (from Hex1b's reflow strategy):{Reset}");
+        Console.WriteLine($"    Reflows logical lines on horizontal resize:  {Color(reflowsCursor)}");
+        Console.WriteLine($"    Cursor follows reflowed content:             {Color(reflowsCursor)}");
+        Console.WriteLine($"    DECSC saved cursor is reflowed:              {Color(reflowsSavedCursor)}");
+        Console.WriteLine($"    preserveCursorRow (Kitty-style anchor):      {Color(preserveCursorRow)}");
+        if (!string.IsNullOrEmpty(comment))
+        {
+            Console.WriteLine($"    {Dim}Note:{Reset} {comment}");
+        }
+        Console.WriteLine();
+    }
+
+    void PrintInstructions()
+    {
+        Console.WriteLine($"{Bold}What to do:{Reset}");
+        Console.WriteLine($"  1. Look at where the cursor lands (block at start of the {Yellow}YELLOW{Reset} reference line).");
+        Console.WriteLine($"  2. Resize the terminal horizontally - shrink several columns, then expand back.");
+        Console.WriteLine($"  3. Observe:");
+        Console.WriteLine($"     {Green}OK{Reset} cursor moves with the {Yellow}YELLOW{Reset} reference line  -> terminal reflows cursor (good)");
+        Console.WriteLine($"     {Red}NO{Reset} cursor drifts away from the {Yellow}YELLOW{Reset} line          -> terminal does NOT reflow cursor (problem)");
+        Console.WriteLine($"     {Green}OK{Reset} {Magenta}MAGENTA{Reset} '[step row N]' lines stay at their rows -> cell content does not reflow (good)");
+        Console.WriteLine($"     {Red}NO{Reset} {Magenta}MAGENTA{Reset} lines wrap or relocate                  -> cell content also reflows (problem)");
+        Console.WriteLine($"  4. Press {Bold}R{Reset} to redraw with the new size. Press {Bold}Q{Reset} to quit.");
+        Console.WriteLine();
+    }
+
+    void PrintTombstone()
+    {
+        Console.WriteLine($"{Cyan}--- BEGIN TOMBSTONE (one long logical line, should reflow with terminal width) ---{Reset}");
+
+        var filler = new string('=', 220);
+        // Single logical line ending in \n. The host terminal owns wrapping.
+        Console.WriteLine($"{Cyan}[TOMBSTONE]{Reset} {filler} {Cyan}[/TOMBSTONE]{Reset}");
+        Console.WriteLine($"{Cyan}--- END TOMBSTONE ---{Reset}");
+    }
+
+    void PrintReferenceLine()
+    {
+        // Logical line - should reflow alongside the tombstone.
+        // We want the cursor to land at column 0 of THIS row when no reflow has
+        // happened, and to follow the reflow of THIS row as the user resizes.
+        Console.WriteLine($"{Yellow}>>> CURSOR-ANCHOR REFERENCE - the cursor should sit at col 0 of this YELLOW row <<<{Reset}");
+    }
+
+    void PrintStepContent()
+    {
+        // 'Step' content: cell-positioned, like an active flow step would be.
+        for (int i = 1; i <= 5; i++)
+        {
+            Console.WriteLine($"{Magenta}[step row {i}] cell-positioned content - should NOT reflow on resize{Reset}");
+        }
+        Console.WriteLine();
+        Console.WriteLine($"{Dim}(cursor will return to col 0 of the YELLOW reference line above){Reset}");
+    }
+
+    void PositionCursorAtAnchor()
+    {
+        // Move the cursor back to column 0 of the YELLOW reference line.
+        // We've just printed (relative to the YELLOW line):
+        //   YELLOW line                   (1)
+        //   step row 1..5                 (5)
+        //   blank line                    (1)
+        //   "(cursor will return ...)"    (1)
+        // = 8 rows past the YELLOW line.
+        // CUU is bounded to the top of the viewport, so even if reflow has
+        // already extended the printed content slightly, it can't go below 0.
+        const int RowsToMoveUp = 8;
+        Console.Write($"{Esc}[{RowsToMoveUp}A");
+        Console.Write("\r");
+    }
+}
+
+static string Color(bool value) => value
+    ? $"{Esc}[32mYES{Esc}[0m"
+    : $"{Esc}[31mNO{Esc}[0m";
+
+static (bool preserveCursorRow, bool reflowsCursor, bool reflowsSavedCursor, string comment)
+    ClassifyStrategy(ITerminalReflowProvider provider)
+{
+    if (provider is AutoReflowStrategy auto)
+    {
+        return ClassifyStrategy(auto.DetectedStrategy);
+    }
+
+    var typeName = provider.GetType().Name;
+    return typeName switch
+    {
+        nameof(NoReflowStrategy) => (false, false, false,
+            "No reflow at all - cursor and content both stay at absolute positions on resize."),
+
+        nameof(WindowsTerminalReflowStrategy) => (false, true, false,
+            "Bottom-fill reflow; cursor follows logical content. DECSC saved cursor becomes stale across reflow."),
+
+        nameof(KittyReflowStrategy) => (true, true, false,
+            "Cursor visual row is anchored (Kitty-style). DECSC saved cursor becomes stale."),
+
+        nameof(GhosttyReflowStrategy) => (true, true, true,
+            "Cursor visual row anchored AND DECSC saved cursor is reflowed."),
+
+        nameof(VteReflowStrategy) => (true, true, true,
+            "VTE-based (gnome-terminal, tilix, xfce4-terminal). Cursor anchored, DECSC reflowed."),
+
+        nameof(WezTermReflowStrategy) => (true, true, false,
+            "Cursor anchored. DECSC saved cursor becomes stale."),
+
+        nameof(FootReflowStrategy) => (true, true, true,
+            "Cursor anchored, DECSC reflowed."),
+
+        nameof(ITerm2ReflowStrategy) => (false, true, false,
+            "Bottom-fill reflow; cursor follows logical content. DECSC saved cursor becomes stale."),
+
+        nameof(AlacrittyReflowStrategy) => (false, false, false,
+            "Alacritty does not reflow logical lines on resize. Cursor and content stay at their absolute positions."),
+
+        nameof(XtermReflowStrategy) => (false, false, false,
+            "Xterm crops/extends; logical lines do not reflow. Cursor and content stay at their absolute positions."),
+
+        _ => (false, false, false,
+            $"Unknown strategy: {typeName}. Test empirically."),
+    };
+}

--- a/samples/FlowReflowProbe/Program.cs
+++ b/samples/FlowReflowProbe/Program.cs
@@ -56,10 +56,18 @@ Console.WriteLine("Probe ended.");
 
 void Render()
 {
-    var width = Console.WindowWidth;
+    var width = Math.Max(1, Console.WindowWidth);
+    var height = Math.Max(1, Console.WindowHeight);
 
     Console.Write(ClearScreen);
     Console.Write(ShowCursor);
+
+    // Cursor is now at row 1 col 1 (1-indexed). Track the absolute row we'd
+    // be on if the terminal didn't scroll — we'll fold scrolling in at the
+    // end via a single CUP, since CUU is bounded by the viewport top and
+    // can't recover a row that scrolled off.
+    int currentAbsoluteRow = 1;
+    int? yellowAbsoluteRow = null;
 
     PrintHeader();
     PrintInstructions();
@@ -69,86 +77,125 @@ void Render()
     PositionCursorAtAnchor();
     Console.Out.Flush();
 
+    void TrackedWriteLine(string s)
+    {
+        Console.WriteLine(s);
+        var visible = VisibleLength(s);
+        var rows = Math.Max(1, (visible + width - 1) / width);
+        currentAbsoluteRow += rows;
+    }
+
+    void TrackedBlankLine()
+    {
+        Console.WriteLine();
+        currentAbsoluteRow += 1;
+    }
+
     void PrintHeader()
     {
-        Console.WriteLine($"{Bold}{Cyan}=== Hex1b Flow Reflow Probe ==={Reset}");
-        Console.WriteLine();
-        Console.WriteLine($"  {Dim}Terminal:{Reset}        {detectedName}");
-        Console.WriteLine($"  {Dim}Window size:{Reset}     {width} x {Console.WindowHeight}");
-        Console.WriteLine($"  {Dim}TERM:{Reset}            {Environment.GetEnvironmentVariable("TERM") ?? "(unset)"}");
-        Console.WriteLine($"  {Dim}TERM_PROGRAM:{Reset}    {Environment.GetEnvironmentVariable("TERM_PROGRAM") ?? "(unset)"}");
-        Console.WriteLine($"  {Dim}WT_SESSION:{Reset}      {(Environment.GetEnvironmentVariable("WT_SESSION") is not null ? "set" : "(unset)")}");
-        Console.WriteLine();
-        Console.WriteLine($"  {Bold}Prediction (from Hex1b's reflow strategy):{Reset}");
-        Console.WriteLine($"    Reflows logical lines on horizontal resize:  {Color(reflowsCursor)}");
-        Console.WriteLine($"    Cursor follows reflowed content:             {Color(reflowsCursor)}");
-        Console.WriteLine($"    DECSC saved cursor is reflowed:              {Color(reflowsSavedCursor)}");
-        Console.WriteLine($"    preserveCursorRow (Kitty-style anchor):      {Color(preserveCursorRow)}");
+        TrackedWriteLine($"{Bold}{Cyan}=== Hex1b Flow Reflow Probe ==={Reset}");
+        TrackedBlankLine();
+        TrackedWriteLine($"  {Dim}Terminal:{Reset}        {detectedName}");
+        TrackedWriteLine($"  {Dim}Window size:{Reset}     {width} x {height}");
+        TrackedWriteLine($"  {Dim}TERM:{Reset}            {Environment.GetEnvironmentVariable("TERM") ?? "(unset)"}");
+        TrackedWriteLine($"  {Dim}TERM_PROGRAM:{Reset}    {Environment.GetEnvironmentVariable("TERM_PROGRAM") ?? "(unset)"}");
+        TrackedWriteLine($"  {Dim}WT_SESSION:{Reset}      {(Environment.GetEnvironmentVariable("WT_SESSION") is not null ? "set" : "(unset)")}");
+        TrackedBlankLine();
+        TrackedWriteLine($"  {Bold}Prediction (from Hex1b's reflow strategy):{Reset}");
+        TrackedWriteLine($"    Reflows logical lines on horizontal resize:  {Color(reflowsCursor)}");
+        TrackedWriteLine($"    Cursor follows reflowed content:             {Color(reflowsCursor)}");
+        TrackedWriteLine($"    DECSC saved cursor is reflowed:              {Color(reflowsSavedCursor)}");
+        TrackedWriteLine($"    preserveCursorRow (Kitty-style anchor):      {Color(preserveCursorRow)}");
         if (!string.IsNullOrEmpty(comment))
         {
-            Console.WriteLine($"    {Dim}Note:{Reset} {comment}");
+            TrackedWriteLine($"    {Dim}Note:{Reset} {comment}");
         }
-        Console.WriteLine();
+        TrackedBlankLine();
     }
 
     void PrintInstructions()
     {
-        Console.WriteLine($"{Bold}What to do:{Reset}");
-        Console.WriteLine($"  1. Look at where the cursor lands (block at start of the {Yellow}YELLOW{Reset} reference line).");
-        Console.WriteLine($"  2. Resize the terminal horizontally - shrink several columns, then expand back.");
-        Console.WriteLine($"  3. Observe:");
-        Console.WriteLine($"     {Green}OK{Reset} cursor moves with the {Yellow}YELLOW{Reset} reference line  -> terminal reflows cursor (good)");
-        Console.WriteLine($"     {Red}NO{Reset} cursor drifts away from the {Yellow}YELLOW{Reset} line          -> terminal does NOT reflow cursor (problem)");
-        Console.WriteLine($"     {Green}OK{Reset} {Magenta}MAGENTA{Reset} '[step row N]' lines stay at their rows -> cell content does not reflow (good)");
-        Console.WriteLine($"     {Red}NO{Reset} {Magenta}MAGENTA{Reset} lines wrap or relocate                  -> cell content also reflows (problem)");
-        Console.WriteLine($"  4. Press {Bold}R{Reset} to redraw with the new size. Press {Bold}Q{Reset} to quit.");
-        Console.WriteLine();
+        TrackedWriteLine($"{Bold}What to do:{Reset} resize horizontally, then press R to redraw, Q to quit.");
+        TrackedWriteLine($"  {Green}OK{Reset} cursor follows the {Yellow}YELLOW{Reset} reference  -> terminal reflows cursor (good).");
+        TrackedWriteLine($"  {Red}NO{Reset} cursor drifts away                  -> terminal does NOT reflow cursor.");
+        TrackedBlankLine();
     }
 
     void PrintTombstone()
     {
-        Console.WriteLine($"{Cyan}--- BEGIN TOMBSTONE (one long logical line, should reflow with terminal width) ---{Reset}");
-
+        TrackedWriteLine($"{Cyan}--- BEGIN TOMBSTONE (one long logical line, should reflow) ---{Reset}");
         var filler = new string('=', 220);
-        // Single logical line ending in \n. The host terminal owns wrapping.
-        Console.WriteLine($"{Cyan}[TOMBSTONE]{Reset} {filler} {Cyan}[/TOMBSTONE]{Reset}");
-        Console.WriteLine($"{Cyan}--- END TOMBSTONE ---{Reset}");
+        TrackedWriteLine($"{Cyan}[TOMBSTONE]{Reset} {filler} {Cyan}[/TOMBSTONE]{Reset}");
+        TrackedWriteLine($"{Cyan}--- END TOMBSTONE ---{Reset}");
     }
 
     void PrintReferenceLine()
     {
-        // Logical line - should reflow alongside the tombstone.
-        // We want the cursor to land at column 0 of THIS row when no reflow has
-        // happened, and to follow the reflow of THIS row as the user resizes.
-        Console.WriteLine($"{Yellow}>>> CURSOR-ANCHOR REFERENCE - the cursor should sit at col 0 of this YELLOW row <<<{Reset}");
+        // Capture the row at which the YELLOW line will be printed BEFORE we
+        // print it. This is the row the cursor should ultimately park on.
+        yellowAbsoluteRow = currentAbsoluteRow;
+        TrackedWriteLine($"{Yellow}>>> CURSOR-ANCHOR REFERENCE - cursor should park at col 0 of this YELLOW row <<<{Reset}");
     }
 
     void PrintStepContent()
     {
-        // 'Step' content: cell-positioned, like an active flow step would be.
-        for (int i = 1; i <= 5; i++)
+        for (int i = 1; i <= 3; i++)
         {
-            Console.WriteLine($"{Magenta}[step row {i}] cell-positioned content - should NOT reflow on resize{Reset}");
+            TrackedWriteLine($"{Magenta}[step row {i}] cell-positioned content - should NOT reflow on resize{Reset}");
         }
-        Console.WriteLine();
-        Console.WriteLine($"{Dim}(cursor will return to col 0 of the YELLOW reference line above){Reset}");
     }
 
     void PositionCursorAtAnchor()
     {
-        // Move the cursor back to column 0 of the YELLOW reference line.
-        // We've just printed (relative to the YELLOW line):
-        //   YELLOW line                   (1)
-        //   step row 1..5                 (5)
-        //   blank line                    (1)
-        //   "(cursor will return ...)"    (1)
-        // = 8 rows past the YELLOW line.
-        // CUU is bounded to the top of the viewport, so even if reflow has
-        // already extended the printed content slightly, it can't go below 0.
-        const int RowsToMoveUp = 8;
-        Console.Write($"{Esc}[{RowsToMoveUp}A");
-        Console.Write("\r");
+        if (yellowAbsoluteRow is null)
+        {
+            return;
+        }
+
+        // Total content rows we asked the terminal to display past row 1.
+        // If this exceeds the viewport, the terminal has scrolled and the
+        // YELLOW line has effectively shifted up by that amount.
+        var lastRowOccupied = currentAbsoluteRow - 1;
+        var scrollAmount = Math.Max(0, lastRowOccupied - height);
+        var visibleYellowRow = yellowAbsoluteRow.Value - scrollAmount;
+
+        if (visibleYellowRow < 1)
+        {
+            // YELLOW line scrolled off. Surface a clear banner at the top so
+            // the user understands the cursor anchor isn't observable here,
+            // rather than letting CUU silently clamp to the wrong row.
+            Console.Write($"{Esc}[1;1H");
+            var banner = $"{Bold}{Red}[VIEWPORT TOO SMALL]{Reset} YELLOW reference scrolled off; resize taller/wider and press R.";
+            Console.Write(banner);
+            Console.Write($"{Esc}[K"); // clear to end of line so any tail of pre-existing content goes away
+            return;
+        }
+
+        // CUP is 1-indexed; visibleYellowRow is already 1-indexed.
+        Console.Write($"{Esc}[{visibleYellowRow};1H");
     }
+}
+
+static int VisibleLength(string s)
+{
+    var count = 0;
+    var inEsc = false;
+    foreach (var c in s)
+    {
+        if (inEsc)
+        {
+            // Final byte of a CSI / SGR sequence is in 0x40..0x7E; we end on it.
+            if (c >= 0x40 && c <= 0x7E) inEsc = false;
+            continue;
+        }
+        if (c == '\x1b')
+        {
+            inEsc = true;
+            continue;
+        }
+        count++;
+    }
+    return count;
 }
 
 static string Color(bool value) => value
@@ -200,3 +247,4 @@ static (bool preserveCursorRow, bool reflowsCursor, bool reflowsSavedCursor, str
             $"Unknown strategy: {typeName}. Test empirically."),
     };
 }
+

--- a/samples/FlowReflowProbe/README.md
+++ b/samples/FlowReflowProbe/README.md
@@ -1,0 +1,94 @@
+# FlowReflowProbe
+
+A small interactive probe that validates whether the host terminal cooperates
+with the design proposed for fixing Hex1b's Flow-app resize behaviour.
+
+## Why this exists
+
+Hex1b Flow apps render in the **normal buffer** (not the alternate buffer)
+because they want to preserve the user's shell prompt above and feed
+completed-step output ("tombstones") into the terminal's scrollback. This
+puts the runner in a tracking bind: when the user resizes the terminal,
+content reflows, but the runner has no way to query "where did my old
+content end up" — standard VT only lets us query the cursor position, not
+arbitrary buffer state.
+
+The current shipped behaviour is "tombstones are append-only, active step
+is bottom-anchored, accept any visual overlap on shrink." The next step
+of the design relies on a single observable: **does the host terminal
+move the cursor with reflowed logical lines?** If yes, the runner can
+query the cursor with DSR (`ESC[6n`) immediately after a resize event
+and recover the post-reflow tombstone-bottom row.
+
+`src/Hex1b/Reflow/` already encodes per-terminal reflow strategies for
+the **emulator side** of the codebase. The probe surfaces that knowledge
+as an empirical visual check: it predicts what your terminal should do
+based on Hex1b's recorded behaviour, then asks you to confirm by eye.
+
+## How to run
+
+```powershell
+dotnet run --project samples/FlowReflowProbe
+```
+
+## What the screen shows
+
+- A header with the auto-detected reflow strategy and what to expect.
+- A long single logical line (the "tombstone") that should reflow on
+  horizontal resize.
+- A bright YELLOW reference line directly past the tombstone — the
+  cursor is positioned at column 0 of this line on every redraw.
+- Five MAGENTA "step row" lines below, written with cell positioning,
+  representing what an active flow step looks like on screen.
+
+## What to do
+
+1. Note where the cursor block sits (should be at column 0 of the
+   YELLOW reference line).
+2. Resize the terminal **horizontally** — shrink several columns,
+   then expand back. Do NOT press R yet.
+3. Watch:
+   - **Cursor moves with the YELLOW reference line.** ✓ Terminal
+     reflows the cursor along with logical content. The DSR-anchor
+     design is achievable on this terminal.
+   - **Cursor drifts away from the YELLOW line.** ✗ Terminal does
+     not reflow the cursor (or reflow misbehaves). DSR-anchor cannot
+     give an exact answer here; we'd have to fall back to the
+     current bottom-anchor design.
+   - **MAGENTA `[step row N]` lines stay at the same terminal rows
+     they started at.** ✓ Cell-positioned content does not reflow.
+   - **MAGENTA lines wrap or relocate.** ✗ Cell-positioned content
+     is also being moved by the terminal — more invasive design
+     would be needed.
+4. Press `R` to redraw the full layout at the new size (useful after
+   you've inspected what changed). Press `Q` to quit.
+
+## What the predictions are based on
+
+The classifier in `Program.cs` mirrors the strategies in
+`src/Hex1b/Reflow/`:
+
+| Strategy                         | Reflows logical lines | Cursor follows | DECSC reflowed | Anchors cursor row |
+|----------------------------------|-----------------------|----------------|----------------|--------------------|
+| `WindowsTerminalReflowStrategy`  | Yes                   | Yes            | No             | No (bottom-fill)   |
+| `ITerm2ReflowStrategy`           | Yes                   | Yes            | No             | No (bottom-fill)   |
+| `KittyReflowStrategy`            | Yes                   | Yes            | No             | Yes                |
+| `WezTermReflowStrategy`          | Yes                   | Yes            | No             | Yes                |
+| `GhosttyReflowStrategy`          | Yes                   | Yes            | Yes            | Yes                |
+| `VteReflowStrategy`              | Yes                   | Yes            | Yes            | Yes                |
+| `FootReflowStrategy`             | Yes                   | Yes            | Yes            | Yes                |
+| `XtermReflowStrategy`            | No                    | N/A            | N/A            | N/A                |
+| `AlacrittyReflowStrategy`        | No                    | N/A            | N/A            | N/A                |
+
+If a terminal shows behaviour different from what the table predicts,
+that's a finding worth capturing — either Hex1b's recorded strategy is
+out of date, or the terminal's behaviour has changed across versions.
+
+## What this probe is NOT
+
+- It does not actually use DSR programmatically. The "does the cursor
+  follow reflow" check is purely visual. A future enhancement could
+  add a programmatic DSR roundtrip.
+- It does not exercise the active-step render path of Flow apps. It
+  only validates the underlying terminal behaviour that the next
+  iteration of the resize fix would depend on.

--- a/src/Hex1b/Flow/FlowResizeMath.cs
+++ b/src/Hex1b/Flow/FlowResizeMath.cs
@@ -36,9 +36,13 @@ internal static class FlowResizeMath
     /// <c>ClearRegion(rowOrigin, height)</c>. Under the legacy path this is
     /// always <c>(0, terminalHeight)</c> — every row in the visible area gets
     /// cleared because cell-positioned tombstones cannot survive a resize
-    /// anyway. Under the soft-wrap path this is the bottom-aligned active-step
-    /// region only — tombstones above have been reflowed by the host terminal
-    /// and must not be touched.
+    /// anyway. The soft-wrap path no longer calls into this helper at all:
+    /// the runner owns the resize repaint there (clears the viewport, redraws
+    /// every tracked tombstone at the new width via
+    /// <c>SoftWrapEmitter</c>, then re-anchors the active step). The
+    /// soft-wrap branch in this method is retained only for tests and
+    /// possible future reuse — production code on the soft-wrap path
+    /// bypasses it.
     /// </returns>
     public static (int RowOrigin, int Height) ComputeClearRegion(
         bool useSoftWrapTombstones,

--- a/src/Hex1b/Flow/FlowResizeMath.cs
+++ b/src/Hex1b/Flow/FlowResizeMath.cs
@@ -1,0 +1,55 @@
+namespace Hex1b.Flow;
+
+/// <summary>
+/// Pure helpers for the flow runner's resize handler. Extracted so the
+/// behavioural choice between the legacy "clear the whole visible area" path
+/// and the soft-wrap "clear only the active-step region" path can be unit
+/// tested without spinning up a real terminal pipeline.
+/// </summary>
+internal static class FlowResizeMath
+{
+    /// <summary>
+    /// Clamps the desired step height to the terminal's available rows.
+    /// </summary>
+    /// <param name="maxHeight">Caller-supplied max height (from
+    /// <see cref="Hex1bFlowStepOptions.MaxHeight"/>); when <c>null</c> the
+    /// step is allowed to fill the terminal.</param>
+    /// <param name="terminalHeight">New terminal height in rows.</param>
+    /// <returns>Step height in rows, never less than 1.</returns>
+    public static int ComputeStepHeight(int? maxHeight, int terminalHeight)
+    {
+        var stepHeight = Math.Min(maxHeight ?? terminalHeight, terminalHeight);
+        return stepHeight < 1 ? 1 : stepHeight;
+    }
+
+    /// <summary>
+    /// Selects the rows that the resize handler should clear before the
+    /// active step's app re-renders into the new region.
+    /// </summary>
+    /// <param name="useSoftWrapTombstones">The
+    /// <see cref="Hex1bFlowOptions.UseSoftWrapTombstones"/> flag.</param>
+    /// <param name="terminalHeight">New terminal height in rows.</param>
+    /// <param name="stepHeight">New step height in rows (see
+    /// <see cref="ComputeStepHeight(int?, int)"/>).</param>
+    /// <returns>
+    /// A <c>(rowOrigin, height)</c> tuple suitable for
+    /// <c>ClearRegion(rowOrigin, height)</c>. Under the legacy path this is
+    /// always <c>(0, terminalHeight)</c> — every row in the visible area gets
+    /// cleared because cell-positioned tombstones cannot survive a resize
+    /// anyway. Under the soft-wrap path this is the bottom-aligned active-step
+    /// region only — tombstones above have been reflowed by the host terminal
+    /// and must not be touched.
+    /// </returns>
+    public static (int RowOrigin, int Height) ComputeClearRegion(
+        bool useSoftWrapTombstones,
+        int terminalHeight,
+        int stepHeight)
+    {
+        if (useSoftWrapTombstones)
+        {
+            var rowOrigin = Math.Max(0, terminalHeight - stepHeight);
+            return (rowOrigin, stepHeight);
+        }
+        return (0, terminalHeight);
+    }
+}

--- a/src/Hex1b/Flow/Hex1bFlowRunner.cs
+++ b/src/Hex1b/Flow/Hex1bFlowRunner.cs
@@ -114,8 +114,10 @@ internal sealed class Hex1bFlowRunner
     {
         _cancellationToken = ct;
 
-        // Query the current cursor position using DSR (Device Status Report)
-        _cursorRow = await QueryCursorRowAsync(ct);
+        // Query the current cursor position using the host terminal's
+        // synchronous cursor API (when available). Falls back to
+        // InitialCursorRow or 0 when no live query is wired.
+        _cursorRow = await QueryCursorRowAsync(ct) ?? _options.InitialCursorRow ?? 0;
 
         Trace($"RunAsync start: termSize={_parentAdapter.Width}x{_parentAdapter.Height} cursorRow={_cursorRow} useSoftWrap={_options.UseSoftWrapTombstones}");
 
@@ -742,6 +744,18 @@ internal sealed class Hex1bFlowRunner
         // *below* the last visible tombstone row, so the next render lands
         // there cleanly.
         _cursorRow += height;
+
+        // Park the cursor at the new tombstone-past row so a resize that
+        // arrives before the first step output flush still finds the
+        // cursor on a logical line the host terminal will reflow with the
+        // tombstones above. Only relevant when a live cursor query is
+        // available (CursorRowProvider) — without one there's nothing
+        // for the runner to recover from the parked position.
+        if (_options.CursorRowProvider != null)
+        {
+            _parentAdapter.SetCursorPosition(0, _cursorRow);
+        }
+
         Trace($"EmitSoftWrapTombstone[#{emitId}] exit: cursorRow={_cursorRow}");
     }
 
@@ -753,22 +767,23 @@ internal sealed class Hex1bFlowRunner
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The runner clears the OLD active-step region (using the row origin
-    /// and height the step occupied immediately before the resize fired)
-    /// and then clears the NEW bottom-anchored region into which the step
-    /// app will re-render. The active step uses absolute cursor positioning
-    /// rather than logical lines, so the host terminal does not reflow it
-    /// — explicit clear-and-re-anchor is required.
+    /// When a live cursor query is available
+    /// (<see cref="Hex1bFlowOptions.CursorRowProvider"/>) and
+    /// <see cref="PumpStepOutputAsync"/> has been parking the cursor at
+    /// the tombstone-past row, the runner queries the cursor first to
+    /// learn where that row landed after the host terminal reflowed the
+    /// tombstones above. The new active-step origin is computed from the
+    /// queried row using a hybrid strategy: top-anchor immediately past
+    /// the tombstones when the step fits in the remaining viewport;
+    /// bottom-anchor otherwise (which may overlap the bottom of the
+    /// reflowed tombstones — accepted as the cost of fitting the step
+    /// into a viewport that became too small).
     /// </para>
     /// <para>
-    /// Trade-off: if a horizontal shrink causes a tombstone above the
-    /// active step to wrap downward into the new step region, the bottom
-    /// of that tombstone is wiped by the new-region clear and the step
-    /// repaints over it. The remainder of the tombstone above the step
-    /// stays visible. This is the deliberate cost of the
-    /// "tombstones-are-append-only" design: we never fight the host
-    /// terminal's reflow algorithm or risk stacking up duplicate
-    /// tombstones by re-emitting on every resize.
+    /// When no live cursor query is available the runner falls back to
+    /// pure bottom-anchor based on the OLD captured origin/height, which
+    /// is the prior behaviour: simple, safe, but doesn't recover from
+    /// horizontal reflow.
     /// </para>
     /// <para>
     /// The clear+repaint is bracketed in DEC private mode 2026
@@ -782,33 +797,85 @@ internal sealed class Hex1bFlowRunner
     /// <param name="oldStepHeight">Height of the active step before the resize.</param>
     /// <param name="newHeight">New terminal height.</param>
     /// <param name="newStepHeight">Computed new height for the active step.</param>
-    /// <returns>The new bottom-anchored row origin for the active step.</returns>
+    /// <returns>The new row origin for the active step.</returns>
     private int AnchorActiveStepOnResize(int oldRowOrigin, int oldStepHeight, int newHeight, int newStepHeight)
     {
         var resizeId = Interlocked.Increment(ref _resizeCounter);
-        var newRowOrigin = Math.Max(0, newHeight - newStepHeight);
 
-        Trace($"AnchorActiveStep[#{resizeId}] enter: oldRO={oldRowOrigin} oldH={oldStepHeight} newH={newHeight} newSH={newStepHeight} newRO={newRowOrigin}");
+        // Try to recover the post-reflow tombstone-bottom row from the
+        // host terminal. The output pump has been parking the cursor at
+        // _cursorRow (i.e. the row past the last tombstone) after every
+        // step output flush, so cooperative terminals reflow that
+        // logical position alongside the tombstones above.
+        int? dsrRow = null;
+        if (_options.CursorRowProvider != null)
+        {
+            try
+            {
+                dsrRow = _options.CursorRowProvider();
+            }
+            catch
+            {
+                dsrRow = null;
+            }
+        }
+
+        int newRowOrigin;
+        bool topAnchored;
+        if (dsrRow is int row && row >= 0 && row < newHeight)
+        {
+            // Hybrid strategy. Prefer top-anchor immediately past the
+            // tombstones so the step appears in the same logical position
+            // it was before the resize. Fall back to bottom-anchor when
+            // the step would overflow the viewport from that origin.
+            if (row + newStepHeight <= newHeight)
+            {
+                newRowOrigin = row;
+                topAnchored = true;
+            }
+            else
+            {
+                newRowOrigin = Math.Max(0, newHeight - newStepHeight);
+                topAnchored = false;
+            }
+        }
+        else
+        {
+            // No live cursor query (or implausible result) — bottom-anchor
+            // and accept that the tombstones above may have shifted.
+            newRowOrigin = Math.Max(0, newHeight - newStepHeight);
+            topAnchored = false;
+        }
+
+        Trace($"AnchorActiveStep[#{resizeId}] enter: oldRO={oldRowOrigin} oldH={oldStepHeight} newH={newHeight} newSH={newStepHeight} dsrRow={dsrRow?.ToString() ?? "<none>"} newRO={newRowOrigin} topAnchored={topAnchored}");
 
         _parentAdapter.Write(SyncUpdateBegin);
         try
         {
-            // Clear the OLD step region first. After horizontal-only resize
-            // the old absolute-positioned cells typically remain at the same
-            // rows, so this hits the right place. After vertical resize or
-            // unusual reflow the clear may miss — leftover ghost cells are
-            // accepted as part of the append-only design.
-            if (oldStepHeight > 0)
+            // Clear the OLD step region first, but only when bottom-anchoring
+            // without a cursor query — that's the path where oldRowOrigin
+            // is still meaningful (no horizontal reflow). When the cursor
+            // query succeeded the tombstones above have reflowed and the
+            // OLD region is no longer where it was; clearing there would
+            // wipe reflowed tombstone content.
+            if (oldStepHeight > 0 && dsrRow is null)
             {
                 ClearRegion(oldRowOrigin, oldStepHeight);
             }
 
             // Clear the NEW step region so the step app's first post-resize
-            // render lands on a clean canvas, even if the new region overlaps
-            // the old one or any reflowed tombstone content above.
+            // render lands on a clean canvas.
             ClearRegion(newRowOrigin, newStepHeight);
 
             _cursorRow = newRowOrigin;
+
+            // Re-park the cursor at the new tombstone-past row so the next
+            // resize-during-idle finds it in the right place.
+            if (_options.CursorRowProvider != null)
+            {
+                _parentAdapter.SetCursorPosition(0, _cursorRow);
+            }
+
             Trace($"AnchorActiveStep[#{resizeId}] exit: cursorRow={_cursorRow}");
             return newRowOrigin;
         }
@@ -821,6 +888,16 @@ internal sealed class Hex1bFlowRunner
     /// <summary>
     /// Pumps output from a step adapter to the parent adapter.
     /// </summary>
+    /// <remarks>
+    /// On the soft-wrap path the cursor is "parked" at the row past the
+    /// last tombstone after every output flush. Cooperative terminals
+    /// (Windows Terminal, iTerm2, Kitty, Foot, VTE, Ghostty, WezTerm) move
+    /// the cursor along with reflowed logical lines on horizontal resize
+    /// — by parking the cursor on the empty logical line just past the
+    /// tombstones, the runner can recover the post-reflow tombstone-bottom
+    /// row via <see cref="QueryCursorRowAsync"/> when a resize event fires
+    /// while the step is idle.
+    /// </remarks>
     private async Task PumpStepOutputAsync(InlineStepAdapter stepAdapter, CancellationToken ct)
     {
         try
@@ -830,6 +907,18 @@ internal sealed class Hex1bFlowRunner
                 var data = await stepAdapter.ReadOutputAsync(ct);
                 if (data.IsEmpty) continue;
                 _parentAdapter.Write(Encoding.UTF8.GetString(data.Span));
+
+                if (_options.UseSoftWrapTombstones && _options.CursorRowProvider != null)
+                {
+                    // Park the cursor at the row past the last tombstone so
+                    // a resize-during-idle catches it on a logical line the
+                    // host terminal will reflow correctly. The next step
+                    // frame uses absolute CUP for every cell so this leak
+                    // does not corrupt rendering — at worst the user sees
+                    // a brief cursor blip at column 0 of the parked row,
+                    // which is hidden in TUI mode anyway.
+                    _parentAdapter.SetCursorPosition(0, _cursorRow);
+                }
             }
         }
         catch (OperationCanceledException) { }
@@ -867,13 +956,30 @@ internal sealed class Hex1bFlowRunner
     }
 
     /// <summary>
-    /// Queries the current cursor row position using Device Status Report (DSR).
-    /// Falls back to bottom of terminal if query fails.
+    /// Queries the host terminal's current cursor row (0-based). Uses the
+    /// <see cref="Hex1bFlowOptions.CursorRowProvider"/> delegate when set so
+    /// the runner can read the post-reflow position of the parked cursor
+    /// after a horizontal resize. Falls back to
+    /// <see cref="Hex1bFlowOptions.InitialCursorRow"/> when no provider is
+    /// available (headless/test scenarios).
     /// </summary>
-    private Task<int> QueryCursorRowAsync(CancellationToken ct)
+    private Task<int?> QueryCursorRowAsync(CancellationToken ct)
     {
-        // Use the initial cursor row from options if provided
-        return Task.FromResult(_options.InitialCursorRow ?? 0);
+        if (_options.CursorRowProvider is { } provider)
+        {
+            try
+            {
+                return Task.FromResult(provider());
+            }
+            catch
+            {
+                // Provider failures collapse to "unavailable" so callers
+                // can fall back to bottom-anchor behaviour.
+                return Task.FromResult<int?>(null);
+            }
+        }
+
+        return Task.FromResult<int?>(_options.InitialCursorRow);
     }
 }
 
@@ -898,6 +1004,27 @@ public sealed class Hex1bFlowOptions
     /// If null, defaults to 0.
     /// </summary>
     public int? InitialCursorRow { get; set; }
+
+    /// <summary>
+    /// Optional delegate that returns the host terminal's current cursor row
+    /// (0-based). When set, the flow runner uses this to recover the
+    /// post-reflow position of the row past the last tombstone after a
+    /// horizontal resize on cooperative terminals.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Implemented on top of <c>Console.GetCursorPosition()</c> by
+    /// <c>Hex1bTerminalBuilder.WithHex1bFlow</c> when a presentation adapter
+    /// is available. On Windows this resolves through Win32
+    /// <c>GetConsoleScreenBufferInfo</c> (no DSR roundtrip); on Unix the BCL
+    /// uses a real DSR query.
+    /// </para>
+    /// <para>
+    /// Returns <c>null</c> to indicate the cursor row could not be
+    /// determined; the runner then falls back to bottom-anchor on resize.
+    /// </para>
+    /// </remarks>
+    public Func<int?>? CursorRowProvider { get; set; }
 
     /// <summary>
     /// When <c>true</c>, tombstoned (yield) widget output is emitted as

--- a/src/Hex1b/Flow/Hex1bFlowRunner.cs
+++ b/src/Hex1b/Flow/Hex1bFlowRunner.cs
@@ -34,6 +34,40 @@ internal sealed class Hex1bFlowRunner
     // CancellationToken from RunAsync, surfaced to flow callbacks via Hex1bFlowContext.
     private CancellationToken _cancellationToken;
 
+    // Builders for every soft-wrap tombstone emitted by this runner, in
+    // emission order. Used by the resize handler on the
+    // UseSoftWrapTombstones path to re-render the entire tombstone history
+    // at the new terminal width: the host terminal's reflow algorithm is
+    // unpredictable across terminal emulators (xterm vs Windows Terminal vs
+    // iTerm2 vs VTE), and the previous "clear only the active-step region
+    // and trust the terminal" strategy left ghost copies of the old active
+    // step above the new one and could clip wrapped tombstones. Owning the
+    // re-render eliminates the dependence on terminal-specific behaviour at
+    // the cost of one extra surface render per tombstone per resize event.
+    // Resize is rare and tombstones are small, so the cost is negligible.
+    // List is appended to from the soft-wrap branches of RenderStaticAsync
+    // and RunStepLifecycleAsync's post-step block; never cleared during the
+    // flow's lifetime.
+    private readonly List<Func<RootContext, Hex1bWidget>> _tombstoneBuilders = new();
+
+    // The terminal row at which this flow's content begins. Initialised
+    // from Hex1bFlowOptions.InitialCursorRow at the start of RunAsync, then
+    // decremented by overflow whenever the runner pre-scrolls the terminal
+    // (in EmitSoftWrapTombstone, RenderStaticAsync, or
+    // RunStepLifecycleAsync). The resize handler uses this to position the
+    // cursor at the flow's origin and clear-from-cursor-to-end (ESC[J),
+    // preserving any user content above the flow (typically a shell prompt)
+    // that hasn't yet been scrolled into the host terminal's scrollback.
+    private int _flowOriginRow;
+
+    // DEC private mode 2026 (Synchronized Update Mode). Wrapping the
+    // resize-time clear-and-re-render in BSU/ESU lets supporting terminals
+    // present the whole repaint as a single atomic frame, eliminating the
+    // brief blank flash between "clear viewport" and "tombstones drawn".
+    // Terminals that don't recognise mode 2026 ignore both sequences.
+    private const string SyncUpdateBegin = "\x1b[?2026h";
+    private const string SyncUpdateEnd = "\x1b[?2026l";
+
     public Hex1bFlowRunner(
         Func<Hex1bFlowContext, Task> flowCallback,
         Hex1bFlowOptions options,
@@ -74,6 +108,7 @@ internal sealed class Hex1bFlowRunner
 
         // Query the current cursor position using DSR (Device Status Report)
         _cursorRow = await QueryCursorRowAsync(ct);
+        _flowOriginRow = _cursorRow;
 
         var context = new Hex1bFlowContext(this);
         await _flowCallback(context);
@@ -106,6 +141,7 @@ internal sealed class Hex1bFlowRunner
                 _parentAdapter.Write("\n");
             }
             _cursorRow -= overflow;
+            _flowOriginRow = Math.Max(0, _flowOriginRow - overflow);
         }
 
         // Clear and render
@@ -119,6 +155,9 @@ internal sealed class Hex1bFlowRunner
             if (surface is not null)
             {
                 EmitSoftWrapTombstone(surface);
+                // Track the builder so a later resize can re-render this
+                // static tombstone at the new width via the resize handler.
+                _tombstoneBuilders.Add(builder);
                 return;
             }
             // Fall through to legacy path if surface rendering failed.
@@ -224,6 +263,7 @@ internal sealed class Hex1bFlowRunner
                 }
                 rowOrigin -= overflow;
                 _cursorRow = rowOrigin;
+                _flowOriginRow = Math.Max(0, _flowOriginRow - overflow);
             }
 
             // Clear the step region
@@ -263,17 +303,42 @@ internal sealed class Hex1bFlowRunner
                 onResize: (newWidth, newHeight) =>
                 {
                     var newStepHeight = FlowResizeMath.ComputeStepHeight(options?.MaxHeight, newHeight);
-                    var (clearOrigin, clearHeight) = FlowResizeMath.ComputeClearRegion(
-                        _options.UseSoftWrapTombstones, newHeight, newStepHeight);
-                    var newRowOrigin = Math.Max(0, newHeight - newStepHeight);
 
-                    ClearRegion(clearOrigin, clearHeight);
+                    if (_options.UseSoftWrapTombstones)
+                    {
+                        // Owned re-render: clear the entire visible area and
+                        // redraw the tombstone history from scratch at the new
+                        // width, then re-anchor the active step. This avoids
+                        // the unpredictable host-terminal reflow behaviour that
+                        // would otherwise leave a ghost of the old active step
+                        // above the new one and could clip wrapped tombstones
+                        // on width shrink. See the comment on
+                        // _tombstoneBuilders for the full rationale.
+                        var newRowOrigin = ReRenderTombstonesAndAnchorStep(newWidth, newHeight, newStepHeight);
 
-                    stepAdapter.RowOrigin = newRowOrigin;
-                    rowOrigin = newRowOrigin;
-                    _cursorRow = newRowOrigin;
-                    desiredHeight = newStepHeight;
-                    step.StepHeight = newStepHeight;
+                        stepAdapter.RowOrigin = newRowOrigin;
+                        rowOrigin = newRowOrigin;
+                        _cursorRow = newRowOrigin;
+                        desiredHeight = newStepHeight;
+                        step.StepHeight = newStepHeight;
+                    }
+                    else
+                    {
+                        // Legacy path: cell-positioned tombstones can't be
+                        // preserved across reflow, so we wipe the whole visible
+                        // area and bottom-anchor the new step.
+                        var (clearOrigin, clearHeight) = FlowResizeMath.ComputeClearRegion(
+                            useSoftWrapTombstones: false, newHeight, newStepHeight);
+                        var newRowOrigin = Math.Max(0, newHeight - newStepHeight);
+
+                        ClearRegion(clearOrigin, clearHeight);
+
+                        stepAdapter.RowOrigin = newRowOrigin;
+                        rowOrigin = newRowOrigin;
+                        _cursorRow = newRowOrigin;
+                        desiredHeight = newStepHeight;
+                        step.StepHeight = newStepHeight;
+                    }
 
                     _ = stepAdapter.ResizeAsync(newWidth, newStepHeight);
                 });
@@ -312,6 +377,10 @@ internal sealed class Hex1bFlowRunner
                     if (surface is not null)
                     {
                         EmitSoftWrapTombstone(surface);
+                        // Track the builder so a later resize can re-render
+                        // this completed-step tombstone at the new width
+                        // via the resize handler.
+                        _tombstoneBuilders.Add(completedBuilder);
                     }
                     else
                     {
@@ -420,6 +489,7 @@ internal sealed class Hex1bFlowRunner
                 for (int i = 0; i < overflow; i++)
                     _parentAdapter.Write("\n");
                 _cursorRow -= overflow;
+                _flowOriginRow = Math.Max(0, _flowOriginRow - overflow);
             }
 
             // Clear the page region
@@ -643,6 +713,7 @@ internal sealed class Hex1bFlowRunner
                 _parentAdapter.Write("\n");
             }
             _cursorRow -= overflow;
+            _flowOriginRow = Math.Max(0, _flowOriginRow - overflow);
         }
 
         // Position the cursor at the row where the tombstone should land.
@@ -662,6 +733,112 @@ internal sealed class Hex1bFlowRunner
         // *below* the last visible tombstone row, so the next render lands
         // there cleanly.
         _cursorRow += height;
+    }
+
+    /// <summary>
+    /// Resize-time owned re-render: clears the viewport from the flow's
+    /// origin row down, re-emits every tracked tombstone at the new terminal
+    /// width, and computes the row origin where the active step should be
+    /// anchored. Called only on the soft-wrap path. Returns the row origin
+    /// for the active step.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The previous resize strategy ("clear only the bottom-anchored
+    /// active-step region and trust the host terminal to have reflowed the
+    /// tombstones above it") had two unfixable problems: it left a ghost of
+    /// the old active step (rendered with absolute positioning, so the host
+    /// terminal had no way to remove it), and it could clip wrapped
+    /// tombstones whose reflowed rows landed inside the new step region.
+    /// Both problems disappear if Hex1b owns the post-resize layout from
+    /// the flow's origin row down: we clear from there to the bottom of the
+    /// viewport, redraw every tombstone via <see cref="SoftWrapEmitter"/>
+    /// at the new width, and pre-scroll if needed to make room for the
+    /// active step.
+    /// </para>
+    /// <para>
+    /// The starting row is <see cref="_flowOriginRow"/>, clamped to the new
+    /// viewport. This preserves any user content above the flow (typically a
+    /// shell prompt) that hasn't yet been scrolled into the host terminal's
+    /// scrollback by previous tombstone overflows. <c>ESC[J</c> clears from
+    /// the cursor to the end of the screen, leaving rows above the cursor
+    /// untouched.
+    /// </para>
+    /// <para>
+    /// The clear+redraw is bracketed in DEC private mode 2026
+    /// (Synchronized Update Mode), so terminals that recognise it present
+    /// the entire repaint as one atomic frame instead of a brief blank
+    /// flash. Terminals that ignore mode 2026 see a slightly more visible
+    /// repaint but no functional regression.
+    /// </para>
+    /// <para>
+    /// <see cref="EmitSoftWrapTombstone"/>'s pre-scroll logic handles
+    /// overflow into the host terminal's scrollback the same way it does
+    /// during normal flow execution, so the user's mental model — "oldest
+    /// tombstones go up into scrollback as new ones land at the bottom" —
+    /// is preserved across resize.
+    /// </para>
+    /// </remarks>
+    private int ReRenderTombstonesAndAnchorStep(int newWidth, int newHeight, int newStepHeight)
+    {
+        // Begin synchronized update so supporting terminals present the whole
+        // clear-and-redraw as a single atomic frame.
+        _parentAdapter.Write(SyncUpdateBegin);
+
+        try
+        {
+            // Position the cursor at the flow's origin row (clamped into the
+            // new viewport in case the terminal shrank below it) and clear
+            // from there to the end of the screen with ESC[J. Anything above
+            // the flow's origin (the shell prompt, previous output) is left
+            // untouched so the user keeps the context they had before the
+            // flow began.
+            var startRow = Math.Max(0, Math.Min(_flowOriginRow, newHeight - 1));
+            _parentAdapter.SetCursorPosition(0, startRow);
+            _parentAdapter.Write("\x1b[J");
+            _cursorRow = startRow;
+
+            // Re-emit every tracked tombstone at the new width. The emitter's
+            // pre-scroll logic naturally pushes earlier tombstones into
+            // scrollback when the viewport can't hold them all (which also
+            // decrements _flowOriginRow via the pre-scroll bookkeeping in
+            // EmitSoftWrapTombstone), matching the behaviour of normal flow
+            // execution.
+            foreach (var builder in _tombstoneBuilders)
+            {
+                var surface = RenderToSurface(builder, newWidth, newHeight);
+                if (surface is null) continue;
+                EmitSoftWrapTombstone(surface);
+            }
+
+            // Pre-scroll if the active step won't fit below the last
+            // tombstone. After this, _cursorRow + newStepHeight <= newHeight
+            // is guaranteed, so the step region we hand back is fully on
+            // screen.
+            var overflow = (_cursorRow + newStepHeight) - newHeight;
+            if (overflow > 0)
+            {
+                _parentAdapter.SetCursorPosition(0, newHeight - 1);
+                for (int i = 0; i < overflow; i++)
+                {
+                    _parentAdapter.Write("\n");
+                }
+                _cursorRow -= overflow;
+                _flowOriginRow = Math.Max(0, _flowOriginRow - overflow);
+            }
+
+            // Clear the active-step region so the step app's first
+            // post-resize render lands on a clean canvas. Without this the
+            // tombstone renderer's last emitted glyph would still be visible
+            // in column 0 of the step's first row until overwritten.
+            ClearRegion(_cursorRow, newStepHeight);
+
+            return _cursorRow;
+        }
+        finally
+        {
+            _parentAdapter.Write(SyncUpdateEnd);
+        }
     }
 
     /// <summary>

--- a/src/Hex1b/Flow/Hex1bFlowRunner.cs
+++ b/src/Hex1b/Flow/Hex1bFlowRunner.cs
@@ -294,6 +294,14 @@ internal sealed class Hex1bFlowRunner
                 WorkloadAdapter = stepAdapter,
                 EnableMouse = options?.EnableMouse ?? false,
                 EnableDefaultCtrlCExit = true,
+                // On the soft-wrap path the active step is rendered as
+                // logical lines (text + ESC[K + CR+LF) instead of as a
+                // CUP-positioned cell diff. This makes the step content
+                // reflowable by the host terminal alongside any
+                // tombstones above it, so a horizontal resize doesn't
+                // leave wrap-spillover ghost cells around the new step
+                // region.
+                UseSoftWrapEmission = _options.UseSoftWrapTombstones,
             };
 
             if (_options.Theme != null)
@@ -772,18 +780,33 @@ internal sealed class Hex1bFlowRunner
     /// <see cref="PumpStepOutputAsync"/> has been parking the cursor at
     /// the tombstone-past row, the runner queries the cursor first to
     /// learn where that row landed after the host terminal reflowed the
-    /// tombstones above. The new active-step origin is computed from the
-    /// queried row using a hybrid strategy: top-anchor immediately past
-    /// the tombstones when the step fits in the remaining viewport;
-    /// bottom-anchor otherwise (which may overlap the bottom of the
-    /// reflowed tombstones — accepted as the cost of fitting the step
-    /// into a viewport that became too small).
+    /// tombstones above. The new active-step origin is anchored at the
+    /// queried row (top-anchor) so the step appears in the same logical
+    /// position it was before the resize. Soft-wrap step rendering
+    /// (<see cref="Hex1bAppOptions.UseSoftWrapEmission"/>) handles the
+    /// case where the step doesn't fit by scrolling some tombstones off
+    /// the top of the viewport into the host terminal's scrollback.
     /// </para>
     /// <para>
     /// When no live cursor query is available the runner falls back to
-    /// pure bottom-anchor based on the OLD captured origin/height, which
-    /// is the prior behaviour: simple, safe, but doesn't recover from
-    /// horizontal reflow.
+    /// bottom-anchor based on the new viewport height, which is the prior
+    /// behaviour: simple, safe, but doesn't recover from horizontal
+    /// reflow.
+    /// </para>
+    /// <para>
+    /// On the soft-wrap path the runner does NOT clear the OLD or NEW
+    /// step regions itself. The active step's
+    /// <see cref="Hex1bApp"/> emits each frame as a full-surface soft-wrap
+    /// dump prefixed by <c>ESC[1;1H ESC[J</c> — so the first post-resize
+    /// frame both clears the new step region AND wipes any leftover
+    /// content below it (including the OLD step region wherever the
+    /// terminal's reflow left it). Clearing here would only race against
+    /// that emission and risk wiping reflowed tombstone content.
+    /// </para>
+    /// <para>
+    /// The legacy (non-soft-wrap) path still clears the old/new regions
+    /// itself because the active step renders via absolute CUP and won't
+    /// emit a clear of its own.
     /// </para>
     /// <para>
     /// The clear+repaint is bracketed in DEC private mode 2026
@@ -824,20 +847,13 @@ internal sealed class Hex1bFlowRunner
         bool topAnchored;
         if (dsrRow is int row && row >= 0 && row < newHeight)
         {
-            // Hybrid strategy. Prefer top-anchor immediately past the
-            // tombstones so the step appears in the same logical position
-            // it was before the resize. Fall back to bottom-anchor when
-            // the step would overflow the viewport from that origin.
-            if (row + newStepHeight <= newHeight)
-            {
-                newRowOrigin = row;
-                topAnchored = true;
-            }
-            else
-            {
-                newRowOrigin = Math.Max(0, newHeight - newStepHeight);
-                topAnchored = false;
-            }
+            // Top-anchor at the queried row so the step appears in the
+            // same logical position it was before the resize. Soft-wrap
+            // step rendering handles overflow by scrolling some
+            // tombstones off the top of the viewport — preferable to a
+            // bottom-anchor that overlaps reflowed tombstone content.
+            newRowOrigin = row;
+            topAnchored = true;
         }
         else
         {
@@ -847,25 +863,33 @@ internal sealed class Hex1bFlowRunner
             topAnchored = false;
         }
 
-        Trace($"AnchorActiveStep[#{resizeId}] enter: oldRO={oldRowOrigin} oldH={oldStepHeight} newH={newHeight} newSH={newStepHeight} dsrRow={dsrRow?.ToString() ?? "<none>"} newRO={newRowOrigin} topAnchored={topAnchored}");
+        Trace($"AnchorActiveStep[#{resizeId}] enter: oldRO={oldRowOrigin} oldH={oldStepHeight} newH={newHeight} newSH={newStepHeight} dsrRow={dsrRow?.ToString() ?? "<none>"} newRO={newRowOrigin} topAnchored={topAnchored} softWrap={_options.UseSoftWrapTombstones}");
 
         _parentAdapter.Write(SyncUpdateBegin);
         try
         {
-            // Clear the OLD step region first, but only when bottom-anchoring
-            // without a cursor query — that's the path where oldRowOrigin
-            // is still meaningful (no horizontal reflow). When the cursor
-            // query succeeded the tombstones above have reflowed and the
-            // OLD region is no longer where it was; clearing there would
-            // wipe reflowed tombstone content.
-            if (oldStepHeight > 0 && dsrRow is null)
+            // On the soft-wrap path the step's Hex1bApp emits each frame
+            // as a full-surface dump prefixed by ESC[1;1H ESC[J. Once it
+            // re-renders after the resize, the leading ESC[1;1H ESC[J
+            // both positions to the new step origin AND wipes everything
+            // from there to the bottom of the viewport — which covers
+            // both the new step region AND any leftover content from the
+            // old step region wherever the host terminal's reflow left
+            // it. Clearing here would race with that emission and risk
+            // wiping reflowed tombstone content from above the new
+            // origin.
+            //
+            // The legacy (non-soft-wrap) path still clears both regions
+            // here because the step renders via absolute CUP and won't
+            // emit a clear of its own.
+            if (!_options.UseSoftWrapTombstones)
             {
-                ClearRegion(oldRowOrigin, oldStepHeight);
+                if (oldStepHeight > 0 && dsrRow is null)
+                {
+                    ClearRegion(oldRowOrigin, oldStepHeight);
+                }
+                ClearRegion(newRowOrigin, newStepHeight);
             }
-
-            // Clear the NEW step region so the step app's first post-resize
-            // render lands on a clean canvas.
-            ClearRegion(newRowOrigin, newStepHeight);
 
             _cursorRow = newRowOrigin;
 

--- a/src/Hex1b/Flow/Hex1bFlowRunner.cs
+++ b/src/Hex1b/Flow/Hex1bFlowRunner.cs
@@ -323,22 +323,20 @@ internal sealed class Hex1bFlowRunner
 
                     if (_options.UseSoftWrapTombstones)
                     {
-                        // Tombstones above are append-only — once they were
-                        // emitted as logical lines they belong to the host
-                        // terminal, which reflows them naturally on width
-                        // change and scrolls them into scrollback when they
-                        // overflow. The runner only needs to re-anchor the
-                        // active step (which uses absolute cursor positioning
-                        // and therefore does NOT reflow with the terminal).
-                        // Capture the OLD origin/height before mutating so
-                        // AnchorActiveStepOnResize can clear the right region.
-                        var oldRowOrigin = rowOrigin;
-                        var oldStepHeight = desiredHeight;
-                        var newRowOrigin = AnchorActiveStepOnResize(oldRowOrigin, oldStepHeight, newHeight, newStepHeight);
+                        // Resize strategy: push everything currently visible
+                        // up off the top of the viewport into the host
+                        // terminal's scrollback (where it will appear
+                        // soft-wrapped because tombstones were emitted as
+                        // logical lines), then clear the viewport and
+                        // re-anchor the active step at row 0. This avoids
+                        // any visual mangling from cell-positioned step
+                        // content trying to coexist with reflowed
+                        // tombstones at unpredictable rows.
+                        ScrollViewportToScrollback(newHeight);
 
-                        stepAdapter.RowOrigin = newRowOrigin;
-                        rowOrigin = newRowOrigin;
-                        _cursorRow = newRowOrigin;
+                        stepAdapter.RowOrigin = 0;
+                        rowOrigin = 0;
+                        _cursorRow = 0;
                         desiredHeight = newStepHeight;
                         step.StepHeight = newStepHeight;
                     }
@@ -753,147 +751,77 @@ internal sealed class Hex1bFlowRunner
         // there cleanly.
         _cursorRow += height;
 
-        // Park the cursor at the new tombstone-past row so a resize that
-        // arrives before the first step output flush still finds the
-        // cursor on a logical line the host terminal will reflow with the
-        // tombstones above. Only relevant when a live cursor query is
-        // available (CursorRowProvider) — without one there's nothing
-        // for the runner to recover from the parked position.
-        if (_options.CursorRowProvider != null)
-        {
-            _parentAdapter.SetCursorPosition(0, _cursorRow);
-        }
-
         Trace($"EmitSoftWrapTombstone[#{emitId}] exit: cursorRow={_cursorRow}");
     }
 
     /// <summary>
-    /// Resize-time helper that re-positions only the active step. Emitted
-    /// tombstones are append-only — once written into the host terminal's
-    /// buffer they are owned by the terminal, which reflows and scrolls
-    /// them naturally on resize. The runner never re-emits them.
+    /// Pushes the entire current viewport contents up off the top of the
+    /// screen and into the host terminal's scrollback buffer, then clears
+    /// the viewport. Used by the soft-wrap resize handler so the active
+    /// step (which uses absolute cursor positioning) can be cleanly
+    /// re-anchored at row 0 without competing with reflowed tombstone
+    /// content from the previous viewport.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// When a live cursor query is available
-    /// (<see cref="Hex1bFlowOptions.CursorRowProvider"/>) and
-    /// <see cref="PumpStepOutputAsync"/> has been parking the cursor at
-    /// the tombstone-past row, the runner queries the cursor first to
-    /// learn where that row landed after the host terminal reflowed the
-    /// tombstones above. The new active-step origin is anchored at the
-    /// queried row (top-anchor) so the step appears in the same logical
-    /// position it was before the resize. Soft-wrap step rendering
-    /// (<see cref="Hex1bAppOptions.UseSoftWrapEmission"/>) handles the
-    /// case where the step doesn't fit by scrolling some tombstones off
-    /// the top of the viewport into the host terminal's scrollback.
+    /// Tombstones above the active step were emitted as soft-wrap-friendly
+    /// logical lines, so once they are scrolled into scrollback the host
+    /// terminal renders them with proper word wrap at the new width.
+    /// Cell-positioned step content cannot reflow that way, so we just
+    /// scroll it away and let the step app repaint at the new size.
     /// </para>
     /// <para>
-    /// When no live cursor query is available the runner falls back to
-    /// bottom-anchor based on the new viewport height, which is the prior
-    /// behaviour: simple, safe, but doesn't recover from horizontal
-    /// reflow.
+    /// Mechanism: park cursor at the bottom row, write <paramref name="newHeight"/>
+    /// linefeeds. Each LF at the bottom row scrolls the viewport up by one
+    /// row (pushing the top row into scrollback), so writing a full
+    /// viewport-height worth of LFs guarantees every previously-visible
+    /// row ends up in scrollback. Then position cursor at home and clear
+    /// from there to end of screen — this leaves a fully blank viewport
+    /// with cursor at (0,0), ready for the step to re-render.
     /// </para>
     /// <para>
-    /// On the soft-wrap path the runner does NOT clear the OLD or NEW
-    /// step regions itself. The active step's
-    /// <see cref="Hex1bApp"/> emits each frame as a full-surface soft-wrap
-    /// dump prefixed by <c>ESC[1;1H ESC[J</c> — so the first post-resize
-    /// frame both clears the new step region AND wipes any leftover
-    /// content below it (including the OLD step region wherever the
-    /// terminal's reflow left it). Clearing here would only race against
-    /// that emission and risk wiping reflowed tombstone content.
-    /// </para>
-    /// <para>
-    /// The legacy (non-soft-wrap) path still clears the old/new regions
-    /// itself because the active step renders via absolute CUP and won't
-    /// emit a clear of its own.
-    /// </para>
-    /// <para>
-    /// The clear+repaint is bracketed in DEC private mode 2026
-    /// (Synchronized Update Mode), so terminals that recognise it present
-    /// the entire repaint as one atomic frame instead of a brief blank
-    /// flash. Terminals that ignore mode 2026 see a slightly more visible
-    /// repaint but no functional regression.
+    /// Bracketed in DEC private mode 2026 (Synchronized Update Mode) so
+    /// supporting terminals present the scroll+clear as one atomic frame.
+    /// Terminals that ignore mode 2026 see a brief flash but no
+    /// functional regression.
     /// </para>
     /// </remarks>
-    /// <param name="oldRowOrigin">Top row of the active step before the resize.</param>
-    /// <param name="oldStepHeight">Height of the active step before the resize.</param>
-    /// <param name="newHeight">New terminal height.</param>
-    /// <param name="newStepHeight">Computed new height for the active step.</param>
-    /// <returns>The new row origin for the active step.</returns>
-    private int AnchorActiveStepOnResize(int oldRowOrigin, int oldStepHeight, int newHeight, int newStepHeight)
+    private void ScrollViewportToScrollback(int newHeight)
     {
         var resizeId = Interlocked.Increment(ref _resizeCounter);
-
-        // NOTE: Do NOT call CursorRowProvider here. On Unix, CursorRowProvider
-        // calls Console.GetCursorPosition() which sends ESC[6n to the terminal
-        // and then reads the ESC[row;colR response from stdin. But Hex1b's input
-        // pump is also reading from stdin in a background loop. This creates a
-        // deadlock: the resize handler blocks waiting for the DSR response while
-        // the background stdin reader consumes those bytes first. Always use
-        // bottom-anchor for the active step during resize — it is safe, matches
-        // pre-PR behaviour, and avoids the cross-platform stdin contention.
-        var newRowOrigin = Math.Max(0, newHeight - newStepHeight);
-
-        Trace($"AnchorActiveStep[#{resizeId}] enter: oldRO={oldRowOrigin} oldH={oldStepHeight} newH={newHeight} newSH={newStepHeight} newRO={newRowOrigin} softWrap={_options.UseSoftWrapTombstones}");
+        Trace($"ScrollViewportToScrollback[#{resizeId}] enter: newHeight={newHeight}");
 
         _parentAdapter.Write(SyncUpdateBegin);
         try
         {
-            // On the soft-wrap path the step's Hex1bApp emits each frame
-            // as a full-surface dump prefixed by ESC[1;1H ESC[J. Once it
-            // re-renders after the resize, the leading ESC[1;1H ESC[J
-            // both positions to the new step origin AND wipes everything
-            // from there to the bottom of the viewport — which covers
-            // both the new step region AND any leftover content from the
-            // old step region wherever the host terminal's reflow left
-            // it. Clearing here would race with that emission and risk
-            // wiping reflowed tombstone content from above the new
-            // origin.
-            //
-            // The legacy (non-soft-wrap) path still clears both regions
-            // here because the step renders via absolute CUP and won't
-            // emit a clear of its own.
-            if (!_options.UseSoftWrapTombstones)
+            // Park at bottom-left and emit one LF per viewport row. Each
+            // LF at the bottom scrolls the viewport up by one row, moving
+            // the top line into scrollback. After newHeight LFs every
+            // previously-visible row has been pushed into scrollback.
+            _parentAdapter.SetCursorPosition(0, newHeight - 1);
+            var sb = new StringBuilder(newHeight);
+            for (int i = 0; i < newHeight; i++)
             {
-                if (oldStepHeight > 0)
-                {
-                    ClearRegion(oldRowOrigin, oldStepHeight);
-                }
-                ClearRegion(newRowOrigin, newStepHeight);
+                sb.Append('\n');
             }
+            _parentAdapter.Write(sb.ToString());
 
-            _cursorRow = newRowOrigin;
-
-            // Re-park the cursor at the new bottom-anchor row so the next
-            // resize-during-idle finds it in the right place.
-            if (_options.UseSoftWrapTombstones)
-            {
-                _parentAdapter.SetCursorPosition(0, _cursorRow);
-            }
-
-            Trace($"AnchorActiveStep[#{resizeId}] exit: cursorRow={_cursorRow}");
-            return newRowOrigin;
+            // Home + clear-to-end-of-screen. After scrolling, the cursor
+            // may be anywhere; reset to top-left and wipe so the step can
+            // render from a known-blank canvas.
+            _parentAdapter.Write("\x1b[1;1H\x1b[J");
         }
         finally
         {
             _parentAdapter.Write(SyncUpdateEnd);
         }
+
+        Trace($"ScrollViewportToScrollback[#{resizeId}] exit");
     }
 
     /// <summary>
     /// Pumps output from a step adapter to the parent adapter.
     /// </summary>
-    /// <remarks>
-    /// On the soft-wrap path the cursor is "parked" at the row past the
-    /// last tombstone after every output flush. Cooperative terminals
-    /// (Windows Terminal, iTerm2, Kitty, Foot, VTE, Ghostty, WezTerm) move
-    /// the cursor along with reflowed logical lines on horizontal resize
-    /// — by parking the cursor on the empty logical line just past the
-    /// tombstones, the runner can recover the post-reflow tombstone-bottom
-    /// row via <see cref="QueryCursorRowAsync"/> when a resize event fires
-    /// while the step is idle.
-    /// </remarks>
     private async Task PumpStepOutputAsync(InlineStepAdapter stepAdapter, CancellationToken ct)
     {
         try
@@ -903,18 +831,6 @@ internal sealed class Hex1bFlowRunner
                 var data = await stepAdapter.ReadOutputAsync(ct);
                 if (data.IsEmpty) continue;
                 _parentAdapter.Write(Encoding.UTF8.GetString(data.Span));
-
-                if (_options.UseSoftWrapTombstones && _options.CursorRowProvider != null)
-                {
-                    // Park the cursor at the row past the last tombstone so
-                    // a resize-during-idle catches it on a logical line the
-                    // host terminal will reflow correctly. The next step
-                    // frame uses absolute CUP for every cell so this leak
-                    // does not corrupt rendering — at worst the user sees
-                    // a brief cursor blip at column 0 of the parked row,
-                    // which is hidden in TUI mode anyway.
-                    _parentAdapter.SetCursorPosition(0, _cursorRow);
-                }
             }
         }
         catch (OperationCanceledException) { }

--- a/src/Hex1b/Flow/Hex1bFlowRunner.cs
+++ b/src/Hex1b/Flow/Hex1bFlowRunner.cs
@@ -825,45 +825,17 @@ internal sealed class Hex1bFlowRunner
     {
         var resizeId = Interlocked.Increment(ref _resizeCounter);
 
-        // Try to recover the post-reflow tombstone-bottom row from the
-        // host terminal. The output pump has been parking the cursor at
-        // _cursorRow (i.e. the row past the last tombstone) after every
-        // step output flush, so cooperative terminals reflow that
-        // logical position alongside the tombstones above.
-        int? dsrRow = null;
-        if (_options.CursorRowProvider != null)
-        {
-            try
-            {
-                dsrRow = _options.CursorRowProvider();
-            }
-            catch
-            {
-                dsrRow = null;
-            }
-        }
+        // NOTE: Do NOT call CursorRowProvider here. On Unix, CursorRowProvider
+        // calls Console.GetCursorPosition() which sends ESC[6n to the terminal
+        // and then reads the ESC[row;colR response from stdin. But Hex1b's input
+        // pump is also reading from stdin in a background loop. This creates a
+        // deadlock: the resize handler blocks waiting for the DSR response while
+        // the background stdin reader consumes those bytes first. Always use
+        // bottom-anchor for the active step during resize — it is safe, matches
+        // pre-PR behaviour, and avoids the cross-platform stdin contention.
+        var newRowOrigin = Math.Max(0, newHeight - newStepHeight);
 
-        int newRowOrigin;
-        bool topAnchored;
-        if (dsrRow is int row && row >= 0 && row < newHeight)
-        {
-            // Top-anchor at the queried row so the step appears in the
-            // same logical position it was before the resize. Soft-wrap
-            // step rendering handles overflow by scrolling some
-            // tombstones off the top of the viewport — preferable to a
-            // bottom-anchor that overlaps reflowed tombstone content.
-            newRowOrigin = row;
-            topAnchored = true;
-        }
-        else
-        {
-            // No live cursor query (or implausible result) — bottom-anchor
-            // and accept that the tombstones above may have shifted.
-            newRowOrigin = Math.Max(0, newHeight - newStepHeight);
-            topAnchored = false;
-        }
-
-        Trace($"AnchorActiveStep[#{resizeId}] enter: oldRO={oldRowOrigin} oldH={oldStepHeight} newH={newHeight} newSH={newStepHeight} dsrRow={dsrRow?.ToString() ?? "<none>"} newRO={newRowOrigin} topAnchored={topAnchored} softWrap={_options.UseSoftWrapTombstones}");
+        Trace($"AnchorActiveStep[#{resizeId}] enter: oldRO={oldRowOrigin} oldH={oldStepHeight} newH={newHeight} newSH={newStepHeight} newRO={newRowOrigin} softWrap={_options.UseSoftWrapTombstones}");
 
         _parentAdapter.Write(SyncUpdateBegin);
         try
@@ -884,7 +856,7 @@ internal sealed class Hex1bFlowRunner
             // emit a clear of its own.
             if (!_options.UseSoftWrapTombstones)
             {
-                if (oldStepHeight > 0 && dsrRow is null)
+                if (oldStepHeight > 0)
                 {
                     ClearRegion(oldRowOrigin, oldStepHeight);
                 }
@@ -893,9 +865,9 @@ internal sealed class Hex1bFlowRunner
 
             _cursorRow = newRowOrigin;
 
-            // Re-park the cursor at the new tombstone-past row so the next
+            // Re-park the cursor at the new bottom-anchor row so the next
             // resize-during-idle finds it in the right place.
-            if (_options.CursorRowProvider != null)
+            if (_options.UseSoftWrapTombstones)
             {
                 _parentAdapter.SetCursorPosition(0, _cursorRow);
             }
@@ -1031,9 +1003,8 @@ public sealed class Hex1bFlowOptions
 
     /// <summary>
     /// Optional delegate that returns the host terminal's current cursor row
-    /// (0-based). When set, the flow runner uses this to recover the
-    /// post-reflow position of the row past the last tombstone after a
-    /// horizontal resize on cooperative terminals.
+    /// (0-based). When set, the flow runner uses this to read the initial
+    /// cursor position at startup, before the input pump is running.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -1041,11 +1012,18 @@ public sealed class Hex1bFlowOptions
     /// <c>Hex1bTerminalBuilder.WithHex1bFlow</c> when a presentation adapter
     /// is available. On Windows this resolves through Win32
     /// <c>GetConsoleScreenBufferInfo</c> (no DSR roundtrip); on Unix the BCL
-    /// uses a real DSR query.
+    /// uses a raw DSR query that reads the response from stdin.
+    /// </para>
+    /// <para>
+    /// <strong>Must not be called from within a resize handler.</strong>
+    /// On Unix, calling this while Hex1b's input pump is running causes a
+    /// deadlock: the DSR response arrives on the same stdin file descriptor
+    /// that the input pump owns, so <c>Console.GetCursorPosition()</c>
+    /// blocks forever waiting for bytes it will never receive.
     /// </para>
     /// <para>
     /// Returns <c>null</c> to indicate the cursor row could not be
-    /// determined; the runner then falls back to bottom-anchor on resize.
+    /// determined.
     /// </para>
     /// </remarks>
     public Func<int?>? CursorRowProvider { get; set; }

--- a/src/Hex1b/Flow/Hex1bFlowRunner.cs
+++ b/src/Hex1b/Flow/Hex1bFlowRunner.cs
@@ -650,9 +650,17 @@ internal sealed class Hex1bFlowRunner
 
         SoftWrapEmitter.Emit(surface, _parentAdapter);
 
-        // Each row in the surface terminates with a hard '\n', so the
-        // terminal cursor has advanced exactly `height` rows. Update our
-        // bookkeeping accordingly.
+        // The emitter terminates rows 0 .. height-2 with CR + LF (each
+        // advances the cursor down one row, with no scrolling because we
+        // pre-scrolled above to guarantee the last row lands at or above the
+        // bottom of the viewport). The final row deliberately has no trailing
+        // newline so emitting a tombstone at the very bottom does not scroll
+        // the content one row up — visually the tombstone freezes in place
+        // exactly where the step was. The terminal cursor therefore ends up
+        // at (last-row-content-column, _cursorRow + height - 1); for our
+        // bookkeeping we want _cursorRow to point at the row immediately
+        // *below* the last visible tombstone row, so the next render lands
+        // there cleanly.
         _cursorRow += height;
     }
 

--- a/src/Hex1b/Flow/Hex1bFlowRunner.cs
+++ b/src/Hex1b/Flow/Hex1bFlowRunner.cs
@@ -24,7 +24,8 @@ internal sealed class Hex1bFlowRunner
     /// the last emitted line (capped to the bottom of the viewport when the
     /// terminal had to scroll). After a resize on the soft-wrap path, this is
     /// re-anchored to the top of the bottom-aligned active-step region so the
-    /// next tombstone appears immediately above the active step again.
+    /// next tombstone (when the active step completes) lands directly in the
+    /// step's place.
     /// </summary>
     private int _cursorRow;
 
@@ -34,45 +35,20 @@ internal sealed class Hex1bFlowRunner
     // CancellationToken from RunAsync, surfaced to flow callbacks via Hex1bFlowContext.
     private CancellationToken _cancellationToken;
 
-    // Builders for every soft-wrap tombstone emitted by this runner, in
-    // emission order. Used by the resize handler on the
-    // UseSoftWrapTombstones path to re-render the entire tombstone history
-    // at the new terminal width: the host terminal's reflow algorithm is
-    // unpredictable across terminal emulators (xterm vs Windows Terminal vs
-    // iTerm2 vs VTE), and the previous "clear only the active-step region
-    // and trust the terminal" strategy left ghost copies of the old active
-    // step above the new one and could clip wrapped tombstones. Owning the
-    // re-render eliminates the dependence on terminal-specific behaviour at
-    // the cost of one extra surface render per tombstone per resize event.
-    // Resize is rare and tombstones are small, so the cost is negligible.
-    // List is appended to from the soft-wrap branches of RenderStaticAsync
-    // and RunStepLifecycleAsync's post-step block; never cleared during the
-    // flow's lifetime.
-    private readonly List<Func<RootContext, Hex1bWidget>> _tombstoneBuilders = new();
-
-    // The terminal row at which this flow's content begins. Initialised
-    // from Hex1bFlowOptions.InitialCursorRow at the start of RunAsync, then
-    // decremented by overflow whenever the runner pre-scrolls the terminal
-    // (in EmitSoftWrapTombstone, RenderStaticAsync, or
-    // RunStepLifecycleAsync). The resize handler uses this to position the
-    // cursor at the flow's origin and clear-from-cursor-to-end (ESC[J),
-    // preserving any user content above the flow (typically a shell prompt)
-    // that hasn't yet been scrolled into the host terminal's scrollback.
-    private int _flowOriginRow;
-
     // DEC private mode 2026 (Synchronized Update Mode). Wrapping the
-    // resize-time clear-and-re-render in BSU/ESU lets supporting terminals
-    // present the whole repaint as a single atomic frame, eliminating the
-    // brief blank flash between "clear viewport" and "tombstones drawn".
-    // Terminals that don't recognise mode 2026 ignore both sequences.
+    // resize-time clear-and-redraw in BSU/ESU lets supporting terminals
+    // present the whole repaint as a single atomic frame, eliminating any
+    // brief blank flash between clearing the old step region and the step
+    // app re-rendering into the new one. Terminals that don't recognise
+    // mode 2026 ignore both sequences.
     private const string SyncUpdateBegin = "\x1b[?2026h";
     private const string SyncUpdateEnd = "\x1b[?2026l";
 
     // Diagnostic trace gated on the HEX1B_FLOW_TRACE environment variable.
     // When set to a writable file path, every interesting state transition
-    // (tombstone emission, pre-scroll, resize handling, re-render) is
-    // appended to that file. Used to investigate visual artefacts like
-    // duplicate tombstones on resize. The path is read once at process start.
+    // (tombstone emission, pre-scroll, resize handling) is appended to
+    // that file. Used to investigate visual artefacts like duplicate
+    // tombstones on resize. The path is read once at process start.
     private static readonly string? TraceLogPath = Environment.GetEnvironmentVariable("HEX1B_FLOW_TRACE");
     private static readonly object TraceLock = new();
     private static int _resizeCounter;
@@ -140,14 +116,13 @@ internal sealed class Hex1bFlowRunner
 
         // Query the current cursor position using DSR (Device Status Report)
         _cursorRow = await QueryCursorRowAsync(ct);
-        _flowOriginRow = _cursorRow;
 
-        Trace($"RunAsync start: termSize={_parentAdapter.Width}x{_parentAdapter.Height} cursorRow={_cursorRow} flowOriginRow={_flowOriginRow} useSoftWrap={_options.UseSoftWrapTombstones}");
+        Trace($"RunAsync start: termSize={_parentAdapter.Width}x{_parentAdapter.Height} cursorRow={_cursorRow} useSoftWrap={_options.UseSoftWrapTombstones}");
 
         var context = new Hex1bFlowContext(this);
         await _flowCallback(context);
 
-        Trace($"RunAsync end: cursorRow={_cursorRow} flowOriginRow={_flowOriginRow} tombstones={_tombstoneBuilders.Count}");
+        Trace($"RunAsync end: cursorRow={_cursorRow}");
 
         // After flow completes, position cursor below the last yield widget
         _parentAdapter.SetCursorPosition(0, _cursorRow);
@@ -177,7 +152,6 @@ internal sealed class Hex1bFlowRunner
                 _parentAdapter.Write("\n");
             }
             _cursorRow -= overflow;
-            _flowOriginRow = Math.Max(0, _flowOriginRow - overflow);
         }
 
         // Clear and render
@@ -186,14 +160,11 @@ internal sealed class Hex1bFlowRunner
         {
             // Render the static content into a surface and emit it as
             // soft-wrap-friendly logical lines so the host terminal owns
-            // the reflow/scroll behaviour.
+            // the reflow/scroll behaviour for the lifetime of the flow.
             var surface = RenderToSurface(builder, terminalWidth, contentHeight);
             if (surface is not null)
             {
                 EmitSoftWrapTombstone(surface);
-                // Track the builder so a later resize can re-render this
-                // static tombstone at the new width via the resize handler.
-                _tombstoneBuilders.Add(builder);
                 return;
             }
             // Fall through to legacy path if surface rendering failed.
@@ -299,7 +270,6 @@ internal sealed class Hex1bFlowRunner
                 }
                 rowOrigin -= overflow;
                 _cursorRow = rowOrigin;
-                _flowOriginRow = Math.Max(0, _flowOriginRow - overflow);
             }
 
             // Clear the step region
@@ -343,15 +313,18 @@ internal sealed class Hex1bFlowRunner
 
                     if (_options.UseSoftWrapTombstones)
                     {
-                        // Owned re-render: clear the entire visible area and
-                        // redraw the tombstone history from scratch at the new
-                        // width, then re-anchor the active step. This avoids
-                        // the unpredictable host-terminal reflow behaviour that
-                        // would otherwise leave a ghost of the old active step
-                        // above the new one and could clip wrapped tombstones
-                        // on width shrink. See the comment on
-                        // _tombstoneBuilders for the full rationale.
-                        var newRowOrigin = ReRenderTombstonesAndAnchorStep(newWidth, newHeight, newStepHeight);
+                        // Tombstones above are append-only — once they were
+                        // emitted as logical lines they belong to the host
+                        // terminal, which reflows them naturally on width
+                        // change and scrolls them into scrollback when they
+                        // overflow. The runner only needs to re-anchor the
+                        // active step (which uses absolute cursor positioning
+                        // and therefore does NOT reflow with the terminal).
+                        // Capture the OLD origin/height before mutating so
+                        // AnchorActiveStepOnResize can clear the right region.
+                        var oldRowOrigin = rowOrigin;
+                        var oldStepHeight = desiredHeight;
+                        var newRowOrigin = AnchorActiveStepOnResize(oldRowOrigin, oldStepHeight, newHeight, newStepHeight);
 
                         stepAdapter.RowOrigin = newRowOrigin;
                         rowOrigin = newRowOrigin;
@@ -414,11 +387,7 @@ internal sealed class Hex1bFlowRunner
                     if (surface is not null)
                     {
                         EmitSoftWrapTombstone(surface);
-                        // Track the builder so a later resize can re-render
-                        // this completed-step tombstone at the new width
-                        // via the resize handler.
-                        _tombstoneBuilders.Add(completedBuilder);
-                        Trace($"Step completed: tombstone tracked, total builders={_tombstoneBuilders.Count}");
+                        Trace("Step completed: tombstone emitted (append-only, terminal owns reflow)");
                     }
                     else
                     {
@@ -527,7 +496,6 @@ internal sealed class Hex1bFlowRunner
                 for (int i = 0; i < overflow; i++)
                     _parentAdapter.Write("\n");
                 _cursorRow -= overflow;
-                _flowOriginRow = Math.Max(0, _flowOriginRow - overflow);
             }
 
             // Clear the page region
@@ -738,7 +706,7 @@ internal sealed class Hex1bFlowRunner
         var height = surface.Height;
         var terminalHeight = _parentAdapter.Height;
 
-        Trace($"EmitSoftWrapTombstone[#{emitId}] enter: surfaceSize={surface.Width}x{height} cursorRow={_cursorRow} flowOriginRow={_flowOriginRow} termH={terminalHeight}");
+        Trace($"EmitSoftWrapTombstone[#{emitId}] enter: surfaceSize={surface.Width}x{height} cursorRow={_cursorRow} termH={terminalHeight}");
 
         // Pre-scroll the viewport if there isn't enough room below the cursor
         // for the tombstone. We use the same trick as the legacy paths
@@ -754,8 +722,7 @@ internal sealed class Hex1bFlowRunner
                 _parentAdapter.Write("\n");
             }
             _cursorRow -= overflow;
-            _flowOriginRow = Math.Max(0, _flowOriginRow - overflow);
-            Trace($"EmitSoftWrapTombstone[#{emitId}] pre-scroll: overflow={overflow} -> cursorRow={_cursorRow} flowOriginRow={_flowOriginRow}");
+            Trace($"EmitSoftWrapTombstone[#{emitId}] pre-scroll: overflow={overflow} -> cursorRow={_cursorRow}");
         }
 
         // Position the cursor at the row where the tombstone should land.
@@ -775,129 +742,75 @@ internal sealed class Hex1bFlowRunner
         // *below* the last visible tombstone row, so the next render lands
         // there cleanly.
         _cursorRow += height;
-        Trace($"EmitSoftWrapTombstone[#{emitId}] exit: cursorRow={_cursorRow} flowOriginRow={_flowOriginRow}");
+        Trace($"EmitSoftWrapTombstone[#{emitId}] exit: cursorRow={_cursorRow}");
     }
 
     /// <summary>
-    /// Resize-time owned re-render: clears the entire visible viewport,
-    /// re-emits every tracked tombstone at the new terminal width starting
-    /// at the top of the screen, and computes the row origin where the
-    /// active step should be anchored. Called only on the soft-wrap path.
-    /// Returns the row origin for the active step.
+    /// Resize-time helper that re-positions only the active step. Emitted
+    /// tombstones are append-only — once written into the host terminal's
+    /// buffer they are owned by the terminal, which reflows and scrolls
+    /// them naturally on resize. The runner never re-emits them.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The previous resize strategy ("clear from <see cref="_flowOriginRow"/>
-    /// down and trust our row tracking to be in sync") had an unfixable
-    /// problem on terminals that reflow logical lines on horizontal resize
-    /// (Windows Terminal, iTerm2, modern xterm builds): tombstones are
-    /// emitted as logical lines via <see cref="SoftWrapEmitter"/> precisely
-    /// so that they reflow naturally, but reflow also moves them around
-    /// vertically — what was at row N before the resize might now be at
-    /// row M after the resize. <see cref="_flowOriginRow"/> tracked our
-    /// own pre-scrolls but had no way to learn about reflow-induced row
-    /// shifts. The result was that <c>SetCursorPosition(0, _flowOriginRow)
-    /// + ESC[J</c> sometimes left terminal-reflowed copies of the
-    /// tombstones above the cursor, and our re-emitted copies landed
-    /// below them — duplicate tombstones on screen.
+    /// The runner clears the OLD active-step region (using the row origin
+    /// and height the step occupied immediately before the resize fired)
+    /// and then clears the NEW bottom-anchored region into which the step
+    /// app will re-render. The active step uses absolute cursor positioning
+    /// rather than logical lines, so the host terminal does not reflow it
+    /// — explicit clear-and-re-anchor is required.
     /// </para>
     /// <para>
-    /// To make the resize repaint deterministic regardless of host
-    /// terminal reflow behaviour, this method now wipes the entire
-    /// visible viewport (<c>ESC[H ESC[2J</c>) and redraws the tombstone
-    /// history starting at row 0 of the visible area. Any user content
-    /// that was visible above the flow before the resize (typically a
-    /// shell prompt) is therefore lost from the visible area on the
-    /// first resize. It is preserved in the host terminal's scrollback
-    /// (the host has already reflowed it there as part of its own resize
-    /// handling), so the user can still scroll up to see it. This is a
-    /// deliberate trade-off: a one-time loss of the prompt from view is
-    /// less disruptive than ghost copies of every tombstone stacking up
-    /// each time the user resizes.
+    /// Trade-off: if a horizontal shrink causes a tombstone above the
+    /// active step to wrap downward into the new step region, the bottom
+    /// of that tombstone is wiped by the new-region clear and the step
+    /// repaints over it. The remainder of the tombstone above the step
+    /// stays visible. This is the deliberate cost of the
+    /// "tombstones-are-append-only" design: we never fight the host
+    /// terminal's reflow algorithm or risk stacking up duplicate
+    /// tombstones by re-emitting on every resize.
     /// </para>
     /// <para>
-    /// The clear+redraw is bracketed in DEC private mode 2026
+    /// The clear+repaint is bracketed in DEC private mode 2026
     /// (Synchronized Update Mode), so terminals that recognise it present
     /// the entire repaint as one atomic frame instead of a brief blank
     /// flash. Terminals that ignore mode 2026 see a slightly more visible
     /// repaint but no functional regression.
     /// </para>
-    /// <para>
-    /// <see cref="EmitSoftWrapTombstone"/>'s pre-scroll logic handles
-    /// overflow into the host terminal's scrollback the same way it does
-    /// during normal flow execution, so the user's mental model — "oldest
-    /// tombstones go up into scrollback as new ones land at the bottom" —
-    /// is preserved across resize.
-    /// </para>
     /// </remarks>
-    private int ReRenderTombstonesAndAnchorStep(int newWidth, int newHeight, int newStepHeight)
+    /// <param name="oldRowOrigin">Top row of the active step before the resize.</param>
+    /// <param name="oldStepHeight">Height of the active step before the resize.</param>
+    /// <param name="newHeight">New terminal height.</param>
+    /// <param name="newStepHeight">Computed new height for the active step.</param>
+    /// <returns>The new bottom-anchored row origin for the active step.</returns>
+    private int AnchorActiveStepOnResize(int oldRowOrigin, int oldStepHeight, int newHeight, int newStepHeight)
     {
         var resizeId = Interlocked.Increment(ref _resizeCounter);
-        Trace($"ReRender[#{resizeId}] enter: newSize={newWidth}x{newHeight} newStepH={newStepHeight} cursorRow={_cursorRow} flowOriginRow={_flowOriginRow} builders={_tombstoneBuilders.Count}");
+        var newRowOrigin = Math.Max(0, newHeight - newStepHeight);
 
-        // Begin synchronized update so supporting terminals present the whole
-        // clear-and-redraw as a single atomic frame.
+        Trace($"AnchorActiveStep[#{resizeId}] enter: oldRO={oldRowOrigin} oldH={oldStepHeight} newH={newHeight} newSH={newStepHeight} newRO={newRowOrigin}");
+
         _parentAdapter.Write(SyncUpdateBegin);
-
         try
         {
-            // Wipe the entire visible viewport. We deliberately do NOT use
-            // _flowOriginRow + ESC[J here: the host terminal may have
-            // already reflowed our tombstones to a different row range
-            // before this handler runs, and our row tracking has no way
-            // to learn about that. ESC[H ESC[2J unconditionally homes the
-            // cursor and clears the visible area, giving us a known-good
-            // starting state. Anything previously visible above the flow
-            // is preserved in scrollback (the host terminal puts it
-            // there during its own resize handling).
-            _parentAdapter.Write("\x1b[H\x1b[2J");
-            _cursorRow = 0;
-            _flowOriginRow = 0;
-            Trace($"ReRender[#{resizeId}] cleared full viewport, reset to row 0");
-
-            // Re-emit every tracked tombstone at the new width starting at
-            // row 0. The emitter's pre-scroll logic naturally pushes
-            // earlier tombstones into scrollback when the viewport can't
-            // hold them all, matching the behaviour of normal flow
-            // execution.
-            for (int i = 0; i < _tombstoneBuilders.Count; i++)
+            // Clear the OLD step region first. After horizontal-only resize
+            // the old absolute-positioned cells typically remain at the same
+            // rows, so this hits the right place. After vertical resize or
+            // unusual reflow the clear may miss — leftover ghost cells are
+            // accepted as part of the append-only design.
+            if (oldStepHeight > 0)
             {
-                var builder = _tombstoneBuilders[i];
-                var surface = RenderToSurface(builder, newWidth, newHeight);
-                if (surface is null)
-                {
-                    Trace($"ReRender[#{resizeId}] tombstone[{i}] surface=NULL, skipping");
-                    continue;
-                }
-                Trace($"ReRender[#{resizeId}] tombstone[{i}] re-emit: size={surface.Width}x{surface.Height}");
-                EmitSoftWrapTombstone(surface);
+                ClearRegion(oldRowOrigin, oldStepHeight);
             }
 
-            // Pre-scroll if the active step won't fit below the last
-            // tombstone. After this, _cursorRow + newStepHeight <= newHeight
-            // is guaranteed, so the step region we hand back is fully on
-            // screen.
-            var overflow = (_cursorRow + newStepHeight) - newHeight;
-            if (overflow > 0)
-            {
-                _parentAdapter.SetCursorPosition(0, newHeight - 1);
-                for (int i = 0; i < overflow; i++)
-                {
-                    _parentAdapter.Write("\n");
-                }
-                _cursorRow -= overflow;
-                _flowOriginRow = Math.Max(0, _flowOriginRow - overflow);
-                Trace($"ReRender[#{resizeId}] step pre-scroll: overflow={overflow} -> cursorRow={_cursorRow} flowOriginRow={_flowOriginRow}");
-            }
+            // Clear the NEW step region so the step app's first post-resize
+            // render lands on a clean canvas, even if the new region overlaps
+            // the old one or any reflowed tombstone content above.
+            ClearRegion(newRowOrigin, newStepHeight);
 
-            // Clear the active-step region so the step app's first
-            // post-resize render lands on a clean canvas. Without this the
-            // tombstone renderer's last emitted glyph would still be visible
-            // in column 0 of the step's first row until overwritten.
-            ClearRegion(_cursorRow, newStepHeight);
-
-            Trace($"ReRender[#{resizeId}] exit: returning rowOrigin={_cursorRow} flowOriginRow={_flowOriginRow}");
-            return _cursorRow;
+            _cursorRow = newRowOrigin;
+            Trace($"AnchorActiveStep[#{resizeId}] exit: cursorRow={_cursorRow}");
+            return newRowOrigin;
         }
         finally
         {

--- a/src/Hex1b/Flow/Hex1bFlowRunner.cs
+++ b/src/Hex1b/Flow/Hex1bFlowRunner.cs
@@ -68,6 +68,38 @@ internal sealed class Hex1bFlowRunner
     private const string SyncUpdateBegin = "\x1b[?2026h";
     private const string SyncUpdateEnd = "\x1b[?2026l";
 
+    // Diagnostic trace gated on the HEX1B_FLOW_TRACE environment variable.
+    // When set to a writable file path, every interesting state transition
+    // (tombstone emission, pre-scroll, resize handling, re-render) is
+    // appended to that file. Used to investigate visual artefacts like
+    // duplicate tombstones on resize. The path is read once at process start.
+    private static readonly string? TraceLogPath = Environment.GetEnvironmentVariable("HEX1B_FLOW_TRACE");
+    private static readonly object TraceLock = new();
+    private static int _resizeCounter;
+    private static int _emitCounter;
+
+    // Always callable; becomes a near-zero-cost no-op when the env var is
+    // unset (one nullable field read, one early return). Not gated on
+    // [Conditional("DEBUG")] so users can capture traces from a Release-mode
+    // build of FlowDemo without a special rebuild.
+    private static void Trace(string message)
+    {
+        var path = TraceLogPath;
+        if (string.IsNullOrEmpty(path)) return;
+        lock (TraceLock)
+        {
+            try
+            {
+                File.AppendAllText(path, $"[{DateTime.UtcNow:HH:mm:ss.fff}] {message}{Environment.NewLine}");
+            }
+            catch
+            {
+                // Diagnostic logging is best-effort; never let a trace write
+                // disrupt the flow.
+            }
+        }
+    }
+
     public Hex1bFlowRunner(
         Func<Hex1bFlowContext, Task> flowCallback,
         Hex1bFlowOptions options,
@@ -110,8 +142,12 @@ internal sealed class Hex1bFlowRunner
         _cursorRow = await QueryCursorRowAsync(ct);
         _flowOriginRow = _cursorRow;
 
+        Trace($"RunAsync start: termSize={_parentAdapter.Width}x{_parentAdapter.Height} cursorRow={_cursorRow} flowOriginRow={_flowOriginRow} useSoftWrap={_options.UseSoftWrapTombstones}");
+
         var context = new Hex1bFlowContext(this);
         await _flowCallback(context);
+
+        Trace($"RunAsync end: cursorRow={_cursorRow} flowOriginRow={_flowOriginRow} tombstones={_tombstoneBuilders.Count}");
 
         // After flow completes, position cursor below the last yield widget
         _parentAdapter.SetCursorPosition(0, _cursorRow);
@@ -303,6 +339,7 @@ internal sealed class Hex1bFlowRunner
                 onResize: (newWidth, newHeight) =>
                 {
                     var newStepHeight = FlowResizeMath.ComputeStepHeight(options?.MaxHeight, newHeight);
+                    Trace($"onResize: newSize={newWidth}x{newHeight} newStepH={newStepHeight} useSoftWrap={_options.UseSoftWrapTombstones}");
 
                     if (_options.UseSoftWrapTombstones)
                     {
@@ -381,6 +418,7 @@ internal sealed class Hex1bFlowRunner
                         // this completed-step tombstone at the new width
                         // via the resize handler.
                         _tombstoneBuilders.Add(completedBuilder);
+                        Trace($"Step completed: tombstone tracked, total builders={_tombstoneBuilders.Count}");
                     }
                     else
                     {
@@ -696,8 +734,11 @@ internal sealed class Hex1bFlowRunner
     /// </summary>
     private void EmitSoftWrapTombstone(Surface surface)
     {
+        var emitId = Interlocked.Increment(ref _emitCounter);
         var height = surface.Height;
         var terminalHeight = _parentAdapter.Height;
+
+        Trace($"EmitSoftWrapTombstone[#{emitId}] enter: surfaceSize={surface.Width}x{height} cursorRow={_cursorRow} flowOriginRow={_flowOriginRow} termH={terminalHeight}");
 
         // Pre-scroll the viewport if there isn't enough room below the cursor
         // for the tombstone. We use the same trick as the legacy paths
@@ -714,6 +755,7 @@ internal sealed class Hex1bFlowRunner
             }
             _cursorRow -= overflow;
             _flowOriginRow = Math.Max(0, _flowOriginRow - overflow);
+            Trace($"EmitSoftWrapTombstone[#{emitId}] pre-scroll: overflow={overflow} -> cursorRow={_cursorRow} flowOriginRow={_flowOriginRow}");
         }
 
         // Position the cursor at the row where the tombstone should land.
@@ -733,36 +775,45 @@ internal sealed class Hex1bFlowRunner
         // *below* the last visible tombstone row, so the next render lands
         // there cleanly.
         _cursorRow += height;
+        Trace($"EmitSoftWrapTombstone[#{emitId}] exit: cursorRow={_cursorRow} flowOriginRow={_flowOriginRow}");
     }
 
     /// <summary>
-    /// Resize-time owned re-render: clears the viewport from the flow's
-    /// origin row down, re-emits every tracked tombstone at the new terminal
-    /// width, and computes the row origin where the active step should be
-    /// anchored. Called only on the soft-wrap path. Returns the row origin
-    /// for the active step.
+    /// Resize-time owned re-render: clears the entire visible viewport,
+    /// re-emits every tracked tombstone at the new terminal width starting
+    /// at the top of the screen, and computes the row origin where the
+    /// active step should be anchored. Called only on the soft-wrap path.
+    /// Returns the row origin for the active step.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The previous resize strategy ("clear only the bottom-anchored
-    /// active-step region and trust the host terminal to have reflowed the
-    /// tombstones above it") had two unfixable problems: it left a ghost of
-    /// the old active step (rendered with absolute positioning, so the host
-    /// terminal had no way to remove it), and it could clip wrapped
-    /// tombstones whose reflowed rows landed inside the new step region.
-    /// Both problems disappear if Hex1b owns the post-resize layout from
-    /// the flow's origin row down: we clear from there to the bottom of the
-    /// viewport, redraw every tombstone via <see cref="SoftWrapEmitter"/>
-    /// at the new width, and pre-scroll if needed to make room for the
-    /// active step.
+    /// The previous resize strategy ("clear from <see cref="_flowOriginRow"/>
+    /// down and trust our row tracking to be in sync") had an unfixable
+    /// problem on terminals that reflow logical lines on horizontal resize
+    /// (Windows Terminal, iTerm2, modern xterm builds): tombstones are
+    /// emitted as logical lines via <see cref="SoftWrapEmitter"/> precisely
+    /// so that they reflow naturally, but reflow also moves them around
+    /// vertically — what was at row N before the resize might now be at
+    /// row M after the resize. <see cref="_flowOriginRow"/> tracked our
+    /// own pre-scrolls but had no way to learn about reflow-induced row
+    /// shifts. The result was that <c>SetCursorPosition(0, _flowOriginRow)
+    /// + ESC[J</c> sometimes left terminal-reflowed copies of the
+    /// tombstones above the cursor, and our re-emitted copies landed
+    /// below them — duplicate tombstones on screen.
     /// </para>
     /// <para>
-    /// The starting row is <see cref="_flowOriginRow"/>, clamped to the new
-    /// viewport. This preserves any user content above the flow (typically a
-    /// shell prompt) that hasn't yet been scrolled into the host terminal's
-    /// scrollback by previous tombstone overflows. <c>ESC[J</c> clears from
-    /// the cursor to the end of the screen, leaving rows above the cursor
-    /// untouched.
+    /// To make the resize repaint deterministic regardless of host
+    /// terminal reflow behaviour, this method now wipes the entire
+    /// visible viewport (<c>ESC[H ESC[2J</c>) and redraws the tombstone
+    /// history starting at row 0 of the visible area. Any user content
+    /// that was visible above the flow before the resize (typically a
+    /// shell prompt) is therefore lost from the visible area on the
+    /// first resize. It is preserved in the host terminal's scrollback
+    /// (the host has already reflowed it there as part of its own resize
+    /// handling), so the user can still scroll up to see it. This is a
+    /// deliberate trade-off: a one-time loss of the prompt from view is
+    /// less disruptive than ghost copies of every tombstone stacking up
+    /// each time the user resizes.
     /// </para>
     /// <para>
     /// The clear+redraw is bracketed in DEC private mode 2026
@@ -781,33 +832,44 @@ internal sealed class Hex1bFlowRunner
     /// </remarks>
     private int ReRenderTombstonesAndAnchorStep(int newWidth, int newHeight, int newStepHeight)
     {
+        var resizeId = Interlocked.Increment(ref _resizeCounter);
+        Trace($"ReRender[#{resizeId}] enter: newSize={newWidth}x{newHeight} newStepH={newStepHeight} cursorRow={_cursorRow} flowOriginRow={_flowOriginRow} builders={_tombstoneBuilders.Count}");
+
         // Begin synchronized update so supporting terminals present the whole
         // clear-and-redraw as a single atomic frame.
         _parentAdapter.Write(SyncUpdateBegin);
 
         try
         {
-            // Position the cursor at the flow's origin row (clamped into the
-            // new viewport in case the terminal shrank below it) and clear
-            // from there to the end of the screen with ESC[J. Anything above
-            // the flow's origin (the shell prompt, previous output) is left
-            // untouched so the user keeps the context they had before the
-            // flow began.
-            var startRow = Math.Max(0, Math.Min(_flowOriginRow, newHeight - 1));
-            _parentAdapter.SetCursorPosition(0, startRow);
-            _parentAdapter.Write("\x1b[J");
-            _cursorRow = startRow;
+            // Wipe the entire visible viewport. We deliberately do NOT use
+            // _flowOriginRow + ESC[J here: the host terminal may have
+            // already reflowed our tombstones to a different row range
+            // before this handler runs, and our row tracking has no way
+            // to learn about that. ESC[H ESC[2J unconditionally homes the
+            // cursor and clears the visible area, giving us a known-good
+            // starting state. Anything previously visible above the flow
+            // is preserved in scrollback (the host terminal puts it
+            // there during its own resize handling).
+            _parentAdapter.Write("\x1b[H\x1b[2J");
+            _cursorRow = 0;
+            _flowOriginRow = 0;
+            Trace($"ReRender[#{resizeId}] cleared full viewport, reset to row 0");
 
-            // Re-emit every tracked tombstone at the new width. The emitter's
-            // pre-scroll logic naturally pushes earlier tombstones into
-            // scrollback when the viewport can't hold them all (which also
-            // decrements _flowOriginRow via the pre-scroll bookkeeping in
-            // EmitSoftWrapTombstone), matching the behaviour of normal flow
+            // Re-emit every tracked tombstone at the new width starting at
+            // row 0. The emitter's pre-scroll logic naturally pushes
+            // earlier tombstones into scrollback when the viewport can't
+            // hold them all, matching the behaviour of normal flow
             // execution.
-            foreach (var builder in _tombstoneBuilders)
+            for (int i = 0; i < _tombstoneBuilders.Count; i++)
             {
+                var builder = _tombstoneBuilders[i];
                 var surface = RenderToSurface(builder, newWidth, newHeight);
-                if (surface is null) continue;
+                if (surface is null)
+                {
+                    Trace($"ReRender[#{resizeId}] tombstone[{i}] surface=NULL, skipping");
+                    continue;
+                }
+                Trace($"ReRender[#{resizeId}] tombstone[{i}] re-emit: size={surface.Width}x{surface.Height}");
                 EmitSoftWrapTombstone(surface);
             }
 
@@ -825,6 +887,7 @@ internal sealed class Hex1bFlowRunner
                 }
                 _cursorRow -= overflow;
                 _flowOriginRow = Math.Max(0, _flowOriginRow - overflow);
+                Trace($"ReRender[#{resizeId}] step pre-scroll: overflow={overflow} -> cursorRow={_cursorRow} flowOriginRow={_flowOriginRow}");
             }
 
             // Clear the active-step region so the step app's first
@@ -833,6 +896,7 @@ internal sealed class Hex1bFlowRunner
             // in column 0 of the step's first row until overwritten.
             ClearRegion(_cursorRow, newStepHeight);
 
+            Trace($"ReRender[#{resizeId}] exit: returning rowOrigin={_cursorRow} flowOriginRow={_flowOriginRow}");
             return _cursorRow;
         }
         finally

--- a/src/Hex1b/Flow/Hex1bFlowRunner.cs
+++ b/src/Hex1b/Flow/Hex1bFlowRunner.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using Hex1b.Input;
 using Hex1b.Layout;
+using Hex1b.Surfaces;
 using Hex1b.Theming;
 using Hex1b.Widgets;
 
@@ -16,7 +17,15 @@ internal sealed class Hex1bFlowRunner
     private readonly Hex1bFlowOptions _options;
     private readonly IHex1bAppTerminalWorkloadAdapter _parentAdapter;
 
-    // Current cursor row in the terminal buffer (0-based, relative to terminal top)
+    /// <summary>
+    /// Current cursor row in the terminal buffer (0-based, relative to terminal top).
+    /// Tracks where the next yield widget or step should be rendered. After a
+    /// soft-wrap tombstone is emitted, this becomes the row immediately past
+    /// the last emitted line (capped to the bottom of the viewport when the
+    /// terminal had to scroll). After a resize on the soft-wrap path, this is
+    /// re-anchored to the top of the bottom-aligned active-step region so the
+    /// next tombstone appears immediately above the active step again.
+    /// </summary>
     private int _cursorRow;
 
     // The currently active step, if any. Only one step may run at a time.
@@ -101,6 +110,20 @@ internal sealed class Hex1bFlowRunner
 
         // Clear and render
         ClearRegion(_cursorRow, contentHeight);
+        if (_options.UseSoftWrapTombstones)
+        {
+            // Render the static content into a surface and emit it as
+            // soft-wrap-friendly logical lines so the host terminal owns
+            // the reflow/scroll behaviour.
+            var surface = RenderToSurface(builder, terminalWidth, contentHeight);
+            if (surface is not null)
+            {
+                EmitSoftWrapTombstone(surface);
+                return;
+            }
+            // Fall through to legacy path if surface rendering failed.
+        }
+
         var renderedHeight = await RenderYieldWidgetAsync(builder, terminalWidth, contentHeight);
         _cursorRow += renderedHeight;
     }
@@ -239,12 +262,12 @@ internal sealed class Hex1bFlowRunner
             var inputPumpTask = PumpStepInputAsync(stepAdapter, inputPumpCts.Token,
                 onResize: (newWidth, newHeight) =>
                 {
-                    var newStepHeight = Math.Min(options?.MaxHeight ?? newHeight, newHeight);
-                    if (newStepHeight < 1) newStepHeight = 1;
-
+                    var newStepHeight = FlowResizeMath.ComputeStepHeight(options?.MaxHeight, newHeight);
+                    var (clearOrigin, clearHeight) = FlowResizeMath.ComputeClearRegion(
+                        _options.UseSoftWrapTombstones, newHeight, newStepHeight);
                     var newRowOrigin = Math.Max(0, newHeight - newStepHeight);
 
-                    ClearRegion(0, newHeight);
+                    ClearRegion(clearOrigin, clearHeight);
 
                     stepAdapter.RowOrigin = newRowOrigin;
                     rowOrigin = newRowOrigin;
@@ -283,8 +306,25 @@ internal sealed class Hex1bFlowRunner
             var completedBuilder = step.CompletedBuilder;
             if (completedBuilder != null)
             {
-                var completedHeight = await RenderYieldWidgetAsync(completedBuilder, terminalWidth, desiredHeight);
-                _cursorRow += completedHeight;
+                if (_options.UseSoftWrapTombstones)
+                {
+                    var surface = RenderToSurface(completedBuilder, terminalWidth, desiredHeight);
+                    if (surface is not null)
+                    {
+                        EmitSoftWrapTombstone(surface);
+                    }
+                    else
+                    {
+                        // Fall back to the legacy path if surface rendering failed.
+                        var completedHeight = await RenderYieldWidgetAsync(completedBuilder, terminalWidth, desiredHeight);
+                        _cursorRow += completedHeight;
+                    }
+                }
+                else
+                {
+                    var completedHeight = await RenderYieldWidgetAsync(completedBuilder, terminalWidth, desiredHeight);
+                    _cursorRow += completedHeight;
+                }
             }
 
             _activeStep = null;
@@ -522,6 +562,101 @@ internal sealed class Hex1bFlowRunner
     }
 
     /// <summary>
+    /// Renders a yield builder into a freshly-allocated <see cref="Surface"/>.
+    /// Returns <c>null</c> if reconciliation, measurement, or rendering fails
+    /// — callers should fall back to the legacy emission path in that case.
+    /// </summary>
+    /// <remarks>
+    /// Used only on the soft-wrap tombstone path
+    /// (<see cref="Hex1bFlowOptions.UseSoftWrapTombstones"/>). The surface is
+    /// sized to <paramref name="width"/> by the widget's measured height
+    /// (clamped to <paramref name="maxHeight"/> × 10 to bound page-by-page
+    /// content). The surface is then arranged and rendered using the standard
+    /// rendering pipeline so any widget that works on screen will work here.
+    /// </remarks>
+    private Surface? RenderToSurface(
+        Func<RootContext, Hex1bWidget> builder,
+        int width,
+        int maxHeight)
+    {
+        try
+        {
+            var rootCtx = new RootContext();
+            var widget = builder(rootCtx);
+            if (widget == null) return null;
+
+            var reconcileCtx = ReconcileContext.CreateRoot();
+            var nodeTask = widget.ReconcileAsync(null, reconcileCtx);
+            // Reconciliation should complete synchronously for the widgets
+            // used in flow tombstones today; if it doesn't, defer to the
+            // legacy renderer which has its own measurement fallback.
+            if (!nodeTask.IsCompleted) return null;
+
+            var node = nodeTask.Result;
+            if (node == null) return null;
+
+            // Measure with a generous height bound so multi-line tombstones
+            // get their full height, then clamp to a safety ceiling so a
+            // misbehaving widget can't allocate an unbounded surface.
+            var measureMax = Math.Max(maxHeight * 10, maxHeight);
+            var constraints = new Constraints(0, width, 0, measureMax);
+            var measured = node.Measure(constraints);
+            var height = Math.Max(1, Math.Min(measured.Height, measureMax));
+
+            var surface = new Surface(width, height);
+            node.Arrange(new Rect(0, 0, width, height));
+
+            var renderCtx = new SurfaceRenderContext(surface, _options.Theme);
+            renderCtx.SetCapabilities(_parentAdapter.Capabilities);
+            node.Render(renderCtx);
+
+            return surface;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Emits the contents of <paramref name="surface"/> as a tombstone via
+    /// <see cref="SoftWrapEmitter"/>, pre-scrolling the terminal as needed so
+    /// the emission fits in the visible area, and updating <see cref="_cursorRow"/>
+    /// to point at the row directly below the tombstone.
+    /// </summary>
+    private void EmitSoftWrapTombstone(Surface surface)
+    {
+        var height = surface.Height;
+        var terminalHeight = _parentAdapter.Height;
+
+        // Pre-scroll the viewport if there isn't enough room below the cursor
+        // for the tombstone. We use the same trick as the legacy paths
+        // (writing newlines at the bottom row) which causes the terminal to
+        // scroll the existing content up — including any older tombstones,
+        // which is the desired behaviour.
+        var overflow = (_cursorRow + height) - terminalHeight;
+        if (overflow > 0)
+        {
+            _parentAdapter.SetCursorPosition(0, terminalHeight - 1);
+            for (int i = 0; i < overflow; i++)
+            {
+                _parentAdapter.Write("\n");
+            }
+            _cursorRow -= overflow;
+        }
+
+        // Position the cursor at the row where the tombstone should land.
+        _parentAdapter.SetCursorPosition(0, _cursorRow);
+
+        SoftWrapEmitter.Emit(surface, _parentAdapter);
+
+        // Each row in the surface terminates with a hard '\n', so the
+        // terminal cursor has advanced exactly `height` rows. Update our
+        // bookkeeping accordingly.
+        _cursorRow += height;
+    }
+
+    /// <summary>
     /// Pumps output from a step adapter to the parent adapter.
     /// </summary>
     private async Task PumpStepOutputAsync(InlineStepAdapter stepAdapter, CancellationToken ct)
@@ -601,4 +736,29 @@ public sealed class Hex1bFlowOptions
     /// If null, defaults to 0.
     /// </summary>
     public int? InitialCursorRow { get; set; }
+
+    /// <summary>
+    /// When <c>true</c>, tombstoned (yield) widget output is emitted as
+    /// soft-wrap-friendly logical lines (text + <c>ESC[K</c> + LF) so the host
+    /// terminal can reflow tombstones during a resize and scroll older
+    /// tombstones into the scrollback buffer naturally. When <c>false</c>
+    /// (the default), tombstones are emitted with absolute cursor positioning
+    /// and the entire visible area is cleared on every resize, which causes
+    /// tombstones to disappear when the terminal is resized.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This option is experimental and gates two related behaviours together:
+    /// the tombstone emission path and the resize handler. The new resize
+    /// handler only clears the active step region and trusts the host
+    /// terminal to have reflowed tombstones above it — that is only a valid
+    /// assumption when tombstones were emitted as proper logical lines, so
+    /// both behaviours move together under this single flag.
+    /// </para>
+    /// <para>
+    /// Once validated across the supported terminal matrix this will become
+    /// the default and the legacy cell-positioning path will be removed.
+    /// </para>
+    /// </remarks>
+    public bool UseSoftWrapTombstones { get; set; }
 }

--- a/src/Hex1b/Flow/SoftWrapEmitter.cs
+++ b/src/Hex1b/Flow/SoftWrapEmitter.cs
@@ -1,0 +1,351 @@
+using System.Globalization;
+using System.Text;
+using Hex1b.Surfaces;
+using Hex1b.Theming;
+
+namespace Hex1b.Flow;
+
+/// <summary>
+/// Walks a <see cref="Surface"/> and emits its contents as soft-wrap-friendly
+/// terminal output: per row, the visible characters with grouped SGR runs,
+/// followed by <c>ESC[K</c> (clear-to-end-of-line) and <c>\n</c> (line feed).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The legacy flow rendering path emits tombstones using absolute cursor
+/// positioning (<c>ESC[r;cH&lt;text&gt;</c>) which writes characters into
+/// specific terminal cells without producing soft-wrap state. When the host
+/// terminal is later resized, those cells cannot be reflowed because the
+/// terminal sees no logical line boundaries — the content disappears or
+/// becomes corrupted.
+/// </para>
+/// <para>
+/// <see cref="SoftWrapEmitter"/> renders content as proper logical lines so
+/// the host terminal can:
+/// <list type="bullet">
+///   <item>soft-wrap rows that exceed the current width;</item>
+///   <item>scroll older rows into the scrollback buffer naturally when new
+///         rows are emitted at the bottom of the viewport;</item>
+///   <item>preserve content across width and height resizes without any
+///         intervention from Hex1b.</item>
+/// </list>
+/// </para>
+/// <para>
+/// Each row is emitted as <c>(SGR runs and characters) + ESC[K + \n</c>.
+/// The terminating <c>ESC[K</c> clears any residual content past the rendered
+/// glyphs, and the <c>\n</c> makes the row a hard logical line so subsequent
+/// content cannot be confused with a wrapped continuation.
+/// </para>
+/// </remarks>
+internal static class SoftWrapEmitter
+{
+    /// <summary>
+    /// Emits the contents of <paramref name="surface"/> to the supplied
+    /// adapter as soft-wrap-friendly text. The cursor is hidden for the
+    /// duration of the emission and restored before the method returns.
+    /// </summary>
+    /// <param name="surface">The surface whose cells should be emitted.</param>
+    /// <param name="adapter">
+    /// The workload adapter receiving the bytes. Output is staged in a single
+    /// buffer and flushed as one <see cref="IHex1bAppTerminalWorkloadAdapter.Write(string)"/>
+    /// call to minimise tearing.
+    /// </param>
+    public static void Emit(Surface surface, IHex1bAppTerminalWorkloadAdapter adapter)
+    {
+        ArgumentNullException.ThrowIfNull(surface);
+        ArgumentNullException.ThrowIfNull(adapter);
+
+        var sb = new StringBuilder(EstimateBufferSize(surface));
+
+        // Hide cursor and force wraparound on while we paint. Wraparound is
+        // on by default in every supported terminal, but we send DECAWM
+        // explicitly so a host that previously toggled it off (e.g. via a
+        // misbehaving sub-process) still gets the soft-wrap behaviour we
+        // depend on. Cursor is restored at the end.
+        sb.Append("\x1b[?25l");
+        sb.Append("\x1b[?7h");
+
+        for (int row = 0; row < surface.Height; row++)
+        {
+            EmitRow(surface, row, sb);
+        }
+
+        sb.Append("\x1b[?25h");
+
+        adapter.Write(sb.ToString());
+    }
+
+    /// <summary>
+    /// Builds the bytes that <see cref="Emit"/> would write, returning them
+    /// instead of dispatching to an adapter. Used by tests.
+    /// </summary>
+    internal static string Format(Surface surface)
+    {
+        ArgumentNullException.ThrowIfNull(surface);
+
+        var sb = new StringBuilder(EstimateBufferSize(surface));
+        sb.Append("\x1b[?25l");
+        sb.Append("\x1b[?7h");
+        for (int row = 0; row < surface.Height; row++)
+        {
+            EmitRow(surface, row, sb);
+        }
+        sb.Append("\x1b[?25h");
+        return sb.ToString();
+    }
+
+    private static int EstimateBufferSize(Surface surface)
+    {
+        // Rough estimate: each cell averages ~2 chars (SGR overhead amortises
+        // across runs), plus 4 bytes per row for ESC[K + \n, plus the cursor
+        // and wraparound preamble.
+        return surface.Width * surface.Height * 2 + surface.Height * 4 + 16;
+    }
+
+    private static void EmitRow(Surface surface, int row, StringBuilder sb)
+    {
+        // Track SGR state within the row. We always emit a leading reset
+        // ("\x1b[0m") as part of the first SGR — see BuildSgrParameters where
+        // stateUnknown=true forces a "0" — which guarantees the row starts
+        // from a clean slate regardless of any prior styling left by the
+        // caller (e.g. the active-step app).
+        Hex1bColor? currentFg = null;
+        Hex1bColor? currentBg = null;
+        var currentAttrs = CellAttributes.None;
+        var currentUnderlineStyle = UnderlineStyle.None;
+        Hex1bColor? currentUnderlineColor = null;
+        bool stateUnknown = true;
+
+        var lastContent = FindLastContentColumn(surface, row);
+
+        // Emit cells from column 0 up to and including the last content
+        // column. Anything past that is wiped with ESC[K below.
+        int x = 0;
+        while (x <= lastContent)
+        {
+            var cell = surface.GetCell(x, row);
+
+            if (cell.IsContinuation)
+            {
+                // Wide-character continuation cells produce no output of
+                // their own — the wide glyph in the previous cell already
+                // covered this column.
+                x++;
+                continue;
+            }
+
+            var emit = cell;
+            if (IsBlank(cell))
+            {
+                // Empty / unwritten cells render as a plain space with no
+                // colour state so they don't accidentally extend a coloured
+                // run from the previous cell.
+                emit = SurfaceCells.Space(null, null);
+            }
+
+            var sgr = BuildSgrParameters(
+                emit,
+                stateUnknown,
+                ref currentFg,
+                ref currentBg,
+                ref currentAttrs,
+                ref currentUnderlineStyle,
+                ref currentUnderlineColor);
+
+            stateUnknown = false;
+
+            if (sgr.Length > 0)
+            {
+                sb.Append("\x1b[");
+                sb.Append(sgr);
+                sb.Append('m');
+            }
+
+            sb.Append(emit.Character);
+
+            x += Math.Max(1, emit.DisplayWidth);
+        }
+
+        // Reset SGR before the line clear so the cleared cells don't inherit
+        // a coloured background from the last run on the row.
+        if (!stateUnknown && (currentAttrs != CellAttributes.None
+            || currentFg is not null
+            || currentBg is not null))
+        {
+            sb.Append("\x1b[0m");
+        }
+
+        // Clear any residual content past the rendered glyphs (handles
+        // overwriting the active-step region) and terminate the row as a
+        // hard logical line.
+        sb.Append("\x1b[K");
+        sb.Append('\n');
+    }
+
+    private static int FindLastContentColumn(Surface surface, int row)
+    {
+        for (int x = surface.Width - 1; x >= 0; x--)
+        {
+            var cell = surface.GetCell(x, row);
+            if (!IsBlank(cell) && !cell.IsContinuation)
+            {
+                return x;
+            }
+        }
+        return -1;
+    }
+
+    private static bool IsBlank(SurfaceCell cell)
+    {
+        // Unwritten sentinel cell, or a cell that paints nothing visible.
+        if (ReferenceEquals(cell.Character, SurfaceCells.UnwrittenMarker)
+            || cell.Character == SurfaceCells.UnwrittenMarker)
+        {
+            return true;
+        }
+
+        if (string.IsNullOrEmpty(cell.Character))
+        {
+            return cell.Background is null;
+        }
+
+        return false;
+    }
+
+    // SGR parameter generation. Mirrors SurfaceComparer.BuildSgrParameters
+    // intentionally — the surface comparer is the canonical implementation
+    // for incremental SGR diffing during redraws, but it is private and
+    // optimised for the diff path. Tombstone emission here is one-shot per
+    // row, so we duplicate the small amount of logic rather than coupling
+    // the two code paths.
+
+    private static string BuildSgrParameters(
+        SurfaceCell targetCell,
+        bool stateUnknown,
+        ref Hex1bColor? currentFg,
+        ref Hex1bColor? currentBg,
+        ref CellAttributes currentAttrs,
+        ref UnderlineStyle currentUnderlineStyle,
+        ref Hex1bColor? currentUnderlineColor)
+    {
+        var parts = new List<string>();
+
+        var turnedOff = currentAttrs & ~targetCell.Attributes;
+        bool needsReset = stateUnknown
+            || turnedOff != CellAttributes.None
+            || (currentFg is not null && targetCell.Foreground is null)
+            || (currentBg is not null && targetCell.Background is null);
+
+        if (needsReset)
+        {
+            parts.Add("0");
+            currentAttrs = CellAttributes.None;
+            currentFg = null;
+            currentBg = null;
+            currentUnderlineStyle = UnderlineStyle.None;
+            currentUnderlineColor = null;
+        }
+
+        var toTurnOn = targetCell.Attributes & ~currentAttrs;
+
+        if ((toTurnOn & CellAttributes.Bold) != 0)
+            parts.Add("1");
+        if ((toTurnOn & CellAttributes.Dim) != 0)
+            parts.Add("2");
+        if ((toTurnOn & CellAttributes.Italic) != 0)
+            parts.Add("3");
+        if ((toTurnOn & CellAttributes.Underline) != 0)
+        {
+            parts.Add(targetCell.UnderlineStyle switch
+            {
+                UnderlineStyle.Double => "21",
+                UnderlineStyle.Curly => "4:3",
+                UnderlineStyle.Dotted => "4:4",
+                UnderlineStyle.Dashed => "4:5",
+                _ => "4",
+            });
+        }
+        else if ((currentAttrs & CellAttributes.Underline) != 0
+            && (targetCell.Attributes & CellAttributes.Underline) != 0
+            && targetCell.UnderlineStyle != currentUnderlineStyle)
+        {
+            parts.Add(targetCell.UnderlineStyle switch
+            {
+                UnderlineStyle.Double => "21",
+                UnderlineStyle.Curly => "4:3",
+                UnderlineStyle.Dotted => "4:4",
+                UnderlineStyle.Dashed => "4:5",
+                _ => "4",
+            });
+        }
+        if ((toTurnOn & CellAttributes.Blink) != 0)
+            parts.Add("5");
+        if ((toTurnOn & CellAttributes.Reverse) != 0)
+            parts.Add("7");
+        if ((toTurnOn & CellAttributes.Hidden) != 0)
+            parts.Add("8");
+        if ((toTurnOn & CellAttributes.Strikethrough) != 0)
+            parts.Add("9");
+        if ((toTurnOn & CellAttributes.Overline) != 0)
+            parts.Add("53");
+
+        if (!ColorsEqual(targetCell.Foreground, currentFg) && targetCell.Foreground is not null)
+        {
+            parts.Add(BuildColorSgr(targetCell.Foreground.Value, isForeground: true));
+        }
+
+        if (!ColorsEqual(targetCell.Background, currentBg) && targetCell.Background is not null)
+        {
+            parts.Add(BuildColorSgr(targetCell.Background.Value, isForeground: false));
+        }
+
+        if (!ColorsEqual(targetCell.UnderlineColor, currentUnderlineColor))
+        {
+            if (targetCell.UnderlineColor is not null)
+            {
+                var ulc = targetCell.UnderlineColor.Value;
+                parts.Add(string.Create(CultureInfo.InvariantCulture, $"58;2;{ulc.R};{ulc.G};{ulc.B}"));
+            }
+            else if (currentUnderlineColor is not null)
+            {
+                parts.Add("59");
+            }
+        }
+
+        currentAttrs = targetCell.Attributes;
+        currentFg = targetCell.Foreground;
+        currentBg = targetCell.Background;
+        currentUnderlineStyle = targetCell.UnderlineStyle;
+        currentUnderlineColor = targetCell.UnderlineColor;
+
+        return string.Join(";", parts);
+    }
+
+    private static string BuildColorSgr(Hex1bColor color, bool isForeground)
+    {
+        return color.Kind switch
+        {
+            Hex1bColorKind.Standard => (isForeground ? 30 + color.AnsiIndex : 40 + color.AnsiIndex)
+                .ToString(CultureInfo.InvariantCulture),
+            Hex1bColorKind.Bright => (isForeground ? 90 + color.AnsiIndex : 100 + color.AnsiIndex)
+                .ToString(CultureInfo.InvariantCulture),
+            Hex1bColorKind.Indexed => string.Create(
+                CultureInfo.InvariantCulture,
+                $"{(isForeground ? "38;5" : "48;5")};{color.AnsiIndex}"),
+            _ => string.Create(
+                CultureInfo.InvariantCulture,
+                $"{(isForeground ? "38;2" : "48;2")};{color.R};{color.G};{color.B}"),
+        };
+    }
+
+    private static bool ColorsEqual(Hex1bColor? a, Hex1bColor? b)
+    {
+        if (a is null && b is null) return true;
+        if (a is null || b is null) return false;
+        return a.Value.R == b.Value.R
+            && a.Value.G == b.Value.G
+            && a.Value.B == b.Value.B
+            && a.Value.Kind == b.Value.Kind
+            && a.Value.AnsiIndex == b.Value.AnsiIndex;
+    }
+}

--- a/src/Hex1b/Flow/SoftWrapEmitter.cs
+++ b/src/Hex1b/Flow/SoftWrapEmitter.cs
@@ -8,7 +8,9 @@ namespace Hex1b.Flow;
 /// <summary>
 /// Walks a <see cref="Surface"/> and emits its contents as soft-wrap-friendly
 /// terminal output: per row, the visible characters with grouped SGR runs,
-/// followed by <c>ESC[K</c> (clear-to-end-of-line) and <c>\n</c> (line feed).
+/// followed by <c>ESC[K</c> (clear-to-end-of-line). Rows other than the last
+/// are also terminated with <c>CR + LF</c> so the next row starts at column
+/// zero of the next terminal line.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -31,10 +33,20 @@ namespace Hex1b.Flow;
 /// </list>
 /// </para>
 /// <para>
-/// Each row is emitted as <c>(SGR runs and characters) + ESC[K + \n</c>.
-/// The terminating <c>ESC[K</c> clears any residual content past the rendered
-/// glyphs, and the <c>\n</c> makes the row a hard logical line so subsequent
-/// content cannot be confused with a wrapped continuation.
+/// Each row except the last is emitted as
+/// <c>(SGR runs and characters) + ESC[K + CR + LF</c>. The terminating
+/// <c>ESC[K</c> clears any residual content past the rendered glyphs, and
+/// <c>CR + LF</c> moves the cursor to column zero of the next row so the
+/// following row's characters start at the left margin (a bare LF would only
+/// move the cursor down and would shift each subsequent row right by the
+/// width of the previous row's content — a raw-mode terminal does not
+/// translate LF to CRLF). The final row deliberately omits the trailing
+/// <c>CR + LF</c>: when a tombstone is emitted at the very bottom of the
+/// viewport, a trailing newline would scroll the screen up by one row,
+/// causing the tombstone to appear one row higher than the step it is
+/// freezing in place. The next operation that writes to the terminal
+/// (typically <see cref="IHex1bAppTerminalWorkloadAdapter.SetCursorPosition"/>
+/// for the next step) terminates the open row implicitly.
 /// </para>
 /// </remarks>
 internal static class SoftWrapEmitter
@@ -67,7 +79,7 @@ internal static class SoftWrapEmitter
 
         for (int row = 0; row < surface.Height; row++)
         {
-            EmitRow(surface, row, sb);
+            EmitRow(surface, row, sb, isLastRow: row == surface.Height - 1);
         }
 
         sb.Append("\x1b[?25h");
@@ -88,7 +100,7 @@ internal static class SoftWrapEmitter
         sb.Append("\x1b[?7h");
         for (int row = 0; row < surface.Height; row++)
         {
-            EmitRow(surface, row, sb);
+            EmitRow(surface, row, sb, isLastRow: row == surface.Height - 1);
         }
         sb.Append("\x1b[?25h");
         return sb.ToString();
@@ -97,12 +109,13 @@ internal static class SoftWrapEmitter
     private static int EstimateBufferSize(Surface surface)
     {
         // Rough estimate: each cell averages ~2 chars (SGR overhead amortises
-        // across runs), plus 4 bytes per row for ESC[K + \n, plus the cursor
-        // and wraparound preamble.
-        return surface.Width * surface.Height * 2 + surface.Height * 4 + 16;
+        // across runs), plus 5 bytes per row for ESC[K + CR + LF (the last
+        // row drops the CR + LF but the over-estimate is harmless), plus the
+        // cursor and wraparound preamble.
+        return surface.Width * surface.Height * 2 + surface.Height * 5 + 16;
     }
 
-    private static void EmitRow(Surface surface, int row, StringBuilder sb)
+    private static void EmitRow(Surface surface, int row, StringBuilder sb, bool isLastRow)
     {
         // Track SGR state within the row. We always emit a leading reset
         // ("\x1b[0m") as part of the first SGR — see BuildSgrParameters where
@@ -176,10 +189,26 @@ internal static class SoftWrapEmitter
         }
 
         // Clear any residual content past the rendered glyphs (handles
-        // overwriting the active-step region) and terminate the row as a
-        // hard logical line.
+        // overwriting the active-step region). For every row except the
+        // last we also emit CR + LF to terminate the row as a hard logical
+        // line and reset the cursor to column zero of the next row. The
+        // CR (\r) is essential: in raw output mode a bare LF (\n) only
+        // moves the cursor down one row without resetting the column, so
+        // every row after the first would emit at the column where the
+        // previous row's content ended, producing a cumulative right-shift
+        // and effectively losing the leading content of each row.
+        //
+        // The final row deliberately omits the CR + LF: when a tombstone is
+        // emitted at the very bottom of the viewport, a trailing newline
+        // would scroll the screen up by one row, causing the tombstone to
+        // appear one row higher than the step it is freezing in place. The
+        // next operation that writes to the terminal terminates the open
+        // row implicitly.
         sb.Append("\x1b[K");
-        sb.Append('\n');
+        if (!isLastRow)
+        {
+            sb.Append("\r\n");
+        }
     }
 
     private static int FindLastContentColumn(Surface surface, int row)

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Threading.Channels;
 using Hex1b.Animation;
 using Hex1b.Diagnostics;
+using Hex1b.Flow;
 using Hex1b.Input;
 using Hex1b.Layout;
 using Hex1b.Nodes;
@@ -153,6 +154,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
 
     // Surface RenderChild caching (opt-in).
     private readonly bool _enableRenderCaching;
+    private readonly bool _useSoftWrapEmission;
     
     // Surface rendering double-buffer
     private Surface? _currentSurface;
@@ -267,6 +269,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         _inputCoalescingMaxDelayMs = options.InputCoalescingMaxDelayMs;
 
         _enableRenderCaching = options.EnableRenderCaching;
+        _useSoftWrapEmission = options.UseSoftWrapEmission;
 
         _surfacePool = options.EnableSurfacePooling
             ? new SurfacePool(options.SurfacePoolMaxSurfacesPerBucket, options.SurfacePoolMaxIdleFrames)
@@ -1117,7 +1120,34 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                 $"frame-rendered size={width}x{height} images={_kgpRegistry.Images.Count} " +
                 $"occluders={_kgpRegistry.Occluders.Count} surfaceHasKgp={_currentSurface.HasKgp}");
         }
-        
+
+        // Soft-wrap emission: every frame emits the entire surface as
+        // logical lines (text + ESC[K + CR+LF per row), so the host
+        // terminal owns reflow and scroll. Used by inline (non-alt-buffer)
+        // step rendering where the active step content has to survive
+        // horizontal terminal resizes alongside any tombstones above it.
+        // KGP/sixel content is not supported in this mode — soft-wrap
+        // rendering targets text-only step UIs.
+        if (_useSoftWrapEmission)
+        {
+            // CUP to top-left of frame, then clear from cursor to end of
+            // screen. When the workload adapter rebases CUP coordinates
+            // (InlineStepAdapter), the leading "ESC[1;1H" lands at the
+            // top of the host-terminal region the adapter owns, and the
+            // trailing "ESC[J" wipes that region down to the bottom of
+            // the screen — leaving any content above it intact.
+            _adapter.Write("\x1b[1;1H\x1b[J");
+            SoftWrapEmitter.Emit(_currentSurface, _adapter);
+            // Reset the previous-surface cache so a future switch off of
+            // soft-wrap emission (or a downstream diff) starts from a
+            // known-empty baseline rather than a stale cell grid that the
+            // diff path never observed being written.
+            _previousSurface?.Clear();
+            _isFirstFrame = false;
+            _metrics.OutputCellsChanged.Record(width * height);
+            return true;
+        }
+
         // Diff current vs previous and emit changes
         var diffStart = Stopwatch.GetTimestamp();
         var diff = _isFirstFrame || _previousSurface == null

--- a/src/Hex1b/Hex1bAppOptions.cs
+++ b/src/Hex1b/Hex1bAppOptions.cs
@@ -94,6 +94,36 @@ public class Hex1bAppOptions
     /// </para>
     /// </remarks>
     public bool EnableRenderCaching { get; set; }
+
+    /// <summary>
+    /// When true, every rendered frame is emitted as soft-wrap-friendly logical lines
+    /// (text + ESC[K + CR+LF per row) instead of as a CUP-positioned cell diff.
+    /// The host terminal then owns reflow and scroll behaviour for the rendered
+    /// content, which is essential for inline (non-alternate-buffer) rendering
+    /// scenarios where the content needs to survive horizontal terminal resizes.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Each frame is preceded by <c>ESC[1;1H ESC[J</c> (cursor to top-left of the
+    /// frame's coordinate space, clear from cursor to end of screen) and emitted in
+    /// full — there is no incremental diff. When the workload adapter rebases CUP
+    /// coordinates (e.g. <c>InlineStepAdapter</c>), the leading <c>ESC[1;1H</c> is
+    /// rewritten to position the cursor at the top of the host-terminal region the
+    /// adapter owns, and the trailing <c>ESC[J</c> clears just that region down to
+    /// the bottom of the screen — leaving any content above it intact.
+    /// </para>
+    /// <para>
+    /// This mode is used by <c>Hex1bFlowRunner</c> when soft-wrap tombstones are
+    /// enabled, so the active step renders as logical lines that reflow naturally
+    /// alongside the tombstones above it. KGP/sixel emission is bypassed in this
+    /// mode; soft-wrap rendering targets text-only step UIs.
+    /// </para>
+    /// <para>
+    /// Default is false. Cell-diffed CUP rendering remains the default for all
+    /// alternate-buffer and full-screen use cases.
+    /// </para>
+    /// </remarks>
+    public bool UseSoftWrapEmission { get; set; }
     
     /// <summary>
     /// Initial delay in milliseconds for input coalescing. After processing an input,

--- a/src/Hex1b/Hex1bTerminalBuilder.cs
+++ b/src/Hex1b/Hex1bTerminalBuilder.cs
@@ -882,14 +882,16 @@ public sealed class Hex1bTerminalBuilder
             // This must happen before raw mode is entered (i.e., at Build() time).
             options.InitialCursorRow ??= presentation?.GetCursorPosition().Row ?? 0;
 
-            // Wire a live cursor query so the runner can recover the
-            // post-reflow row past the last tombstone after a horizontal
-            // resize. Console.GetCursorPosition() is synchronous on every
-            // supported platform (Win32 GetConsoleScreenBufferInfo on
-            // Windows, raw DSR on Unix) so this is safe to call from a
-            // resize handler. Returns null when the presentation adapter
-            // is null (headless/test scenarios) so the runner falls back
-            // to bottom-anchor.
+            // Wire a live cursor query so the runner can read the current
+            // cursor position at startup (before the input pump begins).
+            // IMPORTANT: on Unix, Console.GetCursorPosition() sends ESC[6n
+            // and reads the response from stdin. It must NOT be called from
+            // within the resize handler because Hex1b's input pump owns stdin
+            // in a background loop — calling it there deadlocks the terminal.
+            // The CursorRowProvider is therefore only used at RunAsync startup,
+            // before the input pump is running. Returns null when presentation
+            // is null (headless/test scenarios) so the runner falls back to
+            // bottom-anchor.
             if (presentation != null)
             {
                 var liveCursor = presentation;

--- a/src/Hex1b/Hex1bTerminalBuilder.cs
+++ b/src/Hex1b/Hex1bTerminalBuilder.cs
@@ -882,6 +882,30 @@ public sealed class Hex1bTerminalBuilder
             // This must happen before raw mode is entered (i.e., at Build() time).
             options.InitialCursorRow ??= presentation?.GetCursorPosition().Row ?? 0;
 
+            // Wire a live cursor query so the runner can recover the
+            // post-reflow row past the last tombstone after a horizontal
+            // resize. Console.GetCursorPosition() is synchronous on every
+            // supported platform (Win32 GetConsoleScreenBufferInfo on
+            // Windows, raw DSR on Unix) so this is safe to call from a
+            // resize handler. Returns null when the presentation adapter
+            // is null (headless/test scenarios) so the runner falls back
+            // to bottom-anchor.
+            if (presentation != null)
+            {
+                var liveCursor = presentation;
+                options.CursorRowProvider ??= () =>
+                {
+                    try
+                    {
+                        return liveCursor.GetCursorPosition().Row;
+                    }
+                    catch
+                    {
+                        return null;
+                    }
+                };
+            }
+
             var runner = new Flow.Hex1bFlowRunner(flowCallback, options, workloadAdapter);
 
             Func<CancellationToken, Task<int>> runCallback = async ct =>

--- a/tests/Hex1b.Tests/Flow/FlowResizeMathTests.cs
+++ b/tests/Hex1b.Tests/Flow/FlowResizeMathTests.cs
@@ -1,0 +1,116 @@
+using Hex1b.Flow;
+
+namespace Hex1b.Tests.Flow;
+
+/// <summary>
+/// Tests for <see cref="FlowResizeMath"/> — the pure helpers that decide,
+/// on a flow resize, how tall the active step should be and which rows the
+/// runner should clear.
+/// </summary>
+public class FlowResizeMathTests
+{
+    [Theory]
+    [InlineData(null, 24, 24)] // No max → fills terminal
+    [InlineData(10, 24, 10)]   // Max smaller than terminal → max wins
+    [InlineData(40, 24, 24)]   // Max larger than terminal → terminal wins
+    [InlineData(0, 24, 1)]     // Zero clamps to 1
+    [InlineData(-5, 24, 1)]    // Negative clamps to 1
+    public void ComputeStepHeight_ClampsToTerminalAndMinimumOfOne(
+        int? maxHeight, int terminalHeight, int expected)
+    {
+        var actual = FlowResizeMath.ComputeStepHeight(maxHeight, terminalHeight);
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void ComputeClearRegion_LegacyPath_ClearsEntireVisibleArea()
+    {
+        // Legacy behaviour: cell-positioned tombstones can't survive a resize,
+        // so the runner wipes the whole visible area to avoid leaving
+        // half-reflowed garbage on screen.
+        var (origin, height) = FlowResizeMath.ComputeClearRegion(
+            useSoftWrapTombstones: false,
+            terminalHeight: 24,
+            stepHeight: 5);
+
+        Assert.Equal(0, origin);
+        Assert.Equal(24, height);
+    }
+
+    [Fact]
+    public void ComputeClearRegion_LegacyPath_StepHeightDoesNotShrinkClear()
+    {
+        // Even when the step is small, the legacy path still clears the
+        // entire visible area — tombstones can't be preserved either way.
+        var (origin, height) = FlowResizeMath.ComputeClearRegion(
+            useSoftWrapTombstones: false,
+            terminalHeight: 100,
+            stepHeight: 1);
+
+        Assert.Equal(0, origin);
+        Assert.Equal(100, height);
+    }
+
+    [Fact]
+    public void ComputeClearRegion_SoftWrapPath_ClearsOnlyTheActiveStepRegion()
+    {
+        // Soft-wrap behaviour: tombstones above the active step are real
+        // logical lines that the host terminal has already reflowed. The
+        // runner must scope its clear to the bottom-aligned active-step
+        // region; clearing higher rows would erase tombstones the user is
+        // actively reading.
+        var (origin, height) = FlowResizeMath.ComputeClearRegion(
+            useSoftWrapTombstones: true,
+            terminalHeight: 24,
+            stepHeight: 5);
+
+        Assert.Equal(19, origin); // 24 - 5
+        Assert.Equal(5, height);
+    }
+
+    [Fact]
+    public void ComputeClearRegion_SoftWrapPath_StepFillsTerminal_ClearsEntireArea()
+    {
+        // When the step occupies the full terminal there is no tombstone
+        // history to preserve, so the soft-wrap path effectively matches the
+        // legacy clear region — but it gets there via the bottom-anchored
+        // calculation, not by special-casing.
+        var (origin, height) = FlowResizeMath.ComputeClearRegion(
+            useSoftWrapTombstones: true,
+            terminalHeight: 24,
+            stepHeight: 24);
+
+        Assert.Equal(0, origin);
+        Assert.Equal(24, height);
+    }
+
+    [Fact]
+    public void ComputeClearRegion_SoftWrapPath_StepLargerThanTerminal_ClampsRowOriginAtZero()
+    {
+        // Defensive: callers should already have clamped via
+        // ComputeStepHeight, but if they pass a step taller than the
+        // terminal we still produce a valid (non-negative) row origin.
+        var (origin, height) = FlowResizeMath.ComputeClearRegion(
+            useSoftWrapTombstones: true,
+            terminalHeight: 10,
+            stepHeight: 20);
+
+        Assert.Equal(0, origin);
+        Assert.Equal(20, height);
+    }
+
+    [Fact]
+    public void ComputeClearRegion_SoftWrapPath_PreservesTombstonesAboveOrigin()
+    {
+        // The crux of the fix: with a 24-row terminal and a 3-row active
+        // step, rows 0..20 hold tombstones and must NOT be cleared.
+        var (origin, _) = FlowResizeMath.ComputeClearRegion(
+            useSoftWrapTombstones: true,
+            terminalHeight: 24,
+            stepHeight: 3);
+
+        // Origin is 21, so rows 0..20 are untouched — exactly the tombstone
+        // history the terminal just reflowed for us.
+        Assert.Equal(21, origin);
+    }
+}

--- a/tests/Hex1b.Tests/Flow/SoftWrapEmitterTests.cs
+++ b/tests/Hex1b.Tests/Flow/SoftWrapEmitterTests.cs
@@ -1,0 +1,212 @@
+using Hex1b.Flow;
+using Hex1b.Surfaces;
+using Hex1b.Theming;
+
+namespace Hex1b.Tests.Flow;
+
+/// <summary>
+/// Unit tests for <see cref="SoftWrapEmitter"/>. These verify the byte-level
+/// shape of the output so the host terminal can soft-wrap and scroll
+/// tombstoned content naturally on resize.
+/// </summary>
+public class SoftWrapEmitterTests
+{
+    [Fact]
+    public void Format_ZeroHeightSurface_RejectedByCtor()
+    {
+        // Surface requires a non-zero height; SoftWrapEmitter is therefore
+        // never invoked on an empty surface in practice. Document the
+        // boundary so we don't accidentally start passing zero in the runner.
+        Assert.Throws<ArgumentOutOfRangeException>(() => new Surface(10, 0));
+    }
+
+    [Fact]
+    public void Format_AllRowsBlank_EmitsClearLineAndNewlinePerRow()
+    {
+        var surface = new Surface(20, 3);
+
+        var output = SoftWrapEmitter.Format(surface);
+
+        // Preamble + (ESC[K + \n) per row + epilogue.
+        Assert.Equal(
+            "\x1b[?25l\x1b[?7h" +
+            "\x1b[K\n" +
+            "\x1b[K\n" +
+            "\x1b[K\n" +
+            "\x1b[?25h",
+            output);
+    }
+
+    [Fact]
+    public void Format_PlainTextRow_EmitsCharactersThenClearAndNewline()
+    {
+        var surface = new Surface(20, 1);
+        surface.WriteText(0, 0, "hello");
+
+        var output = SoftWrapEmitter.Format(surface);
+
+        Assert.Contains("hello\x1b[K\n", output);
+        Assert.StartsWith("\x1b[?25l\x1b[?7h", output);
+        Assert.EndsWith("\x1b[?25h", output);
+    }
+
+    [Fact]
+    public void Format_PlainTextRow_DoesNotEmitTrailingBlanksAsCharacters()
+    {
+        var surface = new Surface(20, 1);
+        surface.WriteText(0, 0, "hi");
+
+        var output = SoftWrapEmitter.Format(surface);
+
+        // The row must end with the two characters and the clear-line directly
+        // after them; trailing 18 columns must not be emitted as literal
+        // spaces (they are wiped by ESC[K).
+        Assert.Contains("hi\x1b[K\n", output);
+        Assert.DoesNotContain("hi  ", output);
+    }
+
+    [Fact]
+    public void Format_RowWithLeadingBlanks_EmitsSpacesUpToContent()
+    {
+        // Leading blanks must be preserved as actual spaces because we can't
+        // use cursor-positioning and still call the output a "logical line".
+        var surface = new Surface(20, 1);
+        surface.WriteText(3, 0, "x");
+
+        var output = SoftWrapEmitter.Format(surface);
+
+        Assert.Contains("   x\x1b[K\n", output);
+    }
+
+    [Fact]
+    public void Format_RowWithForegroundColor_EmitsSgrResetThenColor()
+    {
+        var surface = new Surface(10, 1);
+        surface.WriteText(0, 0, "X", foreground: Hex1bColor.FromStandard(1, 128, 0, 0));
+
+        var output = SoftWrapEmitter.Format(surface);
+
+        // First SGR on row always resets, then sets the colour: ESC[0;31m.
+        Assert.Contains("\x1b[0;31mX", output);
+        // Reset SGR before the line clear so cleared cells don't inherit colour.
+        Assert.Contains("X\x1b[0m\x1b[K\n", output);
+    }
+
+    [Fact]
+    public void Format_MultipleColorsInRow_GroupsConsecutiveCellsIntoRuns()
+    {
+        var surface = new Surface(10, 1);
+        var red = Hex1bColor.FromStandard(1, 128, 0, 0);
+        var green = Hex1bColor.FromStandard(2, 0, 128, 0);
+        surface.WriteText(0, 0, "AB", foreground: red);
+        surface.WriteText(2, 0, "CD", foreground: green);
+
+        var output = SoftWrapEmitter.Format(surface);
+
+        // Two SGR transitions, not four. "AB" share one run; "CD" share another.
+        Assert.Contains("\x1b[0;31mAB\x1b[32mCD", output);
+    }
+
+    [Fact]
+    public void Format_BackgroundColor_ResetBeforeClearLineSoCellsDontInherit()
+    {
+        var surface = new Surface(5, 1);
+        var blue = Hex1bColor.FromStandard(4, 0, 0, 128);
+        surface.WriteText(0, 0, "ZZZZZ", background: blue);
+
+        var output = SoftWrapEmitter.Format(surface);
+
+        // Without the reset, ESC[K would paint the blue background to the
+        // edge of the terminal — not what we want for a logical-line emit.
+        Assert.Contains("\x1b[0m\x1b[K\n", output);
+    }
+
+    [Fact]
+    public void Format_WideCharacter_EmitsGraphemeOnceAndSkipsContinuation()
+    {
+        var surface = new Surface(10, 1);
+        // "漢" is a 2-cell grapheme. WriteText writes the primary cell at x=0
+        // and a continuation cell at x=1.
+        surface.WriteText(0, 0, "漢A");
+
+        var output = SoftWrapEmitter.Format(surface);
+
+        // The wide char should appear exactly once and immediately precede
+        // 'A'; the continuation cell at x=1 must not produce any glyph.
+        Assert.Contains("漢A\x1b[K\n", output);
+    }
+
+    [Fact]
+    public void Format_StartsWithCursorHide_EndsWithCursorShow()
+    {
+        var surface = new Surface(10, 2);
+        surface.WriteText(0, 0, "row1");
+        surface.WriteText(0, 1, "row2");
+
+        var output = SoftWrapEmitter.Format(surface);
+
+        Assert.StartsWith("\x1b[?25l", output);
+        Assert.EndsWith("\x1b[?25h", output);
+    }
+
+    [Fact]
+    public void Format_EmitsAutowrapEnableInPreamble()
+    {
+        var surface = new Surface(5, 1);
+        surface.WriteText(0, 0, "a");
+
+        var output = SoftWrapEmitter.Format(surface);
+
+        // Defensive ESC[?7h so a host that previously turned wraparound off
+        // still gets the soft-wrap behaviour we depend on.
+        Assert.Contains("\x1b[?7h", output);
+        // The hint comes before any row content.
+        var awmIdx = output.IndexOf("\x1b[?7h", StringComparison.Ordinal);
+        var firstA = output.IndexOf('a');
+        Assert.True(awmIdx < firstA);
+    }
+
+    [Fact]
+    public void Format_MultiRow_EmitsExpectedNumberOfLineFeeds()
+    {
+        var surface = new Surface(8, 4);
+        surface.WriteText(0, 0, "r0");
+        surface.WriteText(0, 1, "r1");
+        surface.WriteText(0, 2, "r2");
+        surface.WriteText(0, 3, "r3");
+
+        var output = SoftWrapEmitter.Format(surface);
+
+        // One \n per row, exactly.
+        var lfCount = output.Count(c => c == '\n');
+        Assert.Equal(4, lfCount);
+    }
+
+    [Fact]
+    public void Format_BoldAttribute_EmittedAsSgr1()
+    {
+        var surface = new Surface(5, 1);
+        surface.WriteText(0, 0, "B", attributes: CellAttributes.Bold);
+
+        var output = SoftWrapEmitter.Format(surface);
+
+        Assert.Contains("\x1b[0;1mB", output);
+    }
+
+    [Fact]
+    public void Format_RowWithOnlyBlanks_BetweenContentRows_StillCleared()
+    {
+        var surface = new Surface(8, 3);
+        surface.WriteText(0, 0, "top");
+        // row 1 is left blank
+        surface.WriteText(0, 2, "bottom");
+
+        var output = SoftWrapEmitter.Format(surface);
+
+        // Each row including the empty middle row terminates with ESC[K\n.
+        Assert.Contains("top\x1b[K\n", output);
+        Assert.Contains("bottom\x1b[K\n", output);
+        // Three line feeds total.
+        Assert.Equal(3, output.Count(c => c == '\n'));
+    }
+}

--- a/tests/Hex1b.Tests/Flow/SoftWrapEmitterTests.cs
+++ b/tests/Hex1b.Tests/Flow/SoftWrapEmitterTests.cs
@@ -21,31 +21,37 @@ public class SoftWrapEmitterTests
     }
 
     [Fact]
-    public void Format_AllRowsBlank_EmitsClearLineAndNewlinePerRow()
+    public void Format_AllRowsBlank_EmitsClearLinePerRow_AndCrLfBetweenRows()
     {
         var surface = new Surface(20, 3);
 
         var output = SoftWrapEmitter.Format(surface);
 
-        // Preamble + (ESC[K + \n) per row + epilogue.
+        // Preamble + (ESC[K + CR + LF) for rows 0..n-2 + ESC[K for the last row + epilogue.
+        // The last row deliberately omits the CR + LF so emitting at the bottom
+        // of the viewport does not scroll the screen.
         Assert.Equal(
             "\x1b[?25l\x1b[?7h" +
-            "\x1b[K\n" +
-            "\x1b[K\n" +
-            "\x1b[K\n" +
+            "\x1b[K\r\n" +
+            "\x1b[K\r\n" +
+            "\x1b[K" +
             "\x1b[?25h",
             output);
     }
 
     [Fact]
-    public void Format_PlainTextRow_EmitsCharactersThenClearAndNewline()
+    public void Format_PlainTextRow_EmitsCharactersThenClearLine()
     {
         var surface = new Surface(20, 1);
         surface.WriteText(0, 0, "hello");
 
         var output = SoftWrapEmitter.Format(surface);
 
-        Assert.Contains("hello\x1b[K\n", output);
+        // Single-row surface: the only row is also the last row, so it ends
+        // with ESC[K and no trailing CR + LF.
+        Assert.Contains("hello\x1b[K", output);
+        Assert.DoesNotContain("hello\x1b[K\r\n", output);
+        Assert.DoesNotContain("hello\x1b[K\n", output);
         Assert.StartsWith("\x1b[?25l\x1b[?7h", output);
         Assert.EndsWith("\x1b[?25h", output);
     }
@@ -61,7 +67,7 @@ public class SoftWrapEmitterTests
         // The row must end with the two characters and the clear-line directly
         // after them; trailing 18 columns must not be emitted as literal
         // spaces (they are wiped by ESC[K).
-        Assert.Contains("hi\x1b[K\n", output);
+        Assert.Contains("hi\x1b[K", output);
         Assert.DoesNotContain("hi  ", output);
     }
 
@@ -75,7 +81,7 @@ public class SoftWrapEmitterTests
 
         var output = SoftWrapEmitter.Format(surface);
 
-        Assert.Contains("   x\x1b[K\n", output);
+        Assert.Contains("   x\x1b[K", output);
     }
 
     [Fact]
@@ -89,7 +95,7 @@ public class SoftWrapEmitterTests
         // First SGR on row always resets, then sets the colour: ESC[0;31m.
         Assert.Contains("\x1b[0;31mX", output);
         // Reset SGR before the line clear so cleared cells don't inherit colour.
-        Assert.Contains("X\x1b[0m\x1b[K\n", output);
+        Assert.Contains("X\x1b[0m\x1b[K", output);
     }
 
     [Fact]
@@ -118,7 +124,7 @@ public class SoftWrapEmitterTests
 
         // Without the reset, ESC[K would paint the blue background to the
         // edge of the terminal — not what we want for a logical-line emit.
-        Assert.Contains("\x1b[0m\x1b[K\n", output);
+        Assert.Contains("\x1b[0m\x1b[K", output);
     }
 
     [Fact]
@@ -133,7 +139,7 @@ public class SoftWrapEmitterTests
 
         // The wide char should appear exactly once and immediately precede
         // 'A'; the continuation cell at x=1 must not produce any glyph.
-        Assert.Contains("漢A\x1b[K\n", output);
+        Assert.Contains("漢A\x1b[K", output);
     }
 
     [Fact]
@@ -167,7 +173,7 @@ public class SoftWrapEmitterTests
     }
 
     [Fact]
-    public void Format_MultiRow_EmitsExpectedNumberOfLineFeeds()
+    public void Format_MultiRow_EmitsCrLfBetweenRowsButNotAfterLast()
     {
         var surface = new Surface(8, 4);
         surface.WriteText(0, 0, "r0");
@@ -177,9 +183,41 @@ public class SoftWrapEmitterTests
 
         var output = SoftWrapEmitter.Format(surface);
 
-        // One \n per row, exactly.
-        var lfCount = output.Count(c => c == '\n');
-        Assert.Equal(4, lfCount);
+        // CR + LF between rows: 3 of them for a 4-row surface (rows 0, 1, 2 end
+        // with CR + LF; row 3 — the last row — ends with just ESC[K).
+        Assert.Equal(3, output.Count(c => c == '\n'));
+        Assert.Equal(3, output.Count(c => c == '\r'));
+
+        // Rows 0, 1, 2 each terminate with ESC[K + CR + LF.
+        Assert.Contains("r0\x1b[K\r\n", output);
+        Assert.Contains("r1\x1b[K\r\n", output);
+        Assert.Contains("r2\x1b[K\r\n", output);
+
+        // Row 3 (last) terminates with just ESC[K, immediately followed by
+        // the cursor-show epilogue.
+        Assert.Contains("r3\x1b[K\x1b[?25h", output);
+        Assert.DoesNotContain("r3\x1b[K\r\n", output);
+        Assert.DoesNotContain("r3\x1b[K\n", output);
+    }
+
+    [Fact]
+    public void Format_MultiRow_EmitsCarriageReturnBeforeLineFeed_SoNextRowStartsAtColumnZero()
+    {
+        // Regression: in raw output mode a bare LF only moves the cursor down
+        // one row without resetting the column, so a subsequent row's
+        // characters would emit at the column where the previous row ended,
+        // shifting every row except the first to the right and effectively
+        // losing their leading content. The CR before LF is the fix.
+        var surface = new Surface(8, 2);
+        surface.WriteText(0, 0, "abc");
+        surface.WriteText(0, 1, "xyz");
+
+        var output = SoftWrapEmitter.Format(surface);
+
+        // Critically: the line feed must be immediately preceded by a CR,
+        // not by a bare ESC[K. This guarantees column reset between rows.
+        Assert.Contains("abc\x1b[K\r\n", output);
+        Assert.DoesNotContain("abc\x1b[K\n", output);
     }
 
     [Fact]
@@ -203,10 +241,13 @@ public class SoftWrapEmitterTests
 
         var output = SoftWrapEmitter.Format(surface);
 
-        // Each row including the empty middle row terminates with ESC[K\n.
-        Assert.Contains("top\x1b[K\n", output);
-        Assert.Contains("bottom\x1b[K\n", output);
-        // Three line feeds total.
-        Assert.Equal(3, output.Count(c => c == '\n'));
+        // Row 0 (top) terminates with ESC[K + CR + LF.
+        Assert.Contains("top\x1b[K\r\n", output);
+        // Row 2 (bottom, last) terminates with just ESC[K.
+        Assert.Contains("bottom\x1b[K", output);
+        Assert.DoesNotContain("bottom\x1b[K\r\n", output);
+        // Two line feeds total: one between rows 0/1, one between rows 1/2.
+        Assert.Equal(2, output.Count(c => c == '\n'));
+        Assert.Equal(2, output.Count(c => c == '\r'));
     }
 }


### PR DESCRIPTION
## Why

Hex1b Flow apps render into the normal terminal buffer and "reserve" a region beneath any tombstoned content from prior steps. On terminal resize this fell apart: tombstones were pushed up into scrollback (lost forever), the active step left ghost cells outside its known region on horizontal shrink, and on subsequent resizes earlier tombstones could be re-emitted multiple times. Even with no tombstones present, horizontal resize produced visible glitches.

The architectural root cause is that the active step (and the original tombstone path) emitted content as absolute CUP cell pokes, which the host terminal cannot reflow. No amount of cursor recovery fixes content the terminal cannot reflow on its own.

## Approach

Hand reflow back to the host terminal by making everything Hex1b Flow emits look like ordinary scrollback: text + `ESC[K` + `CR/LF` per logical row. The terminal then handles wrap, clipping, and scroll on resize the way it does for any normal command output.

Three layers of changes implement that:

* **`SoftWrapEmitter`** turns a `Surface` into soft-wrap-friendly logical lines (SGR runs, `ESC[K` to clear residue, `CR/LF` between rows). It is shared between tombstone emission and the active step.

* **Tombstones are append-only.** Once `Hex1bFlowRunner` has emitted a tombstone for a completed step it never re-emits it. Resize handling re-positions and re-renders only the active step. `FlowResizeMath` centralizes the "where does the active step go after a resize" calculation, with unit tests in `FlowResizeMathTests`.

* **`Hex1bAppOptions.UseSoftWrapEmission`** lets the active step opt out of the `SurfaceComparer`/CUP-diff render path entirely. When set, every frame is `ESC[1;1H` + `ESC[J` + `SoftWrapEmitter.Emit(surface)`. The leading CUP gets rebased by `InlineStepAdapter` to land at the step's row origin, and the trailing `ESC[J` wipes that region down to the bottom of the screen — so any tombstones above survive untouched, and any wrap-spillover below is cleared. `Hex1bFlowRunner` flips this on whenever `UseSoftWrapTombstones=true`.

For step positioning across a resize, `Hex1bFlowRunner.AnchorActiveStepOnResize` does a DSR query to recover the actual cursor row after the host terminal reflowed everything, then top-anchors the next step frame at that row. On the soft-wrap path it skips its own region clears because the step app's own `ESC[J` covers them. The legacy CUP path is byte-for-byte unchanged.

## Notable bits

* The whole new behavior is gated behind `Hex1bAppOptions.UseSoftWrapTombstones` (and the derived `UseSoftWrapEmission` on the step's `Hex1bAppOptions`). Both default to `false`, so existing flow apps keep their old rendering.
* Trade-off: soft-wrap step rendering emits the full surface every frame instead of a diff. For typical prompt UIs (5-20 rows x ~80 cols) that is a few KB per frame — negligible. KGP/sixel content is bypassed in soft-wrap mode (no inline step uses it today).
* When the step plus its tombstones exceed the new viewport height, older tombstones scroll into the host's scrollback rather than overlapping the step. That is intentional and matches normal command output.
* `samples/FlowReflowProbe` is a tiny standalone harness used to verify "does the host terminal actually keep the cursor stuck to a known row across resize" (DECAWM + DSR semantics) on real terminals before relying on it in the runner.
* `samples/FlowDemo` gains a `--soft-wrap` flag that wires `UseSoftWrapTombstones=true` end to end so this can be exercised manually.

## Tests

* New `FlowResizeMathTests` and `SoftWrapEmitterTests` cover the pure-logic pieces.
* Full suite: `dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj` -> 7734 passed / 27 skipped / 0 failed.
* Manual verification against `samples/FlowDemo -- new --soft-wrap` for the no-tombstone, single-tombstone, and vertical-overflow resize cases.