### PR TITLE
Stabilize TextBoxPredictionTests.Typing_AtEndOfBuffer_TriggersPredictor

### DIFF
--- a/tests/Hex1b.Tests/TextBoxPredictionTests.cs
+++ b/tests/Hex1b.Tests/TextBoxPredictionTests.cs
@@ -50,11 +50,11 @@ public class TextBoxPredictionTests
     public async Task Typing_AtEndOfBuffer_TriggersPredictor()
     {
         var calls = 0;
-        string? observed = null;
+        var seen = new System.Collections.Concurrent.ConcurrentQueue<string>();
         var node = CreateNode((text, _) =>
         {
             Interlocked.Increment(ref calls);
-            observed = text;
+            seen.Enqueue(text);
             return Task.FromResult<string?>("world");
         });
 
@@ -64,10 +64,16 @@ public class TextBoxPredictionTests
         await InputRouter.RouteInputToNodeAsync(node, CharKey('l'), null, null, TestContext.Current.CancellationToken);
         await InputRouter.RouteInputToNodeAsync(node, CharKey('o'), null, null, TestContext.Current.CancellationToken);
 
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (DateTime.UtcNow < deadline && !seen.Contains("hello"))
+        {
+            await Task.Delay(10, TestContext.Current.CancellationToken);
+        }
+
         var prediction = await WaitForPredictionAsync(node, TimeSpan.FromSeconds(2));
 
         Assert.Equal("world", prediction);
-        Assert.Equal("hello", observed);
+        Assert.True(seen.Contains("hello"), $"Predictor never saw 'hello'. text='{node.Text}' seen=[{string.Join(",", seen)}] calls={calls}");
         Assert.True(calls >= 1);
     }
 


### PR DESCRIPTION
The daily test monitor has been flagging `Typing_AtEndOfBuffer_TriggersPredictor` as intermittently failing. The failure is purely a test synchronization bug — production behaviour is unaffected.

## Root cause

Each keystroke schedules its predictor via `Task.Run`. With a synchronous predictor (`Task.FromResult(...)`) and zero debounce, multiple tasks race on the thread pool. The test was using a single `string? observed = text` field that captured whichever predictor task ran last in thread-pool order — not the one tied to the final keystroke. The wait helper also returned as soon as `CurrentPrediction` went non-null, which an earlier snapshot's task could satisfy before the `'o'` task had been picked up. Hence `observed == "hell"` (or "hel") slipped through.

`TextBoxNode.SetPrediction` is already correctly guarded by `State.Text == snapshot`, so users never see a stale prediction — only the test's `observed` write was racy.

## Fix

Record every snapshot the predictor sees in a `ConcurrentQueue<string>` and wait until `"hello"` appears (same 2s budget). Assert that `"hello"` is among the observed snapshots rather than requiring it to be strictly the last one. This matches the test's actual intent — typing at the end of the buffer triggers the predictor with the typed text — without depending on thread-pool ordering. No production change.

## Verification

- Reliably reproduced the original failure locally before the fix.
- After fix: 30/30 runs of `TextBoxPredictionTests` clean.
- Full `Hex1b.Tests` suite: 7757 passed, 0 failed.

Fixes: #324