### PR TITLE
Add context-aware EffectPanel.Effect overload

### DIFF
--- a/src/Hex1b/EffectPanelExtensions.cs
+++ b/src/Hex1b/EffectPanelExtensions.cs
@@ -10,7 +10,7 @@ public static class EffectPanelExtensions
 {
     /// <summary>
     /// Creates an effect panel that wraps the given child widget.
-    /// Use <see cref="EffectPanelWidget.Effect"/> to apply a post-processing effect.
+    /// Use <see cref="EffectPanelWidget.Effect(Action{Surface})"/> to apply a post-processing effect.
     /// </summary>
     /// <typeparam name="TParent">The parent widget type.</typeparam>
     /// <param name="context">The widget context.</param>
@@ -36,4 +36,22 @@ public static class EffectPanelExtensions
         Action<Surface> effect)
         where TParent : Hex1bWidget
         => new(child) { EffectCallback = effect };
+
+    /// <summary>
+    /// Creates an effect panel that wraps the given child widget with a context-aware
+    /// effect applied. The callback receives both the rendered surface and the parent
+    /// <see cref="Hex1bRenderContext"/> (useful for reading the global background colour
+    /// when blending).
+    /// </summary>
+    /// <typeparam name="TParent">The parent widget type.</typeparam>
+    /// <param name="context">The widget context.</param>
+    /// <param name="child">The child widget to wrap.</param>
+    /// <param name="effect">A callback that receives the rendered <see cref="Surface"/> and render context.</param>
+    /// <returns>An <see cref="EffectPanelWidget"/> with the effect applied.</returns>
+    public static EffectPanelWidget EffectPanel<TParent>(
+        this WidgetContext<TParent> context,
+        Hex1bWidget child,
+        Action<Surface, Hex1bRenderContext> effect)
+        where TParent : Hex1bWidget
+        => new(child) { EffectWithContextCallback = effect };
 }

--- a/src/Hex1b/Nodes/EffectPanelNode.cs
+++ b/src/Hex1b/Nodes/EffectPanelNode.cs
@@ -21,6 +21,14 @@ public sealed class EffectPanelNode : Hex1bNode
     /// </summary>
     public Action<Surface>? Effect { get; set; }
 
+    /// <summary>
+    /// Gets or sets a context-aware effect callback that post-processes the child's
+    /// rendered surface and additionally receives the parent <see cref="Hex1bRenderContext"/>
+    /// (handy for reading <c>context.Theme.GetGlobalBackground()</c> when blending).
+    /// Invoked after <see cref="Effect"/>.
+    /// </summary>
+    public Action<Surface, Hex1bRenderContext>? EffectWithContext { get; set; }
+
     protected override Size MeasureCore(Constraints constraints)
     {
         if (Child is null)
@@ -38,7 +46,7 @@ public sealed class EffectPanelNode : Hex1bNode
     {
         if (Child is null) return;
 
-        if (Effect is null || context is not SurfaceRenderContext surfaceCtx)
+        if (Effect is null && EffectWithContext is null || context is not SurfaceRenderContext surfaceCtx)
         {
             // No effect or non-surface context: pass through unchanged
             context.RenderChild(Child);
@@ -71,8 +79,9 @@ public sealed class EffectPanelNode : Hex1bNode
             tempContext.SetCursorPosition(Child.Bounds.X, Child.Bounds.Y);
             tempContext.RenderChild(Child);
 
-            // 4. Apply effect
-            Effect(tempSurface);
+            // 4. Apply effect(s)
+            Effect?.Invoke(tempSurface);
+            EffectWithContext?.Invoke(tempSurface, context);
 
             // 5. Composite modified surface into parent, respecting clip region
             Rect? clipRect = null;

--- a/src/Hex1b/Widgets/EffectPanelWidget.cs
+++ b/src/Hex1b/Widgets/EffectPanelWidget.cs
@@ -26,6 +26,12 @@ public sealed record EffectPanelWidget(Hex1bWidget Child) : Hex1bWidget
     internal Action<Surface>? EffectCallback { get; init; }
 
     /// <summary>
+    /// Gets the context-aware effect callback that post-processes the rendered surface
+    /// and additionally receives the parent <see cref="Hex1bRenderContext"/>.
+    /// </summary>
+    internal Action<Surface, Hex1bRenderContext>? EffectWithContextCallback { get; init; }
+
+    /// <summary>
     /// Sets the effect callback that post-processes the child's rendered surface.
     /// </summary>
     /// <param name="effect">A callback that receives the rendered <see cref="Surface"/> for in-place modification.</param>
@@ -33,11 +39,22 @@ public sealed record EffectPanelWidget(Hex1bWidget Child) : Hex1bWidget
     public EffectPanelWidget Effect(Action<Surface> effect)
         => this with { EffectCallback = effect };
 
+    /// <summary>
+    /// Sets a context-aware effect callback that receives both the rendered <see cref="Surface"/>
+    /// and the parent <see cref="Hex1bRenderContext"/> (use <c>context.Theme.GetGlobalBackground()</c>
+    /// when blending toward the terminal's effective background).
+    /// </summary>
+    /// <param name="effect">A callback that receives the rendered surface and render context.</param>
+    /// <returns>A new <see cref="EffectPanelWidget"/> with the effect applied.</returns>
+    public EffectPanelWidget Effect(Action<Surface, Hex1bRenderContext> effect)
+        => this with { EffectWithContextCallback = effect };
+
     internal override async Task<Hex1bNode> ReconcileAsync(Hex1bNode? existingNode, ReconcileContext context)
     {
         var node = existingNode as EffectPanelNode ?? new EffectPanelNode();
 
         node.Effect = EffectCallback;
+        node.EffectWithContext = EffectWithContextCallback;
 
         // Reconcile the child widget
         node.Child = await context.ReconcileChildAsync(node.Child, Child, node);


### PR DESCRIPTION
Closes #336.

Adds an `Action<Surface, Hex1bRenderContext>` overload of `EffectPanelWidget.Effect` (and a matching `ctx.EffectPanel` extension) so post-processing effects can read the parent render context alongside the rendered surface. The motivating use case is letting an effect read the terminal's effective background colour (via `ctx.Theme.GetGlobalBackground()` / `ctx.Capabilities.DefaultBackground`) when blending toward the real terminal background — e.g. a glow effect that fades cleanly into the surrounding scrollback.

## Approach

- Adds an internal `EffectWithContextCallback` on `EffectPanelWidget` plumbed through to a corresponding `EffectWithContext` setter on `EffectPanelNode`.
- `EffectPanelNode.Render` now takes the surface-rendering fast-path only when *both* callbacks are null. When the context-aware callback is set, it runs after the surface-only callback (if any), in the same render-to-temp-surface-then-composite pass.
- New widget method: `EffectPanelWidget.Effect(Action<Surface, Hex1bRenderContext>)`.
- New extension: `ctx.EffectPanel(child, Action<Surface, Hex1bRenderContext>)`.

The existing `Action<Surface>` overload is unchanged.

## Background

This was originally introduced as part of #334 for a glow background on the FancyFlowDemo prompt frame. The glow was later removed, so the new overload had no in-tree caller in that PR. Split out into its own change so it can be reviewed on its own merits.