### PR TITLE
Profile and optimise rendering perf (Tier 1 + 2 + fast-path diff)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -522,3 +522,4 @@ test-*.svg
 src/Hex1b/runtimes/linux-arm64/native/libhex1binterop.so
 src/Hex1b/runtimes/osx-x64/native/libhex1binterop.dylib
 src/Hex1b/runtimes/osx-arm64/native/libhex1binterop.dylib
+aspire.config.json

--- a/docs/perf/baseline.md
+++ b/docs/perf/baseline.md
@@ -169,3 +169,25 @@ dotnet-trace collect --format speedscope --profile dotnet-sampled-thread-time \
 | `--busy-grid-cols N` | 12 | Dashboard grid columns |
 | `--width N` | 160 (busy) | Terminal width |
 | `--height N` | 50 (busy) | Terminal height |
+
+## Interactive repro: `samples/PerfStressDemo`
+
+`PerfDemo` measures with the output discarded. `PerfStressDemo` is the
+companion that runs as a *real* TUI so the regression is visible to the
+naked eye (and to a `dotnet-trace` run against the live process).
+
+```bash
+dotnet run -c Release --project samples/PerfStressDemo                # defaults: pool on, ~30 fps target
+dotnet run -c Release --project samples/PerfStressDemo -- --no-pool   # A/B: pool off
+```
+
+* `PgUp` / `PgDn` switch between stress pages, `Q` quits.
+* The status bar shows live FPS and accumulated GC counts (Gen0 / Gen1 /
+  Gen2), so the SurfacePool win is unmistakable: with the pool on Gen2
+  stays at 0; with `--no-pool` it climbs steadily.
+
+Pages currently shipped:
+
+1. **Ripple over noise** — full-screen white random ASCII inside an
+   `EffectPanel` painting a continuously expanding circular ripple. This
+   is the workload that originally motivated the perf investigation.

--- a/docs/perf/baseline.md
+++ b/docs/perf/baseline.md
@@ -1,0 +1,167 @@
+# Hex1b rendering performance — baseline (2026-05-26)
+
+> Captured on Apple Silicon (`Darwin 25.5.0 arm64`), .NET SDK 10.0.300,
+> `Release` build, using `samples/PerfDemo` with the new `--busy` mode.
+>
+> Repro:
+> ```bash
+> dotnet run -c Release --project samples/PerfDemo -- --busy --frames 300 --warmup 50
+> ```
+
+## Workload
+
+A representative "busy" UX:
+
+- Outer `HSplitter`: sidebar (Border + 20-item VStack, one row mutates per frame)
+  on the left; main pane on the right.
+- Main pane: outer `Border` wrapping a `VSplitter` of a Dashboard (Progress bar
+  + 8×12 numeric grid that mutates every cell every frame) and a Log
+  (20-line scrolling list — every visible row changes every frame).
+- 160 × 50 cells, frame-rate-limit 1 ms, surface rendering with the discard
+  workload adapter.
+
+The scene is deliberately tuned so that the per-frame diff produces ~200
+changed cells / ~330 ANSI tokens / ~1.2 KB output — non-trivial but not
+unrealistic for a real app.
+
+## Headline numbers (no caching, no pooling — i.e. defaults)
+
+| metric                              | mean    | p50     | p95     | p99     | max     |
+| ----------------------------------- | ------- | ------- | ------- | ------- | ------- |
+| `hex1b.frame.duration` (ms)         | 12.22   | 12.29   | 14.87   | 15.30   | 15.60   |
+| `hex1b.frame.build.duration` (ms)   | 0.011   | 0.006   | 0.022   | 0.040   | 1.104   |
+| `hex1b.frame.reconcile.duration`    | 0.050   | 0.031   | 0.098   | 0.113   | 2.554   |
+| `hex1b.frame.render.duration`       | 12.10   | 12.15   | 14.67   | 15.24   | 15.31   |
+| `hex1b.surface.diff.duration`       | 0.095   | 0.070   | 0.111   | 0.639   | 1.054   |
+| `hex1b.surface.tokens.duration`     | 0.013   | 0.007   | 0.028   | 0.045   | 0.053   |
+| `hex1b.surface.serialize.duration`  | 0.007   | 0.003   | 0.017   | 0.035   | 0.036   |
+
+| accounting | per frame |
+| ---------- | --------- |
+| allocations | **7.45 MB** |
+| Gen0 / Gen1 / Gen2 over 300 frames | **267 / 171 / 121** |
+| measure calls per frame (~162 nodes) | **~668** (~4× per node) |
+
+### Interpretation
+
+1. **Render phase is 99% of frame time** (12.10 / 12.22 ms).
+2. **The instrumented sub-phases of render (diff + tokens + serialize) total
+   ~0.12 ms** — i.e. less than 1% of the frame. The other ~12 ms is in
+   `node.Render` (cells being drawn onto the surface) and to a lesser
+   extent measure/arrange.
+3. **Allocations are the elephant in the room**: 7.45 MB per frame and
+   **121 Gen2 collections in 300 frames** (≈40% of frames trigger a Gen2 on
+   this machine). This is what makes the UI feel "crappy" even on fast
+   hardware — Gen2 collections produce visible stalls.
+4. The 4× over-measuring (~668 measure calls for 162 nodes) is real but
+   small compared to the allocation cost.
+
+## A/B: caching and pooling
+
+300-frame busy run, same machine, identical workload:
+
+| variant                | frame mean (ms) | bytes/frame | Gen0/Gen1/Gen2 |
+| ---------------------- | --------------: | ----------: | -------------: |
+| **defaults**           | 12.22           | 7,455,729   | 267 / 171 / 121 |
+| `EnableRenderCaching`  | 12.31           | 7,323,975   | 244 / 180 / 111 |
+| `EnableSurfacePooling` | **10.86**       | **3,495,117** | **125 / 39 / 0** |
+
+### What this means
+
+- **`EnableSurfacePooling` is a massive win on this workload** and ships
+  *off by default*:
+  - **-53% allocations per frame**
+  - **121 → 0 Gen2 GCs**
+  - **-11% mean frame time**
+- `EnableRenderCaching` does nothing here because every visible widget
+  changes every frame (the scrolling log). It's still useful in scenes
+  with large static subtrees — `samples/PerfDemo` (non-busy mode) is the
+  case to validate that.
+
+## CPU hotspots (managed inclusive time, ~300 frames sampled)
+
+From `dotnet-trace --profile dotnet-sampled-thread-time` (Apple Silicon)
+converted to speedscope. Managed self-time per frame is below the sampling
+floor (≤10 ms ticks vs ~12 ms total per frame), so we read **inclusive**
+time:
+
+| % wall | inclusive ms | function |
+| -----: | ----------: | -------- |
+| 73.96  | 26,898 | `Surfaces.SurfaceRenderContext.RenderChild` (root of the render tree) |
+| 19.01  |  6,914 | `SplitterNode.Render` |
+| 18.70  |  6,802 | `Nodes.LayoutNode.Render` |
+| 18.32  |  6,663 | `Nodes.BorderNode.Render` |
+| 14.83  |  5,393 | `VStackNode.Render` |
+| 13.64  |  4,960 | `Hex1bApp.RenderFrameWithSurface` |
+| 13.36  |  4,858 | `ZStackNode.Render` |
+|  8.81  |  3,202 | `Hex1bApp.RenderFrameAsync` |
+|  8.70  |  3,162 | `Thread.PollGC` *(GC pressure signal)* |
+|  8.49  |  3,086 | `Buffer.BulkMoveWithWriteBarrier` *(surface composite/array copies)* |
+
+The most expensive *leaf* operation on the render path is
+**`Buffer.BulkMoveWithWriteBarrier`** at ~8.5%, which is the bulk-copy
+behind `Surface.Composite` / `SurfaceCell[]` clones. The next layer up is
+the per-cell write path through `SurfaceRenderContext.WriteToSurface` /
+`SliceByDisplayWidthWithAnsi` / `DisplayWidth.GetGraphemeAtIndex` /
+`TextSegmentationUtility.GetLengthOfFirstExtendedGraphemeCluster` — i.e.
+**grapheme analysis runs on every single cell write**, which is likely a
+significant fraction of the per-node render time.
+
+Raw speedscope JSON is saved to
+`~/.copilot/session-state/<session>/files/baseline-busy300.speedscope.json`
+for inspection in https://speedscope.app .
+
+## Ranked optimisation opportunities
+
+| # | hypothesis | est. impact | risk |
+|---|------------|-------------|------|
+| 1 | **Flip `EnableSurfacePooling` default to `true`** (or document loudly). Measured: -53% allocations, -11% frame, 0 Gen2 GCs. Need to confirm there's no correctness issue keeping it off. | very high | low if the only reason it's off is "didn't get around to it"; investigate before flipping |
+| 2 | Cache / fast-path grapheme analysis for ASCII writes. `DisplayWidth.GetGraphemeAtIndex` + `TextSegmentationUtility.GetLengthOfFirstExtendedGraphemeCluster` are called for every cell — but the overwhelming majority of cells are ASCII (width 1, single byte). An ASCII fast path would skip the unicode segmentation entirely. | high | low |
+| 3 | Reduce measure-pass amplification. ~4× per node on splitter-heavy trees. Likely two-pass measure inside `SplitterNode`; verify and short-circuit when constraints are tight. | medium | medium |
+| 4 | Pool / reuse the `ChangedCell` list and other per-frame collections inside `SurfaceComparer`. Currently allocates a fresh `List<ChangedCell>` and sorts it every frame. | medium | low |
+| 5 | Per-node `Render` allocations (Splitter / Border / VStack / ZStack). Investigate `string.Format`, `string` interpolation, and any `LINQ`/`ToList()` inside these — the inclusive-time signal is loud but cell-write cost may be the bulk. Need per-call allocation instrumentation. | medium | low |
+| 6 | `Buffer.BulkMoveWithWriteBarrier` at 8.5% suggests `SurfaceCell[]` is being cloned. Investigate `Surface.Composite` / `Surface.Clone`; if cells are value-type-ish and bigger than 16 bytes, copy cost can be reduced via in-place writes or smaller cell representation. | medium | medium |
+
+Numbers 2–6 should each get a BenchmarkDotNet case in
+`benchmarks/Hex1b.Benchmarks/` and an A/B run via this same `--busy`
+workload before/after.
+
+## How to reproduce / re-measure
+
+```bash
+# Build once
+dotnet build -c Release samples/PerfDemo/PerfDemo.csproj
+
+# Headline busy run (prints metrics summary at the end)
+dotnet run -c Release --project samples/PerfDemo --no-build -- \
+    --busy --frames 300 --warmup 50
+
+# Enable per-node histograms (tagged by node metric path)
+dotnet run -c Release --project samples/PerfDemo --no-build -- \
+    --busy --per-node --frames 300 --warmup 50
+
+# Compare cache / pool variants
+dotnet run -c Release --project samples/PerfDemo --no-build -- --busy --cache
+dotnet run -c Release --project samples/PerfDemo --no-build -- --busy --pool
+
+# CPU profile (macOS / Linux compatible profile)
+dotnet-trace collect --format speedscope --profile dotnet-sampled-thread-time \
+  --duration 00:00:00:30 \
+  -- $HOME/.dotnet/dotnet samples/PerfDemo/bin/Release/net10.0/PerfDemo.dll \
+        --busy --frames 300 --warmup 50 --no-summary
+# Then open the .speedscope.json file in https://speedscope.app
+```
+
+### New flags added to `PerfDemo`
+
+| flag | default | meaning |
+|------|---------|---------|
+| `--busy` | off | Use the realistic "busy" widget tree instead of the static panel |
+| `--per-node` | off | Enable per-node histograms (extra meter instruments) |
+| `--no-summary` | summary on | Suppress the end-of-run metric summary |
+| `--busy-sidebar N` | 20 | Sidebar item count |
+| `--busy-log N` | 20 | Scrolling log line count |
+| `--busy-grid-rows N` | 8 | Dashboard grid rows |
+| `--busy-grid-cols N` | 12 | Dashboard grid columns |
+| `--width N` | 160 (busy) | Terminal width |
+| `--height N` | 50 (busy) | Terminal height |

--- a/docs/perf/baseline.md
+++ b/docs/perf/baseline.md
@@ -60,19 +60,21 @@ unrealistic for a real app.
 
 300-frame busy run, same machine, identical workload:
 
-| variant                | frame mean (ms) | bytes/frame | Gen0/Gen1/Gen2 |
-| ---------------------- | --------------: | ----------: | -------------: |
-| **defaults**           | 12.22           | 7,455,729   | 267 / 171 / 121 |
-| `EnableRenderCaching`  | 12.31           | 7,323,975   | 244 / 180 / 111 |
-| `EnableSurfacePooling` | **10.86**       | **3,495,117** | **125 / 39 / 0** |
+| variant                 | frame mean (ms) | bytes/frame | Gen0/Gen1/Gen2 |
+| ----------------------- | --------------: | ----------: | -------------: |
+| **new defaults (pool on)** | **10.72**    | **3,462,716** | **124 / 32 / 0** |
+| `--no-pool` (legacy default) | 12.16       | 7,436,100   | 279 / 192 / 138 |
+| `--cache` (caching on)  | 12.31           | 7,323,975   | 244 / 180 / 111 |
 
 ### What this means
 
-- **`EnableSurfacePooling` is a massive win on this workload** and ships
-  *off by default*:
+- **`EnableSurfacePooling` is now the default** as of this branch — the
+  full Hex1b test suite (7902 tests across 5 projects) passes unchanged,
+  and the original commit message only described it as "opt-in" with no
+  recorded correctness reason. Measured against the previous default:
   - **-53% allocations per frame**
-  - **121 → 0 Gen2 GCs**
-  - **-11% mean frame time**
+  - **138 → 0 Gen2 GCs** over 300 frames
+  - **-12% mean frame time**
 - `EnableRenderCaching` does nothing here because every visible widget
   changes every frame (the scrolling log). It's still useful in scenes
   with large static subtrees — `samples/PerfDemo` (non-busy mode) is the
@@ -115,8 +117,8 @@ for inspection in https://speedscope.app .
 
 | # | hypothesis | est. impact | risk |
 |---|------------|-------------|------|
-| 1 | **Flip `EnableSurfacePooling` default to `true`** (or document loudly). Measured: -53% allocations, -11% frame, 0 Gen2 GCs. Need to confirm there's no correctness issue keeping it off. | very high | low if the only reason it's off is "didn't get around to it"; investigate before flipping |
-| 2 | Cache / fast-path grapheme analysis for ASCII writes. `DisplayWidth.GetGraphemeAtIndex` + `TextSegmentationUtility.GetLengthOfFirstExtendedGraphemeCluster` are called for every cell — but the overwhelming majority of cells are ASCII (width 1, single byte). An ASCII fast path would skip the unicode segmentation entirely. | high | low |
+| 1 | ✅ **DONE — `EnableSurfacePooling` default flipped to `true`.** Full test suite still green (7902 tests, 0 failures). Measured -53% allocations, -12% frame, 0 Gen2 GCs vs previous default. | shipped | — |
+| 2 | ASCII fast path for any remaining hot grapheme calls (`DisplayWidth.GetGraphemeAtIndex` / `TextSegmentationUtility.GetLengthOfFirstExtendedGraphemeCluster` still appear in the busy trace despite an existing fast-path in `GetNextGrapheme` — likely a second call site). | high | low |
 | 3 | Reduce measure-pass amplification. ~4× per node on splitter-heavy trees. Likely two-pass measure inside `SplitterNode`; verify and short-circuit when constraints are tight. | medium | medium |
 | 4 | Pool / reuse the `ChangedCell` list and other per-frame collections inside `SurfaceComparer`. Currently allocates a fresh `List<ChangedCell>` and sorts it every frame. | medium | low |
 | 5 | Per-node `Render` allocations (Splitter / Border / VStack / ZStack). Investigate `string.Format`, `string` interpolation, and any `LINQ`/`ToList()` inside these — the inclusive-time signal is loud but cell-write cost may be the bulk. Need per-call allocation instrumentation. | medium | low |
@@ -142,7 +144,7 @@ dotnet run -c Release --project samples/PerfDemo --no-build -- \
 
 # Compare cache / pool variants
 dotnet run -c Release --project samples/PerfDemo --no-build -- --busy --cache
-dotnet run -c Release --project samples/PerfDemo --no-build -- --busy --pool
+dotnet run -c Release --project samples/PerfDemo --no-build -- --busy --no-pool
 
 # CPU profile (macOS / Linux compatible profile)
 dotnet-trace collect --format speedscope --profile dotnet-sampled-thread-time \
@@ -159,6 +161,8 @@ dotnet-trace collect --format speedscope --profile dotnet-sampled-thread-time \
 | `--busy` | off | Use the realistic "busy" widget tree instead of the static panel |
 | `--per-node` | off | Enable per-node histograms (extra meter instruments) |
 | `--no-summary` | summary on | Suppress the end-of-run metric summary |
+| `--no-pool` | pool on | Disable surface pooling (matches the pre-default-flip behaviour for A/B) |
+| `--cache` | off | Enable widget-tree render caching |
 | `--busy-sidebar N` | 20 | Sidebar item count |
 | `--busy-log N` | 20 | Scrolling log line count |
 | `--busy-grid-rows N` | 8 | Dashboard grid rows |

--- a/samples/AccordionDemo/Program.cs
+++ b/samples/AccordionDemo/Program.cs
@@ -229,7 +229,7 @@ var rootEntry = FileEntry.ScanDirectory(workspaceDir, workspaceDir);
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithDiagnostics()
     .WithMouse()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         return ctx.VStack(v =>
         [

--- a/samples/AgenticPromptDemo/Program.cs
+++ b/samples/AgenticPromptDemo/Program.cs
@@ -95,7 +95,9 @@ string lastCopySummary = "no copies yet";
 IReadOnlyList<SelectionPanelSelectedNode> lastSelectedNodes = Array.Empty<SelectionPanelSelectedNode>();
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(
+        _ => { },
+        app => ctx =>
     {
         return ctx.VStack(v =>
         [

--- a/samples/AnimationProof/Program.cs
+++ b/samples/AnimationProof/Program.cs
@@ -17,7 +17,9 @@ var serverLoading = false;
 var serverChildren = new List<TreeItemWidget>();
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+    .WithHex1bApp(
+        _ => { },
+        app => ctx => ctx.VStack(v => [
         v.Text("🧪 Animation & Tree API Proof-of-Concept"),
         v.Text(""),
         

--- a/samples/AsciinemaPlaybackDemo/Program.cs
+++ b/samples/AsciinemaPlaybackDemo/Program.cs
@@ -225,7 +225,9 @@ Hex1bWidget BuildUI(RootContext ctx)
 using var appCts = new CancellationTokenSource();
 await using var displayTerminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((a, options) =>
+    .WithHex1bApp(
+        _ => { },
+        a =>
     {
         app = a;
         return ctx => BuildUI(ctx);

--- a/samples/BlazorDemo/GlobeRunner.cs
+++ b/samples/BlazorDemo/GlobeRunner.cs
@@ -56,7 +56,7 @@ public static class GlobeRunner
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithPresentation(adapter)
-            .WithHex1bApp((app, options) => ctx =>
+            .WithHex1bApp(ctx =>
                 ctx.ZStack(z => [
                     z.Interactable((Func<InteractableContext, Hex1bWidget>)(ic =>
                         ic.Surface(s =>

--- a/samples/BuildLogoDemo/Program.cs
+++ b/samples/BuildLogoDemo/Program.cs
@@ -2,7 +2,7 @@ using Hex1b;
 using Hex1b.Layout;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         return ctx.Center(c =>
             c.Surface(s => BuildLogoDemo.BuildLogo.BuildLayers(s))

--- a/samples/CalendarDemo/Program.cs
+++ b/samples/CalendarDemo/Program.cs
@@ -9,7 +9,7 @@ var pickerDate = "None";
 
 await using var terminal = Hex1b.Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         return ctx.VStack(v =>
         {

--- a/samples/ChartingDemo/Program.cs
+++ b/samples/ChartingDemo/Program.cs
@@ -135,7 +135,7 @@ var regionData = new[]
 
 var terminal = Hex1bTerminal.CreateBuilder()
     .WithDiagnostics()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
         ctx.TabPanel(tp => [
             tp.Tab("Simple Columns", t => [
                 t.ColumnChart(monthlySales)

--- a/samples/CompositionDemo/Program.cs
+++ b/samples/CompositionDemo/Program.cs
@@ -24,7 +24,9 @@ using Hex1b.Widgets;
 Hex1bApp? app = null;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((a, options) =>
+    .WithHex1bApp(
+        _ => { },
+        a =>
     {
         app = a;
         return ctx => ctx.AppShell(InvalidateApp, RequestStopApp);

--- a/samples/DockerDemo/Program.cs
+++ b/samples/DockerDemo/Program.cs
@@ -271,7 +271,9 @@ CellPatternSearcher BuildMarkerSearcher(string marker)
 // Build the TUI app
 await using var app = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((appRef, options) =>
+    .WithHex1bApp(
+        _ => { },
+        appRef =>
     {
         displayApp = appRef;
 

--- a/samples/DragBarPanelDemo/Program.cs
+++ b/samples/DragBarPanelDemo/Program.cs
@@ -2,7 +2,7 @@ using Hex1b;
 using Hex1b.Widgets;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
         ctx.VStack(outer => [
             outer.Text(" DragBarPanel Demo").FixedHeight(1),
             outer.Text("─────────────────────────────────────────────────").FixedHeight(1),

--- a/samples/DrawerDemo/Program.cs
+++ b/samples/DrawerDemo/Program.cs
@@ -26,7 +26,7 @@ _ = Task.Run(async () =>
 });
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     // Wrap in ZStack for popup support (required for overlay mode)
     ctx.ZStack(z => [
         z.VStack(outer => [

--- a/samples/EmbeddedTerminalDemo/Program.cs
+++ b/samples/EmbeddedTerminalDemo/Program.cs
@@ -452,7 +452,9 @@ Hex1bWidget BuildTerminalWidget(RootContext ctx)
 // Create the TUI app that displays terminals
 await using var displayTerminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((app, options) =>
+    .WithHex1bApp(
+        _ => { },
+        app =>
     {
         displayApp = app;
         return ctx => BuildTerminalWidget(ctx);

--- a/samples/EncryptedMuxerDemo/SessionManagerApp.cs
+++ b/samples/EncryptedMuxerDemo/SessionManagerApp.cs
@@ -23,7 +23,9 @@ internal sealed class SessionManagerApp
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithMouse()
-            .WithHex1bApp((app, _) =>
+            .WithHex1bApp(
+                _ => { },
+                app =>
             {
                 _app = app;
                 return ctx =>

--- a/samples/FigletTextDemo/Program.cs
+++ b/samples/FigletTextDemo/Program.cs
@@ -33,7 +33,7 @@ var effectIdx = 0;
 var clock = Stopwatch.StartNew();
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         var font = FigletFont.LoadBundled(fontNames[selectedFontIdx]);
         var preview = ctx.FigletText(sampleText)

--- a/samples/FloatPanelDemo/Program.cs
+++ b/samples/FloatPanelDemo/Program.cs
@@ -9,7 +9,9 @@ var state = new BouncingState();
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((app, options) =>
+    .WithHex1bApp(
+        _ => { },
+        app =>
     {
         state.App = app;
         state.Start();

--- a/samples/FlowChartDemo/Program.cs
+++ b/samples/FlowChartDemo/Program.cs
@@ -22,7 +22,7 @@ var nodes = new List<FlowNode>
 string? lastAction = null;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         return ctx.VStack(v => [
             // Header

--- a/samples/FormDemo/Program.cs
+++ b/samples/FormDemo/Program.cs
@@ -76,7 +76,7 @@ void TriggerGeocode()
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithDiagnostics("FormDemo")
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         var labelPlacement = labelPlacementIndex == 0
             ? LabelPlacement.Above

--- a/samples/FullAppDemo/Program.cs
+++ b/samples/FullAppDemo/Program.cs
@@ -59,7 +59,7 @@ var autoSaveIndex = 0;
 var statusMessage = "Ready";
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     ctx.ZStack(z => [
         z.VStack(outer => [
             // ─────────────────────────────────────────────────────────────────

--- a/samples/GlobeDemo/Program.cs
+++ b/samples/GlobeDemo/Program.cs
@@ -97,7 +97,7 @@ var pois = new List<PointOfInterest>
 };
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
         ctx.ZStack(z => [
             // Layer 1: Globe surface with interaction (bottom)
             z.Interactable(ic =>

--- a/samples/GridDemo/Program.cs
+++ b/samples/GridDemo/Program.cs
@@ -1,7 +1,7 @@
 using Hex1b;
 
 await using var terminal = Hex1b.Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         return ctx.Grid(g =>
         {

--- a/samples/InfoBarDemo/Program.cs
+++ b/samples/InfoBarDemo/Program.cs
@@ -25,7 +25,7 @@ var patterns = new[]
 var selectedPattern = 0;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         return ctx.VStack(v => [
             // Header

--- a/samples/InteractableDemo/Program.cs
+++ b/samples/InteractableDemo/Program.cs
@@ -22,7 +22,7 @@ string? selectedResource = null;
 string? lastAction = null;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         return ctx.VStack(v => [
             // Header

--- a/samples/KanbanDemo/Program.cs
+++ b/samples/KanbanDemo/Program.cs
@@ -31,7 +31,7 @@ var showDragSource = true;
 var rainbowTimer = System.Diagnostics.Stopwatch.StartNew();
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         return ctx.VStack(v => [
             // Header

--- a/samples/KeyBindingTester/Program.cs
+++ b/samples/KeyBindingTester/Program.cs
@@ -232,7 +232,7 @@ void RegisterTestBindings(InputBindingsBuilder b)
 try
 {
     await using var terminal = Hex1bTerminal.CreateBuilder()
-        .WithHex1bApp((app, options) => ctx =>
+        .WithHex1bApp(ctx =>
         {
             bool isDone = currentIndex >= bindings.Count;
             int totalPass = status.Count(s => s == PASS);

--- a/samples/KgpDemo/Program.cs
+++ b/samples/KgpDemo/Program.cs
@@ -39,15 +39,16 @@ var statusMessage = "Use File menu to open windows";
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithDiagnostics("KgpDemo", forceEnable: true)
     .WithMouse()
-    .WithHex1bApp((app, options) =>
-    {
-        options.OnRescue = args =>
+    .WithHex1bApp(
+        options =>
         {
-            File.AppendAllText("/tmp/kgp-demo-errors.log",
-                $"[{DateTime.Now:HH:mm:ss.fff}] RESCUE: phase={args.Phase} error={args.Exception}\n");
-        };
-
-        return ctx =>
+            options.OnRescue = args =>
+            {
+                File.AppendAllText("/tmp/kgp-demo-errors.log",
+                    $"[{DateTime.Now:HH:mm:ss.fff}] RESCUE: phase={args.Phase} error={args.Exception}\n");
+            };
+        },
+        ctx =>
         {
         return ctx.VStack(outer =>
         [
@@ -99,7 +100,6 @@ await using var terminal = Hex1bTerminal.CreateBuilder()
                 "Ctrl+C", "Exit"
             ])
         ]);
-        };
     })
     .Build();
 

--- a/samples/LanguageServerDemo/Program.cs
+++ b/samples/LanguageServerDemo/Program.cs
@@ -808,7 +808,9 @@ _ = Task.Run(async () =>
 // ── Build the terminal UI ────────────────────────────────────────────────────
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((app, options) =>
+    .WithHex1bApp(
+        _ => { },
+        app =>
     {
         displayApp = app;
         return ctx =>

--- a/samples/LoggerPanelDemo/Program.cs
+++ b/samples/LoggerPanelDemo/Program.cs
@@ -37,12 +37,15 @@ _ = Task.Run(async () =>
 
 // Run the TUI alongside the host
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) =>
+    .WithHex1bApp(
+        options =>
+        {
+            options.Theme = new Hex1bTheme("LoggerPanelDemo")
+                .Set(DrawerTheme.BackgroundColor, Hex1bColor.Black)
+                .Set(TableTheme.BackgroundColor, Hex1bColor.Black);
+        },
+        app =>
     {
-        options.Theme = new Hex1bTheme("LoggerPanelDemo")
-            .Set(DrawerTheme.BackgroundColor, Hex1bColor.Black)
-            .Set(TableTheme.BackgroundColor, Hex1bColor.Black);
-        
         return ctx =>
     {
         return ctx.VStack(outer => [

--- a/samples/LogicBuilderDemo/Program.cs
+++ b/samples/LogicBuilderDemo/Program.cs
@@ -4,7 +4,9 @@ using LogicBuilderDemo.Models;
 var state = new AppState();
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) =>
+    .WithHex1bApp(
+        _ => { },
+        app =>
     {
         state.App = app;
         return ctx => LogicBuilderApp.Build(ctx, state);

--- a/samples/MarkdownSample/Program.cs
+++ b/samples/MarkdownSample/Program.cs
@@ -21,7 +21,7 @@ var sampleMarkdown = """
 
     ```csharp
     var app = Hex1bTerminal.CreateBuilder()
-        .WithHex1bApp((app, options) => ctx =>
+        .WithHex1bApp(ctx =>
             ctx.Markdown("# Hello World"))
         .Build();
     await app.RunAsync();
@@ -127,29 +127,25 @@ static MarkdownImageData CreateGradientImage(int width, int height)
 }
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) =>
-    {
-        Func<RootContext, Hex1bWidget> builder = ctx =>
-            ctx.HSplitter(
-                // Left pane: Editor
-                ctx.Editor(editorState).LineNumbers(),
-                // Right pane: Markdown preview in scroll panel with focusable links
-                ctx.VScrollPanel(
-                    ctx.Markdown(document)
-                        .Focusable(children: true)
-                        .OnImageLoad((uri, alt) =>
-                            Task.FromResult<MarkdownImageData?>(CreateGradientImage(120, 60)))
-                        .OnLinkActivated(args =>
-                        {
-                            // Log link activation to the status bar
-                            // For external links, the default handler opens the browser
-                            // Set args.Handled = true to suppress default behavior
-                        })
-                ),
-                leftWidth: 45
-            );
-        return builder;
-    })
+    .WithHex1bApp(ctx =>
+        ctx.HSplitter(
+            // Left pane: Editor
+            ctx.Editor(editorState).LineNumbers(),
+            // Right pane: Markdown preview in scroll panel with focusable links
+            ctx.VScrollPanel(
+                ctx.Markdown(document)
+                    .Focusable(children: true)
+                    .OnImageLoad((uri, alt) =>
+                        Task.FromResult<MarkdownImageData?>(CreateGradientImage(120, 60)))
+                    .OnLinkActivated(args =>
+                    {
+                        // Log link activation to the status bar
+                        // For external links, the default handler opens the browser
+                        // Set args.Handled = true to suppress default behavior
+                    })
+            ),
+            leftWidth: 45
+        ))
     .WithMouse()
     .Build();
 

--- a/samples/MenuBarDemo/Program.cs
+++ b/samples/MenuBarDemo/Program.cs
@@ -17,7 +17,7 @@ var fontSizes = new[] { "Small", "Medium", "Large", "Extra Large" };
 var selectedFontSize = 1; // Medium
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     ctx.VStack(main => [
         // Menu bar at the top
         main.MenuBar(m => [

--- a/samples/ModelViewerDemo/Program.cs
+++ b/samples/ModelViewerDemo/Program.cs
@@ -51,7 +51,9 @@ void SwitchLod(int newLod)
 }
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(
+        _ => { },
+        app => ctx =>
         ctx.Interactable(ic =>
             ic.Surface(s =>
             {

--- a/samples/MouseTest/Program.cs
+++ b/samples/MouseTest/Program.cs
@@ -146,8 +146,7 @@ Hex1bWidget BuildScenarioPanel(WidgetContext<VStackWidget> v)
 try
 {
     await using var terminal = Hex1bTerminal.CreateBuilder()
-        .WithHex1bApp((app, options) =>
-            ctx => ctx.VStack(root => [
+        .WithHex1bApp(ctx => ctx.VStack(root => [
             // Main content wrapped in a border
             root.Border(
                 // Splitter with scenario list on left, controls on right

--- a/samples/MuxerDemo/SessionManagerApp.cs
+++ b/samples/MuxerDemo/SessionManagerApp.cs
@@ -22,7 +22,9 @@ internal sealed class SessionManagerApp
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithMouse()
-            .WithHex1bApp((app, _) =>
+            .WithHex1bApp(
+                _ => { },
+                app =>
             {
                 _app = app;
                 return ctx =>

--- a/samples/Osc8Test/Program.cs
+++ b/samples/Osc8Test/Program.cs
@@ -15,7 +15,7 @@ var lastClickedUri = "(none)";
 try
 {
     await using var terminal = Hex1bTerminal.CreateBuilder()
-        .WithHex1bApp((app, options) => ctx => ctx.VStack(root => [
+        .WithHex1bApp(ctx => ctx.VStack(root => [
             root.Border(
                 root.VStack(content => [
                     content.Text("OSC 8 Hyperlink Widget Demo"),

--- a/samples/PasteDemo/Program.cs
+++ b/samples/PasteDemo/Program.cs
@@ -25,7 +25,9 @@ static string FormatCount(long n) => n switch
 };
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(
+        _ => { },
+        app => ctx =>
     {
         var elapsed = stopwatch.IsRunning ? stopwatch.Elapsed : TimeSpan.Zero;
         var spinner = spinnerFrames[(int)(elapsed.TotalMilliseconds / 80) % spinnerFrames.Length];

--- a/samples/PerfDemo/BusyScene.cs
+++ b/samples/PerfDemo/BusyScene.cs
@@ -1,0 +1,108 @@
+using Hex1b;
+using Hex1b.Layout;
+using Hex1b.Widgets;
+
+namespace PerfDemo;
+
+/// <summary>
+/// Builds a representative "busy" widget tree for performance profiling.
+///
+/// Layout:
+///   ┌── HSplitter ───────────────────────────────────────────────┐
+///   │  Left column (sidebar)         │  Main pane                │
+///   │  Border + VStack of N entries  │  VSplitter:               │
+///   │  - one row mutates per frame   │   Top: dashboard grid     │
+///   │                                 │   Bot: scrolling log     │
+///   └─────────────────────────────────────────────────────────────┘
+///
+/// Cell-level changes per frame are bounded but spread across multiple
+/// non-cached subtrees so the surface diff, token emission, and ANSI
+/// serialize phases all do real work.
+/// </summary>
+internal static class BusyScene
+{
+    public static Hex1bWidget Build(int frame, int sidebarItems, int logLines, int gridRows, int gridCols)
+    {
+        var sidebar = BuildSidebar(frame, sidebarItems);
+        var dashboard = BuildDashboard(frame, gridRows, gridCols);
+        var log = BuildLog(frame, logLines);
+
+        var mainPane = new BorderWidget(
+            new SplitterWidget(
+                first: new BorderWidget(dashboard).Title("Dashboard"),
+                second: new BorderWidget(log).Title("Log"),
+                firstSize: Math.Max(6, gridRows + 2),
+                orientation: SplitterOrientation.Vertical));
+
+        var root = new SplitterWidget(
+            first: new BorderWidget(sidebar).Title("Navigation"),
+            second: mainPane,
+            firstSize: 28,
+            orientation: SplitterOrientation.Horizontal);
+
+        var header = new TextBlockWidget($"Hex1b PerfDemo — busy frame {frame:N0}");
+
+        return new VStackWidget(new Hex1bWidget[]
+        {
+            header,
+            root,
+        });
+    }
+
+    private static Hex1bWidget BuildSidebar(int frame, int items)
+    {
+        var children = new Hex1bWidget[items];
+        var selected = frame % items;
+        for (var i = 0; i < items; i++)
+        {
+            // Only the "selected" row visibly changes per frame; the rest are static.
+            var marker = i == selected ? "▶" : " ";
+            children[i] = new TextBlockWidget($"{marker} item-{i:000}  ");
+        }
+        return new VStackWidget(children);
+    }
+
+    private static Hex1bWidget BuildDashboard(int frame, int rows, int cols)
+    {
+        var rowWidgets = new Hex1bWidget[rows];
+        for (var r = 0; r < rows; r++)
+        {
+            var cells = new Hex1bWidget[cols];
+            for (var c = 0; c < cols; c++)
+            {
+                // Phase shift per cell so we exercise scattered diffs, not a single
+                // contiguous run.
+                var v = (frame + (r * 17) + (c * 29)) % 100;
+                cells[c] = new TextBlockWidget($" {v,3} ");
+            }
+            rowWidgets[r] = new HStackWidget(cells);
+        }
+
+        // A progress bar that advances every frame to add another small diff target.
+        var progress = new ProgressWidget
+        {
+            Value = (frame % 100),
+            Minimum = 0,
+            Maximum = 100
+        };
+
+        return new VStackWidget(new Hex1bWidget[]
+        {
+            progress,
+            new VStackWidget(rowWidgets)
+        });
+    }
+
+    private static Hex1bWidget BuildLog(int frame, int lines)
+    {
+        // Scrolling log: every line moves up by one each frame, so every visible
+        // row changes. This is the most expensive subtree.
+        var children = new Hex1bWidget[lines];
+        for (var i = 0; i < lines; i++)
+        {
+            var n = frame - lines + i + 1;
+            children[i] = new TextBlockWidget($"{n:0000000}  evt={(n * 1103515245 + 12345) & 0xFFFF:X4}  msg=line content {i}");
+        }
+        return new VStackWidget(children);
+    }
+}

--- a/samples/PerfDemo/MetricsCollector.cs
+++ b/samples/PerfDemo/MetricsCollector.cs
@@ -1,0 +1,158 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+
+namespace PerfDemo;
+
+/// <summary>
+/// In-process MeterListener that subscribes to the "Hex1b" meter and aggregates
+/// every histogram into mean / p50 / p95 / p99 / max + counters into totals.
+///
+/// This converts the rich System.Diagnostics.Metrics instrumentation in
+/// <c>Hex1b.Diagnostics.Hex1bMetrics</c> into a one-shot, human-readable report
+/// without needing OTLP or any external collector.
+/// </summary>
+internal sealed class MetricsCollector : IDisposable
+{
+    private readonly MeterListener _listener;
+    private readonly ConcurrentDictionary<string, HistogramSink> _histograms = new();
+    private readonly ConcurrentDictionary<string, long> _counters = new();
+    private bool _capturing;
+
+    public MetricsCollector(string meterName = "Hex1b")
+    {
+        _listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == meterName)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+
+        _listener.SetMeasurementEventCallback<double>((inst, value, _, _) =>
+        {
+            if (!_capturing) return;
+            _histograms.GetOrAdd(inst.Name, _ => new HistogramSink(inst.Unit)).Add(value);
+        });
+        _listener.SetMeasurementEventCallback<int>((inst, value, _, _) =>
+        {
+            if (!_capturing) return;
+            _histograms.GetOrAdd(inst.Name, _ => new HistogramSink(inst.Unit)).Add(value);
+        });
+        _listener.SetMeasurementEventCallback<long>((inst, value, _, _) =>
+        {
+            if (!_capturing) return;
+            if (inst is Counter<long>)
+            {
+                _counters.AddOrUpdate(inst.Name, value, (_, acc) => acc + value);
+            }
+            else
+            {
+                _histograms.GetOrAdd(inst.Name, _ => new HistogramSink(inst.Unit)).Add(value);
+            }
+        });
+
+        _listener.Start();
+    }
+
+    /// <summary>Begin recording. Call after warmup to exclude first-frame noise.</summary>
+    public void StartCapture() => _capturing = true;
+
+    /// <summary>Stop recording.</summary>
+    public void StopCapture() => _capturing = false;
+
+    public void Dispose() => _listener.Dispose();
+
+    public void PrintSummary(TextWriter writer)
+    {
+        writer.WriteLine();
+        writer.WriteLine("== Hex1b metrics ==");
+
+        if (_counters.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine("Counters:");
+            foreach (var (name, value) in _counters.OrderBy(p => p.Key))
+            {
+                writer.WriteLine($"  {name,-44} {value,12:N0}");
+            }
+        }
+
+        if (_histograms.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine("Histograms (count, mean, p50, p95, p99, max, unit):");
+            writer.WriteLine($"  {"name",-44} {"count",8} {"mean",10} {"p50",10} {"p95",10} {"p99",10} {"max",10} unit");
+
+            foreach (var (name, sink) in _histograms.OrderBy(p => p.Key))
+            {
+                var s = sink.Snapshot();
+                writer.WriteLine(
+                    $"  {name,-44} {s.Count,8:N0} {s.Mean,10:N3} {s.P50,10:N3} {s.P95,10:N3} {s.P99,10:N3} {s.Max,10:N3} {sink.Unit ?? ""}");
+            }
+        }
+    }
+
+    private sealed class HistogramSink
+    {
+        private readonly object _gate = new();
+        private double[] _values = new double[1024];
+        private int _count;
+
+        public HistogramSink(string? unit) { Unit = unit; }
+        public string? Unit { get; }
+
+        public void Add(double value)
+        {
+            lock (_gate)
+            {
+                if (_count == _values.Length)
+                {
+                    Array.Resize(ref _values, _values.Length * 2);
+                }
+                _values[_count++] = value;
+            }
+        }
+
+        public Stats Snapshot()
+        {
+            double[] copy;
+            int count;
+            lock (_gate)
+            {
+                count = _count;
+                copy = new double[count];
+                Array.Copy(_values, copy, count);
+            }
+            if (count == 0)
+            {
+                return new Stats(0, 0, 0, 0, 0, 0);
+            }
+            Array.Sort(copy);
+            double sum = 0;
+            for (var i = 0; i < count; i++) sum += copy[i];
+            return new Stats(
+                Count: count,
+                Mean: sum / count,
+                P50: Percentile(copy, 0.50),
+                P95: Percentile(copy, 0.95),
+                P99: Percentile(copy, 0.99),
+                Max: copy[count - 1]);
+        }
+
+        private static double Percentile(double[] sorted, double p)
+        {
+            if (sorted.Length == 0) return 0;
+            var rank = p * (sorted.Length - 1);
+            var lo = (int)Math.Floor(rank);
+            var hi = (int)Math.Ceiling(rank);
+            if (lo == hi) return sorted[lo];
+            var frac = rank - lo;
+            return sorted[lo] * (1 - frac) + sorted[hi] * frac;
+        }
+    }
+
+    private readonly record struct Stats(int Count, double Mean, double P50, double P95, double P99, double Max);
+}

--- a/samples/PerfDemo/Program.cs
+++ b/samples/PerfDemo/Program.cs
@@ -232,7 +232,9 @@ internal sealed record PerfOptions(
 
         var compare = HasFlag(args, "--compare");
         var enableCaching = HasFlag(args, "--cache");
-        var enablePooling = HasFlag(args, "--pool");
+        // Surface pooling is now ON by default in Hex1bAppOptions. Mirror that
+        // here, with --no-pool as the explicit opt-out for A/B measurements.
+        var enablePooling = !HasFlag(args, "--no-pool");
         var busy = HasFlag(args, "--busy");
         var perNode = HasFlag(args, "--per-node");
         var noSummary = HasFlag(args, "--no-summary");

--- a/samples/PerfDemo/Program.cs
+++ b/samples/PerfDemo/Program.cs
@@ -1,9 +1,11 @@
 using System.Diagnostics;
 using System.Threading.Channels;
 using Hex1b;
+using Hex1b.Diagnostics;
 using Hex1b.Input;
 using Hex1b.Theming;
 using Hex1b.Widgets;
+using PerfDemo;
 
 var options = PerfOptions.Parse(args);
 
@@ -30,7 +32,7 @@ static async Task<PerfResult> RunOnceAsync(bool enableCaching, PerfOptions optio
         .Set(GlobalTheme.BackgroundColor, Hex1bColor.DarkGray)
         .Lock();
 
-    var staticPanel = BuildStaticPanel(options.StaticLines);
+    var staticPanel = options.Busy ? null : BuildStaticPanel(options.StaticLines);
 
     var warmupFrames = options.WarmupFrames;
     var measureFrames = options.MeasureFrames;
@@ -52,6 +54,12 @@ static async Task<PerfResult> RunOnceAsync(bool enableCaching, PerfOptions optio
 
     using var adapter = new PerfWorkloadAdapter(options.Width, options.Height, TerminalCapabilities.Minimal);
 
+    using var metrics = new Hex1bMetrics(new Hex1bMetricsOptions
+    {
+        EnablePerNodeMetrics = options.EnablePerNodeMetrics
+    });
+    using var collector = new MetricsCollector();
+
     Hex1bApp? app = null;
     app = new Hex1bApp(ctx =>
     {
@@ -68,6 +76,7 @@ static async Task<PerfResult> RunOnceAsync(bool enableCaching, PerfOptions optio
             startGen1 = GC.CollectionCount(1);
             startGen2 = GC.CollectionCount(2);
             startTimestamp = Stopwatch.GetTimestamp();
+            collector.StartCapture();
         }
 
         if (frame == stopFrame)
@@ -77,21 +86,30 @@ static async Task<PerfResult> RunOnceAsync(bool enableCaching, PerfOptions optio
             endGen0 = GC.CollectionCount(0);
             endGen1 = GC.CollectionCount(1);
             endGen2 = GC.CollectionCount(2);
+            collector.StopCapture();
             app!.RequestStop();
             return new TextBlockWidget("Stopping...");
         }
 
-        var root = new VStackWidget(new Hex1bWidget[]
-        {
-            new TextBlockWidget($"Tick: {frame}"),
-            staticPanel
-        });
+        Hex1bWidget root = options.Busy
+            ? BusyScene.Build(
+                frame,
+                sidebarItems: options.BusySidebarItems,
+                logLines: options.BusyLogLines,
+                gridRows: options.BusyGridRows,
+                gridCols: options.BusyGridCols)
+            : new VStackWidget(new Hex1bWidget[]
+            {
+                new TextBlockWidget($"Tick: {frame}"),
+                staticPanel!
+            });
         renderedFrames++;
         return root;
     }, new Hex1bAppOptions
     {
         WorkloadAdapter = adapter,
         Theme = theme,
+        Metrics = metrics,
         EnableRenderCaching = enableCaching,
         EnableSurfacePooling = options.EnableSurfacePooling,
         EnableDefaultCtrlCExit = false,
@@ -116,7 +134,7 @@ static async Task<PerfResult> RunOnceAsync(bool enableCaching, PerfOptions optio
         : Stopwatch.GetElapsedTime(startTimestamp, endTimestamp);
     var allocatedBytes = endAllocated - startAllocated;
 
-    return new PerfResult
+    var result = new PerfResult
     {
         EnableCaching = enableCaching,
         EnableSurfacePooling = options.EnableSurfacePooling,
@@ -133,6 +151,13 @@ static async Task<PerfResult> RunOnceAsync(bool enableCaching, PerfOptions optio
         Gen1 = endGen1 - startGen1,
         Gen2 = endGen2 - startGen2
     };
+
+    if (options.PrintMetricsSummary)
+    {
+        collector.PrintSummary(Console.Out);
+    }
+
+    return result;
 }
 
 static Hex1bWidget BuildStaticPanel(int lines)
@@ -184,7 +209,14 @@ internal sealed record PerfOptions(
     int Height,
     int StaticLines,
     int WarmupFrames,
-    int MeasureFrames)
+    int MeasureFrames,
+    bool Busy,
+    int BusySidebarItems,
+    int BusyLogLines,
+    int BusyGridRows,
+    int BusyGridCols,
+    bool EnablePerNodeMetrics,
+    bool PrintMetricsSummary)
 {
     public static PerfOptions Parse(string[] args)
     {
@@ -201,12 +233,22 @@ internal sealed record PerfOptions(
         var compare = HasFlag(args, "--compare");
         var enableCaching = HasFlag(args, "--cache");
         var enablePooling = HasFlag(args, "--pool");
+        var busy = HasFlag(args, "--busy");
+        var perNode = HasFlag(args, "--per-node");
+        var noSummary = HasFlag(args, "--no-summary");
 
-        var width = ReadInt(args, "--width", 120);
-        var height = ReadInt(args, "--height", 40);
+        // The busy scene fills a larger frame by default so the render pipeline
+        // has meaningful work to do (more cells = more diff/encode work).
+        var width = ReadInt(args, "--width", busy ? 160 : 120);
+        var height = ReadInt(args, "--height", busy ? 50 : 40);
         var staticLines = ReadInt(args, "--lines", 200);
-        var warmup = ReadInt(args, "--warmup", 25);
-        var frames = ReadInt(args, "--frames", 200);
+        var warmup = ReadInt(args, "--warmup", 50);
+        var frames = ReadInt(args, "--frames", busy ? 500 : 200);
+
+        var sidebarItems = ReadInt(args, "--busy-sidebar", 20);
+        var logLines = ReadInt(args, "--busy-log", 20);
+        var gridRows = ReadInt(args, "--busy-grid-rows", 8);
+        var gridCols = ReadInt(args, "--busy-grid-cols", 12);
 
         return new PerfOptions(
             EnableCaching: enableCaching,
@@ -216,7 +258,14 @@ internal sealed record PerfOptions(
             Height: height,
             StaticLines: staticLines,
             WarmupFrames: warmup,
-            MeasureFrames: frames);
+            MeasureFrames: frames,
+            Busy: busy,
+            BusySidebarItems: sidebarItems,
+            BusyLogLines: logLines,
+            BusyGridRows: gridRows,
+            BusyGridCols: gridCols,
+            EnablePerNodeMetrics: perNode,
+            PrintMetricsSummary: !noSummary);
     }
 }
 

--- a/samples/PerfStressDemo/IStressPage.cs
+++ b/samples/PerfStressDemo/IStressPage.cs
@@ -16,12 +16,20 @@ internal interface IStressPage
     string Description { get; }
 
     /// <summary>
-    /// Build the page's widget tree. Called every frame. The implementation
-    /// should call <c>RedrawAfter</c> (or otherwise schedule continuous
-    /// invalidation) on any animated subtree so the frame rate is driven by
-    /// the page rather than by external input.
+    /// Build the page's widget tree. Called every frame <b>only while this
+    /// page is the active one</b>. Inactive pages never have <c>Build</c>
+    /// invoked, so their simulations are naturally paused.
     /// </summary>
     Hex1bWidget Build(StressContext ctx);
+
+    /// <summary>
+    /// True when this page has fully settled and has nothing to animate.
+    /// The root checks this <i>after</i> calling <see cref="Build"/> to
+    /// decide whether to schedule another redraw — when the active page is
+    /// idle, the framework sleeps until a real input event (mouse move,
+    /// key press) arrives, dropping CPU to ~zero.
+    /// </summary>
+    bool IsIdle => false;
 }
 
 /// <summary>

--- a/samples/PerfStressDemo/IStressPage.cs
+++ b/samples/PerfStressDemo/IStressPage.cs
@@ -1,0 +1,34 @@
+using Hex1b;
+using Hex1b.Widgets;
+
+namespace PerfStressDemo;
+
+/// <summary>
+/// A single stress-test "page" in the demo. Each page returns a full-screen
+/// widget tree designed to exercise some specific part of the render pipeline.
+/// </summary>
+internal interface IStressPage
+{
+    /// <summary>Short name shown in the status bar.</summary>
+    string Name { get; }
+
+    /// <summary>One-line description of what this page is stressing.</summary>
+    string Description { get; }
+
+    /// <summary>
+    /// Build the page's widget tree. Called every frame. The implementation
+    /// should call <c>RedrawAfter</c> (or otherwise schedule continuous
+    /// invalidation) on any animated subtree so the frame rate is driven by
+    /// the page rather than by external input.
+    /// </summary>
+    Hex1bWidget Build(StressContext ctx);
+}
+
+/// <summary>
+/// Ambient information passed to <see cref="IStressPage.Build"/> on every
+/// frame. Kept tiny — pages should pull their own state from their own fields.
+/// </summary>
+internal readonly record struct StressContext(
+    RootContext Root,
+    double ElapsedSeconds,
+    int RedrawIntervalMs);

--- a/samples/PerfStressDemo/PerfStressDemo.csproj
+++ b/samples/PerfStressDemo/PerfStressDemo.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <PublishAot>true</PublishAot>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Hex1b/Hex1b.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/PerfStressDemo/PondRipplePage.cs
+++ b/samples/PerfStressDemo/PondRipplePage.cs
@@ -299,10 +299,15 @@ internal sealed class PondRipplePage : IStressPage
                 var neighbours = cur[i - 1] + cur[i + 1] + cur[i - w] + cur[i + w];
                 var next = (neighbours * 0.5f) - prv[i];
                 next *= damping;
-                // Floor extremely small values to 0 so settled pond doesn't
-                // keep emitting micro-differences forever (lets the renderer
-                // fast-path engage).
-                if (next > -0.001f && next < 0.001f) next = 0f;
+                // Floor small values to 0. The scheme is at CFL=1 (the 2D
+                // stability boundary) so the Nyquist mode is non-dissipative
+                // and only the damping multiplier decays it — without a
+                // generous floor, tiny residual oscillations can sit just
+                // above the cutoff for thousands of steps, and the hard
+                // boundary between floored and not-quite-floored cells
+                // re-injects energy. 0.01 is well below visible brightness
+                // (level 40.4 vs 40 at MaxDisplay=6) so killing it is free.
+                if (next > -0.01f && next < 0.01f) next = 0f;
                 prv[i] = next;
             }
         }
@@ -313,12 +318,13 @@ internal sealed class PondRipplePage : IStressPage
 
     private void DrawPond(Surface surface)
     {
-        if (_current is null || _noise is null) return;
+        if (_current is null || _previous is null || _noise is null) return;
 
         var w = surface.Width;
         var h = surface.Height;
         var black = Hex1bColor.Black;
         var field = _current;
+        var prev = _previous;
 
         // Map signed displacement to brightness with a linear ramp clamped
         // at ±maxDisplay. Peaks brighten, troughs ALSO brighten (we display
@@ -326,6 +332,13 @@ internal sealed class PondRipplePage : IStressPage
         // distinguishes constructive vs destructive interference is the
         // *amplitude* of the resulting peak/trough — keep it linear here so
         // those amplitude differences are visible instead of saturating.
+        //
+        // We display max(|cur|, |prv|) per cell rather than just |cur|.
+        // For a propagating sinusoid the instantaneous magnitude swings
+        // through zero at every half-period, which would show up as a
+        // strobing pattern at the cell level even when the wave itself is
+        // smooth. The envelope across two adjacent timesteps captures the
+        // local amplitude and reads as a steady band of brightness.
         const float MaxDisplay = 6.0f;
         for (var y = 0; y < h; y++)
         {
@@ -333,8 +346,11 @@ internal sealed class PondRipplePage : IStressPage
             for (var x = 0; x < w; x++)
             {
                 var i = row + x;
-                var d = field[i];
-                var mag = d < 0 ? -d : d;
+                var c = field[i];
+                var p = prev[i];
+                var mc = c < 0 ? -c : c;
+                var mp = p < 0 ? -p : p;
+                var mag = mc > mp ? mc : mp;
                 var t = mag / MaxDisplay;
                 if (t > 1.0f) t = 1.0f;
                 var level = (byte)(40 + (215 * t));

--- a/samples/PerfStressDemo/PondRipplePage.cs
+++ b/samples/PerfStressDemo/PondRipplePage.cs
@@ -73,9 +73,11 @@ internal sealed class PondRipplePage : IStressPage
     private const float Damping = 0.985f;
 
     // Splash impulse amplitude. Negative = displaces water downward (the
-    // "finger pushes the surface down" mental model). Magnitude is in the
-    // same units as the field; the colour mapper rescales to brightness.
-    private const float SplashAmplitude = -8.0f;
+    // "finger pushes the surface down" mental model). Tuned so per-move
+    // impulses stay in the linear part of the brightness mapping; that
+    // way constructive interference reads as a brighter peak and
+    // destructive interference reads as a darker trough.
+    private const float SplashAmplitude = -3.0f;
 
     public Hex1bWidget Build(StressContext sc)
     {
@@ -91,19 +93,26 @@ internal sealed class PondRipplePage : IStressPage
                 // "dragging a finger" feel without needing a click.
                 var mx = layer.MouseX;
                 var my = layer.MouseY;
-                if (mx >= 0 && my >= 0 && mx < layer.Width && my < layer.Height)
+                var inPond = mx >= 0 && my >= 0 && mx < layer.Width && my < layer.Height;
+                var moved = inPond && (mx != _lastMouseX || my != _lastMouseY);
+
+                if (moved)
                 {
-                    // Splash on every "in-pond" frame so a steady hover
-                    // still injects a little energy; a moving cursor
-                    // injects across each cell of its path.
+                    // Splash along the Bresenham line from the last known
+                    // position so fast drags feel continuous instead of
+                    // dotty. If the last position was "absent" (-1),
+                    // SplashLine collapses to a single-point splash.
                     SplashLine(_lastMouseX, _lastMouseY, mx, my);
                     _lastMouseX = mx;
                     _lastMouseY = my;
                 }
                 else
                 {
-                    // Pointer left the pond — stop tracking but let the
-                    // existing waves continue to evolve.
+                    // No movement this frame — treat as if the mouse were
+                    // not present at all. Resetting last-known position
+                    // means the *next* movement starts a fresh trail
+                    // rather than drawing a stale line from wherever the
+                    // cursor was parked.
                     _lastMouseX = -1;
                     _lastMouseY = -1;
                 }
@@ -241,9 +250,13 @@ internal sealed class PondRipplePage : IStressPage
         var black = Hex1bColor.Black;
         var field = _current;
 
-        // Map field displacement (~ -10..+10) to brightness 0..1 via a
-        // soft compressor so big splashes don't clip immediately.
-        // mag/(mag+k) is a smooth tanh-like saturator in [0,1).
+        // Map signed displacement to brightness with a linear ramp clamped
+        // at ±maxDisplay. Peaks brighten, troughs ALSO brighten (we display
+        // |displacement|) so a wave reads as a band of brightness; what
+        // distinguishes constructive vs destructive interference is the
+        // *amplitude* of the resulting peak/trough — keep it linear here so
+        // those amplitude differences are visible instead of saturating.
+        const float MaxDisplay = 6.0f;
         for (var y = 0; y < h; y++)
         {
             var row = y * w;
@@ -252,7 +265,8 @@ internal sealed class PondRipplePage : IStressPage
                 var i = row + x;
                 var d = field[i];
                 var mag = d < 0 ? -d : d;
-                var t = mag / (mag + 4.0f);
+                var t = mag / MaxDisplay;
+                if (t > 1.0f) t = 1.0f;
                 var level = (byte)(40 + (215 * t));
                 var colour = Hex1bColor.FromRgb(level, level, level);
                 surface[x, y] = new SurfaceCell(_noise[i], colour, black);

--- a/samples/PerfStressDemo/PondRipplePage.cs
+++ b/samples/PerfStressDemo/PondRipplePage.cs
@@ -65,19 +65,73 @@ internal sealed class PondRipplePage : IStressPage
     private float[]? _previous;
     private int _fieldWidth;
     private int _fieldHeight;
-    private int _lastMouseX = -1;
-    private int _lastMouseY = -1;
+    // Last MouseX/Y values *observed* from the layer context, used purely
+    // to detect whether the mouse actually moved between frames. Distinct
+    // from the splash trail head below: the observed position persists
+    // across stationary frames, the trail head does not.
+    private int _observedMouseX = int.MinValue;
+    private int _observedMouseY = int.MinValue;
+    // Position of the last splash (head of the current drag trail), or -1
+    // when the trail is "broken" (mouse outside the pond, or stationary
+    // for a frame). Reset to -1 ends the trail so the next movement
+    // starts a fresh single-point splash instead of drawing a Bresenham
+    // line from a stale position.
+    private int _trailX = -1;
+    private int _trailY = -1;
 
-    // Damping per step. 1.0 = lossless (waves never settle), 0.99 ≈ a few
-    // seconds to settle, 0.95 = quick decay. Tuned for visual taste.
-    private const float Damping = 0.985f;
+    /// <summary>
+    /// One viscosity preset — combines damping, step rate, and splash
+    /// amplitude so each preset reads as a coherent fluid feel rather
+    /// than independent knobs.
+    /// </summary>
+    /// <param name="Name">Short label shown in the status bar.</param>
+    /// <param name="Damping">
+    /// Per-step amplitude multiplier. 1.0 = lossless; values below 1
+    /// dissipate energy over time. Lower = more viscous (waves die
+    /// faster).
+    /// </param>
+    /// <param name="StepEveryNFrames">
+    /// Run a physics step every Nth frame. Higher = slower wavefront
+    /// propagation (acts as time dilation on the fluid). 1 = fast water,
+    /// 3+ = slow glob.
+    /// </param>
+    /// <param name="SplashAmplitude">
+    /// Magnitude of the splash impulse, scaled to keep single moves
+    /// visible against the chosen damping.
+    /// </param>
+    internal readonly record struct ViscosityPreset(
+        string Name,
+        float Damping,
+        int StepEveryNFrames,
+        float SplashAmplitude);
 
-    // Splash impulse amplitude. Negative = displaces water downward (the
-    // "finger pushes the surface down" mental model). Tuned so per-move
-    // impulses stay in the linear part of the brightness mapping; that
-    // way constructive interference reads as a brighter peak and
-    // destructive interference reads as a darker trough.
-    private const float SplashAmplitude = -3.0f;
+    /// <summary>
+    /// Cyclable viscosity presets, ordered thin → thick. Press V to
+    /// advance through them.
+    /// </summary>
+    internal static readonly ViscosityPreset[] Presets = new[]
+    {
+        new ViscosityPreset("water",  0.995f, 1, -2.5f),
+        new ViscosityPreset("light",  0.98f,  1, -3.5f),
+        new ViscosityPreset("medium", 0.96f,  1, -4.5f),
+        new ViscosityPreset("thick",  0.94f,  2, -5.5f),
+        new ViscosityPreset("glob",   0.92f,  3, -6.5f),
+    };
+
+    /// <summary>
+    /// Index into <see cref="Presets"/> for the current fluid feel.
+    /// Mutated by the V key binding in Program.cs.
+    /// </summary>
+    public static int PresetIndex { get; set; } = 1; // "light" by default
+
+    /// <summary>Human-readable preset name for the status bar.</summary>
+    public static string PresetLabel => Presets[PresetIndex].Name;
+
+    /// <summary>Advances to the next preset (wrapping).</summary>
+    public static void CyclePreset()
+        => PresetIndex = (PresetIndex + 1) % Presets.Length;
+
+    private int _stepCounter;
 
     public Hex1bWidget Build(StressContext sc)
     {
@@ -94,30 +148,43 @@ internal sealed class PondRipplePage : IStressPage
                 var mx = layer.MouseX;
                 var my = layer.MouseY;
                 var inPond = mx >= 0 && my >= 0 && mx < layer.Width && my < layer.Height;
-                var moved = inPond && (mx != _lastMouseX || my != _lastMouseY);
+                // "Moved this frame" = the layer's mouse coords differ from
+                // what we observed last frame. layer.MouseX/Y holds the
+                // last reported value, so a stationary mouse reports the
+                // same coords frame after frame.
+                var movedThisFrame = inPond
+                    && (mx != _observedMouseX || my != _observedMouseY);
+                _observedMouseX = mx;
+                _observedMouseY = my;
 
-                if (moved)
+                if (movedThisFrame)
                 {
-                    // Splash along the Bresenham line from the last known
-                    // position so fast drags feel continuous instead of
-                    // dotty. If the last position was "absent" (-1),
-                    // SplashLine collapses to a single-point splash.
-                    SplashLine(_lastMouseX, _lastMouseY, mx, my);
-                    _lastMouseX = mx;
-                    _lastMouseY = my;
+                    // If the trail head is valid, draw a Bresenham splash
+                    // line from it to the new position (continuous drag).
+                    // If the trail was broken (pause or just entered the
+                    // pond), splash only at the new position so we don't
+                    // yank a wave across the screen.
+                    SplashLine(_trailX, _trailY, mx, my);
+                    _trailX = mx;
+                    _trailY = my;
                 }
                 else
                 {
-                    // No movement this frame — treat as if the mouse were
-                    // not present at all. Resetting last-known position
-                    // means the *next* movement starts a fresh trail
-                    // rather than drawing a stale line from wherever the
-                    // cursor was parked.
-                    _lastMouseX = -1;
-                    _lastMouseY = -1;
+                    // No movement this frame (or mouse not in pond): break
+                    // the trail so the next movement starts fresh.
+                    _trailX = -1;
+                    _trailY = -1;
                 }
 
-                Step();
+                // Sub-step: only advance the simulation every Nth frame so
+                // wavefronts propagate at a fraction of cell-per-frame
+                // speed. Combined with damping this gives the chosen
+                // viscosity preset its characteristic fluid feel.
+                if (++_stepCounter >= Presets[PresetIndex].StepEveryNFrames)
+                {
+                    _stepCounter = 0;
+                    Step();
+                }
 
                 return new[] { layer.Layer(DrawPond) };
             })
@@ -147,8 +214,10 @@ internal sealed class PondRipplePage : IStressPage
         _fieldHeight = h;
         _current = new float[w * h];
         _previous = new float[w * h];
-        _lastMouseX = -1;
-        _lastMouseY = -1;
+        _observedMouseX = int.MinValue;
+        _observedMouseY = int.MinValue;
+        _trailX = -1;
+        _trailY = -1;
     }
 
     /// <summary>
@@ -200,7 +269,7 @@ internal sealed class PondRipplePage : IStressPage
                 var x = cx + dx;
                 if ((uint)x >= (uint)w) continue;
                 var falloff = (dx == 0 && dy == 0) ? 1.0f : ((dx == 0 || dy == 0) ? 0.5f : 0.25f);
-                _current[y * w + x] += SplashAmplitude * falloff;
+                _current[y * w + x] += Presets[PresetIndex].SplashAmplitude * falloff;
             }
         }
     }
@@ -218,6 +287,7 @@ internal sealed class PondRipplePage : IStressPage
         var h = _fieldHeight;
         var cur = _current;
         var prv = _previous;
+        var damping = Presets[PresetIndex].Damping;
 
         // Update interior cells. Edge cells stay at 0 (solid boundary).
         for (var y = 1; y < h - 1; y++)
@@ -228,7 +298,7 @@ internal sealed class PondRipplePage : IStressPage
                 var i = row + x;
                 var neighbours = cur[i - 1] + cur[i + 1] + cur[i - w] + cur[i + w];
                 var next = (neighbours * 0.5f) - prv[i];
-                next *= Damping;
+                next *= damping;
                 // Floor extremely small values to 0 so settled pond doesn't
                 // keep emitting micro-differences forever (lets the renderer
                 // fast-path engage).

--- a/samples/PerfStressDemo/PondRipplePage.cs
+++ b/samples/PerfStressDemo/PondRipplePage.cs
@@ -1,0 +1,262 @@
+using Hex1b;
+using Hex1b.Surfaces;
+using Hex1b.Theming;
+using Hex1b.Widgets;
+
+namespace PerfStressDemo;
+
+/// <summary>
+/// Page 2 — "Pond ripple".
+///
+/// Same noise-character background as page 1, but instead of a fixed
+/// concentric ripple driven by elapsed time, the wave field is driven
+/// interactively by the mouse cursor. Move the mouse over the page and
+/// the cells underneath light up; the disturbance propagates outward as
+/// a real shallow-water wave (height-field with 2D wave-equation
+/// integration), bounces off the edges, interferes with itself, and
+/// dampens to stillness once you stop moving.
+///
+/// Render cost characteristics are similar to page 1's ripple — every
+/// cell typically changes some amount each frame while waves are alive,
+/// so the SurfaceComparer diff stays large. The key difference is that
+/// the wave field actually decays to zero, so you can see the
+/// renderer's "idle" path engage when the pond settles (the fast-path
+/// CellsEqual short-circuit kicks in and the per-frame byte count
+/// collapses).
+/// </summary>
+internal sealed class PondRipplePage : IStressPage
+{
+    public string Name => "Pond ripple (mouse)";
+
+    public string Description =>
+        "Move the mouse over the page — waves propagate from the cursor "
+        + "across the pond and dampen to stillness.";
+
+    // --- Noise background ----------------------------------------------------
+
+    private const int RangeStart = 0x21; // '!'
+    private const int RangeEnd = 0x7E;   // '~'
+    private const int RangeSize = RangeEnd - RangeStart + 1;
+
+    private static readonly string[] s_asciiChars = BuildAsciiChars();
+
+    private static string[] BuildAsciiChars()
+    {
+        var arr = new string[RangeSize];
+        for (var i = 0; i < RangeSize; i++)
+            arr[i] = ((char)(RangeStart + i)).ToString();
+        return arr;
+    }
+
+    // The character at each cell; stable across resizes for a given size.
+    private string[]? _noise;
+
+    // --- Wave physics --------------------------------------------------------
+    //
+    // Classic discretised 2D wave equation on a heightfield:
+    //     next[x,y] = (prev[x-1,y] + prev[x+1,y]
+    //                + prev[x,y-1] + prev[x,y+1]) / 2
+    //                - current[x,y];
+    //     next[x,y] *= damping;
+    // We ping-pong between two buffers (current ↔ previous) and treat
+    // out-of-bounds neighbours as 0 (Dirichlet) so the pond has solid edges.
+
+    private float[]? _current;
+    private float[]? _previous;
+    private int _fieldWidth;
+    private int _fieldHeight;
+    private int _lastMouseX = -1;
+    private int _lastMouseY = -1;
+
+    // Damping per step. 1.0 = lossless (waves never settle), 0.99 ≈ a few
+    // seconds to settle, 0.95 = quick decay. Tuned for visual taste.
+    private const float Damping = 0.985f;
+
+    // Splash impulse amplitude. Negative = displaces water downward (the
+    // "finger pushes the surface down" mental model). Magnitude is in the
+    // same units as the field; the colour mapper rescales to brightness.
+    private const float SplashAmplitude = -8.0f;
+
+    public Hex1bWidget Build(StressContext sc)
+    {
+        return sc.Root
+            .Surface(layer =>
+            {
+                EnsureFieldSize(layer.Width, layer.Height);
+                EnsureNoise(layer.Width, layer.Height);
+
+                // Mouse coords are relative to the surface widget; -1 when
+                // the pointer isn't over us. Treat any frame where the
+                // pointer is present as a splash impulse — this gives the
+                // "dragging a finger" feel without needing a click.
+                var mx = layer.MouseX;
+                var my = layer.MouseY;
+                if (mx >= 0 && my >= 0 && mx < layer.Width && my < layer.Height)
+                {
+                    // Splash on every "in-pond" frame so a steady hover
+                    // still injects a little energy; a moving cursor
+                    // injects across each cell of its path.
+                    SplashLine(_lastMouseX, _lastMouseY, mx, my);
+                    _lastMouseX = mx;
+                    _lastMouseY = my;
+                }
+                else
+                {
+                    // Pointer left the pond — stop tracking but let the
+                    // existing waves continue to evolve.
+                    _lastMouseX = -1;
+                    _lastMouseY = -1;
+                }
+
+                Step();
+
+                return new[] { layer.Layer(DrawPond) };
+            })
+            // Keep stepping the simulation every frame even with no input
+            // so waves dampen naturally to stillness.
+            .RedrawAfter(sc.RedrawIntervalMs);
+    }
+
+    private void EnsureNoise(int w, int h)
+    {
+        if (_noise is { } existing && existing.Length == w * h)
+            return;
+
+        var rng = new Random(0xC0FFEE);
+        var arr = new string[w * h];
+        for (var i = 0; i < arr.Length; i++)
+            arr[i] = s_asciiChars[rng.Next(RangeSize)];
+        _noise = arr;
+    }
+
+    private void EnsureFieldSize(int w, int h)
+    {
+        if (_current is not null && _fieldWidth == w && _fieldHeight == h)
+            return;
+
+        _fieldWidth = w;
+        _fieldHeight = h;
+        _current = new float[w * h];
+        _previous = new float[w * h];
+        _lastMouseX = -1;
+        _lastMouseY = -1;
+    }
+
+    /// <summary>
+    /// Adds a splash impulse along the segment from (x0,y0) to (x1,y1).
+    /// When the cursor moves several cells in a single frame, splashing
+    /// only at the endpoint gives a "skipping" feel — splashing along
+    /// the line gives the continuous "dragging a finger" feel.
+    /// </summary>
+    private void SplashLine(int x0, int y0, int x1, int y1)
+    {
+        if (x0 < 0 || y0 < 0)
+        {
+            Splash(x1, y1);
+            return;
+        }
+
+        // Bresenham line, splashing at every step.
+        var dx = Math.Abs(x1 - x0);
+        var dy = -Math.Abs(y1 - y0);
+        var sx = x0 < x1 ? 1 : -1;
+        var sy = y0 < y1 ? 1 : -1;
+        var err = dx + dy;
+
+        while (true)
+        {
+            Splash(x0, y0);
+            if (x0 == x1 && y0 == y1) break;
+            var e2 = 2 * err;
+            if (e2 >= dy) { err += dy; x0 += sx; }
+            if (e2 <= dx) { err += dx; y0 += sy; }
+        }
+    }
+
+    private void Splash(int cx, int cy)
+    {
+        if (_current is null) return;
+        if ((uint)cx >= (uint)_fieldWidth || (uint)cy >= (uint)_fieldHeight) return;
+
+        // 3x3 splat with a softer falloff at the corners so the disturbance
+        // reads as a "fingertip" rather than a square.
+        var w = _fieldWidth;
+        var h = _fieldHeight;
+        for (var dy = -1; dy <= 1; dy++)
+        {
+            var y = cy + dy;
+            if ((uint)y >= (uint)h) continue;
+            for (var dx = -1; dx <= 1; dx++)
+            {
+                var x = cx + dx;
+                if ((uint)x >= (uint)w) continue;
+                var falloff = (dx == 0 && dy == 0) ? 1.0f : ((dx == 0 || dy == 0) ? 0.5f : 0.25f);
+                _current[y * w + x] += SplashAmplitude * falloff;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Advances the wave simulation by one step. Reads from
+    /// <see cref="_previous"/>, writes into a new buffer, then swaps
+    /// so the new state becomes "current" for the next frame.
+    /// </summary>
+    private void Step()
+    {
+        if (_current is null || _previous is null) return;
+
+        var w = _fieldWidth;
+        var h = _fieldHeight;
+        var cur = _current;
+        var prv = _previous;
+
+        // Update interior cells. Edge cells stay at 0 (solid boundary).
+        for (var y = 1; y < h - 1; y++)
+        {
+            var row = y * w;
+            for (var x = 1; x < w - 1; x++)
+            {
+                var i = row + x;
+                var neighbours = cur[i - 1] + cur[i + 1] + cur[i - w] + cur[i + w];
+                var next = (neighbours * 0.5f) - prv[i];
+                next *= Damping;
+                // Floor extremely small values to 0 so settled pond doesn't
+                // keep emitting micro-differences forever (lets the renderer
+                // fast-path engage).
+                if (next > -0.001f && next < 0.001f) next = 0f;
+                prv[i] = next;
+            }
+        }
+
+        // Swap buffers: prv now holds the next state.
+        (_current, _previous) = (prv, cur);
+    }
+
+    private void DrawPond(Surface surface)
+    {
+        if (_current is null || _noise is null) return;
+
+        var w = surface.Width;
+        var h = surface.Height;
+        var black = Hex1bColor.Black;
+        var field = _current;
+
+        // Map field displacement (~ -10..+10) to brightness 0..1 via a
+        // soft compressor so big splashes don't clip immediately.
+        // mag/(mag+k) is a smooth tanh-like saturator in [0,1).
+        for (var y = 0; y < h; y++)
+        {
+            var row = y * w;
+            for (var x = 0; x < w; x++)
+            {
+                var i = row + x;
+                var d = field[i];
+                var mag = d < 0 ? -d : d;
+                var t = mag / (mag + 4.0f);
+                var level = (byte)(40 + (215 * t));
+                var colour = Hex1bColor.FromRgb(level, level, level);
+                surface[x, y] = new SurfaceCell(_noise[i], colour, black);
+            }
+        }
+    }
+}

--- a/samples/PerfStressDemo/PondRipplePage.cs
+++ b/samples/PerfStressDemo/PondRipplePage.cs
@@ -78,6 +78,12 @@ internal sealed class PondRipplePage : IStressPage
     // line from a stale position.
     private int _trailX = -1;
     private int _trailY = -1;
+    // True when both wave buffers are fully zero and there's no mouse-driven
+    // input pending. Lets the page tell the framework to stop redrawing.
+    // Starts true (pond is calm at construction); flipped false whenever a
+    // splash is injected, flipped back to true at the end of any Step() that
+    // floored every cell to zero.
+    private bool _quiescent = true;
 
     /// <summary>
     /// One viscosity preset — combines damping, step rate, and splash
@@ -135,7 +141,7 @@ internal sealed class PondRipplePage : IStressPage
 
     public Hex1bWidget Build(StressContext sc)
     {
-        return sc.Root
+        var widget = sc.Root
             .Surface(layer =>
             {
                 EnsureFieldSize(layer.Width, layer.Height);
@@ -187,11 +193,22 @@ internal sealed class PondRipplePage : IStressPage
                 }
 
                 return new[] { layer.Layer(DrawPond) };
-            })
-            // Keep stepping the simulation every frame even with no input
-            // so waves dampen naturally to stillness.
-            .RedrawAfter(sc.RedrawIntervalMs);
+            });
+
+        // Only schedule continuous redraws while the simulation has energy
+        // to dissipate. Once the pond fully settles, drop RedrawAfter so
+        // the framework idles until a mouse event wakes it back up.
+        return _quiescent ? widget : widget.RedrawAfter(sc.RedrawIntervalMs);
     }
+
+    /// <summary>
+    /// True when the wave field is fully settled and the page has nothing
+    /// to animate. Program.cs queries this after <see cref="Build"/> to
+    /// decide whether the root tree needs a RedrawAfter — when both this
+    /// page and the root are content to idle, the framework sleeps until
+    /// real input arrives.
+    /// </summary>
+    public bool IsIdle => _quiescent;
 
     private void EnsureNoise(int w, int h)
     {
@@ -218,6 +235,7 @@ internal sealed class PondRipplePage : IStressPage
         _observedMouseY = int.MinValue;
         _trailX = -1;
         _trailY = -1;
+        _quiescent = true;
     }
 
     /// <summary>
@@ -272,6 +290,8 @@ internal sealed class PondRipplePage : IStressPage
                 _current[y * w + x] += Presets[PresetIndex].SplashAmplitude * falloff;
             }
         }
+        // Injecting energy wakes the simulation back up.
+        _quiescent = false;
     }
 
     /// <summary>
@@ -288,6 +308,7 @@ internal sealed class PondRipplePage : IStressPage
         var cur = _current;
         var prv = _previous;
         var damping = Presets[PresetIndex].Damping;
+        var anyAlive = false;
 
         // Update interior cells. Edge cells stay at 0 (solid boundary).
         for (var y = 1; y < h - 1; y++)
@@ -308,12 +329,17 @@ internal sealed class PondRipplePage : IStressPage
                 // re-injects energy. 0.01 is well below visible brightness
                 // (level 40.4 vs 40 at MaxDisplay=6) so killing it is free.
                 if (next > -0.01f && next < 0.01f) next = 0f;
+                else anyAlive = true;
                 prv[i] = next;
             }
         }
 
         // Swap buffers: prv now holds the next state.
         (_current, _previous) = (prv, cur);
+        // If every interior cell floored to zero, the pond is fully settled
+        // — flip the flag so the page reports IsIdle and the framework can
+        // stop scheduling frames until input wakes us back up.
+        if (!anyAlive) _quiescent = true;
     }
 
     private void DrawPond(Surface surface)

--- a/samples/PerfStressDemo/Program.cs
+++ b/samples/PerfStressDemo/Program.cs
@@ -1,0 +1,148 @@
+using System.Diagnostics;
+using Hex1b;
+using Hex1b.Input;
+using Hex1b.Widgets;
+using PerfStressDemo;
+
+// ─────────────────────────────────────────────────────────────────────────
+// PerfStressDemo
+// ─────────────────────────────────────────────────────────────────────────
+// A multi-page TUI sample whose only purpose is to push the renderer hard
+// so we can visually inspect how it copes. PgUp/PgDn navigate between
+// stress pages. Each page targets a different render hotspot.
+//
+// Page 1 is the "ripple over noise" repro that originally motivated the
+// rendering-perf investigation: a full screen of random characters with
+// an EffectPanel painting a continuous ripple wave. The status bar shows
+// live frame rate and Gen2 collection count so the GC pressure win from
+// SurfacePool is visible to the naked eye.
+//
+// CLI flags:
+//     --no-pool         Disable the surface pool (A/B against default).
+//     --target-fps <N>  Redraw cadence in frames per second (default 30).
+//     --no-cache        Disable render caching.
+// ─────────────────────────────────────────────────────────────────────────
+
+bool enablePool = true;
+bool enableCache = true;
+int targetFps = 30;
+
+for (var i = 0; i < args.Length; i++)
+{
+    var arg = args[i];
+    switch (arg)
+    {
+        case "--no-pool":
+            enablePool = false;
+            break;
+        case "--no-cache":
+            enableCache = false;
+            break;
+        case "--target-fps" when i + 1 < args.Length && int.TryParse(args[i + 1], out var fps) && fps > 0:
+            targetFps = fps;
+            i++;
+            break;
+        case "-h":
+        case "--help":
+            Console.WriteLine("PerfStressDemo — multi-page TUI render stress harness");
+            Console.WriteLine();
+            Console.WriteLine("  --no-pool            Disable surface pooling");
+            Console.WriteLine("  --no-cache           Disable render caching");
+            Console.WriteLine("  --target-fps <N>     Target frame rate (default 30)");
+            Console.WriteLine("  PgUp / PgDn          Switch between stress pages");
+            Console.WriteLine("  Q                    Quit");
+            return;
+    }
+}
+
+var pages = new IStressPage[]
+{
+    new RippleOverNoisePage(),
+};
+
+int currentPageIndex = 0;
+int redrawIntervalMs = Math.Max(1, 1000 / targetFps);
+
+// FPS / GC counters refreshed lazily — sample on every Build call.
+var clock = Stopwatch.StartNew();
+long frameCount = 0;
+double lastFpsSampleSeconds = 0;
+long lastFpsSampleFrames = 0;
+double currentFps = 0;
+int baselineGen2 = GC.CollectionCount(2);
+int baselineGen1 = GC.CollectionCount(1);
+int baselineGen0 = GC.CollectionCount(0);
+
+Hex1bApp? appRef = null;
+
+await using var terminal = Hex1bTerminal.CreateBuilder()
+    .WithHex1bApp((app, options) =>
+    {
+        appRef = app;
+        options.EnableSurfacePooling = enablePool;
+        options.EnableRenderCaching = enableCache;
+        return ctx => BuildRoot(ctx);
+    })
+    .Build();
+
+await terminal.RunAsync();
+return;
+
+Hex1bWidget BuildRoot(RootContext root)
+{
+    frameCount++;
+
+    // Sample FPS once per ~500ms so the number is readable.
+    var nowSeconds = clock.Elapsed.TotalSeconds;
+    var dt = nowSeconds - lastFpsSampleSeconds;
+    if (dt >= 0.5)
+    {
+        currentFps = (frameCount - lastFpsSampleFrames) / dt;
+        lastFpsSampleFrames = frameCount;
+        lastFpsSampleSeconds = nowSeconds;
+    }
+
+    var page = pages[currentPageIndex];
+    var stressCtx = new StressContext(root, nowSeconds, redrawIntervalMs);
+    var pageWidget = page.Build(stressCtx);
+
+    var gen2 = GC.CollectionCount(2) - baselineGen2;
+    var gen1 = GC.CollectionCount(1) - baselineGen1;
+    var gen0 = GC.CollectionCount(0) - baselineGen0;
+
+    var pageLabel = $"Page {currentPageIndex + 1}/{pages.Length}: {page.Name}";
+    var perfLabel = $"{currentFps,5:0.0} fps  GC[0/1/2]={gen0}/{gen1}/{gen2}";
+    var poolLabel = enablePool ? "pool=on" : "pool=OFF";
+    var cacheLabel = enableCache ? "cache=on" : "cache=OFF";
+
+    return root.VStack(v => new Hex1bWidget[]
+    {
+        // The page itself fills all remaining vertical space.
+        pageWidget.Fill(),
+
+        // Status bar at the bottom.
+        v.InfoBar(s => new IInfoBarChild[]
+        {
+            s.Section(pageLabel).FillWidth(),
+            s.Divider(" │ "),
+            s.Section(perfLabel),
+            s.Divider(" │ "),
+            s.Section($"{poolLabel}  {cacheLabel}"),
+            s.Divider(" │ "),
+            s.Section("PgUp/PgDn  Q quit"),
+        }),
+    }).InputBindings(bindings =>
+    {
+        bindings.Key(Hex1bKey.PageDown).Global().Action(_ =>
+        {
+            currentPageIndex = (currentPageIndex + 1) % pages.Length;
+        }, "Next page");
+
+        bindings.Key(Hex1bKey.PageUp).Global().Action(_ =>
+        {
+            currentPageIndex = (currentPageIndex - 1 + pages.Length) % pages.Length;
+        }, "Previous page");
+
+        bindings.Key(Hex1bKey.Q).Global().Action(_ => appRef?.RequestStop(), "Quit");
+    });
+}

--- a/samples/PerfStressDemo/Program.cs
+++ b/samples/PerfStressDemo/Program.cs
@@ -21,6 +21,9 @@ using PerfStressDemo;
 //     --no-pool         Disable the surface pool (A/B against default).
 //     --target-fps <N>  Redraw cadence in frames per second (default 30).
 //     --no-cache        Disable render caching.
+//     --ripple-levels <N>  Quantise the ripple gradient into N greyscale
+//                          bands (default 256 = smooth true-color). Lower
+//                          values dramatically reduce bytes/frame.
 // ─────────────────────────────────────────────────────────────────────────
 
 bool enablePool = true;
@@ -42,6 +45,10 @@ for (var i = 0; i < args.Length; i++)
             targetFps = fps;
             i++;
             break;
+        case "--ripple-levels" when i + 1 < args.Length && int.TryParse(args[i + 1], out var lvl) && lvl > 0:
+            RippleOverNoisePage.Levels = lvl;
+            i++;
+            break;
         case "-h":
         case "--help":
             Console.WriteLine("PerfStressDemo — multi-page TUI render stress harness");
@@ -49,7 +56,9 @@ for (var i = 0; i < args.Length; i++)
             Console.WriteLine("  --no-pool            Disable surface pooling");
             Console.WriteLine("  --no-cache           Disable render caching");
             Console.WriteLine("  --target-fps <N>     Target frame rate (default 30)");
+            Console.WriteLine("  --ripple-levels <N>  Quantise ripple to N greyscale bands (default 256)");
             Console.WriteLine("  PgUp / PgDn          Switch between stress pages");
+            Console.WriteLine("  L                    Cycle ripple quantisation 256→16→8→4→2→256");
             Console.WriteLine("  Q                    Quit");
             return;
     }
@@ -135,9 +144,9 @@ Hex1bWidget BuildRoot(RootContext root)
             s.Divider(" │ "),
             s.Section(perfLabel),
             s.Divider(" │ "),
-            s.Section($"{poolLabel}  {cacheLabel}"),
+            s.Section($"{poolLabel}  {cacheLabel}  ripple={RippleOverNoisePage.LevelsLabel}"),
             s.Divider(" │ "),
-            s.Section("PgUp/PgDn  Q quit"),
+            s.Section("PgUp/PgDn  L levels  Q quit"),
         }),
     })
     // Drive continuous animation from the root so the framework always
@@ -157,5 +166,18 @@ Hex1bWidget BuildRoot(RootContext root)
         }, "Previous page");
 
         bindings.Key(Hex1bKey.Q).Global().Action(_ => appRef?.RequestStop(), "Quit");
+
+        bindings.Key(Hex1bKey.L).Global().Action(_ =>
+        {
+            // Cycle: 256 (smooth) → 16 → 8 → 4 → 2 → 256
+            RippleOverNoisePage.Levels = RippleOverNoisePage.Levels switch
+            {
+                >= 256 => 16,
+                16 => 8,
+                8 => 4,
+                4 => 2,
+                _ => 256,
+            };
+        }, "Cycle ripple levels");
     });
 }

--- a/samples/PerfStressDemo/Program.cs
+++ b/samples/PerfStressDemo/Program.cs
@@ -60,7 +60,7 @@ for (var i = 0; i < args.Length; i++)
             Console.WriteLine("  PgUp / PgDn          Switch between stress pages");
             Console.WriteLine("  L                    Cycle ripple quantisation 256→16→8→4→2→256");
             Console.WriteLine("  V                    Cycle pond viscosity (water→light→medium→thick→glob)");
-            Console.WriteLine("  Click / Scroll       Whirlpool: L=outlet, R=inlet, Shift+L/R clears, R-key resets");
+            Console.WriteLine("  Click / Scroll       Whirlpool: L=outlet, R=inlet, Ctrl+L/R clears, R-key resets");
             Console.WriteLine("  Q                    Quit");
             return;
     }

--- a/samples/PerfStressDemo/Program.cs
+++ b/samples/PerfStressDemo/Program.cs
@@ -67,6 +67,7 @@ for (var i = 0; i < args.Length; i++)
 var pages = new IStressPage[]
 {
     new RippleOverNoisePage(),
+    new PondRipplePage(),
 };
 
 int currentPageIndex = 0;

--- a/samples/PerfStressDemo/Program.cs
+++ b/samples/PerfStressDemo/Program.cs
@@ -149,7 +149,7 @@ Hex1bWidget BuildRoot(RootContext root)
             s.Divider(" │ "),
             s.Section(perfLabel),
             s.Divider(" │ "),
-            s.Section($"{poolLabel}  {cacheLabel}  ripple={RippleOverNoisePage.LevelsLabel}  pond={PondRipplePage.PresetLabel}  whirl={(WhirlpoolPage.WellActive ? "on" : "off")}@{WhirlpoolPage.CurrentStrength:0.0}"),
+            s.Section($"{poolLabel}  {cacheLabel}  ripple={RippleOverNoisePage.LevelsLabel}  pond={PondRipplePage.PresetLabel}  whirl={(WhirlpoolPage.DrainOpen ? "drain" : "fill")}@{WhirlpoolPage.CurrentStrength:0.0}"),
             s.Divider(" │ "),
             s.Section("PgUp/PgDn  L levels  V viscosity  Click/Scroll whirlpool  Q quit"),
         }),

--- a/samples/PerfStressDemo/Program.cs
+++ b/samples/PerfStressDemo/Program.cs
@@ -60,7 +60,7 @@ for (var i = 0; i < args.Length; i++)
             Console.WriteLine("  PgUp / PgDn          Switch between stress pages");
             Console.WriteLine("  L                    Cycle ripple quantisation 256→16→8→4→2→256");
             Console.WriteLine("  V                    Cycle pond viscosity (water→light→medium→thick→glob)");
-            Console.WriteLine("  Click / Scroll       Whirlpool: left=on/move, right=off, scroll=strength");
+            Console.WriteLine("  Click / Scroll       Whirlpool: left=outlet, right=inlet, R=reset, scroll=strength");
             Console.WriteLine("  Q                    Quit");
             return;
     }
@@ -149,7 +149,7 @@ Hex1bWidget BuildRoot(RootContext root)
             s.Divider(" │ "),
             s.Section(perfLabel),
             s.Divider(" │ "),
-            s.Section($"{poolLabel}  {cacheLabel}  ripple={RippleOverNoisePage.LevelsLabel}  pond={PondRipplePage.PresetLabel}  whirl={(WhirlpoolPage.DrainOpen ? "drain" : "fill")}@{WhirlpoolPage.CurrentStrength:0.0}"),
+            s.Section($"{poolLabel}  {cacheLabel}  ripple={RippleOverNoisePage.LevelsLabel}  pond={PondRipplePage.PresetLabel}  whirl={(WhirlpoolPage.DrainOpen && WhirlpoolPage.InletOpen ? "both" : WhirlpoolPage.DrainOpen ? "drain" : WhirlpoolPage.InletOpen ? "fill" : "idle")}@{WhirlpoolPage.CurrentStrength:0.0}"),
             s.Divider(" │ "),
             s.Section("PgUp/PgDn  L levels  V viscosity  Click/Scroll whirlpool  Q quit"),
         }),

--- a/samples/PerfStressDemo/Program.cs
+++ b/samples/PerfStressDemo/Program.cs
@@ -60,6 +60,7 @@ for (var i = 0; i < args.Length; i++)
             Console.WriteLine("  PgUp / PgDn          Switch between stress pages");
             Console.WriteLine("  L                    Cycle ripple quantisation 256→16→8→4→2→256");
             Console.WriteLine("  V                    Cycle pond viscosity (water→light→medium→thick→glob)");
+            Console.WriteLine("  Click / Scroll       Whirlpool: click sets well, scroll adjusts strength");
             Console.WriteLine("  Q                    Quit");
             return;
     }
@@ -69,6 +70,7 @@ var pages = new IStressPage[]
 {
     new RippleOverNoisePage(),
     new PondRipplePage(),
+    new WhirlpoolPage(),
 };
 
 int currentPageIndex = 0;
@@ -147,9 +149,9 @@ Hex1bWidget BuildRoot(RootContext root)
             s.Divider(" │ "),
             s.Section(perfLabel),
             s.Divider(" │ "),
-            s.Section($"{poolLabel}  {cacheLabel}  ripple={RippleOverNoisePage.LevelsLabel}  pond={PondRipplePage.PresetLabel}"),
+            s.Section($"{poolLabel}  {cacheLabel}  ripple={RippleOverNoisePage.LevelsLabel}  pond={PondRipplePage.PresetLabel}  whirl={WhirlpoolPage.CurrentStrength:0.0}"),
             s.Divider(" │ "),
-            s.Section("PgUp/PgDn  L levels  V viscosity  Q quit"),
+            s.Section("PgUp/PgDn  L levels  V viscosity  Click/Scroll whirlpool  Q quit"),
         }),
     });
 

--- a/samples/PerfStressDemo/Program.cs
+++ b/samples/PerfStressDemo/Program.cs
@@ -76,16 +76,19 @@ int baselineGen0 = GC.CollectionCount(0);
 Hex1bApp? appRef = null;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
+    .WithHex1bAppOptions(o =>
+    {
+        o.EnableSurfacePooling = enablePool;
+        o.EnableRenderCaching = enableCache;
+        // Enforce the target frame rate at the framework's animation timer
+        // level. This MUST be set before Hex1bApp construction (the timer's
+        // minimum interval is captured in the ctor), so we set it via
+        // WithHex1bAppOptions which runs before WithHex1bApp's configure.
+        o.FrameRateLimitMs = redrawIntervalMs;
+    })
     .WithHex1bApp((app, options) =>
     {
         appRef = app;
-        options.EnableSurfacePooling = enablePool;
-        options.EnableRenderCaching = enableCache;
-        // Enforce the target frame rate from the framework side. Without
-        // this the render loop will happily run as fast as the renderer
-        // can build a frame (300+ fps on a fast machine), wasting CPU
-        // and amplifying any per-frame allocations into Gen2 collections.
-        options.FrameRateLimitMs = redrawIntervalMs;
         return ctx => BuildRoot(ctx);
     })
     .Build();

--- a/samples/PerfStressDemo/Program.cs
+++ b/samples/PerfStressDemo/Program.cs
@@ -86,6 +86,7 @@ int baselineGen0 = GC.CollectionCount(0);
 Hex1bApp? appRef = null;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
+    .WithMouse()
     .WithHex1bAppOptions(o =>
     {
         o.EnableSurfacePooling = enablePool;

--- a/samples/PerfStressDemo/Program.cs
+++ b/samples/PerfStressDemo/Program.cs
@@ -135,7 +135,7 @@ Hex1bWidget BuildRoot(RootContext root)
     var poolLabel = enablePool ? "pool=on" : "pool=OFF";
     var cacheLabel = enableCache ? "cache=on" : "cache=OFF";
 
-    return root.VStack(v => new Hex1bWidget[]
+    var rootWidget = root.VStack(v => new Hex1bWidget[]
     {
         // The page itself fills all remaining vertical space.
         pageWidget.Fill(),
@@ -151,11 +151,18 @@ Hex1bWidget BuildRoot(RootContext root)
             s.Divider(" │ "),
             s.Section("PgUp/PgDn  L levels  V viscosity  Q quit"),
         }),
-    })
-    // Drive continuous animation from the root so the framework always
-    // knows when to wake up — this is independent of whatever the page's
-    // subtree does with its own RedrawDelay.
-    .RedrawAfter(redrawIntervalMs)
+    });
+
+    // Only drive continuous animation when the active page has something
+    // to animate. When the page reports IsIdle (e.g. pond fully settled,
+    // no mouse activity), drop RedrawAfter so the framework sleeps until
+    // a real input event arrives — this is what actually drops CPU to
+    // ~zero between interactions, not pausing the inactive page (which is
+    // already paused — its Build isn't called when it's not selected).
+    if (!page.IsIdle)
+        rootWidget = rootWidget.RedrawAfter(redrawIntervalMs);
+
+    return rootWidget
     .InputBindings(bindings =>
     {
         bindings.Key(Hex1bKey.PageDown).Global().Action(_ =>

--- a/samples/PerfStressDemo/Program.cs
+++ b/samples/PerfStressDemo/Program.cs
@@ -60,7 +60,7 @@ for (var i = 0; i < args.Length; i++)
             Console.WriteLine("  PgUp / PgDn          Switch between stress pages");
             Console.WriteLine("  L                    Cycle ripple quantisation 256→16→8→4→2→256");
             Console.WriteLine("  V                    Cycle pond viscosity (water→light→medium→thick→glob)");
-            Console.WriteLine("  Click / Scroll       Whirlpool: left=outlet, right=inlet, R=reset, scroll=strength");
+            Console.WriteLine("  Click / Scroll       Whirlpool: L=outlet, R=inlet, Shift+L/R clears, R-key resets");
             Console.WriteLine("  Q                    Quit");
             return;
     }

--- a/samples/PerfStressDemo/Program.cs
+++ b/samples/PerfStressDemo/Program.cs
@@ -60,7 +60,7 @@ for (var i = 0; i < args.Length; i++)
             Console.WriteLine("  PgUp / PgDn          Switch between stress pages");
             Console.WriteLine("  L                    Cycle ripple quantisation 256→16→8→4→2→256");
             Console.WriteLine("  V                    Cycle pond viscosity (water→light→medium→thick→glob)");
-            Console.WriteLine("  Click / Scroll       Whirlpool: click sets well, scroll adjusts strength");
+            Console.WriteLine("  Click / Scroll       Whirlpool: left=on/move, right=off, scroll=strength");
             Console.WriteLine("  Q                    Quit");
             return;
     }
@@ -149,7 +149,7 @@ Hex1bWidget BuildRoot(RootContext root)
             s.Divider(" │ "),
             s.Section(perfLabel),
             s.Divider(" │ "),
-            s.Section($"{poolLabel}  {cacheLabel}  ripple={RippleOverNoisePage.LevelsLabel}  pond={PondRipplePage.PresetLabel}  whirl={WhirlpoolPage.CurrentStrength:0.0}"),
+            s.Section($"{poolLabel}  {cacheLabel}  ripple={RippleOverNoisePage.LevelsLabel}  pond={PondRipplePage.PresetLabel}  whirl={(WhirlpoolPage.WellActive ? "on" : "off")}@{WhirlpoolPage.CurrentStrength:0.0}"),
             s.Divider(" │ "),
             s.Section("PgUp/PgDn  L levels  V viscosity  Click/Scroll whirlpool  Q quit"),
         }),

--- a/samples/PerfStressDemo/Program.cs
+++ b/samples/PerfStressDemo/Program.cs
@@ -90,17 +90,18 @@ Hex1bApp? appRef = null;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bAppOptions(o =>
-    {
-        o.EnableSurfacePooling = enablePool;
-        o.EnableRenderCaching = enableCache;
-        // Enforce the target frame rate at the framework's animation timer
-        // level. This MUST be set before Hex1bApp construction (the timer's
-        // minimum interval is captured in the ctor), so we set it via
-        // WithHex1bAppOptions which runs before WithHex1bApp's configure.
-        o.FrameRateLimitMs = redrawIntervalMs;
-    })
-    .WithHex1bApp((app, options) =>
+    .WithHex1bApp(
+        o =>
+        {
+            o.EnableSurfacePooling = enablePool;
+            o.EnableRenderCaching = enableCache;
+            // Enforce the target frame rate at the framework's animation timer
+            // level. This MUST be set before Hex1bApp construction (the timer's
+            // minimum interval is captured in the ctor), so we set it via the
+            // options callback which runs before the app callback.
+            o.FrameRateLimitMs = redrawIntervalMs;
+        },
+        app =>
     {
         appRef = app;
         return ctx => BuildRoot(ctx);

--- a/samples/PerfStressDemo/Program.cs
+++ b/samples/PerfStressDemo/Program.cs
@@ -81,6 +81,11 @@ await using var terminal = Hex1bTerminal.CreateBuilder()
         appRef = app;
         options.EnableSurfacePooling = enablePool;
         options.EnableRenderCaching = enableCache;
+        // Enforce the target frame rate from the framework side. Without
+        // this the render loop will happily run as fast as the renderer
+        // can build a frame (300+ fps on a fast machine), wasting CPU
+        // and amplifying any per-frame allocations into Gen2 collections.
+        options.FrameRateLimitMs = redrawIntervalMs;
         return ctx => BuildRoot(ctx);
     })
     .Build();
@@ -131,7 +136,12 @@ Hex1bWidget BuildRoot(RootContext root)
             s.Divider(" │ "),
             s.Section("PgUp/PgDn  Q quit"),
         }),
-    }).InputBindings(bindings =>
+    })
+    // Drive continuous animation from the root so the framework always
+    // knows when to wake up — this is independent of whatever the page's
+    // subtree does with its own RedrawDelay.
+    .RedrawAfter(redrawIntervalMs)
+    .InputBindings(bindings =>
     {
         bindings.Key(Hex1bKey.PageDown).Global().Action(_ =>
         {

--- a/samples/PerfStressDemo/Program.cs
+++ b/samples/PerfStressDemo/Program.cs
@@ -59,6 +59,7 @@ for (var i = 0; i < args.Length; i++)
             Console.WriteLine("  --ripple-levels <N>  Quantise ripple to N greyscale bands (default 256)");
             Console.WriteLine("  PgUp / PgDn          Switch between stress pages");
             Console.WriteLine("  L                    Cycle ripple quantisation 256→16→8→4→2→256");
+            Console.WriteLine("  V                    Cycle pond viscosity (water→light→medium→thick→glob)");
             Console.WriteLine("  Q                    Quit");
             return;
     }
@@ -146,9 +147,9 @@ Hex1bWidget BuildRoot(RootContext root)
             s.Divider(" │ "),
             s.Section(perfLabel),
             s.Divider(" │ "),
-            s.Section($"{poolLabel}  {cacheLabel}  ripple={RippleOverNoisePage.LevelsLabel}"),
+            s.Section($"{poolLabel}  {cacheLabel}  ripple={RippleOverNoisePage.LevelsLabel}  pond={PondRipplePage.PresetLabel}"),
             s.Divider(" │ "),
-            s.Section("PgUp/PgDn  L levels  Q quit"),
+            s.Section("PgUp/PgDn  L levels  V viscosity  Q quit"),
         }),
     })
     // Drive continuous animation from the root so the framework always
@@ -181,5 +182,10 @@ Hex1bWidget BuildRoot(RootContext root)
                 _ => 256,
             };
         }, "Cycle ripple levels");
+
+        bindings.Key(Hex1bKey.V).Global().Action(_ =>
+        {
+            PondRipplePage.CyclePreset();
+        }, "Cycle pond viscosity");
     });
 }

--- a/samples/PerfStressDemo/RippleOverNoisePage.cs
+++ b/samples/PerfStressDemo/RippleOverNoisePage.cs
@@ -50,8 +50,13 @@ internal sealed class RippleOverNoisePage : IStressPage
 
     public Hex1bWidget Build(StressContext sc)
     {
-        // The noise itself is static. We only rebuild it on a resize.
-        var noise = sc.Root.Surface(layer => GetOrBuildNoiseLayer(layer));
+        // The noise itself is static. We only rebuild it on a resize, and we mark
+        // the SurfaceWidget as cacheable so the framework doesn't reallocate a
+        // ~64-bytes-per-cell child surface every reconcile (any reasonably sized
+        // terminal puts that surface on the LOH → straight to Gen2).
+        var noise = sc.Root
+            .Surface(layer => GetOrBuildNoiseLayer(layer))
+            .Cached(static _ => true);
 
         // Wrap the noise in an EffectPanel that overlays a circular ripple
         // expanding from the center, animated by elapsed time.

--- a/samples/PerfStressDemo/RippleOverNoisePage.cs
+++ b/samples/PerfStressDemo/RippleOverNoisePage.cs
@@ -23,6 +23,24 @@ internal sealed class RippleOverNoisePage : IStressPage
         "Full-screen white random ASCII + continuous ripple EffectPanel. "
         + "The original 'tanks the machine' workload.";
 
+    /// <summary>
+    /// Number of distinct greyscale shades the ripple modulates the foreground
+    /// across. 256 = true-color smooth gradient (worst case — every cell tends
+    /// to a unique colour, so SGR run-collapsing in the surface comparer can't
+    /// help and the per-frame byte count to the host terminal is maximised).
+    /// Lower values quantise the gradient into bands so neighbouring cells
+    /// often share the same SGR — fewer bytes/frame, easier for slow terminal
+    /// emulators to keep up. 0 is a sentinel meaning "no quantisation".
+    /// </summary>
+    public static int Levels { get; set; } = 256;
+
+    /// <summary>
+    /// Human-readable label for the current <see cref="Levels"/> value, used
+    /// by the status bar.
+    /// </summary>
+    public static string LevelsLabel =>
+        Levels >= 256 ? "smooth (256)" : Levels.ToString();
+
     // Cached noise surface. Regenerated only when the terminal is resized.
     // Without this, generating a fresh 160×50 random char field every frame
     // would allocate 8000 strings/frame (240k/sec at 30 fps) which would
@@ -123,6 +141,18 @@ internal sealed class RippleOverNoisePage : IStressPage
                 var s3 = Math.Sin(r * 0.85 - wave3);
                 var combined = (s1 + s2 + s3) / 3.0; // -1..+1
                 var brightness = 0.5 + 0.5 * combined; // 0..1
+
+                // Optionally quantise into N bands so neighbouring cells share
+                // a value, which lets the SurfaceComparer's SGR state tracking
+                // collapse long runs of cells into a single SGR. Massive
+                // bytes/frame reduction on slow host terminals.
+                var levels = Levels;
+                if (levels > 0 && levels < 256)
+                {
+                    var bucket = (int)(brightness * levels);
+                    if (bucket >= levels) bucket = levels - 1;
+                    brightness = bucket / (double)(levels - 1);
+                }
 
                 // Stay in greyscale: just modulate the white intensity so
                 // the ripple reads as the original characters pulsing

--- a/samples/PerfStressDemo/RippleOverNoisePage.cs
+++ b/samples/PerfStressDemo/RippleOverNoisePage.cs
@@ -99,7 +99,7 @@ internal sealed class RippleOverNoisePage : IStressPage
         const double aspect = 2.0;
 
         // Three concentric waves at different speeds keep the surface
-        // visually busy and ensure the colour at every cell changes
+        // visually busy and ensure the brightness at every cell changes
         // frequently (so the diff stays large).
         var wave1 = seconds * 6.0;
         var wave2 = seconds * 9.0;
@@ -119,35 +119,16 @@ internal sealed class RippleOverNoisePage : IStressPage
                 var combined = (s1 + s2 + s3) / 3.0; // -1..+1
                 var brightness = 0.5 + 0.5 * combined; // 0..1
 
-                // Smooth hue rotation around the wave so the ripple is
-                // unmistakable and exercises the full RGB colour output path.
-                var hue = (r * 0.04 - seconds * 0.25) % 1.0;
-                if (hue < 0) hue += 1.0;
-                var colour = HsvToColor(hue, 0.85, 0.35 + 0.65 * brightness);
+                // Stay in greyscale: just modulate the white intensity so
+                // the ripple reads as the original characters pulsing
+                // between dim and bright rather than cycling hue.
+                var level = (byte)(40 + 215 * brightness); // 40..255
+                var colour = Hex1bColor.FromRgb(level, level, level);
 
                 var cell = surface[x, y];
                 surface[x, y] = cell with { Foreground = colour };
             }
         }
-    }
-
-    internal static Hex1bColor HsvToColor(double h, double s, double v)
-    {
-        var i = (int)Math.Floor(h * 6.0) % 6;
-        var f = h * 6.0 - Math.Floor(h * 6.0);
-        var p = v * (1.0 - s);
-        var q = v * (1.0 - f * s);
-        var t = v * (1.0 - (1.0 - f) * s);
-        var (r, g, b) = i switch
-        {
-            0 => (v, t, p),
-            1 => (q, v, p),
-            2 => (p, v, t),
-            3 => (p, q, v),
-            4 => (t, p, v),
-            _ => (v, p, q),
-        };
-        return Hex1bColor.FromRgb((byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
     }
 }
 

--- a/samples/PerfStressDemo/RippleOverNoisePage.cs
+++ b/samples/PerfStressDemo/RippleOverNoisePage.cs
@@ -1,0 +1,153 @@
+using Hex1b;
+using Hex1b.Surfaces;
+using Hex1b.Theming;
+using Hex1b.Widgets;
+
+namespace PerfStressDemo;
+
+/// <summary>
+/// Page 1 — "Ripple over noise".
+///
+/// Full-screen field of random printable ASCII characters in white, with an
+/// <see cref="EffectPanelWidget"/> wrapped around it that paints a continuously
+/// expanding circular ripple wave. The wave touches every cell each frame, so
+/// the EffectPanel allocates and composites a full-screen surface every frame
+/// — this was the original "tanks the machine" scenario that prompted the
+/// perf investigation.
+/// </summary>
+internal sealed class RippleOverNoisePage : IStressPage
+{
+    public string Name => "Ripple over noise";
+
+    public string Description =>
+        "Full-screen white random ASCII + continuous ripple EffectPanel. "
+        + "The original 'tanks the machine' workload.";
+
+    // Cached noise surface. Regenerated only when the terminal is resized.
+    // Without this, generating a fresh 160×50 random char field every frame
+    // would allocate 8000 strings/frame (240k/sec at 30 fps) which would
+    // dwarf any allocation savings from the SurfacePool and make the
+    // ripple animation hitch.
+    private Surface? _noiseSurface;
+
+    // Pre-computed single-character strings for printable ASCII so that
+    // building the noise surface is allocation-free. char.ToString() is not
+    // cached by the BCL — for hot fill paths like this you must do it
+    // yourself.
+    private static readonly string[] s_asciiChars = BuildAsciiChars();
+
+    private const int RangeStart = 0x21; // '!'
+    private const int RangeEnd = 0x7E;   // '~'
+    private const int RangeSize = RangeEnd - RangeStart + 1;
+
+    private static string[] BuildAsciiChars()
+    {
+        var arr = new string[RangeSize];
+        for (var i = 0; i < RangeSize; i++)
+            arr[i] = ((char)(RangeStart + i)).ToString();
+        return arr;
+    }
+
+    public Hex1bWidget Build(StressContext sc)
+    {
+        // The noise itself is static. We only rebuild it on a resize.
+        var noise = sc.Root.Surface(layer => GetOrBuildNoiseLayer(layer));
+
+        // Wrap the noise in an EffectPanel that overlays a circular ripple
+        // expanding from the center, animated by elapsed time.
+        return sc.Root
+            .EffectPanel(noise, surface => Ripple(surface, sc.ElapsedSeconds))
+            .RedrawAfter(sc.RedrawIntervalMs);
+    }
+
+    private IEnumerable<SurfaceLayer> GetOrBuildNoiseLayer(SurfaceLayerContext layer)
+    {
+        var w = layer.Width;
+        var h = layer.Height;
+        if (_noiseSurface is null || _noiseSurface.Width != w || _noiseSurface.Height != h)
+        {
+            _noiseSurface = new Surface(w, h);
+            FillNoise(_noiseSurface);
+        }
+        return new[] { layer.Layer(_noiseSurface) };
+    }
+
+    private static void FillNoise(Surface surface)
+    {
+        // Deterministic seed so the static background is stable across resizes
+        // for a given size. The visible variety is plenty.
+        var rng = new Random(0xC0FFEE);
+        var white = Hex1bColor.White;
+        var black = Hex1bColor.Black;
+
+        for (var y = 0; y < surface.Height; y++)
+        {
+            for (var x = 0; x < surface.Width; x++)
+            {
+                var ch = s_asciiChars[rng.Next(RangeSize)];
+                surface[x, y] = new SurfaceCell(ch, white, black);
+            }
+        }
+    }
+
+    private static void Ripple(Surface surface, double seconds)
+    {
+        // Center of the screen, with x scaled so the ripple appears round
+        // despite cells being roughly twice as tall as wide.
+        var cx = surface.Width / 2.0;
+        var cy = surface.Height / 2.0;
+        const double aspect = 2.0;
+
+        // Three concentric waves at different speeds keep the surface
+        // visually busy and ensure the colour at every cell changes
+        // frequently (so the diff stays large).
+        var wave1 = seconds * 6.0;
+        var wave2 = seconds * 9.0;
+        var wave3 = seconds * 4.0;
+
+        for (var y = 0; y < surface.Height; y++)
+        {
+            for (var x = 0; x < surface.Width; x++)
+            {
+                var dx = (x - cx) / aspect;
+                var dy = y - cy;
+                var r = Math.Sqrt(dx * dx + dy * dy);
+
+                var s1 = Math.Sin(r * 0.45 - wave1);
+                var s2 = Math.Sin(r * 0.25 - wave2);
+                var s3 = Math.Sin(r * 0.85 - wave3);
+                var combined = (s1 + s2 + s3) / 3.0; // -1..+1
+                var brightness = 0.5 + 0.5 * combined; // 0..1
+
+                // Smooth hue rotation around the wave so the ripple is
+                // unmistakable and exercises the full RGB colour output path.
+                var hue = (r * 0.04 - seconds * 0.25) % 1.0;
+                if (hue < 0) hue += 1.0;
+                var colour = HsvToColor(hue, 0.85, 0.35 + 0.65 * brightness);
+
+                var cell = surface[x, y];
+                surface[x, y] = cell with { Foreground = colour };
+            }
+        }
+    }
+
+    internal static Hex1bColor HsvToColor(double h, double s, double v)
+    {
+        var i = (int)Math.Floor(h * 6.0) % 6;
+        var f = h * 6.0 - Math.Floor(h * 6.0);
+        var p = v * (1.0 - s);
+        var q = v * (1.0 - f * s);
+        var t = v * (1.0 - (1.0 - f) * s);
+        var (r, g, b) = i switch
+        {
+            0 => (v, t, p),
+            1 => (q, v, p),
+            2 => (p, v, t),
+            3 => (p, q, v),
+            4 => (t, p, v),
+            _ => (v, p, q),
+        };
+        return Hex1bColor.FromRgb((byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
+    }
+}
+

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -1,4 +1,3 @@
-using System.Numerics;
 using Hex1b;
 using Hex1b.Input;
 using Hex1b.Surfaces;
@@ -10,141 +9,131 @@ namespace PerfStressDemo;
 /// <summary>
 /// Page 3 — "Whirlpool".
 ///
-/// A voxel-column fluid simulation, viewed top-down.
-///
-/// The "tank" is the interior of the screen: a 1-cell-thick solid
-/// border surrounds a rectangular pool whose floor is at the bottom
-/// of every interior column. Each interior sub-cell stores a
-/// <c>uint</c> bitmap of up to <see cref="D"/> stacked water voxels,
-/// gravity-compacted to the low bits (the tank floor). The top-down
-/// renderer colours each sub-cell purely by its column's bit-count
-/// (popcount), so a deeper column is darker blue and an empty one
-/// shows the sandy floor.
-///
-/// Physics is three cellular-automaton rules over the column grid:
-/// <list type="number">
-///   <item><b>Drain</b> — when the user opens the hole, voxels are
-///         removed from random columns within a small disc each
-///         frame. The disc grows from a dimple to its full width
-///         over a few seconds so the whirlpool forms locally before
-///         pulling water from further out.</item>
-///   <item><b>Tangential rotation</b> — within the drain's reach,
-///         each column probabilistically donates a single voxel to
-///         the neighbour in its tangential direction (perpendicular
-///         to the radial vector from the drain), with probability
-///         falling off as a Gaussian of the radius. This is what
-///         spins the water into a visible whirlpool.</item>
-///   <item><b>Lateral pressure</b> — between every adjacent pair of
-///         columns, if the height difference exceeds 1 voxel, move
-///         a single voxel from the taller to the shorter. Done in
-///         two phases per axis (even/odd parity) for race-free
-///         transfer. This is the slow, granular "flow" you see
-///         carrying outer water toward the developing whirlpool.</item>
+/// A shallow-water-equations fluid in a top-down tank. Each interior
+/// sub-cell holds an integer column height (a stack of unit voxels)
+/// plus a 2D velocity vector. Velocities evolve via:
+/// <list type="bullet">
+///   <item><b>Pressure gradient</b> — water accelerates away from
+///         high-water cells toward low-water cells (<c>∂v/∂t ∝ -∇h</c>).</item>
+///   <item><b>Drain attraction + swirl</b> — when the drain is open,
+///         each cell within reach gains a radially-inward and
+///         tangential acceleration, weighted by a Gaussian on
+///         distance to the drain. This is what spins the visible
+///         whirlpool.</item>
+///   <item><b>Damping</b> — multiplicative per-frame velocity decay
+///         plus a hard cap; the system loses energy over time so it
+///         eventually settles.</item>
 /// </list>
+/// Heights evolve via integer voxel transfers. For each edge between
+/// adjacent cells, the volumetric flux is
+/// <c>avg(velocity) × upwind(height)</c>; we accumulate it on a
+/// per-edge float and whenever it crosses ±1 we transfer one voxel
+/// across the edge. So even single-voxel motion is conserved and
+/// driven by the velocity field.
 ///
-/// When the drain is closed, a roaming inlet drips voxels into a
-/// random interior column, refilling the tank. When every column is
-/// full and nothing is moving, the page reports IsIdle so the
-/// framework can sleep.
+/// The combination gives genuinely elastic flow: open the drain and
+/// water spirals into the hole; close the drain and momentum carries
+/// the surrounding water inward past the equilibrium level, the
+/// pressure-gradient force then pushes it back out, and the basin
+/// sloshes for several seconds before settling.
 ///
-/// Controls: left click opens the drain at the cursor (and resets
-/// the reach ramp), right click closes it, scroll up/down adjusts
-/// drain strength.
+/// Voxels are still individuals — they're stored as the height count
+/// in their column — but their motion is governed by the per-cell
+/// velocity field. All hot arrays (heights, vx, vy, flow accumulators)
+/// are dense float/short data with no branches in the inner loops
+/// of damping or advection, so a future SIMD pass over Vector&lt;float&gt;
+/// is straightforward.
+///
+/// The tank is the interior of the screen: a 1-cell-thick solid
+/// border is drawn around the perimeter, with the drain hole appearing
+/// as a dark dot at the cursor while it's open.
+///
+/// Controls: left click opens the drain at the cursor and resets the
+/// reach ramp; right click closes it; scroll up/down adjusts drain
+/// strength.
 /// </summary>
 internal sealed class WhirlpoolPage : IStressPage
 {
     public string Name => "Whirlpool";
 
     public string Description =>
-        "Voxel-column fluid: each interior sub-cell stores up to "
-        + "16 stacked water voxels in a uint bitmap. Drain, tangential "
-        + "rotation, and lateral pressure all run as cellular rules.";
+        "Shallow-water voxel fluid: per-cell height + 2D velocity, "
+        + "pressure-gradient acceleration, drain attraction + swirl, "
+        + "integer voxel flux transfers. Water sloshes back elastically "
+        + "when the drain closes.";
 
     // ----------------------------------------------------------------
-    // Voxel column geometry. D = max voxels per column, so a full
-    // column is FullColumn = (1u << D) - 1. Storing as uint keeps the
-    // entire grid SIMD-friendly for later (Vector<uint>.PopCount on
-    // .NET 8+).
+    // Geometry — voxels are unit-height, columns top out at D voxels.
     // ----------------------------------------------------------------
     private const int D = 16;
-    private const uint FullColumn = (1u << D) - 1u;
+    private const short DShort = (short)D;
 
-    private uint[] _columns = Array.Empty<uint>();
-    private int _screenW;     // surface width  (cells, including walls)
-    private int _screenH;     // surface height (cells, including walls)
-    private int _dw;          // interior width  in sub-cells (columns array X)
-    private int _dh;          // interior height in sub-cells (columns array Y)
+    private short[] _height = Array.Empty<short>();
+    private float[] _vx = Array.Empty<float>();
+    private float[] _vy = Array.Empty<float>();
+    private float[] _flowAccX = Array.Empty<float>();
+    private float[] _flowAccY = Array.Empty<float>();
 
-    // Wall thickness is 1 cell on each side of the screen — the
-    // "tank" pool is the inner rectangle. Sub-cell offsets place the
-    // interior columns into the right physical region of the screen.
+    private int _screenW, _screenH;
+    private int _dw, _dh;
     private const int WallCells = 1;
 
     // ----------------------------------------------------------------
     // Drain state.
     // ----------------------------------------------------------------
     private bool _drainActive;
-    private int _drainCx;          // drain column (interior sub-cell coords)
+    private int _drainCx;
     private int _drainCy;
     private float _strength = 1.0f;
     private int _drainOpenFrames;
     private const float MinStrength = 0.3f;
     private const float MaxStrength = 4.0f;
 
-    private const float DrainReachInitial = 2.0f;   // initial Gaussian sigma + drain disc radius
-    private const float DrainReachMax     = 18f;
-    private const int   DrainReachRampFrames = 360;
-    private const float DrainDiscRadiusMax = 11f;
-    private const float DrainDensity      = 0.5f;    // voxels removed per disc-area unit per frame
-    private const float TangentialBiasBase = 0.7f;   // peak probability of a tangential donation per column per frame
+    private const float DrainReachInitial   = 2.0f;
+    private const float DrainReachMax       = 18f;
+    private const int   DrainReachRampFrames = 300;
+    private const float DrainDiscRadiusMax  = 10f;
+    private const float DrainDensity        = 0.35f;
+    private const float PullStrength        = 0.45f; // peak inward accel per frame at drain centre
+    private const float SwirlStrength       = 0.75f; // peak tangential accel per frame
 
     // ----------------------------------------------------------------
-    // Lateral / pressure equalisation. Move at most 1 voxel per pair
-    // per frame whenever |dh| > LateralThreshold — keeps the flow
-    // visibly granular.
+    // Shallow-water dynamics. Tune for visible momentum / sloshing
+    // without runaway oscillation.
     // ----------------------------------------------------------------
-    private const int LateralThreshold = 1;
+    private const float PressureGain = 0.06f;
+    private const float Damping      = 0.975f;
+    private const float MaxSpeed     = 2.0f;
+    private const float VelocityFloor = 0.003f;
 
     // ----------------------------------------------------------------
-    // Refill — roaming inlet that drips voxels into one interior
-    // column at a time. No jet/wave splash here; the discrete voxel
-    // accumulation IS the visible motion.
+    // Refill — roaming inlet drips voxels into a small interior disc.
     // ----------------------------------------------------------------
     private float _inletX;
     private float _inletY;
     private int _inletAge;
     private int _inletGap;
-    private const int InletLifetime = 80;
-    private const int InletGapMin = 0;
-    private const int InletGapMax = 10;
-    private const int InletVoxelsPerFrame = 8;
-    private const float InletRadius = 3f;
+    private const int InletLifetime  = 80;
+    private const int InletGapMin    = 0;
+    private const int InletGapMax    = 10;
+    private const int InletVoxelsPerFrame = 10;
+    private const float InletRadius  = 3f;
 
-    // ----------------------------------------------------------------
-    // Activity / idleness.
-    // ----------------------------------------------------------------
     private bool _quiescent = true;
     public bool IsIdle => _quiescent;
 
-    public static float CurrentStrength { get; private set; } = 1.0f;
+    public static float CurrentStrength { get; private set; } = 1f;
     public static bool DrainOpen { get; private set; }
 
-    // ----------------------------------------------------------------
-    // Fast deterministic RNG (xorshift32).
-    // ----------------------------------------------------------------
+    // xorshift32 RNG
     private uint _rng = 0xDEADBEEFu;
     private uint NextRandom()
     {
-        var x = _rng;
-        x ^= x << 13; x ^= x >> 17; x ^= x << 5;
-        _rng = x;
-        return x;
+        var x = _rng; x ^= x << 13; x ^= x >> 17; x ^= x << 5;
+        _rng = x; return x;
     }
     private float NextFloat() => (NextRandom() & 0xFFFFFF) / (float)0x1000000;
 
-    // ----------------------------------------------------------------
-    // Colour stops.
-    // ----------------------------------------------------------------
     private static readonly (byte R, byte G, byte B) SandColour    = (235, 215, 175);
     private static readonly (byte R, byte G, byte B) ShallowColour = (160, 220, 245);
     private static readonly (byte R, byte G, byte B) MidColour     = (40, 130, 200);
@@ -155,7 +144,6 @@ internal sealed class WhirlpoolPage : IStressPage
 
     public Hex1bWidget Build(StressContext sc)
     {
-        // Surface alone doesn't route mouse; Interactable does.
         var widget = sc.Root.Interactable(ic =>
             ic.Surface(layer =>
             {
@@ -195,9 +183,6 @@ internal sealed class WhirlpoolPage : IStressPage
     private bool TryMouseToInteriorColumn(int mouseX, int mouseY, out int icx, out int icy)
     {
         icx = mouseX - WallCells;
-        // Use the bottom sub-cell of the clicked cell as the drain
-        // centre so the hole's vertical position matches what the
-        // user sees their cursor over.
         icy = (mouseY - WallCells) * 2 + 1;
         if (mouseX < WallCells || mouseX >= _screenW - WallCells) return false;
         if (mouseY < WallCells || mouseY >= _screenH - WallCells) return false;
@@ -207,15 +192,18 @@ internal sealed class WhirlpoolPage : IStressPage
 
     private void EnsureField(int w, int h)
     {
-        if (_screenW == w && _screenH == h && _columns.Length > 0) return;
+        if (_screenW == w && _screenH == h && _height.Length > 0) return;
         _screenW = w;
         _screenH = h;
-        var interiorW = Math.Max(0, w - 2 * WallCells);
-        var interiorH = Math.Max(0, h - 2 * WallCells);
-        _dw = interiorW;
-        _dh = interiorH * 2;
-        _columns = new uint[_dw * _dh];
-        Array.Fill(_columns, FullColumn);
+        _dw = Math.Max(0, w - 2 * WallCells);
+        _dh = Math.Max(0, h - 2 * WallCells) * 2;
+        var n = _dw * _dh;
+        _height = new short[n];
+        _vx = new float[n];
+        _vy = new float[n];
+        _flowAccX = new float[n];
+        _flowAccY = new float[n];
+        for (var i = 0; i < n; i++) _height[i] = DShort;
         _quiescent = true;
         _drainActive = false;
         _drainOpenFrames = 0;
@@ -225,26 +213,26 @@ internal sealed class WhirlpoolPage : IStressPage
 
     private void Step()
     {
-        if (_columns.Length == 0) return;
+        if (_height.Length == 0) return;
         CurrentStrength = _strength;
         DrainOpen = _drainActive;
 
-        var changed = false;
+        ApplyForces();
+        ApplyDamping();
+        var moved = ApplyAdvection();
 
+        var consumed = false;
         if (_drainActive)
         {
             _drainOpenFrames++;
-            changed |= ApplyDrain();
-            changed |= ApplyTangential();
+            consumed = ApplyDrain();
         }
 
-        changed |= ApplyLateralX();
-        changed |= ApplyLateralY();
-
         var basinFull = IsBasinFull();
+        var refilled = false;
         if (!_drainActive && !basinFull)
         {
-            changed |= ApplyRefill();
+            refilled = ApplyRefill();
         }
         else
         {
@@ -252,20 +240,23 @@ internal sealed class WhirlpoolPage : IStressPage
             _inletGap = 0;
         }
 
-        _quiescent = !changed && !_drainActive && basinFull;
+        _quiescent = !_drainActive
+                     && basinFull
+                     && !moved
+                     && !consumed
+                     && !refilled
+                     && AllVelocitiesQuiescent();
     }
 
-    // ----------------------------------------------------------------
-    // Column helpers — keep the bitmap representation consistent.
-    // Voxels stack from bit 0 (floor) upward, so a column of height h
-    // is (1 << h) - 1. PopCount gives the height in O(1) hardware op.
-    // ----------------------------------------------------------------
-    private static int Height(uint col) => BitOperations.PopCount(col);
-    private static uint MakeCol(int height)
+    private bool AllVelocitiesQuiescent()
     {
-        if (height <= 0) return 0u;
-        if (height >= D) return FullColumn;
-        return (1u << height) - 1u;
+        var vx = _vx; var vy = _vy;
+        for (var i = 0; i < vx.Length; i++)
+        {
+            if (vx[i] > VelocityFloor || vx[i] < -VelocityFloor) return false;
+            if (vy[i] > VelocityFloor || vy[i] < -VelocityFloor) return false;
+        }
+        return true;
     }
 
     private float CurrentDrainReach()
@@ -275,11 +266,179 @@ internal sealed class WhirlpoolPage : IStressPage
         return DrainReachInitial + (DrainReachMax - DrainReachInitial) * s;
     }
 
-    // ----------------------------------------------------------------
-    // Drain — remove the top voxel from a random sample of columns
-    // within a disc around the drain centre. The disc starts as a
-    // dimple and grows with the drain's reach.
-    // ----------------------------------------------------------------
+    /// <summary>
+    /// Per-cell acceleration: pressure gradient pushes velocity from
+    /// high water toward low water; while the drain is open each
+    /// cell within reach also receives a radial-inward + tangential
+    /// acceleration weighted by a Gaussian on its distance to the
+    /// drain centre. Boundaries reflect by mirroring the centre
+    /// height into the off-grid neighbour — so the wall pushes back
+    /// on water trying to flow into it.
+    /// </summary>
+    private void ApplyForces()
+    {
+        var dw = _dw; var dh = _dh;
+        var h = _height; var vx = _vx; var vy = _vy;
+        var drainOn = _drainActive;
+        var cx = (float)_drainCx;
+        var cy = (float)_drainCy;
+        var reach = CurrentDrainReach();
+        var twoR2 = 2f * reach * reach;
+        var skip2 = (3f * reach) * (3f * reach);
+        var pull = PullStrength * _strength;
+        var swirl = SwirlStrength * _strength;
+
+        for (var y = 0; y < dh; y++)
+        {
+            var row = y * dw;
+            for (var x = 0; x < dw; x++)
+            {
+                var i = row + x;
+                var hi = h[i];
+                int hL = x > 0 ? h[i - 1] : hi;
+                int hR = x + 1 < dw ? h[i + 1] : hi;
+                int hU = y > 0 ? h[i - dw] : hi;
+                int hD = y + 1 < dh ? h[i + dw] : hi;
+                var gradX = (hR - hL) * 0.5f;
+                var gradY = (hD - hU) * 0.5f;
+                vx[i] -= gradX * PressureGain;
+                vy[i] -= gradY * PressureGain;
+
+                if (drainOn)
+                {
+                    var dxc = x - cx;
+                    var dyc = y - cy;
+                    var d2 = dxc * dxc + dyc * dyc;
+                    if (d2 > skip2 || d2 < 0.1f) continue;
+                    var falloff = MathF.Exp(-d2 / twoR2);
+                    var invR = 1f / MathF.Sqrt(d2);
+                    var inX = -dxc * invR;
+                    var inY = -dyc * invR;
+                    var tX = -dyc * invR; // CCW tangential
+                    var tY =  dxc * invR;
+                    vx[i] += (pull * inX + swirl * tX) * falloff;
+                    vy[i] += (pull * inY + swirl * tY) * falloff;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Multiplicative velocity damping with a hard cap and a small
+    /// floor that zeroes near-quiescent noise. SIMD-friendly tight
+    /// loop with no branches inside the cap; on .NET 8+ this could
+    /// be vectorised over Vector&lt;float&gt;.
+    /// </summary>
+    private void ApplyDamping()
+    {
+        var vx = _vx; var vy = _vy;
+        var n = vx.Length;
+        for (var i = 0; i < n; i++)
+        {
+            var x = vx[i] * Damping;
+            var y = vy[i] * Damping;
+            if (x >  MaxSpeed) x =  MaxSpeed;
+            if (x < -MaxSpeed) x = -MaxSpeed;
+            if (y >  MaxSpeed) y =  MaxSpeed;
+            if (y < -MaxSpeed) y = -MaxSpeed;
+            if (x > -VelocityFloor && x < VelocityFloor) x = 0f;
+            if (y > -VelocityFloor && y < VelocityFloor) y = 0f;
+            vx[i] = x;
+            vy[i] = y;
+        }
+    }
+
+    /// <summary>
+    /// Integer-voxel flux advection. For each X edge (between cells
+    /// i and i+1 in the same row) and each Y edge (between cells i
+    /// and i+_dw in the same column) we compute the volumetric flux
+    /// as <c>avg(velocity) × upwind(height)</c>, accumulate it on a
+    /// per-edge float, and transfer one voxel whenever the
+    /// accumulator crosses ±1. Returns true if any voxel moved.
+    /// </summary>
+    private bool ApplyAdvection()
+    {
+        var dw = _dw; var dh = _dh;
+        var h = _height; var vx = _vx; var vy = _vy;
+        var ax = _flowAccX; var ay = _flowAccY;
+        var moved = false;
+
+        // X edges within each row.
+        for (var y = 0; y < dh; y++)
+        {
+            var row = y * dw;
+            for (var x = 0; x + 1 < dw; x++)
+            {
+                var i = row + x;
+                var j = i + 1;
+                var v = (vx[i] + vx[j]) * 0.5f;
+                var acc = ax[i];
+                if (v == 0f && acc == 0f) continue;
+                var hUp = v >= 0f ? h[i] : h[j];
+                acc += v * hUp;
+                while (acc >= 1f)
+                {
+                    if (h[i] > 0 && h[j] < DShort)
+                    {
+                        h[i]--; h[j]++;
+                        acc -= 1f;
+                        moved = true;
+                    }
+                    else { acc = 0f; break; }
+                }
+                while (acc <= -1f)
+                {
+                    if (h[j] > 0 && h[i] < DShort)
+                    {
+                        h[j]--; h[i]++;
+                        acc += 1f;
+                        moved = true;
+                    }
+                    else { acc = 0f; break; }
+                }
+                ax[i] = acc;
+            }
+        }
+
+        // Y edges within each column.
+        for (var y = 0; y + 1 < dh; y++)
+        {
+            var row = y * dw;
+            for (var x = 0; x < dw; x++)
+            {
+                var i = row + x;
+                var j = i + dw;
+                var v = (vy[i] + vy[j]) * 0.5f;
+                var acc = ay[i];
+                if (v == 0f && acc == 0f) continue;
+                var hUp = v >= 0f ? h[i] : h[j];
+                acc += v * hUp;
+                while (acc >= 1f)
+                {
+                    if (h[i] > 0 && h[j] < DShort)
+                    {
+                        h[i]--; h[j]++;
+                        acc -= 1f;
+                        moved = true;
+                    }
+                    else { acc = 0f; break; }
+                }
+                while (acc <= -1f)
+                {
+                    if (h[j] > 0 && h[i] < DShort)
+                    {
+                        h[j]--; h[i]++;
+                        acc += 1f;
+                        moved = true;
+                    }
+                    else { acc = 0f; break; }
+                }
+                ay[i] = acc;
+            }
+        }
+        return moved;
+    }
+
     private bool ApplyDrain()
     {
         var reach = CurrentDrainReach();
@@ -305,150 +464,20 @@ internal sealed class WhirlpoolPage : IStressPage
             var dy = ry - _drainCy;
             if (dx * dx + dy * dy > discR2) continue;
             var i = ry * _dw + rx;
-            var col = _columns[i];
-            if (col == 0u) continue;
-            // Remove the top voxel (column height shrinks by one).
-            _columns[i] = MakeCol(Height(col) - 1);
-            changed = true;
-        }
-        return changed;
-    }
-
-    // ----------------------------------------------------------------
-    // Tangential rotation — for columns near the drain, with
-    // Gaussian-falloff probability donate one voxel to the neighbour
-    // in the tangential (perpendicular-to-radial) direction. This is
-    // what makes the water visibly spin into the hole.
-    // ----------------------------------------------------------------
-    private bool ApplyTangential()
-    {
-        var cx = (float)_drainCx;
-        var cy = (float)_drainCy;
-        var reach = CurrentDrainReach();
-        var twoReach2 = 2f * reach * reach;
-        var skip2 = (3f * reach) * (3f * reach);
-        var biasPeak = TangentialBiasBase * _strength;
-        var changed = false;
-
-        for (var y = 0; y < _dh; y++)
-        {
-            var dyc = y - cy;
-            var row = y * _dw;
-            for (var x = 0; x < _dw; x++)
+            if (_height[i] > 0)
             {
-                var dxc = x - cx;
-                var d2 = dxc * dxc + dyc * dyc;
-                if (d2 > skip2 || d2 < 0.5f) continue;
-                var prob = biasPeak * MathF.Exp(-d2 / twoReach2);
-                if (NextFloat() > prob) continue;
-
-                var r = MathF.Sqrt(d2);
-                // Tangential = perpendicular to radial (CCW): rotate
-                // (dxc/r, dyc/r) by 90°.
-                var tx = -dyc / r;
-                var ty = dxc / r;
-                var nx = x + (tx > 0.4f ? 1 : tx < -0.4f ? -1 : 0);
-                var ny = y + (ty > 0.4f ? 1 : ty < -0.4f ? -1 : 0);
-                if (nx == x && ny == y) continue;
-                if ((uint)nx >= (uint)_dw || (uint)ny >= (uint)_dh) continue;
-
-                var srcIdx = row + x;
-                var dstIdx = ny * _dw + nx;
-                var srcH = Height(_columns[srcIdx]);
-                var dstH = Height(_columns[dstIdx]);
-                if (srcH == 0 || dstH >= D) continue;
-                _columns[srcIdx] = MakeCol(srcH - 1);
-                _columns[dstIdx] = MakeCol(dstH + 1);
+                _height[i]--;
                 changed = true;
             }
         }
         return changed;
     }
 
-    // ----------------------------------------------------------------
-    // Lateral pressure on the X axis. Two phases: process pairs
-    // starting at even x, then pairs starting at odd x. Race-free
-    // because no column appears in two pairs in the same phase.
-    // ----------------------------------------------------------------
-    private bool ApplyLateralX()
-    {
-        var changed = false;
-        for (var phase = 0; phase < 2; phase++)
-        {
-            for (var y = 0; y < _dh; y++)
-            {
-                var row = y * _dw;
-                for (var x = phase; x + 1 < _dw; x += 2)
-                {
-                    var i = row + x;
-                    var j = i + 1;
-                    var ha = Height(_columns[i]);
-                    var hb = Height(_columns[j]);
-                    var diff = ha - hb;
-                    if (diff > LateralThreshold)
-                    {
-                        _columns[i] = MakeCol(ha - 1);
-                        _columns[j] = MakeCol(hb + 1);
-                        changed = true;
-                    }
-                    else if (diff < -LateralThreshold)
-                    {
-                        _columns[i] = MakeCol(ha + 1);
-                        _columns[j] = MakeCol(hb - 1);
-                        changed = true;
-                    }
-                }
-            }
-        }
-        return changed;
-    }
-
-    private bool ApplyLateralY()
-    {
-        var changed = false;
-        for (var phase = 0; phase < 2; phase++)
-        {
-            for (var y = phase; y + 1 < _dh; y += 2)
-            {
-                var row = y * _dw;
-                var nextRow = row + _dw;
-                for (var x = 0; x < _dw; x++)
-                {
-                    var i = row + x;
-                    var j = nextRow + x;
-                    var ha = Height(_columns[i]);
-                    var hb = Height(_columns[j]);
-                    var diff = ha - hb;
-                    if (diff > LateralThreshold)
-                    {
-                        _columns[i] = MakeCol(ha - 1);
-                        _columns[j] = MakeCol(hb + 1);
-                        changed = true;
-                    }
-                    else if (diff < -LateralThreshold)
-                    {
-                        _columns[i] = MakeCol(ha + 1);
-                        _columns[j] = MakeCol(hb - 1);
-                        changed = true;
-                    }
-                }
-            }
-        }
-        return changed;
-    }
-
-    // ----------------------------------------------------------------
-    // Refill — drip InletVoxelsPerFrame voxels into a small disc
-    // around a roaming inlet point, picking a fresh point every
-    // InletLifetime frames with a short cooldown between.
-    // ----------------------------------------------------------------
     private bool ApplyRefill()
     {
         if (_inletAge == 0)
         {
             if (_inletGap > 0) { _inletGap--; return false; }
-            // New inlet anywhere in the interior — gives a "rain
-            // dropping into the tank" feel rather than only edges.
             _inletX = NextFloat() * _dw;
             _inletY = NextFloat() * _dh;
         }
@@ -459,7 +488,6 @@ internal sealed class WhirlpoolPage : IStressPage
             _inletGap = InletGapMin + (int)(NextFloat() * (InletGapMax - InletGapMin + 1));
             return false;
         }
-
         var r = InletRadius;
         var r2 = r * r;
         var x0 = Math.Max(0, (int)(_inletX - r));
@@ -479,51 +507,44 @@ internal sealed class WhirlpoolPage : IStressPage
             var dy = ry - _inletY;
             if (dx * dx + dy * dy > r2) continue;
             var i = ry * _dw + rx;
-            var col = _columns[i];
-            var h = Height(col);
-            if (h >= D) continue;
-            _columns[i] = MakeCol(h + 1);
-            changed = true;
+            if (_height[i] < DShort)
+            {
+                _height[i]++;
+                changed = true;
+            }
         }
         return changed;
     }
 
     private bool IsBasinFull()
     {
-        var cols = _columns;
-        for (var i = 0; i < cols.Length; i++)
+        var h = _height;
+        for (var i = 0; i < h.Length; i++)
         {
-            if (cols[i] != FullColumn) return false;
+            if (h[i] != DShort) return false;
         }
         return true;
     }
 
-    // ----------------------------------------------------------------
-    // Rendering — top-down. Walls drawn as a solid border, interior
-    // sub-cells coloured by column height. Open drain hole rendered
-    // as a dark dot on the floor at the drain cell.
-    // ----------------------------------------------------------------
     private void DrawTank(Surface surface)
     {
         var w = surface.Width;
-        var h = surface.Height;
+        var hsz = surface.Height;
 
-        // Walls — top, bottom, left, right.
         for (var x = 0; x < w; x++)
         {
             surface[x, 0] = new SurfaceCell("▄", WallColour, WallTrim);
-            surface[x, h - 1] = new SurfaceCell("▀", WallColour, WallTrim);
+            surface[x, hsz - 1] = new SurfaceCell("▀", WallColour, WallTrim);
         }
-        for (var y = 1; y < h - 1; y++)
+        for (var y = 1; y < hsz - 1; y++)
         {
             surface[0, y] = new SurfaceCell("█", WallColour, WallColour);
             surface[w - 1, y] = new SurfaceCell("█", WallColour, WallColour);
         }
 
-        // Interior — half-block per cell from two stacked sub-cells.
         var dw = _dw;
-        var cols = _columns;
-        for (var cy = WallCells; cy < h - WallCells; cy++)
+        var heights = _height;
+        for (var cy = WallCells; cy < hsz - WallCells; cy++)
         {
             var iy = cy - WallCells;
             var topRow = (iy * 2) * dw;
@@ -531,35 +552,24 @@ internal sealed class WhirlpoolPage : IStressPage
             for (var cx = WallCells; cx < w - WallCells; cx++)
             {
                 var ix = cx - WallCells;
-                var hTop = Height(cols[topRow + ix]);
-                var hBot = Height(cols[botRow + ix]);
                 surface[cx, cy] = new SurfaceCell("▀",
-                    DepthColour(hTop), DepthColour(hBot));
+                    DepthColour(heights[topRow + ix]),
+                    DepthColour(heights[botRow + ix]));
             }
         }
 
-        // Drain hole — a dark dot on the tank floor at the drain
-        // location, visible when the drain is open. Sits on top of
-        // the half-block water so you can see it through whatever
-        // water depth remains.
         if (_drainActive)
         {
             var holeCx = _drainCx + WallCells;
             var holeCy = _drainCy / 2 + WallCells;
             if (holeCx >= WallCells && holeCx < w - WallCells
-                && holeCy >= WallCells && holeCy < h - WallCells)
+                && holeCy >= WallCells && holeCy < hsz - WallCells)
             {
                 var iy = holeCy - WallCells;
-                var topRow = (iy * 2) * dw;
                 var botRow = (iy * 2 + 1) * dw;
                 var ix = holeCx - WallCells;
-                var hTop = Height(cols[topRow + ix]);
-                var hBot = Height(cols[botRow + ix]);
                 surface[holeCx, holeCy] = new SurfaceCell("◉",
-                    HoleColour, DepthColour(hBot == 0 ? 0 : hBot));
-                // Suppress: keep DepthColour(hTop) ignored for the
-                // foreground because the glyph is the hole indicator.
-                _ = hTop;
+                    HoleColour, DepthColour(heights[botRow + ix]));
             }
         }
     }

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -9,35 +9,39 @@ namespace PerfStressDemo;
 /// <summary>
 /// Page 3 — "Whirlpool".
 ///
-/// A particle system in which ~3000 single-glyph particles drift across the
-/// screen and are pulled toward a user-controllable gravity well. As they
-/// approach the well a tangential force gives them an orbital spin, so the
-/// late-stage motion looks like matter spiralling into a black hole. When a
-/// particle crosses the swallow radius (or sails off-screen) it respawns at
-/// a random edge with a small inward velocity and a fresh glyph.
+/// A fluid-like field of one character per cell. By default everything sits
+/// still in a uniform grid. <b>Left click</b> opens a gravity well at the
+/// cursor: characters are pulled in (with a tangential swirl giving the
+/// spiral), and the void created at the centre propagates outward as a
+/// pressure-gradient — overlapping/compressed particles push toward
+/// lower-density neighbours, which keeps the field flowing toward the hole.
+/// Particles that fall in are respawned at a random edge. <b>Right click</b>
+/// turns the well off and the field settles wherever it landed (damping
+/// kills residual velocity in a few seconds).
 ///
 /// Controls:
-///   * Left click — relocate the well to the cursor.
-///   * Scroll wheel — adjust well strength (up = stronger pull, down = weaker).
+///   * Left click   — place/move the well (activates it).
+///   * Right click  — remove the well; field stabilises.
+///   * Scroll wheel — adjust well strength.
 ///
-/// Stress profile: every particle is recomputed every frame and every
-/// particle writes one cell, so the surface is touched ~3000 times/frame
-/// at scattered positions. This exercises the renderer's sparse-update path
-/// rather than the bulk-fill path the other pages hit.
+/// Stress profile: ~w·h particles updated every frame, density binning
+/// over a w·h grid each frame, plus one sparse cell write per particle.
+/// Exercises scattered writes + a tight integer-accumulation pass over a
+/// surface-sized buffer.
 /// </summary>
 internal sealed class WhirlpoolPage : IStressPage
 {
     public string Name => "Whirlpool";
 
     public string Description =>
-        "Particle system pulled toward a mouse-controlled gravity well. "
-        + "Click to reposition, scroll to adjust strength.";
+        "Pressure-driven character field. Left click to open a gravity well, "
+        + "right click to remove it. Scroll adjusts strength.";
 
-    // --------------------------------------------------------------
-    // Particle storage (Struct-of-Arrays for cache friendliness in
-    // the hot per-frame loop — we touch every particle's px/py/vx/vy
-    // sequentially each step).
-    // --------------------------------------------------------------
+    // ----------------------------------------------------------------
+    // Particle storage. Struct-of-Arrays — the hot loop touches each
+    // field independently, so packed parallel arrays are kinder to the
+    // cache than an array of structs.
+    // ----------------------------------------------------------------
     private float[] _px = Array.Empty<float>();
     private float[] _py = Array.Empty<float>();
     private float[] _vx = Array.Empty<float>();
@@ -47,34 +51,47 @@ internal sealed class WhirlpoolPage : IStressPage
     private int _surfaceWidth;
     private int _surfaceHeight;
 
-    // Well state. Mutated by mouse bindings; read by the sim each frame.
-    // Negative coords sentinel = not yet positioned (centred on first frame).
-    private float _wellX = -1;
-    private float _wellY = -1;
-    // Per-frame strength multiplier. The radial pull is roughly
-    // strength * size² / r, where strength scales the magnitude.
-    // 1.0 is a noticeable pull at typical screen sizes; the user can tune
-    // via scroll. Clamped to a sensible range.
+    // Density grid: how many particles currently occupy each cell.
+    // Recomputed from scratch every frame; gradients drive the pressure
+    // force that redistributes the fluid toward low-density regions.
+    private int[] _density = Array.Empty<int>();
+
+    // Well state. _wellActive gates the entire pull/spin/swallow path.
+    // When inactive only the pressure + damping terms run, so the field
+    // settles into whatever shape it had when the user right-clicked.
+    private bool _wellActive;
+    private float _wellX;
+    private float _wellY;
+    // User-adjustable strength multiplier (scroll wheel). Multiplicative
+    // scrolling so the same number of notches has the same perceptual
+    // effect at any starting value. Clamped to a usable range.
     private float _strength = 1.0f;
     private const float MinStrength = 0.2f;
-    private const float MaxStrength = 8.0f;
+    private const float MaxStrength = 6.0f;
 
-    // Physics constants.
-    private const float Damping = 0.985f;            // mild — we *want* fast in-fall
-    private const float MaxSpeed = 8.0f;             // cells per frame, hard clamp
-    private const float SwallowRadius = 1.5f;        // particles closer than this respawn
-    private const float MinPullDistance = 2.5f;      // floor for r in pull calc — avoids /0 spikes
-    private const float SpinRatio = 0.85f;           // tangential / radial; 0 = pure radial, 1 = circular
-    private const float ParticlesPerCell = 0.5f;     // density (~3200 for 80×40)
+    // ----------------------------------------------------------------
+    // Physics constants. The whole point of this page is to be SLOW
+    // enough that you can track individual characters, so MaxSpeed is
+    // tiny and damping is aggressive — set these too high and the
+    // visual reads as snow rather than fluid.
+    // ----------------------------------------------------------------
+    private const float MaxSpeed = 0.35f;        // cells per frame, hard clamp
+    private const float Damping = 0.94f;         // per-frame velocity multiplier
+    private const float SwallowRadius = 1.2f;    // particle this close to well -> respawn
+    private const float MinPullDistance = 2.0f;  // floor on r in the 1/r pull law
+    private const float SpinRatio = 0.85f;       // tangential / radial force ratio
+    private const float PressureK = 0.04f;       // how hard density gradients push
+    // sizeFactor coefficient — kept low so default strength feels right
+    // even on big monitors. The displayed strength is normalised by this
+    // so different screens behave consistently.
+    private const float SizeFactor = 0.05f;
 
-    // Glyph palette. Mix of small, dense, and "streak"-looking ASCII so
-    // moving particles read as bits of matter, not just dots. Excludes
-    // wide chars and whitespace.
+    // Glyph palette — kept narrow and mostly punctuation so motion reads
+    // as discrete bits of debris. Excludes whitespace and wide chars.
     private static readonly string[] s_glyphs = BuildGlyphs();
 
     private static string[] BuildGlyphs()
     {
-        // Pre-cached so particle draws are allocation-free.
         const string source = ".,'`*+/\\|-_~:;!?o0aXxv^=<>#%&";
         var arr = new string[source.Length];
         for (var i = 0; i < source.Length; i++)
@@ -82,13 +99,12 @@ internal sealed class WhirlpoolPage : IStressPage
         return arr;
     }
 
-    // Deterministic-ish RNG state for respawns. Not security-critical;
-    // xorshift32 keeps the hot path allocation-free.
+    // xorshift32 RNG — allocation-free, deterministic seed for reproducible
+    // initial scatter.
     private uint _rng = 0xCAFEBABEu;
 
     private uint NextRandom()
     {
-        // xorshift32 — small, fast, good enough for visual jitter.
         var x = _rng;
         x ^= x << 13;
         x ^= x >> 17;
@@ -105,27 +121,31 @@ internal sealed class WhirlpoolPage : IStressPage
             .Surface(layer =>
             {
                 EnsureField(layer.Width, layer.Height);
-                // First-frame centring: drop the well in the middle until
-                // the user clicks somewhere.
-                if (_wellX < 0)
-                {
-                    _wellX = layer.Width * 0.5f;
-                    _wellY = layer.Height * 0.5f;
-                }
                 Step();
                 return new[] { layer.Layer(DrawParticles) };
             })
             .InputBindings(bindings =>
             {
+                // Left click: position the well at the cursor and activate
+                // it. Subsequent clicks just relocate.
                 bindings.Mouse(MouseButton.Left).Action(ctx =>
                 {
                     if (ctx.MouseX < 0 || ctx.MouseY < 0) return;
                     _wellX = ctx.MouseX;
                     _wellY = ctx.MouseY;
+                    _wellActive = true;
                 });
-                // Scroll up = stronger pull, scroll down = weaker.
-                // Multiplicative so it feels exponential — a few notches
-                // visibly change behaviour without bottoming out.
+
+                // Right click: kill the well. Existing particles keep
+                // their velocity and damping settles them; pressure
+                // pushes residual clumps back toward uniformity.
+                bindings.Mouse(MouseButton.Right).Action(_ =>
+                {
+                    _wellActive = false;
+                });
+
+                // Scroll wheel: strength. Multiplicative so a couple of
+                // notches visibly changes feel.
                 bindings.Mouse(MouseButton.ScrollUp).Action(_ =>
                 {
                     _strength = Math.Min(MaxStrength, _strength * 1.2f);
@@ -141,6 +161,9 @@ internal sealed class WhirlpoolPage : IStressPage
     /// <summary>Status-bar label exposing current strength.</summary>
     public static float CurrentStrength { get; private set; } = 1.0f;
 
+    /// <summary>Status-bar label: whether the well is currently active.</summary>
+    public static bool WellActive { get; private set; }
+
     private void EnsureField(int w, int h)
     {
         if (_surfaceWidth == w && _surfaceHeight == h && _px.Length > 0)
@@ -148,145 +171,202 @@ internal sealed class WhirlpoolPage : IStressPage
 
         _surfaceWidth = w;
         _surfaceHeight = h;
-        _count = Math.Max(64, (int)(w * h * ParticlesPerCell));
-
-        // Reallocate arrays to fit the new count. We don't try to pool
-        // these — resizes are rare (resize-only) and the simulation
-        // resumes from a fresh scatter, which is fine since the previous
-        // arrangement is meaningless at a different resolution anyway.
+        // One particle per cell — a fully populated grid is what makes the
+        // pressure model sensible (gradients are well-defined) and gives
+        // the user the "I can see the whole fluid" feel they asked for.
+        _count = w * h;
         _px = new float[_count];
         _py = new float[_count];
         _vx = new float[_count];
         _vy = new float[_count];
         _glyphIdx = new byte[_count];
+        _density = new int[w * h];
 
-        for (var i = 0; i < _count; i++)
+        // Initial scatter: one particle at the centre of each cell, with
+        // zero velocity and a random glyph. With no well and zero motion
+        // density is uniform 1 per cell, gradients are zero everywhere,
+        // and nothing moves until the user clicks.
+        var idx = 0;
+        for (var y = 0; y < h; y++)
         {
-            _px[i] = NextFloat() * w;
-            _py[i] = NextFloat() * h;
-            // Small initial drift so things move on frame 1.
-            _vx[i] = (NextFloat() - 0.5f) * 0.4f;
-            _vy[i] = (NextFloat() - 0.5f) * 0.4f;
-            _glyphIdx[i] = (byte)(NextRandom() % (uint)s_glyphs.Length);
+            for (var x = 0; x < w; x++)
+            {
+                _px[idx] = x + 0.5f;
+                _py[idx] = y + 0.5f;
+                _vx[idx] = 0;
+                _vy[idx] = 0;
+                _glyphIdx[idx] = (byte)(NextRandom() % (uint)s_glyphs.Length);
+                idx++;
+            }
         }
     }
 
     private void Step()
     {
         if (_count == 0) return;
-        CurrentStrength = _strength;
 
         var w = _surfaceWidth;
         var h = _surfaceHeight;
-        var wx = _wellX;
-        var wy = _wellY;
-        var s = _strength;
-        // Radial pull magnitude = s * sizeFactor / max(r, MinPullDistance).
-        // sizeFactor scales with surface area so the same `strength` value
-        // feels equivalent across a small laptop terminal and a giant
-        // external monitor — without it, large screens make the well
-        // feel weak because particles are mostly far away.
-        var sizeFactor = MathF.Sqrt(w * h) * 0.25f;
-        var pullScale = s * sizeFactor;
-        var spinScale = pullScale * SpinRatio;
-        var swallowSq = SwallowRadius * SwallowRadius;
 
+        // -------- 1. Rebuild density grid --------
+        // Zero it (Array.Clear is JIT-optimised to memset) then bin each
+        // particle into the cell it currently occupies.
+        Array.Clear(_density, 0, _density.Length);
         for (var i = 0; i < _count; i++)
         {
-            var dx = wx - _px[i];
-            var dy = wy - _py[i];
-            var rSq = dx * dx + dy * dy;
-            if (rSq < swallowSq)
+            var cx = (int)_px[i];
+            var cy = (int)_py[i];
+            if ((uint)cx >= (uint)w || (uint)cy >= (uint)h) continue;
+            _density[cy * w + cx]++;
+        }
+
+        // -------- 2. Precompute well-related scalars --------
+        // sizeFactor scales the absolute pull magnitude with surface area
+        // so the user's chosen strength feels equivalent on small and
+        // large terminals.
+        var sizeFactor = MathF.Sqrt(w * h) * SizeFactor;
+        var pullScale = _strength * sizeFactor;
+        var spinScale = pullScale * SpinRatio;
+        var swallowSq = SwallowRadius * SwallowRadius;
+        var wellActive = _wellActive;
+        var wx = _wellX;
+        var wy = _wellY;
+
+        // Expose to status bar.
+        CurrentStrength = _strength;
+        WellActive = wellActive;
+
+        // -------- 3. Per-particle update --------
+        for (var i = 0; i < _count; i++)
+        {
+            var px = _px[i];
+            var py = _py[i];
+            var vx = _vx[i];
+            var vy = _vy[i];
+
+            // Pressure gradient at the particle's current cell. We use
+            // central differences in the density grid: high density to
+            // one side pushes the particle the other way. Clamp the
+            // sample coords so the boundary doesn't sample out of bounds.
+            var cx = (int)px;
+            var cy = (int)py;
+            if ((uint)cx < (uint)w && (uint)cy < (uint)h)
             {
-                Respawn(i);
-                continue;
+                var xl = cx > 0 ? cx - 1 : cx;
+                var xr = cx < w - 1 ? cx + 1 : cx;
+                var yu = cy > 0 ? cy - 1 : cy;
+                var yd = cy < h - 1 ? cy + 1 : cy;
+                var gx = _density[cy * w + xr] - _density[cy * w + xl];
+                var gy = _density[yd * w + cx] - _density[yu * w + cx];
+                // Force points from high density toward low density.
+                vx -= PressureK * gx;
+                vy -= PressureK * gy;
             }
 
-            var r = MathF.Sqrt(rSq);
-            var rEff = r < MinPullDistance ? MinPullDistance : r;
-            var invR = 1f / rEff;
-            // Unit vector toward the well.
-            var ux = dx * invR;
-            var uy = dy * invR;
-            // Tangential unit vector — rotate (ux,uy) 90° CCW so the spiral
-            // always winds the same direction (visually consistent).
-            var tx = -uy;
-            var ty = ux;
+            if (wellActive)
+            {
+                var dx = wx - px;
+                var dy = wy - py;
+                var rSq = dx * dx + dy * dy;
+                if (rSq < swallowSq)
+                {
+                    Respawn(i);
+                    continue;
+                }
+                var r = MathF.Sqrt(rSq);
+                var rEff = r < MinPullDistance ? MinPullDistance : r;
+                var invR = 1f / rEff;
+                var ux = dx * invR;
+                var uy = dy * invR;
+                // Tangential (CCW rotation) gives the spiral. Same 1/r
+                // falloff so the outer field stays alive — physical 1/r²
+                // goes inert far from the well and the wider field looks
+                // dead.
+                var tx = -uy;
+                var ty = ux;
+                var a = pullScale * invR;
+                var at = spinScale * invR;
+                vx += ux * a + tx * at;
+                vy += uy * a + ty * at;
+            }
 
-            // Acceleration: radial pull + tangential swirl. Both fall off
-            // as 1/r so the inner orbit accelerates dramatically. The pure
-            // 1/r law isn't physical for gravity (which is 1/r²) but reads
-            // much better visually — the outer field stays alive instead
-            // of going inert.
-            var a = pullScale * invR;
-            var at = spinScale * invR;
-            _vx[i] += (ux * a + tx * at);
-            _vy[i] += (uy * a + ty * at);
+            // Damping. With the well off this is the only velocity
+            // change, so the field settles into stillness in a couple
+            // of seconds. With the well on, damping bounds the slingshot
+            // effect of close approaches.
+            vx *= Damping;
+            vy *= Damping;
 
-            // Damping prevents runaway escapes from the slingshot effect
-            // of the inner orbit.
-            _vx[i] *= Damping;
-            _vy[i] *= Damping;
-
-            // Clamp speed so a particle that nearly grazes the well doesn't
-            // teleport across the screen in one frame.
-            var sp2 = _vx[i] * _vx[i] + _vy[i] * _vy[i];
+            // Speed clamp. Tiny — the whole point of this page is that
+            // the user can follow individual glyphs as they drift.
+            var sp2 = vx * vx + vy * vy;
             if (sp2 > MaxSpeed * MaxSpeed)
             {
                 var sc = MaxSpeed / MathF.Sqrt(sp2);
-                _vx[i] *= sc;
-                _vy[i] *= sc;
+                vx *= sc;
+                vy *= sc;
             }
 
-            _px[i] += _vx[i];
-            _py[i] += _vy[i];
+            px += vx;
+            py += vy;
 
-            // Out-of-bounds → respawn at the edge.
-            if (_px[i] < 0 || _px[i] >= w || _py[i] < 0 || _py[i] >= h)
-                Respawn(i);
+            // Boundary handling depends on whether the well is on.
+            // With the well active, OOB particles respawn at an edge so
+            // the fluid keeps flowing in. Without the well there's no
+            // sink so it'd be wrong to teleport: just clamp the position
+            // and zero the corresponding velocity component so things
+            // come to rest against the wall.
+            if (wellActive)
+            {
+                if (px < 0 || px >= w || py < 0 || py >= h)
+                {
+                    Respawn(i);
+                    continue;
+                }
+            }
+            else
+            {
+                if (px < 0) { px = 0; vx = 0; }
+                else if (px >= w) { px = w - 0.001f; vx = 0; }
+                if (py < 0) { py = 0; vy = 0; }
+                else if (py >= h) { py = h - 0.001f; vy = 0; }
+            }
+
+            _px[i] = px;
+            _py[i] = py;
+            _vx[i] = vx;
+            _vy[i] = vy;
         }
     }
 
     private void Respawn(int i)
     {
-        // Pick a random edge: 0=top, 1=bottom, 2=left, 3=right.
-        var edge = NextRandom() & 3;
         var w = _surfaceWidth;
         var h = _surfaceHeight;
+        var edge = NextRandom() & 3;
+        const float Seed = 0.25f; // small inward push so they're visibly
+                                   // moving when they appear, but still
+                                   // slow enough to track.
         float px, py, vx, vy;
-        // Small inward velocity so they don't immediately satisfy the
-        // out-of-bounds check again on a frame where their position rounds
-        // wrong, and so the first few frames of motion are visible.
-        const float Seed = 0.6f;
-
         switch (edge)
         {
             case 0: // top
-                px = NextFloat() * w;
-                py = 0;
-                vx = (NextFloat() - 0.5f) * 0.3f;
-                vy = Seed;
+                px = NextFloat() * w; py = 0.1f;
+                vx = (NextFloat() - 0.5f) * 0.1f; vy = Seed;
                 break;
             case 1: // bottom
-                px = NextFloat() * w;
-                py = h - 1;
-                vx = (NextFloat() - 0.5f) * 0.3f;
-                vy = -Seed;
+                px = NextFloat() * w; py = h - 0.1f;
+                vx = (NextFloat() - 0.5f) * 0.1f; vy = -Seed;
                 break;
             case 2: // left
-                px = 0;
-                py = NextFloat() * h;
-                vx = Seed;
-                vy = (NextFloat() - 0.5f) * 0.3f;
+                px = 0.1f; py = NextFloat() * h;
+                vx = Seed; vy = (NextFloat() - 0.5f) * 0.1f;
                 break;
             default: // right
-                px = w - 1;
-                py = NextFloat() * h;
-                vx = -Seed;
-                vy = (NextFloat() - 0.5f) * 0.3f;
+                px = w - 0.1f; py = NextFloat() * h;
+                vx = -Seed; vy = (NextFloat() - 0.5f) * 0.1f;
                 break;
         }
-
         _px[i] = px;
         _py[i] = py;
         _vx[i] = vx;
@@ -300,35 +380,40 @@ internal sealed class WhirlpoolPage : IStressPage
         var h = surface.Height;
         var black = Hex1bColor.Black;
 
-        // Surfaces come out of the pool zeroed/blank, so we don't need to
-        // explicitly clear — but we *do* want a hint of texture (the well
-        // and a faint halo) before the particles go down. Keep this O(1):
-        // just stamp the well marker; the rest stays default.
-
+        // Draw each particle. Multiple particles overlapping the same
+        // cell just means the last write wins for the glyph; brightness
+        // comes from the density grid we already computed in Step, so
+        // compressed regions visibly brighten and depleted regions go
+        // dim — even though only one glyph shows, the density readout
+        // tells you a clump is here.
         for (var i = 0; i < _count; i++)
         {
             var x = (int)_px[i];
             var y = (int)_py[i];
             if ((uint)x >= (uint)w || (uint)y >= (uint)h) continue;
 
-            // Brightness rises with speed — fast inner-orbit streaks
-            // pop out from the slower outer drift.
-            var sp = MathF.Sqrt(_vx[i] * _vx[i] + _vy[i] * _vy[i]);
-            var t = sp / MaxSpeed;
-            if (t > 1f) t = 1f;
-            var level = (byte)(80 + (int)(175 * t));
+            var d = _density[y * w + x];
+            // Uniform density is 1; treat that as baseline grey. Stack
+            // up to ~6 deep before saturating to white.
+            var t = (d - 1) / 5f;
+            if (t < 0f) t = 0f;
+            else if (t > 1f) t = 1f;
+            var level = (byte)(120 + (int)(135 * t));
             var fg = Hex1bColor.FromRgb(level, level, level);
             surface[x, y] = new SurfaceCell(s_glyphs[_glyphIdx[i]], fg, black);
         }
 
-        // Well marker — bright red '@' on top of everything. Use integer
-        // floor to align with particle positions.
-        var wxI = (int)_wellX;
-        var wyI = (int)_wellY;
-        if ((uint)wxI < (uint)w && (uint)wyI < (uint)h)
+        // Well marker drawn last so it's always visible on top, but only
+        // when active. A right-clicked-off well leaves no visible cursor.
+        if (_wellActive)
         {
-            surface[wxI, wyI] = new SurfaceCell(
-                "@", Hex1bColor.FromRgb(255, 64, 64), black);
+            var wxI = (int)_wellX;
+            var wyI = (int)_wellY;
+            if ((uint)wxI < (uint)w && (uint)wyI < (uint)h)
+            {
+                surface[wxI, wyI] = new SurfaceCell(
+                    "@", Hex1bColor.FromRgb(255, 64, 64), black);
+            }
         }
     }
 }

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -99,13 +99,16 @@ internal sealed class WhirlpoolPage : IStressPage
     // already moves water from high to low, so a localised source is
     // enough — the fluid will visibly flow toward whatever cell has
     // the least water.
-    private const float InletInjectRate = 0.10f;    // per-frame approach toward MaxDepth at jet head
-    private const float InletRadius     = 5.0f;     // sub-cells (deposit radius around jet head)
-    private const int   InletLifetime   = 220;      // frames of the fade-in/peak/fade-out envelope
-    private const int   InletGapMin     = 20;
-    private const int   InletGapMax     = 70;
-    private const float InletJetSpeed   = 0.45f;    // sub-cells per frame — jet head march speed
-    private const float InletWaveImpulse = 0.18f;   // splat at jet head per frame, scaled by envelope
+    private const float InletInjectRate = 0.32f;    // per-frame approach toward MaxDepth at jet head
+    private const float InletRadius     = 7.5f;     // sub-cells (deposit radius around jet head)
+    private const int   InletLifetime   = 160;      // frames of the fade-in/peak/fade-out envelope
+    private const int   InletGapMin     = 0;
+    private const int   InletGapMax     = 10;
+    private const float InletJetSpeed   = 1.4f;     // sub-cells per frame — jet head march speed
+    private const float InletWaveImpulse = 0.55f;   // splat at jet head per frame, scaled by envelope
+    private const int   InletChopPerFrame = 8;      // turbulent chop sites sprayed around jet head
+    private const float InletChopRadius = 12f;      // radius (sub-cells) of the chop spray cloud
+    private const float InletChopAmplitude = 0.18f; // per-impulse amplitude of jet-head chop
 
     // ----------------------------------------------------------------
     // Physics constants — wave equation. Matches pond's "light"
@@ -500,17 +503,33 @@ internal sealed class WhirlpoolPage : IStressPage
         }
         else if (_inletEnvelope > 0f)
         {
-            // Refill — splat a positive impulse at the jet head and
-            // a smaller one offset further inward, producing a
-            // visible wave front that runs ahead of the deposit and
-            // sells the "water has velocity" feel.
+            // Refill — splat a strong positive impulse at the jet
+            // head plus a lead impulse further inward, and spray a
+            // cloud of turbulent chop around the head. Together
+            // these give the inlet a violent, churning, advancing
+            // wavefront instead of a polite bloom.
             var amp2 = _inletEnvelope * amp;
             var jx = (int)_jetX;
             var jy = (int)_jetY;
             Splat(wave, dw, dh, jx, jy, InletWaveImpulse * amp2);
-            var leadX = (int)(_jetX + _inletDirX * 3f);
-            var leadY = (int)(_jetY + _inletDirY * 3f);
-            Splat(wave, dw, dh, leadX, leadY, InletWaveImpulse * 0.6f * amp2);
+            var leadX = (int)(_jetX + _inletDirX * 4f);
+            var leadY = (int)(_jetY + _inletDirY * 4f);
+            Splat(wave, dw, dh, leadX, leadY, InletWaveImpulse * 0.75f * amp2);
+            var lead2X = (int)(_jetX + _inletDirX * 8f);
+            var lead2Y = (int)(_jetY + _inletDirY * 8f);
+            Splat(wave, dw, dh, lead2X, lead2Y, InletWaveImpulse * 0.4f * amp2);
+
+            // Turbulent spray — random chop around the jet head.
+            for (var k = 0; k < InletChopPerFrame; k++)
+            {
+                var rx = (NextFloat() * 2f - 1f) * InletChopRadius;
+                var ry = (NextFloat() * 2f - 1f) * InletChopRadius;
+                var cx = (int)(_jetX + rx);
+                var cy = (int)(_jetY + ry);
+                if ((uint)cx >= (uint)dw || (uint)cy >= (uint)dh) continue;
+                var sign = (NextRandom() & 1) == 0 ? 1f : -1f;
+                wave[cy * dw + cx] += InletChopAmplitude * amp2 * sign;
+            }
         }
 
         // Background ocean chop — small scattered impulses.

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -94,13 +94,18 @@ internal sealed class WhirlpoolPage : IStressPage
     private const float DiffusionK = 0.045f;
     private const float DrainRadius = 6.5f;        // sub-cells
     private const float DrainPerFrameBase = 0.32f;
-    // Refill (drain off): pull baseline toward MaxDepth at an edge-
-    // weighted rate so water visibly "flows in" from outside. Edge
-    // cells fill in ~1s, interior fills via diffusion + the small
-    // base rate over a few more seconds.
-    private const float RefillEdgeRate = 0.045f;
-    private const float RefillBaseRate = 0.004f;
-    private const int   RefillReachCells = 8;       // edge boost falls off over this many sub-cells
+    // Refill (drain off): water enters through a single roaming
+    // inlet that fades in/out on the edge of the basin. Diffusion
+    // already moves water from high to low, so a localised source is
+    // enough — the fluid will visibly flow toward whatever cell has
+    // the least water.
+    private const float InletInjectRate = 0.10f;    // per-frame approach toward MaxDepth at jet head
+    private const float InletRadius     = 5.0f;     // sub-cells (deposit radius around jet head)
+    private const int   InletLifetime   = 220;      // frames of the fade-in/peak/fade-out envelope
+    private const int   InletGapMin     = 20;
+    private const int   InletGapMax     = 70;
+    private const float InletJetSpeed   = 0.45f;    // sub-cells per frame — jet head march speed
+    private const float InletWaveImpulse = 0.18f;   // splat at jet head per frame, scaled by envelope
 
     // ----------------------------------------------------------------
     // Physics constants — wave equation. Matches pond's "light"
@@ -111,7 +116,6 @@ internal sealed class WhirlpoolPage : IStressPage
     private const float WaveDisplayScale = 0.32f;   // how much wave modulates rendered depth
     private const float WaveFloor = 0.005f;          // floor for "alive" tracking
     private const float DrainImpulse = -0.18f;       // per frame, at drain centre
-    private const float RefillImpulse = 0.12f;       // per frame, per active edge cell during refill
     private const float ChopAmplitude = 0.06f;       // random impulse magnitude while active
     private const int   ChopPerFrame = 4;            // random chop sites per frame while active
 
@@ -124,6 +128,21 @@ internal sealed class WhirlpoolPage : IStressPage
     private const float SinkStrength = 9.0f;
     private const float SwirlStrength = 18.0f;
     private const float VelocitySoftening = 2.5f;
+
+    // ----------------------------------------------------------------
+    // Inlet — one localised refill source at a time. Picked at random
+    // on the basin edge, fades in over its lifetime, then a short
+    // gap, then a new inlet at a new location.
+    // ----------------------------------------------------------------
+    private float _inletX;       // inlet spawn point (sub-cell coords)
+    private float _inletY;
+    private float _inletDirX;    // inward unit vector
+    private float _inletDirY;
+    private int _inletAge;       // frames since spawn, 0 if inactive
+    private int _inletGap;       // frames until next inlet spawns
+    private float _inletEnvelope; // 0..1 amplitude this frame
+    private float _jetX;         // current jet head position (sub-cell coords)
+    private float _jetY;
 
     // ----------------------------------------------------------------
     // Activity tracking. _activity ramps to 1 whenever something is
@@ -347,39 +366,115 @@ internal sealed class WhirlpoolPage : IStressPage
     }
 
     /// <summary>
-    /// Pulls the baseline back toward <see cref="MaxDepth"/> at a
-    /// rate that decays from the screen edge toward the interior.
-    /// Edge cells refill in roughly a second; interior cells rely on
-    /// diffusion (and a tiny base rate) to top up. <paramref name="basinFull"/>
-    /// is set true if every cell ended up within a small epsilon of
-    /// MaxDepth this frame — used by the activity tracker.
+    /// Drives baseline refill via a single localised inlet that
+    /// spawns at a random point on the basin edge, then marches a
+    /// "jet head" inward at <see cref="InletJetSpeed"/> sub-cells per
+    /// frame. Each frame we deposit water around the jet head and
+    /// raise the inlet's amplitude envelope (triangular over
+    /// <see cref="InletLifetime"/> frames). Diffusion does the rest
+    /// of the work — water flows from the freshly-injected region
+    /// toward whatever cells have the least depth. After the inlet
+    /// expires we wait <see cref="InletGapMin"/>..<see cref="InletGapMax"/>
+    /// frames and spawn a new one somewhere else.
+    /// <paramref name="basinFull"/> is set true if every cell ended
+    /// up within a small epsilon of MaxDepth — used by the activity
+    /// tracker so the page can eventually IsIdle.
     /// </summary>
     private bool ApplyRefill(float[] depth, int dw, int dh, out bool basinFull)
     {
-        var changed = false;
+        // Snapshot fullness before deposition so the inlet keeps
+        // running until the basin is truly full.
         basinFull = true;
-        var reach = RefillReachCells;
-        var edgeBoost = RefillEdgeRate - RefillBaseRate;
         var basMax = MaxDepth - 0.003f;
-        for (var y = 0; y < dh; y++)
+        for (var i = 0; i < depth.Length; i++)
         {
-            var rowBaseY = y * dw;
-            var ed_y = Math.Min(y, dh - 1 - y);
-            for (var x = 0; x < dw; x++)
+            if (depth[i] < basMax) { basinFull = false; break; }
+        }
+        if (basinFull)
+        {
+            _inletAge = 0;
+            _inletEnvelope = 0f;
+            return false;
+        }
+
+        // Inlet lifecycle.
+        if (_inletAge == 0)
+        {
+            if (_inletGap > 0) { _inletGap--; _inletEnvelope = 0f; return false; }
+            SpawnInlet(dw, dh);
+        }
+        _inletAge++;
+        if (_inletAge >= InletLifetime)
+        {
+            _inletAge = 0;
+            _inletEnvelope = 0f;
+            _inletGap = InletGapMin + (int)(NextFloat() * (InletGapMax - InletGapMin));
+            return false;
+        }
+
+        // Triangular envelope 0 → 1 → 0 over the inlet lifetime.
+        var t = _inletAge / (float)InletLifetime;
+        var env = 4f * t * (1f - t);
+        _inletEnvelope = env;
+
+        // March the jet head inward.
+        _jetX = _inletX + _inletDirX * InletJetSpeed * _inletAge;
+        _jetY = _inletY + _inletDirY * InletJetSpeed * _inletAge;
+
+        // Deposit baseline water at the jet head.
+        var rate = InletInjectRate * env;
+        var r = InletRadius;
+        var r2 = r * r;
+        var x0 = Math.Max(0, (int)(_jetX - r));
+        var x1 = Math.Min(dw - 1, (int)(_jetX + r + 0.5f));
+        var y0 = Math.Max(0, (int)(_jetY - r));
+        var y1 = Math.Min(dh - 1, (int)(_jetY + r + 0.5f));
+        var changed = false;
+        for (var y = y0; y <= y1; y++)
+        {
+            for (var x = x0; x <= x1; x++)
             {
-                var i = rowBaseY + x;
+                var dx = x - _jetX;
+                var dy = y - _jetY;
+                var d2 = dx * dx + dy * dy;
+                if (d2 > r2) continue;
+                var falloff = 1f - MathF.Sqrt(d2) / r;
+                var localRate = rate * falloff;
+                if (localRate <= 0f) continue;
+                var i = y * dw + x;
                 var d = depth[i];
-                if (d < basMax) basinFull = false;
-                var ed_x = Math.Min(x, dw - 1 - x);
-                var edgeDist = Math.Min(ed_x, ed_y);
-                var edgeFactor = edgeDist >= reach ? 0f : 1f - edgeDist / (float)reach;
-                var rate = RefillBaseRate + edgeBoost * edgeFactor;
-                var nv = d + (MaxDepth - d) * rate;
+                var nv = d + (MaxDepth - d) * localRate;
                 if (nv > MaxDepth) nv = MaxDepth;
                 if (nv != d) { depth[i] = nv; changed = true; }
             }
         }
         return changed;
+    }
+
+    /// <summary>
+    /// Picks a random spot on one of the four edges of the basin,
+    /// records the inward-pointing unit vector from that spot to the
+    /// basin centre, and resets the inlet age.
+    /// </summary>
+    private void SpawnInlet(int dw, int dh)
+    {
+        var edge = NextRandom() & 3;
+        switch (edge)
+        {
+            case 0: _inletX = NextFloat() * dw; _inletY = 0f; break;
+            case 1: _inletX = NextFloat() * dw; _inletY = dh - 1f; break;
+            case 2: _inletX = 0f; _inletY = NextFloat() * dh; break;
+            default: _inletX = dw - 1f; _inletY = NextFloat() * dh; break;
+        }
+        var cx = dw * 0.5f;
+        var cy = dh * 0.5f;
+        var dx = cx - _inletX;
+        var dy = cy - _inletY;
+        var len = MathF.Sqrt(dx * dx + dy * dy);
+        if (len < 1e-4f) { _inletDirX = 0f; _inletDirY = 1f; }
+        else { _inletDirX = dx / len; _inletDirY = dy / len; }
+        _jetX = _inletX;
+        _jetY = _inletY;
     }
 
     /// <summary>
@@ -403,24 +498,19 @@ internal sealed class WhirlpoolPage : IStressPage
             var imp = DrainImpulse * _strength * amp;
             Splat(wave, dw, dh, cx, cy, imp);
         }
-        else
+        else if (_inletEnvelope > 0f)
         {
-            // Refill — drop a few positive splashes along whichever
-            // edge the RNG picks each frame. Read as bubbling springs
-            // running inward.
-            for (var k = 0; k < 3; k++)
-            {
-                var edge = NextRandom() & 3;
-                int ex, ey;
-                switch (edge)
-                {
-                    case 0: ex = (int)(NextFloat() * dw); ey = 0; break;
-                    case 1: ex = (int)(NextFloat() * dw); ey = dh - 1; break;
-                    case 2: ex = 0; ey = (int)(NextFloat() * dh); break;
-                    default: ex = dw - 1; ey = (int)(NextFloat() * dh); break;
-                }
-                Splat(wave, dw, dh, ex, ey, RefillImpulse * amp);
-            }
+            // Refill — splat a positive impulse at the jet head and
+            // a smaller one offset further inward, producing a
+            // visible wave front that runs ahead of the deposit and
+            // sells the "water has velocity" feel.
+            var amp2 = _inletEnvelope * amp;
+            var jx = (int)_jetX;
+            var jy = (int)_jetY;
+            Splat(wave, dw, dh, jx, jy, InletWaveImpulse * amp2);
+            var leadX = (int)(_jetX + _inletDirX * 3f);
+            var leadY = (int)(_jetY + _inletDirY * 3f);
+            Splat(wave, dw, dh, leadX, leadY, InletWaveImpulse * 0.6f * amp2);
         }
 
         // Background ocean chop — small scattered impulses.

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -93,17 +93,17 @@ internal sealed class WhirlpoolPage : IStressPage
     private const float DrainReachMax       = 18f;
     private const int   DrainReachRampFrames = 300;
     private const float DrainDiscRadiusMax  = 10f;
-    private const float DrainDensity        = 0.35f;
-    private const float PullStrength        = 0.45f; // peak inward accel per frame at drain centre
-    private const float SwirlStrength       = 0.75f; // peak tangential accel per frame
+    private const float DrainDensity        = 0.75f;
+    private const float PullStrength        = 0.35f; // peak inward accel per frame at drain centre
+    private const float SwirlStrength       = 0.60f; // peak tangential accel per frame
 
     // ----------------------------------------------------------------
     // Shallow-water dynamics. Tune for visible momentum / sloshing
     // without runaway oscillation.
     // ----------------------------------------------------------------
     private const float PressureGain = 0.06f;
-    private const float Damping      = 0.975f;
-    private const float MaxSpeed     = 2.0f;
+    private const float Damping      = 0.965f;
+    private const float MaxSpeed     = 1.1f;
     private const float VelocityFloor = 0.003f;
 
     // ----------------------------------------------------------------

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -91,11 +91,11 @@ internal sealed class WhirlpoolPage : IStressPage
     private const float MinStrength = 0.3f;
     private const float MaxStrength = 4.0f;
 
-    private const float DrainReachInitial   = 2.0f;
-    private const float DrainReachMax       = 18f;
-    private const int   DrainReachRampFrames = 300;
-    private const float DrainDiscRadiusMax  = 10f;
-    private const float DrainDensity        = 0.75f;
+    private const float DrainReachInitial   = 4.0f;
+    private const float DrainReachMax       = 22f;
+    private const int   DrainReachRampFrames = 90;
+    private const float DrainDiscRadiusMax  = 16f;
+    private const float DrainDensity        = 1.5f;
     private const float PullStrength        = 0.35f; // peak inward accel per frame at drain centre
     private const float SwirlStrength       = 0.60f; // peak tangential accel per frame
 
@@ -115,8 +115,8 @@ internal sealed class WhirlpoolPage : IStressPage
     private bool _inletActive;
     private int _inletCx;
     private int _inletCy;
-    private const int InletVoxelsPerFrame = 10;
-    private const float InletRadius  = 3f;
+    private const int InletVoxelsPerFrame = 60;
+    private const float InletRadius  = 5f;
 
     private bool _quiescent = true;
     public bool IsIdle => _quiescent;

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -9,417 +9,491 @@ namespace PerfStressDemo;
 /// <summary>
 /// Page 3 — "Whirlpool".
 ///
-/// A fluid-like field of one character per cell. By default everything sits
-/// still in a uniform grid. <b>Left click</b> opens a gravity well at the
-/// cursor: characters are pulled in (with a tangential swirl giving the
-/// spiral), and the void created at the centre propagates outward as a
-/// pressure-gradient — overlapping/compressed particles push toward
-/// lower-density neighbours, which keeps the field flowing toward the hole.
-/// Particles that fall in are respawned at a random edge. <b>Right click</b>
-/// turns the well off and the field settles wherever it landed (damping
-/// kills residual velocity in a few seconds).
+/// Top-down water simulated on a half-block grid (each terminal cell holds
+/// two stacked sub-cells, rendered as <c>▀</c> with foreground = top
+/// sub-cell colour and background = bottom sub-cell colour, doubling the
+/// vertical resolution of the simulation).
 ///
-/// Controls:
-///   * Left click   — place/move the well (activates it).
-///   * Right click  — remove the well; field stabilises.
-///   * Scroll wheel — adjust well strength.
+/// Water has a per-sub-cell depth in [0, 1]. The whole screen starts at
+/// full depth — a deep blue ocean. Pressure equalises between neighbours
+/// each frame using mass-conserving diffusion, so disturbances spread
+/// outward as flat waves of slightly different depth.
 ///
-/// Stress profile: ~w·h particles updated every frame, density binning
-/// over a w·h grid each frame, plus one sparse cell write per particle.
-/// Exercises scattered writes + a tight integer-accumulation pass over a
-/// surface-sized buffer.
+/// <list type="bullet">
+///   <item>Left click — open a drain at the cursor. Water in a small disc
+///         around the drain is consumed each frame; the surrounding water
+///         flows in to fill the void.</item>
+///   <item>Right click — close the drain. Edge inlets begin pulsing water
+///         back into the basin at random positions; the basin gradually
+///         refills. Once every sub-cell is at maximum depth no further
+///         inlets spawn and the system goes idle.</item>
+///   <item>Scroll — adjust drain strength (clamped). Scroll up = stronger.</item>
+/// </list>
+///
+/// Colour: empty sub-cell = warm sandy beach; shallow = light blue;
+/// full = deep ocean blue. Lerped continuously so a draining basin
+/// reads as a colour gradient from beach (at the centre) to ocean (at
+/// the edges).
+///
+/// Stress profile: two w·2h-sized passes per frame (diffusion delta
+/// pass + apply pass) over a flat float[] grid, plus one cell write per
+/// surface cell on the render pass. Exercises tight numeric loops on
+/// large flat buffers — distinct from the scattered sparse writes of
+/// the earlier particle prototype.
 /// </summary>
 internal sealed class WhirlpoolPage : IStressPage
 {
     public string Name => "Whirlpool";
 
     public string Description =>
-        "Pressure-driven character field. Left click to open a gravity well, "
-        + "right click to remove it. Scroll adjusts strength.";
+        "Half-block water field with mouse-controlled drain and edge inlets. "
+        + "Left click opens a drain, right click closes and basin refills.";
 
     // ----------------------------------------------------------------
-    // Particle storage. Struct-of-Arrays — the hot loop touches each
-    // field independently, so packed parallel arrays are kinder to the
-    // cache than an array of structs.
+    // Simulation grid. _depth[y * dotWidth + x] holds the water depth
+    // in [0, MaxDepth] for sub-cell (x, y). _delta is the change to
+    // apply this step (computed in pass 1, applied in pass 2 so flow
+    // is order-independent).
     // ----------------------------------------------------------------
-    private float[] _px = Array.Empty<float>();
-    private float[] _py = Array.Empty<float>();
-    private float[] _vx = Array.Empty<float>();
-    private float[] _vy = Array.Empty<float>();
-    private byte[] _glyphIdx = Array.Empty<byte>();
-    private int _count;
+    private float[] _depth = Array.Empty<float>();
+    private float[] _delta = Array.Empty<float>();
     private int _surfaceWidth;
     private int _surfaceHeight;
+    private int _dotWidth;
+    private int _dotHeight;
 
-    // Density grid: how many particles currently occupy each cell.
-    // Recomputed from scratch every frame; gradients drive the pressure
-    // force that redistributes the fluid toward low-density regions.
-    private int[] _density = Array.Empty<int>();
-
-    // Well state. _wellActive gates the entire pull/spin/swallow path.
-    // When inactive only the pressure + damping terms run, so the field
-    // settles into whatever shape it had when the user right-clicked.
-    private bool _wellActive;
-    private float _wellX;
-    private float _wellY;
-    // User-adjustable strength multiplier (scroll wheel). Multiplicative
-    // scrolling so the same number of notches has the same perceptual
-    // effect at any starting value. Clamped to a usable range.
+    // ----------------------------------------------------------------
+    // Drain state. _drainActive gates consumption; the well can be
+    // placed (left click) or removed (right click) independently of
+    // its position. Coords are in surface (cell) units — they're
+    // doubled to sub-cell units when the drain is applied.
+    // ----------------------------------------------------------------
+    private bool _drainActive;
+    private float _drainX;
+    private float _drainY;
     private float _strength = 1.0f;
-    private const float MinStrength = 0.2f;
-    private const float MaxStrength = 6.0f;
+    private const float MinStrength = 0.3f;
+    private const float MaxStrength = 4.0f;
 
     // ----------------------------------------------------------------
-    // Physics constants. The whole point of this page is to be SLOW
-    // enough that you can track individual characters, so MaxSpeed is
-    // tiny and damping is aggressive — set these too high and the
-    // visual reads as snow rather than fluid.
+    // Inlets — small periodically-spawned sources on the screen edge.
+    // Active only when the drain is OFF and the basin isn't full;
+    // each inlet pulses its flow with a sinusoidal envelope so they
+    // visibly fade in and out at varying strengths instead of being
+    // hard step functions.
     // ----------------------------------------------------------------
-    private const float MaxSpeed = 0.35f;        // cells per frame, hard clamp
-    private const float Damping = 0.94f;         // per-frame velocity multiplier
-    private const float SwallowRadius = 1.2f;    // particle this close to well -> respawn
-    private const float MinPullDistance = 2.0f;  // floor on r in the 1/r pull law
-    private const float SpinRatio = 0.85f;       // tangential / radial force ratio
-    private const float PressureK = 0.04f;       // how hard density gradients push
-    // sizeFactor coefficient — kept low so default strength feels right
-    // even on big monitors. The displayed strength is normalised by this
-    // so different screens behave consistently.
-    private const float SizeFactor = 0.05f;
-
-    // Glyph palette — kept narrow and mostly punctuation so motion reads
-    // as discrete bits of debris. Excludes whitespace and wide chars.
-    private static readonly string[] s_glyphs = BuildGlyphs();
-
-    private static string[] BuildGlyphs()
+    private struct Inlet
     {
-        const string source = ".,'`*+/\\|-_~:;!?o0aXxv^=<>#%&";
-        var arr = new string[source.Length];
-        for (var i = 0; i < source.Length; i++)
-            arr[i] = source[i].ToString();
-        return arr;
+        public int X;            // sub-cell coords (dot units)
+        public int Y;
+        public float PeakRate;   // depth added per frame at envelope peak
+        public int Age;          // frames since spawned
+        public int Lifetime;     // total frames before removal
     }
 
-    // xorshift32 RNG — allocation-free, deterministic seed for reproducible
-    // initial scatter.
-    private uint _rng = 0xCAFEBABEu;
+    private readonly List<Inlet> _inlets = new(16);
+    private int _framesUntilNextInletCheck;
 
+    // ----------------------------------------------------------------
+    // Physics constants.
+    // ----------------------------------------------------------------
+    private const float MaxDepth = 1.0f;
+    // Diffusion rate per neighbour per frame. With 4 neighbours, total
+    // outflow per step is 4 * DiffusionK. Keep < 0.25 for stability of
+    // the explicit scheme (CFL).
+    private const float DiffusionK = 0.18f;
+    private const float DrainRadius = 4.0f;       // sub-cell units
+    private const float DrainPerFrameBase = 0.05f; // strength multiplier
+    private const int   InletCheckInterval = 12;   // frames between spawn attempts
+    private const int   InletMaxConcurrent = 6;
+    private const int   InletLifetimeMin = 90;
+    private const int   InletLifetimeMax = 220;
+    private const float InletPeakRateMin = 0.015f;
+    private const float InletPeakRateMax = 0.045f;
+    private const float InletRadius = 2.5f;        // sub-cell units, spread of deposit
+
+    // ----------------------------------------------------------------
+    // Quiescence tracking — used by IsIdle so the framework can sleep
+    // when the basin is completely full, the drain is off, and no
+    // inlets are active. The diffusion delta sum is the cheapest
+    // "anything moving?" detector available since we already compute
+    // every cell's delta in the diffusion pass.
+    // ----------------------------------------------------------------
+    private bool _quiescent = true;
+    public bool IsIdle => _quiescent;
+
+    // Status-bar accessors.
+    public static float CurrentStrength { get; private set; } = 1.0f;
+    public static bool DrainOpen { get; private set; }
+
+    // xorshift32 — small, fast, allocation-free, deterministic seed.
+    private uint _rng = 0xDEADBEEFu;
     private uint NextRandom()
     {
         var x = _rng;
-        x ^= x << 13;
-        x ^= x >> 17;
-        x ^= x << 5;
+        x ^= x << 13; x ^= x >> 17; x ^= x << 5;
         _rng = x;
         return x;
     }
-
     private float NextFloat() => (NextRandom() & 0xFFFFFF) / (float)0x1000000;
+
+    // Pre-computed colour endpoints. SurfaceCell stores Hex1bColor
+    // values so we avoid allocating new ones in the hot render loop
+    // by lerping bytes and constructing the colour once per cell.
+    private static readonly (byte R, byte G, byte B) SandColour = (235, 215, 175); // warm beach
+    private static readonly (byte R, byte G, byte B) ShallowColour = (140, 210, 240); // pale aqua
+    private static readonly (byte R, byte G, byte B) DeepColour = (8, 60, 130);       // deep ocean
 
     public Hex1bWidget Build(StressContext sc)
     {
-        // The Surface widget on its own doesn't participate in mouse-event
-        // routing — wrap it in an Interactable so left/right click and
-        // scroll wheel events get delivered to our bindings. (The Pond
-        // page can get away without this because it samples mouse *position*
-        // every frame from SurfaceLayerContext, which goes through a
-        // different path; click/scroll *events* need explicit routing.)
-        return sc.Root.Interactable(ic =>
+        // Surface needs an Interactable wrapper to participate in mouse
+        // event routing; the pond's position-tracking goes through a
+        // separate (poll-based) path that doesn't need this.
+        var widget = sc.Root.Interactable(ic =>
             ic.Surface(layer =>
             {
                 EnsureField(layer.Width, layer.Height);
                 Step();
-                return new[] { layer.Layer(DrawParticles) };
+                return new[] { layer.Layer(DrawWater) };
             }))
             .InputBindings(bindings =>
             {
-                // Left click: position the well at the cursor and activate
-                // it. Subsequent clicks just relocate.
                 bindings.Mouse(MouseButton.Left).Action(ctx =>
                 {
                     if (ctx.MouseX < 0 || ctx.MouseY < 0) return;
-                    _wellX = ctx.MouseX;
-                    _wellY = ctx.MouseY;
-                    _wellActive = true;
+                    _drainX = ctx.MouseX;
+                    _drainY = ctx.MouseY;
+                    _drainActive = true;
+                    _quiescent = false;
                 });
-
-                // Right click: kill the well. Existing particles keep
-                // their velocity and damping settles them; pressure
-                // pushes residual clumps back toward uniformity.
                 bindings.Mouse(MouseButton.Right).Action(_ =>
                 {
-                    _wellActive = false;
+                    _drainActive = false;
+                    // Don't flip _quiescent here — inlets / refilling
+                    // still need ticks. The diffusion pass will set it
+                    // true again once everything settles.
                 });
-
-                // Scroll wheel: strength. Multiplicative so a couple of
-                // notches visibly changes feel.
                 bindings.Mouse(MouseButton.ScrollUp).Action(_ =>
                 {
-                    _strength = Math.Min(MaxStrength, _strength * 1.2f);
+                    _strength = MathF.Min(MaxStrength, _strength * 1.2f);
                 });
                 bindings.Mouse(MouseButton.ScrollDown).Action(_ =>
                 {
-                    _strength = Math.Max(MinStrength, _strength * 0.83f);
+                    _strength = MathF.Max(MinStrength, _strength * 0.83f);
                 });
-            })
-            .RedrawAfter(sc.RedrawIntervalMs);
+            });
+
+        // Drop RedrawAfter when the basin is fully settled so the root
+        // can idle.
+        return _quiescent ? widget : widget.RedrawAfter(sc.RedrawIntervalMs);
     }
-
-    /// <summary>Status-bar label exposing current strength.</summary>
-    public static float CurrentStrength { get; private set; } = 1.0f;
-
-    /// <summary>Status-bar label: whether the well is currently active.</summary>
-    public static bool WellActive { get; private set; }
 
     private void EnsureField(int w, int h)
     {
-        if (_surfaceWidth == w && _surfaceHeight == h && _px.Length > 0)
+        if (_surfaceWidth == w && _surfaceHeight == h && _depth.Length > 0)
             return;
-
         _surfaceWidth = w;
         _surfaceHeight = h;
-        // One particle per cell — a fully populated grid is what makes the
-        // pressure model sensible (gradients are well-defined) and gives
-        // the user the "I can see the whole fluid" feel they asked for.
-        _count = w * h;
-        _px = new float[_count];
-        _py = new float[_count];
-        _vx = new float[_count];
-        _vy = new float[_count];
-        _glyphIdx = new byte[_count];
-        _density = new int[w * h];
-
-        // Initial scatter: one particle at the centre of each cell, with
-        // zero velocity and a random glyph. With no well and zero motion
-        // density is uniform 1 per cell, gradients are zero everywhere,
-        // and nothing moves until the user clicks.
-        var idx = 0;
-        for (var y = 0; y < h; y++)
-        {
-            for (var x = 0; x < w; x++)
-            {
-                _px[idx] = x + 0.5f;
-                _py[idx] = y + 0.5f;
-                _vx[idx] = 0;
-                _vy[idx] = 0;
-                _glyphIdx[idx] = (byte)(NextRandom() % (uint)s_glyphs.Length);
-                idx++;
-            }
-        }
+        _dotWidth = w;          // one sub-cell per cell horizontally
+        _dotHeight = h * 2;     // two sub-cells per cell vertically (half-block)
+        var n = _dotWidth * _dotHeight;
+        _depth = new float[n];
+        _delta = new float[n];
+        // Start full — deep ocean everywhere.
+        Array.Fill(_depth, MaxDepth);
+        _inlets.Clear();
+        _quiescent = true;
     }
 
     private void Step()
     {
-        if (_count == 0) return;
-
-        var w = _surfaceWidth;
-        var h = _surfaceHeight;
-
-        // -------- 1. Rebuild density grid --------
-        // Zero it (Array.Clear is JIT-optimised to memset) then bin each
-        // particle into the cell it currently occupies.
-        Array.Clear(_density, 0, _density.Length);
-        for (var i = 0; i < _count; i++)
-        {
-            var cx = (int)_px[i];
-            var cy = (int)_py[i];
-            if ((uint)cx >= (uint)w || (uint)cy >= (uint)h) continue;
-            _density[cy * w + cx]++;
-        }
-
-        // -------- 2. Precompute well-related scalars --------
-        // sizeFactor scales the absolute pull magnitude with surface area
-        // so the user's chosen strength feels equivalent on small and
-        // large terminals.
-        var sizeFactor = MathF.Sqrt(w * h) * SizeFactor;
-        var pullScale = _strength * sizeFactor;
-        var spinScale = pullScale * SpinRatio;
-        var swallowSq = SwallowRadius * SwallowRadius;
-        var wellActive = _wellActive;
-        var wx = _wellX;
-        var wy = _wellY;
-
-        // Expose to status bar.
+        if (_depth.Length == 0) return;
         CurrentStrength = _strength;
-        WellActive = wellActive;
+        DrainOpen = _drainActive;
 
-        // -------- 3. Per-particle update --------
-        for (var i = 0; i < _count; i++)
+        var dw = _dotWidth;
+        var dh = _dotHeight;
+        var depth = _depth;
+        var delta = _delta;
+        Array.Clear(delta, 0, delta.Length);
+
+        // ---- Pass 1: diffusion. Flow between each cell and its right
+        //      and down neighbours; doing only two of the four edges
+        //      per cell visits every edge exactly once (every pair
+        //      shares exactly one direction). Symmetric add/subtract
+        //      makes the operation mass-conserving by construction.
+        var anyFlow = false;
+        for (var y = 0; y < dh; y++)
         {
-            var px = _px[i];
-            var py = _py[i];
-            var vx = _vx[i];
-            var vy = _vy[i];
-
-            // Pressure gradient at the particle's current cell. We use
-            // central differences in the density grid: high density to
-            // one side pushes the particle the other way. Clamp the
-            // sample coords so the boundary doesn't sample out of bounds.
-            var cx = (int)px;
-            var cy = (int)py;
-            if ((uint)cx < (uint)w && (uint)cy < (uint)h)
+            var row = y * dw;
+            for (var x = 0; x < dw; x++)
             {
-                var xl = cx > 0 ? cx - 1 : cx;
-                var xr = cx < w - 1 ? cx + 1 : cx;
-                var yu = cy > 0 ? cy - 1 : cy;
-                var yd = cy < h - 1 ? cy + 1 : cy;
-                var gx = _density[cy * w + xr] - _density[cy * w + xl];
-                var gy = _density[yd * w + cx] - _density[yu * w + cx];
-                // Force points from high density toward low density.
-                vx -= PressureK * gx;
-                vy -= PressureK * gy;
-            }
-
-            if (wellActive)
-            {
-                var dx = wx - px;
-                var dy = wy - py;
-                var rSq = dx * dx + dy * dy;
-                if (rSq < swallowSq)
+                var i = row + x;
+                var di = depth[i];
+                // Right neighbour
+                if (x + 1 < dw)
                 {
-                    Respawn(i);
-                    continue;
+                    var j = i + 1;
+                    var f = (di - depth[j]) * DiffusionK;
+                    if (f != 0f) anyFlow = true;
+                    delta[i] -= f;
+                    delta[j] += f;
                 }
-                var r = MathF.Sqrt(rSq);
-                var rEff = r < MinPullDistance ? MinPullDistance : r;
-                var invR = 1f / rEff;
-                var ux = dx * invR;
-                var uy = dy * invR;
-                // Tangential (CCW rotation) gives the spiral. Same 1/r
-                // falloff so the outer field stays alive — physical 1/r²
-                // goes inert far from the well and the wider field looks
-                // dead.
-                var tx = -uy;
-                var ty = ux;
-                var a = pullScale * invR;
-                var at = spinScale * invR;
-                vx += ux * a + tx * at;
-                vy += uy * a + ty * at;
-            }
-
-            // Damping. With the well off this is the only velocity
-            // change, so the field settles into stillness in a couple
-            // of seconds. With the well on, damping bounds the slingshot
-            // effect of close approaches.
-            vx *= Damping;
-            vy *= Damping;
-
-            // Speed clamp. Tiny — the whole point of this page is that
-            // the user can follow individual glyphs as they drift.
-            var sp2 = vx * vx + vy * vy;
-            if (sp2 > MaxSpeed * MaxSpeed)
-            {
-                var sc = MaxSpeed / MathF.Sqrt(sp2);
-                vx *= sc;
-                vy *= sc;
-            }
-
-            px += vx;
-            py += vy;
-
-            // Boundary handling depends on whether the well is on.
-            // With the well active, OOB particles respawn at an edge so
-            // the fluid keeps flowing in. Without the well there's no
-            // sink so it'd be wrong to teleport: just clamp the position
-            // and zero the corresponding velocity component so things
-            // come to rest against the wall.
-            if (wellActive)
-            {
-                if (px < 0 || px >= w || py < 0 || py >= h)
+                // Down neighbour
+                if (y + 1 < dh)
                 {
-                    Respawn(i);
-                    continue;
+                    var j = i + dw;
+                    var f = (di - depth[j]) * DiffusionK;
+                    if (f != 0f) anyFlow = true;
+                    delta[i] -= f;
+                    delta[j] += f;
                 }
             }
-            else
-            {
-                if (px < 0) { px = 0; vx = 0; }
-                else if (px >= w) { px = w - 0.001f; vx = 0; }
-                if (py < 0) { py = 0; vy = 0; }
-                else if (py >= h) { py = h - 0.001f; vy = 0; }
-            }
-
-            _px[i] = px;
-            _py[i] = py;
-            _vx[i] = vx;
-            _vy[i] = vy;
         }
+
+        // ---- Pass 2: apply deltas, then drain, then inlets.
+        var changed = anyFlow;
+        for (var i = 0; i < depth.Length; i++)
+        {
+            var d = depth[i] + delta[i];
+            if (d < 0f) d = 0f;
+            else if (d > MaxDepth) d = MaxDepth;
+            depth[i] = d;
+        }
+
+        if (_drainActive)
+        {
+            changed |= ApplyDrain(depth, dw, dh);
+        }
+
+        // Inlets only spawn / pulse when the drain is OFF, mirroring
+        // the spec: open drain == active draining, closed drain ==
+        // refill phase.
+        if (!_drainActive)
+        {
+            changed |= TickInlets(depth, dw, dh);
+        }
+
+        _quiescent = !changed && _inlets.Count == 0;
     }
 
-    private void Respawn(int i)
+    /// <summary>
+    /// Subtracts water inside a disc around the drain. Falls off linearly
+    /// with distance from the centre so the boundary doesn't appear as a
+    /// hard ring; clamps each cell to zero so we don't generate negative
+    /// depth (which would otherwise inject "anti-water" into the
+    /// diffusion pass on subsequent frames).
+    /// </summary>
+    private bool ApplyDrain(float[] depth, int dw, int dh)
     {
-        var w = _surfaceWidth;
-        var h = _surfaceHeight;
+        // Drain coords arrive in cell units; convert to sub-cell. The
+        // user clicked between two stacked sub-cells, so target the
+        // boundary by adding 1 (so y*2 + 1 lands on the lower half).
+        var cx = _drainX;
+        var cy = _drainY * 2 + 0.5f;
+        var rate = DrainPerFrameBase * _strength;
+        var r2 = DrainRadius * DrainRadius;
+        var x0 = Math.Max(0, (int)(cx - DrainRadius));
+        var x1 = Math.Min(dw - 1, (int)(cx + DrainRadius + 0.5f));
+        var y0 = Math.Max(0, (int)(cy - DrainRadius * 2));   // x2 to compensate for cell aspect
+        var y1 = Math.Min(dh - 1, (int)(cy + DrainRadius * 2 + 0.5f));
+        var changed = false;
+        for (var y = y0; y <= y1; y++)
+        {
+            for (var x = x0; x <= x1; x++)
+            {
+                var dx = x - cx;
+                var dy = (y - cy) * 0.5f; // halve y delta — terminal cells are ~2x tall as wide
+                var d2 = dx * dx + dy * dy;
+                if (d2 > r2) continue;
+                var falloff = 1f - MathF.Sqrt(d2) / DrainRadius;
+                var sub = rate * falloff;
+                if (sub <= 0f) continue;
+                var i = y * dw + x;
+                var nv = depth[i] - sub;
+                if (nv < 0f) nv = 0f;
+                if (nv != depth[i]) { depth[i] = nv; changed = true; }
+            }
+        }
+        return changed;
+    }
+
+    /// <summary>
+    /// Periodically spawns new inlet sources on the screen edge (only
+    /// when not already at saturation), advances existing inlets, and
+    /// retires expired ones. Each inlet's flow follows a sinusoidal
+    /// envelope so it visibly fades in and out instead of stepping
+    /// on/off.
+    /// </summary>
+    private bool TickInlets(float[] depth, int dw, int dh)
+    {
+        var changed = false;
+
+        // Cheap saturation check — if any cell is below MaxDepth -
+        // epsilon, we still have room. Single pass, early exit.
+        var roomToFill = false;
+        for (var i = 0; i < depth.Length; i++)
+        {
+            if (depth[i] < MaxDepth - 0.005f) { roomToFill = true; break; }
+        }
+
+        // Maybe spawn a new inlet.
+        if (--_framesUntilNextInletCheck <= 0)
+        {
+            _framesUntilNextInletCheck = InletCheckInterval;
+            if (roomToFill && _inlets.Count < InletMaxConcurrent)
+            {
+                _inlets.Add(SpawnInlet(dw, dh));
+            }
+        }
+
+        // Advance / apply / retire inlets.
+        for (var k = _inlets.Count - 1; k >= 0; k--)
+        {
+            var inlet = _inlets[k];
+            inlet.Age++;
+            if (inlet.Age >= inlet.Lifetime)
+            {
+                _inlets.RemoveAt(k);
+                continue;
+            }
+            // Sin envelope: 0 at birth, 1 at midlife, 0 at death.
+            var phase = MathF.PI * inlet.Age / inlet.Lifetime;
+            var envelope = MathF.Sin(phase);
+            var rate = inlet.PeakRate * envelope;
+            if (DepositInlet(depth, dw, dh, inlet.X, inlet.Y, rate))
+                changed = true;
+            _inlets[k] = inlet;
+        }
+
+        return changed;
+    }
+
+    private Inlet SpawnInlet(int dw, int dh)
+    {
         var edge = NextRandom() & 3;
-        const float Seed = 0.25f; // small inward push so they're visibly
-                                   // moving when they appear, but still
-                                   // slow enough to track.
-        float px, py, vx, vy;
+        int x, y;
         switch (edge)
         {
-            case 0: // top
-                px = NextFloat() * w; py = 0.1f;
-                vx = (NextFloat() - 0.5f) * 0.1f; vy = Seed;
-                break;
-            case 1: // bottom
-                px = NextFloat() * w; py = h - 0.1f;
-                vx = (NextFloat() - 0.5f) * 0.1f; vy = -Seed;
-                break;
-            case 2: // left
-                px = 0.1f; py = NextFloat() * h;
-                vx = Seed; vy = (NextFloat() - 0.5f) * 0.1f;
-                break;
-            default: // right
-                px = w - 0.1f; py = NextFloat() * h;
-                vx = -Seed; vy = (NextFloat() - 0.5f) * 0.1f;
-                break;
+            case 0: x = (int)(NextFloat() * dw); y = 0; break;
+            case 1: x = (int)(NextFloat() * dw); y = dh - 1; break;
+            case 2: x = 0; y = (int)(NextFloat() * dh); break;
+            default: x = dw - 1; y = (int)(NextFloat() * dh); break;
         }
-        _px[i] = px;
-        _py[i] = py;
-        _vx[i] = vx;
-        _vy[i] = vy;
-        _glyphIdx[i] = (byte)(NextRandom() % (uint)s_glyphs.Length);
+        var peak = InletPeakRateMin
+            + NextFloat() * (InletPeakRateMax - InletPeakRateMin);
+        var life = InletLifetimeMin
+            + (int)(NextFloat() * (InletLifetimeMax - InletLifetimeMin));
+        return new Inlet
+        {
+            X = x,
+            Y = y,
+            PeakRate = peak,
+            Age = 0,
+            Lifetime = life,
+        };
     }
 
-    private void DrawParticles(Surface surface)
+    private bool DepositInlet(float[] depth, int dw, int dh, int cx, int cy, float rate)
+    {
+        if (rate <= 0f) return false;
+        var r2 = InletRadius * InletRadius;
+        var x0 = Math.Max(0, cx - (int)InletRadius);
+        var x1 = Math.Min(dw - 1, cx + (int)InletRadius);
+        var y0 = Math.Max(0, cy - (int)(InletRadius * 2));
+        var y1 = Math.Min(dh - 1, cy + (int)(InletRadius * 2));
+        var changed = false;
+        for (var y = y0; y <= y1; y++)
+        {
+            for (var x = x0; x <= x1; x++)
+            {
+                var dx = x - cx;
+                var dy = (y - cy) * 0.5f;
+                var d2 = dx * dx + dy * dy;
+                if (d2 > r2) continue;
+                var falloff = 1f - MathF.Sqrt(d2) / InletRadius;
+                var add = rate * falloff;
+                var i = y * dw + x;
+                var nv = depth[i] + add;
+                if (nv > MaxDepth) nv = MaxDepth;
+                if (nv != depth[i]) { depth[i] = nv; changed = true; }
+            }
+        }
+        return changed;
+    }
+
+    /// <summary>
+    /// Renders the depth field using half-blocks. Each terminal cell
+    /// shows two stacked sub-cells via the upper-half-block character
+    /// (<c>▀</c>): foreground is the top sub-cell colour, background
+    /// is the bottom sub-cell colour. This doubles the vertical
+    /// simulation resolution at no extra render cost.
+    /// </summary>
+    private void DrawWater(Surface surface)
     {
         var w = surface.Width;
         var h = surface.Height;
-        var black = Hex1bColor.Black;
-
-        // Draw each particle. Multiple particles overlapping the same
-        // cell just means the last write wins for the glyph; brightness
-        // comes from the density grid we already computed in Step, so
-        // compressed regions visibly brighten and depleted regions go
-        // dim — even though only one glyph shows, the density readout
-        // tells you a clump is here.
-        for (var i = 0; i < _count; i++)
+        var dw = _dotWidth;
+        var depth = _depth;
+        for (var cy = 0; cy < h; cy++)
         {
-            var x = (int)_px[i];
-            var y = (int)_py[i];
-            if ((uint)x >= (uint)w || (uint)y >= (uint)h) continue;
-
-            var d = _density[y * w + x];
-            // Uniform density is 1; treat that as baseline grey. Stack
-            // up to ~6 deep before saturating to white.
-            var t = (d - 1) / 5f;
-            if (t < 0f) t = 0f;
-            else if (t > 1f) t = 1f;
-            var level = (byte)(120 + (int)(135 * t));
-            var fg = Hex1bColor.FromRgb(level, level, level);
-            surface[x, y] = new SurfaceCell(s_glyphs[_glyphIdx[i]], fg, black);
-        }
-
-        // Well marker drawn last so it's always visible on top, but only
-        // when active. A right-clicked-off well leaves no visible cursor.
-        if (_wellActive)
-        {
-            var wxI = (int)_wellX;
-            var wyI = (int)_wellY;
-            if ((uint)wxI < (uint)w && (uint)wyI < (uint)h)
+            var topRow = (cy * 2) * dw;
+            var botRow = (cy * 2 + 1) * dw;
+            for (var cx = 0; cx < w; cx++)
             {
-                surface[wxI, wyI] = new SurfaceCell(
-                    "@", Hex1bColor.FromRgb(255, 64, 64), black);
+                var topD = depth[topRow + cx];
+                var botD = depth[botRow + cx];
+                var topCol = DepthColour(topD);
+                var botCol = DepthColour(botD);
+                surface[cx, cy] = new SurfaceCell("▀", topCol, botCol);
             }
         }
+
+        // Stamp drain marker last so it sits on top. Use the rendered
+        // cell's existing background colour so the marker doesn't
+        // create a visible black square around itself when the
+        // surrounding water is mid-tone.
+        if (_drainActive)
+        {
+            var mx = (int)_drainX;
+            var my = (int)_drainY;
+            if ((uint)mx < (uint)w && (uint)my < (uint)h)
+            {
+                // The bottom sub-cell of the cell at (mx, my) is the
+                // closest drain sample; use that as our backdrop.
+                var bg = DepthColour(depth[(my * 2 + 1) * dw + mx]);
+                surface[mx, my] = new SurfaceCell("◉",
+                    Hex1bColor.FromRgb(255, 240, 200), bg);
+            }
+        }
+    }
+
+    private static Hex1bColor DepthColour(float d)
+    {
+        // Two-segment lerp: empty (0) → sand → shallow (0.25) → deep (1).
+        // The sand→shallow band is short so a barely-wet sub-cell
+        // already reads as "water" rather than damp sand.
+        if (d <= 0f) return Hex1bColor.FromRgb(SandColour.R, SandColour.G, SandColour.B);
+        if (d >= 1f) return Hex1bColor.FromRgb(DeepColour.R, DeepColour.G, DeepColour.B);
+        if (d < 0.25f)
+        {
+            var t = d / 0.25f;
+            return Lerp(SandColour, ShallowColour, t);
+        }
+        else
+        {
+            var t = (d - 0.25f) / 0.75f;
+            return Lerp(ShallowColour, DeepColour, t);
+        }
+    }
+
+    private static Hex1bColor Lerp((byte R, byte G, byte B) a, (byte R, byte G, byte B) b, float t)
+    {
+        if (t < 0f) t = 0f;
+        else if (t > 1f) t = 1f;
+        var r = (byte)(a.R + (b.R - a.R) * t);
+        var g = (byte)(a.G + (b.G - a.G) * t);
+        var bl = (byte)(a.B + (b.B - a.B) * t);
+        return Hex1bColor.FromRgb(r, g, bl);
     }
 }

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -84,6 +84,7 @@ internal sealed class WhirlpoolPage : IStressPage
     private float _drainY;
     private float _strength = 1.0f;
     private int _frame;
+    private int _drainOpenFrames;  // resets to 0 every time drain re-opens; clamps growth of reach
     private const float MinStrength = 0.3f;
     private const float MaxStrength = 4.0f;
 
@@ -92,8 +93,12 @@ internal sealed class WhirlpoolPage : IStressPage
     // ----------------------------------------------------------------
     private const float MaxDepth = 1.0f;
     private const float DiffusionK = 0.045f;
-    private const float DrainRadius = 6.5f;        // sub-cells
+    private const float DrainRadius = 6.5f;        // sub-cells (max consumption disc radius)
     private const float DrainPerFrameBase = 0.32f;
+    private const float DrainReachInitial = 2.5f;   // initial Gaussian sigma for advection window
+    private const float DrainReachMax     = 28f;    // peak Gaussian sigma for advection window
+    private const int   DrainReachRampFrames = 360; // ~6s @ 60fps to reach full whirlpool extent
+    private const float MaxDrainPerFrame  = 7f;     // total depth-units consumed across the disc per frame
     // Refill (drain off): water enters through a single roaming
     // inlet that fades in/out on the edge of the basin. Diffusion
     // already moves water from high to low, so a localised source is
@@ -118,6 +123,7 @@ internal sealed class WhirlpoolPage : IStressPage
     private const float WaveDamping = 0.985f;
     private const float WaveDisplayScale = 0.32f;   // how much wave modulates rendered depth
     private const float WaveFloor = 0.005f;          // floor for "alive" tracking
+    private const float WaveDepthThreshold = 0.08f;  // suppress wave injection / display below this depth
     private const float DrainImpulse = -0.18f;       // per frame, at drain centre
     private const float ChopAmplitude = 0.06f;       // random impulse magnitude while active
     private const int   ChopPerFrame = 4;            // random chop sites per frame while active
@@ -198,6 +204,7 @@ internal sealed class WhirlpoolPage : IStressPage
                     if (ctx.MouseX < 0 || ctx.MouseY < 0) return;
                     _drainX = ctx.MouseX;
                     _drainY = ctx.MouseY;
+                    if (!_drainActive) _drainOpenFrames = 0; // ramp reach from scratch each open
                     _drainActive = true;
                     _activity = 1f;
                     _quiescent = false;
@@ -252,9 +259,14 @@ internal sealed class WhirlpoolPage : IStressPage
 
         // ---- Pass 0: advection of baseline when drain is open. Same
         //      analytic potential-flow field that drives the spiral
-        //      look in the original whirlpool draft.
+        //      look in the original whirlpool draft. Velocity is
+        //      windowed by a Gaussian centred on the drain whose
+        //      sigma ramps from DrainReachInitial to DrainReachMax
+        //      over DrainReachRampFrames — that gives the whirlpool
+        //      time to form locally before the outer water joins in.
         if (_drainActive)
         {
+            _drainOpenFrames++;
             AdvectField(depth, delta, dw, dh);
             (depth, delta) = (delta, depth);
             _depth = depth;
@@ -337,27 +349,69 @@ internal sealed class WhirlpoolPage : IStressPage
         _quiescent = !changed && !active && !waveAlive;
     }
 
+    /// <summary>
+    /// Returns the current Gaussian sigma for the drain's influence
+    /// window, ramping smoothly from <see cref="DrainReachInitial"/>
+    /// to <see cref="DrainReachMax"/> over
+    /// <see cref="DrainReachRampFrames"/> frames since the drain was
+    /// opened. Used to size both the consumption disc and the
+    /// advection velocity window.
+    /// </summary>
+    private float CurrentDrainReach()
+    {
+        var t = MathF.Min(1f, _drainOpenFrames / (float)DrainReachRampFrames);
+        var s = t * t * (3f - 2f * t); // smoothstep
+        return DrainReachInitial + (DrainReachMax - DrainReachInitial) * s;
+    }
+
     private bool ApplyDrain(float[] depth, int dw, int dh)
     {
         var cx = _drainX;
         var cy = _drainY * 2 + 0.5f;
+        // Disc radius grows with the reach but is capped at DrainRadius —
+        // the hole itself never exceeds the original physical drain.
+        var reach = CurrentDrainReach();
+        var radius = MathF.Min(DrainRadius, reach);
         var rate = DrainPerFrameBase * _strength;
-        var r2 = DrainRadius * DrainRadius;
-        var x0 = Math.Max(0, (int)(cx - DrainRadius));
-        var x1 = Math.Min(dw - 1, (int)(cx + DrainRadius + 0.5f));
-        var y0 = Math.Max(0, (int)(cy - DrainRadius * 2));
-        var y1 = Math.Min(dh - 1, (int)(cy + DrainRadius * 2 + 0.5f));
-        var changed = false;
+        var r2 = radius * radius;
+        var x0 = Math.Max(0, (int)(cx - radius));
+        var x1 = Math.Min(dw - 1, (int)(cx + radius + 0.5f));
+        var y0 = Math.Max(0, (int)(cy - radius * 2));
+        var y1 = Math.Min(dh - 1, (int)(cy + radius * 2 + 0.5f));
+
+        // First pass: gather raw per-cell consumption requests; cap
+        // total egress at MaxDrainPerFrame * strength so the drain
+        // can't slurp arbitrary amounts when sitting on full water.
+        Span<float> requests = stackalloc float[(x1 - x0 + 1) * (y1 - y0 + 1)];
+        var dw1 = x1 - x0 + 1;
+        var total = 0f;
         for (var y = y0; y <= y1; y++)
         {
+            var ry = (y - y0) * dw1;
             for (var x = x0; x <= x1; x++)
             {
                 var dx = x - cx;
                 var dy = (y - cy) * 0.5f;
                 var d2 = dx * dx + dy * dy;
-                if (d2 > r2) continue;
-                var falloff = 1f - MathF.Sqrt(d2) / DrainRadius;
+                if (d2 > r2) { requests[ry + (x - x0)] = 0f; continue; }
+                var falloff = 1f - MathF.Sqrt(d2) / radius;
                 var sub = rate * falloff;
+                var available = depth[y * dw + x];
+                if (sub > available) sub = available;
+                requests[ry + (x - x0)] = sub;
+                total += sub;
+            }
+        }
+
+        var cap = MaxDrainPerFrame * _strength;
+        var scale = (total > cap && total > 0f) ? cap / total : 1f;
+        var changed = false;
+        for (var y = y0; y <= y1; y++)
+        {
+            var ry = (y - y0) * dw1;
+            for (var x = x0; x <= x1; x++)
+            {
+                var sub = requests[ry + (x - x0)] * scale;
                 if (sub <= 0f) continue;
                 var i = y * dw + x;
                 var nv = depth[i] - sub;
@@ -519,7 +573,10 @@ internal sealed class WhirlpoolPage : IStressPage
             var lead2Y = (int)(_jetY + _inletDirY * 8f);
             Splat(wave, dw, dh, lead2X, lead2Y, InletWaveImpulse * 0.4f * amp2);
 
-            // Turbulent spray — random chop around the jet head.
+            // Turbulent spray — random chop around the jet head, but
+            // only where there's enough water to support the ripple.
+            // Without this we leave visible wake lines across dry
+            // basin which look wrong.
             for (var k = 0; k < InletChopPerFrame; k++)
             {
                 var rx = (NextFloat() * 2f - 1f) * InletChopRadius;
@@ -527,19 +584,22 @@ internal sealed class WhirlpoolPage : IStressPage
                 var cx = (int)(_jetX + rx);
                 var cy = (int)(_jetY + ry);
                 if ((uint)cx >= (uint)dw || (uint)cy >= (uint)dh) continue;
+                var i = cy * dw + cx;
+                if (_depth[i] < WaveDepthThreshold) continue;
                 var sign = (NextRandom() & 1) == 0 ? 1f : -1f;
-                wave[cy * dw + cx] += InletChopAmplitude * amp2 * sign;
+                wave[i] += InletChopAmplitude * amp2 * sign;
             }
         }
 
-        // Background ocean chop — small scattered impulses.
+        // Background ocean chop — small scattered impulses, also
+        // suppressed where there's effectively no water.
         for (var k = 0; k < ChopPerFrame; k++)
         {
             var cx = (int)(NextFloat() * dw);
             var cy = (int)(NextFloat() * dh);
             var sign = (NextRandom() & 1) == 0 ? 1f : -1f;
             var i = cy * dw + cx;
-            if ((uint)i < (uint)wave.Length)
+            if ((uint)i < (uint)wave.Length && _depth[i] >= WaveDepthThreshold)
                 wave[i] += ChopAmplitude * amp * sign;
         }
     }
@@ -608,7 +668,12 @@ internal sealed class WhirlpoolPage : IStressPage
     /// Semi-Lagrangian advection of <paramref name="src"/> into
     /// <paramref name="dst"/>. Out-of-grid samples return 0 so the
     /// basin actually drains while the drain is open instead of
-    /// being topped up by a fictitious infinite ocean.
+    /// being topped up by a fictitious infinite ocean. The velocity
+    /// is gated by a Gaussian window centred on the drain whose
+    /// sigma is <see cref="CurrentDrainReach"/>: outside that radius
+    /// the velocity is effectively zero, so far-from-drain water
+    /// stays put until the whirlpool's influence has grown out to it.
+    /// Cells fully outside the window are copied through unchanged.
     /// </summary>
     private void AdvectField(float[] src, float[] dst, int dw, int dh)
     {
@@ -617,12 +682,29 @@ internal sealed class WhirlpoolPage : IStressPage
         var Q = SinkStrength * _strength;
         var G = SwirlStrength * _strength;
         var soft = VelocitySoftening;
+        var sigma = CurrentDrainReach();
+        var invTwoSigmaSq = 1f / (2f * sigma * sigma);
+        // Beyond ~3 sigma the Gaussian is < 0.012; skip advection
+        // entirely there so the field outside the whirlpool's reach
+        // stays exactly put (no creeping numerical drift).
+        var skip2 = (3f * sigma) * (3f * sigma);
         for (var y = 0; y < dh; y++)
         {
             var row = y * dw;
+            var dyc = y - cy;
             for (var x = 0; x < dw; x++)
             {
+                var dxc = x - cx;
+                var d2 = dxc * dxc + dyc * dyc;
+                if (d2 > skip2)
+                {
+                    dst[row + x] = src[row + x];
+                    continue;
+                }
+                var window = MathF.Exp(-d2 * invTwoSigmaSq);
                 VelocityAt(x, y, cx, cy, Q, G, soft, out var vx, out var vy);
+                vx *= window;
+                vy *= window;
                 var sx = x - vx;
                 var sy = y - vy;
                 dst[row + x] = SampleBilinearOrZero(src, dw, dh, sx, sy);
@@ -664,8 +746,16 @@ internal sealed class WhirlpoolPage : IStressPage
             {
                 var iTop = topRow + cx;
                 var iBot = botRow + cx;
-                var topV = depth[iTop] + WaveDisplayScale * wave[iTop];
-                var botV = depth[iBot] + WaveDisplayScale * wave[iBot];
+                var dTop = depth[iTop];
+                var dBot = depth[iBot];
+                // Mask wave contribution by local depth — no waves
+                // can ride on dry basin. Ramps 0..1 over the wave-
+                // depth threshold so the transition isn't a hard
+                // edge as a cell drains/fills past it.
+                var maskTop = dTop >= WaveDepthThreshold ? 1f : dTop / WaveDepthThreshold;
+                var maskBot = dBot >= WaveDepthThreshold ? 1f : dBot / WaveDepthThreshold;
+                var topV = dTop + WaveDisplayScale * wave[iTop] * maskTop;
+                var botV = dBot + WaveDisplayScale * wave[iBot] * maskBot;
                 if (topV < 0f) topV = 0f; else if (topV > 1f) topV = 1f;
                 if (botV < 0f) botV = 0f; else if (botV > 1f) botV = 1f;
                 surface[cx, cy] = new SurfaceCell("▀",

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -77,23 +77,29 @@ internal sealed class WhirlpoolPage : IStressPage
     private const float MaxStrength = 4.0f;
 
     // ----------------------------------------------------------------
-    // Surface bubbles. Modelled as PASSIVE tracers carried by the
-    // velocity field — no momentum, no orbits, no escape. Real
-    // surface particles in a fluid don't have inertia separate from
-    // the fluid itself; the mass of the water behind them keeps
-    // pushing them toward the sink. To simulate that we look up the
-    // local potential-flow velocity each frame and step by it.
+    // Ocean swell. The depth field starts flat and a flat field
+    // gives advection nothing to organise into spirals — pulling
+    // the plug on a glassy bathtub doesn't form a visible whirlpool
+    // either; you need the river/ocean's existing texture for the
+    // vortex to wind into spiral arms.
+    //
+    // Each frame (while active) we relax depth toward a moving
+    // multi-octave sinusoidal swell. The relaxation rate is small
+    // enough that the drain and inlets always dominate locally, but
+    // in calm regions the field gets continuously stirred and
+    // advection winds those wave patterns into the drain.
+    //
+    // _swellAmpScale ramps to 1 while there's any activity (drain
+    // open, inlets running) and decays back to zero when everything
+    // settles — so the truly idle ocean is glassy still and the
+    // page can sleep.
     // ----------------------------------------------------------------
-    private struct Bubble
-    {
-        public float X;   // sub-cell coords
-        public float Y;
-    }
-    private Bubble[] _bubbles = Array.Empty<Bubble>();
-    private float[] _foam = Array.Empty<float>();
-    private const float FoamDecay = 0.84f;             // per frame
-    private const float BubbleMaxSpeed = 2.5f;         // sub-cells / frame (anti-overshoot)
-    private const float BubbleAbsorbRadius = 1.6f;     // sub-cells
+    private float _swellAmpScale;
+    private const float SwellAmpBase = 0.06f;       // depth units, peak deviation
+    private const float SwellBlendRate = 0.035f;    // toward target per frame
+    private const float SwellPhaseRate = 0.05f;     // radians per frame
+    private const float SwellNominalLevel = 0.93f;  // mean depth the swell sits around
+    private const float SwellAmpDecay = 0.96f;      // per frame when no activity
 
     // ----------------------------------------------------------------
     // Potential-flow velocity field. A 2D sink at the drain has
@@ -232,20 +238,10 @@ internal sealed class WhirlpoolPage : IStressPage
         var n = _dotWidth * _dotHeight;
         _depth = new float[n];
         _delta = new float[n];
-        _foam = new float[n];
         // Start full — deep ocean everywhere.
         Array.Fill(_depth, MaxDepth);
         _inlets.Clear();
-        // Bubble count scales with surface area but is bounded so a
-        // very large terminal doesn't degenerate into a foam wash.
-        var bubbleCount = Math.Clamp(n / 70, 80, 600);
-        _bubbles = new Bubble[bubbleCount];
-        for (var i = 0; i < bubbleCount; i++)
-        {
-            ref var b = ref _bubbles[i];
-            b.X = NextFloat() * _dotWidth;
-            b.Y = NextFloat() * _dotHeight;
-        }
+        _swellAmpScale = 0f;
         _quiescent = true;
     }
 
@@ -340,12 +336,30 @@ internal sealed class WhirlpoolPage : IStressPage
             changed |= TickInlets(depth, dw, dh);
         }
 
-        // Surface bubbles run every frame: they need to keep coasting
-        // (and decaying foam) after the drain closes so the basin
-        // smoothly settles back to glassy water.
-        var bubblesMoving = StepBubbles(dw, dh);
+        // ---- Ocean swell. Runs whenever there's activity (drain
+        //      open OR inlets running). When activity stops, the
+        //      amplitude decays to zero so the basin returns to a
+        //      perfectly still mirror — which is when the page can
+        //      finally idle.
+        if (_drainActive || _inlets.Count > 0)
+        {
+            _swellAmpScale = 1f;
+        }
+        else
+        {
+            _swellAmpScale *= SwellAmpDecay;
+            if (_swellAmpScale < 0.01f) _swellAmpScale = 0f;
+        }
+        var swellActive = _swellAmpScale > 0.01f;
+        if (swellActive)
+        {
+            InjectSwell(depth, dw, dh);
+        }
 
-        _quiescent = !changed && _inlets.Count == 0 && !_drainActive && !bubblesMoving;
+        _quiescent = !changed
+            && _inlets.Count == 0
+            && !_drainActive
+            && !swellActive;
     }
 
     /// <summary>
@@ -506,7 +520,6 @@ internal sealed class WhirlpoolPage : IStressPage
         var h = surface.Height;
         var dw = _dotWidth;
         var depth = _depth;
-        var foam = _foam;
 
         for (var cy = 0; cy < h; cy++)
         {
@@ -514,20 +527,8 @@ internal sealed class WhirlpoolPage : IStressPage
             var botRow = (cy * 2 + 1) * dw;
             for (var cx = 0; cx < w; cx++)
             {
-                var topD = depth[topRow + cx];
-                var botD = depth[botRow + cx];
-                var topCol = DepthColour(topD);
-                var botCol = DepthColour(botD);
-
-                // Foam blend: bubbles deposit foam along their path
-                // and it decays each frame, so fast-moving bubbles
-                // leave bright streaks that read as stretching as they
-                // accelerate toward the drain.
-                var topFoam = foam[topRow + cx];
-                var botFoam = foam[botRow + cx];
-                if (topFoam > 0f) topCol = BlendFoam(topCol, topFoam);
-                if (botFoam > 0f) botCol = BlendFoam(botCol, botFoam);
-
+                var topCol = DepthColour(depth[topRow + cx]);
+                var botCol = DepthColour(depth[botRow + cx]);
                 surface[cx, cy] = new SurfaceCell("▀", topCol, botCol);
             }
         }
@@ -545,95 +546,45 @@ internal sealed class WhirlpoolPage : IStressPage
         }
     }
 
-    private static Hex1bColor BlendFoam(Hex1bColor col, float intensity)
-    {
-        if (intensity > 1f) intensity = 1f;
-        var r = (byte)(col.R + (255 - col.R) * intensity);
-        var g = (byte)(col.G + (255 - col.G) * intensity);
-        var b = (byte)(col.B + (255 - col.B) * intensity);
-        return Hex1bColor.FromRgb(r, g, b);
-    }
-
     /// <summary>
-    /// Advances all surface bubbles one frame as PASSIVE TRACERS in
-    /// the potential-flow velocity field. There is no momentum: each
-    /// bubble's new position is simply its old position plus the
-    /// local velocity. This is physically right for a surface particle
-    /// floating on a draining fluid — it goes wherever the surface
-    /// goes, with the mass of water behind it continuously pushing.
-    /// Particles cannot escape orbit; they follow streamlines
-    /// (logarithmic spirals) inevitably into the drain.
+    /// Blends each depth cell toward a slowly evolving multi-octave
+    /// sinusoidal swell. This injects the ocean-like surface texture
+    /// that a real whirlpool organises into spiral arms — a perfectly
+    /// flat field has nothing for advection to wind up. The blend
+    /// rate is small enough that the drain and inlets always
+    /// dominate locally, but the swell continuously stirs calm
+    /// regions and (via advection in Pass 0) gets pulled into the
+    /// drain as visible spiral contours.
     /// </summary>
-    /// <returns>true if anything is moving or any foam remains —
-    /// used by the quiescence check.</returns>
-    private bool StepBubbles(int dw, int dh)
+    private void InjectSwell(float[] depth, int dw, int dh)
     {
-        // ---- foam decay pass (and "any foam left?" probe)
-        var foam = _foam;
-        var anyFoam = false;
-        for (var i = 0; i < foam.Length; i++)
+        var amp = SwellAmpBase * _swellAmpScale;
+        var blend = SwellBlendRate * _swellAmpScale;
+        var t = _frame * SwellPhaseRate;
+        // Pre-bake phase terms that don't depend on x so the inner
+        // loop reduces to a couple of muls + sin per octave.
+        var t1 = t;
+        var t2 = t * 1.7f;
+        var t3 = t * 2.4f;
+        for (var y = 0; y < dh; y++)
         {
-            var f = foam[i] * FoamDecay;
-            if (f < 0.005f) f = 0f;
-            else anyFoam = true;
-            foam[i] = f;
-        }
-
-        if (!_drainActive)
-        {
-            // No drain → no flow → tracers are stationary. (Inlet
-            // flow is too localised to bother sampling here.)
-            return anyFoam;
-        }
-
-        var cx = _drainX;
-        var cy = _drainY * 2f + 0.5f;
-        var Q = SinkStrength * _strength;
-        var G = SwirlStrength * _strength;
-        var soft = VelocitySoftening;
-        var absorbR2 = BubbleAbsorbRadius * BubbleAbsorbRadius;
-
-        for (var i = 0; i < _bubbles.Length; i++)
-        {
-            ref var b = ref _bubbles[i];
-            var px = b.X;
-            var py = b.Y;
-
-            var ddx = cx - px;
-            var ddy = cy - py;
-            if (ddx * ddx + ddy * ddy < absorbR2)
+            var yt1 = y * 0.08f;
+            var yt2 = y * -0.13f;
+            var yt3 = y * 0.21f;
+            var row = y * dw;
+            for (var x = 0; x < dw; x++)
             {
-                RespawnBubbleAtEdge(ref b, dw, dh);
-                continue;
+                // 3 octaves: long swell + cross-direction medium + fine ripple.
+                var n = MathF.Sin(x * 0.07f + yt1 + t1) * 0.55f
+                      + MathF.Sin(x * 0.13f + yt2 + t2) * 0.30f
+                      + MathF.Sin(x * 0.21f + yt3 + t3) * 0.15f;
+                var target = SwellNominalLevel + amp * n;
+                if (target > MaxDepth) target = MaxDepth;
+                else if (target < 0f) target = 0f;
+                var i = row + x;
+                depth[i] += (target - depth[i]) * blend;
             }
-
-            VelocityAt(px, py, cx, cy, Q, G, soft, out var vx, out var vy);
-
-            // Speed cap — guards against the centre singularity and
-            // keeps semi-Lagrangian / line rasterisation stable.
-            var vmag2 = vx * vx + vy * vy;
-            if (vmag2 > BubbleMaxSpeed * BubbleMaxSpeed)
-            {
-                var s = BubbleMaxSpeed / MathF.Sqrt(vmag2);
-                vx *= s;
-                vy *= s;
-            }
-
-            var nx = px + vx;
-            var ny = py + vy;
-
-            if (nx < 0f || nx >= dw || ny < 0f || ny >= dh)
-            {
-                RespawnBubbleAtEdge(ref b, dw, dh);
-                continue;
-            }
-
-            b.X = nx;
-            b.Y = ny;
-            DepositFoamLine(foam, dw, dh, px, py, nx, ny);
         }
-
-        return true; // drain active → always moving
     }
 
     /// <summary>
@@ -710,50 +661,6 @@ internal sealed class WhirlpoolPage : IStressPage
         var top = a + (b - a) * fx;
         var bot = c + (d - c) * fx;
         return top + (bot - top) * fy;
-    }
-
-    /// <summary>
-    /// Rasterises a line from (x0,y0) to (x1,y1) into the foam grid,
-    /// accumulating intensity at each integer sub-cell. Brightness
-    /// scales with segment length so the streak fades to invisible
-    /// for stationary bubbles and pops for fast ones.
-    /// </summary>
-    private static void DepositFoamLine(float[] foam, int dw, int dh,
-        float x0, float y0, float x1, float y1)
-    {
-        var dx = x1 - x0;
-        var dy = y1 - y0;
-        var len = MathF.Sqrt(dx * dx + dy * dy);
-        var steps = Math.Max(1, (int)MathF.Ceiling(len));
-        var invSteps = 1f / steps;
-        var stepX = dx * invSteps;
-        var stepY = dy * invSteps;
-        // Base brightness + speed boost. Drifting bubbles add a faint
-        // sheen; fast in-rushing ones add bright streaks.
-        var intensity = MathF.Min(1f, 0.35f + len * 0.4f);
-        for (var s = 0; s <= steps; s++)
-        {
-            var fx = (int)(x0 + stepX * s);
-            var fy = (int)(y0 + stepY * s);
-            if ((uint)fx >= (uint)dw || (uint)fy >= (uint)dh) continue;
-            var idx = fy * dw + fx;
-            var existing = foam[idx];
-            // Saturating add — foam approaches 1 but never overshoots.
-            var v = existing + intensity * (1f - existing);
-            foam[idx] = v;
-        }
-    }
-
-    private void RespawnBubbleAtEdge(ref Bubble b, int dw, int dh)
-    {
-        var edge = NextRandom() & 3;
-        switch (edge)
-        {
-            case 0: b.X = NextFloat() * dw; b.Y = 0f; break;
-            case 1: b.X = NextFloat() * dw; b.Y = dh - 1f; break;
-            case 2: b.X = 0f; b.Y = NextFloat() * dh; break;
-            default: b.X = dw - 1f; b.Y = NextFloat() * dh; break;
-        }
     }
 
     private static Hex1bColor DepthColour(float d)

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -9,51 +9,55 @@ namespace PerfStressDemo;
 /// <summary>
 /// Page 3 — "Whirlpool".
 ///
-/// Top-down water simulated on a half-block grid (each terminal cell holds
-/// two stacked sub-cells, rendered as <c>▀</c> with foreground = top
-/// sub-cell colour and background = bottom sub-cell colour, doubling the
-/// vertical resolution of the simulation).
-///
-/// Water has a per-sub-cell depth in [0, 1]. The whole screen starts at
-/// full depth — a deep blue ocean. Pressure equalises between neighbours
-/// each frame using mass-conserving diffusion, so disturbances spread
-/// outward as flat waves of slightly different depth.
-///
+/// Top-down water simulated on a half-block grid (each terminal cell
+/// renders as <c>▀</c> with foreground = top sub-cell colour and
+/// background = bottom sub-cell colour, doubling the vertical
+/// simulation resolution). Two layered physics fields:
 /// <list type="bullet">
-///   <item>Left click — open a drain at the cursor. Water in a small disc
-///         around the drain is consumed each frame; the surrounding water
-///         flows in to fill the void.</item>
-///   <item>Right click — close the drain. Edge inlets begin pulsing water
-///         back into the basin at random positions; the basin gradually
-///         refills. Once every sub-cell is at maximum depth no further
-///         inlets spawn and the system goes idle.</item>
-///   <item>Scroll — adjust drain strength (clamped). Scroll up = stronger.</item>
+///   <item><b>Baseline depth</b> — slow-evolving bulk water level in
+///         <c>[0, 1]</c>. Drain consumes it at the cursor; refill
+///         relaxes the edges back toward full when the drain is shut.
+///         Semi-Lagrangian-advected by a potential-flow velocity
+///         field while the drain is open, which spirals the radial
+///         depth dip into logarithmic-spiral contours.</item>
+///   <item><b>Wave field</b> — high-frequency signed displacement
+///         around zero, evolved by the same 2D wave-equation scheme
+///         as the pond page (ping-pong buffers, neighbour-average
+///         minus previous, damped). Sources of energy:
+///         a continuous negative impulse at the drain (turbulence at
+///         the hole), continuous positive impulses along the edges
+///         during refill (water rushing in), and a sprinkle of
+///         random small chop while anything is active (the ocean's
+///         own movement).</item>
 /// </list>
 ///
-/// Colour: empty sub-cell = warm sandy beach; shallow = light blue;
-/// full = deep ocean blue. Lerped continuously so a draining basin
-/// reads as a colour gradient from beach (at the centre) to ocean (at
-/// the edges).
+/// Display blends the two: each sub-cell renders
+/// <c>baseline + WaveDisplayScale * wave</c>, clamped to <c>[0, 1]</c>
+/// and lerped through the sand → shallow → deep colour ramp.
 ///
-/// Stress profile: two w·2h-sized passes per frame (diffusion delta
-/// pass + apply pass) over a flat float[] grid, plus one cell write per
-/// surface cell on the render pass. Exercises tight numeric loops on
-/// large flat buffers — distinct from the scattered sparse writes of
-/// the earlier particle prototype.
+/// Controls:
+/// <list type="bullet">
+///   <item><b>Left click</b> — open the drain at the cursor. Water
+///         drains; if held long enough the basin empties completely.</item>
+///   <item><b>Right click</b> — close the drain. The basin refills
+///         from the edges; once full and the ripples die out, the
+///         page reports IsIdle and the framework sleeps.</item>
+///   <item><b>Scroll up/down</b> — adjust drain strength.</item>
+/// </list>
 /// </summary>
 internal sealed class WhirlpoolPage : IStressPage
 {
     public string Name => "Whirlpool";
 
     public string Description =>
-        "Half-block water field with mouse-controlled drain and edge inlets. "
-        + "Left click opens a drain, right click closes and basin refills.";
+        "Layered baseline + wave-equation water. Left click drains; "
+        + "right click refills from the edges; scroll for drain strength.";
 
     // ----------------------------------------------------------------
-    // Simulation grid. _depth[y * dotWidth + x] holds the water depth
-    // in [0, MaxDepth] for sub-cell (x, y). _delta is the change to
-    // apply this step (computed in pass 1, applied in pass 2 so flow
-    // is order-independent).
+    // Baseline depth grid. _depth[y * dotWidth + x] holds the water
+    // depth in [0, MaxDepth] for sub-cell (x, y). _delta is a scratch
+    // buffer used both as the advection destination and as the
+    // diffusion delta accumulator.
     // ----------------------------------------------------------------
     private float[] _depth = Array.Empty<float>();
     private float[] _delta = Array.Empty<float>();
@@ -63,10 +67,17 @@ internal sealed class WhirlpoolPage : IStressPage
     private int _dotHeight;
 
     // ----------------------------------------------------------------
-    // Drain state. _drainActive gates consumption; the well can be
-    // placed (left click) or removed (right click) independently of
-    // its position. Coords are in surface (cell) units — they're
-    // doubled to sub-cell units when the drain is applied.
+    // Wave field — pond-style 2D wave equation with ping-pong
+    // buffers. _wave / _wavePrev oscillate around zero; the renderer
+    // adds a scaled fraction onto the baseline depth for the final
+    // sub-cell value.
+    // ----------------------------------------------------------------
+    private float[] _wave = Array.Empty<float>();
+    private float[] _wavePrev = Array.Empty<float>();
+
+    // ----------------------------------------------------------------
+    // Drain state. _drainActive gates consumption; placement (left
+    // click) and removal (right click) are independent.
     // ----------------------------------------------------------------
     private bool _drainActive;
     private float _drainX;
@@ -77,86 +88,52 @@ internal sealed class WhirlpoolPage : IStressPage
     private const float MaxStrength = 4.0f;
 
     // ----------------------------------------------------------------
-    // Ocean swell. The depth field starts flat and a flat field
-    // gives advection nothing to organise into spirals — pulling
-    // the plug on a glassy bathtub doesn't form a visible whirlpool
-    // either; you need the river/ocean's existing texture for the
-    // vortex to wind into spiral arms.
-    //
-    // Each frame (while active) we relax depth toward a moving
-    // multi-octave sinusoidal swell. The relaxation rate is small
-    // enough that the drain and inlets always dominate locally, but
-    // in calm regions the field gets continuously stirred and
-    // advection winds those wave patterns into the drain.
-    //
-    // _swellAmpScale ramps to 1 while there's any activity (drain
-    // open, inlets running) and decays back to zero when everything
-    // settles — so the truly idle ocean is glassy still and the
-    // page can sleep.
+    // Physics constants — baseline.
     // ----------------------------------------------------------------
-    private float _swellAmpScale;
-    private const float SwellAmpBase = 0.06f;       // depth units, peak deviation
-    private const float SwellBlendRate = 0.035f;    // toward target per frame
-    private const float SwellPhaseRate = 0.05f;     // radians per frame
-    private const float SwellNominalLevel = 0.93f;  // mean depth the swell sits around
-    private const float SwellAmpDecay = 0.96f;      // per frame when no activity
+    private const float MaxDepth = 1.0f;
+    private const float DiffusionK = 0.045f;
+    private const float DrainRadius = 6.5f;        // sub-cells
+    private const float DrainPerFrameBase = 0.32f;
+    // Refill (drain off): pull baseline toward MaxDepth at an edge-
+    // weighted rate so water visibly "flows in" from outside. Edge
+    // cells fill in ~1s, interior fills via diffusion + the small
+    // base rate over a few more seconds.
+    private const float RefillEdgeRate = 0.045f;
+    private const float RefillBaseRate = 0.004f;
+    private const int   RefillReachCells = 8;       // edge boost falls off over this many sub-cells
 
     // ----------------------------------------------------------------
-    // Potential-flow velocity field. A 2D sink at the drain has
-    // velocity v_r = -Q/r (inward); adding a free vortex of
-    // circulation Γ gives v_θ = Γ/r (tangential). Streamlines are
-    // logarithmic spirals at angle atan(Γ/Q) from the radial.
-    // VelocitySoftening avoids the 1/0 singularity at the drain
-    // centre and keeps the cell-skip rate manageable.
+    // Physics constants — wave equation. Matches pond's "light"
+    // preset feel: lively but settles in reasonable time without
+    // continuous forcing.
+    // ----------------------------------------------------------------
+    private const float WaveDamping = 0.985f;
+    private const float WaveDisplayScale = 0.32f;   // how much wave modulates rendered depth
+    private const float WaveFloor = 0.005f;          // floor for "alive" tracking
+    private const float DrainImpulse = -0.18f;       // per frame, at drain centre
+    private const float RefillImpulse = 0.12f;       // per frame, per active edge cell during refill
+    private const float ChopAmplitude = 0.06f;       // random impulse magnitude while active
+    private const int   ChopPerFrame = 4;            // random chop sites per frame while active
+
+    // ----------------------------------------------------------------
+    // Potential-flow velocity field for advection of the baseline:
+    //   v(r) = -Q/(r+s) r_hat + G/(r+s) theta_hat
+    // With G ≈ 2Q the streamlines are ~63° spirals. VelocitySoftening
+    // tames the 1/0 singularity at the drain centre.
     // ----------------------------------------------------------------
     private const float SinkStrength = 9.0f;
-    private const float SwirlStrength = 18.0f;         // Γ ~ 2Q → ~63° spirals
+    private const float SwirlStrength = 18.0f;
     private const float VelocitySoftening = 2.5f;
 
     // ----------------------------------------------------------------
-    // Inlets — small periodically-spawned sources on the screen edge.
-    // Active only when the drain is OFF and the basin isn't full;
-    // each inlet pulses its flow with a sinusoidal envelope so they
-    // visibly fade in and out at varying strengths instead of being
-    // hard step functions.
+    // Activity tracking. _activity ramps to 1 whenever something is
+    // happening (drain open OR basin not full) and decays to 0 when
+    // everything settles. Used to gate wave-injection (chop / refill
+    // impulses) and IsIdle.
     // ----------------------------------------------------------------
-    private struct Inlet
-    {
-        public int X;            // sub-cell coords (dot units)
-        public int Y;
-        public float PeakRate;   // depth added per frame at envelope peak
-        public int Age;          // frames since spawned
-        public int Lifetime;     // total frames before removal
-    }
+    private float _activity;
+    private const float ActivityDecay = 0.04f;       // per frame when no activity
 
-    private readonly List<Inlet> _inlets = new(16);
-    private int _framesUntilNextInletCheck;
-
-    // ----------------------------------------------------------------
-    // Physics constants.
-    // ----------------------------------------------------------------
-    private const float MaxDepth = 1.0f;
-    // Diffusion rate per neighbour per frame. Kept small now that
-    // advection is the primary transport — too much diffusion blurs
-    // away the spiral contours that advection deliberately creates.
-    private const float DiffusionK = 0.045f;
-    private const float DrainRadius = 6.5f;       // sub-cell units
-    private const float DrainPerFrameBase = 0.28f; // strength multiplier
-    private const int   InletCheckInterval = 12;   // frames between spawn attempts
-    private const int   InletMaxConcurrent = 6;
-    private const int   InletLifetimeMin = 90;
-    private const int   InletLifetimeMax = 220;
-    private const float InletPeakRateMin = 0.015f;
-    private const float InletPeakRateMax = 0.045f;
-    private const float InletRadius = 2.5f;        // sub-cell units, spread of deposit
-
-    // ----------------------------------------------------------------
-    // Quiescence tracking — used by IsIdle so the framework can sleep
-    // when the basin is completely full, the drain is off, and no
-    // inlets are active. The diffusion delta sum is the cheapest
-    // "anything moving?" detector available since we already compute
-    // every cell's delta in the diffusion pass.
-    // ----------------------------------------------------------------
     private bool _quiescent = true;
     public bool IsIdle => _quiescent;
 
@@ -164,7 +141,7 @@ internal sealed class WhirlpoolPage : IStressPage
     public static float CurrentStrength { get; private set; } = 1.0f;
     public static bool DrainOpen { get; private set; }
 
-    // xorshift32 — small, fast, allocation-free, deterministic seed.
+    // xorshift32 RNG — small, fast, deterministic seed.
     private uint _rng = 0xDEADBEEFu;
     private uint NextRandom()
     {
@@ -175,19 +152,16 @@ internal sealed class WhirlpoolPage : IStressPage
     }
     private float NextFloat() => (NextRandom() & 0xFFFFFF) / (float)0x1000000;
 
-    // Pre-computed colour endpoints. SurfaceCell stores Hex1bColor
-    // values so we avoid allocating new ones in the hot render loop
-    // by lerping bytes and constructing the colour once per cell.
-    private static readonly (byte R, byte G, byte B) SandColour = (235, 215, 175); // warm beach
-    private static readonly (byte R, byte G, byte B) ShallowColour = (160, 220, 245); // pale aqua
-    private static readonly (byte R, byte G, byte B) MidColour = (40, 130, 200);      // mid teal-blue
-    private static readonly (byte R, byte G, byte B) DeepColour = (8, 40, 100);       // deep ocean
+    // Colour stops. Pre-built as byte triples so the per-cell lerp
+    // doesn't allocate.
+    private static readonly (byte R, byte G, byte B) SandColour    = (235, 215, 175);
+    private static readonly (byte R, byte G, byte B) ShallowColour = (160, 220, 245);
+    private static readonly (byte R, byte G, byte B) MidColour     = (40, 130, 200);
+    private static readonly (byte R, byte G, byte B) DeepColour    = (8, 40, 100);
 
     public Hex1bWidget Build(StressContext sc)
     {
-        // Surface needs an Interactable wrapper to participate in mouse
-        // event routing; the pond's position-tracking goes through a
-        // separate (poll-based) path that doesn't need this.
+        // Surface alone doesn't route mouse events; Interactable does.
         var widget = sc.Root.Interactable(ic =>
             ic.Surface(layer =>
             {
@@ -203,14 +177,13 @@ internal sealed class WhirlpoolPage : IStressPage
                     _drainX = ctx.MouseX;
                     _drainY = ctx.MouseY;
                     _drainActive = true;
+                    _activity = 1f;
                     _quiescent = false;
                 });
                 bindings.Mouse(MouseButton.Right).Action(_ =>
                 {
                     _drainActive = false;
-                    // Don't flip _quiescent here — inlets / refilling
-                    // still need ticks. The diffusion pass will set it
-                    // true again once everything settles.
+                    // Don't flip _quiescent — refill still has work to do.
                 });
                 bindings.Mouse(MouseButton.ScrollUp).Action(_ =>
                 {
@@ -222,8 +195,6 @@ internal sealed class WhirlpoolPage : IStressPage
                 });
             });
 
-        // Drop RedrawAfter when the basin is fully settled so the root
-        // can idle.
         return _quiescent ? widget : widget.RedrawAfter(sc.RedrawIntervalMs);
     }
 
@@ -233,15 +204,15 @@ internal sealed class WhirlpoolPage : IStressPage
             return;
         _surfaceWidth = w;
         _surfaceHeight = h;
-        _dotWidth = w;          // one sub-cell per cell horizontally
-        _dotHeight = h * 2;     // two sub-cells per cell vertically (half-block)
+        _dotWidth = w;
+        _dotHeight = h * 2;
         var n = _dotWidth * _dotHeight;
         _depth = new float[n];
         _delta = new float[n];
-        // Start full — deep ocean everywhere.
+        _wave = new float[n];
+        _wavePrev = new float[n];
         Array.Fill(_depth, MaxDepth);
-        _inlets.Clear();
-        _swellAmpScale = 0f;
+        _activity = 0f;
         _quiescent = true;
     }
 
@@ -257,19 +228,12 @@ internal sealed class WhirlpoolPage : IStressPage
         var depth = _depth;
         var delta = _delta;
 
-        // ---- Pass 0: advection. When the drain is open, semi-
-        //      Lagrangian-advect the depth field by the analytic
-        //      potential-flow velocity. This is what makes spiral
-        //      contours appear: the radial-plus-tangential velocity
-        //      drags the depth dip created by the drain around in
-        //      logarithmic spirals. Without this step the depth
-        //      field would stay rotationally symmetric no matter
-        //      what.
+        // ---- Pass 0: advection of baseline when drain is open. Same
+        //      analytic potential-flow field that drives the spiral
+        //      look in the original whirlpool draft.
         if (_drainActive)
         {
             AdvectField(depth, delta, dw, dh);
-            // delta now holds the advected field. Swap so the rest
-            // of Step reads/writes the advected one.
             (depth, delta) = (delta, depth);
             _depth = depth;
             _delta = delta;
@@ -277,13 +241,7 @@ internal sealed class WhirlpoolPage : IStressPage
 
         Array.Clear(delta, 0, delta.Length);
 
-        // ---- Pass 1: diffusion. Flow between each cell and its right
-        //      and down neighbours; doing only two of the four edges
-        //      per cell visits every edge exactly once (every pair
-        //      shares exactly one direction). Symmetric add/subtract
-        //      makes the operation mass-conserving by construction.
-        //      Kept gentle so spiral contours from advection survive
-        //      a few frames before being smoothed out.
+        // ---- Pass 1: gentle diffusion of baseline.
         var anyFlow = false;
         for (var y = 0; y < dh; y++)
         {
@@ -292,7 +250,6 @@ internal sealed class WhirlpoolPage : IStressPage
             {
                 var i = row + x;
                 var di = depth[i];
-                // Right neighbour
                 if (x + 1 < dw)
                 {
                     var j = i + 1;
@@ -301,7 +258,6 @@ internal sealed class WhirlpoolPage : IStressPage
                     delta[i] -= f;
                     delta[j] += f;
                 }
-                // Down neighbour
                 if (y + 1 < dh)
                 {
                     var j = i + dw;
@@ -313,7 +269,6 @@ internal sealed class WhirlpoolPage : IStressPage
             }
         }
 
-        // ---- Pass 2: apply deltas, then drain, then inlets.
         var changed = anyFlow;
         for (var i = 0; i < depth.Length; i++)
         {
@@ -323,64 +278,52 @@ internal sealed class WhirlpoolPage : IStressPage
             depth[i] = d;
         }
 
+        // ---- Pass 2: drain (consume baseline at cursor) or refill
+        //      (pull baseline back up toward MaxDepth from edges).
+        var basinFull = true;
         if (_drainActive)
         {
             changed |= ApplyDrain(depth, dw, dh);
-        }
-
-        // Inlets only spawn / pulse when the drain is OFF, mirroring
-        // the spec: open drain == active draining, closed drain ==
-        // refill phase.
-        if (!_drainActive)
-        {
-            changed |= TickInlets(depth, dw, dh);
-        }
-
-        // ---- Ocean swell. Runs whenever there's activity (drain
-        //      open OR inlets running). When activity stops, the
-        //      amplitude decays to zero so the basin returns to a
-        //      perfectly still mirror — which is when the page can
-        //      finally idle.
-        if (_drainActive || _inlets.Count > 0)
-        {
-            _swellAmpScale = 1f;
+            basinFull = false; // doesn't matter, _drainActive forces activity
         }
         else
         {
-            _swellAmpScale *= SwellAmpDecay;
-            if (_swellAmpScale < 0.01f) _swellAmpScale = 0f;
-        }
-        var swellActive = _swellAmpScale > 0.01f;
-        if (swellActive)
-        {
-            InjectSwell(depth, dw, dh);
+            changed |= ApplyRefill(depth, dw, dh, out basinFull);
         }
 
-        _quiescent = !changed
-            && _inlets.Count == 0
-            && !_drainActive
-            && !swellActive;
+        // ---- Pass 3: activity tracking. Wave injection, chop, and
+        //      idleness all key off this single scalar.
+        if (_drainActive || !basinFull)
+        {
+            _activity = 1f;
+        }
+        else
+        {
+            _activity = MathF.Max(0f, _activity - ActivityDecay);
+        }
+        var active = _activity > 0.05f;
+
+        // ---- Pass 4: inject impulses into the wave field, then run
+        //      the wave-equation step. Wave runs every frame so
+        //      energy injected last frame propagates immediately.
+        if (active)
+        {
+            InjectWaveImpulses(dw, dh);
+        }
+        var waveAlive = WaveStep(dw, dh);
+
+        _quiescent = !changed && !active && !waveAlive;
     }
 
-    /// <summary>
-    /// Subtracts water inside a disc around the drain. Falls off linearly
-    /// with distance from the centre so the boundary doesn't appear as a
-    /// hard ring; clamps each cell to zero so we don't generate negative
-    /// depth (which would otherwise inject "anti-water" into the
-    /// diffusion pass on subsequent frames).
-    /// </summary>
     private bool ApplyDrain(float[] depth, int dw, int dh)
     {
-        // Drain coords arrive in cell units; convert to sub-cell. The
-        // user clicked between two stacked sub-cells, so target the
-        // boundary by adding 1 (so y*2 + 1 lands on the lower half).
         var cx = _drainX;
         var cy = _drainY * 2 + 0.5f;
         var rate = DrainPerFrameBase * _strength;
         var r2 = DrainRadius * DrainRadius;
         var x0 = Math.Max(0, (int)(cx - DrainRadius));
         var x1 = Math.Min(dw - 1, (int)(cx + DrainRadius + 0.5f));
-        var y0 = Math.Max(0, (int)(cy - DrainRadius * 2));   // x2 to compensate for cell aspect
+        var y0 = Math.Max(0, (int)(cy - DrainRadius * 2));
         var y1 = Math.Min(dh - 1, (int)(cy + DrainRadius * 2 + 0.5f));
         var changed = false;
         for (var y = y0; y <= y1; y++)
@@ -388,7 +331,7 @@ internal sealed class WhirlpoolPage : IStressPage
             for (var x = x0; x <= x1; x++)
             {
                 var dx = x - cx;
-                var dy = (y - cy) * 0.5f; // halve y delta — terminal cells are ~2x tall as wide
+                var dy = (y - cy) * 0.5f;
                 var d2 = dx * dx + dy * dy;
                 if (d2 > r2) continue;
                 var falloff = 1f - MathF.Sqrt(d2) / DrainRadius;
@@ -404,222 +347,159 @@ internal sealed class WhirlpoolPage : IStressPage
     }
 
     /// <summary>
-    /// Periodically spawns new inlet sources on the screen edge (only
-    /// when not already at saturation), advances existing inlets, and
-    /// retires expired ones. Each inlet's flow follows a sinusoidal
-    /// envelope so it visibly fades in and out instead of stepping
-    /// on/off.
+    /// Pulls the baseline back toward <see cref="MaxDepth"/> at a
+    /// rate that decays from the screen edge toward the interior.
+    /// Edge cells refill in roughly a second; interior cells rely on
+    /// diffusion (and a tiny base rate) to top up. <paramref name="basinFull"/>
+    /// is set true if every cell ended up within a small epsilon of
+    /// MaxDepth this frame — used by the activity tracker.
     /// </summary>
-    private bool TickInlets(float[] depth, int dw, int dh)
+    private bool ApplyRefill(float[] depth, int dw, int dh, out bool basinFull)
     {
         var changed = false;
-
-        // Cheap saturation check — if any cell is below MaxDepth -
-        // epsilon, we still have room. Single pass, early exit.
-        var roomToFill = false;
-        for (var i = 0; i < depth.Length; i++)
+        basinFull = true;
+        var reach = RefillReachCells;
+        var edgeBoost = RefillEdgeRate - RefillBaseRate;
+        var basMax = MaxDepth - 0.003f;
+        for (var y = 0; y < dh; y++)
         {
-            if (depth[i] < MaxDepth - 0.005f) { roomToFill = true; break; }
-        }
-
-        // Maybe spawn a new inlet.
-        if (--_framesUntilNextInletCheck <= 0)
-        {
-            _framesUntilNextInletCheck = InletCheckInterval;
-            if (roomToFill && _inlets.Count < InletMaxConcurrent)
+            var rowBaseY = y * dw;
+            var ed_y = Math.Min(y, dh - 1 - y);
+            for (var x = 0; x < dw; x++)
             {
-                _inlets.Add(SpawnInlet(dw, dh));
-            }
-        }
-
-        // Advance / apply / retire inlets.
-        for (var k = _inlets.Count - 1; k >= 0; k--)
-        {
-            var inlet = _inlets[k];
-            inlet.Age++;
-            if (inlet.Age >= inlet.Lifetime)
-            {
-                _inlets.RemoveAt(k);
-                continue;
-            }
-            // Sin envelope: 0 at birth, 1 at midlife, 0 at death.
-            var phase = MathF.PI * inlet.Age / inlet.Lifetime;
-            var envelope = MathF.Sin(phase);
-            var rate = inlet.PeakRate * envelope;
-            if (DepositInlet(depth, dw, dh, inlet.X, inlet.Y, rate))
-                changed = true;
-            _inlets[k] = inlet;
-        }
-
-        return changed;
-    }
-
-    private Inlet SpawnInlet(int dw, int dh)
-    {
-        var edge = NextRandom() & 3;
-        int x, y;
-        switch (edge)
-        {
-            case 0: x = (int)(NextFloat() * dw); y = 0; break;
-            case 1: x = (int)(NextFloat() * dw); y = dh - 1; break;
-            case 2: x = 0; y = (int)(NextFloat() * dh); break;
-            default: x = dw - 1; y = (int)(NextFloat() * dh); break;
-        }
-        var peak = InletPeakRateMin
-            + NextFloat() * (InletPeakRateMax - InletPeakRateMin);
-        var life = InletLifetimeMin
-            + (int)(NextFloat() * (InletLifetimeMax - InletLifetimeMin));
-        return new Inlet
-        {
-            X = x,
-            Y = y,
-            PeakRate = peak,
-            Age = 0,
-            Lifetime = life,
-        };
-    }
-
-    private bool DepositInlet(float[] depth, int dw, int dh, int cx, int cy, float rate)
-    {
-        if (rate <= 0f) return false;
-        var r2 = InletRadius * InletRadius;
-        var x0 = Math.Max(0, cx - (int)InletRadius);
-        var x1 = Math.Min(dw - 1, cx + (int)InletRadius);
-        var y0 = Math.Max(0, cy - (int)(InletRadius * 2));
-        var y1 = Math.Min(dh - 1, cy + (int)(InletRadius * 2));
-        var changed = false;
-        for (var y = y0; y <= y1; y++)
-        {
-            for (var x = x0; x <= x1; x++)
-            {
-                var dx = x - cx;
-                var dy = (y - cy) * 0.5f;
-                var d2 = dx * dx + dy * dy;
-                if (d2 > r2) continue;
-                var falloff = 1f - MathF.Sqrt(d2) / InletRadius;
-                var add = rate * falloff;
-                var i = y * dw + x;
-                var nv = depth[i] + add;
+                var i = rowBaseY + x;
+                var d = depth[i];
+                if (d < basMax) basinFull = false;
+                var ed_x = Math.Min(x, dw - 1 - x);
+                var edgeDist = Math.Min(ed_x, ed_y);
+                var edgeFactor = edgeDist >= reach ? 0f : 1f - edgeDist / (float)reach;
+                var rate = RefillBaseRate + edgeBoost * edgeFactor;
+                var nv = d + (MaxDepth - d) * rate;
                 if (nv > MaxDepth) nv = MaxDepth;
-                if (nv != depth[i]) { depth[i] = nv; changed = true; }
+                if (nv != d) { depth[i] = nv; changed = true; }
             }
         }
         return changed;
     }
 
     /// <summary>
-    /// Renders the depth field using half-blocks. Each terminal cell
-    /// shows two stacked sub-cells via the upper-half-block character
-    /// (<c>▀</c>): foreground is the top sub-cell colour, background
-    /// is the bottom sub-cell colour. This doubles the vertical
-    /// simulation resolution at no extra render cost.
+    /// Injects energy into the wave field. Three sources:
+    /// (1) a continuous negative impulse at the drain centre while
+    /// the drain is open (the suction is felt as turbulence);
+    /// (2) continuous positive impulses scattered along the screen
+    /// edges during refill (water rushing in splashes); (3) a few
+    /// small random impulses anywhere on the field while anything is
+    /// active, giving the ocean its own background chop.
     /// </summary>
-    private void DrawWater(Surface surface)
+    private void InjectWaveImpulses(int dw, int dh)
     {
-        var w = surface.Width;
-        var h = surface.Height;
-        var dw = _dotWidth;
-        var depth = _depth;
-
-        for (var cy = 0; cy < h; cy++)
-        {
-            var topRow = (cy * 2) * dw;
-            var botRow = (cy * 2 + 1) * dw;
-            for (var cx = 0; cx < w; cx++)
-            {
-                var topCol = DepthColour(depth[topRow + cx]);
-                var botCol = DepthColour(depth[botRow + cx]);
-                surface[cx, cy] = new SurfaceCell("▀", topCol, botCol);
-            }
-        }
+        var wave = _wave;
+        var amp = _activity;
 
         if (_drainActive)
         {
-            var mx = (int)_drainX;
-            var my = (int)_drainY;
-            if ((uint)mx < (uint)w && (uint)my < (uint)h)
-            {
-                var bg = DepthColour(depth[(my * 2 + 1) * dw + mx]);
-                surface[mx, my] = new SurfaceCell("◉",
-                    Hex1bColor.FromRgb(255, 240, 200), bg);
-            }
+            var cx = (int)_drainX;
+            var cy = (int)(_drainY * 2 + 0.5f);
+            var imp = DrainImpulse * _strength * amp;
+            Splat(wave, dw, dh, cx, cy, imp);
         }
-    }
-
-    /// <summary>
-    /// Blends each depth cell toward a slowly evolving multi-octave
-    /// sinusoidal swell. This injects the ocean-like surface texture
-    /// that a real whirlpool organises into spiral arms — a perfectly
-    /// flat field has nothing for advection to wind up. The blend
-    /// rate is small enough that the drain and inlets always
-    /// dominate locally, but the swell continuously stirs calm
-    /// regions and (via advection in Pass 0) gets pulled into the
-    /// drain as visible spiral contours.
-    /// </summary>
-    private void InjectSwell(float[] depth, int dw, int dh)
-    {
-        var amp = SwellAmpBase * _swellAmpScale;
-        var blend = SwellBlendRate * _swellAmpScale;
-        var t = _frame * SwellPhaseRate;
-        // Pre-bake phase terms that don't depend on x so the inner
-        // loop reduces to a couple of muls + sin per octave.
-        var t1 = t;
-        var t2 = t * 1.7f;
-        var t3 = t * 2.4f;
-        for (var y = 0; y < dh; y++)
+        else
         {
-            var yt1 = y * 0.08f;
-            var yt2 = y * -0.13f;
-            var yt3 = y * 0.21f;
-            var row = y * dw;
-            for (var x = 0; x < dw; x++)
+            // Refill — drop a few positive splashes along whichever
+            // edge the RNG picks each frame. Read as bubbling springs
+            // running inward.
+            for (var k = 0; k < 3; k++)
             {
-                // 3 octaves: long swell + cross-direction medium + fine ripple.
-                var n = MathF.Sin(x * 0.07f + yt1 + t1) * 0.55f
-                      + MathF.Sin(x * 0.13f + yt2 + t2) * 0.30f
-                      + MathF.Sin(x * 0.21f + yt3 + t3) * 0.15f;
-                var target = SwellNominalLevel + amp * n;
-                if (target > MaxDepth) target = MaxDepth;
-                else if (target < 0f) target = 0f;
-                var i = row + x;
-                depth[i] += (target - depth[i]) * blend;
+                var edge = NextRandom() & 3;
+                int ex, ey;
+                switch (edge)
+                {
+                    case 0: ex = (int)(NextFloat() * dw); ey = 0; break;
+                    case 1: ex = (int)(NextFloat() * dw); ey = dh - 1; break;
+                    case 2: ex = 0; ey = (int)(NextFloat() * dh); break;
+                    default: ex = dw - 1; ey = (int)(NextFloat() * dh); break;
+                }
+                Splat(wave, dw, dh, ex, ey, RefillImpulse * amp);
+            }
+        }
+
+        // Background ocean chop — small scattered impulses.
+        for (var k = 0; k < ChopPerFrame; k++)
+        {
+            var cx = (int)(NextFloat() * dw);
+            var cy = (int)(NextFloat() * dh);
+            var sign = (NextRandom() & 1) == 0 ? 1f : -1f;
+            var i = cy * dw + cx;
+            if ((uint)i < (uint)wave.Length)
+                wave[i] += ChopAmplitude * amp * sign;
+        }
+    }
+
+    /// <summary>3×3 soft splat of an impulse into the wave field.</summary>
+    private static void Splat(float[] wave, int dw, int dh, int cx, int cy, float amp)
+    {
+        for (var dy = -1; dy <= 1; dy++)
+        {
+            var y = cy + dy;
+            if ((uint)y >= (uint)dh) continue;
+            for (var dx = -1; dx <= 1; dx++)
+            {
+                var x = cx + dx;
+                if ((uint)x >= (uint)dw) continue;
+                var f = (dx == 0 && dy == 0) ? 1f : ((dx == 0 || dy == 0) ? 0.5f : 0.25f);
+                wave[y * dw + x] += amp * f;
             }
         }
     }
 
     /// <summary>
-    /// Computes the 2D potential-flow velocity at a sample point: a
-    /// sink (radial inflow) plus a free vortex (tangential swirl),
-    /// both with <c>1/(r + softening)</c> falloff. With Γ ≈ 2Q the
-    /// streamlines are tight logarithmic spirals at ≈63° from the
-    /// radial — visually a strong whirlpool.
+    /// Pond-style discretised 2D wave-equation step:
+    /// <c>next = (sum of 4 neighbours)/2 - prev; next *= damping</c>.
+    /// Ping-pongs <see cref="_wave"/> and <see cref="_wavePrev"/>.
+    /// Returns true if any cell carries energy above the floor.
     /// </summary>
+    private bool WaveStep(int dw, int dh)
+    {
+        var cur = _wave;
+        var prv = _wavePrev;
+        var anyAlive = false;
+        for (var y = 1; y < dh - 1; y++)
+        {
+            var row = y * dw;
+            for (var x = 1; x < dw - 1; x++)
+            {
+                var i = row + x;
+                var nb = cur[i - 1] + cur[i + 1] + cur[i - dw] + cur[i + dw];
+                var next = (nb * 0.5f) - prv[i];
+                next *= WaveDamping;
+                if (next > -WaveFloor && next < WaveFloor) next = 0f;
+                else anyAlive = true;
+                prv[i] = next;
+            }
+        }
+        (_wave, _wavePrev) = (prv, cur);
+        return anyAlive;
+    }
+
     private static void VelocityAt(float x, float y, float cx, float cy,
         float Q, float G, float soft, out float vx, out float vy)
     {
         var dx = x - cx;
         var dy = y - cy;
-        var r2 = dx * dx + dy * dy;
-        var r = MathF.Sqrt(r2);
+        var r = MathF.Sqrt(dx * dx + dy * dy);
         var inv = 1f / (r + 1e-4f);
         var mag = 1f / (r + soft);
-        // Unit radial outward (rx, ry); tangential CCW is (-ry, rx).
         var rx = dx * inv;
         var ry = dy * inv;
-        // v = -Q * r_hat + G * t_hat
         vx = -Q * mag * rx + G * mag * (-ry);
         vy = -Q * mag * ry + G * mag *  rx;
     }
 
     /// <summary>
-    /// Semi-Lagrangian advection: for each destination cell, trace
-    /// the velocity field backwards by one step and sample the source
-    /// field (bilinearly) at that upstream position. Unconditionally
-    /// stable for any timestep — the price is some numerical
-    /// diffusion, but at our 1-frame dt and small velocities outside
-    /// the drain core, it's tolerable. Cells whose upstream sample
-    /// falls outside the grid clamp to MaxDepth, on the assumption
-    /// that "outside" is an effectively infinite ocean.
+    /// Semi-Lagrangian advection of <paramref name="src"/> into
+    /// <paramref name="dst"/>. Out-of-grid samples return 0 so the
+    /// basin actually drains while the drain is open instead of
+    /// being topped up by a fictitious infinite ocean.
     /// </summary>
     private void AdvectField(float[] src, float[] dst, int dw, int dh)
     {
@@ -636,18 +516,14 @@ internal sealed class WhirlpoolPage : IStressPage
                 VelocityAt(x, y, cx, cy, Q, G, soft, out var vx, out var vy);
                 var sx = x - vx;
                 var sy = y - vy;
-                dst[row + x] = SampleBilinear(src, dw, dh, sx, sy);
+                dst[row + x] = SampleBilinearOrZero(src, dw, dh, sx, sy);
             }
         }
     }
 
-    private static float SampleBilinear(float[] field, int dw, int dh, float x, float y)
+    private static float SampleBilinearOrZero(float[] field, int dw, int dh, float x, float y)
     {
-        // Outside-grid samples treat the basin as surrounded by full
-        // ocean — this is what makes the basin try to "refill" itself
-        // along the streamlines that wrap in from the screen edges.
-        if (x < 0f || x > dw - 1f || y < 0f || y > dh - 1f)
-            return MaxDepth;
+        if (x < 0f || x > dw - 1f || y < 0f || y > dh - 1f) return 0f;
         var x0 = (int)x;
         var y0 = (int)y;
         var x1 = Math.Min(x0 + 1, dw - 1);
@@ -663,23 +539,50 @@ internal sealed class WhirlpoolPage : IStressPage
         return top + (bot - top) * fy;
     }
 
+    private void DrawWater(Surface surface)
+    {
+        var w = surface.Width;
+        var h = surface.Height;
+        var dw = _dotWidth;
+        var depth = _depth;
+        var wave = _wave;
+
+        for (var cy = 0; cy < h; cy++)
+        {
+            var topRow = (cy * 2) * dw;
+            var botRow = (cy * 2 + 1) * dw;
+            for (var cx = 0; cx < w; cx++)
+            {
+                var iTop = topRow + cx;
+                var iBot = botRow + cx;
+                var topV = depth[iTop] + WaveDisplayScale * wave[iTop];
+                var botV = depth[iBot] + WaveDisplayScale * wave[iBot];
+                if (topV < 0f) topV = 0f; else if (topV > 1f) topV = 1f;
+                if (botV < 0f) botV = 0f; else if (botV > 1f) botV = 1f;
+                surface[cx, cy] = new SurfaceCell("▀",
+                    DepthColour(topV), DepthColour(botV));
+            }
+        }
+
+        if (_drainActive)
+        {
+            var mx = (int)_drainX;
+            var my = (int)_drainY;
+            if ((uint)mx < (uint)w && (uint)my < (uint)h)
+            {
+                var bg = DepthColour(depth[(my * 2 + 1) * dw + mx]);
+                surface[mx, my] = new SurfaceCell("◉",
+                    Hex1bColor.FromRgb(255, 240, 200), bg);
+            }
+        }
+    }
+
     private static Hex1bColor DepthColour(float d)
     {
-        // Three-segment lerp tuned so the full [0, 1] depth range is
-        // visually distinguishable: a partially-drained cell at 0.7
-        // must read clearly differently from the surrounding 1.0
-        // ocean, otherwise the whirlpool's gradient is invisible.
-        // Bands: sand → shallow (0..0.2) → mid (0.2..0.6) → deep (0.6..1).
         if (d <= 0f) return Hex1bColor.FromRgb(SandColour.R, SandColour.G, SandColour.B);
         if (d >= 1f) return Hex1bColor.FromRgb(DeepColour.R, DeepColour.G, DeepColour.B);
-        if (d < 0.2f)
-        {
-            return Lerp(SandColour, ShallowColour, d / 0.2f);
-        }
-        if (d < 0.6f)
-        {
-            return Lerp(ShallowColour, MidColour, (d - 0.2f) / 0.4f);
-        }
+        if (d < 0.2f) return Lerp(SandColour, ShallowColour, d / 0.2f);
+        if (d < 0.6f) return Lerp(ShallowColour, MidColour, (d - 0.2f) / 0.4f);
         return Lerp(MidColour, DeepColour, (d - 0.6f) / 0.4f);
     }
 

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -61,22 +61,23 @@ internal sealed class WhirlpoolPage : IStressPage
     public string Name => "Whirlpool";
 
     public string Description =>
-        "Shallow-water voxel fluid: per-cell height + 2D velocity, "
+        "Shallow-water fluid: per-cell continuous height + 2D velocity, "
         + "pressure-gradient acceleration, radial drain attraction, "
-        + "integer voxel flux transfers. Water sloshes back elastically "
-        + "when the drain closes.";
+        + "fractional volumetric flux transfers. Water sloshes back "
+        + "elastically when the drain closes.";
 
     // ----------------------------------------------------------------
-    // Geometry — voxels are unit-height, columns top out at D voxels.
+    // Geometry — heights are continuous, columns top out at D units.
+    // The integer ceiling exists only for rendering buckets; the
+    // underlying physics is fractional so gravity can level a surface
+    // to its true equilibrium instead of getting stuck on a slope-1
+    // staircase that a pure integer field would consider "settled".
     // ----------------------------------------------------------------
-    private const int D = 16;
-    private const short DShort = (short)D;
+    private const float D = 16f;
 
-    private short[] _height = Array.Empty<short>();
+    private float[] _height = Array.Empty<float>();
     private float[] _vx = Array.Empty<float>();
     private float[] _vy = Array.Empty<float>();
-    private float[] _flowAccX = Array.Empty<float>();
-    private float[] _flowAccY = Array.Empty<float>();
     private bool[] _solid = Array.Empty<bool>();
 
     private int _screenW, _screenH;
@@ -98,17 +99,20 @@ internal sealed class WhirlpoolPage : IStressPage
     private const float DrainReachMax       = 22f;
     private const int   DrainReachRampFrames = 90;
     private const float DrainDiscRadiusMax  = 3.0f;
-    private const float DrainDensity        = 2.0f;
+    private const float DrainDensity        = 4.0f;
     private const float PullStrength        = 0.15f; // peak inward accel per frame at drain centre
 
     // ----------------------------------------------------------------
     // Shallow-water dynamics. Tune for visible momentum / sloshing
     // without runaway oscillation.
     // ----------------------------------------------------------------
-    private const float PressureGain = 0.05f;
-    private const float Damping      = 0.85f;
+    private const float PressureGain = 0.06f;
+    private const float Damping      = 0.92f;
     private const float MaxSpeed     = 0.6f;
-    private const float VelocityFloor = 0.04f;
+    private const float VelocityFloor = 0.01f;
+    // Fraction of the per-edge volumetric flux applied per frame.
+    // Lower = more viscous / stable; higher = sloshier.
+    private const float AdvectionRate = 0.5f;
 
     // ----------------------------------------------------------------
     // Surface tension / film thickness.
@@ -130,7 +134,7 @@ internal sealed class WhirlpoolPage : IStressPage
     private bool _inletActive;
     private int _inletCx;
     private int _inletCy;
-    private const int InletVoxelsPerFrame = 60;
+    private const float InletFlowPerFrame = 120f;
     private const float InletRadius  = 5f;
 
     private bool _quiescent = true;
@@ -228,11 +232,9 @@ internal sealed class WhirlpoolPage : IStressPage
         var n = _height.Length;
         for (var i = 0; i < n; i++)
         {
-            _height[i] = 0;
+            _height[i] = 0f;
             _vx[i] = 0f;
             _vy[i] = 0f;
-            _flowAccX[i] = 0f;
-            _flowAccY[i] = 0f;
         }
         _drainActive = false;
         _drainOpenFrames = 0;
@@ -249,14 +251,12 @@ internal sealed class WhirlpoolPage : IStressPage
         _dw = Math.Max(0, w - 2 * WallCells);
         _dh = Math.Max(0, h - 2 * WallCells) * 2;
         var n = _dw * _dh;
-        _height = new short[n];
+        _height = new float[n];
         _vx = new float[n];
         _vy = new float[n];
-        _flowAccX = new float[n];
-        _flowAccY = new float[n];
         _solid = new bool[n];
         GenerateObstacles();
-        for (var i = 0; i < n; i++) _height[i] = 0;
+        for (var i = 0; i < n; i++) _height[i] = 0f;
         _quiescent = true;
         _drainActive = false;
         _drainOpenFrames = 0;
@@ -381,10 +381,10 @@ internal sealed class WhirlpoolPage : IStressPage
                 var i = row + x;
                 if (solid[i]) { vx[i] = 0f; vy[i] = 0f; continue; }
                 var hi = h[i];
-                int hL = (x > 0     && !solid[i - 1])  ? h[i - 1]  : hi;
-                int hR = (x + 1 < dw && !solid[i + 1])  ? h[i + 1]  : hi;
-                int hU = (y > 0     && !solid[i - dw]) ? h[i - dw] : hi;
-                int hD = (y + 1 < dh && !solid[i + dw]) ? h[i + dw] : hi;
+                var hL = (x > 0     && !solid[i - 1])  ? h[i - 1]  : hi;
+                var hR = (x + 1 < dw && !solid[i + 1])  ? h[i + 1]  : hi;
+                var hU = (y > 0     && !solid[i - dw]) ? h[i - dw] : hi;
+                var hD = (y + 1 < dh && !solid[i + dw]) ? h[i + dw] : hi;
                 // Surface tension: only the depth above FilmThickness contributes
                 // to the pressure gradient. A thin film has no net force on it.
                 var eL = MathF.Max(0f, hL - FilmThickness);
@@ -449,18 +449,25 @@ internal sealed class WhirlpoolPage : IStressPage
     }
 
     /// <summary>
-    /// Integer-voxel flux advection. For each X edge (between cells
+    /// Continuous-flux advection. For each X edge (between cells
     /// i and i+1 in the same row) and each Y edge (between cells i
-    /// and i+_dw in the same column) we compute the volumetric flux
-    /// as <c>avg(velocity) × upwind(height)</c>, accumulate it on a
-    /// per-edge float, and transfer one voxel whenever the
-    /// accumulator crosses ±1. Returns true if any voxel moved.
+    /// and i+_dw in the same column) we compute volumetric flux as
+    /// <c>avg(velocity) × upwind(effective height)</c> and apply a
+    /// fraction (<see cref="AdvectionRate"/>) of it directly to the
+    /// height field — no integer accumulator, no per-edge state.
+    ///
+    /// With float heights, gravity can drive water to its true
+    /// equilibrium (flat surface) instead of getting stuck on a
+    /// slope-1 integer staircase, and the pressure gradient never
+    /// re-pumps the velocity to swap a voxel back the way it came.
+    /// Mass is conserved exactly (clamped flux is symmetric across
+    /// the edge), and the only remaining source of perpetual motion
+    /// is the small floor on velocity, which damping kills quickly.
     /// </summary>
     private bool ApplyAdvection()
     {
         var dw = _dw; var dh = _dh;
         var h = _height; var vx = _vx; var vy = _vy;
-        var ax = _flowAccX; var ay = _flowAccY;
         var solid = _solid;
         var moved = false;
 
@@ -472,38 +479,35 @@ internal sealed class WhirlpoolPage : IStressPage
             {
                 var i = row + x;
                 var j = i + 1;
-                if (solid[i] || solid[j]) { ax[i] = 0f; continue; }
+                if (solid[i] || solid[j]) continue;
                 var v = (vx[i] + vx[j]) * 0.5f;
-                var acc = ax[i];
-                if (v == 0f && acc == 0f) continue;
+                if (v == 0f) continue;
                 var hUp = v >= 0f ? h[i] : h[j];
-                var eUp = MathF.Max(0f, hUp - FilmThickness);
-                acc += v * eUp;
-                while (acc >= 1f)
+                var eUp = hUp - FilmThickness;
+                if (eUp <= 0f) continue;
+                var flux = v * eUp * AdvectionRate;
+                // Cap by available water at the source and free space
+                // at the sink so the field stays within [0, D].
+                if (flux > 0f)
                 {
-                    // Hysteresis: only transfer i->j when i is at least 2 voxels
-                    // higher. Without this, neighbouring cells perpetually
-                    // ping-pong a single voxel back and forth as the
-                    // gradient flips after each transfer.
-                    if (h[i] - h[j] >= 2 && h[i] > 0 && h[j] < DShort)
-                    {
-                        h[i]--; h[j]++;
-                        acc -= 1f;
-                        moved = true;
-                    }
-                    else { acc = 0f; break; }
+                    var room = D - h[j];
+                    if (flux > h[i]) flux = h[i];
+                    if (flux > room) flux = room;
+                    if (flux <= 0f) continue;
                 }
-                while (acc <= -1f)
+                else
                 {
-                    if (h[j] - h[i] >= 2 && h[j] > 0 && h[i] < DShort)
-                    {
-                        h[j]--; h[i]++;
-                        acc += 1f;
-                        moved = true;
-                    }
-                    else { acc = 0f; break; }
+                    var avail = h[j];
+                    var room = D - h[i];
+                    var neg = -flux;
+                    if (neg > avail) neg = avail;
+                    if (neg > room)  neg = room;
+                    if (neg <= 0f) continue;
+                    flux = -neg;
                 }
-                ax[i] = acc;
+                h[i] -= flux;
+                h[j] += flux;
+                moved = true;
             }
         }
 
@@ -515,34 +519,33 @@ internal sealed class WhirlpoolPage : IStressPage
             {
                 var i = row + x;
                 var j = i + dw;
-                if (solid[i] || solid[j]) { ay[i] = 0f; continue; }
+                if (solid[i] || solid[j]) continue;
                 var v = (vy[i] + vy[j]) * 0.5f;
-                var acc = ay[i];
-                if (v == 0f && acc == 0f) continue;
+                if (v == 0f) continue;
                 var hUp = v >= 0f ? h[i] : h[j];
-                var eUp = MathF.Max(0f, hUp - FilmThickness);
-                acc += v * eUp;
-                while (acc >= 1f)
+                var eUp = hUp - FilmThickness;
+                if (eUp <= 0f) continue;
+                var flux = v * eUp * AdvectionRate;
+                if (flux > 0f)
                 {
-                    if (h[i] - h[j] >= 2 && h[i] > 0 && h[j] < DShort)
-                    {
-                        h[i]--; h[j]++;
-                        acc -= 1f;
-                        moved = true;
-                    }
-                    else { acc = 0f; break; }
+                    var room = D - h[j];
+                    if (flux > h[i]) flux = h[i];
+                    if (flux > room) flux = room;
+                    if (flux <= 0f) continue;
                 }
-                while (acc <= -1f)
+                else
                 {
-                    if (h[j] - h[i] >= 2 && h[j] > 0 && h[i] < DShort)
-                    {
-                        h[j]--; h[i]++;
-                        acc += 1f;
-                        moved = true;
-                    }
-                    else { acc = 0f; break; }
+                    var avail = h[j];
+                    var room = D - h[i];
+                    var neg = -flux;
+                    if (neg > avail) neg = avail;
+                    if (neg > room)  neg = room;
+                    if (neg <= 0f) continue;
+                    flux = -neg;
                 }
-                ay[i] = acc;
+                h[i] -= flux;
+                h[j] += flux;
+                moved = true;
             }
         }
         return moved;
@@ -574,9 +577,10 @@ internal sealed class WhirlpoolPage : IStressPage
             if (dx * dx + dy * dy > discR2) continue;
             var i = ry * _dw + rx;
             if (_solid[i]) continue;
-            if (_height[i] > 0)
+            if (_height[i] > 0f)
             {
-                _height[i]--;
+                var take = MathF.Min(0.5f, _height[i]);
+                _height[i] -= take;
                 changed = true;
             }
         }
@@ -596,7 +600,7 @@ internal sealed class WhirlpoolPage : IStressPage
         if (spanW <= 0 || spanH <= 0) return false;
 
         var changed = false;
-        var per = (int)MathF.Max(1f, InletVoxelsPerFrame * _strength);
+        var per = (int)MathF.Max(1f, InletFlowPerFrame * _strength);
         for (var n = 0; n < per; n++)
         {
             var rx = x0 + (int)(NextFloat() * spanW);
@@ -606,9 +610,11 @@ internal sealed class WhirlpoolPage : IStressPage
             if (dx * dx + dy * dy > r2) continue;
             var i = ry * _dw + rx;
             if (_solid[i]) continue;
-            if (_height[i] < DShort)
+            if (_height[i] < D)
             {
-                _height[i]++;
+                var room = D - _height[i];
+                var add = MathF.Min(0.5f, room);
+                _height[i] += add;
                 changed = true;
             }
         }
@@ -681,11 +687,11 @@ internal sealed class WhirlpoolPage : IStressPage
         }
     }
 
-    private static Hex1bColor DepthColour(int h)
+    private static Hex1bColor DepthColour(float h)
     {
-        if (h <= 0) return Hex1bColor.FromRgb(SandColour.R, SandColour.G, SandColour.B);
+        if (h <= 0f) return Hex1bColor.FromRgb(SandColour.R, SandColour.G, SandColour.B);
         if (h >= D) return Hex1bColor.FromRgb(DeepColour.R, DeepColour.G, DeepColour.B);
-        var t = h / (float)D;
+        var t = h / D;
         if (t < 0.25f) return Lerp(SandColour, ShallowColour, t / 0.25f);
         if (t < 0.65f) return Lerp(ShallowColour, MidColour, (t - 0.25f) / 0.4f);
         return Lerp(MidColour, DeepColour, (t - 0.65f) / 0.35f);

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Hex1b;
 using Hex1b.Input;
 using Hex1b.Surfaces;
@@ -9,167 +10,128 @@ namespace PerfStressDemo;
 /// <summary>
 /// Page 3 — "Whirlpool".
 ///
-/// Top-down water simulated on a half-block grid (each terminal cell
-/// renders as <c>▀</c> with foreground = top sub-cell colour and
-/// background = bottom sub-cell colour, doubling the vertical
-/// simulation resolution). Two layered physics fields:
-/// <list type="bullet">
-///   <item><b>Baseline depth</b> — slow-evolving bulk water level in
-///         <c>[0, 1]</c>. Drain consumes it at the cursor; refill
-///         relaxes the edges back toward full when the drain is shut.
-///         Semi-Lagrangian-advected by a potential-flow velocity
-///         field while the drain is open, which spirals the radial
-///         depth dip into logarithmic-spiral contours.</item>
-///   <item><b>Wave field</b> — high-frequency signed displacement
-///         around zero, evolved by the same 2D wave-equation scheme
-///         as the pond page (ping-pong buffers, neighbour-average
-///         minus previous, damped). Sources of energy:
-///         a continuous negative impulse at the drain (turbulence at
-///         the hole), continuous positive impulses along the edges
-///         during refill (water rushing in), and a sprinkle of
-///         random small chop while anything is active (the ocean's
-///         own movement).</item>
+/// A voxel-column fluid simulation, viewed top-down.
+///
+/// The "tank" is the interior of the screen: a 1-cell-thick solid
+/// border surrounds a rectangular pool whose floor is at the bottom
+/// of every interior column. Each interior sub-cell stores a
+/// <c>uint</c> bitmap of up to <see cref="D"/> stacked water voxels,
+/// gravity-compacted to the low bits (the tank floor). The top-down
+/// renderer colours each sub-cell purely by its column's bit-count
+/// (popcount), so a deeper column is darker blue and an empty one
+/// shows the sandy floor.
+///
+/// Physics is three cellular-automaton rules over the column grid:
+/// <list type="number">
+///   <item><b>Drain</b> — when the user opens the hole, voxels are
+///         removed from random columns within a small disc each
+///         frame. The disc grows from a dimple to its full width
+///         over a few seconds so the whirlpool forms locally before
+///         pulling water from further out.</item>
+///   <item><b>Tangential rotation</b> — within the drain's reach,
+///         each column probabilistically donates a single voxel to
+///         the neighbour in its tangential direction (perpendicular
+///         to the radial vector from the drain), with probability
+///         falling off as a Gaussian of the radius. This is what
+///         spins the water into a visible whirlpool.</item>
+///   <item><b>Lateral pressure</b> — between every adjacent pair of
+///         columns, if the height difference exceeds 1 voxel, move
+///         a single voxel from the taller to the shorter. Done in
+///         two phases per axis (even/odd parity) for race-free
+///         transfer. This is the slow, granular "flow" you see
+///         carrying outer water toward the developing whirlpool.</item>
 /// </list>
 ///
-/// Display blends the two: each sub-cell renders
-/// <c>baseline + WaveDisplayScale * wave</c>, clamped to <c>[0, 1]</c>
-/// and lerped through the sand → shallow → deep colour ramp.
+/// When the drain is closed, a roaming inlet drips voxels into a
+/// random interior column, refilling the tank. When every column is
+/// full and nothing is moving, the page reports IsIdle so the
+/// framework can sleep.
 ///
-/// Controls:
-/// <list type="bullet">
-///   <item><b>Left click</b> — open the drain at the cursor. Water
-///         drains; if held long enough the basin empties completely.</item>
-///   <item><b>Right click</b> — close the drain. The basin refills
-///         from the edges; once full and the ripples die out, the
-///         page reports IsIdle and the framework sleeps.</item>
-///   <item><b>Scroll up/down</b> — adjust drain strength.</item>
-/// </list>
+/// Controls: left click opens the drain at the cursor (and resets
+/// the reach ramp), right click closes it, scroll up/down adjusts
+/// drain strength.
 /// </summary>
 internal sealed class WhirlpoolPage : IStressPage
 {
     public string Name => "Whirlpool";
 
     public string Description =>
-        "Layered baseline + wave-equation water. Left click drains; "
-        + "right click refills from the edges; scroll for drain strength.";
+        "Voxel-column fluid: each interior sub-cell stores up to "
+        + "16 stacked water voxels in a uint bitmap. Drain, tangential "
+        + "rotation, and lateral pressure all run as cellular rules.";
 
     // ----------------------------------------------------------------
-    // Baseline depth grid. _depth[y * dotWidth + x] holds the water
-    // depth in [0, MaxDepth] for sub-cell (x, y). _delta is a scratch
-    // buffer used both as the advection destination and as the
-    // diffusion delta accumulator.
+    // Voxel column geometry. D = max voxels per column, so a full
+    // column is FullColumn = (1u << D) - 1. Storing as uint keeps the
+    // entire grid SIMD-friendly for later (Vector<uint>.PopCount on
+    // .NET 8+).
     // ----------------------------------------------------------------
-    private float[] _depth = Array.Empty<float>();
-    private float[] _delta = Array.Empty<float>();
-    private int _surfaceWidth;
-    private int _surfaceHeight;
-    private int _dotWidth;
-    private int _dotHeight;
+    private const int D = 16;
+    private const uint FullColumn = (1u << D) - 1u;
+
+    private uint[] _columns = Array.Empty<uint>();
+    private int _screenW;     // surface width  (cells, including walls)
+    private int _screenH;     // surface height (cells, including walls)
+    private int _dw;          // interior width  in sub-cells (columns array X)
+    private int _dh;          // interior height in sub-cells (columns array Y)
+
+    // Wall thickness is 1 cell on each side of the screen — the
+    // "tank" pool is the inner rectangle. Sub-cell offsets place the
+    // interior columns into the right physical region of the screen.
+    private const int WallCells = 1;
 
     // ----------------------------------------------------------------
-    // Wave field — pond-style 2D wave equation with ping-pong
-    // buffers. _wave / _wavePrev oscillate around zero; the renderer
-    // adds a scaled fraction onto the baseline depth for the final
-    // sub-cell value.
-    // ----------------------------------------------------------------
-    private float[] _wave = Array.Empty<float>();
-    private float[] _wavePrev = Array.Empty<float>();
-
-    // ----------------------------------------------------------------
-    // Drain state. _drainActive gates consumption; placement (left
-    // click) and removal (right click) are independent.
+    // Drain state.
     // ----------------------------------------------------------------
     private bool _drainActive;
-    private float _drainX;
-    private float _drainY;
+    private int _drainCx;          // drain column (interior sub-cell coords)
+    private int _drainCy;
     private float _strength = 1.0f;
-    private int _frame;
-    private int _drainOpenFrames;  // resets to 0 every time drain re-opens; clamps growth of reach
+    private int _drainOpenFrames;
     private const float MinStrength = 0.3f;
     private const float MaxStrength = 4.0f;
 
-    // ----------------------------------------------------------------
-    // Physics constants — baseline.
-    // ----------------------------------------------------------------
-    private const float MaxDepth = 1.0f;
-    private const float DiffusionK = 0.045f;
-    private const float DrainRadius = 6.5f;        // sub-cells (max consumption disc radius)
-    private const float DrainPerFrameBase = 0.32f;
-    private const float DrainReachInitial = 2.5f;   // initial Gaussian sigma for advection window
-    private const float DrainReachMax     = 28f;    // peak Gaussian sigma for advection window
-    private const int   DrainReachRampFrames = 360; // ~6s @ 60fps to reach full whirlpool extent
-    private const float MaxDrainPerFrame  = 7f;     // total depth-units consumed across the disc per frame
-    // Refill (drain off): water enters through a single roaming
-    // inlet that fades in/out on the edge of the basin. Diffusion
-    // already moves water from high to low, so a localised source is
-    // enough — the fluid will visibly flow toward whatever cell has
-    // the least water.
-    private const float InletInjectRate = 0.32f;    // per-frame approach toward MaxDepth at jet head
-    private const float InletRadius     = 7.5f;     // sub-cells (deposit radius around jet head)
-    private const int   InletLifetime   = 160;      // frames of the fade-in/peak/fade-out envelope
-    private const int   InletGapMin     = 0;
-    private const int   InletGapMax     = 10;
-    private const float InletJetSpeed   = 1.4f;     // sub-cells per frame — jet head march speed
-    private const float InletWaveImpulse = 0.55f;   // splat at jet head per frame, scaled by envelope
-    private const int   InletChopPerFrame = 8;      // turbulent chop sites sprayed around jet head
-    private const float InletChopRadius = 12f;      // radius (sub-cells) of the chop spray cloud
-    private const float InletChopAmplitude = 0.18f; // per-impulse amplitude of jet-head chop
+    private const float DrainReachInitial = 2.0f;   // initial Gaussian sigma + drain disc radius
+    private const float DrainReachMax     = 18f;
+    private const int   DrainReachRampFrames = 360;
+    private const float DrainDiscRadiusMax = 11f;
+    private const float DrainDensity      = 0.5f;    // voxels removed per disc-area unit per frame
+    private const float TangentialBiasBase = 0.7f;   // peak probability of a tangential donation per column per frame
 
     // ----------------------------------------------------------------
-    // Physics constants — wave equation. Matches pond's "light"
-    // preset feel: lively but settles in reasonable time without
-    // continuous forcing.
+    // Lateral / pressure equalisation. Move at most 1 voxel per pair
+    // per frame whenever |dh| > LateralThreshold — keeps the flow
+    // visibly granular.
     // ----------------------------------------------------------------
-    private const float WaveDamping = 0.985f;
-    private const float WaveDisplayScale = 0.32f;   // how much wave modulates rendered depth
-    private const float WaveFloor = 0.005f;          // floor for "alive" tracking
-    private const float WaveDepthThreshold = 0.08f;  // suppress wave injection / display below this depth
-    private const float DrainImpulse = -0.18f;       // per frame, at drain centre
-    private const float ChopAmplitude = 0.06f;       // random impulse magnitude while active
-    private const int   ChopPerFrame = 4;            // random chop sites per frame while active
+    private const int LateralThreshold = 1;
 
     // ----------------------------------------------------------------
-    // Potential-flow velocity field for advection of the baseline:
-    //   v(r) = -Q/(r+s) r_hat + G/(r+s) theta_hat
-    // With G ≈ 2Q the streamlines are ~63° spirals. VelocitySoftening
-    // tames the 1/0 singularity at the drain centre.
+    // Refill — roaming inlet that drips voxels into one interior
+    // column at a time. No jet/wave splash here; the discrete voxel
+    // accumulation IS the visible motion.
     // ----------------------------------------------------------------
-    private const float SinkStrength = 9.0f;
-    private const float SwirlStrength = 18.0f;
-    private const float VelocitySoftening = 2.5f;
-
-    // ----------------------------------------------------------------
-    // Inlet — one localised refill source at a time. Picked at random
-    // on the basin edge, fades in over its lifetime, then a short
-    // gap, then a new inlet at a new location.
-    // ----------------------------------------------------------------
-    private float _inletX;       // inlet spawn point (sub-cell coords)
+    private float _inletX;
     private float _inletY;
-    private float _inletDirX;    // inward unit vector
-    private float _inletDirY;
-    private int _inletAge;       // frames since spawn, 0 if inactive
-    private int _inletGap;       // frames until next inlet spawns
-    private float _inletEnvelope; // 0..1 amplitude this frame
-    private float _jetX;         // current jet head position (sub-cell coords)
-    private float _jetY;
+    private int _inletAge;
+    private int _inletGap;
+    private const int InletLifetime = 80;
+    private const int InletGapMin = 0;
+    private const int InletGapMax = 10;
+    private const int InletVoxelsPerFrame = 8;
+    private const float InletRadius = 3f;
 
     // ----------------------------------------------------------------
-    // Activity tracking. _activity ramps to 1 whenever something is
-    // happening (drain open OR basin not full) and decays to 0 when
-    // everything settles. Used to gate wave-injection (chop / refill
-    // impulses) and IsIdle.
+    // Activity / idleness.
     // ----------------------------------------------------------------
-    private float _activity;
-    private const float ActivityDecay = 0.04f;       // per frame when no activity
-
     private bool _quiescent = true;
     public bool IsIdle => _quiescent;
 
-    // Status-bar accessors.
     public static float CurrentStrength { get; private set; } = 1.0f;
     public static bool DrainOpen { get; private set; }
 
-    // xorshift32 RNG — small, fast, deterministic seed.
+    // ----------------------------------------------------------------
+    // Fast deterministic RNG (xorshift32).
+    // ----------------------------------------------------------------
     private uint _rng = 0xDEADBEEFu;
     private uint NextRandom()
     {
@@ -180,39 +142,42 @@ internal sealed class WhirlpoolPage : IStressPage
     }
     private float NextFloat() => (NextRandom() & 0xFFFFFF) / (float)0x1000000;
 
-    // Colour stops. Pre-built as byte triples so the per-cell lerp
-    // doesn't allocate.
+    // ----------------------------------------------------------------
+    // Colour stops.
+    // ----------------------------------------------------------------
     private static readonly (byte R, byte G, byte B) SandColour    = (235, 215, 175);
     private static readonly (byte R, byte G, byte B) ShallowColour = (160, 220, 245);
     private static readonly (byte R, byte G, byte B) MidColour     = (40, 130, 200);
     private static readonly (byte R, byte G, byte B) DeepColour    = (8, 40, 100);
+    private static readonly Hex1bColor WallColour = Hex1bColor.FromRgb(70, 55, 40);
+    private static readonly Hex1bColor WallTrim   = Hex1bColor.FromRgb(40, 30, 22);
+    private static readonly Hex1bColor HoleColour = Hex1bColor.FromRgb(8, 8, 12);
 
     public Hex1bWidget Build(StressContext sc)
     {
-        // Surface alone doesn't route mouse events; Interactable does.
+        // Surface alone doesn't route mouse; Interactable does.
         var widget = sc.Root.Interactable(ic =>
             ic.Surface(layer =>
             {
                 EnsureField(layer.Width, layer.Height);
                 Step();
-                return new[] { layer.Layer(DrawWater) };
+                return new[] { layer.Layer(DrawTank) };
             }))
             .InputBindings(bindings =>
             {
                 bindings.Mouse(MouseButton.Left).Action(ctx =>
                 {
-                    if (ctx.MouseX < 0 || ctx.MouseY < 0) return;
-                    _drainX = ctx.MouseX;
-                    _drainY = ctx.MouseY;
-                    if (!_drainActive) _drainOpenFrames = 0; // ramp reach from scratch each open
+                    if (!TryMouseToInteriorColumn(ctx.MouseX, ctx.MouseY, out var icx, out var icy))
+                        return;
+                    _drainCx = icx;
+                    _drainCy = icy;
+                    if (!_drainActive) _drainOpenFrames = 0;
                     _drainActive = true;
-                    _activity = 1f;
                     _quiescent = false;
                 });
                 bindings.Mouse(MouseButton.Right).Action(_ =>
                 {
                     _drainActive = false;
-                    // Don't flip _quiescent — refill still has work to do.
                 });
                 bindings.Mouse(MouseButton.ScrollUp).Action(_ =>
                 {
@@ -227,562 +192,386 @@ internal sealed class WhirlpoolPage : IStressPage
         return _quiescent ? widget : widget.RedrawAfter(sc.RedrawIntervalMs);
     }
 
+    private bool TryMouseToInteriorColumn(int mouseX, int mouseY, out int icx, out int icy)
+    {
+        icx = mouseX - WallCells;
+        // Use the bottom sub-cell of the clicked cell as the drain
+        // centre so the hole's vertical position matches what the
+        // user sees their cursor over.
+        icy = (mouseY - WallCells) * 2 + 1;
+        if (mouseX < WallCells || mouseX >= _screenW - WallCells) return false;
+        if (mouseY < WallCells || mouseY >= _screenH - WallCells) return false;
+        if (icx < 0 || icx >= _dw || icy < 0 || icy >= _dh) return false;
+        return true;
+    }
+
     private void EnsureField(int w, int h)
     {
-        if (_surfaceWidth == w && _surfaceHeight == h && _depth.Length > 0)
-            return;
-        _surfaceWidth = w;
-        _surfaceHeight = h;
-        _dotWidth = w;
-        _dotHeight = h * 2;
-        var n = _dotWidth * _dotHeight;
-        _depth = new float[n];
-        _delta = new float[n];
-        _wave = new float[n];
-        _wavePrev = new float[n];
-        Array.Fill(_depth, MaxDepth);
-        _activity = 0f;
+        if (_screenW == w && _screenH == h && _columns.Length > 0) return;
+        _screenW = w;
+        _screenH = h;
+        var interiorW = Math.Max(0, w - 2 * WallCells);
+        var interiorH = Math.Max(0, h - 2 * WallCells);
+        _dw = interiorW;
+        _dh = interiorH * 2;
+        _columns = new uint[_dw * _dh];
+        Array.Fill(_columns, FullColumn);
         _quiescent = true;
+        _drainActive = false;
+        _drainOpenFrames = 0;
+        _inletAge = 0;
+        _inletGap = 0;
     }
 
     private void Step()
     {
-        if (_depth.Length == 0) return;
-        _frame++;
+        if (_columns.Length == 0) return;
         CurrentStrength = _strength;
         DrainOpen = _drainActive;
 
-        var dw = _dotWidth;
-        var dh = _dotHeight;
-        var depth = _depth;
-        var delta = _delta;
+        var changed = false;
 
-        // ---- Pass 0: advection of baseline when drain is open. Same
-        //      analytic potential-flow field that drives the spiral
-        //      look in the original whirlpool draft. Velocity is
-        //      windowed by a Gaussian centred on the drain whose
-        //      sigma ramps from DrainReachInitial to DrainReachMax
-        //      over DrainReachRampFrames — that gives the whirlpool
-        //      time to form locally before the outer water joins in.
         if (_drainActive)
         {
             _drainOpenFrames++;
-            AdvectField(depth, delta, dw, dh);
-            (depth, delta) = (delta, depth);
-            _depth = depth;
-            _delta = delta;
+            changed |= ApplyDrain();
+            changed |= ApplyTangential();
         }
 
-        Array.Clear(delta, 0, delta.Length);
+        changed |= ApplyLateralX();
+        changed |= ApplyLateralY();
 
-        // ---- Pass 1: gentle diffusion of baseline.
-        var anyFlow = false;
-        for (var y = 0; y < dh; y++)
+        var basinFull = IsBasinFull();
+        if (!_drainActive && !basinFull)
         {
-            var row = y * dw;
-            for (var x = 0; x < dw; x++)
-            {
-                var i = row + x;
-                var di = depth[i];
-                if (x + 1 < dw)
-                {
-                    var j = i + 1;
-                    var f = (di - depth[j]) * DiffusionK;
-                    if (f != 0f) anyFlow = true;
-                    delta[i] -= f;
-                    delta[j] += f;
-                }
-                if (y + 1 < dh)
-                {
-                    var j = i + dw;
-                    var f = (di - depth[j]) * DiffusionK;
-                    if (f != 0f) anyFlow = true;
-                    delta[i] -= f;
-                    delta[j] += f;
-                }
-            }
-        }
-
-        var changed = anyFlow;
-        for (var i = 0; i < depth.Length; i++)
-        {
-            var d = depth[i] + delta[i];
-            if (d < 0f) d = 0f;
-            else if (d > MaxDepth) d = MaxDepth;
-            depth[i] = d;
-        }
-
-        // ---- Pass 2: drain (consume baseline at cursor) or refill
-        //      (pull baseline back up toward MaxDepth from edges).
-        var basinFull = true;
-        if (_drainActive)
-        {
-            changed |= ApplyDrain(depth, dw, dh);
-            basinFull = false; // doesn't matter, _drainActive forces activity
+            changed |= ApplyRefill();
         }
         else
         {
-            changed |= ApplyRefill(depth, dw, dh, out basinFull);
+            _inletAge = 0;
+            _inletGap = 0;
         }
 
-        // ---- Pass 3: activity tracking. Wave injection, chop, and
-        //      idleness all key off this single scalar.
-        if (_drainActive || !basinFull)
-        {
-            _activity = 1f;
-        }
-        else
-        {
-            _activity = MathF.Max(0f, _activity - ActivityDecay);
-        }
-        var active = _activity > 0.05f;
-
-        // ---- Pass 4: inject impulses into the wave field, then run
-        //      the wave-equation step. Wave runs every frame so
-        //      energy injected last frame propagates immediately.
-        if (active)
-        {
-            InjectWaveImpulses(dw, dh);
-        }
-        var waveAlive = WaveStep(dw, dh);
-
-        _quiescent = !changed && !active && !waveAlive;
+        _quiescent = !changed && !_drainActive && basinFull;
     }
 
-    /// <summary>
-    /// Returns the current Gaussian sigma for the drain's influence
-    /// window, ramping smoothly from <see cref="DrainReachInitial"/>
-    /// to <see cref="DrainReachMax"/> over
-    /// <see cref="DrainReachRampFrames"/> frames since the drain was
-    /// opened. Used to size both the consumption disc and the
-    /// advection velocity window.
-    /// </summary>
+    // ----------------------------------------------------------------
+    // Column helpers — keep the bitmap representation consistent.
+    // Voxels stack from bit 0 (floor) upward, so a column of height h
+    // is (1 << h) - 1. PopCount gives the height in O(1) hardware op.
+    // ----------------------------------------------------------------
+    private static int Height(uint col) => BitOperations.PopCount(col);
+    private static uint MakeCol(int height)
+    {
+        if (height <= 0) return 0u;
+        if (height >= D) return FullColumn;
+        return (1u << height) - 1u;
+    }
+
     private float CurrentDrainReach()
     {
         var t = MathF.Min(1f, _drainOpenFrames / (float)DrainReachRampFrames);
-        var s = t * t * (3f - 2f * t); // smoothstep
+        var s = t * t * (3f - 2f * t);
         return DrainReachInitial + (DrainReachMax - DrainReachInitial) * s;
     }
 
-    private bool ApplyDrain(float[] depth, int dw, int dh)
+    // ----------------------------------------------------------------
+    // Drain — remove the top voxel from a random sample of columns
+    // within a disc around the drain centre. The disc starts as a
+    // dimple and grows with the drain's reach.
+    // ----------------------------------------------------------------
+    private bool ApplyDrain()
     {
-        var cx = _drainX;
-        var cy = _drainY * 2 + 0.5f;
-        // Disc radius grows with the reach but is capped at DrainRadius —
-        // the hole itself never exceeds the original physical drain.
         var reach = CurrentDrainReach();
-        var radius = MathF.Min(DrainRadius, reach);
-        var rate = DrainPerFrameBase * _strength;
-        var r2 = radius * radius;
-        var x0 = Math.Max(0, (int)(cx - radius));
-        var x1 = Math.Min(dw - 1, (int)(cx + radius + 0.5f));
-        var y0 = Math.Max(0, (int)(cy - radius * 2));
-        var y1 = Math.Min(dh - 1, (int)(cy + radius * 2 + 0.5f));
+        var discR = MathF.Min(DrainDiscRadiusMax, reach * 0.7f + 0.5f);
+        if (discR < 0.5f) discR = 0.5f;
+        var discR2 = discR * discR;
+        var discArea = MathF.PI * discR2;
+        var k = (int)MathF.Max(1f, discArea * DrainDensity * _strength);
+        var x0 = Math.Max(0, (int)(_drainCx - discR));
+        var x1 = Math.Min(_dw - 1, (int)(_drainCx + discR + 0.5f));
+        var y0 = Math.Max(0, (int)(_drainCy - discR));
+        var y1 = Math.Min(_dh - 1, (int)(_drainCy + discR + 0.5f));
+        var spanW = x1 - x0 + 1;
+        var spanH = y1 - y0 + 1;
+        if (spanW <= 0 || spanH <= 0) return false;
 
-        // First pass: gather raw per-cell consumption requests; cap
-        // total egress at MaxDrainPerFrame * strength so the drain
-        // can't slurp arbitrary amounts when sitting on full water.
-        Span<float> requests = stackalloc float[(x1 - x0 + 1) * (y1 - y0 + 1)];
-        var dw1 = x1 - x0 + 1;
-        var total = 0f;
-        for (var y = y0; y <= y1; y++)
-        {
-            var ry = (y - y0) * dw1;
-            for (var x = x0; x <= x1; x++)
-            {
-                var dx = x - cx;
-                var dy = (y - cy) * 0.5f;
-                var d2 = dx * dx + dy * dy;
-                if (d2 > r2) { requests[ry + (x - x0)] = 0f; continue; }
-                var falloff = 1f - MathF.Sqrt(d2) / radius;
-                var sub = rate * falloff;
-                var available = depth[y * dw + x];
-                if (sub > available) sub = available;
-                requests[ry + (x - x0)] = sub;
-                total += sub;
-            }
-        }
-
-        var cap = MaxDrainPerFrame * _strength;
-        var scale = (total > cap && total > 0f) ? cap / total : 1f;
         var changed = false;
-        for (var y = y0; y <= y1; y++)
+        for (var n = 0; n < k; n++)
         {
-            var ry = (y - y0) * dw1;
-            for (var x = x0; x <= x1; x++)
+            var rx = x0 + (int)(NextFloat() * spanW);
+            var ry = y0 + (int)(NextFloat() * spanH);
+            var dx = rx - _drainCx;
+            var dy = ry - _drainCy;
+            if (dx * dx + dy * dy > discR2) continue;
+            var i = ry * _dw + rx;
+            var col = _columns[i];
+            if (col == 0u) continue;
+            // Remove the top voxel (column height shrinks by one).
+            _columns[i] = MakeCol(Height(col) - 1);
+            changed = true;
+        }
+        return changed;
+    }
+
+    // ----------------------------------------------------------------
+    // Tangential rotation — for columns near the drain, with
+    // Gaussian-falloff probability donate one voxel to the neighbour
+    // in the tangential (perpendicular-to-radial) direction. This is
+    // what makes the water visibly spin into the hole.
+    // ----------------------------------------------------------------
+    private bool ApplyTangential()
+    {
+        var cx = (float)_drainCx;
+        var cy = (float)_drainCy;
+        var reach = CurrentDrainReach();
+        var twoReach2 = 2f * reach * reach;
+        var skip2 = (3f * reach) * (3f * reach);
+        var biasPeak = TangentialBiasBase * _strength;
+        var changed = false;
+
+        for (var y = 0; y < _dh; y++)
+        {
+            var dyc = y - cy;
+            var row = y * _dw;
+            for (var x = 0; x < _dw; x++)
             {
-                var sub = requests[ry + (x - x0)] * scale;
-                if (sub <= 0f) continue;
-                var i = y * dw + x;
-                var nv = depth[i] - sub;
-                if (nv < 0f) nv = 0f;
-                if (nv != depth[i]) { depth[i] = nv; changed = true; }
+                var dxc = x - cx;
+                var d2 = dxc * dxc + dyc * dyc;
+                if (d2 > skip2 || d2 < 0.5f) continue;
+                var prob = biasPeak * MathF.Exp(-d2 / twoReach2);
+                if (NextFloat() > prob) continue;
+
+                var r = MathF.Sqrt(d2);
+                // Tangential = perpendicular to radial (CCW): rotate
+                // (dxc/r, dyc/r) by 90°.
+                var tx = -dyc / r;
+                var ty = dxc / r;
+                var nx = x + (tx > 0.4f ? 1 : tx < -0.4f ? -1 : 0);
+                var ny = y + (ty > 0.4f ? 1 : ty < -0.4f ? -1 : 0);
+                if (nx == x && ny == y) continue;
+                if ((uint)nx >= (uint)_dw || (uint)ny >= (uint)_dh) continue;
+
+                var srcIdx = row + x;
+                var dstIdx = ny * _dw + nx;
+                var srcH = Height(_columns[srcIdx]);
+                var dstH = Height(_columns[dstIdx]);
+                if (srcH == 0 || dstH >= D) continue;
+                _columns[srcIdx] = MakeCol(srcH - 1);
+                _columns[dstIdx] = MakeCol(dstH + 1);
+                changed = true;
             }
         }
         return changed;
     }
 
-    /// <summary>
-    /// Drives baseline refill via a single localised inlet that
-    /// spawns at a random point on the basin edge, then marches a
-    /// "jet head" inward at <see cref="InletJetSpeed"/> sub-cells per
-    /// frame. Each frame we deposit water around the jet head and
-    /// raise the inlet's amplitude envelope (triangular over
-    /// <see cref="InletLifetime"/> frames). Diffusion does the rest
-    /// of the work — water flows from the freshly-injected region
-    /// toward whatever cells have the least depth. After the inlet
-    /// expires we wait <see cref="InletGapMin"/>..<see cref="InletGapMax"/>
-    /// frames and spawn a new one somewhere else.
-    /// <paramref name="basinFull"/> is set true if every cell ended
-    /// up within a small epsilon of MaxDepth — used by the activity
-    /// tracker so the page can eventually IsIdle.
-    /// </summary>
-    private bool ApplyRefill(float[] depth, int dw, int dh, out bool basinFull)
+    // ----------------------------------------------------------------
+    // Lateral pressure on the X axis. Two phases: process pairs
+    // starting at even x, then pairs starting at odd x. Race-free
+    // because no column appears in two pairs in the same phase.
+    // ----------------------------------------------------------------
+    private bool ApplyLateralX()
     {
-        // Snapshot fullness before deposition so the inlet keeps
-        // running until the basin is truly full.
-        basinFull = true;
-        var basMax = MaxDepth - 0.003f;
-        for (var i = 0; i < depth.Length; i++)
+        var changed = false;
+        for (var phase = 0; phase < 2; phase++)
         {
-            if (depth[i] < basMax) { basinFull = false; break; }
+            for (var y = 0; y < _dh; y++)
+            {
+                var row = y * _dw;
+                for (var x = phase; x + 1 < _dw; x += 2)
+                {
+                    var i = row + x;
+                    var j = i + 1;
+                    var ha = Height(_columns[i]);
+                    var hb = Height(_columns[j]);
+                    var diff = ha - hb;
+                    if (diff > LateralThreshold)
+                    {
+                        _columns[i] = MakeCol(ha - 1);
+                        _columns[j] = MakeCol(hb + 1);
+                        changed = true;
+                    }
+                    else if (diff < -LateralThreshold)
+                    {
+                        _columns[i] = MakeCol(ha + 1);
+                        _columns[j] = MakeCol(hb - 1);
+                        changed = true;
+                    }
+                }
+            }
         }
-        if (basinFull)
-        {
-            _inletAge = 0;
-            _inletEnvelope = 0f;
-            return false;
-        }
+        return changed;
+    }
 
-        // Inlet lifecycle.
+    private bool ApplyLateralY()
+    {
+        var changed = false;
+        for (var phase = 0; phase < 2; phase++)
+        {
+            for (var y = phase; y + 1 < _dh; y += 2)
+            {
+                var row = y * _dw;
+                var nextRow = row + _dw;
+                for (var x = 0; x < _dw; x++)
+                {
+                    var i = row + x;
+                    var j = nextRow + x;
+                    var ha = Height(_columns[i]);
+                    var hb = Height(_columns[j]);
+                    var diff = ha - hb;
+                    if (diff > LateralThreshold)
+                    {
+                        _columns[i] = MakeCol(ha - 1);
+                        _columns[j] = MakeCol(hb + 1);
+                        changed = true;
+                    }
+                    else if (diff < -LateralThreshold)
+                    {
+                        _columns[i] = MakeCol(ha + 1);
+                        _columns[j] = MakeCol(hb - 1);
+                        changed = true;
+                    }
+                }
+            }
+        }
+        return changed;
+    }
+
+    // ----------------------------------------------------------------
+    // Refill — drip InletVoxelsPerFrame voxels into a small disc
+    // around a roaming inlet point, picking a fresh point every
+    // InletLifetime frames with a short cooldown between.
+    // ----------------------------------------------------------------
+    private bool ApplyRefill()
+    {
         if (_inletAge == 0)
         {
-            if (_inletGap > 0) { _inletGap--; _inletEnvelope = 0f; return false; }
-            SpawnInlet(dw, dh);
+            if (_inletGap > 0) { _inletGap--; return false; }
+            // New inlet anywhere in the interior — gives a "rain
+            // dropping into the tank" feel rather than only edges.
+            _inletX = NextFloat() * _dw;
+            _inletY = NextFloat() * _dh;
         }
         _inletAge++;
         if (_inletAge >= InletLifetime)
         {
             _inletAge = 0;
-            _inletEnvelope = 0f;
-            _inletGap = InletGapMin + (int)(NextFloat() * (InletGapMax - InletGapMin));
+            _inletGap = InletGapMin + (int)(NextFloat() * (InletGapMax - InletGapMin + 1));
             return false;
         }
 
-        // Triangular envelope 0 → 1 → 0 over the inlet lifetime.
-        var t = _inletAge / (float)InletLifetime;
-        var env = 4f * t * (1f - t);
-        _inletEnvelope = env;
-
-        // March the jet head inward.
-        _jetX = _inletX + _inletDirX * InletJetSpeed * _inletAge;
-        _jetY = _inletY + _inletDirY * InletJetSpeed * _inletAge;
-
-        // Deposit baseline water at the jet head.
-        var rate = InletInjectRate * env;
         var r = InletRadius;
         var r2 = r * r;
-        var x0 = Math.Max(0, (int)(_jetX - r));
-        var x1 = Math.Min(dw - 1, (int)(_jetX + r + 0.5f));
-        var y0 = Math.Max(0, (int)(_jetY - r));
-        var y1 = Math.Min(dh - 1, (int)(_jetY + r + 0.5f));
+        var x0 = Math.Max(0, (int)(_inletX - r));
+        var x1 = Math.Min(_dw - 1, (int)(_inletX + r + 0.5f));
+        var y0 = Math.Max(0, (int)(_inletY - r));
+        var y1 = Math.Min(_dh - 1, (int)(_inletY + r + 0.5f));
+        var spanW = x1 - x0 + 1;
+        var spanH = y1 - y0 + 1;
+        if (spanW <= 0 || spanH <= 0) return false;
+
         var changed = false;
-        for (var y = y0; y <= y1; y++)
+        for (var n = 0; n < InletVoxelsPerFrame; n++)
         {
-            for (var x = x0; x <= x1; x++)
-            {
-                var dx = x - _jetX;
-                var dy = y - _jetY;
-                var d2 = dx * dx + dy * dy;
-                if (d2 > r2) continue;
-                var falloff = 1f - MathF.Sqrt(d2) / r;
-                var localRate = rate * falloff;
-                if (localRate <= 0f) continue;
-                var i = y * dw + x;
-                var d = depth[i];
-                var nv = d + (MaxDepth - d) * localRate;
-                if (nv > MaxDepth) nv = MaxDepth;
-                if (nv != d) { depth[i] = nv; changed = true; }
-            }
+            var rx = x0 + (int)(NextFloat() * spanW);
+            var ry = y0 + (int)(NextFloat() * spanH);
+            var dx = rx - _inletX;
+            var dy = ry - _inletY;
+            if (dx * dx + dy * dy > r2) continue;
+            var i = ry * _dw + rx;
+            var col = _columns[i];
+            var h = Height(col);
+            if (h >= D) continue;
+            _columns[i] = MakeCol(h + 1);
+            changed = true;
         }
         return changed;
     }
 
-    /// <summary>
-    /// Picks a random spot on one of the four edges of the basin,
-    /// records the inward-pointing unit vector from that spot to the
-    /// basin centre, and resets the inlet age.
-    /// </summary>
-    private void SpawnInlet(int dw, int dh)
+    private bool IsBasinFull()
     {
-        var edge = NextRandom() & 3;
-        switch (edge)
+        var cols = _columns;
+        for (var i = 0; i < cols.Length; i++)
         {
-            case 0: _inletX = NextFloat() * dw; _inletY = 0f; break;
-            case 1: _inletX = NextFloat() * dw; _inletY = dh - 1f; break;
-            case 2: _inletX = 0f; _inletY = NextFloat() * dh; break;
-            default: _inletX = dw - 1f; _inletY = NextFloat() * dh; break;
+            if (cols[i] != FullColumn) return false;
         }
-        var cx = dw * 0.5f;
-        var cy = dh * 0.5f;
-        var dx = cx - _inletX;
-        var dy = cy - _inletY;
-        var len = MathF.Sqrt(dx * dx + dy * dy);
-        if (len < 1e-4f) { _inletDirX = 0f; _inletDirY = 1f; }
-        else { _inletDirX = dx / len; _inletDirY = dy / len; }
-        _jetX = _inletX;
-        _jetY = _inletY;
+        return true;
     }
 
-    /// <summary>
-    /// Injects energy into the wave field. Three sources:
-    /// (1) a continuous negative impulse at the drain centre while
-    /// the drain is open (the suction is felt as turbulence);
-    /// (2) continuous positive impulses scattered along the screen
-    /// edges during refill (water rushing in splashes); (3) a few
-    /// small random impulses anywhere on the field while anything is
-    /// active, giving the ocean its own background chop.
-    /// </summary>
-    private void InjectWaveImpulses(int dw, int dh)
-    {
-        var wave = _wave;
-        var amp = _activity;
-
-        if (_drainActive)
-        {
-            var cx = (int)_drainX;
-            var cy = (int)(_drainY * 2 + 0.5f);
-            var imp = DrainImpulse * _strength * amp;
-            Splat(wave, dw, dh, cx, cy, imp);
-        }
-        else if (_inletEnvelope > 0f)
-        {
-            // Refill — splat a strong positive impulse at the jet
-            // head plus a lead impulse further inward, and spray a
-            // cloud of turbulent chop around the head. Together
-            // these give the inlet a violent, churning, advancing
-            // wavefront instead of a polite bloom.
-            var amp2 = _inletEnvelope * amp;
-            var jx = (int)_jetX;
-            var jy = (int)_jetY;
-            Splat(wave, dw, dh, jx, jy, InletWaveImpulse * amp2);
-            var leadX = (int)(_jetX + _inletDirX * 4f);
-            var leadY = (int)(_jetY + _inletDirY * 4f);
-            Splat(wave, dw, dh, leadX, leadY, InletWaveImpulse * 0.75f * amp2);
-            var lead2X = (int)(_jetX + _inletDirX * 8f);
-            var lead2Y = (int)(_jetY + _inletDirY * 8f);
-            Splat(wave, dw, dh, lead2X, lead2Y, InletWaveImpulse * 0.4f * amp2);
-
-            // Turbulent spray — random chop around the jet head, but
-            // only where there's enough water to support the ripple.
-            // Without this we leave visible wake lines across dry
-            // basin which look wrong.
-            for (var k = 0; k < InletChopPerFrame; k++)
-            {
-                var rx = (NextFloat() * 2f - 1f) * InletChopRadius;
-                var ry = (NextFloat() * 2f - 1f) * InletChopRadius;
-                var cx = (int)(_jetX + rx);
-                var cy = (int)(_jetY + ry);
-                if ((uint)cx >= (uint)dw || (uint)cy >= (uint)dh) continue;
-                var i = cy * dw + cx;
-                if (_depth[i] < WaveDepthThreshold) continue;
-                var sign = (NextRandom() & 1) == 0 ? 1f : -1f;
-                wave[i] += InletChopAmplitude * amp2 * sign;
-            }
-        }
-
-        // Background ocean chop — small scattered impulses, also
-        // suppressed where there's effectively no water.
-        for (var k = 0; k < ChopPerFrame; k++)
-        {
-            var cx = (int)(NextFloat() * dw);
-            var cy = (int)(NextFloat() * dh);
-            var sign = (NextRandom() & 1) == 0 ? 1f : -1f;
-            var i = cy * dw + cx;
-            if ((uint)i < (uint)wave.Length && _depth[i] >= WaveDepthThreshold)
-                wave[i] += ChopAmplitude * amp * sign;
-        }
-    }
-
-    /// <summary>3×3 soft splat of an impulse into the wave field.</summary>
-    private static void Splat(float[] wave, int dw, int dh, int cx, int cy, float amp)
-    {
-        for (var dy = -1; dy <= 1; dy++)
-        {
-            var y = cy + dy;
-            if ((uint)y >= (uint)dh) continue;
-            for (var dx = -1; dx <= 1; dx++)
-            {
-                var x = cx + dx;
-                if ((uint)x >= (uint)dw) continue;
-                var f = (dx == 0 && dy == 0) ? 1f : ((dx == 0 || dy == 0) ? 0.5f : 0.25f);
-                wave[y * dw + x] += amp * f;
-            }
-        }
-    }
-
-    /// <summary>
-    /// Pond-style discretised 2D wave-equation step:
-    /// <c>next = (sum of 4 neighbours)/2 - prev; next *= damping</c>.
-    /// Ping-pongs <see cref="_wave"/> and <see cref="_wavePrev"/>.
-    /// Returns true if any cell carries energy above the floor.
-    /// </summary>
-    private bool WaveStep(int dw, int dh)
-    {
-        var cur = _wave;
-        var prv = _wavePrev;
-        var anyAlive = false;
-        for (var y = 1; y < dh - 1; y++)
-        {
-            var row = y * dw;
-            for (var x = 1; x < dw - 1; x++)
-            {
-                var i = row + x;
-                var nb = cur[i - 1] + cur[i + 1] + cur[i - dw] + cur[i + dw];
-                var next = (nb * 0.5f) - prv[i];
-                next *= WaveDamping;
-                if (next > -WaveFloor && next < WaveFloor) next = 0f;
-                else anyAlive = true;
-                prv[i] = next;
-            }
-        }
-        (_wave, _wavePrev) = (prv, cur);
-        return anyAlive;
-    }
-
-    private static void VelocityAt(float x, float y, float cx, float cy,
-        float Q, float G, float soft, out float vx, out float vy)
-    {
-        var dx = x - cx;
-        var dy = y - cy;
-        var r = MathF.Sqrt(dx * dx + dy * dy);
-        var inv = 1f / (r + 1e-4f);
-        var mag = 1f / (r + soft);
-        var rx = dx * inv;
-        var ry = dy * inv;
-        vx = -Q * mag * rx + G * mag * (-ry);
-        vy = -Q * mag * ry + G * mag *  rx;
-    }
-
-    /// <summary>
-    /// Semi-Lagrangian advection of <paramref name="src"/> into
-    /// <paramref name="dst"/>. Out-of-grid samples return 0 so the
-    /// basin actually drains while the drain is open instead of
-    /// being topped up by a fictitious infinite ocean. The velocity
-    /// is gated by a Gaussian window centred on the drain whose
-    /// sigma is <see cref="CurrentDrainReach"/>: outside that radius
-    /// the velocity is effectively zero, so far-from-drain water
-    /// stays put until the whirlpool's influence has grown out to it.
-    /// Cells fully outside the window are copied through unchanged.
-    /// </summary>
-    private void AdvectField(float[] src, float[] dst, int dw, int dh)
-    {
-        var cx = _drainX;
-        var cy = _drainY * 2f + 0.5f;
-        var Q = SinkStrength * _strength;
-        var G = SwirlStrength * _strength;
-        var soft = VelocitySoftening;
-        var sigma = CurrentDrainReach();
-        var invTwoSigmaSq = 1f / (2f * sigma * sigma);
-        // Beyond ~3 sigma the Gaussian is < 0.012; skip advection
-        // entirely there so the field outside the whirlpool's reach
-        // stays exactly put (no creeping numerical drift).
-        var skip2 = (3f * sigma) * (3f * sigma);
-        for (var y = 0; y < dh; y++)
-        {
-            var row = y * dw;
-            var dyc = y - cy;
-            for (var x = 0; x < dw; x++)
-            {
-                var dxc = x - cx;
-                var d2 = dxc * dxc + dyc * dyc;
-                if (d2 > skip2)
-                {
-                    dst[row + x] = src[row + x];
-                    continue;
-                }
-                var window = MathF.Exp(-d2 * invTwoSigmaSq);
-                VelocityAt(x, y, cx, cy, Q, G, soft, out var vx, out var vy);
-                vx *= window;
-                vy *= window;
-                var sx = x - vx;
-                var sy = y - vy;
-                dst[row + x] = SampleBilinearOrZero(src, dw, dh, sx, sy);
-            }
-        }
-    }
-
-    private static float SampleBilinearOrZero(float[] field, int dw, int dh, float x, float y)
-    {
-        if (x < 0f || x > dw - 1f || y < 0f || y > dh - 1f) return 0f;
-        var x0 = (int)x;
-        var y0 = (int)y;
-        var x1 = Math.Min(x0 + 1, dw - 1);
-        var y1 = Math.Min(y0 + 1, dh - 1);
-        var fx = x - x0;
-        var fy = y - y0;
-        var a = field[y0 * dw + x0];
-        var b = field[y0 * dw + x1];
-        var c = field[y1 * dw + x0];
-        var d = field[y1 * dw + x1];
-        var top = a + (b - a) * fx;
-        var bot = c + (d - c) * fx;
-        return top + (bot - top) * fy;
-    }
-
-    private void DrawWater(Surface surface)
+    // ----------------------------------------------------------------
+    // Rendering — top-down. Walls drawn as a solid border, interior
+    // sub-cells coloured by column height. Open drain hole rendered
+    // as a dark dot on the floor at the drain cell.
+    // ----------------------------------------------------------------
+    private void DrawTank(Surface surface)
     {
         var w = surface.Width;
         var h = surface.Height;
-        var dw = _dotWidth;
-        var depth = _depth;
-        var wave = _wave;
 
-        for (var cy = 0; cy < h; cy++)
+        // Walls — top, bottom, left, right.
+        for (var x = 0; x < w; x++)
         {
-            var topRow = (cy * 2) * dw;
-            var botRow = (cy * 2 + 1) * dw;
-            for (var cx = 0; cx < w; cx++)
+            surface[x, 0] = new SurfaceCell("▄", WallColour, WallTrim);
+            surface[x, h - 1] = new SurfaceCell("▀", WallColour, WallTrim);
+        }
+        for (var y = 1; y < h - 1; y++)
+        {
+            surface[0, y] = new SurfaceCell("█", WallColour, WallColour);
+            surface[w - 1, y] = new SurfaceCell("█", WallColour, WallColour);
+        }
+
+        // Interior — half-block per cell from two stacked sub-cells.
+        var dw = _dw;
+        var cols = _columns;
+        for (var cy = WallCells; cy < h - WallCells; cy++)
+        {
+            var iy = cy - WallCells;
+            var topRow = (iy * 2) * dw;
+            var botRow = (iy * 2 + 1) * dw;
+            for (var cx = WallCells; cx < w - WallCells; cx++)
             {
-                var iTop = topRow + cx;
-                var iBot = botRow + cx;
-                var dTop = depth[iTop];
-                var dBot = depth[iBot];
-                // Mask wave contribution by local depth — no waves
-                // can ride on dry basin. Ramps 0..1 over the wave-
-                // depth threshold so the transition isn't a hard
-                // edge as a cell drains/fills past it.
-                var maskTop = dTop >= WaveDepthThreshold ? 1f : dTop / WaveDepthThreshold;
-                var maskBot = dBot >= WaveDepthThreshold ? 1f : dBot / WaveDepthThreshold;
-                var topV = dTop + WaveDisplayScale * wave[iTop] * maskTop;
-                var botV = dBot + WaveDisplayScale * wave[iBot] * maskBot;
-                if (topV < 0f) topV = 0f; else if (topV > 1f) topV = 1f;
-                if (botV < 0f) botV = 0f; else if (botV > 1f) botV = 1f;
+                var ix = cx - WallCells;
+                var hTop = Height(cols[topRow + ix]);
+                var hBot = Height(cols[botRow + ix]);
                 surface[cx, cy] = new SurfaceCell("▀",
-                    DepthColour(topV), DepthColour(botV));
+                    DepthColour(hTop), DepthColour(hBot));
             }
         }
 
+        // Drain hole — a dark dot on the tank floor at the drain
+        // location, visible when the drain is open. Sits on top of
+        // the half-block water so you can see it through whatever
+        // water depth remains.
         if (_drainActive)
         {
-            var mx = (int)_drainX;
-            var my = (int)_drainY;
-            if ((uint)mx < (uint)w && (uint)my < (uint)h)
+            var holeCx = _drainCx + WallCells;
+            var holeCy = _drainCy / 2 + WallCells;
+            if (holeCx >= WallCells && holeCx < w - WallCells
+                && holeCy >= WallCells && holeCy < h - WallCells)
             {
-                var bg = DepthColour(depth[(my * 2 + 1) * dw + mx]);
-                surface[mx, my] = new SurfaceCell("◉",
-                    Hex1bColor.FromRgb(255, 240, 200), bg);
+                var iy = holeCy - WallCells;
+                var topRow = (iy * 2) * dw;
+                var botRow = (iy * 2 + 1) * dw;
+                var ix = holeCx - WallCells;
+                var hTop = Height(cols[topRow + ix]);
+                var hBot = Height(cols[botRow + ix]);
+                surface[holeCx, holeCy] = new SurfaceCell("◉",
+                    HoleColour, DepthColour(hBot == 0 ? 0 : hBot));
+                // Suppress: keep DepthColour(hTop) ignored for the
+                // foreground because the glyph is the hole indicator.
+                _ = hTop;
             }
         }
     }
 
-    private static Hex1bColor DepthColour(float d)
+    private static Hex1bColor DepthColour(int h)
     {
-        if (d <= 0f) return Hex1bColor.FromRgb(SandColour.R, SandColour.G, SandColour.B);
-        if (d >= 1f) return Hex1bColor.FromRgb(DeepColour.R, DeepColour.G, DeepColour.B);
-        if (d < 0.2f) return Lerp(SandColour, ShallowColour, d / 0.2f);
-        if (d < 0.6f) return Lerp(ShallowColour, MidColour, (d - 0.2f) / 0.4f);
-        return Lerp(MidColour, DeepColour, (d - 0.6f) / 0.4f);
+        if (h <= 0) return Hex1bColor.FromRgb(SandColour.R, SandColour.G, SandColour.B);
+        if (h >= D) return Hex1bColor.FromRgb(DeepColour.R, DeepColour.G, DeepColour.B);
+        var t = h / (float)D;
+        if (t < 0.25f) return Lerp(SandColour, ShallowColour, t / 0.25f);
+        if (t < 0.65f) return Lerp(ShallowColour, MidColour, (t - 0.25f) / 0.4f);
+        return Lerp(MidColour, DeepColour, (t - 0.65f) / 0.35f);
     }
 
     private static Hex1bColor Lerp((byte R, byte G, byte B) a, (byte R, byte G, byte B) b, float t)

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -117,13 +117,19 @@ internal sealed class WhirlpoolPage : IStressPage
 
     public Hex1bWidget Build(StressContext sc)
     {
-        return sc.Root
-            .Surface(layer =>
+        // The Surface widget on its own doesn't participate in mouse-event
+        // routing — wrap it in an Interactable so left/right click and
+        // scroll wheel events get delivered to our bindings. (The Pond
+        // page can get away without this because it samples mouse *position*
+        // every frame from SurfaceLayerContext, which goes through a
+        // different path; click/scroll *events* need explicit routing.)
+        return sc.Root.Interactable(ic =>
+            ic.Surface(layer =>
             {
                 EnsureField(layer.Width, layer.Height);
                 Step();
                 return new[] { layer.Layer(DrawParticles) };
-            })
+            }))
             .InputBindings(bindings =>
             {
                 // Left click: position the well at the cursor and activate

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -90,8 +90,8 @@ internal sealed class WhirlpoolPage : IStressPage
     private int _drainCy;
     private float _strength = 1.0f;
     private int _drainOpenFrames;
-    private const float MinStrength = 0.3f;
-    private const float MaxStrength = 4.0f;
+    private const float MinStrength = 0.2f;
+    private const float MaxStrength = 8.0f;
 
     private const float DrainReachInitial   = 2.0f;
     private const float DrainReachMax       = 22f;
@@ -191,11 +191,11 @@ internal sealed class WhirlpoolPage : IStressPage
                 });
                 bindings.Mouse(MouseButton.ScrollUp).Action(_ =>
                 {
-                    _strength = MathF.Min(MaxStrength, _strength * 1.2f);
+                    _strength = MathF.Min(MaxStrength, _strength * 1.4f);
                 });
                 bindings.Mouse(MouseButton.ScrollDown).Action(_ =>
                 {
-                    _strength = MathF.Max(MinStrength, _strength * 0.83f);
+                    _strength = MathF.Max(MinStrength, _strength * 0.71f);
                 });
                 bindings.Mouse(MouseButton.Left).Ctrl().Action(_ =>
                 {

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -15,11 +15,12 @@ namespace PerfStressDemo;
 /// <list type="bullet">
 ///   <item><b>Pressure gradient</b> — water accelerates away from
 ///         high-water cells toward low-water cells (<c>∂v/∂t ∝ -∇h</c>).</item>
-///   <item><b>Drain attraction + swirl</b> — when the drain is open,
-///         each cell within reach gains a radially-inward and
-///         tangential acceleration, weighted by a Gaussian on
-///         distance to the drain. This is what spins the visible
-///         whirlpool.</item>
+///   <item><b>Drain attraction</b> — when the drain is open, each
+///         cell within reach receives a radially-inward acceleration
+///         weighted by a Gaussian on distance to the drain centre.
+///         The vortex shape emerges naturally from this radial pull
+///         plus the pressure gradient and the obstacle field, with
+///         no artificial tangential swirl.</item>
 ///   <item><b>Damping</b> — multiplicative per-frame velocity decay
 ///         plus a hard cap; the system loses energy over time so it
 ///         eventually settles.</item>
@@ -61,7 +62,7 @@ internal sealed class WhirlpoolPage : IStressPage
 
     public string Description =>
         "Shallow-water voxel fluid: per-cell height + 2D velocity, "
-        + "pressure-gradient acceleration, drain attraction + swirl, "
+        + "pressure-gradient acceleration, radial drain attraction, "
         + "integer voxel flux transfers. Water sloshes back elastically "
         + "when the drain closes.";
 
@@ -99,7 +100,6 @@ internal sealed class WhirlpoolPage : IStressPage
     private const float DrainDiscRadiusMax  = 3.0f;
     private const float DrainDensity        = 2.0f;
     private const float PullStrength        = 0.35f; // peak inward accel per frame at drain centre
-    private const float SwirlStrength       = 0.60f; // peak tangential accel per frame
 
     // ----------------------------------------------------------------
     // Shallow-water dynamics. Tune for visible momentum / sloshing
@@ -354,7 +354,7 @@ internal sealed class WhirlpoolPage : IStressPage
     /// <summary>
     /// Per-cell acceleration: pressure gradient pushes velocity from
     /// high water toward low water; while the drain is open each
-    /// cell within reach also receives a radial-inward + tangential
+    /// cell within reach also receives a radial-inward
     /// acceleration weighted by a Gaussian on its distance to the
     /// drain centre. Boundaries reflect by mirroring the centre
     /// height into the off-grid neighbour — so the wall pushes back
@@ -372,7 +372,6 @@ internal sealed class WhirlpoolPage : IStressPage
         var twoR2 = 2f * reach * reach;
         var skip2 = (3f * reach) * (3f * reach);
         var pull = PullStrength * _strength;
-        var swirl = SwirlStrength * _strength;
 
         for (var y = 0; y < dh; y++)
         {
@@ -417,10 +416,8 @@ internal sealed class WhirlpoolPage : IStressPage
                     var invR = 1f / MathF.Sqrt(d2);
                     var inX = -dxc * invR;
                     var inY = -dyc * invR;
-                    var tX = -dyc * invR; // CCW tangential
-                    var tY =  dxc * invR;
-                    vx[i] += (pull * inX + swirl * tX) * w;
-                    vy[i] += (pull * inY + swirl * tY) * w;
+                    vx[i] += pull * inX * w;
+                    vy[i] += pull * inY * w;
                 }
             }
         }

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -77,29 +77,35 @@ internal sealed class WhirlpoolPage : IStressPage
     private const float MaxStrength = 4.0f;
 
     // ----------------------------------------------------------------
-    // Surface bubbles. The depth field alone is rotationally
-    // symmetric, so it reads as a hole — not a whirlpool. Floating
-    // bubbles that get sucked inward AND tangentially around the
-    // drain, leaving fading foam streaks along their paths, sell the
-    // rotation. Bubbles are SoA-ish via Bubble[]; foam is a flat
-    // float grid the size of the depth grid that decays each frame
-    // and is blended over the water colour at render time.
+    // Surface bubbles. Modelled as PASSIVE tracers carried by the
+    // velocity field — no momentum, no orbits, no escape. Real
+    // surface particles in a fluid don't have inertia separate from
+    // the fluid itself; the mass of the water behind them keeps
+    // pushing them toward the sink. To simulate that we look up the
+    // local potential-flow velocity each frame and step by it.
     // ----------------------------------------------------------------
     private struct Bubble
     {
         public float X;   // sub-cell coords
         public float Y;
-        public float VX;
-        public float VY;
     }
     private Bubble[] _bubbles = Array.Empty<Bubble>();
     private float[] _foam = Array.Empty<float>();
     private const float FoamDecay = 0.84f;             // per frame
-    private const float BubbleDamping = 0.94f;         // when drain inactive
-    private const float BubbleMaxSpeed = 1.4f;         // sub-cells / frame
-    private const float DrainPullBase = 1.6f;          // accel scale, inward
-    private const float DrainSwirlBase = 1.05f;        // accel scale, tangential
+    private const float BubbleMaxSpeed = 2.5f;         // sub-cells / frame (anti-overshoot)
     private const float BubbleAbsorbRadius = 1.6f;     // sub-cells
+
+    // ----------------------------------------------------------------
+    // Potential-flow velocity field. A 2D sink at the drain has
+    // velocity v_r = -Q/r (inward); adding a free vortex of
+    // circulation Γ gives v_θ = Γ/r (tangential). Streamlines are
+    // logarithmic spirals at angle atan(Γ/Q) from the radial.
+    // VelocitySoftening avoids the 1/0 singularity at the drain
+    // centre and keeps the cell-skip rate manageable.
+    // ----------------------------------------------------------------
+    private const float SinkStrength = 9.0f;
+    private const float SwirlStrength = 18.0f;         // Γ ~ 2Q → ~63° spirals
+    private const float VelocitySoftening = 2.5f;
 
     // ----------------------------------------------------------------
     // Inlets — small periodically-spawned sources on the screen edge.
@@ -124,10 +130,10 @@ internal sealed class WhirlpoolPage : IStressPage
     // Physics constants.
     // ----------------------------------------------------------------
     private const float MaxDepth = 1.0f;
-    // Diffusion rate per neighbour per frame. With 4 neighbours, total
-    // outflow per step is 4 * DiffusionK. Keep < 0.25 for stability of
-    // the explicit scheme (CFL).
-    private const float DiffusionK = 0.18f;
+    // Diffusion rate per neighbour per frame. Kept small now that
+    // advection is the primary transport — too much diffusion blurs
+    // away the spiral contours that advection deliberately creates.
+    private const float DiffusionK = 0.045f;
     private const float DrainRadius = 6.5f;       // sub-cell units
     private const float DrainPerFrameBase = 0.28f; // strength multiplier
     private const int   InletCheckInterval = 12;   // frames between spawn attempts
@@ -239,8 +245,6 @@ internal sealed class WhirlpoolPage : IStressPage
             ref var b = ref _bubbles[i];
             b.X = NextFloat() * _dotWidth;
             b.Y = NextFloat() * _dotHeight;
-            b.VX = 0;
-            b.VY = 0;
         }
         _quiescent = true;
     }
@@ -256,6 +260,25 @@ internal sealed class WhirlpoolPage : IStressPage
         var dh = _dotHeight;
         var depth = _depth;
         var delta = _delta;
+
+        // ---- Pass 0: advection. When the drain is open, semi-
+        //      Lagrangian-advect the depth field by the analytic
+        //      potential-flow velocity. This is what makes spiral
+        //      contours appear: the radial-plus-tangential velocity
+        //      drags the depth dip created by the drain around in
+        //      logarithmic spirals. Without this step the depth
+        //      field would stay rotationally symmetric no matter
+        //      what.
+        if (_drainActive)
+        {
+            AdvectField(depth, delta, dw, dh);
+            // delta now holds the advected field. Swap so the rest
+            // of Step reads/writes the advected one.
+            (depth, delta) = (delta, depth);
+            _depth = depth;
+            _delta = delta;
+        }
+
         Array.Clear(delta, 0, delta.Length);
 
         // ---- Pass 1: diffusion. Flow between each cell and its right
@@ -263,6 +286,8 @@ internal sealed class WhirlpoolPage : IStressPage
         //      per cell visits every edge exactly once (every pair
         //      shares exactly one direction). Symmetric add/subtract
         //      makes the operation mass-conserving by construction.
+        //      Kept gentle so spiral contours from advection survive
+        //      a few frames before being smoothed out.
         var anyFlow = false;
         for (var y = 0; y < dh; y++)
         {
@@ -530,16 +555,17 @@ internal sealed class WhirlpoolPage : IStressPage
     }
 
     /// <summary>
-    /// Advances all surface bubbles one frame. When the drain is
-    /// active, each bubble feels an inward pull (~1/r) plus a
-    /// tangential swirl (~1/r), so bubbles spiral in and accelerate
-    /// as they approach the drain. Bubbles that reach the centre are
-    /// absorbed and respawned at a random screen edge. Each bubble
-    /// deposits foam along the line from its previous position to its
-    /// new position, so faster bubbles leave longer/brighter streaks.
+    /// Advances all surface bubbles one frame as PASSIVE TRACERS in
+    /// the potential-flow velocity field. There is no momentum: each
+    /// bubble's new position is simply its old position plus the
+    /// local velocity. This is physically right for a surface particle
+    /// floating on a draining fluid — it goes wherever the surface
+    /// goes, with the mass of water behind it continuously pushing.
+    /// Particles cannot escape orbit; they follow streamlines
+    /// (logarithmic spirals) inevitably into the drain.
     /// </summary>
-    /// <returns>true if any bubble has non-trivial velocity or any
-    /// foam is still visible — used by the quiescence check.</returns>
+    /// <returns>true if anything is moving or any foam remains —
+    /// used by the quiescence check.</returns>
     private bool StepBubbles(int dw, int dh)
     {
         // ---- foam decay pass (and "any foam left?" probe)
@@ -553,12 +579,19 @@ internal sealed class WhirlpoolPage : IStressPage
             foam[i] = f;
         }
 
+        if (!_drainActive)
+        {
+            // No drain → no flow → tracers are stationary. (Inlet
+            // flow is too localised to bother sampling here.)
+            return anyFoam;
+        }
+
         var cx = _drainX;
         var cy = _drainY * 2f + 0.5f;
-        var pullScale = DrainPullBase * _strength;
-        var swirlScale = DrainSwirlBase * _strength;
+        var Q = SinkStrength * _strength;
+        var G = SwirlStrength * _strength;
+        var soft = VelocitySoftening;
         var absorbR2 = BubbleAbsorbRadius * BubbleAbsorbRadius;
-        var moving = false;
 
         for (var i = 0; i < _bubbles.Length; i++)
         {
@@ -566,52 +599,29 @@ internal sealed class WhirlpoolPage : IStressPage
             var px = b.X;
             var py = b.Y;
 
-            if (_drainActive)
+            var ddx = cx - px;
+            var ddy = cy - py;
+            if (ddx * ddx + ddy * ddy < absorbR2)
             {
-                var ddx = cx - px;
-                var ddy = cy - py;
-                var d2 = ddx * ddx + ddy * ddy;
-                if (d2 < absorbR2)
-                {
-                    // Bubble swallowed — respawn at a random edge.
-                    RespawnBubbleAtEdge(ref b, dw, dh);
-                    continue;
-                }
-                var d = MathF.Sqrt(d2);
-                var inv = 1f / d;
-                // Soft 1/(d+1) falloff so close-in particles don't
-                // get infinite force.
-                var falloff = 1f / (d + 1.5f);
-                // Inward acceleration.
-                b.VX += pullScale * falloff * ddx * inv;
-                b.VY += pullScale * falloff * ddy * inv;
-                // Tangential (counter-clockwise) — perpendicular to
-                // the inward vector.
-                b.VX += swirlScale * falloff * (-ddy * inv);
-                b.VY += swirlScale * falloff * ( ddx * inv);
-            }
-            else
-            {
-                // Drain off → glide to a halt.
-                b.VX *= BubbleDamping;
-                b.VY *= BubbleDamping;
+                RespawnBubbleAtEdge(ref b, dw, dh);
+                continue;
             }
 
-            // Speed cap.
-            var vmag2 = b.VX * b.VX + b.VY * b.VY;
+            VelocityAt(px, py, cx, cy, Q, G, soft, out var vx, out var vy);
+
+            // Speed cap — guards against the centre singularity and
+            // keeps semi-Lagrangian / line rasterisation stable.
+            var vmag2 = vx * vx + vy * vy;
             if (vmag2 > BubbleMaxSpeed * BubbleMaxSpeed)
             {
                 var s = BubbleMaxSpeed / MathF.Sqrt(vmag2);
-                b.VX *= s;
-                b.VY *= s;
-                vmag2 = BubbleMaxSpeed * BubbleMaxSpeed;
+                vx *= s;
+                vy *= s;
             }
-            if (vmag2 > 0.0004f) moving = true;
 
-            var nx = px + b.VX;
-            var ny = py + b.VY;
+            var nx = px + vx;
+            var ny = py + vy;
 
-            // Out of bounds → respawn at a random edge.
             if (nx < 0f || nx >= dw || ny < 0f || ny >= dh)
             {
                 RespawnBubbleAtEdge(ref b, dw, dh);
@@ -623,7 +633,83 @@ internal sealed class WhirlpoolPage : IStressPage
             DepositFoamLine(foam, dw, dh, px, py, nx, ny);
         }
 
-        return moving || anyFoam;
+        return true; // drain active → always moving
+    }
+
+    /// <summary>
+    /// Computes the 2D potential-flow velocity at a sample point: a
+    /// sink (radial inflow) plus a free vortex (tangential swirl),
+    /// both with <c>1/(r + softening)</c> falloff. With Γ ≈ 2Q the
+    /// streamlines are tight logarithmic spirals at ≈63° from the
+    /// radial — visually a strong whirlpool.
+    /// </summary>
+    private static void VelocityAt(float x, float y, float cx, float cy,
+        float Q, float G, float soft, out float vx, out float vy)
+    {
+        var dx = x - cx;
+        var dy = y - cy;
+        var r2 = dx * dx + dy * dy;
+        var r = MathF.Sqrt(r2);
+        var inv = 1f / (r + 1e-4f);
+        var mag = 1f / (r + soft);
+        // Unit radial outward (rx, ry); tangential CCW is (-ry, rx).
+        var rx = dx * inv;
+        var ry = dy * inv;
+        // v = -Q * r_hat + G * t_hat
+        vx = -Q * mag * rx + G * mag * (-ry);
+        vy = -Q * mag * ry + G * mag *  rx;
+    }
+
+    /// <summary>
+    /// Semi-Lagrangian advection: for each destination cell, trace
+    /// the velocity field backwards by one step and sample the source
+    /// field (bilinearly) at that upstream position. Unconditionally
+    /// stable for any timestep — the price is some numerical
+    /// diffusion, but at our 1-frame dt and small velocities outside
+    /// the drain core, it's tolerable. Cells whose upstream sample
+    /// falls outside the grid clamp to MaxDepth, on the assumption
+    /// that "outside" is an effectively infinite ocean.
+    /// </summary>
+    private void AdvectField(float[] src, float[] dst, int dw, int dh)
+    {
+        var cx = _drainX;
+        var cy = _drainY * 2f + 0.5f;
+        var Q = SinkStrength * _strength;
+        var G = SwirlStrength * _strength;
+        var soft = VelocitySoftening;
+        for (var y = 0; y < dh; y++)
+        {
+            var row = y * dw;
+            for (var x = 0; x < dw; x++)
+            {
+                VelocityAt(x, y, cx, cy, Q, G, soft, out var vx, out var vy);
+                var sx = x - vx;
+                var sy = y - vy;
+                dst[row + x] = SampleBilinear(src, dw, dh, sx, sy);
+            }
+        }
+    }
+
+    private static float SampleBilinear(float[] field, int dw, int dh, float x, float y)
+    {
+        // Outside-grid samples treat the basin as surrounded by full
+        // ocean — this is what makes the basin try to "refill" itself
+        // along the streamlines that wrap in from the screen edges.
+        if (x < 0f || x > dw - 1f || y < 0f || y > dh - 1f)
+            return MaxDepth;
+        var x0 = (int)x;
+        var y0 = (int)y;
+        var x1 = Math.Min(x0 + 1, dw - 1);
+        var y1 = Math.Min(y0 + 1, dh - 1);
+        var fx = x - x0;
+        var fy = y - y0;
+        var a = field[y0 * dw + x0];
+        var b = field[y0 * dw + x1];
+        var c = field[y1 * dw + x0];
+        var d = field[y1 * dw + x1];
+        var top = a + (b - a) * fx;
+        var bot = c + (d - c) * fx;
+        return top + (bot - top) * fy;
     }
 
     /// <summary>
@@ -668,8 +754,6 @@ internal sealed class WhirlpoolPage : IStressPage
             case 2: b.X = 0f; b.Y = NextFloat() * dh; break;
             default: b.X = dw - 1f; b.Y = NextFloat() * dh; break;
         }
-        b.VX = 0f;
-        b.VY = 0f;
     }
 
     private static Hex1bColor DepthColour(float d)

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -48,9 +48,9 @@ namespace PerfStressDemo;
 /// border is drawn around the perimeter, with the drain hole appearing
 /// as a dark dot at the cursor while it's open.
 ///
-/// Controls: left click opens the drain at the cursor and resets the
-/// reach ramp; right click closes it; scroll up/down adjusts drain
-/// strength.
+/// Controls: left click places the outlet (drain) at the cursor;
+/// right click places the inlet (refill source); R clears both and
+/// refills the basin to full; scroll up/down adjusts drain strength.
 /// </summary>
 internal sealed class WhirlpoolPage : IStressPage
 {
@@ -107,15 +107,12 @@ internal sealed class WhirlpoolPage : IStressPage
     private const float VelocityFloor = 0.003f;
 
     // ----------------------------------------------------------------
-    // Refill — roaming inlet drips voxels into a small interior disc.
+    // Refill — fixed inlet placed by right click, drips voxels into a
+    // small interior disc until the user clears or relocates it.
     // ----------------------------------------------------------------
-    private float _inletX;
-    private float _inletY;
-    private int _inletAge;
-    private int _inletGap;
-    private const int InletLifetime  = 80;
-    private const int InletGapMin    = 0;
-    private const int InletGapMax    = 10;
+    private bool _inletActive;
+    private int _inletCx;
+    private int _inletCy;
     private const int InletVoxelsPerFrame = 10;
     private const float InletRadius  = 3f;
 
@@ -124,6 +121,7 @@ internal sealed class WhirlpoolPage : IStressPage
 
     public static float CurrentStrength { get; private set; } = 1f;
     public static bool DrainOpen { get; private set; }
+    public static bool InletOpen { get; private set; }
 
     // xorshift32 RNG
     private uint _rng = 0xDEADBEEFu;
@@ -141,6 +139,7 @@ internal sealed class WhirlpoolPage : IStressPage
     private static readonly Hex1bColor WallColour = Hex1bColor.FromRgb(70, 55, 40);
     private static readonly Hex1bColor WallTrim   = Hex1bColor.FromRgb(40, 30, 22);
     private static readonly Hex1bColor HoleColour = Hex1bColor.FromRgb(8, 8, 12);
+    private static readonly Hex1bColor InletColour = Hex1bColor.FromRgb(240, 240, 255);
 
     public Hex1bWidget Build(StressContext sc)
     {
@@ -163,9 +162,14 @@ internal sealed class WhirlpoolPage : IStressPage
                     _drainActive = true;
                     _quiescent = false;
                 });
-                bindings.Mouse(MouseButton.Right).Action(_ =>
+                bindings.Mouse(MouseButton.Right).Action(ctx =>
                 {
-                    _drainActive = false;
+                    if (!TryMouseToInteriorColumn(ctx.MouseX, ctx.MouseY, out var icx, out var icy))
+                        return;
+                    _inletCx = icx;
+                    _inletCy = icy;
+                    _inletActive = true;
+                    _quiescent = false;
                 });
                 bindings.Mouse(MouseButton.ScrollUp).Action(_ =>
                 {
@@ -204,8 +208,7 @@ internal sealed class WhirlpoolPage : IStressPage
         }
         _drainActive = false;
         _drainOpenFrames = 0;
-        _inletAge = 0;
-        _inletGap = 0;
+        _inletActive = false;
         _strength = 1f;
         _quiescent = false;
     }
@@ -227,8 +230,7 @@ internal sealed class WhirlpoolPage : IStressPage
         _quiescent = true;
         _drainActive = false;
         _drainOpenFrames = 0;
-        _inletAge = 0;
-        _inletGap = 0;
+        _inletActive = false;
     }
 
     private void Step()
@@ -236,6 +238,7 @@ internal sealed class WhirlpoolPage : IStressPage
         if (_height.Length == 0) return;
         CurrentStrength = _strength;
         DrainOpen = _drainActive;
+        InletOpen = _inletActive;
 
         ApplyForces();
         ApplyDamping();
@@ -248,20 +251,14 @@ internal sealed class WhirlpoolPage : IStressPage
             consumed = ApplyDrain();
         }
 
-        var basinFull = IsBasinFull();
         var refilled = false;
-        if (!_drainActive && !basinFull)
+        if (_inletActive)
         {
             refilled = ApplyRefill();
         }
-        else
-        {
-            _inletAge = 0;
-            _inletGap = 0;
-        }
 
         _quiescent = !_drainActive
-                     && basinFull
+                     && !_inletActive
                      && !moved
                      && !consumed
                      && !refilled
@@ -495,36 +492,24 @@ internal sealed class WhirlpoolPage : IStressPage
 
     private bool ApplyRefill()
     {
-        if (_inletAge == 0)
-        {
-            if (_inletGap > 0) { _inletGap--; return false; }
-            _inletX = NextFloat() * _dw;
-            _inletY = NextFloat() * _dh;
-        }
-        _inletAge++;
-        if (_inletAge >= InletLifetime)
-        {
-            _inletAge = 0;
-            _inletGap = InletGapMin + (int)(NextFloat() * (InletGapMax - InletGapMin + 1));
-            return false;
-        }
         var r = InletRadius;
         var r2 = r * r;
-        var x0 = Math.Max(0, (int)(_inletX - r));
-        var x1 = Math.Min(_dw - 1, (int)(_inletX + r + 0.5f));
-        var y0 = Math.Max(0, (int)(_inletY - r));
-        var y1 = Math.Min(_dh - 1, (int)(_inletY + r + 0.5f));
+        var x0 = Math.Max(0, (int)(_inletCx - r));
+        var x1 = Math.Min(_dw - 1, (int)(_inletCx + r + 0.5f));
+        var y0 = Math.Max(0, (int)(_inletCy - r));
+        var y1 = Math.Min(_dh - 1, (int)(_inletCy + r + 0.5f));
         var spanW = x1 - x0 + 1;
         var spanH = y1 - y0 + 1;
         if (spanW <= 0 || spanH <= 0) return false;
 
         var changed = false;
-        for (var n = 0; n < InletVoxelsPerFrame; n++)
+        var per = (int)MathF.Max(1f, InletVoxelsPerFrame * _strength);
+        for (var n = 0; n < per; n++)
         {
             var rx = x0 + (int)(NextFloat() * spanW);
             var ry = y0 + (int)(NextFloat() * spanH);
-            var dx = rx - _inletX;
-            var dy = ry - _inletY;
+            var dx = rx - _inletCx;
+            var dy = ry - _inletCy;
             if (dx * dx + dy * dy > r2) continue;
             var i = ry * _dw + rx;
             if (_height[i] < DShort)
@@ -534,16 +519,6 @@ internal sealed class WhirlpoolPage : IStressPage
             }
         }
         return changed;
-    }
-
-    private bool IsBasinFull()
-    {
-        var h = _height;
-        for (var i = 0; i < h.Length; i++)
-        {
-            if (h[i] != DShort) return false;
-        }
-        return true;
     }
 
     private void DrawTank(Surface surface)
@@ -575,6 +550,21 @@ internal sealed class WhirlpoolPage : IStressPage
                 surface[cx, cy] = new SurfaceCell("▀",
                     DepthColour(heights[topRow + ix]),
                     DepthColour(heights[botRow + ix]));
+            }
+        }
+
+        if (_inletActive)
+        {
+            var inCx = _inletCx + WallCells;
+            var inCy = _inletCy / 2 + WallCells;
+            if (inCx >= WallCells && inCx < w - WallCells
+                && inCy >= WallCells && inCy < hsz - WallCells)
+            {
+                var iy = inCy - WallCells;
+                var botRow = (iy * 2 + 1) * dw;
+                var ix = inCx - WallCells;
+                surface[inCx, inCy] = new SurfaceCell("◎",
+                    InletColour, DepthColour(heights[botRow + ix]));
             }
         }
 

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -72,8 +72,34 @@ internal sealed class WhirlpoolPage : IStressPage
     private float _drainX;
     private float _drainY;
     private float _strength = 1.0f;
+    private int _frame;
     private const float MinStrength = 0.3f;
     private const float MaxStrength = 4.0f;
+
+    // ----------------------------------------------------------------
+    // Surface bubbles. The depth field alone is rotationally
+    // symmetric, so it reads as a hole — not a whirlpool. Floating
+    // bubbles that get sucked inward AND tangentially around the
+    // drain, leaving fading foam streaks along their paths, sell the
+    // rotation. Bubbles are SoA-ish via Bubble[]; foam is a flat
+    // float grid the size of the depth grid that decays each frame
+    // and is blended over the water colour at render time.
+    // ----------------------------------------------------------------
+    private struct Bubble
+    {
+        public float X;   // sub-cell coords
+        public float Y;
+        public float VX;
+        public float VY;
+    }
+    private Bubble[] _bubbles = Array.Empty<Bubble>();
+    private float[] _foam = Array.Empty<float>();
+    private const float FoamDecay = 0.84f;             // per frame
+    private const float BubbleDamping = 0.94f;         // when drain inactive
+    private const float BubbleMaxSpeed = 1.4f;         // sub-cells / frame
+    private const float DrainPullBase = 1.6f;          // accel scale, inward
+    private const float DrainSwirlBase = 1.05f;        // accel scale, tangential
+    private const float BubbleAbsorbRadius = 1.6f;     // sub-cells
 
     // ----------------------------------------------------------------
     // Inlets — small periodically-spawned sources on the screen edge.
@@ -200,15 +226,29 @@ internal sealed class WhirlpoolPage : IStressPage
         var n = _dotWidth * _dotHeight;
         _depth = new float[n];
         _delta = new float[n];
+        _foam = new float[n];
         // Start full — deep ocean everywhere.
         Array.Fill(_depth, MaxDepth);
         _inlets.Clear();
+        // Bubble count scales with surface area but is bounded so a
+        // very large terminal doesn't degenerate into a foam wash.
+        var bubbleCount = Math.Clamp(n / 70, 80, 600);
+        _bubbles = new Bubble[bubbleCount];
+        for (var i = 0; i < bubbleCount; i++)
+        {
+            ref var b = ref _bubbles[i];
+            b.X = NextFloat() * _dotWidth;
+            b.Y = NextFloat() * _dotHeight;
+            b.VX = 0;
+            b.VY = 0;
+        }
         _quiescent = true;
     }
 
     private void Step()
     {
         if (_depth.Length == 0) return;
+        _frame++;
         CurrentStrength = _strength;
         DrainOpen = _drainActive;
 
@@ -275,7 +315,12 @@ internal sealed class WhirlpoolPage : IStressPage
             changed |= TickInlets(depth, dw, dh);
         }
 
-        _quiescent = !changed && _inlets.Count == 0;
+        // Surface bubbles run every frame: they need to keep coasting
+        // (and decaying foam) after the drain closes so the basin
+        // smoothly settles back to glassy water.
+        var bubblesMoving = StepBubbles(dw, dh);
+
+        _quiescent = !changed && _inlets.Count == 0 && !_drainActive && !bubblesMoving;
     }
 
     /// <summary>
@@ -436,6 +481,8 @@ internal sealed class WhirlpoolPage : IStressPage
         var h = surface.Height;
         var dw = _dotWidth;
         var depth = _depth;
+        var foam = _foam;
+
         for (var cy = 0; cy < h; cy++)
         {
             var topRow = (cy * 2) * dw;
@@ -446,27 +493,183 @@ internal sealed class WhirlpoolPage : IStressPage
                 var botD = depth[botRow + cx];
                 var topCol = DepthColour(topD);
                 var botCol = DepthColour(botD);
+
+                // Foam blend: bubbles deposit foam along their path
+                // and it decays each frame, so fast-moving bubbles
+                // leave bright streaks that read as stretching as they
+                // accelerate toward the drain.
+                var topFoam = foam[topRow + cx];
+                var botFoam = foam[botRow + cx];
+                if (topFoam > 0f) topCol = BlendFoam(topCol, topFoam);
+                if (botFoam > 0f) botCol = BlendFoam(botCol, botFoam);
+
                 surface[cx, cy] = new SurfaceCell("▀", topCol, botCol);
             }
         }
 
-        // Stamp drain marker last so it sits on top. Use the rendered
-        // cell's existing background colour so the marker doesn't
-        // create a visible black square around itself when the
-        // surrounding water is mid-tone.
         if (_drainActive)
         {
             var mx = (int)_drainX;
             var my = (int)_drainY;
             if ((uint)mx < (uint)w && (uint)my < (uint)h)
             {
-                // The bottom sub-cell of the cell at (mx, my) is the
-                // closest drain sample; use that as our backdrop.
                 var bg = DepthColour(depth[(my * 2 + 1) * dw + mx]);
                 surface[mx, my] = new SurfaceCell("◉",
                     Hex1bColor.FromRgb(255, 240, 200), bg);
             }
         }
+    }
+
+    private static Hex1bColor BlendFoam(Hex1bColor col, float intensity)
+    {
+        if (intensity > 1f) intensity = 1f;
+        var r = (byte)(col.R + (255 - col.R) * intensity);
+        var g = (byte)(col.G + (255 - col.G) * intensity);
+        var b = (byte)(col.B + (255 - col.B) * intensity);
+        return Hex1bColor.FromRgb(r, g, b);
+    }
+
+    /// <summary>
+    /// Advances all surface bubbles one frame. When the drain is
+    /// active, each bubble feels an inward pull (~1/r) plus a
+    /// tangential swirl (~1/r), so bubbles spiral in and accelerate
+    /// as they approach the drain. Bubbles that reach the centre are
+    /// absorbed and respawned at a random screen edge. Each bubble
+    /// deposits foam along the line from its previous position to its
+    /// new position, so faster bubbles leave longer/brighter streaks.
+    /// </summary>
+    /// <returns>true if any bubble has non-trivial velocity or any
+    /// foam is still visible — used by the quiescence check.</returns>
+    private bool StepBubbles(int dw, int dh)
+    {
+        // ---- foam decay pass (and "any foam left?" probe)
+        var foam = _foam;
+        var anyFoam = false;
+        for (var i = 0; i < foam.Length; i++)
+        {
+            var f = foam[i] * FoamDecay;
+            if (f < 0.005f) f = 0f;
+            else anyFoam = true;
+            foam[i] = f;
+        }
+
+        var cx = _drainX;
+        var cy = _drainY * 2f + 0.5f;
+        var pullScale = DrainPullBase * _strength;
+        var swirlScale = DrainSwirlBase * _strength;
+        var absorbR2 = BubbleAbsorbRadius * BubbleAbsorbRadius;
+        var moving = false;
+
+        for (var i = 0; i < _bubbles.Length; i++)
+        {
+            ref var b = ref _bubbles[i];
+            var px = b.X;
+            var py = b.Y;
+
+            if (_drainActive)
+            {
+                var ddx = cx - px;
+                var ddy = cy - py;
+                var d2 = ddx * ddx + ddy * ddy;
+                if (d2 < absorbR2)
+                {
+                    // Bubble swallowed — respawn at a random edge.
+                    RespawnBubbleAtEdge(ref b, dw, dh);
+                    continue;
+                }
+                var d = MathF.Sqrt(d2);
+                var inv = 1f / d;
+                // Soft 1/(d+1) falloff so close-in particles don't
+                // get infinite force.
+                var falloff = 1f / (d + 1.5f);
+                // Inward acceleration.
+                b.VX += pullScale * falloff * ddx * inv;
+                b.VY += pullScale * falloff * ddy * inv;
+                // Tangential (counter-clockwise) — perpendicular to
+                // the inward vector.
+                b.VX += swirlScale * falloff * (-ddy * inv);
+                b.VY += swirlScale * falloff * ( ddx * inv);
+            }
+            else
+            {
+                // Drain off → glide to a halt.
+                b.VX *= BubbleDamping;
+                b.VY *= BubbleDamping;
+            }
+
+            // Speed cap.
+            var vmag2 = b.VX * b.VX + b.VY * b.VY;
+            if (vmag2 > BubbleMaxSpeed * BubbleMaxSpeed)
+            {
+                var s = BubbleMaxSpeed / MathF.Sqrt(vmag2);
+                b.VX *= s;
+                b.VY *= s;
+                vmag2 = BubbleMaxSpeed * BubbleMaxSpeed;
+            }
+            if (vmag2 > 0.0004f) moving = true;
+
+            var nx = px + b.VX;
+            var ny = py + b.VY;
+
+            // Out of bounds → respawn at a random edge.
+            if (nx < 0f || nx >= dw || ny < 0f || ny >= dh)
+            {
+                RespawnBubbleAtEdge(ref b, dw, dh);
+                continue;
+            }
+
+            b.X = nx;
+            b.Y = ny;
+            DepositFoamLine(foam, dw, dh, px, py, nx, ny);
+        }
+
+        return moving || anyFoam;
+    }
+
+    /// <summary>
+    /// Rasterises a line from (x0,y0) to (x1,y1) into the foam grid,
+    /// accumulating intensity at each integer sub-cell. Brightness
+    /// scales with segment length so the streak fades to invisible
+    /// for stationary bubbles and pops for fast ones.
+    /// </summary>
+    private static void DepositFoamLine(float[] foam, int dw, int dh,
+        float x0, float y0, float x1, float y1)
+    {
+        var dx = x1 - x0;
+        var dy = y1 - y0;
+        var len = MathF.Sqrt(dx * dx + dy * dy);
+        var steps = Math.Max(1, (int)MathF.Ceiling(len));
+        var invSteps = 1f / steps;
+        var stepX = dx * invSteps;
+        var stepY = dy * invSteps;
+        // Base brightness + speed boost. Drifting bubbles add a faint
+        // sheen; fast in-rushing ones add bright streaks.
+        var intensity = MathF.Min(1f, 0.35f + len * 0.4f);
+        for (var s = 0; s <= steps; s++)
+        {
+            var fx = (int)(x0 + stepX * s);
+            var fy = (int)(y0 + stepY * s);
+            if ((uint)fx >= (uint)dw || (uint)fy >= (uint)dh) continue;
+            var idx = fy * dw + fx;
+            var existing = foam[idx];
+            // Saturating add — foam approaches 1 but never overshoots.
+            var v = existing + intensity * (1f - existing);
+            foam[idx] = v;
+        }
+    }
+
+    private void RespawnBubbleAtEdge(ref Bubble b, int dw, int dh)
+    {
+        var edge = NextRandom() & 3;
+        switch (edge)
+        {
+            case 0: b.X = NextFloat() * dw; b.Y = 0f; break;
+            case 1: b.X = NextFloat() * dw; b.Y = dh - 1f; break;
+            case 2: b.X = 0f; b.Y = NextFloat() * dh; break;
+            default: b.X = dw - 1f; b.Y = NextFloat() * dh; break;
+        }
+        b.VX = 0f;
+        b.VY = 0f;
     }
 
     private static Hex1bColor DepthColour(float d)

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -111,6 +111,19 @@ internal sealed class WhirlpoolPage : IStressPage
     private const float VelocityFloor = 0.003f;
 
     // ----------------------------------------------------------------
+    // Surface tension / film thickness.
+    //
+    // Real fluids have cohesion: a thin film of water sits put against
+    // a surface until enough volume accumulates above it to overflow.
+    // We model that with a single threshold — water at or below
+    // FilmThickness voxels is considered a "skin" with no internal
+    // pressure gradient and no advective flux. Only the excess above
+    // the threshold drives flow. Drain forces likewise only attract
+    // cells that have water depth above the skin.
+    // ----------------------------------------------------------------
+    private const float FilmThickness = 1.5f;
+
+    // ----------------------------------------------------------------
     // Refill — fixed inlet placed by right click, drips voxels into a
     // small interior disc until the user clears or relocates it.
     // ----------------------------------------------------------------
@@ -373,12 +386,21 @@ internal sealed class WhirlpoolPage : IStressPage
                 int hR = (x + 1 < dw && !solid[i + 1])  ? h[i + 1]  : hi;
                 int hU = (y > 0     && !solid[i - dw]) ? h[i - dw] : hi;
                 int hD = (y + 1 < dh && !solid[i + dw]) ? h[i + dw] : hi;
-                var gradX = (hR - hL) * 0.5f;
-                var gradY = (hD - hU) * 0.5f;
+                // Surface tension: only the depth above FilmThickness contributes
+                // to the pressure gradient. A thin film has no net force on it.
+                var eL = MathF.Max(0f, hL - FilmThickness);
+                var eR = MathF.Max(0f, hR - FilmThickness);
+                var eU = MathF.Max(0f, hU - FilmThickness);
+                var eD = MathF.Max(0f, hD - FilmThickness);
+                var gradX = (eR - eL) * 0.5f;
+                var gradY = (eD - eU) * 0.5f;
                 vx[i] -= gradX * PressureGain;
                 vy[i] -= gradY * PressureGain;
 
-                if (drainOn)
+                // Drain only attracts cells that actually hold water above the
+                // film threshold — a dry cell on the other side of the screen
+                // doesn't feel the drain until water reaches it.
+                if (drainOn && hi > FilmThickness)
                 {
                     var dxc = x - cx;
                     var dyc = y - cy;
@@ -451,7 +473,8 @@ internal sealed class WhirlpoolPage : IStressPage
                 var acc = ax[i];
                 if (v == 0f && acc == 0f) continue;
                 var hUp = v >= 0f ? h[i] : h[j];
-                acc += v * hUp;
+                var eUp = MathF.Max(0f, hUp - FilmThickness);
+                acc += v * eUp;
                 while (acc >= 1f)
                 {
                     if (h[i] > 0 && h[j] < DShort)
@@ -489,7 +512,8 @@ internal sealed class WhirlpoolPage : IStressPage
                 var acc = ay[i];
                 if (v == 0f && acc == 0f) continue;
                 var hUp = v >= 0f ? h[i] : h[j];
-                acc += v * hUp;
+                var eUp = MathF.Max(0f, hUp - FilmThickness);
+                acc += v * eUp;
                 while (acc >= 1f)
                 {
                     if (h[i] > 0 && h[j] < DShort)

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -50,8 +50,8 @@ namespace PerfStressDemo;
 /// The drain hole appears as a dark dot at the cursor while it's open.
 ///
 /// Controls: left click places the outlet (drain) at the cursor;
-/// right click places the inlet (refill source); shift+left or
-/// shift+right click clears the outlet or inlet respectively;
+/// right click places the inlet (refill source); ctrl+left or
+/// ctrl+right click clears the outlet or inlet respectively;
 /// R clears both and empties the basin; scroll up/down adjusts
 /// strength (drain consumption and inlet flow).
 /// </summary>
@@ -197,12 +197,12 @@ internal sealed class WhirlpoolPage : IStressPage
                 {
                     _strength = MathF.Max(MinStrength, _strength * 0.83f);
                 });
-                bindings.Mouse(MouseButton.Left).Shift().Action(_ =>
+                bindings.Mouse(MouseButton.Left).Ctrl().Action(_ =>
                 {
                     _drainActive = false;
                     _quiescent = false;
                 });
-                bindings.Mouse(MouseButton.Right).Shift().Action(_ =>
+                bindings.Mouse(MouseButton.Right).Ctrl().Action(_ =>
                 {
                     _inletActive = false;
                     _quiescent = false;

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -105,10 +105,10 @@ internal sealed class WhirlpoolPage : IStressPage
     // Shallow-water dynamics. Tune for visible momentum / sloshing
     // without runaway oscillation.
     // ----------------------------------------------------------------
-    private const float PressureGain = 0.10f;
-    private const float Damping      = 0.965f;
+    private const float PressureGain = 0.07f;
+    private const float Damping      = 0.92f;
     private const float MaxSpeed     = 1.1f;
-    private const float VelocityFloor = 0.003f;
+    private const float VelocityFloor = 0.015f;
 
     // ----------------------------------------------------------------
     // Surface tension / film thickness.

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -102,8 +102,8 @@ internal sealed class WhirlpoolPage : IStressPage
     // outflow per step is 4 * DiffusionK. Keep < 0.25 for stability of
     // the explicit scheme (CFL).
     private const float DiffusionK = 0.18f;
-    private const float DrainRadius = 4.0f;       // sub-cell units
-    private const float DrainPerFrameBase = 0.05f; // strength multiplier
+    private const float DrainRadius = 6.5f;       // sub-cell units
+    private const float DrainPerFrameBase = 0.28f; // strength multiplier
     private const int   InletCheckInterval = 12;   // frames between spawn attempts
     private const int   InletMaxConcurrent = 6;
     private const int   InletLifetimeMin = 90;
@@ -141,8 +141,9 @@ internal sealed class WhirlpoolPage : IStressPage
     // values so we avoid allocating new ones in the hot render loop
     // by lerping bytes and constructing the colour once per cell.
     private static readonly (byte R, byte G, byte B) SandColour = (235, 215, 175); // warm beach
-    private static readonly (byte R, byte G, byte B) ShallowColour = (140, 210, 240); // pale aqua
-    private static readonly (byte R, byte G, byte B) DeepColour = (8, 60, 130);       // deep ocean
+    private static readonly (byte R, byte G, byte B) ShallowColour = (160, 220, 245); // pale aqua
+    private static readonly (byte R, byte G, byte B) MidColour = (40, 130, 200);      // mid teal-blue
+    private static readonly (byte R, byte G, byte B) DeepColour = (8, 40, 100);       // deep ocean
 
     public Hex1bWidget Build(StressContext sc)
     {
@@ -470,21 +471,22 @@ internal sealed class WhirlpoolPage : IStressPage
 
     private static Hex1bColor DepthColour(float d)
     {
-        // Two-segment lerp: empty (0) → sand → shallow (0.25) → deep (1).
-        // The sand→shallow band is short so a barely-wet sub-cell
-        // already reads as "water" rather than damp sand.
+        // Three-segment lerp tuned so the full [0, 1] depth range is
+        // visually distinguishable: a partially-drained cell at 0.7
+        // must read clearly differently from the surrounding 1.0
+        // ocean, otherwise the whirlpool's gradient is invisible.
+        // Bands: sand → shallow (0..0.2) → mid (0.2..0.6) → deep (0.6..1).
         if (d <= 0f) return Hex1bColor.FromRgb(SandColour.R, SandColour.G, SandColour.B);
         if (d >= 1f) return Hex1bColor.FromRgb(DeepColour.R, DeepColour.G, DeepColour.B);
-        if (d < 0.25f)
+        if (d < 0.2f)
         {
-            var t = d / 0.25f;
-            return Lerp(SandColour, ShallowColour, t);
+            return Lerp(SandColour, ShallowColour, d / 0.2f);
         }
-        else
+        if (d < 0.6f)
         {
-            var t = (d - 0.25f) / 0.75f;
-            return Lerp(ShallowColour, DeepColour, t);
+            return Lerp(ShallowColour, MidColour, (d - 0.2f) / 0.4f);
         }
+        return Lerp(MidColour, DeepColour, (d - 0.6f) / 0.4f);
     }
 
     private static Hex1bColor Lerp((byte R, byte G, byte B) a, (byte R, byte G, byte B) b, float t)

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -45,8 +45,9 @@ namespace PerfStressDemo;
 /// is straightforward.
 ///
 /// The tank is the interior of the screen: a 1-cell-thick solid
-/// border is drawn around the perimeter, with the drain hole appearing
-/// as a dark dot at the cursor while it's open.
+/// border is drawn around the perimeter, with a scatter of random
+/// solid disc obstacles inside that the water has to flow around.
+/// The drain hole appears as a dark dot at the cursor while it's open.
 ///
 /// Controls: left click places the outlet (drain) at the cursor;
 /// right click places the inlet (refill source); shift+left or
@@ -75,6 +76,7 @@ internal sealed class WhirlpoolPage : IStressPage
     private float[] _vy = Array.Empty<float>();
     private float[] _flowAccX = Array.Empty<float>();
     private float[] _flowAccY = Array.Empty<float>();
+    private bool[] _solid = Array.Empty<bool>();
 
     private int _screenW, _screenH;
     private int _dw, _dh;
@@ -142,6 +144,7 @@ internal sealed class WhirlpoolPage : IStressPage
     private static readonly Hex1bColor WallTrim   = Hex1bColor.FromRgb(40, 30, 22);
     private static readonly Hex1bColor HoleColour = Hex1bColor.FromRgb(8, 8, 12);
     private static readonly Hex1bColor InletColour = Hex1bColor.FromRgb(240, 240, 255);
+    private static readonly Hex1bColor RockColour = Hex1bColor.FromRgb(95, 85, 75);
 
     public Hex1bWidget Build(StressContext sc)
     {
@@ -238,11 +241,51 @@ internal sealed class WhirlpoolPage : IStressPage
         _vy = new float[n];
         _flowAccX = new float[n];
         _flowAccY = new float[n];
+        _solid = new bool[n];
+        GenerateObstacles();
         for (var i = 0; i < n; i++) _height[i] = 0;
         _quiescent = true;
         _drainActive = false;
         _drainOpenFrames = 0;
         _inletActive = false;
+    }
+
+    /// <summary>
+    /// Scatters a handful of random solid disc obstacles inside the
+    /// tank interior, leaving a margin from the perimeter walls so
+    /// every cell on the border remains traversable.
+    /// </summary>
+    private void GenerateObstacles()
+    {
+        var n = _solid.Length;
+        for (var i = 0; i < n; i++) _solid[i] = false;
+        if (_dw < 8 || _dh < 8) return;
+
+        var area = _dw * _dh;
+        var count = Math.Max(4, area / 600); // ~ a couple of dozen on a typical screen
+        var margin = 2;
+
+        for (var k = 0; k < count; k++)
+        {
+            var cx = margin + (int)(NextFloat() * (_dw - 2 * margin));
+            var cy = margin + (int)(NextFloat() * (_dh - 2 * margin));
+            var r = 1.5f + NextFloat() * 3.5f;
+            var r2 = r * r;
+            var x0 = Math.Max(0, (int)(cx - r));
+            var x1 = Math.Min(_dw - 1, (int)(cx + r + 0.5f));
+            var y0 = Math.Max(0, (int)(cy - r));
+            var y1 = Math.Min(_dh - 1, (int)(cy + r + 0.5f));
+            for (var y = y0; y <= y1; y++)
+            {
+                var row = y * _dw;
+                for (var x = x0; x <= x1; x++)
+                {
+                    var dx = x - cx;
+                    var dy = y - cy;
+                    if (dx * dx + dy * dy <= r2) _solid[row + x] = true;
+                }
+            }
+        }
     }
 
     private void Step()
@@ -308,6 +351,7 @@ internal sealed class WhirlpoolPage : IStressPage
     {
         var dw = _dw; var dh = _dh;
         var h = _height; var vx = _vx; var vy = _vy;
+        var solid = _solid;
         var drainOn = _drainActive;
         var cx = (float)_drainCx;
         var cy = (float)_drainCy;
@@ -323,11 +367,12 @@ internal sealed class WhirlpoolPage : IStressPage
             for (var x = 0; x < dw; x++)
             {
                 var i = row + x;
+                if (solid[i]) { vx[i] = 0f; vy[i] = 0f; continue; }
                 var hi = h[i];
-                int hL = x > 0 ? h[i - 1] : hi;
-                int hR = x + 1 < dw ? h[i + 1] : hi;
-                int hU = y > 0 ? h[i - dw] : hi;
-                int hD = y + 1 < dh ? h[i + dw] : hi;
+                int hL = (x > 0     && !solid[i - 1])  ? h[i - 1]  : hi;
+                int hR = (x + 1 < dw && !solid[i + 1])  ? h[i + 1]  : hi;
+                int hU = (y > 0     && !solid[i - dw]) ? h[i - dw] : hi;
+                int hD = (y + 1 < dh && !solid[i + dw]) ? h[i + dw] : hi;
                 var gradX = (hR - hL) * 0.5f;
                 var gradY = (hD - hU) * 0.5f;
                 vx[i] -= gradX * PressureGain;
@@ -390,6 +435,7 @@ internal sealed class WhirlpoolPage : IStressPage
         var dw = _dw; var dh = _dh;
         var h = _height; var vx = _vx; var vy = _vy;
         var ax = _flowAccX; var ay = _flowAccY;
+        var solid = _solid;
         var moved = false;
 
         // X edges within each row.
@@ -400,6 +446,7 @@ internal sealed class WhirlpoolPage : IStressPage
             {
                 var i = row + x;
                 var j = i + 1;
+                if (solid[i] || solid[j]) { ax[i] = 0f; continue; }
                 var v = (vx[i] + vx[j]) * 0.5f;
                 var acc = ax[i];
                 if (v == 0f && acc == 0f) continue;
@@ -437,6 +484,7 @@ internal sealed class WhirlpoolPage : IStressPage
             {
                 var i = row + x;
                 var j = i + dw;
+                if (solid[i] || solid[j]) { ay[i] = 0f; continue; }
                 var v = (vy[i] + vy[j]) * 0.5f;
                 var acc = ay[i];
                 if (v == 0f && acc == 0f) continue;
@@ -493,6 +541,7 @@ internal sealed class WhirlpoolPage : IStressPage
             var dy = ry - _drainCy;
             if (dx * dx + dy * dy > discR2) continue;
             var i = ry * _dw + rx;
+            if (_solid[i]) continue;
             if (_height[i] > 0)
             {
                 _height[i]--;
@@ -524,6 +573,7 @@ internal sealed class WhirlpoolPage : IStressPage
             var dy = ry - _inletCy;
             if (dx * dx + dy * dy > r2) continue;
             var i = ry * _dw + rx;
+            if (_solid[i]) continue;
             if (_height[i] < DShort)
             {
                 _height[i]++;
@@ -551,6 +601,7 @@ internal sealed class WhirlpoolPage : IStressPage
 
         var dw = _dw;
         var heights = _height;
+        var solid = _solid;
         for (var cy = WallCells; cy < hsz - WallCells; cy++)
         {
             var iy = cy - WallCells;
@@ -559,9 +610,11 @@ internal sealed class WhirlpoolPage : IStressPage
             for (var cx = WallCells; cx < w - WallCells; cx++)
             {
                 var ix = cx - WallCells;
-                surface[cx, cy] = new SurfaceCell("▀",
-                    DepthColour(heights[topRow + ix]),
-                    DepthColour(heights[botRow + ix]));
+                var topI = topRow + ix;
+                var botI = botRow + ix;
+                var topCol = solid[topI] ? RockColour : DepthColour(heights[topI]);
+                var botCol = solid[botI] ? RockColour : DepthColour(heights[botI]);
+                surface[cx, cy] = new SurfaceCell("▀", topCol, botCol);
             }
         }
 

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -105,10 +105,10 @@ internal sealed class WhirlpoolPage : IStressPage
     // Shallow-water dynamics. Tune for visible momentum / sloshing
     // without runaway oscillation.
     // ----------------------------------------------------------------
-    private const float PressureGain = 0.07f;
-    private const float Damping      = 0.92f;
+    private const float PressureGain = 0.05f;
+    private const float Damping      = 0.85f;
     private const float MaxSpeed     = 0.6f;
-    private const float VelocityFloor = 0.015f;
+    private const float VelocityFloor = 0.04f;
 
     // ----------------------------------------------------------------
     // Surface tension / film thickness.
@@ -481,7 +481,11 @@ internal sealed class WhirlpoolPage : IStressPage
                 acc += v * eUp;
                 while (acc >= 1f)
                 {
-                    if (h[i] > 0 && h[j] < DShort)
+                    // Hysteresis: only transfer i->j when i is at least 2 voxels
+                    // higher. Without this, neighbouring cells perpetually
+                    // ping-pong a single voxel back and forth as the
+                    // gradient flips after each transfer.
+                    if (h[i] - h[j] >= 2 && h[i] > 0 && h[j] < DShort)
                     {
                         h[i]--; h[j]++;
                         acc -= 1f;
@@ -491,7 +495,7 @@ internal sealed class WhirlpoolPage : IStressPage
                 }
                 while (acc <= -1f)
                 {
-                    if (h[j] > 0 && h[i] < DShort)
+                    if (h[j] - h[i] >= 2 && h[j] > 0 && h[i] < DShort)
                     {
                         h[j]--; h[i]++;
                         acc += 1f;
@@ -520,7 +524,7 @@ internal sealed class WhirlpoolPage : IStressPage
                 acc += v * eUp;
                 while (acc >= 1f)
                 {
-                    if (h[i] > 0 && h[j] < DShort)
+                    if (h[i] - h[j] >= 2 && h[i] > 0 && h[j] < DShort)
                     {
                         h[i]--; h[j]++;
                         acc -= 1f;
@@ -530,7 +534,7 @@ internal sealed class WhirlpoolPage : IStressPage
                 }
                 while (acc <= -1f)
                 {
-                    if (h[j] > 0 && h[i] < DShort)
+                    if (h[j] - h[i] >= 2 && h[j] > 0 && h[i] < DShort)
                     {
                         h[j]--; h[i]++;
                         acc += 1f;

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -49,8 +49,10 @@ namespace PerfStressDemo;
 /// as a dark dot at the cursor while it's open.
 ///
 /// Controls: left click places the outlet (drain) at the cursor;
-/// right click places the inlet (refill source); R clears both and
-/// refills the basin to full; scroll up/down adjusts drain strength.
+/// right click places the inlet (refill source); shift+left or
+/// shift+right click clears the outlet or inlet respectively;
+/// R clears both and empties the basin; scroll up/down adjusts
+/// strength (drain consumption and inlet flow).
 /// </summary>
 internal sealed class WhirlpoolPage : IStressPage
 {
@@ -179,6 +181,16 @@ internal sealed class WhirlpoolPage : IStressPage
                 {
                     _strength = MathF.Max(MinStrength, _strength * 0.83f);
                 });
+                bindings.Mouse(MouseButton.Left).Shift().Action(_ =>
+                {
+                    _drainActive = false;
+                    _quiescent = false;
+                });
+                bindings.Mouse(MouseButton.Right).Shift().Action(_ =>
+                {
+                    _inletActive = false;
+                    _quiescent = false;
+                });
                 bindings.Key(Hex1bKey.R).Action(_ => ResetBasin(), "Reset");
             });
 
@@ -200,7 +212,7 @@ internal sealed class WhirlpoolPage : IStressPage
         var n = _height.Length;
         for (var i = 0; i < n; i++)
         {
-            _height[i] = DShort;
+            _height[i] = 0;
             _vx[i] = 0f;
             _vy[i] = 0f;
             _flowAccX[i] = 0f;
@@ -226,7 +238,7 @@ internal sealed class WhirlpoolPage : IStressPage
         _vy = new float[n];
         _flowAccX = new float[n];
         _flowAccY = new float[n];
-        for (var i = 0; i < n; i++) _height[i] = DShort;
+        for (var i = 0; i < n; i++) _height[i] = 0;
         _quiescent = true;
         _drainActive = false;
         _drainOpenFrames = 0;

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -1,0 +1,334 @@
+using Hex1b;
+using Hex1b.Input;
+using Hex1b.Surfaces;
+using Hex1b.Theming;
+using Hex1b.Widgets;
+
+namespace PerfStressDemo;
+
+/// <summary>
+/// Page 3 — "Whirlpool".
+///
+/// A particle system in which ~3000 single-glyph particles drift across the
+/// screen and are pulled toward a user-controllable gravity well. As they
+/// approach the well a tangential force gives them an orbital spin, so the
+/// late-stage motion looks like matter spiralling into a black hole. When a
+/// particle crosses the swallow radius (or sails off-screen) it respawns at
+/// a random edge with a small inward velocity and a fresh glyph.
+///
+/// Controls:
+///   * Left click — relocate the well to the cursor.
+///   * Scroll wheel — adjust well strength (up = stronger pull, down = weaker).
+///
+/// Stress profile: every particle is recomputed every frame and every
+/// particle writes one cell, so the surface is touched ~3000 times/frame
+/// at scattered positions. This exercises the renderer's sparse-update path
+/// rather than the bulk-fill path the other pages hit.
+/// </summary>
+internal sealed class WhirlpoolPage : IStressPage
+{
+    public string Name => "Whirlpool";
+
+    public string Description =>
+        "Particle system pulled toward a mouse-controlled gravity well. "
+        + "Click to reposition, scroll to adjust strength.";
+
+    // --------------------------------------------------------------
+    // Particle storage (Struct-of-Arrays for cache friendliness in
+    // the hot per-frame loop — we touch every particle's px/py/vx/vy
+    // sequentially each step).
+    // --------------------------------------------------------------
+    private float[] _px = Array.Empty<float>();
+    private float[] _py = Array.Empty<float>();
+    private float[] _vx = Array.Empty<float>();
+    private float[] _vy = Array.Empty<float>();
+    private byte[] _glyphIdx = Array.Empty<byte>();
+    private int _count;
+    private int _surfaceWidth;
+    private int _surfaceHeight;
+
+    // Well state. Mutated by mouse bindings; read by the sim each frame.
+    // Negative coords sentinel = not yet positioned (centred on first frame).
+    private float _wellX = -1;
+    private float _wellY = -1;
+    // Per-frame strength multiplier. The radial pull is roughly
+    // strength * size² / r, where strength scales the magnitude.
+    // 1.0 is a noticeable pull at typical screen sizes; the user can tune
+    // via scroll. Clamped to a sensible range.
+    private float _strength = 1.0f;
+    private const float MinStrength = 0.2f;
+    private const float MaxStrength = 8.0f;
+
+    // Physics constants.
+    private const float Damping = 0.985f;            // mild — we *want* fast in-fall
+    private const float MaxSpeed = 8.0f;             // cells per frame, hard clamp
+    private const float SwallowRadius = 1.5f;        // particles closer than this respawn
+    private const float MinPullDistance = 2.5f;      // floor for r in pull calc — avoids /0 spikes
+    private const float SpinRatio = 0.85f;           // tangential / radial; 0 = pure radial, 1 = circular
+    private const float ParticlesPerCell = 0.5f;     // density (~3200 for 80×40)
+
+    // Glyph palette. Mix of small, dense, and "streak"-looking ASCII so
+    // moving particles read as bits of matter, not just dots. Excludes
+    // wide chars and whitespace.
+    private static readonly string[] s_glyphs = BuildGlyphs();
+
+    private static string[] BuildGlyphs()
+    {
+        // Pre-cached so particle draws are allocation-free.
+        const string source = ".,'`*+/\\|-_~:;!?o0aXxv^=<>#%&";
+        var arr = new string[source.Length];
+        for (var i = 0; i < source.Length; i++)
+            arr[i] = source[i].ToString();
+        return arr;
+    }
+
+    // Deterministic-ish RNG state for respawns. Not security-critical;
+    // xorshift32 keeps the hot path allocation-free.
+    private uint _rng = 0xCAFEBABEu;
+
+    private uint NextRandom()
+    {
+        // xorshift32 — small, fast, good enough for visual jitter.
+        var x = _rng;
+        x ^= x << 13;
+        x ^= x >> 17;
+        x ^= x << 5;
+        _rng = x;
+        return x;
+    }
+
+    private float NextFloat() => (NextRandom() & 0xFFFFFF) / (float)0x1000000;
+
+    public Hex1bWidget Build(StressContext sc)
+    {
+        return sc.Root
+            .Surface(layer =>
+            {
+                EnsureField(layer.Width, layer.Height);
+                // First-frame centring: drop the well in the middle until
+                // the user clicks somewhere.
+                if (_wellX < 0)
+                {
+                    _wellX = layer.Width * 0.5f;
+                    _wellY = layer.Height * 0.5f;
+                }
+                Step();
+                return new[] { layer.Layer(DrawParticles) };
+            })
+            .InputBindings(bindings =>
+            {
+                bindings.Mouse(MouseButton.Left).Action(ctx =>
+                {
+                    if (ctx.MouseX < 0 || ctx.MouseY < 0) return;
+                    _wellX = ctx.MouseX;
+                    _wellY = ctx.MouseY;
+                });
+                // Scroll up = stronger pull, scroll down = weaker.
+                // Multiplicative so it feels exponential — a few notches
+                // visibly change behaviour without bottoming out.
+                bindings.Mouse(MouseButton.ScrollUp).Action(_ =>
+                {
+                    _strength = Math.Min(MaxStrength, _strength * 1.2f);
+                });
+                bindings.Mouse(MouseButton.ScrollDown).Action(_ =>
+                {
+                    _strength = Math.Max(MinStrength, _strength * 0.83f);
+                });
+            })
+            .RedrawAfter(sc.RedrawIntervalMs);
+    }
+
+    /// <summary>Status-bar label exposing current strength.</summary>
+    public static float CurrentStrength { get; private set; } = 1.0f;
+
+    private void EnsureField(int w, int h)
+    {
+        if (_surfaceWidth == w && _surfaceHeight == h && _px.Length > 0)
+            return;
+
+        _surfaceWidth = w;
+        _surfaceHeight = h;
+        _count = Math.Max(64, (int)(w * h * ParticlesPerCell));
+
+        // Reallocate arrays to fit the new count. We don't try to pool
+        // these — resizes are rare (resize-only) and the simulation
+        // resumes from a fresh scatter, which is fine since the previous
+        // arrangement is meaningless at a different resolution anyway.
+        _px = new float[_count];
+        _py = new float[_count];
+        _vx = new float[_count];
+        _vy = new float[_count];
+        _glyphIdx = new byte[_count];
+
+        for (var i = 0; i < _count; i++)
+        {
+            _px[i] = NextFloat() * w;
+            _py[i] = NextFloat() * h;
+            // Small initial drift so things move on frame 1.
+            _vx[i] = (NextFloat() - 0.5f) * 0.4f;
+            _vy[i] = (NextFloat() - 0.5f) * 0.4f;
+            _glyphIdx[i] = (byte)(NextRandom() % (uint)s_glyphs.Length);
+        }
+    }
+
+    private void Step()
+    {
+        if (_count == 0) return;
+        CurrentStrength = _strength;
+
+        var w = _surfaceWidth;
+        var h = _surfaceHeight;
+        var wx = _wellX;
+        var wy = _wellY;
+        var s = _strength;
+        // Radial pull magnitude = s * sizeFactor / max(r, MinPullDistance).
+        // sizeFactor scales with surface area so the same `strength` value
+        // feels equivalent across a small laptop terminal and a giant
+        // external monitor — without it, large screens make the well
+        // feel weak because particles are mostly far away.
+        var sizeFactor = MathF.Sqrt(w * h) * 0.25f;
+        var pullScale = s * sizeFactor;
+        var spinScale = pullScale * SpinRatio;
+        var swallowSq = SwallowRadius * SwallowRadius;
+
+        for (var i = 0; i < _count; i++)
+        {
+            var dx = wx - _px[i];
+            var dy = wy - _py[i];
+            var rSq = dx * dx + dy * dy;
+            if (rSq < swallowSq)
+            {
+                Respawn(i);
+                continue;
+            }
+
+            var r = MathF.Sqrt(rSq);
+            var rEff = r < MinPullDistance ? MinPullDistance : r;
+            var invR = 1f / rEff;
+            // Unit vector toward the well.
+            var ux = dx * invR;
+            var uy = dy * invR;
+            // Tangential unit vector — rotate (ux,uy) 90° CCW so the spiral
+            // always winds the same direction (visually consistent).
+            var tx = -uy;
+            var ty = ux;
+
+            // Acceleration: radial pull + tangential swirl. Both fall off
+            // as 1/r so the inner orbit accelerates dramatically. The pure
+            // 1/r law isn't physical for gravity (which is 1/r²) but reads
+            // much better visually — the outer field stays alive instead
+            // of going inert.
+            var a = pullScale * invR;
+            var at = spinScale * invR;
+            _vx[i] += (ux * a + tx * at);
+            _vy[i] += (uy * a + ty * at);
+
+            // Damping prevents runaway escapes from the slingshot effect
+            // of the inner orbit.
+            _vx[i] *= Damping;
+            _vy[i] *= Damping;
+
+            // Clamp speed so a particle that nearly grazes the well doesn't
+            // teleport across the screen in one frame.
+            var sp2 = _vx[i] * _vx[i] + _vy[i] * _vy[i];
+            if (sp2 > MaxSpeed * MaxSpeed)
+            {
+                var sc = MaxSpeed / MathF.Sqrt(sp2);
+                _vx[i] *= sc;
+                _vy[i] *= sc;
+            }
+
+            _px[i] += _vx[i];
+            _py[i] += _vy[i];
+
+            // Out-of-bounds → respawn at the edge.
+            if (_px[i] < 0 || _px[i] >= w || _py[i] < 0 || _py[i] >= h)
+                Respawn(i);
+        }
+    }
+
+    private void Respawn(int i)
+    {
+        // Pick a random edge: 0=top, 1=bottom, 2=left, 3=right.
+        var edge = NextRandom() & 3;
+        var w = _surfaceWidth;
+        var h = _surfaceHeight;
+        float px, py, vx, vy;
+        // Small inward velocity so they don't immediately satisfy the
+        // out-of-bounds check again on a frame where their position rounds
+        // wrong, and so the first few frames of motion are visible.
+        const float Seed = 0.6f;
+
+        switch (edge)
+        {
+            case 0: // top
+                px = NextFloat() * w;
+                py = 0;
+                vx = (NextFloat() - 0.5f) * 0.3f;
+                vy = Seed;
+                break;
+            case 1: // bottom
+                px = NextFloat() * w;
+                py = h - 1;
+                vx = (NextFloat() - 0.5f) * 0.3f;
+                vy = -Seed;
+                break;
+            case 2: // left
+                px = 0;
+                py = NextFloat() * h;
+                vx = Seed;
+                vy = (NextFloat() - 0.5f) * 0.3f;
+                break;
+            default: // right
+                px = w - 1;
+                py = NextFloat() * h;
+                vx = -Seed;
+                vy = (NextFloat() - 0.5f) * 0.3f;
+                break;
+        }
+
+        _px[i] = px;
+        _py[i] = py;
+        _vx[i] = vx;
+        _vy[i] = vy;
+        _glyphIdx[i] = (byte)(NextRandom() % (uint)s_glyphs.Length);
+    }
+
+    private void DrawParticles(Surface surface)
+    {
+        var w = surface.Width;
+        var h = surface.Height;
+        var black = Hex1bColor.Black;
+
+        // Surfaces come out of the pool zeroed/blank, so we don't need to
+        // explicitly clear — but we *do* want a hint of texture (the well
+        // and a faint halo) before the particles go down. Keep this O(1):
+        // just stamp the well marker; the rest stays default.
+
+        for (var i = 0; i < _count; i++)
+        {
+            var x = (int)_px[i];
+            var y = (int)_py[i];
+            if ((uint)x >= (uint)w || (uint)y >= (uint)h) continue;
+
+            // Brightness rises with speed — fast inner-orbit streaks
+            // pop out from the slower outer drift.
+            var sp = MathF.Sqrt(_vx[i] * _vx[i] + _vy[i] * _vy[i]);
+            var t = sp / MaxSpeed;
+            if (t > 1f) t = 1f;
+            var level = (byte)(80 + (int)(175 * t));
+            var fg = Hex1bColor.FromRgb(level, level, level);
+            surface[x, y] = new SurfaceCell(s_glyphs[_glyphIdx[i]], fg, black);
+        }
+
+        // Well marker — bright red '@' on top of everything. Use integer
+        // floor to align with particle positions.
+        var wxI = (int)_wellX;
+        var wyI = (int)_wellY;
+        if ((uint)wxI < (uint)w && (uint)wyI < (uint)h)
+        {
+            surface[wxI, wyI] = new SurfaceCell(
+                "@", Hex1bColor.FromRgb(255, 64, 64), black);
+        }
+    }
+}

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -175,6 +175,7 @@ internal sealed class WhirlpoolPage : IStressPage
                 {
                     _strength = MathF.Max(MinStrength, _strength * 0.83f);
                 });
+                bindings.Key(Hex1bKey.R).Action(_ => ResetBasin(), "Reset");
             });
 
         return _quiescent ? widget : widget.RedrawAfter(sc.RedrawIntervalMs);
@@ -188,6 +189,25 @@ internal sealed class WhirlpoolPage : IStressPage
         if (mouseY < WallCells || mouseY >= _screenH - WallCells) return false;
         if (icx < 0 || icx >= _dw || icy < 0 || icy >= _dh) return false;
         return true;
+    }
+
+    private void ResetBasin()
+    {
+        var n = _height.Length;
+        for (var i = 0; i < n; i++)
+        {
+            _height[i] = DShort;
+            _vx[i] = 0f;
+            _vy[i] = 0f;
+            _flowAccX[i] = 0f;
+            _flowAccY[i] = 0f;
+        }
+        _drainActive = false;
+        _drainOpenFrames = 0;
+        _inletAge = 0;
+        _inletGap = 0;
+        _strength = 1f;
+        _quiescent = false;
     }
 
     private void EnsureField(int w, int h)

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -99,7 +99,7 @@ internal sealed class WhirlpoolPage : IStressPage
     private const int   DrainReachRampFrames = 90;
     private const float DrainDiscRadiusMax  = 3.0f;
     private const float DrainDensity        = 2.0f;
-    private const float PullStrength        = 0.35f; // peak inward accel per frame at drain centre
+    private const float PullStrength        = 0.15f; // peak inward accel per frame at drain centre
 
     // ----------------------------------------------------------------
     // Shallow-water dynamics. Tune for visible momentum / sloshing
@@ -107,7 +107,7 @@ internal sealed class WhirlpoolPage : IStressPage
     // ----------------------------------------------------------------
     private const float PressureGain = 0.07f;
     private const float Damping      = 0.92f;
-    private const float MaxSpeed     = 1.1f;
+    private const float MaxSpeed     = 0.6f;
     private const float VelocityFloor = 0.015f;
 
     // ----------------------------------------------------------------

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -93,11 +93,11 @@ internal sealed class WhirlpoolPage : IStressPage
     private const float MinStrength = 0.3f;
     private const float MaxStrength = 4.0f;
 
-    private const float DrainReachInitial   = 4.0f;
+    private const float DrainReachInitial   = 2.0f;
     private const float DrainReachMax       = 22f;
     private const int   DrainReachRampFrames = 90;
-    private const float DrainDiscRadiusMax  = 16f;
-    private const float DrainDensity        = 1.5f;
+    private const float DrainDiscRadiusMax  = 3.0f;
+    private const float DrainDensity        = 2.0f;
     private const float PullStrength        = 0.35f; // peak inward accel per frame at drain centre
     private const float SwirlStrength       = 0.60f; // peak tangential accel per frame
 

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -105,7 +105,7 @@ internal sealed class WhirlpoolPage : IStressPage
     // Shallow-water dynamics. Tune for visible momentum / sloshing
     // without runaway oscillation.
     // ----------------------------------------------------------------
-    private const float PressureGain = 0.06f;
+    private const float PressureGain = 0.10f;
     private const float Damping      = 0.965f;
     private const float MaxSpeed     = 1.1f;
     private const float VelocityFloor = 0.003f;
@@ -399,7 +399,10 @@ internal sealed class WhirlpoolPage : IStressPage
 
                 // Drain only attracts cells that actually hold water above the
                 // film threshold — a dry cell on the other side of the screen
-                // doesn't feel the drain until water reaches it.
+                // doesn't feel the drain until water reaches it. The
+                // attraction is also scaled down as a cell approaches full
+                // depth, so water can't "climb" into a mound around the
+                // drain that's deeper than the surrounding basin.
                 if (drainOn && hi > FilmThickness)
                 {
                     var dxc = x - cx;
@@ -407,13 +410,17 @@ internal sealed class WhirlpoolPage : IStressPage
                     var d2 = dxc * dxc + dyc * dyc;
                     if (d2 > skip2 || d2 < 0.1f) continue;
                     var falloff = MathF.Exp(-d2 / twoR2);
+                    var capacity = MathF.Max(0f, 1f - hi / (float)D);
+                    capacity *= capacity; // sharper rolloff as the cell nears full
+                    var w = falloff * capacity;
+                    if (w <= 0f) continue;
                     var invR = 1f / MathF.Sqrt(d2);
                     var inX = -dxc * invR;
                     var inY = -dyc * invR;
                     var tX = -dyc * invR; // CCW tangential
                     var tY =  dxc * invR;
-                    vx[i] += (pull * inX + swirl * tX) * falloff;
-                    vy[i] += (pull * inY + swirl * tY) * falloff;
+                    vx[i] += (pull * inX + swirl * tX) * w;
+                    vy[i] += (pull * inY + swirl * tY) * w;
                 }
             }
         }

--- a/samples/PickerDemo/Program.cs
+++ b/samples/PickerDemo/Program.cs
@@ -7,7 +7,7 @@ var selectedColor = "Blue";
 var lastAction = "";
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
         ctx.VStack(v => [
             v.Text("Picker Demo - Select your favorite fruit:"),
             v.Text(""),

--- a/samples/PredictiveTextDemo/Program.cs
+++ b/samples/PredictiveTextDemo/Program.cs
@@ -19,7 +19,7 @@ var submissionCount = 0;
 var stats = new Stats();
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+    .WithHex1bApp(ctx => ctx.VStack(v => [
         v.Text("Predictive Text Demo"),
         v.Separator(),
         v.Text(""),

--- a/samples/QrCodeDemo/Program.cs
+++ b/samples/QrCodeDemo/Program.cs
@@ -15,7 +15,7 @@ var customUrl = "";
 var quietZone = 1;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     ctx.VStack(main => [
         // Title
         main.Border(

--- a/samples/ReflowDemo/Program.cs
+++ b/samples/ReflowDemo/Program.cs
@@ -45,7 +45,7 @@ void Resize(int delta)
 
 // Build the display application
 await using var display = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         return ctx.VStack(v => [
             v.Text($"  Terminal Reflow Demo \u2014 Width: {currentWidth}"),

--- a/samples/RescueDemo/Program.cs
+++ b/samples/RescueDemo/Program.cs
@@ -7,7 +7,7 @@ var throwCount = 0;
 var lastAction = "Ready";
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
         ctx.VStack(v => [
             v.Text("RescueWidget Demo"),
             v.Text("================"),

--- a/samples/ScrollPanelDemo/Program.cs
+++ b/samples/ScrollPanelDemo/Program.cs
@@ -38,7 +38,7 @@ var items = Enumerable.Range(1, 60)
     .ToList();
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         var status = panelNode is null
             ? "Status: (scroll the panel once — any arrow or PageUp/Dn — to enable imperative buttons)"

--- a/samples/ScrollbackTerminalDemo/Program.cs
+++ b/samples/ScrollbackTerminalDemo/Program.cs
@@ -100,7 +100,9 @@ Hex1bWidget BuildUI(RootContext ctx)
 // Create the display terminal
 await using var displayTerminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((app, options) =>
+    .WithHex1bApp(
+        _ => { },
+        app =>
     {
         displayApp = app;
         return ctx => BuildUI(ctx);

--- a/samples/SharedEditor/Program.cs
+++ b/samples/SharedEditor/Program.cs
@@ -152,7 +152,9 @@ void RunStressTest(MenuItemActivatedEventArgs args)
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithDiagnostics()
     .WithMouse()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(
+        _ => { },
+        app => ctx =>
     {
         return ctx.VStack(v =>
         [

--- a/samples/SliderDemo/Program.cs
+++ b/samples/SliderDemo/Program.cs
@@ -16,7 +16,7 @@ var blue = 192.0;
 var temperature = 22.0;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+    .WithHex1bApp(ctx => ctx.VStack(v => [
         v.Text("Slider Demo"),
         v.Separator(),
         v.Text(""),

--- a/samples/SpinnerDemo/Program.cs
+++ b/samples/SpinnerDemo/Program.cs
@@ -14,7 +14,7 @@ var themeConfigs = new (string Name, Action<Hex1bTheme> Configure)[]
 int selectedThemeIndex = 0;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         var currentThemeConfig = themeConfigs[selectedThemeIndex];
 

--- a/samples/StatePanelDemo/Program.cs
+++ b/samples/StatePanelDemo/Program.cs
@@ -27,7 +27,9 @@ string statusMessage = "S=shuffle  A=add  D=delete last  Q=quit";
 int nextId = 1;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((a, options) =>
+    .WithHex1bApp(
+        _ => { },
+        a =>
     {
         app = a;
         return ctx =>

--- a/samples/SubProcessDemo/Program.cs
+++ b/samples/SubProcessDemo/Program.cs
@@ -26,7 +26,9 @@ while (true)
     
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, appOptions) =>
+            .WithHex1bApp(
+                _ => { },
+                app =>
             {
                 return ctx => ctx
                     .ZStack(z =>

--- a/samples/SurfaceDemo/Program.cs
+++ b/samples/SurfaceDemo/Program.cs
@@ -26,7 +26,7 @@ async Task RunConsoleMode()
 
     await using var terminal = Hex1bTerminal.CreateBuilder()
         .WithMouse()
-        .WithHex1bApp((app, options) => ctx =>
+        .WithHex1bApp(ctx =>
         {
             if (selectedDemo == 0)
                 FirefliesDemo.Update(fireflies, random);
@@ -101,7 +101,7 @@ async Task RunWebMode(string[] args)
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithPresentation(presentation)
-            .WithHex1bApp((app, options) => ctx =>
+            .WithHex1bApp(ctx =>
             {
                 if (selectedDemo == 0)
                     FirefliesDemo.Update(fireflies, random);

--- a/samples/TabPanelDemo/Program.cs
+++ b/samples/TabPanelDemo/Program.cs
@@ -37,13 +37,13 @@ public class {{className}}
     public static async Task Main(string[] args)
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => BuildUI(app))
+            .WithHex1bApp(ctx => BuildUI())
             .Build();
 
         await terminal.RunAsync();
     }
 
-    private static Hex1bWidget BuildUI(Hex1bApp app)
+    private static Hex1bWidget BuildUI()
     {
         return new VStackWidget([
             new TextBlockWidget("Hello from {{className}}!"),
@@ -282,7 +282,7 @@ var statusMessage = "Ready";
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     ctx.VStack(main => [
         // ─────────────────────────────────────────────────────────────────
         // MENU BAR

--- a/samples/TableDemo/Program.cs
+++ b/samples/TableDemo/Program.cs
@@ -495,7 +495,7 @@ Hex1bWidget BuildNoDataScenario<TParent>(WidgetContext<TParent> ctx) where TPare
 using var terminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
     .WithDiagnostics("TableDemo", forceEnable: true)
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         return ctx.VStack(v => [
             new SplitterWidget(

--- a/samples/TermPetDemo/Program.cs
+++ b/samples/TermPetDemo/Program.cs
@@ -82,7 +82,9 @@ _ = Task.Run(async () =>
 });
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, _) =>
+    .WithHex1bApp(
+        _ => { },
+        app =>
     {
         theApp = app;
         return ctx =>

--- a/samples/TerminalSelectionDemo/Program.cs
+++ b/samples/TerminalSelectionDemo/Program.cs
@@ -98,7 +98,9 @@ Hex1bWidget Build(RootContext ctx)
 // Create the display terminal
 await using var displayTerminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((a, options) =>
+    .WithHex1bApp(
+        _ => { },
+        a =>
     {
         app = a;
         return ctx => Build(ctx);

--- a/samples/TileDemo/Program.cs
+++ b/samples/TileDemo/Program.cs
@@ -15,7 +15,7 @@ var pois = CreateLandmarks(camera);
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         var (cx, cy) = camera.CharCenter;
         return ctx.VStack(v =>

--- a/samples/TreeDemo/Program.cs
+++ b/samples/TreeDemo/Program.cs
@@ -77,7 +77,9 @@ List<TreeItemWidget> BuildServerChildren(TreeContext t, Hex1bApp app)
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithDiagnostics("TableDemo", forceEnable: true)
-    .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+    .WithHex1bApp(
+        _ => { },
+        app => ctx => ctx.VStack(v => [
         v.Text("🌳 Tree Widget Demo"),
         v.Separator(),
         v.Text(""),

--- a/samples/UnicodeSelectorDemo/Program.cs
+++ b/samples/UnicodeSelectorDemo/Program.cs
@@ -89,7 +89,7 @@ string GetCategoryShortName(UnicodeCategory category) => category switch
 };
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         var currentBlock = unicodeBlocks[selectedBlockIndex];
         var characters = GetBlockCharacters(selectedBlockIndex);

--- a/samples/WasmDemo/Program.cs
+++ b/samples/WasmDemo/Program.cs
@@ -71,7 +71,7 @@ WasmPresentationAdapter.Instance = adapter;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithPresentation(adapter)
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
         ctx.ZStack(z => [
             // Layer 1: Globe surface with interaction (bottom)
             z.Interactable(ic =>

--- a/samples/WebMuxerDemo/Cli/CliViewerApp.cs
+++ b/samples/WebMuxerDemo/Cli/CliViewerApp.cs
@@ -165,7 +165,9 @@ internal sealed class CliViewerApp
         {
             await using var outer = Hex1bTerminal.CreateBuilder()
                 .WithMouse()
-                .WithHex1bApp((app, _) =>
+                .WithHex1bApp(
+                    _ => { },
+                    app =>
                 {
                     _app = app;
                     return ctx => Render(ctx);

--- a/samples/WidgetLayerDemo/Program.cs
+++ b/samples/WidgetLayerDemo/Program.cs
@@ -127,7 +127,7 @@ CellCompute BuildEffect(int effectIndex, double progress, int width, int height)
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         var progress = GetProgress();
 

--- a/samples/WindowingDemo/Program.cs
+++ b/samples/WindowingDemo/Program.cs
@@ -242,7 +242,7 @@ async Task CleanupTerminalInstanceAsync(Hex1bTerminal terminalToDispose, Cancell
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithDiagnostics("WindowingDemo", forceEnable: true)
     .WithMouse()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         // Update fireflies each frame
         FirefliesDemo.Update(fireflies, demoRandom);

--- a/samples/ZStackDemo/Program.cs
+++ b/samples/ZStackDemo/Program.cs
@@ -32,8 +32,7 @@ var allItems = new[]
 try
 {
     await using var terminal = Hex1bTerminal.CreateBuilder()
-        .WithHex1bApp((app, options) =>
-            ctx => ctx.ThemePanel(
+        .WithHex1bApp(ctx => ctx.ThemePanel(
             theme => theme.Set(GlobalTheme.BackgroundColor, Hex1bColor.FromRgb(40, 40, 40)),
             ctx.VStack(main => [
                 // Menu bar - buttons use PushAnchored for positioned menus

--- a/src/Hex1b.Tool/Commands/Capture/PlaybackPlayerApp.cs
+++ b/src/Hex1b.Tool/Commands/Capture/PlaybackPlayerApp.cs
@@ -43,7 +43,9 @@ internal sealed class PlaybackPlayerApp
         // Build the display TUI
         await using var displayTerminal = Hex1bTerminal.CreateBuilder()
             .WithMouse()
-            .WithHex1bApp((app, options) =>
+            .WithHex1bApp(
+                _ => { },
+                app =>
             {
                 _app = app;
                 return ctx => BuildWidget(ctx);

--- a/src/Hex1b.Tool/Commands/Terminal/AttachTuiApp.cs
+++ b/src/Hex1b.Tool/Commands/Terminal/AttachTuiApp.cs
@@ -150,7 +150,9 @@ internal sealed class AttachTuiApp : IAsyncDisposable
         await using var displayTerminal = Hex1bTerminal.CreateBuilder()
             .WithMouse()
             .AddPresentationFilter(new ResizeFilter(this))
-            .WithHex1bApp((app, options) =>
+            .WithHex1bApp(
+                _ => { },
+                app =>
             {
                 _app = app;
                 return ctx => BuildWidget(ctx, handle);

--- a/src/Hex1b/Diagnostics/Hex1bMetrics.cs
+++ b/src/Hex1b/Diagnostics/Hex1bMetrics.cs
@@ -102,6 +102,14 @@ public sealed class Hex1bMetrics : IDisposable
     /// <summary>Time to diff previous vs current surface.</summary>
     public Histogram<double> SurfaceDiffDuration { get; }
 
+    /// <summary>Number of surface diffs that took the simple 4-field fast path. Compare against
+    /// <see cref="SurfaceDiffSlowPathCount"/> to see how often complex content forces the slow path.</summary>
+    public Counter<long> SurfaceDiffFastPathCount { get; }
+
+    /// <summary>Number of surface diffs that took the full per-cell slow path because at least
+    /// one cell on either side had wide width, underline, a multi-codepoint grapheme, or a tracked ref.</summary>
+    public Counter<long> SurfaceDiffSlowPathCount { get; }
+
     /// <summary>Time to convert surface diff to ANSI tokens.</summary>
     public Histogram<double> SurfaceTokensDuration { get; }
 
@@ -158,6 +166,8 @@ public sealed class Hex1bMetrics : IDisposable
 
         // Surface pipeline (always-on)
         SurfaceDiffDuration = Meter.CreateHistogram<double>("hex1b.surface.diff.duration", "ms", "Surface diff duration");
+        SurfaceDiffFastPathCount = Meter.CreateCounter<long>("hex1b.surface.diff.fast_path", "{diff}", "Surface diffs that took the 4-field fast path");
+        SurfaceDiffSlowPathCount = Meter.CreateCounter<long>("hex1b.surface.diff.slow_path", "{diff}", "Surface diffs that took the full per-cell slow path");
         SurfaceTokensDuration = Meter.CreateHistogram<double>("hex1b.surface.tokens.duration", "ms", "Diff to ANSI tokens duration");
         SurfaceSerializeDuration = Meter.CreateHistogram<double>("hex1b.surface.serialize.duration", "ms", "Token serialization duration");
 

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -1262,12 +1262,24 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
             }
             
             var serializeStart = Stopwatch.GetTimestamp();
-            var ansiOutput = Tokens.AnsiTokenUtf8Serializer.Serialize(tokens);
+            // Use the pool-backed serializer so the per-frame ANSI byte buffer (often
+            // well over the 85 KB LOH threshold for fullscreen renders) is rented from
+            // ArrayPool rather than allocated fresh on the LOH every frame.
+            byte[]? pooledOutput = null;
+            ReadOnlyMemory<byte> ansiOutput;
+            if (_adapter is Hex1bAppWorkloadAdapter)
+            {
+                ansiOutput = Tokens.AnsiTokenUtf8Serializer.SerializeRented(tokens, out pooledOutput);
+            }
+            else
+            {
+                ansiOutput = Tokens.AnsiTokenUtf8Serializer.Serialize(tokens);
+            }
             _metrics.SurfaceSerializeDuration.Record(Stopwatch.GetElapsedTime(serializeStart).TotalMilliseconds);
-            
+
             if (_adapter is Hex1bAppWorkloadAdapter workloadAdapter)
             {
-                workloadAdapter.WriteTokensWithBytes(tokens, ansiOutput);
+                workloadAdapter.WriteTokensWithBytes(tokens, ansiOutput, pooledOutput);
             }
             else
             {

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -159,6 +159,36 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
     // Surface rendering double-buffer
     private Surface? _currentSurface;
     private Surface? _previousSurface;
+    // Renderer hot-path pools — reused across frames so SurfaceComparer doesn't
+    // allocate a fresh diff/list of changed cells or a fresh token list every frame.
+    private readonly Surfaces.SurfaceDiff _frameDiff = new();
+    // Token lists are rotated through a small pool so that a list shipped to the
+    // terminal-side consumer (via the workload channel) can continue to be enumerated
+    // even after the producer starts building the next frame. Without this, the
+    // producer would mutate the list while the consumer iterates it. The consumer
+    // returns the list via WorkloadOutputItem.PooledTokens once it's done.
+    private readonly System.Collections.Concurrent.ConcurrentStack<List<Tokens.AnsiToken>> _tokenListPool = new();
+    private List<Tokens.AnsiToken>? _frameTokens;
+    // Used only when KGP placements need to be interleaved with text tokens; reused to
+    // avoid a per-frame scratch allocation when KGP is active. Not shipped across the
+    // channel — only used to assemble the merged list — so single-buffering is safe.
+    private readonly List<Tokens.AnsiToken> _frameKgpScratchTokens = new();
+
+    private List<Tokens.AnsiToken> RentTokenList()
+    {
+        if (_tokenListPool.TryPop(out var list))
+        {
+            list.Clear();
+            return list;
+        }
+        return new List<Tokens.AnsiToken>();
+    }
+
+    internal void ReturnTokenList(List<Tokens.AnsiToken> list)
+    {
+        list.Clear();
+        _tokenListPool.Push(list);
+    }
     
     // KGP placement lifecycle tracker (persists across frames)
     private readonly Kgp.KgpPlacementTracker _kgpTracker = new();
@@ -1190,11 +1220,18 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
             return true;
         }
 
-        // Diff current vs previous and emit changes
+        // Diff current vs previous and emit changes. _frameDiff is a pooled
+        // SurfaceDiff reused every frame to avoid the List<ChangedCell> growth cost.
         var diffStart = Stopwatch.GetTimestamp();
-        var diff = _isFirstFrame || _previousSurface == null
-            ? SurfaceComparer.CompareToEmpty(_currentSurface)
-            : SurfaceComparer.Compare(_previousSurface, _currentSurface);
+        if (_isFirstFrame || _previousSurface == null)
+        {
+            SurfaceComparer.CompareToEmptyInto(_currentSurface, _frameDiff);
+        }
+        else
+        {
+            SurfaceComparer.CompareInto(_previousSurface, _currentSurface, _frameDiff);
+        }
+        var diff = _frameDiff;
         _metrics.SurfaceDiffDuration.Record(Stopwatch.GetElapsedTime(diffStart).TotalMilliseconds);
         
         _metrics.OutputCellsChanged.Record(diff.Count);
@@ -1241,25 +1278,29 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         if (wroteOutput)
         {
             // Generate text/sixel tokens (KGP emission skipped — handled by tracker above)
+            // Generate text/sixel tokens (KGP emission skipped — handled by tracker above).
+            // Rent a token list from the per-frame pool; the consumer returns it once it
+            // has finished forwarding the bytes/applying tokens, so the producer never
+            // mutates a list that's still being read on the consumer thread.
             var tokensStart = Stopwatch.GetTimestamp();
-            var textTokens = diff.IsEmpty
-                ? Array.Empty<Tokens.AnsiToken>()
-                : SurfaceComparer.ToTokens(diff, _currentSurface, _previousSurface, skipKgpEmission: hasKgp);
-            _metrics.SurfaceTokensDuration.Record(Stopwatch.GetElapsedTime(tokensStart).TotalMilliseconds);
-            
-            // Merge: KGP before-text + text tokens + KGP after-text
-            List<Tokens.AnsiToken> tokens;
+            _frameTokens = RentTokenList();
             if (hasKgpChanges)
             {
-                tokens = new List<Tokens.AnsiToken>(kgpBefore.Count + textTokens.Count + kgpAfter.Count);
-                tokens.AddRange(kgpBefore);
-                tokens.AddRange(textTokens);
-                tokens.AddRange(kgpAfter);
+                _frameTokens.AddRange(kgpBefore);
+                if (!diff.IsEmpty)
+                {
+                    var scratch = _frameKgpScratchTokens;
+                    SurfaceComparer.ToTokensInto(diff, _currentSurface, _previousSurface, skipKgpEmission: true, scratch);
+                    _frameTokens.AddRange(scratch);
+                }
+                _frameTokens.AddRange(kgpAfter);
             }
-            else
+            else if (!diff.IsEmpty)
             {
-                tokens = textTokens is List<Tokens.AnsiToken> list ? list : new List<Tokens.AnsiToken>(textTokens);
+                SurfaceComparer.ToTokensInto(diff, _currentSurface, _previousSurface, skipKgpEmission: hasKgp, _frameTokens);
             }
+            var tokens = _frameTokens;
+            _metrics.SurfaceTokensDuration.Record(Stopwatch.GetElapsedTime(tokensStart).TotalMilliseconds);
             
             var serializeStart = Stopwatch.GetTimestamp();
             // Use the pool-backed serializer so the per-frame ANSI byte buffer (often
@@ -1279,11 +1320,26 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
 
             if (_adapter is Hex1bAppWorkloadAdapter workloadAdapter)
             {
-                workloadAdapter.WriteTokensWithBytes(tokens, ansiOutput, pooledOutput);
+                // Transfer ownership of the pooled token list to the consumer; null out
+                // _frameTokens so the next frame rents a fresh one.
+                var ownedTokens = _frameTokens;
+                _frameTokens = null;
+                workloadAdapter.WriteTokensWithBytes(
+                    tokens,
+                    ansiOutput,
+                    pooledOutput,
+                    ownedTokens,
+                    ReturnTokenList);
             }
             else
             {
                 _adapter.Write(ansiOutput);
+                // No consumer to hand off to: return the token list now.
+                if (_frameTokens is { } own)
+                {
+                    _frameTokens = null;
+                    ReturnTokenList(own);
+                }
             }
             
             _metrics.OutputTokens.Record(tokens.Count);

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -1033,7 +1033,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                 {
                     long renderFrameStart = Stopwatch.GetTimestamp();
                     
-                    wroteOutput = RenderFrameWithSurface(frameWidth, frameHeight, frameCapabilities);
+                    wroteOutput = await RenderFrameWithSurfaceAsync(frameWidth, frameHeight, frameCapabilities, cancellationToken).ConfigureAwait(false);
                     
                     renderTicks = Stopwatch.GetTimestamp() - renderFrameStart;
                     if (_diagnosticTimingEnabled) _diagRenderTicks = renderTicks;
@@ -1096,8 +1096,29 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
     /// Callers use this to know whether the hardware cursor may have been moved by
     /// the emitted tokens.
     /// </returns>
+    private async ValueTask<bool> RenderFrameWithSurfaceAsync(int width, int height, TerminalCapabilities caps, CancellationToken cancellationToken)
+    {
+        var result = RenderFrameWithSurfaceCore(width, height, caps, out var asyncWriteWork);
+        if (asyncWriteWork != null)
+            await asyncWriteWork(cancellationToken).ConfigureAwait(false);
+        return result;
+    }
+
     private bool RenderFrameWithSurface(int width, int height, TerminalCapabilities caps)
     {
+        // Sync wrapper retained for non-async call sites (e.g. tests). The async
+        // write-work continuation should never be produced in this path because
+        // bounded backpressure is not used outside the live render loop, but if
+        // it is, we synchronously wait — the same sync-over-async hazard
+        // documented on WriteTokensWithBytes applies.
+        var result = RenderFrameWithSurfaceCore(width, height, caps, out var asyncWriteWork);
+        asyncWriteWork?.Invoke(CancellationToken.None).AsTask().GetAwaiter().GetResult();
+        return result;
+    }
+
+    private bool RenderFrameWithSurfaceCore(int width, int height, TerminalCapabilities caps, out Func<CancellationToken, ValueTask>? asyncWriteWork)
+    {
+        asyncWriteWork = null;
         _surfacePool?.NextFrame();
         
         // Get cell metrics from terminal capabilities
@@ -1223,16 +1244,21 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         // Diff current vs previous and emit changes. _frameDiff is a pooled
         // SurfaceDiff reused every frame to avoid the List<ChangedCell> growth cost.
         var diffStart = Stopwatch.GetTimestamp();
+        bool fastPathTaken;
         if (_isFirstFrame || _previousSurface == null)
         {
-            SurfaceComparer.CompareToEmptyInto(_currentSurface, _frameDiff);
+            fastPathTaken = SurfaceComparer.CompareToEmptyInto(_currentSurface, _frameDiff);
         }
         else
         {
-            SurfaceComparer.CompareInto(_previousSurface, _currentSurface, _frameDiff);
+            fastPathTaken = SurfaceComparer.CompareInto(_previousSurface, _currentSurface, _frameDiff);
         }
         var diff = _frameDiff;
         _metrics.SurfaceDiffDuration.Record(Stopwatch.GetElapsedTime(diffStart).TotalMilliseconds);
+        if (fastPathTaken)
+            _metrics.SurfaceDiffFastPathCount.Add(1);
+        else
+            _metrics.SurfaceDiffSlowPathCount.Add(1);
         
         _metrics.OutputCellsChanged.Record(diff.Count);
         
@@ -1277,73 +1303,111 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         
         if (wroteOutput)
         {
-            // Generate text/sixel tokens (KGP emission skipped — handled by tracker above)
-            // Generate text/sixel tokens (KGP emission skipped — handled by tracker above).
-            // Rent a token list from the per-frame pool; the consumer returns it once it
-            // has finished forwarding the bytes/applying tokens, so the producer never
-            // mutates a list that's still being read on the consumer thread.
+            // Token-list pool ownership protocol:
+            //   1. Rent a list from _tokenListPool.
+            //   2. Fill it via ToTokensInto.
+            //   3. On the happy path, transfer ownership to the consumer via
+            //      WriteTokensWithBytes(Async); the consumer returns it once
+            //      it has finished iterating.
+            //   4. On any throw before step 3 completes, the finally below
+            //      returns the list and any rented ANSI buffer to their pools
+            //      so we don't slowly bleed pool capacity on error paths.
+            //
+            // The pooled output buffer is similarly owned by this scope until
+            // it crosses into the WorkloadOutputItem; we then null both locals
+            // so the finally is a no-op on the success path.
             var tokensStart = Stopwatch.GetTimestamp();
             _frameTokens = RentTokenList();
-            if (hasKgpChanges)
-            {
-                _frameTokens.AddRange(kgpBefore);
-                if (!diff.IsEmpty)
-                {
-                    var scratch = _frameKgpScratchTokens;
-                    SurfaceComparer.ToTokensInto(diff, _currentSurface, _previousSurface, skipKgpEmission: true, scratch);
-                    _frameTokens.AddRange(scratch);
-                }
-                _frameTokens.AddRange(kgpAfter);
-            }
-            else if (!diff.IsEmpty)
-            {
-                SurfaceComparer.ToTokensInto(diff, _currentSurface, _previousSurface, skipKgpEmission: hasKgp, _frameTokens);
-            }
-            var tokens = _frameTokens;
-            _metrics.SurfaceTokensDuration.Record(Stopwatch.GetElapsedTime(tokensStart).TotalMilliseconds);
-            
-            var serializeStart = Stopwatch.GetTimestamp();
-            // Use the pool-backed serializer so the per-frame ANSI byte buffer (often
-            // well over the 85 KB LOH threshold for fullscreen renders) is rented from
-            // ArrayPool rather than allocated fresh on the LOH every frame.
             byte[]? pooledOutput = null;
-            ReadOnlyMemory<byte> ansiOutput;
-            if (_adapter is Hex1bAppWorkloadAdapter)
+            var ownershipTransferred = false;
+            try
             {
-                ansiOutput = Tokens.AnsiTokenUtf8Serializer.SerializeRented(tokens, out pooledOutput);
-            }
-            else
-            {
-                ansiOutput = Tokens.AnsiTokenUtf8Serializer.Serialize(tokens);
-            }
-            _metrics.SurfaceSerializeDuration.Record(Stopwatch.GetElapsedTime(serializeStart).TotalMilliseconds);
-
-            if (_adapter is Hex1bAppWorkloadAdapter workloadAdapter)
-            {
-                // Transfer ownership of the pooled token list to the consumer; null out
-                // _frameTokens so the next frame rents a fresh one.
-                var ownedTokens = _frameTokens;
-                _frameTokens = null;
-                workloadAdapter.WriteTokensWithBytes(
-                    tokens,
-                    ansiOutput,
-                    pooledOutput,
-                    ownedTokens,
-                    ReturnTokenList);
-            }
-            else
-            {
-                _adapter.Write(ansiOutput);
-                // No consumer to hand off to: return the token list now.
-                if (_frameTokens is { } own)
+                if (hasKgpChanges)
                 {
+                    _frameTokens.AddRange(kgpBefore);
+                    if (!diff.IsEmpty)
+                    {
+                        var scratch = _frameKgpScratchTokens;
+                        SurfaceComparer.ToTokensInto(diff, _currentSurface, _previousSurface, skipKgpEmission: true, scratch);
+                        _frameTokens.AddRange(scratch);
+                    }
+                    _frameTokens.AddRange(kgpAfter);
+                }
+                else if (!diff.IsEmpty)
+                {
+                    SurfaceComparer.ToTokensInto(diff, _currentSurface, _previousSurface, skipKgpEmission: hasKgp, _frameTokens);
+                }
+                var tokens = _frameTokens;
+                _metrics.SurfaceTokensDuration.Record(Stopwatch.GetElapsedTime(tokensStart).TotalMilliseconds);
+
+                var serializeStart = Stopwatch.GetTimestamp();
+                // Use the pool-backed serializer so the per-frame ANSI byte buffer (often
+                // well over the 85 KB LOH threshold for fullscreen renders) is rented from
+                // ArrayPool rather than allocated fresh on the LOH every frame.
+                ReadOnlyMemory<byte> ansiOutput;
+                if (_adapter is Hex1bAppWorkloadAdapter)
+                {
+                    ansiOutput = Tokens.AnsiTokenUtf8Serializer.SerializeRented(tokens, out pooledOutput);
+                }
+                else
+                {
+                    ansiOutput = Tokens.AnsiTokenUtf8Serializer.Serialize(tokens);
+                }
+                _metrics.SurfaceSerializeDuration.Record(Stopwatch.GetElapsedTime(serializeStart).TotalMilliseconds);
+
+                if (_adapter is Hex1bAppWorkloadAdapter workloadAdapter)
+                {
+                    // Transfer ownership of the pooled token list AND the rented
+                    // byte buffer to the consumer; capture them into locals so the
+                    // async continuation can reference them, and null the field /
+                    // local so the finally below treats this as a successful handoff.
+                    var ownedTokens = _frameTokens;
+                    var ownedPooledOutput = pooledOutput;
                     _frameTokens = null;
-                    ReturnTokenList(own);
+                    pooledOutput = null;
+                    ownershipTransferred = true;
+
+                    asyncWriteWork = ct => workloadAdapter.WriteTokensWithBytesAsync(
+                        tokens,
+                        ansiOutput,
+                        ownedPooledOutput,
+                        ownedTokens,
+                        ReturnTokenList,
+                        ct);
+                }
+                else
+                {
+                    _adapter.Write(ansiOutput);
+                    // No workload-channel consumer: return the rented list here.
+                    if (_frameTokens is { } own)
+                    {
+                        _frameTokens = null;
+                        ReturnTokenList(own);
+                    }
+                    ownershipTransferred = true;
+                }
+
+                _metrics.OutputTokens.Record(tokens.Count);
+                _metrics.OutputBytes.Record(ansiOutput.Length);
+            }
+            finally
+            {
+                if (!ownershipTransferred)
+                {
+                    // Some step between rent and handoff threw. Return everything we
+                    // still own so the pools don't slowly bleed capacity.
+                    if (_frameTokens is { } orphaned)
+                    {
+                        _frameTokens = null;
+                        ReturnTokenList(orphaned);
+                    }
+                    if (pooledOutput is not null)
+                    {
+                        System.Buffers.ArrayPool<byte>.Shared.Return(pooledOutput);
+                        pooledOutput = null;
+                    }
                 }
             }
-            
-            _metrics.OutputTokens.Record(tokens.Count);
-            _metrics.OutputBytes.Record(ansiOutput.Length);
         }
         
         _isFirstFrame = false;

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -187,6 +187,13 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
     
     // Animation timer for RedrawAfter() support
     private readonly AnimationTimer _animationTimer;
+
+    // Minimum interval between rendered frames (paces the render loop, not just Schedule()).
+    private readonly TimeSpan _frameRateLimit;
+    // Timestamp of the last frame actually rendered. Used by the render loop
+    // to enforce _frameRateLimit so invalidations triggered faster than the
+    // configured cadence get coalesced into a single render.
+    private long _lastRenderTimestamp;
     
     // Window manager registry for accessing WindowManagers from anywhere
     private readonly WindowManagerRegistry _windowManagerRegistry = new();
@@ -227,6 +234,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         // Create animation timer with configured frame rate limit
         var frameRateLimitMs = Math.Max(1, options.FrameRateLimitMs);
         _animationTimer = new AnimationTimer(TimeSpan.FromMilliseconds(frameRateLimitMs));
+        _frameRateLimit = TimeSpan.FromMilliseconds(frameRateLimitMs);
         
         // Check if mouse is enabled in options
         _mouseEnabled = options.EnableMouse;
@@ -557,7 +565,9 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                 }
 
                 // Re-render after handling input or invalidation (state may have changed)
+                await PaceFrameAsync(cancellationToken);
                 await RenderFrameAsync(cancellationToken);
+                _lastRenderTimestamp = Stopwatch.GetTimestamp();
                 
                 // IMPORTANT: Handle race condition where output arrived during render.
                 // If invalidation was signaled while we were rendering, we need to re-render
@@ -568,6 +578,13 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                 
                 while (_invalidateChannel.Reader.TryRead(out _) && extraRenders < maxExtraRenders)
                 {
+                    // If we're already inside the frame budget, defer remaining invalidations
+                    // to the next outer iteration so the render loop honors FrameRateLimitMs.
+                    var elapsedSinceLastRender = TimeSpan.FromSeconds(
+                        (Stopwatch.GetTimestamp() - _lastRenderTimestamp) / (double)Stopwatch.Frequency);
+                    if (elapsedSinceLastRender < _frameRateLimit)
+                        break;
+
                     // ALWAYS process pending input before each re-render to prevent starvation
                     while (_adapter.InputEvents.TryRead(out var pendingEvent))
                     {
@@ -583,6 +600,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                     _animationTimer.FireDue();
                         
                     await RenderFrameAsync(cancellationToken);
+                    _lastRenderTimestamp = Stopwatch.GetTimestamp();
                     extraRenders++;
                 }
                 
@@ -794,6 +812,30 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         _metrics.InputCount.Add(1, new KeyValuePair<string, object?>("type", eventType));
         _metrics.InputDuration.Record(
             (Stopwatch.GetTimestamp() - inputStart) * 1000.0 / Stopwatch.Frequency);
+    }
+
+    /// <summary>
+    /// Sleeps until the configured per-frame minimum interval has elapsed since
+    /// the last rendered frame, so invalidations triggered faster than
+    /// <see cref="Hex1bAppOptions.FrameRateLimitMs"/> are coalesced.
+    /// </summary>
+    private async Task PaceFrameAsync(CancellationToken cancellationToken)
+    {
+        if (_lastRenderTimestamp == 0)
+            return;
+        var elapsed = TimeSpan.FromSeconds((Stopwatch.GetTimestamp() - _lastRenderTimestamp) / (double)Stopwatch.Frequency);
+        var remaining = _frameRateLimit - elapsed;
+        if (remaining > TimeSpan.Zero)
+        {
+            try
+            {
+                await Task.Delay(remaining, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Caller handles cancellation
+            }
+        }
     }
 
     private async Task RenderFrameAsync(CancellationToken cancellationToken)

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -565,7 +565,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                         await ProcessInputEventAsync(inputEvent, cancellationToken);
                     }
                     
-                    // Input coalescing: batch rapid inputs together before rendering
+                    // Input coalescing: batch rapid inputs together before rendering.
                     if (_enableInputCoalescing)
                     {
                         var outputBacklog = _adapter.OutputQueueDepth;
@@ -573,7 +573,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                             _inputCoalescingInitialDelayMs + (outputBacklog * 10), 
                             _inputCoalescingMaxDelayMs);
                         await Task.Delay(coalescingDelayMs, cancellationToken);
-                    
+
                         while (_adapter.InputEvents.TryRead(out var delayedInput))
                         {
                             await ProcessInputEventAsync(delayedInput, cancellationToken);
@@ -594,8 +594,14 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                     }
                 }
 
-                // Re-render after handling input or invalidation (state may have changed)
-                await PaceFrameAsync(cancellationToken);
+                // Re-render after handling input or invalidation (state may have changed).
+                // Skip the frame-rate pace whenever input was processed - inputs are user-driven
+                // and shouldn't be rate-limited (would starve a fast typist at one keystroke
+                // per FrameRateLimitMs). Pacing applies only to timer/invalidation-driven frames.
+                if (!inputReady)
+                {
+                    await PaceFrameAsync(cancellationToken);
+                }
                 await RenderFrameAsync(cancellationToken);
                 _lastRenderTimestamp = Stopwatch.GetTimestamp();
                 

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -1104,18 +1104,6 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         return result;
     }
 
-    private bool RenderFrameWithSurface(int width, int height, TerminalCapabilities caps)
-    {
-        // Sync wrapper retained for non-async call sites (e.g. tests). The async
-        // write-work continuation should never be produced in this path because
-        // bounded backpressure is not used outside the live render loop, but if
-        // it is, we synchronously wait — the same sync-over-async hazard
-        // documented on WriteTokensWithBytes applies.
-        var result = RenderFrameWithSurfaceCore(width, height, caps, out var asyncWriteWork);
-        asyncWriteWork?.Invoke(CancellationToken.None).AsTask().GetAwaiter().GetResult();
-        return result;
-    }
-
     private bool RenderFrameWithSurfaceCore(int width, int height, TerminalCapabilities caps, out Func<CancellationToken, ValueTask>? asyncWriteWork)
     {
         asyncWriteWork = null;
@@ -1307,7 +1295,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
             //   1. Rent a list from _tokenListPool.
             //   2. Fill it via ToTokensInto.
             //   3. On the happy path, transfer ownership to the consumer via
-            //      WriteTokensWithBytes(Async); the consumer returns it once
+            //      WriteTokensWithBytesAsync; the consumer returns it once
             //      it has finished iterating.
             //   4. On any throw before step 3 completes, the finally below
             //      returns the list and any rented ANSI buffer to their pools

--- a/src/Hex1b/Hex1bAppOptions.cs
+++ b/src/Hex1b/Hex1bAppOptions.cs
@@ -161,9 +161,19 @@ public class Hex1bAppOptions
     /// <summary>
     /// Whether to enable pooling of temporary <see cref="Surfaces.Surface"/> instances during rendering.
     /// This primarily affects <see cref="Widgets.SurfaceWidget"/> layers and nodes like EffectPanel.
-    /// Default is false.
     /// </summary>
-    public bool EnableSurfacePooling { get; set; }
+    /// <remarks>
+    /// <para>
+    /// Enabled by default. On representative busy UIs this measures at roughly
+    /// -50% per-frame allocations and eliminates Gen2 collections that would
+    /// otherwise cause visible stutter (see <c>docs/perf/baseline.md</c>).
+    /// </para>
+    /// <para>
+    /// Set to <c>false</c> to opt out — for example, in environments where the
+    /// extra retained surfaces would matter more than allocation pressure.
+    /// </para>
+    /// </remarks>
+    public bool EnableSurfacePooling { get; set; } = true;
 
     /// <summary>
     /// Maximum number of pooled surfaces kept per (width, height, cell metrics) bucket.

--- a/src/Hex1b/Hex1bAppWorkloadAdapter.cs
+++ b/src/Hex1b/Hex1bAppWorkloadAdapter.cs
@@ -173,20 +173,39 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
     /// processing the item. If the write fails (channel closed), the buffer is returned here so
     /// callers don't have to worry about double-free.
     /// </param>
-    internal void WriteTokensWithBytes(IReadOnlyList<AnsiToken> tokens, ReadOnlyMemory<byte> bytes, byte[]? pooledBuffer = null)
+    /// <param name="pooledTokens">
+    /// Optional list backing <paramref name="tokens"/> that should be returned to a pool after
+    /// the consumer has finished with it. <paramref name="pooledTokensReturn"/> is the callback
+    /// the consumer invokes to return it. Both must be supplied together or both null.
+    /// </param>
+    /// <param name="pooledTokensReturn">See <paramref name="pooledTokens"/>.</param>
+    internal void WriteTokensWithBytes(
+        IReadOnlyList<AnsiToken> tokens,
+        ReadOnlyMemory<byte> bytes,
+        byte[]? pooledBuffer = null,
+        List<AnsiToken>? pooledTokens = null,
+        Action<List<AnsiToken>>? pooledTokensReturn = null)
     {
         if (_disposed)
         {
             if (pooledBuffer is not null) System.Buffers.ArrayPool<byte>.Shared.Return(pooledBuffer);
+            if (pooledTokens is not null && pooledTokensReturn is not null) pooledTokensReturn(pooledTokens);
             return;
         }
-        if (_outputChannel.Writer.TryWrite(new WorkloadOutputItem(bytes, tokens) { PooledBuffer = pooledBuffer }))
+        var item = new WorkloadOutputItem(bytes, tokens)
+        {
+            PooledBuffer = pooledBuffer,
+            PooledTokens = pooledTokens,
+            PooledTokensReturn = pooledTokensReturn,
+        };
+        if (_outputChannel.Writer.TryWrite(item))
         {
             Interlocked.Increment(ref _outputQueueDepth);
         }
-        else if (pooledBuffer is not null)
+        else
         {
-            System.Buffers.ArrayPool<byte>.Shared.Return(pooledBuffer);
+            if (pooledBuffer is not null) System.Buffers.ArrayPool<byte>.Shared.Return(pooledBuffer);
+            if (pooledTokens is not null && pooledTokensReturn is not null) pooledTokensReturn(pooledTokens);
         }
     }
 

--- a/src/Hex1b/Hex1bAppWorkloadAdapter.cs
+++ b/src/Hex1b/Hex1bAppWorkloadAdapter.cs
@@ -46,6 +46,7 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
     private bool _inTuiMode;
     private bool _dimensionsInitialized;
     private int _outputQueueDepth; // Manual tracking since unbounded channels don't support Count
+    private readonly int _maxQueuedOutputItems;
 
     /// <summary>
     /// Optional diagnostic tree provider for MCP diagnostics.
@@ -63,14 +64,27 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
     /// Creates a new app workload adapter.
     /// </summary>
     /// <param name="capabilities">Terminal capabilities. If null, defaults with full support.</param>
+    /// <param name="maxQueuedOutputItems">
+    /// Maximum number of pending output items (frame buffers, control sequences, etc.) the
+    /// adapter will buffer before applying backpressure. <c>0</c> (default) means unbounded —
+    /// producers never block, at the cost of unbounded memory growth if a slow consumer falls
+    /// behind. A small positive value (e.g. <c>8</c>) caps memory and makes the render loop's
+    /// effective frame rate track the consumer's drain rate. Drop semantics are deliberately
+    /// not offered: each output item carries an incremental diff, so dropping a queued item
+    /// would desynchronise the host terminal's surface state.
+    /// </param>
     /// <remarks>
     /// Dimensions are set by the terminal via <see cref="ResizeAsync"/>.
     /// Initial dimensions default to 0x0 until the terminal notifies.
     /// </remarks>
-    public Hex1bAppWorkloadAdapter(TerminalCapabilities? capabilities = null)
+    public Hex1bAppWorkloadAdapter(TerminalCapabilities? capabilities = null, int maxQueuedOutputItems = 0)
     {
+        if (maxQueuedOutputItems < 0)
+            throw new ArgumentOutOfRangeException(nameof(maxQueuedOutputItems), "Must be >= 0.");
+
         _width = 0;
         _height = 0;
+        _maxQueuedOutputItems = maxQueuedOutputItems;
         _staticCapabilities = capabilities ?? new TerminalCapabilities
         {
             SupportsMouse = true,
@@ -80,11 +94,7 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
             SupportsUnderlineColor = true,
         };
 
-        _outputChannel = Channel.CreateUnbounded<WorkloadOutputItem>(new UnboundedChannelOptions
-        {
-            SingleReader = true,
-            SingleWriter = false
-        });
+        _outputChannel = CreateOutputChannel(maxQueuedOutputItems);
 
         _inputChannel = Channel.CreateUnbounded<Hex1bEvent>(new UnboundedChannelOptions
         {
@@ -97,27 +107,51 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
     /// Creates a new app workload adapter connected to a presentation adapter.
     /// </summary>
     /// <param name="presentationAdapter">The presentation adapter to delegate capabilities to.</param>
+    /// <param name="maxQueuedOutputItems">
+    /// See <see cref="Hex1bAppWorkloadAdapter(TerminalCapabilities?, int)"/>.
+    /// </param>
     /// <remarks>
     /// When a presentation adapter is provided, capabilities are read live from it,
     /// allowing updates to cell dimensions (e.g., after resize) to be reflected.
     /// </remarks>
-    public Hex1bAppWorkloadAdapter(IHex1bTerminalPresentationAdapter presentationAdapter)
+    public Hex1bAppWorkloadAdapter(IHex1bTerminalPresentationAdapter presentationAdapter, int maxQueuedOutputItems = 0)
     {
+        if (maxQueuedOutputItems < 0)
+            throw new ArgumentOutOfRangeException(nameof(maxQueuedOutputItems), "Must be >= 0.");
+
         _width = 0;
         _height = 0;
+        _maxQueuedOutputItems = maxQueuedOutputItems;
         _presentationAdapter = presentationAdapter;
         _staticCapabilities = null;
 
-        _outputChannel = Channel.CreateUnbounded<WorkloadOutputItem>(new UnboundedChannelOptions
-        {
-            SingleReader = true,
-            SingleWriter = false
-        });
+        _outputChannel = CreateOutputChannel(maxQueuedOutputItems);
 
         _inputChannel = Channel.CreateUnbounded<Hex1bEvent>(new UnboundedChannelOptions
         {
             SingleReader = true,
             SingleWriter = true
+        });
+    }
+
+    private static Channel<WorkloadOutputItem> CreateOutputChannel(int maxQueuedOutputItems)
+    {
+        if (maxQueuedOutputItems > 0)
+        {
+            return Channel.CreateBounded<WorkloadOutputItem>(new BoundedChannelOptions(maxQueuedOutputItems)
+            {
+                FullMode = BoundedChannelFullMode.Wait,
+                SingleReader = true,
+                // SingleWriter intentionally false: clipboard/paste/exit paths may
+                // write from threads other than the render loop.
+                SingleWriter = false,
+            });
+        }
+
+        return Channel.CreateUnbounded<WorkloadOutputItem>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false,
         });
     }
 
@@ -132,10 +166,7 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
     {
         if (_disposed) return;
         var bytes = Encoding.UTF8.GetBytes(text);
-        if (_outputChannel.Writer.TryWrite(new WorkloadOutputItem(bytes, Tokens: null)))
-        {
-            Interlocked.Increment(ref _outputQueueDepth);
-        }
+        EnqueueOutput(new WorkloadOutputItem(bytes, Tokens: null));
     }
 
     /// <summary>
@@ -144,24 +175,18 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
     public void Write(ReadOnlySpan<byte> data)
     {
         if (_disposed) return;
-        if (_outputChannel.Writer.TryWrite(new WorkloadOutputItem(data.ToArray(), Tokens: null)))
-        {
-            Interlocked.Increment(ref _outputQueueDepth);
-        }
+        EnqueueOutput(new WorkloadOutputItem(data.ToArray(), Tokens: null));
     }
-    
+
     /// <summary>
     /// Write raw bytes to the terminal without forcing a copy.
     /// </summary>
     public void Write(ReadOnlyMemory<byte> data)
     {
         if (_disposed) return;
-        if (_outputChannel.Writer.TryWrite(new WorkloadOutputItem(data, Tokens: null)))
-        {
-            Interlocked.Increment(ref _outputQueueDepth);
-        }
+        EnqueueOutput(new WorkloadOutputItem(data, Tokens: null));
     }
-    
+
     /// <summary>
     /// Writes output with an already-tokenized representation to avoid terminal-side UTF-8 decode + tokenization.
     /// </summary>
@@ -186,27 +211,70 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
         List<AnsiToken>? pooledTokens = null,
         Action<List<AnsiToken>>? pooledTokensReturn = null)
     {
-        if (_disposed)
-        {
-            if (pooledBuffer is not null) System.Buffers.ArrayPool<byte>.Shared.Return(pooledBuffer);
-            if (pooledTokens is not null && pooledTokensReturn is not null) pooledTokensReturn(pooledTokens);
-            return;
-        }
         var item = new WorkloadOutputItem(bytes, tokens)
         {
             PooledBuffer = pooledBuffer,
             PooledTokens = pooledTokens,
             PooledTokensReturn = pooledTokensReturn,
         };
+        if (_disposed)
+        {
+            ReturnPooledResources(item);
+            return;
+        }
+        EnqueueOutput(item);
+    }
+
+    /// <summary>
+    /// Centralised enqueue for output items. Handles the bounded-channel
+    /// backpressure case (block the producer until a slot frees) and ensures
+    /// pooled resources carried by the item are returned to their pools on
+    /// any failure path so callers can't leak them.
+    /// </summary>
+    private void EnqueueOutput(WorkloadOutputItem item)
+    {
+        // Fast path: unbounded channel always accepts; bounded channel
+        // accepts when capacity is available.
         if (_outputChannel.Writer.TryWrite(item))
         {
             Interlocked.Increment(ref _outputQueueDepth);
+            return;
         }
-        else
+
+        // Slow path: bounded channel is full. Block the producer until a
+        // slot frees. This is the deliberate backpressure: if the consumer
+        // can't keep up, the producer's effective frame rate falls to match
+        // the consumer's drain rate, which is exactly what we want.
+        //
+        // sync-over-async is acceptable here: the producer is the render
+        // loop (or a control-sequence writer), already inside a Task-based
+        // async chain, and slowing it down is the goal.
+        try
         {
-            if (pooledBuffer is not null) System.Buffers.ArrayPool<byte>.Shared.Return(pooledBuffer);
-            if (pooledTokens is not null && pooledTokensReturn is not null) pooledTokensReturn(pooledTokens);
+            var writeTask = _outputChannel.Writer.WriteAsync(item);
+            if (!writeTask.IsCompletedSuccessfully)
+                writeTask.AsTask().GetAwaiter().GetResult();
+            Interlocked.Increment(ref _outputQueueDepth);
         }
+        catch (ChannelClosedException)
+        {
+            // Channel completed while we were waiting; return pooled
+            // resources so they aren't leaked.
+            ReturnPooledResources(item);
+        }
+        catch (InvalidOperationException)
+        {
+            // Same: channel may surface a writer-completed state as IOE.
+            ReturnPooledResources(item);
+        }
+    }
+
+    private static void ReturnPooledResources(WorkloadOutputItem item)
+    {
+        if (item.PooledBuffer is not null)
+            System.Buffers.ArrayPool<byte>.Shared.Return(item.PooledBuffer);
+        if (item.PooledTokens is not null && item.PooledTokensReturn is not null)
+            item.PooledTokensReturn(item.PooledTokens);
     }
 
     /// <summary>

--- a/src/Hex1b/Hex1bAppWorkloadAdapter.cs
+++ b/src/Hex1b/Hex1bAppWorkloadAdapter.cs
@@ -204,6 +204,16 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
     /// the consumer invokes to return it. Both must be supplied together or both null.
     /// </param>
     /// <param name="pooledTokensReturn">See <paramref name="pooledTokens"/>.</param>
+    /// <remarks>
+    /// <para>
+    /// This sync overload uses sync-over-async when backpressure forces the bounded channel to
+    /// wait, which is safe only when the producer is on a thread that is not the channel's
+    /// reader thread (the standard arrangement, since the reader runs on its own
+    /// <c>Task.Run</c>). Callers hosted under a single-threaded
+    /// <see cref="System.Threading.SynchronizationContext"/> (some UI frameworks) should prefer
+    /// <see cref="WriteTokensWithBytesAsync"/> to avoid potential deadlock.
+    /// </para>
+    /// </remarks>
     internal void WriteTokensWithBytes(
         IReadOnlyList<AnsiToken> tokens,
         ReadOnlyMemory<byte> bytes,
@@ -223,6 +233,38 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
             return;
         }
         EnqueueOutput(item);
+    }
+
+    /// <summary>
+    /// Async variant of <see cref="WriteTokensWithBytes"/>. Producers on async render loops
+    /// should prefer this overload — when the bounded channel is full the returned
+    /// <see cref="ValueTask"/> awaits a slot freeing up without blocking the producer thread,
+    /// avoiding the sync-over-async hazard documented on the sync overload.
+    /// </summary>
+    /// <returns>
+    /// A completed <see cref="ValueTask"/> when the item was enqueued without contention;
+    /// otherwise a task that completes once backpressure has cleared.
+    /// </returns>
+    internal ValueTask WriteTokensWithBytesAsync(
+        IReadOnlyList<AnsiToken> tokens,
+        ReadOnlyMemory<byte> bytes,
+        byte[]? pooledBuffer = null,
+        List<AnsiToken>? pooledTokens = null,
+        Action<List<AnsiToken>>? pooledTokensReturn = null,
+        CancellationToken cancellationToken = default)
+    {
+        var item = new WorkloadOutputItem(bytes, tokens)
+        {
+            PooledBuffer = pooledBuffer,
+            PooledTokens = pooledTokens,
+            PooledTokensReturn = pooledTokensReturn,
+        };
+        if (_disposed)
+        {
+            ReturnPooledResources(item);
+            return ValueTask.CompletedTask;
+        }
+        return EnqueueOutputAsync(item, cancellationToken);
     }
 
     /// <summary>
@@ -275,6 +317,40 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
             System.Buffers.ArrayPool<byte>.Shared.Return(item.PooledBuffer);
         if (item.PooledTokens is not null && item.PooledTokensReturn is not null)
             item.PooledTokensReturn(item.PooledTokens);
+    }
+
+    /// <summary>
+    /// Async counterpart of <see cref="EnqueueOutput"/>. Awaits a slot instead of
+    /// blocking the producer thread when the bounded channel is full — required by
+    /// callers hosted under single-threaded sync contexts where sync-over-async would
+    /// deadlock.
+    /// </summary>
+    private async ValueTask EnqueueOutputAsync(WorkloadOutputItem item, CancellationToken cancellationToken)
+    {
+        if (_outputChannel.Writer.TryWrite(item))
+        {
+            Interlocked.Increment(ref _outputQueueDepth);
+            return;
+        }
+
+        try
+        {
+            await _outputChannel.Writer.WriteAsync(item, cancellationToken).ConfigureAwait(false);
+            Interlocked.Increment(ref _outputQueueDepth);
+        }
+        catch (ChannelClosedException)
+        {
+            ReturnPooledResources(item);
+        }
+        catch (InvalidOperationException)
+        {
+            ReturnPooledResources(item);
+        }
+        catch (OperationCanceledException)
+        {
+            ReturnPooledResources(item);
+            throw;
+        }
     }
 
     /// <summary>

--- a/src/Hex1b/Hex1bAppWorkloadAdapter.cs
+++ b/src/Hex1b/Hex1bAppWorkloadAdapter.cs
@@ -165,12 +165,28 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
     /// <summary>
     /// Writes output with an already-tokenized representation to avoid terminal-side UTF-8 decode + tokenization.
     /// </summary>
-    internal void WriteTokensWithBytes(IReadOnlyList<AnsiToken> tokens, ReadOnlyMemory<byte> bytes)
+    /// <param name="tokens">The tokens to ship to the consumer.</param>
+    /// <param name="bytes">The serialised bytes of <paramref name="tokens"/>.</param>
+    /// <param name="pooledBuffer">
+    /// Optional array rented from <see cref="System.Buffers.ArrayPool{T}.Shared"/> that backs
+    /// <paramref name="bytes"/>. When provided, the consumer side returns it to the pool after
+    /// processing the item. If the write fails (channel closed), the buffer is returned here so
+    /// callers don't have to worry about double-free.
+    /// </param>
+    internal void WriteTokensWithBytes(IReadOnlyList<AnsiToken> tokens, ReadOnlyMemory<byte> bytes, byte[]? pooledBuffer = null)
     {
-        if (_disposed) return;
-        if (_outputChannel.Writer.TryWrite(new WorkloadOutputItem(bytes, tokens)))
+        if (_disposed)
+        {
+            if (pooledBuffer is not null) System.Buffers.ArrayPool<byte>.Shared.Return(pooledBuffer);
+            return;
+        }
+        if (_outputChannel.Writer.TryWrite(new WorkloadOutputItem(bytes, tokens, pooledBuffer)))
         {
             Interlocked.Increment(ref _outputQueueDepth);
+        }
+        else if (pooledBuffer is not null)
+        {
+            System.Buffers.ArrayPool<byte>.Shared.Return(pooledBuffer);
         }
     }
 

--- a/src/Hex1b/Hex1bAppWorkloadAdapter.cs
+++ b/src/Hex1b/Hex1bAppWorkloadAdapter.cs
@@ -180,7 +180,7 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
             if (pooledBuffer is not null) System.Buffers.ArrayPool<byte>.Shared.Return(pooledBuffer);
             return;
         }
-        if (_outputChannel.Writer.TryWrite(new WorkloadOutputItem(bytes, tokens, pooledBuffer)))
+        if (_outputChannel.Writer.TryWrite(new WorkloadOutputItem(bytes, tokens) { PooledBuffer = pooledBuffer }))
         {
             Interlocked.Increment(ref _outputQueueDepth);
         }

--- a/src/Hex1b/Hex1bAppWorkloadAdapter.cs
+++ b/src/Hex1b/Hex1bAppWorkloadAdapter.cs
@@ -204,46 +204,11 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
     /// the consumer invokes to return it. Both must be supplied together or both null.
     /// </param>
     /// <param name="pooledTokensReturn">See <paramref name="pooledTokens"/>.</param>
-    /// <remarks>
-    /// <para>
-    /// This sync overload uses sync-over-async when backpressure forces the bounded channel to
-    /// wait, which is safe only when the producer is on a thread that is not the channel's
-    /// reader thread (the standard arrangement, since the reader runs on its own
-    /// <c>Task.Run</c>). Callers hosted under a single-threaded
-    /// <see cref="System.Threading.SynchronizationContext"/> (some UI frameworks) should prefer
-    /// <see cref="WriteTokensWithBytesAsync"/> to avoid potential deadlock.
-    /// </para>
-    /// </remarks>
-    internal void WriteTokensWithBytes(
-        IReadOnlyList<AnsiToken> tokens,
-        ReadOnlyMemory<byte> bytes,
-        byte[]? pooledBuffer = null,
-        List<AnsiToken>? pooledTokens = null,
-        Action<List<AnsiToken>>? pooledTokensReturn = null)
-    {
-        var item = new WorkloadOutputItem(bytes, tokens)
-        {
-            PooledBuffer = pooledBuffer,
-            PooledTokens = pooledTokens,
-            PooledTokensReturn = pooledTokensReturn,
-        };
-        if (_disposed)
-        {
-            ReturnPooledResources(item);
-            return;
-        }
-        EnqueueOutput(item);
-    }
-
-    /// <summary>
-    /// Async variant of <see cref="WriteTokensWithBytes"/>. Producers on async render loops
-    /// should prefer this overload — when the bounded channel is full the returned
-    /// <see cref="ValueTask"/> awaits a slot freeing up without blocking the producer thread,
-    /// avoiding the sync-over-async hazard documented on the sync overload.
-    /// </summary>
+    /// <param name="cancellationToken">Cancellation token for awaiting backpressure.</param>
     /// <returns>
     /// A completed <see cref="ValueTask"/> when the item was enqueued without contention;
-    /// otherwise a task that completes once backpressure has cleared.
+    /// otherwise a task that completes once backpressure has cleared. The hot path
+    /// (unbounded channel or bounded channel with capacity) allocates no async state machine.
     /// </returns>
     internal ValueTask WriteTokensWithBytesAsync(
         IReadOnlyList<AnsiToken> tokens,

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -1313,6 +1313,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 ReadOnlyMemory<byte> data;
                 IReadOnlyList<AnsiToken>? preTokenizedTokens = null;
                 byte[]? pooledItemBuffer = null;
+                List<AnsiToken>? pooledItemTokens = null;
+                Action<List<AnsiToken>>? pooledItemTokensReturn = null;
 
                 if (_workload is IHex1bTerminalTokenWorkloadAdapter tokenWorkload)
                 {
@@ -1320,6 +1322,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                     data = item.Bytes;
                     preTokenizedTokens = item.Tokens;
                     pooledItemBuffer = item.PooledBuffer;
+                    pooledItemTokens = item.PooledTokens;
+                    pooledItemTokensReturn = item.PooledTokensReturn;
                 }
                 else
                 {
@@ -1330,6 +1334,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 {
                     if (pooledItemBuffer is not null)
                         System.Buffers.ArrayPool<byte>.Shared.Return(pooledItemBuffer);
+                    if (pooledItemTokens is not null && pooledItemTokensReturn is not null)
+                        pooledItemTokensReturn(pooledItemTokens);
 
                     // Channel empty - this is a frame boundary
                     await NotifyWorkloadFiltersFrameCompleteAsync();
@@ -1443,6 +1449,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 {
                     if (pooledItemBuffer is not null)
                         System.Buffers.ArrayPool<byte>.Shared.Return(pooledItemBuffer);
+                    if (pooledItemTokens is not null && pooledItemTokensReturn is not null)
+                        pooledItemTokensReturn(pooledItemTokens);
                 }
             }
         }

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -1312,12 +1312,14 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             {
                 ReadOnlyMemory<byte> data;
                 IReadOnlyList<AnsiToken>? preTokenizedTokens = null;
+                byte[]? pooledItemBuffer = null;
 
                 if (_workload is IHex1bTerminalTokenWorkloadAdapter tokenWorkload)
                 {
                     var item = await tokenWorkload.ReadOutputItemAsync(ct);
                     data = item.Bytes;
                     preTokenizedTokens = item.Tokens;
+                    pooledItemBuffer = item.PooledBuffer;
                 }
                 else
                 {
@@ -1326,6 +1328,9 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 
                 if (data.IsEmpty)
                 {
+                    if (pooledItemBuffer is not null)
+                        System.Buffers.ArrayPool<byte>.Shared.Return(pooledItemBuffer);
+
                     // Channel empty - this is a frame boundary
                     await NotifyWorkloadFiltersFrameCompleteAsync();
                     
@@ -1334,6 +1339,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                     continue;
                 }
                 
+                try
+                {
                 string? completeText = null;
                 IReadOnlyList<AnsiToken> tokens;
 
@@ -1430,6 +1437,12 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                         await _presentation.WriteOutputAsync(filteredBytes, ct);
                         _metrics.TerminalOutputBytes.Record(filteredBytes.Length);
                     }
+                }
+                }
+                finally
+                {
+                    if (pooledItemBuffer is not null)
+                        System.Buffers.ArrayPool<byte>.Shared.Return(pooledItemBuffer);
                 }
             }
         }

--- a/src/Hex1b/Hex1bTerminalBuilder.cs
+++ b/src/Hex1b/Hex1bTerminalBuilder.cs
@@ -54,7 +54,6 @@ public sealed class Hex1bTerminalBuilder
     private Reflow.ITerminalReflowProvider? _reflowStrategy;
     private bool _reflowEnabled;
     private Action<Hex1bAppOptions>? _appOptionsConfigurator;
-    private int _maxQueuedOutputItems;
 
     /// <summary>
     /// Creates a new terminal builder.
@@ -121,8 +120,8 @@ public sealed class Hex1bTerminalBuilder
             // If presentation adapter is available, use it for live capabilities
             // Otherwise fall back to static capabilities
             var workloadAdapter = presentation != null
-                ? new Hex1bAppWorkloadAdapter(presentation, _maxQueuedOutputItems)
-                : new Hex1bAppWorkloadAdapter(maxQueuedOutputItems: _maxQueuedOutputItems);
+                ? new Hex1bAppWorkloadAdapter(presentation)
+                : new Hex1bAppWorkloadAdapter();
             workloadAdapter.DiagnosticTimingEnabled = _diagnosticsEnabled;
             var enableMouse = _enableMouse;
 
@@ -199,8 +198,8 @@ public sealed class Hex1bTerminalBuilder
             // If presentation adapter is available, use it for live capabilities
             // Otherwise fall back to static capabilities
             var workloadAdapter = presentation != null 
-                ? new Hex1bAppWorkloadAdapter(presentation, _maxQueuedOutputItems)
-                : new Hex1bAppWorkloadAdapter(maxQueuedOutputItems: _maxQueuedOutputItems);
+                ? new Hex1bAppWorkloadAdapter(presentation)
+                : new Hex1bAppWorkloadAdapter();
             workloadAdapter.DiagnosticTimingEnabled = _diagnosticsEnabled;
             var enableMouse = _enableMouse;
             
@@ -821,35 +820,6 @@ public sealed class Hex1bTerminalBuilder
         return this;
     }
 
-    /// <summary>
-    /// Caps the number of pending output items the app-to-terminal channel will
-    /// buffer. When the channel is full, the render-loop producer blocks until
-    /// the consumer drains a slot — its effective frame rate then tracks the
-    /// consumer's drain rate instead of racing ahead.
-    /// </summary>
-    /// <param name="maxItems">
-    /// Maximum queued items. <c>0</c> (default) means unbounded — producers
-    /// never block, but memory can grow without limit if the consumer is slow.
-    /// A small positive value (e.g. <c>8</c>) gives natural backpressure on
-    /// slow host terminals (iTerm, Terminal.app under heavy true-color
-    /// workloads) at the cost of capping perceived frame rate to what the host
-    /// can drain. Drop semantics are deliberately not offered: each item
-    /// carries an incremental diff, so dropping one would desynchronise the
-    /// host terminal's surface state.
-    /// </param>
-    /// <returns>This builder instance for fluent chaining.</returns>
-    /// <remarks>
-    /// Must be called before <c>WithHex1bApp</c> — the bound is captured into
-    /// the workload adapter at construction time.
-    /// </remarks>
-    public Hex1bTerminalBuilder WithMaxQueuedOutputItems(int maxItems)
-    {
-        if (maxItems < 0)
-            throw new ArgumentOutOfRangeException(nameof(maxItems), "Must be >= 0.");
-        _maxQueuedOutputItems = maxItems;
-        return this;
-    }
-
     // === Recording and Optimization ===
 
     /// <summary>
@@ -965,8 +935,8 @@ public sealed class Hex1bTerminalBuilder
         SetWorkloadFactory(presentation =>
         {
             var workloadAdapter = presentation != null
-                ? new Hex1bAppWorkloadAdapter(presentation, _maxQueuedOutputItems)
-                : new Hex1bAppWorkloadAdapter(maxQueuedOutputItems: _maxQueuedOutputItems);
+                ? new Hex1bAppWorkloadAdapter(presentation)
+                : new Hex1bAppWorkloadAdapter();
 
             var options = new Flow.Hex1bFlowOptions();
             configureOptions?.Invoke(options);

--- a/src/Hex1b/Hex1bTerminalBuilder.cs
+++ b/src/Hex1b/Hex1bTerminalBuilder.cs
@@ -54,6 +54,7 @@ public sealed class Hex1bTerminalBuilder
     private Reflow.ITerminalReflowProvider? _reflowStrategy;
     private bool _reflowEnabled;
     private Action<Hex1bAppOptions>? _appOptionsConfigurator;
+    private int _maxQueuedOutputItems;
 
     /// <summary>
     /// Creates a new terminal builder.
@@ -120,8 +121,8 @@ public sealed class Hex1bTerminalBuilder
             // If presentation adapter is available, use it for live capabilities
             // Otherwise fall back to static capabilities
             var workloadAdapter = presentation != null
-                ? new Hex1bAppWorkloadAdapter(presentation)
-                : new Hex1bAppWorkloadAdapter();
+                ? new Hex1bAppWorkloadAdapter(presentation, _maxQueuedOutputItems)
+                : new Hex1bAppWorkloadAdapter(maxQueuedOutputItems: _maxQueuedOutputItems);
             workloadAdapter.DiagnosticTimingEnabled = _diagnosticsEnabled;
             var enableMouse = _enableMouse;
 
@@ -198,8 +199,8 @@ public sealed class Hex1bTerminalBuilder
             // If presentation adapter is available, use it for live capabilities
             // Otherwise fall back to static capabilities
             var workloadAdapter = presentation != null 
-                ? new Hex1bAppWorkloadAdapter(presentation)
-                : new Hex1bAppWorkloadAdapter();
+                ? new Hex1bAppWorkloadAdapter(presentation, _maxQueuedOutputItems)
+                : new Hex1bAppWorkloadAdapter(maxQueuedOutputItems: _maxQueuedOutputItems);
             workloadAdapter.DiagnosticTimingEnabled = _diagnosticsEnabled;
             var enableMouse = _enableMouse;
             
@@ -820,6 +821,35 @@ public sealed class Hex1bTerminalBuilder
         return this;
     }
 
+    /// <summary>
+    /// Caps the number of pending output items the app-to-terminal channel will
+    /// buffer. When the channel is full, the render-loop producer blocks until
+    /// the consumer drains a slot — its effective frame rate then tracks the
+    /// consumer's drain rate instead of racing ahead.
+    /// </summary>
+    /// <param name="maxItems">
+    /// Maximum queued items. <c>0</c> (default) means unbounded — producers
+    /// never block, but memory can grow without limit if the consumer is slow.
+    /// A small positive value (e.g. <c>8</c>) gives natural backpressure on
+    /// slow host terminals (iTerm, Terminal.app under heavy true-color
+    /// workloads) at the cost of capping perceived frame rate to what the host
+    /// can drain. Drop semantics are deliberately not offered: each item
+    /// carries an incremental diff, so dropping one would desynchronise the
+    /// host terminal's surface state.
+    /// </param>
+    /// <returns>This builder instance for fluent chaining.</returns>
+    /// <remarks>
+    /// Must be called before <c>WithHex1bApp</c> — the bound is captured into
+    /// the workload adapter at construction time.
+    /// </remarks>
+    public Hex1bTerminalBuilder WithMaxQueuedOutputItems(int maxItems)
+    {
+        if (maxItems < 0)
+            throw new ArgumentOutOfRangeException(nameof(maxItems), "Must be >= 0.");
+        _maxQueuedOutputItems = maxItems;
+        return this;
+    }
+
     // === Recording and Optimization ===
 
     /// <summary>
@@ -935,8 +965,8 @@ public sealed class Hex1bTerminalBuilder
         SetWorkloadFactory(presentation =>
         {
             var workloadAdapter = presentation != null
-                ? new Hex1bAppWorkloadAdapter(presentation)
-                : new Hex1bAppWorkloadAdapter();
+                ? new Hex1bAppWorkloadAdapter(presentation, _maxQueuedOutputItems)
+                : new Hex1bAppWorkloadAdapter(maxQueuedOutputItems: _maxQueuedOutputItems);
 
             var options = new Flow.Hex1bFlowOptions();
             configureOptions?.Invoke(options);

--- a/src/Hex1b/Hex1bTerminalBuilder.cs
+++ b/src/Hex1b/Hex1bTerminalBuilder.cs
@@ -17,7 +17,7 @@ namespace Hex1b;
 /// <para>Simple Hex1bApp:</para>
 /// <code>
 /// await using var terminal = Hex1bTerminal.CreateBuilder()
-///     .WithHex1bApp((app, options) => ctx => ctx.Text("Hello, World!"))
+///     .WithHex1bApp(ctx => ctx.Text("Hello, World!"))
 ///     .Build();
 /// 
 /// await terminal.RunAsync();
@@ -53,7 +53,6 @@ public sealed class Hex1bTerminalBuilder
     private Action<ScrollbackRowEventArgs>? _scrollbackCallback;
     private Reflow.ITerminalReflowProvider? _reflowStrategy;
     private bool _reflowEnabled;
-    private Action<Hex1bAppOptions>? _appOptionsConfigurator;
 
     /// <summary>
     /// Creates a new terminal builder.
@@ -63,69 +62,135 @@ public sealed class Hex1bTerminalBuilder
     }
 
     /// <summary>
-    /// Configures the terminal to run a Hex1bApp with the specified widget builder.
+    /// Configures the terminal to run a Hex1bApp that renders the widget tree
+    /// produced by <paramref name="widgetBuilder"/>.
     /// </summary>
-    /// <param name="configure">
-    /// A configuration function that receives the <see cref="Hex1bApp"/> instance and 
-    /// <see cref="Hex1bAppOptions"/> for customization, and returns the widget builder function.
+    /// <param name="widgetBuilder">Builds the root widget for each render frame.</param>
+    /// <returns>This builder instance for fluent chaining.</returns>
+    /// <example>
+    /// <code>
+    /// await using var terminal = Hex1bTerminal.CreateBuilder()
+    ///     .WithHex1bApp(ctx => ctx.Text("Hello, World!"))
+    ///     .Build();
+    /// </code>
+    /// </example>
+    public Hex1bTerminalBuilder WithHex1bApp(Func<RootContext, Hex1bWidget> widgetBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(widgetBuilder);
+        return WithHex1bAppCore(
+            configureOptions: null,
+            configureApp: _ => widgetBuilder);
+    }
+
+    /// <summary>
+    /// Configures the terminal to run a Hex1bApp with the given async widget builder.
+    /// </summary>
+    /// <param name="widgetBuilder">Builds the root widget asynchronously for each render frame.</param>
+    /// <returns>This builder instance for fluent chaining.</returns>
+    public Hex1bTerminalBuilder WithHex1bApp(Func<RootContext, Task<Hex1bWidget>> widgetBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(widgetBuilder);
+        return WithHex1bAppCoreAsync(
+            configureOptions: null,
+            configureApp: _ => widgetBuilder);
+    }
+
+    /// <summary>
+    /// Configures the terminal to run a Hex1bApp with eager option configuration
+    /// followed by a synchronous widget builder.
+    /// </summary>
+    /// <param name="configureOptions">
+    /// Callback that mutates the <see cref="Hex1bAppOptions"/>. Runs eagerly,
+    /// before <see cref="Hex1bApp"/> is constructed, so settings the constructor
+    /// snapshots (e.g. <see cref="Hex1bAppOptions.FrameRateLimitMs"/>) take
+    /// effect.
+    /// </param>
+    /// <param name="widgetBuilder">Builds the root widget for each render frame.</param>
+    /// <returns>This builder instance for fluent chaining.</returns>
+    public Hex1bTerminalBuilder WithHex1bApp(
+        Action<Hex1bAppOptions> configureOptions,
+        Func<RootContext, Hex1bWidget> widgetBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(configureOptions);
+        ArgumentNullException.ThrowIfNull(widgetBuilder);
+        return WithHex1bAppCore(configureOptions, _ => widgetBuilder);
+    }
+
+    /// <summary>
+    /// Configures the terminal to run a Hex1bApp with eager option configuration
+    /// followed by an asynchronous widget builder.
+    /// </summary>
+    public Hex1bTerminalBuilder WithHex1bApp(
+        Action<Hex1bAppOptions> configureOptions,
+        Func<RootContext, Task<Hex1bWidget>> widgetBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(configureOptions);
+        ArgumentNullException.ThrowIfNull(widgetBuilder);
+        return WithHex1bAppCoreAsync(configureOptions, _ => widgetBuilder);
+    }
+
+    /// <summary>
+    /// Configures the terminal to run a Hex1bApp with full control: eager option
+    /// configuration plus access to the <see cref="Hex1bApp"/> instance when
+    /// building the widget tree.
+    /// </summary>
+    /// <param name="configureOptions">
+    /// Callback that mutates the <see cref="Hex1bAppOptions"/>. Runs eagerly,
+    /// before <see cref="Hex1bApp"/> is constructed.
+    /// </param>
+    /// <param name="configureApp">
+    /// Callback that receives the constructed <see cref="Hex1bApp"/> and returns
+    /// the widget builder. Runs lazily on the first widget build, so the
+    /// <see cref="Hex1bApp"/> instance is fully constructed and safe to capture.
     /// </param>
     /// <returns>This builder instance for fluent chaining.</returns>
-    /// <remarks>
-    /// <para>
-    /// The configure function provides access to the <see cref="Hex1bApp"/> instance
-    /// for external control (e.g., calling <c>RequestStop()</c> or <c>Invalidate()</c>),
-    /// and <see cref="Hex1bAppOptions"/> for setting theme and other options.
-    /// </para>
-    /// <para>
-    /// For simple cases where you don't need app capture or options, you can ignore them:
-    /// <c>.WithHex1bApp((app, options) => ctx => ctx.Text("Hello"))</c>
-    /// </para>
-    /// <para>
-    /// The <see cref="Hex1bAppOptions.WorkloadAdapter"/> and <see cref="Hex1bAppOptions.EnableMouse"/>
-    /// properties are managed by the builder. Use <see cref="WithMouse"/> to enable mouse support.
-    /// </para>
-    /// </remarks>
     /// <example>
-    /// <para>Simple usage:</para>
-    /// <code>
-    /// await using var terminal = Hex1bTerminal.CreateBuilder()
-    ///     .WithHex1bApp((app, options) => ctx => ctx.Text("Hello, World!"))
-    ///     .Build();
-    /// 
-    /// await terminal.RunAsync();
-    /// </code>
-    /// <para>With app capture and theming:</para>
     /// <code>
     /// Hex1bApp? capturedApp = null;
-    /// 
     /// await using var terminal = Hex1bTerminal.CreateBuilder()
-    ///     .WithHex1bApp((app, options) =>
-    ///     {
-    ///         capturedApp = app;
-    ///         options.Theme = MyCustomTheme;
-    ///         return ctx => ctx.Text("Hello");
-    ///     })
+    ///     .WithHex1bApp(
+    ///         options => options.FrameRateLimitMs = 16,
+    ///         app =>
+    ///         {
+    ///             capturedApp = app;
+    ///             return ctx => ctx.Text("Hello");
+    ///         })
     ///     .Build();
-    /// 
-    /// await terminal.RunAsync();
     /// </code>
     /// </example>
     public Hex1bTerminalBuilder WithHex1bApp(
-        Func<Hex1bApp, Hex1bAppOptions, Func<RootContext, Hex1bWidget>> configure)
+        Action<Hex1bAppOptions> configureOptions,
+        Func<Hex1bApp, Func<RootContext, Hex1bWidget>> configureApp)
     {
-        ArgumentNullException.ThrowIfNull(configure);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+        ArgumentNullException.ThrowIfNull(configureApp);
+        return WithHex1bAppCore(configureOptions, configureApp);
+    }
 
+    /// <summary>
+    /// Async counterpart of <see cref="WithHex1bApp(Action{Hex1bAppOptions}, Func{Hex1bApp, Func{RootContext, Hex1bWidget}})"/>.
+    /// </summary>
+    public Hex1bTerminalBuilder WithHex1bApp(
+        Action<Hex1bAppOptions> configureOptions,
+        Func<Hex1bApp, Func<RootContext, Task<Hex1bWidget>>> configureApp)
+    {
+        ArgumentNullException.ThrowIfNull(configureOptions);
+        ArgumentNullException.ThrowIfNull(configureApp);
+        return WithHex1bAppCoreAsync(configureOptions, configureApp);
+    }
+
+    private Hex1bTerminalBuilder WithHex1bAppCore(
+        Action<Hex1bAppOptions>? configureOptions,
+        Func<Hex1bApp, Func<RootContext, Hex1bWidget>> configureApp)
+    {
         SetWorkloadFactory(presentation =>
         {
-            // If presentation adapter is available, use it for live capabilities
-            // Otherwise fall back to static capabilities
             var workloadAdapter = presentation != null
                 ? new Hex1bAppWorkloadAdapter(presentation)
                 : new Hex1bAppWorkloadAdapter();
             workloadAdapter.DiagnosticTimingEnabled = _diagnosticsEnabled;
             var enableMouse = _enableMouse;
 
-            // Create options with managed properties already set
             var options = new Hex1bAppOptions
             {
                 WorkloadAdapter = workloadAdapter,
@@ -133,28 +198,24 @@ public sealed class Hex1bTerminalBuilder
                 Metrics = ResolveMetrics()
             };
 
-            // Apply user-supplied option configuration BEFORE constructing the
-            // Hex1bApp so settings like FrameRateLimitMs (which is captured
-            // into the AnimationTimer at construction time) actually take
-            // effect. The configure callback runs lazily on first build, so
-            // anything it mutates on options is read too late.
-            _appOptionsConfigurator?.Invoke(options);
+            // Apply user-supplied option configuration eagerly, BEFORE constructing
+            // the Hex1bApp, so settings the constructor snapshots (e.g.
+            // FrameRateLimitMs which the AnimationTimer captures) actually take
+            // effect.
+            configureOptions?.Invoke(options);
 
-            // Create the run callback - app is created here so user can capture it
             Func<CancellationToken, Task<int>> runCallback = async ct =>
             {
                 Hex1bApp? app = null;
                 Func<RootContext, Hex1bWidget>? widgetBuilder = null;
                 bool configureInvoked = false;
 
-                // Widget builder that wraps the user's builder
                 Func<RootContext, Hex1bWidget> wrappedBuilder = ctx =>
                 {
-                    // On first call, invoke configure to get the real builder
                     if (!configureInvoked)
                     {
                         configureInvoked = true;
-                        widgetBuilder = configure(app!, options);
+                        widgetBuilder = configureApp(app!);
                     }
                     return widgetBuilder!(ctx);
                 };
@@ -173,37 +234,18 @@ public sealed class Hex1bTerminalBuilder
         return this;
     }
 
-    /// <summary>
-    /// Configures the terminal to run a Hex1bApp with full control over options, app capture,
-    /// and async widget building.
-    /// </summary>
-    /// <param name="configure">
-    /// A configuration function that receives the <see cref="Hex1bApp"/> instance and 
-    /// <see cref="Hex1bAppOptions"/> for customization, and returns an async widget builder function.
-    /// </param>
-    /// <returns>This builder instance for fluent chaining.</returns>
-    /// <remarks>
-    /// <para>
-    /// This overload provides full control over the Hex1bApp configuration and allows
-    /// capturing the app instance for external control, with async widget building support.
-    /// </para>
-    /// </remarks>
-    public Hex1bTerminalBuilder WithHex1bApp(
-        Func<Hex1bApp, Hex1bAppOptions, Func<RootContext, Task<Hex1bWidget>>> configure)
+    private Hex1bTerminalBuilder WithHex1bAppCoreAsync(
+        Action<Hex1bAppOptions>? configureOptions,
+        Func<Hex1bApp, Func<RootContext, Task<Hex1bWidget>>> configureApp)
     {
-        ArgumentNullException.ThrowIfNull(configure);
-
         SetWorkloadFactory(presentation =>
         {
-            // If presentation adapter is available, use it for live capabilities
-            // Otherwise fall back to static capabilities
-            var workloadAdapter = presentation != null 
+            var workloadAdapter = presentation != null
                 ? new Hex1bAppWorkloadAdapter(presentation)
                 : new Hex1bAppWorkloadAdapter();
             workloadAdapter.DiagnosticTimingEnabled = _diagnosticsEnabled;
             var enableMouse = _enableMouse;
-            
-            // Create options with managed properties already set
+
             var options = new Hex1bAppOptions
             {
                 WorkloadAdapter = workloadAdapter,
@@ -211,9 +253,8 @@ public sealed class Hex1bTerminalBuilder
                 Metrics = ResolveMetrics()
             };
 
-            // Apply user-supplied option configuration BEFORE constructing
-            // the Hex1bApp (see comment on the sync overload).
-            _appOptionsConfigurator?.Invoke(options);
+            // See sync overload comment — eager option configuration.
+            configureOptions?.Invoke(options);
 
             Func<CancellationToken, Task<int>> runCallback = async ct =>
             {
@@ -226,7 +267,7 @@ public sealed class Hex1bTerminalBuilder
                     if (!configureInvoked)
                     {
                         configureInvoked = true;
-                        widgetBuilder = configure(app!, options);
+                        widgetBuilder = configureApp(app!);
                     }
                     return await widgetBuilder!(ctx);
                 };
@@ -769,57 +810,6 @@ public sealed class Hex1bTerminalBuilder
         return this;
     }
 
-    /// <summary>
-    /// Registers a callback that configures the <see cref="Hex1bAppOptions"/> used
-    /// when a subsequent call to <see cref="WithHex1bApp(Func{Hex1bApp, Hex1bAppOptions, Func{RootContext, Hex1bWidget}})"/>
-    /// (or its async overload) constructs the <see cref="Hex1bApp"/>.
-    /// </summary>
-    /// <param name="configure">Callback that mutates the options instance.</param>
-    /// <returns>This builder instance for fluent chaining.</returns>
-    /// <remarks>
-    /// <para>
-    /// Use this when you need to set options that are captured during
-    /// <c>Hex1bApp</c> construction — most notably
-    /// <see cref="Hex1bAppOptions.FrameRateLimitMs"/>, which is baked into the
-    /// internal animation timer at construction time. Settings made inside the
-    /// <c>WithHex1bApp</c> configure callback would otherwise be read too late.
-    /// </para>
-    /// <para>
-    /// Multiple calls compose: each callback is invoked in registration order
-    /// against the same options instance.
-    /// </para>
-    /// </remarks>
-    /// <example>
-    /// <code>
-    /// await using var terminal = Hex1bTerminal.CreateBuilder()
-    ///     .WithHex1bAppOptions(o =>
-    ///     {
-    ///         o.FrameRateLimitMs = 33;          // cap at ~30 fps
-    ///         o.EnableSurfacePooling = false;   // opt out of pooling
-    ///     })
-    ///     .WithHex1bApp((app, options) => ctx => ctx.Text("Hello"))
-    ///     .Build();
-    /// </code>
-    /// </example>
-    public Hex1bTerminalBuilder WithHex1bAppOptions(Action<Hex1bAppOptions> configure)
-    {
-        ArgumentNullException.ThrowIfNull(configure);
-        if (_appOptionsConfigurator is null)
-        {
-            _appOptionsConfigurator = configure;
-        }
-        else
-        {
-            var existing = _appOptionsConfigurator;
-            _appOptionsConfigurator = options =>
-            {
-                existing(options);
-                configure(options);
-            };
-        }
-        return this;
-    }
-
     // === Recording and Optimization ===
 
     /// <summary>
@@ -1122,7 +1112,7 @@ public sealed class Hex1bTerminalBuilder
     /// <code>
     /// await using var terminal = Hex1bTerminal.CreateBuilder()
     ///     .WithDiagnostics()
-    ///     .WithHex1bApp((app, options) => ctx => ctx.Text("Hello!"))
+    ///     .WithHex1bApp(ctx => ctx.Text("Hello!"))
     ///     .Build();
     /// 
     /// await terminal.RunAsync();

--- a/src/Hex1b/Hex1bTerminalBuilder.cs
+++ b/src/Hex1b/Hex1bTerminalBuilder.cs
@@ -53,6 +53,7 @@ public sealed class Hex1bTerminalBuilder
     private Action<ScrollbackRowEventArgs>? _scrollbackCallback;
     private Reflow.ITerminalReflowProvider? _reflowStrategy;
     private bool _reflowEnabled;
+    private Action<Hex1bAppOptions>? _appOptionsConfigurator;
 
     /// <summary>
     /// Creates a new terminal builder.
@@ -132,6 +133,13 @@ public sealed class Hex1bTerminalBuilder
                 Metrics = ResolveMetrics()
             };
 
+            // Apply user-supplied option configuration BEFORE constructing the
+            // Hex1bApp so settings like FrameRateLimitMs (which is captured
+            // into the AnimationTimer at construction time) actually take
+            // effect. The configure callback runs lazily on first build, so
+            // anything it mutates on options is read too late.
+            _appOptionsConfigurator?.Invoke(options);
+
             // Create the run callback - app is created here so user can capture it
             Func<CancellationToken, Task<int>> runCallback = async ct =>
             {
@@ -202,6 +210,10 @@ public sealed class Hex1bTerminalBuilder
                 EnableMouse = enableMouse,
                 Metrics = ResolveMetrics()
             };
+
+            // Apply user-supplied option configuration BEFORE constructing
+            // the Hex1bApp (see comment on the sync overload).
+            _appOptionsConfigurator?.Invoke(options);
 
             Func<CancellationToken, Task<int>> runCallback = async ct =>
             {
@@ -754,6 +766,57 @@ public sealed class Hex1bTerminalBuilder
     public Hex1bTerminalBuilder WithMouse(bool enable = true)
     {
         _enableMouse = enable;
+        return this;
+    }
+
+    /// <summary>
+    /// Registers a callback that configures the <see cref="Hex1bAppOptions"/> used
+    /// when a subsequent call to <see cref="WithHex1bApp(Func{Hex1bApp, Hex1bAppOptions, Func{RootContext, Hex1bWidget}})"/>
+    /// (or its async overload) constructs the <see cref="Hex1bApp"/>.
+    /// </summary>
+    /// <param name="configure">Callback that mutates the options instance.</param>
+    /// <returns>This builder instance for fluent chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// Use this when you need to set options that are captured during
+    /// <c>Hex1bApp</c> construction — most notably
+    /// <see cref="Hex1bAppOptions.FrameRateLimitMs"/>, which is baked into the
+    /// internal animation timer at construction time. Settings made inside the
+    /// <c>WithHex1bApp</c> configure callback would otherwise be read too late.
+    /// </para>
+    /// <para>
+    /// Multiple calls compose: each callback is invoked in registration order
+    /// against the same options instance.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// await using var terminal = Hex1bTerminal.CreateBuilder()
+    ///     .WithHex1bAppOptions(o =>
+    ///     {
+    ///         o.FrameRateLimitMs = 33;          // cap at ~30 fps
+    ///         o.EnableSurfacePooling = false;   // opt out of pooling
+    ///     })
+    ///     .WithHex1bApp((app, options) => ctx => ctx.Text("Hello"))
+    ///     .Build();
+    /// </code>
+    /// </example>
+    public Hex1bTerminalBuilder WithHex1bAppOptions(Action<Hex1bAppOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        if (_appOptionsConfigurator is null)
+        {
+            _appOptionsConfigurator = configure;
+        }
+        else
+        {
+            var existing = _appOptionsConfigurator;
+            _appOptionsConfigurator = options =>
+            {
+                existing(options);
+                configure(options);
+            };
+        }
         return this;
     }
 

--- a/src/Hex1b/Nodes/Hex1bNode.cs
+++ b/src/Hex1b/Nodes/Hex1bNode.cs
@@ -199,6 +199,15 @@ public abstract class Hex1bNode
     /// Returning <c>false</c> forces a cache miss for this subtree.
     /// </summary>
     internal Func<RenderCacheContext, bool>? CachePredicate { get; set; }
+
+    /// <summary>
+    /// A retained child surface that survives <see cref="InvalidateCache"/> so the
+    /// next render miss can reuse the same backing array instead of allocating a
+    /// fresh (often LOH-sized, 64-bytes-per-cell) surface every frame. Cleared
+    /// when the node's bounds change or the buffer dimensions otherwise no longer
+    /// match what the renderer needs.
+    /// </summary>
+    internal Surface? RenderBuffer { get; set; }
      
     /// <summary>
     /// When set to a non-default color, RenderChild will fill all transparent backgrounds
@@ -256,6 +265,11 @@ public abstract class Hex1bNode
     /// </summary>
     internal void InvalidateCache()
     {
+        // Retain the previously cached surface as a reusable render buffer so the
+        // next cache miss can render into it without allocating a fresh surface
+        // (which for any reasonably sized node lives on the LOH).
+        if (CachedSurface is not null)
+            RenderBuffer = CachedSurface;
         CachedSurface = null;
         CachedSubtreeRenderVersion = -1;
     }

--- a/src/Hex1b/Surfaces/Surface.cs
+++ b/src/Hex1b/Surfaces/Surface.cs
@@ -42,6 +42,19 @@ public sealed class Surface : ISurfaceSource
     private int _contentMinX;
     private int _contentMaxY = -1;
     private int _contentMinY;
+
+    // Latched flag indicating that at least one cell on this surface has a value
+    // that the fast diff path cannot safely ignore: wide/continuation cells,
+    // multi-codepoint graphemes, underline state, or tracked refs (sixel/kgp/hyperlink).
+    // When false, SurfaceComparer can use a slimmer per-cell equality that skips
+    // those checks entirely.
+    //
+    // The flag is intentionally permissive (latched-on-write, only reset by Clear/
+    // ClearAndReleaseTrackedObjects). A surface that briefly held complex content
+    // and then had it overwritten with simple content will keep the flag set until
+    // the next Clear — that just falls back to the slow path, never produces wrong
+    // diffs.
+    private bool _hasComplexContent;
     
     /// <summary>
     /// Gets the width of the surface in columns.
@@ -161,7 +174,9 @@ public sealed class Surface : ISurfaceSource
             // Track content bounding box
             if (value != SurfaceCells.Empty)
                 ExpandContentBounds(x, y);
-            
+
+            MarkComplexIfNeeded(value);
+
             _cells[index] = value;
         }
     }
@@ -222,7 +237,9 @@ public sealed class Surface : ISurfaceSource
             // Track content bounding box
             if (cell != SurfaceCells.Empty)
                 ExpandContentBounds(x, y);
-            
+
+            MarkComplexIfNeeded(cell);
+
             _cells[index] = cell;
             return true;
         }
@@ -246,6 +263,7 @@ public sealed class Surface : ISurfaceSource
         Array.Fill(_cells, SurfaceCells.Empty);
         _sixelCount = 0;
         _kgpCount = 0;
+        _hasComplexContent = false;
         ResetContentBounds();
     }
 
@@ -270,6 +288,7 @@ public sealed class Surface : ISurfaceSource
 
         _sixelCount = 0;
         _kgpCount = 0;
+        _hasComplexContent = false;
         ResetContentBounds();
     }
 
@@ -282,6 +301,7 @@ public sealed class Surface : ISurfaceSource
         Array.Fill(_cells, cell);
         _sixelCount = cell.HasSixel ? CellCount : 0;
         _kgpCount = cell.HasKgp ? CellCount : 0;
+        _hasComplexContent = IsCellComplex(cell);
         if (cell != SurfaceCells.Empty && Width > 0 && Height > 0)
             SetContentBoundsToFull();
         else
@@ -307,6 +327,9 @@ public sealed class Surface : ISurfaceSource
             ExpandContentBounds(startX, startY);
             ExpandContentBounds(endX - 1, endY - 1);
         }
+
+        if (startX < endX && startY < endY)
+            MarkComplexIfNeeded(cell);
 
         for (var y = startY; y < endY; y++)
         {
@@ -403,6 +426,7 @@ public sealed class Surface : ISurfaceSource
             var cell = new SurfaceCell(grapheme, foreground, background, attributes, graphemeWidth);
             if (startX < 0) startX = currentX;
             _cells[y * Width + currentX] = cell;
+            MarkComplexIfNeeded(cell);
             currentX++;
             columnsWritten++;
 
@@ -411,7 +435,9 @@ public sealed class Surface : ISurfaceSource
             {
                 if (currentX < Width)
                 {
-                    _cells[y * Width + currentX] = SurfaceCell.CreateContinuation(background);
+                    var continuation = SurfaceCell.CreateContinuation(background);
+                    _cells[y * Width + currentX] = continuation;
+                    MarkComplexIfNeeded(continuation);
                     currentX++;
                     columnsWritten++;
                 }
@@ -623,6 +649,7 @@ public sealed class Surface : ISurfaceSource
                     _kgpCount++;
 
                 _cells[index] = srcCell;
+                MarkComplexIfNeeded(srcCell);
                 ExpandContentBounds(destX, destY);
             }
         }
@@ -844,6 +871,44 @@ public sealed class Surface : ISurfaceSource
     /// (e.g., in async contexts). Use with caution - no bounds checking.
     /// </remarks>
     internal SurfaceCell[] CellsUnsafe => _cells;
+
+    /// <summary>
+    /// Gets whether this surface contains only cells that the diff fast path can
+    /// safely treat as 4-field (Character/Foreground/Background/Attributes) cells.
+    /// </summary>
+    /// <remarks>
+    /// False when at least one cell was written with a wide/continuation display width,
+    /// a multi-codepoint grapheme, an underline style/colour, or a tracked sixel/KGP/
+    /// hyperlink reference. The flag is permissive: once set it stays set until the
+    /// next <see cref="Clear()"/> or <see cref="ClearAndReleaseTrackedObjects"/>.
+    /// A false negative just falls back to the slow path; it can never produce a
+    /// wrong diff.
+    /// </remarks>
+    internal bool IsFastPathEligible => !_hasComplexContent;
+
+    /// <summary>
+    /// True if <paramref name="cell"/> has any property that the fast diff path
+    /// cannot ignore: a non-default display width, a multi-codepoint grapheme,
+    /// an underline style or colour, or any tracked reference.
+    /// </summary>
+    private static bool IsCellComplex(in SurfaceCell cell)
+    {
+        if (cell.DisplayWidth != 1) return true;
+        if (cell.UnderlineStyle != UnderlineStyle.None) return true;
+        if (cell.UnderlineColor.HasValue) return true;
+        if (cell.Sixel is not null) return true;
+        if (cell.Kgp is not null) return true;
+        if (cell.Hyperlink is not null) return true;
+        var character = cell.Character;
+        if (character is not null && character.Length > 1) return true;
+        return false;
+    }
+
+    private void MarkComplexIfNeeded(in SurfaceCell cell)
+    {
+        if (!_hasComplexContent && IsCellComplex(cell))
+            _hasComplexContent = true;
+    }
 
     private void ValidateBounds(int x, int y)
     {

--- a/src/Hex1b/Surfaces/Surface.cs
+++ b/src/Hex1b/Surfaces/Surface.cs
@@ -175,9 +175,7 @@ public sealed class Surface : ISurfaceSource
             if (value != SurfaceCells.Empty)
                 ExpandContentBounds(x, y);
 
-            MarkComplexIfNeeded(value);
-
-            _cells[index] = value;
+            SetCellInternal(index, value);
         }
     }
 
@@ -238,9 +236,7 @@ public sealed class Surface : ISurfaceSource
             if (cell != SurfaceCells.Empty)
                 ExpandContentBounds(x, y);
 
-            MarkComplexIfNeeded(cell);
-
-            _cells[index] = cell;
+            SetCellInternal(index, cell);
             return true;
         }
         return false;
@@ -328,6 +324,11 @@ public sealed class Surface : ISurfaceSource
             ExpandContentBounds(endX - 1, endY - 1);
         }
 
+        // Cell is loop-invariant, so we mark complexity once up-front
+        // rather than calling SetCellInternal per cell (which would
+        // re-check IsCellComplex on every iteration). The contract
+        // documented on SetCellInternal still holds because we mark
+        // before writing.
         if (startX < endX && startY < endY)
             MarkComplexIfNeeded(cell);
 
@@ -415,7 +416,7 @@ public sealed class Surface : ISurfaceSource
                 while (currentX < Width)
                 {
                     if (startX < 0) startX = currentX;
-                    _cells[y * Width + currentX] = new SurfaceCell(" ", foreground, background, attributes, 1);
+                    SetCellInternal(y * Width + currentX, new SurfaceCell(" ", foreground, background, attributes, 1));
                     currentX++;
                     columnsWritten++;
                 }
@@ -425,8 +426,7 @@ public sealed class Surface : ISurfaceSource
             // Write the primary cell
             var cell = new SurfaceCell(grapheme, foreground, background, attributes, graphemeWidth);
             if (startX < 0) startX = currentX;
-            _cells[y * Width + currentX] = cell;
-            MarkComplexIfNeeded(cell);
+            SetCellInternal(y * Width + currentX, cell);
             currentX++;
             columnsWritten++;
 
@@ -435,9 +435,7 @@ public sealed class Surface : ISurfaceSource
             {
                 if (currentX < Width)
                 {
-                    var continuation = SurfaceCell.CreateContinuation(background);
-                    _cells[y * Width + currentX] = continuation;
-                    MarkComplexIfNeeded(continuation);
+                    SetCellInternal(y * Width + currentX, SurfaceCell.CreateContinuation(background));
                     currentX++;
                     columnsWritten++;
                 }
@@ -468,7 +466,7 @@ public sealed class Surface : ISurfaceSource
         if (!IsInBounds(x, y))
             return false;
 
-        _cells[y * Width + x] = new SurfaceCell(character.ToString(), foreground, background, attributes, 1);
+        SetCellInternal(y * Width + x, new SurfaceCell(character.ToString(), foreground, background, attributes, 1));
         ExpandContentBounds(x, y);
         return true;
     }
@@ -487,11 +485,11 @@ public sealed class Surface : ISurfaceSource
             var cell = _cells[i];
             if (cell == SurfaceCells.Empty)
             {
-                _cells[i] = bgCell;
+                SetCellInternal(i, bgCell);
             }
             else if (cell.HasTransparentBackground)
             {
-                _cells[i] = cell with { Background = background };
+                SetCellInternal(i, cell with { Background = background });
             }
         }
         // After FillBackground, every cell has content (either rendered or bgCell)
@@ -526,11 +524,11 @@ public sealed class Surface : ISurfaceSource
                 var cell = _cells[i];
                 if (cell == SurfaceCells.Empty)
                 {
-                    _cells[i] = bgCell;
+                    SetCellInternal(i, bgCell);
                 }
                 else if (cell.HasTransparentBackground)
                 {
-                    _cells[i] = cell with { Background = background };
+                    SetCellInternal(i, cell with { Background = background });
                 }
             }
         }
@@ -648,8 +646,7 @@ public sealed class Surface : ISurfaceSource
                 else if (!oldCell.HasKgp && srcCell.HasKgp)
                     _kgpCount++;
 
-                _cells[index] = srcCell;
-                MarkComplexIfNeeded(srcCell);
+                SetCellInternal(index, srcCell);
                 ExpandContentBounds(destX, destY);
             }
         }
@@ -908,6 +905,26 @@ public sealed class Surface : ISurfaceSource
     {
         if (!_hasComplexContent && IsCellComplex(cell))
             _hasComplexContent = true;
+    }
+
+    /// <summary>
+    /// The single internal entry point for storing a <see cref="SurfaceCell"/> into the
+    /// backing array. Every direct <c>_cells[index] = cell</c> site MUST go through this
+    /// helper so that <see cref="_hasComplexContent"/> stays in sync with the cell data —
+    /// otherwise the diff fast path in <see cref="SurfaceComparer"/> can silently drop
+    /// underline / wide-cell / grapheme / tracked-ref changes.
+    /// </summary>
+    /// <remarks>
+    /// Bounds tracking, sixel/KGP refcount maintenance, and content-bounds expansion
+    /// remain the caller's responsibility — they are context-dependent (e.g. <c>Fill</c>
+    /// hoists them out of the loop). The complex-flag bookkeeping is the only invariant
+    /// this helper enforces, because forgetting it is a correctness escape valve rather
+    /// than a perf hit.
+    /// </remarks>
+    private void SetCellInternal(int index, in SurfaceCell cell)
+    {
+        MarkComplexIfNeeded(cell);
+        _cells[index] = cell;
     }
 
     private void ValidateBounds(int x, int y)

--- a/src/Hex1b/Surfaces/SurfaceComparer.cs
+++ b/src/Hex1b/Surfaces/SurfaceComparer.cs
@@ -81,7 +81,9 @@ public static class SurfaceComparer
             }
         }
 
-        dest.SortChanges();
+        // No SortChanges call: we add in row-major order (Y outer, X inner),
+        // which is exactly the order SortChanges produces. Skipping the sort
+        // saves an O(N log N) pass on every frame.
     }
 
     /// <summary>
@@ -133,7 +135,7 @@ public static class SurfaceComparer
             }
         }
 
-        dest.SortChanges();
+        // No SortChanges call: see CompareInto - same row-major add order.
     }
 
     /// <summary>
@@ -748,7 +750,9 @@ public static class SurfaceComparer
             !ColorsEqual(a.Foreground, b.Foreground) ||
             !ColorsEqual(a.Background, b.Background) ||
             a.Attributes != b.Attributes ||
-            a.DisplayWidth != b.DisplayWidth)
+            a.DisplayWidth != b.DisplayWidth ||
+            a.UnderlineStyle != b.UnderlineStyle ||
+            !ColorsEqual(a.UnderlineColor, b.UnderlineColor))
         {
             return false;
         }

--- a/src/Hex1b/Surfaces/SurfaceComparer.cs
+++ b/src/Hex1b/Surfaces/SurfaceComparer.cs
@@ -503,6 +503,11 @@ public static class SurfaceComparer
         bool stateUnknown = true;
         TrackedObject<HyperlinkData>? currentHyperlink = null;
 
+        // Reused across all changed cells; passed by ref to BuildSgrParametersBytes.
+        // SGR parameter strings cap out well below 96 bytes even with reset+attrs+RGB
+        // foreground+RGB background+RGB underline colour, e.g. "0;1;3;38;2;255;255;255;48;2;255;255;255;58;2;255;255;255" is 56 bytes.
+        Span<byte> sgrBuf = stackalloc byte[96];
+
         foreach (var change in diff.ChangedCells)
         {
             // Skip continuation cells - they're handled by the wide character before them
@@ -558,7 +563,8 @@ public static class SurfaceComparer
 
             if (needsSgr)
             {
-                var sgrBuilder = BuildSgrParameters(
+                var written = BuildSgrParametersBytes(
+                    sgrBuf,
                     change.Cell,
                     stateUnknown,
                     ref currentFg,
@@ -566,10 +572,10 @@ public static class SurfaceComparer
                     ref currentAttrs,
                     ref currentUnderlineStyle,
                     ref currentUnderlineColor);
-                
-                if (sgrBuilder.Length > 0)
+
+                if (written > 0)
                 {
-                    tokens.Add(AnsiTokenCache.GetSgrToken(sgrBuilder));
+                    tokens.Add(AnsiTokenCache.GetSgrTokenFromBytes(sgrBuf.Slice(0, written)));
                 }
                 stateUnknown = false;
             }
@@ -975,6 +981,172 @@ public static class SurfaceComparer
     private static void AppendSeparator(StringBuilder sb)
     {
         if (sb.Length > 0) sb.Append(';');
+    }
+
+    // -----------------------------------------------------------------------
+    // Fast byte-formatting SGR builder. Writes directly into a stackalloc'd
+    // Span<byte> via Utf8Formatter.TryFormat — bypasses StringBuilder rent +
+    // char Append + ToString + GetHashCode-over-chars + string-keyed dict
+    // lookup that the legacy BuildSgrParameters path goes through. The output
+    // span is fed to AnsiTokenCache.GetSgrTokenFromBytes which uses a
+    // byte-keyed cache and stores the wire-ready bytes on SgrToken for the
+    // serializer to memcpy.
+    //
+    // Mirror of BuildSgrParameters; keep the two in lockstep. Any new SGR
+    // emit case must be ported to both until BuildSgrParameters is retired.
+    // -----------------------------------------------------------------------
+    private static int BuildSgrParametersBytes(
+        Span<byte> dest,
+        SurfaceCell targetCell,
+        bool stateUnknown,
+        ref Hex1bColor? currentFg,
+        ref Hex1bColor? currentBg,
+        ref CellAttributes currentAttrs,
+        ref UnderlineStyle currentUnderlineStyle,
+        ref Hex1bColor? currentUnderlineColor)
+    {
+        int pos = 0;
+
+        var turnedOff = currentAttrs & ~targetCell.Attributes;
+        bool needsReset = stateUnknown ||
+                         turnedOff != CellAttributes.None ||
+                         (currentFg is not null && targetCell.Foreground is null) ||
+                         (currentBg is not null && targetCell.Background is null);
+
+        if (needsReset)
+        {
+            dest[pos++] = (byte)'0';
+            currentAttrs = CellAttributes.None;
+            currentFg = null;
+            currentBg = null;
+            currentUnderlineStyle = UnderlineStyle.None;
+            currentUnderlineColor = null;
+        }
+
+        var toTurnOn = targetCell.Attributes & ~currentAttrs;
+
+        if ((toTurnOn & CellAttributes.Bold) != 0) AppendPartBytes(dest, ref pos, "1"u8);
+        if ((toTurnOn & CellAttributes.Dim) != 0) AppendPartBytes(dest, ref pos, "2"u8);
+        if ((toTurnOn & CellAttributes.Italic) != 0) AppendPartBytes(dest, ref pos, "3"u8);
+        if ((toTurnOn & CellAttributes.Underline) != 0)
+        {
+            AppendPartBytes(dest, ref pos, UnderlineSgrCodeBytes(targetCell.UnderlineStyle));
+        }
+        else if ((currentAttrs & CellAttributes.Underline) != 0 &&
+                 (targetCell.Attributes & CellAttributes.Underline) != 0 &&
+                 targetCell.UnderlineStyle != currentUnderlineStyle)
+        {
+            AppendPartBytes(dest, ref pos, UnderlineSgrCodeBytes(targetCell.UnderlineStyle));
+        }
+        if ((toTurnOn & CellAttributes.Blink) != 0) AppendPartBytes(dest, ref pos, "5"u8);
+        if ((toTurnOn & CellAttributes.Reverse) != 0) AppendPartBytes(dest, ref pos, "7"u8);
+        if ((toTurnOn & CellAttributes.Hidden) != 0) AppendPartBytes(dest, ref pos, "8"u8);
+        if ((toTurnOn & CellAttributes.Strikethrough) != 0) AppendPartBytes(dest, ref pos, "9"u8);
+        if ((toTurnOn & CellAttributes.Overline) != 0) AppendPartBytes(dest, ref pos, "53"u8);
+
+        if (!ColorsEqual(targetCell.Foreground, currentFg) && targetCell.Foreground is not null)
+        {
+            AppendSeparatorByte(dest, ref pos);
+            AppendColorSgrBytes(dest, ref pos, targetCell.Foreground.Value, isForeground: true);
+        }
+
+        if (!ColorsEqual(targetCell.Background, currentBg) && targetCell.Background is not null)
+        {
+            AppendSeparatorByte(dest, ref pos);
+            AppendColorSgrBytes(dest, ref pos, targetCell.Background.Value, isForeground: false);
+        }
+
+        if (!ColorsEqual(targetCell.UnderlineColor, currentUnderlineColor))
+        {
+            if (targetCell.UnderlineColor is not null)
+            {
+                var ulc = targetCell.UnderlineColor.Value;
+                AppendSeparatorByte(dest, ref pos);
+                AppendBytes(dest, ref pos, "58;2;"u8);
+                AppendByteAsAscii(dest, ref pos, ulc.R);
+                dest[pos++] = (byte)';';
+                AppendByteAsAscii(dest, ref pos, ulc.G);
+                dest[pos++] = (byte)';';
+                AppendByteAsAscii(dest, ref pos, ulc.B);
+            }
+            else if (currentUnderlineColor is not null)
+            {
+                AppendPartBytes(dest, ref pos, "59"u8);
+            }
+        }
+
+        currentAttrs = targetCell.Attributes;
+        currentFg = targetCell.Foreground;
+        currentBg = targetCell.Background;
+        currentUnderlineStyle = targetCell.UnderlineStyle;
+        currentUnderlineColor = targetCell.UnderlineColor;
+
+        return pos;
+    }
+
+    private static void AppendPartBytes(Span<byte> dest, ref int pos, ReadOnlySpan<byte> part)
+    {
+        AppendSeparatorByte(dest, ref pos);
+        AppendBytes(dest, ref pos, part);
+    }
+
+    private static void AppendSeparatorByte(Span<byte> dest, ref int pos)
+    {
+        if (pos > 0) dest[pos++] = (byte)';';
+    }
+
+    private static void AppendBytes(Span<byte> dest, ref int pos, ReadOnlySpan<byte> src)
+    {
+        src.CopyTo(dest.Slice(pos));
+        pos += src.Length;
+    }
+
+    private static void AppendIntAsAscii(Span<byte> dest, ref int pos, int value)
+    {
+        if (!System.Buffers.Text.Utf8Formatter.TryFormat(value, dest.Slice(pos), out var written))
+            throw new InvalidOperationException("SGR int formatting buffer overflow.");
+        pos += written;
+    }
+
+    private static void AppendByteAsAscii(Span<byte> dest, ref int pos, byte value)
+    {
+        if (!System.Buffers.Text.Utf8Formatter.TryFormat(value, dest.Slice(pos), out var written))
+            throw new InvalidOperationException("SGR byte formatting buffer overflow.");
+        pos += written;
+    }
+
+    private static ReadOnlySpan<byte> UnderlineSgrCodeBytes(UnderlineStyle style) => style switch
+    {
+        UnderlineStyle.Double => "21"u8,
+        UnderlineStyle.Curly => "4:3"u8,
+        UnderlineStyle.Dotted => "4:4"u8,
+        UnderlineStyle.Dashed => "4:5"u8,
+        _ => "4"u8,
+    };
+
+    private static void AppendColorSgrBytes(Span<byte> dest, ref int pos, Hex1bColor color, bool isForeground)
+    {
+        switch (color.Kind)
+        {
+            case Hex1bColorKind.Standard:
+                AppendIntAsAscii(dest, ref pos, isForeground ? 30 + color.AnsiIndex : 40 + color.AnsiIndex);
+                break;
+            case Hex1bColorKind.Bright:
+                AppendIntAsAscii(dest, ref pos, isForeground ? 90 + color.AnsiIndex : 100 + color.AnsiIndex);
+                break;
+            case Hex1bColorKind.Indexed:
+                AppendBytes(dest, ref pos, isForeground ? "38;5;"u8 : "48;5;"u8);
+                AppendByteAsAscii(dest, ref pos, color.AnsiIndex);
+                break;
+            default:
+                AppendBytes(dest, ref pos, isForeground ? "38;2;"u8 : "48;2;"u8);
+                AppendByteAsAscii(dest, ref pos, color.R);
+                dest[pos++] = (byte)';';
+                AppendByteAsAscii(dest, ref pos, color.G);
+                dest[pos++] = (byte)';';
+                AppendByteAsAscii(dest, ref pos, color.B);
+                break;
+        }
     }
 
     private static string UnderlineSgrCode(UnderlineStyle style) => style switch

--- a/src/Hex1b/Surfaces/SurfaceComparer.cs
+++ b/src/Hex1b/Surfaces/SurfaceComparer.cs
@@ -30,9 +30,28 @@ public static class SurfaceComparer
         ArgumentNullException.ThrowIfNull(previous);
         ArgumentNullException.ThrowIfNull(current);
 
+        var diff = new SurfaceDiff();
+        CompareInto(previous, current, diff);
+        return diff;
+    }
+
+    /// <summary>
+    /// Reusable variant of <see cref="Compare(Surface, Surface)"/> that populates the
+    /// supplied <see cref="SurfaceDiff"/> in place. The renderer hot path uses this to
+    /// avoid allocating a fresh diff and backing list every frame.
+    /// </summary>
+    internal static void CompareInto(Surface previous, Surface current, SurfaceDiff dest)
+    {
+        ArgumentNullException.ThrowIfNull(previous);
+        ArgumentNullException.ThrowIfNull(current);
+        ArgumentNullException.ThrowIfNull(dest);
+
+        var changed = dest.MutableCells;
+        changed.Clear();
+
         // Fast path: same instance means no changes
         if (ReferenceEquals(previous, current))
-            return SurfaceDiff.Empty;
+            return;
 
         if (previous.Width != current.Width || previous.Height != current.Height)
         {
@@ -44,8 +63,6 @@ public static class SurfaceComparer
         var height = current.Height;
         var prevCells = previous.CellsUnsafe;
         var currCells = current.CellsUnsafe;
-        
-        var changedCells = new List<ChangedCell>();
 
         for (var y = 0; y < height; y++)
         {
@@ -58,12 +75,12 @@ public static class SurfaceComparer
 
                 if (!CellsEqual(prevCell, currCell))
                 {
-                    changedCells.Add(new ChangedCell(x, y, currCell));
+                    changed.Add(new ChangedCell(x, y, currCell));
                 }
             }
         }
 
-        return new SurfaceDiff(changedCells);
+        dest.SortChanges();
     }
 
     /// <summary>
@@ -79,12 +96,27 @@ public static class SurfaceComparer
     {
         ArgumentNullException.ThrowIfNull(surface);
 
+        var diff = new SurfaceDiff();
+        CompareToEmptyInto(surface, diff);
+        return diff;
+    }
+
+    /// <summary>
+    /// Reusable variant of <see cref="CompareToEmpty(Surface)"/> that populates the
+    /// supplied <see cref="SurfaceDiff"/> in place.
+    /// </summary>
+    internal static void CompareToEmptyInto(Surface surface, SurfaceDiff dest)
+    {
+        ArgumentNullException.ThrowIfNull(surface);
+        ArgumentNullException.ThrowIfNull(dest);
+
+        var changed = dest.MutableCells;
+        changed.Clear();
+
         var width = surface.Width;
         var height = surface.Height;
         var cells = surface.CellsUnsafe;
         var empty = SurfaceCells.Empty;
-        
-        var changedCells = new List<ChangedCell>();
 
         for (var y = 0; y < height; y++)
         {
@@ -95,12 +127,12 @@ public static class SurfaceComparer
 
                 if (!CellsEqual(cell, empty))
                 {
-                    changedCells.Add(new ChangedCell(x, y, cell));
+                    changed.Add(new ChangedCell(x, y, cell));
                 }
             }
         }
 
-        return new SurfaceDiff(changedCells);
+        dest.SortChanges();
     }
 
     /// <summary>
@@ -145,11 +177,29 @@ public static class SurfaceComparer
     public static IReadOnlyList<AnsiToken> ToTokens(SurfaceDiff diff, Surface? currentSurface, Surface? previousSurface, bool skipKgpEmission = false)
     {
         ArgumentNullException.ThrowIfNull(diff);
+        if (diff.IsEmpty) return Array.Empty<AnsiToken>();
 
-        if (diff.IsEmpty)
-            return Array.Empty<AnsiToken>();
+        var output = new List<AnsiToken>();
+        ToTokensInto(diff, currentSurface, previousSurface, skipKgpEmission, output);
+        return output.Count == 0 ? Array.Empty<AnsiToken>() : output;
+    }
 
-        var tokens = new List<AnsiToken>();
+    /// <summary>
+    /// Reusable variant of <see cref="ToTokens(SurfaceDiff, Surface?, Surface?, bool)"/> that
+    /// appends to the supplied <paramref name="output"/> list. The renderer hot path uses
+    /// this with a list it owns across frames to avoid per-frame token-list allocations.
+    /// The list is cleared before population.
+    /// </summary>
+    internal static void ToTokensInto(SurfaceDiff diff, Surface? currentSurface, Surface? previousSurface, bool skipKgpEmission, List<AnsiToken> output)
+    {
+        ArgumentNullException.ThrowIfNull(diff);
+        ArgumentNullException.ThrowIfNull(output);
+
+        output.Clear();
+
+        if (diff.IsEmpty) return;
+
+        var tokens = output;
         
         // Emit KGP delete commands for images that were in the previous surface but have
         // moved or been removed. KGP placements persist in the terminal until explicitly
@@ -567,8 +617,6 @@ public static class SurfaceComparer
                 EmitKgpTokens(tokens, data);
             }
         }
-
-        return tokens;
     }
     
     /// <summary>

--- a/src/Hex1b/Surfaces/SurfaceComparer.cs
+++ b/src/Hex1b/Surfaces/SurfaceComparer.cs
@@ -1,5 +1,6 @@
 using Hex1b.Theming;
 using Hex1b.Tokens;
+using System.Text;
 
 namespace Hex1b.Surfaces;
 
@@ -509,7 +510,7 @@ public static class SurfaceComparer
 
             if (needsSgr)
             {
-                var sgrParams = BuildSgrParameters(
+                var sgrBuilder = BuildSgrParameters(
                     change.Cell,
                     stateUnknown,
                     ref currentFg,
@@ -518,9 +519,9 @@ public static class SurfaceComparer
                     ref currentUnderlineStyle,
                     ref currentUnderlineColor);
                 
-                if (!string.IsNullOrEmpty(sgrParams))
+                if (sgrBuilder.Length > 0)
                 {
-                    tokens.Add(new SgrToken(sgrParams));
+                    tokens.Add(AnsiTokenCache.GetSgrToken(sgrBuilder));
                 }
                 stateUnknown = false;
             }
@@ -595,7 +596,7 @@ public static class SurfaceComparer
                 ? " " 
                 : change.Cell.Character;
             
-            tokens.Add(new TextToken(charToOutput));
+            tokens.Add(AnsiTokenCache.GetTextToken(charToOutput));
             
             // Cursor advances by display width
             cursorX += Math.Max(1, change.Cell.DisplayWidth);
@@ -802,7 +803,7 @@ public static class SurfaceComparer
                a.Value.AnsiIndex == b.Value.AnsiIndex;
     }
 
-    private static string BuildSgrParameters(
+    private static StringBuilder BuildSgrParameters(
         SurfaceCell targetCell,
         bool stateUnknown,
         ref Hex1bColor? currentFg,
@@ -811,7 +812,7 @@ public static class SurfaceComparer
         ref UnderlineStyle currentUnderlineStyle,
         ref Hex1bColor? currentUnderlineColor)
     {
-        var parts = new List<string>();
+        var sb = AnsiTokenCache.GetSgrBuilder();
 
         // Check if we need a reset first
         // Reset if: state is unknown, OR turning OFF any attributes, OR clearing colors
@@ -823,7 +824,7 @@ public static class SurfaceComparer
 
         if (needsReset)
         {
-            parts.Add("0"); // Reset to defaults
+            sb.Append('0'); // Reset to defaults
             currentAttrs = CellAttributes.None;
             currentFg = null;
             currentBg = null;
@@ -835,60 +836,45 @@ public static class SurfaceComparer
         var toTurnOn = targetCell.Attributes & ~currentAttrs;
 
         if ((toTurnOn & CellAttributes.Bold) != 0)
-            parts.Add("1");
+            AppendPart(sb, "1");
         if ((toTurnOn & CellAttributes.Dim) != 0)
-            parts.Add("2");
+            AppendPart(sb, "2");
         if ((toTurnOn & CellAttributes.Italic) != 0)
-            parts.Add("3");
+            AppendPart(sb, "3");
         if ((toTurnOn & CellAttributes.Underline) != 0)
         {
-            // Emit styled underline using colon sub-parameter syntax
-            var style = targetCell.UnderlineStyle;
-            parts.Add(style switch
-            {
-                UnderlineStyle.Double => "21",
-                UnderlineStyle.Curly => "4:3",
-                UnderlineStyle.Dotted => "4:4",
-                UnderlineStyle.Dashed => "4:5",
-                _ => "4", // Single or default
-            });
+            AppendPart(sb, UnderlineSgrCode(targetCell.UnderlineStyle));
         }
         else if ((currentAttrs & CellAttributes.Underline) != 0 &&
                  (targetCell.Attributes & CellAttributes.Underline) != 0 &&
                  targetCell.UnderlineStyle != currentUnderlineStyle)
         {
             // Underline is already on but style changed — re-emit with new style
-            var style = targetCell.UnderlineStyle;
-            parts.Add(style switch
-            {
-                UnderlineStyle.Double => "21",
-                UnderlineStyle.Curly => "4:3",
-                UnderlineStyle.Dotted => "4:4",
-                UnderlineStyle.Dashed => "4:5",
-                _ => "4",
-            });
+            AppendPart(sb, UnderlineSgrCode(targetCell.UnderlineStyle));
         }
         if ((toTurnOn & CellAttributes.Blink) != 0)
-            parts.Add("5");
+            AppendPart(sb, "5");
         if ((toTurnOn & CellAttributes.Reverse) != 0)
-            parts.Add("7");
+            AppendPart(sb, "7");
         if ((toTurnOn & CellAttributes.Hidden) != 0)
-            parts.Add("8");
+            AppendPart(sb, "8");
         if ((toTurnOn & CellAttributes.Strikethrough) != 0)
-            parts.Add("9");
+            AppendPart(sb, "9");
         if ((toTurnOn & CellAttributes.Overline) != 0)
-            parts.Add("53");
+            AppendPart(sb, "53");
 
         // Add foreground color if different
         if (!ColorsEqual(targetCell.Foreground, currentFg) && targetCell.Foreground is not null)
         {
-            parts.Add(BuildColorSgr(targetCell.Foreground.Value, isForeground: true));
+            AppendSeparator(sb);
+            AppendColorSgr(sb, targetCell.Foreground.Value, isForeground: true);
         }
 
         // Add background color if different
         if (!ColorsEqual(targetCell.Background, currentBg) && targetCell.Background is not null)
         {
-            parts.Add(BuildColorSgr(targetCell.Background.Value, isForeground: false));
+            AppendSeparator(sb);
+            AppendColorSgr(sb, targetCell.Background.Value, isForeground: false);
         }
 
         // Underline color (SGR 58;2;R;G;B)
@@ -897,11 +883,12 @@ public static class SurfaceComparer
             if (targetCell.UnderlineColor is not null)
             {
                 var ulc = targetCell.UnderlineColor.Value;
-                parts.Add($"58;2;{ulc.R};{ulc.G};{ulc.B}");
+                AppendSeparator(sb);
+                sb.Append("58;2;").Append(ulc.R).Append(';').Append(ulc.G).Append(';').Append(ulc.B);
             }
             else if (currentUnderlineColor is not null)
             {
-                parts.Add("59"); // Default underline color
+                AppendPart(sb, "59"); // Default underline color
             }
         }
 
@@ -912,18 +899,54 @@ public static class SurfaceComparer
         currentUnderlineStyle = targetCell.UnderlineStyle;
         currentUnderlineColor = targetCell.UnderlineColor;
 
-        return string.Join(";", parts);
+        return sb;
+    }
+
+    private static void AppendPart(StringBuilder sb, string part)
+    {
+        AppendSeparator(sb);
+        sb.Append(part);
+    }
+
+    private static void AppendSeparator(StringBuilder sb)
+    {
+        if (sb.Length > 0) sb.Append(';');
+    }
+
+    private static string UnderlineSgrCode(UnderlineStyle style) => style switch
+    {
+        UnderlineStyle.Double => "21",
+        UnderlineStyle.Curly => "4:3",
+        UnderlineStyle.Dotted => "4:4",
+        UnderlineStyle.Dashed => "4:5",
+        _ => "4",
+    };
+
+    private static void AppendColorSgr(StringBuilder sb, Hex1bColor color, bool isForeground)
+    {
+        switch (color.Kind)
+        {
+            case Hex1bColorKind.Standard:
+                sb.Append(isForeground ? 30 + color.AnsiIndex : 40 + color.AnsiIndex);
+                break;
+            case Hex1bColorKind.Bright:
+                sb.Append(isForeground ? 90 + color.AnsiIndex : 100 + color.AnsiIndex);
+                break;
+            case Hex1bColorKind.Indexed:
+                sb.Append(isForeground ? "38;5;" : "48;5;").Append(color.AnsiIndex);
+                break;
+            default:
+                sb.Append(isForeground ? "38;2;" : "48;2;")
+                  .Append(color.R).Append(';').Append(color.G).Append(';').Append(color.B);
+                break;
+        }
     }
 
     private static string BuildColorSgr(Hex1bColor color, bool isForeground)
     {
-        return color.Kind switch
-        {
-            Hex1bColorKind.Standard => (isForeground ? 30 + color.AnsiIndex : 40 + color.AnsiIndex).ToString(),
-            Hex1bColorKind.Bright => (isForeground ? 90 + color.AnsiIndex : 100 + color.AnsiIndex).ToString(),
-            Hex1bColorKind.Indexed => $"{(isForeground ? "38;5" : "48;5")};{color.AnsiIndex}",
-            _ => $"{(isForeground ? "38;2" : "48;2")};{color.R};{color.G};{color.B}"
-        };
+        var sb = new StringBuilder(16);
+        AppendColorSgr(sb, color, isForeground);
+        return sb.ToString();
     }
 
     #endregion

--- a/src/Hex1b/Surfaces/SurfaceComparer.cs
+++ b/src/Hex1b/Surfaces/SurfaceComparer.cs
@@ -65,6 +65,31 @@ public static class SurfaceComparer
         var prevCells = previous.CellsUnsafe;
         var currCells = current.CellsUnsafe;
 
+        // Fast path: when neither surface contains wide cells, underline state,
+        // multi-codepoint graphemes, or tracked refs (sixel/kgp/hyperlink), we can
+        // skip the per-cell branches for those fields entirely. This is a 4-field
+        // compare instead of ~10, and the helper is small enough to inline.
+        if (previous.IsFastPathEligible && current.IsFastPathEligible)
+        {
+            for (var y = 0; y < height; y++)
+            {
+                var rowOffset = y * width;
+                for (var x = 0; x < width; x++)
+                {
+                    var index = rowOffset + x;
+                    ref readonly var prevCell = ref prevCells[index];
+                    ref readonly var currCell = ref currCells[index];
+
+                    if (!CellsEqualFast(in prevCell, in currCell))
+                    {
+                        changed.Add(new ChangedCell(x, y, currCell));
+                    }
+                }
+            }
+
+            return;
+        }
+
         for (var y = 0; y < height; y++)
         {
             var rowOffset = y * width;
@@ -120,6 +145,27 @@ public static class SurfaceComparer
         var height = surface.Height;
         var cells = surface.CellsUnsafe;
         var empty = SurfaceCells.Empty;
+
+        // Fast path: see CompareInto. Empty is itself a "simple" cell, so when the
+        // surface is fast-eligible we can compare against it with the 4-field equal.
+        if (surface.IsFastPathEligible)
+        {
+            for (var y = 0; y < height; y++)
+            {
+                var rowOffset = y * width;
+                for (var x = 0; x < width; x++)
+                {
+                    ref readonly var cell = ref cells[rowOffset + x];
+
+                    if (!CellsEqualFast(in cell, in empty))
+                    {
+                        changed.Add(new ChangedCell(x, y, cell));
+                    }
+                }
+            }
+
+            return;
+        }
 
         for (var y = 0; y < height; y++)
         {
@@ -742,6 +788,20 @@ public static class SurfaceComparer
     }
 
     #region Private Helpers
+
+    /// <summary>
+    /// Slim 4-field equality used by the fast diff path. Only safe to call when
+    /// both cells are known not to carry tracked refs, underline state, multi-
+    /// codepoint graphemes, or a non-default display width — i.e. when both
+    /// owning surfaces report <see cref="Surface.IsFastPathEligible"/>.
+    /// </summary>
+    private static bool CellsEqualFast(in SurfaceCell a, in SurfaceCell b)
+    {
+        return a.Character == b.Character
+            && a.Attributes == b.Attributes
+            && ColorsEqual(a.Foreground, b.Foreground)
+            && ColorsEqual(a.Background, b.Background);
+    }
 
     private static bool CellsEqual(SurfaceCell a, SurfaceCell b)
     {

--- a/src/Hex1b/Surfaces/SurfaceComparer.cs
+++ b/src/Hex1b/Surfaces/SurfaceComparer.cs
@@ -41,7 +41,13 @@ public static class SurfaceComparer
     /// supplied <see cref="SurfaceDiff"/> in place. The renderer hot path uses this to
     /// avoid allocating a fresh diff and backing list every frame.
     /// </summary>
-    internal static void CompareInto(Surface previous, Surface current, SurfaceDiff dest)
+    /// <returns>
+    /// <see langword="true"/> if the simple 4-field fast path was used (both surfaces report
+    /// <see cref="Surface.IsFastPathEligible"/>), otherwise <see langword="false"/> for the
+    /// full per-cell slow path. Used by the renderer to record fast/slow-path engagement
+    /// metrics.
+    /// </returns>
+    internal static bool CompareInto(Surface previous, Surface current, SurfaceDiff dest)
     {
         ArgumentNullException.ThrowIfNull(previous);
         ArgumentNullException.ThrowIfNull(current);
@@ -52,7 +58,7 @@ public static class SurfaceComparer
 
         // Fast path: same instance means no changes
         if (ReferenceEquals(previous, current))
-            return;
+            return true;
 
         if (previous.Width != current.Width || previous.Height != current.Height)
         {
@@ -87,7 +93,7 @@ public static class SurfaceComparer
                 }
             }
 
-            return;
+            return true;
         }
 
         for (var y = 0; y < height; y++)
@@ -109,6 +115,7 @@ public static class SurfaceComparer
         // No SortChanges call: we add in row-major order (Y outer, X inner),
         // which is exactly the order SortChanges produces. Skipping the sort
         // saves an O(N log N) pass on every frame.
+        return false;
     }
 
     /// <summary>
@@ -133,7 +140,11 @@ public static class SurfaceComparer
     /// Reusable variant of <see cref="CompareToEmpty(Surface)"/> that populates the
     /// supplied <see cref="SurfaceDiff"/> in place.
     /// </summary>
-    internal static void CompareToEmptyInto(Surface surface, SurfaceDiff dest)
+    /// <returns>
+    /// <see langword="true"/> when the simple 4-field fast path was used (the surface
+    /// is <see cref="Surface.IsFastPathEligible"/>); otherwise <see langword="false"/>.
+    /// </returns>
+    internal static bool CompareToEmptyInto(Surface surface, SurfaceDiff dest)
     {
         ArgumentNullException.ThrowIfNull(surface);
         ArgumentNullException.ThrowIfNull(dest);
@@ -164,7 +175,7 @@ public static class SurfaceComparer
                 }
             }
 
-            return;
+            return true;
         }
 
         for (var y = 0; y < height; y++)
@@ -182,6 +193,7 @@ public static class SurfaceComparer
         }
 
         // No SortChanges call: see CompareInto - same row-major add order.
+        return false;
     }
 
     /// <summary>

--- a/src/Hex1b/Surfaces/SurfaceDiff.cs
+++ b/src/Hex1b/Surfaces/SurfaceDiff.cs
@@ -40,9 +40,34 @@ public sealed class SurfaceDiff
     internal SurfaceDiff(List<ChangedCell> changedCells)
     {
         _changedCells = changedCells;
-        
-        // Sort by Y, then X for optimal cursor movement
-        _changedCells.Sort((a, b) =>
+        SortChanges();
+    }
+
+    /// <summary>
+    /// Creates an empty, reusable diff. Used by the renderer hot path with
+    /// <see cref="MutableCells"/> + <see cref="SortChanges"/> to avoid allocating a
+    /// fresh diff per frame.
+    /// </summary>
+    internal SurfaceDiff()
+    {
+        _changedCells = new List<ChangedCell>();
+    }
+
+    /// <summary>
+    /// Mutable access to the backing list for the renderer's reusable diff. After
+    /// mutation, the caller must invoke <see cref="SortChanges"/> to restore the
+    /// row-major ordering contract.
+    /// </summary>
+    internal List<ChangedCell> MutableCells => _changedCells;
+
+    /// <summary>
+    /// Sorts the backing list into row-major order (Y, then X). The comparer used is a
+    /// static, capture-free lambda, so the JIT caches it and no delegate is allocated
+    /// per call.
+    /// </summary>
+    internal void SortChanges()
+    {
+        _changedCells.Sort(static (a, b) =>
         {
             var yCompare = a.Y.CompareTo(b.Y);
             return yCompare != 0 ? yCompare : a.X.CompareTo(b.X);

--- a/src/Hex1b/Surfaces/SurfaceRenderContext.cs
+++ b/src/Hex1b/Surfaces/SurfaceRenderContext.cs
@@ -795,7 +795,35 @@ public class SurfaceRenderContext : Hex1bRenderContext
             // Clamp dimensions to prevent overflow with unconstrained children
             var clampedWidth = Math.Min(child.Bounds.Width, MaxSurfaceDimension);
             var clampedHeight = Math.Min(child.Bounds.Height, MaxSurfaceDimension);
-            var childSurface = new Surface(clampedWidth, clampedHeight, CellMetrics);
+
+            // Reuse the previously cached buffer in place when its dimensions still match.
+            // CachedSurface for non-trivial sizes lands on the Large Object Heap (~64
+            // bytes/cell), so reallocating per cache miss produces a steady stream of
+            // Gen2 garbage. Only fall back to a fresh allocation (or pool rent) when
+            // the buffer is missing or differently sized.
+            Surface childSurface;
+            var existingBuffer = child.CachedSurface ?? child.RenderBuffer;
+            if (existingBuffer is not null
+                && existingBuffer.Width == clampedWidth
+                && existingBuffer.Height == clampedHeight
+                && existingBuffer.CellMetrics == CellMetrics)
+            {
+                childSurface = existingBuffer;
+                childSurface.ClearAndReleaseTrackedObjects();
+                child.RenderBuffer = null;
+            }
+            else
+            {
+                var pool = SurfacePool;
+                // The retained buffer no longer fits — surrender it to the pool
+                // (or let GC collect it) before allocating a new one.
+                if (pool != null && child.RenderBuffer is { } retired)
+                    pool.Return(retired);
+                child.RenderBuffer = null;
+                childSurface = pool != null
+                    ? pool.Rent(clampedWidth, clampedHeight, CellMetrics)
+                    : new Surface(clampedWidth, clampedHeight, CellMetrics);
+            }
             var subtreeVersionBeforeRender = child.SubtreeRenderVersion;
             
             // Create context with offset so child's absolute coordinates map to surface (0,0)

--- a/src/Hex1b/Surfaces/SurfaceRenderContext.cs
+++ b/src/Hex1b/Surfaces/SurfaceRenderContext.cs
@@ -838,6 +838,7 @@ public class SurfaceRenderContext : Hex1bRenderContext
                 MouseY = MouseY,
                 CellMetrics = CellMetrics,  // Propagate cell metrics for sixel sizing
                 Metrics = Metrics,
+                SurfacePool = SurfacePool, // Propagate the pool so descendants (EffectPanel temp surfaces, nested RenderChild surfaces) reuse buffers instead of falling back to `new Surface`.
                 _capabilities = _capabilities,
                 _kgpRegistry = _kgpRegistry,
                 _kgpLayer = _kgpLayer,

--- a/src/Hex1b/Tokens/AnsiTokenCache.cs
+++ b/src/Hex1b/Tokens/AnsiTokenCache.cs
@@ -1,0 +1,136 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Hex1b.Tokens;
+
+/// <summary>
+/// Internal pool of frequently-emitted token instances so the renderer hot path
+/// can reuse <see cref="SgrToken"/> / <see cref="TextToken"/> values instead of
+/// allocating a fresh record per cell every frame.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Tokens are <see langword="public sealed record"/> types with value-based equality
+/// and no mutable state, so two callers receiving the same cached instance behave
+/// identically to two callers receiving distinct equal instances. The caches are
+/// bounded to avoid unbounded growth from pathological workloads; on overflow the
+/// fallback path simply allocates a fresh record.
+/// </para>
+/// <para>
+/// The SGR cache is keyed by a hash of the assembled <see cref="StringBuilder"/>
+/// contents with a span-vs-string equality verification on lookup, so cache hits
+/// never materialise the SGR text into a heap string. <c>GetAlternateLookup</c>
+/// would be a cleaner API but is .NET 9+ only and this lib targets net8.0.
+/// </para>
+/// <para>
+/// Per-thread state (<see cref="ThreadStaticAttribute">thread-static</see>) avoids
+/// lock contention when multiple Hex1bApp instances render concurrently in tests.
+/// </para>
+/// </remarks>
+internal static class AnsiTokenCache
+{
+    [ThreadStatic] private static StringBuilder? t_sgrBuilder;
+    [ThreadStatic] private static Dictionary<ulong, SgrEntry>? t_sgrCache;
+
+    private static readonly ConcurrentDictionary<string, TextToken> s_textCache = new();
+
+    private const int MaxSgrCache = 4096;
+    private const int MaxTextCache = 2048;
+
+    private readonly struct SgrEntry
+    {
+        public readonly string Parameters;
+        public readonly SgrToken Token;
+        public SgrEntry(string parameters, SgrToken token)
+        {
+            Parameters = parameters;
+            Token = token;
+        }
+    }
+
+    /// <summary>
+    /// Returns a cleared <see cref="StringBuilder"/> for assembling SGR parameter
+    /// strings on the current thread.
+    /// </summary>
+    public static StringBuilder GetSgrBuilder()
+    {
+        var sb = t_sgrBuilder ??= new StringBuilder(64);
+        sb.Clear();
+        return sb;
+    }
+
+    /// <summary>
+    /// Looks up a cached <see cref="SgrToken"/> matching the assembled contents of
+    /// <paramref name="builder"/>, allocating one (and the backing string) only on
+    /// cache miss. Lookup hashes the builder contents and verifies span equality
+    /// against the stored key without materialising a string on the hot path.
+    /// </summary>
+    public static SgrToken GetSgrToken(StringBuilder builder)
+    {
+        if (builder.Length == 0)
+            return SgrToken.Reset;
+
+        var cache = t_sgrCache ??= new Dictionary<ulong, SgrEntry>(capacity: 256);
+        var hash = HashBuilder(builder);
+
+        if (cache.TryGetValue(hash, out var entry) && BuilderEqualsString(builder, entry.Parameters))
+            return entry.Token;
+
+        // Cache miss (or once-in-a-blue-moon hash collision) — materialise the string.
+        var parameters = builder.ToString();
+        var token = new SgrToken(parameters);
+        if (cache.Count < MaxSgrCache)
+            cache[hash] = new SgrEntry(parameters, token);
+        return token;
+    }
+
+    /// <summary>
+    /// Returns a cached <see cref="TextToken"/> for the given text, allocating
+    /// one on cache miss. Short strings (single graphemes — the common case for
+    /// the per-cell text emission path) are cached aggressively; long strings
+    /// bypass the cache entirely since they're unlikely to recur.
+    /// </summary>
+    public static TextToken GetTextToken(string text)
+    {
+        if (text.Length > 8)
+            return new TextToken(text);
+
+        if (s_textCache.TryGetValue(text, out var token))
+            return token;
+
+        token = new TextToken(text);
+        if (s_textCache.Count < MaxTextCache)
+            s_textCache.TryAdd(text, token);
+        return token;
+    }
+
+    // FNV-1a 64-bit hash over the builder's chars. Cheap, allocation-free, good
+    // collision resistance for short SGR strings (<128 chars).
+    private static ulong HashBuilder(StringBuilder builder)
+    {
+        const ulong fnvOffset = 14695981039346656037UL;
+        const ulong fnvPrime = 1099511628211UL;
+        ulong hash = fnvOffset;
+        var len = builder.Length;
+        for (var i = 0; i < len; i++)
+        {
+            var ch = builder[i];
+            hash ^= ch;
+            hash *= fnvPrime;
+        }
+        return hash;
+    }
+
+    private static bool BuilderEqualsString(StringBuilder builder, string s)
+    {
+        if (builder.Length != s.Length) return false;
+        for (var i = 0; i < builder.Length; i++)
+        {
+            if (builder[i] != s[i]) return false;
+        }
+        return true;
+    }
+}
+
+

--- a/src/Hex1b/Tokens/AnsiTokenCache.cs
+++ b/src/Hex1b/Tokens/AnsiTokenCache.cs
@@ -32,6 +32,7 @@ internal static class AnsiTokenCache
 {
     [ThreadStatic] private static StringBuilder? t_sgrBuilder;
     [ThreadStatic] private static Dictionary<ulong, SgrEntry>? t_sgrCache;
+    [ThreadStatic] private static Dictionary<ulong, SgrEntry>? t_sgrBytesCache;
 
     private static readonly ConcurrentDictionary<string, TextToken> s_textCache = new();
 
@@ -120,6 +121,59 @@ internal static class AnsiTokenCache
             hash *= fnvPrime;
         }
         return hash;
+    }
+
+    /// <summary>
+    /// Returns a cached <see cref="SgrToken"/> whose <see cref="SgrToken.PreformattedBytes"/>
+    /// is the wire-ready UTF-8 representation of the SGR parameters (without the
+    /// surrounding <c>ESC[</c> ... <c>m</c>). Lookup is keyed by an FNV-1a hash
+    /// over <paramref name="parameterBytes"/> with a span-vs-array equality verify
+    /// on lookup, so cache hits allocate nothing.
+    /// </summary>
+    /// <remarks>
+    /// On miss this copies the bytes into a heap byte[] and materialises an ASCII
+    /// string for <see cref="SgrToken.Parameters"/> (one-time cost; cache hits skip
+    /// both). SGR parameters are pure ASCII (digits, semicolons, colons), so ASCII
+    /// decode is exact.
+    /// </remarks>
+    public static SgrToken GetSgrTokenFromBytes(ReadOnlySpan<byte> parameterBytes)
+    {
+        if (parameterBytes.Length == 0)
+            return SgrToken.Reset;
+
+        var cache = t_sgrBytesCache ??= new Dictionary<ulong, SgrEntry>(capacity: 256);
+        var hash = HashBytes(parameterBytes);
+
+        if (cache.TryGetValue(hash, out var entry) && BytesEqualsBytes(parameterBytes, entry.Token.PreformattedBytes))
+            return entry.Token;
+
+        // Cache miss — materialise the wire bytes + the parameter string.
+        var bytes = parameterBytes.ToArray();
+        var parameters = System.Text.Encoding.ASCII.GetString(bytes);
+        var token = new SgrToken(parameters) { PreformattedBytes = bytes };
+        if (cache.Count < MaxSgrCache)
+            cache[hash] = new SgrEntry(parameters, token);
+        return token;
+    }
+
+    // FNV-1a 64-bit hash over a byte span.
+    private static ulong HashBytes(ReadOnlySpan<byte> data)
+    {
+        const ulong fnvOffset = 14695981039346656037UL;
+        const ulong fnvPrime = 1099511628211UL;
+        ulong hash = fnvOffset;
+        for (var i = 0; i < data.Length; i++)
+        {
+            hash ^= data[i];
+            hash *= fnvPrime;
+        }
+        return hash;
+    }
+
+    private static bool BytesEqualsBytes(ReadOnlySpan<byte> a, byte[]? b)
+    {
+        if (b is null) return false;
+        return a.SequenceEqual(b);
     }
 
     private static bool BuilderEqualsString(StringBuilder builder, string s)

--- a/src/Hex1b/Tokens/AnsiTokenUtf8Serializer.cs
+++ b/src/Hex1b/Tokens/AnsiTokenUtf8Serializer.cs
@@ -32,6 +32,48 @@ public static class AnsiTokenUtf8Serializer
     }
 
     /// <summary>
+    /// Serializes a list of tokens into a UTF-8 byte buffer backed by an array rented from
+    /// <see cref="ArrayPool{T}.Shared"/>. The caller MUST return <paramref name="pooledBuffer"/>
+    /// to the pool when done with the bytes (typically after writing them to the wire).
+    /// This avoids per-frame Large Object Heap allocations for busy fullscreen renders where
+    /// the serialised output routinely exceeds the LOH threshold (~85 KB).
+    /// </summary>
+    /// <param name="tokens">The tokens to serialise.</param>
+    /// <param name="pooledBuffer">
+    /// Receives the rented array. Pass to <see cref="ArrayPool{T}.Return"/> when finished.
+    /// Will be <see langword="null"/> only if <paramref name="tokens"/> contains no bytes.
+    /// </param>
+    /// <returns>
+    /// A memory window over the first N bytes of <paramref name="pooledBuffer"/>, where N is
+    /// the serialised length. The memory becomes invalid once the buffer is returned to the pool.
+    /// </returns>
+    public static ReadOnlyMemory<byte> SerializeRented(IEnumerable<AnsiToken> tokens, out byte[] pooledBuffer)
+    {
+        ArgumentNullException.ThrowIfNull(tokens);
+
+        var initialCapacity = tokens is IReadOnlyCollection<AnsiToken> c
+            ? Math.Clamp(c.Count * 4, 256, 128 * 1024)
+            : 1024;
+
+        var writer = new PooledArrayBufferWriter(initialCapacity);
+        try
+        {
+            foreach (var token in tokens)
+            {
+                WriteToken(writer, token);
+            }
+        }
+        catch
+        {
+            writer.ReturnToPool();
+            throw;
+        }
+
+        pooledBuffer = writer.DetachBuffer(out var length);
+        return new ReadOnlyMemory<byte>(pooledBuffer, 0, length);
+    }
+
+    /// <summary>
     /// Serializes a single token into a UTF-8 byte buffer.
     /// </summary>
     public static ReadOnlyMemory<byte> Serialize(AnsiToken token)
@@ -43,7 +85,7 @@ public static class AnsiTokenUtf8Serializer
         return writer.WrittenMemory;
     }
 
-    private static void WriteToken(ArrayBufferWriter<byte> writer, AnsiToken token)
+    private static void WriteToken(IBufferWriter<byte> writer, AnsiToken token)
     {
         switch (token)
         {
@@ -314,7 +356,7 @@ public static class AnsiTokenUtf8Serializer
         }
     }
 
-    private static void WriteCursorPosition(ArrayBufferWriter<byte> writer, CursorPositionToken token)
+    private static void WriteCursorPosition(IBufferWriter<byte> writer, CursorPositionToken token)
     {
         // Mirror AnsiTokenSerializer.SerializeCursorPosition() exactly, including OriginalParams.
         if (token.OriginalParams is not null)
@@ -350,7 +392,7 @@ public static class AnsiTokenUtf8Serializer
         WriteByte(writer, (byte)'H');
     }
 
-    private static void WriteCursorMove(ArrayBufferWriter<byte> writer, CursorMoveToken token)
+    private static void WriteCursorMove(IBufferWriter<byte> writer, CursorMoveToken token)
     {
         WriteEscLeftBracket(writer);
 
@@ -371,7 +413,7 @@ public static class AnsiTokenUtf8Serializer
         WriteByte(writer, command);
     }
 
-    private static void WriteOsc(ArrayBufferWriter<byte> writer, OscToken token)
+    private static void WriteOsc(IBufferWriter<byte> writer, OscToken token)
     {
         // Preserve original terminator style (ESC \ vs BEL)
         // Mirror AnsiTokenSerializer.SerializeOsc() exactly.
@@ -403,7 +445,7 @@ public static class AnsiTokenUtf8Serializer
         WriteOscTerminator(writer, token.UseEscBackslash);
     }
 
-    private static void WriteOscTerminator(ArrayBufferWriter<byte> writer, bool useEscBackslash)
+    private static void WriteOscTerminator(IBufferWriter<byte> writer, bool useEscBackslash)
     {
         if (useEscBackslash)
         {
@@ -416,7 +458,7 @@ public static class AnsiTokenUtf8Serializer
         }
     }
 
-    private static void WriteControlCharacter(ArrayBufferWriter<byte> writer, ControlCharacterToken token)
+    private static void WriteControlCharacter(IBufferWriter<byte> writer, ControlCharacterToken token)
     {
         switch (token.Character)
         {
@@ -431,7 +473,7 @@ public static class AnsiTokenUtf8Serializer
         }
     }
 
-    private static void WriteEscLeftBracket(ArrayBufferWriter<byte> writer)
+    private static void WriteEscLeftBracket(IBufferWriter<byte> writer)
     {
         var span = writer.GetSpan(2);
         span[0] = 0x1b;
@@ -439,14 +481,14 @@ public static class AnsiTokenUtf8Serializer
         writer.Advance(2);
     }
 
-    private static void WriteByte(ArrayBufferWriter<byte> writer, byte value)
+    private static void WriteByte(IBufferWriter<byte> writer, byte value)
     {
         var span = writer.GetSpan(1);
         span[0] = value;
         writer.Advance(1);
     }
 
-    private static void WriteInt(ArrayBufferWriter<byte> writer, int value)
+    private static void WriteInt(IBufferWriter<byte> writer, int value)
     {
         var span = writer.GetSpan(11); // int32 max length
         if (!Utf8Formatter.TryFormat(value, span, out var written))
@@ -454,7 +496,7 @@ public static class AnsiTokenUtf8Serializer
         writer.Advance(written);
     }
 
-    private static void WriteUtf8(ArrayBufferWriter<byte> writer, string text)
+    private static void WriteUtf8(IBufferWriter<byte> writer, string text)
     {
         if (string.IsNullOrEmpty(text))
             return;
@@ -478,7 +520,7 @@ public static class AnsiTokenUtf8Serializer
         writer.Advance(text.Length);
     }
 
-    private static void WriteCharUtf8(ArrayBufferWriter<byte> writer, char ch)
+    private static void WriteCharUtf8(IBufferWriter<byte> writer, char ch)
     {
         Span<char> chars = stackalloc char[1];
         chars[0] = ch;
@@ -488,7 +530,7 @@ public static class AnsiTokenUtf8Serializer
         writer.Advance(written);
     }
 
-    private static void WriteUtf8Slow(ArrayBufferWriter<byte> writer, ReadOnlySpan<char> text)
+    private static void WriteUtf8Slow(IBufferWriter<byte> writer, ReadOnlySpan<char> text)
     {
         if (text.IsEmpty)
             return;

--- a/src/Hex1b/Tokens/AnsiTokenUtf8Serializer.cs
+++ b/src/Hex1b/Tokens/AnsiTokenUtf8Serializer.cs
@@ -99,7 +99,16 @@ public static class AnsiTokenUtf8Serializer
 
             case SgrToken sgr:
                 WriteEscLeftBracket(writer);
-                WriteUtf8(writer, sgr.Parameters);
+                if (sgr.PreformattedBytes is { } sgrBytes)
+                {
+                    var dst = writer.GetSpan(sgrBytes.Length);
+                    sgrBytes.AsSpan().CopyTo(dst);
+                    writer.Advance(sgrBytes.Length);
+                }
+                else
+                {
+                    WriteUtf8(writer, sgr.Parameters);
+                }
                 WriteByte(writer, (byte)'m');
                 return;
 

--- a/src/Hex1b/Tokens/PooledArrayBufferWriter.cs
+++ b/src/Hex1b/Tokens/PooledArrayBufferWriter.cs
@@ -1,0 +1,89 @@
+using System.Buffers;
+
+namespace Hex1b.Tokens;
+
+/// <summary>
+/// An <see cref="IBufferWriter{T}"/> backed by an array rented from
+/// <see cref="ArrayPool{T}.Shared"/>. The caller takes ownership of the array via
+/// <see cref="DetachBuffer"/> and is responsible for returning it to the pool when done.
+/// </summary>
+/// <remarks>
+/// This exists so the ANSI serializer can write directly into pooled storage. The default
+/// <see cref="ArrayBufferWriter{T}"/> allocates with <c>new T[]</c>, which for a busy
+/// fullscreen frame routinely lands in the Large Object Heap (≥ 85 KB) — that allocation
+/// is one of the largest per-frame Gen2 contributors in the render loop.
+/// </remarks>
+internal sealed class PooledArrayBufferWriter : IBufferWriter<byte>
+{
+    private byte[] _buffer;
+    private int _written;
+
+    public PooledArrayBufferWriter(int initialCapacity)
+    {
+        if (initialCapacity <= 0) initialCapacity = 256;
+        _buffer = ArrayPool<byte>.Shared.Rent(initialCapacity);
+    }
+
+    public int WrittenCount => _written;
+
+    public void Advance(int count)
+    {
+        if (count < 0 || _written + count > _buffer.Length)
+            throw new ArgumentOutOfRangeException(nameof(count));
+        _written += count;
+    }
+
+    public Memory<byte> GetMemory(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+        return _buffer.AsMemory(_written);
+    }
+
+    public Span<byte> GetSpan(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+        return _buffer.AsSpan(_written);
+    }
+
+    /// <summary>
+    /// Transfers ownership of the underlying pooled buffer to the caller. The caller must
+    /// return it to <see cref="ArrayPool{T}.Shared"/> when the bytes have been fully consumed.
+    /// After this call the writer must not be used.
+    /// </summary>
+    public byte[] DetachBuffer(out int length)
+    {
+        var buf = _buffer;
+        length = _written;
+        _buffer = Array.Empty<byte>();
+        _written = 0;
+        return buf;
+    }
+
+    /// <summary>
+    /// Returns the underlying buffer to the pool and resets the writer. Use this when
+    /// disposing of a writer whose contents will not be consumed (e.g. an exception path).
+    /// </summary>
+    public void ReturnToPool()
+    {
+        if (_buffer.Length > 0)
+        {
+            ArrayPool<byte>.Shared.Return(_buffer);
+            _buffer = Array.Empty<byte>();
+            _written = 0;
+        }
+    }
+
+    private void EnsureCapacity(int sizeHint)
+    {
+        if (sizeHint < 1) sizeHint = 1;
+        var required = _written + sizeHint;
+        if (required <= _buffer.Length) return;
+
+        // Grow by doubling, but at least to required.
+        var newSize = Math.Max(required, _buffer.Length * 2);
+        var next = ArrayPool<byte>.Shared.Rent(newSize);
+        Buffer.BlockCopy(_buffer, 0, next, 0, _written);
+        ArrayPool<byte>.Shared.Return(_buffer);
+        _buffer = next;
+    }
+}

--- a/src/Hex1b/Tokens/SgrToken.cs
+++ b/src/Hex1b/Tokens/SgrToken.cs
@@ -30,4 +30,23 @@ public sealed record SgrToken(string Parameters) : AnsiToken
 {
     /// <summary>SGR reset - clears all attributes and colors.</summary>
     public static readonly SgrToken Reset = new("");
+
+    /// <summary>
+    /// Optional pre-formatted UTF-8 representation of <see cref="Parameters"/>
+    /// (without the surrounding <c>ESC[</c> ... <c>m</c>). When the renderer hot
+    /// path emits an SGR via the byte-formatting fast path it stores the wire
+    /// bytes here so <see cref="AnsiTokenUtf8Serializer"/> can <c>memcpy</c>
+    /// them instead of re-encoding the string.
+    /// </summary>
+    /// <remarks>
+    /// This is a cache and MUST NOT participate in value equality — two
+    /// <see cref="SgrToken"/> instances with the same <see cref="Parameters"/>
+    /// are equal regardless of whether one carries pre-formatted bytes.
+    /// </remarks>
+    internal byte[]? PreformattedBytes { get; init; }
+
+    public bool Equals(SgrToken? other) =>
+        other is not null && Parameters == other.Parameters;
+
+    public override int GetHashCode() => Parameters?.GetHashCode() ?? 0;
 }

--- a/src/Hex1b/Widgets/FigletTextWidget.cs
+++ b/src/Hex1b/Widgets/FigletTextWidget.cs
@@ -30,7 +30,7 @@ namespace Hex1b.Widgets;
 /// using Hex1b.Widgets;
 ///
 /// await using var terminal = Hex1bTerminal.CreateBuilder()
-///     .WithHex1bApp((app, options) =&gt; ctx =&gt;
+///     .WithHex1bApp(ctx =&gt;
 ///         ctx.FigletText("Hello").Font(FigletFonts.Slant))
 ///     .Build();
 ///

--- a/src/Hex1b/Widgets/SurfaceWidget.cs
+++ b/src/Hex1b/Widgets/SurfaceWidget.cs
@@ -65,9 +65,16 @@ public record SurfaceWidget(
     {
         var node = existingNode as SurfaceNode ?? new SurfaceNode();
 
-        // Always mark dirty since layers may have changed content
-        // (we can't easily compare layer contents)
-        node.MarkDirty();
+        // If the user has not opted into per-widget cache control via .Cached(...),
+        // we conservatively mark the node dirty every reconcile because we can't
+        // cheaply diff layer contents. When a CachePredicate IS present, the user
+        // is taking responsibility for declaring when the rendered surface needs
+        // to be regenerated — invalidating here would force a new (often LOH)
+        // Surface allocation per frame and defeat the cache entirely.
+        if (CachePredicate is null)
+        {
+            node.MarkDirty();
+        }
 
         node.LayerBuilder = LayerBuilder;
         // HeightHint and WidthHint are set by ReconcileContext from the base Hex1bWidget properties.

--- a/src/Hex1b/WorkloadOutputItem.cs
+++ b/src/Hex1b/WorkloadOutputItem.cs
@@ -22,5 +22,15 @@ namespace Hex1b;
 /// Optional pre-tokenized representation of <paramref name="Bytes"/>. When provided, it should
 /// represent the same output as <paramref name="Bytes"/>.
 /// </param>
-public readonly record struct WorkloadOutputItem(ReadOnlyMemory<byte> Bytes, IReadOnlyList<AnsiToken>? Tokens);
+/// <param name="PooledBuffer">
+/// Optional pooled array backing <paramref name="Bytes"/>. When non-null, the consumer should
+/// call <see cref="System.Buffers.ArrayPool{T}.Return(T[], bool)"/> on
+/// <see cref="System.Buffers.ArrayPool{T}.Shared"/> with this array after the bytes have been
+/// fully consumed. This is the runtime's mechanism to avoid per-frame LOH allocations for
+/// large ANSI output buffers (a busy fullscreen frame is well over the 85KB LOH threshold).
+/// </param>
+public readonly record struct WorkloadOutputItem(
+    ReadOnlyMemory<byte> Bytes,
+    IReadOnlyList<AnsiToken>? Tokens,
+    byte[]? PooledBuffer = null);
 

--- a/src/Hex1b/WorkloadOutputItem.cs
+++ b/src/Hex1b/WorkloadOutputItem.cs
@@ -22,15 +22,19 @@ namespace Hex1b;
 /// Optional pre-tokenized representation of <paramref name="Bytes"/>. When provided, it should
 /// represent the same output as <paramref name="Bytes"/>.
 /// </param>
-/// <param name="PooledBuffer">
-/// Optional pooled array backing <paramref name="Bytes"/>. When non-null, the consumer should
-/// call <see cref="System.Buffers.ArrayPool{T}.Return(T[], bool)"/> on
-/// <see cref="System.Buffers.ArrayPool{T}.Shared"/> with this array after the bytes have been
-/// fully consumed. This is the runtime's mechanism to avoid per-frame LOH allocations for
-/// large ANSI output buffers (a busy fullscreen frame is well over the 85KB LOH threshold).
-/// </param>
 public readonly record struct WorkloadOutputItem(
     ReadOnlyMemory<byte> Bytes,
-    IReadOnlyList<AnsiToken>? Tokens,
-    byte[]? PooledBuffer = null);
+    IReadOnlyList<AnsiToken>? Tokens)
+{
+    /// <summary>
+    /// Optional pooled array backing <see cref="Bytes"/>. When non-null, the terminal returns
+    /// it to <see cref="System.Buffers.ArrayPool{T}.Shared"/> after the bytes have been fully
+    /// forwarded. This is an internal mechanism used by the in-process Hex1bApp ↔ Hex1bTerminal
+    /// bridge to avoid per-frame LOH allocations for large ANSI output buffers (a busy
+    /// fullscreen frame is well over the 85KB LOH threshold). External workload adapters
+    /// should not set this — they should manage any pooling internally and present
+    /// <see cref="Bytes"/> as a stable window valid until their next read call.
+    /// </summary>
+    internal byte[]? PooledBuffer { get; init; }
+}
 

--- a/src/Hex1b/WorkloadOutputItem.cs
+++ b/src/Hex1b/WorkloadOutputItem.cs
@@ -36,5 +36,20 @@ public readonly record struct WorkloadOutputItem(
     /// <see cref="Bytes"/> as a stable window valid until their next read call.
     /// </summary>
     internal byte[]? PooledBuffer { get; init; }
+
+    /// <summary>
+    /// Optional pooled token list backing <see cref="Tokens"/>. When non-null, the terminal
+    /// returns it to the originating <see cref="Hex1bApp"/> via
+    /// <see cref="Hex1bApp.ReturnTokenList"/> after consumption. Same purpose and constraints
+    /// as <see cref="PooledBuffer"/>: this is an internal in-process mechanism and external
+    /// workload adapters should leave it null.
+    /// </summary>
+    internal List<AnsiToken>? PooledTokens { get; init; }
+
+    /// <summary>
+    /// Internal callback the consumer invokes to return <see cref="PooledTokens"/> to its
+    /// owning pool. Decoupled from <see cref="Hex1bApp"/> to avoid a circular type reference.
+    /// </summary>
+    internal Action<List<AnsiToken>>? PooledTokensReturn { get; init; }
 }
 

--- a/src/content/guide/widgets/snippets/figlet-custom-font.cs
+++ b/src/content/guide/widgets/snippets/figlet-custom-font.cs
@@ -2,7 +2,7 @@
 var customFont = await FigletFont.LoadFileAsync("fonts/colossal.flf");
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
         ctx.FigletText("Hi!").Font(customFont))
     .Build();
 

--- a/src/content/guide/widgets/snippets/markdown-document.cs
+++ b/src/content/guide/widgets/snippets/markdown-document.cs
@@ -5,7 +5,7 @@ var document = new Hex1bDocument("# Hello\n\nInitial content.");
 var editorState = new EditorState(document);
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
         ctx.HSplitter(
             ctx.Editor(editorState),
             ctx.VScrollPanel(ctx.Markdown(document)),

--- a/src/content/guide/widgets/snippets/progress-theming.cs
+++ b/src/content/guide/widgets/snippets/progress-theming.cs
@@ -6,10 +6,9 @@ var theme = new Hex1bThemeBuilder()
     .Build();
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => {
-        options.Theme = theme;
-        return ctx => ctx.Progress(60);
-    })
+    .WithHex1bApp(
+        options => options.Theme = theme,
+        ctx => ctx.Progress(60))
     .Build();
 
 await terminal.RunAsync();

--- a/src/content/guide/widgets/snippets/responsive-basic.cs
+++ b/src/content/guide/widgets/snippets/responsive-basic.cs
@@ -1,7 +1,7 @@
 using Hex1b;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.Responsive(r => [
+    .WithHex1bApp(ctx => ctx.Responsive(r => [
         r.WhenMinWidth(80, r => 
             r.Text("Wide layout - Terminal width >= 80 columns")
         ),

--- a/src/content/guide/widgets/snippets/responsive-custom.cs
+++ b/src/content/guide/widgets/snippets/responsive-custom.cs
@@ -1,7 +1,7 @@
 using Hex1b;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.Responsive(r => [
+    .WithHex1bApp(ctx => ctx.Responsive(r => [
         // Custom condition: Both width and height
         r.When(
             (width, height) => width >= 100 && height >= 20,

--- a/src/content/guide/widgets/snippets/responsive-layout.cs
+++ b/src/content/guide/widgets/snippets/responsive-layout.cs
@@ -1,7 +1,7 @@
 using Hex1b;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.Responsive(r => [
+    .WithHex1bApp(ctx => ctx.Responsive(r => [
         // Wide layout: Horizontal split
         r.WhenMinWidth(100, r =>
             r.HStack(h => [

--- a/src/content/guide/widgets/snippets/responsive-multiple.cs
+++ b/src/content/guide/widgets/snippets/responsive-multiple.cs
@@ -1,7 +1,7 @@
 using Hex1b;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.Responsive(r => [
+    .WithHex1bApp(ctx => ctx.Responsive(r => [
         // Extra wide: Three columns
         r.WhenMinWidth(120, r =>
             r.HStack(h => [

--- a/src/content/guide/widgets/snippets/terminal-basic.cs
+++ b/src/content/guide/widgets/snippets/terminal-basic.cs
@@ -11,7 +11,7 @@ _ = terminal.RunAsync();
 
 // Use the widget in your Hex1bApp
 await using var app = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => 
+    .WithHex1bApp(ctx => 
         ctx.Border(
             ctx.Terminal(bashHandle)
         ).Title("Embedded Terminal"))

--- a/src/content/guide/widgets/snippets/toggle-switch-binary.cs
+++ b/src/content/guide/widgets/snippets/toggle-switch-binary.cs
@@ -3,7 +3,7 @@ using Hex1b;
 string power = "Off";
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+    .WithHex1bApp(ctx => ctx.VStack(v => [
         v.Text("Binary Toggle Example"),
         v.Text(""),
         v.HStack(h => [

--- a/src/content/guide/widgets/snippets/toggle-switch-focus.cs
+++ b/src/content/guide/widgets/snippets/toggle-switch-focus.cs
@@ -1,7 +1,7 @@
 using Hex1b;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+    .WithHex1bApp(ctx => ctx.VStack(v => [
         v.Text("Unfocused:"),
         v.ToggleSwitch(["Off", "On"], selectedIndex: 1),
         v.Text(""),

--- a/src/content/guide/widgets/snippets/toggle-switch-modes.cs
+++ b/src/content/guide/widgets/snippets/toggle-switch-modes.cs
@@ -3,7 +3,7 @@ using Hex1b;
 string mode = "Auto";
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+    .WithHex1bApp(ctx => ctx.VStack(v => [
         v.Text("Mode Selection Example"),
         v.Text(""),
         v.HStack(h => [

--- a/src/content/guide/widgets/snippets/toggle-switch-multi.cs
+++ b/src/content/guide/widgets/snippets/toggle-switch-multi.cs
@@ -1,7 +1,7 @@
 using Hex1b;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+    .WithHex1bApp(ctx => ctx.VStack(v => [
         v.Text("Speed Settings:"),
         v.ToggleSwitch(["Slow", "Normal", "Fast"], selectedIndex: 1)
     ]))

--- a/src/content/guide/widgets/snippets/toggle-switch-settings.cs
+++ b/src/content/guide/widgets/snippets/toggle-switch-settings.cs
@@ -4,7 +4,7 @@ string theme = "Light";
 string sound = "On";
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+    .WithHex1bApp(ctx => ctx.VStack(v => [
         v.Text("Settings Panel"),
         v.Text(""),
         v.HStack(h => [

--- a/tests/Hex1b.Tests/AccordionNodeTests.cs
+++ b/tests/Hex1b.Tests/AccordionNodeTests.cs
@@ -300,7 +300,7 @@ public class AccordionIntegrationTests
     public async Task Accordion_BasicRender_ShowsSectionTitles()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.Accordion(a => [
+            .WithHex1bApp(ctx => ctx.Accordion(a => [
                 a.Section(s => [s.Text("Content 1")]).Title("Section A"),
                 a.Section(s => [s.Text("Content 2")]).Title("Section B"),
             ]))
@@ -330,7 +330,7 @@ public class AccordionKeyboardTests
     public async Task Accordion_EnterKey_TogglesSections()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.Accordion(a => [
+            .WithHex1bApp(ctx => ctx.Accordion(a => [
                 a.Section(s => [s.Text("Content A")]).Title("First"),
                 a.Section(s => [s.Text("Content B")]).Title("Second"),
             ]))
@@ -370,7 +370,7 @@ public class AccordionLayoutTests
         // Regression: VStack measures children with maxHeight=int.MaxValue,
         // which caused accordion to freeze trying to distribute infinite space.
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+            .WithHex1bApp(ctx => ctx.VStack(v => [
                 v.Text("Title"),
                 v.Separator(),
                 v.HStack(h => [

--- a/tests/Hex1b.Tests/CopyModeBindingsFunctionalTests.cs
+++ b/tests/Hex1b.Tests/CopyModeBindingsFunctionalTests.cs
@@ -49,7 +49,9 @@ public class CopyModeBindingsFunctionalTests
             CopyModeTestContext? capturedContext = null;
 
             var builder = Hex1bTerminal.CreateBuilder()
-                .WithHex1bApp((app, options) =>
+                .WithHex1bApp(
+                    _ => { },
+                    app =>
                 {
                     if (capturedContext != null)
                         capturedContext.App = app;

--- a/tests/Hex1b.Tests/DiagnosticShellIntegrationTests.cs
+++ b/tests/Hex1b.Tests/DiagnosticShellIntegrationTests.cs
@@ -287,7 +287,9 @@ public class DiagnosticShellIntegrationTests
             
             // Create the outer terminal (runs the Hex1bApp with TerminalWidget)
             var outerTerminal = Hex1bTerminal.CreateBuilder()
-                .WithHex1bApp((app, options) =>
+                .WithHex1bApp(
+                    _ => { },
+                    app =>
                 {
                     // Capture the app for test access
                     if (capturedContext != null)

--- a/tests/Hex1b.Tests/EditorNodeRenderingTests.cs
+++ b/tests/Hex1b.Tests/EditorNodeRenderingTests.cs
@@ -484,7 +484,13 @@ public class EditorNodeRenderingTests
 
         node.Render(context);
 
-        var pattern = new CellPatternSearcher().Find("L1");
+        // Wait for the LAST line ("L3") to be parsed, not the first.
+        // The render pipeline is asynchronous: node.Render() enqueues many
+        // ANSI fragments which are drained by a background pump. Waiting for
+        // "L1" (which is rendered first) can return before "L3" has been
+        // applied, leaving row 2 still blank when the snapshot is captured.
+        // Waiting for the last-rendered marker is the deterministic gate.
+        var pattern = new CellPatternSearcher().Find("L3");
         await new Hex1bTerminalInputSequenceBuilder()
             .WaitUntil(s => s.SearchPattern(pattern).HasMatches,
                 TimeSpan.FromSeconds(2), "first 3 lines visible")

--- a/tests/Hex1b.Tests/Hex1bAppWorkloadAdapterBackpressureTests.cs
+++ b/tests/Hex1b.Tests/Hex1bAppWorkloadAdapterBackpressureTests.cs
@@ -1,0 +1,103 @@
+using System.Buffers;
+using System.Diagnostics;
+using Hex1b;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Tests for the bounded output channel + backpressure behaviour on
+/// <see cref="Hex1bAppWorkloadAdapter"/>. The default is unbounded
+/// (back-compat), so most tests opt in via the constructor parameter.
+/// </summary>
+public class Hex1bAppWorkloadAdapterBackpressureTests
+{
+    [Fact]
+    public void Write_OnUnboundedAdapter_NeverBlocks()
+    {
+        using var adapter = new Hex1bAppWorkloadAdapter();
+        // Many writes without a reader should all enqueue immediately on
+        // the default unbounded channel.
+        for (var i = 0; i < 1000; i++)
+            adapter.Write("x");
+        Assert.Equal(1000, adapter.OutputQueueDepth);
+    }
+
+    [Fact]
+    public async Task Write_OnBoundedAdapter_BlocksProducerWhenFull()
+    {
+        using var adapter = new Hex1bAppWorkloadAdapter(maxQueuedOutputItems: 2);
+
+        // Fill the channel to capacity.
+        adapter.Write("a");
+        adapter.Write("b");
+        Assert.Equal(2, adapter.OutputQueueDepth);
+
+        // Producer thread - third write must block until a slot frees.
+        var producerStarted = new TaskCompletionSource();
+        var producerDone = new TaskCompletionSource();
+        var producer = Task.Run(() =>
+        {
+            producerStarted.SetResult();
+            adapter.Write("c"); // expected to block
+            producerDone.SetResult();
+        });
+
+        await producerStarted.Task;
+        // Give the producer time to attempt the write and block on the channel.
+        await Task.Delay(150);
+        Assert.False(producerDone.Task.IsCompleted, "Producer should be blocked while channel is full.");
+
+        // Drain one item; producer should unblock and complete.
+        var read = await adapter.TryReadOutputAsync(TimeSpan.FromSeconds(1));
+        Assert.True(read.HasValue);
+
+        await producerDone.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await producer;
+        Assert.Equal(2, adapter.OutputQueueDepth);
+    }
+
+    [Fact]
+    public async Task Write_OnBoundedAdapter_ChannelCompletionUnblocksProducer()
+    {
+        using var adapter = new Hex1bAppWorkloadAdapter(maxQueuedOutputItems: 1);
+
+        adapter.Write("a"); // fill capacity
+
+        var producer = Task.Run(() => adapter.Write("b")); // blocks
+
+        await Task.Delay(100);
+        Assert.False(producer.IsCompleted, "Producer should block until disposal unblocks it.");
+
+        // Disposing completes the writer, which should unblock the blocked
+        // write attempt without leaking resources or throwing out of the
+        // adapter API.
+        adapter.Dispose();
+        await producer.WaitAsync(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public void Constructor_NegativeMaxQueued_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new Hex1bAppWorkloadAdapter(maxQueuedOutputItems: -1));
+    }
+}
+
+internal static class BackpressureTestHelpers
+{
+    public static async Task<WorkloadOutputItem?> TryReadOutputAsync(this Hex1bAppWorkloadAdapter adapter, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        try
+        {
+            var item = await adapter.ReadOutputItemAsync(cts.Token);
+            if (item.Bytes.Length > 0 || item.Tokens is not null)
+                return item;
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        return null;
+    }
+}

--- a/tests/Hex1b.Tests/Hex1bTerminalAutomatorTests.cs
+++ b/tests/Hex1b.Tests/Hex1bTerminalAutomatorTests.cs
@@ -13,7 +13,7 @@ public class Hex1bTerminalAutomatorTests
     public async Task WaitUntilTextAsync_WaitsForText()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Hello World"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Hello World"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -34,7 +34,7 @@ public class Hex1bTerminalAutomatorTests
     public async Task WaitUntilTextAsync_Timeout_ThrowsHex1bAutomationException()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Hello"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -214,7 +214,7 @@ public class Hex1bTerminalAutomatorTests
     public async Task WaitUntilAsync_WithCustomPredicate_Works()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Count: 42"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Count: 42"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -347,7 +347,7 @@ public class Hex1bTerminalAutomatorTests
     public async Task CompletedSteps_TracksCallerInfo()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Test"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Test"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -371,7 +371,7 @@ public class Hex1bTerminalAutomatorTests
     public async Task AutomationException_TotalElapsed_SumsAllSteps()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Hello"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -398,7 +398,7 @@ public class Hex1bTerminalAutomatorTests
     public async Task CreateSnapshot_ReturnsCurrentState()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Snapshot Test"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Snapshot Test"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -419,7 +419,7 @@ public class Hex1bTerminalAutomatorTests
     public async Task WaitUntilAsync_WithPredicateExpression_CapturesExpression()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Hello"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -474,7 +474,7 @@ public class Hex1bTerminalAutomatorTests
     public async Task WaitAsync_PausesForDuration()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Test"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Test"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();

--- a/tests/Hex1b.Tests/Hex1bTerminalBuilderTests.cs
+++ b/tests/Hex1b.Tests/Hex1bTerminalBuilderTests.cs
@@ -246,26 +246,26 @@ public class Hex1bTerminalBuilderTests
     [Fact]
     public async Task WithHex1bApp_NullConfigure_ThrowsArgumentNullException()
     {
-        Func<Hex1bApp, Hex1bAppOptions, Func<RootContext, Hex1bWidget>>? nullConfigure = null;
+        Func<RootContext, Hex1bWidget>? nullBuilder = null;
         
         Assert.Throws<ArgumentNullException>(() =>
-            Hex1bTerminal.CreateBuilder().WithHex1bApp(nullConfigure!));
+            Hex1bTerminal.CreateBuilder().WithHex1bApp(nullBuilder!));
     }
 
     [Fact]
     public async Task WithHex1bApp_AsyncNullConfigure_ThrowsArgumentNullException()
     {
-        Func<Hex1bApp, Hex1bAppOptions, Func<RootContext, Task<Hex1bWidget>>>? nullConfigure = null;
+        Func<RootContext, Task<Hex1bWidget>>? nullBuilder = null;
         
         Assert.Throws<ArgumentNullException>(() =>
-            Hex1bTerminal.CreateBuilder().WithHex1bApp(nullConfigure!));
+            Hex1bTerminal.CreateBuilder().WithHex1bApp(nullBuilder!));
     }
 
     [Fact]
     public async Task WithHex1bApp_ReturnsBuilder()
     {
         var result = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.Text("Hello"));
+            .WithHex1bApp(ctx => ctx.Text("Hello"));
         
         Assert.IsType<Hex1bTerminalBuilder>(result);
     }
@@ -275,7 +275,7 @@ public class Hex1bTerminalBuilderTests
     {
         // Should not throw - uses explicit presentation
         var builder = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.Text("Hello"))
+            .WithHex1bApp(ctx => ctx.Text("Hello"))
             .WithPresentation(new TestPresentationAdapter());
         
         using var terminal = builder.Build();
@@ -289,7 +289,7 @@ public class Hex1bTerminalBuilderTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
         
         var builder = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => async ctx =>
+            .WithHex1bApp(async ctx =>
             {
                 builderCalled = true;
                 await Task.Yield();
@@ -313,7 +313,7 @@ public class Hex1bTerminalBuilderTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
         
         var builder = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx =>
+            .WithHex1bApp(ctx =>
             {
                 builderCalled = true;
                 return ctx.Text("Hello");
@@ -343,7 +343,7 @@ public class Hex1bTerminalBuilderTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
         
         var builder = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.Text("Hello"))
+            .WithHex1bApp(ctx => ctx.Text("Hello"))
             .WithMouse(true)
             .WithDimensions(100, 40)
             .AddWorkloadFilter(filter)
@@ -364,7 +364,9 @@ public class Hex1bTerminalBuilderTests
         var pattern = new CellPatternSearcher().Find("Hello from captured app");
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) =>
+            .WithHex1bApp(
+                _ => { },
+                app =>
             {
                 capturedApp = app;
                 return ctx => ctx.Text("Hello from captured app");
@@ -392,12 +394,9 @@ public class Hex1bTerminalBuilderTests
         var pattern = new CellPatternSearcher().Find("Themed content");
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) =>
-            {
-                // Setting Theme should work (it's not a restricted property)
-                options.Theme = new Hex1b.Theming.Hex1bTheme("TestTheme");
-                return ctx => ctx.Text("Themed content");
-            })
+            .WithHex1bApp(
+                options => options.Theme = new Hex1b.Theming.Hex1bTheme("TestTheme"),
+                ctx => ctx.Text("Themed content"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -420,7 +419,9 @@ public class Hex1bTerminalBuilderTests
         var pattern = new CellPatternSearcher().Find("Async Hello World");
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) =>
+            .WithHex1bApp(
+                _ => { },
+                app =>
             {
                 capturedApp = app;
                 return async ctx =>
@@ -979,7 +980,7 @@ public class Hex1bTerminalBuilderTests
         try
         {
             var result = Hex1bTerminal.CreateBuilder()
-                .WithHex1bApp((app, options) => ctx => ctx.Text("Hello"))
+                .WithHex1bApp(ctx => ctx.Text("Hello"))
                 .WithAsciinemaRecording(tempFile);
 
             Assert.IsType<Hex1bTerminalBuilder>(result);
@@ -1012,7 +1013,7 @@ public class Hex1bTerminalBuilderTests
         {
             AsciinemaRecorder? capturedRecorder = null;
             var result = Hex1bTerminal.CreateBuilder()
-                .WithHex1bApp((app, options) => ctx => ctx.Text("Hello"))
+                .WithHex1bApp(ctx => ctx.Text("Hello"))
                 .WithAsciinemaRecording(tempFile, r => capturedRecorder = r);
 
             Assert.IsType<Hex1bTerminalBuilder>(result);
@@ -1041,7 +1042,7 @@ public class Hex1bTerminalBuilderTests
             var pattern = new CellPatternSearcher().Find("Recorded");
 
             await using (var terminal = Hex1bTerminal.CreateBuilder()
-                .WithHex1bApp((app, options) => ctx => ctx.Text("Recorded"))
+                .WithHex1bApp(ctx => ctx.Text("Recorded"))
                 .WithAsciinemaRecording(tempFile, r => recorder = r, new AsciinemaRecorderOptions
                 {
                     Title = "Test Recording",
@@ -1086,7 +1087,7 @@ public class Hex1bTerminalBuilderTests
             AsciinemaRecorder? recorder = null;
 
             var result = Hex1bTerminal.CreateBuilder()
-                .WithHex1bApp((app, options) => ctx => ctx.Text("Hello"))
+                .WithHex1bApp(ctx => ctx.Text("Hello"))
                 .WithAsciinemaRecording(tempFile, r => recorder = r, new AsciinemaRecorderOptions
                 {
                     Title = "Custom Title",
@@ -1118,7 +1119,7 @@ public class Hex1bTerminalBuilderTests
             var pattern = new CellPatternSearcher().Find("Full chain");
 
             await using var terminal = Hex1bTerminal.CreateBuilder()
-                .WithHex1bApp((app, options) => ctx => ctx.Text("Full chain"))
+                .WithHex1bApp(ctx => ctx.Text("Full chain"))
                 .WithAsciinemaRecording(tempFile, r => recorder = r, new AsciinemaRecorderOptions
                 {
                     Title = "Chain Test",

--- a/tests/Hex1b.Tests/InfoBarWidgetTests.cs
+++ b/tests/Hex1b.Tests/InfoBarWidgetTests.cs
@@ -16,7 +16,7 @@ public class InfoBarWidgetTests
     public async Task InfoBar_SingleSection_RendersText()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.InfoBar("Ready"))
+            .WithHex1bApp(ctx => ctx.InfoBar("Ready"))
             .WithHeadless()
             .WithDimensions(40, 5)
             .Build();
@@ -39,7 +39,7 @@ public class InfoBarWidgetTests
     public async Task InfoBar_MultipleSections_RendersAll()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.InfoBar(s => [
+            .WithHex1bApp(ctx => ctx.InfoBar(s => [
                 s.Section("Mode: Insert"),
                 s.Divider(" | "),
                 s.Section("UTF-8"),
@@ -72,7 +72,7 @@ public class InfoBarWidgetTests
     public async Task InfoBar_Divider_InsertsDividersBetweenSections()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.InfoBar(s => [
+            .WithHex1bApp(ctx => ctx.InfoBar(s => [
                 s.Section("A"),
                 s.Section("B"),
                 s.Section("C")
@@ -106,7 +106,7 @@ public class InfoBarWidgetTests
     public async Task InfoBar_WithSpacer_PushesContentApart()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.InfoBar(s => [
+            .WithHex1bApp(ctx => ctx.InfoBar(s => [
                 s.Section("Left"),
                 s.Spacer(),
                 s.Section("Right")
@@ -143,11 +143,9 @@ public class InfoBarWidgetTests
             .Set(GlobalTheme.BackgroundColor, Hex1bColor.Black);
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) =>
-            {
-                options.Theme = theme;
-                return ctx => new InfoBarWidget([new InfoBarSectionWidget(new TextBlockWidget("Inverted"))], InvertColors: true);
-            })
+            .WithHex1bApp(
+                options => options.Theme = theme,
+                ctx => new InfoBarWidget([new InfoBarSectionWidget(new TextBlockWidget("Inverted"))], InvertColors: true))
             .WithHeadless()
             .WithDimensions(40, 5)
             .Build();
@@ -176,11 +174,9 @@ public class InfoBarWidgetTests
             .Set(GlobalTheme.BackgroundColor, Hex1bColor.Blue);
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) =>
-            {
-                options.Theme = theme;
-                return ctx => new InfoBarWidget([new InfoBarSectionWidget(new TextBlockWidget("Normal"))], InvertColors: false);
-            })
+            .WithHex1bApp(
+                options => options.Theme = theme,
+                ctx => new InfoBarWidget([new InfoBarSectionWidget(new TextBlockWidget("Normal"))], InvertColors: false))
             .WithHeadless()
             .WithDimensions(40, 5)
             .Build();
@@ -208,7 +204,7 @@ public class InfoBarWidgetTests
     public async Task InfoBar_SectionWithTheme_AppliesCustomColors()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.InfoBar(s => [
+            .WithHex1bApp(ctx => ctx.InfoBar(s => [
                 s.Section("Normal"),
                 s.Section("Error").Theme(t => t
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.Red)
@@ -245,7 +241,7 @@ public class InfoBarWidgetTests
     public async Task InfoBar_InVStack_PositionedCorrectly()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+            .WithHex1bApp(ctx => ctx.VStack(v => [
                 v.Text("Main Content"),
                 v.InfoBar("Status Bar")
             ]))
@@ -276,7 +272,7 @@ public class InfoBarWidgetTests
     public async Task InfoBar_VariousTerminalSizes_RendersCorrectly(int width, int height)
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.InfoBar(s => [
+            .WithHex1bApp(ctx => ctx.InfoBar(s => [
                 s.Section("Mode"),
                 s.Spacer(),
                 s.Section("Ready")
@@ -313,11 +309,9 @@ public class InfoBarWidgetTests
             .Set(InfoBarTheme.BackgroundColor, Hex1bColor.DarkGray);
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) =>
-            {
-                options.Theme = theme;
-                return ctx => new InfoBarWidget([new InfoBarSectionWidget(new TextBlockWidget("Themed"))], InvertColors: false);
-            })
+            .WithHex1bApp(
+                options => options.Theme = theme,
+                ctx => new InfoBarWidget([new InfoBarSectionWidget(new TextBlockWidget("Themed"))], InvertColors: false))
             .WithHeadless()
             .WithDimensions(40, 5)
             .Build();
@@ -344,7 +338,7 @@ public class InfoBarWidgetTests
     public async Task InfoBar_SectionWithWidgetContent_RendersWidget()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.InfoBar(s => [
+            .WithHex1bApp(ctx => ctx.InfoBar(s => [
                 s.Section(x => x.HStack(h => [
                     h.Text("Status: "),
                     h.Text("OK")

--- a/tests/Hex1b.Tests/MenuBarIntegrationTests.cs
+++ b/tests/Hex1b.Tests/MenuBarIntegrationTests.cs
@@ -1302,7 +1302,7 @@ public class MenuBarIntegrationTests
     {
         // Arrange
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => CreateTestMenuBar(ctx, _ => { }, includeSubmenus: true))
+            .WithHex1bApp(ctx => CreateTestMenuBar(ctx, _ => { }, includeSubmenus: true))
             .WithHeadless()
             .WithDimensions(80, 24)
             .Build();

--- a/tests/Hex1b.Tests/PickerIntegrationTests.cs
+++ b/tests/Hex1b.Tests/PickerIntegrationTests.cs
@@ -15,7 +15,7 @@ public class PickerIntegrationTests
     {
         // Arrange & Act
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new PickerWidget(["Apple", "Banana", "Cherry"])
             ]))
             .WithHeadless()
@@ -45,7 +45,7 @@ public class PickerIntegrationTests
         var selectedText = "";
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new PickerWidget(["Apple", "Banana", "Cherry"])
                     .OnSelectionChanged(e => { selectedText = e.SelectedText; })
             ]))
@@ -81,7 +81,7 @@ public class PickerIntegrationTests
         var selectionChangedCount = 0;
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new PickerWidget(["Apple", "Banana", "Cherry"])
                     .OnSelectionChanged(e => { selectionChangedCount++; })
             ]))
@@ -117,15 +117,13 @@ public class PickerIntegrationTests
         var selectionChangedCount = 0;
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) =>
-            {
-                options.EnableMouse = true;
-                return ctx => new VStackWidget([
+            .WithHex1bApp(
+                options => options.EnableMouse = true,
+                ctx => new VStackWidget([
                     new TextBlockWidget("Click here to dismiss"),
                     new PickerWidget(["Apple", "Banana", "Cherry"])
                         .OnSelectionChanged(e => { selectionChangedCount++; })
-                ]);
-            })
+                ]))
             .WithHeadless()
             .WithDimensions(80, 24)
             .Build();
@@ -156,13 +154,11 @@ public class PickerIntegrationTests
     {
         // Arrange
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) =>
-            {
-                options.EnableMouse = true;
-                return ctx => new VStackWidget([
+            .WithHex1bApp(
+                options => options.EnableMouse = true,
+                ctx => new VStackWidget([
                     new PickerWidget(["Apple", "Banana", "Cherry"])
-                ]);
-            })
+                ]))
             .WithHeadless()
             .WithDimensions(80, 24)
             .Build();
@@ -226,7 +222,7 @@ public class PickerIntegrationTests
         var selectedText = "";
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new PickerWidget(["Apple", "Banana", "Cherry"])
                     .OnSelectionChanged(e => { selectedText = e.SelectedText; })
             ]))
@@ -258,7 +254,7 @@ public class PickerIntegrationTests
         var selectedText = "";
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new PickerWidget(["Apple", "Banana", "Cherry"]) { InitialSelectedIndex = 2 }
                     .OnSelectionChanged(e => { selectedText = e.SelectedText; })
             ]))
@@ -288,7 +284,7 @@ public class PickerIntegrationTests
     {
         // Arrange & Act
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new PickerWidget(["Apple", "Banana", "Cherry"])
             ]))
             .WithHeadless()
@@ -318,7 +314,7 @@ public class PickerIntegrationTests
     {
         // Arrange & Act
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new PickerWidget(["Apple", "Banana", "Cherry"])
             ]))
             .WithHeadless()
@@ -354,7 +350,7 @@ public class PickerIntegrationTests
         var selectedColor = "Red";
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new HStackWidget([
                     new TextBlockWidget("Fruit: "),
                     new PickerWidget(["Apple", "Banana", "Cherry"])
@@ -419,7 +415,7 @@ public class PickerIntegrationTests
         // bounding box stays painted by the dropdown's BackgroundPanel, even
         // after the selected row moves away.
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new PickerWidget(["Apple", "Banana", "Cherry"]),
                 new TextBlockWidget(""),
                 new TextBlockWidget(""),

--- a/tests/Hex1b.Tests/SgrTokenFastPathTests.cs
+++ b/tests/Hex1b.Tests/SgrTokenFastPathTests.cs
@@ -1,0 +1,61 @@
+using System.Text;
+using Hex1b.Tokens;
+using Xunit;
+
+namespace Hex1b.Tests;
+
+public class SgrTokenFastPathTests
+{
+    [Fact]
+    public void GetSgrTokenFromBytes_EmptySpan_ReturnsReset()
+    {
+        var token = AnsiTokenCache.GetSgrTokenFromBytes(ReadOnlySpan<byte>.Empty);
+        Assert.Same(SgrToken.Reset, token);
+    }
+
+    [Fact]
+    public void GetSgrTokenFromBytes_RoundTripsParameters()
+    {
+        ReadOnlySpan<byte> bytes = "38;2;255;128;64"u8;
+        var token = AnsiTokenCache.GetSgrTokenFromBytes(bytes);
+
+        Assert.Equal("38;2;255;128;64", token.Parameters);
+        Assert.NotNull(token.PreformattedBytes);
+        Assert.Equal(bytes.ToArray(), token.PreformattedBytes!);
+    }
+
+    [Fact]
+    public void GetSgrTokenFromBytes_SecondCallReturnsCachedInstance()
+    {
+        ReadOnlySpan<byte> bytes = "1;31"u8;
+        var first = AnsiTokenCache.GetSgrTokenFromBytes(bytes);
+        var second = AnsiTokenCache.GetSgrTokenFromBytes(bytes);
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void SgrToken_EqualityIgnoresPreformattedBytes()
+    {
+        var plain = new SgrToken("31");
+        var withBytes = new SgrToken("31") { PreformattedBytes = "31"u8.ToArray() };
+        Assert.Equal(plain, withBytes);
+        Assert.Equal(plain.GetHashCode(), withBytes.GetHashCode());
+    }
+
+    [Fact]
+    public void Serialize_UsesPreformattedBytes_WhenAvailable()
+    {
+        var token = new SgrToken("ignored-on-fast-path") { PreformattedBytes = "31"u8.ToArray() };
+        var bytes = AnsiTokenUtf8Serializer.Serialize(new[] { token });
+        // Should emit "\x1b[31m" using the PreformattedBytes, not the Parameters string.
+        Assert.Equal("\x1b[31m", Encoding.UTF8.GetString(bytes.Span));
+    }
+
+    [Fact]
+    public void Serialize_FallsBackToParameters_WhenPreformattedBytesNull()
+    {
+        var token = new SgrToken("1;38;2;255;0;0");
+        var bytes = AnsiTokenUtf8Serializer.Serialize(new[] { token });
+        Assert.Equal("\x1b[1;38;2;255;0;0m", Encoding.UTF8.GetString(bytes.Span));
+    }
+}

--- a/tests/Hex1b.Tests/SplitButtonIntegrationTests.cs
+++ b/tests/Hex1b.Tests/SplitButtonIntegrationTests.cs
@@ -51,7 +51,7 @@ public class SplitButtonIntegrationTests
     public async Task SplitButton_InitialRender_ShowsPrimaryLabelAndDropdownArrow()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([BuildButton()]))
+            .WithHex1bApp(ctx => new VStackWidget([BuildButton()]))
             .WithHeadless()
             .WithDimensions(40, 5)
             .Build();
@@ -85,7 +85,7 @@ public class SplitButtonIntegrationTests
     public async Task SplitButton_Focused_PaintsFocusedChipBackground()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([BuildButton()]))
+            .WithHex1bApp(ctx => new VStackWidget([BuildButton()]))
             .WithHeadless()
             .WithDimensions(40, 5)
             .Build();
@@ -123,7 +123,7 @@ public class SplitButtonIntegrationTests
     public async Task SplitButton_Unfocused_PaintsRestingChipBackground()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new ButtonWidget("Decoy"),
                 BuildButton(),
             ]))
@@ -163,7 +163,7 @@ public class SplitButtonIntegrationTests
     public async Task SplitButton_DownArrow_OpensDropdownWithBothOptionsVisible()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([BuildButton()]))
+            .WithHex1bApp(ctx => new VStackWidget([BuildButton()]))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -198,7 +198,7 @@ public class SplitButtonIntegrationTests
     public async Task SplitButton_DropdownOpen_DownArrow_MovesSelectionToOptionB()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([BuildButton()]))
+            .WithHex1bApp(ctx => new VStackWidget([BuildButton()]))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -232,7 +232,7 @@ public class SplitButtonIntegrationTests
         var primaryCount = 0;
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 BuildButton(
                     onPrimary: () => primaryCount++,
                     onOptionA: _ => optionACount++,
@@ -272,7 +272,7 @@ public class SplitButtonIntegrationTests
         SplitButtonClickedEventArgs? optionBArgs = null;
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 BuildButton(
                     onPrimary: () => primaryCount++,
                     onOptionA: _ => optionACount++,
@@ -312,7 +312,7 @@ public class SplitButtonIntegrationTests
         var primaryCount = 0;
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 BuildButton(
                     onPrimary: () => primaryCount++,
                     onOptionA: _ => optionACount++,
@@ -344,7 +344,7 @@ public class SplitButtonIntegrationTests
         var primaryCount = 0;
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 BuildButton(
                     onPrimary: () => primaryCount++,
                     onOptionA: _ => optionACount++,
@@ -407,7 +407,7 @@ public class SplitButtonIntegrationTests
         SplitButtonClickedEventArgs? optionBArgs = null;
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 BuildButton(
                     onPrimary: () => primaryCount++,
                     onOptionA: _ => optionACount++,
@@ -489,7 +489,7 @@ public class SplitButtonIntegrationTests
     public async Task SplitButton_NoSecondaryActions_RendersUniformChipWithoutDivider()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new SplitButtonWidget().PrimaryAction("Action", _ => { })
             ]))
             .WithHeadless()
@@ -551,7 +551,7 @@ public class SplitButtonIntegrationTests
             .SecondaryAction("Choice Y", _ => { });
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 topButton,
                 new TextBlockWidget(""),
                 new TextBlockWidget(""),

--- a/tests/Hex1b.Tests/SurfaceComparerUnderlineDiffTests.cs
+++ b/tests/Hex1b.Tests/SurfaceComparerUnderlineDiffTests.cs
@@ -1,0 +1,79 @@
+using Hex1b;
+using Hex1b.Surfaces;
+using Hex1b.Theming;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Regression tests for <see cref="SurfaceComparer.Compare"/> covering
+/// underline-style and underline-color changes. Historically these fields
+/// were absent from the cell-equality fast path, so a cell that changed only
+/// in its underline state was treated as unchanged - the diff would skip it
+/// and the host terminal would keep displaying stale underline state.
+/// </summary>
+public class SurfaceComparerUnderlineDiffTests
+{
+    [Fact]
+    public void Compare_CellWithChangedUnderlineStyleOnly_IsIncludedInDiff()
+    {
+        var previous = new Surface(1, 1);
+        var current = new Surface(1, 1);
+
+        previous[0, 0] = new SurfaceCell(
+            "A",
+            Hex1bColor.White,
+            Hex1bColor.Black,
+            CellAttributes.Underline,
+            UnderlineStyle: UnderlineStyle.Single);
+
+        current[0, 0] = previous[0, 0] with { UnderlineStyle = UnderlineStyle.Curly };
+
+        var diff = SurfaceComparer.Compare(previous, current);
+
+        Assert.Single(diff.ChangedCells);
+        Assert.Equal(UnderlineStyle.Curly, diff.ChangedCells[0].Cell.UnderlineStyle);
+    }
+
+    [Fact]
+    public void Compare_CellWithChangedUnderlineColorOnly_IsIncludedInDiff()
+    {
+        var previous = new Surface(1, 1);
+        var current = new Surface(1, 1);
+
+        previous[0, 0] = new SurfaceCell(
+            "A",
+            Hex1bColor.White,
+            Hex1bColor.Black,
+            CellAttributes.Underline,
+            UnderlineStyle: UnderlineStyle.Single,
+            UnderlineColor: Hex1bColor.Red);
+
+        current[0, 0] = previous[0, 0] with { UnderlineColor = Hex1bColor.Blue };
+
+        var diff = SurfaceComparer.Compare(previous, current);
+
+        Assert.Single(diff.ChangedCells);
+        Assert.Equal(Hex1bColor.Blue, diff.ChangedCells[0].Cell.UnderlineColor);
+    }
+
+    [Fact]
+    public void Compare_CellWithIdenticalUnderlineState_IsNotInDiff()
+    {
+        var previous = new Surface(1, 1);
+        var current = new Surface(1, 1);
+
+        previous[0, 0] = new SurfaceCell(
+            "A",
+            Hex1bColor.White,
+            Hex1bColor.Black,
+            CellAttributes.Underline,
+            UnderlineStyle: UnderlineStyle.Curly,
+            UnderlineColor: Hex1bColor.Green);
+
+        current[0, 0] = previous[0, 0];
+
+        var diff = SurfaceComparer.Compare(previous, current);
+
+        Assert.Empty(diff.ChangedCells);
+    }
+}

--- a/tests/Hex1b.Tests/SurfaceFastPathTests.cs
+++ b/tests/Hex1b.Tests/SurfaceFastPathTests.cs
@@ -1,0 +1,196 @@
+using Hex1b;
+using Hex1b.Surfaces;
+using Hex1b.Theming;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Covers the <see cref="Surface.IsFastPathEligible"/> latch and the matching
+/// fast diff path in <see cref="SurfaceComparer"/>. The fast path skips the
+/// underline / display-width / tracked-ref branches in per-cell equality, so
+/// the latch MUST flip to false whenever any such complexity is introduced.
+/// Conversely, when both surfaces remain in the simple lane, the diff output
+/// must be identical to the slow path.
+/// </summary>
+public class SurfaceFastPathTests
+{
+    [Fact]
+    public void NewSurface_HasFastPathEligibleTrue()
+    {
+        var surface = new Surface(4, 2);
+        Assert.True(surface.IsFastPathEligible);
+    }
+
+    [Fact]
+    public void SimpleAsciiWrite_KeepsFastPathEligible()
+    {
+        var surface = new Surface(4, 2);
+        surface[0, 0] = new SurfaceCell("A", Hex1bColor.White, Hex1bColor.Black);
+        surface.WriteText(1, 0, "BCD", Hex1bColor.White, Hex1bColor.Black);
+        Assert.True(surface.IsFastPathEligible);
+    }
+
+    [Theory]
+    [InlineData("e\u0301")]   // combining acute => grapheme length > 1
+    public void MultiCodePointGrapheme_MarksComplex(string grapheme)
+    {
+        var surface = new Surface(4, 1);
+        surface[0, 0] = new SurfaceCell(grapheme, null, null);
+        Assert.False(surface.IsFastPathEligible);
+    }
+
+    [Fact]
+    public void UnderlineStyle_MarksComplex()
+    {
+        var surface = new Surface(4, 1);
+        surface[0, 0] = new SurfaceCell(
+            "A", Hex1bColor.White, Hex1bColor.Black,
+            UnderlineStyle: UnderlineStyle.Single);
+        Assert.False(surface.IsFastPathEligible);
+    }
+
+    [Fact]
+    public void UnderlineColor_MarksComplex()
+    {
+        var surface = new Surface(4, 1);
+        surface[0, 0] = new SurfaceCell(
+            "A", Hex1bColor.White, Hex1bColor.Black,
+            UnderlineColor: Hex1bColor.Red);
+        Assert.False(surface.IsFastPathEligible);
+    }
+
+    [Fact]
+    public void WideCharacter_MarksComplex()
+    {
+        var surface = new Surface(4, 1);
+        // "あ" is a wide CJK char with DisplayWidth=2.
+        surface.WriteText(0, 0, "あ", Hex1bColor.White, Hex1bColor.Black);
+        Assert.False(surface.IsFastPathEligible);
+    }
+
+    [Fact]
+    public void Clear_ResetsFastPathFlag()
+    {
+        var surface = new Surface(4, 1);
+        surface[0, 0] = new SurfaceCell(
+            "A", Hex1bColor.White, Hex1bColor.Black,
+            UnderlineStyle: UnderlineStyle.Single);
+        Assert.False(surface.IsFastPathEligible);
+
+        surface.Clear();
+
+        Assert.True(surface.IsFastPathEligible);
+    }
+
+    [Fact]
+    public void ClearWithComplexCell_LeavesFlagSet()
+    {
+        var surface = new Surface(4, 1);
+        var complex = new SurfaceCell(
+            "A", Hex1bColor.White, Hex1bColor.Black,
+            UnderlineStyle: UnderlineStyle.Single);
+
+        surface.Clear(complex);
+
+        Assert.False(surface.IsFastPathEligible);
+    }
+
+    [Fact]
+    public void ClearWithSimpleCell_KeepsFlagClear()
+    {
+        var surface = new Surface(4, 1);
+        surface[0, 0] = new SurfaceCell(
+            "A", Hex1bColor.White, Hex1bColor.Black,
+            UnderlineStyle: UnderlineStyle.Single);
+        Assert.False(surface.IsFastPathEligible);
+
+        surface.Clear(new SurfaceCell(" ", null, Hex1bColor.Black));
+
+        Assert.True(surface.IsFastPathEligible);
+    }
+
+    [Fact]
+    public void Compare_FastPath_ProducesIdenticalDiffToSlowPath()
+    {
+        // Two surfaces filled with simple ASCII content; both are fast-eligible.
+        // The fast path output must exactly match what the slow path would produce.
+        var prev = new Surface(8, 3);
+        var curr = new Surface(8, 3);
+
+        for (var y = 0; y < 3; y++)
+        {
+            for (var x = 0; x < 8; x++)
+            {
+                prev[x, y] = new SurfaceCell("a", Hex1bColor.White, Hex1bColor.Black);
+                // Change every other cell to "b" with a different bg.
+                curr[x, y] = ((x + y) % 2 == 0)
+                    ? new SurfaceCell("a", Hex1bColor.White, Hex1bColor.Black)
+                    : new SurfaceCell("b", Hex1bColor.White, Hex1bColor.Red);
+            }
+        }
+
+        Assert.True(prev.IsFastPathEligible);
+        Assert.True(curr.IsFastPathEligible);
+
+        var diff = SurfaceComparer.Compare(prev, curr);
+
+        // Manually compute the expected changed-cell set.
+        var expected = new List<(int X, int Y, string Char)>();
+        for (var y = 0; y < 3; y++)
+            for (var x = 0; x < 8; x++)
+                if ((x + y) % 2 != 0)
+                    expected.Add((x, y, "b"));
+
+        Assert.Equal(expected.Count, diff.ChangedCells.Count);
+        for (var i = 0; i < expected.Count; i++)
+        {
+            Assert.Equal(expected[i].X, diff.ChangedCells[i].X);
+            Assert.Equal(expected[i].Y, diff.ChangedCells[i].Y);
+            Assert.Equal(expected[i].Char, diff.ChangedCells[i].Cell.Character);
+        }
+    }
+
+    [Fact]
+    public void Compare_MixedEligibility_FallsBackToSlowPathAndStillDetectsUnderlineChange()
+    {
+        // prev has only a plain cell; curr has an underline-changed cell.
+        // Because curr is NOT fast-eligible, the slow path runs and the underline
+        // change must be detected (this is the same scenario as the existing
+        // underline regression test, but through the new gating).
+        var prev = new Surface(1, 1);
+        var curr = new Surface(1, 1);
+
+        prev[0, 0] = new SurfaceCell("A", Hex1bColor.White, Hex1bColor.Black);
+        curr[0, 0] = new SurfaceCell(
+            "A", Hex1bColor.White, Hex1bColor.Black,
+            UnderlineStyle: UnderlineStyle.Single);
+
+        Assert.True(prev.IsFastPathEligible);
+        Assert.False(curr.IsFastPathEligible);
+
+        var diff = SurfaceComparer.Compare(prev, curr);
+
+        Assert.Single(diff.ChangedCells);
+        Assert.Equal(UnderlineStyle.Single, diff.ChangedCells[0].Cell.UnderlineStyle);
+    }
+
+    [Fact]
+    public void CompareToEmpty_FastPath_MatchesSlowPath()
+    {
+        var surface = new Surface(4, 2);
+        surface[0, 0] = new SurfaceCell("A", Hex1bColor.White, Hex1bColor.Black);
+        surface[3, 1] = new SurfaceCell("Z", Hex1bColor.White, Hex1bColor.Red);
+
+        Assert.True(surface.IsFastPathEligible);
+
+        var diff = SurfaceComparer.CompareToEmpty(surface);
+
+        Assert.Equal(2, diff.ChangedCells.Count);
+        Assert.Equal(0, diff.ChangedCells[0].X);
+        Assert.Equal(0, diff.ChangedCells[0].Y);
+        Assert.Equal("A", diff.ChangedCells[0].Cell.Character);
+        Assert.Equal(3, diff.ChangedCells[1].X);
+        Assert.Equal(1, diff.ChangedCells[1].Y);
+        Assert.Equal("Z", diff.ChangedCells[1].Cell.Character);
+    }
+}

--- a/tests/Hex1b.Tests/TableVisualTestHelper.cs
+++ b/tests/Hex1b.Tests/TableVisualTestHelper.cs
@@ -101,7 +101,7 @@ public static class TableVisualTestHelper
         using var terminal = Hex1bTerminal.CreateBuilder()
             .WithHeadless()
             .WithDimensions(testCase.Width, testCase.Height)
-            .WithHex1bApp((app, options) => ctx => BuildTableWidget(ctx, testCase, data))
+            .WithHex1bApp(ctx => BuildTableWidget(ctx, testCase, data))
             .Build();
         
         // Start terminal/app

--- a/tests/Hex1b.Tests/TerminalWidgetIntegrationTests.cs
+++ b/tests/Hex1b.Tests/TerminalWidgetIntegrationTests.cs
@@ -60,7 +60,9 @@ public class TerminalWidgetIntegrationTests
             
             // Create the terminal using the builder pattern (proper lifecycle)
             var terminal = Hex1bTerminal.CreateBuilder()
-                .WithHex1bApp((app, options) =>
+                .WithHex1bApp(
+                    _ => { },
+                    app =>
                 {
                     // Capture the app for test access
                     if (capturedContext != null)

--- a/tests/Hex1b.Tests/TilePanelNodeTests.cs
+++ b/tests/Hex1b.Tests/TilePanelNodeTests.cs
@@ -312,7 +312,7 @@ public class TilePanelIntegrationTests
         var ds = new TestTileDataSource();
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.VStack(v =>
+            .WithHex1bApp(ctx => ctx.VStack(v =>
             [
                 v.Text($"Camera: ({cameraX:F1}, {cameraY:F1})"),
                 v.TilePanel(ds, cameraX, cameraY, zoomLevel)
@@ -356,7 +356,7 @@ public class TilePanelIntegrationTests
         var ds = new TestTileDataSource();
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.VStack(v =>
+            .WithHex1bApp(ctx => ctx.VStack(v =>
             [
                 v.Text($"Zoom: {zoomLevel}"),
                 v.TilePanel(ds, 0, 0, zoomLevel)

--- a/tests/Hex1b.Tests/TrackedObjectTests.cs
+++ b/tests/Hex1b.Tests/TrackedObjectTests.cs
@@ -102,7 +102,7 @@ public class TrackedObjectTests
         };
 
         var bytes = AnsiTokenUtf8Serializer.Serialize(tokens);
-        workload.WriteTokensWithBytes(tokens, bytes);
+        await workload.WriteTokensWithBytesAsync(tokens, bytes);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .WaitUntil(s => s.ContainsSixelData(), TimeSpan.FromSeconds(5))

--- a/tests/Hex1b.Tests/TreeIntegrationTests.cs
+++ b/tests/Hex1b.Tests/TreeIntegrationTests.cs
@@ -91,7 +91,7 @@ public class TreeIntegrationTests
     public async Task Tree_RendersWithCorrectStructure()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => CreateSimpleTree())
+            .WithHex1bApp(ctx => CreateSimpleTree())
             .WithHeadless()
             .WithDimensions(60, 20)
             .Build();
@@ -119,7 +119,7 @@ public class TreeIntegrationTests
     public async Task Tree_RendersGuideLines_Unicode()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => CreateMultiRootTree())
+            .WithHex1bApp(ctx => CreateMultiRootTree())
             .WithHeadless()
             .WithDimensions(60, 20)
             .Build();
@@ -142,7 +142,7 @@ public class TreeIntegrationTests
     public async Task Tree_RendersGuideLines_Ascii()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.ThemePanel(
+            .WithHex1bApp(ctx => ctx.ThemePanel(
                 theme => theme
                     .Set(Theming.TreeTheme.Branch, "+- ")
                     .Set(Theming.TreeTheme.LastBranch, "\\- ")
@@ -171,7 +171,7 @@ public class TreeIntegrationTests
     public async Task Tree_CollapsedItem_HidesChildren()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TreeWidget([
+            .WithHex1bApp(ctx => new TreeWidget([
                 new TreeItemWidget("Root").Children(  // Not expanded
                     new TreeItemWidget("Hidden Child")
                 )
@@ -202,7 +202,7 @@ public class TreeIntegrationTests
     public async Task Tree_DownArrow_MovesToNextItem()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => CreateMultiRootTree())
+            .WithHex1bApp(ctx => CreateMultiRootTree())
             .WithHeadless()
             .WithDimensions(60, 20)
             .Build();
@@ -226,7 +226,7 @@ public class TreeIntegrationTests
     public async Task Tree_UpArrow_MovesToPreviousItem()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => CreateMultiRootTree())
+            .WithHex1bApp(ctx => CreateMultiRootTree())
             .WithHeadless()
             .WithDimensions(60, 20)
             .Build();
@@ -255,7 +255,7 @@ public class TreeIntegrationTests
     public async Task Tree_DownArrow_WrapsToFirst()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TreeWidget([
+            .WithHex1bApp(ctx => new TreeWidget([
                 new TreeItemWidget("Item 1"),
                 new TreeItemWidget("Item 2"),
                 new TreeItemWidget("Item 3")
@@ -284,7 +284,7 @@ public class TreeIntegrationTests
     public async Task Tree_UpArrow_WrapsToLast()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TreeWidget([
+            .WithHex1bApp(ctx => new TreeWidget([
                 new TreeItemWidget("Item 1"),
                 new TreeItemWidget("Item 2"),
                 new TreeItemWidget("Item 3")
@@ -379,7 +379,7 @@ public class TreeIntegrationTests
     public async Task Tree_RightArrow_OnExpandedItem_MovesToFirstChild()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TreeWidget([
+            .WithHex1bApp(ctx => new TreeWidget([
                 new TreeItemWidget("Parent").Expanded().Children(
                     new TreeItemWidget("First Child"),
                     new TreeItemWidget("Second Child")
@@ -407,7 +407,7 @@ public class TreeIntegrationTests
     public async Task Tree_LeftArrow_OnChild_MovesToParent()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TreeWidget([
+            .WithHex1bApp(ctx => new TreeWidget([
                 new TreeItemWidget("Parent").Expanded().Children(
                     new TreeItemWidget("Child")
                 )
@@ -437,7 +437,7 @@ public class TreeIntegrationTests
         var activatedLabel = "";
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TreeWidget([
+            .WithHex1bApp(ctx => new TreeWidget([
                 new TreeItemWidget("Item 1"),
                 new TreeItemWidget("Item 2")
             ]).OnItemActivated(e => { activatedLabel = e.Item.Label; }))
@@ -540,7 +540,7 @@ public class TreeIntegrationTests
     public async Task Tree_MultiSelect_RendersCheckboxes()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TreeWidget([
+            .WithHex1bApp(ctx => new TreeWidget([
                 new TreeItemWidget("Unchecked Item"),
                 new TreeItemWidget("Checked Item").Selected()
             ]).MultiSelect())
@@ -569,15 +569,13 @@ public class TreeIntegrationTests
     public async Task Tree_MouseClick_SelectsItem()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) =>
-            {
-                options.EnableMouse = true;
-                return ctx => new TreeWidget([
+            .WithHex1bApp(
+                options => options.EnableMouse = true,
+                ctx => new TreeWidget([
                     new TreeItemWidget("Item 1"),
                     new TreeItemWidget("Item 2"),
                     new TreeItemWidget("Item 3")
-                ]);
-            })
+                ]))
             .WithHeadless()
             .WithDimensions(60, 20)
             .Build();
@@ -606,7 +604,7 @@ public class TreeIntegrationTests
     public async Task Tree_InBorder_RendersCorrectly()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.Border(b => [
+            .WithHex1bApp(ctx => ctx.Border(b => [
                 b.Tree(
                     new TreeItemWidget("Root").Expanded().Children(
                         new TreeItemWidget("Child 1"),
@@ -642,7 +640,7 @@ public class TreeIntegrationTests
     public async Task Tree_InBorder_BorderCornersAtCorrectPositions()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.Border(b => [
+            .WithHex1bApp(ctx => ctx.Border(b => [
                 b.Tree(
                     new TreeItemWidget("Item 1"),
                     new TreeItemWidget("Item 2")
@@ -679,7 +677,7 @@ public class TreeIntegrationTests
     public async Task Tree_InNestedBorders_RendersCorrectly()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.Border(b => [
+            .WithHex1bApp(ctx => ctx.Border(b => [
                 b.Border(inner => [
                     inner.Tree(
                         new TreeItemWidget("Deep Item")
@@ -715,7 +713,7 @@ public class TreeIntegrationTests
         var longLabel = "This is a very long label that should be clipped when rendered in a narrow container";
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.Border(b => [
+            .WithHex1bApp(ctx => ctx.Border(b => [
                 b.Tree(
                     new TreeItemWidget(longLabel)
                 )
@@ -743,7 +741,7 @@ public class TreeIntegrationTests
     public async Task Tree_Clipping_ContentStaysWithinBorder()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.HStack(h => [
+            .WithHex1bApp(ctx => ctx.HStack(h => [
                 h.Border(b => [
                     b.Tree(
                         new TreeItemWidget("Left Tree Item")
@@ -788,7 +786,7 @@ public class TreeIntegrationTests
     public async Task Tree_TabNavigatesBetweenMultipleTrees()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.HStack(h => [
+            .WithHex1bApp(ctx => ctx.HStack(h => [
                 h.Border(b => [
                     b.Tree(
                         new TreeItemWidget("Left Item 1"),
@@ -842,7 +840,7 @@ public class TreeIntegrationTests
     public async Task Tree_DeepNavigation_TraversesAllLevels()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => CreateDeepTree())
+            .WithHex1bApp(ctx => CreateDeepTree())
             .WithHeadless()
             .WithDimensions(60, 20)
             .Build();
@@ -914,7 +912,7 @@ public class TreeIntegrationTests
         string expectedBranch, string expectedLastBranch)
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.ThemePanel(
+            .WithHex1bApp(ctx => ctx.ThemePanel(
                 theme => theme
                     .Set(Theming.TreeTheme.Branch, branch)
                     .Set(Theming.TreeTheme.LastBranch, lastBranch)
@@ -1068,7 +1066,7 @@ public class TreeIntegrationTests
     public async Task Tree_FirstItemFocusedOnRender()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TreeWidget([
+            .WithHex1bApp(ctx => new TreeWidget([
                 new TreeItemWidget("First"),
                 new TreeItemWidget("Second"),
                 new TreeItemWidget("Third")
@@ -1094,7 +1092,7 @@ public class TreeIntegrationTests
     public async Task Tree_PreExpandedItems_ShowChildren()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TreeWidget([
+            .WithHex1bApp(ctx => new TreeWidget([
                 new TreeItemWidget("Root").Expanded().Children(
                     new TreeItemWidget("Visible Child")
                 )

--- a/tests/Hex1b.Tests/WaitUntilTimeoutTests.cs
+++ b/tests/Hex1b.Tests/WaitUntilTimeoutTests.cs
@@ -13,7 +13,7 @@ public class WaitUntilTimeoutTests
     public async Task WaitUntil_Timeout_ThrowsWaitUntilTimeoutException()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Hello"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -34,7 +34,7 @@ public class WaitUntilTimeoutTests
     public async Task WaitUntil_Timeout_MessageContainsPredicateExpression()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Hello"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -56,7 +56,7 @@ public class WaitUntilTimeoutTests
     public async Task WaitUntil_Timeout_MessageContainsExplicitDescription()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Hello"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -78,7 +78,7 @@ public class WaitUntilTimeoutTests
     public async Task WaitUntil_Timeout_MessageContainsCallerLocation()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Hello"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -191,7 +191,7 @@ public class WaitUntilTimeoutTests
     public async Task WaitUntil_Timeout_MessageContainsTimeoutDuration()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Hello"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();

--- a/tests/Hex1b.Tool.Tests/RecordingProtocolTests.cs
+++ b/tests/Hex1b.Tool.Tests/RecordingProtocolTests.cs
@@ -12,7 +12,7 @@ public class RecordingProtocolTests
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithDimensions(80, 24)
             .WithHeadless()
-            .WithHex1bApp((app, options) => ctx => new Hex1b.Widgets.TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new Hex1b.Widgets.TextBlockWidget("Hello"))
             .WithDiagnostics(appName: "RecordTest", forceEnable: true)
             .Build();
 
@@ -70,7 +70,7 @@ public class RecordingProtocolTests
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithDimensions(80, 24)
             .WithHeadless()
-            .WithHex1bApp((app, options) => ctx => new Hex1b.Widgets.TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new Hex1b.Widgets.TextBlockWidget("Hello"))
             .WithDiagnostics(appName: "RecordTest2", forceEnable: true)
             .Build();
 
@@ -107,7 +107,7 @@ public class RecordingProtocolTests
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithDimensions(80, 24)
             .WithHeadless()
-            .WithHex1bApp((app, options) => ctx => new Hex1b.Widgets.TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new Hex1b.Widgets.TextBlockWidget("Hello"))
             .WithDiagnostics(appName: "RecordTest3", forceEnable: true)
             .Build();
 


### PR DESCRIPTION
Banks a chunk of rendering-perf work from a profiling pass on macOS. Opens for follow-up SGR/ToTokens prototype on the same branch.

## What's in this PR

### Render-loop frame cap
- `039b9223` — Hex1bApp rate-limits the **whole render loop**, not just animation `Schedule()`. Stops uncapped repaint storms.
- `f3a9a727` / `e89df73c` — PerfStressDemo wires `--target-fps` through `FrameRateLimitMs`; new `WithHex1bAppOptions` lets the builder configure app options pre-construction.

### Gen2 / LOH GC pressure (Tier 0)
- `59e8b4a7` — flips `EnableSurfacePooling` on by default after verifying tests pass.
- `fa574c6a` — render buffers retained across cache misses (Gen2 was being driven by per-frame replacements).
- `3dd69631` — eliminates per-frame LOH allocations in the renderer hot path (ANSI byte buffer was crossing 85 KB on busy fullscreen frames).
- `b60db010` — hides `WorkloadOutputItem.PooledBuffer` from the public API surface (internal pooling mechanism only).

### SOH / Gen0 churn (Tiers 1 + 2)
- `1d38b3f6` — pools per-frame `SurfaceDiff` and `AnsiToken` lists.
- `9e002e5c` — pools `AnsiToken` records and `SgrToken` strings via hash-keyed cache.

### Diff hot path
- `d5034e3d` — fixes a `CellsEqual` underline-state bug and drops a redundant per-frame sort.
- `351c85c9` — adds optional bounded backpressure on the workload→terminal channel.
- `c845f6ea` — **fast-path diff for surfaces with only simple cells**. A latched `IsFastPathEligible` flag on `Surface` (write-time; only reset on `Clear`) gates a slimmer 4-field `CellsEqualFast` in `SurfaceComparer`. Measured at 300×100, 5000 iter:
  - NoDiff: **1.91×** faster
  - SparseDiff (~10%): **1.55×** faster
  - FullDiff (ripple): 0.99× (per-cell compare is no longer the bottleneck)

### Demo / perf harness
- `4dea74ff` — PerfDemo gains busy mode + per-run metrics summary + baseline findings docs.
- `a09e211c` / `7d064837` — PerfStressDemo: cached noise surface, ASCII string pool, ripple uses brightness rather than hue.
- `6b3daad0` — PerfStressDemo `L` keybind cycles ripple quantisation levels.

## What's NOT in this PR (follow-up on same branch)

Profiling at 300×100 ripple FullDiff shows the remaining frame cost is:

| Stage | Cost |
|---|---|
| Compare (now fast-pathed) | 968 µs |
| **ToTokens** | **2,496 µs** |
| Serialize (bytes for presentation adapter) | 758 µs |

ToTokens dominates because every changed cell calls `BuildSgrParameters` → rents a `StringBuilder` → formats `38;2;R;G;B`. Follow-up prototype will try a span-based direct-encode path that bypasses StringBuilder for the common "only colours changed" case.

Token-list materialisation and serialization are NOT bypassable — tokens are consumed independently by workload filters / snapshot / asciinema; bytes are consumed by the presentation adapter to reach the actual TTY.

## Tests
- All 7772 tests pass (one known flake — #331 — recurs ~1/5–10 runs on macOS, unrelated to these changes).
- Added 12 new tests in `SurfaceFastPathTests.cs` covering flag latching, Clear semantics, fast/slow equivalence, mixed-eligibility fallback.

## Related
- Filed #331 for the pre-existing `ApplyAsync_SendsKeyEventsToTerminal` flake noticed during this work.
