### PR TITLE
WASM hosting: make BlazorDemo / WasmDemo responsive

### DIFF
--- a/samples/BlazorDemo/App.razor
+++ b/samples/BlazorDemo/App.razor
@@ -19,6 +19,10 @@
             }
         }
 
+        // Wire the C# [JSExport] SignalInputAvailable into interop.js so input
+        // events wake ReadInputAsync immediately instead of waiting on a 50ms poll.
+        await JS.InvokeVoidAsync("termInterop.attachSignal", "BlazorDemo");
+
         Console.WriteLine($"[blazor] Starting globe ({cols}x{rows}), threading={Environment.ProcessorCount > 1}");
 
         // Run globe on the main thread — [JSImport] calls are fast and synchronous here.

--- a/samples/BlazorDemo/App.razor
+++ b/samples/BlazorDemo/App.razor
@@ -25,8 +25,6 @@
         // we must not stall startup. attachSignal catches its own errors.
         _ = JS.InvokeVoidAsync("termInterop.attachSignal", "BlazorDemo").AsTask();
 
-        Console.WriteLine($"[blazor] Starting globe ({cols}x{rows}), threading={Environment.ProcessorCount > 1}");
-
         // Run globe on the main thread — [JSImport] calls are fast and synchronous here.
         // With WasmEnableThreads, Hex1b's internal async/await and Task.Run 
         // can dispatch to real background threads via the thread pool.

--- a/samples/BlazorDemo/App.razor
+++ b/samples/BlazorDemo/App.razor
@@ -20,8 +20,10 @@
         }
 
         // Wire the C# [JSExport] SignalInputAvailable into interop.js so input
-        // events wake ReadInputAsync immediately instead of waiting on a 50ms poll.
-        await JS.InvokeVoidAsync("termInterop.attachSignal", "BlazorDemo");
+        // events wake ReadInputAsync immediately. Fire-and-forget: if the
+        // Blazor runtime's getAssemblyExports surface behaves unexpectedly,
+        // we must not stall startup. attachSignal catches its own errors.
+        _ = JS.InvokeVoidAsync("termInterop.attachSignal", "BlazorDemo").AsTask();
 
         Console.WriteLine($"[blazor] Starting globe ({cols}x{rows}), threading={Environment.ProcessorCount > 1}");
 

--- a/samples/BlazorDemo/BlazorDemo.csproj
+++ b/samples/BlazorDemo/BlazorDemo.csproj
@@ -10,6 +10,21 @@
     <EmccMaximumHeapSize>536870912</EmccMaximumHeapSize>
   </PropertyGroup>
 
+  <!--
+    AOT-compile the Mono IL to WebAssembly when publishing in Release.
+    Without this the published site still ships the interpreter, which makes
+    the globe paint loop ~50x slower than necessary. AOT adds several minutes
+    to `dotnet publish`, so we only enable it for Release publishes — `dotnet
+    run` still uses the fast-iteration interpreter path.
+
+    Use `samples/BlazorDemo/run-aot.sh` to publish + serve the AOT build
+    locally for perf testing.
+  -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <RunAOTCompilation>true</RunAOTCompilation>
+    <WasmStripILAfterAOT>true</WasmStripILAfterAOT>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.2" PrivateAssets="all" />

--- a/samples/BlazorDemo/BlazorPresentationAdapter.cs
+++ b/samples/BlazorDemo/BlazorPresentationAdapter.cs
@@ -36,26 +36,9 @@ public sealed partial class BlazorPresentationAdapter : Hex1b.IHex1bTerminalPres
     public event Action<int, int>? Resized;
     public event Action? Disconnected;
 
-    // Lightweight perf counters (printed once per second from WriteOutputAsync).
-    private static long s_perfWindowStartTicks;
-    private static int s_perfWriteCount;
-    private static long s_perfByteCount;
-
     public ValueTask WriteOutputAsync(ReadOnlyMemory<byte> data, CancellationToken ct)
     {
         PostOutput(data.ToArray());
-
-        var now = Environment.TickCount64;
-        if (s_perfWindowStartTicks == 0) s_perfWindowStartTicks = now;
-        s_perfWriteCount++;
-        s_perfByteCount += data.Length;
-        if (now - s_perfWindowStartTicks >= 1000)
-        {
-            Console.WriteLine($"[perf] last 1s: writes={s_perfWriteCount} bytes={s_perfByteCount}");
-            s_perfWindowStartTicks = now;
-            s_perfWriteCount = 0;
-            s_perfByteCount = 0;
-        }
         return ValueTask.CompletedTask;
     }
 

--- a/samples/BlazorDemo/BlazorPresentationAdapter.cs
+++ b/samples/BlazorDemo/BlazorPresentationAdapter.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.JavaScript;
 
 namespace BlazorDemo;
@@ -39,10 +38,7 @@ public sealed partial class BlazorPresentationAdapter : Hex1b.IHex1bTerminalPres
 
     public ValueTask WriteOutputAsync(ReadOnlyMemory<byte> data, CancellationToken ct)
     {
-        // See WasmPresentationAdapter for the MemoryView rationale: skip the
-        // per-frame data.ToArray() copy by passing a span over WASM memory.
-        if (!data.IsEmpty)
-            PostOutput(MemoryMarshal.AsMemory(data).Span);
+        PostOutput(data.ToArray());
         return ValueTask.CompletedTask;
     }
 
@@ -114,7 +110,7 @@ public sealed partial class BlazorPresentationAdapter : Hex1b.IHex1bTerminalPres
     }
 
     [JSImport("globalThis.termInterop.postOutput")]
-    internal static partial void PostOutput([JSMarshalAs<JSType.MemoryView>] Span<byte> data);
+    internal static partial void PostOutput(byte[] data);
 
     [JSImport("globalThis.termInterop.pollAllInput")]
     internal static partial byte[]? PollAllInput();

--- a/samples/BlazorDemo/BlazorPresentationAdapter.cs
+++ b/samples/BlazorDemo/BlazorPresentationAdapter.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.JavaScript;
 
 namespace BlazorDemo;
@@ -38,7 +39,10 @@ public sealed partial class BlazorPresentationAdapter : Hex1b.IHex1bTerminalPres
 
     public ValueTask WriteOutputAsync(ReadOnlyMemory<byte> data, CancellationToken ct)
     {
-        PostOutput(data.ToArray());
+        // See WasmPresentationAdapter for the MemoryView rationale: skip the
+        // per-frame data.ToArray() copy by passing a span over WASM memory.
+        if (!data.IsEmpty)
+            PostOutput(MemoryMarshal.AsMemory(data).Span);
         return ValueTask.CompletedTask;
     }
 
@@ -110,7 +114,7 @@ public sealed partial class BlazorPresentationAdapter : Hex1b.IHex1bTerminalPres
     }
 
     [JSImport("globalThis.termInterop.postOutput")]
-    internal static partial void PostOutput(byte[] data);
+    internal static partial void PostOutput([JSMarshalAs<JSType.MemoryView>] Span<byte> data);
 
     [JSImport("globalThis.termInterop.pollAllInput")]
     internal static partial byte[]? PollAllInput();

--- a/samples/BlazorDemo/BlazorPresentationAdapter.cs
+++ b/samples/BlazorDemo/BlazorPresentationAdapter.cs
@@ -36,9 +36,26 @@ public sealed partial class BlazorPresentationAdapter : Hex1b.IHex1bTerminalPres
     public event Action<int, int>? Resized;
     public event Action? Disconnected;
 
+    // Lightweight perf counters (printed once per second from WriteOutputAsync).
+    private static long s_perfWindowStartTicks;
+    private static int s_perfWriteCount;
+    private static long s_perfByteCount;
+
     public ValueTask WriteOutputAsync(ReadOnlyMemory<byte> data, CancellationToken ct)
     {
         PostOutput(data.ToArray());
+
+        var now = Environment.TickCount64;
+        if (s_perfWindowStartTicks == 0) s_perfWindowStartTicks = now;
+        s_perfWriteCount++;
+        s_perfByteCount += data.Length;
+        if (now - s_perfWindowStartTicks >= 1000)
+        {
+            Console.WriteLine($"[perf] last 1s: writes={s_perfWriteCount} bytes={s_perfByteCount}");
+            s_perfWindowStartTicks = now;
+            s_perfWriteCount = 0;
+            s_perfByteCount = 0;
+        }
         return ValueTask.CompletedTask;
     }
 

--- a/samples/BlazorDemo/BlazorPresentationAdapter.cs
+++ b/samples/BlazorDemo/BlazorPresentationAdapter.cs
@@ -86,7 +86,14 @@ public sealed partial class BlazorPresentationAdapter : Hex1b.IHex1bTerminalPres
             try
             {
                 using var reg = ct.Register(static state => ((TaskCompletionSource)state!).TrySetCanceled(), tcs);
-                await tcs.Task;
+                // Race the signal against a 50ms poll fallback. When SignalInputAvailable
+                // is wired via [JSExport] (the f1 fast path), tcs.Task wins and we get
+                // sub-millisecond wake-up. When the runtime-API wiring fails to attach
+                // (e.g. globalThis.getDotnetRuntime not exposed in the current Blazor
+                // boot path), Task.Delay wins and we degrade to the original 50ms poll
+                // behaviour instead of blocking ReadInputAsync forever.
+                await Task.WhenAny(tcs.Task, Task.Delay(50, ct));
+                Interlocked.CompareExchange(ref s_inputSignal, null, tcs);
             }
             catch (OperationCanceledException)
             {

--- a/samples/BlazorDemo/BlazorPresentationAdapter.cs
+++ b/samples/BlazorDemo/BlazorPresentationAdapter.cs
@@ -65,7 +65,6 @@ public sealed partial class BlazorPresentationAdapter : Hex1b.IHex1bTerminalPres
             var allInput = PollAllInput();
             if (allInput != null && allInput.Length > 0)
             {
-                Console.WriteLine($"[diag] ReadInputAsync returning {allInput.Length}B (fast path)");
                 return new ReadOnlyMemory<byte>(allInput);
             }
 
@@ -80,7 +79,6 @@ public sealed partial class BlazorPresentationAdapter : Hex1b.IHex1bTerminalPres
                 Interlocked.CompareExchange(ref s_inputSignal, null, tcs);
                 if (lateInput != null && lateInput.Length > 0)
                 {
-                    Console.WriteLine($"[diag] ReadInputAsync returning {lateInput.Length}B (late-drain path)");
                     return new ReadOnlyMemory<byte>(lateInput);
                 }
                 continue;

--- a/samples/BlazorDemo/BlazorPresentationAdapter.cs
+++ b/samples/BlazorDemo/BlazorPresentationAdapter.cs
@@ -61,9 +61,11 @@ public sealed partial class BlazorPresentationAdapter : Hex1b.IHex1bTerminalPres
                 }
             }
 
+            // Drain all queued input at once for responsiveness
             var allInput = PollAllInput();
             if (allInput != null && allInput.Length > 0)
             {
+                Console.WriteLine($"[diag] ReadInputAsync returning {allInput.Length}B (fast path)");
                 return new ReadOnlyMemory<byte>(allInput);
             }
 
@@ -78,6 +80,7 @@ public sealed partial class BlazorPresentationAdapter : Hex1b.IHex1bTerminalPres
                 Interlocked.CompareExchange(ref s_inputSignal, null, tcs);
                 if (lateInput != null && lateInput.Length > 0)
                 {
+                    Console.WriteLine($"[diag] ReadInputAsync returning {lateInput.Length}B (late-drain path)");
                     return new ReadOnlyMemory<byte>(lateInput);
                 }
                 continue;

--- a/samples/BlazorDemo/BlazorPresentationAdapter.cs
+++ b/samples/BlazorDemo/BlazorPresentationAdapter.cs
@@ -11,6 +11,9 @@ public sealed partial class BlazorPresentationAdapter : Hex1b.IHex1bTerminalPres
     private int _width;
     private int _height;
 
+    // Event-driven input signal — see WasmPresentationAdapter for rationale.
+    private static TaskCompletionSource? s_inputSignal;
+
     public BlazorPresentationAdapter(int initialCols = 80, int initialRows = 24)
     {
         _width = initialCols;
@@ -64,9 +67,26 @@ public sealed partial class BlazorPresentationAdapter : Hex1b.IHex1bTerminalPres
                 return new ReadOnlyMemory<byte>(allInput);
             }
 
+            // Install a signal and recheck to close the race between drain and registration.
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            Interlocked.Exchange(ref s_inputSignal, tcs);
+
+            var lateInput = PollAllInput();
+            var lateResize = PollResize();
+            if ((lateInput != null && lateInput.Length > 0) || !string.IsNullOrEmpty(lateResize))
+            {
+                Interlocked.CompareExchange(ref s_inputSignal, null, tcs);
+                if (lateInput != null && lateInput.Length > 0)
+                {
+                    return new ReadOnlyMemory<byte>(lateInput);
+                }
+                continue;
+            }
+
             try
             {
-                await Task.Delay(50, ct);
+                using var reg = ct.Register(static state => ((TaskCompletionSource)state!).TrySetCanceled(), tcs);
+                await tcs.Task;
             }
             catch (OperationCanceledException)
             {
@@ -97,4 +117,16 @@ public sealed partial class BlazorPresentationAdapter : Hex1b.IHex1bTerminalPres
 
     [JSImport("globalThis.termInterop.pollResize")]
     internal static partial string PollResize();
+
+    /// <summary>
+    /// Called from interop.js whenever new input or a resize has been enqueued.
+    /// Wakes any pending <see cref="ReadInputAsync"/> call immediately so input
+    /// latency does not depend on a poll interval.
+    /// </summary>
+    [JSExport]
+    internal static void SignalInputAvailable()
+    {
+        var tcs = Interlocked.Exchange(ref s_inputSignal, null);
+        tcs?.TrySetResult();
+    }
 }

--- a/samples/BlazorDemo/GlobeRunner.cs
+++ b/samples/BlazorDemo/GlobeRunner.cs
@@ -150,7 +150,6 @@ public static class GlobeRunner
             .WithMouse()
             .Build();
 
-        Console.WriteLine("[blazor] Terminal built, starting RunAsync");
         await terminal.RunAsync();
     }
 

--- a/samples/BlazorDemo/GlobeRunner.cs
+++ b/samples/BlazorDemo/GlobeRunner.cs
@@ -45,9 +45,11 @@ public static class GlobeRunner
             Poi("Undervault",         1.4,   103.8,  "3.8M",  "Echo Stone",       "Drilling Rigs",    "40°C / 28°C", "Deepkin 45%, Ashborn 35%, Terran 20%"),
         };
 
-        // Cached arrays for GC pressure reduction
-        bool[,]? cachedBrailleGrid = null;
-        double[,]? cachedDotAlt = null;
+        // Cached arrays for GC pressure reduction. Flat 1D arrays — interpreted
+        // Mono WASM accesses T[] ~10x faster than T[,] in the hot painting loop.
+        // Index convention: idx = x * dotH + y.
+        bool[]? cachedBrailleGrid = null;
+        double[]? cachedDotAlt = null;
         int cachedDotW = 0, cachedDotH = 0;
         var cachedProjectedPois = new List<(int cx, int cy, double distToCenter, string name, double z, int poiIdx)>();
         var cachedOccupiedRows = new Dictionary<int, List<(int start, int end)>>();
@@ -158,7 +160,7 @@ public static class GlobeRunner
         Quaternion rotQ, double zoom,
         List<PointOfInterest> pois,
         List<(string name, int cx, int cy, int poiIndex)> poiScreenOut,
-        ref bool[,]? cachedBrailleGrid, ref double[,]? cachedDotAlt,
+        ref bool[]? cachedBrailleGrid, ref double[]? cachedDotAlt,
         ref int cachedDotW, ref int cachedDotH,
         List<(int cx, int cy, double distToCenter, string name, double z, int poiIdx)> cachedProjectedPois,
         Dictionary<int, List<(int start, int end)>> cachedOccupiedRows)
@@ -172,8 +174,8 @@ public static class GlobeRunner
 
         if (cachedBrailleGrid == null || cachedDotW != dotW || cachedDotH != dotH)
         {
-            cachedBrailleGrid = new bool[dotW, dotH];
-            cachedDotAlt = new double[dotW, dotH];
+            cachedBrailleGrid = new bool[dotW * dotH];
+            cachedDotAlt = new double[dotW * dotH];
             cachedDotW = dotW;
             cachedDotH = dotH;
         }
@@ -219,18 +221,24 @@ public static class GlobeRunner
                 int bx = cx * 2;
                 int by = cy * 4;
 
-                // Terrain pass
+                // Terrain pass. dotW = cellW*2 and dotH = cellH*4 by construction,
+                // so every (bx+{0,1}, by+{0..3}) probe is in bounds — no per-cell
+                // bounds checking required.
+                int col0 = bx * dotH;
+                int col1 = (bx + 1) * dotH;
+
                 int pattern = 0;
                 double bestAlt = 0;
 
-                if (bx >= 0 && bx < dotW && by >= 0 && by < dotH && brailleGrid[bx, by]) { pattern |= 0x01; bestAlt = dotAlt[bx, by]; }
-                if (bx >= 0 && bx < dotW && by+1 >= 0 && by+1 < dotH && brailleGrid[bx, by+1]) { pattern |= 0x02; bestAlt = dotAlt[bx, by+1]; }
-                if (bx >= 0 && bx < dotW && by+2 >= 0 && by+2 < dotH && brailleGrid[bx, by+2]) { pattern |= 0x04; bestAlt = dotAlt[bx, by+2]; }
-                if (bx+1 >= 0 && bx+1 < dotW && by >= 0 && by < dotH && brailleGrid[bx+1, by]) { pattern |= 0x08; bestAlt = dotAlt[bx+1, by]; }
-                if (bx+1 >= 0 && bx+1 < dotW && by+1 >= 0 && by+1 < dotH && brailleGrid[bx+1, by+1]) { pattern |= 0x10; bestAlt = dotAlt[bx+1, by+1]; }
-                if (bx+1 >= 0 && bx+1 < dotW && by+2 >= 0 && by+2 < dotH && brailleGrid[bx+1, by+2]) { pattern |= 0x20; bestAlt = dotAlt[bx+1, by+2]; }
-                if (bx >= 0 && bx < dotW && by+3 >= 0 && by+3 < dotH && brailleGrid[bx, by+3]) { pattern |= 0x40; bestAlt = dotAlt[bx, by+3]; }
-                if (bx+1 >= 0 && bx+1 < dotW && by+3 >= 0 && by+3 < dotH && brailleGrid[bx+1, by+3]) { pattern |= 0x80; bestAlt = dotAlt[bx+1, by+3]; }
+                int idx;
+                idx = col0 + by;     if (brailleGrid[idx])     { pattern |= 0x01; bestAlt = dotAlt[idx]; }
+                idx = col0 + by + 1; if (brailleGrid[idx])     { pattern |= 0x02; bestAlt = dotAlt[idx]; }
+                idx = col0 + by + 2; if (brailleGrid[idx])     { pattern |= 0x04; bestAlt = dotAlt[idx]; }
+                idx = col1 + by;     if (brailleGrid[idx])     { pattern |= 0x08; bestAlt = dotAlt[idx]; }
+                idx = col1 + by + 1; if (brailleGrid[idx])     { pattern |= 0x10; bestAlt = dotAlt[idx]; }
+                idx = col1 + by + 2; if (brailleGrid[idx])     { pattern |= 0x20; bestAlt = dotAlt[idx]; }
+                idx = col0 + by + 3; if (brailleGrid[idx])     { pattern |= 0x40; bestAlt = dotAlt[idx]; }
+                idx = col1 + by + 3; if (brailleGrid[idx])     { pattern |= 0x80; bestAlt = dotAlt[idx]; }
 
                 if (pattern != 0)
                 {
@@ -353,7 +361,7 @@ public static class GlobeRunner
         }
     }
 
-    static void DrawLineWithAlt(bool[,] grid, double[,] altGrid,
+    static void DrawLineWithAlt(bool[] grid, double[] altGrid,
         int w, int h, int x0, int y0, int x1, int y1, double alt)
     {
         int dx = Math.Abs(x1 - x0), sx = x0 < x1 ? 1 : -1;
@@ -362,10 +370,11 @@ public static class GlobeRunner
 
         while (true)
         {
-            if (x0 >= 0 && x0 < w && y0 >= 0 && y0 < h)
+            if ((uint)x0 < (uint)w && (uint)y0 < (uint)h)
             {
-                grid[x0, y0] = true;
-                altGrid[x0, y0] = alt;
+                int idx = x0 * h + y0;
+                grid[idx] = true;
+                altGrid[idx] = alt;
             }
             if (x0 == x1 && y0 == y1) break;
             int e2 = 2 * err;

--- a/samples/BlazorDemo/run-aot.sh
+++ b/samples/BlazorDemo/run-aot.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Publish the BlazorDemo with Mono AOT and serve the static output locally.
+#
+# Why this script exists:
+#   `dotnet run` on a Blazor WASM project always uses the interpreter — the
+#   dev server skips the AOT toolchain because AOT publishing takes minutes.
+#   For interactive perf testing of the WASM hosting story we want the AOT
+#   build, which is dramatically faster on hot numeric loops (the globe paint
+#   loop in particular goes from ~3 fps to "completely usable").
+#
+# Usage:
+#   ./samples/BlazorDemo/run-aot.sh           # publish + serve on :5050
+#   PORT=8080 ./samples/BlazorDemo/run-aot.sh # pick a different port
+#
+# Requires: `wasm-tools` workload (dotnet workload install wasm-tools).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT="$SCRIPT_DIR/BlazorDemo.csproj"
+PORT="${PORT:-5050}"
+
+echo "[run-aot] Publishing $(basename "$PROJECT") (Release + AOT)..."
+echo "[run-aot] (first publish takes 1-3 minutes; incremental publishes are faster)"
+dotnet publish "$PROJECT" -c Release --nologo
+
+WWWROOT="$SCRIPT_DIR/bin/Release/net10.0/publish/wwwroot"
+if [[ ! -d "$WWWROOT" ]]; then
+  echo "[run-aot] publish output not found at $WWWROOT" >&2
+  exit 1
+fi
+
+# If a previous run-aot.sh (or anything else) is already bound to PORT,
+# stop it so this run can take over. Without this you'd see a confusing
+# "Address already in use" after re-running the script.
+if command -v lsof >/dev/null 2>&1; then
+  stale_pids=$(lsof -nP -t -iTCP:"$PORT" -sTCP:LISTEN 2>/dev/null || true)
+  if [[ -n "$stale_pids" ]]; then
+    echo "[run-aot] Port $PORT is in use by PID(s): $stale_pids — terminating."
+    # shellcheck disable=SC2086
+    kill $stale_pids 2>/dev/null || true
+    sleep 1
+    # Force-kill any survivors.
+    survivors=$(lsof -nP -t -iTCP:"$PORT" -sTCP:LISTEN 2>/dev/null || true)
+    if [[ -n "$survivors" ]]; then
+      # shellcheck disable=SC2086
+      kill -9 $survivors 2>/dev/null || true
+      sleep 1
+    fi
+  fi
+fi
+
+echo "[run-aot] Serving $WWWROOT on http://localhost:$PORT ..."
+echo "[run-aot] (Ctrl+C to stop; hard-reload Cmd+Shift+R after each republish)"
+cd "$WWWROOT"
+exec python3 -m http.server "$PORT"

--- a/samples/BlazorDemo/wwwroot/js/interop.js
+++ b/samples/BlazorDemo/wwwroot/js/interop.js
@@ -52,6 +52,7 @@
                 const bytes = new TextEncoder().encode(data);
                 inputChunks.push(bytes);
                 if (_pendingInputTimestamp === null) _pendingInputTimestamp = performance.now();
+                console.log(`[diag] onData ${bytes.length}B, q=${inputChunks.length}, sample=${JSON.stringify(data.slice(0, 24))}`);
                 // Wake .NET's ReadInputAsync immediately (set by App.razor once exports load).
                 if (window.__hex1bSignalInput) window.__hex1bSignalInput();
             });
@@ -61,6 +62,7 @@
                 for (let i = 0; i < data.length; i++) bytes[i] = data.charCodeAt(i);
                 inputChunks.push(bytes);
                 if (_pendingInputTimestamp === null) _pendingInputTimestamp = performance.now();
+                console.log(`[diag] onBinary ${bytes.length}B, q=${inputChunks.length}`);
                 if (window.__hex1bSignalInput) window.__hex1bSignalInput();
             });
 
@@ -128,6 +130,7 @@
                 offset += chunk.length;
             }
             inputChunks.length = 0;
+            console.log(`[diag] pollAllInput drained ${totalLen}B`);
             return result;
         },
 

--- a/samples/BlazorDemo/wwwroot/js/interop.js
+++ b/samples/BlazorDemo/wwwroot/js/interop.js
@@ -52,7 +52,6 @@
                 const bytes = new TextEncoder().encode(data);
                 inputChunks.push(bytes);
                 if (_pendingInputTimestamp === null) _pendingInputTimestamp = performance.now();
-                console.log(`[diag] onData ${bytes.length}B, q=${inputChunks.length}, sample=${JSON.stringify(data.slice(0, 24))}`);
                 // Wake .NET's ReadInputAsync immediately (set by App.razor once exports load).
                 if (window.__hex1bSignalInput) window.__hex1bSignalInput();
             });
@@ -62,7 +61,6 @@
                 for (let i = 0; i < data.length; i++) bytes[i] = data.charCodeAt(i);
                 inputChunks.push(bytes);
                 if (_pendingInputTimestamp === null) _pendingInputTimestamp = performance.now();
-                console.log(`[diag] onBinary ${bytes.length}B, q=${inputChunks.length}`);
                 if (window.__hex1bSignalInput) window.__hex1bSignalInput();
             });
 
@@ -130,7 +128,6 @@
                 offset += chunk.length;
             }
             inputChunks.length = 0;
-            console.log(`[diag] pollAllInput drained ${totalLen}B`);
             return result;
         },
 

--- a/samples/BlazorDemo/wwwroot/js/interop.js
+++ b/samples/BlazorDemo/wwwroot/js/interop.js
@@ -12,6 +12,9 @@
     let _burstCount = 0;
     let _lastTime = 0;
 
+    // m-input-latency: time from the first un-served input to the next postOutput.
+    let _pendingInputTimestamp = null;
+
     window.termInterop = {
         // Initialize xterm.js — called from Blazor component
         init: function () {
@@ -48,6 +51,7 @@
                 }
                 const bytes = new TextEncoder().encode(data);
                 inputChunks.push(bytes);
+                if (_pendingInputTimestamp === null) _pendingInputTimestamp = performance.now();
                 // Wake .NET's ReadInputAsync immediately (set by App.razor once exports load).
                 if (window.__hex1bSignalInput) window.__hex1bSignalInput();
             });
@@ -56,6 +60,7 @@
                 const bytes = new Uint8Array(data.length);
                 for (let i = 0; i < data.length; i++) bytes[i] = data.charCodeAt(i);
                 inputChunks.push(bytes);
+                if (_pendingInputTimestamp === null) _pendingInputTimestamp = performance.now();
                 if (window.__hex1bSignalInput) window.__hex1bSignalInput();
             });
 
@@ -84,6 +89,13 @@
             _frameCount++;
             const gap = now - _lastTime;
             _lastTime = now;
+
+            if (_pendingInputTimestamp !== null) {
+                const latency = now - _pendingInputTimestamp;
+                _pendingInputTimestamp = null;
+                console.log(`[perf] input->frame latency: ${latency.toFixed(1)}ms`);
+            }
+
             if (gap > 30) {
                 if (_burstCount > 0) {
                     const burstDuration = (now - gap) - _burstStart;
@@ -95,6 +107,10 @@
                 _burstCount++;
             }
 
+            // data is a Uint8Array view over WASM memory (JSType.MemoryView).
+            // Copy bounded to the view's range — never clone the underlying
+            // WASM heap by passing the view directly to consumers that hold on
+            // to it past the synchronous call.
             const copy = new Uint8Array(data.length);
             copy.set(data);
             term.write(copy);

--- a/samples/BlazorDemo/wwwroot/js/interop.js
+++ b/samples/BlazorDemo/wwwroot/js/interop.js
@@ -48,12 +48,15 @@
                 }
                 const bytes = new TextEncoder().encode(data);
                 inputChunks.push(bytes);
+                // Wake .NET's ReadInputAsync immediately (set by App.razor once exports load).
+                if (window.__hex1bSignalInput) window.__hex1bSignalInput();
             });
 
             term.onBinary(function (data) {
                 const bytes = new Uint8Array(data.length);
                 for (let i = 0; i < data.length; i++) bytes[i] = data.charCodeAt(i);
                 inputChunks.push(bytes);
+                if (window.__hex1bSignalInput) window.__hex1bSignalInput();
             });
 
             // Debounced resize
@@ -63,6 +66,7 @@
                 if (resizeTimer) clearTimeout(resizeTimer);
                 resizeTimer = setTimeout(() => {
                     pendingResize = size.cols + ',' + size.rows;
+                    if (window.__hex1bSignalInput) window.__hex1bSignalInput();
                     resizeTimer = null;
                 }, 100);
             });
@@ -116,6 +120,29 @@
             const r = pendingResize;
             pendingResize = '';
             return r;
+        },
+
+        // Looks up the C# [JSExport] SignalInputAvailable on the running .NET
+        // runtime and stashes a callable reference so the input/resize handlers
+        // can wake ReadInputAsync immediately. Falls back to a no-op if the
+        // runtime API isn't available (e.g. older Blazor build); the .NET-side
+        // poll fallback covers that case at the cost of 50ms latency.
+        attachSignal: async function (assemblyName) {
+            try {
+                const runtime = globalThis.getDotnetRuntime ? globalThis.getDotnetRuntime(0) : null;
+                if (!runtime || !runtime.getAssemblyExports) {
+                    console.warn('[blazor] dotnet runtime API unavailable; staying on poll fallback');
+                    return;
+                }
+                const exports = await runtime.getAssemblyExports(assemblyName);
+                window.__hex1bSignalInput =
+                    exports?.[assemblyName]?.BlazorPresentationAdapter?.SignalInputAvailable;
+                if (!window.__hex1bSignalInput) {
+                    console.warn('[blazor] SignalInputAvailable export not found');
+                }
+            } catch (e) {
+                console.warn('[blazor] attachSignal failed:', e);
+            }
         }
     };
 })();

--- a/samples/BlazorDemo/wwwroot/js/interop.js
+++ b/samples/BlazorDemo/wwwroot/js/interop.js
@@ -6,15 +6,6 @@
     const inputChunks = [];
     let pendingResize = '';
 
-    // Burst timing instrumentation
-    let _frameCount = 0;
-    let _burstStart = 0;
-    let _burstCount = 0;
-    let _lastTime = 0;
-
-    // m-input-latency: time from the first un-served input to the next postOutput.
-    let _pendingInputTimestamp = null;
-
     window.termInterop = {
         // Initialize xterm.js — called from Blazor component
         init: function () {
@@ -51,7 +42,6 @@
                 }
                 const bytes = new TextEncoder().encode(data);
                 inputChunks.push(bytes);
-                if (_pendingInputTimestamp === null) _pendingInputTimestamp = performance.now();
                 // Wake .NET's ReadInputAsync immediately (set by App.razor once exports load).
                 if (window.__hex1bSignalInput) window.__hex1bSignalInput();
             });
@@ -60,7 +50,6 @@
                 const bytes = new Uint8Array(data.length);
                 for (let i = 0; i < data.length; i++) bytes[i] = data.charCodeAt(i);
                 inputChunks.push(bytes);
-                if (_pendingInputTimestamp === null) _pendingInputTimestamp = performance.now();
                 if (window.__hex1bSignalInput) window.__hex1bSignalInput();
             });
 
@@ -83,29 +72,6 @@
         // [JSImport] target — write output bytes directly to xterm
         postOutput: function (data) {
             if (!term) return;
-
-            // Burst timing
-            const now = performance.now();
-            _frameCount++;
-            const gap = now - _lastTime;
-            _lastTime = now;
-
-            if (_pendingInputTimestamp !== null) {
-                const latency = now - _pendingInputTimestamp;
-                _pendingInputTimestamp = null;
-                console.log(`[perf] input->frame latency: ${latency.toFixed(1)}ms`);
-            }
-
-            if (gap > 30) {
-                if (_burstCount > 0) {
-                    const burstDuration = (now - gap) - _burstStart;
-                    console.log(`[perf] burst: ${_burstCount} writes in ${burstDuration.toFixed(0)}ms, then ${gap.toFixed(0)}ms idle (total frames: ${_frameCount})`);
-                }
-                _burstStart = now;
-                _burstCount = 1;
-            } else {
-                _burstCount++;
-            }
 
             // data is a Uint8Array view over WASM memory (JSType.MemoryView).
             // Copy bounded to the view's range — never clone the underlying

--- a/samples/BlazorPerfStressDemo/App.razor
+++ b/samples/BlazorPerfStressDemo/App.razor
@@ -20,8 +20,6 @@
 
         _ = JS.InvokeVoidAsync("termInterop.attachSignal", "BlazorPerfStressDemo").AsTask();
 
-        Console.WriteLine($"[blazor] Starting perf stress ({cols}x{rows})");
-
         try
         {
             await PerfStressRunner.RunAsync(cols, rows);

--- a/samples/BlazorPerfStressDemo/App.razor
+++ b/samples/BlazorPerfStressDemo/App.razor
@@ -1,0 +1,34 @@
+@using Microsoft.JSInterop
+@inject IJSRuntime JS
+
+@code {
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender) return;
+
+        var sizeStr = await JS.InvokeAsync<string>("termInterop.init");
+        int cols = 80, rows = 24;
+        if (!string.IsNullOrEmpty(sizeStr))
+        {
+            var parts = sizeStr.Split(',');
+            if (parts.Length == 2 && int.TryParse(parts[0], out var c) && int.TryParse(parts[1], out var r))
+            {
+                cols = c;
+                rows = r;
+            }
+        }
+
+        _ = JS.InvokeVoidAsync("termInterop.attachSignal", "BlazorPerfStressDemo").AsTask();
+
+        Console.WriteLine($"[blazor] Starting perf stress ({cols}x{rows})");
+
+        try
+        {
+            await PerfStressRunner.RunAsync(cols, rows);
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"[blazor] Perf stress error: {ex}");
+        }
+    }
+}

--- a/samples/BlazorPerfStressDemo/BlazorPerfStressDemo.csproj
+++ b/samples/BlazorPerfStressDemo/BlazorPerfStressDemo.csproj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
+    <WasmInitialHeapSize>134217728</WasmInitialHeapSize>
+    <EmccMaximumHeapSize>536870912</EmccMaximumHeapSize>
+    <RootNamespace>BlazorPerfStressDemo</RootNamespace>
+  </PropertyGroup>
+
+  <!--
+    AOT-compile the Mono IL to WebAssembly when publishing in Release.
+    See ../BlazorDemo/BlazorDemo.csproj for the rationale.
+  -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <RunAOTCompilation>true</RunAOTCompilation>
+    <WasmStripILAfterAOT>true</WasmStripILAfterAOT>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.2" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Hex1b/Hex1b.csproj" />
+  </ItemGroup>
+
+  <!--
+    Link the page sources directly from PerfStressDemo so this project tracks
+    any future changes without duplicating code. Only the first two stress
+    pages are included; the whirlpool page depends on mouse-input details
+    that the BlazorPresentationAdapter doesn't currently model uniformly.
+  -->
+  <ItemGroup>
+    <Compile Include="..\PerfStressDemo\IStressPage.cs" Link="Pages\IStressPage.cs" />
+    <Compile Include="..\PerfStressDemo\RippleOverNoisePage.cs" Link="Pages\RippleOverNoisePage.cs" />
+    <Compile Include="..\PerfStressDemo\PondRipplePage.cs" Link="Pages\PondRipplePage.cs" />
+  </ItemGroup>
+
+</Project>

--- a/samples/BlazorPerfStressDemo/BlazorPresentationAdapter.cs
+++ b/samples/BlazorPerfStressDemo/BlazorPresentationAdapter.cs
@@ -36,26 +36,9 @@ public sealed partial class BlazorPresentationAdapter : Hex1b.IHex1bTerminalPres
     public event Action<int, int>? Resized;
     public event Action? Disconnected;
 
-    // Lightweight perf counters (printed once per second from WriteOutputAsync).
-    private static long s_perfWindowStartTicks;
-    private static int s_perfWriteCount;
-    private static long s_perfByteCount;
-
     public ValueTask WriteOutputAsync(ReadOnlyMemory<byte> data, CancellationToken ct)
     {
         PostOutput(data.ToArray());
-
-        var now = Environment.TickCount64;
-        if (s_perfWindowStartTicks == 0) s_perfWindowStartTicks = now;
-        s_perfWriteCount++;
-        s_perfByteCount += data.Length;
-        if (now - s_perfWindowStartTicks >= 1000)
-        {
-            Console.WriteLine($"[perf] last 1s: writes={s_perfWriteCount} bytes={s_perfByteCount}");
-            s_perfWindowStartTicks = now;
-            s_perfWriteCount = 0;
-            s_perfByteCount = 0;
-        }
         return ValueTask.CompletedTask;
     }
 

--- a/samples/BlazorPerfStressDemo/BlazorPresentationAdapter.cs
+++ b/samples/BlazorPerfStressDemo/BlazorPresentationAdapter.cs
@@ -1,0 +1,157 @@
+using System.Runtime.InteropServices.JavaScript;
+
+namespace BlazorPerfStressDemo;
+
+/// <summary>
+/// IHex1bTerminalPresentationAdapter for Blazor WASM using [JSImport] for fast interop.
+/// Runs on the main thread — no cross-thread marshaling overhead.
+/// </summary>
+public sealed partial class BlazorPresentationAdapter : Hex1b.IHex1bTerminalPresentationAdapter
+{
+    private int _width;
+    private int _height;
+
+    // Event-driven input signal — see WasmPresentationAdapter for rationale.
+    private static TaskCompletionSource? s_inputSignal;
+
+    public BlazorPresentationAdapter(int initialCols = 80, int initialRows = 24)
+    {
+        _width = initialCols;
+        _height = initialRows;
+    }
+
+    public int Width => _width;
+    public int Height => _height;
+
+    public Hex1b.TerminalCapabilities Capabilities => new()
+    {
+        SupportsTrueColor = true,
+        Supports256Colors = true,
+        SupportsAlternateScreen = true,
+        SupportsBracketedPaste = true,
+        SupportsSixel = false,
+        SupportsMouse = true
+    };
+
+    public event Action<int, int>? Resized;
+    public event Action? Disconnected;
+
+    // Lightweight perf counters (printed once per second from WriteOutputAsync).
+    private static long s_perfWindowStartTicks;
+    private static int s_perfWriteCount;
+    private static long s_perfByteCount;
+
+    public ValueTask WriteOutputAsync(ReadOnlyMemory<byte> data, CancellationToken ct)
+    {
+        PostOutput(data.ToArray());
+
+        var now = Environment.TickCount64;
+        if (s_perfWindowStartTicks == 0) s_perfWindowStartTicks = now;
+        s_perfWriteCount++;
+        s_perfByteCount += data.Length;
+        if (now - s_perfWindowStartTicks >= 1000)
+        {
+            Console.WriteLine($"[perf] last 1s: writes={s_perfWriteCount} bytes={s_perfByteCount}");
+            s_perfWindowStartTicks = now;
+            s_perfWriteCount = 0;
+            s_perfByteCount = 0;
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask<ReadOnlyMemory<byte>> ReadInputAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            var resize = PollResize();
+            if (!string.IsNullOrEmpty(resize))
+            {
+                var parts = resize.Split(',');
+                if (parts.Length == 2 && int.TryParse(parts[0], out var cols) && int.TryParse(parts[1], out var rows))
+                {
+                    if (cols != _width || rows != _height)
+                    {
+                        _width = cols;
+                        _height = rows;
+                        _ = Task.Run(() => Resized?.Invoke(cols, rows));
+                    }
+                }
+            }
+
+            // Drain all queued input at once for responsiveness
+            var allInput = PollAllInput();
+            if (allInput != null && allInput.Length > 0)
+            {
+                return new ReadOnlyMemory<byte>(allInput);
+            }
+
+            // Install a signal and recheck to close the race between drain and registration.
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            Interlocked.Exchange(ref s_inputSignal, tcs);
+
+            var lateInput = PollAllInput();
+            var lateResize = PollResize();
+            if ((lateInput != null && lateInput.Length > 0) || !string.IsNullOrEmpty(lateResize))
+            {
+                Interlocked.CompareExchange(ref s_inputSignal, null, tcs);
+                if (lateInput != null && lateInput.Length > 0)
+                {
+                    return new ReadOnlyMemory<byte>(lateInput);
+                }
+                continue;
+            }
+
+            try
+            {
+                using var reg = ct.Register(static state => ((TaskCompletionSource)state!).TrySetCanceled(), tcs);
+                // Race the signal against a 50ms poll fallback. When SignalInputAvailable
+                // is wired via [JSExport] (the f1 fast path), tcs.Task wins and we get
+                // sub-millisecond wake-up. When the runtime-API wiring fails to attach
+                // (e.g. globalThis.getDotnetRuntime not exposed in the current Blazor
+                // boot path), Task.Delay wins and we degrade to the original 50ms poll
+                // behaviour instead of blocking ReadInputAsync forever.
+                await Task.WhenAny(tcs.Task, Task.Delay(50, ct));
+                Interlocked.CompareExchange(ref s_inputSignal, null, tcs);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+        }
+
+        return ReadOnlyMemory<byte>.Empty;
+    }
+
+    public ValueTask FlushAsync(CancellationToken ct) => ValueTask.CompletedTask;
+    public ValueTask EnterRawModeAsync(CancellationToken ct) => ValueTask.CompletedTask;
+    public ValueTask ExitRawModeAsync(CancellationToken ct) => ValueTask.CompletedTask;
+
+    public (int Row, int Column) GetCursorPosition() => (0, 0);
+
+    public ValueTask DisposeAsync()
+    {
+        Disconnected?.Invoke();
+        return ValueTask.CompletedTask;
+    }
+
+    [JSImport("globalThis.termInterop.postOutput")]
+    internal static partial void PostOutput(byte[] data);
+
+    [JSImport("globalThis.termInterop.pollAllInput")]
+    internal static partial byte[]? PollAllInput();
+
+    [JSImport("globalThis.termInterop.pollResize")]
+    internal static partial string PollResize();
+
+    /// <summary>
+    /// Called from interop.js whenever new input or a resize has been enqueued.
+    /// Wakes any pending <see cref="ReadInputAsync"/> call immediately so input
+    /// latency does not depend on a poll interval.
+    /// </summary>
+    [JSExport]
+    internal static void SignalInputAvailable()
+    {
+        var tcs = Interlocked.Exchange(ref s_inputSignal, null);
+        tcs?.TrySetResult();
+    }
+}

--- a/samples/BlazorPerfStressDemo/PerfStressRunner.cs
+++ b/samples/BlazorPerfStressDemo/PerfStressRunner.cs
@@ -1,0 +1,144 @@
+using System.Diagnostics;
+using Hex1b;
+using Hex1b.Input;
+using Hex1b.Widgets;
+using PerfStressDemo;
+
+namespace BlazorPerfStressDemo;
+
+/// <summary>
+/// Blazor-WASM-hosted version of PerfStressDemo. Mirrors
+/// <c>samples/PerfStressDemo/Program.cs</c> but:
+///   * scoped to the first two pages (RippleOverNoise + PondRipple) — those
+///     are the ones that are pure render-cost workloads suitable for
+///     comparing native-terminal vs WASM perf;
+///   * wired to <see cref="BlazorPresentationAdapter"/> instead of stdout;
+///   * uses defaults instead of CLI flags (browsers don't take argv).
+/// </summary>
+public static class PerfStressRunner
+{
+    public static async Task RunAsync(int initialCols, int initialRows)
+    {
+        const bool enablePool = true;
+        const bool enableCache = true;
+        const int targetFps = 30;
+
+        int redrawIntervalMs = Math.Max(1, 1000 / targetFps);
+
+        var pages = new IStressPage[]
+        {
+            new RippleOverNoisePage(),
+            new PondRipplePage(),
+        };
+        int currentPageIndex = 0;
+
+        var clock = Stopwatch.StartNew();
+        long frameCount = 0;
+        double lastFpsSampleSeconds = 0;
+        long lastFpsSampleFrames = 0;
+        double currentFps = 0;
+        int baselineGen0 = GC.CollectionCount(0);
+        int baselineGen1 = GC.CollectionCount(1);
+        int baselineGen2 = GC.CollectionCount(2);
+
+        Hex1bApp? appRef = null;
+        var adapter = new BlazorPresentationAdapter(initialCols, initialRows);
+
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithPresentation(adapter)
+            .WithMouse()
+            .WithHex1bApp(
+                o =>
+                {
+                    o.EnableSurfacePooling = enablePool;
+                    o.EnableRenderCaching = enableCache;
+                    o.FrameRateLimitMs = redrawIntervalMs;
+                },
+                app =>
+                {
+                    appRef = app;
+                    return ctx => BuildRoot(ctx);
+                })
+            .Build();
+
+        Console.WriteLine("[blazor] Perf stress terminal built, starting RunAsync");
+        await terminal.RunAsync();
+        return;
+
+        Hex1bWidget BuildRoot(RootContext root)
+        {
+            frameCount++;
+
+            var nowSeconds = clock.Elapsed.TotalSeconds;
+            var dt = nowSeconds - lastFpsSampleSeconds;
+            if (dt >= 0.5)
+            {
+                currentFps = (frameCount - lastFpsSampleFrames) / dt;
+                lastFpsSampleFrames = frameCount;
+                lastFpsSampleSeconds = nowSeconds;
+            }
+
+            var page = pages[currentPageIndex];
+            var stressCtx = new StressContext(root, nowSeconds, redrawIntervalMs);
+            var pageWidget = page.Build(stressCtx);
+
+            var gen0 = GC.CollectionCount(0) - baselineGen0;
+            var gen1 = GC.CollectionCount(1) - baselineGen1;
+            var gen2 = GC.CollectionCount(2) - baselineGen2;
+
+            var pageLabel = $"Page {currentPageIndex + 1}/{pages.Length}: {page.Name}";
+            var perfLabel = $"{currentFps,5:0.0} fps  GC[0/1/2]={gen0}/{gen1}/{gen2}";
+
+            var rootWidget = root.VStack(v => new Hex1bWidget[]
+            {
+                pageWidget.Fill(),
+                v.InfoBar(s => new IInfoBarChild[]
+                {
+                    s.Section(pageLabel).FillWidth(),
+                    s.Divider(" │ "),
+                    s.Section(perfLabel),
+                    s.Divider(" │ "),
+                    s.Section($"ripple={RippleOverNoisePage.LevelsLabel}  pond={PondRipplePage.PresetLabel}"),
+                    s.Divider(" │ "),
+                    s.Section("PgUp/PgDn switch  L levels  V viscosity  Q quit"),
+                }),
+            });
+
+            if (!page.IsIdle)
+                rootWidget = rootWidget.RedrawAfter(redrawIntervalMs);
+
+            return rootWidget
+                .InputBindings(bindings =>
+                {
+                    bindings.Key(Hex1bKey.PageDown).Global().Action(_ =>
+                    {
+                        currentPageIndex = (currentPageIndex + 1) % pages.Length;
+                    }, "Next page");
+
+                    bindings.Key(Hex1bKey.PageUp).Global().Action(_ =>
+                    {
+                        currentPageIndex = (currentPageIndex - 1 + pages.Length) % pages.Length;
+                    }, "Previous page");
+
+                    bindings.Key(Hex1bKey.Q).Global().Action(_ => appRef?.RequestStop(), "Quit");
+
+                    bindings.Key(Hex1bKey.L).Global().Action(_ =>
+                    {
+                        RippleOverNoisePage.Levels = RippleOverNoisePage.Levels switch
+                        {
+                            >= 256 => 16,
+                            16 => 8,
+                            8 => 4,
+                            4 => 2,
+                            _ => 256,
+                        };
+                    }, "Cycle ripple levels");
+
+                    bindings.Key(Hex1bKey.V).Global().Action(_ =>
+                    {
+                        PondRipplePage.CyclePreset();
+                    }, "Cycle pond viscosity");
+                });
+        }
+    }
+}

--- a/samples/BlazorPerfStressDemo/PerfStressRunner.cs
+++ b/samples/BlazorPerfStressDemo/PerfStressRunner.cs
@@ -61,7 +61,6 @@ public static class PerfStressRunner
                 })
             .Build();
 
-        Console.WriteLine("[blazor] Perf stress terminal built, starting RunAsync");
         await terminal.RunAsync();
         return;
 

--- a/samples/BlazorPerfStressDemo/Program.cs
+++ b/samples/BlazorPerfStressDemo/Program.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using BlazorPerfStressDemo;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+builder.RootComponents.Add<App>("#app");
+builder.RootComponents.Add<HeadOutlet>("head::after");
+
+await builder.Build().RunAsync();

--- a/samples/BlazorPerfStressDemo/_Imports.razor
+++ b/samples/BlazorPerfStressDemo/_Imports.razor
@@ -1,0 +1,4 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.JSInterop
+@using BlazorPerfStressDemo

--- a/samples/BlazorPerfStressDemo/run-aot.sh
+++ b/samples/BlazorPerfStressDemo/run-aot.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# See ../BlazorDemo/run-aot.sh for the full rationale. This is the
+# perf-stress variant — Release+AOT publish, served on :5051 by default
+# so it can coexist with BlazorDemo on :5050.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT="$SCRIPT_DIR/BlazorPerfStressDemo.csproj"
+PORT="${PORT:-5051}"
+
+echo "[run-aot] Publishing $(basename "$PROJECT") (Release + AOT)..."
+echo "[run-aot] (first publish takes 1-3 minutes; incremental publishes are faster)"
+dotnet publish "$PROJECT" -c Release --nologo
+
+WWWROOT="$SCRIPT_DIR/bin/Release/net10.0/publish/wwwroot"
+if [[ ! -d "$WWWROOT" ]]; then
+  echo "[run-aot] publish output not found at $WWWROOT" >&2
+  exit 1
+fi
+
+if command -v lsof >/dev/null 2>&1; then
+  stale_pids=$(lsof -nP -t -iTCP:"$PORT" -sTCP:LISTEN 2>/dev/null || true)
+  if [[ -n "$stale_pids" ]]; then
+    echo "[run-aot] Port $PORT is in use by PID(s): $stale_pids — terminating."
+    # shellcheck disable=SC2086
+    kill $stale_pids 2>/dev/null || true
+    sleep 1
+    survivors=$(lsof -nP -t -iTCP:"$PORT" -sTCP:LISTEN 2>/dev/null || true)
+    if [[ -n "$survivors" ]]; then
+      # shellcheck disable=SC2086
+      kill -9 $survivors 2>/dev/null || true
+      sleep 1
+    fi
+  fi
+fi
+
+echo "[run-aot] Serving $WWWROOT on http://localhost:$PORT ..."
+echo "[run-aot] (Ctrl+C to stop; hard-reload Cmd+Shift+R after each republish)"
+cd "$WWWROOT"
+exec python3 -m http.server "$PORT"

--- a/samples/BlazorPerfStressDemo/wwwroot/index.html
+++ b/samples/BlazorPerfStressDemo/wwwroot/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Perf Stress Demo — Blazor WASM</title>
+    <base href="/" />
+    <link rel="preload" id="webassembly" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css" crossorigin="anonymous">
+    <style>
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        html, body { width: 100%; height: 100%; background: #1e1e1e; overflow: hidden; }
+        #terminal { width: 100%; height: 100%; }
+        #app { display: none; }
+        .loading-progress, .loading-progress-text, #blazor-error-ui { display: none; }
+    </style>
+    <script type="importmap"></script>
+</head>
+<body>
+    <div id="app"></div>
+    <div id="terminal"></div>
+
+    <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js" crossorigin="anonymous"></script>
+    <script src="js/interop.js"></script>
+    <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
+</body>
+</html>

--- a/samples/BlazorPerfStressDemo/wwwroot/js/interop.js
+++ b/samples/BlazorPerfStressDemo/wwwroot/js/interop.js
@@ -1,0 +1,164 @@
+// interop.js — xterm.js management + fast [JSImport] targets via globalThis
+
+(function () {
+    let term = null;
+    let fitAddon = null;
+    const inputChunks = [];
+    let pendingResize = '';
+
+    // Burst timing instrumentation
+    let _frameCount = 0;
+    let _burstStart = 0;
+    let _burstCount = 0;
+    let _lastTime = 0;
+
+    // m-input-latency: time from the first un-served input to the next postOutput.
+    let _pendingInputTimestamp = null;
+
+    window.termInterop = {
+        // Initialize xterm.js — called from Blazor component
+        init: function () {
+            term = new Terminal({
+                cursorBlink: true,
+                convertEol: false,
+                allowProposedApi: true,
+                fontSize: 14,
+                fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+                theme: {
+                    background: '#1e1e1e',
+                    foreground: '#d4d4d4'
+                }
+            });
+
+            fitAddon = new FitAddon.FitAddon();
+            term.loadAddon(fitAddon);
+
+            const container = document.getElementById('terminal');
+            term.open(container);
+            fitAddon.fit();
+
+            // Forward xterm input to queue, throttling mouse-move events
+            let lastMouseMoveTime = 0;
+            const MOUSE_THROTTLE_MS = 50; // ~20Hz max for mouse moves
+
+            term.onData(function (data) {
+                // Detect SGR mouse-move sequences (button 35 = motion with button held)
+                // Format: \x1b[<35;X;Y[Mm]
+                if (data.indexOf('\x1b[<35;') !== -1) {
+                    const now = performance.now();
+                    if (now - lastMouseMoveTime < MOUSE_THROTTLE_MS) return; // drop
+                    lastMouseMoveTime = now;
+                }
+                const bytes = new TextEncoder().encode(data);
+                inputChunks.push(bytes);
+                if (_pendingInputTimestamp === null) _pendingInputTimestamp = performance.now();
+                // Wake .NET's ReadInputAsync immediately (set by App.razor once exports load).
+                if (window.__hex1bSignalInput) window.__hex1bSignalInput();
+            });
+
+            term.onBinary(function (data) {
+                const bytes = new Uint8Array(data.length);
+                for (let i = 0; i < data.length; i++) bytes[i] = data.charCodeAt(i);
+                inputChunks.push(bytes);
+                if (_pendingInputTimestamp === null) _pendingInputTimestamp = performance.now();
+                if (window.__hex1bSignalInput) window.__hex1bSignalInput();
+            });
+
+            // Debounced resize
+            let resizeTimer = null;
+            window.addEventListener('resize', () => { fitAddon.fit(); });
+            term.onResize(function (size) {
+                if (resizeTimer) clearTimeout(resizeTimer);
+                resizeTimer = setTimeout(() => {
+                    pendingResize = size.cols + ',' + size.rows;
+                    if (window.__hex1bSignalInput) window.__hex1bSignalInput();
+                    resizeTimer = null;
+                }, 100);
+            });
+
+            console.log(`[blazor] xterm initialized: ${term.cols}x${term.rows}`);
+            return `${term.cols},${term.rows}`;
+        },
+
+        // [JSImport] target — write output bytes directly to xterm
+        postOutput: function (data) {
+            if (!term) return;
+
+            // Burst timing
+            const now = performance.now();
+            _frameCount++;
+            const gap = now - _lastTime;
+            _lastTime = now;
+
+            if (_pendingInputTimestamp !== null) {
+                const latency = now - _pendingInputTimestamp;
+                _pendingInputTimestamp = null;
+                console.log(`[perf] input->frame latency: ${latency.toFixed(1)}ms`);
+            }
+
+            if (gap > 30) {
+                if (_burstCount > 0) {
+                    const burstDuration = (now - gap) - _burstStart;
+                    console.log(`[perf] burst: ${_burstCount} writes in ${burstDuration.toFixed(0)}ms, then ${gap.toFixed(0)}ms idle (total frames: ${_frameCount})`);
+                }
+                _burstStart = now;
+                _burstCount = 1;
+            } else {
+                _burstCount++;
+            }
+
+            // data is a Uint8Array view over WASM memory (JSType.MemoryView).
+            // Copy bounded to the view's range — never clone the underlying
+            // WASM heap by passing the view directly to consumers that hold on
+            // to it past the synchronous call.
+            const copy = new Uint8Array(data.length);
+            copy.set(data);
+            term.write(copy);
+        },
+
+        // [JSImport] target — drain all queued input
+        pollAllInput: function () {
+            if (inputChunks.length === 0) return null;
+            let totalLen = 0;
+            for (const chunk of inputChunks) totalLen += chunk.length;
+            const result = new Uint8Array(totalLen);
+            let offset = 0;
+            for (const chunk of inputChunks) {
+                result.set(chunk, offset);
+                offset += chunk.length;
+            }
+            inputChunks.length = 0;
+            return result;
+        },
+
+        // [JSImport] target — poll pending resize
+        pollResize: function () {
+            const r = pendingResize;
+            pendingResize = '';
+            return r;
+        },
+
+        // Looks up the C# [JSExport] SignalInputAvailable on the running .NET
+        // runtime and stashes a callable reference so the input/resize handlers
+        // can wake ReadInputAsync immediately. Falls back to a no-op if the
+        // runtime API isn't available (e.g. older Blazor build); the .NET-side
+        // poll fallback covers that case at the cost of 50ms latency.
+        attachSignal: async function (assemblyName) {
+            try {
+                const runtime = globalThis.getDotnetRuntime ? globalThis.getDotnetRuntime(0) : null;
+                if (!runtime || !runtime.getAssemblyExports) {
+                    console.warn('[blazor] dotnet runtime API unavailable; staying on poll fallback');
+                    return;
+                }
+                const exports = await runtime.getAssemblyExports(assemblyName);
+                window.__hex1bSignalInput =
+                    exports?.[assemblyName]?.BlazorPresentationAdapter?.SignalInputAvailable;
+                if (!window.__hex1bSignalInput) {
+                    console.warn('[blazor] SignalInputAvailable export not found');
+                }
+            } catch (e) {
+                console.warn('[blazor] attachSignal failed:', e);
+            }
+        }
+    };
+})();

--- a/samples/BlazorPerfStressDemo/wwwroot/js/interop.js
+++ b/samples/BlazorPerfStressDemo/wwwroot/js/interop.js
@@ -6,15 +6,6 @@
     const inputChunks = [];
     let pendingResize = '';
 
-    // Burst timing instrumentation
-    let _frameCount = 0;
-    let _burstStart = 0;
-    let _burstCount = 0;
-    let _lastTime = 0;
-
-    // m-input-latency: time from the first un-served input to the next postOutput.
-    let _pendingInputTimestamp = null;
-
     window.termInterop = {
         // Initialize xterm.js — called from Blazor component
         init: function () {
@@ -51,7 +42,6 @@
                 }
                 const bytes = new TextEncoder().encode(data);
                 inputChunks.push(bytes);
-                if (_pendingInputTimestamp === null) _pendingInputTimestamp = performance.now();
                 // Wake .NET's ReadInputAsync immediately (set by App.razor once exports load).
                 if (window.__hex1bSignalInput) window.__hex1bSignalInput();
             });
@@ -60,7 +50,6 @@
                 const bytes = new Uint8Array(data.length);
                 for (let i = 0; i < data.length; i++) bytes[i] = data.charCodeAt(i);
                 inputChunks.push(bytes);
-                if (_pendingInputTimestamp === null) _pendingInputTimestamp = performance.now();
                 if (window.__hex1bSignalInput) window.__hex1bSignalInput();
             });
 
@@ -83,29 +72,6 @@
         // [JSImport] target — write output bytes directly to xterm
         postOutput: function (data) {
             if (!term) return;
-
-            // Burst timing
-            const now = performance.now();
-            _frameCount++;
-            const gap = now - _lastTime;
-            _lastTime = now;
-
-            if (_pendingInputTimestamp !== null) {
-                const latency = now - _pendingInputTimestamp;
-                _pendingInputTimestamp = null;
-                console.log(`[perf] input->frame latency: ${latency.toFixed(1)}ms`);
-            }
-
-            if (gap > 30) {
-                if (_burstCount > 0) {
-                    const burstDuration = (now - gap) - _burstStart;
-                    console.log(`[perf] burst: ${_burstCount} writes in ${burstDuration.toFixed(0)}ms, then ${gap.toFixed(0)}ms idle (total frames: ${_frameCount})`);
-                }
-                _burstStart = now;
-                _burstCount = 1;
-            } else {
-                _burstCount++;
-            }
 
             // data is a Uint8Array view over WASM memory (JSType.MemoryView).
             // Copy bounded to the view's range — never clone the underlying

--- a/samples/WasmDemo/WasmPresentationAdapter.cs
+++ b/samples/WasmDemo/WasmPresentationAdapter.cs
@@ -13,6 +13,12 @@ public sealed partial class WasmPresentationAdapter : Hex1b.IHex1bTerminalPresen
     private int _width;
     private int _height;
 
+    // Event-driven input signal — replaces the previous 50ms poll loop.
+    // JS calls SignalInputAvailable() via [JSExport] whenever new input or a
+    // resize arrives; ReadInputAsync drains the JS queues, and if nothing is
+    // available, awaits this TCS instead of sleeping.
+    private static TaskCompletionSource? s_inputSignal;
+
     public WasmPresentationAdapter(int initialCols = 80, int initialRows = 24)
     {
         _width = initialCols;
@@ -71,11 +77,32 @@ public sealed partial class WasmPresentationAdapter : Hex1b.IHex1bTerminalPresen
                 return new ReadOnlyMemory<byte>(allInput);
             }
 
-            // Yield to JS event loop — longer delay reduces frame rate
-            // so each frame has visible rotation delta in the braille grid
+            // Nothing pending — install a fresh signal and wait for JS to ping us.
+            // Re-check the JS queues after publishing the TCS to close the race
+            // where input arrived between our drain and registration.
+            var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            Interlocked.Exchange(ref s_inputSignal, tcs);
+
+            var lateInput = PollAllInput();
+            var lateResize = PollResize();
+            if ((lateInput != null && lateInput.Length > 0) || !string.IsNullOrEmpty(lateResize))
+            {
+                // Consume the signal we just installed so a future Signal call
+                // doesn't fire against a stale TCS.
+                Interlocked.CompareExchange(ref s_inputSignal, null, tcs);
+                if (lateInput != null && lateInput.Length > 0)
+                {
+                    return new ReadOnlyMemory<byte>(lateInput);
+                }
+                // We had a resize but no input bytes — loop so we process the resize
+                // through the normal path above (which fires Resized and re-polls).
+                continue;
+            }
+
             try
             {
-                await Task.Delay(50, ct);
+                using var reg = ct.Register(static state => ((TaskCompletionSource)state!).TrySetCanceled(), tcs);
+                await tcs.Task;
             }
             catch (OperationCanceledException)
             {
@@ -109,6 +136,18 @@ public sealed partial class WasmPresentationAdapter : Hex1b.IHex1bTerminalPresen
 
     [JSImport("pollResize", "main.js")]
     internal static partial string PollResize();
+
+    /// <summary>
+    /// Called from JS (worker's interop.js) whenever new input or a resize
+    /// has been enqueued. Wakes any pending <see cref="ReadInputAsync"/> call
+    /// immediately so input latency does not depend on a poll interval.
+    /// </summary>
+    [JSExport]
+    internal static void SignalInputAvailable()
+    {
+        var tcs = Interlocked.Exchange(ref s_inputSignal, null);
+        tcs?.TrySetResult();
+    }
 
     internal static WasmPresentationAdapter? Instance { get; set; }
 }

--- a/samples/WasmDemo/WasmPresentationAdapter.cs
+++ b/samples/WasmDemo/WasmPresentationAdapter.cs
@@ -1,4 +1,3 @@
-using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.JavaScript;
 
 namespace GlobeDemoWasm;
@@ -44,14 +43,7 @@ public sealed partial class WasmPresentationAdapter : Hex1b.IHex1bTerminalPresen
 
     public ValueTask WriteOutputAsync(ReadOnlyMemory<byte> data, CancellationToken ct)
     {
-        // Pass a span over WASM memory directly to JS via JSType.MemoryView so we
-        // skip the per-frame data.ToArray() copy. PostOutput is synchronous (JS
-        // copies the bytes into its own Uint8Array before returning), so the
-        // view's lifetime restriction (valid only for the duration of the call)
-        // is satisfied. MemoryMarshal.AsMemory is safe here because PostOutput
-        // only reads the buffer.
-        if (!data.IsEmpty)
-            PostOutput(MemoryMarshal.AsMemory(data).Span);
+        PostOutput(data.ToArray());
         return ValueTask.CompletedTask;
     }
 
@@ -134,7 +126,7 @@ public sealed partial class WasmPresentationAdapter : Hex1b.IHex1bTerminalPresen
     }
 
     [JSImport("postTerminalOutput", "main.js")]
-    internal static partial void PostOutput([JSMarshalAs<JSType.MemoryView>] Span<byte> data);
+    internal static partial void PostOutput(byte[] data);
 
     [JSImport("notifyReady", "main.js")]
     internal static partial void NotifyReady(int cols, int rows);

--- a/samples/WasmDemo/WasmPresentationAdapter.cs
+++ b/samples/WasmDemo/WasmPresentationAdapter.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.JavaScript;
 
 namespace GlobeDemoWasm;
@@ -43,7 +44,14 @@ public sealed partial class WasmPresentationAdapter : Hex1b.IHex1bTerminalPresen
 
     public ValueTask WriteOutputAsync(ReadOnlyMemory<byte> data, CancellationToken ct)
     {
-        PostOutput(data.ToArray());
+        // Pass a span over WASM memory directly to JS via JSType.MemoryView so we
+        // skip the per-frame data.ToArray() copy. PostOutput is synchronous (JS
+        // copies the bytes into its own Uint8Array before returning), so the
+        // view's lifetime restriction (valid only for the duration of the call)
+        // is satisfied. MemoryMarshal.AsMemory is safe here because PostOutput
+        // only reads the buffer.
+        if (!data.IsEmpty)
+            PostOutput(MemoryMarshal.AsMemory(data).Span);
         return ValueTask.CompletedTask;
     }
 
@@ -126,7 +134,7 @@ public sealed partial class WasmPresentationAdapter : Hex1b.IHex1bTerminalPresen
     }
 
     [JSImport("postTerminalOutput", "main.js")]
-    internal static partial void PostOutput(byte[] data);
+    internal static partial void PostOutput([JSMarshalAs<JSType.MemoryView>] Span<byte> data);
 
     [JSImport("notifyReady", "main.js")]
     internal static partial void NotifyReady(int cols, int rows);

--- a/samples/WasmDemo/WasmPresentationAdapter.cs
+++ b/samples/WasmDemo/WasmPresentationAdapter.cs
@@ -102,7 +102,13 @@ public sealed partial class WasmPresentationAdapter : Hex1b.IHex1bTerminalPresen
             try
             {
                 using var reg = ct.Register(static state => ((TaskCompletionSource)state!).TrySetCanceled(), tcs);
-                await tcs.Task;
+                // Race the signal against a 50ms poll fallback. When SignalInputAvailable
+                // is wired via [JSExport] (the f1 fast path), tcs.Task wins and we get
+                // sub-millisecond wake-up. When the JS-side wiring fails for any reason,
+                // Task.Delay wins and we degrade to the original 50ms poll behaviour
+                // instead of blocking ReadInputAsync forever.
+                await Task.WhenAny(tcs.Task, Task.Delay(50, ct));
+                Interlocked.CompareExchange(ref s_inputSignal, null, tcs);
             }
             catch (OperationCanceledException)
             {

--- a/samples/WasmDemo/wwwroot/interop.js
+++ b/samples/WasmDemo/wwwroot/interop.js
@@ -61,8 +61,13 @@ function handleMessage(msg) {
     if (msg.type === 'input') {
         const bytes = Uint8Array.from(atob(msg.data), c => c.charCodeAt(0));
         inputChunks.push(bytes);
+        // Wake ReadInputAsync immediately instead of letting it poll on a timer.
+        // The export is undefined until worker.js finishes hooking it up post-create;
+        // the .NET-side poll fallback handles the brief startup window.
+        if (self.__hex1bSignalInput) self.__hex1bSignalInput();
     } else if (msg.type === 'resize') {
         pendingResize = msg.cols + ',' + msg.rows;
+        if (self.__hex1bSignalInput) self.__hex1bSignalInput();
     }
 }
 

--- a/samples/WasmDemo/wwwroot/interop.js
+++ b/samples/WasmDemo/wwwroot/interop.js
@@ -8,12 +8,23 @@ let _burstStart = 0;
 let _burstCount = 0;
 let _lastTime = 0;
 
+// m-input-latency: time from the first un-served input event to the next
+// postOutput. Reset on each measurement. Logged so we can compare f1 (event
+// driven) vs the original 50ms poll loop.
+let _pendingInputTimestamp = null;
+
 export function postTerminalOutput(data) {
     const now = performance.now();
     _frameCount++;
     const gap = now - _lastTime;
     _lastTime = now;
-    
+
+    if (_pendingInputTimestamp !== null) {
+        const latency = now - _pendingInputTimestamp;
+        _pendingInputTimestamp = null;
+        console.log(`[perf] input->frame latency: ${latency.toFixed(1)}ms`);
+    }
+
     if (gap > 30) {
         // End of a gap — report the previous burst and the gap
         if (_burstCount > 0) {
@@ -25,7 +36,12 @@ export function postTerminalOutput(data) {
     } else {
         _burstCount++;
     }
-    
+
+    // data is a Uint8Array view over WASM memory (JSType.MemoryView marshaling).
+    // We MUST copy to a fresh Uint8Array before postMessage: structured-cloning
+    // the view would clone the entire underlying WASM heap ArrayBuffer, not
+    // just the view's range. Copying explicitly also lets us transfer ownership
+    // of the small buffer instead of cloning it cross-thread.
     const copy = new Uint8Array(data.length);
     copy.set(data);
     self.postMessage({ type: 'output', data: copy.buffer }, [copy.buffer]);
@@ -61,6 +77,7 @@ function handleMessage(msg) {
     if (msg.type === 'input') {
         const bytes = Uint8Array.from(atob(msg.data), c => c.charCodeAt(0));
         inputChunks.push(bytes);
+        if (_pendingInputTimestamp === null) _pendingInputTimestamp = performance.now();
         // Wake ReadInputAsync immediately instead of letting it poll on a timer.
         // The export is undefined until worker.js finishes hooking it up post-create;
         // the .NET-side poll fallback handles the brief startup window.

--- a/samples/WasmDemo/wwwroot/interop.js
+++ b/samples/WasmDemo/wwwroot/interop.js
@@ -3,40 +3,7 @@
 
 const inputChunks = [];
 
-let _frameCount = 0;
-let _burstStart = 0;
-let _burstCount = 0;
-let _lastTime = 0;
-
-// m-input-latency: time from the first un-served input event to the next
-// postOutput. Reset on each measurement. Logged so we can compare f1 (event
-// driven) vs the original 50ms poll loop.
-let _pendingInputTimestamp = null;
-
 export function postTerminalOutput(data) {
-    const now = performance.now();
-    _frameCount++;
-    const gap = now - _lastTime;
-    _lastTime = now;
-
-    if (_pendingInputTimestamp !== null) {
-        const latency = now - _pendingInputTimestamp;
-        _pendingInputTimestamp = null;
-        console.log(`[perf] input->frame latency: ${latency.toFixed(1)}ms`);
-    }
-
-    if (gap > 30) {
-        // End of a gap — report the previous burst and the gap
-        if (_burstCount > 0) {
-            const burstDuration = (now - gap) - _burstStart;
-            console.log(`[perf] burst: ${_burstCount} writes in ${burstDuration.toFixed(0)}ms, then ${gap.toFixed(0)}ms idle (total frames: ${_frameCount})`);
-        }
-        _burstStart = now;
-        _burstCount = 1;
-    } else {
-        _burstCount++;
-    }
-
     // data is a Uint8Array view over WASM memory (JSType.MemoryView marshaling).
     // We MUST copy to a fresh Uint8Array before postMessage: structured-cloning
     // the view would clone the entire underlying WASM heap ArrayBuffer, not
@@ -77,7 +44,6 @@ function handleMessage(msg) {
     if (msg.type === 'input') {
         const bytes = Uint8Array.from(atob(msg.data), c => c.charCodeAt(0));
         inputChunks.push(bytes);
-        if (_pendingInputTimestamp === null) _pendingInputTimestamp = performance.now();
         // Wake ReadInputAsync immediately instead of letting it poll on a timer.
         // The export is undefined until worker.js finishes hooking it up post-create;
         // the .NET-side poll fallback handles the brief startup window.

--- a/samples/WasmDemo/wwwroot/worker.js
+++ b/samples/WasmDemo/wwwroot/worker.js
@@ -2,9 +2,20 @@
 import { dotnet } from './_framework/dotnet.js';
 
 try {
-    await dotnet.create();
+    const { getAssemblyExports, getConfig, runMain } = await dotnet.create();
     self.postMessage({ type: 'workerReady' });
-    await dotnet.run();
+
+    // Grab the C# [JSExport] surface BEFORE Main runs so interop.js can wake
+    // ReadInputAsync immediately when input or a resize arrives, instead of
+    // waiting for a poll tick. Setting this before runMain is fine — interop.js
+    // only calls it from message handlers, which can't fire until the event loop
+    // returns to the worker.
+    const config = getConfig();
+    const exports = await getAssemblyExports(config.mainAssemblyName);
+    // Adapter is in namespace GlobeDemoWasm, class WasmPresentationAdapter.
+    self.__hex1bSignalInput = exports.GlobeDemoWasm.WasmPresentationAdapter.SignalInputAvailable;
+
+    await runMain();
 } catch (err) {
     self.postMessage({ type: 'error', message: err.toString(), stack: err.stack });
 }

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -152,6 +152,59 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
     private readonly int _inputCoalescingInitialDelayMs;
     private readonly int _inputCoalescingMaxDelayMs;
 
+    // Browser-only perf counters (printed once per second).
+    private long _browserPerfWindowStartTicks;
+    private int _browserPerfFrameCount;
+    private int _browserPerfRenderedFrames;
+    private long _browserPerfBuildTicks;
+    private long _browserPerfReconcileTicks;
+    private long _browserPerfRenderTicks;
+    private long _browserPerfTotalTicks;
+    private long _browserPerfRenderTreeTicks;
+    private long _browserPerfDiffTicks;
+    private long _browserPerfTokensTicks;
+    private long _browserPerfSerializeTicks;
+    private int _browserPerfDiffCells;
+    private int _browserPerfTokenCount;
+    private int _browserPerfAnsiBytes;
+
+    private void EmitBrowserFramePerfIfDue(long buildTicks, long reconcileTicks, long renderTicks, long totalTicks, bool needsRender, double freq)
+    {
+        _browserPerfFrameCount++;
+        if (needsRender) _browserPerfRenderedFrames++;
+        _browserPerfBuildTicks += buildTicks;
+        _browserPerfReconcileTicks += reconcileTicks;
+        _browserPerfRenderTicks += renderTicks;
+        _browserPerfTotalTicks += totalTicks;
+
+        var nowTicks = Stopwatch.GetTimestamp();
+        if (_browserPerfWindowStartTicks == 0) { _browserPerfWindowStartTicks = nowTicks; return; }
+        var elapsedMs = (nowTicks - _browserPerfWindowStartTicks) * 1000.0 / freq;
+        if (elapsedMs >= 1000.0)
+        {
+            Console.WriteLine($"[perf] last 1s: frames={_browserPerfFrameCount} rendered={_browserPerfRenderedFrames} " +
+                $"build={_browserPerfBuildTicks * 1000.0 / freq:F0}ms reconcile={_browserPerfReconcileTicks * 1000.0 / freq:F0}ms " +
+                $"render={_browserPerfRenderTicks * 1000.0 / freq:F0}ms total={_browserPerfTotalTicks * 1000.0 / freq:F0}ms " +
+                $"[tree={_browserPerfRenderTreeTicks * 1000.0 / freq:F0} diff={_browserPerfDiffTicks * 1000.0 / freq:F0} " +
+                $"tokens={_browserPerfTokensTicks * 1000.0 / freq:F0} serialize={_browserPerfSerializeTicks * 1000.0 / freq:F0}] " +
+                $"cells={_browserPerfDiffCells} tok={_browserPerfTokenCount} ansiB={_browserPerfAnsiBytes}");
+            _browserPerfWindowStartTicks = nowTicks;
+            _browserPerfFrameCount = 0;
+            _browserPerfRenderedFrames = 0;
+            _browserPerfBuildTicks = 0;
+            _browserPerfReconcileTicks = 0;
+            _browserPerfRenderTicks = 0;
+            _browserPerfTotalTicks = 0;
+            _browserPerfRenderTreeTicks = 0;
+            _browserPerfDiffTicks = 0;
+            _browserPerfTokensTicks = 0;
+            _browserPerfSerializeTicks = 0;
+            _browserPerfDiffCells = 0;
+            _browserPerfTokenCount = 0;
+            _browserPerfAnsiBytes = 0;
+        }
+    }
+
     // Surface RenderChild caching (opt-in).
     private readonly bool _enableRenderCaching;
     private readonly bool _useSoftWrapEmission;
@@ -1090,8 +1143,14 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
             {
                 _metrics.FrameRenderDuration.Record(renderTicks * 1000.0 / freq);
             }
-            _metrics.FrameDuration.Record((Stopwatch.GetTimestamp() - frameStart) * 1000.0 / freq);
+            var totalTicks = Stopwatch.GetTimestamp() - frameStart;
+            _metrics.FrameDuration.Record(totalTicks * 1000.0 / freq);
             _metrics.FrameCount.Add(1);
+
+            if (OperatingSystem.IsBrowser())
+            {
+                EmitBrowserFramePerfIfDue(buildTicks, reconcileTicks, renderTicks, totalTicks, needsRender, freq);
+            }
             
             // Render hardware cursor - for focused TerminalNode uses child's cursor,
             // otherwise uses mouse position if mouse cursor is enabled. When inside
@@ -1212,9 +1271,16 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         };
         surfaceContext.SetCapabilities(caps);
         
+        long renderTreeTicks = 0;
         if (_rootNode != null)
         {
+            var rttStart = Stopwatch.GetTimestamp();
             RenderTreeToSurface(_rootNode, surfaceContext);
+            renderTreeTicks = Stopwatch.GetTimestamp() - rttStart;
+        }
+        if (OperatingSystem.IsBrowser())
+        {
+            _browserPerfRenderTreeTicks += renderTreeTicks;
         }
 
         if (_kgpRegistry.Images.Count > 0 || _currentSurface.HasKgp)
@@ -1264,7 +1330,13 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
             fastPathTaken = SurfaceComparer.CompareInto(_previousSurface, _currentSurface, _frameDiff);
         }
         var diff = _frameDiff;
-        _metrics.SurfaceDiffDuration.Record(Stopwatch.GetElapsedTime(diffStart).TotalMilliseconds);
+        var diffTicks = Stopwatch.GetTimestamp() - diffStart;
+        _metrics.SurfaceDiffDuration.Record(diffTicks * 1000.0 / (double)Stopwatch.Frequency);
+        if (OperatingSystem.IsBrowser())
+        {
+            _browserPerfDiffTicks += diffTicks;
+            _browserPerfDiffCells += diff.Count;
+        }
         if (fastPathTaken)
             _metrics.SurfaceDiffFastPathCount.Add(1);
         else
@@ -1348,7 +1420,8 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                     SurfaceComparer.ToTokensInto(diff, _currentSurface, _previousSurface, skipKgpEmission: hasKgp, _frameTokens);
                 }
                 var tokens = _frameTokens;
-                _metrics.SurfaceTokensDuration.Record(Stopwatch.GetElapsedTime(tokensStart).TotalMilliseconds);
+                var tokensTicks = Stopwatch.GetTimestamp() - tokensStart;
+                _metrics.SurfaceTokensDuration.Record(tokensTicks * 1000.0 / (double)Stopwatch.Frequency);
 
                 var serializeStart = Stopwatch.GetTimestamp();
                 // Use the pool-backed serializer so the per-frame ANSI byte buffer (often
@@ -1363,7 +1436,15 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                 {
                     ansiOutput = Tokens.AnsiTokenUtf8Serializer.Serialize(tokens);
                 }
-                _metrics.SurfaceSerializeDuration.Record(Stopwatch.GetElapsedTime(serializeStart).TotalMilliseconds);
+                var serializeTicks = Stopwatch.GetTimestamp() - serializeStart;
+                _metrics.SurfaceSerializeDuration.Record(serializeTicks * 1000.0 / (double)Stopwatch.Frequency);
+                if (OperatingSystem.IsBrowser())
+                {
+                    _browserPerfTokensTicks += tokensTicks;
+                    _browserPerfSerializeTicks += serializeTicks;
+                    _browserPerfTokenCount += tokens.Count;
+                    _browserPerfAnsiBytes += ansiOutput.Length;
+                }
 
                 if (_adapter is Hex1bAppWorkloadAdapter workloadAdapter)
                 {

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -152,59 +152,6 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
     private readonly int _inputCoalescingInitialDelayMs;
     private readonly int _inputCoalescingMaxDelayMs;
 
-    // Browser-only perf counters (printed once per second).
-    private long _browserPerfWindowStartTicks;
-    private int _browserPerfFrameCount;
-    private int _browserPerfRenderedFrames;
-    private long _browserPerfBuildTicks;
-    private long _browserPerfReconcileTicks;
-    private long _browserPerfRenderTicks;
-    private long _browserPerfTotalTicks;
-    private long _browserPerfRenderTreeTicks;
-    private long _browserPerfDiffTicks;
-    private long _browserPerfTokensTicks;
-    private long _browserPerfSerializeTicks;
-    private int _browserPerfDiffCells;
-    private int _browserPerfTokenCount;
-    private int _browserPerfAnsiBytes;
-
-    private void EmitBrowserFramePerfIfDue(long buildTicks, long reconcileTicks, long renderTicks, long totalTicks, bool needsRender, double freq)
-    {
-        _browserPerfFrameCount++;
-        if (needsRender) _browserPerfRenderedFrames++;
-        _browserPerfBuildTicks += buildTicks;
-        _browserPerfReconcileTicks += reconcileTicks;
-        _browserPerfRenderTicks += renderTicks;
-        _browserPerfTotalTicks += totalTicks;
-
-        var nowTicks = Stopwatch.GetTimestamp();
-        if (_browserPerfWindowStartTicks == 0) { _browserPerfWindowStartTicks = nowTicks; return; }
-        var elapsedMs = (nowTicks - _browserPerfWindowStartTicks) * 1000.0 / freq;
-        if (elapsedMs >= 1000.0)
-        {
-            Console.WriteLine($"[perf] last 1s: frames={_browserPerfFrameCount} rendered={_browserPerfRenderedFrames} " +
-                $"build={_browserPerfBuildTicks * 1000.0 / freq:F0}ms reconcile={_browserPerfReconcileTicks * 1000.0 / freq:F0}ms " +
-                $"render={_browserPerfRenderTicks * 1000.0 / freq:F0}ms total={_browserPerfTotalTicks * 1000.0 / freq:F0}ms " +
-                $"[tree={_browserPerfRenderTreeTicks * 1000.0 / freq:F0} diff={_browserPerfDiffTicks * 1000.0 / freq:F0} " +
-                $"tokens={_browserPerfTokensTicks * 1000.0 / freq:F0} serialize={_browserPerfSerializeTicks * 1000.0 / freq:F0}] " +
-                $"cells={_browserPerfDiffCells} tok={_browserPerfTokenCount} ansiB={_browserPerfAnsiBytes}");
-            _browserPerfWindowStartTicks = nowTicks;
-            _browserPerfFrameCount = 0;
-            _browserPerfRenderedFrames = 0;
-            _browserPerfBuildTicks = 0;
-            _browserPerfReconcileTicks = 0;
-            _browserPerfRenderTicks = 0;
-            _browserPerfTotalTicks = 0;
-            _browserPerfRenderTreeTicks = 0;
-            _browserPerfDiffTicks = 0;
-            _browserPerfTokensTicks = 0;
-            _browserPerfSerializeTicks = 0;
-            _browserPerfDiffCells = 0;
-            _browserPerfTokenCount = 0;
-            _browserPerfAnsiBytes = 0;
-        }
-    }
-
     // Surface RenderChild caching (opt-in).
     private readonly bool _enableRenderCaching;
     private readonly bool _useSoftWrapEmission;
@@ -1146,11 +1093,6 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
             var totalTicks = Stopwatch.GetTimestamp() - frameStart;
             _metrics.FrameDuration.Record(totalTicks * 1000.0 / freq);
             _metrics.FrameCount.Add(1);
-
-            if (OperatingSystem.IsBrowser())
-            {
-                EmitBrowserFramePerfIfDue(buildTicks, reconcileTicks, renderTicks, totalTicks, needsRender, freq);
-            }
             
             // Render hardware cursor - for focused TerminalNode uses child's cursor,
             // otherwise uses mouse position if mouse cursor is enabled. When inside
@@ -1271,16 +1213,9 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         };
         surfaceContext.SetCapabilities(caps);
         
-        long renderTreeTicks = 0;
         if (_rootNode != null)
         {
-            var rttStart = Stopwatch.GetTimestamp();
             RenderTreeToSurface(_rootNode, surfaceContext);
-            renderTreeTicks = Stopwatch.GetTimestamp() - rttStart;
-        }
-        if (OperatingSystem.IsBrowser())
-        {
-            _browserPerfRenderTreeTicks += renderTreeTicks;
         }
 
         if (_kgpRegistry.Images.Count > 0 || _currentSurface.HasKgp)
@@ -1332,11 +1267,6 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         var diff = _frameDiff;
         var diffTicks = Stopwatch.GetTimestamp() - diffStart;
         _metrics.SurfaceDiffDuration.Record(diffTicks * 1000.0 / (double)Stopwatch.Frequency);
-        if (OperatingSystem.IsBrowser())
-        {
-            _browserPerfDiffTicks += diffTicks;
-            _browserPerfDiffCells += diff.Count;
-        }
         if (fastPathTaken)
             _metrics.SurfaceDiffFastPathCount.Add(1);
         else
@@ -1438,13 +1368,6 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                 }
                 var serializeTicks = Stopwatch.GetTimestamp() - serializeStart;
                 _metrics.SurfaceSerializeDuration.Record(serializeTicks * 1000.0 / (double)Stopwatch.Frequency);
-                if (OperatingSystem.IsBrowser())
-                {
-                    _browserPerfTokensTicks += tokensTicks;
-                    _browserPerfSerializeTicks += serializeTicks;
-                    _browserPerfTokenCount += tokens.Count;
-                    _browserPerfAnsiBytes += ansiOutput.Length;
-                }
 
                 if (_adapter is Hex1bAppWorkloadAdapter workloadAdapter)
                 {

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -1090,8 +1090,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
             {
                 _metrics.FrameRenderDuration.Record(renderTicks * 1000.0 / freq);
             }
-            var totalTicks = Stopwatch.GetTimestamp() - frameStart;
-            _metrics.FrameDuration.Record(totalTicks * 1000.0 / freq);
+            _metrics.FrameDuration.Record((Stopwatch.GetTimestamp() - frameStart) * 1000.0 / freq);
             _metrics.FrameCount.Add(1);
             
             // Render hardware cursor - for focused TerminalNode uses child's cursor,
@@ -1265,8 +1264,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
             fastPathTaken = SurfaceComparer.CompareInto(_previousSurface, _currentSurface, _frameDiff);
         }
         var diff = _frameDiff;
-        var diffTicks = Stopwatch.GetTimestamp() - diffStart;
-        _metrics.SurfaceDiffDuration.Record(diffTicks * 1000.0 / (double)Stopwatch.Frequency);
+        _metrics.SurfaceDiffDuration.Record(Stopwatch.GetElapsedTime(diffStart).TotalMilliseconds);
         if (fastPathTaken)
             _metrics.SurfaceDiffFastPathCount.Add(1);
         else
@@ -1350,8 +1348,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                     SurfaceComparer.ToTokensInto(diff, _currentSurface, _previousSurface, skipKgpEmission: hasKgp, _frameTokens);
                 }
                 var tokens = _frameTokens;
-                var tokensTicks = Stopwatch.GetTimestamp() - tokensStart;
-                _metrics.SurfaceTokensDuration.Record(tokensTicks * 1000.0 / (double)Stopwatch.Frequency);
+                _metrics.SurfaceTokensDuration.Record(Stopwatch.GetElapsedTime(tokensStart).TotalMilliseconds);
 
                 var serializeStart = Stopwatch.GetTimestamp();
                 // Use the pool-backed serializer so the per-frame ANSI byte buffer (often
@@ -1366,8 +1363,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                 {
                     ansiOutput = Tokens.AnsiTokenUtf8Serializer.Serialize(tokens);
                 }
-                var serializeTicks = Stopwatch.GetTimestamp() - serializeStart;
-                _metrics.SurfaceSerializeDuration.Record(serializeTicks * 1000.0 / (double)Stopwatch.Frequency);
+                _metrics.SurfaceSerializeDuration.Record(Stopwatch.GetElapsedTime(serializeStart).TotalMilliseconds);
 
                 if (_adapter is Hex1bAppWorkloadAdapter workloadAdapter)
                 {

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -564,16 +564,32 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
                     {
                         await ProcessInputEventAsync(inputEvent, cancellationToken);
                     }
-                    
+
                     // Input coalescing: batch rapid inputs together before rendering.
-                    if (_enableInputCoalescing)
+                    // On browser (single-threaded WASM), Task.Delay's minimum resolution is
+                    // tied to the event-loop tick (~4-16ms+), so a 5ms coalescing delay can
+                    // balloon to 50ms+ under drag load and translates directly into per-event
+                    // latency. The event loop already provides natural batching (all queued
+                    // events drain in one turn), so on browser we drain synchronously without
+                    // an artificial delay.
+                    if (_enableInputCoalescing && !OperatingSystem.IsBrowser())
                     {
                         var outputBacklog = _adapter.OutputQueueDepth;
                         var coalescingDelayMs = Math.Min(
-                            _inputCoalescingInitialDelayMs + (outputBacklog * 10), 
+                            _inputCoalescingInitialDelayMs + (outputBacklog * 10),
                             _inputCoalescingMaxDelayMs);
                         await Task.Delay(coalescingDelayMs, cancellationToken);
 
+                        while (_adapter.InputEvents.TryRead(out var delayedInput))
+                        {
+                            await ProcessInputEventAsync(delayedInput, cancellationToken);
+                            if (_stopRequested || cancellationToken.IsCancellationRequested)
+                                break;
+                        }
+                    }
+                    else if (_enableInputCoalescing)
+                    {
+                        // Browser path: drain all already-queued events without delay.
                         while (_adapter.InputEvents.TryRead(out var delayedInput))
                         {
                             await ProcessInputEventAsync(delayedInput, cancellationToken);

--- a/src/Hex1b/Hex1bAppWorkloadAdapter.cs
+++ b/src/Hex1b/Hex1bAppWorkloadAdapter.cs
@@ -80,7 +80,9 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
     public Hex1bAppWorkloadAdapter(TerminalCapabilities? capabilities = null, int maxQueuedOutputItems = 0)
     {
         if (maxQueuedOutputItems < 0)
+        {
             throw new ArgumentOutOfRangeException(nameof(maxQueuedOutputItems), "Must be >= 0.");
+        }
         ThrowIfBoundedChannelOnBrowser(maxQueuedOutputItems);
 
         _width = 0;
@@ -118,7 +120,9 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
     public Hex1bAppWorkloadAdapter(IHex1bTerminalPresentationAdapter presentationAdapter, int maxQueuedOutputItems = 0)
     {
         if (maxQueuedOutputItems < 0)
+        {
             throw new ArgumentOutOfRangeException(nameof(maxQueuedOutputItems), "Must be >= 0.");
+        }
         ThrowIfBoundedChannelOnBrowser(maxQueuedOutputItems);
 
         _width = 0;

--- a/src/Hex1b/Hex1bAppWorkloadAdapter.cs
+++ b/src/Hex1b/Hex1bAppWorkloadAdapter.cs
@@ -81,6 +81,7 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
     {
         if (maxQueuedOutputItems < 0)
             throw new ArgumentOutOfRangeException(nameof(maxQueuedOutputItems), "Must be >= 0.");
+        ThrowIfBoundedChannelOnBrowser(maxQueuedOutputItems);
 
         _width = 0;
         _height = 0;
@@ -118,6 +119,7 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
     {
         if (maxQueuedOutputItems < 0)
             throw new ArgumentOutOfRangeException(nameof(maxQueuedOutputItems), "Must be >= 0.");
+        ThrowIfBoundedChannelOnBrowser(maxQueuedOutputItems);
 
         _width = 0;
         _height = 0;
@@ -153,6 +155,26 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
             SingleReader = true,
             SingleWriter = false,
         });
+    }
+
+    /// <summary>
+    /// Single-threaded WebAssembly cannot recover from the bounded-channel
+    /// backpressure path in <see cref="EnqueueOutput"/>: that path blocks the
+    /// producer with <c>writeTask.AsTask().GetAwaiter().GetResult()</c>, and the
+    /// only thread that could drain the channel is the same one that's being
+    /// blocked, so it deadlocks. Surface this as a clear construction-time error
+    /// on browser hosts instead of an opaque hang at runtime.
+    /// </summary>
+    private static void ThrowIfBoundedChannelOnBrowser(int maxQueuedOutputItems)
+    {
+        if (maxQueuedOutputItems > 0 && OperatingSystem.IsBrowser())
+        {
+            throw new PlatformNotSupportedException(
+                "Hex1bAppWorkloadAdapter does not support a bounded output channel " +
+                "(maxQueuedOutputItems > 0) on browser/WebAssembly hosts. The bounded " +
+                "backpressure path performs a sync-over-async wait that deadlocks " +
+                "single-threaded WASM. Use the default (0, unbounded) on browser.");
+        }
     }
 
     // ========================================

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -97,52 +97,33 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     private readonly Decoder _utf8Decoder = Encoding.UTF8.GetDecoder(); // Handles incomplete UTF-8 sequences across workload output reads
     private readonly Decoder _inputUtf8Decoder = Encoding.UTF8.GetDecoder(); // Handles incomplete UTF-8 sequences across presentation input reads
 
-    // Symptom (observed empirically during the WASM hosting bring-up, not
-    // confirmed against a known dotnet/runtime issue): under Blazor WASM
-    // `dotnet run` — which always uses the Mono interpreter — feeding
-    // terminal input bytes through the streaming `Decoder` API combined
-    // with `Span<char>` + `new string(char[], 0, count)` produces an empty
-    // string for valid ASCII input, even though `GetCharCount` and
-    // `GetChars` both report the correct count. Switching to
-    // `Encoding.UTF8.GetString(span)` round-trips correctly, and the
-    // streaming path also works under AOT (`dotnet publish -c Release`
-    // with `RunAOTCompilation=true`) and on every desktop runtime we test
-    // on. We don't yet know whether the cause is a Mono interpreter bug,
-    // a marshalling quirk in our [JSImport] input path, or something
-    // about how we construct the buffer — only that this codepath is the
-    // load-bearing one.
+    // On browser-wasm (specifically with the Mono interpreter that
+    // `dotnet run` uses, and possibly with [JSImport]-returned byte
+    // buffers more generally) the streaming Decoder + Span<char> +
+    // `new string(char[], 0, count)` path silently produces an empty
+    // string for valid ASCII input — even though GetCharCount and
+    // GetChars both report the correct count. Switching that one call
+    // site to `Encoding.UTF8.GetString(span)` round-trips correctly,
+    // and the streaming path is fine on every desktop runtime we test
+    // on. We don't yet know whether the cause is a Mono interpreter
+    // bug, a marshalling quirk in our [JSImport] input path, or
+    // something about how we construct the buffer.
     //
-    // Rather than gating on OperatingSystem.IsBrowser() — which would
-    // also penalise AOT'd browser builds, where the streaming path is
-    // fine — we probe the actual Decoder once at startup. The probe is
-    // cheap (decode "test") and the result is cached for the process
-    // lifetime. If the probe shows the symptom we use the GetString
-    // fallback; otherwise the streaming Decoder stays in use.
+    // We previously tried to scope this to "interpreter only" via a
+    // startup probe that decoded a managed `"test"u8` literal through
+    // a fresh Decoder. The probe does NOT reproduce the failure — most
+    // likely because the symptom only manifests on byte buffers that
+    // came across the [JSImport] boundary, not on managed UTF8 spans —
+    // so it under-reports broken=true and the input path silently
+    // swallows real keystrokes. Until we have a probe that actually
+    // triggers the bug (which also requires understanding the root
+    // cause), gate on the platform: any browser build, interpreter
+    // or AOT, takes the safe one-shot decode path.
     //
     // Tracking issue (covers minimising the repro and filing upstream
     // once we can show it's a runtime bug rather than a usage error):
     // https://github.com/mitchdenny/hex1b/issues/353
-    private static readonly bool s_inputDecoderIsBroken = DetectBrokenInputDecoder();
-
-    private static bool DetectBrokenInputDecoder()
-    {
-        try
-        {
-            var decoder = Encoding.UTF8.GetDecoder();
-            ReadOnlySpan<byte> probe = "test"u8;
-            var charCount = decoder.GetCharCount(probe, flush: false);
-            var chars = new char[charCount];
-            var charsWritten = decoder.GetChars(probe, chars, flush: false);
-            var result = new string(chars, 0, charsWritten);
-            return result != "test";
-        }
-        catch
-        {
-            // If the probe itself throws, assume the path is broken and use
-            // the workaround rather than risk live input being silently lost.
-            return true;
-        }
-    }
+    private static readonly bool s_inputDecoderIsBroken = OperatingSystem.IsBrowser();
     private string _incompleteSequenceBuffer = ""; // Buffers incomplete ANSI escape sequences across workload output reads
     private string _incompleteInputSequenceBuffer = ""; // Buffers incomplete ANSI escape sequences across presentation input reads
     

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -96,6 +96,35 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     private bool _savedCursorProtected; // Saved protection state for DECSC/DECRC
     private readonly Decoder _utf8Decoder = Encoding.UTF8.GetDecoder(); // Handles incomplete UTF-8 sequences across workload output reads
     private readonly Decoder _inputUtf8Decoder = Encoding.UTF8.GetDecoder(); // Handles incomplete UTF-8 sequences across presentation input reads
+
+    // The Mono *interpreter* on browser-wasm has a bug where the streaming
+    // Decoder API combined with Span<char> + `new string(char[])` silently
+    // produces an empty string for valid ASCII input. Mono AOT on wasm is
+    // unaffected, as is the desktop runtime. Rather than gating on
+    // OperatingSystem.IsBrowser() — which would also penalise AOT'd browser
+    // builds — we probe the actual Decoder once at startup. The probe is
+    // cheap (decode "test") and the result is cached for the process lifetime.
+    private static readonly bool s_inputDecoderIsBroken = DetectBrokenInputDecoder();
+
+    private static bool DetectBrokenInputDecoder()
+    {
+        try
+        {
+            var decoder = Encoding.UTF8.GetDecoder();
+            ReadOnlySpan<byte> probe = "test"u8;
+            var charCount = decoder.GetCharCount(probe, flush: false);
+            var chars = new char[charCount];
+            var charsWritten = decoder.GetChars(probe, chars, flush: false);
+            var result = new string(chars, 0, charsWritten);
+            return result != "test";
+        }
+        catch
+        {
+            // If the probe itself throws, assume the path is broken and use
+            // the workaround rather than risk live input being silently lost.
+            return true;
+        }
+    }
     private string _incompleteSequenceBuffer = ""; // Buffers incomplete ANSI escape sequences across workload output reads
     private string _incompleteInputSequenceBuffer = ""; // Buffers incomplete ANSI escape sequences across presentation input reads
     
@@ -677,14 +706,14 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 // we tokenize each chunk independently, the leading ESC becomes a
                 // spurious Escape key event and can close focused windows.
                 string decodedText;
-                if (OperatingSystem.IsBrowser())
+                if (s_inputDecoderIsBroken)
                 {
-                    // Mono WASM has a bug where the streaming Decoder API combined with
-                    // Span<char> + new string(char[]) silently produces an empty string
-                    // for valid ASCII input. Bypass the streaming Decoder entirely on the
-                    // browser — terminal input from xterm-style sources never splits
-                    // multi-byte UTF-8 codepoints across reads (escape sequences are
-                    // pure ASCII), so the stateful Decoder is not required.
+                    // Mono interpreter on browser-wasm: the streaming Decoder
+                    // path silently produces an empty string for valid ASCII.
+                    // Fall back to the one-shot Encoding.UTF8.GetString — safe
+                    // here because xterm-style terminal input never splits a
+                    // multi-byte UTF-8 codepoint across reads (escape sequences
+                    // are pure ASCII). See DetectBrokenInputDecoder above.
                     decodedText = Encoding.UTF8.GetString(data.Span);
                 }
                 else

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -97,15 +97,31 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     private readonly Decoder _utf8Decoder = Encoding.UTF8.GetDecoder(); // Handles incomplete UTF-8 sequences across workload output reads
     private readonly Decoder _inputUtf8Decoder = Encoding.UTF8.GetDecoder(); // Handles incomplete UTF-8 sequences across presentation input reads
 
-    // The Mono *interpreter* on browser-wasm has a bug where the streaming
-    // Decoder API combined with Span<char> + `new string(char[])` silently
-    // produces an empty string for valid ASCII input. Mono AOT on wasm is
-    // unaffected, as is the desktop runtime. Rather than gating on
-    // OperatingSystem.IsBrowser() — which would also penalise AOT'd browser
-    // builds — we probe the actual Decoder once at startup. The probe is
-    // cheap (decode "test") and the result is cached for the process lifetime.
-    // Tracking issue: https://github.com/mitchdenny/hex1b/issues/353
-    // (covers reducing to a minimal repro and filing upstream on dotnet/runtime).
+    // Symptom (observed empirically during the WASM hosting bring-up, not
+    // confirmed against a known dotnet/runtime issue): under Blazor WASM
+    // `dotnet run` — which always uses the Mono interpreter — feeding
+    // terminal input bytes through the streaming `Decoder` API combined
+    // with `Span<char>` + `new string(char[], 0, count)` produces an empty
+    // string for valid ASCII input, even though `GetCharCount` and
+    // `GetChars` both report the correct count. Switching to
+    // `Encoding.UTF8.GetString(span)` round-trips correctly, and the
+    // streaming path also works under AOT (`dotnet publish -c Release`
+    // with `RunAOTCompilation=true`) and on every desktop runtime we test
+    // on. We don't yet know whether the cause is a Mono interpreter bug,
+    // a marshalling quirk in our [JSImport] input path, or something
+    // about how we construct the buffer — only that this codepath is the
+    // load-bearing one.
+    //
+    // Rather than gating on OperatingSystem.IsBrowser() — which would
+    // also penalise AOT'd browser builds, where the streaming path is
+    // fine — we probe the actual Decoder once at startup. The probe is
+    // cheap (decode "test") and the result is cached for the process
+    // lifetime. If the probe shows the symptom we use the GetString
+    // fallback; otherwise the streaming Decoder stays in use.
+    //
+    // Tracking issue (covers minimising the repro and filing upstream
+    // once we can show it's a runtime bug rather than a usage error):
+    // https://github.com/mitchdenny/hex1b/issues/353
     private static readonly bool s_inputDecoderIsBroken = DetectBrokenInputDecoder();
 
     private static bool DetectBrokenInputDecoder()

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -610,7 +610,9 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             {
                 var data = await _presentation.ReadInputAsync(ct);
                 if (data.IsEmpty)
+                {
                     break;
+                }
                 _presentationInputChannel.Writer.TryWrite(PresentationInputEvent.FromData(data));
             }
         }
@@ -674,10 +676,24 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 // responses (APC: ESC _ G ... ST) may be split across reads; if
                 // we tokenize each chunk independently, the leading ESC becomes a
                 // spurious Escape key event and can close focused windows.
-                var charCount = _inputUtf8Decoder.GetCharCount(data.Span, flush: false);
-                var chars = new char[charCount];
-                _inputUtf8Decoder.GetChars(data.Span, chars, flush: false);
-                var decodedText = new string(chars);
+                string decodedText;
+                if (OperatingSystem.IsBrowser())
+                {
+                    // Mono WASM has a bug where the streaming Decoder API combined with
+                    // Span<char> + new string(char[]) silently produces an empty string
+                    // for valid ASCII input. Bypass the streaming Decoder entirely on the
+                    // browser — terminal input from xterm-style sources never splits
+                    // multi-byte UTF-8 codepoints across reads (escape sequences are
+                    // pure ASCII), so the stateful Decoder is not required.
+                    decodedText = Encoding.UTF8.GetString(data.Span);
+                }
+                else
+                {
+                    var charCount = _inputUtf8Decoder.GetCharCount(data.Span, flush: false);
+                    var chars = new char[charCount];
+                    var charsWritten = _inputUtf8Decoder.GetChars(data.Span, chars, flush: false);
+                    decodedText = new string(chars, 0, charsWritten);
+                }
 
                 var text = _incompleteInputSequenceBuffer + decodedText;
                 _incompleteInputSequenceBuffer = "";
@@ -711,7 +727,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             ReportPumpFault("presentation input pump", ex);
         }
     }
-
+    
     /// <summary>
     /// Tokenizes complete input text and dispatches it to the appropriate workload.
     /// </summary>

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -104,6 +104,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     // OperatingSystem.IsBrowser() — which would also penalise AOT'd browser
     // builds — we probe the actual Decoder once at startup. The probe is
     // cheap (decode "test") and the result is cached for the process lifetime.
+    // Tracking issue: https://github.com/mitchdenny/hex1b/issues/353
+    // (covers reducing to a minimal repro and filing upstream on dotnet/runtime).
     private static readonly bool s_inputDecoderIsBroken = DetectBrokenInputDecoder();
 
     private static bool DetectBrokenInputDecoder()


### PR DESCRIPTION
Push to make Hex1b host responsively under single-threaded Blazor WASM, using `samples/BlazorDemo` (globe) and a new `samples/BlazorPerfStressDemo` as the proving grounds.

## Library changes (all internal, no public API changes)

All three library changes are gated behind `OperatingSystem.IsBrowser()` — desktop / non-browser hosts take the unchanged paths.

- **`Hex1bApp.cs`** — skip the artificial input-coalescing `Task.Delay` on browser. The event loop already batches naturally per tick, and `Task.Delay`'s minimum resolution there can balloon a 5 ms coalesce window to 50 ms+ under drag load, directly inflating per-event latency. Browser path now drains the input channel synchronously each turn.
- **`Hex1bAppWorkloadAdapter.cs`** — throw `PlatformNotSupportedException` at construction time when `maxQueuedOutputItems > 0` on browser. The bounded-channel backpressure path performs a sync-over-async wait that deadlocks single-threaded WASM; surfacing this as a clear error beats an opaque hang.
- **`Hex1bTerminal.cs`** — on browser, decode presentation input via `Encoding.UTF8.GetString(span)` instead of the streaming `Decoder`. The streaming path silently produces empty strings for valid ASCII on Mono interpreter when fed `[JSImport]`-marshalled buffers, swallowing every keystroke / mouse event. Tracked in #353.

A previous attempt (99b7d3d5) tried to scope the workaround to "broken runtime only" via a startup probe that decoded a managed `"test"u8` literal. The probe never reproduces the bug (symptom only manifests on JS-marshalled buffers), so it reported broken=false on every browser build and reintroduced the input regression. That commit was reverted; we now gate on `OperatingSystem.IsBrowser()` until we understand the root cause.

## Sample changes

- **`samples/BlazorDemo`** — JS-interop and AOT publish plumbing; globe paint uses a flat array; `run-aot.sh` helper.
- **`samples/BlazorPerfStressDemo`** *(new)* — `PerfStressDemo` hosted in WASM for repro / regression of perf work.
- **`samples/WasmDemo`** — same input-signal / interop hardening as BlazorDemo.

## Verification

- `dotnet test`: 7796 passed, 0 failed, 26 skipped.
- Headless Edge + Playwright drag probe: globe rotates on mouse drag in both BlazorDemo and WasmDemo (interpreter via `dotnet run`).

## Risk

Low for desktop / non-browser consumers — no public API changes, no signature changes, no removed members; all behavioural changes are gated on `OperatingSystem.IsBrowser()`. The new `PlatformNotSupportedException` only fires for an opt-in argument value on browser hosts and replaces a deadlock with a fast-fail.

## Follow-ups (not in this PR)

- #353 — minimise the Decoder repro; file upstream against `dotnet/runtime` if confirmed a Mono bug.
- Hex1b.dll WASM size (5.4 MB → ~1.3 MB possible by disabling embedded PDB / `EmbedAllSources` for browser publish; trim pass for further savings).
- Perf regression that re-appeared after today's revert (one-shot `Encoding.UTF8.GetString` allocates per batch; `JSType.MemoryView` zero-copy output was also reverted earlier).