### PR TITLE
Stabilize Render_MultiLineHighlight_SpansCorrectly test

### DIFF
--- a/tests/Hex1b.Tests/RangeHighlightTests.cs
+++ b/tests/Hex1b.Tests/RangeHighlightTests.cs
@@ -256,17 +256,25 @@ public class RangeHighlightTests
 
         node.Render(context);
 
+        var expectedBg = ToCellColor(theme.Get(RangeHighlightTheme.DefaultBackground));
+        var editorBg = ToCellColor(theme.Get(EditorTheme.BackgroundColor));
+
+        // Wait for both lines to fully render — the terminal flushes writes
+        // asynchronously, so simply matching "abc" on line 0 can race with
+        // line 1's cells still being repainted with the highlight background.
         var pattern = new CellPatternSearcher().Find("abc");
         await new Hex1bTerminalInputSequenceBuilder()
-            .WaitUntil(s => s.SearchPattern(pattern).HasMatches,
-                TimeSpan.FromSeconds(2), "text rendered")
+            .WaitUntil(s =>
+            {
+                if (!s.SearchPattern(pattern).HasMatches) return false;
+                // Last line cell the test asserts on — ensures line 1 has been painted.
+                return ColorEquals(expectedBg, s.GetCell(0, 1).Background);
+            },
+                TimeSpan.FromSeconds(2), "multi-line highlight rendered")
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         var snapshot = terminal.CreateSnapshot();
-
-        var expectedBg = ToCellColor(theme.Get(RangeHighlightTheme.DefaultBackground));
-        var editorBg = ToCellColor(theme.Get(EditorTheme.BackgroundColor));
 
         // Line 0: 'a' no highlight, 'b' and 'c' highlighted
         Assert.True(ColorEquals(editorBg, snapshot.GetCell(0, 0).Background),


### PR DESCRIPTION
Daily test monitoring flagged `Render_MultiLineHighlight_SpansCorrectly` as intermittently failing in CI with `Line 1 col 0: should be highlighted`. The rendering math is correct; the failure is a test-only race.

The test calls `node.Render(context)` and then waits via `WaitUntil` for the pattern `"abc"` (line 0) to appear before taking a snapshot. But the assertions also check cells on line 1, and the terminal flushes writes asynchronously, so under CI load the snapshot can land after line 0 paints but before line 1's highlight background is applied.

Fix: strengthen the `WaitUntil` predicate to require both the `"abc"` pattern match and the expected highlight background on `GetCell(0, 1)` before snapshotting. This mirrors the existing pattern used by `Render_ClearedHighlights_BackgroundReverts`. Test-only change; no production code touched.

Verified locally with 20 consecutive runs (20/20 pass) and the full `RangeHighlightTests` class (10/10 pass).

Fixes: #302