### PR TITLE
Stabilize flow runner drag-resize behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -522,3 +522,4 @@ test-*.svg
 src/Hex1b/runtimes/linux-arm64/native/libhex1binterop.so
 src/Hex1b/runtimes/osx-x64/native/libhex1binterop.dylib
 src/Hex1b/runtimes/osx-arm64/native/libhex1binterop.dylib
+aspire.config.json

--- a/docs/perf/baseline.md
+++ b/docs/perf/baseline.md
@@ -1,0 +1,193 @@
+# Hex1b rendering performance — baseline (2026-05-26)
+
+> Captured on Apple Silicon (`Darwin 25.5.0 arm64`), .NET SDK 10.0.300,
+> `Release` build, using `samples/PerfDemo` with the new `--busy` mode.
+>
+> Repro:
+> ```bash
+> dotnet run -c Release --project samples/PerfDemo -- --busy --frames 300 --warmup 50
+> ```
+
+## Workload
+
+A representative "busy" UX:
+
+- Outer `HSplitter`: sidebar (Border + 20-item VStack, one row mutates per frame)
+  on the left; main pane on the right.
+- Main pane: outer `Border` wrapping a `VSplitter` of a Dashboard (Progress bar
+  + 8×12 numeric grid that mutates every cell every frame) and a Log
+  (20-line scrolling list — every visible row changes every frame).
+- 160 × 50 cells, frame-rate-limit 1 ms, surface rendering with the discard
+  workload adapter.
+
+The scene is deliberately tuned so that the per-frame diff produces ~200
+changed cells / ~330 ANSI tokens / ~1.2 KB output — non-trivial but not
+unrealistic for a real app.
+
+## Headline numbers (no caching, no pooling — i.e. defaults)
+
+| metric                              | mean    | p50     | p95     | p99     | max     |
+| ----------------------------------- | ------- | ------- | ------- | ------- | ------- |
+| `hex1b.frame.duration` (ms)         | 12.22   | 12.29   | 14.87   | 15.30   | 15.60   |
+| `hex1b.frame.build.duration` (ms)   | 0.011   | 0.006   | 0.022   | 0.040   | 1.104   |
+| `hex1b.frame.reconcile.duration`    | 0.050   | 0.031   | 0.098   | 0.113   | 2.554   |
+| `hex1b.frame.render.duration`       | 12.10   | 12.15   | 14.67   | 15.24   | 15.31   |
+| `hex1b.surface.diff.duration`       | 0.095   | 0.070   | 0.111   | 0.639   | 1.054   |
+| `hex1b.surface.tokens.duration`     | 0.013   | 0.007   | 0.028   | 0.045   | 0.053   |
+| `hex1b.surface.serialize.duration`  | 0.007   | 0.003   | 0.017   | 0.035   | 0.036   |
+
+| accounting | per frame |
+| ---------- | --------- |
+| allocations | **7.45 MB** |
+| Gen0 / Gen1 / Gen2 over 300 frames | **267 / 171 / 121** |
+| measure calls per frame (~162 nodes) | **~668** (~4× per node) |
+
+### Interpretation
+
+1. **Render phase is 99% of frame time** (12.10 / 12.22 ms).
+2. **The instrumented sub-phases of render (diff + tokens + serialize) total
+   ~0.12 ms** — i.e. less than 1% of the frame. The other ~12 ms is in
+   `node.Render` (cells being drawn onto the surface) and to a lesser
+   extent measure/arrange.
+3. **Allocations are the elephant in the room**: 7.45 MB per frame and
+   **121 Gen2 collections in 300 frames** (≈40% of frames trigger a Gen2 on
+   this machine). This is what makes the UI feel "crappy" even on fast
+   hardware — Gen2 collections produce visible stalls.
+4. The 4× over-measuring (~668 measure calls for 162 nodes) is real but
+   small compared to the allocation cost.
+
+## A/B: caching and pooling
+
+300-frame busy run, same machine, identical workload:
+
+| variant                 | frame mean (ms) | bytes/frame | Gen0/Gen1/Gen2 |
+| ----------------------- | --------------: | ----------: | -------------: |
+| **new defaults (pool on)** | **10.72**    | **3,462,716** | **124 / 32 / 0** |
+| `--no-pool` (legacy default) | 12.16       | 7,436,100   | 279 / 192 / 138 |
+| `--cache` (caching on)  | 12.31           | 7,323,975   | 244 / 180 / 111 |
+
+### What this means
+
+- **`EnableSurfacePooling` is now the default** as of this branch — the
+  full Hex1b test suite (7902 tests across 5 projects) passes unchanged,
+  and the original commit message only described it as "opt-in" with no
+  recorded correctness reason. Measured against the previous default:
+  - **-53% allocations per frame**
+  - **138 → 0 Gen2 GCs** over 300 frames
+  - **-12% mean frame time**
+- `EnableRenderCaching` does nothing here because every visible widget
+  changes every frame (the scrolling log). It's still useful in scenes
+  with large static subtrees — `samples/PerfDemo` (non-busy mode) is the
+  case to validate that.
+
+## CPU hotspots (managed inclusive time, ~300 frames sampled)
+
+From `dotnet-trace --profile dotnet-sampled-thread-time` (Apple Silicon)
+converted to speedscope. Managed self-time per frame is below the sampling
+floor (≤10 ms ticks vs ~12 ms total per frame), so we read **inclusive**
+time:
+
+| % wall | inclusive ms | function |
+| -----: | ----------: | -------- |
+| 73.96  | 26,898 | `Surfaces.SurfaceRenderContext.RenderChild` (root of the render tree) |
+| 19.01  |  6,914 | `SplitterNode.Render` |
+| 18.70  |  6,802 | `Nodes.LayoutNode.Render` |
+| 18.32  |  6,663 | `Nodes.BorderNode.Render` |
+| 14.83  |  5,393 | `VStackNode.Render` |
+| 13.64  |  4,960 | `Hex1bApp.RenderFrameWithSurface` |
+| 13.36  |  4,858 | `ZStackNode.Render` |
+|  8.81  |  3,202 | `Hex1bApp.RenderFrameAsync` |
+|  8.70  |  3,162 | `Thread.PollGC` *(GC pressure signal)* |
+|  8.49  |  3,086 | `Buffer.BulkMoveWithWriteBarrier` *(surface composite/array copies)* |
+
+The most expensive *leaf* operation on the render path is
+**`Buffer.BulkMoveWithWriteBarrier`** at ~8.5%, which is the bulk-copy
+behind `Surface.Composite` / `SurfaceCell[]` clones. The next layer up is
+the per-cell write path through `SurfaceRenderContext.WriteToSurface` /
+`SliceByDisplayWidthWithAnsi` / `DisplayWidth.GetGraphemeAtIndex` /
+`TextSegmentationUtility.GetLengthOfFirstExtendedGraphemeCluster` — i.e.
+**grapheme analysis runs on every single cell write**, which is likely a
+significant fraction of the per-node render time.
+
+Raw speedscope JSON is saved to
+`~/.copilot/session-state/<session>/files/baseline-busy300.speedscope.json`
+for inspection in https://speedscope.app .
+
+## Ranked optimisation opportunities
+
+| # | hypothesis | est. impact | risk |
+|---|------------|-------------|------|
+| 1 | ✅ **DONE — `EnableSurfacePooling` default flipped to `true`.** Full test suite still green (7902 tests, 0 failures). Measured -53% allocations, -12% frame, 0 Gen2 GCs vs previous default. | shipped | — |
+| 2 | ASCII fast path for any remaining hot grapheme calls (`DisplayWidth.GetGraphemeAtIndex` / `TextSegmentationUtility.GetLengthOfFirstExtendedGraphemeCluster` still appear in the busy trace despite an existing fast-path in `GetNextGrapheme` — likely a second call site). | high | low |
+| 3 | Reduce measure-pass amplification. ~4× per node on splitter-heavy trees. Likely two-pass measure inside `SplitterNode`; verify and short-circuit when constraints are tight. | medium | medium |
+| 4 | Pool / reuse the `ChangedCell` list and other per-frame collections inside `SurfaceComparer`. Currently allocates a fresh `List<ChangedCell>` and sorts it every frame. | medium | low |
+| 5 | Per-node `Render` allocations (Splitter / Border / VStack / ZStack). Investigate `string.Format`, `string` interpolation, and any `LINQ`/`ToList()` inside these — the inclusive-time signal is loud but cell-write cost may be the bulk. Need per-call allocation instrumentation. | medium | low |
+| 6 | `Buffer.BulkMoveWithWriteBarrier` at 8.5% suggests `SurfaceCell[]` is being cloned. Investigate `Surface.Composite` / `Surface.Clone`; if cells are value-type-ish and bigger than 16 bytes, copy cost can be reduced via in-place writes or smaller cell representation. | medium | medium |
+
+Numbers 2–6 should each get a BenchmarkDotNet case in
+`benchmarks/Hex1b.Benchmarks/` and an A/B run via this same `--busy`
+workload before/after.
+
+## How to reproduce / re-measure
+
+```bash
+# Build once
+dotnet build -c Release samples/PerfDemo/PerfDemo.csproj
+
+# Headline busy run (prints metrics summary at the end)
+dotnet run -c Release --project samples/PerfDemo --no-build -- \
+    --busy --frames 300 --warmup 50
+
+# Enable per-node histograms (tagged by node metric path)
+dotnet run -c Release --project samples/PerfDemo --no-build -- \
+    --busy --per-node --frames 300 --warmup 50
+
+# Compare cache / pool variants
+dotnet run -c Release --project samples/PerfDemo --no-build -- --busy --cache
+dotnet run -c Release --project samples/PerfDemo --no-build -- --busy --no-pool
+
+# CPU profile (macOS / Linux compatible profile)
+dotnet-trace collect --format speedscope --profile dotnet-sampled-thread-time \
+  --duration 00:00:00:30 \
+  -- $HOME/.dotnet/dotnet samples/PerfDemo/bin/Release/net10.0/PerfDemo.dll \
+        --busy --frames 300 --warmup 50 --no-summary
+# Then open the .speedscope.json file in https://speedscope.app
+```
+
+### New flags added to `PerfDemo`
+
+| flag | default | meaning |
+|------|---------|---------|
+| `--busy` | off | Use the realistic "busy" widget tree instead of the static panel |
+| `--per-node` | off | Enable per-node histograms (extra meter instruments) |
+| `--no-summary` | summary on | Suppress the end-of-run metric summary |
+| `--no-pool` | pool on | Disable surface pooling (matches the pre-default-flip behaviour for A/B) |
+| `--cache` | off | Enable widget-tree render caching |
+| `--busy-sidebar N` | 20 | Sidebar item count |
+| `--busy-log N` | 20 | Scrolling log line count |
+| `--busy-grid-rows N` | 8 | Dashboard grid rows |
+| `--busy-grid-cols N` | 12 | Dashboard grid columns |
+| `--width N` | 160 (busy) | Terminal width |
+| `--height N` | 50 (busy) | Terminal height |
+
+## Interactive repro: `samples/PerfStressDemo`
+
+`PerfDemo` measures with the output discarded. `PerfStressDemo` is the
+companion that runs as a *real* TUI so the regression is visible to the
+naked eye (and to a `dotnet-trace` run against the live process).
+
+```bash
+dotnet run -c Release --project samples/PerfStressDemo                # defaults: pool on, ~30 fps target
+dotnet run -c Release --project samples/PerfStressDemo -- --no-pool   # A/B: pool off
+```
+
+* `PgUp` / `PgDn` switch between stress pages, `Q` quits.
+* The status bar shows live FPS and accumulated GC counts (Gen0 / Gen1 /
+  Gen2), so the SurfacePool win is unmistakable: with the pool on Gen2
+  stays at 0; with `--no-pool` it climbs steadily.
+
+Pages currently shipped:
+
+1. **Ripple over noise** — full-screen white random ASCII inside an
+   `EffectPanel` painting a continuously expanding circular ripple. This
+   is the workload that originally motivated the perf investigation.

--- a/samples/AccordionDemo/Program.cs
+++ b/samples/AccordionDemo/Program.cs
@@ -229,7 +229,7 @@ var rootEntry = FileEntry.ScanDirectory(workspaceDir, workspaceDir);
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithDiagnostics()
     .WithMouse()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         return ctx.VStack(v =>
         [

--- a/samples/AgenticPromptDemo/Program.cs
+++ b/samples/AgenticPromptDemo/Program.cs
@@ -95,7 +95,9 @@ string lastCopySummary = "no copies yet";
 IReadOnlyList<SelectionPanelSelectedNode> lastSelectedNodes = Array.Empty<SelectionPanelSelectedNode>();
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(
+        _ => { },
+        app => ctx =>
     {
         return ctx.VStack(v =>
         [

--- a/samples/AnimationProof/Program.cs
+++ b/samples/AnimationProof/Program.cs
@@ -17,7 +17,9 @@ var serverLoading = false;
 var serverChildren = new List<TreeItemWidget>();
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+    .WithHex1bApp(
+        _ => { },
+        app => ctx => ctx.VStack(v => [
         v.Text("🧪 Animation & Tree API Proof-of-Concept"),
         v.Text(""),
         

--- a/samples/AsciinemaPlaybackDemo/Program.cs
+++ b/samples/AsciinemaPlaybackDemo/Program.cs
@@ -225,7 +225,9 @@ Hex1bWidget BuildUI(RootContext ctx)
 using var appCts = new CancellationTokenSource();
 await using var displayTerminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((a, options) =>
+    .WithHex1bApp(
+        _ => { },
+        a =>
     {
         app = a;
         return ctx => BuildUI(ctx);

--- a/samples/BlazorDemo/GlobeRunner.cs
+++ b/samples/BlazorDemo/GlobeRunner.cs
@@ -56,7 +56,7 @@ public static class GlobeRunner
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithPresentation(adapter)
-            .WithHex1bApp((app, options) => ctx =>
+            .WithHex1bApp(ctx =>
                 ctx.ZStack(z => [
                     z.Interactable((Func<InteractableContext, Hex1bWidget>)(ic =>
                         ic.Surface(s =>

--- a/samples/BuildLogoDemo/Program.cs
+++ b/samples/BuildLogoDemo/Program.cs
@@ -2,7 +2,7 @@ using Hex1b;
 using Hex1b.Layout;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         return ctx.Center(c =>
             c.Surface(s => BuildLogoDemo.BuildLogo.BuildLayers(s))

--- a/samples/CalendarDemo/Program.cs
+++ b/samples/CalendarDemo/Program.cs
@@ -9,7 +9,7 @@ var pickerDate = "None";
 
 await using var terminal = Hex1b.Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         return ctx.VStack(v =>
         {

--- a/samples/ChartingDemo/Program.cs
+++ b/samples/ChartingDemo/Program.cs
@@ -135,7 +135,7 @@ var regionData = new[]
 
 var terminal = Hex1bTerminal.CreateBuilder()
     .WithDiagnostics()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
         ctx.TabPanel(tp => [
             tp.Tab("Simple Columns", t => [
                 t.ColumnChart(monthlySales)

--- a/samples/CompositionDemo/Program.cs
+++ b/samples/CompositionDemo/Program.cs
@@ -24,7 +24,9 @@ using Hex1b.Widgets;
 Hex1bApp? app = null;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((a, options) =>
+    .WithHex1bApp(
+        _ => { },
+        a =>
     {
         app = a;
         return ctx => ctx.AppShell(InvalidateApp, RequestStopApp);

--- a/samples/DockerDemo/Program.cs
+++ b/samples/DockerDemo/Program.cs
@@ -271,7 +271,9 @@ CellPatternSearcher BuildMarkerSearcher(string marker)
 // Build the TUI app
 await using var app = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((appRef, options) =>
+    .WithHex1bApp(
+        _ => { },
+        appRef =>
     {
         displayApp = appRef;
 

--- a/samples/DragBarPanelDemo/Program.cs
+++ b/samples/DragBarPanelDemo/Program.cs
@@ -2,7 +2,7 @@ using Hex1b;
 using Hex1b.Widgets;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
         ctx.VStack(outer => [
             outer.Text(" DragBarPanel Demo").FixedHeight(1),
             outer.Text("─────────────────────────────────────────────────").FixedHeight(1),

--- a/samples/DrawerDemo/Program.cs
+++ b/samples/DrawerDemo/Program.cs
@@ -26,7 +26,7 @@ _ = Task.Run(async () =>
 });
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     // Wrap in ZStack for popup support (required for overlay mode)
     ctx.ZStack(z => [
         z.VStack(outer => [

--- a/samples/EmbeddedTerminalDemo/Program.cs
+++ b/samples/EmbeddedTerminalDemo/Program.cs
@@ -452,7 +452,9 @@ Hex1bWidget BuildTerminalWidget(RootContext ctx)
 // Create the TUI app that displays terminals
 await using var displayTerminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((app, options) =>
+    .WithHex1bApp(
+        _ => { },
+        app =>
     {
         displayApp = app;
         return ctx => BuildTerminalWidget(ctx);

--- a/samples/EncryptedMuxerDemo/SessionManagerApp.cs
+++ b/samples/EncryptedMuxerDemo/SessionManagerApp.cs
@@ -23,7 +23,9 @@ internal sealed class SessionManagerApp
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithMouse()
-            .WithHex1bApp((app, _) =>
+            .WithHex1bApp(
+                _ => { },
+                app =>
             {
                 _app = app;
                 return ctx =>

--- a/samples/FancyFlowDemo/FancyFlowDemo.csproj
+++ b/samples/FancyFlowDemo/FancyFlowDemo.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <PublishAot>true</PublishAot>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Hex1b/Hex1b.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/FancyFlowDemo/Flow/FancyFlowCancellation.cs
+++ b/samples/FancyFlowDemo/Flow/FancyFlowCancellation.cs
@@ -1,0 +1,48 @@
+using Hex1b;
+using Hex1b.Flow;
+using Hex1b.Input;
+using Hex1b.Widgets;
+
+namespace FancyFlowDemo.Flow;
+
+/// <summary>
+/// Shared cancellation state for a single FancyFlowDemo run. A Ctrl+C binding
+/// installed on each step's root widget calls <see cref="Cancel"/> and ends
+/// the active step; the orchestrator then propagates an
+/// <see cref="OperationCanceledException"/> via <see cref="ThrowIfCancelled"/>
+/// so the run unwinds cleanly to the top-level catch.
+/// </summary>
+internal sealed class FancyFlowCancellation
+{
+    private readonly CancellationTokenSource _cts = new();
+
+    public CancellationToken Token => _cts.Token;
+    public bool IsCancelled => _cts.IsCancellationRequested;
+
+    public void Cancel()
+    {
+        try { _cts.Cancel(); } catch (ObjectDisposedException) { }
+    }
+
+    public void ThrowIfCancelled() => _cts.Token.ThrowIfCancellationRequested();
+}
+
+internal static class FancyFlowCancellationExtensions
+{
+    /// <summary>
+    /// Wraps a step's root widget with a Ctrl+C binding that signals
+    /// cancellation and exits the current step.
+    /// </summary>
+    public static TWidget ExitOnCtrlC<TWidget>(this TWidget widget, FancyFlowCancellation cancel, FlowStepContext ctx)
+        where TWidget : Hex1bWidget
+    {
+        return widget.InputBindings(b =>
+        {
+            b.Ctrl().Key(Hex1bKey.C).Action(_ =>
+            {
+                cancel.Cancel();
+                ctx.Step.Complete();
+            }, "Cancel and exit");
+        });
+    }
+}

--- a/samples/FancyFlowDemo/Flow/FancyFlowOrchestrator.cs
+++ b/samples/FancyFlowDemo/Flow/FancyFlowOrchestrator.cs
@@ -94,15 +94,15 @@ internal static class FancyFlowOrchestrator
                     options.InitialCursorRow = cursorRow;
 
                     // Hold the live step still during interactive drag-resize.
-                    // The runner track-and-clears the active region on every
-                    // Hex1bResizeEvent, paints the placeholder below in its
-                    // place, then debounces the real repaint until the user
-                    // stops dragging. If the final dimensions differ from where
-                    // the drag started, the marker is dropped as a one-off
-                    // tombstone above the repainted step so the scrollback
-                    // visibly records that a resize happened.
+                    // The runner tracks cursor position internally on every
+                    // resize event but does not mutate the screen — letting
+                    // the host terminal's own reflow keep the tombstones
+                    // above the active step intact. The actual repaint of
+                    // the live step is debounced until events settle, and
+                    // if the final dimensions differ from where the drag
+                    // started a one-off ResizeMarker tombstone is dropped
+                    // above the repainted step.
                     options.ResizeSettleDelay = TimeSpan.FromMilliseconds(80);
-                    options.ResizePlaceholder = BuildResizePlaceholder;
                     options.ResizeMarker = BuildResizeMarker;
                 })
                 .Build()
@@ -116,26 +116,6 @@ internal static class FancyFlowOrchestrator
             // more to do — the inline tombstone is the final word.
         }
     }
-
-    /// <summary>
-    /// Drawn into the active prompt's region on every resize event during a
-    /// drag — kept deliberately spartan since it re-renders many times in
-    /// quick succession and any chrome would just smear under a fast drag.
-    /// Preserves the flow's gutter bar so the visual rhythm survives the
-    /// drag, with a single muted "resizing…" line in place of the prompt.
-    /// </summary>
-    private static Hex1b.Widgets.Hex1bWidget BuildResizePlaceholder(RootContext ctx) =>
-        ctx.HStack(h =>
-        [
-            h.Text(" "),
-            h.ThemePanel(
-                t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.BarColor),
-                h.Text(TemplatePromptWidget.BarChar)),
-            h.Text("  "),
-            h.ThemePanel(
-                t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.MutedColor),
-                h.Text("resizing…")),
-        ]);
 
     /// <summary>
     /// Dropped into scrollback as a one-off marker once a resize has settled

--- a/samples/FancyFlowDemo/Flow/FancyFlowOrchestrator.cs
+++ b/samples/FancyFlowDemo/Flow/FancyFlowOrchestrator.cs
@@ -93,6 +93,15 @@ internal static class FancyFlowOrchestrator
                 {
                     options.InitialCursorRow = cursorRow;
 
+                    // Emit completed steps as soft-wrap tombstones (proper
+                    // logical lines that the host terminal reflows) and
+                    // turn on the track-and-clear settle-based resize
+                    // pipeline. Without this flag the runner falls back
+                    // to the legacy eager-repaint resize path which
+                    // re-emits the active step on every resize event —
+                    // catastrophic during a drag-resize burst.
+                    options.UseSoftWrapTombstones = true;
+
                     // Hold the live step still during interactive drag-resize.
                     // The runner tracks cursor position internally on every
                     // resize event but does not mutate the screen — letting

--- a/samples/FancyFlowDemo/Flow/FancyFlowOrchestrator.cs
+++ b/samples/FancyFlowDemo/Flow/FancyFlowOrchestrator.cs
@@ -107,12 +107,8 @@ internal static class FancyFlowOrchestrator
                     // resize event but does not mutate the screen — letting
                     // the host terminal's own reflow keep the tombstones
                     // above the active step intact. The actual repaint of
-                    // the live step is debounced until events settle, and
-                    // if the final dimensions differ from where the drag
-                    // started a one-off ResizeMarker tombstone is dropped
-                    // above the repainted step.
+                    // the live step is debounced until events settle.
                     options.ResizeSettleDelay = TimeSpan.FromMilliseconds(80);
-                    options.ResizeMarker = BuildResizeMarker;
                 })
                 .Build()
                 .RunAsync();
@@ -126,23 +122,6 @@ internal static class FancyFlowOrchestrator
         }
     }
 
-    /// <summary>
-    /// Dropped into scrollback as a one-off marker once a resize has settled
-    /// and the final dimensions actually differ from where the drag started.
-    /// Acts as a faint breadcrumb between the pre- and post-resize renders.
-    /// </summary>
-    private static Hex1b.Widgets.Hex1bWidget BuildResizeMarker(RootContext ctx) =>
-        ctx.HStack(h =>
-        [
-            h.Text(" "),
-            h.ThemePanel(
-                t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.BarColor),
-                h.Text(TemplatePromptWidget.BarChar)),
-            h.Text("  "),
-            h.ThemePanel(
-                t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.MutedColor),
-                h.Text("─── terminal resized ───")),
-        ]);
 
     private static Task RunStepAsync(
         Hex1b.Flow.Hex1bFlowContext flow,

--- a/samples/FancyFlowDemo/Flow/FancyFlowOrchestrator.cs
+++ b/samples/FancyFlowDemo/Flow/FancyFlowOrchestrator.cs
@@ -129,18 +129,19 @@ internal static class FancyFlowOrchestrator
     /// muted-grey line keeps the visible footprint minimal and fits
     /// inside even an aggressively shrunken terminal.
     /// </summary>
-    private static Hex1b.Widgets.Hex1bWidget BuildResizePlaceholder(RootContext ctx) =>
-        ctx.HStack(h =>
-        [
-            h.Text(" "),
-            h.ThemePanel(
-                t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.BarColor),
-                h.Text(TemplatePromptWidget.BarChar)),
-            h.Text("  "),
-            h.ThemePanel(
-                t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.MutedColor),
-                h.Text("Resizing…")),
-        ]);
+    private static Task<Hex1b.Widgets.Hex1bWidget> BuildResizePlaceholder(RootContext ctx) =>
+        Task.FromResult<Hex1b.Widgets.Hex1bWidget>(
+            ctx.HStack(h =>
+            [
+                h.Text(" "),
+                h.ThemePanel(
+                    t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.BarColor),
+                    h.Text(TemplatePromptWidget.BarChar)),
+                h.Text("  "),
+                h.ThemePanel(
+                    t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.MutedColor),
+                    h.Text("Resizing…")),
+            ]));
 
 
     private static Task RunStepAsync(

--- a/samples/FancyFlowDemo/Flow/FancyFlowOrchestrator.cs
+++ b/samples/FancyFlowDemo/Flow/FancyFlowOrchestrator.cs
@@ -1,0 +1,99 @@
+using FancyFlowDemo.State;
+using FancyFlowDemo.Widgets;
+using Hex1b;
+
+namespace FancyFlowDemo.Flow;
+
+/// <summary>
+/// Drives the FancyFlowDemo prompt sequence end-to-end. The orchestrator owns
+/// the terminal builder, the flow callback, and the post-flow summary so the
+/// <c>Program.cs</c> entry point can stay a single line.
+/// </summary>
+internal static class FancyFlowOrchestrator
+{
+    private static readonly string[] Languages = ["C#", "TypeScript", "Python", "F#"];
+
+    private static readonly (string Id, string Name, string Description)[] Templates =
+    [
+        ("aspire-starter",       "Starter (ASP.NET Core + Blazor)",   "An ASP.NET Core API and a Blazor frontend."),
+        ("aspire-react-starter", "Starter (ASP.NET Core + React)",    "An ASP.NET Core API and a Vite/React frontend."),
+        ("aspire-py-starter",    "Starter (FastAPI + React)",         "A FastAPI backend and a Vite/React frontend."),
+        ("aspire-empty",         "Empty AppHost",                     "Just an Aspire AppHost — bring your own services."),
+    ];
+
+    private static readonly string[] HostnamePatterns = ["localhost", "*.dev.localhost"];
+
+    public static async Task RunAsync()
+    {
+        var cancel = new FancyFlowCancellation();
+        var selections = new FancyFlowSelections();
+
+        try
+        {
+            var cursorRow = Console.GetCursorPosition().Top;
+
+            // Note: deliberately not `await using` — disposing the terminal emits
+            // the alternate-screen exit sequence (ESC[?1049l) which most terminals
+            // interpret as "restore the pre-flow buffer", visually clearing the
+            // inline flow output we just wrote. Letting the terminal go out of
+            // scope without explicit dispose keeps the rendered flow on screen,
+            // matching the FlowDemo/NewCommand pattern.
+            await Hex1bTerminal.CreateBuilder()
+                .WithScrollback()
+                .WithHex1bFlow(async flow =>
+                {
+                    // Blank bar-only row above the first prompt to give the gutter
+                    // somewhere to "start" before any tombstone is emitted.
+                    await flow.ShowAsync(ctx => TombstoneFactory.BuildBarRow(ctx));
+
+                    await RunStepAsync(flow, ctx => ctx.LanguagePrompt(ctx, cancel, selections, Languages), Languages.Length + 9);
+                    cancel.ThrowIfCancelled();
+
+                    await RunStepAsync(flow, ctx => ctx.TemplatePromptStep(ctx, cancel, selections, Templates), Templates.Length + 9);
+                    cancel.ThrowIfCancelled();
+
+                    await RunStepAsync(flow, ctx => ctx.FolderPrompt(ctx, cancel, selections), 11);
+                    cancel.ThrowIfCancelled();
+
+                    await RunStepAsync(flow, ctx => ctx.HostnamePrompt(ctx, cancel, selections, HostnamePatterns), 9);
+                    cancel.ThrowIfCancelled();
+                },
+                options =>
+                {
+                    options.InitialCursorRow = cursorRow;
+                })
+                .Build()
+                .RunAsync();
+
+            cancel.ThrowIfCancelled();
+
+            PrintSummary(selections);
+        }
+        catch (OperationCanceledException) when (cancel.IsCancelled)
+        {
+            Console.WriteLine();
+            Console.WriteLine("✗ Cancelled. Goodbye!");
+        }
+    }
+
+    private static Task RunStepAsync(
+        Hex1b.Flow.Hex1bFlowContext flow,
+        Func<Hex1b.Flow.FlowStepContext, Hex1b.Widgets.Hex1bWidget> builder,
+        int maxHeight)
+    {
+        var step = flow.Step(builder, opts => opts.MaxHeight = maxHeight);
+        return step.WaitForCompletionAsync();
+    }
+
+    private static void PrintSummary(FancyFlowSelections selections)
+    {
+        Console.WriteLine();
+        Console.WriteLine("✨ All set! Here's what we'll create:");
+        Console.WriteLine();
+        Console.WriteLine($"   Language : {selections.Language}");
+        Console.WriteLine($"   Template : {selections.TemplateName} ({selections.TemplateId})");
+        Console.WriteLine($"   Folder   : {selections.Folder}");
+        Console.WriteLine($"   Hostname : {selections.HostnamePattern}");
+        Console.WriteLine();
+    }
+}

--- a/samples/FancyFlowDemo/Flow/FancyFlowOrchestrator.cs
+++ b/samples/FancyFlowDemo/Flow/FancyFlowOrchestrator.cs
@@ -109,6 +109,7 @@ internal static class FancyFlowOrchestrator
                     // above the active step intact. The actual repaint of
                     // the live step is debounced until events settle.
                     options.ResizeSettleDelay = TimeSpan.FromMilliseconds(80);
+                    options.ResizePlaceholder = BuildResizePlaceholder;
                 })
                 .Build()
                 .RunAsync();
@@ -121,6 +122,25 @@ internal static class FancyFlowOrchestrator
             // more to do — the inline tombstone is the final word.
         }
     }
+
+    /// <summary>
+    /// Rendered in the active step's rectangle during a resize burst,
+    /// replaced by the real prompt as soon as events settle. A single
+    /// muted-grey line keeps the visible footprint minimal and fits
+    /// inside even an aggressively shrunken terminal.
+    /// </summary>
+    private static Hex1b.Widgets.Hex1bWidget BuildResizePlaceholder(RootContext ctx) =>
+        ctx.HStack(h =>
+        [
+            h.Text(" "),
+            h.ThemePanel(
+                t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.BarColor),
+                h.Text(TemplatePromptWidget.BarChar)),
+            h.Text("  "),
+            h.ThemePanel(
+                t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.MutedColor),
+                h.Text("Resizing…")),
+        ]);
 
 
     private static Task RunStepAsync(

--- a/samples/FancyFlowDemo/Flow/FancyFlowOrchestrator.cs
+++ b/samples/FancyFlowDemo/Flow/FancyFlowOrchestrator.cs
@@ -129,19 +129,18 @@ internal static class FancyFlowOrchestrator
     /// muted-grey line keeps the visible footprint minimal and fits
     /// inside even an aggressively shrunken terminal.
     /// </summary>
-    private static Task<Hex1b.Widgets.Hex1bWidget> BuildResizePlaceholder(RootContext ctx) =>
-        Task.FromResult<Hex1b.Widgets.Hex1bWidget>(
-            ctx.HStack(h =>
-            [
-                h.Text(" "),
-                h.ThemePanel(
-                    t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.BarColor),
-                    h.Text(TemplatePromptWidget.BarChar)),
-                h.Text("  "),
-                h.ThemePanel(
-                    t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.MutedColor),
-                    h.Text("Resizing…")),
-            ]));
+    private static Hex1b.Widgets.Hex1bWidget BuildResizePlaceholder(RootContext ctx) =>
+        ctx.HStack(h =>
+        [
+            h.Text(" "),
+            h.ThemePanel(
+                t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.BarColor),
+                h.Text(TemplatePromptWidget.BarChar)),
+            h.Text("  "),
+            h.ThemePanel(
+                t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.MutedColor),
+                h.Text("Resizing…")),
+        ]);
 
 
     private static Task RunStepAsync(

--- a/samples/FancyFlowDemo/Flow/FancyFlowOrchestrator.cs
+++ b/samples/FancyFlowDemo/Flow/FancyFlowOrchestrator.cs
@@ -1,6 +1,7 @@
 using FancyFlowDemo.State;
 using FancyFlowDemo.Widgets;
 using Hex1b;
+using Hex1b.Theming;
 
 namespace FancyFlowDemo.Flow;
 
@@ -42,39 +43,117 @@ internal static class FancyFlowOrchestrator
                 .WithScrollback()
                 .WithHex1bFlow(async flow =>
                 {
-                    // Blank bar-only row above the first prompt to give the gutter
-                    // somewhere to "start" before any tombstone is emitted.
-                    await flow.ShowAsync(ctx => TombstoneFactory.BuildBarRow(ctx));
+                    // Opening "header" marker — anchors the start of the flow
+                    // and gives the gutter somewhere to begin.
+                    await flow.ShowAsync(ctx => TombstoneFactory.BuildHeader(ctx, "Create a new app"));
 
-                    await RunStepAsync(flow, ctx => ctx.LanguagePrompt(ctx, cancel, selections, Languages), Languages.Length + 9);
-                    cancel.ThrowIfCancelled();
+                    try
+                    {
+                        await RunStepAsync(flow, ctx => ctx.LanguagePrompt(ctx, cancel, selections, Languages), Languages.Length + 9);
+                        cancel.ThrowIfCancelled();
 
-                    await RunStepAsync(flow, ctx => ctx.TemplatePromptStep(ctx, cancel, selections, Templates), Templates.Length + 9);
-                    cancel.ThrowIfCancelled();
+                        await RunStepAsync(flow, ctx => ctx.TemplatePromptStep(ctx, cancel, selections, Templates), Templates.Length + 9);
+                        cancel.ThrowIfCancelled();
 
-                    await RunStepAsync(flow, ctx => ctx.FolderPrompt(ctx, cancel, selections), 11);
-                    cancel.ThrowIfCancelled();
+                        await RunStepAsync(flow, ctx => ctx.FolderPrompt(ctx, cancel, selections), 11);
+                        cancel.ThrowIfCancelled();
 
-                    await RunStepAsync(flow, ctx => ctx.HostnamePrompt(ctx, cancel, selections, HostnamePatterns), 9);
-                    cancel.ThrowIfCancelled();
+                        await RunStepAsync(flow, ctx => ctx.HostnamePrompt(ctx, cancel, selections, HostnamePatterns), 9);
+                        cancel.ThrowIfCancelled();
+
+                        // Simulated work between the final prompt and the success
+                        // outcome — keeps the flow feeling like a real scaffolder.
+                        await RunStepAsync(flow, ctx => ctx.ProcessingStep(ctx, cancel, selections), 9);
+                        cancel.ThrowIfCancelled();
+
+                        await flow.ShowAsync(ctx => TombstoneFactory.BuildOutcome(
+                            ctx,
+                            TombstoneFactory.SuccessMarker,
+                            TombstoneFactory.SuccessColor,
+                            "All set — your app is ready.",
+                            $"Language : {selections.Language}",
+                            $"Template : {selections.TemplateName} ({selections.TemplateId})",
+                            $"Folder   : {selections.Folder}",
+                            $"Hostname : {selections.HostnamePattern}"));
+                    }
+                    catch (OperationCanceledException) when (cancel.IsCancelled)
+                    {
+                        // Render the cancel outcome inline so it sits naturally
+                        // beneath whichever prompt the user bailed from, then
+                        // rethrow so the outer handler can short-circuit cleanly.
+                        await flow.ShowAsync(ctx => TombstoneFactory.BuildOutcome(
+                            ctx,
+                            TombstoneFactory.CancelMarker,
+                            TombstoneFactory.CancelColor,
+                            "Cancelled. No app was created."));
+                        throw;
+                    }
                 },
                 options =>
                 {
                     options.InitialCursorRow = cursorRow;
+
+                    // Hold the live step still during interactive drag-resize.
+                    // The runner track-and-clears the active region on every
+                    // Hex1bResizeEvent, paints the placeholder below in its
+                    // place, then debounces the real repaint until the user
+                    // stops dragging. If the final dimensions differ from where
+                    // the drag started, the marker is dropped as a one-off
+                    // tombstone above the repainted step so the scrollback
+                    // visibly records that a resize happened.
+                    options.ResizeSettleDelay = TimeSpan.FromMilliseconds(80);
+                    options.ResizePlaceholder = BuildResizePlaceholder;
+                    options.ResizeMarker = BuildResizeMarker;
                 })
                 .Build()
                 .RunAsync();
 
             cancel.ThrowIfCancelled();
-
-            PrintSummary(selections);
         }
         catch (OperationCanceledException) when (cancel.IsCancelled)
         {
-            Console.WriteLine();
-            Console.WriteLine("✗ Cancelled. Goodbye!");
+            // Cancel outcome was already rendered inside the flow; nothing
+            // more to do — the inline tombstone is the final word.
         }
     }
+
+    /// <summary>
+    /// Drawn into the active prompt's region on every resize event during a
+    /// drag — kept deliberately spartan since it re-renders many times in
+    /// quick succession and any chrome would just smear under a fast drag.
+    /// Preserves the flow's gutter bar so the visual rhythm survives the
+    /// drag, with a single muted "resizing…" line in place of the prompt.
+    /// </summary>
+    private static Hex1b.Widgets.Hex1bWidget BuildResizePlaceholder(RootContext ctx) =>
+        ctx.HStack(h =>
+        [
+            h.Text(" "),
+            h.ThemePanel(
+                t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.BarColor),
+                h.Text(TemplatePromptWidget.BarChar)),
+            h.Text("  "),
+            h.ThemePanel(
+                t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.MutedColor),
+                h.Text("resizing…")),
+        ]);
+
+    /// <summary>
+    /// Dropped into scrollback as a one-off marker once a resize has settled
+    /// and the final dimensions actually differ from where the drag started.
+    /// Acts as a faint breadcrumb between the pre- and post-resize renders.
+    /// </summary>
+    private static Hex1b.Widgets.Hex1bWidget BuildResizeMarker(RootContext ctx) =>
+        ctx.HStack(h =>
+        [
+            h.Text(" "),
+            h.ThemePanel(
+                t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.BarColor),
+                h.Text(TemplatePromptWidget.BarChar)),
+            h.Text("  "),
+            h.ThemePanel(
+                t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.MutedColor),
+                h.Text("─── terminal resized ───")),
+        ]);
 
     private static Task RunStepAsync(
         Hex1b.Flow.Hex1bFlowContext flow,
@@ -83,17 +162,5 @@ internal static class FancyFlowOrchestrator
     {
         var step = flow.Step(builder, opts => opts.MaxHeight = maxHeight);
         return step.WaitForCompletionAsync();
-    }
-
-    private static void PrintSummary(FancyFlowSelections selections)
-    {
-        Console.WriteLine();
-        Console.WriteLine("✨ All set! Here's what we'll create:");
-        Console.WriteLine();
-        Console.WriteLine($"   Language : {selections.Language}");
-        Console.WriteLine($"   Template : {selections.TemplateName} ({selections.TemplateId})");
-        Console.WriteLine($"   Folder   : {selections.Folder}");
-        Console.WriteLine($"   Hostname : {selections.HostnamePattern}");
-        Console.WriteLine();
     }
 }

--- a/samples/FancyFlowDemo/Program.cs
+++ b/samples/FancyFlowDemo/Program.cs
@@ -1,0 +1,3 @@
+using FancyFlowDemo.Flow;
+
+await FancyFlowOrchestrator.RunAsync();

--- a/samples/FancyFlowDemo/State/FancyFlowSelections.cs
+++ b/samples/FancyFlowDemo/State/FancyFlowSelections.cs
@@ -1,0 +1,15 @@
+namespace FancyFlowDemo.State;
+
+/// <summary>
+/// Holds the answers collected across the FancyFlowDemo prompt sequence.
+/// Mutated by each prompt's completion handler and read after the flow finishes
+/// to print the summary block.
+/// </summary>
+internal sealed class FancyFlowSelections
+{
+    public string Language { get; set; } = "C#";
+    public string TemplateId { get; set; } = "";
+    public string TemplateName { get; set; } = "";
+    public string Folder { get; set; } = "./my-app";
+    public string HostnamePattern { get; set; } = "localhost";
+}

--- a/samples/FancyFlowDemo/Widgets/FancyFlowExtensions.cs
+++ b/samples/FancyFlowDemo/Widgets/FancyFlowExtensions.cs
@@ -1,0 +1,53 @@
+using FancyFlowDemo.Flow;
+using FancyFlowDemo.State;
+using Hex1b;
+using Hex1b.Flow;
+using Hex1b.Widgets;
+
+namespace FancyFlowDemo.Widgets;
+
+/// <summary>
+/// Fluent <c>ctx.X(...)</c> entry points for the FancyFlowDemo composites so
+/// orchestration code never <c>new</c>'s a widget directly.
+/// </summary>
+internal static class FancyFlowExtensions
+{
+    public static TemplatePromptWidget TemplatePrompt<T>(
+        this WidgetContext<T> context,
+        int stepNumber,
+        string title,
+        string description,
+        Hex1bWidget content) where T : Hex1bWidget
+        => new(stepNumber, title, description, content);
+
+    public static LanguagePromptWidget LanguagePrompt<T>(
+        this WidgetContext<T> context,
+        FlowStepContext step,
+        FancyFlowCancellation cancel,
+        FancyFlowSelections selections,
+        IReadOnlyList<string> languages) where T : Hex1bWidget
+        => new(step, cancel, selections, languages);
+
+    public static TemplatePromptStepWidget TemplatePromptStep<T>(
+        this WidgetContext<T> context,
+        FlowStepContext step,
+        FancyFlowCancellation cancel,
+        FancyFlowSelections selections,
+        IReadOnlyList<(string Id, string Name, string Description)> templates) where T : Hex1bWidget
+        => new(step, cancel, selections, templates);
+
+    public static FolderPromptWidget FolderPrompt<T>(
+        this WidgetContext<T> context,
+        FlowStepContext step,
+        FancyFlowCancellation cancel,
+        FancyFlowSelections selections) where T : Hex1bWidget
+        => new(step, cancel, selections);
+
+    public static HostnamePromptWidget HostnamePrompt<T>(
+        this WidgetContext<T> context,
+        FlowStepContext step,
+        FancyFlowCancellation cancel,
+        FancyFlowSelections selections,
+        IReadOnlyList<string> patterns) where T : Hex1bWidget
+        => new(step, cancel, selections, patterns);
+}

--- a/samples/FancyFlowDemo/Widgets/FancyFlowExtensions.cs
+++ b/samples/FancyFlowDemo/Widgets/FancyFlowExtensions.cs
@@ -50,4 +50,11 @@ internal static class FancyFlowExtensions
         FancyFlowSelections selections,
         IReadOnlyList<string> patterns) where T : Hex1bWidget
         => new(step, cancel, selections, patterns);
+
+    public static ProcessingStepWidget ProcessingStep<T>(
+        this WidgetContext<T> context,
+        FlowStepContext step,
+        FancyFlowCancellation cancel,
+        FancyFlowSelections selections) where T : Hex1bWidget
+        => new(step, cancel, selections);
 }

--- a/samples/FancyFlowDemo/Widgets/FolderPromptWidget.cs
+++ b/samples/FancyFlowDemo/Widgets/FolderPromptWidget.cs
@@ -1,0 +1,162 @@
+using FancyFlowDemo.Flow;
+using FancyFlowDemo.State;
+using Hex1b;
+using Hex1b.Composition;
+using Hex1b.Flow;
+using Hex1b.Theming;
+using Hex1b.Widgets;
+
+namespace FancyFlowDemo.Widgets;
+
+/// <summary>
+/// Step 3 — picks an output folder. The predictor walks the actual filesystem
+/// from the current working directory: it splits the typed text into a
+/// directory portion and a partial leaf name, then suggests the first matching
+/// entry in that directory. A second line shows the fully-resolved absolute
+/// path the user is currently pointing at.
+/// </summary>
+internal sealed record FolderPromptWidget(
+    FlowStepContext Step,
+    FancyFlowCancellation Cancel,
+    FancyFlowSelections Selections) : Hex1bWidget
+{
+    private static readonly Hex1bColor PathColor = Hex1bColor.FromRgb(140, 130, 160);
+
+    private sealed class FolderState
+    {
+        public string CurrentText = "";
+    }
+
+    protected override Hex1bWidget Build(CompositionContext ctx)
+    {
+        var state = ctx.UseState(() => new FolderState { CurrentText = Selections.Folder });
+
+        var textBox = ctx.TextBox(Selections.Folder)
+            .Predict(async (text, ct) =>
+            {
+                await Task.Yield();
+                return PredictFromFilesystem(text);
+            })
+            .OnTextChanged(e =>
+            {
+                state.CurrentText = e.NewText;
+                Step.Step.Invalidate();
+            })
+            .OnSubmit(e =>
+            {
+                Selections.Folder = string.IsNullOrWhiteSpace(e.Text) ? Selections.Folder : e.Text;
+                Step.Step.Complete(y => TombstoneFactory.Build(y, $"✓ Folder: {Selections.Folder}"));
+            })
+            .FillWidth();
+
+        var resolved = ResolvePath(state.CurrentText);
+
+        // Wrap the textbox + resolved-path line in the shared 1/3-width
+        // rounded yellow border (matches the framing used by the list and
+        // toggle prompts).
+        var content = PromptBorder.Wrap(ctx, ctx.VStack(v =>
+        [
+            textBox,
+            v.ThemePanel(
+                p => p.Set(GlobalTheme.ForegroundColor, PathColor),
+                v.Text($"→ {resolved}")),
+        ]));
+
+        return ctx.TemplatePrompt(
+                stepNumber: 3,
+                title: "Pick an output folder",
+                description: "Type a path. Right arrow accepts the dim suggestion. Enter to confirm.",
+                content: content)
+            .ExitOnCtrlC(Cancel, Step);
+    }
+
+    private static string ResolvePath(string input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return Directory.GetCurrentDirectory();
+        }
+
+        try
+        {
+            return Path.GetFullPath(input);
+        }
+        catch
+        {
+            return input;
+        }
+    }
+
+    /// <summary>
+    /// Splits the typed text into a directory portion and a partial leaf name,
+    /// enumerates the directory, and returns the suffix of the first matching
+    /// entry. Directories are preferred and a trailing separator is included
+    /// so successive Right-arrow accepts walk down the tree naturally.
+    /// </summary>
+    private static string? PredictFromFilesystem(string input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            return null;
+        }
+
+        try
+        {
+            string dirPart;
+            string leafPart;
+
+            // If the input ends in a separator, treat it as "list this directory, no filter".
+            var lastChar = input[^1];
+            if (lastChar == Path.DirectorySeparatorChar || lastChar == Path.AltDirectorySeparatorChar)
+            {
+                dirPart = input;
+                leafPart = "";
+            }
+            else
+            {
+                dirPart = Path.GetDirectoryName(input) ?? "";
+                leafPart = Path.GetFileName(input);
+            }
+
+            var searchDir = string.IsNullOrEmpty(dirPart)
+                ? Directory.GetCurrentDirectory()
+                : Path.GetFullPath(dirPart);
+
+            if (!Directory.Exists(searchDir))
+            {
+                return null;
+            }
+
+            // Directories first, then files, both alphabetically.
+            var matches = Directory.EnumerateFileSystemEntries(searchDir)
+                .Select(p => new
+                {
+                    Name = Path.GetFileName(p),
+                    IsDir = Directory.Exists(p),
+                })
+                .Where(e => !string.IsNullOrEmpty(e.Name)
+                    && e.Name.StartsWith(leafPart, StringComparison.OrdinalIgnoreCase))
+                .OrderByDescending(e => e.IsDir)
+                .ThenBy(e => e.Name, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            if (matches.Count == 0)
+            {
+                return null;
+            }
+
+            var best = matches[0];
+            var suffix = best.Name[leafPart.Length..];
+            if (best.IsDir)
+            {
+                suffix += Path.DirectorySeparatorChar;
+            }
+            return suffix.Length == 0 ? null : suffix;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}
+

--- a/samples/FancyFlowDemo/Widgets/HostnamePromptWidget.cs
+++ b/samples/FancyFlowDemo/Widgets/HostnamePromptWidget.cs
@@ -1,0 +1,47 @@
+using FancyFlowDemo.Flow;
+using FancyFlowDemo.State;
+using Hex1b;
+using Hex1b.Composition;
+using Hex1b.Flow;
+using Hex1b.Input;
+using Hex1b.Widgets;
+
+namespace FancyFlowDemo.Widgets;
+
+/// <summary>
+/// Step 4 — picks the hostname pattern via a <see cref="ToggleSwitchWidget"/>.
+/// Left/right arrows switch options; Enter confirms.
+/// </summary>
+internal sealed record HostnamePromptWidget(
+    FlowStepContext Step,
+    FancyFlowCancellation Cancel,
+    FancyFlowSelections Selections,
+    IReadOnlyList<string> Patterns) : Hex1bWidget
+{
+    protected override Hex1bWidget Build(CompositionContext ctx)
+    {
+        var initialIndex = Math.Max(0, Patterns.ToList().IndexOf(Selections.HostnamePattern));
+
+        var toggle = ctx.ToggleSwitch(Patterns, initialIndex)
+            .OnSelectionChanged(e =>
+            {
+                Selections.HostnamePattern = e.SelectedOption;
+            })
+            .InputBindings(b =>
+            {
+                b.Key(Hex1bKey.Enter).Action(_ =>
+                {
+                    Step.Step.Complete(y => TombstoneFactory.Build(y, $"✓ Hostname: {Selections.HostnamePattern}"));
+                }, "Confirm");
+            });
+
+        var content = PromptBorder.Wrap(ctx, toggle);
+
+        return ctx.TemplatePrompt(
+                stepNumber: 4,
+                title: "Pick a hostname pattern",
+                description: "Use ←/→ to switch. Enter to confirm.",
+                content: content)
+            .ExitOnCtrlC(Cancel, Step);
+    }
+}

--- a/samples/FancyFlowDemo/Widgets/LanguagePromptWidget.cs
+++ b/samples/FancyFlowDemo/Widgets/LanguagePromptWidget.cs
@@ -1,0 +1,39 @@
+using FancyFlowDemo.Flow;
+using FancyFlowDemo.State;
+using Hex1b;
+using Hex1b.Composition;
+using Hex1b.Flow;
+using Hex1b.Widgets;
+
+namespace FancyFlowDemo.Widgets;
+
+/// <summary>
+/// Step 1 — picks the project language. Wraps a <see cref="ListWidget"/> in a
+/// <see cref="TemplatePromptWidget"/> for consistent decoration.
+/// </summary>
+internal sealed record LanguagePromptWidget(
+    FlowStepContext Step,
+    FancyFlowCancellation Cancel,
+    FancyFlowSelections Selections,
+    IReadOnlyList<string> Languages) : Hex1bWidget
+{
+    protected override Hex1bWidget Build(CompositionContext ctx)
+    {
+        var list = ctx.List(Languages)
+            .OnItemActivated(e =>
+            {
+                Selections.Language = Languages[e.ActivatedIndex];
+                Step.Step.Complete(y => TombstoneFactory.Build(y, $"✓ Language: {Selections.Language}"));
+            })
+            .FixedHeight(Languages.Count + 1);
+
+        var content = PromptBorder.Wrap(ctx, list);
+
+        return ctx.TemplatePrompt(
+                stepNumber: 1,
+                title: "Pick a language",
+                description: "Used for the AppHost project and any sample code.",
+                content: content)
+            .ExitOnCtrlC(Cancel, Step);
+    }
+}

--- a/samples/FancyFlowDemo/Widgets/ProcessingStepWidget.cs
+++ b/samples/FancyFlowDemo/Widgets/ProcessingStepWidget.cs
@@ -1,0 +1,95 @@
+using FancyFlowDemo.Flow;
+using FancyFlowDemo.State;
+using Hex1b;
+using Hex1b.Composition;
+using Hex1b.Flow;
+using Hex1b.Theming;
+using Hex1b.Widgets;
+
+namespace FancyFlowDemo.Widgets;
+
+/// <summary>
+/// Step 5 — a simulated "doing the work" stage that sits between the final
+/// prompt and the success outcome. Cycles through a series of phases with a
+/// spinner and then auto-completes the flow step, emitting a tombstone that
+/// matches the other steps' visual rhythm.
+/// </summary>
+internal sealed record ProcessingStepWidget(
+    FlowStepContext Step,
+    FancyFlowCancellation Cancel,
+    FancyFlowSelections Selections) : Hex1bWidget
+{
+    // Tuneable simulated work: each phase shows for this many milliseconds
+    // before advancing. The total dwell time is the sum of all phases.
+    private static readonly (string Label, int DwellMs)[] Phases =
+    [
+        ("Resolving template…",     700),
+        ("Scaffolding project…",    900),
+        ("Restoring dependencies…", 1100),
+        ("Wiring up AppHost…",      600),
+    ];
+
+    private sealed class ProcessingState
+    {
+        public int PhaseIndex;
+        public bool Started;
+    }
+
+    protected override Hex1bWidget Build(CompositionContext ctx)
+    {
+        var state = ctx.UseState(() => new ProcessingState());
+
+        // Kick off the work the first time this composite is built. The
+        // background task drives PhaseIndex forward, calls Step.Invalidate
+        // after each phase, and finally completes the step with a normal
+        // hollow-diamond tombstone.
+        if (!state.Started)
+        {
+            state.Started = true;
+            _ = RunPhasesAsync(state, Step);
+        }
+
+        var phaseLabel = state.PhaseIndex < Phases.Length
+            ? Phases[state.PhaseIndex].Label
+            : Phases[^1].Label;
+
+        var body = ctx.HStack(h =>
+        [
+            h.ThemePanel(
+                t => t.Set(SpinnerTheme.ForegroundColor, TemplatePromptWidget.ActiveColor),
+                h.Spinner()),
+            h.Text(" "),
+            h.ThemePanel(
+                t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.BodyColor),
+                h.Text(phaseLabel)),
+        ]);
+
+        var content = PromptBorder.Wrap(ctx, body);
+
+        return ctx.TemplatePrompt(
+                stepNumber: 5,
+                title: "Creating your app",
+                description: "Sit tight — this only takes a moment.",
+                content: content);
+    }
+
+    private static async Task RunPhasesAsync(ProcessingState state, FlowStepContext stepContext)
+    {
+        try
+        {
+            for (var i = 0; i < Phases.Length; i++)
+            {
+                state.PhaseIndex = i;
+                stepContext.Step.Invalidate();
+                await Task.Delay(Phases[i].DwellMs).ConfigureAwait(false);
+            }
+
+            stepContext.Step.Complete(y => TombstoneFactory.Build(y, "✓ Project created"));
+        }
+        catch
+        {
+            // Background failures during the simulated phases shouldn't bring
+            // down the flow — just leave the step in its current phase.
+        }
+    }
+}

--- a/samples/FancyFlowDemo/Widgets/PromptBorder.cs
+++ b/samples/FancyFlowDemo/Widgets/PromptBorder.cs
@@ -1,0 +1,44 @@
+using Hex1b;
+using Hex1b.Theming;
+using Hex1b.Widgets;
+
+namespace FancyFlowDemo.Widgets;
+
+/// <summary>
+/// Shared helper that wraps any prompt's interactive content in a rounded
+/// yellow border. Used by every step so the four prompts share a consistent
+/// "input frame" visual language.
+/// </summary>
+internal static class PromptBorder
+{
+    /// <summary>
+    /// The accent yellow used for the active marker (◆) in
+    /// <see cref="TemplatePromptWidget"/>. Re-used here so the input frame
+    /// reads as part of the same accent family.
+    /// </summary>
+    public static readonly Hex1bColor Accent = Hex1bColor.FromRgb(255, 215, 100);
+
+    /// <summary>
+    /// Wraps <paramref name="child"/> in a rounded yellow border constrained
+    /// to roughly one third of the available width (left-aligned). The right
+    /// two thirds of the row are intentionally empty so each prompt reads as
+    /// a compact "card" against the gutter.
+    /// </summary>
+    public static Hex1bWidget Wrap<TParent>(WidgetContext<TParent> context, Hex1bWidget child)
+        where TParent : Hex1bWidget
+    {
+        var bordered = context.ThemePanel(
+            t => t.Set(BorderTheme.BorderColor, Accent)
+                  .Set(BorderTheme.TopLeftCorner, "╭")
+                  .Set(BorderTheme.TopRightCorner, "╮")
+                  .Set(BorderTheme.BottomLeftCorner, "╰")
+                  .Set(BorderTheme.BottomRightCorner, "╯"),
+            context.Border(child));
+
+        return context.HStack(h =>
+        [
+            bordered.FillWidth(1),
+            h.Text("").FillWidth(2),
+        ]);
+    }
+}

--- a/samples/FancyFlowDemo/Widgets/TemplatePromptStepWidget.cs
+++ b/samples/FancyFlowDemo/Widgets/TemplatePromptStepWidget.cs
@@ -1,0 +1,42 @@
+using FancyFlowDemo.Flow;
+using FancyFlowDemo.State;
+using Hex1b;
+using Hex1b.Composition;
+using Hex1b.Flow;
+using Hex1b.Widgets;
+
+namespace FancyFlowDemo.Widgets;
+
+/// <summary>
+/// Step 2 — picks the project template.
+/// </summary>
+internal sealed record TemplatePromptStepWidget(
+    FlowStepContext Step,
+    FancyFlowCancellation Cancel,
+    FancyFlowSelections Selections,
+    IReadOnlyList<(string Id, string Name, string Description)> Templates) : Hex1bWidget
+{
+    protected override Hex1bWidget Build(CompositionContext ctx)
+    {
+        var labels = Templates.Select(t => $"{t.Name}  —  {t.Description}").ToArray();
+
+        var list = ctx.List(labels)
+            .OnItemActivated(e =>
+            {
+                var picked = Templates[e.ActivatedIndex];
+                Selections.TemplateId = picked.Id;
+                Selections.TemplateName = picked.Name;
+                Step.Step.Complete(y => TombstoneFactory.Build(y, $"✓ Template: {picked.Name}"));
+            })
+            .FixedHeight(Templates.Count + 1);
+
+        var content = PromptBorder.Wrap(ctx, list);
+
+        return ctx.TemplatePrompt(
+                stepNumber: 2,
+                title: "Pick a template",
+                description: "The starter project layout that will be scaffolded.",
+                content: content)
+            .ExitOnCtrlC(Cancel, Step);
+    }
+}

--- a/samples/FancyFlowDemo/Widgets/TemplatePromptWidget.cs
+++ b/samples/FancyFlowDemo/Widgets/TemplatePromptWidget.cs
@@ -34,38 +34,9 @@ internal sealed record TemplatePromptWidget(
     internal const string ActiveMarker = "◆";
     internal const string SubmittedMarker = "◇";
 
-    // --- Glow effect tuning ---------------------------------------------------
-    // The glow paints a soft purple wash anchored to the gutter that fades as it
-    // travels right and as it approaches the top/bottom of the prompt block. A
-    // slow travelling sine wave gives it an organic, non-uniform pulse so each
-    // row breathes slightly out of phase with its neighbours.
-    //
-    // Because EffectPanel post-processes the child's already-rendered surface,
-    // we don't actually know the terminal's true background colour. We model it
-    // as near-black and paint *additive* tints on top — i.e. the brighter the
-    // glow, the more saturated purple we write into the cell's background.
-    private static readonly Hex1bColor GlowColor = Hex1bColor.FromRgb(180, 120, 220);
-    private const int GlowWidthMax = 36;     // peak width of the wash (middle row)
-    private const int GlowWidthMin = 2;      // width at the very top/bottom rows
-    private const float MaxAlpha = 0.55f;    // peak background tint strength
-    private const float PulseHz = 0.35f;     // overall slow breathing rate
-    private const float SpatialKx = 0.18f;   // horizontal wave density
-    private const float SpatialKy = 0.55f;   // vertical phase offset (per row)
-    private const float AlphaCutoff = 0.02f; // ignore truly negligible contributions
-
     protected override Hex1bWidget Build(CompositionContext ctx)
     {
-        var grid = BuildGrid(ctx);
-
-        // EffectPanel post-processes the whole frame's surface in place. The
-        // context-aware overload also gives us the render context so we can
-        // read the global background colour and blend toward it (instead of
-        // multiplying GlowColor by alpha, which crushes to black on most
-        // terminals). Cells the child explicitly painted are left untouched
-        // so deliberate shading (selected list rows, focused textbox, etc.)
-        // is preserved.
-        return ctx.EffectPanel(grid, ApplyGlow)
-            .RedrawAfter(50);
+        return BuildGrid(ctx);
     }
 
     private Hex1bWidget BuildGrid(CompositionContext ctx)
@@ -127,81 +98,6 @@ internal sealed record TemplatePromptWidget(
                     .Row(4).Column(3),
             ];
         });
-    }
-
-    private static void ApplyGlow(Surface surface, Hex1bRenderContext ctx)
-    {
-        // Resolve the terminal's effective background:
-        //  1. If a global theme bg is set, use that (a parent ThemePanel etc).
-        //  2. Otherwise use the terminal's reported default bg (probed at
-        //     startup via OSC 11 — see ConsolePresentationAdapter).
-        //  3. Fall back to neutral dark grey if nothing is known.
-        Hex1bColor baseBg;
-        var globalBg = ctx.Theme.GetGlobalBackground();
-        if (!globalBg.IsDefault)
-        {
-            baseBg = globalBg;
-        }
-        else
-        {
-            var probed = ctx.Capabilities.DefaultBackground;
-            baseBg = Hex1bColor.FromRgb(
-                (byte)((probed >> 16) & 0xFF),
-                (byte)((probed >> 8) & 0xFF),
-                (byte)(probed & 0xFF));
-        }
-
-        // Wall-clock time in seconds drives the breathing pulse.
-        var t = (float)(Environment.TickCount64 / 1000.0);
-        var height = surface.Height;
-        var width = surface.Width;
-
-        for (int y = 0; y < height; y++)
-        {
-            // Vertical envelope: 0 at top edge, 1 in the middle, 0 at bottom.
-            float vertEnv = height <= 1
-                ? 1f
-                : MathF.Sin(MathF.PI * (y + 0.5f) / height);
-            if (vertEnv <= 0f) continue;
-
-            // The glow forms a lens/leaf shape: the top and bottom rows only
-            // wash the first GlowWidthMin cells, while the middle row reaches
-            // out to GlowWidthMax. Per-row width is interpolated by vertEnv,
-            // and per-cell alpha is further attenuated by vertEnv so the very
-            // edges still fade close to the terminal background.
-            float rowWidth = GlowWidthMin + (GlowWidthMax - GlowWidthMin) * vertEnv;
-
-            for (int x = 0; x < width; x++)
-            {
-                // Horizontal falloff inside the row's effective width.
-                float horiz = 1f - x / rowWidth;
-                if (horiz <= 0f) break;
-                horiz *= horiz; // ease-out so the leading edge looks softer
-
-                var cell = surface.GetCell(x, y);
-                // Skip cells the child explicitly painted (selected list row,
-                // textbox cursor, focused chip, etc.) so we never obliterate
-                // intentional shading.
-                if (!cell.HasTransparentBackground) continue;
-
-                // Travelling wave with a per-row phase offset gives a gently
-                // rolling glow rather than a uniform pulse.
-                float wave = 0.5f + 0.5f * MathF.Sin(
-                    t * MathF.PI * 2f * PulseHz - x * SpatialKx + y * SpatialKy);
-
-                float alpha = MaxAlpha * vertEnv * horiz * (0.55f + 0.45f * wave);
-                if (alpha <= AlphaCutoff) continue;
-
-                // Linear blend in RGB toward the glow colour from the
-                // resolved terminal background. At alpha=0 the cell would
-                // match the surroundings (and is skipped anyway); at the
-                // peak we get GlowColor at MaxAlpha intensity.
-                byte br = (byte)(baseBg.R + (GlowColor.R - baseBg.R) * alpha);
-                byte bg = (byte)(baseBg.G + (GlowColor.G - baseBg.G) * alpha);
-                byte bb = (byte)(baseBg.B + (GlowColor.B - baseBg.B) * alpha);
-                surface.TrySetCell(x, y, cell.WithBackground(Hex1bColor.FromRgb(br, bg, bb)));
-            }
-        }
     }
 }
 

--- a/samples/FancyFlowDemo/Widgets/TemplatePromptWidget.cs
+++ b/samples/FancyFlowDemo/Widgets/TemplatePromptWidget.cs
@@ -1,0 +1,207 @@
+using Hex1b;
+using Hex1b.Composition;
+using Hex1b.Layout;
+using Hex1b.Surfaces;
+using Hex1b.Theming;
+using Hex1b.Widgets;
+
+namespace FancyFlowDemo.Widgets;
+
+/// <summary>
+/// Shared visual frame for every prompt in the FancyFlowDemo flow. Renders the
+/// purple gutter bar one cell in from the left edge, with vertical breathing
+/// room above the title and a special active-row marker at the row where the
+/// prompt's interactive content starts.
+/// </summary>
+/// <param name="StepNumber">1-based step number shown in the header.</param>
+/// <param name="Title">Short prompt title (e.g. "Pick a language").</param>
+/// <param name="Description">One-line elaboration shown beneath the title.</param>
+/// <param name="Content">The actual interactive prompt body.</param>
+internal sealed record TemplatePromptWidget(
+    int StepNumber,
+    string Title,
+    string Description,
+    Hex1bWidget Content) : Hex1bWidget
+{
+    internal static readonly Hex1bColor BarColor = Hex1bColor.FromRgb(155, 89, 182);
+    internal static readonly Hex1bColor ActiveColor = Hex1bColor.FromRgb(255, 215, 100);
+    internal static readonly Hex1bColor TitleColor = Hex1bColor.FromRgb(187, 134, 252);
+    internal static readonly Hex1bColor BodyColor = Hex1bColor.FromRgb(220, 200, 245);
+    internal static readonly Hex1bColor MutedColor = Hex1bColor.FromRgb(140, 130, 160);
+    internal const string BarChar = "┃";
+    // Filled diamond marks the active prompt; the hollow diamond (◇) is used by
+    // TombstoneFactory for completed steps, mirroring Clack's vertical timeline.
+    internal const string ActiveMarker = "◆";
+    internal const string SubmittedMarker = "◇";
+
+    // --- Glow effect tuning ---------------------------------------------------
+    // The glow paints a soft purple wash anchored to the gutter that fades as it
+    // travels right and as it approaches the top/bottom of the prompt block. A
+    // slow travelling sine wave gives it an organic, non-uniform pulse so each
+    // row breathes slightly out of phase with its neighbours.
+    //
+    // Because EffectPanel post-processes the child's already-rendered surface,
+    // we don't actually know the terminal's true background colour. We model it
+    // as near-black and paint *additive* tints on top — i.e. the brighter the
+    // glow, the more saturated purple we write into the cell's background.
+    private static readonly Hex1bColor GlowColor = Hex1bColor.FromRgb(180, 120, 220);
+    private const int GlowWidthMax = 36;     // peak width of the wash (middle row)
+    private const int GlowWidthMin = 2;      // width at the very top/bottom rows
+    private const float MaxAlpha = 0.55f;    // peak background tint strength
+    private const float PulseHz = 0.35f;     // overall slow breathing rate
+    private const float SpatialKx = 0.18f;   // horizontal wave density
+    private const float SpatialKy = 0.55f;   // vertical phase offset (per row)
+    private const float AlphaCutoff = 0.02f; // ignore truly negligible contributions
+
+    protected override Hex1bWidget Build(CompositionContext ctx)
+    {
+        var grid = BuildGrid(ctx);
+
+        // EffectPanel post-processes the whole frame's surface in place. The
+        // context-aware overload also gives us the render context so we can
+        // read the global background colour and blend toward it (instead of
+        // multiplying GlowColor by alpha, which crushes to black on most
+        // terminals). Cells the child explicitly painted are left untouched
+        // so deliberate shading (selected list rows, focused textbox, etc.)
+        // is preserved.
+        return ctx.EffectPanel(grid, ApplyGlow)
+            .RedrawAfter(50);
+    }
+
+    private Hex1bWidget BuildGrid(CompositionContext ctx)
+    {
+        return ctx.Grid(g =>
+        {
+            // gutter | bar | gap | body
+            g.Columns.Add(SizeHint.Fixed(1));
+            g.Columns.Add(SizeHint.Fixed(1));
+            g.Columns.Add(SizeHint.Fixed(2));
+            g.Columns.Add(SizeHint.Fill);
+
+            // 0 top spacer | 1 title | 2 desc | 3 mid spacer | 4 content | 5 bottom spacer
+            g.Rows.Add(SizeHint.Fixed(1));
+            g.Rows.Add(SizeHint.Content);
+            g.Rows.Add(SizeHint.Content);
+            g.Rows.Add(SizeHint.Fixed(1));
+            g.Rows.Add(SizeHint.Content);
+            g.Rows.Add(SizeHint.Fixed(1));
+
+            return
+            [
+                // Top spacer bar (row 0).
+                g.Cell(c => c.ThemePanel(
+                        t => t.Set(SeparatorTheme.Color, BarColor)
+                              .Set(SeparatorTheme.VerticalChar, BarChar),
+                        c.VSeparator()))
+                    .Row(0).Column(1),
+
+                // Active marker on the title row — that's the prompt itself.
+                g.Cell(c => c.ThemePanel(
+                        t => t.Set(GlobalTheme.ForegroundColor, ActiveColor),
+                        c.Text(ActiveMarker)))
+                    .Row(1).Column(1),
+
+                // Bar segment below the marker (rows 2..5).
+                g.Cell(c => c.ThemePanel(
+                        t => t.Set(SeparatorTheme.Color, BarColor)
+                              .Set(SeparatorTheme.VerticalChar, BarChar),
+                        c.VSeparator()))
+                    .RowSpan(2, 4).Column(1),
+
+                // Body cells.
+                g.Cell(c => c.ThemePanel(
+                        t => t.Set(GlobalTheme.ForegroundColor, TitleColor),
+                        c.Text($"Step {StepNumber} — {Title}")))
+                    .Row(1).Column(3),
+
+                g.Cell(c => c.ThemePanel(
+                        t => t.Set(GlobalTheme.ForegroundColor, MutedColor),
+                        c.Text(Description)))
+                    .Row(2).Column(3),
+
+                g.Cell(c => c.ThemePanel(
+                        t => t.Set(GlobalTheme.ForegroundColor, BodyColor)
+                              .Set(ListTheme.SelectedBackgroundColor, ActiveColor)
+                              .Set(ListTheme.SelectedForegroundColor, Hex1bColor.Black),
+                        Content))
+                    .Row(4).Column(3),
+            ];
+        });
+    }
+
+    private static void ApplyGlow(Surface surface, Hex1bRenderContext ctx)
+    {
+        // Resolve the terminal's effective background:
+        //  1. If a global theme bg is set, use that (a parent ThemePanel etc).
+        //  2. Otherwise use the terminal's reported default bg (probed at
+        //     startup via OSC 11 — see ConsolePresentationAdapter).
+        //  3. Fall back to neutral dark grey if nothing is known.
+        Hex1bColor baseBg;
+        var globalBg = ctx.Theme.GetGlobalBackground();
+        if (!globalBg.IsDefault)
+        {
+            baseBg = globalBg;
+        }
+        else
+        {
+            var probed = ctx.Capabilities.DefaultBackground;
+            baseBg = Hex1bColor.FromRgb(
+                (byte)((probed >> 16) & 0xFF),
+                (byte)((probed >> 8) & 0xFF),
+                (byte)(probed & 0xFF));
+        }
+
+        // Wall-clock time in seconds drives the breathing pulse.
+        var t = (float)(Environment.TickCount64 / 1000.0);
+        var height = surface.Height;
+        var width = surface.Width;
+
+        for (int y = 0; y < height; y++)
+        {
+            // Vertical envelope: 0 at top edge, 1 in the middle, 0 at bottom.
+            float vertEnv = height <= 1
+                ? 1f
+                : MathF.Sin(MathF.PI * (y + 0.5f) / height);
+            if (vertEnv <= 0f) continue;
+
+            // The glow forms a lens/leaf shape: the top and bottom rows only
+            // wash the first GlowWidthMin cells, while the middle row reaches
+            // out to GlowWidthMax. Per-row width is interpolated by vertEnv,
+            // and per-cell alpha is further attenuated by vertEnv so the very
+            // edges still fade close to the terminal background.
+            float rowWidth = GlowWidthMin + (GlowWidthMax - GlowWidthMin) * vertEnv;
+
+            for (int x = 0; x < width; x++)
+            {
+                // Horizontal falloff inside the row's effective width.
+                float horiz = 1f - x / rowWidth;
+                if (horiz <= 0f) break;
+                horiz *= horiz; // ease-out so the leading edge looks softer
+
+                var cell = surface.GetCell(x, y);
+                // Skip cells the child explicitly painted (selected list row,
+                // textbox cursor, focused chip, etc.) so we never obliterate
+                // intentional shading.
+                if (!cell.HasTransparentBackground) continue;
+
+                // Travelling wave with a per-row phase offset gives a gently
+                // rolling glow rather than a uniform pulse.
+                float wave = 0.5f + 0.5f * MathF.Sin(
+                    t * MathF.PI * 2f * PulseHz - x * SpatialKx + y * SpatialKy);
+
+                float alpha = MaxAlpha * vertEnv * horiz * (0.55f + 0.45f * wave);
+                if (alpha <= AlphaCutoff) continue;
+
+                // Linear blend in RGB toward the glow colour from the
+                // resolved terminal background. At alpha=0 the cell would
+                // match the surroundings (and is skipped anyway); at the
+                // peak we get GlowColor at MaxAlpha intensity.
+                byte br = (byte)(baseBg.R + (GlowColor.R - baseBg.R) * alpha);
+                byte bg = (byte)(baseBg.G + (GlowColor.G - baseBg.G) * alpha);
+                byte bb = (byte)(baseBg.B + (GlowColor.B - baseBg.B) * alpha);
+                surface.TrySetCell(x, y, cell.WithBackground(Hex1bColor.FromRgb(br, bg, bb)));
+            }
+        }
+    }
+}
+

--- a/samples/FancyFlowDemo/Widgets/TombstoneFactory.cs
+++ b/samples/FancyFlowDemo/Widgets/TombstoneFactory.cs
@@ -12,12 +12,25 @@ namespace FancyFlowDemo.Widgets;
 /// </summary>
 internal static class TombstoneFactory
 {
+    // Outcome markers — filled circles read as "punctuation" against the
+    // prompt diamonds, giving the flow a clear start/end shape.
+    internal const string HeaderMarker = "●";
+    internal const string SuccessMarker = "●";
+    internal const string CancelMarker = "●";
+    internal const string ErrorMarker = "●";
+
+    internal static readonly Hex1bColor HeaderColor = Hex1bColor.FromRgb(120, 180, 255);   // soft cyan-blue
+    internal static readonly Hex1bColor SuccessColor = Hex1bColor.FromRgb(120, 210, 130);  // friendly green
+    internal static readonly Hex1bColor CancelColor = Hex1bColor.FromRgb(245, 165, 65);    // warm orange
+    internal static readonly Hex1bColor ErrorColor = Hex1bColor.FromRgb(230, 95, 95);      // alert red
+
     /// <summary>
     /// Builds a "bar only" row — used to seed the gutter above the very first
     /// prompt and as the trailing spacer beneath each completed step.
     /// </summary>
-    public static Hex1bWidget BuildBarRow(RootContext ctx) =>
-        ctx.HStack(h =>
+    public static Hex1bWidget BuildBarRow<TParent>(WidgetContext<TParent> ctx)
+        where TParent : Hex1bWidget
+        => ctx.HStack(h =>
         [
             h.Text(" "),
             h.ThemePanel(
@@ -33,17 +46,7 @@ internal static class TombstoneFactory
     public static Hex1bWidget Build(RootContext ctx, string label) =>
         ctx.VStack(v =>
         [
-            v.HStack(h =>
-            [
-                h.Text(" "),
-                h.ThemePanel(
-                    t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.BarColor),
-                    h.Text(TemplatePromptWidget.SubmittedMarker)),
-                h.Text("  "),
-                h.ThemePanel(
-                    t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.BodyColor),
-                    h.Text(label)),
-            ]),
+            BuildMarkerRow(v, TemplatePromptWidget.SubmittedMarker, TemplatePromptWidget.BarColor, label, TemplatePromptWidget.BodyColor),
             v.HStack(h =>
             [
                 h.Text(" "),
@@ -52,4 +55,79 @@ internal static class TombstoneFactory
                     h.Text(TemplatePromptWidget.BarChar)),
             ]),
         ]);
+
+    /// <summary>
+    /// Header row anchoring the start of the flow. Renders the supplied label
+    /// next to a filled circle in the header colour, with a trailing bar-only
+    /// spacer so the gutter flows naturally into the first prompt.
+    /// </summary>
+    public static Hex1bWidget BuildHeader(RootContext ctx, string label) =>
+        ctx.VStack(v =>
+        [
+            BuildMarkerRow(v, HeaderMarker, HeaderColor, label, HeaderColor, bold: true),
+            BuildBarRow(v),
+        ]);
+
+    /// <summary>
+    /// Terminal outcome tombstone (success / cancel / error). The marker, the
+    /// primary label, and any continuation detail lines are all painted in
+    /// <paramref name="color"/>. The gutter stops here — no trailing bar row.
+    /// </summary>
+    public static Hex1bWidget BuildOutcome(
+        RootContext ctx,
+        string marker,
+        Hex1bColor color,
+        string primaryLabel,
+        params string[] detailLines)
+    {
+        return ctx.VStack(v =>
+        {
+            var rows = new List<Hex1bWidget>
+            {
+                BuildMarkerRow(v, marker, color, primaryLabel, color, bold: true),
+            };
+
+            foreach (var detail in detailLines)
+            {
+                rows.Add(v.HStack(h =>
+                [
+                    h.Text(" "),
+                    // Use a faint gutter-coloured bar so detail rows feel like
+                    // a continuation of the flow rather than free-floating text.
+                    h.ThemePanel(
+                        t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.BarColor),
+                        h.Text(TemplatePromptWidget.BarChar)),
+                    h.Text("   "),
+                    h.ThemePanel(
+                        t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.BodyColor),
+                        h.Text(detail)),
+                ]));
+            }
+
+            return rows.ToArray();
+        });
+    }
+
+    private static Hex1bWidget BuildMarkerRow<TParent>(
+        WidgetContext<TParent> ctx,
+        string marker,
+        Hex1bColor markerColor,
+        string label,
+        Hex1bColor labelColor,
+        bool bold = false)
+        where TParent : Hex1bWidget
+    {
+        return ctx.HStack(h =>
+        [
+            h.Text(" "),
+            h.ThemePanel(
+                t => t.Set(GlobalTheme.ForegroundColor, markerColor),
+                h.Text(marker)),
+            h.Text("  "),
+            h.ThemePanel(
+                t => t.Set(GlobalTheme.ForegroundColor, labelColor),
+                h.Text(label)),
+        ]);
+    }
 }
+

--- a/samples/FancyFlowDemo/Widgets/TombstoneFactory.cs
+++ b/samples/FancyFlowDemo/Widgets/TombstoneFactory.cs
@@ -1,0 +1,55 @@
+using Hex1b;
+using Hex1b.Theming;
+using Hex1b.Widgets;
+
+namespace FancyFlowDemo.Widgets;
+
+/// <summary>
+/// Builds the frozen "tombstone" widget that each prompt emits via
+/// <c>FlowStep.Complete(...)</c>. Wraps the supplied label in the same
+/// 1-cell gutter + purple bar layout as the live prompt frame so the bar
+/// runs continuously down the screen as steps complete.
+/// </summary>
+internal static class TombstoneFactory
+{
+    /// <summary>
+    /// Builds a "bar only" row — used to seed the gutter above the very first
+    /// prompt and as the trailing spacer beneath each completed step.
+    /// </summary>
+    public static Hex1bWidget BuildBarRow(RootContext ctx) =>
+        ctx.HStack(h =>
+        [
+            h.Text(" "),
+            h.ThemePanel(
+                t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.BarColor),
+                h.Text(TemplatePromptWidget.BarChar)),
+        ]);
+
+    /// <summary>
+    /// Builds the frozen tombstone for a completed prompt: a hollow-diamond
+    /// marker on the gutter line, the supplied label, and a trailing bar-only
+    /// row to give consecutive tombstones some breathing room.
+    /// </summary>
+    public static Hex1bWidget Build(RootContext ctx, string label) =>
+        ctx.VStack(v =>
+        [
+            v.HStack(h =>
+            [
+                h.Text(" "),
+                h.ThemePanel(
+                    t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.BarColor),
+                    h.Text(TemplatePromptWidget.SubmittedMarker)),
+                h.Text("  "),
+                h.ThemePanel(
+                    t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.BodyColor),
+                    h.Text(label)),
+            ]),
+            v.HStack(h =>
+            [
+                h.Text(" "),
+                h.ThemePanel(
+                    t => t.Set(GlobalTheme.ForegroundColor, TemplatePromptWidget.BarColor),
+                    h.Text(TemplatePromptWidget.BarChar)),
+            ]),
+        ]);
+}

--- a/samples/FigletTextDemo/Program.cs
+++ b/samples/FigletTextDemo/Program.cs
@@ -33,7 +33,7 @@ var effectIdx = 0;
 var clock = Stopwatch.StartNew();
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         var font = FigletFont.LoadBundled(fontNames[selectedFontIdx]);
         var preview = ctx.FigletText(sampleText)

--- a/samples/FloatPanelDemo/Program.cs
+++ b/samples/FloatPanelDemo/Program.cs
@@ -9,7 +9,9 @@ var state = new BouncingState();
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((app, options) =>
+    .WithHex1bApp(
+        _ => { },
+        app =>
     {
         state.App = app;
         state.Start();

--- a/samples/FlowChartDemo/Program.cs
+++ b/samples/FlowChartDemo/Program.cs
@@ -22,7 +22,7 @@ var nodes = new List<FlowNode>
 string? lastAction = null;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         return ctx.VStack(v => [
             // Header

--- a/samples/FormDemo/Program.cs
+++ b/samples/FormDemo/Program.cs
@@ -76,7 +76,7 @@ void TriggerGeocode()
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithDiagnostics("FormDemo")
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         var labelPlacement = labelPlacementIndex == 0
             ? LabelPlacement.Above

--- a/samples/FullAppDemo/Program.cs
+++ b/samples/FullAppDemo/Program.cs
@@ -59,7 +59,7 @@ var autoSaveIndex = 0;
 var statusMessage = "Ready";
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     ctx.ZStack(z => [
         z.VStack(outer => [
             // ─────────────────────────────────────────────────────────────────

--- a/samples/GlobeDemo/Program.cs
+++ b/samples/GlobeDemo/Program.cs
@@ -97,7 +97,7 @@ var pois = new List<PointOfInterest>
 };
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
         ctx.ZStack(z => [
             // Layer 1: Globe surface with interaction (bottom)
             z.Interactable(ic =>

--- a/samples/GridDemo/Program.cs
+++ b/samples/GridDemo/Program.cs
@@ -1,7 +1,7 @@
 using Hex1b;
 
 await using var terminal = Hex1b.Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         return ctx.Grid(g =>
         {

--- a/samples/InfoBarDemo/Program.cs
+++ b/samples/InfoBarDemo/Program.cs
@@ -25,7 +25,7 @@ var patterns = new[]
 var selectedPattern = 0;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         return ctx.VStack(v => [
             // Header

--- a/samples/InteractableDemo/Program.cs
+++ b/samples/InteractableDemo/Program.cs
@@ -22,7 +22,7 @@ string? selectedResource = null;
 string? lastAction = null;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         return ctx.VStack(v => [
             // Header

--- a/samples/KanbanDemo/Program.cs
+++ b/samples/KanbanDemo/Program.cs
@@ -31,7 +31,7 @@ var showDragSource = true;
 var rainbowTimer = System.Diagnostics.Stopwatch.StartNew();
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         return ctx.VStack(v => [
             // Header

--- a/samples/KeyBindingTester/Program.cs
+++ b/samples/KeyBindingTester/Program.cs
@@ -232,7 +232,7 @@ void RegisterTestBindings(InputBindingsBuilder b)
 try
 {
     await using var terminal = Hex1bTerminal.CreateBuilder()
-        .WithHex1bApp((app, options) => ctx =>
+        .WithHex1bApp(ctx =>
         {
             bool isDone = currentIndex >= bindings.Count;
             int totalPass = status.Count(s => s == PASS);

--- a/samples/KgpDemo/Program.cs
+++ b/samples/KgpDemo/Program.cs
@@ -39,15 +39,16 @@ var statusMessage = "Use File menu to open windows";
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithDiagnostics("KgpDemo", forceEnable: true)
     .WithMouse()
-    .WithHex1bApp((app, options) =>
-    {
-        options.OnRescue = args =>
+    .WithHex1bApp(
+        options =>
         {
-            File.AppendAllText("/tmp/kgp-demo-errors.log",
-                $"[{DateTime.Now:HH:mm:ss.fff}] RESCUE: phase={args.Phase} error={args.Exception}\n");
-        };
-
-        return ctx =>
+            options.OnRescue = args =>
+            {
+                File.AppendAllText("/tmp/kgp-demo-errors.log",
+                    $"[{DateTime.Now:HH:mm:ss.fff}] RESCUE: phase={args.Phase} error={args.Exception}\n");
+            };
+        },
+        ctx =>
         {
         return ctx.VStack(outer =>
         [
@@ -99,7 +100,6 @@ await using var terminal = Hex1bTerminal.CreateBuilder()
                 "Ctrl+C", "Exit"
             ])
         ]);
-        };
     })
     .Build();
 

--- a/samples/LanguageServerDemo/Program.cs
+++ b/samples/LanguageServerDemo/Program.cs
@@ -808,7 +808,9 @@ _ = Task.Run(async () =>
 // ── Build the terminal UI ────────────────────────────────────────────────────
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((app, options) =>
+    .WithHex1bApp(
+        _ => { },
+        app =>
     {
         displayApp = app;
         return ctx =>

--- a/samples/LoggerPanelDemo/Program.cs
+++ b/samples/LoggerPanelDemo/Program.cs
@@ -37,12 +37,15 @@ _ = Task.Run(async () =>
 
 // Run the TUI alongside the host
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) =>
+    .WithHex1bApp(
+        options =>
+        {
+            options.Theme = new Hex1bTheme("LoggerPanelDemo")
+                .Set(DrawerTheme.BackgroundColor, Hex1bColor.Black)
+                .Set(TableTheme.BackgroundColor, Hex1bColor.Black);
+        },
+        app =>
     {
-        options.Theme = new Hex1bTheme("LoggerPanelDemo")
-            .Set(DrawerTheme.BackgroundColor, Hex1bColor.Black)
-            .Set(TableTheme.BackgroundColor, Hex1bColor.Black);
-        
         return ctx =>
     {
         return ctx.VStack(outer => [

--- a/samples/LogicBuilderDemo/Program.cs
+++ b/samples/LogicBuilderDemo/Program.cs
@@ -4,7 +4,9 @@ using LogicBuilderDemo.Models;
 var state = new AppState();
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) =>
+    .WithHex1bApp(
+        _ => { },
+        app =>
     {
         state.App = app;
         return ctx => LogicBuilderApp.Build(ctx, state);

--- a/samples/MarkdownSample/Program.cs
+++ b/samples/MarkdownSample/Program.cs
@@ -21,7 +21,7 @@ var sampleMarkdown = """
 
     ```csharp
     var app = Hex1bTerminal.CreateBuilder()
-        .WithHex1bApp((app, options) => ctx =>
+        .WithHex1bApp(ctx =>
             ctx.Markdown("# Hello World"))
         .Build();
     await app.RunAsync();
@@ -127,29 +127,25 @@ static MarkdownImageData CreateGradientImage(int width, int height)
 }
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) =>
-    {
-        Func<RootContext, Hex1bWidget> builder = ctx =>
-            ctx.HSplitter(
-                // Left pane: Editor
-                ctx.Editor(editorState).LineNumbers(),
-                // Right pane: Markdown preview in scroll panel with focusable links
-                ctx.VScrollPanel(
-                    ctx.Markdown(document)
-                        .Focusable(children: true)
-                        .OnImageLoad((uri, alt) =>
-                            Task.FromResult<MarkdownImageData?>(CreateGradientImage(120, 60)))
-                        .OnLinkActivated(args =>
-                        {
-                            // Log link activation to the status bar
-                            // For external links, the default handler opens the browser
-                            // Set args.Handled = true to suppress default behavior
-                        })
-                ),
-                leftWidth: 45
-            );
-        return builder;
-    })
+    .WithHex1bApp(ctx =>
+        ctx.HSplitter(
+            // Left pane: Editor
+            ctx.Editor(editorState).LineNumbers(),
+            // Right pane: Markdown preview in scroll panel with focusable links
+            ctx.VScrollPanel(
+                ctx.Markdown(document)
+                    .Focusable(children: true)
+                    .OnImageLoad((uri, alt) =>
+                        Task.FromResult<MarkdownImageData?>(CreateGradientImage(120, 60)))
+                    .OnLinkActivated(args =>
+                    {
+                        // Log link activation to the status bar
+                        // For external links, the default handler opens the browser
+                        // Set args.Handled = true to suppress default behavior
+                    })
+            ),
+            leftWidth: 45
+        ))
     .WithMouse()
     .Build();
 

--- a/samples/MenuBarDemo/Program.cs
+++ b/samples/MenuBarDemo/Program.cs
@@ -17,7 +17,7 @@ var fontSizes = new[] { "Small", "Medium", "Large", "Extra Large" };
 var selectedFontSize = 1; // Medium
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     ctx.VStack(main => [
         // Menu bar at the top
         main.MenuBar(m => [

--- a/samples/ModelViewerDemo/Program.cs
+++ b/samples/ModelViewerDemo/Program.cs
@@ -51,7 +51,9 @@ void SwitchLod(int newLod)
 }
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(
+        _ => { },
+        app => ctx =>
         ctx.Interactable(ic =>
             ic.Surface(s =>
             {

--- a/samples/MouseTest/Program.cs
+++ b/samples/MouseTest/Program.cs
@@ -146,8 +146,7 @@ Hex1bWidget BuildScenarioPanel(WidgetContext<VStackWidget> v)
 try
 {
     await using var terminal = Hex1bTerminal.CreateBuilder()
-        .WithHex1bApp((app, options) =>
-            ctx => ctx.VStack(root => [
+        .WithHex1bApp(ctx => ctx.VStack(root => [
             // Main content wrapped in a border
             root.Border(
                 // Splitter with scenario list on left, controls on right

--- a/samples/MuxerDemo/SessionManagerApp.cs
+++ b/samples/MuxerDemo/SessionManagerApp.cs
@@ -22,7 +22,9 @@ internal sealed class SessionManagerApp
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithMouse()
-            .WithHex1bApp((app, _) =>
+            .WithHex1bApp(
+                _ => { },
+                app =>
             {
                 _app = app;
                 return ctx =>

--- a/samples/Osc8Test/Program.cs
+++ b/samples/Osc8Test/Program.cs
@@ -15,7 +15,7 @@ var lastClickedUri = "(none)";
 try
 {
     await using var terminal = Hex1bTerminal.CreateBuilder()
-        .WithHex1bApp((app, options) => ctx => ctx.VStack(root => [
+        .WithHex1bApp(ctx => ctx.VStack(root => [
             root.Border(
                 root.VStack(content => [
                     content.Text("OSC 8 Hyperlink Widget Demo"),

--- a/samples/PasteDemo/Program.cs
+++ b/samples/PasteDemo/Program.cs
@@ -25,7 +25,9 @@ static string FormatCount(long n) => n switch
 };
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(
+        _ => { },
+        app => ctx =>
     {
         var elapsed = stopwatch.IsRunning ? stopwatch.Elapsed : TimeSpan.Zero;
         var spinner = spinnerFrames[(int)(elapsed.TotalMilliseconds / 80) % spinnerFrames.Length];

--- a/samples/PerfDemo/BusyScene.cs
+++ b/samples/PerfDemo/BusyScene.cs
@@ -1,0 +1,108 @@
+using Hex1b;
+using Hex1b.Layout;
+using Hex1b.Widgets;
+
+namespace PerfDemo;
+
+/// <summary>
+/// Builds a representative "busy" widget tree for performance profiling.
+///
+/// Layout:
+///   ┌── HSplitter ───────────────────────────────────────────────┐
+///   │  Left column (sidebar)         │  Main pane                │
+///   │  Border + VStack of N entries  │  VSplitter:               │
+///   │  - one row mutates per frame   │   Top: dashboard grid     │
+///   │                                 │   Bot: scrolling log     │
+///   └─────────────────────────────────────────────────────────────┘
+///
+/// Cell-level changes per frame are bounded but spread across multiple
+/// non-cached subtrees so the surface diff, token emission, and ANSI
+/// serialize phases all do real work.
+/// </summary>
+internal static class BusyScene
+{
+    public static Hex1bWidget Build(int frame, int sidebarItems, int logLines, int gridRows, int gridCols)
+    {
+        var sidebar = BuildSidebar(frame, sidebarItems);
+        var dashboard = BuildDashboard(frame, gridRows, gridCols);
+        var log = BuildLog(frame, logLines);
+
+        var mainPane = new BorderWidget(
+            new SplitterWidget(
+                first: new BorderWidget(dashboard).Title("Dashboard"),
+                second: new BorderWidget(log).Title("Log"),
+                firstSize: Math.Max(6, gridRows + 2),
+                orientation: SplitterOrientation.Vertical));
+
+        var root = new SplitterWidget(
+            first: new BorderWidget(sidebar).Title("Navigation"),
+            second: mainPane,
+            firstSize: 28,
+            orientation: SplitterOrientation.Horizontal);
+
+        var header = new TextBlockWidget($"Hex1b PerfDemo — busy frame {frame:N0}");
+
+        return new VStackWidget(new Hex1bWidget[]
+        {
+            header,
+            root,
+        });
+    }
+
+    private static Hex1bWidget BuildSidebar(int frame, int items)
+    {
+        var children = new Hex1bWidget[items];
+        var selected = frame % items;
+        for (var i = 0; i < items; i++)
+        {
+            // Only the "selected" row visibly changes per frame; the rest are static.
+            var marker = i == selected ? "▶" : " ";
+            children[i] = new TextBlockWidget($"{marker} item-{i:000}  ");
+        }
+        return new VStackWidget(children);
+    }
+
+    private static Hex1bWidget BuildDashboard(int frame, int rows, int cols)
+    {
+        var rowWidgets = new Hex1bWidget[rows];
+        for (var r = 0; r < rows; r++)
+        {
+            var cells = new Hex1bWidget[cols];
+            for (var c = 0; c < cols; c++)
+            {
+                // Phase shift per cell so we exercise scattered diffs, not a single
+                // contiguous run.
+                var v = (frame + (r * 17) + (c * 29)) % 100;
+                cells[c] = new TextBlockWidget($" {v,3} ");
+            }
+            rowWidgets[r] = new HStackWidget(cells);
+        }
+
+        // A progress bar that advances every frame to add another small diff target.
+        var progress = new ProgressWidget
+        {
+            Value = (frame % 100),
+            Minimum = 0,
+            Maximum = 100
+        };
+
+        return new VStackWidget(new Hex1bWidget[]
+        {
+            progress,
+            new VStackWidget(rowWidgets)
+        });
+    }
+
+    private static Hex1bWidget BuildLog(int frame, int lines)
+    {
+        // Scrolling log: every line moves up by one each frame, so every visible
+        // row changes. This is the most expensive subtree.
+        var children = new Hex1bWidget[lines];
+        for (var i = 0; i < lines; i++)
+        {
+            var n = frame - lines + i + 1;
+            children[i] = new TextBlockWidget($"{n:0000000}  evt={(n * 1103515245 + 12345) & 0xFFFF:X4}  msg=line content {i}");
+        }
+        return new VStackWidget(children);
+    }
+}

--- a/samples/PerfDemo/MetricsCollector.cs
+++ b/samples/PerfDemo/MetricsCollector.cs
@@ -1,0 +1,158 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+
+namespace PerfDemo;
+
+/// <summary>
+/// In-process MeterListener that subscribes to the "Hex1b" meter and aggregates
+/// every histogram into mean / p50 / p95 / p99 / max + counters into totals.
+///
+/// This converts the rich System.Diagnostics.Metrics instrumentation in
+/// <c>Hex1b.Diagnostics.Hex1bMetrics</c> into a one-shot, human-readable report
+/// without needing OTLP or any external collector.
+/// </summary>
+internal sealed class MetricsCollector : IDisposable
+{
+    private readonly MeterListener _listener;
+    private readonly ConcurrentDictionary<string, HistogramSink> _histograms = new();
+    private readonly ConcurrentDictionary<string, long> _counters = new();
+    private bool _capturing;
+
+    public MetricsCollector(string meterName = "Hex1b")
+    {
+        _listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == meterName)
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+
+        _listener.SetMeasurementEventCallback<double>((inst, value, _, _) =>
+        {
+            if (!_capturing) return;
+            _histograms.GetOrAdd(inst.Name, _ => new HistogramSink(inst.Unit)).Add(value);
+        });
+        _listener.SetMeasurementEventCallback<int>((inst, value, _, _) =>
+        {
+            if (!_capturing) return;
+            _histograms.GetOrAdd(inst.Name, _ => new HistogramSink(inst.Unit)).Add(value);
+        });
+        _listener.SetMeasurementEventCallback<long>((inst, value, _, _) =>
+        {
+            if (!_capturing) return;
+            if (inst is Counter<long>)
+            {
+                _counters.AddOrUpdate(inst.Name, value, (_, acc) => acc + value);
+            }
+            else
+            {
+                _histograms.GetOrAdd(inst.Name, _ => new HistogramSink(inst.Unit)).Add(value);
+            }
+        });
+
+        _listener.Start();
+    }
+
+    /// <summary>Begin recording. Call after warmup to exclude first-frame noise.</summary>
+    public void StartCapture() => _capturing = true;
+
+    /// <summary>Stop recording.</summary>
+    public void StopCapture() => _capturing = false;
+
+    public void Dispose() => _listener.Dispose();
+
+    public void PrintSummary(TextWriter writer)
+    {
+        writer.WriteLine();
+        writer.WriteLine("== Hex1b metrics ==");
+
+        if (_counters.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine("Counters:");
+            foreach (var (name, value) in _counters.OrderBy(p => p.Key))
+            {
+                writer.WriteLine($"  {name,-44} {value,12:N0}");
+            }
+        }
+
+        if (_histograms.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine("Histograms (count, mean, p50, p95, p99, max, unit):");
+            writer.WriteLine($"  {"name",-44} {"count",8} {"mean",10} {"p50",10} {"p95",10} {"p99",10} {"max",10} unit");
+
+            foreach (var (name, sink) in _histograms.OrderBy(p => p.Key))
+            {
+                var s = sink.Snapshot();
+                writer.WriteLine(
+                    $"  {name,-44} {s.Count,8:N0} {s.Mean,10:N3} {s.P50,10:N3} {s.P95,10:N3} {s.P99,10:N3} {s.Max,10:N3} {sink.Unit ?? ""}");
+            }
+        }
+    }
+
+    private sealed class HistogramSink
+    {
+        private readonly object _gate = new();
+        private double[] _values = new double[1024];
+        private int _count;
+
+        public HistogramSink(string? unit) { Unit = unit; }
+        public string? Unit { get; }
+
+        public void Add(double value)
+        {
+            lock (_gate)
+            {
+                if (_count == _values.Length)
+                {
+                    Array.Resize(ref _values, _values.Length * 2);
+                }
+                _values[_count++] = value;
+            }
+        }
+
+        public Stats Snapshot()
+        {
+            double[] copy;
+            int count;
+            lock (_gate)
+            {
+                count = _count;
+                copy = new double[count];
+                Array.Copy(_values, copy, count);
+            }
+            if (count == 0)
+            {
+                return new Stats(0, 0, 0, 0, 0, 0);
+            }
+            Array.Sort(copy);
+            double sum = 0;
+            for (var i = 0; i < count; i++) sum += copy[i];
+            return new Stats(
+                Count: count,
+                Mean: sum / count,
+                P50: Percentile(copy, 0.50),
+                P95: Percentile(copy, 0.95),
+                P99: Percentile(copy, 0.99),
+                Max: copy[count - 1]);
+        }
+
+        private static double Percentile(double[] sorted, double p)
+        {
+            if (sorted.Length == 0) return 0;
+            var rank = p * (sorted.Length - 1);
+            var lo = (int)Math.Floor(rank);
+            var hi = (int)Math.Ceiling(rank);
+            if (lo == hi) return sorted[lo];
+            var frac = rank - lo;
+            return sorted[lo] * (1 - frac) + sorted[hi] * frac;
+        }
+    }
+
+    private readonly record struct Stats(int Count, double Mean, double P50, double P95, double P99, double Max);
+}

--- a/samples/PerfDemo/Program.cs
+++ b/samples/PerfDemo/Program.cs
@@ -1,9 +1,11 @@
 using System.Diagnostics;
 using System.Threading.Channels;
 using Hex1b;
+using Hex1b.Diagnostics;
 using Hex1b.Input;
 using Hex1b.Theming;
 using Hex1b.Widgets;
+using PerfDemo;
 
 var options = PerfOptions.Parse(args);
 
@@ -30,7 +32,7 @@ static async Task<PerfResult> RunOnceAsync(bool enableCaching, PerfOptions optio
         .Set(GlobalTheme.BackgroundColor, Hex1bColor.DarkGray)
         .Lock();
 
-    var staticPanel = BuildStaticPanel(options.StaticLines);
+    var staticPanel = options.Busy ? null : BuildStaticPanel(options.StaticLines);
 
     var warmupFrames = options.WarmupFrames;
     var measureFrames = options.MeasureFrames;
@@ -52,6 +54,12 @@ static async Task<PerfResult> RunOnceAsync(bool enableCaching, PerfOptions optio
 
     using var adapter = new PerfWorkloadAdapter(options.Width, options.Height, TerminalCapabilities.Minimal);
 
+    using var metrics = new Hex1bMetrics(new Hex1bMetricsOptions
+    {
+        EnablePerNodeMetrics = options.EnablePerNodeMetrics
+    });
+    using var collector = new MetricsCollector();
+
     Hex1bApp? app = null;
     app = new Hex1bApp(ctx =>
     {
@@ -68,6 +76,7 @@ static async Task<PerfResult> RunOnceAsync(bool enableCaching, PerfOptions optio
             startGen1 = GC.CollectionCount(1);
             startGen2 = GC.CollectionCount(2);
             startTimestamp = Stopwatch.GetTimestamp();
+            collector.StartCapture();
         }
 
         if (frame == stopFrame)
@@ -77,21 +86,30 @@ static async Task<PerfResult> RunOnceAsync(bool enableCaching, PerfOptions optio
             endGen0 = GC.CollectionCount(0);
             endGen1 = GC.CollectionCount(1);
             endGen2 = GC.CollectionCount(2);
+            collector.StopCapture();
             app!.RequestStop();
             return new TextBlockWidget("Stopping...");
         }
 
-        var root = new VStackWidget(new Hex1bWidget[]
-        {
-            new TextBlockWidget($"Tick: {frame}"),
-            staticPanel
-        });
+        Hex1bWidget root = options.Busy
+            ? BusyScene.Build(
+                frame,
+                sidebarItems: options.BusySidebarItems,
+                logLines: options.BusyLogLines,
+                gridRows: options.BusyGridRows,
+                gridCols: options.BusyGridCols)
+            : new VStackWidget(new Hex1bWidget[]
+            {
+                new TextBlockWidget($"Tick: {frame}"),
+                staticPanel!
+            });
         renderedFrames++;
         return root;
     }, new Hex1bAppOptions
     {
         WorkloadAdapter = adapter,
         Theme = theme,
+        Metrics = metrics,
         EnableRenderCaching = enableCaching,
         EnableSurfacePooling = options.EnableSurfacePooling,
         EnableDefaultCtrlCExit = false,
@@ -116,7 +134,7 @@ static async Task<PerfResult> RunOnceAsync(bool enableCaching, PerfOptions optio
         : Stopwatch.GetElapsedTime(startTimestamp, endTimestamp);
     var allocatedBytes = endAllocated - startAllocated;
 
-    return new PerfResult
+    var result = new PerfResult
     {
         EnableCaching = enableCaching,
         EnableSurfacePooling = options.EnableSurfacePooling,
@@ -133,6 +151,13 @@ static async Task<PerfResult> RunOnceAsync(bool enableCaching, PerfOptions optio
         Gen1 = endGen1 - startGen1,
         Gen2 = endGen2 - startGen2
     };
+
+    if (options.PrintMetricsSummary)
+    {
+        collector.PrintSummary(Console.Out);
+    }
+
+    return result;
 }
 
 static Hex1bWidget BuildStaticPanel(int lines)
@@ -184,7 +209,14 @@ internal sealed record PerfOptions(
     int Height,
     int StaticLines,
     int WarmupFrames,
-    int MeasureFrames)
+    int MeasureFrames,
+    bool Busy,
+    int BusySidebarItems,
+    int BusyLogLines,
+    int BusyGridRows,
+    int BusyGridCols,
+    bool EnablePerNodeMetrics,
+    bool PrintMetricsSummary)
 {
     public static PerfOptions Parse(string[] args)
     {
@@ -200,13 +232,25 @@ internal sealed record PerfOptions(
 
         var compare = HasFlag(args, "--compare");
         var enableCaching = HasFlag(args, "--cache");
-        var enablePooling = HasFlag(args, "--pool");
+        // Surface pooling is now ON by default in Hex1bAppOptions. Mirror that
+        // here, with --no-pool as the explicit opt-out for A/B measurements.
+        var enablePooling = !HasFlag(args, "--no-pool");
+        var busy = HasFlag(args, "--busy");
+        var perNode = HasFlag(args, "--per-node");
+        var noSummary = HasFlag(args, "--no-summary");
 
-        var width = ReadInt(args, "--width", 120);
-        var height = ReadInt(args, "--height", 40);
+        // The busy scene fills a larger frame by default so the render pipeline
+        // has meaningful work to do (more cells = more diff/encode work).
+        var width = ReadInt(args, "--width", busy ? 160 : 120);
+        var height = ReadInt(args, "--height", busy ? 50 : 40);
         var staticLines = ReadInt(args, "--lines", 200);
-        var warmup = ReadInt(args, "--warmup", 25);
-        var frames = ReadInt(args, "--frames", 200);
+        var warmup = ReadInt(args, "--warmup", 50);
+        var frames = ReadInt(args, "--frames", busy ? 500 : 200);
+
+        var sidebarItems = ReadInt(args, "--busy-sidebar", 20);
+        var logLines = ReadInt(args, "--busy-log", 20);
+        var gridRows = ReadInt(args, "--busy-grid-rows", 8);
+        var gridCols = ReadInt(args, "--busy-grid-cols", 12);
 
         return new PerfOptions(
             EnableCaching: enableCaching,
@@ -216,7 +260,14 @@ internal sealed record PerfOptions(
             Height: height,
             StaticLines: staticLines,
             WarmupFrames: warmup,
-            MeasureFrames: frames);
+            MeasureFrames: frames,
+            Busy: busy,
+            BusySidebarItems: sidebarItems,
+            BusyLogLines: logLines,
+            BusyGridRows: gridRows,
+            BusyGridCols: gridCols,
+            EnablePerNodeMetrics: perNode,
+            PrintMetricsSummary: !noSummary);
     }
 }
 

--- a/samples/PerfStressDemo/IStressPage.cs
+++ b/samples/PerfStressDemo/IStressPage.cs
@@ -1,0 +1,42 @@
+using Hex1b;
+using Hex1b.Widgets;
+
+namespace PerfStressDemo;
+
+/// <summary>
+/// A single stress-test "page" in the demo. Each page returns a full-screen
+/// widget tree designed to exercise some specific part of the render pipeline.
+/// </summary>
+internal interface IStressPage
+{
+    /// <summary>Short name shown in the status bar.</summary>
+    string Name { get; }
+
+    /// <summary>One-line description of what this page is stressing.</summary>
+    string Description { get; }
+
+    /// <summary>
+    /// Build the page's widget tree. Called every frame <b>only while this
+    /// page is the active one</b>. Inactive pages never have <c>Build</c>
+    /// invoked, so their simulations are naturally paused.
+    /// </summary>
+    Hex1bWidget Build(StressContext ctx);
+
+    /// <summary>
+    /// True when this page has fully settled and has nothing to animate.
+    /// The root checks this <i>after</i> calling <see cref="Build"/> to
+    /// decide whether to schedule another redraw — when the active page is
+    /// idle, the framework sleeps until a real input event (mouse move,
+    /// key press) arrives, dropping CPU to ~zero.
+    /// </summary>
+    bool IsIdle => false;
+}
+
+/// <summary>
+/// Ambient information passed to <see cref="IStressPage.Build"/> on every
+/// frame. Kept tiny — pages should pull their own state from their own fields.
+/// </summary>
+internal readonly record struct StressContext(
+    RootContext Root,
+    double ElapsedSeconds,
+    int RedrawIntervalMs);

--- a/samples/PerfStressDemo/PerfStressDemo.csproj
+++ b/samples/PerfStressDemo/PerfStressDemo.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <PublishAot>true</PublishAot>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Hex1b/Hex1b.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/PerfStressDemo/PondRipplePage.cs
+++ b/samples/PerfStressDemo/PondRipplePage.cs
@@ -1,0 +1,388 @@
+using Hex1b;
+using Hex1b.Surfaces;
+using Hex1b.Theming;
+using Hex1b.Widgets;
+
+namespace PerfStressDemo;
+
+/// <summary>
+/// Page 2 — "Pond ripple".
+///
+/// Same noise-character background as page 1, but instead of a fixed
+/// concentric ripple driven by elapsed time, the wave field is driven
+/// interactively by the mouse cursor. Move the mouse over the page and
+/// the cells underneath light up; the disturbance propagates outward as
+/// a real shallow-water wave (height-field with 2D wave-equation
+/// integration), bounces off the edges, interferes with itself, and
+/// dampens to stillness once you stop moving.
+///
+/// Render cost characteristics are similar to page 1's ripple — every
+/// cell typically changes some amount each frame while waves are alive,
+/// so the SurfaceComparer diff stays large. The key difference is that
+/// the wave field actually decays to zero, so you can see the
+/// renderer's "idle" path engage when the pond settles (the fast-path
+/// CellsEqual short-circuit kicks in and the per-frame byte count
+/// collapses).
+/// </summary>
+internal sealed class PondRipplePage : IStressPage
+{
+    public string Name => "Pond ripple (mouse)";
+
+    public string Description =>
+        "Move the mouse over the page — waves propagate from the cursor "
+        + "across the pond and dampen to stillness.";
+
+    // --- Noise background ----------------------------------------------------
+
+    private const int RangeStart = 0x21; // '!'
+    private const int RangeEnd = 0x7E;   // '~'
+    private const int RangeSize = RangeEnd - RangeStart + 1;
+
+    private static readonly string[] s_asciiChars = BuildAsciiChars();
+
+    private static string[] BuildAsciiChars()
+    {
+        var arr = new string[RangeSize];
+        for (var i = 0; i < RangeSize; i++)
+            arr[i] = ((char)(RangeStart + i)).ToString();
+        return arr;
+    }
+
+    // The character at each cell; stable across resizes for a given size.
+    private string[]? _noise;
+
+    // --- Wave physics --------------------------------------------------------
+    //
+    // Classic discretised 2D wave equation on a heightfield:
+    //     next[x,y] = (prev[x-1,y] + prev[x+1,y]
+    //                + prev[x,y-1] + prev[x,y+1]) / 2
+    //                - current[x,y];
+    //     next[x,y] *= damping;
+    // We ping-pong between two buffers (current ↔ previous) and treat
+    // out-of-bounds neighbours as 0 (Dirichlet) so the pond has solid edges.
+
+    private float[]? _current;
+    private float[]? _previous;
+    private int _fieldWidth;
+    private int _fieldHeight;
+    // Last MouseX/Y values *observed* from the layer context, used purely
+    // to detect whether the mouse actually moved between frames. Distinct
+    // from the splash trail head below: the observed position persists
+    // across stationary frames, the trail head does not.
+    private int _observedMouseX = int.MinValue;
+    private int _observedMouseY = int.MinValue;
+    // Position of the last splash (head of the current drag trail), or -1
+    // when the trail is "broken" (mouse outside the pond, or stationary
+    // for a frame). Reset to -1 ends the trail so the next movement
+    // starts a fresh single-point splash instead of drawing a Bresenham
+    // line from a stale position.
+    private int _trailX = -1;
+    private int _trailY = -1;
+    // True when both wave buffers are fully zero and there's no mouse-driven
+    // input pending. Lets the page tell the framework to stop redrawing.
+    // Starts true (pond is calm at construction); flipped false whenever a
+    // splash is injected, flipped back to true at the end of any Step() that
+    // floored every cell to zero.
+    private bool _quiescent = true;
+
+    /// <summary>
+    /// One viscosity preset — combines damping, step rate, and splash
+    /// amplitude so each preset reads as a coherent fluid feel rather
+    /// than independent knobs.
+    /// </summary>
+    /// <param name="Name">Short label shown in the status bar.</param>
+    /// <param name="Damping">
+    /// Per-step amplitude multiplier. 1.0 = lossless; values below 1
+    /// dissipate energy over time. Lower = more viscous (waves die
+    /// faster).
+    /// </param>
+    /// <param name="StepEveryNFrames">
+    /// Run a physics step every Nth frame. Higher = slower wavefront
+    /// propagation (acts as time dilation on the fluid). 1 = fast water,
+    /// 3+ = slow glob.
+    /// </param>
+    /// <param name="SplashAmplitude">
+    /// Magnitude of the splash impulse, scaled to keep single moves
+    /// visible against the chosen damping.
+    /// </param>
+    internal readonly record struct ViscosityPreset(
+        string Name,
+        float Damping,
+        int StepEveryNFrames,
+        float SplashAmplitude);
+
+    /// <summary>
+    /// Cyclable viscosity presets, ordered thin → thick. Press V to
+    /// advance through them.
+    /// </summary>
+    internal static readonly ViscosityPreset[] Presets = new[]
+    {
+        new ViscosityPreset("water",  0.995f, 1, -2.5f),
+        new ViscosityPreset("light",  0.98f,  1, -3.5f),
+        new ViscosityPreset("medium", 0.96f,  1, -4.5f),
+        new ViscosityPreset("thick",  0.94f,  2, -5.5f),
+        new ViscosityPreset("glob",   0.92f,  3, -6.5f),
+    };
+
+    /// <summary>
+    /// Index into <see cref="Presets"/> for the current fluid feel.
+    /// Mutated by the V key binding in Program.cs.
+    /// </summary>
+    public static int PresetIndex { get; set; } = 1; // "light" by default
+
+    /// <summary>Human-readable preset name for the status bar.</summary>
+    public static string PresetLabel => Presets[PresetIndex].Name;
+
+    /// <summary>Advances to the next preset (wrapping).</summary>
+    public static void CyclePreset()
+        => PresetIndex = (PresetIndex + 1) % Presets.Length;
+
+    private int _stepCounter;
+
+    public Hex1bWidget Build(StressContext sc)
+    {
+        var widget = sc.Root
+            .Surface(layer =>
+            {
+                EnsureFieldSize(layer.Width, layer.Height);
+                EnsureNoise(layer.Width, layer.Height);
+
+                // Mouse coords are relative to the surface widget; -1 when
+                // the pointer isn't over us. Treat any frame where the
+                // pointer is present as a splash impulse — this gives the
+                // "dragging a finger" feel without needing a click.
+                var mx = layer.MouseX;
+                var my = layer.MouseY;
+                var inPond = mx >= 0 && my >= 0 && mx < layer.Width && my < layer.Height;
+                // "Moved this frame" = the layer's mouse coords differ from
+                // what we observed last frame. layer.MouseX/Y holds the
+                // last reported value, so a stationary mouse reports the
+                // same coords frame after frame.
+                var movedThisFrame = inPond
+                    && (mx != _observedMouseX || my != _observedMouseY);
+                _observedMouseX = mx;
+                _observedMouseY = my;
+
+                if (movedThisFrame)
+                {
+                    // If the trail head is valid, draw a Bresenham splash
+                    // line from it to the new position (continuous drag).
+                    // If the trail was broken (pause or just entered the
+                    // pond), splash only at the new position so we don't
+                    // yank a wave across the screen.
+                    SplashLine(_trailX, _trailY, mx, my);
+                    _trailX = mx;
+                    _trailY = my;
+                }
+                else
+                {
+                    // No movement this frame (or mouse not in pond): break
+                    // the trail so the next movement starts fresh.
+                    _trailX = -1;
+                    _trailY = -1;
+                }
+
+                // Sub-step: only advance the simulation every Nth frame so
+                // wavefronts propagate at a fraction of cell-per-frame
+                // speed. Combined with damping this gives the chosen
+                // viscosity preset its characteristic fluid feel.
+                if (++_stepCounter >= Presets[PresetIndex].StepEveryNFrames)
+                {
+                    _stepCounter = 0;
+                    Step();
+                }
+
+                return new[] { layer.Layer(DrawPond) };
+            });
+
+        // Only schedule continuous redraws while the simulation has energy
+        // to dissipate. Once the pond fully settles, drop RedrawAfter so
+        // the framework idles until a mouse event wakes it back up.
+        return _quiescent ? widget : widget.RedrawAfter(sc.RedrawIntervalMs);
+    }
+
+    /// <summary>
+    /// True when the wave field is fully settled and the page has nothing
+    /// to animate. Program.cs queries this after <see cref="Build"/> to
+    /// decide whether the root tree needs a RedrawAfter — when both this
+    /// page and the root are content to idle, the framework sleeps until
+    /// real input arrives.
+    /// </summary>
+    public bool IsIdle => _quiescent;
+
+    private void EnsureNoise(int w, int h)
+    {
+        if (_noise is { } existing && existing.Length == w * h)
+            return;
+
+        var rng = new Random(0xC0FFEE);
+        var arr = new string[w * h];
+        for (var i = 0; i < arr.Length; i++)
+            arr[i] = s_asciiChars[rng.Next(RangeSize)];
+        _noise = arr;
+    }
+
+    private void EnsureFieldSize(int w, int h)
+    {
+        if (_current is not null && _fieldWidth == w && _fieldHeight == h)
+            return;
+
+        _fieldWidth = w;
+        _fieldHeight = h;
+        _current = new float[w * h];
+        _previous = new float[w * h];
+        _observedMouseX = int.MinValue;
+        _observedMouseY = int.MinValue;
+        _trailX = -1;
+        _trailY = -1;
+        _quiescent = true;
+    }
+
+    /// <summary>
+    /// Adds a splash impulse along the segment from (x0,y0) to (x1,y1).
+    /// When the cursor moves several cells in a single frame, splashing
+    /// only at the endpoint gives a "skipping" feel — splashing along
+    /// the line gives the continuous "dragging a finger" feel.
+    /// </summary>
+    private void SplashLine(int x0, int y0, int x1, int y1)
+    {
+        if (x0 < 0 || y0 < 0)
+        {
+            Splash(x1, y1);
+            return;
+        }
+
+        // Bresenham line, splashing at every step.
+        var dx = Math.Abs(x1 - x0);
+        var dy = -Math.Abs(y1 - y0);
+        var sx = x0 < x1 ? 1 : -1;
+        var sy = y0 < y1 ? 1 : -1;
+        var err = dx + dy;
+
+        while (true)
+        {
+            Splash(x0, y0);
+            if (x0 == x1 && y0 == y1) break;
+            var e2 = 2 * err;
+            if (e2 >= dy) { err += dy; x0 += sx; }
+            if (e2 <= dx) { err += dx; y0 += sy; }
+        }
+    }
+
+    private void Splash(int cx, int cy)
+    {
+        if (_current is null) return;
+        if ((uint)cx >= (uint)_fieldWidth || (uint)cy >= (uint)_fieldHeight) return;
+
+        // 3x3 splat with a softer falloff at the corners so the disturbance
+        // reads as a "fingertip" rather than a square.
+        var w = _fieldWidth;
+        var h = _fieldHeight;
+        for (var dy = -1; dy <= 1; dy++)
+        {
+            var y = cy + dy;
+            if ((uint)y >= (uint)h) continue;
+            for (var dx = -1; dx <= 1; dx++)
+            {
+                var x = cx + dx;
+                if ((uint)x >= (uint)w) continue;
+                var falloff = (dx == 0 && dy == 0) ? 1.0f : ((dx == 0 || dy == 0) ? 0.5f : 0.25f);
+                _current[y * w + x] += Presets[PresetIndex].SplashAmplitude * falloff;
+            }
+        }
+        // Injecting energy wakes the simulation back up.
+        _quiescent = false;
+    }
+
+    /// <summary>
+    /// Advances the wave simulation by one step. Reads from
+    /// <see cref="_previous"/>, writes into a new buffer, then swaps
+    /// so the new state becomes "current" for the next frame.
+    /// </summary>
+    private void Step()
+    {
+        if (_current is null || _previous is null) return;
+
+        var w = _fieldWidth;
+        var h = _fieldHeight;
+        var cur = _current;
+        var prv = _previous;
+        var damping = Presets[PresetIndex].Damping;
+        var anyAlive = false;
+
+        // Update interior cells. Edge cells stay at 0 (solid boundary).
+        for (var y = 1; y < h - 1; y++)
+        {
+            var row = y * w;
+            for (var x = 1; x < w - 1; x++)
+            {
+                var i = row + x;
+                var neighbours = cur[i - 1] + cur[i + 1] + cur[i - w] + cur[i + w];
+                var next = (neighbours * 0.5f) - prv[i];
+                next *= damping;
+                // Floor small values to 0. The scheme is at CFL=1 (the 2D
+                // stability boundary) so the Nyquist mode is non-dissipative
+                // and only the damping multiplier decays it — without a
+                // generous floor, tiny residual oscillations can sit just
+                // above the cutoff for thousands of steps, and the hard
+                // boundary between floored and not-quite-floored cells
+                // re-injects energy. 0.01 is well below visible brightness
+                // (level 40.4 vs 40 at MaxDisplay=6) so killing it is free.
+                if (next > -0.01f && next < 0.01f) next = 0f;
+                else anyAlive = true;
+                prv[i] = next;
+            }
+        }
+
+        // Swap buffers: prv now holds the next state.
+        (_current, _previous) = (prv, cur);
+        // If every interior cell floored to zero, the pond is fully settled
+        // — flip the flag so the page reports IsIdle and the framework can
+        // stop scheduling frames until input wakes us back up.
+        if (!anyAlive) _quiescent = true;
+    }
+
+    private void DrawPond(Surface surface)
+    {
+        if (_current is null || _previous is null || _noise is null) return;
+
+        var w = surface.Width;
+        var h = surface.Height;
+        var black = Hex1bColor.Black;
+        var field = _current;
+        var prev = _previous;
+
+        // Map signed displacement to brightness with a linear ramp clamped
+        // at ±maxDisplay. Peaks brighten, troughs ALSO brighten (we display
+        // |displacement|) so a wave reads as a band of brightness; what
+        // distinguishes constructive vs destructive interference is the
+        // *amplitude* of the resulting peak/trough — keep it linear here so
+        // those amplitude differences are visible instead of saturating.
+        //
+        // We display max(|cur|, |prv|) per cell rather than just |cur|.
+        // For a propagating sinusoid the instantaneous magnitude swings
+        // through zero at every half-period, which would show up as a
+        // strobing pattern at the cell level even when the wave itself is
+        // smooth. The envelope across two adjacent timesteps captures the
+        // local amplitude and reads as a steady band of brightness.
+        const float MaxDisplay = 6.0f;
+        for (var y = 0; y < h; y++)
+        {
+            var row = y * w;
+            for (var x = 0; x < w; x++)
+            {
+                var i = row + x;
+                var c = field[i];
+                var p = prev[i];
+                var mc = c < 0 ? -c : c;
+                var mp = p < 0 ? -p : p;
+                var mag = mc > mp ? mc : mp;
+                var t = mag / MaxDisplay;
+                if (t > 1.0f) t = 1.0f;
+                var level = (byte)(40 + (215 * t));
+                var colour = Hex1bColor.FromRgb(level, level, level);
+                surface[x, y] = new SurfaceCell(_noise[i], colour, black);
+            }
+        }
+    }
+}

--- a/samples/PerfStressDemo/Program.cs
+++ b/samples/PerfStressDemo/Program.cs
@@ -1,0 +1,201 @@
+using System.Diagnostics;
+using Hex1b;
+using Hex1b.Input;
+using Hex1b.Widgets;
+using PerfStressDemo;
+
+// ─────────────────────────────────────────────────────────────────────────
+// PerfStressDemo
+// ─────────────────────────────────────────────────────────────────────────
+// A multi-page TUI sample whose only purpose is to push the renderer hard
+// so we can visually inspect how it copes. PgUp/PgDn navigate between
+// stress pages. Each page targets a different render hotspot.
+//
+// Page 1 is the "ripple over noise" repro that originally motivated the
+// rendering-perf investigation: a full screen of random characters with
+// an EffectPanel painting a continuous ripple wave. The status bar shows
+// live frame rate and Gen2 collection count so the GC pressure win from
+// SurfacePool is visible to the naked eye.
+//
+// CLI flags:
+//     --no-pool         Disable the surface pool (A/B against default).
+//     --target-fps <N>  Redraw cadence in frames per second (default 30).
+//     --no-cache        Disable render caching.
+//     --ripple-levels <N>  Quantise the ripple gradient into N greyscale
+//                          bands (default 256 = smooth true-color). Lower
+//                          values dramatically reduce bytes/frame.
+// ─────────────────────────────────────────────────────────────────────────
+
+bool enablePool = true;
+bool enableCache = true;
+int targetFps = 30;
+
+for (var i = 0; i < args.Length; i++)
+{
+    var arg = args[i];
+    switch (arg)
+    {
+        case "--no-pool":
+            enablePool = false;
+            break;
+        case "--no-cache":
+            enableCache = false;
+            break;
+        case "--target-fps" when i + 1 < args.Length && int.TryParse(args[i + 1], out var fps) && fps > 0:
+            targetFps = fps;
+            i++;
+            break;
+        case "--ripple-levels" when i + 1 < args.Length && int.TryParse(args[i + 1], out var lvl) && lvl > 0:
+            RippleOverNoisePage.Levels = lvl;
+            i++;
+            break;
+        case "-h":
+        case "--help":
+            Console.WriteLine("PerfStressDemo — multi-page TUI render stress harness");
+            Console.WriteLine();
+            Console.WriteLine("  --no-pool            Disable surface pooling");
+            Console.WriteLine("  --no-cache           Disable render caching");
+            Console.WriteLine("  --target-fps <N>     Target frame rate (default 30)");
+            Console.WriteLine("  --ripple-levels <N>  Quantise ripple to N greyscale bands (default 256)");
+            Console.WriteLine("  PgUp / PgDn          Switch between stress pages");
+            Console.WriteLine("  L                    Cycle ripple quantisation 256→16→8→4→2→256");
+            Console.WriteLine("  V                    Cycle pond viscosity (water→light→medium→thick→glob)");
+            Console.WriteLine("  Click / Scroll       Whirlpool: L=outlet, R=inlet, Ctrl+L/R clears, R-key resets");
+            Console.WriteLine("  Q                    Quit");
+            return;
+    }
+}
+
+var pages = new IStressPage[]
+{
+    new RippleOverNoisePage(),
+    new PondRipplePage(),
+    new WhirlpoolPage(),
+};
+
+int currentPageIndex = 0;
+int redrawIntervalMs = Math.Max(1, 1000 / targetFps);
+
+// FPS / GC counters refreshed lazily — sample on every Build call.
+var clock = Stopwatch.StartNew();
+long frameCount = 0;
+double lastFpsSampleSeconds = 0;
+long lastFpsSampleFrames = 0;
+double currentFps = 0;
+int baselineGen2 = GC.CollectionCount(2);
+int baselineGen1 = GC.CollectionCount(1);
+int baselineGen0 = GC.CollectionCount(0);
+
+Hex1bApp? appRef = null;
+
+await using var terminal = Hex1bTerminal.CreateBuilder()
+    .WithMouse()
+    .WithHex1bApp(
+        o =>
+        {
+            o.EnableSurfacePooling = enablePool;
+            o.EnableRenderCaching = enableCache;
+            // Enforce the target frame rate at the framework's animation timer
+            // level. This MUST be set before Hex1bApp construction (the timer's
+            // minimum interval is captured in the ctor), so we set it via the
+            // options callback which runs before the app callback.
+            o.FrameRateLimitMs = redrawIntervalMs;
+        },
+        app =>
+    {
+        appRef = app;
+        return ctx => BuildRoot(ctx);
+    })
+    .Build();
+
+await terminal.RunAsync();
+return;
+
+Hex1bWidget BuildRoot(RootContext root)
+{
+    frameCount++;
+
+    // Sample FPS once per ~500ms so the number is readable.
+    var nowSeconds = clock.Elapsed.TotalSeconds;
+    var dt = nowSeconds - lastFpsSampleSeconds;
+    if (dt >= 0.5)
+    {
+        currentFps = (frameCount - lastFpsSampleFrames) / dt;
+        lastFpsSampleFrames = frameCount;
+        lastFpsSampleSeconds = nowSeconds;
+    }
+
+    var page = pages[currentPageIndex];
+    var stressCtx = new StressContext(root, nowSeconds, redrawIntervalMs);
+    var pageWidget = page.Build(stressCtx);
+
+    var gen2 = GC.CollectionCount(2) - baselineGen2;
+    var gen1 = GC.CollectionCount(1) - baselineGen1;
+    var gen0 = GC.CollectionCount(0) - baselineGen0;
+
+    var pageLabel = $"Page {currentPageIndex + 1}/{pages.Length}: {page.Name}";
+    var perfLabel = $"{currentFps,5:0.0} fps  GC[0/1/2]={gen0}/{gen1}/{gen2}";
+    var poolLabel = enablePool ? "pool=on" : "pool=OFF";
+    var cacheLabel = enableCache ? "cache=on" : "cache=OFF";
+
+    var rootWidget = root.VStack(v => new Hex1bWidget[]
+    {
+        // The page itself fills all remaining vertical space.
+        pageWidget.Fill(),
+
+        // Status bar at the bottom.
+        v.InfoBar(s => new IInfoBarChild[]
+        {
+            s.Section(pageLabel).FillWidth(),
+            s.Divider(" │ "),
+            s.Section(perfLabel),
+            s.Divider(" │ "),
+            s.Section($"{poolLabel}  {cacheLabel}  ripple={RippleOverNoisePage.LevelsLabel}  pond={PondRipplePage.PresetLabel}  whirl={(WhirlpoolPage.DrainOpen && WhirlpoolPage.InletOpen ? "both" : WhirlpoolPage.DrainOpen ? "drain" : WhirlpoolPage.InletOpen ? "fill" : "idle")}@{WhirlpoolPage.CurrentStrength:0.0}"),
+            s.Divider(" │ "),
+            s.Section("PgUp/PgDn  L levels  V viscosity  Click/Scroll whirlpool  Q quit"),
+        }),
+    });
+
+    // Only drive continuous animation when the active page has something
+    // to animate. When the page reports IsIdle (e.g. pond fully settled,
+    // no mouse activity), drop RedrawAfter so the framework sleeps until
+    // a real input event arrives — this is what actually drops CPU to
+    // ~zero between interactions, not pausing the inactive page (which is
+    // already paused — its Build isn't called when it's not selected).
+    if (!page.IsIdle)
+        rootWidget = rootWidget.RedrawAfter(redrawIntervalMs);
+
+    return rootWidget
+    .InputBindings(bindings =>
+    {
+        bindings.Key(Hex1bKey.PageDown).Global().Action(_ =>
+        {
+            currentPageIndex = (currentPageIndex + 1) % pages.Length;
+        }, "Next page");
+
+        bindings.Key(Hex1bKey.PageUp).Global().Action(_ =>
+        {
+            currentPageIndex = (currentPageIndex - 1 + pages.Length) % pages.Length;
+        }, "Previous page");
+
+        bindings.Key(Hex1bKey.Q).Global().Action(_ => appRef?.RequestStop(), "Quit");
+
+        bindings.Key(Hex1bKey.L).Global().Action(_ =>
+        {
+            // Cycle: 256 (smooth) → 16 → 8 → 4 → 2 → 256
+            RippleOverNoisePage.Levels = RippleOverNoisePage.Levels switch
+            {
+                >= 256 => 16,
+                16 => 8,
+                8 => 4,
+                4 => 2,
+                _ => 256,
+            };
+        }, "Cycle ripple levels");
+
+        bindings.Key(Hex1bKey.V).Global().Action(_ =>
+        {
+            PondRipplePage.CyclePreset();
+        }, "Cycle pond viscosity");
+    });
+}

--- a/samples/PerfStressDemo/RippleOverNoisePage.cs
+++ b/samples/PerfStressDemo/RippleOverNoisePage.cs
@@ -1,0 +1,169 @@
+using Hex1b;
+using Hex1b.Surfaces;
+using Hex1b.Theming;
+using Hex1b.Widgets;
+
+namespace PerfStressDemo;
+
+/// <summary>
+/// Page 1 — "Ripple over noise".
+///
+/// Full-screen field of random printable ASCII characters in white, with an
+/// <see cref="EffectPanelWidget"/> wrapped around it that paints a continuously
+/// expanding circular ripple wave. The wave touches every cell each frame, so
+/// the EffectPanel allocates and composites a full-screen surface every frame
+/// — this was the original "tanks the machine" scenario that prompted the
+/// perf investigation.
+/// </summary>
+internal sealed class RippleOverNoisePage : IStressPage
+{
+    public string Name => "Ripple over noise";
+
+    public string Description =>
+        "Full-screen white random ASCII + continuous ripple EffectPanel. "
+        + "The original 'tanks the machine' workload.";
+
+    /// <summary>
+    /// Number of distinct greyscale shades the ripple modulates the foreground
+    /// across. 256 = true-color smooth gradient (worst case — every cell tends
+    /// to a unique colour, so SGR run-collapsing in the surface comparer can't
+    /// help and the per-frame byte count to the host terminal is maximised).
+    /// Lower values quantise the gradient into bands so neighbouring cells
+    /// often share the same SGR — fewer bytes/frame, easier for slow terminal
+    /// emulators to keep up. 0 is a sentinel meaning "no quantisation".
+    /// </summary>
+    public static int Levels { get; set; } = 256;
+
+    /// <summary>
+    /// Human-readable label for the current <see cref="Levels"/> value, used
+    /// by the status bar.
+    /// </summary>
+    public static string LevelsLabel =>
+        Levels >= 256 ? "smooth (256)" : Levels.ToString();
+
+    // Cached noise surface. Regenerated only when the terminal is resized.
+    // Without this, generating a fresh 160×50 random char field every frame
+    // would allocate 8000 strings/frame (240k/sec at 30 fps) which would
+    // dwarf any allocation savings from the SurfacePool and make the
+    // ripple animation hitch.
+    private Surface? _noiseSurface;
+
+    // Pre-computed single-character strings for printable ASCII so that
+    // building the noise surface is allocation-free. char.ToString() is not
+    // cached by the BCL — for hot fill paths like this you must do it
+    // yourself.
+    private static readonly string[] s_asciiChars = BuildAsciiChars();
+
+    private const int RangeStart = 0x21; // '!'
+    private const int RangeEnd = 0x7E;   // '~'
+    private const int RangeSize = RangeEnd - RangeStart + 1;
+
+    private static string[] BuildAsciiChars()
+    {
+        var arr = new string[RangeSize];
+        for (var i = 0; i < RangeSize; i++)
+            arr[i] = ((char)(RangeStart + i)).ToString();
+        return arr;
+    }
+
+    public Hex1bWidget Build(StressContext sc)
+    {
+        // The noise itself is static. We only rebuild it on a resize, and we mark
+        // the SurfaceWidget as cacheable so the framework doesn't reallocate a
+        // ~64-bytes-per-cell child surface every reconcile (any reasonably sized
+        // terminal puts that surface on the LOH → straight to Gen2).
+        var noise = sc.Root
+            .Surface(layer => GetOrBuildNoiseLayer(layer))
+            .Cached(static _ => true);
+
+        // Wrap the noise in an EffectPanel that overlays a circular ripple
+        // expanding from the center, animated by elapsed time.
+        return sc.Root
+            .EffectPanel(noise, surface => Ripple(surface, sc.ElapsedSeconds))
+            .RedrawAfter(sc.RedrawIntervalMs);
+    }
+
+    private IEnumerable<SurfaceLayer> GetOrBuildNoiseLayer(SurfaceLayerContext layer)
+    {
+        var w = layer.Width;
+        var h = layer.Height;
+        if (_noiseSurface is null || _noiseSurface.Width != w || _noiseSurface.Height != h)
+        {
+            _noiseSurface = new Surface(w, h);
+            FillNoise(_noiseSurface);
+        }
+        return new[] { layer.Layer(_noiseSurface) };
+    }
+
+    private static void FillNoise(Surface surface)
+    {
+        // Deterministic seed so the static background is stable across resizes
+        // for a given size. The visible variety is plenty.
+        var rng = new Random(0xC0FFEE);
+        var white = Hex1bColor.White;
+        var black = Hex1bColor.Black;
+
+        for (var y = 0; y < surface.Height; y++)
+        {
+            for (var x = 0; x < surface.Width; x++)
+            {
+                var ch = s_asciiChars[rng.Next(RangeSize)];
+                surface[x, y] = new SurfaceCell(ch, white, black);
+            }
+        }
+    }
+
+    private static void Ripple(Surface surface, double seconds)
+    {
+        // Center of the screen, with x scaled so the ripple appears round
+        // despite cells being roughly twice as tall as wide.
+        var cx = surface.Width / 2.0;
+        var cy = surface.Height / 2.0;
+        const double aspect = 2.0;
+
+        // Three concentric waves at different speeds keep the surface
+        // visually busy and ensure the brightness at every cell changes
+        // frequently (so the diff stays large).
+        var wave1 = seconds * 6.0;
+        var wave2 = seconds * 9.0;
+        var wave3 = seconds * 4.0;
+
+        for (var y = 0; y < surface.Height; y++)
+        {
+            for (var x = 0; x < surface.Width; x++)
+            {
+                var dx = (x - cx) / aspect;
+                var dy = y - cy;
+                var r = Math.Sqrt(dx * dx + dy * dy);
+
+                var s1 = Math.Sin(r * 0.45 - wave1);
+                var s2 = Math.Sin(r * 0.25 - wave2);
+                var s3 = Math.Sin(r * 0.85 - wave3);
+                var combined = (s1 + s2 + s3) / 3.0; // -1..+1
+                var brightness = 0.5 + 0.5 * combined; // 0..1
+
+                // Optionally quantise into N bands so neighbouring cells share
+                // a value, which lets the SurfaceComparer's SGR state tracking
+                // collapse long runs of cells into a single SGR. Massive
+                // bytes/frame reduction on slow host terminals.
+                var levels = Levels;
+                if (levels > 0 && levels < 256)
+                {
+                    var bucket = (int)(brightness * levels);
+                    if (bucket >= levels) bucket = levels - 1;
+                    brightness = bucket / (double)(levels - 1);
+                }
+
+                // Stay in greyscale: just modulate the white intensity so
+                // the ripple reads as the original characters pulsing
+                // between dim and bright rather than cycling hue.
+                var level = (byte)(40 + 215 * brightness); // 40..255
+                var colour = Hex1bColor.FromRgb(level, level, level);
+
+                var cell = surface[x, y];
+                surface[x, y] = cell with { Foreground = colour };
+            }
+        }
+    }
+}
+

--- a/samples/PerfStressDemo/WhirlpoolPage.cs
+++ b/samples/PerfStressDemo/WhirlpoolPage.cs
@@ -1,0 +1,709 @@
+using Hex1b;
+using Hex1b.Input;
+using Hex1b.Surfaces;
+using Hex1b.Theming;
+using Hex1b.Widgets;
+
+namespace PerfStressDemo;
+
+/// <summary>
+/// Page 3 — "Whirlpool".
+///
+/// A shallow-water-equations fluid in a top-down tank. Each interior
+/// sub-cell holds an integer column height (a stack of unit voxels)
+/// plus a 2D velocity vector. Velocities evolve via:
+/// <list type="bullet">
+///   <item><b>Pressure gradient</b> — water accelerates away from
+///         high-water cells toward low-water cells (<c>∂v/∂t ∝ -∇h</c>).</item>
+///   <item><b>Drain attraction</b> — when the drain is open, each
+///         cell within reach receives a radially-inward acceleration
+///         weighted by a Gaussian on distance to the drain centre.
+///         The vortex shape emerges naturally from this radial pull
+///         plus the pressure gradient and the obstacle field, with
+///         no artificial tangential swirl.</item>
+///   <item><b>Damping</b> — multiplicative per-frame velocity decay
+///         plus a hard cap; the system loses energy over time so it
+///         eventually settles.</item>
+/// </list>
+/// Heights evolve via integer voxel transfers. For each edge between
+/// adjacent cells, the volumetric flux is
+/// <c>avg(velocity) × upwind(height)</c>; we accumulate it on a
+/// per-edge float and whenever it crosses ±1 we transfer one voxel
+/// across the edge. So even single-voxel motion is conserved and
+/// driven by the velocity field.
+///
+/// The combination gives genuinely elastic flow: open the drain and
+/// water spirals into the hole; close the drain and momentum carries
+/// the surrounding water inward past the equilibrium level, the
+/// pressure-gradient force then pushes it back out, and the basin
+/// sloshes for several seconds before settling.
+///
+/// Voxels are still individuals — they're stored as the height count
+/// in their column — but their motion is governed by the per-cell
+/// velocity field. All hot arrays (heights, vx, vy, flow accumulators)
+/// are dense float/short data with no branches in the inner loops
+/// of damping or advection, so a future SIMD pass over Vector&lt;float&gt;
+/// is straightforward.
+///
+/// The tank is the interior of the screen: a 1-cell-thick solid
+/// border is drawn around the perimeter, with a scatter of random
+/// solid disc obstacles inside that the water has to flow around.
+/// The drain hole appears as a dark dot at the cursor while it's open.
+///
+/// Controls: left click places the outlet (drain) at the cursor;
+/// right click places the inlet (refill source); ctrl+left or
+/// ctrl+right click clears the outlet or inlet respectively;
+/// R clears both and empties the basin; scroll up/down adjusts
+/// strength (drain consumption and inlet flow).
+/// </summary>
+internal sealed class WhirlpoolPage : IStressPage
+{
+    public string Name => "Whirlpool";
+
+    public string Description =>
+        "Shallow-water fluid: per-cell continuous height + 2D velocity, "
+        + "pressure-gradient acceleration, radial drain attraction, "
+        + "fractional volumetric flux transfers. Water sloshes back "
+        + "elastically when the drain closes.";
+
+    // ----------------------------------------------------------------
+    // Geometry — heights are continuous, columns top out at D units.
+    // The integer ceiling exists only for rendering buckets; the
+    // underlying physics is fractional so gravity can level a surface
+    // to its true equilibrium instead of getting stuck on a slope-1
+    // staircase that a pure integer field would consider "settled".
+    // ----------------------------------------------------------------
+    private const float D = 16f;
+
+    private float[] _height = Array.Empty<float>();
+    private float[] _vx = Array.Empty<float>();
+    private float[] _vy = Array.Empty<float>();
+    private bool[] _solid = Array.Empty<bool>();
+
+    private int _screenW, _screenH;
+    private int _dw, _dh;
+    private const int WallCells = 1;
+
+    // ----------------------------------------------------------------
+    // Drain state.
+    // ----------------------------------------------------------------
+    private bool _drainActive;
+    private int _drainCx;
+    private int _drainCy;
+    private float _strength = 1.0f;
+    private int _drainOpenFrames;
+    private const float MinStrength = 0.2f;
+    private const float MaxStrength = 8.0f;
+
+    private const float DrainReachInitial   = 2.0f;
+    private const float DrainReachMax       = 22f;
+    private const int   DrainReachRampFrames = 90;
+    private const float DrainDiscRadiusMax  = 3.0f;
+    private const float DrainDensity        = 4.0f;
+    private const float PullStrength        = 0.15f; // peak inward accel per frame at drain centre
+
+    // ----------------------------------------------------------------
+    // Shallow-water dynamics. Tune for visible momentum / sloshing
+    // without runaway oscillation.
+    // ----------------------------------------------------------------
+    private const float PressureGain = 0.06f;
+    private const float Damping      = 0.92f;
+    private const float MaxSpeed     = 0.6f;
+    private const float VelocityFloor = 0.01f;
+    // Fraction of the per-edge volumetric flux applied per frame.
+    // Lower = more viscous / stable; higher = sloshier.
+    private const float AdvectionRate = 0.5f;
+
+    // ----------------------------------------------------------------
+    // Surface tension / film thickness.
+    //
+    // Real fluids have cohesion: a thin film of water sits put against
+    // a surface until enough volume accumulates above it to overflow.
+    // We model that with a single threshold — water at or below
+    // FilmThickness voxels is considered a "skin" with no internal
+    // pressure gradient and no advective flux. Only the excess above
+    // the threshold drives flow. Drain forces likewise only attract
+    // cells that have water depth above the skin.
+    // ----------------------------------------------------------------
+    private const float FilmThickness = 1.5f;
+
+    // ----------------------------------------------------------------
+    // Refill — fixed inlet placed by right click, drips voxels into a
+    // small interior disc until the user clears or relocates it.
+    // ----------------------------------------------------------------
+    private bool _inletActive;
+    private int _inletCx;
+    private int _inletCy;
+    private const float InletFlowPerFrame = 120f;
+    private const float InletRadius  = 5f;
+
+    private bool _quiescent = true;
+    public bool IsIdle => _quiescent;
+
+    public static float CurrentStrength { get; private set; } = 1f;
+    public static bool DrainOpen { get; private set; }
+    public static bool InletOpen { get; private set; }
+
+    // xorshift32 RNG
+    private uint _rng = 0xDEADBEEFu;
+    private uint NextRandom()
+    {
+        var x = _rng; x ^= x << 13; x ^= x >> 17; x ^= x << 5;
+        _rng = x; return x;
+    }
+    private float NextFloat() => (NextRandom() & 0xFFFFFF) / (float)0x1000000;
+
+    private static readonly (byte R, byte G, byte B) SandColour    = (235, 215, 175);
+    private static readonly (byte R, byte G, byte B) ShallowColour = (160, 220, 245);
+    private static readonly (byte R, byte G, byte B) MidColour     = (40, 130, 200);
+    private static readonly (byte R, byte G, byte B) DeepColour    = (8, 40, 100);
+    private static readonly Hex1bColor WallColour = Hex1bColor.FromRgb(70, 55, 40);
+    private static readonly Hex1bColor WallTrim   = Hex1bColor.FromRgb(40, 30, 22);
+    private static readonly Hex1bColor HoleColour = Hex1bColor.FromRgb(8, 8, 12);
+    private static readonly Hex1bColor InletColour = Hex1bColor.FromRgb(240, 240, 255);
+    private static readonly Hex1bColor RockColour = Hex1bColor.FromRgb(95, 85, 75);
+
+    public Hex1bWidget Build(StressContext sc)
+    {
+        var widget = sc.Root.Interactable(ic =>
+            ic.Surface(layer =>
+            {
+                EnsureField(layer.Width, layer.Height);
+                Step();
+                return new[] { layer.Layer(DrawTank) };
+            }))
+            .InputBindings(bindings =>
+            {
+                bindings.Mouse(MouseButton.Left).Action(ctx =>
+                {
+                    if (!TryMouseToInteriorColumn(ctx.MouseX, ctx.MouseY, out var icx, out var icy))
+                        return;
+                    _drainCx = icx;
+                    _drainCy = icy;
+                    if (!_drainActive) _drainOpenFrames = 0;
+                    _drainActive = true;
+                    _quiescent = false;
+                });
+                bindings.Mouse(MouseButton.Right).Action(ctx =>
+                {
+                    if (!TryMouseToInteriorColumn(ctx.MouseX, ctx.MouseY, out var icx, out var icy))
+                        return;
+                    _inletCx = icx;
+                    _inletCy = icy;
+                    _inletActive = true;
+                    _quiescent = false;
+                });
+                bindings.Mouse(MouseButton.ScrollUp).Action(_ =>
+                {
+                    _strength = MathF.Min(MaxStrength, _strength * 1.4f);
+                });
+                bindings.Mouse(MouseButton.ScrollDown).Action(_ =>
+                {
+                    _strength = MathF.Max(MinStrength, _strength * 0.71f);
+                });
+                bindings.Mouse(MouseButton.Left).Ctrl().Action(_ =>
+                {
+                    _drainActive = false;
+                    _quiescent = false;
+                });
+                bindings.Mouse(MouseButton.Right).Ctrl().Action(_ =>
+                {
+                    _inletActive = false;
+                    _quiescent = false;
+                });
+                bindings.Key(Hex1bKey.R).Action(_ => ResetBasin(), "Reset");
+            });
+
+        return _quiescent ? widget : widget.RedrawAfter(sc.RedrawIntervalMs);
+    }
+
+    private bool TryMouseToInteriorColumn(int mouseX, int mouseY, out int icx, out int icy)
+    {
+        icx = mouseX - WallCells;
+        icy = (mouseY - WallCells) * 2 + 1;
+        if (mouseX < WallCells || mouseX >= _screenW - WallCells) return false;
+        if (mouseY < WallCells || mouseY >= _screenH - WallCells) return false;
+        if (icx < 0 || icx >= _dw || icy < 0 || icy >= _dh) return false;
+        return true;
+    }
+
+    private void ResetBasin()
+    {
+        var n = _height.Length;
+        for (var i = 0; i < n; i++)
+        {
+            _height[i] = 0f;
+            _vx[i] = 0f;
+            _vy[i] = 0f;
+        }
+        _drainActive = false;
+        _drainOpenFrames = 0;
+        _inletActive = false;
+        _strength = 1f;
+        _quiescent = false;
+    }
+
+    private void EnsureField(int w, int h)
+    {
+        if (_screenW == w && _screenH == h && _height.Length > 0) return;
+        _screenW = w;
+        _screenH = h;
+        _dw = Math.Max(0, w - 2 * WallCells);
+        _dh = Math.Max(0, h - 2 * WallCells) * 2;
+        var n = _dw * _dh;
+        _height = new float[n];
+        _vx = new float[n];
+        _vy = new float[n];
+        _solid = new bool[n];
+        GenerateObstacles();
+        for (var i = 0; i < n; i++) _height[i] = 0f;
+        _quiescent = true;
+        _drainActive = false;
+        _drainOpenFrames = 0;
+        _inletActive = false;
+    }
+
+    /// <summary>
+    /// Scatters a handful of random solid disc obstacles inside the
+    /// tank interior, leaving a margin from the perimeter walls so
+    /// every cell on the border remains traversable.
+    /// </summary>
+    private void GenerateObstacles()
+    {
+        var n = _solid.Length;
+        for (var i = 0; i < n; i++) _solid[i] = false;
+        if (_dw < 8 || _dh < 8) return;
+
+        var area = _dw * _dh;
+        var count = Math.Max(4, area / 600); // ~ a couple of dozen on a typical screen
+        var margin = 2;
+
+        for (var k = 0; k < count; k++)
+        {
+            var cx = margin + (int)(NextFloat() * (_dw - 2 * margin));
+            var cy = margin + (int)(NextFloat() * (_dh - 2 * margin));
+            var r = 1.5f + NextFloat() * 3.5f;
+            var r2 = r * r;
+            var x0 = Math.Max(0, (int)(cx - r));
+            var x1 = Math.Min(_dw - 1, (int)(cx + r + 0.5f));
+            var y0 = Math.Max(0, (int)(cy - r));
+            var y1 = Math.Min(_dh - 1, (int)(cy + r + 0.5f));
+            for (var y = y0; y <= y1; y++)
+            {
+                var row = y * _dw;
+                for (var x = x0; x <= x1; x++)
+                {
+                    var dx = x - cx;
+                    var dy = y - cy;
+                    if (dx * dx + dy * dy <= r2) _solid[row + x] = true;
+                }
+            }
+        }
+    }
+
+    private void Step()
+    {
+        if (_height.Length == 0) return;
+        CurrentStrength = _strength;
+        DrainOpen = _drainActive;
+        InletOpen = _inletActive;
+
+        ApplyForces();
+        ApplyDamping();
+        var moved = ApplyAdvection();
+
+        var consumed = false;
+        if (_drainActive)
+        {
+            _drainOpenFrames++;
+            consumed = ApplyDrain();
+        }
+
+        var refilled = false;
+        if (_inletActive)
+        {
+            refilled = ApplyRefill();
+        }
+
+        _quiescent = !_drainActive
+                     && !_inletActive
+                     && !moved
+                     && !consumed
+                     && !refilled
+                     && AllVelocitiesQuiescent();
+    }
+
+    private bool AllVelocitiesQuiescent()
+    {
+        var vx = _vx; var vy = _vy;
+        for (var i = 0; i < vx.Length; i++)
+        {
+            if (vx[i] > VelocityFloor || vx[i] < -VelocityFloor) return false;
+            if (vy[i] > VelocityFloor || vy[i] < -VelocityFloor) return false;
+        }
+        return true;
+    }
+
+    private float CurrentDrainReach()
+    {
+        var t = MathF.Min(1f, _drainOpenFrames / (float)DrainReachRampFrames);
+        var s = t * t * (3f - 2f * t);
+        return DrainReachInitial + (DrainReachMax - DrainReachInitial) * s;
+    }
+
+    /// <summary>
+    /// Per-cell acceleration: pressure gradient pushes velocity from
+    /// high water toward low water; while the drain is open each
+    /// cell within reach also receives a radial-inward
+    /// acceleration weighted by a Gaussian on its distance to the
+    /// drain centre. Boundaries reflect by mirroring the centre
+    /// height into the off-grid neighbour — so the wall pushes back
+    /// on water trying to flow into it.
+    /// </summary>
+    private void ApplyForces()
+    {
+        var dw = _dw; var dh = _dh;
+        var h = _height; var vx = _vx; var vy = _vy;
+        var solid = _solid;
+        var drainOn = _drainActive;
+        var cx = (float)_drainCx;
+        var cy = (float)_drainCy;
+        var reach = CurrentDrainReach();
+        var twoR2 = 2f * reach * reach;
+        var skip2 = (3f * reach) * (3f * reach);
+        var pull = PullStrength * _strength;
+
+        for (var y = 0; y < dh; y++)
+        {
+            var row = y * dw;
+            for (var x = 0; x < dw; x++)
+            {
+                var i = row + x;
+                if (solid[i]) { vx[i] = 0f; vy[i] = 0f; continue; }
+                var hi = h[i];
+                var hL = (x > 0     && !solid[i - 1])  ? h[i - 1]  : hi;
+                var hR = (x + 1 < dw && !solid[i + 1])  ? h[i + 1]  : hi;
+                var hU = (y > 0     && !solid[i - dw]) ? h[i - dw] : hi;
+                var hD = (y + 1 < dh && !solid[i + dw]) ? h[i + dw] : hi;
+                // Surface tension: only the depth above FilmThickness contributes
+                // to the pressure gradient. A thin film has no net force on it.
+                var eL = MathF.Max(0f, hL - FilmThickness);
+                var eR = MathF.Max(0f, hR - FilmThickness);
+                var eU = MathF.Max(0f, hU - FilmThickness);
+                var eD = MathF.Max(0f, hD - FilmThickness);
+                var gradX = (eR - eL) * 0.5f;
+                var gradY = (eD - eU) * 0.5f;
+                vx[i] -= gradX * PressureGain;
+                vy[i] -= gradY * PressureGain;
+
+                // Drain only attracts cells that actually hold water above the
+                // film threshold — a dry cell on the other side of the screen
+                // doesn't feel the drain until water reaches it. The
+                // attraction is also scaled down as a cell approaches full
+                // depth, so water can't "climb" into a mound around the
+                // drain that's deeper than the surrounding basin.
+                if (drainOn && hi > FilmThickness)
+                {
+                    var dxc = x - cx;
+                    var dyc = y - cy;
+                    var d2 = dxc * dxc + dyc * dyc;
+                    if (d2 > skip2 || d2 < 0.1f) continue;
+                    var falloff = MathF.Exp(-d2 / twoR2);
+                    var capacity = MathF.Max(0f, 1f - hi / (float)D);
+                    capacity *= capacity; // sharper rolloff as the cell nears full
+                    var w = falloff * capacity;
+                    if (w <= 0f) continue;
+                    var invR = 1f / MathF.Sqrt(d2);
+                    var inX = -dxc * invR;
+                    var inY = -dyc * invR;
+                    vx[i] += pull * inX * w;
+                    vy[i] += pull * inY * w;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Multiplicative velocity damping with a hard cap and a small
+    /// floor that zeroes near-quiescent noise. SIMD-friendly tight
+    /// loop with no branches inside the cap; on .NET 8+ this could
+    /// be vectorised over Vector&lt;float&gt;.
+    /// </summary>
+    private void ApplyDamping()
+    {
+        var vx = _vx; var vy = _vy;
+        var n = vx.Length;
+        for (var i = 0; i < n; i++)
+        {
+            var x = vx[i] * Damping;
+            var y = vy[i] * Damping;
+            if (x >  MaxSpeed) x =  MaxSpeed;
+            if (x < -MaxSpeed) x = -MaxSpeed;
+            if (y >  MaxSpeed) y =  MaxSpeed;
+            if (y < -MaxSpeed) y = -MaxSpeed;
+            if (x > -VelocityFloor && x < VelocityFloor) x = 0f;
+            if (y > -VelocityFloor && y < VelocityFloor) y = 0f;
+            vx[i] = x;
+            vy[i] = y;
+        }
+    }
+
+    /// <summary>
+    /// Continuous-flux advection. For each X edge (between cells
+    /// i and i+1 in the same row) and each Y edge (between cells i
+    /// and i+_dw in the same column) we compute volumetric flux as
+    /// <c>avg(velocity) × upwind(effective height)</c> and apply a
+    /// fraction (<see cref="AdvectionRate"/>) of it directly to the
+    /// height field — no integer accumulator, no per-edge state.
+    ///
+    /// With float heights, gravity can drive water to its true
+    /// equilibrium (flat surface) instead of getting stuck on a
+    /// slope-1 integer staircase, and the pressure gradient never
+    /// re-pumps the velocity to swap a voxel back the way it came.
+    /// Mass is conserved exactly (clamped flux is symmetric across
+    /// the edge), and the only remaining source of perpetual motion
+    /// is the small floor on velocity, which damping kills quickly.
+    /// </summary>
+    private bool ApplyAdvection()
+    {
+        var dw = _dw; var dh = _dh;
+        var h = _height; var vx = _vx; var vy = _vy;
+        var solid = _solid;
+        var moved = false;
+
+        // X edges within each row.
+        for (var y = 0; y < dh; y++)
+        {
+            var row = y * dw;
+            for (var x = 0; x + 1 < dw; x++)
+            {
+                var i = row + x;
+                var j = i + 1;
+                if (solid[i] || solid[j]) continue;
+                var v = (vx[i] + vx[j]) * 0.5f;
+                if (v == 0f) continue;
+                var hUp = v >= 0f ? h[i] : h[j];
+                var eUp = hUp - FilmThickness;
+                if (eUp <= 0f) continue;
+                var flux = v * eUp * AdvectionRate;
+                // Cap by available water at the source and free space
+                // at the sink so the field stays within [0, D].
+                if (flux > 0f)
+                {
+                    var room = D - h[j];
+                    if (flux > h[i]) flux = h[i];
+                    if (flux > room) flux = room;
+                    if (flux <= 0f) continue;
+                }
+                else
+                {
+                    var avail = h[j];
+                    var room = D - h[i];
+                    var neg = -flux;
+                    if (neg > avail) neg = avail;
+                    if (neg > room)  neg = room;
+                    if (neg <= 0f) continue;
+                    flux = -neg;
+                }
+                h[i] -= flux;
+                h[j] += flux;
+                moved = true;
+            }
+        }
+
+        // Y edges within each column.
+        for (var y = 0; y + 1 < dh; y++)
+        {
+            var row = y * dw;
+            for (var x = 0; x < dw; x++)
+            {
+                var i = row + x;
+                var j = i + dw;
+                if (solid[i] || solid[j]) continue;
+                var v = (vy[i] + vy[j]) * 0.5f;
+                if (v == 0f) continue;
+                var hUp = v >= 0f ? h[i] : h[j];
+                var eUp = hUp - FilmThickness;
+                if (eUp <= 0f) continue;
+                var flux = v * eUp * AdvectionRate;
+                if (flux > 0f)
+                {
+                    var room = D - h[j];
+                    if (flux > h[i]) flux = h[i];
+                    if (flux > room) flux = room;
+                    if (flux <= 0f) continue;
+                }
+                else
+                {
+                    var avail = h[j];
+                    var room = D - h[i];
+                    var neg = -flux;
+                    if (neg > avail) neg = avail;
+                    if (neg > room)  neg = room;
+                    if (neg <= 0f) continue;
+                    flux = -neg;
+                }
+                h[i] -= flux;
+                h[j] += flux;
+                moved = true;
+            }
+        }
+        return moved;
+    }
+
+    private bool ApplyDrain()
+    {
+        var reach = CurrentDrainReach();
+        var discR = MathF.Min(DrainDiscRadiusMax, reach * 0.7f + 0.5f);
+        if (discR < 0.5f) discR = 0.5f;
+        var discR2 = discR * discR;
+        var discArea = MathF.PI * discR2;
+        var k = (int)MathF.Max(1f, discArea * DrainDensity * _strength);
+        var x0 = Math.Max(0, (int)(_drainCx - discR));
+        var x1 = Math.Min(_dw - 1, (int)(_drainCx + discR + 0.5f));
+        var y0 = Math.Max(0, (int)(_drainCy - discR));
+        var y1 = Math.Min(_dh - 1, (int)(_drainCy + discR + 0.5f));
+        var spanW = x1 - x0 + 1;
+        var spanH = y1 - y0 + 1;
+        if (spanW <= 0 || spanH <= 0) return false;
+
+        var changed = false;
+        for (var n = 0; n < k; n++)
+        {
+            var rx = x0 + (int)(NextFloat() * spanW);
+            var ry = y0 + (int)(NextFloat() * spanH);
+            var dx = rx - _drainCx;
+            var dy = ry - _drainCy;
+            if (dx * dx + dy * dy > discR2) continue;
+            var i = ry * _dw + rx;
+            if (_solid[i]) continue;
+            if (_height[i] > 0f)
+            {
+                var take = MathF.Min(0.5f, _height[i]);
+                _height[i] -= take;
+                changed = true;
+            }
+        }
+        return changed;
+    }
+
+    private bool ApplyRefill()
+    {
+        var r = InletRadius;
+        var r2 = r * r;
+        var x0 = Math.Max(0, (int)(_inletCx - r));
+        var x1 = Math.Min(_dw - 1, (int)(_inletCx + r + 0.5f));
+        var y0 = Math.Max(0, (int)(_inletCy - r));
+        var y1 = Math.Min(_dh - 1, (int)(_inletCy + r + 0.5f));
+        var spanW = x1 - x0 + 1;
+        var spanH = y1 - y0 + 1;
+        if (spanW <= 0 || spanH <= 0) return false;
+
+        var changed = false;
+        var per = (int)MathF.Max(1f, InletFlowPerFrame * _strength);
+        for (var n = 0; n < per; n++)
+        {
+            var rx = x0 + (int)(NextFloat() * spanW);
+            var ry = y0 + (int)(NextFloat() * spanH);
+            var dx = rx - _inletCx;
+            var dy = ry - _inletCy;
+            if (dx * dx + dy * dy > r2) continue;
+            var i = ry * _dw + rx;
+            if (_solid[i]) continue;
+            if (_height[i] < D)
+            {
+                var room = D - _height[i];
+                var add = MathF.Min(0.5f, room);
+                _height[i] += add;
+                changed = true;
+            }
+        }
+        return changed;
+    }
+
+    private void DrawTank(Surface surface)
+    {
+        var w = surface.Width;
+        var hsz = surface.Height;
+
+        for (var x = 0; x < w; x++)
+        {
+            surface[x, 0] = new SurfaceCell("▄", WallColour, WallTrim);
+            surface[x, hsz - 1] = new SurfaceCell("▀", WallColour, WallTrim);
+        }
+        for (var y = 1; y < hsz - 1; y++)
+        {
+            surface[0, y] = new SurfaceCell("█", WallColour, WallColour);
+            surface[w - 1, y] = new SurfaceCell("█", WallColour, WallColour);
+        }
+
+        var dw = _dw;
+        var heights = _height;
+        var solid = _solid;
+        for (var cy = WallCells; cy < hsz - WallCells; cy++)
+        {
+            var iy = cy - WallCells;
+            var topRow = (iy * 2) * dw;
+            var botRow = (iy * 2 + 1) * dw;
+            for (var cx = WallCells; cx < w - WallCells; cx++)
+            {
+                var ix = cx - WallCells;
+                var topI = topRow + ix;
+                var botI = botRow + ix;
+                var topCol = solid[topI] ? RockColour : DepthColour(heights[topI]);
+                var botCol = solid[botI] ? RockColour : DepthColour(heights[botI]);
+                surface[cx, cy] = new SurfaceCell("▀", topCol, botCol);
+            }
+        }
+
+        if (_inletActive)
+        {
+            var inCx = _inletCx + WallCells;
+            var inCy = _inletCy / 2 + WallCells;
+            if (inCx >= WallCells && inCx < w - WallCells
+                && inCy >= WallCells && inCy < hsz - WallCells)
+            {
+                var iy = inCy - WallCells;
+                var botRow = (iy * 2 + 1) * dw;
+                var ix = inCx - WallCells;
+                surface[inCx, inCy] = new SurfaceCell("◎",
+                    InletColour, DepthColour(heights[botRow + ix]));
+            }
+        }
+
+        if (_drainActive)
+        {
+            var holeCx = _drainCx + WallCells;
+            var holeCy = _drainCy / 2 + WallCells;
+            if (holeCx >= WallCells && holeCx < w - WallCells
+                && holeCy >= WallCells && holeCy < hsz - WallCells)
+            {
+                var iy = holeCy - WallCells;
+                var botRow = (iy * 2 + 1) * dw;
+                var ix = holeCx - WallCells;
+                surface[holeCx, holeCy] = new SurfaceCell("◉",
+                    HoleColour, DepthColour(heights[botRow + ix]));
+            }
+        }
+    }
+
+    private static Hex1bColor DepthColour(float h)
+    {
+        if (h <= 0f) return Hex1bColor.FromRgb(SandColour.R, SandColour.G, SandColour.B);
+        if (h >= D) return Hex1bColor.FromRgb(DeepColour.R, DeepColour.G, DeepColour.B);
+        var t = h / D;
+        if (t < 0.25f) return Lerp(SandColour, ShallowColour, t / 0.25f);
+        if (t < 0.65f) return Lerp(ShallowColour, MidColour, (t - 0.25f) / 0.4f);
+        return Lerp(MidColour, DeepColour, (t - 0.65f) / 0.35f);
+    }
+
+    private static Hex1bColor Lerp((byte R, byte G, byte B) a, (byte R, byte G, byte B) b, float t)
+    {
+        if (t < 0f) t = 0f;
+        else if (t > 1f) t = 1f;
+        var r = (byte)(a.R + (b.R - a.R) * t);
+        var g = (byte)(a.G + (b.G - a.G) * t);
+        var bl = (byte)(a.B + (b.B - a.B) * t);
+        return Hex1bColor.FromRgb(r, g, bl);
+    }
+}

--- a/samples/PickerDemo/Program.cs
+++ b/samples/PickerDemo/Program.cs
@@ -7,7 +7,7 @@ var selectedColor = "Blue";
 var lastAction = "";
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
         ctx.VStack(v => [
             v.Text("Picker Demo - Select your favorite fruit:"),
             v.Text(""),

--- a/samples/PredictiveTextDemo/Program.cs
+++ b/samples/PredictiveTextDemo/Program.cs
@@ -19,7 +19,7 @@ var submissionCount = 0;
 var stats = new Stats();
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+    .WithHex1bApp(ctx => ctx.VStack(v => [
         v.Text("Predictive Text Demo"),
         v.Separator(),
         v.Text(""),

--- a/samples/QrCodeDemo/Program.cs
+++ b/samples/QrCodeDemo/Program.cs
@@ -15,7 +15,7 @@ var customUrl = "";
 var quietZone = 1;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     ctx.VStack(main => [
         // Title
         main.Border(

--- a/samples/ReflowDemo/Program.cs
+++ b/samples/ReflowDemo/Program.cs
@@ -45,7 +45,7 @@ void Resize(int delta)
 
 // Build the display application
 await using var display = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         return ctx.VStack(v => [
             v.Text($"  Terminal Reflow Demo \u2014 Width: {currentWidth}"),

--- a/samples/RescueDemo/Program.cs
+++ b/samples/RescueDemo/Program.cs
@@ -7,7 +7,7 @@ var throwCount = 0;
 var lastAction = "Ready";
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
         ctx.VStack(v => [
             v.Text("RescueWidget Demo"),
             v.Text("================"),

--- a/samples/ScrollPanelDemo/Program.cs
+++ b/samples/ScrollPanelDemo/Program.cs
@@ -38,7 +38,7 @@ var items = Enumerable.Range(1, 60)
     .ToList();
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         var status = panelNode is null
             ? "Status: (scroll the panel once — any arrow or PageUp/Dn — to enable imperative buttons)"

--- a/samples/ScrollbackTerminalDemo/Program.cs
+++ b/samples/ScrollbackTerminalDemo/Program.cs
@@ -100,7 +100,9 @@ Hex1bWidget BuildUI(RootContext ctx)
 // Create the display terminal
 await using var displayTerminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((app, options) =>
+    .WithHex1bApp(
+        _ => { },
+        app =>
     {
         displayApp = app;
         return ctx => BuildUI(ctx);

--- a/samples/SharedEditor/Program.cs
+++ b/samples/SharedEditor/Program.cs
@@ -152,7 +152,9 @@ void RunStressTest(MenuItemActivatedEventArgs args)
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithDiagnostics()
     .WithMouse()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(
+        _ => { },
+        app => ctx =>
     {
         return ctx.VStack(v =>
         [

--- a/samples/SliderDemo/Program.cs
+++ b/samples/SliderDemo/Program.cs
@@ -16,7 +16,7 @@ var blue = 192.0;
 var temperature = 22.0;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+    .WithHex1bApp(ctx => ctx.VStack(v => [
         v.Text("Slider Demo"),
         v.Separator(),
         v.Text(""),

--- a/samples/SpinnerDemo/Program.cs
+++ b/samples/SpinnerDemo/Program.cs
@@ -14,7 +14,7 @@ var themeConfigs = new (string Name, Action<Hex1bTheme> Configure)[]
 int selectedThemeIndex = 0;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         var currentThemeConfig = themeConfigs[selectedThemeIndex];
 

--- a/samples/StatePanelDemo/Program.cs
+++ b/samples/StatePanelDemo/Program.cs
@@ -27,7 +27,9 @@ string statusMessage = "S=shuffle  A=add  D=delete last  Q=quit";
 int nextId = 1;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((a, options) =>
+    .WithHex1bApp(
+        _ => { },
+        a =>
     {
         app = a;
         return ctx =>

--- a/samples/SubProcessDemo/Program.cs
+++ b/samples/SubProcessDemo/Program.cs
@@ -26,7 +26,9 @@ while (true)
     
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, appOptions) =>
+            .WithHex1bApp(
+                _ => { },
+                app =>
             {
                 return ctx => ctx
                     .ZStack(z =>

--- a/samples/SurfaceDemo/Program.cs
+++ b/samples/SurfaceDemo/Program.cs
@@ -26,7 +26,7 @@ async Task RunConsoleMode()
 
     await using var terminal = Hex1bTerminal.CreateBuilder()
         .WithMouse()
-        .WithHex1bApp((app, options) => ctx =>
+        .WithHex1bApp(ctx =>
         {
             if (selectedDemo == 0)
                 FirefliesDemo.Update(fireflies, random);
@@ -101,7 +101,7 @@ async Task RunWebMode(string[] args)
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithPresentation(presentation)
-            .WithHex1bApp((app, options) => ctx =>
+            .WithHex1bApp(ctx =>
             {
                 if (selectedDemo == 0)
                     FirefliesDemo.Update(fireflies, random);

--- a/samples/TabPanelDemo/Program.cs
+++ b/samples/TabPanelDemo/Program.cs
@@ -37,13 +37,13 @@ public class {{className}}
     public static async Task Main(string[] args)
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => BuildUI(app))
+            .WithHex1bApp(ctx => BuildUI())
             .Build();
 
         await terminal.RunAsync();
     }
 
-    private static Hex1bWidget BuildUI(Hex1bApp app)
+    private static Hex1bWidget BuildUI()
     {
         return new VStackWidget([
             new TextBlockWidget("Hello from {{className}}!"),
@@ -282,7 +282,7 @@ var statusMessage = "Ready";
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     ctx.VStack(main => [
         // ─────────────────────────────────────────────────────────────────
         // MENU BAR

--- a/samples/TableDemo/Program.cs
+++ b/samples/TableDemo/Program.cs
@@ -495,7 +495,7 @@ Hex1bWidget BuildNoDataScenario<TParent>(WidgetContext<TParent> ctx) where TPare
 using var terminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
     .WithDiagnostics("TableDemo", forceEnable: true)
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         return ctx.VStack(v => [
             new SplitterWidget(

--- a/samples/TermPetDemo/Program.cs
+++ b/samples/TermPetDemo/Program.cs
@@ -82,7 +82,9 @@ _ = Task.Run(async () =>
 });
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, _) =>
+    .WithHex1bApp(
+        _ => { },
+        app =>
     {
         theApp = app;
         return ctx =>

--- a/samples/TerminalSelectionDemo/Program.cs
+++ b/samples/TerminalSelectionDemo/Program.cs
@@ -98,7 +98,9 @@ Hex1bWidget Build(RootContext ctx)
 // Create the display terminal
 await using var displayTerminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((a, options) =>
+    .WithHex1bApp(
+        _ => { },
+        a =>
     {
         app = a;
         return ctx => Build(ctx);

--- a/samples/TileDemo/Program.cs
+++ b/samples/TileDemo/Program.cs
@@ -15,7 +15,7 @@ var pois = CreateLandmarks(camera);
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         var (cx, cy) = camera.CharCenter;
         return ctx.VStack(v =>

--- a/samples/TreeDemo/Program.cs
+++ b/samples/TreeDemo/Program.cs
@@ -77,7 +77,9 @@ List<TreeItemWidget> BuildServerChildren(TreeContext t, Hex1bApp app)
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithDiagnostics("TableDemo", forceEnable: true)
-    .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+    .WithHex1bApp(
+        _ => { },
+        app => ctx => ctx.VStack(v => [
         v.Text("🌳 Tree Widget Demo"),
         v.Separator(),
         v.Text(""),

--- a/samples/UnicodeSelectorDemo/Program.cs
+++ b/samples/UnicodeSelectorDemo/Program.cs
@@ -89,7 +89,7 @@ string GetCategoryShortName(UnicodeCategory category) => category switch
 };
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         var currentBlock = unicodeBlocks[selectedBlockIndex];
         var characters = GetBlockCharacters(selectedBlockIndex);

--- a/samples/WasmDemo/Program.cs
+++ b/samples/WasmDemo/Program.cs
@@ -71,7 +71,7 @@ WasmPresentationAdapter.Instance = adapter;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithPresentation(adapter)
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
         ctx.ZStack(z => [
             // Layer 1: Globe surface with interaction (bottom)
             z.Interactable(ic =>

--- a/samples/WebMuxerDemo/Cli/CliViewerApp.cs
+++ b/samples/WebMuxerDemo/Cli/CliViewerApp.cs
@@ -165,7 +165,9 @@ internal sealed class CliViewerApp
         {
             await using var outer = Hex1bTerminal.CreateBuilder()
                 .WithMouse()
-                .WithHex1bApp((app, _) =>
+                .WithHex1bApp(
+                    _ => { },
+                    app =>
                 {
                     _app = app;
                     return ctx => Render(ctx);

--- a/samples/WidgetLayerDemo/Program.cs
+++ b/samples/WidgetLayerDemo/Program.cs
@@ -127,7 +127,7 @@ CellCompute BuildEffect(int effectIndex, double progress, int width, int height)
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         var progress = GetProgress();
 

--- a/samples/WindowingDemo/Program.cs
+++ b/samples/WindowingDemo/Program.cs
@@ -242,7 +242,7 @@ async Task CleanupTerminalInstanceAsync(Hex1bTerminal terminalToDispose, Cancell
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithDiagnostics("WindowingDemo", forceEnable: true)
     .WithMouse()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
     {
         // Update fireflies each frame
         FirefliesDemo.Update(fireflies, demoRandom);

--- a/samples/ZStackDemo/Program.cs
+++ b/samples/ZStackDemo/Program.cs
@@ -32,8 +32,7 @@ var allItems = new[]
 try
 {
     await using var terminal = Hex1bTerminal.CreateBuilder()
-        .WithHex1bApp((app, options) =>
-            ctx => ctx.ThemePanel(
+        .WithHex1bApp(ctx => ctx.ThemePanel(
             theme => theme.Set(GlobalTheme.BackgroundColor, Hex1bColor.FromRgb(40, 40, 40)),
             ctx.VStack(main => [
                 // Menu bar - buttons use PushAnchored for positioned menus

--- a/src/Hex1b.Tool/Commands/Capture/PlaybackPlayerApp.cs
+++ b/src/Hex1b.Tool/Commands/Capture/PlaybackPlayerApp.cs
@@ -43,7 +43,9 @@ internal sealed class PlaybackPlayerApp
         // Build the display TUI
         await using var displayTerminal = Hex1bTerminal.CreateBuilder()
             .WithMouse()
-            .WithHex1bApp((app, options) =>
+            .WithHex1bApp(
+                _ => { },
+                app =>
             {
                 _app = app;
                 return ctx => BuildWidget(ctx);

--- a/src/Hex1b.Tool/Commands/Terminal/AttachTuiApp.cs
+++ b/src/Hex1b.Tool/Commands/Terminal/AttachTuiApp.cs
@@ -150,7 +150,9 @@ internal sealed class AttachTuiApp : IAsyncDisposable
         await using var displayTerminal = Hex1bTerminal.CreateBuilder()
             .WithMouse()
             .AddPresentationFilter(new ResizeFilter(this))
-            .WithHex1bApp((app, options) =>
+            .WithHex1bApp(
+                _ => { },
+                app =>
             {
                 _app = app;
                 return ctx => BuildWidget(ctx, handle);

--- a/src/Hex1b/ConsolePresentationAdapter.cs
+++ b/src/Hex1b/ConsolePresentationAdapter.cs
@@ -17,6 +17,11 @@ public sealed class ConsolePresentationAdapter : IHex1bTerminalPresentationAdapt
     private const uint KgpProbeImageId = 2147483647u;
     private static readonly byte[] KgpProbeQuery = Encoding.ASCII.GetBytes(
         $"\x1b_Gi={KgpProbeImageId},s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\");
+    // OSC 11 with "?" payload asks the terminal to report its current default
+    // background colour. The response comes back as ESC ] 11 ; rgb:RRRR/GGGG/BBBB
+    // ST (where ST is either ESC \ or BEL). Most modern terminals support this
+    // (xterm, iTerm2, kitty, WezTerm, Alacritty, Windows Terminal, VS Code).
+    private static readonly byte[] BackgroundProbeQuery = Encoding.ASCII.GetBytes("\x1b]11;?\x1b\\");
     private static readonly TimeSpan DefaultKgpProbeTimeout = TimeSpan.FromMilliseconds(150);
 
     private readonly IConsoleDriver _driver;
@@ -28,6 +33,7 @@ public sealed class ConsolePresentationAdapter : IHex1bTerminalPresentationAdapt
     private TerminalCapabilities _capabilities;
     private byte[] _prefetchedInput = [];
     private bool _kgpProbeCompleted;
+    private bool _backgroundProbeCompleted;
     private bool _reflowEnabled;
     private bool _disposed;
     private bool _inRawMode;
@@ -253,6 +259,9 @@ public sealed class ConsolePresentationAdapter : IHex1bTerminalPresentationAdapt
             return;
 
         _driver.Write(KgpProbeQuery);
+        // Piggyback an OSC 11 background-colour query on the same probe pass.
+        // Both responses arrive on stdin and are demuxed by signature.
+        _driver.Write(BackgroundProbeQuery);
         _driver.Flush();
 
         var bufferedInput = new List<byte>();
@@ -274,13 +283,22 @@ public sealed class ConsolePresentationAdapter : IHex1bTerminalPresentationAdapt
                 if (TryConsumeKgpProbeResponse(bufferedInput, KgpProbeImageId))
                 {
                     _capabilities = _capabilities with { SupportsKgp = true };
-                    break;
                 }
+
+                if (!_backgroundProbeCompleted &&
+                    TryConsumeBackgroundProbeResponse(bufferedInput, out var bgRgb))
+                {
+                    _capabilities = _capabilities with { DefaultBackground = bgRgb };
+                    _backgroundProbeCompleted = true;
+                }
+
+                if (_capabilities.SupportsKgp && _backgroundProbeCompleted)
+                    break;
             }
         }
         catch (OperationCanceledException) when (!ct.IsCancellationRequested && !_disposeCts.IsCancellationRequested)
         {
-            // Timed out waiting for a KGP reply: treat as unsupported.
+            // Timed out waiting for a probe reply: treat unanswered probes as unsupported / use defaults.
         }
         finally
         {
@@ -354,6 +372,102 @@ public sealed class ConsolePresentationAdapter : IHex1bTerminalPresentationAdapt
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Scans the buffered input for an OSC 11 background-colour reply. The reply
+    /// has the shape <c>ESC ] 11 ; rgb:RRRR/GGGG/BBBB ST</c> where ST is either
+    /// <c>ESC \</c> (string terminator) or <c>BEL</c> (0x07). Component widths
+    /// vary by terminal — common widths are 4 hex digits (xterm) but 2 and even
+    /// 1 are also seen in the wild — so we parse leniently and scale up.
+    /// </summary>
+    private static bool TryConsumeBackgroundProbeResponse(List<byte> buffer, out int rgb)
+    {
+        rgb = 0;
+        var span = CollectionsMarshal.AsSpan(buffer);
+        for (var start = 0; start <= span.Length - 5; start++)
+        {
+            // Match ESC ] 1 1 ;
+            if (span[start] != 0x1b || span[start + 1] != (byte)']' ||
+                span[start + 2] != (byte)'1' || span[start + 3] != (byte)'1' ||
+                span[start + 4] != (byte)';')
+                continue;
+
+            // Find the string terminator (ESC \ or BEL).
+            var end = -1;
+            var terminatorLength = 0;
+            for (var i = start + 5; i < span.Length; i++)
+            {
+                if (span[i] == 0x07)
+                {
+                    end = i;
+                    terminatorLength = 1;
+                    break;
+                }
+                if (span[i] == 0x1b && i + 1 < span.Length && span[i + 1] == (byte)'\\')
+                {
+                    end = i;
+                    terminatorLength = 2;
+                    break;
+                }
+            }
+
+            if (end < 0)
+                return false; // payload incomplete; wait for more bytes
+
+            var payload = Encoding.ASCII.GetString(span[(start + 5)..end]);
+            if (TryParseRgbColor(payload, out rgb))
+            {
+                buffer.RemoveRange(start, end + terminatorLength - start);
+                return true;
+            }
+
+            // Malformed payload; skip past this match and keep looking.
+            start = end + terminatorLength - 1;
+        }
+
+        return false;
+    }
+
+    private static bool TryParseRgbColor(string payload, out int rgb)
+    {
+        rgb = 0;
+
+        // Expected form: "rgb:RRRR/GGGG/BBBB" (xterm) or shorter widths.
+        const string prefix = "rgb:";
+        if (!payload.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        var components = payload[prefix.Length..].Split('/');
+        if (components.Length != 3)
+            return false;
+
+        Span<byte> rgbBytes = stackalloc byte[3];
+        for (var i = 0; i < 3; i++)
+        {
+            var c = components[i];
+            if (c.Length == 0 || c.Length > 4)
+                return false;
+            if (!ushort.TryParse(c, System.Globalization.NumberStyles.HexNumber,
+                System.Globalization.CultureInfo.InvariantCulture, out var value))
+                return false;
+
+            // Scale variable-width hex (1..4 digits) up to 8 bits. xterm uses 4
+            // digits per channel (16-bit), so RRRR maps to (RRRR >> 8). Shorter
+            // widths are bit-extended by repeating the highest nibble.
+            int scaled = c.Length switch
+            {
+                1 => (value << 4) | value,                  // 0xR  -> 0xRR
+                2 => value,                                  // already 8-bit
+                3 => (value << 4) | (value & 0x000F),        // pad low nibble
+                4 => value >> 8,                             // xterm 16-bit -> 8-bit
+                _ => value
+            };
+            rgbBytes[i] = (byte)Math.Clamp(scaled, 0, 255);
+        }
+
+        rgb = (rgbBytes[0] << 16) | (rgbBytes[1] << 8) | rgbBytes[2];
+        return true;
     }
 
     /// <inheritdoc />

--- a/src/Hex1b/Diagnostics/Hex1bMetrics.cs
+++ b/src/Hex1b/Diagnostics/Hex1bMetrics.cs
@@ -102,6 +102,14 @@ public sealed class Hex1bMetrics : IDisposable
     /// <summary>Time to diff previous vs current surface.</summary>
     public Histogram<double> SurfaceDiffDuration { get; }
 
+    /// <summary>Number of surface diffs that took the simple 4-field fast path. Compare against
+    /// <see cref="SurfaceDiffSlowPathCount"/> to see how often complex content forces the slow path.</summary>
+    public Counter<long> SurfaceDiffFastPathCount { get; }
+
+    /// <summary>Number of surface diffs that took the full per-cell slow path because at least
+    /// one cell on either side had wide width, underline, a multi-codepoint grapheme, or a tracked ref.</summary>
+    public Counter<long> SurfaceDiffSlowPathCount { get; }
+
     /// <summary>Time to convert surface diff to ANSI tokens.</summary>
     public Histogram<double> SurfaceTokensDuration { get; }
 
@@ -158,6 +166,8 @@ public sealed class Hex1bMetrics : IDisposable
 
         // Surface pipeline (always-on)
         SurfaceDiffDuration = Meter.CreateHistogram<double>("hex1b.surface.diff.duration", "ms", "Surface diff duration");
+        SurfaceDiffFastPathCount = Meter.CreateCounter<long>("hex1b.surface.diff.fast_path", "{diff}", "Surface diffs that took the 4-field fast path");
+        SurfaceDiffSlowPathCount = Meter.CreateCounter<long>("hex1b.surface.diff.slow_path", "{diff}", "Surface diffs that took the full per-cell slow path");
         SurfaceTokensDuration = Meter.CreateHistogram<double>("hex1b.surface.tokens.duration", "ms", "Diff to ANSI tokens duration");
         SurfaceSerializeDuration = Meter.CreateHistogram<double>("hex1b.surface.serialize.duration", "ms", "Token serialization duration");
 

--- a/src/Hex1b/EffectPanelExtensions.cs
+++ b/src/Hex1b/EffectPanelExtensions.cs
@@ -10,7 +10,7 @@ public static class EffectPanelExtensions
 {
     /// <summary>
     /// Creates an effect panel that wraps the given child widget.
-    /// Use <see cref="EffectPanelWidget.Effect(Action{Surface})"/> to apply a post-processing effect.
+    /// Use <see cref="EffectPanelWidget.Effect"/> to apply a post-processing effect.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
     /// <param name="context">The widget context.</param>
@@ -36,22 +36,4 @@ public static class EffectPanelExtensions
         Action<Surface> effect)
         where TParent : Hex1bWidget
         => new(child) { EffectCallback = effect };
-
-    /// <summary>
-    /// Creates an effect panel that wraps the given child widget with a context-aware
-    /// effect applied. The callback receives both the rendered surface and the parent
-    /// <see cref="Hex1bRenderContext"/> (useful for reading the global background colour
-    /// when blending).
-    /// </summary>
-    /// <typeparam name="TParent">The parent widget type.</typeparam>
-    /// <param name="context">The widget context.</param>
-    /// <param name="child">The child widget to wrap.</param>
-    /// <param name="effect">A callback that receives the rendered <see cref="Surface"/> and render context.</param>
-    /// <returns>An <see cref="EffectPanelWidget"/> with the effect applied.</returns>
-    public static EffectPanelWidget EffectPanel<TParent>(
-        this WidgetContext<TParent> context,
-        Hex1bWidget child,
-        Action<Surface, Hex1bRenderContext> effect)
-        where TParent : Hex1bWidget
-        => new(child) { EffectWithContextCallback = effect };
 }

--- a/src/Hex1b/EffectPanelExtensions.cs
+++ b/src/Hex1b/EffectPanelExtensions.cs
@@ -10,7 +10,7 @@ public static class EffectPanelExtensions
 {
     /// <summary>
     /// Creates an effect panel that wraps the given child widget.
-    /// Use <see cref="EffectPanelWidget.Effect"/> to apply a post-processing effect.
+    /// Use <see cref="EffectPanelWidget.Effect(Action{Surface})"/> to apply a post-processing effect.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
     /// <param name="context">The widget context.</param>
@@ -36,4 +36,22 @@ public static class EffectPanelExtensions
         Action<Surface> effect)
         where TParent : Hex1bWidget
         => new(child) { EffectCallback = effect };
+
+    /// <summary>
+    /// Creates an effect panel that wraps the given child widget with a context-aware
+    /// effect applied. The callback receives both the rendered surface and the parent
+    /// <see cref="Hex1bRenderContext"/> (useful for reading the global background colour
+    /// when blending).
+    /// </summary>
+    /// <typeparam name="TParent">The parent widget type.</typeparam>
+    /// <param name="context">The widget context.</param>
+    /// <param name="child">The child widget to wrap.</param>
+    /// <param name="effect">A callback that receives the rendered <see cref="Surface"/> and render context.</param>
+    /// <returns>An <see cref="EffectPanelWidget"/> with the effect applied.</returns>
+    public static EffectPanelWidget EffectPanel<TParent>(
+        this WidgetContext<TParent> context,
+        Hex1bWidget child,
+        Action<Surface, Hex1bRenderContext> effect)
+        where TParent : Hex1bWidget
+        => new(child) { EffectWithContextCallback = effect };
 }

--- a/src/Hex1b/Flow/FlowResizeMath.cs
+++ b/src/Hex1b/Flow/FlowResizeMath.cs
@@ -56,4 +56,59 @@ internal static class FlowResizeMath
         }
         return (0, terminalHeight);
     }
+
+    /// <summary>
+    /// Computes the display row where the active step's top will sit, given
+    /// the per-paragraph logical widths of every tombstone emitted above the
+    /// active step and the current terminal width.
+    /// </summary>
+    /// <param name="initialRowOrigin">The row at which the very first
+    /// tombstone (or active step, if none) starts. Captured at flow start
+    /// and never changes for the life of the flow.</param>
+    /// <param name="tombstoneParagraphWidths">For each tombstone, in
+    /// emission order, the logical width (in cells) of each CR+LF-terminated
+    /// paragraph it contains. Hard-newline-terminated paragraphs never merge
+    /// across resize on any surveyed emulator, so we only need their widths
+    /// to recompute reflow at any terminal width.</param>
+    /// <param name="terminalWidth">Current terminal width in cells. Must be
+    /// at least 1.</param>
+    /// <returns>The 0-based display row where the active step begins after
+    /// the host terminal reflows the tombstones above it at the given
+    /// width.</returns>
+    /// <remarks>
+    /// This is the core primitive the resize handler relies on: it lets the
+    /// runner answer "where should I move the cursor before erasing the
+    /// active-step region?" without round-tripping a CPR query to the
+    /// terminal. Its correctness is pinned by the feasibility tests in
+    /// <c>FlowResizeRowOriginFeasibilityTests</c>, which drive the same
+    /// inputs through a reference reflow simulator and assert agreement.
+    /// </remarks>
+    public static int ComputeRowOriginAtWidth(
+        int initialRowOrigin,
+        IReadOnlyList<IReadOnlyList<int>> tombstoneParagraphWidths,
+        int terminalWidth)
+    {
+        if (terminalWidth < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(terminalWidth),
+                terminalWidth, "terminalWidth must be at least 1");
+        }
+
+        var rows = initialRowOrigin;
+        foreach (var tombstone in tombstoneParagraphWidths)
+        {
+            foreach (var paragraphWidth in tombstone)
+            {
+                if (paragraphWidth < 0)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(tombstoneParagraphWidths), paragraphWidth,
+                        "paragraph widths must be non-negative");
+                }
+
+                rows += Math.Max(1, (paragraphWidth + terminalWidth - 1) / terminalWidth);
+            }
+        }
+        return rows;
+    }
 }

--- a/src/Hex1b/Flow/FlowStep.cs
+++ b/src/Hex1b/Flow/FlowStep.cs
@@ -3,8 +3,8 @@ using Hex1b.Widgets;
 namespace Hex1b.Flow;
 
 /// <summary>
-/// Handle returned by <see cref="Hex1bFlowContext.Step"/> that controls a running
-/// inline step. Use <see cref="Invalidate"/> to trigger re-renders from background
+/// Handle returned by <see cref="Hex1bFlowContext.Step(Func{FlowStepContext, Task{Hex1bWidget}}, Action{Hex1bFlowStepOptions}?)"/>
+/// that controls a running inline step. Use <see cref="Invalidate"/> to trigger re-renders from background
 /// work, and <see cref="Complete()"/> or <see cref="CompleteAsync(CancellationToken)"/> to finish the step.
 /// </summary>
 public sealed class FlowStep
@@ -21,10 +21,12 @@ public sealed class FlowStep
     }
 
     /// <summary>
-    /// Gets the completed builder set by <see cref="Complete(Func{RootContext, Hex1bWidget})"/>,
-    /// or null if the step exited without one.
+    /// Gets the completed builder set by <see cref="Complete(Func{RootContext, Hex1bWidget})"/>
+    /// or its async overloads, or null if the step exited without one.
+    /// Always stored as an async builder; sync overloads wrap with
+    /// <see cref="Task.FromResult{TResult}(TResult)"/> before assigning.
     /// </summary>
-    internal Func<RootContext, Hex1bWidget>? CompletedBuilder { get; private set; }
+    internal Func<RootContext, Task<Hex1bWidget>>? CompletedBuilder { get; private set; }
 
     /// <summary>
     /// Width of the terminal in columns.
@@ -85,17 +87,28 @@ public sealed class FlowStep
     /// </summary>
     /// <remarks>
     /// This is a fire-and-forget call suitable for use in event handlers.
-    /// Use <see cref="CompleteAsync(Func{RootContext, Hex1bWidget}, CancellationToken)"/> from the
-    /// flow callback to also wait for cleanup to finish.
+    /// Use <see cref="CompleteAsync(Func{RootContext, Task{Hex1bWidget}}, CancellationToken)"/> from
+    /// the flow callback to also wait for cleanup to finish.
     /// </remarks>
-    /// <param name="builder">Widget builder for the frozen output.</param>
-    public void Complete(Func<RootContext, Hex1bWidget> builder)
+    /// <param name="builder">Async widget builder for the frozen output.</param>
+    public void Complete(Func<RootContext, Task<Hex1bWidget>> builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
         if (Interlocked.CompareExchange(ref _completed, 1, 0) != 0)
             return;
         CompletedBuilder = builder;
         _app?.RequestStop();
+    }
+
+    /// <summary>
+    /// Sync overload of <see cref="Complete(Func{RootContext, Task{Hex1bWidget}})"/>.
+    /// Wraps the sync builder with <see cref="Task.FromResult{TResult}(TResult)"/>.
+    /// </summary>
+    /// <param name="builder">Sync widget builder for the frozen output.</param>
+    public void Complete(Func<RootContext, Hex1bWidget> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        Complete(ctx => Task.FromResult(builder(ctx)));
     }
 
     /// <summary>
@@ -114,7 +127,20 @@ public sealed class FlowStep
     /// Completes the step with frozen output and waits for cleanup
     /// (yield widget rendering, cursor advancement) to finish.
     /// </summary>
-    /// <param name="builder">Widget builder for the frozen output.</param>
+    /// <param name="builder">Async widget builder for the frozen output.</param>
+    /// <param name="cancellationToken">Optional token to cancel the wait.</param>
+    /// <returns>A task that completes when the step is fully cleaned up.</returns>
+    public Task CompleteAsync(Func<RootContext, Task<Hex1bWidget>> builder, CancellationToken cancellationToken = default)
+    {
+        Complete(builder);
+        return WaitForCompletionAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Sync overload of <see cref="CompleteAsync(Func{RootContext, Task{Hex1bWidget}}, CancellationToken)"/>.
+    /// Wraps the sync builder with <see cref="Task.FromResult{TResult}(TResult)"/>.
+    /// </summary>
+    /// <param name="builder">Sync widget builder for the frozen output.</param>
     /// <param name="cancellationToken">Optional token to cancel the wait.</param>
     /// <returns>A task that completes when the step is fully cleaned up.</returns>
     public Task CompleteAsync(Func<RootContext, Hex1bWidget> builder, CancellationToken cancellationToken = default)

--- a/src/Hex1b/Flow/Hex1bFlowContext.cs
+++ b/src/Hex1b/Flow/Hex1bFlowContext.cs
@@ -67,14 +67,30 @@ public sealed class Hex1bFlowContext
     /// step handle without needing a separate variable.
     /// </para>
     /// </remarks>
-    /// <param name="builder">Widget builder for the interactive TUI content.</param>
+    /// <param name="builder">Async widget builder for the interactive TUI content.</param>
+    /// <param name="options">Optional callback to configure step options.</param>
+    /// <returns>A <see cref="FlowStep"/> handle for controlling the running step.</returns>
+    public FlowStep Step(
+        Func<FlowStepContext, Task<Hex1bWidget>> builder,
+        Action<Hex1bFlowStepOptions>? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        return _runner.StartStep(builder, BuildOptions(options));
+    }
+
+    /// <summary>
+    /// Sync overload of <see cref="Step(Func{FlowStepContext, Task{Hex1bWidget}}, Action{Hex1bFlowStepOptions}?)"/>.
+    /// Wraps the sync builder with <see cref="Task.FromResult{TResult}(TResult)"/>.
+    /// </summary>
+    /// <param name="builder">Sync widget builder for the interactive TUI content.</param>
     /// <param name="options">Optional callback to configure step options.</param>
     /// <returns>A <see cref="FlowStep"/> handle for controlling the running step.</returns>
     public FlowStep Step(
         Func<FlowStepContext, Hex1bWidget> builder,
         Action<Hex1bFlowStepOptions>? options = null)
     {
-        return _runner.StartStep(builder, BuildOptions(options));
+        ArgumentNullException.ThrowIfNull(builder);
+        return Step(ctx => Task.FromResult(builder(ctx)), options);
     }
 
     /// <summary>
@@ -83,12 +99,24 @@ public sealed class Hex1bFlowContext
     /// need interactivity. The widget is rendered once and scrolls naturally into
     /// the scrollback buffer.
     /// </summary>
-    /// <param name="builder">Widget builder for the static content.</param>
+    /// <param name="builder">Async widget builder for the static content.</param>
+    /// <returns>A task that completes when the content has been rendered.</returns>
+    public Task ShowAsync(Func<RootContext, Task<Hex1bWidget>> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        return _runner.RenderStaticAsync(builder);
+    }
+
+    /// <summary>
+    /// Sync overload of <see cref="ShowAsync(Func{RootContext, Task{Hex1bWidget}})"/>.
+    /// Wraps the sync builder with <see cref="Task.FromResult{TResult}(TResult)"/>.
+    /// </summary>
+    /// <param name="builder">Sync widget builder for the static content.</param>
     /// <returns>A task that completes when the content has been rendered.</returns>
     public Task ShowAsync(Func<RootContext, Hex1bWidget> builder)
     {
         ArgumentNullException.ThrowIfNull(builder);
-        return _runner.RenderStaticAsync(builder);
+        return ShowAsync(ctx => Task.FromResult(builder(ctx)));
     }
 
     /// <summary>
@@ -96,13 +124,32 @@ public sealed class Hex1bFlowContext
     /// Inline state is saved before entering and restored after exiting.
     /// </summary>
     /// <param name="configure">
-    /// Configuration callback that receives the app and options, returning the widget builder.
+    /// Configuration callback that receives the app and options, returning the async widget builder.
     /// Same pattern as the builder's WithHex1bApp method.
+    /// </param>
+    public Task FullScreenStepAsync(
+        Func<Hex1bApp, Hex1bAppOptions, Func<RootContext, Task<Hex1bWidget>>> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        return _runner.RunFullScreenStepAsync(configure);
+    }
+
+    /// <summary>
+    /// Sync overload of <see cref="FullScreenStepAsync(Func{Hex1bApp, Hex1bAppOptions, Func{RootContext, Task{Hex1bWidget}}})"/>.
+    /// Wraps the inner sync builder with <see cref="Task.FromResult{TResult}(TResult)"/>.
+    /// </summary>
+    /// <param name="configure">
+    /// Configuration callback that receives the app and options, returning the sync widget builder.
     /// </param>
     public Task FullScreenStepAsync(
         Func<Hex1bApp, Hex1bAppOptions, Func<RootContext, Hex1bWidget>> configure)
     {
-        return _runner.RunFullScreenStepAsync(configure);
+        ArgumentNullException.ThrowIfNull(configure);
+        return FullScreenStepAsync((app, opts) =>
+        {
+            var syncBuilder = configure(app, opts);
+            return ctx => Task.FromResult(syncBuilder(ctx));
+        });
     }
 }
 

--- a/src/Hex1b/Flow/Hex1bFlowRunner.cs
+++ b/src/Hex1b/Flow/Hex1bFlowRunner.cs
@@ -359,6 +359,13 @@ internal sealed class Hex1bFlowRunner
             var settleSync = new object();
             CancellationTokenSource? settleTimerCts = null;
             (int Width, int Height)? settleOriginalDims = null;
+            // Snapshot of where the active step's render region *was* when
+            // the current burst started. Used at settle time to clear the
+            // pre-burst rectangle in addition to the post-settle one — so
+            // a stale frame the inner Hex1bApp emitted just before the
+            // mute gate closed cannot leave artifacts above or below the
+            // new render.
+            (int RowOrigin, int Height)? settleOriginalRect = null;
             (int Width, int Height) settleLatestDims = default;
             var lastKnownWidth = _parentAdapter.Width;
             var lastKnownHeight = _parentAdapter.Height;
@@ -393,7 +400,15 @@ internal sealed class Hex1bFlowRunner
                         CancellationToken settleToken;
                         lock (settleSync)
                         {
-                            settleOriginalDims ??= (lastKnownWidth, lastKnownHeight);
+                            // First event of a burst: snapshot the pre-burst
+                            // rect so we can clear it at settle (the inner
+                            // Hex1bApp may have left a frame painted at the
+                            // old origin/height before the mute gate closed).
+                            if (settleOriginalDims is null)
+                            {
+                                settleOriginalDims = (lastKnownWidth, lastKnownHeight);
+                                settleOriginalRect = (rowOrigin, step.StepHeight);
+                            }
                             settleLatestDims = (newWidth, newHeight);
 
                             // Hide the cursor for the duration of the drag
@@ -539,17 +554,34 @@ internal sealed class Hex1bFlowRunner
                                     }
                                 }
 
-                                // Clear ONLY the active-step rectangle —
-                                // row by row with ESC[K, never ESC[J — so
-                                // we cannot accidentally erase a tombstone
-                                // above if our computed origin is off.
+                                // Clear the union of the pre-burst rect
+                                // and the post-settle rect. Per-event we
+                                // mute the inner Hex1bApp's output pump,
+                                // but the very first frame of a burst may
+                                // already have been written to the parent
+                                // before the mute gate flipped — leaving a
+                                // partial render at the OLD origin/height.
+                                // If settledRowOrigin or settledStepHeight
+                                // moved, that stale fragment can sit above
+                                // or below the new render unless we wipe
+                                // the old rect too. Row-by-row ESC[2K
+                                // (never ESC[J) so a wrong computation
+                                // can't erase tombstones above.
                                 _parentAdapter.Write(SyncUpdateBegin);
                                 try
                                 {
                                     _parentAdapter.Write("\x1b[?7l");
-                                    for (var i = 0; i < settledStepHeight; i++)
+
+                                    var clearTop = rowOrigin;
+                                    var clearBottom = rowOrigin + settledStepHeight - 1;
+                                    if (settleOriginalRect is { } origRect)
                                     {
-                                        var row = rowOrigin + i;
+                                        clearTop = Math.Min(clearTop, origRect.RowOrigin);
+                                        clearBottom = Math.Max(
+                                            clearBottom, origRect.RowOrigin + origRect.Height - 1);
+                                    }
+                                    for (var row = clearTop; row <= clearBottom; row++)
+                                    {
                                         if (row < 0 || row >= settledHeight) continue;
                                         _parentAdapter.SetCursorPosition(0, row);
                                         _parentAdapter.Write("\x1b[2K");
@@ -574,6 +606,7 @@ internal sealed class Hex1bFlowRunner
                                 System.Threading.Volatile.Write(ref outputMuteGate.Value, false);
 
                                 settleOriginalDims = null;
+                                settleOriginalRect = null;
                                 settleTimerCts = null;
                             }
                         });

--- a/src/Hex1b/Flow/Hex1bFlowRunner.cs
+++ b/src/Hex1b/Flow/Hex1bFlowRunner.cs
@@ -334,9 +334,18 @@ internal sealed class Hex1bFlowRunner
                 appOptions.Theme = _options.Theme;
             }
 
-            // Pump output from step adapter to parent adapter
+            // Pump output from step adapter to parent adapter. The pump is
+            // muted for the duration of a resize burst (see resize handler
+            // below) — without it, the inner Hex1bApp's continuous frame
+            // emission (glow animations, focus blink, etc.) lands at the
+            // stale rowOrigin/oldHeight and scrolls the buffer up via the
+            // CR+LF row terminators inside each frame.
             using var outputPumpCts = new CancellationTokenSource();
-            var outputPumpTask = PumpStepOutputAsync(stepAdapter, outputPumpCts.Token);
+            var outputMuteGate = new System.Runtime.CompilerServices.StrongBox<bool>(false);
+            var outputPumpTask = PumpStepOutputAsync(
+                stepAdapter,
+                outputPumpCts.Token,
+                isMuted: () => System.Threading.Volatile.Read(ref outputMuteGate.Value));
 
             // Pump input from parent adapter to step adapter, with resize handling
             using var inputPumpCts = new CancellationTokenSource();
@@ -406,6 +415,21 @@ internal sealed class Hex1bFlowRunner
                             // settle pass re-enables DECAWM as its last
                             // act before showing the cursor.
                             _parentAdapter.Write("\x1b[?7l");
+
+                            // Mute the inner-app output pump for the
+                            // duration of the drag. DECAWM-off protects
+                            // against right-edge wrap, but the inner
+                            // app's frames also contain explicit CR+LF
+                            // row separators (UseSoftWrapEmission =
+                            // true). Those CR+LFs advance the cursor
+                            // unconditionally — if the cursor lands at
+                            // the bottom row of the now-shrunken
+                            // terminal, the buffer scrolls and the
+                            // tombstones above slide off-screen. Muting
+                            // the pump lets the inner app keep rendering
+                            // into the channel without those frames ever
+                            // reaching the parent terminal.
+                            System.Threading.Volatile.Write(ref outputMuteGate.Value, true);
 
                             // Update internal state for the eventual
                             // settle. Note: we deliberately don't write
@@ -520,6 +544,14 @@ internal sealed class Hex1bFlowRunner
                                 }
 
                                 _ = stepAdapter.ResizeAsync(settledWidth, settledStepHeight);
+
+                                // Unmute the output pump. From this point
+                                // the inner Hex1bApp's frames flow back
+                                // through to the parent — its very next
+                                // frame is rendered at the settled
+                                // dimensions so it lands in the cleared
+                                // active rectangle cleanly.
+                                System.Threading.Volatile.Write(ref outputMuteGate.Value, false);
 
                                 settleOriginalDims = null;
                                 settleTimerCts = null;
@@ -1080,7 +1112,10 @@ internal sealed class Hex1bFlowRunner
     /// <summary>
     /// Pumps output from a step adapter to the parent adapter.
     /// </summary>
-    private async Task PumpStepOutputAsync(InlineStepAdapter stepAdapter, CancellationToken ct)
+    private async Task PumpStepOutputAsync(
+        InlineStepAdapter stepAdapter,
+        CancellationToken ct,
+        Func<bool>? isMuted = null)
     {
         try
         {
@@ -1088,6 +1123,11 @@ internal sealed class Hex1bFlowRunner
             {
                 var data = await stepAdapter.ReadOutputAsync(ct);
                 if (data.IsEmpty) continue;
+                // Drop frames while the runner has the pump muted (e.g.
+                // during a resize burst). Forwarding them would replay
+                // stale-sized content at the stale rowOrigin, which is
+                // the dominant cause of buffer-scroll during a drag.
+                if (isMuted?.Invoke() == true) continue;
                 _parentAdapter.Write(Encoding.UTF8.GetString(data.Span));
             }
         }

--- a/src/Hex1b/Flow/Hex1bFlowRunner.cs
+++ b/src/Hex1b/Flow/Hex1bFlowRunner.cs
@@ -999,6 +999,12 @@ internal sealed class Hex1bFlowRunner
         _parentAdapter.Write(sb.ToString());
     }
 
+    private Surface? RenderToSurface(
+        Func<RootContext, Hex1bWidget> builder,
+        int width,
+        int maxHeight)
+        => RenderToSurface(ctx => Task.FromResult(builder(ctx)), width, maxHeight);
+
     /// <summary>
     /// Renders an async widget builder into a freshly-allocated <see cref="Surface"/>
     /// synchronously. Returns <c>null</c> if the builder Task hasn't already completed,
@@ -1451,7 +1457,7 @@ public sealed class Hex1bFlowOptions
     public TimeSpan? ResizeSettleDelay { get; set; }
 
     /// <summary>
-    /// Optional async widget builder emitted as a one-off hard-newline tombstone
+    /// Optional widget builder emitted as a one-off hard-newline tombstone
     /// <em>above</em> the repainted step after the resize has settled, but
     /// only when the final dimensions differ from the dimensions at the
     /// start of the settle window. Intended for a faint
@@ -1461,18 +1467,16 @@ public sealed class Hex1bFlowOptions
     /// <remarks>
     /// <para>Has no effect when <see cref="ResizeSettleDelay"/> is <c>null</c>.</para>
     /// <para>
-    /// Async-only because properties cannot be overloaded. For purely-sync builders
-    /// wrap with <see cref="Task.FromResult{TResult}(TResult)"/>:
-    /// <c>options.ResizeMarker = ctx =&gt; Task.FromResult&lt;Hex1bWidget&gt;(ctx.Text("resized"));</c>.
-    /// The Task is expected to complete synchronously (the runner invokes the
-    /// builder from a render-time critical section); truly-async builders simply
-    /// skip a single resize frame and the next event re-triggers.
+    /// Sync-only by design: the runner invokes this builder from a render-time
+    /// critical section that cannot <c>await</c>. Build the widget from
+    /// already-resolved state and rely on the rest of the flow API's async
+    /// surface for IO-bearing work.
     /// </para>
     /// </remarks>
-    public Func<RootContext, Task<Hex1bWidget>>? ResizeMarker { get; set; }
+    public Func<RootContext, Hex1bWidget>? ResizeMarker { get; set; }
 
     /// <summary>
-    /// Optional async widget builder rendered in place of the active step's
+    /// Optional widget builder rendered in place of the active step's
     /// content during a drag-resize burst. The placeholder is drawn at
     /// each per-event tick into the active rectangle and is then replaced
     /// by the actual repainted step at settle. Use a deliberately tiny
@@ -1483,13 +1487,11 @@ public sealed class Hex1bFlowOptions
     /// <remarks>
     /// <para>Has no effect when <see cref="ResizeSettleDelay"/> is <c>null</c>.</para>
     /// <para>
-    /// Async-only because properties cannot be overloaded. For purely-sync builders
-    /// wrap with <see cref="Task.FromResult{TResult}(TResult)"/>:
-    /// <c>options.ResizePlaceholder = ctx =&gt; Task.FromResult&lt;Hex1bWidget&gt;(ctx.Text("resizing"));</c>.
-    /// The Task is expected to complete synchronously (the runner invokes the
-    /// builder per resize event); truly-async builders simply skip a single
-    /// frame and the next event re-triggers.
+    /// Sync-only by design: the runner invokes this builder per resize event
+    /// from a critical section that cannot <c>await</c>. Build the widget
+    /// from already-resolved state and rely on the rest of the flow API's
+    /// async surface for IO-bearing work.
     /// </para>
     /// </remarks>
-    public Func<RootContext, Task<Hex1bWidget>>? ResizePlaceholder { get; set; }
+    public Func<RootContext, Hex1bWidget>? ResizePlaceholder { get; set; }
 }

--- a/src/Hex1b/Flow/Hex1bFlowRunner.cs
+++ b/src/Hex1b/Flow/Hex1bFlowRunner.cs
@@ -29,6 +29,29 @@ internal sealed class Hex1bFlowRunner
     /// </summary>
     private int _cursorRow;
 
+    /// <summary>
+    /// The row at which the very first tombstone (or the active step, if no
+    /// tombstones have been emitted yet) is anchored. Captured at flow start
+    /// from <see cref="_cursorRow"/> and decremented whenever a tombstone
+    /// emission triggers a pre-scroll (so the anchor tracks "where the top
+    /// of the flow's content currently lives in the viewport"). Combined
+    /// with the per-paragraph widths in <see cref="_emittedTombstones"/>,
+    /// this lets the resize handler compute where the active step should
+    /// land at any new width without round-tripping a CPR query.
+    /// </summary>
+    private int _initialRowOrigin;
+
+    /// <summary>
+    /// Per-tombstone records of paragraph widths (one inner list per
+    /// emitted tombstone, one int per CR+LF-terminated paragraph it
+    /// contained). The host terminal guarantees hard-newline-terminated
+    /// paragraphs are never reflowed across paragraph boundaries, so the
+    /// only thing we need to track to recompute on-screen layout at any
+    /// width is the widths themselves. Used by the soft-wrap settle-mode
+    /// resize handler.
+    /// </summary>
+    private readonly List<IReadOnlyList<int>> _emittedTombstones = new();
+
     // The currently active step, if any. Only one step may run at a time.
     private FlowStep? _activeStep;
 
@@ -118,6 +141,8 @@ internal sealed class Hex1bFlowRunner
         // synchronous cursor API (when available). Falls back to
         // InitialCursorRow or 0 when no live query is wired.
         _cursorRow = await QueryCursorRowAsync(ct) ?? _options.InitialCursorRow ?? 0;
+        _initialRowOrigin = _cursorRow;
+        _emittedTombstones.Clear();
 
         Trace($"RunAsync start: termSize={_parentAdapter.Width}x{_parentAdapter.Height} cursorRow={_cursorRow} useSoftWrap={_options.UseSoftWrapTombstones}");
 
@@ -315,28 +340,187 @@ internal sealed class Hex1bFlowRunner
 
             // Pump input from parent adapter to step adapter, with resize handling
             using var inputPumpCts = new CancellationTokenSource();
+
+            // Settle state for the new debounced resize path. Captured by
+            // both the per-event handler and the timer callback. The lock
+            // protects every write the resize machinery makes to the parent
+            // adapter so a settle timer firing on the threadpool cannot
+            // interleave with a track-and-clear pass running on the pump
+            // loop.
+            var settleSync = new object();
+            CancellationTokenSource? settleTimerCts = null;
+            (int Width, int Height)? settleOriginalDims = null;
+            (int Width, int Height) settleLatestDims = default;
+            var lastKnownWidth = _parentAdapter.Width;
+            var lastKnownHeight = _parentAdapter.Height;
+
             var inputPumpTask = PumpStepInputAsync(stepAdapter, inputPumpCts.Token,
                 onResize: (newWidth, newHeight) =>
                 {
                     var newStepHeight = FlowResizeMath.ComputeStepHeight(options?.MaxHeight, newHeight);
-                    Trace($"onResize: newSize={newWidth}x{newHeight} newStepH={newStepHeight} useSoftWrap={_options.UseSoftWrapTombstones}");
+                    Trace($"onResize: newSize={newWidth}x{newHeight} newStepH={newStepHeight} useSoftWrap={_options.UseSoftWrapTombstones} settleDelay={_options.ResizeSettleDelay}");
+
+                    var useSettle = _options.UseSoftWrapTombstones
+                        && _options.ResizeSettleDelay is { } _;
+
+                    if (useSettle)
+                    {
+                        // New "track-and-clear on every event, repaint on
+                        // settle" path. Each Hex1bResizeEvent recomputes
+                        // where the active step should land at the new
+                        // width (using the per-paragraph widths of every
+                        // emitted tombstone above it), moves the cursor
+                        // there, and erases the region below. The inner
+                        // Hex1bApp is NOT asked to repaint until the
+                        // terminal has been idle for ResizeSettleDelay; in
+                        // the meantime an optional ResizePlaceholder
+                        // renders into the cleared region.
+                        CancellationToken settleToken;
+                        lock (settleSync)
+                        {
+                            settleOriginalDims ??= (lastKnownWidth, lastKnownHeight);
+                            settleLatestDims = (newWidth, newHeight);
+
+                            // Track-and-clear pass (inline so we can mutate
+                            // the closure-captured rowOrigin/desiredHeight).
+                            var newRowOrigin = FlowResizeMath.ComputeRowOriginAtWidth(
+                                _initialRowOrigin, _emittedTombstones, newWidth);
+
+                            // Bottom-overflow handling: if the active step
+                            // would extend past the bottom of the viewport
+                            // at the new width/height, emit LFs at the
+                            // bottom row to scroll the whole viewport up
+                            // so the active region stays fully visible.
+                            var bottomOverflow = (newRowOrigin + newStepHeight) - newHeight;
+                            if (bottomOverflow > 0)
+                            {
+                                _parentAdapter.SetCursorPosition(0, newHeight - 1);
+                                for (var i = 0; i < bottomOverflow; i++)
+                                {
+                                    _parentAdapter.Write("\n");
+                                }
+                                _initialRowOrigin -= bottomOverflow;
+                                newRowOrigin -= bottomOverflow;
+                            }
+
+                            _parentAdapter.Write(SyncUpdateBegin);
+                            try
+                            {
+                                _parentAdapter.Write("\x1b[?25l"); // hide cursor
+                                _parentAdapter.Write("\x1b[?7l");  // DECAWM off (defensive)
+                                _parentAdapter.SetCursorPosition(0, newRowOrigin);
+                                _parentAdapter.Write("\x1b[J");    // erase to end of screen
+
+                                if (_options.ResizePlaceholder is { } placeholderBuilder)
+                                {
+                                    RenderPlaceholder(
+                                        placeholderBuilder,
+                                        newWidth, newStepHeight, newRowOrigin);
+                                }
+
+                                _parentAdapter.Write("\x1b[?7h");  // DECAWM on
+                                // Cursor stays hidden until settle.
+                            }
+                            finally
+                            {
+                                _parentAdapter.Write(SyncUpdateEnd);
+                            }
+
+                            rowOrigin = newRowOrigin;
+                            stepAdapter.RowOrigin = newRowOrigin;
+                            _cursorRow = newRowOrigin;
+                            desiredHeight = newStepHeight;
+                            step.StepHeight = newStepHeight;
+
+                            settleTimerCts?.Cancel();
+                            settleTimerCts = CancellationTokenSource.CreateLinkedTokenSource(inputPumpCts.Token);
+                            settleToken = settleTimerCts.Token;
+                            lastKnownWidth = newWidth;
+                            lastKnownHeight = newHeight;
+                        }
+
+                        var delay = _options.ResizeSettleDelay!.Value;
+                        _ = Task.Run(async () =>
+                        {
+                            try
+                            {
+                                await Task.Delay(delay, settleToken);
+                            }
+                            catch (OperationCanceledException)
+                            {
+                                return;
+                            }
+
+                            lock (settleSync)
+                            {
+                                if (settleToken.IsCancellationRequested) return;
+
+                                var original = settleOriginalDims ?? settleLatestDims;
+                                var dimsChanged = original != settleLatestDims;
+
+                                // Settle: optionally emit a resize-marker
+                                // tombstone above the active step, then ask
+                                // the inner Hex1bApp to repaint at the
+                                // settled dimensions. Its output flows
+                                // through the existing output pump and
+                                // lands in the region we cleared in the
+                                // last track-and-clear pass.
+                                if (dimsChanged && _options.ResizeMarker is { } markerBuilder)
+                                {
+                                    var markerSurface = RenderToSurface(
+                                        markerBuilder,
+                                        settleLatestDims.Width,
+                                        Math.Max(1, settleLatestDims.Height - desiredHeight - 1));
+                                    if (markerSurface is not null)
+                                    {
+                                        // Emit at the current active-step
+                                        // origin; EmitSoftWrapTombstone
+                                        // advances _cursorRow past the
+                                        // marker so the step lands below.
+                                        _parentAdapter.SetCursorPosition(0, rowOrigin);
+                                        EmitSoftWrapTombstone(markerSurface);
+                                        rowOrigin = _cursorRow;
+                                        stepAdapter.RowOrigin = rowOrigin;
+                                    }
+                                }
+
+                                _parentAdapter.Write(SyncUpdateBegin);
+                                try
+                                {
+                                    _parentAdapter.Write("\x1b[?7l");
+                                    _parentAdapter.SetCursorPosition(0, rowOrigin);
+                                    _parentAdapter.Write("\x1b[J");
+                                    _parentAdapter.Write("\x1b[?7h");
+                                    _parentAdapter.Write("\x1b[?25h"); // show cursor
+                                }
+                                finally
+                                {
+                                    _parentAdapter.Write(SyncUpdateEnd);
+                                }
+
+                                _ = stepAdapter.ResizeAsync(
+                                    settleLatestDims.Width, desiredHeight);
+
+                                settleOriginalDims = null;
+                                settleTimerCts = null;
+                            }
+                        });
+                        return;
+                    }
 
                     if (_options.UseSoftWrapTombstones)
                     {
-                        // Resize strategy: push everything currently visible
-                        // up off the top of the viewport into the host
-                        // terminal's scrollback (where it will appear
-                        // soft-wrapped because tombstones were emitted as
-                        // logical lines), then clear the viewport and
-                        // re-anchor the active step at row 0. This avoids
-                        // any visual mangling from cell-positioned step
-                        // content trying to coexist with reflowed
-                        // tombstones at unpredictable rows.
+                        // Eager soft-wrap path (no settle delay): preserve
+                        // the existing scroll-to-scrollback behaviour so
+                        // callers who haven't opted into settle keep the
+                        // same semantics they've always had.
                         ScrollViewportToScrollback(newHeight);
 
                         stepAdapter.RowOrigin = 0;
                         rowOrigin = 0;
                         _cursorRow = 0;
+                        _initialRowOrigin = 0;
+                        _emittedTombstones.Clear();
                         desiredHeight = newStepHeight;
                         step.StepHeight = newStepHeight;
                     }
@@ -357,6 +541,9 @@ internal sealed class Hex1bFlowRunner
                         desiredHeight = newStepHeight;
                         step.StepHeight = newStepHeight;
                     }
+
+                    lastKnownWidth = newWidth;
+                    lastKnownHeight = newHeight;
 
                     _ = stepAdapter.ResizeAsync(newWidth, newStepHeight);
                 });
@@ -730,13 +917,34 @@ internal sealed class Hex1bFlowRunner
                 _parentAdapter.Write("\n");
             }
             _cursorRow -= overflow;
-            Trace($"EmitSoftWrapTombstone[#{emitId}] pre-scroll: overflow={overflow} -> cursorRow={_cursorRow}");
+            // The viewport scrolled up by `overflow` rows, so every
+            // previously-emitted tombstone (and the initial anchor) moved up
+            // by the same amount on screen. Track that shift so
+            // ComputeRowOriginAtWidth keeps returning the correct on-screen
+            // row for the active step after a future resize.
+            _initialRowOrigin -= overflow;
+            Trace($"EmitSoftWrapTombstone[#{emitId}] pre-scroll: overflow={overflow} -> cursorRow={_cursorRow} initialRowOrigin={_initialRowOrigin}");
         }
 
         // Position the cursor at the row where the tombstone should land.
         _parentAdapter.SetCursorPosition(0, _cursorRow);
 
         SoftWrapEmitter.Emit(surface, _parentAdapter);
+
+        // Capture this tombstone's per-paragraph widths so the soft-wrap
+        // settle-mode resize handler can recompute the active step's
+        // row origin at any width. Each surface row corresponds to one
+        // CR+LF-terminated paragraph (the SoftWrapEmitter contract); the
+        // logical width is the column index of the last non-blank cell
+        // plus one. Empty rows count as zero-width paragraphs and still
+        // occupy one display row on reflow (the Math.Max(1, ...) in
+        // ComputeRowOriginAtWidth handles that).
+        var paragraphWidths = new int[height];
+        for (var row = 0; row < height; row++)
+        {
+            paragraphWidths[row] = MeasureSurfaceRowWidth(surface, row);
+        }
+        _emittedTombstones.Add(paragraphWidths);
 
         // The emitter terminates rows 0 .. height-2 with CR + LF (each
         // advances the cursor down one row, with no scrolling because we
@@ -752,6 +960,62 @@ internal sealed class Hex1bFlowRunner
         _cursorRow += height;
 
         Trace($"EmitSoftWrapTombstone[#{emitId}] exit: cursorRow={_cursorRow}");
+    }
+
+    /// <summary>
+    /// Renders the user-supplied <see cref="Hex1bFlowOptions.ResizePlaceholder"/>
+    /// directly into the cleared active-step region during a track-and-clear
+    /// pass. Bypasses the step adapter's output pump so the placeholder
+    /// appears immediately on every resize event without waiting for the
+    /// inner Hex1bApp's render loop.
+    /// </summary>
+    /// <remarks>
+    /// Uses <see cref="SoftWrapEmitter"/> so each row is terminated with
+    /// <c>CR + LF</c> just like a tombstone — the placeholder is rendered as
+    /// proper logical lines that survive any reflow until the next
+    /// track-and-clear pass overwrites them.
+    /// </remarks>
+    private void RenderPlaceholder(
+        Func<RootContext, Hex1bWidget> builder,
+        int width,
+        int heightCap,
+        int originRow)
+    {
+        var surface = RenderToSurface(builder, width, heightCap);
+        if (surface is null) return;
+
+        _parentAdapter.SetCursorPosition(0, originRow);
+        SoftWrapEmitter.Emit(surface, _parentAdapter);
+    }
+
+    /// <summary>
+    /// Returns the logical paragraph width of the given surface row — the
+    /// column index of the last non-blank cell plus one. Mirrors the
+    /// trailing-blank trimming that <see cref="SoftWrapEmitter"/> performs
+    /// when it emits the row, so the recorded paragraph width matches the
+    /// number of cells the host terminal will actually have to reflow.
+    /// </summary>
+    private static int MeasureSurfaceRowWidth(Surface surface, int row)
+    {
+        var width = surface.Width;
+        for (var x = width - 1; x >= 0; x--)
+        {
+            var cell = surface.GetCell(x, row);
+            if (cell.IsContinuation)
+            {
+                // A continuation cell means the wide glyph occupies (x-1, x);
+                // treat (x) as content because removing only the continuation
+                // would mis-report the wide character's footprint.
+                return x + 1;
+            }
+            if (cell.Character != " "
+                && cell.Character != string.Empty
+                && cell.Character != SurfaceCells.UnwrittenMarker)
+            {
+                return x + 1;
+            }
+        }
+        return 0;
     }
 
     /// <summary>
@@ -968,4 +1232,50 @@ public sealed class Hex1bFlowOptions
     /// </para>
     /// </remarks>
     public bool UseSoftWrapTombstones { get; set; }
+
+    /// <summary>
+    /// Quiet window required after the last <c>Hex1bResizeEvent</c> before
+    /// the runner re-renders the active step at the new size. When
+    /// <c>null</c> (the default), the runner repaints eagerly on every
+    /// resize event — today's behaviour. When set, the runner enters a
+    /// two-phase resize mode: every resize event performs a cheap
+    /// "track-and-clear" pass (recompute where the active step should
+    /// land at the new width, move the cursor there, and erase the region
+    /// below), and only after the terminal has been idle for the settle
+    /// delay does the inner step app re-render.
+    /// </summary>
+    /// <remarks>
+    /// Only takes effect when <see cref="UseSoftWrapTombstones"/> is also
+    /// <c>true</c>: the track-and-clear pass relies on tombstones above
+    /// the active step being hard-newline-terminated paragraphs that the
+    /// host terminal will not reflow across paragraph boundaries.
+    /// Recommended value: 50–100 ms.
+    /// </remarks>
+    public TimeSpan? ResizeSettleDelay { get; set; }
+
+    /// <summary>
+    /// Optional widget builder rendered into the active-step region
+    /// <em>during</em> the settle window, in place of the live step.
+    /// Designed to be safe to render repeatedly in a hostile,
+    /// actively-resizing environment — keep it cheap, layout-tolerant, and
+    /// free of input affordances. When <c>null</c> (the default), the
+    /// active region is simply erased during the drag.
+    /// </summary>
+    /// <remarks>
+    /// Has no effect when <see cref="ResizeSettleDelay"/> is <c>null</c>.
+    /// </remarks>
+    public Func<RootContext, Hex1bWidget>? ResizePlaceholder { get; set; }
+
+    /// <summary>
+    /// Optional widget builder emitted as a one-off hard-newline tombstone
+    /// <em>above</em> the repainted step after the resize has settled, but
+    /// only when the final dimensions differ from the dimensions at the
+    /// start of the settle window. Intended for a faint
+    /// "─── terminal resized ───" breadcrumb. When <c>null</c> (the
+    /// default), no marker is emitted.
+    /// </summary>
+    /// <remarks>
+    /// Has no effect when <see cref="ResizeSettleDelay"/> is <c>null</c>.
+    /// </remarks>
+    public Func<RootContext, Hex1bWidget>? ResizeMarker { get; set; }
 }

--- a/src/Hex1b/Flow/Hex1bFlowRunner.cs
+++ b/src/Hex1b/Flow/Hex1bFlowRunner.cs
@@ -160,13 +160,13 @@ internal sealed class Hex1bFlowRunner
     /// Renders a static widget as frozen terminal output and advances the cursor.
     /// No interactive step is created — this is a fire-and-forget render.
     /// </summary>
-    internal async Task RenderStaticAsync(Func<RootContext, Hex1bWidget> builder)
+    internal async Task RenderStaticAsync(Func<RootContext, Task<Hex1bWidget>> builder)
     {
         var terminalWidth = _parentAdapter.Width;
         var terminalHeight = _parentAdapter.Height;
 
         // Measure the content to determine how much space it needs
-        var contentHeight = MeasureYieldHeight(builder, terminalWidth, terminalHeight);
+        var contentHeight = await MeasureYieldHeightAsync(builder, terminalWidth, terminalHeight);
         if (contentHeight < 1) contentHeight = 1;
 
         // Scroll if needed to make room
@@ -188,7 +188,7 @@ internal sealed class Hex1bFlowRunner
             // Render the static content into a surface and emit it as
             // soft-wrap-friendly logical lines so the host terminal owns
             // the reflow/scroll behaviour for the lifetime of the flow.
-            var surface = RenderToSurface(builder, terminalWidth, contentHeight);
+            var surface = await RenderToSurfaceAsync(builder, terminalWidth, contentHeight);
             if (surface is not null)
             {
                 EmitSoftWrapTombstone(surface);
@@ -207,7 +207,7 @@ internal sealed class Hex1bFlowRunner
     /// invalidate, complete, and await the step.
     /// </summary>
     internal FlowStep StartStep(
-        Func<FlowStepContext, Hex1bWidget> builder,
+        Func<FlowStepContext, Task<Hex1bWidget>> builder,
         Hex1bFlowStepOptions? options)
     {
         if (_activeStep != null)
@@ -240,7 +240,7 @@ internal sealed class Hex1bFlowRunner
     /// the widget without rendering it.
     /// </summary>
     private int MeasureStepContent(
-        Func<FlowStepContext, Hex1bWidget> builder,
+        Func<FlowStepContext, Task<Hex1bWidget>> builder,
         FlowStep step,
         int width,
         int maxHeight)
@@ -248,7 +248,11 @@ internal sealed class Hex1bFlowRunner
         try
         {
             var stepCtx = new FlowStepContext(step);
-            var widget = builder(stepCtx);
+            var widgetTask = builder(stepCtx);
+            // Synchronous fallback for the measurement pass — see the
+            // RenderToSurface invariant for the rationale.
+            if (!widgetTask.IsCompletedSuccessfully) return maxHeight;
+            var widget = widgetTask.Result;
             if (widget == null) return maxHeight;
 
             // Reconcile the widget into a node tree and measure it
@@ -274,7 +278,7 @@ internal sealed class Hex1bFlowRunner
 
     private async Task RunStepLifecycleAsync(
         FlowStep step,
-        Func<FlowStepContext, Hex1bWidget> builder,
+        Func<FlowStepContext, Task<Hex1bWidget>> builder,
         Hex1bFlowStepOptions? options,
         int desiredHeight)
     {
@@ -777,7 +781,7 @@ internal sealed class Hex1bFlowRunner
     /// Runs a full-screen TUI application in the alternate screen buffer.
     /// </summary>
     internal async Task RunFullScreenStepAsync(
-        Func<Hex1bApp, Hex1bAppOptions, Func<RootContext, Hex1bWidget>> configure)
+        Func<Hex1bApp, Hex1bAppOptions, Func<RootContext, Task<Hex1bWidget>>> configure)
     {
         // The parent adapter handles alt-buffer transitions naturally
         // We create a standard Hex1bApp with the parent adapter
@@ -793,10 +797,10 @@ internal sealed class Hex1bFlowRunner
         }
 
         Hex1bApp? app = null;
-        Func<RootContext, Hex1bWidget>? widgetBuilder = null;
+        Func<RootContext, Task<Hex1bWidget>>? widgetBuilder = null;
         bool configureInvoked = false;
 
-        Func<RootContext, Hex1bWidget> wrappedBuilder = ctx =>
+        Func<RootContext, Task<Hex1bWidget>> wrappedBuilder = ctx =>
         {
             if (!configureInvoked)
             {
@@ -822,12 +826,12 @@ internal sealed class Hex1bFlowRunner
     /// pages with the terminal scrolling between each page so no content is lost.
     /// </summary>
     private async Task<int> RenderYieldWidgetAsync(
-        Func<RootContext, Hex1bWidget> yieldBuilder,
+        Func<RootContext, Task<Hex1bWidget>> yieldBuilder,
         int width,
         int maxHeight)
     {
         // First, measure the yield widget to determine its natural height.
-        var measuredHeight = MeasureYieldHeight(yieldBuilder, width, maxHeight * 10);
+        var measuredHeight = await MeasureYieldHeightAsync(yieldBuilder, width, maxHeight * 10);
         if (measuredHeight < 1) measuredHeight = 1;
 
         // If it fits in one screen, render in place
@@ -863,10 +867,10 @@ internal sealed class Hex1bFlowRunner
 
             // Render a step of the yield content at the current offset
             int offset = totalRendered;
-            await RenderYieldPageAsync(ctx =>
+            await RenderYieldPageAsync(async ctx =>
             {
                 // Build a wrapper that skips the first 'offset' rows and takes 'pageHeight'
-                var fullWidget = yieldBuilder(ctx);
+                var fullWidget = await yieldBuilder(ctx);
                 return fullWidget;
             }, width, pageHeight, offset);
 
@@ -879,21 +883,19 @@ internal sealed class Hex1bFlowRunner
     }
 
     /// <summary>
-    /// Measures the natural height of a yield widget tree.
+    /// Measures the natural height of a yield widget tree. Async sibling that awaits the builder
+    /// properly; falls back to height 1 if the builder or reconciliation isn't synchronous.
     /// </summary>
-    private int MeasureYieldHeight(Func<RootContext, Hex1bWidget> yieldBuilder, int width, int maxHeight)
+    private async Task<int> MeasureYieldHeightAsync(Func<RootContext, Task<Hex1bWidget>> yieldBuilder, int width, int maxHeight)
     {
         try
         {
             var rootCtx = new RootContext();
-            var widget = yieldBuilder(rootCtx);
+            var widget = await yieldBuilder(rootCtx);
             if (widget == null) return 1;
 
             var reconcileCtx = ReconcileContext.CreateRoot();
-            var nodeTask = widget.ReconcileAsync(null, reconcileCtx);
-            if (!nodeTask.IsCompleted) return 1;
-
-            var node = nodeTask.Result;
+            var node = await widget.ReconcileAsync(null, reconcileCtx);
             if (node == null) return 1;
 
             var constraints = new Constraints(0, width, 0, maxHeight);
@@ -910,17 +912,17 @@ internal sealed class Hex1bFlowRunner
     /// Renders a yield widget page at the current cursor position.
     /// </summary>
     private async Task RenderYieldPageAsync(
-        Func<RootContext, Hex1bWidget> yieldBuilder,
+        Func<RootContext, Task<Hex1bWidget>> yieldBuilder,
         int width,
         int height,
         int skipRows = 0)
     {
-        Func<RootContext, Hex1bWidget> actualBuilder;
+        Func<RootContext, Task<Hex1bWidget>> actualBuilder;
         if (skipRows > 0)
         {
-            actualBuilder = ctx =>
+            actualBuilder = async ctx =>
             {
-                var widget = yieldBuilder(ctx);
+                var widget = await yieldBuilder(ctx);
                 if (widget is VStackWidget vstack && skipRows < vstack.Children.Count)
                 {
                     var remaining = vstack.Children.Skip(skipRows).Take(height).ToArray();
@@ -958,7 +960,7 @@ internal sealed class Hex1bFlowRunner
 
             yieldApp = new Hex1bApp(ctx =>
             {
-                var widget = actualBuilder(ctx);
+                var widgetTask = actualBuilder(ctx);
                 if (!rendered)
                 {
                     rendered = true;
@@ -968,7 +970,7 @@ internal sealed class Hex1bFlowRunner
                         yieldApp?.RequestStop();
                     });
                 }
-                return widget;
+                return widgetTask;
             }, yieldOptions);
 
             await using (yieldApp)
@@ -998,27 +1000,41 @@ internal sealed class Hex1bFlowRunner
     }
 
     /// <summary>
-    /// Renders a yield builder into a freshly-allocated <see cref="Surface"/>.
-    /// Returns <c>null</c> if reconciliation, measurement, or rendering fails
-    /// — callers should fall back to the legacy emission path in that case.
+    /// Renders an async widget builder into a freshly-allocated <see cref="Surface"/>
+    /// synchronously. Returns <c>null</c> if the builder Task hasn't already completed,
+    /// if reconciliation needs to go async, or if anything throws — callers should
+    /// fall back to the legacy emission path in that case.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// Used by call sites that can't await (the per-event resize-burst handler and
+    /// the settle-task body, both of which run inside <c>lock(settleSync)</c>).
+    /// The "must already be completed" invariant mirrors the existing constraint
+    /// on <see cref="Hex1bWidget.ReconcileAsync"/>: flow tombstones build widgets
+    /// from pre-resolved state and wrap them with <see cref="Task.FromResult{TResult}(TResult)"/>,
+    /// so the Task is completed inline on the caller's thread. Truly-async builders
+    /// (network IO etc.) simply skip a resize frame and the next event re-triggers.
+    /// </para>
+    /// <para>
     /// Used only on the soft-wrap tombstone path
-    /// (<see cref="Hex1bFlowOptions.UseSoftWrapTombstones"/>). The surface is
-    /// sized to <paramref name="width"/> by the widget's measured height
-    /// (clamped to <paramref name="maxHeight"/> × 10 to bound page-by-page
-    /// content). The surface is then arranged and rendered using the standard
-    /// rendering pipeline so any widget that works on screen will work here.
+    /// (<see cref="Hex1bFlowOptions.UseSoftWrapTombstones"/>). The surface is sized
+    /// to <paramref name="width"/> by the widget's measured height (clamped to
+    /// <paramref name="maxHeight"/> × 10 to bound page-by-page content). The surface
+    /// is then arranged and rendered using the standard rendering pipeline so any
+    /// widget that works on screen will work here.
+    /// </para>
     /// </remarks>
     private Surface? RenderToSurface(
-        Func<RootContext, Hex1bWidget> builder,
+        Func<RootContext, Task<Hex1bWidget>> builder,
         int width,
         int maxHeight)
     {
         try
         {
             var rootCtx = new RootContext();
-            var widget = builder(rootCtx);
+            var widgetTask = builder(rootCtx);
+            if (!widgetTask.IsCompletedSuccessfully) return null;
+            var widget = widgetTask.Result;
             if (widget == null) return null;
 
             var reconcileCtx = ReconcileContext.CreateRoot();
@@ -1031,27 +1047,61 @@ internal sealed class Hex1bFlowRunner
             var node = nodeTask.Result;
             if (node == null) return null;
 
-            // Measure with a generous height bound so multi-line tombstones
-            // get their full height, then clamp to a safety ceiling so a
-            // misbehaving widget can't allocate an unbounded surface.
-            var measureMax = Math.Max(maxHeight * 10, maxHeight);
-            var constraints = new Constraints(0, width, 0, measureMax);
-            var measured = node.Measure(constraints);
-            var height = Math.Max(1, Math.Min(measured.Height, measureMax));
-
-            var surface = new Surface(width, height);
-            node.Arrange(new Rect(0, 0, width, height));
-
-            var renderCtx = new SurfaceRenderContext(surface, _options.Theme);
-            renderCtx.SetCapabilities(_parentAdapter.Capabilities);
-            node.Render(renderCtx);
-
-            return surface;
+            return MaterializeSurface(node, width, maxHeight);
         }
         catch
         {
             return null;
         }
+    }
+
+    /// <summary>
+    /// Async sibling of <see cref="RenderToSurface(Func{RootContext, Task{Hex1bWidget}}, int, int)"/>
+    /// for callers that can <c>await</c> the builder (and reconciliation) properly.
+    /// Used by the static/yield/completed-tombstone paths that already run in
+    /// <c>async Task</c> methods.
+    /// </summary>
+    private async Task<Surface?> RenderToSurfaceAsync(
+        Func<RootContext, Task<Hex1bWidget>> builder,
+        int width,
+        int maxHeight)
+    {
+        try
+        {
+            var rootCtx = new RootContext();
+            var widget = await builder(rootCtx);
+            if (widget == null) return null;
+
+            var reconcileCtx = ReconcileContext.CreateRoot();
+            var node = await widget.ReconcileAsync(null, reconcileCtx);
+            if (node == null) return null;
+
+            return MaterializeSurface(node, width, maxHeight);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private Surface? MaterializeSurface(Hex1bNode node, int width, int maxHeight)
+    {
+        // Measure with a generous height bound so multi-line tombstones
+        // get their full height, then clamp to a safety ceiling so a
+        // misbehaving widget can't allocate an unbounded surface.
+        var measureMax = Math.Max(maxHeight * 10, maxHeight);
+        var constraints = new Constraints(0, width, 0, measureMax);
+        var measured = node.Measure(constraints);
+        var height = Math.Max(1, Math.Min(measured.Height, measureMax));
+
+        var surface = new Surface(width, height);
+        node.Arrange(new Rect(0, 0, width, height));
+
+        var renderCtx = new SurfaceRenderContext(surface, _options.Theme);
+        renderCtx.SetCapabilities(_parentAdapter.Capabilities);
+        node.Render(renderCtx);
+
+        return surface;
     }
 
     /// <summary>
@@ -1401,7 +1451,7 @@ public sealed class Hex1bFlowOptions
     public TimeSpan? ResizeSettleDelay { get; set; }
 
     /// <summary>
-    /// Optional widget builder emitted as a one-off hard-newline tombstone
+    /// Optional async widget builder emitted as a one-off hard-newline tombstone
     /// <em>above</em> the repainted step after the resize has settled, but
     /// only when the final dimensions differ from the dimensions at the
     /// start of the settle window. Intended for a faint
@@ -1409,12 +1459,20 @@ public sealed class Hex1bFlowOptions
     /// default), no marker is emitted.
     /// </summary>
     /// <remarks>
-    /// Has no effect when <see cref="ResizeSettleDelay"/> is <c>null</c>.
+    /// <para>Has no effect when <see cref="ResizeSettleDelay"/> is <c>null</c>.</para>
+    /// <para>
+    /// Async-only because properties cannot be overloaded. For purely-sync builders
+    /// wrap with <see cref="Task.FromResult{TResult}(TResult)"/>:
+    /// <c>options.ResizeMarker = ctx =&gt; Task.FromResult&lt;Hex1bWidget&gt;(ctx.Text("resized"));</c>.
+    /// The Task is expected to complete synchronously (the runner invokes the
+    /// builder from a render-time critical section); truly-async builders simply
+    /// skip a single resize frame and the next event re-triggers.
+    /// </para>
     /// </remarks>
-    public Func<RootContext, Hex1bWidget>? ResizeMarker { get; set; }
+    public Func<RootContext, Task<Hex1bWidget>>? ResizeMarker { get; set; }
 
     /// <summary>
-    /// Optional widget builder rendered in place of the active step's
+    /// Optional async widget builder rendered in place of the active step's
     /// content during a drag-resize burst. The placeholder is drawn at
     /// each per-event tick into the active rectangle and is then replaced
     /// by the actual repainted step at settle. Use a deliberately tiny
@@ -1423,7 +1481,15 @@ public sealed class Hex1bFlowOptions
     /// the active rectangle simply stays cleared during the drag.
     /// </summary>
     /// <remarks>
-    /// Has no effect when <see cref="ResizeSettleDelay"/> is <c>null</c>.
+    /// <para>Has no effect when <see cref="ResizeSettleDelay"/> is <c>null</c>.</para>
+    /// <para>
+    /// Async-only because properties cannot be overloaded. For purely-sync builders
+    /// wrap with <see cref="Task.FromResult{TResult}(TResult)"/>:
+    /// <c>options.ResizePlaceholder = ctx =&gt; Task.FromResult&lt;Hex1bWidget&gt;(ctx.Text("resizing"));</c>.
+    /// The Task is expected to complete synchronously (the runner invokes the
+    /// builder per resize event); truly-async builders simply skip a single
+    /// frame and the next event re-triggers.
+    /// </para>
     /// </remarks>
-    public Func<RootContext, Hex1bWidget>? ResizePlaceholder { get; set; }
+    public Func<RootContext, Task<Hex1bWidget>>? ResizePlaceholder { get; set; }
 }

--- a/src/Hex1b/Flow/Hex1bFlowRunner.cs
+++ b/src/Hex1b/Flow/Hex1bFlowRunner.cs
@@ -368,62 +368,36 @@ internal sealed class Hex1bFlowRunner
                         // "Track cursor on every event, repaint on settle".
                         //
                         // Per-event we do NOT touch the screen at all — no
-                        // ESC[J, no placeholder draw. Touching the screen
-                        // mid-drag risks clobbering the tombstones above
-                        // the active step if our computed origin is even
-                        // one row off (e.g. the terminal scrolled in a way
-                        // we didn't track). Instead we just hide the
-                        // cursor (so the user doesn't see it dancing around
-                        // the reflow garbage) and update our internal
-                        // bookkeeping; the host terminal owns reflow of
-                        // every byte we've emitted so the tombstones above
-                        // stay put.
+                        // ESC[J, no placeholder draw, no bottom-overflow
+                        // LFs. The host terminal already owns reflow of
+                        // every byte we've emitted, so its own scrolling
+                        // (if any) keeps the tombstones above naturally
+                        // anchored. We only update internal bookkeeping
+                        // so the settle-time repaint knows where to land.
                         //
                         // When events go quiet for ResizeSettleDelay, we
-                        // clear ONLY the active-step rectangle (using ESC[K
-                        // per row, never ESC[J), optionally drop a resize
-                        // marker tombstone above it, then ask the inner
-                        // Hex1bApp to repaint into the cleared region.
+                        // do any necessary bottom-overflow scroll, clear
+                        // ONLY the active-step rectangle (per-row ESC[2K,
+                        // never ESC[J), optionally drop a resize-marker
+                        // tombstone above it, then ask the inner Hex1bApp
+                        // to repaint into the cleared region.
                         CancellationToken settleToken;
                         lock (settleSync)
                         {
                             settleOriginalDims ??= (lastKnownWidth, lastKnownHeight);
                             settleLatestDims = (newWidth, newHeight);
 
-                            // Recompute where the active step lands at the
-                            // new width — purely internal bookkeeping, no
-                            // writes to the parent terminal.
-                            var newRowOrigin = FlowResizeMath.ComputeRowOriginAtWidth(
-                                _initialRowOrigin, _emittedTombstones, newWidth);
-
-                            // Bottom-overflow handling: if the active step
-                            // would extend past the bottom of the viewport
-                            // at the new height, emit LFs at the bottom
-                            // row to scroll the whole viewport up so the
-                            // active region stays fully visible. This is a
-                            // necessary screen mutation — without it the
-                            // step would render off the bottom — but it
-                            // only touches the bottom row, never the
-                            // tombstones above.
-                            var bottomOverflow = (newRowOrigin + newStepHeight) - newHeight;
-                            if (bottomOverflow > 0)
-                            {
-                                _parentAdapter.SetCursorPosition(0, newHeight - 1);
-                                for (var i = 0; i < bottomOverflow; i++)
-                                {
-                                    _parentAdapter.Write("\n");
-                                }
-                                _initialRowOrigin -= bottomOverflow;
-                                newRowOrigin -= bottomOverflow;
-                            }
-
                             // Hide the cursor for the duration of the drag
                             // so it doesn't visibly chase the reflow.
                             _parentAdapter.Write("\x1b[?25l");
 
-                            rowOrigin = newRowOrigin;
-                            stepAdapter.RowOrigin = newRowOrigin;
-                            _cursorRow = newRowOrigin;
+                            // Update internal state for the eventual
+                            // settle. Note: we deliberately don't write
+                            // anything to the parent here — the settle
+                            // pass below recomputes the origin against
+                            // whatever the LATEST dimensions ended up
+                            // being and does the scroll/clear/repaint as
+                            // a single atomic pass.
                             desiredHeight = newStepHeight;
                             step.StepHeight = newStepHeight;
 
@@ -453,6 +427,39 @@ internal sealed class Hex1bFlowRunner
                                 var original = settleOriginalDims ?? settleLatestDims;
                                 var dimsChanged = original != settleLatestDims;
 
+                                var settledWidth = settleLatestDims.Width;
+                                var settledHeight = settleLatestDims.Height;
+                                var settledStepHeight = FlowResizeMath.ComputeStepHeight(
+                                    options?.MaxHeight, settledHeight);
+
+                                // Compute where the active step lands at
+                                // the FINAL settled width.
+                                var settledRowOrigin = FlowResizeMath.ComputeRowOriginAtWidth(
+                                    _initialRowOrigin, _emittedTombstones, settledWidth);
+
+                                // Bottom-overflow scroll — applied ONCE,
+                                // at settle time, against the final
+                                // dimensions. Without this the active
+                                // region would render off the bottom of
+                                // a shrunken terminal.
+                                var bottomOverflow = (settledRowOrigin + settledStepHeight) - settledHeight;
+                                if (bottomOverflow > 0)
+                                {
+                                    _parentAdapter.SetCursorPosition(0, settledHeight - 1);
+                                    for (var i = 0; i < bottomOverflow; i++)
+                                    {
+                                        _parentAdapter.Write("\n");
+                                    }
+                                    _initialRowOrigin -= bottomOverflow;
+                                    settledRowOrigin -= bottomOverflow;
+                                }
+
+                                rowOrigin = settledRowOrigin;
+                                stepAdapter.RowOrigin = settledRowOrigin;
+                                _cursorRow = settledRowOrigin;
+                                desiredHeight = settledStepHeight;
+                                step.StepHeight = settledStepHeight;
+
                                 // Optional one-off marker tombstone above
                                 // the active step. EmitSoftWrapTombstone
                                 // advances _cursorRow past the marker so
@@ -461,8 +468,8 @@ internal sealed class Hex1bFlowRunner
                                 {
                                     var markerSurface = RenderToSurface(
                                         markerBuilder,
-                                        settleLatestDims.Width,
-                                        Math.Max(1, settleLatestDims.Height - desiredHeight - 1));
+                                        settledWidth,
+                                        Math.Max(1, settledHeight - settledStepHeight - 1));
                                     if (markerSurface is not null)
                                     {
                                         _parentAdapter.SetCursorPosition(0, rowOrigin);
@@ -480,10 +487,10 @@ internal sealed class Hex1bFlowRunner
                                 try
                                 {
                                     _parentAdapter.Write("\x1b[?7l");
-                                    for (var i = 0; i < desiredHeight; i++)
+                                    for (var i = 0; i < settledStepHeight; i++)
                                     {
                                         var row = rowOrigin + i;
-                                        if (row < 0 || row >= settleLatestDims.Height) continue;
+                                        if (row < 0 || row >= settledHeight) continue;
                                         _parentAdapter.SetCursorPosition(0, row);
                                         _parentAdapter.Write("\x1b[2K");
                                     }
@@ -496,8 +503,7 @@ internal sealed class Hex1bFlowRunner
                                     _parentAdapter.Write(SyncUpdateEnd);
                                 }
 
-                                _ = stepAdapter.ResizeAsync(
-                                    settleLatestDims.Width, desiredHeight);
+                                _ = stepAdapter.ResizeAsync(settledWidth, settledStepHeight);
 
                                 settleOriginalDims = null;
                                 settleTimerCts = null;

--- a/src/Hex1b/Flow/Hex1bFlowRunner.cs
+++ b/src/Hex1b/Flow/Hex1bFlowRunner.cs
@@ -391,6 +391,22 @@ internal sealed class Hex1bFlowRunner
                             // so it doesn't visibly chase the reflow.
                             _parentAdapter.Write("\x1b[?25l");
 
+                            // Disable line wrap (DECAWM) for the duration
+                            // of the drag. The inner Hex1bApp keeps
+                            // rendering at the OLD width via the output
+                            // pump (glow animations, focus blink, etc.);
+                            // when the terminal is shrunk, that stale
+                            // wide content would wrap at the new right
+                            // edge and — if any wrap lands on the bottom
+                            // row — scroll the buffer up, pushing the
+                            // tombstones above off-screen. With DECAWM
+                            // off the host terminal truncates instead of
+                            // wrapping, so the stale content lands on
+                            // the active region but never scrolls. The
+                            // settle pass re-enables DECAWM as its last
+                            // act before showing the cursor.
+                            _parentAdapter.Write("\x1b[?7l");
+
                             // Update internal state for the eventual
                             // settle. Note: we deliberately don't write
                             // anything to the parent here — the settle

--- a/src/Hex1b/Flow/Hex1bFlowRunner.cs
+++ b/src/Hex1b/Flow/Hex1bFlowRunner.cs
@@ -466,6 +466,66 @@ internal sealed class Hex1bFlowRunner
                             // restores the cursor to its proper place.
                             _parentAdapter.Write("\x1b[H");
 
+                            // Render the placeholder (if any) into the
+                            // active rect. With the inner-app output
+                            // pump muted, the prompt would otherwise
+                            // stay frozen showing the pre-resize frame
+                            // (which is laid out for the OLD width and
+                            // would visibly clip/wrap on shrink). The
+                            // placeholder is a deliberately tiny widget
+                            // (typically a single short line) so it
+                            // fits inside even an aggressively shrunken
+                            // viewport.
+                            if (_options.ResizePlaceholder is { } placeholderBuilder)
+                            {
+                                var placeholderRowOrigin = settleOriginalRect?.RowOrigin
+                                    ?? rowOrigin;
+                                var placeholderHeight = settleOriginalRect?.Height
+                                    ?? step.StepHeight;
+
+                                // Use the most up-to-date width we have
+                                // (latest event in the burst). DECAWM
+                                // is off so any over-wide content
+                                // simply truncates at the right edge.
+                                var phSurface = RenderToSurface(
+                                    placeholderBuilder,
+                                    Math.Max(1, newWidth),
+                                    Math.Max(1, placeholderHeight));
+                                if (phSurface is not null)
+                                {
+                                    _parentAdapter.Write(SyncUpdateBegin);
+                                    try
+                                    {
+                                        // Wipe the rect first so we don't
+                                        // composite the placeholder onto
+                                        // the old prompt's leftovers.
+                                        for (var i = 0; i < placeholderHeight; i++)
+                                        {
+                                            var row = placeholderRowOrigin + i;
+                                            if (row < 0 || row >= newHeight) continue;
+                                            _parentAdapter.SetCursorPosition(0, row);
+                                            _parentAdapter.Write("\x1b[2K");
+                                        }
+                                        if (placeholderRowOrigin >= 0
+                                            && placeholderRowOrigin < newHeight)
+                                        {
+                                            _parentAdapter.SetCursorPosition(0, placeholderRowOrigin);
+                                            SoftWrapEmitter.Emit(phSurface, _parentAdapter);
+                                        }
+                                    }
+                                    finally
+                                    {
+                                        _parentAdapter.Write(SyncUpdateEnd);
+                                    }
+                                    // Park the cursor at home again so
+                                    // the placeholder emission (which
+                                    // leaves the cursor at the end of
+                                    // the last paragraph) cannot anchor
+                                    // a subsequent shrink-scroll.
+                                    _parentAdapter.Write("\x1b[H");
+                                }
+                            }
+
                             // Update internal state for the eventual
                             // settle. Note: we deliberately don't write
                             // anything to the parent here — the settle
@@ -1352,4 +1412,18 @@ public sealed class Hex1bFlowOptions
     /// Has no effect when <see cref="ResizeSettleDelay"/> is <c>null</c>.
     /// </remarks>
     public Func<RootContext, Hex1bWidget>? ResizeMarker { get; set; }
+
+    /// <summary>
+    /// Optional widget builder rendered in place of the active step's
+    /// content during a drag-resize burst. The placeholder is drawn at
+    /// each per-event tick into the active rectangle and is then replaced
+    /// by the actual repainted step at settle. Use a deliberately tiny
+    /// widget (a single short line is ideal) so it fits inside even an
+    /// aggressively shrunken viewport. When <c>null</c> (the default),
+    /// the active rectangle simply stays cleared during the drag.
+    /// </summary>
+    /// <remarks>
+    /// Has no effect when <see cref="ResizeSettleDelay"/> is <c>null</c>.
+    /// </remarks>
+    public Func<RootContext, Hex1bWidget>? ResizePlaceholder { get; set; }
 }

--- a/src/Hex1b/Flow/Hex1bFlowRunner.cs
+++ b/src/Hex1b/Flow/Hex1bFlowRunner.cs
@@ -431,6 +431,26 @@ internal sealed class Hex1bFlowRunner
                             // reaching the parent terminal.
                             System.Threading.Volatile.Write(ref outputMuteGate.Value, true);
 
+                            // Park the cursor at the home position
+                            // (1,1). The host terminal scrolls the
+                            // primary buffer on shrink to keep the
+                            // cursor visible — and the cursor is
+                            // wherever the inner Hex1bApp last left it
+                            // (typically the textbox row near the
+                            // bottom of the active step). If we don't
+                            // intervene, every subsequent shrink event
+                            // in the burst pushes another row off the
+                            // top. With the cursor parked at the home
+                            // position, the host has no reason to
+                            // scroll on subsequent shrink events. The
+                            // very first event of a burst still loses
+                            // a row or two (the host has already
+                            // scrolled by the time our event handler
+                            // runs), but all later events in the same
+                            // drag are anchored. The settle pass
+                            // restores the cursor to its proper place.
+                            _parentAdapter.Write("\x1b[H");
+
                             // Update internal state for the eventual
                             // settle. Note: we deliberately don't write
                             // anything to the parent here — the settle

--- a/src/Hex1b/Flow/Hex1bFlowRunner.cs
+++ b/src/Hex1b/Flow/Hex1bFlowRunner.cs
@@ -365,32 +365,46 @@ internal sealed class Hex1bFlowRunner
 
                     if (useSettle)
                     {
-                        // New "track-and-clear on every event, repaint on
-                        // settle" path. Each Hex1bResizeEvent recomputes
-                        // where the active step should land at the new
-                        // width (using the per-paragraph widths of every
-                        // emitted tombstone above it), moves the cursor
-                        // there, and erases the region below. The inner
-                        // Hex1bApp is NOT asked to repaint until the
-                        // terminal has been idle for ResizeSettleDelay; in
-                        // the meantime an optional ResizePlaceholder
-                        // renders into the cleared region.
+                        // "Track cursor on every event, repaint on settle".
+                        //
+                        // Per-event we do NOT touch the screen at all — no
+                        // ESC[J, no placeholder draw. Touching the screen
+                        // mid-drag risks clobbering the tombstones above
+                        // the active step if our computed origin is even
+                        // one row off (e.g. the terminal scrolled in a way
+                        // we didn't track). Instead we just hide the
+                        // cursor (so the user doesn't see it dancing around
+                        // the reflow garbage) and update our internal
+                        // bookkeeping; the host terminal owns reflow of
+                        // every byte we've emitted so the tombstones above
+                        // stay put.
+                        //
+                        // When events go quiet for ResizeSettleDelay, we
+                        // clear ONLY the active-step rectangle (using ESC[K
+                        // per row, never ESC[J), optionally drop a resize
+                        // marker tombstone above it, then ask the inner
+                        // Hex1bApp to repaint into the cleared region.
                         CancellationToken settleToken;
                         lock (settleSync)
                         {
                             settleOriginalDims ??= (lastKnownWidth, lastKnownHeight);
                             settleLatestDims = (newWidth, newHeight);
 
-                            // Track-and-clear pass (inline so we can mutate
-                            // the closure-captured rowOrigin/desiredHeight).
+                            // Recompute where the active step lands at the
+                            // new width — purely internal bookkeeping, no
+                            // writes to the parent terminal.
                             var newRowOrigin = FlowResizeMath.ComputeRowOriginAtWidth(
                                 _initialRowOrigin, _emittedTombstones, newWidth);
 
                             // Bottom-overflow handling: if the active step
                             // would extend past the bottom of the viewport
-                            // at the new width/height, emit LFs at the
-                            // bottom row to scroll the whole viewport up
-                            // so the active region stays fully visible.
+                            // at the new height, emit LFs at the bottom
+                            // row to scroll the whole viewport up so the
+                            // active region stays fully visible. This is a
+                            // necessary screen mutation — without it the
+                            // step would render off the bottom — but it
+                            // only touches the bottom row, never the
+                            // tombstones above.
                             var bottomOverflow = (newRowOrigin + newStepHeight) - newHeight;
                             if (bottomOverflow > 0)
                             {
@@ -403,28 +417,9 @@ internal sealed class Hex1bFlowRunner
                                 newRowOrigin -= bottomOverflow;
                             }
 
-                            _parentAdapter.Write(SyncUpdateBegin);
-                            try
-                            {
-                                _parentAdapter.Write("\x1b[?25l"); // hide cursor
-                                _parentAdapter.Write("\x1b[?7l");  // DECAWM off (defensive)
-                                _parentAdapter.SetCursorPosition(0, newRowOrigin);
-                                _parentAdapter.Write("\x1b[J");    // erase to end of screen
-
-                                if (_options.ResizePlaceholder is { } placeholderBuilder)
-                                {
-                                    RenderPlaceholder(
-                                        placeholderBuilder,
-                                        newWidth, newStepHeight, newRowOrigin);
-                                }
-
-                                _parentAdapter.Write("\x1b[?7h");  // DECAWM on
-                                // Cursor stays hidden until settle.
-                            }
-                            finally
-                            {
-                                _parentAdapter.Write(SyncUpdateEnd);
-                            }
+                            // Hide the cursor for the duration of the drag
+                            // so it doesn't visibly chase the reflow.
+                            _parentAdapter.Write("\x1b[?25l");
 
                             rowOrigin = newRowOrigin;
                             stepAdapter.RowOrigin = newRowOrigin;
@@ -458,13 +453,10 @@ internal sealed class Hex1bFlowRunner
                                 var original = settleOriginalDims ?? settleLatestDims;
                                 var dimsChanged = original != settleLatestDims;
 
-                                // Settle: optionally emit a resize-marker
-                                // tombstone above the active step, then ask
-                                // the inner Hex1bApp to repaint at the
-                                // settled dimensions. Its output flows
-                                // through the existing output pump and
-                                // lands in the region we cleared in the
-                                // last track-and-clear pass.
+                                // Optional one-off marker tombstone above
+                                // the active step. EmitSoftWrapTombstone
+                                // advances _cursorRow past the marker so
+                                // the step lands cleanly below it.
                                 if (dimsChanged && _options.ResizeMarker is { } markerBuilder)
                                 {
                                     var markerSurface = RenderToSurface(
@@ -473,10 +465,6 @@ internal sealed class Hex1bFlowRunner
                                         Math.Max(1, settleLatestDims.Height - desiredHeight - 1));
                                     if (markerSurface is not null)
                                     {
-                                        // Emit at the current active-step
-                                        // origin; EmitSoftWrapTombstone
-                                        // advances _cursorRow past the
-                                        // marker so the step lands below.
                                         _parentAdapter.SetCursorPosition(0, rowOrigin);
                                         EmitSoftWrapTombstone(markerSurface);
                                         rowOrigin = _cursorRow;
@@ -484,12 +472,22 @@ internal sealed class Hex1bFlowRunner
                                     }
                                 }
 
+                                // Clear ONLY the active-step rectangle —
+                                // row by row with ESC[K, never ESC[J — so
+                                // we cannot accidentally erase a tombstone
+                                // above if our computed origin is off.
                                 _parentAdapter.Write(SyncUpdateBegin);
                                 try
                                 {
                                     _parentAdapter.Write("\x1b[?7l");
+                                    for (var i = 0; i < desiredHeight; i++)
+                                    {
+                                        var row = rowOrigin + i;
+                                        if (row < 0 || row >= settleLatestDims.Height) continue;
+                                        _parentAdapter.SetCursorPosition(0, row);
+                                        _parentAdapter.Write("\x1b[2K");
+                                    }
                                     _parentAdapter.SetCursorPosition(0, rowOrigin);
-                                    _parentAdapter.Write("\x1b[J");
                                     _parentAdapter.Write("\x1b[?7h");
                                     _parentAdapter.Write("\x1b[?25h"); // show cursor
                                 }
@@ -963,32 +961,6 @@ internal sealed class Hex1bFlowRunner
     }
 
     /// <summary>
-    /// Renders the user-supplied <see cref="Hex1bFlowOptions.ResizePlaceholder"/>
-    /// directly into the cleared active-step region during a track-and-clear
-    /// pass. Bypasses the step adapter's output pump so the placeholder
-    /// appears immediately on every resize event without waiting for the
-    /// inner Hex1bApp's render loop.
-    /// </summary>
-    /// <remarks>
-    /// Uses <see cref="SoftWrapEmitter"/> so each row is terminated with
-    /// <c>CR + LF</c> just like a tombstone — the placeholder is rendered as
-    /// proper logical lines that survive any reflow until the next
-    /// track-and-clear pass overwrites them.
-    /// </remarks>
-    private void RenderPlaceholder(
-        Func<RootContext, Hex1bWidget> builder,
-        int width,
-        int heightCap,
-        int originRow)
-    {
-        var surface = RenderToSurface(builder, width, heightCap);
-        if (surface is null) return;
-
-        _parentAdapter.SetCursorPosition(0, originRow);
-        SoftWrapEmitter.Emit(surface, _parentAdapter);
-    }
-
-    /// <summary>
     /// Returns the logical paragraph width of the given surface row — the
     /// column index of the last non-blank cell plus one. Mirrors the
     /// trailing-blank trimming that <see cref="SoftWrapEmitter"/> performs
@@ -1252,19 +1224,6 @@ public sealed class Hex1bFlowOptions
     /// Recommended value: 50–100 ms.
     /// </remarks>
     public TimeSpan? ResizeSettleDelay { get; set; }
-
-    /// <summary>
-    /// Optional widget builder rendered into the active-step region
-    /// <em>during</em> the settle window, in place of the live step.
-    /// Designed to be safe to render repeatedly in a hostile,
-    /// actively-resizing environment — keep it cheap, layout-tolerant, and
-    /// free of input affordances. When <c>null</c> (the default), the
-    /// active region is simply erased during the drag.
-    /// </summary>
-    /// <remarks>
-    /// Has no effect when <see cref="ResizeSettleDelay"/> is <c>null</c>.
-    /// </remarks>
-    public Func<RootContext, Hex1bWidget>? ResizePlaceholder { get; set; }
 
     /// <summary>
     /// Optional widget builder emitted as a one-off hard-newline tombstone

--- a/src/Hex1b/Flow/InlineStepAdapter.cs
+++ b/src/Hex1b/Flow/InlineStepAdapter.cs
@@ -231,13 +231,18 @@ internal sealed partial class InlineStepAdapter : IHex1bAppTerminalWorkloadAdapt
 
     public ValueTask ResizeAsync(int width, int height, CancellationToken ct = default)
     {
-        var changed = _width != width || _height != height;
+        // Always push a resize event, even if the dimensions didn't change.
+        // The inner Hex1bApp treats a resize event as a re-render trigger,
+        // and the flow runner clears the active rectangle on every settle
+        // before calling ResizeAsync — if we suppress the event here, the
+        // cleared rectangle stays blank until something else invalidates
+        // the inner app. (Example: a vertical-only terminal resize where
+        // the step height is clamped by MaxHeight ends up with the same
+        // width and same step height, but the flow runner has already
+        // wiped the prior frame.)
         _width = width;
         _height = height;
-        if (changed)
-        {
-            _inputChannel.Writer.TryWrite(new Hex1bResizeEvent(width, height));
-        }
+        _inputChannel.Writer.TryWrite(new Hex1bResizeEvent(width, height));
         return ValueTask.CompletedTask;
     }
 

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -159,6 +159,36 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
     // Surface rendering double-buffer
     private Surface? _currentSurface;
     private Surface? _previousSurface;
+    // Renderer hot-path pools — reused across frames so SurfaceComparer doesn't
+    // allocate a fresh diff/list of changed cells or a fresh token list every frame.
+    private readonly Surfaces.SurfaceDiff _frameDiff = new();
+    // Token lists are rotated through a small pool so that a list shipped to the
+    // terminal-side consumer (via the workload channel) can continue to be enumerated
+    // even after the producer starts building the next frame. Without this, the
+    // producer would mutate the list while the consumer iterates it. The consumer
+    // returns the list via WorkloadOutputItem.PooledTokens once it's done.
+    private readonly System.Collections.Concurrent.ConcurrentStack<List<Tokens.AnsiToken>> _tokenListPool = new();
+    private List<Tokens.AnsiToken>? _frameTokens;
+    // Used only when KGP placements need to be interleaved with text tokens; reused to
+    // avoid a per-frame scratch allocation when KGP is active. Not shipped across the
+    // channel — only used to assemble the merged list — so single-buffering is safe.
+    private readonly List<Tokens.AnsiToken> _frameKgpScratchTokens = new();
+
+    private List<Tokens.AnsiToken> RentTokenList()
+    {
+        if (_tokenListPool.TryPop(out var list))
+        {
+            list.Clear();
+            return list;
+        }
+        return new List<Tokens.AnsiToken>();
+    }
+
+    internal void ReturnTokenList(List<Tokens.AnsiToken> list)
+    {
+        list.Clear();
+        _tokenListPool.Push(list);
+    }
     
     // KGP placement lifecycle tracker (persists across frames)
     private readonly Kgp.KgpPlacementTracker _kgpTracker = new();
@@ -187,6 +217,13 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
     
     // Animation timer for RedrawAfter() support
     private readonly AnimationTimer _animationTimer;
+
+    // Minimum interval between rendered frames (paces the render loop, not just Schedule()).
+    private readonly TimeSpan _frameRateLimit;
+    // Timestamp of the last frame actually rendered. Used by the render loop
+    // to enforce _frameRateLimit so invalidations triggered faster than the
+    // configured cadence get coalesced into a single render.
+    private long _lastRenderTimestamp;
     
     // Window manager registry for accessing WindowManagers from anywhere
     private readonly WindowManagerRegistry _windowManagerRegistry = new();
@@ -227,6 +264,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         // Create animation timer with configured frame rate limit
         var frameRateLimitMs = Math.Max(1, options.FrameRateLimitMs);
         _animationTimer = new AnimationTimer(TimeSpan.FromMilliseconds(frameRateLimitMs));
+        _frameRateLimit = TimeSpan.FromMilliseconds(frameRateLimitMs);
         
         // Check if mouse is enabled in options
         _mouseEnabled = options.EnableMouse;
@@ -527,7 +565,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                         await ProcessInputEventAsync(inputEvent, cancellationToken);
                     }
                     
-                    // Input coalescing: batch rapid inputs together before rendering
+                    // Input coalescing: batch rapid inputs together before rendering.
                     if (_enableInputCoalescing)
                     {
                         var outputBacklog = _adapter.OutputQueueDepth;
@@ -535,7 +573,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                             _inputCoalescingInitialDelayMs + (outputBacklog * 10), 
                             _inputCoalescingMaxDelayMs);
                         await Task.Delay(coalescingDelayMs, cancellationToken);
-                    
+
                         while (_adapter.InputEvents.TryRead(out var delayedInput))
                         {
                             await ProcessInputEventAsync(delayedInput, cancellationToken);
@@ -556,8 +594,16 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                     }
                 }
 
-                // Re-render after handling input or invalidation (state may have changed)
+                // Re-render after handling input or invalidation (state may have changed).
+                // Skip the frame-rate pace whenever input was processed - inputs are user-driven
+                // and shouldn't be rate-limited (would starve a fast typist at one keystroke
+                // per FrameRateLimitMs). Pacing applies only to timer/invalidation-driven frames.
+                if (!inputReady)
+                {
+                    await PaceFrameAsync(cancellationToken);
+                }
                 await RenderFrameAsync(cancellationToken);
+                _lastRenderTimestamp = Stopwatch.GetTimestamp();
                 
                 // IMPORTANT: Handle race condition where output arrived during render.
                 // If invalidation was signaled while we were rendering, we need to re-render
@@ -568,6 +614,13 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                 
                 while (_invalidateChannel.Reader.TryRead(out _) && extraRenders < maxExtraRenders)
                 {
+                    // If we're already inside the frame budget, defer remaining invalidations
+                    // to the next outer iteration so the render loop honors FrameRateLimitMs.
+                    var elapsedSinceLastRender = TimeSpan.FromSeconds(
+                        (Stopwatch.GetTimestamp() - _lastRenderTimestamp) / (double)Stopwatch.Frequency);
+                    if (elapsedSinceLastRender < _frameRateLimit)
+                        break;
+
                     // ALWAYS process pending input before each re-render to prevent starvation
                     while (_adapter.InputEvents.TryRead(out var pendingEvent))
                     {
@@ -583,6 +636,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                     _animationTimer.FireDue();
                         
                     await RenderFrameAsync(cancellationToken);
+                    _lastRenderTimestamp = Stopwatch.GetTimestamp();
                     extraRenders++;
                 }
                 
@@ -796,6 +850,30 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
             (Stopwatch.GetTimestamp() - inputStart) * 1000.0 / Stopwatch.Frequency);
     }
 
+    /// <summary>
+    /// Sleeps until the configured per-frame minimum interval has elapsed since
+    /// the last rendered frame, so invalidations triggered faster than
+    /// <see cref="Hex1bAppOptions.FrameRateLimitMs"/> are coalesced.
+    /// </summary>
+    private async Task PaceFrameAsync(CancellationToken cancellationToken)
+    {
+        if (_lastRenderTimestamp == 0)
+            return;
+        var elapsed = TimeSpan.FromSeconds((Stopwatch.GetTimestamp() - _lastRenderTimestamp) / (double)Stopwatch.Frequency);
+        var remaining = _frameRateLimit - elapsed;
+        if (remaining > TimeSpan.Zero)
+        {
+            try
+            {
+                await Task.Delay(remaining, cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Caller handles cancellation
+            }
+        }
+    }
+
     private async Task RenderFrameAsync(CancellationToken cancellationToken)
     {
         // NOTE: We intentionally do NOT clear animation timers here.
@@ -961,7 +1039,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                 {
                     long renderFrameStart = Stopwatch.GetTimestamp();
                     
-                    wroteOutput = RenderFrameWithSurface(frameWidth, frameHeight, frameCapabilities);
+                    wroteOutput = await RenderFrameWithSurfaceAsync(frameWidth, frameHeight, frameCapabilities, cancellationToken).ConfigureAwait(false);
                     
                     renderTicks = Stopwatch.GetTimestamp() - renderFrameStart;
                     if (_diagnosticTimingEnabled) _diagRenderTicks = renderTicks;
@@ -1024,8 +1102,17 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
     /// Callers use this to know whether the hardware cursor may have been moved by
     /// the emitted tokens.
     /// </returns>
-    private bool RenderFrameWithSurface(int width, int height, TerminalCapabilities caps)
+    private async ValueTask<bool> RenderFrameWithSurfaceAsync(int width, int height, TerminalCapabilities caps, CancellationToken cancellationToken)
     {
+        var result = RenderFrameWithSurfaceCore(width, height, caps, out var asyncWriteWork);
+        if (asyncWriteWork != null)
+            await asyncWriteWork(cancellationToken).ConfigureAwait(false);
+        return result;
+    }
+
+    private bool RenderFrameWithSurfaceCore(int width, int height, TerminalCapabilities caps, out Func<CancellationToken, ValueTask>? asyncWriteWork)
+    {
+        asyncWriteWork = null;
         _surfacePool?.NextFrame();
         
         // Get cell metrics from terminal capabilities
@@ -1148,12 +1235,24 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
             return true;
         }
 
-        // Diff current vs previous and emit changes
+        // Diff current vs previous and emit changes. _frameDiff is a pooled
+        // SurfaceDiff reused every frame to avoid the List<ChangedCell> growth cost.
         var diffStart = Stopwatch.GetTimestamp();
-        var diff = _isFirstFrame || _previousSurface == null
-            ? SurfaceComparer.CompareToEmpty(_currentSurface)
-            : SurfaceComparer.Compare(_previousSurface, _currentSurface);
+        bool fastPathTaken;
+        if (_isFirstFrame || _previousSurface == null)
+        {
+            fastPathTaken = SurfaceComparer.CompareToEmptyInto(_currentSurface, _frameDiff);
+        }
+        else
+        {
+            fastPathTaken = SurfaceComparer.CompareInto(_previousSurface, _currentSurface, _frameDiff);
+        }
+        var diff = _frameDiff;
         _metrics.SurfaceDiffDuration.Record(Stopwatch.GetElapsedTime(diffStart).TotalMilliseconds);
+        if (fastPathTaken)
+            _metrics.SurfaceDiffFastPathCount.Add(1);
+        else
+            _metrics.SurfaceDiffSlowPathCount.Add(1);
         
         _metrics.OutputCellsChanged.Record(diff.Count);
         
@@ -1198,42 +1297,111 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         
         if (wroteOutput)
         {
-            // Generate text/sixel tokens (KGP emission skipped — handled by tracker above)
+            // Token-list pool ownership protocol:
+            //   1. Rent a list from _tokenListPool.
+            //   2. Fill it via ToTokensInto.
+            //   3. On the happy path, transfer ownership to the consumer via
+            //      WriteTokensWithBytesAsync; the consumer returns it once
+            //      it has finished iterating.
+            //   4. On any throw before step 3 completes, the finally below
+            //      returns the list and any rented ANSI buffer to their pools
+            //      so we don't slowly bleed pool capacity on error paths.
+            //
+            // The pooled output buffer is similarly owned by this scope until
+            // it crosses into the WorkloadOutputItem; we then null both locals
+            // so the finally is a no-op on the success path.
             var tokensStart = Stopwatch.GetTimestamp();
-            var textTokens = diff.IsEmpty
-                ? Array.Empty<Tokens.AnsiToken>()
-                : SurfaceComparer.ToTokens(diff, _currentSurface, _previousSurface, skipKgpEmission: hasKgp);
-            _metrics.SurfaceTokensDuration.Record(Stopwatch.GetElapsedTime(tokensStart).TotalMilliseconds);
-            
-            // Merge: KGP before-text + text tokens + KGP after-text
-            List<Tokens.AnsiToken> tokens;
-            if (hasKgpChanges)
+            _frameTokens = RentTokenList();
+            byte[]? pooledOutput = null;
+            var ownershipTransferred = false;
+            try
             {
-                tokens = new List<Tokens.AnsiToken>(kgpBefore.Count + textTokens.Count + kgpAfter.Count);
-                tokens.AddRange(kgpBefore);
-                tokens.AddRange(textTokens);
-                tokens.AddRange(kgpAfter);
+                if (hasKgpChanges)
+                {
+                    _frameTokens.AddRange(kgpBefore);
+                    if (!diff.IsEmpty)
+                    {
+                        var scratch = _frameKgpScratchTokens;
+                        SurfaceComparer.ToTokensInto(diff, _currentSurface, _previousSurface, skipKgpEmission: true, scratch);
+                        _frameTokens.AddRange(scratch);
+                    }
+                    _frameTokens.AddRange(kgpAfter);
+                }
+                else if (!diff.IsEmpty)
+                {
+                    SurfaceComparer.ToTokensInto(diff, _currentSurface, _previousSurface, skipKgpEmission: hasKgp, _frameTokens);
+                }
+                var tokens = _frameTokens;
+                _metrics.SurfaceTokensDuration.Record(Stopwatch.GetElapsedTime(tokensStart).TotalMilliseconds);
+
+                var serializeStart = Stopwatch.GetTimestamp();
+                // Use the pool-backed serializer so the per-frame ANSI byte buffer (often
+                // well over the 85 KB LOH threshold for fullscreen renders) is rented from
+                // ArrayPool rather than allocated fresh on the LOH every frame.
+                ReadOnlyMemory<byte> ansiOutput;
+                if (_adapter is Hex1bAppWorkloadAdapter)
+                {
+                    ansiOutput = Tokens.AnsiTokenUtf8Serializer.SerializeRented(tokens, out pooledOutput);
+                }
+                else
+                {
+                    ansiOutput = Tokens.AnsiTokenUtf8Serializer.Serialize(tokens);
+                }
+                _metrics.SurfaceSerializeDuration.Record(Stopwatch.GetElapsedTime(serializeStart).TotalMilliseconds);
+
+                if (_adapter is Hex1bAppWorkloadAdapter workloadAdapter)
+                {
+                    // Transfer ownership of the pooled token list AND the rented
+                    // byte buffer to the consumer; capture them into locals so the
+                    // async continuation can reference them, and null the field /
+                    // local so the finally below treats this as a successful handoff.
+                    var ownedTokens = _frameTokens;
+                    var ownedPooledOutput = pooledOutput;
+                    _frameTokens = null;
+                    pooledOutput = null;
+                    ownershipTransferred = true;
+
+                    asyncWriteWork = ct => workloadAdapter.WriteTokensWithBytesAsync(
+                        tokens,
+                        ansiOutput,
+                        ownedPooledOutput,
+                        ownedTokens,
+                        ReturnTokenList,
+                        ct);
+                }
+                else
+                {
+                    _adapter.Write(ansiOutput);
+                    // No workload-channel consumer: return the rented list here.
+                    if (_frameTokens is { } own)
+                    {
+                        _frameTokens = null;
+                        ReturnTokenList(own);
+                    }
+                    ownershipTransferred = true;
+                }
+
+                _metrics.OutputTokens.Record(tokens.Count);
+                _metrics.OutputBytes.Record(ansiOutput.Length);
             }
-            else
+            finally
             {
-                tokens = textTokens is List<Tokens.AnsiToken> list ? list : new List<Tokens.AnsiToken>(textTokens);
+                if (!ownershipTransferred)
+                {
+                    // Some step between rent and handoff threw. Return everything we
+                    // still own so the pools don't slowly bleed capacity.
+                    if (_frameTokens is { } orphaned)
+                    {
+                        _frameTokens = null;
+                        ReturnTokenList(orphaned);
+                    }
+                    if (pooledOutput is not null)
+                    {
+                        System.Buffers.ArrayPool<byte>.Shared.Return(pooledOutput);
+                        pooledOutput = null;
+                    }
+                }
             }
-            
-            var serializeStart = Stopwatch.GetTimestamp();
-            var ansiOutput = Tokens.AnsiTokenUtf8Serializer.Serialize(tokens);
-            _metrics.SurfaceSerializeDuration.Record(Stopwatch.GetElapsedTime(serializeStart).TotalMilliseconds);
-            
-            if (_adapter is Hex1bAppWorkloadAdapter workloadAdapter)
-            {
-                workloadAdapter.WriteTokensWithBytes(tokens, ansiOutput);
-            }
-            else
-            {
-                _adapter.Write(ansiOutput);
-            }
-            
-            _metrics.OutputTokens.Record(tokens.Count);
-            _metrics.OutputBytes.Record(ansiOutput.Length);
         }
         
         _isFirstFrame = false;

--- a/src/Hex1b/Hex1bAppOptions.cs
+++ b/src/Hex1b/Hex1bAppOptions.cs
@@ -161,9 +161,19 @@ public class Hex1bAppOptions
     /// <summary>
     /// Whether to enable pooling of temporary <see cref="Surfaces.Surface"/> instances during rendering.
     /// This primarily affects <see cref="Widgets.SurfaceWidget"/> layers and nodes like EffectPanel.
-    /// Default is false.
     /// </summary>
-    public bool EnableSurfacePooling { get; set; }
+    /// <remarks>
+    /// <para>
+    /// Enabled by default. On representative busy UIs this measures at roughly
+    /// -50% per-frame allocations and eliminates Gen2 collections that would
+    /// otherwise cause visible stutter (see <c>docs/perf/baseline.md</c>).
+    /// </para>
+    /// <para>
+    /// Set to <c>false</c> to opt out — for example, in environments where the
+    /// extra retained surfaces would matter more than allocation pressure.
+    /// </para>
+    /// </remarks>
+    public bool EnableSurfacePooling { get; set; } = true;
 
     /// <summary>
     /// Maximum number of pooled surfaces kept per (width, height, cell metrics) bucket.

--- a/src/Hex1b/Hex1bAppWorkloadAdapter.cs
+++ b/src/Hex1b/Hex1bAppWorkloadAdapter.cs
@@ -46,6 +46,7 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
     private bool _inTuiMode;
     private bool _dimensionsInitialized;
     private int _outputQueueDepth; // Manual tracking since unbounded channels don't support Count
+    private readonly int _maxQueuedOutputItems;
 
     /// <summary>
     /// Optional diagnostic tree provider for MCP diagnostics.
@@ -63,14 +64,27 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
     /// Creates a new app workload adapter.
     /// </summary>
     /// <param name="capabilities">Terminal capabilities. If null, defaults with full support.</param>
+    /// <param name="maxQueuedOutputItems">
+    /// Maximum number of pending output items (frame buffers, control sequences, etc.) the
+    /// adapter will buffer before applying backpressure. <c>0</c> (default) means unbounded —
+    /// producers never block, at the cost of unbounded memory growth if a slow consumer falls
+    /// behind. A small positive value (e.g. <c>8</c>) caps memory and makes the render loop's
+    /// effective frame rate track the consumer's drain rate. Drop semantics are deliberately
+    /// not offered: each output item carries an incremental diff, so dropping a queued item
+    /// would desynchronise the host terminal's surface state.
+    /// </param>
     /// <remarks>
     /// Dimensions are set by the terminal via <see cref="ResizeAsync"/>.
     /// Initial dimensions default to 0x0 until the terminal notifies.
     /// </remarks>
-    public Hex1bAppWorkloadAdapter(TerminalCapabilities? capabilities = null)
+    public Hex1bAppWorkloadAdapter(TerminalCapabilities? capabilities = null, int maxQueuedOutputItems = 0)
     {
+        if (maxQueuedOutputItems < 0)
+            throw new ArgumentOutOfRangeException(nameof(maxQueuedOutputItems), "Must be >= 0.");
+
         _width = 0;
         _height = 0;
+        _maxQueuedOutputItems = maxQueuedOutputItems;
         _staticCapabilities = capabilities ?? new TerminalCapabilities
         {
             SupportsMouse = true,
@@ -80,11 +94,7 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
             SupportsUnderlineColor = true,
         };
 
-        _outputChannel = Channel.CreateUnbounded<WorkloadOutputItem>(new UnboundedChannelOptions
-        {
-            SingleReader = true,
-            SingleWriter = false
-        });
+        _outputChannel = CreateOutputChannel(maxQueuedOutputItems);
 
         _inputChannel = Channel.CreateUnbounded<Hex1bEvent>(new UnboundedChannelOptions
         {
@@ -97,27 +107,51 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
     /// Creates a new app workload adapter connected to a presentation adapter.
     /// </summary>
     /// <param name="presentationAdapter">The presentation adapter to delegate capabilities to.</param>
+    /// <param name="maxQueuedOutputItems">
+    /// See <see cref="Hex1bAppWorkloadAdapter(TerminalCapabilities?, int)"/>.
+    /// </param>
     /// <remarks>
     /// When a presentation adapter is provided, capabilities are read live from it,
     /// allowing updates to cell dimensions (e.g., after resize) to be reflected.
     /// </remarks>
-    public Hex1bAppWorkloadAdapter(IHex1bTerminalPresentationAdapter presentationAdapter)
+    public Hex1bAppWorkloadAdapter(IHex1bTerminalPresentationAdapter presentationAdapter, int maxQueuedOutputItems = 0)
     {
+        if (maxQueuedOutputItems < 0)
+            throw new ArgumentOutOfRangeException(nameof(maxQueuedOutputItems), "Must be >= 0.");
+
         _width = 0;
         _height = 0;
+        _maxQueuedOutputItems = maxQueuedOutputItems;
         _presentationAdapter = presentationAdapter;
         _staticCapabilities = null;
 
-        _outputChannel = Channel.CreateUnbounded<WorkloadOutputItem>(new UnboundedChannelOptions
-        {
-            SingleReader = true,
-            SingleWriter = false
-        });
+        _outputChannel = CreateOutputChannel(maxQueuedOutputItems);
 
         _inputChannel = Channel.CreateUnbounded<Hex1bEvent>(new UnboundedChannelOptions
         {
             SingleReader = true,
             SingleWriter = true
+        });
+    }
+
+    private static Channel<WorkloadOutputItem> CreateOutputChannel(int maxQueuedOutputItems)
+    {
+        if (maxQueuedOutputItems > 0)
+        {
+            return Channel.CreateBounded<WorkloadOutputItem>(new BoundedChannelOptions(maxQueuedOutputItems)
+            {
+                FullMode = BoundedChannelFullMode.Wait,
+                SingleReader = true,
+                // SingleWriter intentionally false: clipboard/paste/exit paths may
+                // write from threads other than the render loop.
+                SingleWriter = false,
+            });
+        }
+
+        return Channel.CreateUnbounded<WorkloadOutputItem>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false,
         });
     }
 
@@ -132,10 +166,7 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
     {
         if (_disposed) return;
         var bytes = Encoding.UTF8.GetBytes(text);
-        if (_outputChannel.Writer.TryWrite(new WorkloadOutputItem(bytes, Tokens: null)))
-        {
-            Interlocked.Increment(ref _outputQueueDepth);
-        }
+        EnqueueOutput(new WorkloadOutputItem(bytes, Tokens: null));
     }
 
     /// <summary>
@@ -144,33 +175,146 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
     public void Write(ReadOnlySpan<byte> data)
     {
         if (_disposed) return;
-        if (_outputChannel.Writer.TryWrite(new WorkloadOutputItem(data.ToArray(), Tokens: null)))
-        {
-            Interlocked.Increment(ref _outputQueueDepth);
-        }
+        EnqueueOutput(new WorkloadOutputItem(data.ToArray(), Tokens: null));
     }
-    
+
     /// <summary>
     /// Write raw bytes to the terminal without forcing a copy.
     /// </summary>
     public void Write(ReadOnlyMemory<byte> data)
     {
         if (_disposed) return;
-        if (_outputChannel.Writer.TryWrite(new WorkloadOutputItem(data, Tokens: null)))
-        {
-            Interlocked.Increment(ref _outputQueueDepth);
-        }
+        EnqueueOutput(new WorkloadOutputItem(data, Tokens: null));
     }
-    
+
     /// <summary>
     /// Writes output with an already-tokenized representation to avoid terminal-side UTF-8 decode + tokenization.
     /// </summary>
-    internal void WriteTokensWithBytes(IReadOnlyList<AnsiToken> tokens, ReadOnlyMemory<byte> bytes)
+    /// <param name="tokens">The tokens to ship to the consumer.</param>
+    /// <param name="bytes">The serialised bytes of <paramref name="tokens"/>.</param>
+    /// <param name="pooledBuffer">
+    /// Optional array rented from <see cref="System.Buffers.ArrayPool{T}.Shared"/> that backs
+    /// <paramref name="bytes"/>. When provided, the consumer side returns it to the pool after
+    /// processing the item. If the write fails (channel closed), the buffer is returned here so
+    /// callers don't have to worry about double-free.
+    /// </param>
+    /// <param name="pooledTokens">
+    /// Optional list backing <paramref name="tokens"/> that should be returned to a pool after
+    /// the consumer has finished with it. <paramref name="pooledTokensReturn"/> is the callback
+    /// the consumer invokes to return it. Both must be supplied together or both null.
+    /// </param>
+    /// <param name="pooledTokensReturn">See <paramref name="pooledTokens"/>.</param>
+    /// <param name="cancellationToken">Cancellation token for awaiting backpressure.</param>
+    /// <returns>
+    /// A completed <see cref="ValueTask"/> when the item was enqueued without contention;
+    /// otherwise a task that completes once backpressure has cleared. The hot path
+    /// (unbounded channel or bounded channel with capacity) allocates no async state machine.
+    /// </returns>
+    internal ValueTask WriteTokensWithBytesAsync(
+        IReadOnlyList<AnsiToken> tokens,
+        ReadOnlyMemory<byte> bytes,
+        byte[]? pooledBuffer = null,
+        List<AnsiToken>? pooledTokens = null,
+        Action<List<AnsiToken>>? pooledTokensReturn = null,
+        CancellationToken cancellationToken = default)
     {
-        if (_disposed) return;
-        if (_outputChannel.Writer.TryWrite(new WorkloadOutputItem(bytes, tokens)))
+        var item = new WorkloadOutputItem(bytes, tokens)
+        {
+            PooledBuffer = pooledBuffer,
+            PooledTokens = pooledTokens,
+            PooledTokensReturn = pooledTokensReturn,
+        };
+        if (_disposed)
+        {
+            ReturnPooledResources(item);
+            return ValueTask.CompletedTask;
+        }
+        return EnqueueOutputAsync(item, cancellationToken);
+    }
+
+    /// <summary>
+    /// Centralised enqueue for output items. Handles the bounded-channel
+    /// backpressure case (block the producer until a slot frees) and ensures
+    /// pooled resources carried by the item are returned to their pools on
+    /// any failure path so callers can't leak them.
+    /// </summary>
+    private void EnqueueOutput(WorkloadOutputItem item)
+    {
+        // Fast path: unbounded channel always accepts; bounded channel
+        // accepts when capacity is available.
+        if (_outputChannel.Writer.TryWrite(item))
         {
             Interlocked.Increment(ref _outputQueueDepth);
+            return;
+        }
+
+        // Slow path: bounded channel is full. Block the producer until a
+        // slot frees. This is the deliberate backpressure: if the consumer
+        // can't keep up, the producer's effective frame rate falls to match
+        // the consumer's drain rate, which is exactly what we want.
+        //
+        // sync-over-async is acceptable here: the producer is the render
+        // loop (or a control-sequence writer), already inside a Task-based
+        // async chain, and slowing it down is the goal.
+        try
+        {
+            var writeTask = _outputChannel.Writer.WriteAsync(item);
+            if (!writeTask.IsCompletedSuccessfully)
+                writeTask.AsTask().GetAwaiter().GetResult();
+            Interlocked.Increment(ref _outputQueueDepth);
+        }
+        catch (ChannelClosedException)
+        {
+            // Channel completed while we were waiting; return pooled
+            // resources so they aren't leaked.
+            ReturnPooledResources(item);
+        }
+        catch (InvalidOperationException)
+        {
+            // Same: channel may surface a writer-completed state as IOE.
+            ReturnPooledResources(item);
+        }
+    }
+
+    private static void ReturnPooledResources(WorkloadOutputItem item)
+    {
+        if (item.PooledBuffer is not null)
+            System.Buffers.ArrayPool<byte>.Shared.Return(item.PooledBuffer);
+        if (item.PooledTokens is not null && item.PooledTokensReturn is not null)
+            item.PooledTokensReturn(item.PooledTokens);
+    }
+
+    /// <summary>
+    /// Async counterpart of <see cref="EnqueueOutput"/>. Awaits a slot instead of
+    /// blocking the producer thread when the bounded channel is full — required by
+    /// callers hosted under single-threaded sync contexts where sync-over-async would
+    /// deadlock.
+    /// </summary>
+    private async ValueTask EnqueueOutputAsync(WorkloadOutputItem item, CancellationToken cancellationToken)
+    {
+        if (_outputChannel.Writer.TryWrite(item))
+        {
+            Interlocked.Increment(ref _outputQueueDepth);
+            return;
+        }
+
+        try
+        {
+            await _outputChannel.Writer.WriteAsync(item, cancellationToken).ConfigureAwait(false);
+            Interlocked.Increment(ref _outputQueueDepth);
+        }
+        catch (ChannelClosedException)
+        {
+            ReturnPooledResources(item);
+        }
+        catch (InvalidOperationException)
+        {
+            ReturnPooledResources(item);
+        }
+        catch (OperationCanceledException)
+        {
+            ReturnPooledResources(item);
+            throw;
         }
     }
 

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -1312,12 +1312,18 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             {
                 ReadOnlyMemory<byte> data;
                 IReadOnlyList<AnsiToken>? preTokenizedTokens = null;
+                byte[]? pooledItemBuffer = null;
+                List<AnsiToken>? pooledItemTokens = null;
+                Action<List<AnsiToken>>? pooledItemTokensReturn = null;
 
                 if (_workload is IHex1bTerminalTokenWorkloadAdapter tokenWorkload)
                 {
                     var item = await tokenWorkload.ReadOutputItemAsync(ct);
                     data = item.Bytes;
                     preTokenizedTokens = item.Tokens;
+                    pooledItemBuffer = item.PooledBuffer;
+                    pooledItemTokens = item.PooledTokens;
+                    pooledItemTokensReturn = item.PooledTokensReturn;
                 }
                 else
                 {
@@ -1326,6 +1332,11 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 
                 if (data.IsEmpty)
                 {
+                    if (pooledItemBuffer is not null)
+                        System.Buffers.ArrayPool<byte>.Shared.Return(pooledItemBuffer);
+                    if (pooledItemTokens is not null && pooledItemTokensReturn is not null)
+                        pooledItemTokensReturn(pooledItemTokens);
+
                     // Channel empty - this is a frame boundary
                     await NotifyWorkloadFiltersFrameCompleteAsync();
                     
@@ -1334,6 +1345,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                     continue;
                 }
                 
+                try
+                {
                 string? completeText = null;
                 IReadOnlyList<AnsiToken> tokens;
 
@@ -1430,6 +1443,14 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                         await _presentation.WriteOutputAsync(filteredBytes, ct);
                         _metrics.TerminalOutputBytes.Record(filteredBytes.Length);
                     }
+                }
+                }
+                finally
+                {
+                    if (pooledItemBuffer is not null)
+                        System.Buffers.ArrayPool<byte>.Shared.Return(pooledItemBuffer);
+                    if (pooledItemTokens is not null && pooledItemTokensReturn is not null)
+                        pooledItemTokensReturn(pooledItemTokens);
                 }
             }
         }

--- a/src/Hex1b/Hex1bTerminalBuilder.cs
+++ b/src/Hex1b/Hex1bTerminalBuilder.cs
@@ -911,8 +911,8 @@ public sealed class Hex1bTerminalBuilder
     /// and optional full-screen TUI applications in the normal terminal buffer.
     /// </summary>
     /// <param name="flowCallback">
-    /// Async callback that defines the flow steps. Use the flow context's <see cref="Flow.Hex1bFlowContext.Step"/>
-    /// for inline micro-TUIs and <see cref="Flow.Hex1bFlowContext.FullScreenStepAsync"/> for full-screen apps.
+    /// Async callback that defines the flow steps. Use the flow context's <see cref="Flow.Hex1bFlowContext.Step(Func{Flow.FlowStepContext, Task{Widgets.Hex1bWidget}}, Action{Flow.Hex1bFlowStepOptions}?)"/>
+    /// for inline micro-TUIs and <see cref="Flow.Hex1bFlowContext.FullScreenStepAsync(Func{Hex1bApp, Hex1bAppOptions, Func{RootContext, Task{Widgets.Hex1bWidget}}})"/> for full-screen apps.
     /// </param>
     /// <param name="configureOptions">Optional callback to configure flow options (theme, etc.).</param>
     /// <returns>This builder for chaining.</returns>

--- a/src/Hex1b/Hex1bTerminalBuilder.cs
+++ b/src/Hex1b/Hex1bTerminalBuilder.cs
@@ -17,7 +17,7 @@ namespace Hex1b;
 /// <para>Simple Hex1bApp:</para>
 /// <code>
 /// await using var terminal = Hex1bTerminal.CreateBuilder()
-///     .WithHex1bApp((app, options) => ctx => ctx.Text("Hello, World!"))
+///     .WithHex1bApp(ctx => ctx.Text("Hello, World!"))
 ///     .Build();
 /// 
 /// await terminal.RunAsync();
@@ -62,69 +62,135 @@ public sealed class Hex1bTerminalBuilder
     }
 
     /// <summary>
-    /// Configures the terminal to run a Hex1bApp with the specified widget builder.
+    /// Configures the terminal to run a Hex1bApp that renders the widget tree
+    /// produced by <paramref name="widgetBuilder"/>.
     /// </summary>
-    /// <param name="configure">
-    /// A configuration function that receives the <see cref="Hex1bApp"/> instance and 
-    /// <see cref="Hex1bAppOptions"/> for customization, and returns the widget builder function.
+    /// <param name="widgetBuilder">Builds the root widget for each render frame.</param>
+    /// <returns>This builder instance for fluent chaining.</returns>
+    /// <example>
+    /// <code>
+    /// await using var terminal = Hex1bTerminal.CreateBuilder()
+    ///     .WithHex1bApp(ctx => ctx.Text("Hello, World!"))
+    ///     .Build();
+    /// </code>
+    /// </example>
+    public Hex1bTerminalBuilder WithHex1bApp(Func<RootContext, Hex1bWidget> widgetBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(widgetBuilder);
+        return WithHex1bAppCore(
+            configureOptions: null,
+            configureApp: _ => widgetBuilder);
+    }
+
+    /// <summary>
+    /// Configures the terminal to run a Hex1bApp with the given async widget builder.
+    /// </summary>
+    /// <param name="widgetBuilder">Builds the root widget asynchronously for each render frame.</param>
+    /// <returns>This builder instance for fluent chaining.</returns>
+    public Hex1bTerminalBuilder WithHex1bApp(Func<RootContext, Task<Hex1bWidget>> widgetBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(widgetBuilder);
+        return WithHex1bAppCoreAsync(
+            configureOptions: null,
+            configureApp: _ => widgetBuilder);
+    }
+
+    /// <summary>
+    /// Configures the terminal to run a Hex1bApp with eager option configuration
+    /// followed by a synchronous widget builder.
+    /// </summary>
+    /// <param name="configureOptions">
+    /// Callback that mutates the <see cref="Hex1bAppOptions"/>. Runs eagerly,
+    /// before <see cref="Hex1bApp"/> is constructed, so settings the constructor
+    /// snapshots (e.g. <see cref="Hex1bAppOptions.FrameRateLimitMs"/>) take
+    /// effect.
+    /// </param>
+    /// <param name="widgetBuilder">Builds the root widget for each render frame.</param>
+    /// <returns>This builder instance for fluent chaining.</returns>
+    public Hex1bTerminalBuilder WithHex1bApp(
+        Action<Hex1bAppOptions> configureOptions,
+        Func<RootContext, Hex1bWidget> widgetBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(configureOptions);
+        ArgumentNullException.ThrowIfNull(widgetBuilder);
+        return WithHex1bAppCore(configureOptions, _ => widgetBuilder);
+    }
+
+    /// <summary>
+    /// Configures the terminal to run a Hex1bApp with eager option configuration
+    /// followed by an asynchronous widget builder.
+    /// </summary>
+    public Hex1bTerminalBuilder WithHex1bApp(
+        Action<Hex1bAppOptions> configureOptions,
+        Func<RootContext, Task<Hex1bWidget>> widgetBuilder)
+    {
+        ArgumentNullException.ThrowIfNull(configureOptions);
+        ArgumentNullException.ThrowIfNull(widgetBuilder);
+        return WithHex1bAppCoreAsync(configureOptions, _ => widgetBuilder);
+    }
+
+    /// <summary>
+    /// Configures the terminal to run a Hex1bApp with full control: eager option
+    /// configuration plus access to the <see cref="Hex1bApp"/> instance when
+    /// building the widget tree.
+    /// </summary>
+    /// <param name="configureOptions">
+    /// Callback that mutates the <see cref="Hex1bAppOptions"/>. Runs eagerly,
+    /// before <see cref="Hex1bApp"/> is constructed.
+    /// </param>
+    /// <param name="configureApp">
+    /// Callback that receives the constructed <see cref="Hex1bApp"/> and returns
+    /// the widget builder. Runs lazily on the first widget build, so the
+    /// <see cref="Hex1bApp"/> instance is fully constructed and safe to capture.
     /// </param>
     /// <returns>This builder instance for fluent chaining.</returns>
-    /// <remarks>
-    /// <para>
-    /// The configure function provides access to the <see cref="Hex1bApp"/> instance
-    /// for external control (e.g., calling <c>RequestStop()</c> or <c>Invalidate()</c>),
-    /// and <see cref="Hex1bAppOptions"/> for setting theme and other options.
-    /// </para>
-    /// <para>
-    /// For simple cases where you don't need app capture or options, you can ignore them:
-    /// <c>.WithHex1bApp((app, options) => ctx => ctx.Text("Hello"))</c>
-    /// </para>
-    /// <para>
-    /// The <see cref="Hex1bAppOptions.WorkloadAdapter"/> and <see cref="Hex1bAppOptions.EnableMouse"/>
-    /// properties are managed by the builder. Use <see cref="WithMouse"/> to enable mouse support.
-    /// </para>
-    /// </remarks>
     /// <example>
-    /// <para>Simple usage:</para>
-    /// <code>
-    /// await using var terminal = Hex1bTerminal.CreateBuilder()
-    ///     .WithHex1bApp((app, options) => ctx => ctx.Text("Hello, World!"))
-    ///     .Build();
-    /// 
-    /// await terminal.RunAsync();
-    /// </code>
-    /// <para>With app capture and theming:</para>
     /// <code>
     /// Hex1bApp? capturedApp = null;
-    /// 
     /// await using var terminal = Hex1bTerminal.CreateBuilder()
-    ///     .WithHex1bApp((app, options) =>
-    ///     {
-    ///         capturedApp = app;
-    ///         options.Theme = MyCustomTheme;
-    ///         return ctx => ctx.Text("Hello");
-    ///     })
+    ///     .WithHex1bApp(
+    ///         options => options.FrameRateLimitMs = 16,
+    ///         app =>
+    ///         {
+    ///             capturedApp = app;
+    ///             return ctx => ctx.Text("Hello");
+    ///         })
     ///     .Build();
-    /// 
-    /// await terminal.RunAsync();
     /// </code>
     /// </example>
     public Hex1bTerminalBuilder WithHex1bApp(
-        Func<Hex1bApp, Hex1bAppOptions, Func<RootContext, Hex1bWidget>> configure)
+        Action<Hex1bAppOptions> configureOptions,
+        Func<Hex1bApp, Func<RootContext, Hex1bWidget>> configureApp)
     {
-        ArgumentNullException.ThrowIfNull(configure);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+        ArgumentNullException.ThrowIfNull(configureApp);
+        return WithHex1bAppCore(configureOptions, configureApp);
+    }
 
+    /// <summary>
+    /// Async counterpart of <see cref="WithHex1bApp(Action{Hex1bAppOptions}, Func{Hex1bApp, Func{RootContext, Hex1bWidget}})"/>.
+    /// </summary>
+    public Hex1bTerminalBuilder WithHex1bApp(
+        Action<Hex1bAppOptions> configureOptions,
+        Func<Hex1bApp, Func<RootContext, Task<Hex1bWidget>>> configureApp)
+    {
+        ArgumentNullException.ThrowIfNull(configureOptions);
+        ArgumentNullException.ThrowIfNull(configureApp);
+        return WithHex1bAppCoreAsync(configureOptions, configureApp);
+    }
+
+    private Hex1bTerminalBuilder WithHex1bAppCore(
+        Action<Hex1bAppOptions>? configureOptions,
+        Func<Hex1bApp, Func<RootContext, Hex1bWidget>> configureApp)
+    {
         SetWorkloadFactory(presentation =>
         {
-            // If presentation adapter is available, use it for live capabilities
-            // Otherwise fall back to static capabilities
             var workloadAdapter = presentation != null
                 ? new Hex1bAppWorkloadAdapter(presentation)
                 : new Hex1bAppWorkloadAdapter();
             workloadAdapter.DiagnosticTimingEnabled = _diagnosticsEnabled;
             var enableMouse = _enableMouse;
 
-            // Create options with managed properties already set
             var options = new Hex1bAppOptions
             {
                 WorkloadAdapter = workloadAdapter,
@@ -132,21 +198,24 @@ public sealed class Hex1bTerminalBuilder
                 Metrics = ResolveMetrics()
             };
 
-            // Create the run callback - app is created here so user can capture it
+            // Apply user-supplied option configuration eagerly, BEFORE constructing
+            // the Hex1bApp, so settings the constructor snapshots (e.g.
+            // FrameRateLimitMs which the AnimationTimer captures) actually take
+            // effect.
+            configureOptions?.Invoke(options);
+
             Func<CancellationToken, Task<int>> runCallback = async ct =>
             {
                 Hex1bApp? app = null;
                 Func<RootContext, Hex1bWidget>? widgetBuilder = null;
                 bool configureInvoked = false;
 
-                // Widget builder that wraps the user's builder
                 Func<RootContext, Hex1bWidget> wrappedBuilder = ctx =>
                 {
-                    // On first call, invoke configure to get the real builder
                     if (!configureInvoked)
                     {
                         configureInvoked = true;
-                        widgetBuilder = configure(app!, options);
+                        widgetBuilder = configureApp(app!);
                     }
                     return widgetBuilder!(ctx);
                 };
@@ -165,43 +234,27 @@ public sealed class Hex1bTerminalBuilder
         return this;
     }
 
-    /// <summary>
-    /// Configures the terminal to run a Hex1bApp with full control over options, app capture,
-    /// and async widget building.
-    /// </summary>
-    /// <param name="configure">
-    /// A configuration function that receives the <see cref="Hex1bApp"/> instance and 
-    /// <see cref="Hex1bAppOptions"/> for customization, and returns an async widget builder function.
-    /// </param>
-    /// <returns>This builder instance for fluent chaining.</returns>
-    /// <remarks>
-    /// <para>
-    /// This overload provides full control over the Hex1bApp configuration and allows
-    /// capturing the app instance for external control, with async widget building support.
-    /// </para>
-    /// </remarks>
-    public Hex1bTerminalBuilder WithHex1bApp(
-        Func<Hex1bApp, Hex1bAppOptions, Func<RootContext, Task<Hex1bWidget>>> configure)
+    private Hex1bTerminalBuilder WithHex1bAppCoreAsync(
+        Action<Hex1bAppOptions>? configureOptions,
+        Func<Hex1bApp, Func<RootContext, Task<Hex1bWidget>>> configureApp)
     {
-        ArgumentNullException.ThrowIfNull(configure);
-
         SetWorkloadFactory(presentation =>
         {
-            // If presentation adapter is available, use it for live capabilities
-            // Otherwise fall back to static capabilities
-            var workloadAdapter = presentation != null 
+            var workloadAdapter = presentation != null
                 ? new Hex1bAppWorkloadAdapter(presentation)
                 : new Hex1bAppWorkloadAdapter();
             workloadAdapter.DiagnosticTimingEnabled = _diagnosticsEnabled;
             var enableMouse = _enableMouse;
-            
-            // Create options with managed properties already set
+
             var options = new Hex1bAppOptions
             {
                 WorkloadAdapter = workloadAdapter,
                 EnableMouse = enableMouse,
                 Metrics = ResolveMetrics()
             };
+
+            // See sync overload comment — eager option configuration.
+            configureOptions?.Invoke(options);
 
             Func<CancellationToken, Task<int>> runCallback = async ct =>
             {
@@ -214,7 +267,7 @@ public sealed class Hex1bTerminalBuilder
                     if (!configureInvoked)
                     {
                         configureInvoked = true;
-                        widgetBuilder = configure(app!, options);
+                        widgetBuilder = configureApp(app!);
                     }
                     return await widgetBuilder!(ctx);
                 };
@@ -1059,7 +1112,7 @@ public sealed class Hex1bTerminalBuilder
     /// <code>
     /// await using var terminal = Hex1bTerminal.CreateBuilder()
     ///     .WithDiagnostics()
-    ///     .WithHex1bApp((app, options) => ctx => ctx.Text("Hello!"))
+    ///     .WithHex1bApp(ctx => ctx.Text("Hello!"))
     ///     .Build();
     /// 
     /// await terminal.RunAsync();

--- a/src/Hex1b/Nodes/EffectPanelNode.cs
+++ b/src/Hex1b/Nodes/EffectPanelNode.cs
@@ -21,14 +21,6 @@ public sealed class EffectPanelNode : Hex1bNode
     /// </summary>
     public Action<Surface>? Effect { get; set; }
 
-    /// <summary>
-    /// Gets or sets a context-aware effect callback that post-processes the child's
-    /// rendered surface and additionally receives the parent <see cref="Hex1bRenderContext"/>
-    /// (handy for reading <c>context.Theme.GetGlobalBackground()</c> when blending).
-    /// Invoked after <see cref="Effect"/>.
-    /// </summary>
-    public Action<Surface, Hex1bRenderContext>? EffectWithContext { get; set; }
-
     protected override Size MeasureCore(Constraints constraints)
     {
         if (Child is null)
@@ -46,7 +38,7 @@ public sealed class EffectPanelNode : Hex1bNode
     {
         if (Child is null) return;
 
-        if (Effect is null && EffectWithContext is null || context is not SurfaceRenderContext surfaceCtx)
+        if (Effect is null || context is not SurfaceRenderContext surfaceCtx)
         {
             // No effect or non-surface context: pass through unchanged
             context.RenderChild(Child);
@@ -79,9 +71,8 @@ public sealed class EffectPanelNode : Hex1bNode
             tempContext.SetCursorPosition(Child.Bounds.X, Child.Bounds.Y);
             tempContext.RenderChild(Child);
 
-            // 4. Apply effect(s)
-            Effect?.Invoke(tempSurface);
-            EffectWithContext?.Invoke(tempSurface, context);
+            // 4. Apply effect
+            Effect(tempSurface);
 
             // 5. Composite modified surface into parent, respecting clip region
             Rect? clipRect = null;

--- a/src/Hex1b/Nodes/EffectPanelNode.cs
+++ b/src/Hex1b/Nodes/EffectPanelNode.cs
@@ -21,6 +21,14 @@ public sealed class EffectPanelNode : Hex1bNode
     /// </summary>
     public Action<Surface>? Effect { get; set; }
 
+    /// <summary>
+    /// Gets or sets a context-aware effect callback that post-processes the child's
+    /// rendered surface and additionally receives the parent <see cref="Hex1bRenderContext"/>
+    /// (handy for reading <c>context.Theme.GetGlobalBackground()</c> when blending).
+    /// Invoked after <see cref="Effect"/>.
+    /// </summary>
+    public Action<Surface, Hex1bRenderContext>? EffectWithContext { get; set; }
+
     protected override Size MeasureCore(Constraints constraints)
     {
         if (Child is null)
@@ -38,7 +46,7 @@ public sealed class EffectPanelNode : Hex1bNode
     {
         if (Child is null) return;
 
-        if (Effect is null || context is not SurfaceRenderContext surfaceCtx)
+        if (Effect is null && EffectWithContext is null || context is not SurfaceRenderContext surfaceCtx)
         {
             // No effect or non-surface context: pass through unchanged
             context.RenderChild(Child);
@@ -71,8 +79,9 @@ public sealed class EffectPanelNode : Hex1bNode
             tempContext.SetCursorPosition(Child.Bounds.X, Child.Bounds.Y);
             tempContext.RenderChild(Child);
 
-            // 4. Apply effect
-            Effect(tempSurface);
+            // 4. Apply effect(s)
+            Effect?.Invoke(tempSurface);
+            EffectWithContext?.Invoke(tempSurface, context);
 
             // 5. Composite modified surface into parent, respecting clip region
             Rect? clipRect = null;

--- a/src/Hex1b/Nodes/Hex1bNode.cs
+++ b/src/Hex1b/Nodes/Hex1bNode.cs
@@ -199,6 +199,15 @@ public abstract class Hex1bNode
     /// Returning <c>false</c> forces a cache miss for this subtree.
     /// </summary>
     internal Func<RenderCacheContext, bool>? CachePredicate { get; set; }
+
+    /// <summary>
+    /// A retained child surface that survives <see cref="InvalidateCache"/> so the
+    /// next render miss can reuse the same backing array instead of allocating a
+    /// fresh (often LOH-sized, 64-bytes-per-cell) surface every frame. Cleared
+    /// when the node's bounds change or the buffer dimensions otherwise no longer
+    /// match what the renderer needs.
+    /// </summary>
+    internal Surface? RenderBuffer { get; set; }
      
     /// <summary>
     /// When set to a non-default color, RenderChild will fill all transparent backgrounds
@@ -256,6 +265,11 @@ public abstract class Hex1bNode
     /// </summary>
     internal void InvalidateCache()
     {
+        // Retain the previously cached surface as a reusable render buffer so the
+        // next cache miss can render into it without allocating a fresh surface
+        // (which for any reasonably sized node lives on the LOH).
+        if (CachedSurface is not null)
+            RenderBuffer = CachedSurface;
         CachedSurface = null;
         CachedSubtreeRenderVersion = -1;
     }

--- a/src/Hex1b/Surfaces/Surface.cs
+++ b/src/Hex1b/Surfaces/Surface.cs
@@ -42,6 +42,19 @@ public sealed class Surface : ISurfaceSource
     private int _contentMinX;
     private int _contentMaxY = -1;
     private int _contentMinY;
+
+    // Latched flag indicating that at least one cell on this surface has a value
+    // that the fast diff path cannot safely ignore: wide/continuation cells,
+    // multi-codepoint graphemes, underline state, or tracked refs (sixel/kgp/hyperlink).
+    // When false, SurfaceComparer can use a slimmer per-cell equality that skips
+    // those checks entirely.
+    //
+    // The flag is intentionally permissive (latched-on-write, only reset by Clear/
+    // ClearAndReleaseTrackedObjects). A surface that briefly held complex content
+    // and then had it overwritten with simple content will keep the flag set until
+    // the next Clear — that just falls back to the slow path, never produces wrong
+    // diffs.
+    private bool _hasComplexContent;
     
     /// <summary>
     /// Gets the width of the surface in columns.
@@ -161,8 +174,8 @@ public sealed class Surface : ISurfaceSource
             // Track content bounding box
             if (value != SurfaceCells.Empty)
                 ExpandContentBounds(x, y);
-            
-            _cells[index] = value;
+
+            SetCellInternal(index, value);
         }
     }
 
@@ -222,8 +235,8 @@ public sealed class Surface : ISurfaceSource
             // Track content bounding box
             if (cell != SurfaceCells.Empty)
                 ExpandContentBounds(x, y);
-            
-            _cells[index] = cell;
+
+            SetCellInternal(index, cell);
             return true;
         }
         return false;
@@ -246,6 +259,7 @@ public sealed class Surface : ISurfaceSource
         Array.Fill(_cells, SurfaceCells.Empty);
         _sixelCount = 0;
         _kgpCount = 0;
+        _hasComplexContent = false;
         ResetContentBounds();
     }
 
@@ -270,6 +284,7 @@ public sealed class Surface : ISurfaceSource
 
         _sixelCount = 0;
         _kgpCount = 0;
+        _hasComplexContent = false;
         ResetContentBounds();
     }
 
@@ -282,6 +297,7 @@ public sealed class Surface : ISurfaceSource
         Array.Fill(_cells, cell);
         _sixelCount = cell.HasSixel ? CellCount : 0;
         _kgpCount = cell.HasKgp ? CellCount : 0;
+        _hasComplexContent = IsCellComplex(cell);
         if (cell != SurfaceCells.Empty && Width > 0 && Height > 0)
             SetContentBoundsToFull();
         else
@@ -307,6 +323,14 @@ public sealed class Surface : ISurfaceSource
             ExpandContentBounds(startX, startY);
             ExpandContentBounds(endX - 1, endY - 1);
         }
+
+        // Cell is loop-invariant, so we mark complexity once up-front
+        // rather than calling SetCellInternal per cell (which would
+        // re-check IsCellComplex on every iteration). The contract
+        // documented on SetCellInternal still holds because we mark
+        // before writing.
+        if (startX < endX && startY < endY)
+            MarkComplexIfNeeded(cell);
 
         for (var y = startY; y < endY; y++)
         {
@@ -392,7 +416,7 @@ public sealed class Surface : ISurfaceSource
                 while (currentX < Width)
                 {
                     if (startX < 0) startX = currentX;
-                    _cells[y * Width + currentX] = new SurfaceCell(" ", foreground, background, attributes, 1);
+                    SetCellInternal(y * Width + currentX, new SurfaceCell(" ", foreground, background, attributes, 1));
                     currentX++;
                     columnsWritten++;
                 }
@@ -402,7 +426,7 @@ public sealed class Surface : ISurfaceSource
             // Write the primary cell
             var cell = new SurfaceCell(grapheme, foreground, background, attributes, graphemeWidth);
             if (startX < 0) startX = currentX;
-            _cells[y * Width + currentX] = cell;
+            SetCellInternal(y * Width + currentX, cell);
             currentX++;
             columnsWritten++;
 
@@ -411,7 +435,7 @@ public sealed class Surface : ISurfaceSource
             {
                 if (currentX < Width)
                 {
-                    _cells[y * Width + currentX] = SurfaceCell.CreateContinuation(background);
+                    SetCellInternal(y * Width + currentX, SurfaceCell.CreateContinuation(background));
                     currentX++;
                     columnsWritten++;
                 }
@@ -442,7 +466,7 @@ public sealed class Surface : ISurfaceSource
         if (!IsInBounds(x, y))
             return false;
 
-        _cells[y * Width + x] = new SurfaceCell(character.ToString(), foreground, background, attributes, 1);
+        SetCellInternal(y * Width + x, new SurfaceCell(character.ToString(), foreground, background, attributes, 1));
         ExpandContentBounds(x, y);
         return true;
     }
@@ -461,11 +485,11 @@ public sealed class Surface : ISurfaceSource
             var cell = _cells[i];
             if (cell == SurfaceCells.Empty)
             {
-                _cells[i] = bgCell;
+                SetCellInternal(i, bgCell);
             }
             else if (cell.HasTransparentBackground)
             {
-                _cells[i] = cell with { Background = background };
+                SetCellInternal(i, cell with { Background = background });
             }
         }
         // After FillBackground, every cell has content (either rendered or bgCell)
@@ -500,11 +524,11 @@ public sealed class Surface : ISurfaceSource
                 var cell = _cells[i];
                 if (cell == SurfaceCells.Empty)
                 {
-                    _cells[i] = bgCell;
+                    SetCellInternal(i, bgCell);
                 }
                 else if (cell.HasTransparentBackground)
                 {
-                    _cells[i] = cell with { Background = background };
+                    SetCellInternal(i, cell with { Background = background });
                 }
             }
         }
@@ -622,7 +646,7 @@ public sealed class Surface : ISurfaceSource
                 else if (!oldCell.HasKgp && srcCell.HasKgp)
                     _kgpCount++;
 
-                _cells[index] = srcCell;
+                SetCellInternal(index, srcCell);
                 ExpandContentBounds(destX, destY);
             }
         }
@@ -844,6 +868,64 @@ public sealed class Surface : ISurfaceSource
     /// (e.g., in async contexts). Use with caution - no bounds checking.
     /// </remarks>
     internal SurfaceCell[] CellsUnsafe => _cells;
+
+    /// <summary>
+    /// Gets whether this surface contains only cells that the diff fast path can
+    /// safely treat as 4-field (Character/Foreground/Background/Attributes) cells.
+    /// </summary>
+    /// <remarks>
+    /// False when at least one cell was written with a wide/continuation display width,
+    /// a multi-codepoint grapheme, an underline style/colour, or a tracked sixel/KGP/
+    /// hyperlink reference. The flag is permissive: once set it stays set until the
+    /// next <see cref="Clear()"/> or <see cref="ClearAndReleaseTrackedObjects"/>.
+    /// A false negative just falls back to the slow path; it can never produce a
+    /// wrong diff.
+    /// </remarks>
+    internal bool IsFastPathEligible => !_hasComplexContent;
+
+    /// <summary>
+    /// True if <paramref name="cell"/> has any property that the fast diff path
+    /// cannot ignore: a non-default display width, a multi-codepoint grapheme,
+    /// an underline style or colour, or any tracked reference.
+    /// </summary>
+    private static bool IsCellComplex(in SurfaceCell cell)
+    {
+        if (cell.DisplayWidth != 1) return true;
+        if (cell.UnderlineStyle != UnderlineStyle.None) return true;
+        if (cell.UnderlineColor.HasValue) return true;
+        if (cell.Sixel is not null) return true;
+        if (cell.Kgp is not null) return true;
+        if (cell.Hyperlink is not null) return true;
+        var character = cell.Character;
+        if (character is not null && character.Length > 1) return true;
+        return false;
+    }
+
+    private void MarkComplexIfNeeded(in SurfaceCell cell)
+    {
+        if (!_hasComplexContent && IsCellComplex(cell))
+            _hasComplexContent = true;
+    }
+
+    /// <summary>
+    /// The single internal entry point for storing a <see cref="SurfaceCell"/> into the
+    /// backing array. Every direct <c>_cells[index] = cell</c> site MUST go through this
+    /// helper so that <see cref="_hasComplexContent"/> stays in sync with the cell data —
+    /// otherwise the diff fast path in <see cref="SurfaceComparer"/> can silently drop
+    /// underline / wide-cell / grapheme / tracked-ref changes.
+    /// </summary>
+    /// <remarks>
+    /// Bounds tracking, sixel/KGP refcount maintenance, and content-bounds expansion
+    /// remain the caller's responsibility — they are context-dependent (e.g. <c>Fill</c>
+    /// hoists them out of the loop). The complex-flag bookkeeping is the only invariant
+    /// this helper enforces, because forgetting it is a correctness escape valve rather
+    /// than a perf hit.
+    /// </remarks>
+    private void SetCellInternal(int index, in SurfaceCell cell)
+    {
+        MarkComplexIfNeeded(cell);
+        _cells[index] = cell;
+    }
 
     private void ValidateBounds(int x, int y)
     {

--- a/src/Hex1b/Surfaces/SurfaceComparer.cs
+++ b/src/Hex1b/Surfaces/SurfaceComparer.cs
@@ -1,5 +1,6 @@
 using Hex1b.Theming;
 using Hex1b.Tokens;
+using System.Text;
 
 namespace Hex1b.Surfaces;
 
@@ -30,9 +31,34 @@ public static class SurfaceComparer
         ArgumentNullException.ThrowIfNull(previous);
         ArgumentNullException.ThrowIfNull(current);
 
+        var diff = new SurfaceDiff();
+        CompareInto(previous, current, diff);
+        return diff;
+    }
+
+    /// <summary>
+    /// Reusable variant of <see cref="Compare(Surface, Surface)"/> that populates the
+    /// supplied <see cref="SurfaceDiff"/> in place. The renderer hot path uses this to
+    /// avoid allocating a fresh diff and backing list every frame.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> if the simple 4-field fast path was used (both surfaces report
+    /// <see cref="Surface.IsFastPathEligible"/>), otherwise <see langword="false"/> for the
+    /// full per-cell slow path. Used by the renderer to record fast/slow-path engagement
+    /// metrics.
+    /// </returns>
+    internal static bool CompareInto(Surface previous, Surface current, SurfaceDiff dest)
+    {
+        ArgumentNullException.ThrowIfNull(previous);
+        ArgumentNullException.ThrowIfNull(current);
+        ArgumentNullException.ThrowIfNull(dest);
+
+        var changed = dest.MutableCells;
+        changed.Clear();
+
         // Fast path: same instance means no changes
         if (ReferenceEquals(previous, current))
-            return SurfaceDiff.Empty;
+            return true;
 
         if (previous.Width != current.Width || previous.Height != current.Height)
         {
@@ -44,8 +70,31 @@ public static class SurfaceComparer
         var height = current.Height;
         var prevCells = previous.CellsUnsafe;
         var currCells = current.CellsUnsafe;
-        
-        var changedCells = new List<ChangedCell>();
+
+        // Fast path: when neither surface contains wide cells, underline state,
+        // multi-codepoint graphemes, or tracked refs (sixel/kgp/hyperlink), we can
+        // skip the per-cell branches for those fields entirely. This is a 4-field
+        // compare instead of ~10, and the helper is small enough to inline.
+        if (previous.IsFastPathEligible && current.IsFastPathEligible)
+        {
+            for (var y = 0; y < height; y++)
+            {
+                var rowOffset = y * width;
+                for (var x = 0; x < width; x++)
+                {
+                    var index = rowOffset + x;
+                    ref readonly var prevCell = ref prevCells[index];
+                    ref readonly var currCell = ref currCells[index];
+
+                    if (!CellsEqualFast(in prevCell, in currCell))
+                    {
+                        changed.Add(new ChangedCell(x, y, currCell));
+                    }
+                }
+            }
+
+            return true;
+        }
 
         for (var y = 0; y < height; y++)
         {
@@ -58,12 +107,15 @@ public static class SurfaceComparer
 
                 if (!CellsEqual(prevCell, currCell))
                 {
-                    changedCells.Add(new ChangedCell(x, y, currCell));
+                    changed.Add(new ChangedCell(x, y, currCell));
                 }
             }
         }
 
-        return new SurfaceDiff(changedCells);
+        // No SortChanges call: we add in row-major order (Y outer, X inner),
+        // which is exactly the order SortChanges produces. Skipping the sort
+        // saves an O(N log N) pass on every frame.
+        return false;
     }
 
     /// <summary>
@@ -79,12 +131,52 @@ public static class SurfaceComparer
     {
         ArgumentNullException.ThrowIfNull(surface);
 
+        var diff = new SurfaceDiff();
+        CompareToEmptyInto(surface, diff);
+        return diff;
+    }
+
+    /// <summary>
+    /// Reusable variant of <see cref="CompareToEmpty(Surface)"/> that populates the
+    /// supplied <see cref="SurfaceDiff"/> in place.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> when the simple 4-field fast path was used (the surface
+    /// is <see cref="Surface.IsFastPathEligible"/>); otherwise <see langword="false"/>.
+    /// </returns>
+    internal static bool CompareToEmptyInto(Surface surface, SurfaceDiff dest)
+    {
+        ArgumentNullException.ThrowIfNull(surface);
+        ArgumentNullException.ThrowIfNull(dest);
+
+        var changed = dest.MutableCells;
+        changed.Clear();
+
         var width = surface.Width;
         var height = surface.Height;
         var cells = surface.CellsUnsafe;
         var empty = SurfaceCells.Empty;
-        
-        var changedCells = new List<ChangedCell>();
+
+        // Fast path: see CompareInto. Empty is itself a "simple" cell, so when the
+        // surface is fast-eligible we can compare against it with the 4-field equal.
+        if (surface.IsFastPathEligible)
+        {
+            for (var y = 0; y < height; y++)
+            {
+                var rowOffset = y * width;
+                for (var x = 0; x < width; x++)
+                {
+                    ref readonly var cell = ref cells[rowOffset + x];
+
+                    if (!CellsEqualFast(in cell, in empty))
+                    {
+                        changed.Add(new ChangedCell(x, y, cell));
+                    }
+                }
+            }
+
+            return true;
+        }
 
         for (var y = 0; y < height; y++)
         {
@@ -95,12 +187,13 @@ public static class SurfaceComparer
 
                 if (!CellsEqual(cell, empty))
                 {
-                    changedCells.Add(new ChangedCell(x, y, cell));
+                    changed.Add(new ChangedCell(x, y, cell));
                 }
             }
         }
 
-        return new SurfaceDiff(changedCells);
+        // No SortChanges call: see CompareInto - same row-major add order.
+        return false;
     }
 
     /// <summary>
@@ -145,11 +238,29 @@ public static class SurfaceComparer
     public static IReadOnlyList<AnsiToken> ToTokens(SurfaceDiff diff, Surface? currentSurface, Surface? previousSurface, bool skipKgpEmission = false)
     {
         ArgumentNullException.ThrowIfNull(diff);
+        if (diff.IsEmpty) return Array.Empty<AnsiToken>();
 
-        if (diff.IsEmpty)
-            return Array.Empty<AnsiToken>();
+        var output = new List<AnsiToken>();
+        ToTokensInto(diff, currentSurface, previousSurface, skipKgpEmission, output);
+        return output.Count == 0 ? Array.Empty<AnsiToken>() : output;
+    }
 
-        var tokens = new List<AnsiToken>();
+    /// <summary>
+    /// Reusable variant of <see cref="ToTokens(SurfaceDiff, Surface?, Surface?, bool)"/> that
+    /// appends to the supplied <paramref name="output"/> list. The renderer hot path uses
+    /// this with a list it owns across frames to avoid per-frame token-list allocations.
+    /// The list is cleared before population.
+    /// </summary>
+    internal static void ToTokensInto(SurfaceDiff diff, Surface? currentSurface, Surface? previousSurface, bool skipKgpEmission, List<AnsiToken> output)
+    {
+        ArgumentNullException.ThrowIfNull(diff);
+        ArgumentNullException.ThrowIfNull(output);
+
+        output.Clear();
+
+        if (diff.IsEmpty) return;
+
+        var tokens = output;
         
         // Emit KGP delete commands for images that were in the previous surface but have
         // moved or been removed. KGP placements persist in the terminal until explicitly
@@ -404,6 +515,11 @@ public static class SurfaceComparer
         bool stateUnknown = true;
         TrackedObject<HyperlinkData>? currentHyperlink = null;
 
+        // Reused across all changed cells; passed by ref to BuildSgrParametersBytes.
+        // SGR parameter strings cap out well below 96 bytes even with reset+attrs+RGB
+        // foreground+RGB background+RGB underline colour, e.g. "0;1;3;38;2;255;255;255;48;2;255;255;255;58;2;255;255;255" is 56 bytes.
+        Span<byte> sgrBuf = stackalloc byte[96];
+
         foreach (var change in diff.ChangedCells)
         {
             // Skip continuation cells - they're handled by the wide character before them
@@ -459,7 +575,8 @@ public static class SurfaceComparer
 
             if (needsSgr)
             {
-                var sgrParams = BuildSgrParameters(
+                var written = BuildSgrParametersBytes(
+                    sgrBuf,
                     change.Cell,
                     stateUnknown,
                     ref currentFg,
@@ -467,10 +584,10 @@ public static class SurfaceComparer
                     ref currentAttrs,
                     ref currentUnderlineStyle,
                     ref currentUnderlineColor);
-                
-                if (!string.IsNullOrEmpty(sgrParams))
+
+                if (written > 0)
                 {
-                    tokens.Add(new SgrToken(sgrParams));
+                    tokens.Add(AnsiTokenCache.GetSgrTokenFromBytes(sgrBuf.Slice(0, written)));
                 }
                 stateUnknown = false;
             }
@@ -545,7 +662,7 @@ public static class SurfaceComparer
                 ? " " 
                 : change.Cell.Character;
             
-            tokens.Add(new TextToken(charToOutput));
+            tokens.Add(AnsiTokenCache.GetTextToken(charToOutput));
             
             // Cursor advances by display width
             cursorX += Math.Max(1, change.Cell.DisplayWidth);
@@ -567,8 +684,6 @@ public static class SurfaceComparer
                 EmitKgpTokens(tokens, data);
             }
         }
-
-        return tokens;
     }
     
     /// <summary>
@@ -692,6 +807,20 @@ public static class SurfaceComparer
 
     #region Private Helpers
 
+    /// <summary>
+    /// Slim 4-field equality used by the fast diff path. Only safe to call when
+    /// both cells are known not to carry tracked refs, underline state, multi-
+    /// codepoint graphemes, or a non-default display width — i.e. when both
+    /// owning surfaces report <see cref="Surface.IsFastPathEligible"/>.
+    /// </summary>
+    private static bool CellsEqualFast(in SurfaceCell a, in SurfaceCell b)
+    {
+        return a.Character == b.Character
+            && a.Attributes == b.Attributes
+            && ColorsEqual(a.Foreground, b.Foreground)
+            && ColorsEqual(a.Background, b.Background);
+    }
+
     private static bool CellsEqual(SurfaceCell a, SurfaceCell b)
     {
         // Compare visual properties and hyperlink
@@ -699,7 +828,9 @@ public static class SurfaceComparer
             !ColorsEqual(a.Foreground, b.Foreground) ||
             !ColorsEqual(a.Background, b.Background) ||
             a.Attributes != b.Attributes ||
-            a.DisplayWidth != b.DisplayWidth)
+            a.DisplayWidth != b.DisplayWidth ||
+            a.UnderlineStyle != b.UnderlineStyle ||
+            !ColorsEqual(a.UnderlineColor, b.UnderlineColor))
         {
             return false;
         }
@@ -754,7 +885,7 @@ public static class SurfaceComparer
                a.Value.AnsiIndex == b.Value.AnsiIndex;
     }
 
-    private static string BuildSgrParameters(
+    private static StringBuilder BuildSgrParameters(
         SurfaceCell targetCell,
         bool stateUnknown,
         ref Hex1bColor? currentFg,
@@ -763,7 +894,7 @@ public static class SurfaceComparer
         ref UnderlineStyle currentUnderlineStyle,
         ref Hex1bColor? currentUnderlineColor)
     {
-        var parts = new List<string>();
+        var sb = AnsiTokenCache.GetSgrBuilder();
 
         // Check if we need a reset first
         // Reset if: state is unknown, OR turning OFF any attributes, OR clearing colors
@@ -775,7 +906,7 @@ public static class SurfaceComparer
 
         if (needsReset)
         {
-            parts.Add("0"); // Reset to defaults
+            sb.Append('0'); // Reset to defaults
             currentAttrs = CellAttributes.None;
             currentFg = null;
             currentBg = null;
@@ -787,60 +918,45 @@ public static class SurfaceComparer
         var toTurnOn = targetCell.Attributes & ~currentAttrs;
 
         if ((toTurnOn & CellAttributes.Bold) != 0)
-            parts.Add("1");
+            AppendPart(sb, "1");
         if ((toTurnOn & CellAttributes.Dim) != 0)
-            parts.Add("2");
+            AppendPart(sb, "2");
         if ((toTurnOn & CellAttributes.Italic) != 0)
-            parts.Add("3");
+            AppendPart(sb, "3");
         if ((toTurnOn & CellAttributes.Underline) != 0)
         {
-            // Emit styled underline using colon sub-parameter syntax
-            var style = targetCell.UnderlineStyle;
-            parts.Add(style switch
-            {
-                UnderlineStyle.Double => "21",
-                UnderlineStyle.Curly => "4:3",
-                UnderlineStyle.Dotted => "4:4",
-                UnderlineStyle.Dashed => "4:5",
-                _ => "4", // Single or default
-            });
+            AppendPart(sb, UnderlineSgrCode(targetCell.UnderlineStyle));
         }
         else if ((currentAttrs & CellAttributes.Underline) != 0 &&
                  (targetCell.Attributes & CellAttributes.Underline) != 0 &&
                  targetCell.UnderlineStyle != currentUnderlineStyle)
         {
             // Underline is already on but style changed — re-emit with new style
-            var style = targetCell.UnderlineStyle;
-            parts.Add(style switch
-            {
-                UnderlineStyle.Double => "21",
-                UnderlineStyle.Curly => "4:3",
-                UnderlineStyle.Dotted => "4:4",
-                UnderlineStyle.Dashed => "4:5",
-                _ => "4",
-            });
+            AppendPart(sb, UnderlineSgrCode(targetCell.UnderlineStyle));
         }
         if ((toTurnOn & CellAttributes.Blink) != 0)
-            parts.Add("5");
+            AppendPart(sb, "5");
         if ((toTurnOn & CellAttributes.Reverse) != 0)
-            parts.Add("7");
+            AppendPart(sb, "7");
         if ((toTurnOn & CellAttributes.Hidden) != 0)
-            parts.Add("8");
+            AppendPart(sb, "8");
         if ((toTurnOn & CellAttributes.Strikethrough) != 0)
-            parts.Add("9");
+            AppendPart(sb, "9");
         if ((toTurnOn & CellAttributes.Overline) != 0)
-            parts.Add("53");
+            AppendPart(sb, "53");
 
         // Add foreground color if different
         if (!ColorsEqual(targetCell.Foreground, currentFg) && targetCell.Foreground is not null)
         {
-            parts.Add(BuildColorSgr(targetCell.Foreground.Value, isForeground: true));
+            AppendSeparator(sb);
+            AppendColorSgr(sb, targetCell.Foreground.Value, isForeground: true);
         }
 
         // Add background color if different
         if (!ColorsEqual(targetCell.Background, currentBg) && targetCell.Background is not null)
         {
-            parts.Add(BuildColorSgr(targetCell.Background.Value, isForeground: false));
+            AppendSeparator(sb);
+            AppendColorSgr(sb, targetCell.Background.Value, isForeground: false);
         }
 
         // Underline color (SGR 58;2;R;G;B)
@@ -849,11 +965,12 @@ public static class SurfaceComparer
             if (targetCell.UnderlineColor is not null)
             {
                 var ulc = targetCell.UnderlineColor.Value;
-                parts.Add($"58;2;{ulc.R};{ulc.G};{ulc.B}");
+                AppendSeparator(sb);
+                sb.Append("58;2;").Append(ulc.R).Append(';').Append(ulc.G).Append(';').Append(ulc.B);
             }
             else if (currentUnderlineColor is not null)
             {
-                parts.Add("59"); // Default underline color
+                AppendPart(sb, "59"); // Default underline color
             }
         }
 
@@ -864,18 +981,220 @@ public static class SurfaceComparer
         currentUnderlineStyle = targetCell.UnderlineStyle;
         currentUnderlineColor = targetCell.UnderlineColor;
 
-        return string.Join(";", parts);
+        return sb;
+    }
+
+    private static void AppendPart(StringBuilder sb, string part)
+    {
+        AppendSeparator(sb);
+        sb.Append(part);
+    }
+
+    private static void AppendSeparator(StringBuilder sb)
+    {
+        if (sb.Length > 0) sb.Append(';');
+    }
+
+    // -----------------------------------------------------------------------
+    // Fast byte-formatting SGR builder. Writes directly into a stackalloc'd
+    // Span<byte> via Utf8Formatter.TryFormat — bypasses StringBuilder rent +
+    // char Append + ToString + GetHashCode-over-chars + string-keyed dict
+    // lookup that the legacy BuildSgrParameters path goes through. The output
+    // span is fed to AnsiTokenCache.GetSgrTokenFromBytes which uses a
+    // byte-keyed cache and stores the wire-ready bytes on SgrToken for the
+    // serializer to memcpy.
+    //
+    // Mirror of BuildSgrParameters; keep the two in lockstep. Any new SGR
+    // emit case must be ported to both until BuildSgrParameters is retired.
+    // -----------------------------------------------------------------------
+    private static int BuildSgrParametersBytes(
+        Span<byte> dest,
+        SurfaceCell targetCell,
+        bool stateUnknown,
+        ref Hex1bColor? currentFg,
+        ref Hex1bColor? currentBg,
+        ref CellAttributes currentAttrs,
+        ref UnderlineStyle currentUnderlineStyle,
+        ref Hex1bColor? currentUnderlineColor)
+    {
+        int pos = 0;
+
+        var turnedOff = currentAttrs & ~targetCell.Attributes;
+        bool needsReset = stateUnknown ||
+                         turnedOff != CellAttributes.None ||
+                         (currentFg is not null && targetCell.Foreground is null) ||
+                         (currentBg is not null && targetCell.Background is null);
+
+        if (needsReset)
+        {
+            dest[pos++] = (byte)'0';
+            currentAttrs = CellAttributes.None;
+            currentFg = null;
+            currentBg = null;
+            currentUnderlineStyle = UnderlineStyle.None;
+            currentUnderlineColor = null;
+        }
+
+        var toTurnOn = targetCell.Attributes & ~currentAttrs;
+
+        if ((toTurnOn & CellAttributes.Bold) != 0) AppendPartBytes(dest, ref pos, "1"u8);
+        if ((toTurnOn & CellAttributes.Dim) != 0) AppendPartBytes(dest, ref pos, "2"u8);
+        if ((toTurnOn & CellAttributes.Italic) != 0) AppendPartBytes(dest, ref pos, "3"u8);
+        if ((toTurnOn & CellAttributes.Underline) != 0)
+        {
+            AppendPartBytes(dest, ref pos, UnderlineSgrCodeBytes(targetCell.UnderlineStyle));
+        }
+        else if ((currentAttrs & CellAttributes.Underline) != 0 &&
+                 (targetCell.Attributes & CellAttributes.Underline) != 0 &&
+                 targetCell.UnderlineStyle != currentUnderlineStyle)
+        {
+            AppendPartBytes(dest, ref pos, UnderlineSgrCodeBytes(targetCell.UnderlineStyle));
+        }
+        if ((toTurnOn & CellAttributes.Blink) != 0) AppendPartBytes(dest, ref pos, "5"u8);
+        if ((toTurnOn & CellAttributes.Reverse) != 0) AppendPartBytes(dest, ref pos, "7"u8);
+        if ((toTurnOn & CellAttributes.Hidden) != 0) AppendPartBytes(dest, ref pos, "8"u8);
+        if ((toTurnOn & CellAttributes.Strikethrough) != 0) AppendPartBytes(dest, ref pos, "9"u8);
+        if ((toTurnOn & CellAttributes.Overline) != 0) AppendPartBytes(dest, ref pos, "53"u8);
+
+        if (!ColorsEqual(targetCell.Foreground, currentFg) && targetCell.Foreground is not null)
+        {
+            AppendSeparatorByte(dest, ref pos);
+            AppendColorSgrBytes(dest, ref pos, targetCell.Foreground.Value, isForeground: true);
+        }
+
+        if (!ColorsEqual(targetCell.Background, currentBg) && targetCell.Background is not null)
+        {
+            AppendSeparatorByte(dest, ref pos);
+            AppendColorSgrBytes(dest, ref pos, targetCell.Background.Value, isForeground: false);
+        }
+
+        if (!ColorsEqual(targetCell.UnderlineColor, currentUnderlineColor))
+        {
+            if (targetCell.UnderlineColor is not null)
+            {
+                var ulc = targetCell.UnderlineColor.Value;
+                AppendSeparatorByte(dest, ref pos);
+                AppendBytes(dest, ref pos, "58;2;"u8);
+                AppendByteAsAscii(dest, ref pos, ulc.R);
+                dest[pos++] = (byte)';';
+                AppendByteAsAscii(dest, ref pos, ulc.G);
+                dest[pos++] = (byte)';';
+                AppendByteAsAscii(dest, ref pos, ulc.B);
+            }
+            else if (currentUnderlineColor is not null)
+            {
+                AppendPartBytes(dest, ref pos, "59"u8);
+            }
+        }
+
+        currentAttrs = targetCell.Attributes;
+        currentFg = targetCell.Foreground;
+        currentBg = targetCell.Background;
+        currentUnderlineStyle = targetCell.UnderlineStyle;
+        currentUnderlineColor = targetCell.UnderlineColor;
+
+        return pos;
+    }
+
+    private static void AppendPartBytes(Span<byte> dest, ref int pos, ReadOnlySpan<byte> part)
+    {
+        AppendSeparatorByte(dest, ref pos);
+        AppendBytes(dest, ref pos, part);
+    }
+
+    private static void AppendSeparatorByte(Span<byte> dest, ref int pos)
+    {
+        if (pos > 0) dest[pos++] = (byte)';';
+    }
+
+    private static void AppendBytes(Span<byte> dest, ref int pos, ReadOnlySpan<byte> src)
+    {
+        src.CopyTo(dest.Slice(pos));
+        pos += src.Length;
+    }
+
+    private static void AppendIntAsAscii(Span<byte> dest, ref int pos, int value)
+    {
+        if (!System.Buffers.Text.Utf8Formatter.TryFormat(value, dest.Slice(pos), out var written))
+            throw new InvalidOperationException("SGR int formatting buffer overflow.");
+        pos += written;
+    }
+
+    private static void AppendByteAsAscii(Span<byte> dest, ref int pos, byte value)
+    {
+        if (!System.Buffers.Text.Utf8Formatter.TryFormat(value, dest.Slice(pos), out var written))
+            throw new InvalidOperationException("SGR byte formatting buffer overflow.");
+        pos += written;
+    }
+
+    private static ReadOnlySpan<byte> UnderlineSgrCodeBytes(UnderlineStyle style) => style switch
+    {
+        UnderlineStyle.Double => "21"u8,
+        UnderlineStyle.Curly => "4:3"u8,
+        UnderlineStyle.Dotted => "4:4"u8,
+        UnderlineStyle.Dashed => "4:5"u8,
+        _ => "4"u8,
+    };
+
+    private static void AppendColorSgrBytes(Span<byte> dest, ref int pos, Hex1bColor color, bool isForeground)
+    {
+        switch (color.Kind)
+        {
+            case Hex1bColorKind.Standard:
+                AppendIntAsAscii(dest, ref pos, isForeground ? 30 + color.AnsiIndex : 40 + color.AnsiIndex);
+                break;
+            case Hex1bColorKind.Bright:
+                AppendIntAsAscii(dest, ref pos, isForeground ? 90 + color.AnsiIndex : 100 + color.AnsiIndex);
+                break;
+            case Hex1bColorKind.Indexed:
+                AppendBytes(dest, ref pos, isForeground ? "38;5;"u8 : "48;5;"u8);
+                AppendByteAsAscii(dest, ref pos, color.AnsiIndex);
+                break;
+            default:
+                AppendBytes(dest, ref pos, isForeground ? "38;2;"u8 : "48;2;"u8);
+                AppendByteAsAscii(dest, ref pos, color.R);
+                dest[pos++] = (byte)';';
+                AppendByteAsAscii(dest, ref pos, color.G);
+                dest[pos++] = (byte)';';
+                AppendByteAsAscii(dest, ref pos, color.B);
+                break;
+        }
+    }
+
+    private static string UnderlineSgrCode(UnderlineStyle style) => style switch
+    {
+        UnderlineStyle.Double => "21",
+        UnderlineStyle.Curly => "4:3",
+        UnderlineStyle.Dotted => "4:4",
+        UnderlineStyle.Dashed => "4:5",
+        _ => "4",
+    };
+
+    private static void AppendColorSgr(StringBuilder sb, Hex1bColor color, bool isForeground)
+    {
+        switch (color.Kind)
+        {
+            case Hex1bColorKind.Standard:
+                sb.Append(isForeground ? 30 + color.AnsiIndex : 40 + color.AnsiIndex);
+                break;
+            case Hex1bColorKind.Bright:
+                sb.Append(isForeground ? 90 + color.AnsiIndex : 100 + color.AnsiIndex);
+                break;
+            case Hex1bColorKind.Indexed:
+                sb.Append(isForeground ? "38;5;" : "48;5;").Append(color.AnsiIndex);
+                break;
+            default:
+                sb.Append(isForeground ? "38;2;" : "48;2;")
+                  .Append(color.R).Append(';').Append(color.G).Append(';').Append(color.B);
+                break;
+        }
     }
 
     private static string BuildColorSgr(Hex1bColor color, bool isForeground)
     {
-        return color.Kind switch
-        {
-            Hex1bColorKind.Standard => (isForeground ? 30 + color.AnsiIndex : 40 + color.AnsiIndex).ToString(),
-            Hex1bColorKind.Bright => (isForeground ? 90 + color.AnsiIndex : 100 + color.AnsiIndex).ToString(),
-            Hex1bColorKind.Indexed => $"{(isForeground ? "38;5" : "48;5")};{color.AnsiIndex}",
-            _ => $"{(isForeground ? "38;2" : "48;2")};{color.R};{color.G};{color.B}"
-        };
+        var sb = new StringBuilder(16);
+        AppendColorSgr(sb, color, isForeground);
+        return sb.ToString();
     }
 
     #endregion

--- a/src/Hex1b/Surfaces/SurfaceDiff.cs
+++ b/src/Hex1b/Surfaces/SurfaceDiff.cs
@@ -40,9 +40,34 @@ public sealed class SurfaceDiff
     internal SurfaceDiff(List<ChangedCell> changedCells)
     {
         _changedCells = changedCells;
-        
-        // Sort by Y, then X for optimal cursor movement
-        _changedCells.Sort((a, b) =>
+        SortChanges();
+    }
+
+    /// <summary>
+    /// Creates an empty, reusable diff. Used by the renderer hot path with
+    /// <see cref="MutableCells"/> + <see cref="SortChanges"/> to avoid allocating a
+    /// fresh diff per frame.
+    /// </summary>
+    internal SurfaceDiff()
+    {
+        _changedCells = new List<ChangedCell>();
+    }
+
+    /// <summary>
+    /// Mutable access to the backing list for the renderer's reusable diff. After
+    /// mutation, the caller must invoke <see cref="SortChanges"/> to restore the
+    /// row-major ordering contract.
+    /// </summary>
+    internal List<ChangedCell> MutableCells => _changedCells;
+
+    /// <summary>
+    /// Sorts the backing list into row-major order (Y, then X). The comparer used is a
+    /// static, capture-free lambda, so the JIT caches it and no delegate is allocated
+    /// per call.
+    /// </summary>
+    internal void SortChanges()
+    {
+        _changedCells.Sort(static (a, b) =>
         {
             var yCompare = a.Y.CompareTo(b.Y);
             return yCompare != 0 ? yCompare : a.X.CompareTo(b.X);

--- a/src/Hex1b/Surfaces/SurfaceRenderContext.cs
+++ b/src/Hex1b/Surfaces/SurfaceRenderContext.cs
@@ -795,7 +795,35 @@ public class SurfaceRenderContext : Hex1bRenderContext
             // Clamp dimensions to prevent overflow with unconstrained children
             var clampedWidth = Math.Min(child.Bounds.Width, MaxSurfaceDimension);
             var clampedHeight = Math.Min(child.Bounds.Height, MaxSurfaceDimension);
-            var childSurface = new Surface(clampedWidth, clampedHeight, CellMetrics);
+
+            // Reuse the previously cached buffer in place when its dimensions still match.
+            // CachedSurface for non-trivial sizes lands on the Large Object Heap (~64
+            // bytes/cell), so reallocating per cache miss produces a steady stream of
+            // Gen2 garbage. Only fall back to a fresh allocation (or pool rent) when
+            // the buffer is missing or differently sized.
+            Surface childSurface;
+            var existingBuffer = child.CachedSurface ?? child.RenderBuffer;
+            if (existingBuffer is not null
+                && existingBuffer.Width == clampedWidth
+                && existingBuffer.Height == clampedHeight
+                && existingBuffer.CellMetrics == CellMetrics)
+            {
+                childSurface = existingBuffer;
+                childSurface.ClearAndReleaseTrackedObjects();
+                child.RenderBuffer = null;
+            }
+            else
+            {
+                var pool = SurfacePool;
+                // The retained buffer no longer fits — surrender it to the pool
+                // (or let GC collect it) before allocating a new one.
+                if (pool != null && child.RenderBuffer is { } retired)
+                    pool.Return(retired);
+                child.RenderBuffer = null;
+                childSurface = pool != null
+                    ? pool.Rent(clampedWidth, clampedHeight, CellMetrics)
+                    : new Surface(clampedWidth, clampedHeight, CellMetrics);
+            }
             var subtreeVersionBeforeRender = child.SubtreeRenderVersion;
             
             // Create context with offset so child's absolute coordinates map to surface (0,0)
@@ -810,6 +838,7 @@ public class SurfaceRenderContext : Hex1bRenderContext
                 MouseY = MouseY,
                 CellMetrics = CellMetrics,  // Propagate cell metrics for sixel sizing
                 Metrics = Metrics,
+                SurfacePool = SurfacePool, // Propagate the pool so descendants (EffectPanel temp surfaces, nested RenderChild surfaces) reuse buffers instead of falling back to `new Surface`.
                 _capabilities = _capabilities,
                 _kgpRegistry = _kgpRegistry,
                 _kgpLayer = _kgpLayer,

--- a/src/Hex1b/Tokens/AnsiTokenCache.cs
+++ b/src/Hex1b/Tokens/AnsiTokenCache.cs
@@ -1,0 +1,190 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Hex1b.Tokens;
+
+/// <summary>
+/// Internal pool of frequently-emitted token instances so the renderer hot path
+/// can reuse <see cref="SgrToken"/> / <see cref="TextToken"/> values instead of
+/// allocating a fresh record per cell every frame.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Tokens are <see langword="public sealed record"/> types with value-based equality
+/// and no mutable state, so two callers receiving the same cached instance behave
+/// identically to two callers receiving distinct equal instances. The caches are
+/// bounded to avoid unbounded growth from pathological workloads; on overflow the
+/// fallback path simply allocates a fresh record.
+/// </para>
+/// <para>
+/// The SGR cache is keyed by a hash of the assembled <see cref="StringBuilder"/>
+/// contents with a span-vs-string equality verification on lookup, so cache hits
+/// never materialise the SGR text into a heap string. <c>GetAlternateLookup</c>
+/// would be a cleaner API but is .NET 9+ only and this lib targets net8.0.
+/// </para>
+/// <para>
+/// Per-thread state (<see cref="ThreadStaticAttribute">thread-static</see>) avoids
+/// lock contention when multiple Hex1bApp instances render concurrently in tests.
+/// </para>
+/// </remarks>
+internal static class AnsiTokenCache
+{
+    [ThreadStatic] private static StringBuilder? t_sgrBuilder;
+    [ThreadStatic] private static Dictionary<ulong, SgrEntry>? t_sgrCache;
+    [ThreadStatic] private static Dictionary<ulong, SgrEntry>? t_sgrBytesCache;
+
+    private static readonly ConcurrentDictionary<string, TextToken> s_textCache = new();
+
+    private const int MaxSgrCache = 4096;
+    private const int MaxTextCache = 2048;
+
+    private readonly struct SgrEntry
+    {
+        public readonly string Parameters;
+        public readonly SgrToken Token;
+        public SgrEntry(string parameters, SgrToken token)
+        {
+            Parameters = parameters;
+            Token = token;
+        }
+    }
+
+    /// <summary>
+    /// Returns a cleared <see cref="StringBuilder"/> for assembling SGR parameter
+    /// strings on the current thread.
+    /// </summary>
+    public static StringBuilder GetSgrBuilder()
+    {
+        var sb = t_sgrBuilder ??= new StringBuilder(64);
+        sb.Clear();
+        return sb;
+    }
+
+    /// <summary>
+    /// Looks up a cached <see cref="SgrToken"/> matching the assembled contents of
+    /// <paramref name="builder"/>, allocating one (and the backing string) only on
+    /// cache miss. Lookup hashes the builder contents and verifies span equality
+    /// against the stored key without materialising a string on the hot path.
+    /// </summary>
+    public static SgrToken GetSgrToken(StringBuilder builder)
+    {
+        if (builder.Length == 0)
+            return SgrToken.Reset;
+
+        var cache = t_sgrCache ??= new Dictionary<ulong, SgrEntry>(capacity: 256);
+        var hash = HashBuilder(builder);
+
+        if (cache.TryGetValue(hash, out var entry) && BuilderEqualsString(builder, entry.Parameters))
+            return entry.Token;
+
+        // Cache miss (or once-in-a-blue-moon hash collision) — materialise the string.
+        var parameters = builder.ToString();
+        var token = new SgrToken(parameters);
+        if (cache.Count < MaxSgrCache)
+            cache[hash] = new SgrEntry(parameters, token);
+        return token;
+    }
+
+    /// <summary>
+    /// Returns a cached <see cref="TextToken"/> for the given text, allocating
+    /// one on cache miss. Short strings (single graphemes — the common case for
+    /// the per-cell text emission path) are cached aggressively; long strings
+    /// bypass the cache entirely since they're unlikely to recur.
+    /// </summary>
+    public static TextToken GetTextToken(string text)
+    {
+        if (text.Length > 8)
+            return new TextToken(text);
+
+        if (s_textCache.TryGetValue(text, out var token))
+            return token;
+
+        token = new TextToken(text);
+        if (s_textCache.Count < MaxTextCache)
+            s_textCache.TryAdd(text, token);
+        return token;
+    }
+
+    // FNV-1a 64-bit hash over the builder's chars. Cheap, allocation-free, good
+    // collision resistance for short SGR strings (<128 chars).
+    private static ulong HashBuilder(StringBuilder builder)
+    {
+        const ulong fnvOffset = 14695981039346656037UL;
+        const ulong fnvPrime = 1099511628211UL;
+        ulong hash = fnvOffset;
+        var len = builder.Length;
+        for (var i = 0; i < len; i++)
+        {
+            var ch = builder[i];
+            hash ^= ch;
+            hash *= fnvPrime;
+        }
+        return hash;
+    }
+
+    /// <summary>
+    /// Returns a cached <see cref="SgrToken"/> whose <see cref="SgrToken.PreformattedBytes"/>
+    /// is the wire-ready UTF-8 representation of the SGR parameters (without the
+    /// surrounding <c>ESC[</c> ... <c>m</c>). Lookup is keyed by an FNV-1a hash
+    /// over <paramref name="parameterBytes"/> with a span-vs-array equality verify
+    /// on lookup, so cache hits allocate nothing.
+    /// </summary>
+    /// <remarks>
+    /// On miss this copies the bytes into a heap byte[] and materialises an ASCII
+    /// string for <see cref="SgrToken.Parameters"/> (one-time cost; cache hits skip
+    /// both). SGR parameters are pure ASCII (digits, semicolons, colons), so ASCII
+    /// decode is exact.
+    /// </remarks>
+    public static SgrToken GetSgrTokenFromBytes(ReadOnlySpan<byte> parameterBytes)
+    {
+        if (parameterBytes.Length == 0)
+            return SgrToken.Reset;
+
+        var cache = t_sgrBytesCache ??= new Dictionary<ulong, SgrEntry>(capacity: 256);
+        var hash = HashBytes(parameterBytes);
+
+        if (cache.TryGetValue(hash, out var entry) && BytesEqualsBytes(parameterBytes, entry.Token.PreformattedBytes))
+            return entry.Token;
+
+        // Cache miss — materialise the wire bytes + the parameter string.
+        var bytes = parameterBytes.ToArray();
+        var parameters = System.Text.Encoding.ASCII.GetString(bytes);
+        var token = new SgrToken(parameters) { PreformattedBytes = bytes };
+        if (cache.Count < MaxSgrCache)
+            cache[hash] = new SgrEntry(parameters, token);
+        return token;
+    }
+
+    // FNV-1a 64-bit hash over a byte span.
+    private static ulong HashBytes(ReadOnlySpan<byte> data)
+    {
+        const ulong fnvOffset = 14695981039346656037UL;
+        const ulong fnvPrime = 1099511628211UL;
+        ulong hash = fnvOffset;
+        for (var i = 0; i < data.Length; i++)
+        {
+            hash ^= data[i];
+            hash *= fnvPrime;
+        }
+        return hash;
+    }
+
+    private static bool BytesEqualsBytes(ReadOnlySpan<byte> a, byte[]? b)
+    {
+        if (b is null) return false;
+        return a.SequenceEqual(b);
+    }
+
+    private static bool BuilderEqualsString(StringBuilder builder, string s)
+    {
+        if (builder.Length != s.Length) return false;
+        for (var i = 0; i < builder.Length; i++)
+        {
+            if (builder[i] != s[i]) return false;
+        }
+        return true;
+    }
+}
+
+

--- a/src/Hex1b/Tokens/AnsiTokenUtf8Serializer.cs
+++ b/src/Hex1b/Tokens/AnsiTokenUtf8Serializer.cs
@@ -32,6 +32,48 @@ public static class AnsiTokenUtf8Serializer
     }
 
     /// <summary>
+    /// Serializes a list of tokens into a UTF-8 byte buffer backed by an array rented from
+    /// <see cref="ArrayPool{T}.Shared"/>. The caller MUST return <paramref name="pooledBuffer"/>
+    /// to the pool when done with the bytes (typically after writing them to the wire).
+    /// This avoids per-frame Large Object Heap allocations for busy fullscreen renders where
+    /// the serialised output routinely exceeds the LOH threshold (~85 KB).
+    /// </summary>
+    /// <param name="tokens">The tokens to serialise.</param>
+    /// <param name="pooledBuffer">
+    /// Receives the rented array. Pass to <see cref="ArrayPool{T}.Return"/> when finished.
+    /// Will be <see langword="null"/> only if <paramref name="tokens"/> contains no bytes.
+    /// </param>
+    /// <returns>
+    /// A memory window over the first N bytes of <paramref name="pooledBuffer"/>, where N is
+    /// the serialised length. The memory becomes invalid once the buffer is returned to the pool.
+    /// </returns>
+    public static ReadOnlyMemory<byte> SerializeRented(IEnumerable<AnsiToken> tokens, out byte[] pooledBuffer)
+    {
+        ArgumentNullException.ThrowIfNull(tokens);
+
+        var initialCapacity = tokens is IReadOnlyCollection<AnsiToken> c
+            ? Math.Clamp(c.Count * 4, 256, 128 * 1024)
+            : 1024;
+
+        var writer = new PooledArrayBufferWriter(initialCapacity);
+        try
+        {
+            foreach (var token in tokens)
+            {
+                WriteToken(writer, token);
+            }
+        }
+        catch
+        {
+            writer.ReturnToPool();
+            throw;
+        }
+
+        pooledBuffer = writer.DetachBuffer(out var length);
+        return new ReadOnlyMemory<byte>(pooledBuffer, 0, length);
+    }
+
+    /// <summary>
     /// Serializes a single token into a UTF-8 byte buffer.
     /// </summary>
     public static ReadOnlyMemory<byte> Serialize(AnsiToken token)
@@ -43,7 +85,7 @@ public static class AnsiTokenUtf8Serializer
         return writer.WrittenMemory;
     }
 
-    private static void WriteToken(ArrayBufferWriter<byte> writer, AnsiToken token)
+    private static void WriteToken(IBufferWriter<byte> writer, AnsiToken token)
     {
         switch (token)
         {
@@ -57,7 +99,16 @@ public static class AnsiTokenUtf8Serializer
 
             case SgrToken sgr:
                 WriteEscLeftBracket(writer);
-                WriteUtf8(writer, sgr.Parameters);
+                if (sgr.PreformattedBytes is { } sgrBytes)
+                {
+                    var dst = writer.GetSpan(sgrBytes.Length);
+                    sgrBytes.AsSpan().CopyTo(dst);
+                    writer.Advance(sgrBytes.Length);
+                }
+                else
+                {
+                    WriteUtf8(writer, sgr.Parameters);
+                }
                 WriteByte(writer, (byte)'m');
                 return;
 
@@ -314,7 +365,7 @@ public static class AnsiTokenUtf8Serializer
         }
     }
 
-    private static void WriteCursorPosition(ArrayBufferWriter<byte> writer, CursorPositionToken token)
+    private static void WriteCursorPosition(IBufferWriter<byte> writer, CursorPositionToken token)
     {
         // Mirror AnsiTokenSerializer.SerializeCursorPosition() exactly, including OriginalParams.
         if (token.OriginalParams is not null)
@@ -350,7 +401,7 @@ public static class AnsiTokenUtf8Serializer
         WriteByte(writer, (byte)'H');
     }
 
-    private static void WriteCursorMove(ArrayBufferWriter<byte> writer, CursorMoveToken token)
+    private static void WriteCursorMove(IBufferWriter<byte> writer, CursorMoveToken token)
     {
         WriteEscLeftBracket(writer);
 
@@ -371,7 +422,7 @@ public static class AnsiTokenUtf8Serializer
         WriteByte(writer, command);
     }
 
-    private static void WriteOsc(ArrayBufferWriter<byte> writer, OscToken token)
+    private static void WriteOsc(IBufferWriter<byte> writer, OscToken token)
     {
         // Preserve original terminator style (ESC \ vs BEL)
         // Mirror AnsiTokenSerializer.SerializeOsc() exactly.
@@ -403,7 +454,7 @@ public static class AnsiTokenUtf8Serializer
         WriteOscTerminator(writer, token.UseEscBackslash);
     }
 
-    private static void WriteOscTerminator(ArrayBufferWriter<byte> writer, bool useEscBackslash)
+    private static void WriteOscTerminator(IBufferWriter<byte> writer, bool useEscBackslash)
     {
         if (useEscBackslash)
         {
@@ -416,7 +467,7 @@ public static class AnsiTokenUtf8Serializer
         }
     }
 
-    private static void WriteControlCharacter(ArrayBufferWriter<byte> writer, ControlCharacterToken token)
+    private static void WriteControlCharacter(IBufferWriter<byte> writer, ControlCharacterToken token)
     {
         switch (token.Character)
         {
@@ -431,7 +482,7 @@ public static class AnsiTokenUtf8Serializer
         }
     }
 
-    private static void WriteEscLeftBracket(ArrayBufferWriter<byte> writer)
+    private static void WriteEscLeftBracket(IBufferWriter<byte> writer)
     {
         var span = writer.GetSpan(2);
         span[0] = 0x1b;
@@ -439,14 +490,14 @@ public static class AnsiTokenUtf8Serializer
         writer.Advance(2);
     }
 
-    private static void WriteByte(ArrayBufferWriter<byte> writer, byte value)
+    private static void WriteByte(IBufferWriter<byte> writer, byte value)
     {
         var span = writer.GetSpan(1);
         span[0] = value;
         writer.Advance(1);
     }
 
-    private static void WriteInt(ArrayBufferWriter<byte> writer, int value)
+    private static void WriteInt(IBufferWriter<byte> writer, int value)
     {
         var span = writer.GetSpan(11); // int32 max length
         if (!Utf8Formatter.TryFormat(value, span, out var written))
@@ -454,7 +505,7 @@ public static class AnsiTokenUtf8Serializer
         writer.Advance(written);
     }
 
-    private static void WriteUtf8(ArrayBufferWriter<byte> writer, string text)
+    private static void WriteUtf8(IBufferWriter<byte> writer, string text)
     {
         if (string.IsNullOrEmpty(text))
             return;
@@ -478,7 +529,7 @@ public static class AnsiTokenUtf8Serializer
         writer.Advance(text.Length);
     }
 
-    private static void WriteCharUtf8(ArrayBufferWriter<byte> writer, char ch)
+    private static void WriteCharUtf8(IBufferWriter<byte> writer, char ch)
     {
         Span<char> chars = stackalloc char[1];
         chars[0] = ch;
@@ -488,7 +539,7 @@ public static class AnsiTokenUtf8Serializer
         writer.Advance(written);
     }
 
-    private static void WriteUtf8Slow(ArrayBufferWriter<byte> writer, ReadOnlySpan<char> text)
+    private static void WriteUtf8Slow(IBufferWriter<byte> writer, ReadOnlySpan<char> text)
     {
         if (text.IsEmpty)
             return;

--- a/src/Hex1b/Tokens/PooledArrayBufferWriter.cs
+++ b/src/Hex1b/Tokens/PooledArrayBufferWriter.cs
@@ -1,0 +1,89 @@
+using System.Buffers;
+
+namespace Hex1b.Tokens;
+
+/// <summary>
+/// An <see cref="IBufferWriter{T}"/> backed by an array rented from
+/// <see cref="ArrayPool{T}.Shared"/>. The caller takes ownership of the array via
+/// <see cref="DetachBuffer"/> and is responsible for returning it to the pool when done.
+/// </summary>
+/// <remarks>
+/// This exists so the ANSI serializer can write directly into pooled storage. The default
+/// <see cref="ArrayBufferWriter{T}"/> allocates with <c>new T[]</c>, which for a busy
+/// fullscreen frame routinely lands in the Large Object Heap (≥ 85 KB) — that allocation
+/// is one of the largest per-frame Gen2 contributors in the render loop.
+/// </remarks>
+internal sealed class PooledArrayBufferWriter : IBufferWriter<byte>
+{
+    private byte[] _buffer;
+    private int _written;
+
+    public PooledArrayBufferWriter(int initialCapacity)
+    {
+        if (initialCapacity <= 0) initialCapacity = 256;
+        _buffer = ArrayPool<byte>.Shared.Rent(initialCapacity);
+    }
+
+    public int WrittenCount => _written;
+
+    public void Advance(int count)
+    {
+        if (count < 0 || _written + count > _buffer.Length)
+            throw new ArgumentOutOfRangeException(nameof(count));
+        _written += count;
+    }
+
+    public Memory<byte> GetMemory(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+        return _buffer.AsMemory(_written);
+    }
+
+    public Span<byte> GetSpan(int sizeHint = 0)
+    {
+        EnsureCapacity(sizeHint);
+        return _buffer.AsSpan(_written);
+    }
+
+    /// <summary>
+    /// Transfers ownership of the underlying pooled buffer to the caller. The caller must
+    /// return it to <see cref="ArrayPool{T}.Shared"/> when the bytes have been fully consumed.
+    /// After this call the writer must not be used.
+    /// </summary>
+    public byte[] DetachBuffer(out int length)
+    {
+        var buf = _buffer;
+        length = _written;
+        _buffer = Array.Empty<byte>();
+        _written = 0;
+        return buf;
+    }
+
+    /// <summary>
+    /// Returns the underlying buffer to the pool and resets the writer. Use this when
+    /// disposing of a writer whose contents will not be consumed (e.g. an exception path).
+    /// </summary>
+    public void ReturnToPool()
+    {
+        if (_buffer.Length > 0)
+        {
+            ArrayPool<byte>.Shared.Return(_buffer);
+            _buffer = Array.Empty<byte>();
+            _written = 0;
+        }
+    }
+
+    private void EnsureCapacity(int sizeHint)
+    {
+        if (sizeHint < 1) sizeHint = 1;
+        var required = _written + sizeHint;
+        if (required <= _buffer.Length) return;
+
+        // Grow by doubling, but at least to required.
+        var newSize = Math.Max(required, _buffer.Length * 2);
+        var next = ArrayPool<byte>.Shared.Rent(newSize);
+        Buffer.BlockCopy(_buffer, 0, next, 0, _written);
+        ArrayPool<byte>.Shared.Return(_buffer);
+        _buffer = next;
+    }
+}

--- a/src/Hex1b/Tokens/SgrToken.cs
+++ b/src/Hex1b/Tokens/SgrToken.cs
@@ -30,4 +30,23 @@ public sealed record SgrToken(string Parameters) : AnsiToken
 {
     /// <summary>SGR reset - clears all attributes and colors.</summary>
     public static readonly SgrToken Reset = new("");
+
+    /// <summary>
+    /// Optional pre-formatted UTF-8 representation of <see cref="Parameters"/>
+    /// (without the surrounding <c>ESC[</c> ... <c>m</c>). When the renderer hot
+    /// path emits an SGR via the byte-formatting fast path it stores the wire
+    /// bytes here so <see cref="AnsiTokenUtf8Serializer"/> can <c>memcpy</c>
+    /// them instead of re-encoding the string.
+    /// </summary>
+    /// <remarks>
+    /// This is a cache and MUST NOT participate in value equality — two
+    /// <see cref="SgrToken"/> instances with the same <see cref="Parameters"/>
+    /// are equal regardless of whether one carries pre-formatted bytes.
+    /// </remarks>
+    internal byte[]? PreformattedBytes { get; init; }
+
+    public bool Equals(SgrToken? other) =>
+        other is not null && Parameters == other.Parameters;
+
+    public override int GetHashCode() => Parameters?.GetHashCode() ?? 0;
 }

--- a/src/Hex1b/Widgets/EffectPanelWidget.cs
+++ b/src/Hex1b/Widgets/EffectPanelWidget.cs
@@ -26,12 +26,6 @@ public sealed record EffectPanelWidget(Hex1bWidget Child) : Hex1bWidget
     internal Action<Surface>? EffectCallback { get; init; }
 
     /// <summary>
-    /// Gets the context-aware effect callback that post-processes the rendered surface
-    /// and additionally receives the parent <see cref="Hex1bRenderContext"/>.
-    /// </summary>
-    internal Action<Surface, Hex1bRenderContext>? EffectWithContextCallback { get; init; }
-
-    /// <summary>
     /// Sets the effect callback that post-processes the child's rendered surface.
     /// </summary>
     /// <param name="effect">A callback that receives the rendered <see cref="Surface"/> for in-place modification.</param>
@@ -39,22 +33,11 @@ public sealed record EffectPanelWidget(Hex1bWidget Child) : Hex1bWidget
     public EffectPanelWidget Effect(Action<Surface> effect)
         => this with { EffectCallback = effect };
 
-    /// <summary>
-    /// Sets a context-aware effect callback that receives both the rendered <see cref="Surface"/>
-    /// and the parent <see cref="Hex1bRenderContext"/> (use <c>context.Theme.GetGlobalBackground()</c>
-    /// when blending toward the terminal's effective background).
-    /// </summary>
-    /// <param name="effect">A callback that receives the rendered surface and render context.</param>
-    /// <returns>A new <see cref="EffectPanelWidget"/> with the effect applied.</returns>
-    public EffectPanelWidget Effect(Action<Surface, Hex1bRenderContext> effect)
-        => this with { EffectWithContextCallback = effect };
-
     internal override async Task<Hex1bNode> ReconcileAsync(Hex1bNode? existingNode, ReconcileContext context)
     {
         var node = existingNode as EffectPanelNode ?? new EffectPanelNode();
 
         node.Effect = EffectCallback;
-        node.EffectWithContext = EffectWithContextCallback;
 
         // Reconcile the child widget
         node.Child = await context.ReconcileChildAsync(node.Child, Child, node);

--- a/src/Hex1b/Widgets/EffectPanelWidget.cs
+++ b/src/Hex1b/Widgets/EffectPanelWidget.cs
@@ -26,6 +26,12 @@ public sealed record EffectPanelWidget(Hex1bWidget Child) : Hex1bWidget
     internal Action<Surface>? EffectCallback { get; init; }
 
     /// <summary>
+    /// Gets the context-aware effect callback that post-processes the rendered surface
+    /// and additionally receives the parent <see cref="Hex1bRenderContext"/>.
+    /// </summary>
+    internal Action<Surface, Hex1bRenderContext>? EffectWithContextCallback { get; init; }
+
+    /// <summary>
     /// Sets the effect callback that post-processes the child's rendered surface.
     /// </summary>
     /// <param name="effect">A callback that receives the rendered <see cref="Surface"/> for in-place modification.</param>
@@ -33,11 +39,22 @@ public sealed record EffectPanelWidget(Hex1bWidget Child) : Hex1bWidget
     public EffectPanelWidget Effect(Action<Surface> effect)
         => this with { EffectCallback = effect };
 
+    /// <summary>
+    /// Sets a context-aware effect callback that receives both the rendered <see cref="Surface"/>
+    /// and the parent <see cref="Hex1bRenderContext"/> (use <c>context.Theme.GetGlobalBackground()</c>
+    /// when blending toward the terminal's effective background).
+    /// </summary>
+    /// <param name="effect">A callback that receives the rendered surface and render context.</param>
+    /// <returns>A new <see cref="EffectPanelWidget"/> with the effect applied.</returns>
+    public EffectPanelWidget Effect(Action<Surface, Hex1bRenderContext> effect)
+        => this with { EffectWithContextCallback = effect };
+
     internal override async Task<Hex1bNode> ReconcileAsync(Hex1bNode? existingNode, ReconcileContext context)
     {
         var node = existingNode as EffectPanelNode ?? new EffectPanelNode();
 
         node.Effect = EffectCallback;
+        node.EffectWithContext = EffectWithContextCallback;
 
         // Reconcile the child widget
         node.Child = await context.ReconcileChildAsync(node.Child, Child, node);

--- a/src/Hex1b/Widgets/FigletTextWidget.cs
+++ b/src/Hex1b/Widgets/FigletTextWidget.cs
@@ -30,7 +30,7 @@ namespace Hex1b.Widgets;
 /// using Hex1b.Widgets;
 ///
 /// await using var terminal = Hex1bTerminal.CreateBuilder()
-///     .WithHex1bApp((app, options) =&gt; ctx =&gt;
+///     .WithHex1bApp(ctx =&gt;
 ///         ctx.FigletText("Hello").Font(FigletFonts.Slant))
 ///     .Build();
 ///

--- a/src/Hex1b/Widgets/SurfaceWidget.cs
+++ b/src/Hex1b/Widgets/SurfaceWidget.cs
@@ -65,9 +65,16 @@ public record SurfaceWidget(
     {
         var node = existingNode as SurfaceNode ?? new SurfaceNode();
 
-        // Always mark dirty since layers may have changed content
-        // (we can't easily compare layer contents)
-        node.MarkDirty();
+        // If the user has not opted into per-widget cache control via .Cached(...),
+        // we conservatively mark the node dirty every reconcile because we can't
+        // cheaply diff layer contents. When a CachePredicate IS present, the user
+        // is taking responsibility for declaring when the rendered surface needs
+        // to be regenerated — invalidating here would force a new (often LOH)
+        // Surface allocation per frame and defeat the cache entirely.
+        if (CachePredicate is null)
+        {
+            node.MarkDirty();
+        }
 
         node.LayerBuilder = LayerBuilder;
         // HeightHint and WidthHint are set by ReconcileContext from the base Hex1bWidget properties.

--- a/src/Hex1b/WorkloadOutputItem.cs
+++ b/src/Hex1b/WorkloadOutputItem.cs
@@ -22,5 +22,34 @@ namespace Hex1b;
 /// Optional pre-tokenized representation of <paramref name="Bytes"/>. When provided, it should
 /// represent the same output as <paramref name="Bytes"/>.
 /// </param>
-public readonly record struct WorkloadOutputItem(ReadOnlyMemory<byte> Bytes, IReadOnlyList<AnsiToken>? Tokens);
+public readonly record struct WorkloadOutputItem(
+    ReadOnlyMemory<byte> Bytes,
+    IReadOnlyList<AnsiToken>? Tokens)
+{
+    /// <summary>
+    /// Optional pooled array backing <see cref="Bytes"/>. When non-null, the terminal returns
+    /// it to <see cref="System.Buffers.ArrayPool{T}.Shared"/> after the bytes have been fully
+    /// forwarded. This is an internal mechanism used by the in-process Hex1bApp ↔ Hex1bTerminal
+    /// bridge to avoid per-frame LOH allocations for large ANSI output buffers (a busy
+    /// fullscreen frame is well over the 85KB LOH threshold). External workload adapters
+    /// should not set this — they should manage any pooling internally and present
+    /// <see cref="Bytes"/> as a stable window valid until their next read call.
+    /// </summary>
+    internal byte[]? PooledBuffer { get; init; }
+
+    /// <summary>
+    /// Optional pooled token list backing <see cref="Tokens"/>. When non-null, the terminal
+    /// returns it to the originating <see cref="Hex1bApp"/> via
+    /// <see cref="Hex1bApp.ReturnTokenList"/> after consumption. Same purpose and constraints
+    /// as <see cref="PooledBuffer"/>: this is an internal in-process mechanism and external
+    /// workload adapters should leave it null.
+    /// </summary>
+    internal List<AnsiToken>? PooledTokens { get; init; }
+
+    /// <summary>
+    /// Internal callback the consumer invokes to return <see cref="PooledTokens"/> to its
+    /// owning pool. Decoupled from <see cref="Hex1bApp"/> to avoid a circular type reference.
+    /// </summary>
+    internal Action<List<AnsiToken>>? PooledTokensReturn { get; init; }
+}
 

--- a/src/content/guide/widgets/snippets/figlet-custom-font.cs
+++ b/src/content/guide/widgets/snippets/figlet-custom-font.cs
@@ -2,7 +2,7 @@
 var customFont = await FigletFont.LoadFileAsync("fonts/colossal.flf");
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
         ctx.FigletText("Hi!").Font(customFont))
     .Build();
 

--- a/src/content/guide/widgets/snippets/markdown-document.cs
+++ b/src/content/guide/widgets/snippets/markdown-document.cs
@@ -5,7 +5,7 @@ var document = new Hex1bDocument("# Hello\n\nInitial content.");
 var editorState = new EditorState(document);
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx =>
+    .WithHex1bApp(ctx =>
         ctx.HSplitter(
             ctx.Editor(editorState),
             ctx.VScrollPanel(ctx.Markdown(document)),

--- a/src/content/guide/widgets/snippets/progress-theming.cs
+++ b/src/content/guide/widgets/snippets/progress-theming.cs
@@ -6,10 +6,9 @@ var theme = new Hex1bThemeBuilder()
     .Build();
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => {
-        options.Theme = theme;
-        return ctx => ctx.Progress(60);
-    })
+    .WithHex1bApp(
+        options => options.Theme = theme,
+        ctx => ctx.Progress(60))
     .Build();
 
 await terminal.RunAsync();

--- a/src/content/guide/widgets/snippets/responsive-basic.cs
+++ b/src/content/guide/widgets/snippets/responsive-basic.cs
@@ -1,7 +1,7 @@
 using Hex1b;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.Responsive(r => [
+    .WithHex1bApp(ctx => ctx.Responsive(r => [
         r.WhenMinWidth(80, r => 
             r.Text("Wide layout - Terminal width >= 80 columns")
         ),

--- a/src/content/guide/widgets/snippets/responsive-custom.cs
+++ b/src/content/guide/widgets/snippets/responsive-custom.cs
@@ -1,7 +1,7 @@
 using Hex1b;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.Responsive(r => [
+    .WithHex1bApp(ctx => ctx.Responsive(r => [
         // Custom condition: Both width and height
         r.When(
             (width, height) => width >= 100 && height >= 20,

--- a/src/content/guide/widgets/snippets/responsive-layout.cs
+++ b/src/content/guide/widgets/snippets/responsive-layout.cs
@@ -1,7 +1,7 @@
 using Hex1b;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.Responsive(r => [
+    .WithHex1bApp(ctx => ctx.Responsive(r => [
         // Wide layout: Horizontal split
         r.WhenMinWidth(100, r =>
             r.HStack(h => [

--- a/src/content/guide/widgets/snippets/responsive-multiple.cs
+++ b/src/content/guide/widgets/snippets/responsive-multiple.cs
@@ -1,7 +1,7 @@
 using Hex1b;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.Responsive(r => [
+    .WithHex1bApp(ctx => ctx.Responsive(r => [
         // Extra wide: Three columns
         r.WhenMinWidth(120, r =>
             r.HStack(h => [

--- a/src/content/guide/widgets/snippets/terminal-basic.cs
+++ b/src/content/guide/widgets/snippets/terminal-basic.cs
@@ -11,7 +11,7 @@ _ = terminal.RunAsync();
 
 // Use the widget in your Hex1bApp
 await using var app = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => 
+    .WithHex1bApp(ctx => 
         ctx.Border(
             ctx.Terminal(bashHandle)
         ).Title("Embedded Terminal"))

--- a/src/content/guide/widgets/snippets/toggle-switch-binary.cs
+++ b/src/content/guide/widgets/snippets/toggle-switch-binary.cs
@@ -3,7 +3,7 @@ using Hex1b;
 string power = "Off";
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+    .WithHex1bApp(ctx => ctx.VStack(v => [
         v.Text("Binary Toggle Example"),
         v.Text(""),
         v.HStack(h => [

--- a/src/content/guide/widgets/snippets/toggle-switch-focus.cs
+++ b/src/content/guide/widgets/snippets/toggle-switch-focus.cs
@@ -1,7 +1,7 @@
 using Hex1b;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+    .WithHex1bApp(ctx => ctx.VStack(v => [
         v.Text("Unfocused:"),
         v.ToggleSwitch(["Off", "On"], selectedIndex: 1),
         v.Text(""),

--- a/src/content/guide/widgets/snippets/toggle-switch-modes.cs
+++ b/src/content/guide/widgets/snippets/toggle-switch-modes.cs
@@ -3,7 +3,7 @@ using Hex1b;
 string mode = "Auto";
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+    .WithHex1bApp(ctx => ctx.VStack(v => [
         v.Text("Mode Selection Example"),
         v.Text(""),
         v.HStack(h => [

--- a/src/content/guide/widgets/snippets/toggle-switch-multi.cs
+++ b/src/content/guide/widgets/snippets/toggle-switch-multi.cs
@@ -1,7 +1,7 @@
 using Hex1b;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+    .WithHex1bApp(ctx => ctx.VStack(v => [
         v.Text("Speed Settings:"),
         v.ToggleSwitch(["Slow", "Normal", "Fast"], selectedIndex: 1)
     ]))

--- a/src/content/guide/widgets/snippets/toggle-switch-settings.cs
+++ b/src/content/guide/widgets/snippets/toggle-switch-settings.cs
@@ -4,7 +4,7 @@ string theme = "Light";
 string sound = "On";
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+    .WithHex1bApp(ctx => ctx.VStack(v => [
         v.Text("Settings Panel"),
         v.Text(""),
         v.HStack(h => [

--- a/tests/Hex1b.Tests/AccordionNodeTests.cs
+++ b/tests/Hex1b.Tests/AccordionNodeTests.cs
@@ -300,7 +300,7 @@ public class AccordionIntegrationTests
     public async Task Accordion_BasicRender_ShowsSectionTitles()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.Accordion(a => [
+            .WithHex1bApp(ctx => ctx.Accordion(a => [
                 a.Section(s => [s.Text("Content 1")]).Title("Section A"),
                 a.Section(s => [s.Text("Content 2")]).Title("Section B"),
             ]))
@@ -330,7 +330,7 @@ public class AccordionKeyboardTests
     public async Task Accordion_EnterKey_TogglesSections()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.Accordion(a => [
+            .WithHex1bApp(ctx => ctx.Accordion(a => [
                 a.Section(s => [s.Text("Content A")]).Title("First"),
                 a.Section(s => [s.Text("Content B")]).Title("Second"),
             ]))
@@ -370,7 +370,7 @@ public class AccordionLayoutTests
         // Regression: VStack measures children with maxHeight=int.MaxValue,
         // which caused accordion to freeze trying to distribute infinite space.
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+            .WithHex1bApp(ctx => ctx.VStack(v => [
                 v.Text("Title"),
                 v.Separator(),
                 v.HStack(h => [

--- a/tests/Hex1b.Tests/CopyModeBindingsFunctionalTests.cs
+++ b/tests/Hex1b.Tests/CopyModeBindingsFunctionalTests.cs
@@ -49,7 +49,9 @@ public class CopyModeBindingsFunctionalTests
             CopyModeTestContext? capturedContext = null;
 
             var builder = Hex1bTerminal.CreateBuilder()
-                .WithHex1bApp((app, options) =>
+                .WithHex1bApp(
+                    _ => { },
+                    app =>
                 {
                     if (capturedContext != null)
                         capturedContext.App = app;

--- a/tests/Hex1b.Tests/DiagnosticShellIntegrationTests.cs
+++ b/tests/Hex1b.Tests/DiagnosticShellIntegrationTests.cs
@@ -287,7 +287,9 @@ public class DiagnosticShellIntegrationTests
             
             // Create the outer terminal (runs the Hex1bApp with TerminalWidget)
             var outerTerminal = Hex1bTerminal.CreateBuilder()
-                .WithHex1bApp((app, options) =>
+                .WithHex1bApp(
+                    _ => { },
+                    app =>
                 {
                     // Capture the app for test access
                     if (capturedContext != null)

--- a/tests/Hex1b.Tests/EditorNodeRenderingTests.cs
+++ b/tests/Hex1b.Tests/EditorNodeRenderingTests.cs
@@ -484,7 +484,13 @@ public class EditorNodeRenderingTests
 
         node.Render(context);
 
-        var pattern = new CellPatternSearcher().Find("L1");
+        // Wait for the LAST line ("L3") to be parsed, not the first.
+        // The render pipeline is asynchronous: node.Render() enqueues many
+        // ANSI fragments which are drained by a background pump. Waiting for
+        // "L1" (which is rendered first) can return before "L3" has been
+        // applied, leaving row 2 still blank when the snapshot is captured.
+        // Waiting for the last-rendered marker is the deterministic gate.
+        var pattern = new CellPatternSearcher().Find("L3");
         await new Hex1bTerminalInputSequenceBuilder()
             .WaitUntil(s => s.SearchPattern(pattern).HasMatches,
                 TimeSpan.FromSeconds(2), "first 3 lines visible")

--- a/tests/Hex1b.Tests/Flow/FlowResizeRowOriginFeasibilityTests.cs
+++ b/tests/Hex1b.Tests/Flow/FlowResizeRowOriginFeasibilityTests.cs
@@ -1,0 +1,243 @@
+using Hex1b.Flow;
+
+namespace Hex1b.Tests.Flow;
+
+/// <summary>
+/// Feasibility tests for the resize-handler design described in
+/// <c>plan.md</c>: confirms that <see cref="FlowResizeMath.ComputeRowOriginAtWidth"/>
+/// correctly predicts where the top of the active step will land on screen
+/// after the host terminal reflows the tombstones above it at a new width.
+/// <para/>
+/// The whole "track-and-clear on every event, repaint on settle" design
+/// hinges on this primitive being correct. If these tests fail, none of the
+/// downstream debounce / placeholder / marker work matters — we'd need to
+/// fall back to a CPR-based approach instead.
+/// <para/>
+/// We validate the math against a separate reference simulator
+/// (<see cref="FakeReflowTerminal"/>) that performs reflow on a true 2D grid
+/// by writing characters cell-by-cell. That gives an independent oracle:
+/// the formula and the simulator can't drift in lockstep because the
+/// simulator never calls the formula.
+/// </summary>
+public class FlowResizeRowOriginFeasibilityTests
+{
+    [Fact]
+    public void NoTombstones_RowOriginEqualsInitial()
+    {
+        var sim = new FakeReflowTerminal(width: 80, initialCursorRow: 0);
+        sim.MarkActiveWidgetTop();
+
+        var actual = ComputeOrigin(initial: 0, sim, width: 80);
+        Assert.Equal(sim.ActiveWidgetRow, actual);
+        Assert.Equal(0, actual);
+    }
+
+    [Fact]
+    public void ShortTombstone_FitsAtBothWidths()
+    {
+        var sim = new FakeReflowTerminal(width: 80, initialCursorRow: 0);
+        sim.WriteParagraph("hello");
+        sim.MarkActiveWidgetTop();
+
+        foreach (var width in new[] { 80, 40, 20, 10, 6 })
+        {
+            sim.Resize(width);
+            var math = ComputeOrigin(initial: 0, sim, width);
+            Assert.Equal(sim.ActiveWidgetRow, math);
+            Assert.Equal(1, math);
+        }
+    }
+
+    [Fact]
+    public void LongSingleParagraph_WrapsWhenWidthShrinks()
+    {
+        var sim = new FakeReflowTerminal(width: 80, initialCursorRow: 0);
+        sim.WriteParagraph(new string('x', 60));
+        sim.MarkActiveWidgetTop();
+
+        sim.Resize(80);
+        Assert.Equal(1, sim.ActiveWidgetRow);
+        Assert.Equal(1, ComputeOrigin(0, sim, 80));
+
+        sim.Resize(40);
+        Assert.Equal(2, sim.ActiveWidgetRow);
+        Assert.Equal(2, ComputeOrigin(0, sim, 40));
+
+        sim.Resize(20);
+        Assert.Equal(3, sim.ActiveWidgetRow);
+        Assert.Equal(3, ComputeOrigin(0, sim, 20));
+    }
+
+    [Fact]
+    public void MultiParagraph_MixedWidths()
+    {
+        var sim = new FakeReflowTerminal(width: 40, initialCursorRow: 0);
+        sim.WriteParagraph(new string('a', 10));
+        sim.WriteParagraph(new string('b', 60));
+        sim.WriteParagraph(new string('c', 5));
+        sim.MarkActiveWidgetTop();
+
+        Assert.Equal(4, sim.ActiveWidgetRow); // 1 + 2 + 1
+        Assert.Equal(sim.ActiveWidgetRow, ComputeOrigin(0, sim, 40));
+    }
+
+    [Fact]
+    public void DragResizeSequence_OriginTracksSimulator()
+    {
+        var sim = new FakeReflowTerminal(width: 80, initialCursorRow: 0);
+        // Three paragraphs of varying widths.
+        sim.WriteParagraph(new string('a', 35));
+        sim.WriteParagraph(new string('b', 70));
+        sim.WriteParagraph(new string('c', 12));
+        sim.MarkActiveWidgetTop();
+
+        foreach (var width in new[] { 80, 70, 60, 50, 40, 30, 25, 20, 15, 10, 30, 80 })
+        {
+            sim.Resize(width);
+            Assert.Equal(sim.ActiveWidgetRow, ComputeOrigin(0, sim, width));
+        }
+    }
+
+    [Fact]
+    public void WidthGrows_PreviouslyWrappedParagraphUnwraps()
+    {
+        var sim = new FakeReflowTerminal(width: 40, initialCursorRow: 0);
+        sim.WriteParagraph(new string('x', 60));
+        sim.MarkActiveWidgetTop();
+
+        sim.Resize(40);
+        Assert.Equal(2, sim.ActiveWidgetRow);
+        Assert.Equal(2, ComputeOrigin(0, sim, 40));
+
+        sim.Resize(80);
+        Assert.Equal(1, sim.ActiveWidgetRow);
+        Assert.Equal(1, ComputeOrigin(0, sim, 80));
+    }
+
+    [Fact]
+    public void RandomWalk_NoCumulativeDrift()
+    {
+        // Deterministic seed so the test is reproducible.
+        var rng = new Random(0xBEEF);
+        var sim = new FakeReflowTerminal(width: 80, initialCursorRow: 5);
+        for (var i = 0; i < 7; i++)
+        {
+            sim.WriteParagraph(new string('p', rng.Next(0, 200)));
+        }
+        sim.MarkActiveWidgetTop();
+
+        for (var step = 0; step < 50; step++)
+        {
+            var width = rng.Next(4, 200);
+            sim.Resize(width);
+            var simRow = sim.ActiveWidgetRow;
+            var mathRow = ComputeOrigin(initial: 5, sim, width);
+            Assert.True(
+                simRow == mathRow,
+                $"step={step} width={width} sim={simRow} math={mathRow}");
+        }
+    }
+
+    [Fact]
+    public void EmptyParagraph_StillTakesOneRow()
+    {
+        var sim = new FakeReflowTerminal(width: 40, initialCursorRow: 0);
+        sim.WriteParagraph("");
+        sim.MarkActiveWidgetTop();
+
+        Assert.Equal(1, sim.ActiveWidgetRow);
+        Assert.Equal(1, ComputeOrigin(0, sim, 40));
+    }
+
+    [Fact]
+    public void ParagraphExactlyTerminalWidth_DoesNotForceExtraRow()
+    {
+        var sim = new FakeReflowTerminal(width: 40, initialCursorRow: 0);
+        sim.WriteParagraph(new string('x', 40));
+        sim.MarkActiveWidgetTop();
+
+        Assert.Equal(1, sim.ActiveWidgetRow);
+        Assert.Equal(1, ComputeOrigin(0, sim, 40));
+    }
+
+    private static int ComputeOrigin(int initial, FakeReflowTerminal sim, int width)
+    {
+        return FlowResizeMath.ComputeRowOriginAtWidth(
+            initial,
+            sim.TombstoneParagraphWidths,
+            width);
+    }
+
+    /// <summary>
+    /// Reference reflow simulator: writes characters into an infinite 2D
+    /// grid, wrapping at the current terminal width, and treats CR+LF as a
+    /// hard paragraph boundary (the next character starts on a fresh row).
+    /// Mirrors the wrap behaviour every modern emulator surveyed in the
+    /// resize research uses for hard-newline-terminated paragraphs.
+    /// </summary>
+    private sealed class FakeReflowTerminal
+    {
+        private readonly List<string> _paragraphs = new();
+        private readonly int _initialCursorRow;
+        private int _markedParagraphCount = -1;
+
+        public FakeReflowTerminal(int width, int initialCursorRow)
+        {
+            Width = width;
+            _initialCursorRow = initialCursorRow;
+        }
+
+        public int Width { get; private set; }
+
+        public void WriteParagraph(string text) => _paragraphs.Add(text);
+
+        public void MarkActiveWidgetTop() => _markedParagraphCount = _paragraphs.Count;
+
+        public void Resize(int width)
+        {
+            if (width < 1) throw new ArgumentOutOfRangeException(nameof(width));
+            Width = width;
+        }
+
+        public IReadOnlyList<IReadOnlyList<int>> TombstoneParagraphWidths =>
+            _paragraphs
+                .Take(_markedParagraphCount < 0 ? _paragraphs.Count : _markedParagraphCount)
+                .Select(p => (IReadOnlyList<int>)new[] { p.Length })
+                .ToList();
+
+        /// <summary>
+        /// Independently computes the display row of the active widget by
+        /// simulating cell-by-cell writes into a width-bounded grid, then
+        /// returning the cursor row after the last paragraph above the
+        /// active widget. Crucially does NOT call ComputeRowOriginAtWidth.
+        /// </summary>
+        public int ActiveWidgetRow
+        {
+            get
+            {
+                var row = _initialCursorRow;
+                var col = 0;
+                var stop = _markedParagraphCount < 0 ? _paragraphs.Count : _markedParagraphCount;
+
+                for (var i = 0; i < stop; i++)
+                {
+                    var text = _paragraphs[i];
+                    foreach (var _ in text)
+                    {
+                        if (col == Width)
+                        {
+                            row++;
+                            col = 0;
+                        }
+                        col++;
+                    }
+                    // Hard newline: paragraph boundary always advances to a fresh row,
+                    // regardless of whether the current row had content.
+                    row++;
+                    col = 0;
+                }
+                return row;
+            }
+        }
+    }
+}

--- a/tests/Hex1b.Tests/Flow/FlowRunnerResizeHarnessTests.cs
+++ b/tests/Hex1b.Tests/Flow/FlowRunnerResizeHarnessTests.cs
@@ -1,0 +1,233 @@
+using System.Collections.Concurrent;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Channels;
+using Hex1b;
+using Hex1b.Flow;
+using Hex1b.Input;
+using Hex1b.Widgets;
+using Xunit;
+
+namespace Hex1b.Tests.Flow;
+
+/// <summary>
+/// Minimal in-process harness that wires up <see cref="Hex1bFlowRunner"/>
+/// against a fake parent adapter (<see cref="RecordingParentAdapter"/>)
+/// which captures every byte the runner writes during the lifecycle.
+/// Designed to answer one question: <b>what side effects does the runner
+/// emit to the parent terminal during a resize event burst?</b>
+/// </summary>
+/// <remarks>
+/// The harness deliberately ignores everything the inner Hex1bApp/step
+/// adapter writes (those bytes are captured separately and asserted on
+/// their own) so test assertions can focus on the runner's own
+/// resize-handling discipline without being noised up by the inner app's
+/// continuous render output.
+/// </remarks>
+public class FlowRunnerResizeHarnessTests
+{
+    [Fact]
+    public async Task PerEventDuringDrag_DoesNotEmitBytesThatWouldScrollHostTerminal()
+    {
+        var adapter = new RecordingParentAdapter(width: 80, height: 24);
+
+        var stepStarted = new TaskCompletionSource();
+        FlowStep? step = null;
+
+        var runner = new Hex1bFlowRunner(
+            flowCallback: async flow =>
+            {
+                await flow.ShowAsync(ctx => ctx.Text("HEADER"));
+
+                step = flow.Step(ctx => ctx.Text("ACTIVE"));
+                stepStarted.SetResult();
+                await step.WaitForCompletionAsync();
+            },
+            options: new Hex1bFlowOptions
+            {
+                UseSoftWrapTombstones = true,
+                InitialCursorRow = 0,
+                ResizeSettleDelay = TimeSpan.FromMilliseconds(60),
+            },
+            parentAdapter: adapter);
+
+        var runTask = runner.RunAsync(CancellationToken.None);
+
+        // Let the flow get into the active step.
+        await stepStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await Task.Delay(50); // small grace for the step to render its first frame.
+
+        var beforeBurst = adapter.SnapshotWrites();
+
+        // Simulate a drag: shrink the terminal across multiple events.
+        // Width shrinks each tick — the very pattern that, in the bug,
+        // caused the runner's bottom-overflow handler to emit a "\n" at
+        // the bottom row and scroll the tombstones above off-screen.
+        for (int w = 78; w >= 40; w -= 2)
+        {
+            adapter.SetSize(w, 24);
+            await adapter.PushEventAsync(new Hex1bResizeEvent(w, 24));
+            await Task.Delay(5); // tighter than the 60ms settle window
+        }
+
+        // Capture writes that the runner emitted during the burst,
+        // BEFORE the settle pass fires. The settle pass writes its own
+        // (legitimate) clear+repaint sequence which we don't want to
+        // mistake for a per-event scroll.
+        var duringBurstWrites = adapter.SnapshotWritesSince(beforeBurst);
+        var duringBurst = string.Concat(duringBurstWrites);
+
+        // The runner's per-event discipline: at most a cursor-hide. No
+        // newlines, no ESC[J, no ESC[2K, no SetCursorPosition.
+        Assert.DoesNotContain("\n", duringBurst);
+        Assert.DoesNotContain("\x1b[J", duringBurst);
+        Assert.DoesNotContain("\x1b[2K", duringBurst);
+        Assert.DoesNotContain("\x1b[K", duringBurst);
+        Assert.False(
+            Regex.IsMatch(duringBurst, @"\x1b\[\d+;\d+H"),
+            "Runner must not emit CUP (cursor position) during a resize burst.");
+
+        // Let settle fire.
+        await Task.Delay(150);
+
+        step!.Complete();
+        await runTask.WaitAsync(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public async Task DuringDrag_RunnerDisablesDECAWM_SoStaleInnerAppOutputCannotScrollTombstones()
+    {
+        // The inner Hex1bApp keeps emitting frames during a drag (focus
+        // blink, animations, etc.). If the terminal has been shrunk and
+        // DECAWM is on, that stale wide content wraps at the new right
+        // edge — and any wrap that lands on the bottom row scrolls the
+        // buffer, pushing the tombstones above off-screen. The runner
+        // must defensively turn DECAWM off for the duration of the drag.
+        var adapter = new RecordingParentAdapter(width: 80, height: 24);
+
+        var stepStarted = new TaskCompletionSource();
+        FlowStep? step = null;
+
+        var runner = new Hex1bFlowRunner(
+            flowCallback: async flow =>
+            {
+                await flow.ShowAsync(ctx => ctx.Text("HEADER"));
+
+                step = flow.Step(ctx => ctx.Text("ACTIVE"));
+                stepStarted.SetResult();
+                await step.WaitForCompletionAsync();
+            },
+            options: new Hex1bFlowOptions
+            {
+                UseSoftWrapTombstones = true,
+                InitialCursorRow = 0,
+                ResizeSettleDelay = TimeSpan.FromMilliseconds(60),
+            },
+            parentAdapter: adapter);
+
+        var runTask = runner.RunAsync(CancellationToken.None);
+
+        await stepStarted.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await Task.Delay(50);
+
+        var beforeBurst = adapter.SnapshotWrites();
+
+        adapter.SetSize(60, 24);
+        await adapter.PushEventAsync(new Hex1bResizeEvent(60, 24));
+        await Task.Delay(5);
+
+        // Per-event must have disabled DECAWM. We assert this BEFORE the
+        // settle window fires so the assertion can't be satisfied by the
+        // settle pass's own DECAWM toggling.
+        var perEventWrites = string.Concat(adapter.SnapshotWritesSince(beforeBurst));
+        Assert.Contains("\x1b[?7l", perEventWrites);
+
+        // And the per-event pass must NOT have re-enabled it (otherwise
+        // the rest of the drag is unprotected). Only the settle pass is
+        // allowed to turn DECAWM back on.
+        Assert.DoesNotContain("\x1b[?7h", perEventWrites);
+
+        // Wait for settle and assert DECAWM is re-enabled.
+        await Task.Delay(150);
+        var fullWrites = string.Concat(adapter.SnapshotWritesSince(beforeBurst));
+        Assert.Contains("\x1b[?7h", fullWrites);
+
+        step!.Complete();
+        await runTask.WaitAsync(TimeSpan.FromSeconds(2));
+    }
+}
+
+/// <summary>
+/// Records every <c>Write</c> call against a synthetic parent adapter and
+/// exposes a settable <c>Width</c>/<c>Height</c> plus a writable input
+/// event channel — the minimum surface the flow runner needs to observe a
+/// "resize burst" in a unit test.
+/// </summary>
+internal sealed class RecordingParentAdapter : IHex1bAppTerminalWorkloadAdapter
+{
+    private readonly Channel<Hex1bEvent> _inputChannel = Channel.CreateUnbounded<Hex1bEvent>();
+    private readonly ConcurrentQueue<string> _writes = new();
+    private int _width;
+    private int _height;
+
+    public RecordingParentAdapter(int width, int height)
+    {
+        _width = width;
+        _height = height;
+    }
+
+    public int Width => _width;
+    public int Height => _height;
+    public TerminalCapabilities Capabilities { get; } = TerminalCapabilities.Modern;
+    public ChannelReader<Hex1bEvent> InputEvents => _inputChannel.Reader;
+    public int OutputQueueDepth => 0;
+
+    public event Action? Disconnected;
+
+    public void Write(string text) => _writes.Enqueue(text);
+    public void Write(ReadOnlySpan<byte> data) => _writes.Enqueue(Encoding.UTF8.GetString(data));
+    public void Flush() { }
+
+    public void EnterTuiMode() { }
+    public void ExitTuiMode() { }
+    public void Clear() => _writes.Enqueue("\x1b[2J");
+    public void SetCursorPosition(int left, int top) =>
+        _writes.Enqueue($"\x1b[{top + 1};{left + 1}H");
+
+    public ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(CancellationToken ct = default)
+        => ValueTask.FromResult<ReadOnlyMemory<byte>>(ReadOnlyMemory<byte>.Empty);
+    public ValueTask WriteInputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+        => ValueTask.CompletedTask;
+    public ValueTask ResizeAsync(int width, int height, CancellationToken ct = default)
+    {
+        _width = width;
+        _height = height;
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _inputChannel.Writer.TryComplete();
+        Disconnected?.Invoke();
+        return ValueTask.CompletedTask;
+    }
+
+    public void SetSize(int width, int height)
+    {
+        _width = width;
+        _height = height;
+    }
+
+    public ValueTask PushEventAsync(Hex1bEvent evt) => _inputChannel.Writer.WriteAsync(evt);
+
+    /// <summary>Returns a snapshot count of writes so far.</summary>
+    public int SnapshotWrites() => _writes.Count;
+
+    /// <summary>Returns all writes captured since the supplied snapshot index.</summary>
+    public IReadOnlyList<string> SnapshotWritesSince(int snapshotIndex)
+    {
+        var all = _writes.ToArray();
+        if (snapshotIndex >= all.Length) return Array.Empty<string>();
+        return all.AsSpan(snapshotIndex).ToArray();
+    }
+}

--- a/tests/Hex1b.Tests/Flow/SoftWrapEmitterHardNewlineTests.cs
+++ b/tests/Hex1b.Tests/Flow/SoftWrapEmitterHardNewlineTests.cs
@@ -1,0 +1,78 @@
+using Hex1b.Flow;
+using Hex1b.Surfaces;
+
+namespace Hex1b.Tests.Flow;
+
+/// <summary>
+/// Pins the CR + LF hard-newline contract that <see cref="SoftWrapEmitter"/>
+/// must honour. The flow resize handler relies on every inter-row boundary
+/// in an emitted tombstone being terminated with <c>"\r\n"</c> (not a bare
+/// <c>"\n"</c>): hard-newline-terminated paragraphs are the *only* way
+/// xterm, Windows Terminal, VTE, iTerm2 and friends guarantee a row will
+/// not be reflowed across a resize. If someone accidentally changes the
+/// terminator to a bare LF, paragraph boundaries become soft-wrap state on
+/// the host's grid and the row-origin recompute described in
+/// <c>FlowResizeRowOriginFeasibilityTests</c> stops matching reality.
+/// </summary>
+public class SoftWrapEmitterHardNewlineTests
+{
+    [Fact]
+    public void Format_MultiRowSurface_TerminatesInteriorRowsWithCarriageReturnPlusLineFeed()
+    {
+        var surface = new Surface(20, 4);
+        surface.WriteText(0, 0, "row-0");
+        surface.WriteText(0, 1, "row-1");
+        surface.WriteText(0, 2, "row-2");
+        surface.WriteText(0, 3, "row-3");
+
+        var output = SoftWrapEmitter.Format(surface);
+
+        // Every interior row must be terminated with CR + LF.
+        Assert.Contains("row-0\x1b[K\r\n", output);
+        Assert.Contains("row-1\x1b[K\r\n", output);
+        Assert.Contains("row-2\x1b[K\r\n", output);
+
+        // The final row must NOT carry a trailing newline (deliberate — see
+        // SoftWrapEmitter remarks).
+        Assert.EndsWith("row-3\x1b[K\x1b[?25h", output);
+    }
+
+    [Fact]
+    public void Format_NoBareLineFeedsAtInteriorRowBoundaries()
+    {
+        // Walk the output looking for any inter-row boundary terminated by
+        // a bare LF (LF without an immediately preceding CR). Such a
+        // terminator would survive the existing happy-path assertions
+        // (which only check the *presence* of CR+LF) but break the
+        // hard-newline contract on hosts that don't auto-translate.
+        var surface = new Surface(12, 5);
+        for (var row = 0; row < 5; row++)
+        {
+            surface.WriteText(0, row, $"r{row}");
+        }
+
+        var output = SoftWrapEmitter.Format(surface);
+
+        for (var i = 0; i < output.Length; i++)
+        {
+            if (output[i] != '\n') continue;
+            Assert.True(i > 0 && output[i - 1] == '\r',
+                $"Bare LF found at index {i}; every LF must be preceded by CR. Output: {output.Replace("\x1b", "ESC")}");
+        }
+    }
+
+    [Fact]
+    public void Format_SingleRowSurface_HasNoLineTerminatorAtAll()
+    {
+        // Single-row case: the only row is also the last row, so no CR or
+        // LF should appear in the output. This pins the "no trailing
+        // newline on the final row" half of the contract.
+        var surface = new Surface(10, 1);
+        surface.WriteText(0, 0, "only");
+
+        var output = SoftWrapEmitter.Format(surface);
+
+        Assert.DoesNotContain("\r", output);
+        Assert.DoesNotContain("\n", output);
+    }
+}

--- a/tests/Hex1b.Tests/Hex1bAppWorkloadAdapterBackpressureTests.cs
+++ b/tests/Hex1b.Tests/Hex1bAppWorkloadAdapterBackpressureTests.cs
@@ -1,0 +1,103 @@
+using System.Buffers;
+using System.Diagnostics;
+using Hex1b;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Tests for the bounded output channel + backpressure behaviour on
+/// <see cref="Hex1bAppWorkloadAdapter"/>. The default is unbounded
+/// (back-compat), so most tests opt in via the constructor parameter.
+/// </summary>
+public class Hex1bAppWorkloadAdapterBackpressureTests
+{
+    [Fact]
+    public void Write_OnUnboundedAdapter_NeverBlocks()
+    {
+        using var adapter = new Hex1bAppWorkloadAdapter();
+        // Many writes without a reader should all enqueue immediately on
+        // the default unbounded channel.
+        for (var i = 0; i < 1000; i++)
+            adapter.Write("x");
+        Assert.Equal(1000, adapter.OutputQueueDepth);
+    }
+
+    [Fact]
+    public async Task Write_OnBoundedAdapter_BlocksProducerWhenFull()
+    {
+        using var adapter = new Hex1bAppWorkloadAdapter(maxQueuedOutputItems: 2);
+
+        // Fill the channel to capacity.
+        adapter.Write("a");
+        adapter.Write("b");
+        Assert.Equal(2, adapter.OutputQueueDepth);
+
+        // Producer thread - third write must block until a slot frees.
+        var producerStarted = new TaskCompletionSource();
+        var producerDone = new TaskCompletionSource();
+        var producer = Task.Run(() =>
+        {
+            producerStarted.SetResult();
+            adapter.Write("c"); // expected to block
+            producerDone.SetResult();
+        });
+
+        await producerStarted.Task;
+        // Give the producer time to attempt the write and block on the channel.
+        await Task.Delay(150);
+        Assert.False(producerDone.Task.IsCompleted, "Producer should be blocked while channel is full.");
+
+        // Drain one item; producer should unblock and complete.
+        var read = await adapter.TryReadOutputAsync(TimeSpan.FromSeconds(1));
+        Assert.True(read.HasValue);
+
+        await producerDone.Task.WaitAsync(TimeSpan.FromSeconds(2));
+        await producer;
+        Assert.Equal(2, adapter.OutputQueueDepth);
+    }
+
+    [Fact]
+    public async Task Write_OnBoundedAdapter_ChannelCompletionUnblocksProducer()
+    {
+        using var adapter = new Hex1bAppWorkloadAdapter(maxQueuedOutputItems: 1);
+
+        adapter.Write("a"); // fill capacity
+
+        var producer = Task.Run(() => adapter.Write("b")); // blocks
+
+        await Task.Delay(100);
+        Assert.False(producer.IsCompleted, "Producer should block until disposal unblocks it.");
+
+        // Disposing completes the writer, which should unblock the blocked
+        // write attempt without leaking resources or throwing out of the
+        // adapter API.
+        adapter.Dispose();
+        await producer.WaitAsync(TimeSpan.FromSeconds(2));
+    }
+
+    [Fact]
+    public void Constructor_NegativeMaxQueued_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new Hex1bAppWorkloadAdapter(maxQueuedOutputItems: -1));
+    }
+}
+
+internal static class BackpressureTestHelpers
+{
+    public static async Task<WorkloadOutputItem?> TryReadOutputAsync(this Hex1bAppWorkloadAdapter adapter, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        try
+        {
+            var item = await adapter.ReadOutputItemAsync(cts.Token);
+            if (item.Bytes.Length > 0 || item.Tokens is not null)
+                return item;
+        }
+        catch (OperationCanceledException)
+        {
+        }
+        return null;
+    }
+}

--- a/tests/Hex1b.Tests/Hex1bTerminalAutomatorTests.cs
+++ b/tests/Hex1b.Tests/Hex1bTerminalAutomatorTests.cs
@@ -13,7 +13,7 @@ public class Hex1bTerminalAutomatorTests
     public async Task WaitUntilTextAsync_WaitsForText()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Hello World"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Hello World"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -34,7 +34,7 @@ public class Hex1bTerminalAutomatorTests
     public async Task WaitUntilTextAsync_Timeout_ThrowsHex1bAutomationException()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Hello"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -214,7 +214,7 @@ public class Hex1bTerminalAutomatorTests
     public async Task WaitUntilAsync_WithCustomPredicate_Works()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Count: 42"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Count: 42"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -347,7 +347,7 @@ public class Hex1bTerminalAutomatorTests
     public async Task CompletedSteps_TracksCallerInfo()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Test"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Test"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -371,7 +371,7 @@ public class Hex1bTerminalAutomatorTests
     public async Task AutomationException_TotalElapsed_SumsAllSteps()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Hello"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -398,7 +398,7 @@ public class Hex1bTerminalAutomatorTests
     public async Task CreateSnapshot_ReturnsCurrentState()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Snapshot Test"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Snapshot Test"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -419,7 +419,7 @@ public class Hex1bTerminalAutomatorTests
     public async Task WaitUntilAsync_WithPredicateExpression_CapturesExpression()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Hello"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -474,7 +474,7 @@ public class Hex1bTerminalAutomatorTests
     public async Task WaitAsync_PausesForDuration()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Test"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Test"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();

--- a/tests/Hex1b.Tests/Hex1bTerminalBuilderTests.cs
+++ b/tests/Hex1b.Tests/Hex1bTerminalBuilderTests.cs
@@ -246,26 +246,26 @@ public class Hex1bTerminalBuilderTests
     [Fact]
     public async Task WithHex1bApp_NullConfigure_ThrowsArgumentNullException()
     {
-        Func<Hex1bApp, Hex1bAppOptions, Func<RootContext, Hex1bWidget>>? nullConfigure = null;
+        Func<RootContext, Hex1bWidget>? nullBuilder = null;
         
         Assert.Throws<ArgumentNullException>(() =>
-            Hex1bTerminal.CreateBuilder().WithHex1bApp(nullConfigure!));
+            Hex1bTerminal.CreateBuilder().WithHex1bApp(nullBuilder!));
     }
 
     [Fact]
     public async Task WithHex1bApp_AsyncNullConfigure_ThrowsArgumentNullException()
     {
-        Func<Hex1bApp, Hex1bAppOptions, Func<RootContext, Task<Hex1bWidget>>>? nullConfigure = null;
+        Func<RootContext, Task<Hex1bWidget>>? nullBuilder = null;
         
         Assert.Throws<ArgumentNullException>(() =>
-            Hex1bTerminal.CreateBuilder().WithHex1bApp(nullConfigure!));
+            Hex1bTerminal.CreateBuilder().WithHex1bApp(nullBuilder!));
     }
 
     [Fact]
     public async Task WithHex1bApp_ReturnsBuilder()
     {
         var result = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.Text("Hello"));
+            .WithHex1bApp(ctx => ctx.Text("Hello"));
         
         Assert.IsType<Hex1bTerminalBuilder>(result);
     }
@@ -275,7 +275,7 @@ public class Hex1bTerminalBuilderTests
     {
         // Should not throw - uses explicit presentation
         var builder = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.Text("Hello"))
+            .WithHex1bApp(ctx => ctx.Text("Hello"))
             .WithPresentation(new TestPresentationAdapter());
         
         using var terminal = builder.Build();
@@ -289,7 +289,7 @@ public class Hex1bTerminalBuilderTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
         
         var builder = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => async ctx =>
+            .WithHex1bApp(async ctx =>
             {
                 builderCalled = true;
                 await Task.Yield();
@@ -313,7 +313,7 @@ public class Hex1bTerminalBuilderTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
         
         var builder = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx =>
+            .WithHex1bApp(ctx =>
             {
                 builderCalled = true;
                 return ctx.Text("Hello");
@@ -343,7 +343,7 @@ public class Hex1bTerminalBuilderTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
         
         var builder = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.Text("Hello"))
+            .WithHex1bApp(ctx => ctx.Text("Hello"))
             .WithMouse(true)
             .WithDimensions(100, 40)
             .AddWorkloadFilter(filter)
@@ -364,7 +364,9 @@ public class Hex1bTerminalBuilderTests
         var pattern = new CellPatternSearcher().Find("Hello from captured app");
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) =>
+            .WithHex1bApp(
+                _ => { },
+                app =>
             {
                 capturedApp = app;
                 return ctx => ctx.Text("Hello from captured app");
@@ -392,12 +394,9 @@ public class Hex1bTerminalBuilderTests
         var pattern = new CellPatternSearcher().Find("Themed content");
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) =>
-            {
-                // Setting Theme should work (it's not a restricted property)
-                options.Theme = new Hex1b.Theming.Hex1bTheme("TestTheme");
-                return ctx => ctx.Text("Themed content");
-            })
+            .WithHex1bApp(
+                options => options.Theme = new Hex1b.Theming.Hex1bTheme("TestTheme"),
+                ctx => ctx.Text("Themed content"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -420,7 +419,9 @@ public class Hex1bTerminalBuilderTests
         var pattern = new CellPatternSearcher().Find("Async Hello World");
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) =>
+            .WithHex1bApp(
+                _ => { },
+                app =>
             {
                 capturedApp = app;
                 return async ctx =>
@@ -979,7 +980,7 @@ public class Hex1bTerminalBuilderTests
         try
         {
             var result = Hex1bTerminal.CreateBuilder()
-                .WithHex1bApp((app, options) => ctx => ctx.Text("Hello"))
+                .WithHex1bApp(ctx => ctx.Text("Hello"))
                 .WithAsciinemaRecording(tempFile);
 
             Assert.IsType<Hex1bTerminalBuilder>(result);
@@ -1012,7 +1013,7 @@ public class Hex1bTerminalBuilderTests
         {
             AsciinemaRecorder? capturedRecorder = null;
             var result = Hex1bTerminal.CreateBuilder()
-                .WithHex1bApp((app, options) => ctx => ctx.Text("Hello"))
+                .WithHex1bApp(ctx => ctx.Text("Hello"))
                 .WithAsciinemaRecording(tempFile, r => capturedRecorder = r);
 
             Assert.IsType<Hex1bTerminalBuilder>(result);
@@ -1041,7 +1042,7 @@ public class Hex1bTerminalBuilderTests
             var pattern = new CellPatternSearcher().Find("Recorded");
 
             await using (var terminal = Hex1bTerminal.CreateBuilder()
-                .WithHex1bApp((app, options) => ctx => ctx.Text("Recorded"))
+                .WithHex1bApp(ctx => ctx.Text("Recorded"))
                 .WithAsciinemaRecording(tempFile, r => recorder = r, new AsciinemaRecorderOptions
                 {
                     Title = "Test Recording",
@@ -1086,7 +1087,7 @@ public class Hex1bTerminalBuilderTests
             AsciinemaRecorder? recorder = null;
 
             var result = Hex1bTerminal.CreateBuilder()
-                .WithHex1bApp((app, options) => ctx => ctx.Text("Hello"))
+                .WithHex1bApp(ctx => ctx.Text("Hello"))
                 .WithAsciinemaRecording(tempFile, r => recorder = r, new AsciinemaRecorderOptions
                 {
                     Title = "Custom Title",
@@ -1118,7 +1119,7 @@ public class Hex1bTerminalBuilderTests
             var pattern = new CellPatternSearcher().Find("Full chain");
 
             await using var terminal = Hex1bTerminal.CreateBuilder()
-                .WithHex1bApp((app, options) => ctx => ctx.Text("Full chain"))
+                .WithHex1bApp(ctx => ctx.Text("Full chain"))
                 .WithAsciinemaRecording(tempFile, r => recorder = r, new AsciinemaRecorderOptions
                 {
                     Title = "Chain Test",

--- a/tests/Hex1b.Tests/InfoBarWidgetTests.cs
+++ b/tests/Hex1b.Tests/InfoBarWidgetTests.cs
@@ -16,7 +16,7 @@ public class InfoBarWidgetTests
     public async Task InfoBar_SingleSection_RendersText()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.InfoBar("Ready"))
+            .WithHex1bApp(ctx => ctx.InfoBar("Ready"))
             .WithHeadless()
             .WithDimensions(40, 5)
             .Build();
@@ -39,7 +39,7 @@ public class InfoBarWidgetTests
     public async Task InfoBar_MultipleSections_RendersAll()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.InfoBar(s => [
+            .WithHex1bApp(ctx => ctx.InfoBar(s => [
                 s.Section("Mode: Insert"),
                 s.Divider(" | "),
                 s.Section("UTF-8"),
@@ -72,7 +72,7 @@ public class InfoBarWidgetTests
     public async Task InfoBar_Divider_InsertsDividersBetweenSections()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.InfoBar(s => [
+            .WithHex1bApp(ctx => ctx.InfoBar(s => [
                 s.Section("A"),
                 s.Section("B"),
                 s.Section("C")
@@ -106,7 +106,7 @@ public class InfoBarWidgetTests
     public async Task InfoBar_WithSpacer_PushesContentApart()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.InfoBar(s => [
+            .WithHex1bApp(ctx => ctx.InfoBar(s => [
                 s.Section("Left"),
                 s.Spacer(),
                 s.Section("Right")
@@ -143,11 +143,9 @@ public class InfoBarWidgetTests
             .Set(GlobalTheme.BackgroundColor, Hex1bColor.Black);
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) =>
-            {
-                options.Theme = theme;
-                return ctx => new InfoBarWidget([new InfoBarSectionWidget(new TextBlockWidget("Inverted"))], InvertColors: true);
-            })
+            .WithHex1bApp(
+                options => options.Theme = theme,
+                ctx => new InfoBarWidget([new InfoBarSectionWidget(new TextBlockWidget("Inverted"))], InvertColors: true))
             .WithHeadless()
             .WithDimensions(40, 5)
             .Build();
@@ -176,11 +174,9 @@ public class InfoBarWidgetTests
             .Set(GlobalTheme.BackgroundColor, Hex1bColor.Blue);
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) =>
-            {
-                options.Theme = theme;
-                return ctx => new InfoBarWidget([new InfoBarSectionWidget(new TextBlockWidget("Normal"))], InvertColors: false);
-            })
+            .WithHex1bApp(
+                options => options.Theme = theme,
+                ctx => new InfoBarWidget([new InfoBarSectionWidget(new TextBlockWidget("Normal"))], InvertColors: false))
             .WithHeadless()
             .WithDimensions(40, 5)
             .Build();
@@ -208,7 +204,7 @@ public class InfoBarWidgetTests
     public async Task InfoBar_SectionWithTheme_AppliesCustomColors()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.InfoBar(s => [
+            .WithHex1bApp(ctx => ctx.InfoBar(s => [
                 s.Section("Normal"),
                 s.Section("Error").Theme(t => t
                     .Set(GlobalTheme.ForegroundColor, Hex1bColor.Red)
@@ -245,7 +241,7 @@ public class InfoBarWidgetTests
     public async Task InfoBar_InVStack_PositionedCorrectly()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.VStack(v => [
+            .WithHex1bApp(ctx => ctx.VStack(v => [
                 v.Text("Main Content"),
                 v.InfoBar("Status Bar")
             ]))
@@ -276,7 +272,7 @@ public class InfoBarWidgetTests
     public async Task InfoBar_VariousTerminalSizes_RendersCorrectly(int width, int height)
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.InfoBar(s => [
+            .WithHex1bApp(ctx => ctx.InfoBar(s => [
                 s.Section("Mode"),
                 s.Spacer(),
                 s.Section("Ready")
@@ -313,11 +309,9 @@ public class InfoBarWidgetTests
             .Set(InfoBarTheme.BackgroundColor, Hex1bColor.DarkGray);
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) =>
-            {
-                options.Theme = theme;
-                return ctx => new InfoBarWidget([new InfoBarSectionWidget(new TextBlockWidget("Themed"))], InvertColors: false);
-            })
+            .WithHex1bApp(
+                options => options.Theme = theme,
+                ctx => new InfoBarWidget([new InfoBarSectionWidget(new TextBlockWidget("Themed"))], InvertColors: false))
             .WithHeadless()
             .WithDimensions(40, 5)
             .Build();
@@ -344,7 +338,7 @@ public class InfoBarWidgetTests
     public async Task InfoBar_SectionWithWidgetContent_RendersWidget()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.InfoBar(s => [
+            .WithHex1bApp(ctx => ctx.InfoBar(s => [
                 s.Section(x => x.HStack(h => [
                     h.Text("Status: "),
                     h.Text("OK")

--- a/tests/Hex1b.Tests/MenuBarIntegrationTests.cs
+++ b/tests/Hex1b.Tests/MenuBarIntegrationTests.cs
@@ -1302,7 +1302,7 @@ public class MenuBarIntegrationTests
     {
         // Arrange
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => CreateTestMenuBar(ctx, _ => { }, includeSubmenus: true))
+            .WithHex1bApp(ctx => CreateTestMenuBar(ctx, _ => { }, includeSubmenus: true))
             .WithHeadless()
             .WithDimensions(80, 24)
             .Build();

--- a/tests/Hex1b.Tests/PickerIntegrationTests.cs
+++ b/tests/Hex1b.Tests/PickerIntegrationTests.cs
@@ -15,7 +15,7 @@ public class PickerIntegrationTests
     {
         // Arrange & Act
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new PickerWidget(["Apple", "Banana", "Cherry"])
             ]))
             .WithHeadless()
@@ -45,7 +45,7 @@ public class PickerIntegrationTests
         var selectedText = "";
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new PickerWidget(["Apple", "Banana", "Cherry"])
                     .OnSelectionChanged(e => { selectedText = e.SelectedText; })
             ]))
@@ -81,7 +81,7 @@ public class PickerIntegrationTests
         var selectionChangedCount = 0;
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new PickerWidget(["Apple", "Banana", "Cherry"])
                     .OnSelectionChanged(e => { selectionChangedCount++; })
             ]))
@@ -117,15 +117,13 @@ public class PickerIntegrationTests
         var selectionChangedCount = 0;
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) =>
-            {
-                options.EnableMouse = true;
-                return ctx => new VStackWidget([
+            .WithHex1bApp(
+                options => options.EnableMouse = true,
+                ctx => new VStackWidget([
                     new TextBlockWidget("Click here to dismiss"),
                     new PickerWidget(["Apple", "Banana", "Cherry"])
                         .OnSelectionChanged(e => { selectionChangedCount++; })
-                ]);
-            })
+                ]))
             .WithHeadless()
             .WithDimensions(80, 24)
             .Build();
@@ -156,13 +154,11 @@ public class PickerIntegrationTests
     {
         // Arrange
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) =>
-            {
-                options.EnableMouse = true;
-                return ctx => new VStackWidget([
+            .WithHex1bApp(
+                options => options.EnableMouse = true,
+                ctx => new VStackWidget([
                     new PickerWidget(["Apple", "Banana", "Cherry"])
-                ]);
-            })
+                ]))
             .WithHeadless()
             .WithDimensions(80, 24)
             .Build();
@@ -226,7 +222,7 @@ public class PickerIntegrationTests
         var selectedText = "";
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new PickerWidget(["Apple", "Banana", "Cherry"])
                     .OnSelectionChanged(e => { selectedText = e.SelectedText; })
             ]))
@@ -258,7 +254,7 @@ public class PickerIntegrationTests
         var selectedText = "";
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new PickerWidget(["Apple", "Banana", "Cherry"]) { InitialSelectedIndex = 2 }
                     .OnSelectionChanged(e => { selectedText = e.SelectedText; })
             ]))
@@ -288,7 +284,7 @@ public class PickerIntegrationTests
     {
         // Arrange & Act
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new PickerWidget(["Apple", "Banana", "Cherry"])
             ]))
             .WithHeadless()
@@ -318,7 +314,7 @@ public class PickerIntegrationTests
     {
         // Arrange & Act
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new PickerWidget(["Apple", "Banana", "Cherry"])
             ]))
             .WithHeadless()
@@ -354,7 +350,7 @@ public class PickerIntegrationTests
         var selectedColor = "Red";
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new HStackWidget([
                     new TextBlockWidget("Fruit: "),
                     new PickerWidget(["Apple", "Banana", "Cherry"])
@@ -419,7 +415,7 @@ public class PickerIntegrationTests
         // bounding box stays painted by the dropdown's BackgroundPanel, even
         // after the selected row moves away.
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new PickerWidget(["Apple", "Banana", "Cherry"]),
                 new TextBlockWidget(""),
                 new TextBlockWidget(""),

--- a/tests/Hex1b.Tests/SgrTokenFastPathTests.cs
+++ b/tests/Hex1b.Tests/SgrTokenFastPathTests.cs
@@ -1,0 +1,61 @@
+using System.Text;
+using Hex1b.Tokens;
+using Xunit;
+
+namespace Hex1b.Tests;
+
+public class SgrTokenFastPathTests
+{
+    [Fact]
+    public void GetSgrTokenFromBytes_EmptySpan_ReturnsReset()
+    {
+        var token = AnsiTokenCache.GetSgrTokenFromBytes(ReadOnlySpan<byte>.Empty);
+        Assert.Same(SgrToken.Reset, token);
+    }
+
+    [Fact]
+    public void GetSgrTokenFromBytes_RoundTripsParameters()
+    {
+        ReadOnlySpan<byte> bytes = "38;2;255;128;64"u8;
+        var token = AnsiTokenCache.GetSgrTokenFromBytes(bytes);
+
+        Assert.Equal("38;2;255;128;64", token.Parameters);
+        Assert.NotNull(token.PreformattedBytes);
+        Assert.Equal(bytes.ToArray(), token.PreformattedBytes!);
+    }
+
+    [Fact]
+    public void GetSgrTokenFromBytes_SecondCallReturnsCachedInstance()
+    {
+        ReadOnlySpan<byte> bytes = "1;31"u8;
+        var first = AnsiTokenCache.GetSgrTokenFromBytes(bytes);
+        var second = AnsiTokenCache.GetSgrTokenFromBytes(bytes);
+        Assert.Same(first, second);
+    }
+
+    [Fact]
+    public void SgrToken_EqualityIgnoresPreformattedBytes()
+    {
+        var plain = new SgrToken("31");
+        var withBytes = new SgrToken("31") { PreformattedBytes = "31"u8.ToArray() };
+        Assert.Equal(plain, withBytes);
+        Assert.Equal(plain.GetHashCode(), withBytes.GetHashCode());
+    }
+
+    [Fact]
+    public void Serialize_UsesPreformattedBytes_WhenAvailable()
+    {
+        var token = new SgrToken("ignored-on-fast-path") { PreformattedBytes = "31"u8.ToArray() };
+        var bytes = AnsiTokenUtf8Serializer.Serialize(new[] { token });
+        // Should emit "\x1b[31m" using the PreformattedBytes, not the Parameters string.
+        Assert.Equal("\x1b[31m", Encoding.UTF8.GetString(bytes.Span));
+    }
+
+    [Fact]
+    public void Serialize_FallsBackToParameters_WhenPreformattedBytesNull()
+    {
+        var token = new SgrToken("1;38;2;255;0;0");
+        var bytes = AnsiTokenUtf8Serializer.Serialize(new[] { token });
+        Assert.Equal("\x1b[1;38;2;255;0;0m", Encoding.UTF8.GetString(bytes.Span));
+    }
+}

--- a/tests/Hex1b.Tests/SplitButtonIntegrationTests.cs
+++ b/tests/Hex1b.Tests/SplitButtonIntegrationTests.cs
@@ -51,7 +51,7 @@ public class SplitButtonIntegrationTests
     public async Task SplitButton_InitialRender_ShowsPrimaryLabelAndDropdownArrow()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([BuildButton()]))
+            .WithHex1bApp(ctx => new VStackWidget([BuildButton()]))
             .WithHeadless()
             .WithDimensions(40, 5)
             .Build();
@@ -85,7 +85,7 @@ public class SplitButtonIntegrationTests
     public async Task SplitButton_Focused_PaintsFocusedChipBackground()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([BuildButton()]))
+            .WithHex1bApp(ctx => new VStackWidget([BuildButton()]))
             .WithHeadless()
             .WithDimensions(40, 5)
             .Build();
@@ -123,7 +123,7 @@ public class SplitButtonIntegrationTests
     public async Task SplitButton_Unfocused_PaintsRestingChipBackground()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new ButtonWidget("Decoy"),
                 BuildButton(),
             ]))
@@ -163,7 +163,7 @@ public class SplitButtonIntegrationTests
     public async Task SplitButton_DownArrow_OpensDropdownWithBothOptionsVisible()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([BuildButton()]))
+            .WithHex1bApp(ctx => new VStackWidget([BuildButton()]))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -198,7 +198,7 @@ public class SplitButtonIntegrationTests
     public async Task SplitButton_DropdownOpen_DownArrow_MovesSelectionToOptionB()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([BuildButton()]))
+            .WithHex1bApp(ctx => new VStackWidget([BuildButton()]))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -232,7 +232,7 @@ public class SplitButtonIntegrationTests
         var primaryCount = 0;
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 BuildButton(
                     onPrimary: () => primaryCount++,
                     onOptionA: _ => optionACount++,
@@ -272,7 +272,7 @@ public class SplitButtonIntegrationTests
         SplitButtonClickedEventArgs? optionBArgs = null;
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 BuildButton(
                     onPrimary: () => primaryCount++,
                     onOptionA: _ => optionACount++,
@@ -312,7 +312,7 @@ public class SplitButtonIntegrationTests
         var primaryCount = 0;
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 BuildButton(
                     onPrimary: () => primaryCount++,
                     onOptionA: _ => optionACount++,
@@ -344,7 +344,7 @@ public class SplitButtonIntegrationTests
         var primaryCount = 0;
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 BuildButton(
                     onPrimary: () => primaryCount++,
                     onOptionA: _ => optionACount++,
@@ -407,7 +407,7 @@ public class SplitButtonIntegrationTests
         SplitButtonClickedEventArgs? optionBArgs = null;
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 BuildButton(
                     onPrimary: () => primaryCount++,
                     onOptionA: _ => optionACount++,
@@ -489,7 +489,7 @@ public class SplitButtonIntegrationTests
     public async Task SplitButton_NoSecondaryActions_RendersUniformChipWithoutDivider()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 new SplitButtonWidget().PrimaryAction("Action", _ => { })
             ]))
             .WithHeadless()
@@ -551,7 +551,7 @@ public class SplitButtonIntegrationTests
             .SecondaryAction("Choice Y", _ => { });
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+            .WithHex1bApp(ctx => new VStackWidget([
                 topButton,
                 new TextBlockWidget(""),
                 new TextBlockWidget(""),

--- a/tests/Hex1b.Tests/SurfaceComparerUnderlineDiffTests.cs
+++ b/tests/Hex1b.Tests/SurfaceComparerUnderlineDiffTests.cs
@@ -1,0 +1,79 @@
+using Hex1b;
+using Hex1b.Surfaces;
+using Hex1b.Theming;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Regression tests for <see cref="SurfaceComparer.Compare"/> covering
+/// underline-style and underline-color changes. Historically these fields
+/// were absent from the cell-equality fast path, so a cell that changed only
+/// in its underline state was treated as unchanged - the diff would skip it
+/// and the host terminal would keep displaying stale underline state.
+/// </summary>
+public class SurfaceComparerUnderlineDiffTests
+{
+    [Fact]
+    public void Compare_CellWithChangedUnderlineStyleOnly_IsIncludedInDiff()
+    {
+        var previous = new Surface(1, 1);
+        var current = new Surface(1, 1);
+
+        previous[0, 0] = new SurfaceCell(
+            "A",
+            Hex1bColor.White,
+            Hex1bColor.Black,
+            CellAttributes.Underline,
+            UnderlineStyle: UnderlineStyle.Single);
+
+        current[0, 0] = previous[0, 0] with { UnderlineStyle = UnderlineStyle.Curly };
+
+        var diff = SurfaceComparer.Compare(previous, current);
+
+        Assert.Single(diff.ChangedCells);
+        Assert.Equal(UnderlineStyle.Curly, diff.ChangedCells[0].Cell.UnderlineStyle);
+    }
+
+    [Fact]
+    public void Compare_CellWithChangedUnderlineColorOnly_IsIncludedInDiff()
+    {
+        var previous = new Surface(1, 1);
+        var current = new Surface(1, 1);
+
+        previous[0, 0] = new SurfaceCell(
+            "A",
+            Hex1bColor.White,
+            Hex1bColor.Black,
+            CellAttributes.Underline,
+            UnderlineStyle: UnderlineStyle.Single,
+            UnderlineColor: Hex1bColor.Red);
+
+        current[0, 0] = previous[0, 0] with { UnderlineColor = Hex1bColor.Blue };
+
+        var diff = SurfaceComparer.Compare(previous, current);
+
+        Assert.Single(diff.ChangedCells);
+        Assert.Equal(Hex1bColor.Blue, diff.ChangedCells[0].Cell.UnderlineColor);
+    }
+
+    [Fact]
+    public void Compare_CellWithIdenticalUnderlineState_IsNotInDiff()
+    {
+        var previous = new Surface(1, 1);
+        var current = new Surface(1, 1);
+
+        previous[0, 0] = new SurfaceCell(
+            "A",
+            Hex1bColor.White,
+            Hex1bColor.Black,
+            CellAttributes.Underline,
+            UnderlineStyle: UnderlineStyle.Curly,
+            UnderlineColor: Hex1bColor.Green);
+
+        current[0, 0] = previous[0, 0];
+
+        var diff = SurfaceComparer.Compare(previous, current);
+
+        Assert.Empty(diff.ChangedCells);
+    }
+}

--- a/tests/Hex1b.Tests/SurfaceFastPathTests.cs
+++ b/tests/Hex1b.Tests/SurfaceFastPathTests.cs
@@ -1,0 +1,196 @@
+using Hex1b;
+using Hex1b.Surfaces;
+using Hex1b.Theming;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Covers the <see cref="Surface.IsFastPathEligible"/> latch and the matching
+/// fast diff path in <see cref="SurfaceComparer"/>. The fast path skips the
+/// underline / display-width / tracked-ref branches in per-cell equality, so
+/// the latch MUST flip to false whenever any such complexity is introduced.
+/// Conversely, when both surfaces remain in the simple lane, the diff output
+/// must be identical to the slow path.
+/// </summary>
+public class SurfaceFastPathTests
+{
+    [Fact]
+    public void NewSurface_HasFastPathEligibleTrue()
+    {
+        var surface = new Surface(4, 2);
+        Assert.True(surface.IsFastPathEligible);
+    }
+
+    [Fact]
+    public void SimpleAsciiWrite_KeepsFastPathEligible()
+    {
+        var surface = new Surface(4, 2);
+        surface[0, 0] = new SurfaceCell("A", Hex1bColor.White, Hex1bColor.Black);
+        surface.WriteText(1, 0, "BCD", Hex1bColor.White, Hex1bColor.Black);
+        Assert.True(surface.IsFastPathEligible);
+    }
+
+    [Theory]
+    [InlineData("e\u0301")]   // combining acute => grapheme length > 1
+    public void MultiCodePointGrapheme_MarksComplex(string grapheme)
+    {
+        var surface = new Surface(4, 1);
+        surface[0, 0] = new SurfaceCell(grapheme, null, null);
+        Assert.False(surface.IsFastPathEligible);
+    }
+
+    [Fact]
+    public void UnderlineStyle_MarksComplex()
+    {
+        var surface = new Surface(4, 1);
+        surface[0, 0] = new SurfaceCell(
+            "A", Hex1bColor.White, Hex1bColor.Black,
+            UnderlineStyle: UnderlineStyle.Single);
+        Assert.False(surface.IsFastPathEligible);
+    }
+
+    [Fact]
+    public void UnderlineColor_MarksComplex()
+    {
+        var surface = new Surface(4, 1);
+        surface[0, 0] = new SurfaceCell(
+            "A", Hex1bColor.White, Hex1bColor.Black,
+            UnderlineColor: Hex1bColor.Red);
+        Assert.False(surface.IsFastPathEligible);
+    }
+
+    [Fact]
+    public void WideCharacter_MarksComplex()
+    {
+        var surface = new Surface(4, 1);
+        // "あ" is a wide CJK char with DisplayWidth=2.
+        surface.WriteText(0, 0, "あ", Hex1bColor.White, Hex1bColor.Black);
+        Assert.False(surface.IsFastPathEligible);
+    }
+
+    [Fact]
+    public void Clear_ResetsFastPathFlag()
+    {
+        var surface = new Surface(4, 1);
+        surface[0, 0] = new SurfaceCell(
+            "A", Hex1bColor.White, Hex1bColor.Black,
+            UnderlineStyle: UnderlineStyle.Single);
+        Assert.False(surface.IsFastPathEligible);
+
+        surface.Clear();
+
+        Assert.True(surface.IsFastPathEligible);
+    }
+
+    [Fact]
+    public void ClearWithComplexCell_LeavesFlagSet()
+    {
+        var surface = new Surface(4, 1);
+        var complex = new SurfaceCell(
+            "A", Hex1bColor.White, Hex1bColor.Black,
+            UnderlineStyle: UnderlineStyle.Single);
+
+        surface.Clear(complex);
+
+        Assert.False(surface.IsFastPathEligible);
+    }
+
+    [Fact]
+    public void ClearWithSimpleCell_KeepsFlagClear()
+    {
+        var surface = new Surface(4, 1);
+        surface[0, 0] = new SurfaceCell(
+            "A", Hex1bColor.White, Hex1bColor.Black,
+            UnderlineStyle: UnderlineStyle.Single);
+        Assert.False(surface.IsFastPathEligible);
+
+        surface.Clear(new SurfaceCell(" ", null, Hex1bColor.Black));
+
+        Assert.True(surface.IsFastPathEligible);
+    }
+
+    [Fact]
+    public void Compare_FastPath_ProducesIdenticalDiffToSlowPath()
+    {
+        // Two surfaces filled with simple ASCII content; both are fast-eligible.
+        // The fast path output must exactly match what the slow path would produce.
+        var prev = new Surface(8, 3);
+        var curr = new Surface(8, 3);
+
+        for (var y = 0; y < 3; y++)
+        {
+            for (var x = 0; x < 8; x++)
+            {
+                prev[x, y] = new SurfaceCell("a", Hex1bColor.White, Hex1bColor.Black);
+                // Change every other cell to "b" with a different bg.
+                curr[x, y] = ((x + y) % 2 == 0)
+                    ? new SurfaceCell("a", Hex1bColor.White, Hex1bColor.Black)
+                    : new SurfaceCell("b", Hex1bColor.White, Hex1bColor.Red);
+            }
+        }
+
+        Assert.True(prev.IsFastPathEligible);
+        Assert.True(curr.IsFastPathEligible);
+
+        var diff = SurfaceComparer.Compare(prev, curr);
+
+        // Manually compute the expected changed-cell set.
+        var expected = new List<(int X, int Y, string Char)>();
+        for (var y = 0; y < 3; y++)
+            for (var x = 0; x < 8; x++)
+                if ((x + y) % 2 != 0)
+                    expected.Add((x, y, "b"));
+
+        Assert.Equal(expected.Count, diff.ChangedCells.Count);
+        for (var i = 0; i < expected.Count; i++)
+        {
+            Assert.Equal(expected[i].X, diff.ChangedCells[i].X);
+            Assert.Equal(expected[i].Y, diff.ChangedCells[i].Y);
+            Assert.Equal(expected[i].Char, diff.ChangedCells[i].Cell.Character);
+        }
+    }
+
+    [Fact]
+    public void Compare_MixedEligibility_FallsBackToSlowPathAndStillDetectsUnderlineChange()
+    {
+        // prev has only a plain cell; curr has an underline-changed cell.
+        // Because curr is NOT fast-eligible, the slow path runs and the underline
+        // change must be detected (this is the same scenario as the existing
+        // underline regression test, but through the new gating).
+        var prev = new Surface(1, 1);
+        var curr = new Surface(1, 1);
+
+        prev[0, 0] = new SurfaceCell("A", Hex1bColor.White, Hex1bColor.Black);
+        curr[0, 0] = new SurfaceCell(
+            "A", Hex1bColor.White, Hex1bColor.Black,
+            UnderlineStyle: UnderlineStyle.Single);
+
+        Assert.True(prev.IsFastPathEligible);
+        Assert.False(curr.IsFastPathEligible);
+
+        var diff = SurfaceComparer.Compare(prev, curr);
+
+        Assert.Single(diff.ChangedCells);
+        Assert.Equal(UnderlineStyle.Single, diff.ChangedCells[0].Cell.UnderlineStyle);
+    }
+
+    [Fact]
+    public void CompareToEmpty_FastPath_MatchesSlowPath()
+    {
+        var surface = new Surface(4, 2);
+        surface[0, 0] = new SurfaceCell("A", Hex1bColor.White, Hex1bColor.Black);
+        surface[3, 1] = new SurfaceCell("Z", Hex1bColor.White, Hex1bColor.Red);
+
+        Assert.True(surface.IsFastPathEligible);
+
+        var diff = SurfaceComparer.CompareToEmpty(surface);
+
+        Assert.Equal(2, diff.ChangedCells.Count);
+        Assert.Equal(0, diff.ChangedCells[0].X);
+        Assert.Equal(0, diff.ChangedCells[0].Y);
+        Assert.Equal("A", diff.ChangedCells[0].Cell.Character);
+        Assert.Equal(3, diff.ChangedCells[1].X);
+        Assert.Equal(1, diff.ChangedCells[1].Y);
+        Assert.Equal("Z", diff.ChangedCells[1].Cell.Character);
+    }
+}

--- a/tests/Hex1b.Tests/TableVisualTestHelper.cs
+++ b/tests/Hex1b.Tests/TableVisualTestHelper.cs
@@ -101,7 +101,7 @@ public static class TableVisualTestHelper
         using var terminal = Hex1bTerminal.CreateBuilder()
             .WithHeadless()
             .WithDimensions(testCase.Width, testCase.Height)
-            .WithHex1bApp((app, options) => ctx => BuildTableWidget(ctx, testCase, data))
+            .WithHex1bApp(ctx => BuildTableWidget(ctx, testCase, data))
             .Build();
         
         // Start terminal/app

--- a/tests/Hex1b.Tests/TerminalWidgetIntegrationTests.cs
+++ b/tests/Hex1b.Tests/TerminalWidgetIntegrationTests.cs
@@ -60,7 +60,9 @@ public class TerminalWidgetIntegrationTests
             
             // Create the terminal using the builder pattern (proper lifecycle)
             var terminal = Hex1bTerminal.CreateBuilder()
-                .WithHex1bApp((app, options) =>
+                .WithHex1bApp(
+                    _ => { },
+                    app =>
                 {
                     // Capture the app for test access
                     if (capturedContext != null)

--- a/tests/Hex1b.Tests/TilePanelNodeTests.cs
+++ b/tests/Hex1b.Tests/TilePanelNodeTests.cs
@@ -312,7 +312,7 @@ public class TilePanelIntegrationTests
         var ds = new TestTileDataSource();
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.VStack(v =>
+            .WithHex1bApp(ctx => ctx.VStack(v =>
             [
                 v.Text($"Camera: ({cameraX:F1}, {cameraY:F1})"),
                 v.TilePanel(ds, cameraX, cameraY, zoomLevel)
@@ -356,7 +356,7 @@ public class TilePanelIntegrationTests
         var ds = new TestTileDataSource();
 
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.VStack(v =>
+            .WithHex1bApp(ctx => ctx.VStack(v =>
             [
                 v.Text($"Zoom: {zoomLevel}"),
                 v.TilePanel(ds, 0, 0, zoomLevel)

--- a/tests/Hex1b.Tests/TrackedObjectTests.cs
+++ b/tests/Hex1b.Tests/TrackedObjectTests.cs
@@ -102,7 +102,7 @@ public class TrackedObjectTests
         };
 
         var bytes = AnsiTokenUtf8Serializer.Serialize(tokens);
-        workload.WriteTokensWithBytes(tokens, bytes);
+        await workload.WriteTokensWithBytesAsync(tokens, bytes);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .WaitUntil(s => s.ContainsSixelData(), TimeSpan.FromSeconds(5))

--- a/tests/Hex1b.Tests/TreeIntegrationTests.cs
+++ b/tests/Hex1b.Tests/TreeIntegrationTests.cs
@@ -91,7 +91,7 @@ public class TreeIntegrationTests
     public async Task Tree_RendersWithCorrectStructure()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => CreateSimpleTree())
+            .WithHex1bApp(ctx => CreateSimpleTree())
             .WithHeadless()
             .WithDimensions(60, 20)
             .Build();
@@ -119,7 +119,7 @@ public class TreeIntegrationTests
     public async Task Tree_RendersGuideLines_Unicode()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => CreateMultiRootTree())
+            .WithHex1bApp(ctx => CreateMultiRootTree())
             .WithHeadless()
             .WithDimensions(60, 20)
             .Build();
@@ -142,7 +142,7 @@ public class TreeIntegrationTests
     public async Task Tree_RendersGuideLines_Ascii()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.ThemePanel(
+            .WithHex1bApp(ctx => ctx.ThemePanel(
                 theme => theme
                     .Set(Theming.TreeTheme.Branch, "+- ")
                     .Set(Theming.TreeTheme.LastBranch, "\\- ")
@@ -171,7 +171,7 @@ public class TreeIntegrationTests
     public async Task Tree_CollapsedItem_HidesChildren()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TreeWidget([
+            .WithHex1bApp(ctx => new TreeWidget([
                 new TreeItemWidget("Root").Children(  // Not expanded
                     new TreeItemWidget("Hidden Child")
                 )
@@ -202,7 +202,7 @@ public class TreeIntegrationTests
     public async Task Tree_DownArrow_MovesToNextItem()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => CreateMultiRootTree())
+            .WithHex1bApp(ctx => CreateMultiRootTree())
             .WithHeadless()
             .WithDimensions(60, 20)
             .Build();
@@ -226,7 +226,7 @@ public class TreeIntegrationTests
     public async Task Tree_UpArrow_MovesToPreviousItem()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => CreateMultiRootTree())
+            .WithHex1bApp(ctx => CreateMultiRootTree())
             .WithHeadless()
             .WithDimensions(60, 20)
             .Build();
@@ -255,7 +255,7 @@ public class TreeIntegrationTests
     public async Task Tree_DownArrow_WrapsToFirst()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TreeWidget([
+            .WithHex1bApp(ctx => new TreeWidget([
                 new TreeItemWidget("Item 1"),
                 new TreeItemWidget("Item 2"),
                 new TreeItemWidget("Item 3")
@@ -284,7 +284,7 @@ public class TreeIntegrationTests
     public async Task Tree_UpArrow_WrapsToLast()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TreeWidget([
+            .WithHex1bApp(ctx => new TreeWidget([
                 new TreeItemWidget("Item 1"),
                 new TreeItemWidget("Item 2"),
                 new TreeItemWidget("Item 3")
@@ -379,7 +379,7 @@ public class TreeIntegrationTests
     public async Task Tree_RightArrow_OnExpandedItem_MovesToFirstChild()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TreeWidget([
+            .WithHex1bApp(ctx => new TreeWidget([
                 new TreeItemWidget("Parent").Expanded().Children(
                     new TreeItemWidget("First Child"),
                     new TreeItemWidget("Second Child")
@@ -407,7 +407,7 @@ public class TreeIntegrationTests
     public async Task Tree_LeftArrow_OnChild_MovesToParent()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TreeWidget([
+            .WithHex1bApp(ctx => new TreeWidget([
                 new TreeItemWidget("Parent").Expanded().Children(
                     new TreeItemWidget("Child")
                 )
@@ -437,7 +437,7 @@ public class TreeIntegrationTests
         var activatedLabel = "";
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TreeWidget([
+            .WithHex1bApp(ctx => new TreeWidget([
                 new TreeItemWidget("Item 1"),
                 new TreeItemWidget("Item 2")
             ]).OnItemActivated(e => { activatedLabel = e.Item.Label; }))
@@ -540,7 +540,7 @@ public class TreeIntegrationTests
     public async Task Tree_MultiSelect_RendersCheckboxes()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TreeWidget([
+            .WithHex1bApp(ctx => new TreeWidget([
                 new TreeItemWidget("Unchecked Item"),
                 new TreeItemWidget("Checked Item").Selected()
             ]).MultiSelect())
@@ -569,15 +569,13 @@ public class TreeIntegrationTests
     public async Task Tree_MouseClick_SelectsItem()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) =>
-            {
-                options.EnableMouse = true;
-                return ctx => new TreeWidget([
+            .WithHex1bApp(
+                options => options.EnableMouse = true,
+                ctx => new TreeWidget([
                     new TreeItemWidget("Item 1"),
                     new TreeItemWidget("Item 2"),
                     new TreeItemWidget("Item 3")
-                ]);
-            })
+                ]))
             .WithHeadless()
             .WithDimensions(60, 20)
             .Build();
@@ -606,7 +604,7 @@ public class TreeIntegrationTests
     public async Task Tree_InBorder_RendersCorrectly()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.Border(b => [
+            .WithHex1bApp(ctx => ctx.Border(b => [
                 b.Tree(
                     new TreeItemWidget("Root").Expanded().Children(
                         new TreeItemWidget("Child 1"),
@@ -642,7 +640,7 @@ public class TreeIntegrationTests
     public async Task Tree_InBorder_BorderCornersAtCorrectPositions()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.Border(b => [
+            .WithHex1bApp(ctx => ctx.Border(b => [
                 b.Tree(
                     new TreeItemWidget("Item 1"),
                     new TreeItemWidget("Item 2")
@@ -679,7 +677,7 @@ public class TreeIntegrationTests
     public async Task Tree_InNestedBorders_RendersCorrectly()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.Border(b => [
+            .WithHex1bApp(ctx => ctx.Border(b => [
                 b.Border(inner => [
                     inner.Tree(
                         new TreeItemWidget("Deep Item")
@@ -715,7 +713,7 @@ public class TreeIntegrationTests
         var longLabel = "This is a very long label that should be clipped when rendered in a narrow container";
         
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.Border(b => [
+            .WithHex1bApp(ctx => ctx.Border(b => [
                 b.Tree(
                     new TreeItemWidget(longLabel)
                 )
@@ -743,7 +741,7 @@ public class TreeIntegrationTests
     public async Task Tree_Clipping_ContentStaysWithinBorder()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.HStack(h => [
+            .WithHex1bApp(ctx => ctx.HStack(h => [
                 h.Border(b => [
                     b.Tree(
                         new TreeItemWidget("Left Tree Item")
@@ -788,7 +786,7 @@ public class TreeIntegrationTests
     public async Task Tree_TabNavigatesBetweenMultipleTrees()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.HStack(h => [
+            .WithHex1bApp(ctx => ctx.HStack(h => [
                 h.Border(b => [
                     b.Tree(
                         new TreeItemWidget("Left Item 1"),
@@ -842,7 +840,7 @@ public class TreeIntegrationTests
     public async Task Tree_DeepNavigation_TraversesAllLevels()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => CreateDeepTree())
+            .WithHex1bApp(ctx => CreateDeepTree())
             .WithHeadless()
             .WithDimensions(60, 20)
             .Build();
@@ -914,7 +912,7 @@ public class TreeIntegrationTests
         string expectedBranch, string expectedLastBranch)
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => ctx.ThemePanel(
+            .WithHex1bApp(ctx => ctx.ThemePanel(
                 theme => theme
                     .Set(Theming.TreeTheme.Branch, branch)
                     .Set(Theming.TreeTheme.LastBranch, lastBranch)
@@ -1068,7 +1066,7 @@ public class TreeIntegrationTests
     public async Task Tree_FirstItemFocusedOnRender()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TreeWidget([
+            .WithHex1bApp(ctx => new TreeWidget([
                 new TreeItemWidget("First"),
                 new TreeItemWidget("Second"),
                 new TreeItemWidget("Third")
@@ -1094,7 +1092,7 @@ public class TreeIntegrationTests
     public async Task Tree_PreExpandedItems_ShowChildren()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TreeWidget([
+            .WithHex1bApp(ctx => new TreeWidget([
                 new TreeItemWidget("Root").Expanded().Children(
                     new TreeItemWidget("Visible Child")
                 )

--- a/tests/Hex1b.Tests/WaitUntilTimeoutTests.cs
+++ b/tests/Hex1b.Tests/WaitUntilTimeoutTests.cs
@@ -13,7 +13,7 @@ public class WaitUntilTimeoutTests
     public async Task WaitUntil_Timeout_ThrowsWaitUntilTimeoutException()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Hello"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -34,7 +34,7 @@ public class WaitUntilTimeoutTests
     public async Task WaitUntil_Timeout_MessageContainsPredicateExpression()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Hello"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -56,7 +56,7 @@ public class WaitUntilTimeoutTests
     public async Task WaitUntil_Timeout_MessageContainsExplicitDescription()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Hello"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -78,7 +78,7 @@ public class WaitUntilTimeoutTests
     public async Task WaitUntil_Timeout_MessageContainsCallerLocation()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Hello"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();
@@ -191,7 +191,7 @@ public class WaitUntilTimeoutTests
     public async Task WaitUntil_Timeout_MessageContainsTimeoutDuration()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
-            .WithHex1bApp((app, options) => ctx => new TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new TextBlockWidget("Hello"))
             .WithHeadless()
             .WithDimensions(40, 10)
             .Build();

--- a/tests/Hex1b.Tool.Tests/RecordingProtocolTests.cs
+++ b/tests/Hex1b.Tool.Tests/RecordingProtocolTests.cs
@@ -12,7 +12,7 @@ public class RecordingProtocolTests
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithDimensions(80, 24)
             .WithHeadless()
-            .WithHex1bApp((app, options) => ctx => new Hex1b.Widgets.TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new Hex1b.Widgets.TextBlockWidget("Hello"))
             .WithDiagnostics(appName: "RecordTest", forceEnable: true)
             .Build();
 
@@ -70,7 +70,7 @@ public class RecordingProtocolTests
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithDimensions(80, 24)
             .WithHeadless()
-            .WithHex1bApp((app, options) => ctx => new Hex1b.Widgets.TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new Hex1b.Widgets.TextBlockWidget("Hello"))
             .WithDiagnostics(appName: "RecordTest2", forceEnable: true)
             .Build();
 
@@ -107,7 +107,7 @@ public class RecordingProtocolTests
         await using var terminal = Hex1bTerminal.CreateBuilder()
             .WithDimensions(80, 24)
             .WithHeadless()
-            .WithHex1bApp((app, options) => ctx => new Hex1b.Widgets.TextBlockWidget("Hello"))
+            .WithHex1bApp(ctx => new Hex1b.Widgets.TextBlockWidget("Hello"))
             .WithDiagnostics(appName: "RecordTest3", forceEnable: true)
             .Build();
 


### PR DESCRIPTION
## Why

Interactive drag-resize of the host terminal made flow-mode apps essentially unusable. During a drag the active prompt would scroll off-screen, tombstones above would slide into oblivion, and stale partial frames from the inner Hex1bApp would smear into the cleared region. This PR reworks the flow runner's resize pipeline so a drag-resize stays anchored and visually stable, and lands a `FancyFlowDemo` sample as the smoke target the new behavior was tuned against.

## Approach

**Track-and-clear settle pipeline (`Hex1bFlowOptions.ResizeSettleDelay`).** Replaces the legacy eager-repaint resize path with a two-phase model that only fully repaints once the user has finished dragging:

- *Per-event* (one tick per `Hex1bResizeEvent` in the burst): hide the cursor, disable DECAWM, mute the inner-app output pump, park the cursor at `ESC[H`, and optionally render a `ResizePlaceholder` into the active rect.
- *Settle* (fires once after the configured quiet window): compute the post-reflow row origin via `FlowResizeMath.ComputeRowOriginAtWidth`, scroll for bottom overflow if needed, clear the union of the pre-burst and post-settle rects, re-enable DECAWM, unmute the pump, and tell the inner app to re-render via `InlineStepAdapter.ResizeAsync`.

**Distinct artifacts diagnosed and fixed along the way:**

- The host terminal scrolls the primary buffer to keep the cursor visible on shrink. Parking the cursor at `ESC[H` on every event prevents subsequent shrinks in the same gesture from pushing tombstones off the top.
- The inner Hex1bApp's frames contain explicit `CR+LF` row separators which scroll the buffer when they land past the shrunken viewport bottom. DECAWM-off only protects against implicit right-edge wrap, so the runner additionally mutes the output pump for the duration of the drag.
- `InlineStepAdapter.ResizeAsync` used to suppress the inner `Hex1bResizeEvent` when dimensions hadn't changed. On a vertical-only host resize where `MaxHeight` clamps the step height, the inner app never re-rendered into the runner-cleared rect and the prompt vanished until the next horizontal drag. Now always forwards the event.
- The first frame of a burst can land before the mute gate flips, leaving a stale partial render at the OLD origin/height. The settle pass now clears the union of the pre-burst rect and the post-settle rect.

**New option: `ResizePlaceholder`.** A `Func<RootContext, Hex1bWidget>?` rendered into the active step's rectangle on every per-event tick (a single short line is ideal so it fits inside even an aggressively shrunken viewport). With the inner-app pump muted, this is what the user actually sees during the drag in place of the frozen prompt.

**FancyFlowDemo sample.** A four-step "create a new app" wizard (language list, template list, folder textbox with predictive text, hostname toggle) framed as a Clack-style vertical timeline. Used as the concrete smoke target for the new resize behavior; also exercises start/processing/success/cancel tombstones, bordered input zones constrained to 1/3 screen width, and the new placeholder wiring (`Resizing...`).

## Testing

- New `tests/Hex1b.Tests/Flow/FlowRunnerResizeHarnessTests.cs` -- a minimal in-process harness with a `RecordingParentAdapter` that captures every byte the runner writes. Regression tests pin the per-event discipline (no `\n` / `ESC[J` / `ESC[2K` / `ESC[K` / CUP during a burst) and the DECAWM toggle pattern.
- New `tests/Hex1b.Tests/Flow/FlowResizeRowOriginFeasibilityTests.cs` -- unit coverage for `ComputeRowOriginAtWidth` across reflow scenarios.
- 151/151 flow tests pass.

## Notes for reviewers

- One residual one-row slip can still occur at the very start of a drag because the host terminal scrolls before our event handler runs. Subsequent events in the same gesture are anchored.
- The settle-based pipeline only activates when both `UseSoftWrapTombstones = true` AND `ResizeSettleDelay` is set; otherwise the runner falls back to the legacy eager-repaint path for backward compatibility.
- The `ResizeMarker` option (faint "terminal resized" breadcrumb above the post-settle render) is retained on the runner but not wired into FancyFlowDemo.
- The `EffectPanel` glow background was removed from `TemplatePromptWidget` -- its continuous redraw cadence was the load that originally exposed the resize bugs, and it added little once the timeline framing landed.


## Note

The `EffectPanel.Effect(Action<Surface, Hex1bRenderContext>)` overload that was originally added on this branch for the (now-removed) glow background has been split out into #337 (tracked by #336) so this PR stays focused on flow-runner resize behavior.
