### PR TITLE
Fix #321: Correct display width in button-like widgets, tabs, etc.

### DIFF
--- a/samples/FSharpDemo/FSharpDemo.fsproj
+++ b/samples/FSharpDemo/FSharpDemo.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Hex1b/Hex1b.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/FSharpDemo/Program.fs
+++ b/samples/FSharpDemo/Program.fs
@@ -1,0 +1,57 @@
+// F# Demo - mirrors the repro from issue #321, adapted to use the
+// Hex1bTerminal.CreateBuilder(...) pattern instead of constructing
+// Hex1bApp directly.
+
+open System
+open Hex1b
+open Hex1b.Events
+open Hex1b.Widgets
+
+// ToggleSwitchWidget is a controlled component: every reconcile resets the
+// node's selection to whatever SelectedIndex the widget supplies. We hold
+// the current selection here and feed it back in on each rebuild.
+let mutable toggleIndex = 0
+
+let buildWidget (_ctx: RootContext) : Hex1bWidget =
+    let toggle =
+        ToggleSwitchWidget(
+            [| "正しいですか？"; "正しくないです。" |],
+            toggleIndex
+        )
+            .OnSelectionChanged(fun (e: ToggleSelectionChangedEventArgs) ->
+                toggleIndex <- e.SelectedIndex)
+
+    let btns : Hex1bWidget seq =
+        seq {
+            ButtonWidget("第一个按钮") :> Hex1bWidget
+            HStackWidget [|
+                ButtonWidget("第二个按钮") :> Hex1bWidget
+                TextBlockWidget " " :> Hex1bWidget
+                ButtonWidget("第三个按钮") :> Hex1bWidget
+            |] :> Hex1bWidget
+            HStackWidget [|
+                ButtonWidget("第二个按钮").Fill() :> Hex1bWidget
+                TextBlockWidget " " :> Hex1bWidget
+                ButtonWidget("第三个按钮") :> Hex1bWidget
+            |] :> Hex1bWidget
+            AlignWidget(ButtonWidget("第二个按钮"), Alignment.Center) :> Hex1bWidget
+            AlignWidget(ButtonWidget("第二个按钮").FixedWidth(12), Alignment.Center) :> Hex1bWidget
+            AlignWidget(toggle, Alignment.Center) :> Hex1bWidget
+        }
+
+    TabPanelWidget(
+        [| TabItemWidget("한국어 제목", fun _ -> btns) |]
+    ) :> Hex1bWidget
+
+[<EntryPoint>]
+let main _argv =
+    use terminal =
+        Hex1bTerminal
+            .CreateBuilder()
+            .WithMouse()
+            .WithHex1bApp(fun _app _options ->
+                Func<RootContext, Hex1bWidget>(buildWidget))
+            .Build()
+
+    terminal.RunAsync().GetAwaiter().GetResult() |> ignore
+    0

--- a/src/Hex1b/Nodes/ButtonNode.cs
+++ b/src/Hex1b/Nodes/ButtonNode.cs
@@ -69,7 +69,7 @@ public sealed class ButtonNode : Hex1bNode
     {
         // Button renders as " Label " on a chip background - one cell of
         // padding either side of the label.
-        var width = Label.Length + 2;
+        var width = DisplayWidth.GetStringWidth(Label) + 2;
         var height = 1;
         _measuredSize = constraints.Constrain(new Size(width, height));
         return _measuredSize;

--- a/src/Hex1b/Nodes/SplitButtonNode.cs
+++ b/src/Hex1b/Nodes/SplitButtonNode.cs
@@ -192,11 +192,11 @@ public sealed class SplitButtonNode : Hex1bNode
 
     protected override Size MeasureCore(Constraints constraints)
     {
-        // Without secondary actions the chip is " Label " (Label.Length + 2).
+        // Without secondary actions the chip is " Label " (display width + 2).
         // With secondary actions the chip becomes " Label │ ▼ " — the
         // ArrowRegionWidth trailing cells render the divider + space + arrow
         // + trailing pad.
-        var width = PrimaryLabel.Length + 2;
+        var width = DisplayWidth.GetStringWidth(PrimaryLabel) + 2;
         if (HasSecondaryActions)
         {
             width += ArrowRegionWidth;

--- a/src/Hex1b/Nodes/TabBarNode.cs
+++ b/src/Hex1b/Nodes/TabBarNode.cs
@@ -186,20 +186,20 @@ public sealed class TabBarNode : Hex1bNode
 
     private int CalculateTabWidth(TabInfo tab)
     {
-        var textWidth = tab.Title.Length;
+        var textWidth = DisplayWidth.GetStringWidth(tab.Title);
         if (!string.IsNullOrEmpty(tab.Icon))
         {
-            textWidth += tab.Icon.Length + 1;
+            textWidth += DisplayWidth.GetStringWidth(tab.Icon) + 1;
         }
         // Add space for left icons (each icon + space)
         foreach (var icon in tab.LeftActions)
         {
-            textWidth += icon.Icon.Length + 1;
+            textWidth += DisplayWidth.GetStringWidth(icon.Icon) + 1;
         }
         // Add space for right icons (space + each icon)
         foreach (var icon in tab.RightActions)
         {
-            textWidth += icon.Icon.Length + 1;
+            textWidth += DisplayWidth.GetStringWidth(icon.Icon) + 1;
         }
         return textWidth + 2; // padding
     }
@@ -286,7 +286,7 @@ public sealed class TabBarNode : Hex1bNode
             for (int iconIdx = 0; iconIdx < tab.LeftActions.Count; iconIdx++)
             {
                 var icon = tab.LeftActions[iconIdx];
-                var iconWidth = icon.Icon.Length;
+                var iconWidth = DisplayWidth.GetStringWidth(icon.Icon);
                 _iconHitRegions.Add((x, iconWidth, i, iconIdx, true, icon));
                 context.WriteClipped(x, _tabRowY, $"{fgCode}{bgCode}{icon.Icon} {resetToGlobal}");
                 x += iconWidth + 1;
@@ -296,18 +296,18 @@ public sealed class TabBarNode : Hex1bNode
             if (!string.IsNullOrEmpty(tab.Icon))
             {
                 context.WriteClipped(x, _tabRowY, $"{fgCode}{bgCode}{tab.Icon} {resetToGlobal}");
-                x += tab.Icon.Length + 1;
+                x += DisplayWidth.GetStringWidth(tab.Icon) + 1;
             }
 
             // Render title
             context.WriteClipped(x, _tabRowY, $"{fgCode}{bgCode}{tab.Title}{resetToGlobal}");
-            x += tab.Title.Length;
+            x += DisplayWidth.GetStringWidth(tab.Title);
 
             // Render right icons
             for (int iconIdx = 0; iconIdx < tab.RightActions.Count; iconIdx++)
             {
                 var icon = tab.RightActions[iconIdx];
-                var iconWidth = icon.Icon.Length;
+                var iconWidth = DisplayWidth.GetStringWidth(icon.Icon);
                 context.WriteClipped(x, _tabRowY, $"{fgCode}{bgCode} {icon.Icon}{resetToGlobal}");
                 x += 1; // space before icon
                 _iconHitRegions.Add((x, iconWidth, i, iconIdx, false, icon));

--- a/src/Hex1b/Nodes/TabItemNode.cs
+++ b/src/Hex1b/Nodes/TabItemNode.cs
@@ -37,10 +37,10 @@ public sealed class TabItemNode : Hex1bNode
     protected override Size MeasureCore(Constraints constraints)
     {
         // Tab renders as " [Icon] Title " with padding
-        var textWidth = Title.Length;
+        var textWidth = DisplayWidth.GetStringWidth(Title);
         if (!string.IsNullOrEmpty(Icon))
         {
-            textWidth += Icon.Length + 1; // icon + space
+            textWidth += DisplayWidth.GetStringWidth(Icon) + 1; // icon + space
         }
         var width = textWidth + 2; // 1 char padding on each side
         var height = 1;

--- a/src/Hex1b/Nodes/TabPanelNode.cs
+++ b/src/Hex1b/Nodes/TabPanelNode.cs
@@ -364,7 +364,7 @@ public sealed class TabPanelNode : Hex1bNode, ILayoutProvider
             for (int iconIdx = 0; iconIdx < tab.LeftActions.Count; iconIdx++)
             {
                 var icon = tab.LeftActions[iconIdx];
-                var iconWidth = icon.Icon.Length;
+                var iconWidth = DisplayWidth.GetStringWidth(icon.Icon);
                 _iconHitRegions.Add((x, iconWidth, i, iconIdx, true, icon));
                 context.WriteClipped(x, _tabRowY, $"{fgCode}{bgCode}{icon.Icon} {resetToGlobal}");
                 x += iconWidth + 1;
@@ -374,18 +374,18 @@ public sealed class TabPanelNode : Hex1bNode, ILayoutProvider
             if (!string.IsNullOrEmpty(tab.Icon))
             {
                 context.WriteClipped(x, _tabRowY, $"{fgCode}{bgCode}{tab.Icon} {resetToGlobal}");
-                x += tab.Icon.Length + 1;
+                x += DisplayWidth.GetStringWidth(tab.Icon) + 1;
             }
 
             // Render title
             context.WriteClipped(x, _tabRowY, $"{fgCode}{bgCode}{tab.Title}{resetToGlobal}");
-            x += tab.Title.Length;
+            x += DisplayWidth.GetStringWidth(tab.Title);
 
             // Render right icons
             for (int iconIdx = 0; iconIdx < tab.RightActions.Count; iconIdx++)
             {
                 var icon = tab.RightActions[iconIdx];
-                var iconWidth = icon.Icon.Length;
+                var iconWidth = DisplayWidth.GetStringWidth(icon.Icon);
                 context.WriteClipped(x, _tabRowY, $"{fgCode}{bgCode} {icon.Icon}{resetToGlobal}");
                 x += 1; // space before icon
                 _iconHitRegions.Add((x, iconWidth, i, iconIdx, false, icon));
@@ -460,20 +460,20 @@ public sealed class TabPanelNode : Hex1bNode, ILayoutProvider
 
     private static int CalculateTabWidth(TabBarNode.TabInfo tab)
     {
-        var textWidth = tab.Title.Length;
+        var textWidth = DisplayWidth.GetStringWidth(tab.Title);
         if (!string.IsNullOrEmpty(tab.Icon))
         {
-            textWidth += tab.Icon.Length + 1;
+            textWidth += DisplayWidth.GetStringWidth(tab.Icon) + 1;
         }
         // Add space for left icons (each icon + space)
         foreach (var icon in tab.LeftActions)
         {
-            textWidth += icon.Icon.Length + 1;
+            textWidth += DisplayWidth.GetStringWidth(icon.Icon) + 1;
         }
         // Add space for right icons (space + each icon)
         foreach (var icon in tab.RightActions)
         {
-            textWidth += icon.Icon.Length + 1;
+            textWidth += DisplayWidth.GetStringWidth(icon.Icon) + 1;
         }
         return textWidth + 2; // padding
     }

--- a/src/Hex1b/Nodes/ToggleSwitchNode.cs
+++ b/src/Hex1b/Nodes/ToggleSwitchNode.cs
@@ -12,7 +12,7 @@ namespace Hex1b;
 /// preserved across reconciliation.
 /// </summary>
 /// <remarks>
-/// Each option occupies <c>1 + label_length + 1</c> cells (a single
+/// Each option occupies <c>1 + label_display_width + 1</c> cells (a single
 /// padding cell on each side of the label) and is painted in its own
 /// colours — the selected option gets the
 /// <see cref="ToggleSwitchTheme.FocusedSelectedBackgroundColor"/> /
@@ -110,7 +110,7 @@ public sealed class ToggleSwitchNode : Hex1bNode
     {
         if (Options.Count == 0) return;
 
-        // Layout: per-option chips of width (1 + label + 1) tiled left
+        // Layout: per-option chips of width (1 + display width + 1) tiled left
         // to right with no separator. The whole strip is clickable —
         // every cell of an option's chip (including its leading and
         // trailing padding cells) selects that option.
@@ -119,7 +119,7 @@ public sealed class ToggleSwitchNode : Hex1bNode
 
         for (int i = 0; i < Options.Count; i++)
         {
-            var chipWidth = Options[i].Length + 2;
+            var chipWidth = DisplayWidth.GetStringWidth(Options[i]) + 2;
             var endX = currentX + chipWidth; // exclusive
 
             if (localX >= currentX && localX < endX)
@@ -166,14 +166,14 @@ public sealed class ToggleSwitchNode : Hex1bNode
     {
         if (Options.Count == 0) return InputResult.NotHandled;
 
-        // Per-option chips of width (1 + label + 1) tiled left to right
+        // Per-option chips of width (1 + display width + 1) tiled left to right
         // with no separator. Padding cells are part of the chip's hit
         // region, so the entire strip is clickable.
         var currentX = 0;
 
         for (int i = 0; i < Options.Count; i++)
         {
-            var chipWidth = Options[i].Length + 2;
+            var chipWidth = DisplayWidth.GetStringWidth(Options[i]) + 2;
             var endX = currentX + chipWidth; // exclusive
 
             if (localX >= currentX && localX < endX)
@@ -196,12 +196,12 @@ public sealed class ToggleSwitchNode : Hex1bNode
             return constraints.Constrain(new Size(0, 1));
         }
 
-        // Per-option chips of width (1 + label + 1) tiled with no
-        // separator. Total width = Σ(label_len + 2) = Σlabel_len + 2n.
+        // Per-option chips of width (1 + display width + 1) tiled with no
+        // separator. Total width = Σ(display_width + 2).
         var totalWidth = 0;
         for (int i = 0; i < Options.Count; i++)
         {
-            totalWidth += Options[i].Length + 2;
+            totalWidth += DisplayWidth.GetStringWidth(Options[i]) + 2;
         }
 
         return constraints.Constrain(new Size(totalWidth, 1));

--- a/tests/Hex1b.Tests/ButtonNodeTests.cs
+++ b/tests/Hex1b.Tests/ButtonNodeTests.cs
@@ -26,6 +26,18 @@ public class ButtonNodeTests
     }
 
     [Fact]
+    public async Task Measure_CJKCharacters_CorrectSize()
+    {
+        var node = new ButtonNode { Label = "汉字かな한글" };
+
+        var size = node.Measure(Constraints.Unbounded);
+
+        // " 汉字かな한글 " = 2 (chip padding) + 6 (CJK chars) * 2 (width) = 14
+        Assert.Equal(14, size.Width);
+        Assert.Equal(1, size.Height);
+    }
+
+    [Fact]
     public async Task Measure_EmptyLabel_HasMinSize()
     {
         var node = new ButtonNode { Label = "" };
@@ -229,12 +241,12 @@ public class ButtonNodeTests
         unfocusedNode.Render(unfocusedContext);
 
         var pattern = new CellPatternSearcher().Find("Click");
-        
+
         await new Hex1bTerminalInputSequenceBuilder()
             .WaitUntil(s => s.SearchPattern(pattern).HasMatches, TimeSpan.FromSeconds(5))
             .Build()
             .ApplyAsync(focusedTerminal);
-        
+
         await new Hex1bTerminalInputSequenceBuilder()
             .WaitUntil(s => s.SearchPattern(pattern).HasMatches, TimeSpan.FromSeconds(5))
             .Build()
@@ -243,14 +255,14 @@ public class ButtonNodeTests
         // Focused button should have different styling (colors or attributes)
         var focusedMatch = focusedTerminal.CreateSnapshot().SearchPattern(pattern).First;
         Assert.NotNull(focusedMatch);
-        
+
         // The focused button should have either reverse attribute or foreground/background colors
         var focusedCells = focusedMatch.Cells;
-        var focusedHasStyling = focusedCells.Any(c => 
-            c.Cell.IsReverse || 
-            c.Cell.Foreground.HasValue || 
+        var focusedHasStyling = focusedCells.Any(c =>
+            c.Cell.IsReverse ||
+            c.Cell.Foreground.HasValue ||
             c.Cell.Background.HasValue);
-        
+
         Assert.True(focusedHasStyling, "Focused button should have styling applied");
     }
 

--- a/tests/Hex1b.Tests/SplitButtonNodeTests.cs
+++ b/tests/Hex1b.Tests/SplitButtonNodeTests.cs
@@ -118,6 +118,18 @@ public class SplitButtonNodeTests
     }
 
     [Fact]
+    public void Measure_CJKCharacters_CorrectSize()
+    {
+        var node = new SplitButtonNode { PrimaryLabel = "汉字かな한글" };
+
+        var size = node.Measure(Constraints.Unbounded);
+
+        // " 汉字かな한글 " = 2 (chip padding) + 6 (CJK chars) * 2 (width) = 14
+        Assert.Equal(14, size.Width);
+        Assert.Equal(1, size.Height);
+    }
+
+    [Fact]
     public void Measure_SecondaryActions_IncludesArrow()
     {
         var node = new SplitButtonNode 

--- a/tests/Hex1b.Tests/TabPanelNodeTests.cs
+++ b/tests/Hex1b.Tests/TabPanelNodeTests.cs
@@ -48,6 +48,43 @@ public class TabPanelNodeTests
     }
 
     [Fact]
+    public async Task TabPanel_WideTabTitle_UsesDisplayWidthForSelectedIndicator()
+    {
+        // Arrange
+        const string title = "한국어 제목";
+        var expectedTabWidth = DisplayWidth.GetStringWidth(title) + 2;
+        Assert.True(expectedTabWidth > title.Length + 2, "Test title must contain wide characters.");
+
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(40, 8).Build();
+
+        using var app = new Hex1bApp(
+            ctx => Task.FromResult<Hex1bWidget>(ctx.TabPanel(tp => [
+                tp.Tab(title, t => [t.Text("Content")])
+            ])),
+            new Hex1bAppOptions { WorkloadAdapter = workload }
+        );
+
+        // Act
+        var runTask = app.RunAsync(TestContext.Current.CancellationToken);
+        var snapshot = await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.ContainsText(title) && s.ContainsText("Content"), TimeSpan.FromSeconds(5), "wide tab rendered")
+            .Capture("wide-tab-title")
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
+        await runTask;
+
+        // Assert - the selected-tab indicator spans the full display width of the wide title.
+        for (var x = 0; x < expectedTabWidth; x++)
+        {
+            Assert.Equal("▁", snapshot.GetCell(x, 0).Character);
+        }
+
+        Assert.NotEqual("▁", snapshot.GetCell(expectedTabWidth, 0).Character);
+    }
+
+    [Fact]
     public async Task TabPanel_AltRight_SwitchesToNextTab()
     {
         // Arrange

--- a/tests/Hex1b.Tests/ToggleSwitchNodeTests.cs
+++ b/tests/Hex1b.Tests/ToggleSwitchNodeTests.cs
@@ -74,6 +74,21 @@ public class ToggleSwitchNodeTests
     }
 
     [Fact]
+    public async Task Measure_CJKCharacters_CorrectSize()
+    {
+        var node = new ToggleSwitchNode
+        {
+            Options = ["汉字", "Auto", "한글"]
+        };
+
+        var size = node.Measure(Constraints.Unbounded);
+
+        // Per-option chips: " 汉字 " (6) + " Auto " (6) + " 한글 " (6) = 18
+        Assert.Equal(18, size.Width);
+        Assert.Equal(1, size.Height);
+    }
+
+    [Fact]
     public async Task Measure_RespectsMaxWidthConstraint()
     {
         var node = new ToggleSwitchNode
@@ -702,6 +717,26 @@ public class ToggleSwitchNodeTests
         // Click on chip 0's leading padding cell (X=0)
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 0, 0, Hex1bModifiers.None);
         var result = node.HandleMouseClick(0, 0, mouseEvent);
+
+        Assert.Equal(InputResult.Handled, result);
+        Assert.Equal(0, node.SelectedIndex);
+    }
+
+    [Fact]
+    public async Task HandleMouseClick_CJKCharacters_UsesDisplayWidth()
+    {
+        // Layout: " 汉字  Off " — chip 0 covers cells 0-5 because
+        // "汉字" is 4 display cells wide, and chip 1 starts at cell 6.
+        var node = new ToggleSwitchNode
+        {
+            Options = ["汉字", "Off"],
+            SelectedIndex = 1
+        };
+        node.Measure(Constraints.Unbounded);
+        node.Arrange(new Rect(0, 0, 11, 1));
+
+        var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 4, 0, Hex1bModifiers.None);
+        var result = node.HandleMouseClick(4, 0, mouseEvent);
 
         Assert.Equal(InputResult.Handled, result);
         Assert.Equal(0, node.SelectedIndex);


### PR DESCRIPTION
See #321 

# Summary of Fixes

1. `fix: correct width in Button, SplitButton and ToggleSwitch.`
   - Replaces raw `string.Length` width calculations with `DisplayWidth.GetStringWidth(...)` in Button, SplitButton, and ToggleSwitch nodes.
   - Fixes layout measurement and mouse hit testing for wide Unicode labels.

2. `test: Add wide character width tests for controls`
   - Adds regression coverage for CJK labels in Button, SplitButton, and ToggleSwitch.
   - Verifies both measured width and ToggleSwitch mouse hit regions.

3. `fix: Correct tab display width handling`
   - Updates TabPanel, TabBar, and TabItem width calculations to use terminal display width.
   - Fixes selected tab indicators, tab spacing, overflow math, and icon/title hit regions with wide-character tab titles.

4. `test: Add wide character tab title coverage`
   - Adds a regression test for Wide-character tab titles.
   - Confirms the selected-tab indicator spans the real terminal display width, not the raw string length.

# Effect

Before (with `#r "nuget: Hex1b, 0.154.0"`): 

<img width="800" height="240" alt="before" src="https://github.com/user-attachments/assets/06d67433-74f9-4e57-b54c-5c92e8d9eee7" />

After (the version of this pr):

<img width="800" height="240" alt="after" src="https://github.com/user-attachments/assets/b5b7fc7e-db4d-4612-bb88-dd28ddda7017" />