### PR TITLE
Fix flaky CellPatternSearcherTests.UpUntil_StopsAtMatch (#325)

### DIFF
--- a/tests/Hex1b.Tests/CellPatternSearcherTests.cs
+++ b/tests/Hex1b.Tests/CellPatternSearcherTests.cs
@@ -19,10 +19,22 @@ public class CellPatternSearcherTests
             workload.Write(line + "\r\n");
         }
 
-        // Wait for content to be processed by the output pump - wait for last line to ensure all content is rendered
+        // Wait for content to be processed by the output pump. Check that the last
+        // line appears at its expected row position rather than anywhere in the
+        // buffer; the pump writes in order, so seeing the final line at the final
+        // row guarantees that all preceding rows have also been flushed. Using
+        // ContainsText here would race when intermediate rows share characters
+        // with the last line (e.g. lines = { "-", "A", "A", "A" } would be
+        // considered "ready" as soon as the first "A" lands on row 1, before
+        // rows 2 and 3 are written).
         var lastLine = lines.Length > 0 ? lines[^1] : "";
+        var lastLineIndex = lines.Length - 1;
         await new Hex1bTerminalInputSequenceBuilder()
-            .WaitUntil(s => string.IsNullOrEmpty(lastLine) || s.ContainsText(lastLine), TimeSpan.FromSeconds(5), "last line content")
+            .WaitUntil(
+                s => string.IsNullOrEmpty(lastLine)
+                     || s.GetLineTrimmed(lastLineIndex).Contains(lastLine, StringComparison.Ordinal),
+                TimeSpan.FromSeconds(5),
+                "last line content at expected row")
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 


### PR DESCRIPTION
The daily test monitor flagged `Hex1b.Tests.CellPatternSearcherTests.UpUntil_StopsAtMatch` as intermittently failing in CI (#325). The test passes locally on every run, which is the classic symptom of a flush race in the test setup rather than a bug in the production searcher.

## Root cause

`CreateSnapshotAsync(string[] lines, ...)` waits for the output pump to drain using `s.ContainsText(lastLine)`. `ContainsText` matches if **any** row contains the substring, so for inputs like `{ "-", "A", "A", "A" }` (where `lastLine = "A"`) the predicate is satisfied as soon as the first `A` lands on row 1, before rows 2 and 3 are written. The snapshot is taken with row 3 still empty, `Find(Y == 3 && Char == "A")` returns no match, and `Assert.True(result.HasMatches)` fails.

The sibling test `DownUntil_StopsAtMatch` is not affected because its `lastLine` (`"-"`) is unique and only appears after all preceding rows.

## Fix

Wait for the last line at its **expected row index** (`lines.Length - 1`) using `GetLineTrimmed`. Because the output pump writes in order, observing the final line at the final row implies all earlier rows are flushed too. This is a one-line behavioural fix to a single test helper; no production code changes.

## Verification

- `UpUntil_StopsAtMatch` passes (20/20 in tight loop locally).
- Full `CellPatternSearcherTests` class: 91/91 passing.

Fixes: #325