### PR TITLE
Migrate test suite from xUnit to MSTest (with MTP)

### DIFF
--- a/.github/skills/test-fixer/SKILL.md
+++ b/.github/skills/test-fixer/SKILL.md
@@ -5,7 +5,7 @@ description: Agent for diagnosing and fixing flaky terminal UI tests in the Hex1
 
 # Test Fixer Skill
 
-This skill provides guidelines for AI agents to diagnose and fix flaky tests in the Hex1b TUI library test suite. These tests use `Hex1bTerminalInputSequenceBuilder` to simulate user interactions with terminal applications.
+This skill provides guidelines for AI agents to diagnose and fix flaky tests in the Hex1b TUI library test suite. These tests use MSTest 4 (`MSTest.Sdk/4.2.3`, `OutputType=Exe`) with Microsoft.Testing.Platform and `Hex1bTerminalInputSequenceBuilder` to simulate user interactions with terminal applications. `global.json` configures `dotnet test` to use MTP, and test projects can also be run as executables with `dotnet run --project tests/SomeProject/`.
 
 ## Quick Reference: Common Flaky Test Patterns
 
@@ -16,7 +16,7 @@ This skill provides guidelines for AI agents to diagnose and fix flaky tests in 
 | [Race with Ctrl+C](#pattern-3-race-condition-with-ctrlc) | Snapshot missing expected content | Add `WaitUntil` between last action and `Capture` |
 | [Task.WhenAny Race](#pattern-4-taskwhenany-race-condition) | Test sometimes times out | Replace with proper `WaitUntil` or increase timeout |
 | [Test Interference](#pattern-5-test-interference) | Pass isolated, fail in suite | Check for shared state, file locks, or parallel execution issues |
-| [Platform-Specific](#pattern-6-platform-specific-failures) | Fails consistently on Windows/Linux | Add platform skip trait or fix platform-specific code |
+| [Platform-Specific](#pattern-6-platform-specific-failures) | Fails consistently on Windows/Linux | Add `TestCategory`/`Ignore` or fix platform-specific code |
 | [Task.Delay for Async Events](#pattern-7-taskdelay-for-async-events) | Flaky on slower CI runners | Replace `Task.Delay` with `TaskCompletionSource` signal |
 | [Helper Partial Wait](#pattern-8-test-helper-partial-wait) | Tests using multi-line helpers fail intermittently | Wait for all/last content, not just first line |
 
@@ -30,7 +30,7 @@ This skill provides guidelines for AI agents to diagnose and fix flaky tests in 
 - Test passes consistently on Windows
 - Test fails on Linux CI (GitHub Actions ubuntu-latest)
 - Assertion fails with content that "should" be there
-- Error messages like `Assert.True() Failure` or `An item should be selected with indicator`
+- Error messages like `Assert.IsTrue failed` or `An item should be selected with indicator`
 
 #### Root Cause
 
@@ -49,7 +49,7 @@ var snapshot = await new Hex1bTerminalInputSequenceBuilder()
     .Build()
     .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 // snapshot is from AFTER Ctrl+C, not from Capture step!
-Assert.True(snapshot.ContainsText("Counter: 3")); // May fail on Linux!
+Assert.IsTrue(snapshot.ContainsText("Counter: 3")); // May fail on Linux!
 ```
 
 #### How It Works
@@ -77,7 +77,7 @@ await runTask;
 
 // If the WaitUntil passed, we know the content was there at Capture time
 // The assertion is now checking what WaitUntil already verified
-Assert.True(snapshot.ContainsText("Counter: 3"));
+Assert.IsTrue(snapshot.ContainsText("Counter: 3"));
 ```
 
 **Option B: Don't use snapshot for content assertions**
@@ -95,7 +95,7 @@ await new Hex1bTerminalInputSequenceBuilder()
 await runTask;
 
 // Assert on counters/state captured during execution, not snapshot content
-Assert.Equal(1, staticRenderCount);
+Assert.AreEqual(1, staticRenderCount);
 ```
 
 **Option C: Use WaitUntil as the assertion itself**
@@ -135,7 +135,7 @@ var snapshot = await new Hex1bTerminalInputSequenceBuilder()
     .Ctrl().Key(Hex1bKey.C)
     .Build()
     .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-Assert.True(snapshot.ContainsText("> Second")); // Flaky!
+Assert.IsTrue(snapshot.ContainsText("> Second")); // Flaky!
 ```
 
 #### Fix
@@ -150,7 +150,7 @@ var snapshot = await new Hex1bTerminalInputSequenceBuilder()
     .Ctrl().Key(Hex1bKey.C)
     .Build()
     .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-Assert.True(snapshot.ContainsText("> Second")); // Reliable
+Assert.IsTrue(snapshot.ContainsText("> Second")); // Reliable
 ```
 
 ---
@@ -177,7 +177,7 @@ var snapshot = await new Hex1bTerminalInputSequenceBuilder()
     .Ctrl().Key(Hex1bKey.C)  // May interrupt scroll processing!
     .Build()
     .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-Assert.True(snapshot.ContainsText("> Item 06")); // Flaky!
+Assert.IsTrue(snapshot.ContainsText("> Item 06")); // Flaky!
 ```
 
 #### Fix
@@ -192,7 +192,7 @@ var snapshot = await new Hex1bTerminalInputSequenceBuilder()
     .Ctrl().Key(Hex1bKey.C)
     .Build()
     .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-Assert.True(snapshot.ContainsText("> Item 06")); // Reliable
+Assert.IsTrue(snapshot.ContainsText("> Item 06")); // Reliable
 ```
 
 ---
@@ -247,8 +247,8 @@ gh run view <run-id> --log-failed
 
 # Look for test names and error messages
 # Common patterns:
-# - Assert.True() Failure
-# - Expected: True / Actual: False
+# - Assert.IsTrue failed
+# - Expected:<True> or equivalent / Actual:<False>
 # - "An item should be selected with indicator"
 ```
 
@@ -274,7 +274,7 @@ Look for these anti-patterns:
 .Capture("final")
 .Ctrl().Key(Hex1bKey.C)
 // ... later ...
-Assert.True(snapshot.ContainsText("expected"));  // ❌
+Assert.IsTrue(snapshot.ContainsText("expected"));  // ❌
 
 // Anti-pattern 2: Action without WaitUntil before Capture
 .Down()
@@ -300,7 +300,7 @@ Assert.True(snapshot.ContainsText("expected"));  // ❌
 ### Pattern A: Full Integration Test with Exit
 
 ```csharp
-[Fact]
+[TestMethod]
 public async Task Navigation_DownArrow_SelectsNextItem()
 {
     using var workload = new Hex1bAppWorkloadAdapter();
@@ -329,14 +329,14 @@ public async Task Navigation_DownArrow_SelectsNextItem()
     await runTask;
     
     // This assertion is technically redundant since WaitUntil verified it
-    Assert.True(snapshot.ContainsText("> Second"));
+    Assert.IsTrue(snapshot.ContainsText("> Second"));
 }
 ```
 
 ### Pattern B: Render Count Test (No Snapshot Assertions)
 
 ```csharp
-[Fact]
+[TestMethod]
 public async Task StaticWidget_OnlyRendersOnce()
 {
     using var workload = new Hex1bAppWorkloadAdapter();
@@ -366,14 +366,14 @@ public async Task StaticWidget_OnlyRendersOnce()
     await runTask;
     
     // Assert on counter, not snapshot content
-    Assert.Equal(1, renderCount);
+    Assert.AreEqual(1, renderCount);
 }
 ```
 
 ### Pattern C: Unit Test Without App Exit
 
 ```csharp
-[Fact]
+[TestMethod]
 public async Task Render_AllItems_AreVisible()
 {
     using var workload = new Hex1bAppWorkloadAdapter();
@@ -398,9 +398,9 @@ public async Task Render_AllItems_AreVisible()
         .Build()
         .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
     
-    Assert.True(snapshot.ContainsText("Item 1"));
-    Assert.True(snapshot.ContainsText("Item 2"));
-    Assert.True(snapshot.ContainsText("Item 3"));
+    Assert.IsTrue(snapshot.ContainsText("Item 1"));
+    Assert.IsTrue(snapshot.ContainsText("Item 2"));
+    Assert.IsTrue(snapshot.ContainsText("Item 3"));
 }
 ```
 
@@ -431,7 +431,7 @@ await new Hex1bTerminalInputSequenceBuilder()
     .ApplyAsync(terminal);
 
 var completed = await Task.WhenAny(runTask, Task.Delay(2000));
-Assert.True(completed == runTask, "Expected CTRL-C to exit");  // Flaky!
+Assert.IsTrue(completed == runTask, "Expected CTRL-C to exit");  // Flaky!
 ```
 
 #### Fix
@@ -482,7 +482,7 @@ dotnet test --filter "FullyQualifiedName~TestName|FullyQualifiedName~OtherTest" 
 1. **Use unique temp paths** - Include test name or GUID in temp file paths
 2. **Properly dispose resources** - Ensure `using` statements on terminals/workloads
 3. **Avoid static state** - Use instance fields or dependency injection
-4. **Add xUnit collection** - Force sequential execution for conflicting tests
+4. **Add `[DoNotParallelize]` on the test class** - tests parallelize by default, and this forces sequential execution for conflicting tests
 
 ```csharp
 // Use unique temp file names
@@ -510,12 +510,12 @@ var tempPath = Path.Combine(Path.GetTempPath(), $"hex1b_{nameof(MyTestMethod)}.c
 | File locking | Strict | Flexible |
 | Path separators | `\` | `/` |
 
-#### Fix: Add Platform Skip Trait
+#### Fix: Add Platform Skip Category or Ignore
 
 ```csharp
 // Skip on Windows - PTY tests require Unix
-[Fact]
-[Trait("Category", "LinuxOnly")]
+[TestMethod]
+[TestCategory("LinuxOnly")]
 public async Task WithPtyProcess_ExecutesProcess()
 {
     if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -526,19 +526,26 @@ public async Task WithPtyProcess_ExecutesProcess()
     // ... test code
 }
 
-// Or use Skip property
-[Fact(Skip = "Requires Unix PTY support")]
+// Or use Ignore attribute
+[TestMethod]
+[Ignore("Requires Unix PTY support")]
 public async Task PtyTest() { }
 
-// Or conditional skip with xUnit
-public class LinuxOnlyFactAttribute : FactAttribute
+// Or conditional skip with MSTest
+public sealed class LinuxOnlyTestMethodAttribute : TestMethodAttribute
 {
-    public LinuxOnlyFactAttribute()
+    public override async Task<TestResult[]> ExecuteAsync(ITestMethod testMethod)
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            Skip = "This test requires Linux";
+            return [new TestResult
+            {
+                Outcome = UnitTestOutcome.Inconclusive,
+                TestFailureException = new AssertInconclusiveException("This test requires Linux")
+            }];
         }
+
+        return await base.ExecuteAsync(testMethod);
     }
 }
 ```
@@ -598,7 +605,7 @@ await new Hex1bTerminalInputSequenceBuilder()
 
 await Task.Delay(100);  // ❌ Fixed delay - may not be long enough!
 
-Assert.True(bindingFired);  // Flaky!
+Assert.IsTrue(bindingFired);  // Flaky!
 ```
 
 #### Fix
@@ -638,7 +645,7 @@ await new Hex1bTerminalInputSequenceBuilder()
 await bindingFired.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
 
 // If we got here, the binding fired (the wait would have timed out otherwise)
-Assert.True(bindingFired.Task.IsCompleted);  // Reliable
+Assert.IsTrue(bindingFired.Task.IsCompleted);  // Reliable
 ```
 
 #### Key Points
@@ -738,5 +745,5 @@ Before committing test changes, verify:
 - [ ] No `Task.WhenAny` race conditions - use `WaitAsync` instead
 - [ ] No `Task.Delay` for async events - use `TaskCompletionSource` instead
 - [ ] Test passes both in isolation and in full suite
-- [ ] Platform-specific tests have appropriate skip traits
+- [ ] Platform-specific tests have appropriate `TestCategory`, `Ignore`, or conditional `TestMethodAttribute` handling
 - [ ] Test helpers writing multiple lines wait for all/last content

--- a/.github/skills/widget-creator/SKILL.md
+++ b/.github/skills/widget-creator/SKILL.md
@@ -343,7 +343,7 @@ public static class MyExtensions
 
 ### Step 6: Write Unit Tests
 
-Tests verify that the node behaves correctly.
+Tests verify that the node behaves correctly. Test files use MSTest 4 (`MSTest.Sdk/4.2.3` with `OutputType=Exe`) and import `Microsoft.VisualStudio.TestTools.UnitTesting`; `Hex1b.Testing` is global-using'd for `TestSeq` helpers.
 
 **Location**: `tests/Hex1b.Tests/{Name}NodeTests.cs`
 
@@ -361,12 +361,14 @@ using Hex1b;
 using Hex1b.Input;
 using Hex1b.Layout;
 using Hex1b.Theming;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class MyNodeTests
 {
-    [Fact]
+    [TestMethod]
     public void Measure_ReturnsCorrectSize()
     {
         // Arrange
@@ -377,11 +379,11 @@ public class MyNodeTests
         var size = node.Measure(constraints);
 
         // Assert
-        Assert.Equal(5, size.Width); // "Hello".Length
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(5, size.Width); // "Hello".Length
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void PropertyChange_MarksDirty()
     {
         // Arrange
@@ -395,7 +397,7 @@ public class MyNodeTests
         // This depends on whether your node implements dirty tracking in setters
     }
 
-    [Fact]
+    [TestMethod]
     public void IsFocused_WhenSet_MarksDirty()
     {
         // Arrange
@@ -406,7 +408,7 @@ public class MyNodeTests
         node.IsFocused = true;
 
         // Assert
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 }
 ```
@@ -419,8 +421,11 @@ After creating all files:
 # Build the library
 dotnet build src/Hex1b
 
-# Run all tests
+# Run all tests (MTP via global.json)
 dotnet test
+
+# Or run a test project as an executable
+dotnet run --project tests/Hex1b.Tests/
 
 # Or run specific tests
 dotnet test --filter "MyNodeTests"
@@ -490,16 +495,16 @@ Unit tests verify isolated node behavior without running a full app.
 **Example pattern**:
 
 ```csharp
-[Fact]
+[TestMethod]
 public void Measure_FillsAvailableWidth()
 {
     var node = new ProgressNode { Value = 50, Maximum = 100 };
     var size = node.Measure(new Constraints(0, 80, 0, 10));
-    Assert.Equal(80, size.Width);
-    Assert.Equal(1, size.Height);
+    Assert.AreEqual(80, size.Width);
+    Assert.AreEqual(1, size.Height);
 }
 
-[Fact]
+[TestMethod]
 public void PropertyChange_MarksDirty()
 {
     var node = new ProgressNode { Value = 50 };
@@ -509,7 +514,7 @@ public void PropertyChange_MarksDirty()
     var widget = new ProgressWidget { Value = 75 };
     widget.Reconcile(node, new ReconcileContext(...));
     
-    Assert.True(node.IsDirty);
+    Assert.IsTrue(node.IsDirty);
 }
 ```
 
@@ -529,7 +534,9 @@ Integration tests spin up a real `Hex1bApp` and test the widget in various layou
 using Hex1b;
 using Hex1b.Input;
 using Hex1b.Theming;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+[TestClass]
 public class MyWidgetIntegrationTests : IDisposable
 {
     private readonly List<string> _tempFiles = new();
@@ -554,7 +561,7 @@ public class MyWidgetIntegrationTests : IDisposable
 #### Basic Integration Test Pattern
 
 ```csharp
-[Fact]
+[TestMethod]
 public async Task MyWidget_RendersCorrectly()
 {
     using var workload = new Hex1bAppWorkloadAdapter();
@@ -586,7 +593,7 @@ public async Task MyWidget_RendersCorrectly()
 Test the widget in all common layout containers:
 
 ```csharp
-[Fact]
+[TestMethod]
 public async Task MyWidget_InBorder()
 {
     using var workload = new Hex1bAppWorkloadAdapter();
@@ -612,7 +619,7 @@ public async Task MyWidget_InBorder()
     await runTask;
 }
 
-[Fact]
+[TestMethod]
 public async Task MyWidget_InHStackWithFill()
 {
     using var workload = new Hex1bAppWorkloadAdapter();
@@ -638,11 +645,11 @@ public async Task MyWidget_InHStackWithFill()
     await runTask;
 }
 
-[Theory]
-[InlineData(40)]
-[InlineData(60)]
-[InlineData(80)]
-[InlineData(120)]
+[TestMethod]
+[DataRow(40)]
+[DataRow(60)]
+[DataRow(80)]
+[DataRow(120)]
 public async Task MyWidget_RespondsToTerminalWidth(int width)
 {
     using var workload = new Hex1bAppWorkloadAdapter();
@@ -671,7 +678,7 @@ public async Task MyWidget_RespondsToTerminalWidth(int width)
 For widgets with animation or dynamic behavior, record asciinema sessions:
 
 ```csharp
-[Fact]
+[TestMethod]
 public async Task MyWidget_RecordsAnimation()
 {
     var tempFile = GetTempFile();
@@ -725,7 +732,7 @@ public async Task MyWidget_RecordsAnimation()
 Test how widgets respond to terminal resizing:
 
 ```csharp
-[Fact]
+[TestMethod]
 public async Task MyWidget_RecordsResizeScenario()
 {
     var tempFile = GetTempFile();
@@ -789,7 +796,7 @@ public async Task MyWidget_RecordsResizeScenario()
 Verify custom themes are applied correctly:
 
 ```csharp
-[Fact]
+[TestMethod]
 public async Task MyWidget_RespectsCustomTheme()
 {
     using var workload = new Hex1bAppWorkloadAdapter();
@@ -831,7 +838,7 @@ Every widget should have integration tests covering:
 - [ ] **Multiple instances** - Several widgets in a VStack
 - [ ] **Fixed width** - Widget with `.FixedWidth()` constraint
 - [ ] **Fill behavior** - Widget with `.Fill()` in cross-axis container
-- [ ] **Various terminal widths** - Theory test with 40, 60, 80, 120 columns
+- [ ] **Various terminal widths** - MSTest `DataRow` test with 40, 60, 80, 120 columns
 - [ ] **Custom theme** - Widget with custom theme elements
 - [ ] **Dynamic updates** - Widget responding to `app.Invalidate()` (if applicable)
 - [ ] **Animation recording** - Asciinema recording for animated states (if applicable)

--- a/.github/skills/writing-unit-tests/SKILL.md
+++ b/.github/skills/writing-unit-tests/SKILL.md
@@ -5,7 +5,7 @@ description: Guidelines for writing unit tests in the Hex1b TUI library. Use whe
 
 # Writing Unit Tests Skill
 
-This skill provides guidelines for AI agents writing unit tests for the Hex1b TUI library. It outlines the preferred testing approach, patterns, and anti-patterns to avoid.
+This skill provides guidelines for AI agents writing unit tests for the Hex1b TUI library. It outlines the preferred testing approach, patterns, and anti-patterns to avoid. Tests use MSTest 4 with `MSTest.Sdk/4.2.3`, `OutputType=Exe`, and Microsoft.Testing.Platform (MTP). `global.json` configures `dotnet test` to use MTP; test projects can also run in executable mode with `dotnet run --project tests/SomeProject/`.
 
 ## Core Philosophy
 
@@ -30,34 +30,42 @@ This skill provides guidelines for AI agents writing unit tests for the Hex1b TU
 
 ### Full Stack Integration Test
 
+Test files import `Microsoft.VisualStudio.TestTools.UnitTesting`. The `Hex1b.Testing` namespace is global-using'd via `Directory.Build.props` for helpers such as `TestSeq`. For test output, add `public TestContext TestContext { get; set; } = null!;` and call `TestContext.WriteLine(...)`. Suppressed MSTest analyzers are MSTEST0014, MSTEST0030, MSTEST0032, and MSTEST0057.
+
 This is the **preferred pattern** for most tests:
 
 ```csharp
-[Fact]
-public async Task WidgetName_Scenario_ExpectedBehavior()
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+[TestClass]
+public class WidgetNameTests
 {
-    // Arrange - Build the terminal with the app
-    await using var terminal = Hex1bTerminal.CreateBuilder()
-        .WithHex1bApp((app, options) => ctx => new VStackWidget([
-            new TextBlockWidget("Hello"),
-            new ButtonWidget("Click Me")
-        ]))
-        .WithHeadless()
-        .WithDimensions(80, 24)
-        .Build();
+    [TestMethod]
+    public async Task WidgetName_Scenario_ExpectedBehavior()
+    {
+        // Arrange - Build the terminal with the app
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithHex1bApp((app, options) => ctx => new VStackWidget([
+                new TextBlockWidget("Hello"),
+                new ButtonWidget("Click Me")
+            ]))
+            .WithHeadless()
+            .WithDimensions(80, 24)
+            .Build();
 
-    // Act & Assert - Use input sequencer with WaitUntil
-    var snapshot = await new Hex1bTerminalInputSequenceBuilder()
-        .WaitUntil(s => s.ContainsText("Hello"), TimeSpan.FromSeconds(2), "initial render")
-        .Down()  // Navigate to button
-        .WaitUntil(s => s.ContainsText("> Click Me"), TimeSpan.FromSeconds(2), "button focused")
-        .Capture("focused-button")
-        .Ctrl().Key(Hex1bKey.C)
-        .Build()
-        .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
+        // Act & Assert - Use input sequencer with WaitUntil
+        var snapshot = await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.ContainsText("Hello"), TimeSpan.FromSeconds(2), "initial render")
+            .Down()  // Navigate to button
+            .WaitUntil(s => s.ContainsText("> Click Me"), TimeSpan.FromSeconds(2), "button focused")
+            .Capture("focused-button")
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-    // Assert (often redundant if WaitUntil already verified)
-    Assert.True(snapshot.ContainsText("> Click Me"));
+        // Assert (often redundant if WaitUntil already verified)
+        Assert.IsTrue(snapshot.ContainsText("> Click Me"));
+    }
 }
 ```
 
@@ -127,19 +135,19 @@ For precise cell-level assertions:
 // Find a specific character
 var pattern = new CellPatternSearcher().Find('█');
 var result = pattern.Search(snapshot);
-Assert.True(result.HasMatches);
-Assert.Equal(expectedX, result.First!.Start.X);
+Assert.IsTrue(result.HasMatches);
+Assert.AreEqual(expectedX, result.First!.Start.X);
 
 // Find with regex pattern
 var pattern = new CellPatternSearcher().FindPattern(@"Count:\s*\d+");
 var result = pattern.Search(snapshot);
-Assert.True(result.HasMatches);
+Assert.IsTrue(result.HasMatches);
 
 // Find with predicate
 var pattern = new CellPatternSearcher()
     .Find(ctx => char.IsDigit(ctx.Cell.Character[0]));
 var result = pattern.Search(snapshot);
-Assert.Equal(3, result.Count);
+Assert.AreEqual(3, result.Count);
 ```
 
 ### Color Assertions
@@ -148,19 +156,19 @@ For verifying themed/styled output:
 
 ```csharp
 // Check if any cell has a specific background color
-Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(0, 100, 200)),
+Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(0, 100, 200)),
     "Button should have blue background");
 
 // Check if any cell has a specific foreground color
-Assert.True(snapshot.HasForegroundColor(Hex1bColor.FromRgb(255, 255, 255)),
+Assert.IsTrue(snapshot.HasForegroundColor(Hex1bColor.FromRgb(255, 255, 255)),
     "Text should be white");
 
 // Get color at specific position
 var bgColor = snapshot.GetBackgroundColor(10, 5);
-Assert.Equal(Hex1bColor.FromRgb(255, 0, 0), bgColor);
+Assert.AreEqual(Hex1bColor.FromRgb(255, 0, 0), bgColor);
 
 // Check uniform row background
-Assert.True(snapshot.HasUniformBackgroundColor(0, Hex1bColor.FromRgb(50, 50, 50)),
+Assert.IsTrue(snapshot.HasUniformBackgroundColor(0, Hex1bColor.FromRgb(50, 50, 50)),
     "Header row should have dark background");
 ```
 
@@ -194,7 +202,7 @@ await new Hex1bTerminalInputSequenceBuilder()
     .ApplyAsync(terminal, ct);
 
 // Assertion on footer may fail - it wasn't part of the WaitUntil!
-Assert.True(snapshot.ContainsText("Footer"));
+Assert.IsTrue(snapshot.ContainsText("Footer"));
 ```
 
 **Problem**: Rendering is inherently async. Finding "Header" doesn't guarantee "Footer" has rendered yet. This is especially problematic when testing other terminal frameworks (like Spectre Console) which may drop input if they're not ready to receive it.
@@ -224,7 +232,7 @@ var snapshot = await new Hex1bTerminalInputSequenceBuilder()
     .Build()
     .ApplyWithCaptureAsync(terminal, ct);
 
-Assert.True(snapshot.ContainsText("Hello"));  // ❌ May fail on Linux CI
+Assert.IsTrue(snapshot.ContainsText("Hello"));  // ❌ May fail on Linux CI
 ```
 
 **Fix**: The `WaitUntil` already verified the content. If you need to assert, the `WaitUntil` serves as the assertion.
@@ -256,7 +264,7 @@ await new Hex1bTerminalInputSequenceBuilder()
 // BROKEN: Fixed delay may not be long enough on slow CI
 await terminal.SendKeyAsync(Hex1bKey.Enter);
 await Task.Delay(100);  // ❌ Arbitrary delay
-Assert.True(eventFired);
+Assert.IsTrue(eventFired);
 ```
 
 **Fix**: Use `TaskCompletionSource` to signal completion:
@@ -292,14 +300,14 @@ When writing tests for widgets, consider all the **dimensions** that affect beha
 
 ### 1. Terminal Size Variations
 
-Widgets must work across different terminal sizes. Test the realistic range:
+Widgets must work across different terminal sizes. Use MSTest `DataRow` for parameterized cases:
 
 ```csharp
-[Theory]
-[InlineData(40, 10)]   // Minimum realistic size
-[InlineData(80, 24)]   // Standard terminal
-[InlineData(120, 40)]  // Large terminal
-[InlineData(200, 60)]  // Very large terminal
+[TestMethod]
+[DataRow(40, 10)]   // Minimum realistic size
+[DataRow(80, 24)]   // Standard terminal
+[DataRow(120, 40)]  // Large terminal
+[DataRow(200, 60)]  // Very large terminal
 public async Task ListWidget_VariousTerminalSizes_RendersCorrectly(int width, int height)
 {
     await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -328,7 +336,7 @@ public async Task ListWidget_VariousTerminalSizes_RendersCorrectly(int width, in
 Widgets behave differently depending on their parent container. Test inside various layouts:
 
 ```csharp
-[Fact]
+[TestMethod]
 public async Task ProgressWidget_InsideBorder_RendersWithCorrectWidth()
 {
     await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -348,7 +356,7 @@ public async Task ProgressWidget_InsideBorder_RendersWithCorrectWidth()
         .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 }
 
-[Fact]
+[TestMethod]
 public async Task Button_InsideHStack_SharesSpaceCorrectly()
 {
     await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -382,7 +390,7 @@ public async Task Button_InsideHStack_SharesSpaceCorrectly()
 Verify that widgets respect theme colors and can be customized:
 
 ```csharp
-[Fact]
+[TestMethod]
 public async Task Button_WithCustomTheme_UsesThemeColors()
 {
     var customTheme = new Hex1bTheme("TestTheme")
@@ -406,13 +414,13 @@ public async Task Button_WithCustomTheme_UsesThemeColors()
         .Build()
         .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-    Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 0, 0)),
+    Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 0, 0)),
         "Button should have red background from theme");
-    Assert.True(snapshot.HasForegroundColor(Hex1bColor.FromRgb(255, 255, 255)),
+    Assert.IsTrue(snapshot.HasForegroundColor(Hex1bColor.FromRgb(255, 255, 255)),
         "Button should have white text from theme");
 }
 
-[Fact]
+[TestMethod]
 public async Task Button_FocusedState_UsesFocusedThemeColors()
 {
     await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -434,7 +442,7 @@ public async Task Button_FocusedState_UsesFocusedThemeColors()
         .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
     // Verify focused state uses different colors than unfocused
-    Assert.True(snapshot.HasBackgroundColor(), "Focused button should have background color");
+    Assert.IsTrue(snapshot.HasBackgroundColor(), "Focused button should have background color");
 }
 ```
 
@@ -466,7 +474,7 @@ Not every widget needs every combination, but consider which dimensions are rele
 For APIs that are dependencies of `Hex1bApp` (like `Surface`), test in isolation:
 
 ```csharp
-[Fact]
+[TestMethod]
 public void Surface_WriteText_SetsCorrectCells()
 {
     // Arrange
@@ -476,23 +484,23 @@ public void Surface_WriteText_SetsCorrectCells()
     surface.WriteText(0, 0, "Hello");
     
     // Assert
-    Assert.Equal('H', surface[0, 0].Character[0]);
-    Assert.Equal('e', surface[1, 0].Character[0]);
-    Assert.Equal('l', surface[2, 0].Character[0]);
-    Assert.Equal('l', surface[3, 0].Character[0]);
-    Assert.Equal('o', surface[4, 0].Character[0]);
+    Assert.AreEqual('H', surface[0, 0].Character[0]);
+    Assert.AreEqual('e', surface[1, 0].Character[0]);
+    Assert.AreEqual('l', surface[2, 0].Character[0]);
+    Assert.AreEqual('l', surface[3, 0].Character[0]);
+    Assert.AreEqual('o', surface[4, 0].Character[0]);
 }
 
-[Fact]
+[TestMethod]
 public void SurfaceCell_WithColor_PreservesColor()
 {
     // Arrange
     var cell = new SurfaceCell('X', Hex1bColor.Red, Hex1bColor.Blue);
     
     // Assert
-    Assert.Equal('X', cell.Character[0]);
-    Assert.Equal(Hex1bColor.Red, cell.Foreground);
-    Assert.Equal(Hex1bColor.Blue, cell.Background);
+    Assert.AreEqual('X', cell.Character[0]);
+    Assert.AreEqual(Hex1bColor.Red, cell.Foreground);
+    Assert.AreEqual(Hex1bColor.Blue, cell.Background);
 }
 ```
 
@@ -503,16 +511,16 @@ public void SurfaceCell_WithColor_PreservesColor()
 Follow `MethodName_Scenario_ExpectedBehavior`:
 
 ```csharp
-[Fact]
+[TestMethod]
 public async Task ListWidget_DownArrow_SelectsNextItem() { }
 
-[Fact]
+[TestMethod]
 public async Task TextBox_TypeText_DisplaysInput() { }
 
-[Fact]
+[TestMethod]
 public async Task Button_EnterKey_TriggersClickHandler() { }
 
-[Fact]
+[TestMethod]
 public void Surface_Fill_SetsAllCellsInRegion() { }
 ```
 

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -59,20 +59,20 @@ jobs:
         run: |
           dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj \
             --no-build \
-            --logger "trx;LogFileName=test-results.trx" \
-            --results-directory ./TestResults
+            -- --report-trx --report-trx-filename test-results.trx \
+               --results-directory ./TestResults
           dotnet test tests/Hex1b.Analyzers.Tests/Hex1b.Analyzers.Tests.csproj \
             --no-build \
-            --logger "trx;LogFileName=analyzer-test-results.trx" \
-            --results-directory ./TestResults
+            -- --report-trx --report-trx-filename analyzer-test-results.trx \
+               --results-directory ./TestResults
           dotnet test tests/Hex1b.McpServer.Tests/Hex1b.McpServer.Tests.csproj \
             --no-build \
-            --logger "trx;LogFileName=mcp-test-results.trx" \
-            --results-directory ./TestResults
+            -- --report-trx --report-trx-filename mcp-test-results.trx \
+               --results-directory ./TestResults
           dotnet test tests/Hex1b.Tool.Tests/Hex1b.Tool.Tests.csproj \
             --no-build \
-            --logger "trx;LogFileName=tool-test-results.trx" \
-            --results-directory ./TestResults
+            -- --report-trx --report-trx-filename tool-test-results.trx \
+               --results-directory ./TestResults
 
       - name: Download and install Aspire CLI
         if: runner.os == 'Linux'

--- a/.github/workflows/daily-tests.yml
+++ b/.github/workflows/daily-tests.yml
@@ -46,13 +46,13 @@ jobs:
         run: |
           dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj \
             --no-build \
-            --logger "trx;LogFileName=test-results.trx" \
-            --results-directory ./TestResults \
-            --filter "FullyQualifiedName!~EditorFuzzTests"
+            -- --report-trx --report-trx-filename test-results.trx \
+               --results-directory ./TestResults \
+               --filter "FullyQualifiedName!~EditorFuzzTests"
           dotnet test tests/Hex1b.McpServer.Tests/Hex1b.McpServer.Tests.csproj \
             --no-build \
-            --logger "trx;LogFileName=mcp-test-results.trx" \
-            --results-directory ./TestResults
+            -- --report-trx --report-trx-filename mcp-test-results.trx \
+               --results-directory ./TestResults
 
       - name: Process test results
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Skills are invoked automatically by AI agents based on the task context. They co
 ### Key Technologies
 - **.NET 10.0** (preview) - Target framework
 - **C# 12+** - Modern C# features enabled
-- **xUnit** - Testing framework
+- **MSTest** (MSTest.Sdk 4.x with Microsoft.Testing.Platform) - Testing framework
 - **.NET Aspire** - Used for running sample applications
 
 ### Repository Layout
@@ -174,11 +174,19 @@ Quick checklist:
 
 Follow the `MethodName_Scenario_ExpectedBehavior` naming pattern:
 ```csharp
-[Fact]
+[TestMethod]
 public void Measure_WithConstraints_ReturnsExpectedSize()
 {
     // Arrange, Act, Assert
 }
+```
+
+Test projects use `MSTest.Sdk` with `OutputType=Exe` and Microsoft.Testing.Platform (MTP). Use `[TestMethod]` for facts, `[TestMethod] [DataRow(...)]` for theories, `[TestInitialize]`/`[TestCleanup]` for setup/teardown, and `[DoNotParallelize]` instead of xUnit collections. For collection-equality, single-element, and type-cast assertions, prefer the `TestSeq` helpers in `eng/TestSeq.cs` (auto-imported via `Hex1b.Testing`):
+
+```csharp
+TestSeq.AreEqual(expected, actual);   // deep collection equality
+var item = TestSeq.Single(items);     // assert single + return element
+var node = TestSeq.IsType<MyNode>(x); // assert type + return cast value
 ```
 
 ## 🔧 Common Tasks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,7 +181,7 @@ public void Measure_WithConstraints_ReturnsExpectedSize()
 }
 ```
 
-Test projects use `MSTest.Sdk` with `OutputType=Exe` and Microsoft.Testing.Platform (MTP). Use `[TestMethod]` for facts, `[TestMethod] [DataRow(...)]` for theories, `[TestInitialize]`/`[TestCleanup]` for setup/teardown, and `[DoNotParallelize]` instead of xUnit collections. For collection-equality, single-element, and type-cast assertions, prefer the `TestSeq` helpers in `eng/TestSeq.cs` (auto-imported via `Hex1b.Testing`):
+Test projects use `MSTest.Sdk` with `OutputType=Exe` and Microsoft.Testing.Platform (MTP). Use `[TestMethod]` for facts, `[TestMethod] [DataRow(...)]` for theories, `[TestInitialize]`/`[TestCleanup]` for setup/teardown, and `[DoNotParallelize]` on a class to opt out of parallel execution. For collection-equality, single-element, and type-cast assertions, prefer the `TestSeq` helpers in `tests/Shared/TestSeq.cs` (auto-imported via `Hex1b.Testing`):
 
 ```csharp
 TestSeq.AreEqual(expected, actual);   // deep collection equality

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ hex1b/
 │   └── IHex1bTerminal.cs   # Terminal interface for testing
 ├── samples/                # Example applications
 │   └── Cancellation/       # Master-detail contact editor sample
-├── tests/Hex1b.Tests/      # Unit tests (xUnit)
+├── tests/Hex1b.Tests/      # Unit tests (MSTest)
 └── apphost.cs              # Aspire app host
 ```
 
@@ -102,14 +102,14 @@ dotnet test --filter "FullyQualifiedName~ButtonNodeTests"
 
 ### Writing Tests
 
-- Tests use xUnit framework
+- Tests use the MSTest framework (`MSTest.Sdk` 4.x with Microsoft.Testing.Platform)
 - Test files are in `tests/Hex1b.Tests/`
 - Use `IHex1bTerminal` interface for mocking terminal interactions
 - Follow the naming convention: `MethodName_Scenario_ExpectedBehavior`
 
 Example:
 ```csharp
-[Fact]
+[TestMethod]
 public void HandleInput_EnterKey_TriggersClickAction()
 {
     var clicked = false;
@@ -121,8 +121,8 @@ public void HandleInput_EnterKey_TriggersClickAction()
     
     var result = node.HandleInput(new Hex1bKeyEvent(Hex1bKey.Enter, '\r', Hex1bModifiers.None));
     
-    Assert.Equal(InputResult.Handled, result);
-    Assert.True(clicked);
+    Assert.AreEqual(InputResult.Handled, result);
+    Assert.IsTrue(clicked);
 }
 ```
 
@@ -231,7 +231,8 @@ dotnet run --project apphost.cs
 
 - [.NET Console APIs](https://learn.microsoft.com/dotnet/api/system.console)
 - [ANSI Escape Codes](https://en.wikipedia.org/wiki/ANSI_escape_code)
-- [xUnit Documentation](https://xunit.net/docs/getting-started/netcore/cmdline)
+- [MSTest Documentation](https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-intro)
+- [Microsoft.Testing.Platform](https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-intro)
 - [.NET Aspire](https://learn.microsoft.com/dotnet/aspire/)
 
 ## ❓ Questions?

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,40 @@
   </PropertyGroup>
 
   <!--
+    MSTest 4 exposes a handful of evaluation-only APIs (e.g. TestContext.Current,
+    Assert.ThrowsExactly overloads) via diagnostic id MSTESTEXP. Suppress that
+    diagnostic for test projects so they can keep using these APIs without
+    forcing every call site to <SuppressMessage> them.
+
+    CS8602/CS8604 suppression mirrors the previous xUnit1031/xUnit1051 suppression
+    posture: nuisance warnings in test code (TestContext.Current dereferences,
+    nullable string args to Assert.Contains) that xUnit's annotated overloads
+    didn't generate but MSTest 4's stricter annotations do.
+  -->
+  <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
+    <!--
+      MSTESTEXP: opt-in to experimental TestContext.Current / Assert.ThrowsExactly APIs.
+      CS8602/CS8604: nullable nuisance warnings around TestContext.Current dereferences.
+      MSTEST0014: DataRow arg type mismatch (xUnit InlineData was looser; int<->byte etc.).
+      MSTEST0030: "missing [TestClass]" — fires on attribute-only classes (custom Fact-derived).
+      MSTEST0032: "condition known to be always true" — fires on Assert.IsNotNull after capture.
+      MSTEST0057: requires CallerFilePath/LineNumber on custom TestMethodAttribute subclasses;
+                  not actionable while preserving xUnit-style constructor signatures.
+    -->
+    <NoWarn>$(NoWarn);MSTESTEXP;CS8602;CS8604;MSTEST0014;MSTEST0030;MSTEST0032;MSTEST0057</NoWarn>
+  </PropertyGroup>
+
+  <!--
+    Link the shared TestSeq helper into every test project. TestSeq bridges
+    xUnit-style Assert.Equal(collection, collection) semantics to MSTest's
+    CollectionAssert + ToList() materialisation. See eng/TestSeq.cs.
+  -->
+  <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
+    <Compile Include="$(MSBuildThisFileDirectory)eng\TestSeq.cs" Link="eng\TestSeq.cs" />
+    <Using Include="Hex1b.Testing" />
+  </ItemGroup>
+
+  <!--
     Wire the repository-local Hex1b.Analyzers analyzer into every project. PrivateAssets="all"
     keeps the analyzer out of the Hex1b NuGet package so it is enforced only inside this repo.
     The Condition excludes the analyzer project itself and its test project from referencing it,

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,31 +18,31 @@
     diagnostic for test projects so they can keep using these APIs without
     forcing every call site to <SuppressMessage> them.
 
-    CS8602/CS8604 suppression mirrors the previous xUnit1031/xUnit1051 suppression
-    posture: nuisance warnings in test code (TestContext.Current dereferences,
-    nullable string args to Assert.Contains) that xUnit's annotated overloads
-    didn't generate but MSTest 4's stricter annotations do.
+    CS8602/CS8604 suppression covers nuisance nullable warnings in test code
+    (TestContext.Current dereferences, nullable string args to Assert.Contains)
+    that MSTest 4's stricter annotations surface.
   -->
   <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
     <!--
       MSTESTEXP: opt-in to experimental TestContext.Current / Assert.ThrowsExactly APIs.
       CS8602/CS8604: nullable nuisance warnings around TestContext.Current dereferences.
-      MSTEST0014: DataRow arg type mismatch (xUnit InlineData was looser; int<->byte etc.).
-      MSTEST0030: "missing [TestClass]" — fires on attribute-only classes (custom Fact-derived).
+      MSTEST0014: DataRow arg type mismatch (int<->byte etc. tolerated by some legacy tests).
+      MSTEST0030: "missing [TestClass]" — fires on attribute-only classes (custom skip-fact subclasses).
       MSTEST0032: "condition known to be always true" — fires on Assert.IsNotNull after capture.
       MSTEST0057: requires CallerFilePath/LineNumber on custom TestMethodAttribute subclasses;
-                  not actionable while preserving xUnit-style constructor signatures.
+                  not actionable while preserving the existing constructor signatures.
     -->
     <NoWarn>$(NoWarn);MSTESTEXP;CS8602;CS8604;MSTEST0014;MSTEST0030;MSTEST0032;MSTEST0057</NoWarn>
   </PropertyGroup>
 
   <!--
-    Link the shared TestSeq helper into every test project. TestSeq bridges
-    xUnit-style Assert.Equal(collection, collection) semantics to MSTest's
-    CollectionAssert + ToList() materialisation. See eng/TestSeq.cs.
+    Link the shared TestSeq helper into every test project. TestSeq materialises
+    both sides of a sequence-equality comparison via ToList() and delegates to
+    CollectionAssert, since MSTest's Assert.AreEqual on IEnumerable<T> collapses
+    to reference equality. See tests/Shared/TestSeq.cs.
   -->
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
-    <Compile Include="$(MSBuildThisFileDirectory)eng\TestSeq.cs" Link="eng\TestSeq.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)tests\Shared\TestSeq.cs" Link="Shared\TestSeq.cs" />
     <Using Include="Hex1b.Testing" />
   </ItemGroup>
 

--- a/eng/TestSeq.cs
+++ b/eng/TestSeq.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Hex1b contributors. Licensed under the MIT license.
+//
+// Repo-wide test helper that bridges xUnit's `Assert.Equal(coll, coll)` semantics
+// (sequence equality) to MSTest. MSTest's own `Assert.AreEqual` uses
+// `EqualityComparer<T>.Default` which on collection types collapses to reference
+// equality, while `CollectionAssert.AreEqual` requires `ICollection` rather than
+// `IEnumerable<T>`. `TestSeq` papers over both: it materialises both sides via
+// `ToList()` and delegates to `CollectionAssert`.
+//
+// The xunit -> mstest codemod (`eng/codemod/xunit_to_mstest.py`) rewrites
+// `Assert.Equal(a, b)` to `TestSeq.AreEqual(a, b)` whenever either argument
+// looks like a collection literal, LINQ chain, or collection-typed expression.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Hex1b.Testing;
+
+internal static class TestSeq
+{
+    public static void AreEqual<T>(IEnumerable<T>? expected, IEnumerable<T>? actual, string? message = null)
+        => CollectionAssert.AreEqual(expected?.ToList(), actual?.ToList(), message ?? string.Empty);
+
+    public static void AreNotEqual<T>(IEnumerable<T>? notExpected, IEnumerable<T>? actual, string? message = null)
+        => CollectionAssert.AreNotEqual(notExpected?.ToList(), actual?.ToList(), message ?? string.Empty);
+
+    /// <summary>
+    /// xUnit's <c>Assert.Single(coll)</c> returns the single element. MSTest's
+    /// <c>Assert.HasCount(1, coll)</c> returns void, so the codemod routes
+    /// `var x = Assert.Single(coll)` to `var x = TestSeq.Single(coll)`.
+    /// </summary>
+    public static T Single<T>(IEnumerable<T> source)
+    {
+        Assert.HasCount(1, source);
+        return source.Single();
+    }
+
+    /// <summary>
+    /// xUnit's <c>Assert.IsType&lt;T&gt;(value)</c> returns the cast value.
+    /// MSTest's <c>Assert.IsInstanceOfType&lt;T&gt;(value)</c> returns void,
+    /// so the codemod routes `var x = Assert.IsType&lt;T&gt;(v)` to
+    /// `var x = TestSeq.IsType&lt;T&gt;(v)`.
+    /// </summary>
+    public static T IsType<T>(object? value)
+    {
+        Assert.IsInstanceOfType<T>(value);
+        return (T)value!;
+    }
+
+    /// <summary>
+    /// xUnit's <c>Assert.Single(coll, predicate)</c>: assert exactly one
+    /// matching element exists, and return it.
+    /// </summary>
+    public static T Single<T>(IEnumerable<T> source, Func<T, bool> predicate)
+    {
+        var matches = source.Where(predicate).ToList();
+        Assert.HasCount(1, matches);
+        return matches[0];
+    }
+
+    /// <summary>
+    /// xUnit's <c>Assert.All(coll, action)</c>. MSTest has no equivalent;
+    /// emulate by invoking the assertion action for every element.
+    /// </summary>
+    public static void All<T>(IEnumerable<T> source, Action<T> action)
+    {
+        foreach (var item in source)
+        {
+            action(item);
+        }
+    }
+
+    /// <summary>
+    /// xUnit's <c>Assert.Collection(coll, e1, e2, ...)</c>: assert the
+    /// collection has exactly <c>elementInspectors.Length</c> items, then
+    /// apply each inspector to the matching element by index.
+    /// </summary>
+    public static void Collection<T>(IEnumerable<T> source, params Action<T>[] elementInspectors)
+    {
+        var list = source.ToList();
+        Assert.HasCount(elementInspectors.Length, list);
+        for (var i = 0; i < elementInspectors.Length; i++)
+        {
+            elementInspectors[i](list[i]);
+        }
+    }
+
+    /// <summary>xUnit's <c>Assert.InRange(value, low, high)</c>.</summary>
+    public static void InRange<T>(T actual, T low, T high) where T : IComparable<T>
+    {
+        Assert.IsTrue(
+            actual.CompareTo(low) >= 0 && actual.CompareTo(high) <= 0,
+            $"Expected {actual} to be in range [{low}, {high}].");
+    }
+
+    /// <summary>xUnit's <c>Assert.Matches(pattern, input)</c>.</summary>
+    public static void Matches(string pattern, string? input)
+    {
+        Assert.IsNotNull(input);
+        Assert.IsTrue(
+            System.Text.RegularExpressions.Regex.IsMatch(input, pattern),
+            $"Expected input to match pattern '{pattern}'. Actual: {input}");
+    }
+
+    /// <summary>xUnit's <c>Record.Exception(action)</c> — capture an exception or return null.</summary>
+    public static Exception? RecordException(Action action)
+    {
+        try { action(); return null; }
+        catch (Exception ex) { return ex; }
+    }
+
+    public static async Task<Exception?> RecordExceptionAsync(Func<Task> action)
+    {
+        try { await action(); return null; }
+        catch (Exception ex) { return ex; }
+    }
+}
+
+/// <summary>
+/// xUnit-style TheoryData shim. MSTest's <c>[DynamicData]</c> consumes
+/// <c>IEnumerable&lt;object[]&gt;</c>, so this acts as a drop-in replacement
+/// for xUnit's <c>TheoryData&lt;T&gt;</c> via collection-initializer syntax.
+/// </summary>
+public sealed class TheoryData<T> : List<object?[]>
+{
+    public void Add(T value) => base.Add(new object?[] { value });
+}
+
+public sealed class TheoryData<T1, T2> : List<object?[]>
+{
+    public void Add(T1 a, T2 b) => base.Add(new object?[] { a, b });
+}
+
+public sealed class TheoryData<T1, T2, T3> : List<object?[]>
+{
+    public void Add(T1 a, T2 b, T3 c) => base.Add(new object?[] { a, b, c });
+}
+
+public sealed class TheoryData<T1, T2, T3, T4> : List<object?[]>
+{
+    public void Add(T1 a, T2 b, T3 c, T4 d) => base.Add(new object?[] { a, b, c, d });
+}

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/samples/AccordionDemo/Program.cs
+++ b/samples/AccordionDemo/Program.cs
@@ -105,34 +105,35 @@ var sampleFiles = new Dictionary<string, string>
         }
         """,
     ["tests/ProgramTests.cs"] = """
-        using Xunit;
+        using Microsoft.VisualStudio.TestTools.UnitTesting;
         using MyProject;
 
+        [TestClass]
         public class ProgramTests
         {
-            [Fact]
+            [TestMethod]
             public void Greet_ReturnsExpected()
             {
-                Assert.Equal("Hello, Alice!", Utils.Greet("Alice"));
+                Assert.AreEqual("Hello, Alice!", Utils.Greet("Alice"));
             }
 
-            [Fact]
+            [TestMethod]
             public void Add_ReturnsSum()
             {
-                Assert.Equal(5, Utils.Add(2, 3));
+                Assert.AreEqual(5, Utils.Add(2, 3));
             }
 
-            [Fact]
+            [TestMethod]
             public void FormatDate_ReturnsIso()
             {
                 var date = new DateTime(2025, 1, 15, 10, 30, 0);
-                Assert.Equal("2025-01-15 10:30:00", Utils.FormatDate(date));
+                Assert.AreEqual("2025-01-15 10:30:00", Utils.FormatDate(date));
             }
 
-            [Fact]
+            [TestMethod]
             public void IsValidEmail_ValidEmail_ReturnsTrue()
             {
-                Assert.True(Utils.IsValidEmail("test@example.com"));
+                Assert.IsTrue(Utils.IsValidEmail("test@example.com"));
             }
         }
         """,
@@ -144,7 +145,7 @@ var sampleFiles = new Dictionary<string, string>
         1. **Program** — entry point
         2. **Models** — data records (User, Product)
         3. **Utils** — shared helper methods
-        4. **Tests** — xUnit test suite
+        4. **Tests** — MSTest test suite
 
         ## Data Flow
 
@@ -154,7 +155,7 @@ var sampleFiles = new Dictionary<string, string>
 
         - Records for immutable data models
         - Static utility class for shared logic
-        - xUnit for testing
+        - MSTest for testing
         """,
     [".gitignore"] = "bin/\nobj/\n*.user\n.vs/\n*.swp\n",
 };

--- a/samples/SharedEditor/Program.cs
+++ b/samples/SharedEditor/Program.cs
@@ -16,8 +16,8 @@ var sampleFiles = new Dictionary<string, string>
     ["src/Program.cs"] = "using System;\n\nnamespace MyProject;\n\nclass Program\n{\n    static void Main(string[] args)\n    {\n        Console.WriteLine(\"Hello, World!\");\n    }\n}",
     ["src/Config.json"] = "{\n  \"name\": \"my-project\",\n  \"version\": \"1.0.0\",\n  \"settings\": {\n    \"theme\": \"dark\",\n    \"fontSize\": 14,\n    \"tabSize\": 4\n  }\n}",
     ["src/Utils.cs"] = "namespace MyProject;\n\npublic static class Utils\n{\n    public static string Greet(string name)\n        => $\"Hello, {name}!\";\n\n    public static int Add(int a, int b) => a + b;\n}",
-    ["tests/ProgramTests.cs"] = "using Xunit;\nusing MyProject;\n\npublic class ProgramTests\n{\n    [Fact]\n    public void Greet_ReturnsExpected()\n    {\n        Assert.Equal(\"Hello, Alice!\", Utils.Greet(\"Alice\"));\n    }\n\n    [Fact]\n    public void Add_ReturnsSum()\n    {\n        Assert.Equal(5, Utils.Add(2, 3));\n    }\n}",
-    ["docs/ARCHITECTURE.md"] = "# Architecture\n\nThis project follows a simple layered architecture:\n\n1. **Program** — entry point\n2. **Utils** — shared helpers\n3. **Tests** — xUnit test suite\n\n## Data Flow\n\nInput → Program → Utils → Output",
+    ["tests/ProgramTests.cs"] = "using Microsoft.VisualStudio.TestTools.UnitTesting;\nusing MyProject;\n\n[TestClass]\npublic class ProgramTests\n{\n    [TestMethod]\n    public void Greet_ReturnsExpected()\n    {\n        Assert.AreEqual(\"Hello, Alice!\", Utils.Greet(\"Alice\"));\n    }\n\n    [TestMethod]\n    public void Add_ReturnsSum()\n    {\n        Assert.AreEqual(5, Utils.Add(2, 3));\n    }\n}",
+    ["docs/ARCHITECTURE.md"] = "# Architecture\n\nThis project follows a simple layered architecture:\n\n1. **Program** — entry point\n2. **Utils** — shared helpers\n3. **Tests** — MSTest test suite\n\n## Data Flow\n\nInput → Program → Utils → Output",
     [".gitignore"] = "bin/\nobj/\n*.user\n.vs/\n*.swp",
 };
 

--- a/src/content/guide/mcp-server.md
+++ b/src/content/guide/mcp-server.md
@@ -116,7 +116,7 @@ The MCP server maintains a pool of terminal sessions:
 Let AI agents help with development tasks:
 
 ```
-"Set up a new .NET project with xUnit tests"
+"Set up a new .NET project with MSTest tests"
 "Run the build and fix any errors you find"
 "Deploy this to the staging environment"
 ```

--- a/src/content/guide/testing.md
+++ b/src/content/guide/testing.md
@@ -7,7 +7,7 @@ title: Testing
 Hex1b provides first-class testing support through its virtual terminal and input sequence builder. You can write automated tests that simulate user interactions and verify your application's behavior.
 
 ::: info Framework Agnostic
-Hex1b's testing APIs work with any .NET testing framework. This guide uses **xUnit** as an example, but the same patterns apply to NUnit, MSTest, or any other framework.
+Hex1b's testing APIs work with any .NET testing framework. This guide uses **MSTest** as an example, but the same patterns apply to xUnit, NUnit, or any other framework.
 :::
 
 ## Overview
@@ -31,7 +31,7 @@ var sequence = new Hex1bInputSequenceBuilder()
 
 await sequence.ApplyAsync(terminal);
 
-Assert.Contains("Hello", terminal.GetScreenText());
+StringAssert.Contains(terminal.GetScreenText(, "Hello"));
 ```
 
 ## A Sample Application
@@ -69,23 +69,30 @@ public static class CounterApp
 Add the Hex1b package to your test project:
 
 ```xml
-<ItemGroup>
-  <PackageReference Include="Hex1b" Version="*" />
-  <PackageReference Include="xunit" Version="2.9.0" />
-  <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
-</ItemGroup>
+<Project Sdk="MSTest.Sdk/3.6.4">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Hex1b" Version="*" />
+  </ItemGroup>
+</Project>
 ```
+
+The `MSTest.Sdk` meta-package pulls in MSTest itself plus the Microsoft.Testing.Platform runner, so no separate test-runner package is needed.
 
 ## Writing Your First Test
 
 ```csharp
 using Hex1b;
 using Hex1b.Widgets;
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+[TestClass]
 public class CounterAppTests
 {
-    [Fact]
+    [TestMethod]
     public async Task InitialState_ShowsZero()
     {
         // Arrange
@@ -105,7 +112,7 @@ public class CounterAppTests
         await runTask;
 
         // Assert
-        Assert.Contains("Count: 0", terminal.GetScreenText());
+        StringAssert.Contains(terminal.GetScreenText(, "Count: 0"));
     }
 }
 ```
@@ -124,7 +131,7 @@ public class CounterAppTests
 Use `Hex1bInputSequenceBuilder` to simulate user input:
 
 ```csharp
-[Fact]
+[TestMethod]
 public async Task ClickIncrement_IncreasesCount()
 {
     using var terminal = new Hex1bTerminal(80, 24);
@@ -155,7 +162,7 @@ public async Task ClickIncrement_IncreasesCount()
     await runTask;
 
     // Assert
-    Assert.Contains("Count: 3", terminal.GetScreenText());
+    StringAssert.Contains(terminal.GetScreenText(, "Count: 3"));
 }
 ```
 
@@ -244,7 +251,7 @@ var sequence = new Hex1bInputSequenceBuilder()
 ## Testing Keyboard Navigation
 
 ```csharp
-[Fact]
+[TestMethod]
 public async Task TabNavigation_MovesBetweenButtons()
 {
     using var terminal = new Hex1bTerminal(80, 24);
@@ -271,14 +278,14 @@ public async Task TabNavigation_MovesBetweenButtons()
     cts.Cancel();
     await runTask;
 
-    Assert.Contains("Count: -1", terminal.GetScreenText());
+    StringAssert.Contains(terminal.GetScreenText(, "Count: -1"));
 }
 ```
 
 ## Testing Text Input
 
 ```csharp
-[Fact]
+[TestMethod]
 public async Task TextBox_CapturesInput()
 {
     using var terminal = new Hex1bTerminal(80, 24);
@@ -312,14 +319,14 @@ public async Task TextBox_CapturesInput()
     cts.Cancel();
     await runTask;
 
-    Assert.Equal("Hello, Hex1b!", capturedText);
+    Assert.AreEqual("Hello, Hex1b!", capturedText);
 }
 ```
 
 ## Testing Keyboard Shortcuts
 
 ```csharp
-[Fact]
+[TestMethod]
 public async Task CtrlS_TriggersSave()
 {
     using var terminal = new Hex1bTerminal(80, 24);
@@ -356,7 +363,7 @@ public async Task CtrlS_TriggersSave()
     cts.Cancel();
     await runTask;
 
-    Assert.True(saveTriggered);
+    Assert.IsTrue(saveTriggered);
 }
 ```
 
@@ -436,11 +443,11 @@ await runTask;  // Ensure clean shutdown
 
 ```csharp
 // ✅ Focused test
-[Fact]
+[TestMethod]
 public async Task Increment_WhenClicked_IncreasesCountByOne()
 
 // ❌ Too broad
-[Fact]
+[TestMethod]
 public async Task Counter_WorksCorrectly()
 ```
 
@@ -473,7 +480,7 @@ using Hex1b.Automation;
 using Hex1b.Input;
 using Hex1b.Widgets;
 
-[Fact]
+[TestMethod]
 public async Task MenuItem_NavigatesToNextItem()
 {
     await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -679,8 +686,9 @@ Here's a full test class for the counter app:
 using Hex1b;
 using Hex1b.Input;
 using Hex1b.Widgets;
-using Xunit;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+[TestClass]
 public class CounterAppTests
 {
     private static Hex1bApp CreateApp(Hex1bTerminal terminal)
@@ -691,7 +699,7 @@ public class CounterAppTests
         );
     }
 
-    [Fact]
+    [TestMethod]
     public async Task InitialRender_DisplaysZero()
     {
         using var terminal = new Hex1bTerminal(80, 24);
@@ -705,10 +713,10 @@ public class CounterAppTests
             .ApplyAsync(terminal);
         await runTask;
 
-        Assert.Contains("Count: 0", terminal.GetScreenText());
+        StringAssert.Contains(terminal.GetScreenText(, "Count: 0"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Increment_IncreasesCount()
     {
         using var terminal = new Hex1bTerminal(80, 24);
@@ -728,10 +736,10 @@ public class CounterAppTests
         cts.Cancel();
         await runTask;
 
-        Assert.Contains("Count: 1", terminal.GetScreenText());
+        StringAssert.Contains(terminal.GetScreenText(, "Count: 1"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Decrement_DecreasesCount()
     {
         using var terminal = new Hex1bTerminal(80, 24);
@@ -752,10 +760,10 @@ public class CounterAppTests
         cts.Cancel();
         await runTask;
 
-        Assert.Contains("Count: -1", terminal.GetScreenText());
+        StringAssert.Contains(terminal.GetScreenText(, "Count: -1"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reset_SetsCountToZero()
     {
         using var terminal = new Hex1bTerminal(80, 24);
@@ -778,7 +786,7 @@ public class CounterAppTests
         cts.Cancel();
         await runTask;
 
-        Assert.Contains("Count: 0", terminal.GetScreenText());
+        StringAssert.Contains(terminal.GetScreenText(, "Count: 0"));
     }
 }
 ```

--- a/tests/AgenticPromptDemo.Tests/AgenticPromptDemo.Tests.csproj
+++ b/tests/AgenticPromptDemo.Tests/AgenticPromptDemo.Tests.csproj
@@ -1,24 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSTest.Sdk/4.2.3">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <!-- Suppress xUnit analyzer recommendations (not bugs):
-         xUnit1031: blocking task operations
-         xUnit1051: CancellationToken usage -->
-    <NoWarn>xUnit1031;xUnit1051</NoWarn>
     <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
-  </ItemGroup>
 
   <ItemGroup>
     <!-- Reference the demo so we can drive its widgets directly.
@@ -28,7 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="Xunit" />
     <Using Include="Hex1b.Automation" />
   </ItemGroup>
 

--- a/tests/AgenticPromptDemo.Tests/SlashCommandPromptWidgetTests.cs
+++ b/tests/AgenticPromptDemo.Tests/SlashCommandPromptWidgetTests.cs
@@ -16,6 +16,7 @@ namespace AgenticPromptDemo.Tests;
 /// sibling above, multiple focusables) so we cover the trees the demo —
 /// and other consumers — actually use.
 /// </summary>
+[TestClass]
 public class SlashCommandPromptWidgetTests
 {
     private static readonly IReadOnlyList<SlashCommand> Commands =
@@ -41,7 +42,7 @@ public class SlashCommandPromptWidgetTests
     /// composite previously passed Text=null (textbox owns its own text),
     /// the new node started empty, dropping the '/' the user just typed.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task TypingSlash_OpensPaletteAndShowsFirstMatchPreview()
     {
         var screen = await DriveAsync(b => b
@@ -66,7 +67,7 @@ public class SlashCommandPromptWidgetTests
     /// starting with 'p' AND show a preview of the (now sole) match in the
     /// textbox.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task TypingPrefix_FiltersPaletteAndShowsPreview()
     {
         var screen = await DriveAsync(b => b
@@ -88,7 +89,7 @@ public class SlashCommandPromptWidgetTests
     /// Typing a non-slash leading char must NOT open the palette, and the
     /// textbox must hold what was typed.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task TypingPlainText_DoesNotOpenPalette()
     {
         var screen = await DriveAsync(b => b
@@ -105,7 +106,7 @@ public class SlashCommandPromptWidgetTests
     /// <summary>
     /// DownArrow with the palette open moves the '❯' marker to the next row.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task DownArrow_MovesPaletteSelection()
     {
         var screen = await DriveAsync(b => b
@@ -126,7 +127,7 @@ public class SlashCommandPromptWidgetTests
     /// <summary>
     /// UpArrow at the top of the list is a no-op (does not wrap).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task UpArrow_AtTop_StaysOnFirstRow()
     {
         var screen = await DriveAsync(b => b
@@ -149,7 +150,7 @@ public class SlashCommandPromptWidgetTests
     /// the FIRST focusable in the app and the DownArrow ends up scrolling
     /// the transcript instead of moving the palette selection.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task DownArrow_WithFocusableAbove_MovesPaletteSelection()
     {
         var screen = await DriveAsync<FocusableAboveHostWidget>(b => b
@@ -173,7 +174,7 @@ public class SlashCommandPromptWidgetTests
     /// in the textbox to the newly highlighted command — so the user can see
     /// exactly what would be inserted before they confirm.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task DownArrow_UpdatesPreviewInTextbox()
     {
         var screen = await DriveAsync(b => b
@@ -195,7 +196,7 @@ public class SlashCommandPromptWidgetTests
     /// remains '/picker' (now showing the first match of the unfiltered
     /// list).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Backspace_ShrinksTypedTextNotPreview()
     {
         var screen = await DriveAsync(b => b
@@ -220,7 +221,7 @@ public class SlashCommandPromptWidgetTests
     /// close the palette and leave the textbox empty — proving that the
     /// preview was a hint, not a commitment.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task BackspaceTwice_ClearsTypedTextAndClosesPalette()
     {
         var screen = await DriveAsync(b => b
@@ -238,7 +239,7 @@ public class SlashCommandPromptWidgetTests
         // Textbox row only contains the prompt chevron — no preview, no typed text.
         var lines = screen.Split('\n');
         var promptRow = lines.First(l => l.Contains(SlashCommandPromptWidget.PromptChevron));
-        Assert.Equal(SlashCommandPromptWidget.PromptChevron.TrimEnd(), promptRow.TrimEnd());
+        Assert.AreEqual(SlashCommandPromptWidget.PromptChevron.TrimEnd(), promptRow.TrimEnd());
     }
 
     /// <summary>
@@ -247,7 +248,7 @@ public class SlashCommandPromptWidgetTests
     /// '/picker'; typing 'x' must take typed text from '/p' → '/px',
     /// which matches nothing → palette closes → textbox shows literal '/px'.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task TypingOntoPreview_AppendsToTypedTextNotPreview()
     {
         var screen = await DriveAsync(b => b
@@ -271,7 +272,7 @@ public class SlashCommandPromptWidgetTests
     /// Hovering the mouse over a palette row updates the highlighted
     /// selection and, by extension, the preview shown in the textbox.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task MouseHoverOnPaletteRow_UpdatesPreviewInTextbox()
     {
         var screen = await DriveAsync(b => b
@@ -297,7 +298,7 @@ public class SlashCommandPromptWidgetTests
     /// Clicking on a palette row CONFIRMS that command — bakes /<name>
     /// (with trailing space) into the typed text — without firing OnSubmit.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task MouseClickOnPaletteRow_ConfirmsCommand()
     {
         var submitted = new List<string>();
@@ -310,7 +311,7 @@ public class SlashCommandPromptWidgetTests
             submitted.Add);
 
         // Did NOT submit (clicking confirms but does not send).
-        Assert.Empty(submitted);
+        Assert.IsEmpty(submitted);
 
         // Confirmed text is in the box and the palette is closed (because
         // the trailing space disqualifies the prefix).
@@ -353,7 +354,7 @@ public class SlashCommandPromptWidgetTests
     /// command (with a trailing space for arguments) into the textbox and
     /// does NOT fire OnSubmit.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task EnterWithVisiblePalette_InsertsSelectedCommand()
     {
         var submitted = new List<string>();
@@ -365,7 +366,7 @@ public class SlashCommandPromptWidgetTests
             .Wait(TimeSpan.FromMilliseconds(250)),
             submitted.Add);
 
-        Assert.Empty(submitted);
+        Assert.IsEmpty(submitted);
         AssertTextboxContains(screen, "/picker");
     }
 
@@ -373,7 +374,7 @@ public class SlashCommandPromptWidgetTests
     /// Tab acts as another accept gesture (parity with Enter while the
     /// palette is visible).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task TabWithVisiblePalette_InsertsSelectedCommand()
     {
         var submitted = new List<string>();
@@ -385,7 +386,7 @@ public class SlashCommandPromptWidgetTests
             .Wait(TimeSpan.FromMilliseconds(250)),
             submitted.Add);
 
-        Assert.Empty(submitted);
+        Assert.IsEmpty(submitted);
         AssertTextboxContains(screen, "/picker");
     }
 
@@ -394,7 +395,7 @@ public class SlashCommandPromptWidgetTests
     /// pressing Enter submits the literal text via OnSubmit rather than
     /// completing anything.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task EnterWithNoMatches_SubmitsTextAsIs()
     {
         var submitted = new List<string>();
@@ -405,14 +406,14 @@ public class SlashCommandPromptWidgetTests
             .Wait(TimeSpan.FromMilliseconds(250)),
             submitted.Add);
 
-        Assert.Single(submitted);
-        Assert.Equal("/zzzz", submitted[0]);
+        Assert.HasCount(1, submitted);
+        Assert.AreEqual("/zzzz", submitted[0]);
     }
 
     /// <summary>
     /// Plain (non-slash) text submits via OnSubmit and clears the textbox.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task EnterWithPlainText_SubmitsAndClears()
     {
         var submitted = new List<string>();
@@ -423,8 +424,8 @@ public class SlashCommandPromptWidgetTests
             .Wait(TimeSpan.FromMilliseconds(250)),
             submitted.Add);
 
-        Assert.Single(submitted);
-        Assert.Equal("hello world", submitted[0]);
+        Assert.HasCount(1, submitted);
+        Assert.AreEqual("hello world", submitted[0]);
         Assert.DoesNotContain("hello world", screen);
     }
 
@@ -432,7 +433,7 @@ public class SlashCommandPromptWidgetTests
     /// Pressing Escape while the palette is visible clears the textbox and
     /// dismisses the palette.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task EscapeWithVisiblePalette_ClearsTextAndDismisses()
     {
         var screen = await DriveAsync(b => b
@@ -451,7 +452,7 @@ public class SlashCommandPromptWidgetTests
     /// the inserted '/cmd ' and submit the full string — which must include
     /// both the command and the typed arguments.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task AcceptThenTypeArgs_SubmitsFullCommand()
     {
         var submitted = new List<string>();
@@ -467,8 +468,8 @@ public class SlashCommandPromptWidgetTests
             .Wait(TimeSpan.FromMilliseconds(250)),
             submitted.Add);
 
-        Assert.Single(submitted);
-        Assert.Equal("/picker now", submitted[0]);
+        Assert.HasCount(1, submitted);
+        Assert.AreEqual("/picker now", submitted[0]);
     }
 
     // ---- Drivers / hosts ----
@@ -533,8 +534,8 @@ public class SlashCommandPromptWidgetTests
         // a command name like "/picker").
         var lines = screen.Split('\n');
         var textboxRow = lines.FirstOrDefault(l => l.Contains(SlashCommandPromptWidget.PromptChevron));
-        Assert.True(textboxRow is not null, $"Could not locate prompt row in screen:\n{screen}");
-        Assert.True(textboxRow!.Contains(expected),
+        Assert.IsTrue(textboxRow is not null, $"Could not locate prompt row in screen:\n{screen}");
+        Assert.IsTrue(textboxRow!.Contains(expected),
             $"Textbox row '{textboxRow.TrimEnd()}' did not contain expected '{expected}'.\n\nScreen:\n{screen}");
     }
 

--- a/tests/Hex1b.Analyzers.Tests/Hex1b.Analyzers.Tests.csproj
+++ b/tests/Hex1b.Analyzers.Tests/Hex1b.Analyzers.Tests.csproj
@@ -1,20 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSTest.Sdk/4.2.3">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>xUnit1031;xUnit1051</NoWarn>
     <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.MSTest" Version="1.1.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
     <!--
       Override stale transitive Workspaces references (the analyzer-testing package depends on
@@ -29,10 +25,6 @@
     <ProjectReference Include="..\..\src\Hex1b.Analyzers\Hex1b.Analyzers.csproj" />
     <!-- Reference Hex1b for symbols (Hex1bWidget, Hex1bNode) used by analyzer test inputs. -->
     <ProjectReference Include="..\..\src\Hex1b\Hex1b.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Xunit" />
   </ItemGroup>
 
 </Project>

--- a/tests/Hex1b.Analyzers.Tests/NodeMustBeClassAnalyzerTests.cs
+++ b/tests/Hex1b.Analyzers.Tests/NodeMustBeClassAnalyzerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.Testing;
 
 namespace Hex1b.Analyzers.Tests;
 
+[TestClass]
 public class NodeMustBeClassAnalyzerTests
 {
     private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
@@ -11,7 +12,7 @@ public class NodeMustBeClassAnalyzerTests
     private static DiagnosticResult Diagnostic()
         => AnalyzerTestHelpers<NodeMustBeClassAnalyzer>.Diagnostic(NodeMustBeClassAnalyzer.Rule);
 
-    [Fact]
+    [TestMethod]
     public async Task ClassNode_NoDiagnostic()
     {
         const string source = """
@@ -25,7 +26,7 @@ public class NodeMustBeClassAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RecordNode_Reports()
     {
         const string source = """
@@ -39,7 +40,7 @@ public class NodeMustBeClassAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("FooNode"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AbstractClassNode_NoDiagnostic()
     {
         const string source = """

--- a/tests/Hex1b.Analyzers.Tests/NodeTypeNameSuffixAnalyzerTests.cs
+++ b/tests/Hex1b.Analyzers.Tests/NodeTypeNameSuffixAnalyzerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.Testing;
 
 namespace Hex1b.Analyzers.Tests;
 
+[TestClass]
 public class NodeTypeNameSuffixAnalyzerTests
 {
     private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
@@ -11,7 +12,7 @@ public class NodeTypeNameSuffixAnalyzerTests
     private static DiagnosticResult Diagnostic()
         => AnalyzerTestHelpers<NodeTypeNameSuffixAnalyzer>.Diagnostic(NodeTypeNameSuffixAnalyzer.Rule);
 
-    [Fact]
+    [TestMethod]
     public async Task NodeSuffix_NoDiagnostic()
     {
         const string source = """
@@ -25,7 +26,7 @@ public class NodeTypeNameSuffixAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MissingSuffix_DirectInheritance_Reports()
     {
         const string source = """
@@ -39,7 +40,7 @@ public class NodeTypeNameSuffixAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("Foo"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NonNodeType_NoDiagnostic()
     {
         const string source = """

--- a/tests/Hex1b.Analyzers.Tests/WidgetBuilderCallbackNameAnalyzerTests.cs
+++ b/tests/Hex1b.Analyzers.Tests/WidgetBuilderCallbackNameAnalyzerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.Testing;
 
 namespace Hex1b.Analyzers.Tests;
 
+[TestClass]
 public class WidgetBuilderCallbackNameAnalyzerTests
 {
     private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
@@ -11,7 +12,7 @@ public class WidgetBuilderCallbackNameAnalyzerTests
     private static DiagnosticResult Diagnostic()
         => AnalyzerTestHelpers<WidgetBuilderCallbackNameAnalyzer>.Diagnostic(WidgetBuilderCallbackNameAnalyzer.Rule);
 
-    [Fact]
+    [TestMethod]
     public async Task SingleBuilder_AlternateName_OnWidgetContextExtension_Reports()
     {
         const string source = """
@@ -36,7 +37,7 @@ public class WidgetBuilderCallbackNameAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("childBuilder", "Foo"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SingleBuilder_NamedBuilder_NoDiagnostic()
     {
         const string source = """
@@ -61,7 +62,7 @@ public class WidgetBuilderCallbackNameAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SingleBuilder_ReturningArray_AlternateName_Reports()
     {
         const string source = """
@@ -86,7 +87,7 @@ public class WidgetBuilderCallbackNameAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("children", "Foo"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SingleBuilder_ReturningIEnumerable_NamedBuilder_NoDiagnostic()
     {
         const string source = """
@@ -112,7 +113,7 @@ public class WidgetBuilderCallbackNameAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SingleBuilder_OnWidgetInstanceExtension_Reports()
     {
         const string source = """
@@ -136,7 +137,7 @@ public class WidgetBuilderCallbackNameAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("backgroundBuilder", "Background"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TwoBuilders_NoDiagnostic_FromThisRule()
     {
         // HEX1B0009 owns the multi-builder shape; HEX1B0008 must stay silent on it.
@@ -163,7 +164,7 @@ public class WidgetBuilderCallbackNameAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NoBuilder_NoDiagnostic()
     {
         const string source = """
@@ -184,7 +185,7 @@ public class WidgetBuilderCallbackNameAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ActionConfigure_NotABuilder_NoDiagnostic()
     {
         // Action<T> configure callbacks aren't widget-builder callbacks; the analyzer must ignore them.
@@ -205,7 +206,7 @@ public class WidgetBuilderCallbackNameAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OnXMethod_HandlerCallback_NoDiagnostic()
     {
         // 'OnFoo' methods are event-handler decorators per the Hex1b convention; their callback
@@ -231,7 +232,7 @@ public class WidgetBuilderCallbackNameAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NonWidgetExtension_NoDiagnostic()
     {
         const string source = """

--- a/tests/Hex1b.Analyzers.Tests/WidgetContextReceiverNameAnalyzerTests.cs
+++ b/tests/Hex1b.Analyzers.Tests/WidgetContextReceiverNameAnalyzerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.Testing;
 
 namespace Hex1b.Analyzers.Tests;
 
+[TestClass]
 public class WidgetContextReceiverNameAnalyzerTests
 {
     private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
@@ -11,7 +12,7 @@ public class WidgetContextReceiverNameAnalyzerTests
     private static DiagnosticResult Diagnostic()
         => AnalyzerTestHelpers<WidgetContextReceiverNameAnalyzer>.Diagnostic(WidgetContextReceiverNameAnalyzer.Rule);
 
-    [Fact]
+    [TestMethod]
     public async Task Receiver_NamedCtx_Reports()
     {
         const string source = """
@@ -32,7 +33,7 @@ public class WidgetContextReceiverNameAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("ctx", "Foo"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Receiver_NamedContext_NoDiagnostic()
     {
         const string source = """
@@ -53,7 +54,7 @@ public class WidgetContextReceiverNameAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Receiver_AlternateName_Reports()
     {
         const string source = """
@@ -74,7 +75,7 @@ public class WidgetContextReceiverNameAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("builder", "Foo"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NonExtensionMethod_NoDiagnostic()
     {
         const string source = """
@@ -95,7 +96,7 @@ public class WidgetContextReceiverNameAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NonWidgetContextReceiver_NoDiagnostic()
     {
         const string source = """
@@ -110,7 +111,7 @@ public class WidgetContextReceiverNameAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WidgetReceiver_NoDiagnostic()
     {
         // Receiver is a widget instance, not WidgetContext<T> — HEX1B0007 territory.

--- a/tests/Hex1b.Analyzers.Tests/WidgetInstanceReceiverNameAnalyzerTests.cs
+++ b/tests/Hex1b.Analyzers.Tests/WidgetInstanceReceiverNameAnalyzerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.Testing;
 
 namespace Hex1b.Analyzers.Tests;
 
+[TestClass]
 public class WidgetInstanceReceiverNameAnalyzerTests
 {
     private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
@@ -11,7 +12,7 @@ public class WidgetInstanceReceiverNameAnalyzerTests
     private static DiagnosticResult Diagnostic()
         => AnalyzerTestHelpers<WidgetInstanceReceiverNameAnalyzer>.Diagnostic(WidgetInstanceReceiverNameAnalyzer.Rule);
 
-    [Fact]
+    [TestMethod]
     public async Task Receiver_RoleNamed_OnConcreteWidget_Reports()
     {
         const string source = """
@@ -30,7 +31,7 @@ public class WidgetInstanceReceiverNameAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("editor", "LanguageServer"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Receiver_NamedWidget_OnConcreteWidget_NoDiagnostic()
     {
         const string source = """
@@ -49,7 +50,7 @@ public class WidgetInstanceReceiverNameAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Receiver_GenericWidgetConstrained_NamedNonWidget_Reports()
     {
         const string source = """
@@ -68,7 +69,7 @@ public class WidgetInstanceReceiverNameAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("w", "InputBindings"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Receiver_GenericWidgetConstrained_NamedWidget_NoDiagnostic()
     {
         const string source = """
@@ -87,7 +88,7 @@ public class WidgetInstanceReceiverNameAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WidgetContextReceiver_NoDiagnostic()
     {
         // WidgetContext<T> is HEX1B0006 territory; this analyzer must stay silent.
@@ -109,7 +110,7 @@ public class WidgetInstanceReceiverNameAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NonWidgetReceiver_NoDiagnostic()
     {
         const string source = """
@@ -124,7 +125,7 @@ public class WidgetInstanceReceiverNameAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NonExtensionMethod_NoDiagnostic()
     {
         const string source = """

--- a/tests/Hex1b.Analyzers.Tests/WidgetMethodWithPrefixAnalyzerTests.cs
+++ b/tests/Hex1b.Analyzers.Tests/WidgetMethodWithPrefixAnalyzerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.Testing;
 
 namespace Hex1b.Analyzers.Tests;
 
+[TestClass]
 public class WidgetMethodWithPrefixAnalyzerTests
 {
     private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
@@ -11,7 +12,7 @@ public class WidgetMethodWithPrefixAnalyzerTests
     private static DiagnosticResult Diagnostic()
         => AnalyzerTestHelpers<WidgetMethodWithPrefixAnalyzer>.Diagnostic(WidgetMethodWithPrefixAnalyzer.Rule);
 
-    [Fact]
+    [TestMethod]
     public async Task ExtensionMethod_WithPrefix_OnConcreteWidget_Reports()
     {
         const string source = """
@@ -30,7 +31,7 @@ public class WidgetMethodWithPrefixAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("WithBar"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ExtensionMethod_NoPrefix_OnConcreteWidget_NoDiagnostic()
     {
         const string source = """
@@ -49,7 +50,7 @@ public class WidgetMethodWithPrefixAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ExtensionMethod_WithPrefix_OnNonWidgetType_NoDiagnostic()
     {
         const string source = """
@@ -64,7 +65,7 @@ public class WidgetMethodWithPrefixAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ExtensionMethod_WithPrefix_OnWidgetContext_NoDiagnostic()
     {
         // WidgetContext<T> is the parent-builder context, not a widget itself; the rule
@@ -86,7 +87,7 @@ public class WidgetMethodWithPrefixAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ExtensionMethod_WithPrefix_GenericConstrainedToWidget_Reports()
     {
         const string source = """
@@ -105,7 +106,7 @@ public class WidgetMethodWithPrefixAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("WithMetric"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ExtensionMethod_WithPrefix_GenericNotConstrainedToWidget_NoDiagnostic()
     {
         const string source = """
@@ -120,7 +121,7 @@ public class WidgetMethodWithPrefixAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task InstanceMethod_WithPrefix_OnWidgetRecord_Reports()
     {
         const string source = """
@@ -137,7 +138,7 @@ public class WidgetMethodWithPrefixAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("WithText"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task InstanceMethod_WithPrefix_OnNonWidgetRecord_NoDiagnostic()
     {
         const string source = """
@@ -152,7 +153,7 @@ public class WidgetMethodWithPrefixAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ExactlyNamedWith_NoDiagnostic()
     {
         // The rule requires "With" + an uppercase letter so that members literally named
@@ -172,7 +173,7 @@ public class WidgetMethodWithPrefixAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task BuilderType_WithPrefix_NoDiagnostic()
     {
         // Builder-style hosts may legitimately use the With* prefix.
@@ -188,7 +189,7 @@ public class WidgetMethodWithPrefixAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PrivateInstanceMethod_WithPrefix_OnWidget_NoDiagnostic()
     {
         // Internal helpers (private/protected) are implementation details and should not
@@ -207,7 +208,7 @@ public class WidgetMethodWithPrefixAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task InstanceMethod_WithPrefix_Internal_Reports()
     {
         const string source = """
@@ -224,7 +225,7 @@ public class WidgetMethodWithPrefixAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("WithFoo"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task InstanceMethod_WithPrefix_Override_NoDiagnostic()
     {
         // The violation belongs on the base declaration; subclasses overriding a With* method
@@ -248,7 +249,7 @@ public class WidgetMethodWithPrefixAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("WithBar"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task InstanceMethod_WithPrefix_ExplicitInterfaceImpl_NoDiagnostic()
     {
         // Explicit interface implementations cannot rename; the violation (if any) belongs on
@@ -272,7 +273,7 @@ public class WidgetMethodWithPrefixAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ExtensionMethod_WithPrefix_NestedGenericConstraintChain_Reports()
     {
         // T : TWidget : Hex1bWidget — analyzer must walk the constraint chain transitively.

--- a/tests/Hex1b.Analyzers.Tests/WidgetMultipleBuilderCallbacksAnalyzerTests.cs
+++ b/tests/Hex1b.Analyzers.Tests/WidgetMultipleBuilderCallbacksAnalyzerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.Testing;
 
 namespace Hex1b.Analyzers.Tests;
 
+[TestClass]
 public class WidgetMultipleBuilderCallbacksAnalyzerTests
 {
     private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
@@ -11,7 +12,7 @@ public class WidgetMultipleBuilderCallbacksAnalyzerTests
     private static DiagnosticResult Diagnostic()
         => AnalyzerTestHelpers<WidgetMultipleBuilderCallbacksAnalyzer>.Diagnostic(WidgetMultipleBuilderCallbacksAnalyzer.Rule);
 
-    [Fact]
+    [TestMethod]
     public async Task TwoBuilders_OnWidgetContextExtension_Reports()
     {
         const string source = """
@@ -37,7 +38,7 @@ public class WidgetMultipleBuilderCallbacksAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("HSplitter", 2));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ThreeBuilders_Reports()
     {
         const string source = """
@@ -67,7 +68,7 @@ public class WidgetMultipleBuilderCallbacksAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("Tri", 3));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SingleBuilder_NoDiagnostic()
     {
         const string source = """
@@ -92,7 +93,7 @@ public class WidgetMultipleBuilderCallbacksAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NoBuilder_NoDiagnostic()
     {
         const string source = """
@@ -113,7 +114,7 @@ public class WidgetMultipleBuilderCallbacksAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SuppressMessage_OnMultiBuilderMethod_NoDiagnostic()
     {
         const string source = """
@@ -141,7 +142,7 @@ public class WidgetMultipleBuilderCallbacksAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TwoBuilders_OnWidgetInstanceExtension_Reports()
     {
         const string source = """
@@ -170,7 +171,7 @@ public class WidgetMultipleBuilderCallbacksAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("HeaderAndFooter", 2));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TwoActionConfigures_NoDiagnostic()
     {
         // Two Action<T> callbacks aren't builder callbacks; rule must stay silent.
@@ -191,7 +192,7 @@ public class WidgetMultipleBuilderCallbacksAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OnXMethod_TwoHandlerCallbacks_NoDiagnostic()
     {
         // 'On*' methods host handler callbacks, not widget-tree builders, so HEX1B0009 must
@@ -216,7 +217,7 @@ public class WidgetMultipleBuilderCallbacksAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NonWidgetExtension_NoDiagnostic()
     {
         const string source = """

--- a/tests/Hex1b.Analyzers.Tests/WidgetMustBeRecordAnalyzerTests.cs
+++ b/tests/Hex1b.Analyzers.Tests/WidgetMustBeRecordAnalyzerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.Testing;
 
 namespace Hex1b.Analyzers.Tests;
 
+[TestClass]
 public class WidgetMustBeRecordAnalyzerTests
 {
     private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
@@ -11,7 +12,7 @@ public class WidgetMustBeRecordAnalyzerTests
     private static DiagnosticResult Diagnostic()
         => AnalyzerTestHelpers<WidgetMustBeRecordAnalyzer>.Diagnostic(WidgetMustBeRecordAnalyzer.Rule);
 
-    [Fact]
+    [TestMethod]
     public async Task RecordWidget_NoDiagnostic()
     {
         const string source = """
@@ -25,7 +26,7 @@ public class WidgetMustBeRecordAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ClassWidget_Reports()
     {
         const string source = """
@@ -39,7 +40,7 @@ public class WidgetMustBeRecordAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("FooWidget"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NonWidgetClass_NoDiagnostic()
     {
         const string source = """
@@ -51,7 +52,7 @@ public class WidgetMustBeRecordAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AbstractRecordWidget_NoDiagnostic()
     {
         const string source = """

--- a/tests/Hex1b.Analyzers.Tests/WidgetOverridesBuildAndReconcileAnalyzerTests.cs
+++ b/tests/Hex1b.Analyzers.Tests/WidgetOverridesBuildAndReconcileAnalyzerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.Testing;
 
 namespace Hex1b.Analyzers.Tests;
 
+[TestClass]
 public class WidgetOverridesBuildAndReconcileAnalyzerTests
 {
     private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
@@ -11,7 +12,7 @@ public class WidgetOverridesBuildAndReconcileAnalyzerTests
     private static DiagnosticResult Diagnostic()
         => AnalyzerTestHelpers<WidgetOverridesBuildAndReconcileAnalyzer>.Diagnostic(WidgetOverridesBuildAndReconcileAnalyzer.Rule);
 
-    [Fact]
+    [TestMethod]
     public async Task NoOverrides_NoDiagnostic()
     {
         const string source = """
@@ -25,7 +26,7 @@ public class WidgetOverridesBuildAndReconcileAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OverridesBuildOnly_NoDiagnostic()
     {
         const string source = """
@@ -43,7 +44,7 @@ public class WidgetOverridesBuildAndReconcileAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OverridesReconcileOnly_NoDiagnostic()
     {
         // Note: ReconcileAsync is internal, so this scenario is only realistic for code
@@ -69,7 +70,7 @@ public class WidgetOverridesBuildAndReconcileAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OverridesBoth_Reports()
     {
         const string source = """
@@ -95,7 +96,7 @@ public class WidgetOverridesBuildAndReconcileAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("FooWidget"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NonWidgetClass_NoDiagnostic()
     {
         const string source = """

--- a/tests/Hex1b.Analyzers.Tests/WidgetTypeNameSuffixAnalyzerTests.cs
+++ b/tests/Hex1b.Analyzers.Tests/WidgetTypeNameSuffixAnalyzerTests.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.Testing;
 
 namespace Hex1b.Analyzers.Tests;
 
+[TestClass]
 public class WidgetTypeNameSuffixAnalyzerTests
 {
     private static Task VerifyAsync(string source, params DiagnosticResult[] expected)
@@ -11,7 +12,7 @@ public class WidgetTypeNameSuffixAnalyzerTests
     private static DiagnosticResult Diagnostic()
         => AnalyzerTestHelpers<WidgetTypeNameSuffixAnalyzer>.Diagnostic(WidgetTypeNameSuffixAnalyzer.Rule);
 
-    [Fact]
+    [TestMethod]
     public async Task WidgetSuffix_NoDiagnostic()
     {
         const string source = """
@@ -25,7 +26,7 @@ public class WidgetTypeNameSuffixAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MissingSuffix_DirectInheritance_Reports()
     {
         const string source = """
@@ -39,7 +40,7 @@ public class WidgetTypeNameSuffixAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("Foo"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MissingSuffix_TransitiveInheritance_Reports()
     {
         const string source = """
@@ -54,7 +55,7 @@ public class WidgetTypeNameSuffixAnalyzerTests
         await VerifyAsync(source, Diagnostic().WithLocation(0).WithArguments("CustomThing"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NonWidgetType_NoDiagnostic()
     {
         const string source = """
@@ -66,7 +67,7 @@ public class WidgetTypeNameSuffixAnalyzerTests
         await VerifyAsync(source);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GenericWidgetSuffix_NoDiagnostic()
     {
         const string source = """

--- a/tests/Hex1b.McpServer.Tests/Hex1b.McpServer.Tests.csproj
+++ b/tests/Hex1b.McpServer.Tests/Hex1b.McpServer.Tests.csproj
@@ -1,23 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSTest.Sdk/4.2.3">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <!-- Suppress xUnit analyzer recommendations (not bugs):
-         xUnit1031: blocking task operations
-         xUnit1051: CancellationToken usage -->
-    <NoWarn>xUnit1031;xUnit1051</NoWarn>
     <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <!-- For in-memory MCP server testing -->
     <PackageReference Include="ModelContextProtocol" Version="0.5.0-preview.1" />
   </ItemGroup>
@@ -25,10 +17,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Hex1b.McpServer\Hex1b.McpServer.csproj" />
     <ProjectReference Include="..\..\src\Hex1b\Hex1b.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Xunit" />
   </ItemGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsOSPlatform('Windows'))">

--- a/tests/Hex1b.McpServer.Tests/RecordingToolsTests.cs
+++ b/tests/Hex1b.McpServer.Tests/RecordingToolsTests.cs
@@ -7,6 +7,7 @@ namespace Hex1b.McpServer.Tests;
 /// <summary>
 /// Integration tests for the asciinema recording MCP tools.
 /// </summary>
+[TestClass]
 public class RecordingToolsTests : McpServerTestBase
 {
     private readonly List<string> _tempFiles = new();
@@ -53,7 +54,7 @@ public class RecordingToolsTests : McpServerTestBase
             cancellationToken: TestCancellationToken);
 
         var createText = GetTextContent(createResult);
-        Assert.NotNull(createText);
+        Assert.IsNotNull(createText);
 
         var createResponse = JsonSerializer.Deserialize<JsonElement>(createText);
         var success = createResponse.TryGetProperty("success", out var successValue) && successValue.GetBoolean();
@@ -61,8 +62,8 @@ public class RecordingToolsTests : McpServerTestBase
             ? messageValue.GetString()
             : null;
 
-        Assert.True(success, message ?? $"Expected {StartTerminalToolName} to succeed.");
-        Assert.True(
+        Assert.IsTrue(success, message ?? $"Expected {StartTerminalToolName} to succeed.");
+        Assert.IsTrue(
             createResponse.TryGetProperty("sessionId", out var sessionIdValue)
             && !string.IsNullOrWhiteSpace(sessionIdValue.GetString()),
             $"Expected terminal start response to include a sessionId. Response: {createText}");
@@ -70,7 +71,7 @@ public class RecordingToolsTests : McpServerTestBase
         return sessionIdValue.GetString()!;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task StartAsciinemaRecording_ValidSession_StartsRecording()
     {
         // Arrange
@@ -91,17 +92,17 @@ public class RecordingToolsTests : McpServerTestBase
             cancellationToken: TestCancellationToken);
 
         // Assert
-        Assert.NotNull(startResult);
+        Assert.IsNotNull(startResult);
         var startText = GetTextContent(startResult);
-        Assert.NotNull(startText);
+        Assert.IsNotNull(startText);
         var startResponse = JsonSerializer.Deserialize<JsonElement>(startText);
-        Assert.True(startResponse.GetProperty("success").GetBoolean());
+        Assert.IsTrue(startResponse.GetProperty("success").GetBoolean());
         // File path includes .cast extension enforcement
         Assert.Contains(".cast", startResponse.GetProperty("filePath").GetString());
         
         // Verify file was created
         var actualPath = startResponse.GetProperty("filePath").GetString()!;
-        Assert.True(File.Exists(actualPath), "Recording file should exist");
+        Assert.IsTrue(File.Exists(actualPath), "Recording file should exist");
 
         // Cleanup - remove the session
         await client.CallToolAsync(
@@ -110,7 +111,7 @@ public class RecordingToolsTests : McpServerTestBase
             cancellationToken: TestCancellationToken);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task StopAsciinemaRecording_ActiveRecording_StopsAndFinalizesFile()
     {
         // Arrange
@@ -131,7 +132,7 @@ public class RecordingToolsTests : McpServerTestBase
             cancellationToken: TestCancellationToken);
         
         var startText = GetTextContent(startResult);
-        Assert.NotNull(startText);
+        Assert.IsNotNull(startText);
         var startResp = JsonSerializer.Deserialize<JsonElement>(startText);
         var recordingPath = startResp.GetProperty("filePath").GetString()!;
 
@@ -145,23 +146,23 @@ public class RecordingToolsTests : McpServerTestBase
             cancellationToken: TestCancellationToken);
 
         // Assert
-        Assert.NotNull(stopResult);
+        Assert.IsNotNull(stopResult);
         var stopText = GetTextContent(stopResult);
-        Assert.NotNull(stopText);
+        Assert.IsNotNull(stopText);
         var stopResponse = JsonSerializer.Deserialize<JsonElement>(stopText);
-        Assert.True(stopResponse.GetProperty("success").GetBoolean());
-        Assert.True(stopResponse.GetProperty("wasRecording").GetBoolean());
+        Assert.IsTrue(stopResponse.GetProperty("success").GetBoolean());
+        Assert.IsTrue(stopResponse.GetProperty("wasRecording").GetBoolean());
 
         // Verify file contains valid asciinema content
         var content = await File.ReadAllTextAsync(recordingPath);
         var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-        Assert.True(lines.Length >= 1, "Should have at least a header");
+        Assert.IsTrue(lines.Length >= 1, "Should have at least a header");
         
         // Verify header is valid JSON with asciinema format
         var header = JsonSerializer.Deserialize<JsonElement>(lines[0]);
-        Assert.Equal(2, header.GetProperty("version").GetInt32());
-        Assert.Equal(80, header.GetProperty("width").GetInt32());
-        Assert.Equal(24, header.GetProperty("height").GetInt32());
+        Assert.AreEqual(2, header.GetProperty("version").GetInt32());
+        Assert.AreEqual(80, header.GetProperty("width").GetInt32());
+        Assert.AreEqual(24, header.GetProperty("height").GetInt32());
 
         // Cleanup
         await client.CallToolAsync(
@@ -170,7 +171,7 @@ public class RecordingToolsTests : McpServerTestBase
             cancellationToken: TestCancellationToken);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ListTerminals_WithRecording_ShowsRecordingStatus()
     {
         // Arrange
@@ -198,14 +199,14 @@ public class RecordingToolsTests : McpServerTestBase
 
         // Assert
         var listText = GetTextContent(listResult);
-        Assert.NotNull(listText);
+        Assert.IsNotNull(listText);
         var listResponse = JsonSerializer.Deserialize<JsonElement>(listText);
         var sessions = listResponse.GetProperty("sessions");
-        Assert.Equal(1, sessions.GetArrayLength());
+        Assert.AreEqual(1, sessions.GetArrayLength());
         
         var session = sessions[0];
-        Assert.True(session.GetProperty("isRecording").GetBoolean());
-        Assert.NotNull(session.GetProperty("activeRecordingPath").GetString());
+        Assert.IsTrue(session.GetProperty("isRecording").GetBoolean());
+        Assert.IsNotNull(session.GetProperty("activeRecordingPath").GetString());
 
         // Cleanup
         await client.CallToolAsync(
@@ -214,7 +215,7 @@ public class RecordingToolsTests : McpServerTestBase
             cancellationToken: TestCancellationToken);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task StartAsciinemaRecording_InvalidSessionId_ReturnsError()
     {
         // Arrange
@@ -234,13 +235,13 @@ public class RecordingToolsTests : McpServerTestBase
 
         // Assert
         var text = GetTextContent(result);
-        Assert.NotNull(text);
+        Assert.IsNotNull(text);
         var response = JsonSerializer.Deserialize<JsonElement>(text);
-        Assert.False(response.GetProperty("success").GetBoolean());
+        Assert.IsFalse(response.GetProperty("success").GetBoolean());
         Assert.Contains("not found", response.GetProperty("message").GetString(), StringComparison.OrdinalIgnoreCase);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task StartAsciinemaRecording_AlreadyRecording_ReturnsError()
     {
         // Arrange
@@ -273,9 +274,9 @@ public class RecordingToolsTests : McpServerTestBase
 
         // Assert
         var text = GetTextContent(result);
-        Assert.NotNull(text);
+        Assert.IsNotNull(text);
         var response = JsonSerializer.Deserialize<JsonElement>(text);
-        Assert.False(response.GetProperty("success").GetBoolean());
+        Assert.IsFalse(response.GetProperty("success").GetBoolean());
         Assert.Contains("already recording", response.GetProperty("message").GetString(), StringComparison.OrdinalIgnoreCase);
 
         // Cleanup
@@ -285,7 +286,7 @@ public class RecordingToolsTests : McpServerTestBase
             cancellationToken: TestCancellationToken);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task StopAsciinemaRecording_NotRecording_ReturnsGracefully()
     {
         // Arrange
@@ -302,10 +303,10 @@ public class RecordingToolsTests : McpServerTestBase
 
         // Assert - this is considered success, just wasRecording is false
         var text = GetTextContent(result);
-        Assert.NotNull(text);
+        Assert.IsNotNull(text);
         var response = JsonSerializer.Deserialize<JsonElement>(text);
-        Assert.True(response.GetProperty("success").GetBoolean());
-        Assert.False(response.GetProperty("wasRecording").GetBoolean());
+        Assert.IsTrue(response.GetProperty("success").GetBoolean());
+        Assert.IsFalse(response.GetProperty("wasRecording").GetBoolean());
         Assert.Contains("not recording", response.GetProperty("message").GetString(), StringComparison.OrdinalIgnoreCase);
 
         // Cleanup

--- a/tests/Hex1b.Tests/AccordionNodeTests.cs
+++ b/tests/Hex1b.Tests/AccordionNodeTests.cs
@@ -5,6 +5,7 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class AccordionNodeTests
 {
     private static AccordionNode CreateNode(int sectionCount, bool[] expanded)
@@ -26,7 +27,7 @@ public class AccordionNodeTests
         return node;
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_AllCollapsed_ReturnsHeaderHeightOnly()
     {
         var node = CreateNode(3, [false, false, false]);
@@ -34,11 +35,11 @@ public class AccordionNodeTests
 
         var size = node.Measure(constraints);
 
-        Assert.Equal(40, size.Width);
-        Assert.Equal(3, size.Height); // 3 headers, 1 row each
+        Assert.AreEqual(40, size.Width);
+        Assert.AreEqual(3, size.Height); // 3 headers, 1 row each
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_FillsAvailableHeight()
     {
         var node = CreateNode(3, [true, false, false]);
@@ -46,41 +47,41 @@ public class AccordionNodeTests
 
         var size = node.Measure(constraints);
 
-        Assert.Equal(40, size.Width);
-        Assert.Equal(20, size.Height); // fills available
+        Assert.AreEqual(40, size.Width);
+        Assert.AreEqual(20, size.Height); // fills available
     }
 
-    [Fact]
+    [TestMethod]
     public void SectionCount_ReturnsCorrectCount()
     {
         var node = CreateNode(3, [true, false, true]);
 
-        Assert.Equal(3, node.SectionCount);
+        Assert.AreEqual(3, node.SectionCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsSectionExpanded_ReturnsCorrectState()
     {
         var node = CreateNode(3, [true, false, true]);
 
-        Assert.True(node.IsSectionExpanded(0));
-        Assert.False(node.IsSectionExpanded(1));
-        Assert.True(node.IsSectionExpanded(2));
+        Assert.IsTrue(node.IsSectionExpanded(0));
+        Assert.IsFalse(node.IsSectionExpanded(1));
+        Assert.IsTrue(node.IsSectionExpanded(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void ToggleSection_ChangesExpandedState()
     {
         var node = CreateNode(3, [true, false, false]);
 
         node.ToggleSection(0);
-        Assert.False(node.IsSectionExpanded(0));
+        Assert.IsFalse(node.IsSectionExpanded(0));
 
         node.ToggleSection(1);
-        Assert.True(node.IsSectionExpanded(1));
+        Assert.IsTrue(node.IsSectionExpanded(1));
     }
 
-    [Fact]
+    [TestMethod]
     public void SetSectionExpanded_CollapseOthers_WhenMultipleNotAllowed()
     {
         var node = CreateNode(3, [true, false, false]);
@@ -88,12 +89,12 @@ public class AccordionNodeTests
 
         node.SetSectionExpanded(2, true);
 
-        Assert.False(node.IsSectionExpanded(0)); // collapsed
-        Assert.False(node.IsSectionExpanded(1));
-        Assert.True(node.IsSectionExpanded(2));
+        Assert.IsFalse(node.IsSectionExpanded(0)); // collapsed
+        Assert.IsFalse(node.IsSectionExpanded(1));
+        Assert.IsTrue(node.IsSectionExpanded(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void SetSectionExpanded_KeepsOthers_WhenMultipleAllowed()
     {
         var node = CreateNode(3, [true, false, false]);
@@ -101,12 +102,12 @@ public class AccordionNodeTests
 
         node.SetSectionExpanded(2, true);
 
-        Assert.True(node.IsSectionExpanded(0));
-        Assert.False(node.IsSectionExpanded(1));
-        Assert.True(node.IsSectionExpanded(2));
+        Assert.IsTrue(node.IsSectionExpanded(0));
+        Assert.IsFalse(node.IsSectionExpanded(1));
+        Assert.IsTrue(node.IsSectionExpanded(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsFocused_WhenSet_MarksDirty()
     {
         var node = CreateNode(1, [true]);
@@ -114,45 +115,45 @@ public class AccordionNodeTests
 
         node.IsFocused = true;
 
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsFocusable_ReturnsTrue()
     {
         var node = CreateNode(1, [true]);
 
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public void ManagesChildFocus_ReturnsTrue()
     {
         var node = CreateNode(1, [true]);
 
-        Assert.True(node.ManagesChildFocus);
+        Assert.IsTrue(node.ManagesChildFocus);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_ReturnsOnlyContentNodes()
     {
         var node = CreateNode(3, [true, false, true]);
 
         // No content nodes set, so no children
         var children = node.GetChildren().ToList();
-        Assert.Empty(children);
+        Assert.IsEmpty(children);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsSectionExpanded_OutOfRange_ReturnsFalse()
     {
         var node = CreateNode(2, [true, false]);
 
-        Assert.False(node.IsSectionExpanded(-1));
-        Assert.False(node.IsSectionExpanded(5));
+        Assert.IsFalse(node.IsSectionExpanded(-1));
+        Assert.IsFalse(node.IsSectionExpanded(5));
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_DistributesContentHeightEqually()
     {
         var node = CreateNode(2, [true, true]);
@@ -162,141 +163,142 @@ public class AccordionNodeTests
 
         // 2 headers (2 rows) + 10 remaining / 2 expanded = 5 each
         // Verify via GetChildren - content nodes would have bounds if set
-        Assert.Equal(2, node.SectionCount);
+        Assert.AreEqual(2, node.SectionCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void AccordionSectionWidget_Title_SetsTitle()
     {
         var section = new AccordionSectionWidget(s => []).Title("Test Title");
 
-        Assert.Equal("Test Title", section.SectionTitle);
+        Assert.AreEqual("Test Title", section.SectionTitle);
     }
 
-    [Fact]
+    [TestMethod]
     public void AccordionSectionWidget_Expanded_SetsFlag()
     {
         var section = new AccordionSectionWidget(s => []).Expanded();
 
-        Assert.True(section.IsExpanded);
+        Assert.IsTrue(section.IsExpanded);
     }
 
-    [Fact]
+    [TestMethod]
     public void AccordionSectionWidget_ExpandedFalse_SetsFlag()
     {
         var section = new AccordionSectionWidget(s => []).Expanded(false);
 
-        Assert.False(section.IsExpanded);
+        Assert.IsFalse(section.IsExpanded);
     }
 
-    [Fact]
+    [TestMethod]
     public void AccordionSectionWidget_DirectReconcile_Throws()
     {
         var section = new AccordionSectionWidget(s => []);
 
-        Assert.Throws<InvalidOperationException>(() =>
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
             section.ReconcileAsync(null, null!).GetAwaiter().GetResult());
     }
 
-    [Fact]
+    [TestMethod]
     public void AccordionSectionWidget_LeftActions_SetsActions()
     {
         var section = new AccordionSectionWidget(s => [])
             .LeftActions(a => [a.Icon("+")]);
 
-        Assert.Single(section.LeftSectionActions);
-        Assert.Equal("+", section.LeftSectionActions[0].Icon);
+        TestSeq.Single(section.LeftSectionActions);
+        Assert.AreEqual("+", section.LeftSectionActions[0].Icon);
     }
 
-    [Fact]
+    [TestMethod]
     public void AccordionSectionWidget_RightActions_SetsActions()
     {
         var section = new AccordionSectionWidget(s => [])
             .RightActions(a => [a.Icon("×"), a.Icon("⟳")]);
 
-        Assert.Equal(2, section.RightSectionActions.Count);
+        Assert.AreEqual(2, section.RightSectionActions.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void AccordionSectionWidget_LeftActions_Toggle_SetsIsToggle()
     {
         var section = new AccordionSectionWidget(s => [])
             .LeftActions(a => [a.Toggle("▶", "▼")]);
 
-        Assert.Single(section.LeftSectionActions);
-        Assert.True(section.LeftSectionActions[0].IsToggle);
+        TestSeq.Single(section.LeftSectionActions);
+        Assert.IsTrue(section.LeftSectionActions[0].IsToggle);
     }
 
-    [Fact]
+    [TestMethod]
     public void AccordionWidget_MultipleExpanded_DefaultsToFalse()
     {
         var widget = new AccordionWidget([]);
 
-        Assert.False(widget.AllowMultipleExpanded);
+        Assert.IsFalse(widget.AllowMultipleExpanded);
     }
 
-    [Fact]
+    [TestMethod]
     public void AccordionWidget_MultipleExpanded_CanBeEnabled()
     {
         var widget = new AccordionWidget([]).MultipleExpanded(true);
 
-        Assert.True(widget.AllowMultipleExpanded);
+        Assert.IsTrue(widget.AllowMultipleExpanded);
     }
 
-    [Fact]
+    [TestMethod]
     public void AccordionContext_Section_CreatesWidget()
     {
         var ctx = new AccordionContext();
         var section = ctx.Section(s => []);
 
-        Assert.NotNull(section);
-        Assert.Equal("", section.SectionTitle);
+        Assert.IsNotNull(section);
+        Assert.AreEqual("", section.SectionTitle);
     }
 
-    [Fact]
+    [TestMethod]
     public void AccordionContext_SectionWithTitle_CreatesWidget()
     {
         var ctx = new AccordionContext();
         var section = ctx.Section("My Title", s => []);
 
-        Assert.Equal("My Title", section.SectionTitle);
+        Assert.AreEqual("My Title", section.SectionTitle);
     }
 
-    [Fact]
+    [TestMethod]
     public void AccordionSectionActionContext_Toggle_ChangesState()
     {
         var node = CreateNode(2, [true, false]);
         var actionCtx = new AccordionSectionActionContext(node, 0);
 
-        Assert.True(actionCtx.IsExpanded);
+        Assert.IsTrue(actionCtx.IsExpanded);
         actionCtx.Toggle();
-        Assert.False(actionCtx.IsExpanded);
+        Assert.IsFalse(actionCtx.IsExpanded);
     }
 
-    [Fact]
+    [TestMethod]
     public void AccordionSectionActionContext_Collapse_CollapsesSection()
     {
         var node = CreateNode(2, [true, false]);
         var actionCtx = new AccordionSectionActionContext(node, 0);
 
         actionCtx.Collapse();
-        Assert.False(actionCtx.IsExpanded);
+        Assert.IsFalse(actionCtx.IsExpanded);
     }
 
-    [Fact]
+    [TestMethod]
     public void AccordionSectionActionContext_Expand_ExpandsSection()
     {
         var node = CreateNode(2, [false, false]);
         var actionCtx = new AccordionSectionActionContext(node, 1);
 
         actionCtx.Expand();
-        Assert.True(actionCtx.IsExpanded);
+        Assert.IsTrue(actionCtx.IsExpanded);
     }
 }
 
+[TestClass]
 public class AccordionIntegrationTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Accordion_BasicRender_ShowsSectionTitles()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -319,14 +321,15 @@ public class AccordionIntegrationTests
 
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Section A"));
-        Assert.True(snapshot.ContainsText("Section B"));
+        Assert.IsTrue(snapshot.ContainsText("Section A"));
+        Assert.IsTrue(snapshot.ContainsText("Section B"));
     }
 }
 
+[TestClass]
 public class AccordionKeyboardTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Accordion_EnterKey_TogglesSections()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -358,13 +361,14 @@ public class AccordionKeyboardTests
         await runTask;
 
         // After expanding second, "Content B" should be visible
-        Assert.True(snapshot.ContainsText("Content B"));
+        Assert.IsTrue(snapshot.ContainsText("Content B"));
     }
 }
 
+[TestClass]
 public class AccordionLayoutTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Accordion_InVStackWithBorder_Renders()
     {
         // Regression: VStack measures children with maxHeight=int.MaxValue,
@@ -410,7 +414,7 @@ public class AccordionLayoutTests
         var screenDump = string.Join("\n", lines);
         if (!snapshot.ContainsText("EXPLORER"))
             Assert.Fail($"Missing EXPLORER.\nScreen:\n{screenDump}");
-        Assert.True(snapshot.ContainsText("OUTLINE"));
-        Assert.True(snapshot.ContainsText("SOURCE CONTROL"));
+        Assert.IsTrue(snapshot.ContainsText("OUTLINE"));
+        Assert.IsTrue(snapshot.ContainsText("SOURCE CONTROL"));
     }
 }

--- a/tests/Hex1b.Tests/ActionMenuTests.cs
+++ b/tests/Hex1b.Tests/ActionMenuTests.cs
@@ -8,6 +8,7 @@ namespace Hex1b.Tests;
 /// Tests for <see cref="ActionMenu"/>, <see cref="ActionMenuItem"/>,
 /// and their integration with <see cref="IEditorSession"/> on <see cref="EditorNode"/>.
 /// </summary>
+[TestClass]
 public class ActionMenuTests
 {
     private static IEditorSession CreateSession(string text = "test")
@@ -20,7 +21,7 @@ public class ActionMenuTests
 
     // ── ActionMenu construction ──────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void ActionMenu_WithItems_StoresAnchorAndItems()
     {
         var anchor = new DocumentPosition(5, 10);
@@ -29,45 +30,45 @@ public class ActionMenuTests
             new ActionMenuItem("Inline Variable", "inline-var")
         ]);
 
-        Assert.Equal(anchor, menu.Anchor);
-        Assert.Equal(2, menu.Items.Count);
-        Assert.Equal("Extract Method", menu.Items[0].Label);
-        Assert.Equal("extract-method", menu.Items[0].Id);
-        Assert.Equal("Inline Variable", menu.Items[1].Label);
-        Assert.Equal("inline-var", menu.Items[1].Id);
+        Assert.AreEqual(anchor, menu.Anchor);
+        Assert.AreEqual(2, menu.Items.Count);
+        Assert.AreEqual("Extract Method", menu.Items[0].Label);
+        Assert.AreEqual("extract-method", menu.Items[0].Id);
+        Assert.AreEqual("Inline Variable", menu.Items[1].Label);
+        Assert.AreEqual("inline-var", menu.Items[1].Id);
     }
 
-    [Fact]
+    [TestMethod]
     public void ActionMenu_WithTitle_StoresTitle()
     {
         var menu = new ActionMenu(new DocumentPosition(1, 1), [
             new ActionMenuItem("Fix", "fix-1")
         ]) { Title = "Quick Fixes" };
 
-        Assert.Equal("Quick Fixes", menu.Title);
+        Assert.AreEqual("Quick Fixes", menu.Title);
     }
 
-    [Fact]
+    [TestMethod]
     public void ActionMenu_WithoutTitle_IsNull()
     {
         var menu = new ActionMenu(new DocumentPosition(1, 1), [
             new ActionMenuItem("Fix", "fix-1")
         ]);
 
-        Assert.Null(menu.Title);
+        Assert.IsNull(menu.Title);
     }
 
-    [Fact]
+    [TestMethod]
     public void ActionMenu_EmptyItems_IsValid()
     {
         var menu = new ActionMenu(new DocumentPosition(1, 1), []);
 
-        Assert.Empty(menu.Items);
+        Assert.IsEmpty(menu.Items);
     }
 
     // ── ActionMenuItem construction ──────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void ActionMenuItem_WithDetail_StoresValue()
     {
         var item = new ActionMenuItem("Extract Method", "extract-method")
@@ -75,34 +76,34 @@ public class ActionMenuTests
             Detail = "Extract selected code into a new method"
         };
 
-        Assert.Equal("Extract selected code into a new method", item.Detail);
+        Assert.AreEqual("Extract selected code into a new method", item.Detail);
     }
 
-    [Fact]
+    [TestMethod]
     public void ActionMenuItem_WithoutDetail_IsNull()
     {
         var item = new ActionMenuItem("Rename", "rename");
 
-        Assert.Null(item.Detail);
+        Assert.IsNull(item.Detail);
     }
 
-    [Fact]
+    [TestMethod]
     public void ActionMenuItem_WithIsPreferred_StoresTrue()
     {
         var item = new ActionMenuItem("Fix All", "fix-all") { IsPreferred = true };
 
-        Assert.True(item.IsPreferred);
+        Assert.IsTrue(item.IsPreferred);
     }
 
-    [Fact]
+    [TestMethod]
     public void ActionMenuItem_DefaultIsPreferred_IsFalse()
     {
         var item = new ActionMenuItem("Fix All", "fix-all");
 
-        Assert.False(item.IsPreferred);
+        Assert.IsFalse(item.IsPreferred);
     }
 
-    [Fact]
+    [TestMethod]
     public void ActionMenuItem_FullyPopulated_PreservesAllProperties()
     {
         var item = new ActionMenuItem("Add Import", "add-import")
@@ -111,15 +112,15 @@ public class ActionMenuTests
             IsPreferred = true
         };
 
-        Assert.Equal("Add Import", item.Label);
-        Assert.Equal("add-import", item.Id);
-        Assert.Equal("using System.Linq;", item.Detail);
-        Assert.True(item.IsPreferred);
+        Assert.AreEqual("Add Import", item.Label);
+        Assert.AreEqual("add-import", item.Id);
+        Assert.AreEqual("using System.Linq;", item.Detail);
+        Assert.IsTrue(item.IsPreferred);
     }
 
     // ── IEditorSession integration ───────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task ShowActionMenuAsync_ReturnsNull_CurrentStubBehavior()
     {
         var session = CreateSession();
@@ -130,10 +131,10 @@ public class ActionMenuTests
 
         var result = await session.ShowActionMenuAsync(menu);
 
-        Assert.Null(result);
+        Assert.IsNull(result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ShowActionMenuAsync_WithTitle_ReturnsNull()
     {
         var session = CreateSession();
@@ -143,12 +144,12 @@ public class ActionMenuTests
 
         var result = await session.ShowActionMenuAsync(menu);
 
-        Assert.Null(result);
+        Assert.IsNull(result);
     }
 
     // ── Record equality ──────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void ActionMenu_RecordEquality_EqualWhenSameListReference()
     {
         var items = new List<ActionMenuItem> { new("Fix", "fix-1") };
@@ -156,10 +157,10 @@ public class ActionMenuTests
         var a = new ActionMenu(new DocumentPosition(1, 1), items) { Title = "Actions" };
         var b = new ActionMenu(new DocumentPosition(1, 1), items) { Title = "Actions" };
 
-        Assert.Equal(a, b);
+        Assert.AreEqual(a, b);
     }
 
-    [Fact]
+    [TestMethod]
     public void ActionMenu_RecordEquality_NotEqualWhenDifferentAnchor()
     {
         var items = new List<ActionMenuItem> { new("Fix", "fix-1") };
@@ -167,24 +168,24 @@ public class ActionMenuTests
         var a = new ActionMenu(new DocumentPosition(1, 1), items);
         var b = new ActionMenu(new DocumentPosition(2, 3), items);
 
-        Assert.NotEqual(a, b);
+        Assert.AreNotEqual(a, b);
     }
 
-    [Fact]
+    [TestMethod]
     public void ActionMenuItem_RecordEquality_EqualWhenSameValues()
     {
         var a = new ActionMenuItem("Rename", "rename") { Detail = "Rename symbol", IsPreferred = true };
         var b = new ActionMenuItem("Rename", "rename") { Detail = "Rename symbol", IsPreferred = true };
 
-        Assert.Equal(a, b);
+        Assert.AreEqual(a, b);
     }
 
-    [Fact]
+    [TestMethod]
     public void ActionMenuItem_RecordEquality_NotEqualWhenDifferentId()
     {
         var a = new ActionMenuItem("Fix", "fix-1");
         var b = new ActionMenuItem("Fix", "fix-2");
 
-        Assert.NotEqual(a, b);
+        Assert.AreNotEqual(a, b);
     }
 }

--- a/tests/Hex1b.Tests/AlignNodeTests.cs
+++ b/tests/Hex1b.Tests/AlignNodeTests.cs
@@ -4,9 +4,10 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class AlignNodeTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Measure_ReturnsChildSize()
     {
         // Arrange
@@ -18,11 +19,11 @@ public class AlignNodeTests
         var size = node.Measure(constraints);
 
         // Assert - returns child's natural size, not full available space
-        Assert.Equal(5, size.Width);  // "Hello".Length
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(5, size.Width);  // "Hello".Length
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_WithFillHint_StillReturnsChildSize_ParentHandlesExpansion()
     {
         // Arrange
@@ -35,11 +36,11 @@ public class AlignNodeTests
         var size = node.Measure(constraints);
 
         // Assert - Measure still returns child size; Fill is applied by parent during Arrange
-        Assert.Equal(5, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(5, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_Center_PositionsChildInCenter()
     {
         // Arrange
@@ -52,13 +53,13 @@ public class AlignNodeTests
 
         // Assert - child should be centered
         // (80 - 2) / 2 = 39 for x, (24 - 1) / 2 = 11 for y
-        Assert.Equal(39, child.Bounds.X);
-        Assert.Equal(11, child.Bounds.Y);
-        Assert.Equal(2, child.Bounds.Width);
-        Assert.Equal(1, child.Bounds.Height);
+        Assert.AreEqual(39, child.Bounds.X);
+        Assert.AreEqual(11, child.Bounds.Y);
+        Assert.AreEqual(2, child.Bounds.Width);
+        Assert.AreEqual(1, child.Bounds.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_TopLeft_PositionsChildAtTopLeft()
     {
         // Arrange
@@ -70,11 +71,11 @@ public class AlignNodeTests
         node.Arrange(new Rect(0, 0, 80, 24));
 
         // Assert
-        Assert.Equal(0, child.Bounds.X);
-        Assert.Equal(0, child.Bounds.Y);
+        Assert.AreEqual(0, child.Bounds.X);
+        Assert.AreEqual(0, child.Bounds.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_TopRight_PositionsChildAtTopRight()
     {
         // Arrange
@@ -86,11 +87,11 @@ public class AlignNodeTests
         node.Arrange(new Rect(0, 0, 80, 24));
 
         // Assert
-        Assert.Equal(78, child.Bounds.X); // 80 - 2
-        Assert.Equal(0, child.Bounds.Y);
+        Assert.AreEqual(78, child.Bounds.X); // 80 - 2
+        Assert.AreEqual(0, child.Bounds.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_BottomLeft_PositionsChildAtBottomLeft()
     {
         // Arrange
@@ -102,11 +103,11 @@ public class AlignNodeTests
         node.Arrange(new Rect(0, 0, 80, 24));
 
         // Assert
-        Assert.Equal(0, child.Bounds.X);
-        Assert.Equal(23, child.Bounds.Y); // 24 - 1
+        Assert.AreEqual(0, child.Bounds.X);
+        Assert.AreEqual(23, child.Bounds.Y); // 24 - 1
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_BottomRight_PositionsChildAtBottomRight()
     {
         // Arrange
@@ -118,11 +119,11 @@ public class AlignNodeTests
         node.Arrange(new Rect(0, 0, 80, 24));
 
         // Assert
-        Assert.Equal(78, child.Bounds.X); // 80 - 2
-        Assert.Equal(23, child.Bounds.Y); // 24 - 1
+        Assert.AreEqual(78, child.Bounds.X); // 80 - 2
+        Assert.AreEqual(23, child.Bounds.Y); // 24 - 1
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_HCenter_CentersHorizontallyAtTop()
     {
         // Arrange
@@ -134,11 +135,11 @@ public class AlignNodeTests
         node.Arrange(new Rect(0, 0, 80, 24));
 
         // Assert
-        Assert.Equal(39, child.Bounds.X); // (80 - 2) / 2
-        Assert.Equal(0, child.Bounds.Y); // Top (default)
+        Assert.AreEqual(39, child.Bounds.X); // (80 - 2) / 2
+        Assert.AreEqual(0, child.Bounds.Y); // Top (default)
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_VCenter_CentersVerticallyAtLeft()
     {
         // Arrange
@@ -150,11 +151,11 @@ public class AlignNodeTests
         node.Arrange(new Rect(0, 0, 80, 24));
 
         // Assert
-        Assert.Equal(0, child.Bounds.X); // Left (default)
-        Assert.Equal(11, child.Bounds.Y); // (24 - 1) / 2
+        Assert.AreEqual(0, child.Bounds.X); // Left (default)
+        Assert.AreEqual(11, child.Bounds.Y); // (24 - 1) / 2
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_BottomCenter_PositionsAtBottomCenter()
     {
         // Arrange
@@ -166,11 +167,11 @@ public class AlignNodeTests
         node.Arrange(new Rect(0, 0, 80, 24));
 
         // Assert
-        Assert.Equal(39, child.Bounds.X); // (80 - 2) / 2
-        Assert.Equal(23, child.Bounds.Y); // 24 - 1
+        Assert.AreEqual(39, child.Bounds.X); // (80 - 2) / 2
+        Assert.AreEqual(23, child.Bounds.Y); // 24 - 1
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_WithOffset_PositionsRelativeToParentBounds()
     {
         // Arrange
@@ -182,11 +183,11 @@ public class AlignNodeTests
         node.Arrange(new Rect(10, 5, 40, 10));
 
         // Assert - should be centered within parent bounds
-        Assert.Equal(10 + (40 - 2) / 2, child.Bounds.X); // 10 + 19 = 29
-        Assert.Equal(5 + (10 - 1) / 2, child.Bounds.Y);  // 5 + 4 = 9
+        Assert.AreEqual(10 + (40 - 2) / 2, child.Bounds.X); // 10 + 19 = 29
+        Assert.AreEqual(5 + (10 - 1) / 2, child.Bounds.Y);  // 5 + 4 = 9
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AlignmentChange_MarksDirty()
     {
         // Arrange
@@ -201,10 +202,10 @@ public class AlignNodeTests
         node.Alignment = Alignment.Center;
 
         // Assert
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_ReturnsChildFocusables()
     {
         // Arrange
@@ -215,11 +216,11 @@ public class AlignNodeTests
         var focusables = node.GetFocusableNodes().ToList();
 
         // Assert
-        Assert.Single(focusables);
-        Assert.Same(button, focusables[0]);
+        TestSeq.Single(focusables);
+        Assert.AreSame(button, focusables[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetChildren_ReturnsChild()
     {
         // Arrange
@@ -230,11 +231,11 @@ public class AlignNodeTests
         var children = node.GetChildren().ToList();
 
         // Assert
-        Assert.Single(children);
-        Assert.Same(child, children[0]);
+        TestSeq.Single(children);
+        Assert.AreSame(child, children[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetChildren_WhenNoChild_ReturnsEmpty()
     {
         // Arrange
@@ -244,6 +245,6 @@ public class AlignNodeTests
         var children = node.GetChildren().ToList();
 
         // Assert
-        Assert.Empty(children);
+        Assert.IsEmpty(children);
     }
 }

--- a/tests/Hex1b.Tests/AnchoredNodeTests.cs
+++ b/tests/Hex1b.Tests/AnchoredNodeTests.cs
@@ -10,9 +10,10 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for AnchoredNode positioning and stale anchor handling.
 /// </summary>
+[TestClass]
 public class AnchoredNodeTests
 {
-    [Fact]
+    [TestMethod]
     public void AnchoredNode_ValidAnchor_PositionsCorrectly()
     {
         // Arrange - Create an anchor node with known bounds
@@ -37,11 +38,11 @@ public class AnchoredNodeTests
         
         // Assert - Content should be positioned below the anchor
         // Anchor is at (50, 10) with height 1, so popup should be at Y=11
-        Assert.Equal(50, contentNode.Bounds.X);
-        Assert.Equal(11, contentNode.Bounds.Y);
+        Assert.AreEqual(50, contentNode.Bounds.X);
+        Assert.AreEqual(11, contentNode.Bounds.Y);
     }
     
-    [Fact]
+    [TestMethod]
     public void AnchoredNode_StaleAnchorWithZeroBounds_PositionsSafely()
     {
         // Arrange - Simulate a stale anchor node that has never been arranged
@@ -50,10 +51,10 @@ public class AnchoredNodeTests
         // Intentionally NOT calling Measure/Arrange - simulates a replaced node
         
         // Verify anchor has zero bounds (the stale state)
-        Assert.Equal(0, staleAnchorNode.Bounds.X);
-        Assert.Equal(0, staleAnchorNode.Bounds.Y);
-        Assert.Equal(0, staleAnchorNode.Bounds.Width);
-        Assert.Equal(0, staleAnchorNode.Bounds.Height);
+        Assert.AreEqual(0, staleAnchorNode.Bounds.X);
+        Assert.AreEqual(0, staleAnchorNode.Bounds.Y);
+        Assert.AreEqual(0, staleAnchorNode.Bounds.Width);
+        Assert.AreEqual(0, staleAnchorNode.Bounds.Height);
         
         // Create anchored content
         var contentNode = new TextBlockNode { Text = "Popup Content" };
@@ -73,11 +74,10 @@ public class AnchoredNodeTests
         // Assert - With fix: Content should NOT be at (0, 0) when anchor has zero bounds
         // The node should detect the stale anchor and mark itself for cleanup
         // For now, verify the IsAnchorStale flag is set
-        Assert.True(anchoredNode.IsAnchorStale, 
-            "AnchoredNode should detect stale anchor with zero bounds");
+        Assert.IsTrue(anchoredNode.IsAnchorStale, "AnchoredNode should detect stale anchor with zero bounds");
     }
     
-    [Fact]
+    [TestMethod]
     public void AnchoredNode_AnchorOutsideScreen_PositionsSafely()
     {
         // Arrange - Create an anchor node with bounds completely outside the screen
@@ -101,11 +101,11 @@ public class AnchoredNodeTests
         anchoredNode.Arrange(new Rect(0, 0, 100, 50));
         
         // Assert - Content should be clamped to screen bounds (0, 0) minimum
-        Assert.True(contentNode.Bounds.X >= 0, "Content X should be >= 0");
-        Assert.True(contentNode.Bounds.Y >= 0, "Content Y should be >= 0");
+        Assert.IsTrue(contentNode.Bounds.X >= 0, "Content X should be >= 0");
+        Assert.IsTrue(contentNode.Bounds.Y >= 0, "Content Y should be >= 0");
     }
     
-    [Fact]
+    [TestMethod]
     public void AnchoredNode_NullAnchor_DoesNotPosition()
     {
         // Arrange - Create anchored node with no anchor
@@ -124,10 +124,10 @@ public class AnchoredNodeTests
         anchoredNode.Arrange(new Rect(0, 0, 100, 50));
         
         // Assert - Content bounds should be unchanged (not arranged)
-        Assert.Equal(0, contentNode.Bounds.Width);
+        Assert.AreEqual(0, contentNode.Bounds.Width);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task PickerPopup_WhenAnchorNodeReplaced_DetectsStaleAnchor()
     {
         // This test simulates the real-world scenario:
@@ -172,7 +172,6 @@ public class AnchoredNodeTests
         await runTask;
         
         // Verify picker dropdown appeared (shows all options including Medium and High)
-        Assert.True(snapshot.ContainsText("Medium") && snapshot.ContainsText("High"),
-            $"Picker dropdown should show options. Screen:\n{snapshot}");
+        Assert.IsTrue(snapshot.ContainsText("Medium") && snapshot.ContainsText("High"), $"Picker dropdown should show options. Screen:\n{snapshot}");
     }
 }

--- a/tests/Hex1b.Tests/Animation/AnimationCollectionTests.cs
+++ b/tests/Hex1b.Tests/Animation/AnimationCollectionTests.cs
@@ -3,20 +3,21 @@ using Hex1b.Animation;
 
 namespace Hex1b.Tests.Animation;
 
+[TestClass]
 public class AnimationCollectionTests
 {
-    [Fact]
+    [TestMethod]
     public void Get_CreatesNewAnimator()
     {
         var collection = new AnimationCollection();
 
         var animator = collection.Get<NumericAnimator<double>>("fade");
 
-        Assert.NotNull(animator);
-        Assert.IsType<NumericAnimator<double>>(animator);
+        Assert.IsNotNull(animator);
+        TestSeq.IsType<NumericAnimator<double>>(animator);
     }
 
-    [Fact]
+    [TestMethod]
     public void Get_ReturnsSameInstance()
     {
         var collection = new AnimationCollection();
@@ -24,10 +25,10 @@ public class AnimationCollectionTests
         var a1 = collection.Get<NumericAnimator<double>>("fade");
         var a2 = collection.Get<NumericAnimator<double>>("fade");
 
-        Assert.Same(a1, a2);
+        Assert.AreSame(a1, a2);
     }
 
-    [Fact]
+    [TestMethod]
     public void Get_ConfigureCalledOnCreation()
     {
         var collection = new AnimationCollection();
@@ -37,11 +38,11 @@ public class AnimationCollectionTests
             a.Duration = TimeSpan.FromMilliseconds(500);
         });
 
-        Assert.Equal(TimeSpan.FromMilliseconds(500), animator.Duration);
-        Assert.True(animator.IsRunning); // auto-started
+        Assert.AreEqual(TimeSpan.FromMilliseconds(500), animator.Duration);
+        Assert.IsTrue(animator.IsRunning); // auto-started
     }
 
-    [Fact]
+    [TestMethod]
     public void Get_ConfigureNotCalledOnRetrieval()
     {
         var collection = new AnimationCollection();
@@ -51,28 +52,28 @@ public class AnimationCollectionTests
         collection.Get<NumericAnimator<double>>("fade", _ => configCount++);
 
         // Configure called only once (on creation)
-        Assert.Equal(1, configCount);
+        Assert.AreEqual(1, configCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void Get_AutoStartTrue_StartsAnimator()
     {
         var collection = new AnimationCollection();
         var animator = collection.Get<NumericAnimator<double>>("fade");
 
-        Assert.True(animator.IsRunning);
+        Assert.IsTrue(animator.IsRunning);
     }
 
-    [Fact]
+    [TestMethod]
     public void Get_AutoStartFalse_DoesNotStartAnimator()
     {
         var collection = new AnimationCollection();
         var animator = collection.Get<NumericAnimator<double>>("fade", autoStart: false);
 
-        Assert.False(animator.IsRunning);
+        Assert.IsFalse(animator.IsRunning);
     }
 
-    [Fact]
+    [TestMethod]
     public void Get_DifferentNames_DifferentInstances()
     {
         var collection = new AnimationCollection();
@@ -80,10 +81,10 @@ public class AnimationCollectionTests
         var a = collection.Get<NumericAnimator<double>>("fade-in");
         var b = collection.Get<NumericAnimator<double>>("fade-out");
 
-        Assert.NotSame(a, b);
+        Assert.AreNotSame(a, b);
     }
 
-    [Fact]
+    [TestMethod]
     public void AdvanceAll_TicksAllRunning()
     {
         var collection = new AnimationCollection();
@@ -98,11 +99,11 @@ public class AnimationCollectionTests
 
         collection.AdvanceAll(TimeSpan.FromMilliseconds(50));
 
-        Assert.Equal(0.5, a1.RawProgress, 6);
-        Assert.Equal(0.25, a2.RawProgress, 6);
+        Assert.AreEqual(0.5, a1.RawProgress, 6);
+        Assert.AreEqual(0.25, a2.RawProgress, 6);
     }
 
-    [Fact]
+    [TestMethod]
     public void AdvanceAll_SkipsNonRunning()
     {
         var collection = new AnimationCollection();
@@ -114,29 +115,29 @@ public class AnimationCollectionTests
 
         collection.AdvanceAll(TimeSpan.FromMilliseconds(50));
 
-        Assert.Equal(0.5, a1.RawProgress, 6);
-        Assert.Equal(0.0, a2.RawProgress, 6);
+        Assert.AreEqual(0.5, a1.RawProgress, 6);
+        Assert.AreEqual(0.0, a2.RawProgress, 6);
     }
 
-    [Fact]
+    [TestMethod]
     public void HasActiveAnimations_TrueWhenRunning()
     {
         var collection = new AnimationCollection();
         collection.Get<NumericAnimator<double>>("fade");
 
-        Assert.True(collection.HasActiveAnimations);
+        Assert.IsTrue(collection.HasActiveAnimations);
     }
 
-    [Fact]
+    [TestMethod]
     public void HasActiveAnimations_FalseWhenNoneRunning()
     {
         var collection = new AnimationCollection();
         collection.Get<NumericAnimator<double>>("fade", autoStart: false);
 
-        Assert.False(collection.HasActiveAnimations);
+        Assert.IsFalse(collection.HasActiveAnimations);
     }
 
-    [Fact]
+    [TestMethod]
     public void DisposeAll_ClearsCollection()
     {
         var collection = new AnimationCollection();
@@ -144,13 +145,13 @@ public class AnimationCollectionTests
 
         collection.Dispose();
 
-        Assert.False(collection.HasActiveAnimations);
+        Assert.IsFalse(collection.HasActiveAnimations);
         // Get after dispose creates a new instance
         var animator = collection.Get<NumericAnimator<double>>("fade", autoStart: false);
-        Assert.False(animator.IsRunning);
+        Assert.IsFalse(animator.IsRunning);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_AdvancesAnimations_AcrossFrames()
     {
         // This is the critical test: prove that animations actually progress
@@ -173,7 +174,7 @@ public class AnimationCollectionTests
         });
 
         var node = await widget1.ReconcileAsync(null, context);
-        Assert.Equal(0.0, progressOnFrame1, 6); // Just started
+        Assert.AreEqual(0.0, progressOnFrame1, 6); // Just started
 
         // Wait real time so Stopwatch.GetTimestamp() moves forward
         await Task.Delay(100);
@@ -189,11 +190,10 @@ public class AnimationCollectionTests
         await widget2.ReconcileAsync(node, context);
 
         // Animation MUST have advanced — this is the bug the original code missed
-        Assert.True(progressOnFrame2 > 0.0,
-            $"Animation did not advance! Progress was {progressOnFrame2} on frame 2");
+        Assert.IsTrue(progressOnFrame2 > 0.0, $"Animation did not advance! Progress was {progressOnFrame2} on frame 2");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_SchedulesTimerCallback_WhenAnimationsActive()
     {
         var stateKey = new object();
@@ -216,11 +216,11 @@ public class AnimationCollectionTests
         await widget.ReconcileAsync(null, context);
 
         // Timer callback MUST be scheduled for re-render
-        Assert.NotEmpty(scheduledCallbacks);
-        Assert.Equal(TimeSpan.FromMilliseconds(16), scheduledCallbacks[0].delay);
+        Assert.IsNotEmpty(scheduledCallbacks);
+        Assert.AreEqual(TimeSpan.FromMilliseconds(16), scheduledCallbacks[0].delay);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_DoesNotScheduleTimer_WhenNoActiveAnimations()
     {
         var stateKey = new object();
@@ -236,10 +236,10 @@ public class AnimationCollectionTests
 
         await widget.ReconcileAsync(null, context);
 
-        Assert.Empty(scheduledCallbacks);
+        Assert.IsEmpty(scheduledCallbacks);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_AnimationValue_ChangesOverTime()
     {
         // End-to-end: animation value is different between frames
@@ -276,14 +276,13 @@ public class AnimationCollectionTests
         });
         await widget2.ReconcileAsync(node, context);
 
-        Assert.Equal(0.0, valueFrame1, 1);
-        Assert.True(valueFrame2 > 0.0,
-            $"NumericAnimator value did not change! Was {valueFrame2}");
+        Assert.AreEqual(0.0, valueFrame1, 1);
+        Assert.IsTrue(valueFrame2 > 0.0, $"NumericAnimator value did not change! Was {valueFrame2}");
     }
 
     // --- Integration with StatePanel ---
 
-    [Fact]
+    [TestMethod]
     public async Task StatePanelContext_ExposesAnimations()
     {
         AnimationCollection? capturedAnimations = null;
@@ -298,10 +297,10 @@ public class AnimationCollectionTests
         var context = Hex1b.Widgets.ReconcileContext.CreateRoot();
         await widget.ReconcileAsync(null, context);
 
-        Assert.NotNull(capturedAnimations);
+        Assert.IsNotNull(capturedAnimations);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Animations_PersistAcrossReconciliation()
     {
         var stateKey = new object();
@@ -327,11 +326,11 @@ public class AnimationCollectionTests
         await widget2.ReconcileAsync(node, context);
 
         // Same AnimationCollection instance persists
-        Assert.Same(animations1, animations2);
-        Assert.True(animations2!.HasActiveAnimations);
+        Assert.AreSame(animations1, animations2);
+        Assert.IsTrue(animations2!.HasActiveAnimations);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Animations_DisposedOnSweep()
     {
         var keyRoot = new object();
@@ -350,7 +349,7 @@ public class AnimationCollectionTests
             }));
 
         var root = await widget1.ReconcileAsync(null, context);
-        Assert.True(childAnimations!.HasActiveAnimations);
+        Assert.IsTrue(childAnimations!.HasActiveAnimations);
 
         // Frame 2: root without child — child gets swept
         var widget2 = new Hex1b.Widgets.StatePanelWidget(keyRoot, sp =>
@@ -359,6 +358,6 @@ public class AnimationCollectionTests
         await widget2.ReconcileAsync(root, context);
 
         // Animations should be disposed
-        Assert.False(childAnimations.HasActiveAnimations);
+        Assert.IsFalse(childAnimations.HasActiveAnimations);
     }
 }

--- a/tests/Hex1b.Tests/Animation/AnimatorTests.cs
+++ b/tests/Hex1b.Tests/Animation/AnimatorTests.cs
@@ -2,23 +2,24 @@ using Hex1b.Animation;
 
 namespace Hex1b.Tests.Animation;
 
+[TestClass]
 public class AnimatorTests
 {
     // --- Hex1bAnimator base tests ---
 
-    [Fact]
+    [TestMethod]
     public void Start_SetsRunning()
     {
         var animator = new NumericAnimator<double>();
         animator.Start();
 
-        Assert.True(animator.IsRunning);
-        Assert.False(animator.IsPaused);
-        Assert.False(animator.IsCompleted);
-        Assert.Equal(0.0, animator.RawProgress);
+        Assert.IsTrue(animator.IsRunning);
+        Assert.IsFalse(animator.IsPaused);
+        Assert.IsFalse(animator.IsCompleted);
+        Assert.AreEqual(0.0, animator.RawProgress);
     }
 
-    [Fact]
+    [TestMethod]
     public void Advance_ProgressesOverDuration()
     {
         var animator = new NumericAnimator<double> { Duration = TimeSpan.FromMilliseconds(100) };
@@ -26,11 +27,11 @@ public class AnimatorTests
 
         animator.Advance(TimeSpan.FromMilliseconds(50));
 
-        Assert.Equal(0.5, animator.RawProgress, 6);
-        Assert.True(animator.IsRunning);
+        Assert.AreEqual(0.5, animator.RawProgress, 6);
+        Assert.IsTrue(animator.IsRunning);
     }
 
-    [Fact]
+    [TestMethod]
     public void Advance_CompletesAtDuration()
     {
         var animator = new NumericAnimator<double> { Duration = TimeSpan.FromMilliseconds(100) };
@@ -38,12 +39,12 @@ public class AnimatorTests
 
         animator.Advance(TimeSpan.FromMilliseconds(100));
 
-        Assert.Equal(1.0, animator.RawProgress, 6);
-        Assert.True(animator.IsCompleted);
-        Assert.False(animator.IsRunning);
+        Assert.AreEqual(1.0, animator.RawProgress, 6);
+        Assert.IsTrue(animator.IsCompleted);
+        Assert.IsFalse(animator.IsRunning);
     }
 
-    [Fact]
+    [TestMethod]
     public void Advance_ClampsToOneWithoutRepeat()
     {
         var animator = new NumericAnimator<double> { Duration = TimeSpan.FromMilliseconds(100) };
@@ -51,11 +52,11 @@ public class AnimatorTests
 
         animator.Advance(TimeSpan.FromMilliseconds(200));
 
-        Assert.Equal(1.0, animator.RawProgress, 6);
-        Assert.True(animator.IsCompleted);
+        Assert.AreEqual(1.0, animator.RawProgress, 6);
+        Assert.IsTrue(animator.IsCompleted);
     }
 
-    [Fact]
+    [TestMethod]
     public void Advance_Repeat_WrapsProgress()
     {
         var animator = new NumericAnimator<double> { Duration = TimeSpan.FromMilliseconds(100), Repeat = true };
@@ -63,11 +64,11 @@ public class AnimatorTests
 
         animator.Advance(TimeSpan.FromMilliseconds(150));
 
-        Assert.Equal(0.5, animator.RawProgress, 6);
-        Assert.True(animator.IsRunning);
+        Assert.AreEqual(0.5, animator.RawProgress, 6);
+        Assert.IsTrue(animator.IsRunning);
     }
 
-    [Fact]
+    [TestMethod]
     public void Advance_RepeatReverse_PingPongs()
     {
         var animator = new NumericAnimator<double>
@@ -81,11 +82,11 @@ public class AnimatorTests
         // Advance to 150ms: should be at 0.5 on the way back (1.0 - 0.5)
         animator.Advance(TimeSpan.FromMilliseconds(150));
 
-        Assert.Equal(0.5, animator.RawProgress, 6);
-        Assert.True(animator.IsRunning);
+        Assert.AreEqual(0.5, animator.RawProgress, 6);
+        Assert.IsTrue(animator.IsRunning);
     }
 
-    [Fact]
+    [TestMethod]
     public void Pause_StopsAdvancing()
     {
         var animator = new NumericAnimator<double> { Duration = TimeSpan.FromMilliseconds(100) };
@@ -96,11 +97,11 @@ public class AnimatorTests
         var progressAtPause = animator.RawProgress;
         animator.Advance(TimeSpan.FromMilliseconds(50));
 
-        Assert.Equal(progressAtPause, animator.RawProgress, 6);
-        Assert.True(animator.IsPaused);
+        Assert.AreEqual(progressAtPause, animator.RawProgress, 6);
+        Assert.IsTrue(animator.IsPaused);
     }
 
-    [Fact]
+    [TestMethod]
     public void Resume_ContinuesAdvancing()
     {
         var animator = new NumericAnimator<double> { Duration = TimeSpan.FromMilliseconds(100) };
@@ -111,11 +112,11 @@ public class AnimatorTests
 
         animator.Advance(TimeSpan.FromMilliseconds(30));
 
-        Assert.Equal(0.6, animator.RawProgress, 6);
-        Assert.True(animator.IsRunning);
+        Assert.AreEqual(0.6, animator.RawProgress, 6);
+        Assert.IsTrue(animator.IsRunning);
     }
 
-    [Fact]
+    [TestMethod]
     public void Reset_ClearsState()
     {
         var animator = new NumericAnimator<double>();
@@ -123,27 +124,27 @@ public class AnimatorTests
         animator.Advance(TimeSpan.FromMilliseconds(50));
         animator.Reset();
 
-        Assert.Equal(0.0, animator.RawProgress, 6);
-        Assert.False(animator.IsRunning);
-        Assert.False(animator.IsPaused);
-        Assert.False(animator.IsCompleted);
+        Assert.AreEqual(0.0, animator.RawProgress, 6);
+        Assert.IsFalse(animator.IsRunning);
+        Assert.IsFalse(animator.IsPaused);
+        Assert.IsFalse(animator.IsCompleted);
     }
 
-    [Fact]
+    [TestMethod]
     public void Restart_ResetsAndStarts()
     {
         var animator = new NumericAnimator<double> { Duration = TimeSpan.FromMilliseconds(100) };
         animator.Start();
         animator.Advance(TimeSpan.FromMilliseconds(100));
-        Assert.True(animator.IsCompleted);
+        Assert.IsTrue(animator.IsCompleted);
 
         animator.Restart();
 
-        Assert.Equal(0.0, animator.RawProgress, 6);
-        Assert.True(animator.IsRunning);
+        Assert.AreEqual(0.0, animator.RawProgress, 6);
+        Assert.IsTrue(animator.IsRunning);
     }
 
-    [Fact]
+    [TestMethod]
     public void Progress_AppliesEasing()
     {
         var animator = new NumericAnimator<double>
@@ -155,13 +156,13 @@ public class AnimatorTests
         animator.Advance(TimeSpan.FromMilliseconds(50));
 
         // Raw: 0.5, Eased: 0.25 (quad)
-        Assert.Equal(0.5, animator.RawProgress, 6);
-        Assert.Equal(0.25, animator.Progress, 6);
+        Assert.AreEqual(0.5, animator.RawProgress, 6);
+        Assert.AreEqual(0.25, animator.Progress, 6);
     }
 
     // --- NumericAnimator tests ---
 
-    [Fact]
+    [TestMethod]
     public void NumericAnimator_Double_Interpolates()
     {
         var animator = new NumericAnimator<double>
@@ -172,10 +173,10 @@ public class AnimatorTests
         animator.Start();
         animator.Advance(TimeSpan.FromMilliseconds(50));
 
-        Assert.Equal(15.0, animator.Value, 6);
+        Assert.AreEqual(15.0, animator.Value, 6);
     }
 
-    [Fact]
+    [TestMethod]
     public void NumericAnimator_Float_Interpolates()
     {
         var animator = new NumericAnimator<float>
@@ -186,10 +187,10 @@ public class AnimatorTests
         animator.Start();
         animator.Advance(TimeSpan.FromMilliseconds(25));
 
-        Assert.Equal(25f, animator.Value, 1);
+        Assert.AreEqual(25f, animator.Value, 1);
     }
 
-    [Fact]
+    [TestMethod]
     public void NumericAnimator_Int_Rounds()
     {
         var animator = new NumericAnimator<int>
@@ -201,10 +202,10 @@ public class AnimatorTests
         animator.Advance(TimeSpan.FromMilliseconds(33));
 
         // 0.33 * 10 = 3.3 → rounds to 3
-        Assert.Equal(3, animator.Value);
+        Assert.AreEqual(3, animator.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void NumericAnimator_WithEasing_AppliesEasingToValue()
     {
         var animator = new NumericAnimator<double>
@@ -217,33 +218,33 @@ public class AnimatorTests
         animator.Advance(TimeSpan.FromMilliseconds(50));
 
         // Eased progress = 0.25, value = 25.0
-        Assert.Equal(25.0, animator.Value, 6);
+        Assert.AreEqual(25.0, animator.Value, 6);
     }
 
     // --- NumericAnimator<double> tests ---
 
-    [Fact]
+    [TestMethod]
     public void NumericAnimatorDouble_DefaultsFromZeroToZero()
     {
         var animator = new NumericAnimator<double>();
 
-        Assert.Equal(0.0, animator.From);
-        Assert.Equal(0.0, animator.To);
+        Assert.AreEqual(0.0, animator.From);
+        Assert.AreEqual(0.0, animator.To);
     }
 
-    [Fact]
+    [TestMethod]
     public void NumericAnimatorDouble_InterpolatesCorrectly()
     {
         var animator = new NumericAnimator<double> { From = 0.0, To = 1.0, Duration = TimeSpan.FromMilliseconds(100) };
         animator.Start();
         animator.Advance(TimeSpan.FromMilliseconds(75));
 
-        Assert.Equal(0.75, animator.Value, 6);
+        Assert.AreEqual(0.75, animator.Value, 6);
     }
 
     // --- AnimateTo (retargeting) tests ---
 
-    [Fact]
+    [TestMethod]
     public void AnimateTo_StartsFromCurrentValue()
     {
         var animator = new NumericAnimator<double>
@@ -256,13 +257,13 @@ public class AnimatorTests
 
         animator.AnimateTo(0.0); // Retarget back to 0
 
-        Assert.Equal(50.0, animator.From, 1);
-        Assert.Equal(0.0, animator.To, 1);
-        Assert.True(animator.IsRunning);
-        Assert.Equal(50.0, animator.Value, 1); // Starts at current position
+        Assert.AreEqual(50.0, animator.From, 1);
+        Assert.AreEqual(0.0, animator.To, 1);
+        Assert.IsTrue(animator.IsRunning);
+        Assert.AreEqual(50.0, animator.Value, 1); // Starts at current position
     }
 
-    [Fact]
+    [TestMethod]
     public void AnimateTo_SameTarget_DoesNotRestart()
     {
         var animator = new NumericAnimator<double>
@@ -276,10 +277,10 @@ public class AnimatorTests
         var progressBefore = animator.RawProgress;
         animator.AnimateTo(1.0); // Same target — should not restart
 
-        Assert.Equal(progressBefore, animator.RawProgress, 6);
+        Assert.AreEqual(progressBefore, animator.RawProgress, 6);
     }
 
-    [Fact]
+    [TestMethod]
     public void AnimateTo_CompletedAnimation_NewTarget_Restarts()
     {
         var animator = new NumericAnimator<double>
@@ -289,12 +290,12 @@ public class AnimatorTests
         };
         animator.Start();
         animator.Advance(TimeSpan.FromMilliseconds(100)); // Completed at 1.0
-        Assert.True(animator.IsCompleted);
+        Assert.IsTrue(animator.IsCompleted);
 
         animator.AnimateTo(0.0); // New target
 
-        Assert.True(animator.IsRunning);
-        Assert.Equal(1.0, animator.From, 6); // Starts from where we were
-        Assert.Equal(0.0, animator.To, 6);
+        Assert.IsTrue(animator.IsRunning);
+        Assert.AreEqual(1.0, animator.From, 6); // Starts from where we were
+        Assert.AreEqual(0.0, animator.To, 6);
     }
 }

--- a/tests/Hex1b.Tests/Animation/EasingTests.cs
+++ b/tests/Hex1b.Tests/Animation/EasingTests.cs
@@ -2,111 +2,112 @@ using Hex1b.Animation;
 
 namespace Hex1b.Tests.Animation;
 
+[TestClass]
 public class EasingTests
 {
-    [Theory]
-    [InlineData(0.0, 0.0)]
-    [InlineData(1.0, 1.0)]
+    [TestMethod]
+    [DataRow(0.0, 0.0)]
+    [DataRow(1.0, 1.0)]
     public void Linear_AtBoundaries(double input, double expected)
     {
-        Assert.Equal(expected, Easing.Linear(input), 6);
+        Assert.AreEqual(expected, Easing.Linear(input), 6);
     }
 
-    [Fact]
+    [TestMethod]
     public void Linear_AtMidpoint_Returns05()
     {
-        Assert.Equal(0.5, Easing.Linear(0.5), 6);
+        Assert.AreEqual(0.5, Easing.Linear(0.5), 6);
     }
 
-    [Theory]
-    [InlineData(0.0, 0.0)]
-    [InlineData(1.0, 1.0)]
+    [TestMethod]
+    [DataRow(0.0, 0.0)]
+    [DataRow(1.0, 1.0)]
     public void EaseInQuad_AtBoundaries(double input, double expected)
     {
-        Assert.Equal(expected, Easing.EaseInQuad(input), 6);
+        Assert.AreEqual(expected, Easing.EaseInQuad(input), 6);
     }
 
-    [Fact]
+    [TestMethod]
     public void EaseInQuad_AtMidpoint_Returns025()
     {
         // 0.5^2 = 0.25
-        Assert.Equal(0.25, Easing.EaseInQuad(0.5), 6);
+        Assert.AreEqual(0.25, Easing.EaseInQuad(0.5), 6);
     }
 
-    [Theory]
-    [InlineData(0.0, 0.0)]
-    [InlineData(1.0, 1.0)]
+    [TestMethod]
+    [DataRow(0.0, 0.0)]
+    [DataRow(1.0, 1.0)]
     public void EaseOutQuad_AtBoundaries(double input, double expected)
     {
-        Assert.Equal(expected, Easing.EaseOutQuad(input), 6);
+        Assert.AreEqual(expected, Easing.EaseOutQuad(input), 6);
     }
 
-    [Fact]
+    [TestMethod]
     public void EaseOutQuad_AtMidpoint_Returns075()
     {
         // 0.5 * (2 - 0.5) = 0.75
-        Assert.Equal(0.75, Easing.EaseOutQuad(0.5), 6);
+        Assert.AreEqual(0.75, Easing.EaseOutQuad(0.5), 6);
     }
 
-    [Theory]
-    [InlineData(0.0, 0.0)]
-    [InlineData(1.0, 1.0)]
+    [TestMethod]
+    [DataRow(0.0, 0.0)]
+    [DataRow(1.0, 1.0)]
     public void EaseInOutQuad_AtBoundaries(double input, double expected)
     {
-        Assert.Equal(expected, Easing.EaseInOutQuad(input), 6);
+        Assert.AreEqual(expected, Easing.EaseInOutQuad(input), 6);
     }
 
-    [Fact]
+    [TestMethod]
     public void EaseInOutQuad_AtMidpoint_Returns05()
     {
-        Assert.Equal(0.5, Easing.EaseInOutQuad(0.5), 6);
+        Assert.AreEqual(0.5, Easing.EaseInOutQuad(0.5), 6);
     }
 
-    [Theory]
-    [InlineData(0.0, 0.0)]
-    [InlineData(1.0, 1.0)]
+    [TestMethod]
+    [DataRow(0.0, 0.0)]
+    [DataRow(1.0, 1.0)]
     public void EaseInCubic_AtBoundaries(double input, double expected)
     {
-        Assert.Equal(expected, Easing.EaseInCubic(input), 6);
+        Assert.AreEqual(expected, Easing.EaseInCubic(input), 6);
     }
 
-    [Fact]
+    [TestMethod]
     public void EaseInCubic_AtMidpoint_Returns0125()
     {
         // 0.5^3 = 0.125
-        Assert.Equal(0.125, Easing.EaseInCubic(0.5), 6);
+        Assert.AreEqual(0.125, Easing.EaseInCubic(0.5), 6);
     }
 
-    [Theory]
-    [InlineData(0.0, 0.0)]
-    [InlineData(1.0, 1.0)]
+    [TestMethod]
+    [DataRow(0.0, 0.0)]
+    [DataRow(1.0, 1.0)]
     public void EaseOutCubic_AtBoundaries(double input, double expected)
     {
-        Assert.Equal(expected, Easing.EaseOutCubic(input), 6);
+        Assert.AreEqual(expected, Easing.EaseOutCubic(input), 6);
     }
 
-    [Fact]
+    [TestMethod]
     public void EaseOutCubic_AtMidpoint_Returns0875()
     {
         // (0.5-1)^3 + 1 = -0.125 + 1 = 0.875
-        Assert.Equal(0.875, Easing.EaseOutCubic(0.5), 6);
+        Assert.AreEqual(0.875, Easing.EaseOutCubic(0.5), 6);
     }
 
-    [Theory]
-    [InlineData(0.0, 0.0)]
-    [InlineData(1.0, 1.0)]
+    [TestMethod]
+    [DataRow(0.0, 0.0)]
+    [DataRow(1.0, 1.0)]
     public void EaseInOutCubic_AtBoundaries(double input, double expected)
     {
-        Assert.Equal(expected, Easing.EaseInOutCubic(input), 6);
+        Assert.AreEqual(expected, Easing.EaseInOutCubic(input), 6);
     }
 
-    [Fact]
+    [TestMethod]
     public void EaseInOutCubic_AtMidpoint_Returns05()
     {
-        Assert.Equal(0.5, Easing.EaseInOutCubic(0.5), 6);
+        Assert.AreEqual(0.5, Easing.EaseInOutCubic(0.5), 6);
     }
 
-    [Fact]
+    [TestMethod]
     public void AllEasings_AreMonotonicallyIncreasing()
     {
         var easings = new[]
@@ -122,8 +123,7 @@ public class EasingTests
             for (var t = 0.01; t <= 1.0; t += 0.01)
             {
                 var current = easing(t);
-                Assert.True(current >= prev - 1e-10,
-                    $"Easing not monotonic at t={t}: {prev} -> {current}");
+                Assert.IsTrue(current >= prev - 1e-10, $"Easing not monotonic at t={t}: {prev} -> {current}");
                 prev = current;
             }
         }

--- a/tests/Hex1b.Tests/AnimationTimerTests.cs
+++ b/tests/Hex1b.Tests/AnimationTimerTests.cs
@@ -2,9 +2,10 @@ namespace Hex1b.Tests;
 
 using Hex1b.Animation;
 
+[TestClass]
 public class AnimationTimerTests
 {
-    [Fact]
+    [TestMethod]
     public void Schedule_AddsTimer()
     {
         var timer = new AnimationTimer();
@@ -12,19 +13,19 @@ public class AnimationTimerTests
         
         timer.Schedule(TimeSpan.FromMilliseconds(100), () => fired = true);
         
-        Assert.True(timer.HasScheduledTimers);
-        Assert.False(fired);
+        Assert.IsTrue(timer.HasScheduledTimers);
+        Assert.IsFalse(fired);
     }
     
-    [Fact]
+    [TestMethod]
     public void GetTimeUntilNextDue_ReturnsNullWhenNoTimers()
     {
         var timer = new AnimationTimer();
         
-        Assert.Null(timer.GetTimeUntilNextDue());
+        Assert.IsNull(timer.GetTimeUntilNextDue());
     }
     
-    [Fact]
+    [TestMethod]
     public void GetTimeUntilNextDue_ReturnsTimeWhenTimerScheduled()
     {
         var timer = new AnimationTimer();
@@ -32,12 +33,12 @@ public class AnimationTimerTests
         
         var timeUntil = timer.GetTimeUntilNextDue();
         
-        Assert.NotNull(timeUntil);
-        Assert.True(timeUntil.Value.TotalMilliseconds > 0);
-        Assert.True(timeUntil.Value.TotalMilliseconds <= 100);
+        Assert.IsNotNull(timeUntil);
+        Assert.IsTrue(timeUntil.Value.TotalMilliseconds > 0);
+        Assert.IsTrue(timeUntil.Value.TotalMilliseconds <= 100);
     }
     
-    [Fact]
+    [TestMethod]
     public void FireDue_FiresExpiredTimers()
     {
         var timer = new AnimationTimer();
@@ -51,11 +52,11 @@ public class AnimationTimerTests
         
         timer.FireDue();
         
-        Assert.True(fired);
-        Assert.False(timer.HasScheduledTimers);
+        Assert.IsTrue(fired);
+        Assert.IsFalse(timer.HasScheduledTimers);
     }
     
-    [Fact]
+    [TestMethod]
     public void FireDue_DoesNotFireFutureTimers()
     {
         var timer = new AnimationTimer();
@@ -64,11 +65,11 @@ public class AnimationTimerTests
         timer.Schedule(TimeSpan.FromSeconds(10), () => fired = true);
         timer.FireDue();
         
-        Assert.False(fired);
-        Assert.True(timer.HasScheduledTimers);
+        Assert.IsFalse(fired);
+        Assert.IsTrue(timer.HasScheduledTimers);
     }
     
-    [Fact]
+    [TestMethod]
     public void Schedule_ClampsToMinimum16ms()
     {
         var timer = new AnimationTimer();
@@ -77,11 +78,11 @@ public class AnimationTimerTests
         var timeUntil = timer.GetTimeUntilNextDue();
         
         // Should be close to 16ms minimum, not 1ms
-        Assert.NotNull(timeUntil);
-        Assert.True(timeUntil.Value.TotalMilliseconds >= 15); // Allow 1ms tolerance
+        Assert.IsNotNull(timeUntil);
+        Assert.IsTrue(timeUntil.Value.TotalMilliseconds >= 15); // Allow 1ms tolerance
     }
     
-    [Fact]
+    [TestMethod]
     public void FireDue_FiresMultipleExpiredTimers()
     {
         var timer = new AnimationTimer();
@@ -94,11 +95,11 @@ public class AnimationTimerTests
         Thread.Sleep(50);
         timer.FireDue();
         
-        Assert.Equal(3, count);
-        Assert.False(timer.HasScheduledTimers);
+        Assert.AreEqual(3, count);
+        Assert.IsFalse(timer.HasScheduledTimers);
     }
     
-    [Fact]
+    [TestMethod]
     public void GetTimeUntilNextDue_ReturnsZeroWhenTimerPastDue()
     {
         var timer = new AnimationTimer();
@@ -109,11 +110,11 @@ public class AnimationTimerTests
         
         var timeUntil = timer.GetTimeUntilNextDue();
         
-        Assert.NotNull(timeUntil);
-        Assert.Equal(TimeSpan.Zero, timeUntil.Value);
+        Assert.IsNotNull(timeUntil);
+        Assert.AreEqual(TimeSpan.Zero, timeUntil.Value);
     }
     
-    [Fact]
+    [TestMethod]
     public void MultipleTimers_GetTimeReturnsEarliest()
     {
         var timer = new AnimationTimer();
@@ -124,8 +125,8 @@ public class AnimationTimerTests
         
         var timeUntil = timer.GetTimeUntilNextDue();
         
-        Assert.NotNull(timeUntil);
+        Assert.IsNotNull(timeUntil);
         // Should be ~100ms or less (whichever is minimum after clamping)
-        Assert.True(timeUntil.Value.TotalMilliseconds <= 100);
+        Assert.IsTrue(timeUntil.Value.TotalMilliseconds <= 100);
     }
 }

--- a/tests/Hex1b.Tests/AnsiColorPreservationTests.cs
+++ b/tests/Hex1b.Tests/AnsiColorPreservationTests.cs
@@ -11,126 +11,127 @@ namespace Hex1b.Tests;
 /// (SGR 38;5;N) must be stored with their original encoding and re-emitted faithfully
 /// so that the user's terminal palette is respected.
 /// </summary>
+[TestClass]
 public class AnsiColorPreservationTests
 {
     #region Hex1bColor Kind Preservation
 
-    [Fact]
+    [TestMethod]
     public void FromStandard_PreservesKindAndIndex()
     {
         var color = Hex1bColor.FromStandard(4, 0, 0, 128);
 
-        Assert.Equal(Hex1bColorKind.Standard, color.Kind);
-        Assert.Equal(4, color.AnsiIndex);
-        Assert.Equal(0, color.R);
-        Assert.Equal(0, color.G);
-        Assert.Equal(128, color.B);
+        Assert.AreEqual(Hex1bColorKind.Standard, color.Kind);
+        Assert.AreEqual(4, color.AnsiIndex);
+        Assert.AreEqual(0, color.R);
+        Assert.AreEqual(0, color.G);
+        Assert.AreEqual(128, color.B);
     }
 
-    [Fact]
+    [TestMethod]
     public void FromBright_PreservesKindAndIndex()
     {
         var color = Hex1bColor.FromBright(1, 255, 0, 0);
 
-        Assert.Equal(Hex1bColorKind.Bright, color.Kind);
-        Assert.Equal(1, color.AnsiIndex);
+        Assert.AreEqual(Hex1bColorKind.Bright, color.Kind);
+        Assert.AreEqual(1, color.AnsiIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void FromIndexed_PreservesKindAndIndex()
     {
         var color = Hex1bColor.FromIndexed(196, 255, 0, 0);
 
-        Assert.Equal(Hex1bColorKind.Indexed, color.Kind);
-        Assert.Equal(196, color.AnsiIndex);
+        Assert.AreEqual(Hex1bColorKind.Indexed, color.Kind);
+        Assert.AreEqual(196, color.AnsiIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void FromRgb_HasRgbKind()
     {
         var color = Hex1bColor.FromRgb(100, 200, 50);
 
-        Assert.Equal(Hex1bColorKind.Rgb, color.Kind);
-        Assert.Equal(0, color.AnsiIndex);
+        Assert.AreEqual(Hex1bColorKind.Rgb, color.Kind);
+        Assert.AreEqual(0, color.AnsiIndex);
     }
 
     #endregion
 
     #region Hex1bColor ANSI Serialization
 
-    [Theory]
-    [InlineData(0, "\x1b[30m")]  // Black
-    [InlineData(1, "\x1b[31m")]  // Red
-    [InlineData(2, "\x1b[32m")]  // Green
-    [InlineData(3, "\x1b[33m")]  // Yellow
-    [InlineData(4, "\x1b[34m")]  // Blue
-    [InlineData(5, "\x1b[35m")]  // Magenta
-    [InlineData(6, "\x1b[36m")]  // Cyan
-    [InlineData(7, "\x1b[37m")]  // White
+    [TestMethod]
+    [DataRow(0, "\x1b[30m")]  // Black
+    [DataRow(1, "\x1b[31m")]  // Red
+    [DataRow(2, "\x1b[32m")]  // Green
+    [DataRow(3, "\x1b[33m")]  // Yellow
+    [DataRow(4, "\x1b[34m")]  // Blue
+    [DataRow(5, "\x1b[35m")]  // Magenta
+    [DataRow(6, "\x1b[36m")]  // Cyan
+    [DataRow(7, "\x1b[37m")]  // White
     public void ToForegroundAnsi_StandardColor_EmitsOriginalCode(int index, string expected)
     {
         var color = Hex1bColor.FromStandard((byte)index, 0, 0, 0);
-        Assert.Equal(expected, color.ToForegroundAnsi());
+        Assert.AreEqual(expected, color.ToForegroundAnsi());
     }
 
-    [Theory]
-    [InlineData(0, "\x1b[40m")]
-    [InlineData(4, "\x1b[44m")]  // Blue background
+    [TestMethod]
+    [DataRow(0, "\x1b[40m")]
+    [DataRow(4, "\x1b[44m")]  // Blue background
     public void ToBackgroundAnsi_StandardColor_EmitsOriginalCode(int index, string expected)
     {
         var color = Hex1bColor.FromStandard((byte)index, 0, 0, 0);
-        Assert.Equal(expected, color.ToBackgroundAnsi());
+        Assert.AreEqual(expected, color.ToBackgroundAnsi());
     }
 
-    [Theory]
-    [InlineData(0, "\x1b[90m")]   // Bright black
-    [InlineData(1, "\x1b[91m")]   // Bright red
-    [InlineData(4, "\x1b[94m")]   // Bright blue
-    [InlineData(7, "\x1b[97m")]   // Bright white
+    [TestMethod]
+    [DataRow(0, "\x1b[90m")]   // Bright black
+    [DataRow(1, "\x1b[91m")]   // Bright red
+    [DataRow(4, "\x1b[94m")]   // Bright blue
+    [DataRow(7, "\x1b[97m")]   // Bright white
     public void ToForegroundAnsi_BrightColor_EmitsOriginalCode(int index, string expected)
     {
         var color = Hex1bColor.FromBright((byte)index, 0, 0, 0);
-        Assert.Equal(expected, color.ToForegroundAnsi());
+        Assert.AreEqual(expected, color.ToForegroundAnsi());
     }
 
-    [Theory]
-    [InlineData(0, "\x1b[100m")]
-    [InlineData(4, "\x1b[104m")]  // Bright blue background
+    [TestMethod]
+    [DataRow(0, "\x1b[100m")]
+    [DataRow(4, "\x1b[104m")]  // Bright blue background
     public void ToBackgroundAnsi_BrightColor_EmitsOriginalCode(int index, string expected)
     {
         var color = Hex1bColor.FromBright((byte)index, 0, 0, 0);
-        Assert.Equal(expected, color.ToBackgroundAnsi());
+        Assert.AreEqual(expected, color.ToBackgroundAnsi());
     }
 
-    [Fact]
+    [TestMethod]
     public void ToForegroundAnsi_IndexedColor_Emits256Code()
     {
         var color = Hex1bColor.FromIndexed(196, 255, 0, 0);
-        Assert.Equal("\x1b[38;5;196m", color.ToForegroundAnsi());
+        Assert.AreEqual("\x1b[38;5;196m", color.ToForegroundAnsi());
     }
 
-    [Fact]
+    [TestMethod]
     public void ToBackgroundAnsi_IndexedColor_Emits256Code()
     {
         var color = Hex1bColor.FromIndexed(21, 0, 0, 255);
-        Assert.Equal("\x1b[48;5;21m", color.ToBackgroundAnsi());
+        Assert.AreEqual("\x1b[48;5;21m", color.ToBackgroundAnsi());
     }
 
-    [Fact]
+    [TestMethod]
     public void ToForegroundAnsi_RgbColor_Emits24BitCode()
     {
         var color = Hex1bColor.FromRgb(100, 200, 50);
-        Assert.Equal("\x1b[38;2;100;200;50m", color.ToForegroundAnsi());
+        Assert.AreEqual("\x1b[38;2;100;200;50m", color.ToForegroundAnsi());
     }
 
     #endregion
 
     #region Terminal ProcessSgr Preservation
 
-    [Theory]
-    [InlineData("34", Hex1bColorKind.Standard, 4)]     // Blue
-    [InlineData("31", Hex1bColorKind.Standard, 1)]     // Red
-    [InlineData("37", Hex1bColorKind.Standard, 7)]     // White
+    [TestMethod]
+    [DataRow("34", Hex1bColorKind.Standard, 4)]     // Blue
+    [DataRow("31", Hex1bColorKind.Standard, 1)]     // Red
+    [DataRow("37", Hex1bColorKind.Standard, 7)]     // White
     public void ProcessSgr_StandardForeground_PreservesIndex(string sgr, Hex1bColorKind expectedKind, int expectedIndex)
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -139,14 +140,14 @@ public class AnsiColorPreservationTests
         terminal.ApplyTokens([new SgrToken(sgr), new TextToken("X")]);
 
         var cell = terminal.CreateSnapshot().GetCell(0, 0);
-        Assert.NotNull(cell.Foreground);
-        Assert.Equal(expectedKind, cell.Foreground.Value.Kind);
-        Assert.Equal(expectedIndex, cell.Foreground.Value.AnsiIndex);
+        Assert.IsNotNull(cell.Foreground);
+        Assert.AreEqual(expectedKind, cell.Foreground.Value.Kind);
+        Assert.AreEqual(expectedIndex, cell.Foreground.Value.AnsiIndex);
     }
 
-    [Theory]
-    [InlineData("44", Hex1bColorKind.Standard, 4)]     // Blue bg
-    [InlineData("41", Hex1bColorKind.Standard, 1)]     // Red bg
+    [TestMethod]
+    [DataRow("44", Hex1bColorKind.Standard, 4)]     // Blue bg
+    [DataRow("41", Hex1bColorKind.Standard, 1)]     // Red bg
     public void ProcessSgr_StandardBackground_PreservesIndex(string sgr, Hex1bColorKind expectedKind, int expectedIndex)
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -155,14 +156,14 @@ public class AnsiColorPreservationTests
         terminal.ApplyTokens([new SgrToken(sgr), new TextToken("X")]);
 
         var cell = terminal.CreateSnapshot().GetCell(0, 0);
-        Assert.NotNull(cell.Background);
-        Assert.Equal(expectedKind, cell.Background.Value.Kind);
-        Assert.Equal(expectedIndex, cell.Background.Value.AnsiIndex);
+        Assert.IsNotNull(cell.Background);
+        Assert.AreEqual(expectedKind, cell.Background.Value.Kind);
+        Assert.AreEqual(expectedIndex, cell.Background.Value.AnsiIndex);
     }
 
-    [Theory]
-    [InlineData("94", Hex1bColorKind.Bright, 4)]    // Bright blue
-    [InlineData("91", Hex1bColorKind.Bright, 1)]    // Bright red
+    [TestMethod]
+    [DataRow("94", Hex1bColorKind.Bright, 4)]    // Bright blue
+    [DataRow("91", Hex1bColorKind.Bright, 1)]    // Bright red
     public void ProcessSgr_BrightForeground_PreservesIndex(string sgr, Hex1bColorKind expectedKind, int expectedIndex)
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -171,12 +172,12 @@ public class AnsiColorPreservationTests
         terminal.ApplyTokens([new SgrToken(sgr), new TextToken("X")]);
 
         var cell = terminal.CreateSnapshot().GetCell(0, 0);
-        Assert.NotNull(cell.Foreground);
-        Assert.Equal(expectedKind, cell.Foreground.Value.Kind);
-        Assert.Equal(expectedIndex, cell.Foreground.Value.AnsiIndex);
+        Assert.IsNotNull(cell.Foreground);
+        Assert.AreEqual(expectedKind, cell.Foreground.Value.Kind);
+        Assert.AreEqual(expectedIndex, cell.Foreground.Value.AnsiIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void ProcessSgr_256ColorForeground_PreservesIndex()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -185,12 +186,12 @@ public class AnsiColorPreservationTests
         terminal.ApplyTokens([new SgrToken("38;5;196"), new TextToken("X")]);
 
         var cell = terminal.CreateSnapshot().GetCell(0, 0);
-        Assert.NotNull(cell.Foreground);
-        Assert.Equal(Hex1bColorKind.Indexed, cell.Foreground.Value.Kind);
-        Assert.Equal(196, cell.Foreground.Value.AnsiIndex);
+        Assert.IsNotNull(cell.Foreground);
+        Assert.AreEqual(Hex1bColorKind.Indexed, cell.Foreground.Value.Kind);
+        Assert.AreEqual(196, cell.Foreground.Value.AnsiIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void ProcessSgr_24BitRgb_StaysRgbKind()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -199,18 +200,18 @@ public class AnsiColorPreservationTests
         terminal.ApplyTokens([new SgrToken("38;2;100;200;50"), new TextToken("X")]);
 
         var cell = terminal.CreateSnapshot().GetCell(0, 0);
-        Assert.NotNull(cell.Foreground);
-        Assert.Equal(Hex1bColorKind.Rgb, cell.Foreground.Value.Kind);
-        Assert.Equal(100, cell.Foreground.Value.R);
-        Assert.Equal(200, cell.Foreground.Value.G);
-        Assert.Equal(50, cell.Foreground.Value.B);
+        Assert.IsNotNull(cell.Foreground);
+        Assert.AreEqual(Hex1bColorKind.Rgb, cell.Foreground.Value.Kind);
+        Assert.AreEqual(100, cell.Foreground.Value.R);
+        Assert.AreEqual(200, cell.Foreground.Value.G);
+        Assert.AreEqual(50, cell.Foreground.Value.B);
     }
 
     #endregion
 
     #region ToAnsi Round-Trip Preservation
 
-    [Fact]
+    [TestMethod]
     public void ToAnsi_StandardBlue_EmitsOriginalSgrCode()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -227,7 +228,7 @@ public class AnsiColorPreservationTests
         Assert.DoesNotContain("38;2;0;0;128", ansi);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToAnsi_BrightRed_EmitsOriginalSgrCode()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -242,7 +243,7 @@ public class AnsiColorPreservationTests
         Assert.DoesNotContain("38;2;255;0;0", ansi);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToAnsi_256Color_Emits256Code()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -256,7 +257,7 @@ public class AnsiColorPreservationTests
         Assert.Contains("38;5;196", ansi);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToAnsi_24BitRgb_Emits24BitCode()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -274,7 +275,7 @@ public class AnsiColorPreservationTests
 
     #region SurfaceComparer Preservation
 
-    [Fact]
+    [TestMethod]
     public void SurfaceComparer_StandardColor_EmitsOriginalCode()
     {
         var previous = new Surface(10, 1);
@@ -285,13 +286,13 @@ public class AnsiColorPreservationTests
         var tokens = SurfaceComparer.ToTokens(diff);
 
         var sgr = tokens.OfType<SgrToken>().FirstOrDefault();
-        Assert.NotNull(sgr);
+        Assert.IsNotNull(sgr);
         // Should emit "34" (standard blue), not "38;2;0;0;128"
         Assert.Contains("34", sgr.Parameters.Split(';'));
         Assert.DoesNotContain("38;2", sgr.Parameters);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceComparer_BrightColor_EmitsOriginalCode()
     {
         var previous = new Surface(10, 1);
@@ -302,11 +303,11 @@ public class AnsiColorPreservationTests
         var tokens = SurfaceComparer.ToTokens(diff);
 
         var sgr = tokens.OfType<SgrToken>().FirstOrDefault();
-        Assert.NotNull(sgr);
+        Assert.IsNotNull(sgr);
         Assert.Contains("94", sgr.Parameters.Split(';'));
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceComparer_IndexedColor_Emits256Code()
     {
         var previous = new Surface(10, 1);
@@ -317,11 +318,11 @@ public class AnsiColorPreservationTests
         var tokens = SurfaceComparer.ToTokens(diff);
 
         var sgr = tokens.OfType<SgrToken>().FirstOrDefault();
-        Assert.NotNull(sgr);
+        Assert.IsNotNull(sgr);
         Assert.Contains("38;5;196", sgr.Parameters);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceComparer_RgbColor_Emits24BitCode()
     {
         var previous = new Surface(10, 1);
@@ -332,11 +333,11 @@ public class AnsiColorPreservationTests
         var tokens = SurfaceComparer.ToTokens(diff);
 
         var sgr = tokens.OfType<SgrToken>().FirstOrDefault();
-        Assert.NotNull(sgr);
+        Assert.IsNotNull(sgr);
         Assert.Contains("38;2;100;200;50", sgr.Parameters);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceComparer_StandardBackground_EmitsOriginalCode()
     {
         var previous = new Surface(10, 1);
@@ -347,7 +348,7 @@ public class AnsiColorPreservationTests
         var tokens = SurfaceComparer.ToTokens(diff);
 
         var sgr = tokens.OfType<SgrToken>().FirstOrDefault();
-        Assert.NotNull(sgr);
+        Assert.IsNotNull(sgr);
         // Background standard red = SGR 41
         Assert.Contains("41", sgr.Parameters.Split(';'));
     }
@@ -356,7 +357,7 @@ public class AnsiColorPreservationTests
 
     #region Full Pipeline (Terminal → Surface → ANSI Output)
 
-    [Fact]
+    [TestMethod]
     public async Task EmbeddedTerminal_StandardBlue_PreservedThroughSurface()
     {
         // This tests the full rendering pipeline used by EmbeddedTerminalDemo:
@@ -378,9 +379,9 @@ public class AnsiColorPreservationTests
         // Verify the child terminal stores the color with its index
         var childSnapshot = childTerminal.CreateSnapshot();
         var childCell = childSnapshot.GetCell(0, 0);
-        Assert.NotNull(childCell.Foreground);
-        Assert.Equal(Hex1bColorKind.Standard, childCell.Foreground.Value.Kind);
-        Assert.Equal(4, childCell.Foreground.Value.AnsiIndex);
+        Assert.IsNotNull(childCell.Foreground);
+        Assert.AreEqual(Hex1bColorKind.Standard, childCell.Foreground.Value.Kind);
+        Assert.AreEqual(4, childCell.Foreground.Value.AnsiIndex);
 
         // Now verify the ToAnsi output preserves it
         var ansi = childSnapshot.ToAnsi(new TerminalAnsiOptions { IncludeClearScreen = true });
@@ -388,7 +389,7 @@ public class AnsiColorPreservationTests
         Assert.DoesNotContain("38;2;0;0;128", ansi);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceRenderContext_StandardBlue_PreservesColorKind()
     {
         // Test that SurfaceRenderContext's ANSI parser preserves color indices
@@ -402,13 +403,13 @@ public class AnsiColorPreservationTests
 
         // The surface cell should preserve the standard blue index
         var cell = surface[0, 0];
-        Assert.Equal("B", cell.Character);
-        Assert.NotNull(cell.Foreground);
-        Assert.Equal(Hex1bColorKind.Standard, cell.Foreground.Value.Kind);
-        Assert.Equal(4, cell.Foreground.Value.AnsiIndex);
+        Assert.AreEqual("B", cell.Character);
+        Assert.IsNotNull(cell.Foreground);
+        Assert.AreEqual(Hex1bColorKind.Standard, cell.Foreground.Value.Kind);
+        Assert.AreEqual(4, cell.Foreground.Value.AnsiIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceRenderContext_BrightRed_PreservesColorKind()
     {
         var surface = new Surface(20, 1);
@@ -417,12 +418,12 @@ public class AnsiColorPreservationTests
         context.WriteClipped(0, 0, "\x1b[91mRed!");
 
         var cell = surface[0, 0];
-        Assert.NotNull(cell.Foreground);
-        Assert.Equal(Hex1bColorKind.Bright, cell.Foreground.Value.Kind);
-        Assert.Equal(1, cell.Foreground.Value.AnsiIndex);
+        Assert.IsNotNull(cell.Foreground);
+        Assert.AreEqual(Hex1bColorKind.Bright, cell.Foreground.Value.Kind);
+        Assert.AreEqual(1, cell.Foreground.Value.AnsiIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceRenderContext_256Color_PreservesColorKind()
     {
         var surface = new Surface(20, 1);
@@ -431,12 +432,12 @@ public class AnsiColorPreservationTests
         context.WriteClipped(0, 0, "\x1b[38;5;196mRed!");
 
         var cell = surface[0, 0];
-        Assert.NotNull(cell.Foreground);
-        Assert.Equal(Hex1bColorKind.Indexed, cell.Foreground.Value.Kind);
-        Assert.Equal(196, cell.Foreground.Value.AnsiIndex);
+        Assert.IsNotNull(cell.Foreground);
+        Assert.AreEqual(Hex1bColorKind.Indexed, cell.Foreground.Value.Kind);
+        Assert.AreEqual(196, cell.Foreground.Value.AnsiIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceRenderContext_24BitRgb_StaysRgbKind()
     {
         var surface = new Surface(20, 1);
@@ -445,11 +446,11 @@ public class AnsiColorPreservationTests
         context.WriteClipped(0, 0, "\x1b[38;2;100;200;50mGreen!");
 
         var cell = surface[0, 0];
-        Assert.NotNull(cell.Foreground);
-        Assert.Equal(Hex1bColorKind.Rgb, cell.Foreground.Value.Kind);
-        Assert.Equal(100, cell.Foreground.Value.R);
-        Assert.Equal(200, cell.Foreground.Value.G);
-        Assert.Equal(50, cell.Foreground.Value.B);
+        Assert.IsNotNull(cell.Foreground);
+        Assert.AreEqual(Hex1bColorKind.Rgb, cell.Foreground.Value.Kind);
+        Assert.AreEqual(100, cell.Foreground.Value.R);
+        Assert.AreEqual(200, cell.Foreground.Value.G);
+        Assert.AreEqual(50, cell.Foreground.Value.B);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/AnsiTokenApplyTests.cs
+++ b/tests/Hex1b.Tests/AnsiTokenApplyTests.cs
@@ -6,11 +6,12 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for applying ANSI tokens to the terminal buffer.
 /// </summary>
+[TestClass]
 public class AnsiTokenApplyTests
 {
     #region TextToken Tests
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_TextToken_WritesToBuffer()
     {
         // Arrange
@@ -23,10 +24,10 @@ public class AnsiTokenApplyTests
 
         // Assert
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal("Hello", snapshot.GetLine(0).TrimEnd());
+        Assert.AreEqual("Hello", snapshot.GetLine(0).TrimEnd());
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_TextToken_AdvancesCursor()
     {
         // Arrange
@@ -38,11 +39,11 @@ public class AnsiTokenApplyTests
         terminal.ApplyTokens(tokens);
 
         // Assert
-        Assert.Equal(2, terminal.CursorX);
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(2, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_TextToken_WrapsAtEdge()
     {
         // Arrange
@@ -55,15 +56,15 @@ public class AnsiTokenApplyTests
 
         // Assert
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal("Hello", snapshot.GetLine(0));
-        Assert.Equal(" Worl", snapshot.GetLine(1));
+        Assert.AreEqual("Hello", snapshot.GetLine(0));
+        Assert.AreEqual(" Worl", snapshot.GetLine(1));
     }
 
     #endregion
 
     #region ControlCharacterToken Tests
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_NewLine_MovesCursorDown()
     {
         // Arrange
@@ -77,11 +78,11 @@ public class AnsiTokenApplyTests
 
         // Assert
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal('A', snapshot.GetLine(0)[0]);
-        Assert.Equal('B', snapshot.GetLine(1)[0]);
+        Assert.AreEqual('A', snapshot.GetLine(0)[0]);
+        Assert.AreEqual('B', snapshot.GetLine(1)[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_CarriageReturn_MovesCursorToStart()
     {
         // Arrange
@@ -94,10 +95,10 @@ public class AnsiTokenApplyTests
 
         // Assert
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal("XBC", snapshot.GetLine(0).TrimEnd());
+        Assert.AreEqual("XBC", snapshot.GetLine(0).TrimEnd());
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_Tab_MovesToNextTabStop()
     {
         // Arrange
@@ -109,14 +110,14 @@ public class AnsiTokenApplyTests
         terminal.ApplyTokens(tokens);
 
         // Assert
-        Assert.Equal(9, terminal.CursorX); // 'B' written at position 8, cursor at 9
+        Assert.AreEqual(9, terminal.CursorX); // 'B' written at position 8, cursor at 9
     }
 
     #endregion
 
     #region CursorPositionToken Tests
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_CursorPosition_MovesCursor()
     {
         // Arrange
@@ -129,10 +130,10 @@ public class AnsiTokenApplyTests
 
         // Assert
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal('X', snapshot.GetCell(4, 2).Character[0]); // 0-based: col 4, row 2
+        Assert.AreEqual('X', snapshot.GetCell(4, 2).Character[0]); // 0-based: col 4, row 2
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_CursorPosition_ClampsToScreen()
     {
         // Arrange
@@ -144,15 +145,15 @@ public class AnsiTokenApplyTests
         terminal.ApplyTokens(tokens);
 
         // Assert
-        Assert.Equal(4, terminal.CursorY); // 0-based, clamped to height-1
-        Assert.Equal(9, terminal.CursorX); // 0-based, clamped to width-1
+        Assert.AreEqual(4, terminal.CursorY); // 0-based, clamped to height-1
+        Assert.AreEqual(9, terminal.CursorX); // 0-based, clamped to width-1
     }
 
     #endregion
 
     #region SgrToken Tests
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_SgrBold_SetsAttribute()
     {
         // Arrange
@@ -166,10 +167,10 @@ public class AnsiTokenApplyTests
         // Assert
         var snapshot = terminal.CreateSnapshot();
         var cell = snapshot.GetCell(0, 0);
-        Assert.True((cell.Attributes & CellAttributes.Bold) != 0);
+        Assert.IsTrue((cell.Attributes & CellAttributes.Bold) != 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_SgrReset_ClearsAttributes()
     {
         // Arrange
@@ -182,11 +183,11 @@ public class AnsiTokenApplyTests
 
         // Assert
         var snapshot = terminal.CreateSnapshot();
-        Assert.True((snapshot.GetCell(0, 0).Attributes & CellAttributes.Bold) != 0);
-        Assert.True((snapshot.GetCell(1, 0).Attributes & CellAttributes.Bold) == 0);
+        Assert.IsTrue((snapshot.GetCell(0, 0).Attributes & CellAttributes.Bold) != 0);
+        Assert.IsTrue((snapshot.GetCell(1, 0).Attributes & CellAttributes.Bold) == 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_SgrForeground_SetsColor()
     {
         // Arrange
@@ -200,17 +201,17 @@ public class AnsiTokenApplyTests
         // Assert
         var snapshot = terminal.CreateSnapshot();
         var cell = snapshot.GetCell(0, 0);
-        Assert.NotNull(cell.Foreground);
-        Assert.Equal(255, cell.Foreground.Value.R);
-        Assert.Equal(0, cell.Foreground.Value.G);
-        Assert.Equal(0, cell.Foreground.Value.B);
+        Assert.IsNotNull(cell.Foreground);
+        Assert.AreEqual(255, cell.Foreground.Value.R);
+        Assert.AreEqual(0, cell.Foreground.Value.G);
+        Assert.AreEqual(0, cell.Foreground.Value.B);
     }
 
     #endregion
 
     #region ClearScreenToken Tests
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_ClearScreenToEnd_ClearsFromCursor()
     {
         // Arrange
@@ -225,12 +226,12 @@ public class AnsiTokenApplyTests
 
         // Assert
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal("AAAAAAAAAA", snapshot.GetLine(0));
-        Assert.Equal("BBBBB", snapshot.GetLine(1).TrimEnd()); // Cleared from position 5
-        Assert.Equal("", snapshot.GetLine(2).TrimEnd()); // Fully cleared
+        Assert.AreEqual("AAAAAAAAAA", snapshot.GetLine(0));
+        Assert.AreEqual("BBBBB", snapshot.GetLine(1).TrimEnd()); // Cleared from position 5
+        Assert.AreEqual("", snapshot.GetLine(2).TrimEnd()); // Fully cleared
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_ClearScreenAll_ClearsEntireBuffer()
     {
         // Arrange
@@ -241,14 +242,14 @@ public class AnsiTokenApplyTests
 
         // Assert
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal("", snapshot.GetLine(0).TrimEnd());
+        Assert.AreEqual("", snapshot.GetLine(0).TrimEnd());
     }
 
     #endregion
 
     #region ClearLineToken Tests
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_ClearLineToEnd_ClearsFromCursor()
     {
         // Arrange
@@ -259,10 +260,10 @@ public class AnsiTokenApplyTests
 
         // Assert
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal("ABC", snapshot.GetLine(0).TrimEnd());
+        Assert.AreEqual("ABC", snapshot.GetLine(0).TrimEnd());
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_ClearLineAll_ClearsEntireLine()
     {
         // Arrange
@@ -273,14 +274,14 @@ public class AnsiTokenApplyTests
 
         // Assert
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal("", snapshot.GetLine(0).TrimEnd());
+        Assert.AreEqual("", snapshot.GetLine(0).TrimEnd());
     }
 
     #endregion
 
     #region PrivateModeToken Tests
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_AlternateScreenEnable_EntersAlternateScreen()
     {
         // Arrange
@@ -292,12 +293,12 @@ public class AnsiTokenApplyTests
         terminal.ApplyTokens(new AnsiToken[] { new PrivateModeToken(1049, true) });
 
         // Assert
-        Assert.True(terminal.InAlternateScreen);
+        Assert.IsTrue(terminal.InAlternateScreen);
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal("", snapshot.GetLine(0).TrimEnd()); // Alt screen is blank
+        Assert.AreEqual("", snapshot.GetLine(0).TrimEnd()); // Alt screen is blank
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_AlternateScreenDisable_ExitsAlternateScreen()
     {
         // Arrange
@@ -309,10 +310,10 @@ public class AnsiTokenApplyTests
         terminal.ApplyTokens(new AnsiToken[] { new PrivateModeToken(1049, false) });
 
         // Assert
-        Assert.False(terminal.InAlternateScreen);
+        Assert.IsFalse(terminal.InAlternateScreen);
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_AlternateScreen_SavesAndRestoresCursorPosition()
     {
         // Arrange
@@ -334,23 +335,23 @@ public class AnsiTokenApplyTests
         terminal.ApplyTokens(new AnsiToken[] { new PrivateModeToken(1049, true) });
         
         // Verify cursor position is preserved from primary screen
-        Assert.Equal(cursorXBeforeAltScreen, terminal.CursorX);
-        Assert.Equal(cursorYBeforeAltScreen, terminal.CursorY);
+        Assert.AreEqual(cursorXBeforeAltScreen, terminal.CursorX);
+        Assert.AreEqual(cursorYBeforeAltScreen, terminal.CursorY);
         
         // Move cursor in alternate screen
         terminal.ApplyTokens(new AnsiToken[] { new CursorPositionToken(3, 5) });
-        Assert.Equal(4, terminal.CursorX); // 0-based
-        Assert.Equal(2, terminal.CursorY); // 0-based
+        Assert.AreEqual(4, terminal.CursorX); // 0-based
+        Assert.AreEqual(2, terminal.CursorY); // 0-based
         
         // Exit alternate screen
         terminal.ApplyTokens(new AnsiToken[] { new PrivateModeToken(1049, false) });
         
         // Assert - Cursor should be restored to position before entering alt screen
-        Assert.Equal(cursorXBeforeAltScreen, terminal.CursorX);
-        Assert.Equal(cursorYBeforeAltScreen, terminal.CursorY);
+        Assert.AreEqual(cursorXBeforeAltScreen, terminal.CursorX);
+        Assert.AreEqual(cursorYBeforeAltScreen, terminal.CursorY);
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_AlternateScreen_SavesAndRestoresMainScreenBuffer()
     {
         // Arrange
@@ -380,7 +381,7 @@ public class AnsiTokenApplyTests
         Assert.StartsWith("Main Screen", restoredText);
     }
     
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_AlternateScreen_ExitWithoutEnter_DoesNotClearScreen()
     {
         // Arrange - create terminal with content
@@ -393,8 +394,8 @@ public class AnsiTokenApplyTests
         
         // Save original cursor position
         terminal.ApplyTokens(new AnsiToken[] { new CursorPositionToken(3, 10) });
-        Assert.Equal(9, terminal.CursorX); // 0-based
-        Assert.Equal(2, terminal.CursorY); // 0-based
+        Assert.AreEqual(9, terminal.CursorX); // 0-based
+        Assert.AreEqual(2, terminal.CursorY); // 0-based
         
         // Act - Exit alternate screen WITHOUT having entered it
         // This should NOT clear the screen or change cursor position
@@ -405,11 +406,11 @@ public class AnsiTokenApplyTests
         Assert.StartsWith("Important Data", afterText);
         
         // Cursor position should also be preserved
-        Assert.Equal(9, terminal.CursorX);
-        Assert.Equal(2, terminal.CursorY);
+        Assert.AreEqual(9, terminal.CursorX);
+        Assert.AreEqual(2, terminal.CursorY);
     }
     
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_AlternateScreen_SeparateCursorSaveFromDECSC()
     {
         // Arrange - verify alternate screen cursor save doesn't conflict with DECSC
@@ -430,31 +431,31 @@ public class AnsiTokenApplyTests
         terminal.ApplyTokens(new AnsiToken[] { new PrivateModeToken(1049, true) });
         
         // Cursor position is preserved from primary screen on alt screen entry
-        Assert.Equal(14, terminal.CursorX);
-        Assert.Equal(5, terminal.CursorY);
+        Assert.AreEqual(14, terminal.CursorX);
+        Assert.AreEqual(5, terminal.CursorY);
         
         // Move cursor in alternate screen
         terminal.ApplyTokens(new AnsiToken[] { new CursorPositionToken(4, 10) }); // y=3, x=9
         
         // Use DECRC to restore the DECSC position (should be 4, 1 from before)
         terminal.ApplyTokens(new AnsiToken[] { new RestoreCursorToken(true) });
-        Assert.Equal(4, terminal.CursorX); // from DECSC
-        Assert.Equal(1, terminal.CursorY); // from DECSC
+        Assert.AreEqual(4, terminal.CursorX); // from DECSC
+        Assert.AreEqual(1, terminal.CursorY); // from DECSC
         
         // Exit alternate screen
         terminal.ApplyTokens(new AnsiToken[] { new PrivateModeToken(1049, false) });
         
         // Cursor should be restored to position when we ENTERED alternate screen (5, 14 -> y=5, x=14)
         // NOT the DECSC position
-        Assert.Equal(14, terminal.CursorX);
-        Assert.Equal(5, terminal.CursorY);
+        Assert.AreEqual(14, terminal.CursorX);
+        Assert.AreEqual(5, terminal.CursorY);
     }
 
     #endregion
 
     #region SaveCursor / RestoreCursor Tests
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_SaveAndRestoreCursor_PreservesPosition()
     {
         // Arrange
@@ -471,15 +472,15 @@ public class AnsiTokenApplyTests
         });
 
         // Assert
-        Assert.Equal(9, terminal.CursorX); // 0-based from column 10
-        Assert.Equal(4, terminal.CursorY); // 0-based from row 5
+        Assert.AreEqual(9, terminal.CursorX); // 0-based from column 10
+        Assert.AreEqual(4, terminal.CursorY); // 0-based from row 5
     }
 
     #endregion
 
     #region Round-trip Tests
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_RoundTrip_TokenizeAndApply_ProducesExpectedResult()
     {
         // Arrange - complex ANSI sequence
@@ -494,11 +495,11 @@ public class AnsiTokenApplyTests
 
         // Assert - buffer should have expected content
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal("Hello World", snapshot.GetLine(0).TrimEnd());
-        Assert.Equal("Line 2", snapshot.GetLine(1).TrimEnd());
+        Assert.AreEqual("Hello World", snapshot.GetLine(0).TrimEnd());
+        Assert.AreEqual("Line 2", snapshot.GetLine(1).TrimEnd());
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_ComplexSequence_AppliesCorrectly()
     {
         // Arrange
@@ -512,18 +513,18 @@ public class AnsiTokenApplyTests
 
         // Assert
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal("Orange Bold Italic", snapshot.GetLine(0).TrimEnd());
+        Assert.AreEqual("Orange Bold Italic", snapshot.GetLine(0).TrimEnd());
         
         // Check cell attributes
         var cell = snapshot.GetCell(0, 0);
-        Assert.Equal(Hex1bColor.FromRgb(255, 128, 64), cell.Foreground);
+        Assert.AreEqual(Hex1bColor.FromRgb(255, 128, 64), cell.Foreground);
     }
 
     #endregion
 
     #region Edge Cases
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_EmptyList_DoesNothing()
     {
         // Arrange
@@ -534,11 +535,11 @@ public class AnsiTokenApplyTests
         terminal.ApplyTokens(Array.Empty<AnsiToken>());
 
         // Assert - no crash, cursor at origin
-        Assert.Equal(0, terminal.CursorX);
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplyTokens_UnrecognizedSequence_Ignored()
     {
         // Arrange
@@ -551,7 +552,7 @@ public class AnsiTokenApplyTests
 
         // Assert
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal("OK", snapshot.GetLine(0).TrimEnd());
+        Assert.AreEqual("OK", snapshot.GetLine(0).TrimEnd());
     }
 
     #endregion

--- a/tests/Hex1b.Tests/AnsiTokenSerializerTests.cs
+++ b/tests/Hex1b.Tests/AnsiTokenSerializerTests.cs
@@ -2,360 +2,361 @@ using Hex1b.Tokens;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class AnsiTokenSerializerTests
 {
     #region TextToken Tests
 
-    [Fact]
+    [TestMethod]
     public void Serialize_TextToken_ReturnsText()
     {
         var token = new TextToken("Hello, World!");
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("Hello, World!", result);
+        Assert.AreEqual("Hello, World!", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_TextTokenWithUnicode_PreservesText()
     {
         var token = new TextToken("Hello 👨‍👩‍👧 World");
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("Hello 👨‍👩‍👧 World", result);
+        Assert.AreEqual("Hello 👨‍👩‍👧 World", result);
     }
 
     #endregion
 
     #region ControlCharacterToken Tests
 
-    [Fact]
+    [TestMethod]
     public void Serialize_LineFeed_ReturnsNewline()
     {
         var result = AnsiTokenSerializer.Serialize(ControlCharacterToken.LineFeed);
-        Assert.Equal("\n", result);
+        Assert.AreEqual("\n", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_CarriageReturn_ReturnsCarriageReturn()
     {
         var result = AnsiTokenSerializer.Serialize(ControlCharacterToken.CarriageReturn);
-        Assert.Equal("\r", result);
+        Assert.AreEqual("\r", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_Tab_ReturnsTab()
     {
         var result = AnsiTokenSerializer.Serialize(ControlCharacterToken.Tab);
-        Assert.Equal("\t", result);
+        Assert.AreEqual("\t", result);
     }
 
     #endregion
 
     #region SgrToken Tests
 
-    [Fact]
+    [TestMethod]
     public void Serialize_SgrReset_ReturnsResetSequence()
     {
         var token = new SgrToken("0");
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b[0m", result);
+        Assert.AreEqual("\x1b[0m", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_SgrEmpty_ReturnsEmptyParams()
     {
         var token = new SgrToken("");
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b[m", result);
+        Assert.AreEqual("\x1b[m", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_SgrBold_ReturnsBoldSequence()
     {
         var token = new SgrToken("1");
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b[1m", result);
+        Assert.AreEqual("\x1b[1m", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_SgrMultipleParams_PreservesParams()
     {
         var token = new SgrToken("1;31;42");
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b[1;31;42m", result);
+        Assert.AreEqual("\x1b[1;31;42m", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_SgrRgbColor_PreservesParams()
     {
         var token = new SgrToken("38;2;255;128;64");
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b[38;2;255;128;64m", result);
+        Assert.AreEqual("\x1b[38;2;255;128;64m", result);
     }
 
     #endregion
 
     #region CursorPositionToken Tests
 
-    [Fact]
+    [TestMethod]
     public void Serialize_CursorPositionDefault_ReturnsOptimized()
     {
         var token = new CursorPositionToken(1, 1);
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b[H", result);
+        Assert.AreEqual("\x1b[H", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_CursorPositionRowOnly_ReturnsOptimized()
     {
         var token = new CursorPositionToken(5, 1);
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b[5H", result);
+        Assert.AreEqual("\x1b[5H", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_CursorPositionFull_ReturnsBothParams()
     {
         var token = new CursorPositionToken(10, 20);
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b[10;20H", result);
+        Assert.AreEqual("\x1b[10;20H", result);
     }
 
     #endregion
 
     #region CursorShapeToken Tests
 
-    [Fact]
+    [TestMethod]
     public void Serialize_CursorShapeDefault_ReturnsDefaultSequence()
     {
         var result = AnsiTokenSerializer.Serialize(CursorShapeToken.Default);
-        Assert.Equal("\x1b[0 q", result);
+        Assert.AreEqual("\x1b[0 q", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_CursorShapeBlinkingBlock_ReturnsCorrectSequence()
     {
         var result = AnsiTokenSerializer.Serialize(CursorShapeToken.BlinkingBlock);
-        Assert.Equal("\x1b[1 q", result);
+        Assert.AreEqual("\x1b[1 q", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_CursorShapeSteadyBar_ReturnsCorrectSequence()
     {
         var result = AnsiTokenSerializer.Serialize(CursorShapeToken.SteadyBar);
-        Assert.Equal("\x1b[6 q", result);
+        Assert.AreEqual("\x1b[6 q", result);
     }
 
     #endregion
 
     #region ClearScreenToken Tests
 
-    [Fact]
+    [TestMethod]
     public void Serialize_ClearScreenToEnd_ReturnsOptimized()
     {
         var token = new ClearScreenToken(ClearMode.ToEnd);
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b[J", result);
+        Assert.AreEqual("\x1b[J", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_ClearScreenToStart_ReturnsWithParam()
     {
         var token = new ClearScreenToken(ClearMode.ToStart);
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b[1J", result);
+        Assert.AreEqual("\x1b[1J", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_ClearScreenAll_ReturnsWithParam()
     {
         var token = new ClearScreenToken(ClearMode.All);
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b[2J", result);
+        Assert.AreEqual("\x1b[2J", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_ClearScreenAllAndScrollback_ReturnsWithParam()
     {
         var token = new ClearScreenToken(ClearMode.AllAndScrollback);
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b[3J", result);
+        Assert.AreEqual("\x1b[3J", result);
     }
 
     #endregion
 
     #region ClearLineToken Tests
 
-    [Fact]
+    [TestMethod]
     public void Serialize_ClearLineToEnd_ReturnsOptimized()
     {
         var token = new ClearLineToken(ClearMode.ToEnd);
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b[K", result);
+        Assert.AreEqual("\x1b[K", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_ClearLineToStart_ReturnsWithParam()
     {
         var token = new ClearLineToken(ClearMode.ToStart);
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b[1K", result);
+        Assert.AreEqual("\x1b[1K", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_ClearLineAll_ReturnsWithParam()
     {
         var token = new ClearLineToken(ClearMode.All);
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b[2K", result);
+        Assert.AreEqual("\x1b[2K", result);
     }
 
     #endregion
 
     #region ScrollRegionToken Tests
 
-    [Fact]
+    [TestMethod]
     public void Serialize_ScrollRegionReset_ReturnsResetSequence()
     {
         var result = AnsiTokenSerializer.Serialize(ScrollRegionToken.Reset);
-        Assert.Equal("\x1b[r", result);
+        Assert.AreEqual("\x1b[r", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_ScrollRegionExplicit_ReturnsWithParams()
     {
         var token = new ScrollRegionToken(5, 20);
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b[5;20r", result);
+        Assert.AreEqual("\x1b[5;20r", result);
     }
 
     #endregion
 
     #region SaveCursorToken Tests
 
-    [Fact]
+    [TestMethod]
     public void Serialize_SaveCursorDec_ReturnsDecSequence()
     {
         var result = AnsiTokenSerializer.Serialize(SaveCursorToken.Dec);
-        Assert.Equal("\x1b" + "7", result);
+        Assert.AreEqual("\x1b" + "7", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_SaveCursorAnsi_ReturnsAnsiSequence()
     {
         var result = AnsiTokenSerializer.Serialize(SaveCursorToken.Ansi);
-        Assert.Equal("\x1b[s", result);
+        Assert.AreEqual("\x1b[s", result);
     }
 
     #endregion
 
     #region RestoreCursorToken Tests
 
-    [Fact]
+    [TestMethod]
     public void Serialize_RestoreCursorDec_ReturnsDecSequence()
     {
         var result = AnsiTokenSerializer.Serialize(RestoreCursorToken.Dec);
-        Assert.Equal("\x1b" + "8", result);
+        Assert.AreEqual("\x1b" + "8", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_RestoreCursorAnsi_ReturnsAnsiSequence()
     {
         var result = AnsiTokenSerializer.Serialize(RestoreCursorToken.Ansi);
-        Assert.Equal("\x1b[u", result);
+        Assert.AreEqual("\x1b[u", result);
     }
 
     #endregion
 
     #region PrivateModeToken Tests
 
-    [Fact]
+    [TestMethod]
     public void Serialize_PrivateModeEnable_ReturnsEnableSequence()
     {
         var token = new PrivateModeToken(1049, true);
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b[?1049h", result);
+        Assert.AreEqual("\x1b[?1049h", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_PrivateModeDisable_ReturnsDisableSequence()
     {
         var token = new PrivateModeToken(1049, false);
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b[?1049l", result);
+        Assert.AreEqual("\x1b[?1049l", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_PrivateModeCursorHide_ReturnsCorrectSequence()
     {
         var token = new PrivateModeToken(25, false);
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b[?25l", result);
+        Assert.AreEqual("\x1b[?25l", result);
     }
 
     #endregion
 
     #region OscToken Tests
 
-    [Fact]
+    [TestMethod]
     public void Serialize_OscHyperlink_ReturnsHyperlinkSequence()
     {
         var token = new OscToken("8", "", "https://example.com");
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b]8;;https://example.com\x07", result);
+        Assert.AreEqual("\x1b]8;;https://example.com\x07", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_OscHyperlinkWithParams_IncludesParams()
     {
         var token = new OscToken("8", "id=mylink", "https://example.com");
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b]8;id=mylink;https://example.com\x07", result);
+        Assert.AreEqual("\x1b]8;id=mylink;https://example.com\x07", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_OscHyperlinkEnd_ReturnsEndSequence()
     {
         var token = new OscToken("8", "", "");
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b]8;;\x07", result);
+        Assert.AreEqual("\x1b]8;;\x07", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_OscWindowTitle_ReturnsCorrectSequence()
     {
         var token = new OscToken("0", "", "My Window Title");
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b]0;My Window Title\x07", result);
+        Assert.AreEqual("\x1b]0;My Window Title\x07", result);
     }
 
     #endregion
 
     #region DcsToken Tests
 
-    [Fact]
+    [TestMethod]
     public void Serialize_DcsSequence_ReturnsDcsWithSt()
     {
         var token = new DcsToken("q#0;2;0;0;0");
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1bPq#0;2;0;0;0\x1b\\", result);
+        Assert.AreEqual("\x1bPq#0;2;0;0;0\x1b\\", result);
     }
 
     #endregion
 
     #region UnrecognizedSequenceToken Tests
 
-    [Fact]
+    [TestMethod]
     public void Serialize_UnrecognizedSequence_ReturnsRawSequence()
     {
         var token = new UnrecognizedSequenceToken("\x1b[5Z");
         var result = AnsiTokenSerializer.Serialize(token);
-        Assert.Equal("\x1b[5Z", result);
+        Assert.AreEqual("\x1b[5Z", result);
     }
 
     #endregion
 
     #region Multi-Token Tests
 
-    [Fact]
+    [TestMethod]
     public void Serialize_MultipleTokens_ConcatenatesResults()
     {
         var tokens = new AnsiToken[]
@@ -366,17 +367,17 @@ public class AnsiTokenSerializerTests
         };
 
         var result = AnsiTokenSerializer.Serialize(tokens);
-        Assert.Equal("\x1b[31mHello\x1b[0m", result);
+        Assert.AreEqual("\x1b[31mHello\x1b[0m", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_EmptyList_ReturnsEmptyString()
     {
         var result = AnsiTokenSerializer.Serialize(Array.Empty<AnsiToken>());
-        Assert.Equal("", result);
+        Assert.AreEqual("", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_ComplexSequence_ProducesValidOutput()
     {
         var tokens = new AnsiToken[]
@@ -391,30 +392,30 @@ public class AnsiTokenSerializerTests
         };
 
         var result = AnsiTokenSerializer.Serialize(tokens);
-        Assert.Equal("\x1b[?1049h\x1b[2J\x1b[H\x1b[1;32mWelcome!\x1b[0m\n", result);
+        Assert.AreEqual("\x1b[?1049h\x1b[2J\x1b[H\x1b[1;32mWelcome!\x1b[0m\n", result);
     }
 
     #endregion
 
     #region Round-Trip Tests
 
-    [Theory]
-    [InlineData("Hello, World!")]
-    [InlineData("\x1b[31mRed\x1b[0m")]
-    [InlineData("\x1b[H")]
-    [InlineData("\x1b[10;20H")]
-    [InlineData("\x1b[2J")]
-    [InlineData("\x1b[K")]
-    [InlineData("\x1b[?1049h")]
-    [InlineData("\x1b[?25l")]
+    [TestMethod]
+    [DataRow("Hello, World!")]
+    [DataRow("\x1b[31mRed\x1b[0m")]
+    [DataRow("\x1b[H")]
+    [DataRow("\x1b[10;20H")]
+    [DataRow("\x1b[2J")]
+    [DataRow("\x1b[K")]
+    [DataRow("\x1b[?1049h")]
+    [DataRow("\x1b[?25l")]
     public void RoundTrip_TokenizeAndSerialize_ProducesEquivalentOutput(string input)
     {
         var tokens = AnsiTokenizer.Tokenize(input);
         var output = AnsiTokenSerializer.Serialize(tokens);
-        Assert.Equal(input, output);
+        Assert.AreEqual(input, output);
     }
 
-    [Fact]
+    [TestMethod]
     public void RoundTrip_ComplexAnsiSequence_PreservesSemantics()
     {
         // Note: The round-trip might not produce identical output due to optimizations,
@@ -424,14 +425,14 @@ public class AnsiTokenSerializerTests
         var output = AnsiTokenSerializer.Serialize(tokens);
         var retokenized = AnsiTokenizer.Tokenize(output);
 
-        Assert.Equal(tokens.Count, retokenized.Count);
+        Assert.AreEqual(tokens.Count, retokenized.Count);
         for (int i = 0; i < tokens.Count; i++)
         {
-            Assert.Equal(tokens[i], retokenized[i]);
+            Assert.AreEqual(tokens[i], retokenized[i]);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void RoundTrip_HyperlinkSequence_PreservesPayload()
     {
         var input = "\x1b]8;;https://example.com\x07" + "Click\x1b]8;;\x07";
@@ -439,18 +440,18 @@ public class AnsiTokenSerializerTests
         var output = AnsiTokenSerializer.Serialize(tokens);
         var retokenized = AnsiTokenizer.Tokenize(output);
 
-        Assert.Equal(3, retokenized.Count);
+        Assert.AreEqual(3, retokenized.Count);
 
-        var startLink = Assert.IsType<OscToken>(retokenized[0]);
-        Assert.Equal("8", startLink.Command);
-        Assert.Equal("https://example.com", startLink.Payload);
+        var startLink = TestSeq.IsType<OscToken>(retokenized[0]);
+        Assert.AreEqual("8", startLink.Command);
+        Assert.AreEqual("https://example.com", startLink.Payload);
 
-        var text = Assert.IsType<TextToken>(retokenized[1]);
-        Assert.Equal("Click", text.Text);
+        var text = TestSeq.IsType<TextToken>(retokenized[1]);
+        Assert.AreEqual("Click", text.Text);
 
-        var endLink = Assert.IsType<OscToken>(retokenized[2]);
-        Assert.Equal("8", endLink.Command);
-        Assert.Equal("", endLink.Payload);
+        var endLink = TestSeq.IsType<OscToken>(retokenized[2]);
+        Assert.AreEqual("8", endLink.Command);
+        Assert.AreEqual("", endLink.Payload);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/AnsiTokenTests.cs
+++ b/tests/Hex1b.Tests/AnsiTokenTests.cs
@@ -5,181 +5,182 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for ANSI token types.
 /// </summary>
+[TestClass]
 public class AnsiTokenTests
 {
     // ===================
     // TextToken Tests
     // ===================
 
-    [Fact]
+    [TestMethod]
     public void TextToken_StoresText()
     {
         var token = new TextToken("Hello");
-        Assert.Equal("Hello", token.Text);
+        Assert.AreEqual("Hello", token.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void TextToken_SupportsGraphemeClusters()
     {
         // Emoji with skin tone modifier (multiple code points, single grapheme)
         var token = new TextToken("👋🏽");
-        Assert.Equal("👋🏽", token.Text);
+        Assert.AreEqual("👋🏽", token.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void TextToken_Equality()
     {
         var token1 = new TextToken("Hello");
         var token2 = new TextToken("Hello");
         var token3 = new TextToken("World");
 
-        Assert.Equal(token1, token2);
-        Assert.NotEqual(token1, token3);
+        Assert.AreEqual(token1, token2);
+        Assert.AreNotEqual(token1, token3);
     }
 
     // ===================
     // ControlCharacterToken Tests
     // ===================
 
-    [Fact]
+    [TestMethod]
     public void ControlCharacterToken_StoresCharacter()
     {
         var token = new ControlCharacterToken('\n');
-        Assert.Equal('\n', token.Character);
+        Assert.AreEqual('\n', token.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void ControlCharacterToken_StaticInstances()
     {
-        Assert.Equal('\r', ControlCharacterToken.CarriageReturn.Character);
-        Assert.Equal('\n', ControlCharacterToken.LineFeed.Character);
-        Assert.Equal('\t', ControlCharacterToken.Tab.Character);
+        Assert.AreEqual('\r', ControlCharacterToken.CarriageReturn.Character);
+        Assert.AreEqual('\n', ControlCharacterToken.LineFeed.Character);
+        Assert.AreEqual('\t', ControlCharacterToken.Tab.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void ControlCharacterToken_StaticInstancesAreEqual()
     {
         // Static instances should equal newly created ones
-        Assert.Equal(ControlCharacterToken.LineFeed, new ControlCharacterToken('\n'));
-        Assert.Equal(ControlCharacterToken.CarriageReturn, new ControlCharacterToken('\r'));
+        Assert.AreEqual(ControlCharacterToken.LineFeed, new ControlCharacterToken('\n'));
+        Assert.AreEqual(ControlCharacterToken.CarriageReturn, new ControlCharacterToken('\r'));
     }
 
     // ===================
     // CursorPositionToken Tests
     // ===================
 
-    [Fact]
+    [TestMethod]
     public void CursorPositionToken_DefaultsToTopLeft()
     {
         var token = new CursorPositionToken();
-        Assert.Equal(1, token.Row);
-        Assert.Equal(1, token.Column);
+        Assert.AreEqual(1, token.Row);
+        Assert.AreEqual(1, token.Column);
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorPositionToken_StoresPosition()
     {
         var token = new CursorPositionToken(5, 10);
-        Assert.Equal(5, token.Row);
-        Assert.Equal(10, token.Column);
+        Assert.AreEqual(5, token.Row);
+        Assert.AreEqual(10, token.Column);
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorPositionToken_Equality()
     {
         var token1 = new CursorPositionToken(5, 10);
         var token2 = new CursorPositionToken(5, 10);
         var token3 = new CursorPositionToken(5, 11);
 
-        Assert.Equal(token1, token2);
-        Assert.NotEqual(token1, token3);
+        Assert.AreEqual(token1, token2);
+        Assert.AreNotEqual(token1, token3);
     }
 
     // ===================
     // SgrToken Tests
     // ===================
 
-    [Fact]
+    [TestMethod]
     public void SgrToken_StoresParameters()
     {
         var token = new SgrToken("1;38;2;255;0;0");
-        Assert.Equal("1;38;2;255;0;0", token.Parameters);
+        Assert.AreEqual("1;38;2;255;0;0", token.Parameters);
     }
 
-    [Fact]
+    [TestMethod]
     public void SgrToken_ResetInstance()
     {
-        Assert.Equal("", SgrToken.Reset.Parameters);
+        Assert.AreEqual("", SgrToken.Reset.Parameters);
     }
 
-    [Fact]
+    [TestMethod]
     public void SgrToken_ResetEqualsEmptyParameters()
     {
-        Assert.Equal(SgrToken.Reset, new SgrToken(""));
+        Assert.AreEqual(SgrToken.Reset, new SgrToken(""));
     }
 
-    [Fact]
+    [TestMethod]
     public void SgrToken_Equality()
     {
         var token1 = new SgrToken("1");
         var token2 = new SgrToken("1");
         var token3 = new SgrToken("0");
 
-        Assert.Equal(token1, token2);
-        Assert.NotEqual(token1, token3);
+        Assert.AreEqual(token1, token2);
+        Assert.AreNotEqual(token1, token3);
     }
 
     // ===================
     // ClearScreenToken Tests
     // ===================
 
-    [Fact]
+    [TestMethod]
     public void ClearScreenToken_DefaultsToToEnd()
     {
         var token = new ClearScreenToken();
-        Assert.Equal(ClearMode.ToEnd, token.Mode);
+        Assert.AreEqual(ClearMode.ToEnd, token.Mode);
     }
 
-    [Theory]
-    [InlineData(ClearMode.ToEnd)]
-    [InlineData(ClearMode.ToStart)]
-    [InlineData(ClearMode.All)]
-    [InlineData(ClearMode.AllAndScrollback)]
+    [TestMethod]
+    [DataRow(ClearMode.ToEnd)]
+    [DataRow(ClearMode.ToStart)]
+    [DataRow(ClearMode.All)]
+    [DataRow(ClearMode.AllAndScrollback)]
     public void ClearScreenToken_StoresMode(ClearMode mode)
     {
         var token = new ClearScreenToken(mode);
-        Assert.Equal(mode, token.Mode);
+        Assert.AreEqual(mode, token.Mode);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClearScreenToken_Equality()
     {
         var token1 = new ClearScreenToken(ClearMode.All);
         var token2 = new ClearScreenToken(ClearMode.All);
         var token3 = new ClearScreenToken(ClearMode.ToEnd);
 
-        Assert.Equal(token1, token2);
-        Assert.NotEqual(token1, token3);
+        Assert.AreEqual(token1, token2);
+        Assert.AreNotEqual(token1, token3);
     }
 
     // ===================
     // PrivateModeToken Tests
     // ===================
 
-    [Fact]
+    [TestMethod]
     public void PrivateModeToken_StoresModeAndEnable()
     {
         var enableToken = new PrivateModeToken(1049, true);
         var disableToken = new PrivateModeToken(1049, false);
 
-        Assert.Equal(1049, enableToken.Mode);
-        Assert.True(enableToken.Enable);
+        Assert.AreEqual(1049, enableToken.Mode);
+        Assert.IsTrue(enableToken.Enable);
         
-        Assert.Equal(1049, disableToken.Mode);
-        Assert.False(disableToken.Enable);
+        Assert.AreEqual(1049, disableToken.Mode);
+        Assert.IsFalse(disableToken.Enable);
     }
 
-    [Fact]
+    [TestMethod]
     public void PrivateModeToken_Equality()
     {
         var token1 = new PrivateModeToken(1049, true);
@@ -187,259 +188,259 @@ public class AnsiTokenTests
         var token3 = new PrivateModeToken(1049, false);
         var token4 = new PrivateModeToken(25, true);
 
-        Assert.Equal(token1, token2);
-        Assert.NotEqual(token1, token3);  // Different enable
-        Assert.NotEqual(token1, token4);  // Different mode
+        Assert.AreEqual(token1, token2);
+        Assert.AreNotEqual(token1, token3);  // Different enable
+        Assert.AreNotEqual(token1, token4);  // Different mode
     }
 
     // ===================
     // OscToken Tests
     // ===================
 
-    [Fact]
+    [TestMethod]
     public void OscToken_StoresAllParts()
     {
         var token = new OscToken("8", "id=link1", "https://example.com");
         
-        Assert.Equal("8", token.Command);
-        Assert.Equal("id=link1", token.Parameters);
-        Assert.Equal("https://example.com", token.Payload);
+        Assert.AreEqual("8", token.Command);
+        Assert.AreEqual("id=link1", token.Parameters);
+        Assert.AreEqual("https://example.com", token.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void OscToken_EmptyPartsAllowed()
     {
         var token = new OscToken("8", "", "https://example.com");
         
-        Assert.Equal("8", token.Command);
-        Assert.Equal("", token.Parameters);
-        Assert.Equal("https://example.com", token.Payload);
+        Assert.AreEqual("8", token.Command);
+        Assert.AreEqual("", token.Parameters);
+        Assert.AreEqual("https://example.com", token.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void OscToken_Equality()
     {
         var token1 = new OscToken("8", "", "https://example.com");
         var token2 = new OscToken("8", "", "https://example.com");
         var token3 = new OscToken("8", "", "https://other.com");
 
-        Assert.Equal(token1, token2);
-        Assert.NotEqual(token1, token3);
+        Assert.AreEqual(token1, token2);
+        Assert.AreNotEqual(token1, token3);
     }
 
     // ===================
     // DcsToken Tests
     // ===================
 
-    [Fact]
+    [TestMethod]
     public void DcsToken_StoresPayload()
     {
         var sixelPayload = "\x1bPq#0;2;0;0;0~-\x1b\\";
         var token = new DcsToken(sixelPayload);
         
-        Assert.Equal(sixelPayload, token.Payload);
+        Assert.AreEqual(sixelPayload, token.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void DcsToken_Equality()
     {
         var token1 = new DcsToken("\x1bPq~\x1b\\");
         var token2 = new DcsToken("\x1bPq~\x1b\\");
         var token3 = new DcsToken("\x1bPq-\x1b\\");
 
-        Assert.Equal(token1, token2);
-        Assert.NotEqual(token1, token3);
+        Assert.AreEqual(token1, token2);
+        Assert.AreNotEqual(token1, token3);
     }
 
     // ===================
     // UnrecognizedSequenceToken Tests
     // ===================
 
-    [Fact]
+    [TestMethod]
     public void UnrecognizedSequenceToken_StoresSequence()
     {
         var token = new UnrecognizedSequenceToken("\x1b[?999z");
-        Assert.Equal("\x1b[?999z", token.Sequence);
+        Assert.AreEqual("\x1b[?999z", token.Sequence);
     }
 
-    [Fact]
+    [TestMethod]
     public void UnrecognizedSequenceToken_Equality()
     {
         var token1 = new UnrecognizedSequenceToken("\x1b[?1z");
         var token2 = new UnrecognizedSequenceToken("\x1b[?1z");
         var token3 = new UnrecognizedSequenceToken("\x1b[?2z");
 
-        Assert.Equal(token1, token2);
-        Assert.NotEqual(token1, token3);
+        Assert.AreEqual(token1, token2);
+        Assert.AreNotEqual(token1, token3);
     }
 
     // ===================
     // ClearLineToken Tests
     // ===================
 
-    [Fact]
+    [TestMethod]
     public void ClearLineToken_DefaultsToToEnd()
     {
         var token = new ClearLineToken();
-        Assert.Equal(ClearMode.ToEnd, token.Mode);
+        Assert.AreEqual(ClearMode.ToEnd, token.Mode);
     }
 
-    [Theory]
-    [InlineData(ClearMode.ToEnd)]
-    [InlineData(ClearMode.ToStart)]
-    [InlineData(ClearMode.All)]
+    [TestMethod]
+    [DataRow(ClearMode.ToEnd)]
+    [DataRow(ClearMode.ToStart)]
+    [DataRow(ClearMode.All)]
     public void ClearLineToken_StoresMode(ClearMode mode)
     {
         var token = new ClearLineToken(mode);
-        Assert.Equal(mode, token.Mode);
+        Assert.AreEqual(mode, token.Mode);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClearLineToken_Equality()
     {
         var token1 = new ClearLineToken(ClearMode.All);
         var token2 = new ClearLineToken(ClearMode.All);
         var token3 = new ClearLineToken(ClearMode.ToEnd);
 
-        Assert.Equal(token1, token2);
-        Assert.NotEqual(token1, token3);
+        Assert.AreEqual(token1, token2);
+        Assert.AreNotEqual(token1, token3);
     }
 
     // ===================
     // ScrollRegionToken Tests
     // ===================
 
-    [Fact]
+    [TestMethod]
     public void ScrollRegionToken_DefaultsToReset()
     {
         var token = new ScrollRegionToken();
-        Assert.Equal(1, token.Top);
-        Assert.Equal(0, token.Bottom);
+        Assert.AreEqual(1, token.Top);
+        Assert.AreEqual(0, token.Bottom);
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollRegionToken_StoresRegion()
     {
         var token = new ScrollRegionToken(5, 20);
-        Assert.Equal(5, token.Top);
-        Assert.Equal(20, token.Bottom);
+        Assert.AreEqual(5, token.Top);
+        Assert.AreEqual(20, token.Bottom);
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollRegionToken_ResetInstance()
     {
-        Assert.Equal(1, ScrollRegionToken.Reset.Top);
-        Assert.Equal(0, ScrollRegionToken.Reset.Bottom);
+        Assert.AreEqual(1, ScrollRegionToken.Reset.Top);
+        Assert.AreEqual(0, ScrollRegionToken.Reset.Bottom);
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollRegionToken_Equality()
     {
         var token1 = new ScrollRegionToken(5, 20);
         var token2 = new ScrollRegionToken(5, 20);
         var token3 = new ScrollRegionToken(5, 21);
 
-        Assert.Equal(token1, token2);
-        Assert.NotEqual(token1, token3);
+        Assert.AreEqual(token1, token2);
+        Assert.AreNotEqual(token1, token3);
     }
 
     // ===================
     // SaveCursorToken Tests
     // ===================
 
-    [Fact]
+    [TestMethod]
     public void SaveCursorToken_DefaultsToDec()
     {
         var token = new SaveCursorToken();
-        Assert.True(token.UseDec);
+        Assert.IsTrue(token.UseDec);
     }
 
-    [Fact]
+    [TestMethod]
     public void SaveCursorToken_StaticInstances()
     {
-        Assert.True(SaveCursorToken.Dec.UseDec);
-        Assert.False(SaveCursorToken.Ansi.UseDec);
+        Assert.IsTrue(SaveCursorToken.Dec.UseDec);
+        Assert.IsFalse(SaveCursorToken.Ansi.UseDec);
     }
 
-    [Fact]
+    [TestMethod]
     public void SaveCursorToken_Equality()
     {
         var token1 = new SaveCursorToken(true);
         var token2 = new SaveCursorToken(true);
         var token3 = new SaveCursorToken(false);
 
-        Assert.Equal(token1, token2);
-        Assert.NotEqual(token1, token3);
+        Assert.AreEqual(token1, token2);
+        Assert.AreNotEqual(token1, token3);
     }
 
     // ===================
     // RestoreCursorToken Tests
     // ===================
 
-    [Fact]
+    [TestMethod]
     public void RestoreCursorToken_DefaultsToDec()
     {
         var token = new RestoreCursorToken();
-        Assert.True(token.UseDec);
+        Assert.IsTrue(token.UseDec);
     }
 
-    [Fact]
+    [TestMethod]
     public void RestoreCursorToken_StaticInstances()
     {
-        Assert.True(RestoreCursorToken.Dec.UseDec);
-        Assert.False(RestoreCursorToken.Ansi.UseDec);
+        Assert.IsTrue(RestoreCursorToken.Dec.UseDec);
+        Assert.IsFalse(RestoreCursorToken.Ansi.UseDec);
     }
 
-    [Fact]
+    [TestMethod]
     public void RestoreCursorToken_Equality()
     {
         var token1 = new RestoreCursorToken(true);
         var token2 = new RestoreCursorToken(true);
         var token3 = new RestoreCursorToken(false);
 
-        Assert.Equal(token1, token2);
-        Assert.NotEqual(token1, token3);
+        Assert.AreEqual(token1, token2);
+        Assert.AreNotEqual(token1, token3);
     }
 
     // ===================
     // CursorShapeToken Tests
     // ===================
 
-    [Fact]
+    [TestMethod]
     public void CursorShapeToken_StoresShape()
     {
         var token = new CursorShapeToken(2);
-        Assert.Equal(2, token.Shape);
+        Assert.AreEqual(2, token.Shape);
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorShapeToken_StaticInstances()
     {
-        Assert.Equal(0, CursorShapeToken.Default.Shape);
-        Assert.Equal(1, CursorShapeToken.BlinkingBlock.Shape);
-        Assert.Equal(2, CursorShapeToken.SteadyBlock.Shape);
-        Assert.Equal(3, CursorShapeToken.BlinkingUnderline.Shape);
-        Assert.Equal(4, CursorShapeToken.SteadyUnderline.Shape);
-        Assert.Equal(5, CursorShapeToken.BlinkingBar.Shape);
-        Assert.Equal(6, CursorShapeToken.SteadyBar.Shape);
+        Assert.AreEqual(0, CursorShapeToken.Default.Shape);
+        Assert.AreEqual(1, CursorShapeToken.BlinkingBlock.Shape);
+        Assert.AreEqual(2, CursorShapeToken.SteadyBlock.Shape);
+        Assert.AreEqual(3, CursorShapeToken.BlinkingUnderline.Shape);
+        Assert.AreEqual(4, CursorShapeToken.SteadyUnderline.Shape);
+        Assert.AreEqual(5, CursorShapeToken.BlinkingBar.Shape);
+        Assert.AreEqual(6, CursorShapeToken.SteadyBar.Shape);
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorShapeToken_Equality()
     {
         var token1 = new CursorShapeToken(2);
         var token2 = new CursorShapeToken(2);
         var token3 = new CursorShapeToken(4);
 
-        Assert.Equal(token1, token2);
-        Assert.NotEqual(token1, token3);
+        Assert.AreEqual(token1, token2);
+        Assert.AreNotEqual(token1, token3);
     }
 
     // ===================
     // Polymorphism Tests
     // ===================
 
-    [Fact]
+    [TestMethod]
     public void AllTokens_AreAnsiToken()
     {
         AnsiToken[] tokens = 
@@ -460,11 +461,11 @@ public class AnsiTokenTests
             new RestoreCursorToken(true)
         ];
 
-        Assert.Equal(14, tokens.Length);
-        Assert.All(tokens, t => Assert.IsAssignableFrom<AnsiToken>(t));
+        Assert.AreEqual(14, tokens.Length);
+        TestSeq.All(tokens, t => TestSeq.IsType<AnsiToken>(t));
     }
 
-    [Fact]
+    [TestMethod]
     public void AllTokens_SupportPatternMatching()
     {
         AnsiToken token = new CursorPositionToken(5, 10);
@@ -488,20 +489,20 @@ public class AnsiTokenTests
             _ => "other"
         };
 
-        Assert.Equal("cursor:5,10", result);
+        Assert.AreEqual("cursor:5,10", result);
     }
 
     // ===================
     // ClearMode Enum Tests
     // ===================
 
-    [Fact]
+    [TestMethod]
     public void ClearMode_HasCorrectValues()
     {
         // These values must match ANSI spec for serialization
-        Assert.Equal(0, (int)ClearMode.ToEnd);
-        Assert.Equal(1, (int)ClearMode.ToStart);
-        Assert.Equal(2, (int)ClearMode.All);
-        Assert.Equal(3, (int)ClearMode.AllAndScrollback);
+        Assert.AreEqual(0, (int)ClearMode.ToEnd);
+        Assert.AreEqual(1, (int)ClearMode.ToStart);
+        Assert.AreEqual(2, (int)ClearMode.All);
+        Assert.AreEqual(3, (int)ClearMode.AllAndScrollback);
     }
 }

--- a/tests/Hex1b.Tests/AnsiTokenUtf8SerializerTests.cs
+++ b/tests/Hex1b.Tests/AnsiTokenUtf8SerializerTests.cs
@@ -3,9 +3,10 @@ using Hex1b.Tokens;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class AnsiTokenUtf8SerializerTests
 {
-    [Fact]
+    [TestMethod]
     public void Serialize_SingleToken_MatchesStringSerializerUtf8()
     {
         var token = new CursorPositionToken(10, 20);
@@ -13,10 +14,10 @@ public class AnsiTokenUtf8SerializerTests
         var expected = Encoding.UTF8.GetBytes(AnsiTokenSerializer.Serialize(token));
         var actual = AnsiTokenUtf8Serializer.Serialize(token).Span.ToArray();
 
-        Assert.Equal(expected, actual);
+        TestSeq.AreEqual(expected, actual);
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_TokenList_MatchesStringSerializerUtf8()
     {
         IReadOnlyList<AnsiToken> tokens =
@@ -34,7 +35,7 @@ public class AnsiTokenUtf8SerializerTests
         var expected = Encoding.UTF8.GetBytes(AnsiTokenSerializer.Serialize(tokens));
         var actual = AnsiTokenUtf8Serializer.Serialize(tokens).Span.ToArray();
 
-        Assert.Equal(expected, actual);
+        TestSeq.AreEqual(expected, actual);
     }
 }
 

--- a/tests/Hex1b.Tests/AnsiTokenizerTests.cs
+++ b/tests/Hex1b.Tests/AnsiTokenizerTests.cs
@@ -2,890 +2,859 @@ using Hex1b.Tokens;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class AnsiTokenizerTests
 {
     #region Basic Text Tests
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_EmptyString_ReturnsEmptyList()
     {
         var result = AnsiTokenizer.Tokenize("");
-        Assert.Empty(result);
+        Assert.IsEmpty(result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_NullString_ReturnsEmptyList()
     {
         var result = AnsiTokenizer.Tokenize(null!);
-        Assert.Empty(result);
+        Assert.IsEmpty(result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_PlainText_ReturnsSingleTextToken()
     {
         var result = AnsiTokenizer.Tokenize("Hello, World!");
 
-        var token = Assert.Single(result);
-        var textToken = Assert.IsType<TextToken>(token);
-        Assert.Equal("Hello, World!", textToken.Text);
+        var token = TestSeq.Single(result);
+        var textToken = TestSeq.IsType<TextToken>(token);
+        Assert.AreEqual("Hello, World!", textToken.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_ConsecutiveTextAndControlChars_BatchesTextCorrectly()
     {
         var result = AnsiTokenizer.Tokenize("Hello\nWorld");
 
-        Assert.Collection(result,
-            t => Assert.Equal("Hello", Assert.IsType<TextToken>(t).Text),
-            t => Assert.Same(ControlCharacterToken.LineFeed, t),
-            t => Assert.Equal("World", Assert.IsType<TextToken>(t).Text));
+        TestSeq.Collection(result, t => Assert.AreEqual("Hello", TestSeq.IsType<TextToken>(t).Text), t => Assert.AreSame(ControlCharacterToken.LineFeed, t), t => Assert.AreEqual("World", TestSeq.IsType<TextToken>(t).Text));
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_UnicodeEmoji_PreservesGraphemeClusters()
     {
         // Family emoji is a complex grapheme cluster
         var result = AnsiTokenizer.Tokenize("Hello 👨‍👩‍👧 World");
 
-        var token = Assert.Single(result);
-        var textToken = Assert.IsType<TextToken>(token);
-        Assert.Equal("Hello 👨‍👩‍👧 World", textToken.Text);
+        var token = TestSeq.Single(result);
+        var textToken = TestSeq.IsType<TextToken>(token);
+        Assert.AreEqual("Hello 👨‍👩‍👧 World", textToken.Text);
     }
 
     #endregion
 
     #region Control Character Tests
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_LineFeed_ReturnsLineFeedToken()
     {
         var result = AnsiTokenizer.Tokenize("\n");
 
-        var token = Assert.Single(result);
-        Assert.Same(ControlCharacterToken.LineFeed, token);
+        var token = TestSeq.Single(result);
+        Assert.AreSame(ControlCharacterToken.LineFeed, token);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_CarriageReturn_ReturnsCarriageReturnToken()
     {
         var result = AnsiTokenizer.Tokenize("\r");
 
-        var token = Assert.Single(result);
-        Assert.Same(ControlCharacterToken.CarriageReturn, token);
+        var token = TestSeq.Single(result);
+        Assert.AreSame(ControlCharacterToken.CarriageReturn, token);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_Tab_ReturnsTabToken()
     {
         var result = AnsiTokenizer.Tokenize("\t");
 
-        var token = Assert.Single(result);
-        Assert.Same(ControlCharacterToken.Tab, token);
+        var token = TestSeq.Single(result);
+        Assert.AreSame(ControlCharacterToken.Tab, token);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_CrLf_ReturnsTwoTokens()
     {
         var result = AnsiTokenizer.Tokenize("\r\n");
 
-        Assert.Collection(result,
-            t => Assert.Same(ControlCharacterToken.CarriageReturn, t),
-            t => Assert.Same(ControlCharacterToken.LineFeed, t));
+        TestSeq.Collection(result, t => Assert.AreSame(ControlCharacterToken.CarriageReturn, t), t => Assert.AreSame(ControlCharacterToken.LineFeed, t));
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_MultipleNewlines_ReturnsSeparateTokens()
     {
         var result = AnsiTokenizer.Tokenize("\n\n\n");
 
-        Assert.Equal(3, result.Count);
-        Assert.All(result, t => Assert.Same(ControlCharacterToken.LineFeed, t));
+        Assert.AreEqual(3, result.Count);
+        TestSeq.All(result, t => Assert.AreSame(ControlCharacterToken.LineFeed, t));
     }
 
     #endregion
 
     #region SGR Token Tests
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_SgrReset_ReturnsSgrToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[0m");
 
-        var token = Assert.Single(result);
-        var sgrToken = Assert.IsType<SgrToken>(token);
-        Assert.Equal("0", sgrToken.Parameters);
+        var token = TestSeq.Single(result);
+        var sgrToken = TestSeq.IsType<SgrToken>(token);
+        Assert.AreEqual("0", sgrToken.Parameters);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_SgrEmpty_ReturnsSgrTokenWithEmptyParams()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[m");
 
-        var token = Assert.Single(result);
-        var sgrToken = Assert.IsType<SgrToken>(token);
-        Assert.Equal("", sgrToken.Parameters);
+        var token = TestSeq.Single(result);
+        var sgrToken = TestSeq.IsType<SgrToken>(token);
+        Assert.AreEqual("", sgrToken.Parameters);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_SgrBold_ReturnsSgrToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[1m");
 
-        var token = Assert.Single(result);
-        var sgrToken = Assert.IsType<SgrToken>(token);
-        Assert.Equal("1", sgrToken.Parameters);
+        var token = TestSeq.Single(result);
+        var sgrToken = TestSeq.IsType<SgrToken>(token);
+        Assert.AreEqual("1", sgrToken.Parameters);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_SgrMultipleParams_PreservesAllParams()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[1;31;42m");
 
-        var token = Assert.Single(result);
-        var sgrToken = Assert.IsType<SgrToken>(token);
-        Assert.Equal("1;31;42", sgrToken.Parameters);
+        var token = TestSeq.Single(result);
+        var sgrToken = TestSeq.IsType<SgrToken>(token);
+        Assert.AreEqual("1;31;42", sgrToken.Parameters);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_Sgr256Color_PreservesParams()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[38;5;196m");
 
-        var token = Assert.Single(result);
-        var sgrToken = Assert.IsType<SgrToken>(token);
-        Assert.Equal("38;5;196", sgrToken.Parameters);
+        var token = TestSeq.Single(result);
+        var sgrToken = TestSeq.IsType<SgrToken>(token);
+        Assert.AreEqual("38;5;196", sgrToken.Parameters);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_SgrRgbColor_PreservesParams()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[38;2;255;128;64m");
 
-        var token = Assert.Single(result);
-        var sgrToken = Assert.IsType<SgrToken>(token);
-        Assert.Equal("38;2;255;128;64", sgrToken.Parameters);
+        var token = TestSeq.Single(result);
+        var sgrToken = TestSeq.IsType<SgrToken>(token);
+        Assert.AreEqual("38;2;255;128;64", sgrToken.Parameters);
     }
 
     #endregion
 
     #region Cursor Position Tests
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_CursorPositionDefault_ReturnsOneOne()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[H");
 
-        var token = Assert.Single(result);
-        var posToken = Assert.IsType<CursorPositionToken>(token);
-        Assert.Equal(1, posToken.Row);
-        Assert.Equal(1, posToken.Column);
+        var token = TestSeq.Single(result);
+        var posToken = TestSeq.IsType<CursorPositionToken>(token);
+        Assert.AreEqual(1, posToken.Row);
+        Assert.AreEqual(1, posToken.Column);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_CursorPositionExplicit_ReturnsCorrectPosition()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[10;20H");
 
-        var token = Assert.Single(result);
-        var posToken = Assert.IsType<CursorPositionToken>(token);
-        Assert.Equal(10, posToken.Row);
-        Assert.Equal(20, posToken.Column);
+        var token = TestSeq.Single(result);
+        var posToken = TestSeq.IsType<CursorPositionToken>(token);
+        Assert.AreEqual(10, posToken.Row);
+        Assert.AreEqual(20, posToken.Column);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_CursorPositionRowOnly_ReturnsRowWithDefaultColumn()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[5H");
 
-        var token = Assert.Single(result);
-        var posToken = Assert.IsType<CursorPositionToken>(token);
-        Assert.Equal(5, posToken.Row);
-        Assert.Equal(1, posToken.Column);
+        var token = TestSeq.Single(result);
+        var posToken = TestSeq.IsType<CursorPositionToken>(token);
+        Assert.AreEqual(5, posToken.Row);
+        Assert.AreEqual(1, posToken.Column);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_CursorPositionWithF_SameAsH()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[10;20f");
 
-        var token = Assert.Single(result);
-        var posToken = Assert.IsType<CursorPositionToken>(token);
-        Assert.Equal(10, posToken.Row);
-        Assert.Equal(20, posToken.Column);
+        var token = TestSeq.Single(result);
+        var posToken = TestSeq.IsType<CursorPositionToken>(token);
+        Assert.AreEqual(10, posToken.Row);
+        Assert.AreEqual(20, posToken.Column);
     }
 
     #endregion
 
     #region Clear Screen Tests
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_ClearScreenDefault_ReturnsClearToEnd()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[J");
 
-        var token = Assert.Single(result);
-        var clearToken = Assert.IsType<ClearScreenToken>(token);
-        Assert.Equal(ClearMode.ToEnd, clearToken.Mode);
+        var token = TestSeq.Single(result);
+        var clearToken = TestSeq.IsType<ClearScreenToken>(token);
+        Assert.AreEqual(ClearMode.ToEnd, clearToken.Mode);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_ClearScreenToEnd_ReturnsClearToEnd()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[0J");
 
-        var token = Assert.Single(result);
-        var clearToken = Assert.IsType<ClearScreenToken>(token);
-        Assert.Equal(ClearMode.ToEnd, clearToken.Mode);
+        var token = TestSeq.Single(result);
+        var clearToken = TestSeq.IsType<ClearScreenToken>(token);
+        Assert.AreEqual(ClearMode.ToEnd, clearToken.Mode);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_ClearScreenToStart_ReturnsClearToStart()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[1J");
 
-        var token = Assert.Single(result);
-        var clearToken = Assert.IsType<ClearScreenToken>(token);
-        Assert.Equal(ClearMode.ToStart, clearToken.Mode);
+        var token = TestSeq.Single(result);
+        var clearToken = TestSeq.IsType<ClearScreenToken>(token);
+        Assert.AreEqual(ClearMode.ToStart, clearToken.Mode);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_ClearScreenAll_ReturnsClearAll()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[2J");
 
-        var token = Assert.Single(result);
-        var clearToken = Assert.IsType<ClearScreenToken>(token);
-        Assert.Equal(ClearMode.All, clearToken.Mode);
+        var token = TestSeq.Single(result);
+        var clearToken = TestSeq.IsType<ClearScreenToken>(token);
+        Assert.AreEqual(ClearMode.All, clearToken.Mode);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_ClearScreenAllAndScrollback_ReturnsClearAllAndScrollback()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[3J");
 
-        var token = Assert.Single(result);
-        var clearToken = Assert.IsType<ClearScreenToken>(token);
-        Assert.Equal(ClearMode.AllAndScrollback, clearToken.Mode);
+        var token = TestSeq.Single(result);
+        var clearToken = TestSeq.IsType<ClearScreenToken>(token);
+        Assert.AreEqual(ClearMode.AllAndScrollback, clearToken.Mode);
     }
 
     #endregion
 
     #region Clear Line Tests
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_ClearLineDefault_ReturnsClearToEnd()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[K");
 
-        var token = Assert.Single(result);
-        var clearToken = Assert.IsType<ClearLineToken>(token);
-        Assert.Equal(ClearMode.ToEnd, clearToken.Mode);
+        var token = TestSeq.Single(result);
+        var clearToken = TestSeq.IsType<ClearLineToken>(token);
+        Assert.AreEqual(ClearMode.ToEnd, clearToken.Mode);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_ClearLineToEnd_ReturnsClearToEnd()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[0K");
 
-        var token = Assert.Single(result);
-        var clearToken = Assert.IsType<ClearLineToken>(token);
-        Assert.Equal(ClearMode.ToEnd, clearToken.Mode);
+        var token = TestSeq.Single(result);
+        var clearToken = TestSeq.IsType<ClearLineToken>(token);
+        Assert.AreEqual(ClearMode.ToEnd, clearToken.Mode);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_ClearLineToStart_ReturnsClearToStart()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[1K");
 
-        var token = Assert.Single(result);
-        var clearToken = Assert.IsType<ClearLineToken>(token);
-        Assert.Equal(ClearMode.ToStart, clearToken.Mode);
+        var token = TestSeq.Single(result);
+        var clearToken = TestSeq.IsType<ClearLineToken>(token);
+        Assert.AreEqual(ClearMode.ToStart, clearToken.Mode);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_ClearLineAll_ReturnsClearAll()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[2K");
 
-        var token = Assert.Single(result);
-        var clearToken = Assert.IsType<ClearLineToken>(token);
-        Assert.Equal(ClearMode.All, clearToken.Mode);
+        var token = TestSeq.Single(result);
+        var clearToken = TestSeq.IsType<ClearLineToken>(token);
+        Assert.AreEqual(ClearMode.All, clearToken.Mode);
     }
 
     #endregion
 
     #region Private Mode Tests
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_AlternateScreenEnable_ReturnsPrivateModeToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[?1049h");
 
-        var token = Assert.Single(result);
-        var pmToken = Assert.IsType<PrivateModeToken>(token);
-        Assert.Equal(1049, pmToken.Mode);
-        Assert.True(pmToken.Enable);
+        var token = TestSeq.Single(result);
+        var pmToken = TestSeq.IsType<PrivateModeToken>(token);
+        Assert.AreEqual(1049, pmToken.Mode);
+        Assert.IsTrue(pmToken.Enable);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_AlternateScreenDisable_ReturnsPrivateModeToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[?1049l");
 
-        var token = Assert.Single(result);
-        var pmToken = Assert.IsType<PrivateModeToken>(token);
-        Assert.Equal(1049, pmToken.Mode);
-        Assert.False(pmToken.Enable);
+        var token = TestSeq.Single(result);
+        var pmToken = TestSeq.IsType<PrivateModeToken>(token);
+        Assert.AreEqual(1049, pmToken.Mode);
+        Assert.IsFalse(pmToken.Enable);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_CursorVisible_ReturnsPrivateModeToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[?25h");
 
-        var token = Assert.Single(result);
-        var pmToken = Assert.IsType<PrivateModeToken>(token);
-        Assert.Equal(25, pmToken.Mode);
-        Assert.True(pmToken.Enable);
+        var token = TestSeq.Single(result);
+        var pmToken = TestSeq.IsType<PrivateModeToken>(token);
+        Assert.AreEqual(25, pmToken.Mode);
+        Assert.IsTrue(pmToken.Enable);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_CursorHidden_ReturnsPrivateModeToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[?25l");
 
-        var token = Assert.Single(result);
-        var pmToken = Assert.IsType<PrivateModeToken>(token);
-        Assert.Equal(25, pmToken.Mode);
-        Assert.False(pmToken.Enable);
+        var token = TestSeq.Single(result);
+        var pmToken = TestSeq.IsType<PrivateModeToken>(token);
+        Assert.AreEqual(25, pmToken.Mode);
+        Assert.IsFalse(pmToken.Enable);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_MultiplePrivateModesEnable_EmitsTokenPerMode()
     {
         // edit.exe sends this to enable mouse tracking + SGR mouse + bracketed paste
         var result = AnsiTokenizer.Tokenize("\x1b[?1002;1006;2004h");
 
-        Assert.Equal(3, result.Count);
-        var pm0 = Assert.IsType<PrivateModeToken>(result[0]);
-        Assert.Equal(1002, pm0.Mode);
-        Assert.True(pm0.Enable);
-        var pm1 = Assert.IsType<PrivateModeToken>(result[1]);
-        Assert.Equal(1006, pm1.Mode);
-        Assert.True(pm1.Enable);
-        var pm2 = Assert.IsType<PrivateModeToken>(result[2]);
-        Assert.Equal(2004, pm2.Mode);
-        Assert.True(pm2.Enable);
+        Assert.AreEqual(3, result.Count);
+        var pm0 = TestSeq.IsType<PrivateModeToken>(result[0]);
+        Assert.AreEqual(1002, pm0.Mode);
+        Assert.IsTrue(pm0.Enable);
+        var pm1 = TestSeq.IsType<PrivateModeToken>(result[1]);
+        Assert.AreEqual(1006, pm1.Mode);
+        Assert.IsTrue(pm1.Enable);
+        var pm2 = TestSeq.IsType<PrivateModeToken>(result[2]);
+        Assert.AreEqual(2004, pm2.Mode);
+        Assert.IsTrue(pm2.Enable);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_MultiplePrivateModesDisable_EmitsTokenPerMode()
     {
         // edit.exe cleanup sequence
         var result = AnsiTokenizer.Tokenize("\x1b[?1002;1006;2004l");
 
-        Assert.Equal(3, result.Count);
-        var pm0 = Assert.IsType<PrivateModeToken>(result[0]);
-        Assert.Equal(1002, pm0.Mode);
-        Assert.False(pm0.Enable);
-        var pm1 = Assert.IsType<PrivateModeToken>(result[1]);
-        Assert.Equal(1006, pm1.Mode);
-        Assert.False(pm1.Enable);
-        var pm2 = Assert.IsType<PrivateModeToken>(result[2]);
-        Assert.Equal(2004, pm2.Mode);
-        Assert.False(pm2.Enable);
+        Assert.AreEqual(3, result.Count);
+        var pm0 = TestSeq.IsType<PrivateModeToken>(result[0]);
+        Assert.AreEqual(1002, pm0.Mode);
+        Assert.IsFalse(pm0.Enable);
+        var pm1 = TestSeq.IsType<PrivateModeToken>(result[1]);
+        Assert.AreEqual(1006, pm1.Mode);
+        Assert.IsFalse(pm1.Enable);
+        var pm2 = TestSeq.IsType<PrivateModeToken>(result[2]);
+        Assert.AreEqual(2004, pm2.Mode);
+        Assert.IsFalse(pm2.Enable);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_TwoPrivateModesEnable_EmitsTokenPerMode()
     {
         // Common pattern: alt screen + cursor hide
         var result = AnsiTokenizer.Tokenize("\x1b[?1049;25h");
 
-        Assert.Equal(2, result.Count);
-        Assert.Equal(1049, Assert.IsType<PrivateModeToken>(result[0]).Mode);
-        Assert.Equal(25, Assert.IsType<PrivateModeToken>(result[1]).Mode);
+        Assert.AreEqual(2, result.Count);
+        Assert.AreEqual(1049, TestSeq.IsType<PrivateModeToken>(result[0]).Mode);
+        Assert.AreEqual(25, TestSeq.IsType<PrivateModeToken>(result[1]).Mode);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_MultipleStandardModesEnable_EmitsTokenPerMode()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[4;20h");
 
-        Assert.Equal(2, result.Count);
-        var sm0 = Assert.IsType<StandardModeToken>(result[0]);
-        Assert.Equal(4, sm0.Mode);
-        Assert.True(sm0.Enable);
-        var sm1 = Assert.IsType<StandardModeToken>(result[1]);
-        Assert.Equal(20, sm1.Mode);
-        Assert.True(sm1.Enable);
+        Assert.AreEqual(2, result.Count);
+        var sm0 = TestSeq.IsType<StandardModeToken>(result[0]);
+        Assert.AreEqual(4, sm0.Mode);
+        Assert.IsTrue(sm0.Enable);
+        var sm1 = TestSeq.IsType<StandardModeToken>(result[1]);
+        Assert.AreEqual(20, sm1.Mode);
+        Assert.IsTrue(sm1.Enable);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_MouseTrackingModes_AllRecognized()
     {
         // Verify all mouse tracking private modes are correctly tokenized
         var result1000 = AnsiTokenizer.Tokenize("\x1b[?1000h");
-        Assert.Equal(1000, Assert.IsType<PrivateModeToken>(Assert.Single(result1000)).Mode);
+        Assert.AreEqual(1000, TestSeq.IsType<PrivateModeToken>(TestSeq.Single(result1000)).Mode);
 
         var result1002 = AnsiTokenizer.Tokenize("\x1b[?1002h");
-        Assert.Equal(1002, Assert.IsType<PrivateModeToken>(Assert.Single(result1002)).Mode);
+        Assert.AreEqual(1002, TestSeq.IsType<PrivateModeToken>(TestSeq.Single(result1002)).Mode);
 
         var result1003 = AnsiTokenizer.Tokenize("\x1b[?1003h");
-        Assert.Equal(1003, Assert.IsType<PrivateModeToken>(Assert.Single(result1003)).Mode);
+        Assert.AreEqual(1003, TestSeq.IsType<PrivateModeToken>(TestSeq.Single(result1003)).Mode);
 
         var result1006 = AnsiTokenizer.Tokenize("\x1b[?1006h");
-        Assert.Equal(1006, Assert.IsType<PrivateModeToken>(Assert.Single(result1006)).Mode);
+        Assert.AreEqual(1006, TestSeq.IsType<PrivateModeToken>(TestSeq.Single(result1006)).Mode);
     }
 
     #endregion
 
     #region Cursor Shape Tests
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_CursorShapeDefault_ReturnsDefaultToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[0q");
 
-        var token = Assert.Single(result);
-        Assert.Same(CursorShapeToken.Default, token);
+        var token = TestSeq.Single(result);
+        Assert.AreSame(CursorShapeToken.Default, token);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_CursorShapeBlinkingBlock_ReturnsCorrectToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[1q");
 
-        var token = Assert.Single(result);
-        Assert.Same(CursorShapeToken.BlinkingBlock, token);
+        var token = TestSeq.Single(result);
+        Assert.AreSame(CursorShapeToken.BlinkingBlock, token);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_CursorShapeSteadyBlock_ReturnsCorrectToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[2q");
 
-        var token = Assert.Single(result);
-        Assert.Same(CursorShapeToken.SteadyBlock, token);
+        var token = TestSeq.Single(result);
+        Assert.AreSame(CursorShapeToken.SteadyBlock, token);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_CursorShapeBlinkingUnderline_ReturnsCorrectToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[3q");
 
-        var token = Assert.Single(result);
-        Assert.Same(CursorShapeToken.BlinkingUnderline, token);
+        var token = TestSeq.Single(result);
+        Assert.AreSame(CursorShapeToken.BlinkingUnderline, token);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_CursorShapeSteadyUnderline_ReturnsCorrectToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[4q");
 
-        var token = Assert.Single(result);
-        Assert.Same(CursorShapeToken.SteadyUnderline, token);
+        var token = TestSeq.Single(result);
+        Assert.AreSame(CursorShapeToken.SteadyUnderline, token);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_CursorShapeBlinkingBar_ReturnsCorrectToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[5q");
 
-        var token = Assert.Single(result);
-        Assert.Same(CursorShapeToken.BlinkingBar, token);
+        var token = TestSeq.Single(result);
+        Assert.AreSame(CursorShapeToken.BlinkingBar, token);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_CursorShapeSteadyBar_ReturnsCorrectToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[6q");
 
-        var token = Assert.Single(result);
-        Assert.Same(CursorShapeToken.SteadyBar, token);
+        var token = TestSeq.Single(result);
+        Assert.AreSame(CursorShapeToken.SteadyBar, token);
     }
 
     #endregion
 
     #region Scroll Region Tests
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_ScrollRegionReset_ReturnsResetToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[r");
 
-        var token = Assert.Single(result);
-        Assert.Same(ScrollRegionToken.Reset, token);
+        var token = TestSeq.Single(result);
+        Assert.AreSame(ScrollRegionToken.Reset, token);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_ScrollRegionExplicit_ReturnsCorrectRegion()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[5;20r");
 
-        var token = Assert.Single(result);
-        var scrollToken = Assert.IsType<ScrollRegionToken>(token);
-        Assert.Equal(5, scrollToken.Top);
-        Assert.Equal(20, scrollToken.Bottom);
+        var token = TestSeq.Single(result);
+        var scrollToken = TestSeq.IsType<ScrollRegionToken>(token);
+        Assert.AreEqual(5, scrollToken.Top);
+        Assert.AreEqual(20, scrollToken.Bottom);
     }
 
     #endregion
 
     #region Save/Restore Cursor Tests
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_SaveCursorAnsi_ReturnsAnsiToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[s");
 
-        var token = Assert.Single(result);
-        Assert.Same(SaveCursorToken.Ansi, token);
+        var token = TestSeq.Single(result);
+        Assert.AreSame(SaveCursorToken.Ansi, token);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_RestoreCursorAnsi_ReturnsAnsiToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[u");
 
-        var token = Assert.Single(result);
-        Assert.Same(RestoreCursorToken.Ansi, token);
+        var token = TestSeq.Single(result);
+        Assert.AreSame(RestoreCursorToken.Ansi, token);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_SaveCursorDec_ReturnsDecToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b" + "7");
 
-        var token = Assert.Single(result);
-        Assert.Same(SaveCursorToken.Dec, token);
+        var token = TestSeq.Single(result);
+        Assert.AreSame(SaveCursorToken.Dec, token);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_RestoreCursorDec_ReturnsDecToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b" + "8");
 
-        var token = Assert.Single(result);
-        Assert.Same(RestoreCursorToken.Dec, token);
+        var token = TestSeq.Single(result);
+        Assert.AreSame(RestoreCursorToken.Dec, token);
     }
 
     #endregion
 
     #region OSC Token Tests
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_OscHyperlinkWithBel_ReturnsOscToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b]8;;https://example.com\x07");
 
-        var token = Assert.Single(result);
-        var oscToken = Assert.IsType<OscToken>(token);
-        Assert.Equal("8", oscToken.Command);
-        Assert.Equal("", oscToken.Parameters);
-        Assert.Equal("https://example.com", oscToken.Payload);
+        var token = TestSeq.Single(result);
+        var oscToken = TestSeq.IsType<OscToken>(token);
+        Assert.AreEqual("8", oscToken.Command);
+        Assert.AreEqual("", oscToken.Parameters);
+        Assert.AreEqual("https://example.com", oscToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_OscHyperlinkWithST_ReturnsOscToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b]8;;https://example.com\x1b\\");
 
-        var token = Assert.Single(result);
-        var oscToken = Assert.IsType<OscToken>(token);
-        Assert.Equal("8", oscToken.Command);
-        Assert.Equal("https://example.com", oscToken.Payload);
+        var token = TestSeq.Single(result);
+        var oscToken = TestSeq.IsType<OscToken>(token);
+        Assert.AreEqual("8", oscToken.Command);
+        Assert.AreEqual("https://example.com", oscToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_OscHyperlinkWithParams_PreservesParams()
     {
         var result = AnsiTokenizer.Tokenize("\x1b]8;id=mylink;https://example.com\x07");
 
-        var token = Assert.Single(result);
-        var oscToken = Assert.IsType<OscToken>(token);
-        Assert.Equal("8", oscToken.Command);
-        Assert.Equal("id=mylink", oscToken.Parameters);
-        Assert.Equal("https://example.com", oscToken.Payload);
+        var token = TestSeq.Single(result);
+        var oscToken = TestSeq.IsType<OscToken>(token);
+        Assert.AreEqual("8", oscToken.Command);
+        Assert.AreEqual("id=mylink", oscToken.Parameters);
+        Assert.AreEqual("https://example.com", oscToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_OscHyperlinkEnd_ReturnsOscWithEmptyPayload()
     {
         var result = AnsiTokenizer.Tokenize("\x1b]8;;\x07");
 
-        var token = Assert.Single(result);
-        var oscToken = Assert.IsType<OscToken>(token);
-        Assert.Equal("8", oscToken.Command);
-        Assert.Equal("", oscToken.Parameters);
-        Assert.Equal("", oscToken.Payload);
+        var token = TestSeq.Single(result);
+        var oscToken = TestSeq.IsType<OscToken>(token);
+        Assert.AreEqual("8", oscToken.Command);
+        Assert.AreEqual("", oscToken.Parameters);
+        Assert.AreEqual("", oscToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_OscWithC1Start_ReturnsOscToken()
     {
         var result = AnsiTokenizer.Tokenize("\x9d" + "8;;https://example.com\x07");
 
-        var token = Assert.Single(result);
-        var oscToken = Assert.IsType<OscToken>(token);
-        Assert.Equal("8", oscToken.Command);
-        Assert.Equal("https://example.com", oscToken.Payload);
+        var token = TestSeq.Single(result);
+        var oscToken = TestSeq.IsType<OscToken>(token);
+        Assert.AreEqual("8", oscToken.Command);
+        Assert.AreEqual("https://example.com", oscToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_OscWithC1Terminator_ReturnsOscToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b]8;;https://example.com\x9c");
 
-        var token = Assert.Single(result);
-        var oscToken = Assert.IsType<OscToken>(token);
-        Assert.Equal("8", oscToken.Command);
-        Assert.Equal("https://example.com", oscToken.Payload);
+        var token = TestSeq.Single(result);
+        var oscToken = TestSeq.IsType<OscToken>(token);
+        Assert.AreEqual("8", oscToken.Command);
+        Assert.AreEqual("https://example.com", oscToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_OscWindowTitle_ReturnsOscToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b]0;My Window Title\x07");
 
-        var token = Assert.Single(result);
-        var oscToken = Assert.IsType<OscToken>(token);
-        Assert.Equal("0", oscToken.Command);
-        Assert.Equal("My Window Title", oscToken.Payload);
+        var token = TestSeq.Single(result);
+        var oscToken = TestSeq.IsType<OscToken>(token);
+        Assert.AreEqual("0", oscToken.Command);
+        Assert.AreEqual("My Window Title", oscToken.Payload);
     }
 
     #endregion
 
     #region DCS Token Tests
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_DcsSequence_ReturnsDcsToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1bPq#0;2;0;0;0\x1b\\");
 
-        var token = Assert.Single(result);
-        var dcsToken = Assert.IsType<DcsToken>(token);
-        Assert.Equal("q#0;2;0;0;0", dcsToken.Payload);
+        var token = TestSeq.Single(result);
+        var dcsToken = TestSeq.IsType<DcsToken>(token);
+        Assert.AreEqual("q#0;2;0;0;0", dcsToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_DcsWithC1Start_ReturnsDcsToken()
     {
         var result = AnsiTokenizer.Tokenize("\x90q#0;2;0;0;0\x1b\\");
 
-        var token = Assert.Single(result);
-        var dcsToken = Assert.IsType<DcsToken>(token);
-        Assert.Equal("q#0;2;0;0;0", dcsToken.Payload);
+        var token = TestSeq.Single(result);
+        var dcsToken = TestSeq.IsType<DcsToken>(token);
+        Assert.AreEqual("q#0;2;0;0;0", dcsToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_DcsWithC1Terminator_ReturnsDcsToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1bPq#0;2;0;0;0\x9c");
 
-        var token = Assert.Single(result);
-        var dcsToken = Assert.IsType<DcsToken>(token);
-        Assert.Equal("q#0;2;0;0;0", dcsToken.Payload);
+        var token = TestSeq.Single(result);
+        var dcsToken = TestSeq.IsType<DcsToken>(token);
+        Assert.AreEqual("q#0;2;0;0;0", dcsToken.Payload);
     }
 
     #endregion
 
     #region Unrecognized Sequence Tests
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_UnrecognizedEscapeSequence_ReturnsUnrecognizedToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1bX");
 
-        var token = Assert.Single(result);
-        var unrecToken = Assert.IsType<UnrecognizedSequenceToken>(token);
-        Assert.Equal("\x1bX", unrecToken.Sequence);
+        var token = TestSeq.Single(result);
+        var unrecToken = TestSeq.IsType<UnrecognizedSequenceToken>(token);
+        Assert.AreEqual("\x1bX", unrecToken.Sequence);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_IncompleteEscapeSequence_ReturnsUnrecognizedToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b");
 
-        var token = Assert.Single(result);
-        var unrecToken = Assert.IsType<UnrecognizedSequenceToken>(token);
-        Assert.Equal("\x1b", unrecToken.Sequence);
+        var token = TestSeq.Single(result);
+        var unrecToken = TestSeq.IsType<UnrecognizedSequenceToken>(token);
+        Assert.AreEqual("\x1b", unrecToken.Sequence);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_UnknownCsiCommand_ReturnsUnrecognizedToken()
     {
         // Use CSI W which is not a standard command
         var result = AnsiTokenizer.Tokenize("\x1b[5W");
 
-        var token = Assert.Single(result);
-        var unrecToken = Assert.IsType<UnrecognizedSequenceToken>(token);
-        Assert.Equal("\x1b[5W", unrecToken.Sequence);
+        var token = TestSeq.Single(result);
+        var unrecToken = TestSeq.IsType<UnrecognizedSequenceToken>(token);
+        Assert.AreEqual("\x1b[5W", unrecToken.Sequence);
     }
     
-    [Fact]
+    [TestMethod]
     public void Tokenize_BackTab_ReturnsBackTabToken()
     {
         // CSI Z is Shift+Tab (Backtab)
         var result = AnsiTokenizer.Tokenize("\x1b[Z");
 
-        var token = Assert.Single(result);
-        Assert.Same(BackTabToken.Instance, token);
+        var token = TestSeq.Single(result);
+        Assert.AreSame(BackTabToken.Instance, token);
     }
 
     #endregion
 
     #region Complex Sequence Tests
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_ColoredText_ReturnsCorrectTokenSequence()
     {
         // ESC[31m (red) + "Hello" + ESC[0m (reset)
         var result = AnsiTokenizer.Tokenize("\x1b[31mHello\x1b[0m");
 
-        Assert.Collection(result,
-            t => Assert.Equal("31", Assert.IsType<SgrToken>(t).Parameters),
-            t => Assert.Equal("Hello", Assert.IsType<TextToken>(t).Text),
-            t => Assert.Equal("0", Assert.IsType<SgrToken>(t).Parameters));
+        TestSeq.Collection(result, t => Assert.AreEqual("31", TestSeq.IsType<SgrToken>(t).Parameters), t => Assert.AreEqual("Hello", TestSeq.IsType<TextToken>(t).Text), t => Assert.AreEqual("0", TestSeq.IsType<SgrToken>(t).Parameters));
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_PositionedText_ReturnsCorrectTokenSequence()
     {
         // ESC[5;10H + "Hello"
         var result = AnsiTokenizer.Tokenize("\x1b[5;10HHello");
 
-        Assert.Collection(result,
-            t =>
+        TestSeq.Collection(result, t =>
             {
-                var pos = Assert.IsType<CursorPositionToken>(t);
-                Assert.Equal(5, pos.Row);
-                Assert.Equal(10, pos.Column);
-            },
-            t => Assert.Equal("Hello", Assert.IsType<TextToken>(t).Text));
+                var pos = TestSeq.IsType<CursorPositionToken>(t);
+                Assert.AreEqual(5, pos.Row);
+                Assert.AreEqual(10, pos.Column);
+            }, t => Assert.AreEqual("Hello", TestSeq.IsType<TextToken>(t).Text));
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_MultiLineOutput_ReturnsCorrectSequence()
     {
         var result = AnsiTokenizer.Tokenize("Line 1\r\nLine 2\r\nLine 3");
 
-        Assert.Collection(result,
-            t => Assert.Equal("Line 1", Assert.IsType<TextToken>(t).Text),
-            t => Assert.Same(ControlCharacterToken.CarriageReturn, t),
-            t => Assert.Same(ControlCharacterToken.LineFeed, t),
-            t => Assert.Equal("Line 2", Assert.IsType<TextToken>(t).Text),
-            t => Assert.Same(ControlCharacterToken.CarriageReturn, t),
-            t => Assert.Same(ControlCharacterToken.LineFeed, t),
-            t => Assert.Equal("Line 3", Assert.IsType<TextToken>(t).Text));
+        TestSeq.Collection(result, t => Assert.AreEqual("Line 1", TestSeq.IsType<TextToken>(t).Text), t => Assert.AreSame(ControlCharacterToken.CarriageReturn, t), t => Assert.AreSame(ControlCharacterToken.LineFeed, t), t => Assert.AreEqual("Line 2", TestSeq.IsType<TextToken>(t).Text), t => Assert.AreSame(ControlCharacterToken.CarriageReturn, t), t => Assert.AreSame(ControlCharacterToken.LineFeed, t), t => Assert.AreEqual("Line 3", TestSeq.IsType<TextToken>(t).Text));
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_HyperlinkWithText_ReturnsCorrectSequence()
     {
         // Start hyperlink, text, end hyperlink
         var result = AnsiTokenizer.Tokenize("\x1b]8;;https://example.com\x07" + "Click here\x1b]8;;\x07");
 
-        Assert.Collection(result,
-            t =>
+        TestSeq.Collection(result, t =>
             {
-                var osc = Assert.IsType<OscToken>(t);
-                Assert.Equal("8", osc.Command);
-                Assert.Equal("https://example.com", osc.Payload);
-            },
-            t => Assert.Equal("Click here", Assert.IsType<TextToken>(t).Text),
-            t =>
+                var osc = TestSeq.IsType<OscToken>(t);
+                Assert.AreEqual("8", osc.Command);
+                Assert.AreEqual("https://example.com", osc.Payload);
+            }, t => Assert.AreEqual("Click here", TestSeq.IsType<TextToken>(t).Text), t =>
             {
-                var osc = Assert.IsType<OscToken>(t);
-                Assert.Equal("8", osc.Command);
-                Assert.Equal("", osc.Payload);
+                var osc = TestSeq.IsType<OscToken>(t);
+                Assert.AreEqual("8", osc.Command);
+                Assert.AreEqual("", osc.Payload);
             });
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_ClearAndPosition_ReturnsCorrectSequence()
     {
         // Clear screen + position cursor + write text
         var result = AnsiTokenizer.Tokenize("\x1b[2J\x1b[1;1HWelcome");
 
-        Assert.Collection(result,
-            t =>
+        TestSeq.Collection(result, t =>
             {
-                var clear = Assert.IsType<ClearScreenToken>(t);
-                Assert.Equal(ClearMode.All, clear.Mode);
-            },
-            t =>
+                var clear = TestSeq.IsType<ClearScreenToken>(t);
+                Assert.AreEqual(ClearMode.All, clear.Mode);
+            }, t =>
             {
-                var pos = Assert.IsType<CursorPositionToken>(t);
-                Assert.Equal(1, pos.Row);
-                Assert.Equal(1, pos.Column);
-            },
-            t => Assert.Equal("Welcome", Assert.IsType<TextToken>(t).Text));
+                var pos = TestSeq.IsType<CursorPositionToken>(t);
+                Assert.AreEqual(1, pos.Row);
+                Assert.AreEqual(1, pos.Column);
+            }, t => Assert.AreEqual("Welcome", TestSeq.IsType<TextToken>(t).Text));
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_AlternateScreenSequence_ReturnsCorrectSequence()
     {
         // Enter alternate screen + clear + text + exit alternate screen
         var result = AnsiTokenizer.Tokenize("\x1b[?1049h\x1b[2JHello\x1b[?1049l");
 
-        Assert.Collection(result,
-            t =>
+        TestSeq.Collection(result, t =>
             {
-                var pm = Assert.IsType<PrivateModeToken>(t);
-                Assert.Equal(1049, pm.Mode);
-                Assert.True(pm.Enable);
-            },
-            t => Assert.IsType<ClearScreenToken>(t),
-            t => Assert.Equal("Hello", Assert.IsType<TextToken>(t).Text),
-            t =>
+                var pm = TestSeq.IsType<PrivateModeToken>(t);
+                Assert.AreEqual(1049, pm.Mode);
+                Assert.IsTrue(pm.Enable);
+            }, t => TestSeq.IsType<ClearScreenToken>(t), t => Assert.AreEqual("Hello", TestSeq.IsType<TextToken>(t).Text), t =>
             {
-                var pm = Assert.IsType<PrivateModeToken>(t);
-                Assert.Equal(1049, pm.Mode);
-                Assert.False(pm.Enable);
+                var pm = TestSeq.IsType<PrivateModeToken>(t);
+                Assert.AreEqual(1049, pm.Mode);
+                Assert.IsFalse(pm.Enable);
             });
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_SaveRestoreCursor_ReturnsCorrectSequence()
     {
         // Save cursor, move, restore cursor
         var result = AnsiTokenizer.Tokenize("\x1b" + "7\x1b[10;20H\x1b" + "8");
 
-        Assert.Collection(result,
-            t => Assert.Same(SaveCursorToken.Dec, t),
-            t =>
+        TestSeq.Collection(result, t => Assert.AreSame(SaveCursorToken.Dec, t), t =>
             {
-                var pos = Assert.IsType<CursorPositionToken>(t);
-                Assert.Equal(10, pos.Row);
-                Assert.Equal(20, pos.Column);
-            },
-            t => Assert.Same(RestoreCursorToken.Dec, t));
+                var pos = TestSeq.IsType<CursorPositionToken>(t);
+                Assert.AreEqual(10, pos.Row);
+                Assert.AreEqual(20, pos.Column);
+            }, t => Assert.AreSame(RestoreCursorToken.Dec, t));
     }
 
     #endregion
 
     #region Edge Cases
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_TrailingEscape_ReturnsUnrecognizedToken()
     {
         var result = AnsiTokenizer.Tokenize("Hello\x1b");
 
-        Assert.Collection(result,
-            t => Assert.Equal("Hello", Assert.IsType<TextToken>(t).Text),
-            t => Assert.IsType<UnrecognizedSequenceToken>(t));
+        TestSeq.Collection(result, t => Assert.AreEqual("Hello", TestSeq.IsType<TextToken>(t).Text), t => TestSeq.IsType<UnrecognizedSequenceToken>(t));
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_IncompleteCsi_ReturnsUnrecognizedToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[123");
 
-        var token = Assert.Single(result);
-        Assert.IsType<UnrecognizedSequenceToken>(token);
+        var token = TestSeq.Single(result);
+        TestSeq.IsType<UnrecognizedSequenceToken>(token);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_IncompleteOsc_ReturnsText()
     {
         // OSC without terminator - should not be parsed as OSC
@@ -894,27 +863,25 @@ public class AnsiTokenizerTests
 
         // Since there's no terminator, the OSC parsing fails
         // and we get an unrecognized sequence for the ESC ]
-        Assert.True(result.Count >= 1);
+        Assert.IsTrue(result.Count >= 1);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_EmptyGrapheme_HandledCorrectly()
     {
         var result = AnsiTokenizer.Tokenize("");
-        Assert.Empty(result);
+        Assert.IsEmpty(result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_MixedSgrAndClear_ReturnsCorrectSequence()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[1;31m\x1b[2K");
 
-        Assert.Collection(result,
-            t => Assert.Equal("1;31", Assert.IsType<SgrToken>(t).Parameters),
-            t =>
+        TestSeq.Collection(result, t => Assert.AreEqual("1;31", TestSeq.IsType<SgrToken>(t).Parameters), t =>
             {
-                var clear = Assert.IsType<ClearLineToken>(t);
-                Assert.Equal(ClearMode.All, clear.Mode);
+                var clear = TestSeq.IsType<ClearLineToken>(t);
+                Assert.AreEqual(ClearMode.All, clear.Mode);
             });
     }
 
@@ -922,73 +889,73 @@ public class AnsiTokenizerTests
 
     #region DECSLRM Tests
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_DECSLRM_WithParameters_ReturnsLeftRightMarginToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[91;178s");
 
-        var token = Assert.Single(result);
-        var lrmToken = Assert.IsType<LeftRightMarginToken>(token);
-        Assert.Equal(91, lrmToken.Left);
-        Assert.Equal(178, lrmToken.Right);
+        var token = TestSeq.Single(result);
+        var lrmToken = TestSeq.IsType<LeftRightMarginToken>(token);
+        Assert.AreEqual(91, lrmToken.Left);
+        Assert.AreEqual(178, lrmToken.Right);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_SaveCursor_WithNoParameters_ReturnsSaveCursorToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[s");
 
-        var token = Assert.Single(result);
-        Assert.IsType<SaveCursorToken>(token);
+        var token = TestSeq.Single(result);
+        TestSeq.IsType<SaveCursorToken>(token);
     }
 
     #endregion
 
     #region Arrow Key With Modifiers Tests
 
-    [Theory]
-    [InlineData("\x1b[A", CursorMoveDirection.Up)]
-    [InlineData("\x1b[B", CursorMoveDirection.Down)]
-    [InlineData("\x1b[C", CursorMoveDirection.Forward)]
-    [InlineData("\x1b[D", CursorMoveDirection.Back)]
+    [TestMethod]
+    [DataRow("\x1b[A", CursorMoveDirection.Up)]
+    [DataRow("\x1b[B", CursorMoveDirection.Down)]
+    [DataRow("\x1b[C", CursorMoveDirection.Forward)]
+    [DataRow("\x1b[D", CursorMoveDirection.Back)]
     public void Tokenize_PlainArrowKey_ReturnsCursorMoveToken(string input, CursorMoveDirection expectedDirection)
     {
         var result = AnsiTokenizer.Tokenize(input);
 
-        var token = Assert.Single(result);
-        var moveToken = Assert.IsType<CursorMoveToken>(token);
-        Assert.Equal(expectedDirection, moveToken.Direction);
-        Assert.Equal(1, moveToken.Count);
+        var token = TestSeq.Single(result);
+        var moveToken = TestSeq.IsType<CursorMoveToken>(token);
+        Assert.AreEqual(expectedDirection, moveToken.Direction);
+        Assert.AreEqual(1, moveToken.Count);
     }
 
-    [Theory]
-    [InlineData("\x1b[1;2D", CursorMoveDirection.Back, 2)]   // Shift+Left
-    [InlineData("\x1b[1;5D", CursorMoveDirection.Back, 5)]   // Ctrl+Left
-    [InlineData("\x1b[1;2C", CursorMoveDirection.Forward, 2)] // Shift+Right
-    [InlineData("\x1b[1;5C", CursorMoveDirection.Forward, 5)] // Ctrl+Right
-    [InlineData("\x1b[1;3A", CursorMoveDirection.Up, 3)]     // Alt+Up
-    [InlineData("\x1b[1;6B", CursorMoveDirection.Down, 6)]   // Shift+Ctrl+Down
+    [TestMethod]
+    [DataRow("\x1b[1;2D", CursorMoveDirection.Back, 2)]   // Shift+Left
+    [DataRow("\x1b[1;5D", CursorMoveDirection.Back, 5)]   // Ctrl+Left
+    [DataRow("\x1b[1;2C", CursorMoveDirection.Forward, 2)] // Shift+Right
+    [DataRow("\x1b[1;5C", CursorMoveDirection.Forward, 5)] // Ctrl+Right
+    [DataRow("\x1b[1;3A", CursorMoveDirection.Up, 3)]     // Alt+Up
+    [DataRow("\x1b[1;6B", CursorMoveDirection.Down, 6)]   // Shift+Ctrl+Down
     public void Tokenize_ArrowKeyWithModifiers_ReturnsArrowKeyToken(string input, CursorMoveDirection expectedDirection, int expectedModifiers)
     {
         var result = AnsiTokenizer.Tokenize(input);
 
-        var token = Assert.Single(result);
-        var arrowToken = Assert.IsType<ArrowKeyToken>(token);
-        Assert.Equal(expectedDirection, arrowToken.Direction);
-        Assert.Equal(expectedModifiers, arrowToken.Modifiers);
+        var token = TestSeq.Single(result);
+        var arrowToken = TestSeq.IsType<ArrowKeyToken>(token);
+        Assert.AreEqual(expectedDirection, arrowToken.Direction);
+        Assert.AreEqual(expectedModifiers, arrowToken.Modifiers);
     }
 
-    [Theory]
-    [InlineData("\x1b[5A", CursorMoveDirection.Up, 5)]    // Move up 5 lines (no modifiers)
-    [InlineData("\x1b[10C", CursorMoveDirection.Forward, 10)] // Move right 10 columns (no modifiers)
+    [TestMethod]
+    [DataRow("\x1b[5A", CursorMoveDirection.Up, 5)]    // Move up 5 lines (no modifiers)
+    [DataRow("\x1b[10C", CursorMoveDirection.Forward, 10)] // Move right 10 columns (no modifiers)
     public void Tokenize_CursorMoveWithCount_ReturnsCursorMoveToken(string input, CursorMoveDirection expectedDirection, int expectedCount)
     {
         var result = AnsiTokenizer.Tokenize(input);
 
-        var token = Assert.Single(result);
-        var moveToken = Assert.IsType<CursorMoveToken>(token);
-        Assert.Equal(expectedDirection, moveToken.Direction);
-        Assert.Equal(expectedCount, moveToken.Count);
+        var token = TestSeq.Single(result);
+        var moveToken = TestSeq.IsType<CursorMoveToken>(token);
+        Assert.AreEqual(expectedDirection, moveToken.Direction);
+        Assert.AreEqual(expectedCount, moveToken.Count);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/AsciinemaFileWorkloadAdapterTests.cs
+++ b/tests/Hex1b.Tests/AsciinemaFileWorkloadAdapterTests.cs
@@ -1,9 +1,9 @@
 using System.Text;
 using Hex1b;
-using Xunit;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class AsciinemaFileWorkloadAdapterTests : IDisposable
 {
     private readonly List<string> _tempFiles = new();
@@ -38,7 +38,7 @@ public class AsciinemaFileWorkloadAdapterTests : IDisposable
         return filePath;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Constructor_WithValidFilePath_CreatesAdapter()
     {
         // Arrange
@@ -49,34 +49,34 @@ public class AsciinemaFileWorkloadAdapterTests : IDisposable
         await using var adapter = new AsciinemaFileWorkloadAdapter(filePath);
 
         // Assert
-        Assert.NotNull(adapter);
+        Assert.IsNotNull(adapter);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_WithNullFilePath_ThrowsArgumentException()
     {
         // Act & Assert
-        Assert.Throws<ArgumentNullException>(() => new AsciinemaFileWorkloadAdapter(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => new AsciinemaFileWorkloadAdapter(null!));
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_WithEmptyFilePath_ThrowsArgumentException()
     {
         // Act & Assert
-        Assert.Throws<ArgumentException>(() => new AsciinemaFileWorkloadAdapter(""));
+        Assert.ThrowsExactly<ArgumentException>(() => new AsciinemaFileWorkloadAdapter(""));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task StartAsync_WithNonexistentFile_ThrowsFileNotFoundException()
     {
         // Arrange
         await using var adapter = new AsciinemaFileWorkloadAdapter("/nonexistent/file.cast");
 
         // Act & Assert
-        await Assert.ThrowsAsync<FileNotFoundException>(async () => await adapter.StartAsync());
+        await Assert.ThrowsExactlyAsync<FileNotFoundException>(async () => await adapter.StartAsync());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task StartAsync_CalledTwice_ThrowsInvalidOperationException()
     {
         // Arrange
@@ -88,10 +88,10 @@ public class AsciinemaFileWorkloadAdapterTests : IDisposable
         await adapter.StartAsync();
 
         // Assert
-        await Assert.ThrowsAsync<InvalidOperationException>(async () => await adapter.StartAsync());
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () => await adapter.StartAsync());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadOutputAsync_ReadsEventsFromFile()
     {
         // Arrange
@@ -112,7 +112,7 @@ public class AsciinemaFileWorkloadAdapterTests : IDisposable
         Assert.Contains("Hello, World!", text1);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadOutputAsync_RespectsTimingDelays()
     {
         // Arrange
@@ -128,20 +128,19 @@ public class AsciinemaFileWorkloadAdapterTests : IDisposable
         // Read first event (at 0.0s)
         await Task.Delay(100);
         var output1 = await adapter.ReadOutputAsync(TestContext.Current.CancellationToken);
-        Assert.NotEmpty(output1.ToArray());
+        Assert.IsNotEmpty(output1.ToArray());
 
         // Read second event (at 0.5s, should have ~500ms delay)
         var output2 = await adapter.ReadOutputAsync(TestContext.Current.CancellationToken);
-        Assert.NotEmpty(output2.ToArray());
+        Assert.IsNotEmpty(output2.ToArray());
 
         var elapsed = DateTime.UtcNow - startTime;
 
         // Should have taken at least 400ms (allowing some margin)
-        Assert.True(elapsed.TotalMilliseconds >= 400, 
-            $"Expected at least 400ms delay, got {elapsed.TotalMilliseconds}ms");
+        Assert.IsTrue(elapsed.TotalMilliseconds >= 400, $"Expected at least 400ms delay, got {elapsed.TotalMilliseconds}ms");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SpeedMultiplier_AffectsPlaybackSpeed()
     {
         // Arrange
@@ -160,20 +159,19 @@ public class AsciinemaFileWorkloadAdapterTests : IDisposable
         // Read events
         await Task.Delay(50);
         var output1 = await adapter.ReadOutputAsync(TestContext.Current.CancellationToken);
-        Assert.NotEmpty(output1.ToArray());
+        Assert.IsNotEmpty(output1.ToArray());
 
         var output2 = await adapter.ReadOutputAsync(TestContext.Current.CancellationToken);
-        Assert.NotEmpty(output2.ToArray());
+        Assert.IsNotEmpty(output2.ToArray());
 
         var elapsed = DateTime.UtcNow - startTime;
 
         // At 2x speed, 0.5s delay should take ~250ms
         // Allow some margin (should be less than 400ms)
-        Assert.True(elapsed.TotalMilliseconds < 400,
-            $"Expected less than 400ms at 2x speed, got {elapsed.TotalMilliseconds}ms");
+        Assert.IsTrue(elapsed.TotalMilliseconds < 400, $"Expected less than 400ms at 2x speed, got {elapsed.TotalMilliseconds}ms");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SpeedMultiplier_SetToZero_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
@@ -181,10 +179,10 @@ public class AsciinemaFileWorkloadAdapterTests : IDisposable
         await using var adapter = new AsciinemaFileWorkloadAdapter(filePath);
 
         // Act & Assert
-        Assert.Throws<ArgumentOutOfRangeException>(() => adapter.SpeedMultiplier = 0);
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => adapter.SpeedMultiplier = 0);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SpeedMultiplier_SetToNegative_ThrowsArgumentOutOfRangeException()
     {
         // Arrange
@@ -192,10 +190,10 @@ public class AsciinemaFileWorkloadAdapterTests : IDisposable
         await using var adapter = new AsciinemaFileWorkloadAdapter(filePath);
 
         // Act & Assert
-        Assert.Throws<ArgumentOutOfRangeException>(() => adapter.SpeedMultiplier = -1.0);
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => adapter.SpeedMultiplier = -1.0);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Width_Height_ReadFromHeader()
     {
         // Arrange
@@ -208,11 +206,11 @@ public class AsciinemaFileWorkloadAdapterTests : IDisposable
         await Task.Delay(100); // Give time to read header
 
         // Assert
-        Assert.Equal(80, adapter.Width);
-        Assert.Equal(24, adapter.Height);
+        Assert.AreEqual(80, adapter.Width);
+        Assert.AreEqual(24, adapter.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Disconnected_FiredWhenPlaybackCompletes()
     {
         // Arrange
@@ -241,10 +239,10 @@ public class AsciinemaFileWorkloadAdapterTests : IDisposable
         await Task.Delay(200);
 
         // Assert
-        Assert.True(disconnectedFired);
+        Assert.IsTrue(disconnectedFired);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WriteInputAsync_DoesNotThrow()
     {
         // Arrange
@@ -256,7 +254,7 @@ public class AsciinemaFileWorkloadAdapterTests : IDisposable
         await adapter.WriteInputAsync(Encoding.UTF8.GetBytes("test"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ResizeAsync_DoesNotThrow()
     {
         // Arrange
@@ -268,7 +266,7 @@ public class AsciinemaFileWorkloadAdapterTests : IDisposable
         await adapter.ResizeAsync(100, 40);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DisposeAsync_StopsPlayback()
     {
         // Arrange
@@ -284,6 +282,6 @@ public class AsciinemaFileWorkloadAdapterTests : IDisposable
 
         // Assert - subsequent reads should return empty
         var output = await adapter.ReadOutputAsync(TestContext.Current.CancellationToken);
-        Assert.True(output.IsEmpty);
+        Assert.IsTrue(output.IsEmpty);
     }
 }

--- a/tests/Hex1b.Tests/AsciinemaRecorderDiagnosticShellTests.cs
+++ b/tests/Hex1b.Tests/AsciinemaRecorderDiagnosticShellTests.cs
@@ -10,6 +10,7 @@ namespace Hex1b.Tests;
 /// These tests validate both backward compatibility (recording from session start) and
 /// the new dynamic recording functionality.
 /// </summary>
+[TestClass]
 public class AsciinemaRecorderDiagnosticShellTests : IAsyncDisposable
 {
     private readonly List<string> _tempFiles = new();
@@ -133,7 +134,7 @@ public class AsciinemaRecorderDiagnosticShellTests : IAsyncDisposable
                 await Task.Delay(50, TestContext.Current.CancellationToken);
             }
 
-            throw new Xunit.Sdk.XunitException(
+            throw new AssertFailedException(
                 $"Timed out waiting for {description ?? "terminal state"}.\nLast terminal text:\n{lastText}");
         }
 
@@ -223,7 +224,7 @@ public class AsciinemaRecorderDiagnosticShellTests : IAsyncDisposable
             await Task.Delay(50, TestContext.Current.CancellationToken);
         }
 
-        throw new Xunit.Sdk.XunitException(
+        throw new AssertFailedException(
             $"Timed out waiting for {description} in recording '{path}'.\nLast file content:\n{lastContent}");
     }
 
@@ -231,7 +232,7 @@ public class AsciinemaRecorderDiagnosticShellTests : IAsyncDisposable
     // Phase 3.5.1: Backward Compatibility Tests
     // ==========================================
 
-    [Fact]
+    [TestMethod]
     public async Task AsciinemaRecorder_WithFilePath_RecordsFromSessionStart()
     {
         // Arrange
@@ -247,21 +248,21 @@ public class AsciinemaRecorderDiagnosticShellTests : IAsyncDisposable
         var content = await ReadAllTextSharedAsync(tempFile, TestContext.Current.CancellationToken);
         var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
         
-        Assert.True(lines.Length >= 2, "Should have header and at least one event");
+        Assert.IsTrue(lines.Length >= 2, "Should have header and at least one event");
         
         // Check header
         var header = JsonDocument.Parse(lines[0]);
-        Assert.Equal(2, header.RootElement.GetProperty("version").GetInt32());
-        Assert.Equal(80, header.RootElement.GetProperty("width").GetInt32());
-        Assert.Equal(24, header.RootElement.GetProperty("height").GetInt32());
+        Assert.AreEqual(2, header.RootElement.GetProperty("version").GetInt32());
+        Assert.AreEqual(80, header.RootElement.GetProperty("width").GetInt32());
+        Assert.AreEqual(24, header.RootElement.GetProperty("height").GetInt32());
         
         // First output event should have timestamp close to 0
         var firstEvent = JsonDocument.Parse(lines[1]);
         var firstTime = firstEvent.RootElement[0].GetDouble();
-        Assert.True(firstTime < 1.0, $"First event should be near time 0, was {firstTime}");
+        Assert.IsTrue(firstTime < 1.0, $"First event should be near time 0, was {firstTime}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AsciinemaRecorder_WithDiagnosticShell_CapturesInitialPrompt()
     {
         // Arrange
@@ -280,7 +281,7 @@ public class AsciinemaRecorderDiagnosticShellTests : IAsyncDisposable
         Assert.Contains("diag", content);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AsciinemaRecorder_WithDiagnosticShell_CapturesCommandOutput()
     {
         // Arrange
@@ -302,7 +303,7 @@ public class AsciinemaRecorderDiagnosticShellTests : IAsyncDisposable
     // Phase 3.5.2: Command Recording Tests
     // ==========================================
 
-    [Fact]
+    [TestMethod]
     public async Task AsciinemaRecorder_DiagnosticShell_HelpCommand_RecordsAllOutput()
     {
         // Arrange
@@ -324,7 +325,7 @@ public class AsciinemaRecorderDiagnosticShellTests : IAsyncDisposable
         Assert.Contains("ping", content);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AsciinemaRecorder_DiagnosticShell_EchoCommand_RecordsEchoedText()
     {
         // Arrange
@@ -346,7 +347,7 @@ public class AsciinemaRecorderDiagnosticShellTests : IAsyncDisposable
     // Phase 3.5.3: Dynamic Recording Tests
     // ==========================================
 
-    [Fact]
+    [TestMethod]
     public async Task AsciinemaRecorder_StartRecordingMidSession_CreatesFile()
     {
         // Arrange - create without starting recording
@@ -367,12 +368,12 @@ public class AsciinemaRecorderDiagnosticShellTests : IAsyncDisposable
         await WaitForRecordingTextAsync(tempFile, "PONG");
 
         // Assert
-        Assert.True(File.Exists(tempFile), "Recording file should exist");
+        Assert.IsTrue(File.Exists(tempFile), "Recording file should exist");
         var content = await ReadAllTextSharedAsync(tempFile, TestContext.Current.CancellationToken);
         Assert.Contains("PONG", content);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AsciinemaRecorder_StopRecording_FinalizesFile()
     {
         // Arrange
@@ -385,8 +386,8 @@ public class AsciinemaRecorderDiagnosticShellTests : IAsyncDisposable
         var completedPath = await ctx.Recorder.StopRecordingAsync();
 
         // Assert
-        Assert.Equal(tempFile, completedPath);
-        Assert.False(ctx.Recorder.IsRecording);
+        Assert.AreEqual(tempFile, completedPath);
+        Assert.IsFalse(ctx.Recorder.IsRecording);
 
         // File should be finalized and readable
         await WaitForRecordingTextAsync(tempFile, "PONG");
@@ -394,7 +395,7 @@ public class AsciinemaRecorderDiagnosticShellTests : IAsyncDisposable
         Assert.Contains("PONG", content);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AsciinemaRecorder_StopAndStartNewRecording_CreatesSeparateFiles()
     {
         // Arrange
@@ -428,7 +429,7 @@ public class AsciinemaRecorderDiagnosticShellTests : IAsyncDisposable
     // Phase 3.5.4: Non-overlapping Recording Tests
     // ==========================================
 
-    [Fact]
+    [TestMethod]
     public async Task AsciinemaRecorder_StartWhileRecording_ThrowsInvalidOperationException()
     {
         // Arrange
@@ -438,13 +439,13 @@ public class AsciinemaRecorderDiagnosticShellTests : IAsyncDisposable
         await ctx.StartAsync();
 
         // Act & Assert
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() =>
             ctx.Recorder.StartRecording(tempFile2, new AsciinemaRecorderOptions()));
         
         Assert.Contains("already recording", ex.Message.ToLower());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AsciinemaRecorder_StopWhileNotRecording_ReturnsNull()
     {
         // Arrange - create without starting recording
@@ -456,6 +457,6 @@ public class AsciinemaRecorderDiagnosticShellTests : IAsyncDisposable
         var result = await ctx.Recorder.StopRecordingAsync();
 
         // Assert
-        Assert.Null(result);
+        Assert.IsNull(result);
     }
 }

--- a/tests/Hex1b.Tests/AsciinemaRecorderTests.cs
+++ b/tests/Hex1b.Tests/AsciinemaRecorderTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Time.Testing;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class AsciinemaRecorderTests : IDisposable
 {
     private readonly List<string> _tempFiles = new();
@@ -27,7 +28,7 @@ public class AsciinemaRecorderTests : IDisposable
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FlushAsync_WritesValidAsciicastV2Format()
     {
         // Arrange
@@ -55,23 +56,23 @@ public class AsciinemaRecorderTests : IDisposable
         // Assert
         var content = await File.ReadAllTextAsync(tempFile, TestContext.Current.CancellationToken);
         var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-        Assert.True(lines.Length >= 2, "Should have header and at least one event");
+        Assert.IsTrue(lines.Length >= 2, "Should have header and at least one event");
 
         var header = JsonDocument.Parse(lines[0]);
-        Assert.Equal(2, header.RootElement.GetProperty("version").GetInt32());
-        Assert.Equal(80, header.RootElement.GetProperty("width").GetInt32());
-        Assert.Equal(24, header.RootElement.GetProperty("height").GetInt32());
-        Assert.Equal("Test Recording", header.RootElement.GetProperty("title").GetString());
+        Assert.AreEqual(2, header.RootElement.GetProperty("version").GetInt32());
+        Assert.AreEqual(80, header.RootElement.GetProperty("width").GetInt32());
+        Assert.AreEqual(24, header.RootElement.GetProperty("height").GetInt32());
+        Assert.AreEqual("Test Recording", header.RootElement.GetProperty("title").GetString());
 
         // Check for output event
         var eventArray = JsonDocument.Parse(lines[1]);
-        Assert.Equal(JsonValueKind.Array, eventArray.RootElement.ValueKind);
-        Assert.Equal(3, eventArray.RootElement.GetArrayLength());
-        Assert.Equal("o", eventArray.RootElement[1].GetString());
+        Assert.AreEqual(JsonValueKind.Array, eventArray.RootElement.ValueKind);
+        Assert.AreEqual(3, eventArray.RootElement.GetArrayLength());
+        Assert.AreEqual("o", eventArray.RootElement[1].GetString());
         Assert.Contains("Hello", eventArray.RootElement[2].GetString());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FlushAsync_RecordsResizeEvents()
     {
         // Arrange
@@ -104,16 +105,16 @@ public class AsciinemaRecorderTests : IDisposable
             var evt = JsonDocument.Parse(line);
             if (evt.RootElement[1].GetString() == "r")
             {
-                Assert.Equal("100x40", evt.RootElement[2].GetString());
+                Assert.AreEqual("100x40", evt.RootElement[2].GetString());
                 foundResize = true;
                 break;
             }
         }
 
-        Assert.True(foundResize, "Should have recorded a resize event");
+        Assert.IsTrue(foundResize, "Should have recorded a resize event");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FlushAsync_CapturesInputWhenEnabled()
     {
         // Arrange
@@ -139,14 +140,14 @@ public class AsciinemaRecorderTests : IDisposable
         // Assert
         var content = await File.ReadAllTextAsync(tempFile, TestContext.Current.CancellationToken);
         var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-        Assert.True(lines.Length >= 2);
+        Assert.IsTrue(lines.Length >= 2);
 
         var evt = JsonDocument.Parse(lines[1]);
-        Assert.Equal("i", evt.RootElement[1].GetString());
-        Assert.Equal("hello", evt.RootElement[2].GetString());
+        Assert.AreEqual("i", evt.RootElement[1].GetString());
+        Assert.AreEqual("hello", evt.RootElement[2].GetString());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FlushAsync_DoesNotCaptureInputByDefault()
     {
         // Arrange
@@ -174,10 +175,10 @@ public class AsciinemaRecorderTests : IDisposable
         var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
         
         // Should be only header (input not captured)
-        Assert.Single(lines);
+        TestSeq.Single(lines);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AddMarker_AddsMarkerEvent()
     {
         // Arrange
@@ -197,10 +198,10 @@ public class AsciinemaRecorderTests : IDisposable
         recorder.AddMarker("Chapter 1", TimeSpan.FromSeconds(5));
 
         // Assert
-        Assert.Equal(1, recorder.PendingEventCount);
+        Assert.AreEqual(1, recorder.PendingEventCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FlushAsync_IncludesMarkerEvents()
     {
         // Arrange
@@ -236,12 +237,12 @@ public class AsciinemaRecorderTests : IDisposable
             }
         }
 
-        Assert.Equal(2, markers.Count);
-        Assert.Equal("Start", markers[0]);
-        Assert.Equal("Chapter 1", markers[1]);
+        Assert.AreEqual(2, markers.Count);
+        Assert.AreEqual("Start", markers[0]);
+        Assert.AreEqual("Chapter 1", markers[1]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FlushAsync_IncludesEnvironmentWhenEnabled()
     {
         // Arrange
@@ -263,14 +264,14 @@ public class AsciinemaRecorderTests : IDisposable
         // Assert
         var content = await File.ReadAllTextAsync(tempFile, TestContext.Current.CancellationToken);
         var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-        Assert.NotEmpty(lines);
+        Assert.IsNotEmpty(lines);
 
         var header = JsonDocument.Parse(lines[0]);
-        Assert.True(header.RootElement.TryGetProperty("env", out var env));
-        Assert.True(env.TryGetProperty("TERM", out _));
+        Assert.IsTrue(header.RootElement.TryGetProperty("env", out var env));
+        Assert.IsTrue(env.TryGetProperty("TERM", out _));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FlushAsync_ExcludesEnvironmentWhenDisabled()
     {
         // Arrange
@@ -292,13 +293,13 @@ public class AsciinemaRecorderTests : IDisposable
         // Assert
         var content = await File.ReadAllTextAsync(tempFile, TestContext.Current.CancellationToken);
         var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-        Assert.NotEmpty(lines);
+        Assert.IsNotEmpty(lines);
 
         var header = JsonDocument.Parse(lines[0]);
-        Assert.False(header.RootElement.TryGetProperty("env", out _));
+        Assert.IsFalse(header.RootElement.TryGetProperty("env", out _));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ClearPending_RemovesPendingEvents()
     {
         // Arrange
@@ -308,16 +309,16 @@ public class AsciinemaRecorderTests : IDisposable
         await filter.OnSessionStartAsync(80, 24, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
         await filter.OnOutputAsync(Hex1b.Tokens.AnsiTokenizer.Tokenize("test"), TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        Assert.Equal(1, recorder.PendingEventCount);
+        Assert.AreEqual(1, recorder.PendingEventCount);
 
         // Act
         recorder.ClearPending();
 
         // Assert
-        Assert.Equal(0, recorder.PendingEventCount);
+        Assert.AreEqual(0, recorder.PendingEventCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FlushAsync_WritesToFile()
     {
         // Arrange
@@ -343,14 +344,14 @@ public class AsciinemaRecorderTests : IDisposable
         await recorder.FlushAsync(TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.True(File.Exists(tempFile));
+        Assert.IsTrue(File.Exists(tempFile));
         var content = await File.ReadAllTextAsync(tempFile, TestContext.Current.CancellationToken);
         Assert.Contains("\"version\":2", content);
         Assert.Contains("File Test", content);
         Assert.Contains("Hello!", content);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CaptureCast_AttachesToTestResults()
     {
         // Arrange
@@ -376,7 +377,7 @@ public class AsciinemaRecorderTests : IDisposable
         await TestCaptureHelper.CaptureCastAsync(recorder, "demo", TestContext.Current.CancellationToken);
 
         // Assert - check that the file was written
-        Assert.True(File.Exists(tempFile));
+        Assert.IsTrue(File.Exists(tempFile));
         var content = await File.ReadAllTextAsync(tempFile, TestContext.Current.CancellationToken);
         Assert.Contains("Green bold text", content);
     }
@@ -386,7 +387,7 @@ public class AsciinemaRecorderTests : IDisposable
     /// with resizes, navigation, text input, and button interactions.
     /// The generated .cast file can be played back with asciinema.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task RecordResponsiveTodoSession_10Seconds()
     {
         // === Setup: Create a responsive todo app similar to the website example ===
@@ -585,11 +586,11 @@ public class AsciinemaRecorderTests : IDisposable
         var content = await File.ReadAllTextAsync(tempFile, TestContext.Current.CancellationToken);
         var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
         // Surface mode is more efficient, producing fewer events than Legacy mode
-        Assert.True(lines.Length > 30, $"Should have many events, got {lines.Length}");
+        Assert.IsTrue(lines.Length > 30, $"Should have many events, got {lines.Length}");
         
         // Verify the new todos were added
-        Assert.Contains(state.Items, t => t.Title == "Buy holiday gifts");
-        Assert.Contains(state.Items, t => t.Title == "Call mom");
+        Assert.IsTrue(state.Items.Any(t => t.Title == "Buy holiday gifts"));
+        Assert.IsTrue(state.Items.Any(t => t.Title == "Call mom"));
     }
 
     // === Helper classes and methods for the responsive todo test ===

--- a/tests/Hex1b.Tests/BackgroundBleedThroughTests.cs
+++ b/tests/Hex1b.Tests/BackgroundBleedThroughTests.cs
@@ -9,9 +9,10 @@ using Microsoft.Extensions.Logging;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class BackgroundBleedThroughTests
 {
-    [Fact]
+    [TestMethod]
     public void Composite_TransparentBgPicksUpDestBackground()
     {
         var bg = Hex1bColor.FromRgb(10, 20, 30);
@@ -20,30 +21,30 @@ public class BackgroundBleedThroughTests
         var src = new Surface(10, 1);
         src[0, 0] = new SurfaceCell("H", null, null, CellAttributes.None, 1);
         dest.Composite(src, 0, 0);
-        Assert.Equal("H", dest[0, 0].Character);
-        Assert.Equal(bg, dest[0, 0].Background);
+        Assert.AreEqual("H", dest[0, 0].Character);
+        Assert.AreEqual(bg, dest[0, 0].Background);
     }
 
-    [Fact]
+    [TestMethod]
     public void FillBackground_ReplacesTransparentBg()
     {
         var bg = Hex1bColor.FromRgb(10, 20, 30);
         var surface = new Surface(5, 1);
         surface[0, 0] = new SurfaceCell("H", null, null, CellAttributes.None, 1);
         surface.FillBackground(bg);
-        Assert.Equal(bg, surface[0, 0].Background);
+        Assert.AreEqual(bg, surface[0, 0].Background);
     }
 
-    [Fact]
+    [TestMethod]
     public void FillBackground_FillsEmptyCells()
     {
         var bg = Hex1bColor.FromRgb(10, 20, 30);
         var surface = new Surface(5, 1);
         surface.FillBackground(bg);
-        Assert.Equal(bg, surface[0, 0].Background);
+        Assert.AreEqual(bg, surface[0, 0].Background);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task BackgroundPanel_TextBlock_HasPanelBackground()
     {
         var panelBg = Hex1bColor.FromRgb(10, 20, 30);
@@ -63,9 +64,8 @@ public class BackgroundBleedThroughTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
         var cell = snapshot.GetCell(0, 0);
-        Assert.True(cell.Background.HasValue,
-            $"'H' should have bg. Row:\n{DumpRow(snapshot, 0, 20)}");
-        Assert.Equal(panelBg, cell.Background.Value);
+        Assert.IsTrue(cell.Background.HasValue, $"'H' should have bg. Row:\n{DumpRow(snapshot, 0, 20)}");
+        Assert.AreEqual(panelBg, cell.Background.Value);
     }
 
     /// <summary>
@@ -73,7 +73,7 @@ public class BackgroundBleedThroughTests
     /// On top of a RED background in a ZStack. The table header and data rows
     /// must have the BLACK bg from the panel, NOT red bleed-through.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task BackgroundPanel_WithLoggerTable_NoBleedThrough()
     {
         var windowBg = Hex1bColor.FromRgb(255, 0, 0);  // RED
@@ -159,15 +159,15 @@ public class BackgroundBleedThroughTests
         report += $"\nRow 0 detail:\n{DumpRow(snapshot, 0, 50)}";
         report += $"\nRow 1 detail:\n{DumpRow(snapshot, 1, 50)}";
 
-        Assert.True(redCells.Count == 0, $"RED bleed-through detected!\n{report}");
-        Assert.True(nullBgCells.Count == 0, $"Null bg = potential bleed-through!\n{report}");
+        Assert.IsTrue(redCells.Count == 0, $"RED bleed-through detected!\n{report}");
+        Assert.IsTrue(nullBgCells.Count == 0, $"Null bg = potential bleed-through!\n{report}");
     }
 
     /// <summary>
     /// Deep nesting: ZStack → VStack → Border → BackgroundPanel → VStack → DragBarPanel → LoggerPanel.
     /// Matches the popup rendering chain depth.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task BackgroundPanel_DeeplyNested_WithDragBarAndLoggerTable()
     {
         var windowBg = Hex1bColor.FromRgb(255, 0, 0);
@@ -228,8 +228,8 @@ public class BackgroundBleedThroughTests
             }
 
         var screen = DumpScreen(snapshot, 20, 100);
-        Assert.True(redCells.Count == 0, $"RED bleed!\n{string.Join(", ", redCells.Take(20))}\n{screen}");
-        Assert.True(nullBgCells.Count == 0, $"Null bg!\n{string.Join(", ", nullBgCells.Take(20))}\n{screen}");
+        Assert.IsTrue(redCells.Count == 0, $"RED bleed!\n{string.Join(", ", redCells.Take(20))}\n{screen}");
+        Assert.IsTrue(nullBgCells.Count == 0, $"Null bg!\n{string.Join(", ", nullBgCells.Take(20))}\n{screen}");
     }
 
     private static string DumpRow(Hex1b.Automation.IHex1bTerminalRegion snap, int row, int cols)

--- a/tests/Hex1b.Tests/BorderNodeTests.cs
+++ b/tests/Hex1b.Tests/BorderNodeTests.cs
@@ -10,6 +10,7 @@ namespace Hex1b.Tests;
 /// Comprehensive tests for BorderNode layout, rendering, theming, and input handling.
 /// Tests both direct node operations and integration with Hex1bApp using fluent API.
 /// </summary>
+[TestClass]
 public class BorderNodeTests
 {
     private static Hex1bRenderContext CreateContext(IHex1bAppTerminalWorkloadAdapter workload)
@@ -19,7 +20,7 @@ public class BorderNodeTests
 
     #region Measurement Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_AddsBorderToChildSize()
     {
         var child = new TextBlockNode { Text = "Hello" };
@@ -28,11 +29,11 @@ public class BorderNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // Child is 5 wide, 1 tall. Border adds 2 to each dimension.
-        Assert.Equal(7, size.Width);
-        Assert.Equal(3, size.Height);
+        Assert.AreEqual(7, size.Width);
+        Assert.AreEqual(3, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_WithNoChild_ReturnsMinimalBorder()
     {
         var node = new BorderNode { Child = null };
@@ -40,11 +41,11 @@ public class BorderNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // Just the border: 2 wide, 2 tall
-        Assert.Equal(2, size.Width);
-        Assert.Equal(2, size.Height);
+        Assert.AreEqual(2, size.Width);
+        Assert.AreEqual(2, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_RespectsConstraints()
     {
         var child = new TextBlockNode { Text = "This is a long text line" };
@@ -52,11 +53,11 @@ public class BorderNodeTests
 
         var size = node.Measure(new Constraints(0, 15, 0, 5));
 
-        Assert.True(size.Width <= 15);
-        Assert.True(size.Height <= 5);
+        Assert.IsTrue(size.Width <= 15);
+        Assert.IsTrue(size.Height <= 5);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_WithMultilineChild_CalculatesCorrectHeight()
     {
         // Simulate a VStack with multiple children
@@ -74,11 +75,11 @@ public class BorderNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // VStack: 6 chars wide, 3 tall + 2 for border = 8x5
-        Assert.Equal(8, size.Width);
-        Assert.Equal(5, size.Height);
+        Assert.AreEqual(8, size.Width);
+        Assert.AreEqual(5, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_WithTightConstraints_RespectsMinimum()
     {
         var child = new TextBlockNode { Text = "Hi" };
@@ -87,11 +88,11 @@ public class BorderNodeTests
         // Very tight constraints
         var size = node.Measure(new Constraints(3, 3, 3, 3));
 
-        Assert.Equal(3, size.Width);
-        Assert.Equal(3, size.Height);
+        Assert.AreEqual(3, size.Width);
+        Assert.AreEqual(3, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithFixedSizeHints_RespectsHints()
     {
         var child = new TextBlockNode { Text = "Small" };
@@ -105,11 +106,11 @@ public class BorderNodeTests
         // Even with unbounded constraints, should return the fixed size
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(82, size.Width);
-        Assert.Equal(26, size.Height);
+        Assert.AreEqual(82, size.Width);
+        Assert.AreEqual(26, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithFixedSizeHints_ClampsToConstraints()
     {
         var child = new TextBlockNode { Text = "Small" };
@@ -123,11 +124,11 @@ public class BorderNodeTests
         // Constraints are smaller than hints - should clamp
         var size = node.Measure(new Constraints(0, 80, 0, 24));
 
-        Assert.Equal(80, size.Width);
-        Assert.Equal(24, size.Height);
+        Assert.AreEqual(80, size.Width);
+        Assert.AreEqual(24, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithPartialFixedHint_UsesChildForOther()
     {
         var child = new TextBlockNode { Text = "Hello" }; // 5 wide, 1 tall
@@ -140,15 +141,15 @@ public class BorderNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(20, size.Width);
-        Assert.Equal(3, size.Height); // child height (1) + border (2)
+        Assert.AreEqual(20, size.Width);
+        Assert.AreEqual(3, size.Height); // child height (1) + border (2)
     }
 
     #endregion
 
     #region Arrange Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_PositionsChildInsideBorder()
     {
         var child = new TextBlockNode { Text = "Test" };
@@ -158,14 +159,14 @@ public class BorderNodeTests
         node.Arrange(new Rect(5, 3, 20, 10));
 
         // Child should be offset by 1 in each direction
-        Assert.Equal(6, child.Bounds.X);
-        Assert.Equal(4, child.Bounds.Y);
+        Assert.AreEqual(6, child.Bounds.X);
+        Assert.AreEqual(4, child.Bounds.Y);
         // Child should be 2 smaller in each dimension
-        Assert.Equal(18, child.Bounds.Width);
-        Assert.Equal(8, child.Bounds.Height);
+        Assert.AreEqual(18, child.Bounds.Width);
+        Assert.AreEqual(8, child.Bounds.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_SetsBounds()
     {
         var node = new BorderNode { Child = new TextBlockNode { Text = "Test" } };
@@ -173,22 +174,22 @@ public class BorderNodeTests
 
         node.Arrange(bounds);
 
-        Assert.Equal(bounds, node.Bounds);
+        Assert.AreEqual(bounds, node.Bounds);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_WithMinimalBounds_DoesNotCrash()
     {
         var node = new BorderNode { Child = new TextBlockNode { Text = "Test" } };
         
         // Minimal 2x2 border with no inner space
         node.Measure(Constraints.Tight(2, 2));
-        var ex = Record.Exception(() => node.Arrange(new Rect(0, 0, 2, 2)));
+        var ex = TestSeq.RecordException(() => node.Arrange(new Rect(0, 0, 2, 2)));
         
-        Assert.Null(ex);
+        Assert.IsNull(ex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_ChildGetsZeroSizeWhenBorderFillsSpace()
     {
         var child = new TextBlockNode { Text = "Test" };
@@ -198,15 +199,15 @@ public class BorderNodeTests
         node.Arrange(new Rect(0, 0, 2, 2));
 
         // Child should have zero width and height
-        Assert.Equal(0, child.Bounds.Width);
-        Assert.Equal(0, child.Bounds.Height);
+        Assert.AreEqual(0, child.Bounds.Width);
+        Assert.AreEqual(0, child.Bounds.Height);
     }
 
     #endregion
 
     #region Rendering Tests - Border Characters
 
-    [Fact]
+    [TestMethod]
     public async Task Render_DrawsTopBorder()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -237,7 +238,7 @@ public class BorderNodeTests
         Assert.Contains("┐", topLine);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_DrawsBottomBorder()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -266,7 +267,7 @@ public class BorderNodeTests
         Assert.Contains("┘", bottomLine);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_DrawsVerticalBorders()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -293,7 +294,7 @@ public class BorderNodeTests
         Assert.Contains("│", middleLine);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_CompleteBorderBox()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -331,7 +332,7 @@ public class BorderNodeTests
 
     #region Rendering Tests - Title
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithTitle_ShowsTitleInTopBorder()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -358,7 +359,7 @@ public class BorderNodeTests
         Assert.Contains("My Title", topLine);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithLongTitle_TruncatesTitle()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -387,7 +388,7 @@ public class BorderNodeTests
         Assert.Contains("This I", topLine);  // First 6 chars of title
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithShortTitle_CentersTitleInBorder()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -418,7 +419,7 @@ public class BorderNodeTests
         Assert.Contains("T─", topLine);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithEmptyTitle_DrawsNormalBorder()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -443,10 +444,10 @@ public class BorderNodeTests
 
         var topLine = snapshot.GetLineTrimmed(0);
         // Should be ┌────────┐ without title
-        Assert.Equal("┌────────┐", topLine);
+        Assert.AreEqual("┌────────┐", topLine);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithNullTitle_DrawsNormalBorder()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -470,14 +471,14 @@ public class BorderNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
         var topLine = snapshot.GetLineTrimmed(0);
-        Assert.Equal("┌────────┐", topLine);
+        Assert.AreEqual("┌────────┐", topLine);
     }
 
     #endregion
 
     #region Rendering Tests - Child Content
 
-    [Fact]
+    [TestMethod]
     public async Task Render_RendersChildContent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -500,7 +501,7 @@ public class BorderNodeTests
         Assert.Contains("Hello", terminal.CreateSnapshot().GetScreenText());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_ChildContentInsideBorder()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -528,7 +529,7 @@ public class BorderNodeTests
         Assert.Contains("┌", line0);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithNoChild_DrawsEmptyBorder()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -558,7 +559,7 @@ public class BorderNodeTests
 
     #region Rendering Tests - Narrow Terminal
 
-    [Fact]
+    [TestMethod]
     public async Task Render_InNarrowTerminal_StillDrawsBorder()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -587,7 +588,7 @@ public class BorderNodeTests
         Assert.Contains("┘", screenText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_MinimalBorder_DrawsCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -610,15 +611,15 @@ public class BorderNodeTests
         var line1 = snapshot.GetLineTrimmed(1);
         
         // With width=2, we get: ┌┐ on top, └┘ on bottom
-        Assert.Equal("┌┐", line0);
-        Assert.Equal("└┘", line1);
+        Assert.AreEqual("┌┐", line0);
+        Assert.AreEqual("└┘", line1);
     }
 
     #endregion
 
     #region Theming Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithCustomTheme_UsesThemeCharacters()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -655,7 +656,7 @@ public class BorderNodeTests
         Assert.Contains("║", screenText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_DoubleLineBorderTheme_DrawsCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -689,17 +690,17 @@ public class BorderNodeTests
         var line1 = snapshot.GetLineTrimmed(1);
         var line2 = snapshot.GetLineTrimmed(2);
 
-        Assert.Equal("╔════╗", line0);
+        Assert.AreEqual("╔════╗", line0);
         Assert.StartsWith("║", line1);
         Assert.EndsWith("║", line1);
-        Assert.Equal("╚════╝", line2);
+        Assert.AreEqual("╚════╝", line2);
     }
 
     #endregion
 
     #region Focus Tests
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_ReturnsFocusableChildren()
     {
         var textBox = new TextBoxNode { State = new TextBoxState() };
@@ -707,11 +708,11 @@ public class BorderNodeTests
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Single(focusables);
+        TestSeq.Single(focusables);
         Assert.Contains(textBox, focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_WithNonFocusableChild_ReturnsEmpty()
     {
         var textBlock = new TextBlockNode { Text = "Not focusable" };
@@ -719,20 +720,20 @@ public class BorderNodeTests
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Empty(focusables);
+        Assert.IsEmpty(focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_WithNoChild_ReturnsEmpty()
     {
         var node = new BorderNode { Child = null };
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Empty(focusables);
+        Assert.IsEmpty(focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_WithNestedContainers_FindsAllFocusables()
     {
         var textBox1 = new TextBoxNode { State = new TextBoxState() };
@@ -745,24 +746,24 @@ public class BorderNodeTests
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Equal(2, focusables.Count);
+        Assert.AreEqual(2, focusables.Count);
         Assert.Contains(textBox1, focusables);
         Assert.Contains(textBox2, focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task IsFocusable_ReturnsFalse()
     {
         var node = new BorderNode();
 
-        Assert.False(node.IsFocusable);
+        Assert.IsFalse(node.IsFocusable);
     }
 
     #endregion
 
     #region Input Handling Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_PassesToChild()
     {
         var state = new TextBoxState { Text = "test", CursorPosition = 4 };
@@ -777,21 +778,21 @@ public class BorderNodeTests
         // Use InputRouter to dispatch input through the node tree
         var result = await InputRouter.RouteInputAsync(node, new Hex1bKeyEvent(Hex1bKey.A, 'A', Hex1bModifiers.None), focusRing, routerState, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal("testA", state.Text);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual("testA", state.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_WithNoChild_ReturnsFalse()
     {
         var node = new BorderNode { Child = null };
 
         var result = node.HandleInput(new Hex1bKeyEvent(Hex1bKey.A, 'A', Hex1bModifiers.None));
 
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_WithNonFocusedChild_ReturnsFalse()
     {
         var state = new TextBoxState { Text = "test" };
@@ -801,15 +802,15 @@ public class BorderNodeTests
         var result = node.HandleInput(new Hex1bKeyEvent(Hex1bKey.A, 'A', Hex1bModifiers.None));
 
         // TextBox should not handle input when not focused
-        Assert.Equal(InputResult.NotHandled, result);
-        Assert.Equal("test", state.Text);
+        Assert.AreEqual(InputResult.NotHandled, result);
+        Assert.AreEqual("test", state.Text);
     }
 
     #endregion
 
     #region Integration Tests with Hex1bApp
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_BorderWithTextBlock_RendersCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -836,15 +837,15 @@ public class BorderNodeTests
         await runTask;
 
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("Hello World"));
+        Assert.IsTrue(snapshot.ContainsText("Hello World"));
         // Check for border characters
-        Assert.True(snapshot.ContainsText("┌"));
-        Assert.True(snapshot.ContainsText("┐"));
-        Assert.True(snapshot.ContainsText("└"));
-        Assert.True(snapshot.ContainsText("┘"));
+        Assert.IsTrue(snapshot.ContainsText("┌"));
+        Assert.IsTrue(snapshot.ContainsText("┐"));
+        Assert.IsTrue(snapshot.ContainsText("└"));
+        Assert.IsTrue(snapshot.ContainsText("┘"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_BorderWithTitle_ShowsTitle()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -871,11 +872,11 @@ public class BorderNodeTests
         await runTask;
 
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("My Panel"));
-        Assert.True(snapshot.ContainsText("Content"));
+        Assert.IsTrue(snapshot.ContainsText("My Panel"));
+        Assert.IsTrue(snapshot.ContainsText("Content"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_BorderWithVStack_RendersMultipleLines()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -906,13 +907,13 @@ public class BorderNodeTests
         await runTask;
 
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("Line 1"));
-        Assert.True(snapshot.ContainsText("Line 2"));
-        Assert.True(snapshot.ContainsText("Line 3"));
-        Assert.True(snapshot.ContainsText("List"));
+        Assert.IsTrue(snapshot.ContainsText("Line 1"));
+        Assert.IsTrue(snapshot.ContainsText("Line 2"));
+        Assert.IsTrue(snapshot.ContainsText("Line 3"));
+        Assert.IsTrue(snapshot.ContainsText("List"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_BorderWithTextBox_HandlesFocus()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -939,10 +940,10 @@ public class BorderNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("Hello", text);
+        Assert.AreEqual("Hello", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_NestedBorders_RenderCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -971,12 +972,12 @@ public class BorderNodeTests
         await runTask;
 
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("Outer"));
-        Assert.True(snapshot.ContainsText("Inner"));
-        Assert.True(snapshot.ContainsText("Nested"));
+        Assert.IsTrue(snapshot.ContainsText("Outer"));
+        Assert.IsTrue(snapshot.ContainsText("Inner"));
+        Assert.IsTrue(snapshot.ContainsText("Nested"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_BorderInNarrowTerminal_TruncatesGracefully()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1004,11 +1005,11 @@ public class BorderNodeTests
         await runTask;
 
         // Border characters should be present - use captured snapshot
-        Assert.True(snapshot.ContainsText("┌"));
-        Assert.True(snapshot.ContainsText("┐"));
+        Assert.IsTrue(snapshot.ContainsText("┌"));
+        Assert.IsTrue(snapshot.ContainsText("┐"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_MultipleBordersInHStack_RenderSideBySide()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1038,13 +1039,13 @@ public class BorderNodeTests
         await runTask;
 
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("Left"));
-        Assert.True(snapshot.ContainsText("Right"));
-        Assert.True(snapshot.ContainsText("L"));
-        Assert.True(snapshot.ContainsText("R"));
+        Assert.IsTrue(snapshot.ContainsText("Left"));
+        Assert.IsTrue(snapshot.ContainsText("Right"));
+        Assert.IsTrue(snapshot.ContainsText("L"));
+        Assert.IsTrue(snapshot.ContainsText("R"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_BorderWithButton_HandlesClick()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1070,10 +1071,10 @@ public class BorderNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(clicked);
+        Assert.IsTrue(clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_BorderWithMultipleButtons_NavigatesFocus()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1103,10 +1104,10 @@ public class BorderNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("Second", clickedButton);
+        Assert.AreEqual("Second", clickedButton);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_BorderAtOffset_RendersAtCorrectPosition()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1136,13 +1137,13 @@ public class BorderNodeTests
         await runTask;
 
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("Header"));
-        Assert.True(snapshot.ContainsText("Content"));
+        Assert.IsTrue(snapshot.ContainsText("Header"));
+        Assert.IsTrue(snapshot.ContainsText("Content"));
         // Border characters should be present
-        Assert.True(snapshot.ContainsText("┌"));
+        Assert.IsTrue(snapshot.ContainsText("┌"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_EmptyBorder_RendersMinimalBox()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1184,7 +1185,7 @@ public class BorderNodeTests
     /// The border should use the default (empty) global background, not inherit
     /// a modified theme from a sibling ThemePanelNode.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task BorderNode_UsesGlobalBackground_WhenThemeIsDefault()
     {
         // Arrange
@@ -1198,15 +1199,15 @@ public class BorderNodeTests
         var globalBgAnsi = globalBg.IsDefault ? "" : globalBg.ToBackgroundAnsi();
         
         // Assert - default theme should have default background (empty ANSI code)
-        Assert.True(globalBg.IsDefault, "Default theme should have IsDefault=true for BackgroundColor");
-        Assert.Equal("", globalBgAnsi);
+        Assert.IsTrue(globalBg.IsDefault, "Default theme should have IsDefault=true for BackgroundColor");
+        Assert.AreEqual("", globalBgAnsi);
     }
 
     /// <summary>
     /// Verifies that when a theme is mutated with a white global background,
     /// the mutated theme returns the correct white ANSI code.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemeMutation_SetsGlobalBackground_ReturnsCorrectAnsi()
     {
         // Arrange - Clone the theme to allow mutation
@@ -1221,18 +1222,18 @@ public class BorderNodeTests
         var mutatedBg = mutatedTheme.GetGlobalBackground();
         
         // Assert
-        Assert.True(originalBg.IsDefault, "Original theme should have default background");
-        Assert.False(mutatedBg.IsDefault, "Mutated theme should NOT have default background");
-        Assert.Equal(255, mutatedBg.R);
-        Assert.Equal(255, mutatedBg.G);
-        Assert.Equal(255, mutatedBg.B);
+        Assert.IsTrue(originalBg.IsDefault, "Original theme should have default background");
+        Assert.IsFalse(mutatedBg.IsDefault, "Mutated theme should NOT have default background");
+        Assert.AreEqual(255, mutatedBg.R);
+        Assert.AreEqual(255, mutatedBg.G);
+        Assert.AreEqual(255, mutatedBg.B);
     }
 
     /// <summary>
     /// Tests that ThemePanelNode correctly restores the theme after rendering.
     /// This is critical for siblings that render after the ThemePanelNode.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanelNode_RestoresTheme_AfterRendering()
     {
         // Arrange
@@ -1258,16 +1259,16 @@ public class BorderNodeTests
         var themeAfter = context.Theme;
         var bgAfter = themeAfter.GetGlobalBackground();
         
-        Assert.True(bgBefore.IsDefault, "Theme before should have default background");
-        Assert.True(bgAfter.IsDefault, "Theme after should be restored to default background");
-        Assert.Same(themeBefore, themeAfter);
+        Assert.IsTrue(bgBefore.IsDefault, "Theme before should have default background");
+        Assert.IsTrue(bgAfter.IsDefault, "Theme after should be restored to default background");
+        Assert.AreSame(themeBefore, themeAfter);
     }
 
     /// <summary>
     /// Tests the full scenario: rendering a VStack with InfoBar (white bg theme)
     /// followed by a Border (should use default bg theme).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task VStack_WithInfoBarThenBorder_BorderHasDefaultBackground()
     {
         // This simulates the bug scenario:
@@ -1311,15 +1312,14 @@ public class BorderNodeTests
         
         // Assert
         // After infobar, theme should be restored to default
-        Assert.True(bgAfterInfoBar.IsDefault, 
-            "Theme should be restored after ThemePanelNode renders, but global background is still modified!");
+        Assert.IsTrue(bgAfterInfoBar.IsDefault, "Theme should be restored after ThemePanelNode renders, but global background is still modified!");
     }
 
     /// <summary>
     /// Tests the actual border rendering to verify no white background is in the output.
     /// This catches the case where the border incorrectly gets a background color.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task BorderNode_Render_NoBackgroundColorWhenDefaultTheme()
     {
         // Arrange
@@ -1335,20 +1335,18 @@ public class BorderNodeTests
         
         // Assert - Check the top-left corner cell's background
         var topLeftCell = surface[0, 0];
-        Assert.True(topLeftCell.Background == null, 
-            $"Top-left corner should have null background, but has RGB({topLeftCell.Background?.R},{topLeftCell.Background?.G},{topLeftCell.Background?.B})");
+        Assert.IsTrue(topLeftCell.Background == null, $"Top-left corner should have null background, but has RGB({topLeftCell.Background?.R},{topLeftCell.Background?.G},{topLeftCell.Background?.B})");
         
         // Check a border character cell (horizontal line)
         var topBorderCell = surface[1, 0];
-        Assert.True(topBorderCell.Background == null, 
-            $"Top border should have null background, but has RGB({topBorderCell.Background?.R},{topBorderCell.Background?.G},{topBorderCell.Background?.B})");
+        Assert.IsTrue(topBorderCell.Background == null, $"Top border should have null background, but has RGB({topBorderCell.Background?.R},{topBorderCell.Background?.G},{topBorderCell.Background?.B})");
     }
 
     /// <summary>
     /// Tests that after a ThemePanelNode renders with white background,
     /// a sibling BorderNode does NOT have white background in its cells.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task BorderNode_AfterThemePanelRender_NoWhiteBackground()
     {
         // Arrange
@@ -1379,35 +1377,34 @@ public class BorderNodeTests
                       borderTopLeft.Background.Value.G == 255 && 
                       borderTopLeft.Background.Value.B == 255;
         
-        Assert.False(isWhite, 
-            $"Border top-left should NOT have white background, but has RGB({borderTopLeft.Background?.R},{borderTopLeft.Background?.G},{borderTopLeft.Background?.B})");
+        Assert.IsFalse(isWhite, $"Border top-left should NOT have white background, but has RGB({borderTopLeft.Background?.R},{borderTopLeft.Background?.G},{borderTopLeft.Background?.B})");
     }
 
     #endregion
 
     #region Theme Fallback Chain Tests
 
-    [Fact]
+    [TestMethod]
     public void ThemeFallback_ExplicitValueWins()
     {
         var theme = new Hex1bTheme("Test")
             .Set(BorderTheme.TopLine, "━");
         
-        Assert.Equal("━", theme.Get(BorderTheme.TopLine));
+        Assert.AreEqual("━", theme.Get(BorderTheme.TopLine));
     }
 
-    [Fact]
+    [TestMethod]
     public void ThemeFallback_FallsBackToParentElement()
     {
         var theme = new Hex1bTheme("Test")
             .Set(BorderTheme.HorizontalLine, "═");
         
         // TopLine not set → falls back to HorizontalLine
-        Assert.Equal("═", theme.Get(BorderTheme.TopLine));
-        Assert.Equal("═", theme.Get(BorderTheme.BottomLine));
+        Assert.AreEqual("═", theme.Get(BorderTheme.TopLine));
+        Assert.AreEqual("═", theme.Get(BorderTheme.BottomLine));
     }
 
-    [Fact]
+    [TestMethod]
     public void ThemeFallback_ExplicitOverridesTakesPrecedence()
     {
         var theme = new Hex1bTheme("Test")
@@ -1415,23 +1412,23 @@ public class BorderNodeTests
             .Set(BorderTheme.TopLine, "━");
         
         // TopLine explicitly set → uses it; BottomLine falls back
-        Assert.Equal("━", theme.Get(BorderTheme.TopLine));
-        Assert.Equal("═", theme.Get(BorderTheme.BottomLine));
+        Assert.AreEqual("━", theme.Get(BorderTheme.TopLine));
+        Assert.AreEqual("═", theme.Get(BorderTheme.BottomLine));
     }
 
-    [Fact]
+    [TestMethod]
     public void ThemeFallback_DefaultThemeUsesDefaults()
     {
         var theme = new Hex1bTheme("Test");
         
         // Nothing set → falls through chain to DefaultValue
-        Assert.Equal("─", theme.Get(BorderTheme.TopLine));
-        Assert.Equal("─", theme.Get(BorderTheme.BottomLine));
-        Assert.Equal("│", theme.Get(BorderTheme.LeftLine));
-        Assert.Equal("│", theme.Get(BorderTheme.RightLine));
+        Assert.AreEqual("─", theme.Get(BorderTheme.TopLine));
+        Assert.AreEqual("─", theme.Get(BorderTheme.BottomLine));
+        Assert.AreEqual("│", theme.Get(BorderTheme.LeftLine));
+        Assert.AreEqual("│", theme.Get(BorderTheme.RightLine));
     }
 
-    [Fact]
+    [TestMethod]
     public void ThemeFallback_ColorChainResolvesCorrectly()
     {
         var red = Hex1bColor.FromRgb(255, 0, 0);
@@ -1441,14 +1438,14 @@ public class BorderNodeTests
             .Set(BorderTheme.TopBorderColor, blue);
         
         // TopBorderColor explicitly set → blue
-        Assert.Equal(blue, theme.Get(BorderTheme.TopBorderColor));
+        Assert.AreEqual(blue, theme.Get(BorderTheme.TopBorderColor));
         // BottomBorderColor → HorizontalBorderColor → BorderColor → red
-        Assert.Equal(red, theme.Get(BorderTheme.BottomBorderColor));
+        Assert.AreEqual(red, theme.Get(BorderTheme.BottomBorderColor));
         // LeftBorderColor → VerticalBorderColor → BorderColor → red
-        Assert.Equal(red, theme.Get(BorderTheme.LeftBorderColor));
+        Assert.AreEqual(red, theme.Get(BorderTheme.LeftBorderColor));
     }
 
-    [Fact]
+    [TestMethod]
     public void ThemeFallback_AxisColorOverridesBase()
     {
         var red = Hex1bColor.FromRgb(255, 0, 0);
@@ -1458,39 +1455,39 @@ public class BorderNodeTests
             .Set(BorderTheme.HorizontalBorderColor, green);
         
         // Top/Bottom → HorizontalBorderColor → green
-        Assert.Equal(green, theme.Get(BorderTheme.TopBorderColor));
-        Assert.Equal(green, theme.Get(BorderTheme.BottomBorderColor));
+        Assert.AreEqual(green, theme.Get(BorderTheme.TopBorderColor));
+        Assert.AreEqual(green, theme.Get(BorderTheme.BottomBorderColor));
         // Left/Right → VerticalBorderColor → BorderColor → red
-        Assert.Equal(red, theme.Get(BorderTheme.LeftBorderColor));
-        Assert.Equal(red, theme.Get(BorderTheme.RightBorderColor));
+        Assert.AreEqual(red, theme.Get(BorderTheme.LeftBorderColor));
+        Assert.AreEqual(red, theme.Get(BorderTheme.RightBorderColor));
     }
 
-    [Fact]
+    [TestMethod]
     public void ThemeFallback_VerticalLineChain()
     {
         var theme = new Hex1bTheme("Test")
             .Set(BorderTheme.VerticalLine, "║");
         
-        Assert.Equal("║", theme.Get(BorderTheme.LeftLine));
-        Assert.Equal("║", theme.Get(BorderTheme.RightLine));
+        Assert.AreEqual("║", theme.Get(BorderTheme.LeftLine));
+        Assert.AreEqual("║", theme.Get(BorderTheme.RightLine));
     }
 
-    [Fact]
+    [TestMethod]
     public void ThemeFallback_PerSideVerticalOverride()
     {
         var theme = new Hex1bTheme("Test")
             .Set(BorderTheme.VerticalLine, "║")
             .Set(BorderTheme.LeftLine, "┃");
         
-        Assert.Equal("┃", theme.Get(BorderTheme.LeftLine));
-        Assert.Equal("║", theme.Get(BorderTheme.RightLine));
+        Assert.AreEqual("┃", theme.Get(BorderTheme.LeftLine));
+        Assert.AreEqual("║", theme.Get(BorderTheme.RightLine));
     }
 
     #endregion
 
     #region Per-Side Border Rendering Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithDifferentTopAndBottomLines_DrawsCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1522,7 +1519,7 @@ public class BorderNodeTests
         Assert.DoesNotContain("━", line2);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithDifferentLeftAndRightLines_DrawsCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1550,7 +1547,7 @@ public class BorderNodeTests
         Assert.EndsWith("║", line1);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_HorizontalLineFallback_AppliesToBothTopAndBottom()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1578,8 +1575,8 @@ public class BorderNodeTests
         var line0 = snapshot.GetLineTrimmed(0);
         var line2 = snapshot.GetLineTrimmed(2);
 
-        Assert.Equal("╔════╗", line0);
-        Assert.Equal("╚════╝", line2);
+        Assert.AreEqual("╔════╗", line0);
+        Assert.AreEqual("╚════╝", line2);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/BracketedPasteEdgeCaseTests.cs
+++ b/tests/Hex1b.Tests/BracketedPasteEdgeCaseTests.cs
@@ -8,45 +8,46 @@ namespace Hex1b.Tests;
 /// and that content between paste markers tokenizes correctly even with unusual content.
 /// Inspired by psmux's test_ssh_vt_paste.rs edge cases.
 /// </summary>
+[TestClass]
 public class BracketedPasteEdgeCaseTests
 {
-    [Fact]
+    [TestMethod]
     public void Tokenize_PasteStartMarker_ReturnsSpecialKeyToken200()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[200~");
 
-        var token = Assert.Single(result);
-        var sk = Assert.IsType<SpecialKeyToken>(token);
-        Assert.Equal(200, sk.KeyCode);
+        var token = TestSeq.Single(result);
+        var sk = TestSeq.IsType<SpecialKeyToken>(token);
+        Assert.AreEqual(200, sk.KeyCode);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_PasteEndMarker_ReturnsSpecialKeyToken201()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[201~");
 
-        var token = Assert.Single(result);
-        var sk = Assert.IsType<SpecialKeyToken>(token);
-        Assert.Equal(201, sk.KeyCode);
+        var token = TestSeq.Single(result);
+        var sk = TestSeq.IsType<SpecialKeyToken>(token);
+        Assert.AreEqual(201, sk.KeyCode);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_CompletePasteSequence_ProducesStartContentEnd()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[200~hello world\x1b[201~");
 
-        Assert.Equal(3, result.Count);
-        Assert.IsType<SpecialKeyToken>(result[0]);
-        Assert.Equal(200, ((SpecialKeyToken)result[0]).KeyCode);
+        Assert.AreEqual(3, result.Count);
+        TestSeq.IsType<SpecialKeyToken>(result[0]);
+        Assert.AreEqual(200, ((SpecialKeyToken)result[0]).KeyCode);
 
-        Assert.IsType<TextToken>(result[1]);
-        Assert.Equal("hello world", ((TextToken)result[1]).Text);
+        TestSeq.IsType<TextToken>(result[1]);
+        Assert.AreEqual("hello world", ((TextToken)result[1]).Text);
 
-        Assert.IsType<SpecialKeyToken>(result[2]);
-        Assert.Equal(201, ((SpecialKeyToken)result[2]).KeyCode);
+        TestSeq.IsType<SpecialKeyToken>(result[2]);
+        Assert.AreEqual(201, ((SpecialKeyToken)result[2]).KeyCode);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_PasteWithEscInsideContent_TokenizesEscSeparately()
     {
         // Paste containing ESC followed by a non-CSI character
@@ -54,39 +55,39 @@ public class BracketedPasteEdgeCaseTests
         var result = AnsiTokenizer.Tokenize("\x1b[200~before\x1b[31mred\x1b[201~");
 
         // Should see: SpecialKey(200), Text("before"), SGR(31), Text("red"), SpecialKey(201)
-        Assert.True(result.Count >= 4, $"Expected at least 4 tokens, got {result.Count}");
+        Assert.IsTrue(result.Count >= 4, $"Expected at least 4 tokens, got {result.Count}");
 
-        Assert.IsType<SpecialKeyToken>(result[0]);
-        Assert.Equal(200, ((SpecialKeyToken)result[0]).KeyCode);
+        TestSeq.IsType<SpecialKeyToken>(result[0]);
+        Assert.AreEqual(200, ((SpecialKeyToken)result[0]).KeyCode);
 
-        Assert.IsType<SpecialKeyToken>(result[^1]);
-        Assert.Equal(201, ((SpecialKeyToken)result[^1]).KeyCode);
+        TestSeq.IsType<SpecialKeyToken>(result[^1]);
+        Assert.AreEqual(201, ((SpecialKeyToken)result[^1]).KeyCode);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_ConsecutivePasteSequences_ProducesSeparateMarkers()
     {
         var result = AnsiTokenizer.Tokenize(
             "\x1b[200~first\x1b[201~\x1b[200~second\x1b[201~");
 
         // Should have: Start, "first", End, Start, "second", End
-        Assert.Equal(6, result.Count);
+        Assert.AreEqual(6, result.Count);
 
-        Assert.Equal(200, ((SpecialKeyToken)result[0]).KeyCode);
-        Assert.Equal("first", ((TextToken)result[1]).Text);
-        Assert.Equal(201, ((SpecialKeyToken)result[2]).KeyCode);
-        Assert.Equal(200, ((SpecialKeyToken)result[3]).KeyCode);
-        Assert.Equal("second", ((TextToken)result[4]).Text);
-        Assert.Equal(201, ((SpecialKeyToken)result[5]).KeyCode);
+        Assert.AreEqual(200, ((SpecialKeyToken)result[0]).KeyCode);
+        Assert.AreEqual("first", ((TextToken)result[1]).Text);
+        Assert.AreEqual(201, ((SpecialKeyToken)result[2]).KeyCode);
+        Assert.AreEqual(200, ((SpecialKeyToken)result[3]).KeyCode);
+        Assert.AreEqual("second", ((TextToken)result[4]).Text);
+        Assert.AreEqual(201, ((SpecialKeyToken)result[5]).KeyCode);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_EmptyPasteSequence_ProducesStartEnd()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[200~\x1b[201~");
 
-        Assert.Equal(2, result.Count);
-        Assert.Equal(200, ((SpecialKeyToken)result[0]).KeyCode);
-        Assert.Equal(201, ((SpecialKeyToken)result[1]).KeyCode);
+        Assert.AreEqual(2, result.Count);
+        Assert.AreEqual(200, ((SpecialKeyToken)result[0]).KeyCode);
+        Assert.AreEqual(201, ((SpecialKeyToken)result[1]).KeyCode);
     }
 }

--- a/tests/Hex1b.Tests/BreadcrumbDataTests.cs
+++ b/tests/Hex1b.Tests/BreadcrumbDataTests.cs
@@ -8,6 +8,7 @@ namespace Hex1b.Tests;
 /// Tests for <see cref="BreadcrumbData"/>, <see cref="BreadcrumbSymbol"/>,
 /// and their integration with <see cref="IEditorSession"/> on <see cref="EditorNode"/>.
 /// </summary>
+[TestClass]
 public class BreadcrumbDataTests
 {
     private static IEditorSession CreateSession(string text = "test")
@@ -20,7 +21,7 @@ public class BreadcrumbDataTests
 
     // ── IEditorSession integration ───────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void SetBreadcrumbs_WithData_StoresAndReturnsBreadcrumbs()
     {
         var session = CreateSession();
@@ -31,12 +32,12 @@ public class BreadcrumbDataTests
 
         session.SetBreadcrumbs(data);
 
-        Assert.NotNull(session.Breadcrumbs);
-        Assert.Single(session.Breadcrumbs!.Symbols);
-        Assert.Equal("Program", session.Breadcrumbs.Symbols[0].Name);
+        Assert.IsNotNull(session.Breadcrumbs);
+        TestSeq.Single(session.Breadcrumbs!.Symbols);
+        Assert.AreEqual("Program", session.Breadcrumbs.Symbols[0].Name);
     }
 
-    [Fact]
+    [TestMethod]
     public void SetBreadcrumbs_Null_ClearsBreadcrumbs()
     {
         var session = CreateSession();
@@ -47,18 +48,18 @@ public class BreadcrumbDataTests
 
         session.SetBreadcrumbs(null);
 
-        Assert.Null(session.Breadcrumbs);
+        Assert.IsNull(session.Breadcrumbs);
     }
 
-    [Fact]
+    [TestMethod]
     public void Breadcrumbs_Default_ReturnsNull()
     {
         var session = CreateSession();
 
-        Assert.Null(session.Breadcrumbs);
+        Assert.IsNull(session.Breadcrumbs);
     }
 
-    [Fact]
+    [TestMethod]
     public void SetBreadcrumbs_CalledTwice_ReplacesData()
     {
         var session = CreateSession();
@@ -74,14 +75,14 @@ public class BreadcrumbDataTests
         session.SetBreadcrumbs(first);
         session.SetBreadcrumbs(second);
 
-        Assert.NotNull(session.Breadcrumbs);
-        Assert.Single(session.Breadcrumbs!.Symbols);
-        Assert.Equal("Second", session.Breadcrumbs.Symbols[0].Name);
+        Assert.IsNotNull(session.Breadcrumbs);
+        TestSeq.Single(session.Breadcrumbs!.Symbols);
+        Assert.AreEqual("Second", session.Breadcrumbs.Symbols[0].Name);
     }
 
     // ── BreadcrumbSymbol construction ────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void BreadcrumbSymbol_WithChildren_CreatesHierarchy()
     {
         var children = new List<BreadcrumbSymbol>
@@ -93,22 +94,22 @@ public class BreadcrumbDataTests
         var parent = new BreadcrumbSymbol("OuterClass", BreadcrumbSymbolKind.Class,
             new DocumentPosition(1, 1), new DocumentPosition(10, 1), children);
 
-        Assert.NotNull(parent.Children);
-        Assert.Single(parent.Children!);
-        Assert.Equal("InnerMethod", parent.Children[0].Name);
-        Assert.Equal(BreadcrumbSymbolKind.Method, parent.Children[0].Kind);
+        Assert.IsNotNull(parent.Children);
+        TestSeq.Single(parent.Children!);
+        Assert.AreEqual("InnerMethod", parent.Children[0].Name);
+        Assert.AreEqual(BreadcrumbSymbolKind.Method, parent.Children[0].Kind);
     }
 
-    [Fact]
+    [TestMethod]
     public void BreadcrumbSymbol_WithoutChildren_HasNullChildren()
     {
         var symbol = new BreadcrumbSymbol("Standalone", BreadcrumbSymbolKind.Function,
             new DocumentPosition(1, 1), new DocumentPosition(5, 1));
 
-        Assert.Null(symbol.Children);
+        Assert.IsNull(symbol.Children);
     }
 
-    [Fact]
+    [TestMethod]
     public void BreadcrumbSymbol_NestedHierarchy_ClassMethodBlock()
     {
         var block = new BreadcrumbSymbol("if-block", BreadcrumbSymbolKind.Object,
@@ -122,62 +123,62 @@ public class BreadcrumbDataTests
             new DocumentPosition(1, 1), new DocumentPosition(11, 1),
             [method]);
 
-        Assert.Equal("MyService", cls.Name);
-        Assert.Single(cls.Children!);
-        Assert.Equal("Execute", cls.Children![0].Name);
-        Assert.Single(cls.Children[0].Children!);
-        Assert.Equal("if-block", cls.Children[0].Children![0].Name);
+        Assert.AreEqual("MyService", cls.Name);
+        TestSeq.Single(cls.Children!);
+        Assert.AreEqual("Execute", cls.Children![0].Name);
+        TestSeq.Single(cls.Children[0].Children!);
+        Assert.AreEqual("if-block", cls.Children[0].Children![0].Name);
     }
 
     // ── BreadcrumbSymbolKind ─────────────────────────────────
 
-    [Theory]
-    [InlineData(BreadcrumbSymbolKind.File)]
-    [InlineData(BreadcrumbSymbolKind.Module)]
-    [InlineData(BreadcrumbSymbolKind.Namespace)]
-    [InlineData(BreadcrumbSymbolKind.Package)]
-    [InlineData(BreadcrumbSymbolKind.Class)]
-    [InlineData(BreadcrumbSymbolKind.Method)]
-    [InlineData(BreadcrumbSymbolKind.Property)]
-    [InlineData(BreadcrumbSymbolKind.Field)]
-    [InlineData(BreadcrumbSymbolKind.Constructor)]
-    [InlineData(BreadcrumbSymbolKind.Enum)]
-    [InlineData(BreadcrumbSymbolKind.Interface)]
-    [InlineData(BreadcrumbSymbolKind.Function)]
-    [InlineData(BreadcrumbSymbolKind.Variable)]
-    [InlineData(BreadcrumbSymbolKind.Constant)]
-    [InlineData(BreadcrumbSymbolKind.String)]
-    [InlineData(BreadcrumbSymbolKind.Number)]
-    [InlineData(BreadcrumbSymbolKind.Boolean)]
-    [InlineData(BreadcrumbSymbolKind.Array)]
-    [InlineData(BreadcrumbSymbolKind.Object)]
-    [InlineData(BreadcrumbSymbolKind.Key)]
-    [InlineData(BreadcrumbSymbolKind.Null)]
-    [InlineData(BreadcrumbSymbolKind.EnumMember)]
-    [InlineData(BreadcrumbSymbolKind.Struct)]
-    [InlineData(BreadcrumbSymbolKind.Event)]
-    [InlineData(BreadcrumbSymbolKind.Operator)]
-    [InlineData(BreadcrumbSymbolKind.TypeParameter)]
+    [TestMethod]
+    [DataRow(BreadcrumbSymbolKind.File)]
+    [DataRow(BreadcrumbSymbolKind.Module)]
+    [DataRow(BreadcrumbSymbolKind.Namespace)]
+    [DataRow(BreadcrumbSymbolKind.Package)]
+    [DataRow(BreadcrumbSymbolKind.Class)]
+    [DataRow(BreadcrumbSymbolKind.Method)]
+    [DataRow(BreadcrumbSymbolKind.Property)]
+    [DataRow(BreadcrumbSymbolKind.Field)]
+    [DataRow(BreadcrumbSymbolKind.Constructor)]
+    [DataRow(BreadcrumbSymbolKind.Enum)]
+    [DataRow(BreadcrumbSymbolKind.Interface)]
+    [DataRow(BreadcrumbSymbolKind.Function)]
+    [DataRow(BreadcrumbSymbolKind.Variable)]
+    [DataRow(BreadcrumbSymbolKind.Constant)]
+    [DataRow(BreadcrumbSymbolKind.String)]
+    [DataRow(BreadcrumbSymbolKind.Number)]
+    [DataRow(BreadcrumbSymbolKind.Boolean)]
+    [DataRow(BreadcrumbSymbolKind.Array)]
+    [DataRow(BreadcrumbSymbolKind.Object)]
+    [DataRow(BreadcrumbSymbolKind.Key)]
+    [DataRow(BreadcrumbSymbolKind.Null)]
+    [DataRow(BreadcrumbSymbolKind.EnumMember)]
+    [DataRow(BreadcrumbSymbolKind.Struct)]
+    [DataRow(BreadcrumbSymbolKind.Event)]
+    [DataRow(BreadcrumbSymbolKind.Operator)]
+    [DataRow(BreadcrumbSymbolKind.TypeParameter)]
     public void BreadcrumbSymbolKind_AllValues_AreValidForSymbol(BreadcrumbSymbolKind kind)
     {
         var symbol = new BreadcrumbSymbol("test", kind,
             new DocumentPosition(1, 1), new DocumentPosition(1, 5));
 
-        Assert.Equal(kind, symbol.Kind);
+        Assert.AreEqual(kind, symbol.Kind);
     }
 
     // ── BreadcrumbData construction ──────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void BreadcrumbData_EmptySymbolList_IsValid()
     {
         var data = new BreadcrumbData([]);
 
-        Assert.NotNull(data.Symbols);
-        Assert.Empty(data.Symbols);
+        Assert.IsNotNull(data.Symbols);
+        Assert.IsEmpty(data.Symbols);
     }
 
-    [Fact]
+    [TestMethod]
     public void BreadcrumbData_MultipleTopLevelSymbols_PreservesAll()
     {
         var data = new BreadcrumbData([
@@ -189,15 +190,15 @@ public class BreadcrumbDataTests
                 new DocumentPosition(22, 1), new DocumentPosition(25, 1))
         ]);
 
-        Assert.Equal(3, data.Symbols.Count);
-        Assert.Equal("ClassA", data.Symbols[0].Name);
-        Assert.Equal("ClassB", data.Symbols[1].Name);
-        Assert.Equal("EnumC", data.Symbols[2].Name);
+        Assert.AreEqual(3, data.Symbols.Count);
+        Assert.AreEqual("ClassA", data.Symbols[0].Name);
+        Assert.AreEqual("ClassB", data.Symbols[1].Name);
+        Assert.AreEqual("EnumC", data.Symbols[2].Name);
     }
 
     // ── Record equality ──────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void BreadcrumbSymbol_RecordEquality_EqualWhenSameValues()
     {
         var a = new BreadcrumbSymbol("Foo", BreadcrumbSymbolKind.Method,
@@ -205,10 +206,10 @@ public class BreadcrumbDataTests
         var b = new BreadcrumbSymbol("Foo", BreadcrumbSymbolKind.Method,
             new DocumentPosition(1, 1), new DocumentPosition(5, 1));
 
-        Assert.Equal(a, b);
+        Assert.AreEqual(a, b);
     }
 
-    [Fact]
+    [TestMethod]
     public void BreadcrumbSymbol_RecordEquality_NotEqualWhenDifferentKind()
     {
         var a = new BreadcrumbSymbol("Foo", BreadcrumbSymbolKind.Method,
@@ -216,6 +217,6 @@ public class BreadcrumbDataTests
         var b = new BreadcrumbSymbol("Foo", BreadcrumbSymbolKind.Property,
             new DocumentPosition(1, 1), new DocumentPosition(5, 1));
 
-        Assert.NotEqual(a, b);
+        Assert.AreNotEqual(a, b);
     }
 }

--- a/tests/Hex1b.Tests/ButtonNodeTests.cs
+++ b/tests/Hex1b.Tests/ButtonNodeTests.cs
@@ -9,11 +9,12 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for ButtonNode rendering and input handling.
 /// </summary>
+[TestClass]
 public class ButtonNodeTests
 {
     #region Measurement Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_ReturnsCorrectSize()
     {
         var node = new ButtonNode { Label = "Click" };
@@ -21,11 +22,11 @@ public class ButtonNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // " Click " = 2 (chip padding) + 5 label = 7
-        Assert.Equal(7, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(7, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_CJKCharacters_CorrectSize()
     {
         var node = new ButtonNode { Label = "汉字かな한글" };
@@ -33,11 +34,11 @@ public class ButtonNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // " 汉字かな한글 " = 2 (chip padding) + 6 (CJK chars) * 2 (width) = 14
-        Assert.Equal(14, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(14, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_EmptyLabel_HasMinSize()
     {
         var node = new ButtonNode { Label = "" };
@@ -45,10 +46,10 @@ public class ButtonNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // "  " = 2 (chip padding only)
-        Assert.Equal(2, size.Width);
+        Assert.AreEqual(2, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_LongLabel_MeasuresFullWidth()
     {
         var node = new ButtonNode { Label = "Click Here To Continue" };
@@ -56,35 +57,35 @@ public class ButtonNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // 22 chars + 2 chip padding = 24
-        Assert.Equal(24, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(24, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_RespectsMaxWidthConstraint()
     {
         var node = new ButtonNode { Label = "A Very Long Button Label" };
 
         var size = node.Measure(new Constraints(0, 15, 0, 5));
 
-        Assert.Equal(15, size.Width);
+        Assert.AreEqual(15, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_RespectsMinWidthConstraint()
     {
         var node = new ButtonNode { Label = "OK" };
 
         var size = node.Measure(new Constraints(20, 30, 0, 5));
 
-        Assert.Equal(20, size.Width);
+        Assert.AreEqual(20, size.Width);
     }
 
     #endregion
 
     #region Rendering Tests - Unfocused State
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Unfocused_RendersLabelInChip()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -107,13 +108,13 @@ public class ButtonNodeTests
 
         Assert.Contains("OK", snapshot.GetLineTrimmed(0));
         // Chip layout: cell 0 = leading pad, cells 1-2 = label, cell 3 = trailing pad
-        Assert.Equal(" ", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("O", snapshot.GetCell(1, 0).Character);
-        Assert.Equal("K", snapshot.GetCell(2, 0).Character);
-        Assert.Equal(" ", snapshot.GetCell(3, 0).Character);
+        Assert.AreEqual(" ", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("O", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("K", snapshot.GetCell(2, 0).Character);
+        Assert.AreEqual(" ", snapshot.GetCell(3, 0).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Unfocused_PaintsRestingChipBackground()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -138,11 +139,11 @@ public class ButtonNodeTests
         // Every cell of the chip — both pads and the label — sits on the resting background.
         for (var x = 0; x <= 5; x++)
         {
-            Assert.Equal(expectedRestingBg, snapshot.GetCell(x, 0).Background);
+            Assert.AreEqual(expectedRestingBg, snapshot.GetCell(x, 0).Background);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Unfocused_EmptyLabel_StillRendersChipPad()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -164,17 +165,17 @@ public class ButtonNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
         var expectedRestingBg = context.Theme.Get(ButtonTheme.BackgroundColor);
-        Assert.Equal(" ", snapshot.GetCell(0, 0).Character);
-        Assert.Equal(" ", snapshot.GetCell(1, 0).Character);
-        Assert.Equal(expectedRestingBg, snapshot.GetCell(0, 0).Background);
-        Assert.Equal(expectedRestingBg, snapshot.GetCell(1, 0).Background);
+        Assert.AreEqual(" ", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual(" ", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual(expectedRestingBg, snapshot.GetCell(0, 0).Background);
+        Assert.AreEqual(expectedRestingBg, snapshot.GetCell(1, 0).Background);
     }
 
     #endregion
 
     #region Rendering Tests - Focused State
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Focused_HasDifferentStyle()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -195,11 +196,11 @@ public class ButtonNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
         // Should contain styling for focus
-        Assert.True(snapshot.HasForegroundColor() || snapshot.HasBackgroundColor() || snapshot.HasAttribute(CellAttributes.Reverse));
+        Assert.IsTrue(snapshot.HasForegroundColor() || snapshot.HasBackgroundColor() || snapshot.HasAttribute(CellAttributes.Reverse));
         Assert.Contains("OK", snapshot.GetLineTrimmed(0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Focused_ContainsLabel()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -222,7 +223,7 @@ public class ButtonNodeTests
         Assert.Contains("Submit Form", snapshot.GetLineTrimmed(0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_FocusedAndUnfocused_ProduceDifferentOutput()
     {
         using var focusedWorkload = new Hex1bAppWorkloadAdapter();
@@ -254,7 +255,7 @@ public class ButtonNodeTests
 
         // Focused button should have different styling (colors or attributes)
         var focusedMatch = focusedTerminal.CreateSnapshot().SearchPattern(pattern).First;
-        Assert.NotNull(focusedMatch);
+        Assert.IsNotNull(focusedMatch);
 
         // The focused button should have either reverse attribute or foreground/background colors
         var focusedCells = focusedMatch.Cells;
@@ -263,10 +264,10 @@ public class ButtonNodeTests
             c.Cell.Foreground.HasValue ||
             c.Cell.Background.HasValue);
 
-        Assert.True(focusedHasStyling, "Focused button should have styling applied");
+        Assert.IsTrue(focusedHasStyling, "Focused button should have styling applied");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Focused_PaintsFocusedChipBackground()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -291,17 +292,17 @@ public class ButtonNodeTests
         // Every cell of the chip — both pads and the label — sits on the focused background.
         for (var x = 0; x <= 5; x++)
         {
-            Assert.Equal(expectedFocusedBg, snapshot.GetCell(x, 0).Background);
+            Assert.AreEqual(expectedFocusedBg, snapshot.GetCell(x, 0).Background);
         }
-        Assert.Equal("S", snapshot.GetCell(1, 0).Character);
-        Assert.Equal("e", snapshot.GetCell(4, 0).Character);
+        Assert.AreEqual("S", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("e", snapshot.GetCell(4, 0).Character);
     }
 
     #endregion
 
     #region Input Handling Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Enter_TriggersClickAction()
     {
         var clicked = false;
@@ -314,11 +315,11 @@ public class ButtonNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Enter, '\r', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(clicked);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Space_TriggersClickAction()
     {
         var clicked = false;
@@ -331,11 +332,11 @@ public class ButtonNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Spacebar, ' ', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(clicked);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_OtherKey_DoesNotClick()
     {
         var clicked = false;
@@ -348,11 +349,11 @@ public class ButtonNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.A, 'a', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.NotHandled, result);
-        Assert.False(clicked);
+        Assert.AreEqual(InputResult.NotHandled, result);
+        Assert.IsFalse(clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_NotFocused_DoesNotClick()
     {
         var clicked = false;
@@ -367,11 +368,11 @@ public class ButtonNodeTests
 
         // Bindings execute regardless of focus (focus check is for HandleInput fallback)
         // But the action should still fire since bindings don't check focus
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(clicked);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_NullClickAction_DoesNotThrow()
     {
         var node = new ButtonNode
@@ -384,10 +385,10 @@ public class ButtonNodeTests
         // With no ClickAction, no bindings are registered, so Enter falls through
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Enter, '\r', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Tab_DoesNotTriggerClick()
     {
         var clicked = false;
@@ -400,27 +401,27 @@ public class ButtonNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Tab, '\t', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.NotHandled, result);
-        Assert.False(clicked);
+        Assert.AreEqual(InputResult.NotHandled, result);
+        Assert.IsFalse(clicked);
     }
 
     #endregion
 
     #region Focus Tests
 
-    [Fact]
+    [TestMethod]
     public async Task IsFocusable_ReturnsTrue()
     {
         var node = new ButtonNode();
 
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
 
     #endregion
 
     #region Layout Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_SetsBounds()
     {
         var node = new ButtonNode { Label = "Test" };
@@ -428,14 +429,14 @@ public class ButtonNodeTests
 
         node.Arrange(bounds);
 
-        Assert.Equal(bounds, node.Bounds);
+        Assert.AreEqual(bounds, node.Bounds);
     }
 
     #endregion
 
     #region Integration Tests with Hex1bApp
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Button_RendersViaHex1bApp()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -460,10 +461,10 @@ public class ButtonNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Click Me"));
+        Assert.IsTrue(snapshot.ContainsText("Click Me"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Button_Enter_TriggersAction()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -490,10 +491,10 @@ public class ButtonNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(clicked);
+        Assert.IsTrue(clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Button_Space_TriggersAction()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -520,10 +521,10 @@ public class ButtonNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(clicked);
+        Assert.IsTrue(clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Button_ClickUpdatesState()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -555,11 +556,11 @@ public class ButtonNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal(3, counter);
-        Assert.True(snapshot.ContainsText("Count: 3"));
+        Assert.AreEqual(3, counter);
+        Assert.IsTrue(snapshot.ContainsText("Count: 3"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_MultipleButtons_TabNavigates()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -590,11 +591,11 @@ public class ButtonNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.False(button1Clicked);
-        Assert.True(button2Clicked);
+        Assert.IsFalse(button1Clicked);
+        Assert.IsTrue(button2Clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Button_InNarrowTerminal_StillWorks()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -621,11 +622,11 @@ public class ButtonNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(clicked);
-        Assert.True(snapshot.ContainsText("OK"));
+        Assert.IsTrue(clicked);
+        Assert.IsTrue(snapshot.ContainsText("OK"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Button_LongLabelInNarrowTerminal_Wraps()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -651,10 +652,10 @@ public class ButtonNodeTests
         await runTask;
 
         // The button text should be present (possibly wrapped)
-        Assert.True(snapshot.ContainsText("Click Here"));
+        Assert.IsTrue(snapshot.ContainsText("Click Here"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Button_WithTextBox_TabBetween()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -686,11 +687,11 @@ public class ButtonNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("Hi", text);
-        Assert.True(buttonClicked);
+        Assert.AreEqual("Hi", text);
+        Assert.IsTrue(buttonClicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Button_MultipleClicks_AllProcessed()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -722,10 +723,10 @@ public class ButtonNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal(5, clickCount);
+        Assert.AreEqual(5, clickCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Button_DynamicLabel_UpdatesOnRender()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -754,7 +755,7 @@ public class ButtonNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Clicked 2 times"));
+        Assert.IsTrue(snapshot.ContainsText("Clicked 2 times"));
     }
 
     #endregion

--- a/tests/Hex1b.Tests/CalendarWidgetTests.cs
+++ b/tests/Hex1b.Tests/CalendarWidgetTests.cs
@@ -6,6 +6,7 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class CalendarWidgetTests
 {
     /// <summary>
@@ -30,16 +31,16 @@ public class CalendarWidgetTests
 
     #region Grid Construction Tests
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_ProducesSevenColumns()
     {
         var widget = new CalendarWidget(new DateOnly(2026, 3, 1));
         var (grid, _) = BuildGrid(widget);
 
-        Assert.Equal(7, grid.ColumnDefinitions.Count);
+        Assert.AreEqual(7, grid.ColumnDefinitions.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_WithHeader_HasHeaderAndDayCells()
     {
         var widget = new CalendarWidget(new DateOnly(2026, 3, 1));
@@ -47,39 +48,39 @@ public class CalendarWidgetTests
 
         // March 2026: starts on Sunday, 31 days
         // Total cells = 7 (header) + 31 (days) = 38
-        Assert.Equal(38, grid.Cells.Count);
+        Assert.AreEqual(38, grid.Cells.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_WithoutHeader_HasNoDayLabels()
     {
         var widget = new CalendarWidget(new DateOnly(2026, 3, 1)) { ShowHeader = false };
         var (grid, _) = BuildGrid(widget);
 
-        Assert.Equal(31, grid.Cells.Count);
+        Assert.AreEqual(31, grid.Cells.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_March2026_CorrectRowCount()
     {
         // March 2026 starts on Sunday, 31 days → 5 week rows + 1 header = 6 rows
         var widget = new CalendarWidget(new DateOnly(2026, 3, 1));
         var (grid, _) = BuildGrid(widget);
 
-        Assert.Equal(6, grid.RowDefinitions.Count);
+        Assert.AreEqual(6, grid.RowDefinitions.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_February2026_CorrectRowCount()
     {
         // Feb 2026 starts on Sunday, 28 days → 4 week rows + 1 header = 5 rows
         var widget = new CalendarWidget(new DateOnly(2026, 2, 1));
         var (grid, _) = BuildGrid(widget, daysInMonth: 28);
 
-        Assert.Equal(5, grid.RowDefinitions.Count);
+        Assert.AreEqual(5, grid.RowDefinitions.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_MonthStartingMidWeek_CorrectPlacement()
     {
         // April 2026 starts on Wednesday (day of week = 3)
@@ -89,11 +90,11 @@ public class CalendarWidgetTests
         // First day cell is after the 7 header cells, at column 3 (Wednesday)
         var dayCells = grid.Cells.Skip(7).ToList();
         var firstDayCell = dayCells[0];
-        Assert.Equal(3, firstDayCell.ColumnIndex);
-        Assert.Equal(1, firstDayCell.RowIndex);
+        Assert.AreEqual(3, firstDayCell.ColumnIndex);
+        Assert.AreEqual(1, firstDayCell.RowIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_MondayFirstDay_ShiftsColumns()
     {
         // March 2026 starts on Sunday. With Monday as first day, Sunday = column 6
@@ -105,10 +106,10 @@ public class CalendarWidgetTests
 
         var dayCells = grid.Cells.Skip(7).ToList();
         var firstDayCell = dayCells[0];
-        Assert.Equal(6, firstDayCell.ColumnIndex);
+        Assert.AreEqual(6, firstDayCell.ColumnIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_LastDayInCorrectPosition()
     {
         // March 2026: 31 days, starts Sunday, day 31 at col 2 (Tuesday)
@@ -117,32 +118,32 @@ public class CalendarWidgetTests
 
         var dayCells = grid.Cells.Skip(7).ToList();
         var lastDayCell = dayCells[^1];
-        Assert.Equal(2, lastDayCell.ColumnIndex);
+        Assert.AreEqual(2, lastDayCell.ColumnIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_DefaultMode_HasGridLines()
     {
         var widget = new CalendarWidget(new DateOnly(2026, 3, 1));
         var (grid, _) = BuildGrid(widget);
 
-        Assert.Equal(GridLinesMode.All, grid.GridLines);
+        Assert.AreEqual(GridLinesMode.All, grid.GridLines);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_CompactMode_NoGridLines()
     {
         var widget = new CalendarWidget(new DateOnly(2026, 3, 1)) { IsCompact = true };
         var (grid, _) = BuildGrid(widget);
 
-        Assert.Equal(GridLinesMode.None, grid.GridLines);
+        Assert.AreEqual(GridLinesMode.None, grid.GridLines);
     }
 
     #endregion
 
     #region Day Cell Interactable Tests
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_DayCells_AreInteractableWidgets()
     {
         var widget = new CalendarWidget(new DateOnly(2026, 3, 1))
@@ -155,11 +156,11 @@ public class CalendarWidgetTests
         var dayCells = grid.Cells.Skip(7).ToList();
         foreach (var cell in dayCells)
         {
-            Assert.IsType<InteractableWidget>(cell.Child);
+            TestSeq.IsType<InteractableWidget>(cell.Child);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_HeaderCells_AreCalendarHeaderWidgets()
     {
         var widget = new CalendarWidget(new DateOnly(2026, 3, 1));
@@ -168,7 +169,7 @@ public class CalendarWidgetTests
         var headerCells = grid.Cells.Take(7).ToList();
         foreach (var cell in headerCells)
         {
-            Assert.IsType<CalendarHeaderWidget>(cell.Child);
+            TestSeq.IsType<CalendarHeaderWidget>(cell.Child);
         }
     }
 
@@ -176,7 +177,7 @@ public class CalendarWidgetTests
 
     #region Day Builder Tests
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_WithDayBuilder_CreatesHStackInsideInteractable()
     {
         var widget = new CalendarWidget(new DateOnly(2026, 3, 1))
@@ -190,10 +191,10 @@ public class CalendarWidgetTests
         var day1Cell = dayCells[0];
 
         // The cell is an InteractableWidget; its builder produces an HStack
-        Assert.IsType<InteractableWidget>(day1Cell.Child);
+        TestSeq.IsType<InteractableWidget>(day1Cell.Child);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_CompactMode_SkipsDayBuilder()
     {
         var builderCalled = false;
@@ -211,15 +212,15 @@ public class CalendarWidgetTests
 
         // Force the InteractableWidget builders to run
         var dayCells = grid.Cells.Skip(7).ToList();
-        var interactable = Assert.IsType<InteractableWidget>(dayCells[0].Child);
+        var interactable = TestSeq.IsType<InteractableWidget>(dayCells[0].Child);
         var dummyNode = new InteractableNode();
         var ic = new InteractableContext(dummyNode);
         interactable.Builder(ic);
 
-        Assert.False(builderCalled, "Day builder should not be called in compact mode");
+        Assert.IsFalse(builderCalled, "Day builder should not be called in compact mode");
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_NonCompact_UsesFillColumnsContentRows()
     {
         var widget = new CalendarWidget(new DateOnly(2026, 3, 1));
@@ -227,15 +228,15 @@ public class CalendarWidgetTests
 
         foreach (var col in grid.ColumnDefinitions)
         {
-            Assert.True(col.Width.IsFill, "Non-compact columns should use Fill sizing");
+            Assert.IsTrue(col.Width.IsFill, "Non-compact columns should use Fill sizing");
         }
         foreach (var row in grid.RowDefinitions)
         {
-            Assert.True(row.Height.IsContent, "Non-compact rows should use Content sizing");
+            Assert.IsTrue(row.Height.IsContent, "Non-compact rows should use Content sizing");
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_Compact_UsesContentSizing()
     {
         var widget = new CalendarWidget(new DateOnly(2026, 3, 1)) { IsCompact = true };
@@ -243,11 +244,11 @@ public class CalendarWidgetTests
 
         foreach (var col in grid.ColumnDefinitions)
         {
-            Assert.True(col.Width.IsContent, "Compact columns should use Content sizing");
+            Assert.IsTrue(col.Width.IsContent, "Compact columns should use Content sizing");
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_DayBuilder_ReceivesCorrectContext()
     {
         CalendarDayContext? capturedContext = null;
@@ -270,24 +271,24 @@ public class CalendarWidgetTests
         // Force the InteractableWidget builders to run to capture context
         var dayCells = grid.Cells.Skip(7).ToList();
         var day14Cell = dayCells[13];
-        var interactable = Assert.IsType<InteractableWidget>(day14Cell.Child);
+        var interactable = TestSeq.IsType<InteractableWidget>(day14Cell.Child);
         // Invoke the builder with a dummy context to trigger the DayBuilder
         var dummyNode = new InteractableNode();
         var ic = new InteractableContext(dummyNode);
         interactable.Builder(ic);
 
-        Assert.NotNull(capturedContext);
-        Assert.Equal(new DateOnly(2026, 3, 14), capturedContext.Date);
-        Assert.True(capturedContext.IsToday);
-        Assert.Equal(DayOfWeek.Saturday, capturedContext.DayOfWeek);
-        Assert.True(capturedContext.IsWeekend);
+        Assert.IsNotNull(capturedContext);
+        Assert.AreEqual(new DateOnly(2026, 3, 14), capturedContext.Date);
+        Assert.IsTrue(capturedContext.IsToday);
+        Assert.AreEqual(DayOfWeek.Saturday, capturedContext.DayOfWeek);
+        Assert.IsTrue(capturedContext.IsWeekend);
     }
 
     #endregion
 
     #region Week Calculation Tests
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_FebruaryLeapYear_CorrectDays()
     {
         var widget = new CalendarWidget(new DateOnly(2028, 2, 1))
@@ -297,10 +298,10 @@ public class CalendarWidgetTests
         var (grid, _) = BuildGrid(widget, daysInMonth: 29);
 
         var dayCells = grid.Cells.Skip(7).ToList();
-        Assert.Equal(29, dayCells.Count);
+        Assert.AreEqual(29, dayCells.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_FebruaryNonLeapYear_CorrectDays()
     {
         var widget = new CalendarWidget(new DateOnly(2026, 2, 1))
@@ -310,119 +311,119 @@ public class CalendarWidgetTests
         var (grid, _) = BuildGrid(widget, daysInMonth: 28);
 
         var dayCells = grid.Cells.Skip(7).ToList();
-        Assert.Equal(28, dayCells.Count);
+        Assert.AreEqual(28, dayCells.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_MonthNeeding6WeekRows()
     {
         // August 2025 starts on Friday, 31 days → needs 6 week rows
         var widget = new CalendarWidget(new DateOnly(2025, 8, 1));
         var (grid, _) = BuildGrid(widget);
 
-        Assert.Equal(7, grid.RowDefinitions.Count); // 1 header + 6 week rows
+        Assert.AreEqual(7, grid.RowDefinitions.Count); // 1 header + 6 week rows
     }
 
     #endregion
 
     #region CalendarNode Tests
 
-    [Fact]
+    [TestMethod]
     public void CalendarNode_IsNotFocusable()
     {
         // CalendarNode delegates focus to its child InteractableNodes
         var node = new CalendarNode();
-        Assert.False(node.IsFocusable);
+        Assert.IsFalse(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public void CalendarNode_SelectedDay_ClampsToBounds()
     {
         var node = new CalendarNode { DaysInMonth = 28 };
         node.SelectedDay = 30;
-        Assert.Equal(28, node.SelectedDay);
+        Assert.AreEqual(28, node.SelectedDay);
     }
 
-    [Fact]
+    [TestMethod]
     public void CalendarNode_SelectedDay_ClampsToMin()
     {
         var node = new CalendarNode { DaysInMonth = 28 };
         node.SelectedDay = 0;
-        Assert.Equal(1, node.SelectedDay);
+        Assert.AreEqual(1, node.SelectedDay);
     }
 
-    [Fact]
+    [TestMethod]
     public void CalendarNode_SelectedDay_DefaultsToNull()
     {
         var node = new CalendarNode { DaysInMonth = 28 };
-        Assert.Null(node.SelectedDay);
+        Assert.IsNull(node.SelectedDay);
     }
 
     #endregion
 
     #region Extension Method Tests
 
-    [Fact]
+    [TestMethod]
     public void Calendar_WithYearMonth_CreatesCorrectWidget()
     {
         var ctx = new WidgetContext<VStackWidget>();
         var widget = ctx.Calendar(2026, 3);
 
-        Assert.Equal(2026, widget.Month.Year);
-        Assert.Equal(3, widget.Month.Month);
+        Assert.AreEqual(2026, widget.Month.Year);
+        Assert.AreEqual(3, widget.Month.Month);
     }
 
-    [Fact]
+    [TestMethod]
     public void ShowHeader_False_DisablesHeader()
     {
         var ctx = new WidgetContext<VStackWidget>();
         var widget = ctx.Calendar(2026, 3).ShowHeader(false);
 
-        Assert.False(widget.ShowHeader);
+        Assert.IsFalse(widget.ShowHeader);
     }
 
-    [Fact]
+    [TestMethod]
     public void FirstDayOfWeek_Monday_SetsCorrectly()
     {
         var ctx = new WidgetContext<VStackWidget>();
         var widget = ctx.Calendar(2026, 3).FirstDayOfWeek(DayOfWeek.Monday);
 
-        Assert.Equal(DayOfWeek.Monday, widget.FirstDayOfWeek);
+        Assert.AreEqual(DayOfWeek.Monday, widget.FirstDayOfWeek);
     }
 
-    [Fact]
+    [TestMethod]
     public void Today_SetsOverride()
     {
         var ctx = new WidgetContext<VStackWidget>();
         var today = new DateOnly(2026, 3, 15);
         var widget = ctx.Calendar(2026, 3).Today(today);
 
-        Assert.Equal(today, widget.Today);
+        Assert.AreEqual(today, widget.Today);
     }
 
-    [Fact]
+    [TestMethod]
     public void Compact_SetsIsCompact()
     {
         var ctx = new WidgetContext<VStackWidget>();
         var widget = ctx.Calendar(2026, 3).Compact();
 
-        Assert.True(widget.IsCompact);
+        Assert.IsTrue(widget.IsCompact);
     }
 
-    [Fact]
+    [TestMethod]
     public void Day_SetsDayBuilder()
     {
         var ctx = new WidgetContext<VStackWidget>();
         var widget = ctx.Calendar(2026, 3).Day(ctx => new TextBlockWidget("test"));
 
-        Assert.NotNull(widget.DayBuilder);
+        Assert.IsNotNull(widget.DayBuilder);
     }
 
     #endregion
 
     #region Column Consistency Tests
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_AllDaysInColumns0Through6()
     {
         var months = new[]
@@ -442,12 +443,12 @@ public class CalendarWidgetTests
 
             foreach (var cell in dayCells)
             {
-                Assert.InRange(cell.ColumnIndex, 0, 6);
+                TestSeq.InRange(cell.ColumnIndex, 0, 6);
             }
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildGridWidget_HeaderCells_SpanAllColumns()
     {
         var widget = new CalendarWidget(new DateOnly(2026, 3, 1));
@@ -456,25 +457,25 @@ public class CalendarWidgetTests
         var headerCells = grid.Cells.Take(7).ToList();
         var columns = headerCells.Select(c => c.ColumnIndex).OrderBy(c => c).ToList();
 
-        Assert.Equal([0, 1, 2, 3, 4, 5, 6], columns);
+        TestSeq.AreEqual([0, 1, 2, 3, 4, 5, 6], columns);
     }
 
     #endregion
 
     #region GetExpectedNodeType Tests
 
-    [Fact]
+    [TestMethod]
     public void GetExpectedNodeType_ReturnsCalendarNode()
     {
         var widget = new CalendarWidget(new DateOnly(2026, 3, 1));
-        Assert.Equal(typeof(CalendarNode), widget.GetExpectedNodeType());
+        Assert.AreEqual(typeof(CalendarNode), widget.GetExpectedNodeType());
     }
 
     #endregion
 
     #region Integration Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Calendar_RendersMonthDays()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -505,12 +506,12 @@ public class CalendarWidgetTests
 
         // Compact header uses the best format that fits: single-char ("S") or two-char ("Su")
         // depending on column width. Check for day numbers instead of header format.
-        Assert.True(snapshot.ContainsText("1"));
-        Assert.True(snapshot.ContainsText("14"));
-        Assert.True(snapshot.ContainsText("31")); // March has 31 days
+        Assert.IsTrue(snapshot.ContainsText("1"));
+        Assert.IsTrue(snapshot.ContainsText("14"));
+        Assert.IsTrue(snapshot.ContainsText("31")); // March has 31 days
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Calendar_ClickDay_FiresOnSelected()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -544,11 +545,11 @@ public class CalendarWidgetTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Single(selectedDates);
-        Assert.Equal(new DateOnly(2026, 3, 1), selectedDates[0]);
+        TestSeq.Single(selectedDates);
+        Assert.AreEqual(new DateOnly(2026, 3, 1), selectedDates[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Calendar_DefaultMode_HasGridLines()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -577,7 +578,7 @@ public class CalendarWidgetTests
         await runTask;
 
         // Default mode should have gridline box-drawing characters
-        Assert.True(snapshot.ContainsText("┌") || snapshot.ContainsText("│") || snapshot.ContainsText("─"));
+        Assert.IsTrue(snapshot.ContainsText("┌") || snapshot.ContainsText("│") || snapshot.ContainsText("─"));
     }
 
     #endregion

--- a/tests/Hex1b.Tests/CaptureOverrideChordTests.cs
+++ b/tests/Hex1b.Tests/CaptureOverrideChordTests.cs
@@ -7,9 +7,10 @@ namespace Hex1b.Tests;
 /// Tests for OverridesCapture chord bindings — multi-step key sequences that
 /// work even when a node (e.g., TerminalWidget) has captured all input.
 /// </summary>
+[TestClass]
 public class CaptureOverrideChordTests
 {
-    [Fact]
+    [TestMethod]
     public async Task OverridesCapture_Chord_FiresWhenTerminalHasCapture()
     {
         // Arrange: TerminalWidget captures input, but Ctrl+B,D chord should still work
@@ -72,7 +73,7 @@ public class CaptureOverrideChordTests
         try { await runTask; } catch (OperationCanceledException) { }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OverridesCapture_MultipleChordsSamePrefix_BothWork()
     {
         // Arrange: Two chords sharing Ctrl+B prefix, one ends with D, other with S
@@ -135,7 +136,7 @@ public class CaptureOverrideChordTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         await switchFired.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
-        Assert.False(detachFired.Task.IsCompleted, "Detach should not have fired");
+        Assert.IsFalse(detachFired.Task.IsCompleted, "Detach should not have fired");
 
         // Act - Send Ctrl+B, D chord
         await new Hex1bTerminalInputSequenceBuilder()
@@ -151,7 +152,7 @@ public class CaptureOverrideChordTests
         try { await runTask; } catch (OperationCanceledException) { }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OverridesCapture_ChordCancelled_ByNonMatchingSecondKey()
     {
         // Arrange: Ctrl+B,D is bound, but we send Ctrl+B,X (no binding for X)
@@ -206,7 +207,7 @@ public class CaptureOverrideChordTests
 
         // Wait a bit to ensure chord doesn't fire
         await Task.Delay(200);
-        Assert.False(chordFired.Task.IsCompleted, "Chord should not fire for non-matching second key");
+        Assert.IsFalse(chordFired.Task.IsCompleted, "Chord should not fire for non-matching second key");
 
         // Act - Now send the correct chord: Ctrl+B, D — should still work after failed attempt
         await new Hex1bTerminalInputSequenceBuilder()
@@ -222,7 +223,7 @@ public class CaptureOverrideChordTests
         try { await runTask; } catch (OperationCanceledException) { }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OverridesCapture_SingleKeyBinding_StillWorks()
     {
         // Arrange: Single-key OverridesCapture binding (not a chord) should work as before

--- a/tests/Hex1b.Tests/CellAttributeMatrixTests.cs
+++ b/tests/Hex1b.Tests/CellAttributeMatrixTests.cs
@@ -5,6 +5,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests that render a visual matrix of cell attribute combinations and capture SVGs.
 /// </summary>
+[TestClass]
 public class CellAttributeMatrixTests
 {
     /// <summary>
@@ -64,7 +65,7 @@ public class CellAttributeMatrixTests
     /// <summary>
     /// Renders individual attributes each on their own line.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void IndividualAttributes_RendersCorrectly()
     {
         using var test = new TestTerminal(40, 25);
@@ -99,16 +100,16 @@ public class CellAttributeMatrixTests
         // Verify attributes via first row's single chars
         var snapshot = test.Terminal.CreateSnapshot();
 
-        Assert.True(HasCellWithAttributes(snapshot, 'N', CellAttributes.None), "Normal");
-        Assert.True(HasCellWithAttributes(snapshot, 'B', CellAttributes.Bold), "Bold");
-        Assert.True(HasCellWithAttributes(snapshot, 'D', CellAttributes.Dim), "Dim");
-        Assert.True(HasCellWithAttributes(snapshot, 'I', CellAttributes.Italic), "Italic");
-        Assert.True(HasCellWithAttributes(snapshot, 'U', CellAttributes.Underline), "Underline");
-        Assert.True(HasCellWithAttributes(snapshot, 'K', CellAttributes.Blink), "Blink");
-        Assert.True(HasCellWithAttributes(snapshot, 'R', CellAttributes.Reverse), "Reverse");
-        Assert.True(HasCellWithAttributes(snapshot, 'H', CellAttributes.Hidden), "Hidden");
-        Assert.True(HasCellWithAttributes(snapshot, 'S', CellAttributes.Strikethrough), "Strikethrough");
-        Assert.True(HasCellWithAttributes(snapshot, 'O', CellAttributes.Overline), "Overline");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, 'N', CellAttributes.None), "Normal");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, 'B', CellAttributes.Bold), "Bold");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, 'D', CellAttributes.Dim), "Dim");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, 'I', CellAttributes.Italic), "Italic");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, 'U', CellAttributes.Underline), "Underline");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, 'K', CellAttributes.Blink), "Blink");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, 'R', CellAttributes.Reverse), "Reverse");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, 'H', CellAttributes.Hidden), "Hidden");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, 'S', CellAttributes.Strikethrough), "Strikethrough");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, 'O', CellAttributes.Overline), "Overline");
 
         TestCaptureHelper.Capture(test.Terminal, "individual-attributes");
     }
@@ -116,7 +117,7 @@ public class CellAttributeMatrixTests
     /// <summary>
     /// Renders common attribute combinations.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void CommonCombinations_RendersCorrectly()
     {
         using var test = new TestTerminal(50, 25);  // Increased height
@@ -161,14 +162,14 @@ public class CellAttributeMatrixTests
         // Verify combinations via test characters
         var snapshot = test.Terminal.CreateSnapshot();
 
-        Assert.True(HasCellWithAttributes(snapshot, '1', CellAttributes.Bold | CellAttributes.Italic), "Bold+Italic");
-        Assert.True(HasCellWithAttributes(snapshot, '2', CellAttributes.Bold | CellAttributes.Underline), "Bold+Underline");
-        Assert.True(HasCellWithAttributes(snapshot, '3', CellAttributes.Bold | CellAttributes.Strikethrough), "Bold+Strike");
-        Assert.True(HasCellWithAttributes(snapshot, '4', CellAttributes.Italic | CellAttributes.Underline), "Italic+Underline");
-        Assert.True(HasCellWithAttributes(snapshot, '5', CellAttributes.Italic | CellAttributes.Strikethrough), "Italic+Strike");
-        Assert.True(HasCellWithAttributes(snapshot, '6', CellAttributes.Underline | CellAttributes.Strikethrough), "Underline+Strike");
-        Assert.True(HasCellWithAttributes(snapshot, '7', CellAttributes.Bold | CellAttributes.Italic | CellAttributes.Underline), "Bold+Italic+Underline");
-        Assert.True(HasCellWithAttributes(snapshot, '8', CellAttributes.Bold | CellAttributes.Italic | CellAttributes.Underline | CellAttributes.Strikethrough), "All four");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, '1', CellAttributes.Bold | CellAttributes.Italic), "Bold+Italic");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, '2', CellAttributes.Bold | CellAttributes.Underline), "Bold+Underline");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, '3', CellAttributes.Bold | CellAttributes.Strikethrough), "Bold+Strike");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, '4', CellAttributes.Italic | CellAttributes.Underline), "Italic+Underline");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, '5', CellAttributes.Italic | CellAttributes.Strikethrough), "Italic+Strike");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, '6', CellAttributes.Underline | CellAttributes.Strikethrough), "Underline+Strike");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, '7', CellAttributes.Bold | CellAttributes.Italic | CellAttributes.Underline), "Bold+Italic+Underline");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, '8', CellAttributes.Bold | CellAttributes.Italic | CellAttributes.Underline | CellAttributes.Strikethrough), "All four");
 
         TestCaptureHelper.Capture(test.Terminal, "common-combinations");
     }
@@ -176,7 +177,7 @@ public class CellAttributeMatrixTests
     /// <summary>
     /// Renders attributes with colors.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void AttributesWithColors_RendersCorrectly()
     {
         using var test = new TestTerminal(50, 16);
@@ -220,7 +221,7 @@ public class CellAttributeMatrixTests
     /// <summary>
     /// Renders a full matrix grid of attribute combinations.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void FullAttributeMatrix_RendersCorrectly()
     {
         using var test = new TestTerminal(80, 30);
@@ -277,7 +278,7 @@ public class CellAttributeMatrixTests
     /// <summary>
     /// Tests that attribute reset codes work correctly.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void AttributeReset_WorksCorrectly()
     {
         using var test = new TestTerminal(60, 15);
@@ -307,27 +308,22 @@ public class CellAttributeMatrixTests
         var snapshot = test.Terminal.CreateSnapshot();
 
         // "A" should have all four attributes
-        Assert.True(HasCellWithAttributes(snapshot, 'A', 
-            CellAttributes.Bold | CellAttributes.Italic | CellAttributes.Underline | CellAttributes.Strikethrough),
-            "A should have all attributes");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, 'A', 
+            CellAttributes.Bold | CellAttributes.Italic | CellAttributes.Underline | CellAttributes.Strikethrough), "A should have all attributes");
 
         // "E" should have bold, italic, underline (no strikethrough)
-        Assert.True(HasCellWithAttributes(snapshot, 'E', 
-            CellAttributes.Bold | CellAttributes.Italic | CellAttributes.Underline),
-            "E should not have strikethrough");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, 'E', 
+            CellAttributes.Bold | CellAttributes.Italic | CellAttributes.Underline), "E should not have strikethrough");
 
         // "I" should have bold, italic (no underline, no strikethrough)
-        Assert.True(HasCellWithAttributes(snapshot, 'I', 
-            CellAttributes.Bold | CellAttributes.Italic),
-            "I should only have bold+italic");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, 'I', 
+            CellAttributes.Bold | CellAttributes.Italic), "I should only have bold+italic");
 
         // "M" should have bold only
-        Assert.True(HasCellWithAttributes(snapshot, 'M', CellAttributes.Bold),
-            "M should only have bold");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, 'M', CellAttributes.Bold), "M should only have bold");
 
         // "Q" should be normal
-        Assert.True(HasCellWithAttributes(snapshot, 'Q', CellAttributes.None),
-            "Q should be normal");
+        Assert.IsTrue(HasCellWithAttributes(snapshot, 'Q', CellAttributes.None), "Q should be normal");
 
         TestCaptureHelper.Capture(test.Terminal, "attribute-reset");
     }
@@ -335,7 +331,7 @@ public class CellAttributeMatrixTests
     /// <summary>
     /// Tests all possible combinations of the 4 most common attributes.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void CommonAttributePowerSet_RendersCorrectly()
     {
         using var test = new TestTerminal(60, 22);
@@ -388,7 +384,7 @@ public class CellAttributeMatrixTests
     /// Renders underlines with colors distinct from the foreground text.
     /// Verifies that SGR 58 (underline color) is stored in cells and rendered in SVG/HTML.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void ColoredUnderlines_RendersCorrectly()
     {
         using var test = new TestTerminal(60, 20);
@@ -436,54 +432,54 @@ public class CellAttributeMatrixTests
 
         // Row 4 (0-indexed): "White text, red underline" — SGR 58;2;255;0;0
         var redUlCell = snapshot.GetCell(0, 4);
-        Assert.True(redUlCell.IsUnderline);
-        Assert.NotNull(redUlCell.UnderlineColor);
-        Assert.Equal(255, redUlCell.UnderlineColor!.Value.R);
-        Assert.Equal(0, redUlCell.UnderlineColor!.Value.G);
-        Assert.Equal(0, redUlCell.UnderlineColor!.Value.B);
+        Assert.IsTrue(redUlCell.IsUnderline);
+        Assert.IsNotNull(redUlCell.UnderlineColor);
+        Assert.AreEqual(255, redUlCell.UnderlineColor!.Value.R);
+        Assert.AreEqual(0, redUlCell.UnderlineColor!.Value.G);
+        Assert.AreEqual(0, redUlCell.UnderlineColor!.Value.B);
         // Foreground is white (37)
-        Assert.NotNull(redUlCell.Foreground);
+        Assert.IsNotNull(redUlCell.Foreground);
 
         // Row 8 (colon syntax): cyan text, coral underline
         var colonCell = snapshot.GetCell(0, 8);
-        Assert.True(colonCell.IsUnderline);
-        Assert.NotNull(colonCell.UnderlineColor);
-        Assert.Equal(255, colonCell.UnderlineColor!.Value.R);
-        Assert.Equal(100, colonCell.UnderlineColor!.Value.G);
-        Assert.Equal(50, colonCell.UnderlineColor!.Value.B);
+        Assert.IsTrue(colonCell.IsUnderline);
+        Assert.IsNotNull(colonCell.UnderlineColor);
+        Assert.AreEqual(255, colonCell.UnderlineColor!.Value.R);
+        Assert.AreEqual(100, colonCell.UnderlineColor!.Value.G);
+        Assert.AreEqual(50, colonCell.UnderlineColor!.Value.B);
 
         // Row 10: after SGR 59 reset, the second half should have no underline color
         // "Red text blue ul " then SGR 59 "red text default ul"
         // Find the cell after reset — at position 18 ("red text default ul" starts there)
         var resetCell = snapshot.GetCell(18, 10);
-        Assert.True(resetCell.IsUnderline);
-        Assert.Null(resetCell.UnderlineColor); // SGR 59 clears underline color
+        Assert.IsTrue(resetCell.IsUnderline);
+        Assert.IsNull(resetCell.UnderlineColor); // SGR 59 clears underline color
 
         // Verify underline styles are stored correctly
         // Row 3: default underline via SGR 4 → Single style
         var defaultUlCell = snapshot.GetCell(0, 3);
-        Assert.Equal(UnderlineStyle.Single, defaultUlCell.UnderlineStyle);
+        Assert.AreEqual(UnderlineStyle.Single, defaultUlCell.UnderlineStyle);
 
         // Row 12 (after empty line): "Single (4:1)  Double (4:2)  Curly (4:3)"
         var singleCell = snapshot.GetCell(0, 13);
-        Assert.Equal(UnderlineStyle.Single, singleCell.UnderlineStyle);
+        Assert.AreEqual(UnderlineStyle.Single, singleCell.UnderlineStyle);
 
         var doubleCell = snapshot.GetCell(14, 13); // "Double (4:2)" starts after "Single (4:1)  "
-        Assert.Equal(UnderlineStyle.Double, doubleCell.UnderlineStyle);
+        Assert.AreEqual(UnderlineStyle.Double, doubleCell.UnderlineStyle);
 
         var curlyCell = snapshot.GetCell(28, 13); // "Curly (4:3)" starts after "Double (4:2)  "
-        Assert.Equal(UnderlineStyle.Curly, curlyCell.UnderlineStyle);
+        Assert.AreEqual(UnderlineStyle.Curly, curlyCell.UnderlineStyle);
 
         // Row 14: "Dotted (4:4)  Dashed (4:5)"
         var dottedCell = snapshot.GetCell(0, 14);
-        Assert.Equal(UnderlineStyle.Dotted, dottedCell.UnderlineStyle);
+        Assert.AreEqual(UnderlineStyle.Dotted, dottedCell.UnderlineStyle);
 
         var dashedCell = snapshot.GetCell(14, 14); // "Dashed (4:5)" starts after "Dotted (4:4)  "
-        Assert.Equal(UnderlineStyle.Dashed, dashedCell.UnderlineStyle);
+        Assert.AreEqual(UnderlineStyle.Dashed, dashedCell.UnderlineStyle);
 
         // Row 16: Kakoune curly (4:3)
         var kakouneCell = snapshot.GetCell(0, 16);
-        Assert.Equal(UnderlineStyle.Curly, kakouneCell.UnderlineStyle);
+        Assert.AreEqual(UnderlineStyle.Curly, kakouneCell.UnderlineStyle);
 
         TestCaptureHelper.Capture(test.Terminal, "colored-underlines");
     }

--- a/tests/Hex1b.Tests/CellPatternSearcherTests.cs
+++ b/tests/Hex1b.Tests/CellPatternSearcherTests.cs
@@ -5,6 +5,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Comprehensive tests for the CellPatternSearcher API.
 /// </summary>
+[TestClass]
 public class CellPatternSearcherTests
 {
     #region Helper Methods
@@ -73,26 +74,26 @@ public class CellPatternSearcherTests
 
     #region TraversedCell Tests
 
-    [Fact]
+    [TestMethod]
     public async Task TraversedCell_HasCorrectProperties()
     {
         var cell = new TerminalCell("A", null, null);
         var traversed = new TraversedCell(5, 10, cell, null);
 
-        Assert.Equal(5, traversed.X);
-        Assert.Equal(10, traversed.Y);
-        Assert.Equal("A", traversed.Cell.Character);
-        Assert.Null(traversed.CaptureNames);
+        Assert.AreEqual(5, traversed.X);
+        Assert.AreEqual(10, traversed.Y);
+        Assert.AreEqual("A", traversed.Cell.Character);
+        Assert.IsNull(traversed.CaptureNames);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TraversedCell_WithCaptureNames()
     {
         var cell = new TerminalCell("B", null, null);
         var captures = new HashSet<string> { "name", "value" };
         var traversed = new TraversedCell(0, 0, cell, captures);
 
-        Assert.NotNull(traversed.CaptureNames);
+        Assert.IsNotNull(traversed.CaptureNames);
         Assert.Contains("name", traversed.CaptureNames);
         Assert.Contains("value", traversed.CaptureNames);
     }
@@ -101,23 +102,23 @@ public class CellPatternSearcherTests
 
     #region CellMatchContext Tests
 
-    [Fact]
+    [TestMethod]
     public async Task CellMatchContext_ProvidesRegionAccess()
     {
         var snapshot = await CreateSnapshotAsync("Hello World");
         var pattern = new CellPatternSearcher()
             .Find(ctx =>
             {
-                Assert.NotNull(ctx.Region);
-                Assert.Equal(80, ctx.Region.Width);
+                Assert.IsNotNull(ctx.Region);
+                Assert.AreEqual(80, ctx.Region.Width);
                 return ctx.Cell.Character == "H";
             });
 
         var result = pattern.Search(snapshot);
-        Assert.True(result.HasMatches);
+        Assert.IsTrue(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CellMatchContext_ProvidesCurrentPosition()
     {
         var snapshot = await CreateSnapshotAsync("Hello");
@@ -138,7 +139,7 @@ public class CellPatternSearcherTests
         Assert.Contains((3, 0), positions); // 'l'
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CellMatchContext_ProvidesMatchStartCell()
     {
         var snapshot = await CreateSnapshotAsync("ABC");
@@ -154,11 +155,11 @@ public class CellPatternSearcherTests
 
         pattern.Search(snapshot);
 
-        Assert.NotNull(capturedStartCell);
-        Assert.Equal("A", capturedStartCell.Value.Character);
+        Assert.IsNotNull(capturedStartCell);
+        Assert.AreEqual("A", capturedStartCell.Value.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CellMatchContext_ProvidesPreviousCell()
     {
         var snapshot = await CreateSnapshotAsync("ABC");
@@ -179,12 +180,12 @@ public class CellPatternSearcherTests
 
         pattern.Search(snapshot);
 
-        Assert.Equal(2, previousChars.Count);
-        Assert.Equal("A", previousChars[0]);
-        Assert.Equal("B", previousChars[1]);
+        Assert.AreEqual(2, previousChars.Count);
+        Assert.AreEqual("A", previousChars[0]);
+        Assert.AreEqual("B", previousChars[1]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CellMatchContext_GetRelative_ReturnsCorrectCell()
     {
         var snapshot = await CreateSnapshotAsync(new[] { "ABC", "DEF", "GHI" });
@@ -202,11 +203,11 @@ public class CellPatternSearcherTests
 
         pattern.Search(snapshot);
 
-        Assert.NotNull(relativeCell);
-        Assert.Equal("A", relativeCell.Value.Character);
+        Assert.IsNotNull(relativeCell);
+        Assert.AreEqual("A", relativeCell.Value.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CellMatchContext_GetAbsolute_ReturnsCorrectCell()
     {
         var snapshot = await CreateSnapshotAsync(new[] { "ABC", "DEF" });
@@ -222,11 +223,11 @@ public class CellPatternSearcherTests
 
         pattern.Search(snapshot);
 
-        Assert.NotNull(absoluteCell);
-        Assert.Equal("F", absoluteCell.Value.Character);
+        Assert.IsNotNull(absoluteCell);
+        Assert.AreEqual("F", absoluteCell.Value.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CellMatchContext_TraversedCells_TracksProgress()
     {
         var snapshot = await CreateSnapshotAsync("ABCD");
@@ -252,17 +253,17 @@ public class CellPatternSearcherTests
 
         pattern.Search(snapshot);
 
-        Assert.Equal(3, traversedCounts.Count);
-        Assert.Equal(1, traversedCounts[0]); // After Find('A')
-        Assert.Equal(2, traversedCounts[1]); // After first Right
-        Assert.Equal(3, traversedCounts[2]); // After second Right
+        Assert.AreEqual(3, traversedCounts.Count);
+        Assert.AreEqual(1, traversedCounts[0]); // After Find('A')
+        Assert.AreEqual(2, traversedCounts[1]); // After first Right
+        Assert.AreEqual(3, traversedCounts[2]); // After second Right
     }
 
     #endregion
 
     #region Find Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Find_WithChar_MatchesSingleCharacter()
     {
         var snapshot = await CreateSnapshotAsync("Hello World");
@@ -270,12 +271,12 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Single(result.Matches);
-        Assert.Equal(6, result.First!.Start.X);
+        Assert.IsTrue(result.HasMatches);
+        TestSeq.Single(result.Matches);
+        Assert.AreEqual(6, result.First!.Start.X);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Find_WithChar_FindsMultipleOccurrences()
     {
         var snapshot = await CreateSnapshotAsync("ababa");
@@ -283,10 +284,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.Equal(3, result.Count);
+        Assert.AreEqual(3, result.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Find_WithPredicate_MatchesCondition()
     {
         var snapshot = await CreateSnapshotAsync("abc123def");
@@ -295,10 +296,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.Equal(3, result.Count);
+        Assert.AreEqual(3, result.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindPattern_WithRegexString_MatchesPattern()
     {
         var snapshot = await CreateSnapshotAsync("Name: John, Age: 30");
@@ -306,10 +307,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
+        Assert.IsTrue(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindPattern_WithCompiledRegex_MatchesPattern()
     {
         var snapshot = await CreateSnapshotAsync("Error: file not found");
@@ -318,10 +319,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
+        Assert.IsTrue(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Find_NoMatch_ReturnsEmptyResult()
     {
         var snapshot = await CreateSnapshotAsync("Hello World");
@@ -329,12 +330,12 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.False(result.HasMatches);
-        Assert.Equal(0, result.Count);
-        Assert.Null(result.First);
+        Assert.IsFalse(result.HasMatches);
+        Assert.AreEqual(0, result.Count);
+        Assert.IsNull(result.First);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Find_AcrossMultipleLines()
     {
         var snapshot = await CreateSnapshotAsync(new[] { "Line 1", "Line 2", "Line 3" });
@@ -342,17 +343,17 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.Equal(3, result.Count);
-        Assert.Equal(0, result.Matches[0].Start.Y);
-        Assert.Equal(1, result.Matches[1].Start.Y);
-        Assert.Equal(2, result.Matches[2].Start.Y);
+        Assert.AreEqual(3, result.Count);
+        Assert.AreEqual(0, result.Matches[0].Start.Y);
+        Assert.AreEqual(1, result.Matches[1].Start.Y);
+        Assert.AreEqual(2, result.Matches[2].Start.Y);
     }
 
     #endregion
 
     #region Directional Movement Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Right_WithChar_MovesAndMatches()
     {
         var snapshot = await CreateSnapshotAsync("AB");
@@ -360,11 +361,11 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal(2, result.First!.Cells.Count);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual(2, result.First!.Cells.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Right_WithPredicate_MovesAndMatches()
     {
         var snapshot = await CreateSnapshotAsync("A1");
@@ -374,10 +375,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
+        Assert.IsTrue(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Right_FailsIfNoMatch()
     {
         var snapshot = await CreateSnapshotAsync("AC");
@@ -385,10 +386,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.False(result.HasMatches);
+        Assert.IsFalse(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Right_WithCount_MovesMultipleCells()
     {
         var snapshot = await CreateSnapshotAsync("ABCDE");
@@ -396,12 +397,12 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal(4, result.First!.Cells.Count); // A + 3 more
-        Assert.Equal((3, 0), result.First!.End);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual(4, result.First!.Cells.Count); // A + 3 more
+        Assert.AreEqual((3, 0), result.First!.End);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Right_WithCountAndPredicate_AllMustMatch()
     {
         var snapshot = await CreateSnapshotAsync("A111B");
@@ -411,10 +412,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
+        Assert.IsTrue(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Right_WithCountAndPredicate_FailsIfAnyDontMatch()
     {
         var snapshot = await CreateSnapshotAsync("A121B");
@@ -424,10 +425,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.False(result.HasMatches);
+        Assert.IsFalse(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Left_WithChar_MovesLeft()
     {
         var snapshot = await CreateSnapshotAsync("BA");
@@ -435,10 +436,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
+        Assert.IsTrue(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Up_WithChar_MovesUp()
     {
         var snapshot = await CreateSnapshotAsync(new[] { "A", "B" });
@@ -446,10 +447,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
+        Assert.IsTrue(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Down_WithChar_MovesDown()
     {
         var snapshot = await CreateSnapshotAsync(new[] { "A", "B" });
@@ -457,10 +458,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
+        Assert.IsTrue(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Left_WithCount_MovesMultipleCells()
     {
         var snapshot = await CreateSnapshotAsync("ABCDE");
@@ -468,11 +469,11 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal(5, result.First!.Cells.Count);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual(5, result.First!.Cells.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Up_WithCount_MovesMultipleCells()
     {
         var snapshot = await CreateSnapshotAsync(new[] { "A", "B", "C", "D", "E" });
@@ -480,11 +481,11 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal(5, result.First!.Cells.Count);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual(5, result.First!.Cells.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Down_WithCount_MovesMultipleCells()
     {
         var snapshot = await CreateSnapshotAsync(new[] { "A", "B", "C", "D", "E" });
@@ -492,15 +493,15 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal(5, result.First!.Cells.Count);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual(5, result.First!.Cells.Count);
     }
 
     #endregion
 
     #region Text Sequence Tests
 
-    [Fact]
+    [TestMethod]
     public async Task RightText_MatchesExactSequence()
     {
         var snapshot = await CreateSnapshotAsync("Hello World");
@@ -508,11 +509,11 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal("Hello", result.First!.Text);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual("Hello", result.First!.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RightText_FailsOnMismatch()
     {
         var snapshot = await CreateSnapshotAsync("Hello World");
@@ -520,10 +521,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.False(result.HasMatches);
+        Assert.IsFalse(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LeftText_MatchesExactSequence()
     {
         var snapshot = await CreateSnapshotAsync("Hello");
@@ -531,14 +532,14 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
+        Assert.IsTrue(result.HasMatches);
     }
 
     #endregion
 
     #region While Tests
 
-    [Fact]
+    [TestMethod]
     public async Task RightWhile_ConsumesMatchingCells()
     {
         var snapshot = await CreateSnapshotAsync("AAA123");
@@ -548,11 +549,11 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal("AAA", result.First!.Text);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual("AAA", result.First!.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RightWhile_StopsAtNonMatch()
     {
         var snapshot = await CreateSnapshotAsync("AAABBB");
@@ -562,10 +563,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.Equal("AAA", result.First!.Text);
+        Assert.AreEqual("AAA", result.First!.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RightWhile_ZeroMatchesIsValid()
     {
         var snapshot = await CreateSnapshotAsync("AB");
@@ -576,10 +577,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
+        Assert.IsTrue(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LeftWhile_ConsumesMatchingCells()
     {
         var snapshot = await CreateSnapshotAsync("123AAA");
@@ -589,11 +590,11 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal(3, result.First!.Cells.Count);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual(3, result.First!.Cells.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task UpWhile_ConsumesMatchingCells()
     {
         var snapshot = await CreateSnapshotAsync(new[] { "1", "A", "A", "A" });
@@ -603,11 +604,11 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal(3, result.First!.Cells.Count);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual(3, result.First!.Cells.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DownWhile_ConsumesMatchingCells()
     {
         var snapshot = await CreateSnapshotAsync(new[] { "A", "A", "A", "1" });
@@ -617,15 +618,15 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal(3, result.First!.Cells.Count);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual(3, result.First!.Cells.Count);
     }
 
     #endregion
 
     #region Until Tests
 
-    [Fact]
+    [TestMethod]
     public async Task RightUntil_WithPredicate_StopsAtMatch()
     {
         var snapshot = await CreateSnapshotAsync("ABC]DEF");
@@ -635,11 +636,11 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal("ABC]", result.First!.Text);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual("ABC]", result.First!.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RightUntil_WithChar_StopsAtChar()
     {
         var snapshot = await CreateSnapshotAsync("[content]");
@@ -649,11 +650,11 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal("[content]", result.First!.Text);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual("[content]", result.First!.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RightUntil_FailsIfNotFound()
     {
         var snapshot = await CreateSnapshotAsync("ABC");
@@ -663,10 +664,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.False(result.HasMatches);
+        Assert.IsFalse(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LeftUntil_StopsAtMatch()
     {
         var snapshot = await CreateSnapshotAsync("[content]");
@@ -676,10 +677,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
+        Assert.IsTrue(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task UpUntil_StopsAtMatch()
     {
         var snapshot = await CreateSnapshotAsync(new[] { "-", "A", "A", "A" });
@@ -689,11 +690,11 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal(4, result.First!.Cells.Count);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual(4, result.First!.Cells.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DownUntil_StopsAtMatch()
     {
         var snapshot = await CreateSnapshotAsync(new[] { "A", "A", "A", "-" });
@@ -703,15 +704,15 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal(4, result.First!.Cells.Count);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual(4, result.First!.Cells.Count);
     }
 
     #endregion
 
     #region Boundary Tests
 
-    [Fact]
+    [TestMethod]
     public async Task RightToEnd_GoesToEndOfLine()
     {
         var snapshot = await CreateSnapshotAsync("Hello", 10, 1);
@@ -721,12 +722,12 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal(10, result.First!.Cells.Count);
-        Assert.Equal((9, 0), result.First!.End);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual(10, result.First!.Cells.Count);
+        Assert.AreEqual((9, 0), result.First!.End);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LeftToStart_GoesToStartOfLine()
     {
         var snapshot = await CreateSnapshotAsync("Hello", 10, 1);
@@ -736,11 +737,11 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal((0, 0), result.First!.End);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual((0, 0), result.First!.End);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DownToBottom_GoesToBottomOfRegion()
     {
         var snapshot = await CreateSnapshotAsync(new[] { "A", "B", "C" }, 10, 5);
@@ -750,11 +751,11 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal((0, 4), result.First!.End);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual((0, 4), result.First!.End);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task UpToTop_GoesToTopOfRegion()
     {
         var snapshot = await CreateSnapshotAsync(new[] { "A", "B", "C" }, 10, 5);
@@ -764,15 +765,15 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal((0, 0), result.First!.End);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual((0, 0), result.First!.End);
     }
 
     #endregion
 
     #region Capture Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Capture_CapturesTraversedCells()
     {
         var snapshot = await CreateSnapshotAsync("Name: John");
@@ -784,12 +785,12 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.True(result.First!.HasCapture("value"));
-        Assert.Equal("John", result.First!.GetCaptureText("value"));
+        Assert.IsTrue(result.HasMatches);
+        Assert.IsTrue(result.First!.HasCapture("value"));
+        Assert.AreEqual("John", result.First!.GetCaptureText("value"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Capture_MultipleCapturesInOnePattern()
     {
         var snapshot = await CreateSnapshotAsync("A=1 B=2");
@@ -808,12 +809,12 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal("A=1", result.First!.GetCaptureText("first"));
-        Assert.Equal("B=2", result.First!.GetCaptureText("second"));
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual("A=1", result.First!.GetCaptureText("first"));
+        Assert.AreEqual("B=2", result.First!.GetCaptureText("second"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Capture_NestedCaptures()
     {
         var snapshot = await CreateSnapshotAsync("[ERROR] msg");
@@ -831,13 +832,13 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.True(result.First!.HasCapture("all"));
-        Assert.True(result.First!.HasCapture("tag"));
-        Assert.True(result.First!.HasCapture("msg"));
+        Assert.IsTrue(result.HasMatches);
+        Assert.IsTrue(result.First!.HasCapture("all"));
+        Assert.IsTrue(result.First!.HasCapture("tag"));
+        Assert.IsTrue(result.First!.HasCapture("msg"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Capture_GetCaptureBounds_ReturnsCorrectRect()
     {
         var snapshot = await CreateSnapshotAsync("XX[val]XX");
@@ -850,12 +851,12 @@ public class CellPatternSearcherTests
         var result = pattern.Search(snapshot);
         var bounds = result.First!.GetCaptureBounds("inner");
 
-        Assert.Equal(3, bounds.X); // Starts at 'v'
-        Assert.Equal(0, bounds.Y);
-        Assert.True(bounds.Width >= 3); // 'val]'
+        Assert.AreEqual(3, bounds.X); // Starts at 'v'
+        Assert.AreEqual(0, bounds.Y);
+        Assert.IsTrue(bounds.Width >= 3); // 'val]'
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Capture_NonExistentCapture_ReturnsEmpty()
     {
         var snapshot = await CreateSnapshotAsync("test");
@@ -863,16 +864,16 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.False(result.First!.HasCapture("nonexistent"));
-        Assert.Empty(result.First!.GetCapture("nonexistent"));
-        Assert.Equal("", result.First!.GetCaptureText("nonexistent"));
+        Assert.IsFalse(result.First!.HasCapture("nonexistent"));
+        Assert.IsEmpty(result.First!.GetCapture("nonexistent"));
+        Assert.AreEqual("", result.First!.GetCaptureText("nonexistent"));
     }
 
     #endregion
 
     #region Composition Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Then_ChainsPatterns()
     {
         var prefix = new CellPatternSearcher().Find('[').RightUntil(']');
@@ -885,10 +886,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
+        Assert.IsTrue(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Then_WithAction_BuildsSubPattern()
     {
         var snapshot = await CreateSnapshotAsync("ABC123");
@@ -898,11 +899,11 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal("ABC", result.First!.Text);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual("ABC", result.First!.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ThenOptional_ContinuesIfSubPatternFails()
     {
         var snapshot = await CreateSnapshotAsync("AD");
@@ -915,10 +916,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
+        Assert.IsTrue(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ThenOptional_IncludesMatchWhenSuccessful()
     {
         var snapshot = await CreateSnapshotAsync("ABCD");
@@ -931,11 +932,11 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal("ABCD", result.First!.Text);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual("ABCD", result.First!.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ThenEither_UsesFirstIfMatches()
     {
         var snapshot = await CreateSnapshotAsync("AB");
@@ -948,11 +949,11 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal("AB", result.First!.Text);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual("AB", result.First!.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ThenEither_UsesSecondIfFirstFails()
     {
         var snapshot = await CreateSnapshotAsync("AX");
@@ -965,11 +966,11 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal("AX", result.First!.Text);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual("AX", result.First!.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ThenEither_FailsIfBothFail()
     {
         var snapshot = await CreateSnapshotAsync("AZ");
@@ -982,10 +983,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.False(result.HasMatches);
+        Assert.IsFalse(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ThenEither_WithMatch_MatchesTextAtCurrentPosition()
     {
         // Simulates the prompt matching scenario:
@@ -1013,24 +1014,24 @@ public class CellPatternSearcherTests
 
         var results = pattern.Search(snapshot);
 
-        Assert.True(results.HasMatches);
-        Assert.Equal(3, results.Count);
+        Assert.IsTrue(results.HasMatches);
+        Assert.AreEqual(3, results.Count);
         
         // First match: [1 OK]
-        Assert.Equal("1", results.Matches[0].GetCaptureText("seqno"));
-        Assert.False(results.Matches[0].HasCapture("errno"));
+        Assert.AreEqual("1", results.Matches[0].GetCaptureText("seqno"));
+        Assert.IsFalse(results.Matches[0].HasCapture("errno"));
         
         // Second match: [2 OK]
-        Assert.Equal("2", results.Matches[1].GetCaptureText("seqno"));
-        Assert.False(results.Matches[1].HasCapture("errno"));
+        Assert.AreEqual("2", results.Matches[1].GetCaptureText("seqno"));
+        Assert.IsFalse(results.Matches[1].HasCapture("errno"));
         
         // Third match: [3 ERR:127]
-        Assert.Equal("3", results.Matches[2].GetCaptureText("seqno"));
-        Assert.True(results.Matches[2].HasCapture("errno"));
-        Assert.Equal("127", results.Matches[2].GetCaptureText("errno"));
+        Assert.AreEqual("3", results.Matches[2].GetCaptureText("seqno"));
+        Assert.IsTrue(results.Matches[2].HasCapture("errno"));
+        Assert.AreEqual("127", results.Matches[2].GetCaptureText("errno"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Match_DebugCursorPosition()
     {
         // Test Match followed by RightWhile followed by Right
@@ -1044,12 +1045,12 @@ public class CellPatternSearcherTests
             .Right(']');  // Should match ]
 
         var result = pattern.Search(snapshot);
-        Assert.True(result.HasMatches, "Pattern should match :127]");
-        Assert.Equal(":127]", result.First!.Text);
-        Assert.Equal("127", result.First!.GetCaptureText("errno"));
+        Assert.IsTrue(result.HasMatches, "Pattern should match :127]");
+        Assert.AreEqual(":127]", result.First!.Text);
+        Assert.AreEqual("127", result.First!.GetCaptureText("errno"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ThenRepeat_RepeatsPatternNTimes()
     {
         var snapshot = await CreateSnapshotAsync("ABCABCABC");
@@ -1063,11 +1064,11 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal("ABCABCABC", result.First!.Text);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual("ABCABCABC", result.First!.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ThenRepeat_WithoutCount_RepeatsWhileMatching()
     {
         var snapshot = await CreateSnapshotAsync("AAAB");
@@ -1079,15 +1080,15 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal("AAA", result.First!.Text);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual("AAA", result.First!.Text);
     }
 
     #endregion
 
     #region CellPatternMatch Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Match_Bounds_CoversAllCells()
     {
         var snapshot = await CreateSnapshotAsync(new[] { "AB", "CD" });
@@ -1100,13 +1101,13 @@ public class CellPatternSearcherTests
         var result = pattern.Search(snapshot);
         var bounds = result.First!.Bounds;
 
-        Assert.Equal(0, bounds.X);
-        Assert.Equal(0, bounds.Y);
-        Assert.Equal(2, bounds.Width);
-        Assert.Equal(2, bounds.Height);
+        Assert.AreEqual(0, bounds.X);
+        Assert.AreEqual(0, bounds.Y);
+        Assert.AreEqual(2, bounds.Width);
+        Assert.AreEqual(2, bounds.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Match_Start_IsFirstCell()
     {
         var snapshot = await CreateSnapshotAsync("XXX[ABC]XXX");
@@ -1116,10 +1117,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.Equal((3, 0), result.First!.Start);
+        Assert.AreEqual((3, 0), result.First!.Start);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Match_End_IsLastCell()
     {
         var snapshot = await CreateSnapshotAsync("XXX[ABC]XXX");
@@ -1129,10 +1130,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.Equal((7, 0), result.First!.End);
+        Assert.AreEqual((7, 0), result.First!.End);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Match_Text_ConcatenatesAllCells()
     {
         var snapshot = await CreateSnapshotAsync("Hello");
@@ -1142,10 +1143,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.Equal("Hello", result.First!.Text);
+        Assert.AreEqual("Hello", result.First!.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Match_CaptureNames_ListsAllCaptures()
     {
         var snapshot = await CreateSnapshotAsync("A=1");
@@ -1168,7 +1169,7 @@ public class CellPatternSearcherTests
 
     #region CellPatternSearchResult Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Result_HasMatches_TrueWhenMatchesExist()
     {
         var snapshot = await CreateSnapshotAsync("test");
@@ -1176,10 +1177,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
+        Assert.IsTrue(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Result_HasMatches_FalseWhenNoMatches()
     {
         var snapshot = await CreateSnapshotAsync("test");
@@ -1187,10 +1188,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.False(result.HasMatches);
+        Assert.IsFalse(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Result_Count_ReturnsMatchCount()
     {
         var snapshot = await CreateSnapshotAsync("aaa");
@@ -1198,10 +1199,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.Equal(3, result.Count);
+        Assert.AreEqual(3, result.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Result_First_ReturnsFirstMatch()
     {
         var snapshot = await CreateSnapshotAsync("abc");
@@ -1209,11 +1210,11 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.NotNull(result.First);
-        Assert.Equal((0, 0), result.First!.Start);
+        Assert.IsNotNull(result.First);
+        Assert.AreEqual((0, 0), result.First!.Start);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Result_Matches_AreOrderedByPosition()
     {
         var snapshot = await CreateSnapshotAsync(new[] { "a", "a", "aZ" });
@@ -1221,17 +1222,17 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.Matches.Count >= 3, $"Expected at least 3 matches but got {result.Matches.Count}");
-        Assert.Equal(0, result.Matches[0].Start.Y);
-        Assert.Equal(1, result.Matches[1].Start.Y);
-        Assert.Equal(2, result.Matches[2].Start.Y);
+        Assert.IsTrue(result.Matches.Count >= 3, $"Expected at least 3 matches but got {result.Matches.Count}");
+        Assert.AreEqual(0, result.Matches[0].Start.Y);
+        Assert.AreEqual(1, result.Matches[1].Start.Y);
+        Assert.AreEqual(2, result.Matches[2].Start.Y);
     }
 
     #endregion
 
     #region SearchFirst Tests
 
-    [Fact]
+    [TestMethod]
     public async Task SearchFirst_ReturnsSingleMatch()
     {
         var snapshot = await CreateSnapshotAsync("aaa");
@@ -1239,11 +1240,11 @@ public class CellPatternSearcherTests
 
         var match = pattern.SearchFirst(snapshot);
 
-        Assert.NotNull(match);
-        Assert.Equal((0, 0), match!.Start);
+        Assert.IsNotNull(match);
+        Assert.AreEqual((0, 0), match!.Start);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SearchFirst_ReturnsNullWhenNoMatch()
     {
         var snapshot = await CreateSnapshotAsync("test");
@@ -1251,14 +1252,14 @@ public class CellPatternSearcherTests
 
         var match = pattern.SearchFirst(snapshot);
 
-        Assert.Null(match);
+        Assert.IsNull(match);
     }
 
     #endregion
 
     #region Extension Methods Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Region_SearchPattern_Works()
     {
         var snapshot = await CreateSnapshotAsync("Hello");
@@ -1266,10 +1267,10 @@ public class CellPatternSearcherTests
 
         var result = snapshot.SearchPattern(pattern);
 
-        Assert.True(result.HasMatches);
+        Assert.IsTrue(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Region_SearchFirstPattern_Works()
     {
         var snapshot = await CreateSnapshotAsync("Hello");
@@ -1277,10 +1278,10 @@ public class CellPatternSearcherTests
 
         var match = snapshot.SearchFirstPattern(pattern);
 
-        Assert.NotNull(match);
+        Assert.IsNotNull(match);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Region_CreateSnapshot_FromMatch_Works()
     {
         var snapshot = await CreateSnapshotAsync("XX[content]XX");
@@ -1291,11 +1292,11 @@ public class CellPatternSearcherTests
         var match = pattern.SearchFirst(snapshot);
         var region = snapshot.CreateSnapshot(match!);
 
-        Assert.Equal(match!.Bounds.Width, region.Width);
-        Assert.Equal(match!.Bounds.Height, region.Height);
+        Assert.AreEqual(match!.Bounds.Width, region.Width);
+        Assert.AreEqual(match!.Bounds.Height, region.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Region_CreateSnapshot_FromCapture_Works()
     {
         var snapshot = await CreateSnapshotAsync("[TAG] message");
@@ -1308,14 +1309,14 @@ public class CellPatternSearcherTests
         var match = pattern.SearchFirst(snapshot);
         var region = snapshot.CreateSnapshot(match!, "inner");
 
-        Assert.True(region.Width >= 3);
+        Assert.IsTrue(region.Width >= 3);
     }
 
     #endregion
 
     #region Complex Scenarios
 
-    [Fact]
+    [TestMethod]
     public async Task Scenario_ParseKeyValuePairs()
     {
         var snapshot = await CreateSnapshotAsync("Name: John\r\nAge: 30");
@@ -1332,10 +1333,10 @@ public class CellPatternSearcherTests
 
         var result = kvPattern.Search(snapshot);
 
-        Assert.True(result.Count >= 2);
+        Assert.IsTrue(result.Count >= 2);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Scenario_FindBoxDrawingCorners()
     {
         var snapshot = await CreateSnapshotAsync(new[]
@@ -1352,10 +1353,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
+        Assert.IsTrue(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Scenario_FindStyledText()
     {
         // This would need styled content - test structure only
@@ -1370,11 +1371,11 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal("Bold", result.First!.GetCaptureText("styled"));
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual("Bold", result.First!.GetCaptureText("styled"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Scenario_MatchLogEntry()
     {
         var snapshot = await CreateSnapshotAsync("[2024-01-01] [INFO] Application started");
@@ -1396,12 +1397,12 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
+        Assert.IsTrue(result.HasMatches);
         Assert.Contains("2024-01-01", result.First!.GetCaptureText("timestamp"));
         Assert.Contains("INFO", result.First!.GetCaptureText("level"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Scenario_TwoDimensionalPattern()
     {
         var snapshot = await CreateSnapshotAsync(new[]
@@ -1420,12 +1421,12 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
+        Assert.IsTrue(result.HasMatches);
         // Pattern traverses rows 0, 1, 2 = 3 rows of height
-        Assert.Equal(3, result.First!.Bounds.Height);
+        Assert.AreEqual(3, result.First!.Bounds.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Scenario_MultipleMatchesWithCaptures()
     {
         var snapshot = await CreateSnapshotAsync("x=1 y=2 z=3");
@@ -1441,13 +1442,13 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.Equal(3, result.Count);
-        Assert.Equal("x", result.Matches[0].GetCaptureText("var"));
-        Assert.Equal("y", result.Matches[1].GetCaptureText("var"));
-        Assert.Equal("z", result.Matches[2].GetCaptureText("var"));
+        Assert.AreEqual(3, result.Count);
+        Assert.AreEqual("x", result.Matches[0].GetCaptureText("var"));
+        Assert.AreEqual("y", result.Matches[1].GetCaptureText("var"));
+        Assert.AreEqual("z", result.Matches[2].GetCaptureText("var"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Scenario_Immutability_PatternCanBeReused()
     {
         var basePattern = new CellPatternSearcher().Find('[').RightUntil(']');
@@ -1458,12 +1459,12 @@ public class CellPatternSearcherTests
         var result1 = basePattern.Search(snapshot1);
         var result2 = basePattern.Search(snapshot2);
 
-        Assert.True(result1.HasMatches);
-        Assert.True(result2.HasMatches);
-        Assert.NotEqual(result1.First!.Text, result2.First!.Text);
+        Assert.IsTrue(result1.HasMatches);
+        Assert.IsTrue(result2.HasMatches);
+        Assert.AreNotEqual(result1.First!.Text, result2.First!.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Scenario_EdgeCase_EmptyRegion()
     {
         var snapshot = await CreateSnapshotAsync("", 10, 1);
@@ -1471,10 +1472,10 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.False(result.HasMatches);
+        Assert.IsFalse(result.HasMatches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Scenario_EdgeCase_PatternAtBoundary()
     {
         var snapshot = await CreateSnapshotAsync("ABC", 3, 1);
@@ -1485,11 +1486,11 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.True(result.HasMatches);
-        Assert.Equal((2, 0), result.First!.End);
+        Assert.IsTrue(result.HasMatches);
+        Assert.AreEqual((2, 0), result.First!.End);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Scenario_EdgeCase_PatternExceedsBoundary()
     {
         var snapshot = await CreateSnapshotAsync("AB", 2, 1);
@@ -1500,27 +1501,27 @@ public class CellPatternSearcherTests
 
         var result = pattern.Search(snapshot);
 
-        Assert.False(result.HasMatches);
+        Assert.IsFalse(result.HasMatches);
     }
 
     #endregion
 
     #region Debug Tests
 
-    [Fact]
+    [TestMethod]
     public async Task FindOptions_Default_HasCorrectDefaults()
     {
         var options = FindOptions.Default;
-        Assert.True(options.IncludeMatchInCells, "IncludeMatchInCells should be true by default");
-        Assert.Equal(FindCursorPosition.End, options.CursorPosition);
+        Assert.IsTrue(options.IncludeMatchInCells, "IncludeMatchInCells should be true by default");
+        Assert.AreEqual(FindCursorPosition.End, options.CursorPosition);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task FindOptions_Constructor_HasCorrectDefaults()
     {
         var options = new FindOptions(); // Constructor with defaults
-        Assert.True(options.IncludeMatchInCells, "IncludeMatchInCells should be true by default");
-        Assert.Equal(FindCursorPosition.End, options.CursorPosition);
+        Assert.IsTrue(options.IncludeMatchInCells, "IncludeMatchInCells should be true by default");
+        Assert.AreEqual(FindCursorPosition.End, options.CursorPosition);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/ChartFormattersTests.cs
+++ b/tests/Hex1b.Tests/ChartFormattersTests.cs
@@ -1,81 +1,81 @@
 using Hex1b.Charts;
-using Xunit;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class ChartFormattersTests
 {
-    [Fact]
+    [TestMethod]
     public void FormatValue_Zero_ReturnsZero()
     {
-        Assert.Equal("0", ChartFormatters.FormatValue(0));
+        Assert.AreEqual("0", ChartFormatters.FormatValue(0));
     }
 
-    [Theory]
-    [InlineData(1, "1")]
-    [InlineData(42, "42")]
-    [InlineData(999, "999")]
-    [InlineData(1234, "1,234")]
-    [InlineData(9999, "9,999")]
+    [TestMethod]
+    [DataRow(1, "1")]
+    [DataRow(42, "42")]
+    [DataRow(999, "999")]
+    [DataRow(1234, "1,234")]
+    [DataRow(9999, "9,999")]
     public void FormatValue_WholeNumbersUnder10K_UsesGroupedFormat(double value, string expected)
     {
-        Assert.Equal(expected, ChartFormatters.FormatValue(value));
+        Assert.AreEqual(expected, ChartFormatters.FormatValue(value));
     }
 
-    [Theory]
-    [InlineData(10000, "10.0K")]
-    [InlineData(12345, "12.3K")]
-    [InlineData(100000, "100K")]
-    [InlineData(999999, "1,000K")]
+    [TestMethod]
+    [DataRow(10000, "10.0K")]
+    [DataRow(12345, "12.3K")]
+    [DataRow(100000, "100K")]
+    [DataRow(999999, "1,000K")]
     public void FormatValue_TensOfThousands_UsesSuffixK(double value, string expected)
     {
-        Assert.Equal(expected, ChartFormatters.FormatValue(value));
+        Assert.AreEqual(expected, ChartFormatters.FormatValue(value));
     }
 
-    [Theory]
-    [InlineData(1000000, "1.0M")]
-    [InlineData(1500000, "1.5M")]
-    [InlineData(12345678, "12.3M")]
-    [InlineData(999999999, "1,000M")]
+    [TestMethod]
+    [DataRow(1000000, "1.0M")]
+    [DataRow(1500000, "1.5M")]
+    [DataRow(12345678, "12.3M")]
+    [DataRow(999999999, "1,000M")]
     public void FormatValue_Millions_UsesSuffixM(double value, string expected)
     {
-        Assert.Equal(expected, ChartFormatters.FormatValue(value));
+        Assert.AreEqual(expected, ChartFormatters.FormatValue(value));
     }
 
-    [Theory]
-    [InlineData(1000000000, "1.0B")]
-    [InlineData(2500000000, "2.5B")]
-    [InlineData(123456789012, "123B")]
+    [TestMethod]
+    [DataRow(1000000000, "1.0B")]
+    [DataRow(2500000000, "2.5B")]
+    [DataRow(123456789012, "123B")]
     public void FormatValue_Billions_UsesSuffixB(double value, string expected)
     {
-        Assert.Equal(expected, ChartFormatters.FormatValue(value));
+        Assert.AreEqual(expected, ChartFormatters.FormatValue(value));
     }
 
-    [Theory]
-    [InlineData(-42, "-42")]
-    [InlineData(-1234, "-1,234")]
-    [InlineData(-12345, "-12.3K")]
-    [InlineData(-1500000, "-1.5M")]
+    [TestMethod]
+    [DataRow(-42, "-42")]
+    [DataRow(-1234, "-1,234")]
+    [DataRow(-12345, "-12.3K")]
+    [DataRow(-1500000, "-1.5M")]
     public void FormatValue_NegativeValues_IncludesSign(double value, string expected)
     {
-        Assert.Equal(expected, ChartFormatters.FormatValue(value));
+        Assert.AreEqual(expected, ChartFormatters.FormatValue(value));
     }
 
-    [Theory]
-    [InlineData(3.14, "3.1")]
-    [InlineData(42.5, "42.5")]
-    [InlineData(1234.5, "1,234.5")]
+    [TestMethod]
+    [DataRow(3.14, "3.1")]
+    [DataRow(42.5, "42.5")]
+    [DataRow(1234.5, "1,234.5")]
     public void FormatValue_FractionalAboveOne_ShowsOneDecimal(double value, string expected)
     {
-        Assert.Equal(expected, ChartFormatters.FormatValue(value));
+        Assert.AreEqual(expected, ChartFormatters.FormatValue(value));
     }
 
-    [Theory]
-    [InlineData(0.5, "0.5")]
-    [InlineData(0.42, "0.42")]
-    [InlineData(0.001, "0.001")]
+    [TestMethod]
+    [DataRow(0.5, "0.5")]
+    [DataRow(0.42, "0.42")]
+    [DataRow(0.001, "0.001")]
     public void FormatValue_SmallFractions_UsesSignificantDigits(double value, string expected)
     {
-        Assert.Equal(expected, ChartFormatters.FormatValue(value));
+        Assert.AreEqual(expected, ChartFormatters.FormatValue(value));
     }
 }

--- a/tests/Hex1b.Tests/CheckboxNodeTests.cs
+++ b/tests/Hex1b.Tests/CheckboxNodeTests.cs
@@ -8,38 +8,39 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Unit tests for CheckboxNode behavior.
 /// </summary>
+[TestClass]
 public class CheckboxNodeTests
 {
-    [Fact]
+    [TestMethod]
     public void Measure_ReturnsCorrectSize_NoLabel()
     {
         var node = new CheckboxNode { State = CheckboxState.Unchecked };
         var size = node.Measure(new Constraints(0, 100, 0, 10));
 
         // " ▢ " = 3 display cells, no label
-        Assert.Equal(3, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(3, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_ReturnsCorrectSize_WithLabel()
     {
         var node = new CheckboxNode { State = CheckboxState.Unchecked, Label = "Option" };
         var size = node.Measure(new Constraints(0, 100, 0, 10));
 
         // " ▢ " = 3 cells + " " + "Option" = 3 + 1 + 6 = 10
-        Assert.Equal(10, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(10, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsFocusable_ReturnsTrue()
     {
         var node = new CheckboxNode();
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsFocused_WhenSet_MarksDirty()
     {
         var node = new CheckboxNode();
@@ -47,10 +48,10 @@ public class CheckboxNodeTests
 
         node.IsFocused = true;
 
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Widget_Reconcile_CreatesNode()
     {
         var widget = new CheckboxWidget(CheckboxValue.Checked);
@@ -58,11 +59,11 @@ public class CheckboxNodeTests
         var context = ReconcileContext.CreateRoot();
         var node = await widget.ReconcileAsync(null, context) as CheckboxNode;
 
-        Assert.NotNull(node);
-        Assert.Equal(CheckboxValue.Checked, node.State.Value);
+        Assert.IsNotNull(node);
+        Assert.AreEqual(CheckboxValue.Checked, node.State.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Widget_Reconcile_UpdatesState()
     {
         var widget1 = new CheckboxWidget(CheckboxValue.Unchecked);
@@ -70,16 +71,16 @@ public class CheckboxNodeTests
 
         var context = ReconcileContext.CreateRoot();
         var node = await widget1.ReconcileAsync(null, context) as CheckboxNode;
-        Assert.Equal(CheckboxValue.Unchecked, node!.State.Value);
+        Assert.AreEqual(CheckboxValue.Unchecked, node!.State.Value);
 
         node.ClearDirty();
         await widget2.ReconcileAsync(node, context);
 
-        Assert.Equal(CheckboxValue.Checked, node.State.Value);
-        Assert.True(node.IsDirty);
+        Assert.AreEqual(CheckboxValue.Checked, node.State.Value);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Widget_WithLabel_SetsLabel()
     {
         var widget = new CheckboxWidget().Label("Test Label");
@@ -87,29 +88,29 @@ public class CheckboxNodeTests
         var context = ReconcileContext.CreateRoot();
         var node = await widget.ReconcileAsync(null, context) as CheckboxNode;
 
-        Assert.Equal("Test Label", node!.Label);
+        Assert.AreEqual("Test Label", node!.Label);
     }
 
-    [Fact]
+    [TestMethod]
     public void Widget_FluentApi_ChainsCorrectly()
     {
         var widget = new CheckboxWidget()
             .Checked()
             .Label("Option 1");
 
-        Assert.Equal(CheckboxValue.Checked, widget.Value);
-        Assert.Equal("Option 1", widget.LabelText);
+        Assert.AreEqual(CheckboxValue.Checked, widget.Value);
+        Assert.AreEqual("Option 1", widget.LabelText);
     }
 
-    [Fact]
+    [TestMethod]
     public void Widget_Indeterminate_SetsState()
     {
         var widget = new CheckboxWidget().Indeterminate();
 
-        Assert.Equal(CheckboxValue.Indeterminate, widget.Value);
+        Assert.AreEqual(CheckboxValue.Indeterminate, widget.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Widget_HoistedState_RoutesParentInstanceIntoNode()
     {
         // When the parent supplies a CheckboxState via .State(...), the node
@@ -120,11 +121,11 @@ public class CheckboxNodeTests
         var context = ReconcileContext.CreateRoot();
         var node = await widget.ReconcileAsync(null, context) as CheckboxNode;
 
-        Assert.Same(parentState, node!.State);
-        Assert.Equal(CheckboxValue.Checked, parentState.Value);
+        Assert.AreSame(parentState, node!.State);
+        Assert.AreEqual(CheckboxValue.Checked, parentState.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Widget_HoistedState_TogglePropagatesToParent()
     {
         // The framework's Toggle() mutates State.Value in place — so when a
@@ -141,6 +142,6 @@ public class CheckboxNodeTests
             ? CheckboxValue.Unchecked
             : CheckboxValue.Checked;
 
-        Assert.Equal(CheckboxValue.Checked, parentState.Value);
+        Assert.AreEqual(CheckboxValue.Checked, parentState.Value);
     }
 }

--- a/tests/Hex1b.Tests/CheckboxWidgetHoistedStateTests.cs
+++ b/tests/Hex1b.Tests/CheckboxWidgetHoistedStateTests.cs
@@ -8,9 +8,10 @@ namespace Hex1b.Tests;
 /// <see cref="CheckboxNodeTests"/> doesn't already cover. Mirrors the
 /// <see cref="TextBoxWidgetTests"/> hoisted-state suite.
 /// </summary>
+[TestClass]
 public class CheckboxWidgetHoistedStateTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_HoistedState_PreservedAcrossReconciles()
     {
         var state = new CheckboxState(CheckboxValue.Unchecked);
@@ -19,7 +20,7 @@ public class CheckboxWidgetHoistedStateTests
         context.IsNew = true;
 
         var node = (CheckboxNode)await new CheckboxWidget().State(state).ReconcileAsync(null, context);
-        Assert.Same(state, node.State);
+        Assert.AreSame(state, node.State);
 
         // A new widget instance pointing at the same state must NOT replace
         // the state instance on the node — that would discard any user
@@ -27,11 +28,11 @@ public class CheckboxWidgetHoistedStateTests
         context.IsNew = false;
         var node2 = (CheckboxNode)await new CheckboxWidget().State(state).ReconcileAsync(node, context);
 
-        Assert.Same(node, node2);
-        Assert.Same(state, node2.State);
+        Assert.AreSame(node, node2);
+        Assert.AreSame(state, node2.State);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_HoistedState_ParentMutationVisibleAfterReconcile()
     {
         var state = new CheckboxState(CheckboxValue.Unchecked);
@@ -40,7 +41,7 @@ public class CheckboxWidgetHoistedStateTests
         context.IsNew = true;
 
         var node = (CheckboxNode)await new CheckboxWidget().State(state).ReconcileAsync(null, context);
-        Assert.Equal(CheckboxValue.Unchecked, node.State.Value);
+        Assert.AreEqual(CheckboxValue.Unchecked, node.State.Value);
 
         // Parent flips the value from outside the widget tree, then
         // reconciles. The node observes the new value because it shares
@@ -50,10 +51,10 @@ public class CheckboxWidgetHoistedStateTests
         context.IsNew = false;
         await new CheckboxWidget().State(state).ReconcileAsync(node, context);
 
-        Assert.Equal(CheckboxValue.Checked, node.State.Value);
+        Assert.AreEqual(CheckboxValue.Checked, node.State.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_HoistedState_PeerInstancesAreIndependent()
     {
         var stateA = new CheckboxState(CheckboxValue.Unchecked);
@@ -67,12 +68,12 @@ public class CheckboxWidgetHoistedStateTests
 
         stateA.Value = CheckboxValue.Checked;
 
-        Assert.Equal(CheckboxValue.Checked, nodeA.State.Value);
-        Assert.Equal(CheckboxValue.Unchecked, nodeB.State.Value);
-        Assert.NotSame(nodeA.State, nodeB.State);
+        Assert.AreEqual(CheckboxValue.Checked, nodeA.State.Value);
+        Assert.AreEqual(CheckboxValue.Unchecked, nodeB.State.Value);
+        Assert.AreNotSame(nodeA.State, nodeB.State);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_HoistedState_IgnoresCtorValue()
     {
         // CheckboxWidget's ctor `Value` parameter has a default and is
@@ -88,11 +89,11 @@ public class CheckboxWidgetHoistedStateTests
         context.IsNew = true;
         var node = (CheckboxNode)await widget.ReconcileAsync(null, context);
 
-        Assert.Same(state, node.State);
-        Assert.Equal(CheckboxValue.Checked, node.State.Value);
+        Assert.AreSame(state, node.State);
+        Assert.AreEqual(CheckboxValue.Checked, node.State.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_HoistedState_OutOfBandChangeMarksDirty()
     {
         // After the first reconcile the node is marked clean. If the parent
@@ -111,7 +112,7 @@ public class CheckboxWidgetHoistedStateTests
         context.IsNew = false;
         await new CheckboxWidget().State(second).ReconcileAsync(node, context);
 
-        Assert.True(node.IsDirty);
-        Assert.Same(second, node.State);
+        Assert.IsTrue(node.IsDirty);
+        Assert.AreSame(second, node.State);
     }
 }

--- a/tests/Hex1b.Tests/ClipboardTests.cs
+++ b/tests/Hex1b.Tests/ClipboardTests.cs
@@ -7,6 +7,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for clipboard functionality via OSC 52.
 /// </summary>
+[TestClass]
 public class ClipboardTests
 {
     /// <summary>
@@ -68,7 +69,7 @@ public class ClipboardTests
         public void TriggerDisconnect() => Disconnected?.Invoke();
     }
 
-    [Fact(Skip = "Integration test needs rework - terminal/app connection issue")]
+    [TestMethod, Ignore("Integration test needs rework - terminal/app connection issue")]
     public async Task CopyToClipboard_SendsOsc52Sequence_ToOutput()
     {
         // Arrange
@@ -117,7 +118,7 @@ public class ClipboardTests
         await runTask;
         
         // Assert
-        Assert.True(copyTriggered, "Button click should have triggered copy");
+        Assert.IsTrue(copyTriggered, "Button click should have triggered copy");
         
         // Verify the OSC 52 sequence was sent
         var output = presentation.CapturedOutput;
@@ -127,7 +128,7 @@ public class ClipboardTests
         Assert.Contains(expectedOsc52, output);
     }
 
-    [Fact]
+    [TestMethod]
     public void CopyToClipboard_GeneratesCorrectOsc52Format()
     {
         // This is a unit test to verify the OSC 52 format is correct
@@ -139,10 +140,10 @@ public class ClipboardTests
         // ESC = 0x1B, BEL = 0x07
         Assert.StartsWith("\x1b]52;c;", expected);
         Assert.EndsWith("\x07", expected);
-        Assert.Equal("SGVsbG8sIFdvcmxkIQ==", expectedBase64);
+        Assert.AreEqual("SGVsbG8sIFdvcmxkIQ==", expectedBase64);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task InputBindingActionContext_CopyToClipboard_InvokesCallback()
     {
         // Arrange
@@ -161,7 +162,7 @@ public class ClipboardTests
         context.CopyToClipboard("Test text");
 
         // Assert
-        Assert.Equal("Test text", copiedText);
+        Assert.AreEqual("Test text", copiedText);
         await Task.CompletedTask; // Make the compiler happy about async
     }
 }

--- a/tests/Hex1b.Tests/ColorIndexMappingTests.cs
+++ b/tests/Hex1b.Tests/ColorIndexMappingTests.cs
@@ -9,6 +9,7 @@ namespace Hex1b.Tests;
 /// pass through correctly. Guards against the index 7/15 swap bug found in psmux.
 /// Inspired by psmux's test_issue155_rendering.rs color mapping tests.
 /// </summary>
+[TestClass]
 public class ColorIndexMappingTests
 {
     private sealed class TestTerminal : IDisposable
@@ -35,7 +36,7 @@ public class ColorIndexMappingTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Sgr37_Index7_IsLightGrayNotWhite()
     {
         using var t = new TestTerminal();
@@ -43,17 +44,17 @@ public class ColorIndexMappingTests
 
         var snap = t.Terminal.CreateSnapshot();
         var fg = snap.GetCell(0, 0).Foreground;
-        Assert.NotNull(fg);
+        Assert.IsNotNull(fg);
 
         // Index 7 (SGR 37) should be light gray (192,192,192), NOT white (255,255,255)
-        Assert.Equal(192, fg.Value.R);
-        Assert.Equal(192, fg.Value.G);
-        Assert.Equal(192, fg.Value.B);
-        Assert.Equal(Hex1bColorKind.Standard, fg.Value.Kind);
-        Assert.Equal(7, fg.Value.AnsiIndex);
+        Assert.AreEqual(192, fg.Value.R);
+        Assert.AreEqual(192, fg.Value.G);
+        Assert.AreEqual(192, fg.Value.B);
+        Assert.AreEqual(Hex1bColorKind.Standard, fg.Value.Kind);
+        Assert.AreEqual(7, fg.Value.AnsiIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void Sgr97_Index15_IsWhiteNotGray()
     {
         using var t = new TestTerminal();
@@ -61,17 +62,17 @@ public class ColorIndexMappingTests
 
         var snap = t.Terminal.CreateSnapshot();
         var fg = snap.GetCell(0, 0).Foreground;
-        Assert.NotNull(fg);
+        Assert.IsNotNull(fg);
 
         // Index 15 (SGR 97) should be white (255,255,255), NOT gray
-        Assert.Equal(255, fg.Value.R);
-        Assert.Equal(255, fg.Value.G);
-        Assert.Equal(255, fg.Value.B);
-        Assert.Equal(Hex1bColorKind.Bright, fg.Value.Kind);
-        Assert.Equal(7, fg.Value.AnsiIndex);
+        Assert.AreEqual(255, fg.Value.R);
+        Assert.AreEqual(255, fg.Value.G);
+        Assert.AreEqual(255, fg.Value.B);
+        Assert.AreEqual(Hex1bColorKind.Bright, fg.Value.Kind);
+        Assert.AreEqual(7, fg.Value.AnsiIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void Sgr37_And_Sgr97_ProduceDistinctColors()
     {
         using var t = new TestTerminal();
@@ -81,60 +82,60 @@ public class ColorIndexMappingTests
         var fg37 = snap.GetCell(0, 0).Foreground;
         var fg97 = snap.GetCell(1, 0).Foreground;
 
-        Assert.NotNull(fg37);
-        Assert.NotNull(fg97);
-        Assert.NotEqual(fg37, fg97);
+        Assert.IsNotNull(fg37);
+        Assert.IsNotNull(fg97);
+        Assert.AreNotEqual(fg37, fg97);
     }
 
-    [Theory]
-    [InlineData(30, 0, 0, 0)]       // Black
-    [InlineData(31, 128, 0, 0)]     // Red
-    [InlineData(32, 0, 128, 0)]     // Green
-    [InlineData(33, 128, 128, 0)]   // Yellow
-    [InlineData(34, 0, 0, 128)]     // Blue
-    [InlineData(35, 128, 0, 128)]   // Magenta
-    [InlineData(36, 0, 128, 128)]   // Cyan
-    [InlineData(37, 192, 192, 192)] // White/LightGray
-    public void StandardForegroundColors_MapCorrectly(int sgr, byte r, byte g, byte b)
+    [TestMethod]
+    [DataRow(30, 0, 0, 0)]       // Black
+    [DataRow(31, 128, 0, 0)]     // Red
+    [DataRow(32, 0, 128, 0)]     // Green
+    [DataRow(33, 128, 128, 0)]   // Yellow
+    [DataRow(34, 0, 0, 128)]     // Blue
+    [DataRow(35, 128, 0, 128)]   // Magenta
+    [DataRow(36, 0, 128, 128)]   // Cyan
+    [DataRow(37, 192, 192, 192)] // White/LightGray
+    public void StandardForegroundColors_MapCorrectly(int sgr, int r, int g, int b)
     {
         using var t = new TestTerminal();
         t.Write($"\x1b[{sgr}mX");
 
         var snap = t.Terminal.CreateSnapshot();
         var fg = snap.GetCell(0, 0).Foreground;
-        Assert.NotNull(fg);
-        Assert.Equal(r, fg.Value.R);
-        Assert.Equal(g, fg.Value.G);
-        Assert.Equal(b, fg.Value.B);
-        Assert.Equal(Hex1bColorKind.Standard, fg.Value.Kind);
-        Assert.Equal(sgr - 30, fg.Value.AnsiIndex);
+        Assert.IsNotNull(fg);
+        Assert.AreEqual(r, fg.Value.R);
+        Assert.AreEqual(g, fg.Value.G);
+        Assert.AreEqual(b, fg.Value.B);
+        Assert.AreEqual(Hex1bColorKind.Standard, fg.Value.Kind);
+        Assert.AreEqual(sgr - 30, fg.Value.AnsiIndex);
     }
 
-    [Theory]
-    [InlineData(90, 128, 128, 128)]   // Bright Black (Dark Gray)
-    [InlineData(91, 255, 0, 0)]       // Bright Red
-    [InlineData(92, 0, 255, 0)]       // Bright Green
-    [InlineData(93, 255, 255, 0)]     // Bright Yellow
-    [InlineData(94, 0, 0, 255)]       // Bright Blue
-    [InlineData(95, 255, 0, 255)]     // Bright Magenta
-    [InlineData(96, 0, 255, 255)]     // Bright Cyan
-    [InlineData(97, 255, 255, 255)]   // Bright White
-    public void BrightForegroundColors_MapCorrectly(int sgr, byte r, byte g, byte b)
+    [TestMethod]
+    [DataRow(90, 128, 128, 128)]   // Bright Black (Dark Gray)
+    [DataRow(91, 255, 0, 0)]       // Bright Red
+    [DataRow(92, 0, 255, 0)]       // Bright Green
+    [DataRow(93, 255, 255, 0)]     // Bright Yellow
+    [DataRow(94, 0, 0, 255)]       // Bright Blue
+    [DataRow(95, 255, 0, 255)]     // Bright Magenta
+    [DataRow(96, 0, 255, 255)]     // Bright Cyan
+    [DataRow(97, 255, 255, 255)]   // Bright White
+    public void BrightForegroundColors_MapCorrectly(int sgr, int r, int g, int b)
     {
         using var t = new TestTerminal();
         t.Write($"\x1b[{sgr}mX");
 
         var snap = t.Terminal.CreateSnapshot();
         var fg = snap.GetCell(0, 0).Foreground;
-        Assert.NotNull(fg);
-        Assert.Equal(r, fg.Value.R);
-        Assert.Equal(g, fg.Value.G);
-        Assert.Equal(b, fg.Value.B);
-        Assert.Equal(Hex1bColorKind.Bright, fg.Value.Kind);
-        Assert.Equal(sgr - 90, fg.Value.AnsiIndex);
+        Assert.IsNotNull(fg);
+        Assert.AreEqual(r, fg.Value.R);
+        Assert.AreEqual(g, fg.Value.G);
+        Assert.AreEqual(b, fg.Value.B);
+        Assert.AreEqual(Hex1bColorKind.Bright, fg.Value.Kind);
+        Assert.AreEqual(sgr - 90, fg.Value.AnsiIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void Color256_Index196_MapsCorrectly()
     {
         using var t = new TestTerminal();
@@ -142,17 +143,17 @@ public class ColorIndexMappingTests
 
         var snap = t.Terminal.CreateSnapshot();
         var fg = snap.GetCell(0, 0).Foreground;
-        Assert.NotNull(fg);
+        Assert.IsNotNull(fg);
 
         // Index 196 = 6x6x6 cube: (196-16)=180, r=180/36=5→255, g=0, b=0
-        Assert.Equal(255, fg.Value.R);
-        Assert.Equal(0, fg.Value.G);
-        Assert.Equal(0, fg.Value.B);
-        Assert.Equal(Hex1bColorKind.Indexed, fg.Value.Kind);
-        Assert.Equal(196, fg.Value.AnsiIndex);
+        Assert.AreEqual(255, fg.Value.R);
+        Assert.AreEqual(0, fg.Value.G);
+        Assert.AreEqual(0, fg.Value.B);
+        Assert.AreEqual(Hex1bColorKind.Indexed, fg.Value.Kind);
+        Assert.AreEqual(196, fg.Value.AnsiIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void RgbColor_PassthroughExact()
     {
         using var t = new TestTerminal();
@@ -160,11 +161,11 @@ public class ColorIndexMappingTests
 
         var snap = t.Terminal.CreateSnapshot();
         var fg = snap.GetCell(0, 0).Foreground;
-        Assert.NotNull(fg);
-        Assert.Equal(Hex1bColor.FromRgb(171, 205, 239), fg.Value);
+        Assert.IsNotNull(fg);
+        Assert.AreEqual(Hex1bColor.FromRgb(171, 205, 239), fg.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void Sgr39_ResetsToDefaultForeground()
     {
         using var t = new TestTerminal();
@@ -174,7 +175,7 @@ public class ColorIndexMappingTests
         var fgR = snap.GetCell(0, 0).Foreground;
         var fgD = snap.GetCell(1, 0).Foreground;
 
-        Assert.NotNull(fgR); // Red should be set
-        Assert.Null(fgD);    // Default foreground = null
+        Assert.IsNotNull(fgR); // Red should be set
+        Assert.IsNull(fgD);    // Default foreground = null
     }
 }

--- a/tests/Hex1b.Tests/Composition/CompositeBuildPipelineTests.cs
+++ b/tests/Hex1b.Tests/Composition/CompositeBuildPipelineTests.cs
@@ -11,75 +11,76 @@ namespace Hex1b.Tests.Composition;
 /// dispatches into <see cref="Hex1bWidget.Build(CompositionContext)"/>. Covers node
 /// recycling, state lifetime, and disposal across widget-type swaps.
 /// </summary>
+[TestClass]
 public class CompositeBuildPipelineTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_NewComposite_BuildsChildAndStoresType()
     {
         var widget = new TextOnlyCompositeWidget("hello");
         var node = await ReconcileAsync(widget, null);
 
-        Assert.NotNull(node.Child);
-        Assert.IsType<TextBlockNode>(node.Child);
-        Assert.Equal(typeof(TextOnlyCompositeWidget), node.CompositeWidgetType);
+        Assert.IsNotNull(node.Child);
+        TestSeq.IsType<TextBlockNode>(node.Child);
+        Assert.AreEqual(typeof(TextOnlyCompositeWidget), node.CompositeWidgetType);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_NullBuildOutput_Throws()
     {
-        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () =>
             await ReconcileAsync(new NullReturningCompositeWidget(), null));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_SameCompositeType_ReusesNodeAndPreservesState()
     {
         // The composite increments its UseState counter on every Build pass.
         // First reconciliation: state initialised to 0, then incremented to 1.
         var node1 = await ReconcileAsync(new StatefulCounterCompositeWidget(), null);
-        Assert.Equal("count=1", LabelOf(node1));
+        Assert.AreEqual("count=1", LabelOf(node1));
 
         // Second reconciliation: state must persist across frames.
         var node2 = await ReconcileAsync(new StatefulCounterCompositeWidget(), node1);
 
-        Assert.Same(node1, node2);
-        Assert.Equal("count=2", LabelOf(node2));
+        Assert.AreSame(node1, node2);
+        Assert.AreEqual("count=2", LabelOf(node2));
 
         // Third reconciliation: still persistent.
         var node3 = await ReconcileAsync(new StatefulCounterCompositeWidget(), node2);
-        Assert.Equal("count=3", LabelOf(node3));
+        Assert.AreEqual("count=3", LabelOf(node3));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_DifferentCompositeType_DisposesStateAndStartsFresh()
     {
         var node1 = await ReconcileAsync(new StatefulCounterCompositeWidget(), null);
-        Assert.Equal("count=1", LabelOf(node1));
+        Assert.AreEqual("count=1", LabelOf(node1));
 
         // Replace with a different composite type at the same tree position. The framework's
         // GetExpectedNodeType match would normally reuse the node shell, so the composite
         // reconciler must spot the type change and wipe the prior state.
         var node2 = (Hex1bCompositeNode)await ReconcileAsync(new TextOnlyCompositeWidget("after-swap"), node1);
-        Assert.Equal(typeof(TextOnlyCompositeWidget), node2.CompositeWidgetType);
-        Assert.Equal("after-swap", LabelOf(node2));
+        Assert.AreEqual(typeof(TextOnlyCompositeWidget), node2.CompositeWidgetType);
+        Assert.AreEqual("after-swap", LabelOf(node2));
 
         // Going back to the counter composite should start its state fresh — the previous count is gone.
         var node3 = await ReconcileAsync(new StatefulCounterCompositeWidget(), node2);
-        Assert.Equal("count=1", LabelOf(node3));
+        Assert.AreEqual("count=1", LabelOf(node3));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_DifferentCompositeType_DisposesIDisposableState()
     {
         var disposable = new TrackingDisposable();
         DisposableSeedingCompositeWidget.NextSeed = disposable;
 
         var node1 = await ReconcileAsync(new DisposableSeedingCompositeWidget(), null);
-        Assert.False(disposable.WasDisposed);
+        Assert.IsFalse(disposable.WasDisposed);
 
         // Swapping composite types must dispose the previous state objects that implement IDisposable.
         await ReconcileAsync(new TextOnlyCompositeWidget("done"), node1);
-        Assert.True(disposable.WasDisposed);
+        Assert.IsTrue(disposable.WasDisposed);
     }
 
     // --- Composite test fixtures ---
@@ -131,8 +132,8 @@ public class CompositeBuildPipelineTests
 
     private static string LabelOf(Hex1bNode node)
     {
-        var composite = Assert.IsType<Hex1bCompositeNode>(node);
-        var textNode = Assert.IsType<TextBlockNode>(composite.Child);
+        var composite = TestSeq.IsType<Hex1bCompositeNode>(node);
+        var textNode = TestSeq.IsType<TextBlockNode>(composite.Child);
         return textNode.Text;
     }
 
@@ -141,7 +142,7 @@ public class CompositeBuildPipelineTests
         var context = ReconcileContext.CreateRoot();
         var rootShell = new RootShellNode();
         var node = await context.ReconcileChildAsync(existing, widget, rootShell);
-        return Assert.IsType<Hex1bCompositeNode>(node);
+        return TestSeq.IsType<Hex1bCompositeNode>(node);
     }
 
     private sealed class RootShellNode : Hex1bNode

--- a/tests/Hex1b.Tests/Composition/CompositionContextTests.cs
+++ b/tests/Hex1b.Tests/Composition/CompositionContextTests.cs
@@ -6,9 +6,10 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests.Composition;
 
+[TestClass]
 public class CompositionContextTests
 {
-    [Fact]
+    [TestMethod]
     public async Task UseState_ReturnsSameInstanceAcrossReconciliations()
     {
         var node1 = await ReconcileAsync(new InspectStateCompositeWidget(), null);
@@ -17,49 +18,49 @@ public class CompositionContextTests
         await ReconcileAsync(new InspectStateCompositeWidget(), node1);
         var captured2 = InspectStateCompositeWidget.LastSeenState;
 
-        Assert.NotNull(captured1);
-        Assert.Same(captured1, captured2);
+        Assert.IsNotNull(captured1);
+        Assert.AreSame(captured1, captured2);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task IsNew_TrueOnFirstFrameThenFalse()
     {
         var node1 = await ReconcileAsync(new IsNewObservingCompositeWidget(), null);
-        Assert.True(IsNewObservingCompositeWidget.LastIsNew);
+        Assert.IsTrue(IsNewObservingCompositeWidget.LastIsNew);
 
         await ReconcileAsync(new IsNewObservingCompositeWidget(), node1);
-        Assert.False(IsNewObservingCompositeWidget.LastIsNew);
+        Assert.IsFalse(IsNewObservingCompositeWidget.LastIsNew);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Use_NoAncestorProvided_ReturnsNull()
     {
         var node = await ReconcileAsync(new UseFooCompositeWidget(), null);
-        var composite = Assert.IsType<Hex1bCompositeNode>(node);
-        var text = Assert.IsType<TextBlockNode>(composite.Child);
-        Assert.Equal("Foo=<none>", text.Text);
+        var composite = TestSeq.IsType<Hex1bCompositeNode>(node);
+        var text = TestSeq.IsType<TextBlockNode>(composite.Child);
+        Assert.AreEqual("Foo=<none>", text.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Require_NoAncestorProvided_BubblesUpInvalidOperationException()
     {
-        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () =>
             await ReconcileAsync(new RequireFooCompositeWidget(), null));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Provide_FromAncestorComposite_FlowsToDescendantUse()
     {
         var node = await ReconcileAsync(new ProvideFooCompositeWidget("hello"), null);
 
         // Tree shape: ProvideFooCompositeWidget → UseFooCompositeWidget → TextBlock("Foo=hello")
-        var outer = Assert.IsType<Hex1bCompositeNode>(node);
-        var inner = Assert.IsType<Hex1bCompositeNode>(outer.Child);
-        var text = Assert.IsType<TextBlockNode>(inner.Child);
-        Assert.Equal("Foo=hello", text.Text);
+        var outer = TestSeq.IsType<Hex1bCompositeNode>(node);
+        var inner = TestSeq.IsType<Hex1bCompositeNode>(outer.Child);
+        var text = TestSeq.IsType<TextBlockNode>(inner.Child);
+        Assert.AreEqual("Foo=hello", text.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Provide_NestedSameType_InnerShadowsOuter()
     {
         var node = await ReconcileAsync(
@@ -67,14 +68,14 @@ public class CompositionContextTests
             null);
 
         // Tree: outer Provide("outer") → inner Provide("inner") → UseFooCompositeWidget → TextBlock("Foo=inner")
-        var outer = Assert.IsType<Hex1bCompositeNode>(node);
-        var middle = Assert.IsType<Hex1bCompositeNode>(outer.Child);
-        var leaf = Assert.IsType<Hex1bCompositeNode>(middle.Child);
-        var text = Assert.IsType<TextBlockNode>(leaf.Child);
-        Assert.Equal("Foo=inner", text.Text);
+        var outer = TestSeq.IsType<Hex1bCompositeNode>(node);
+        var middle = TestSeq.IsType<Hex1bCompositeNode>(outer.Child);
+        var leaf = TestSeq.IsType<Hex1bCompositeNode>(middle.Child);
+        var text = TestSeq.IsType<TextBlockNode>(leaf.Child);
+        Assert.AreEqual("Foo=inner", text.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Provide_OnlyVisibleToDescendants_NotSiblings()
     {
         // VStack of two ProvideFoo peers; the second uses Use<FooContext>().
@@ -91,9 +92,9 @@ public class CompositionContextTests
         var rootShell = new RootShellNode();
         var ctx = ReconcileContext.CreateRoot();
         var stack = (VStackNode)(await ctx.ReconcileChildAsync(null, widget, rootShell))!;
-        var second = Assert.IsType<Hex1bCompositeNode>(stack.Children[1]);
-        var text = Assert.IsType<TextBlockNode>(second.Child);
-        Assert.Equal("Foo=<none>", text.Text);
+        var second = TestSeq.IsType<Hex1bCompositeNode>(stack.Children[1]);
+        var text = TestSeq.IsType<TextBlockNode>(second.Child);
+        Assert.AreEqual("Foo=<none>", text.Text);
     }
 
     // --- Composite test fixtures ---

--- a/tests/Hex1b.Tests/Composition/Hex1bCompositeNodeTests.cs
+++ b/tests/Hex1b.Tests/Composition/Hex1bCompositeNodeTests.cs
@@ -7,11 +7,12 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests.Composition;
 
+[TestClass]
 public class Hex1bCompositeNodeTests
 {
     // --- Layout pass-through (mirrors StatePanelNode tests) ---
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithChild_DelegatesToChild()
     {
         var child = new TextBlockNode { Text = "Hello" };
@@ -19,22 +20,22 @@ public class Hex1bCompositeNodeTests
 
         var size = node.Measure(new Constraints(0, 50, 0, 5));
 
-        Assert.True(size.Width > 0);
-        Assert.True(size.Height > 0);
+        Assert.IsTrue(size.Width > 0);
+        Assert.IsTrue(size.Height > 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithoutChild_ReturnsConstrainedZero()
     {
         var node = new Hex1bCompositeNode();
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(0, size.Width);
-        Assert.Equal(0, size.Height);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(0, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_PassesThroughToChild()
     {
         var child = new TextBlockNode { Text = "Hello" };
@@ -44,22 +45,22 @@ public class Hex1bCompositeNodeTests
         var rect = new Rect(5, 10, 30, 1);
         node.Arrange(rect);
 
-        Assert.Equal(rect, node.Bounds);
-        Assert.Equal(rect, child.Bounds);
+        Assert.AreEqual(rect, node.Bounds);
+        Assert.AreEqual(rect, child.Bounds);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_ReturnsChildOrEmpty()
     {
         var empty = new Hex1bCompositeNode();
-        Assert.Empty(empty.GetChildren());
+        Assert.IsEmpty(empty.GetChildren());
 
         var child = new TextBlockNode { Text = "x" };
         var withChild = new Hex1bCompositeNode { Child = child };
-        Assert.Equal(new[] { (Hex1bNode)child }, withChild.GetChildren());
+        TestSeq.AreEqual(new[] { (Hex1bNode)child }, withChild.GetChildren());
     }
 
-    [Fact]
+    [TestMethod]
     public void GetFocusableNodes_DelegatesToChild()
     {
         var button = new ButtonNode { Label = "OK" };
@@ -67,11 +68,11 @@ public class Hex1bCompositeNodeTests
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Single(focusables);
-        Assert.Same(button, focusables[0]);
+        TestSeq.Single(focusables);
+        Assert.AreSame(button, focusables[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_WithoutChild_DoesNothing()
     {
         var surface = new Surface(20, 3);
@@ -79,8 +80,8 @@ public class Hex1bCompositeNodeTests
         var node = new Hex1bCompositeNode();
         node.Arrange(new Rect(0, 0, 20, 3));
 
-        var ex = Record.Exception(() => ctx.RenderChild(node));
+        var ex = TestSeq.RecordException(() => ctx.RenderChild(node));
 
-        Assert.Null(ex);
+        Assert.IsNull(ex);
     }
 }

--- a/tests/Hex1b.Tests/Composition/SlashCommandIntegrationTests.cs
+++ b/tests/Hex1b.Tests/Composition/SlashCommandIntegrationTests.cs
@@ -16,9 +16,10 @@ namespace Hex1b.Tests.Composition;
 /// arranged outside those bounds is clipped. Putting the palette in flow makes
 /// the composite grow vertically when visible, which is what users expect.
 /// </summary>
+[TestClass]
 public class SlashCommandIntegrationTests
 {
-    [Fact]
+    [TestMethod]
     public async Task TypingSlash_RendersPaletteAboveTextBox()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -49,15 +50,12 @@ public class SlashCommandIntegrationTests
             catch { return ""; }
         }));
 
-        Assert.True(snapshot.ContainsText("washthedishes"),
-            $"Palette should appear when text starts with '/'\n\nScreen:\n{screen}");
-        Assert.True(snapshot.ContainsText("picker"),
-            $"All matching commands should appear\n\nScreen:\n{screen}");
-        Assert.True(snapshot.ContainsText("Commands"),
-            $"Border title should appear\n\nScreen:\n{screen}");
+        Assert.IsTrue(snapshot.ContainsText("washthedishes"), $"Palette should appear when text starts with '/'\n\nScreen:\n{screen}");
+        Assert.IsTrue(snapshot.ContainsText("picker"), $"All matching commands should appear\n\nScreen:\n{screen}");
+        Assert.IsTrue(snapshot.ContainsText("Commands"), $"Border title should appear\n\nScreen:\n{screen}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TypingNonSlash_DoesNotRenderPalette()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -82,13 +80,11 @@ public class SlashCommandIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.False(snapshot.ContainsText("Commands"),
-            "Palette should NOT appear when text does not start with '/'");
-        Assert.False(snapshot.ContainsText("washthedishes"),
-            "No completions should be shown");
+        Assert.IsFalse(snapshot.ContainsText("Commands"), "Palette should NOT appear when text does not start with '/'");
+        Assert.IsFalse(snapshot.ContainsText("washthedishes"), "No completions should be shown");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DownArrow_MovesPaletteSelection()
     {
         // Drives the prompt with "/", then DownArrow, and verifies the
@@ -132,10 +128,8 @@ public class SlashCommandIntegrationTests
         var pickerLine = lines.FirstOrDefault(l => l.Contains("picker")) ?? "";
         var clearLine = lines.FirstOrDefault(l => l.Contains("clear")) ?? "";
 
-        Assert.True(clearLine.Contains(">"),
-            $"After DownArrow, '>' should mark the 'clear' row but did not. Screen:\n{screen}");
-        Assert.False(pickerLine.Contains(">"),
-            $"After DownArrow, '>' should no longer mark the 'picker' row. Screen:\n{screen}");
+        Assert.IsTrue(clearLine.Contains(">"), $"After DownArrow, '>' should mark the 'clear' row but did not. Screen:\n{screen}");
+        Assert.IsFalse(pickerLine.Contains(">"), $"After DownArrow, '>' should no longer mark the 'picker' row. Screen:\n{screen}");
     }
 
     private sealed record SlashPromptHostWidget : Hex1bWidget

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyAltScreenWrapConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyAltScreenWrapConformanceTests.cs
@@ -1,4 +1,3 @@
-using Xunit;
 
 namespace Hex1b.Tests.Conformance.Ghostty;
 
@@ -7,7 +6,8 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// soft wrap, and other misc operations.
 /// Translated from Ghostty's Terminal.zig.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyAltScreenWrapConformanceTests
 {
     private static Hex1bTerminal CreateTerminal(int cols = 80, int rows = 24)
@@ -15,8 +15,8 @@ public class GhosttyAltScreenWrapConformanceTests
 
     #region Alt Screen Modes (47, 1047, 1049)
 
-    [Fact]
-    [Trait("FailureReason", "MissingFeature")]
+    [TestMethod]
+    [TestCategory("FailureReason:MissingFeature")]
     public void Mode47_AltScreenPlain()
     {
         // Ghostty: "Terminal: mode 47 alt screen plain"
@@ -25,19 +25,19 @@ public class GhosttyAltScreenWrapConformanceTests
 
         // Go to alt screen with mode 47
         GhosttyTestFixture.Feed(t, "\u001b[?47h");
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
 
         // Print on alt screen — cursor position copied from primary
         GhosttyTestFixture.Feed(t, "2B");
-        Assert.Equal("  2B", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("  2B", GhosttyTestFixture.GetLine(t, 0));
 
         // Go back to primary
         GhosttyTestFixture.Feed(t, "\u001b[?47l");
-        Assert.Equal("1A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("1A", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
-    [Trait("FailureReason", "MissingFeature")]
+    [TestMethod]
+    [TestCategory("FailureReason:MissingFeature")]
     public void Mode1047_AltScreenPlain()
     {
         // Ghostty: "Terminal: mode 1047 alt screen plain"
@@ -45,16 +45,16 @@ public class GhosttyAltScreenWrapConformanceTests
         GhosttyTestFixture.Feed(t, "1A");
 
         GhosttyTestFixture.Feed(t, "\u001b[?1047h");
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
 
         GhosttyTestFixture.Feed(t, "2B");
-        Assert.Equal("  2B", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("  2B", GhosttyTestFixture.GetLine(t, 0));
 
         GhosttyTestFixture.Feed(t, "\u001b[?1047l");
-        Assert.Equal("1A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("1A", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void Mode1049_AltScreenPlain()
     {
         // Ghostty: "Terminal: mode 1049 alt screen plain"
@@ -63,7 +63,7 @@ public class GhosttyAltScreenWrapConformanceTests
 
         // Mode 1049 saves cursor then switches to alt screen
         GhosttyTestFixture.Feed(t, "\u001b[?1049h");
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
 
         // Print on alt screen — cursor position is copied from primary
         GhosttyTestFixture.Feed(t, "2B");
@@ -71,14 +71,14 @@ public class GhosttyAltScreenWrapConformanceTests
 
         // Go back to primary — cursor is restored
         GhosttyTestFixture.Feed(t, "\u001b[?1049l");
-        Assert.Equal("1A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("1A", GhosttyTestFixture.GetLine(t, 0));
     }
 
     #endregion
 
     #region Disabled Wraparound with Wide Characters
 
-    [Fact]
+    [TestMethod]
     public void DisabledWraparound_WideCharAndNoSpace()
     {
         // Ghostty: "Terminal: disabled wraparound with wide char and no space"
@@ -87,12 +87,12 @@ public class GhosttyAltScreenWrapConformanceTests
         GhosttyTestFixture.Feed(t, "AAAAA");
         GhosttyTestFixture.Feed(t, "\U0001F6A8"); // Police car light (wide)
 
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(4, t.CursorX);
-        Assert.Equal("AAAAA", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(4, t.CursorX);
+        Assert.AreEqual("AAAAA", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void DisabledWraparound_WideCharAndOneSpace()
     {
         // Ghostty: "Terminal: disabled wraparound with wide char and one space"
@@ -101,12 +101,12 @@ public class GhosttyAltScreenWrapConformanceTests
         GhosttyTestFixture.Feed(t, "AAAA");
         GhosttyTestFixture.Feed(t, "\U0001F6A8"); // Police car light (wide)
 
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(4, t.CursorX);
-        Assert.Equal("AAAA", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(4, t.CursorX);
+        Assert.AreEqual("AAAA", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void DisabledWraparound_WideGraphemeAndHalfSpace()
     {
         // Ghostty: "Terminal: disabled wraparound with wide grapheme and half space"
@@ -117,8 +117,8 @@ public class GhosttyAltScreenWrapConformanceTests
         GhosttyTestFixture.Feed(t, "\u2764");  // Heart (narrow)
         GhosttyTestFixture.Feed(t, "\uFE0F");  // VS16 — should make wide but no space
 
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(4, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(4, t.CursorX);
         Assert.Contains("\u2764", GhosttyTestFixture.GetLine(t, 0));
     }
 
@@ -126,66 +126,66 @@ public class GhosttyAltScreenWrapConformanceTests
 
     #region Input and Wrap
 
-    [Fact]
+    [TestMethod]
     public void Input_NoControlCharacters()
     {
         // Ghostty: "Terminal: input with no control characters"
         using var t = CreateTerminal(cols: 40, rows: 40);
         GhosttyTestFixture.Feed(t, "hello");
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(5, t.CursorX);
-        Assert.Equal("hello", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(5, t.CursorX);
+        Assert.AreEqual("hello", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void Input_BasicWraparound()
     {
         // Ghostty: "Terminal: input with basic wraparound"
         using var t = CreateTerminal(cols: 5, rows: 40);
         GhosttyTestFixture.Feed(t, "helloworldabc12");
-        Assert.Equal(2, t.CursorY);
-        Assert.Equal(4, t.CursorX);
-        Assert.True(t.PendingWrap);
-        Assert.Equal("hello", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("world", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("abc12", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual(2, t.CursorY);
+        Assert.AreEqual(4, t.CursorX);
+        Assert.IsTrue(t.PendingWrap);
+        Assert.AreEqual("hello", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("world", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("abc12", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void SoftWrap()
     {
         // Ghostty: "Terminal: soft wrap"
         using var t = CreateTerminal(cols: 3, rows: 80);
         GhosttyTestFixture.Feed(t, "hello");
-        Assert.Equal(1, t.CursorY);
-        Assert.Equal(2, t.CursorX);
-        Assert.Equal("hel", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("lo", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual(1, t.CursorY);
+        Assert.AreEqual(2, t.CursorX);
+        Assert.AreEqual("hel", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("lo", GhosttyTestFixture.GetLine(t, 1));
     }
 
     #endregion
 
     #region DECALN Preserves Color
 
-    [Fact]
+    [TestMethod]
     public void Decaln_PreservesColor()
     {
         // Ghostty: "Terminal: decaln preserves color"
         using var t = CreateTerminal(cols: 5, rows: 5);
         GhosttyTestFixture.Feed(t, "\u001b#8"); // DECALN
-        Assert.Equal("EEEEE", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("EEEEE", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("EEEEE", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("EEEEE", GhosttyTestFixture.GetLine(t, 3));
-        Assert.Equal("EEEEE", GhosttyTestFixture.GetLine(t, 4));
+        Assert.AreEqual("EEEEE", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("EEEEE", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("EEEEE", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("EEEEE", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("EEEEE", GhosttyTestFixture.GetLine(t, 4));
     }
 
     #endregion
 
     #region DeleteChars Zero Count
 
-    [Fact]
-    [Trait("FailureReason", "Bug")]
+    [TestMethod]
+    [TestCategory("FailureReason:Bug")]
     public void DeleteChars_ZeroCount()
     {
         // Ghostty: "Terminal: deleteChars zero count"
@@ -194,14 +194,14 @@ public class GhosttyAltScreenWrapConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H"); // setCursorPos(1,1)
         GhosttyTestFixture.Feed(t, "\u001b[0P"); // deleteChars(0) — should delete 1
 
-        Assert.Equal("BCDE", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("BCDE", GhosttyTestFixture.GetLine(t, 0));
     }
 
     #endregion
 
     #region SaveCursor Resize
 
-    [Fact]
+    [TestMethod]
     public void SaveCursor_Resize()
     {
         // Ghostty: "Terminal: saveCursor resize"
@@ -211,15 +211,15 @@ public class GhosttyAltScreenWrapConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b7"); // saveCursor
         GhosttyTestFixture.Feed(t, "\u001b[1;1H"); // move home
         GhosttyTestFixture.Feed(t, "\u001b8"); // restoreCursor
-        Assert.Equal(7, t.CursorX);
-        Assert.Equal(0, t.CursorY);
+        Assert.AreEqual(7, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
     }
 
     #endregion
 
     #region EraseChars Wide Char Wrap Boundary
 
-    [Fact]
+    [TestMethod]
     public void EraseChars_WideCharWrapBoundary()
     {
         // Ghostty: "Terminal: eraseChars wide char wrap boundary conditions"
@@ -229,7 +229,7 @@ public class GhosttyAltScreenWrapConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;5H"); // setCursorPos(1,5) → col 4
         GhosttyTestFixture.Feed(t, "\u001b[X"); // eraseChars(1)
 
-        Assert.Equal("ABCD", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("ABCD", GhosttyTestFixture.GetLine(t, 0));
         Assert.StartsWith("\u6A4B", GhosttyTestFixture.GetLine(t, 1));
     }
 

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyBatch4ConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyBatch4ConformanceTests.cs
@@ -7,13 +7,14 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// Batch 4: Full reset (RIS), print repeat (REP), VS15, overwrite, soft wrap, zero-width chars.
 /// Translated from Ghostty Terminal.zig conformance tests.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyBatch4ConformanceTests
 {
     #region Full Reset (RIS - ESC c)
 
     // Ghostty: test "Terminal: fullReset with a non-empty pen"
-    [Fact]
+    [TestMethod]
     public void FullReset_ClearsPen()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
@@ -27,13 +28,13 @@ public class GhosttyBatch4ConformanceTests
         // Print after reset — should have default style (no colors)
         Feed(terminal, "A");
         var cell = GetCell(terminal, 0, 0);
-        Assert.Equal("A", cell.Character);
-        Assert.Null(cell.Foreground); // Default foreground
-        Assert.Null(cell.Background); // Default background
+        Assert.AreEqual("A", cell.Character);
+        Assert.IsNull(cell.Foreground); // Default foreground
+        Assert.IsNull(cell.Background); // Default background
     }
 
     // Ghostty: test "Terminal: fullReset with a non-empty saved cursor"
-    [Fact]
+    [TestMethod]
     public void FullReset_ClearsSavedCursor()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
@@ -49,13 +50,13 @@ public class GhosttyBatch4ConformanceTests
         Feed(terminal, "\x1b" + "8"); // DECRC (restore cursor)
         Feed(terminal, "A");
         var cell = GetCell(terminal, 0, 0);
-        Assert.Equal("A", cell.Character);
-        Assert.Null(cell.Foreground);
-        Assert.Null(cell.Background);
+        Assert.AreEqual("A", cell.Character);
+        Assert.IsNull(cell.Foreground);
+        Assert.IsNull(cell.Background);
     }
 
     // Ghostty: test "Terminal: fullReset origin mode"
-    [Fact]
+    [TestMethod]
     public void FullReset_ClearsOriginMode()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 10);
@@ -67,29 +68,29 @@ public class GhosttyBatch4ConformanceTests
         Feed(terminal, "\u001bc");
         
         // Origin mode should be reset and cursor at (0,0)
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(0, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorX);
     }
 
     // Test that fullReset clears screen content
-    [Fact]
+    [TestMethod]
     public void FullReset_ClearsScreen()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
         Feed(terminal, "Hello");
-        Assert.Equal("Hello", GetLine(terminal, 0));
+        Assert.AreEqual("Hello", GetLine(terminal, 0));
         
         // Full reset
         Feed(terminal, "\u001bc");
         
         // Screen should be cleared
-        Assert.Equal("", GetLine(terminal, 0));
-        Assert.Equal(0, terminal.CursorX);
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual("", GetLine(terminal, 0));
+        Assert.AreEqual(0, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
     }
 
     // Test that fullReset clears scroll regions
-    [Fact]
+    [TestMethod]
     public void FullReset_ClearsScrollRegion()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 10);
@@ -102,11 +103,11 @@ public class GhosttyBatch4ConformanceTests
         
         // Now fill screen with text — if regions were cleared, it should wrap at screen edges
         Feed(terminal, "1234567890");
-        Assert.Equal("1234567890", GetLine(terminal, 0));
+        Assert.AreEqual("1234567890", GetLine(terminal, 0));
     }
 
     // Test that fullReset resets IRM
-    [Fact]
+    [TestMethod]
     public void FullReset_ClearsInsertMode()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -119,11 +120,11 @@ public class GhosttyBatch4ConformanceTests
         Feed(terminal, "12345");
         Feed(terminal, "\x1b[1;1H"); // CUP(1,1) — go to start
         Feed(terminal, "X"); // Should overwrite, not insert
-        Assert.Equal("X2345", GetLine(terminal, 0));
+        Assert.AreEqual("X2345", GetLine(terminal, 0));
     }
 
     // Test that fullReset resets pending wrap
-    [Fact]
+    [TestMethod]
     public void FullReset_ClearsPendingWrap()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -133,9 +134,9 @@ public class GhosttyBatch4ConformanceTests
         Feed(terminal, "\u001bc");
         
         Feed(terminal, "A");
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(1, terminal.CursorX);
-        Assert.Equal("A", GetLine(terminal, 0));
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(1, terminal.CursorX);
+        Assert.AreEqual("A", GetLine(terminal, 0));
     }
 
     #endregion
@@ -143,48 +144,48 @@ public class GhosttyBatch4ConformanceTests
     #region Print Repeat (REP - CSI b)
 
     // Ghostty: test "Terminal: printRepeat simple"
-    [Fact]
+    [TestMethod]
     public void PrintRepeat_Simple()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
         Feed(terminal, "A");
         Feed(terminal, "\x1b[b"); // REP — repeat last char 1 time (default)
         
-        Assert.Equal("AA", GetLine(terminal, 0));
+        Assert.AreEqual("AA", GetLine(terminal, 0));
     }
 
     // Ghostty: test "Terminal: printRepeat wrap"
-    [Fact]
+    [TestMethod]
     public void PrintRepeat_Wrap()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
         Feed(terminal, "    A"); // Fill row, cursor in pending wrap
         Feed(terminal, "\x1b[b"); // REP — repeat last char
         
-        Assert.Equal("    A", GetLine(terminal, 0));
-        Assert.Equal("A", GetLine(terminal, 1));
+        Assert.AreEqual("    A", GetLine(terminal, 0));
+        Assert.AreEqual("A", GetLine(terminal, 1));
     }
 
     // Ghostty: test "Terminal: printRepeat no previous character"
-    [Fact]
+    [TestMethod]
     public void PrintRepeat_NoPreviousCharacter()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
         Feed(terminal, "\x1b[b"); // REP with no previous char — should be no-op
         
-        Assert.Equal("", GetLine(terminal, 0));
-        Assert.Equal(0, terminal.CursorX);
+        Assert.AreEqual("", GetLine(terminal, 0));
+        Assert.AreEqual(0, terminal.CursorX);
     }
 
     // REP with explicit count
-    [Fact]
+    [TestMethod]
     public void PrintRepeat_WithCount()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
         Feed(terminal, "X");
         Feed(terminal, "\x1b[3b"); // REP 3 — repeat 3 times
         
-        Assert.Equal("XXXX", GetLine(terminal, 0)); // Original + 3 repeats
+        Assert.AreEqual("XXXX", GetLine(terminal, 0)); // Original + 3 repeats
     }
 
     #endregion
@@ -194,36 +195,36 @@ public class GhosttyBatch4ConformanceTests
     // Ghostty: test "Terminal: VS15 to make narrow character"
     // VS15 (U+FE0E) converts wide emoji to text presentation (narrow)
     // Requires retroactive cell modification when VS15 arrives after base char
-    [Fact]
+    [TestMethod]
     public void VS15_MakeNarrowCharacter()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
         // U+2614 Umbrella with rain drops — default width 2
         Feed(terminal, "\u2614");
-        Assert.Equal(2, terminal.CursorX); // Wide char takes 2 cells
+        Assert.AreEqual(2, terminal.CursorX); // Wide char takes 2 cells
         
         // VS15 makes it narrow
         Feed(terminal, "\uFE0E");
-        Assert.Equal(1, terminal.CursorX); // Should now take 1 cell
+        Assert.AreEqual(1, terminal.CursorX); // Should now take 1 cell
     }
 
     // Ghostty: test "Terminal: VS15 on already narrow emoji"
-    [Fact]
+    [TestMethod]
     public void VS15_AlreadyNarrowEmoji()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
         // U+26C8 Thunder cloud and rain — already narrow (width 1)
         Feed(terminal, "\u26C8");
-        Assert.Equal(1, terminal.CursorX);
+        Assert.AreEqual(1, terminal.CursorX);
         
         // VS15 on already narrow — should remain at 1
         Feed(terminal, "\uFE0E");
-        Assert.Equal(1, terminal.CursorX);
+        Assert.AreEqual(1, terminal.CursorX);
     }
 
     // Ghostty: test "Terminal: VS15 to make narrow character with pending wrap"
     // Requires retroactive cell modification when VS15 arrives after base char
-    [Fact]
+    [TestMethod]
     public void VS15_WithPendingWrap()
     {
         using var terminal = CreateTerminal(cols: 4, rows: 5);
@@ -231,13 +232,13 @@ public class GhosttyBatch4ConformanceTests
         Feed(terminal, "\U0001F34B");
         // U+2614 Umbrella — wide (2 cells), fills cols 2-3, pending wrap set
         Feed(terminal, "\u2614");
-        Assert.Equal(0, terminal.CursorY); // Still on row 0 (pending wrap)
-        Assert.Equal(3, terminal.CursorX); // At last column
+        Assert.AreEqual(0, terminal.CursorY); // Still on row 0 (pending wrap)
+        Assert.AreEqual(3, terminal.CursorX); // At last column
         
         // VS15 on the umbrella — makes it narrow, should resolve pending wrap
         // and leave cursor at col 3 (not wrapped)
         Feed(terminal, "\uFE0E");
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorY);
     }
 
     #endregion
@@ -245,14 +246,14 @@ public class GhosttyBatch4ConformanceTests
     #region Zero-Width Character
 
     // Ghostty: test "Terminal: zero-width character at start"
-    [Fact]
+    [TestMethod]
     public void ZeroWidth_AtStart()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
         // ZWJ at start of empty screen — should be ignored
         Feed(terminal, "\u200D");
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(0, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorX);
     }
 
     #endregion
@@ -260,27 +261,27 @@ public class GhosttyBatch4ConformanceTests
     #region Soft Wrap
 
     // Ghostty: test "Terminal: soft wrap"
-    [Fact]
+    [TestMethod]
     public void SoftWrap_Basic()
     {
         using var terminal = CreateTerminal(cols: 3, rows: 80);
         Feed(terminal, "hello");
-        Assert.Equal(1, terminal.CursorY); // Wrapped to next line
-        Assert.Equal(2, terminal.CursorX); // 'l','o' on row 1, cursor after 'o'
-        Assert.Equal("hel", GetLine(terminal, 0));
-        Assert.Equal("lo", GetLine(terminal, 1));
+        Assert.AreEqual(1, terminal.CursorY); // Wrapped to next line
+        Assert.AreEqual(2, terminal.CursorX); // 'l','o' on row 1, cursor after 'o'
+        Assert.AreEqual("hel", GetLine(terminal, 0));
+        Assert.AreEqual("lo", GetLine(terminal, 1));
     }
 
     // Test long line wrapping doesn't crash (Ghostty issue #1400)
-    [Fact]
+    [TestMethod]
     public void SoftWrap_VeryLongLine()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
         // Print 1000 characters — should not crash
         Feed(terminal, new string('x', 1000));
         // Just verify we didn't crash and cursor is in valid position
-        Assert.True(terminal.CursorX >= 0 && terminal.CursorX < 5);
-        Assert.True(terminal.CursorY >= 0 && terminal.CursorY < 5);
+        Assert.IsTrue(terminal.CursorX >= 0 && terminal.CursorX < 5);
+        Assert.IsTrue(terminal.CursorY >= 0 && terminal.CursorY < 5);
     }
 
     #endregion
@@ -288,26 +289,26 @@ public class GhosttyBatch4ConformanceTests
     #region Overwrite Wide Character
 
     // Ghostty: test "Terminal: overwrite multicodepoint grapheme clears grapheme data"
-    [Fact]
+    [TestMethod]
     public void Overwrite_WideCharWithNarrow()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 10);
         // Print a wide character (takes 2 cells)
         Feed(terminal, "\U0001F600"); // 😀
-        Assert.Equal(2, terminal.CursorX);
+        Assert.AreEqual(2, terminal.CursorX);
         
         // Move back and overwrite with narrow character
         Feed(terminal, "\x1b[1;1H"); // CUP(1,1)
         Feed(terminal, "X");
         
-        Assert.Equal(1, terminal.CursorX);
-        Assert.Equal("X", GetCell(terminal, 0, 0).Character);
+        Assert.AreEqual(1, terminal.CursorX);
+        Assert.AreEqual("X", GetCell(terminal, 0, 0).Character);
         // The continuation cell should be cleared
-        Assert.NotEqual("\U0001F600", GetCell(terminal, 0, 1).Character);
+        Assert.AreNotEqual("\U0001F600", GetCell(terminal, 0, 1).Character);
     }
 
     // Overwrite wide char at tail position
-    [Fact]
+    [TestMethod]
     public void Overwrite_WideCharTail()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 10);
@@ -318,8 +319,8 @@ public class GhosttyBatch4ConformanceTests
         Feed(terminal, "X");
         
         // Both cells of the old wide char should be affected
-        Assert.NotEqual("\U0001F600", GetCell(terminal, 0, 0).Character);
-        Assert.Equal("X", GetCell(terminal, 0, 1).Character);
+        Assert.AreNotEqual("\U0001F600", GetCell(terminal, 0, 0).Character);
+        Assert.AreEqual("X", GetCell(terminal, 0, 1).Character);
     }
 
     #endregion
@@ -327,7 +328,7 @@ public class GhosttyBatch4ConformanceTests
     #region Disabled Wraparound
 
     // Ghostty: test "Terminal: disabled wraparound with wide char and one space"
-    [Fact]
+    [TestMethod]
     public void DisabledWraparound_WideCharNoSpace()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -336,21 +337,21 @@ public class GhosttyBatch4ConformanceTests
         
         // Try to print a wide char with only 1 cell remaining — should not fit
         Feed(terminal, "\U0001F6A8"); // 🚨 — wide char
-        Assert.Equal(0, terminal.CursorY); // Should not wrap
-        Assert.Equal(4, terminal.CursorX); // At last column
-        Assert.Equal("AAAA", GetLine(terminal, 0)); // Wide char not printed
+        Assert.AreEqual(0, terminal.CursorY); // Should not wrap
+        Assert.AreEqual(4, terminal.CursorX); // At last column
+        Assert.AreEqual("AAAA", GetLine(terminal, 0)); // Wide char not printed
     }
 
     // Ghostty: test "Terminal: disabled wraparound" (basic)
-    [Fact]
+    [TestMethod]
     public void DisabledWraparound_Basic()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
         Feed(terminal, "\x1b[?7l"); // Disable wraparound
         Feed(terminal, "ABCDEFGH"); // More chars than columns
         
-        Assert.Equal(0, terminal.CursorY); // Should not wrap
-        Assert.Equal("ABCDH", GetLine(terminal, 0)); // Last char overwrites col 4
+        Assert.AreEqual(0, terminal.CursorY); // Should not wrap
+        Assert.AreEqual("ABCDH", GetLine(terminal, 0)); // Last char overwrites col 4
     }
 
     #endregion
@@ -360,7 +361,7 @@ public class GhosttyBatch4ConformanceTests
     // Ghostty: test "Terminal: Fitzpatrick skin tone next to non-base"
     // .NET grapheme clustering incorrectly combines modifier with non-base;
     // GetGraphemeAt splits them for terminal-correct rendering.
-    [Fact]
+    [TestMethod]
     public void FitzpatrickSkinTone_NonBase()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
@@ -369,7 +370,7 @@ public class GhosttyBatch4ConformanceTests
         Feed(terminal, "\"\U0001F3FF\""); // " + 🏿 + "
         
         // " is 1 cell, 🏿 is 2 cells (wide), " is 1 cell = 4 cells total
-        Assert.Equal(4, terminal.CursorX);
+        Assert.AreEqual(4, terminal.CursorX);
     }
 
     #endregion
@@ -377,7 +378,7 @@ public class GhosttyBatch4ConformanceTests
     #region Bold Style
 
     // Ghostty: test "Terminal: bold style"
-    [Fact]
+    [TestMethod]
     public void Bold_AppliesAttribute()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -385,22 +386,22 @@ public class GhosttyBatch4ConformanceTests
         Feed(terminal, "A");
         
         var cell = GetCell(terminal, 0, 0);
-        Assert.Equal("A", cell.Character);
-        Assert.True(cell.Attributes.HasFlag(CellAttributes.Bold));
+        Assert.AreEqual("A", cell.Character);
+        Assert.IsTrue(cell.Attributes.HasFlag(CellAttributes.Bold));
     }
 
     // Ghostty: test "Terminal: default style is empty"
-    [Fact]
+    [TestMethod]
     public void DefaultStyle_IsEmpty()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
         Feed(terminal, "A");
         
         var cell = GetCell(terminal, 0, 0);
-        Assert.Equal("A", cell.Character);
-        Assert.Null(cell.Foreground);
-        Assert.Null(cell.Background);
-        Assert.Equal(CellAttributes.None, cell.Attributes);
+        Assert.AreEqual("A", cell.Character);
+        Assert.IsNull(cell.Foreground);
+        Assert.IsNull(cell.Background);
+        Assert.AreEqual(CellAttributes.None, cell.Attributes);
     }
 
     #endregion
@@ -409,7 +410,7 @@ public class GhosttyBatch4ConformanceTests
 
     // Ghostty: test "Terminal: overwrite hyperlink"
     // When a hyperlink cell is overwritten, the hyperlink reference should be cleared
-    [Fact]
+    [TestMethod]
     public void Overwrite_ClearsHyperlink()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -423,13 +424,13 @@ public class GhosttyBatch4ConformanceTests
         Feed(terminal, "X");
         
         var cell = GetCell(terminal, 0, 0);
-        Assert.Equal("X", cell.Character);
-        Assert.Null(cell.TrackedHyperlink); // Hyperlink should be cleared
+        Assert.AreEqual("X", cell.Character);
+        Assert.IsNull(cell.TrackedHyperlink); // Hyperlink should be cleared
         
         // But the next cell should still have the hyperlink
         var cell2 = GetCell(terminal, 0, 1);
-        Assert.Equal("E", cell2.Character);
-        Assert.NotNull(cell2.TrackedHyperlink);
+        Assert.AreEqual("E", cell2.Character);
+        Assert.IsNotNull(cell2.TrackedHyperlink);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyBatch5ConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyBatch5ConformanceTests.cs
@@ -7,31 +7,32 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// Batch 5: Horizontal tabs, alt screen modes, basic input, disabled wraparound extras.
 /// Translated from Ghostty Terminal.zig conformance tests.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyBatch5ConformanceTests
 {
     #region Horizontal Tabs
 
     // Ghostty: test "Terminal: horizontal tabs"
-    [Fact]
+    [TestMethod]
     public void HorizontalTab_Basic()
     {
         using var terminal = CreateTerminal(cols: 20, rows: 5);
         Feed(terminal, "1");
         Feed(terminal, "\t"); // Tab from col 1 → col 8
-        Assert.Equal(8, terminal.CursorX);
+        Assert.AreEqual(8, terminal.CursorX);
 
         Feed(terminal, "\t"); // Tab from col 8 → col 16
-        Assert.Equal(16, terminal.CursorX);
+        Assert.AreEqual(16, terminal.CursorX);
 
         Feed(terminal, "\t"); // Tab at end → col 19
-        Assert.Equal(19, terminal.CursorX);
+        Assert.AreEqual(19, terminal.CursorX);
         Feed(terminal, "\t"); // Tab at end again → still col 19
-        Assert.Equal(19, terminal.CursorX);
+        Assert.AreEqual(19, terminal.CursorX);
     }
 
     // Ghostty: test "Terminal: horizontal tabs starting on tabstop"
-    [Fact]
+    [TestMethod]
     public void HorizontalTab_StartingOnTabstop()
     {
         using var terminal = CreateTerminal(cols: 20, rows: 5);
@@ -42,11 +43,11 @@ public class GhosttyBatch5ConformanceTests
         Feed(terminal, "\t"); // Tab from col 8 → col 16
         Feed(terminal, "A");
 
-        Assert.Equal("        X       A", GetLine(terminal, 0));
+        Assert.AreEqual("        X       A", GetLine(terminal, 0));
     }
 
     // Ghostty: test "Terminal: horizontal tabs back"
-    [Fact]
+    [TestMethod]
     public void HorizontalTabBack_Basic()
     {
         using var terminal = CreateTerminal(cols: 20, rows: 5);
@@ -54,19 +55,19 @@ public class GhosttyBatch5ConformanceTests
         Feed(terminal, "\x1b[1;20H"); // CUP(1,20) — col 19
         
         Feed(terminal, "\x1b[Z"); // Back tab → col 16
-        Assert.Equal(16, terminal.CursorX);
+        Assert.AreEqual(16, terminal.CursorX);
 
         Feed(terminal, "\x1b[Z"); // Back tab → col 8
-        Assert.Equal(8, terminal.CursorX);
+        Assert.AreEqual(8, terminal.CursorX);
 
         Feed(terminal, "\x1b[Z"); // Back tab → col 0
-        Assert.Equal(0, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorX);
         Feed(terminal, "\x1b[Z"); // Back tab at col 0 → still col 0
-        Assert.Equal(0, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorX);
     }
 
     // Ghostty: test "Terminal: horizontal tabs back starting on tabstop"
-    [Fact]
+    [TestMethod]
     public void HorizontalTabBack_StartingOnTabstop()
     {
         using var terminal = CreateTerminal(cols: 20, rows: 5);
@@ -76,7 +77,7 @@ public class GhosttyBatch5ConformanceTests
         Feed(terminal, "\x1b[Z"); // Back tab from col 8 → col 0
         Feed(terminal, "A");
 
-        Assert.Equal("A       X", GetLine(terminal, 0));
+        Assert.AreEqual("A       X", GetLine(terminal, 0));
     }
 
     #endregion
@@ -84,7 +85,7 @@ public class GhosttyBatch5ConformanceTests
     #region Alt Screen Modes
 
     // Ghostty: test "Terminal: mode 1049 alt screen plain"
-    [Fact]
+    [TestMethod]
     public void AltScreen_Mode1049_Basic()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -95,25 +96,25 @@ public class GhosttyBatch5ConformanceTests
         Feed(terminal, "\x1b[?1049h");
         
         // Alt screen should be empty
-        Assert.Equal("", GetLine(terminal, 0));
+        Assert.AreEqual("", GetLine(terminal, 0));
 
         // Print on alt screen — cursor position preserved from primary
         Feed(terminal, "2B");
-        Assert.Equal("  2B", GetLine(terminal, 0));
+        Assert.AreEqual("  2B", GetLine(terminal, 0));
 
         // Return to primary screen
         Feed(terminal, "\x1b[?1049l");
         
         // Primary screen should be preserved
-        Assert.Equal("1A", GetLine(terminal, 0));
+        Assert.AreEqual("1A", GetLine(terminal, 0));
 
         // Write after restore — cursor should be restored to primary position
         Feed(terminal, "C");
-        Assert.Equal("1AC", GetLine(terminal, 0));
+        Assert.AreEqual("1AC", GetLine(terminal, 0));
     }
 
     // Test re-entering alt screen clears it
-    [Fact]
+    [TestMethod]
     public void AltScreen_Mode1049_ReEnterClears()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -125,11 +126,11 @@ public class GhosttyBatch5ConformanceTests
         Feed(terminal, "\x1b[?1049l");
         
         // Primary preserved
-        Assert.Equal("1A", GetLine(terminal, 0));
+        Assert.AreEqual("1A", GetLine(terminal, 0));
 
         // Re-enter alt screen — should be cleared
         Feed(terminal, "\x1b[?1049h");
-        Assert.Equal("", GetLine(terminal, 0));
+        Assert.AreEqual("", GetLine(terminal, 0));
     }
 
     #endregion
@@ -137,42 +138,42 @@ public class GhosttyBatch5ConformanceTests
     #region Basic Input (print + scroll)
 
     // Ghostty: test "Terminal: input with no control characters"
-    [Fact]
+    [TestMethod]
     public void Input_NoControlCharacters()
     {
         using var terminal = CreateTerminal(cols: 40, rows: 40);
         Feed(terminal, "hello");
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(5, terminal.CursorX);
-        Assert.Equal("hello", GetLine(terminal, 0));
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(5, terminal.CursorX);
+        Assert.AreEqual("hello", GetLine(terminal, 0));
     }
 
     // Ghostty: test "Terminal: input with basic wraparound"
-    [Fact]
+    [TestMethod]
     public void Input_BasicWraparound()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 40);
         Feed(terminal, "helloworldabc12");
-        Assert.Equal(2, terminal.CursorY);
-        Assert.Equal("hello", GetLine(terminal, 0));
-        Assert.Equal("world", GetLine(terminal, 1));
-        Assert.Equal("abc12", GetLine(terminal, 2));
+        Assert.AreEqual(2, terminal.CursorY);
+        Assert.AreEqual("hello", GetLine(terminal, 0));
+        Assert.AreEqual("world", GetLine(terminal, 1));
+        Assert.AreEqual("abc12", GetLine(terminal, 2));
     }
 
     // Ghostty: test "Terminal: input that forces scroll"
-    [Fact]
+    [TestMethod]
     public void Input_ForcesScroll()
     {
         using var terminal = CreateTerminal(cols: 1, rows: 5);
         Feed(terminal, "abcdef"); // 6 chars in 1-col terminal, forces scroll
-        Assert.Equal(4, terminal.CursorY);
-        Assert.Equal(0, terminal.CursorX);
+        Assert.AreEqual(4, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorX);
         // First char 'a' scrolled off, remaining: b,c,d,e,f
-        Assert.Equal("b", GetLine(terminal, 0));
-        Assert.Equal("c", GetLine(terminal, 1));
-        Assert.Equal("d", GetLine(terminal, 2));
-        Assert.Equal("e", GetLine(terminal, 3));
-        Assert.Equal("f", GetLine(terminal, 4));
+        Assert.AreEqual("b", GetLine(terminal, 0));
+        Assert.AreEqual("c", GetLine(terminal, 1));
+        Assert.AreEqual("d", GetLine(terminal, 2));
+        Assert.AreEqual("e", GetLine(terminal, 3));
+        Assert.AreEqual("f", GetLine(terminal, 4));
     }
 
     #endregion
@@ -181,16 +182,16 @@ public class GhosttyBatch5ConformanceTests
 
     // Ghostty: test "Terminal: disabled wraparound with wide char and no space"
     // All 5 cols filled with 'A', then try to print wide char
-    [Fact]
+    [TestMethod]
     public void DisabledWraparound_WideCharFilledRow()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
         Feed(terminal, "\x1b[?7l"); // Disable wraparound
         Feed(terminal, "AAAAA"); // Fill all 5 cols
         Feed(terminal, "\U0001F6A8"); // Try wide char — no space at all
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(4, terminal.CursorX);
-        Assert.Equal("AAAAA", GetLine(terminal, 0)); // Wide char not printed
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(4, terminal.CursorX);
+        Assert.AreEqual("AAAAA", GetLine(terminal, 0)); // Wide char not printed
     }
 
     #endregion
@@ -198,18 +199,18 @@ public class GhosttyBatch5ConformanceTests
     #region Overwrite with Print Repeat
 
     // Ghostty: test "Terminal: overwrite" (basic overwrite)
-    [Fact]
+    [TestMethod]
     public void Overwrite_Basic()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
         Feed(terminal, "ABCDE");
         Feed(terminal, "\x1b[1;1H"); // CUP(1,1)
         Feed(terminal, "XYZ");
-        Assert.Equal("XYZDE", GetLine(terminal, 0));
+        Assert.AreEqual("XYZDE", GetLine(terminal, 0));
     }
 
     // Print repeat with attributes preserved
-    [Fact]
+    [TestMethod]
     public void PrintRepeat_PreservesAttributes()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -220,11 +221,11 @@ public class GhosttyBatch5ConformanceTests
         var cell0 = GetCell(terminal, 0, 0);
         var cell1 = GetCell(terminal, 0, 1);
         var cell2 = GetCell(terminal, 0, 2);
-        Assert.Equal("A", cell0.Character);
-        Assert.Equal("A", cell1.Character);
-        Assert.Equal("A", cell2.Character);
-        Assert.True(cell1.Attributes.HasFlag(CellAttributes.Bold));
-        Assert.True(cell2.Attributes.HasFlag(CellAttributes.Bold));
+        Assert.AreEqual("A", cell0.Character);
+        Assert.AreEqual("A", cell1.Character);
+        Assert.AreEqual("A", cell2.Character);
+        Assert.IsTrue(cell1.Attributes.HasFlag(CellAttributes.Bold));
+        Assert.IsTrue(cell2.Attributes.HasFlag(CellAttributes.Bold));
     }
 
     #endregion
@@ -233,28 +234,28 @@ public class GhosttyBatch5ConformanceTests
 
     // Ghostty: test "Terminal: linefeed and carriage return"
     // This test exists in misc already, but let's test the sequence behavior directly
-    [Fact]
+    [TestMethod]
     public void NewlineAndCR_BasicSequence()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
         Feed(terminal, "ABC");
         Feed(terminal, "\r\n"); // CR+LF
         Feed(terminal, "DEF");
-        Assert.Equal("ABC", GetLine(terminal, 0));
-        Assert.Equal("DEF", GetLine(terminal, 1));
+        Assert.AreEqual("ABC", GetLine(terminal, 0));
+        Assert.AreEqual("DEF", GetLine(terminal, 1));
     }
 
     // Test that LF alone doesn't perform CR (default behavior)
-    [Fact]
+    [TestMethod]
     public void Linefeed_NoCR_ByDefault()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
         Feed(terminal, "ABC");
         Feed(terminal, "\n"); // LF only — should NOT do CR
         Feed(terminal, "X");
-        Assert.Equal("ABC", GetLine(terminal, 0));
+        Assert.AreEqual("ABC", GetLine(terminal, 0));
         // X should be at the same column (col 3), not at col 0
-        Assert.Equal("   X", GetLine(terminal, 1));
+        Assert.AreEqual("   X", GetLine(terminal, 1));
     }
 
     #endregion
@@ -262,7 +263,7 @@ public class GhosttyBatch5ConformanceTests
     #region Set Top and Bottom Margin Edge Cases
 
     // Ghostty: test "Terminal: setTopAndBottomMargin simple"
-    [Fact]
+    [TestMethod]
     public void DECSTBM_Simple()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 10);
@@ -286,7 +287,7 @@ public class GhosttyBatch5ConformanceTests
     #region Full Reset Additional
 
     // Test RIS resets LNM mode
-    [Fact]
+    [TestMethod]
     public void FullReset_ClearsLnm()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -299,12 +300,12 @@ public class GhosttyBatch5ConformanceTests
         Feed(terminal, "ABC");
         Feed(terminal, "\n");
         Feed(terminal, "X");
-        Assert.Equal("ABC", GetLine(terminal, 0));
-        Assert.Equal("   X", GetLine(terminal, 1)); // X at col 3, not col 0
+        Assert.AreEqual("ABC", GetLine(terminal, 0));
+        Assert.AreEqual("   X", GetLine(terminal, 1)); // X at col 3, not col 0
     }
 
     // Test RIS resets DECLRMM
-    [Fact]
+    [TestMethod]
     public void FullReset_ClearsDeclrmm()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -316,7 +317,7 @@ public class GhosttyBatch5ConformanceTests
         
         // After reset, text should fill the full width
         Feed(terminal, "1234567890");
-        Assert.Equal("1234567890", GetLine(terminal, 0));
+        Assert.AreEqual("1234567890", GetLine(terminal, 0));
     }
 
     #endregion

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyCursorConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyCursorConformanceTests.cs
@@ -1,4 +1,3 @@
-using Xunit;
 
 namespace Hex1b.Tests.Conformance.Ghostty;
 
@@ -7,7 +6,8 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// cursor positioning (CUP) with origin mode, DECALN, and save/restore cursor.
 /// Translated from Ghostty's Terminal.zig test suite.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyCursorConformanceTests
 {
     private static Hex1bTerminal CreateTerminal(int cols = 80, int rows = 24)
@@ -24,7 +24,7 @@ public class GhosttyCursorConformanceTests
     #region CursorUp (CUU — CSI n A)
 
     // Ghostty: test "Terminal: cursorUp basic"
-    [Fact]
+    [TestMethod]
     public void CursorUp_Basic()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -33,13 +33,13 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\x1b[10A"); // CUU(10) — clamped to top
         Feed(terminal, "X");
 
-        Assert.Equal(" X", GetLine(terminal, 0));
-        Assert.Equal("", GetLine(terminal, 1));
-        Assert.Equal("A", GetLine(terminal, 2));
+        Assert.AreEqual(" X", GetLine(terminal, 0));
+        Assert.AreEqual("", GetLine(terminal, 1));
+        Assert.AreEqual("A", GetLine(terminal, 2));
     }
 
     // Ghostty: test "Terminal: cursorUp below top scroll margin"
-    [Fact]
+    [TestMethod]
     public void CursorUp_BelowTopScrollMargin()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -49,13 +49,13 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\x1b[5A"); // CUU(5) — clamped to top margin (row 1)
         Feed(terminal, "X");
 
-        Assert.Equal("", GetLine(terminal, 0));
-        Assert.Equal(" X", GetLine(terminal, 1));
-        Assert.Equal("A", GetLine(terminal, 2));
+        Assert.AreEqual("", GetLine(terminal, 0));
+        Assert.AreEqual(" X", GetLine(terminal, 1));
+        Assert.AreEqual("A", GetLine(terminal, 2));
     }
 
     // Ghostty: test "Terminal: cursorUp above top scroll margin"
-    [Fact]
+    [TestMethod]
     public void CursorUp_AboveTopScrollMargin()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -66,13 +66,13 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\x1b[10A"); // CUU(10) — clamped to row 0 (ignores margin since above)
         Feed(terminal, "X");
 
-        Assert.Equal("X", GetLine(terminal, 0));
-        Assert.Equal("", GetLine(terminal, 1));
-        Assert.Equal("A", GetLine(terminal, 2));
+        Assert.AreEqual("X", GetLine(terminal, 0));
+        Assert.AreEqual("", GetLine(terminal, 1));
+        Assert.AreEqual("A", GetLine(terminal, 2));
     }
 
     // Ghostty: test "Terminal: cursorUp resets wrap"
-    [Fact]
+    [TestMethod]
     public void CursorUp_ResetsWrap()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -81,7 +81,7 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "X");
 
         // Should overwrite 'E' since wrap was reset and cursor stays at last col
-        Assert.Equal("ABCDX", GetLine(terminal, 0));
+        Assert.AreEqual("ABCDX", GetLine(terminal, 0));
     }
 
     #endregion
@@ -89,7 +89,7 @@ public class GhosttyCursorConformanceTests
     #region CursorDown (CUD — CSI n B)
 
     // Ghostty: test "Terminal: cursorDown basic"
-    [Fact]
+    [TestMethod]
     public void CursorDown_Basic()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -97,12 +97,12 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\x1b[10B"); // CUD(10) — clamped to bottom
         Feed(terminal, "X");
 
-        Assert.Equal("A", GetLine(terminal, 0));
-        Assert.Equal(" X", GetLine(terminal, 4));
+        Assert.AreEqual("A", GetLine(terminal, 0));
+        Assert.AreEqual(" X", GetLine(terminal, 4));
     }
 
     // Ghostty: test "Terminal: cursorDown above bottom scroll margin"
-    [Fact]
+    [TestMethod]
     public void CursorDown_AboveBottomScrollMargin()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -111,12 +111,12 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\x1b[10B"); // CUD(10) — clamped to bottom margin (row 2)
         Feed(terminal, "X");
 
-        Assert.Equal("A", GetLine(terminal, 0));
-        Assert.Equal(" X", GetLine(terminal, 2));
+        Assert.AreEqual("A", GetLine(terminal, 0));
+        Assert.AreEqual(" X", GetLine(terminal, 2));
     }
 
     // Ghostty: test "Terminal: cursorDown below bottom scroll margin"
-    [Fact]
+    [TestMethod]
     public void CursorDown_BelowBottomScrollMargin()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -126,12 +126,12 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\x1b[10B"); // CUD(10) — clamped to bottom of screen
         Feed(terminal, "X");
 
-        Assert.Equal("A", GetLine(terminal, 0));
-        Assert.Equal("X", GetLine(terminal, 4));
+        Assert.AreEqual("A", GetLine(terminal, 0));
+        Assert.AreEqual("X", GetLine(terminal, 4));
     }
 
     // Ghostty: test "Terminal: cursorDown resets wrap"
-    [Fact]
+    [TestMethod]
     public void CursorDown_ResetsWrap()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -139,8 +139,8 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\x1b[1B"); // CUD(1) — resets wrap
         Feed(terminal, "X");
 
-        Assert.Equal("ABCDE", GetLine(terminal, 0));
-        Assert.Equal("    X", GetLine(terminal, 1));
+        Assert.AreEqual("ABCDE", GetLine(terminal, 0));
+        Assert.AreEqual("    X", GetLine(terminal, 1));
     }
 
     #endregion
@@ -148,7 +148,7 @@ public class GhosttyCursorConformanceTests
     #region CursorRight (CUF — CSI n C)
 
     // Ghostty: test "Terminal: cursorRight resets wrap"
-    [Fact]
+    [TestMethod]
     public void CursorRight_ResetsWrap()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -156,22 +156,22 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\x1b[1C"); // CUF(1) — resets wrap, stays at last col
         Feed(terminal, "X");
 
-        Assert.Equal("ABCDX", GetLine(terminal, 0));
+        Assert.AreEqual("ABCDX", GetLine(terminal, 0));
     }
 
     // Ghostty: test "Terminal: cursorRight to the edge of screen"
-    [Fact]
+    [TestMethod]
     public void CursorRight_ToEdgeOfScreen()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
         Feed(terminal, "\x1b[100C"); // CUF(100) — clamped to last col
         Feed(terminal, "X");
 
-        Assert.Equal("    X", GetLine(terminal, 0));
+        Assert.AreEqual("    X", GetLine(terminal, 0));
     }
 
     // Ghostty: test "Terminal: cursorRight left of right margin"
-    [Fact]
+    [TestMethod]
     public void CursorRight_LeftOfRightMargin()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -180,11 +180,11 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\x1b[100C"); // CUF(100) — clamped to right margin
         Feed(terminal, "X");
 
-        Assert.Equal("  X", GetLine(terminal, 0));
+        Assert.AreEqual("  X", GetLine(terminal, 0));
     }
 
     // Ghostty: test "Terminal: cursorRight right of right margin"
-    [Fact]
+    [TestMethod]
     public void CursorRight_RightOfRightMargin()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -194,7 +194,7 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\x1b[100C"); // CUF(100) — clamped to edge of screen (outside margin)
         Feed(terminal, "X");
 
-        Assert.Equal("    X", GetLine(terminal, 0));
+        Assert.AreEqual("    X", GetLine(terminal, 0));
     }
 
     #endregion
@@ -202,7 +202,7 @@ public class GhosttyCursorConformanceTests
     #region CursorLeft (CUB — CSI n D)
 
     // Ghostty: test "Terminal: cursorLeft no wrap"
-    [Fact]
+    [TestMethod]
     public void CursorLeft_NoWrap()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -212,12 +212,12 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\x1b[10D"); // CUB(10) — clamped to col 0
 
         // Cursor should be at col 0, row 1 — no wrapping to previous line
-        Assert.Equal(0, terminal.CursorX);
-        Assert.Equal(1, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorX);
+        Assert.AreEqual(1, terminal.CursorY);
     }
 
     // Ghostty: test "Terminal: cursorLeft unsets pending wrap state"
-    [Fact]
+    [TestMethod]
     public void CursorLeft_UnsetsPendingWrap()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -225,11 +225,11 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\x1b[1D"); // CUB(1) — resets wrap
         Feed(terminal, "X");
 
-        Assert.Equal("ABCXE", GetLine(terminal, 0));
+        Assert.AreEqual("ABCXE", GetLine(terminal, 0));
     }
 
     // Ghostty: test "Terminal: cursorLeft unsets pending wrap state with longer jump"
-    [Fact]
+    [TestMethod]
     public void CursorLeft_UnsetsPendingWrap_LongerJump()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -237,7 +237,7 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\x1b[3D"); // CUB(3) — resets wrap, moves back 3
         Feed(terminal, "X");
 
-        Assert.Equal("AXCDE", GetLine(terminal, 0));
+        Assert.AreEqual("AXCDE", GetLine(terminal, 0));
     }
 
     #endregion
@@ -245,7 +245,7 @@ public class GhosttyCursorConformanceTests
     #region CursorPos (CUP) with Origin Mode
 
     // Ghostty: test "Terminal: cursorPos resets wrap"
-    [Fact]
+    [TestMethod]
     public void CursorPos_ResetsWrap()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -253,23 +253,23 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\x1b[1;1H"); // CUP(1,1) — resets wrap
         Feed(terminal, "X");
 
-        Assert.Equal("XBCDE", GetLine(terminal, 0));
+        Assert.AreEqual("XBCDE", GetLine(terminal, 0));
     }
 
     // Ghostty: test "Terminal: cursorPos off the screen"
-    [Fact]
+    [TestMethod]
     public void CursorPos_OffTheScreen()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
         Feed(terminal, "\x1b[500;500H"); // CUP(500,500) — clamped
         Feed(terminal, "X");
 
-        Assert.Equal(4, terminal.CursorY);
-        Assert.Equal("    X", GetLine(terminal, 4));
+        Assert.AreEqual(4, terminal.CursorY);
+        Assert.AreEqual("    X", GetLine(terminal, 4));
     }
 
     // Ghostty: test "Terminal: cursorPos relative to origin"
-    [Fact]
+    [TestMethod]
     public void CursorPos_RelativeToOrigin()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -279,13 +279,13 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "X");
 
         // Origin mode: row 1 maps to scroll region top (row 2, 0-based)
-        Assert.Equal("", GetLine(terminal, 0));
-        Assert.Equal("", GetLine(terminal, 1));
-        Assert.Equal("X", GetLine(terminal, 2));
+        Assert.AreEqual("", GetLine(terminal, 0));
+        Assert.AreEqual("", GetLine(terminal, 1));
+        Assert.AreEqual("X", GetLine(terminal, 2));
     }
 
     // Ghostty: test "Terminal: cursorPos relative to origin with left/right"
-    [Fact]
+    [TestMethod]
     public void CursorPos_RelativeToOrigin_WithLeftRight()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -296,13 +296,13 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\x1b[1;1H"); // CUP(1,1) — relative to both margins
         Feed(terminal, "X");
 
-        Assert.Equal("", GetLine(terminal, 0));
-        Assert.Equal("", GetLine(terminal, 1));
-        Assert.Equal("  X", GetLine(terminal, 2));
+        Assert.AreEqual("", GetLine(terminal, 0));
+        Assert.AreEqual("", GetLine(terminal, 1));
+        Assert.AreEqual("  X", GetLine(terminal, 2));
     }
 
     // Ghostty: test "Terminal: cursorPos limits with full scroll region"
-    [Fact]
+    [TestMethod]
     public void CursorPos_LimitsWithFullScrollRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -314,27 +314,27 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "X");
 
         // Should be clamped to bottom-right of scroll region
-        Assert.Equal("    X", GetLine(terminal, 3));
+        Assert.AreEqual("    X", GetLine(terminal, 3));
     }
 
     // Ghostty: test "Terminal: setCursorPos (original test)"
-    [Fact]
+    [TestMethod]
     public void SetCursorPos_OriginalTest()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
 
-        Assert.Equal(0, terminal.CursorX);
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
 
         // Setting to 0 should keep it zero (CUP is 1-based, 0 treated as 1)
         Feed(terminal, "\x1b[0;0H");
-        Assert.Equal(0, terminal.CursorX);
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
 
         // Should clamp to size
         Feed(terminal, "\x1b[81;81H");
-        Assert.Equal(79, terminal.CursorX);
-        Assert.Equal(79, terminal.CursorY);
+        Assert.AreEqual(79, terminal.CursorX);
+        Assert.AreEqual(79, terminal.CursorY);
     }
 
     #endregion
@@ -342,7 +342,7 @@ public class GhosttyCursorConformanceTests
     #region DECALN (Screen Alignment Test — ESC # 8)
 
     // Ghostty: test "Terminal: DECALN"
-    [Fact]
+    [TestMethod]
     public void Decaln_FillsWithE()
     {
         using var terminal = CreateTerminal(cols: 2, rows: 2);
@@ -351,14 +351,14 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "B");
         Feed(terminal, "\x1b#8"); // DECALN
 
-        Assert.Equal(0, terminal.CursorX);
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal("EE", GetLine(terminal, 0));
-        Assert.Equal("EE", GetLine(terminal, 1));
+        Assert.AreEqual(0, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual("EE", GetLine(terminal, 0));
+        Assert.AreEqual("EE", GetLine(terminal, 1));
     }
 
     // Ghostty: test "Terminal: decaln reset margins"
-    [Fact]
+    [TestMethod]
     public void Decaln_ResetMargins()
     {
         using var terminal = CreateTerminal(cols: 3, rows: 3);
@@ -368,13 +368,13 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\x1b[1T"); // SD(1) — scroll down
 
         // After DECALN resets margins, scroll down shifts all 3 rows
-        Assert.Equal("", GetLine(terminal, 0));
-        Assert.Equal("EEE", GetLine(terminal, 1));
-        Assert.Equal("EEE", GetLine(terminal, 2));
+        Assert.AreEqual("", GetLine(terminal, 0));
+        Assert.AreEqual("EEE", GetLine(terminal, 1));
+        Assert.AreEqual("EEE", GetLine(terminal, 2));
     }
 
     // Ghostty: test "Terminal: decaln preserves color"
-    [Fact]
+    [TestMethod]
     public void Decaln_PreservesColor()
     {
         using var terminal = CreateTerminal(cols: 3, rows: 3);
@@ -384,17 +384,17 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\x1b#8"); // DECALN — should reset margins, preserve bg
         Feed(terminal, "\x1b[1T"); // SD(1) — scroll down
 
-        Assert.Equal("", GetLine(terminal, 0));
-        Assert.Equal("EEE", GetLine(terminal, 1));
-        Assert.Equal("EEE", GetLine(terminal, 2));
+        Assert.AreEqual("", GetLine(terminal, 0));
+        Assert.AreEqual("EEE", GetLine(terminal, 1));
+        Assert.AreEqual("EEE", GetLine(terminal, 2));
 
         // Verify background color is preserved on the blank line
         var cell = GetCell(terminal, 0, 0);
-        Assert.NotNull(cell.Background);
+        Assert.IsNotNull(cell.Background);
         var bg = cell.Background!.Value;
-        Assert.Equal((byte)255, bg.R);
-        Assert.Equal((byte)0, bg.G);
-        Assert.Equal((byte)0, bg.B);
+        Assert.AreEqual((byte)255, bg.R);
+        Assert.AreEqual((byte)0, bg.G);
+        Assert.AreEqual((byte)0, bg.B);
     }
 
     #endregion
@@ -402,7 +402,7 @@ public class GhosttyCursorConformanceTests
     #region Save/Restore Cursor (DECSC/DECRC — ESC 7 / ESC 8)
 
     // Ghostty: test "Terminal: saveCursor position"
-    [Fact]
+    [TestMethod]
     public void SaveCursor_Position()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -414,11 +414,11 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\x1b" + "8"); // DECRC (restore cursor)
         Feed(terminal, "X");
 
-        Assert.Equal("B   AX", GetLine(terminal, 0));
+        Assert.AreEqual("B   AX", GetLine(terminal, 0));
     }
 
     // Ghostty: test "Terminal: saveCursor pending wrap state"
-    [Fact]
+    [TestMethod]
     public void SaveCursor_PendingWrapState()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -430,12 +430,12 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\x1b" + "8"); // DECRC — restores pending wrap
         Feed(terminal, "X");
 
-        Assert.Equal("B   A", GetLine(terminal, 0));
-        Assert.Equal("X", GetLine(terminal, 1));
+        Assert.AreEqual("B   A", GetLine(terminal, 0));
+        Assert.AreEqual("X", GetLine(terminal, 1));
     }
 
     // Ghostty: test "Terminal: saveCursor origin mode"
-    [Fact]
+    [TestMethod]
     public void SaveCursor_OriginMode()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -449,11 +449,11 @@ public class GhosttyCursorConformanceTests
 
         // With origin mode restored, CUP should position relative to margins
         // But cursor position was (0,0) when saved, so X goes at (0,0)
-        Assert.Equal("X", GetLine(terminal, 0));
+        Assert.AreEqual("X", GetLine(terminal, 0));
     }
 
     // Ghostty: test "Terminal: saveCursor resize"
-    [Fact]
+    [TestMethod]
     public void SaveCursor_Resize()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -466,7 +466,7 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\x1b" + "8"); // DECRC — restore
         Feed(terminal, "X");
 
-        Assert.Equal("         X", GetLine(terminal, 0));
+        Assert.AreEqual("         X", GetLine(terminal, 0));
     }
 
     #endregion
@@ -474,7 +474,7 @@ public class GhosttyCursorConformanceTests
     #region Carriage Return with Margins
 
     // Ghostty: test "Terminal: carriage return origin mode moves to left margin"
-    [Fact]
+    [TestMethod]
     public void CarriageReturn_OriginMode_MovesToLeftMargin()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -485,11 +485,11 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\r"); // CR — should go to left margin (col 2)
         Feed(terminal, "X");
 
-        Assert.Equal("  X", GetLine(terminal, 0));
+        Assert.AreEqual("  X", GetLine(terminal, 0));
     }
 
     // Ghostty: test "Terminal: carriage return left of left margin moves to zero"
-    [Fact]
+    [TestMethod]
     public void CarriageReturn_LeftOfLeftMargin_MovesToZero()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -499,11 +499,11 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\r"); // CR — should go to col 0 (outside margin)
         Feed(terminal, "X");
 
-        Assert.Equal("X", GetLine(terminal, 0));
+        Assert.AreEqual("X", GetLine(terminal, 0));
     }
 
     // Ghostty: test "Terminal: carriage return right of left margin moves to left margin"
-    [Fact]
+    [TestMethod]
     public void CarriageReturn_RightOfLeftMargin_MovesToLeftMargin()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -513,7 +513,7 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "\r"); // CR — should go to left margin (col 2)
         Feed(terminal, "X");
 
-        Assert.Equal("  X", GetLine(terminal, 0));
+        Assert.AreEqual("  X", GetLine(terminal, 0));
     }
 
     #endregion
@@ -521,7 +521,7 @@ public class GhosttyCursorConformanceTests
     #region Horizontal Tabs with Margins
 
     // Ghostty: test "Terminal: horizontal tabs with right margin"
-    [Fact]
+    [TestMethod]
     public void HorizontalTabs_WithRightMargin()
     {
         using var terminal = CreateTerminal(cols: 20, rows: 5);
@@ -531,7 +531,7 @@ public class GhosttyCursorConformanceTests
         Feed(terminal, "X");
 
         // Default tab stops at every 8 columns. Tab from col 0 → col 7 (right margin)
-        Assert.True(terminal.CursorX <= 8, $"CursorX {terminal.CursorX} should be within right margin");
+        Assert.IsTrue(terminal.CursorX <= 8, $"CursorX {terminal.CursorX} should be within right margin");
     }
 
     #endregion

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyDeleteCharsInsertBlanksConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyDeleteCharsInsertBlanksConformanceTests.cs
@@ -1,4 +1,4 @@
-using Xunit;
+
 using static Hex1b.Tests.Conformance.Ghostty.GhosttyTestFixture;
 
 namespace Hex1b.Tests.Conformance.Ghostty;
@@ -7,12 +7,13 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// Conformance tests for deleteChars (DCH — CSI n P) and insertBlanks (ICH — CSI n @)
 /// translated from Ghostty Terminal.zig.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyDeleteCharsInsertBlanksConformanceTests
 {
     #region deleteChars (DCH — CSI n P)
 
-    [Fact]
+    [TestMethod]
     public void DeleteChars_Basic()
     {
         // Ghostty: "Terminal: deleteChars"
@@ -21,10 +22,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[1;2H"); // setCursorPos(1, 2) → col 1
         Feed(t, "\u001b[2P");   // deleteChars(2)
 
-        Assert.Equal("ADE", GetLine(t, 0));
+        Assert.AreEqual("ADE", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteChars_MoreThanHalf()
     {
         // Ghostty: "Terminal: deleteChars more than half"
@@ -33,10 +34,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[1;2H"); // setCursorPos(1, 2) → col 1
         Feed(t, "\u001b[3P");   // deleteChars(3)
 
-        Assert.Equal("AE", GetLine(t, 0));
+        Assert.AreEqual("AE", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteChars_MoreThanLineWidth()
     {
         // Ghostty: "Terminal: deleteChars more than line width"
@@ -45,10 +46,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[1;2H"); // setCursorPos(1, 2) → col 1
         Feed(t, "\u001b[10P");  // deleteChars(10)
 
-        Assert.Equal("A", GetLine(t, 0));
+        Assert.AreEqual("A", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteChars_ShouldShiftLeft()
     {
         // Ghostty: "Terminal: deleteChars should shift left"
@@ -57,24 +58,24 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[1;2H"); // setCursorPos(1, 2) → col 1
         Feed(t, "\u001b[1P");   // deleteChars(1)
 
-        Assert.Equal("ACDE", GetLine(t, 0));
+        Assert.AreEqual("ACDE", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteChars_ResetsPendingWrap()
     {
         // Ghostty: "Terminal: deleteChars resets pending wrap"
         using var t = CreateTerminal(cols: 5, rows: 5);
         Feed(t, "ABCDE");       // fills row, pending wrap
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
         Feed(t, "\u001b[1P");   // deleteChars(1) — resets pending wrap
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
         Feed(t, "X");
 
-        Assert.Equal("ABCDX", GetLine(t, 0));
+        Assert.AreEqual("ABCDX", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteChars_ResetsWrap()
     {
         // Ghostty: "Terminal: deleteChars resets wrap"
@@ -84,11 +85,11 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[1P");   // deleteChars(1)
         Feed(t, "X");
 
-        Assert.Equal("XCDE", GetLine(t, 0));
-        Assert.Equal("123", GetLine(t, 1));
+        Assert.AreEqual("XCDE", GetLine(t, 0));
+        Assert.AreEqual("123", GetLine(t, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteChars_SimpleOperation()
     {
         // Ghostty: "Terminal: deleteChars simple operation"
@@ -97,10 +98,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[1;3H"); // setCursorPos(1, 3) → col 2
         Feed(t, "\u001b[2P");   // deleteChars(2)
 
-        Assert.Equal("AB23", GetLine(t, 0));
+        Assert.AreEqual("AB23", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteChars_PreservesBackgroundSgr()
     {
         // Ghostty: "Terminal: deleteChars preserves background sgr"
@@ -110,17 +111,17 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[48;2;255;0;0m"); // direct_color_bg red
         Feed(t, "\u001b[2P");           // deleteChars(2)
 
-        Assert.Equal("AB23", GetLine(t, 0));
+        Assert.AreEqual("AB23", GetLine(t, 0));
 
         // Verify background color on cleared cells (cols 8 and 9)
         for (int x = 8; x < 10; x++)
         {
             var cell = GetCell(t, 0, x);
-            Assert.NotNull(cell.Background);
+            Assert.IsNotNull(cell.Background);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteChars_OutsideScrollRegion()
     {
         // Ghostty: "Terminal: deleteChars outside scroll region"
@@ -132,10 +133,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[1;7H");         // CUP → col 5 (clamped, outside scroll region)
         Feed(t, "\u001b[2P");           // deleteChars(2) — should be no-op
 
-        Assert.Equal("ABC123", GetLine(t, 0));
+        Assert.AreEqual("ABC123", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteChars_InsideScrollRegion()
     {
         // Ghostty: "Terminal: deleteChars inside scroll region"
@@ -146,10 +147,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[1;4H");         // setCursorPos(1, 4) → col 3 (inside scroll region)
         Feed(t, "\u001b[1P");           // deleteChars(1)
 
-        Assert.Equal("ABC2 3", GetLine(t, 0));
+        Assert.AreEqual("ABC2 3", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteChars_SplitWideCharFromSpacerTail()
     {
         // Ghostty: "Terminal: deleteChars split wide character from spacer tail"
@@ -158,10 +159,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[1;3H");         // setCursorPos(1, 3) → col 2 (spacer tail of 橋)
         Feed(t, "\u001b[1P");           // deleteChars(1)
 
-        Assert.Equal("A 123", GetLine(t, 0));
+        Assert.AreEqual("A 123", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteChars_SplitWideCharFromWide()
     {
         // Ghostty: "Terminal: deleteChars split wide character from wide"
@@ -173,10 +174,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         // Cell at (0,0) should be empty (codepoint 0), cell at (0,1) should be '1'
         var cell0 = GetCell(t, 0, 0);
         var cell1 = GetCell(t, 0, 1);
-        Assert.Equal("1", cell1.Character);
+        Assert.AreEqual("1", cell1.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteChars_SplitWideCharFromEnd()
     {
         // Ghostty: "Terminal: deleteChars split wide character from end"
@@ -187,10 +188,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
 
         // 橋 should shift left to cols 0-1
         var cell0 = GetCell(t, 0, 0);
-        Assert.Equal("\u6A4B", cell0.Character); // 橋
+        Assert.AreEqual("\u6A4B", cell0.Character); // 橋
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteChars_WithSpacerHeadAtEnd()
     {
         // Ghostty: "Terminal: deleteChars with a spacer head at the end"
@@ -202,10 +203,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
 
         // After delete: spacer head at col 4 shifts to col 3, becomes empty
         // Row 0 should be "123" (with trailing empty cells)
-        Assert.Equal("123", GetLine(t, 0));
+        Assert.AreEqual("123", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteChars_SplitWideCharTail()
     {
         // Ghostty: "Terminal: deleteChars split wide character tail"
@@ -216,10 +217,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, $"\u001b[4P");          // deleteChars(cols - 1 = 4)
         Feed(t, "0");
 
-        Assert.Equal("0", GetLine(t, 0));
+        Assert.AreEqual("0", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteChars_WideCharBoundaryConditions()
     {
         // Ghostty: "Terminal: deleteChars wide char boundary conditions"
@@ -228,15 +229,15 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         using var t = CreateTerminal(cols: 8, rows: 1);
         Feed(t, "\U0001F600a\U0001F600b\U0001F600"); // 😀a😀b😀
 
-        Assert.Equal("\U0001F600a\U0001F600b\U0001F600", GetLine(t, 0));
+        Assert.AreEqual("\U0001F600a\U0001F600b\U0001F600", GetLine(t, 0));
 
         Feed(t, "\u001b[1;2H");         // setCursorPos(1, 2) → col 1
         Feed(t, "\u001b[3P");           // deleteChars(3)
 
-        Assert.Equal("  b\U0001F600", GetLine(t, 0));
+        Assert.AreEqual("  b\U0001F600", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteChars_WideCharWrapBoundaryConditions()
     {
         // Ghostty: "Terminal: deleteChars wide char wrap boundary conditions"
@@ -248,20 +249,20 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         using var t = CreateTerminal(cols: 8, rows: 3);
         Feed(t, ".......\U0001F600abcde\U0001F600......");
 
-        Assert.Equal(".......", GetLine(t, 0));
-        Assert.Equal("\U0001F600abcde", GetLine(t, 1));
-        Assert.Equal("\U0001F600......", GetLine(t, 2));
+        Assert.AreEqual(".......", GetLine(t, 0));
+        Assert.AreEqual("\U0001F600abcde", GetLine(t, 1));
+        Assert.AreEqual("\U0001F600......", GetLine(t, 2));
 
         Feed(t, "\u001b[2;2H");         // setCursorPos(2, 2) → row 1, col 1
         Feed(t, "\u001b[3P");           // deleteChars(3)
 
-        Assert.Equal(".......", GetLine(t, 0));
-        Assert.Equal(" cde", GetLine(t, 1));
-        Assert.Equal("\U0001F600......", GetLine(t, 2));
+        Assert.AreEqual(".......", GetLine(t, 0));
+        Assert.AreEqual(" cde", GetLine(t, 1));
+        Assert.AreEqual("\U0001F600......", GetLine(t, 2));
     }
 
-    [Fact]
-    [Trait("FailureReason", "Bug")]
+    [TestMethod]
+    [TestCategory("FailureReason:Bug")]
     public void DeleteChars_WideCharAcrossRightMargin()
     {
         // Ghostty: "Terminal: deleteChars wide char across right margin"
@@ -270,21 +271,21 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         using var t = CreateTerminal(cols: 8, rows: 3);
         Feed(t, "123456\u6A4B");        // 123456橋
 
-        Assert.Equal("123456\u6A4B", GetLine(t, 0));
+        Assert.AreEqual("123456\u6A4B", GetLine(t, 0));
 
         Feed(t, "\u001b[?69h");         // Enable DECLRMM
         Feed(t, "\u001b[2;7s");         // DECSLRM(2,7) = left=1, right=6 (0-based)
         Feed(t, "\u001b[1;2H");         // setCursorPos(1, 2) → col 1 (inside left margin)
         Feed(t, "\u001b[1P");           // deleteChars(1)
 
-        Assert.Equal("13456", GetLine(t, 0));
+        Assert.AreEqual("13456", GetLine(t, 0));
     }
 
     #endregion
 
     #region insertBlanks (ICH — CSI n @)
 
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_Zero()
     {
         // Ghostty: "Terminal: insertBlanks zero"
@@ -297,10 +298,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
 
         // If Hex1b defaults param 0 to 1 (VT spec), content would shift.
         // Ghostty's internal function treats 0 as no-op.
-        Assert.Equal("ABC", GetLine(t, 0));
+        Assert.AreEqual("ABC", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_Basic()
     {
         // Ghostty: "Terminal: insertBlanks"
@@ -309,10 +310,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[1;1H");         // setCursorPos(1, 1) → col 0
         Feed(t, "\u001b[2@");           // insertBlanks(2)
 
-        Assert.Equal("  ABC", GetLine(t, 0));
+        Assert.AreEqual("  ABC", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_PushesOffEnd()
     {
         // Ghostty: "Terminal: insertBlanks pushes off end"
@@ -321,10 +322,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[1;1H");         // setCursorPos(1, 1) → col 0
         Feed(t, "\u001b[2@");           // insertBlanks(2)
 
-        Assert.Equal("  A", GetLine(t, 0));
+        Assert.AreEqual("  A", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_MoreThanSize()
     {
         // Ghostty: "Terminal: insertBlanks more than size"
@@ -333,10 +334,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[1;1H");         // setCursorPos(1, 1) → col 0
         Feed(t, "\u001b[5@");           // insertBlanks(5)
 
-        Assert.Equal("", GetLine(t, 0));
+        Assert.AreEqual("", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_NoScrollRegionFits()
     {
         // Ghostty: "Terminal: insertBlanks no scroll region, fits"
@@ -345,10 +346,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[1;1H");         // setCursorPos(1, 1) → col 0
         Feed(t, "\u001b[2@");           // insertBlanks(2)
 
-        Assert.Equal("  ABC", GetLine(t, 0));
+        Assert.AreEqual("  ABC", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_PreservesBackgroundSgr()
     {
         // Ghostty: "Terminal: insertBlanks preserves background sgr"
@@ -358,14 +359,14 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[48;2;255;0;0m"); // direct_color_bg red
         Feed(t, "\u001b[2@");           // insertBlanks(2)
 
-        Assert.Equal("  ABC", GetLine(t, 0));
+        Assert.AreEqual("  ABC", GetLine(t, 0));
 
         // Verify inserted blank at col 0 has red background
         var cell = GetCell(t, 0, 0);
-        Assert.NotNull(cell.Background);
+        Assert.IsNotNull(cell.Background);
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_ShiftOffScreen()
     {
         // Ghostty: "Terminal: insertBlanks shift off screen"
@@ -375,10 +376,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[2@");           // insertBlanks(2)
         Feed(t, "X");
 
-        Assert.Equal("  X A", GetLine(t, 0));
+        Assert.AreEqual("  X A", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_SplitMultiCellCharacter()
     {
         // Ghostty: "Terminal: insertBlanks split multi-cell character"
@@ -387,10 +388,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[1;1H");         // setCursorPos(1, 1) → col 0
         Feed(t, "\u001b[1@");           // insertBlanks(1)
 
-        Assert.Equal(" 123", GetLine(t, 0));
+        Assert.AreEqual(" 123", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_InsideLeftRightScrollRegion()
     {
         // Ghostty: "Terminal: insertBlanks inside left/right scroll region"
@@ -403,10 +404,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[2@");           // insertBlanks(2)
         Feed(t, "X");
 
-        Assert.Equal("  X A", GetLine(t, 0));
+        Assert.AreEqual("  X A", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_OutsideLeftRightScrollRegion()
     {
         // Ghostty: "Terminal: insertBlanks outside left/right scroll region"
@@ -421,10 +422,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[2@");           // insertBlanks(2) — cursor outside scroll region
         Feed(t, "X");
 
-        Assert.Equal("   ABX", GetLine(t, 0));
+        Assert.AreEqual("   ABX", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_LeftRightScrollRegionLargeCount()
     {
         // Ghostty: "Terminal: insertBlanks left/right scroll region large count"
@@ -436,10 +437,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[140@");         // insertBlanks(140)
         Feed(t, "X");
 
-        Assert.Equal("  X", GetLine(t, 0));
+        Assert.AreEqual("  X", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_DeletingGraphemes()
     {
         // Ghostty: "Terminal: insertBlanks deleting graphemes"
@@ -456,10 +457,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[1;1H");         // setCursorPos(1, 1) → col 0
         Feed(t, "\u001b[4@");           // insertBlanks(4)
 
-        Assert.Equal("    A", GetLine(t, 0));
+        Assert.AreEqual("    A", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_ShiftGraphemes()
     {
         // Ghostty: "Terminal: insertBlanks shift graphemes"
@@ -476,10 +477,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[1;1H");         // setCursorPos(1, 1) → col 0
         Feed(t, "\u001b[1@");           // insertBlanks(1)
 
-        Assert.Equal(" A\U0001F468\u200D\U0001F469\u200D\U0001F467", GetLine(t, 0));
+        Assert.AreEqual(" A\U0001F468\u200D\U0001F469\u200D\U0001F467", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_SplitMultiCellCharFromTail()
     {
         // Ghostty: "Terminal: insertBlanks split multi-cell character from tail"
@@ -488,10 +489,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[1;2H");         // setCursorPos(1, 2) → col 1 (tail of 橋)
         Feed(t, "\u001b[1@");           // insertBlanks(1)
 
-        Assert.Equal("   12", GetLine(t, 0));
+        Assert.AreEqual("   12", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_WideCharStraddlingRightMargin()
     {
         // Ghostty: "Terminal: insertBlanks wide char straddling right margin"
@@ -503,10 +504,10 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "\u001b[1;3H");         // setCursorPos(1, 3) → col 2
         Feed(t, "\u001b[1@");           // insertBlanks(1)
 
-        Assert.Equal("AB CD", GetLine(t, 0));
+        Assert.AreEqual("AB CD", GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_WideCharSpacerTailOrphanedBeyondRightMargin()
     {
         // Ghostty: "Terminal: insertBlanks wide char spacer_tail orphaned beyond right margin"
@@ -519,7 +520,7 @@ public class GhosttyDeleteCharsInsertBlanksConformanceTests
         Feed(t, "a");                   // at col 0 (cursor homed after DECSLRM)
         Feed(t, "\u001b[8@");           // insertBlanks(8) at col 1
 
-        Assert.Equal("a", GetLine(t, 0));
+        Assert.AreEqual("a", GetLine(t, 0));
     }
 
     #endregion

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyDeleteInsertLinesConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyDeleteInsertLinesConformanceTests.cs
@@ -1,4 +1,3 @@
-using Xunit;
 
 namespace Hex1b.Tests.Conformance.Ghostty;
 
@@ -6,7 +5,8 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// Conformance tests for deleteLines (DL / CSI M) and insertLines (IL / CSI L),
 /// translated from Ghostty's Terminal.zig.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyDeleteInsertLinesConformanceTests
 {
     private static Hex1bTerminal CreateTerminal(int cols = 80, int rows = 24)
@@ -15,7 +15,7 @@ public class GhosttyDeleteInsertLinesConformanceTests
     #region DeleteLines (DL / CSI M)
 
     // Ghostty: "Terminal: deleteLines simple"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_Simple()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -23,13 +23,13 @@ public class GhosttyDeleteInsertLinesConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H"); // setCursorPos(2, 2)
         GhosttyTestFixture.Feed(t, "\u001b[1M");    // deleteLines(1)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
     }
 
     // Ghostty: "Terminal: deleteLines zero"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_Zero_NoOp()
     {
         using var t = CreateTerminal(cols: 2, rows: 5);
@@ -39,22 +39,22 @@ public class GhosttyDeleteInsertLinesConformanceTests
     }
 
     // Ghostty: "Terminal: deleteLines resets pending wrap"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_ResetsPendingWrap()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
         GhosttyTestFixture.Feed(t, "ABCDE");
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
 
         GhosttyTestFixture.Feed(t, "\u001b[1M"); // deleteLines(1)
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
 
         GhosttyTestFixture.Feed(t, "B");
-        Assert.Equal("B", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("B", GhosttyTestFixture.GetLine(t, 0));
     }
 
     // Ghostty: "Terminal: deleteLines with scroll region"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_WithScrollRegion()
     {
         using var t = CreateTerminal(cols: 80, rows: 80);
@@ -64,14 +64,14 @@ public class GhosttyDeleteInsertLinesConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1M");     // deleteLines(1)
         GhosttyTestFixture.Feed(t, "E\r\n");
 
-        Assert.Equal("E", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("C", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("D", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("E", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("C", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("D", GhosttyTestFixture.GetLine(t, 3));
     }
 
     // Ghostty: "Terminal: deleteLines with scroll region, cursor outside of region"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_WithScrollRegion_CursorOutside()
     {
         using var t = CreateTerminal(cols: 80, rows: 80);
@@ -80,14 +80,14 @@ public class GhosttyDeleteInsertLinesConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[4;1H");  // setCursorPos(4, 1) — outside region
         GhosttyTestFixture.Feed(t, "\u001b[1M");     // deleteLines(1)
 
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("B", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("C", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("D", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("B", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("C", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("D", GhosttyTestFixture.GetLine(t, 3));
     }
 
     // Ghostty: "Terminal: deleteLines with scroll region, large count"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_WithScrollRegion_LargeCount()
     {
         using var t = CreateTerminal(cols: 80, rows: 80);
@@ -97,14 +97,14 @@ public class GhosttyDeleteInsertLinesConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[5M");     // deleteLines(5)
         GhosttyTestFixture.Feed(t, "E\r\n");
 
-        Assert.Equal("E", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("D", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("E", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("D", GhosttyTestFixture.GetLine(t, 3));
     }
 
     // Ghostty: "Terminal: deleteLines (legacy)"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_Legacy()
     {
         using var t = CreateTerminal(cols: 80, rows: 80);
@@ -113,12 +113,12 @@ public class GhosttyDeleteInsertLinesConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1M");     // deleteLines(1)
         GhosttyTestFixture.Feed(t, "E\r\n");
 
-        Assert.Equal(0, t.CursorX);
-        Assert.Equal(2, t.CursorY);
+        Assert.AreEqual(0, t.CursorX);
+        Assert.AreEqual(2, t.CursorY);
 
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("E", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("D", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("E", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("D", GhosttyTestFixture.GetLine(t, 2));
     }
 
     #endregion
@@ -126,7 +126,7 @@ public class GhosttyDeleteInsertLinesConformanceTests
     #region InsertLines (IL / CSI L)
 
     // Ghostty: "Terminal: insertLines simple"
-    [Fact]
+    [TestMethod]
     public void InsertLines_Simple()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -134,14 +134,14 @@ public class GhosttyDeleteInsertLinesConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H"); // setCursorPos(2, 2)
         GhosttyTestFixture.Feed(t, "\u001b[1L");    // insertLines(1)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 3));
     }
 
     // Ghostty: "Terminal: insertLines zero"
-    [Fact]
+    [TestMethod]
     public void InsertLines_Zero_NoOp()
     {
         using var t = CreateTerminal(cols: 2, rows: 5);
@@ -151,23 +151,23 @@ public class GhosttyDeleteInsertLinesConformanceTests
     }
 
     // Ghostty: "Terminal: insertLines resets pending wrap"
-    [Fact]
+    [TestMethod]
     public void InsertLines_ResetsPendingWrap()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
         GhosttyTestFixture.Feed(t, "ABCDE");
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
 
         GhosttyTestFixture.Feed(t, "\u001b[1L"); // insertLines(1)
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
 
         GhosttyTestFixture.Feed(t, "B");
-        Assert.Equal("B", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("ABCDE", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("B", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("ABCDE", GhosttyTestFixture.GetLine(t, 1));
     }
 
     // Ghostty: "Terminal: insertLines with scroll region"
-    [Fact]
+    [TestMethod]
     public void InsertLines_WithScrollRegion()
     {
         using var t = CreateTerminal(cols: 2, rows: 6);
@@ -177,15 +177,15 @@ public class GhosttyDeleteInsertLinesConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1L");     // insertLines(1)
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("X", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("C", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("D", GhosttyTestFixture.GetLine(t, 3));
-        Assert.Equal("E", GhosttyTestFixture.GetLine(t, 4));
+        Assert.AreEqual("X", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("C", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("D", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("E", GhosttyTestFixture.GetLine(t, 4));
     }
 
     // Ghostty: "Terminal: insertLines more than remaining"
-    [Fact]
+    [TestMethod]
     public void InsertLines_MoreThanRemaining()
     {
         using var t = CreateTerminal(cols: 2, rows: 5);
@@ -193,15 +193,15 @@ public class GhosttyDeleteInsertLinesConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;1H");  // setCursorPos(2, 1)
         GhosttyTestFixture.Feed(t, "\u001b[20L");    // insertLines(20)
 
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 3));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 4));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 4));
     }
 
     // Ghostty: "Terminal: insertLines outside of scroll region"
-    [Fact]
+    [TestMethod]
     public void InsertLines_OutsideScrollRegion()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -210,13 +210,13 @@ public class GhosttyDeleteInsertLinesConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H");  // setCursorPos(2, 2) — outside region
         GhosttyTestFixture.Feed(t, "\u001b[1L");     // insertLines(1)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 2));
     }
 
     // Ghostty: "Terminal: insertLines (legacy test)"
-    [Fact]
+    [TestMethod]
     public void InsertLines_Legacy()
     {
         using var t = CreateTerminal(cols: 2, rows: 5);
@@ -224,15 +224,15 @@ public class GhosttyDeleteInsertLinesConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;1H");  // setCursorPos(2, 1)
         GhosttyTestFixture.Feed(t, "\u001b[2L");     // insertLines(2)
 
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("B", GhosttyTestFixture.GetLine(t, 3));
-        Assert.Equal("C", GhosttyTestFixture.GetLine(t, 4));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("B", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("C", GhosttyTestFixture.GetLine(t, 4));
     }
 
     // Ghostty: "Terminal: insertLines top/bottom scroll region"
-    [Fact]
+    [TestMethod]
     public void InsertLines_TopBottomScrollRegion()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -241,10 +241,10 @@ public class GhosttyDeleteInsertLinesConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H");  // setCursorPos(2, 2)
         GhosttyTestFixture.Feed(t, "\u001b[1L");     // insertLines(1)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("123", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("123", GhosttyTestFixture.GetLine(t, 3));
     }
 
     #endregion

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyDeleteInsertLinesMarginConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyDeleteInsertLinesMarginConformanceTests.cs
@@ -1,4 +1,3 @@
-using Xunit;
 
 namespace Hex1b.Tests.Conformance.Ghostty;
 
@@ -7,7 +6,8 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// focusing on left/right margins and wide character handling,
 /// translated from Ghostty's Terminal.zig.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyDeleteInsertLinesMarginConformanceTests
 {
     private static Hex1bTerminal CreateTerminal(int cols = 80, int rows = 24)
@@ -16,7 +16,7 @@ public class GhosttyDeleteInsertLinesMarginConformanceTests
     #region DeleteLines – wrap and color
 
     // Ghostty: "Terminal: deleteLines resets wrap"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_ResetsWrap()
     {
         using var t = CreateTerminal(cols: 3, rows: 3);
@@ -26,13 +26,13 @@ public class GhosttyDeleteInsertLinesMarginConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1M");     // deleteLines(1)
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("XBC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("XBC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 2));
     }
 
     // Ghostty: "Terminal: deleteLines colors with bg color"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_ColorsWithBgColor()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -41,18 +41,18 @@ public class GhosttyDeleteInsertLinesMarginConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[48;2;255;0;0m"); // set bg red
         GhosttyTestFixture.Feed(t, "\u001b[1M");            // deleteLines(1)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
 
         // The newly blanked bottom row (row 4) should have the red bg color
         for (int x = 0; x < 5; x++)
         {
             var cell = GhosttyTestFixture.GetCell(t, 4, x);
-            Assert.NotNull(cell.Background);
-            Assert.Equal(255, cell.Background!.Value.R);
-            Assert.Equal(0, cell.Background!.Value.G);
-            Assert.Equal(0, cell.Background!.Value.B);
+            Assert.IsNotNull(cell.Background);
+            Assert.AreEqual(255, cell.Background!.Value.R);
+            Assert.AreEqual(0, cell.Background!.Value.G);
+            Assert.AreEqual(0, cell.Background!.Value.B);
         }
     }
 
@@ -61,7 +61,7 @@ public class GhosttyDeleteInsertLinesMarginConformanceTests
     #region DeleteLines – left/right scroll region
 
     // Ghostty: "Terminal: deleteLines left/right scroll region"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_LeftRightScrollRegion()
     {
         using var t = CreateTerminal(cols: 10, rows: 10);
@@ -71,13 +71,13 @@ public class GhosttyDeleteInsertLinesMarginConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H");   // setCursorPos(2, 2)
         GhosttyTestFixture.Feed(t, "\u001b[1M");      // deleteLines(1)
 
-        Assert.Equal("ABC123", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("DHI756", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("G   89", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("ABC123", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("DHI756", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("G   89", GhosttyTestFixture.GetLine(t, 2));
     }
 
     // Ghostty: "Terminal: deleteLines left/right scroll region from top"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_LeftRightScrollRegion_FromTop()
     {
         using var t = CreateTerminal(cols: 10, rows: 10);
@@ -87,13 +87,13 @@ public class GhosttyDeleteInsertLinesMarginConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;2H");   // setCursorPos(1, 2)
         GhosttyTestFixture.Feed(t, "\u001b[1M");      // deleteLines(1)
 
-        Assert.Equal("AEF423", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("DHI756", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("G   89", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("AEF423", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("DHI756", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("G   89", GhosttyTestFixture.GetLine(t, 2));
     }
 
     // Ghostty: "Terminal: deleteLines left/right scroll region high count"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_LeftRightScrollRegion_HighCount()
     {
         using var t = CreateTerminal(cols: 10, rows: 10);
@@ -103,9 +103,9 @@ public class GhosttyDeleteInsertLinesMarginConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H");   // setCursorPos(2, 2)
         GhosttyTestFixture.Feed(t, "\u001b[100M");    // deleteLines(100)
 
-        Assert.Equal("ABC123", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("D   56", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("G   89", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("ABC123", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("D   56", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("G   89", GhosttyTestFixture.GetLine(t, 2));
     }
 
     #endregion
@@ -113,7 +113,7 @@ public class GhosttyDeleteInsertLinesMarginConformanceTests
     #region DeleteLines – wide character spacer head
 
     // Ghostty: "Terminal: deleteLines wide character spacer head"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_WideCharSpacerHead()
     {
         using var t = CreateTerminal(cols: 5, rows: 3);
@@ -126,12 +126,12 @@ public class GhosttyDeleteInsertLinesMarginConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1M");    // deleteLines(1)
 
         // Spacer head should become empty cell, wrap unset
-        Assert.Equal("BBBB", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("\U0001F600CCC", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("BBBB", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("\U0001F600CCC", GhosttyTestFixture.GetLine(t, 1));
     }
 
     // Ghostty: "Terminal: deleteLines wide character spacer head left scroll margin"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_WideCharSpacerHead_LeftScrollMargin()
     {
         using var t = CreateTerminal(cols: 5, rows: 3);
@@ -141,13 +141,13 @@ public class GhosttyDeleteInsertLinesMarginConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;3H");   // setCursorPos(1, 3)
         GhosttyTestFixture.Feed(t, "\u001b[1M");      // deleteLines(1)
 
-        Assert.Equal("AABB", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("BBCCC", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("\U0001F600", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("AABB", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("BBCCC", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("\U0001F600", GhosttyTestFixture.GetLine(t, 2));
     }
 
     // Ghostty: "Terminal: deleteLines wide character spacer head right scroll margin"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_WideCharSpacerHead_RightScrollMargin()
     {
         using var t = CreateTerminal(cols: 5, rows: 3);
@@ -157,13 +157,13 @@ public class GhosttyDeleteInsertLinesMarginConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H");   // setCursorPos(1, 1)
         GhosttyTestFixture.Feed(t, "\u001b[1M");      // deleteLines(1)
 
-        Assert.Equal("BBBBA", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("\U0001F600CC", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("    C", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("BBBBA", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("\U0001F600CC", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("    C", GhosttyTestFixture.GetLine(t, 2));
     }
 
     // Ghostty: "Terminal: deleteLines wide character spacer head left and right scroll margin"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_WideCharSpacerHead_LeftAndRightScrollMargin()
     {
         using var t = CreateTerminal(cols: 5, rows: 3);
@@ -173,14 +173,14 @@ public class GhosttyDeleteInsertLinesMarginConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;3H");   // setCursorPos(1, 3)
         GhosttyTestFixture.Feed(t, "\u001b[1M");      // deleteLines(1)
 
-        Assert.Equal("AABBA", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("BBCC", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("\U0001F600  C", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("AABBA", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("BBCC", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("\U0001F600  C", GhosttyTestFixture.GetLine(t, 2));
     }
 
     // Ghostty: "Terminal: deleteLines wide character spacer head left (< 2) and right scroll margin"
-    [Fact]
-    [Trait("FailureReason", "Bug")]
+    [TestMethod]
+    [TestCategory("FailureReason:Bug")]
     public void DeleteLines_WideCharSpacerHead_LeftLessThan2_AndRightScrollMargin()
     {
         using var t = CreateTerminal(cols: 5, rows: 3);
@@ -191,14 +191,14 @@ public class GhosttyDeleteInsertLinesMarginConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1M");      // deleteLines(1)
 
         // Wide char at boundary is split and removed
-        Assert.Equal("ABBBA", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("B CC", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("    C", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("ABBBA", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("B CC", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("    C", GhosttyTestFixture.GetLine(t, 2));
     }
 
     // Ghostty: "Terminal: deleteLines wide characters split by left/right scroll region boundaries"
-    [Fact]
-    [Trait("FailureReason", "Bug")]
+    [TestMethod]
+    [TestCategory("FailureReason:Bug")]
     public void DeleteLines_WideCharsSplitByScrollRegionBoundaries()
     {
         using var t = CreateTerminal(cols: 5, rows: 2);
@@ -215,11 +215,11 @@ public class GhosttyDeleteInsertLinesMarginConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1M");      // deleteLines(1)
 
         // Wide chars split by scroll region edges are removed
-        Assert.Equal("A B A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("A B A", GhosttyTestFixture.GetLine(t, 0));
     }
 
     // Ghostty: "Terminal: deleteLines wide char at right margin with full clear"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_WideCharAtRightMarginWithFullClear()
     {
         using var t = CreateTerminal(cols: 80, rows: 24);
@@ -237,7 +237,7 @@ public class GhosttyDeleteInsertLinesMarginConformanceTests
     #region InsertLines – wrap, color, margins, graphemes
 
     // Ghostty: "Terminal: insertLines resets wrap"
-    [Fact]
+    [TestMethod]
     public void InsertLines_ResetsWrap()
     {
         using var t = CreateTerminal(cols: 3, rows: 3);
@@ -246,13 +246,13 @@ public class GhosttyDeleteInsertLinesMarginConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1L");     // insertLines(1)
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("X", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("1", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("X", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("1", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 2));
     }
 
     // Ghostty: "Terminal: insertLines colors with bg color"
-    [Fact]
+    [TestMethod]
     public void InsertLines_ColorsWithBgColor()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -261,24 +261,24 @@ public class GhosttyDeleteInsertLinesMarginConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[48;2;255;0;0m"); // set bg red
         GhosttyTestFixture.Feed(t, "\u001b[1L");            // insertLines(1)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 3));
 
         // The newly inserted blank row (row 1) should have the red bg color
         for (int x = 0; x < 5; x++)
         {
             var cell = GhosttyTestFixture.GetCell(t, 1, x);
-            Assert.NotNull(cell.Background);
-            Assert.Equal(255, cell.Background!.Value.R);
-            Assert.Equal(0, cell.Background!.Value.G);
-            Assert.Equal(0, cell.Background!.Value.B);
+            Assert.IsNotNull(cell.Background);
+            Assert.AreEqual(255, cell.Background!.Value.R);
+            Assert.AreEqual(0, cell.Background!.Value.G);
+            Assert.AreEqual(0, cell.Background!.Value.B);
         }
     }
 
     // Ghostty: "Terminal: insertLines left/right scroll region"
-    [Fact]
+    [TestMethod]
     public void InsertLines_LeftRightScrollRegion()
     {
         using var t = CreateTerminal(cols: 10, rows: 10);
@@ -288,14 +288,14 @@ public class GhosttyDeleteInsertLinesMarginConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H");   // setCursorPos(2, 2)
         GhosttyTestFixture.Feed(t, "\u001b[1L");      // insertLines(1)
 
-        Assert.Equal("ABC123", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("D   56", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("GEF489", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal(" HI7", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("ABC123", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("D   56", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("GEF489", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual(" HI7", GhosttyTestFixture.GetLine(t, 3));
     }
 
     // Ghostty: "Terminal: insertLines multi-codepoint graphemes"
-    [Fact]
+    [TestMethod]
     public void InsertLines_MultiCodepointGraphemes()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -307,10 +307,10 @@ public class GhosttyDeleteInsertLinesMarginConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H");   // setCursorPos(2, 2)
         GhosttyTestFixture.Feed(t, "\u001b[1L");      // insertLines(1)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("\U0001F468\u200D\U0001F469\u200D\U0001F467", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("\U0001F468\u200D\U0001F469\u200D\U0001F467", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 3));
     }
 
     #endregion

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyEraseAndMiscConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyEraseAndMiscConformanceTests.cs
@@ -1,4 +1,3 @@
-using Xunit;
 
 namespace Hex1b.Tests.Conformance.Ghostty;
 
@@ -6,14 +5,15 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// Additional erase operation, DECALN, and cursor position tests.
 /// Translated from Ghostty's Terminal.zig.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyEraseAndMiscConformanceTests
 {
     // ═══════════════════════════════════════════════════════════════
     // eraseChars — basic and edge cases (non-protected)
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void EraseChars_SimpleOperation()
     {
         // Ghostty: "Terminal: eraseChars simple operation"
@@ -24,10 +24,10 @@ public class GhosttyEraseAndMiscConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2X");    // eraseChars(2)
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("X C", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("X C", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseChars_MinimumOne()
     {
         // Ghostty: "Terminal: eraseChars minimum one"
@@ -39,10 +39,10 @@ public class GhosttyEraseAndMiscConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[0X");    // eraseChars(0) → treated as 1
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("XBC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("XBC", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseChars_BeyondScreenEdge()
     {
         // Ghostty: "Terminal: eraseChars beyond screen edge"
@@ -52,10 +52,10 @@ public class GhosttyEraseAndMiscConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;4H"); // setCursorPos(1,4)
         GhosttyTestFixture.Feed(t, "\u001b[10X");   // eraseChars(10)
 
-        Assert.Equal("  A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("  A", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseChars_WideCharacter()
     {
         // Ghostty: "Terminal: eraseChars wide character"
@@ -66,40 +66,40 @@ public class GhosttyEraseAndMiscConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1X");    // eraseChars(1) — erases leading cell of wide char
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("X BC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("X BC", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseChars_ResetsPendingWrap()
     {
         // Ghostty: "Terminal: eraseChars resets pending wrap"
         var t = GhosttyTestFixture.CreateTerminal(5, 5);
 
         GhosttyTestFixture.Feed(t, "ABCDE");
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "\u001b[1X"); // eraseChars(1)
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("ABCDX", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("ABCDX", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseChars_WideCharBoundaryConditions()
     {
         // Ghostty: "Terminal: eraseChars wide char boundary conditions"
         var t = GhosttyTestFixture.CreateTerminal(8, 1);
 
         GhosttyTestFixture.Feed(t, "😀a😀b😀");
-        Assert.Equal("😀a😀b😀", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("😀a😀b😀", GhosttyTestFixture.GetLine(t, 0));
 
         GhosttyTestFixture.Feed(t, "\u001b[1;2H"); // setCursorPos(1,2) — on continuation of first emoji
         GhosttyTestFixture.Feed(t, "\u001b[3X");    // eraseChars(3)
 
-        Assert.Equal("     b😀", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("     b😀", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseChars_WideCharSplitsProperCellBoundaries()
     {
         // Ghostty: "Terminal: eraseChars wide char splits proper cell boundaries"
@@ -107,19 +107,19 @@ public class GhosttyEraseAndMiscConformanceTests
         var t = GhosttyTestFixture.CreateTerminal(30, 1);
 
         GhosttyTestFixture.Feed(t, "x食べて下さい");
-        Assert.Equal("x食べて下さい", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("x食べて下さい", GhosttyTestFixture.GetLine(t, 0));
 
         GhosttyTestFixture.Feed(t, "\u001b[1;6H"); // setCursorPos(1,6) — at て
         GhosttyTestFixture.Feed(t, "\u001b[4X");    // eraseChars(4) — erase て下
 
-        Assert.Equal("x食べ    さい", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("x食べ    さい", GhosttyTestFixture.GetLine(t, 0));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // eraseLine — basic operations (non-protected)
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_SimpleEraseRight()
     {
         // Ghostty: "Terminal: eraseLine simple erase right"
@@ -129,25 +129,25 @@ public class GhosttyEraseAndMiscConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;3H"); // setCursorPos(1,3)
         GhosttyTestFixture.Feed(t, "\u001b[K");     // eraseLine right
 
-        Assert.Equal("AB", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("AB", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_ResetsPendingWrap()
     {
         // Ghostty: "Terminal: eraseLine resets pending wrap"
         var t = GhosttyTestFixture.CreateTerminal(5, 5);
 
         GhosttyTestFixture.Feed(t, "ABCDE");
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "\u001b[K"); // eraseLine right
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "B");
 
-        Assert.Equal("ABCDB", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("ABCDB", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_RightWideCharacter()
     {
         // Ghostty: "Terminal: eraseLine right wide character"
@@ -158,10 +158,10 @@ public class GhosttyEraseAndMiscConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;4H"); // setCursorPos(1,4) — on continuation of 橋
         GhosttyTestFixture.Feed(t, "\u001b[K");     // eraseLine right
 
-        Assert.Equal("AB", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("AB", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_SimpleEraseLeft()
     {
         // Ghostty: "Terminal: eraseLine simple erase left"
@@ -171,25 +171,25 @@ public class GhosttyEraseAndMiscConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;3H"); // setCursorPos(1,3)
         GhosttyTestFixture.Feed(t, "\u001b[1K");    // eraseLine left
 
-        Assert.Equal("   DE", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("   DE", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_LeftResetsWrap()
     {
         // Ghostty: "Terminal: eraseLine left resets wrap"
         var t = GhosttyTestFixture.CreateTerminal(5, 5);
 
         GhosttyTestFixture.Feed(t, "ABCDE");
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "\u001b[1K"); // eraseLine left
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "B");
 
-        Assert.Equal("    B", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("    B", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_LeftWideCharacter()
     {
         // Ghostty: "Terminal: eraseLine left wide character"
@@ -200,14 +200,14 @@ public class GhosttyEraseAndMiscConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;3H"); // setCursorPos(1,3) — on leading cell of 橋
         GhosttyTestFixture.Feed(t, "\u001b[1K");    // eraseLine left
 
-        Assert.Equal("    DE", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("    DE", GhosttyTestFixture.GetLine(t, 0));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // eraseDisplay — basic operations (non-protected)
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_SimpleEraseBelow()
     {
         // Ghostty: "Terminal: eraseDisplay simple erase below"
@@ -217,12 +217,12 @@ public class GhosttyEraseAndMiscConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H"); // setCursorPos(2,2)
         GhosttyTestFixture.Feed(t, "\u001b[J");     // eraseDisplay below
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("D", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("D", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_SimpleEraseAbove()
     {
         // Ghostty: "Terminal: eraseDisplay simple erase above"
@@ -232,12 +232,12 @@ public class GhosttyEraseAndMiscConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H"); // setCursorPos(2,2)
         GhosttyTestFixture.Feed(t, "\u001b[1J");    // eraseDisplay above
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("  F", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("  F", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_BelowSplitMultiCell()
     {
         // Ghostty: "Terminal: eraseDisplay below split multi-cell"
@@ -247,11 +247,11 @@ public class GhosttyEraseAndMiscConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;4H"); // setCursorPos(2,4) — on continuation of 橋
         GhosttyTestFixture.Feed(t, "\u001b[J");     // eraseDisplay below
 
-        Assert.Equal("AB橋C", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("DE", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("AB橋C", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("DE", GhosttyTestFixture.GetLine(t, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_AboveSplitMultiCell()
     {
         // Ghostty: "Terminal: eraseDisplay above split multi-cell"
@@ -261,12 +261,12 @@ public class GhosttyEraseAndMiscConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;3H"); // setCursorPos(2,3) — on leading cell of 橋
         GhosttyTestFixture.Feed(t, "\u001b[1J");    // eraseDisplay above
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("    F", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("GH橋I", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("    F", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("GH橋I", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_ScrollComplete()
     {
         // Ghostty: "Terminal: eraseDisplay scroll complete"
@@ -275,14 +275,14 @@ public class GhosttyEraseAndMiscConformanceTests
         GhosttyTestFixture.Feed(t, "A\r\n");
         GhosttyTestFixture.Feed(t, "\u001b[3J"); // eraseDisplay scroll_complete
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // DECALN
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void Decaln_Basic()
     {
         // Ghostty: "Terminal: DECALN"
@@ -291,13 +291,13 @@ public class GhosttyEraseAndMiscConformanceTests
         GhosttyTestFixture.Feed(t, "A\r\nB");
         GhosttyTestFixture.Feed(t, "\u001b#8"); // DECALN
 
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(0, t.CursorX);
-        Assert.Equal("EE", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("EE", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(0, t.CursorX);
+        Assert.AreEqual("EE", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("EE", GhosttyTestFixture.GetLine(t, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void Decaln_ResetMargins()
     {
         // Ghostty: "Terminal: decaln reset margins"
@@ -309,16 +309,16 @@ public class GhosttyEraseAndMiscConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b#8");       // DECALN — resets margins
         GhosttyTestFixture.Feed(t, "\u001b[T");       // scrollDown(1) — should scroll entire screen now
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("EEE", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("EEE", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("EEE", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("EEE", GhosttyTestFixture.GetLine(t, 2));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // saveCursor / restoreCursor
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void SaveCursor_Position()
     {
         // Ghostty: "Terminal: saveCursor position"
@@ -329,26 +329,26 @@ public class GhosttyEraseAndMiscConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H"); // home
         GhosttyTestFixture.Feed(t, "\u001b8");      // restoreCursor
 
-        Assert.Equal(4, t.CursorX); // col 5, 0-based = 4
-        Assert.Equal(2, t.CursorY); // row 3, 0-based = 2
+        Assert.AreEqual(4, t.CursorX); // col 5, 0-based = 4
+        Assert.AreEqual(2, t.CursorY); // row 3, 0-based = 2
     }
 
-    [Fact]
+    [TestMethod]
     public void SaveCursor_PendingWrapState()
     {
         // Ghostty: "Terminal: saveCursor pending wrap state"
         var t = GhosttyTestFixture.CreateTerminal(5, 5);
 
         GhosttyTestFixture.Feed(t, "ABCDE");
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "\u001b7");      // saveCursor
         GhosttyTestFixture.Feed(t, "\u001b[1;1H"); // home
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "\u001b8");      // restoreCursor
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
     }
 
-    [Fact]
+    [TestMethod]
     public void SaveCursor_OriginMode()
     {
         // Ghostty: "Terminal: saveCursor origin mode"
@@ -360,15 +360,15 @@ public class GhosttyEraseAndMiscConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H"); // position in origin mode
         GhosttyTestFixture.Feed(t, "\u001b7");      // saveCursor
 
-        Assert.Equal(0, t.CursorX);
-        Assert.Equal(2, t.CursorY); // Origin mode maps row 1 to actual row 3 (0-based: 2)
+        Assert.AreEqual(0, t.CursorX);
+        Assert.AreEqual(2, t.CursorY); // Origin mode maps row 1 to actual row 3 (0-based: 2)
     }
 
     // ═══════════════════════════════════════════════════════════════
     // Horizontal tabs
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void TabClear_Single()
     {
         // Ghostty: "Terminal: tabClear single"
@@ -379,10 +379,10 @@ public class GhosttyEraseAndMiscConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H"); // Home
         GhosttyTestFixture.Feed(t, "\t");  // Tab should now skip 8 and go to 16
 
-        Assert.Equal(16, t.CursorX);
+        Assert.AreEqual(16, t.CursorX);
     }
 
-    [Fact]
+    [TestMethod]
     public void TabClear_All()
     {
         // Ghostty: "Terminal: tabClear all"
@@ -392,6 +392,6 @@ public class GhosttyEraseAndMiscConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H"); // Home
         GhosttyTestFixture.Feed(t, "\t");          // Tab with no stops goes to last col
 
-        Assert.Equal(29, t.CursorX); // Last column (0-based)
+        Assert.AreEqual(29, t.CursorX); // Last column (0-based)
     }
 }

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyEraseConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyEraseConformanceTests.cs
@@ -6,7 +6,8 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// Conformance tests for eraseDisplay (ED) and eraseLine (EL) operations,
 /// translated from Ghostty's Terminal.zig.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyEraseConformanceTests
 {
     private static Hex1bTerminal CreateTerminal(int cols = 5, int rows = 5)
@@ -18,19 +19,19 @@ public class GhosttyEraseConformanceTests
         for (int i = 0; i < expectedLines.Length; i++)
         {
             var actualLine = GhosttyTestFixture.GetLine(terminal, i);
-            Assert.Equal(expectedLines[i], actualLine);
+            Assert.AreEqual(expectedLines[i], actualLine);
         }
         for (int i = expectedLines.Length; i < terminal.Height; i++)
         {
             var line = GhosttyTestFixture.GetLine(terminal, i);
-            Assert.Equal("", line);
+            Assert.AreEqual("", line);
         }
     }
 
     // ── EraseDisplay (ED) ────────────────────────────────────────────────
 
     // Ghostty: test "eraseDisplay: simple erase below"
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_EraseBelow_ErasesFromCursorDown()
     {
         using var terminal = CreateTerminal();
@@ -44,7 +45,7 @@ public class GhosttyEraseConformanceTests
     }
 
     // Ghostty: test "eraseDisplay: simple erase above"
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_EraseAbove_ErasesFromCursorUp()
     {
         using var terminal = CreateTerminal();
@@ -58,7 +59,7 @@ public class GhosttyEraseConformanceTests
     }
 
     // Ghostty: test "eraseDisplay: erase complete"
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_EraseComplete_ClearsAllContent()
     {
         using var terminal = CreateTerminal();
@@ -71,15 +72,15 @@ public class GhosttyEraseConformanceTests
         // All lines should be empty
         for (int i = 0; i < terminal.Height; i++)
         {
-            Assert.Equal("", GhosttyTestFixture.GetLine(terminal, i));
+            Assert.AreEqual("", GhosttyTestFixture.GetLine(terminal, i));
         }
         // Cursor should NOT move
-        Assert.Equal(1, terminal.CursorX);
-        Assert.Equal(1, terminal.CursorY);
+        Assert.AreEqual(1, terminal.CursorX);
+        Assert.AreEqual(1, terminal.CursorY);
     }
 
     // Ghostty: test "eraseDisplay: erase below preserves cursor"
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_EraseBelow_PreservesCursorPosition()
     {
         using var terminal = CreateTerminal();
@@ -89,15 +90,15 @@ public class GhosttyEraseConformanceTests
         // ED 0
         GhosttyTestFixture.Feed(terminal, "\u001b[J");
 
-        Assert.Equal(2, terminal.CursorX);
-        Assert.Equal(1, terminal.CursorY);
+        Assert.AreEqual(2, terminal.CursorX);
+        Assert.AreEqual(1, terminal.CursorY);
         AssertPlainText(terminal, "ABC\nDE");
     }
 
     // ── EraseLine (EL) ──────────────────────────────────────────────────
 
     // Ghostty: test "eraseLine: simple erase right"
-    [Fact]
+    [TestMethod]
     public void EraseLine_EraseRight_ErasesFromCursorToEnd()
     {
         using var terminal = CreateTerminal();
@@ -111,7 +112,7 @@ public class GhosttyEraseConformanceTests
     }
 
     // Ghostty: test "eraseLine: erase right preserves cursor"
-    [Fact]
+    [TestMethod]
     public void EraseLine_EraseRight_PreservesCursorPosition()
     {
         using var terminal = CreateTerminal();
@@ -121,12 +122,12 @@ public class GhosttyEraseConformanceTests
         // EL 0
         GhosttyTestFixture.Feed(terminal, "\u001b[K");
 
-        Assert.Equal(2, terminal.CursorX);
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(2, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
     }
 
     // Ghostty: test "eraseLine: simple erase left"
-    [Fact]
+    [TestMethod]
     public void EraseLine_EraseLeft_ErasesFromCursorToStart()
     {
         using var terminal = CreateTerminal();
@@ -140,7 +141,7 @@ public class GhosttyEraseConformanceTests
     }
 
     // Ghostty: test "eraseLine: erase complete"
-    [Fact]
+    [TestMethod]
     public void EraseLine_EraseComplete_ClearsEntireLine()
     {
         using var terminal = CreateTerminal();
@@ -151,13 +152,13 @@ public class GhosttyEraseConformanceTests
         GhosttyTestFixture.Feed(terminal, "\u001b[2K");
 
         AssertPlainText(terminal, "");
-        Assert.Equal(2, terminal.CursorX);
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(2, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
     }
 
     // Ghostty: test "eraseLine: erase right preserves background SGR"
     // BUG: Hex1b's EL doesn't apply current background SGR to erased cells
-    [Fact]
+    [TestMethod]
     public void EraseLine_EraseRight_PreservesBackgroundSgr()
     {
         using var terminal = CreateTerminal(10, 10);
@@ -169,17 +170,17 @@ public class GhosttyEraseConformanceTests
         GhosttyTestFixture.Feed(terminal, "\u001b[K");
 
         // Cols 0-1 survive ("AB"), cols 2+ erased with red background
-        Assert.Equal("AB", GhosttyTestFixture.GetLine(terminal, 0));
+        Assert.AreEqual("AB", GhosttyTestFixture.GetLine(terminal, 0));
 
         // Erased cell (0,2) should have red background
         var cell = GhosttyTestFixture.GetCell(terminal, 0, 2);
-        Assert.NotNull(cell.Background);
-        Assert.Equal(Hex1bColor.FromRgb(255, 0, 0), cell.Background);
+        Assert.IsNotNull(cell.Background);
+        Assert.AreEqual(Hex1bColor.FromRgb(255, 0, 0), cell.Background);
     }
 
     // Ghostty: test "eraseLine: erase right with wide character"
     // BUG: When EL starts at a wide char spacer cell, the leading half should also be cleared
-    [Fact]
+    [TestMethod]
     public void EraseLine_EraseRight_WithWideCharacter()
     {
         using var terminal = CreateTerminal();
@@ -194,7 +195,7 @@ public class GhosttyEraseConformanceTests
     }
 
     // Ghostty: test "eraseLine: resets pending wrap"
-    [Fact]
+    [TestMethod]
     public void EraseLine_EraseRight_ResetsPendingWrap()
     {
         using var terminal = CreateTerminal();
@@ -209,7 +210,7 @@ public class GhosttyEraseConformanceTests
     }
 
     // Ghostty: test "eraseLine: resets wrap marker"
-    [Fact]
+    [TestMethod]
     public void EraseLine_EraseRight_ResetsWrapMarker()
     {
         using var terminal = CreateTerminal();
@@ -228,7 +229,7 @@ public class GhosttyEraseConformanceTests
     // ── Edge Cases ──────────────────────────────────────────────────────
 
     // Ghostty: test "eraseDisplay: scrollback (ED 3)"
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_ClearScrollback_NotImplemented()
     {
         using var terminal = CreateTerminal();
@@ -236,7 +237,7 @@ public class GhosttyEraseConformanceTests
     }
 
     // Ghostty: test "eraseLine: erase left with wide character"
-    [Fact]
+    [TestMethod]
     public void EraseLine_EraseLeft_WithWideCharacter()
     {
         using var terminal = CreateTerminal();
@@ -251,7 +252,7 @@ public class GhosttyEraseConformanceTests
     }
 
     // Ghostty: test "eraseDisplay: erase below resets pending wrap"
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_EraseBelow_ResetsPendingWrap()
     {
         using var terminal = CreateTerminal();

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyFitzpatrickConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyFitzpatrickConformanceTests.cs
@@ -14,11 +14,10 @@
 //
 // This matches the behavior of Ghostty, kitty, WezTerm, and other conformant terminals.
 
-using Xunit;
-
 namespace Hex1b.Tests.Conformance.Ghostty;
 
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyFitzpatrickConformanceTests
 {
     // =================================================================
@@ -27,7 +26,7 @@ public class GhosttyFitzpatrickConformanceTests
 
     // Ghostty: "Terminal: Fitzpatrick skin tone next valid base"
     // 👋 (U+1F44B) is Emoji_Modifier_Base — modifier should combine with it.
-    [Fact]
+    [TestMethod]
     public void FitzpatrickSkinTone_ValidBase_CombinesIntoSingleGrapheme()
     {
         var terminal = GhosttyTestFixture.CreateTerminal(80, 80);
@@ -36,17 +35,17 @@ public class GhosttyFitzpatrickConformanceTests
         GhosttyTestFixture.Feed(terminal, "\U0001F44B\U0001F3FF");
         
         // Should combine into one grapheme taking 2 cells
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(2, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(2, terminal.CursorX);
         
         // Cell 0 should contain the waving hand (base emoji)
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.Equal("👋🏿", cell0.Character);
+        Assert.AreEqual("👋🏿", cell0.Character);
     }
 
     // Ghostty: "Terminal: Fitzpatrick skin tone next to non-base"
     // '"' (U+0022) is NOT Emoji_Modifier_Base — modifier must be standalone.
-    [Fact]
+    [TestMethod]
     public void FitzpatrickSkinTone_NonBase_Quote_SplitsIntoSeparateCharacters()
     {
         var terminal = GhosttyTestFixture.CreateTerminal(80, 80);
@@ -55,32 +54,32 @@ public class GhosttyFitzpatrickConformanceTests
         GhosttyTestFixture.Feed(terminal, "\"\U0001F3FF\"");
         
         // " (1 cell) + 🏿 (2 cells) + " (1 cell) = 4 cells
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(4, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(4, terminal.CursorX);
         
         // Cell 0: quote mark
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.Equal("\"", cell0.Character);
+        Assert.AreEqual("\"", cell0.Character);
         
         // Cell 1: dark skin tone (wide)
         var cell1 = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.Equal("\U0001F3FF", cell1.Character);
+        Assert.AreEqual("\U0001F3FF", cell1.Character);
         
         // Cell 3: closing quote (cell 2 is the wide char continuation)
         var cell3 = GhosttyTestFixture.GetCell(terminal, 0, 3);
-        Assert.Equal("\"", cell3.Character);
+        Assert.AreEqual("\"", cell3.Character);
     }
 
     // =================================================================
     // All five Fitzpatrick modifiers with non-base
     // =================================================================
 
-    [Theory]
-    [InlineData(0x1F3FB, "Light")]
-    [InlineData(0x1F3FC, "MediumLight")]
-    [InlineData(0x1F3FD, "Medium")]
-    [InlineData(0x1F3FE, "MediumDark")]
-    [InlineData(0x1F3FF, "Dark")]
+    [TestMethod]
+    [DataRow(0x1F3FB, "Light")]
+    [DataRow(0x1F3FC, "MediumLight")]
+    [DataRow(0x1F3FD, "Medium")]
+    [DataRow(0x1F3FE, "MediumDark")]
+    [DataRow(0x1F3FF, "Dark")]
     public void FitzpatrickSkinTone_AllModifiers_NonBase_SplitCorrectly(int modifierCodepoint, string _)
     {
         var terminal = GhosttyTestFixture.CreateTerminal(80, 80);
@@ -90,25 +89,25 @@ public class GhosttyFitzpatrickConformanceTests
         GhosttyTestFixture.Feed(terminal, "A" + modifier);
         
         // A (1 cell) + modifier (2 cells) = 3 cells
-        Assert.Equal(3, terminal.CursorX);
+        Assert.AreEqual(3, terminal.CursorX);
         
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.Equal("A", cell0.Character);
+        Assert.AreEqual("A", cell0.Character);
         
         var cell1 = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.Equal(modifier, cell1.Character);
+        Assert.AreEqual(modifier, cell1.Character);
     }
 
     // =================================================================
     // All five Fitzpatrick modifiers with valid base
     // =================================================================
 
-    [Theory]
-    [InlineData(0x1F3FB)]
-    [InlineData(0x1F3FC)]
-    [InlineData(0x1F3FD)]
-    [InlineData(0x1F3FE)]
-    [InlineData(0x1F3FF)]
+    [TestMethod]
+    [DataRow(0x1F3FB)]
+    [DataRow(0x1F3FC)]
+    [DataRow(0x1F3FD)]
+    [DataRow(0x1F3FE)]
+    [DataRow(0x1F3FF)]
     public void FitzpatrickSkinTone_AllModifiers_ValidBase_CombineCorrectly(int modifierCodepoint)
     {
         var terminal = GhosttyTestFixture.CreateTerminal(80, 80);
@@ -118,17 +117,17 @@ public class GhosttyFitzpatrickConformanceTests
         GhosttyTestFixture.Feed(terminal, "\U0001F44D" + modifier);
         
         // Combined grapheme takes 2 cells
-        Assert.Equal(2, terminal.CursorX);
+        Assert.AreEqual(2, terminal.CursorX);
         
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.Equal("\U0001F44D" + modifier, cell0.Character);
+        Assert.AreEqual("\U0001F44D" + modifier, cell0.Character);
     }
 
     // =================================================================
     // Various non-base character types
     // =================================================================
 
-    [Fact]
+    [TestMethod]
     public void FitzpatrickSkinTone_NonBase_AsciiLetter()
     {
         var terminal = GhosttyTestFixture.CreateTerminal(80, 80);
@@ -136,12 +135,12 @@ public class GhosttyFitzpatrickConformanceTests
         // 'n' + skin tone — must not combine
         GhosttyTestFixture.Feed(terminal, "n\U0001F3FF");
         
-        Assert.Equal(3, terminal.CursorX); // n(1) + 🏿(2)
-        Assert.Equal("n", GhosttyTestFixture.GetCell(terminal, 0, 0).Character);
-        Assert.Equal("\U0001F3FF", GhosttyTestFixture.GetCell(terminal, 0, 1).Character);
+        Assert.AreEqual(3, terminal.CursorX); // n(1) + 🏿(2)
+        Assert.AreEqual("n", GhosttyTestFixture.GetCell(terminal, 0, 0).Character);
+        Assert.AreEqual("\U0001F3FF", GhosttyTestFixture.GetCell(terminal, 0, 1).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void FitzpatrickSkinTone_NonBase_Space()
     {
         var terminal = GhosttyTestFixture.CreateTerminal(80, 80);
@@ -149,12 +148,12 @@ public class GhosttyFitzpatrickConformanceTests
         // space + skin tone — must not combine
         GhosttyTestFixture.Feed(terminal, " \U0001F3FF");
         
-        Assert.Equal(3, terminal.CursorX); // space(1) + 🏿(2)
-        Assert.Equal(" ", GhosttyTestFixture.GetCell(terminal, 0, 0).Character);
-        Assert.Equal("\U0001F3FF", GhosttyTestFixture.GetCell(terminal, 0, 1).Character);
+        Assert.AreEqual(3, terminal.CursorX); // space(1) + 🏿(2)
+        Assert.AreEqual(" ", GhosttyTestFixture.GetCell(terminal, 0, 0).Character);
+        Assert.AreEqual("\U0001F3FF", GhosttyTestFixture.GetCell(terminal, 0, 1).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void FitzpatrickSkinTone_NonBase_Digit()
     {
         var terminal = GhosttyTestFixture.CreateTerminal(80, 80);
@@ -162,12 +161,12 @@ public class GhosttyFitzpatrickConformanceTests
         // '5' + skin tone — must not combine
         GhosttyTestFixture.Feed(terminal, "5\U0001F3FF");
         
-        Assert.Equal(3, terminal.CursorX);
-        Assert.Equal("5", GhosttyTestFixture.GetCell(terminal, 0, 0).Character);
-        Assert.Equal("\U0001F3FF", GhosttyTestFixture.GetCell(terminal, 0, 1).Character);
+        Assert.AreEqual(3, terminal.CursorX);
+        Assert.AreEqual("5", GhosttyTestFixture.GetCell(terminal, 0, 0).Character);
+        Assert.AreEqual("\U0001F3FF", GhosttyTestFixture.GetCell(terminal, 0, 1).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void FitzpatrickSkinTone_NonBase_NonPersonEmoji()
     {
         var terminal = GhosttyTestFixture.CreateTerminal(80, 80);
@@ -175,12 +174,12 @@ public class GhosttyFitzpatrickConformanceTests
         // 🌍 (U+1F30D, Earth globe) is NOT Emoji_Modifier_Base — must not combine
         GhosttyTestFixture.Feed(terminal, "\U0001F30D\U0001F3FF");
         
-        Assert.Equal(4, terminal.CursorX); // 🌍(2) + 🏿(2)
-        Assert.Equal("\U0001F30D", GhosttyTestFixture.GetCell(terminal, 0, 0).Character);
-        Assert.Equal("\U0001F3FF", GhosttyTestFixture.GetCell(terminal, 0, 2).Character);
+        Assert.AreEqual(4, terminal.CursorX); // 🌍(2) + 🏿(2)
+        Assert.AreEqual("\U0001F30D", GhosttyTestFixture.GetCell(terminal, 0, 0).Character);
+        Assert.AreEqual("\U0001F3FF", GhosttyTestFixture.GetCell(terminal, 0, 2).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void FitzpatrickSkinTone_NonBase_Heart()
     {
         var terminal = GhosttyTestFixture.CreateTerminal(80, 80);
@@ -189,16 +188,16 @@ public class GhosttyFitzpatrickConformanceTests
         // Note: ❤ is text-presentation by default, so width 1 without VS16
         GhosttyTestFixture.Feed(terminal, "\u2764\U0001F3FF");
         
-        Assert.Equal(3, terminal.CursorX); // ❤(1) + 🏿(2)
-        Assert.Equal("\u2764", GhosttyTestFixture.GetCell(terminal, 0, 0).Character);
-        Assert.Equal("\U0001F3FF", GhosttyTestFixture.GetCell(terminal, 0, 1).Character);
+        Assert.AreEqual(3, terminal.CursorX); // ❤(1) + 🏿(2)
+        Assert.AreEqual("\u2764", GhosttyTestFixture.GetCell(terminal, 0, 0).Character);
+        Assert.AreEqual("\U0001F3FF", GhosttyTestFixture.GetCell(terminal, 0, 1).Character);
     }
 
     // =================================================================
     // Emoji_Modifier_Base characters (valid combinations)
     // =================================================================
 
-    [Fact]
+    [TestMethod]
     public void FitzpatrickSkinTone_ValidBase_IndexFinger()
     {
         var terminal = GhosttyTestFixture.CreateTerminal(80, 80);
@@ -208,12 +207,12 @@ public class GhosttyFitzpatrickConformanceTests
         
         // Should combine — ☝ is text-presentation by default (1 cell) but with
         // skin tone modifier it forms a combined emoji grapheme
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorY);
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.Equal("\u261D\U0001F3FD", cell0.Character);
+        Assert.AreEqual("\u261D\U0001F3FD", cell0.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void FitzpatrickSkinTone_ValidBase_RaisedFist()
     {
         var terminal = GhosttyTestFixture.CreateTerminal(80, 80);
@@ -221,12 +220,12 @@ public class GhosttyFitzpatrickConformanceTests
         // ✊ (U+270A) is Emoji_Modifier_Base
         GhosttyTestFixture.Feed(terminal, "\u270A\U0001F3FB");
         
-        Assert.Equal(2, terminal.CursorX);
+        Assert.AreEqual(2, terminal.CursorX);
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.Equal("\u270A\U0001F3FB", cell0.Character);
+        Assert.AreEqual("\u270A\U0001F3FB", cell0.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void FitzpatrickSkinTone_ValidBase_FlexedBiceps()
     {
         var terminal = GhosttyTestFixture.CreateTerminal(80, 80);
@@ -234,12 +233,12 @@ public class GhosttyFitzpatrickConformanceTests
         // 💪 (U+1F4AA) is Emoji_Modifier_Base
         GhosttyTestFixture.Feed(terminal, "\U0001F4AA\U0001F3FE");
         
-        Assert.Equal(2, terminal.CursorX);
+        Assert.AreEqual(2, terminal.CursorX);
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.Equal("\U0001F4AA\U0001F3FE", cell0.Character);
+        Assert.AreEqual("\U0001F4AA\U0001F3FE", cell0.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void FitzpatrickSkinTone_ValidBase_PersonBowingDeeply()
     {
         var terminal = GhosttyTestFixture.CreateTerminal(80, 80);
@@ -247,16 +246,16 @@ public class GhosttyFitzpatrickConformanceTests
         // 🙇 (U+1F647) is Emoji_Modifier_Base
         GhosttyTestFixture.Feed(terminal, "\U0001F647\U0001F3FC");
         
-        Assert.Equal(2, terminal.CursorX);
+        Assert.AreEqual(2, terminal.CursorX);
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.Equal("\U0001F647\U0001F3FC", cell0.Character);
+        Assert.AreEqual("\U0001F647\U0001F3FC", cell0.Character);
     }
 
     // =================================================================
     // Edge cases
     // =================================================================
 
-    [Fact]
+    [TestMethod]
     public void FitzpatrickSkinTone_AtStartOfLine()
     {
         var terminal = GhosttyTestFixture.CreateTerminal(80, 80);
@@ -264,12 +263,12 @@ public class GhosttyFitzpatrickConformanceTests
         // Skin tone modifier alone at start of line — should be standalone wide char
         GhosttyTestFixture.Feed(terminal, "\U0001F3FF");
         
-        Assert.Equal(2, terminal.CursorX);
+        Assert.AreEqual(2, terminal.CursorX);
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.Equal("\U0001F3FF", cell0.Character);
+        Assert.AreEqual("\U0001F3FF", cell0.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void FitzpatrickSkinTone_MultipleInSequence_NonBase()
     {
         var terminal = GhosttyTestFixture.CreateTerminal(80, 80);
@@ -278,13 +277,13 @@ public class GhosttyFitzpatrickConformanceTests
         GhosttyTestFixture.Feed(terminal, "x\U0001F3FB\U0001F3FF");
         
         // x(1) + 🏻(2) + 🏿(2) = 5 cells
-        Assert.Equal(5, terminal.CursorX);
-        Assert.Equal("x", GhosttyTestFixture.GetCell(terminal, 0, 0).Character);
-        Assert.Equal("\U0001F3FB", GhosttyTestFixture.GetCell(terminal, 0, 1).Character);
-        Assert.Equal("\U0001F3FF", GhosttyTestFixture.GetCell(terminal, 0, 3).Character);
+        Assert.AreEqual(5, terminal.CursorX);
+        Assert.AreEqual("x", GhosttyTestFixture.GetCell(terminal, 0, 0).Character);
+        Assert.AreEqual("\U0001F3FB", GhosttyTestFixture.GetCell(terminal, 0, 1).Character);
+        Assert.AreEqual("\U0001F3FF", GhosttyTestFixture.GetCell(terminal, 0, 3).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void FitzpatrickSkinTone_ValidBase_ThenNonBase_InSequence()
     {
         var terminal = GhosttyTestFixture.CreateTerminal(80, 80);
@@ -293,13 +292,13 @@ public class GhosttyFitzpatrickConformanceTests
         GhosttyTestFixture.Feed(terminal, "\U0001F44B\U0001F3FF" + "x\U0001F3FB");
         
         // 👋🏿(2) + x(1) + 🏻(2) = 5 cells
-        Assert.Equal(5, terminal.CursorX);
-        Assert.Equal("\U0001F44B\U0001F3FF", GhosttyTestFixture.GetCell(terminal, 0, 0).Character);
-        Assert.Equal("x", GhosttyTestFixture.GetCell(terminal, 0, 2).Character);
-        Assert.Equal("\U0001F3FB", GhosttyTestFixture.GetCell(terminal, 0, 3).Character);
+        Assert.AreEqual(5, terminal.CursorX);
+        Assert.AreEqual("\U0001F44B\U0001F3FF", GhosttyTestFixture.GetCell(terminal, 0, 0).Character);
+        Assert.AreEqual("x", GhosttyTestFixture.GetCell(terminal, 0, 2).Character);
+        Assert.AreEqual("\U0001F3FB", GhosttyTestFixture.GetCell(terminal, 0, 3).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void FitzpatrickSkinTone_NonBase_CJK()
     {
         var terminal = GhosttyTestFixture.CreateTerminal(80, 80);
@@ -307,12 +306,12 @@ public class GhosttyFitzpatrickConformanceTests
         // CJK character (漢) is NOT Emoji_Modifier_Base — must split
         GhosttyTestFixture.Feed(terminal, "\u6F22\U0001F3FF");
         
-        Assert.Equal(4, terminal.CursorX); // 漢(2) + 🏿(2)
-        Assert.Equal("\u6F22", GhosttyTestFixture.GetCell(terminal, 0, 0).Character);
-        Assert.Equal("\U0001F3FF", GhosttyTestFixture.GetCell(terminal, 0, 2).Character);
+        Assert.AreEqual(4, terminal.CursorX); // 漢(2) + 🏿(2)
+        Assert.AreEqual("\u6F22", GhosttyTestFixture.GetCell(terminal, 0, 0).Character);
+        Assert.AreEqual("\U0001F3FF", GhosttyTestFixture.GetCell(terminal, 0, 2).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void FitzpatrickSkinTone_NonBase_Punctuation()
     {
         var terminal = GhosttyTestFixture.CreateTerminal(80, 80);
@@ -320,60 +319,60 @@ public class GhosttyFitzpatrickConformanceTests
         // Various punctuation — none are Emoji_Modifier_Base
         GhosttyTestFixture.Feed(terminal, "!\U0001F3FF");
         
-        Assert.Equal(3, terminal.CursorX); // !(1) + 🏿(2)
-        Assert.Equal("!", GhosttyTestFixture.GetCell(terminal, 0, 0).Character);
-        Assert.Equal("\U0001F3FF", GhosttyTestFixture.GetCell(terminal, 0, 1).Character);
+        Assert.AreEqual(3, terminal.CursorX); // !(1) + 🏿(2)
+        Assert.AreEqual("!", GhosttyTestFixture.GetCell(terminal, 0, 0).Character);
+        Assert.AreEqual("\U0001F3FF", GhosttyTestFixture.GetCell(terminal, 0, 1).Character);
     }
 
     // =================================================================
     // DisplayWidth.IsEmojiModifierBase unit tests
     // =================================================================
 
-    [Theory]
+    [TestMethod]
     // BMP Emoji_Modifier_Base
-    [InlineData(0x261D, true)]   // ☝ Index pointing up
-    [InlineData(0x26F9, true)]   // ⛹ Person bouncing ball
-    [InlineData(0x270A, true)]   // ✊ Raised fist
-    [InlineData(0x270B, true)]   // ✋ Raised hand
-    [InlineData(0x270C, true)]   // ✌ Victory hand
-    [InlineData(0x270D, true)]   // ✍ Writing hand
+    [DataRow(0x261D, true)]   // ☝ Index pointing up
+    [DataRow(0x26F9, true)]   // ⛹ Person bouncing ball
+    [DataRow(0x270A, true)]   // ✊ Raised fist
+    [DataRow(0x270B, true)]   // ✋ Raised hand
+    [DataRow(0x270C, true)]   // ✌ Victory hand
+    [DataRow(0x270D, true)]   // ✍ Writing hand
     // SMP Emoji_Modifier_Base  
-    [InlineData(0x1F385, true)]  // 🎅 Santa Claus
-    [InlineData(0x1F3C2, true)]  // 🏂 Snowboarder
-    [InlineData(0x1F44B, true)]  // 👋 Waving hand
-    [InlineData(0x1F44D, true)]  // 👍 Thumbs up
-    [InlineData(0x1F4AA, true)]  // 💪 Flexed biceps
-    [InlineData(0x1F590, true)]  // 🖐 Raised hand with fingers splayed
-    [InlineData(0x1F64F, true)]  // 🙏 Folded hands
-    [InlineData(0x1F926, true)]  // 🤦 Facepalm
-    [InlineData(0x1F9D1, true)]  // 🧑 Person
-    [InlineData(0x1FAF0, true)]  // 🫰 Hand with index finger and thumb crossed
-    [InlineData(0x1FAF8, true)]  // 🫸 Rightwards pushing hand
+    [DataRow(0x1F385, true)]  // 🎅 Santa Claus
+    [DataRow(0x1F3C2, true)]  // 🏂 Snowboarder
+    [DataRow(0x1F44B, true)]  // 👋 Waving hand
+    [DataRow(0x1F44D, true)]  // 👍 Thumbs up
+    [DataRow(0x1F4AA, true)]  // 💪 Flexed biceps
+    [DataRow(0x1F590, true)]  // 🖐 Raised hand with fingers splayed
+    [DataRow(0x1F64F, true)]  // 🙏 Folded hands
+    [DataRow(0x1F926, true)]  // 🤦 Facepalm
+    [DataRow(0x1F9D1, true)]  // 🧑 Person
+    [DataRow(0x1FAF0, true)]  // 🫰 Hand with index finger and thumb crossed
+    [DataRow(0x1FAF8, true)]  // 🫸 Rightwards pushing hand
     // NOT Emoji_Modifier_Base
-    [InlineData(0x0022, false)]  // " Quote
-    [InlineData(0x0041, false)]  // A
-    [InlineData(0x0020, false)]  // Space
-    [InlineData(0x2764, false)]  // ❤ Heart (not modifier base)
-    [InlineData(0x1F30D, false)] // 🌍 Earth globe
-    [InlineData(0x1F600, false)] // 😀 Grinning face
-    [InlineData(0x1F4A9, false)] // 💩 Pile of poo
-    [InlineData(0x1F3FB, false)] // Fitzpatrick modifier itself is not a base
+    [DataRow(0x0022, false)]  // " Quote
+    [DataRow(0x0041, false)]  // A
+    [DataRow(0x0020, false)]  // Space
+    [DataRow(0x2764, false)]  // ❤ Heart (not modifier base)
+    [DataRow(0x1F30D, false)] // 🌍 Earth globe
+    [DataRow(0x1F600, false)] // 😀 Grinning face
+    [DataRow(0x1F4A9, false)] // 💩 Pile of poo
+    [DataRow(0x1F3FB, false)] // Fitzpatrick modifier itself is not a base
     public void IsEmojiModifierBase_ReturnsCorrectResult(int codePoint, bool expected)
     {
-        Assert.Equal(expected, DisplayWidth.IsEmojiModifierBase(codePoint));
+        Assert.AreEqual(expected, DisplayWidth.IsEmojiModifierBase(codePoint));
     }
 
-    [Theory]
-    [InlineData(0x1F3FB, true)]  // Light skin tone
-    [InlineData(0x1F3FC, true)]  // Medium-light skin tone
-    [InlineData(0x1F3FD, true)]  // Medium skin tone
-    [InlineData(0x1F3FE, true)]  // Medium-dark skin tone
-    [InlineData(0x1F3FF, true)]  // Dark skin tone
-    [InlineData(0x1F3FA, false)] // Before range (Amphora 🏺)
-    [InlineData(0x1F400, false)] // After range (Rat 🐀)
-    [InlineData(0x0041, false)]  // ASCII A
+    [TestMethod]
+    [DataRow(0x1F3FB, true)]  // Light skin tone
+    [DataRow(0x1F3FC, true)]  // Medium-light skin tone
+    [DataRow(0x1F3FD, true)]  // Medium skin tone
+    [DataRow(0x1F3FE, true)]  // Medium-dark skin tone
+    [DataRow(0x1F3FF, true)]  // Dark skin tone
+    [DataRow(0x1F3FA, false)] // Before range (Amphora 🏺)
+    [DataRow(0x1F400, false)] // After range (Rat 🐀)
+    [DataRow(0x0041, false)]  // ASCII A
     public void IsFitzpatrickModifier_ReturnsCorrectResult(int codePoint, bool expected)
     {
-        Assert.Equal(expected, DisplayWidth.IsFitzpatrickModifier(codePoint));
+        Assert.AreEqual(expected, DisplayWidth.IsFitzpatrickModifier(codePoint));
     }
 }

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyHyperlinkConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyHyperlinkConformanceTests.cs
@@ -1,6 +1,5 @@
 using System;
 using Hex1b;
-using Xunit;
 
 namespace Hex1b.Tests.Conformance.Ghostty;
 
@@ -9,7 +8,8 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// Tests hyperlink attachment to cells, preservation through scrolling,
 /// clearing on overwrite, and interaction with insert/delete operations.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyHyperlinkConformanceTests
 {
     private static Hex1bTerminal CreateTerminal(int cols, int rows) => GhosttyTestFixture.CreateTerminal(cols, rows);
@@ -32,7 +32,7 @@ public class GhosttyHyperlinkConformanceTests
     #region Basic Hyperlink Printing
 
     // Ghostty: "Terminal: print with hyperlink"
-    [Fact]
+    [TestMethod]
     public void PrintWithHyperlink()
     {
         using var t = CreateTerminal(cols: 80, rows: 80);
@@ -44,13 +44,13 @@ public class GhosttyHyperlinkConformanceTests
         for (int x = 0; x < 6; x++)
         {
             var cell = GetCell(t, 0, x);
-            Assert.True(cell.HasHyperlinkData, $"Cell at col {x} should have hyperlink");
-            Assert.Equal("http://example.com", cell.HyperlinkData!.Uri);
+            Assert.IsTrue(cell.HasHyperlinkData, $"Cell at col {x} should have hyperlink");
+            Assert.AreEqual("http://example.com", cell.HyperlinkData!.Uri);
         }
     }
 
     // Ghostty: "Terminal: print over cell with same hyperlink"
-    [Fact]
+    [TestMethod]
     public void PrintOverCellWithSameHyperlink()
     {
         using var t = CreateTerminal(cols: 80, rows: 80);
@@ -63,13 +63,13 @@ public class GhosttyHyperlinkConformanceTests
         for (int x = 0; x < 6; x++)
         {
             var cell = GetCell(t, 0, x);
-            Assert.True(cell.HasHyperlinkData, $"Cell at col {x} should have hyperlink");
-            Assert.Equal("http://example.com", cell.HyperlinkData!.Uri);
+            Assert.IsTrue(cell.HasHyperlinkData, $"Cell at col {x} should have hyperlink");
+            Assert.AreEqual("http://example.com", cell.HyperlinkData!.Uri);
         }
     }
 
     // Ghostty: "Terminal: print and end hyperlink"
-    [Fact]
+    [TestMethod]
     public void PrintAndEndHyperlink()
     {
         using var t = CreateTerminal(cols: 80, rows: 80);
@@ -83,20 +83,20 @@ public class GhosttyHyperlinkConformanceTests
         for (int x = 0; x < 3; x++)
         {
             var cell = GetCell(t, 0, x);
-            Assert.True(cell.HasHyperlinkData, $"Cell at col {x} should have hyperlink");
-            Assert.Equal("http://example.com", cell.HyperlinkData!.Uri);
+            Assert.IsTrue(cell.HasHyperlinkData, $"Cell at col {x} should have hyperlink");
+            Assert.AreEqual("http://example.com", cell.HyperlinkData!.Uri);
         }
 
         // Next 3 cells do NOT have hyperlink
         for (int x = 3; x < 6; x++)
         {
             var cell = GetCell(t, 0, x);
-            Assert.False(cell.HasHyperlinkData, $"Cell at col {x} should NOT have hyperlink");
+            Assert.IsFalse(cell.HasHyperlinkData, $"Cell at col {x} should NOT have hyperlink");
         }
     }
 
     // Ghostty: "Terminal: print and change hyperlink"
-    [Fact]
+    [TestMethod]
     public void PrintAndChangeHyperlink()
     {
         using var t = CreateTerminal(cols: 80, rows: 80);
@@ -110,22 +110,22 @@ public class GhosttyHyperlinkConformanceTests
         for (int x = 0; x < 3; x++)
         {
             var cell = GetCell(t, 0, x);
-            Assert.True(cell.HasHyperlinkData, $"Cell at col {x} should have hyperlink");
-            Assert.Equal("http://one.example.com", cell.HyperlinkData!.Uri);
+            Assert.IsTrue(cell.HasHyperlinkData, $"Cell at col {x} should have hyperlink");
+            Assert.AreEqual("http://one.example.com", cell.HyperlinkData!.Uri);
         }
 
         // Next 3 cells have second hyperlink
         for (int x = 3; x < 6; x++)
         {
             var cell = GetCell(t, 0, x);
-            Assert.True(cell.HasHyperlinkData, $"Cell at col {x} should have hyperlink");
-            Assert.Equal("http://two.example.com", cell.HyperlinkData!.Uri);
+            Assert.IsTrue(cell.HasHyperlinkData, $"Cell at col {x} should have hyperlink");
+            Assert.AreEqual("http://two.example.com", cell.HyperlinkData!.Uri);
         }
     }
 
     // Ghostty: "Terminal: overwrite hyperlink"
     // Writing non-hyperlinked text over hyperlinked cells clears the hyperlink.
-    [Fact]
+    [TestMethod]
     public void OverwriteHyperlink()
     {
         using var t = CreateTerminal(cols: 80, rows: 80);
@@ -140,12 +140,12 @@ public class GhosttyHyperlinkConformanceTests
         for (int x = 0; x < 3; x++)
         {
             var cell = GetCell(t, 0, x);
-            Assert.False(cell.HasHyperlinkData, $"Cell at col {x} should NOT have hyperlink after overwrite");
+            Assert.IsFalse(cell.HasHyperlinkData, $"Cell at col {x} should NOT have hyperlink after overwrite");
         }
     }
 
     // Ghostty: "Terminal: print wide char at right edge with hyperlink"
-    [Fact]
+    [TestMethod]
     public void PrintWideCharAtRightEdgeWithHyperlink()
     {
         using var t = CreateTerminal(cols: 10, rows: 5);
@@ -157,24 +157,21 @@ public class GhosttyHyperlinkConformanceTests
         Feed(t, "\u4E2D");
 
         // Cursor should be on row 1 after the wide char
-        Assert.Equal(1, t.CursorY);
-        Assert.Equal(2, t.CursorX);
+        Assert.AreEqual(1, t.CursorY);
+        Assert.AreEqual(2, t.CursorX);
 
         // Row 0, col 9: spacer head should have hyperlink
         var spacerHead = GetCell(t, 0, 9);
-        Assert.True(spacerHead.HasHyperlinkData,
-            "Spacer head at right edge should have hyperlink");
+        Assert.IsTrue(spacerHead.HasHyperlinkData, "Spacer head at right edge should have hyperlink");
 
         // Row 1, col 0: the wide char should have hyperlink
         var wideCell = GetCell(t, 1, 0);
-        Assert.True(wideCell.HasHyperlinkData,
-            "Wide char should have hyperlink");
-        Assert.Equal("http://example.com", wideCell.HyperlinkData!.Uri);
+        Assert.IsTrue(wideCell.HasHyperlinkData, "Wide char should have hyperlink");
+        Assert.AreEqual("http://example.com", wideCell.HyperlinkData!.Uri);
 
         // Row 1, col 1: spacer tail should have hyperlink
         var spacerTail = GetCell(t, 1, 1);
-        Assert.True(spacerTail.HasHyperlinkData,
-            "Spacer tail should have hyperlink");
+        Assert.IsTrue(spacerTail.HasHyperlinkData, "Spacer tail should have hyperlink");
     }
 
     #endregion
@@ -182,7 +179,7 @@ public class GhosttyHyperlinkConformanceTests
     #region Scrolling with Hyperlinks
 
     // Ghostty: "Terminal: scrollUp moves hyperlink"
-    [Fact]
+    [TestMethod]
     public void ScrollUp_MovesHyperlink()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -197,30 +194,28 @@ public class GhosttyHyperlinkConformanceTests
         Feed(t, "\u001b[2;2H"); // CUP(2,2)
         Feed(t, "\u001b[S");     // SU 1 (scroll up)
 
-        Assert.Equal("DEF", GetLine(t, 0).TrimEnd());
-        Assert.Equal("GHI", GetLine(t, 1).TrimEnd());
+        Assert.AreEqual("DEF", GetLine(t, 0).TrimEnd());
+        Assert.AreEqual("GHI", GetLine(t, 1).TrimEnd());
 
         // Row 0 should have hyperlinks (the DEF row moved up)
         for (int x = 0; x < 3; x++)
         {
             var cell = GetCell(t, 0, x);
-            Assert.True(cell.HasHyperlinkData,
-                $"Cell at (0,{x}) should have hyperlink after scroll");
-            Assert.Equal("http://example.com", cell.HyperlinkData!.Uri);
+            Assert.IsTrue(cell.HasHyperlinkData, $"Cell at (0,{x}) should have hyperlink after scroll");
+            Assert.AreEqual("http://example.com", cell.HyperlinkData!.Uri);
         }
 
         // Row 1 should NOT have hyperlinks (GHI was plain text)
         for (int x = 0; x < 3; x++)
         {
             var cell = GetCell(t, 1, x);
-            Assert.False(cell.HasHyperlinkData,
-                $"Cell at (1,{x}) should NOT have hyperlink");
+            Assert.IsFalse(cell.HasHyperlinkData, $"Cell at (1,{x}) should NOT have hyperlink");
         }
     }
 
     // Ghostty: "Terminal: scrollUp clears hyperlink"
     // When a row with hyperlinks scrolls off the top, the hyperlinks are cleared.
-    [Fact]
+    [TestMethod]
     public void ScrollUp_ClearsHyperlink()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -235,20 +230,19 @@ public class GhosttyHyperlinkConformanceTests
         Feed(t, "\u001b[2;2H"); // CUP(2,2)
         Feed(t, "\u001b[S");     // SU 1
 
-        Assert.Equal("DEF", GetLine(t, 0).TrimEnd());
-        Assert.Equal("GHI", GetLine(t, 1).TrimEnd());
+        Assert.AreEqual("DEF", GetLine(t, 0).TrimEnd());
+        Assert.AreEqual("GHI", GetLine(t, 1).TrimEnd());
 
         // Row 0 (was DEF, no hyperlink) should not have hyperlinks
         for (int x = 0; x < 3; x++)
         {
             var cell = GetCell(t, 0, x);
-            Assert.False(cell.HasHyperlinkData,
-                $"Cell at (0,{x}) should NOT have hyperlink");
+            Assert.IsFalse(cell.HasHyperlinkData, $"Cell at (0,{x}) should NOT have hyperlink");
         }
     }
 
     // Ghostty: "Terminal: scrollDown hyperlink moves"
-    [Fact]
+    [TestMethod]
     public void ScrollDown_HyperlinkMoves()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -263,24 +257,22 @@ public class GhosttyHyperlinkConformanceTests
         Feed(t, "\u001b[2;2H"); // CUP(2,2)
         Feed(t, "\u001b[T");     // SD 1 (scroll down)
 
-        Assert.Equal("ABC", GetLine(t, 1).TrimEnd());
-        Assert.Equal("DEF", GetLine(t, 2).TrimEnd());
+        Assert.AreEqual("ABC", GetLine(t, 1).TrimEnd());
+        Assert.AreEqual("DEF", GetLine(t, 2).TrimEnd());
 
         // Row 1 should have hyperlinks (ABC moved down)
         for (int x = 0; x < 3; x++)
         {
             var cell = GetCell(t, 1, x);
-            Assert.True(cell.HasHyperlinkData,
-                $"Cell at (1,{x}) should have hyperlink after scroll down");
-            Assert.Equal("http://example.com", cell.HyperlinkData!.Uri);
+            Assert.IsTrue(cell.HasHyperlinkData, $"Cell at (1,{x}) should have hyperlink after scroll down");
+            Assert.AreEqual("http://example.com", cell.HyperlinkData!.Uri);
         }
 
         // Row 0 (new blank row) should NOT have hyperlinks
         for (int x = 0; x < 3; x++)
         {
             var cell = GetCell(t, 0, x);
-            Assert.False(cell.HasHyperlinkData,
-                $"Cell at (0,{x}) should NOT have hyperlink (new blank row)");
+            Assert.IsFalse(cell.HasHyperlinkData, $"Cell at (0,{x}) should NOT have hyperlink (new blank row)");
         }
     }
 
@@ -289,7 +281,7 @@ public class GhosttyHyperlinkConformanceTests
     #region Index with Hyperlinks
 
     // Ghostty: "Terminal: index scrolling with hyperlink"
-    [Fact]
+    [TestMethod]
     public void Index_ScrollingWithHyperlink()
     {
         using var t = CreateTerminal(cols: 2, rows: 5);
@@ -302,21 +294,21 @@ public class GhosttyHyperlinkConformanceTests
         Feed(t, "\u001bD");   // IND (index — scroll up if at bottom)
         Feed(t, "B");
 
-        Assert.Equal("A", GetLine(t, 3).TrimEnd());
-        Assert.Equal("B", GetLine(t, 4).TrimEnd());
+        Assert.AreEqual("A", GetLine(t, 3).TrimEnd());
+        Assert.AreEqual("B", GetLine(t, 4).TrimEnd());
 
         // Row 3, col 0 should have hyperlink (A moved up by index)
         var cellA = GetCell(t, 3, 0);
-        Assert.True(cellA.HasHyperlinkData, "Cell A should have hyperlink");
-        Assert.Equal("http://example.com", cellA.HyperlinkData!.Uri);
+        Assert.IsTrue(cellA.HasHyperlinkData, "Cell A should have hyperlink");
+        Assert.AreEqual("http://example.com", cellA.HyperlinkData!.Uri);
 
         // Row 4, col 0 should NOT have hyperlink (B printed without hyperlink)
         var cellB = GetCell(t, 4, 0);
-        Assert.False(cellB.HasHyperlinkData, "Cell B should NOT have hyperlink");
+        Assert.IsFalse(cellB.HasHyperlinkData, "Cell B should NOT have hyperlink");
     }
 
     // Ghostty: "Terminal: index bottom of scroll region with hyperlinks"
-    [Fact]
+    [TestMethod]
     public void Index_BottomOfScrollRegion_WithHyperlinks()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -332,21 +324,21 @@ public class GhosttyHyperlinkConformanceTests
         Feed(t, "\r");          // CR
         Feed(t, "C");
 
-        Assert.Equal("B", GetLine(t, 0).TrimEnd());
-        Assert.Equal("C", GetLine(t, 1).TrimEnd());
+        Assert.AreEqual("B", GetLine(t, 0).TrimEnd());
+        Assert.AreEqual("C", GetLine(t, 1).TrimEnd());
 
         // Row 0 (B) should have hyperlink
         var cellB = GetCell(t, 0, 0);
-        Assert.True(cellB.HasHyperlinkData, "Cell B should have hyperlink");
-        Assert.Equal("http://example.com", cellB.HyperlinkData!.Uri);
+        Assert.IsTrue(cellB.HasHyperlinkData, "Cell B should have hyperlink");
+        Assert.AreEqual("http://example.com", cellB.HyperlinkData!.Uri);
 
         // Row 1 (C) should NOT have hyperlink
         var cellC = GetCell(t, 1, 0);
-        Assert.False(cellC.HasHyperlinkData, "Cell C should NOT have hyperlink");
+        Assert.IsFalse(cellC.HasHyperlinkData, "Cell C should NOT have hyperlink");
     }
 
     // Ghostty: "Terminal: index bottom of scroll region clear hyperlinks"
-    [Fact]
+    [TestMethod]
     public void Index_BottomOfScrollRegion_ClearsHyperlinks()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -363,15 +355,14 @@ public class GhosttyHyperlinkConformanceTests
         Feed(t, "\r");
         Feed(t, "C");
 
-        Assert.Equal("B", GetLine(t, 1).TrimEnd());
-        Assert.Equal("C", GetLine(t, 2).TrimEnd());
+        Assert.AreEqual("B", GetLine(t, 1).TrimEnd());
+        Assert.AreEqual("C", GetLine(t, 2).TrimEnd());
 
         // Rows 1-2 should NOT have hyperlinks (A scrolled off)
         for (int y = 1; y <= 2; y++)
         {
             var cell = GetCell(t, y, 0);
-            Assert.False(cell.HasHyperlinkData,
-                $"Cell at ({y},0) should NOT have hyperlink");
+            Assert.IsFalse(cell.HasHyperlinkData, $"Cell at ({y},0) should NOT have hyperlink");
         }
     }
 
@@ -380,7 +371,7 @@ public class GhosttyHyperlinkConformanceTests
     #region InsertBlanks with Hyperlinks
 
     // Ghostty: "Terminal: insertBlanks shifts hyperlinks"
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_ShiftsHyperlinks()
     {
         using var t = CreateTerminal(cols: 10, rows: 2);
@@ -390,28 +381,26 @@ public class GhosttyHyperlinkConformanceTests
         Feed(t, "\u001b[1;1H"); // CUP back to start
         Feed(t, "\u001b[2@");    // ICH 2 (insert 2 blanks)
 
-        Assert.Equal("  ABC", GetLine(t, 0).TrimEnd());
+        Assert.AreEqual("  ABC", GetLine(t, 0).TrimEnd());
 
         // Shifted cells (cols 2-4) should have hyperlink
         for (int x = 2; x < 5; x++)
         {
             var cell = GetCell(t, 0, x);
-            Assert.True(cell.HasHyperlinkData,
-                $"Shifted cell at col {x} should have hyperlink");
-            Assert.Equal("http://example.com", cell.HyperlinkData!.Uri);
+            Assert.IsTrue(cell.HasHyperlinkData, $"Shifted cell at col {x} should have hyperlink");
+            Assert.AreEqual("http://example.com", cell.HyperlinkData!.Uri);
         }
 
         // Inserted blank cells (cols 0-1) should NOT have hyperlink
         for (int x = 0; x < 2; x++)
         {
             var cell = GetCell(t, 0, x);
-            Assert.False(cell.HasHyperlinkData,
-                $"Blank cell at col {x} should NOT have hyperlink");
+            Assert.IsFalse(cell.HasHyperlinkData, $"Blank cell at col {x} should NOT have hyperlink");
         }
     }
 
     // Ghostty: "Terminal: insertBlanks pushes hyperlink off end completely"
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_PushesHyperlinkOffEndCompletely()
     {
         using var t = CreateTerminal(cols: 3, rows: 2);
@@ -421,14 +410,13 @@ public class GhosttyHyperlinkConformanceTests
         Feed(t, "\u001b[1;1H"); // CUP back to start
         Feed(t, "\u001b[3@");    // ICH 3 — pushes all hyperlinked chars off
 
-        Assert.Equal("", GetLine(t, 0).TrimEnd());
+        Assert.AreEqual("", GetLine(t, 0).TrimEnd());
 
         // All cells should have NO hyperlink
         for (int x = 0; x < 3; x++)
         {
             var cell = GetCell(t, 0, x);
-            Assert.False(cell.HasHyperlinkData,
-                $"Cell at col {x} should NOT have hyperlink after push-off");
+            Assert.IsFalse(cell.HasHyperlinkData, $"Cell at col {x} should NOT have hyperlink after push-off");
         }
     }
 
@@ -437,7 +425,7 @@ public class GhosttyHyperlinkConformanceTests
     #region Save/Restore and Reset
 
     // Ghostty: "Terminal: saveCursor doesn't modify hyperlink state"
-    [Fact]
+    [TestMethod]
     public void SaveCursor_DoesNotModifyHyperlinkState()
     {
         using var t = CreateTerminal(cols: 3, rows: 3);
@@ -450,12 +438,12 @@ public class GhosttyHyperlinkConformanceTests
         // Hyperlink should still be active — print and verify
         Feed(t, "A");
         var cell = GetCell(t, 0, 0);
-        Assert.True(cell.HasHyperlinkData, "Hyperlink should still be active after save/restore");
-        Assert.Equal("http://example.com", cell.HyperlinkData!.Uri);
+        Assert.IsTrue(cell.HasHyperlinkData, "Hyperlink should still be active after save/restore");
+        Assert.AreEqual("http://example.com", cell.HyperlinkData!.Uri);
     }
 
     // Ghostty: "Terminal: fullReset hyperlink"
-    [Fact]
+    [TestMethod]
     public void FullReset_ClearsHyperlink()
     {
         using var t = CreateTerminal(cols: 80, rows: 80);
@@ -466,7 +454,7 @@ public class GhosttyHyperlinkConformanceTests
         // After reset, hyperlink should be cleared — printing should not have hyperlink
         Feed(t, "A");
         var cell = GetCell(t, 0, 0);
-        Assert.False(cell.HasHyperlinkData, "Hyperlink should be cleared after RIS");
+        Assert.IsFalse(cell.HasHyperlinkData, "Hyperlink should be cleared after RIS");
     }
 
     #endregion

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyInsertDeleteConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyInsertDeleteConformanceTests.cs
@@ -6,7 +6,8 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// Covers insertBlanks (ICH), deleteChars (DCH), insertLines (IL),
 /// deleteLines (DL), and insert mode behavior with wide characters.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyInsertDeleteConformanceTests
 {
     private static Hex1bTerminal CreateTerminal(int cols = 80, int rows = 24)
@@ -15,13 +16,13 @@ public class GhosttyInsertDeleteConformanceTests
     private static void AssertPlainText(Hex1bTerminal terminal, int row, string expected)
     {
         var line = GhosttyTestFixture.GetLine(terminal, row);
-        Assert.Equal(expected, line);
+        Assert.AreEqual(expected, line);
     }
 
     #region InsertBlanks (ICH / CSI @)
 
     // Ghostty: test "Terminal: insertBlanks zero"
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_ZeroCount_NoOp()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 2);
@@ -32,7 +33,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: insertBlanks"
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_Basic_ShiftsRight()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 2);
@@ -43,7 +44,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: insertBlanks pushes off end"
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_PushesOffEnd()
     {
         using var terminal = CreateTerminal(cols: 3, rows: 2);
@@ -54,7 +55,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: insertBlanks more than size"
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_MoreThanSize_ClearsLine()
     {
         using var terminal = CreateTerminal(cols: 3, rows: 2);
@@ -65,7 +66,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: insertBlanks no scroll region, fits"
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_NoScrollRegion_Fits()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 10);
@@ -76,7 +77,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: insertBlanks shift off screen"
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_ShiftOffScreen()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 10);
@@ -88,7 +89,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: insertBlanks split multi-cell character"
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_SplitWideChar_ClearsWide()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 10);
@@ -100,7 +101,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: insertBlanks split multi-cell character from tail"
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_SplitWideCharFromTail()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 10);
@@ -112,7 +113,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: insertBlanks preserves background sgr"
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_PreservesBackgroundSgr()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 10);
@@ -124,7 +125,7 @@ public class GhosttyInsertDeleteConformanceTests
 
         // Inserted blank cells should have red background
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.NotNull(cell0.Background);
+        Assert.IsNotNull(cell0.Background);
     }
 
     #endregion
@@ -132,7 +133,7 @@ public class GhosttyInsertDeleteConformanceTests
     #region DeleteChars (DCH / CSI P)
 
     // Ghostty: test "Terminal: deleteChars"
-    [Fact]
+    [TestMethod]
     public void DeleteChars_Basic()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -144,7 +145,7 @@ public class GhosttyInsertDeleteConformanceTests
 
     // Ghostty: test "Terminal: deleteChars zero count"
     // Ghostty's internal deleteChars(0) is a no-op, but CSI 0P defaults to 1 per ECMA-48.
-    [Fact]
+    [TestMethod]
     public void DeleteChars_ZeroCount_DefaultsToOne()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -155,7 +156,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: deleteChars more than half"
-    [Fact]
+    [TestMethod]
     public void DeleteChars_MoreThanHalf()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -166,7 +167,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: deleteChars more than line width"
-    [Fact]
+    [TestMethod]
     public void DeleteChars_MoreThanLineWidth()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -177,7 +178,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: deleteChars should shift left"
-    [Fact]
+    [TestMethod]
     public void DeleteChars_ShiftLeft()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -188,7 +189,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: deleteChars resets pending wrap"
-    [Fact]
+    [TestMethod]
     public void DeleteChars_ResetsPendingWrap()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -200,7 +201,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: deleteChars simple operation"
-    [Fact]
+    [TestMethod]
     public void DeleteChars_SimpleOperation()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 10);
@@ -211,7 +212,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: deleteChars preserves background sgr"
-    [Fact]
+    [TestMethod]
     public void DeleteChars_PreservesBackgroundSgr()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 10);
@@ -223,11 +224,11 @@ public class GhosttyInsertDeleteConformanceTests
 
         // Vacated cells at end should have background color
         var cellEnd = GhosttyTestFixture.GetCell(terminal, 0, 9);
-        Assert.NotNull(cellEnd.Background);
+        Assert.IsNotNull(cellEnd.Background);
     }
 
     // Ghostty: test "Terminal: deleteChars split wide character from spacer tail"
-    [Fact]
+    [TestMethod]
     public void DeleteChars_SplitWideCharFromSpacerTail()
     {
         using var terminal = CreateTerminal(cols: 6, rows: 10);
@@ -239,7 +240,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: deleteChars split wide character from wide"
-    [Fact]
+    [TestMethod]
     public void DeleteChars_SplitWideCharFromWide()
     {
         using var terminal = CreateTerminal(cols: 6, rows: 10);
@@ -248,14 +249,13 @@ public class GhosttyInsertDeleteConformanceTests
         GhosttyTestFixture.Feed(terminal, "\x1b[1P"); // DCH 1
         // Deleting from wide head should clear continuation and shift
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.True(cell0.Character == "" || cell0.Character == " ",
-            $"Expected cleared cell, got '{cell0.Character}'");
+        Assert.IsTrue(cell0.Character == "" || cell0.Character == " ", $"Expected cleared cell, got '{cell0.Character}'");
         var cell1 = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.Equal("1", cell1.Character);
+        Assert.AreEqual("1", cell1.Character);
     }
 
     // Ghostty: test "Terminal: deleteChars split wide character from end"
-    [Fact]
+    [TestMethod]
     public void DeleteChars_SplitWideCharFromEnd()
     {
         using var terminal = CreateTerminal(cols: 6, rows: 10);
@@ -264,9 +264,9 @@ public class GhosttyInsertDeleteConformanceTests
         GhosttyTestFixture.Feed(terminal, "\x1b[1P"); // DCH 1
         // "A" deleted, wide char shifts left intact
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.Equal("橋", cell0.Character);
+        Assert.AreEqual("橋", cell0.Character);
         var cell1 = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.Equal("", cell1.Character); // continuation
+        Assert.AreEqual("", cell1.Character); // continuation
     }
 
     #endregion
@@ -274,7 +274,7 @@ public class GhosttyInsertDeleteConformanceTests
     #region InsertLines (IL / CSI L)
 
     // Ghostty: test "Terminal: insertLines simple"
-    [Fact]
+    [TestMethod]
     public void InsertLines_Simple()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -291,7 +291,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: insertLines zero"
-    [Fact]
+    [TestMethod]
     public void InsertLines_Zero_NoOp()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -306,7 +306,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: insertLines with scroll region"
-    [Fact]
+    [TestMethod]
     public void InsertLines_WithScrollRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -324,7 +324,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: insertLines more than remaining"
-    [Fact]
+    [TestMethod]
     public void InsertLines_MoreThanRemaining()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -340,14 +340,14 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: insertLines resets pending wrap"
-    [Fact]
+    [TestMethod]
     public void InsertLines_ResetsPendingWrap()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
         GhosttyTestFixture.Feed(terminal, "ABCDE"); // pending wrap
         GhosttyTestFixture.Feed(terminal, "\x1b[1L"); // IL 1
         GhosttyTestFixture.Feed(terminal, "X");
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorY);
         AssertPlainText(terminal, 0, "X");
         AssertPlainText(terminal, 1, "ABCDE");
     }
@@ -357,7 +357,7 @@ public class GhosttyInsertDeleteConformanceTests
     #region DeleteLines (DL / CSI M)
 
     // Ghostty: test "Terminal: deleteLines simple"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_Simple()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -373,7 +373,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: deleteLines with scroll region"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_WithScrollRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -390,7 +390,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: deleteLines with scroll region, large count"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_WithScrollRegion_LargeCount()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -407,14 +407,14 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: deleteLines resets pending wrap"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_ResetsPendingWrap()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
         GhosttyTestFixture.Feed(terminal, "ABCDE"); // pending wrap
         GhosttyTestFixture.Feed(terminal, "\x1b[1M"); // DL 1
         GhosttyTestFixture.Feed(terminal, "X");
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorY);
         AssertPlainText(terminal, 0, "X");
     }
 
@@ -423,7 +423,7 @@ public class GhosttyInsertDeleteConformanceTests
     #region Insert Mode (IRM / CSI 4h)
 
     // Ghostty: test "Terminal: insert mode with space"
-    [Fact]
+    [TestMethod]
     public void InsertMode_Basic()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 2);
@@ -435,7 +435,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: insert mode doesn't wrap pushed characters"
-    [Fact]
+    [TestMethod]
     public void InsertMode_DoesNotWrapPushed()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 2);
@@ -447,7 +447,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: insert mode with wide characters"
-    [Fact]
+    [TestMethod]
     public void InsertMode_WithWideChars()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 2);
@@ -459,7 +459,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: insert mode pushing off wide character"
-    [Fact]
+    [TestMethod]
     public void InsertMode_PushingOffWideChar()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 2);
@@ -472,7 +472,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: insert mode does nothing at the end of the line"
-    [Fact]
+    [TestMethod]
     public void InsertMode_AtEndOfLine_Wraps()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 2);
@@ -485,7 +485,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: insert mode with wide characters at end"
-    [Fact]
+    [TestMethod]
     public void InsertMode_WideCharAtEnd()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 2);
@@ -502,7 +502,7 @@ public class GhosttyInsertDeleteConformanceTests
     #region Wide Character Edge Cases in Delete/Insert
 
     // Ghostty: test "Terminal: deleteChars wide char boundary conditions"
-    [Fact]
+    [TestMethod]
     public void DeleteChars_WideCharBoundaryConditions()
     {
         using var terminal = CreateTerminal(cols: 8, rows: 1);
@@ -518,7 +518,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: deleteChars split wide character tail"
-    [Fact]
+    [TestMethod]
     public void DeleteChars_SplitWideCharTail()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -533,7 +533,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: insertBlanks wide char straddling right margin"
-    [Fact]
+    [TestMethod]
     public void InsertBlanks_WideCharStraddlingRightMargin()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -551,7 +551,7 @@ public class GhosttyInsertDeleteConformanceTests
     #region InsertLines/DeleteLines with Wide Characters
 
     // Ghostty: test "Terminal: deleteLines wide character spacer head"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_WideCharSpacerHead()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -566,7 +566,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: insertLines resets wrap"
-    [Fact]
+    [TestMethod]
     public void InsertLines_ResetsWrap()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -581,7 +581,7 @@ public class GhosttyInsertDeleteConformanceTests
     }
 
     // Ghostty: test "Terminal: insertLines multi-codepoint graphemes"
-    [Fact]
+    [TestMethod]
     public void InsertLines_MultiCodepointGraphemes()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -600,7 +600,7 @@ public class GhosttyInsertDeleteConformanceTests
     #region ECH (Erase Characters) with Wide Characters
 
     // Ghostty: test "Terminal: eraseChars with wide char splitting"
-    [Fact]
+    [TestMethod]
     public void EraseChars_WideCharSplitting()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -610,12 +610,11 @@ public class GhosttyInsertDeleteConformanceTests
 
         // Erasing at the wide char's head should clear both cells
         var cell1 = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.True(cell1.Character == " " || cell1.Character == "",
-            $"Expected cleared, got '{cell1.Character}'");
+        Assert.IsTrue(cell1.Character == " " || cell1.Character == "", $"Expected cleared, got '{cell1.Character}'");
     }
 
     // Ghostty: test "Terminal: eraseChars over wide character continuation"
-    [Fact]
+    [TestMethod]
     public void EraseChars_OverWideContinuation()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -625,8 +624,7 @@ public class GhosttyInsertDeleteConformanceTests
 
         // Erasing at the continuation should clear leading cell too
         var cell1 = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.True(cell1.Character == " " || cell1.Character == "",
-            $"Expected leading cleared, got '{cell1.Character}'");
+        Assert.IsTrue(cell1.Character == " " || cell1.Character == "", $"Expected leading cleared, got '{cell1.Character}'");
     }
 
     #endregion

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyInsertModeConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyInsertModeConformanceTests.cs
@@ -5,7 +5,8 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// CSI 4 h enables insert mode, CSI 4 l disables (back to replace mode).
 /// In insert mode, printing a character shifts existing content right.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyInsertModeConformanceTests
 {
     private static Hex1bTerminal CreateTerminal(int cols = 80, int rows = 24)
@@ -14,12 +15,12 @@ public class GhosttyInsertModeConformanceTests
     private static void AssertPlainText(Hex1bTerminal terminal, int row, string expected)
     {
         var line = GhosttyTestFixture.GetLine(terminal, row);
-        Assert.Equal(expected, line);
+        Assert.AreEqual(expected, line);
     }
 
     #region Basic Insert Mode Toggle
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_DefaultOff_OverwritesCharacters()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 2);
@@ -30,7 +31,7 @@ public class GhosttyInsertModeConformanceTests
         AssertPlainText(terminal, 0, "ABXDE");
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_Enable_InsertsCharacters()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 2);
@@ -42,7 +43,7 @@ public class GhosttyInsertModeConformanceTests
         AssertPlainText(terminal, 0, "ABXCDE");
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_DisableWithCSI4l_ReturnsToReplace()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 2);
@@ -55,7 +56,7 @@ public class GhosttyInsertModeConformanceTests
         AssertPlainText(terminal, 0, "ABXDE");
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_MultipleCharsInserted()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 2);
@@ -71,7 +72,7 @@ public class GhosttyInsertModeConformanceTests
 
     #region Edge Cases — Line Boundary
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_PushesCharsOffEnd()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 2);
@@ -83,7 +84,7 @@ public class GhosttyInsertModeConformanceTests
         AssertPlainText(terminal, 0, "XABCD");
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_PushedCharsDoNotWrapToNextLine()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 2);
@@ -96,7 +97,7 @@ public class GhosttyInsertModeConformanceTests
         AssertPlainText(terminal, 1, "");
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_AtEndOfLine_PendingWrap()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 3);
@@ -108,7 +109,7 @@ public class GhosttyInsertModeConformanceTests
         AssertPlainText(terminal, 1, "X");
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_FillEntireLine()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 2);
@@ -118,21 +119,21 @@ public class GhosttyInsertModeConformanceTests
         AssertPlainText(terminal, 0, "ABCDE");
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_InsertAtCol0_EmptyLine()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 2);
         GhosttyTestFixture.Feed(terminal, "\x1b[4h"); // Enable IRM
         GhosttyTestFixture.Feed(terminal, "ABC");
         AssertPlainText(terminal, 0, "ABC");
-        Assert.Equal(3, terminal.CursorX);
+        Assert.AreEqual(3, terminal.CursorX);
     }
 
     #endregion
 
     #region Wide Characters
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_WideCharInserted()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 2);
@@ -144,7 +145,7 @@ public class GhosttyInsertModeConformanceTests
         AssertPlainText(terminal, 0, "AB😀CDE");
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_WideCharPushedOff()
     {
         // Wide char at cols 3-4 gets split when pushed to 4-5 (col 4 is last)
@@ -158,7 +159,7 @@ public class GhosttyInsertModeConformanceTests
         AssertPlainText(terminal, 0, "XAB😀");
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_WideCharSplitAtEdge()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 2);
@@ -171,7 +172,7 @@ public class GhosttyInsertModeConformanceTests
         AssertPlainText(terminal, 0, "ZAB😀");
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_WideCharDoesntFitAtEnd()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 2);
@@ -188,7 +189,7 @@ public class GhosttyInsertModeConformanceTests
 
     #region SGR Attributes Preservation
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_PreservesAttributesOnShiftedChars()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 2);
@@ -203,11 +204,11 @@ public class GhosttyInsertModeConformanceTests
 
         // Shifted 'A' (now at col 1) should still have red foreground
         var cellA = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.Equal("A", cellA.Character);
-        Assert.NotNull(cellA.Foreground);
+        Assert.AreEqual("A", cellA.Character);
+        Assert.IsNotNull(cellA.Foreground);
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_InsertedBlankHasCurrentBg()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 2);
@@ -218,15 +219,15 @@ public class GhosttyInsertModeConformanceTests
         GhosttyTestFixture.Feed(terminal, "X");
         // X at col 2 should have red background
         var cellX = GhosttyTestFixture.GetCell(terminal, 0, 2);
-        Assert.Equal("X", cellX.Character);
-        Assert.NotNull(cellX.Background);
+        Assert.AreEqual("X", cellX.Character);
+        Assert.IsNotNull(cellX.Background);
     }
 
     #endregion
 
     #region Interaction with Other Operations
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_CursorMoveDoesNotInsert()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 2);
@@ -237,7 +238,7 @@ public class GhosttyInsertModeConformanceTests
         AssertPlainText(terminal, 0, "ABCDE");
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_PersistsAcrossLines()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 3);
@@ -251,7 +252,7 @@ public class GhosttyInsertModeConformanceTests
         AssertPlainText(terminal, 1, "XFG");
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_WithBackspace()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 2);
@@ -263,10 +264,10 @@ public class GhosttyInsertModeConformanceTests
         AssertPlainText(terminal, 0, "ABCXDE");
         // Backspace moves cursor but doesn't insert
         GhosttyTestFixture.Feed(terminal, "\b");
-        Assert.Equal(3, terminal.CursorX);
+        Assert.AreEqual(3, terminal.CursorX);
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_WithTab()
     {
         using var terminal = CreateTerminal(cols: 20, rows: 2);
@@ -276,7 +277,7 @@ public class GhosttyInsertModeConformanceTests
         // Tab should not insert — it's a control character
         GhosttyTestFixture.Feed(terminal, "\t");
         // Cursor moves to next tab stop but doesn't shift anything
-        Assert.Equal(8, terminal.CursorX);
+        Assert.AreEqual(8, terminal.CursorX);
         AssertPlainText(terminal, 0, "ABCDE");
     }
 
@@ -284,7 +285,7 @@ public class GhosttyInsertModeConformanceTests
 
     #region Tokenizer Roundtrip
 
-    [Fact]
+    [TestMethod]
     public void StandardModeToken_ParsedCorrectly()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 2);
@@ -297,7 +298,7 @@ public class GhosttyInsertModeConformanceTests
         AssertPlainText(terminal, 0, "XAB");
     }
 
-    [Fact]
+    [TestMethod]
     public void StandardModeToken_DisableParsedCorrectly()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 2);
@@ -314,7 +315,7 @@ public class GhosttyInsertModeConformanceTests
 
     #region Stress / Boundary Tests
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_SingleColumnTerminal()
     {
         using var terminal = CreateTerminal(cols: 1, rows: 3);
@@ -327,7 +328,7 @@ public class GhosttyInsertModeConformanceTests
         AssertPlainText(terminal, 0, "B");
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_InsertManyCharsRapidly()
     {
         using var terminal = CreateTerminal(cols: 20, rows: 2);
@@ -339,7 +340,7 @@ public class GhosttyInsertModeConformanceTests
         AssertPlainText(terminal, 0, "1234567890ABCDE");
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_ExactlyFillsLine()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 2);
@@ -351,7 +352,7 @@ public class GhosttyInsertModeConformanceTests
         AssertPlainText(terminal, 0, "XYZAB");
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_OverflowExactly()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 2);

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyMarginScrollConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyMarginScrollConformanceTests.cs
@@ -1,4 +1,3 @@
-using Xunit;
 
 namespace Hex1b.Tests.Conformance.Ghostty;
 
@@ -7,7 +6,8 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// with left/right margins (DECSLRM), and erase reset-wrap/SGR behavior.
 /// Translated from Ghostty's Terminal.zig.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyMarginScrollConformanceTests
 {
     private static Hex1bTerminal CreateTerminal(int cols = 80, int rows = 24)
@@ -15,20 +15,20 @@ public class GhosttyMarginScrollConformanceTests
 
     #region EraseChars — reset wrap and preserves SGR
 
-    [Fact]
+    [TestMethod]
     public void EraseChars_ResetsPendingWrap()
     {
         // Ghostty: "Terminal: eraseChars resets pending wrap"
         using var t = CreateTerminal(cols: 5, rows: 5);
         GhosttyTestFixture.Feed(t, "ABCDE");
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "\u001b[X"); // eraseChars(1)
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "X");
-        Assert.Equal("ABCDX", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("ABCDX", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseChars_ResetsWrap()
     {
         // Ghostty: "Terminal: eraseChars resets wrap"
@@ -37,11 +37,11 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H"); // setCursorPos(1,1)
         GhosttyTestFixture.Feed(t, "\u001b[X");     // eraseChars(1)
         GhosttyTestFixture.Feed(t, "X");
-        Assert.Equal("XBCDE", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("123", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("XBCDE", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("123", GhosttyTestFixture.GetLine(t, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseChars_PreservesBackgroundSgr()
     {
         // Ghostty: "Terminal: eraseChars preserves background sgr"
@@ -55,34 +55,34 @@ public class GhosttyMarginScrollConformanceTests
         var cell0 = GhosttyTestFixture.GetCell(t, 0, 0);
         var cell1 = GhosttyTestFixture.GetCell(t, 0, 1);
         var cell2 = GhosttyTestFixture.GetCell(t, 0, 2);
-        Assert.Equal(" ", cell0.Character);
-        Assert.Equal(" ", cell1.Character);
-        Assert.Equal("C", cell2.Character);
+        Assert.AreEqual(" ", cell0.Character);
+        Assert.AreEqual(" ", cell1.Character);
+        Assert.AreEqual("C", cell2.Character);
         // Erased cells should have the background color set
-        Assert.Equal(255, cell0.Background!.Value.R);
-        Assert.Equal(0, cell0.Background!.Value.G);
-        Assert.Equal(0, cell0.Background!.Value.B);
-        Assert.Equal(255, cell1.Background!.Value.R);
+        Assert.AreEqual(255, cell0.Background!.Value.R);
+        Assert.AreEqual(0, cell0.Background!.Value.G);
+        Assert.AreEqual(0, cell0.Background!.Value.B);
+        Assert.AreEqual(255, cell1.Background!.Value.R);
     }
 
     #endregion
 
     #region EraseLine — reset wrap and preserves SGR
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_ResetsPendingWrap()
     {
         // Ghostty: "Terminal: eraseLine resets pending wrap"
         using var t = CreateTerminal(cols: 5, rows: 5);
         GhosttyTestFixture.Feed(t, "ABCDE");
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "\u001b[K"); // eraseLine(.right)
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "B");
-        Assert.Equal("ABCDB", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("ABCDB", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_ResetsWrap()
     {
         // Ghostty: "Terminal: eraseLine resets wrap"
@@ -91,11 +91,11 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H"); // setCursorPos(1,1)
         GhosttyTestFixture.Feed(t, "\u001b[K");     // eraseLine(.right)
         GhosttyTestFixture.Feed(t, "X");
-        Assert.Equal("X", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("123", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("X", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("123", GhosttyTestFixture.GetLine(t, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_RightPreservesBackgroundSgr()
     {
         // Ghostty: "Terminal: eraseLine right preserves background sgr"
@@ -105,29 +105,29 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[48;2;255;0;0m"); // bg = red
         GhosttyTestFixture.Feed(t, "\u001b[K"); // eraseLine(.right)
 
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 0));
         for (int x = 1; x < 5; x++)
         {
             var cell = GhosttyTestFixture.GetCell(t, 0, x);
-            Assert.Equal(255, cell.Background!.Value.R);
-            Assert.Equal(0, cell.Background!.Value.G);
+            Assert.AreEqual(255, cell.Background!.Value.R);
+            Assert.AreEqual(0, cell.Background!.Value.G);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_LeftResetsWrap()
     {
         // Ghostty: "Terminal: eraseLine left resets wrap" (adapted — skip dirty check)
         using var t = CreateTerminal(cols: 5, rows: 5);
         GhosttyTestFixture.Feed(t, "ABCDE");
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "\u001b[1K"); // eraseLine(.left)
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "B");
-        Assert.Equal("    B", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("    B", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_LeftPreservesBackgroundSgr()
     {
         // Ghostty: "Terminal: eraseLine left preserves background sgr"
@@ -138,15 +138,15 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1K"); // eraseLine(.left)
 
         // First two cells erased (cols 0-1), rest remain
-        Assert.Equal("  CDE", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("  CDE", GhosttyTestFixture.GetLine(t, 0));
         for (int x = 0; x < 2; x++)
         {
             var cell = GhosttyTestFixture.GetCell(t, 0, x);
-            Assert.Equal(255, cell.Background!.Value.R);
+            Assert.AreEqual(255, cell.Background!.Value.R);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_CompletePreservesBackgroundSgr()
     {
         // Ghostty: "Terminal: eraseLine complete preserves background sgr"
@@ -156,11 +156,11 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[48;2;255;0;0m"); // bg = red
         GhosttyTestFixture.Feed(t, "\u001b[2K"); // eraseLine(.complete)
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
         for (int x = 0; x < 5; x++)
         {
             var cell = GhosttyTestFixture.GetCell(t, 0, x);
-            Assert.Equal(255, cell.Background!.Value.R);
+            Assert.AreEqual(255, cell.Background!.Value.R);
         }
     }
 
@@ -168,7 +168,7 @@ public class GhosttyMarginScrollConformanceTests
 
     #region EraseDisplay — preserves SGR and cursor
 
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_BelowPreservesSgrBg()
     {
         // Ghostty: "Terminal: eraseDisplay erase below preserves SGR bg"
@@ -178,17 +178,17 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[48;2;255;0;0m"); // bg = red
         GhosttyTestFixture.Feed(t, "\u001b[J"); // eraseDisplay(.below)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("D", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("D", GhosttyTestFixture.GetLine(t, 1));
         // Erased cells on row 1 (cols 1-4) should have red bg
         for (int x = 1; x < 5; x++)
         {
             var cell = GhosttyTestFixture.GetCell(t, 1, x);
-            Assert.Equal(255, cell.Background!.Value.R);
+            Assert.AreEqual(255, cell.Background!.Value.R);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_AbovePreservesSgrBg()
     {
         // Ghostty: "Terminal: eraseDisplay erase above preserves SGR bg"
@@ -198,19 +198,19 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[48;2;255;0;0m"); // bg = red
         GhosttyTestFixture.Feed(t, "\u001b[1J"); // eraseDisplay(.above)
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
         // Row 1: first two cells erased, "F" remains
-        Assert.Equal("  F", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("  F", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 2));
         // Erased cells on row 1 (cols 0-1) should have red bg
         for (int x = 0; x < 2; x++)
         {
             var cell = GhosttyTestFixture.GetCell(t, 1, x);
-            Assert.Equal(255, cell.Background!.Value.R);
+            Assert.AreEqual(255, cell.Background!.Value.R);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_CompletePreservesCursor()
     {
         // Ghostty: "Terminal: eraseDisplay complete preserves cursor"
@@ -222,15 +222,15 @@ public class GhosttyMarginScrollConformanceTests
         var cursorY = t.CursorY;
         GhosttyTestFixture.Feed(t, "\u001b[2J"); // eraseDisplay(.complete)
         // Cursor position should be preserved
-        Assert.Equal(cursorX, t.CursorX);
-        Assert.Equal(cursorY, t.CursorY);
+        Assert.AreEqual(cursorX, t.CursorX);
+        Assert.AreEqual(cursorY, t.CursorY);
     }
 
     #endregion
 
     #region Index — SGR bg and left/right margins
 
-    [Fact]
+    [TestMethod]
     public void Index_BottomOfPrimaryScreen_BackgroundSgr()
     {
         // Ghostty: "Terminal: index bottom of primary screen background sgr"
@@ -241,16 +241,16 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001bD"); // index
 
         // After scrolling, 'A' moves to row 3, row 4 is blank with red bg
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 3));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 4));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 4));
         for (int x = 0; x < 5; x++)
         {
             var cell = GhosttyTestFixture.GetCell(t, 4, x);
-            Assert.Equal(255, cell.Background!.Value.R);
+            Assert.AreEqual(255, cell.Background!.Value.R);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Index_BottomOfScrollRegion_BackgroundSgr()
     {
         // Ghostty: "Terminal: index bottom of scroll region with background SGR"
@@ -263,19 +263,19 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[48;2;255;0;0m"); // bg = red
         GhosttyTestFixture.Feed(t, "\u001bD"); // index (scrolls within region)
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("B", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("B", GhosttyTestFixture.GetLine(t, 3));
         // New blank line (row 2) should have red bg
         for (int x = 0; x < 5; x++)
         {
             var cell = GhosttyTestFixture.GetCell(t, 2, x);
-            Assert.Equal(255, cell.Background!.Value.R);
+            Assert.AreEqual(255, cell.Background!.Value.R);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Index_BottomOfScrollRegion_BlankLinePreservesSgr()
     {
         // Ghostty: "Terminal: index bottom of scroll region blank line preserves SGR"
@@ -288,19 +288,19 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[48;2;255;0;0m"); // bg = red
         GhosttyTestFixture.Feed(t, "\u001bD"); // index
 
-        Assert.Equal("2", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("3", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("X", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("2", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("3", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("X", GhosttyTestFixture.GetLine(t, 3));
         // Blank line (row 2) should preserve red bg
         for (int x = 0; x < 5; x++)
         {
             var cell = GhosttyTestFixture.GetCell(t, 2, x);
-            Assert.Equal(255, cell.Background!.Value.R);
+            Assert.AreEqual(255, cell.Background!.Value.R);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Index_OutsideLeftRightMargin()
     {
         // Ghostty: "Terminal: index outside left/right margin"
@@ -316,12 +316,12 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001bD"); // index
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
         Assert.StartsWith("X A", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void Index_InsideLeftRightMargin()
     {
         // Ghostty: "Terminal: index inside left/right margin"
@@ -333,19 +333,19 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[3;1H"); // setCursorPos(3,1) → row 2, col 0
         GhosttyTestFixture.Feed(t, "\u001bD"); // index
 
-        Assert.Equal(2, t.CursorY);
-        Assert.Equal(0, t.CursorX);
-        Assert.Equal("AAAAAA", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("AAAAAA", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual(2, t.CursorY);
+        Assert.AreEqual(0, t.CursorX);
+        Assert.AreEqual("AAAAAA", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("AAAAAA", GhosttyTestFixture.GetLine(t, 1));
         // After scrolling within L/R margins, the margin region shifts up
-        Assert.Equal("   AAA", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("   AAA", GhosttyTestFixture.GetLine(t, 2));
     }
 
     #endregion
 
     #region ReverseIndex — left/right margins
 
-    [Fact]
+    [TestMethod]
     public void ReverseIndex_LeftRightMargins()
     {
         // Ghostty: "Terminal: reverseIndex left/right margins"
@@ -360,13 +360,13 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;2H"); // setCursorPos(1,2) → row 0, col 1 (inside margin)
         GhosttyTestFixture.Feed(t, "\u001bM"); // reverseIndex
 
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("DBC", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("GEF", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal(" HI", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("DBC", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("GEF", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual(" HI", GhosttyTestFixture.GetLine(t, 3));
     }
 
-    [Fact]
+    [TestMethod]
     public void ReverseIndex_OutsideLeftRightMargins()
     {
         // Ghostty: "Terminal: reverseIndex outside left/right margins"
@@ -382,12 +382,12 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001bM"); // reverseIndex
 
         // Outside margin — no scrolling happens, content unchanged
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void ReverseIndex_TopOfScrollingRegion()
     {
         // Ghostty: "Terminal: reverseIndex top of scrolling region"
@@ -400,18 +400,18 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001bM"); // reverseIndex
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("X", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("B", GhosttyTestFixture.GetLine(t, 3));
-        Assert.Equal("C", GhosttyTestFixture.GetLine(t, 4));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("X", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("B", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("C", GhosttyTestFixture.GetLine(t, 4));
     }
 
     #endregion
 
     #region ScrollUp — left/right margins
 
-    [Fact]
+    [TestMethod]
     public void ScrollUp_LeftRightScrollRegion()
     {
         // Ghostty: "Terminal: scrollUp left/right scroll region"
@@ -422,12 +422,12 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H"); // setCursorPos(2,2)
         GhosttyTestFixture.Feed(t, "\u001b[S"); // scrollUp(1)
 
-        Assert.Equal("AEF423", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("DHI756", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("G   89", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("AEF423", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("DHI756", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("G   89", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollUp_FullTopBottomRegion()
     {
         // Ghostty: "Terminal: scrollUp full top/bottom region"
@@ -438,11 +438,11 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;5r"); // setTopAndBottomMargin(2,5)
         GhosttyTestFixture.Feed(t, "\u001b[4S"); // scrollUp(4)
 
-        Assert.Equal("top", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("top", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollUp_FullTopBottomLeftRightRegion()
     {
         // Ghostty: "Terminal: scrollUp full top/bottomleft/right scroll region"
@@ -455,18 +455,18 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;4s"); // setLeftAndRightMargin(2,4)
         GhosttyTestFixture.Feed(t, "\u001b[4S"); // scrollUp(4)
 
-        Assert.Equal("top", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 3));
-        Assert.Equal("A   E", GhosttyTestFixture.GetLine(t, 4));
+        Assert.AreEqual("top", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("A   E", GhosttyTestFixture.GetLine(t, 4));
     }
 
     #endregion
 
     #region ScrollDown — left/right margins
 
-    [Fact]
+    [TestMethod]
     public void ScrollDown_LeftRightScrollRegion()
     {
         // Ghostty: "Terminal: scrollDown left/right scroll region"
@@ -477,13 +477,13 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H"); // setCursorPos(2,2)
         GhosttyTestFixture.Feed(t, "\u001b[T"); // scrollDown(1)
 
-        Assert.Equal("A   23", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("DBC156", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("GEF489", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal(" HI7", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("A   23", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("DBC156", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("GEF489", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual(" HI7", GhosttyTestFixture.GetLine(t, 3));
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollDown_OutsideLeftRightScrollRegion()
     {
         // Ghostty: "Terminal: scrollDown outside of left/right scroll region"
@@ -495,17 +495,17 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[T"); // scrollDown(1)
 
         // Cursor outside margin — scroll still affects the margin region
-        Assert.Equal("A   23", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("DBC156", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("GEF489", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal(" HI7", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("A   23", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("DBC156", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("GEF489", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual(" HI7", GhosttyTestFixture.GetLine(t, 3));
     }
 
     #endregion
 
     #region FullReset — origin mode
 
-    [Fact]
+    [TestMethod]
     public void FullReset_OriginMode()
     {
         // Ghostty: "Terminal: fullReset origin mode"
@@ -515,11 +515,11 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001bc"); // fullReset (RIS)
 
         // Origin mode should be reset and cursor should be at home
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(0, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(0, t.CursorX);
     }
 
-    [Fact]
+    [TestMethod]
     public void FullReset_NonEmptyPen()
     {
         // Ghostty: "Terminal: fullReset with a non-empty pen"
@@ -532,11 +532,11 @@ public class GhosttyMarginScrollConformanceTests
 
         // After reset, 'A' should have default styling
         var cell = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.Equal("A", cell.Character);
-        Assert.False(cell.IsBold);
+        Assert.AreEqual("A", cell.Character);
+        Assert.IsFalse(cell.IsBold);
     }
 
-    [Fact]
+    [TestMethod]
     public void FullReset_NonEmptySavedCursor()
     {
         // Ghostty: "Terminal: fullReset with a non-empty saved cursor"
@@ -547,15 +547,15 @@ public class GhosttyMarginScrollConformanceTests
         // After reset, saved cursor should also be reset
         GhosttyTestFixture.Feed(t, "\u001b8"); // restore cursor — should restore to defaults
         // Cursor should be at origin after reset
-        Assert.Equal(0, t.CursorX);
-        Assert.Equal(0, t.CursorY);
+        Assert.AreEqual(0, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
     }
 
     #endregion
 
     #region SetTopAndBottomMargin — additional edge cases
 
-    [Fact]
+    [TestMethod]
     public void SetTopAndBottomMargin_TopOnly()
     {
         // Ghostty: "Terminal: setTopAndBottomMargin top only"
@@ -565,14 +565,14 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[3;1H"); // setCursorPos(3,1)
         GhosttyTestFixture.Feed(t, "\u001b[M"); // deleteLines(1)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("JKL", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("MNO", GhosttyTestFixture.GetLine(t, 3));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 4));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("JKL", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("MNO", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 4));
     }
 
-    [Fact]
+    [TestMethod]
     public void SetTopAndBottomMargin_TopEqualBottom()
     {
         // Ghostty: "Terminal: setTopAndBottomMargin top equal to bottom"
@@ -583,18 +583,18 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[3;1H"); // setCursorPos(3,1)
         GhosttyTestFixture.Feed(t, "\u001b[M"); // deleteLines(1)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("JKL", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("MNO", GhosttyTestFixture.GetLine(t, 3));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 4));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("JKL", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("MNO", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 4));
     }
 
     #endregion
 
     #region SetLeftAndRightMargin — edge cases
 
-    [Fact]
+    [TestMethod]
     public void SetLeftAndRightMargin_LeftAndRight()
     {
         // Ghostty: "Terminal: setLeftAndRightMargin left and right"
@@ -605,12 +605,12 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H"); // home
         GhosttyTestFixture.Feed(t, "\u001b[M"); // deleteLines(1) — within margin
 
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void SetLeftAndRightMargin_LeftEqualRight()
     {
         // Ghostty: "Terminal: setLeftAndRightMargin left equal right"
@@ -622,12 +622,12 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H"); // home
         GhosttyTestFixture.Feed(t, "\u001b[M"); // deleteLines(1)
 
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void SetLeftAndRightMargin_LeftOnly()
     {
         // Ghostty: "Terminal: setLeftAndRightMargin left only"
@@ -640,16 +640,16 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[M");     // deleteLines(1) — within margin
 
         // Only cols 1-4 should be affected
-        Assert.Equal("AGHIJ", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("FLMNO", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("K", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("AGHIJ", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("FLMNO", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("K", GhosttyTestFixture.GetLine(t, 2));
     }
 
     #endregion
 
     #region SaveCursor — additional tests
 
-    [Fact]
+    [TestMethod]
     public void SaveCursor_Basic()
     {
         // Ghostty: "Terminal: saveCursor"
@@ -658,8 +658,8 @@ public class GhosttyMarginScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b7"); // saveCursor
         GhosttyTestFixture.Feed(t, "\u001b[2;3H"); // move cursor
         GhosttyTestFixture.Feed(t, "\u001b8"); // restoreCursor
-        Assert.Equal(5, t.CursorX); // cursor was at col 5 before save
-        Assert.Equal(0, t.CursorY);
+        Assert.AreEqual(5, t.CursorX); // cursor was at col 5 before save
+        Assert.AreEqual(0, t.CursorY);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyMiscConformance2Tests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyMiscConformance2Tests.cs
@@ -1,6 +1,5 @@
 using System;
 using Hex1b;
-using Xunit;
 
 namespace Hex1b.Tests.Conformance.Ghostty;
 
@@ -9,7 +8,8 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// LNM mode, zero-width characters, wide char at right margin with DECLRMM,
 /// bold style application, and basic LF+CR interaction.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyMiscConformance2Tests
 {
     private static Hex1bTerminal CreateTerminal(int cols, int rows) => GhosttyTestFixture.CreateTerminal(cols, rows);
@@ -23,7 +23,7 @@ public class GhosttyMiscConformance2Tests
     /// Ghostty: "Terminal: linefeed mode automatic carriage return"
     /// When LNM (mode 20) is set, LF automatically performs CR.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void LinefeedMode_AutomaticCarriageReturn()
     {
         using var t = CreateTerminal(10, 10);
@@ -34,15 +34,15 @@ public class GhosttyMiscConformance2Tests
         Feed(t, "\n"); // LF — with LNM, should also do CR
         Feed(t, "X");
 
-        Assert.Equal("123456", GetLine(t, 0));
-        Assert.Equal("X", GetLine(t, 1));
+        Assert.AreEqual("123456", GetLine(t, 0));
+        Assert.AreEqual("X", GetLine(t, 1));
     }
 
     /// <summary>
     /// Ghostty: "Terminal: linefeed and carriage return"
     /// Basic test: print, CR, LF, print produces correct output.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void LinefeedAndCarriageReturn()
     {
         using var t = CreateTerminal(80, 80);
@@ -52,26 +52,26 @@ public class GhosttyMiscConformance2Tests
         Feed(t, "\n");     // LF
         Feed(t, "world");
 
-        Assert.Equal(1, t.CursorY);
-        Assert.Equal(5, t.CursorX);
-        Assert.Equal("hello", GetLine(t, 0));
-        Assert.Equal("world", GetLine(t, 1));
+        Assert.AreEqual(1, t.CursorY);
+        Assert.AreEqual(5, t.CursorX);
+        Assert.AreEqual("hello", GetLine(t, 0));
+        Assert.AreEqual("world", GetLine(t, 1));
     }
 
     /// <summary>
     /// Ghostty: "Terminal: linefeed unsets pending wrap"
     /// LF clears pending wrap state.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Linefeed_UnsetsPendingWrap()
     {
         using var t = CreateTerminal(5, 80);
 
         Feed(t, "hello"); // Fills 5 cols, sets pending wrap
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
 
         Feed(t, "\n"); // LF should clear pending wrap
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
     }
 
     #endregion
@@ -82,7 +82,7 @@ public class GhosttyMiscConformance2Tests
     /// Ghostty: "Terminal: zero-width character at start"
     /// A zero-width character (ZWJ) at position 0,0 should be ignored, not crash.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void ZeroWidth_CharacterAtStart()
     {
         using var t = CreateTerminal(80, 80);
@@ -90,8 +90,8 @@ public class GhosttyMiscConformance2Tests
         // ZWJ at start should be silently ignored
         Feed(t, "\u200D");
 
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(0, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(0, t.CursorX);
     }
 
     #endregion
@@ -103,7 +103,7 @@ public class GhosttyMiscConformance2Tests
     /// With DECLRMM active and right margin set, a wide char at the right margin
     /// should wrap to left margin on next row without creating a spacer head.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void WideChar_AtRightMargin_NoSpacerHead_WithDECLRMM()
     {
         using var t = CreateTerminal(10, 10);
@@ -115,16 +115,15 @@ public class GhosttyMiscConformance2Tests
         Feed(t, "\U0001F600");    // Smiley face (wide char) — doesn't fit at col 5
 
         // Should have wrapped to next row, at left margin + 2 (after wide char)
-        Assert.Equal(1, t.CursorY);
+        Assert.AreEqual(1, t.CursorY);
 
         // Col 4 (0-based) on row 0 should be empty (no spacer head)
         var cell = GetCell(t, 0, 4);
-        Assert.True(string.IsNullOrWhiteSpace(cell.Character),
-            $"Expected empty cell at [0,4] but got '{cell.Character}'");
+        Assert.IsTrue(string.IsNullOrWhiteSpace(cell.Character), $"Expected empty cell at [0,4] but got '{cell.Character}'");
 
         // Wide char should be on row 1 at left margin (col 2, 0-based)
         var wideCell = GetCell(t, 1, 2);
-        Assert.Equal("\U0001F600", wideCell.Character);
+        Assert.AreEqual("\U0001F600", wideCell.Character);
     }
 
     #endregion
@@ -135,7 +134,7 @@ public class GhosttyMiscConformance2Tests
     /// Ghostty: "Terminal: bold style"
     /// Printing with bold SGR attribute marks the cell with Bold attribute.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void BoldStyle_AppliedToCell()
     {
         using var t = CreateTerminal(5, 5);
@@ -144,14 +143,14 @@ public class GhosttyMiscConformance2Tests
         Feed(t, "A");
 
         var cell = GetCell(t, 0, 0);
-        Assert.Equal("A", cell.Character);
-        Assert.True(cell.Attributes.HasFlag(CellAttributes.Bold));
+        Assert.AreEqual("A", cell.Character);
+        Assert.IsTrue(cell.Attributes.HasFlag(CellAttributes.Bold));
     }
 
     /// <summary>
     /// Printing with bold then reset — second char should not be bold.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void BoldStyle_ResetClearsAttribute()
     {
         using var t = CreateTerminal(5, 5);
@@ -162,10 +161,10 @@ public class GhosttyMiscConformance2Tests
         Feed(t, "B");
 
         var boldCell = GetCell(t, 0, 0);
-        Assert.True(boldCell.Attributes.HasFlag(CellAttributes.Bold));
+        Assert.IsTrue(boldCell.Attributes.HasFlag(CellAttributes.Bold));
 
         var normalCell = GetCell(t, 0, 1);
-        Assert.False(normalCell.Attributes.HasFlag(CellAttributes.Bold));
+        Assert.IsFalse(normalCell.Attributes.HasFlag(CellAttributes.Bold));
     }
 
     #endregion
@@ -176,23 +175,23 @@ public class GhosttyMiscConformance2Tests
     /// Ghostty: "Terminal: carriage return unsets pending wrap"
     /// CR clears pending wrap state.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void CarriageReturn_UnsetsPendingWrap()
     {
         using var t = CreateTerminal(5, 80);
 
         Feed(t, "hello"); // Fills 5 cols, sets pending wrap
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
 
         Feed(t, "\r"); // CR should clear pending wrap
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
     }
 
     /// <summary>
     /// Ghostty: "Terminal: carriage return origin mode moves to left margin"
     /// With origin mode enabled, CR moves to the left margin.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void CarriageReturn_OriginMode_MovesToLeftMargin()
     {
         using var t = CreateTerminal(5, 80);
@@ -204,14 +203,14 @@ public class GhosttyMiscConformance2Tests
 
         // In origin mode, cursor should be at left margin
         Feed(t, "\r");
-        Assert.Equal(2, t.CursorX); // 0-based: left margin is col 2
+        Assert.AreEqual(2, t.CursorX); // 0-based: left margin is col 2
     }
 
     /// <summary>
     /// Ghostty: "Terminal: carriage return left of left margin moves to zero"
     /// When cursor is left of the left margin, CR moves to column 0 (not the margin).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void CarriageReturn_LeftOfLeftMargin_MovesToZero()
     {
         using var t = CreateTerminal(5, 80);
@@ -223,14 +222,14 @@ public class GhosttyMiscConformance2Tests
         Feed(t, "\x1b[1;2H");     // Move to row 1, col 2 (left of margin, 1-based)
 
         Feed(t, "\r");
-        Assert.Equal(0, t.CursorX); // Should go to col 0, not margin
+        Assert.AreEqual(0, t.CursorX); // Should go to col 0, not margin
     }
 
     /// <summary>
     /// Ghostty: "Terminal: carriage return right of left margin moves to left margin"
     /// When cursor is right of (or at) the left margin, CR moves to left margin.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void CarriageReturn_RightOfLeftMargin_MovesToLeftMargin()
     {
         using var t = CreateTerminal(5, 80);
@@ -240,7 +239,7 @@ public class GhosttyMiscConformance2Tests
         Feed(t, "\x1b[1;4H");     // Move to row 1, col 4 (right of left margin, 1-based)
 
         Feed(t, "\r");
-        Assert.Equal(2, t.CursorX); // Should go to left margin (col 2, 0-based)
+        Assert.AreEqual(2, t.CursorX); // Should go to left margin (col 2, 0-based)
     }
 
     #endregion
@@ -251,7 +250,7 @@ public class GhosttyMiscConformance2Tests
     /// Ghostty: "Terminal: print right margin wrap"
     /// With DECLRMM, printing past right margin wraps to left margin on next row.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void PrintRightMarginWrap_NoSoftWrap()
     {
         using var t = CreateTerminal(10, 5);
@@ -262,12 +261,12 @@ public class GhosttyMiscConformance2Tests
         Feed(t, "\x1b[1;5H");     // Move to row 1, col 5 (right margin)
         Feed(t, "XY");            // X at col 5 (right margin), Y wraps to next row
 
-        Assert.Equal("1234X6789", GetLine(t, 0));
-        Assert.Equal("  Y", GetLine(t, 1));
+        Assert.AreEqual("1234X6789", GetLine(t, 0));
+        Assert.AreEqual("  Y", GetLine(t, 1));
 
         // Row 0 should NOT have soft wrap flag
         var cell = GetCell(t, 0, 9);
-        Assert.False(cell.Attributes.HasFlag(CellAttributes.SoftWrap));
+        Assert.IsFalse(cell.Attributes.HasFlag(CellAttributes.SoftWrap));
     }
 
     #endregion
@@ -278,17 +277,17 @@ public class GhosttyMiscConformance2Tests
     /// Ghostty: "Terminal: soft wrap"
     /// Writing beyond the terminal width wraps to the next line.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void SoftWrap_Basic()
     {
         using var t = CreateTerminal(3, 80);
 
         Feed(t, "hello"); // 5 chars in 3-col terminal
-        Assert.Equal(1, t.CursorY);
-        Assert.Equal(2, t.CursorX); // After 'o' on second row
+        Assert.AreEqual(1, t.CursorY);
+        Assert.AreEqual(2, t.CursorX); // After 'o' on second row
 
-        Assert.Equal("hel", GetLine(t, 0));
-        Assert.Equal("lo", GetLine(t, 1));
+        Assert.AreEqual("hel", GetLine(t, 0));
+        Assert.AreEqual("lo", GetLine(t, 1));
     }
 
     #endregion
@@ -299,7 +298,7 @@ public class GhosttyMiscConformance2Tests
     /// Ghostty: "Terminal: disabled wraparound with wide char and no space"
     /// With wraparound disabled, wide char at last col with existing content is not printed.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void DisabledWraparound_WideChar_NoSpace()
     {
         using var t = CreateTerminal(5, 5);
@@ -308,13 +307,13 @@ public class GhosttyMiscConformance2Tests
         Feed(t, "AAAAA");    // Fill all 5 cols
         Feed(t, "\U0001F6A8"); // Police car light (wide) — no space
 
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(4, t.CursorX);
-        Assert.Equal("AAAAA", GetLine(t, 0));
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(4, t.CursorX);
+        Assert.AreEqual("AAAAA", GetLine(t, 0));
 
         // Last cell should still be 'A' — wide char was not printed
         var cell = GetCell(t, 0, 4);
-        Assert.Equal("A", cell.Character);
+        Assert.AreEqual("A", cell.Character);
     }
 
     /// <summary>
@@ -322,7 +321,7 @@ public class GhosttyMiscConformance2Tests
     /// With wraparound disabled, wide char at second-to-last col (1 space left)
     /// is not printed because it needs 2 columns.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void DisabledWraparound_WideChar_OneSpace()
     {
         using var t = CreateTerminal(5, 5);
@@ -331,13 +330,12 @@ public class GhosttyMiscConformance2Tests
         Feed(t, "AAAA");     // Fill 4 cols, cursor at col 4
         Feed(t, "\U0001F6A8"); // Police car light (wide) — only 1 space left
 
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(4, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(4, t.CursorX);
 
         // The wide char should NOT have been printed — cell should remain empty
         var cell = GetCell(t, 0, 4);
-        Assert.True(string.IsNullOrWhiteSpace(cell.Character),
-            $"Expected empty cell at [0,4] but got '{cell.Character}'");
+        Assert.IsTrue(string.IsNullOrWhiteSpace(cell.Character), $"Expected empty cell at [0,4] but got '{cell.Character}'");
     }
 
     /// <summary>
@@ -345,7 +343,7 @@ public class GhosttyMiscConformance2Tests
     /// With wraparound disabled and mode 2027, a VS16 widening at the edge
     /// should leave the narrow char as-is since there's no room for wide.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void DisabledWraparound_WideGrapheme_HalfSpace()
     {
         using var t = CreateTerminal(5, 5);
@@ -356,11 +354,11 @@ public class GhosttyMiscConformance2Tests
         Feed(t, "\u2764");      // Heart (narrow by default)
         Feed(t, "\uFE0F");      // VS16 — try to make wide, but no room
 
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(4, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(4, t.CursorX);
 
         // Heart should remain narrow since VS16 widening has no room
-        Assert.Equal("AAAA❤", GetLine(t, 0));
+        Assert.AreEqual("AAAA❤", GetLine(t, 0));
     }
 
     #endregion
@@ -371,7 +369,7 @@ public class GhosttyMiscConformance2Tests
     /// Ghostty: "Terminal: print single very long line"
     /// Printing a very long line (1000 chars) should not crash.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void PrintSingleVeryLongLine_DoesNotCrash()
     {
         using var t = CreateTerminal(5, 5);
@@ -380,7 +378,7 @@ public class GhosttyMiscConformance2Tests
         Feed(t, new string('x', 1000));
 
         // If we got here without exception, the test passes
-        Assert.True(true);
+        Assert.IsTrue(true);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyMiscConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyMiscConformanceTests.cs
@@ -1,6 +1,5 @@
 using System;
 using Hex1b;
-using Xunit;
 
 namespace Hex1b.Tests.Conformance.Ghostty;
 
@@ -9,7 +8,8 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// deleteLines with margins, insertLines extras, print wrapping with L/R margins,
 /// linefeed mode, insertLines/deleteLines bg color preservation.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyMiscConformanceTests
 {
     private static Hex1bTerminal CreateTerminal(int cols, int rows) => GhosttyTestFixture.CreateTerminal(cols, rows);
@@ -20,7 +20,7 @@ public class GhosttyMiscConformanceTests
     #region deleteLines with L/R scroll region
 
     // Ghostty: test "Terminal: deleteLines left/right scroll region"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_LeftRightScrollRegion()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 10);
@@ -30,13 +30,13 @@ public class GhosttyMiscConformanceTests
         Feed(terminal, "\x1b[2;2H"); // CUP(2,2)
         Feed(terminal, "\x1b[1M"); // DL(1)
 
-        Assert.Equal("ABC123", GetLine(terminal, 0));
-        Assert.Equal("DHI756", GetLine(terminal, 1));
-        Assert.Equal("G   89", GetLine(terminal, 2));
+        Assert.AreEqual("ABC123", GetLine(terminal, 0));
+        Assert.AreEqual("DHI756", GetLine(terminal, 1));
+        Assert.AreEqual("G   89", GetLine(terminal, 2));
     }
 
     // Ghostty: test "Terminal: deleteLines left/right scroll region from top"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_LeftRightScrollRegion_FromTop()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 10);
@@ -46,13 +46,13 @@ public class GhosttyMiscConformanceTests
         Feed(terminal, "\x1b[1;2H"); // CUP(1,2)
         Feed(terminal, "\x1b[1M"); // DL(1)
 
-        Assert.Equal("AEF423", GetLine(terminal, 0));
-        Assert.Equal("DHI756", GetLine(terminal, 1));
-        Assert.Equal("G   89", GetLine(terminal, 2));
+        Assert.AreEqual("AEF423", GetLine(terminal, 0));
+        Assert.AreEqual("DHI756", GetLine(terminal, 1));
+        Assert.AreEqual("G   89", GetLine(terminal, 2));
     }
 
     // Ghostty: test "Terminal: deleteLines left/right scroll region high count"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_LeftRightScrollRegion_HighCount()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 10);
@@ -62,13 +62,13 @@ public class GhosttyMiscConformanceTests
         Feed(terminal, "\x1b[2;2H"); // CUP(2,2)
         Feed(terminal, "\x1b[100M"); // DL(100)
 
-        Assert.Equal("ABC123", GetLine(terminal, 0));
-        Assert.Equal("D   56", GetLine(terminal, 1));
-        Assert.Equal("G   89", GetLine(terminal, 2));
+        Assert.AreEqual("ABC123", GetLine(terminal, 0));
+        Assert.AreEqual("D   56", GetLine(terminal, 1));
+        Assert.AreEqual("G   89", GetLine(terminal, 2));
     }
 
     // Ghostty: test "Terminal: deleteLines with scroll region, cursor outside of region"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_CursorOutsideScrollRegion()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
@@ -77,10 +77,10 @@ public class GhosttyMiscConformanceTests
         Feed(terminal, "\x1b[4;1H"); // CUP(4,1) → outside scroll region
         Feed(terminal, "\x1b[1M"); // DL(1) — no-op since outside region
 
-        Assert.Equal("A", GetLine(terminal, 0));
-        Assert.Equal("B", GetLine(terminal, 1));
-        Assert.Equal("C", GetLine(terminal, 2));
-        Assert.Equal("D", GetLine(terminal, 3));
+        Assert.AreEqual("A", GetLine(terminal, 0));
+        Assert.AreEqual("B", GetLine(terminal, 1));
+        Assert.AreEqual("C", GetLine(terminal, 2));
+        Assert.AreEqual("D", GetLine(terminal, 3));
     }
 
     #endregion
@@ -88,7 +88,7 @@ public class GhosttyMiscConformanceTests
     #region insertLines extras
 
     // Ghostty: test "Terminal: insertLines outside of scroll region"
-    [Fact]
+    [TestMethod]
     public void InsertLines_OutsideScrollRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -97,13 +97,13 @@ public class GhosttyMiscConformanceTests
         Feed(terminal, "\x1b[2;2H"); // CUP(2,2) → row 1 (outside region)
         Feed(terminal, "\x1b[1L"); // IL(1) — no-op since outside
 
-        Assert.Equal("ABC", GetLine(terminal, 0));
-        Assert.Equal("DEF", GetLine(terminal, 1));
-        Assert.Equal("GHI", GetLine(terminal, 2));
+        Assert.AreEqual("ABC", GetLine(terminal, 0));
+        Assert.AreEqual("DEF", GetLine(terminal, 1));
+        Assert.AreEqual("GHI", GetLine(terminal, 2));
     }
 
     // Ghostty: test "Terminal: insertLines top/bottom scroll region"
-    [Fact]
+    [TestMethod]
     public void InsertLines_TopBottomScrollRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -112,14 +112,14 @@ public class GhosttyMiscConformanceTests
         Feed(terminal, "\x1b[2;2H"); // CUP(2,2)
         Feed(terminal, "\x1b[1L"); // IL(1)
 
-        Assert.Equal("ABC", GetLine(terminal, 0));
-        Assert.Equal("", GetLine(terminal, 1));
-        Assert.Equal("DEF", GetLine(terminal, 2));
-        Assert.Equal("123", GetLine(terminal, 3));
+        Assert.AreEqual("ABC", GetLine(terminal, 0));
+        Assert.AreEqual("", GetLine(terminal, 1));
+        Assert.AreEqual("DEF", GetLine(terminal, 2));
+        Assert.AreEqual("123", GetLine(terminal, 3));
     }
 
     // Ghostty: test "Terminal: insertLines colors with bg color"
-    [Fact]
+    [TestMethod]
     public void InsertLines_ColorsWithBgColor()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -128,22 +128,22 @@ public class GhosttyMiscConformanceTests
         Feed(terminal, "\x1b[48;2;255;0;0m"); // Set bg to red
         Feed(terminal, "\x1b[1L"); // IL(1)
 
-        Assert.Equal("ABC", GetLine(terminal, 0));
-        Assert.Equal("", GetLine(terminal, 1));
-        Assert.Equal("DEF", GetLine(terminal, 2));
-        Assert.Equal("GHI", GetLine(terminal, 3));
+        Assert.AreEqual("ABC", GetLine(terminal, 0));
+        Assert.AreEqual("", GetLine(terminal, 1));
+        Assert.AreEqual("DEF", GetLine(terminal, 2));
+        Assert.AreEqual("GHI", GetLine(terminal, 3));
 
         // Verify the inserted blank line has the bg color
         var cell = GetCell(terminal, 1, 0);
-        Assert.NotNull(cell.Background);
+        Assert.IsNotNull(cell.Background);
         var bg = cell.Background!.Value;
-        Assert.Equal((byte)255, bg.R);
-        Assert.Equal((byte)0, bg.G);
-        Assert.Equal((byte)0, bg.B);
+        Assert.AreEqual((byte)255, bg.R);
+        Assert.AreEqual((byte)0, bg.G);
+        Assert.AreEqual((byte)0, bg.B);
     }
 
     // Ghostty: test "Terminal: deleteLines colors with bg color"
-    [Fact]
+    [TestMethod]
     public void DeleteLines_ColorsWithBgColor()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -152,16 +152,16 @@ public class GhosttyMiscConformanceTests
         Feed(terminal, "\x1b[48;2;255;0;0m"); // Set bg to red
         Feed(terminal, "\x1b[1M"); // DL(1)
 
-        Assert.Equal("ABC", GetLine(terminal, 0));
-        Assert.Equal("GHI", GetLine(terminal, 1));
+        Assert.AreEqual("ABC", GetLine(terminal, 0));
+        Assert.AreEqual("GHI", GetLine(terminal, 1));
 
         // Verify the newly blank bottom line has the bg color
         var cell = GetCell(terminal, 4, 0);
-        Assert.NotNull(cell.Background);
+        Assert.IsNotNull(cell.Background);
         var bg = cell.Background!.Value;
-        Assert.Equal((byte)255, bg.R);
-        Assert.Equal((byte)0, bg.G);
-        Assert.Equal((byte)0, bg.B);
+        Assert.AreEqual((byte)255, bg.R);
+        Assert.AreEqual((byte)0, bg.G);
+        Assert.AreEqual((byte)0, bg.B);
     }
 
     #endregion
@@ -169,7 +169,7 @@ public class GhosttyMiscConformanceTests
     #region Print wrapping with L/R margins
 
     // Ghostty: test "Terminal: print right margin wrap"
-    [Fact]
+    [TestMethod]
     public void Print_RightMarginWrap()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -179,12 +179,12 @@ public class GhosttyMiscConformanceTests
         Feed(terminal, "\x1b[1;5H"); // CUP(1,5) → col 4 (right margin)
         Feed(terminal, "XY"); // X at col 4, Y wraps to col 2 of row 1
 
-        Assert.Equal("1234X6789", GetLine(terminal, 0));
-        Assert.Equal("  Y", GetLine(terminal, 1));
+        Assert.AreEqual("1234X6789", GetLine(terminal, 0));
+        Assert.AreEqual("  Y", GetLine(terminal, 1));
     }
 
     // Ghostty: test "Terminal: print right margin outside"
-    [Fact]
+    [TestMethod]
     public void Print_RightMarginOutside()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -194,11 +194,11 @@ public class GhosttyMiscConformanceTests
         Feed(terminal, "\x1b[1;6H"); // CUP(1,6) → col 5 (outside right margin)
         Feed(terminal, "XY");
 
-        Assert.Equal("12345XY89", GetLine(terminal, 0));
+        Assert.AreEqual("12345XY89", GetLine(terminal, 0));
     }
 
     // Ghostty: test "Terminal: print right margin outside wrap"
-    [Fact]
+    [TestMethod]
     public void Print_RightMarginOutsideWrap()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -208,8 +208,8 @@ public class GhosttyMiscConformanceTests
         Feed(terminal, "\x1b[1;10H"); // CUP(1,10) → col 9 (far right, outside margin)
         Feed(terminal, "XY"); // X at col 9, Y wraps to left margin col 2
 
-        Assert.Equal("123456789X", GetLine(terminal, 0));
-        Assert.Equal("  Y", GetLine(terminal, 1));
+        Assert.AreEqual("123456789X", GetLine(terminal, 0));
+        Assert.AreEqual("  Y", GetLine(terminal, 1));
     }
 
     #endregion
@@ -217,20 +217,20 @@ public class GhosttyMiscConformanceTests
     #region Linefeed behavior
 
     // Ghostty: test "Terminal: linefeed and carriage return"
-    [Fact]
+    [TestMethod]
     public void Linefeed_AndCarriageReturn()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
         Feed(terminal, "hello\r\nworld");
 
-        Assert.Equal(1, terminal.CursorY);
-        Assert.Equal(5, terminal.CursorX);
-        Assert.Equal("hello", GetLine(terminal, 0));
-        Assert.Equal("world", GetLine(terminal, 1));
+        Assert.AreEqual(1, terminal.CursorY);
+        Assert.AreEqual(5, terminal.CursorX);
+        Assert.AreEqual("hello", GetLine(terminal, 0));
+        Assert.AreEqual("world", GetLine(terminal, 1));
     }
 
     // Ghostty: test "Terminal: linefeed mode automatic carriage return"
-    [Fact]
+    [TestMethod]
     public void Linefeed_AutomaticCarriageReturn()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 10);
@@ -239,12 +239,12 @@ public class GhosttyMiscConformanceTests
         Feed(terminal, "\n"); // LF — in LNM, this also does CR
         Feed(terminal, "X");
 
-        Assert.Equal("123456", GetLine(terminal, 0));
-        Assert.Equal("X", GetLine(terminal, 1));
+        Assert.AreEqual("123456", GetLine(terminal, 0));
+        Assert.AreEqual("X", GetLine(terminal, 1));
     }
 
     // Ghostty: test "Terminal: carriage return origin mode moves to left margin"
-    [Fact]
+    [TestMethod]
     public void CarriageReturn_OriginMode_MovesToLeftMargin_Direct()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 80);
@@ -254,7 +254,7 @@ public class GhosttyMiscConformanceTests
         Feed(terminal, "\x1b[1;1H"); // CUP — goes to origin (margin left=2)
         Feed(terminal, "\r"); // CR — should go to left margin
 
-        Assert.Equal(2, terminal.CursorX);
+        Assert.AreEqual(2, terminal.CursorX);
     }
 
     #endregion
@@ -262,25 +262,25 @@ public class GhosttyMiscConformanceTests
     #region Backspace
 
     // Ghostty: test "Terminal: backspace"
-    [Fact]
+    [TestMethod]
     public void Backspace_Basic()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
         Feed(terminal, "A\b");
 
-        Assert.Equal(0, terminal.CursorX);
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
     }
 
     // Ghostty: test "Terminal: backspace at left margin"
-    [Fact]
+    [TestMethod]
     public void Backspace_AtLeftMargin()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
         Feed(terminal, "\b"); // Backspace at col 0 — should be no-op
 
-        Assert.Equal(0, terminal.CursorX);
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
     }
 
     #endregion
@@ -288,7 +288,7 @@ public class GhosttyMiscConformanceTests
     #region Additional index/scroll behavior
 
     // Ghostty: test "Terminal: index bottom of primary screen background sgr"
-    [Fact]
+    [TestMethod]
     public void Index_BottomOfScreen_BackgroundSgr()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -297,25 +297,25 @@ public class GhosttyMiscConformanceTests
         Feed(terminal, "\x1b[48;2;255;0;0m"); // Set bg to red
         Feed(terminal, "\u001bD"); // IND — scrolls, new blank line has bg color
 
-        Assert.Equal("", GetLine(terminal, 0));
-        Assert.Equal("", GetLine(terminal, 1));
-        Assert.Equal("", GetLine(terminal, 2));
-        Assert.Equal("A", GetLine(terminal, 3));
+        Assert.AreEqual("", GetLine(terminal, 0));
+        Assert.AreEqual("", GetLine(terminal, 1));
+        Assert.AreEqual("", GetLine(terminal, 2));
+        Assert.AreEqual("A", GetLine(terminal, 3));
 
         // Verify the new blank bottom line has red background
         var cell = GetCell(terminal, 4, 0);
-        Assert.NotNull(cell.Background);
+        Assert.IsNotNull(cell.Background);
         var bg = cell.Background!.Value;
-        Assert.Equal((byte)255, bg.R);
-        Assert.Equal((byte)0, bg.G);
-        Assert.Equal((byte)0, bg.B);
+        Assert.AreEqual((byte)255, bg.R);
+        Assert.AreEqual((byte)0, bg.G);
+        Assert.AreEqual((byte)0, bg.B);
     }
 
     // Ghostty: test "Terminal: scrollUp preserves pending wrap" (from scrollUp tests)
     // Already covered in GhosttyScrollMarginConformanceTests — verify cursor positioning
     
     // Ghostty: test "Terminal: input that forces scroll"
-    [Fact]
+    [TestMethod]
     public void Input_ForcesScroll()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 5);
@@ -324,11 +324,11 @@ public class GhosttyMiscConformanceTests
         // Now print another char which forces scroll
         Feed(terminal, "\r\n6");
 
-        Assert.Equal("2", GetLine(terminal, 0));
-        Assert.Equal("3", GetLine(terminal, 1));
-        Assert.Equal("4", GetLine(terminal, 2));
-        Assert.Equal("5", GetLine(terminal, 3));
-        Assert.Equal("6", GetLine(terminal, 4));
+        Assert.AreEqual("2", GetLine(terminal, 0));
+        Assert.AreEqual("3", GetLine(terminal, 1));
+        Assert.AreEqual("4", GetLine(terminal, 2));
+        Assert.AreEqual("5", GetLine(terminal, 3));
+        Assert.AreEqual("6", GetLine(terminal, 4));
     }
 
     #endregion
@@ -336,7 +336,7 @@ public class GhosttyMiscConformanceTests
     #region setTopAndBottomMargin extras
 
     // Ghostty: test "Terminal: setTopAndBottomMargin top only"
-    [Fact]
+    [TestMethod]
     public void SetTopAndBottomMargin_TopOnly()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -345,14 +345,14 @@ public class GhosttyMiscConformanceTests
         Feed(terminal, "\x1b[2;1H"); // CUP(2,1)
         Feed(terminal, "\x1b[1L"); // IL(1) — within scroll region
 
-        Assert.Equal("ABC", GetLine(terminal, 0));
-        Assert.Equal("", GetLine(terminal, 1));
-        Assert.Equal("DEF", GetLine(terminal, 2));
-        Assert.Equal("GHI", GetLine(terminal, 3));
+        Assert.AreEqual("ABC", GetLine(terminal, 0));
+        Assert.AreEqual("", GetLine(terminal, 1));
+        Assert.AreEqual("DEF", GetLine(terminal, 2));
+        Assert.AreEqual("GHI", GetLine(terminal, 3));
     }
 
     // Ghostty: test "Terminal: setTopAndBottomMargin top and bottom"
-    [Fact]
+    [TestMethod]
     public void SetTopAndBottomMargin_TopAndBottom()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -361,14 +361,14 @@ public class GhosttyMiscConformanceTests
         Feed(terminal, "\x1b[2;1H"); // CUP(2,1)
         Feed(terminal, "\x1b[1L"); // IL(1)
 
-        Assert.Equal("ABC", GetLine(terminal, 0));
-        Assert.Equal("", GetLine(terminal, 1));
-        Assert.Equal("DEF", GetLine(terminal, 2));
-        Assert.Equal("123", GetLine(terminal, 3));
+        Assert.AreEqual("ABC", GetLine(terminal, 0));
+        Assert.AreEqual("", GetLine(terminal, 1));
+        Assert.AreEqual("DEF", GetLine(terminal, 2));
+        Assert.AreEqual("123", GetLine(terminal, 3));
     }
 
     // Ghostty: test "Terminal: setTopAndBottomMargin top equal to bottom"
-    [Fact]
+    [TestMethod]
     public void SetTopAndBottomMargin_TopEqualBottom()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -378,10 +378,10 @@ public class GhosttyMiscConformanceTests
         Feed(terminal, "\x1b[1L"); // IL(1)
 
         // With top=bottom, DECSTBM should be treated as invalid → full height
-        Assert.Equal("ABC", GetLine(terminal, 0));
-        Assert.Equal("", GetLine(terminal, 1));
-        Assert.Equal("DEF", GetLine(terminal, 2));
-        Assert.Equal("GHI", GetLine(terminal, 3));
+        Assert.AreEqual("ABC", GetLine(terminal, 0));
+        Assert.AreEqual("", GetLine(terminal, 1));
+        Assert.AreEqual("DEF", GetLine(terminal, 2));
+        Assert.AreEqual("GHI", GetLine(terminal, 3));
     }
 
     #endregion
@@ -389,25 +389,25 @@ public class GhosttyMiscConformanceTests
     #region Print wrapping edge cases
 
     // Ghostty: test "Terminal: printRepeat wrap"
-    [Fact]
+    [TestMethod]
     public void PrintRepeat_Wrap()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
         Feed(terminal, "    A");
         Feed(terminal, "\x1b[b"); // REP(1) — repeat last char
 
-        Assert.Equal("    A", GetLine(terminal, 0));
-        Assert.Equal("A", GetLine(terminal, 1));
+        Assert.AreEqual("    A", GetLine(terminal, 0));
+        Assert.AreEqual("A", GetLine(terminal, 1));
     }
 
     // Ghostty: test "Terminal: printRepeat no previous character"
-    [Fact]
+    [TestMethod]
     public void PrintRepeat_NoPreviousCharacter()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
         Feed(terminal, "\x1b[b"); // REP(1) — no previous char, should be no-op
 
-        Assert.Equal("", GetLine(terminal, 0));
+        Assert.AreEqual("", GetLine(terminal, 0));
     }
 
     #endregion

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyMovementConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyMovementConformanceTests.cs
@@ -1,4 +1,3 @@
-using Xunit;
 
 namespace Hex1b.Tests.Conformance.Ghostty;
 
@@ -6,26 +5,27 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// Tests for cursor movement conformance.
 /// Translated from Ghostty's Terminal.zig cursor tests.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyMovementConformanceTests
 {
     // ═══════════════════════════════════════════════════════════════
     // Carriage Return
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void CarriageReturn_UnsetsPendingWrap()
     {
         // Ghostty: "Terminal: carriage return unsets pending wrap"
         var t = GhosttyTestFixture.CreateTerminal(5, 80);
 
         GhosttyTestFixture.Feed(t, "hello");
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "\r");
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
     }
 
-    [Fact]
+    [TestMethod]
     public void CarriageReturn_OriginMode_MovesToLeftMargin()
     {
         // Ghostty: "Terminal: carriage return origin mode moves to left margin"
@@ -38,10 +38,10 @@ public class GhosttyMovementConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[?6h");        // Enable origin mode
         GhosttyTestFixture.Feed(t, "\u001b[1;1H");       // Move to origin (which is now at left margin)
         GhosttyTestFixture.Feed(t, "\r");
-        Assert.Equal(2, t.CursorX); // Left margin at column 2 (0-based)
+        Assert.AreEqual(2, t.CursorX); // Left margin at column 2 (0-based)
     }
 
-    [Fact]
+    [TestMethod]
     public void CarriageReturn_LeftOfLeftMargin_MovesToZero()
     {
         // Ghostty: "Terminal: carriage return left of left margin moves to zero"
@@ -53,10 +53,10 @@ public class GhosttyMovementConformanceTests
         // Cursor starts at 0, which is left of margin (2)
         GhosttyTestFixture.Feed(t, "\u001b[1;2H");       // Move to col 2 (0-based: 1), left of margin
         GhosttyTestFixture.Feed(t, "\r");
-        Assert.Equal(0, t.CursorX);
+        Assert.AreEqual(0, t.CursorX);
     }
 
-    [Fact]
+    [TestMethod]
     public void CarriageReturn_RightOfLeftMargin_MovesToLeftMargin()
     {
         // Ghostty: "Terminal: carriage return right of left margin moves to left margin"
@@ -67,14 +67,14 @@ public class GhosttyMovementConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[3;5s");       // Set left=3, right=5
         GhosttyTestFixture.Feed(t, "\u001b[1;4H");       // Move to col 4 (0-based: 3), right of margin
         GhosttyTestFixture.Feed(t, "\r");
-        Assert.Equal(2, t.CursorX); // Left margin at column 2 (0-based)
+        Assert.AreEqual(2, t.CursorX); // Left margin at column 2 (0-based)
     }
 
     // ═══════════════════════════════════════════════════════════════
     // Backspace
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void Backspace_Basic()
     {
         // Ghostty: "Terminal: backspace"
@@ -83,31 +83,31 @@ public class GhosttyMovementConformanceTests
         GhosttyTestFixture.Feed(t, "hello");
         GhosttyTestFixture.Feed(t, "\b"); // BS
         GhosttyTestFixture.Feed(t, "y");
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(5, t.CursorX);
-        Assert.Equal("helly", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(5, t.CursorX);
+        Assert.AreEqual("helly", GhosttyTestFixture.GetLine(t, 0));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // cursorPos (CUP — CSI H)
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void CursorPos_ResetsWrap()
     {
         // Ghostty: "Terminal: cursorPos resets wrap"
         var t = GhosttyTestFixture.CreateTerminal(5, 5);
 
         GhosttyTestFixture.Feed(t, "ABCDE");
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "\u001b[1;1H");
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("XBCDE", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("XBCDE", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorPos_OffTheScreen()
     {
         // Ghostty: "Terminal: cursorPos off the screen"
@@ -116,14 +116,14 @@ public class GhosttyMovementConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[500;500H");
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 3));
-        Assert.Equal("    X", GhosttyTestFixture.GetLine(t, 4));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("    X", GhosttyTestFixture.GetLine(t, 4));
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorPos_RelativeToOrigin()
     {
         // Ghostty: "Terminal: cursorPos relative to origin"
@@ -134,12 +134,12 @@ public class GhosttyMovementConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H");  // CUP(1,1) — relative to origin
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("X", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("X", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorPos_RelativeToOriginWithLeftRight()
     {
         // Ghostty: "Terminal: cursorPos relative to origin with left/right"
@@ -152,12 +152,12 @@ public class GhosttyMovementConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H");    // CUP(1,1) — relative to origin
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("  X", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("  X", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorPos_LimitsWithFullScrollRegion()
     {
         // Ghostty: "Terminal: cursorPos limits with full scroll region"
@@ -170,44 +170,44 @@ public class GhosttyMovementConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[500;500H"); // CUP beyond limits
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("    X", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("    X", GhosttyTestFixture.GetLine(t, 3));
     }
 
-    [Fact]
+    [TestMethod]
     public void SetCursorPos_Original()
     {
         // Ghostty: "Terminal: setCursorPos (original test)"
         var t = GhosttyTestFixture.CreateTerminal(80, 80);
 
-        Assert.Equal(0, t.CursorX);
-        Assert.Equal(0, t.CursorY);
+        Assert.AreEqual(0, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
 
         // Setting to 0 should keep it at 0 (1-based, 0 treated as 1)
         GhosttyTestFixture.Feed(t, "\u001b[0;0H");
-        Assert.Equal(0, t.CursorX);
-        Assert.Equal(0, t.CursorY);
+        Assert.AreEqual(0, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
 
         // Should clamp to size
         GhosttyTestFixture.Feed(t, "\u001b[81;81H");
-        Assert.Equal(79, t.CursorX);
-        Assert.Equal(79, t.CursorY);
+        Assert.AreEqual(79, t.CursorX);
+        Assert.AreEqual(79, t.CursorY);
 
         // Should reset pending wrap
         GhosttyTestFixture.Feed(t, "\u001b[1;80H"); // Row 1, Col 80 (last col)
         GhosttyTestFixture.Feed(t, "c");
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "\u001b[1;80H");
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
     }
 
     // ═══════════════════════════════════════════════════════════════
     // cursorUp (CUU — CSI A)
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void CursorUp_Basic()
     {
         // Ghostty: "Terminal: cursorUp basic"
@@ -218,12 +218,12 @@ public class GhosttyMovementConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[10A");  // cursorUp(10)
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal(" X", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual(" X", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorUp_BelowTopScrollMargin()
     {
         // Ghostty: "Terminal: cursorUp below top scroll margin"
@@ -236,12 +236,12 @@ public class GhosttyMovementConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[5A");    // cursorUp(5) — clamps to top margin
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal(" X", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual(" X", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorUp_AboveTopScrollMargin()
     {
         // Ghostty: "Terminal: cursorUp above top scroll margin"
@@ -255,31 +255,31 @@ public class GhosttyMovementConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[10A");   // cursorUp(10)
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("X", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("X", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorUp_ResetsWrap()
     {
         // Ghostty: "Terminal: cursorUp resets wrap"
         var t = GhosttyTestFixture.CreateTerminal(5, 5);
 
         GhosttyTestFixture.Feed(t, "ABCDE");
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "\u001b[1A"); // cursorUp(1)
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("ABCDX", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("ABCDX", GhosttyTestFixture.GetLine(t, 0));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // cursorDown (CUD — CSI B)
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void CursorDown_Basic()
     {
         // Ghostty: "Terminal: cursorDown basic"
@@ -289,14 +289,14 @@ public class GhosttyMovementConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[10B"); // cursorDown(10)
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 3));
-        Assert.Equal(" X", GhosttyTestFixture.GetLine(t, 4));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual(" X", GhosttyTestFixture.GetLine(t, 4));
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorDown_AboveBottomScrollMargin()
     {
         // Ghostty: "Terminal: cursorDown above bottom scroll margin"
@@ -309,12 +309,12 @@ public class GhosttyMovementConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[10B");  // cursorDown(10)
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal(" X", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual(" X", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorDown_BelowBottomScrollMargin()
     {
         // Ghostty: "Terminal: cursorDown below bottom scroll margin"
@@ -328,34 +328,34 @@ public class GhosttyMovementConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[10B");  // cursorDown(10)
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 3));
-        Assert.Equal("X", GhosttyTestFixture.GetLine(t, 4));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("X", GhosttyTestFixture.GetLine(t, 4));
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorDown_ResetsWrap()
     {
         // Ghostty: "Terminal: cursorDown resets wrap"
         var t = GhosttyTestFixture.CreateTerminal(5, 5);
 
         GhosttyTestFixture.Feed(t, "ABCDE");
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "\u001b[1B"); // cursorDown(1)
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("ABCDE", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("    X", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("ABCDE", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("    X", GhosttyTestFixture.GetLine(t, 1));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // cursorLeft (CUB — CSI D) — non-reverse-wrap tests only
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void CursorLeft_NoWrap()
     {
         // Ghostty: "Terminal: cursorLeft no wrap"
@@ -366,60 +366,60 @@ public class GhosttyMovementConformanceTests
         GhosttyTestFixture.Feed(t, "B");
         GhosttyTestFixture.Feed(t, "\u001b[10D"); // cursorLeft(10)
 
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("B", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("B", GhosttyTestFixture.GetLine(t, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorLeft_UnsetsPendingWrapState()
     {
         // Ghostty: "Terminal: cursorLeft unsets pending wrap state"
         var t = GhosttyTestFixture.CreateTerminal(5, 5);
 
         GhosttyTestFixture.Feed(t, "ABCDE");
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "\u001b[1D"); // cursorLeft(1)
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("ABCXE", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("ABCXE", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorLeft_UnsetsPendingWrapStateWithLongerJump()
     {
         // Ghostty: "Terminal: cursorLeft unsets pending wrap state with longer jump"
         var t = GhosttyTestFixture.CreateTerminal(5, 5);
 
         GhosttyTestFixture.Feed(t, "ABCDE");
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "\u001b[3D"); // cursorLeft(3)
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("AXCDE", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("AXCDE", GhosttyTestFixture.GetLine(t, 0));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // cursorRight (CUF — CSI C)
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void CursorRight_ResetsWrap()
     {
         // Ghostty: "Terminal: cursorRight resets wrap"
         var t = GhosttyTestFixture.CreateTerminal(5, 5);
 
         GhosttyTestFixture.Feed(t, "ABCDE");
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "\u001b[1C"); // cursorRight(1)
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("ABCDX", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("ABCDX", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorRight_ToEdgeOfScreen()
     {
         // Ghostty: "Terminal: cursorRight to the edge of screen"
@@ -428,10 +428,10 @@ public class GhosttyMovementConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[100C"); // cursorRight(100)
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("    X", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("    X", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorRight_LeftOfRightMargin()
     {
         // Ghostty: "Terminal: cursorRight left of right margin"
@@ -443,10 +443,10 @@ public class GhosttyMovementConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[100C");    // cursorRight(100)
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("  X", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("  X", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorRight_RightOfRightMargin()
     {
         // Ghostty: "Terminal: cursorRight right of right margin"
@@ -459,6 +459,6 @@ public class GhosttyMovementConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[100C");    // cursorRight(100)
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("    X", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("    X", GhosttyTestFixture.GetLine(t, 0));
     }
 }

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyPrintOverwriteConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyPrintOverwriteConformanceTests.cs
@@ -1,4 +1,3 @@
-using Xunit;
 
 namespace Hex1b.Tests.Conformance.Ghostty;
 
@@ -6,7 +5,8 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// Conformance tests for print and overwrite operations,
 /// translated from Ghostty's Terminal.zig.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyPrintOverwriteConformanceTests
 {
     private static Hex1bTerminal CreateTerminal(int cols = 80, int rows = 24)
@@ -14,7 +14,7 @@ public class GhosttyPrintOverwriteConformanceTests
 
     #region Print Basics
 
-    [Fact]
+    [TestMethod]
     public void PrintSingleVeryLongLine_DoesNotCrash()
     {
         // Ghostty: "Terminal: print single very long line"
@@ -28,7 +28,7 @@ public class GhosttyPrintOverwriteConformanceTests
 
     #region Print Over Wide Characters
 
-    [Fact]
+    [TestMethod]
     public void PrintOverWideCharAtCol0_DoesNotCorruptPreviousRow()
     {
         // Ghostty: "Terminal: print over wide char at col 0 corrupts previous row"
@@ -45,23 +45,23 @@ public class GhosttyPrintOverwriteConformanceTests
 
         // Row 1, col 0 should be the narrow 'A'
         var cell10 = GhosttyTestFixture.GetCell(t, 1, 0);
-        Assert.Equal("A", cell10.Character);
+        Assert.AreEqual("A", cell10.Character);
 
         // Row 0, col 8 should still be wide (last wide char on the row)
         var cell08 = GhosttyTestFixture.GetCell(t, 0, 8);
-        Assert.Equal("中", cell08.Character);
+        Assert.AreEqual("中", cell08.Character);
 
         // Row 0, col 9 must remain spacer_tail (continuation cell)
         var cell09 = GhosttyTestFixture.GetCell(t, 0, 9);
-        Assert.Equal("", cell09.Character);
+        Assert.AreEqual("", cell09.Character);
     }
 
     #endregion
 
     #region Print Multicodepoint Grapheme
 
-    [Trait("FailureReason", "Bug")]
-    [Fact]
+    [TestCategory("FailureReason:Bug")]
+    [TestMethod]
     public void PrintMulticodepointGrapheme_DisabledMode2027_TreatedAsSeparateChars()
     {
         // Ghostty: "Terminal: print multicodepoint grapheme, disabled mode 2027"
@@ -75,8 +75,8 @@ public class GhosttyPrintOverwriteConformanceTests
         GhosttyTestFixture.Feed(t, "\U0001F468\u200D\U0001F469\u200D\U0001F467");
 
         // Without grapheme clustering, 3 wide chars × 2 cells = 6
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(6, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(6, t.CursorX);
 
         // First cell should have the first emoji (possibly with ZWJ appended)
         var cell = GhosttyTestFixture.GetCell(t, 0, 0);
@@ -87,7 +87,7 @@ public class GhosttyPrintOverwriteConformanceTests
 
     #region Overwrite Grapheme Data
 
-    [Fact]
+    [TestMethod]
     public void OverwriteGrapheme_ClearsGraphemeData()
     {
         // Ghostty: "Terminal: overwrite grapheme should clear grapheme data"
@@ -104,13 +104,13 @@ public class GhosttyPrintOverwriteConformanceTests
         GhosttyTestFixture.Feed(t, "A");
 
         var line = GhosttyTestFixture.GetLine(t, 0);
-        Assert.Equal("A", line);
+        Assert.AreEqual("A", line);
 
         var cell = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.Equal("A", cell.Character);
+        Assert.AreEqual("A", cell.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void OverwriteMulticodepointGrapheme_ClearsGraphemeData()
     {
         // Ghostty: "Terminal: overwrite multicodepoint grapheme clears grapheme data"
@@ -123,21 +123,21 @@ public class GhosttyPrintOverwriteConformanceTests
         GhosttyTestFixture.Feed(t, "\U0001F468\u200D\U0001F469\u200D\U0001F467");
 
         // With mode 2027, treated as single wide grapheme (2 cells)
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(2, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(2, t.CursorX);
 
         // Go back and overwrite
         GhosttyTestFixture.Feed(t, "\u001b[1;1H");
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(1, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(1, t.CursorX);
 
         var line = GhosttyTestFixture.GetLine(t, 0);
-        Assert.Equal("X", line);
+        Assert.AreEqual("X", line);
     }
 
-    [Fact]
+    [TestMethod]
     public void OverwriteMulticodepointGraphemeTail_ClearsGraphemeData()
     {
         // Ghostty: "Terminal: overwrite multicodepoint grapheme tail clears grapheme data"
@@ -149,26 +149,26 @@ public class GhosttyPrintOverwriteConformanceTests
         // Print family emoji: 👨‍👩‍👧
         GhosttyTestFixture.Feed(t, "\U0001F468\u200D\U0001F469\u200D\U0001F467");
 
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(2, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(2, t.CursorX);
 
         // Move to col 2 (1-based) = col 1 (0-based, the tail/spacer) and overwrite
         GhosttyTestFixture.Feed(t, "\u001b[1;2H");
         GhosttyTestFixture.Feed(t, "X");
 
         var line = GhosttyTestFixture.GetLine(t, 0);
-        Assert.Equal(" X", line);
+        Assert.AreEqual(" X", line);
 
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(2, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(2, t.CursorX);
     }
 
     #endregion
 
     #region Print Charset
 
-    [Trait("FailureReason", "Bug")]
-    [Fact]
+    [TestCategory("FailureReason:Bug")]
+    [TestMethod]
     public void PrintCharset_DecSpecialGraphics()
     {
         // Ghostty: "Terminal: print charset"
@@ -196,11 +196,11 @@ public class GhosttyPrintOverwriteConformanceTests
 
         // Expected: "```◆" — first three are literal backticks, fourth is diamond
         var line = GhosttyTestFixture.GetLine(t, 0);
-        Assert.Equal("```◆", line);
+        Assert.AreEqual("```◆", line);
     }
 
-    [Trait("FailureReason", "Bug")]
-    [Fact]
+    [TestCategory("FailureReason:Bug")]
+    [TestMethod]
     public void PrintCharset_OutsideAscii()
     {
         // Ghostty: "Terminal: print charset outside of ASCII"
@@ -220,7 +220,7 @@ public class GhosttyPrintOverwriteConformanceTests
 
         // Verify diamond at col 0
         var cell0 = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.Equal("◆", cell0.Character);
+        Assert.AreEqual("◆", cell0.Character);
 
         // Ghostty expects "◆ " — non-ASCII emoji in DEC special mode produces
         // a space. GetLine trims trailing spaces, so check trimmed result.
@@ -228,8 +228,8 @@ public class GhosttyPrintOverwriteConformanceTests
         Assert.StartsWith("◆", line);
     }
 
-    [Trait("FailureReason", "Bug")]
-    [Fact]
+    [TestCategory("FailureReason:Bug")]
+    [TestMethod]
     public void PrintInvokeCharset_ShiftInOut()
     {
         // Ghostty: "Terminal: print invoke charset"
@@ -256,14 +256,14 @@ public class GhosttyPrintOverwriteConformanceTests
 
         // Expected: "`◆◆`"
         var line = GhosttyTestFixture.GetLine(t, 0);
-        Assert.Equal("`\u25C6\u25C6`", line);
+        Assert.AreEqual("`\u25C6\u25C6`", line);
     }
 
     #endregion
 
     #region Print Right Margin
 
-    [Fact]
+    [TestMethod]
     public void PrintRightMarginWrap()
     {
         // Ghostty: "Terminal: print right margin wrap"
@@ -282,14 +282,14 @@ public class GhosttyPrintOverwriteConformanceTests
 
         // Row 0: X replaces col 4 (was '5'), rest unchanged
         var line0 = GhosttyTestFixture.GetLine(t, 0);
-        Assert.Equal("1234X6789", line0);
+        Assert.AreEqual("1234X6789", line0);
 
         // Y wraps within margin to next row at left margin (col 2, 0-based)
         var line1 = GhosttyTestFixture.GetLine(t, 1);
-        Assert.Equal("  Y", line1);
+        Assert.AreEqual("  Y", line1);
     }
 
-    [Fact]
+    [TestMethod]
     public void PrintRightMarginOutside()
     {
         // Ghostty: "Terminal: print right margin outside"
@@ -305,10 +305,10 @@ public class GhosttyPrintOverwriteConformanceTests
 
         // Printing outside margin doesn't trigger margin wrap
         var line0 = GhosttyTestFixture.GetLine(t, 0);
-        Assert.Equal("12345XY89", line0);
+        Assert.AreEqual("12345XY89", line0);
     }
 
-    [Fact]
+    [TestMethod]
     public void PrintRightMarginOutsideWrap()
     {
         // Ghostty: "Terminal: print right margin outside wrap"
@@ -324,11 +324,11 @@ public class GhosttyPrintOverwriteConformanceTests
 
         // X prints at col 9 (last column), then wraps
         var line0 = GhosttyTestFixture.GetLine(t, 0);
-        Assert.Equal("123456789X", line0);
+        Assert.AreEqual("123456789X", line0);
 
         // Y wraps to next row at left margin (col 2, 0-based)
         var line1 = GhosttyTestFixture.GetLine(t, 1);
-        Assert.Equal("  Y", line1);
+        Assert.AreEqual("  Y", line1);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyPrintWideEdgeCaseConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyPrintWideEdgeCaseConformanceTests.cs
@@ -7,14 +7,15 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// overwriting wide chars, spacer cells, and single-width terminals.
 /// Translated from Ghostty's Terminal.zig test suite.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyPrintWideEdgeCaseConformanceTests
 {
     // ═══════════════════════════════════════════════════════════════
     // Print wide char at edge
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void PrintWideCharAtEdge_CreatesSpacerAndWraps()
     {
         // Ghostty: "Terminal: print wide char at edge creates spacer head"
@@ -26,25 +27,23 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
         GhosttyTestFixture.Feed(t, "\U0001F600");      // 😀 wide emoji
 
         // Cursor should wrap to row 1, col 2 (after the wide char)
-        Assert.Equal(1, t.CursorY);
-        Assert.Equal(2, t.CursorX);
+        Assert.AreEqual(1, t.CursorY);
+        Assert.AreEqual(2, t.CursorX);
 
         // Col 9 on row 0 should be empty (spacer head)
         var spacerCell = GhosttyTestFixture.GetCell(t, 0, 9);
-        Assert.True(spacerCell.Character == " " || spacerCell.Character == "",
-            $"Expected empty spacer at edge, got '{spacerCell.Character}'");
+        Assert.IsTrue(spacerCell.Character == " " || spacerCell.Character == "", $"Expected empty spacer at edge, got '{spacerCell.Character}'");
 
         // Row 1, col 0 should have the emoji (wide char)
         var wideCell = GhosttyTestFixture.GetCell(t, 1, 0);
-        Assert.Equal("\U0001F600", wideCell.Character);
+        Assert.AreEqual("\U0001F600", wideCell.Character);
 
         // Row 1, col 1 should be continuation (spacer tail)
         var tailCell = GhosttyTestFixture.GetCell(t, 1, 1);
-        Assert.True(tailCell.Character == " " || tailCell.Character == "",
-            $"Expected continuation cell, got '{tailCell.Character}'");
+        Assert.IsTrue(tailCell.Character == " " || tailCell.Character == "", $"Expected continuation cell, got '{tailCell.Character}'");
     }
 
-    [Fact]
+    [TestMethod]
     public void PrintWideCharInSingleWidthTerminal_PrintsSpace()
     {
         // Ghostty: "Terminal: print wide char in single-width terminal"
@@ -55,16 +54,15 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
         GhosttyTestFixture.Feed(t, "\U0001F600");  // 😀
 
         // Cursor stays at row 0, col 0 (with pending wrap)
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(0, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(0, t.CursorX);
 
         // Cell should be empty (wide char was dropped)
         var cell = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.True(cell.Character == " " || cell.Character == "" || cell.Character == "\0",
-            $"Expected empty cell in 1-col terminal, got '{cell.Character}'");
+        Assert.IsTrue(cell.Character == " " || cell.Character == "" || cell.Character == "\0", $"Expected empty cell in 1-col terminal, got '{cell.Character}'");
     }
 
-    [Fact]
+    [TestMethod]
     public void PrintWideCharWithOneColWidth_Truncated()
     {
         // Ghostty: "Terminal: print wide char with 1-column width"
@@ -75,15 +73,14 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
 
         // Cell should be empty
         var cell = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.True(cell.Character == " " || cell.Character == "" || cell.Character == "\0",
-            $"Expected empty cell, got '{cell.Character}'");
+        Assert.IsTrue(cell.Character == " " || cell.Character == "" || cell.Character == "\0", $"Expected empty cell, got '{cell.Character}'");
     }
 
     // ═══════════════════════════════════════════════════════════════
     // Overwrite wide char
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void PrintOverWideCharAt00()
     {
         // Ghostty: "Terminal: print over wide char at 0,0"
@@ -95,20 +92,19 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H");      // CUP(1,1) → col 0
         GhosttyTestFixture.Feed(t, "A");
 
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(1, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(1, t.CursorX);
 
         // Col 0 should be 'A' (narrow)
         var cell0 = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.Equal("A", cell0.Character);
+        Assert.AreEqual("A", cell0.Character);
 
         // Col 1 should be blank (former continuation cleared)
         var cell1 = GhosttyTestFixture.GetCell(t, 0, 1);
-        Assert.True(cell1.Character == " " || cell1.Character == "" || cell1.Character == "\0",
-            $"Expected cleared continuation, got '{cell1.Character}'");
+        Assert.IsTrue(cell1.Character == " " || cell1.Character == "" || cell1.Character == "\0", $"Expected cleared continuation, got '{cell1.Character}'");
     }
 
-    [Fact]
+    [TestMethod]
     public void PrintOverWideSpacerTail()
     {
         // Ghostty: "Terminal: print over wide spacer tail"
@@ -122,22 +118,21 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
 
         // Col 0 should be blank (wide char destroyed when tail overwritten)
         var cell0 = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.True(cell0.Character == " " || cell0.Character == "",
-            $"Expected blank at col 0, got '{cell0.Character}'");
+        Assert.IsTrue(cell0.Character == " " || cell0.Character == "", $"Expected blank at col 0, got '{cell0.Character}'");
 
         // Col 1 should be 'X'
         var cell1 = GhosttyTestFixture.GetCell(t, 0, 1);
-        Assert.Equal("X", cell1.Character);
+        Assert.AreEqual("X", cell1.Character);
 
         // Full line content
-        Assert.Equal(" X", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual(" X", GhosttyTestFixture.GetLine(t, 0));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // Grapheme with combining mark (narrow)
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void PrintGrapheme_OWithCombiningGrave_IsNarrow()
     {
         // Ghostty: "Terminal: print grapheme ò (o with nonspacing mark) should be narrow"
@@ -147,20 +142,19 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
         GhosttyTestFixture.Feed(t, "o\u0300");  // o + combining grave
 
         // Should take 1 cell
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(1, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(1, t.CursorX);
 
         // Cell 0 should contain the composed character (may be NFC composed "ò" or decomposed "o\u0300")
         var cell = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.False(string.IsNullOrWhiteSpace(cell.Character),
-            "Expected grapheme character, got empty/whitespace");
+        Assert.IsFalse(string.IsNullOrWhiteSpace(cell.Character), "Expected grapheme character, got empty/whitespace");
     }
 
     // ═══════════════════════════════════════════════════════════════
     // Invalid VS16 (VS16 on non-emoji base)
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void PrintInvalidVS16_NonGrapheme_RemainsNarrow()
     {
         // Ghostty: "Terminal: print invalid VS16 non-grapheme"
@@ -170,15 +164,15 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
         GhosttyTestFixture.Feed(t, "x\uFE0F");
 
         // Should have 1 cell, narrow
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(1, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(1, t.CursorX);
 
         // Cell 0 should be 'x'
         var cell = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.Equal("x", cell.Character);
+        Assert.AreEqual("x", cell.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void PrintInvalidVS16_Grapheme_RemainsNarrow()
     {
         // Ghostty: "Terminal: print invalid VS16 grapheme"
@@ -187,14 +181,14 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
 
         GhosttyTestFixture.Feed(t, "x\uFE0F");
 
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(1, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(1, t.CursorX);
 
         var cell = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.Equal("x", cell.Character);
+        Assert.AreEqual("x", cell.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void PrintInvalidVS16_WithSecondChar_TwoNarrowCells()
     {
         // Ghostty: "Terminal: print invalid VS16 with second char"
@@ -203,17 +197,17 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
 
         GhosttyTestFixture.Feed(t, "x\uFE0Fy");
 
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(2, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(2, t.CursorX);
 
         var cell0 = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.Equal("x", cell0.Character);
+        Assert.AreEqual("x", cell0.Character);
 
         var cell1 = GhosttyTestFixture.GetCell(t, 0, 1);
-        Assert.Equal("y", cell1.Character);
+        Assert.AreEqual("y", cell1.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void PrintInvalidVS16_WithCombiningChar_CombinesWithBase()
     {
         // Ghostty: "Terminal: print invalid VS16 with second char (combining)"
@@ -222,8 +216,8 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
 
         GhosttyTestFixture.Feed(t, "n\uFE0F\u0303");
 
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(1, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(1, t.CursorX);
 
         var cell = GhosttyTestFixture.GetCell(t, 0, 0);
         // Should contain 'n' with combining tilde
@@ -234,7 +228,7 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
     // VS15 (text presentation selector — makes emoji narrow)
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void VS15_MakesNarrowCharacter()
     {
         // Ghostty: "Terminal: VS15 to make narrow character"
@@ -242,16 +236,16 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
         var t = GhosttyTestFixture.CreateTerminal(5, 5);
 
         GhosttyTestFixture.Feed(t, "\u2614");   // ☔ umbrella (wide)
-        Assert.Equal(2, t.CursorX);             // Wide: takes 2 cols
+        Assert.AreEqual(2, t.CursorX);             // Wide: takes 2 cols
 
         GhosttyTestFixture.Feed(t, "\uFE0E");   // VS15 → narrow
 
         // After VS15, cursor should move back to col 1 (narrow = 1 cell)
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(1, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(1, t.CursorX);
     }
 
-    [Fact]
+    [TestMethod]
     public void VS15_OnAlreadyNarrowEmoji()
     {
         // Ghostty: "Terminal: VS15 on already narrow emoji"
@@ -261,11 +255,11 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
         GhosttyTestFixture.Feed(t, "\u26C8");   // ⛈ thunder cloud (narrow)
         GhosttyTestFixture.Feed(t, "\uFE0E");   // VS15
 
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(1, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(1, t.CursorX);
     }
 
-    [Fact]
+    [TestMethod]
     public void VS15_WithPendingWrap_ClearsPendingWrap()
     {
         // Ghostty: "Terminal: VS15 to make narrow character with pending wrap"
@@ -277,20 +271,20 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
         GhosttyTestFixture.Feed(t, "\u2614");       // ☔ umbrella (wide, cols 2-3)
 
         // Should be at row 0 with pending wrap
-        Assert.Equal(0, t.CursorY);
+        Assert.AreEqual(0, t.CursorY);
 
         GhosttyTestFixture.Feed(t, "\uFE0E");       // VS15 → narrow
 
         // Should still be on row 0, pending wrap cleared
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(3, t.CursorX);  // col 2 (narrow umbrella) + 1
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(3, t.CursorX);  // col 2 (narrow umbrella) + 1
 
         // First cell should still be lemon
         var lemonCell = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.Equal("\U0001F34B", lemonCell.Character);
+        Assert.AreEqual("\U0001F34B", lemonCell.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void PrintInvalidVS15_FollowingEmoji_StaysWide()
     {
         // Ghostty: "Terminal: print invalid VS15 following emoji is wide"
@@ -299,18 +293,18 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
 
         GhosttyTestFixture.Feed(t, "\U0001F9E0\uFE0E");  // 🧠 + VS15
 
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(2, t.CursorX);  // Still wide
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(2, t.CursorX);  // Still wide
 
         var cell = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.Equal("\U0001F9E0", cell.Character);
+        Assert.AreEqual("\U0001F9E0", cell.Character);
     }
 
     // ═══════════════════════════════════════════════════════════════
     // VS16 on next line (wrapping due to widening)
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void VS16_MakesWideOnNextLine()
     {
         // Ghostty: "Terminal: VS16 to make wide character on next line"
@@ -321,18 +315,17 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;3H");  // CUP(1,3) → col 2
         GhosttyTestFixture.Feed(t, "#");              // Narrow char at col 2
 
-        Assert.Equal(2, t.CursorX);
+        Assert.AreEqual(2, t.CursorX);
 
         GhosttyTestFixture.Feed(t, "\uFE0F");         // VS16 → wide
 
         // Should wrap to next line
-        Assert.Equal(1, t.CursorY);
-        Assert.Equal(2, t.CursorX);
+        Assert.AreEqual(1, t.CursorY);
+        Assert.AreEqual(2, t.CursorX);
 
         // Col 2 on row 0 should be spacer head (empty)
         var spacerCell = GhosttyTestFixture.GetCell(t, 0, 2);
-        Assert.True(spacerCell.Character == " " || spacerCell.Character == "",
-            $"Expected spacer head, got '{spacerCell.Character}'");
+        Assert.IsTrue(spacerCell.Character == " " || spacerCell.Character == "", $"Expected spacer head, got '{spacerCell.Character}'");
 
         // Row 1, col 0 should be '#' (wide, with emoji presentation)
         var hashCell = GhosttyTestFixture.GetCell(t, 1, 0);
@@ -343,7 +336,7 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
     // Keypad sequences with VS15/VS16
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void KeypadSequenceVS15_NarrowPresentation()
     {
         // Ghostty: "Terminal: keypad sequence VS15"
@@ -353,14 +346,14 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
         GhosttyTestFixture.Feed(t, "#\uFE0E");
 
         // Should be 1 cell (narrow)
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(1, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(1, t.CursorX);
 
         var cell = GhosttyTestFixture.GetCell(t, 0, 0);
         Assert.Contains("#", cell.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void KeypadSequenceVS16_WidePresentation()
     {
         // Ghostty: "Terminal: keypad sequence VS16"
@@ -370,8 +363,8 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
         GhosttyTestFixture.Feed(t, "#\uFE0F");
 
         // Should be 2 cells (wide)
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(2, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(2, t.CursorX);
 
         var cell = GhosttyTestFixture.GetCell(t, 0, 0);
         Assert.Contains("#", cell.Character);
@@ -381,7 +374,7 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
     // Alt screen mode 47/1047 cursor copying
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void Mode47_CopiesCursorBothDirections()
     {
         // Ghostty: "Terminal: mode 47 copies cursor both directions"
@@ -400,7 +393,7 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
 
         var altCell = GhosttyTestFixture.GetCell(t, 0, 0);
         // Verify alt screen has the green color
-        Assert.NotNull(altCell.Foreground);
+        Assert.IsNotNull(altCell.Foreground);
 
         // Exit alt screen
         GhosttyTestFixture.Feed(t, "\u001b[?47l");
@@ -408,10 +401,10 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
         // Primary screen should have the green foreground (copied back)
         GhosttyTestFixture.Feed(t, "Y");
         var primaryCell = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.NotNull(primaryCell.Foreground);
+        Assert.IsNotNull(primaryCell.Foreground);
     }
 
-    [Fact]
+    [TestMethod]
     public void Mode1047_CopiesCursorBothDirections()
     {
         // Ghostty: "Terminal: mode 1047 copies cursor both directions"
@@ -429,7 +422,7 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
         GhosttyTestFixture.Feed(t, "X");
 
         var altCell = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.NotNull(altCell.Foreground);
+        Assert.IsNotNull(altCell.Foreground);
 
         // Exit alt screen
         GhosttyTestFixture.Feed(t, "\u001b[?1047l");
@@ -437,10 +430,10 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
         // Primary screen should have the green foreground (copied back)
         GhosttyTestFixture.Feed(t, "Y");
         var primaryCell = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.NotNull(primaryCell.Foreground);
+        Assert.IsNotNull(primaryCell.Foreground);
     }
 
-    [Fact]
+    [TestMethod]
     public void Mode1047_AltScreenPreservesContent()
     {
         // Ghostty: "Terminal: mode 1047 alt screen plain"
@@ -453,20 +446,20 @@ public class GhosttyPrintWideEdgeCaseConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[?1047h");
 
         // Alt screen should be empty
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0).TrimEnd());
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0).TrimEnd());
 
         // Print on alt, cursor position carried over from primary (col 2)
         GhosttyTestFixture.Feed(t, "2B");
-        Assert.Equal("  2B", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("  2B", GhosttyTestFixture.GetLine(t, 0));
 
         // Exit alt screen
         GhosttyTestFixture.Feed(t, "\u001b[?1047l");
 
         // Primary should still have original content
-        Assert.Equal("1A", GhosttyTestFixture.GetLine(t, 0).TrimEnd());
+        Assert.AreEqual("1A", GhosttyTestFixture.GetLine(t, 0).TrimEnd());
 
         // Re-enter alt screen — should be blank again
         GhosttyTestFixture.Feed(t, "\u001b[?1047h");
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0).TrimEnd());
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0).TrimEnd());
     }
 }

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyPrintWideVSConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyPrintWideVSConformanceTests.cs
@@ -1,4 +1,3 @@
-using Xunit;
 
 namespace Hex1b.Tests.Conformance.Ghostty;
 
@@ -7,7 +6,8 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// (VS15/VS16), Devanagari graphemes, and mode 2027 grapheme clustering,
 /// translated from Ghostty's Terminal.zig.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyPrintWideVSConformanceTests
 {
     private static Hex1bTerminal CreateTerminal(int cols = 80, int rows = 24)
@@ -16,7 +16,7 @@ public class GhosttyPrintWideVSConformanceTests
     #region Print Over Wide Character with Attributes
 
     // Ghostty: "Terminal: print over wide char with bold"
-    [Fact]
+    [TestMethod]
     public void PrintOverWideCharWithBold_ClearsStyle()
     {
         using var t = CreateTerminal(cols: 80, rows: 80);
@@ -30,20 +30,19 @@ public class GhosttyPrintWideVSConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[0m");
         GhosttyTestFixture.Feed(t, "A");
 
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(1, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(1, t.CursorX);
 
         var cell0 = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.Equal("A", cell0.Character);
+        Assert.AreEqual("A", cell0.Character);
 
         // Former continuation cell should be cleared
         var cell1 = GhosttyTestFixture.GetCell(t, 0, 1);
-        Assert.True(cell1.Character == " " || cell1.Character == "",
-            $"Expected cleared cell, got '{cell1.Character}'");
+        Assert.IsTrue(cell1.Character == " " || cell1.Character == "", $"Expected cleared cell, got '{cell1.Character}'");
     }
 
     // Ghostty: "Terminal: print over wide char with bg color"
-    [Fact]
+    [TestMethod]
     public void PrintOverWideCharWithBgColor_ClearsStyle()
     {
         using var t = CreateTerminal(cols: 80, rows: 80);
@@ -54,24 +53,24 @@ public class GhosttyPrintWideVSConformanceTests
 
         // Verify emoji cell has background color
         var emojiCell = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.NotNull(emojiCell.Background);
+        Assert.IsNotNull(emojiCell.Background);
         var bg = emojiCell.Background!.Value;
-        Assert.Equal((byte)255, bg.R);
-        Assert.Equal((byte)0, bg.G);
-        Assert.Equal((byte)0, bg.B);
+        Assert.AreEqual((byte)255, bg.R);
+        Assert.AreEqual((byte)0, bg.G);
+        Assert.AreEqual((byte)0, bg.B);
 
         // Go back and overwrite with no style
         GhosttyTestFixture.Feed(t, "\u001b[1;1H");
         GhosttyTestFixture.Feed(t, "\u001b[0m");
         GhosttyTestFixture.Feed(t, "A");
 
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(1, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(1, t.CursorX);
 
         var cell0 = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.Equal("A", cell0.Character);
+        Assert.AreEqual("A", cell0.Character);
         // Background should be cleared after overwrite with reset attributes
-        Assert.Null(cell0.Background);
+        Assert.IsNull(cell0.Background);
     }
 
     #endregion
@@ -79,7 +78,7 @@ public class GhosttyPrintWideVSConformanceTests
     #region Wide Character at Right Margin
 
     // Ghostty: "Terminal: print wide char at right margin does not create spacer head"
-    [Fact]
+    [TestMethod]
     public void PrintWideCharAtRightMargin_NoSpacerHead()
     {
         using var t = CreateTerminal(cols: 10, rows: 10);
@@ -91,21 +90,20 @@ public class GhosttyPrintWideVSConformanceTests
         GhosttyTestFixture.Feed(t, "\U0001F600");    // 😀 (wide)
 
         // Wide char wraps to next line at left margin
-        Assert.Equal(1, t.CursorY);
-        Assert.Equal(4, t.CursorX);
+        Assert.AreEqual(1, t.CursorY);
+        Assert.AreEqual(4, t.CursorX);
 
         // Cell at right margin of row 0 should be empty/narrow, NOT spacer_head
         var marginCell = GhosttyTestFixture.GetCell(t, 0, 4);
-        Assert.True(marginCell.Character == " " || marginCell.Character == "",
-            $"Expected empty cell at right margin, got '{marginCell.Character}'");
+        Assert.IsTrue(marginCell.Character == " " || marginCell.Character == "", $"Expected empty cell at right margin, got '{marginCell.Character}'");
 
         // Wide char should be on row 1 at left margin (col 2, 0-based)
         var wideCell = GhosttyTestFixture.GetCell(t, 1, 2);
-        Assert.Equal("\U0001F600", wideCell.Character);
+        Assert.AreEqual("\U0001F600", wideCell.Character);
 
         // Spacer tail
         var tailCell = GhosttyTestFixture.GetCell(t, 1, 3);
-        Assert.Equal("", tailCell.Character);
+        Assert.AreEqual("", tailCell.Character);
     }
 
     #endregion
@@ -113,7 +111,7 @@ public class GhosttyPrintWideVSConformanceTests
     #region Devanagari Grapheme Clustering
 
     // Ghostty: "Terminal: print Devanagari grapheme should be wide"
-    [Fact]
+    [TestMethod]
     public void PrintDevanagariGrapheme_ShouldBeWide()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -123,20 +121,20 @@ public class GhosttyPrintWideVSConformanceTests
         GhosttyTestFixture.Feed(t, "\u0915\u094D\u200D\u0937");
 
         // Should take 2 cells (wide grapheme)
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(2, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(2, t.CursorX);
 
         // First cell has the grapheme
         var cell0 = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.True(cell0.Character.Length > 0, "Expected Devanagari grapheme content");
+        Assert.IsTrue(cell0.Character.Length > 0, "Expected Devanagari grapheme content");
 
         // Second cell is continuation
         var cell1 = GhosttyTestFixture.GetCell(t, 0, 1);
-        Assert.Equal("", cell1.Character);
+        Assert.AreEqual("", cell1.Character);
     }
 
     // Ghostty: "Terminal: print Devanagari grapheme should be wide on next line"
-    [Fact]
+    [TestMethod]
     public void PrintDevanagariGrapheme_ShouldBeWideOnNextLine()
     {
         using var t = CreateTerminal(cols: 3, rows: 5);
@@ -151,32 +149,31 @@ public class GhosttyPrintWideVSConformanceTests
         GhosttyTestFixture.Feed(t, "\u200D"); // ZWJ (zero-width)
 
         // Should be at last col with pending wrap
-        Assert.Equal(2, t.CursorX);
-        Assert.True(t.PendingWrap);
+        Assert.AreEqual(2, t.CursorX);
+        Assert.IsTrue(t.PendingWrap);
 
         // Last codepoint makes grapheme wide → wraps to next line
         GhosttyTestFixture.Feed(t, "\u0937"); // ष
 
-        Assert.Equal(1, t.CursorY);
-        Assert.Equal(2, t.CursorX);
-        Assert.False(t.PendingWrap);
+        Assert.AreEqual(1, t.CursorY);
+        Assert.AreEqual(2, t.CursorX);
+        Assert.IsFalse(t.PendingWrap);
 
         // Previous cell becomes spacer head
         var spacerHead = GhosttyTestFixture.GetCell(t, 0, 2);
-        Assert.True(spacerHead.Character == " " || spacerHead.Character == "",
-            "Expected spacer head at previous position");
+        Assert.IsTrue(spacerHead.Character == " " || spacerHead.Character == "", "Expected spacer head at previous position");
 
         // Wide grapheme on next line
         var wideCell = GhosttyTestFixture.GetCell(t, 1, 0);
-        Assert.True(wideCell.Character.Length > 0, "Expected Devanagari grapheme");
+        Assert.IsTrue(wideCell.Character.Length > 0, "Expected Devanagari grapheme");
 
         // Spacer tail
         var tailCell = GhosttyTestFixture.GetCell(t, 1, 1);
-        Assert.Equal("", tailCell.Character);
+        Assert.AreEqual("", tailCell.Character);
     }
 
     // Ghostty: "Terminal: print Devanagari grapheme should be wide on next page"
-    [Fact]
+    [TestMethod]
     public void PrintDevanagariGrapheme_ShouldBeWideOnNextPage()
     {
         // Simplified from Ghostty's page-boundary test: tests wrapping at bottom-right
@@ -191,28 +188,27 @@ public class GhosttyPrintWideVSConformanceTests
         GhosttyTestFixture.Feed(t, "\u094D"); // virama
         GhosttyTestFixture.Feed(t, "\u200D"); // ZWJ
 
-        Assert.Equal(9, t.CursorX);
-        Assert.True(t.PendingWrap);
+        Assert.AreEqual(9, t.CursorX);
+        Assert.IsTrue(t.PendingWrap);
 
         // Last codepoint makes grapheme wide → wraps + scrolls
         GhosttyTestFixture.Feed(t, "\u0937"); // ष
 
-        Assert.Equal(4, t.CursorY); // Still last row (after scroll)
-        Assert.Equal(2, t.CursorX);
-        Assert.False(t.PendingWrap);
+        Assert.AreEqual(4, t.CursorY); // Still last row (after scroll)
+        Assert.AreEqual(2, t.CursorX);
+        Assert.IsFalse(t.PendingWrap);
 
         // Spacer head on previous row's last column
         var spacerHead = GhosttyTestFixture.GetCell(t, 3, 9);
-        Assert.True(spacerHead.Character == " " || spacerHead.Character == "",
-            "Expected spacer head at previous row's last column");
+        Assert.IsTrue(spacerHead.Character == " " || spacerHead.Character == "", "Expected spacer head at previous row's last column");
 
         // Wide Devanagari on last row
         var wideCell = GhosttyTestFixture.GetCell(t, 4, 0);
-        Assert.True(wideCell.Character.Length > 0, "Expected Devanagari grapheme on last row");
+        Assert.IsTrue(wideCell.Character.Length > 0, "Expected Devanagari grapheme on last row");
 
         // Spacer tail
         var tailCell = GhosttyTestFixture.GetCell(t, 4, 1);
-        Assert.Equal("", tailCell.Character);
+        Assert.AreEqual("", tailCell.Character);
     }
 
     #endregion
@@ -220,7 +216,7 @@ public class GhosttyPrintWideVSConformanceTests
     #region Invalid VS15 (Text Presentation Selector)
 
     // Ghostty: "Terminal: print invalid VS15 following emoji is wide"
-    [Fact]
+    [TestMethod]
     public void PrintInvalidVS15FollowingEmoji_RemainsWide()
     {
         using var t = CreateTerminal(cols: 80, rows: 80);
@@ -231,21 +227,20 @@ public class GhosttyPrintWideVSConformanceTests
         GhosttyTestFixture.Feed(t, "\uFE0E");
 
         // Should still be wide (2 cells)
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(2, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(2, t.CursorX);
 
         // Cell should have 🧠, still wide (Hex1b may include VS15 in string)
         var cell0 = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.True(cell0.Character.StartsWith("\U0001F9E0"),
-            $"Expected cell to start with 🧠, got '{cell0.Character}'");
+        Assert.IsTrue(cell0.Character.StartsWith("\U0001F9E0"), $"Expected cell to start with 🧠, got '{cell0.Character}'");
 
         // Spacer tail
         var cell1 = GhosttyTestFixture.GetCell(t, 0, 1);
-        Assert.Equal("", cell1.Character);
+        Assert.AreEqual("", cell1.Character);
     }
 
     // Ghostty: "Terminal: print invalid VS15 in emoji ZWJ sequence"
-    [Fact]
+    [TestMethod]
     public void PrintInvalidVS15InEmojiZWJSequence_RemainsWide()
     {
         using var t = CreateTerminal(cols: 80, rows: 80);
@@ -258,16 +253,16 @@ public class GhosttyPrintWideVSConformanceTests
         GhosttyTestFixture.Feed(t, "\U0001F466");  // 👦
 
         // Should be wide (2 cells) — ZWJ sequence
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(2, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(2, t.CursorX);
 
         // First cell has 👩 with grapheme data
         var cell0 = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.True(cell0.Character.Length > 0, "Expected emoji ZWJ sequence");
+        Assert.IsTrue(cell0.Character.Length > 0, "Expected emoji ZWJ sequence");
 
         // Spacer tail
         var cell1 = GhosttyTestFixture.GetCell(t, 0, 1);
-        Assert.Equal("", cell1.Character);
+        Assert.AreEqual("", cell1.Character);
     }
 
     #endregion
@@ -275,7 +270,7 @@ public class GhosttyPrintWideVSConformanceTests
     #region Invalid VS16 (Emoji Presentation Selector)
 
     // Ghostty: "Terminal: print invalid VS16 grapheme"
-    [Fact]
+    [TestMethod]
     public void PrintInvalidVS16Grapheme_StaysNarrow()
     {
         using var t = CreateTerminal(cols: 80, rows: 80);
@@ -286,17 +281,16 @@ public class GhosttyPrintWideVSConformanceTests
         GhosttyTestFixture.Feed(t, "\uFE0F");
 
         // Should remain narrow (1 cell)
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(1, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(1, t.CursorX);
 
         // Hex1b may include VS16 in character string; key is cursor stays narrow
         var cell0 = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.True(cell0.Character.StartsWith("x"),
-            $"Expected cell to start with 'x', got '{cell0.Character}'");
+        Assert.IsTrue(cell0.Character.StartsWith("x"), $"Expected cell to start with 'x', got '{cell0.Character}'");
     }
 
     // Ghostty: "Terminal: print invalid VS16 non-grapheme"
-    [Fact]
+    [TestMethod]
     public void PrintInvalidVS16NonGrapheme_StaysNarrow()
     {
         using var t = CreateTerminal(cols: 80, rows: 80);
@@ -307,17 +301,16 @@ public class GhosttyPrintWideVSConformanceTests
         GhosttyTestFixture.Feed(t, "\uFE0F");
 
         // Should remain narrow (1 cell)
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(1, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(1, t.CursorX);
 
         // Hex1b may include VS16 in character string; key is cursor stays narrow
         var cell0 = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.True(cell0.Character.StartsWith("x"),
-            $"Expected cell to start with 'x', got '{cell0.Character}'");
+        Assert.IsTrue(cell0.Character.StartsWith("x"), $"Expected cell to start with 'x', got '{cell0.Character}'");
     }
 
     // Ghostty: "Terminal: print invalid VS16 with second char"
-    [Fact]
+    [TestMethod]
     public void PrintInvalidVS16WithSecondChar_BothNarrow()
     {
         using var t = CreateTerminal(cols: 80, rows: 80);
@@ -329,16 +322,15 @@ public class GhosttyPrintWideVSConformanceTests
         GhosttyTestFixture.Feed(t, "y");
 
         // Two separate narrow characters
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(2, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(2, t.CursorX);
 
         // Hex1b may include VS16 in character string for 'x'
         var cell0 = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.True(cell0.Character.StartsWith("x"),
-            $"Expected cell to start with 'x', got '{cell0.Character}'");
+        Assert.IsTrue(cell0.Character.StartsWith("x"), $"Expected cell to start with 'x', got '{cell0.Character}'");
 
         var cell1 = GhosttyTestFixture.GetCell(t, 0, 1);
-        Assert.Equal("y", cell1.Character);
+        Assert.AreEqual("y", cell1.Character);
     }
 
     #endregion
@@ -346,7 +338,7 @@ public class GhosttyPrintWideVSConformanceTests
     #region Mode 2027 Grapheme Clustering
 
     // Ghostty: "Terminal: print multicodepoint grapheme, mode 2027"
-    [Fact]
+    [TestMethod]
     public void PrintMulticodepointGrapheme_Mode2027_SingleWideCluster()
     {
         using var t = CreateTerminal(cols: 80, rows: 80);
@@ -360,20 +352,20 @@ public class GhosttyPrintWideVSConformanceTests
         GhosttyTestFixture.Feed(t, "\U0001F467"); // 👧
 
         // With mode 2027, should be single wide grapheme (2 cells)
-        Assert.Equal(0, t.CursorY);
-        Assert.Equal(2, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.AreEqual(2, t.CursorX);
 
         // First cell has the family emoji grapheme
         var cell0 = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.True(cell0.Character.Length > 0, "Expected family emoji grapheme");
+        Assert.IsTrue(cell0.Character.Length > 0, "Expected family emoji grapheme");
 
         // Spacer tail
         var cell1 = GhosttyTestFixture.GetCell(t, 0, 1);
-        Assert.Equal("", cell1.Character);
+        Assert.AreEqual("", cell1.Character);
     }
 
     // Ghostty: "Terminal: VS16 doesn't make character with 2027 disabled"
-    [Fact]
+    [TestMethod]
     public void VS16_WithMode2027Disabled_DoesNotMakeWide()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -384,14 +376,14 @@ public class GhosttyPrintWideVSConformanceTests
         GhosttyTestFixture.Feed(t, "\uFE0F"); // VS16
 
         // Without mode 2027, heart should remain narrow
-        Assert.Equal(0, t.CursorY);
+        Assert.AreEqual(0, t.CursorY);
 
         var cell0 = GhosttyTestFixture.GetCell(t, 0, 0);
-        Assert.True(cell0.Character.Length > 0, "Expected heart character");
+        Assert.IsTrue(cell0.Character.Length > 0, "Expected heart character");
 
         // Verify line content includes VS16 as grapheme data
         var line = GhosttyTestFixture.GetLine(t, 0);
-        Assert.True(line.Length > 0, "Expected non-empty line");
+        Assert.IsTrue(line.Length > 0, "Expected non-empty line");
     }
 
     #endregion
@@ -399,7 +391,7 @@ public class GhosttyPrintWideVSConformanceTests
     #region VS16 Edge Cases
 
     // Ghostty: "Terminal: VS16 to make wide character with pending wrap"
-    [Fact]
+    [TestMethod]
     public void VS16_WithPendingWrap_MakesWideInPlace()
     {
         using var t = CreateTerminal(cols: 3, rows: 5);
@@ -410,26 +402,24 @@ public class GhosttyPrintWideVSConformanceTests
         GhosttyTestFixture.Feed(t, "#");
 
         // '#' at col 1, cursor at col 2 (last column), no pending wrap
-        Assert.Equal(2, t.CursorX);
-        Assert.False(t.PendingWrap);
+        Assert.AreEqual(2, t.CursorX);
+        Assert.IsFalse(t.PendingWrap);
 
         // VS16 makes '#' wide (2 cells at cols 1-2)
         GhosttyTestFixture.Feed(t, "\uFE0F");
 
         // Cursor at col 2 with pending wrap (wide char fills cols 1-2)
-        Assert.Equal(2, t.CursorX);
-        Assert.Equal(0, t.CursorY);
-        Assert.True(t.PendingWrap);
+        Assert.AreEqual(2, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
+        Assert.IsTrue(t.PendingWrap);
 
         // '#' cell is wide at col 1 (Hex1b may include VS16 in string)
         var wideCell = GhosttyTestFixture.GetCell(t, 0, 1);
-        Assert.True(wideCell.Character.StartsWith("#"),
-            $"Expected cell to start with '#', got '{wideCell.Character}'");
+        Assert.IsTrue(wideCell.Character.StartsWith("#"), $"Expected cell to start with '#', got '{wideCell.Character}'");
 
         // Spacer tail at col 2
         var tailCell = GhosttyTestFixture.GetCell(t, 0, 2);
-        Assert.True(tailCell.Character == "" || tailCell.Character == " ",
-            $"Expected spacer tail (empty or space), got '{tailCell.Character}'");
+        Assert.IsTrue(tailCell.Character == "" || tailCell.Character == " ", $"Expected spacer tail (empty or space), got '{tailCell.Character}'");
     }
 
     #endregion

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyProtectedConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyProtectedConformanceTests.cs
@@ -1,4 +1,3 @@
-using Xunit;
 
 namespace Hex1b.Tests.Conformance.Ghostty;
 
@@ -14,35 +13,36 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// Key behavior: _protectedMode tracks the MOST RECENT mode set (ISO or DEC) and is
 /// never reset to Off. The cursor's protected flag tracks whether new chars are protected.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyProtectedConformanceTests
 {
     // ═══════════════════════════════════════════════════════════════
     // setProtectedMode basic behavior
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void SetProtectedMode_BasicToggle()
     {
         // Ghostty: "Terminal: setProtectedMode"
         var t = GhosttyTestFixture.CreateTerminal(3, 3);
 
-        Assert.False(t.CursorProtected);
+        Assert.IsFalse(t.CursorProtected);
         t.SetProtectedMode(ProtectedMode.Off);
-        Assert.False(t.CursorProtected);
+        Assert.IsFalse(t.CursorProtected);
         t.SetProtectedMode(ProtectedMode.Iso);
-        Assert.True(t.CursorProtected);
+        Assert.IsTrue(t.CursorProtected);
         t.SetProtectedMode(ProtectedMode.Dec);
-        Assert.True(t.CursorProtected);
+        Assert.IsTrue(t.CursorProtected);
         t.SetProtectedMode(ProtectedMode.Off);
-        Assert.False(t.CursorProtected);
+        Assert.IsFalse(t.CursorProtected);
     }
 
     // ═══════════════════════════════════════════════════════════════
     // eraseChars (ECH) — CSI X
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void EraseChars_ProtectedRespectedWithIso()
     {
         // Ghostty: "Terminal: eraseChars protected attributes respected with iso"
@@ -54,10 +54,10 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H"); // setCursorPos(1,1)
         GhosttyTestFixture.Feed(t, "\u001b[2X");    // eraseChars(2)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseChars_ProtectedIgnoredWithDecMostRecent()
     {
         // Ghostty: "Terminal: eraseChars protected attributes ignored with dec most recent"
@@ -72,10 +72,10 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H"); // setCursorPos(1,1)
         GhosttyTestFixture.Feed(t, "\u001b[2X");    // eraseChars(2)
 
-        Assert.Equal("  C", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("  C", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseChars_ProtectedIgnoredWithDecSet()
     {
         // Ghostty: "Terminal: eraseChars protected attributes ignored with dec set"
@@ -87,14 +87,14 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H"); // setCursorPos(1,1)
         GhosttyTestFixture.Feed(t, "\u001b[2X");    // eraseChars(2)
 
-        Assert.Equal("  C", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("  C", GhosttyTestFixture.GetLine(t, 0));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // eraseLine right (EL 0 / DECSEL 0) — CSI K / CSI ? K
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_Right_ProtectedRespectedWithIso()
     {
         // Ghostty: "Terminal: eraseLine right protected attributes respected with iso"
@@ -105,10 +105,10 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H"); // setCursorPos(1,1)
         GhosttyTestFixture.Feed(t, "\u001b[K");     // eraseLine right (normal)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_Right_ProtectedIgnoredWithDecMostRecent()
     {
         // Ghostty: "Terminal: eraseLine right protected attributes ignored with dec most recent"
@@ -121,10 +121,10 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;2H"); // setCursorPos(1,2)
         GhosttyTestFixture.Feed(t, "\u001b[K");     // eraseLine right (normal)
 
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_Right_ProtectedIgnoredWithDecSet()
     {
         // Ghostty: "Terminal: eraseLine right protected attributes ignored with dec set"
@@ -135,10 +135,10 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;2H"); // setCursorPos(1,2)
         GhosttyTestFixture.Feed(t, "\u001b[K");     // eraseLine right (normal)
 
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_Right_ProtectedRequested()
     {
         // Ghostty: "Terminal: eraseLine right protected requested"
@@ -152,14 +152,14 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;4H"); // setCursorPos(1,4) → cursor at col 3
         GhosttyTestFixture.Feed(t, "\u001b[?K");    // DECSEL right (selective)
 
-        Assert.Equal("123  X", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("123  X", GhosttyTestFixture.GetLine(t, 0));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // eraseLine left (EL 1 / DECSEL 1) — CSI 1 K / CSI ? 1 K
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_Left_ProtectedRespectedWithIso()
     {
         // Ghostty: "Terminal: eraseLine left protected attributes respected with iso"
@@ -170,10 +170,10 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H"); // setCursorPos(1,1)
         GhosttyTestFixture.Feed(t, "\u001b[1K");    // eraseLine left (normal)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_Left_ProtectedIgnoredWithDecMostRecent()
     {
         // Ghostty: "Terminal: eraseLine left protected attributes ignored with dec most recent"
@@ -186,10 +186,10 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;2H"); // setCursorPos(1,2)
         GhosttyTestFixture.Feed(t, "\u001b[1K");    // eraseLine left (normal)
 
-        Assert.Equal("  C", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("  C", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_Left_ProtectedIgnoredWithDecSet()
     {
         // Ghostty: "Terminal: eraseLine left protected attributes ignored with dec set"
@@ -200,10 +200,10 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;2H"); // setCursorPos(1,2)
         GhosttyTestFixture.Feed(t, "\u001b[1K");    // eraseLine left (normal)
 
-        Assert.Equal("  C", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("  C", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_Left_ProtectedRequested()
     {
         // Ghostty: "Terminal: eraseLine left protected requested"
@@ -217,14 +217,14 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;8H"); // setCursorPos(1,8) → cursor at col 7
         GhosttyTestFixture.Feed(t, "\u001b[?1K");   // DECSEL left (selective)
 
-        Assert.Equal("     X  9", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("     X  9", GhosttyTestFixture.GetLine(t, 0));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // eraseLine complete (EL 2 / DECSEL 2) — CSI 2 K / CSI ? 2 K
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_Complete_ProtectedRespectedWithIso()
     {
         // Ghostty: "Terminal: eraseLine complete protected attributes respected with iso"
@@ -235,10 +235,10 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H"); // setCursorPos(1,1)
         GhosttyTestFixture.Feed(t, "\u001b[2K");    // eraseLine complete (normal)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_Complete_ProtectedIgnoredWithDecMostRecent()
     {
         // Ghostty: "Terminal: eraseLine complete protected attributes ignored with dec most recent"
@@ -251,10 +251,10 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;2H"); // setCursorPos(1,2)
         GhosttyTestFixture.Feed(t, "\u001b[2K");    // eraseLine complete (normal)
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_Complete_ProtectedIgnoredWithDecSet()
     {
         // Ghostty: "Terminal: eraseLine complete protected attributes ignored with dec set"
@@ -265,10 +265,10 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;2H"); // setCursorPos(1,2)
         GhosttyTestFixture.Feed(t, "\u001b[2K");    // eraseLine complete (normal)
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_Complete_ProtectedRequested()
     {
         // Ghostty: "Terminal: eraseLine complete protected requested"
@@ -282,14 +282,14 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;8H"); // setCursorPos(1,8) → cursor at col 7
         GhosttyTestFixture.Feed(t, "\u001b[?2K");   // DECSEL complete (selective)
 
-        Assert.Equal("     X", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("     X", GhosttyTestFixture.GetLine(t, 0));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // eraseDisplay below (ED 0 / DECSED 0) — CSI J / CSI ? J
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_Below_ProtectedRespectedWithIso()
     {
         // Ghostty: "Terminal: eraseDisplay below protected attributes respected with iso"
@@ -300,12 +300,12 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H"); // setCursorPos(2,2)
         GhosttyTestFixture.Feed(t, "\u001b[J");     // eraseDisplay below (normal)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_Below_ProtectedIgnoredWithDecMostRecent()
     {
         // Ghostty: "Terminal: eraseDisplay below protected attributes ignored with dec most recent"
@@ -318,12 +318,12 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H"); // setCursorPos(2,2)
         GhosttyTestFixture.Feed(t, "\u001b[J");     // eraseDisplay below (normal)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("D", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("D", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_Below_ProtectedIgnoredWithDecSet()
     {
         // Ghostty: "Terminal: eraseDisplay below protected attributes ignored with dec set"
@@ -334,12 +334,12 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H"); // setCursorPos(2,2)
         GhosttyTestFixture.Feed(t, "\u001b[J");     // eraseDisplay below (normal)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("D", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("D", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_Below_ProtectedRespectedWithForce()
     {
         // Ghostty: "Terminal: eraseDisplay below protected attributes respected with force"
@@ -351,16 +351,16 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H"); // setCursorPos(2,2)
         GhosttyTestFixture.Feed(t, "\u001b[?J");    // DECSED below (selective)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 2));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // eraseDisplay above (ED 1 / DECSED 1) — CSI 1 J / CSI ? 1 J
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_Above_ProtectedRespectedWithIso()
     {
         // Ghostty: "Terminal: eraseDisplay above protected attributes respected with iso"
@@ -371,12 +371,12 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H"); // setCursorPos(2,2)
         GhosttyTestFixture.Feed(t, "\u001b[1J");    // eraseDisplay above (normal)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_Above_ProtectedIgnoredWithDecMostRecent()
     {
         // Ghostty: "Terminal: eraseDisplay above protected attributes ignored with dec most recent"
@@ -389,12 +389,12 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H"); // setCursorPos(2,2)
         GhosttyTestFixture.Feed(t, "\u001b[1J");    // eraseDisplay above (normal)
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("  F", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("  F", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_Above_ProtectedIgnoredWithDecSet()
     {
         // Ghostty: "Terminal: eraseDisplay above protected attributes ignored with dec set"
@@ -405,12 +405,12 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H"); // setCursorPos(2,2)
         GhosttyTestFixture.Feed(t, "\u001b[1J");    // eraseDisplay above (normal)
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("  F", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("  F", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_Above_ProtectedRespectedWithForce()
     {
         // Ghostty: "Terminal: eraseDisplay above protected attributes respected with force"
@@ -422,16 +422,16 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H"); // setCursorPos(2,2)
         GhosttyTestFixture.Feed(t, "\u001b[?1J");   // DECSED above (selective)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 2));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // eraseDisplay with mixed protected/unprotected — selective erase
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_ProtectedComplete()
     {
         // Ghostty: "Terminal: eraseDisplay protected complete"
@@ -448,11 +448,11 @@ public class GhosttyProtectedConformanceTests
 
         GhosttyTestFixture.Feed(t, "\u001b[?2J");   // DECSED complete (selective)
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("     X", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("     X", GhosttyTestFixture.GetLine(t, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_ProtectedBelow()
     {
         // Ghostty: "Terminal: eraseDisplay protected below"
@@ -468,11 +468,11 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;4H"); // setCursorPos(2,4)
         GhosttyTestFixture.Feed(t, "\u001b[?J");    // DECSED below (selective)
 
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("123  X", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("123  X", GhosttyTestFixture.GetLine(t, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_ProtectedAbove()
     {
         // Ghostty: "Terminal: eraseDisplay protected above"
@@ -488,15 +488,15 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;8H"); // setCursorPos(2,8)
         GhosttyTestFixture.Feed(t, "\u001b[?1J");   // DECSED above (selective)
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("     X  9", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("     X  9", GhosttyTestFixture.GetLine(t, 1));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // saveCursor / restoreCursor with protected pen
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void SaveCursor_ProtectedPen()
     {
         // Ghostty: "Terminal: saveCursor protected pen"
@@ -504,20 +504,20 @@ public class GhosttyProtectedConformanceTests
         var t = GhosttyTestFixture.CreateTerminal(10, 5);
 
         t.SetProtectedMode(ProtectedMode.Iso);
-        Assert.True(t.CursorProtected);
+        Assert.IsTrue(t.CursorProtected);
         GhosttyTestFixture.Feed(t, "\u001b[1;10H"); // setCursorPos(1,10)
         GhosttyTestFixture.Feed(t, "\u001b7");       // saveCursor (DECSC)
         t.SetProtectedMode(ProtectedMode.Off);
-        Assert.False(t.CursorProtected);
+        Assert.IsFalse(t.CursorProtected);
         GhosttyTestFixture.Feed(t, "\u001b8");       // restoreCursor (DECRC)
-        Assert.True(t.CursorProtected);
+        Assert.IsTrue(t.CursorProtected);
     }
 
     // ═══════════════════════════════════════════════════════════════
     // DECALN resets graphemes with protected mode
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void Decaln_ResetsGraphemesWithProtectedMode()
     {
         // Ghostty: "Terminal: DECALN resets graphemes with protected mode"
@@ -529,35 +529,35 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b#8"); // DECALN
 
         // DECALN preserves cursor protected and mode, but resets cursor position
-        Assert.True(t.CursorProtected);
+        Assert.IsTrue(t.CursorProtected);
 
-        Assert.Equal("EEE", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("EEE", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("EEE", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("EEE", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("EEE", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("EEE", GhosttyTestFixture.GetLine(t, 2));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // DECSCA via escape sequence (CSI Ps " q)
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void Decsca_ViaEscapeSequence_SetsProtection()
     {
         // DECSCA 1 enables character protection, DECSCA 0 disables it.
         var t = GhosttyTestFixture.CreateTerminal(10, 5);
 
-        Assert.False(t.CursorProtected);
+        Assert.IsFalse(t.CursorProtected);
         GhosttyTestFixture.Feed(t, "\u001b[1\"q"); // DECSCA 1 (protected)
-        Assert.True(t.CursorProtected);
+        Assert.IsTrue(t.CursorProtected);
         GhosttyTestFixture.Feed(t, "\u001b[0\"q"); // DECSCA 0 (unprotected)
-        Assert.False(t.CursorProtected);
+        Assert.IsFalse(t.CursorProtected);
         GhosttyTestFixture.Feed(t, "\u001b[1\"q"); // DECSCA 1 (protected)
-        Assert.True(t.CursorProtected);
+        Assert.IsTrue(t.CursorProtected);
         GhosttyTestFixture.Feed(t, "\u001b[2\"q"); // DECSCA 2 (also unprotected)
-        Assert.False(t.CursorProtected);
+        Assert.IsFalse(t.CursorProtected);
     }
 
-    [Fact]
+    [TestMethod]
     public void Decsca_ProtectedCharactersPreservedByIsoErase()
     {
         // Characters printed while DECSCA is active get protection attribute.
@@ -574,6 +574,6 @@ public class GhosttyProtectedConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H"); // Home
         GhosttyTestFixture.Feed(t, "\u001b[2K");    // Erase line complete
 
-        Assert.Equal("ABCDE", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("ABCDE", GhosttyTestFixture.GetLine(t, 0));
     }
 }

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyReverseWrapConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyReverseWrapConformanceTests.cs
@@ -1,6 +1,5 @@
 using System;
 using Hex1b;
-using Xunit;
 
 namespace Hex1b.Tests.Conformance.Ghostty;
 
@@ -8,7 +7,8 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// Ghostty conformance tests for reverse wrap (DECSET 45) and
 /// extended reverse wrap (DECSET 1045 / XTREVWRAP2).
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyReverseWrapConformanceTests
 {
     private static Hex1bTerminal CreateTerminal(int cols, int rows) => GhosttyTestFixture.CreateTerminal(cols, rows);
@@ -21,7 +21,7 @@ public class GhosttyReverseWrapConformanceTests
     // Ghostty: "Terminal: cursorLeft reverse wrap with pending wrap state"
     // When pending wrap is set and reverse wrap is enabled, CUB 1 just
     // clears the pending wrap without moving the cursor.
-    [Fact]
+    [TestMethod]
     public void CursorLeft_ReverseWrap_PendingWrapState()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -29,17 +29,17 @@ public class GhosttyReverseWrapConformanceTests
         Feed(t, "\u001b[?45h"); // Enable reverse wrap
 
         Feed(t, "ABCDE"); // Fill row, pending wrap set
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
 
         Feed(t, "\u001b[D"); // CUB 1 — clears pending wrap
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
 
         Feed(t, "X"); // Overwrites last char
-        Assert.Equal("ABCDX", GetLine(t, 0));
+        Assert.AreEqual("ABCDX", GetLine(t, 0));
     }
 
     // Ghostty: "Terminal: cursorLeft reverse wrap extended with pending wrap state"
-    [Fact]
+    [TestMethod]
     public void CursorLeft_ReverseWrapExtended_PendingWrapState()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -47,19 +47,19 @@ public class GhosttyReverseWrapConformanceTests
         Feed(t, "\u001b[?1045h"); // Enable extended reverse wrap
 
         Feed(t, "ABCDE"); // Fill row, pending wrap set
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
 
         Feed(t, "\u001b[D"); // CUB 1 — clears pending wrap
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
 
         Feed(t, "X"); // Overwrites last char
-        Assert.Equal("ABCDX", GetLine(t, 0));
+        Assert.AreEqual("ABCDX", GetLine(t, 0));
     }
 
     // Ghostty: "Terminal: cursorLeft reverse wrap"
     // CUB wraps to previous line's right margin when reverse wrap is enabled
     // and the previous line was soft-wrapped.
-    [Fact]
+    [TestMethod]
     public void CursorLeft_ReverseWrap()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -70,16 +70,16 @@ public class GhosttyReverseWrapConformanceTests
         Feed(t, "\u001b[2D"); // CUB 2: from col 1 → col 0 → wrap to row 0, col 4
 
         Feed(t, "X"); // Overwrites 'E' at row 0, col 4
-        Assert.True(t.PendingWrap); // Now at col 4 with pending wrap
+        Assert.IsTrue(t.PendingWrap); // Now at col 4 with pending wrap
 
-        Assert.Equal("ABCDX", GetLine(t, 0));
-        Assert.Equal("1", GetLine(t, 1).TrimEnd());
+        Assert.AreEqual("ABCDX", GetLine(t, 0));
+        Assert.AreEqual("1", GetLine(t, 1).TrimEnd());
     }
 
     // Ghostty: "Terminal: cursorLeft reverse wrap with no soft wrap"
     // When the previous line was NOT soft-wrapped (i.e., hard newline),
     // mode 45 reverse wrap does NOT cross the boundary.
-    [Fact]
+    [TestMethod]
     public void CursorLeft_ReverseWrap_NoSoftWrap()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -93,14 +93,14 @@ public class GhosttyReverseWrapConformanceTests
         Feed(t, "\u001b[2D"); // CUB 2: from col 1 → col 0 → can't wrap (no soft wrap) → stays col 0
 
         Feed(t, "X"); // Overwrites at row 1, col 0
-        Assert.Equal("ABCDE", GetLine(t, 0));
-        Assert.Equal("X", GetLine(t, 1).TrimEnd());
+        Assert.AreEqual("ABCDE", GetLine(t, 0));
+        Assert.AreEqual("X", GetLine(t, 1).TrimEnd());
     }
 
     // Ghostty: "Terminal: cursorLeft reverse wrap before left margin"
     // When cursor is within a scroll region and reverse wrap is enabled,
     // it should stop at the top of the scroll region.
-    [Fact]
+    [TestMethod]
     public void CursorLeft_ReverseWrap_BeforeLeftMargin()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -117,12 +117,12 @@ public class GhosttyReverseWrapConformanceTests
         // DECSTBM homes cursor. So cursor is at 0,0.
         // CUB 1 at col 0 with no soft wrap → stays at 0,0.
         // print 'X' → at col 0, row 0
-        Assert.Equal("X", GetLine(t, 2).TrimEnd());
+        Assert.AreEqual("X", GetLine(t, 2).TrimEnd());
     }
 
     // Ghostty: "Terminal: cursorLeft reverse wrap on first row"
     // When at the first row of the scroll region, reverse wrap stops.
-    [Fact]
+    [TestMethod]
     public void CursorLeft_ReverseWrap_FirstRow()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -133,8 +133,8 @@ public class GhosttyReverseWrapConformanceTests
         Feed(t, "\u001b[1;2H");  // CUP: row 1, col 2 (0-indexed: row 0, col 1)
         Feed(t, "\u001b[1000D"); // CUB 1000: massive left move, should clamp
 
-        Assert.Equal(0, t.CursorX);
-        Assert.Equal(0, t.CursorY);
+        Assert.AreEqual(0, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
     }
 
     #endregion
@@ -143,7 +143,7 @@ public class GhosttyReverseWrapConformanceTests
 
     // Ghostty: "Terminal: cursorLeft extended reverse wrap"
     // Extended mode wraps across hard line boundaries (unlike mode 45).
-    [Fact]
+    [TestMethod]
     public void CursorLeft_ExtendedReverseWrap()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -157,13 +157,13 @@ public class GhosttyReverseWrapConformanceTests
         Feed(t, "\u001b[2D"); // CUB 2: col 1 → col 0 → wraps to row 0, col 4 (even without soft wrap!)
 
         Feed(t, "X"); // Overwrites 'E' at row 0, col 4
-        Assert.Equal("ABCDX", GetLine(t, 0));
-        Assert.Equal("1", GetLine(t, 1).TrimEnd());
+        Assert.AreEqual("ABCDX", GetLine(t, 0));
+        Assert.AreEqual("1", GetLine(t, 1).TrimEnd());
     }
 
     // Ghostty: "Terminal: cursorLeft extended reverse wrap bottom wraparound"
     // Extended mode wraps from the top of the scroll region to the bottom.
-    [Fact]
+    [TestMethod]
     public void CursorLeft_ExtendedReverseWrap_BottomWraparound()
     {
         using var t = CreateTerminal(cols: 5, rows: 3);
@@ -178,14 +178,14 @@ public class GhosttyReverseWrapConformanceTests
         Feed(t, "\u001b[7D");
 
         Feed(t, "X");
-        Assert.Equal("ABCDE", GetLine(t, 0));
-        Assert.Equal("1", GetLine(t, 1).TrimEnd());
-        Assert.Equal("    X", GetLine(t, 2));
+        Assert.AreEqual("ABCDE", GetLine(t, 0));
+        Assert.AreEqual("1", GetLine(t, 1).TrimEnd());
+        Assert.AreEqual("    X", GetLine(t, 2));
     }
 
     // Ghostty: "Terminal: cursorLeft extended reverse wrap is priority if both set"
     // When both mode 45 and 1045 are set, 1045 (extended) takes priority.
-    [Fact]
+    [TestMethod]
     public void CursorLeft_ExtendedReverseWrap_PriorityOverMode45()
     {
         using var t = CreateTerminal(cols: 5, rows: 3);
@@ -200,14 +200,14 @@ public class GhosttyReverseWrapConformanceTests
         Feed(t, "\u001b[7D"); // CUB 7: same as bottom wraparound test
 
         Feed(t, "X");
-        Assert.Equal("ABCDE", GetLine(t, 0));
-        Assert.Equal("1", GetLine(t, 1).TrimEnd());
-        Assert.Equal("    X", GetLine(t, 2));
+        Assert.AreEqual("ABCDE", GetLine(t, 0));
+        Assert.AreEqual("1", GetLine(t, 1).TrimEnd());
+        Assert.AreEqual("    X", GetLine(t, 2));
     }
 
     // Ghostty: "Terminal: cursorLeft extended reverse wrap above top scroll region"
     // In extended mode, massive CUB above scroll region stops at (0, 0).
-    [Fact]
+    [TestMethod]
     public void CursorLeft_ExtendedReverseWrap_AboveTopScrollRegion()
     {
         using var t = CreateTerminal(cols: 5, rows: 5);
@@ -218,8 +218,8 @@ public class GhosttyReverseWrapConformanceTests
         Feed(t, "\u001b[2;1H");   // CUP: row 2, col 1 (0-indexed: row 1, col 0)
         Feed(t, "\u001b[1000D");  // CUB 1000
 
-        Assert.Equal(0, t.CursorX);
-        Assert.Equal(0, t.CursorY);
+        Assert.AreEqual(0, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyScrollConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyScrollConformanceTests.cs
@@ -1,4 +1,3 @@
-using Xunit;
 
 namespace Hex1b.Tests.Conformance.Ghostty;
 
@@ -6,14 +5,15 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// Tests for index (IND), reverse index (RI), scrollUp (SU), and scrollDown (SD).
 /// Translated from Ghostty's Terminal.zig.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyScrollConformanceTests
 {
     // ═══════════════════════════════════════════════════════════════
     // index (IND — ESC D, also triggered by LF at bottom of scroll region)
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void Index_Basic()
     {
         // Ghostty: "Terminal: index"
@@ -23,11 +23,11 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001bD");  // IND (ESC D)
         GhosttyTestFixture.Feed(t, "A");
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void Index_FromTheBottom()
     {
         // Ghostty: "Terminal: index from the bottom"
@@ -40,14 +40,14 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001bD");       // IND
         GhosttyTestFixture.Feed(t, "B");
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 3));
-        Assert.Equal("B", GhosttyTestFixture.GetLine(t, 4));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("B", GhosttyTestFixture.GetLine(t, 4));
     }
 
-    [Fact]
+    [TestMethod]
     public void Index_OutsideOfScrollingRegion()
     {
         // Ghostty: "Terminal: index outside of scrolling region"
@@ -57,10 +57,10 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;5r"); // setTopAndBottomMargin(2, 5)
         GhosttyTestFixture.Feed(t, "\u001b[1;1H"); // Home
         GhosttyTestFixture.Feed(t, "\u001bD");       // IND
-        Assert.Equal(1, t.CursorY);
+        Assert.AreEqual(1, t.CursorY);
     }
 
-    [Fact]
+    [TestMethod]
     public void Index_FromTheBottomOutsideOfScrollRegion()
     {
         // Ghostty: "Terminal: index from the bottom outside of scroll region"
@@ -73,14 +73,14 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001bD");       // IND — at row 5 (bottom), outside region
         GhosttyTestFixture.Feed(t, "B");
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 3));
-        Assert.Equal("AB", GhosttyTestFixture.GetLine(t, 4));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("AB", GhosttyTestFixture.GetLine(t, 4));
     }
 
-    [Fact]
+    [TestMethod]
     public void Index_NoScrollRegionTopOfScreen()
     {
         // Ghostty: "Terminal: index no scroll region, top of screen"
@@ -90,11 +90,11 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001bD"); // IND
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal(" X", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual(" X", GhosttyTestFixture.GetLine(t, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void Index_BottomOfPrimaryScreen()
     {
         // Ghostty: "Terminal: index bottom of primary screen"
@@ -106,14 +106,14 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001bD");       // IND
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 3));
-        Assert.Equal(" X", GhosttyTestFixture.GetLine(t, 4));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual(" X", GhosttyTestFixture.GetLine(t, 4));
     }
 
-    [Fact]
+    [TestMethod]
     public void Index_InsideScrollRegion()
     {
         // Ghostty: "Terminal: index inside scroll region"
@@ -125,11 +125,11 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001bD");       // IND
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal(" X", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual(" X", GhosttyTestFixture.GetLine(t, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void Index_BottomOfPrimaryScreenWithScrollRegion()
     {
         // Ghostty: "Terminal: index bottom of primary screen with scroll region"
@@ -141,16 +141,16 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001bD");       // IND at bottom of scroll region
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("B", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("C", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal(" X", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("B", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("C", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual(" X", GhosttyTestFixture.GetLine(t, 2));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // reverseIndex (RI — ESC M)
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void ReverseIndex_Basic()
     {
         // Ghostty: "Terminal: reverseIndex"
@@ -160,12 +160,12 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001bM");  // RI (reverse index)
         GhosttyTestFixture.Feed(t, "D\r\n\r\n");
 
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("BD", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("C", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("BD", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("C", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void ReverseIndex_FromTheTop()
     {
         // Ghostty: "Terminal: reverseIndex from the top"
@@ -180,13 +180,13 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001bM");       // RI
         GhosttyTestFixture.Feed(t, "E\r\n");
 
-        Assert.Equal("E", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("D", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("B", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("E", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("D", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("B", GhosttyTestFixture.GetLine(t, 3));
     }
 
-    [Fact]
+    [TestMethod]
     public void ReverseIndex_TopOfScreen()
     {
         // Ghostty: "Terminal: reverseIndex top of screen"
@@ -201,13 +201,13 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001bM");       // RI
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("X", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("B", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("C", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("X", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("B", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("C", GhosttyTestFixture.GetLine(t, 3));
     }
 
-    [Fact]
+    [TestMethod]
     public void ReverseIndex_NotTopOfScreen()
     {
         // Ghostty: "Terminal: reverseIndex not top of screen"
@@ -223,12 +223,12 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001bM");       // RI — at row 2, goes to row 1
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("X", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("B", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("C", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("X", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("B", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("C", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void ReverseIndex_TopBottomMargins()
     {
         // Ghostty: "Terminal: reverseIndex top/bottom margins"
@@ -244,12 +244,12 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;1H");
         GhosttyTestFixture.Feed(t, "\u001bM");       // RI at top of scroll region
 
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("B", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("B", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void ReverseIndex_OutsideTopBottomMargins()
     {
         // Ghostty: "Terminal: reverseIndex outside top/bottom margins"
@@ -265,16 +265,16 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H"); // row 1 (outside region)
         GhosttyTestFixture.Feed(t, "\u001bM");       // RI
 
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("B", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("C", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("B", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("C", GhosttyTestFixture.GetLine(t, 2));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // scrollUp (SU — CSI S)
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void ScrollUp_Simple()
     {
         // Ghostty: "Terminal: scrollUp simple"
@@ -284,14 +284,14 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H"); // setCursorPos(2,2)
         GhosttyTestFixture.Feed(t, "\u001b[1S");    // scrollUp(1)
 
-        Assert.Equal(1, t.CursorX); // cursor X preserved
-        Assert.Equal(1, t.CursorY); // cursor Y preserved
+        Assert.AreEqual(1, t.CursorX); // cursor X preserved
+        Assert.AreEqual(1, t.CursorY); // cursor Y preserved
 
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollUp_TopBottomScrollRegion()
     {
         // Ghostty: "Terminal: scrollUp top/bottom scroll region"
@@ -301,30 +301,30 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;4r"); // setTopAndBottomMargin(2, 4)
         GhosttyTestFixture.Feed(t, "\u001b[1S");    // scrollUp(1)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("JKL", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 3));
-        Assert.Equal("MNO", GhosttyTestFixture.GetLine(t, 4));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("JKL", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("MNO", GhosttyTestFixture.GetLine(t, 4));
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollUp_PreservesPendingWrap()
     {
         // Ghostty: "Terminal: scrollUp preserves pending wrap"
         var t = GhosttyTestFixture.CreateTerminal(5, 5);
 
         GhosttyTestFixture.Feed(t, "ABCDE");
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "\u001b[1S"); // scrollUp(1)
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
     }
 
     // ═══════════════════════════════════════════════════════════════
     // scrollDown (SD — CSI T)
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void ScrollDown_Simple()
     {
         // Ghostty: "Terminal: scrollDown simple"
@@ -334,16 +334,16 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;2H"); // setCursorPos(2,2)
         GhosttyTestFixture.Feed(t, "\u001b[1T");    // scrollDown(1)
 
-        Assert.Equal(1, t.CursorX); // cursor X preserved
-        Assert.Equal(1, t.CursorY); // cursor Y preserved
+        Assert.AreEqual(1, t.CursorX); // cursor X preserved
+        Assert.AreEqual(1, t.CursorY); // cursor Y preserved
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 3));
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollDown_OutsideOfScrollRegion()
     {
         // Ghostty: "Terminal: scrollDown outside of scroll region"
@@ -353,53 +353,53 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[2;4r"); // setTopAndBottomMargin(2, 4)
         GhosttyTestFixture.Feed(t, "\u001b[1T");    // scrollDown(1)
 
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 3));
-        Assert.Equal("MNO", GhosttyTestFixture.GetLine(t, 4));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("MNO", GhosttyTestFixture.GetLine(t, 4));
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollDown_PreservesPendingWrap()
     {
         // Ghostty: "Terminal: scrollDown preserves pending wrap"
         var t = GhosttyTestFixture.CreateTerminal(5, 5);
 
         GhosttyTestFixture.Feed(t, "ABCDE");
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "\u001b[1T"); // scrollDown(1)
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
     }
 
     // ═══════════════════════════════════════════════════════════════
     // Linefeed
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void Linefeed_UnsetsPendingWrap()
     {
         // Ghostty: "Terminal: linefeed unsets pending wrap"
         var t = GhosttyTestFixture.CreateTerminal(5, 5);
 
         GhosttyTestFixture.Feed(t, "ABCDE");
-        Assert.True(t.PendingWrap);
+        Assert.IsTrue(t.PendingWrap);
         GhosttyTestFixture.Feed(t, "\n");
-        Assert.False(t.PendingWrap);
+        Assert.IsFalse(t.PendingWrap);
     }
 
-    [Fact]
+    [TestMethod]
     public void Linefeed_AndCarriageReturn()
     {
         // Ghostty: "Terminal: linefeed and carriage return"
         var t = GhosttyTestFixture.CreateTerminal(5, 5);
 
         GhosttyTestFixture.Feed(t, "ABC\r\nDEF");
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void Linefeed_ModeAutomaticCarriageReturn()
     {
         // Ghostty: "Terminal: linefeed mode automatic carriage return"
@@ -408,15 +408,15 @@ public class GhosttyScrollConformanceTests
 
         GhosttyTestFixture.Feed(t, "\u001b[20h");  // Set LNM mode
         GhosttyTestFixture.Feed(t, "ABC\nDEF");
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 1));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // setTopAndBottomMargin (DECSTBM — CSI r)
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void SetTopAndBottomMargin_Simple()
     {
         // Ghostty: "Terminal: setTopAndBottomMargin simple"
@@ -428,7 +428,7 @@ public class GhosttyScrollConformanceTests
         // by scrolling down from bottom
     }
 
-    [Fact]
+    [TestMethod]
     public void SetTopAndBottomMargin_TopAndBottom()
     {
         // Ghostty: "Terminal: setTopAndBottomMargin top and bottom"
@@ -436,15 +436,15 @@ public class GhosttyScrollConformanceTests
 
         GhosttyTestFixture.Feed(t, "\u001b[2;4r"); // top=2, bottom=4
         // Verify cursor moved to home
-        Assert.Equal(0, t.CursorX);
-        Assert.Equal(0, t.CursorY);
+        Assert.AreEqual(0, t.CursorX);
+        Assert.AreEqual(0, t.CursorY);
     }
 
     // ═══════════════════════════════════════════════════════════════
     // setLeftAndRightMargin (DECSLRM — CSI s with mode 69)
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void SetLeftAndRightMargin_Simple()
     {
         // Ghostty: "Terminal: setLeftAndRightMargin simple"
@@ -460,12 +460,12 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[0;0s");  // left=0, right=0 → reset to full width
         // Cursor moves to home after DECSLRM
         GhosttyTestFixture.Feed(t, "\u001b[X");     // Erase 1 char at home
-        Assert.Equal(" BC", GhosttyTestFixture.GetLine(t, 0).Substring(0, 3));
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual(" BC", GhosttyTestFixture.GetLine(t, 0).Substring(0, 3));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void SetLeftAndRightMargin_Mode69Unset()
     {
         // Ghostty: "Terminal: setLeftAndRightMargin mode 69 unset"
@@ -482,17 +482,17 @@ public class GhosttyScrollConformanceTests
         // Mode 69 is NOT set, so CSI s is save cursor, not DECSLRM
         GhosttyTestFixture.Feed(t, "\u001b[1;2H"); // setCursorPos(1,2) → row 0, col 1
         GhosttyTestFixture.Feed(t, "\u001b[L");     // insertLines(1)
-        Assert.Equal("", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("ABC", GhosttyTestFixture.GetLine(t, 1));
-        Assert.Equal("DEF", GhosttyTestFixture.GetLine(t, 2));
-        Assert.Equal("GHI", GhosttyTestFixture.GetLine(t, 3));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("ABC", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("DEF", GhosttyTestFixture.GetLine(t, 2));
+        Assert.AreEqual("GHI", GhosttyTestFixture.GetLine(t, 3));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // printRepeat (REP — CSI b)
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void PrintRepeat_Simple()
     {
         // Ghostty: "Terminal: printRepeat simple"
@@ -502,10 +502,10 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[3b"); // REP 3
         GhosttyTestFixture.Feed(t, "B");
 
-        Assert.Equal("AAAAB", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("AAAAB", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void PrintRepeat_NoPreviousCharacter()
     {
         // Ghostty: "Terminal: printRepeat no previous character"
@@ -515,10 +515,10 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "B");
 
         // No previous char — REP is a no-op
-        Assert.Equal("B", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("B", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void PrintRepeat_Wrap()
     {
         // Ghostty: "Terminal: printRepeat wrap"
@@ -527,15 +527,15 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "A");
         GhosttyTestFixture.Feed(t, "\u001b[5b"); // REP 5 → wraps
 
-        Assert.Equal("AAA", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("AAA", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("AAA", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("AAA", GhosttyTestFixture.GetLine(t, 1));
     }
 
     // ═══════════════════════════════════════════════════════════════
     // Zero-width character
     // ═══════════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void ZeroWidthCharacterAtStart()
     {
         // Ghostty: "Terminal: zero-width character at start"
@@ -546,6 +546,6 @@ public class GhosttyScrollConformanceTests
         GhosttyTestFixture.Feed(t, "A");
 
         // Should not crash — the combining char is dropped or handled gracefully
-        Assert.Equal("A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("A", GhosttyTestFixture.GetLine(t, 0));
     }
 }

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyScrollMarginConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyScrollMarginConformanceTests.cs
@@ -1,6 +1,5 @@
 using System;
 using Hex1b;
-using Xunit;
 
 namespace Hex1b.Tests.Conformance.Ghostty;
 
@@ -8,7 +7,8 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// Ghostty conformance tests — Phase 2 Tier 2 Batch 2:
 /// Scroll up/down, index/reverseIndex with margins, setLeftAndRightMargin, insertLines with L/R margins.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyScrollMarginConformanceTests
 {
     private static Hex1bTerminal CreateTerminal(int cols, int rows) => GhosttyTestFixture.CreateTerminal(cols, rows);
@@ -18,7 +18,7 @@ public class GhosttyScrollMarginConformanceTests
     #region scrollUp (CSI n S)
 
     // Ghostty: test "Terminal: scrollUp simple"
-    [Fact]
+    [TestMethod]
     public void ScrollUp_Simple()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -26,17 +26,17 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[2;2H"); // CUP(2,2) → row 1, col 1
         Feed(terminal, "\x1b[1S"); // SU(1)
 
-        Assert.Equal("DEF", GetLine(terminal, 0));
-        Assert.Equal("GHI", GetLine(terminal, 1));
-        Assert.Equal("", GetLine(terminal, 2));
+        Assert.AreEqual("DEF", GetLine(terminal, 0));
+        Assert.AreEqual("GHI", GetLine(terminal, 1));
+        Assert.AreEqual("", GetLine(terminal, 2));
 
         // Cursor position should be preserved
-        Assert.Equal(1, terminal.CursorX);
-        Assert.Equal(1, terminal.CursorY);
+        Assert.AreEqual(1, terminal.CursorX);
+        Assert.AreEqual(1, terminal.CursorY);
     }
 
     // Ghostty: test "Terminal: scrollUp top/bottom scroll region"
-    [Fact]
+    [TestMethod]
     public void ScrollUp_TopBottomScrollRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -45,13 +45,13 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[1;1H"); // CUP(1,1) → top
         Feed(terminal, "\x1b[1S"); // SU(1)
 
-        Assert.Equal("ABC", GetLine(terminal, 0));
-        Assert.Equal("GHI", GetLine(terminal, 1));
-        Assert.Equal("", GetLine(terminal, 2));
+        Assert.AreEqual("ABC", GetLine(terminal, 0));
+        Assert.AreEqual("GHI", GetLine(terminal, 1));
+        Assert.AreEqual("", GetLine(terminal, 2));
     }
 
     // Ghostty: test "Terminal: scrollUp left/right scroll region"
-    [Fact]
+    [TestMethod]
     public void ScrollUp_LeftRightScrollRegion()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 10);
@@ -61,13 +61,13 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[2;2H"); // CUP(2,2)
         Feed(terminal, "\x1b[1S"); // SU(1)
 
-        Assert.Equal("AEF423", GetLine(terminal, 0));
-        Assert.Equal("DHI756", GetLine(terminal, 1));
-        Assert.Equal("G   89", GetLine(terminal, 2));
+        Assert.AreEqual("AEF423", GetLine(terminal, 0));
+        Assert.AreEqual("DHI756", GetLine(terminal, 1));
+        Assert.AreEqual("G   89", GetLine(terminal, 2));
     }
 
     // Ghostty: test "Terminal: scrollUp preserves pending wrap"
-    [Fact]
+    [TestMethod]
     public void ScrollUp_PreservesPendingWrap()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -80,14 +80,14 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[1S"); // SU(1)
         Feed(terminal, "X"); // Should wrap to next line since pending wrap preserved
 
-        Assert.Equal("    B", GetLine(terminal, 0));
-        Assert.Equal("    C", GetLine(terminal, 1));
-        Assert.Equal("", GetLine(terminal, 2));
-        Assert.Equal("X", GetLine(terminal, 3));
+        Assert.AreEqual("    B", GetLine(terminal, 0));
+        Assert.AreEqual("    C", GetLine(terminal, 1));
+        Assert.AreEqual("", GetLine(terminal, 2));
+        Assert.AreEqual("X", GetLine(terminal, 3));
     }
 
     // Ghostty: test "Terminal: scrollUp full top/bottom region"
-    [Fact]
+    [TestMethod]
     public void ScrollUp_FullTopBottomRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -97,13 +97,13 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[2;5r"); // DECSTBM(2,5)
         Feed(terminal, "\x1b[4S"); // SU(4) — scroll up 4 times within region
 
-        Assert.Equal("top", GetLine(terminal, 0));
-        Assert.Equal("", GetLine(terminal, 1));
-        Assert.Equal("", GetLine(terminal, 2));
+        Assert.AreEqual("top", GetLine(terminal, 0));
+        Assert.AreEqual("", GetLine(terminal, 1));
+        Assert.AreEqual("", GetLine(terminal, 2));
     }
 
     // Ghostty: test "Terminal: scrollUp full top/bottomleft/right scroll region"
-    [Fact]
+    [TestMethod]
     public void ScrollUp_FullTopBottomLeftRightRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -115,11 +115,11 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[2;4s"); // DECSLRM(2,4)
         Feed(terminal, "\x1b[4S"); // SU(4)
 
-        Assert.Equal("top", GetLine(terminal, 0));
-        Assert.Equal("", GetLine(terminal, 1));
-        Assert.Equal("", GetLine(terminal, 2));
-        Assert.Equal("", GetLine(terminal, 3));
-        Assert.Equal("A   E", GetLine(terminal, 4));
+        Assert.AreEqual("top", GetLine(terminal, 0));
+        Assert.AreEqual("", GetLine(terminal, 1));
+        Assert.AreEqual("", GetLine(terminal, 2));
+        Assert.AreEqual("", GetLine(terminal, 3));
+        Assert.AreEqual("A   E", GetLine(terminal, 4));
     }
 
     #endregion
@@ -127,7 +127,7 @@ public class GhosttyScrollMarginConformanceTests
     #region scrollDown (CSI n T)
 
     // Ghostty: test "Terminal: scrollDown simple"
-    [Fact]
+    [TestMethod]
     public void ScrollDown_Simple()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -135,18 +135,18 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[2;2H"); // CUP(2,2)
         Feed(terminal, "\x1b[1T"); // SD(1)
 
-        Assert.Equal("", GetLine(terminal, 0));
-        Assert.Equal("ABC", GetLine(terminal, 1));
-        Assert.Equal("DEF", GetLine(terminal, 2));
-        Assert.Equal("GHI", GetLine(terminal, 3));
+        Assert.AreEqual("", GetLine(terminal, 0));
+        Assert.AreEqual("ABC", GetLine(terminal, 1));
+        Assert.AreEqual("DEF", GetLine(terminal, 2));
+        Assert.AreEqual("GHI", GetLine(terminal, 3));
 
         // Cursor preserved
-        Assert.Equal(1, terminal.CursorX);
-        Assert.Equal(1, terminal.CursorY);
+        Assert.AreEqual(1, terminal.CursorX);
+        Assert.AreEqual(1, terminal.CursorY);
     }
 
     // Ghostty: test "Terminal: scrollDown outside of scroll region"
-    [Fact]
+    [TestMethod]
     public void ScrollDown_OutsideScrollRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -155,14 +155,14 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[2;2H"); // CUP(2,2) → inside margin
         Feed(terminal, "\x1b[1T"); // SD(1)
 
-        Assert.Equal("ABC", GetLine(terminal, 0));
-        Assert.Equal("DEF", GetLine(terminal, 1));
-        Assert.Equal("", GetLine(terminal, 2));
-        Assert.Equal("GHI", GetLine(terminal, 3));
+        Assert.AreEqual("ABC", GetLine(terminal, 0));
+        Assert.AreEqual("DEF", GetLine(terminal, 1));
+        Assert.AreEqual("", GetLine(terminal, 2));
+        Assert.AreEqual("GHI", GetLine(terminal, 3));
     }
 
     // Ghostty: test "Terminal: scrollDown left/right scroll region"
-    [Fact]
+    [TestMethod]
     public void ScrollDown_LeftRightScrollRegion()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 10);
@@ -172,14 +172,14 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[2;2H"); // CUP(2,2)
         Feed(terminal, "\x1b[1T"); // SD(1)
 
-        Assert.Equal("A   23", GetLine(terminal, 0));
-        Assert.Equal("DBC156", GetLine(terminal, 1));
-        Assert.Equal("GEF489", GetLine(terminal, 2));
-        Assert.Equal(" HI7", GetLine(terminal, 3));
+        Assert.AreEqual("A   23", GetLine(terminal, 0));
+        Assert.AreEqual("DBC156", GetLine(terminal, 1));
+        Assert.AreEqual("GEF489", GetLine(terminal, 2));
+        Assert.AreEqual(" HI7", GetLine(terminal, 3));
     }
 
     // Ghostty: test "Terminal: scrollDown outside of left/right scroll region"
-    [Fact]
+    [TestMethod]
     public void ScrollDown_OutsideLeftRightScrollRegion()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 10);
@@ -190,14 +190,14 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[1T"); // SD(1)
 
         // Ghostty: same as inside since scrollDown affects the region regardless of cursor column
-        Assert.Equal("A   23", GetLine(terminal, 0));
-        Assert.Equal("DBC156", GetLine(terminal, 1));
-        Assert.Equal("GEF489", GetLine(terminal, 2));
-        Assert.Equal(" HI7", GetLine(terminal, 3));
+        Assert.AreEqual("A   23", GetLine(terminal, 0));
+        Assert.AreEqual("DBC156", GetLine(terminal, 1));
+        Assert.AreEqual("GEF489", GetLine(terminal, 2));
+        Assert.AreEqual(" HI7", GetLine(terminal, 3));
     }
 
     // Ghostty: test "Terminal: scrollDown preserves pending wrap"
-    [Fact]
+    [TestMethod]
     public void ScrollDown_PreservesPendingWrap()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 10);
@@ -210,10 +210,10 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[1T"); // SD(1)
         Feed(terminal, "X"); // Should wrap due to preserved pending wrap
 
-        Assert.Equal("", GetLine(terminal, 0));
-        Assert.Equal("    A", GetLine(terminal, 1));
-        Assert.Equal("    B", GetLine(terminal, 2));
-        Assert.Equal("X   C", GetLine(terminal, 3));
+        Assert.AreEqual("", GetLine(terminal, 0));
+        Assert.AreEqual("    A", GetLine(terminal, 1));
+        Assert.AreEqual("    B", GetLine(terminal, 2));
+        Assert.AreEqual("X   C", GetLine(terminal, 3));
     }
 
     #endregion
@@ -221,7 +221,7 @@ public class GhosttyScrollMarginConformanceTests
     #region setLeftAndRightMargin (DECSLRM)
 
     // Ghostty: test "Terminal: setLeftAndRightMargin simple"
-    [Fact]
+    [TestMethod]
     public void SetLeftAndRightMargin_Simple()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -231,12 +231,12 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[1;1H"); // CUP(1,1)
         Feed(terminal, "\x1b[1X"); // ECH(1)
 
-        Assert.Equal(" BC", GetLine(terminal, 0));
-        Assert.Equal("DEF", GetLine(terminal, 1));
+        Assert.AreEqual(" BC", GetLine(terminal, 0));
+        Assert.AreEqual("DEF", GetLine(terminal, 1));
     }
 
     // Ghostty: test "Terminal: setLeftAndRightMargin left only"
-    [Fact]
+    [TestMethod]
     public void SetLeftAndRightMargin_LeftOnly()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -246,14 +246,14 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[1;2H"); // CUP(1,2) → col 1
         Feed(terminal, "\x1b[1L"); // IL(1)
 
-        Assert.Equal("A", GetLine(terminal, 0));
-        Assert.Equal("DBC", GetLine(terminal, 1));
-        Assert.Equal("GEF", GetLine(terminal, 2));
-        Assert.Equal(" HI", GetLine(terminal, 3));
+        Assert.AreEqual("A", GetLine(terminal, 0));
+        Assert.AreEqual("DBC", GetLine(terminal, 1));
+        Assert.AreEqual("GEF", GetLine(terminal, 2));
+        Assert.AreEqual(" HI", GetLine(terminal, 3));
     }
 
     // Ghostty: test "Terminal: setLeftAndRightMargin left and right"
-    [Fact]
+    [TestMethod]
     public void SetLeftAndRightMargin_LeftAndRight()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -263,14 +263,14 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[1;2H"); // CUP(1,2) → col 1
         Feed(terminal, "\x1b[1L"); // IL(1)
 
-        Assert.Equal("  C", GetLine(terminal, 0));
-        Assert.Equal("ABF", GetLine(terminal, 1));
-        Assert.Equal("DEI", GetLine(terminal, 2));
-        Assert.Equal("GH", GetLine(terminal, 3));
+        Assert.AreEqual("  C", GetLine(terminal, 0));
+        Assert.AreEqual("ABF", GetLine(terminal, 1));
+        Assert.AreEqual("DEI", GetLine(terminal, 2));
+        Assert.AreEqual("GH", GetLine(terminal, 3));
     }
 
     // Ghostty: test "Terminal: setLeftAndRightMargin left equal right"
-    [Fact]
+    [TestMethod]
     public void SetLeftAndRightMargin_LeftEqualRight()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -280,14 +280,14 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[1;2H"); // CUP(1,2)
         Feed(terminal, "\x1b[1L"); // IL(1)
 
-        Assert.Equal("", GetLine(terminal, 0));
-        Assert.Equal("ABC", GetLine(terminal, 1));
-        Assert.Equal("DEF", GetLine(terminal, 2));
-        Assert.Equal("GHI", GetLine(terminal, 3));
+        Assert.AreEqual("", GetLine(terminal, 0));
+        Assert.AreEqual("ABC", GetLine(terminal, 1));
+        Assert.AreEqual("DEF", GetLine(terminal, 2));
+        Assert.AreEqual("GHI", GetLine(terminal, 3));
     }
 
     // Ghostty: test "Terminal: setLeftAndRightMargin mode 69 unset"
-    [Fact]
+    [TestMethod]
     public void SetLeftAndRightMargin_Mode69Unset()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -297,10 +297,10 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[1;2H"); // CUP(1,2) → col 1
         Feed(terminal, "\x1b[1L"); // IL(1) — should use full width
 
-        Assert.Equal("", GetLine(terminal, 0));
-        Assert.Equal("ABC", GetLine(terminal, 1));
-        Assert.Equal("DEF", GetLine(terminal, 2));
-        Assert.Equal("GHI", GetLine(terminal, 3));
+        Assert.AreEqual("", GetLine(terminal, 0));
+        Assert.AreEqual("ABC", GetLine(terminal, 1));
+        Assert.AreEqual("DEF", GetLine(terminal, 2));
+        Assert.AreEqual("GHI", GetLine(terminal, 3));
     }
 
     #endregion
@@ -308,7 +308,7 @@ public class GhosttyScrollMarginConformanceTests
     #region insertLines with L/R scroll region
 
     // Ghostty: test "Terminal: insertLines left/right scroll region"
-    [Fact]
+    [TestMethod]
     public void InsertLines_LeftRightScrollRegion()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 10);
@@ -318,10 +318,10 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[2;2H"); // CUP(2,2)
         Feed(terminal, "\x1b[1L"); // IL(1)
 
-        Assert.Equal("ABC123", GetLine(terminal, 0));
-        Assert.Equal("D   56", GetLine(terminal, 1));
-        Assert.Equal("GEF489", GetLine(terminal, 2));
-        Assert.Equal(" HI7", GetLine(terminal, 3));
+        Assert.AreEqual("ABC123", GetLine(terminal, 0));
+        Assert.AreEqual("D   56", GetLine(terminal, 1));
+        Assert.AreEqual("GEF489", GetLine(terminal, 2));
+        Assert.AreEqual(" HI7", GetLine(terminal, 3));
     }
 
     #endregion
@@ -329,7 +329,7 @@ public class GhosttyScrollMarginConformanceTests
     #region index (ESC D / IND)
 
     // Ghostty: test "Terminal: index no scroll region, top of screen"
-    [Fact]
+    [TestMethod]
     public void Index_NoScrollRegion_TopOfScreen()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -337,12 +337,12 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\u001bD"); // IND
         Feed(terminal, "X");
 
-        Assert.Equal("A", GetLine(terminal, 0));
-        Assert.Equal(" X", GetLine(terminal, 1));
+        Assert.AreEqual("A", GetLine(terminal, 0));
+        Assert.AreEqual(" X", GetLine(terminal, 1));
     }
 
     // Ghostty: test "Terminal: index bottom of primary screen"
-    [Fact]
+    [TestMethod]
     public void Index_BottomOfPrimaryScreen()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -351,15 +351,15 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\u001bD"); // IND — scrolls
         Feed(terminal, "X");
 
-        Assert.Equal("", GetLine(terminal, 0));
-        Assert.Equal("", GetLine(terminal, 1));
-        Assert.Equal("", GetLine(terminal, 2));
-        Assert.Equal("A", GetLine(terminal, 3));
-        Assert.Equal(" X", GetLine(terminal, 4));
+        Assert.AreEqual("", GetLine(terminal, 0));
+        Assert.AreEqual("", GetLine(terminal, 1));
+        Assert.AreEqual("", GetLine(terminal, 2));
+        Assert.AreEqual("A", GetLine(terminal, 3));
+        Assert.AreEqual(" X", GetLine(terminal, 4));
     }
 
     // Ghostty: test "Terminal: index inside scroll region"
-    [Fact]
+    [TestMethod]
     public void Index_InsideScrollRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -368,24 +368,24 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\u001bD"); // IND
         Feed(terminal, "X");
 
-        Assert.Equal("A", GetLine(terminal, 0));
-        Assert.Equal(" X", GetLine(terminal, 1));
+        Assert.AreEqual("A", GetLine(terminal, 0));
+        Assert.AreEqual(" X", GetLine(terminal, 1));
     }
 
     // Ghostty: test "Terminal: index outside of scrolling region"
-    [Fact]
+    [TestMethod]
     public void Index_OutsideOfScrollingRegion()
     {
         using var terminal = CreateTerminal(cols: 2, rows: 5);
         Feed(terminal, "\x1b[2;5r"); // DECSTBM(2,5) — cursor at row 0 is outside
         Feed(terminal, "\u001bD"); // IND — should just move down (outside region)
 
-        Assert.Equal(0, terminal.CursorX);
-        Assert.Equal(1, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorX);
+        Assert.AreEqual(1, terminal.CursorY);
     }
 
     // Ghostty: test "Terminal: index from the bottom outside of scroll region"
-    [Fact]
+    [TestMethod]
     public void Index_FromBottomOutsideScrollRegion()
     {
         using var terminal = CreateTerminal(cols: 2, rows: 5);
@@ -395,15 +395,15 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\u001bD"); // IND — at bottom, outside scroll region, no scroll
         Feed(terminal, "B");
 
-        Assert.Equal("", GetLine(terminal, 0));
-        Assert.Equal("", GetLine(terminal, 1));
-        Assert.Equal("", GetLine(terminal, 2));
-        Assert.Equal("", GetLine(terminal, 3));
-        Assert.Equal("AB", GetLine(terminal, 4));
+        Assert.AreEqual("", GetLine(terminal, 0));
+        Assert.AreEqual("", GetLine(terminal, 1));
+        Assert.AreEqual("", GetLine(terminal, 2));
+        Assert.AreEqual("", GetLine(terminal, 3));
+        Assert.AreEqual("AB", GetLine(terminal, 4));
     }
 
     // Ghostty: test "Terminal: index bottom of primary screen with scroll region"
-    [Fact]
+    [TestMethod]
     public void Index_BottomWithScrollRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -414,14 +414,14 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[3;1H"); // CUP(3,1)
         Feed(terminal, "\u001bD"); // IND — at bottom of scroll region, scrolls within region
 
-        Assert.Equal("2", GetLine(terminal, 0));
-        Assert.Equal("3", GetLine(terminal, 1));
-        Assert.Equal("", GetLine(terminal, 2));
-        Assert.Equal("X", GetLine(terminal, 3));
+        Assert.AreEqual("2", GetLine(terminal, 0));
+        Assert.AreEqual("3", GetLine(terminal, 1));
+        Assert.AreEqual("", GetLine(terminal, 2));
+        Assert.AreEqual("X", GetLine(terminal, 3));
     }
 
     // Ghostty: test "Terminal: index outside left/right margin"
-    [Fact]
+    [TestMethod]
     public void Index_OutsideLeftRightMargin()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -435,13 +435,13 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "X");
 
         // Cursor stays at row 2 (no scroll since outside L/R), X printed at row 2 col 0
-        Assert.Equal("", GetLine(terminal, 0));
-        Assert.Equal("", GetLine(terminal, 1));
-        Assert.Equal("X A", GetLine(terminal, 2));
+        Assert.AreEqual("", GetLine(terminal, 0));
+        Assert.AreEqual("", GetLine(terminal, 1));
+        Assert.AreEqual("X A", GetLine(terminal, 2));
     }
 
     // Ghostty: test "Terminal: index inside left/right margin"
-    [Fact]
+    [TestMethod]
     public void Index_InsideLeftRightMargin()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -452,12 +452,12 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[3;1H"); // CUP(3,1) → bottom of scroll region, inside margin
         Feed(terminal, "\u001bD"); // IND — scrolls within L/R margin region
 
-        Assert.Equal(2, terminal.CursorY);
-        Assert.Equal(0, terminal.CursorX);
+        Assert.AreEqual(2, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorX);
 
-        Assert.Equal("AAAAAA", GetLine(terminal, 0));
-        Assert.Equal("AAAAAA", GetLine(terminal, 1));
-        Assert.Equal("   AAA", GetLine(terminal, 2));
+        Assert.AreEqual("AAAAAA", GetLine(terminal, 0));
+        Assert.AreEqual("AAAAAA", GetLine(terminal, 1));
+        Assert.AreEqual("   AAA", GetLine(terminal, 2));
     }
 
     #endregion
@@ -465,7 +465,7 @@ public class GhosttyScrollMarginConformanceTests
     #region reverseIndex (ESC M / RI)
 
     // Ghostty: test "Terminal: reverseIndex top of scrolling region"
-    [Fact]
+    [TestMethod]
     public void ReverseIndex_TopOfScrollingRegion()
     {
         using var terminal = CreateTerminal(cols: 2, rows: 10);
@@ -476,15 +476,15 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1bM"); // RI — reverse index at top of scroll region → scroll down
         Feed(terminal, "X");
 
-        Assert.Equal("", GetLine(terminal, 0));
-        Assert.Equal("X", GetLine(terminal, 1));
-        Assert.Equal("A", GetLine(terminal, 2));
-        Assert.Equal("B", GetLine(terminal, 3));
-        Assert.Equal("C", GetLine(terminal, 4));
+        Assert.AreEqual("", GetLine(terminal, 0));
+        Assert.AreEqual("X", GetLine(terminal, 1));
+        Assert.AreEqual("A", GetLine(terminal, 2));
+        Assert.AreEqual("B", GetLine(terminal, 3));
+        Assert.AreEqual("C", GetLine(terminal, 4));
     }
 
     // Ghostty: test "Terminal: reverseIndex top of screen"
-    [Fact]
+    [TestMethod]
     public void ReverseIndex_TopOfScreen()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -497,14 +497,14 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1bM"); // RI — at row 0, scrolls down
         Feed(terminal, "X");
 
-        Assert.Equal("X", GetLine(terminal, 0));
-        Assert.Equal("A", GetLine(terminal, 1));
-        Assert.Equal("B", GetLine(terminal, 2));
-        Assert.Equal("C", GetLine(terminal, 3));
+        Assert.AreEqual("X", GetLine(terminal, 0));
+        Assert.AreEqual("A", GetLine(terminal, 1));
+        Assert.AreEqual("B", GetLine(terminal, 2));
+        Assert.AreEqual("C", GetLine(terminal, 3));
     }
 
     // Ghostty: test "Terminal: reverseIndex not top of screen"
-    [Fact]
+    [TestMethod]
     public void ReverseIndex_NotTopOfScreen()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -517,13 +517,13 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1bM"); // RI — not at top, just moves up
         Feed(terminal, "X");
 
-        Assert.Equal("X", GetLine(terminal, 0));
-        Assert.Equal("B", GetLine(terminal, 1));
-        Assert.Equal("C", GetLine(terminal, 2));
+        Assert.AreEqual("X", GetLine(terminal, 0));
+        Assert.AreEqual("B", GetLine(terminal, 1));
+        Assert.AreEqual("C", GetLine(terminal, 2));
     }
 
     // Ghostty: test "Terminal: reverseIndex top/bottom margins"
-    [Fact]
+    [TestMethod]
     public void ReverseIndex_TopBottomMargins()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -536,13 +536,13 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[2;1H"); // CUP(2,1) → top of margin
         Feed(terminal, "\x1bM"); // RI — at top of margin, scrolls within margin
 
-        Assert.Equal("A", GetLine(terminal, 0));
-        Assert.Equal("", GetLine(terminal, 1));
-        Assert.Equal("B", GetLine(terminal, 2));
+        Assert.AreEqual("A", GetLine(terminal, 0));
+        Assert.AreEqual("", GetLine(terminal, 1));
+        Assert.AreEqual("B", GetLine(terminal, 2));
     }
 
     // Ghostty: test "Terminal: reverseIndex outside top/bottom margins"
-    [Fact]
+    [TestMethod]
     public void ReverseIndex_OutsideTopBottomMargins()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -555,13 +555,13 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[1;1H"); // CUP(1,1) → above margin
         Feed(terminal, "\x1bM"); // RI — outside margin, no scroll, just clamp
 
-        Assert.Equal("A", GetLine(terminal, 0));
-        Assert.Equal("B", GetLine(terminal, 1));
-        Assert.Equal("C", GetLine(terminal, 2));
+        Assert.AreEqual("A", GetLine(terminal, 0));
+        Assert.AreEqual("B", GetLine(terminal, 1));
+        Assert.AreEqual("C", GetLine(terminal, 2));
     }
 
     // Ghostty: test "Terminal: reverseIndex left/right margins"
-    [Fact]
+    [TestMethod]
     public void ReverseIndex_LeftRightMargins()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -575,14 +575,14 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[1;2H"); // CUP(1,2) → inside margin, at top
         Feed(terminal, "\x1bM"); // RI — at top with L/R margins
 
-        Assert.Equal("A", GetLine(terminal, 0));
-        Assert.Equal("DBC", GetLine(terminal, 1));
-        Assert.Equal("GEF", GetLine(terminal, 2));
-        Assert.Equal(" HI", GetLine(terminal, 3));
+        Assert.AreEqual("A", GetLine(terminal, 0));
+        Assert.AreEqual("DBC", GetLine(terminal, 1));
+        Assert.AreEqual("GEF", GetLine(terminal, 2));
+        Assert.AreEqual(" HI", GetLine(terminal, 3));
     }
 
     // Ghostty: test "Terminal: reverseIndex outside left/right margins"
-    [Fact]
+    [TestMethod]
     public void ReverseIndex_OutsideLeftRightMargins()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -596,13 +596,13 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\x1b[1;1H"); // CUP(1,1) → outside left margin
         Feed(terminal, "\x1bM"); // RI — outside L/R margin, no scroll
 
-        Assert.Equal("ABC", GetLine(terminal, 0));
-        Assert.Equal("DEF", GetLine(terminal, 1));
-        Assert.Equal("GHI", GetLine(terminal, 2));
+        Assert.AreEqual("ABC", GetLine(terminal, 0));
+        Assert.AreEqual("DEF", GetLine(terminal, 1));
+        Assert.AreEqual("GHI", GetLine(terminal, 2));
     }
 
     // Ghostty: test "Terminal: index bottom of scroll region no scrollback"
-    [Fact]
+    [TestMethod]
     public void Index_BottomOfScrollRegion_NoScrollback()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -614,10 +614,10 @@ public class GhosttyScrollMarginConformanceTests
         Feed(terminal, "\u001bD"); // IND — at bottom of scroll region
         Feed(terminal, "X");
 
-        Assert.Equal("", GetLine(terminal, 0));
-        Assert.Equal("A", GetLine(terminal, 1));
-        Assert.Equal(" X", GetLine(terminal, 2));
-        Assert.Equal("B", GetLine(terminal, 3));
+        Assert.AreEqual("", GetLine(terminal, 0));
+        Assert.AreEqual("A", GetLine(terminal, 1));
+        Assert.AreEqual(" X", GetLine(terminal, 2));
+        Assert.AreEqual("B", GetLine(terminal, 3));
     }
 
     #endregion

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyScrollRegionConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyScrollRegionConformanceTests.cs
@@ -8,7 +8,8 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// Source: https://github.com/ghostty-org/ghostty/blob/main/src/terminal/Terminal.zig
 /// Tests exercise DECSTBM (set top/bottom margins), IL, DL, SU, SD, and RI operations.
 /// </remarks>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyScrollRegionConformanceTests
 {
     private static Hex1bTerminal CreateTerminal(int cols = 80, int rows = 24)
@@ -20,13 +21,13 @@ public class GhosttyScrollRegionConformanceTests
         for (int i = 0; i < expectedLines.Length; i++)
         {
             var actualLine = GhosttyTestFixture.GetLine(terminal, i);
-            Assert.Equal(expectedLines[i], actualLine);
+            Assert.AreEqual(expectedLines[i], actualLine);
         }
 
         for (int i = expectedLines.Length; i < terminal.Height; i++)
         {
             var line = GhosttyTestFixture.GetLine(terminal, i);
-            Assert.Equal("", line);
+            Assert.AreEqual("", line);
         }
     }
 
@@ -41,7 +42,7 @@ public class GhosttyScrollRegionConformanceTests
     /// 5×5 terminal. Write ABC, DEF, GHI. Set margins to full screen (0,0). ScrollDown(1).
     /// Content shifts down by 1, blank line at top.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void SetTopAndBottomMargin_Simple_ScrollsDownFullScreen()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -59,7 +60,7 @@ public class GhosttyScrollRegionConformanceTests
     /// 5×5 terminal. Write ABC, DEF, GHI. Set margin top=2 (1-based), bottom=full.
     /// ScrollDown(1). Only rows 2–5 shift; row 1 stays.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void SetTopAndBottomMargin_TopOnly_ScrollsWithinLowerRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -77,7 +78,7 @@ public class GhosttyScrollRegionConformanceTests
     /// 5×5 terminal. Write ABC, DEF, GHI. Set margin rows 1–2.
     /// ScrollDown(1). DEF pushed out of region, GHI untouched below.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void SetTopAndBottomMargin_TopAndBottom_ScrollsWithinRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -95,7 +96,7 @@ public class GhosttyScrollRegionConformanceTests
     /// 5×5 terminal. Write ABC, DEF, GHI. Set margin(2,2) — single row region.
     /// Ghostty treats equal margins as full screen. ScrollDown(1).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void SetTopAndBottomMargin_TopEqualsBottom_TreatedAsFullScreen()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -121,7 +122,7 @@ public class GhosttyScrollRegionConformanceTests
     /// 5×5 terminal. Write ABC, DEF, GHI. CUP(2,2). InsertLines(1).
     /// Blank line inserted at cursor row (row 1), content below shifts down.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void InsertLines_Simple_InsertsBlankAndShiftsDown()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -133,7 +134,7 @@ public class GhosttyScrollRegionConformanceTests
 
         AssertPlainText(terminal, "ABC\n\nDEF\nGHI");
         // IL resets cursor column to 0
-        Assert.Equal(0, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorX);
     }
 
     /// <summary>
@@ -141,7 +142,7 @@ public class GhosttyScrollRegionConformanceTests
     /// 5×5 terminal. Write ABC, DEF, GHI. Set margin(3,4). CUP(2,2).
     /// Cursor outside scroll region — insertLines has no effect.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void InsertLines_OutsideScrollRegion_NoEffect()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -161,7 +162,7 @@ public class GhosttyScrollRegionConformanceTests
     /// 5×5 terminal. Write ABC, DEF, GHI, 123. Set margin(1,3). CUP(2,2).
     /// InsertLines(1). GHI pushed out of region (rows 1–3), 123 untouched.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void InsertLines_WithTopBottomScrollRegion_PushesOutOfRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -181,7 +182,7 @@ public class GhosttyScrollRegionConformanceTests
     /// 5×5 terminal. Write ABC, DEF, GHI. CUP(2,2). InsertLines(0).
     /// Zero is treated as 1.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void InsertLines_Zero_TreatedAsOne()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -199,7 +200,7 @@ public class GhosttyScrollRegionConformanceTests
     /// 5×5 terminal. Write ABC, DEF, GHI, 123, 456. Set margin(2,4). CUP(3,2).
     /// InsertLines(1). Insert within region rows 2–4, 456 untouched.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void InsertLines_WithScrollRegion_InsertsWithinRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -219,7 +220,7 @@ public class GhosttyScrollRegionConformanceTests
     /// 5×5 terminal. Write 5 rows. Set margin(2,4). CUP(3,2). InsertLines(100).
     /// All remaining rows in region blanked.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void InsertLines_MoreThanRemaining_BlanksRemainingInRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -239,7 +240,7 @@ public class GhosttyScrollRegionConformanceTests
     /// 5×5 terminal. Write "ABCDE" (fills line, sets pending wrap). InsertLines(1).
     /// Write 'X'. Pending wrap reset, X at col 0 of current row, ABCDE pushed down.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void InsertLines_ResetsPendingWrap()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -266,7 +267,7 @@ public class GhosttyScrollRegionConformanceTests
     /// 5×5 terminal. Write ABC, DEF, GHI. CUP(2,2). DeleteLines(1).
     /// Row 1 (DEF) deleted, rows below shift up.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void DeleteLines_Simple_DeletesRowAndShiftsUp()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -278,7 +279,7 @@ public class GhosttyScrollRegionConformanceTests
 
         AssertPlainText(terminal, "ABC\nGHI");
         // DL resets cursor column to 0
-        Assert.Equal(0, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorX);
     }
 
     /// <summary>
@@ -286,7 +287,7 @@ public class GhosttyScrollRegionConformanceTests
     /// 5×5 terminal. Write 5 rows. Set margin(2,4). CUP(3,2). DeleteLines(1).
     /// Within region (rows 2–4), GHI deleted, 123 shifts up, blank at bottom of region.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void DeleteLines_WithScrollRegion_DeletesWithinRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -306,7 +307,7 @@ public class GhosttyScrollRegionConformanceTests
     /// 5×5 terminal. Write 5 rows. Set margin(2,4). CUP(3,2). DeleteLines(100).
     /// All rows in region below cursor deleted.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void DeleteLines_WithScrollRegion_LargeCount_DeletesAllInRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -326,7 +327,7 @@ public class GhosttyScrollRegionConformanceTests
     /// 5×5 terminal. Write 3 rows. Set margin(3,4). CUP(2,2).
     /// Cursor outside scroll region — deleteLines has no effect.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void DeleteLines_CursorOutsideRegion_NoEffect()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -346,7 +347,7 @@ public class GhosttyScrollRegionConformanceTests
     /// 5×5 terminal. Write "ABCDE" (fills line, sets pending wrap). DeleteLines(1).
     /// Write 'X'. Row 0 deleted, X written on blank row 0.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void DeleteLines_ResetsPendingWrap()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -373,7 +374,7 @@ public class GhosttyScrollRegionConformanceTests
     /// 5×5 terminal. Write ABC, DEF, GHI. ScrollUp(1).
     /// Content shifts up by 1, top line (ABC) disappears, bottom line blank.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void ScrollUp_Simple_ShiftsContentUp()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -389,7 +390,7 @@ public class GhosttyScrollRegionConformanceTests
     /// 5×5 terminal. Write ABC, DEF, GHI. Set margin(1,2). ScrollUp(1).
     /// Only rows 1–2 scroll. Row 0 gets DEF, row 1 blank, row 2 (GHI) untouched.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void ScrollUp_WithScrollRegion_ScrollsWithinRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -415,7 +416,7 @@ public class GhosttyScrollRegionConformanceTests
     /// 5×5 terminal. Write ABC, DEF, GHI. ScrollDown(1).
     /// Content shifts down by 1, blank line at top.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void ScrollDown_Simple_ShiftsContentDown()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -439,7 +440,7 @@ public class GhosttyScrollRegionConformanceTests
     /// 5×5 terminal. Write ABC on rows. Set margin 2–4. CUP(2,1).
     /// Reverse index (ESC M) at top of scroll region scrolls content DOWN within region.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void ReverseIndex_AtTopOfScrollRegion_ScrollsDownWithinRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttySgrConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttySgrConformanceTests.cs
@@ -10,7 +10,8 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// Source: https://github.com/ghostty-org/ghostty/blob/main/src/terminal/sgr.zig
 /// These tests verify Hex1b handles SGR sequences the same way Ghostty does.
 /// </remarks>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttySgrConformanceTests
 {
     private static Hex1bTerminal CreateTerminal(int cols = 20, int rows = 5)
@@ -19,7 +20,7 @@ public class GhosttySgrConformanceTests
     #region Basic Attributes
 
     // Ghostty: test "sgr: bold"
-    [Fact]
+    [TestMethod]
     public void Sgr_Bold_SetsAndResets()
     {
         using var terminal = CreateTerminal();
@@ -27,12 +28,12 @@ public class GhosttySgrConformanceTests
 
         var boldCell = GhosttyTestFixture.GetCell(terminal, 0, 0);
         var normalCell = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.True(boldCell.Attributes.HasFlag(CellAttributes.Bold));
-        Assert.False(normalCell.Attributes.HasFlag(CellAttributes.Bold));
+        Assert.IsTrue(boldCell.Attributes.HasFlag(CellAttributes.Bold));
+        Assert.IsFalse(normalCell.Attributes.HasFlag(CellAttributes.Bold));
     }
 
     // Ghostty: test "sgr: italic"
-    [Fact]
+    [TestMethod]
     public void Sgr_Italic_SetsAndResets()
     {
         using var terminal = CreateTerminal();
@@ -40,12 +41,12 @@ public class GhosttySgrConformanceTests
 
         var italicCell = GhosttyTestFixture.GetCell(terminal, 0, 0);
         var normalCell = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.True(italicCell.Attributes.HasFlag(CellAttributes.Italic));
-        Assert.False(normalCell.Attributes.HasFlag(CellAttributes.Italic));
+        Assert.IsTrue(italicCell.Attributes.HasFlag(CellAttributes.Italic));
+        Assert.IsFalse(normalCell.Attributes.HasFlag(CellAttributes.Italic));
     }
 
     // Ghostty: test "sgr: underline"
-    [Fact]
+    [TestMethod]
     public void Sgr_Underline_SetsAndResets()
     {
         using var terminal = CreateTerminal();
@@ -53,12 +54,12 @@ public class GhosttySgrConformanceTests
 
         var underlineCell = GhosttyTestFixture.GetCell(terminal, 0, 0);
         var normalCell = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.True(underlineCell.Attributes.HasFlag(CellAttributes.Underline));
-        Assert.False(normalCell.Attributes.HasFlag(CellAttributes.Underline));
+        Assert.IsTrue(underlineCell.Attributes.HasFlag(CellAttributes.Underline));
+        Assert.IsFalse(normalCell.Attributes.HasFlag(CellAttributes.Underline));
     }
 
     // Ghostty: test "sgr: blink" — codes 5 and 6 both produce blink
-    [Fact]
+    [TestMethod]
     public void Sgr_Blink_BothCodes5And6()
     {
         using var terminal = CreateTerminal();
@@ -67,13 +68,13 @@ public class GhosttySgrConformanceTests
         var cell5 = GhosttyTestFixture.GetCell(terminal, 0, 0);
         var cell6 = GhosttyTestFixture.GetCell(terminal, 0, 1);
         var cellReset = GhosttyTestFixture.GetCell(terminal, 0, 2);
-        Assert.True(cell5.Attributes.HasFlag(CellAttributes.Blink));
-        Assert.True(cell6.Attributes.HasFlag(CellAttributes.Blink));
-        Assert.False(cellReset.Attributes.HasFlag(CellAttributes.Blink));
+        Assert.IsTrue(cell5.Attributes.HasFlag(CellAttributes.Blink));
+        Assert.IsTrue(cell6.Attributes.HasFlag(CellAttributes.Blink));
+        Assert.IsFalse(cellReset.Attributes.HasFlag(CellAttributes.Blink));
     }
 
     // Ghostty: test "sgr: inverse"
-    [Fact]
+    [TestMethod]
     public void Sgr_Inverse_SetsAndResets()
     {
         using var terminal = CreateTerminal();
@@ -81,12 +82,12 @@ public class GhosttySgrConformanceTests
 
         var reverseCell = GhosttyTestFixture.GetCell(terminal, 0, 0);
         var normalCell = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.True(reverseCell.Attributes.HasFlag(CellAttributes.Reverse));
-        Assert.False(normalCell.Attributes.HasFlag(CellAttributes.Reverse));
+        Assert.IsTrue(reverseCell.Attributes.HasFlag(CellAttributes.Reverse));
+        Assert.IsFalse(normalCell.Attributes.HasFlag(CellAttributes.Reverse));
     }
 
     // Ghostty: test "sgr: invisible"
-    [Fact]
+    [TestMethod]
     public void Sgr_Invisible_SetsAndResets()
     {
         using var terminal = CreateTerminal();
@@ -94,12 +95,12 @@ public class GhosttySgrConformanceTests
 
         var hiddenCell = GhosttyTestFixture.GetCell(terminal, 0, 0);
         var visibleCell = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.True(hiddenCell.Attributes.HasFlag(CellAttributes.Hidden));
-        Assert.False(visibleCell.Attributes.HasFlag(CellAttributes.Hidden));
+        Assert.IsTrue(hiddenCell.Attributes.HasFlag(CellAttributes.Hidden));
+        Assert.IsFalse(visibleCell.Attributes.HasFlag(CellAttributes.Hidden));
     }
 
     // Ghostty: test "sgr: strikethrough"
-    [Fact]
+    [TestMethod]
     public void Sgr_Strikethrough_SetsAndResets()
     {
         using var terminal = CreateTerminal();
@@ -107,12 +108,12 @@ public class GhosttySgrConformanceTests
 
         var strikeCell = GhosttyTestFixture.GetCell(terminal, 0, 0);
         var normalCell = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.True(strikeCell.Attributes.HasFlag(CellAttributes.Strikethrough));
-        Assert.False(normalCell.Attributes.HasFlag(CellAttributes.Strikethrough));
+        Assert.IsTrue(strikeCell.Attributes.HasFlag(CellAttributes.Strikethrough));
+        Assert.IsFalse(normalCell.Attributes.HasFlag(CellAttributes.Strikethrough));
     }
 
     // Ghostty: test "sgr: faint" + code 22 resets both bold and faint
-    [Fact]
+    [TestMethod]
     public void Sgr_Faint_SetsAndResetWithCode22()
     {
         using var terminal = CreateTerminal();
@@ -120,12 +121,12 @@ public class GhosttySgrConformanceTests
 
         var dimCell = GhosttyTestFixture.GetCell(terminal, 0, 0);
         var normalCell = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.True(dimCell.Attributes.HasFlag(CellAttributes.Dim));
-        Assert.False(normalCell.Attributes.HasFlag(CellAttributes.Dim));
+        Assert.IsTrue(dimCell.Attributes.HasFlag(CellAttributes.Dim));
+        Assert.IsFalse(normalCell.Attributes.HasFlag(CellAttributes.Dim));
     }
 
     // Ghostty: overline (code 53/55)
-    [Fact]
+    [TestMethod]
     public void Sgr_Overline_SetsAndResets()
     {
         using var terminal = CreateTerminal();
@@ -133,12 +134,12 @@ public class GhosttySgrConformanceTests
 
         var overlineCell = GhosttyTestFixture.GetCell(terminal, 0, 0);
         var normalCell = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.True(overlineCell.Attributes.HasFlag(CellAttributes.Overline));
-        Assert.False(normalCell.Attributes.HasFlag(CellAttributes.Overline));
+        Assert.IsTrue(overlineCell.Attributes.HasFlag(CellAttributes.Overline));
+        Assert.IsFalse(normalCell.Attributes.HasFlag(CellAttributes.Overline));
     }
 
     // Ghostty: code 0 resets all attributes
-    [Fact]
+    [TestMethod]
     public void Sgr_Reset_ClearsAllAttributes()
     {
         using var terminal = CreateTerminal();
@@ -147,17 +148,17 @@ public class GhosttySgrConformanceTests
         var styledCell = GhosttyTestFixture.GetCell(terminal, 0, 0);
         var resetCell = GhosttyTestFixture.GetCell(terminal, 0, 1);
 
-        Assert.True(styledCell.Attributes.HasFlag(CellAttributes.Bold));
-        Assert.True(styledCell.Attributes.HasFlag(CellAttributes.Italic));
-        Assert.True(styledCell.Attributes.HasFlag(CellAttributes.Underline));
-        Assert.True(styledCell.Attributes.HasFlag(CellAttributes.Reverse));
-        Assert.True(styledCell.Attributes.HasFlag(CellAttributes.Strikethrough));
+        Assert.IsTrue(styledCell.Attributes.HasFlag(CellAttributes.Bold));
+        Assert.IsTrue(styledCell.Attributes.HasFlag(CellAttributes.Italic));
+        Assert.IsTrue(styledCell.Attributes.HasFlag(CellAttributes.Underline));
+        Assert.IsTrue(styledCell.Attributes.HasFlag(CellAttributes.Reverse));
+        Assert.IsTrue(styledCell.Attributes.HasFlag(CellAttributes.Strikethrough));
 
-        Assert.Equal(CellAttributes.None, resetCell.Attributes);
+        Assert.AreEqual(CellAttributes.None, resetCell.Attributes);
     }
 
     // Ghostty: empty SGR (ESC[m) is equivalent to reset
-    [Fact]
+    [TestMethod]
     public void Sgr_EmptySequence_IsReset()
     {
         using var terminal = CreateTerminal();
@@ -165,8 +166,8 @@ public class GhosttySgrConformanceTests
 
         var boldCell = GhosttyTestFixture.GetCell(terminal, 0, 0);
         var resetCell = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.True(boldCell.Attributes.HasFlag(CellAttributes.Bold));
-        Assert.Equal(CellAttributes.None, resetCell.Attributes);
+        Assert.IsTrue(boldCell.Attributes.HasFlag(CellAttributes.Bold));
+        Assert.AreEqual(CellAttributes.None, resetCell.Attributes);
     }
 
     #endregion
@@ -174,7 +175,7 @@ public class GhosttySgrConformanceTests
     #region Standard 8 Colors
 
     // Ghostty: test "sgr: 8 color"
-    [Fact]
+    [TestMethod]
     public void Sgr_8Color_ForegroundAndBackground()
     {
         using var terminal = CreateTerminal();
@@ -183,21 +184,21 @@ public class GhosttySgrConformanceTests
         GhosttyTestFixture.Feed(terminal, "\x1b[31;43mA\x1b[0m");
 
         var cell = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.NotNull(cell.Foreground);
-        Assert.NotNull(cell.Background);
+        Assert.IsNotNull(cell.Foreground);
+        Assert.IsNotNull(cell.Background);
         // Red = index 1 → (187, 0, 0) or similar depending on palette
         // We just verify colors are set, not exact RGB (palette-dependent)
     }
 
     // Standard color codes 30-37 (fg) and 40-47 (bg)
-    [Theory]
-    [InlineData(30, true)]   // black fg
-    [InlineData(31, true)]   // red fg
-    [InlineData(32, true)]   // green fg
-    [InlineData(37, true)]   // white fg
-    [InlineData(40, false)]  // black bg
-    [InlineData(41, false)]  // red bg
-    [InlineData(47, false)]  // white bg
+    [TestMethod]
+    [DataRow(30, true)]   // black fg
+    [DataRow(31, true)]   // red fg
+    [DataRow(32, true)]   // green fg
+    [DataRow(37, true)]   // white fg
+    [DataRow(40, false)]  // black bg
+    [DataRow(41, false)]  // red bg
+    [DataRow(47, false)]  // white bg
     public void Sgr_StandardColor_SetsColorByCode(int code, bool isForeground)
     {
         using var terminal = CreateTerminal();
@@ -205,19 +206,19 @@ public class GhosttySgrConformanceTests
 
         var cell = GhosttyTestFixture.GetCell(terminal, 0, 0);
         if (isForeground)
-            Assert.NotNull(cell.Foreground);
+            Assert.IsNotNull(cell.Foreground);
         else
-            Assert.NotNull(cell.Background);
+            Assert.IsNotNull(cell.Background);
     }
 
     // Bright colors 90-97 (fg) and 100-107 (bg)
-    [Theory]
-    [InlineData(90, true)]   // bright black fg
-    [InlineData(91, true)]   // bright red fg
-    [InlineData(97, true)]   // bright white fg
-    [InlineData(100, false)] // bright black bg
-    [InlineData(101, false)] // bright red bg
-    [InlineData(107, false)] // bright white bg
+    [TestMethod]
+    [DataRow(90, true)]   // bright black fg
+    [DataRow(91, true)]   // bright red fg
+    [DataRow(97, true)]   // bright white fg
+    [DataRow(100, false)] // bright black bg
+    [DataRow(101, false)] // bright red bg
+    [DataRow(107, false)] // bright white bg
     public void Sgr_BrightColor_SetsColorByCode(int code, bool isForeground)
     {
         using var terminal = CreateTerminal();
@@ -225,13 +226,13 @@ public class GhosttySgrConformanceTests
 
         var cell = GhosttyTestFixture.GetCell(terminal, 0, 0);
         if (isForeground)
-            Assert.NotNull(cell.Foreground);
+            Assert.IsNotNull(cell.Foreground);
         else
-            Assert.NotNull(cell.Background);
+            Assert.IsNotNull(cell.Background);
     }
 
     // Reset fg (39) and bg (49)
-    [Fact]
+    [TestMethod]
     public void Sgr_ResetColor_ResetsToDefault()
     {
         using var terminal = CreateTerminal();
@@ -239,8 +240,8 @@ public class GhosttySgrConformanceTests
 
         var redCell = GhosttyTestFixture.GetCell(terminal, 0, 0);
         var defaultCell = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.NotNull(redCell.Foreground);
-        Assert.Null(defaultCell.Foreground); // null = default color
+        Assert.IsNotNull(redCell.Foreground);
+        Assert.IsNull(defaultCell.Foreground); // null = default color
     }
 
     #endregion
@@ -248,7 +249,7 @@ public class GhosttySgrConformanceTests
     #region 256 Color
 
     // Ghostty: test "sgr: 256 color"
-    [Fact]
+    [TestMethod]
     public void Sgr_256Color_ForegroundAndBackground()
     {
         using var terminal = CreateTerminal();
@@ -257,8 +258,8 @@ public class GhosttySgrConformanceTests
 
         var fgCell = GhosttyTestFixture.GetCell(terminal, 0, 0);
         var bothCell = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.NotNull(fgCell.Foreground);
-        Assert.NotNull(bothCell.Background);
+        Assert.IsNotNull(fgCell.Foreground);
+        Assert.IsNotNull(bothCell.Background);
     }
 
     #endregion
@@ -266,7 +267,7 @@ public class GhosttySgrConformanceTests
     #region 24-bit True Color (RGB)
 
     // Ghostty: test "sgr: Parser" — direct color fg with semicolons
-    [Fact]
+    [TestMethod]
     public void Sgr_DirectColorFg_Semicolons()
     {
         using var terminal = CreateTerminal();
@@ -274,14 +275,14 @@ public class GhosttySgrConformanceTests
         GhosttyTestFixture.Feed(terminal, "\x1b[38;2;40;44;52mX");
 
         var cell = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.NotNull(cell.Foreground);
-        Assert.Equal(40, cell.Foreground!.Value.R);
-        Assert.Equal(44, cell.Foreground!.Value.G);
-        Assert.Equal(52, cell.Foreground!.Value.B);
+        Assert.IsNotNull(cell.Foreground);
+        Assert.AreEqual(40, cell.Foreground!.Value.R);
+        Assert.AreEqual(44, cell.Foreground!.Value.G);
+        Assert.AreEqual(52, cell.Foreground!.Value.B);
     }
 
     // Ghostty: test "sgr: Parser" — direct color bg with semicolons
-    [Fact]
+    [TestMethod]
     public void Sgr_DirectColorBg_Semicolons()
     {
         using var terminal = CreateTerminal();
@@ -289,14 +290,14 @@ public class GhosttySgrConformanceTests
         GhosttyTestFixture.Feed(terminal, "\x1b[48;2;40;44;52mX");
 
         var cell = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.NotNull(cell.Background);
-        Assert.Equal(40, cell.Background!.Value.R);
-        Assert.Equal(44, cell.Background!.Value.G);
-        Assert.Equal(52, cell.Background!.Value.B);
+        Assert.IsNotNull(cell.Background);
+        Assert.AreEqual(40, cell.Background!.Value.R);
+        Assert.AreEqual(44, cell.Background!.Value.G);
+        Assert.AreEqual(52, cell.Background!.Value.B);
     }
 
     // Ghostty: test "sgr: Parser multiple" — reset then direct color
-    [Fact]
+    [TestMethod]
     public void Sgr_ResetThenDirectColor_MultipleParams()
     {
         using var terminal = CreateTerminal();
@@ -304,14 +305,14 @@ public class GhosttySgrConformanceTests
         GhosttyTestFixture.Feed(terminal, "\x1b[1mB\x1b[0;38;2;40;44;52mX");
 
         var colorCell = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.False(colorCell.Attributes.HasFlag(CellAttributes.Bold)); // reset cleared bold
-        Assert.NotNull(colorCell.Foreground);
-        Assert.Equal(40, colorCell.Foreground!.Value.R);
+        Assert.IsFalse(colorCell.Attributes.HasFlag(CellAttributes.Bold)); // reset cleared bold
+        Assert.IsNotNull(colorCell.Foreground);
+        Assert.AreEqual(40, colorCell.Foreground!.Value.R);
     }
 
     // Ghostty: test "sgr: direct fg/bg/underline ignore optional color space"
     // Semicolon version: ESC[38;2;R;G;B;m — no colorspace, uses first 3 values as RGB
-    [Fact]
+    [TestMethod]
     public void Sgr_DirectColorFg_SemicolonSkipsValues()
     {
         using var terminal = CreateTerminal();
@@ -319,10 +320,10 @@ public class GhosttySgrConformanceTests
         GhosttyTestFixture.Feed(terminal, "\x1b[38;2;0;1;2mX");
 
         var cell = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.NotNull(cell.Foreground);
-        Assert.Equal(0, cell.Foreground!.Value.R);
-        Assert.Equal(1, cell.Foreground!.Value.G);
-        Assert.Equal(2, cell.Foreground!.Value.B);
+        Assert.IsNotNull(cell.Foreground);
+        Assert.AreEqual(0, cell.Foreground!.Value.R);
+        Assert.AreEqual(1, cell.Foreground!.Value.G);
+        Assert.AreEqual(2, cell.Foreground!.Value.B);
     }
 
     #endregion
@@ -331,7 +332,7 @@ public class GhosttySgrConformanceTests
 
     // Ghostty: test "sgr: underline, bg, and fg"
     // ESC[4;38;2;255;247;219;48;2;242;93;147;4m
-    [Fact]
+    [TestMethod]
     public void Sgr_ComplexSequence_UnderlineFgBg()
     {
         using var terminal = CreateTerminal();
@@ -339,41 +340,41 @@ public class GhosttySgrConformanceTests
             "\x1b[4;38;2;255;247;219;48;2;242;93;147mX");
 
         var cell = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.True(cell.Attributes.HasFlag(CellAttributes.Underline));
-        Assert.NotNull(cell.Foreground);
-        Assert.Equal(255, cell.Foreground!.Value.R);
-        Assert.Equal(247, cell.Foreground!.Value.G);
-        Assert.Equal(219, cell.Foreground!.Value.B);
-        Assert.NotNull(cell.Background);
-        Assert.Equal(242, cell.Background!.Value.R);
-        Assert.Equal(93, cell.Background!.Value.G);
-        Assert.Equal(147, cell.Background!.Value.B);
+        Assert.IsTrue(cell.Attributes.HasFlag(CellAttributes.Underline));
+        Assert.IsNotNull(cell.Foreground);
+        Assert.AreEqual(255, cell.Foreground!.Value.R);
+        Assert.AreEqual(247, cell.Foreground!.Value.G);
+        Assert.AreEqual(219, cell.Foreground!.Value.B);
+        Assert.IsNotNull(cell.Background);
+        Assert.AreEqual(242, cell.Background!.Value.R);
+        Assert.AreEqual(93, cell.Background!.Value.G);
+        Assert.AreEqual(147, cell.Background!.Value.B);
     }
 
     // Ghostty: test "sgr: direct color fg missing color" — should not crash
-    [Fact]
+    [TestMethod]
     public void Sgr_DirectColorFg_MissingValues_NoCrash()
     {
         using var terminal = CreateTerminal();
         // ESC[38;5m — missing the actual color index
         GhosttyTestFixture.Feed(terminal, "\x1b[38;5mX");
         // Should not throw — just verify terminal is still functional
-        Assert.Equal("X", GhosttyTestFixture.GetLine(terminal, 0));
+        Assert.AreEqual("X", GhosttyTestFixture.GetLine(terminal, 0));
     }
 
     // Ghostty: test "sgr: direct color bg missing color" — should not crash
-    [Fact]
+    [TestMethod]
     public void Sgr_DirectColorBg_MissingValues_NoCrash()
     {
         using var terminal = CreateTerminal();
         GhosttyTestFixture.Feed(terminal, "\x1b[48;5mX");
-        Assert.Equal("X", GhosttyTestFixture.GetLine(terminal, 0));
+        Assert.AreEqual("X", GhosttyTestFixture.GetLine(terminal, 0));
     }
 
     // Ghostty: code 21 = double underline per ECMA-48
     // BUG FOUND: Hex1b treats code 21 as "reset bold" (same as 22), but ECMA-48
     // and Ghostty both define it as "double underline". This is a conformance bug.
-    [Fact]
+    [TestMethod]
     public void Sgr_Code21_DoubleUnderline()
     {
         using var terminal = CreateTerminal();
@@ -387,8 +388,8 @@ public class GhosttySgrConformanceTests
         // Ghostty and ECMA-48 say 21 = doubly underlined.
         // Hex1bTerminal.cs:2651 — case 21 falls through to case 22 (reset bold).
         // Fix: case 21 should set underline, not reset bold.
-        Assert.True(underlinedCell.Attributes.HasFlag(CellAttributes.Underline));
-        Assert.False(normalCell.Attributes.HasFlag(CellAttributes.Underline));
+        Assert.IsTrue(underlinedCell.Attributes.HasFlag(CellAttributes.Underline));
+        Assert.IsFalse(normalCell.Attributes.HasFlag(CellAttributes.Underline));
     }
 
     #endregion
@@ -400,7 +401,7 @@ public class GhosttySgrConformanceTests
     // NOTE: Hex1b may not support colon-separated params yet.
     // Tests are included to identify this gap.
 
-    [Fact]
+    [TestMethod]
     public void Sgr_UnderlineStyle_Curly_ColonSeparated()
     {
         using var terminal = CreateTerminal();
@@ -408,10 +409,10 @@ public class GhosttySgrConformanceTests
         GhosttyTestFixture.Feed(terminal, "\x1b[4:3mX\x1b[24mY");
 
         var curlyCell = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.True(curlyCell.Attributes.HasFlag(CellAttributes.Underline));
+        Assert.IsTrue(curlyCell.Attributes.HasFlag(CellAttributes.Underline));
     }
 
-    [Fact]
+    [TestMethod]
     public void Sgr_UnderlineStyle_None_ColonSeparated()
     {
         using var terminal = CreateTerminal();
@@ -419,11 +420,11 @@ public class GhosttySgrConformanceTests
         GhosttyTestFixture.Feed(terminal, "\x1b[4mU\x1b[4:0mN");
 
         var noUnderline = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.False(noUnderline.Attributes.HasFlag(CellAttributes.Underline));
+        Assert.IsFalse(noUnderline.Attributes.HasFlag(CellAttributes.Underline));
     }
 
     // Ghostty: test "sgr: underline color" — colon-separated 58:2:R:G:B
-    [Fact]
+    [TestMethod]
     public void Sgr_UnderlineColor_ColonSeparated()
     {
         using var terminal = CreateTerminal();
@@ -431,15 +432,15 @@ public class GhosttySgrConformanceTests
         GhosttyTestFixture.Feed(terminal, "\x1b[4;58:2:1:2:3mX");
 
         var cell = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.True(cell.Attributes.HasFlag(CellAttributes.Underline));
-        Assert.NotNull(cell.UnderlineColor);
-        Assert.Equal(1, cell.UnderlineColor!.Value.R);
-        Assert.Equal(2, cell.UnderlineColor!.Value.G);
-        Assert.Equal(3, cell.UnderlineColor!.Value.B);
+        Assert.IsTrue(cell.Attributes.HasFlag(CellAttributes.Underline));
+        Assert.IsNotNull(cell.UnderlineColor);
+        Assert.AreEqual(1, cell.UnderlineColor!.Value.R);
+        Assert.AreEqual(2, cell.UnderlineColor!.Value.G);
+        Assert.AreEqual(3, cell.UnderlineColor!.Value.B);
     }
 
     // Ghostty: test "sgr: 24-bit bg color" with colon separator
-    [Fact]
+    [TestMethod]
     public void Sgr_DirectColorBg_ColonSeparated()
     {
         using var terminal = CreateTerminal();
@@ -447,15 +448,15 @@ public class GhosttySgrConformanceTests
         GhosttyTestFixture.Feed(terminal, "\x1b[48:2:1:2:3mX");
 
         var cell = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.NotNull(cell.Background);
-        Assert.Equal(1, cell.Background!.Value.R);
-        Assert.Equal(2, cell.Background!.Value.G);
-        Assert.Equal(3, cell.Background!.Value.B);
+        Assert.IsNotNull(cell.Background);
+        Assert.AreEqual(1, cell.Background!.Value.R);
+        Assert.AreEqual(2, cell.Background!.Value.G);
+        Assert.AreEqual(3, cell.Background!.Value.B);
     }
 
     // Ghostty: test "sgr: direct fg/bg/underline ignore optional color space"
     // Colon version with colorspace: 38:2:Pi:R:G:B (6 values → skip Pi)
-    [Fact]
+    [TestMethod]
     public void Sgr_DirectColorFg_ColonWithColorspace()
     {
         using var terminal = CreateTerminal();
@@ -463,15 +464,15 @@ public class GhosttySgrConformanceTests
         GhosttyTestFixture.Feed(terminal, "\x1b[38:2:0:1:2:3mX");
 
         var cell = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.NotNull(cell.Foreground);
-        Assert.Equal(1, cell.Foreground!.Value.R);
-        Assert.Equal(2, cell.Foreground!.Value.G);
-        Assert.Equal(3, cell.Foreground!.Value.B);
+        Assert.IsNotNull(cell.Foreground);
+        Assert.AreEqual(1, cell.Foreground!.Value.R);
+        Assert.AreEqual(2, cell.Foreground!.Value.G);
+        Assert.AreEqual(3, cell.Foreground!.Value.B);
     }
 
     // Ghostty: test "sgr: kakoune input" — complex real-world sequence from Kakoune editor
     // ESC[0;4:3;38;2;175;175;215;58:2:0:190:80:70m
-    [Fact]
+    [TestMethod]
     public void Sgr_KakouneInput_ComplexMixedSequence()
     {
         using var terminal = CreateTerminal();
@@ -480,16 +481,16 @@ public class GhosttySgrConformanceTests
             "\x1b[0;4:3;38;2;175;175;215;58:2:0:190:80:70mX");
 
         var cell = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.True(cell.Attributes.HasFlag(CellAttributes.Underline));
-        Assert.NotNull(cell.Foreground);
-        Assert.Equal(175, cell.Foreground!.Value.R);
-        Assert.Equal(175, cell.Foreground!.Value.G);
-        Assert.Equal(215, cell.Foreground!.Value.B);
+        Assert.IsTrue(cell.Attributes.HasFlag(CellAttributes.Underline));
+        Assert.IsNotNull(cell.Foreground);
+        Assert.AreEqual(175, cell.Foreground!.Value.R);
+        Assert.AreEqual(175, cell.Foreground!.Value.G);
+        Assert.AreEqual(215, cell.Foreground!.Value.B);
     }
 
     // Ghostty: test "sgr: kakoune input issue underline, fg, and bg"
     // ESC[4:3;38;2;51;51;51;48;2;170;170;170;58;2;255;97;136m
-    [Fact]
+    [TestMethod]
     public void Sgr_KakouneInput_UnderlineFgBgUnderlineColor()
     {
         using var terminal = CreateTerminal();
@@ -497,11 +498,11 @@ public class GhosttySgrConformanceTests
             "\x1b[4:3;38;2;51;51;51;48;2;170;170;170;58;2;255;97;136mX");
 
         var cell = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.True(cell.Attributes.HasFlag(CellAttributes.Underline));
-        Assert.NotNull(cell.Foreground);
-        Assert.Equal(51, cell.Foreground!.Value.R);
-        Assert.NotNull(cell.Background);
-        Assert.Equal(170, cell.Background!.Value.R);
+        Assert.IsTrue(cell.Attributes.HasFlag(CellAttributes.Underline));
+        Assert.IsNotNull(cell.Foreground);
+        Assert.AreEqual(51, cell.Foreground!.Value.R);
+        Assert.IsNotNull(cell.Background);
+        Assert.AreEqual(170, cell.Background!.Value.R);
     }
 
     #endregion
@@ -509,7 +510,7 @@ public class GhosttySgrConformanceTests
     #region Edge Cases
 
     // Ghostty: test "sgr: Parser" — too few params for direct color is unknown
-    [Fact]
+    [TestMethod]
     public void Sgr_DirectColorFg_TooFewParams_IsUnknown()
     {
         using var terminal = CreateTerminal();
@@ -517,11 +518,11 @@ public class GhosttySgrConformanceTests
         GhosttyTestFixture.Feed(terminal, "\x1b[38;2;44;52mX");
 
         // Should not crash; terminal should still be functional
-        Assert.Equal("X", GhosttyTestFixture.GetLine(terminal, 0));
+        Assert.AreEqual("X", GhosttyTestFixture.GetLine(terminal, 0));
     }
 
     // Ghostty: code 22 resets both bold AND faint
-    [Fact]
+    [TestMethod]
     public void Sgr_Code22_ResetsBoldAndFaint()
     {
         using var terminal = CreateTerminal();
@@ -532,24 +533,24 @@ public class GhosttySgrConformanceTests
         var boldDimCell = GhosttyTestFixture.GetCell(terminal, 0, 1);
         var normalCell = GhosttyTestFixture.GetCell(terminal, 0, 2);
 
-        Assert.True(boldCell.Attributes.HasFlag(CellAttributes.Bold));
-        Assert.True(boldDimCell.Attributes.HasFlag(CellAttributes.Dim));
-        Assert.False(normalCell.Attributes.HasFlag(CellAttributes.Bold));
-        Assert.False(normalCell.Attributes.HasFlag(CellAttributes.Dim));
+        Assert.IsTrue(boldCell.Attributes.HasFlag(CellAttributes.Bold));
+        Assert.IsTrue(boldDimCell.Attributes.HasFlag(CellAttributes.Dim));
+        Assert.IsFalse(normalCell.Attributes.HasFlag(CellAttributes.Bold));
+        Assert.IsFalse(normalCell.Attributes.HasFlag(CellAttributes.Dim));
     }
 
     // Multiple SGR attributes in single sequence
-    [Fact]
+    [TestMethod]
     public void Sgr_MultipleAttributes_SingleSequence()
     {
         using var terminal = CreateTerminal();
         GhosttyTestFixture.Feed(terminal, "\x1b[1;3;4;9mX");
 
         var cell = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.True(cell.Attributes.HasFlag(CellAttributes.Bold));
-        Assert.True(cell.Attributes.HasFlag(CellAttributes.Italic));
-        Assert.True(cell.Attributes.HasFlag(CellAttributes.Underline));
-        Assert.True(cell.Attributes.HasFlag(CellAttributes.Strikethrough));
+        Assert.IsTrue(cell.Attributes.HasFlag(CellAttributes.Bold));
+        Assert.IsTrue(cell.Attributes.HasFlag(CellAttributes.Italic));
+        Assert.IsTrue(cell.Attributes.HasFlag(CellAttributes.Underline));
+        Assert.IsTrue(cell.Attributes.HasFlag(CellAttributes.Strikethrough));
     }
 
     #endregion

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyTabsInsertModeConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyTabsInsertModeConformanceTests.cs
@@ -1,4 +1,3 @@
-using Xunit;
 
 namespace Hex1b.Tests.Conformance.Ghostty;
 
@@ -7,7 +6,8 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// and insert mode (IRM) behavior.
 /// Translated from Ghostty's Terminal.zig.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyTabsInsertModeConformanceTests
 {
     private static Hex1bTerminal CreateTerminal(int cols = 80, int rows = 24)
@@ -15,7 +15,7 @@ public class GhosttyTabsInsertModeConformanceTests
 
     #region Horizontal Tabs (HT)
 
-    [Fact]
+    [TestMethod]
     public void HorizontalTabs_Basic()
     {
         // Ghostty: "Terminal: horizontal tabs"
@@ -23,19 +23,19 @@ public class GhosttyTabsInsertModeConformanceTests
 
         GhosttyTestFixture.Feed(t, "1");
         GhosttyTestFixture.Feed(t, "\t");
-        Assert.Equal(8, t.CursorX);
+        Assert.AreEqual(8, t.CursorX);
 
         GhosttyTestFixture.Feed(t, "\t");
-        Assert.Equal(16, t.CursorX);
+        Assert.AreEqual(16, t.CursorX);
 
         // HT at the end
         GhosttyTestFixture.Feed(t, "\t");
-        Assert.Equal(19, t.CursorX);
+        Assert.AreEqual(19, t.CursorX);
         GhosttyTestFixture.Feed(t, "\t");
-        Assert.Equal(19, t.CursorX);
+        Assert.AreEqual(19, t.CursorX);
     }
 
-    [Fact]
+    [TestMethod]
     public void HorizontalTabs_StartingOnTabStop()
     {
         // Ghostty: "Terminal: horizontal tabs starting on tabstop"
@@ -47,10 +47,10 @@ public class GhosttyTabsInsertModeConformanceTests
         GhosttyTestFixture.Feed(t, "\t");
         GhosttyTestFixture.Feed(t, "A");
 
-        Assert.Equal("        X       A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("        X       A", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void HorizontalTabs_WithRightMargin()
     {
         // Ghostty: "Terminal: horizontal tabs with right margin"
@@ -64,10 +64,10 @@ public class GhosttyTabsInsertModeConformanceTests
         GhosttyTestFixture.Feed(t, "\t");
         GhosttyTestFixture.Feed(t, "A");
 
-        Assert.Equal("X    A", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("X    A", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void HorizontalTabsBack_Basic()
     {
         // Ghostty: "Terminal: horizontal tabs back"
@@ -76,18 +76,18 @@ public class GhosttyTabsInsertModeConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;20H"); // setCursorPos(y, 20) — col 19
 
         GhosttyTestFixture.Feed(t, "\u001b[Z"); // CBT
-        Assert.Equal(16, t.CursorX);
+        Assert.AreEqual(16, t.CursorX);
 
         GhosttyTestFixture.Feed(t, "\u001b[Z"); // CBT
-        Assert.Equal(8, t.CursorX);
+        Assert.AreEqual(8, t.CursorX);
 
         GhosttyTestFixture.Feed(t, "\u001b[Z"); // CBT
-        Assert.Equal(0, t.CursorX);
+        Assert.AreEqual(0, t.CursorX);
         GhosttyTestFixture.Feed(t, "\u001b[Z"); // CBT again at start
-        Assert.Equal(0, t.CursorX);
+        Assert.AreEqual(0, t.CursorX);
     }
 
-    [Fact]
+    [TestMethod]
     public void HorizontalTabsBack_StartingOnTabStop()
     {
         // Ghostty: "Terminal: horizontal tabs back starting on tabstop"
@@ -99,11 +99,11 @@ public class GhosttyTabsInsertModeConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[Z");     // CBT — back to col 0
         GhosttyTestFixture.Feed(t, "A");
 
-        Assert.Equal("A       X", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("A       X", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
-    [Trait("FailureReason", "Bug")]
+    [TestMethod]
+    [TestCategory("FailureReason:Bug")]
     public void HorizontalTabsBack_WithLeftMarginInOriginMode()
     {
         // Ghostty: "Terminal: horizontal tabs with left margin in origin mode"
@@ -119,10 +119,10 @@ public class GhosttyTabsInsertModeConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[Z");      // CBT — back to left margin (col 2)
         GhosttyTestFixture.Feed(t, "A");
 
-        Assert.Equal("  AX", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("  AX", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void HorizontalTabBack_CursorBeforeLeftMargin()
     {
         // Ghostty: "Terminal: horizontal tab back with cursor before left margin"
@@ -136,14 +136,14 @@ public class GhosttyTabsInsertModeConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[Z");       // CBT
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("X", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("X", GhosttyTestFixture.GetLine(t, 0));
     }
 
     #endregion
 
     #region Insert Mode (IRM)
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_WithSpace()
     {
         // Ghostty: "Terminal: insert mode with space"
@@ -154,10 +154,10 @@ public class GhosttyTabsInsertModeConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[4h");     // enable IRM
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("hXello", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("hXello", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_DoesNotWrapPushedCharacters()
     {
         // Ghostty: "Terminal: insert mode doesn't wrap pushed characters"
@@ -168,10 +168,10 @@ public class GhosttyTabsInsertModeConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[4h");     // enable IRM
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("hXell", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("hXell", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_DoesNothingAtEndOfLine()
     {
         // Ghostty: "Terminal: insert mode does nothing at the end of the line"
@@ -181,11 +181,11 @@ public class GhosttyTabsInsertModeConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[4h");     // enable IRM
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("hello", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("X", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("hello", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("X", GhosttyTestFixture.GetLine(t, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_WithWideCharacters()
     {
         // Ghostty: "Terminal: insert mode with wide characters"
@@ -196,10 +196,10 @@ public class GhosttyTabsInsertModeConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[4h");     // enable IRM
         GhosttyTestFixture.Feed(t, "\U0001F600");     // 😀
 
-        Assert.Equal("h😀el", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("h😀el", GhosttyTestFixture.GetLine(t, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_WideCharAtEnd()
     {
         // Ghostty: "Terminal: insert mode with wide characters at end"
@@ -209,11 +209,11 @@ public class GhosttyTabsInsertModeConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[4h");     // enable IRM
         GhosttyTestFixture.Feed(t, "\U0001F600");     // 😀
 
-        Assert.Equal("well", GhosttyTestFixture.GetLine(t, 0));
-        Assert.Equal("😀", GhosttyTestFixture.GetLine(t, 1));
+        Assert.AreEqual("well", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("😀", GhosttyTestFixture.GetLine(t, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMode_PushingOffWideCharacter()
     {
         // Ghostty: "Terminal: insert mode pushing off wide character"
@@ -225,7 +225,7 @@ public class GhosttyTabsInsertModeConformanceTests
         GhosttyTestFixture.Feed(t, "\u001b[1;1H");    // setCursorPos(1, 1) — col 0
         GhosttyTestFixture.Feed(t, "X");
 
-        Assert.Equal("X123", GhosttyTestFixture.GetLine(t, 0));
+        Assert.AreEqual("X123", GhosttyTestFixture.GetLine(t, 0));
     }
 
     #endregion

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyTerminalConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyTerminalConformanceTests.cs
@@ -9,7 +9,8 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// These tests verify Hex1b handles core terminal operations (cursor movement, erase, scroll,
 /// insert/delete lines, tabs, etc.) the same way Ghostty does.
 /// </remarks>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyTerminalConformanceTests
 {
     private static Hex1bTerminal CreateTerminal(int cols = 80, int rows = 24)
@@ -30,14 +31,14 @@ public class GhosttyTerminalConformanceTests
         for (int i = 0; i < expectedLines.Length; i++)
         {
             var actualLine = GhosttyTestFixture.GetLine(terminal, i);
-            Assert.Equal(expectedLines[i], actualLine);
+            Assert.AreEqual(expectedLines[i], actualLine);
         }
 
         // Check that lines beyond expected are empty
         for (int i = expectedLines.Length; i < terminal.Height; i++)
         {
             var line = GhosttyTestFixture.GetLine(terminal, i);
-            Assert.Equal("", line);
+            Assert.AreEqual("", line);
         }
     }
 
@@ -51,14 +52,14 @@ public class GhosttyTerminalConformanceTests
     /// Ghostty: test "Terminal: input with no control characters"
     /// Writes "hello" to a 40×40 terminal, verifies cursor at (5, 0) and text content.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Input_NoControlCharacters_WritesTextAndAdvancesCursor()
     {
         using var terminal = CreateTerminal(cols: 40, rows: 40);
         GhosttyTestFixture.Feed(terminal, "hello");
 
-        Assert.Equal(5, terminal.CursorX);
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(5, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
         AssertPlainText(terminal, "hello");
     }
 
@@ -68,7 +69,7 @@ public class GhosttyTerminalConformanceTests
     /// line 0 = "hello", line 1 = "world", line 2 = "abc12".
     /// Cursor ends at col 4, row 2 (with pending wrap in Ghostty — here we verify position).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Input_BasicWraparound_WrapsTextAtColumnBoundary()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 40);
@@ -78,7 +79,7 @@ public class GhosttyTerminalConformanceTests
         // After writing "abc12", the cursor is at col 4 row 2 with pending wrap set.
         // In Hex1b, the cursor should be at col 4, row 2 (or col 5 if no pending wrap concept).
         // We check the text content which is the authoritative behavior.
-        Assert.Equal(2, terminal.CursorY);
+        Assert.AreEqual(2, terminal.CursorY);
         AssertPlainText(terminal, "hello\nworld\nabc12");
     }
 
@@ -88,19 +89,19 @@ public class GhosttyTerminalConformanceTests
     /// Each char after the first autowraps to the next row. The 6th char forces a scroll.
     /// After scroll: 'a' is lost, visible = "b","c","d","e","f". Cursor at row 4, col 0.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Input_ForcesScroll_ScrollsContentUp()
     {
         using var terminal = CreateTerminal(cols: 1, rows: 5);
         GhosttyTestFixture.Feed(terminal, "abcdef");
 
-        Assert.Equal(0, terminal.CursorX);
-        Assert.Equal(4, terminal.CursorY);
-        Assert.Equal("b", GhosttyTestFixture.GetLine(terminal, 0));
-        Assert.Equal("c", GhosttyTestFixture.GetLine(terminal, 1));
-        Assert.Equal("d", GhosttyTestFixture.GetLine(terminal, 2));
-        Assert.Equal("e", GhosttyTestFixture.GetLine(terminal, 3));
-        Assert.Equal("f", GhosttyTestFixture.GetLine(terminal, 4));
+        Assert.AreEqual(0, terminal.CursorX);
+        Assert.AreEqual(4, terminal.CursorY);
+        Assert.AreEqual("b", GhosttyTestFixture.GetLine(terminal, 0));
+        Assert.AreEqual("c", GhosttyTestFixture.GetLine(terminal, 1));
+        Assert.AreEqual("d", GhosttyTestFixture.GetLine(terminal, 2));
+        Assert.AreEqual("e", GhosttyTestFixture.GetLine(terminal, 3));
+        Assert.AreEqual("f", GhosttyTestFixture.GetLine(terminal, 4));
     }
 
     /// <summary>
@@ -111,7 +112,7 @@ public class GhosttyTerminalConformanceTests
     /// Behavioral test: without LF, the next char would autowrap to row 1 col 0.
     /// With LF, cursor moves to row 1 preserving col, so 'X' writes at col 4.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Linefeed_AfterFilledLine_UnsetsWrapAndMovesToNextRow()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 40);
@@ -119,9 +120,9 @@ public class GhosttyTerminalConformanceTests
         GhosttyTestFixture.Feed(terminal, "\n");       // LF: clears pending wrap, moves down, keeps col
         GhosttyTestFixture.Feed(terminal, "X");        // writes at (col 4, row 1)
 
-        Assert.Equal(1, terminal.CursorY);
-        Assert.Equal("hello", GhosttyTestFixture.GetLine(terminal, 0));
-        Assert.Equal("    X", GhosttyTestFixture.GetLine(terminal, 1));
+        Assert.AreEqual(1, terminal.CursorY);
+        Assert.AreEqual("hello", GhosttyTestFixture.GetLine(terminal, 0));
+        Assert.AreEqual("    X", GhosttyTestFixture.GetLine(terminal, 1));
     }
 
     /// <summary>
@@ -129,7 +130,7 @@ public class GhosttyTerminalConformanceTests
     /// Writes "hello" filling 5 cols, then CR. CR resets cursor to col 0 on same row.
     /// Writing 'X' overwrites the first character.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void CarriageReturn_AfterFilledLine_UnsetsWrapAndReturnsToCol0()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 40);
@@ -137,8 +138,8 @@ public class GhosttyTerminalConformanceTests
         GhosttyTestFixture.Feed(terminal, "\r");       // CR goes to col 0
         GhosttyTestFixture.Feed(terminal, "X");
 
-        Assert.Equal(1, terminal.CursorX);
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(1, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
         AssertPlainText(terminal, "Xello");
     }
 
@@ -146,7 +147,7 @@ public class GhosttyTerminalConformanceTests
     /// Ghostty: test "Terminal: backspace"
     /// Writes "hello", backspaces, writes 'y'. Result: "helly".
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Backspace_OverwritesPreviousCharacter()
     {
         using var terminal = CreateTerminal(cols: 40, rows: 40);
@@ -170,7 +171,7 @@ public class GhosttyTerminalConformanceTests
     /// Writes "ABCDE" in 5-col terminal (pending wrap), then CUP(1,1) (top-left).
     /// Writing 'X' overwrites 'A'. Result: "XBCDE".
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void CursorPos_ResetsWrap_WritesAtNewPosition()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -186,14 +187,14 @@ public class GhosttyTerminalConformanceTests
     /// CUP(500,500) in 5×5 terminal clamps to bottom-right (row 4, col 4).
     /// Writing 'X' places it at the last cell.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void CursorPos_OffScreen_ClampsToTerminalBounds()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
         GhosttyTestFixture.Feed(terminal, "\x1b[500;500H"); // CUP far off-screen
         GhosttyTestFixture.Feed(terminal, "X");
 
-        Assert.Equal(4, terminal.CursorY);
+        Assert.AreEqual(4, terminal.CursorY);
         var line = GhosttyTestFixture.GetLine(terminal, 4);
         Assert.EndsWith("X", line);
     }
@@ -202,34 +203,34 @@ public class GhosttyTerminalConformanceTests
     /// Ghostty: test "Terminal: setCursorPos"
     /// Tests CUP clamping: CUP(0,0) → (0,0), CUP(81,81) in 80×80 → (79,79).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void CursorPos_Zero_ClampsToTopLeft()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
         // CUP(0,0) should clamp to (0,0) — row 0, col 0
         GhosttyTestFixture.Feed(terminal, "\x1b[0;0H");
-        Assert.Equal(0, terminal.CursorX);
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
     }
 
     /// <summary>
     /// Ghostty: test "Terminal: setCursorPos" — clamping to max
     /// CUP(81,81) in 80×80 terminal clamps to row 79, col 79.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void CursorPos_BeyondMax_ClampsToBottomRight()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
         GhosttyTestFixture.Feed(terminal, "\x1b[81;81H");
-        Assert.Equal(79, terminal.CursorX);
-        Assert.Equal(79, terminal.CursorY);
+        Assert.AreEqual(79, terminal.CursorX);
+        Assert.AreEqual(79, terminal.CursorY);
     }
 
     /// <summary>
     /// Ghostty: test "Terminal: setCursorPos" — with DECOM (origin mode)
     /// Sets scroll region 2–4, enables DECOM, CUP(1,1) should map to row 1 (second row of region).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void CursorPos_WithOriginMode_IsRelativeToScrollRegion()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
@@ -240,8 +241,8 @@ public class GhosttyTerminalConformanceTests
         // CUP(1,1) with DECOM → cursor at top of scroll region (row 1, 0-based)
         GhosttyTestFixture.Feed(terminal, "\x1b[1;1H");
 
-        Assert.Equal(0, terminal.CursorX);
-        Assert.Equal(1, terminal.CursorY); // row 1 (0-based) = top of scroll region (row 2, 1-based)
+        Assert.AreEqual(0, terminal.CursorX);
+        Assert.AreEqual(1, terminal.CursorY); // row 1 (0-based) = top of scroll region (row 2, 1-based)
     }
 
     #endregion
@@ -257,7 +258,7 @@ public class GhosttyTerminalConformanceTests
     /// Writes "ABC", CUP(1,1), ECH(2) erases 2 chars at col 0–1. Then CUP(1,1), write 'X'.
     /// Result: "X C" — A and B erased, X written at col 0, C remains at col 2.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void EraseChars_SimpleOperation_ErasesCharactersAtCursor()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -276,7 +277,7 @@ public class GhosttyTerminalConformanceTests
         // Then write 'X' at col 0: col 0='X', col 1=' ', col 2='C' → trimmed = "X C"
         var line = GhosttyTestFixture.GetLine(terminal, 0);
         // The line has X at 0, space at 1, C at 2 — no trailing spaces after col 2
-        Assert.Equal("X C", line);
+        Assert.AreEqual("X C", line);
     }
 
     /// <summary>
@@ -284,7 +285,7 @@ public class GhosttyTerminalConformanceTests
     /// ECH(0) erases at least 1 character (minimum is 1).
     /// Writes "ABC", CUP(1,1), ECH(0), write 'X' → "XBC".
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void EraseChars_ZeroParameter_ErasesAtLeastOne()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -302,7 +303,7 @@ public class GhosttyTerminalConformanceTests
     /// Writes "  ABC" (2 spaces + ABC), CUP(1,4) → col 3 (0-based). ECH(10) erases from col 3 to end.
     /// Result: "  A" (only cols 0–2 survive).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void EraseChars_BeyondScreenEdge_ClampsToLineEnd()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -318,7 +319,7 @@ public class GhosttyTerminalConformanceTests
     /// Writes "ABCDE" (fills 5 cols, pending wrap). ECH(1) resets wrap and erases col 4.
     /// Then writing 'X' overwrites col 4 (no wrap). Result: "ABCDX".
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void EraseChars_ResetsPendingWrap()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -342,14 +343,14 @@ public class GhosttyTerminalConformanceTests
     /// ESC D (Index) moves cursor down one line. Then write 'A'.
     /// Result: line 0 empty, line 1 = "A".
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Index_MovesCursorDown()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
         GhosttyTestFixture.Feed(terminal, "\u001bD");   // IND — cursor down
         GhosttyTestFixture.Feed(terminal, "A");
 
-        Assert.Equal(1, terminal.CursorY);
+        Assert.AreEqual(1, terminal.CursorY);
         AssertPlainText(terminal, "\nA");
     }
 
@@ -359,7 +360,7 @@ public class GhosttyTerminalConformanceTests
     /// At the bottom row, Index scrolls content up and inserts blank line at bottom.
     /// Then write 'B' on the new last row.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Index_FromBottomRow_ScrollsContentUp()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -374,8 +375,8 @@ public class GhosttyTerminalConformanceTests
 
         var line3 = GhosttyTestFixture.GetLine(terminal, 3);
         var line4 = GhosttyTestFixture.GetLine(terminal, 4);
-        Assert.Equal("A", line3);
-        Assert.Equal("B", line4);
+        Assert.AreEqual("A", line3);
+        Assert.AreEqual("B", line4);
     }
 
     /// <summary>
@@ -383,7 +384,7 @@ public class GhosttyTerminalConformanceTests
     /// Sets scroll region rows 2–5 (1-based). Cursor at row 0 (above region).
     /// Index should move cursor to row 1 (normal movement, not scrolling).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Index_OutsideScrollRegion_MovesCursorNormally()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -394,14 +395,14 @@ public class GhosttyTerminalConformanceTests
 
         GhosttyTestFixture.Feed(terminal, "\u001bD");       // IND
 
-        Assert.Equal(1, terminal.CursorY); // moved to row 1
+        Assert.AreEqual(1, terminal.CursorY); // moved to row 1
     }
 
     /// <summary>
     /// Ghostty: test "Terminal: reverseIndex"
     /// Writes on row 3, then does Reverse Index (ESC M). Cursor moves up one row.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void ReverseIndex_MovesCursorUp()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -411,14 +412,14 @@ public class GhosttyTerminalConformanceTests
         GhosttyTestFixture.Feed(terminal, "\x1b[4;1H");   // Back to row 3, col 0
         GhosttyTestFixture.Feed(terminal, "\x1bM");       // RI — reverse index
 
-        Assert.Equal(2, terminal.CursorY); // moved up to row 2
+        Assert.AreEqual(2, terminal.CursorY); // moved up to row 2
     }
 
     /// <summary>
     /// Ghostty: test "Terminal: reverseIndex from the top"
     /// At row 0, Reverse Index scrolls content down (inserts blank line at top).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void ReverseIndex_FromTopRow_ScrollsContentDown()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -427,11 +428,11 @@ public class GhosttyTerminalConformanceTests
         GhosttyTestFixture.Feed(terminal, "\x1bM");       // RI — at top, scrolls down
 
         // 'A' should have moved down from row 0 to row 1
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorY);
         var line0 = GhosttyTestFixture.GetLine(terminal, 0);
         var line1 = GhosttyTestFixture.GetLine(terminal, 1);
-        Assert.Equal("", line0);
-        Assert.Equal("A", line1);
+        Assert.AreEqual("", line0);
+        Assert.AreEqual("A", line1);
     }
 
     #endregion
@@ -447,7 +448,7 @@ public class GhosttyTerminalConformanceTests
     /// Writes "ABCDE" on 5-col terminal, CUP(1,3) → col 2 (0-based).
     /// EL(0) erases from cursor to end of line. Result: "AB".
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void EraseLine_Right_ErasesFromCursorToEnd()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -463,7 +464,7 @@ public class GhosttyTerminalConformanceTests
     /// Writes "ABCDE" on 5-col terminal, CUP(1,4) → col 3 (0-based).
     /// EL(1) erases from start of line to cursor (inclusive). Result: "    E".
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void EraseLine_Left_ErasesFromStartToCursor()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -474,7 +475,7 @@ public class GhosttyTerminalConformanceTests
         // Cols 0–3 erased, col 4 = 'E'. But GetLine trims trailing spaces.
         // The content is "    E" — leading spaces + E. GetLine trims trailing only.
         var line = GhosttyTestFixture.GetLine(terminal, 0);
-        Assert.Equal("    E", line);
+        Assert.AreEqual("    E", line);
     }
 
     #endregion
@@ -487,7 +488,7 @@ public class GhosttyTerminalConformanceTests
     /// ED(0) erases from cursor position to end of display.
     /// Lines 0–1 untouched, line 2 partially erased from col 2, lines 3–4 fully erased.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_Below_ErasesFromCursorToEndOfScreen()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -501,11 +502,11 @@ public class GhosttyTerminalConformanceTests
         GhosttyTestFixture.Feed(terminal, "\x1b[3;3H");
         GhosttyTestFixture.Feed(terminal, "\x1b[0J");     // ED(0) — erase below
 
-        Assert.Equal("AAAAA", GhosttyTestFixture.GetLine(terminal, 0));
-        Assert.Equal("BBBBB", GhosttyTestFixture.GetLine(terminal, 1));
-        Assert.Equal("CC", GhosttyTestFixture.GetLine(terminal, 2));  // cols 0–1 survive
-        Assert.Equal("", GhosttyTestFixture.GetLine(terminal, 3));
-        Assert.Equal("", GhosttyTestFixture.GetLine(terminal, 4));
+        Assert.AreEqual("AAAAA", GhosttyTestFixture.GetLine(terminal, 0));
+        Assert.AreEqual("BBBBB", GhosttyTestFixture.GetLine(terminal, 1));
+        Assert.AreEqual("CC", GhosttyTestFixture.GetLine(terminal, 2));  // cols 0–1 survive
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(terminal, 3));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(terminal, 4));
     }
 
     /// <summary>
@@ -514,7 +515,7 @@ public class GhosttyTerminalConformanceTests
     /// ED(1) erases from start of display to cursor position.
     /// Lines 0–1 fully erased, line 2 partially erased up to col 2, lines 3–4 untouched.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_Above_ErasesFromStartToCursorPosition()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -528,13 +529,13 @@ public class GhosttyTerminalConformanceTests
         GhosttyTestFixture.Feed(terminal, "\x1b[3;3H");
         GhosttyTestFixture.Feed(terminal, "\x1b[1J");     // ED(1) — erase above
 
-        Assert.Equal("", GhosttyTestFixture.GetLine(terminal, 0));
-        Assert.Equal("", GhosttyTestFixture.GetLine(terminal, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(terminal, 0));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(terminal, 1));
         // Row 2: cols 0–2 erased (inclusive), cols 3–4 survive → "   CC"
         var line2 = GhosttyTestFixture.GetLine(terminal, 2);
-        Assert.Equal("   CC", line2);
-        Assert.Equal("DDDDD", GhosttyTestFixture.GetLine(terminal, 3));
-        Assert.Equal("EEEEE", GhosttyTestFixture.GetLine(terminal, 4));
+        Assert.AreEqual("   CC", line2);
+        Assert.AreEqual("DDDDD", GhosttyTestFixture.GetLine(terminal, 3));
+        Assert.AreEqual("EEEEE", GhosttyTestFixture.GetLine(terminal, 4));
     }
 
     #endregion
@@ -550,21 +551,21 @@ public class GhosttyTerminalConformanceTests
     /// Default tab stops are every 8 columns. Write '1', tab → col 8, tab → col 16.
     /// Tab at end of line clamps to last column.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void HorizontalTab_DefaultStops_MovesToNext8thColumn()
     {
         using var terminal = CreateTerminal(cols: 20, rows: 5);
         GhosttyTestFixture.Feed(terminal, "1");
         GhosttyTestFixture.Feed(terminal, "\t");
 
-        Assert.Equal(8, terminal.CursorX);
+        Assert.AreEqual(8, terminal.CursorX);
 
         GhosttyTestFixture.Feed(terminal, "\t");
-        Assert.Equal(16, terminal.CursorX);
+        Assert.AreEqual(16, terminal.CursorX);
 
         // Tab near end should clamp to last column (cols-1 = 19)
         GhosttyTestFixture.Feed(terminal, "\t");
-        Assert.Equal(19, terminal.CursorX);
+        Assert.AreEqual(19, terminal.CursorX);
     }
 
     #endregion
@@ -579,7 +580,7 @@ public class GhosttyTerminalConformanceTests
     /// Ghostty: test "Terminal: setTopAndBottomMargin simple"
     /// Sets scroll region then verifies scrolling only affects that region.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void ScrollRegion_LimitsScrollingToRegion()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -599,15 +600,15 @@ public class GhosttyTerminalConformanceTests
         GhosttyTestFixture.Feed(terminal, "\u001bD");
 
         // Row 0 and row 4 (outside region) should be unchanged
-        Assert.Equal("AAAAA", GhosttyTestFixture.GetLine(terminal, 0));
+        Assert.AreEqual("AAAAA", GhosttyTestFixture.GetLine(terminal, 0));
         // Rows 1–3 (the scroll region) should have shifted up:
         // row 1 was "BBBBB" → now "CCCCC"
         // row 2 was "CCCCC" → now "DDDDD"
         // row 3 was "DDDDD" → now empty (blank inserted at bottom of region)
-        Assert.Equal("CCCCC", GhosttyTestFixture.GetLine(terminal, 1));
-        Assert.Equal("DDDDD", GhosttyTestFixture.GetLine(terminal, 2));
-        Assert.Equal("", GhosttyTestFixture.GetLine(terminal, 3));
-        Assert.Equal("EEEEE", GhosttyTestFixture.GetLine(terminal, 4));
+        Assert.AreEqual("CCCCC", GhosttyTestFixture.GetLine(terminal, 1));
+        Assert.AreEqual("DDDDD", GhosttyTestFixture.GetLine(terminal, 2));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(terminal, 3));
+        Assert.AreEqual("EEEEE", GhosttyTestFixture.GetLine(terminal, 4));
     }
 
     #endregion
@@ -623,7 +624,7 @@ public class GhosttyTerminalConformanceTests
     /// Fills 5 rows, CUP to middle, IL(1) inserts a blank line pushing rows down.
     /// The last row is lost (scrolled out).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void InsertLines_ShiftsRowsDown()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -639,11 +640,11 @@ public class GhosttyTerminalConformanceTests
         // IL(1) — insert 1 blank line at row 2
         GhosttyTestFixture.Feed(terminal, "\x1b[1L");
 
-        Assert.Equal("AAAAA", GhosttyTestFixture.GetLine(terminal, 0));
-        Assert.Equal("BBBBB", GhosttyTestFixture.GetLine(terminal, 1));
-        Assert.Equal("", GhosttyTestFixture.GetLine(terminal, 2));     // inserted blank
-        Assert.Equal("CCCCC", GhosttyTestFixture.GetLine(terminal, 3));
-        Assert.Equal("DDDDD", GhosttyTestFixture.GetLine(terminal, 4)); // EEEEE lost
+        Assert.AreEqual("AAAAA", GhosttyTestFixture.GetLine(terminal, 0));
+        Assert.AreEqual("BBBBB", GhosttyTestFixture.GetLine(terminal, 1));
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(terminal, 2));     // inserted blank
+        Assert.AreEqual("CCCCC", GhosttyTestFixture.GetLine(terminal, 3));
+        Assert.AreEqual("DDDDD", GhosttyTestFixture.GetLine(terminal, 4)); // EEEEE lost
     }
 
     /// <summary>
@@ -651,7 +652,7 @@ public class GhosttyTerminalConformanceTests
     /// Fills 5 rows, CUP to middle, DL(1) deletes a line shifting rows up.
     /// A blank line appears at the bottom.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void DeleteLines_ShiftsRowsUp()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -667,11 +668,11 @@ public class GhosttyTerminalConformanceTests
         // DL(1) — delete 1 line at row 2
         GhosttyTestFixture.Feed(terminal, "\x1b[1M");
 
-        Assert.Equal("AAAAA", GhosttyTestFixture.GetLine(terminal, 0));
-        Assert.Equal("BBBBB", GhosttyTestFixture.GetLine(terminal, 1));
-        Assert.Equal("DDDDD", GhosttyTestFixture.GetLine(terminal, 2)); // was row 3
-        Assert.Equal("EEEEE", GhosttyTestFixture.GetLine(terminal, 3)); // was row 4
-        Assert.Equal("", GhosttyTestFixture.GetLine(terminal, 4));     // blank at bottom
+        Assert.AreEqual("AAAAA", GhosttyTestFixture.GetLine(terminal, 0));
+        Assert.AreEqual("BBBBB", GhosttyTestFixture.GetLine(terminal, 1));
+        Assert.AreEqual("DDDDD", GhosttyTestFixture.GetLine(terminal, 2)); // was row 3
+        Assert.AreEqual("EEEEE", GhosttyTestFixture.GetLine(terminal, 3)); // was row 4
+        Assert.AreEqual("", GhosttyTestFixture.GetLine(terminal, 4));     // blank at bottom
     }
 
     #endregion
@@ -687,7 +688,7 @@ public class GhosttyTerminalConformanceTests
     /// Writes "ABC", CUP(1,2) → col 1 (0-based). DCH(1) deletes 'B', 'C' shifts left.
     /// Result: "AC".
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void DeleteChars_ShiftsCharactersLeft()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -703,7 +704,7 @@ public class GhosttyTerminalConformanceTests
     /// Writes "ABC", CUP(1,2) → col 1. DCH(10) deletes all from col 1 onward.
     /// Result: "A".
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void DeleteChars_MoreThanLineWidth_ClampsToEnd()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -719,7 +720,7 @@ public class GhosttyTerminalConformanceTests
     /// Ghostty's internal deleteChars(0) is a no-op, but CSI 0P defaults to 1 per ECMA-48 §8.3.27.
     /// Our terminal correctly normalizes parameter 0 → 1, so this deletes 1 character.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void DeleteChars_ZeroCount_DefaultsToOne()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -735,7 +736,7 @@ public class GhosttyTerminalConformanceTests
     /// Writes "ABCDE", CUP(1,2). DCH(3) deletes B,C,D. E shifts to col 1.
     /// Result: "AE".
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void DeleteChars_MoreThanHalf_ShiftsRemaining()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -751,7 +752,7 @@ public class GhosttyTerminalConformanceTests
     /// Writes "ABCDE", CUP(1,2). DCH(1) deletes B. C,D,E shift left.
     /// Result: "ACDE".
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void DeleteChars_ShiftsRemainingLeft()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -767,7 +768,7 @@ public class GhosttyTerminalConformanceTests
     /// After filling 5-col line (pending wrap), DCH(1) resets wrap.
     /// Write 'X' stays on same line.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void DeleteChars_ResetsPendingWrap()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -783,7 +784,7 @@ public class GhosttyTerminalConformanceTests
     /// Writes "ABC123", CUP(1,3) → col 2. DCH(2) deletes C,1. 2,3 shift left.
     /// Result: "AB23".
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void DeleteChars_SimpleOperation_10x10()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 10);

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyTestFixture.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyTestFixture.cs
@@ -9,7 +9,7 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// <remarks>
 /// Ghostty's tests represent their interpretation of VT terminal standards.
 /// Failures are triaged as: Bug, MissingFeature, IntentionalDivergence, or GhosttySpecific.
-/// Use [Trait("Category", "GhosttyConformance")] on all test classes.
+/// Use [TestCategory("GhosttyConformance")] on all test classes.
 /// </remarks>
 public static class GhosttyTestFixture
 {

--- a/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyWideCharConformanceTests.cs
+++ b/tests/Hex1b.Tests/Conformance/Ghostty/GhosttyWideCharConformanceTests.cs
@@ -4,7 +4,8 @@ namespace Hex1b.Tests.Conformance.Ghostty;
 /// Conformance tests for wide character, grapheme cluster, variation selector,
 /// and combining character handling, translated from Ghostty's Terminal.zig.
 /// </summary>
-[Trait("Category", "GhosttyConformance")]
+[TestCategory("GhosttyConformance")]
+[TestClass]
 public class GhosttyWideCharConformanceTests
 {
     private static Hex1bTerminal CreateTerminal(int cols = 80, int rows = 24)
@@ -13,33 +14,33 @@ public class GhosttyWideCharConformanceTests
     private static void AssertPlainText(Hex1bTerminal terminal, int row, string expected)
     {
         var line = GhosttyTestFixture.GetLine(terminal, row);
-        Assert.Equal(expected, line);
+        Assert.AreEqual(expected, line);
     }
 
     #region Wide Character Basics
 
     // Ghostty: test "Terminal: print wide char"
     // Prints smiley face (U+1F600), should take 2 cells
-    [Fact]
+    [TestMethod]
     public void PrintWideChar_TakesTwoCells()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
         GhosttyTestFixture.Feed(terminal, "😀");
 
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(2, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(2, terminal.CursorX);
 
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.Equal("😀", cell0.Character);
+        Assert.AreEqual("😀", cell0.Character);
 
         // Continuation cell should have empty string
         var cell1 = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.Equal("", cell1.Character);
+        Assert.AreEqual("", cell1.Character);
     }
 
     // Ghostty: test "Terminal: print wide char at edge creates spacer head"
     // Wide char at last column wraps to next line
-    [Fact]
+    [TestMethod]
     public void PrintWideChar_AtEdge_WrapsToNextLine()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 10);
@@ -48,42 +49,42 @@ public class GhosttyWideCharConformanceTests
         GhosttyTestFixture.Feed(terminal, "😀");
 
         // Should wrap to next line
-        Assert.Equal(1, terminal.CursorY);
-        Assert.Equal(2, terminal.CursorX);
+        Assert.AreEqual(1, terminal.CursorY);
+        Assert.AreEqual(2, terminal.CursorX);
 
         // Last column of first line should be blank (spacer head)
         var spacerHead = GhosttyTestFixture.GetCell(terminal, 0, 9);
-        Assert.Equal(" ", spacerHead.Character);
+        Assert.AreEqual(" ", spacerHead.Character);
 
         // Wide char should be on second line
         var cell0 = GhosttyTestFixture.GetCell(terminal, 1, 0);
-        Assert.Equal("😀", cell0.Character);
+        Assert.AreEqual("😀", cell0.Character);
 
         var cell1 = GhosttyTestFixture.GetCell(terminal, 1, 1);
-        Assert.Equal("", cell1.Character);
+        Assert.AreEqual("", cell1.Character);
     }
 
     // Ghostty: test "Terminal: print wide char with 1-column width"
     // Wide char in 1-column terminal — can't fit, should not crash
-    [Fact]
+    [TestMethod]
     public void PrintWideChar_InSingleColumnTerminal_NoCrash()
     {
         using var terminal = CreateTerminal(cols: 1, rows: 2);
         GhosttyTestFixture.Feed(terminal, "😀");
 
         // Should not crash — behavior varies but must be safe
-        Assert.True(terminal.CursorX >= 0);
+        Assert.IsTrue(terminal.CursorX >= 0);
     }
 
     // Ghostty: test "Terminal: print wide char in single-width terminal"
-    [Fact]
+    [TestMethod]
     public void PrintWideChar_SingleWidthTerminal_PendingWrap()
     {
         using var terminal = CreateTerminal(cols: 1, rows: 80);
         GhosttyTestFixture.Feed(terminal, "😀");
 
         // Wide char can't fit in 1-col terminal
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorY);
     }
 
     #endregion
@@ -92,7 +93,7 @@ public class GhosttyWideCharConformanceTests
 
     // Ghostty: test "Terminal: print over wide char at 0,0"
     // Print wide char, then overwrite first cell with narrow char
-    [Fact]
+    [TestMethod]
     public void PrintOverWideChar_AtOrigin_ClearsContinuation()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
@@ -100,21 +101,20 @@ public class GhosttyWideCharConformanceTests
         GhosttyTestFixture.Feed(terminal, "\x1b[1;1H"); // CUP(1,1) → col 0
         GhosttyTestFixture.Feed(terminal, "A");
 
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(1, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(1, terminal.CursorX);
 
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.Equal("A", cell0.Character);
+        Assert.AreEqual("A", cell0.Character);
 
         // Former continuation cell should be cleared
         var cell1 = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.True(cell1.Character == " " || cell1.Character == "",
-            $"Expected space or empty but got '{cell1.Character}'");
+        Assert.IsTrue(cell1.Character == " " || cell1.Character == "", $"Expected space or empty but got '{cell1.Character}'");
     }
 
     // Ghostty: test "Terminal: print over wide spacer tail"
     // Print wide char, then overwrite the continuation cell
-    [Fact]
+    [TestMethod]
     public void PrintOverWideSpacerTail_ClearsLeading()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
@@ -124,18 +124,17 @@ public class GhosttyWideCharConformanceTests
 
         // Leading half should be cleared
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.True(cell0.Character == " " || cell0.Character == "",
-            $"Expected leading half cleared, got '{cell0.Character}'");
+        Assert.IsTrue(cell0.Character == " " || cell0.Character == "", $"Expected leading half cleared, got '{cell0.Character}'");
 
         var cell1 = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.Equal("X", cell1.Character);
+        Assert.AreEqual("X", cell1.Character);
 
         // Leading cell cleared to space, so plain text is " X"
         AssertPlainText(terminal, 0, " X");
     }
 
     // Print a wide char, then overwrite it with another wide char
-    [Fact]
+    [TestMethod]
     public void PrintWideOverWide_ReplacesCleanly()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -144,10 +143,10 @@ public class GhosttyWideCharConformanceTests
         GhosttyTestFixture.Feed(terminal, "漢");
 
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.Equal("漢", cell0.Character);
+        Assert.AreEqual("漢", cell0.Character);
 
         var cell1 = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.Equal("", cell1.Character);
+        Assert.AreEqual("", cell1.Character);
     }
 
     #endregion
@@ -155,52 +154,52 @@ public class GhosttyWideCharConformanceTests
     #region Combining Characters
 
     // Ghostty: test "print grapheme ò (o with nonspacing mark) should be narrow"
-    [Fact]
+    [TestMethod]
     public void PrintCombiningCharacter_NarrowWidth()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
         // o + combining grave accent = ò (single cell)
         GhosttyTestFixture.Feed(terminal, "o\u0300");
 
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(1, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(1, terminal.CursorX);
 
         var cell = GhosttyTestFixture.GetCell(terminal, 0, 0);
         // .NET may NFC-compose o+\u0300 into ò (U+00F2)
-        Assert.True(cell.Character.Length > 0, "Cell should have content");
+        Assert.IsTrue(cell.Character.Length > 0, "Cell should have content");
     }
 
     // Test combining character with other text
-    [Fact]
+    [TestMethod]
     public void PrintCombiningCharacter_FollowedByText()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
         GhosttyTestFixture.Feed(terminal, "o\u0300X");
 
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(2, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(2, terminal.CursorX);
 
         var cell1 = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.Equal("X", cell1.Character);
+        Assert.AreEqual("X", cell1.Character);
     }
 
     // Multiple combining marks on one base character
-    [Fact]
+    [TestMethod]
     public void PrintMultipleCombiningMarks_SingleCell()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
         // a + combining acute + combining tilde
         GhosttyTestFixture.Feed(terminal, "a\u0301\u0303X");
 
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(2, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(2, terminal.CursorX);
 
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
         // .NET may NFC-compose a+\u0301 into á, then combine with \u0303
-        Assert.True(cell0.Character.Length > 0, "Cell should have content");
+        Assert.IsTrue(cell0.Character.Length > 0, "Cell should have content");
 
         var cell1 = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.Equal("X", cell1.Character);
+        Assert.AreEqual("X", cell1.Character);
     }
 
     #endregion
@@ -209,30 +208,30 @@ public class GhosttyWideCharConformanceTests
 
     // Ghostty: test "Terminal: zero-width character at start"
     // Zero-width joiner at position 0 should be ignored
-    [Fact]
+    [TestMethod]
     public void ZeroWidthCharacter_AtStart_Ignored()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
         // ZWJ (U+200D) at start — should be ignored
         GhosttyTestFixture.Feed(terminal, "\u200D");
 
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(0, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorX);
     }
 
     // Zero-width space should not advance cursor
-    [Fact]
+    [TestMethod]
     public void ZeroWidthSpace_DoesNotAdvanceCursor()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
         GhosttyTestFixture.Feed(terminal, "A\u200BB");
 
         // Zero-width space (U+200B) should not take a cell
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorY);
 
         // Check that A and B are in adjacent cells
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.Equal("A", cell0.Character);
+        Assert.AreEqual("A", cell0.Character);
     }
 
     #endregion
@@ -241,79 +240,79 @@ public class GhosttyWideCharConformanceTests
 
     // Ghostty: test "Terminal: VS16 to make wide character with mode 2027"
     // Heart (U+2764) + VS16 = emoji presentation (wide)
-    [Fact]
+    [TestMethod]
     public void VS16_MakesCharacterWide()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
         // Heart + VS16 (emoji presentation) → ❤️ (wide)
         GhosttyTestFixture.Feed(terminal, "\u2764\uFE0F");
 
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(2, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(2, terminal.CursorX);
 
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.NotEqual("", cell0.Character);
+        Assert.AreNotEqual("", cell0.Character);
 
         // Continuation cell
         var cell1 = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.Equal("", cell1.Character);
+        Assert.AreEqual("", cell1.Character);
     }
 
     // Ghostty: test "Terminal: VS15 to make narrow character"
     // Thunder cloud (U+26C8) + VS15 = text presentation (narrow)
-    [Fact]
+    [TestMethod]
     public void VS15_MakesCharacterNarrow()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
         // Thunder cloud + VS15 (text presentation)
         GhosttyTestFixture.Feed(terminal, "\u26C8\uFE0E");
 
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(1, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(1, terminal.CursorX);
     }
 
     // Ghostty: test "Terminal: VS16 repeated with mode 2027"
     // Repeated VS16 should be ignored
-    [Fact]
+    [TestMethod]
     public void VS16_Repeated_Ignored()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
         // Heart + VS16 + VS16 (repeated)
         GhosttyTestFixture.Feed(terminal, "\u2764\uFE0F\uFE0F");
 
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(2, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(2, terminal.CursorX);
     }
 
     // Ghostty: test "Terminal: keypad sequence VS16"
     // Number sign (U+0023) + VS16 → emoji presentation (wide)
-    [Fact]
+    [TestMethod]
     public void VS16_KeypadSequence_MakesWide()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
         // # + VS16 (emoji presentation) → #️ (wide)
         GhosttyTestFixture.Feed(terminal, "#\uFE0F");
 
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(2, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(2, terminal.CursorX);
     }
 
     // Ghostty: test "Terminal: keypad sequence VS15"
     // Number sign (U+0023) + VS15 → text presentation (narrow)
-    [Fact]
+    [TestMethod]
     public void VS15_KeypadSequence_StaysNarrow()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
         // # + VS15 (text presentation) → # (narrow)
         GhosttyTestFixture.Feed(terminal, "#\uFE0E");
 
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(1, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(1, terminal.CursorX);
     }
 
     // Ghostty: test "Terminal: VS16 to make wide character on next line"
     // At edge of terminal, VS16 causes character to wrap to next line as wide
-    [Fact]
+    [TestMethod]
     public void VS16_AtEdge_WrapsToNextLine()
     {
         using var terminal = CreateTerminal(cols: 3, rows: 5);
@@ -323,8 +322,8 @@ public class GhosttyWideCharConformanceTests
         GhosttyTestFixture.Feed(terminal, "\u2764\uFE0F");
 
         // Should wrap to next line with width 2
-        Assert.Equal(1, terminal.CursorY);
-        Assert.Equal(2, terminal.CursorX);
+        Assert.AreEqual(1, terminal.CursorY);
+        Assert.AreEqual(2, terminal.CursorX);
     }
 
     #endregion
@@ -333,7 +332,7 @@ public class GhosttyWideCharConformanceTests
 
     // Ghostty: test "Terminal: print multicodepoint grapheme, disabled mode 2027"
     // Family emoji without mode 2027 — each component rendered separately
-    [Fact]
+    [TestMethod]
     public void MultiCodepoint_FamilyEmoji_DisabledMode2027()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
@@ -343,43 +342,43 @@ public class GhosttyWideCharConformanceTests
         // Without mode 2027, each emoji is rendered separately
         // Each wide char takes 2 cells, ZWJ takes 0
         // Hex1b always does grapheme clustering, so behavior depends on implementation
-        Assert.Equal(0, terminal.CursorY);
-        Assert.True(terminal.CursorX >= 2, "Family emoji should take at least 2 cells");
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.IsTrue(terminal.CursorX >= 2, "Family emoji should take at least 2 cells");
     }
 
     // Ghostty: test "Terminal: Fitzpatrick skin tone next valid base"
     // Waving hand + dark skin tone = single grapheme
-    [Fact]
+    [TestMethod]
     public void FitzpatrickSkinTone_CombinesWithBase()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
         // 👋🏿 = Waving hand (U+1F44B) + Dark skin tone (U+1F3FF)
         GhosttyTestFixture.Feed(terminal, "👋🏿");
 
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(2, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(2, terminal.CursorX);
 
         // Should be stored as single grapheme cluster in one cell
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.True(cell0.Character.Length > 0, "Cell should have content");
+        Assert.IsTrue(cell0.Character.Length > 0, "Cell should have content");
         // Continuation cell
         var cell1 = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.Equal("", cell1.Character);
+        Assert.AreEqual("", cell1.Character);
     }
 
     // Ghostty: test "Terminal: print invalid VS16 with second char (combining)"
     // n + invalid VS16 + combining tilde → single narrow cell
-    [Fact]
+    [TestMethod]
     public void InvalidVS16_WithCombining_StaysNarrow()
     {
         using var terminal = CreateTerminal(cols: 80, rows: 80);
         // n + VS16 (invalid for 'n') + combining tilde
         GhosttyTestFixture.Feed(terminal, "n\uFE0F\u0303");
 
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorY);
         // 'n' is not a valid emoji base, so VS16 should be ignored
         // Result should be narrow (1 cell)
-        Assert.Equal(1, terminal.CursorX);
+        Assert.AreEqual(1, terminal.CursorX);
     }
 
     #endregion
@@ -387,19 +386,19 @@ public class GhosttyWideCharConformanceTests
     #region Wide Characters with Other Operations
 
     // Wide character followed by backspace
-    [Fact]
+    [TestMethod]
     public void WideChar_Backspace_MovesOneColumn()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
         GhosttyTestFixture.Feed(terminal, "橋");
-        Assert.Equal(2, terminal.CursorX);
+        Assert.AreEqual(2, terminal.CursorX);
 
         GhosttyTestFixture.Feed(terminal, "\b");
-        Assert.Equal(1, terminal.CursorX);
+        Assert.AreEqual(1, terminal.CursorX);
     }
 
     // Wide character filling a line
-    [Fact]
+    [TestMethod]
     public void WideChars_FillLine_PendingWrap()
     {
         using var terminal = CreateTerminal(cols: 4, rows: 5);
@@ -407,66 +406,66 @@ public class GhosttyWideCharConformanceTests
         GhosttyTestFixture.Feed(terminal, "橋漢");
 
         // Cursor should be at right margin with pending wrap
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorY);
 
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.Equal("橋", cell0.Character);
+        Assert.AreEqual("橋", cell0.Character);
         var cell2 = GhosttyTestFixture.GetCell(terminal, 0, 2);
-        Assert.Equal("漢", cell2.Character);
+        Assert.AreEqual("漢", cell2.Character);
     }
 
     // Wide character at second-to-last column
-    [Fact]
+    [TestMethod]
     public void WideChar_AtSecondToLastCol_FitsWithoutWrap()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
         GhosttyTestFixture.Feed(terminal, "ABC");
-        Assert.Equal(3, terminal.CursorX);
+        Assert.AreEqual(3, terminal.CursorX);
 
         GhosttyTestFixture.Feed(terminal, "橋");
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(4, terminal.CursorX); // or 5 with pending wrap
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(4, terminal.CursorX); // or 5 with pending wrap
 
         var cell3 = GhosttyTestFixture.GetCell(terminal, 0, 3);
-        Assert.Equal("橋", cell3.Character);
+        Assert.AreEqual("橋", cell3.Character);
     }
 
     // Wide character at last column — not enough room
-    [Fact]
+    [TestMethod]
     public void WideChar_AtLastCol_WrapsToNextLine()
     {
         using var terminal = CreateTerminal(cols: 5, rows: 5);
         GhosttyTestFixture.Feed(terminal, "ABCD");
-        Assert.Equal(4, terminal.CursorX);
+        Assert.AreEqual(4, terminal.CursorX);
 
         GhosttyTestFixture.Feed(terminal, "橋");
         // Wide char doesn't fit at col 4, should wrap
-        Assert.Equal(1, terminal.CursorY);
+        Assert.AreEqual(1, terminal.CursorY);
 
         var cell0row1 = GhosttyTestFixture.GetCell(terminal, 1, 0);
-        Assert.Equal("橋", cell0row1.Character);
+        Assert.AreEqual("橋", cell0row1.Character);
     }
 
     // CJK text wrapping across lines
-    [Fact]
+    [TestMethod]
     public void WideChars_WrapAcrossLines()
     {
         using var terminal = CreateTerminal(cols: 6, rows: 5);
         // 3 wide chars = 6 cells = exactly fills one line
         GhosttyTestFixture.Feed(terminal, "漢字橋");
 
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorY);
 
         // Add one more — should wrap
         GhosttyTestFixture.Feed(terminal, "道");
-        Assert.Equal(1, terminal.CursorY);
+        Assert.AreEqual(1, terminal.CursorY);
 
         AssertPlainText(terminal, 0, "漢字橋");
         AssertPlainText(terminal, 1, "道");
     }
 
     // Erase a wide character with ECH
-    [Fact]
+    [TestMethod]
     public void EraseChar_OnWideChar_ClearsBothCells()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
@@ -476,8 +475,7 @@ public class GhosttyWideCharConformanceTests
 
         // Erasing position 0 should clear the wide char
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.True(cell0.Character == " " || cell0.Character == "",
-            "Erased cell should be blank");
+        Assert.IsTrue(cell0.Character == " " || cell0.Character == "", "Erased cell should be blank");
     }
 
     #endregion
@@ -485,47 +483,47 @@ public class GhosttyWideCharConformanceTests
     #region Mixed Content
 
     // ASCII followed by wide chars followed by ASCII
-    [Fact]
+    [TestMethod]
     public void MixedContent_AsciiAndWide()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
         GhosttyTestFixture.Feed(terminal, "A橋B漢C");
 
-        Assert.Equal(0, terminal.CursorY);
-        Assert.Equal(7, terminal.CursorX); // A(1) + 橋(2) + B(1) + 漢(2) + C(1) = 7
+        Assert.AreEqual(0, terminal.CursorY);
+        Assert.AreEqual(7, terminal.CursorX); // A(1) + 橋(2) + B(1) + 漢(2) + C(1) = 7
 
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.Equal("A", cell0.Character);
+        Assert.AreEqual("A", cell0.Character);
 
         var cell1 = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.Equal("橋", cell1.Character);
+        Assert.AreEqual("橋", cell1.Character);
 
         var cell3 = GhosttyTestFixture.GetCell(terminal, 0, 3);
-        Assert.Equal("B", cell3.Character);
+        Assert.AreEqual("B", cell3.Character);
 
         var cell4 = GhosttyTestFixture.GetCell(terminal, 0, 4);
-        Assert.Equal("漢", cell4.Character);
+        Assert.AreEqual("漢", cell4.Character);
 
         var cell6 = GhosttyTestFixture.GetCell(terminal, 0, 6);
-        Assert.Equal("C", cell6.Character);
+        Assert.AreEqual("C", cell6.Character);
     }
 
     // Wide char with SGR attributes
-    [Fact]
+    [TestMethod]
     public void WideChar_WithAttributes_AttributesOnBothCells()
     {
         using var terminal = CreateTerminal(cols: 10, rows: 5);
         GhosttyTestFixture.Feed(terminal, "\x1b[1;31m橋\x1b[0m");
 
         var cell0 = GhosttyTestFixture.GetCell(terminal, 0, 0);
-        Assert.Equal("橋", cell0.Character);
-        Assert.True(cell0.IsBold);
-        Assert.NotNull(cell0.Foreground);
+        Assert.AreEqual("橋", cell0.Character);
+        Assert.IsTrue(cell0.IsBold);
+        Assert.IsNotNull(cell0.Foreground);
 
         // Continuation cell should also have same attributes
         var cell1 = GhosttyTestFixture.GetCell(terminal, 0, 1);
-        Assert.Equal("", cell1.Character);
-        Assert.True(cell1.IsBold);
+        Assert.AreEqual("", cell1.Character);
+        Assert.IsTrue(cell1.IsBold);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/ConsolePresentationAdapterTests.cs
+++ b/tests/Hex1b.Tests/ConsolePresentationAdapterTests.cs
@@ -2,16 +2,17 @@ using System.Text;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class ConsolePresentationAdapterTests
 {
-    [Theory]
-    [InlineData(0x45, '\0', false, false, false, "e")]
-    [InlineData(0x45, '\0', false, false, true, "E")]
-    [InlineData(0x31, '\0', false, false, false, "1")]
-    [InlineData(0x31, '\0', false, false, true, "!")]
-    [InlineData(0xBF, '\0', false, false, false, "/")]
-    [InlineData(0xBF, '\0', false, false, true, "?")]
-    [InlineData(0x20, '\0', false, false, false, " ")]
+    [TestMethod]
+    [DataRow(0x45, '\0', false, false, false, "e")]
+    [DataRow(0x45, '\0', false, false, true, "E")]
+    [DataRow(0x31, '\0', false, false, false, "1")]
+    [DataRow(0x31, '\0', false, false, true, "!")]
+    [DataRow(0xBF, '\0', false, false, false, "/")]
+    [DataRow(0xBF, '\0', false, false, true, "?")]
+    [DataRow(0x20, '\0', false, false, false, " ")]
     public void WindowsConsoleDriver_GetPrintableText_FallsBackToVirtualKeyMapping(
         int virtualKey,
         char unicodeChar,
@@ -22,12 +23,12 @@ public class ConsolePresentationAdapterTests
     {
         var text = WindowsConsoleDriver.GetPrintableText((ushort)virtualKey, unicodeChar, hasCtrl, hasAlt, hasShift);
 
-        Assert.Equal(expected, text);
+        Assert.AreEqual(expected, text);
     }
 
-    [Theory]
-    [InlineData(0x45, true, false)]
-    [InlineData(0x45, false, true)]
+    [TestMethod]
+    [DataRow(0x45, true, false)]
+    [DataRow(0x45, false, true)]
     public void WindowsConsoleDriver_GetPrintableText_DoesNotInventModifiedCharacters(
         int virtualKey,
         bool hasCtrl,
@@ -35,33 +36,33 @@ public class ConsolePresentationAdapterTests
     {
         var text = WindowsConsoleDriver.GetPrintableText((ushort)virtualKey, '\0', hasCtrl, hasAlt, hasShift: false);
 
-        Assert.Null(text);
+        Assert.IsNull(text);
     }
 
-    [Theory]
-    [InlineData("\x1b[65;30;97;1;0;1_", "a")]
-    [InlineData("\x1b[13;28;13;1;0;1_", "\r")]
-    [InlineData("\x1b[65;30;97;1;0;3_", "aaa")]
+    [TestMethod]
+    [DataRow("\x1b[65;30;97;1;0;1_", "a")]
+    [DataRow("\x1b[13;28;13;1;0;1_", "\r")]
+    [DataRow("\x1b[65;30;97;1;0;3_", "aaa")]
     public void WindowsConsoleDriver_TryTranslateWin32InputSequence_DecodesForwardedKeyboardInput(
         string sequence,
         string expected)
     {
         var handled = WindowsConsoleDriver.TryTranslateWin32InputSequence(sequence, out var bytes);
 
-        Assert.True(handled);
-        Assert.Equal(expected, Encoding.UTF8.GetString(bytes));
+        Assert.IsTrue(handled);
+        Assert.AreEqual(expected, Encoding.UTF8.GetString(bytes));
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowsConsoleDriver_TryTranslateWin32InputSequence_IgnoresKeyUpFrames()
     {
         var handled = WindowsConsoleDriver.TryTranslateWin32InputSequence("\x1b[65;30;97;0;0;1_", out var bytes);
 
-        Assert.True(handled);
-        Assert.Empty(bytes);
+        Assert.IsTrue(handled);
+        Assert.IsEmpty(bytes);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Constructor_OnUnsupportedPlatform_ThrowsPlatformNotSupportedException()
     {
         // This test verifies the factory pattern works correctly
@@ -70,7 +71,7 @@ public class ConsolePresentationAdapterTests
         
         if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
         {
-            Assert.Throws<PlatformNotSupportedException>(() => 
+            Assert.ThrowsExactly<PlatformNotSupportedException>(() => 
                 new ConsolePresentationAdapter(enableMouse: false));
         }
         else
@@ -81,7 +82,7 @@ public class ConsolePresentationAdapterTests
             try
             {
                 var adapter = new ConsolePresentationAdapter(enableMouse: false);
-                Assert.NotNull(adapter);
+                Assert.IsNotNull(adapter);
                 // Clean up - must use async dispose
                 await adapter.DisposeAsync();
             }
@@ -93,7 +94,7 @@ public class ConsolePresentationAdapterTests
         }
     }
     
-    [Fact]
+    [TestMethod]
     public void UnixConsoleDriver_OnlyAvailableOnUnixPlatforms()
     {
         if (OperatingSystem.IsLinux())
@@ -102,7 +103,7 @@ public class ConsolePresentationAdapterTests
             try
             {
                 using var driver = new UnixConsoleDriver();
-                Assert.NotNull(driver);
+                Assert.IsNotNull(driver);
             }
             catch (Exception ex) when (ex.Message.Contains("TTY") || ex.Message.Contains("tcgetattr"))
             {
@@ -115,7 +116,7 @@ public class ConsolePresentationAdapterTests
             try
             {
                 using var driver = new UnixConsoleDriver();
-                Assert.NotNull(driver);
+                Assert.IsNotNull(driver);
             }
             catch (Exception ex) when (ex.Message.Contains("TTY") || ex.Message.Contains("tcgetattr"))
             {
@@ -127,12 +128,12 @@ public class ConsolePresentationAdapterTests
             // On Windows, the driver should throw or not be available
             // Suppress CA1416 - we're intentionally testing that this throws on unsupported platforms
 #pragma warning disable CA1416
-            Assert.Throws<PlatformNotSupportedException>(() => new UnixConsoleDriver());
+            Assert.ThrowsExactly<PlatformNotSupportedException>(() => new UnixConsoleDriver());
 #pragma warning restore CA1416
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task EnterRawModeAsync_WhenKgpQueryResponds_EnablesKgpSupport()
     {
         using var driver = new FakeConsoleDriver($"\x1b_Gi=2147483647;OK\x1b\\");
@@ -140,15 +141,15 @@ public class ConsolePresentationAdapterTests
             driver,
             kgpProbeTimeout: TimeSpan.FromMilliseconds(25));
 
-        Assert.False(adapter.Capabilities.SupportsKgp);
+        Assert.IsFalse(adapter.Capabilities.SupportsKgp);
 
         await adapter.EnterRawModeAsync(TestContext.Current.CancellationToken);
 
-        Assert.True(adapter.Capabilities.SupportsKgp);
+        Assert.IsTrue(adapter.Capabilities.SupportsKgp);
         Assert.Contains("\x1b_Gi=2147483647,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\", driver.WrittenText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task EnterRawModeAsync_WhenProbeTimesOut_LeavesKgpDisabled()
     {
         using var driver = new FakeConsoleDriver();
@@ -158,10 +159,10 @@ public class ConsolePresentationAdapterTests
 
         await adapter.EnterRawModeAsync(TestContext.Current.CancellationToken);
 
-        Assert.False(adapter.Capabilities.SupportsKgp);
+        Assert.IsFalse(adapter.Capabilities.SupportsKgp);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task EnterRawModeAsync_WhenProbeReadsMixedInput_PreservesNonProbeBytes()
     {
         using var driver = new FakeConsoleDriver($"\x1b_Gi=2147483647;OK\x1b\\abc");
@@ -172,10 +173,10 @@ public class ConsolePresentationAdapterTests
         await adapter.EnterRawModeAsync(TestContext.Current.CancellationToken);
         var input = await adapter.ReadInputAsync(TestContext.Current.CancellationToken);
 
-        Assert.Equal("abc", Encoding.ASCII.GetString(input.Span));
+        Assert.AreEqual("abc", Encoding.ASCII.GetString(input.Span));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task EnterRawModeAsync_WhenProbeResponseIsSplitAcrossReads_EnablesKgpAndPreservesTrailingBytes()
     {
         using var driver = new FakeConsoleDriver("\x1b_Gi=2147483647", ";OK\x1b\\abc");
@@ -186,14 +187,15 @@ public class ConsolePresentationAdapterTests
         await adapter.EnterRawModeAsync(TestContext.Current.CancellationToken);
         var input = await adapter.ReadInputAsync(TestContext.Current.CancellationToken);
 
-        Assert.True(adapter.Capabilities.SupportsKgp);
-        Assert.Equal("abc", Encoding.ASCII.GetString(input.Span));
+        Assert.IsTrue(adapter.Capabilities.SupportsKgp);
+        Assert.AreEqual("abc", Encoding.ASCII.GetString(input.Span));
     }
 }
 
+[TestClass]
 public class Hex1bTerminalTests_Workload
 {
-    [Fact]
+    [TestMethod]
     public void Constructor_HeadlessMode_CreatesWorkloadAdapter()
     {
         // Headless terminal (no presentation adapter)
@@ -202,21 +204,21 @@ public class Hex1bTerminalTests_Workload
         using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
         
         // WorkloadAdapter should implement the interface
-        Assert.IsAssignableFrom<IHex1bAppTerminalWorkloadAdapter>(workload);
+        TestSeq.IsType<IHex1bAppTerminalWorkloadAdapter>(workload);
     }
     
-    [Fact]
+    [TestMethod]
     public void GetSize_ReturnsConfiguredSize()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
 
         using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(100, 50).Build();
         
-        Assert.Equal(100, terminal.Width);
-        Assert.Equal(50, terminal.Height);
+        Assert.AreEqual(100, terminal.Width);
+        Assert.AreEqual(50, terminal.Height);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Write_CapturesOutput()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -229,10 +231,10 @@ public class Hex1bTerminalTests_Workload
             .Build()
             .ApplyAsync(terminal);
         
-        Assert.True(terminal.CreateSnapshot().ContainsText("Hello"));
+        Assert.IsTrue(terminal.CreateSnapshot().ContainsText("Hello"));
     }
     
-    [Fact]
+    [TestMethod]
     public void InputEvents_ReturnsChannelReader()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -240,10 +242,10 @@ public class Hex1bTerminalTests_Workload
         using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
         
         var reader = workload.InputEvents;
-        Assert.NotNull(reader);
+        Assert.IsNotNull(reader);
     }
     
-    [Fact]
+    [TestMethod]
     public void Capabilities_ReturnsDefaults()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -251,9 +253,9 @@ public class Hex1bTerminalTests_Workload
         using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
         
         var caps = workload.Capabilities;
-        Assert.NotNull(caps);
-        Assert.True(caps.SupportsMouse);
-        Assert.True(caps.SupportsTrueColor);
+        Assert.IsNotNull(caps);
+        Assert.IsTrue(caps.SupportsMouse);
+        Assert.IsTrue(caps.SupportsTrueColor);
     }
 }
 

--- a/tests/Hex1b.Tests/CopyModeBindingsFunctionalTests.cs
+++ b/tests/Hex1b.Tests/CopyModeBindingsFunctionalTests.cs
@@ -12,6 +12,7 @@ namespace Hex1b.Tests;
 /// <c>.CopyModeBindings()</c>, inject text into the handle, send input via
 /// <see cref="Hex1bTerminalInputSequenceBuilder"/>, and assert on handle state.
 /// </summary>
+[TestClass]
 public class CopyModeBindingsFunctionalTests
 {
     /// <summary>
@@ -152,7 +153,7 @@ public class CopyModeBindingsFunctionalTests
     // 1. Entry Key Tests
     // ────────────────────────────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task F6_EntersCopyMode()
     {
         // Arrange
@@ -166,11 +167,11 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert
-        Assert.True(ctx.Handle.IsInCopyMode);
-        Assert.Equal(CopyModeState.Active, ctx.Handle.CopyModeState);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
+        Assert.AreEqual(CopyModeState.Active, ctx.Handle.CopyModeState);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CustomEntryKey_EntersCopyMode()
     {
         // Arrange — configure F5 as entry key instead of default F6
@@ -185,19 +186,19 @@ public class CopyModeBindingsFunctionalTests
         // Act — F5 should enter copy mode
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F5));
         await ctx.WaitForRenderAsync();
-        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
 
         // Exit and verify F6 does NOT enter copy mode
         ctx.Handle.ExitCopyMode();
         await ctx.WaitForRenderAsync();
-        Assert.False(ctx.Handle.IsInCopyMode);
+        Assert.IsFalse(ctx.Handle.IsInCopyMode);
 
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
         await ctx.WaitForRenderAsync();
-        Assert.False(ctx.Handle.IsInCopyMode);
+        Assert.IsFalse(ctx.Handle.IsInCopyMode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MultipleEntryKeys_EachWorks()
     {
         // Arrange
@@ -212,19 +213,19 @@ public class CopyModeBindingsFunctionalTests
         // Act — F5 enters copy mode
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F5));
         await ctx.WaitForRenderAsync();
-        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
 
         // Exit and try F6
         ctx.Handle.ExitCopyMode();
         await ctx.WaitForRenderAsync();
-        Assert.False(ctx.Handle.IsInCopyMode);
+        Assert.IsFalse(ctx.Handle.IsInCopyMode);
 
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
         await ctx.WaitForRenderAsync();
-        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task EntryKeyWithModifier_Works()
     {
         // Arrange — Alt+C as entry key
@@ -241,14 +242,14 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert
-        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
     }
 
     // ────────────────────────────────────────────────────────────────────
     // 2. Cancel / Exit Tests
     // ────────────────────────────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task Escape_ExitsCopyMode()
     {
         // Arrange
@@ -258,18 +259,18 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
         await ctx.WaitForRenderAsync();
-        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
 
         // Act
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Escape));
         await ctx.WaitForRenderAsync();
 
         // Assert
-        Assert.False(ctx.Handle.IsInCopyMode);
-        Assert.Equal(CopyModeState.Inactive, ctx.Handle.CopyModeState);
+        Assert.IsFalse(ctx.Handle.IsInCopyMode);
+        Assert.AreEqual(CopyModeState.Inactive, ctx.Handle.CopyModeState);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Q_ExitsCopyMode()
     {
         // Arrange
@@ -277,17 +278,17 @@ public class CopyModeBindingsFunctionalTests
         await ctx.StartAsync();
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
         await ctx.WaitForRenderAsync();
-        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
 
         // Act
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Q));
         await ctx.WaitForRenderAsync();
 
         // Assert
-        Assert.False(ctx.Handle.IsInCopyMode);
+        Assert.IsFalse(ctx.Handle.IsInCopyMode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CustomCancelKey_Works()
     {
         // Arrange — X as cancel key
@@ -298,26 +299,26 @@ public class CopyModeBindingsFunctionalTests
         await ctx.StartAsync();
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
         await ctx.WaitForRenderAsync();
-        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
 
         // Act — default Escape should NOT exit (replaced)
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Escape));
         await ctx.WaitForRenderAsync();
         // Note: all keys are consumed in copy mode, but Escape is no longer a cancel key
         // The handle should still be in copy mode since Escape is not mapped to cancel
-        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
 
         // X should exit
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.X));
         await ctx.WaitForRenderAsync();
-        Assert.False(ctx.Handle.IsInCopyMode);
+        Assert.IsFalse(ctx.Handle.IsInCopyMode);
     }
 
     // ────────────────────────────────────────────────────────────────────
     // 3. Navigation Tests
     // ────────────────────────────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task ArrowKeys_MoveCursor()
     {
         // Arrange
@@ -339,18 +340,17 @@ public class CopyModeBindingsFunctionalTests
 
         // Assert — row should have increased
         var afterDown = ctx.Handle.Selection!.Cursor;
-        Assert.True(afterDown.Row > initialPos.Row || initialPos.Row == ctx.Handle.VirtualBufferHeight - 1,
-            "Down arrow should move cursor down (or cursor was already at bottom)");
+        Assert.IsTrue(afterDown.Row > initialPos.Row || initialPos.Row == ctx.Handle.VirtualBufferHeight - 1, "Down arrow should move cursor down (or cursor was already at bottom)");
 
         // Move right
         var beforeRight = ctx.Handle.Selection!.Cursor;
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.RightArrow));
         await ctx.WaitForRenderAsync();
         var afterRight = ctx.Handle.Selection!.Cursor;
-        Assert.Equal(beforeRight.Column + 1, afterRight.Column);
+        Assert.AreEqual(beforeRight.Column + 1, afterRight.Column);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ViKeys_HJKL_MoveCursor()
     {
         // Arrange
@@ -370,26 +370,26 @@ public class CopyModeBindingsFunctionalTests
         // Act — L (right)
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.L));
         await ctx.WaitForRenderAsync();
-        Assert.Equal(4, ctx.Handle.Selection!.Cursor.Column);
+        Assert.AreEqual(4, ctx.Handle.Selection!.Cursor.Column);
 
         // H (left)
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.H));
         await ctx.WaitForRenderAsync();
-        Assert.Equal(3, ctx.Handle.Selection!.Cursor.Column);
+        Assert.AreEqual(3, ctx.Handle.Selection!.Cursor.Column);
 
         // J (down)
         var rowBefore = ctx.Handle.Selection!.Cursor.Row;
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.J));
         await ctx.WaitForRenderAsync();
-        Assert.Equal(rowBefore + 1, ctx.Handle.Selection!.Cursor.Row);
+        Assert.AreEqual(rowBefore + 1, ctx.Handle.Selection!.Cursor.Row);
 
         // K (up)
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.K));
         await ctx.WaitForRenderAsync();
-        Assert.Equal(rowBefore, ctx.Handle.Selection!.Cursor.Row);
+        Assert.AreEqual(rowBefore, ctx.Handle.Selection!.Cursor.Row);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CustomCursorKeys_Work()
     {
         // Arrange — WASD navigation, no vi keys
@@ -413,17 +413,17 @@ public class CopyModeBindingsFunctionalTests
         // Act — D (right)
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.D));
         await ctx.WaitForRenderAsync();
-        Assert.Equal(6, ctx.Handle.Selection!.Cursor.Column);
+        Assert.AreEqual(6, ctx.Handle.Selection!.Cursor.Column);
 
         // Default H (vi-left) should NOT move cursor left — it's not mapped
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.H));
         await ctx.WaitForRenderAsync();
         // H is not mapped to any action but all keys are consumed in copy mode
         // Column should remain unchanged since H is no longer a cursor key
-        Assert.Equal(6, ctx.Handle.Selection!.Cursor.Column);
+        Assert.AreEqual(6, ctx.Handle.Selection!.Cursor.Column);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PageUpDown_MovesPage()
     {
         // Arrange
@@ -444,10 +444,10 @@ public class CopyModeBindingsFunctionalTests
         var afterPageUp = ctx.Handle.Selection!.Cursor;
 
         // Assert — row should have decreased (or be at 0 if already near top)
-        Assert.True(afterPageUp.Row <= initial.Row);
+        Assert.IsTrue(afterPageUp.Row <= initial.Row);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HomeEnd_MovesToLineStartEnd()
     {
         // Arrange
@@ -467,15 +467,15 @@ public class CopyModeBindingsFunctionalTests
         // Act — Home should go to column 0
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Home));
         await ctx.WaitForRenderAsync();
-        Assert.Equal(0, ctx.Handle.Selection!.Cursor.Column);
+        Assert.AreEqual(0, ctx.Handle.Selection!.Cursor.Column);
 
         // End should go to last column
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.End));
         await ctx.WaitForRenderAsync();
-        Assert.Equal(ctx.Handle.Width - 1, ctx.Handle.Selection!.Cursor.Column);
+        Assert.AreEqual(ctx.Handle.Width - 1, ctx.Handle.Selection!.Cursor.Column);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task BufferTopBottom_G_ShiftG()
     {
         // Arrange
@@ -491,15 +491,15 @@ public class CopyModeBindingsFunctionalTests
         // Act — g (lowercase) goes to top
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.G));
         await ctx.WaitForRenderAsync();
-        Assert.Equal(0, ctx.Handle.Selection!.Cursor.Row);
+        Assert.AreEqual(0, ctx.Handle.Selection!.Cursor.Row);
 
         // G (Shift+G) goes to bottom
         await ctx.SendKeysAsync(b => b.Shift().Key(Hex1bKey.G));
         await ctx.WaitForRenderAsync();
-        Assert.Equal(ctx.Handle.VirtualBufferHeight - 1, ctx.Handle.Selection!.Cursor.Row);
+        Assert.AreEqual(ctx.Handle.VirtualBufferHeight - 1, ctx.Handle.Selection!.Cursor.Row);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WordForwardBackward_W_B()
     {
         // Arrange
@@ -522,28 +522,26 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         var startPos = ctx.Handle.Selection!.Cursor;
-        Assert.Equal(6, startPos.Column);
+        Assert.AreEqual(6, startPos.Column);
 
         // Act — w (word forward) should advance past "world" to "test"
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.W));
         await ctx.WaitForRenderAsync();
         var afterW = ctx.Handle.Selection!.Cursor;
-        Assert.True(afterW.Column > startPos.Column,
-            $"Word forward should advance column (start={startPos}, after={afterW})");
+        Assert.IsTrue(afterW.Column > startPos.Column, $"Word forward should advance column (start={startPos}, after={afterW})");
 
         // b (word backward) should go back toward "world" or "hello"
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.B));
         await ctx.WaitForRenderAsync();
         var afterB = ctx.Handle.Selection!.Cursor;
-        Assert.True(afterB.Column < afterW.Column,
-            $"Word backward should move cursor left (afterB={afterB}, afterW={afterW})");
+        Assert.IsTrue(afterB.Column < afterW.Column, $"Word backward should move cursor left (afterB={afterB}, afterW={afterW})");
     }
 
     // ────────────────────────────────────────────────────────────────────
     // 4. Selection Mode Tests
     // ────────────────────────────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task V_StartsCharacterSelection()
     {
         // Arrange
@@ -560,12 +558,12 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert
-        Assert.Equal(CopyModeState.CharacterSelection, ctx.Handle.CopyModeState);
-        Assert.True(ctx.Handle.Selection!.IsSelecting);
-        Assert.Equal(SelectionMode.Character, ctx.Handle.Selection!.Mode);
+        Assert.AreEqual(CopyModeState.CharacterSelection, ctx.Handle.CopyModeState);
+        Assert.IsTrue(ctx.Handle.Selection!.IsSelecting);
+        Assert.AreEqual(SelectionMode.Character, ctx.Handle.Selection!.Mode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ShiftV_StartsLineSelection()
     {
         // Arrange
@@ -582,11 +580,11 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert
-        Assert.Equal(CopyModeState.LineSelection, ctx.Handle.CopyModeState);
-        Assert.Equal(SelectionMode.Line, ctx.Handle.Selection!.Mode);
+        Assert.AreEqual(CopyModeState.LineSelection, ctx.Handle.CopyModeState);
+        Assert.AreEqual(SelectionMode.Line, ctx.Handle.Selection!.Mode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AltV_StartsBlockSelection()
     {
         // Arrange
@@ -603,11 +601,11 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert
-        Assert.Equal(CopyModeState.BlockSelection, ctx.Handle.CopyModeState);
-        Assert.Equal(SelectionMode.Block, ctx.Handle.Selection!.Mode);
+        Assert.AreEqual(CopyModeState.BlockSelection, ctx.Handle.CopyModeState);
+        Assert.AreEqual(SelectionMode.Block, ctx.Handle.Selection!.Mode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task V_TogglesCharacterSelection()
     {
         // Arrange
@@ -622,19 +620,19 @@ public class CopyModeBindingsFunctionalTests
         // First V — starts character selection
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.V));
         await ctx.WaitForRenderAsync();
-        Assert.True(ctx.Handle.Selection!.IsSelecting);
+        Assert.IsTrue(ctx.Handle.Selection!.IsSelecting);
 
         // Act — second V — clears selection
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.V));
         await ctx.WaitForRenderAsync();
 
         // Assert — selection should be cleared but still in copy mode
-        Assert.True(ctx.Handle.IsInCopyMode);
-        Assert.False(ctx.Handle.Selection!.IsSelecting);
-        Assert.Equal(CopyModeState.Active, ctx.Handle.CopyModeState);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
+        Assert.IsFalse(ctx.Handle.Selection!.IsSelecting);
+        Assert.AreEqual(CopyModeState.Active, ctx.Handle.CopyModeState);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SelectionModeSwitch_CharacterToLine()
     {
         // Arrange
@@ -649,22 +647,22 @@ public class CopyModeBindingsFunctionalTests
         // Start character selection
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.V));
         await ctx.WaitForRenderAsync();
-        Assert.Equal(SelectionMode.Character, ctx.Handle.Selection!.Mode);
+        Assert.AreEqual(SelectionMode.Character, ctx.Handle.Selection!.Mode);
 
         // Act — switch to line selection
         await ctx.SendKeysAsync(b => b.Shift().Key(Hex1bKey.V));
         await ctx.WaitForRenderAsync();
 
         // Assert
-        Assert.Equal(SelectionMode.Line, ctx.Handle.Selection!.Mode);
-        Assert.Equal(CopyModeState.LineSelection, ctx.Handle.CopyModeState);
+        Assert.AreEqual(SelectionMode.Line, ctx.Handle.Selection!.Mode);
+        Assert.AreEqual(CopyModeState.LineSelection, ctx.Handle.CopyModeState);
     }
 
     // ────────────────────────────────────────────────────────────────────
     // 5. Copy Tests
     // ────────────────────────────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task Y_CopiesAndExits()
     {
         // Arrange
@@ -692,12 +690,12 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert
-        Assert.False(ctx.Handle.IsInCopyMode);
-        Assert.NotNull(copiedText);
+        Assert.IsFalse(ctx.Handle.IsInCopyMode);
+        Assert.IsNotNull(copiedText);
         Assert.Contains("Hello", copiedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Enter_CopiesAndExits()
     {
         // Arrange
@@ -724,12 +722,12 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert
-        Assert.False(ctx.Handle.IsInCopyMode);
-        Assert.NotNull(copiedText);
+        Assert.IsFalse(ctx.Handle.IsInCopyMode);
+        Assert.IsNotNull(copiedText);
         Assert.Contains("Test", copiedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CopiedText_TrimsTrailingWhitespace()
     {
         // Arrange
@@ -755,11 +753,11 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert — trailing whitespace should be trimmed
-        Assert.NotNull(copiedText);
-        Assert.Equal("Hello", copiedText);
+        Assert.IsNotNull(copiedText);
+        Assert.AreEqual("Hello", copiedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CopiedText_CharacterSelection_CorrectContent()
     {
         // Arrange
@@ -785,11 +783,11 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert — should be characters from col 2 to col 5 inclusive
-        Assert.NotNull(copiedText);
-        Assert.Equal("CDEF", copiedText);
+        Assert.IsNotNull(copiedText);
+        Assert.AreEqual("CDEF", copiedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CopiedText_LineSelection_FullRows()
     {
         // Arrange
@@ -818,12 +816,12 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert — line mode copies full rows
-        Assert.NotNull(copiedText);
+        Assert.IsNotNull(copiedText);
         Assert.Contains("First Row", copiedText);
         Assert.Contains("Second Row", copiedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CopiedText_BlockSelection_Rectangle()
     {
         // Arrange
@@ -851,19 +849,19 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert — block selects cols 2-4 from rows 0-2
-        Assert.NotNull(copiedText);
+        Assert.IsNotNull(copiedText);
         var lines = copiedText.Split(Environment.NewLine);
-        Assert.Equal(3, lines.Length);
-        Assert.Equal("CDE", lines[0]);
-        Assert.Equal("MNO", lines[1]);
-        Assert.Equal("WXY", lines[2]);
+        Assert.AreEqual(3, lines.Length);
+        Assert.AreEqual("CDE", lines[0]);
+        Assert.AreEqual("MNO", lines[1]);
+        Assert.AreEqual("WXY", lines[2]);
     }
 
     // ────────────────────────────────────────────────────────────────────
     // 6. Mouse Selection Tests
     // ────────────────────────────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task MouseDrag_EntersCopyModeAndSelects()
     {
         // Arrange — test mouse selection via handle's MouseSelect API
@@ -881,12 +879,12 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert — copy mode should be entered and selection active
-        Assert.True(ctx.Handle.IsInCopyMode);
-        Assert.NotNull(ctx.Handle.Selection);
-        Assert.True(ctx.Handle.Selection.IsSelecting);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
+        Assert.IsNotNull(ctx.Handle.Selection);
+        Assert.IsTrue(ctx.Handle.Selection.IsSelecting);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MouseClick_WithoutDrag_DoesNotEnterCopyMode()
     {
         // Arrange
@@ -901,10 +899,10 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert — should NOT enter copy mode on click-only
-        Assert.False(ctx.Handle.IsInCopyMode);
+        Assert.IsFalse(ctx.Handle.IsInCopyMode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MouseDrag_CharacterSelection_Default()
     {
         // Arrange
@@ -920,12 +918,12 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert
-        Assert.True(ctx.Handle.IsInCopyMode);
-        Assert.NotNull(ctx.Handle.Selection);
-        Assert.Equal(SelectionMode.Character, ctx.Handle.Selection.Mode);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
+        Assert.IsNotNull(ctx.Handle.Selection);
+        Assert.AreEqual(SelectionMode.Character, ctx.Handle.Selection.Mode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MouseDrag_LineSelectionMode()
     {
         // Arrange
@@ -942,12 +940,12 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert
-        Assert.True(ctx.Handle.IsInCopyMode);
-        Assert.NotNull(ctx.Handle.Selection);
-        Assert.Equal(SelectionMode.Line, ctx.Handle.Selection.Mode);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
+        Assert.IsNotNull(ctx.Handle.Selection);
+        Assert.AreEqual(SelectionMode.Line, ctx.Handle.Selection.Mode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MouseDrag_BlockSelectionMode()
     {
         // Arrange
@@ -964,12 +962,12 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert
-        Assert.True(ctx.Handle.IsInCopyMode);
-        Assert.NotNull(ctx.Handle.Selection);
-        Assert.Equal(SelectionMode.Block, ctx.Handle.Selection.Mode);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
+        Assert.IsNotNull(ctx.Handle.Selection);
+        Assert.AreEqual(SelectionMode.Block, ctx.Handle.Selection.Mode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RightClick_CopiesSelection()
     {
         // Arrange
@@ -999,16 +997,16 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert
-        Assert.NotNull(copiedText);
+        Assert.IsNotNull(copiedText);
         Assert.Contains("Hello", copiedText);
-        Assert.False(ctx.Handle.IsInCopyMode);
+        Assert.IsFalse(ctx.Handle.IsInCopyMode);
     }
 
     // ────────────────────────────────────────────────────────────────────
     // 7. CopyModeState Enum Tests
     // ────────────────────────────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task CopyModeState_Inactive_WhenNotInCopyMode()
     {
         // Arrange
@@ -1016,11 +1014,11 @@ public class CopyModeBindingsFunctionalTests
         await ctx.StartAsync();
 
         // Assert — should start inactive
-        Assert.Equal(CopyModeState.Inactive, ctx.Handle.CopyModeState);
-        Assert.False(ctx.Handle.IsInCopyMode);
+        Assert.AreEqual(CopyModeState.Inactive, ctx.Handle.CopyModeState);
+        Assert.IsFalse(ctx.Handle.IsInCopyMode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CopyModeState_Active_WhenInCopyModeNoSelection()
     {
         // Arrange
@@ -1032,13 +1030,13 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert — in copy mode but no selection started yet
-        Assert.True(ctx.Handle.IsInCopyMode);
-        Assert.Equal(CopyModeState.Active, ctx.Handle.CopyModeState);
-        Assert.NotNull(ctx.Handle.Selection);
-        Assert.False(ctx.Handle.Selection.IsSelecting);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
+        Assert.AreEqual(CopyModeState.Active, ctx.Handle.CopyModeState);
+        Assert.IsNotNull(ctx.Handle.Selection);
+        Assert.IsFalse(ctx.Handle.Selection.IsSelecting);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CopyModeState_CharacterSelection_WhenSelecting()
     {
         // Arrange
@@ -1053,10 +1051,10 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert
-        Assert.Equal(CopyModeState.CharacterSelection, ctx.Handle.CopyModeState);
+        Assert.AreEqual(CopyModeState.CharacterSelection, ctx.Handle.CopyModeState);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CopyModeState_LineSelection_WhenSelectingLines()
     {
         // Arrange
@@ -1071,10 +1069,10 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert
-        Assert.Equal(CopyModeState.LineSelection, ctx.Handle.CopyModeState);
+        Assert.AreEqual(CopyModeState.LineSelection, ctx.Handle.CopyModeState);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CopyModeState_BlockSelection_WhenSelectingBlock()
     {
         // Arrange
@@ -1089,10 +1087,10 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert
-        Assert.Equal(CopyModeState.BlockSelection, ctx.Handle.CopyModeState);
+        Assert.AreEqual(CopyModeState.BlockSelection, ctx.Handle.CopyModeState);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CopyModeState_ReturnsToInactive_AfterExit()
     {
         // Arrange
@@ -1101,27 +1099,27 @@ public class CopyModeBindingsFunctionalTests
 
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
         await ctx.WaitForRenderAsync();
-        Assert.Equal(CopyModeState.Active, ctx.Handle.CopyModeState);
+        Assert.AreEqual(CopyModeState.Active, ctx.Handle.CopyModeState);
 
         // Start a selection
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.V));
         await ctx.WaitForRenderAsync();
-        Assert.Equal(CopyModeState.CharacterSelection, ctx.Handle.CopyModeState);
+        Assert.AreEqual(CopyModeState.CharacterSelection, ctx.Handle.CopyModeState);
 
         // Act — exit copy mode
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Escape));
         await ctx.WaitForRenderAsync();
 
         // Assert
-        Assert.Equal(CopyModeState.Inactive, ctx.Handle.CopyModeState);
-        Assert.False(ctx.Handle.IsInCopyMode);
+        Assert.AreEqual(CopyModeState.Inactive, ctx.Handle.CopyModeState);
+        Assert.IsFalse(ctx.Handle.IsInCopyMode);
     }
 
     // ────────────────────────────────────────────────────────────────────
     // 8. Output Queuing Tests
     // ────────────────────────────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task OutputQueued_DuringCopyMode_NotRendered()
     {
         // Arrange
@@ -1133,7 +1131,7 @@ public class CopyModeBindingsFunctionalTests
         // Enter copy mode
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
         await ctx.WaitForRenderAsync();
-        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
 
         // Act — inject new text while in copy mode (should be queued)
         ctx.InjectText(1, 0, "QUEUED_TEXT");
@@ -1148,10 +1146,10 @@ public class CopyModeBindingsFunctionalTests
         // (the buffer is frozen, so the queued output hasn't been applied yet)
         // Note: This depends on the handle's buffer state. The output is queued
         // but the buffer isn't updated until copy mode exits.
-        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task QueuedOutput_FlushedOnExit()
     {
         // Arrange
@@ -1163,7 +1161,7 @@ public class CopyModeBindingsFunctionalTests
         // Enter copy mode
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
         await ctx.WaitForRenderAsync();
-        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
 
         // Inject text while in copy mode (queued)
         ctx.InjectText(1, 0, "AfterExit");
@@ -1174,16 +1172,16 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync(500);
 
         // Assert — queued text should now be visible in the handle's buffer
-        Assert.False(ctx.Handle.IsInCopyMode);
+        Assert.IsFalse(ctx.Handle.IsInCopyMode);
         var cell = ctx.Handle.GetCell(0, 1);
-        Assert.Equal("A", cell.Character);
+        Assert.AreEqual("A", cell.Character);
     }
 
     // ────────────────────────────────────────────────────────────────────
     // 9. Selection Rendering Tests
     // ────────────────────────────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task SelectedCells_RenderedWithInvertedColors()
     {
         // Arrange
@@ -1210,17 +1208,17 @@ public class CopyModeBindingsFunctionalTests
 
         // The selection should render cells 0-4 of the text row with inverted colors.
         // Verify the selection is active and cells are marked as selected.
-        Assert.True(ctx.Handle.Selection!.IsSelecting);
-        Assert.True(ctx.Handle.Selection.IsCellSelected(scrollbackCount + 0, 0));
-        Assert.True(ctx.Handle.Selection.IsCellSelected(scrollbackCount + 0, 4));
-        Assert.False(ctx.Handle.Selection.IsCellSelected(scrollbackCount + 0, 5));
+        Assert.IsTrue(ctx.Handle.Selection!.IsSelecting);
+        Assert.IsTrue(ctx.Handle.Selection.IsCellSelected(scrollbackCount + 0, 0));
+        Assert.IsTrue(ctx.Handle.Selection.IsCellSelected(scrollbackCount + 0, 4));
+        Assert.IsFalse(ctx.Handle.Selection.IsCellSelected(scrollbackCount + 0, 5));
     }
 
     // ────────────────────────────────────────────────────────────────────
     // Additional edge case tests
     // ────────────────────────────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task Spacebar_StartsCharacterSelection()
     {
         // Arrange — Spacebar is also a default character selection key
@@ -1235,10 +1233,10 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert
-        Assert.Equal(CopyModeState.CharacterSelection, ctx.Handle.CopyModeState);
+        Assert.AreEqual(CopyModeState.CharacterSelection, ctx.Handle.CopyModeState);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task D0_MovesToLineStart()
     {
         // Arrange — 0 key is also a default line-start key
@@ -1259,10 +1257,10 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert
-        Assert.Equal(0, ctx.Handle.Selection!.Cursor.Column);
+        Assert.AreEqual(0, ctx.Handle.Selection!.Cursor.Column);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CopyMode_AllKeysConsumed()
     {
         // Arrange — when in copy mode, unmapped keys should still be consumed
@@ -1271,17 +1269,17 @@ public class CopyModeBindingsFunctionalTests
 
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
         await ctx.WaitForRenderAsync();
-        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
 
         // Act — press random keys that aren't mapped to any action
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Z));
         await ctx.WaitForRenderAsync();
 
         // Assert — should still be in copy mode (key was consumed but did nothing)
-        Assert.True(ctx.Handle.IsInCopyMode);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task EnterCopyMode_ExitCopyMode_Roundtrip()
     {
         // Arrange
@@ -1293,19 +1291,19 @@ public class CopyModeBindingsFunctionalTests
         {
             await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
             await ctx.WaitForRenderAsync();
-            Assert.True(ctx.Handle.IsInCopyMode);
+            Assert.IsTrue(ctx.Handle.IsInCopyMode);
 
             await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Q));
             await ctx.WaitForRenderAsync();
-            Assert.False(ctx.Handle.IsInCopyMode);
+            Assert.IsFalse(ctx.Handle.IsInCopyMode);
         }
 
         // Assert — state is clean after multiple roundtrips
-        Assert.Equal(CopyModeState.Inactive, ctx.Handle.CopyModeState);
-        Assert.Null(ctx.Handle.Selection);
+        Assert.AreEqual(CopyModeState.Inactive, ctx.Handle.CopyModeState);
+        Assert.IsNull(ctx.Handle.Selection);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CopyWithNoSelection_DoesNotFireTextCopied()
     {
         // Arrange
@@ -1318,19 +1316,19 @@ public class CopyModeBindingsFunctionalTests
         // Enter copy mode but don't start a selection
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.F6));
         await ctx.WaitForRenderAsync();
-        Assert.True(ctx.Handle.IsInCopyMode);
-        Assert.False(ctx.Handle.Selection!.IsSelecting);
+        Assert.IsTrue(ctx.Handle.IsInCopyMode);
+        Assert.IsFalse(ctx.Handle.Selection!.IsSelecting);
 
         // Act — press Y to copy (but nothing is selected)
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.Y));
         await ctx.WaitForRenderAsync();
 
         // Assert — TextCopied should not fire, but copy mode should exit
-        Assert.Null(copiedText);
-        Assert.False(ctx.Handle.IsInCopyMode);
+        Assert.IsNull(copiedText);
+        Assert.IsFalse(ctx.Handle.IsInCopyMode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SelectionPersists_DuringNavigation()
     {
         // Arrange
@@ -1346,7 +1344,7 @@ public class CopyModeBindingsFunctionalTests
         // Start character selection
         await ctx.SendKeysAsync(b => b.Key(Hex1bKey.V));
         await ctx.WaitForRenderAsync();
-        Assert.True(ctx.Handle.Selection!.IsSelecting);
+        Assert.IsTrue(ctx.Handle.Selection!.IsSelecting);
 
         // Act — navigate while selecting
         await ctx.SendKeysAsync(b => b
@@ -1356,7 +1354,7 @@ public class CopyModeBindingsFunctionalTests
         await ctx.WaitForRenderAsync();
 
         // Assert — selection should still be active
-        Assert.True(ctx.Handle.Selection!.IsSelecting);
-        Assert.Equal(SelectionMode.Character, ctx.Handle.Selection.Mode);
+        Assert.IsTrue(ctx.Handle.Selection!.IsSelecting);
+        Assert.AreEqual(SelectionMode.Character, ctx.Handle.Selection.Mode);
     }
 }

--- a/tests/Hex1b.Tests/DatePickerWidgetTests.cs
+++ b/tests/Hex1b.Tests/DatePickerWidgetTests.cs
@@ -6,39 +6,40 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class DatePickerWidgetTests
 {
     #region DatePickerNode State Tests
 
-    [Fact]
+    [TestMethod]
     public void Node_DefaultStep_IsYear()
     {
         var node = new DatePickerNode();
-        Assert.Equal(PickerStep.Year, node.Step);
+        Assert.AreEqual(PickerStep.Year, node.Step);
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectYear_AdvancesToMonthStep()
     {
         var node = new DatePickerNode();
         node.SelectYear(2026);
 
-        Assert.Equal(PickerStep.Month, node.Step);
-        Assert.Equal(2026, node.DisplayYear);
+        Assert.AreEqual(PickerStep.Month, node.Step);
+        Assert.AreEqual(2026, node.DisplayYear);
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectMonth_AdvancesToCalendarStep()
     {
         var node = new DatePickerNode();
         node.SelectYear(2026);
         node.SelectMonth(3);
 
-        Assert.Equal(PickerStep.Calendar, node.Step);
-        Assert.Equal(3, node.DisplayMonth);
+        Assert.AreEqual(PickerStep.Calendar, node.Step);
+        Assert.AreEqual(3, node.DisplayMonth);
     }
 
-    [Fact]
+    [TestMethod]
     public void GoBack_FromCalendar_ReturnsToMonth()
     {
         var node = new DatePickerNode();
@@ -47,11 +48,11 @@ public class DatePickerWidgetTests
 
         var result = node.GoBack();
 
-        Assert.True(result);
-        Assert.Equal(PickerStep.Month, node.Step);
+        Assert.IsTrue(result);
+        Assert.AreEqual(PickerStep.Month, node.Step);
     }
 
-    [Fact]
+    [TestMethod]
     public void GoBack_FromMonth_ReturnsToYear()
     {
         var node = new DatePickerNode();
@@ -59,40 +60,40 @@ public class DatePickerWidgetTests
 
         var result = node.GoBack();
 
-        Assert.True(result);
-        Assert.Equal(PickerStep.Year, node.Step);
+        Assert.IsTrue(result);
+        Assert.AreEqual(PickerStep.Year, node.Step);
     }
 
-    [Fact]
+    [TestMethod]
     public void GoBack_FromYear_ReturnsFalse()
     {
         var node = new DatePickerNode();
 
         var result = node.GoBack();
 
-        Assert.False(result);
-        Assert.Equal(PickerStep.Year, node.Step);
+        Assert.IsFalse(result);
+        Assert.AreEqual(PickerStep.Year, node.Step);
     }
 
-    [Fact]
+    [TestMethod]
     public void PageYearsForward_ShiftsBy12()
     {
         var node = new DatePickerNode { YearPageStart = 2020 };
         node.PageYearsForward();
 
-        Assert.Equal(2032, node.YearPageStart);
+        Assert.AreEqual(2032, node.YearPageStart);
     }
 
-    [Fact]
+    [TestMethod]
     public void PageYearsBackward_ShiftsBy12()
     {
         var node = new DatePickerNode { YearPageStart = 2020 };
         node.PageYearsBackward();
 
-        Assert.Equal(2008, node.YearPageStart);
+        Assert.AreEqual(2008, node.YearPageStart);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResetStep_ResetsToYear_CenteredOnSelectedDate()
     {
         var node = new DatePickerNode
@@ -104,11 +105,11 @@ public class DatePickerWidgetTests
 
         node.ResetStep();
 
-        Assert.Equal(PickerStep.Year, node.Step);
-        Assert.Equal(2021, node.YearPageStart); // 2026 - 5
+        Assert.AreEqual(PickerStep.Year, node.Step);
+        Assert.AreEqual(2021, node.YearPageStart); // 2026 - 5
     }
 
-    [Fact]
+    [TestMethod]
     public void ResetStep_NoSelectedDate_CenteredOnCurrentYear()
     {
         var node = new DatePickerNode();
@@ -116,35 +117,35 @@ public class DatePickerWidgetTests
 
         node.ResetStep();
 
-        Assert.Equal(PickerStep.Year, node.Step);
-        Assert.Equal(DateTime.Today.Year - 5, node.YearPageStart);
+        Assert.AreEqual(PickerStep.Year, node.Step);
+        Assert.AreEqual(DateTime.Today.Year - 5, node.YearPageStart);
     }
 
     #endregion
 
     #region Display Text Tests
 
-    [Fact]
+    [TestMethod]
     public void GetDisplayText_NoDate_ReturnsPlaceholder()
     {
         var node = new DatePickerNode();
 
         var text = node.GetDisplayText("Choose date");
 
-        Assert.Equal("Choose date", text);
+        Assert.AreEqual("Choose date", text);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetDisplayText_NoDate_DefaultPlaceholder()
     {
         var node = new DatePickerNode();
 
         var text = node.GetDisplayText(null);
 
-        Assert.Equal("Select date...", text);
+        Assert.AreEqual("Select date...", text);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetDisplayText_WithDate_UsesShortDateByDefault()
     {
         var node = new DatePickerNode
@@ -154,10 +155,10 @@ public class DatePickerWidgetTests
 
         var text = node.GetDisplayText("placeholder");
 
-        Assert.Equal(new DateOnly(2026, 3, 15).ToShortDateString(), text);
+        Assert.AreEqual(new DateOnly(2026, 3, 15).ToShortDateString(), text);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetDisplayText_WithDate_UsesCustomFormat()
     {
         var node = new DatePickerNode
@@ -168,14 +169,14 @@ public class DatePickerWidgetTests
 
         var text = node.GetDisplayText("placeholder");
 
-        Assert.Equal("2026-03-15", text);
+        Assert.AreEqual("2026-03-15", text);
     }
 
     #endregion
 
     #region Integration Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_DatePicker_ShowsPlaceholder()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -202,10 +203,10 @@ public class DatePickerWidgetTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Pick a date"));
+        Assert.IsTrue(snapshot.ContainsText("Pick a date"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_DatePicker_OpensYearGrid()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -239,12 +240,12 @@ public class DatePickerWidgetTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText(currentYear.ToString()));
+        Assert.IsTrue(snapshot.ContainsText(currentYear.ToString()));
         // Border title now shows the year range
-        Assert.True(snapshot.ContainsText("–"));
+        Assert.IsTrue(snapshot.ContainsText("–"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_DatePicker_FullFlow_SelectsDate()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -287,10 +288,10 @@ public class DatePickerWidgetTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Single(selectedDates);
+        TestSeq.Single(selectedDates);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_DatePicker_ArrowKeys_NavigateYearGrid()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -330,7 +331,7 @@ public class DatePickerWidgetTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_DatePicker_ArrowKeys_WithSurroundingWidgets()
     {
         // Mirrors CalendarDemo layout: ToggleSwitch + DatePicker
@@ -374,7 +375,7 @@ public class DatePickerWidgetTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_DatePicker_ArrowKeys_DiagnosticRepro()
     {
         // Comprehensive repro: proves arrow key navigation works through the full
@@ -440,17 +441,17 @@ public class DatePickerWidgetTests
         await runTask;
 
         // A date was selected via pure keyboard arrow navigation
-        Assert.Single(selectedDates);
+        TestSeq.Single(selectedDates);
 
         var date = selectedDates[0];
         // Focus starts at currentYear (index 5 in the 12-year grid).
         // Right(2) → index 7, Down(4) → index 11
         var today = DateTime.Today;
         var expectedYear = today.Year - 5 + 11; // YearPageStart + 11 = currentYear + 6
-        Assert.Equal(expectedYear, date.Year);
+        Assert.AreEqual(expectedYear, date.Year);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_DatePicker_YearGrid_EdgeNavigation_PageTransitions()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -499,22 +500,19 @@ public class DatePickerWidgetTests
         await runTask;
 
         var captures = sequence.Steps.OfType<CaptureStep>().ToList();
-        var output = TestContext.Current.TestOutputHelper;
+        var output = TestContext.Current;
         foreach (var cap in captures)
         {
             output?.WriteLine($"=== {cap.Name} ===");
             output?.WriteLine(cap.CapturedSnapshot!.GetScreenText());
         }
 
-        Assert.True(captures[0].CapturedSnapshot!.ContainsText($"{firstPageStart}–{firstPageStart + 11}"),
-            "Initial should be on first page");
-        Assert.True(captures[1].CapturedSnapshot!.ContainsText($"{prevPageStart}–{prevPageStart + 11}"),
-            $"After page back should show {prevPageStart}–{prevPageStart + 11}");
-        Assert.True(captures[2].CapturedSnapshot!.ContainsText($"{firstPageStart}–{firstPageStart + 11}"),
-            "After page forward should be back on first page");
+        Assert.IsTrue(captures[0].CapturedSnapshot!.ContainsText($"{firstPageStart}–{firstPageStart + 11}"), "Initial should be on first page");
+        Assert.IsTrue(captures[1].CapturedSnapshot!.ContainsText($"{prevPageStart}–{prevPageStart + 11}"), $"After page back should show {prevPageStart}–{prevPageStart + 11}");
+        Assert.IsTrue(captures[2].CapturedSnapshot!.ContainsText($"{firstPageStart}–{firstPageStart + 11}"), "After page forward should be back on first page");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_DatePicker_YearGrid_LeftEdge_PageBack_FocusesCorrectYear()
     {
         // Regression test: pressing LEFT twice from the current year should page back
@@ -580,12 +578,11 @@ public class DatePickerWidgetTests
 
         // The month grid shows DisplayYear as a label. After selecting the focused year,
         // it should be cy-10 (row 1, col 3 on prev page), NOT cy-13 (row 1, col 0).
-        Assert.True(snapshot.ContainsText(expectedYear.ToString()),
-            $"Month grid should show year {expectedYear} (index 7, col 3), " +
+        Assert.IsTrue(snapshot.ContainsText(expectedYear.ToString()), $"Month grid should show year {expectedYear} (index 7, col 3), " +
             $"not {buggyYear} (index 4, col 0 — stale focus position).");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_DatePicker_YearGrid_RightEdge_PageForward_FocusesCorrectYear()
     {
         // Same issue as left-edge but for RIGHT at col 3 → page forward.
@@ -638,11 +635,10 @@ public class DatePickerWidgetTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText(expectedYear.ToString()),
-            $"Month grid should show year {expectedYear} (row 1, col 0 on next page).");
+        Assert.IsTrue(snapshot.ContainsText(expectedYear.ToString()), $"Month grid should show year {expectedYear} (row 1, col 0 on next page).");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_DatePicker_YearGrid_VerticalNav_ClampsAtEdges()
     {
         // DOWN from the bottom row should NOT escape to the ◀/▶ icon nodes.
@@ -690,11 +686,10 @@ public class DatePickerWidgetTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText(bottomRowYear.ToString()),
-            $"After DOWN twice from row 1, focus should clamp at row 2, col 1 = {bottomRowYear}.");
+        Assert.IsTrue(snapshot.ContainsText(bottomRowYear.ToString()), $"After DOWN twice from row 1, focus should clamp at row 2, col 1 = {bottomRowYear}.");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_DatePicker_Escape_DismissesPopup()
     {
         // ESC from year step should dismiss the popup entirely.
@@ -730,11 +725,10 @@ public class DatePickerWidgetTests
         await runTask;
 
         // Popup is gone — trigger button should be visible, year grid border should not
-        Assert.True(snapshot.ContainsText("Select date..."),
-            "Trigger button should be visible after ESC dismisses popup.");
+        Assert.IsTrue(snapshot.ContainsText("Select date..."), "Trigger button should be visible after ESC dismisses popup.");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_DatePicker_Escape_DismissesPopup_FromMonthStep()
     {
         // ESC from month step should dismiss the popup entirely (not go back to year).
@@ -771,13 +765,11 @@ public class DatePickerWidgetTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Select date..."),
-            "Trigger button should be visible after ESC from month step.");
-        Assert.False(snapshot.ContainsText("Month"),
-            "Month grid should not be visible after ESC.");
+        Assert.IsTrue(snapshot.ContainsText("Select date..."), "Trigger button should be visible after ESC from month step.");
+        Assert.IsFalse(snapshot.ContainsText("Month"), "Month grid should not be visible after ESC.");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_DatePicker_Backspace_DismissesPopup()
     {
         // Backspace (alternative dismiss key) should also close the popup.
@@ -811,8 +803,7 @@ public class DatePickerWidgetTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Select date..."),
-            "Trigger button should be visible after Backspace dismisses popup.");
+        Assert.IsTrue(snapshot.ContainsText("Select date..."), "Trigger button should be visible after Backspace dismisses popup.");
     }
 
     #endregion

--- a/tests/Hex1b.Tests/DiagnosticShellIntegrationTests.cs
+++ b/tests/Hex1b.Tests/DiagnosticShellIntegrationTests.cs
@@ -12,8 +12,7 @@ namespace Hex1b.Tests;
 /// Collection definition for diagnostic shell tests that cannot run in parallel.
 /// These tests use shared terminal resources and are timing-sensitive.
 /// </summary>
-[CollectionDefinition("DiagnosticShell", DisableParallelization = true)]
-public class DiagnosticShellCollection { }
+
 
 /// <summary>
 /// Integration tests for the DiagnosticShell to debug rendering stall issues.
@@ -32,7 +31,8 @@ public class DiagnosticShellCollection { }
 /// - TerminalWidgetHandle: Bridges inner terminal output to outer app rendering
 /// </para>
 /// </remarks>
-[Collection("DiagnosticShell")]
+[DoNotParallelize]
+[TestClass]
 public class DiagnosticShellIntegrationTests
 {
     /// <summary>
@@ -475,7 +475,7 @@ public class DiagnosticShellIntegrationTests
         }
     }
     
-    [Fact]
+    [TestMethod]
     public async Task DiagnosticShell_HelpCommand_RendersCompletely()
     {
         // Arrange
@@ -487,7 +487,7 @@ public class DiagnosticShellIntegrationTests
 
         // Wait for the last expected help entry so assertions observe the full render.
         var foundDump = await ctx.WaitForTextAsync("dump", TimeSpan.FromSeconds(5));
-        Assert.True(foundDump, $"Should find 'dump' in help output\nOuter:\n{ctx.GetOuterContent()}\nInner:\n{ctx.GetInnerContent()}");
+        Assert.IsTrue(foundDump, $"Should find 'dump' in help output\nOuter:\n{ctx.GetOuterContent()}\nInner:\n{ctx.GetInnerContent()}");
 
         var content = ctx.GetOuterContent();
         
@@ -497,7 +497,7 @@ public class DiagnosticShellIntegrationTests
         Assert.Contains("dump", content);
     }
     
-    [Fact(Skip = "Flaky - timing-sensitive diagnostic shell test")]
+    [TestMethod, Ignore("Flaky - timing-sensitive diagnostic shell test")]
     public async Task DiagnosticShell_PingCommand_RespondsImmediately()
     {
         // Arrange
@@ -535,15 +535,14 @@ public class DiagnosticShellIntegrationTests
         Console.Error.WriteLine(ctx.GetInnerContent());
         
         // Assert
-        Assert.True(foundPong, "Should receive 'pong' response");
-        Assert.True((afterPong - beforePing).TotalMilliseconds < 3000, 
-            $"Pong should appear within 3s, took {(afterPong - beforePing).TotalMilliseconds}ms");
+        Assert.IsTrue(foundPong, "Should receive 'pong' response");
+        Assert.IsTrue((afterPong - beforePing).TotalMilliseconds < 3000, $"Pong should appear within 3s, took {(afterPong - beforePing).TotalMilliseconds}ms");
     }
     
     private static string Truncate(string s, int maxLen) 
         => s.Length <= maxLen ? s.Replace("\n", "\\n").Replace("\r", "\\r") : s[..maxLen].Replace("\n", "\\n").Replace("\r", "\\r") + "...";
     
-    [Fact]
+    [TestMethod]
     public async Task DiagnosticShell_MultipleCommands_AllRender()
     {
         // Arrange
@@ -554,20 +553,20 @@ public class DiagnosticShellIntegrationTests
         // before typing, so the next command can't race the previous render.
         await ctx.SendCommandAsync("echo hello");
         var foundHello = await ctx.WaitForTextAsync("hello", TimeSpan.FromSeconds(5));
-        Assert.True(foundHello, $"Should find 'hello'\nOuter:\n{ctx.GetOuterContent()}\nInner:\n{ctx.GetInnerContent()}");
+        Assert.IsTrue(foundHello, $"Should find 'hello'\nOuter:\n{ctx.GetOuterContent()}\nInner:\n{ctx.GetInnerContent()}");
 
         await ctx.SendCommandAsync("echo world");
         var foundWorld = await ctx.WaitForTextAsync("world", TimeSpan.FromSeconds(5));
-        Assert.True(foundWorld, $"Should find 'world'\nOuter:\n{ctx.GetOuterContent()}\nInner:\n{ctx.GetInnerContent()}");
+        Assert.IsTrue(foundWorld, $"Should find 'world'\nOuter:\n{ctx.GetOuterContent()}\nInner:\n{ctx.GetInnerContent()}");
 
         await ctx.SendCommandAsync("ping");
         var foundPong = await ctx.WaitForTextAsync("PONG", TimeSpan.FromSeconds(5));
         
         // Assert with diagnostics
-        Assert.True(foundPong, $"Should find 'PONG'\nOuter:\n{ctx.GetOuterContent()}\nInner:\n{ctx.GetInnerContent()}");
+        Assert.IsTrue(foundPong, $"Should find 'PONG'\nOuter:\n{ctx.GetOuterContent()}\nInner:\n{ctx.GetInnerContent()}");
     }
     
-    [Fact(Skip = "Flaky in CI - timing-sensitive flood output test")]
+    [TestMethod, Ignore("Flaky in CI - timing-sensitive flood output test")]
     public async Task DiagnosticShell_FloodCommand_HandlesRapidOutput()
     {
         // Arrange
@@ -582,10 +581,10 @@ public class DiagnosticShellIntegrationTests
         var foundComplete = await ctx.WaitForTextAsync("Line 010", TimeSpan.FromSeconds(10));
         
         // Assert
-        Assert.True(foundComplete, "Should see last flood line");
+        Assert.IsTrue(foundComplete, "Should see last flood line");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task InvalidateCallback_IsInvokedOnOutput()
     {
         // This test verifies that OutputReceived triggers Invalidate()
@@ -601,7 +600,7 @@ public class DiagnosticShellIntegrationTests
         // Act
         await ctx.SendCommandAsync("ping");
         var foundPong = await ctx.WaitForTextAsync("PONG", TimeSpan.FromSeconds(5));
-        Assert.True(foundPong, "Should receive PONG output before checking trace events");
+        Assert.IsTrue(foundPong, "Should receive PONG output before checking trace events");
         
         // Get events
         var allEvents = ctx.Tracer.GetEvents();
@@ -612,7 +611,7 @@ public class DiagnosticShellIntegrationTests
         var hasHandleOutput = newEvents.Any(e => e.Source == "Handle" && e.Event.Contains("OutputReceived"));
         
         // Assert
-        Assert.True(hasInnerOutput, "Should have inner workload output event");
+        Assert.IsTrue(hasInnerOutput, "Should have inner workload output event");
         // Note: Handle OutputReceived tracing requires the custom TracingTerminalWidgetHandle
     }
 }

--- a/tests/Hex1b.Tests/DiagnosticTimingTests.cs
+++ b/tests/Hex1b.Tests/DiagnosticTimingTests.cs
@@ -8,9 +8,10 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for diagnostic timing and tree output improvements.
 /// </summary>
+[TestClass]
 public class DiagnosticTimingTests
 {
-    [Fact]
+    [TestMethod]
     public void DiagnosticTiming_FromNode_ConvertsTicksToMilliseconds()
     {
         var node = new TextBlockNode { Text = "test" };
@@ -22,12 +23,12 @@ public class DiagnosticTimingTests
         var now = Stopwatch.GetTimestamp();
         var timing = DiagnosticTiming.FromNode(node, now);
 
-        Assert.InRange(timing.ReconcileMs, 0.9, 1.1);
-        Assert.InRange(timing.RenderMs, 0.4, 0.6);
-        Assert.InRange(timing.LastRenderedMsAgo, 5, 15); // ~10ms ago with tolerance
+        TestSeq.InRange(timing.ReconcileMs, 0.9, 1.1);
+        TestSeq.InRange(timing.RenderMs, 0.4, 0.6);
+        TestSeq.InRange(timing.LastRenderedMsAgo, 5, 15); // ~10ms ago with tolerance
     }
 
-    [Fact]
+    [TestMethod]
     public void DiagnosticTiming_FromNode_ZeroTicks_ReturnsZeros()
     {
         var node = new TextBlockNode { Text = "test" };
@@ -35,12 +36,12 @@ public class DiagnosticTimingTests
 
         var timing = DiagnosticTiming.FromNode(node, now);
 
-        Assert.Equal(0, timing.ReconcileMs);
-        Assert.Equal(0, timing.RenderMs);
-        Assert.Equal(-1, timing.LastRenderedMsAgo);
+        Assert.AreEqual(0, timing.ReconcileMs);
+        Assert.AreEqual(0, timing.RenderMs);
+        Assert.AreEqual(-1, timing.LastRenderedMsAgo);
     }
 
-    [Fact]
+    [TestMethod]
     public void DiagnosticTiming_ToString_FormatsCorrectly()
     {
         var timing = new DiagnosticTiming
@@ -57,7 +58,7 @@ public class DiagnosticTimingTests
         Assert.Contains("last=12ms ago", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void DiagnosticTiming_ToString_OmitsZeroValues()
     {
         var timing = new DiagnosticTiming
@@ -74,7 +75,7 @@ public class DiagnosticTimingTests
         Assert.DoesNotContain("last=", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void DiagnosticNode_FromNode_IncludesTimingWhenSet()
     {
         var node = new ButtonNode { Label = "Click" };
@@ -84,12 +85,12 @@ public class DiagnosticTimingTests
 
         var diagNode = DiagnosticNode.FromNode(node);
 
-        Assert.NotNull(diagNode.Timing);
-        Assert.True(diagNode.Timing.ReconcileMs > 0);
-        Assert.True(diagNode.Timing.RenderMs > 0);
+        Assert.IsNotNull(diagNode.Timing);
+        Assert.IsTrue(diagNode.Timing.ReconcileMs > 0);
+        Assert.IsTrue(diagNode.Timing.RenderMs > 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void DiagnosticNode_FromNode_NoTimingWhenZero()
     {
         var node = new ButtonNode { Label = "Click" };
@@ -97,10 +98,10 @@ public class DiagnosticTimingTests
 
         var diagNode = DiagnosticNode.FromNode(node);
 
-        Assert.Null(diagNode.Timing);
+        Assert.IsNull(diagNode.Timing);
     }
 
-    [Fact]
+    [TestMethod]
     public void DiagnosticRect_ToString_IncludesCornerCoordinates()
     {
         var rect = DiagnosticRect.FromRect(new Rect(5, 10, 20, 8));
@@ -114,7 +115,7 @@ public class DiagnosticTimingTests
         Assert.Contains("(5,10 → 25,18)", str);
     }
 
-    [Fact]
+    [TestMethod]
     public void DiagnosticFrameInfo_ReportsTimingEnabled()
     {
         var frameInfo = new DiagnosticFrameInfo
@@ -125,19 +126,19 @@ public class DiagnosticTimingTests
             TimingEnabled = true
         };
 
-        Assert.True(frameInfo.TimingEnabled);
-        Assert.Equal(1.5, frameInfo.BuildMs);
-        Assert.Equal(0.3, frameInfo.ReconcileMs);
-        Assert.Equal(2.0, frameInfo.RenderMs);
+        Assert.IsTrue(frameInfo.TimingEnabled);
+        Assert.AreEqual(1.5, frameInfo.BuildMs);
+        Assert.AreEqual(0.3, frameInfo.ReconcileMs);
+        Assert.AreEqual(2.0, frameInfo.RenderMs);
     }
 
-    [Fact]
+    [TestMethod]
     public void Hex1bNode_TimingFields_DefaultToZero()
     {
         var node = new TextBlockNode { Text = "test" };
 
-        Assert.Equal(0, node.DiagReconcileTicks);
-        Assert.Equal(0, node.DiagRenderTicks);
-        Assert.Equal(0, node.DiagLastRenderedTimestamp);
+        Assert.AreEqual(0, node.DiagReconcileTicks);
+        Assert.AreEqual(0, node.DiagRenderTicks);
+        Assert.AreEqual(0, node.DiagLastRenderedTimestamp);
     }
 }

--- a/tests/Hex1b.Tests/DisplayWidthTests.cs
+++ b/tests/Hex1b.Tests/DisplayWidthTests.cs
@@ -7,162 +7,163 @@ namespace Hex1b.Tests;
 /// Wide characters (CJK, emoji) occupy 2 terminal cells, while
 /// combining characters occupy 0 cells.
 /// </summary>
+[TestClass]
 public class DisplayWidthTests
 {
     #region ASCII Characters
     
-    [Fact]
+    [TestMethod]
     public void GetStringWidth_AsciiText_EqualsLength()
     {
-        Assert.Equal(5, DisplayWidth.GetStringWidth("Hello"));
-        Assert.Equal(0, DisplayWidth.GetStringWidth(""));
-        Assert.Equal(1, DisplayWidth.GetStringWidth("X"));
+        Assert.AreEqual(5, DisplayWidth.GetStringWidth("Hello"));
+        Assert.AreEqual(0, DisplayWidth.GetStringWidth(""));
+        Assert.AreEqual(1, DisplayWidth.GetStringWidth("X"));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetStringWidth_AsciiWithSpaces_CountsSpaces()
     {
-        Assert.Equal(11, DisplayWidth.GetStringWidth("Hello World"));
-        Assert.Equal(3, DisplayWidth.GetStringWidth("   "));
+        Assert.AreEqual(11, DisplayWidth.GetStringWidth("Hello World"));
+        Assert.AreEqual(3, DisplayWidth.GetStringWidth("   "));
     }
 
     #endregion
 
     #region Emoji Width
 
-    [Fact]
+    [TestMethod]
     public void GetStringWidth_SimpleEmoji_ReturnsTwoColumns()
     {
         // Simple emoji is 2 cells wide
-        Assert.Equal(2, DisplayWidth.GetStringWidth("😀"));
-        Assert.Equal(2, DisplayWidth.GetStringWidth("🎉"));
-        Assert.Equal(2, DisplayWidth.GetStringWidth("🔥"));
+        Assert.AreEqual(2, DisplayWidth.GetStringWidth("😀"));
+        Assert.AreEqual(2, DisplayWidth.GetStringWidth("🎉"));
+        Assert.AreEqual(2, DisplayWidth.GetStringWidth("🔥"));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetStringWidth_EmojiWithSkinTone_ReturnsTwoColumns()
     {
         // Emoji with skin tone modifier is still 2 cells
-        Assert.Equal(2, DisplayWidth.GetStringWidth("👍🏽"));
-        Assert.Equal(2, DisplayWidth.GetStringWidth("👋🏻"));
+        Assert.AreEqual(2, DisplayWidth.GetStringWidth("👍🏽"));
+        Assert.AreEqual(2, DisplayWidth.GetStringWidth("👋🏻"));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetStringWidth_FamilyEmoji_ReturnsTwoColumns()
     {
         // ZWJ family sequence is 2 cells (one visual unit)
-        Assert.Equal(2, DisplayWidth.GetStringWidth("👨‍👩‍👧"));
-        Assert.Equal(2, DisplayWidth.GetStringWidth("👨‍👩‍👧‍👦"));
+        Assert.AreEqual(2, DisplayWidth.GetStringWidth("👨‍👩‍👧"));
+        Assert.AreEqual(2, DisplayWidth.GetStringWidth("👨‍👩‍👧‍👦"));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetStringWidth_FlagEmoji_ReturnsTwoColumns()
     {
         // Flags are 2 cells
-        Assert.Equal(2, DisplayWidth.GetStringWidth("🇺🇸"));
-        Assert.Equal(2, DisplayWidth.GetStringWidth("🇯🇵"));
+        Assert.AreEqual(2, DisplayWidth.GetStringWidth("🇺🇸"));
+        Assert.AreEqual(2, DisplayWidth.GetStringWidth("🇯🇵"));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetStringWidth_MixedTextWithEmoji_CalculatesCorrectly()
     {
         // "Hi" (2) + 😀 (2) + "!" (1) = 5
-        Assert.Equal(5, DisplayWidth.GetStringWidth("Hi😀!"));
+        Assert.AreEqual(5, DisplayWidth.GetStringWidth("Hi😀!"));
         
         // "A" (1) + 😀 (2) + 🇺🇸 (2) + "B" (1) = 6
-        Assert.Equal(6, DisplayWidth.GetStringWidth("A😀🇺🇸B"));
+        Assert.AreEqual(6, DisplayWidth.GetStringWidth("A😀🇺🇸B"));
     }
 
     #endregion
 
     #region CJK Characters
 
-    [Fact]
+    [TestMethod]
     public void GetStringWidth_CJKCharacters_ReturnsTwoColumnsEach()
     {
         // Chinese characters
-        Assert.Equal(2, DisplayWidth.GetStringWidth("中"));
-        Assert.Equal(4, DisplayWidth.GetStringWidth("中文"));
-        Assert.Equal(6, DisplayWidth.GetStringWidth("你好吗"));
+        Assert.AreEqual(2, DisplayWidth.GetStringWidth("中"));
+        Assert.AreEqual(4, DisplayWidth.GetStringWidth("中文"));
+        Assert.AreEqual(6, DisplayWidth.GetStringWidth("你好吗"));
         
         // Japanese hiragana/katakana
-        Assert.Equal(2, DisplayWidth.GetStringWidth("あ"));
-        Assert.Equal(4, DisplayWidth.GetStringWidth("日本"));
+        Assert.AreEqual(2, DisplayWidth.GetStringWidth("あ"));
+        Assert.AreEqual(4, DisplayWidth.GetStringWidth("日本"));
         
         // Korean
-        Assert.Equal(2, DisplayWidth.GetStringWidth("한"));
-        Assert.Equal(4, DisplayWidth.GetStringWidth("한글"));
+        Assert.AreEqual(2, DisplayWidth.GetStringWidth("한"));
+        Assert.AreEqual(4, DisplayWidth.GetStringWidth("한글"));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetStringWidth_MixedCJKAndAscii_CalculatesCorrectly()
     {
         // "Hello" (5) + "中文" (4) = 9
-        Assert.Equal(9, DisplayWidth.GetStringWidth("Hello中文"));
+        Assert.AreEqual(9, DisplayWidth.GetStringWidth("Hello中文"));
         
         // "A" (1) + "日" (2) + "B" (1) + "本" (2) = 6
-        Assert.Equal(6, DisplayWidth.GetStringWidth("A日B本"));
+        Assert.AreEqual(6, DisplayWidth.GetStringWidth("A日B本"));
     }
 
     #endregion
 
     #region Combining Characters
 
-    [Fact]
+    [TestMethod]
     public void GetStringWidth_CombiningAccent_CountsAsBaseCharWidth()
     {
         // "e" + combining acute = 1 cell (one visual unit)
         var combiningE = "e\u0301"; // é as e + combining acute
-        Assert.Equal(1, DisplayWidth.GetStringWidth(combiningE));
+        Assert.AreEqual(1, DisplayWidth.GetStringWidth(combiningE));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetStringWidth_MultipleCombiningMarks_CountsAsBaseCharWidth()
     {
         // "a" + ring above + acute = 1 cell
         var multipleCombining = "a\u030A\u0301";
-        Assert.Equal(1, DisplayWidth.GetStringWidth(multipleCombining));
+        Assert.AreEqual(1, DisplayWidth.GetStringWidth(multipleCombining));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetStringWidth_PrecomposedVsCombining_SameWidth()
     {
         var precomposed = "é"; // Single precomposed character
         var combining = "e\u0301"; // e + combining acute
         
-        Assert.Equal(1, DisplayWidth.GetStringWidth(precomposed));
-        Assert.Equal(1, DisplayWidth.GetStringWidth(combining));
+        Assert.AreEqual(1, DisplayWidth.GetStringWidth(precomposed));
+        Assert.AreEqual(1, DisplayWidth.GetStringWidth(combining));
     }
 
     #endregion
 
     #region Grapheme Width
 
-    [Fact]
+    [TestMethod]
     public void GetGraphemeWidth_SingleAscii_ReturnsOne()
     {
-        Assert.Equal(1, DisplayWidth.GetGraphemeWidth("A"));
-        Assert.Equal(1, DisplayWidth.GetGraphemeWidth(" "));
+        Assert.AreEqual(1, DisplayWidth.GetGraphemeWidth("A"));
+        Assert.AreEqual(1, DisplayWidth.GetGraphemeWidth(" "));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetGraphemeWidth_Emoji_ReturnsTwo()
     {
-        Assert.Equal(2, DisplayWidth.GetGraphemeWidth("😀"));
-        Assert.Equal(2, DisplayWidth.GetGraphemeWidth("👨‍👩‍👧"));
+        Assert.AreEqual(2, DisplayWidth.GetGraphemeWidth("😀"));
+        Assert.AreEqual(2, DisplayWidth.GetGraphemeWidth("👨‍👩‍👧"));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetGraphemeWidth_CJK_ReturnsTwo()
     {
-        Assert.Equal(2, DisplayWidth.GetGraphemeWidth("中"));
-        Assert.Equal(2, DisplayWidth.GetGraphemeWidth("あ"));
+        Assert.AreEqual(2, DisplayWidth.GetGraphemeWidth("中"));
+        Assert.AreEqual(2, DisplayWidth.GetGraphemeWidth("あ"));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetGraphemeWidth_CombiningSequence_ReturnsBaseWidth()
     {
-        Assert.Equal(1, DisplayWidth.GetGraphemeWidth("e\u0301"));
+        Assert.AreEqual(1, DisplayWidth.GetGraphemeWidth("e\u0301"));
     }
 
     #endregion
@@ -173,143 +174,143 @@ public class DisplayWidthTests
     /// These characters have been observed to cause alignment issues in FullAppDemo.
     /// Each should return width 2 (emoji presentation).
     /// </summary>
-    [Theory]
-    [InlineData("✅", 2)] // U+2705 White Heavy Check Mark
-    [InlineData("❌", 2)] // U+274C Cross Mark
-    [InlineData("⭐", 2)] // U+2B50 White Medium Star
-    [InlineData("⚡", 2)] // U+26A1 High Voltage
-    [InlineData("🔴", 2)] // U+1F534 Red Circle
-    [InlineData("🟠", 2)] // U+1F7E0 Orange Circle
-    [InlineData("🟡", 2)] // U+1F7E1 Yellow Circle
-    [InlineData("🟢", 2)] // U+1F7E2 Green Circle
-    [InlineData("🔵", 2)] // U+1F535 Blue Circle
-    [InlineData("⚫", 2)] // U+26AB Black Circle
-    [InlineData("⚪", 2)] // U+26AA White Circle
-    [InlineData("⚠️", 2)] // U+26A0+FE0F Warning with VS16
-    [InlineData("ℹ️", 2)] // U+2139+FE0F Info with VS16
-    [InlineData("❓", 2)] // U+2753 Question Mark Ornament
-    [InlineData("❗", 2)] // U+2757 Exclamation Mark
+    [TestMethod]
+    [DataRow("✅", 2)] // U+2705 White Heavy Check Mark
+    [DataRow("❌", 2)] // U+274C Cross Mark
+    [DataRow("⭐", 2)] // U+2B50 White Medium Star
+    [DataRow("⚡", 2)] // U+26A1 High Voltage
+    [DataRow("🔴", 2)] // U+1F534 Red Circle
+    [DataRow("🟠", 2)] // U+1F7E0 Orange Circle
+    [DataRow("🟡", 2)] // U+1F7E1 Yellow Circle
+    [DataRow("🟢", 2)] // U+1F7E2 Green Circle
+    [DataRow("🔵", 2)] // U+1F535 Blue Circle
+    [DataRow("⚫", 2)] // U+26AB Black Circle
+    [DataRow("⚪", 2)] // U+26AA White Circle
+    [DataRow("⚠️", 2)] // U+26A0+FE0F Warning with VS16
+    [DataRow("ℹ️", 2)] // U+2139+FE0F Info with VS16
+    [DataRow("❓", 2)] // U+2753 Question Mark Ornament
+    [DataRow("❗", 2)] // U+2757 Exclamation Mark
     public void GetGraphemeWidth_ProblematicEmoji_ReturnsTwo(string grapheme, int expectedWidth)
     {
         var actualWidth = DisplayWidth.GetGraphemeWidth(grapheme);
-        Assert.Equal(expectedWidth, actualWidth);
+        Assert.AreEqual(expectedWidth, actualWidth);
     }
     
-    [Theory]
-    [InlineData("🖥️", 2)] // U+1F5A5+FE0F Desktop Computer with VS16
-    [InlineData("➡️", 2)] // U+27A1+FE0F Right Arrow with VS16
-    [InlineData("⬆️", 2)] // U+2B06+FE0F Up Arrow with VS16
-    [InlineData("⬇️", 2)] // U+2B07+FE0F Down Arrow with VS16
-    [InlineData("⬅️", 2)] // U+2B05+FE0F Left Arrow with VS16
+    [TestMethod]
+    [DataRow("🖥️", 2)] // U+1F5A5+FE0F Desktop Computer with VS16
+    [DataRow("➡️", 2)] // U+27A1+FE0F Right Arrow with VS16
+    [DataRow("⬆️", 2)] // U+2B06+FE0F Up Arrow with VS16
+    [DataRow("⬇️", 2)] // U+2B07+FE0F Down Arrow with VS16
+    [DataRow("⬅️", 2)] // U+2B05+FE0F Left Arrow with VS16
     public void GetGraphemeWidth_VariationSelectorEmoji_ReturnsTwo(string grapheme, int expectedWidth)
     {
         var actualWidth = DisplayWidth.GetGraphemeWidth(grapheme);
-        Assert.Equal(expectedWidth, actualWidth);
+        Assert.AreEqual(expectedWidth, actualWidth);
     }
 
     #endregion
 
     #region Slice By Display Width
 
-    [Fact]
+    [TestMethod]
     public void SliceByDisplayWidth_AsciiText_SlicesCorrectly()
     {
         var (text, columns, _, _) = DisplayWidth.SliceByDisplayWidth("Hello World", 0, 5);
-        Assert.Equal("Hello", text);
-        Assert.Equal(5, columns);
+        Assert.AreEqual("Hello", text);
+        Assert.AreEqual(5, columns);
     }
 
-    [Fact]
+    [TestMethod]
     public void SliceByDisplayWidth_WithEmoji_SlicesAtBoundary()
     {
         // "A😀B" - A is 1, 😀 is 2, B is 1
         // Slice 0..3 should give "A😀" (3 columns)
         var (text, columns, _, _) = DisplayWidth.SliceByDisplayWidth("A😀B", 0, 3);
-        Assert.Equal("A😀", text);
-        Assert.Equal(3, columns);
+        Assert.AreEqual("A😀", text);
+        Assert.AreEqual(3, columns);
     }
 
-    [Fact]
+    [TestMethod]
     public void SliceByDisplayWidth_CutsBeforeWideChar_WhenNotEnoughSpace()
     {
         // "A😀" - want only 2 columns
         // 😀 needs 2 columns, but we only have 1 left after A
         var (text, columns, _, _) = DisplayWidth.SliceByDisplayWidth("A😀B", 0, 2);
-        Assert.Equal("A", text);
-        Assert.Equal(1, columns);
+        Assert.AreEqual("A", text);
+        Assert.AreEqual(1, columns);
     }
 
-    [Fact]
+    [TestMethod]
     public void SliceByDisplayWidth_WithCJK_SlicesCorrectly()
     {
         // "中文" is 4 columns (2 + 2)
         var (text, columns, _, _) = DisplayWidth.SliceByDisplayWidth("中文abc", 0, 4);
-        Assert.Equal("中文", text);
-        Assert.Equal(4, columns);
+        Assert.AreEqual("中文", text);
+        Assert.AreEqual(4, columns);
     }
 
-    [Fact]
+    [TestMethod]
     public void SliceByDisplayWidth_FromMiddle_SlicesCorrectly()
     {
         // "Hello" - slice from column 2, length 3 = "llo"
         var (text, columns, _, _) = DisplayWidth.SliceByDisplayWidth("Hello", 2, 3);
-        Assert.Equal("llo", text);
-        Assert.Equal(3, columns);
+        Assert.AreEqual("llo", text);
+        Assert.AreEqual(3, columns);
     }
 
-    [Fact]
+    [TestMethod]
     public void SliceByDisplayWidth_StartInMiddleOfWideChar_SkipsIt()
     {
         // "中文" - start at column 1 (middle of 中), should skip it
         var (text, columns, paddingBefore, _) = DisplayWidth.SliceByDisplayWidth("中文", 1, 3);
         // Should skip 中 and give 文
-        Assert.Equal("文", text);
-        Assert.Equal(2, columns);
-        Assert.Equal(1, paddingBefore); // Need 1 space padding for the cut character
+        Assert.AreEqual("文", text);
+        Assert.AreEqual(2, columns);
+        Assert.AreEqual(1, paddingBefore); // Need 1 space padding for the cut character
     }
 
     #endregion
 
     #region Integration with GraphemeHelper
 
-    [Fact]
+    [TestMethod]
     public void GraphemeHelper_GetDisplayWidth_MatchesDisplayWidth()
     {
         var text = "Hello😀世界";
-        Assert.Equal(DisplayWidth.GetStringWidth(text), GraphemeHelper.GetDisplayWidth(text));
+        Assert.AreEqual(DisplayWidth.GetStringWidth(text), GraphemeHelper.GetDisplayWidth(text));
     }
 
-    [Fact]
+    [TestMethod]
     public void GraphemeHelper_IndexToDisplayColumn_CalculatesCorrectly()
     {
         var text = "A😀B";
         // Index 0: before A, column 0
-        Assert.Equal(0, GraphemeHelper.IndexToDisplayColumn(text, 0));
+        Assert.AreEqual(0, GraphemeHelper.IndexToDisplayColumn(text, 0));
         // Index 1: after A, before 😀, column 1
-        Assert.Equal(1, GraphemeHelper.IndexToDisplayColumn(text, 1));
+        Assert.AreEqual(1, GraphemeHelper.IndexToDisplayColumn(text, 1));
         // Index 3: after 😀 (which is 2 chars), before B, column 3
-        Assert.Equal(3, GraphemeHelper.IndexToDisplayColumn(text, 3));
+        Assert.AreEqual(3, GraphemeHelper.IndexToDisplayColumn(text, 3));
         // Index 4: after B, column 4
-        Assert.Equal(4, GraphemeHelper.IndexToDisplayColumn(text, 4));
+        Assert.AreEqual(4, GraphemeHelper.IndexToDisplayColumn(text, 4));
     }
 
-    [Fact]
+    [TestMethod]
     public void GraphemeHelper_DisplayColumnToIndex_CalculatesCorrectly()
     {
         var text = "A😀B";
         // Column 0: index 0 (before A)
-        Assert.Equal(0, GraphemeHelper.DisplayColumnToIndex(text, 0));
+        Assert.AreEqual(0, GraphemeHelper.DisplayColumnToIndex(text, 0));
         // Column 1: index 1 (after A)
-        Assert.Equal(1, GraphemeHelper.DisplayColumnToIndex(text, 1));
+        Assert.AreEqual(1, GraphemeHelper.DisplayColumnToIndex(text, 1));
         // Column 2: in middle of 😀, should return start of 😀
-        Assert.Equal(1, GraphemeHelper.DisplayColumnToIndex(text, 2));
+        Assert.AreEqual(1, GraphemeHelper.DisplayColumnToIndex(text, 2));
         // Column 3: after 😀, index 3
-        Assert.Equal(3, GraphemeHelper.DisplayColumnToIndex(text, 3));
+        Assert.AreEqual(3, GraphemeHelper.DisplayColumnToIndex(text, 3));
     }
 
     #endregion
     
-    [Fact]
+    [TestMethod]
     public void GetStringWidth_VariationSelectorEmoji_CalculatesCorrectly()
     {
         // "Test ⚠️ char" = Test(4) + space(1) + ⚠️(2) + space(1) + char(4) = 12
@@ -317,10 +318,10 @@ public class DisplayWidthTests
         var expected = 12;
         var actual = DisplayWidth.GetStringWidth(text);
         
-        Assert.Equal(expected, actual);
+        Assert.AreEqual(expected, actual);
     }
     
-    [Fact]
+    [TestMethod]
     public void GetGraphemeWidth_WarningEmojiWithVS16_ReturnsTwo()
     {
         // ⚠️ is U+26A0 + U+FE0F (warning + variation selector-16)
@@ -328,15 +329,15 @@ public class DisplayWidthTests
         
         // Check it's actually the 2-codepoint version
         var runes = warning.EnumerateRunes().ToArray();
-        Assert.Equal(2, runes.Length);
-        Assert.Equal(0x26A0, runes[0].Value);  // Warning sign
-        Assert.Equal(0xFE0F, runes[1].Value);  // Variation selector-16
+        Assert.AreEqual(2, runes.Length);
+        Assert.AreEqual(0x26A0, runes[0].Value);  // Warning sign
+        Assert.AreEqual(0xFE0F, runes[1].Value);  // Variation selector-16
         
         var width = DisplayWidth.GetGraphemeWidth(warning);
-        Assert.Equal(2, width);
+        Assert.AreEqual(2, width);
     }
 
-    [Fact]
+    [TestMethod]
     public void StringInterpolation_PreservesVariationSelector()
     {
         var emoji = "🖥️";
@@ -347,15 +348,15 @@ public class DisplayWidthTests
         
         // Should contain: T,e,s,t, ,🖥,FE0F, ,c,h,a,r
         var hasVS16 = runes.Any(r => r.Value == 0xFE0F);
-        Assert.True(hasVS16, "Variation selector FE0F should be preserved in interpolated string");
+        Assert.IsTrue(hasVS16, "Variation selector FE0F should be preserved in interpolated string");
         
         // Check width calculation
         var width = DisplayWidth.GetStringWidth(interpolated);
         // "Test " = 5, 🖥️ = 2, " char" = 5 → total = 12
-        Assert.Equal(12, width);
+        Assert.AreEqual(12, width);
     }
     
-    [Fact]
+    [TestMethod]
     public void SliceByDisplayWidthWithAnsi_VS16Emoji_NoPaddingWhenNotClipped()
     {
         // When slicing "Test 🖥️ char" (12 columns) with 28 columns max,
@@ -364,13 +365,13 @@ public class DisplayWidthTests
         var (sliced, columns, paddingBefore, paddingAfter) = 
             DisplayWidth.SliceByDisplayWidthWithAnsi(text, 0, 28);
         
-        Assert.Equal(text, sliced);
-        Assert.Equal(12, columns);
-        Assert.Equal(0, paddingBefore);
-        Assert.Equal(0, paddingAfter);
+        Assert.AreEqual(text, sliced);
+        Assert.AreEqual(12, columns);
+        Assert.AreEqual(0, paddingBefore);
+        Assert.AreEqual(0, paddingAfter);
     }
     
-    [Fact]
+    [TestMethod]
     public void SliceByDisplayWidthWithAnsi_InnerFillSpaces_NoPadding()
     {
         // When slicing 28 spaces with 60 columns max, there should be no padding
@@ -378,47 +379,47 @@ public class DisplayWidthTests
         var (sliced, columns, paddingBefore, paddingAfter) = 
             DisplayWidth.SliceByDisplayWidthWithAnsi(innerFill, 0, 28);
         
-        Assert.Equal(28, sliced.Length);
-        Assert.Equal(28, columns);
-        Assert.Equal(0, paddingBefore);
-        Assert.Equal(0, paddingAfter);
+        Assert.AreEqual(28, sliced.Length);
+        Assert.AreEqual(28, columns);
+        Assert.AreEqual(0, paddingBefore);
+        Assert.AreEqual(0, paddingAfter);
     }
     
     #region Checkbox and Symbol Characters
     
-    [Theory]
-    [InlineData("✓", 1)]  // Check Mark U+2713 - NO Emoji_Presentation, defaults to text
-    [InlineData("✔", 1)]  // Heavy Check Mark U+2714 - Emoji=Yes but Emoji_Presentation=No (needs VS16 for wide)
-    [InlineData("○", 1)]  // White Circle U+25CB - NO Emoji_Presentation
-    [InlineData("●", 1)]  // Black Circle U+25CF - NO Emoji_Presentation
-    [InlineData("☑", 1)]  // Ballot Box with Check U+2611 - Emoji=Yes but Emoji_Presentation=No (needs VS16 for wide)
-    [InlineData("☐", 1)]  // Ballot Box U+2610 - NO Emoji_Presentation
+    [TestMethod]
+    [DataRow("✓", 1)]  // Check Mark U+2713 - NO Emoji_Presentation, defaults to text
+    [DataRow("✔", 1)]  // Heavy Check Mark U+2714 - Emoji=Yes but Emoji_Presentation=No (needs VS16 for wide)
+    [DataRow("○", 1)]  // White Circle U+25CB - NO Emoji_Presentation
+    [DataRow("●", 1)]  // Black Circle U+25CF - NO Emoji_Presentation
+    [DataRow("☑", 1)]  // Ballot Box with Check U+2611 - Emoji=Yes but Emoji_Presentation=No (needs VS16 for wide)
+    [DataRow("☐", 1)]  // Ballot Box U+2610 - NO Emoji_Presentation
     public void GetGraphemeWidth_CheckboxSymbols_ReturnsExpected(string symbol, int expectedWidth)
     {
         var actualWidth = DisplayWidth.GetGraphemeWidth(symbol);
-        Assert.Equal(expectedWidth, actualWidth);
+        Assert.AreEqual(expectedWidth, actualWidth);
     }
     
-    [Fact]
+    [TestMethod]
     public void GetStringWidth_CheckmarkLine_CalculatesCorrectly()
     {
         // "  ✓ Completed Tasks" = 2 spaces + ✓ (1) + space (1) + "Completed Tasks" (15) = 19
         // Note: Using ✓ (U+2713) which defaults to text presentation (width 1)
         var line = "  ✓ Completed Tasks";
         var width = DisplayWidth.GetStringWidth(line);
-        Assert.Equal(19, width);
+        Assert.AreEqual(19, width);
     }
     
-    [Fact]
+    [TestMethod]
     public void GetStringWidth_ClipboardEmoji_CalculatesCorrectly()
     {
         // 📋 is a wide emoji (2 columns)
         var clipboard = "📋";
-        Assert.Equal(2, DisplayWidth.GetGraphemeWidth(clipboard));
+        Assert.AreEqual(2, DisplayWidth.GetGraphemeWidth(clipboard));
         
         // "  📋 Pending Tasks" = 2 spaces + 📋 (2) + space (1) + "Pending Tasks" (13) = 18
         var line = "  📋 Pending Tasks";
-        Assert.Equal(18, DisplayWidth.GetStringWidth(line));
+        Assert.AreEqual(18, DisplayWidth.GetStringWidth(line));
     }
     
     #endregion

--- a/tests/Hex1b.Tests/DockerContainerArgBuilderTests.cs
+++ b/tests/Hex1b.Tests/DockerContainerArgBuilderTests.cs
@@ -1,17 +1,18 @@
 namespace Hex1b.Tests;
 
+[TestClass]
 public class DockerContainerArgBuilderTests
 {
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_MinimalOptions_StartsWithRun()
     {
         var options = new DockerContainerOptions { Image = "ubuntu:24.04" };
         var args = DockerContainerArgBuilder.BuildRunArgs(options, "test-ctr");
 
-        Assert.Equal("run", args[0]);
+        Assert.AreEqual("run", args[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_MinimalOptions_IncludesInteractiveFlag()
     {
         var options = new DockerContainerOptions { Image = "ubuntu:24.04" };
@@ -20,7 +21,7 @@ public class DockerContainerArgBuilderTests
         Assert.Contains("-it", args);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_AutoRemoveTrue_IncludesRmFlag()
     {
         var options = new DockerContainerOptions { AutoRemove = true };
@@ -29,7 +30,7 @@ public class DockerContainerArgBuilderTests
         Assert.Contains("--rm", args);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_AutoRemoveFalse_OmitsRmFlag()
     {
         var options = new DockerContainerOptions { AutoRemove = false };
@@ -38,18 +39,18 @@ public class DockerContainerArgBuilderTests
         Assert.DoesNotContain("--rm", args);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_IncludesContainerName()
     {
         var options = new DockerContainerOptions();
         var args = DockerContainerArgBuilder.BuildRunArgs(options, "my-container");
 
         var nameIndex = Array.IndexOf(args, "--name");
-        Assert.True(nameIndex >= 0, "Expected --name flag");
-        Assert.Equal("my-container", args[nameIndex + 1]);
+        Assert.IsTrue(nameIndex >= 0, "Expected --name flag");
+        Assert.AreEqual("my-container", args[nameIndex + 1]);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_WithEnvironment_AddsEnvFlags()
     {
         var options = new DockerContainerOptions();
@@ -62,7 +63,7 @@ public class DockerContainerArgBuilderTests
         Assert.Contains("BAZ=qux", args);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_WithEnvironment_EachVarHasOwnFlag()
     {
         var options = new DockerContainerOptions();
@@ -72,10 +73,10 @@ public class DockerContainerArgBuilderTests
         var args = DockerContainerArgBuilder.BuildRunArgs(options, "test");
 
         var envFlagCount = args.Count(a => a == "-e");
-        Assert.Equal(3, envFlagCount);
+        Assert.AreEqual(3, envFlagCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_WithVolumes_AddsVolumeFlags()
     {
         var options = new DockerContainerOptions();
@@ -86,7 +87,7 @@ public class DockerContainerArgBuilderTests
         Assert.Contains("/host/path:/container/path", args);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_WithMultipleVolumes_EachHasOwnFlag()
     {
         var options = new DockerContainerOptions();
@@ -95,10 +96,10 @@ public class DockerContainerArgBuilderTests
         var args = DockerContainerArgBuilder.BuildRunArgs(options, "test");
 
         var volumeFlagCount = args.Count(a => a == "-v");
-        Assert.Equal(2, volumeFlagCount);
+        Assert.AreEqual(2, volumeFlagCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_MountDockerSocket_AddsSocketVolume()
     {
         var options = new DockerContainerOptions { MountDockerSocket = true };
@@ -107,7 +108,7 @@ public class DockerContainerArgBuilderTests
         Assert.Contains("/var/run/docker.sock:/var/run/docker.sock", args);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_MountDockerSocketFalse_NoSocketVolume()
     {
         var options = new DockerContainerOptions { MountDockerSocket = false };
@@ -116,7 +117,7 @@ public class DockerContainerArgBuilderTests
         Assert.DoesNotContain("/var/run/docker.sock:/var/run/docker.sock", args);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_MountDockerSocket_WithExistingVolumes_IncludesBoth()
     {
         var options = new DockerContainerOptions { MountDockerSocket = true };
@@ -127,18 +128,18 @@ public class DockerContainerArgBuilderTests
         Assert.Contains("/var/run/docker.sock:/var/run/docker.sock", args);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_WithWorkingDirectory_AddsWorkdirFlag()
     {
         var options = new DockerContainerOptions { WorkingDirectory = "/app" };
         var args = DockerContainerArgBuilder.BuildRunArgs(options, "test");
 
         var wIndex = Array.IndexOf(args, "-w");
-        Assert.True(wIndex >= 0, "Expected -w flag");
-        Assert.Equal("/app", args[wIndex + 1]);
+        Assert.IsTrue(wIndex >= 0, "Expected -w flag");
+        Assert.AreEqual("/app", args[wIndex + 1]);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_NoWorkingDirectory_OmitsWorkdirFlag()
     {
         var options = new DockerContainerOptions();
@@ -147,18 +148,18 @@ public class DockerContainerArgBuilderTests
         Assert.DoesNotContain("-w", args);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_WithNetwork_AddsNetworkFlag()
     {
         var options = new DockerContainerOptions { Network = "host" };
         var args = DockerContainerArgBuilder.BuildRunArgs(options, "test");
 
         var netIndex = Array.IndexOf(args, "--network");
-        Assert.True(netIndex >= 0, "Expected --network flag");
-        Assert.Equal("host", args[netIndex + 1]);
+        Assert.IsTrue(netIndex >= 0, "Expected --network flag");
+        Assert.AreEqual("host", args[netIndex + 1]);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_NoNetwork_OmitsNetworkFlag()
     {
         var options = new DockerContainerOptions();
@@ -167,7 +168,7 @@ public class DockerContainerArgBuilderTests
         Assert.DoesNotContain("--network", args);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_ImageIsAfterFlags()
     {
         var options = new DockerContainerOptions
@@ -183,11 +184,11 @@ public class DockerContainerArgBuilderTests
         var nameIndex = Array.IndexOf(args, "--name");
         var networkIndex = Array.IndexOf(args, "--network");
 
-        Assert.True(imageIndex > nameIndex, "Image should come after --name");
-        Assert.True(imageIndex > networkIndex, "Image should come after --network");
+        Assert.IsTrue(imageIndex > nameIndex, "Image should come after --name");
+        Assert.IsTrue(imageIndex > networkIndex, "Image should come after --network");
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_ShellFollowsImage()
     {
         var options = new DockerContainerOptions { Image = "ubuntu:24.04" };
@@ -196,10 +197,10 @@ public class DockerContainerArgBuilderTests
         var imageIndex = Array.IndexOf(args, "ubuntu:24.04");
         var shellIndex = Array.IndexOf(args, "/bin/bash");
 
-        Assert.Equal(imageIndex + 1, shellIndex);
+        Assert.AreEqual(imageIndex + 1, shellIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_ShellArgsFollowShell()
     {
         var options = new DockerContainerOptions
@@ -211,11 +212,11 @@ public class DockerContainerArgBuilderTests
         var args = DockerContainerArgBuilder.BuildRunArgs(options, "test");
 
         var shellIndex = Array.IndexOf(args, "/bin/bash");
-        Assert.Equal("--norc", args[shellIndex + 1]);
-        Assert.Equal("--noprofile", args[shellIndex + 2]);
+        Assert.AreEqual("--norc", args[shellIndex + 1]);
+        Assert.AreEqual("--noprofile", args[shellIndex + 2]);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_ShellArgsAreLastElements()
     {
         var options = new DockerContainerOptions
@@ -225,20 +226,20 @@ public class DockerContainerArgBuilderTests
         };
         var args = DockerContainerArgBuilder.BuildRunArgs(options, "test");
 
-        Assert.Equal("-i", args[^1]);
-        Assert.Equal("/bin/sh", args[^2]);
+        Assert.AreEqual("-i", args[^1]);
+        Assert.AreEqual("/bin/sh", args[^2]);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_EmptyShellArgs_ShellIsLast()
     {
         var options = new DockerContainerOptions { ShellArgs = [] };
         var args = DockerContainerArgBuilder.BuildRunArgs(options, "test");
 
-        Assert.Equal(options.Shell, args[^1]);
+        Assert.AreEqual(options.Shell, args[^1]);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_CustomShell_UsesCustomShell()
     {
         var options = new DockerContainerOptions
@@ -252,7 +253,7 @@ public class DockerContainerArgBuilderTests
         Assert.DoesNotContain("/bin/bash", args);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_AllOptions_ProducesValidArgs()
     {
         var options = new DockerContainerOptions
@@ -272,7 +273,7 @@ public class DockerContainerArgBuilderTests
 
         var args = DockerContainerArgBuilder.BuildRunArgs(options, "full-test");
 
-        Assert.Equal("run", args[0]);
+        Assert.AreEqual("run", args[0]);
         Assert.Contains("-it", args);
         Assert.Contains("--rm", args);
         Assert.Contains("--name", args);
@@ -293,7 +294,7 @@ public class DockerContainerArgBuilderTests
         Assert.Contains("-l", args);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_ManyEnvironmentVars_AllIncluded()
     {
         var options = new DockerContainerOptions();
@@ -302,13 +303,13 @@ public class DockerContainerArgBuilderTests
 
         var args = DockerContainerArgBuilder.BuildRunArgs(options, "test");
         var envCount = args.Count(a => a == "-e");
-        Assert.Equal(10, envCount);
+        Assert.AreEqual(10, envCount);
 
         for (int i = 0; i < 10; i++)
             Assert.Contains($"VAR_{i}=val_{i}", args);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_EnvironmentWithSpecialChars_PreservedExactly()
     {
         var options = new DockerContainerOptions();
@@ -323,7 +324,7 @@ public class DockerContainerArgBuilderTests
 
     // --- BuildBuildArgs tests ---
 
-    [Fact]
+    [TestMethod]
     public void BuildBuildArgs_StartsWithBuild()
     {
         var options = new DockerContainerOptions
@@ -333,10 +334,10 @@ public class DockerContainerArgBuilderTests
         };
         var (args, _) = DockerContainerArgBuilder.BuildBuildArgs(options, "abc123");
 
-        Assert.Equal("build", args[0]);
+        Assert.AreEqual("build", args[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildBuildArgs_IncludesDockerfilePath()
     {
         var options = new DockerContainerOptions
@@ -347,11 +348,11 @@ public class DockerContainerArgBuilderTests
         var (args, _) = DockerContainerArgBuilder.BuildBuildArgs(options, "abc");
 
         var fIndex = Array.IndexOf(args, "-f");
-        Assert.True(fIndex >= 0, "Expected -f flag");
-        Assert.Equal("./test/Dockerfile", args[fIndex + 1]);
+        Assert.IsTrue(fIndex >= 0, "Expected -f flag");
+        Assert.AreEqual("./test/Dockerfile", args[fIndex + 1]);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildBuildArgs_IncludesTag()
     {
         var options = new DockerContainerOptions
@@ -361,12 +362,12 @@ public class DockerContainerArgBuilderTests
         };
         var (args, imageTag) = DockerContainerArgBuilder.BuildBuildArgs(options, "abc123");
 
-        Assert.Equal("hex1b-test-abc123", imageTag);
+        Assert.AreEqual("hex1b-test-abc123", imageTag);
         Assert.Contains("-t", args);
         Assert.Contains("hex1b-test-abc123", args);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildBuildArgs_IncludesBuildContext()
     {
         var options = new DockerContainerOptions
@@ -376,10 +377,10 @@ public class DockerContainerArgBuilderTests
         };
         var (args, _) = DockerContainerArgBuilder.BuildBuildArgs(options, "abc");
 
-        Assert.Equal("./my-context", args[^1]);
+        Assert.AreEqual("./my-context", args[^1]);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildBuildArgs_NullBuildContext_UsesDockerfileDirectory()
     {
         var options = new DockerContainerOptions
@@ -389,10 +390,10 @@ public class DockerContainerArgBuilderTests
         };
         var (args, _) = DockerContainerArgBuilder.BuildBuildArgs(options, "abc");
 
-        Assert.Equal(Path.GetDirectoryName(options.DockerfilePath), args[^1]);
+        Assert.AreEqual(Path.GetDirectoryName(options.DockerfilePath), args[^1]);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildBuildArgs_WithBuildArgs_AddsBuildArgFlags()
     {
         var options = new DockerContainerOptions
@@ -410,7 +411,7 @@ public class DockerContainerArgBuilderTests
         Assert.Contains("VARIANT=alpine", args);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildBuildArgs_WithMultipleBuildArgs_EachHasOwnFlag()
     {
         var options = new DockerContainerOptions
@@ -425,10 +426,10 @@ public class DockerContainerArgBuilderTests
         var (args, _) = DockerContainerArgBuilder.BuildBuildArgs(options, "abc");
 
         var flagCount = args.Count(a => a == "--build-arg");
-        Assert.Equal(3, flagCount);
+        Assert.AreEqual(3, flagCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildBuildArgs_NoBuildArgs_OmitsBuildArgFlag()
     {
         var options = new DockerContainerOptions
@@ -441,7 +442,7 @@ public class DockerContainerArgBuilderTests
         Assert.DoesNotContain("--build-arg", args);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildBuildArgs_BuildContextIsLastArg()
     {
         var options = new DockerContainerOptions
@@ -453,77 +454,77 @@ public class DockerContainerArgBuilderTests
 
         var (args, _) = DockerContainerArgBuilder.BuildBuildArgs(options, "abc");
 
-        Assert.Equal("/context", args[^1]);
+        Assert.AreEqual("/context", args[^1]);
     }
 
     // --- Hash computation tests ---
 
-    [Fact]
+    [TestMethod]
     public void ComputeDockerfileHash_SameContent_SameHash()
     {
         var hash1 = DockerContainerArgBuilder.ComputeDockerfileHash("FROM ubuntu:24.04\nRUN apt-get update");
         var hash2 = DockerContainerArgBuilder.ComputeDockerfileHash("FROM ubuntu:24.04\nRUN apt-get update");
-        Assert.Equal(hash1, hash2);
+        Assert.AreEqual(hash1, hash2);
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputeDockerfileHash_DifferentContent_DifferentHash()
     {
         var hash1 = DockerContainerArgBuilder.ComputeDockerfileHash("FROM ubuntu:24.04");
         var hash2 = DockerContainerArgBuilder.ComputeDockerfileHash("FROM alpine:3.21");
-        Assert.NotEqual(hash1, hash2);
+        Assert.AreNotEqual(hash1, hash2);
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputeDockerfileHash_Returns12Chars()
     {
         var hash = DockerContainerArgBuilder.ComputeDockerfileHash("FROM ubuntu:24.04");
-        Assert.Equal(12, hash.Length);
+        Assert.AreEqual(12, hash.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputeDockerfileHash_ReturnsLowercaseHex()
     {
         var hash = DockerContainerArgBuilder.ComputeDockerfileHash("FROM ubuntu:24.04");
-        Assert.Matches("^[0-9a-f]{12}$", hash);
+        TestSeq.Matches("^[0-9a-f]{12}$", hash);
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputeDockerfileHash_EmptyContent_DoesNotThrow()
     {
         var hash = DockerContainerArgBuilder.ComputeDockerfileHash("");
-        Assert.Equal(12, hash.Length);
+        Assert.AreEqual(12, hash.Length);
     }
 
     // --- Container name generation tests ---
 
-    [Fact]
+    [TestMethod]
     public void GenerateContainerName_StartsWithPrefix()
     {
         var name = DockerContainerArgBuilder.GenerateContainerName();
         Assert.StartsWith("hex1b-test-", name);
     }
 
-    [Fact]
+    [TestMethod]
     public void GenerateContainerName_HasFixedLength()
     {
         var name = DockerContainerArgBuilder.GenerateContainerName();
-        Assert.Equal(32, name.Length);
+        Assert.AreEqual(32, name.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void GenerateContainerName_IsUnique()
     {
         var names = Enumerable.Range(0, 100)
             .Select(_ => DockerContainerArgBuilder.GenerateContainerName())
             .ToHashSet();
 
-        Assert.Equal(100, names.Count);
+        Assert.AreEqual(100, names.Count);
     }
 
     // --- AdditionalRunArgs tests ---
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_WithAdditionalRunArgs_IncludesArgs()
     {
         var options = new DockerContainerOptions();
@@ -533,7 +534,7 @@ public class DockerContainerArgBuilderTests
         Assert.Contains("--privileged", args);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_WithMultipleAdditionalRunArgs_IncludesAll()
     {
         var options = new DockerContainerOptions();
@@ -544,7 +545,7 @@ public class DockerContainerArgBuilderTests
         Assert.Contains("--cgroupns=host", args);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_AdditionalRunArgs_BeforeImage()
     {
         var options = new DockerContainerOptions { Image = "alpine:3.21" };
@@ -553,10 +554,10 @@ public class DockerContainerArgBuilderTests
 
         var privilegedIndex = Array.IndexOf(args, "--privileged");
         var imageIndex = Array.IndexOf(args, "alpine:3.21");
-        Assert.True(privilegedIndex < imageIndex, "Additional args should come before the image");
+        Assert.IsTrue(privilegedIndex < imageIndex, "Additional args should come before the image");
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_EmptyAdditionalRunArgs_NoExtraArgs()
     {
         var options = new DockerContainerOptions { Image = "ubuntu:24.04" };
@@ -566,10 +567,10 @@ public class DockerContainerArgBuilderTests
         var optionsWithEmpty = new DockerContainerOptions { Image = "ubuntu:24.04" };
         var argsWith = DockerContainerArgBuilder.BuildRunArgs(optionsWithEmpty, "test");
 
-        Assert.Equal(argsWithout.Length, argsWith.Length);
+        Assert.AreEqual(argsWithout.Length, argsWith.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildRunArgs_AllOptions_IncludesAdditionalRunArgs()
     {
         var options = new DockerContainerOptions

--- a/tests/Hex1b.Tests/DockerContainerIntegrationTests.cs
+++ b/tests/Hex1b.Tests/DockerContainerIntegrationTests.cs
@@ -3,7 +3,7 @@ using Hex1b.Automation;
 namespace Hex1b.Tests;
 
 /// <summary>
-/// Custom xUnit Fact attribute that skips the test when Docker with Linux containers is not available.
+/// Custom TestMethod attribute that marks a test inconclusive when Docker with Linux containers is not available.
 /// </summary>
 public sealed class DockerAvailableFactAttribute : TestMethodAttribute
 {

--- a/tests/Hex1b.Tests/DockerContainerIntegrationTests.cs
+++ b/tests/Hex1b.Tests/DockerContainerIntegrationTests.cs
@@ -5,19 +5,25 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Custom xUnit Fact attribute that skips the test when Docker with Linux containers is not available.
 /// </summary>
-public sealed class DockerAvailableFactAttribute : FactAttribute
+public sealed class DockerAvailableFactAttribute : TestMethodAttribute
 {
     private static readonly string? s_skipReason = GetSkipReason();
 
-    public DockerAvailableFactAttribute(
-        [System.Runtime.CompilerServices.CallerFilePath] string? sourceFilePath = null,
-        [System.Runtime.CompilerServices.CallerLineNumber] int sourceLineNumber = -1)
-        : base(sourceFilePath, sourceLineNumber)
+    public DockerAvailableFactAttribute()
+    {
+    }
+
+    public override Task<TestResult[]> ExecuteAsync(ITestMethod testMethod)
     {
         if (s_skipReason is not null)
         {
-            Skip = s_skipReason;
+            return Task.FromResult<TestResult[]>([new TestResult
+            {
+                Outcome = UnitTestOutcome.Inconclusive,
+                TestFailureException = new AssertInconclusiveException(s_skipReason),
+            }]);
         }
+        return base.ExecuteAsync(testMethod);
     }
 
     private static string? GetSkipReason()
@@ -111,7 +117,7 @@ public class DockerContainerIntegrationTests
         // Verify pattern was found (WaitUntil would have thrown on timeout)
         var snapshot = terminal.CreateSnapshot();
         var found = linuxPattern.Search(snapshot);
-        Assert.True(found.Count > 0, "Expected 'Linux' in terminal output");
+        Assert.IsTrue(found.Count > 0, "Expected 'Linux' in terminal output");
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Type("exit").Enter()
@@ -149,7 +155,7 @@ public class DockerContainerIntegrationTests
 
         var snapshot = terminal.CreateSnapshot();
         var found = envPattern.Search(snapshot);
-        Assert.True(found.Count > 0, "Expected environment variable value in output");
+        Assert.IsTrue(found.Count > 0, "Expected environment variable value in output");
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Type("exit").Enter()
@@ -228,6 +234,6 @@ public class DockerContainerIntegrationTests
 
         // Default image is dotnet/sdk:10.0, so dotnet should be available
         var found = new CellPatternSearcher().Find("10.").Search(snapshot);
-        Assert.True(found.Count > 0, "Expected dotnet version output in container");
+        Assert.IsTrue(found.Count > 0, "Expected dotnet version output in container");
     }
 }

--- a/tests/Hex1b.Tests/DockerContainerOptionsTests.cs
+++ b/tests/Hex1b.Tests/DockerContainerOptionsTests.cs
@@ -1,136 +1,137 @@
 namespace Hex1b.Tests;
 
+[TestClass]
 public class DockerContainerOptionsTests
 {
-    [Fact]
+    [TestMethod]
     public void DefaultImage_IsDotnetSdk()
     {
         var options = new DockerContainerOptions();
-        Assert.Equal(DockerContainerArgBuilder.DefaultImage, options.Image);
+        Assert.AreEqual(DockerContainerArgBuilder.DefaultImage, options.Image);
     }
 
-    [Fact]
+    [TestMethod]
     public void DefaultShell_IsBashNorc()
     {
         var options = new DockerContainerOptions();
-        Assert.Equal("/bin/bash", options.Shell);
-        Assert.Equal(["--norc"], options.ShellArgs);
+        Assert.AreEqual("/bin/bash", options.Shell);
+        TestSeq.AreEqual(["--norc"], options.ShellArgs);
     }
 
-    [Fact]
+    [TestMethod]
     public void AutoRemove_DefaultsTrue()
     {
         var options = new DockerContainerOptions();
-        Assert.True(options.AutoRemove);
+        Assert.IsTrue(options.AutoRemove);
     }
 
-    [Fact]
+    [TestMethod]
     public void MountDockerSocket_DefaultsFalse()
     {
         var options = new DockerContainerOptions();
-        Assert.False(options.MountDockerSocket);
+        Assert.IsFalse(options.MountDockerSocket);
     }
 
-    [Fact]
+    [TestMethod]
     public void DockerfilePath_DefaultsNull()
     {
         var options = new DockerContainerOptions();
-        Assert.Null(options.DockerfilePath);
+        Assert.IsNull(options.DockerfilePath);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildContext_DefaultsNull()
     {
         var options = new DockerContainerOptions();
-        Assert.Null(options.BuildContext);
+        Assert.IsNull(options.BuildContext);
     }
 
-    [Fact]
+    [TestMethod]
     public void Name_DefaultsNull()
     {
         var options = new DockerContainerOptions();
-        Assert.Null(options.Name);
+        Assert.IsNull(options.Name);
     }
 
-    [Fact]
+    [TestMethod]
     public void WorkingDirectory_DefaultsNull()
     {
         var options = new DockerContainerOptions();
-        Assert.Null(options.WorkingDirectory);
+        Assert.IsNull(options.WorkingDirectory);
     }
 
-    [Fact]
+    [TestMethod]
     public void Network_DefaultsNull()
     {
         var options = new DockerContainerOptions();
-        Assert.Null(options.Network);
+        Assert.IsNull(options.Network);
     }
 
-    [Fact]
+    [TestMethod]
     public void Environment_InitiallyEmpty()
     {
         var options = new DockerContainerOptions();
-        Assert.Empty(options.Environment);
+        Assert.IsEmpty(options.Environment);
     }
 
-    [Fact]
+    [TestMethod]
     public void Volumes_InitiallyEmpty()
     {
         var options = new DockerContainerOptions();
-        Assert.Empty(options.Volumes);
+        Assert.IsEmpty(options.Volumes);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildArgs_InitiallyEmpty()
     {
         var options = new DockerContainerOptions();
-        Assert.Empty(options.BuildArgs);
+        Assert.IsEmpty(options.BuildArgs);
     }
 
-    [Fact]
+    [TestMethod]
     public void Environment_CanAddEntries()
     {
         var options = new DockerContainerOptions();
         options.Environment["FOO"] = "bar";
         options.Environment["BAZ"] = "qux";
-        Assert.Equal(2, options.Environment.Count);
-        Assert.Equal("bar", options.Environment["FOO"]);
+        Assert.AreEqual(2, options.Environment.Count);
+        Assert.AreEqual("bar", options.Environment["FOO"]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Volumes_CanAddEntries()
     {
         var options = new DockerContainerOptions();
         options.Volumes.Add("/host:/container");
         options.Volumes.Add("/tmp:/tmp:ro");
-        Assert.Equal(2, options.Volumes.Count);
+        Assert.AreEqual(2, options.Volumes.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildArgs_CanAddEntries()
     {
         var options = new DockerContainerOptions();
         options.BuildArgs["SDK_VERSION"] = "10.0";
-        Assert.Single(options.BuildArgs);
+        TestSeq.Single(options.BuildArgs);
     }
 
-    [Fact]
+    [TestMethod]
     public void ShellArgs_CanBeOverridden()
     {
         var options = new DockerContainerOptions
         {
             ShellArgs = ["-l", "-i"]
         };
-        Assert.Equal(["-l", "-i"], options.ShellArgs);
+        TestSeq.AreEqual(["-l", "-i"], options.ShellArgs);
     }
 
-    [Fact]
+    [TestMethod]
     public void ShellArgs_CanBeSetToEmpty()
     {
         var options = new DockerContainerOptions
         {
             ShellArgs = []
         };
-        Assert.Empty(options.ShellArgs);
+        Assert.IsEmpty(options.ShellArgs);
     }
 }

--- a/tests/Hex1b.Tests/DockerContainerValidationTests.cs
+++ b/tests/Hex1b.Tests/DockerContainerValidationTests.cs
@@ -1,22 +1,23 @@
 namespace Hex1b.Tests;
 
+[TestClass]
 public class DockerContainerValidationTests
 {
-    [Fact]
+    [TestMethod]
     public void Validate_DefaultOptions_NoThrow()
     {
         var options = new DockerContainerOptions();
         DockerContainerArgBuilder.Validate(options);
     }
 
-    [Fact]
+    [TestMethod]
     public void Validate_CustomImageOnly_NoThrow()
     {
         var options = new DockerContainerOptions { Image = "ubuntu:24.04" };
         DockerContainerArgBuilder.Validate(options);
     }
 
-    [Fact]
+    [TestMethod]
     public void Validate_DockerfileOnly_NoThrow()
     {
         var options = new DockerContainerOptions
@@ -26,7 +27,7 @@ public class DockerContainerValidationTests
         DockerContainerArgBuilder.Validate(options);
     }
 
-    [Fact]
+    [TestMethod]
     public void Validate_DockerfileWithBuildContext_NoThrow()
     {
         var options = new DockerContainerOptions
@@ -37,7 +38,7 @@ public class DockerContainerValidationTests
         DockerContainerArgBuilder.Validate(options);
     }
 
-    [Fact]
+    [TestMethod]
     public void Validate_DockerfileWithBuildArgs_NoThrow()
     {
         var options = new DockerContainerOptions
@@ -48,7 +49,7 @@ public class DockerContainerValidationTests
         DockerContainerArgBuilder.Validate(options);
     }
 
-    [Fact]
+    [TestMethod]
     public void Validate_CustomImageAndDockerfile_Throws()
     {
         var options = new DockerContainerOptions
@@ -57,14 +58,13 @@ public class DockerContainerValidationTests
             DockerfilePath = "./Dockerfile"
         };
 
-        var ex = Assert.Throws<InvalidOperationException>(
-            () => DockerContainerArgBuilder.Validate(options));
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() => DockerContainerArgBuilder.Validate(options));
 
         Assert.Contains("Image", ex.Message);
         Assert.Contains("DockerfilePath", ex.Message);
     }
 
-    [Fact]
+    [TestMethod]
     public void Validate_BuildContextWithoutDockerfile_Throws()
     {
         var options = new DockerContainerOptions
@@ -72,34 +72,31 @@ public class DockerContainerValidationTests
             BuildContext = "/some/context"
         };
 
-        var ex = Assert.Throws<InvalidOperationException>(
-            () => DockerContainerArgBuilder.Validate(options));
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() => DockerContainerArgBuilder.Validate(options));
 
         Assert.Contains("BuildContext", ex.Message);
         Assert.Contains("DockerfilePath", ex.Message);
     }
 
-    [Fact]
+    [TestMethod]
     public void Validate_BuildArgsWithoutDockerfile_Throws()
     {
         var options = new DockerContainerOptions();
         options.BuildArgs["SDK"] = "10.0";
 
-        var ex = Assert.Throws<InvalidOperationException>(
-            () => DockerContainerArgBuilder.Validate(options));
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() => DockerContainerArgBuilder.Validate(options));
 
         Assert.Contains("BuildArgs", ex.Message);
         Assert.Contains("DockerfilePath", ex.Message);
     }
 
-    [Fact]
+    [TestMethod]
     public void Validate_NullOptions_ThrowsArgumentNull()
     {
-        Assert.Throws<ArgumentNullException>(
-            () => DockerContainerArgBuilder.Validate(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => DockerContainerArgBuilder.Validate(null!));
     }
 
-    [Fact]
+    [TestMethod]
     public void Validate_DefaultImageWithDockerfile_NoThrow()
     {
         // Default image + Dockerfile is OK — Dockerfile overrides the default
@@ -110,7 +107,7 @@ public class DockerContainerValidationTests
         DockerContainerArgBuilder.Validate(options);
     }
 
-    [Fact]
+    [TestMethod]
     public void Validate_AllContainerOptionsWithoutDockerfile_NoThrow()
     {
         // Setting all container-level options without Dockerfile is fine

--- a/tests/Hex1b.Tests/Documents/CursorSetTests.cs
+++ b/tests/Hex1b.Tests/Documents/CursorSetTests.cs
@@ -6,35 +6,36 @@ namespace Hex1b.Tests.Documents;
 /// Tests for CursorSet: sorted ordering, merging, snapshot/restore, multi-cursor operations.
 /// NOTE: These tests may need updates when selection rendering or multi-cursor behaviors change.
 /// </summary>
+[TestClass]
 public class CursorSetTests
 {
     // ── Construction ─────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void Constructor_CreatesOneCursorAtOrigin()
     {
         var set = new CursorSet();
-        Assert.Single(set);
-        Assert.Equal(0, set.Primary.Position.Value);
-        Assert.Equal(0, set.PrimaryIndex);
+        TestSeq.Single(set);
+        Assert.AreEqual(0, set.Primary.Position.Value);
+        Assert.AreEqual(0, set.PrimaryIndex);
     }
 
     // ── Add ─────────────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void Add_InsertsInSortedOrder()
     {
         var set = new CursorSet();
         set.Add(new DocumentOffset(10));
         set.Add(new DocumentOffset(5));
 
-        Assert.Equal(3, set.Count);
-        Assert.Equal(0, set[0].Position.Value);
-        Assert.Equal(5, set[1].Position.Value);
-        Assert.Equal(10, set[2].Position.Value);
+        Assert.AreEqual(3, set.Count);
+        Assert.AreEqual(0, set[0].Position.Value);
+        Assert.AreEqual(5, set[1].Position.Value);
+        Assert.AreEqual(10, set[2].Position.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void Add_AdjustsPrimaryIndex_WhenInsertedBefore()
     {
         var set = new CursorSet();
@@ -42,23 +43,23 @@ public class CursorSetTests
         set.Add(new DocumentOffset(5));
 
         // Primary was at index 0 (pos 10), add at index 0 (pos 5) pushes primary to index 1
-        Assert.Equal(1, set.PrimaryIndex);
-        Assert.Equal(10, set.Primary.Position.Value);
+        Assert.AreEqual(1, set.PrimaryIndex);
+        Assert.AreEqual(10, set.Primary.Position.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void Add_WithSelection()
     {
         var set = new CursorSet();
         var idx = set.Add(new DocumentOffset(10), new DocumentOffset(5));
         var cursor = set[idx];
 
-        Assert.Equal(10, cursor.Position.Value);
-        Assert.NotNull(cursor.SelectionAnchor);
-        Assert.Equal(5, cursor.SelectionAnchor!.Value.Value);
+        Assert.AreEqual(10, cursor.Position.Value);
+        Assert.IsNotNull(cursor.SelectionAnchor);
+        Assert.AreEqual(5, cursor.SelectionAnchor!.Value.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void Add_MultipleCursors_MaintainsSortOrder()
     {
         var set = new CursorSet();
@@ -67,16 +68,16 @@ public class CursorSetTests
         set.Add(new DocumentOffset(30));
         set.Add(new DocumentOffset(15));
 
-        Assert.Equal(5, set.Count);
+        Assert.AreEqual(5, set.Count);
         for (var i = 1; i < set.Count; i++)
         {
-            Assert.True(set[i].Position >= set[i - 1].Position);
+            Assert.IsTrue(set[i].Position >= set[i - 1].Position);
         }
     }
 
     // ── CollapseToSingle ────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void CollapseToSingle_KeepsPrimary()
     {
         var set = new CursorSet();
@@ -86,35 +87,35 @@ public class CursorSetTests
 
         set.CollapseToSingle();
 
-        Assert.Single(set);
-        Assert.Equal(5, set.Primary.Position.Value);
+        TestSeq.Single(set);
+        Assert.AreEqual(5, set.Primary.Position.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void CollapseToSingle_NoOp_WhenAlreadySingle()
     {
         var set = new CursorSet();
         set.Primary.Position = new DocumentOffset(5);
         set.CollapseToSingle();
 
-        Assert.Single(set);
-        Assert.Equal(5, set.Primary.Position.Value);
+        TestSeq.Single(set);
+        Assert.AreEqual(5, set.Primary.Position.Value);
     }
 
     // ── MergeOverlapping ────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void MergeOverlapping_MergesSamePosition()
     {
         var set = new CursorSet();
         set.Add(new DocumentOffset(0)); // Duplicate of primary
 
-        Assert.Equal(2, set.Count);
+        Assert.AreEqual(2, set.Count);
         set.MergeOverlapping();
-        Assert.Single(set);
+        TestSeq.Single(set);
     }
 
-    [Fact]
+    [TestMethod]
     public void MergeOverlapping_PreservesNonOverlapping()
     {
         var set = new CursorSet();
@@ -124,13 +125,13 @@ public class CursorSetTests
 
         set.MergeOverlapping();
 
-        Assert.Equal(3, set.Count);
-        Assert.Equal(5, set[0].Position.Value);
-        Assert.Equal(10, set[1].Position.Value);
-        Assert.Equal(20, set[2].Position.Value);
+        Assert.AreEqual(3, set.Count);
+        Assert.AreEqual(5, set[0].Position.Value);
+        Assert.AreEqual(10, set[1].Position.Value);
+        Assert.AreEqual(20, set[2].Position.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void MergeOverlapping_MergesOverlappingSelections()
     {
         var set = new CursorSet();
@@ -142,11 +143,11 @@ public class CursorSetTests
 
         set.MergeOverlapping();
 
-        Assert.Single(set);
+        TestSeq.Single(set);
         // Merged selection should span 0..15
     }
 
-    [Fact]
+    [TestMethod]
     public void MergeOverlapping_PrefersPrimary()
     {
         var set = new CursorSet();
@@ -156,13 +157,13 @@ public class CursorSetTests
 
         set.MergeOverlapping();
 
-        Assert.Single(set);
-        Assert.Same(primary, set.Primary);
+        TestSeq.Single(set);
+        Assert.AreSame(primary, set.Primary);
     }
 
     // ── InReverseOrder ──────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void InReverseOrder_IteratesHighestFirst()
     {
         var set = new CursorSet();
@@ -176,13 +177,13 @@ public class CursorSetTests
             positions.Add(cursor.Position.Value);
         }
 
-        Assert.Equal(3, positions.Count);
-        Assert.Equal(20, positions[0]);
-        Assert.Equal(10, positions[1]);
-        Assert.Equal(5, positions[2]);
+        Assert.AreEqual(3, positions.Count);
+        Assert.AreEqual(20, positions[0]);
+        Assert.AreEqual(10, positions[1]);
+        Assert.AreEqual(5, positions[2]);
     }
 
-    [Fact]
+    [TestMethod]
     public void InReverseOrder_ProvicesCorrectIndices()
     {
         var set = new CursorSet();
@@ -195,12 +196,12 @@ public class CursorSetTests
             indices.Add(index);
         }
 
-        Assert.Equal([2, 1, 0], indices);
+        TestSeq.AreEqual([2, 1, 0], indices);
     }
 
     // ── Snapshot/Restore ────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void Snapshot_CapturesAllCursors()
     {
         var set = new CursorSet();
@@ -210,15 +211,15 @@ public class CursorSetTests
 
         var snap = set.Snapshot();
 
-        Assert.Equal(2, snap.Entries.Count);
-        Assert.Equal(0, snap.PrimaryIndex);
-        Assert.Equal(5, snap.Entries[0].Position.Value);
-        Assert.Equal(new DocumentOffset(2), snap.Entries[0].SelectionAnchor);
-        Assert.Equal(10, snap.Entries[1].Position.Value);
-        Assert.Null(snap.Entries[1].SelectionAnchor);
+        Assert.AreEqual(2, snap.Entries.Count);
+        Assert.AreEqual(0, snap.PrimaryIndex);
+        Assert.AreEqual(5, snap.Entries[0].Position.Value);
+        Assert.AreEqual(new DocumentOffset(2), snap.Entries[0].SelectionAnchor);
+        Assert.AreEqual(10, snap.Entries[1].Position.Value);
+        Assert.IsNull(snap.Entries[1].SelectionAnchor);
     }
 
-    [Fact]
+    [TestMethod]
     public void Restore_ReplacesAllCursors()
     {
         var set = new CursorSet();
@@ -234,14 +235,14 @@ public class CursorSetTests
 
         set.Restore(snap);
 
-        Assert.Equal(2, set.Count);
-        Assert.Equal(1, set.PrimaryIndex);
-        Assert.Equal(3, set[0].Position.Value);
-        Assert.Equal(7, set[1].Position.Value);
-        Assert.Equal(new DocumentOffset(5), set[1].SelectionAnchor);
+        Assert.AreEqual(2, set.Count);
+        Assert.AreEqual(1, set.PrimaryIndex);
+        Assert.AreEqual(3, set[0].Position.Value);
+        Assert.AreEqual(7, set[1].Position.Value);
+        Assert.AreEqual(new DocumentOffset(5), set[1].SelectionAnchor);
     }
 
-    [Fact]
+    [TestMethod]
     public void Snapshot_Restore_Roundtrip()
     {
         var set = new CursorSet();
@@ -258,15 +259,15 @@ public class CursorSetTests
         // Restore
         set.Restore(snap);
 
-        Assert.Equal(3, set.Count);
-        Assert.Equal(5, set[0].Position.Value);
-        Assert.Equal(10, set[1].Position.Value);
-        Assert.Equal(15, set[2].Position.Value);
+        Assert.AreEqual(3, set.Count);
+        Assert.AreEqual(5, set[0].Position.Value);
+        Assert.AreEqual(10, set[1].Position.Value);
+        Assert.AreEqual(15, set[2].Position.Value);
     }
 
     // ── ClampAll ────────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void ClampAll_ClampsAllCursors()
     {
         var set = new CursorSet();
@@ -275,11 +276,11 @@ public class CursorSetTests
 
         set.ClampAll(30);
 
-        Assert.Equal(30, set[0].Position.Value);
-        Assert.Equal(30, set[1].Position.Value);
+        Assert.AreEqual(30, set[0].Position.Value);
+        Assert.AreEqual(30, set[1].Position.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClampAll_ClampsSelectionAnchors()
     {
         var set = new CursorSet();
@@ -288,13 +289,13 @@ public class CursorSetTests
 
         set.ClampAll(20);
 
-        Assert.Equal(10, set.Primary.Position.Value);
-        Assert.Equal(20, set.Primary.SelectionAnchor!.Value.Value);
+        Assert.AreEqual(10, set.Primary.Position.Value);
+        Assert.AreEqual(20, set.Primary.SelectionAnchor!.Value.Value);
     }
 
     // ── Sort ────────────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void Sort_ReordersCursorsAndTracksPrimary()
     {
         var set = new CursorSet();
@@ -306,14 +307,14 @@ public class CursorSetTests
         set.Sort();
 
         // After sort: [other(10), primary(15)]
-        Assert.Equal(10, set[0].Position.Value);
-        Assert.Equal(15, set[1].Position.Value);
-        Assert.Equal(1, set.PrimaryIndex);
+        Assert.AreEqual(10, set[0].Position.Value);
+        Assert.AreEqual(15, set[1].Position.Value);
+        Assert.AreEqual(1, set.PrimaryIndex);
     }
 
     // ── IReadOnlyList ───────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void Enumeration_ReturnsAllCursors()
     {
         var set = new CursorSet();
@@ -325,17 +326,17 @@ public class CursorSetTests
         {
             count++;
         }
-        Assert.Equal(3, count);
+        Assert.AreEqual(3, count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Count_ReflectsAdditions()
     {
         var set = new CursorSet();
-        Assert.Single(set);
+        TestSeq.Single(set);
         set.Add(new DocumentOffset(10));
-        Assert.Equal(2, set.Count);
+        Assert.AreEqual(2, set.Count);
         set.Add(new DocumentOffset(20));
-        Assert.Equal(3, set.Count);
+        Assert.AreEqual(3, set.Count);
     }
 }

--- a/tests/Hex1b.Tests/Documents/DocumentCursorTests.cs
+++ b/tests/Hex1b.Tests/Documents/DocumentCursorTests.cs
@@ -2,30 +2,31 @@ using Hex1b.Documents;
 
 namespace Hex1b.Tests.Documents;
 
+[TestClass]
 public class DocumentCursorTests
 {
-    [Fact]
+    [TestMethod]
     public void Position_DefaultIsZero()
     {
         var cursor = new DocumentCursor();
-        Assert.Equal(DocumentOffset.Zero, cursor.Position);
+        Assert.AreEqual(DocumentOffset.Zero, cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectionAnchor_DefaultIsNull()
     {
         var cursor = new DocumentCursor();
-        Assert.Null(cursor.SelectionAnchor);
+        Assert.IsNull(cursor.SelectionAnchor);
     }
 
-    [Fact]
+    [TestMethod]
     public void HasSelection_NoAnchor_ReturnsFalse()
     {
         var cursor = new DocumentCursor();
-        Assert.False(cursor.HasSelection);
+        Assert.IsFalse(cursor.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void HasSelection_AnchorSameAsPosition_ReturnsFalse()
     {
         var cursor = new DocumentCursor
@@ -33,10 +34,10 @@ public class DocumentCursorTests
             Position = new DocumentOffset(5),
             SelectionAnchor = new DocumentOffset(5)
         };
-        Assert.False(cursor.HasSelection);
+        Assert.IsFalse(cursor.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void HasSelection_AnchorDifferentFromPosition_ReturnsTrue()
     {
         var cursor = new DocumentCursor
@@ -44,12 +45,12 @@ public class DocumentCursorTests
             Position = new DocumentOffset(5),
             SelectionAnchor = new DocumentOffset(2)
         };
-        Assert.True(cursor.HasSelection);
+        Assert.IsTrue(cursor.HasSelection);
     }
 
     // --- SelectionStart / SelectionEnd ---
 
-    [Fact]
+    [TestMethod]
     public void SelectionStart_AnchorBeforePosition_ReturnsAnchor()
     {
         var cursor = new DocumentCursor
@@ -57,10 +58,10 @@ public class DocumentCursorTests
             Position = new DocumentOffset(8),
             SelectionAnchor = new DocumentOffset(3)
         };
-        Assert.Equal(new DocumentOffset(3), cursor.SelectionStart);
+        Assert.AreEqual(new DocumentOffset(3), cursor.SelectionStart);
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectionEnd_AnchorBeforePosition_ReturnsPosition()
     {
         var cursor = new DocumentCursor
@@ -68,10 +69,10 @@ public class DocumentCursorTests
             Position = new DocumentOffset(8),
             SelectionAnchor = new DocumentOffset(3)
         };
-        Assert.Equal(new DocumentOffset(8), cursor.SelectionEnd);
+        Assert.AreEqual(new DocumentOffset(8), cursor.SelectionEnd);
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectionStart_AnchorAfterPosition_ReturnsPosition()
     {
         var cursor = new DocumentCursor
@@ -79,10 +80,10 @@ public class DocumentCursorTests
             Position = new DocumentOffset(3),
             SelectionAnchor = new DocumentOffset(8)
         };
-        Assert.Equal(new DocumentOffset(3), cursor.SelectionStart);
+        Assert.AreEqual(new DocumentOffset(3), cursor.SelectionStart);
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectionEnd_AnchorAfterPosition_ReturnsAnchor()
     {
         var cursor = new DocumentCursor
@@ -90,26 +91,26 @@ public class DocumentCursorTests
             Position = new DocumentOffset(3),
             SelectionAnchor = new DocumentOffset(8)
         };
-        Assert.Equal(new DocumentOffset(8), cursor.SelectionEnd);
+        Assert.AreEqual(new DocumentOffset(8), cursor.SelectionEnd);
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectionStart_NoSelection_ReturnsPosition()
     {
         var cursor = new DocumentCursor { Position = new DocumentOffset(5) };
-        Assert.Equal(new DocumentOffset(5), cursor.SelectionStart);
+        Assert.AreEqual(new DocumentOffset(5), cursor.SelectionStart);
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectionEnd_NoSelection_ReturnsPosition()
     {
         var cursor = new DocumentCursor { Position = new DocumentOffset(5) };
-        Assert.Equal(new DocumentOffset(5), cursor.SelectionEnd);
+        Assert.AreEqual(new DocumentOffset(5), cursor.SelectionEnd);
     }
 
     // --- SelectionRange ---
 
-    [Fact]
+    [TestMethod]
     public void SelectionRange_WithSelection_ReturnsCorrectRange()
     {
         var cursor = new DocumentCursor
@@ -118,22 +119,22 @@ public class DocumentCursorTests
             SelectionAnchor = new DocumentOffset(3)
         };
         var range = cursor.SelectionRange;
-        Assert.Equal(new DocumentOffset(3), range.Start);
-        Assert.Equal(new DocumentOffset(8), range.End);
+        Assert.AreEqual(new DocumentOffset(3), range.Start);
+        Assert.AreEqual(new DocumentOffset(8), range.End);
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectionRange_NoSelection_ReturnsEmptyRangeAtPosition()
     {
         var cursor = new DocumentCursor { Position = new DocumentOffset(5) };
         var range = cursor.SelectionRange;
-        Assert.True(range.IsEmpty);
-        Assert.Equal(new DocumentOffset(5), range.Start);
+        Assert.IsTrue(range.IsEmpty);
+        Assert.AreEqual(new DocumentOffset(5), range.Start);
     }
 
     // --- ClearSelection ---
 
-    [Fact]
+    [TestMethod]
     public void ClearSelection_RemovesAnchor()
     {
         var cursor = new DocumentCursor
@@ -142,37 +143,37 @@ public class DocumentCursorTests
             SelectionAnchor = new DocumentOffset(3)
         };
         cursor.ClearSelection();
-        Assert.Null(cursor.SelectionAnchor);
-        Assert.False(cursor.HasSelection);
+        Assert.IsNull(cursor.SelectionAnchor);
+        Assert.IsFalse(cursor.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClearSelection_WhenNoSelection_IsNoOp()
     {
         var cursor = new DocumentCursor { Position = new DocumentOffset(5) };
         cursor.ClearSelection();
-        Assert.Null(cursor.SelectionAnchor);
+        Assert.IsNull(cursor.SelectionAnchor);
     }
 
     // --- Clamp ---
 
-    [Fact]
+    [TestMethod]
     public void Clamp_PositionWithinRange_NoChange()
     {
         var cursor = new DocumentCursor { Position = new DocumentOffset(3) };
         cursor.Clamp(10);
-        Assert.Equal(new DocumentOffset(3), cursor.Position);
+        Assert.AreEqual(new DocumentOffset(3), cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void Clamp_PositionBeyondRange_ClampsToEnd()
     {
         var cursor = new DocumentCursor { Position = new DocumentOffset(15) };
         cursor.Clamp(10);
-        Assert.Equal(new DocumentOffset(10), cursor.Position);
+        Assert.AreEqual(new DocumentOffset(10), cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void Clamp_AnchorBeyondRange_ClampsToEnd()
     {
         var cursor = new DocumentCursor
@@ -181,11 +182,11 @@ public class DocumentCursorTests
             SelectionAnchor = new DocumentOffset(15)
         };
         cursor.Clamp(10);
-        Assert.Equal(new DocumentOffset(3), cursor.Position);
-        Assert.Equal(new DocumentOffset(10), cursor.SelectionAnchor);
+        Assert.AreEqual(new DocumentOffset(3), cursor.Position);
+        Assert.AreEqual(new DocumentOffset(10), cursor.SelectionAnchor);
     }
 
-    [Fact]
+    [TestMethod]
     public void Clamp_BothBeyondRange_BothClamped()
     {
         var cursor = new DocumentCursor
@@ -194,23 +195,23 @@ public class DocumentCursorTests
             SelectionAnchor = new DocumentOffset(25)
         };
         cursor.Clamp(10);
-        Assert.Equal(new DocumentOffset(10), cursor.Position);
-        Assert.Equal(new DocumentOffset(10), cursor.SelectionAnchor);
+        Assert.AreEqual(new DocumentOffset(10), cursor.Position);
+        Assert.AreEqual(new DocumentOffset(10), cursor.SelectionAnchor);
     }
 
-    [Fact]
+    [TestMethod]
     public void Clamp_NoAnchor_DoesNotCreateAnchor()
     {
         var cursor = new DocumentCursor { Position = new DocumentOffset(15) };
         cursor.Clamp(10);
-        Assert.Null(cursor.SelectionAnchor);
+        Assert.IsNull(cursor.SelectionAnchor);
     }
 
-    [Fact]
+    [TestMethod]
     public void Clamp_ZeroLength_PositionClampsToZero()
     {
         var cursor = new DocumentCursor { Position = new DocumentOffset(5) };
         cursor.Clamp(0);
-        Assert.Equal(DocumentOffset.Zero, cursor.Position);
+        Assert.AreEqual(DocumentOffset.Zero, cursor.Position);
     }
 }

--- a/tests/Hex1b.Tests/Documents/DocumentOffsetTests.cs
+++ b/tests/Hex1b.Tests/Documents/DocumentOffsetTests.cs
@@ -2,264 +2,265 @@ using Hex1b.Documents;
 
 namespace Hex1b.Tests.Documents;
 
+[TestClass]
 public class DocumentOffsetTests
 {
-    [Fact]
+    [TestMethod]
     public void Constructor_Zero_Succeeds()
     {
         var offset = new DocumentOffset(0);
-        Assert.Equal(0, offset.Value);
+        Assert.AreEqual(0, offset.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_Positive_Succeeds()
     {
         var offset = new DocumentOffset(42);
-        Assert.Equal(42, offset.Value);
+        Assert.AreEqual(42, offset.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_Negative_Throws()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new DocumentOffset(-1));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new DocumentOffset(-1));
     }
 
-    [Fact]
+    [TestMethod]
     public void Zero_ReturnsOffsetWithValueZero()
     {
-        Assert.Equal(0, DocumentOffset.Zero.Value);
+        Assert.AreEqual(0, DocumentOffset.Zero.Value);
     }
 
     // --- Implicit/Explicit Conversion ---
 
-    [Fact]
+    [TestMethod]
     public void ImplicitToInt_ReturnsValue()
     {
         var offset = new DocumentOffset(7);
         int val = offset;
-        Assert.Equal(7, val);
+        Assert.AreEqual(7, val);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExplicitFromInt_CreatesOffset()
     {
         var offset = (DocumentOffset)5;
-        Assert.Equal(5, offset.Value);
+        Assert.AreEqual(5, offset.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExplicitFromInt_Negative_Throws()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => (DocumentOffset)(-3));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => (DocumentOffset)(-3));
     }
 
     // --- Arithmetic Operators ---
 
-    [Fact]
+    [TestMethod]
     public void Add_Int_ReturnsNewOffset()
     {
         var offset = new DocumentOffset(5);
         var result = offset + 3;
-        Assert.Equal(8, result.Value);
+        Assert.AreEqual(8, result.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void Add_Zero_ReturnsSame()
     {
         var offset = new DocumentOffset(5);
         var result = offset + 0;
-        Assert.Equal(5, result.Value);
+        Assert.AreEqual(5, result.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void SubtractInt_ReturnsNewOffset()
     {
         var offset = new DocumentOffset(5);
         var result = offset - 3;
-        Assert.Equal(2, result.Value);
+        Assert.AreEqual(2, result.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void SubtractInt_ToZero_ReturnsZero()
     {
         var offset = new DocumentOffset(5);
         var result = offset - 5;
-        Assert.Equal(0, result.Value);
+        Assert.AreEqual(0, result.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void SubtractInt_BelowZero_Throws()
     {
         var offset = new DocumentOffset(2);
-        Assert.Throws<ArgumentOutOfRangeException>(() => offset - 3);
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => offset - 3);
     }
 
-    [Fact]
+    [TestMethod]
     public void SubtractOffset_ReturnsDifference()
     {
         var a = new DocumentOffset(10);
         var b = new DocumentOffset(3);
-        Assert.Equal(7, a - b);
+        Assert.AreEqual(7, a - b);
     }
 
-    [Fact]
+    [TestMethod]
     public void SubtractOffset_SameValue_ReturnsZero()
     {
         var a = new DocumentOffset(5);
-        Assert.Equal(0, a - a);
+        Assert.AreEqual(0, a - a);
     }
 
-    [Fact]
+    [TestMethod]
     public void SubtractOffset_Negative_Allowed()
     {
         // Offset subtraction returns int, which can be negative
         var a = new DocumentOffset(3);
         var b = new DocumentOffset(10);
-        Assert.Equal(-7, a - b);
+        Assert.AreEqual(-7, a - b);
     }
 
     // --- Comparison Operators ---
 
-    [Fact]
+    [TestMethod]
     public void LessThan_WhenSmaller_ReturnsTrue()
     {
-        Assert.True(new DocumentOffset(1) < new DocumentOffset(2));
+        Assert.IsTrue(new DocumentOffset(1) < new DocumentOffset(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void LessThan_WhenEqual_ReturnsFalse()
     {
-        Assert.False(new DocumentOffset(2) < new DocumentOffset(2));
+        Assert.IsFalse(new DocumentOffset(2) < new DocumentOffset(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void LessThan_WhenGreater_ReturnsFalse()
     {
-        Assert.False(new DocumentOffset(3) < new DocumentOffset(2));
+        Assert.IsFalse(new DocumentOffset(3) < new DocumentOffset(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void GreaterThan_WhenGreater_ReturnsTrue()
     {
-        Assert.True(new DocumentOffset(3) > new DocumentOffset(2));
+        Assert.IsTrue(new DocumentOffset(3) > new DocumentOffset(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void GreaterThan_WhenEqual_ReturnsFalse()
     {
-        Assert.False(new DocumentOffset(2) > new DocumentOffset(2));
+        Assert.IsFalse(new DocumentOffset(2) > new DocumentOffset(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void LessThanOrEqual_WhenEqual_ReturnsTrue()
     {
-        Assert.True(new DocumentOffset(2) <= new DocumentOffset(2));
+        Assert.IsTrue(new DocumentOffset(2) <= new DocumentOffset(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void LessThanOrEqual_WhenSmaller_ReturnsTrue()
     {
-        Assert.True(new DocumentOffset(1) <= new DocumentOffset(2));
+        Assert.IsTrue(new DocumentOffset(1) <= new DocumentOffset(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void LessThanOrEqual_WhenGreater_ReturnsFalse()
     {
-        Assert.False(new DocumentOffset(3) <= new DocumentOffset(2));
+        Assert.IsFalse(new DocumentOffset(3) <= new DocumentOffset(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void GreaterThanOrEqual_WhenEqual_ReturnsTrue()
     {
-        Assert.True(new DocumentOffset(2) >= new DocumentOffset(2));
+        Assert.IsTrue(new DocumentOffset(2) >= new DocumentOffset(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void GreaterThanOrEqual_WhenGreater_ReturnsTrue()
     {
-        Assert.True(new DocumentOffset(3) >= new DocumentOffset(2));
+        Assert.IsTrue(new DocumentOffset(3) >= new DocumentOffset(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void GreaterThanOrEqual_WhenSmaller_ReturnsFalse()
     {
-        Assert.False(new DocumentOffset(1) >= new DocumentOffset(2));
+        Assert.IsFalse(new DocumentOffset(1) >= new DocumentOffset(2));
     }
 
     // --- Equality ---
 
-    [Fact]
+    [TestMethod]
     public void Equals_SameValue_ReturnsTrue()
     {
-        Assert.True(new DocumentOffset(5).Equals(new DocumentOffset(5)));
+        Assert.IsTrue(new DocumentOffset(5).Equals(new DocumentOffset(5)));
     }
 
-    [Fact]
+    [TestMethod]
     public void Equals_DifferentValue_ReturnsFalse()
     {
-        Assert.False(new DocumentOffset(5).Equals(new DocumentOffset(6)));
+        Assert.IsFalse(new DocumentOffset(5).Equals(new DocumentOffset(6)));
     }
 
-    [Fact]
+    [TestMethod]
     public void Equals_BoxedSameValue_ReturnsTrue()
     {
         object boxed = new DocumentOffset(5);
-        Assert.True(new DocumentOffset(5).Equals(boxed));
+        Assert.IsTrue(new DocumentOffset(5).Equals(boxed));
     }
 
-    [Fact]
+    [TestMethod]
     public void Equals_BoxedDifferentType_ReturnsFalse()
     {
-        Assert.False(new DocumentOffset(5).Equals("not an offset"));
+        Assert.IsFalse(new DocumentOffset(5).Equals("not an offset"));
     }
 
-    [Fact]
+    [TestMethod]
     public void Equals_Null_ReturnsFalse()
     {
-        Assert.False(new DocumentOffset(5).Equals(null));
+        Assert.IsFalse(new DocumentOffset(5).Equals(null));
     }
 
-    [Fact]
+    [TestMethod]
     public void OperatorEquals_SameValue_ReturnsTrue()
     {
-        Assert.True(new DocumentOffset(5) == new DocumentOffset(5));
+        Assert.IsTrue(new DocumentOffset(5) == new DocumentOffset(5));
     }
 
-    [Fact]
+    [TestMethod]
     public void OperatorNotEquals_DifferentValue_ReturnsTrue()
     {
-        Assert.True(new DocumentOffset(5) != new DocumentOffset(6));
+        Assert.IsTrue(new DocumentOffset(5) != new DocumentOffset(6));
     }
 
     // --- GetHashCode / CompareTo / ToString ---
 
-    [Fact]
+    [TestMethod]
     public void GetHashCode_SameValue_SameHash()
     {
-        Assert.Equal(new DocumentOffset(5).GetHashCode(), new DocumentOffset(5).GetHashCode());
+        Assert.AreEqual(new DocumentOffset(5).GetHashCode(), new DocumentOffset(5).GetHashCode());
     }
 
-    [Fact]
+    [TestMethod]
     public void CompareTo_LessThan_ReturnsNegative()
     {
-        Assert.True(new DocumentOffset(1).CompareTo(new DocumentOffset(2)) < 0);
+        Assert.IsTrue(new DocumentOffset(1).CompareTo(new DocumentOffset(2)) < 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void CompareTo_Equal_ReturnsZero()
     {
-        Assert.Equal(0, new DocumentOffset(5).CompareTo(new DocumentOffset(5)));
+        Assert.AreEqual(0, new DocumentOffset(5).CompareTo(new DocumentOffset(5)));
     }
 
-    [Fact]
+    [TestMethod]
     public void CompareTo_GreaterThan_ReturnsPositive()
     {
-        Assert.True(new DocumentOffset(5).CompareTo(new DocumentOffset(1)) > 0);
+        Assert.IsTrue(new DocumentOffset(5).CompareTo(new DocumentOffset(1)) > 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToString_ReturnsValue()
     {
-        Assert.Equal("42", new DocumentOffset(42).ToString());
+        Assert.AreEqual("42", new DocumentOffset(42).ToString());
     }
 }

--- a/tests/Hex1b.Tests/Documents/DocumentPositionTests.cs
+++ b/tests/Hex1b.Tests/Documents/DocumentPositionTests.cs
@@ -2,179 +2,178 @@ using Hex1b.Documents;
 
 namespace Hex1b.Tests.Documents;
 
+[TestClass]
 public class DocumentPositionTests
 {
-    [Fact]
+    [TestMethod]
     public void Constructor_ValidLineAndColumn_Succeeds()
     {
         var pos = new DocumentPosition(1, 1);
-        Assert.Equal(1, pos.Line);
-        Assert.Equal(1, pos.Column);
+        Assert.AreEqual(1, pos.Line);
+        Assert.AreEqual(1, pos.Column);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_LargeValues_Succeeds()
     {
         var pos = new DocumentPosition(10000, 500);
-        Assert.Equal(10000, pos.Line);
-        Assert.Equal(500, pos.Column);
+        Assert.AreEqual(10000, pos.Line);
+        Assert.AreEqual(500, pos.Column);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_ZeroLine_Throws()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new DocumentPosition(0, 1));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new DocumentPosition(0, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_NegativeLine_Throws()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new DocumentPosition(-1, 1));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new DocumentPosition(-1, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_ZeroColumn_Throws()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new DocumentPosition(1, 0));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new DocumentPosition(1, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_NegativeColumn_Throws()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new DocumentPosition(1, -1));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new DocumentPosition(1, -1));
     }
 
     // --- Comparison ---
 
-    [Fact]
+    [TestMethod]
     public void CompareTo_SameLine_ComparesByColumn()
     {
         var a = new DocumentPosition(1, 3);
         var b = new DocumentPosition(1, 5);
-        Assert.True(a.CompareTo(b) < 0);
+        Assert.IsTrue(a.CompareTo(b) < 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void CompareTo_DifferentLines_ComparesByLine()
     {
         var a = new DocumentPosition(1, 100);
         var b = new DocumentPosition(2, 1);
-        Assert.True(a.CompareTo(b) < 0);
+        Assert.IsTrue(a.CompareTo(b) < 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void CompareTo_Equal_ReturnsZero()
     {
         var a = new DocumentPosition(3, 7);
-        Assert.Equal(0, a.CompareTo(new DocumentPosition(3, 7)));
+        Assert.AreEqual(0, a.CompareTo(new DocumentPosition(3, 7)));
     }
 
-    [Fact]
+    [TestMethod]
     public void LessThan_DifferentLines_ReturnsTrue()
     {
-        Assert.True(new DocumentPosition(1, 5) < new DocumentPosition(2, 1));
+        Assert.IsTrue(new DocumentPosition(1, 5) < new DocumentPosition(2, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void LessThan_SameLineSmallerCol_ReturnsTrue()
     {
-        Assert.True(new DocumentPosition(1, 3) < new DocumentPosition(1, 5));
+        Assert.IsTrue(new DocumentPosition(1, 3) < new DocumentPosition(1, 5));
     }
 
-    [Fact]
+    [TestMethod]
     public void LessThan_Equal_ReturnsFalse()
     {
-        Assert.False(new DocumentPosition(1, 1) < new DocumentPosition(1, 1));
+        Assert.IsFalse(new DocumentPosition(1, 1) < new DocumentPosition(1, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void GreaterThan_DifferentLines_ReturnsTrue()
     {
-        Assert.True(new DocumentPosition(3, 1) > new DocumentPosition(2, 99));
+        Assert.IsTrue(new DocumentPosition(3, 1) > new DocumentPosition(2, 99));
     }
 
-    [Fact]
+    [TestMethod]
     public void GreaterThan_SameLineLargerCol_ReturnsTrue()
     {
-        Assert.True(new DocumentPosition(1, 5) > new DocumentPosition(1, 3));
+        Assert.IsTrue(new DocumentPosition(1, 5) > new DocumentPosition(1, 3));
     }
 
-    [Fact]
+    [TestMethod]
     public void LessThanOrEqual_Equal_ReturnsTrue()
     {
-        Assert.True(new DocumentPosition(2, 3) <= new DocumentPosition(2, 3));
+        Assert.IsTrue(new DocumentPosition(2, 3) <= new DocumentPosition(2, 3));
     }
 
-    [Fact]
+    [TestMethod]
     public void GreaterThanOrEqual_Equal_ReturnsTrue()
     {
-        Assert.True(new DocumentPosition(2, 3) >= new DocumentPosition(2, 3));
+        Assert.IsTrue(new DocumentPosition(2, 3) >= new DocumentPosition(2, 3));
     }
 
     // --- Equality ---
 
-    [Fact]
+    [TestMethod]
     public void Equals_SameValues_ReturnsTrue()
     {
-        Assert.True(new DocumentPosition(2, 3).Equals(new DocumentPosition(2, 3)));
+        Assert.IsTrue(new DocumentPosition(2, 3).Equals(new DocumentPosition(2, 3)));
     }
 
-    [Fact]
+    [TestMethod]
     public void Equals_DifferentLine_ReturnsFalse()
     {
-        Assert.False(new DocumentPosition(1, 3).Equals(new DocumentPosition(2, 3)));
+        Assert.IsFalse(new DocumentPosition(1, 3).Equals(new DocumentPosition(2, 3)));
     }
 
-    [Fact]
+    [TestMethod]
     public void Equals_DifferentColumn_ReturnsFalse()
     {
-        Assert.False(new DocumentPosition(2, 3).Equals(new DocumentPosition(2, 4)));
+        Assert.IsFalse(new DocumentPosition(2, 3).Equals(new DocumentPosition(2, 4)));
     }
 
-    [Fact]
+    [TestMethod]
     public void Equals_BoxedSameValue_ReturnsTrue()
     {
         object boxed = new DocumentPosition(2, 3);
-        Assert.True(new DocumentPosition(2, 3).Equals(boxed));
+        Assert.IsTrue(new DocumentPosition(2, 3).Equals(boxed));
     }
 
-    [Fact]
+    [TestMethod]
     public void Equals_BoxedDifferentType_ReturnsFalse()
     {
-        Assert.False(new DocumentPosition(2, 3).Equals(42));
+        Assert.IsFalse(new DocumentPosition(2, 3).Equals(42));
     }
 
-    [Fact]
+    [TestMethod]
     public void Equals_Null_ReturnsFalse()
     {
-        Assert.False(new DocumentPosition(2, 3).Equals(null));
+        Assert.IsFalse(new DocumentPosition(2, 3).Equals(null));
     }
 
-    [Fact]
+    [TestMethod]
     public void OperatorEquals_ReturnsTrue()
     {
-        Assert.True(new DocumentPosition(2, 3) == new DocumentPosition(2, 3));
+        Assert.IsTrue(new DocumentPosition(2, 3) == new DocumentPosition(2, 3));
     }
 
-    [Fact]
+    [TestMethod]
     public void OperatorNotEquals_ReturnsTrue()
     {
-        Assert.True(new DocumentPosition(2, 3) != new DocumentPosition(2, 4));
+        Assert.IsTrue(new DocumentPosition(2, 3) != new DocumentPosition(2, 4));
     }
 
     // --- GetHashCode / ToString ---
 
-    [Fact]
+    [TestMethod]
     public void GetHashCode_SameValues_SameHash()
     {
-        Assert.Equal(
-            new DocumentPosition(2, 3).GetHashCode(),
-            new DocumentPosition(2, 3).GetHashCode());
+        Assert.AreEqual(new DocumentPosition(2, 3).GetHashCode(), new DocumentPosition(2, 3).GetHashCode());
     }
 
-    [Fact]
+    [TestMethod]
     public void ToString_FormatsCorrectly()
     {
-        Assert.Equal("(2,3)", new DocumentPosition(2, 3).ToString());
+        Assert.AreEqual("(2,3)", new DocumentPosition(2, 3).ToString());
     }
 }

--- a/tests/Hex1b.Tests/Documents/DocumentRangeTests.cs
+++ b/tests/Hex1b.Tests/Documents/DocumentRangeTests.cs
@@ -2,230 +2,229 @@ using Hex1b.Documents;
 
 namespace Hex1b.Tests.Documents;
 
+[TestClass]
 public class DocumentRangeTests
 {
-    [Fact]
+    [TestMethod]
     public void Constructor_ValidRange_Succeeds()
     {
         var range = new DocumentRange(new DocumentOffset(2), new DocumentOffset(5));
-        Assert.Equal(new DocumentOffset(2), range.Start);
-        Assert.Equal(new DocumentOffset(5), range.End);
+        Assert.AreEqual(new DocumentOffset(2), range.Start);
+        Assert.AreEqual(new DocumentOffset(5), range.End);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_EmptyRange_Succeeds()
     {
         var range = new DocumentRange(new DocumentOffset(3), new DocumentOffset(3));
-        Assert.Equal(new DocumentOffset(3), range.Start);
-        Assert.Equal(new DocumentOffset(3), range.End);
+        Assert.AreEqual(new DocumentOffset(3), range.Start);
+        Assert.AreEqual(new DocumentOffset(3), range.End);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_EndBeforeStart_Throws()
     {
-        Assert.Throws<ArgumentException>(() =>
+        Assert.ThrowsExactly<ArgumentException>(() =>
             new DocumentRange(new DocumentOffset(5), new DocumentOffset(3)));
     }
 
     // --- Properties ---
 
-    [Fact]
+    [TestMethod]
     public void Length_ReturnsCorrectLength()
     {
         var range = new DocumentRange(new DocumentOffset(2), new DocumentOffset(7));
-        Assert.Equal(5, range.Length);
+        Assert.AreEqual(5, range.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void Length_EmptyRange_ReturnsZero()
     {
         var range = new DocumentRange(new DocumentOffset(3), new DocumentOffset(3));
-        Assert.Equal(0, range.Length);
+        Assert.AreEqual(0, range.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsEmpty_EmptyRange_ReturnsTrue()
     {
         var range = new DocumentRange(new DocumentOffset(3), new DocumentOffset(3));
-        Assert.True(range.IsEmpty);
+        Assert.IsTrue(range.IsEmpty);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsEmpty_NonEmptyRange_ReturnsFalse()
     {
         var range = new DocumentRange(new DocumentOffset(3), new DocumentOffset(4));
-        Assert.False(range.IsEmpty);
+        Assert.IsFalse(range.IsEmpty);
     }
 
     // --- Contains ---
 
-    [Fact]
+    [TestMethod]
     public void Contains_OffsetInside_ReturnsTrue()
     {
         var range = new DocumentRange(new DocumentOffset(2), new DocumentOffset(5));
-        Assert.True(range.Contains(new DocumentOffset(3)));
+        Assert.IsTrue(range.Contains(new DocumentOffset(3)));
     }
 
-    [Fact]
+    [TestMethod]
     public void Contains_OffsetAtStart_ReturnsTrue()
     {
         var range = new DocumentRange(new DocumentOffset(2), new DocumentOffset(5));
-        Assert.True(range.Contains(new DocumentOffset(2)));
+        Assert.IsTrue(range.Contains(new DocumentOffset(2)));
     }
 
-    [Fact]
+    [TestMethod]
     public void Contains_OffsetAtEnd_ReturnsFalse()
     {
         // Ranges are [start, end) — exclusive end
         var range = new DocumentRange(new DocumentOffset(2), new DocumentOffset(5));
-        Assert.False(range.Contains(new DocumentOffset(5)));
+        Assert.IsFalse(range.Contains(new DocumentOffset(5)));
     }
 
-    [Fact]
+    [TestMethod]
     public void Contains_OffsetBefore_ReturnsFalse()
     {
         var range = new DocumentRange(new DocumentOffset(2), new DocumentOffset(5));
-        Assert.False(range.Contains(new DocumentOffset(1)));
+        Assert.IsFalse(range.Contains(new DocumentOffset(1)));
     }
 
-    [Fact]
+    [TestMethod]
     public void Contains_OffsetAfter_ReturnsFalse()
     {
         var range = new DocumentRange(new DocumentOffset(2), new DocumentOffset(5));
-        Assert.False(range.Contains(new DocumentOffset(6)));
+        Assert.IsFalse(range.Contains(new DocumentOffset(6)));
     }
 
-    [Fact]
+    [TestMethod]
     public void Contains_EmptyRange_NeverContains()
     {
         var range = new DocumentRange(new DocumentOffset(3), new DocumentOffset(3));
-        Assert.False(range.Contains(new DocumentOffset(3)));
+        Assert.IsFalse(range.Contains(new DocumentOffset(3)));
     }
 
     // --- Overlaps ---
 
-    [Fact]
+    [TestMethod]
     public void Overlaps_PartialOverlap_ReturnsTrue()
     {
         var a = new DocumentRange(new DocumentOffset(2), new DocumentOffset(5));
         var b = new DocumentRange(new DocumentOffset(4), new DocumentOffset(7));
-        Assert.True(a.Overlaps(b));
-        Assert.True(b.Overlaps(a)); // Symmetric
+        Assert.IsTrue(a.Overlaps(b));
+        Assert.IsTrue(b.Overlaps(a)); // Symmetric
     }
 
-    [Fact]
+    [TestMethod]
     public void Overlaps_FullyContained_ReturnsTrue()
     {
         var outer = new DocumentRange(new DocumentOffset(1), new DocumentOffset(10));
         var inner = new DocumentRange(new DocumentOffset(3), new DocumentOffset(5));
-        Assert.True(outer.Overlaps(inner));
-        Assert.True(inner.Overlaps(outer));
+        Assert.IsTrue(outer.Overlaps(inner));
+        Assert.IsTrue(inner.Overlaps(outer));
     }
 
-    [Fact]
+    [TestMethod]
     public void Overlaps_Adjacent_ReturnsFalse()
     {
         // [2,5) and [5,8) — they share boundary but no overlapping character
         var a = new DocumentRange(new DocumentOffset(2), new DocumentOffset(5));
         var b = new DocumentRange(new DocumentOffset(5), new DocumentOffset(8));
-        Assert.False(a.Overlaps(b));
-        Assert.False(b.Overlaps(a));
+        Assert.IsFalse(a.Overlaps(b));
+        Assert.IsFalse(b.Overlaps(a));
     }
 
-    [Fact]
+    [TestMethod]
     public void Overlaps_Disjoint_ReturnsFalse()
     {
         var a = new DocumentRange(new DocumentOffset(1), new DocumentOffset(3));
         var b = new DocumentRange(new DocumentOffset(5), new DocumentOffset(8));
-        Assert.False(a.Overlaps(b));
+        Assert.IsFalse(a.Overlaps(b));
     }
 
-    [Fact]
+    [TestMethod]
     public void Overlaps_EmptyRange_ReturnsFalse()
     {
         var a = new DocumentRange(new DocumentOffset(3), new DocumentOffset(3));
         var b = new DocumentRange(new DocumentOffset(2), new DocumentOffset(5));
-        Assert.False(a.Overlaps(b));
+        Assert.IsFalse(a.Overlaps(b));
     }
 
-    [Fact]
+    [TestMethod]
     public void Overlaps_BothEmpty_ReturnsFalse()
     {
         var a = new DocumentRange(new DocumentOffset(3), new DocumentOffset(3));
         var b = new DocumentRange(new DocumentOffset(3), new DocumentOffset(3));
-        Assert.False(a.Overlaps(b));
+        Assert.IsFalse(a.Overlaps(b));
     }
 
     // --- Equality ---
 
-    [Fact]
+    [TestMethod]
     public void Equals_SameValues_ReturnsTrue()
     {
         var a = new DocumentRange(new DocumentOffset(2), new DocumentOffset(5));
         var b = new DocumentRange(new DocumentOffset(2), new DocumentOffset(5));
-        Assert.True(a.Equals(b));
+        Assert.IsTrue(a.Equals(b));
     }
 
-    [Fact]
+    [TestMethod]
     public void Equals_DifferentStart_ReturnsFalse()
     {
         var a = new DocumentRange(new DocumentOffset(2), new DocumentOffset(5));
         var b = new DocumentRange(new DocumentOffset(3), new DocumentOffset(5));
-        Assert.False(a.Equals(b));
+        Assert.IsFalse(a.Equals(b));
     }
 
-    [Fact]
+    [TestMethod]
     public void Equals_DifferentEnd_ReturnsFalse()
     {
         var a = new DocumentRange(new DocumentOffset(2), new DocumentOffset(5));
         var b = new DocumentRange(new DocumentOffset(2), new DocumentOffset(6));
-        Assert.False(a.Equals(b));
+        Assert.IsFalse(a.Equals(b));
     }
 
-    [Fact]
+    [TestMethod]
     public void Equals_BoxedDifferentType_ReturnsFalse()
     {
         var range = new DocumentRange(new DocumentOffset(2), new DocumentOffset(5));
-        Assert.False(range.Equals("not a range"));
+        Assert.IsFalse(range.Equals("not a range"));
     }
 
-    [Fact]
+    [TestMethod]
     public void Equals_Null_ReturnsFalse()
     {
         var range = new DocumentRange(new DocumentOffset(2), new DocumentOffset(5));
-        Assert.False(range.Equals(null));
+        Assert.IsFalse(range.Equals(null));
     }
 
-    [Fact]
+    [TestMethod]
     public void OperatorEquals_SameValues_ReturnsTrue()
     {
-        Assert.True(
-            new DocumentRange(new DocumentOffset(2), new DocumentOffset(5)) ==
+        Assert.IsTrue(new DocumentRange(new DocumentOffset(2), new DocumentOffset(5)) ==
             new DocumentRange(new DocumentOffset(2), new DocumentOffset(5)));
     }
 
-    [Fact]
+    [TestMethod]
     public void OperatorNotEquals_DifferentValues_ReturnsTrue()
     {
-        Assert.True(
-            new DocumentRange(new DocumentOffset(2), new DocumentOffset(5)) !=
+        Assert.IsTrue(new DocumentRange(new DocumentOffset(2), new DocumentOffset(5)) !=
             new DocumentRange(new DocumentOffset(2), new DocumentOffset(6)));
     }
 
     // --- GetHashCode / ToString ---
 
-    [Fact]
+    [TestMethod]
     public void GetHashCode_SameValues_SameHash()
     {
         var a = new DocumentRange(new DocumentOffset(2), new DocumentOffset(5));
         var b = new DocumentRange(new DocumentOffset(2), new DocumentOffset(5));
-        Assert.Equal(a.GetHashCode(), b.GetHashCode());
+        Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
     }
 
-    [Fact]
+    [TestMethod]
     public void ToString_FormatsCorrectly()
     {
         var range = new DocumentRange(new DocumentOffset(2), new DocumentOffset(5));
-        Assert.Equal("[2..5)", range.ToString());
+        Assert.AreEqual("[2..5)", range.ToString());
     }
 }

--- a/tests/Hex1b.Tests/Documents/EditHistoryTests.cs
+++ b/tests/Hex1b.Tests/Documents/EditHistoryTests.cs
@@ -7,6 +7,7 @@ namespace Hex1b.Tests.Documents;
 /// NOTE: Coalescing timeout tests use the default CoalesceTimeoutMs (1000ms).
 /// These tests may need updates if coalescing behavior changes.
 /// </summary>
+[TestClass]
 public class EditHistoryTests
 {
     private static CursorSet MakeCursors(params int[] positions)
@@ -22,7 +23,7 @@ public class EditHistoryTests
 
     // ── Basic record/undo/redo ──────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void RecordEdit_PushesToUndoStack()
     {
         var history = new EditHistory();
@@ -33,11 +34,11 @@ public class EditHistoryTests
             new DeleteOperation(new DocumentRange(new DocumentOffset(0), new DocumentOffset(1))),
             cursors, 0, 1);
 
-        Assert.True(history.CanUndo);
-        Assert.Equal(1, history.UndoCount);
+        Assert.IsTrue(history.CanUndo);
+        Assert.AreEqual(1, history.UndoCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void Undo_ReturnsGroup_ClearsFromUndoStack()
     {
         var history = new EditHistory();
@@ -50,13 +51,13 @@ public class EditHistoryTests
 
         var group = history.Undo();
 
-        Assert.NotNull(group);
-        Assert.Single(group!.Operations);
-        Assert.False(history.CanUndo);
-        Assert.True(history.CanRedo);
+        Assert.IsNotNull(group);
+        TestSeq.Single(group!.Operations);
+        Assert.IsFalse(history.CanUndo);
+        Assert.IsTrue(history.CanRedo);
     }
 
-    [Fact]
+    [TestMethod]
     public void Redo_ReturnsGroup()
     {
         var history = new EditHistory();
@@ -70,13 +71,13 @@ public class EditHistoryTests
         history.Undo();
         var group = history.Redo();
 
-        Assert.NotNull(group);
-        Assert.Single(group!.Operations);
-        Assert.True(history.CanUndo);
-        Assert.False(history.CanRedo);
+        Assert.IsNotNull(group);
+        TestSeq.Single(group!.Operations);
+        Assert.IsTrue(history.CanUndo);
+        Assert.IsFalse(history.CanRedo);
     }
 
-    [Fact]
+    [TestMethod]
     public void NewEdit_ClearsRedoStack()
     {
         var history = new EditHistory();
@@ -88,33 +89,33 @@ public class EditHistoryTests
             cursors, 0, 1);
 
         history.Undo();
-        Assert.True(history.CanRedo);
+        Assert.IsTrue(history.CanRedo);
 
         history.RecordEdit(
             new InsertOperation(new DocumentOffset(0), "b"),
             new DeleteOperation(new DocumentRange(new DocumentOffset(0), new DocumentOffset(1))),
             cursors, 1, 2);
 
-        Assert.False(history.CanRedo);
+        Assert.IsFalse(history.CanRedo);
     }
 
-    [Fact]
+    [TestMethod]
     public void Undo_ReturnsNull_WhenEmpty()
     {
         var history = new EditHistory();
-        Assert.Null(history.Undo());
+        Assert.IsNull(history.Undo());
     }
 
-    [Fact]
+    [TestMethod]
     public void Redo_ReturnsNull_WhenEmpty()
     {
         var history = new EditHistory();
-        Assert.Null(history.Redo());
+        Assert.IsNull(history.Redo());
     }
 
     // ── Cursor snapshots ────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void UndoGroup_HasCursorsBefore()
     {
         var history = new EditHistory();
@@ -126,11 +127,11 @@ public class EditHistoryTests
             cursors, 0, 1);
 
         var group = history.Undo();
-        Assert.NotNull(group);
-        Assert.Equal(5, group!.CursorsBefore.Entries[0].Position.Value);
+        Assert.IsNotNull(group);
+        Assert.AreEqual(5, group!.CursorsBefore.Entries[0].Position.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void UndoGroup_HasCursorsAfter()
     {
         var history = new EditHistory();
@@ -143,12 +144,12 @@ public class EditHistoryTests
 
         // cursors snapshot captures current state at recording time
         var group = history.Undo();
-        Assert.NotNull(group!.CursorsAfter);
+        Assert.IsNotNull(group!.CursorsAfter);
     }
 
     // ── Explicit grouping ───────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void ExplicitGroup_CollectsMultipleOps()
     {
         var history = new EditHistory();
@@ -165,13 +166,13 @@ public class EditHistoryTests
             cursors, 1, 2);
         history.CommitGroup(cursors, 2);
 
-        Assert.Equal(1, history.UndoCount);
+        Assert.AreEqual(1, history.UndoCount);
         var group = history.Undo();
-        Assert.Equal(2, group!.Operations.Count);
-        Assert.Equal(2, group.InverseOperations.Count);
+        Assert.AreEqual(2, group!.Operations.Count);
+        Assert.AreEqual(2, group.InverseOperations.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExplicitGroup_Nested_OnlyOuterCommits()
     {
         var history = new EditHistory();
@@ -186,13 +187,13 @@ public class EditHistoryTests
             cursors, 0, 1);
 
         history.CommitGroup(cursors, 1); // Inner commit — no push yet
-        Assert.Equal(0, history.UndoCount); // Not committed yet
+        Assert.AreEqual(0, history.UndoCount); // Not committed yet
 
         history.CommitGroup(cursors, 1); // Outer commit
-        Assert.Equal(1, history.UndoCount);
+        Assert.AreEqual(1, history.UndoCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void CancelGroup_DropsOperations()
     {
         var history = new EditHistory();
@@ -205,12 +206,12 @@ public class EditHistoryTests
             cursors, 0, 1);
         history.CancelGroup();
 
-        Assert.False(history.CanUndo);
+        Assert.IsFalse(history.CanUndo);
     }
 
     // ── Typing coalescing ───────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void Coalescing_MergesAdjacentSingleCharInserts()
     {
         var history = new EditHistory();
@@ -233,12 +234,12 @@ public class EditHistoryTests
             cursors, 2, 3, coalescable: true);
 
         // All three should be in one group
-        Assert.Equal(1, history.UndoCount);
+        Assert.AreEqual(1, history.UndoCount);
         var group = history.Undo();
-        Assert.Equal(3, group!.Operations.Count);
+        Assert.AreEqual(3, group!.Operations.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Coalescing_DoesNotMerge_NonAdjacentInserts()
     {
         var history = new EditHistory();
@@ -255,10 +256,10 @@ public class EditHistoryTests
             new DeleteOperation(new DocumentRange(new DocumentOffset(5), new DocumentOffset(6))),
             cursors, 1, 2, coalescable: true);
 
-        Assert.Equal(2, history.UndoCount);
+        Assert.AreEqual(2, history.UndoCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void Coalescing_DoesNotMerge_MultiCharInserts()
     {
         var history = new EditHistory();
@@ -275,10 +276,10 @@ public class EditHistoryTests
             cursors, 1, 2, coalescable: true);
 
         // Multi-char insert doesn't coalesce (first op has text.Length > 1)
-        Assert.Equal(2, history.UndoCount);
+        Assert.AreEqual(2, history.UndoCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void Coalescing_DoesNotMerge_NonCoalescable()
     {
         var history = new EditHistory();
@@ -295,12 +296,12 @@ public class EditHistoryTests
             new DeleteOperation(new DocumentRange(new DocumentOffset(1), new DocumentOffset(2))),
             cursors, 1, 2, coalescable: false);
 
-        Assert.Equal(2, history.UndoCount);
+        Assert.AreEqual(2, history.UndoCount);
     }
 
     // ── Clear ───────────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void Clear_RemovesAllHistory()
     {
         var history = new EditHistory();
@@ -314,15 +315,15 @@ public class EditHistoryTests
         history.Undo();
         history.Clear();
 
-        Assert.False(history.CanUndo);
-        Assert.False(history.CanRedo);
-        Assert.Equal(0, history.UndoCount);
-        Assert.Equal(0, history.RedoCount);
+        Assert.IsFalse(history.CanUndo);
+        Assert.IsFalse(history.CanRedo);
+        Assert.AreEqual(0, history.UndoCount);
+        Assert.AreEqual(0, history.RedoCount);
     }
 
     // ── GetGroupsSince ──────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void GetGroupsSince_ReturnsGroupsAfterVersion()
     {
         var history = new EditHistory();
@@ -339,15 +340,15 @@ public class EditHistoryTests
             cursors, 1, 2, coalescable: false);
 
         var since = history.GetGroupsSince(0);
-        Assert.Equal(2, since.Count);
+        Assert.AreEqual(2, since.Count);
 
         var sinceLast = history.GetGroupsSince(1);
-        Assert.Single(sinceLast);
+        TestSeq.Single(sinceLast);
     }
 
     // ── InverseOperations order ─────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void InverseOperations_AreInReverseOrder()
     {
         var history = new EditHistory();
@@ -367,17 +368,17 @@ public class EditHistoryTests
         var group = history.Undo()!;
 
         // Inverse should be in reverse: delete "b" first, then delete "a"
-        Assert.IsType<DeleteOperation>(group.InverseOperations[0]);
-        Assert.IsType<DeleteOperation>(group.InverseOperations[1]);
+        TestSeq.IsType<DeleteOperation>(group.InverseOperations[0]);
+        TestSeq.IsType<DeleteOperation>(group.InverseOperations[1]);
         var delB = (DeleteOperation)group.InverseOperations[0];
         var delA = (DeleteOperation)group.InverseOperations[1];
-        Assert.Equal(1, delB.Range.Start.Value);
-        Assert.Equal(0, delA.Range.Start.Value);
+        Assert.AreEqual(1, delB.Range.Start.Value);
+        Assert.AreEqual(0, delA.Range.Start.Value);
     }
 
     // ── Multiple undo/redo cycles ───────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void MultipleUndoRedo_MaintainsCorrectState()
     {
         var history = new EditHistory();
@@ -391,22 +392,22 @@ public class EditHistoryTests
                 cursors, i, i + 1, coalescable: false);
         }
 
-        Assert.Equal(5, history.UndoCount);
+        Assert.AreEqual(5, history.UndoCount);
 
         // Undo all
         for (var i = 0; i < 5; i++)
         {
-            Assert.NotNull(history.Undo());
+            Assert.IsNotNull(history.Undo());
         }
-        Assert.Equal(0, history.UndoCount);
-        Assert.Equal(5, history.RedoCount);
+        Assert.AreEqual(0, history.UndoCount);
+        Assert.AreEqual(5, history.RedoCount);
 
         // Redo all
         for (var i = 0; i < 5; i++)
         {
-            Assert.NotNull(history.Redo());
+            Assert.IsNotNull(history.Redo());
         }
-        Assert.Equal(5, history.UndoCount);
-        Assert.Equal(0, history.RedoCount);
+        Assert.AreEqual(5, history.UndoCount);
+        Assert.AreEqual(0, history.RedoCount);
     }
 }

--- a/tests/Hex1b.Tests/Documents/EditOperationTests.cs
+++ b/tests/Hex1b.Tests/Documents/EditOperationTests.cs
@@ -2,41 +2,42 @@ using Hex1b.Documents;
 
 namespace Hex1b.Tests.Documents;
 
+[TestClass]
 public class EditOperationTests
 {
-    [Fact]
+    [TestMethod]
     public void InsertOperation_Invert_ReturnsDelete()
     {
         var insert = new InsertOperation(new DocumentOffset(5), "Hello");
         var inverse = insert.Invert("");
-        Assert.IsType<DeleteOperation>(inverse);
+        TestSeq.IsType<DeleteOperation>(inverse);
         var delete = (DeleteOperation)inverse;
-        Assert.Equal(new DocumentOffset(5), delete.Range.Start);
-        Assert.Equal(new DocumentOffset(10), delete.Range.End);
+        Assert.AreEqual(new DocumentOffset(5), delete.Range.Start);
+        Assert.AreEqual(new DocumentOffset(10), delete.Range.End);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteOperation_Invert_ReturnsInsert()
     {
         var delete = new DeleteOperation(new DocumentRange(new DocumentOffset(5), new DocumentOffset(10)));
         var inverse = delete.Invert("Hello");
-        Assert.IsType<InsertOperation>(inverse);
+        TestSeq.IsType<InsertOperation>(inverse);
         var insert = (InsertOperation)inverse;
-        Assert.Equal(new DocumentOffset(5), insert.Offset);
-        Assert.Equal("Hello", insert.Text);
+        Assert.AreEqual(new DocumentOffset(5), insert.Offset);
+        Assert.AreEqual("Hello", insert.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void ReplaceOperation_Invert_ReturnsReplace()
     {
         var replace = new ReplaceOperation(
             new DocumentRange(new DocumentOffset(5), new DocumentOffset(10)),
             "World");
         var inverse = replace.Invert("Hello");
-        Assert.IsType<ReplaceOperation>(inverse);
+        TestSeq.IsType<ReplaceOperation>(inverse);
         var inv = (ReplaceOperation)inverse;
-        Assert.Equal(new DocumentOffset(5), inv.Range.Start);
-        Assert.Equal(new DocumentOffset(10), inv.Range.End); // 5 + "World".Length
-        Assert.Equal("Hello", inv.NewText);
+        Assert.AreEqual(new DocumentOffset(5), inv.Range.Start);
+        Assert.AreEqual(new DocumentOffset(10), inv.Range.End); // 5 + "World".Length
+        Assert.AreEqual("Hello", inv.NewText);
     }
 }

--- a/tests/Hex1b.Tests/Documents/Hex1bDocumentTests.cs
+++ b/tests/Hex1b.Tests/Documents/Hex1bDocumentTests.cs
@@ -2,187 +2,188 @@ using Hex1b.Documents;
 
 namespace Hex1b.Tests.Documents;
 
+[TestClass]
 public class Hex1bDocumentTests
 {
-    [Fact]
+    [TestMethod]
     public void Constructor_EmptyString_HasLengthZero()
     {
         var doc = new Hex1bDocument();
-        Assert.Equal(0, doc.Length);
-        Assert.Equal(1, doc.LineCount);
-        Assert.Equal(0, doc.Version);
+        Assert.AreEqual(0, doc.Length);
+        Assert.AreEqual(1, doc.LineCount);
+        Assert.AreEqual(0, doc.Version);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_WithText_HasCorrectLength()
     {
         var doc = new Hex1bDocument("Hello");
-        Assert.Equal(5, doc.Length);
-        Assert.Equal(1, doc.LineCount);
+        Assert.AreEqual(5, doc.Length);
+        Assert.AreEqual(1, doc.LineCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_WithMultipleLines_HasCorrectLineCount()
     {
         var doc = new Hex1bDocument("Line 1\nLine 2\nLine 3");
-        Assert.Equal(3, doc.LineCount);
+        Assert.AreEqual(3, doc.LineCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetText_ReturnsFullText()
     {
         var doc = new Hex1bDocument("Hello world");
-        Assert.Equal("Hello world", doc.GetText());
+        Assert.AreEqual("Hello world", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void GetText_WithRange_ReturnsSubstring()
     {
         var doc = new Hex1bDocument("Hello world");
         var range = new DocumentRange(new DocumentOffset(6), new DocumentOffset(11));
-        Assert.Equal("world", doc.GetText(range));
+        Assert.AreEqual("world", doc.GetText(range));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetLineText_ReturnsCorrectLine()
     {
         var doc = new Hex1bDocument("Line 1\nLine 2\nLine 3");
-        Assert.Equal("Line 1", doc.GetLineText(1));
-        Assert.Equal("Line 2", doc.GetLineText(2));
-        Assert.Equal("Line 3", doc.GetLineText(3));
+        Assert.AreEqual("Line 1", doc.GetLineText(1));
+        Assert.AreEqual("Line 2", doc.GetLineText(2));
+        Assert.AreEqual("Line 3", doc.GetLineText(3));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetLineLength_ReturnsCorrectLength()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
-        Assert.Equal(5, doc.GetLineLength(1));
-        Assert.Equal(5, doc.GetLineLength(2));
+        Assert.AreEqual(5, doc.GetLineLength(1));
+        Assert.AreEqual(5, doc.GetLineLength(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void OffsetToPosition_ConvertsCorrectly()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
-        Assert.Equal(new DocumentPosition(1, 1), doc.OffsetToPosition(new DocumentOffset(0)));
-        Assert.Equal(new DocumentPosition(1, 6), doc.OffsetToPosition(new DocumentOffset(5)));
-        Assert.Equal(new DocumentPosition(2, 1), doc.OffsetToPosition(new DocumentOffset(6)));
-        Assert.Equal(new DocumentPosition(2, 3), doc.OffsetToPosition(new DocumentOffset(8)));
+        Assert.AreEqual(new DocumentPosition(1, 1), doc.OffsetToPosition(new DocumentOffset(0)));
+        Assert.AreEqual(new DocumentPosition(1, 6), doc.OffsetToPosition(new DocumentOffset(5)));
+        Assert.AreEqual(new DocumentPosition(2, 1), doc.OffsetToPosition(new DocumentOffset(6)));
+        Assert.AreEqual(new DocumentPosition(2, 3), doc.OffsetToPosition(new DocumentOffset(8)));
     }
 
-    [Fact]
+    [TestMethod]
     public void PositionToOffset_ConvertsCorrectly()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
-        Assert.Equal(new DocumentOffset(0), doc.PositionToOffset(new DocumentPosition(1, 1)));
-        Assert.Equal(new DocumentOffset(6), doc.PositionToOffset(new DocumentPosition(2, 1)));
-        Assert.Equal(new DocumentOffset(8), doc.PositionToOffset(new DocumentPosition(2, 3)));
+        Assert.AreEqual(new DocumentOffset(0), doc.PositionToOffset(new DocumentPosition(1, 1)));
+        Assert.AreEqual(new DocumentOffset(6), doc.PositionToOffset(new DocumentPosition(2, 1)));
+        Assert.AreEqual(new DocumentOffset(8), doc.PositionToOffset(new DocumentPosition(2, 3)));
     }
 
-    [Fact]
+    [TestMethod]
     public void Apply_Insert_AddsText()
     {
         var doc = new Hex1bDocument("Hello");
         doc.Apply(new InsertOperation(new DocumentOffset(5), " world"));
-        Assert.Equal("Hello world", doc.GetText());
-        Assert.Equal(11, doc.Length);
+        Assert.AreEqual("Hello world", doc.GetText());
+        Assert.AreEqual(11, doc.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void Apply_InsertAtBeginning_PrependsText()
     {
         var doc = new Hex1bDocument("world");
         doc.Apply(new InsertOperation(new DocumentOffset(0), "Hello "));
-        Assert.Equal("Hello world", doc.GetText());
+        Assert.AreEqual("Hello world", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Apply_InsertInMiddle_SplitsPiece()
     {
         var doc = new Hex1bDocument("Helloworld");
         doc.Apply(new InsertOperation(new DocumentOffset(5), " "));
-        Assert.Equal("Hello world", doc.GetText());
+        Assert.AreEqual("Hello world", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Apply_Delete_RemovesText()
     {
         var doc = new Hex1bDocument("Hello world");
         doc.Apply(new DeleteOperation(new DocumentRange(new DocumentOffset(5), new DocumentOffset(11))));
-        Assert.Equal("Hello", doc.GetText());
-        Assert.Equal(5, doc.Length);
+        Assert.AreEqual("Hello", doc.GetText());
+        Assert.AreEqual(5, doc.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void Apply_Replace_ReplacesText()
     {
         var doc = new Hex1bDocument("Hello world");
         doc.Apply(new ReplaceOperation(
             new DocumentRange(new DocumentOffset(6), new DocumentOffset(11)),
             "earth"));
-        Assert.Equal("Hello earth", doc.GetText());
+        Assert.AreEqual("Hello earth", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Apply_IncrementsVersion()
     {
         var doc = new Hex1bDocument("Hello");
-        Assert.Equal(0, doc.Version);
+        Assert.AreEqual(0, doc.Version);
         doc.Apply(new InsertOperation(new DocumentOffset(5), "!"));
-        Assert.Equal(1, doc.Version);
+        Assert.AreEqual(1, doc.Version);
         doc.Apply(new InsertOperation(new DocumentOffset(6), "!"));
-        Assert.Equal(2, doc.Version);
+        Assert.AreEqual(2, doc.Version);
     }
 
-    [Fact]
+    [TestMethod]
     public void Apply_ReturnsEditResult()
     {
         var doc = new Hex1bDocument("Hello");
         var result = doc.Apply(new InsertOperation(new DocumentOffset(5), " world"));
-        Assert.Equal(0, result.PreviousVersion);
-        Assert.Equal(1, result.NewVersion);
-        Assert.Single(result.Applied);
-        Assert.Single(result.Inverse);
+        Assert.AreEqual(0, result.PreviousVersion);
+        Assert.AreEqual(1, result.NewVersion);
+        TestSeq.Single(result.Applied);
+        TestSeq.Single(result.Inverse);
     }
 
-    [Fact]
+    [TestMethod]
     public void Apply_InverseUndoesInsert()
     {
         var doc = new Hex1bDocument("Hello");
         var result = doc.Apply(new InsertOperation(new DocumentOffset(5), " world"));
-        Assert.Equal("Hello world", doc.GetText());
+        Assert.AreEqual("Hello world", doc.GetText());
 
         // Apply inverse should undo
         doc.Apply(result.Inverse);
-        Assert.Equal("Hello", doc.GetText());
+        Assert.AreEqual("Hello", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Apply_InverseUndoesDelete()
     {
         var doc = new Hex1bDocument("Hello world");
         var result = doc.Apply(new DeleteOperation(
             new DocumentRange(new DocumentOffset(5), new DocumentOffset(11))));
-        Assert.Equal("Hello", doc.GetText());
+        Assert.AreEqual("Hello", doc.GetText());
 
         doc.Apply(result.Inverse);
-        Assert.Equal("Hello world", doc.GetText());
+        Assert.AreEqual("Hello world", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Apply_InverseUndoesReplace()
     {
         var doc = new Hex1bDocument("Hello world");
         var result = doc.Apply(new ReplaceOperation(
             new DocumentRange(new DocumentOffset(6), new DocumentOffset(11)),
             "earth"));
-        Assert.Equal("Hello earth", doc.GetText());
+        Assert.AreEqual("Hello earth", doc.GetText());
 
         doc.Apply(result.Inverse);
-        Assert.Equal("Hello world", doc.GetText());
+        Assert.AreEqual("Hello world", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Changed_FiresOnEdit()
     {
         var doc = new Hex1bDocument("Hello");
@@ -191,12 +192,12 @@ public class Hex1bDocumentTests
 
         doc.Apply(new InsertOperation(new DocumentOffset(5), "!"));
 
-        Assert.NotNull(lastEvent);
-        Assert.Equal(1, lastEvent.Version);
-        Assert.Equal(0, lastEvent.PreviousVersion);
+        Assert.IsNotNull(lastEvent);
+        Assert.AreEqual(1, lastEvent.Version);
+        Assert.AreEqual(0, lastEvent.PreviousVersion);
     }
 
-    [Fact]
+    [TestMethod]
     public void Changed_CarriesSourceTag()
     {
         var doc = new Hex1bDocument("Hello");
@@ -205,10 +206,10 @@ public class Hex1bDocumentTests
 
         doc.Apply(new InsertOperation(new DocumentOffset(5), "!"), source: "test-agent");
 
-        Assert.Equal("test-agent", receivedSource);
+        Assert.AreEqual("test-agent", receivedSource);
     }
 
-    [Fact]
+    [TestMethod]
     public void Apply_MultipleOperations_Atomic()
     {
         var doc = new Hex1bDocument("Hello world");
@@ -216,106 +217,106 @@ public class Hex1bDocumentTests
             new DeleteOperation(new DocumentRange(new DocumentOffset(5), new DocumentOffset(6))),
             new InsertOperation(new DocumentOffset(5), "_"),
         ]);
-        Assert.Equal("Hello_world", doc.GetText());
-        Assert.Equal(2, result.Applied.Count);
-        Assert.Equal(1, result.NewVersion); // single version bump
+        Assert.AreEqual("Hello_world", doc.GetText());
+        Assert.AreEqual(2, result.Applied.Count);
+        Assert.AreEqual(1, result.NewVersion); // single version bump
     }
 
-    [Fact]
+    [TestMethod]
     public void Insert_UpdatesLineCount()
     {
         var doc = new Hex1bDocument("Hello");
-        Assert.Equal(1, doc.LineCount);
+        Assert.AreEqual(1, doc.LineCount);
 
         doc.Apply(new InsertOperation(new DocumentOffset(5), "\nWorld"));
-        Assert.Equal(2, doc.LineCount);
-        Assert.Equal("Hello", doc.GetLineText(1));
-        Assert.Equal("World", doc.GetLineText(2));
+        Assert.AreEqual(2, doc.LineCount);
+        Assert.AreEqual("Hello", doc.GetLineText(1));
+        Assert.AreEqual("World", doc.GetLineText(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void Delete_UpdatesLineCount()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
-        Assert.Equal(2, doc.LineCount);
+        Assert.AreEqual(2, doc.LineCount);
 
         // Delete the newline
         doc.Apply(new DeleteOperation(new DocumentRange(new DocumentOffset(5), new DocumentOffset(6))));
-        Assert.Equal(1, doc.LineCount);
-        Assert.Equal("HelloWorld", doc.GetText());
+        Assert.AreEqual(1, doc.LineCount);
+        Assert.AreEqual("HelloWorld", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void MultipleEdits_MaintainConsistency()
     {
         var doc = new Hex1bDocument("abc");
 
         doc.Apply(new InsertOperation(new DocumentOffset(1), "X"));
-        Assert.Equal("aXbc", doc.GetText());
+        Assert.AreEqual("aXbc", doc.GetText());
 
         doc.Apply(new InsertOperation(new DocumentOffset(3), "Y"));
-        Assert.Equal("aXbYc", doc.GetText());
+        Assert.AreEqual("aXbYc", doc.GetText());
 
         doc.Apply(new DeleteOperation(new DocumentRange(new DocumentOffset(0), new DocumentOffset(1))));
-        Assert.Equal("XbYc", doc.GetText());
+        Assert.AreEqual("XbYc", doc.GetText());
 
-        Assert.Equal(4, doc.Length);
-        Assert.Equal(3, doc.Version);
+        Assert.AreEqual(4, doc.Length);
+        Assert.AreEqual(3, doc.Version);
     }
 
-    [Fact]
+    [TestMethod]
     public void EmptyDocument_HasOneLine()
     {
         var doc = new Hex1bDocument("");
-        Assert.Equal(1, doc.LineCount);
-        Assert.Equal("", doc.GetLineText(1));
+        Assert.AreEqual(1, doc.LineCount);
+        Assert.AreEqual("", doc.GetLineText(1));
     }
 
     // ── Byte API ────────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void ByteCount_AsciiText_EqualsByteLength()
     {
         var doc = new Hex1bDocument("Hello");
-        Assert.Equal(5, doc.ByteCount);
+        Assert.AreEqual(5, doc.ByteCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void ByteCount_MultiByte_ExceedsCharLength()
     {
         // © = C2 A9 (2 bytes), Length=1
         var doc = new Hex1bDocument("©");
-        Assert.Equal(1, doc.Length);
-        Assert.Equal(2, doc.ByteCount);
+        Assert.AreEqual(1, doc.Length);
+        Assert.AreEqual(2, doc.ByteCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetBytes_ReturnsUtf8Encoding()
     {
         var doc = new Hex1bDocument("AB");
         var bytes = doc.GetBytes().ToArray();
-        Assert.Equal(new byte[] { 0x41, 0x42 }, bytes);
+        TestSeq.AreEqual(new byte[] { 0x41, 0x42 }, bytes);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetBytes_Slice_ReturnsCorrectRange()
     {
         var doc = new Hex1bDocument("ABCD");
         var bytes = doc.GetBytes(1, 2).ToArray();
-        Assert.Equal(new byte[] { 0x42, 0x43 }, bytes);
+        TestSeq.AreEqual(new byte[] { 0x42, 0x43 }, bytes);
     }
 
-    [Fact]
+    [TestMethod]
     public void ByteConstructor_StoresRawBytes()
     {
         var raw = new byte[] { 0xAA, 0xBB, 0xCC };
         var doc = new Hex1bDocument(raw);
-        Assert.Equal(3, doc.ByteCount);
+        Assert.AreEqual(3, doc.ByteCount);
         var bytes = doc.GetBytes().ToArray();
-        Assert.Equal(raw, bytes);
+        TestSeq.AreEqual(raw, bytes);
     }
 
-    [Fact]
+    [TestMethod]
     public void ByteConstructor_InvalidUtf8_TextHasReplacementChars()
     {
         var raw = new byte[] { 0xAA, 0xBB };
@@ -323,10 +324,10 @@ public class Hex1bDocumentTests
         // Invalid UTF-8 bytes produce U+FFFD replacement characters
         Assert.Contains('\uFFFD', doc.GetText());
         // But raw bytes are preserved
-        Assert.Equal(raw, doc.GetBytes().ToArray());
+        TestSeq.AreEqual(raw, doc.GetBytes().ToArray());
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplyBytes_ReplaceSingleByte()
     {
         var doc = new Hex1bDocument("ABC");
@@ -334,35 +335,35 @@ public class Hex1bDocumentTests
         doc.ApplyBytes(new ByteReplaceOperation(1, 1, [0xAA]));
 
         var bytes = doc.GetBytes().ToArray();
-        Assert.Equal(3, bytes.Length);
-        Assert.Equal(0x41, bytes[0]); // 'A'
-        Assert.Equal(0xAA, bytes[1]); // replaced
-        Assert.Equal(0x43, bytes[2]); // 'C'
+        Assert.AreEqual(3, bytes.Length);
+        Assert.AreEqual(0x41, bytes[0]); // 'A'
+        Assert.AreEqual(0xAA, bytes[1]); // replaced
+        Assert.AreEqual(0x43, bytes[2]); // 'C'
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplyBytes_InsertBytes()
     {
         var doc = new Hex1bDocument("AC");
         doc.ApplyBytes(new ByteInsertOperation(1, [0xBB, 0xCC]));
 
         var bytes = doc.GetBytes().ToArray();
-        Assert.Equal(4, bytes.Length);
-        Assert.Equal(new byte[] { 0x41, 0xBB, 0xCC, 0x43 }, bytes);
+        Assert.AreEqual(4, bytes.Length);
+        TestSeq.AreEqual(new byte[] { 0x41, 0xBB, 0xCC, 0x43 }, bytes);
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplyBytes_DeleteBytes()
     {
         var doc = new Hex1bDocument("ABCD");
         doc.ApplyBytes(new ByteDeleteOperation(1, 2));
 
         var bytes = doc.GetBytes().ToArray();
-        Assert.Equal(new byte[] { 0x41, 0x44 }, bytes);
-        Assert.Equal("AD", doc.GetText());
+        TestSeq.AreEqual(new byte[] { 0x41, 0x44 }, bytes);
+        Assert.AreEqual("AD", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplyBytes_FiresChangedEvent()
     {
         var doc = new Hex1bDocument("AB");
@@ -370,90 +371,90 @@ public class Hex1bDocumentTests
         doc.Changed += (_, _) => fired = true;
 
         doc.ApplyBytes(new ByteReplaceOperation(0, 1, [0xFF]));
-        Assert.True(fired);
+        Assert.IsTrue(fired);
     }
 
-    [Fact]
+    [TestMethod]
     public void ApplyBytes_IncrementsVersion()
     {
         var doc = new Hex1bDocument("AB");
         var v1 = doc.Version;
         doc.ApplyBytes(new ByteReplaceOperation(0, 1, [0xFF]));
-        Assert.True(doc.Version > v1);
+        Assert.IsTrue(doc.Version > v1);
     }
 
-    [Fact]
+    [TestMethod]
     public void TextApi_WorksAfterByteEdit()
     {
         var doc = new Hex1bDocument("Hello");
         doc.ApplyBytes(new ByteReplaceOperation(0, 1, [0x4A])); // H → J
-        Assert.Equal("Jello", doc.GetText());
-        Assert.Equal(5, doc.Length);
-        Assert.Equal(1, doc.LineCount);
+        Assert.AreEqual("Jello", doc.GetText());
+        Assert.AreEqual(5, doc.Length);
+        Assert.AreEqual(1, doc.LineCount);
     }
 
     // ── Diagnostic info ─────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void GetDiagnosticInfo_NewDocument_ReturnsOnePiece()
     {
         var doc = new Hex1bDocument("Hello");
         var info = doc.GetDiagnosticInfo();
 
-        Assert.NotNull(info);
-        Assert.Equal(0, info.Version);
-        Assert.Equal(5, info.CharCount);
-        Assert.Equal(5, info.ByteCount);
-        Assert.Equal(1, info.LineCount);
-        Assert.Equal(5, info.OriginalBufferSize);
-        Assert.Equal(0, info.AddBufferSize);
-        Assert.Single(info.Pieces);
+        Assert.IsNotNull(info);
+        Assert.AreEqual(0, info.Version);
+        Assert.AreEqual(5, info.CharCount);
+        Assert.AreEqual(5, info.ByteCount);
+        Assert.AreEqual(1, info.LineCount);
+        Assert.AreEqual(5, info.OriginalBufferSize);
+        Assert.AreEqual(0, info.AddBufferSize);
+        TestSeq.Single(info.Pieces);
 
         var piece = info.Pieces[0];
-        Assert.Equal(0, piece.Index);
-        Assert.Equal("Original", piece.Source);
-        Assert.Equal(0, piece.Start);
-        Assert.Equal(5, piece.Length);
-        Assert.Equal("Hello", piece.PreviewText);
+        Assert.AreEqual(0, piece.Index);
+        Assert.AreEqual("Original", piece.Source);
+        Assert.AreEqual(0, piece.Start);
+        Assert.AreEqual(5, piece.Length);
+        Assert.AreEqual("Hello", piece.PreviewText);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetDiagnosticInfo_AfterEdit_ShowsMultiplePieces()
     {
         var doc = new Hex1bDocument("Hello World");
         doc.Apply(new InsertOperation(new DocumentOffset(5), " Beautiful"));
         var info = doc.GetDiagnosticInfo();
 
-        Assert.NotNull(info);
-        Assert.Equal(1, info.Version);
-        Assert.True(info.Pieces.Count > 1, "Should have multiple pieces after edit");
-        Assert.True(info.AddBufferSize > 0, "Add buffer should have content after insert");
+        Assert.IsNotNull(info);
+        Assert.AreEqual(1, info.Version);
+        Assert.IsTrue(info.Pieces.Count > 1, "Should have multiple pieces after edit");
+        Assert.IsTrue(info.AddBufferSize > 0, "Add buffer should have content after insert");
 
         // At least one piece should be from the Added buffer
-        Assert.Contains(info.Pieces, p => p.Source == "Added");
+        Assert.IsTrue(info.Pieces.Any(p => p.Source == "Added"));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetDiagnosticInfo_EmptyDocument_ReturnsNoPieces()
     {
         var doc = new Hex1bDocument();
         var info = doc.GetDiagnosticInfo();
 
-        Assert.NotNull(info);
-        Assert.Equal(0, info.CharCount);
-        Assert.Equal(0, info.ByteCount);
-        Assert.Empty(info.Pieces);
+        Assert.IsNotNull(info);
+        Assert.AreEqual(0, info.CharCount);
+        Assert.AreEqual(0, info.ByteCount);
+        Assert.IsEmpty(info.Pieces);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetDiagnosticInfo_MultiByte_ByteCountDiffersFromCharCount()
     {
         var doc = new Hex1bDocument("café");
         var info = doc.GetDiagnosticInfo();
 
-        Assert.NotNull(info);
-        Assert.Equal(4, info.CharCount); // c, a, f, é
-        Assert.True(info.ByteCount > info.CharCount, "Multi-byte chars should increase byte count");
-        Assert.Equal(5, info.ByteCount); // é is 2 bytes in UTF-8
+        Assert.IsNotNull(info);
+        Assert.AreEqual(4, info.CharCount); // c, a, f, é
+        Assert.IsTrue(info.ByteCount > info.CharCount, "Multi-byte chars should increase byte count");
+        Assert.AreEqual(5, info.ByteCount); // é is 2 bytes in UTF-8
     }
 }

--- a/tests/Hex1b.Tests/Documents/InverseRoundtripTests.cs
+++ b/tests/Hex1b.Tests/Documents/InverseRoundtripTests.cs
@@ -6,45 +6,46 @@ namespace Hex1b.Tests.Documents;
 /// Tests that undo/redo roundtrips via inverse operations preserve document integrity.
 /// This is critical for data safety — users must never lose data through undo/redo.
 /// </summary>
+[TestClass]
 public class InverseRoundtripTests
 {
-    [Fact]
+    [TestMethod]
     public void Insert_ThenUndo_RestoresOriginal()
     {
         var doc = new Hex1bDocument("Hello");
         var result = doc.Apply(new InsertOperation(new DocumentOffset(5), " World"));
-        Assert.Equal("Hello World", doc.GetText());
+        Assert.AreEqual("Hello World", doc.GetText());
 
         doc.Apply(result.Inverse);
-        Assert.Equal("Hello", doc.GetText());
+        Assert.AreEqual("Hello", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Delete_ThenUndo_RestoresOriginal()
     {
         var doc = new Hex1bDocument("Hello World");
         var result = doc.Apply(new DeleteOperation(
             new DocumentRange(new DocumentOffset(5), new DocumentOffset(11))));
-        Assert.Equal("Hello", doc.GetText());
+        Assert.AreEqual("Hello", doc.GetText());
 
         doc.Apply(result.Inverse);
-        Assert.Equal("Hello World", doc.GetText());
+        Assert.AreEqual("Hello World", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Replace_ThenUndo_RestoresOriginal()
     {
         var doc = new Hex1bDocument("Hello World");
         var result = doc.Apply(new ReplaceOperation(
             new DocumentRange(new DocumentOffset(6), new DocumentOffset(11)),
             "Earth"));
-        Assert.Equal("Hello Earth", doc.GetText());
+        Assert.AreEqual("Hello Earth", doc.GetText());
 
         doc.Apply(result.Inverse);
-        Assert.Equal("Hello World", doc.GetText());
+        Assert.AreEqual("Hello World", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void MultipleEdits_UndoInReverseOrder_RestoresOriginal()
     {
         var original = "The quick brown fox";
@@ -52,49 +53,49 @@ public class InverseRoundtripTests
 
         // Edit 1: Insert
         var r1 = doc.Apply(new InsertOperation(new DocumentOffset(doc.Length), " jumps"));
-        Assert.Equal("The quick brown fox jumps", doc.GetText());
+        Assert.AreEqual("The quick brown fox jumps", doc.GetText());
 
         // Edit 2: Replace
         var r2 = doc.Apply(new ReplaceOperation(
             new DocumentRange(new DocumentOffset(4), new DocumentOffset(9)),
             "slow"));
-        Assert.Equal("The slow brown fox jumps", doc.GetText());
+        Assert.AreEqual("The slow brown fox jumps", doc.GetText());
 
         // Edit 3: Delete
         var r3 = doc.Apply(new DeleteOperation(
             new DocumentRange(new DocumentOffset(9), new DocumentOffset(15))));
-        Assert.Equal("The slow fox jumps", doc.GetText());
+        Assert.AreEqual("The slow fox jumps", doc.GetText());
 
         // Undo in reverse order
         doc.Apply(r3.Inverse);
-        Assert.Equal("The slow brown fox jumps", doc.GetText());
+        Assert.AreEqual("The slow brown fox jumps", doc.GetText());
 
         doc.Apply(r2.Inverse);
-        Assert.Equal("The quick brown fox jumps", doc.GetText());
+        Assert.AreEqual("The quick brown fox jumps", doc.GetText());
 
         doc.Apply(r1.Inverse);
-        Assert.Equal(original, doc.GetText());
+        Assert.AreEqual(original, doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Redo_AfterUndo_RestoresEdit()
     {
         var doc = new Hex1bDocument("Hello");
 
         // Edit
         var editResult = doc.Apply(new InsertOperation(new DocumentOffset(5), " World"));
-        Assert.Equal("Hello World", doc.GetText());
+        Assert.AreEqual("Hello World", doc.GetText());
 
         // Undo
         var undoResult = doc.Apply(editResult.Inverse);
-        Assert.Equal("Hello", doc.GetText());
+        Assert.AreEqual("Hello", doc.GetText());
 
         // Redo (undo the undo)
         doc.Apply(undoResult.Inverse);
-        Assert.Equal("Hello World", doc.GetText());
+        Assert.AreEqual("Hello World", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void MultipleUndoRedo_Cycles_MaintainIntegrity()
     {
         var doc = new Hex1bDocument("ABCDE");
@@ -108,10 +109,10 @@ public class InverseRoundtripTests
         }
 
         // Should have "ABCDE" + 10 "X"s
-        Assert.Equal("ABCDE" + new string('X', 10), doc.GetText());
+        Assert.AreEqual("ABCDE" + new string('X', 10), doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void BatchOperation_Undo_RestoresOriginal()
     {
         var doc = new Hex1bDocument("Hello World");
@@ -121,15 +122,15 @@ public class InverseRoundtripTests
             new InsertOperation(new DocumentOffset(5), "_"),
         ]);
 
-        Assert.Equal("Hello_World", doc.GetText());
+        Assert.AreEqual("Hello_World", doc.GetText());
 
         // Undo the batch — must undo in reverse order
         var inverseOps = result.Inverse.Reverse().ToList();
         doc.Apply(inverseOps);
-        Assert.Equal("Hello World", doc.GetText());
+        Assert.AreEqual("Hello World", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Replace_WithMultiLineText_UndoRestoresOriginal()
     {
         var original = "Line 1\nLine 2\nLine 3";
@@ -139,15 +140,15 @@ public class InverseRoundtripTests
             new DocumentRange(new DocumentOffset(7), new DocumentOffset(13)),
             "New L2\nNew L3\nNew L4"));
 
-        Assert.Equal("Line 1\nNew L2\nNew L3\nNew L4\nLine 3", doc.GetText());
-        Assert.Equal(5, doc.LineCount);
+        Assert.AreEqual("Line 1\nNew L2\nNew L3\nNew L4\nLine 3", doc.GetText());
+        Assert.AreEqual(5, doc.LineCount);
 
         doc.Apply(result.Inverse);
-        Assert.Equal(original, doc.GetText());
-        Assert.Equal(3, doc.LineCount);
+        Assert.AreEqual(original, doc.GetText());
+        Assert.AreEqual(3, doc.LineCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void Delete_MultiLine_UndoRestoresLines()
     {
         var original = "A\nB\nC\nD\nE";
@@ -156,27 +157,27 @@ public class InverseRoundtripTests
         // Delete "B\nC\nD\n"
         var result = doc.Apply(new DeleteOperation(
             new DocumentRange(new DocumentOffset(2), new DocumentOffset(8))));
-        Assert.Equal("A\nE", doc.GetText());
-        Assert.Equal(2, doc.LineCount);
+        Assert.AreEqual("A\nE", doc.GetText());
+        Assert.AreEqual(2, doc.LineCount);
 
         doc.Apply(result.Inverse);
-        Assert.Equal(original, doc.GetText());
-        Assert.Equal(5, doc.LineCount);
+        Assert.AreEqual(original, doc.GetText());
+        Assert.AreEqual(5, doc.LineCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void Insert_EmptyText_InversIsEmptyDelete()
     {
         var doc = new Hex1bDocument("Hello");
         var result = doc.Apply(new InsertOperation(new DocumentOffset(2), ""));
-        Assert.Equal("Hello", doc.GetText());
+        Assert.AreEqual("Hello", doc.GetText());
 
         // Inverse should be a no-op delete (empty range)
         doc.Apply(result.Inverse);
-        Assert.Equal("Hello", doc.GetText());
+        Assert.AreEqual("Hello", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void LongChainOfEdits_FullUndoChain_RestoresOriginal()
     {
         var original = "Start";
@@ -192,7 +193,7 @@ public class InverseRoundtripTests
             results.Add(result);
         }
 
-        Assert.NotEqual(original, doc.GetText());
+        Assert.AreNotEqual(original, doc.GetText());
 
         // Undo all in reverse
         for (var i = results.Count - 1; i >= 0; i--)
@@ -200,25 +201,25 @@ public class InverseRoundtripTests
             doc.Apply(results[i].Inverse);
         }
 
-        Assert.Equal(original, doc.GetText());
+        Assert.AreEqual(original, doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Version_IncreasesMonotonically_ThroughUndoRedo()
     {
         var doc = new Hex1bDocument("Hello");
-        Assert.Equal(0, doc.Version);
+        Assert.AreEqual(0, doc.Version);
 
         doc.Apply(new InsertOperation(new DocumentOffset(5), " World"));
-        Assert.Equal(1, doc.Version);
+        Assert.AreEqual(1, doc.Version);
 
         // Undo still increments version (it's a new edit)
         var result = doc.Apply(new DeleteOperation(
             new DocumentRange(new DocumentOffset(5), new DocumentOffset(11))));
-        Assert.Equal(2, doc.Version);
+        Assert.AreEqual(2, doc.Version);
 
         // Redo
         doc.Apply(result.Inverse);
-        Assert.Equal(3, doc.Version);
+        Assert.AreEqual(3, doc.Version);
     }
 }

--- a/tests/Hex1b.Tests/Documents/LineEndingTests.cs
+++ b/tests/Hex1b.Tests/Documents/LineEndingTests.cs
@@ -5,200 +5,201 @@ namespace Hex1b.Tests.Documents;
 /// <summary>
 /// Tests for line ending handling: LF, CRLF, mixed, trailing, empty lines.
 /// </summary>
+[TestClass]
 public class LineEndingTests
 {
     // --- LF (\n) ---
 
-    [Fact]
+    [TestMethod]
     public void LF_SingleNewline_TwoLines()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
-        Assert.Equal(2, doc.LineCount);
-        Assert.Equal("Hello", doc.GetLineText(1));
-        Assert.Equal("World", doc.GetLineText(2));
+        Assert.AreEqual(2, doc.LineCount);
+        Assert.AreEqual("Hello", doc.GetLineText(1));
+        Assert.AreEqual("World", doc.GetLineText(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void LF_TrailingNewline_CreatesEmptyLastLine()
     {
         var doc = new Hex1bDocument("Hello\n");
-        Assert.Equal(2, doc.LineCount);
-        Assert.Equal("Hello", doc.GetLineText(1));
-        Assert.Equal("", doc.GetLineText(2));
+        Assert.AreEqual(2, doc.LineCount);
+        Assert.AreEqual("Hello", doc.GetLineText(1));
+        Assert.AreEqual("", doc.GetLineText(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void LF_LeadingNewline_CreatesEmptyFirstLine()
     {
         var doc = new Hex1bDocument("\nHello");
-        Assert.Equal(2, doc.LineCount);
-        Assert.Equal("", doc.GetLineText(1));
-        Assert.Equal("Hello", doc.GetLineText(2));
+        Assert.AreEqual(2, doc.LineCount);
+        Assert.AreEqual("", doc.GetLineText(1));
+        Assert.AreEqual("Hello", doc.GetLineText(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void LF_MultipleNewlines_CreatesEmptyLines()
     {
         var doc = new Hex1bDocument("A\n\n\nB");
-        Assert.Equal(4, doc.LineCount);
-        Assert.Equal("A", doc.GetLineText(1));
-        Assert.Equal("", doc.GetLineText(2));
-        Assert.Equal("", doc.GetLineText(3));
-        Assert.Equal("B", doc.GetLineText(4));
+        Assert.AreEqual(4, doc.LineCount);
+        Assert.AreEqual("A", doc.GetLineText(1));
+        Assert.AreEqual("", doc.GetLineText(2));
+        Assert.AreEqual("", doc.GetLineText(3));
+        Assert.AreEqual("B", doc.GetLineText(4));
     }
 
-    [Fact]
+    [TestMethod]
     public void LF_OnlyNewlines_AllEmptyLines()
     {
         var doc = new Hex1bDocument("\n\n");
-        Assert.Equal(3, doc.LineCount);
-        Assert.Equal("", doc.GetLineText(1));
-        Assert.Equal("", doc.GetLineText(2));
-        Assert.Equal("", doc.GetLineText(3));
+        Assert.AreEqual(3, doc.LineCount);
+        Assert.AreEqual("", doc.GetLineText(1));
+        Assert.AreEqual("", doc.GetLineText(2));
+        Assert.AreEqual("", doc.GetLineText(3));
     }
 
     // --- CRLF (\r\n) ---
 
-    [Fact]
+    [TestMethod]
     public void CRLF_SingleLineBreak_TwoLines()
     {
         var doc = new Hex1bDocument("Hello\r\nWorld");
-        Assert.Equal(2, doc.LineCount);
-        Assert.Equal("Hello", doc.GetLineText(1));
-        Assert.Equal("World", doc.GetLineText(2));
+        Assert.AreEqual(2, doc.LineCount);
+        Assert.AreEqual("Hello", doc.GetLineText(1));
+        Assert.AreEqual("World", doc.GetLineText(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void CRLF_TrailingLineBreak_CreatesEmptyLastLine()
     {
         var doc = new Hex1bDocument("Hello\r\n");
-        Assert.Equal(2, doc.LineCount);
-        Assert.Equal("Hello", doc.GetLineText(1));
-        Assert.Equal("", doc.GetLineText(2));
+        Assert.AreEqual(2, doc.LineCount);
+        Assert.AreEqual("Hello", doc.GetLineText(1));
+        Assert.AreEqual("", doc.GetLineText(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void CRLF_MultipleLineBreaks()
     {
         var doc = new Hex1bDocument("A\r\nB\r\nC");
-        Assert.Equal(3, doc.LineCount);
-        Assert.Equal("A", doc.GetLineText(1));
-        Assert.Equal("B", doc.GetLineText(2));
-        Assert.Equal("C", doc.GetLineText(3));
+        Assert.AreEqual(3, doc.LineCount);
+        Assert.AreEqual("A", doc.GetLineText(1));
+        Assert.AreEqual("B", doc.GetLineText(2));
+        Assert.AreEqual("C", doc.GetLineText(3));
     }
 
     // --- Line counting after edits ---
 
-    [Fact]
+    [TestMethod]
     public void InsertNewline_IncrementsLineCount()
     {
         var doc = new Hex1bDocument("HelloWorld");
-        Assert.Equal(1, doc.LineCount);
+        Assert.AreEqual(1, doc.LineCount);
 
         doc.Apply(new InsertOperation(new DocumentOffset(5), "\n"));
-        Assert.Equal(2, doc.LineCount);
-        Assert.Equal("Hello", doc.GetLineText(1));
-        Assert.Equal("World", doc.GetLineText(2));
+        Assert.AreEqual(2, doc.LineCount);
+        Assert.AreEqual("Hello", doc.GetLineText(1));
+        Assert.AreEqual("World", doc.GetLineText(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertMultipleNewlines_AtOnce()
     {
         var doc = new Hex1bDocument("Hello");
         doc.Apply(new InsertOperation(new DocumentOffset(5), "\n\n\n"));
-        Assert.Equal(4, doc.LineCount);
+        Assert.AreEqual(4, doc.LineCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteNewline_DecrementsLineCount()
     {
         var doc = new Hex1bDocument("A\nB\nC");
-        Assert.Equal(3, doc.LineCount);
+        Assert.AreEqual(3, doc.LineCount);
 
         // Delete first newline
         doc.Apply(new DeleteOperation(new DocumentRange(new DocumentOffset(1), new DocumentOffset(2))));
-        Assert.Equal("AB\nC", doc.GetText());
-        Assert.Equal(2, doc.LineCount);
+        Assert.AreEqual("AB\nC", doc.GetText());
+        Assert.AreEqual(2, doc.LineCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void ReplaceNewlineWithText_DecrementsLineCount()
     {
         var doc = new Hex1bDocument("A\nB");
-        Assert.Equal(2, doc.LineCount);
+        Assert.AreEqual(2, doc.LineCount);
 
         doc.Apply(new ReplaceOperation(
             new DocumentRange(new DocumentOffset(1), new DocumentOffset(2)),
             " "));
-        Assert.Equal("A B", doc.GetText());
-        Assert.Equal(1, doc.LineCount);
+        Assert.AreEqual("A B", doc.GetText());
+        Assert.AreEqual(1, doc.LineCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void ReplaceTextWithNewline_IncrementsLineCount()
     {
         var doc = new Hex1bDocument("A B");
-        Assert.Equal(1, doc.LineCount);
+        Assert.AreEqual(1, doc.LineCount);
 
         doc.Apply(new ReplaceOperation(
             new DocumentRange(new DocumentOffset(1), new DocumentOffset(2)),
             "\n"));
-        Assert.Equal("A\nB", doc.GetText());
-        Assert.Equal(2, doc.LineCount);
+        Assert.AreEqual("A\nB", doc.GetText());
+        Assert.AreEqual(2, doc.LineCount);
     }
 
     // --- Multi-line text insertions ---
 
-    [Fact]
+    [TestMethod]
     public void InsertMultiLineText_UpdatesLinesCorrectly()
     {
         var doc = new Hex1bDocument("Start End");
         doc.Apply(new InsertOperation(new DocumentOffset(6), "Line1\nLine2\nLine3 "));
-        Assert.Equal("Start Line1\nLine2\nLine3 End", doc.GetText());
-        Assert.Equal(3, doc.LineCount);
-        Assert.Equal("Start Line1", doc.GetLineText(1));
-        Assert.Equal("Line2", doc.GetLineText(2));
-        Assert.Equal("Line3 End", doc.GetLineText(3));
+        Assert.AreEqual("Start Line1\nLine2\nLine3 End", doc.GetText());
+        Assert.AreEqual(3, doc.LineCount);
+        Assert.AreEqual("Start Line1", doc.GetLineText(1));
+        Assert.AreEqual("Line2", doc.GetLineText(2));
+        Assert.AreEqual("Line3 End", doc.GetLineText(3));
     }
 
     // --- GetLineText / GetLineLength consistency ---
 
-    [Fact]
+    [TestMethod]
     public void GetLineText_AndGetLineLength_AreConsistent()
     {
         var doc = new Hex1bDocument("Short\nA much longer line\nX");
         for (var i = 1; i <= doc.LineCount; i++)
         {
-            Assert.Equal(doc.GetLineText(i).Length, doc.GetLineLength(i));
+            Assert.AreEqual(doc.GetLineText(i).Length, doc.GetLineLength(i));
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void GetLineText_EmptyMiddleLine_ReturnsEmpty()
     {
         var doc = new Hex1bDocument("A\n\nB");
-        Assert.Equal("", doc.GetLineText(2));
-        Assert.Equal(0, doc.GetLineLength(2));
+        Assert.AreEqual("", doc.GetLineText(2));
+        Assert.AreEqual(0, doc.GetLineLength(2));
     }
 
     // --- OffsetToPosition with newlines ---
 
-    [Fact]
+    [TestMethod]
     public void OffsetToPosition_AtNewlineChar_ReportsEndOfLine()
     {
         var doc = new Hex1bDocument("AB\nCD");
         // Offset 2 = the \n character — it's still on line 1
         var pos = doc.OffsetToPosition(new DocumentOffset(2));
-        Assert.Equal(1, pos.Line);
-        Assert.Equal(3, pos.Column); // 1-based: 'A'=1, 'B'=2, '\n'=3
+        Assert.AreEqual(1, pos.Line);
+        Assert.AreEqual(3, pos.Column); // 1-based: 'A'=1, 'B'=2, '\n'=3
     }
 
-    [Fact]
+    [TestMethod]
     public void OffsetToPosition_RightAfterNewline_ReportsNextLine()
     {
         var doc = new Hex1bDocument("AB\nCD");
         var pos = doc.OffsetToPosition(new DocumentOffset(3));
-        Assert.Equal(2, pos.Line);
-        Assert.Equal(1, pos.Column);
+        Assert.AreEqual(2, pos.Line);
+        Assert.AreEqual(1, pos.Column);
     }
 }

--- a/tests/Hex1b.Tests/Documents/PieceTableEdgeCaseTests.cs
+++ b/tests/Hex1b.Tests/Documents/PieceTableEdgeCaseTests.cs
@@ -6,168 +6,169 @@ namespace Hex1b.Tests.Documents;
 /// Tests for piece table internal consistency — edge cases in splitting,
 /// merging, and multi-piece operations that exercise the data structure.
 /// </summary>
+[TestClass]
 public class PieceTableEdgeCaseTests
 {
     // --- Insert at piece boundaries ---
 
-    [Fact]
+    [TestMethod]
     public void Insert_AtStartOfDocument_PrependsToPieceList()
     {
         var doc = new Hex1bDocument("World");
         doc.Apply(new InsertOperation(new DocumentOffset(0), "Hello "));
-        Assert.Equal("Hello World", doc.GetText());
-        Assert.Equal(11, doc.Length);
+        Assert.AreEqual("Hello World", doc.GetText());
+        Assert.AreEqual(11, doc.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void Insert_AtEndOfDocument_AppendsToPieceList()
     {
         var doc = new Hex1bDocument("Hello");
         doc.Apply(new InsertOperation(new DocumentOffset(5), " World"));
-        Assert.Equal("Hello World", doc.GetText());
+        Assert.AreEqual("Hello World", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Insert_AtExactPieceBoundary_DoesNotCorrupt()
     {
         // Create a doc, insert in middle to create 3 pieces, then insert at boundary
         var doc = new Hex1bDocument("AABB");
         // Split original piece: "AA" | "X" | "BB"
         doc.Apply(new InsertOperation(new DocumentOffset(2), "X"));
-        Assert.Equal("AAXBB", doc.GetText());
+        Assert.AreEqual("AAXBB", doc.GetText());
 
         // Insert at the boundary between "X" piece and "BB" piece
         doc.Apply(new InsertOperation(new DocumentOffset(3), "Y"));
-        Assert.Equal("AAXYBB", doc.GetText());
+        Assert.AreEqual("AAXYBB", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Insert_EmptyString_IsNoOp()
     {
         var doc = new Hex1bDocument("Hello");
         doc.Apply(new InsertOperation(new DocumentOffset(2), ""));
-        Assert.Equal("Hello", doc.GetText());
-        Assert.Equal(5, doc.Length);
+        Assert.AreEqual("Hello", doc.GetText());
+        Assert.AreEqual(5, doc.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void Insert_IntoEmptyDocument_CreatesContent()
     {
         var doc = new Hex1bDocument("");
         doc.Apply(new InsertOperation(new DocumentOffset(0), "Hello"));
-        Assert.Equal("Hello", doc.GetText());
-        Assert.Equal(5, doc.Length);
+        Assert.AreEqual("Hello", doc.GetText());
+        Assert.AreEqual(5, doc.Length);
     }
 
     // --- Delete at piece boundaries ---
 
-    [Fact]
+    [TestMethod]
     public void Delete_EntirePiece_RemovesItCleanly()
     {
         var doc = new Hex1bDocument("Hello");
         doc.Apply(new DeleteOperation(new DocumentRange(new DocumentOffset(0), new DocumentOffset(5))));
-        Assert.Equal("", doc.GetText());
-        Assert.Equal(0, doc.Length);
+        Assert.AreEqual("", doc.GetText());
+        Assert.AreEqual(0, doc.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void Delete_SpanningMultiplePieces_RemovesCorrectly()
     {
         var doc = new Hex1bDocument("ABCD");
         // Insert to create: "AB" | "X" | "CD"
         doc.Apply(new InsertOperation(new DocumentOffset(2), "X"));
-        Assert.Equal("ABXCD", doc.GetText());
+        Assert.AreEqual("ABXCD", doc.GetText());
 
         // Delete across all three pieces: "B" + "X" + "C"
         doc.Apply(new DeleteOperation(new DocumentRange(new DocumentOffset(1), new DocumentOffset(4))));
-        Assert.Equal("AD", doc.GetText());
+        Assert.AreEqual("AD", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Delete_FirstCharOfPiece_LeavesRemainder()
     {
         var doc = new Hex1bDocument("ABCDE");
         doc.Apply(new DeleteOperation(new DocumentRange(new DocumentOffset(0), new DocumentOffset(1))));
-        Assert.Equal("BCDE", doc.GetText());
+        Assert.AreEqual("BCDE", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Delete_LastCharOfPiece_LeavesRemainder()
     {
         var doc = new Hex1bDocument("ABCDE");
         doc.Apply(new DeleteOperation(new DocumentRange(new DocumentOffset(4), new DocumentOffset(5))));
-        Assert.Equal("ABCD", doc.GetText());
+        Assert.AreEqual("ABCD", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Delete_EmptyRange_IsNoOp()
     {
         var doc = new Hex1bDocument("Hello");
         doc.Apply(new DeleteOperation(new DocumentRange(new DocumentOffset(2), new DocumentOffset(2))));
-        Assert.Equal("Hello", doc.GetText());
+        Assert.AreEqual("Hello", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Delete_AllContent_LeavesEmptyDocument()
     {
         var doc = new Hex1bDocument("Hello World!");
         doc.Apply(new DeleteOperation(new DocumentRange(new DocumentOffset(0), new DocumentOffset(12))));
-        Assert.Equal("", doc.GetText());
-        Assert.Equal(0, doc.Length);
-        Assert.Equal(1, doc.LineCount);
+        Assert.AreEqual("", doc.GetText());
+        Assert.AreEqual(0, doc.Length);
+        Assert.AreEqual(1, doc.LineCount);
     }
 
     // --- Replace at piece boundaries ---
 
-    [Fact]
+    [TestMethod]
     public void Replace_AcrossPieceBoundary_WorksCorrectly()
     {
         var doc = new Hex1bDocument("ABCD");
         doc.Apply(new InsertOperation(new DocumentOffset(2), "XY"));
-        Assert.Equal("ABXYCD", doc.GetText());
+        Assert.AreEqual("ABXYCD", doc.GetText());
 
         // Replace "XYC" with "Z"
         doc.Apply(new ReplaceOperation(
             new DocumentRange(new DocumentOffset(2), new DocumentOffset(5)),
             "Z"));
-        Assert.Equal("ABZD", doc.GetText());
+        Assert.AreEqual("ABZD", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Replace_WithLongerText_IncreasesLength()
     {
         var doc = new Hex1bDocument("Hello world");
         doc.Apply(new ReplaceOperation(
             new DocumentRange(new DocumentOffset(6), new DocumentOffset(11)),
             "beautiful world"));
-        Assert.Equal("Hello beautiful world", doc.GetText());
-        Assert.Equal(21, doc.Length);
+        Assert.AreEqual("Hello beautiful world", doc.GetText());
+        Assert.AreEqual(21, doc.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void Replace_WithShorterText_DecreasesLength()
     {
         var doc = new Hex1bDocument("Hello world");
         doc.Apply(new ReplaceOperation(
             new DocumentRange(new DocumentOffset(0), new DocumentOffset(5)),
             "Hi"));
-        Assert.Equal("Hi world", doc.GetText());
-        Assert.Equal(8, doc.Length);
+        Assert.AreEqual("Hi world", doc.GetText());
+        Assert.AreEqual(8, doc.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void Replace_WithEmptyText_IsDelete()
     {
         var doc = new Hex1bDocument("Hello world");
         doc.Apply(new ReplaceOperation(
             new DocumentRange(new DocumentOffset(5), new DocumentOffset(11)),
             ""));
-        Assert.Equal("Hello", doc.GetText());
+        Assert.AreEqual("Hello", doc.GetText());
     }
 
     // --- Sequential operations creating complex piece lists ---
 
-    [Fact]
+    [TestMethod]
     public void ManyInserts_MaintainConsistency()
     {
         var doc = new Hex1bDocument("");
@@ -177,11 +178,11 @@ public class PieceTableEdgeCaseTests
         {
             doc.Apply(new InsertOperation(new DocumentOffset(i), text[i].ToString()));
         }
-        Assert.Equal(text, doc.GetText());
-        Assert.Equal(text.Length, doc.Length);
+        Assert.AreEqual(text, doc.GetText());
+        Assert.AreEqual(text.Length, doc.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void ManyInserts_AtSamePosition_PrependsCorrectly()
     {
         var doc = new Hex1bDocument("");
@@ -191,32 +192,32 @@ public class PieceTableEdgeCaseTests
         doc.Apply(new InsertOperation(new DocumentOffset(0), "C"));
         doc.Apply(new InsertOperation(new DocumentOffset(0), "B"));
         doc.Apply(new InsertOperation(new DocumentOffset(0), "A"));
-        Assert.Equal("ABCDE", doc.GetText());
+        Assert.AreEqual("ABCDE", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void InterleavedInsertDelete_MaintainsConsistency()
     {
         var doc = new Hex1bDocument("Hello");
         doc.Apply(new InsertOperation(new DocumentOffset(5), " World"));  // "Hello World"
         doc.Apply(new DeleteOperation(new DocumentRange(new DocumentOffset(0), new DocumentOffset(6))));  // "World"
         doc.Apply(new InsertOperation(new DocumentOffset(0), "Brave New "));  // "Brave New World"
-        Assert.Equal("Brave New World", doc.GetText());
-        Assert.Equal(15, doc.Length);
+        Assert.AreEqual("Brave New World", doc.GetText());
+        Assert.AreEqual(15, doc.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void Delete_EntireContent_ThenInsert_Works()
     {
         var doc = new Hex1bDocument("Original");
         doc.Apply(new DeleteOperation(new DocumentRange(new DocumentOffset(0), new DocumentOffset(8))));
-        Assert.Equal("", doc.GetText());
+        Assert.AreEqual("", doc.GetText());
 
         doc.Apply(new InsertOperation(new DocumentOffset(0), "Replacement"));
-        Assert.Equal("Replacement", doc.GetText());
+        Assert.AreEqual("Replacement", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void RapidInsertDeleteCycle_MaintainsConsistency()
     {
         var doc = new Hex1bDocument("Test");
@@ -227,114 +228,114 @@ public class PieceTableEdgeCaseTests
                 new DocumentOffset(doc.Length - 1),
                 new DocumentOffset(doc.Length))));
         }
-        Assert.Equal("Test", doc.GetText());
+        Assert.AreEqual("Test", doc.GetText());
     }
 
     // --- GetText range across piece boundaries ---
 
-    [Fact]
+    [TestMethod]
     public void GetText_RangeSpanningMultiplePieces_ReturnsCorrectText()
     {
         var doc = new Hex1bDocument("ABCDEF");
         doc.Apply(new InsertOperation(new DocumentOffset(3), "XYZ"));
         // Pieces: "ABC" | "XYZ" | "DEF"
-        Assert.Equal("ABCXYZDEF", doc.GetText());
+        Assert.AreEqual("ABCXYZDEF", doc.GetText());
 
         // Range spanning two boundaries: "CXY"
         var range = new DocumentRange(new DocumentOffset(2), new DocumentOffset(6));
-        Assert.Equal("CXYZ", doc.GetText(range));
+        Assert.AreEqual("CXYZ", doc.GetText(range));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetText_EmptyRange_ReturnsEmptyString()
     {
         var doc = new Hex1bDocument("Hello");
         var range = new DocumentRange(new DocumentOffset(2), new DocumentOffset(2));
-        Assert.Equal("", doc.GetText(range));
+        Assert.AreEqual("", doc.GetText(range));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetText_FullRange_ReturnsFullText()
     {
         var doc = new Hex1bDocument("Hello World");
         var range = new DocumentRange(new DocumentOffset(0), new DocumentOffset(11));
-        Assert.Equal("Hello World", doc.GetText(range));
+        Assert.AreEqual("Hello World", doc.GetText(range));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetText_OutOfRange_Throws()
     {
         var doc = new Hex1bDocument("Hello");
         var range = new DocumentRange(new DocumentOffset(0), new DocumentOffset(10));
-        Assert.Throws<ArgumentOutOfRangeException>(() => doc.GetText(range));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => doc.GetText(range));
     }
 
     // --- OffsetToPosition across pieces ---
 
-    [Fact]
+    [TestMethod]
     public void OffsetToPosition_AfterMultipleInserts_StillCorrect()
     {
         var doc = new Hex1bDocument("AB\nCD");
         doc.Apply(new InsertOperation(new DocumentOffset(2), "XY\nZ"));
         // Content: "ABXY\nZ\nCD"
-        Assert.Equal("ABXY\nZ\nCD", doc.GetText());
-        Assert.Equal(3, doc.LineCount);
+        Assert.AreEqual("ABXY\nZ\nCD", doc.GetText());
+        Assert.AreEqual(3, doc.LineCount);
 
-        Assert.Equal(new DocumentPosition(1, 1), doc.OffsetToPosition(new DocumentOffset(0)));
-        Assert.Equal(new DocumentPosition(1, 5), doc.OffsetToPosition(new DocumentOffset(4))); // "Y"
-        Assert.Equal(new DocumentPosition(2, 1), doc.OffsetToPosition(new DocumentOffset(5))); // "Z"
-        Assert.Equal(new DocumentPosition(3, 1), doc.OffsetToPosition(new DocumentOffset(7))); // "C"
+        Assert.AreEqual(new DocumentPosition(1, 1), doc.OffsetToPosition(new DocumentOffset(0)));
+        Assert.AreEqual(new DocumentPosition(1, 5), doc.OffsetToPosition(new DocumentOffset(4))); // "Y"
+        Assert.AreEqual(new DocumentPosition(2, 1), doc.OffsetToPosition(new DocumentOffset(5))); // "Z"
+        Assert.AreEqual(new DocumentPosition(3, 1), doc.OffsetToPosition(new DocumentOffset(7))); // "C"
     }
 
-    [Fact]
+    [TestMethod]
     public void OffsetToPosition_AtEndOfDocument_ReturnsLastLineLastColumn()
     {
         var doc = new Hex1bDocument("AB\nCD");
         var pos = doc.OffsetToPosition(new DocumentOffset(5));
-        Assert.Equal(new DocumentPosition(2, 3), pos);
+        Assert.AreEqual(new DocumentPosition(2, 3), pos);
     }
 
-    [Fact]
+    [TestMethod]
     public void OffsetToPosition_BeyondLength_Throws()
     {
         var doc = new Hex1bDocument("Hello");
-        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
             doc.OffsetToPosition(new DocumentOffset(6)));
     }
 
     // --- PositionToOffset edge cases ---
 
-    [Fact]
+    [TestMethod]
     public void PositionToOffset_InvalidLine_Throws()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
-        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
             doc.PositionToOffset(new DocumentPosition(3, 1)));
     }
 
-    [Fact]
+    [TestMethod]
     public void PositionToOffset_ZeroLine_Throws()
     {
         var doc = new Hex1bDocument("Hello");
-        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
             new DocumentPosition(0, 1));
     }
 
     // --- Line operations edge cases ---
 
-    [Fact]
+    [TestMethod]
     public void GetLineText_InvalidLine_Throws()
     {
         var doc = new Hex1bDocument("Hello");
-        Assert.Throws<ArgumentOutOfRangeException>(() => doc.GetLineText(0));
-        Assert.Throws<ArgumentOutOfRangeException>(() => doc.GetLineText(2));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => doc.GetLineText(0));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => doc.GetLineText(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetLineLength_InvalidLine_Throws()
     {
         var doc = new Hex1bDocument("Hello");
-        Assert.Throws<ArgumentOutOfRangeException>(() => doc.GetLineLength(0));
-        Assert.Throws<ArgumentOutOfRangeException>(() => doc.GetLineLength(2));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => doc.GetLineLength(0));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => doc.GetLineLength(2));
     }
 }

--- a/tests/Hex1b.Tests/Documents/PieceTableStressTests.cs
+++ b/tests/Hex1b.Tests/Documents/PieceTableStressTests.cs
@@ -7,10 +7,11 @@ namespace Hex1b.Tests.Documents;
 /// These tests exercise patterns that produce many small pieces and verify
 /// the document remains consistent after complex operation sequences.
 /// </summary>
-[Collection("CPU-Intensive")]
+[DoNotParallelize]
+[TestClass]
 public class PieceTableStressTests
 {
-    [Fact]
+    [TestMethod]
     public void Insert_OneCharAtATime_BuildsStringCorrectly()
     {
         var expected = "The quick brown fox jumps over the lazy dog";
@@ -21,11 +22,11 @@ public class PieceTableStressTests
             doc.Apply(new InsertOperation(new DocumentOffset(i), expected[i].ToString()));
         }
 
-        Assert.Equal(expected, doc.GetText());
-        Assert.Equal(expected.Length, doc.Length);
+        Assert.AreEqual(expected, doc.GetText());
+        Assert.AreEqual(expected.Length, doc.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void Insert_OneCharAtATime_AtBeginning_BuildsReversedCorrectly()
     {
         // Insert each char at position 0 — result should be reversed
@@ -37,10 +38,10 @@ public class PieceTableStressTests
             doc.Apply(new InsertOperation(new DocumentOffset(0), c.ToString()));
         }
 
-        Assert.Equal("EDCBA", doc.GetText());
+        Assert.AreEqual("EDCBA", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Delete_OneCharAtATime_FromEnd_EmptiesDocument()
     {
         var text = "Hello World! This is a test document.";
@@ -52,11 +53,11 @@ public class PieceTableStressTests
                 new DocumentRange(new DocumentOffset(i - 1), new DocumentOffset(i))));
         }
 
-        Assert.Equal("", doc.GetText());
-        Assert.Equal(0, doc.Length);
+        Assert.AreEqual("", doc.GetText());
+        Assert.AreEqual(0, doc.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void Delete_OneCharAtATime_FromBeginning_EmptiesDocument()
     {
         var text = "Hello World!";
@@ -68,11 +69,11 @@ public class PieceTableStressTests
                 new DocumentRange(new DocumentOffset(0), new DocumentOffset(1))));
         }
 
-        Assert.Equal("", doc.GetText());
-        Assert.Equal(0, doc.Length);
+        Assert.AreEqual("", doc.GetText());
+        Assert.AreEqual(0, doc.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void AlternatingInsertDelete_100Cycles_MaintainsConsistency()
     {
         var doc = new Hex1bDocument("Base");
@@ -89,11 +90,11 @@ public class PieceTableStressTests
 
         // Just verify it doesn't throw and Length is consistent
         var text = doc.GetText();
-        Assert.Equal(text.Length, doc.Length);
-        Assert.True(doc.Length > 0);
+        Assert.AreEqual(text.Length, doc.Length);
+        Assert.IsTrue(doc.Length > 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void ManySmallInserts_InMiddle_CreatesFragmentedPieceList()
     {
         var doc = new Hex1bDocument("AABB");
@@ -106,14 +107,14 @@ public class PieceTableStressTests
         }
 
         var text = doc.GetText();
-        Assert.Equal(text.Length, doc.Length);
-        Assert.Equal(54, doc.Length); // 4 + 50
+        Assert.AreEqual(text.Length, doc.Length);
+        Assert.AreEqual(54, doc.Length); // 4 + 50
         Assert.StartsWith("AA", text);
         Assert.EndsWith("BB", text);
         Assert.Contains("XXXXXXXXXX", text); // At least 10 Xs in a row
     }
 
-    [Fact]
+    [TestMethod]
     public void LargeDocument_InsertAndQuery_PerformsCorrectly()
     {
         // Build a ~10K char document
@@ -125,21 +126,21 @@ public class PieceTableStressTests
                 $"Line {i}: This is some content for testing.\n"));
         }
 
-        Assert.Equal(101, doc.LineCount); // 100 lines + trailing \n creates empty line 101
-        Assert.Equal($"Line 0: This is some content for testing.", doc.GetLineText(1));
-        Assert.Equal($"Line 99: This is some content for testing.", doc.GetLineText(100));
+        Assert.AreEqual(101, doc.LineCount); // 100 lines + trailing \n creates empty line 101
+        Assert.AreEqual($"Line 0: This is some content for testing.", doc.GetLineText(1));
+        Assert.AreEqual($"Line 99: This is some content for testing.", doc.GetLineText(100));
 
         // Verify offset/position roundtrip on first 100 lines (the content lines)
         for (var line = 1; line <= 100; line++)
         {
             var offset = doc.PositionToOffset(new DocumentPosition(line, 1));
             var pos = doc.OffsetToPosition(offset);
-            Assert.Equal(line, pos.Line);
-            Assert.Equal(1, pos.Column);
+            Assert.AreEqual(line, pos.Line);
+            Assert.AreEqual(1, pos.Column);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void GetText_Range_AfterManyEdits_ReturnsCorrectSlice()
     {
         var doc = new Hex1bDocument("0123456789");
@@ -153,7 +154,7 @@ public class PieceTableStressTests
         // "012XY34BCDE56789"
 
         var fullText = doc.GetText();
-        Assert.Equal(fullText.Length, doc.Length);
+        Assert.AreEqual(fullText.Length, doc.Length);
 
         // Verify GetText(range) matches substring for every possible range
         for (var start = 0; start < doc.Length; start++)
@@ -161,12 +162,12 @@ public class PieceTableStressTests
             for (var end = start; end <= doc.Length; end++)
             {
                 var range = new DocumentRange(new DocumentOffset(start), new DocumentOffset(end));
-                Assert.Equal(fullText[start..end], doc.GetText(range));
+                Assert.AreEqual(fullText[start..end], doc.GetText(range));
             }
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void OffsetToPosition_PositionToOffset_Roundtrip_AllPositions()
     {
         var doc = new Hex1bDocument("Line 1\nLine 2\nLine 3\n");
@@ -176,11 +177,11 @@ public class PieceTableStressTests
         {
             var pos = doc.OffsetToPosition(new DocumentOffset(offset));
             var backToOffset = doc.PositionToOffset(pos);
-            Assert.Equal(offset, backToOffset.Value);
+            Assert.AreEqual(offset, backToOffset.Value);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Version_AfterManyEdits_IsCorrect()
     {
         var doc = new Hex1bDocument("Start");
@@ -191,10 +192,10 @@ public class PieceTableStressTests
             doc.Apply(new InsertOperation(new DocumentOffset(doc.Length), "."));
         }
 
-        Assert.Equal(editCount, doc.Version);
+        Assert.AreEqual(editCount, doc.Version);
     }
 
-    [Fact]
+    [TestMethod]
     public void ChangedEvent_FiresForEveryEdit()
     {
         var doc = new Hex1bDocument("Start");
@@ -206,10 +207,10 @@ public class PieceTableStressTests
             doc.Apply(new InsertOperation(new DocumentOffset(doc.Length), "X"));
         }
 
-        Assert.Equal(50, eventCount);
+        Assert.AreEqual(50, eventCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void BatchEdit_FiresSingleEvent()
     {
         var doc = new Hex1bDocument("Hello World");
@@ -222,10 +223,10 @@ public class PieceTableStressTests
             new InsertOperation(new DocumentOffset(2), "C"),
         ]);
 
-        Assert.Equal(1, eventCount); // Single event for batch
+        Assert.AreEqual(1, eventCount); // Single event for batch
     }
 
-    [Fact]
+    [TestMethod]
     public void TypewriterSimulation_ProducesExpectedResult()
     {
         // Simulate typing "Hello\nWorld" one char at a time, 
@@ -237,7 +238,7 @@ public class PieceTableStressTests
         {
             doc.Apply(new InsertOperation(new DocumentOffset(doc.Length), c.ToString()));
         }
-        Assert.Equal("Hello\nWorld", doc.GetText());
+        Assert.AreEqual("Hello\nWorld", doc.GetText());
 
         // Backspace 5 times to delete "World"
         for (var i = 0; i < 5; i++)
@@ -246,16 +247,16 @@ public class PieceTableStressTests
                 new DocumentOffset(doc.Length - 1),
                 new DocumentOffset(doc.Length))));
         }
-        Assert.Equal("Hello\n", doc.GetText());
+        Assert.AreEqual("Hello\n", doc.GetText());
 
         // Type "Earth"
         foreach (var c in "Earth")
         {
             doc.Apply(new InsertOperation(new DocumentOffset(doc.Length), c.ToString()));
         }
-        Assert.Equal("Hello\nEarth", doc.GetText());
-        Assert.Equal(2, doc.LineCount);
-        Assert.Equal("Hello", doc.GetLineText(1));
-        Assert.Equal("Earth", doc.GetLineText(2));
+        Assert.AreEqual("Hello\nEarth", doc.GetText());
+        Assert.AreEqual(2, doc.LineCount);
+        Assert.AreEqual("Hello", doc.GetLineText(1));
+        Assert.AreEqual("Earth", doc.GetLineText(2));
     }
 }

--- a/tests/Hex1b.Tests/DonutChartNodeTests.cs
+++ b/tests/Hex1b.Tests/DonutChartNodeTests.cs
@@ -5,6 +5,7 @@ using Hex1b.Surfaces;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class DonutChartNodeTests
 {
     private static DonutChartNode<ChartItem> CreateNode(
@@ -31,26 +32,26 @@ public class DonutChartNodeTests
 
     #region Measure Tests
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithConstraints_ReturnsPositiveSize()
     {
         var node = CreateNode(SampleData);
         var size = node.Measure(new Constraints(0, 40, 0, 30));
 
-        Assert.True(size.Width > 0);
-        Assert.True(size.Height > 0);
+        Assert.IsTrue(size.Width > 0);
+        Assert.IsTrue(size.Height > 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_FillsAvailableWidth()
     {
         var node = CreateNode(SampleData);
         var size = node.Measure(new Constraints(0, 60, 0, 50));
 
-        Assert.Equal(60, size.Width);
+        Assert.AreEqual(60, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_IncludesTitleRow_WhenTitleSet()
     {
         var withTitle = CreateNode(SampleData, title: "Languages");
@@ -59,10 +60,10 @@ public class DonutChartNodeTests
         var sizeWith = withTitle.Measure(new Constraints(0, 40, 0, 100));
         var sizeWithout = withoutTitle.Measure(new Constraints(0, 40, 0, 100));
 
-        Assert.Equal(sizeWithout.Height + 1, sizeWith.Height);
+        Assert.AreEqual(sizeWithout.Height + 1, sizeWith.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_SameHeight_RegardlessOfDataCount()
     {
         var threeItems = CreateNode(SampleData);
@@ -74,32 +75,32 @@ public class DonutChartNodeTests
         var size5 = fiveItems.Measure(new Constraints(0, 40, 0, 100));
 
         // Without built-in legend, donut height depends only on width, not data count
-        Assert.Equal(size3.Height, size5.Height);
+        Assert.AreEqual(size3.Height, size5.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_UnboundedWidth_DefaultsTo40()
     {
         var node = CreateNode(SampleData);
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(40, size.Width);
+        Assert.AreEqual(40, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_RespectsMaxHeight()
     {
         var node = CreateNode(SampleData);
         var size = node.Measure(new Constraints(0, 40, 0, 5));
 
-        Assert.True(size.Height <= 5);
+        Assert.IsTrue(size.Height <= 5);
     }
 
     #endregion
 
     #region Render Tests
 
-    [Fact]
+    [TestMethod]
     public void Render_ProducesNonEmptySurface()
     {
         var node = CreateNode(SampleData);
@@ -114,10 +115,10 @@ public class DonutChartNodeTests
                 hasContent = true;
         }
 
-        Assert.True(hasContent, "Surface should have rendered content");
+        Assert.IsTrue(hasContent, "Surface should have rendered content");
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_Title_AppearsOnFirstRow()
     {
         var node = CreateNode(SampleData, title: "Languages");
@@ -127,7 +128,7 @@ public class DonutChartNodeTests
         Assert.Contains("Languages", titleRow);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_DonutHasRingShape_PixelsAtEdgeAndNotCenter()
     {
         var node = CreateNode([new("A", 100)], holeSize: 0.5);
@@ -147,10 +148,10 @@ public class DonutChartNodeTests
                              (centerCell.Character is not null && centerCell.Character != "\0" && centerCell.Character != " ");
         // This is a soft assertion — the exact pixel depends on radius math
         // Just verify the render completed without error
-        Assert.True(size.Width > 0);
+        Assert.IsTrue(size.Width > 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_PieMode_HoleSizeZero_FillsCenter()
     {
         var node = CreateNode([new("A", 100)], holeSize: 0.0);
@@ -164,10 +165,10 @@ public class DonutChartNodeTests
         var cell = surface[centerX, centerY];
         var hasContent = cell.Background is not null ||
                          (cell.Character is not null && cell.Character != "\0" && cell.Character != " ");
-        Assert.True(hasContent, "Pie mode (holeSize=0) should fill the center");
+        Assert.IsTrue(hasContent, "Pie mode (holeSize=0) should fill the center");
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_MultipleSegments_ProducesMultipleColors()
     {
         var node = CreateNode(SampleData);
@@ -186,23 +187,23 @@ public class DonutChartNodeTests
                 colors.Add($"bg:{bg.R},{bg.G},{bg.B}");
         }
 
-        Assert.True(colors.Count >= 3, $"Expected at least 3 colors for 3 segments, got {colors.Count}");
+        Assert.IsTrue(colors.Count >= 3, $"Expected at least 3 colors for 3 segments, got {colors.Count}");
     }
 
     #endregion
 
     #region Edge Case Tests
 
-    [Fact]
+    [TestMethod]
     public void Render_EmptyData_DoesNotCrash()
     {
         var node = CreateNode([]);
         var (_, size) = RenderNode(node, 40, 30);
         // Should not throw
-        Assert.True(size.Width > 0);
+        Assert.IsTrue(size.Width > 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_NullData_DoesNotCrash()
     {
         var node = new DonutChartNode<ChartItem>
@@ -220,7 +221,7 @@ public class DonutChartNodeTests
         // Should not throw
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_SingleSegment_FillsEntireRing()
     {
         var node = CreateNode([new("Only", 100)]);
@@ -235,10 +236,10 @@ public class DonutChartNodeTests
             if (surface[x, y].Background is not null || surface[x, y].Foreground is not null)
                 hasColor = true;
         }
-        Assert.True(hasColor, "Single segment donut should have colored content");
+        Assert.IsTrue(hasColor, "Single segment donut should have colored content");
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_VerySmallSize_DoesNotCrash()
     {
         var node = CreateNode(SampleData);
@@ -251,7 +252,7 @@ public class DonutChartNodeTests
         // Should not throw
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_ZeroValues_Excluded()
     {
         var data = new ChartItem[]
@@ -265,7 +266,7 @@ public class DonutChartNodeTests
 
         // Donut no longer renders labels — those are in LegendWidget
         // Just verify the render didn't crash
-        Assert.True(size.Width > 0);
+        Assert.IsTrue(size.Width > 0);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/DragBarPanelNodeTests.cs
+++ b/tests/Hex1b.Tests/DragBarPanelNodeTests.cs
@@ -5,11 +5,12 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class DragBarPanelNodeTests
 {
     #region Measure Tests
 
-    [Fact]
+    [TestMethod]
     public void Measure_RightEdge_ReturnsCurrentSizeAsWidth()
     {
         var node = new DragBarPanelNode
@@ -21,10 +22,10 @@ public class DragBarPanelNodeTests
 
         var size = node.Measure(new Constraints(0, 100, 0, 20));
 
-        Assert.Equal(30, size.Width);
+        Assert.AreEqual(30, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_LeftEdge_ReturnsCurrentSizeAsWidth()
     {
         var node = new DragBarPanelNode
@@ -36,10 +37,10 @@ public class DragBarPanelNodeTests
 
         var size = node.Measure(new Constraints(0, 100, 0, 20));
 
-        Assert.Equal(25, size.Width);
+        Assert.AreEqual(25, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_BottomEdge_ReturnsCurrentSizeAsHeight()
     {
         var node = new DragBarPanelNode
@@ -51,10 +52,10 @@ public class DragBarPanelNodeTests
 
         var size = node.Measure(new Constraints(0, 50, 0, 30));
 
-        Assert.Equal(15, size.Height);
+        Assert.AreEqual(15, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_TopEdge_ReturnsCurrentSizeAsHeight()
     {
         var node = new DragBarPanelNode
@@ -66,10 +67,10 @@ public class DragBarPanelNodeTests
 
         var size = node.Measure(new Constraints(0, 50, 0, 30));
 
-        Assert.Equal(12, size.Height);
+        Assert.AreEqual(12, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_DefaultSize_ReturnsMinimumDefaultOf10()
     {
         var node = new DragBarPanelNode
@@ -81,10 +82,10 @@ public class DragBarPanelNodeTests
         var size = node.Measure(new Constraints(0, 100, 0, 20));
 
         // _currentSize starts at 0, but Measure uses 10 as default minimum
-        Assert.True(size.Width >= 5);
+        Assert.IsTrue(size.Width >= 5);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_ConstrainedToMaxWidth()
     {
         var node = new DragBarPanelNode
@@ -96,14 +97,14 @@ public class DragBarPanelNodeTests
 
         var size = node.Measure(new Constraints(0, 30, 0, 20));
 
-        Assert.True(size.Width <= 30);
+        Assert.IsTrue(size.Width <= 30);
     }
 
     #endregion
 
     #region Arrange Tests
 
-    [Fact]
+    [TestMethod]
     public void Arrange_RightEdge_ContentGetsWidthMinusOne()
     {
         var content = new TextBlockNode { Text = "Content" };
@@ -117,11 +118,11 @@ public class DragBarPanelNodeTests
         node.Measure(new Constraints(0, 100, 0, 20));
         node.Arrange(new Rect(0, 0, 30, 20));
 
-        Assert.Equal(0, content.Bounds.X);
-        Assert.Equal(29, content.Bounds.Width);
+        Assert.AreEqual(0, content.Bounds.X);
+        Assert.AreEqual(29, content.Bounds.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_LeftEdge_ContentShiftedRightByOne()
     {
         var content = new TextBlockNode { Text = "Content" };
@@ -135,11 +136,11 @@ public class DragBarPanelNodeTests
         node.Measure(new Constraints(0, 100, 0, 20));
         node.Arrange(new Rect(5, 0, 30, 20));
 
-        Assert.Equal(6, content.Bounds.X);
-        Assert.Equal(29, content.Bounds.Width);
+        Assert.AreEqual(6, content.Bounds.X);
+        Assert.AreEqual(29, content.Bounds.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_BottomEdge_ContentGetsHeightMinusOne()
     {
         var content = new TextBlockNode { Text = "Content" };
@@ -153,11 +154,11 @@ public class DragBarPanelNodeTests
         node.Measure(new Constraints(0, 50, 0, 30));
         node.Arrange(new Rect(0, 0, 50, 15));
 
-        Assert.Equal(0, content.Bounds.Y);
-        Assert.Equal(14, content.Bounds.Height);
+        Assert.AreEqual(0, content.Bounds.Y);
+        Assert.AreEqual(14, content.Bounds.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_TopEdge_ContentShiftedDownByOne()
     {
         var content = new TextBlockNode { Text = "Content" };
@@ -171,15 +172,15 @@ public class DragBarPanelNodeTests
         node.Measure(new Constraints(0, 50, 0, 30));
         node.Arrange(new Rect(0, 2, 50, 15));
 
-        Assert.Equal(3, content.Bounds.Y);
-        Assert.Equal(14, content.Bounds.Height);
+        Assert.AreEqual(3, content.Bounds.Y);
+        Assert.AreEqual(14, content.Bounds.Height);
     }
 
     #endregion
 
     #region HitTestBounds Tests
 
-    [Fact]
+    [TestMethod]
     public void HitTestBounds_RightEdge_ReturnsRightmostColumn()
     {
         var node = new DragBarPanelNode
@@ -192,12 +193,12 @@ public class DragBarPanelNodeTests
         node.Arrange(new Rect(0, 0, 30, 20));
 
         var hitBounds = node.HitTestBounds;
-        Assert.Equal(29, hitBounds.X);
-        Assert.Equal(1, hitBounds.Width);
-        Assert.Equal(20, hitBounds.Height);
+        Assert.AreEqual(29, hitBounds.X);
+        Assert.AreEqual(1, hitBounds.Width);
+        Assert.AreEqual(20, hitBounds.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void HitTestBounds_LeftEdge_ReturnsLeftmostColumn()
     {
         var node = new DragBarPanelNode
@@ -210,11 +211,11 @@ public class DragBarPanelNodeTests
         node.Arrange(new Rect(5, 0, 30, 20));
 
         var hitBounds = node.HitTestBounds;
-        Assert.Equal(5, hitBounds.X);
-        Assert.Equal(1, hitBounds.Width);
+        Assert.AreEqual(5, hitBounds.X);
+        Assert.AreEqual(1, hitBounds.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void HitTestBounds_BottomEdge_ReturnsBottomRow()
     {
         var node = new DragBarPanelNode
@@ -227,12 +228,12 @@ public class DragBarPanelNodeTests
         node.Arrange(new Rect(0, 0, 50, 15));
 
         var hitBounds = node.HitTestBounds;
-        Assert.Equal(14, hitBounds.Y);
-        Assert.Equal(1, hitBounds.Height);
-        Assert.Equal(50, hitBounds.Width);
+        Assert.AreEqual(14, hitBounds.Y);
+        Assert.AreEqual(1, hitBounds.Height);
+        Assert.AreEqual(50, hitBounds.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void HitTestBounds_TopEdge_ReturnsTopRow()
     {
         var node = new DragBarPanelNode
@@ -245,15 +246,15 @@ public class DragBarPanelNodeTests
         node.Arrange(new Rect(0, 2, 50, 15));
 
         var hitBounds = node.HitTestBounds;
-        Assert.Equal(2, hitBounds.Y);
-        Assert.Equal(1, hitBounds.Height);
+        Assert.AreEqual(2, hitBounds.Y);
+        Assert.AreEqual(1, hitBounds.Height);
     }
 
     #endregion
 
     #region Size Clamping Tests
 
-    [Fact]
+    [TestMethod]
     public void CurrentSize_ClampsToMinSize()
     {
         var node = new DragBarPanelNode
@@ -262,10 +263,10 @@ public class DragBarPanelNodeTests
             CurrentSize = 3
         };
 
-        Assert.Equal(10, node.CurrentSize);
+        Assert.AreEqual(10, node.CurrentSize);
     }
 
-    [Fact]
+    [TestMethod]
     public void CurrentSize_ClampsToMaxSize()
     {
         var node = new DragBarPanelNode
@@ -274,10 +275,10 @@ public class DragBarPanelNodeTests
             CurrentSize = 100
         };
 
-        Assert.Equal(50, node.CurrentSize);
+        Assert.AreEqual(50, node.CurrentSize);
     }
 
-    [Fact]
+    [TestMethod]
     public void CurrentSize_WithinBounds_NotClamped()
     {
         var node = new DragBarPanelNode
@@ -287,14 +288,14 @@ public class DragBarPanelNodeTests
             CurrentSize = 30
         };
 
-        Assert.Equal(30, node.CurrentSize);
+        Assert.AreEqual(30, node.CurrentSize);
     }
 
     #endregion
 
     #region Keyboard Input Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_RightArrow_RightEdge_IncreasesSize()
     {
         var node = new DragBarPanelNode
@@ -311,10 +312,10 @@ public class DragBarPanelNodeTests
             node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None),
             null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(22, node.CurrentSize);
+        Assert.AreEqual(22, node.CurrentSize);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_LeftArrow_RightEdge_DecreasesSize()
     {
         var node = new DragBarPanelNode
@@ -331,10 +332,10 @@ public class DragBarPanelNodeTests
             node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None),
             null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(18, node.CurrentSize);
+        Assert.AreEqual(18, node.CurrentSize);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_LeftArrow_LeftEdge_IncreasesSize()
     {
         var node = new DragBarPanelNode
@@ -351,10 +352,10 @@ public class DragBarPanelNodeTests
             node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None),
             null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(22, node.CurrentSize);
+        Assert.AreEqual(22, node.CurrentSize);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_DownArrow_BottomEdge_IncreasesSize()
     {
         var node = new DragBarPanelNode
@@ -371,10 +372,10 @@ public class DragBarPanelNodeTests
             node, new Hex1bKeyEvent(Hex1bKey.DownArrow, '\0', Hex1bModifiers.None),
             null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(17, node.CurrentSize);
+        Assert.AreEqual(17, node.CurrentSize);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_UpArrow_TopEdge_IncreasesSize()
     {
         var node = new DragBarPanelNode
@@ -391,10 +392,10 @@ public class DragBarPanelNodeTests
             node, new Hex1bKeyEvent(Hex1bKey.UpArrow, '\0', Hex1bModifiers.None),
             null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(17, node.CurrentSize);
+        Assert.AreEqual(17, node.CurrentSize);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_HorizontalArrows_DoNotAffectVerticalEdge()
     {
         var node = new DragBarPanelNode
@@ -412,10 +413,10 @@ public class DragBarPanelNodeTests
             null, null, TestContext.Current.CancellationToken);
 
         // Binding executes but orientation check prevents resize
-        Assert.Equal(15, node.CurrentSize);
+        Assert.AreEqual(15, node.CurrentSize);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_NotFocused_DoesNotResize()
     {
         var node = new DragBarPanelNode
@@ -431,10 +432,10 @@ public class DragBarPanelNodeTests
             node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None),
             null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(20, node.CurrentSize);
+        Assert.AreEqual(20, node.CurrentSize);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Resize_ClampsToMinSize()
     {
         var node = new DragBarPanelNode
@@ -452,10 +453,10 @@ public class DragBarPanelNodeTests
             node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None),
             null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(5, node.CurrentSize);
+        Assert.AreEqual(5, node.CurrentSize);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Resize_ClampsToMaxSize()
     {
         var node = new DragBarPanelNode
@@ -473,21 +474,21 @@ public class DragBarPanelNodeTests
             node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None),
             null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(50, node.CurrentSize);
+        Assert.AreEqual(50, node.CurrentSize);
     }
 
     #endregion
 
     #region Focusable Tests
 
-    [Fact]
+    [TestMethod]
     public void IsFocusable_ReturnsTrue()
     {
         var node = new DragBarPanelNode();
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetFocusableNodes_IncludesSelfAndContentChildren()
     {
         var button = new ButtonNode { Label = "Click" };
@@ -502,7 +503,7 @@ public class DragBarPanelNodeTests
         Assert.Contains(button, focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_ReturnsContentChild()
     {
         var content = new TextBlockNode { Text = "Content" };
@@ -513,23 +514,23 @@ public class DragBarPanelNodeTests
 
         var children = node.GetChildren().ToList();
 
-        Assert.Single(children);
-        Assert.Same(content, children[0]);
+        TestSeq.Single(children);
+        Assert.AreSame(content, children[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_NoContent_ReturnsEmpty()
     {
         var node = new DragBarPanelNode();
         var children = node.GetChildren().ToList();
-        Assert.Empty(children);
+        Assert.IsEmpty(children);
     }
 
     #endregion
 
     #region Edge Auto-Detection Tests (via Widget Reconciliation)
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_HStack_FirstChild_DetectsRightEdge()
     {
         var widget = new DragBarPanelWidget { Content = new TextBlockWidget("Content"), InitialSize = 20 };
@@ -540,11 +541,11 @@ public class DragBarPanelNodeTests
 
         var node = await widget.ReconcileAsync(null, context) as DragBarPanelNode;
 
-        Assert.NotNull(node);
-        Assert.Equal(DragBarEdge.Right, node!.ResolvedEdge);
+        Assert.IsNotNull(node);
+        Assert.AreEqual(DragBarEdge.Right, node!.ResolvedEdge);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_HStack_LastChild_DetectsLeftEdge()
     {
         var widget = new DragBarPanelWidget { Content = new TextBlockWidget("Content"), InitialSize = 20 };
@@ -555,11 +556,11 @@ public class DragBarPanelNodeTests
 
         var node = await widget.ReconcileAsync(null, context) as DragBarPanelNode;
 
-        Assert.NotNull(node);
-        Assert.Equal(DragBarEdge.Left, node!.ResolvedEdge);
+        Assert.IsNotNull(node);
+        Assert.AreEqual(DragBarEdge.Left, node!.ResolvedEdge);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_VStack_FirstChild_DetectsBottomEdge()
     {
         var widget = new DragBarPanelWidget { Content = new TextBlockWidget("Content"), InitialSize = 15 };
@@ -570,11 +571,11 @@ public class DragBarPanelNodeTests
 
         var node = await widget.ReconcileAsync(null, context) as DragBarPanelNode;
 
-        Assert.NotNull(node);
-        Assert.Equal(DragBarEdge.Bottom, node!.ResolvedEdge);
+        Assert.IsNotNull(node);
+        Assert.AreEqual(DragBarEdge.Bottom, node!.ResolvedEdge);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_VStack_LastChild_DetectsTopEdge()
     {
         var widget = new DragBarPanelWidget { Content = new TextBlockWidget("Content"), InitialSize = 15 };
@@ -585,11 +586,11 @@ public class DragBarPanelNodeTests
 
         var node = await widget.ReconcileAsync(null, context) as DragBarPanelNode;
 
-        Assert.NotNull(node);
-        Assert.Equal(DragBarEdge.Top, node!.ResolvedEdge);
+        Assert.IsNotNull(node);
+        Assert.AreEqual(DragBarEdge.Top, node!.ResolvedEdge);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_ExplicitEdge_OverridesAutoDetection()
     {
         var widget = new DragBarPanelWidget { Content = new TextBlockWidget("Content"), InitialSize = 20, Edge = DragBarEdge.Top };
@@ -600,11 +601,11 @@ public class DragBarPanelNodeTests
 
         var node = await widget.ReconcileAsync(null, context) as DragBarPanelNode;
 
-        Assert.NotNull(node);
-        Assert.Equal(DragBarEdge.Top, node!.ResolvedEdge);
+        Assert.IsNotNull(node);
+        Assert.AreEqual(DragBarEdge.Top, node!.ResolvedEdge);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_PreservesCurrentSize_OnRereconcile()
     {
         var widget = new DragBarPanelWidget { Content = new TextBlockWidget("Content"), InitialSize = 20 };
@@ -612,7 +613,7 @@ public class DragBarPanelNodeTests
         context.IsNew = true;
 
         var node = await widget.ReconcileAsync(null, context) as DragBarPanelNode;
-        Assert.Equal(20, node!.CurrentSize);
+        Assert.AreEqual(20, node!.CurrentSize);
 
         // Simulate user resize
         node.CurrentSize = 35;
@@ -622,58 +623,58 @@ public class DragBarPanelNodeTests
         context2.IsNew = false;
         var node2 = await widget.ReconcileAsync(node, context2) as DragBarPanelNode;
 
-        Assert.Same(node, node2);
-        Assert.Equal(35, node2!.CurrentSize); // Preserved, not reset to 20
+        Assert.AreSame(node, node2);
+        Assert.AreEqual(35, node2!.CurrentSize); // Preserved, not reset to 20
     }
 
     #endregion
 
     #region Extension Method Tests
 
-    [Fact]
+    [TestMethod]
     public void DragBarPanel_Extension_CreatesWidget()
     {
         var ctx = new WidgetContext<VStackWidget>();
         var widget = ctx.DragBarPanel(c => c.Text("Hello"));
 
-        Assert.NotNull(widget);
-        Assert.IsType<DragBarPanelWidget>(widget);
+        Assert.IsNotNull(widget);
+        TestSeq.IsType<DragBarPanelWidget>(widget);
     }
 
-    [Fact]
+    [TestMethod]
     public void InitialSize_SetsProperty()
     {
         var ctx = new WidgetContext<VStackWidget>();
         var widget = ctx.DragBarPanel(c => c.Text("Hello")).InitialSize(30);
 
-        Assert.Equal(30, widget.InitialSize);
+        Assert.AreEqual(30, widget.InitialSize);
     }
 
-    [Fact]
+    [TestMethod]
     public void MinSize_SetsProperty()
     {
         var ctx = new WidgetContext<VStackWidget>();
         var widget = ctx.DragBarPanel(c => c.Text("Hello")).MinSize(10);
 
-        Assert.Equal(10, widget.MinimumSize);
+        Assert.AreEqual(10, widget.MinimumSize);
     }
 
-    [Fact]
+    [TestMethod]
     public void MaxSize_SetsProperty()
     {
         var ctx = new WidgetContext<VStackWidget>();
         var widget = ctx.DragBarPanel(c => c.Text("Hello")).MaxSize(50);
 
-        Assert.Equal(50, widget.MaximumSize);
+        Assert.AreEqual(50, widget.MaximumSize);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleEdge_SetsProperty()
     {
         var ctx = new WidgetContext<VStackWidget>();
         var widget = ctx.DragBarPanel(c => c.Text("Hello")).HandleEdge(DragBarEdge.Left);
 
-        Assert.Equal(DragBarEdge.Left, widget.Edge);
+        Assert.AreEqual(DragBarEdge.Left, widget.Edge);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/DragDropIntegrationTests.cs
+++ b/tests/Hex1b.Tests/DragDropIntegrationTests.cs
@@ -12,60 +12,61 @@ namespace Hex1b.Tests;
 /// IconNode clickability, WindowPanel background interactivity,
 /// and a realistic multi-column drag scenario with overlays and drop targets.
 /// </summary>
+[TestClass]
 public class DragDropIntegrationTests
 {
     #region DraggableNode IsHovered Tests
 
-    [Fact]
+    [TestMethod]
     public void DraggableNode_IsHovered_DefaultFalse()
     {
         var node = new DraggableNode();
-        Assert.False(node.IsHovered);
+        Assert.IsFalse(node.IsHovered);
     }
 
-    [Fact]
+    [TestMethod]
     public void DraggableNode_IsHovered_SetTrue_MarksDirty()
     {
         var node = new DraggableNode { Child = new TextBlockNode { Text = "test" } };
         node.IsHovered = true;
-        Assert.True(node.IsHovered);
+        Assert.IsTrue(node.IsHovered);
     }
 
-    [Fact]
+    [TestMethod]
     public void DraggableNode_IsHovered_SetSameValue_NoChange()
     {
         var node = new DraggableNode();
         node.IsHovered = false; // Already false
-        Assert.False(node.IsHovered);
+        Assert.IsFalse(node.IsHovered);
     }
 
-    [Fact]
+    [TestMethod]
     public void DraggableContext_IsHovered_ReflectsNodeState()
     {
         var node = new DraggableNode { DragData = "test" };
         var context = new DraggableContext(node);
 
-        Assert.False(context.IsHovered);
+        Assert.IsFalse(context.IsHovered);
 
         node.IsHovered = true;
-        Assert.True(context.IsHovered);
+        Assert.IsTrue(context.IsHovered);
 
         node.IsHovered = false;
-        Assert.False(context.IsHovered);
+        Assert.IsFalse(context.IsHovered);
     }
 
     #endregion
 
     #region IconNode Focusable Tests
 
-    [Fact]
+    [TestMethod]
     public void IconNode_NotClickable_NotFocusable()
     {
         var node = new IconNode { Icon = "x" };
-        Assert.False(node.IsFocusable);
+        Assert.IsFalse(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public void IconNode_WithClickHandler_IsFocusable()
     {
         var node = new IconNode
@@ -73,11 +74,11 @@ public class DragDropIntegrationTests
             Icon = "x",
             ClickCallback = _ => Task.CompletedTask
         };
-        Assert.True(node.IsFocusable);
-        Assert.True(node.IsClickable);
+        Assert.IsTrue(node.IsFocusable);
+        Assert.IsTrue(node.IsClickable);
     }
 
-    [Fact]
+    [TestMethod]
     public void IconNode_WithClickHandler_HasHitTestBounds()
     {
         var node = new IconNode
@@ -88,24 +89,24 @@ public class DragDropIntegrationTests
         node.Measure(new Constraints(0, 40, 0, 10));
         node.Arrange(new Rect(5, 3, 1, 1));
 
-        Assert.Equal(new Rect(5, 3, 1, 1), node.HitTestBounds);
+        Assert.AreEqual(new Rect(5, 3, 1, 1), node.HitTestBounds);
     }
 
-    [Fact]
+    [TestMethod]
     public void IconNode_WithoutClickHandler_DefaultHitTestBounds()
     {
         var node = new IconNode { Icon = "x" };
         node.Measure(new Constraints(0, 40, 0, 10));
         node.Arrange(new Rect(5, 3, 1, 1));
 
-        Assert.Equal(default(Rect), node.HitTestBounds);
+        Assert.AreEqual(default(Rect), node.HitTestBounds);
     }
 
     #endregion
 
     #region WindowPanel Background Input Routing Tests
 
-    [Fact]
+    [TestMethod]
     public void WindowPanelNode_GetChildren_IncludesBackground()
     {
         var bgNode = new TextBlockNode { Text = "bg" };
@@ -119,10 +120,10 @@ public class DragDropIntegrationTests
         // Background should be first (lowest hit priority), then windows
         Assert.Contains(bgNode, children);
         Assert.Contains(windowNode, children);
-        Assert.Equal(bgNode, children[0]);
+        Assert.AreEqual(bgNode, children[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowPanelNode_GetChildren_NullBackground_OnlyWindows()
     {
         var windowNode = new WindowNode();
@@ -132,15 +133,15 @@ public class DragDropIntegrationTests
 
         var children = panel.GetChildren().ToList();
 
-        Assert.Single(children);
-        Assert.Same(windowNode, children[0]);
+        TestSeq.Single(children);
+        Assert.AreSame(windowNode, children[0]);
     }
 
     #endregion
 
     #region Drop Target Proximity Manhattan Distance Tests
 
-    [Fact]
+    [TestMethod]
     public void DroppableNode_FindDropTargets_HorizontalLayout_FoundByPosition()
     {
         // Simulate a horizontal layout of drop targets (like between commands on a track)
@@ -156,17 +157,17 @@ public class DragDropIntegrationTests
         droppable.Child = hstack;
 
         var targets = droppable.FindDropTargets();
-        Assert.Equal(3, targets.Count);
-        Assert.Equal("pos-0", targets[0].TargetId);
-        Assert.Equal("pos-1", targets[1].TargetId);
-        Assert.Equal("pos-2", targets[2].TargetId);
+        Assert.AreEqual(3, targets.Count);
+        Assert.AreEqual("pos-0", targets[0].TargetId);
+        Assert.AreEqual("pos-1", targets[1].TargetId);
+        Assert.AreEqual("pos-2", targets[2].TargetId);
     }
 
     #endregion
 
     #region Full Stack Drag-Drop Integration Tests
 
-    [Fact]
+    [TestMethod]
     public async Task DragDrop_DragFromSourceToTarget_DropsData()
     {
         var dropped = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -216,10 +217,10 @@ public class DragDropIntegrationTests
         await runTask;
 
         var result = await dropped.Task.WaitAsync(TimeSpan.FromSeconds(2));
-        Assert.Equal("task-1", result);
+        Assert.AreEqual("task-1", result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DragDrop_AcceptPredicate_RejectsInvalidData()
     {
         var dropOccurred = false;
@@ -259,10 +260,10 @@ public class DragDropIntegrationTests
 
         await runTask;
 
-        Assert.False(dropOccurred, "Drop should be rejected because data is int, not string");
+        Assert.IsFalse(dropOccurred, "Drop should be rejected because data is int, not string");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DragDrop_DragOverlay_ShowsGhostWhileDragging()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -309,7 +310,7 @@ public class DragDropIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DragDrop_DropTarget_ActivatesNearestTarget()
     {
         string? droppedTargetId = null;
@@ -360,10 +361,10 @@ public class DragDropIntegrationTests
         await runTask;
 
         // A drop target should have been selected (exact one depends on proximity)
-        Assert.NotNull(droppedTargetId);
+        Assert.IsNotNull(droppedTargetId);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DragDrop_RealisticKanban_DragBetweenColumns()
     {
         // Realistic scenario: two columns with items, drag an item from column 1 to column 2
@@ -461,13 +462,13 @@ public class DragDropIntegrationTests
         await runTask;
 
         var result = await dropSignal.Task.WaitAsync(TimeSpan.FromSeconds(2));
-        Assert.Equal("Task A", result.Item);
-        Assert.Equal("Column 2", result.Column);
+        Assert.AreEqual("Task A", result.Item);
+        Assert.AreEqual("Column 2", result.Column);
         Assert.Contains("Task A", column2Items);
         Assert.DoesNotContain("Task A", column1Items);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DragDrop_IsDragging_SourceShowsPlaceholder()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -509,7 +510,7 @@ public class DragDropIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DragDrop_HoverState_DroppableShowsFeedback()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -557,7 +558,7 @@ public class DragDropIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task IconWidget_Clickable_ReceivesClick()
     {
         var clicked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -592,10 +593,10 @@ public class DragDropIntegrationTests
         await runTask;
 
         var didClick = await Task.WhenAny(clicked.Task, Task.Delay(2000)) == clicked.Task;
-        Assert.True(didClick, "Icon click handler should have fired");
+        Assert.IsTrue(didClick, "Icon click handler should have fired");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WindowPanel_BackgroundInteractive_ReceivesDrops()
     {
         var dropped = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -640,7 +641,7 @@ public class DragDropIntegrationTests
         await runTask;
 
         var result = await dropped.Task.WaitAsync(TimeSpan.FromSeconds(2));
-        Assert.Equal("payload", result);
+        Assert.AreEqual("payload", result);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/DragDropTests.cs
+++ b/tests/Hex1b.Tests/DragDropTests.cs
@@ -9,41 +9,42 @@ namespace Hex1b.Tests;
 /// Tests for DraggableNode, DraggableWidget, DroppableNode, DroppableWidget,
 /// DragDropManager, and the drag-drop extension methods.
 /// </summary>
+[TestClass]
 public class DragDropTests
 {
     #region DraggableNode Tests
 
-    [Fact]
+    [TestMethod]
     public void DraggableNode_IsFocusable_ReturnsTrue()
     {
         var node = new DraggableNode();
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public void DraggableNode_IsDragging_DefaultFalse()
     {
         var node = new DraggableNode();
-        Assert.False(node.IsDragging);
+        Assert.IsFalse(node.IsDragging);
     }
 
-    [Fact]
+    [TestMethod]
     public void DraggableNode_IsDragging_SetTrue_MarksDirty()
     {
         var node = new DraggableNode();
         node.IsDragging = true;
-        Assert.True(node.IsDragging);
+        Assert.IsTrue(node.IsDragging);
     }
 
-    [Fact]
+    [TestMethod]
     public void DraggableNode_IsDragging_SetSameValue_NoChange()
     {
         var node = new DraggableNode();
         node.IsDragging = false; // Already false
-        Assert.False(node.IsDragging);
+        Assert.IsFalse(node.IsDragging);
     }
 
-    [Fact]
+    [TestMethod]
     public void DraggableNode_Measure_DelegatesToChild()
     {
         var child = new ButtonNode { Label = "Drag Me" };
@@ -52,20 +53,20 @@ public class DragDropTests
         var size = node.Measure(Constraints.Unbounded);
 
         // ButtonNode: " Drag Me " = 2 + 7 = 9 (Phase 2 chip layout)
-        Assert.Equal(9, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(9, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void DraggableNode_Measure_NullChild_ReturnsZero()
     {
         var node = new DraggableNode { Child = null };
         var size = node.Measure(Constraints.Unbounded);
-        Assert.Equal(0, size.Width);
-        Assert.Equal(0, size.Height);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(0, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void DraggableNode_Arrange_DelegatesToChild()
     {
         var child = new ButtonNode { Label = "Test" };
@@ -75,10 +76,10 @@ public class DragDropTests
 
         node.Arrange(rect);
 
-        Assert.Equal(rect, child.Bounds);
+        Assert.AreEqual(rect, child.Bounds);
     }
 
-    [Fact]
+    [TestMethod]
     public void DraggableNode_GetChildren_ReturnsChild()
     {
         var child = new ButtonNode { Label = "Test" };
@@ -86,18 +87,18 @@ public class DragDropTests
 
         var children = node.GetChildren();
 
-        Assert.Single(children);
-        Assert.Same(child, children[0]);
+        TestSeq.Single(children);
+        Assert.AreSame(child, children[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void DraggableNode_GetChildren_NullChild_ReturnsEmpty()
     {
         var node = new DraggableNode { Child = null };
-        Assert.Empty(node.GetChildren());
+        Assert.IsEmpty(node.GetChildren());
     }
 
-    [Fact]
+    [TestMethod]
     public void DraggableNode_GetFocusableNodes_ReturnsOnlySelf()
     {
         var child = new ButtonNode { Label = "Focusable" };
@@ -105,11 +106,11 @@ public class DragDropTests
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Single(focusables);
-        Assert.Same(node, focusables[0]);
+        TestSeq.Single(focusables);
+        Assert.AreSame(node, focusables[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void DraggableNode_HitTestBounds_EqualsBounds()
     {
         var node = new DraggableNode { Child = new ButtonNode { Label = "Test" } };
@@ -117,52 +118,52 @@ public class DragDropTests
         var rect = new Rect(0, 0, 10, 1);
         node.Arrange(rect);
 
-        Assert.Equal(rect, node.HitTestBounds);
+        Assert.AreEqual(rect, node.HitTestBounds);
     }
 
-    [Fact]
+    [TestMethod]
     public void DraggableNode_DragData_CanBeSet()
     {
         var data = new { Id = "task-1", Name = "Test Task" };
         var node = new DraggableNode { DragData = data };
-        Assert.Same(data, node.DragData);
+        Assert.AreSame(data, node.DragData);
     }
 
     #endregion
 
     #region DroppableNode Tests
 
-    [Fact]
+    [TestMethod]
     public void DroppableNode_IsFocusable_ReturnsFalse()
     {
         var node = new DroppableNode();
-        Assert.False(node.IsFocusable);
+        Assert.IsFalse(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public void DroppableNode_IsHoveredByDrag_DefaultFalse()
     {
         var node = new DroppableNode();
-        Assert.False(node.IsHoveredByDrag);
+        Assert.IsFalse(node.IsHoveredByDrag);
     }
 
-    [Fact]
+    [TestMethod]
     public void DroppableNode_IsHoveredByDrag_SetTrue_MarksDirty()
     {
         var node = new DroppableNode();
         node.IsHoveredByDrag = true;
-        Assert.True(node.IsHoveredByDrag);
+        Assert.IsTrue(node.IsHoveredByDrag);
     }
 
-    [Fact]
+    [TestMethod]
     public void DroppableNode_Accepts_NoPredicate_AcceptsAll()
     {
         var node = new DroppableNode { AcceptPredicate = null };
-        Assert.True(node.Accepts("anything"));
-        Assert.True(node.Accepts(42));
+        Assert.IsTrue(node.Accepts("anything"));
+        Assert.IsTrue(node.Accepts(42));
     }
 
-    [Fact]
+    [TestMethod]
     public void DroppableNode_Accepts_WithPredicate_FiltersCorrectly()
     {
         var node = new DroppableNode
@@ -170,12 +171,12 @@ public class DragDropTests
             AcceptPredicate = data => data is string s && s.StartsWith("task")
         };
 
-        Assert.True(node.Accepts("task-1"));
-        Assert.False(node.Accepts("bug-1"));
-        Assert.False(node.Accepts(42));
+        Assert.IsTrue(node.Accepts("task-1"));
+        Assert.IsFalse(node.Accepts("bug-1"));
+        Assert.IsFalse(node.Accepts(42));
     }
 
-    [Fact]
+    [TestMethod]
     public void DroppableNode_Measure_DelegatesToChild()
     {
         var child = new ButtonNode { Label = "Drop" };
@@ -183,11 +184,11 @@ public class DragDropTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(6, size.Width); // " Drop " (Phase 2 chip layout)
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(6, size.Width); // " Drop " (Phase 2 chip layout)
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void DroppableNode_GetFocusableNodes_ReturnsFocusableChildren()
     {
         var button = new ButtonNode { Label = "Click" };
@@ -196,29 +197,29 @@ public class DragDropTests
         var focusables = node.GetFocusableNodes().ToList();
 
         // DroppableNode delegates to children
-        Assert.Single(focusables);
-        Assert.Same(button, focusables[0]);
+        TestSeq.Single(focusables);
+        Assert.AreSame(button, focusables[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void DroppableNode_GetFocusableNodes_NullChild_ReturnsEmpty()
     {
         var node = new DroppableNode { Child = null };
-        Assert.Empty(node.GetFocusableNodes());
+        Assert.IsEmpty(node.GetFocusableNodes());
     }
 
     #endregion
 
     #region DragDropManager Tests
 
-    [Fact]
+    [TestMethod]
     public void DragDropManager_IsDragging_DefaultFalse()
     {
         var manager = new DragDropManager();
-        Assert.False(manager.IsDragging);
+        Assert.IsFalse(manager.IsDragging);
     }
 
-    [Fact]
+    [TestMethod]
     public void DragDropManager_StartDrag_SetsState()
     {
         var manager = new DragDropManager();
@@ -226,15 +227,15 @@ public class DragDropTests
 
         manager.StartDrag(source, "test-data", 10, 20);
 
-        Assert.True(manager.IsDragging);
-        Assert.Same(source, manager.ActiveSource);
-        Assert.Equal("test-data", manager.ActiveDragData);
-        Assert.Equal(10, manager.DragX);
-        Assert.Equal(20, manager.DragY);
-        Assert.Null(manager.HoveredTarget);
+        Assert.IsTrue(manager.IsDragging);
+        Assert.AreSame(source, manager.ActiveSource);
+        Assert.AreEqual("test-data", manager.ActiveDragData);
+        Assert.AreEqual(10, manager.DragX);
+        Assert.AreEqual(20, manager.DragY);
+        Assert.IsNull(manager.HoveredTarget);
     }
 
-    [Fact]
+    [TestMethod]
     public void DragDropManager_UpdatePosition_UpdatesState()
     {
         var manager = new DragDropManager();
@@ -244,12 +245,12 @@ public class DragDropTests
         manager.StartDrag(source, "data", 0, 0);
         manager.UpdatePosition(15, 25, target);
 
-        Assert.Equal(15, manager.DragX);
-        Assert.Equal(25, manager.DragY);
-        Assert.Same(target, manager.HoveredTarget);
+        Assert.AreEqual(15, manager.DragX);
+        Assert.AreEqual(25, manager.DragY);
+        Assert.AreSame(target, manager.HoveredTarget);
     }
 
-    [Fact]
+    [TestMethod]
     public void DragDropManager_EndDrag_ClearsState()
     {
         var manager = new DragDropManager();
@@ -260,98 +261,98 @@ public class DragDropTests
         manager.UpdatePosition(15, 25, target);
         manager.EndDrag();
 
-        Assert.False(manager.IsDragging);
-        Assert.Null(manager.ActiveSource);
-        Assert.Null(manager.ActiveDragData);
-        Assert.Null(manager.HoveredTarget);
+        Assert.IsFalse(manager.IsDragging);
+        Assert.IsNull(manager.ActiveSource);
+        Assert.IsNull(manager.ActiveDragData);
+        Assert.IsNull(manager.HoveredTarget);
     }
 
     #endregion
 
     #region Widget Reconciliation Tests
 
-    [Fact]
+    [TestMethod]
     public void DraggableWidget_GetExpectedNodeType_ReturnsDraggableNode()
     {
         var widget = new DraggableWidget("drag-data", dc => new TextBlockWidget("Test"));
-        Assert.Equal(typeof(DraggableNode), widget.GetExpectedNodeType());
+        Assert.AreEqual(typeof(DraggableNode), widget.GetExpectedNodeType());
     }
 
-    [Fact]
+    [TestMethod]
     public void DroppableWidget_GetExpectedNodeType_ReturnsDroppableNode()
     {
         var widget = new DroppableWidget(dc => new TextBlockWidget("Target"));
-        Assert.Equal(typeof(DroppableNode), widget.GetExpectedNodeType());
+        Assert.AreEqual(typeof(DroppableNode), widget.GetExpectedNodeType());
     }
 
     #endregion
 
     #region Context Tests
 
-    [Fact]
+    [TestMethod]
     public void DraggableContext_IsDragging_ReflectsNodeState()
     {
         var node = new DraggableNode { DragData = "test" };
         var context = new DraggableContext(node);
 
-        Assert.False(context.IsDragging);
+        Assert.IsFalse(context.IsDragging);
 
         node.IsDragging = true;
-        Assert.True(context.IsDragging);
+        Assert.IsTrue(context.IsDragging);
     }
 
-    [Fact]
+    [TestMethod]
     public void DraggableContext_DragData_ReflectsNodeState()
     {
         var node = new DraggableNode { DragData = "my-data" };
         var context = new DraggableContext(node);
 
-        Assert.Equal("my-data", context.DragData);
+        Assert.AreEqual("my-data", context.DragData);
     }
 
-    [Fact]
+    [TestMethod]
     public void DroppableContext_IsHoveredByDrag_ReflectsNodeState()
     {
         var node = new DroppableNode();
         var context = new DroppableContext(node);
 
-        Assert.False(context.IsHoveredByDrag);
+        Assert.IsFalse(context.IsHoveredByDrag);
 
         node.IsHoveredByDrag = true;
-        Assert.True(context.IsHoveredByDrag);
+        Assert.IsTrue(context.IsHoveredByDrag);
     }
 
-    [Fact]
+    [TestMethod]
     public void DroppableContext_CanAcceptDrag_ReflectsNodeState()
     {
         var node = new DroppableNode { CanAcceptDrag = true };
         var context = new DroppableContext(node);
-        Assert.True(context.CanAcceptDrag);
+        Assert.IsTrue(context.CanAcceptDrag);
     }
 
-    [Fact]
+    [TestMethod]
     public void DroppableContext_HoveredDragData_ReflectsNodeState()
     {
         var node = new DroppableNode { HoveredDragData = "test-data" };
         var context = new DroppableContext(node);
-        Assert.Equal("test-data", context.HoveredDragData);
+        Assert.AreEqual("test-data", context.HoveredDragData);
     }
 
     #endregion
 
     #region Extension Method Tests
 
-    [Fact]
+    [TestMethod]
     public void Draggable_Extension_CreatesDraggableWidget()
     {
         var ctx = new WidgetContext<VStackWidget>();
         var widget = ctx.Draggable("data", dc => new TextBlockWidget("Content"));
 
-        Assert.IsType<DraggableWidget>(widget);
-        Assert.Equal("data", widget.DragData);
+        TestSeq.IsType<DraggableWidget>(widget);
+        Assert.AreEqual("data", widget.DragData);
     }
 
-    [Fact]
+    [TestMethod]
     public void Draggable_ArrayExtension_CreatesDraggableWidget()
     {
         var ctx = new WidgetContext<VStackWidget>();
@@ -361,57 +362,57 @@ public class DragDropTests
             new TextBlockWidget("Line 2"),
         });
 
-        Assert.IsType<DraggableWidget>(widget);
+        TestSeq.IsType<DraggableWidget>(widget);
     }
 
-    [Fact]
+    [TestMethod]
     public void Droppable_Extension_CreatesDroppableWidget()
     {
         var ctx = new WidgetContext<VStackWidget>();
         var widget = ctx.Droppable(dc => new TextBlockWidget("Target"));
 
-        Assert.IsType<DroppableWidget>(widget);
+        TestSeq.IsType<DroppableWidget>(widget);
     }
 
-    [Fact]
+    [TestMethod]
     public void DraggableWidget_DragOverlay_SetsBuilder()
     {
         var widget = new DraggableWidget("data", dc => new TextBlockWidget("Content"))
             .DragOverlay(dc => new TextBlockWidget("Ghost"));
 
-        Assert.NotNull(widget.DragOverlayBuilder);
+        Assert.IsNotNull(widget.DragOverlayBuilder);
     }
 
-    [Fact]
+    [TestMethod]
     public void DroppableWidget_Accept_SetsPredicate()
     {
         var widget = new DroppableWidget(dc => new TextBlockWidget("Target"))
             .Accept(data => data is string);
 
-        Assert.NotNull(widget.AcceptPredicate);
+        Assert.IsNotNull(widget.AcceptPredicate);
     }
 
-    [Fact]
+    [TestMethod]
     public void DroppableWidget_OnDrop_SetsHandler()
     {
         var widget = new DroppableWidget(dc => new TextBlockWidget("Target"))
             .OnDrop(e => { });
 
-        Assert.NotNull(widget.DropHandler);
+        Assert.IsNotNull(widget.DropHandler);
     }
 
     #endregion
 
     #region Drag Overlay Tests
 
-    [Fact]
+    [TestMethod]
     public void DragDropManager_BuildOverlayWidget_NoDrag_ReturnsNull()
     {
         var manager = new DragDropManager();
-        Assert.Null(manager.BuildOverlayWidget());
+        Assert.IsNull(manager.BuildOverlayWidget());
     }
 
-    [Fact]
+    [TestMethod]
     public void DragDropManager_BuildOverlayWidget_NoBuilder_ReturnsNull()
     {
         var manager = new DragDropManager();
@@ -424,10 +425,10 @@ public class DragDropTests
         manager.StartDrag(source, "test", 10, 20);
 
         // No DragOverlayBuilder set on the widget
-        Assert.Null(manager.BuildOverlayWidget());
+        Assert.IsNull(manager.BuildOverlayWidget());
     }
 
-    [Fact]
+    [TestMethod]
     public void DragDropManager_BuildOverlayWidget_WithBuilder_ReturnsOverlay()
     {
         var manager = new DragDropManager();
@@ -442,11 +443,11 @@ public class DragDropTests
         manager.StartDrag(source, "test", 10, 20);
 
         var overlay = manager.BuildOverlayWidget();
-        Assert.NotNull(overlay);
-        Assert.IsType<DragOverlayWidget>(overlay);
+        Assert.IsNotNull(overlay);
+        TestSeq.IsType<DragOverlayWidget>(overlay);
     }
 
-    [Fact]
+    [TestMethod]
     public void DragDropManager_BuildOverlayWidget_UsesCurrentPosition()
     {
         var manager = new DragDropManager();
@@ -462,26 +463,26 @@ public class DragDropTests
         manager.UpdatePosition(30, 15, null);
 
         var overlay = (DragOverlayWidget)manager.BuildOverlayWidget()!;
-        Assert.Equal(30, overlay.CursorX);
-        Assert.Equal(15, overlay.CursorY);
+        Assert.AreEqual(30, overlay.CursorX);
+        Assert.AreEqual(15, overlay.CursorY);
     }
 
-    [Fact]
+    [TestMethod]
     public void DragOverlayNode_IsFocusable_ReturnsFalse()
     {
         var node = new DragOverlayNode();
-        Assert.False(node.IsFocusable);
+        Assert.IsFalse(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public void DragOverlayNode_GetFocusableNodes_ReturnsEmpty()
     {
         var child = new ButtonNode { Label = "Ghost" };
         var node = new DragOverlayNode { Child = child };
-        Assert.Empty(node.GetFocusableNodes());
+        Assert.IsEmpty(node.GetFocusableNodes());
     }
 
-    [Fact]
+    [TestMethod]
     public void DragOverlayNode_Arrange_PositionsAtCursorWithOffset()
     {
         var child = new TextBlockNode { Text = "Ghost" };
@@ -496,29 +497,29 @@ public class DragDropTests
         node.Arrange(new Rect(0, 0, 80, 24));
 
         // Child should be positioned at cursor + 1 offset
-        Assert.Equal(11, child.Bounds.X);
-        Assert.Equal(5, child.Bounds.Y);
+        Assert.AreEqual(11, child.Bounds.X);
+        Assert.AreEqual(5, child.Bounds.Y);
     }
 
     #endregion
 
     #region DropTargetNode Tests
 
-    [Fact]
+    [TestMethod]
     public void DropTargetNode_IsNotFocusable()
     {
         var node = new DropTargetNode();
-        Assert.False(node.IsFocusable);
+        Assert.IsFalse(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public void DropTargetNode_IsActive_DefaultFalse()
     {
         var node = new DropTargetNode();
-        Assert.False(node.IsActive);
+        Assert.IsFalse(node.IsActive);
     }
 
-    [Fact]
+    [TestMethod]
     public void DropTargetNode_Measure_WhenInactive_MeasuresChild()
     {
         var node = new DropTargetNode();
@@ -528,11 +529,11 @@ public class DragDropTests
         var size = node.Measure(new Constraints(0, 40, 0, 20));
 
         // Inactive node still measures child — visibility is controlled by builder callback
-        Assert.Equal(1, size.Height);
-        Assert.True(size.Width > 0);
+        Assert.AreEqual(1, size.Height);
+        Assert.IsTrue(size.Width > 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void DropTargetNode_Measure_WhenActive_MeasuresChild()
     {
         var node = new DropTargetNode();
@@ -542,28 +543,28 @@ public class DragDropTests
 
         var size = node.Measure(new Constraints(0, 40, 0, 20));
 
-        Assert.Equal(1, size.Height); // TextBlock is 1 row
+        Assert.AreEqual(1, size.Height); // TextBlock is 1 row
     }
 
-    [Fact]
+    [TestMethod]
     public void DropTargetNode_TargetId_CanBeSet()
     {
         var node = new DropTargetNode { TargetId = "after-card-2" };
-        Assert.Equal("after-card-2", node.TargetId);
+        Assert.AreEqual("after-card-2", node.TargetId);
     }
 
-    [Fact]
+    [TestMethod]
     public void DropTargetNode_GetFocusableNodes_ReturnsEmpty()
     {
         var node = new DropTargetNode { Child = new TextBlockNode() };
-        Assert.Empty(node.GetFocusableNodes());
+        Assert.IsEmpty(node.GetFocusableNodes());
     }
 
     #endregion
 
     #region DropTarget Proximity Tests
 
-    [Fact]
+    [TestMethod]
     public void DroppableNode_FindDropTargets_FindsDescendants()
     {
         var droppable = new DroppableNode();
@@ -575,12 +576,12 @@ public class DragDropTests
 
         var targets = droppable.FindDropTargets();
 
-        Assert.Equal(2, targets.Count);
-        Assert.Equal("pos-1", targets[0].TargetId);
-        Assert.Equal("pos-2", targets[1].TargetId);
+        Assert.AreEqual(2, targets.Count);
+        Assert.AreEqual("pos-1", targets[0].TargetId);
+        Assert.AreEqual("pos-2", targets[1].TargetId);
     }
 
-    [Fact]
+    [TestMethod]
     public void DroppableNode_FindDropTargets_EmptyWhenNone()
     {
         var droppable = new DroppableNode();
@@ -588,10 +589,10 @@ public class DragDropTests
 
         var targets = droppable.FindDropTargets();
 
-        Assert.Empty(targets);
+        Assert.IsEmpty(targets);
     }
 
-    [Fact]
+    [TestMethod]
     public void DragDropManager_ActiveDropTarget_ClearedOnEndDrag()
     {
         var manager = new DragDropManager();
@@ -601,35 +602,35 @@ public class DragDropTests
 
         manager.EndDrag();
 
-        Assert.Null(manager.ActiveDropTarget);
+        Assert.IsNull(manager.ActiveDropTarget);
     }
 
     #endregion
 
     #region DropTargetContext Tests
 
-    [Fact]
+    [TestMethod]
     public void DropTargetContext_IsActive_ReflectsNodeState()
     {
         var node = new DropTargetNode { TargetId = "test" };
         var ctx = new DropTargetContext(node);
 
-        Assert.False(ctx.IsActive);
+        Assert.IsFalse(ctx.IsActive);
 
         node.IsActive = true;
-        Assert.True(ctx.IsActive);
+        Assert.IsTrue(ctx.IsActive);
     }
 
-    [Fact]
+    [TestMethod]
     public void DropTargetContext_DragData_ReflectsNodeState()
     {
         var node = new DropTargetNode { TargetId = "test" };
         var ctx = new DropTargetContext(node);
 
-        Assert.Null(ctx.DragData);
+        Assert.IsNull(ctx.DragData);
 
         node.DragData = "some-data";
-        Assert.Equal("some-data", ctx.DragData);
+        Assert.AreEqual("some-data", ctx.DragData);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/DrawerNodeTests.cs
+++ b/tests/Hex1b.Tests/DrawerNodeTests.cs
@@ -10,6 +10,7 @@ namespace Hex1b.Tests;
 /// Comprehensive tests for DrawerNode layout, rendering, state transitions, and focus handling.
 /// Tests cover all combinations of: direction (4), mode (2), state (2), and container (2).
 /// </summary>
+[TestClass]
 public class DrawerNodeTests
 {
     private static Hex1bRenderContext CreateContext(IHex1bAppTerminalWorkloadAdapter workload, Hex1bTheme? theme = null)
@@ -19,7 +20,7 @@ public class DrawerNodeTests
 
     #region Direction Auto-Detection Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Drawer_InHStack_FirstChild_DirectionIsRight()
     {
         // Arrange
@@ -49,7 +50,7 @@ public class DrawerNodeTests
         // Direction is auto-detected as Right (expands right)
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Drawer_InHStack_LastChild_DirectionIsLeft()
     {
         // Arrange
@@ -80,10 +81,10 @@ public class DrawerNodeTests
         var line = snapshot.GetLineTrimmed(0);
         var mainIdx = line.IndexOf("Main Content", StringComparison.Ordinal);
         var drawerIdx = line.IndexOf("«", StringComparison.Ordinal);
-        Assert.True(drawerIdx > mainIdx, $"Expected drawer (at {drawerIdx}) to be after main content (at {mainIdx})");
+        Assert.IsTrue(drawerIdx > mainIdx, $"Expected drawer (at {drawerIdx}) to be after main content (at {mainIdx})");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Drawer_InVStack_FirstChild_DirectionIsDown()
     {
         // Arrange
@@ -115,7 +116,7 @@ public class DrawerNodeTests
         Assert.Contains("Main Content", snapshot.GetLineTrimmed(1));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Drawer_InVStack_LastChild_DirectionIsUp()
     {
         // Arrange
@@ -151,7 +152,7 @@ public class DrawerNodeTests
 
     #region Collapsed State Rendering Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Drawer_Collapsed_ShowsCollapsedContent()
     {
         // Arrange
@@ -179,11 +180,11 @@ public class DrawerNodeTests
         await runTask;
 
         // Assert
-        Assert.True(snapshot.ContainsText("[COLLAPSED]"), "Collapsed content should be visible");
-        Assert.False(snapshot.ContainsText("[EXPANDED]"), "Expanded content should NOT be visible");
+        Assert.IsTrue(snapshot.ContainsText("[COLLAPSED]"), "Collapsed content should be visible");
+        Assert.IsFalse(snapshot.ContainsText("[EXPANDED]"), "Expanded content should NOT be visible");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Drawer_Collapsed_NoContent_IsInvisible()
     {
         // Arrange
@@ -219,7 +220,7 @@ public class DrawerNodeTests
 
     #region Expanded Inline State Rendering Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Drawer_ExpandedInline_ShowsExpandedContent()
     {
         // Arrange
@@ -248,11 +249,11 @@ public class DrawerNodeTests
         await runTask;
 
         // Assert
-        Assert.True(snapshot.ContainsText("[EXPANDED]"), "Expanded content should be visible");
-        Assert.False(snapshot.ContainsText("[COLLAPSED]"), "Collapsed content should NOT be visible");
+        Assert.IsTrue(snapshot.ContainsText("[EXPANDED]"), "Expanded content should be visible");
+        Assert.IsFalse(snapshot.ContainsText("[COLLAPSED]"), "Collapsed content should NOT be visible");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Drawer_ExpandedInline_PushesMainContent()
     {
         // Arrange
@@ -284,14 +285,14 @@ public class DrawerNodeTests
         var line = snapshot.GetLineTrimmed(0);
         var expandedIdx = line.IndexOf("ExpandedPane", StringComparison.Ordinal);
         var mainIdx = line.IndexOf("MainContent", StringComparison.Ordinal);
-        Assert.True(expandedIdx < mainIdx, $"Expanded pane (at {expandedIdx}) should be before main content (at {mainIdx})");
+        Assert.IsTrue(expandedIdx < mainIdx, $"Expanded pane (at {expandedIdx}) should be before main content (at {mainIdx})");
     }
 
     #endregion
 
     #region Expanded Overlay State Rendering Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Drawer_Overlay_Collapsed_IsFocusable()
     {
         // Arrange
@@ -324,10 +325,10 @@ public class DrawerNodeTests
         await runTask;
 
         // The drawer should be focusable in overlay mode when collapsed
-        Assert.True(snapshot.ContainsText("▼ Console"));
+        Assert.IsTrue(snapshot.ContainsText("▼ Console"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Drawer_Overlay_EnterKey_OpensPopup()
     {
         // Arrange
@@ -361,10 +362,10 @@ public class DrawerNodeTests
         await runTask;
 
         // Assert
-        Assert.True(snapshot.ContainsText("POPUP_CONTENT"), "Popup content should be visible");
+        Assert.IsTrue(snapshot.ContainsText("POPUP_CONTENT"), "Popup content should be visible");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Drawer_Overlay_SpaceKey_OpensPopup()
     {
         // Arrange
@@ -398,14 +399,14 @@ public class DrawerNodeTests
         await runTask;
 
         // Assert
-        Assert.True(snapshot.ContainsText("POPUP_SPACE"));
+        Assert.IsTrue(snapshot.ContainsText("POPUP_SPACE"));
     }
 
     #endregion
 
     #region Event Callback Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Drawer_OnExpanded_CallbackFires()
     {
         // Arrange
@@ -440,10 +441,10 @@ public class DrawerNodeTests
         await runTask;
 
         // Assert
-        Assert.True(expandedCalled, "OnExpanded callback should have been invoked");
+        Assert.IsTrue(expandedCalled, "OnExpanded callback should have been invoked");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Drawer_OnCollapsed_CallbackFires()
     {
         // Arrange
@@ -486,40 +487,40 @@ public class DrawerNodeTests
         await runTask;
 
         // Assert
-        Assert.True(collapsedCalled, "OnCollapsed callback should have been invoked");
+        Assert.IsTrue(collapsedCalled, "OnCollapsed callback should have been invoked");
     }
 
     #endregion
 
     #region Focus Management Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Drawer_Inline_NotFocusable()
     {
         // Inline mode drawers should not be focusable themselves
         var node = new DrawerNode { Mode = DrawerMode.Inline, IsExpanded = false };
-        Assert.False(node.IsFocusable);
+        Assert.IsFalse(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Drawer_Overlay_Collapsed_IsFocusableProperty()
     {
         var node = new DrawerNode { Mode = DrawerMode.Overlay, IsExpanded = false };
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Drawer_Overlay_Expanded_NotFocusableProperty()
     {
         var node = new DrawerNode { Mode = DrawerMode.Overlay, IsExpanded = true };
-        Assert.False(node.IsFocusable);
+        Assert.IsFalse(node.IsFocusable);
     }
 
     #endregion
 
     #region Measure and Arrange Tests
 
-    [Fact]
+    [TestMethod]
     public void Drawer_Collapsed_WithContent_MeasuresContentSize()
     {
         var collapsedContent = new TextBlockNode { Text = "»" };
@@ -527,22 +528,22 @@ public class DrawerNodeTests
         
         var size = node.Measure(Constraints.Unbounded);
         
-        Assert.Equal(1, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(1, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Drawer_Collapsed_NoContent_MeasuresZero()
     {
         var node = new DrawerNode { Content = null };
         
         var size = node.Measure(Constraints.Unbounded);
         
-        Assert.Equal(0, size.Width);
-        Assert.Equal(0, size.Height);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(0, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Drawer_Arrange_PassesBoundsToContent()
     {
         var content = new TextBlockNode { Text = "Content" };
@@ -551,7 +552,7 @@ public class DrawerNodeTests
         
         node.Arrange(bounds);
         
-        Assert.Equal(bounds, content.Bounds);
+        Assert.AreEqual(bounds, content.Bounds);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/EditorFuzzTests.cs
+++ b/tests/Hex1b.Tests/EditorFuzzTests.cs
@@ -8,8 +8,7 @@ namespace Hex1b.Tests;
 /// Collection for CPU-intensive tests (fuzz, stress, performance) that should run
 /// serially to avoid starving timing-sensitive integration tests of CPU time.
 /// </summary>
-[CollectionDefinition("CPU-Intensive")]
-public class CpuIntensiveCollection { }
+
 
 /// <summary>
 /// Seed-based fuzz testing for editor operations. Each seed produces a deterministic
@@ -25,7 +24,8 @@ public class CpuIntensiveCollection { }
 ///   [114] InsertChar 'x' (docLen=4, cursor=3)
 ///   ...
 /// </summary>
-[Collection("CPU-Intensive")]
+[DoNotParallelize]
+[TestClass]
 public class EditorFuzzTests
 {
     // ── Operation types ─────────────────────────────────────────
@@ -466,8 +466,8 @@ public class EditorFuzzTests
 
     // ── Single-cursor bulk ──────────────────────────────────────
 
-    [Theory]
-    [MemberData(nameof(FuzzSeeds))]
+    [TestMethod]
+    [DynamicData(nameof(FuzzSeeds))]
     public void Fuzz_SingleCursor_NeverThrows(int seed)
     {
         RunFuzz(seed, iterations: 500,
@@ -485,8 +485,8 @@ public class EditorFuzzTests
 
     // ── Multi-cursor bulk ───────────────────────────────────────
 
-    [Theory]
-    [MemberData(nameof(MultiCursorSeeds))]
+    [TestMethod]
+    [DynamicData(nameof(MultiCursorSeeds))]
     public void Fuzz_MultiCursor_NeverThrows(int seed)
     {
         RunFuzz(seed, iterations: 500,
@@ -504,8 +504,8 @@ public class EditorFuzzTests
 
     // ── Byte-level bulk ─────────────────────────────────────────
 
-    [Theory]
-    [MemberData(nameof(ByteLevelSeeds))]
+    [TestMethod]
+    [DynamicData(nameof(ByteLevelSeeds))]
     public void Fuzz_ByteLevel_NeverThrows(int seed)
     {
         RunFuzz(seed, iterations: 500,
@@ -523,8 +523,8 @@ public class EditorFuzzTests
 
     // ── Full combined (all features) ────────────────────────────
 
-    [Theory]
-    [MemberData(nameof(FullFuzzSeeds))]
+    [TestMethod]
+    [DynamicData(nameof(FullFuzzSeeds))]
     public void Fuzz_AllFeatures_NeverThrows(int seed)
     {
         RunFuzz(seed, iterations: 500,
@@ -542,28 +542,28 @@ public class EditorFuzzTests
 
     // ── Targeted scenarios ──────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void Fuzz_EmptyDocument_NeverThrows()
     {
         for (var seed = 0; seed < 50; seed++)
             RunFuzz(seed, iterations: 200, initialText: "", StandardConfig);
     }
 
-    [Fact]
+    [TestMethod]
     public void Fuzz_SingleCharDocument_NeverThrows()
     {
         for (var seed = 0; seed < 50; seed++)
             RunFuzz(seed, iterations: 200, initialText: "X", StandardConfig);
     }
 
-    [Fact]
+    [TestMethod]
     public void Fuzz_MultiByteContent_NeverThrows()
     {
         for (var seed = 0; seed < 50; seed++)
             RunFuzz(seed, iterations: 200, initialText: "café 😀 日本語\nLine 2 🚀\n", StandardConfig);
     }
 
-    [Fact]
+    [TestMethod]
     public void Fuzz_LongDocument_NeverThrows()
     {
         var longText = string.Join("\n",
@@ -572,7 +572,7 @@ public class EditorFuzzTests
             RunFuzz(seed, iterations: 300, initialText: longText, StandardConfig);
     }
 
-    [Fact]
+    [TestMethod]
     public void Fuzz_DeepUndoRedo_NeverThrows()
     {
         // Dedicated test for deep undo/redo chains that stress history
@@ -580,21 +580,21 @@ public class EditorFuzzTests
             RunFuzz(seed, iterations: 400, initialText: "ABCDEF\nGHIJKL\n", StandardConfig);
     }
 
-    [Fact]
+    [TestMethod]
     public void Fuzz_MultiCursor_EmptyDocument_NeverThrows()
     {
         for (var seed = 0; seed < 50; seed++)
             RunFuzz(seed, iterations: 200, initialText: "", MultiCursorConfig);
     }
 
-    [Fact]
+    [TestMethod]
     public void Fuzz_ByteLevel_EmptyDocument_NeverThrows()
     {
         for (var seed = 0; seed < 50; seed++)
             RunFuzz(seed, iterations: 200, initialText: "", ByteLevelConfig);
     }
 
-    [Fact]
+    [TestMethod]
     public void Fuzz_StaleSelectionAfterExternalEdit_NeverThrows()
     {
         // Targeted test: selection set, document shrinks externally, then type
@@ -609,10 +609,10 @@ public class EditorFuzzTests
 
         // Must not throw
         state.InsertText("Z");
-        Assert.True(state.Cursor.Position.Value <= doc.Length);
+        Assert.IsTrue(state.Cursor.Position.Value <= doc.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void Fuzz_ConcurrentExternalEdits_NeverThrows()
     {
         // Simulates an external collaborator making edits between user operations
@@ -702,12 +702,10 @@ public class EditorFuzzTests
                 }
 
                 // Check invariants
-                Assert.True(doc.Length >= 0,
-                    $"Seed {seed}, iter {i}: doc.Length={doc.Length} < 0");
+                Assert.IsTrue(doc.Length >= 0, $"Seed {seed}, iter {i}: doc.Length={doc.Length} < 0");
                 foreach (var cursor in state.Cursors)
                 {
-                    Assert.True(cursor.Position.Value >= 0 && cursor.Position.Value <= doc.Length,
-                        $"Seed {seed}, iter {i} ({op}): cursor pos={cursor.Position.Value} out of [0, {doc.Length}]");
+                    Assert.IsTrue(cursor.Position.Value >= 0 && cursor.Position.Value <= doc.Length, $"Seed {seed}, iter {i} ({op}): cursor pos={cursor.Position.Value} out of [0, {doc.Length}]");
                 }
 
                 doc.VerifyIntegrity();

--- a/tests/Hex1b.Tests/EditorIntegrationTests.cs
+++ b/tests/Hex1b.Tests/EditorIntegrationTests.cs
@@ -13,12 +13,13 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class EditorIntegrationTests
 {
     private static Hex1bColor? ToCellColor(Hex1bColor color) => color.IsDefault ? null : color;
     private static bool ColorEquals(Hex1bColor? a, Hex1bColor? b) => Nullable.Equals(a, b);
 
-    [Fact]
+    [TestMethod]
     public async Task Editor_RendersInitialContent()
     {
         // NOTE: Initial rendering may change with gutter/line numbers.
@@ -63,7 +64,7 @@ public class EditorIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Editor_TypeCharacter_AppearsOnScreen()
     {
         // NOTE: Character rendering may change with IME support.
@@ -103,10 +104,10 @@ public class EditorIntegrationTests
 
         await runTask;
 
-        Assert.Equal("a", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("a", snapshot.GetCell(0, 0).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Editor_TypeMultipleCharacters_AllVisibleWithCursorAtEnd()
     {
         // NOTE: Multi-char rendering may change with ligature support.
@@ -143,14 +144,14 @@ public class EditorIntegrationTests
 
         await runTask;
 
-        Assert.Equal("h", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("e", snapshot.GetCell(1, 0).Character);
-        Assert.Equal("l", snapshot.GetCell(2, 0).Character);
-        Assert.Equal("l", snapshot.GetCell(3, 0).Character);
-        Assert.Equal("o", snapshot.GetCell(4, 0).Character);
+        Assert.AreEqual("h", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("e", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("l", snapshot.GetCell(2, 0).Character);
+        Assert.AreEqual("l", snapshot.GetCell(3, 0).Character);
+        Assert.AreEqual("o", snapshot.GetCell(4, 0).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Editor_Backspace_DeletesPreviousChar()
     {
         // NOTE: Backspace behavior may change with auto-indent unindent.
@@ -193,10 +194,10 @@ public class EditorIntegrationTests
 
         await runTask;
 
-        Assert.Equal("a", doc.GetText());
+        Assert.AreEqual("a", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Editor_Enter_InsertsNewline()
     {
         // NOTE: Enter behavior may change with auto-indent.
@@ -232,10 +233,10 @@ public class EditorIntegrationTests
 
         await runTask;
 
-        Assert.Equal("A\nB", doc.GetText());
+        Assert.AreEqual("A\nB", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Editor_ArrowKeys_MoveCursorVisually()
     {
         // NOTE: Cursor position may include virtual space in future.
@@ -273,7 +274,7 @@ public class EditorIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Editor_HomeEnd_MoveCursorToLineStartEnd()
     {
         // NOTE: Home may gain smart-home (first non-whitespace) behavior.
@@ -322,7 +323,7 @@ public class EditorIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Editor_Tab_Inserts4Spaces()
     {
         // NOTE: Tab behavior may change with tab-to-spaces toggle.
@@ -358,10 +359,10 @@ public class EditorIntegrationTests
 
         await runTask;
 
-        Assert.Equal("    ", doc.GetText()); // 4 spaces
+        Assert.AreEqual("    ", doc.GetText()); // 4 spaces
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Editor_CursorFollowsTypedText()
     {
         // NOTE: Cursor tracking may change with multi-cursor.
@@ -397,10 +398,10 @@ public class EditorIntegrationTests
 
         await runTask;
 
-        Assert.Equal(new DocumentOffset(5), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(5), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Editor_OnTextChanged_CallbackFires()
     {
         // NOTE: Callback may gain debouncing in future.
@@ -436,7 +437,7 @@ public class EditorIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Editor_EmptyDocumentEditing_TypeAndVerify()
     {
         // NOTE: Empty document may show placeholder text in future.
@@ -473,10 +474,10 @@ public class EditorIntegrationTests
 
         await runTask;
 
-        Assert.Equal("X", doc.GetText());
+        Assert.AreEqual("X", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Editor_LongDocumentScrolling_PageDownShowsLaterLines()
     {
         // NOTE: Scroll behavior may gain smooth scrolling.
@@ -512,7 +513,7 @@ public class EditorIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Editor_DeleteForward_RemovesNextChar()
     {
         // NOTE: Delete forward may change with paired bracket deletion.
@@ -545,10 +546,10 @@ public class EditorIntegrationTests
 
         await runTask;
 
-        Assert.Equal("BC", doc.GetText());
+        Assert.AreEqual("BC", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Editor_CtrlA_SelectsAll()
     {
         // NOTE: Selection rendering will change when highlighting is implemented.
@@ -576,9 +577,9 @@ public class EditorIntegrationTests
         await Task.Delay(200, TestContext.Current.CancellationToken);
 
         // Verify state: selection covers entire document
-        Assert.True(state.Cursor.HasSelection);
-        Assert.Equal(new DocumentOffset(0), state.Cursor.SelectionStart);
-        Assert.Equal(new DocumentOffset(11), state.Cursor.SelectionEnd);
+        Assert.IsTrue(state.Cursor.HasSelection);
+        Assert.AreEqual(new DocumentOffset(0), state.Cursor.SelectionStart);
+        Assert.AreEqual(new DocumentOffset(11), state.Cursor.SelectionEnd);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -587,7 +588,7 @@ public class EditorIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Editor_MultiLinePaste_RendersAcrossLines()
     {
         // NOTE: Paste may gain formatting/indent adjustment in future.
@@ -625,9 +626,9 @@ public class EditorIntegrationTests
 
         // Capture snapshot while still in alternate screen
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal("A", snapshot.GetCell(0, 0).Character); // Alpha
-        Assert.Equal("B", snapshot.GetCell(0, 1).Character); // Beta
-        Assert.Equal("G", snapshot.GetCell(0, 2).Character); // Gamma
+        Assert.AreEqual("A", snapshot.GetCell(0, 0).Character); // Alpha
+        Assert.AreEqual("B", snapshot.GetCell(0, 1).Character); // Beta
+        Assert.AreEqual("G", snapshot.GetCell(0, 2).Character); // Gamma
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -637,7 +638,7 @@ public class EditorIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Editor_ReadOnly_TypingDoesNotModifyDocument()
     {
         // NOTE: Read-only may gain visual indicator (dimmed text, lock icon).
@@ -668,7 +669,7 @@ public class EditorIntegrationTests
         await Task.Delay(200, TestContext.Current.CancellationToken);
 
         // Document should still be "Original"
-        Assert.Equal("Original", doc.GetText());
+        Assert.AreEqual("Original", doc.GetText());
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -677,7 +678,7 @@ public class EditorIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Editor_RapidTyping_AllCharsAppear()
     {
         // NOTE: Input buffering may be added for very rapid typing.
@@ -710,10 +711,10 @@ public class EditorIntegrationTests
 
         await runTask;
 
-        Assert.Equal(expected, doc.GetText());
+        Assert.AreEqual(expected, doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Editor_DeleteAllContent_EmptyEditorWithCursor()
     {
         // NOTE: Undo may restore deleted content in future.
@@ -751,6 +752,6 @@ public class EditorIntegrationTests
 
         await runTask;
 
-        Assert.Equal("", doc.GetText());
+        Assert.AreEqual("", doc.GetText());
     }
 }

--- a/tests/Hex1b.Tests/EditorKeybindingDispatchTests.cs
+++ b/tests/Hex1b.Tests/EditorKeybindingDispatchTests.cs
@@ -10,6 +10,7 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class EditorKeybindingDispatchTests
 {
     private static Hex1bColor? ToCellColor(Hex1bColor color) => color.IsDefault ? null : color;
@@ -54,7 +55,7 @@ public class EditorKeybindingDispatchTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LeftArrow_MovesCursorLeft()
     {
         // NOTE: Left arrow behavior may change with soft-wrap navigation.
@@ -87,11 +88,11 @@ public class EditorKeybindingDispatchTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(new DocumentOffset(1), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(1), state.Cursor.Position);
         await ExitAndWait(terminal, runTask);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RightArrow_MovesCursorRight()
     {
         // NOTE: Right arrow at EOL may gain soft-wrap-to-next-line behavior.
@@ -114,11 +115,11 @@ public class EditorKeybindingDispatchTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(new DocumentOffset(1), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(1), state.Cursor.Position);
         await ExitAndWait(terminal, runTask);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task UpArrow_MovesCursorToPreviousLine()
     {
         // NOTE: Up arrow column tracking may change with virtual column memory.
@@ -151,11 +152,11 @@ public class EditorKeybindingDispatchTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         var pos = state.Document.OffsetToPosition(state.Cursor.Position);
-        Assert.Equal(1, pos.Line);
+        Assert.AreEqual(1, pos.Line);
         await ExitAndWait(terminal, runTask);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DownArrow_MovesCursorToNextLine()
     {
         // NOTE: Down arrow at last line may gain "create new line" option.
@@ -179,11 +180,11 @@ public class EditorKeybindingDispatchTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         var pos = state.Document.OffsetToPosition(state.Cursor.Position);
-        Assert.Equal(2, pos.Line);
+        Assert.AreEqual(2, pos.Line);
         await ExitAndWait(terminal, runTask);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HomeKey_MovesCursorToLineStart()
     {
         // NOTE: Smart-home (first non-whitespace) may be added.
@@ -214,11 +215,11 @@ public class EditorKeybindingDispatchTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(new DocumentOffset(0), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(0), state.Cursor.Position);
         await ExitAndWait(terminal, runTask);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task EndKey_MovesCursorToLineEnd()
     {
         // NOTE: End key behavior may change with trailing whitespace handling.
@@ -241,11 +242,11 @@ public class EditorKeybindingDispatchTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(new DocumentOffset(5), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(5), state.Cursor.Position);
         await ExitAndWait(terminal, runTask);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CtrlHome_MovesCursorToDocumentStart()
     {
         // NOTE: Ctrl+Home may gain scroll animation.
@@ -277,11 +278,11 @@ public class EditorKeybindingDispatchTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(new DocumentOffset(0), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(0), state.Cursor.Position);
         await ExitAndWait(terminal, runTask);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CtrlEnd_MovesCursorToDocumentEnd()
     {
         // NOTE: Ctrl+End may gain scroll animation.
@@ -297,11 +298,11 @@ public class EditorKeybindingDispatchTests
 
         await Task.Delay(200, TestContext.Current.CancellationToken);
 
-        Assert.Equal(new DocumentOffset(11), state.Cursor.Position); // "AAA\nBBB\nCCC" = 11 chars
+        Assert.AreEqual(new DocumentOffset(11), state.Cursor.Position); // "AAA\nBBB\nCCC" = 11 chars
         await ExitAndWait(terminal, runTask);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PageDown_MovesCursorDownByViewportLines()
     {
         // NOTE: PageDown may gain half-page option.
@@ -321,11 +322,11 @@ public class EditorKeybindingDispatchTests
         await Task.Delay(200, TestContext.Current.CancellationToken);
 
         var newLine = state.Document.OffsetToPosition(state.Cursor.Position).Line;
-        Assert.True(newLine > initialLine, $"Cursor should move down from line {initialLine}, now at {newLine}");
+        Assert.IsTrue(newLine > initialLine, $"Cursor should move down from line {initialLine}, now at {newLine}");
         await ExitAndWait(terminal, runTask);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PageUp_MovesCursorUpByViewportLines()
     {
         // NOTE: PageUp may gain half-page option.
@@ -354,11 +355,11 @@ public class EditorKeybindingDispatchTests
         await Task.Delay(200, TestContext.Current.CancellationToken);
 
         var newLine = state.Document.OffsetToPosition(state.Cursor.Position).Line;
-        Assert.True(newLine < lineBeforePageUp, $"Cursor should move up from line {lineBeforePageUp}, now at {newLine}");
+        Assert.IsTrue(newLine < lineBeforePageUp, $"Cursor should move up from line {lineBeforePageUp}, now at {newLine}");
         await ExitAndWait(terminal, runTask);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ShiftRight_ExtendsSelection()
     {
         // NOTE: Selection rendering will be tested when visual selection is implemented.
@@ -375,13 +376,13 @@ public class EditorKeybindingDispatchTests
         await Task.Delay(200, TestContext.Current.CancellationToken);
 
         // Selection anchor at 0, cursor moved to 1
-        Assert.True(state.Cursor.HasSelection);
-        Assert.Equal(new DocumentOffset(0), state.Cursor.SelectionStart);
-        Assert.Equal(new DocumentOffset(1), state.Cursor.SelectionEnd);
+        Assert.IsTrue(state.Cursor.HasSelection);
+        Assert.AreEqual(new DocumentOffset(0), state.Cursor.SelectionStart);
+        Assert.AreEqual(new DocumentOffset(1), state.Cursor.SelectionEnd);
         await ExitAndWait(terminal, runTask);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CtrlBackspace_DeletesPreviousWord()
     {
         // NOTE: Word deletion boundaries may change with language-aware word detection.
@@ -406,7 +407,7 @@ public class EditorKeybindingDispatchTests
         await ExitAndWait(terminal, runTask);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CtrlDelete_DeletesNextWord()
     {
         // NOTE: Word deletion boundaries may change with language-aware word detection.
@@ -427,7 +428,7 @@ public class EditorKeybindingDispatchTests
         await ExitAndWait(terminal, runTask);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CtrlShiftK_DeletesCurrentLine()
     {
         // NOTE: Line deletion may gain undo grouping in future.
@@ -451,7 +452,7 @@ public class EditorKeybindingDispatchTests
         await ExitAndWait(terminal, runTask);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AnyCharacter_InsertsText()
     {
         // NOTE: Character insertion may change with IME composition.
@@ -476,8 +477,8 @@ public class EditorKeybindingDispatchTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal("x", state.Document.GetText());
-        Assert.Equal(new DocumentOffset(1), state.Cursor.Position);
+        Assert.AreEqual("x", state.Document.GetText());
+        Assert.AreEqual(new DocumentOffset(1), state.Cursor.Position);
         await ExitAndWait(terminal, runTask);
     }
 }

--- a/tests/Hex1b.Tests/EditorMouseTests.cs
+++ b/tests/Hex1b.Tests/EditorMouseTests.cs
@@ -10,6 +10,7 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class EditorMouseTests
 {
     private static Hex1bColor? ToCellColor(Hex1bColor color) => color.IsDefault ? null : color;
@@ -47,7 +48,7 @@ public class EditorMouseTests
 
     // ── Click positioning ────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task Click_PositionsCursorAtClickLocation()
     {
         // NOTE: Click behavior may change with margin/gutter support.
@@ -71,10 +72,10 @@ public class EditorMouseTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         // Cursor should be at offset 5 (0-based column 5 = 1-based column 6)
-        Assert.Equal(5, state.Cursor.Position.Value);
+        Assert.AreEqual(5, state.Cursor.Position.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Click_OnSecondLine_PositionsCursorCorrectly()
     {
         var (workload, terminal, app, state, theme, runTask) = SetupEditor("Hello\nWorld\nThird");
@@ -97,10 +98,10 @@ public class EditorMouseTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         // "Hello\n" = 6 chars, then column 2 (0-based) = offset 8
-        Assert.Equal(8, state.Cursor.Position.Value);
+        Assert.AreEqual(8, state.Cursor.Position.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Click_BeyondLineEnd_ClampsToLineEnd()
     {
         var (workload, terminal, app, state, theme, runTask) = SetupEditor("Hi\nWorld");
@@ -117,10 +118,10 @@ public class EditorMouseTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         // "Hi" is 2 chars, so cursor should be at offset 2 (after "Hi")
-        Assert.Equal(2, state.Cursor.Position.Value);
+        Assert.AreEqual(2, state.Cursor.Position.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Click_InTildeArea_ClampsToDocumentEnd()
     {
         var (workload, terminal, app, state, theme, runTask) = SetupEditor("Hello");
@@ -136,10 +137,10 @@ public class EditorMouseTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(5, state.Cursor.Position.Value);
+        Assert.AreEqual(5, state.Cursor.Position.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Click_ClearsExistingSelection()
     {
         var (workload, terminal, app, state, theme, runTask) = SetupEditor("Hello world");
@@ -158,13 +159,13 @@ public class EditorMouseTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.False(state.Cursor.HasSelection);
-        Assert.Equal(3, state.Cursor.Position.Value);
+        Assert.IsFalse(state.Cursor.HasSelection);
+        Assert.AreEqual(3, state.Cursor.Position.Value);
     }
 
     // ── Double-click word selection ──────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task DoubleClick_SelectsWord()
     {
         // NOTE: Word boundary logic may evolve for unicode/programming language tokens.
@@ -188,15 +189,15 @@ public class EditorMouseTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(state.Cursor.HasSelection);
+        Assert.IsTrue(state.Cursor.HasSelection);
         // "world" is at offsets 6-11
-        Assert.Equal(6, state.Cursor.SelectionStart!.Value);
-        Assert.Equal(11, state.Cursor.SelectionEnd!.Value);
+        Assert.AreEqual(6, state.Cursor.SelectionStart!.Value);
+        Assert.AreEqual(11, state.Cursor.SelectionEnd!.Value);
     }
 
     // ── Triple-click line selection ──────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task TripleClick_SelectsEntireLine()
     {
         var (workload, terminal, app, state, theme, runTask) = SetupEditor("Hello\nWorld\nThird");
@@ -216,12 +217,12 @@ public class EditorMouseTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(state.Cursor.HasSelection);
+        Assert.IsTrue(state.Cursor.HasSelection);
     }
 
     // ── Drag selection ───────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task Drag_CreatesSelection()
     {
         var (workload, terminal, app, state, theme, runTask) = SetupEditor("Hello world");
@@ -244,12 +245,12 @@ public class EditorMouseTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(state.Cursor.HasSelection);
-        Assert.Equal(0, state.Cursor.SelectionStart!.Value);
-        Assert.Equal(5, state.Cursor.SelectionEnd!.Value);
+        Assert.IsTrue(state.Cursor.HasSelection);
+        Assert.AreEqual(0, state.Cursor.SelectionStart!.Value);
+        Assert.AreEqual(5, state.Cursor.SelectionEnd!.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Drag_AcrossLines_CreatesMultiLineSelection()
     {
         var (workload, terminal, app, state, theme, runTask) = SetupEditor("Hello\nWorld");
@@ -267,12 +268,12 @@ public class EditorMouseTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(state.Cursor.HasSelection);
+        Assert.IsTrue(state.Cursor.HasSelection);
     }
 
     // ── Scroll wheel ─────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task ScrollDown_ScrollsViewport()
     {
         // NOTE: This test verifies mouse scroll wheel changes the viewport.
@@ -297,7 +298,7 @@ public class EditorMouseTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ScrollUp_ScrollsViewportBack()
     {
         var lines = string.Join("\n", Enumerable.Range(1, 20).Select(i => $"Line {i}"));
@@ -322,7 +323,7 @@ public class EditorMouseTests
 
     // ── Ctrl+Click multi-cursor ───────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task CtrlClick_AddsSecondCursor()
     {
         // NOTE: Ctrl+Click adds a cursor at the clicked position.
@@ -349,14 +350,13 @@ public class EditorMouseTests
         // Original cursor should still be at (0,0)
         var snapshot = terminal.CreateSnapshot();
         var firstCursorCell = snapshot.GetCell(0, 0);
-        Assert.True(ColorEquals(firstCursorCell.Background, cursorBg),
-            "First cursor should still be visible at (0,0)");
+        Assert.IsTrue(ColorEquals(firstCursorCell.Background, cursorBg), "First cursor should still be visible at (0,0)");
 
         // State should have 2 cursors
-        Assert.Equal(2, state.Cursors.Count);
+        Assert.AreEqual(2, state.Cursors.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void AddCursorAtPosition_AddsAndTogglesCursor()
     {
         // Unit test for the toggle behavior
@@ -364,34 +364,34 @@ public class EditorMouseTests
         var state = new EditorState(doc);
 
         // Initial: one cursor at offset 0
-        Assert.Single(state.Cursors);
+        TestSeq.Single(state.Cursors);
 
         // Add cursor at offset 5
         state.AddCursorAtPosition(new DocumentOffset(5));
-        Assert.Equal(2, state.Cursors.Count);
+        Assert.AreEqual(2, state.Cursors.Count);
 
         // Add cursor at offset 5 again — should remove it (toggle)
         state.AddCursorAtPosition(new DocumentOffset(5));
-        Assert.Single(state.Cursors);
+        TestSeq.Single(state.Cursors);
     }
 
     // ── Unit tests for EditorState methods ───────────────────────
 
-    [Fact]
+    [TestMethod]
     public void SetCursorPosition_SetsCursorAndClearsSelection()
     {
         var doc = new Hex1bDocument("Hello world");
         var state = new EditorState(doc);
         state.SelectAll();
-        Assert.True(state.Cursor.HasSelection);
+        Assert.IsTrue(state.Cursor.HasSelection);
 
         state.SetCursorPosition(new DocumentOffset(5));
 
-        Assert.Equal(5, state.Cursor.Position.Value);
-        Assert.False(state.Cursor.HasSelection);
+        Assert.AreEqual(5, state.Cursor.Position.Value);
+        Assert.IsFalse(state.Cursor.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void SetCursorPosition_WithExtend_CreatesSelection()
     {
         var doc = new Hex1bDocument("Hello world");
@@ -399,12 +399,12 @@ public class EditorMouseTests
 
         state.SetCursorPosition(new DocumentOffset(5), extend: true);
 
-        Assert.True(state.Cursor.HasSelection);
-        Assert.Equal(0, state.Cursor.SelectionStart!.Value);
-        Assert.Equal(5, state.Cursor.SelectionEnd!.Value);
+        Assert.IsTrue(state.Cursor.HasSelection);
+        Assert.AreEqual(0, state.Cursor.SelectionStart!.Value);
+        Assert.AreEqual(5, state.Cursor.SelectionEnd!.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void SetCursorPosition_ClampsToDocumentBounds()
     {
         var doc = new Hex1bDocument("Hi");
@@ -412,10 +412,10 @@ public class EditorMouseTests
 
         state.SetCursorPosition(new DocumentOffset(100));
 
-        Assert.Equal(2, state.Cursor.Position.Value);
+        Assert.AreEqual(2, state.Cursor.Position.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void SetCursorPosition_CollapsesMultiCursors()
     {
         var doc = new Hex1bDocument("Hello Hello");
@@ -423,15 +423,15 @@ public class EditorMouseTests
         // Create multi-cursor via AddCursorAtNextMatch
         state.SelectWordAt(new DocumentOffset(0)); // select first "Hello"
         state.AddCursorAtNextMatch(); // adds cursor at second "Hello"
-        Assert.Equal(2, state.Cursors.Count);
+        Assert.AreEqual(2, state.Cursors.Count);
 
         state.SetCursorPosition(new DocumentOffset(3));
 
-        Assert.Single(state.Cursors);
-        Assert.Equal(3, state.Cursor.Position.Value);
+        TestSeq.Single(state.Cursors);
+        Assert.AreEqual(3, state.Cursor.Position.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectWordAt_SelectsWordUnderOffset()
     {
         var doc = new Hex1bDocument("Hello world");
@@ -439,12 +439,12 @@ public class EditorMouseTests
 
         state.SelectWordAt(new DocumentOffset(8)); // in "world"
 
-        Assert.True(state.Cursor.HasSelection);
-        Assert.Equal(6, state.Cursor.SelectionStart!.Value);
-        Assert.Equal(11, state.Cursor.SelectionEnd!.Value);
+        Assert.IsTrue(state.Cursor.HasSelection);
+        Assert.AreEqual(6, state.Cursor.SelectionStart!.Value);
+        Assert.AreEqual(11, state.Cursor.SelectionEnd!.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectLineAt_SelectsEntireLine()
     {
         var doc = new Hex1bDocument("Hello\nWorld\nThird");
@@ -452,12 +452,12 @@ public class EditorMouseTests
 
         state.SelectLineAt(new DocumentOffset(8)); // in "World"
 
-        Assert.True(state.Cursor.HasSelection);
-        Assert.Equal(6, state.Cursor.SelectionStart!.Value);  // start of "World\n"
-        Assert.Equal(12, state.Cursor.SelectionEnd!.Value);   // start of "Third"
+        Assert.IsTrue(state.Cursor.HasSelection);
+        Assert.AreEqual(6, state.Cursor.SelectionStart!.Value);  // start of "World\n"
+        Assert.AreEqual(12, state.Cursor.SelectionEnd!.Value);   // start of "Third"
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectLineAt_LastLine_SelectsToDocumentEnd()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -465,14 +465,14 @@ public class EditorMouseTests
 
         state.SelectLineAt(new DocumentOffset(8)); // in "World" (last line)
 
-        Assert.True(state.Cursor.HasSelection);
-        Assert.Equal(6, state.Cursor.SelectionStart!.Value);
-        Assert.Equal(11, state.Cursor.SelectionEnd!.Value); // doc length
+        Assert.IsTrue(state.Cursor.HasSelection);
+        Assert.AreEqual(6, state.Cursor.SelectionStart!.Value);
+        Assert.AreEqual(11, state.Cursor.SelectionEnd!.Value); // doc length
     }
 
     // ── Editor inside container widgets ──────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task Drag_InsideSplitter_CreatesSelection()
     {
         // Regression: editor drag selection stopped working when editor is inside a splitter.
@@ -508,6 +508,6 @@ public class EditorMouseTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(state.Cursor.HasSelection, "Editor inside splitter should support drag selection");
+        Assert.IsTrue(state.Cursor.HasSelection, "Editor inside splitter should support drag selection");
     }
 }

--- a/tests/Hex1b.Tests/EditorNodeMeasureArrangeTests.cs
+++ b/tests/Hex1b.Tests/EditorNodeMeasureArrangeTests.cs
@@ -7,9 +7,10 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class EditorNodeMeasureArrangeTests
 {
-    [Fact]
+    [TestMethod]
     public void Measure_FillsAvailableSpace()
     {
         // NOTE: Editor may not always fill space if min-size constraints are added.
@@ -19,11 +20,11 @@ public class EditorNodeMeasureArrangeTests
 
         var size = node.Measure(new Constraints(0, 40, 0, 10));
 
-        Assert.Equal(40, size.Width);
-        Assert.Equal(10, size.Height);
+        Assert.AreEqual(40, size.Width);
+        Assert.AreEqual(10, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_Unconstrained_FillsDesiredDefault()
     {
         // NOTE: Default dimensions may become configurable.
@@ -36,11 +37,11 @@ public class EditorNodeMeasureArrangeTests
         var size = node.Measure(new Constraints(0, 200, 0, 100));
 
         // Editor takes all available space up to max
-        Assert.Equal(200, size.Width);
-        Assert.Equal(100, size.Height);
+        Assert.AreEqual(200, size.Width);
+        Assert.AreEqual(100, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_StoresViewportDimensions()
     {
         // NOTE: Viewport may shrink if scrollbar or gutter is added.
@@ -51,11 +52,11 @@ public class EditorNodeMeasureArrangeTests
         node.Measure(new Constraints(0, 50, 0, 20));
         node.Arrange(new Rect(0, 0, 50, 20));
 
-        Assert.Equal(20, node.ViewportLines);
-        Assert.Equal(50, node.ViewportColumns);
+        Assert.AreEqual(20, node.ViewportLines);
+        Assert.AreEqual(50, node.ViewportColumns);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_SubscribesToDocument_ChangesMarkDirty()
     {
         // NOTE: Subscription model may change with reactive/observable patterns.
@@ -73,10 +74,10 @@ public class EditorNodeMeasureArrangeTests
         doc.Apply(new InsertOperation(new DocumentOffset(5), " World"));
 
         // If subscription failed, this would not reach here
-        Assert.Equal("Hello World", doc.GetText());
+        Assert.AreEqual("Hello World", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_SwappingDocument_UnsubscribesOldSubscribesNew()
     {
         // NOTE: Hot-swapping documents may gain animation/transition in future.
@@ -95,14 +96,14 @@ public class EditorNodeMeasureArrangeTests
 
         // Edit doc2 — should not throw (subscription active)
         doc2.Apply(new InsertOperation(new DocumentOffset(4), "!"));
-        Assert.Equal("Doc2!", doc2.GetText());
+        Assert.AreEqual("Doc2!", doc2.GetText());
 
         // Edit doc1 — node should no longer react to it (unsubscribed)
         doc1.Apply(new InsertOperation(new DocumentOffset(4), "?"));
-        Assert.Equal("Doc1?", doc1.GetText());
+        Assert.AreEqual("Doc1?", doc1.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void IsFocusable_ReturnsTrue()
     {
         // NOTE: Read-only editor may still be focusable for navigation.
@@ -110,6 +111,6 @@ public class EditorNodeMeasureArrangeTests
         var state = new EditorState(doc);
         var node = new EditorNode { State = state };
 
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
 }

--- a/tests/Hex1b.Tests/EditorNodeRenderingTests.cs
+++ b/tests/Hex1b.Tests/EditorNodeRenderingTests.cs
@@ -10,6 +10,7 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class EditorNodeRenderingTests
 {
     // Helper: resolve expected cell colors from theme.
@@ -65,7 +66,7 @@ public class EditorNodeRenderingTests
         return (node, workload, terminal, context, theme);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_EmptyDocument_ShowsCursorOnFirstCellAndTildesBelow()
     {
         // NOTE: Empty doc rendering may change if we add line numbers or gutter.
@@ -92,16 +93,16 @@ public class EditorNodeRenderingTests
 
         // Line 0: cursor cell (space with cursor colors), rest are spaces
         var cell00 = snapshot.GetCell(0, 0);
-        Assert.Equal(cursorFg, cell00.Foreground);
-        Assert.Equal(cursorBg, cell00.Background);
+        Assert.AreEqual(cursorFg, cell00.Foreground);
+        Assert.AreEqual(cursorBg, cell00.Background);
 
         // Lines 1-4: tilde markers
         for (var y = 1; y < 5; y++)
         {
-            Assert.Equal("~", snapshot.GetCell(0, y).Character);
+            Assert.AreEqual("~", snapshot.GetCell(0, y).Character);
             for (var x = 1; x < 20; x++)
             {
-                Assert.Equal(" ", snapshot.GetCell(x, y).Character);
+                Assert.AreEqual(" ", snapshot.GetCell(x, y).Character);
             }
         }
 
@@ -109,7 +110,7 @@ public class EditorNodeRenderingTests
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_SingleLineDocument_ShowsTextOnLine0AndTildesBelow()
     {
         // NOTE: May change with line number gutter.
@@ -130,32 +131,32 @@ public class EditorNodeRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // Line 0: "Hello" with cursor on 'H' (cursor at offset 0)
-        Assert.Equal("H", snapshot.GetCell(0, 0).Character);
-        Assert.Equal(cursorFg, snapshot.GetCell(0, 0).Foreground);
-        Assert.Equal(cursorBg, snapshot.GetCell(0, 0).Background);
+        Assert.AreEqual("H", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual(cursorFg, snapshot.GetCell(0, 0).Foreground);
+        Assert.AreEqual(cursorBg, snapshot.GetCell(0, 0).Background);
 
-        Assert.Equal("e", snapshot.GetCell(1, 0).Character);
-        Assert.Equal("l", snapshot.GetCell(2, 0).Character);
-        Assert.Equal("l", snapshot.GetCell(3, 0).Character);
-        Assert.Equal("o", snapshot.GetCell(4, 0).Character);
+        Assert.AreEqual("e", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("l", snapshot.GetCell(2, 0).Character);
+        Assert.AreEqual("l", snapshot.GetCell(3, 0).Character);
+        Assert.AreEqual("o", snapshot.GetCell(4, 0).Character);
 
         // Padding after text
         for (var x = 5; x < 20; x++)
         {
-            Assert.Equal(" ", snapshot.GetCell(x, 0).Character);
+            Assert.AreEqual(" ", snapshot.GetCell(x, 0).Character);
         }
 
         // Lines 1-4: tilde markers
         for (var y = 1; y < 5; y++)
         {
-            Assert.Equal("~", snapshot.GetCell(0, y).Character);
+            Assert.AreEqual("~", snapshot.GetCell(0, y).Character);
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_MultiLineDocument_EachLineAtCorrectYPosition()
     {
         // NOTE: May change with line number gutter.
@@ -176,28 +177,28 @@ public class EditorNodeRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // Line 0: "AAA" (cursor on 'A' at col 0)
-        Assert.Equal("A", snapshot.GetCell(0, 0).Character);
-        Assert.Equal(cursorFg, snapshot.GetCell(0, 0).Foreground);
-        Assert.Equal("A", snapshot.GetCell(1, 0).Character);
-        Assert.Equal("A", snapshot.GetCell(2, 0).Character);
+        Assert.AreEqual("A", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual(cursorFg, snapshot.GetCell(0, 0).Foreground);
+        Assert.AreEqual("A", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("A", snapshot.GetCell(2, 0).Character);
 
         // Line 1: "BBB"
-        Assert.Equal("B", snapshot.GetCell(0, 1).Character);
-        Assert.Equal("B", snapshot.GetCell(1, 1).Character);
-        Assert.Equal("B", snapshot.GetCell(2, 1).Character);
+        Assert.AreEqual("B", snapshot.GetCell(0, 1).Character);
+        Assert.AreEqual("B", snapshot.GetCell(1, 1).Character);
+        Assert.AreEqual("B", snapshot.GetCell(2, 1).Character);
 
         // Line 2: "CCC"
-        Assert.Equal("C", snapshot.GetCell(0, 2).Character);
+        Assert.AreEqual("C", snapshot.GetCell(0, 2).Character);
 
         // Lines 3-4: tilde markers (past 3-line doc)
-        Assert.Equal("~", snapshot.GetCell(0, 3).Character);
-        Assert.Equal("~", snapshot.GetCell(0, 4).Character);
+        Assert.AreEqual("~", snapshot.GetCell(0, 3).Character);
+        Assert.AreEqual("~", snapshot.GetCell(0, 4).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_LineLongerThanViewport_TruncatedToViewportWidth()
     {
         // NOTE: Horizontal scrolling may change truncation behavior in future.
@@ -215,18 +216,18 @@ public class EditorNodeRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // Only first 5 chars visible (viewport width = 5)
-        Assert.Equal("A", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("B", snapshot.GetCell(1, 0).Character);
-        Assert.Equal("C", snapshot.GetCell(2, 0).Character);
-        Assert.Equal("D", snapshot.GetCell(3, 0).Character);
-        Assert.Equal("E", snapshot.GetCell(4, 0).Character);
+        Assert.AreEqual("A", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("B", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("C", snapshot.GetCell(2, 0).Character);
+        Assert.AreEqual("D", snapshot.GetCell(3, 0).Character);
+        Assert.AreEqual("E", snapshot.GetCell(4, 0).Character);
         // No chars past viewport edge (cols 5+ not in our viewport)
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_ShortLine_PaddedWithSpacesToViewportWidth()
     {
         // NOTE: Padding behavior may change with background fill or gutter.
@@ -245,21 +246,21 @@ public class EditorNodeRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // "Hi" at cols 0-1, then spaces at cols 2-9
-        Assert.Equal("H", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("i", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("H", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("i", snapshot.GetCell(1, 0).Character);
         for (var x = 2; x < 10; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.Equal(" ", cell.Character);
-            Assert.Equal(textFg, cell.Foreground);
-            Assert.Equal(textBg, cell.Background);
+            Assert.AreEqual(" ", cell.Character);
+            Assert.AreEqual(textFg, cell.Foreground);
+            Assert.AreEqual(textBg, cell.Background);
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_CursorOnFirstChar_HasCursorColors()
     {
         // NOTE: Cursor rendering may change to use reverse video or underline.
@@ -283,15 +284,15 @@ public class EditorNodeRenderingTests
 
         var snapshot = terminal.CreateSnapshot();
         var cell = snapshot.GetCell(0, 0);
-        Assert.Equal("X", cell.Character);
-        Assert.Equal(cursorFg, cell.Foreground);
-        Assert.Equal(cursorBg, cell.Background);
+        Assert.AreEqual("X", cell.Character);
+        Assert.AreEqual(cursorFg, cell.Foreground);
+        Assert.AreEqual(cursorBg, cell.Background);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_CursorMidLine_OnlyCursorCellHasCursorColors()
     {
         // NOTE: Cursor rendering may change with multi-cursor or selection highlighting.
@@ -318,26 +319,26 @@ public class EditorNodeRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // 'A' and 'B' at cols 0-1: NOT cursor colors
-        Assert.Equal("A", snapshot.GetCell(0, 0).Character);
-        Assert.NotEqual(cursorBg, snapshot.GetCell(0, 0).Background);
+        Assert.AreEqual("A", snapshot.GetCell(0, 0).Character);
+        Assert.AreNotEqual(cursorBg, snapshot.GetCell(0, 0).Background);
 
-        Assert.Equal("B", snapshot.GetCell(1, 0).Character);
-        Assert.NotEqual(cursorBg, snapshot.GetCell(1, 0).Background);
+        Assert.AreEqual("B", snapshot.GetCell(1, 0).Character);
+        Assert.AreNotEqual(cursorBg, snapshot.GetCell(1, 0).Background);
 
         // 'C' at col 2: cursor colors
-        Assert.Equal("C", snapshot.GetCell(2, 0).Character);
-        Assert.Equal(cursorFg, snapshot.GetCell(2, 0).Foreground);
-        Assert.Equal(cursorBg, snapshot.GetCell(2, 0).Background);
+        Assert.AreEqual("C", snapshot.GetCell(2, 0).Character);
+        Assert.AreEqual(cursorFg, snapshot.GetCell(2, 0).Foreground);
+        Assert.AreEqual(cursorBg, snapshot.GetCell(2, 0).Background);
 
         // 'D' and 'E' at cols 3-4: NOT cursor colors
-        Assert.Equal("D", snapshot.GetCell(3, 0).Character);
-        Assert.NotEqual(cursorBg, snapshot.GetCell(3, 0).Background);
+        Assert.AreEqual("D", snapshot.GetCell(3, 0).Character);
+        Assert.AreNotEqual(cursorBg, snapshot.GetCell(3, 0).Background);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_CursorAtEndOfLine_CursorOnSpaceAfterLastChar()
     {
         // NOTE: End-of-line cursor behavior may change with virtual space mode.
@@ -362,19 +363,19 @@ public class EditorNodeRenderingTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal("A", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("B", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("A", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("B", snapshot.GetCell(1, 0).Character);
 
         var cursorCell = snapshot.GetCell(2, 0);
-        Assert.Equal(" ", cursorCell.Character);
-        Assert.Equal(cursorFg, cursorCell.Foreground);
-        Assert.Equal(cursorBg, cursorCell.Background);
+        Assert.AreEqual(" ", cursorCell.Character);
+        Assert.AreEqual(cursorFg, cursorCell.Foreground);
+        Assert.AreEqual(cursorBg, cursorCell.Background);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Unfocused_NoCellHasCursorColors()
     {
         // NOTE: Unfocused editor may gain dimmed cursor in future.
@@ -397,7 +398,7 @@ public class EditorNodeRenderingTests
         {
             for (var x = 0; x < 20; x++)
             {
-                Assert.NotEqual(cursorBg, snapshot.GetCell(x, y).Background);
+                Assert.AreNotEqual(cursorBg, snapshot.GetCell(x, y).Background);
             }
         }
 
@@ -405,7 +406,7 @@ public class EditorNodeRenderingTests
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_EOFTildeMarkers_ShowTildeWithTextColorsNotCursorColors()
     {
         // NOTE: EOF marker style (tilde vs empty) may become configurable.
@@ -429,14 +430,14 @@ public class EditorNodeRenderingTests
         for (var y = 1; y < 4; y++)
         {
             var tildeCell = snapshot.GetCell(0, y);
-            Assert.Equal("~", tildeCell.Character);
-            Assert.Equal(textFg, tildeCell.Foreground);
-            Assert.Equal(textBg, tildeCell.Background);
-            Assert.NotEqual(cursorBg, tildeCell.Background);
+            Assert.AreEqual("~", tildeCell.Character);
+            Assert.AreEqual(textFg, tildeCell.Foreground);
+            Assert.AreEqual(textBg, tildeCell.Background);
+            Assert.AreNotEqual(cursorBg, tildeCell.Background);
 
             for (var x = 1; x < 10; x++)
             {
-                Assert.Equal(" ", snapshot.GetCell(x, y).Character);
+                Assert.AreEqual(" ", snapshot.GetCell(x, y).Character);
             }
         }
 
@@ -444,7 +445,7 @@ public class EditorNodeRenderingTests
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_ViewportFillsBounds_EveryCellHasContent()
     {
         // NOTE: Viewport fill behavior may change with margin/padding support.
@@ -467,8 +468,7 @@ public class EditorNodeRenderingTests
             for (var x = 0; x < 8; x++)
             {
                 var cell = snapshot.GetCell(x, y);
-                Assert.False(string.IsNullOrEmpty(cell.Character),
-                    $"Cell ({x},{y}) should have content but was empty");
+                Assert.IsFalse(string.IsNullOrEmpty(cell.Character), $"Cell ({x},{y}) should have content but was empty");
             }
         }
 
@@ -476,7 +476,7 @@ public class EditorNodeRenderingTests
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_SmallViewport3Lines_Only3RowsRendered()
     {
         // NOTE: With scrollbar, viewport may shrink by 1 column.
@@ -500,16 +500,16 @@ public class EditorNodeRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // Row 0: "L1" (line 1)
-        Assert.Equal("L", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("1", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("L", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("1", snapshot.GetCell(1, 0).Character);
 
         // Row 1: "L2" (line 2)
-        Assert.Equal("L", snapshot.GetCell(0, 1).Character);
-        Assert.Equal("2", snapshot.GetCell(1, 1).Character);
+        Assert.AreEqual("L", snapshot.GetCell(0, 1).Character);
+        Assert.AreEqual("2", snapshot.GetCell(1, 1).Character);
 
         // Row 2: "L3" (line 3)
-        Assert.Equal("L", snapshot.GetCell(0, 2).Character);
-        Assert.Equal("3", snapshot.GetCell(1, 2).Character);
+        Assert.AreEqual("L", snapshot.GetCell(0, 2).Character);
+        Assert.AreEqual("3", snapshot.GetCell(1, 2).Character);
 
         // Lines 4 and 5 are NOT visible (only 3-line viewport)
         // We can't directly assert "not rendered" but they're offscreen
@@ -518,7 +518,7 @@ public class EditorNodeRenderingTests
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_LargeDocSmallViewport_OnlyViewportWindowVisible()
     {
         // NOTE: Scroll indicator may appear in future.
@@ -549,7 +549,7 @@ public class EditorNodeRenderingTests
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_EmptyLinesInDocument_ShowSpacesNotTildes()
     {
         // NOTE: Empty lines may gain whitespace indicators in future.
@@ -568,28 +568,28 @@ public class EditorNodeRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // Row 0: "A"
-        Assert.Equal("A", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("A", snapshot.GetCell(0, 0).Character);
 
         // Row 1: empty line in document — should be spaces, NOT tilde
-        Assert.Equal(" ", snapshot.GetCell(0, 1).Character);
-        Assert.NotEqual("~", snapshot.GetCell(0, 1).Character);
+        Assert.AreEqual(" ", snapshot.GetCell(0, 1).Character);
+        Assert.AreNotEqual("~", snapshot.GetCell(0, 1).Character);
         // Verify it's spaces across the whole line
         for (var x = 0; x < 10; x++)
         {
-            Assert.Equal(" ", snapshot.GetCell(x, 1).Character);
+            Assert.AreEqual(" ", snapshot.GetCell(x, 1).Character);
         }
 
         // Row 2: "B"
-        Assert.Equal("B", snapshot.GetCell(0, 2).Character);
+        Assert.AreEqual("B", snapshot.GetCell(0, 2).Character);
 
         // Row 3: past EOF — should be tilde
-        Assert.Equal("~", snapshot.GetCell(0, 3).Character);
+        Assert.AreEqual("~", snapshot.GetCell(0, 3).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_ThemeColorsOnText_AllNonCursorCellsHaveTextColors()
     {
         // NOTE: Theme color application may change with syntax highlighting.
@@ -612,15 +612,15 @@ public class EditorNodeRenderingTests
         for (var x = 1; x <= 3; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.Equal(textFg, cell.Foreground);
-            Assert.Equal(textBg, cell.Background);
+            Assert.AreEqual(textFg, cell.Foreground);
+            Assert.AreEqual(textBg, cell.Background);
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_ThemeColorsOnCursor_CursorCellMatchesTheme()
     {
         // NOTE: Cursor style (block, bar, underline) may become configurable.
@@ -642,15 +642,15 @@ public class EditorNodeRenderingTests
 
         var snapshot = terminal.CreateSnapshot();
         var cell = snapshot.GetCell(0, 0);
-        Assert.Equal("X", cell.Character);
-        Assert.Equal(cursorFg, cell.Foreground);
-        Assert.Equal(cursorBg, cell.Background);
+        Assert.AreEqual("X", cell.Character);
+        Assert.AreEqual(cursorFg, cell.Foreground);
+        Assert.AreEqual(cursorBg, cell.Background);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_ScrollbarAppearsWhenContentOverflows()
     {
         // NOTE: Scrollbar appears on the rightmost column when doc has more lines than viewport.
@@ -694,13 +694,13 @@ public class EditorNodeRenderingTests
                 hasTrackOrThumb = true;
         }
 
-        Assert.True(hasTrackOrThumb, "Scrollbar should appear in rightmost column");
+        Assert.IsTrue(hasTrackOrThumb, "Scrollbar should appear in rightmost column");
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_NoScrollbarWhenContentFits()
     {
         // NOTE: No scrollbar when all content fits in viewport.
@@ -725,15 +725,15 @@ public class EditorNodeRenderingTests
         for (var row = 0; row < 5; row++)
         {
             var cell = snapshot.GetCell(scrollCol, row);
-            Assert.NotEqual(trackChar, cell.Character);
-            Assert.NotEqual(thumbChar, cell.Character);
+            Assert.AreNotEqual(trackChar, cell.Character);
+            Assert.AreNotEqual(thumbChar, cell.Character);
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_LongLine_ReducesViewportForHorizontalScrollbar()
     {
         // Line longer than viewport should reduce viewport height for horizontal scrollbar
@@ -741,28 +741,28 @@ public class EditorNodeRenderingTests
         var (node, workload, terminal, context, theme) = CreateEditor(longLine, 20, 5);
 
         // With horizontal scrollbar, viewport lines should be reduced by 1
-        Assert.Equal(4, node.ViewportLines);
-        Assert.Equal(20, node.ViewportColumns); // no vertical scrollbar
+        Assert.AreEqual(4, node.ViewportLines);
+        Assert.AreEqual(20, node.ViewportColumns); // no vertical scrollbar
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_VerticalOverflow_ReducesViewportForScrollbar()
     {
         // Many lines should reduce viewport columns for vertical scrollbar
         var lines = string.Join("\n", Enumerable.Range(1, 20).Select(i => $"Line{i}"));
         var (node, workload, terminal, context, theme) = CreateEditor(lines, 20, 5);
 
-        Assert.Equal(19, node.ViewportColumns);
-        Assert.Equal(5, node.ViewportLines); // no horizontal scrollbar
+        Assert.AreEqual(19, node.ViewportColumns);
+        Assert.AreEqual(5, node.ViewportLines); // no horizontal scrollbar
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public void HorizontalScroll_CursorMovesRight_ScrollsHorizontally()
     {
         // Moving cursor past viewport width should trigger horizontal scrolling
@@ -787,13 +787,13 @@ public class EditorNodeRenderingTests
         node.NotifyCursorChanged();
         node.Arrange(new Rect(0, 0, 20, 5));
 
-        Assert.True(node.HorizontalScrollOffset > 0, "Horizontal scroll should be non-zero when cursor is past viewport");
+        Assert.IsTrue(node.HorizontalScrollOffset > 0, "Horizontal scroll should be non-zero when cursor is past viewport");
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_HorizontalScrollbar_AppearsAtBottom()
     {
         // When content is wider than viewport, horizontal scrollbar renders on bottom row
@@ -835,13 +835,13 @@ public class EditorNodeRenderingTests
                 hasTrackOrThumb = true;
         }
 
-        Assert.True(hasTrackOrThumb, "Horizontal scrollbar should appear on bottom row");
+        Assert.IsTrue(hasTrackOrThumb, "Horizontal scrollbar should appear on bottom row");
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WideCharacter_OccupiesTwoDisplayColumns()
     {
         // ⚡ (U+26A1) has Emoji_Presentation → display width 2
@@ -859,22 +859,21 @@ public class EditorNodeRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // Col 0: 'A' (1-wide), cursor on 'A' by default
-        Assert.Equal("A", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("A", snapshot.GetCell(0, 0).Character);
         // Col 1: '⚡' main cell (2-wide)
-        Assert.Equal("⚡", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("⚡", snapshot.GetCell(1, 0).Character);
         // Col 2: continuation cell (empty/wide char continuation)
-        Assert.True(snapshot.GetCell(2, 0).Character is "" or " ",
-            "Col 2 should be continuation cell for wide ⚡");
+        Assert.IsTrue(snapshot.GetCell(2, 0).Character is "" or " ", "Col 2 should be continuation cell for wide ⚡");
         // Col 3: 'B' (1-wide) — shifted by the extra column from ⚡
-        Assert.Equal("B", snapshot.GetCell(3, 0).Character);
+        Assert.AreEqual("B", snapshot.GetCell(3, 0).Character);
         // Col 4+: padding spaces
-        Assert.Equal(" ", snapshot.GetCell(4, 0).Character);
+        Assert.AreEqual(" ", snapshot.GetCell(4, 0).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_CursorOnWideChar_BothColumnsHaveCursorColors()
     {
         // Cursor on ⚡ should highlight both display columns
@@ -901,15 +900,15 @@ public class EditorNodeRenderingTests
 
         // Col 1: ⚡ main cell with cursor colors
         var cell1 = snapshot.GetCell(1, 0);
-        Assert.Equal("⚡", cell1.Character);
-        Assert.Equal(cursorFg, cell1.Foreground);
-        Assert.Equal(cursorBg, cell1.Background);
+        Assert.AreEqual("⚡", cell1.Character);
+        Assert.AreEqual(cursorFg, cell1.Foreground);
+        Assert.AreEqual(cursorBg, cell1.Background);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_CursorAfterWideChar_CursorAtCorrectDisplayColumn()
     {
         // Cursor on 'B' (after 2-wide ⚡) should be at display col 3
@@ -936,24 +935,24 @@ public class EditorNodeRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // Col 0: 'A' (normal colors)
-        Assert.Equal("A", snapshot.GetCell(0, 0).Character);
-        Assert.Equal(textFg, snapshot.GetCell(0, 0).Foreground);
+        Assert.AreEqual("A", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual(textFg, snapshot.GetCell(0, 0).Foreground);
 
         // Col 1: '⚡' (normal colors — cursor has moved past)
-        Assert.Equal("⚡", snapshot.GetCell(1, 0).Character);
-        Assert.Equal(textFg, snapshot.GetCell(1, 0).Foreground);
+        Assert.AreEqual("⚡", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual(textFg, snapshot.GetCell(1, 0).Foreground);
 
         // Col 3: 'B' with cursor colors
         var cellB = snapshot.GetCell(3, 0);
-        Assert.Equal("B", cellB.Character);
-        Assert.Equal(cursorFg, cellB.Foreground);
-        Assert.Equal(cursorBg, cellB.Background);
+        Assert.AreEqual("B", cellB.Character);
+        Assert.AreEqual(cursorFg, cellB.Foreground);
+        Assert.AreEqual(cursorBg, cellB.Background);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_MultipleWideChars_CorrectDisplayLayout()
     {
         // "⌚⌛" — both 2-wide (Emoji_Presentation=Yes), should occupy 4 display columns
@@ -971,19 +970,19 @@ public class EditorNodeRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // Col 0: ⌚ main (2-wide)
-        Assert.Equal("⌚", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("⌚", snapshot.GetCell(0, 0).Character);
         // Col 1: continuation
         // Col 2: ⌛ main (2-wide)
-        Assert.Equal("⌛", snapshot.GetCell(2, 0).Character);
+        Assert.AreEqual("⌛", snapshot.GetCell(2, 0).Character);
         // Col 3: continuation
         // Col 4: X (1-wide)
-        Assert.Equal("X", snapshot.GetCell(4, 0).Character);
+        Assert.AreEqual("X", snapshot.GetCell(4, 0).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WideCharAtViewportEdge_TruncatedNotOverflow()
     {
         // Viewport width 4: "A⚡B" — A(1) + ⚡(2) = 3 cols, B starts at col 3
@@ -1002,9 +1001,9 @@ public class EditorNodeRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // Col 0: A, Col 1: ⚡ (2-wide), Col 3: B — all fit in 4 cols
-        Assert.Equal("A", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("⚡", snapshot.GetCell(1, 0).Character);
-        Assert.Equal("B", snapshot.GetCell(3, 0).Character);
+        Assert.AreEqual("A", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("⚡", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("B", snapshot.GetCell(3, 0).Character);
 
         workload.Dispose();
         terminal.Dispose();

--- a/tests/Hex1b.Tests/EditorNodeScrollTests.cs
+++ b/tests/Hex1b.Tests/EditorNodeScrollTests.cs
@@ -9,6 +9,7 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class EditorNodeScrollTests
 {
     private static EditorNode CreateNode(string text, int width, int height, bool focused = true)
@@ -23,42 +24,42 @@ public class EditorNodeScrollTests
         return node;
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollOffset_AfterArrange_StartsAt1()
     {
         // NOTE: Initial scroll may change if we support restoring scroll position.
         var node = CreateNode("Hello\nWorld", 20, 5);
-        Assert.Equal(1, node.ScrollOffset);
+        Assert.AreEqual(1, node.ScrollOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollOffset_SetToZero_ClampsTo1()
     {
         // NOTE: Clamping behavior may change with virtual scroll support.
         var node = CreateNode("Hello\nWorld", 20, 5);
         node.ScrollOffset = 0;
-        Assert.Equal(1, node.ScrollOffset);
+        Assert.AreEqual(1, node.ScrollOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollOffset_SetToNegative_ClampsTo1()
     {
         // NOTE: Clamping behavior may change with virtual scroll support.
         var node = CreateNode("Hello\nWorld", 20, 5);
         node.ScrollOffset = -5;
-        Assert.Equal(1, node.ScrollOffset);
+        Assert.AreEqual(1, node.ScrollOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollOffset_SetBeyondLineCount_ClampsToLineCount()
     {
         // NOTE: May change if we allow scrolling past end of document.
         var node = CreateNode("A\nB\nC", 20, 5); // 3 lines
         node.ScrollOffset = 100;
-        Assert.Equal(3, node.ScrollOffset);
+        Assert.AreEqual(3, node.ScrollOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public void EnsureCursorVisible_CursorBelowViewport_ScrollsDown()
     {
         // NOTE: Scroll margin (keeping cursor N lines from edge) may be added.
@@ -74,12 +75,11 @@ public class EditorNodeScrollTests
         node.Arrange(new Rect(0, 0, 20, 5));
 
         // Cursor is on line 10; viewport should scroll so line 10 is visible
-        Assert.True(node.ScrollOffset <= 10, $"ScrollOffset {node.ScrollOffset} should be <= 10");
-        Assert.True(node.ScrollOffset + node.ViewportLines > 10,
-            $"ScrollOffset {node.ScrollOffset} + viewport {node.ViewportLines} should show line 10");
+        Assert.IsTrue(node.ScrollOffset <= 10, $"ScrollOffset {node.ScrollOffset} should be <= 10");
+        Assert.IsTrue(node.ScrollOffset + node.ViewportLines > 10, $"ScrollOffset {node.ScrollOffset} + viewport {node.ViewportLines} should show line 10");
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollOffset_SetManually_DoesNotFlickBackToCursor()
     {
         // When scroll is set via scrollbar or wheel (no cursor change), Arrange must
@@ -93,10 +93,10 @@ public class EditorNodeScrollTests
         // Re-arrange should NOT snap back — no cursor change occurred
         node.Arrange(new Rect(0, 0, 20, 5));
 
-        Assert.Equal(15, node.ScrollOffset);
+        Assert.AreEqual(15, node.ScrollOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public void EnsureCursorVisible_CursorWithinViewport_NoScrollChange()
     {
         // NOTE: Scroll behavior may change with smooth scrolling.
@@ -104,7 +104,7 @@ public class EditorNodeScrollTests
         var node = CreateNode(lines, 20, 10);
 
         // Cursor at line 1, viewport shows lines 1-10 → no scroll needed
-        Assert.Equal(1, node.ScrollOffset);
+        Assert.AreEqual(1, node.ScrollOffset);
 
         // Move cursor to line 5 (still within viewport)
         for (var i = 0; i < 4; i++)
@@ -114,10 +114,10 @@ public class EditorNodeScrollTests
         node.Arrange(new Rect(0, 0, 20, 10));
 
         // Should still be at scroll offset 1
-        Assert.Equal(1, node.ScrollOffset);
+        Assert.AreEqual(1, node.ScrollOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public void PageDown_ScrollsViewport()
     {
         // NOTE: PageDown behavior may gain half-page option.
@@ -132,12 +132,12 @@ public class EditorNodeScrollTests
         // Cursor should be on line 11 (started at line 1, moved down by viewport=10);
         // MovePageDown uses the viewport lines count
         var cursorLine = node.State.Document.OffsetToPosition(node.State.Cursor.Position).Line;
-        Assert.True(cursorLine > 1, $"Cursor should have moved past line 1, is on line {cursorLine}");
-        Assert.True(node.ScrollOffset <= cursorLine);
-        Assert.True(node.ScrollOffset + node.ViewportLines > cursorLine);
+        Assert.IsTrue(cursorLine > 1, $"Cursor should have moved past line 1, is on line {cursorLine}");
+        Assert.IsTrue(node.ScrollOffset <= cursorLine);
+        Assert.IsTrue(node.ScrollOffset + node.ViewportLines > cursorLine);
     }
 
-    [Fact]
+    [TestMethod]
     public void PageUp_ScrollsViewportBack()
     {
         // NOTE: PageUp behavior may gain half-page option.
@@ -155,11 +155,11 @@ public class EditorNodeScrollTests
         node.Arrange(new Rect(0, 0, 20, 10));
 
         var cursorLine = node.State.Document.OffsetToPosition(node.State.Cursor.Position).Line;
-        Assert.True(node.ScrollOffset <= cursorLine);
-        Assert.True(node.ScrollOffset + node.ViewportLines > cursorLine);
+        Assert.IsTrue(node.ScrollOffset <= cursorLine);
+        Assert.IsTrue(node.ScrollOffset + node.ViewportLines > cursorLine);
     }
 
-    [Fact]
+    [TestMethod]
     public void TwoEditors_SameDoc_IndependentScroll()
     {
         // NOTE: Linked scroll mode may be added for diff views.
@@ -180,16 +180,16 @@ public class EditorNodeScrollTests
         node1.ScrollOffset = 20;
 
         // node2 should still be at line 1
-        Assert.Equal(20, node1.ScrollOffset);
-        Assert.Equal(1, node2.ScrollOffset);
+        Assert.AreEqual(20, node1.ScrollOffset);
+        Assert.AreEqual(1, node2.ScrollOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public void ViewportLines_MatchArrangedHeight()
     {
         // NOTE: May change if scrollbar or status bar consumes viewport lines.
         var node = CreateNode("Hello", 30, 15);
-        Assert.Equal(15, node.ViewportLines);
-        Assert.Equal(30, node.ViewportColumns);
+        Assert.AreEqual(15, node.ViewportLines);
+        Assert.AreEqual(30, node.ViewportColumns);
     }
 }

--- a/tests/Hex1b.Tests/EditorOverlayTests.cs
+++ b/tests/Hex1b.Tests/EditorOverlayTests.cs
@@ -10,6 +10,7 @@ namespace Hex1b.Tests;
 /// Tests for the editor overlay system — push/dismiss, dismiss-on-cursor-move,
 /// coordinate mapping, and lifecycle management.
 /// </summary>
+[TestClass]
 public class EditorOverlayTests
 {
     /// <summary>
@@ -55,7 +56,7 @@ public class EditorOverlayTests
         return (node, workload, context);
     }
 
-    [Fact]
+    [TestMethod]
     public void Activate_CalledWhenProviderSetViaReconcile()
     {
         // Arrange
@@ -68,11 +69,11 @@ public class EditorOverlayTests
         node.UpdateDecorationProviders([provider]);
 
         // Assert
-        Assert.True(provider.WasActivated);
-        Assert.NotNull(provider.Session);
+        Assert.IsTrue(provider.WasActivated);
+        Assert.IsNotNull(provider.Session);
     }
 
-    [Fact]
+    [TestMethod]
     public void Deactivate_CalledWhenProviderRemoved()
     {
         // Arrange
@@ -84,10 +85,10 @@ public class EditorOverlayTests
         node.UpdateDecorationProviders(null);
 
         // Assert
-        Assert.True(provider.WasDeactivated);
+        Assert.IsTrue(provider.WasDeactivated);
     }
 
-    [Fact]
+    [TestMethod]
     public void PushOverlay_AddsToActiveOverlays()
     {
         // Arrange
@@ -105,11 +106,11 @@ public class EditorOverlayTests
         provider.Session!.PushOverlay(overlay);
 
         // Assert
-        Assert.Single(provider.Session.ActiveOverlays);
-        Assert.Equal("test-overlay", provider.Session.ActiveOverlays[0].Id);
+        TestSeq.Single(provider.Session.ActiveOverlays);
+        Assert.AreEqual("test-overlay", provider.Session.ActiveOverlays[0].Id);
     }
 
-    [Fact]
+    [TestMethod]
     public void PushOverlay_ReplacesSameId()
     {
         // Arrange
@@ -127,12 +128,12 @@ public class EditorOverlayTests
         provider.Session.PushOverlay(overlay2);
 
         // Assert
-        Assert.Single(provider.Session.ActiveOverlays);
-        Assert.Equal("second", provider.Session.ActiveOverlays[0].Content[0].Text);
-        Assert.Equal(OverlayPlacement.Above, provider.Session.ActiveOverlays[0].Placement);
+        TestSeq.Single(provider.Session.ActiveOverlays);
+        Assert.AreEqual("second", provider.Session.ActiveOverlays[0].Content[0].Text);
+        Assert.AreEqual(OverlayPlacement.Above, provider.Session.ActiveOverlays[0].Placement);
     }
 
-    [Fact]
+    [TestMethod]
     public void DismissOverlay_RemovesById()
     {
         // Arrange
@@ -149,11 +150,11 @@ public class EditorOverlayTests
         provider.Session.DismissOverlay("a");
 
         // Assert
-        Assert.Single(provider.Session.ActiveOverlays);
-        Assert.Equal("b", provider.Session.ActiveOverlays[0].Id);
+        TestSeq.Single(provider.Session.ActiveOverlays);
+        Assert.AreEqual("b", provider.Session.ActiveOverlays[0].Id);
     }
 
-    [Fact]
+    [TestMethod]
     public void DismissOnCursorMove_RemovesOverlayWhenCursorMoves()
     {
         // Arrange
@@ -165,16 +166,16 @@ public class EditorOverlayTests
             OverlayPlacement.Below, [new OverlayLine("hover info")],
             DismissOnCursorMove: true));
 
-        Assert.Single(provider.Session.ActiveOverlays);
+        TestSeq.Single(provider.Session.ActiveOverlays);
 
         // Act — simulate cursor move
         node.NotifyCursorChanged();
 
         // Assert
-        Assert.Empty(provider.Session.ActiveOverlays);
+        Assert.IsEmpty(provider.Session.ActiveOverlays);
     }
 
-    [Fact]
+    [TestMethod]
     public void DismissOnCursorMove_False_PreservesOverlayWhenCursorMoves()
     {
         // Arrange
@@ -190,11 +191,11 @@ public class EditorOverlayTests
         node.NotifyCursorChanged();
 
         // Assert — overlay should survive
-        Assert.Single(provider.Session.ActiveOverlays);
-        Assert.Equal("sticky", provider.Session.ActiveOverlays[0].Id);
+        TestSeq.Single(provider.Session.ActiveOverlays);
+        Assert.AreEqual("sticky", provider.Session.ActiveOverlays[0].Id);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_WithOverlay_DoesNotCrash()
     {
         // Arrange — ensure rendering with an active overlay doesn't throw
@@ -213,7 +214,7 @@ public class EditorOverlayTests
         node.Render(context);
     }
 
-    [Fact]
+    [TestMethod]
     public void MultipleProviders_IndependentOverlays()
     {
         // Arrange
@@ -229,7 +230,7 @@ public class EditorOverlayTests
             OverlayPlacement.Above, [new OverlayLine("from provider 2")]));
 
         // Assert — both overlays exist on the same session
-        Assert.Equal(2, provider1.Session.ActiveOverlays.Count);
-        Assert.Equal(2, provider2.Session.ActiveOverlays.Count);
+        Assert.AreEqual(2, provider1.Session.ActiveOverlays.Count);
+        Assert.AreEqual(2, provider2.Session.ActiveOverlays.Count);
     }
 }

--- a/tests/Hex1b.Tests/EditorScrollbarTests.cs
+++ b/tests/Hex1b.Tests/EditorScrollbarTests.cs
@@ -11,6 +11,7 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class EditorScrollbarTests
 {
     // ── Helpers ──────────────────────────────────────────────────
@@ -76,25 +77,25 @@ public class EditorScrollbarTests
     // SECTION 1: Vertical scrollbar visibility & rendering
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void VScrollbar_AppearsWhenContentExceedsViewport()
     {
         // 50 lines in 10-line viewport → scrollbar
         var node = CreateNode(MakeLines(50), 30, 10);
-        Assert.Equal(29, node.ViewportColumns); // 30 - 1 for scrollbar
-        Assert.Equal(10, node.ViewportLines);
+        Assert.AreEqual(29, node.ViewportColumns); // 30 - 1 for scrollbar
+        Assert.AreEqual(10, node.ViewportLines);
     }
 
-    [Fact]
+    [TestMethod]
     public void VScrollbar_AbsentWhenContentFits()
     {
         // 5 lines in 10-line viewport → no scrollbar
         var node = CreateNode(MakeLines(5), 30, 10);
-        Assert.Equal(30, node.ViewportColumns);
-        Assert.Equal(10, node.ViewportLines);
+        Assert.AreEqual(30, node.ViewportColumns);
+        Assert.AreEqual(10, node.ViewportLines);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task VScrollbar_RendersTrackAndThumb()
     {
         var text = MakeLines(50);
@@ -134,31 +135,31 @@ public class EditorScrollbarTests
             if (ch == thumbChar) hasThumb = true;
         }
 
-        Assert.True(hasTrack, "Should have track characters on rightmost column");
-        Assert.True(hasThumb, "Should have thumb characters on rightmost column");
+        Assert.IsTrue(hasTrack, "Should have track characters on rightmost column");
+        Assert.IsTrue(hasThumb, "Should have thumb characters on rightmost column");
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 2: Horizontal scrollbar visibility & rendering
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void HScrollbar_AppearsWhenLinesExceedViewportWidth()
     {
         // 5 lines, each 80 chars, in 30-wide viewport → h-scrollbar
         var node = CreateNode(MakeWideLines(5, 80), 30, 10);
-        Assert.Equal(9, node.ViewportLines); // 10 - 1 for h-scrollbar
+        Assert.AreEqual(9, node.ViewportLines); // 10 - 1 for h-scrollbar
     }
 
-    [Fact]
+    [TestMethod]
     public void HScrollbar_AbsentWhenContentFitsWidth()
     {
         // 5 lines, each 10 chars, in 30-wide viewport → no h-scrollbar
         var node = CreateNode(MakeWideLines(5, 10), 30, 10);
-        Assert.Equal(10, node.ViewportLines);
+        Assert.AreEqual(10, node.ViewportLines);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HScrollbar_RendersOnBottomRow()
     {
         var text = MakeWideLines(3, 80); // 3 lines, 80 chars each
@@ -195,23 +196,23 @@ public class EditorScrollbarTests
             if (ch == trackChar || ch == thumbChar) hasTrackOrThumb = true;
         }
 
-        Assert.True(hasTrackOrThumb, "Horizontal scrollbar should appear on bottom row");
+        Assert.IsTrue(hasTrackOrThumb, "Horizontal scrollbar should appear on bottom row");
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 3: Both scrollbars (wide + tall content)
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void BothScrollbars_WideAndTallContent()
     {
         // 50 lines, each 80 chars → both scrollbars
         var node = CreateNode(MakeWideLines(50, 80), 30, 10);
-        Assert.Equal(29, node.ViewportColumns); // -1 for v-scrollbar
-        Assert.Equal(9, node.ViewportLines);    // -1 for h-scrollbar
+        Assert.AreEqual(29, node.ViewportColumns); // -1 for v-scrollbar
+        Assert.AreEqual(9, node.ViewportLines);    // -1 for h-scrollbar
     }
 
-    [Fact]
+    [TestMethod]
     public async Task BothScrollbars_RenderCorrectly()
     {
         var text = MakeWideLines(50, 80);
@@ -258,7 +259,7 @@ public class EditorScrollbarTests
             var ch = snapshot.GetCell(29, row).Character;
             if (ch == vTrack || ch == vThumb) hasVScrollbar = true;
         }
-        Assert.True(hasVScrollbar, "Vertical scrollbar should render on col 29");
+        Assert.IsTrue(hasVScrollbar, "Vertical scrollbar should render on col 29");
 
         // Horizontal scrollbar on row 9, cols 0-28 (not col 29 — that's the corner)
         var hasHScrollbar = false;
@@ -267,14 +268,14 @@ public class EditorScrollbarTests
             var ch = snapshot.GetCell(col, 9).Character;
             if (ch == hTrack || ch == hThumb) hasHScrollbar = true;
         }
-        Assert.True(hasHScrollbar, "Horizontal scrollbar should render on row 9");
+        Assert.IsTrue(hasHScrollbar, "Horizontal scrollbar should render on row 9");
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 4: Cursor position & scroll at document edges
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public async Task CursorAtDocStart_ContentShowsFirstLines()
     {
         var text = MakeLines(50);
@@ -294,7 +295,7 @@ public class EditorScrollbarTests
         Assert.Contains("L002", snapshot.GetLineTrimmed(1));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CursorAtDocEnd_ContentShowsLastLines()
     {
         var text = MakeLines(50);
@@ -322,10 +323,10 @@ public class EditorScrollbarTests
                 break;
             }
         }
-        Assert.True(foundLast, "Last line L050 should be visible after Ctrl+End");
+        Assert.IsTrue(foundLast, "Last line L050 should be visible after Ctrl+End");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CursorAtEndOfLongLine_HScrollShowsEnd()
     {
         var text = MakeWideLines(5, 80);
@@ -366,29 +367,29 @@ public class EditorScrollbarTests
     // SECTION 5: Scroll-does-NOT-flick-back (stability)
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void ScrollManually_DoesNotFlickBackOnReArrange()
     {
         // Core invariant: Setting scroll offset without moving cursor must be stable
         // across multiple Arrange passes.
         var node = CreateNode(MakeLines(50), 30, 10);
-        Assert.Equal(1, node.ScrollOffset); // starts at top
+        Assert.AreEqual(1, node.ScrollOffset); // starts at top
 
         // Simulate scrollbar/wheel: change scroll without cursor move
         node.ScrollOffset = 25;
         node.Arrange(new Rect(0, 0, 30, 10));
-        Assert.Equal(25, node.ScrollOffset);
+        Assert.AreEqual(25, node.ScrollOffset);
 
         // Arrange again — should STILL be at 25
         node.Arrange(new Rect(0, 0, 30, 10));
-        Assert.Equal(25, node.ScrollOffset);
+        Assert.AreEqual(25, node.ScrollOffset);
 
         // And a third time
         node.Arrange(new Rect(0, 0, 30, 10));
-        Assert.Equal(25, node.ScrollOffset);
+        Assert.AreEqual(25, node.ScrollOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ScrollWheel_ThenWait_DoesNotFlickBack()
     {
         // Integration test: scroll down with wheel, then wait — should stay scrolled.
@@ -426,11 +427,11 @@ public class EditorScrollbarTests
         using (var snapshotAfterWait = terminal.CreateSnapshot())
             line0AfterWait = snapshotAfterWait.GetLineTrimmed(0);
 
-        Assert.Equal(line0After, line0AfterWait);
+        Assert.AreEqual(line0After, line0AfterWait);
         Assert.DoesNotContain("L001", line0AfterWait);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ScrollWheel_ThenTypeChar_SnapsBackToCursor()
     {
         // After scrolling away, typing should snap back to cursor position.
@@ -467,10 +468,10 @@ public class EditorScrollbarTests
                 break;
             }
         }
-        Assert.True(foundX, "After typing, viewport should snap back to show cursor + typed text");
+        Assert.IsTrue(foundX, "After typing, viewport should snap back to show cursor + typed text");
     }
 
-    [Fact]
+    [TestMethod]
     public void EnterManyLines_ThenScrollUp_StaysScrolled()
     {
         // Exact repro of the user's bug: press Enter N times, scroll up, it flicks back.
@@ -486,27 +487,27 @@ public class EditorScrollbarTests
 
         // Cursor is at line 31, scroll shows lines around 22-31
         var scrollAfterEnters = node.ScrollOffset;
-        Assert.True(scrollAfterEnters > 20, $"Should have scrolled down, at {scrollAfterEnters}");
+        Assert.IsTrue(scrollAfterEnters > 20, $"Should have scrolled down, at {scrollAfterEnters}");
 
         // Now scroll up via ScrollOffset (simulates wheel/scrollbar)
         node.ScrollOffset = 1;
         node.Arrange(new Rect(0, 0, 30, 10));
-        Assert.Equal(1, node.ScrollOffset);
+        Assert.AreEqual(1, node.ScrollOffset);
 
         // Re-arrange again — must NOT flick back
         node.Arrange(new Rect(0, 0, 30, 10));
-        Assert.Equal(1, node.ScrollOffset);
+        Assert.AreEqual(1, node.ScrollOffset);
 
         // Third arrange — still stable
         node.Arrange(new Rect(0, 0, 30, 10));
-        Assert.Equal(1, node.ScrollOffset);
+        Assert.AreEqual(1, node.ScrollOffset);
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 6: Mouse wheel scrolling
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public async Task WheelDown_ScrollsContentDown()
     {
         var text = MakeLines(50);
@@ -538,7 +539,7 @@ public class EditorScrollbarTests
         Assert.DoesNotContain("L001", snapshot.GetLineTrimmed(0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WheelUp_ScrollsContentUp()
     {
         var text = MakeLines(50);
@@ -571,7 +572,7 @@ public class EditorScrollbarTests
     // SECTION 7: Scrollbar click (page jump)
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public async Task VScrollbarClick_BelowThumb_PagesDown()
     {
         var text = MakeLines(100);
@@ -599,7 +600,7 @@ public class EditorScrollbarTests
         Assert.DoesNotContain("L001", snapshot.GetLineTrimmed(0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HScrollbarClick_RightOfThumb_PagesRight()
     {
         var text = MakeWideLines(3, 120); // very wide lines
@@ -632,7 +633,7 @@ public class EditorScrollbarTests
     // SECTION 8: Scrollbar thumb drag
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public async Task VScrollbarDrag_ThumbDown_ScrollsContent()
     {
         var text = MakeLines(100);
@@ -660,7 +661,7 @@ public class EditorScrollbarTests
         Assert.DoesNotContain("L001", snapshot.GetLineTrimmed(0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task VScrollbarDrag_IsStable_DoesNotFlickBack()
     {
         // After dragging the scrollbar thumb, the scroll position must remain stable.
@@ -693,7 +694,7 @@ public class EditorScrollbarTests
         var snapshotAfterWait = terminal.CreateSnapshot();
         var line0AfterWait = snapshotAfterWait.GetLineTrimmed(0);
 
-        Assert.Equal(line0After, line0AfterWait);
+        Assert.AreEqual(line0After, line0AfterWait);
         Assert.DoesNotContain("L001", line0AfterWait);
     }
 
@@ -701,7 +702,7 @@ public class EditorScrollbarTests
     // SECTION 9: Predicted content verification
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public async Task ScrollTo_SpecificLine_ShowsExpectedContent()
     {
         // 50 lines: L001..L050, viewport 30x10. After Ctrl+End, viewport should
@@ -730,12 +731,12 @@ public class EditorScrollbarTests
             seenLines.Add(snapshot.GetLineTrimmed(row));
         }
 
-        Assert.Contains(seenLines, l => l.Contains("L050"));
+        Assert.IsTrue(seenLines.Any(l => l.Contains("L050")));
         // L001 should NOT be visible
-        Assert.DoesNotContain(seenLines, l => l.Contains("L001"));
+        Assert.IsFalse(seenLines.Any(l => l.Contains("L001")));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PageDown_ThenPageUp_ReturnsToOriginalContent()
     {
         var text = MakeLines(50);
@@ -775,7 +776,7 @@ public class EditorScrollbarTests
     // SECTION 10: Horizontal scroll stability
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void HScrollManually_DoesNotFlickBackOnReArrange()
     {
         var node = CreateNode(MakeWideLines(5, 80), 30, 10);
@@ -783,14 +784,14 @@ public class EditorScrollbarTests
         // Set horizontal scroll
         node.HorizontalScrollOffset = 20;
         node.Arrange(new Rect(0, 0, 30, 10));
-        Assert.Equal(20, node.HorizontalScrollOffset);
+        Assert.AreEqual(20, node.HorizontalScrollOffset);
 
         // Re-arrange — must stay
         node.Arrange(new Rect(0, 0, 30, 10));
-        Assert.Equal(20, node.HorizontalScrollOffset);
+        Assert.AreEqual(20, node.HorizontalScrollOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorMove_SnapsHorizontalScroll()
     {
         // After horizontal scroll, moving cursor to beginning should snap back.
@@ -800,12 +801,12 @@ public class EditorScrollbarTests
         node.State.MoveToLineEnd();
         node.NotifyCursorChanged();
         node.Arrange(new Rect(0, 0, 30, 10));
-        Assert.True(node.HorizontalScrollOffset > 0, "Should have scrolled right");
+        Assert.IsTrue(node.HorizontalScrollOffset > 0, "Should have scrolled right");
 
         // Now Home (triggers cursor move back to column 0)
         node.State.MoveToLineStart();
         node.NotifyCursorChanged();
         node.Arrange(new Rect(0, 0, 30, 10));
-        Assert.Equal(0, node.HorizontalScrollOffset);
+        Assert.AreEqual(0, node.HorizontalScrollOffset);
     }
 }

--- a/tests/Hex1b.Tests/EditorSelectionRenderingTests.cs
+++ b/tests/Hex1b.Tests/EditorSelectionRenderingTests.cs
@@ -11,6 +11,7 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class EditorSelectionRenderingTests
 {
     private static Hex1bColor? ToCellColor(Hex1bColor color) => color.IsDefault ? null : color;
@@ -53,7 +54,7 @@ public class EditorSelectionRenderingTests
 
     // ── Single-line selection ───────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task Render_SelectionOnSingleLine_HighlightsSelectedCells()
     {
         // NOTE: Selection color may change with theme updates.
@@ -81,47 +82,42 @@ public class EditorSelectionRenderingTests
 
         // 'H' at col 0 should be normal text color
         var hCell = snapshot.GetCell(0, 0);
-        Assert.Equal("H", hCell.Character);
-        Assert.True(ColorEquals(colors.TextFg, hCell.Foreground),
-            $"H fg: expected {colors.TextFg}, got {hCell.Foreground}");
+        Assert.AreEqual("H", hCell.Character);
+        Assert.IsTrue(ColorEquals(colors.TextFg, hCell.Foreground), $"H fg: expected {colors.TextFg}, got {hCell.Foreground}");
 
         // 'e' at col 1 should be selection color (start of selection)
         var eCell = snapshot.GetCell(1, 0);
-        Assert.Equal("e", eCell.Character);
-        Assert.True(ColorEquals(colors.SelectionFg, eCell.Foreground),
-            $"e fg: expected {colors.SelectionFg}, got {eCell.Foreground}");
-        Assert.True(ColorEquals(colors.SelectionBg, eCell.Background),
-            $"e bg: expected {colors.SelectionBg}, got {eCell.Background}");
+        Assert.AreEqual("e", eCell.Character);
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, eCell.Foreground), $"e fg: expected {colors.SelectionFg}, got {eCell.Foreground}");
+        Assert.IsTrue(ColorEquals(colors.SelectionBg, eCell.Background), $"e bg: expected {colors.SelectionBg}, got {eCell.Background}");
 
         // 'l' at col 2 should be selection color
         var lCell = snapshot.GetCell(2, 0);
-        Assert.Equal("l", lCell.Character);
-        Assert.True(ColorEquals(colors.SelectionFg, lCell.Foreground));
-        Assert.True(ColorEquals(colors.SelectionBg, lCell.Background));
+        Assert.AreEqual("l", lCell.Character);
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, lCell.Foreground));
+        Assert.IsTrue(ColorEquals(colors.SelectionBg, lCell.Background));
 
         // 'o' at col 4 should be selection color (last selected char)
         var oCell = snapshot.GetCell(4, 0);
-        Assert.Equal("o", oCell.Character);
-        Assert.True(ColorEquals(colors.SelectionFg, oCell.Foreground));
-        Assert.True(ColorEquals(colors.SelectionBg, oCell.Background));
+        Assert.AreEqual("o", oCell.Character);
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, oCell.Foreground));
+        Assert.IsTrue(ColorEquals(colors.SelectionBg, oCell.Background));
 
         // ' ' at col 5 should be cursor (cursor position is at end of selection)
         var spaceCell = snapshot.GetCell(5, 0);
-        Assert.True(ColorEquals(colors.CursorFg, spaceCell.Foreground),
-            $"cursor fg: expected {colors.CursorFg}, got {spaceCell.Foreground}");
-        Assert.True(ColorEquals(colors.CursorBg, spaceCell.Background),
-            $"cursor bg: expected {colors.CursorBg}, got {spaceCell.Background}");
+        Assert.IsTrue(ColorEquals(colors.CursorFg, spaceCell.Foreground), $"cursor fg: expected {colors.CursorFg}, got {spaceCell.Foreground}");
+        Assert.IsTrue(ColorEquals(colors.CursorBg, spaceCell.Background), $"cursor bg: expected {colors.CursorBg}, got {spaceCell.Background}");
 
         // 'W' at col 6 should be normal
         var wCell = snapshot.GetCell(6, 0);
-        Assert.Equal("W", wCell.Character);
-        Assert.True(ColorEquals(colors.TextFg, wCell.Foreground));
+        Assert.AreEqual("W", wCell.Character);
+        Assert.IsTrue(ColorEquals(colors.TextFg, wCell.Foreground));
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_SelectionReversed_SameHighlighting()
     {
         // NOTE: Reverse selection (anchor after cursor) should highlight the same range.
@@ -147,20 +143,20 @@ public class EditorSelectionRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // 'a' at col 0 should be normal
-        Assert.True(ColorEquals(colors.TextFg, snapshot.GetCell(0, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.TextFg, snapshot.GetCell(0, 0).Foreground));
 
         // Cursor at col 1 — cursor takes priority over selection
-        Assert.True(ColorEquals(colors.CursorFg, snapshot.GetCell(1, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.CursorFg, snapshot.GetCell(1, 0).Foreground));
 
         // 'c' at col 2 should be selection
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(2, 0).Foreground));
-        Assert.True(ColorEquals(colors.SelectionBg, snapshot.GetCell(2, 0).Background));
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(2, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.SelectionBg, snapshot.GetCell(2, 0).Background));
 
         // 'd' at col 3 should be selection
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(3, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(3, 0).Foreground));
 
         // 'e' at col 4 should be normal (selection end is exclusive)
-        Assert.True(ColorEquals(colors.TextFg, snapshot.GetCell(4, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.TextFg, snapshot.GetCell(4, 0).Foreground));
 
         workload.Dispose();
         terminal.Dispose();
@@ -168,7 +164,7 @@ public class EditorSelectionRenderingTests
 
     // ── Multi-line selection ────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task Render_MultiLineSelection_HighlightsAcrossLines()
     {
         // NOTE: Multi-line selection colors the end of line 1 and start of line 2.
@@ -201,19 +197,19 @@ public class EditorSelectionRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // Line 1 (row 0): "abc" — 'a' normal, 'b','c' selected
-        Assert.True(ColorEquals(colors.TextFg, snapshot.GetCell(0, 0).Foreground)); // 'a' normal
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(1, 0).Foreground)); // 'b' selected
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(2, 0).Foreground)); // 'c' selected
+        Assert.IsTrue(ColorEquals(colors.TextFg, snapshot.GetCell(0, 0).Foreground)); // 'a' normal
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(1, 0).Foreground)); // 'b' selected
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(2, 0).Foreground)); // 'c' selected
 
         // Line 2 (row 1): "def" — 'd' selected, cursor at 'e' (offset 5 = line 2 col 2)
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(0, 1).Foreground)); // 'd' selected
-        Assert.True(ColorEquals(colors.CursorFg, snapshot.GetCell(1, 1).Foreground)); // 'e' = cursor
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(0, 1).Foreground)); // 'd' selected
+        Assert.IsTrue(ColorEquals(colors.CursorFg, snapshot.GetCell(1, 1).Foreground)); // 'e' = cursor
 
         // 'f' at col 2 should be normal
-        Assert.True(ColorEquals(colors.TextFg, snapshot.GetCell(2, 1).Foreground)); // 'f' normal
+        Assert.IsTrue(ColorEquals(colors.TextFg, snapshot.GetCell(2, 1).Foreground)); // 'f' normal
 
         // Line 3 (row 2): "ghi" — all normal
-        Assert.True(ColorEquals(colors.TextFg, snapshot.GetCell(0, 2).Foreground)); // 'g' normal
+        Assert.IsTrue(ColorEquals(colors.TextFg, snapshot.GetCell(0, 2).Foreground)); // 'g' normal
 
         workload.Dispose();
         terminal.Dispose();
@@ -221,7 +217,7 @@ public class EditorSelectionRenderingTests
 
     // ── No selection when unfocused ─────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Unfocused_NoSelectionHighlighting()
     {
         // NOTE: Unfocused editors should not show selection or cursor highlighting.
@@ -245,8 +241,7 @@ public class EditorSelectionRenderingTests
         // All cells should be normal text color — no selection, no cursor
         for (var col = 0; col < 5; col++)
         {
-            Assert.True(ColorEquals(colors.TextFg, snapshot.GetCell(col, 0).Foreground),
-                $"Col {col}: expected normal fg, got {snapshot.GetCell(col, 0).Foreground}");
+            Assert.IsTrue(ColorEquals(colors.TextFg, snapshot.GetCell(col, 0).Foreground), $"Col {col}: expected normal fg, got {snapshot.GetCell(col, 0).Foreground}");
         }
 
         workload.Dispose();
@@ -255,7 +250,7 @@ public class EditorSelectionRenderingTests
 
     // ── SelectAll rendering ─────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task Render_SelectAll_HighlightsEntireDocument()
     {
         // NOTE: SelectAll should highlight all text, cursor at end.
@@ -279,12 +274,12 @@ public class EditorSelectionRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // All 3 chars selected
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(0, 0).Foreground)); // 'a'
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(1, 0).Foreground)); // 'b'
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(2, 0).Foreground)); // 'c'
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(0, 0).Foreground)); // 'a'
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(1, 0).Foreground)); // 'b'
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(2, 0).Foreground)); // 'c'
 
         // Cursor at col 3 (after text)
-        Assert.True(ColorEquals(colors.CursorFg, snapshot.GetCell(3, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.CursorFg, snapshot.GetCell(3, 0).Foreground));
 
         workload.Dispose();
         terminal.Dispose();
@@ -292,7 +287,7 @@ public class EditorSelectionRenderingTests
 
     // ── Multi-cursor selection ──────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task Render_MultiCursorWithSelection_HighlightsBothSelections()
     {
         // NOTE: Multiple cursors each with their own selection should all render.
@@ -321,24 +316,24 @@ public class EditorSelectionRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // "aaa" selected (cols 0,1,2)
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(0, 0).Foreground));
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(1, 0).Foreground));
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(2, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(0, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(1, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(2, 0).Foreground));
 
         // Cursor at col 3 (end of "aaa")
-        Assert.True(ColorEquals(colors.CursorFg, snapshot.GetCell(3, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.CursorFg, snapshot.GetCell(3, 0).Foreground));
 
         // " bbb " normal (cols 4..7)
-        Assert.True(ColorEquals(colors.TextFg, snapshot.GetCell(4, 0).Foreground));
-        Assert.True(ColorEquals(colors.TextFg, snapshot.GetCell(5, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.TextFg, snapshot.GetCell(4, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.TextFg, snapshot.GetCell(5, 0).Foreground));
 
         // "ccc" selected (cols 8,9,10)
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(8, 0).Foreground));
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(9, 0).Foreground));
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(10, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(8, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(9, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(10, 0).Foreground));
 
         // Cursor at col 11 (end of "ccc")
-        Assert.True(ColorEquals(colors.CursorFg, snapshot.GetCell(11, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.CursorFg, snapshot.GetCell(11, 0).Foreground));
 
         workload.Dispose();
         terminal.Dispose();
@@ -346,7 +341,7 @@ public class EditorSelectionRenderingTests
 
     // ── Cursor overrides selection ──────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task Render_CursorInsideSelection_CursorTakesPriority()
     {
         // NOTE: When cursor is within a selected range, cursor color should win.
@@ -372,21 +367,21 @@ public class EditorSelectionRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // 'a' at col 0 — normal
-        Assert.True(ColorEquals(colors.TextFg, snapshot.GetCell(0, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.TextFg, snapshot.GetCell(0, 0).Foreground));
 
         // 'b' at col 1 — normal
-        Assert.True(ColorEquals(colors.TextFg, snapshot.GetCell(1, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.TextFg, snapshot.GetCell(1, 0).Foreground));
 
         // 'c' at col 2 — cursor (overrides selection)
-        Assert.True(ColorEquals(colors.CursorFg, snapshot.GetCell(2, 0).Foreground));
-        Assert.True(ColorEquals(colors.CursorBg, snapshot.GetCell(2, 0).Background));
+        Assert.IsTrue(ColorEquals(colors.CursorFg, snapshot.GetCell(2, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.CursorBg, snapshot.GetCell(2, 0).Background));
 
         // 'd' at col 3 — selection
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(3, 0).Foreground));
-        Assert.True(ColorEquals(colors.SelectionBg, snapshot.GetCell(3, 0).Background));
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(3, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.SelectionBg, snapshot.GetCell(3, 0).Background));
 
         // 'e' at col 4 — selection
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(4, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(4, 0).Foreground));
 
         workload.Dispose();
         terminal.Dispose();
@@ -394,7 +389,7 @@ public class EditorSelectionRenderingTests
 
     // ── Empty selection (no highlight) ──────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task Render_NoSelection_NoHighlighting()
     {
         // NOTE: Without any selection, only cursor should be highlighted.
@@ -419,15 +414,15 @@ public class EditorSelectionRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // 'H' and 'e' normal
-        Assert.True(ColorEquals(colors.TextFg, snapshot.GetCell(0, 0).Foreground));
-        Assert.True(ColorEquals(colors.TextFg, snapshot.GetCell(1, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.TextFg, snapshot.GetCell(0, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.TextFg, snapshot.GetCell(1, 0).Foreground));
 
         // 'l' at col 2 — cursor
-        Assert.True(ColorEquals(colors.CursorFg, snapshot.GetCell(2, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.CursorFg, snapshot.GetCell(2, 0).Foreground));
 
         // 'l' at col 3, 'o' at col 4 — normal
-        Assert.True(ColorEquals(colors.TextFg, snapshot.GetCell(3, 0).Foreground));
-        Assert.True(ColorEquals(colors.TextFg, snapshot.GetCell(4, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.TextFg, snapshot.GetCell(3, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.TextFg, snapshot.GetCell(4, 0).Foreground));
 
         workload.Dispose();
         terminal.Dispose();
@@ -435,7 +430,7 @@ public class EditorSelectionRenderingTests
 
     // ── Selection on padded area ────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task Render_SelectionDoesNotExtendBeyondText()
     {
         // NOTE: Selection should not highlight the padding area beyond actual text.
@@ -460,15 +455,15 @@ public class EditorSelectionRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // 'a' and 'b' selected (cols 0,1)
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(0, 0).Foreground));
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(1, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(0, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(1, 0).Foreground));
 
         // Cursor at col 2
-        Assert.True(ColorEquals(colors.CursorFg, snapshot.GetCell(2, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.CursorFg, snapshot.GetCell(2, 0).Foreground));
 
         // Padding beyond text (col 3+) should be normal
-        Assert.True(ColorEquals(colors.TextFg, snapshot.GetCell(3, 0).Foreground));
-        Assert.True(ColorEquals(colors.TextFg, snapshot.GetCell(4, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.TextFg, snapshot.GetCell(3, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.TextFg, snapshot.GetCell(4, 0).Foreground));
 
         workload.Dispose();
         terminal.Dispose();
@@ -476,7 +471,7 @@ public class EditorSelectionRenderingTests
 
     // ── Shift+Right integration test ────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_ShiftRight_CreatesVisibleSelection()
     {
         // NOTE: This integration test verifies that Shift+Right through the app
@@ -527,15 +522,15 @@ public class EditorSelectionRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // 'H','e','l' should be selected (cols 0,1,2)
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(0, 0).Foreground));
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(1, 0).Foreground));
-        Assert.True(ColorEquals(colors.SelectionFg, snapshot.GetCell(2, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(0, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(1, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.SelectionFg, snapshot.GetCell(2, 0).Foreground));
 
         // Cursor at col 3 ('l')
-        Assert.True(ColorEquals(colors.CursorFg, snapshot.GetCell(3, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.CursorFg, snapshot.GetCell(3, 0).Foreground));
 
         // 'o' at col 4 should be normal
-        Assert.True(ColorEquals(colors.TextFg, snapshot.GetCell(4, 0).Foreground));
+        Assert.IsTrue(ColorEquals(colors.TextFg, snapshot.GetCell(4, 0).Foreground));
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -545,7 +540,7 @@ public class EditorSelectionRenderingTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SelectAll_WithTextBeyondViewport_DoesNotCrash()
     {
         // Regression: selecting text longer than the viewport caused IndexOutOfRangeException
@@ -576,15 +571,13 @@ public class EditorSelectionRenderingTests
         for (int col = 0; col < 20; col++)
         {
             var cell = snapshot.GetCell(col, 0);
-            Assert.True(
-                ColorEquals(colors.SelectionBg, cell.Background) || ColorEquals(colors.CursorBg, cell.Background),
-                $"Cell ({col},0) should be selected or cursor, got bg={cell.Background}");
+            Assert.IsTrue(ColorEquals(colors.SelectionBg, cell.Background) || ColorEquals(colors.CursorBg, cell.Background), $"Cell ({col},0) should be selected or cursor, got bg={cell.Background}");
         }
     }
 
     // ── Multi-line selection does NOT highlight past end-of-line ──
 
-    [Fact]
+    [TestMethod]
     public async Task Render_MultiLineSelectAll_DoesNotHighlightPastEndOfLine()
     {
         // "Hi\nBye" — select all, verify padding past line content is NOT highlighted.
@@ -607,28 +600,26 @@ public class EditorSelectionRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // Row 0 "Hi\n": cols 0,1 = content selected, cols 2+ = NOT highlighted (no newline indicator)
-        Assert.True(ColorEquals(colors.SelectionBg, snapshot.GetCell(0, 0).Background), "Row 0 col 0 'H' should be selected");
-        Assert.True(ColorEquals(colors.SelectionBg, snapshot.GetCell(1, 0).Background), "Row 0 col 1 'i' should be selected");
+        Assert.IsTrue(ColorEquals(colors.SelectionBg, snapshot.GetCell(0, 0).Background), "Row 0 col 0 'H' should be selected");
+        Assert.IsTrue(ColorEquals(colors.SelectionBg, snapshot.GetCell(1, 0).Background), "Row 0 col 1 'i' should be selected");
         for (int col = 2; col < 20; col++)
         {
             var cell = snapshot.GetCell(col, 0);
-            Assert.False(ColorEquals(colors.SelectionBg, cell.Background),
-                $"Row 0 col {col} should NOT have selection bg (past 'Hi\\n')");
+            Assert.IsFalse(ColorEquals(colors.SelectionBg, cell.Background), $"Row 0 col {col} should NOT have selection bg (past 'Hi\\n')");
         }
 
         // Row 1 "Bye": cursor is at end of doc (col 3), cols 4+ MUST NOT be selected
         for (int col = 4; col < 20; col++)
         {
             var cell = snapshot.GetCell(col, 1);
-            Assert.False(ColorEquals(colors.SelectionBg, cell.Background),
-                $"Row 1 col {col} should NOT have selection bg (past 'Bye')");
+            Assert.IsFalse(ColorEquals(colors.SelectionBg, cell.Background), $"Row 1 col {col} should NOT have selection bg (past 'Bye')");
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_MultiLineVaryingLengths_NoExcessHighlight()
     {
         // "AB\nC\nDEFG" — select from start through "C\n" (offset 0 to 5)
@@ -654,34 +645,31 @@ public class EditorSelectionRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // Row 0 "AB": cols 0,1 selected, cols 2+ NOT selected
-        Assert.True(ColorEquals(colors.SelectionBg, snapshot.GetCell(0, 0).Background), "Row 0 col 0");
-        Assert.True(ColorEquals(colors.SelectionBg, snapshot.GetCell(1, 0).Background), "Row 0 col 1");
+        Assert.IsTrue(ColorEquals(colors.SelectionBg, snapshot.GetCell(0, 0).Background), "Row 0 col 0");
+        Assert.IsTrue(ColorEquals(colors.SelectionBg, snapshot.GetCell(1, 0).Background), "Row 0 col 1");
         for (int col = 2; col < 20; col++)
         {
-            Assert.False(ColorEquals(colors.SelectionBg, snapshot.GetCell(col, 0).Background),
-                $"Row 0 col {col} should NOT be selected (past 'AB\\n')");
+            Assert.IsFalse(ColorEquals(colors.SelectionBg, snapshot.GetCell(col, 0).Background), $"Row 0 col {col} should NOT be selected (past 'AB\\n')");
         }
 
         // Row 1 "C": col 0 selected, cols 1+ NOT selected
-        Assert.True(ColorEquals(colors.SelectionBg, snapshot.GetCell(0, 1).Background), "Row 1 col 0");
+        Assert.IsTrue(ColorEquals(colors.SelectionBg, snapshot.GetCell(0, 1).Background), "Row 1 col 0");
         for (int col = 1; col < 20; col++)
         {
-            Assert.False(ColorEquals(colors.SelectionBg, snapshot.GetCell(col, 1).Background),
-                $"Row 1 col {col} should NOT be selected (past 'C\\n')");
+            Assert.IsFalse(ColorEquals(colors.SelectionBg, snapshot.GetCell(col, 1).Background), $"Row 1 col {col} should NOT be selected (past 'C\\n')");
         }
 
         // Row 2 "DEFG": cursor at col 0, rest NOT selected
         for (int col = 1; col < 20; col++)
         {
-            Assert.False(ColorEquals(colors.SelectionBg, snapshot.GetCell(col, 2).Background),
-                $"Row 2 col {col} should NOT be selected (unselected line)");
+            Assert.IsFalse(ColorEquals(colors.SelectionBg, snapshot.GetCell(col, 2).Background), $"Row 2 col {col} should NOT be selected (unselected line)");
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_EmptyLineInSelection_OnlyHighlightsNewline()
     {
         // "A\n\nB" — empty middle line
@@ -704,32 +692,29 @@ public class EditorSelectionRenderingTests
         var snapshot = terminal.CreateSnapshot();
 
         // Row 0 "A": col 0 selected, cols 1+ NOT selected
-        Assert.True(ColorEquals(colors.SelectionBg, snapshot.GetCell(0, 0).Background), "Row 0 col 0 'A'");
+        Assert.IsTrue(ColorEquals(colors.SelectionBg, snapshot.GetCell(0, 0).Background), "Row 0 col 0 'A'");
         for (int col = 1; col < 15; col++)
         {
-            Assert.False(ColorEquals(colors.SelectionBg, snapshot.GetCell(col, 0).Background),
-                $"Row 0 col {col} should NOT be selected");
+            Assert.IsFalse(ColorEquals(colors.SelectionBg, snapshot.GetCell(col, 0).Background), $"Row 0 col {col} should NOT be selected");
         }
 
         // Row 1 "": empty line — no content, cols 0+ NOT selected
         for (int col = 0; col < 15; col++)
         {
-            Assert.False(ColorEquals(colors.SelectionBg, snapshot.GetCell(col, 1).Background),
-                $"Row 1 col {col} should NOT be selected (empty line)");
+            Assert.IsFalse(ColorEquals(colors.SelectionBg, snapshot.GetCell(col, 1).Background), $"Row 1 col {col} should NOT be selected (empty line)");
         }
 
         // Row 2 "B": cols 1+ NOT selected
         for (int col = 2; col < 15; col++)
         {
-            Assert.False(ColorEquals(colors.SelectionBg, snapshot.GetCell(col, 2).Background),
-                $"Row 2 col {col} should NOT be selected");
+            Assert.IsFalse(ColorEquals(colors.SelectionBg, snapshot.GetCell(col, 2).Background), $"Row 2 col {col} should NOT be selected");
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectAll_ThenDelete_DoesNotCrashOnArrange()
     {
         // Regression: after Ctrl+A then Delete, cursor position could exceed document length,

--- a/tests/Hex1b.Tests/EditorStateEditingTests.cs
+++ b/tests/Hex1b.Tests/EditorStateEditingTests.cs
@@ -6,11 +6,12 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for EditorState word-level and line-level deletion operations.
 /// </summary>
+[TestClass]
 public class EditorStateEditingTests
 {
     // ── DeleteWordBackward ──────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void DeleteWordBackward_DeletesWord()
     {
         var doc = new Hex1bDocument("Hello World");
@@ -20,11 +21,11 @@ public class EditorStateEditingTests
         state.DeleteWordBackward();
 
         // Should delete "World" (word boundary from end)
-        Assert.Equal(new DocumentOffset(6), state.Cursor.Position);
-        Assert.Equal("Hello ", doc.GetText());
+        Assert.AreEqual(new DocumentOffset(6), state.Cursor.Position);
+        Assert.AreEqual("Hello ", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteWordBackward_AtDocumentStart_NoOp()
     {
         var doc = new Hex1bDocument("Hello");
@@ -33,10 +34,10 @@ public class EditorStateEditingTests
 
         state.DeleteWordBackward();
 
-        Assert.Equal("Hello", doc.GetText());
+        Assert.AreEqual("Hello", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteWordBackward_ReadOnly_NoOp()
     {
         var doc = new Hex1bDocument("Hello World");
@@ -45,10 +46,10 @@ public class EditorStateEditingTests
 
         state.DeleteWordBackward();
 
-        Assert.Equal("Hello World", doc.GetText());
+        Assert.AreEqual("Hello World", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteWordBackward_WithSelection_DeletesSelection()
     {
         var doc = new Hex1bDocument("Hello World");
@@ -58,11 +59,11 @@ public class EditorStateEditingTests
 
         state.DeleteWordBackward();
 
-        Assert.Equal("Hello ", doc.GetText());
-        Assert.False(state.Cursor.HasSelection);
+        Assert.AreEqual("Hello ", doc.GetText());
+        Assert.IsFalse(state.Cursor.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteWordBackward_MiddleOfWord_DeletesPartialWord()
     {
         var doc = new Hex1bDocument("Hello World");
@@ -78,7 +79,7 @@ public class EditorStateEditingTests
 
     // ── DeleteWordForward ───────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void DeleteWordForward_DeletesWord()
     {
         var doc = new Hex1bDocument("Hello World");
@@ -88,11 +89,11 @@ public class EditorStateEditingTests
         state.DeleteWordForward();
 
         // Deletes "Hello " (word + trailing space per word boundary behavior)
-        Assert.Equal(DocumentOffset.Zero, state.Cursor.Position);
-        Assert.Equal("World", doc.GetText());
+        Assert.AreEqual(DocumentOffset.Zero, state.Cursor.Position);
+        Assert.AreEqual("World", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteWordForward_AtDocumentEnd_NoOp()
     {
         var doc = new Hex1bDocument("Hello");
@@ -101,10 +102,10 @@ public class EditorStateEditingTests
 
         state.DeleteWordForward();
 
-        Assert.Equal("Hello", doc.GetText());
+        Assert.AreEqual("Hello", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteWordForward_ReadOnly_NoOp()
     {
         var doc = new Hex1bDocument("Hello World");
@@ -113,10 +114,10 @@ public class EditorStateEditingTests
 
         state.DeleteWordForward();
 
-        Assert.Equal("Hello World", doc.GetText());
+        Assert.AreEqual("Hello World", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteWordForward_WithSelection_DeletesSelection()
     {
         var doc = new Hex1bDocument("Hello World");
@@ -126,13 +127,13 @@ public class EditorStateEditingTests
 
         state.DeleteWordForward();
 
-        Assert.Equal(" World", doc.GetText());
-        Assert.False(state.Cursor.HasSelection);
+        Assert.AreEqual(" World", doc.GetText());
+        Assert.IsFalse(state.Cursor.HasSelection);
     }
 
     // ── DeleteLine ──────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void DeleteLine_DeletesCurrentLine()
     {
         var doc = new Hex1bDocument("Line 1\nLine 2\nLine 3");
@@ -142,11 +143,11 @@ public class EditorStateEditingTests
 
         state.DeleteLine();
 
-        Assert.Equal("Line 1\nLine 3", doc.GetText());
-        Assert.Equal(2, doc.LineCount);
+        Assert.AreEqual("Line 1\nLine 3", doc.GetText());
+        Assert.AreEqual(2, doc.LineCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteLine_FirstLine_DeletesFirstLine()
     {
         var doc = new Hex1bDocument("Line 1\nLine 2\nLine 3");
@@ -155,10 +156,10 @@ public class EditorStateEditingTests
 
         state.DeleteLine();
 
-        Assert.Equal("Line 2\nLine 3", doc.GetText());
+        Assert.AreEqual("Line 2\nLine 3", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteLine_LastLine_DeletesLastLine()
     {
         var doc = new Hex1bDocument("Line 1\nLine 2\nLine 3");
@@ -167,10 +168,10 @@ public class EditorStateEditingTests
 
         state.DeleteLine();
 
-        Assert.Equal("Line 1\nLine 2", doc.GetText());
+        Assert.AreEqual("Line 1\nLine 2", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteLine_OnlyLine_EmptiesDocument()
     {
         var doc = new Hex1bDocument("Hello");
@@ -179,11 +180,11 @@ public class EditorStateEditingTests
 
         state.DeleteLine();
 
-        Assert.Equal("", doc.GetText());
-        Assert.Equal(0, doc.Length);
+        Assert.AreEqual("", doc.GetText());
+        Assert.AreEqual(0, doc.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteLine_ReadOnly_NoOp()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -192,10 +193,10 @@ public class EditorStateEditingTests
 
         state.DeleteLine();
 
-        Assert.Equal("Hello\nWorld", doc.GetText());
+        Assert.AreEqual("Hello\nWorld", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteLine_ClearsSelection()
     {
         var doc = new Hex1bDocument("Line 1\nLine 2\nLine 3");
@@ -205,23 +206,23 @@ public class EditorStateEditingTests
 
         state.DeleteLine();
 
-        Assert.False(state.Cursor.HasSelection);
+        Assert.IsFalse(state.Cursor.HasSelection);
     }
 
     // ── EnsureSelectionAnchor (DocumentCursor) ──────────────────
 
-    [Fact]
+    [TestMethod]
     public void EnsureSelectionAnchor_SetsAnchorIfNull()
     {
         var cursor = new DocumentCursor { Position = new DocumentOffset(5) };
-        Assert.Null(cursor.SelectionAnchor);
+        Assert.IsNull(cursor.SelectionAnchor);
 
         cursor.EnsureSelectionAnchor();
 
-        Assert.Equal(new DocumentOffset(5), cursor.SelectionAnchor);
+        Assert.AreEqual(new DocumentOffset(5), cursor.SelectionAnchor);
     }
 
-    [Fact]
+    [TestMethod]
     public void EnsureSelectionAnchor_DoesNotOverwriteExisting()
     {
         var cursor = new DocumentCursor
@@ -232,6 +233,6 @@ public class EditorStateEditingTests
 
         cursor.EnsureSelectionAnchor();
 
-        Assert.Equal(new DocumentOffset(3), cursor.SelectionAnchor); // unchanged
+        Assert.AreEqual(new DocumentOffset(3), cursor.SelectionAnchor); // unchanged
     }
 }

--- a/tests/Hex1b.Tests/EditorStateMultiCursorTests.cs
+++ b/tests/Hex1b.Tests/EditorStateMultiCursorTests.cs
@@ -8,6 +8,7 @@ namespace Hex1b.Tests;
 /// NOTE: Multi-cursor behavior may change as the editor evolves; these tests document
 /// the current expected behavior for insert, delete, movement, and merge operations.
 /// </summary>
+[TestClass]
 public class EditorStateMultiCursorTests
 {
     private static EditorState CreateState(string text)
@@ -17,7 +18,7 @@ public class EditorStateMultiCursorTests
 
     // ── Multi-cursor insert ─────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void InsertText_MultiCursor_InsertsAtAllPositions()
     {
         var state = CreateState("aaabbb");
@@ -28,10 +29,10 @@ public class EditorStateMultiCursorTests
 
         // After reverse-order insert: cursor at 3 inserts first -> "aaaXbbb"
         // Then cursor at 0 inserts -> "XaaaXbbb"
-        Assert.Equal("XaaaXbbb", state.Document.GetText());
+        Assert.AreEqual("XaaaXbbb", state.Document.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertText_MultiCursor_CursorsAdvancePastInsertedText()
     {
         var state = CreateState("ab");
@@ -41,12 +42,12 @@ public class EditorStateMultiCursorTests
         state.InsertText("X");
 
         // "XaXb", cursors at 1 and 3
-        Assert.Equal("XaXb", state.Document.GetText());
-        Assert.Equal(1, state.Cursors[0].Position.Value);
-        Assert.Equal(3, state.Cursors[1].Position.Value);
+        Assert.AreEqual("XaXb", state.Document.GetText());
+        Assert.AreEqual(1, state.Cursors[0].Position.Value);
+        Assert.AreEqual(3, state.Cursors[1].Position.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertText_MultiCursor_MergesOverlapping()
     {
         var state = CreateState("");
@@ -61,7 +62,7 @@ public class EditorStateMultiCursorTests
 
     // ── Multi-cursor delete ─────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void DeleteBackward_MultiCursor_DeletesAtAllPositions()
     {
         var state = CreateState("XaXb");
@@ -70,10 +71,10 @@ public class EditorStateMultiCursorTests
 
         state.DeleteBackward();
 
-        Assert.Equal("ab", state.Document.GetText());
+        Assert.AreEqual("ab", state.Document.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteForward_MultiCursor_DeletesAtAllPositions()
     {
         var state = CreateState("aXbX");
@@ -82,12 +83,12 @@ public class EditorStateMultiCursorTests
 
         state.DeleteForward();
 
-        Assert.Equal("ab", state.Document.GetText());
+        Assert.AreEqual("ab", state.Document.GetText());
     }
 
     // ── Multi-cursor navigation ─────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_MultiCursor_MovesAll()
     {
         var state = CreateState("Hello\nWorld");
@@ -96,11 +97,11 @@ public class EditorStateMultiCursorTests
 
         state.MoveCursor(CursorDirection.Right);
 
-        Assert.Equal(1, state.Cursors[0].Position.Value);
-        Assert.Equal(7, state.Cursors[1].Position.Value);
+        Assert.AreEqual(1, state.Cursors[0].Position.Value);
+        Assert.AreEqual(7, state.Cursors[1].Position.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveToLineEnd_MultiCursor_MovesAll()
     {
         var state = CreateState("abc\ndef");
@@ -109,11 +110,11 @@ public class EditorStateMultiCursorTests
 
         state.MoveToLineEnd();
 
-        Assert.Equal(3, state.Cursors[0].Position.Value); // End of "abc"
-        Assert.Equal(7, state.Cursors[1].Position.Value); // End of "def"
+        Assert.AreEqual(3, state.Cursors[0].Position.Value); // End of "abc"
+        Assert.AreEqual(7, state.Cursors[1].Position.Value); // End of "def"
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveToDocumentStart_MultiCursor_MergesAll()
     {
         var state = CreateState("Hello\nWorld");
@@ -123,11 +124,11 @@ public class EditorStateMultiCursorTests
         state.MoveToDocumentStart();
 
         // Both cursors move to offset 0 — should merge to 1
-        Assert.Single(state.Cursors);
-        Assert.Equal(0, state.Cursor.Position.Value);
+        TestSeq.Single(state.Cursors);
+        Assert.AreEqual(0, state.Cursor.Position.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveToDocumentEnd_MultiCursor_MergesAll()
     {
         var state = CreateState("Hello\nWorld");
@@ -136,13 +137,13 @@ public class EditorStateMultiCursorTests
 
         state.MoveToDocumentEnd();
 
-        Assert.Single(state.Cursors);
-        Assert.Equal(11, state.Cursor.Position.Value);
+        TestSeq.Single(state.Cursors);
+        Assert.AreEqual(11, state.Cursor.Position.Value);
     }
 
     // ── Multi-cursor selection extend ───────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Extend_MultiCursor_ExtendsAll()
     {
         var state = CreateState("abcdef");
@@ -151,18 +152,18 @@ public class EditorStateMultiCursorTests
 
         state.MoveCursor(CursorDirection.Right, extend: true);
 
-        Assert.Equal(2, state.Cursors[0].Position.Value);
-        Assert.True(state.Cursors[0].HasSelection);
-        Assert.Equal(1, state.Cursors[0].SelectionAnchor!.Value.Value);
+        Assert.AreEqual(2, state.Cursors[0].Position.Value);
+        Assert.IsTrue(state.Cursors[0].HasSelection);
+        Assert.AreEqual(1, state.Cursors[0].SelectionAnchor!.Value.Value);
 
-        Assert.Equal(5, state.Cursors[1].Position.Value);
-        Assert.True(state.Cursors[1].HasSelection);
-        Assert.Equal(4, state.Cursors[1].SelectionAnchor!.Value.Value);
+        Assert.AreEqual(5, state.Cursors[1].Position.Value);
+        Assert.IsTrue(state.Cursors[1].HasSelection);
+        Assert.AreEqual(4, state.Cursors[1].SelectionAnchor!.Value.Value);
     }
 
     // ── AddCursorAtNextMatch ────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void AddCursorAtNextMatch_SelectsWordUnderCursor_IfNoSelection()
     {
         var state = CreateState("hello world hello");
@@ -171,10 +172,10 @@ public class EditorStateMultiCursorTests
         state.AddCursorAtNextMatch();
 
         // First call selects "hello" under cursor, then finds next "hello"
-        Assert.Equal(2, state.Cursors.Count);
+        Assert.AreEqual(2, state.Cursors.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void AddCursorAtNextMatch_FindsNextOccurrence()
     {
         var state = CreateState("abc def abc ghi abc");
@@ -184,15 +185,15 @@ public class EditorStateMultiCursorTests
 
         state.AddCursorAtNextMatch();
 
-        Assert.Equal(2, state.Cursors.Count);
+        Assert.AreEqual(2, state.Cursors.Count);
         // Second cursor should select the second "abc" at positions 8..11
         var second = state.Cursors[1];
-        Assert.True(second.HasSelection);
-        Assert.Equal(8, second.SelectionStart.Value);
-        Assert.Equal(11, second.SelectionEnd.Value);
+        Assert.IsTrue(second.HasSelection);
+        Assert.AreEqual(8, second.SelectionStart.Value);
+        Assert.AreEqual(11, second.SelectionEnd.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void AddCursorAtNextMatch_WrapsAround()
     {
         var state = CreateState("abc def abc");
@@ -203,10 +204,10 @@ public class EditorStateMultiCursorTests
         state.AddCursorAtNextMatch();
 
         // Should wrap around and find the first "abc"
-        Assert.Equal(2, state.Cursors.Count);
+        Assert.AreEqual(2, state.Cursors.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void AddCursorAtNextMatch_NoMatch_DoesNothing()
     {
         var state = CreateState("abc def ghi");
@@ -215,10 +216,10 @@ public class EditorStateMultiCursorTests
 
         state.AddCursorAtNextMatch(); // No more "abc"
 
-        Assert.Single(state.Cursors); // No new cursor added
+        TestSeq.Single(state.Cursors); // No new cursor added
     }
 
-    [Fact]
+    [TestMethod]
     public void AddCursorAtNextMatch_ThreeTimes_ThreeCursors()
     {
         var state = CreateState("ab cd ab ef ab");
@@ -228,12 +229,12 @@ public class EditorStateMultiCursorTests
         state.AddCursorAtNextMatch(); // Finds "ab" at 6
         state.AddCursorAtNextMatch(); // Finds "ab" at 12
 
-        Assert.Equal(3, state.Cursors.Count);
+        Assert.AreEqual(3, state.Cursors.Count);
     }
 
     // ── CollapseToSingleCursor ──────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void CollapseToSingleCursor_KeepsPrimary()
     {
         var state = CreateState("abcdef");
@@ -242,13 +243,13 @@ public class EditorStateMultiCursorTests
 
         state.CollapseToSingleCursor();
 
-        Assert.Single(state.Cursors);
-        Assert.Equal(2, state.Cursor.Position.Value);
+        TestSeq.Single(state.Cursors);
+        Assert.AreEqual(2, state.Cursor.Position.Value);
     }
 
     // ── Multi-cursor word operations ────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void DeleteWordBackward_MultiCursor()
     {
         // "hello world foo bar" with cursors after "hello" and "world"
@@ -262,10 +263,10 @@ public class EditorStateMultiCursorTests
 
         state.DeleteWordBackward();
 
-        Assert.Equal("  foo bar", state.Document.GetText());
+        Assert.AreEqual("  foo bar", state.Document.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteWordForward_MultiCursor()
     {
         // "hello world foo" with cursors before "hello" and before "world"
@@ -278,6 +279,6 @@ public class EditorStateMultiCursorTests
 
         state.DeleteWordForward();
 
-        Assert.Equal("foo", state.Document.GetText());
+        Assert.AreEqual("foo", state.Document.GetText());
     }
 }

--- a/tests/Hex1b.Tests/EditorStateNavigationTests.cs
+++ b/tests/Hex1b.Tests/EditorStateNavigationTests.cs
@@ -6,11 +6,12 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for EditorState navigation and selection operations with the extend pattern.
 /// </summary>
+[TestClass]
 public class EditorStateNavigationTests
 {
     // ── MoveToLineStart / MoveToLineEnd ─────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void MoveToLineStart_MovesToColumnOne()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -19,11 +20,11 @@ public class EditorStateNavigationTests
 
         state.MoveToLineStart();
 
-        Assert.Equal(new DocumentOffset(6), state.Cursor.Position); // start of "World"
-        Assert.False(state.Cursor.HasSelection);
+        Assert.AreEqual(new DocumentOffset(6), state.Cursor.Position); // start of "World"
+        Assert.IsFalse(state.Cursor.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveToLineStart_AlreadyAtStart_NoOp()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -32,10 +33,10 @@ public class EditorStateNavigationTests
 
         state.MoveToLineStart();
 
-        Assert.Equal(new DocumentOffset(6), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(6), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveToLineStart_Extend_CreatesSelection()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -44,12 +45,12 @@ public class EditorStateNavigationTests
 
         state.MoveToLineStart(extend: true);
 
-        Assert.Equal(new DocumentOffset(6), state.Cursor.Position);
-        Assert.True(state.Cursor.HasSelection);
-        Assert.Equal(new DocumentOffset(9), state.Cursor.SelectionAnchor);
+        Assert.AreEqual(new DocumentOffset(6), state.Cursor.Position);
+        Assert.IsTrue(state.Cursor.HasSelection);
+        Assert.AreEqual(new DocumentOffset(9), state.Cursor.SelectionAnchor);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveToLineEnd_MovesToEndOfLine()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -58,11 +59,11 @@ public class EditorStateNavigationTests
 
         state.MoveToLineEnd();
 
-        Assert.Equal(new DocumentOffset(11), state.Cursor.Position); // past "World"
-        Assert.False(state.Cursor.HasSelection);
+        Assert.AreEqual(new DocumentOffset(11), state.Cursor.Position); // past "World"
+        Assert.IsFalse(state.Cursor.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveToLineEnd_FirstLine_StopsBeforeNewline()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -71,10 +72,10 @@ public class EditorStateNavigationTests
 
         state.MoveToLineEnd();
 
-        Assert.Equal(new DocumentOffset(5), state.Cursor.Position); // end of "Hello", before \n
+        Assert.AreEqual(new DocumentOffset(5), state.Cursor.Position); // end of "Hello", before \n
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveToLineEnd_Extend_CreatesSelection()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -83,14 +84,14 @@ public class EditorStateNavigationTests
 
         state.MoveToLineEnd(extend: true);
 
-        Assert.Equal(new DocumentOffset(11), state.Cursor.Position);
-        Assert.True(state.Cursor.HasSelection);
-        Assert.Equal(new DocumentOffset(7), state.Cursor.SelectionAnchor);
+        Assert.AreEqual(new DocumentOffset(11), state.Cursor.Position);
+        Assert.IsTrue(state.Cursor.HasSelection);
+        Assert.AreEqual(new DocumentOffset(7), state.Cursor.SelectionAnchor);
     }
 
     // ── MoveToDocumentStart / MoveToDocumentEnd ─────────────────
 
-    [Fact]
+    [TestMethod]
     public void MoveToDocumentStart_MovesToZero()
     {
         var doc = new Hex1bDocument("Hello\nWorld\nFoo");
@@ -99,11 +100,11 @@ public class EditorStateNavigationTests
 
         state.MoveToDocumentStart();
 
-        Assert.Equal(DocumentOffset.Zero, state.Cursor.Position);
-        Assert.False(state.Cursor.HasSelection);
+        Assert.AreEqual(DocumentOffset.Zero, state.Cursor.Position);
+        Assert.IsFalse(state.Cursor.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveToDocumentEnd_MovesToLength()
     {
         var doc = new Hex1bDocument("Hello\nWorld\nFoo");
@@ -112,10 +113,10 @@ public class EditorStateNavigationTests
 
         state.MoveToDocumentEnd();
 
-        Assert.Equal(new DocumentOffset(15), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(15), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveToDocumentStart_Extend_SelectsAll()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -124,12 +125,12 @@ public class EditorStateNavigationTests
 
         state.MoveToDocumentStart(extend: true);
 
-        Assert.Equal(DocumentOffset.Zero, state.Cursor.Position);
-        Assert.Equal(new DocumentOffset(11), state.Cursor.SelectionAnchor);
-        Assert.True(state.Cursor.HasSelection);
+        Assert.AreEqual(DocumentOffset.Zero, state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(11), state.Cursor.SelectionAnchor);
+        Assert.IsTrue(state.Cursor.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveToDocumentEnd_Extend_SelectsAll()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -138,13 +139,13 @@ public class EditorStateNavigationTests
 
         state.MoveToDocumentEnd(extend: true);
 
-        Assert.Equal(new DocumentOffset(11), state.Cursor.Position);
-        Assert.Equal(DocumentOffset.Zero, state.Cursor.SelectionAnchor);
+        Assert.AreEqual(new DocumentOffset(11), state.Cursor.Position);
+        Assert.AreEqual(DocumentOffset.Zero, state.Cursor.SelectionAnchor);
     }
 
     // ── MoveWordLeft / MoveWordRight ────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void MoveWordLeft_SkipsToWordBoundary()
     {
         var doc = new Hex1bDocument("Hello World");
@@ -154,10 +155,10 @@ public class EditorStateNavigationTests
         state.MoveWordLeft();
 
         // Should land at start of "World" (offset 6)
-        Assert.Equal(new DocumentOffset(6), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(6), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveWordRight_SkipsToWordBoundary()
     {
         var doc = new Hex1bDocument("Hello World");
@@ -167,10 +168,10 @@ public class EditorStateNavigationTests
         state.MoveWordRight();
 
         // Skips remaining "llo" + space → lands at start of "World" (offset 6)
-        Assert.Equal(new DocumentOffset(6), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(6), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveWordLeft_AtDocumentStart_NoOp()
     {
         var doc = new Hex1bDocument("Hello");
@@ -179,10 +180,10 @@ public class EditorStateNavigationTests
 
         state.MoveWordLeft();
 
-        Assert.Equal(DocumentOffset.Zero, state.Cursor.Position);
+        Assert.AreEqual(DocumentOffset.Zero, state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveWordRight_AtDocumentEnd_NoOp()
     {
         var doc = new Hex1bDocument("Hello");
@@ -191,10 +192,10 @@ public class EditorStateNavigationTests
 
         state.MoveWordRight();
 
-        Assert.Equal(new DocumentOffset(5), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(5), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveWordLeft_AtLineStart_MovesToPreviousLine()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -204,10 +205,10 @@ public class EditorStateNavigationTests
         state.MoveWordLeft();
 
         // Should cross the newline to end of previous line
-        Assert.Equal(new DocumentOffset(5), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(5), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveWordRight_AtLineEnd_MovesToNextLine()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -217,10 +218,10 @@ public class EditorStateNavigationTests
         state.MoveWordRight();
 
         // Should cross the newline to start of next line
-        Assert.Equal(new DocumentOffset(6), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(6), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveWordLeft_Extend_CreatesSelection()
     {
         var doc = new Hex1bDocument("Hello World");
@@ -229,11 +230,11 @@ public class EditorStateNavigationTests
 
         state.MoveWordLeft(extend: true);
 
-        Assert.True(state.Cursor.HasSelection);
-        Assert.Equal(new DocumentOffset(11), state.Cursor.SelectionAnchor);
+        Assert.IsTrue(state.Cursor.HasSelection);
+        Assert.AreEqual(new DocumentOffset(11), state.Cursor.SelectionAnchor);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveWordRight_Extend_CreatesSelection()
     {
         var doc = new Hex1bDocument("Hello World");
@@ -242,13 +243,13 @@ public class EditorStateNavigationTests
 
         state.MoveWordRight(extend: true);
 
-        Assert.True(state.Cursor.HasSelection);
-        Assert.Equal(DocumentOffset.Zero, state.Cursor.SelectionAnchor);
+        Assert.IsTrue(state.Cursor.HasSelection);
+        Assert.AreEqual(DocumentOffset.Zero, state.Cursor.SelectionAnchor);
     }
 
     // ── MovePageUp / MovePageDown ───────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void MovePageDown_MovesDownByViewportLines()
     {
         var doc = new Hex1bDocument("L1\nL2\nL3\nL4\nL5\nL6\nL7\nL8\nL9\nL10");
@@ -258,10 +259,10 @@ public class EditorStateNavigationTests
         state.MovePageDown(5); // viewport is 5 lines, move by 4
 
         var pos = doc.OffsetToPosition(state.Cursor.Position);
-        Assert.Equal(5, pos.Line); // moved 4 lines down
+        Assert.AreEqual(5, pos.Line); // moved 4 lines down
     }
 
-    [Fact]
+    [TestMethod]
     public void MovePageUp_MovesUpByViewportLines()
     {
         var doc = new Hex1bDocument("L1\nL2\nL3\nL4\nL5\nL6\nL7\nL8\nL9\nL10");
@@ -272,10 +273,10 @@ public class EditorStateNavigationTests
         state.MovePageUp(5); // viewport is 5 lines, move by 4
 
         var pos = doc.OffsetToPosition(state.Cursor.Position);
-        Assert.Equal(4, pos.Line); // moved 4 lines up
+        Assert.AreEqual(4, pos.Line); // moved 4 lines up
     }
 
-    [Fact]
+    [TestMethod]
     public void MovePageDown_ClampsToLastLine()
     {
         var doc = new Hex1bDocument("L1\nL2\nL3");
@@ -285,10 +286,10 @@ public class EditorStateNavigationTests
         state.MovePageDown(100); // huge viewport
 
         var pos = doc.OffsetToPosition(state.Cursor.Position);
-        Assert.Equal(3, pos.Line); // clamped to last line
+        Assert.AreEqual(3, pos.Line); // clamped to last line
     }
 
-    [Fact]
+    [TestMethod]
     public void MovePageUp_ClampsToFirstLine()
     {
         var doc = new Hex1bDocument("L1\nL2\nL3");
@@ -298,10 +299,10 @@ public class EditorStateNavigationTests
         state.MovePageUp(100);
 
         var pos = doc.OffsetToPosition(state.Cursor.Position);
-        Assert.Equal(1, pos.Line);
+        Assert.AreEqual(1, pos.Line);
     }
 
-    [Fact]
+    [TestMethod]
     public void MovePageDown_Extend_CreatesSelection()
     {
         var doc = new Hex1bDocument("L1\nL2\nL3\nL4\nL5");
@@ -310,13 +311,13 @@ public class EditorStateNavigationTests
 
         state.MovePageDown(3, extend: true);
 
-        Assert.True(state.Cursor.HasSelection);
-        Assert.Equal(DocumentOffset.Zero, state.Cursor.SelectionAnchor);
+        Assert.IsTrue(state.Cursor.HasSelection);
+        Assert.AreEqual(DocumentOffset.Zero, state.Cursor.SelectionAnchor);
     }
 
     // ── SelectAll ───────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void SelectAll_SelectsEntireDocument()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -325,12 +326,12 @@ public class EditorStateNavigationTests
 
         state.SelectAll();
 
-        Assert.Equal(DocumentOffset.Zero, state.Cursor.SelectionAnchor);
-        Assert.Equal(new DocumentOffset(11), state.Cursor.Position);
-        Assert.True(state.Cursor.HasSelection);
+        Assert.AreEqual(DocumentOffset.Zero, state.Cursor.SelectionAnchor);
+        Assert.AreEqual(new DocumentOffset(11), state.Cursor.Position);
+        Assert.IsTrue(state.Cursor.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectAll_EmptyDocument_NoSelection()
     {
         var doc = new Hex1bDocument("");
@@ -339,12 +340,12 @@ public class EditorStateNavigationTests
         state.SelectAll();
 
         // Anchor is 0, position is 0 — HasSelection should be false
-        Assert.False(state.Cursor.HasSelection);
+        Assert.IsFalse(state.Cursor.HasSelection);
     }
 
     // ── MoveCursor with extend ──────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Left_Extend_CreatesSelection()
     {
         var doc = new Hex1bDocument("Hello");
@@ -353,12 +354,12 @@ public class EditorStateNavigationTests
 
         state.MoveCursor(CursorDirection.Left, extend: true);
 
-        Assert.Equal(new DocumentOffset(2), state.Cursor.Position);
-        Assert.Equal(new DocumentOffset(3), state.Cursor.SelectionAnchor);
-        Assert.True(state.Cursor.HasSelection);
+        Assert.AreEqual(new DocumentOffset(2), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(3), state.Cursor.SelectionAnchor);
+        Assert.IsTrue(state.Cursor.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Right_Extend_CreatesSelection()
     {
         var doc = new Hex1bDocument("Hello");
@@ -367,11 +368,11 @@ public class EditorStateNavigationTests
 
         state.MoveCursor(CursorDirection.Right, extend: true);
 
-        Assert.Equal(new DocumentOffset(4), state.Cursor.Position);
-        Assert.Equal(new DocumentOffset(3), state.Cursor.SelectionAnchor);
+        Assert.AreEqual(new DocumentOffset(4), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(3), state.Cursor.SelectionAnchor);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Up_Extend_CreatesSelection()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -380,14 +381,14 @@ public class EditorStateNavigationTests
 
         state.MoveCursor(CursorDirection.Up, extend: true);
 
-        Assert.True(state.Cursor.HasSelection);
-        Assert.Equal(new DocumentOffset(8), state.Cursor.SelectionAnchor);
+        Assert.IsTrue(state.Cursor.HasSelection);
+        Assert.AreEqual(new DocumentOffset(8), state.Cursor.SelectionAnchor);
         // Cursor should be on line 1
         var pos = doc.OffsetToPosition(state.Cursor.Position);
-        Assert.Equal(1, pos.Line);
+        Assert.AreEqual(1, pos.Line);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Down_Extend_CreatesSelection()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -396,13 +397,13 @@ public class EditorStateNavigationTests
 
         state.MoveCursor(CursorDirection.Down, extend: true);
 
-        Assert.True(state.Cursor.HasSelection);
-        Assert.Equal(new DocumentOffset(2), state.Cursor.SelectionAnchor);
+        Assert.IsTrue(state.Cursor.HasSelection);
+        Assert.AreEqual(new DocumentOffset(2), state.Cursor.SelectionAnchor);
         var pos = doc.OffsetToPosition(state.Cursor.Position);
-        Assert.Equal(2, pos.Line);
+        Assert.AreEqual(2, pos.Line);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Left_WithExistingSelection_NoExtend_CollapsesToStart()
     {
         var doc = new Hex1bDocument("Hello");
@@ -412,11 +413,11 @@ public class EditorStateNavigationTests
 
         state.MoveCursor(CursorDirection.Left); // extend: false
 
-        Assert.Equal(new DocumentOffset(1), state.Cursor.Position); // collapsed to selection start
-        Assert.False(state.Cursor.HasSelection);
+        Assert.AreEqual(new DocumentOffset(1), state.Cursor.Position); // collapsed to selection start
+        Assert.IsFalse(state.Cursor.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Right_WithExistingSelection_NoExtend_CollapsesToEnd()
     {
         var doc = new Hex1bDocument("Hello");
@@ -426,13 +427,13 @@ public class EditorStateNavigationTests
 
         state.MoveCursor(CursorDirection.Right); // extend: false
 
-        Assert.Equal(new DocumentOffset(4), state.Cursor.Position); // collapsed to selection end
-        Assert.False(state.Cursor.HasSelection);
+        Assert.AreEqual(new DocumentOffset(4), state.Cursor.Position); // collapsed to selection end
+        Assert.IsFalse(state.Cursor.HasSelection);
     }
 
     // ── Extend chains (multiple extends preserve anchor) ────────
 
-    [Fact]
+    [TestMethod]
     public void MultipleExtends_PreserveOriginalAnchor()
     {
         var doc = new Hex1bDocument("Hello World");
@@ -444,12 +445,12 @@ public class EditorStateNavigationTests
         state.MoveCursor(CursorDirection.Right, extend: true);
         state.MoveCursor(CursorDirection.Right, extend: true);
 
-        Assert.Equal(new DocumentOffset(8), state.Cursor.Position);
-        Assert.Equal(new DocumentOffset(5), state.Cursor.SelectionAnchor); // anchor unchanged
-        Assert.True(state.Cursor.HasSelection);
+        Assert.AreEqual(new DocumentOffset(8), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(5), state.Cursor.SelectionAnchor); // anchor unchanged
+        Assert.IsTrue(state.Cursor.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void Extend_ThenNoExtend_ClearsSelection()
     {
         var doc = new Hex1bDocument("Hello World");
@@ -461,6 +462,6 @@ public class EditorStateNavigationTests
         // Now clear by moving without extend
         state.MoveCursor(CursorDirection.Right);
 
-        Assert.False(state.Cursor.HasSelection);
+        Assert.IsFalse(state.Cursor.HasSelection);
     }
 }

--- a/tests/Hex1b.Tests/EditorStateTests.cs
+++ b/tests/Hex1b.Tests/EditorStateTests.cs
@@ -3,9 +3,10 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class EditorStateTests
 {
-    [Fact]
+    [TestMethod]
     public void InsertText_InsertsAtCursor()
     {
         var doc = new Hex1bDocument("Hello");
@@ -14,11 +15,11 @@ public class EditorStateTests
 
         state.InsertText(" world");
 
-        Assert.Equal("Hello world", doc.GetText());
-        Assert.Equal(new DocumentOffset(11), state.Cursor.Position);
+        Assert.AreEqual("Hello world", doc.GetText());
+        Assert.AreEqual(new DocumentOffset(11), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertText_WhenReadOnly_DoesNothing()
     {
         var doc = new Hex1bDocument("Hello");
@@ -27,10 +28,10 @@ public class EditorStateTests
 
         state.InsertText(" world");
 
-        Assert.Equal("Hello", doc.GetText());
+        Assert.AreEqual("Hello", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertText_WithSelection_ReplacesSelection()
     {
         var doc = new Hex1bDocument("Hello world");
@@ -40,12 +41,12 @@ public class EditorStateTests
 
         state.InsertText("earth");
 
-        Assert.Equal("Hello earth", doc.GetText());
-        Assert.Equal(new DocumentOffset(11), state.Cursor.Position);
-        Assert.False(state.Cursor.HasSelection);
+        Assert.AreEqual("Hello earth", doc.GetText());
+        Assert.AreEqual(new DocumentOffset(11), state.Cursor.Position);
+        Assert.IsFalse(state.Cursor.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertText_EmptyString_DoesNotChangeDocument()
     {
         var doc = new Hex1bDocument("Hello");
@@ -55,11 +56,11 @@ public class EditorStateTests
 
         state.InsertText("");
 
-        Assert.Equal("Hello", doc.GetText());
+        Assert.AreEqual("Hello", doc.GetText());
         // Empty insert still goes through Apply but is a no-op internally
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertText_AtBeginning_Prepends()
     {
         var doc = new Hex1bDocument("World");
@@ -68,11 +69,11 @@ public class EditorStateTests
 
         state.InsertText("Hello ");
 
-        Assert.Equal("Hello World", doc.GetText());
-        Assert.Equal(new DocumentOffset(6), state.Cursor.Position);
+        Assert.AreEqual("Hello World", doc.GetText());
+        Assert.AreEqual(new DocumentOffset(6), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertText_Newline_SplitsLine()
     {
         var doc = new Hex1bDocument("HelloWorld");
@@ -81,12 +82,12 @@ public class EditorStateTests
 
         state.InsertText("\n");
 
-        Assert.Equal("Hello\nWorld", doc.GetText());
-        Assert.Equal(2, doc.LineCount);
-        Assert.Equal(new DocumentOffset(6), state.Cursor.Position);
+        Assert.AreEqual("Hello\nWorld", doc.GetText());
+        Assert.AreEqual(2, doc.LineCount);
+        Assert.AreEqual(new DocumentOffset(6), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteBackward_DeletesCharBeforeCursor()
     {
         var doc = new Hex1bDocument("Hello");
@@ -95,11 +96,11 @@ public class EditorStateTests
 
         state.DeleteBackward();
 
-        Assert.Equal("Hell", doc.GetText());
-        Assert.Equal(new DocumentOffset(4), state.Cursor.Position);
+        Assert.AreEqual("Hell", doc.GetText());
+        Assert.AreEqual(new DocumentOffset(4), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteBackward_AtStart_DoesNothing()
     {
         var doc = new Hex1bDocument("Hello");
@@ -108,11 +109,11 @@ public class EditorStateTests
 
         state.DeleteBackward();
 
-        Assert.Equal("Hello", doc.GetText());
-        Assert.Equal(new DocumentOffset(0), state.Cursor.Position);
+        Assert.AreEqual("Hello", doc.GetText());
+        Assert.AreEqual(new DocumentOffset(0), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteBackward_WhenReadOnly_DoesNothing()
     {
         var doc = new Hex1bDocument("Hello");
@@ -121,10 +122,10 @@ public class EditorStateTests
 
         state.DeleteBackward();
 
-        Assert.Equal("Hello", doc.GetText());
+        Assert.AreEqual("Hello", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteForward_DeletesCharAfterCursor()
     {
         var doc = new Hex1bDocument("Hello");
@@ -133,11 +134,11 @@ public class EditorStateTests
 
         state.DeleteForward();
 
-        Assert.Equal("ello", doc.GetText());
-        Assert.Equal(new DocumentOffset(0), state.Cursor.Position);
+        Assert.AreEqual("ello", doc.GetText());
+        Assert.AreEqual(new DocumentOffset(0), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteForward_AtEnd_DoesNothing()
     {
         var doc = new Hex1bDocument("Hello");
@@ -146,11 +147,11 @@ public class EditorStateTests
 
         state.DeleteForward();
 
-        Assert.Equal("Hello", doc.GetText());
-        Assert.Equal(new DocumentOffset(5), state.Cursor.Position);
+        Assert.AreEqual("Hello", doc.GetText());
+        Assert.AreEqual(new DocumentOffset(5), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteForward_WhenReadOnly_DoesNothing()
     {
         var doc = new Hex1bDocument("Hello");
@@ -159,10 +160,10 @@ public class EditorStateTests
 
         state.DeleteForward();
 
-        Assert.Equal("Hello", doc.GetText());
+        Assert.AreEqual("Hello", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteForward_WithSelection_DeletesSelection()
     {
         var doc = new Hex1bDocument("Hello world");
@@ -172,12 +173,12 @@ public class EditorStateTests
 
         state.DeleteForward();
 
-        Assert.Equal(" world", doc.GetText());
-        Assert.Equal(new DocumentOffset(0), state.Cursor.Position);
-        Assert.False(state.Cursor.HasSelection);
+        Assert.AreEqual(" world", doc.GetText());
+        Assert.AreEqual(new DocumentOffset(0), state.Cursor.Position);
+        Assert.IsFalse(state.Cursor.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Left_DecrementsCursorPosition()
     {
         var doc = new Hex1bDocument("Hello");
@@ -186,10 +187,10 @@ public class EditorStateTests
 
         state.MoveCursor(CursorDirection.Left);
 
-        Assert.Equal(new DocumentOffset(2), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(2), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Left_AtStart_StaysAtZero()
     {
         var doc = new Hex1bDocument("Hello");
@@ -198,10 +199,10 @@ public class EditorStateTests
 
         state.MoveCursor(CursorDirection.Left);
 
-        Assert.Equal(new DocumentOffset(0), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(0), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Right_IncrementsCursorPosition()
     {
         var doc = new Hex1bDocument("Hello");
@@ -210,10 +211,10 @@ public class EditorStateTests
 
         state.MoveCursor(CursorDirection.Right);
 
-        Assert.Equal(new DocumentOffset(4), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(4), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Right_AtEnd_StaysAtEnd()
     {
         var doc = new Hex1bDocument("Hello");
@@ -222,10 +223,10 @@ public class EditorStateTests
 
         state.MoveCursor(CursorDirection.Right);
 
-        Assert.Equal(new DocumentOffset(5), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(5), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Up_MovesPreviousLine()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -236,11 +237,11 @@ public class EditorStateTests
 
         // Should be at Line 1, Col 3
         var pos = doc.OffsetToPosition(state.Cursor.Position);
-        Assert.Equal(1, pos.Line);
-        Assert.Equal(3, pos.Column);
+        Assert.AreEqual(1, pos.Line);
+        Assert.AreEqual(3, pos.Column);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Up_OnFirstLine_StaysOnFirstLine()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -251,10 +252,10 @@ public class EditorStateTests
 
         // Should stay on line 1
         var pos = doc.OffsetToPosition(state.Cursor.Position);
-        Assert.Equal(1, pos.Line);
+        Assert.AreEqual(1, pos.Line);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Down_MovesNextLine()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -264,11 +265,11 @@ public class EditorStateTests
         state.MoveCursor(CursorDirection.Down);
 
         var pos = doc.OffsetToPosition(state.Cursor.Position);
-        Assert.Equal(2, pos.Line);
-        Assert.Equal(3, pos.Column);
+        Assert.AreEqual(2, pos.Line);
+        Assert.AreEqual(3, pos.Column);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Down_OnLastLine_StaysOnLastLine()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -278,10 +279,10 @@ public class EditorStateTests
         state.MoveCursor(CursorDirection.Down);
 
         var pos = doc.OffsetToPosition(state.Cursor.Position);
-        Assert.Equal(2, pos.Line);
+        Assert.AreEqual(2, pos.Line);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Down_ClampsToShorterLine()
     {
         var doc = new Hex1bDocument("Hello World\nHi");
@@ -291,12 +292,12 @@ public class EditorStateTests
         state.MoveCursor(CursorDirection.Down);
 
         var pos = doc.OffsetToPosition(state.Cursor.Position);
-        Assert.Equal(2, pos.Line);
+        Assert.AreEqual(2, pos.Line);
         // Should clamp to end of "Hi" (col 3 = past end)
-        Assert.True(pos.Column <= 3);
+        Assert.IsTrue(pos.Column <= 3);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Up_ClampsToShorterLine()
     {
         var doc = new Hex1bDocument("Hi\nHello World");
@@ -307,11 +308,11 @@ public class EditorStateTests
         state.MoveCursor(CursorDirection.Up);
 
         var pos = doc.OffsetToPosition(state.Cursor.Position);
-        Assert.Equal(1, pos.Line);
-        Assert.True(pos.Column <= 3); // "Hi" only has 2 chars + 1 past end
+        Assert.AreEqual(1, pos.Line);
+        Assert.IsTrue(pos.Column <= 3); // "Hi" only has 2 chars + 1 past end
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_ClearsSelection()
     {
         var doc = new Hex1bDocument("Hello");
@@ -321,10 +322,10 @@ public class EditorStateTests
 
         state.MoveCursor(CursorDirection.Right);
 
-        Assert.False(state.Cursor.HasSelection);
+        Assert.IsFalse(state.Cursor.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_SingleLineDocument_UpDown_NoOp()
     {
         var doc = new Hex1bDocument("Hello");
@@ -332,13 +333,13 @@ public class EditorStateTests
         state.Cursor.Position = new DocumentOffset(3);
 
         state.MoveCursor(CursorDirection.Up);
-        Assert.Equal(new DocumentOffset(3), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(3), state.Cursor.Position);
 
         state.MoveCursor(CursorDirection.Down);
-        Assert.Equal(new DocumentOffset(3), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(3), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void SharedDocument_EditsVisibleInBothStates()
     {
         var doc = new Hex1bDocument("Hello");
@@ -349,14 +350,14 @@ public class EditorStateTests
         state1.InsertText(" world");
 
         // Both see the change through the shared document
-        Assert.Equal("Hello world", doc.GetText());
-        Assert.Equal(11, doc.Length);
+        Assert.AreEqual("Hello world", doc.GetText());
+        Assert.AreEqual(11, doc.Length);
 
         // state2 can also read the updated content
-        Assert.Equal("Hello world", state2.Document.GetText());
+        Assert.AreEqual("Hello world", state2.Document.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void SharedDocument_ChangedEventNotifiesBothStates()
     {
         var doc = new Hex1bDocument("Hello");
@@ -367,10 +368,10 @@ public class EditorStateTests
         state1.Cursor.Position = new DocumentOffset(5);
         state1.InsertText("!");
 
-        Assert.Equal(1, changedCount);
+        Assert.AreEqual(1, changedCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteBackward_WithSelection_DeletesSelection()
     {
         var doc = new Hex1bDocument("Hello world");
@@ -380,34 +381,34 @@ public class EditorStateTests
 
         state.DeleteBackward();
 
-        Assert.Equal("Hello", doc.GetText());
-        Assert.Equal(new DocumentOffset(5), state.Cursor.Position);
-        Assert.False(state.Cursor.HasSelection);
+        Assert.AreEqual("Hello", doc.GetText());
+        Assert.AreEqual(new DocumentOffset(5), state.Cursor.Position);
+        Assert.IsFalse(state.Cursor.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void TabSize_DefaultIsFour()
     {
         var doc = new Hex1bDocument("");
         var state = new EditorState(doc);
-        Assert.Equal(4, state.TabSize);
+        Assert.AreEqual(4, state.TabSize);
     }
 
-    [Fact]
+    [TestMethod]
     public void TabSize_CanBeChanged()
     {
         var doc = new Hex1bDocument("");
         var state = new EditorState(doc) { TabSize = 2 };
-        Assert.Equal(2, state.TabSize);
+        Assert.AreEqual(2, state.TabSize);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_NullDocument_Throws()
     {
-        Assert.Throws<ArgumentNullException>(() => new EditorState(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => new EditorState(null!));
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertText_EmptyDocument_Works()
     {
         var doc = new Hex1bDocument("");
@@ -415,11 +416,11 @@ public class EditorStateTests
 
         state.InsertText("Hello");
 
-        Assert.Equal("Hello", doc.GetText());
-        Assert.Equal(new DocumentOffset(5), state.Cursor.Position);
+        Assert.AreEqual("Hello", doc.GetText());
+        Assert.AreEqual(new DocumentOffset(5), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteBackward_OnNewline_JoinsLines()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -428,11 +429,11 @@ public class EditorStateTests
 
         state.DeleteBackward();
 
-        Assert.Equal("HelloWorld", doc.GetText());
-        Assert.Equal(1, doc.LineCount);
+        Assert.AreEqual("HelloWorld", doc.GetText());
+        Assert.AreEqual(1, doc.LineCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteForward_OnNewline_JoinsLines()
     {
         var doc = new Hex1bDocument("Hello\nWorld");
@@ -441,11 +442,11 @@ public class EditorStateTests
 
         state.DeleteForward();
 
-        Assert.Equal("HelloWorld", doc.GetText());
-        Assert.Equal(1, doc.LineCount);
+        Assert.AreEqual("HelloWorld", doc.GetText());
+        Assert.AreEqual(1, doc.LineCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_ThroughNewline_Left()
     {
         var doc = new Hex1bDocument("AB\nCD");
@@ -455,10 +456,10 @@ public class EditorStateTests
         state.MoveCursor(CursorDirection.Left);
 
         // Should be at offset 2 (the \n char)
-        Assert.Equal(new DocumentOffset(2), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(2), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_ThroughNewline_Right()
     {
         var doc = new Hex1bDocument("AB\nCD");
@@ -467,10 +468,10 @@ public class EditorStateTests
 
         state.MoveCursor(CursorDirection.Right);
 
-        Assert.Equal(new DocumentOffset(3), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(3), state.Cursor.Position);
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertText_WithSelection_ReverseAnchor_Works()
     {
         // Selection where anchor is AFTER position (backward selection)
@@ -481,12 +482,12 @@ public class EditorStateTests
 
         state.InsertText("earth");
 
-        Assert.Equal("Hello earth", doc.GetText());
-        Assert.Equal(new DocumentOffset(11), state.Cursor.Position);
-        Assert.False(state.Cursor.HasSelection);
+        Assert.AreEqual("Hello earth", doc.GetText());
+        Assert.AreEqual(new DocumentOffset(11), state.Cursor.Position);
+        Assert.IsFalse(state.Cursor.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void MultipleEdits_ThenMoveCursor_WorksCorrectly()
     {
         var doc = new Hex1bDocument("");
@@ -495,15 +496,15 @@ public class EditorStateTests
         state.InsertText("Hello\nWorld\nFoo");
 
         // Cursor should be at end
-        Assert.Equal(new DocumentOffset(15), state.Cursor.Position);
+        Assert.AreEqual(new DocumentOffset(15), state.Cursor.Position);
 
         // Move up twice
         state.MoveCursor(CursorDirection.Up);
         var pos1 = doc.OffsetToPosition(state.Cursor.Position);
-        Assert.Equal(2, pos1.Line);
+        Assert.AreEqual(2, pos1.Line);
 
         state.MoveCursor(CursorDirection.Up);
         var pos2 = doc.OffsetToPosition(state.Cursor.Position);
-        Assert.Equal(1, pos2.Line);
+        Assert.AreEqual(1, pos2.Line);
     }
 }

--- a/tests/Hex1b.Tests/EditorStateUndoRedoTests.cs
+++ b/tests/Hex1b.Tests/EditorStateUndoRedoTests.cs
@@ -9,6 +9,7 @@ namespace Hex1b.Tests;
 /// NOTE: These tests depend on the EditHistory coalescing implementation and may
 /// need updates if coalescing rules change.
 /// </summary>
+[TestClass]
 public class EditorStateUndoRedoTests
 {
     private static EditorState CreateState(string text)
@@ -18,7 +19,7 @@ public class EditorStateUndoRedoTests
 
     // ── Basic undo/redo ─────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void Undo_RevertsInsert()
     {
         var state = CreateState("");
@@ -26,10 +27,10 @@ public class EditorStateUndoRedoTests
 
         state.Undo();
 
-        Assert.Equal("", state.Document.GetText());
+        Assert.AreEqual("", state.Document.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Undo_RevertsSingleCharInserts_Coalesced()
     {
         var state = CreateState("");
@@ -41,10 +42,10 @@ public class EditorStateUndoRedoTests
         // Single chars should be coalesced into one undo group
         state.Undo();
 
-        Assert.Equal("", state.Document.GetText());
+        Assert.AreEqual("", state.Document.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Redo_ReappliesInsert()
     {
         var state = CreateState("");
@@ -53,10 +54,10 @@ public class EditorStateUndoRedoTests
         state.Undo();
         state.Redo();
 
-        Assert.Equal("Hello", state.Document.GetText());
+        Assert.AreEqual("Hello", state.Document.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Undo_RevertsDelete()
     {
         var state = CreateState("Hello");
@@ -64,48 +65,48 @@ public class EditorStateUndoRedoTests
 
         state.DeleteBackward();
 
-        Assert.Equal("Hell", state.Document.GetText());
+        Assert.AreEqual("Hell", state.Document.GetText());
 
         state.Undo();
 
-        Assert.Equal("Hello", state.Document.GetText());
+        Assert.AreEqual("Hello", state.Document.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Undo_Redo_Undo_Roundtrip()
     {
         var state = CreateState("abc");
         state.Cursor.Position = new DocumentOffset(3);
         state.InsertText("d");
 
-        Assert.Equal("abcd", state.Document.GetText());
+        Assert.AreEqual("abcd", state.Document.GetText());
 
         state.Undo();
-        Assert.Equal("abc", state.Document.GetText());
+        Assert.AreEqual("abc", state.Document.GetText());
 
         state.Redo();
-        Assert.Equal("abcd", state.Document.GetText());
+        Assert.AreEqual("abcd", state.Document.GetText());
 
         state.Undo();
-        Assert.Equal("abc", state.Document.GetText());
+        Assert.AreEqual("abc", state.Document.GetText());
     }
 
     // ── Cursor restoration ──────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void Undo_RestoresCursorPosition()
     {
         var state = CreateState("Hello");
         state.Cursor.Position = new DocumentOffset(5); // End
 
         state.InsertText(" World");
-        Assert.Equal(11, state.Cursor.Position.Value);
+        Assert.AreEqual(11, state.Cursor.Position.Value);
 
         state.Undo();
-        Assert.Equal(5, state.Cursor.Position.Value); // Restored
+        Assert.AreEqual(5, state.Cursor.Position.Value); // Restored
     }
 
-    [Fact]
+    [TestMethod]
     public void Redo_RestoresCursorPosition()
     {
         var state = CreateState("Hello");
@@ -115,12 +116,12 @@ public class EditorStateUndoRedoTests
         state.Undo();
         state.Redo();
 
-        Assert.Equal(11, state.Cursor.Position.Value);
+        Assert.AreEqual(11, state.Cursor.Position.Value);
     }
 
     // ── Multi-operation undo ────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void Undo_MultipleEdits_UndoesInOrder()
     {
         var state = CreateState("");
@@ -129,52 +130,52 @@ public class EditorStateUndoRedoTests
         state.InsertText("\n"); // Newline breaks coalescing (not single-char coalescable)
 
         state.Undo(); // Undo the newline
-        Assert.Equal("First", state.Document.GetText());
+        Assert.AreEqual("First", state.Document.GetText());
 
         state.Undo(); // Undo "First" (may be coalesced into one group)
-        Assert.Equal("", state.Document.GetText());
+        Assert.AreEqual("", state.Document.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Undo_DeleteBackward_RestoresText()
     {
         var state = CreateState("abcdef");
         state.Cursor.Position = new DocumentOffset(3);
 
         state.DeleteBackward(); // Delete 'c'
-        Assert.Equal("abdef", state.Document.GetText());
+        Assert.AreEqual("abdef", state.Document.GetText());
 
         state.Undo();
-        Assert.Equal("abcdef", state.Document.GetText());
+        Assert.AreEqual("abcdef", state.Document.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Undo_DeleteForward_RestoresText()
     {
         var state = CreateState("abcdef");
         state.Cursor.Position = new DocumentOffset(3);
 
         state.DeleteForward(); // Delete 'd'
-        Assert.Equal("abcef", state.Document.GetText());
+        Assert.AreEqual("abcef", state.Document.GetText());
 
         state.Undo();
-        Assert.Equal("abcdef", state.Document.GetText());
+        Assert.AreEqual("abcdef", state.Document.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Undo_DeleteWordBackward_RestoresWord()
     {
         var state = CreateState("hello world");
         state.Cursor.Position = new DocumentOffset(5); // after "hello"
 
         state.DeleteWordBackward();
-        Assert.Equal(" world", state.Document.GetText());
+        Assert.AreEqual(" world", state.Document.GetText());
 
         state.Undo();
-        Assert.Equal("hello world", state.Document.GetText());
+        Assert.AreEqual("hello world", state.Document.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Undo_DeleteLine_RestoresLine()
     {
         var state = CreateState("line1\nline2\nline3");
@@ -183,47 +184,47 @@ public class EditorStateUndoRedoTests
         state.DeleteLine();
 
         state.Undo();
-        Assert.Equal("line1\nline2\nline3", state.Document.GetText());
+        Assert.AreEqual("line1\nline2\nline3", state.Document.GetText());
     }
 
     // ── New edit after undo clears redo ──────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void NewEdit_AfterUndo_ClearsRedo()
     {
         var state = CreateState("");
         state.InsertText("Hello");
         state.Undo();
 
-        Assert.True(state.History.CanRedo);
+        Assert.IsTrue(state.History.CanRedo);
 
         state.InsertText("World");
 
-        Assert.False(state.History.CanRedo);
-        Assert.Equal("World", state.Document.GetText());
+        Assert.IsFalse(state.History.CanRedo);
+        Assert.AreEqual("World", state.Document.GetText());
     }
 
     // ── Undo with no history ────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void Undo_WithNoHistory_DoesNothing()
     {
         var state = CreateState("Hello");
         state.Undo(); // Should not throw
-        Assert.Equal("Hello", state.Document.GetText());
+        Assert.AreEqual("Hello", state.Document.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void Redo_WithNoHistory_DoesNothing()
     {
         var state = CreateState("Hello");
         state.Redo(); // Should not throw
-        Assert.Equal("Hello", state.Document.GetText());
+        Assert.AreEqual("Hello", state.Document.GetText());
     }
 
     // ── Selection + undo ────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void Undo_ReplaceSelection_RestoresOriginalText()
     {
         var state = CreateState("Hello World");
@@ -231,15 +232,15 @@ public class EditorStateUndoRedoTests
         state.Cursor.Position = new DocumentOffset(11); // Select "World"
 
         state.InsertText("Hex1b"); // Replace selection
-        Assert.Equal("Hello Hex1b", state.Document.GetText());
+        Assert.AreEqual("Hello Hex1b", state.Document.GetText());
 
         state.Undo();
-        Assert.Equal("Hello World", state.Document.GetText());
+        Assert.AreEqual("Hello World", state.Document.GetText());
     }
 
     // ── Read-only ───────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void ReadOnly_DoesNotAddToHistory()
     {
         var state = CreateState("Hello");
@@ -247,13 +248,13 @@ public class EditorStateUndoRedoTests
 
         state.InsertText("X");
 
-        Assert.False(state.History.CanUndo);
-        Assert.Equal("Hello", state.Document.GetText());
+        Assert.IsFalse(state.History.CanUndo);
+        Assert.AreEqual("Hello", state.Document.GetText());
     }
 
     // ── Cross-view undo ─────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void Undo_AffectsSharedDocument()
     {
         var doc = new Hex1bDocument("Hello");
@@ -263,19 +264,19 @@ public class EditorStateUndoRedoTests
         // Edit through state1
         state1.Cursor.Position = new DocumentOffset(5);
         state1.InsertText(" World");
-        Assert.Equal("Hello World", doc.GetText());
+        Assert.AreEqual("Hello World", doc.GetText());
 
         // Undo through state1 — document should revert
         state1.Undo();
-        Assert.Equal("Hello", doc.GetText());
+        Assert.AreEqual("Hello", doc.GetText());
 
         // state2 sees the same document
-        Assert.Equal("Hello", state2.Document.GetText());
+        Assert.AreEqual("Hello", state2.Document.GetText());
     }
 
     // ── Stress: many undo/redo ──────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void Stress_ManyUndoRedo_MaintainsConsistency()
     {
         var state = CreateState("");
@@ -294,7 +295,7 @@ public class EditorStateUndoRedoTests
             state.Undo();
         }
 
-        Assert.Equal("", state.Document.GetText());
+        Assert.AreEqual("", state.Document.GetText());
 
         // Redo everything
         while (state.History.CanRedo)
@@ -302,6 +303,6 @@ public class EditorStateUndoRedoTests
             state.Redo();
         }
 
-        Assert.Equal(afterText, state.Document.GetText());
+        Assert.AreEqual(afterText, state.Document.GetText());
     }
 }

--- a/tests/Hex1b.Tests/EditorWidgetHoistedStateTests.cs
+++ b/tests/Hex1b.Tests/EditorWidgetHoistedStateTests.cs
@@ -10,9 +10,10 @@ namespace Hex1b.Tests;
 /// out-of-band parent mutations, and keeping peer instances isolated. Mirrors
 /// the suite already in place for <see cref="TextBoxWidget"/>.
 /// </summary>
+[TestClass]
 public class EditorWidgetHoistedStateTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_HoistedState_RoutesParentInstanceIntoNode()
     {
         var doc = new Hex1bDocument("hello");
@@ -25,11 +26,11 @@ public class EditorWidgetHoistedStateTests
 
         // The parent's exact state instance must be the one the node uses —
         // not a copy — so subsequent parent mutations are observed.
-        Assert.Same(state, node.State);
-        Assert.Same(doc, node.State.Document);
+        Assert.AreSame(state, node.State);
+        Assert.AreSame(doc, node.State.Document);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_HoistedState_PreservedAcrossReconciles()
     {
         var doc = new Hex1bDocument("first");
@@ -39,18 +40,18 @@ public class EditorWidgetHoistedStateTests
         context.IsNew = true;
 
         var node = (EditorNode)await new EditorWidget(state).ReconcileAsync(null, context);
-        Assert.Same(state, node.State);
+        Assert.AreSame(state, node.State);
 
         // A new widget instance pointing at the same state must NOT replace
         // the state instance on the node.
         context.IsNew = false;
         var node2 = (EditorNode)await new EditorWidget(state).ReconcileAsync(node, context);
 
-        Assert.Same(node, node2);
-        Assert.Same(state, node2.State);
+        Assert.AreSame(node, node2);
+        Assert.AreSame(state, node2.State);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_HoistedState_ParentMutationVisibleAfterReconcile()
     {
         var doc = new Hex1bDocument("hello");
@@ -60,7 +61,7 @@ public class EditorWidgetHoistedStateTests
         context.IsNew = true;
 
         var node = (EditorNode)await new EditorWidget(state).ReconcileAsync(null, context);
-        Assert.Equal("hello", node.State.Document.GetText());
+        Assert.AreEqual("hello", node.State.Document.GetText());
 
         // Parent mutates the document content from outside the widget tree,
         // then reconciles. The node should observe the new text since it
@@ -71,11 +72,11 @@ public class EditorWidgetHoistedStateTests
         context.IsNew = false;
         await new EditorWidget(state).ReconcileAsync(node, context);
 
-        Assert.Equal("hello world", node.State.Document.GetText());
-        Assert.Same(doc, node.State.Document);
+        Assert.AreEqual("hello world", node.State.Document.GetText());
+        Assert.AreSame(doc, node.State.Document);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_HoistedState_PeerInstancesAreIndependent()
     {
         var stateA = new EditorState(new Hex1bDocument("alpha"));
@@ -93,12 +94,12 @@ public class EditorWidgetHoistedStateTests
         stateA.Cursor.Position = new DocumentOffset(5);
         stateA.InsertText("-mutated");
 
-        Assert.Equal("alpha-mutated", nodeA.State.Document.GetText());
-        Assert.Equal("beta", nodeB.State.Document.GetText());
-        Assert.NotSame(nodeA.State, nodeB.State);
+        Assert.AreEqual("alpha-mutated", nodeA.State.Document.GetText());
+        Assert.AreEqual("beta", nodeB.State.Document.GetText());
+        Assert.AreNotSame(nodeA.State, nodeB.State);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_FluentState_OverridesCtorState()
     {
         // The fluent .State(...) overload is the IStatefulWidget contract
@@ -114,7 +115,7 @@ public class EditorWidgetHoistedStateTests
         context.IsNew = true;
         var node = (EditorNode)await widget.ReconcileAsync(null, context);
 
-        Assert.Same(hoistedState, node.State);
-        Assert.Equal("from-hoist", node.State.Document.GetText());
+        Assert.AreSame(hoistedState, node.State);
+        Assert.AreEqual("from-hoist", node.State.Document.GetText());
     }
 }

--- a/tests/Hex1b.Tests/EditorWidgetReconciliationTests.cs
+++ b/tests/Hex1b.Tests/EditorWidgetReconciliationTests.cs
@@ -7,9 +7,10 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class EditorWidgetReconciliationTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_NullExisting_CreatesNewEditorNode()
     {
         // NOTE: Node creation may gain initialization hooks in future.
@@ -20,10 +21,10 @@ public class EditorWidgetReconciliationTests
         var context = ReconcileContext.CreateRoot();
         var node = await widget.ReconcileAsync(null, context);
 
-        Assert.IsType<EditorNode>(node);
+        TestSeq.IsType<EditorNode>(node);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_ExistingEditorNode_ReusesSameInstance()
     {
         // NOTE: Instance reuse preserves scroll position and focus state.
@@ -35,10 +36,10 @@ public class EditorWidgetReconciliationTests
         var context = ReconcileContext.CreateRoot();
         var result = await widget.ReconcileAsync(existingNode, context);
 
-        Assert.Same(existingNode, result);
+        Assert.AreSame(existingNode, result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_UpdatesState()
     {
         // NOTE: State swapping may trigger scroll reset in future.
@@ -52,14 +53,14 @@ public class EditorWidgetReconciliationTests
 
         var context = ReconcileContext.CreateRoot();
         var node = (EditorNode)await widget1.ReconcileAsync(null, context);
-        Assert.Same(state1, node.State);
+        Assert.AreSame(state1, node.State);
 
         // Reconcile with different state
         await widget2.ReconcileAsync(node, context);
-        Assert.Same(state2, node.State);
+        Assert.AreSame(state2, node.State);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_WithOnTextChanged_SetsTextChangedAction()
     {
         // NOTE: TextChangedAction wiring may change with event aggregation.
@@ -71,10 +72,10 @@ public class EditorWidgetReconciliationTests
         var context = ReconcileContext.CreateRoot();
         var node = (EditorNode)await widget.ReconcileAsync(null, context);
 
-        Assert.NotNull(node.TextChangedAction);
+        Assert.IsNotNull(node.TextChangedAction);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_WithoutOnTextChanged_ClearsTextChangedAction()
     {
         // NOTE: Clearing action prevents stale handler references.
@@ -86,15 +87,15 @@ public class EditorWidgetReconciliationTests
             .OnTextChanged((EditorTextChangedEventArgs _) => { });
         var context = ReconcileContext.CreateRoot();
         var node = (EditorNode)await widgetWithHandler.ReconcileAsync(null, context);
-        Assert.NotNull(node.TextChangedAction);
+        Assert.IsNotNull(node.TextChangedAction);
 
         // Second reconcile without handler
         var widgetWithout = new EditorWidget(state);
         await widgetWithout.ReconcileAsync(node, context);
-        Assert.Null(node.TextChangedAction);
+        Assert.IsNull(node.TextChangedAction);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetExpectedNodeType_ReturnsEditorNodeType()
     {
         // NOTE: Node type must match for reconciliation reuse.
@@ -102,10 +103,10 @@ public class EditorWidgetReconciliationTests
         var state = new EditorState(doc);
         var widget = new EditorWidget(state);
 
-        Assert.Equal(typeof(EditorNode), widget.GetExpectedNodeType());
+        Assert.AreEqual(typeof(EditorNode), widget.GetExpectedNodeType());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_TwoWidgetsSameState_NodesShareState()
     {
         // NOTE: Shared state enables synced cursors between views.
@@ -118,7 +119,7 @@ public class EditorWidgetReconciliationTests
         var node1 = (EditorNode)await widget1.ReconcileAsync(null, context);
         var node2 = (EditorNode)await widget2.ReconcileAsync(null, context);
 
-        Assert.Same(node1.State, node2.State);
-        Assert.Same(state, node1.State);
+        Assert.AreSame(node1.State, node2.State);
+        Assert.AreSame(state, node1.State);
     }
 }

--- a/tests/Hex1b.Tests/EffectPanelIntegrationTests.cs
+++ b/tests/Hex1b.Tests/EffectPanelIntegrationTests.cs
@@ -7,12 +7,13 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class EffectPanelIntegrationTests
 {
     /// <summary>
     /// Full widget → reconcile → measure → arrange → render cycle with effect.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task FullCycle_WithEffect_RendersAndAppliesEffect()
     {
         var effectApplied = false;
@@ -39,7 +40,7 @@ public class EffectPanelIntegrationTests
         var renderContext = new SurfaceRenderContext(surface);
         renderContext.RenderChild(node);
 
-        Assert.True(effectApplied);
+        Assert.IsTrue(effectApplied);
 
         // Text should be present
         var text = GetRowText(surface, 0);
@@ -47,16 +48,16 @@ public class EffectPanelIntegrationTests
 
         // Background should be blue
         var cell = surface[0, 0];
-        Assert.NotNull(cell.Background);
-        Assert.Equal(0, cell.Background.Value.R);
-        Assert.Equal(0, cell.Background.Value.G);
-        Assert.Equal(255, cell.Background.Value.B);
+        Assert.IsNotNull(cell.Background);
+        Assert.AreEqual(0, cell.Background.Value.R);
+        Assert.AreEqual(0, cell.Background.Value.G);
+        Assert.AreEqual(255, cell.Background.Value.B);
     }
 
     /// <summary>
     /// Interactive child inside EffectPanel remains focusable.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task InteractiveChild_RemainsFocusable()
     {
         var widget = new EffectPanelWidget(
@@ -68,14 +69,14 @@ public class EffectPanelIntegrationTests
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Single(focusables);
-        Assert.IsType<ButtonNode>(focusables[0]);
+        TestSeq.Single(focusables);
+        TestSeq.IsType<ButtonNode>(focusables[0]);
     }
 
     /// <summary>
     /// Effect applied to a VStack with multiple children.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Effect_AppliedToVStackChildren()
     {
         var capturedSurface = (Surface?)null;
@@ -100,7 +101,7 @@ public class EffectPanelIntegrationTests
         var renderContext = new SurfaceRenderContext(surface);
         renderContext.RenderChild(node);
 
-        Assert.NotNull(capturedSurface);
+        Assert.IsNotNull(capturedSurface);
         var line1 = GetRowText(capturedSurface!, 0);
         var line2 = GetRowText(capturedSurface!, 1);
         Assert.Contains("Line 1", line1);
@@ -110,7 +111,7 @@ public class EffectPanelIntegrationTests
     /// <summary>
     /// EffectPanel composes with StatePanel.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ComposesWithStatePanel()
     {
         var stateKey = new object();
@@ -130,7 +131,7 @@ public class EffectPanelIntegrationTests
         var renderContext = new SurfaceRenderContext(surface);
         renderContext.RenderChild(node);
 
-        Assert.True(effectCalled);
+        Assert.IsTrue(effectCalled);
         var text = GetRowText(surface, 0);
         Assert.Contains("Animated", text);
     }
@@ -138,7 +139,7 @@ public class EffectPanelIntegrationTests
     /// <summary>
     /// Dim effect reduces color values.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task DimEffect_ReducesColorValues()
     {
         // Render a text block with known foreground, then dim it

--- a/tests/Hex1b.Tests/EffectPanelNodeTests.cs
+++ b/tests/Hex1b.Tests/EffectPanelNodeTests.cs
@@ -7,11 +7,12 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class EffectPanelNodeTests
 {
     // --- Layout pass-through tests ---
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithChild_DelegatesToChild()
     {
         var child = new ButtonNode { Label = "OK" };
@@ -19,22 +20,22 @@ public class EffectPanelNodeTests
 
         var size = node.Measure(new Constraints(0, 50, 0, 10));
 
-        Assert.True(size.Width > 0);
-        Assert.True(size.Height > 0);
+        Assert.IsTrue(size.Width > 0);
+        Assert.IsTrue(size.Height > 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithoutChild_ReturnsConstrainedZero()
     {
         var node = new EffectPanelNode { Child = null };
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(0, size.Width);
-        Assert.Equal(0, size.Height);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(0, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_PassesThroughToChild()
     {
         var child = new ButtonNode { Label = "OK" };
@@ -44,13 +45,13 @@ public class EffectPanelNodeTests
         var rect = new Rect(5, 10, 30, 3);
         node.Arrange(rect);
 
-        Assert.Equal(rect, node.Bounds);
-        Assert.Equal(rect, child.Bounds);
+        Assert.AreEqual(rect, node.Bounds);
+        Assert.AreEqual(rect, child.Bounds);
     }
 
     // --- Focus pass-through tests ---
 
-    [Fact]
+    [TestMethod]
     public void GetFocusableNodes_DelegatesToChild()
     {
         var button = new ButtonNode { Label = "OK" };
@@ -58,21 +59,21 @@ public class EffectPanelNodeTests
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Single(focusables);
-        Assert.Same(button, focusables[0]);
+        TestSeq.Single(focusables);
+        Assert.AreSame(button, focusables[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetFocusableNodes_WithoutChild_ReturnsEmpty()
     {
         var node = new EffectPanelNode { Child = null };
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Empty(focusables);
+        Assert.IsEmpty(focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_WithChild_ReturnsSingletonList()
     {
         var child = new TextBlockNode();
@@ -80,23 +81,23 @@ public class EffectPanelNodeTests
 
         var children = node.GetChildren();
 
-        Assert.Single(children);
-        Assert.Same(child, children[0]);
+        TestSeq.Single(children);
+        Assert.AreSame(child, children[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_WithoutChild_ReturnsEmpty()
     {
         var node = new EffectPanelNode { Child = null };
 
         var children = node.GetChildren();
 
-        Assert.Empty(children);
+        Assert.IsEmpty(children);
     }
 
     // --- Render tests ---
 
-    [Fact]
+    [TestMethod]
     public void Render_WithoutEffect_PassesThroughUnchanged()
     {
         var node = SetupRenderedNode("Hello", effect: null);
@@ -107,7 +108,7 @@ public class EffectPanelNodeTests
         Assert.Contains("Hello", text);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_WithEffect_ModifiesSurfaceCells()
     {
         var effectCalled = false;
@@ -125,18 +126,18 @@ public class EffectPanelNodeTests
 
         var surface = RenderToSurface(node, 40, 5);
 
-        Assert.True(effectCalled);
+        Assert.IsTrue(effectCalled);
         // The text should still be present
         var text = GetRowText(surface, 0);
         Assert.Contains("Hello", text);
         // The background should be red on rendered cells
         var cell = surface[0, 0];
-        Assert.NotNull(cell.Background);
-        Assert.Equal(255, cell.Background.Value.R);
-        Assert.Equal(0, cell.Background.Value.G);
+        Assert.IsNotNull(cell.Background);
+        Assert.AreEqual(255, cell.Background.Value.R);
+        Assert.AreEqual(0, cell.Background.Value.G);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_WithEffect_ReceivesCorrectlySizedSurface()
     {
         int? surfaceWidth = null;
@@ -150,11 +151,11 @@ public class EffectPanelNodeTests
 
         RenderToSurface(node, 25, 3);
 
-        Assert.Equal(25, surfaceWidth);
-        Assert.Equal(3, surfaceHeight);
+        Assert.AreEqual(25, surfaceWidth);
+        Assert.AreEqual(3, surfaceHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_WithEffect_ReceivesChildRenderedContent()
     {
         string? capturedText = null;
@@ -166,11 +167,11 @@ public class EffectPanelNodeTests
 
         RenderToSurface(node, 40, 5);
 
-        Assert.NotNull(capturedText);
+        Assert.IsNotNull(capturedText);
         Assert.Contains("TestContent", capturedText);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_WithNullChild_DoesNotThrow()
     {
         var node = new EffectPanelNode
@@ -188,7 +189,7 @@ public class EffectPanelNodeTests
         ctx.RenderChild(node);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_WithZeroBounds_DoesNotThrow()
     {
         var child = new TextBlockNode();
@@ -206,12 +207,12 @@ public class EffectPanelNodeTests
         ctx.RenderChild(node);
 
         // Effect should not be called for zero-sized bounds
-        Assert.False(effectCalled);
+        Assert.IsFalse(effectCalled);
     }
 
     // --- Reconciliation tests ---
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_ReusesExistingNode()
     {
         var childWidget = new TextBlockWidget("Hello");
@@ -221,11 +222,11 @@ public class EffectPanelNodeTests
         var node1 = await widget.ReconcileAsync(null, context);
         var node2 = await widget.ReconcileAsync(node1, context);
 
-        Assert.IsType<EffectPanelNode>(node1);
-        Assert.Same(node1, node2);
+        TestSeq.IsType<EffectPanelNode>(node1);
+        Assert.AreSame(node1, node2);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_SetsEffect()
     {
         Action<Surface> effect = _ => { };
@@ -235,10 +236,10 @@ public class EffectPanelNodeTests
 
         var node = (EffectPanelNode)await widget.ReconcileAsync(null, context);
 
-        Assert.Same(effect, node.Effect);
+        Assert.AreSame(effect, node.Effect);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_UpdatesEffect()
     {
         Action<Surface> effect1 = _ => { };
@@ -247,14 +248,14 @@ public class EffectPanelNodeTests
 
         var widget1 = new EffectPanelWidget(new TextBlockWidget("test")).Effect(effect1);
         var node = (EffectPanelNode)await widget1.ReconcileAsync(null, context);
-        Assert.Same(effect1, node.Effect);
+        Assert.AreSame(effect1, node.Effect);
 
         var widget2 = new EffectPanelWidget(new TextBlockWidget("test")).Effect(effect2);
         await widget2.ReconcileAsync(node, context);
-        Assert.Same(effect2, node.Effect);
+        Assert.AreSame(effect2, node.Effect);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_ReconcileChild()
     {
         var widget = new EffectPanelWidget(new TextBlockWidget("Hello"));
@@ -262,21 +263,21 @@ public class EffectPanelNodeTests
 
         var node = (EffectPanelNode)await widget.ReconcileAsync(null, context);
 
-        Assert.NotNull(node.Child);
-        Assert.IsType<TextBlockNode>(node.Child);
+        Assert.IsNotNull(node.Child);
+        TestSeq.IsType<TextBlockNode>(node.Child);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_GetExpectedNodeType_ReturnsEffectPanelNode()
     {
         var widget = new EffectPanelWidget(new TextBlockWidget("x"));
 
-        Assert.Equal(typeof(EffectPanelNode), widget.GetExpectedNodeType());
+        Assert.AreEqual(typeof(EffectPanelNode), widget.GetExpectedNodeType());
     }
 
     // --- Extension method tests ---
 
-    [Fact]
+    [TestMethod]
     public void Extension_EffectPanel_CreatesWidget()
     {
         var ctx = new WidgetContext<VStackWidget>();
@@ -284,11 +285,11 @@ public class EffectPanelNodeTests
 
         var widget = ctx.EffectPanel(child);
 
-        Assert.IsType<EffectPanelWidget>(widget);
-        Assert.Same(child, widget.Child);
+        TestSeq.IsType<EffectPanelWidget>(widget);
+        Assert.AreSame(child, widget.Child);
     }
 
-    [Fact]
+    [TestMethod]
     public void Extension_EffectPanel_WithEffectOverload()
     {
         var ctx = new WidgetContext<VStackWidget>();
@@ -297,12 +298,12 @@ public class EffectPanelNodeTests
 
         var widget = ctx.EffectPanel(child, effect);
 
-        Assert.IsType<EffectPanelWidget>(widget);
-        Assert.Same(child, widget.Child);
-        Assert.NotNull(widget.EffectCallback);
+        TestSeq.IsType<EffectPanelWidget>(widget);
+        Assert.AreSame(child, widget.Child);
+        Assert.IsNotNull(widget.EffectCallback);
     }
 
-    [Fact]
+    [TestMethod]
     public void Effect_ReturnsCopyWithEffect()
     {
         var child = new TextBlockWidget("hello");
@@ -310,13 +311,13 @@ public class EffectPanelNodeTests
 
         var widget = new EffectPanelWidget(child).Effect(effect);
 
-        Assert.Same(child, widget.Child);
-        Assert.NotNull(widget.EffectCallback);
+        Assert.AreSame(child, widget.Child);
+        Assert.IsNotNull(widget.EffectCallback);
     }
 
     // --- Nested EffectPanels ---
 
-    [Fact]
+    [TestMethod]
     public async Task NestedEffectPanels_BothEffectsApplied()
     {
         var outerCalled = false;
@@ -337,8 +338,8 @@ public class EffectPanelNodeTests
         var renderContext = new SurfaceRenderContext(surface);
         renderContext.RenderChild(node);
 
-        Assert.True(innerCalled);
-        Assert.True(outerCalled);
+        Assert.IsTrue(innerCalled);
+        Assert.IsTrue(outerCalled);
     }
 
     // --- Helpers ---

--- a/tests/Hex1b.Tests/EmojiRenderingTests.cs
+++ b/tests/Hex1b.Tests/EmojiRenderingTests.cs
@@ -12,6 +12,7 @@ namespace Hex1b.Tests;
 /// - Emoji with variation selectors
 /// - Wide character display widths
 /// </summary>
+[TestClass]
 public class EmojiRenderingTests
 {
     /// <summary>
@@ -101,7 +102,7 @@ public class EmojiRenderingTests
     /// <summary>
     /// Renders a variety of simple emoji (single grapheme, surrogate pairs).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void SimpleEmoji_RendersCorrectly()
     {
         using var test = new TestTerminal(60, 20);
@@ -121,9 +122,9 @@ public class EmojiRenderingTests
         var snapshot = test.Terminal.CreateSnapshot();
 
         // Verify some key emoji are present
-        Assert.True(ContainsGrapheme(snapshot, "😀"), "Smile emoji should be present");
-        Assert.True(ContainsGrapheme(snapshot, "🚀"), "Rocket emoji should be present");
-        Assert.True(ContainsGrapheme(snapshot, "🍕"), "Pizza emoji should be present");
+        Assert.IsTrue(ContainsGrapheme(snapshot, "😀"), "Smile emoji should be present");
+        Assert.IsTrue(ContainsGrapheme(snapshot, "🚀"), "Rocket emoji should be present");
+        Assert.IsTrue(ContainsGrapheme(snapshot, "🍕"), "Pizza emoji should be present");
         
         // Debug: Check the cell state for a simple emoji line
         // "Faces:    " is 10 chars, then first emoji at col 10
@@ -131,9 +132,9 @@ public class EmojiRenderingTests
         var contCell = snapshot.GetCell(11, 3);
         
         // Verify emoji is in cell and continuation is empty with matching sequence
-        Assert.Equal("😀", emojiCell.Character);
-        Assert.Equal("", contCell.Character);
-        Assert.Equal(emojiCell.Sequence, contCell.Sequence);
+        Assert.AreEqual("😀", emojiCell.Character);
+        Assert.AreEqual("", contCell.Character);
+        Assert.AreEqual(emojiCell.Sequence, contCell.Sequence);
 
         TestCaptureHelper.Capture(test.Terminal, "simple-emoji");
     }
@@ -141,7 +142,7 @@ public class EmojiRenderingTests
     /// <summary>
     /// Renders emoji with skin tone modifiers.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void SkinToneModifiers_RendersCorrectly()
     {
         using var test = new TestTerminal(70, 18);
@@ -163,8 +164,8 @@ public class EmojiRenderingTests
         var snapshot = test.Terminal.CreateSnapshot();
 
         // Verify skin tone variants are present
-        Assert.True(ContainsGrapheme(snapshot, ThumbsUpLight), "Light skin tone should be present");
-        Assert.True(ContainsGrapheme(snapshot, ThumbsUpDark), "Dark skin tone should be present");
+        Assert.IsTrue(ContainsGrapheme(snapshot, ThumbsUpLight), "Light skin tone should be present");
+        Assert.IsTrue(ContainsGrapheme(snapshot, ThumbsUpDark), "Dark skin tone should be present");
 
         TestCaptureHelper.Capture(test.Terminal, "skin-tone-modifiers");
     }
@@ -172,7 +173,7 @@ public class EmojiRenderingTests
     /// <summary>
     /// Renders ZWJ (Zero-Width Joiner) sequences like families and professions.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void ZwjSequences_RendersCorrectly()
     {
         using var test = new TestTerminal(70, 20);
@@ -199,8 +200,8 @@ public class EmojiRenderingTests
         var snapshot = test.Terminal.CreateSnapshot();
 
         // Verify ZWJ sequences are present as single graphemes
-        Assert.True(ContainsGrapheme(snapshot, Family), "Family emoji should be present");
-        Assert.True(ContainsGrapheme(snapshot, ManTechnologist), "Man technologist should be present");
+        Assert.IsTrue(ContainsGrapheme(snapshot, Family), "Family emoji should be present");
+        Assert.IsTrue(ContainsGrapheme(snapshot, ManTechnologist), "Man technologist should be present");
 
         TestCaptureHelper.Capture(test.Terminal, "zwj-sequences");
     }
@@ -208,7 +209,7 @@ public class EmojiRenderingTests
     /// <summary>
     /// Renders flag emoji (regional indicator pairs).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void FlagEmoji_RendersCorrectly()
     {
         using var test = new TestTerminal(70, 18);
@@ -227,8 +228,8 @@ public class EmojiRenderingTests
 
         var snapshot = test.Terminal.CreateSnapshot();
 
-        Assert.True(ContainsGrapheme(snapshot, FlagUS), "US flag should be present");
-        Assert.True(ContainsGrapheme(snapshot, FlagJP), "Japan flag should be present");
+        Assert.IsTrue(ContainsGrapheme(snapshot, FlagUS), "US flag should be present");
+        Assert.IsTrue(ContainsGrapheme(snapshot, FlagJP), "Japan flag should be present");
 
         TestCaptureHelper.Capture(test.Terminal, "flag-emoji");
     }
@@ -236,7 +237,7 @@ public class EmojiRenderingTests
     /// <summary>
     /// Renders keycap sequences and symbol emoji.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void KeycapsAndSymbols_RendersCorrectly()
     {
         using var test = new TestTerminal(60, 16);
@@ -255,7 +256,7 @@ public class EmojiRenderingTests
 
         var snapshot = test.Terminal.CreateSnapshot();
 
-        Assert.True(ContainsGrapheme(snapshot, Keycap1), "Keycap 1 should be present");
+        Assert.IsTrue(ContainsGrapheme(snapshot, Keycap1), "Keycap 1 should be present");
 
         TestCaptureHelper.Capture(test.Terminal, "keycaps-and-symbols");
     }
@@ -263,7 +264,7 @@ public class EmojiRenderingTests
     /// <summary>
     /// Tests emoji mixed with regular text and ANSI colors.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void EmojiWithTextAndColors_RendersCorrectly()
     {
         using var test = new TestTerminal(70, 20);
@@ -302,7 +303,7 @@ public class EmojiRenderingTests
     /// <summary>
     /// Tests emoji display width handling (most emoji are width 2).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void EmojiDisplayWidth_RendersCorrectly()
     {
         using var test = new TestTerminal(80, 20);
@@ -338,7 +339,7 @@ public class EmojiRenderingTests
     /// <summary>
     /// Tests a comprehensive emoji showcase.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void EmojiShowcase_RendersCorrectly()
     {
         using var test = new TestTerminal(80, 30);
@@ -379,7 +380,7 @@ public class EmojiRenderingTests
     /// When a character is written over the continuation cell of a wide emoji,
     /// the emoji should be partially obscured (truncated) by the newer content.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void WideCharacterTruncation_RendersCorrectly()
     {
         using var test = new TestTerminal(40, 16);
@@ -423,10 +424,10 @@ public class EmojiRenderingTests
 
         // Verify the X was written
         var cell = snapshot.GetCell(1, 6); // Row 7 (0-indexed=6), Col 2 (0-indexed=1)
-        Assert.Equal("X", cell.Character);
+        Assert.AreEqual("X", cell.Character);
 
         // Verify sequence numbers are being assigned
-        Assert.True(cell.Sequence > 0, "Cell should have a sequence number");
+        Assert.IsTrue(cell.Sequence > 0, "Cell should have a sequence number");
 
         TestCaptureHelper.Capture(test.Terminal, "wide-char-truncation");
     }
@@ -434,7 +435,7 @@ public class EmojiRenderingTests
     /// <summary>
     /// Tests sequence ordering in SVG - cells written later should appear on top.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void SequenceOrdering_NewerContentOnTop()
     {
         using var test = new TestTerminal(30, 10);
@@ -462,8 +463,7 @@ public class EmojiRenderingTests
         var emojiCell = snapshot.GetCell(0, 4); // First emoji
         var overwriteCell = snapshot.GetCell(2, 4); // 'A' that was written later
 
-        Assert.True(overwriteCell.Sequence > emojiCell.Sequence, 
-            "Overwrite should have higher sequence than original emoji");
+        Assert.IsTrue(overwriteCell.Sequence > emojiCell.Sequence, "Overwrite should have higher sequence than original emoji");
 
         TestCaptureHelper.Capture(test.Terminal, "sequence-ordering");
     }

--- a/tests/Hex1b.Tests/EraseScrollbackTests.cs
+++ b/tests/Hex1b.Tests/EraseScrollbackTests.cs
@@ -8,6 +8,7 @@ namespace Hex1b.Tests;
 /// and that it differs from CSI 2J which only clears the visible screen.
 /// Inspired by psmux's squelch signal tests for CSI 2J/3J discrimination.
 /// </summary>
+[TestClass]
 public class EraseScrollbackTests
 {
     private sealed class TestTerminal : IDisposable
@@ -40,7 +41,7 @@ public class EraseScrollbackTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Ed3_ClearsScrollback()
     {
         using var t = new TestTerminal(width: 40, height: 5);
@@ -51,18 +52,17 @@ public class EraseScrollbackTests
 
         // Verify scrollback has content
         var snapBefore = t.Terminal.CreateSnapshot(scrollbackLines: 100);
-        Assert.True(snapBefore.ScrollbackLineCount > 0,
-            "Should have scrollback lines before CSI 3J");
+        Assert.IsTrue(snapBefore.ScrollbackLineCount > 0, "Should have scrollback lines before CSI 3J");
 
         // CSI 3J — erase scrollback
         t.Write("\x1b[3J");
 
         // Scrollback should be cleared
         var snapAfter = t.Terminal.CreateSnapshot(scrollbackLines: 100);
-        Assert.Equal(0, snapAfter.ScrollbackLineCount);
+        Assert.AreEqual(0, snapAfter.ScrollbackLineCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void Ed2_DoesNotClearScrollback()
     {
         using var t = new TestTerminal(width: 40, height: 5);
@@ -73,18 +73,17 @@ public class EraseScrollbackTests
 
         var snapBefore = t.Terminal.CreateSnapshot(scrollbackLines: 100);
         var scrollbackBefore = snapBefore.ScrollbackLineCount;
-        Assert.True(scrollbackBefore > 0);
+        Assert.IsTrue(scrollbackBefore > 0);
 
         // CSI 2J — erase visible screen only
         t.Write("\x1b[2J");
 
         // Scrollback should NOT be cleared
         var snapAfter = t.Terminal.CreateSnapshot(scrollbackLines: 100);
-        Assert.True(snapAfter.ScrollbackLineCount > 0,
-            "CSI 2J should not clear scrollback");
+        Assert.IsTrue(snapAfter.ScrollbackLineCount > 0, "CSI 2J should not clear scrollback");
     }
 
-    [Fact]
+    [TestMethod]
     public void Ed3_PreservesCursorPosition()
     {
         using var t = new TestTerminal(width: 40, height: 5);
@@ -106,11 +105,11 @@ public class EraseScrollbackTests
 
         // Cursor should be preserved
         var snapAfter = t.Terminal.CreateSnapshot();
-        Assert.Equal(cursorXBefore, snapAfter.CursorX);
-        Assert.Equal(cursorYBefore, snapAfter.CursorY);
+        Assert.AreEqual(cursorXBefore, snapAfter.CursorX);
+        Assert.AreEqual(cursorYBefore, snapAfter.CursorY);
     }
 
-    [Fact]
+    [TestMethod]
     public void Ed3_CombinedWithEd2_ClearsBothScreenAndScrollback()
     {
         using var t = new TestTerminal(width: 40, height: 5);
@@ -119,12 +118,12 @@ public class EraseScrollbackTests
         for (int i = 0; i < 10; i++)
             t.Write($"Line {i}\n");
 
-        Assert.True(t.Terminal.CreateSnapshot(scrollbackLines: 100).ScrollbackLineCount > 0);
+        Assert.IsTrue(t.Terminal.CreateSnapshot(scrollbackLines: 100).ScrollbackLineCount > 0);
 
         // CSI 2J + CSI 3J — clear both visible screen and scrollback
         t.Write("\x1b[2J\x1b[3J");
 
         var snap = t.Terminal.CreateSnapshot(scrollbackLines: 100);
-        Assert.Equal(0, snap.ScrollbackLineCount);
+        Assert.AreEqual(0, snap.ScrollbackLineCount);
     }
 }

--- a/tests/Hex1b.Tests/FigletConformanceTests.cs
+++ b/tests/Hex1b.Tests/FigletConformanceTests.cs
@@ -15,6 +15,7 @@ namespace Hex1b.Tests;
 /// Expected outputs are derived from the FIGfont 2.0 spec (<c>docs/figfont.txt</c>), not from
 /// any reference implementation.
 /// </summary>
+[TestClass]
 public class FigletConformanceTests
 {
     // ----- Helpers ----------------------------------------------------------------------
@@ -117,7 +118,7 @@ public class FigletConformanceTests
 
     // ----- old_layout / full_layout precedence -----------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Layout_FullLayoutOverridesOldLayout()
     {
         // old_layout=-1 (full width); full_layout=128 (smushing, no rules → universal).
@@ -133,10 +134,10 @@ public class FigletConformanceTests
         var lines = Render(font, "AB");
         // With universal smushing: A's last 'A' meets B's first 'B' → right wins → 'B'.
         // Block: "ABB" (3 cols).
-        Assert.Equal("ABB", lines[0]);
+        Assert.AreEqual("ABB", lines[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Layout_OldLayoutMinus1_FullWidthWhenNoFullLayout()
     {
         var flf = BuildFlf('$', 1, oldLayout: -1, fullLayout: null, new Dictionary<int, string[]>
@@ -147,10 +148,10 @@ public class FigletConformanceTests
         var font = LoadFlf(flf);
 
         var lines = Render(font, "AB");
-        Assert.Equal("AABB", lines[0]); // no overlap
+        Assert.AreEqual("AABB", lines[0]); // no overlap
     }
 
-    [Fact]
+    [TestMethod]
     public void Layout_OldLayout0_FittingWhenNoFullLayout()
     {
         var flf = BuildFlf('$', 1, oldLayout: 0, fullLayout: null, new Dictionary<int, string[]>
@@ -163,10 +164,10 @@ public class FigletConformanceTests
         // Trailing blanks of " A " = 1; leading blanks of " B " = 1; fitted = 2.
         var lines = Render(font, "AB");
         // " A " + " B " with 2 overlap → " AB " → trim trailing → " AB"
-        Assert.Equal(" AB", lines[0]);
+        Assert.AreEqual(" AB", lines[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Layout_OldLayoutPositive_SmushingWithThoseRules()
     {
         // old_layout=1 → smushing enabled with horizontal rule 1 (equal char).
@@ -178,12 +179,12 @@ public class FigletConformanceTests
 
         // "AA": first 'A' glyph "AA" then second; smushed +1: 'A' vs 'A' → rule 1 → 'A'.
         var lines = Render(font, "AA");
-        Assert.Equal("AAA", lines[0]);
+        Assert.AreEqual("AAA", lines[0]);
     }
 
     // ----- Universal smushing edge cases ----------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Universal_VisibleVsHardblank_Rejects()
     {
         // Smushing flag set (full_layout=128), no rules → universal.
@@ -197,10 +198,10 @@ public class FigletConformanceTests
 
         // Try +1: 'A' vs '$' → reject. Backoff to fitted=0. Block: "AA$B$" → " B" after strips.
         var lines = Render(font, "AB");
-        Assert.Equal("AA B", lines[0]);
+        Assert.AreEqual("AA B", lines[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Universal_HardblankVsHardblank_Smushes()
     {
         var flf = BuildFlf('$', 1, oldLayout: 0, fullLayout: 128, new Dictionary<int, string[]>
@@ -212,12 +213,12 @@ public class FigletConformanceTests
 
         // Smushed +1: '$' vs '$' → hardblank. Block: "A$B" → "A B".
         var lines = Render(font, "AB");
-        Assert.Equal("A B", lines[0]);
+        Assert.AreEqual("A B", lines[0]);
     }
 
     // ----- Per-rule conformance --------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Rule1_EqualChar_Smushes()
     {
         // full_layout = smushing (128) + rule 1 (1) = 129.
@@ -228,10 +229,10 @@ public class FigletConformanceTests
         var font = LoadFlf(flf);
 
         var lines = Render(font, "AA");
-        Assert.Equal("AAA", lines[0]);
+        Assert.AreEqual("AAA", lines[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Rule2_Underscore_SmushesWithBracketingChars()
     {
         // full_layout = smushing (128) + rule 2 (2) = 130.
@@ -244,10 +245,10 @@ public class FigletConformanceTests
 
         // Smushed +1: '_' vs '|' → rule 2 → '|'. Block: "A|B".
         var lines = Render(font, "AB");
-        Assert.Equal("A|B", lines[0]);
+        Assert.AreEqual("A|B", lines[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Rule6_Hardblank_SmushesTwoHardblanks()
     {
         // full_layout = smushing (128) + rule 6 (32) = 160. ONLY rule 6, no other rules → 
@@ -260,12 +261,12 @@ public class FigletConformanceTests
         var font = LoadFlf(flf);
 
         var lines = Render(font, "AB");
-        Assert.Equal("A B", lines[0]);
+        Assert.AreEqual("A B", lines[0]);
     }
 
     // ----- Code tag parsing -----------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void CodeTag_Decimal_LoadsExtendedGlyph()
     {
         var flf = BuildFlf('$', 1, oldLayout: 0, fullLayout: null, new Dictionary<int, string[]>
@@ -274,11 +275,11 @@ public class FigletConformanceTests
         });
         var font = LoadFlf(flf);
 
-        Assert.True(font.TryGetGlyph(0x2603, out var glyph));
-        Assert.Equal(1, glyph.Width);
+        Assert.IsTrue(font.TryGetGlyph(0x2603, out var glyph));
+        Assert.AreEqual(1, glyph.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void CodeTag_NegativeOne_IsRejected()
     {
         // -1 is the FIGfont reserved "missing" tag; the parser must reject it as illegal data.
@@ -286,12 +287,12 @@ public class FigletConformanceTests
         var flf = BuildFlf('$', 1, oldLayout: 0, fullLayout: null, new Dictionary<int, string[]>())
             + "-1\n*@\n*@@\n";
 
-        Assert.Throws<FigletFontFormatException>(() => LoadFlf(flf));
+        Assert.ThrowsExactly<FigletFontFormatException>(() => LoadFlf(flf));
     }
 
     // ----- Hardblank rendering --------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Render_OutputDoesNotContainHardblanks()
     {
         var flf = BuildFlf('$', 1, oldLayout: -1, fullLayout: null, new Dictionary<int, string[]>
@@ -306,7 +307,7 @@ public class FigletConformanceTests
 
     // ----- German block --------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void GermanBlock_AllSevenAreLoaded()
     {
         var flf = BuildFlf('$', 1, oldLayout: 0, fullLayout: null, new Dictionary<int, string[]>
@@ -323,7 +324,7 @@ public class FigletConformanceTests
 
         foreach (var cp in new[] { 196, 214, 220, 228, 246, 252, 223 })
         {
-            Assert.True(font.TryGetGlyph(cp, out _), $"Missing glyph for U+{cp:X4}.");
+            Assert.IsTrue(font.TryGetGlyph(cp, out _), $"Missing glyph for U+{cp:X4}.");
         }
     }
 }

--- a/tests/Hex1b.Tests/FigletFontParserTests.cs
+++ b/tests/Hex1b.Tests/FigletFontParserTests.cs
@@ -6,6 +6,7 @@ namespace Hex1b.Tests;
 /// Tests for the internal FIGfont (.flf) parser. Verifies header parsing, comment handling,
 /// FIGcharacter data, hardblank/endmark handling, and code-tag parsing.
 /// </summary>
+[TestClass]
 public class FigletFontParserTests
 {
     // ----- Helpers ---------------------------------------------------------------------
@@ -66,90 +67,90 @@ public class FigletFontParserTests
 
     // ----- Header parsing --------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Parse_RejectsMissingMagic()
     {
-        var ex = Assert.Throws<FigletFontFormatException>(() => FigletFont.Parse("nope$ 1 1 4 0 0\n##@@\n"));
+        var ex = Assert.ThrowsExactly<FigletFontFormatException>(() => FigletFont.Parse("nope$ 1 1 4 0 0\n##@@\n"));
         Assert.Contains("flf2a", ex.Message);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_RejectsTooFewHeaderFields()
     {
-        var ex = Assert.Throws<FigletFontFormatException>(() => FigletFont.Parse("flf2a$ 1 1 4\n##@@\n"));
+        var ex = Assert.ThrowsExactly<FigletFontFormatException>(() => FigletFont.Parse("flf2a$ 1 1 4\n##@@\n"));
         Assert.Contains("at least 5", ex.Message);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_RejectsZeroHeight()
     {
-        var ex = Assert.Throws<FigletFontFormatException>(() => FigletFont.Parse("flf2a$ 0 1 4 0 0\n##@@\n"));
+        var ex = Assert.ThrowsExactly<FigletFontFormatException>(() => FigletFont.Parse("flf2a$ 0 1 4 0 0\n##@@\n"));
         Assert.Contains("height", ex.Message);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_RejectsBaselineGreaterThanHeight()
     {
-        var ex = Assert.Throws<FigletFontFormatException>(() => FigletFont.Parse("flf2a$ 3 4 4 0 0\n##@@\n"));
+        var ex = Assert.ThrowsExactly<FigletFontFormatException>(() => FigletFont.Parse("flf2a$ 3 4 4 0 0\n##@@\n"));
         Assert.Contains("baseline", ex.Message);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_AcceptsAllOptionalHeaderFields()
     {
         var content = MinimalFont(headerExtras: "0 24463 102");
         var font = FigletFont.Parse(content);
-        Assert.Equal(1, font.Height);
-        Assert.Equal(1, font.Baseline);
-        Assert.Equal('$', font.Hardblank);
+        Assert.AreEqual(1, font.Height);
+        Assert.AreEqual(1, font.Baseline);
+        Assert.AreEqual('$', font.Hardblank);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_UsesHardblankFromHeader()
     {
         var content = MinimalFont();
         var font = FigletFont.Parse(content);
-        Assert.Equal('$', font.Hardblank);
+        Assert.AreEqual('$', font.Hardblank);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_NonStandardHardblank_IsHonored()
     {
         var content = "flf2a! 1 1 4 0 0\n" + string.Join("\n", System.Linq.Enumerable.Repeat("##@@", 102)) + "\n";
         var font = FigletFont.Parse(content);
-        Assert.Equal('!', font.Hardblank);
+        Assert.AreEqual('!', font.Hardblank);
     }
 
     // ----- Comment block ---------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Parse_SkipsCommentLines()
     {
         var content = "flf2a$ 1 1 4 0 3\nfont author\nlicense\nmore comments\n"
             + string.Join("\n", System.Linq.Enumerable.Repeat("##@@", 102)) + "\n";
         var font = FigletFont.Parse(content);
-        Assert.True(font.TryGetGlyph(' ', out _));
+        Assert.IsTrue(font.TryGetGlyph(' ', out _));
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_FailsWhenCommentBlockTruncated()
     {
         var content = "flf2a$ 1 1 4 0 5\ncomment1\ncomment2\n";
-        Assert.Throws<FigletFontFormatException>(() => FigletFont.Parse(content));
+        Assert.ThrowsExactly<FigletFontFormatException>(() => FigletFont.Parse(content));
     }
 
     // ----- Endmarks --------------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Parse_StripsTrailingEndmarks()
     {
         var content = "flf2a$ 1 1 4 0 0\n" + string.Join("\n", System.Linq.Enumerable.Repeat("##@@", 102)) + "\n";
         var font = FigletFont.Parse(content);
-        Assert.True(font.TryGetGlyph('!', out var glyph));
-        Assert.Equal("##", glyph.GetRow(0));
+        Assert.IsTrue(font.TryGetGlyph('!', out var glyph));
+        Assert.AreEqual("##", glyph.GetRow(0));
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_AllowsDifferentEndmarkPerRow()
     {
         // Height 2; first row uses '@', second uses '#' (which becomes endmark).
@@ -161,141 +162,141 @@ public class FigletFontParserTests
             sb.AppendLine("cd##");
         }
         var font = FigletFont.Parse(sb.ToString());
-        Assert.True(font.TryGetGlyph('!', out var glyph));
-        Assert.Equal(2, glyph.Height);
-        Assert.Equal("ab", glyph.GetRow(0));
-        Assert.Equal("cd", glyph.GetRow(1));
+        Assert.IsTrue(font.TryGetGlyph('!', out var glyph));
+        Assert.AreEqual(2, glyph.Height);
+        Assert.AreEqual("ab", glyph.GetRow(0));
+        Assert.AreEqual("cd", glyph.GetRow(1));
     }
 
     // ----- Required glyphs -------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Parse_FailsWhenRequiredGlyphsMissing()
     {
         // Only 50 glyphs.
         var content = "flf2a$ 1 1 4 0 0\n" + string.Join("\n", System.Linq.Enumerable.Repeat("##@@", 50)) + "\n";
-        Assert.Throws<FigletFontFormatException>(() => FigletFont.Parse(content));
+        Assert.ThrowsExactly<FigletFontFormatException>(() => FigletFont.Parse(content));
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_StoresGermanBlockAtCorrectCodePoints()
     {
         var content = MinimalFont();
         var font = FigletFont.Parse(content);
-        Assert.True(font.TryGetGlyph(196, out _)); // Ä
-        Assert.True(font.TryGetGlyph(214, out _)); // Ö
-        Assert.True(font.TryGetGlyph(220, out _)); // Ü
-        Assert.True(font.TryGetGlyph(228, out _)); // ä
-        Assert.True(font.TryGetGlyph(246, out _)); // ö
-        Assert.True(font.TryGetGlyph(252, out _)); // ü
-        Assert.True(font.TryGetGlyph(223, out _)); // ß
+        Assert.IsTrue(font.TryGetGlyph(196, out _)); // Ä
+        Assert.IsTrue(font.TryGetGlyph(214, out _)); // Ö
+        Assert.IsTrue(font.TryGetGlyph(220, out _)); // Ü
+        Assert.IsTrue(font.TryGetGlyph(228, out _)); // ä
+        Assert.IsTrue(font.TryGetGlyph(246, out _)); // ö
+        Assert.IsTrue(font.TryGetGlyph(252, out _)); // ü
+        Assert.IsTrue(font.TryGetGlyph(223, out _)); // ß
     }
 
     // ----- Code tags --------------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Parse_AcceptsDecimalCodeTag()
     {
         var content = MinimalFont() + "256  EXTRA\n@@\n";
         // Wait — the glyph data row needs the right shape. Header height=1 so just one row.
         var fixed_ = MinimalFont() + "256  EXTRA\nXX@@\n";
         var font = FigletFont.Parse(fixed_);
-        Assert.True(font.TryGetGlyph(256, out var g));
-        Assert.Equal("XX", g.GetRow(0));
+        Assert.IsTrue(font.TryGetGlyph(256, out var g));
+        Assert.AreEqual("XX", g.GetRow(0));
         _ = content;
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_AcceptsHexCodeTag()
     {
         var content = MinimalFont() + "0x100  EXTRA\nYY@@\n";
         var font = FigletFont.Parse(content);
-        Assert.True(font.TryGetGlyph(0x100, out var g));
-        Assert.Equal("YY", g.GetRow(0));
+        Assert.IsTrue(font.TryGetGlyph(0x100, out var g));
+        Assert.AreEqual("YY", g.GetRow(0));
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_AcceptsOctalCodeTag()
     {
         var content = MinimalFont() + "0400  EXTRA\nZZ@@\n";
         var font = FigletFont.Parse(content);
-        Assert.True(font.TryGetGlyph(256, out var g));
-        Assert.Equal("ZZ", g.GetRow(0));
+        Assert.IsTrue(font.TryGetGlyph(256, out var g));
+        Assert.AreEqual("ZZ", g.GetRow(0));
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_SkipsNegativeCodeTags()
     {
         var content = MinimalFont() + "-2  TAG\nQQ@@\n";
         var font = FigletFont.Parse(content);
-        Assert.False(font.TryGetGlyph(-2, out _));
+        Assert.IsFalse(font.TryGetGlyph(-2, out _));
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_RejectsCodeTagMinusOne()
     {
         var content = MinimalFont() + "-1  forbidden\nXX@@\n";
-        Assert.Throws<FigletFontFormatException>(() => FigletFont.Parse(content));
+        Assert.ThrowsExactly<FigletFontFormatException>(() => FigletFont.Parse(content));
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_HonorsLastDuplicateCodeTag()
     {
         // Spec: "If two or more FIGcharacters have the same character code, the last one wins."
         var content = MinimalFont() + "256\nFIRST@@\n256\nSECOND@@\n";
         var font = FigletFont.Parse(content);
-        Assert.True(font.TryGetGlyph(256, out var g));
-        Assert.Equal("SECOND", g.GetRow(0));
+        Assert.IsTrue(font.TryGetGlyph(256, out var g));
+        Assert.AreEqual("SECOND", g.GetRow(0));
     }
 
     // ----- Layout resolution -----------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Parse_OldLayoutMinusOne_FullWidth()
     {
         var content = "flf2a$ 1 1 4 -1 0\n" + string.Join("\n", System.Linq.Enumerable.Repeat("##@@", 102)) + "\n";
         var font = FigletFont.Parse(content);
-        Assert.False(font.HorizontalSmushing);
-        Assert.False(font.HorizontalFitting);
-        Assert.Equal(0, font.HorizontalSmushingRules);
+        Assert.IsFalse(font.HorizontalSmushing);
+        Assert.IsFalse(font.HorizontalFitting);
+        Assert.AreEqual(0, font.HorizontalSmushingRules);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_OldLayoutZero_Fitting()
     {
         var content = MinimalFont();
         var font = FigletFont.Parse(content);
-        Assert.True(font.HorizontalFitting);
-        Assert.False(font.HorizontalSmushing);
+        Assert.IsTrue(font.HorizontalFitting);
+        Assert.IsFalse(font.HorizontalSmushing);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_OldLayoutPositive_ControlledSmushing()
     {
         var content = "flf2a$ 1 1 4 15 0\n" + string.Join("\n", System.Linq.Enumerable.Repeat("##@@", 102)) + "\n";
         var font = FigletFont.Parse(content);
-        Assert.True(font.HorizontalSmushing);
-        Assert.Equal(15, font.HorizontalSmushingRules);
+        Assert.IsTrue(font.HorizontalSmushing);
+        Assert.AreEqual(15, font.HorizontalSmushingRules);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_FullLayout_OverridesOldLayout()
     {
         // old_layout=0 (fitting), full_layout=24463 = 128|64|... ⇒ smushing
         var content = "flf2a$ 1 1 4 0 0 0 24463\n" + string.Join("\n", System.Linq.Enumerable.Repeat("##@@", 102)) + "\n";
         var font = FigletFont.Parse(content);
-        Assert.True(font.HorizontalSmushing);
-        Assert.Equal(24463 & 0x3F, font.HorizontalSmushingRules);
+        Assert.IsTrue(font.HorizontalSmushing);
+        Assert.AreEqual(24463 & 0x3F, font.HorizontalSmushingRules);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_FullLayout_VerticalFlags()
     {
         // 16384 = vertical smushing default; 256 = vertical rule 1
         var fullLayout = 16384 + 256;
         var content = $"flf2a$ 1 1 4 -1 0 0 {fullLayout}\n" + string.Join("\n", System.Linq.Enumerable.Repeat("##@@", 102)) + "\n";
         var font = FigletFont.Parse(content);
-        Assert.True(font.VerticalSmushing);
-        Assert.Equal(1, font.VerticalSmushingRules);
+        Assert.IsTrue(font.VerticalSmushing);
+        Assert.AreEqual(1, font.VerticalSmushingRules);
     }
 }

--- a/tests/Hex1b.Tests/FigletFontsCatalogTests.cs
+++ b/tests/Hex1b.Tests/FigletFontsCatalogTests.cs
@@ -6,75 +6,76 @@ namespace Hex1b.Tests;
 /// Smoke tests for the bundled fonts on <see cref="FigletFonts"/>. Verifies each can be loaded
 /// from the embedded resource without errors and contains the required 102 FIGcharacters.
 /// </summary>
+[TestClass]
 public class FigletFontsCatalogTests
 {
-    [Theory]
-    [InlineData("standard")]
-    [InlineData("slant")]
-    [InlineData("small")]
-    [InlineData("big")]
-    [InlineData("mini")]
-    [InlineData("shadow")]
-    [InlineData("block")]
-    [InlineData("banner")]
+    [TestMethod]
+    [DataRow("standard")]
+    [DataRow("slant")]
+    [DataRow("small")]
+    [DataRow("big")]
+    [DataRow("mini")]
+    [DataRow("shadow")]
+    [DataRow("block")]
+    [DataRow("banner")]
     public void LoadBundled_AllNames_Succeeds(string name)
     {
         var font = FigletFont.LoadBundled(name);
-        Assert.NotNull(font);
-        Assert.True(font.Height >= 1);
+        Assert.IsNotNull(font);
+        Assert.IsTrue(font.Height >= 1);
     }
 
-    [Theory]
-    [InlineData("standard")]
-    [InlineData("slant")]
-    [InlineData("small")]
-    [InlineData("big")]
-    [InlineData("mini")]
-    [InlineData("shadow")]
-    [InlineData("block")]
-    [InlineData("banner")]
+    [TestMethod]
+    [DataRow("standard")]
+    [DataRow("slant")]
+    [DataRow("small")]
+    [DataRow("big")]
+    [DataRow("mini")]
+    [DataRow("shadow")]
+    [DataRow("block")]
+    [DataRow("banner")]
     public void LoadBundled_HasAllRequiredGlyphs(string name)
     {
         var font = FigletFont.LoadBundled(name);
         for (var c = 32; c <= 126; c++)
         {
-            Assert.True(font.TryGetGlyph(c, out _), $"{name} missing ASCII {c}");
+            Assert.IsTrue(font.TryGetGlyph(c, out _), $"{name} missing ASCII {c}");
         }
         foreach (var c in new[] { 196, 214, 220, 228, 246, 252, 223 })
         {
-            Assert.True(font.TryGetGlyph(c, out _), $"{name} missing German block char {c}");
+            Assert.IsTrue(font.TryGetGlyph(c, out _), $"{name} missing German block char {c}");
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void FigletFonts_All_LoadsEveryBundledFont()
     {
         var all = FigletFonts.All;
-        Assert.Equal(8, all.Count);
+        Assert.AreEqual(8, all.Count);
         foreach (var f in all)
         {
-            Assert.NotNull(f);
+            Assert.IsNotNull(f);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void FigletFonts_Standard_ReturnsSameInstanceOnRepeatedAccess()
     {
         var a = FigletFonts.Standard;
         var b = FigletFonts.Standard;
-        Assert.Same(a, b);
+        Assert.AreSame(a, b);
     }
 
-    [Fact]
+    [TestMethod]
     public void LoadBundled_UnknownName_Throws()
     {
-        Assert.Throws<ArgumentException>(() => FigletFont.LoadBundled("does-not-exist"));
+        Assert.ThrowsExactly<ArgumentException>(() => FigletFont.LoadBundled("does-not-exist"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LoadBundledAsync_StandardLoads()
     {
         var font = await FigletFont.LoadBundledAsync("standard", TestContext.Current.CancellationToken);
-        Assert.NotNull(font);
+        Assert.IsNotNull(font);
     }
 }

--- a/tests/Hex1b.Tests/FigletRendererTests.cs
+++ b/tests/Hex1b.Tests/FigletRendererTests.cs
@@ -7,6 +7,7 @@ namespace Hex1b.Tests;
 /// hand-crafted single-row synthetic fonts. By keeping the fonts tiny we can read the expected
 /// outputs straight off the page and assert byte-for-byte.
 /// </summary>
+[TestClass]
 public class FigletRendererTests
 {
     private const char Hb = '$';
@@ -106,41 +107,41 @@ public class FigletRendererTests
 
     // ----- Empty / single-glyph behavior ------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Render_EmptyText_ProducesEmptyRowsAtFontHeight()
     {
         var font = new StampFont(0, false, false);
         var lines = FigletRenderer.Render("", font, FigletLayoutMode.Default, FigletLayoutMode.Default,
             FigletHorizontalOverflow.Clip, int.MaxValue);
 
-        Assert.Equal(font.Height, lines.Count);
-        foreach (var l in lines) Assert.Equal(string.Empty, l);
+        Assert.AreEqual(font.Height, lines.Count);
+        foreach (var l in lines) Assert.AreEqual(string.Empty, l);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_SingleCharacter_ReturnsThatGlyph()
     {
         var font = new StampFont(0, false, false);
         var lines = FigletRenderer.Render("A", font, FigletLayoutMode.Default, FigletLayoutMode.Default,
             FigletHorizontalOverflow.Clip, int.MaxValue);
 
-        Assert.Single(lines);
-        Assert.Equal("A A", lines[0]);
+        TestSeq.Single(lines);
+        Assert.AreEqual("A A", lines[0]);
     }
 
     // ----- Horizontal layout modes ------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Render_FullWidth_NoOverlap()
     {
         var font = new StampFont(0, false, false);
         var lines = FigletRenderer.Render("AB", font, FigletLayoutMode.FullWidth, FigletLayoutMode.Default,
             FigletHorizontalOverflow.Clip, int.MaxValue);
 
-        Assert.Equal("A AB B", lines[0]);
+        Assert.AreEqual("A AB B", lines[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_Fitted_OverlapAtBoundaryBlanks()
     {
         // Each glyph is "X X" (3 wide, trailing & leading 0 visible chars but middle blank).
@@ -149,10 +150,10 @@ public class FigletRendererTests
         var lines = FigletRenderer.Render("AB", font, FigletLayoutMode.Fitted, FigletLayoutMode.Default,
             FigletHorizontalOverflow.Clip, int.MaxValue);
 
-        Assert.Equal("A AB B", lines[0]);
+        Assert.AreEqual("A AB B", lines[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_Fitted_WithLeadingBlankInGlyph_OverlapsByOne()
     {
         // Letters use ".X." pattern (space-letter-space). Trailing blanks of " A " = 1; leading
@@ -161,10 +162,10 @@ public class FigletRendererTests
         var lines = FigletRenderer.Render("AB", font, FigletLayoutMode.Fitted, FigletLayoutMode.Default,
             FigletHorizontalOverflow.Clip, int.MaxValue);
 
-        Assert.Equal(" AB", lines[0]);
+        Assert.AreEqual(" AB", lines[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_Smushed_UniversalRightWins()
     {
         // No leading/trailing blanks ("XYX") so fitted = 0. Smushed = +1: A's 'A' vs B's 'B' →
@@ -175,10 +176,10 @@ public class FigletRendererTests
         var lines = FigletRenderer.Render("AB", font, FigletLayoutMode.Smushed, FigletLayoutMode.Default,
             FigletHorizontalOverflow.Clip, int.MaxValue);
 
-        Assert.Equal("AABBB", lines[0]);
+        Assert.AreEqual("AABBB", lines[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_Smushed_HardblankProtectsColumn()
     {
         // Glyph A = "AA", glyph B = "$B$". After A: block = "AA". With B:
@@ -199,10 +200,10 @@ public class FigletRendererTests
         var lines = FigletRenderer.Render("AB", font, FigletLayoutMode.Smushed, FigletLayoutMode.Default,
             FigletHorizontalOverflow.Clip, int.MaxValue);
 
-        Assert.Equal("AA B", lines[0]);
+        Assert.AreEqual("AA B", lines[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_Smushed_HardblankBoth_KeepsHardblank()
     {
         // Glyph A = "A$", glyph B = "$B". Smushed +1: '$' vs '$' → both hardblanks (universal) →
@@ -220,10 +221,10 @@ public class FigletRendererTests
         var lines = FigletRenderer.Render("AB", font, FigletLayoutMode.Smushed, FigletLayoutMode.Default,
             FigletHorizontalOverflow.Clip, int.MaxValue);
 
-        Assert.Equal("A B", lines[0]);
+        Assert.AreEqual("A B", lines[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_Smushed_ControlledRule1_EqualCharSmushes()
     {
         // Glyph A = "AA" (no spaces), so for "AA" input: trailing blanks = 0, leading blanks = 0
@@ -240,10 +241,10 @@ public class FigletRendererTests
         var lines = FigletRenderer.Render("AA", font, FigletLayoutMode.Smushed, FigletLayoutMode.Default,
             FigletHorizontalOverflow.Clip, int.MaxValue);
 
-        Assert.Equal("AAA", lines[0]);
+        Assert.AreEqual("AAA", lines[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_Default_PrefersFontFlags()
     {
         // Font opts in to fitting only; Default should resolve to Fitted.
@@ -252,10 +253,10 @@ public class FigletRendererTests
             FigletHorizontalOverflow.Clip, int.MaxValue);
 
         // .A. .B. fitted by 2 → " AB"
-        Assert.Equal(" AB", lines[0]);
+        Assert.AreEqual(" AB", lines[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_Default_NoFlags_FallsBackToFullWidth()
     {
         // Font has neither smushing nor fitting → full width.
@@ -264,12 +265,12 @@ public class FigletRendererTests
             FigletHorizontalOverflow.Clip, int.MaxValue);
 
         // " A " + " B " concatenated, trailing trimmed → " A  B"
-        Assert.Equal(" A  B", lines[0]);
+        Assert.AreEqual(" A  B", lines[0]);
     }
 
     // ----- Hard line breaks (\n) --------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Render_HardNewline_StacksBlocksVertically()
     {
         var font = new StripeFont(height: 2);
@@ -277,16 +278,16 @@ public class FigletRendererTests
             FigletHorizontalOverflow.Clip, int.MaxValue);
 
         // Two paragraphs of height 2, full vertical width, no overlap → 4 rows.
-        Assert.Equal(4, lines.Count);
-        Assert.Equal("A", lines[0]);
-        Assert.Equal("A", lines[1]);
-        Assert.Equal("B", lines[2]);
-        Assert.Equal("B", lines[3]);
+        Assert.AreEqual(4, lines.Count);
+        Assert.AreEqual("A", lines[0]);
+        Assert.AreEqual("A", lines[1]);
+        Assert.AreEqual("B", lines[2]);
+        Assert.AreEqual("B", lines[3]);
     }
 
     // ----- Word wrap --------------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Render_Wrap_BreaksOnSpacesWhenWidthExceeded()
     {
         // Each letter renders to "X" (1 wide). Each rendered word is letterCount columns; no
@@ -296,12 +297,12 @@ public class FigletRendererTests
             FigletHorizontalOverflow.Wrap, wrapWidth: 3);
 
         // Height=1 per paragraph, two paragraphs → 2 lines.
-        Assert.Equal(2, lines.Count);
-        Assert.Equal("AB", lines[0]);
-        Assert.Equal("CD", lines[1]);
+        Assert.AreEqual(2, lines.Count);
+        Assert.AreEqual("AB", lines[0]);
+        Assert.AreEqual("CD", lines[1]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_Wrap_LongWord_BreaksAtCharacters()
     {
         var font = new StampFont(0, false, false, letterPattern: "X");
@@ -309,23 +310,23 @@ public class FigletRendererTests
             FigletHorizontalOverflow.Wrap, wrapWidth: 3);
 
         // Single word longer than wrapWidth → broken at char boundaries: "ABC" (3 wide) + "DE" (2 wide).
-        Assert.Equal(2, lines.Count);
-        Assert.Equal("ABC", lines[0]);
-        Assert.Equal("DE", lines[1]);
+        Assert.AreEqual(2, lines.Count);
+        Assert.AreEqual("ABC", lines[0]);
+        Assert.AreEqual("DE", lines[1]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_Wrap_InfiniteWidth_NoOpsToClipBehavior()
     {
         var font = new StampFont(0, false, false, letterPattern: "X");
         var lines = FigletRenderer.Render("AB CD", font, FigletLayoutMode.FullWidth, FigletLayoutMode.FullWidth,
             FigletHorizontalOverflow.Wrap, wrapWidth: int.MaxValue);
 
-        Assert.Single(lines);
-        Assert.Equal("AB CD", lines[0]);
+        TestSeq.Single(lines);
+        Assert.AreEqual("AB CD", lines[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_Wrap_StacksParagraphsWithoutVerticalSmushing()
     {
         // Stripe font: two-row glyph "X"/"X" with smushable rows. If wrap-induced paragraph
@@ -338,28 +339,28 @@ public class FigletRendererTests
             FigletHorizontalOverflow.Wrap, wrapWidth: 3);
 
         // 2 paragraphs × 2 rows each = 4 rows, no smushing collapse.
-        Assert.Equal(4, lines.Count);
-        Assert.Equal("AB", lines[0]);
-        Assert.Equal("AB", lines[1]);
-        Assert.Equal("CD", lines[2]);
-        Assert.Equal("CD", lines[3]);
+        Assert.AreEqual(4, lines.Count);
+        Assert.AreEqual("AB", lines[0]);
+        Assert.AreEqual("AB", lines[1]);
+        Assert.AreEqual("CD", lines[2]);
+        Assert.AreEqual("CD", lines[3]);
     }
 
     // ----- Vertical layout --------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Render_VerticalFullWidth_StacksWithoutOverlap()
     {
         var font = new StripeFont(height: 2, vRules: 0, vSmush: false, vFit: false);
         var lines = FigletRenderer.Render("A\nB", font, FigletLayoutMode.Default,
             FigletLayoutMode.FullWidth, FigletHorizontalOverflow.Clip, int.MaxValue);
 
-        Assert.Equal(4, lines.Count);
+        Assert.AreEqual(4, lines.Count);
     }
 
     // ----- Hardblanks disappear from output ---------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Render_OutputContainsNoHardblanks()
     {
         var font = new SyntheticFont(
@@ -375,7 +376,7 @@ public class FigletRendererTests
             FigletHorizontalOverflow.Clip, int.MaxValue);
 
         Assert.DoesNotContain('$', lines[0]);
-        Assert.Equal(" A", lines[0]); // " A$" trimmed of trailing blanks (incl. the hardblank-as-space)
+        Assert.AreEqual(" A", lines[0]); // " A$" trimmed of trailing blanks (incl. the hardblank-as-space)
     }
 
     // ----- Helper: synthetic font with explicit glyph table -----------------------------

--- a/tests/Hex1b.Tests/FigletSmushingRulesTests.cs
+++ b/tests/Hex1b.Tests/FigletSmushingRulesTests.cs
@@ -7,185 +7,186 @@ namespace Hex1b.Tests;
 /// with a hand-picked character pair and verifies the produced sub-character matches the FIGfont
 /// 2.0 specification.
 /// </summary>
+[TestClass]
 public class FigletSmushingRulesTests
 {
     private const char Hb = '$';
 
     // ----- Universal smushing (rules == 0) --------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Universal_Blanks_YieldOther()
     {
-        Assert.True(FigletSmushingRules.TrySmushHorizontal(' ', 'A', Hb, 0, out var c));
-        Assert.Equal('A', c);
-        Assert.True(FigletSmushingRules.TrySmushHorizontal('A', ' ', Hb, 0, out c));
-        Assert.Equal('A', c);
+        Assert.IsTrue(FigletSmushingRules.TrySmushHorizontal(' ', 'A', Hb, 0, out var c));
+        Assert.AreEqual('A', c);
+        Assert.IsTrue(FigletSmushingRules.TrySmushHorizontal('A', ' ', Hb, 0, out c));
+        Assert.AreEqual('A', c);
     }
 
-    [Fact]
+    [TestMethod]
     public void Universal_TwoVisibles_RightWins()
     {
-        Assert.True(FigletSmushingRules.TrySmushHorizontal('A', 'B', Hb, 0, out var c));
-        Assert.Equal('B', c);
+        Assert.IsTrue(FigletSmushingRules.TrySmushHorizontal('A', 'B', Hb, 0, out var c));
+        Assert.AreEqual('B', c);
     }
 
-    [Fact]
+    [TestMethod]
     public void Universal_HardblankBoth_KeepsHardblank()
     {
-        Assert.True(FigletSmushingRules.TrySmushHorizontal(Hb, Hb, Hb, 0, out var c));
-        Assert.Equal(Hb, c);
+        Assert.IsTrue(FigletSmushingRules.TrySmushHorizontal(Hb, Hb, Hb, 0, out var c));
+        Assert.AreEqual(Hb, c);
     }
 
-    [Fact]
+    [TestMethod]
     public void Universal_HardblankAndVisible_Rejects()
     {
-        Assert.False(FigletSmushingRules.TrySmushHorizontal(Hb, 'A', Hb, 0, out _));
-        Assert.False(FigletSmushingRules.TrySmushHorizontal('A', Hb, Hb, 0, out _));
+        Assert.IsFalse(FigletSmushingRules.TrySmushHorizontal(Hb, 'A', Hb, 0, out _));
+        Assert.IsFalse(FigletSmushingRules.TrySmushHorizontal('A', Hb, Hb, 0, out _));
     }
 
     // ----- Controlled rule 1: equal character ------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Equal_TwoIdenticalVisibles_Smushes()
     {
-        Assert.True(FigletSmushingRules.TrySmushHorizontal('|', '|', Hb, 1, out var c));
-        Assert.Equal('|', c);
+        Assert.IsTrue(FigletSmushingRules.TrySmushHorizontal('|', '|', Hb, 1, out var c));
+        Assert.AreEqual('|', c);
     }
 
-    [Fact]
+    [TestMethod]
     public void Equal_TwoHardblanks_Rejects_WhenRule6Off()
     {
         // Rule 1 must NOT smush hardblanks (only rule 6 does).
-        Assert.False(FigletSmushingRules.TrySmushHorizontal(Hb, Hb, Hb, 1, out _));
+        Assert.IsFalse(FigletSmushingRules.TrySmushHorizontal(Hb, Hb, Hb, 1, out _));
     }
 
-    [Fact]
+    [TestMethod]
     public void Equal_TwoHardblanks_Smushes_WhenRule6On()
     {
-        Assert.True(FigletSmushingRules.TrySmushHorizontal(Hb, Hb, Hb, 32, out var c));
-        Assert.Equal(Hb, c);
+        Assert.IsTrue(FigletSmushingRules.TrySmushHorizontal(Hb, Hb, Hb, 32, out var c));
+        Assert.AreEqual(Hb, c);
     }
 
     // ----- Controlled rule 2: underscore -----------------------------------------------
 
-    [Theory]
-    [InlineData('|')]
-    [InlineData('/')]
-    [InlineData('\\')]
-    [InlineData('[')]
-    [InlineData(']')]
-    [InlineData('{')]
-    [InlineData('}')]
-    [InlineData('(')]
-    [InlineData(')')]
-    [InlineData('<')]
-    [InlineData('>')]
+    [TestMethod]
+    [DataRow('|')]
+    [DataRow('/')]
+    [DataRow('\\')]
+    [DataRow('[')]
+    [DataRow(']')]
+    [DataRow('{')]
+    [DataRow('}')]
+    [DataRow('(')]
+    [DataRow(')')]
+    [DataRow('<')]
+    [DataRow('>')]
     public void Underscore_ReplacesUnderscoreWithReplacers(char other)
     {
-        Assert.True(FigletSmushingRules.TrySmushHorizontal('_', other, Hb, 2, out var c));
-        Assert.Equal(other, c);
-        Assert.True(FigletSmushingRules.TrySmushHorizontal(other, '_', Hb, 2, out c));
-        Assert.Equal(other, c);
+        Assert.IsTrue(FigletSmushingRules.TrySmushHorizontal('_', other, Hb, 2, out var c));
+        Assert.AreEqual(other, c);
+        Assert.IsTrue(FigletSmushingRules.TrySmushHorizontal(other, '_', Hb, 2, out c));
+        Assert.AreEqual(other, c);
     }
 
-    [Fact]
+    [TestMethod]
     public void Underscore_DoesNotSmush_WithRandomChar()
     {
-        Assert.False(FigletSmushingRules.TrySmushHorizontal('_', 'a', Hb, 2, out _));
+        Assert.IsFalse(FigletSmushingRules.TrySmushHorizontal('_', 'a', Hb, 2, out _));
     }
 
     // ----- Controlled rule 3: hierarchy -----------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Hierarchy_DifferentClasses_HigherWins()
     {
         // |=0, /\=1, []=2, {}=3, ()=4, <>=5
-        Assert.True(FigletSmushingRules.TrySmushHorizontal('|', '/', Hb, 4, out var c));
-        Assert.Equal('/', c);
-        Assert.True(FigletSmushingRules.TrySmushHorizontal('<', '|', Hb, 4, out c));
-        Assert.Equal('<', c);
+        Assert.IsTrue(FigletSmushingRules.TrySmushHorizontal('|', '/', Hb, 4, out var c));
+        Assert.AreEqual('/', c);
+        Assert.IsTrue(FigletSmushingRules.TrySmushHorizontal('<', '|', Hb, 4, out c));
+        Assert.AreEqual('<', c);
     }
 
-    [Fact]
+    [TestMethod]
     public void Hierarchy_SameClass_DoesNotSmush()
     {
-        Assert.False(FigletSmushingRules.TrySmushHorizontal('/', '\\', Hb, 4, out _));
+        Assert.IsFalse(FigletSmushingRules.TrySmushHorizontal('/', '\\', Hb, 4, out _));
     }
 
     // ----- Controlled rule 4: opposite pair --------------------------------------------
 
-    [Theory]
-    [InlineData('[', ']')]
-    [InlineData(']', '[')]
-    [InlineData('{', '}')]
-    [InlineData('}', '{')]
-    [InlineData('(', ')')]
-    [InlineData(')', '(')]
+    [TestMethod]
+    [DataRow('[', ']')]
+    [DataRow(']', '[')]
+    [DataRow('{', '}')]
+    [DataRow('}', '{')]
+    [DataRow('(', ')')]
+    [DataRow(')', '(')]
     public void Opposite_BracesParenBrackets_BecomePipe(char a, char b)
     {
-        Assert.True(FigletSmushingRules.TrySmushHorizontal(a, b, Hb, 8, out var c));
-        Assert.Equal('|', c);
+        Assert.IsTrue(FigletSmushingRules.TrySmushHorizontal(a, b, Hb, 8, out var c));
+        Assert.AreEqual('|', c);
     }
 
     // ----- Controlled rule 5: big X ---------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void BigX_ForwardSlashBackslash_BecomesPipe()
     {
-        Assert.True(FigletSmushingRules.TrySmushHorizontal('/', '\\', Hb, 16, out var c));
-        Assert.Equal('|', c);
+        Assert.IsTrue(FigletSmushingRules.TrySmushHorizontal('/', '\\', Hb, 16, out var c));
+        Assert.AreEqual('|', c);
     }
 
-    [Fact]
+    [TestMethod]
     public void BigX_BackslashForwardSlash_BecomesY()
     {
-        Assert.True(FigletSmushingRules.TrySmushHorizontal('\\', '/', Hb, 16, out var c));
-        Assert.Equal('Y', c);
+        Assert.IsTrue(FigletSmushingRules.TrySmushHorizontal('\\', '/', Hb, 16, out var c));
+        Assert.AreEqual('Y', c);
     }
 
-    [Fact]
+    [TestMethod]
     public void BigX_GreaterLess_BecomesX()
     {
-        Assert.True(FigletSmushingRules.TrySmushHorizontal('>', '<', Hb, 16, out var c));
-        Assert.Equal('X', c);
+        Assert.IsTrue(FigletSmushingRules.TrySmushHorizontal('>', '<', Hb, 16, out var c));
+        Assert.AreEqual('X', c);
     }
 
-    [Fact]
+    [TestMethod]
     public void BigX_LessGreater_DoesNotSmush()
     {
         // Spec note: "<>" is NOT smushed.
-        Assert.False(FigletSmushingRules.TrySmushHorizontal('<', '>', Hb, 16, out _));
+        Assert.IsFalse(FigletSmushingRules.TrySmushHorizontal('<', '>', Hb, 16, out _));
     }
 
     // ----- Vertical rules --------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Vertical_Blanks_YieldOther()
     {
-        Assert.True(FigletSmushingRules.TrySmushVertical(' ', 'X', Hb, 0, out var c));
-        Assert.Equal('X', c);
+        Assert.IsTrue(FigletSmushingRules.TrySmushVertical(' ', 'X', Hb, 0, out var c));
+        Assert.AreEqual('X', c);
     }
 
-    [Fact]
+    [TestMethod]
     public void Vertical_HardblankActsAsBlank()
     {
-        Assert.True(FigletSmushingRules.TrySmushVertical(Hb, 'X', Hb, 0, out var c));
-        Assert.Equal('X', c);
+        Assert.IsTrue(FigletSmushingRules.TrySmushVertical(Hb, 'X', Hb, 0, out var c));
+        Assert.AreEqual('X', c);
     }
 
-    [Fact]
+    [TestMethod]
     public void Vertical_Universal_LowerWins()
     {
-        Assert.True(FigletSmushingRules.TrySmushVertical('A', 'B', Hb, 0, out var c));
-        Assert.Equal('B', c);
+        Assert.IsTrue(FigletSmushingRules.TrySmushVertical('A', 'B', Hb, 0, out var c));
+        Assert.AreEqual('B', c);
     }
 
-    [Fact]
+    [TestMethod]
     public void Vertical_HorizontalLine_DashOverUnderscore_BecomesEquals()
     {
-        Assert.True(FigletSmushingRules.TrySmushVertical('-', '_', Hb, FigletSmushingRules.VerticalRuleHorizontalLine, out var c));
-        Assert.Equal('=', c);
-        Assert.True(FigletSmushingRules.TrySmushVertical('_', '-', Hb, FigletSmushingRules.VerticalRuleHorizontalLine, out c));
-        Assert.Equal('=', c);
+        Assert.IsTrue(FigletSmushingRules.TrySmushVertical('-', '_', Hb, FigletSmushingRules.VerticalRuleHorizontalLine, out var c));
+        Assert.AreEqual('=', c);
+        Assert.IsTrue(FigletSmushingRules.TrySmushVertical('_', '-', Hb, FigletSmushingRules.VerticalRuleHorizontalLine, out c));
+        Assert.AreEqual('=', c);
     }
 }

--- a/tests/Hex1b.Tests/FigletTextNodeTests.cs
+++ b/tests/Hex1b.Tests/FigletTextNodeTests.cs
@@ -8,6 +8,7 @@ namespace Hex1b.Tests;
 /// Tests for <see cref="FigletTextNode"/> covering measurement, render-time vertical truncation,
 /// cache invalidation on property changes, and end-to-end rendering through Hex1bTerminal.
 /// </summary>
+[TestClass]
 public class FigletTextNodeTests
 {
     /// <summary>Single-row 1-cell-per-letter font for predictable measurement.</summary>
@@ -53,46 +54,46 @@ public class FigletTextNodeTests
 
     // ----- Measurement ------------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Measure_ReturnsRenderedWidthAndHeight()
     {
         var node = new FigletTextNode { Text = "ABC", Font = new TinyFont(height: 1) };
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(3, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(3, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_MultiRowFont_ReturnsFontHeight()
     {
         var node = new FigletTextNode { Text = "AB", Font = new TinyFont(height: 4) };
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(2, size.Width);
-        Assert.Equal(4, size.Height);
+        Assert.AreEqual(2, size.Width);
+        Assert.AreEqual(4, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_EmptyText_ReturnsFontHeightZeroWidth()
     {
         var node = new FigletTextNode { Text = "", Font = new TinyFont(height: 3) };
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(0, size.Width);
-        Assert.Equal(3, size.Height);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(3, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_RespectsMaxWidth()
     {
         var node = new FigletTextNode { Text = "ABCDE", Font = new TinyFont(height: 1) };
         var size = node.Measure(new Constraints(0, 3, 0, int.MaxValue));
 
-        Assert.Equal(3, size.Width);
+        Assert.AreEqual(3, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_Wrap_MultipleRowsWhenTextExceedsWrapWidth()
     {
         var node = new FigletTextNode
@@ -106,10 +107,10 @@ public class FigletTextNodeTests
 
         // wrapWidth = 3 → "AB" fits (2 cols), "AB CD" = 5 cols > 3 → second word wraps.
         // 2 rows × 1 row each = 2 lines.
-        Assert.Equal(2, size.Height);
+        Assert.AreEqual(2, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_Wrap_RewrapsToActualArrangedWidthWhenMeasuredUnbounded()
     {
         // Regression: when a parent measures children with int.MaxValue (e.g. HStack/VStack/Border
@@ -138,37 +139,37 @@ public class FigletTextNodeTests
         // Verify the cache now reflects the arranged width: each rendered row must be ≤5 cols.
         var field = typeof(FigletTextNode).GetField("_cachedLines", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
         var lines = (IReadOnlyList<string>)field.GetValue(node)!;
-        Assert.NotEmpty(lines);
-        Assert.All(lines, line => Assert.True(line.Length <= 5, $"Line '{line}' exceeds wrap width 5"));
+        Assert.IsNotEmpty(lines);
+        TestSeq.All(lines, line => Assert.IsTrue(line.Length <= 5, $"Line '{line}' exceeds wrap width 5"));
     }
 
     // ----- Cache invalidation -----------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Text_Change_InvalidatesCache()
     {
         var node = new FigletTextNode { Text = "AB", Font = new TinyFont() };
         var first = node.Measure(Constraints.Unbounded);
-        Assert.Equal(2, first.Width);
+        Assert.AreEqual(2, first.Width);
 
         node.Text = "ABCD";
         var second = node.Measure(Constraints.Unbounded);
-        Assert.Equal(4, second.Width);
+        Assert.AreEqual(4, second.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void Font_Change_InvalidatesCache()
     {
         var node = new FigletTextNode { Text = "AB", Font = new TinyFont(height: 1) };
         var first = node.Measure(Constraints.Unbounded);
-        Assert.Equal(1, first.Height);
+        Assert.AreEqual(1, first.Height);
 
         node.Font = new TinyFont(height: 3);
         var second = node.Measure(Constraints.Unbounded);
-        Assert.Equal(3, second.Height);
+        Assert.AreEqual(3, second.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void HorizontalLayout_Change_InvalidatesCache()
     {
         var node = new FigletTextNode { Text = "AB", Font = new TinyFont(height: 1) };
@@ -178,10 +179,10 @@ public class FigletTextNodeTests
         node.HorizontalLayout = FigletLayoutMode.FullWidth;
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(2, size.Width);
+        Assert.AreEqual(2, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void HorizontalOverflow_Change_InvalidatesCache()
     {
         var node = new FigletTextNode
@@ -194,12 +195,12 @@ public class FigletTextNodeTests
         node.HorizontalOverflow = FigletHorizontalOverflow.Wrap;
         var sizeAfter = node.Measure(new Constraints(0, 3, 0, int.MaxValue));
 
-        Assert.Equal(2, sizeAfter.Height);
+        Assert.AreEqual(2, sizeAfter.Height);
     }
 
     // ----- Render-time vertical truncation ---------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Truncate_DropsPartialBottomRow()
     {
         // A 3-row font rendered into 5 rows of available height with truncate → only 1 full FIGlet
@@ -212,15 +213,15 @@ public class FigletTextNodeTests
         };
 
         var natural = node.Measure(Constraints.Unbounded);
-        Assert.Equal(6, natural.Height); // two stacked FIGlet rows of 3
+        Assert.AreEqual(6, natural.Height); // two stacked FIGlet rows of 3
         node.Arrange(new Rect(0, 0, 10, 5));
 
         // Internal state: render writes only fittable rows. We can't easily inspect without
         // hooking RenderContext, but Measure should still report natural height.
-        Assert.Equal(6, natural.Height);
+        Assert.AreEqual(6, natural.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Truncate_FullHeightFits_RendersAllRows()
     {
         var node = new FigletTextNode
@@ -230,12 +231,12 @@ public class FigletTextNodeTests
             VerticalOverflow = FigletVerticalOverflow.Truncate,
         };
         var size = node.Measure(Constraints.Unbounded);
-        Assert.Equal(3, size.Height);
+        Assert.AreEqual(3, size.Height);
     }
 
     // ----- End-to-end rendering through Hex1bTerminal -----------------------------------
 
-    [Fact]
+    [TestMethod]
     public async Task Render_SmallFont_AppearsInTerminal()
     {
         // Use the bundled small font so we can assert against well-known output.
@@ -259,7 +260,7 @@ public class FigletTextNodeTests
         Assert.Contains("_", firstLine);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Empty_DoesNotThrow()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -276,65 +277,65 @@ public class FigletTextNodeTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal("", terminal.CreateSnapshot().GetLineTrimmed(0));
+        Assert.AreEqual("", terminal.CreateSnapshot().GetLineTrimmed(0));
     }
 
     // ----- Extension API (fluent setters) ----------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Widget_DefaultsToStandardFont()
     {
         var widget = new FigletTextWidget("Hello");
-        Assert.Equal("Hello", widget.Text);
-        Assert.Same(FigletFonts.Standard, widget.Font);
-        Assert.Equal(FigletLayoutMode.Default, widget.HorizontalLayout);
-        Assert.Equal(FigletHorizontalOverflow.Clip, widget.HorizontalOverflow);
-        Assert.Equal(FigletVerticalOverflow.Clip, widget.VerticalOverflow);
+        Assert.AreEqual("Hello", widget.Text);
+        Assert.AreSame(FigletFonts.Standard, widget.Font);
+        Assert.AreEqual(FigletLayoutMode.Default, widget.HorizontalLayout);
+        Assert.AreEqual(FigletHorizontalOverflow.Clip, widget.HorizontalOverflow);
+        Assert.AreEqual(FigletVerticalOverflow.Clip, widget.VerticalOverflow);
     }
 
-    [Fact]
+    [TestMethod]
     public void Font_Extension_SetsFont()
     {
         var custom = new TinyFont();
         var widget = new FigletTextWidget("X").Font(custom);
-        Assert.Same(custom, widget.Font);
+        Assert.AreSame(custom, widget.Font);
     }
 
-    [Fact]
+    [TestMethod]
     public void Layout_Extension_SetsBothAxes()
     {
         var widget = new FigletTextWidget("X").Layout(FigletLayoutMode.Smushed);
-        Assert.Equal(FigletLayoutMode.Smushed, widget.HorizontalLayout);
-        Assert.Equal(FigletLayoutMode.Smushed, widget.VerticalLayout);
+        Assert.AreEqual(FigletLayoutMode.Smushed, widget.HorizontalLayout);
+        Assert.AreEqual(FigletLayoutMode.Smushed, widget.VerticalLayout);
     }
 
-    [Fact]
+    [TestMethod]
     public void Horizontal_Extension_SetsOnlyHorizontal()
     {
         var widget = new FigletTextWidget("X").Horizontal(FigletLayoutMode.Smushed);
-        Assert.Equal(FigletLayoutMode.Smushed, widget.HorizontalLayout);
-        Assert.Equal(FigletLayoutMode.Default, widget.VerticalLayout);
+        Assert.AreEqual(FigletLayoutMode.Smushed, widget.HorizontalLayout);
+        Assert.AreEqual(FigletLayoutMode.Default, widget.VerticalLayout);
     }
 
-    [Fact]
+    [TestMethod]
     public void Vertical_Extension_SetsOnlyVertical()
     {
         var widget = new FigletTextWidget("X").Vertical(FigletLayoutMode.FullWidth);
-        Assert.Equal(FigletLayoutMode.Default, widget.HorizontalLayout);
-        Assert.Equal(FigletLayoutMode.FullWidth, widget.VerticalLayout);
+        Assert.AreEqual(FigletLayoutMode.Default, widget.HorizontalLayout);
+        Assert.AreEqual(FigletLayoutMode.FullWidth, widget.VerticalLayout);
     }
 
-    [Fact]
+    [TestMethod]
     public void HorizontalOverflow_Extension_SetsHorizontalOverflow()
     {
         var widget = new FigletTextWidget("X").HorizontalOverflow(FigletHorizontalOverflow.Wrap);
-        Assert.Equal(FigletHorizontalOverflow.Wrap, widget.HorizontalOverflow);
+        Assert.AreEqual(FigletHorizontalOverflow.Wrap, widget.HorizontalOverflow);
     }
 
-    [Fact]
+    [TestMethod]
     public void VerticalOverflow_Extension_SetsVerticalOverflow()
     {
         var widget = new FigletTextWidget("X").VerticalOverflow(FigletVerticalOverflow.Truncate);
-        Assert.Equal(FigletVerticalOverflow.Truncate, widget.VerticalOverflow);
+        Assert.AreEqual(FigletVerticalOverflow.Truncate, widget.VerticalOverflow);
     }
 }

--- a/tests/Hex1b.Tests/FloatPanelNodeTests.cs
+++ b/tests/Hex1b.Tests/FloatPanelNodeTests.cs
@@ -6,9 +6,10 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class FloatWidgetTests
 {
-    [Fact]
+    [TestMethod]
     public void VStack_FloatAbsolute_PositionsChildAtCoordinates()
     {
         // Arrange
@@ -27,13 +28,13 @@ public class FloatWidgetTests
         node.Arrange(new Rect(0, 0, 80, 24));
 
         // Assert — flow child at top, float at absolute position
-        Assert.Equal(0, child1.Bounds.X);
-        Assert.Equal(0, child1.Bounds.Y);
-        Assert.Equal(10, child2.Bounds.X);
-        Assert.Equal(5, child2.Bounds.Y);
+        Assert.AreEqual(0, child1.Bounds.X);
+        Assert.AreEqual(0, child1.Bounds.Y);
+        Assert.AreEqual(10, child2.Bounds.X);
+        Assert.AreEqual(5, child2.Bounds.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void VStack_FloatAbsolute_OffsetsFromContainerOrigin()
     {
         // Arrange — container at (5, 3)
@@ -48,11 +49,11 @@ public class FloatWidgetTests
         node.Arrange(new Rect(5, 3, 80, 24));
 
         // Assert — float position = container origin + absolute offset
-        Assert.Equal(15, child.Bounds.X);
-        Assert.Equal(8, child.Bounds.Y);
+        Assert.AreEqual(15, child.Bounds.X);
+        Assert.AreEqual(8, child.Bounds.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void VStack_FloatAlignRight_AlignsRightEdges()
     {
         // Arrange
@@ -81,12 +82,12 @@ public class FloatWidgetTests
         // Assert — float's right edge = anchor's right edge
         var anchorRight = anchor.Bounds.X + anchor.Bounds.Width;
         var floatRight = floatNode.Bounds.X + floatNode.Bounds.Width;
-        Assert.Equal(anchorRight, floatRight);
+        Assert.AreEqual(anchorRight, floatRight);
         // Float should be below anchor
-        Assert.Equal(anchor.Bounds.Y + anchor.Bounds.Height, floatNode.Bounds.Y);
+        Assert.AreEqual(anchor.Bounds.Y + anchor.Bounds.Height, floatNode.Bounds.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void VStack_FloatExtendRight_PlacesBesideAnchor()
     {
         // Arrange
@@ -113,11 +114,11 @@ public class FloatWidgetTests
         node.Arrange(new Rect(0, 0, 80, 24));
 
         // Assert — float's left edge = anchor's right edge
-        Assert.Equal(anchor.Bounds.X + anchor.Bounds.Width, floatNode.Bounds.X);
-        Assert.Equal(anchor.Bounds.Y, floatNode.Bounds.Y);
+        Assert.AreEqual(anchor.Bounds.X + anchor.Bounds.Width, floatNode.Bounds.X);
+        Assert.AreEqual(anchor.Bounds.Y, floatNode.Bounds.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_ReturnsAllFlowAndFloatNodes()
     {
         // Arrange
@@ -135,13 +136,13 @@ public class FloatWidgetTests
         var children = node.GetChildren().ToList();
 
         // Assert — declaration order preserved
-        Assert.Equal(3, children.Count);
-        Assert.Same(flow1, children[0]);
-        Assert.Same(floatNode, children[1]);
-        Assert.Same(flow2, children[2]);
+        Assert.AreEqual(3, children.Count);
+        Assert.AreSame(flow1, children[0]);
+        Assert.AreSame(floatNode, children[1]);
+        Assert.AreSame(flow2, children[2]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Reconcile_FloatWidget_SeparatesFromFlowChildren()
     {
         // Arrange
@@ -157,13 +158,13 @@ public class FloatWidgetTests
         var vstackNode = (VStackNode)node;
 
         // Assert — 2 flow children, 1 float
-        Assert.Equal(2, vstackNode.Children.Count);
-        Assert.Single(vstackNode.Floats);
-        Assert.Equal(10, vstackNode.Floats[0].AbsoluteX);
-        Assert.Equal(5, vstackNode.Floats[0].AbsoluteY);
+        Assert.AreEqual(2, vstackNode.Children.Count);
+        TestSeq.Single(vstackNode.Floats);
+        Assert.AreEqual(10, vstackNode.Floats[0].AbsoluteX);
+        Assert.AreEqual(5, vstackNode.Floats[0].AbsoluteY);
     }
 
-    [Fact]
+    [TestMethod]
     public void Reconcile_PreservesNodeOnSameType()
     {
         // Arrange
@@ -180,13 +181,13 @@ public class FloatWidgetTests
         var node2 = widget2.ReconcileAsync(node1, context).GetAwaiter().GetResult();
 
         // Assert — same VStack node reused
-        Assert.Same(node1, node2);
+        Assert.AreSame(node1, node2);
         var vstackNode = (VStackNode)node2;
-        Assert.Single(vstackNode.Floats);
-        Assert.Equal(5, vstackNode.Floats[0].AbsoluteX);
+        TestSeq.Single(vstackNode.Floats);
+        Assert.AreEqual(5, vstackNode.Floats[0].AbsoluteX);
     }
 
-    [Fact]
+    [TestMethod]
     public void EmptyVStack_WithNoFloats_ArrangesWithoutError()
     {
         // Arrange
@@ -195,11 +196,11 @@ public class FloatWidgetTests
         // Act & Assert — should not throw
         node.Measure(new Constraints(0, 80, 0, 24));
         node.Arrange(new Rect(0, 0, 80, 24));
-        Assert.Empty(node.Children);
-        Assert.Empty(node.Floats);
+        Assert.IsEmpty(node.Children);
+        Assert.IsEmpty(node.Floats);
     }
 
-    [Fact]
+    [TestMethod]
     public void HStack_FloatAbsolute_Works()
     {
         // Arrange
@@ -214,11 +215,11 @@ public class FloatWidgetTests
         node.Arrange(new Rect(0, 0, 80, 24));
 
         // Assert
-        Assert.Equal(20, floatNode.Bounds.X);
-        Assert.Equal(3, floatNode.Bounds.Y);
+        Assert.AreEqual(20, floatNode.Bounds.X);
+        Assert.AreEqual(3, floatNode.Bounds.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void FloatWidget_AlignmentComposition_WorksWithSeparateAnchors()
     {
         // Test that horizontal and vertical alignment can be set independently
@@ -227,26 +228,27 @@ public class FloatWidgetTests
             .AlignRight(anchor, 2)
             .ExtendBottom(anchor, 1);
 
-        Assert.Equal(FloatHorizontalAlignment.AlignRight, fw.HorizontalAlignment);
-        Assert.Equal(2, fw.HorizontalOffset);
-        Assert.Equal(FloatVerticalAlignment.ExtendBottom, fw.VerticalAlignment);
-        Assert.Equal(1, fw.VerticalOffset);
-        Assert.Same(anchor, fw.HorizontalAnchor);
-        Assert.Same(anchor, fw.VerticalAnchor);
+        Assert.AreEqual(FloatHorizontalAlignment.AlignRight, fw.HorizontalAlignment);
+        Assert.AreEqual(2, fw.HorizontalOffset);
+        Assert.AreEqual(FloatVerticalAlignment.ExtendBottom, fw.VerticalAlignment);
+        Assert.AreEqual(1, fw.VerticalOffset);
+        Assert.AreSame(anchor, fw.HorizontalAnchor);
+        Assert.AreSame(anchor, fw.VerticalAnchor);
     }
 
-    [Fact]
+    [TestMethod]
     public void FloatWidget_Absolute_SetsCoordinates()
     {
         var fw = new FloatWidget(new IconWidget("X")).Absolute(42, 13);
-        Assert.Equal(42, fw.AbsoluteX);
-        Assert.Equal(13, fw.AbsoluteY);
+        Assert.AreEqual(42, fw.AbsoluteX);
+        Assert.AreEqual(13, fw.AbsoluteY);
     }
 }
 
+[TestClass]
 public class FloatWidgetIntegrationTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Integration_FloatButton_Enter_TriggersAction()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -273,13 +275,14 @@ public class FloatWidgetIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(clicked, "Floated button click handler was not invoked");
+        Assert.IsTrue(clicked, "Floated button click handler was not invoked");
     }
 }
 
+[TestClass]
 public class FloatWidgetZStackIntegrationTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Integration_ZStack_FloatButton_Enter_TriggersAction()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -308,13 +311,14 @@ public class FloatWidgetZStackIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(clicked, "ZStack floated button click handler was not invoked");
+        Assert.IsTrue(clicked, "ZStack floated button click handler was not invoked");
     }
 }
 
+[TestClass]
 public class FloatWidgetPickerIntegrationTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Integration_FlowButtonInVStackWithFloats_ReceivesFocus()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -341,10 +345,10 @@ public class FloatWidgetPickerIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(flowClicked, "Flow button in VStack with floats should receive focus and be clickable");
+        Assert.IsTrue(flowClicked, "Flow button in VStack with floats should receive focus and be clickable");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_AlignmentExplorerLayout_PickerOpensAndSelects()
     {
         // Exact reproduction of the FloatAlignmentExplorer sample layout
@@ -398,10 +402,10 @@ public class FloatWidgetPickerIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("AlignLeft", horizontal);
+        Assert.AreEqual("AlignLeft", horizontal);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_FloatAlignRight_PositionsRelativeToAnchor()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -435,10 +439,10 @@ public class FloatWidgetPickerIntegrationTests
             if (lines[i].Contains("│F│")) floatLine = i;
         }
 
-        Assert.True(floatLine > anchorLine, $"Float (line {floatLine}) should be below Anchor (line {anchorLine}). Screen:\n{text}");
+        Assert.IsTrue(floatLine > anchorLine, $"Float (line {floatLine}) should be below Anchor (line {anchorLine}). Screen:\n{text}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_FloatExtendLeft_AlignTop_NestedAnchor_PositionsCorrectly()
     {
         // Anchor border is nested inside Center(Padding(...)) — tests recursive anchor resolution
@@ -477,9 +481,9 @@ public class FloatWidgetPickerIntegrationTests
         }
 
         // Float should be to the LEFT of the anchor border (ExtendLeft)
-        Assert.True(floatCol < anchorCol, $"Float col {floatCol} should be left of Anchor col {anchorCol}. Screen:\n{text}");
+        Assert.IsTrue(floatCol < anchorCol, $"Float col {floatCol} should be left of Anchor col {anchorCol}. Screen:\n{text}");
         // Float should be top-aligned with the anchor (AlignTop), which means same row or close
-        Assert.True(Math.Abs(floatLine - anchorTitleLine) <= 1, $"Float line {floatLine} should be near Anchor line {anchorTitleLine}. Screen:\n{text}");
+        Assert.IsTrue(Math.Abs(floatLine - anchorTitleLine) <= 1, $"Float line {floatLine} should be near Anchor line {anchorTitleLine}. Screen:\n{text}");
     }
 }
 
@@ -488,6 +492,7 @@ public class FloatWidgetPickerIntegrationTests
 /// Uses a fixed-size container (40x20), a 10x3 anchor at a known position, and a 4x1 float.
 /// Verifies exact cell coordinates by checking rendered screen text.
 /// </summary>
+[TestClass]
 public class FloatWidgetPlacementTests
 {
     // Direct unit test approach: manually set up nodes, measure, arrange, check Bounds.
@@ -528,160 +533,160 @@ public class FloatWidgetPlacementTests
         return (anchor.Bounds, floatNode.Bounds);
     }
 
-    [Fact]
+    [TestMethod]
     public void AlignLeft_AlignTop_FloatLeftEdgeMatchesAnchorLeftEdge_SameRow()
     {
         var (anchor, floatR) = ArrangeWithManualNodes(
             FloatHorizontalAlignment.AlignLeft, FloatVerticalAlignment.AlignTop);
 
-        Assert.Equal(anchor.X, floatR.X);       // left edges aligned
-        Assert.Equal(anchor.Y, floatR.Y);       // same row
+        Assert.AreEqual(anchor.X, floatR.X);       // left edges aligned
+        Assert.AreEqual(anchor.Y, floatR.Y);       // same row
     }
 
-    [Fact]
+    [TestMethod]
     public void AlignRight_AlignTop_FloatRightEdgeMatchesAnchorRightEdge_SameRow()
     {
         var (anchor, floatR) = ArrangeWithManualNodes(
             FloatHorizontalAlignment.AlignRight, FloatVerticalAlignment.AlignTop);
 
         // right edges: anchor.X + 10 == float.X + 4
-        Assert.Equal(anchor.X + anchor.Width, floatR.X + floatR.Width);
-        Assert.Equal(anchor.Y, floatR.Y);
+        Assert.AreEqual(anchor.X + anchor.Width, floatR.X + floatR.Width);
+        Assert.AreEqual(anchor.Y, floatR.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtendRight_AlignTop_FloatLeftEdgeTouchesAnchorRightEdge()
     {
         var (anchor, floatR) = ArrangeWithManualNodes(
             FloatHorizontalAlignment.ExtendRight, FloatVerticalAlignment.AlignTop);
 
-        Assert.Equal(anchor.X + anchor.Width, floatR.X); // float starts where anchor ends
-        Assert.Equal(anchor.Y, floatR.Y);
+        Assert.AreEqual(anchor.X + anchor.Width, floatR.X); // float starts where anchor ends
+        Assert.AreEqual(anchor.Y, floatR.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtendLeft_AlignTop_FloatRightEdgeTouchesAnchorLeftEdge()
     {
         var (anchor, floatR) = ArrangeWithManualNodes(
             FloatHorizontalAlignment.ExtendLeft, FloatVerticalAlignment.AlignTop);
 
-        Assert.Equal(anchor.X, floatR.X + floatR.Width); // float ends where anchor starts
-        Assert.Equal(anchor.Y, floatR.Y);
+        Assert.AreEqual(anchor.X, floatR.X + floatR.Width); // float ends where anchor starts
+        Assert.AreEqual(anchor.Y, floatR.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void AlignLeft_AlignBottom_FloatBottomEdgeMatchesAnchorBottomEdge()
     {
         var (anchor, floatR) = ArrangeWithManualNodes(
             FloatHorizontalAlignment.AlignLeft, FloatVerticalAlignment.AlignBottom);
 
-        Assert.Equal(anchor.X, floatR.X);
+        Assert.AreEqual(anchor.X, floatR.X);
         // Both are 1 row tall, so AlignBottom = same row
-        Assert.Equal(anchor.Y + anchor.Height - floatR.Height, floatR.Y);
+        Assert.AreEqual(anchor.Y + anchor.Height - floatR.Height, floatR.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void AlignLeft_ExtendBottom_FloatTopEdgeTouchesAnchorBottomEdge()
     {
         var (anchor, floatR) = ArrangeWithManualNodes(
             FloatHorizontalAlignment.AlignLeft, FloatVerticalAlignment.ExtendBottom);
 
-        Assert.Equal(anchor.X, floatR.X);
-        Assert.Equal(anchor.Y + anchor.Height, floatR.Y); // float below anchor
+        Assert.AreEqual(anchor.X, floatR.X);
+        Assert.AreEqual(anchor.Y + anchor.Height, floatR.Y); // float below anchor
     }
 
-    [Fact]
+    [TestMethod]
     public void AlignLeft_ExtendTop_FloatBottomEdgeTouchesAnchorTopEdge()
     {
         var (anchor, floatR) = ArrangeWithManualNodes(
             FloatHorizontalAlignment.AlignLeft, FloatVerticalAlignment.ExtendTop);
 
-        Assert.Equal(anchor.X, floatR.X);
-        Assert.Equal(anchor.Y, floatR.Y + floatR.Height); // float above anchor
+        Assert.AreEqual(anchor.X, floatR.X);
+        Assert.AreEqual(anchor.Y, floatR.Y + floatR.Height); // float above anchor
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtendRight_ExtendBottom_FloatCornerTouchesAnchorBottomRightCorner()
     {
         var (anchor, floatR) = ArrangeWithManualNodes(
             FloatHorizontalAlignment.ExtendRight, FloatVerticalAlignment.ExtendBottom);
 
-        Assert.Equal(anchor.X + anchor.Width, floatR.X);  // right of anchor
-        Assert.Equal(anchor.Y + anchor.Height, floatR.Y); // below anchor
+        Assert.AreEqual(anchor.X + anchor.Width, floatR.X);  // right of anchor
+        Assert.AreEqual(anchor.Y + anchor.Height, floatR.Y); // below anchor
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtendLeft_ExtendTop_FloatCornerTouchesAnchorTopLeftCorner()
     {
         var (anchor, floatR) = ArrangeWithManualNodes(
             FloatHorizontalAlignment.ExtendLeft, FloatVerticalAlignment.ExtendTop);
 
-        Assert.Equal(anchor.X, floatR.X + floatR.Width);  // left of anchor
-        Assert.Equal(anchor.Y, floatR.Y + floatR.Height); // above anchor
+        Assert.AreEqual(anchor.X, floatR.X + floatR.Width);  // left of anchor
+        Assert.AreEqual(anchor.Y, floatR.Y + floatR.Height); // above anchor
     }
 
-    [Fact]
+    [TestMethod]
     public void AlignRight_ExtendBottom_FloatRightAlignedBelow()
     {
         var (anchor, floatR) = ArrangeWithManualNodes(
             FloatHorizontalAlignment.AlignRight, FloatVerticalAlignment.ExtendBottom);
 
-        Assert.Equal(anchor.X + anchor.Width, floatR.X + floatR.Width); // right edges aligned
-        Assert.Equal(anchor.Y + anchor.Height, floatR.Y);              // below
+        Assert.AreEqual(anchor.X + anchor.Width, floatR.X + floatR.Width); // right edges aligned
+        Assert.AreEqual(anchor.Y + anchor.Height, floatR.Y);              // below
     }
 
-    [Fact]
+    [TestMethod]
     public void AlignRight_AlignBottom_FloatRightAlignedBottomAligned()
     {
         var (anchor, floatR) = ArrangeWithManualNodes(
             FloatHorizontalAlignment.AlignRight, FloatVerticalAlignment.AlignBottom);
 
-        Assert.Equal(anchor.X + anchor.Width, floatR.X + floatR.Width);
-        Assert.Equal(anchor.Y + anchor.Height - floatR.Height, floatR.Y);
+        Assert.AreEqual(anchor.X + anchor.Width, floatR.X + floatR.Width);
+        Assert.AreEqual(anchor.Y + anchor.Height - floatR.Height, floatR.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtendRight_ExtendTop_FloatAboveAndRight()
     {
         var (anchor, floatR) = ArrangeWithManualNodes(
             FloatHorizontalAlignment.ExtendRight, FloatVerticalAlignment.ExtendTop);
 
-        Assert.Equal(anchor.X + anchor.Width, floatR.X);  // right of anchor
-        Assert.Equal(anchor.Y, floatR.Y + floatR.Height); // above anchor
+        Assert.AreEqual(anchor.X + anchor.Width, floatR.X);  // right of anchor
+        Assert.AreEqual(anchor.Y, floatR.Y + floatR.Height); // above anchor
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtendLeft_ExtendBottom_FloatBelowAndLeft()
     {
         var (anchor, floatR) = ArrangeWithManualNodes(
             FloatHorizontalAlignment.ExtendLeft, FloatVerticalAlignment.ExtendBottom);
 
-        Assert.Equal(anchor.X, floatR.X + floatR.Width);  // left of anchor
-        Assert.Equal(anchor.Y + anchor.Height, floatR.Y); // below anchor
+        Assert.AreEqual(anchor.X, floatR.X + floatR.Width);  // left of anchor
+        Assert.AreEqual(anchor.Y + anchor.Height, floatR.Y); // below anchor
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtendLeft_AlignBottom_FloatLeftAndBottomAligned()
     {
         var (anchor, floatR) = ArrangeWithManualNodes(
             FloatHorizontalAlignment.ExtendLeft, FloatVerticalAlignment.AlignBottom);
 
-        Assert.Equal(anchor.X, floatR.X + floatR.Width);
-        Assert.Equal(anchor.Y + anchor.Height - floatR.Height, floatR.Y);
+        Assert.AreEqual(anchor.X, floatR.X + floatR.Width);
+        Assert.AreEqual(anchor.Y + anchor.Height - floatR.Height, floatR.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void AlignLeft_AlignTop_WithPositiveOffset_ShiftsBoth()
     {
         var (anchor, floatR) = ArrangeWithManualNodes(
             FloatHorizontalAlignment.AlignLeft, FloatVerticalAlignment.AlignTop,
             hOffset: 3, vOffset: 2);
 
-        Assert.Equal(anchor.X + 3, floatR.X);
-        Assert.Equal(anchor.Y + 2, floatR.Y);
+        Assert.AreEqual(anchor.X + 3, floatR.X);
+        Assert.AreEqual(anchor.Y + 2, floatR.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtendRight_AlignTop_NegativeOffset_OverlapsAnchor()
     {
         var (anchor, floatR) = ArrangeWithManualNodes(
@@ -689,29 +694,30 @@ public class FloatWidgetPlacementTests
             hOffset: -2);
 
         // ExtendRight places at anchor.X + 10, offset -2 = anchor.X + 8
-        Assert.Equal(anchor.X + anchor.Width - 2, floatR.X);
-        Assert.Equal(anchor.Y, floatR.Y);
+        Assert.AreEqual(anchor.X + anchor.Width - 2, floatR.X);
+        Assert.AreEqual(anchor.Y, floatR.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtendBottom_NegativeVerticalOffset_OverlapsAnchor()
     {
         var (anchor, floatR) = ArrangeWithManualNodes(
             FloatHorizontalAlignment.AlignLeft, FloatVerticalAlignment.ExtendBottom,
             vOffset: -1);
 
-        Assert.Equal(anchor.X, floatR.X);
+        Assert.AreEqual(anchor.X, floatR.X);
         // ExtendBottom places at anchor.Y + 1, offset -1 = anchor.Y
-        Assert.Equal(anchor.Y + anchor.Height - 1, floatR.Y);
+        Assert.AreEqual(anchor.Y + anchor.Height - 1, floatR.Y);
     }
 }
 
 /// <summary>
 /// Tests for float-anchored-to-float: what happens when a float references another floating widget as its anchor.
 /// </summary>
+[TestClass]
 public class FloatAnchoredToFloatTests
 {
-    [Fact]
+    [TestMethod]
     public async Task FloatAnchoredToFloat_ExtendRight_ChainsHorizontally()
     {
         // Float B anchors to Float A (ExtendRight) — B should appear to the right of A
@@ -748,14 +754,14 @@ public class FloatAnchoredToFloatTests
             if (bi >= 0) { bRow = i; bCol = bi; }
         }
 
-        Assert.True(aCol >= 0 && bCol >= 0, $"Floats not found. Screen:\n{text}");
+        Assert.IsTrue(aCol >= 0 && bCol >= 0, $"Floats not found. Screen:\n{text}");
         // B should be immediately to the right of A
-        Assert.Equal(aCol + 4, bCol);
+        Assert.AreEqual(aCol + 4, bCol);
         // Same row
-        Assert.Equal(aRow, bRow);
+        Assert.AreEqual(aRow, bRow);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FloatAnchoredToFloat_ExtendBottom_ChainsVertically()
     {
         // Float B anchors to Float A (ExtendBottom) — B should appear below A
@@ -792,14 +798,14 @@ public class FloatAnchoredToFloatTests
             if (bi >= 0) { bRow = i; bCol = bi; }
         }
 
-        Assert.True(aCol >= 0 && bCol >= 0, $"Floats not found. Screen:\n{text}");
+        Assert.IsTrue(aCol >= 0 && bCol >= 0, $"Floats not found. Screen:\n{text}");
         // Same column
-        Assert.Equal(aCol, bCol);
+        Assert.AreEqual(aCol, bCol);
         // B should be immediately below A (A is 1 row)
-        Assert.Equal(aRow + 1, bRow);
+        Assert.AreEqual(aRow + 1, bRow);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ThreeFloatsChained_PositionCorrectly()
     {
         // A at (2,2), B ExtendRight of A, C ExtendBottom of B — L-shaped chain
@@ -853,18 +859,18 @@ public class FloatAnchoredToFloatTests
             }
         }
 
-        Assert.True(aCol >= 0 && bCol >= 0 && cCol >= 0, $"Not all floats found. Screen:\n{text}");
+        Assert.IsTrue(aCol >= 0 && bCol >= 0 && cCol >= 0, $"Not all floats found. Screen:\n{text}");
 
         // A at (2, 2)
-        Assert.Equal(2, aCol);
-        Assert.Equal(2, aRow);
+        Assert.AreEqual(2, aCol);
+        Assert.AreEqual(2, aRow);
 
         // B = ExtendRight(A) + AlignTop(A) → col = 2+2=4, row = 2
-        Assert.Equal(aCol + 2, bCol);
-        Assert.Equal(aRow, bRow);
+        Assert.AreEqual(aCol + 2, bCol);
+        Assert.AreEqual(aRow, bRow);
 
         // C = AlignLeft(B) + ExtendBottom(B) → col = 4, row = 2+1=3
-        Assert.Equal(bCol, cCol);
-        Assert.Equal(bRow + 1, cRow);
+        Assert.AreEqual(bCol, cCol);
+        Assert.AreEqual(bRow + 1, cRow);
     }
 }

--- a/tests/Hex1b.Tests/Flow/FlowResizeMathTests.cs
+++ b/tests/Hex1b.Tests/Flow/FlowResizeMathTests.cs
@@ -7,22 +7,23 @@ namespace Hex1b.Tests.Flow;
 /// on a flow resize, how tall the active step should be and which rows the
 /// runner should clear.
 /// </summary>
+[TestClass]
 public class FlowResizeMathTests
 {
-    [Theory]
-    [InlineData(null, 24, 24)] // No max → fills terminal
-    [InlineData(10, 24, 10)]   // Max smaller than terminal → max wins
-    [InlineData(40, 24, 24)]   // Max larger than terminal → terminal wins
-    [InlineData(0, 24, 1)]     // Zero clamps to 1
-    [InlineData(-5, 24, 1)]    // Negative clamps to 1
+    [TestMethod]
+    [DataRow(null, 24, 24)] // No max → fills terminal
+    [DataRow(10, 24, 10)]   // Max smaller than terminal → max wins
+    [DataRow(40, 24, 24)]   // Max larger than terminal → terminal wins
+    [DataRow(0, 24, 1)]     // Zero clamps to 1
+    [DataRow(-5, 24, 1)]    // Negative clamps to 1
     public void ComputeStepHeight_ClampsToTerminalAndMinimumOfOne(
         int? maxHeight, int terminalHeight, int expected)
     {
         var actual = FlowResizeMath.ComputeStepHeight(maxHeight, terminalHeight);
-        Assert.Equal(expected, actual);
+        Assert.AreEqual(expected, actual);
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputeClearRegion_LegacyPath_ClearsEntireVisibleArea()
     {
         // Legacy behaviour: cell-positioned tombstones can't survive a resize,
@@ -33,11 +34,11 @@ public class FlowResizeMathTests
             terminalHeight: 24,
             stepHeight: 5);
 
-        Assert.Equal(0, origin);
-        Assert.Equal(24, height);
+        Assert.AreEqual(0, origin);
+        Assert.AreEqual(24, height);
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputeClearRegion_LegacyPath_StepHeightDoesNotShrinkClear()
     {
         // Even when the step is small, the legacy path still clears the
@@ -47,11 +48,11 @@ public class FlowResizeMathTests
             terminalHeight: 100,
             stepHeight: 1);
 
-        Assert.Equal(0, origin);
-        Assert.Equal(100, height);
+        Assert.AreEqual(0, origin);
+        Assert.AreEqual(100, height);
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputeClearRegion_SoftWrapPath_ClearsOnlyTheActiveStepRegion()
     {
         // Soft-wrap behaviour: tombstones above the active step are real
@@ -64,11 +65,11 @@ public class FlowResizeMathTests
             terminalHeight: 24,
             stepHeight: 5);
 
-        Assert.Equal(19, origin); // 24 - 5
-        Assert.Equal(5, height);
+        Assert.AreEqual(19, origin); // 24 - 5
+        Assert.AreEqual(5, height);
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputeClearRegion_SoftWrapPath_StepFillsTerminal_ClearsEntireArea()
     {
         // When the step occupies the full terminal there is no tombstone
@@ -80,11 +81,11 @@ public class FlowResizeMathTests
             terminalHeight: 24,
             stepHeight: 24);
 
-        Assert.Equal(0, origin);
-        Assert.Equal(24, height);
+        Assert.AreEqual(0, origin);
+        Assert.AreEqual(24, height);
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputeClearRegion_SoftWrapPath_StepLargerThanTerminal_ClampsRowOriginAtZero()
     {
         // Defensive: callers should already have clamped via
@@ -95,11 +96,11 @@ public class FlowResizeMathTests
             terminalHeight: 10,
             stepHeight: 20);
 
-        Assert.Equal(0, origin);
-        Assert.Equal(20, height);
+        Assert.AreEqual(0, origin);
+        Assert.AreEqual(20, height);
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputeClearRegion_SoftWrapPath_PreservesTombstonesAboveOrigin()
     {
         // The crux of the fix: with a 24-row terminal and a 3-row active
@@ -111,6 +112,6 @@ public class FlowResizeMathTests
 
         // Origin is 21, so rows 0..20 are untouched — exactly the tombstone
         // history the terminal just reflowed for us.
-        Assert.Equal(21, origin);
+        Assert.AreEqual(21, origin);
     }
 }

--- a/tests/Hex1b.Tests/Flow/FlowResizeRowOriginFeasibilityTests.cs
+++ b/tests/Hex1b.Tests/Flow/FlowResizeRowOriginFeasibilityTests.cs
@@ -19,20 +19,21 @@ namespace Hex1b.Tests.Flow;
 /// the formula and the simulator can't drift in lockstep because the
 /// simulator never calls the formula.
 /// </summary>
+[TestClass]
 public class FlowResizeRowOriginFeasibilityTests
 {
-    [Fact]
+    [TestMethod]
     public void NoTombstones_RowOriginEqualsInitial()
     {
         var sim = new FakeReflowTerminal(width: 80, initialCursorRow: 0);
         sim.MarkActiveWidgetTop();
 
         var actual = ComputeOrigin(initial: 0, sim, width: 80);
-        Assert.Equal(sim.ActiveWidgetRow, actual);
-        Assert.Equal(0, actual);
+        Assert.AreEqual(sim.ActiveWidgetRow, actual);
+        Assert.AreEqual(0, actual);
     }
 
-    [Fact]
+    [TestMethod]
     public void ShortTombstone_FitsAtBothWidths()
     {
         var sim = new FakeReflowTerminal(width: 80, initialCursorRow: 0);
@@ -43,12 +44,12 @@ public class FlowResizeRowOriginFeasibilityTests
         {
             sim.Resize(width);
             var math = ComputeOrigin(initial: 0, sim, width);
-            Assert.Equal(sim.ActiveWidgetRow, math);
-            Assert.Equal(1, math);
+            Assert.AreEqual(sim.ActiveWidgetRow, math);
+            Assert.AreEqual(1, math);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void LongSingleParagraph_WrapsWhenWidthShrinks()
     {
         var sim = new FakeReflowTerminal(width: 80, initialCursorRow: 0);
@@ -56,19 +57,19 @@ public class FlowResizeRowOriginFeasibilityTests
         sim.MarkActiveWidgetTop();
 
         sim.Resize(80);
-        Assert.Equal(1, sim.ActiveWidgetRow);
-        Assert.Equal(1, ComputeOrigin(0, sim, 80));
+        Assert.AreEqual(1, sim.ActiveWidgetRow);
+        Assert.AreEqual(1, ComputeOrigin(0, sim, 80));
 
         sim.Resize(40);
-        Assert.Equal(2, sim.ActiveWidgetRow);
-        Assert.Equal(2, ComputeOrigin(0, sim, 40));
+        Assert.AreEqual(2, sim.ActiveWidgetRow);
+        Assert.AreEqual(2, ComputeOrigin(0, sim, 40));
 
         sim.Resize(20);
-        Assert.Equal(3, sim.ActiveWidgetRow);
-        Assert.Equal(3, ComputeOrigin(0, sim, 20));
+        Assert.AreEqual(3, sim.ActiveWidgetRow);
+        Assert.AreEqual(3, ComputeOrigin(0, sim, 20));
     }
 
-    [Fact]
+    [TestMethod]
     public void MultiParagraph_MixedWidths()
     {
         var sim = new FakeReflowTerminal(width: 40, initialCursorRow: 0);
@@ -77,11 +78,11 @@ public class FlowResizeRowOriginFeasibilityTests
         sim.WriteParagraph(new string('c', 5));
         sim.MarkActiveWidgetTop();
 
-        Assert.Equal(4, sim.ActiveWidgetRow); // 1 + 2 + 1
-        Assert.Equal(sim.ActiveWidgetRow, ComputeOrigin(0, sim, 40));
+        Assert.AreEqual(4, sim.ActiveWidgetRow); // 1 + 2 + 1
+        Assert.AreEqual(sim.ActiveWidgetRow, ComputeOrigin(0, sim, 40));
     }
 
-    [Fact]
+    [TestMethod]
     public void DragResizeSequence_OriginTracksSimulator()
     {
         var sim = new FakeReflowTerminal(width: 80, initialCursorRow: 0);
@@ -94,11 +95,11 @@ public class FlowResizeRowOriginFeasibilityTests
         foreach (var width in new[] { 80, 70, 60, 50, 40, 30, 25, 20, 15, 10, 30, 80 })
         {
             sim.Resize(width);
-            Assert.Equal(sim.ActiveWidgetRow, ComputeOrigin(0, sim, width));
+            Assert.AreEqual(sim.ActiveWidgetRow, ComputeOrigin(0, sim, width));
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void WidthGrows_PreviouslyWrappedParagraphUnwraps()
     {
         var sim = new FakeReflowTerminal(width: 40, initialCursorRow: 0);
@@ -106,15 +107,15 @@ public class FlowResizeRowOriginFeasibilityTests
         sim.MarkActiveWidgetTop();
 
         sim.Resize(40);
-        Assert.Equal(2, sim.ActiveWidgetRow);
-        Assert.Equal(2, ComputeOrigin(0, sim, 40));
+        Assert.AreEqual(2, sim.ActiveWidgetRow);
+        Assert.AreEqual(2, ComputeOrigin(0, sim, 40));
 
         sim.Resize(80);
-        Assert.Equal(1, sim.ActiveWidgetRow);
-        Assert.Equal(1, ComputeOrigin(0, sim, 80));
+        Assert.AreEqual(1, sim.ActiveWidgetRow);
+        Assert.AreEqual(1, ComputeOrigin(0, sim, 80));
     }
 
-    [Fact]
+    [TestMethod]
     public void RandomWalk_NoCumulativeDrift()
     {
         // Deterministic seed so the test is reproducible.
@@ -132,32 +133,30 @@ public class FlowResizeRowOriginFeasibilityTests
             sim.Resize(width);
             var simRow = sim.ActiveWidgetRow;
             var mathRow = ComputeOrigin(initial: 5, sim, width);
-            Assert.True(
-                simRow == mathRow,
-                $"step={step} width={width} sim={simRow} math={mathRow}");
+            Assert.IsTrue(simRow == mathRow, $"step={step} width={width} sim={simRow} math={mathRow}");
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void EmptyParagraph_StillTakesOneRow()
     {
         var sim = new FakeReflowTerminal(width: 40, initialCursorRow: 0);
         sim.WriteParagraph("");
         sim.MarkActiveWidgetTop();
 
-        Assert.Equal(1, sim.ActiveWidgetRow);
-        Assert.Equal(1, ComputeOrigin(0, sim, 40));
+        Assert.AreEqual(1, sim.ActiveWidgetRow);
+        Assert.AreEqual(1, ComputeOrigin(0, sim, 40));
     }
 
-    [Fact]
+    [TestMethod]
     public void ParagraphExactlyTerminalWidth_DoesNotForceExtraRow()
     {
         var sim = new FakeReflowTerminal(width: 40, initialCursorRow: 0);
         sim.WriteParagraph(new string('x', 40));
         sim.MarkActiveWidgetTop();
 
-        Assert.Equal(1, sim.ActiveWidgetRow);
-        Assert.Equal(1, ComputeOrigin(0, sim, 40));
+        Assert.AreEqual(1, sim.ActiveWidgetRow);
+        Assert.AreEqual(1, ComputeOrigin(0, sim, 40));
     }
 
     private static int ComputeOrigin(int initial, FakeReflowTerminal sim, int width)

--- a/tests/Hex1b.Tests/Flow/FlowRunnerResizeHarnessTests.cs
+++ b/tests/Hex1b.Tests/Flow/FlowRunnerResizeHarnessTests.cs
@@ -6,7 +6,6 @@ using Hex1b;
 using Hex1b.Flow;
 using Hex1b.Input;
 using Hex1b.Widgets;
-using Xunit;
 
 namespace Hex1b.Tests.Flow;
 
@@ -24,9 +23,10 @@ namespace Hex1b.Tests.Flow;
 /// resize-handling discipline without being noised up by the inner app's
 /// continuous render output.
 /// </remarks>
+[TestClass]
 public class FlowRunnerResizeHarnessTests
 {
-    [Fact]
+    [TestMethod]
     public async Task PerEventDuringDrag_DoesNotEmitBytesThatWouldScrollHostTerminal()
     {
         var adapter = new RecordingParentAdapter(width: 80, height: 24);
@@ -83,9 +83,7 @@ public class FlowRunnerResizeHarnessTests
         Assert.DoesNotContain("\x1b[J", duringBurst);
         Assert.DoesNotContain("\x1b[2K", duringBurst);
         Assert.DoesNotContain("\x1b[K", duringBurst);
-        Assert.False(
-            Regex.IsMatch(duringBurst, @"\x1b\[\d+;\d+H"),
-            "Runner must not emit CUP (cursor position) during a resize burst.");
+        Assert.IsFalse(Regex.IsMatch(duringBurst, @"\x1b\[\d+;\d+H"), "Runner must not emit CUP (cursor position) during a resize burst.");
 
         // Let settle fire.
         await Task.Delay(150);
@@ -94,7 +92,7 @@ public class FlowRunnerResizeHarnessTests
         await runTask.WaitAsync(TimeSpan.FromSeconds(2));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DuringDrag_RunnerDisablesDECAWM_SoStaleInnerAppOutputCannotScrollTombstones()
     {
         // The inner Hex1bApp keeps emitting frames during a drag (focus

--- a/tests/Hex1b.Tests/Flow/SoftWrapEmitterHardNewlineTests.cs
+++ b/tests/Hex1b.Tests/Flow/SoftWrapEmitterHardNewlineTests.cs
@@ -14,9 +14,10 @@ namespace Hex1b.Tests.Flow;
 /// the host's grid and the row-origin recompute described in
 /// <c>FlowResizeRowOriginFeasibilityTests</c> stops matching reality.
 /// </summary>
+[TestClass]
 public class SoftWrapEmitterHardNewlineTests
 {
-    [Fact]
+    [TestMethod]
     public void Format_MultiRowSurface_TerminatesInteriorRowsWithCarriageReturnPlusLineFeed()
     {
         var surface = new Surface(20, 4);
@@ -37,7 +38,7 @@ public class SoftWrapEmitterHardNewlineTests
         Assert.EndsWith("row-3\x1b[K\x1b[?25h", output);
     }
 
-    [Fact]
+    [TestMethod]
     public void Format_NoBareLineFeedsAtInteriorRowBoundaries()
     {
         // Walk the output looking for any inter-row boundary terminated by
@@ -56,12 +57,11 @@ public class SoftWrapEmitterHardNewlineTests
         for (var i = 0; i < output.Length; i++)
         {
             if (output[i] != '\n') continue;
-            Assert.True(i > 0 && output[i - 1] == '\r',
-                $"Bare LF found at index {i}; every LF must be preceded by CR. Output: {output.Replace("\x1b", "ESC")}");
+            Assert.IsTrue(i > 0 && output[i - 1] == '\r', $"Bare LF found at index {i}; every LF must be preceded by CR. Output: {output.Replace("\x1b", "ESC")}");
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Format_SingleRowSurface_HasNoLineTerminatorAtAll()
     {
         // Single-row case: the only row is also the last row, so no CR or

--- a/tests/Hex1b.Tests/Flow/SoftWrapEmitterTests.cs
+++ b/tests/Hex1b.Tests/Flow/SoftWrapEmitterTests.cs
@@ -9,18 +9,19 @@ namespace Hex1b.Tests.Flow;
 /// shape of the output so the host terminal can soft-wrap and scroll
 /// tombstoned content naturally on resize.
 /// </summary>
+[TestClass]
 public class SoftWrapEmitterTests
 {
-    [Fact]
+    [TestMethod]
     public void Format_ZeroHeightSurface_RejectedByCtor()
     {
         // Surface requires a non-zero height; SoftWrapEmitter is therefore
         // never invoked on an empty surface in practice. Document the
         // boundary so we don't accidentally start passing zero in the runner.
-        Assert.Throws<ArgumentOutOfRangeException>(() => new Surface(10, 0));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new Surface(10, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void Format_AllRowsBlank_EmitsClearLinePerRow_AndCrLfBetweenRows()
     {
         var surface = new Surface(20, 3);
@@ -30,16 +31,14 @@ public class SoftWrapEmitterTests
         // Preamble + (ESC[K + CR + LF) for rows 0..n-2 + ESC[K for the last row + epilogue.
         // The last row deliberately omits the CR + LF so emitting at the bottom
         // of the viewport does not scroll the screen.
-        Assert.Equal(
-            "\x1b[?25l\x1b[?7h" +
+        Assert.AreEqual("\x1b[?25l\x1b[?7h" +
             "\x1b[K\r\n" +
             "\x1b[K\r\n" +
             "\x1b[K" +
-            "\x1b[?25h",
-            output);
+            "\x1b[?25h", output);
     }
 
-    [Fact]
+    [TestMethod]
     public void Format_PlainTextRow_EmitsCharactersThenClearLine()
     {
         var surface = new Surface(20, 1);
@@ -56,7 +55,7 @@ public class SoftWrapEmitterTests
         Assert.EndsWith("\x1b[?25h", output);
     }
 
-    [Fact]
+    [TestMethod]
     public void Format_PlainTextRow_DoesNotEmitTrailingBlanksAsCharacters()
     {
         var surface = new Surface(20, 1);
@@ -71,7 +70,7 @@ public class SoftWrapEmitterTests
         Assert.DoesNotContain("hi  ", output);
     }
 
-    [Fact]
+    [TestMethod]
     public void Format_RowWithLeadingBlanks_EmitsSpacesUpToContent()
     {
         // Leading blanks must be preserved as actual spaces because we can't
@@ -84,7 +83,7 @@ public class SoftWrapEmitterTests
         Assert.Contains("   x\x1b[K", output);
     }
 
-    [Fact]
+    [TestMethod]
     public void Format_RowWithForegroundColor_EmitsSgrResetThenColor()
     {
         var surface = new Surface(10, 1);
@@ -98,7 +97,7 @@ public class SoftWrapEmitterTests
         Assert.Contains("X\x1b[0m\x1b[K", output);
     }
 
-    [Fact]
+    [TestMethod]
     public void Format_MultipleColorsInRow_GroupsConsecutiveCellsIntoRuns()
     {
         var surface = new Surface(10, 1);
@@ -113,7 +112,7 @@ public class SoftWrapEmitterTests
         Assert.Contains("\x1b[0;31mAB\x1b[32mCD", output);
     }
 
-    [Fact]
+    [TestMethod]
     public void Format_BackgroundColor_ResetBeforeClearLineSoCellsDontInherit()
     {
         var surface = new Surface(5, 1);
@@ -127,7 +126,7 @@ public class SoftWrapEmitterTests
         Assert.Contains("\x1b[0m\x1b[K", output);
     }
 
-    [Fact]
+    [TestMethod]
     public void Format_WideCharacter_EmitsGraphemeOnceAndSkipsContinuation()
     {
         var surface = new Surface(10, 1);
@@ -142,7 +141,7 @@ public class SoftWrapEmitterTests
         Assert.Contains("漢A\x1b[K", output);
     }
 
-    [Fact]
+    [TestMethod]
     public void Format_StartsWithCursorHide_EndsWithCursorShow()
     {
         var surface = new Surface(10, 2);
@@ -155,7 +154,7 @@ public class SoftWrapEmitterTests
         Assert.EndsWith("\x1b[?25h", output);
     }
 
-    [Fact]
+    [TestMethod]
     public void Format_EmitsAutowrapEnableInPreamble()
     {
         var surface = new Surface(5, 1);
@@ -169,10 +168,10 @@ public class SoftWrapEmitterTests
         // The hint comes before any row content.
         var awmIdx = output.IndexOf("\x1b[?7h", StringComparison.Ordinal);
         var firstA = output.IndexOf('a');
-        Assert.True(awmIdx < firstA);
+        Assert.IsTrue(awmIdx < firstA);
     }
 
-    [Fact]
+    [TestMethod]
     public void Format_MultiRow_EmitsCrLfBetweenRowsButNotAfterLast()
     {
         var surface = new Surface(8, 4);
@@ -185,8 +184,8 @@ public class SoftWrapEmitterTests
 
         // CR + LF between rows: 3 of them for a 4-row surface (rows 0, 1, 2 end
         // with CR + LF; row 3 — the last row — ends with just ESC[K).
-        Assert.Equal(3, output.Count(c => c == '\n'));
-        Assert.Equal(3, output.Count(c => c == '\r'));
+        Assert.AreEqual(3, output.Count(c => c == '\n'));
+        Assert.AreEqual(3, output.Count(c => c == '\r'));
 
         // Rows 0, 1, 2 each terminate with ESC[K + CR + LF.
         Assert.Contains("r0\x1b[K\r\n", output);
@@ -200,7 +199,7 @@ public class SoftWrapEmitterTests
         Assert.DoesNotContain("r3\x1b[K\n", output);
     }
 
-    [Fact]
+    [TestMethod]
     public void Format_MultiRow_EmitsCarriageReturnBeforeLineFeed_SoNextRowStartsAtColumnZero()
     {
         // Regression: in raw output mode a bare LF only moves the cursor down
@@ -220,7 +219,7 @@ public class SoftWrapEmitterTests
         Assert.DoesNotContain("abc\x1b[K\n", output);
     }
 
-    [Fact]
+    [TestMethod]
     public void Format_BoldAttribute_EmittedAsSgr1()
     {
         var surface = new Surface(5, 1);
@@ -231,7 +230,7 @@ public class SoftWrapEmitterTests
         Assert.Contains("\x1b[0;1mB", output);
     }
 
-    [Fact]
+    [TestMethod]
     public void Format_RowWithOnlyBlanks_BetweenContentRows_StillCleared()
     {
         var surface = new Surface(8, 3);
@@ -247,7 +246,7 @@ public class SoftWrapEmitterTests
         Assert.Contains("bottom\x1b[K", output);
         Assert.DoesNotContain("bottom\x1b[K\r\n", output);
         // Two line feeds total: one between rows 0/1, one between rows 1/2.
-        Assert.Equal(2, output.Count(c => c == '\n'));
-        Assert.Equal(2, output.Count(c => c == '\r'));
+        Assert.AreEqual(2, output.Count(c => c == '\n'));
+        Assert.AreEqual(2, output.Count(c => c == '\r'));
     }
 }

--- a/tests/Hex1b.Tests/FoldingRegionTests.cs
+++ b/tests/Hex1b.Tests/FoldingRegionTests.cs
@@ -8,6 +8,7 @@ namespace Hex1b.Tests;
 /// Tests for <see cref="FoldingRegion"/>, <see cref="FoldingRegionKind"/>,
 /// and their integration with <see cref="IEditorSession"/> on <see cref="EditorNode"/>.
 /// </summary>
+[TestClass]
 public class FoldingRegionTests
 {
     private static IEditorSession CreateSession(string text = "line1\nline2\nline3\nline4\nline5")
@@ -20,7 +21,7 @@ public class FoldingRegionTests
 
     // ── IEditorSession integration ───────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void SetFoldingRegions_WithRegions_StoresAndReturnsRegions()
     {
         var session = CreateSession();
@@ -32,12 +33,12 @@ public class FoldingRegionTests
 
         session.SetFoldingRegions(regions);
 
-        Assert.Equal(2, session.FoldingRegions.Count);
-        Assert.Equal(1, session.FoldingRegions[0].StartLine);
-        Assert.Equal(5, session.FoldingRegions[0].EndLine);
+        Assert.AreEqual(2, session.FoldingRegions.Count);
+        Assert.AreEqual(1, session.FoldingRegions[0].StartLine);
+        Assert.AreEqual(5, session.FoldingRegions[0].EndLine);
     }
 
-    [Fact]
+    [TestMethod]
     public void SetFoldingRegions_CalledTwice_ReplacesPreviousRegions()
     {
         var session = CreateSession();
@@ -45,11 +46,11 @@ public class FoldingRegionTests
 
         session.SetFoldingRegions([new FoldingRegion(2, 5)]);
 
-        Assert.Single(session.FoldingRegions);
-        Assert.Equal(2, session.FoldingRegions[0].StartLine);
+        TestSeq.Single(session.FoldingRegions);
+        Assert.AreEqual(2, session.FoldingRegions[0].StartLine);
     }
 
-    [Fact]
+    [TestMethod]
     public void SetFoldingRegions_EmptyList_ClearsPreviousRegions()
     {
         var session = CreateSession();
@@ -57,75 +58,75 @@ public class FoldingRegionTests
 
         session.SetFoldingRegions([]);
 
-        Assert.Empty(session.FoldingRegions);
+        Assert.IsEmpty(session.FoldingRegions);
     }
 
-    [Fact]
+    [TestMethod]
     public void FoldingRegions_Default_ReturnsEmptyList()
     {
         var session = CreateSession();
 
-        Assert.Empty(session.FoldingRegions);
+        Assert.IsEmpty(session.FoldingRegions);
     }
 
     // ── FoldingRegion construction ───────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void FoldingRegion_DefaultKind_IsRegion()
     {
         var region = new FoldingRegion(1, 10);
 
-        Assert.Equal(FoldingRegionKind.Region, region.Kind);
+        Assert.AreEqual(FoldingRegionKind.Region, region.Kind);
     }
 
-    [Fact]
+    [TestMethod]
     public void FoldingRegion_DefaultIsCollapsed_IsFalse()
     {
         var region = new FoldingRegion(1, 10);
 
-        Assert.False(region.IsCollapsed);
+        Assert.IsFalse(region.IsCollapsed);
     }
 
-    [Fact]
+    [TestMethod]
     public void FoldingRegion_WithIsCollapsedTrue_PreservesValue()
     {
         var region = new FoldingRegion(1, 10) { IsCollapsed = true };
 
-        Assert.True(region.IsCollapsed);
+        Assert.IsTrue(region.IsCollapsed);
     }
 
-    [Theory]
-    [InlineData(FoldingRegionKind.Region)]
-    [InlineData(FoldingRegionKind.Comment)]
-    [InlineData(FoldingRegionKind.Imports)]
+    [TestMethod]
+    [DataRow(FoldingRegionKind.Region)]
+    [DataRow(FoldingRegionKind.Comment)]
+    [DataRow(FoldingRegionKind.Imports)]
     public void FoldingRegion_AllKinds_AreValid(FoldingRegionKind kind)
     {
         var region = new FoldingRegion(1, 5, kind);
 
-        Assert.Equal(kind, region.Kind);
+        Assert.AreEqual(kind, region.Kind);
     }
 
-    [Fact]
+    [TestMethod]
     public void FoldingRegion_CommentKind_SetsCorrectly()
     {
         var region = new FoldingRegion(1, 5, FoldingRegionKind.Comment);
 
-        Assert.Equal(FoldingRegionKind.Comment, region.Kind);
-        Assert.Equal(1, region.StartLine);
-        Assert.Equal(5, region.EndLine);
+        Assert.AreEqual(FoldingRegionKind.Comment, region.Kind);
+        Assert.AreEqual(1, region.StartLine);
+        Assert.AreEqual(5, region.EndLine);
     }
 
-    [Fact]
+    [TestMethod]
     public void FoldingRegion_ImportsKind_SetsCorrectly()
     {
         var region = new FoldingRegion(1, 3, FoldingRegionKind.Imports);
 
-        Assert.Equal(FoldingRegionKind.Imports, region.Kind);
+        Assert.AreEqual(FoldingRegionKind.Imports, region.Kind);
     }
 
     // ── Overlapping / nested regions ─────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void SetFoldingRegions_OverlappingNestedRegions_StoresAll()
     {
         var session = CreateSession();
@@ -138,16 +139,16 @@ public class FoldingRegionTests
 
         session.SetFoldingRegions(regions);
 
-        Assert.Equal(3, session.FoldingRegions.Count);
-        Assert.Equal(1, session.FoldingRegions[0].StartLine);
-        Assert.Equal(10, session.FoldingRegions[0].EndLine);
-        Assert.Equal(3, session.FoldingRegions[1].StartLine);
-        Assert.Equal(7, session.FoldingRegions[1].EndLine);
-        Assert.Equal(4, session.FoldingRegions[2].StartLine);
-        Assert.Equal(6, session.FoldingRegions[2].EndLine);
+        Assert.AreEqual(3, session.FoldingRegions.Count);
+        Assert.AreEqual(1, session.FoldingRegions[0].StartLine);
+        Assert.AreEqual(10, session.FoldingRegions[0].EndLine);
+        Assert.AreEqual(3, session.FoldingRegions[1].StartLine);
+        Assert.AreEqual(7, session.FoldingRegions[1].EndLine);
+        Assert.AreEqual(4, session.FoldingRegions[2].StartLine);
+        Assert.AreEqual(6, session.FoldingRegions[2].EndLine);
     }
 
-    [Fact]
+    [TestMethod]
     public void SetFoldingRegions_MixedCollapsedState_PreservesEach()
     {
         var session = CreateSession();
@@ -157,37 +158,37 @@ public class FoldingRegionTests
             new FoldingRegion(11, 15) { IsCollapsed = true }
         ]);
 
-        Assert.True(session.FoldingRegions[0].IsCollapsed);
-        Assert.False(session.FoldingRegions[1].IsCollapsed);
-        Assert.True(session.FoldingRegions[2].IsCollapsed);
+        Assert.IsTrue(session.FoldingRegions[0].IsCollapsed);
+        Assert.IsFalse(session.FoldingRegions[1].IsCollapsed);
+        Assert.IsTrue(session.FoldingRegions[2].IsCollapsed);
     }
 
     // ── Record equality ──────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void FoldingRegion_RecordEquality_EqualWhenSameValues()
     {
         var a = new FoldingRegion(1, 10, FoldingRegionKind.Comment);
         var b = new FoldingRegion(1, 10, FoldingRegionKind.Comment);
 
-        Assert.Equal(a, b);
+        Assert.AreEqual(a, b);
     }
 
-    [Fact]
+    [TestMethod]
     public void FoldingRegion_RecordEquality_NotEqualWhenDifferentCollapsed()
     {
         var a = new FoldingRegion(1, 10) { IsCollapsed = false };
         var b = new FoldingRegion(1, 10) { IsCollapsed = true };
 
-        Assert.NotEqual(a, b);
+        Assert.AreNotEqual(a, b);
     }
 
-    [Fact]
+    [TestMethod]
     public void FoldingRegion_RecordEquality_NotEqualWhenDifferentKind()
     {
         var a = new FoldingRegion(1, 10, FoldingRegionKind.Region);
         var b = new FoldingRegion(1, 10, FoldingRegionKind.Comment);
 
-        Assert.NotEqual(a, b);
+        Assert.AreNotEqual(a, b);
     }
 }

--- a/tests/Hex1b.Tests/FormNodeTests.cs
+++ b/tests/Hex1b.Tests/FormNodeTests.cs
@@ -4,9 +4,10 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class FormNodeTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_CreatesFormNode()
     {
         var widget = new FormWidget([new TextBlockWidget("Hello")]);
@@ -14,10 +15,10 @@ public class FormNodeTests
 
         var node = await widget.ReconcileAsync(null, context);
 
-        Assert.IsType<FormNode>(node);
+        TestSeq.IsType<FormNode>(node);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_CreatesContentChild()
     {
         var widget = new FormWidget([new TextBlockWidget("Hello")]);
@@ -25,10 +26,10 @@ public class FormNodeTests
 
         var node = (FormNode)await widget.ReconcileAsync(null, context);
 
-        Assert.NotNull(node.Content);
+        Assert.IsNotNull(node.Content);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_ReusesExistingNode()
     {
         var widget = new FormWidget([new TextBlockWidget("Hello")]);
@@ -37,10 +38,10 @@ public class FormNodeTests
         var node1 = await widget.ReconcileAsync(null, context);
         var node2 = await widget.ReconcileAsync(node1, context);
 
-        Assert.Same(node1, node2);
+        Assert.AreSame(node1, node2);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_SetsLabelPlacement()
     {
         var widget = new FormWidget([new TextBlockWidget("Hello")])
@@ -49,10 +50,10 @@ public class FormNodeTests
 
         var node = (FormNode)await widget.ReconcileAsync(null, context);
 
-        Assert.Equal(LabelPlacement.Inline, node.LabelPlacement);
+        Assert.AreEqual(LabelPlacement.Inline, node.LabelPlacement);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_SetsLabelWidth()
     {
         var widget = new FormWidget([new TextBlockWidget("Hello")])
@@ -61,10 +62,10 @@ public class FormNodeTests
 
         var node = (FormNode)await widget.ReconcileAsync(null, context);
 
-        Assert.Equal(25, node.LabelWidth);
+        Assert.AreEqual(25, node.LabelWidth);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithContent_DelegatesToContent()
     {
         var contentChild = new TextBlockNode { Text = "Field" };
@@ -72,22 +73,22 @@ public class FormNodeTests
 
         var size = node.Measure(new Constraints(0, 40, 0, 10));
 
-        Assert.True(size.Width > 0);
-        Assert.True(size.Height > 0);
+        Assert.IsTrue(size.Width > 0);
+        Assert.IsTrue(size.Height > 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithoutContent_ReturnsZero()
     {
         var node = new FormNode();
 
         var size = node.Measure(new Constraints(0, 40, 0, 10));
 
-        Assert.Equal(0, size.Width);
-        Assert.Equal(0, size.Height);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(0, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_PassesThroughToContent()
     {
         var contentChild = new TextBlockNode { Text = "Field" };
@@ -97,11 +98,11 @@ public class FormNodeTests
         var rect = new Rect(0, 0, 40, 5);
         node.Arrange(rect);
 
-        Assert.Equal(rect, node.Bounds);
-        Assert.Equal(rect, contentChild.Bounds);
+        Assert.AreEqual(rect, node.Bounds);
+        Assert.AreEqual(rect, contentChild.Bounds);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_ReturnsContent()
     {
         var contentChild = new TextBlockNode { Text = "Field" };
@@ -109,41 +110,41 @@ public class FormNodeTests
 
         var children = node.GetChildren().ToList();
 
-        Assert.Single(children);
-        Assert.Same(contentChild, children[0]);
+        TestSeq.Single(children);
+        Assert.AreSame(contentChild, children[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_WhenNoContent_ReturnsEmpty()
     {
         var node = new FormNode();
 
         var children = node.GetChildren().ToList();
 
-        Assert.Empty(children);
+        Assert.IsEmpty(children);
     }
 
-    [Fact]
+    [TestMethod]
     public void SetFieldValue_StoresValue()
     {
         var node = new FormNode();
 
         node.SetFieldValue("firstName", "John");
 
-        Assert.Equal("John", node.GetFieldValue("firstName"));
+        Assert.AreEqual("John", node.GetFieldValue("firstName"));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetFieldValue_WhenNotSet_ReturnsEmpty()
     {
         var node = new FormNode();
 
         var value = node.GetFieldValue("nonexistent");
 
-        Assert.Equal("", value);
+        Assert.AreEqual("", value);
     }
 
-    [Fact]
+    [TestMethod]
     public void SetValidationResult_StoresResult()
     {
         var node = new FormNode();
@@ -152,51 +153,51 @@ public class FormNodeTests
         node.SetValidationResult("email", error);
 
         var result = node.GetValidationResult("email");
-        Assert.False(result.IsValid);
-        Assert.Equal("Required", result.ErrorMessage);
+        Assert.IsFalse(result.IsValid);
+        Assert.AreEqual("Required", result.ErrorMessage);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetValidationResult_WhenNotSet_ReturnsValid()
     {
         var node = new FormNode();
 
         var result = node.GetValidationResult("nonexistent");
 
-        Assert.True(result.IsValid);
+        Assert.IsTrue(result.IsValid);
     }
 
-    [Fact]
+    [TestMethod]
     public void AreFieldsValid_AllValid_ReturnsTrue()
     {
         var node = new FormNode();
         node.SetValidationResult("a", ValidationResult.Valid);
         node.SetValidationResult("b", ValidationResult.Valid);
 
-        Assert.True(node.AreFieldsValid(["a", "b"]));
+        Assert.IsTrue(node.AreFieldsValid(["a", "b"]));
     }
 
-    [Fact]
+    [TestMethod]
     public void AreFieldsValid_OneInvalid_ReturnsFalse()
     {
         var node = new FormNode();
         node.SetValidationResult("a", ValidationResult.Valid);
         node.SetValidationResult("b", ValidationResult.Error("bad"));
 
-        Assert.False(node.AreFieldsValid(["a", "b"]));
+        Assert.IsFalse(node.AreFieldsValid(["a", "b"]));
     }
 
-    [Fact]
+    [TestMethod]
     public void AreFieldsValid_UnknownField_ReturnsTrue()
     {
         var node = new FormNode();
 
-        Assert.True(node.AreFieldsValid(["unknown"]));
+        Assert.IsTrue(node.AreFieldsValid(["unknown"]));
     }
 
     #region FormContext ValidationErrors Tests
 
-    [Fact]
+    [TestMethod]
     public void FormContext_ValidationErrors_ReturnsOnlyErrors()
     {
         // FormContext.ValidationErrors should only include fields with errors, not valid ones.
@@ -210,13 +211,13 @@ public class FormNodeTests
 
         var errors = ctx.ValidationErrors;
 
-        Assert.Equal(2, errors.Count);
-        Assert.True(errors.ContainsKey("field_1_Email"));
-        Assert.True(errors.ContainsKey("field_2_Phone"));
-        Assert.False(errors.ContainsKey("field_0_Name"));
+        Assert.AreEqual(2, errors.Count);
+        Assert.IsTrue(errors.ContainsKey("field_1_Email"));
+        Assert.IsTrue(errors.ContainsKey("field_2_Phone"));
+        Assert.IsFalse(errors.ContainsKey("field_0_Name"));
     }
 
-    [Fact]
+    [TestMethod]
     public void FormContext_ValidationErrors_EmptyWhenAllValid()
     {
         var ctx = new FormContext();
@@ -225,19 +226,19 @@ public class FormNodeTests
 
         formNode.SetValidationResult("field_0_Name", ValidationResult.Valid);
 
-        Assert.Empty(ctx.ValidationErrors);
+        Assert.IsEmpty(ctx.ValidationErrors);
     }
 
-    [Fact]
+    [TestMethod]
     public void FormContext_ValidationErrors_EmptyWhenNoFormNode()
     {
         // Before reconciliation, _formNode is null — should return empty.
         var ctx = new FormContext();
 
-        Assert.Empty(ctx.ValidationErrors);
+        Assert.IsEmpty(ctx.ValidationErrors);
     }
 
-    [Fact]
+    [TestMethod]
     public void FormContext_ValidationResults_ReturnsAll()
     {
         // ValidationResults should include both valid and invalid entries.
@@ -250,16 +251,16 @@ public class FormNodeTests
 
         var results = ctx.ValidationResults;
 
-        Assert.Equal(2, results.Count);
-        Assert.True(results["field_0_Name"].IsValid);
-        Assert.False(results["field_1_Email"].IsValid);
+        Assert.AreEqual(2, results.Count);
+        Assert.IsTrue(results["field_0_Name"].IsValid);
+        Assert.IsFalse(results["field_1_Email"].IsValid);
     }
 
     #endregion
 
     #region ValidationSummary Tests
 
-    [Fact]
+    [TestMethod]
     public async Task ValidationSummary_NoErrors_ReconcilesEmpty()
     {
         // When there are no validation errors, the summary should reconcile
@@ -270,10 +271,10 @@ public class FormNodeTests
         var widget = new ValidationSummaryWidget();
         var node = await widget.ReconcileAsync(null, context);
 
-        Assert.NotNull(node);
+        Assert.IsNotNull(node);
     }
 
-    [Fact]
+    [TestMethod]
     public void ValidationSummaryExtension_CreatesWidget()
     {
         // The form.ValidationSummary() extension should create a ValidationSummaryWidget.
@@ -282,7 +283,7 @@ public class FormNodeTests
 
         var widget = ctx.ValidationSummary();
 
-        Assert.IsType<ValidationSummaryWidget>(widget);
+        TestSeq.IsType<ValidationSummaryWidget>(widget);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/FormTextFieldNodeTests.cs
+++ b/tests/Hex1b.Tests/FormTextFieldNodeTests.cs
@@ -4,9 +4,10 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class FormTextFieldNodeTests
 {
-    [Fact]
+    [TestMethod]
     public void RunValidation_ValidValue_ResultIsValid()
     {
         var node = new FormTextFieldNode
@@ -17,10 +18,10 @@ public class FormTextFieldNodeTests
 
         node.RunValidation();
 
-        Assert.True(node.CurrentValidationResult.IsValid);
+        Assert.IsTrue(node.CurrentValidationResult.IsValid);
     }
 
-    [Fact]
+    [TestMethod]
     public void RunValidation_InvalidValue_SetsErrorResult()
     {
         var node = new FormTextFieldNode
@@ -33,11 +34,11 @@ public class FormTextFieldNodeTests
 
         node.RunValidation();
 
-        Assert.False(node.CurrentValidationResult.IsValid);
-        Assert.Equal("Required", node.CurrentValidationResult.ErrorMessage);
+        Assert.IsFalse(node.CurrentValidationResult.IsValid);
+        Assert.AreEqual("Required", node.CurrentValidationResult.ErrorMessage);
     }
 
-    [Fact]
+    [TestMethod]
     public void RunValidation_MultipleValidators_StopsAtFirstError()
     {
         var secondValidatorCalled = false;
@@ -52,12 +53,12 @@ public class FormTextFieldNodeTests
 
         node.RunValidation();
 
-        Assert.False(node.CurrentValidationResult.IsValid);
-        Assert.Equal("First error", node.CurrentValidationResult.ErrorMessage);
-        Assert.False(secondValidatorCalled);
+        Assert.IsFalse(node.CurrentValidationResult.IsValid);
+        Assert.AreEqual("First error", node.CurrentValidationResult.ErrorMessage);
+        Assert.IsFalse(secondValidatorCalled);
     }
 
-    [Fact]
+    [TestMethod]
     public void RunValidation_NoValidators_RemainsValid()
     {
         var node = new FormTextFieldNode
@@ -68,10 +69,10 @@ public class FormTextFieldNodeTests
 
         node.RunValidation();
 
-        Assert.True(node.CurrentValidationResult.IsValid);
+        Assert.IsTrue(node.CurrentValidationResult.IsValid);
     }
 
-    [Fact]
+    [TestMethod]
     public void RunValidation_ValueBecomesValid_ClearsError()
     {
         var node = new FormTextFieldNode
@@ -83,14 +84,14 @@ public class FormTextFieldNodeTests
         };
 
         node.RunValidation();
-        Assert.False(node.CurrentValidationResult.IsValid);
+        Assert.IsFalse(node.CurrentValidationResult.IsValid);
 
         node.CurrentValue = "now valid";
         node.RunValidation();
-        Assert.True(node.CurrentValidationResult.IsValid);
+        Assert.IsTrue(node.CurrentValidationResult.IsValid);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithLabelAndInput_IncludesBothRows()
     {
         var labelChild = new TextBlockNode { Text = "Name" };
@@ -105,10 +106,10 @@ public class FormTextFieldNodeTests
         var size = node.Measure(new Constraints(0, 30, 0, 20));
 
         // Label row + input row = at least 2 rows
-        Assert.True(size.Height >= 2);
+        Assert.IsTrue(size.Height >= 2);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_InputOnly_SingleRow()
     {
         var inputChild = new TextBoxNode();
@@ -121,10 +122,10 @@ public class FormTextFieldNodeTests
         var size = node.Measure(new Constraints(0, 30, 0, 20));
 
         // Just input row
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_LabelAboveInput()
     {
         var labelChild = new TextBlockNode { Text = "Name" };
@@ -140,11 +141,11 @@ public class FormTextFieldNodeTests
         node.Arrange(new Rect(0, 0, 30, 5));
 
         // Label at row 0, input at row 1
-        Assert.Equal(0, labelChild.Bounds.Y);
-        Assert.Equal(1, inputChild.Bounds.Y);
+        Assert.AreEqual(0, labelChild.Bounds.Y);
+        Assert.AreEqual(1, inputChild.Bounds.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_InlineMode_SingleRow()
     {
         var labelChild = new TextBlockNode { Text = "Name" };
@@ -160,10 +161,10 @@ public class FormTextFieldNodeTests
 
         var size = node.Measure(new Constraints(0, 40, 0, 20));
 
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_InlineMode_LabelBesideInput()
     {
         var labelChild = new TextBlockNode { Text = "Name" };
@@ -181,13 +182,13 @@ public class FormTextFieldNodeTests
         node.Arrange(new Rect(0, 0, 40, 5));
 
         // Same row, label on left, input starts at label width
-        Assert.Equal(0, labelChild.Bounds.Y);
-        Assert.Equal(0, inputChild.Bounds.Y);
-        Assert.Equal(0, labelChild.Bounds.X);
-        Assert.Equal(12, inputChild.Bounds.X);
+        Assert.AreEqual(0, labelChild.Bounds.Y);
+        Assert.AreEqual(0, inputChild.Bounds.Y);
+        Assert.AreEqual(0, labelChild.Bounds.X);
+        Assert.AreEqual(12, inputChild.Bounds.X);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_ReturnsAllChildren()
     {
         var label = new TextBlockNode { Text = "Name" };
@@ -203,13 +204,13 @@ public class FormTextFieldNodeTests
 
         var children = node.GetChildren().ToList();
 
-        Assert.Equal(3, children.Count);
+        Assert.AreEqual(3, children.Count);
         Assert.Contains(label, children);
         Assert.Contains(input, children);
         Assert.Contains(adornment, children);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_SkipsNullChildren()
     {
         var input = new TextBoxNode();
@@ -221,11 +222,11 @@ public class FormTextFieldNodeTests
 
         var children = node.GetChildren().ToList();
 
-        Assert.Single(children);
-        Assert.Same(input, children[0]);
+        TestSeq.Single(children);
+        Assert.AreSame(input, children[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetFocusableNodes_ReturnsInputFocusables()
     {
         var input = new TextBoxNode();
@@ -240,10 +241,10 @@ public class FormTextFieldNodeTests
         var focusables = node.GetFocusableNodes().ToList();
 
         // TextBoxNode is focusable
-        Assert.NotEmpty(focusables);
+        Assert.IsNotEmpty(focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_CreatesFormTextFieldNode()
     {
         var widget = new FormTextFieldWidget("field1", "Name");
@@ -251,10 +252,10 @@ public class FormTextFieldNodeTests
 
         var node = await widget.ReconcileAsync(null, context);
 
-        Assert.IsType<FormTextFieldNode>(node);
+        TestSeq.IsType<FormTextFieldNode>(node);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_SetsFieldIdAndLabel()
     {
         var widget = new FormTextFieldWidget("field1", "Name");
@@ -262,11 +263,11 @@ public class FormTextFieldNodeTests
 
         var node = (FormTextFieldNode)await widget.ReconcileAsync(null, context);
 
-        Assert.Equal("field1", node.FieldId);
-        Assert.Equal("Name", node.Label);
+        Assert.AreEqual("field1", node.FieldId);
+        Assert.AreEqual("Name", node.Label);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_CreatesLabelAndInputChildren()
     {
         var widget = new FormTextFieldWidget("field1", "Name");
@@ -274,11 +275,11 @@ public class FormTextFieldNodeTests
 
         var node = (FormTextFieldNode)await widget.ReconcileAsync(null, context);
 
-        Assert.NotNull(node.LabelChild);
-        Assert.NotNull(node.InputChild);
+        Assert.IsNotNull(node.LabelChild);
+        Assert.IsNotNull(node.InputChild);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_ReusesExistingNode()
     {
         var widget = new FormTextFieldWidget("field1", "Name");
@@ -287,10 +288,10 @@ public class FormTextFieldNodeTests
         var node1 = await widget.ReconcileAsync(null, context);
         var node2 = await widget.ReconcileAsync(node1, context);
 
-        Assert.Same(node1, node2);
+        Assert.AreSame(node1, node2);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_AppliesInitialValue()
     {
         var widget = new FormTextFieldWidget("field1", "Name")
@@ -299,11 +300,11 @@ public class FormTextFieldNodeTests
 
         var node = (FormTextFieldNode)await widget.ReconcileAsync(null, context);
 
-        Assert.Equal("John", node.CurrentValue);
-        Assert.True(node.HasAppliedInitialValue);
+        Assert.AreEqual("John", node.CurrentValue);
+        Assert.IsTrue(node.HasAppliedInitialValue);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_InitialValueAppliedOnlyOnce()
     {
         var widget = new FormTextFieldWidget("field1", "Name")
@@ -316,10 +317,10 @@ public class FormTextFieldNodeTests
         // Re-reconcile — initial value should NOT override user's change
         await widget.ReconcileAsync(node, context);
 
-        Assert.Equal("Jane", node.CurrentValue);
+        Assert.AreEqual("Jane", node.CurrentValue);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_NoAdornmentsWhenValid()
     {
         var widget = new FormTextFieldWidget("field1", "Name");
@@ -327,10 +328,10 @@ public class FormTextFieldNodeTests
 
         var node = (FormTextFieldNode)await widget.ReconcileAsync(null, context);
 
-        Assert.Empty(node.AdornmentChildren);
+        Assert.IsEmpty(node.AdornmentChildren);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_SetsValidators()
     {
         Func<string, ValidationResult> validator = v => ValidationResult.Valid;
@@ -340,12 +341,12 @@ public class FormTextFieldNodeTests
 
         var node = (FormTextFieldNode)await widget.ReconcileAsync(null, context);
 
-        Assert.Single(node.Validators);
+        TestSeq.Single(node.Validators);
     }
 
     #region Adornment Tests
 
-    [Fact]
+    [TestMethod]
     public void EvaluateAdornments_SyncPredicate_SetsVisibilityImmediately()
     {
         // A sync predicate (wrapped in Task.FromResult) should resolve immediately
@@ -362,12 +363,12 @@ public class FormTextFieldNodeTests
         // Give async tasks a moment to complete (they're sync-wrapped)
         Thread.Sleep(50);
 
-        Assert.Equal(2, node.AdornmentVisibility.Count);
-        Assert.True(node.AdornmentVisibility[0]);
-        Assert.False(node.AdornmentVisibility[1]);
+        Assert.AreEqual(2, node.AdornmentVisibility.Count);
+        Assert.IsTrue(node.AdornmentVisibility[0]);
+        Assert.IsFalse(node.AdornmentVisibility[1]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task EvaluateAdornments_AsyncPredicate_SetsVisibilityWhenResolved()
     {
         // An async predicate should set visibility after it resolves.
@@ -381,17 +382,17 @@ public class FormTextFieldNodeTests
         node.EvaluateAdornments(adornments, "test");
 
         // Before resolution, visibility should be false (default)
-        Assert.Single(node.AdornmentVisibility);
-        Assert.False(node.AdornmentVisibility[0]);
+        TestSeq.Single(node.AdornmentVisibility);
+        Assert.IsFalse(node.AdornmentVisibility[0]);
 
         // Resolve the predicate
         tcs.SetResult(true);
         await Task.Delay(50);
 
-        Assert.True(node.AdornmentVisibility[0]);
+        Assert.IsTrue(node.AdornmentVisibility[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task EvaluateAdornments_CancelsPreviousEvaluation()
     {
         // When EvaluateAdornments is called again, previous in-flight predicates
@@ -429,15 +430,15 @@ public class FormTextFieldNodeTests
         // Resolve the first predicate — should be ignored (cancelled)
         firstTcs.SetResult(true);
         await Task.Delay(50);
-        Assert.False(node.AdornmentVisibility[0]);
+        Assert.IsFalse(node.AdornmentVisibility[0]);
 
         // Resolve the second predicate — should update visibility
         secondTcs.SetResult(true);
         await Task.Delay(50);
-        Assert.True(node.AdornmentVisibility[0]);
+        Assert.IsTrue(node.AdornmentVisibility[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void EvaluateAdornments_PredicateException_HidesAdornment()
     {
         // If a predicate throws, the adornment should be hidden (not crash).
@@ -451,11 +452,11 @@ public class FormTextFieldNodeTests
         node.EvaluateAdornments(adornments, "test");
         Thread.Sleep(50);
 
-        Assert.Single(node.AdornmentVisibility);
-        Assert.False(node.AdornmentVisibility[0]);
+        TestSeq.Single(node.AdornmentVisibility);
+        Assert.IsFalse(node.AdornmentVisibility[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_WithAdornment_SyncPredicateTrue_AddsAdornmentChild()
     {
         // When a field has an adornment with a sync-true predicate,
@@ -480,10 +481,10 @@ public class FormTextFieldNodeTests
             .InitialValue("Hello")
             .ReconcileAsync(node, context);
 
-        Assert.NotEmpty(node.AdornmentChildren);
+        Assert.IsNotEmpty(node.AdornmentChildren);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_WithAdornment_PredicateFalse_NoAdornmentChild()
     {
         // When the adornment predicate resolves to false, no adornment child should appear.
@@ -498,10 +499,10 @@ public class FormTextFieldNodeTests
         await Task.Delay(100);
         node = (FormTextFieldNode)await widget.ReconcileAsync(node, context);
 
-        Assert.Empty(node.AdornmentChildren);
+        Assert.IsEmpty(node.AdornmentChildren);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_MultipleAdornments_OnlyVisibleOnesRendered()
     {
         // With multiple adornments, only those whose predicate resolved true
@@ -518,10 +519,10 @@ public class FormTextFieldNodeTests
         node = (FormTextFieldNode)await widget.ReconcileAsync(node, context);
 
         // Should have 2 visible adornments (A and C)
-        Assert.Equal(2, node.AdornmentChildren.Count);
+        Assert.AreEqual(2, node.AdornmentChildren.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_ValidationAdornment_ShowsErrorIndicator()
     {
         // When a field has validators and the value is invalid,
@@ -540,26 +541,26 @@ public class FormTextFieldNodeTests
         node = (FormTextFieldNode)await widget.ReconcileAsync(node, context);
 
         // Should have the validation adornment visible
-        Assert.NotEmpty(node.AdornmentChildren);
+        Assert.IsNotEmpty(node.AdornmentChildren);
     }
 
-    [Fact]
+    [TestMethod]
     public void FormTextFieldWidget_Adornment_FluentMethod_AddsToList()
     {
         var widget = new FormTextFieldWidget("field1", "Name")
             .Adornment(async (v, ct) => true, () => new TextBlockWidget("A"))
             .Adornment(async (v, ct) => false, () => new TextBlockWidget("B"));
 
-        Assert.Equal(2, widget.Adornments.Count);
+        Assert.AreEqual(2, widget.Adornments.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void FormTextFieldWidget_Adornment_WithoutCancellation_Works()
     {
         var widget = new FormTextFieldWidget("field1", "Name")
             .Adornment(async v => true, () => new TextBlockWidget("A"));
 
-        Assert.Single(widget.Adornments);
+        TestSeq.Single(widget.Adornments);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/GraphemeBoundaryWindowTests.cs
+++ b/tests/Hex1b.Tests/GraphemeBoundaryWindowTests.cs
@@ -12,122 +12,123 @@ namespace Hex1b.Tests;
 /// - Adversarial sequences that exceed the 64-char window, confirming the
 ///   documented graceful degradation (cursor lands mid-cluster)
 /// </summary>
+[TestClass]
 public class GraphemeBoundaryWindowTests
 {
     // ── Real-world sequences that fit within the 64-char window ──────
 
-    [Fact]
+    [TestMethod]
     public void PreviousCluster_Ascii_MovesOneChar()
     {
         var text = "Hello";
-        Assert.Equal(3, GraphemeHelper.GetPreviousClusterBoundary(text, 4));
+        Assert.AreEqual(3, GraphemeHelper.GetPreviousClusterBoundary(text, 4));
     }
 
-    [Fact]
+    [TestMethod]
     public void NextCluster_Ascii_MovesOneChar()
     {
         var text = "Hello";
-        Assert.Equal(2, GraphemeHelper.GetNextClusterBoundary(text, 1));
+        Assert.AreEqual(2, GraphemeHelper.GetNextClusterBoundary(text, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void PreviousCluster_SurrogatePairEmoji_SkipsEntirePair()
     {
         // 😀 = U+1F600 = 2 UTF-16 chars (surrogate pair)
         var text = "A😀B";
         // Cursor after 😀 (index 3), should skip back to index 1
-        Assert.Equal(1, GraphemeHelper.GetPreviousClusterBoundary(text, 3));
+        Assert.AreEqual(1, GraphemeHelper.GetPreviousClusterBoundary(text, 3));
     }
 
-    [Fact]
+    [TestMethod]
     public void NextCluster_SurrogatePairEmoji_SkipsEntirePair()
     {
         var text = "A😀B";
         // Cursor at 😀 start (index 1), should skip to index 3
-        Assert.Equal(3, GraphemeHelper.GetNextClusterBoundary(text, 1));
+        Assert.AreEqual(3, GraphemeHelper.GetNextClusterBoundary(text, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void PreviousCluster_EmojiWithSkinTone_SkipsEntireSequence()
     {
         // 👍🏽 = U+1F44D U+1F3FD = 4 UTF-16 chars
         var emoji = "👍🏽";
-        Assert.Equal(4, emoji.Length); // Verify our assumption
+        Assert.AreEqual(4, emoji.Length); // Verify our assumption
         var text = "X" + emoji + "Y";
         // Cursor after emoji (index 5), should skip back to index 1
-        Assert.Equal(1, GraphemeHelper.GetPreviousClusterBoundary(text, 5));
+        Assert.AreEqual(1, GraphemeHelper.GetPreviousClusterBoundary(text, 5));
     }
 
-    [Fact]
+    [TestMethod]
     public void NextCluster_EmojiWithSkinTone_SkipsEntireSequence()
     {
         var emoji = "👍🏽";
         var text = "X" + emoji + "Y";
-        Assert.Equal(5, GraphemeHelper.GetNextClusterBoundary(text, 1));
+        Assert.AreEqual(5, GraphemeHelper.GetNextClusterBoundary(text, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void PreviousCluster_FlagEmoji_SkipsEntirePair()
     {
         // 🇺🇸 = U+1F1FA U+1F1F8 = 4 UTF-16 chars (2 regional indicators)
         var flag = "🇺🇸";
-        Assert.Equal(4, flag.Length);
+        Assert.AreEqual(4, flag.Length);
         var text = "A" + flag + "B";
-        Assert.Equal(1, GraphemeHelper.GetPreviousClusterBoundary(text, 5));
+        Assert.AreEqual(1, GraphemeHelper.GetPreviousClusterBoundary(text, 5));
     }
 
-    [Fact]
+    [TestMethod]
     public void NextCluster_FlagEmoji_SkipsEntirePair()
     {
         var flag = "🇺🇸";
         var text = "A" + flag + "B";
-        Assert.Equal(5, GraphemeHelper.GetNextClusterBoundary(text, 1));
+        Assert.AreEqual(5, GraphemeHelper.GetNextClusterBoundary(text, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void PreviousCluster_CombiningDiacritical_SkipsBaseAndMark()
     {
         // e + combining acute accent = 2 chars, 1 grapheme cluster
         var text = "A" + "e\u0301" + "B";
-        Assert.Equal(1, GraphemeHelper.GetPreviousClusterBoundary(text, 3));
+        Assert.AreEqual(1, GraphemeHelper.GetPreviousClusterBoundary(text, 3));
     }
 
-    [Fact]
+    [TestMethod]
     public void NextCluster_CombiningDiacritical_SkipsBaseAndMark()
     {
         var text = "A" + "e\u0301" + "B";
-        Assert.Equal(3, GraphemeHelper.GetNextClusterBoundary(text, 1));
+        Assert.AreEqual(3, GraphemeHelper.GetNextClusterBoundary(text, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void PreviousCluster_ZwjFamily_SkipsEntireSequence()
     {
         // 👨‍👩‍👧 = man ZWJ woman ZWJ girl = 8 UTF-16 chars
         var family = "👨\u200D👩\u200D👧";
         var text = "X" + family + "Y";
         var familyEnd = 1 + family.Length;
-        Assert.Equal(1, GraphemeHelper.GetPreviousClusterBoundary(text, familyEnd));
+        Assert.AreEqual(1, GraphemeHelper.GetPreviousClusterBoundary(text, familyEnd));
     }
 
-    [Fact]
+    [TestMethod]
     public void NextCluster_ZwjFamily_SkipsEntireSequence()
     {
         var family = "👨\u200D👩\u200D👧";
         var text = "X" + family + "Y";
-        Assert.Equal(1 + family.Length, GraphemeHelper.GetNextClusterBoundary(text, 1));
+        Assert.AreEqual(1 + family.Length, GraphemeHelper.GetNextClusterBoundary(text, 1));
     }
 
-    [Fact]
+    [TestMethod]
     public void PreviousCluster_LargestStandardZwjFamily_FitsInWindow()
     {
         // 👨‍👩‍👧‍👦 = man ZWJ woman ZWJ girl ZWJ boy = 11 UTF-16 chars
         var family = "👨\u200D👩\u200D👧\u200D👦";
-        Assert.Equal(11, family.Length);
+        Assert.AreEqual(11, family.Length);
         var text = "X" + family + "Y";
-        Assert.Equal(1, GraphemeHelper.GetPreviousClusterBoundary(text, 12));
+        Assert.AreEqual(1, GraphemeHelper.GetPreviousClusterBoundary(text, 12));
     }
 
-    [Fact]
+    [TestMethod]
     public void PreviousCluster_SkinTonedZwjFamily_FitsInWindow()
     {
         // Family with skin tones: 👨🏻‍👩🏽‍👧🏾‍👦🏿
@@ -136,11 +137,11 @@ public class GraphemeBoundaryWindowTests
         var family = "👨🏻\u200D👩🏽\u200D👧🏾\u200D👦🏿";
         var text = "X" + family + "Y";
         var familyEnd = 1 + family.Length;
-        Assert.True(family.Length <= 64, $"Skin-toned family should fit in window ({family.Length} chars)");
-        Assert.Equal(1, GraphemeHelper.GetPreviousClusterBoundary(text, familyEnd));
+        Assert.IsTrue(family.Length <= 64, $"Skin-toned family should fit in window ({family.Length} chars)");
+        Assert.AreEqual(1, GraphemeHelper.GetPreviousClusterBoundary(text, familyEnd));
     }
 
-    [Fact]
+    [TestMethod]
     public void PreviousCluster_MultipleCombiningMarks_FitsInWindow()
     {
         // Base char + 10 combining diacritical marks = 11 chars, 1 cluster
@@ -149,12 +150,12 @@ public class GraphemeBoundaryWindowTests
         for (int i = 0; i < 10; i++)
             sb.Append('\u0308'); // combining diaeresis
         var zalgo = sb.ToString();
-        Assert.Equal(11, zalgo.Length);
+        Assert.AreEqual(11, zalgo.Length);
         var text = "X" + zalgo + "Y";
-        Assert.Equal(1, GraphemeHelper.GetPreviousClusterBoundary(text, 1 + zalgo.Length));
+        Assert.AreEqual(1, GraphemeHelper.GetPreviousClusterBoundary(text, 1 + zalgo.Length));
     }
 
-    [Fact]
+    [TestMethod]
     public void PreviousCluster_HeavyZalgo30Marks_FitsInWindow()
     {
         // Base char + 30 combining marks = 31 chars, well within 64
@@ -163,12 +164,12 @@ public class GraphemeBoundaryWindowTests
         for (int i = 0; i < 30; i++)
             sb.Append('\u0308');
         var zalgo = sb.ToString();
-        Assert.Equal(31, zalgo.Length);
+        Assert.AreEqual(31, zalgo.Length);
         var text = "X" + zalgo + "Y";
-        Assert.Equal(1, GraphemeHelper.GetPreviousClusterBoundary(text, 1 + zalgo.Length));
+        Assert.AreEqual(1, GraphemeHelper.GetPreviousClusterBoundary(text, 1 + zalgo.Length));
     }
 
-    [Fact]
+    [TestMethod]
     public void PreviousCluster_63CombiningMarks_FitsExactlyInWindow()
     {
         // Base char + 63 combining marks = 64 chars — exactly fits the window
@@ -177,17 +178,17 @@ public class GraphemeBoundaryWindowTests
         for (int i = 0; i < 63; i++)
             sb.Append('\u0308');
         var zalgo = sb.ToString();
-        Assert.Equal(64, zalgo.Length);
+        Assert.AreEqual(64, zalgo.Length);
         var text = "X" + zalgo + "Y";
         // Window scans back exactly 64 chars from cursor, capturing the full cluster
-        Assert.Equal(1, GraphemeHelper.GetPreviousClusterBoundary(text, 1 + zalgo.Length));
+        Assert.AreEqual(1, GraphemeHelper.GetPreviousClusterBoundary(text, 1 + zalgo.Length));
     }
 
     // ── Sequences that EXCEED the 64-char window ────────────────
     // These confirm the documented graceful degradation behavior:
     // the cursor lands mid-cluster instead of at the true start.
 
-    [Fact]
+    [TestMethod]
     public void PreviousCluster_65CombiningMarks_ExceedsWindow_LandsMidCluster()
     {
         // Base char + 65 combining marks = 66 chars — exceeds 64-char window
@@ -196,7 +197,7 @@ public class GraphemeBoundaryWindowTests
         for (int i = 0; i < 65; i++)
             sb.Append('\u0308');
         var cluster = sb.ToString();
-        Assert.Equal(66, cluster.Length);
+        Assert.AreEqual(66, cluster.Length);
         var text = "X" + cluster + "Y";
         var cursorPos = 1 + cluster.Length; // After the cluster
 
@@ -205,15 +206,14 @@ public class GraphemeBoundaryWindowTests
         // The window starts at cursorPos - 64, missing the base char 'a' at index 1.
         // The scan sees only combining marks, so it returns a position inside the
         // cluster rather than index 1. This is the expected degradation.
-        Assert.True(result > 1,
-            $"Expected cursor to land mid-cluster (>1) but got {result}. " +
+        Assert.IsTrue(result > 1, $"Expected cursor to land mid-cluster (>1) but got {result}. " +
             "Window should not reach back to the cluster start at index 1.");
         // Should not crash or return negative
-        Assert.True(result >= 0);
-        Assert.True(result < cursorPos, "Should move backward at least somewhat");
+        Assert.IsTrue(result >= 0);
+        Assert.IsTrue(result < cursorPos, "Should move backward at least somewhat");
     }
 
-    [Fact]
+    [TestMethod]
     public void PreviousCluster_100CombiningMarks_ExceedsWindow_LandsMidCluster()
     {
         // Base char + 100 combining marks = 101 chars — far exceeds window
@@ -222,19 +222,18 @@ public class GraphemeBoundaryWindowTests
         for (int i = 0; i < 100; i++)
             sb.Append('\u0308');
         var cluster = sb.ToString();
-        Assert.Equal(101, cluster.Length);
+        Assert.AreEqual(101, cluster.Length);
         var text = "X" + cluster + "Y";
         var cursorPos = 1 + cluster.Length;
 
         var result = GraphemeHelper.GetPreviousClusterBoundary(text, cursorPos);
 
-        Assert.True(result > 1,
-            $"Expected mid-cluster landing (>1) but got {result}");
-        Assert.True(result >= 0);
-        Assert.True(result < cursorPos);
+        Assert.IsTrue(result > 1, $"Expected mid-cluster landing (>1) but got {result}");
+        Assert.IsTrue(result >= 0);
+        Assert.IsTrue(result < cursorPos);
     }
 
-    [Fact]
+    [TestMethod]
     public void NextCluster_ExceedsWindow_StillMovesForward()
     {
         // Forward scan: if cluster exceeds 64 chars, GetNextClusterBoundary still
@@ -252,16 +251,15 @@ public class GraphemeBoundaryWindowTests
 
         // Should move forward past at least 64 chars (the window), but may not
         // reach the true cluster end if it exceeds the window
-        Assert.True(result > 1, "Should advance from cursor position");
+        Assert.IsTrue(result > 1, "Should advance from cursor position");
         // The window is 64 chars, so the enumerator sees at most 64 chars of the
         // cluster and may report that as one element
-        Assert.True(result <= 1 + cluster.Length,
-            "Should not overshoot past the cluster");
+        Assert.IsTrue(result <= 1 + cluster.Length, "Should not overshoot past the cluster");
     }
 
     // ── Navigation through sequences of complex clusters ────────
 
-    [Fact]
+    [TestMethod]
     public void NavigateForward_ThroughMixedClusters_EachStepCorrect()
     {
         // "A" + flag + skin-tone emoji + "B"
@@ -272,16 +270,16 @@ public class GraphemeBoundaryWindowTests
 
         var pos = 0;
         pos = GraphemeHelper.GetNextClusterBoundary(text, pos); // skip 'A'
-        Assert.Equal(1, pos);
+        Assert.AreEqual(1, pos);
         pos = GraphemeHelper.GetNextClusterBoundary(text, pos); // skip flag
-        Assert.Equal(5, pos);
+        Assert.AreEqual(5, pos);
         pos = GraphemeHelper.GetNextClusterBoundary(text, pos); // skip thumb
-        Assert.Equal(9, pos);
+        Assert.AreEqual(9, pos);
         pos = GraphemeHelper.GetNextClusterBoundary(text, pos); // skip 'B'
-        Assert.Equal(10, pos);
+        Assert.AreEqual(10, pos);
     }
 
-    [Fact]
+    [TestMethod]
     public void NavigateBackward_ThroughMixedClusters_EachStepCorrect()
     {
         var flag = "🇺🇸";
@@ -290,114 +288,114 @@ public class GraphemeBoundaryWindowTests
 
         var pos = text.Length; // 10
         pos = GraphemeHelper.GetPreviousClusterBoundary(text, pos); // before 'B'
-        Assert.Equal(9, pos);
+        Assert.AreEqual(9, pos);
         pos = GraphemeHelper.GetPreviousClusterBoundary(text, pos); // before thumb
-        Assert.Equal(5, pos);
+        Assert.AreEqual(5, pos);
         pos = GraphemeHelper.GetPreviousClusterBoundary(text, pos); // before flag
-        Assert.Equal(1, pos);
+        Assert.AreEqual(1, pos);
         pos = GraphemeHelper.GetPreviousClusterBoundary(text, pos); // before 'A'
-        Assert.Equal(0, pos);
+        Assert.AreEqual(0, pos);
     }
 
-    [Fact]
+    [TestMethod]
     public void NavigateForward_MultipleFlagEmojis()
     {
         // 🇺🇸🇬🇧🇫🇷 — three flags, each 4 chars
         var text = "🇺🇸🇬🇧🇫🇷";
-        Assert.Equal(12, text.Length);
+        Assert.AreEqual(12, text.Length);
 
         var pos = 0;
         pos = GraphemeHelper.GetNextClusterBoundary(text, pos);
-        Assert.Equal(4, pos);
+        Assert.AreEqual(4, pos);
         pos = GraphemeHelper.GetNextClusterBoundary(text, pos);
-        Assert.Equal(8, pos);
+        Assert.AreEqual(8, pos);
         pos = GraphemeHelper.GetNextClusterBoundary(text, pos);
-        Assert.Equal(12, pos);
+        Assert.AreEqual(12, pos);
     }
 
-    [Fact]
+    [TestMethod]
     public void NavigateBackward_MultipleFlagEmojis()
     {
         var text = "🇺🇸🇬🇧🇫🇷";
 
         var pos = text.Length;
         pos = GraphemeHelper.GetPreviousClusterBoundary(text, pos);
-        Assert.Equal(8, pos);
+        Assert.AreEqual(8, pos);
         pos = GraphemeHelper.GetPreviousClusterBoundary(text, pos);
-        Assert.Equal(4, pos);
+        Assert.AreEqual(4, pos);
         pos = GraphemeHelper.GetPreviousClusterBoundary(text, pos);
-        Assert.Equal(0, pos);
+        Assert.AreEqual(0, pos);
     }
 
     // ── Edge cases ──────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void PreviousCluster_EmptyString_ReturnsZero()
     {
-        Assert.Equal(0, GraphemeHelper.GetPreviousClusterBoundary("", 0));
-        Assert.Equal(0, GraphemeHelper.GetPreviousClusterBoundary("", 5));
+        Assert.AreEqual(0, GraphemeHelper.GetPreviousClusterBoundary("", 0));
+        Assert.AreEqual(0, GraphemeHelper.GetPreviousClusterBoundary("", 5));
     }
 
-    [Fact]
+    [TestMethod]
     public void NextCluster_EmptyString_ReturnsZero()
     {
-        Assert.Equal(0, GraphemeHelper.GetNextClusterBoundary("", 0));
+        Assert.AreEqual(0, GraphemeHelper.GetNextClusterBoundary("", 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void PreviousCluster_NullString_ReturnsZero()
     {
-        Assert.Equal(0, GraphemeHelper.GetPreviousClusterBoundary(null!, 0));
+        Assert.AreEqual(0, GraphemeHelper.GetPreviousClusterBoundary(null!, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void NextCluster_NullString_ReturnsZero()
     {
-        Assert.Equal(0, GraphemeHelper.GetNextClusterBoundary(null!, 0));
+        Assert.AreEqual(0, GraphemeHelper.GetNextClusterBoundary(null!, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void PreviousCluster_IndexBeyondEnd_ClampsToLength()
     {
         var text = "AB";
-        Assert.Equal(1, GraphemeHelper.GetPreviousClusterBoundary(text, 100));
+        Assert.AreEqual(1, GraphemeHelper.GetPreviousClusterBoundary(text, 100));
     }
 
-    [Fact]
+    [TestMethod]
     public void NextCluster_IndexBeyondEnd_ReturnsLength()
     {
         var text = "AB";
-        Assert.Equal(2, GraphemeHelper.GetNextClusterBoundary(text, 100));
+        Assert.AreEqual(2, GraphemeHelper.GetNextClusterBoundary(text, 100));
     }
 
-    [Fact]
+    [TestMethod]
     public void NextCluster_NegativeIndex_ClampsToZero()
     {
         var text = "AB";
-        Assert.Equal(1, GraphemeHelper.GetNextClusterBoundary(text, -5));
+        Assert.AreEqual(1, GraphemeHelper.GetNextClusterBoundary(text, -5));
     }
 
-    [Fact]
+    [TestMethod]
     public void PreviousCluster_IndexAtZero_ReturnsZero()
     {
         var text = "Hello";
-        Assert.Equal(0, GraphemeHelper.GetPreviousClusterBoundary(text, 0));
+        Assert.AreEqual(0, GraphemeHelper.GetPreviousClusterBoundary(text, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void NextCluster_IndexAtEnd_ReturnsLength()
     {
         var text = "Hello";
-        Assert.Equal(5, GraphemeHelper.GetNextClusterBoundary(text, 5));
+        Assert.AreEqual(5, GraphemeHelper.GetNextClusterBoundary(text, 5));
     }
 
     // ── Verify window boundary is exactly 64 ────────────────────
 
-    [Theory]
-    [InlineData(62, true)]  // 63 chars total (base + 62 marks) — within window
-    [InlineData(63, true)]  // 64 chars total — exactly fits window
-    [InlineData(64, false)] // 65 chars total — exceeds window by 1
-    [InlineData(70, false)] // 71 chars total — clearly exceeds
+    [TestMethod]
+    [DataRow(62, true)]  // 63 chars total (base + 62 marks) — within window
+    [DataRow(63, true)]  // 64 chars total — exactly fits window
+    [DataRow(64, false)] // 65 chars total — exceeds window by 1
+    [DataRow(70, false)] // 71 chars total — clearly exceeds
     public void PreviousCluster_WindowBoundary_ExactThreshold(int combiningMarks, bool shouldReachClusterStart)
     {
         var sb = new StringBuilder();
@@ -412,12 +410,11 @@ public class GraphemeBoundaryWindowTests
 
         if (shouldReachClusterStart)
         {
-            Assert.Equal(1, result);
+            Assert.AreEqual(1, result);
         }
         else
         {
-            Assert.True(result > 1,
-                $"With {combiningMarks} combining marks ({cluster.Length} total chars), " +
+            Assert.IsTrue(result > 1, $"With {combiningMarks} combining marks ({cluster.Length} total chars), " +
                 $"expected mid-cluster landing (>1) but got {result}");
         }
     }

--- a/tests/Hex1b.Tests/GraphemeClusterTests.cs
+++ b/tests/Hex1b.Tests/GraphemeClusterTests.cs
@@ -24,6 +24,7 @@ namespace Hex1b.Tests;
 /// 4. Select by grapheme cluster boundaries
 /// 5. Never split a cluster, which would result in broken/invalid text
 /// </summary>
+[TestClass]
 public class GraphemeClusterTests
 {
     #region Test Data
@@ -56,68 +57,68 @@ public class GraphemeClusterTests
 
     #region StringInfo Baseline Tests (verify our understanding)
 
-    [Fact]
+    [TestMethod]
     public void StringInfo_SimpleEmoji_IsOneGrapheme()
     {
         var info = new StringInfo(Emoji);
-        Assert.Equal(1, info.LengthInTextElements);
-        Assert.Equal(2, Emoji.Length); // But 2 chars in UTF-16
+        Assert.AreEqual(1, info.LengthInTextElements);
+        Assert.AreEqual(2, Emoji.Length); // But 2 chars in UTF-16
     }
 
-    [Fact]
+    [TestMethod]
     public void StringInfo_EmojiWithSkinTone_IsOneGrapheme()
     {
         var info = new StringInfo(EmojiWithSkinTone);
-        Assert.Equal(1, info.LengthInTextElements);
-        Assert.True(EmojiWithSkinTone.Length >= 4); // 4+ chars in UTF-16
+        Assert.AreEqual(1, info.LengthInTextElements);
+        Assert.IsTrue(EmojiWithSkinTone.Length >= 4); // 4+ chars in UTF-16
     }
 
-    [Fact]
+    [TestMethod]
     public void StringInfo_FamilyEmoji_IsOneGrapheme()
     {
         var info = new StringInfo(FamilyEmoji);
-        Assert.Equal(1, info.LengthInTextElements);
-        Assert.True(FamilyEmoji.Length >= 8); // 8+ chars in UTF-16
+        Assert.AreEqual(1, info.LengthInTextElements);
+        Assert.IsTrue(FamilyEmoji.Length >= 8); // 8+ chars in UTF-16
     }
 
-    [Fact]
+    [TestMethod]
     public void StringInfo_FlagEmoji_IsOneGrapheme()
     {
         var info = new StringInfo(FlagEmoji);
-        Assert.Equal(1, info.LengthInTextElements);
-        Assert.Equal(4, FlagEmoji.Length); // 4 chars (2 regional indicators, each 2 chars)
+        Assert.AreEqual(1, info.LengthInTextElements);
+        Assert.AreEqual(4, FlagEmoji.Length); // 4 chars (2 regional indicators, each 2 chars)
     }
 
-    [Fact]
+    [TestMethod]
     public void StringInfo_CombiningCharacter_IsOneGrapheme()
     {
         var info = new StringInfo(CombiningE);
-        Assert.Equal(1, info.LengthInTextElements);
-        Assert.Equal(2, CombiningE.Length); // e + combining accent
+        Assert.AreEqual(1, info.LengthInTextElements);
+        Assert.AreEqual(2, CombiningE.Length); // e + combining accent
     }
 
-    [Fact]
+    [TestMethod]
     public void StringInfo_MultipleCombining_IsOneGrapheme()
     {
         var info = new StringInfo(MultipleCombining);
-        Assert.Equal(1, info.LengthInTextElements);
-        Assert.Equal(3, MultipleCombining.Length); // a + 2 combining marks
+        Assert.AreEqual(1, info.LengthInTextElements);
+        Assert.AreEqual(3, MultipleCombining.Length); // a + 2 combining marks
     }
 
-    [Fact]
+    [TestMethod]
     public void StringInfo_MixedText_CountsCorrectly()
     {
         var text = "Hi" + Emoji + "!"; // 4 graphemes: H, i, 😀, !
         var info = new StringInfo(text);
-        Assert.Equal(4, info.LengthInTextElements);
-        Assert.Equal(5, text.Length); // 2 + 2 + 1 chars
+        Assert.AreEqual(4, info.LengthInTextElements);
+        Assert.AreEqual(5, text.Length); // 2 + 2 + 1 chars
     }
 
     #endregion
 
     #region Insert Text Tests
 
-    [Fact]
+    [TestMethod]
     public async Task InsertText_SimpleEmoji_InsertsAsAtomicUnit()
     {
         var state = new TextBoxState { Text = "Hello", CursorPosition = 5 };
@@ -125,11 +126,11 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, Hex1bKeyEvent.FromText(Emoji), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("Hello" + Emoji, state.Text);
-        Assert.Equal(7, state.CursorPosition); // Moved by 2 chars
+        Assert.AreEqual("Hello" + Emoji, state.Text);
+        Assert.AreEqual(7, state.CursorPosition); // Moved by 2 chars
     }
 
-    [Fact]
+    [TestMethod]
     public async Task InsertText_EmojiWithSkinTone_InsertsAsAtomicUnit()
     {
         var state = new TextBoxState { Text = "Test", CursorPosition = 4 };
@@ -137,11 +138,11 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, Hex1bKeyEvent.FromText(EmojiWithSkinTone), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("Test" + EmojiWithSkinTone, state.Text);
-        Assert.Equal(4 + EmojiWithSkinTone.Length, state.CursorPosition);
+        Assert.AreEqual("Test" + EmojiWithSkinTone, state.Text);
+        Assert.AreEqual(4 + EmojiWithSkinTone.Length, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task InsertText_FamilyEmoji_InsertsAsAtomicUnit()
     {
         var state = new TextBoxState { Text = "", CursorPosition = 0 };
@@ -149,11 +150,11 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, Hex1bKeyEvent.FromText(FamilyEmoji), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(FamilyEmoji, state.Text);
-        Assert.Equal(FamilyEmoji.Length, state.CursorPosition);
+        Assert.AreEqual(FamilyEmoji, state.Text);
+        Assert.AreEqual(FamilyEmoji.Length, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task InsertText_MultipleEmojis_InsertsAll()
     {
         var state = new TextBoxState { Text = "", CursorPosition = 0 };
@@ -163,10 +164,10 @@ public class GraphemeClusterTests
         await InputRouter.RouteInputToNodeAsync(node, Hex1bKeyEvent.FromText(FlagEmoji), null, null, TestContext.Current.CancellationToken);
         await InputRouter.RouteInputToNodeAsync(node, Hex1bKeyEvent.FromText(EmojiWithSkinTone), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(Emoji + FlagEmoji + EmojiWithSkinTone, state.Text);
+        Assert.AreEqual(Emoji + FlagEmoji + EmojiWithSkinTone, state.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task InsertText_CombiningCharacter_InsertsAsAtomicUnit()
     {
         var state = new TextBoxState { Text = "cafe", CursorPosition = 4 };
@@ -176,10 +177,10 @@ public class GraphemeClusterTests
         state.CursorPosition = 3;
         await InputRouter.RouteInputToNodeAsync(node, Hex1bKeyEvent.FromText(CombiningE), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("caf" + CombiningE + "e", state.Text);
+        Assert.AreEqual("caf" + CombiningE + "e", state.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task InsertText_InMiddleOfText_InsertsCorrectly()
     {
         var state = new TextBoxState { Text = "AB", CursorPosition = 1 };
@@ -187,15 +188,15 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, Hex1bKeyEvent.FromText(Emoji), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("A" + Emoji + "B", state.Text);
-        Assert.Equal(1 + Emoji.Length, state.CursorPosition);
+        Assert.AreEqual("A" + Emoji + "B", state.Text);
+        Assert.AreEqual(1 + Emoji.Length, state.CursorPosition);
     }
 
     #endregion
 
     #region Delete Backward (Backspace) Tests
 
-    [Fact]
+    [TestMethod]
     public async Task DeleteBackward_SimpleEmoji_DeletesEntireCluster()
     {
         var state = new TextBoxState { Text = "A" + Emoji + "B", CursorPosition = 1 + Emoji.Length };
@@ -203,11 +204,11 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Backspace, '\b', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("AB", state.Text);
-        Assert.Equal(1, state.CursorPosition);
+        Assert.AreEqual("AB", state.Text);
+        Assert.AreEqual(1, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DeleteBackward_EmojiWithSkinTone_DeletesEntireCluster()
     {
         var state = new TextBoxState { Text = "X" + EmojiWithSkinTone, CursorPosition = 1 + EmojiWithSkinTone.Length };
@@ -215,11 +216,11 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Backspace, '\b', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("X", state.Text);
-        Assert.Equal(1, state.CursorPosition);
+        Assert.AreEqual("X", state.Text);
+        Assert.AreEqual(1, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DeleteBackward_FamilyEmoji_DeletesEntireCluster()
     {
         var state = new TextBoxState { Text = FamilyEmoji, CursorPosition = FamilyEmoji.Length };
@@ -227,11 +228,11 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Backspace, '\b', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("", state.Text);
-        Assert.Equal(0, state.CursorPosition);
+        Assert.AreEqual("", state.Text);
+        Assert.AreEqual(0, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DeleteBackward_FlagEmoji_DeletesEntireCluster()
     {
         var state = new TextBoxState { Text = "Flag: " + FlagEmoji, CursorPosition = 6 + FlagEmoji.Length };
@@ -239,11 +240,11 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Backspace, '\b', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("Flag: ", state.Text);
-        Assert.Equal(6, state.CursorPosition);
+        Assert.AreEqual("Flag: ", state.Text);
+        Assert.AreEqual(6, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DeleteBackward_CombiningCharacter_DeletesEntireCluster()
     {
         var state = new TextBoxState { Text = "caf" + CombiningE, CursorPosition = 3 + CombiningE.Length };
@@ -251,11 +252,11 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Backspace, '\b', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("caf", state.Text);
-        Assert.Equal(3, state.CursorPosition);
+        Assert.AreEqual("caf", state.Text);
+        Assert.AreEqual(3, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DeleteBackward_MultipleCombining_DeletesEntireCluster()
     {
         var state = new TextBoxState { Text = MultipleCombining, CursorPosition = MultipleCombining.Length };
@@ -263,11 +264,11 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Backspace, '\b', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("", state.Text);
-        Assert.Equal(0, state.CursorPosition);
+        Assert.AreEqual("", state.Text);
+        Assert.AreEqual(0, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DeleteBackward_NeverSplitsCluster()
     {
         // Even if cursor is somehow in middle of cluster (shouldn't happen),
@@ -286,11 +287,11 @@ public class GraphemeClusterTests
         {
             var textElement = (string)enumerator.Current;
             // Each text element should be valid (no isolated surrogates)
-            Assert.True(textElement.Length > 0);
+            Assert.IsTrue(textElement.Length > 0);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DeleteBackward_AsciiBeforeEmoji_DeletesOnlyAscii()
     {
         var state = new TextBoxState { Text = "AB" + Emoji, CursorPosition = 2 };
@@ -298,11 +299,11 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Backspace, '\b', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("A" + Emoji, state.Text);
-        Assert.Equal(1, state.CursorPosition);
+        Assert.AreEqual("A" + Emoji, state.Text);
+        Assert.AreEqual(1, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DeleteBackward_MultipleBackspaces_DeletesCorrectly()
     {
         var state = new TextBoxState { Text = "X" + Emoji + FlagEmoji, CursorPosition = 1 + Emoji.Length + FlagEmoji.Length };
@@ -310,22 +311,22 @@ public class GraphemeClusterTests
 
         // Delete flag
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Backspace, '\b', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
-        Assert.Equal("X" + Emoji, state.Text);
+        Assert.AreEqual("X" + Emoji, state.Text);
 
         // Delete emoji
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Backspace, '\b', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
-        Assert.Equal("X", state.Text);
+        Assert.AreEqual("X", state.Text);
 
         // Delete X
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Backspace, '\b', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
-        Assert.Equal("", state.Text);
+        Assert.AreEqual("", state.Text);
     }
 
     #endregion
 
     #region Delete Forward (Delete key) Tests
 
-    [Fact]
+    [TestMethod]
     public async Task DeleteForward_SimpleEmoji_DeletesEntireCluster()
     {
         var state = new TextBoxState { Text = Emoji + "B", CursorPosition = 0 };
@@ -333,11 +334,11 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Delete, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("B", state.Text);
-        Assert.Equal(0, state.CursorPosition);
+        Assert.AreEqual("B", state.Text);
+        Assert.AreEqual(0, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DeleteForward_EmojiWithSkinTone_DeletesEntireCluster()
     {
         var state = new TextBoxState { Text = "X" + EmojiWithSkinTone + "Y", CursorPosition = 1 };
@@ -345,11 +346,11 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Delete, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("XY", state.Text);
-        Assert.Equal(1, state.CursorPosition);
+        Assert.AreEqual("XY", state.Text);
+        Assert.AreEqual(1, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DeleteForward_FamilyEmoji_DeletesEntireCluster()
     {
         var state = new TextBoxState { Text = FamilyEmoji + "!", CursorPosition = 0 };
@@ -357,11 +358,11 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Delete, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("!", state.Text);
-        Assert.Equal(0, state.CursorPosition);
+        Assert.AreEqual("!", state.Text);
+        Assert.AreEqual(0, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DeleteForward_CombiningCharacter_DeletesEntireCluster()
     {
         var state = new TextBoxState { Text = CombiningE + "x", CursorPosition = 0 };
@@ -369,11 +370,11 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Delete, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("x", state.Text);
-        Assert.Equal(0, state.CursorPosition);
+        Assert.AreEqual("x", state.Text);
+        Assert.AreEqual(0, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DeleteForward_AsciiAfterEmoji_DeletesOnlyAscii()
     {
         var state = new TextBoxState { Text = Emoji + "AB", CursorPosition = Emoji.Length };
@@ -381,15 +382,15 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Delete, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(Emoji + "B", state.Text);
-        Assert.Equal(Emoji.Length, state.CursorPosition);
+        Assert.AreEqual(Emoji + "B", state.Text);
+        Assert.AreEqual(Emoji.Length, state.CursorPosition);
     }
 
     #endregion
 
     #region Cursor Movement Tests
 
-    [Fact]
+    [TestMethod]
     public async Task MoveLeft_OverEmoji_MovesEntireCluster()
     {
         var state = new TextBoxState { Text = "A" + Emoji + "B", CursorPosition = 1 + Emoji.Length };
@@ -398,10 +399,10 @@ public class GraphemeClusterTests
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
         // Cursor should be before the emoji, not in the middle of it
-        Assert.Equal(1, state.CursorPosition);
+        Assert.AreEqual(1, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MoveRight_OverEmoji_MovesEntireCluster()
     {
         var state = new TextBoxState { Text = "A" + Emoji + "B", CursorPosition = 1 };
@@ -410,10 +411,10 @@ public class GraphemeClusterTests
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
         // Cursor should be after the emoji
-        Assert.Equal(1 + Emoji.Length, state.CursorPosition);
+        Assert.AreEqual(1 + Emoji.Length, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MoveLeft_OverFamilyEmoji_MovesEntireCluster()
     {
         var state = new TextBoxState { Text = FamilyEmoji, CursorPosition = FamilyEmoji.Length };
@@ -421,10 +422,10 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(0, state.CursorPosition);
+        Assert.AreEqual(0, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MoveRight_OverFamilyEmoji_MovesEntireCluster()
     {
         var state = new TextBoxState { Text = FamilyEmoji, CursorPosition = 0 };
@@ -432,10 +433,10 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(FamilyEmoji.Length, state.CursorPosition);
+        Assert.AreEqual(FamilyEmoji.Length, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MoveLeft_OverCombiningCharacter_MovesEntireCluster()
     {
         var state = new TextBoxState { Text = "a" + CombiningE + "b", CursorPosition = 1 + CombiningE.Length };
@@ -443,10 +444,10 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(1, state.CursorPosition);
+        Assert.AreEqual(1, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MoveRight_OverCombiningCharacter_MovesEntireCluster()
     {
         var state = new TextBoxState { Text = "a" + CombiningE + "b", CursorPosition = 1 };
@@ -454,10 +455,10 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(1 + CombiningE.Length, state.CursorPosition);
+        Assert.AreEqual(1 + CombiningE.Length, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MoveLeft_ThroughMixedText_NeverLandsMidCluster()
     {
         var text = "A" + Emoji + FlagEmoji + "B";
@@ -474,7 +475,7 @@ public class GraphemeClusterTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MoveRight_ThroughMixedText_NeverLandsMidCluster()
     {
         var text = "A" + Emoji + FlagEmoji + "B";
@@ -495,7 +496,7 @@ public class GraphemeClusterTests
 
     #region Selection Tests
 
-    [Fact]
+    [TestMethod]
     public async Task SelectLeft_OverEmoji_SelectsEntireCluster()
     {
         var state = new TextBoxState { Text = "A" + Emoji + "B", CursorPosition = 1 + Emoji.Length };
@@ -503,12 +504,12 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.Shift), null, null, TestContext.Current.CancellationToken);
 
-        Assert.True(state.HasSelection);
-        Assert.Equal(Emoji, state.SelectedText);
-        Assert.Equal(1, state.CursorPosition);
+        Assert.IsTrue(state.HasSelection);
+        Assert.AreEqual(Emoji, state.SelectedText);
+        Assert.AreEqual(1, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SelectRight_OverEmoji_SelectsEntireCluster()
     {
         var state = new TextBoxState { Text = "A" + Emoji + "B", CursorPosition = 1 };
@@ -516,12 +517,12 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.Shift), null, null, TestContext.Current.CancellationToken);
 
-        Assert.True(state.HasSelection);
-        Assert.Equal(Emoji, state.SelectedText);
-        Assert.Equal(1 + Emoji.Length, state.CursorPosition);
+        Assert.IsTrue(state.HasSelection);
+        Assert.AreEqual(Emoji, state.SelectedText);
+        Assert.AreEqual(1 + Emoji.Length, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SelectLeft_OverFamilyEmoji_SelectsEntireCluster()
     {
         var state = new TextBoxState { Text = FamilyEmoji, CursorPosition = FamilyEmoji.Length };
@@ -529,11 +530,11 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.Shift), null, null, TestContext.Current.CancellationToken);
 
-        Assert.True(state.HasSelection);
-        Assert.Equal(FamilyEmoji, state.SelectedText);
+        Assert.IsTrue(state.HasSelection);
+        Assert.AreEqual(FamilyEmoji, state.SelectedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SelectAndDelete_Emoji_DeletesEntireCluster()
     {
         var state = new TextBoxState { Text = "A" + Emoji + "B", CursorPosition = 1 };
@@ -545,12 +546,12 @@ public class GraphemeClusterTests
         // Delete selection
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Backspace, '\b', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("AB", state.Text);
-        Assert.Equal(1, state.CursorPosition);
-        Assert.False(state.HasSelection);
+        Assert.AreEqual("AB", state.Text);
+        Assert.AreEqual(1, state.CursorPosition);
+        Assert.IsFalse(state.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SelectAndDelete_MultipleEmojis_DeletesAll()
     {
         var text = "A" + Emoji + FlagEmoji + "B";
@@ -561,15 +562,15 @@ public class GraphemeClusterTests
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.Shift), null, null, TestContext.Current.CancellationToken);
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.Shift), null, null, TestContext.Current.CancellationToken);
         
-        Assert.Equal(Emoji + FlagEmoji, state.SelectedText);
+        Assert.AreEqual(Emoji + FlagEmoji, state.SelectedText);
 
         // Delete selection
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Delete, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("AB", state.Text);
+        Assert.AreEqual("AB", state.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SelectAll_WithEmojis_SelectsCorrectly()
     {
         var text = Emoji + "Hello" + FamilyEmoji;
@@ -578,11 +579,11 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.A, 'a', Hex1bModifiers.Control), null, null, TestContext.Current.CancellationToken);
 
-        Assert.True(state.HasSelection);
-        Assert.Equal(text, state.SelectedText);
+        Assert.IsTrue(state.HasSelection);
+        Assert.AreEqual(text, state.SelectedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TypeOverSelection_WithEmoji_ReplacesCorrectly()
     {
         var state = new TextBoxState { Text = "A" + Emoji + "B", CursorPosition = 1 };
@@ -594,16 +595,16 @@ public class GraphemeClusterTests
         // Type replacement text
         await InputRouter.RouteInputToNodeAsync(node, Hex1bKeyEvent.FromText(FlagEmoji), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("A" + FlagEmoji + "B", state.Text);
-        Assert.Equal(1 + FlagEmoji.Length, state.CursorPosition);
-        Assert.False(state.HasSelection);
+        Assert.AreEqual("A" + FlagEmoji + "B", state.Text);
+        Assert.AreEqual(1 + FlagEmoji.Length, state.CursorPosition);
+        Assert.IsFalse(state.HasSelection);
     }
 
     #endregion
 
     #region Edge Cases and Invariant Tests
 
-    [Fact]
+    [TestMethod]
     public async Task TextAlwaysValid_AfterAnyOperation()
     {
         var operations = new Func<TextBoxNode, Task>[]
@@ -638,7 +639,7 @@ public class GraphemeClusterTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task EmptyText_DeleteBackward_DoesNothing()
     {
         var state = new TextBoxState { Text = "", CursorPosition = 0 };
@@ -646,11 +647,11 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Backspace, '\b', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("", state.Text);
-        Assert.Equal(0, state.CursorPosition);
+        Assert.AreEqual("", state.Text);
+        Assert.AreEqual(0, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task EmptyText_DeleteForward_DoesNothing()
     {
         var state = new TextBoxState { Text = "", CursorPosition = 0 };
@@ -658,11 +659,11 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Delete, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("", state.Text);
-        Assert.Equal(0, state.CursorPosition);
+        Assert.AreEqual("", state.Text);
+        Assert.AreEqual(0, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CursorAtStart_MoveLeft_StaysAtStart()
     {
         var state = new TextBoxState { Text = Emoji, CursorPosition = 0 };
@@ -670,10 +671,10 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(0, state.CursorPosition);
+        Assert.AreEqual(0, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CursorAtEnd_MoveRight_StaysAtEnd()
     {
         var state = new TextBoxState { Text = Emoji, CursorPosition = Emoji.Length };
@@ -681,10 +682,10 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(Emoji.Length, state.CursorPosition);
+        Assert.AreEqual(Emoji.Length, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Home_WithEmojis_MovesToStart()
     {
         var text = Emoji + FamilyEmoji + "Test";
@@ -693,10 +694,10 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Home, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(0, state.CursorPosition);
+        Assert.AreEqual(0, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task End_WithEmojis_MovesToEnd()
     {
         var text = Emoji + FamilyEmoji + "Test";
@@ -705,7 +706,7 @@ public class GraphemeClusterTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.End, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(text.Length, state.CursorPosition);
+        Assert.AreEqual(text.Length, state.CursorPosition);
     }
 
     #endregion
@@ -735,8 +736,7 @@ public class GraphemeClusterTests
         {
             if (char.IsHighSurrogate(text[i]))
             {
-                Assert.True(i + 1 < text.Length && char.IsLowSurrogate(text[i + 1]),
-                    $"Isolated high surrogate at position {i}");
+                Assert.IsTrue(i + 1 < text.Length && char.IsLowSurrogate(text[i + 1]), $"Isolated high surrogate at position {i}");
                 i++; // Skip the low surrogate
             }
             else if (char.IsLowSurrogate(text[i]))
@@ -750,90 +750,90 @@ public class GraphemeClusterTests
 
     #region Word Boundary Tests
 
-    [Theory]
-    [InlineData("hello world", 11, 6)]   // End of "world" -> start of "world"
-    [InlineData("hello world", 6, 0)]    // Start of "world" -> start of "hello"
-    [InlineData("hello world", 5, 0)]    // Space after "hello" -> start of "hello"
-    [InlineData("hello world", 3, 0)]    // Middle of "hello" -> start of "hello"
-    [InlineData("hello world", 0, 0)]    // Already at start -> stays at start
+    [TestMethod]
+    [DataRow("hello world", 11, 6)]   // End of "world" -> start of "world"
+    [DataRow("hello world", 6, 0)]    // Start of "world" -> start of "hello"
+    [DataRow("hello world", 5, 0)]    // Space after "hello" -> start of "hello"
+    [DataRow("hello world", 3, 0)]    // Middle of "hello" -> start of "hello"
+    [DataRow("hello world", 0, 0)]    // Already at start -> stays at start
     public void GetPreviousWordBoundary_ReturnsCorrectPosition(string text, int cursor, int expected)
     {
         var result = GraphemeHelper.GetPreviousWordBoundary(text, cursor);
-        Assert.Equal(expected, result);
+        Assert.AreEqual(expected, result);
     }
 
-    [Theory]
-    [InlineData("hello world", 0, 6)]    // Start of "hello" -> start of "world"
-    [InlineData("hello world", 3, 6)]    // Middle of "hello" -> start of "world"
-    [InlineData("hello world", 5, 6)]    // Space after "hello" -> start of "world"
-    [InlineData("hello world", 6, 11)]   // Start of "world" -> end of string
-    [InlineData("hello world", 11, 11)]  // Already at end -> stays at end
+    [TestMethod]
+    [DataRow("hello world", 0, 6)]    // Start of "hello" -> start of "world"
+    [DataRow("hello world", 3, 6)]    // Middle of "hello" -> start of "world"
+    [DataRow("hello world", 5, 6)]    // Space after "hello" -> start of "world"
+    [DataRow("hello world", 6, 11)]   // Start of "world" -> end of string
+    [DataRow("hello world", 11, 11)]  // Already at end -> stays at end
     public void GetNextWordBoundary_ReturnsCorrectPosition(string text, int cursor, int expected)
     {
         var result = GraphemeHelper.GetNextWordBoundary(text, cursor);
-        Assert.Equal(expected, result);
+        Assert.AreEqual(expected, result);
     }
 
-    [Theory]
-    [InlineData("hello, world!", 13, 7)]  // End -> start of "world"
-    [InlineData("hello, world!", 7, 0)]   // Start of "world" -> start of "hello"
-    [InlineData("hello, world!", 6, 0)]   // Space before "world" -> start of "hello"
-    [InlineData("hello, world!", 5, 0)]   // Comma after "hello" -> start of "hello"
+    [TestMethod]
+    [DataRow("hello, world!", 13, 7)]  // End -> start of "world"
+    [DataRow("hello, world!", 7, 0)]   // Start of "world" -> start of "hello"
+    [DataRow("hello, world!", 6, 0)]   // Space before "world" -> start of "hello"
+    [DataRow("hello, world!", 5, 0)]   // Comma after "hello" -> start of "hello"
     public void GetPreviousWordBoundary_WithPunctuation_SkipsPunctuation(string text, int cursor, int expected)
     {
         var result = GraphemeHelper.GetPreviousWordBoundary(text, cursor);
-        Assert.Equal(expected, result);
+        Assert.AreEqual(expected, result);
     }
 
-    [Theory]
-    [InlineData("hello, world!", 0, 7)]   // Start -> start of "world" (skips comma and space)
-    [InlineData("hello, world!", 5, 7)]   // End of "hello" -> start of "world"
-    [InlineData("hello, world!", 7, 13)]  // Start of "world" -> end (skips "!")
+    [TestMethod]
+    [DataRow("hello, world!", 0, 7)]   // Start -> start of "world" (skips comma and space)
+    [DataRow("hello, world!", 5, 7)]   // End of "hello" -> start of "world"
+    [DataRow("hello, world!", 7, 13)]  // Start of "world" -> end (skips "!")
     public void GetNextWordBoundary_WithPunctuation_SkipsPunctuation(string text, int cursor, int expected)
     {
         var result = GraphemeHelper.GetNextWordBoundary(text, cursor);
-        Assert.Equal(expected, result);
+        Assert.AreEqual(expected, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetPreviousWordBoundary_EmptyString_ReturnsZero()
     {
-        Assert.Equal(0, GraphemeHelper.GetPreviousWordBoundary("", 0));
-        Assert.Equal(0, GraphemeHelper.GetPreviousWordBoundary("", 5));
+        Assert.AreEqual(0, GraphemeHelper.GetPreviousWordBoundary("", 0));
+        Assert.AreEqual(0, GraphemeHelper.GetPreviousWordBoundary("", 5));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetNextWordBoundary_EmptyString_ReturnsZero()
     {
-        Assert.Equal(0, GraphemeHelper.GetNextWordBoundary("", 0));
-        Assert.Equal(0, GraphemeHelper.GetNextWordBoundary("", 5));
+        Assert.AreEqual(0, GraphemeHelper.GetNextWordBoundary("", 0));
+        Assert.AreEqual(0, GraphemeHelper.GetNextWordBoundary("", 5));
     }
 
-    [Theory]
-    [InlineData("hello   world", 13, 8)]  // End -> start of "world"
-    [InlineData("hello   world", 8, 0)]   // Start of "world" -> start of "hello"
+    [TestMethod]
+    [DataRow("hello   world", 13, 8)]  // End -> start of "world"
+    [DataRow("hello   world", 8, 0)]   // Start of "world" -> start of "hello"
     public void GetPreviousWordBoundary_MultipleSpaces_SkipsAllSpaces(string text, int cursor, int expected)
     {
         var result = GraphemeHelper.GetPreviousWordBoundary(text, cursor);
-        Assert.Equal(expected, result);
+        Assert.AreEqual(expected, result);
     }
 
-    [Theory]
-    [InlineData("hello   world", 0, 8)]   // Start -> start of "world"
-    [InlineData("hello   world", 5, 8)]   // After "hello" -> start of "world"
+    [TestMethod]
+    [DataRow("hello   world", 0, 8)]   // Start -> start of "world"
+    [DataRow("hello   world", 5, 8)]   // After "hello" -> start of "world"
     public void GetNextWordBoundary_MultipleSpaces_SkipsAllSpaces(string text, int cursor, int expected)
     {
         var result = GraphemeHelper.GetNextWordBoundary(text, cursor);
-        Assert.Equal(expected, result);
+        Assert.AreEqual(expected, result);
     }
 
-    [Theory]
-    [InlineData("test123", 7, 0)]  // End -> start (alphanumeric is one word)
-    [InlineData("test_var", 8, 0)] // End -> start (underscore is word char)
+    [TestMethod]
+    [DataRow("test123", 7, 0)]  // End -> start (alphanumeric is one word)
+    [DataRow("test_var", 8, 0)] // End -> start (underscore is word char)
     public void GetPreviousWordBoundary_AlphanumericAndUnderscore_TreatedAsWordChars(string text, int cursor, int expected)
     {
         var result = GraphemeHelper.GetPreviousWordBoundary(text, cursor);
-        Assert.Equal(expected, result);
+        Assert.AreEqual(expected, result);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/GridNodeTests.cs
+++ b/tests/Hex1b.Tests/GridNodeTests.cs
@@ -3,20 +3,21 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class GridNodeTests
 {
     #region Measure Tests
 
-    [Fact]
+    [TestMethod]
     public void Measure_EmptyGrid_ReturnsZero()
     {
         var node = CreateGridNode([], 0, 0, [], []);
         var size = node.Measure(Constraints.Unbounded);
-        Assert.Equal(0, size.Width);
-        Assert.Equal(0, size.Height);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(0, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_SingleCell_ReturnsContentSize()
     {
         var child = new TextBlockNode { Text = "Hello" }; // 5 wide, 1 tall
@@ -28,11 +29,11 @@ public class GridNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(5, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(5, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_TwoColumnContent_SumsWidths()
     {
         var left = new TextBlockNode { Text = "Left" };   // 4 wide
@@ -48,11 +49,11 @@ public class GridNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(10, size.Width); // 4 + 6
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(10, size.Width); // 4 + 6
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_TwoRowContent_SumsHeights()
     {
         var top = new TextBlockNode { Text = "Top" };
@@ -68,11 +69,11 @@ public class GridNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(6, size.Width); // max("Top", "Bottom")
-        Assert.Equal(2, size.Height); // 1 + 1
+        Assert.AreEqual(6, size.Width); // max("Top", "Bottom")
+        Assert.AreEqual(2, size.Height); // 1 + 1
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_FixedColumns_UsesFixedWidths()
     {
         var child = new TextBlockNode { Text = "Hi" };
@@ -84,10 +85,10 @@ public class GridNodeTests
 
         var size = node.Measure(new Constraints(0, 100, 0, 100));
 
-        Assert.Equal(50, size.Width); // 20 + 30
+        Assert.AreEqual(50, size.Width); // 20 + 30
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_FillColumns_DistributeRemainingSpace()
     {
         var child = new TextBlockNode { Text = "Hi" };
@@ -99,10 +100,10 @@ public class GridNodeTests
 
         var size = node.Measure(new Constraints(0, 100, 0, 100));
 
-        Assert.Equal(100, size.Width); // 10 + 45 + 45
+        Assert.AreEqual(100, size.Width); // 10 + 45 + 45
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_WeightedFillColumns_DistributeProportionally()
     {
         var child = new TextBlockNode { Text = "Hi" };
@@ -114,14 +115,14 @@ public class GridNodeTests
 
         var size = node.Measure(new Constraints(0, 80, 0, 100));
 
-        Assert.Equal(80, size.Width); // 20 + 60
+        Assert.AreEqual(80, size.Width); // 20 + 60
     }
 
     #endregion
 
     #region Arrange Tests
 
-    [Fact]
+    [TestMethod]
     public void Arrange_SingleCell_FillsBounds()
     {
         var child = new TextBlockNode { Text = "Hello" };
@@ -134,11 +135,11 @@ public class GridNodeTests
         node.Measure(new Constraints(0, 80, 0, 24));
         node.Arrange(new Rect(0, 0, 80, 24));
 
-        Assert.Equal(0, child.Bounds.X);
-        Assert.Equal(0, child.Bounds.Y);
+        Assert.AreEqual(0, child.Bounds.X);
+        Assert.AreEqual(0, child.Bounds.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_TwoFixedColumns_PositionsCorrectly()
     {
         var left = new TextBlockNode { Text = "L" };
@@ -155,13 +156,13 @@ public class GridNodeTests
         node.Measure(new Constraints(0, 80, 0, 24));
         node.Arrange(new Rect(0, 0, 80, 24));
 
-        Assert.Equal(0, left.Bounds.X);
-        Assert.Equal(20, left.Bounds.Width);
-        Assert.Equal(20, right.Bounds.X);
-        Assert.Equal(30, right.Bounds.Width);
+        Assert.AreEqual(0, left.Bounds.X);
+        Assert.AreEqual(20, left.Bounds.Width);
+        Assert.AreEqual(20, right.Bounds.X);
+        Assert.AreEqual(30, right.Bounds.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_TwoFixedRows_PositionsCorrectly()
     {
         var top = new TextBlockNode { Text = "T" };
@@ -178,13 +179,13 @@ public class GridNodeTests
         node.Measure(new Constraints(0, 80, 0, 24));
         node.Arrange(new Rect(0, 0, 80, 24));
 
-        Assert.Equal(0, top.Bounds.Y);
-        Assert.Equal(5, top.Bounds.Height);
-        Assert.Equal(5, bottom.Bounds.Y);
-        Assert.Equal(10, bottom.Bounds.Height);
+        Assert.AreEqual(0, top.Bounds.Y);
+        Assert.AreEqual(5, top.Bounds.Height);
+        Assert.AreEqual(5, bottom.Bounds.Y);
+        Assert.AreEqual(10, bottom.Bounds.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_MixedFixedAndFillColumns_DistributesCorrectly()
     {
         var nav = new TextBlockNode { Text = "Nav" };
@@ -201,13 +202,13 @@ public class GridNodeTests
         node.Measure(new Constraints(0, 80, 0, 24));
         node.Arrange(new Rect(0, 0, 80, 24));
 
-        Assert.Equal(0, nav.Bounds.X);
-        Assert.Equal(20, nav.Bounds.Width);
-        Assert.Equal(20, content.Bounds.X);
-        Assert.Equal(60, content.Bounds.Width); // 80 - 20
+        Assert.AreEqual(0, nav.Bounds.X);
+        Assert.AreEqual(20, nav.Bounds.Width);
+        Assert.AreEqual(20, content.Bounds.X);
+        Assert.AreEqual(60, content.Bounds.Width); // 80 - 20
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_WithOffset_PositionsRelativeToOrigin()
     {
         var child = new TextBlockNode { Text = "Hi" };
@@ -220,15 +221,15 @@ public class GridNodeTests
         node.Measure(new Constraints(0, 80, 0, 24));
         node.Arrange(new Rect(10, 5, 80, 24));
 
-        Assert.Equal(10, child.Bounds.X);
-        Assert.Equal(5, child.Bounds.Y);
+        Assert.AreEqual(10, child.Bounds.X);
+        Assert.AreEqual(5, child.Bounds.Y);
     }
 
     #endregion
 
     #region Spanning Tests
 
-    [Fact]
+    [TestMethod]
     public void Arrange_RowSpan_CellSpansMultipleRows()
     {
         var nav = new TextBlockNode { Text = "Nav" };
@@ -249,25 +250,25 @@ public class GridNodeTests
         node.Arrange(new Rect(0, 0, 80, 24));
 
         // Nav spans rows 0-1
-        Assert.Equal(0, nav.Bounds.X);
-        Assert.Equal(0, nav.Bounds.Y);
-        Assert.Equal(20, nav.Bounds.Width);
-        Assert.Equal(10, nav.Bounds.Height); // 3 + 7
+        Assert.AreEqual(0, nav.Bounds.X);
+        Assert.AreEqual(0, nav.Bounds.Y);
+        Assert.AreEqual(20, nav.Bounds.Width);
+        Assert.AreEqual(10, nav.Bounds.Height); // 3 + 7
 
         // Header is row 0, col 1
-        Assert.Equal(20, header.Bounds.X);
-        Assert.Equal(0, header.Bounds.Y);
-        Assert.Equal(60, header.Bounds.Width);
-        Assert.Equal(3, header.Bounds.Height);
+        Assert.AreEqual(20, header.Bounds.X);
+        Assert.AreEqual(0, header.Bounds.Y);
+        Assert.AreEqual(60, header.Bounds.Width);
+        Assert.AreEqual(3, header.Bounds.Height);
 
         // Content is row 1, col 1
-        Assert.Equal(20, content.Bounds.X);
-        Assert.Equal(3, content.Bounds.Y);
-        Assert.Equal(60, content.Bounds.Width);
-        Assert.Equal(7, content.Bounds.Height);
+        Assert.AreEqual(20, content.Bounds.X);
+        Assert.AreEqual(3, content.Bounds.Y);
+        Assert.AreEqual(60, content.Bounds.Width);
+        Assert.AreEqual(7, content.Bounds.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_ColumnSpan_CellSpansMultipleColumns()
     {
         var header = new TextBlockNode { Text = "Header" };
@@ -288,124 +289,124 @@ public class GridNodeTests
         node.Arrange(new Rect(0, 0, 80, 24));
 
         // Header spans both columns
-        Assert.Equal(0, header.Bounds.X);
-        Assert.Equal(80, header.Bounds.Width); // 30 + 50
-        Assert.Equal(3, header.Bounds.Height);
+        Assert.AreEqual(0, header.Bounds.X);
+        Assert.AreEqual(80, header.Bounds.Width); // 30 + 50
+        Assert.AreEqual(3, header.Bounds.Height);
 
         // Left in col 0
-        Assert.Equal(0, left.Bounds.X);
-        Assert.Equal(30, left.Bounds.Width);
+        Assert.AreEqual(0, left.Bounds.X);
+        Assert.AreEqual(30, left.Bounds.Width);
 
         // Right in col 1
-        Assert.Equal(30, right.Bounds.X);
-        Assert.Equal(50, right.Bounds.Width);
+        Assert.AreEqual(30, right.Bounds.X);
+        Assert.AreEqual(50, right.Bounds.Width);
     }
 
     #endregion
 
     #region GridCellWidget Fluent API Tests
 
-    [Fact]
+    [TestMethod]
     public void GridCellWidget_Row_SetsRowAndDefaultSpan()
     {
         var cell = new GridCellWidget(new TextBlockWidget("test")).Row(2);
-        Assert.Equal(2, cell.RowIndex);
-        Assert.Equal(1, cell.RowSpanCount);
+        Assert.AreEqual(2, cell.RowIndex);
+        Assert.AreEqual(1, cell.RowSpanCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void GridCellWidget_RowSpan_SetsRowAndSpan()
     {
         var cell = new GridCellWidget(new TextBlockWidget("test")).RowSpan(1, 3);
-        Assert.Equal(1, cell.RowIndex);
-        Assert.Equal(3, cell.RowSpanCount);
+        Assert.AreEqual(1, cell.RowIndex);
+        Assert.AreEqual(3, cell.RowSpanCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void GridCellWidget_Column_SetsColumnAndDefaultSpan()
     {
         var cell = new GridCellWidget(new TextBlockWidget("test")).Column(4);
-        Assert.Equal(4, cell.ColumnIndex);
-        Assert.Equal(1, cell.ColumnSpanCount);
+        Assert.AreEqual(4, cell.ColumnIndex);
+        Assert.AreEqual(1, cell.ColumnSpanCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void GridCellWidget_ColumnSpan_SetsColumnAndSpan()
     {
         var cell = new GridCellWidget(new TextBlockWidget("test")).ColumnSpan(2, 3);
-        Assert.Equal(2, cell.ColumnIndex);
-        Assert.Equal(3, cell.ColumnSpanCount);
+        Assert.AreEqual(2, cell.ColumnIndex);
+        Assert.AreEqual(3, cell.ColumnSpanCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void GridCellWidget_Width_SetsFixedWidthHint()
     {
         var cell = new GridCellWidget(new TextBlockWidget("test")).Width(25);
-        Assert.Equal(SizeHint.Fixed(25), cell.CellWidthHint);
+        Assert.AreEqual(SizeHint.Fixed(25), cell.CellWidthHint);
     }
 
-    [Fact]
+    [TestMethod]
     public void GridCellWidget_FillWidth_SetsFillHint()
     {
         var cell = new GridCellWidget(new TextBlockWidget("test")).FillWidth();
-        Assert.Equal(SizeHint.Fill, cell.CellWidthHint);
+        Assert.AreEqual(SizeHint.Fill, cell.CellWidthHint);
     }
 
-    [Fact]
+    [TestMethod]
     public void GridCellWidget_Height_SetsFixedHeightHint()
     {
         var cell = new GridCellWidget(new TextBlockWidget("test")).Height(10);
-        Assert.Equal(SizeHint.Fixed(10), cell.CellHeightHint);
+        Assert.AreEqual(SizeHint.Fixed(10), cell.CellHeightHint);
     }
 
-    [Fact]
+    [TestMethod]
     public void GridCellWidget_FillHeight_SetsFillHint()
     {
         var cell = new GridCellWidget(new TextBlockWidget("test")).FillHeight();
-        Assert.Equal(SizeHint.Fill, cell.CellHeightHint);
+        Assert.AreEqual(SizeHint.Fill, cell.CellHeightHint);
     }
 
     #endregion
 
     #region GridColumnDefinition / GridRowDefinition Tests
 
-    [Fact]
+    [TestMethod]
     public void GridColumnDefinition_DefaultConstructor_UsesContentSizing()
     {
         var def = new GridColumnDefinition();
-        Assert.Equal(SizeHint.Content, def.Width);
+        Assert.AreEqual(SizeHint.Content, def.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void GridRowDefinition_DefaultConstructor_UsesContentSizing()
     {
         var def = new GridRowDefinition();
-        Assert.Equal(SizeHint.Content, def.Height);
+        Assert.AreEqual(SizeHint.Content, def.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void GridDefinitionCollection_AddSizeHint_CreatesColumnDefinition()
     {
         var columns = new GridDefinitionCollection<GridColumnDefinition>();
         columns.Add(SizeHint.Fixed(20));
-        Assert.Single(columns);
-        Assert.Equal(SizeHint.Fixed(20), columns[0].Width);
+        TestSeq.Single(columns);
+        Assert.AreEqual(SizeHint.Fixed(20), columns[0].Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void GridDefinitionCollection_AddSizeHint_CreatesRowDefinition()
     {
         var rows = new GridDefinitionCollection<GridRowDefinition>();
         rows.Add(SizeHint.Fill);
-        Assert.Single(rows);
-        Assert.Equal(SizeHint.Fill, rows[0].Height);
+        TestSeq.Single(rows);
+        Assert.AreEqual(SizeHint.Fill, rows[0].Height);
     }
 
     #endregion
 
     #region GetChildren Tests
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_ReturnsAllCellNodes()
     {
         var a = new TextBlockNode { Text = "A" };
@@ -424,7 +425,7 @@ public class GridNodeTests
 
         var children = node.GetChildren().ToList();
 
-        Assert.Equal(3, children.Count);
+        Assert.AreEqual(3, children.Count);
         Assert.Contains(a, children);
         Assert.Contains(b, children);
         Assert.Contains(c, children);
@@ -434,7 +435,7 @@ public class GridNodeTests
 
     #region Classic Layout Scenario
 
-    [Fact]
+    [TestMethod]
     public void Arrange_ClassicSidebarLayout_PositionsCorrectly()
     {
         // Sidebar layout:
@@ -458,13 +459,13 @@ public class GridNodeTests
         node.Arrange(new Rect(0, 0, 80, 24));
 
         // Nav: col 0, rows 0-1, 20w × 24h
-        Assert.Equal(new Rect(0, 0, 20, 24), nav.Bounds);
+        Assert.AreEqual(new Rect(0, 0, 20, 24), nav.Bounds);
 
         // Header: col 1, row 0, 60w × 3h
-        Assert.Equal(new Rect(20, 0, 60, 3), header.Bounds);
+        Assert.AreEqual(new Rect(20, 0, 60, 3), header.Bounds);
 
         // Content: col 1, row 1, 60w × 21h
-        Assert.Equal(new Rect(20, 3, 60, 21), content.Bounds);
+        Assert.AreEqual(new Rect(20, 3, 60, 21), content.Bounds);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/GutterDecorationTests.cs
+++ b/tests/Hex1b.Tests/GutterDecorationTests.cs
@@ -10,6 +10,7 @@ namespace Hex1b.Tests;
 /// Tests for gutter decorations — icons/markers in the editor margin
 /// via <see cref="DecorationGutterProvider"/>.
 /// </summary>
+[TestClass]
 public class GutterDecorationTests
 {
     private static Hex1bColor? ToCellColor(Hex1bColor color) => color.IsDefault ? null : color;
@@ -39,7 +40,7 @@ public class GutterDecorationTests
 
     // ── State management tests ────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void PushGutterDecorations_StoresOnSession()
     {
         var doc = new Hex1bDocument("abc\ndef");
@@ -52,10 +53,10 @@ public class GutterDecorationTests
             new GutterDecoration(2, '⚠', GutterDecorationKind.Warning)
         ]);
 
-        Assert.Equal(2, session.ActiveGutterDecorations.Count);
+        Assert.AreEqual(2, session.ActiveGutterDecorations.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClearGutterDecorations_RemovesAll()
     {
         var doc = new Hex1bDocument("test");
@@ -66,12 +67,12 @@ public class GutterDecorationTests
         session.PushGutterDecorations([new GutterDecoration(1, 'X')]);
         session.ClearGutterDecorations();
 
-        Assert.Empty(session.ActiveGutterDecorations);
+        Assert.IsEmpty(session.ActiveGutterDecorations);
     }
 
     // ── Visual rendering tests ────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task Render_GutterDecoration_ShowsIconAtCorrectLine()
     {
         var (node, workload, terminal, context, theme) = CreateEditor("abc\ndef\nghi", 20, 5);
@@ -98,22 +99,22 @@ public class GutterDecorationTests
         var snapshot = terminal.CreateSnapshot();
 
         // Line 0 (doc line 1): no decoration → space in gutter
-        Assert.Equal(" ", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("a", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual(" ", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("a", snapshot.GetCell(1, 0).Character);
 
         // Line 1 (doc line 2): '*' decoration
-        Assert.Equal("*", snapshot.GetCell(0, 1).Character);
-        Assert.Equal("d", snapshot.GetCell(1, 1).Character);
+        Assert.AreEqual("*", snapshot.GetCell(0, 1).Character);
+        Assert.AreEqual("d", snapshot.GetCell(1, 1).Character);
 
         // Line 2 (doc line 3): no decoration → space
-        Assert.Equal(" ", snapshot.GetCell(0, 2).Character);
-        Assert.Equal("g", snapshot.GetCell(1, 2).Character);
+        Assert.AreEqual(" ", snapshot.GetCell(0, 2).Character);
+        Assert.AreEqual("g", snapshot.GetCell(1, 2).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_ErrorDecoration_UsesThemeErrorColor()
     {
         var (node, workload, terminal, context, theme) = CreateEditor("abc", 20, 3);
@@ -138,15 +139,14 @@ public class GutterDecorationTests
 
         var expectedFg = ToCellColor(theme.Get(GutterDecorationTheme.ErrorIconColor));
         var cell = snapshot.GetCell(0, 0);
-        Assert.Equal("E", cell.Character);
-        Assert.True(ColorEquals(expectedFg, cell.Foreground),
-            $"Expected error color {expectedFg}, got {cell.Foreground}");
+        Assert.AreEqual("E", cell.Character);
+        Assert.IsTrue(ColorEquals(expectedFg, cell.Foreground), $"Expected error color {expectedFg}, got {cell.Foreground}");
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_CustomForeground_OverridesKindDefault()
     {
         var customColor = Hex1bColor.FromRgb(0, 255, 0);
@@ -172,14 +172,13 @@ public class GutterDecorationTests
 
         var expectedFg = ToCellColor(customColor);
         var cell = snapshot.GetCell(0, 0);
-        Assert.True(ColorEquals(expectedFg, cell.Foreground),
-            $"Expected custom fg {expectedFg}, got {cell.Foreground}");
+        Assert.IsTrue(ColorEquals(expectedFg, cell.Foreground), $"Expected custom fg {expectedFg}, got {cell.Foreground}");
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithLineNumbers_DecorationsAppearBeforeLineNumbers()
     {
         var (node, workload, terminal, context, theme) = CreateEditor("abc\ndef", 20, 3, showLineNumbers: true);
@@ -205,21 +204,21 @@ public class GutterDecorationTests
         var snapshot = terminal.CreateSnapshot();
 
         // Col 0: decoration icon '*'
-        Assert.Equal("*", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("*", snapshot.GetCell(0, 0).Character);
         // Col 1: line number padding ' '
-        Assert.Equal(" ", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual(" ", snapshot.GetCell(1, 0).Character);
         // Col 2: line number '1'
-        Assert.Equal("1", snapshot.GetCell(2, 0).Character);
+        Assert.AreEqual("1", snapshot.GetCell(2, 0).Character);
         // Col 3: separator ' '
-        Assert.Equal(" ", snapshot.GetCell(3, 0).Character);
+        Assert.AreEqual(" ", snapshot.GetCell(3, 0).Character);
         // Col 4: content 'a'
-        Assert.Equal("a", snapshot.GetCell(4, 0).Character);
+        Assert.AreEqual("a", snapshot.GetCell(4, 0).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_NoDecorations_NoGutterColumn()
     {
         // Without decorations, the DecorationGutterProvider should have width 0
@@ -237,7 +236,7 @@ public class GutterDecorationTests
         var snapshot = terminal.CreateSnapshot();
 
         // Content starts at column 0 (no gutter)
-        Assert.Equal("a", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("a", snapshot.GetCell(0, 0).Character);
 
         workload.Dispose();
         terminal.Dispose();

--- a/tests/Hex1b.Tests/GutterProviderTests.cs
+++ b/tests/Hex1b.Tests/GutterProviderTests.cs
@@ -10,6 +10,7 @@ namespace Hex1b.Tests;
 /// Tests for the extensible gutter system: <see cref="IGutterProvider"/>,
 /// <see cref="LineNumberGutterProvider"/>, and composable gutter rendering.
 /// </summary>
+[TestClass]
 public class GutterProviderTests
 {
     private static Hex1bColor? ToCellColor(Hex1bColor color) => color.IsDefault ? null : color;
@@ -65,17 +66,17 @@ public class GutterProviderTests
 
     // ── LineNumberGutterProvider tests ─────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void LineNumberProvider_GetWidth_ReturnsDigitsPlusSeparator()
     {
         var doc = new Hex1bDocument("line1\nline2\nline3");
         var width = LineNumberGutterProvider.Instance.GetWidth(doc);
 
         // 3 lines → 1 digit → min 2 digits + 1 separator = 3
-        Assert.Equal(3, width);
+        Assert.AreEqual(3, width);
     }
 
-    [Fact]
+    [TestMethod]
     public void LineNumberProvider_GetWidth_ScalesWithLineCount()
     {
         var lines = string.Join("\n", Enumerable.Range(1, 100).Select(i => $"line{i}"));
@@ -83,20 +84,20 @@ public class GutterProviderTests
         var width = LineNumberGutterProvider.Instance.GetWidth(doc);
 
         // 100 lines → 3 digits + 1 separator = 4
-        Assert.Equal(4, width);
+        Assert.AreEqual(4, width);
     }
 
-    [Fact]
+    [TestMethod]
     public void LineNumberProvider_GetWidth_Minimum2Digits()
     {
         var doc = new Hex1bDocument("single line");
         var width = LineNumberGutterProvider.Instance.GetWidth(doc);
 
         // 1 line → min 2 digits + 1 separator = 3
-        Assert.Equal(3, width);
+        Assert.AreEqual(3, width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ShowLineNumbers_RendersIdenticallyAfterRefactor()
     {
         // Original API: ShowLineNumbers = true should render line numbers via the provider
@@ -116,24 +117,24 @@ public class GutterProviderTests
 
         // Gutter width = 3 (min 2 digits + 1 separator)
         // Line 1: " 1 abc"
-        Assert.Equal(" ", snapshot.GetCell(0, 0).Character); // padding
-        Assert.Equal("1", snapshot.GetCell(1, 0).Character); // digit
-        Assert.Equal(" ", snapshot.GetCell(2, 0).Character); // separator
-        Assert.Equal("a", snapshot.GetCell(3, 0).Character); // content starts
+        Assert.AreEqual(" ", snapshot.GetCell(0, 0).Character); // padding
+        Assert.AreEqual("1", snapshot.GetCell(1, 0).Character); // digit
+        Assert.AreEqual(" ", snapshot.GetCell(2, 0).Character); // separator
+        Assert.AreEqual("a", snapshot.GetCell(3, 0).Character); // content starts
 
         // Line 2: " 2 def"
-        Assert.Equal("2", snapshot.GetCell(1, 1).Character);
-        Assert.Equal("d", snapshot.GetCell(3, 1).Character);
+        Assert.AreEqual("2", snapshot.GetCell(1, 1).Character);
+        Assert.AreEqual("d", snapshot.GetCell(3, 1).Character);
 
         // Line 3: " 3 ghi"
-        Assert.Equal("3", snapshot.GetCell(1, 2).Character);
-        Assert.Equal("g", snapshot.GetCell(3, 2).Character);
+        Assert.AreEqual("3", snapshot.GetCell(1, 2).Character);
+        Assert.AreEqual("g", snapshot.GetCell(3, 2).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ShowLineNumbers_GutterUsesThemeColor()
     {
         var (node, workload, terminal, context, theme) = CreateEditor("abc", 20, 3, showLineNumbers: true);
@@ -152,8 +153,7 @@ public class GutterProviderTests
         // Line number should use GutterTheme.LineNumberForegroundColor
         var expectedFg = ToCellColor(theme.Get(GutterTheme.LineNumberForegroundColor));
         var cell = snapshot.GetCell(1, 0); // the "1" digit
-        Assert.True(ColorEquals(expectedFg, cell.Foreground),
-            $"Expected gutter fg {expectedFg}, got {cell.Foreground}");
+        Assert.IsTrue(ColorEquals(expectedFg, cell.Foreground), $"Expected gutter fg {expectedFg}, got {cell.Foreground}");
 
         workload.Dispose();
         terminal.Dispose();
@@ -161,7 +161,7 @@ public class GutterProviderTests
 
     // ── Custom gutter provider tests ──────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task CustomGutterProvider_RendersAtCorrectPosition()
     {
         var provider = new FixedCharGutterProvider('*');
@@ -179,16 +179,16 @@ public class GutterProviderTests
 
         var snapshot = terminal.CreateSnapshot();
 
-        Assert.Equal("*", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("a", snapshot.GetCell(1, 0).Character);
-        Assert.Equal("*", snapshot.GetCell(0, 1).Character);
-        Assert.Equal("d", snapshot.GetCell(1, 1).Character);
+        Assert.AreEqual("*", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("a", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("*", snapshot.GetCell(0, 1).Character);
+        Assert.AreEqual("d", snapshot.GetCell(1, 1).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MultipleProviders_RenderLeftToRight()
     {
         var provider1 = new FixedCharGutterProvider('A');
@@ -207,15 +207,15 @@ public class GutterProviderTests
 
         var snapshot = terminal.CreateSnapshot();
 
-        Assert.Equal("A", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("B", snapshot.GetCell(1, 0).Character);
-        Assert.Equal("x", snapshot.GetCell(2, 0).Character);
+        Assert.AreEqual("A", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("B", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("x", snapshot.GetCell(2, 0).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GutterProvider_PastEndOfDocument_RendersBlank()
     {
         var provider = new FixedCharGutterProvider('*');
@@ -234,16 +234,16 @@ public class GutterProviderTests
         var snapshot = terminal.CreateSnapshot();
 
         // Line 0: '*' (docLine > 0)
-        Assert.Equal("*", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("*", snapshot.GetCell(0, 0).Character);
         // Lines 1-2: ' ' (docLine == 0, past end of document)
-        Assert.Equal(" ", snapshot.GetCell(0, 1).Character);
-        Assert.Equal(" ", snapshot.GetCell(0, 2).Character);
+        Assert.AreEqual(" ", snapshot.GetCell(0, 1).Character);
+        Assert.AreEqual(" ", snapshot.GetCell(0, 2).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GutterProvider_ReducesViewportColumns()
     {
         // With a 2-wide gutter provider, content area should be reduced
@@ -263,16 +263,16 @@ public class GutterProviderTests
 
         var snapshot = terminal.CreateSnapshot();
 
-        Assert.Equal("X", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("X", snapshot.GetCell(1, 0).Character);
-        Assert.Equal("X", snapshot.GetCell(2, 0).Character);
-        Assert.Equal("a", snapshot.GetCell(3, 0).Character);
+        Assert.AreEqual("X", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("X", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("X", snapshot.GetCell(2, 0).Character);
+        Assert.AreEqual("a", snapshot.GetCell(3, 0).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NoGutterProviders_NoShowLineNumbers_NoGutter()
     {
         // No providers and ShowLineNumbers=false → no gutter, content starts at col 0
@@ -289,13 +289,13 @@ public class GutterProviderTests
 
         var snapshot = terminal.CreateSnapshot();
 
-        Assert.Equal("h", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("h", snapshot.GetCell(0, 0).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ExplicitGutterProvider_OverridesShowLineNumbers()
     {
         // When explicit providers are set, they take priority over ShowLineNumbers
@@ -315,14 +315,14 @@ public class GutterProviderTests
 
         var snapshot = terminal.CreateSnapshot();
 
-        Assert.Equal("#", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("a", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("#", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("a", snapshot.GetCell(1, 0).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public void WidgetGutterApi_AccumulatesProviders()
     {
         var provider1 = new FixedCharGutterProvider('A');
@@ -332,7 +332,7 @@ public class GutterProviderTests
 
         var widget = new EditorWidget(state).Gutter(provider1).Gutter(provider2);
 
-        Assert.NotNull(widget.GutterProvidersValue);
-        Assert.Equal(2, widget.GutterProvidersValue!.Count);
+        Assert.IsNotNull(widget.GutterProvidersValue);
+        Assert.AreEqual(2, widget.GutterProvidersValue!.Count);
     }
 }

--- a/tests/Hex1b.Tests/HStackNodeTests.cs
+++ b/tests/Hex1b.Tests/HStackNodeTests.cs
@@ -7,11 +7,12 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for HStackNode layout, rendering, and focus management.
 /// </summary>
+[TestClass]
 public class HStackNodeTests
 {
     #region Measurement Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_SumsChildWidths()
     {
         var node = new HStackNode
@@ -26,10 +27,10 @@ public class HStackNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(9, size.Width);
+        Assert.AreEqual(9, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_TakesMaxHeight()
     {
         var node = new HStackNode
@@ -45,21 +46,21 @@ public class HStackNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // All TextBlocks are 1 line tall
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_EmptyChildren_ReturnsZeroSize()
     {
         var node = new HStackNode { Children = new List<Hex1bNode>() };
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(0, size.Width);
-        Assert.Equal(0, size.Height);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(0, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_RespectsMaxConstraints()
     {
         var node = new HStackNode
@@ -73,14 +74,14 @@ public class HStackNodeTests
 
         var size = node.Measure(new Constraints(0, 15, 0, 5));
 
-        Assert.Equal(15, size.Width);
+        Assert.AreEqual(15, size.Width);
     }
 
     #endregion
 
     #region Arrange Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_PositionsChildrenHorizontally()
     {
         var child1 = new TextBlockNode { Text = "AAA" };
@@ -90,11 +91,11 @@ public class HStackNodeTests
         node.Measure(Constraints.Unbounded);
         node.Arrange(new Rect(0, 0, 80, 24));
 
-        Assert.Equal(0, child1.Bounds.X);
-        Assert.Equal(3, child2.Bounds.X);
+        Assert.AreEqual(0, child1.Bounds.X);
+        Assert.AreEqual(3, child2.Bounds.X);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_WithFillHints_DistributesWidth()
     {
         var child1 = new TextBlockNode { Text = "A" };
@@ -108,12 +109,12 @@ public class HStackNodeTests
         node.Arrange(new Rect(0, 0, 20, 10));
 
         // First child should be content-sized (1 char)
-        Assert.Equal(1, child1.Bounds.Width);
+        Assert.AreEqual(1, child1.Bounds.Width);
         // Second child should fill remaining space
-        Assert.Equal(19, child2.Bounds.Width);
+        Assert.AreEqual(19, child2.Bounds.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_WithFixedHints_UsesExactSize()
     {
         var child1 = new TextBlockNode { Text = "Fixed1", WidthHint = SizeHint.Fixed(10) };
@@ -126,11 +127,11 @@ public class HStackNodeTests
         node.Measure(Constraints.Tight(40, 10));
         node.Arrange(new Rect(0, 0, 40, 10));
 
-        Assert.Equal(10, child1.Bounds.Width);
-        Assert.Equal(15, child2.Bounds.Width);
+        Assert.AreEqual(10, child1.Bounds.Width);
+        Assert.AreEqual(15, child2.Bounds.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_WithMixedHints_DistributesCorrectly()
     {
         var child1 = new TextBlockNode { Text = "Fixed", WidthHint = SizeHint.Fixed(10) };
@@ -144,13 +145,13 @@ public class HStackNodeTests
         node.Measure(Constraints.Tight(40, 10));
         node.Arrange(new Rect(0, 0, 40, 10));
 
-        Assert.Equal(10, child1.Bounds.Width);
+        Assert.AreEqual(10, child1.Bounds.Width);
         // Remaining 30 units split between 2 fill children
-        Assert.Equal(15, child2.Bounds.Width);
-        Assert.Equal(15, child3.Bounds.Width);
+        Assert.AreEqual(15, child2.Bounds.Width);
+        Assert.AreEqual(15, child3.Bounds.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_AtOffset_PositionsChildrenCorrectly()
     {
         var child1 = new TextBlockNode { Text = "AAA" };
@@ -160,17 +161,17 @@ public class HStackNodeTests
         node.Measure(Constraints.Unbounded);
         node.Arrange(new Rect(5, 10, 30, 20));
 
-        Assert.Equal(5, child1.Bounds.X);
-        Assert.Equal(10, child1.Bounds.Y);
-        Assert.Equal(8, child2.Bounds.X);
-        Assert.Equal(10, child2.Bounds.Y);
+        Assert.AreEqual(5, child1.Bounds.X);
+        Assert.AreEqual(10, child1.Bounds.Y);
+        Assert.AreEqual(8, child2.Bounds.X);
+        Assert.AreEqual(10, child2.Bounds.Y);
     }
 
     #endregion
 
     #region Focus Tests
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_FindsAllFocusable()
     {
         var button1 = new ButtonNode { Label = "1" };
@@ -184,12 +185,12 @@ public class HStackNodeTests
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Equal(2, focusables.Count);
+        Assert.AreEqual(2, focusables.Count);
         Assert.Contains(button1, focusables);
         Assert.Contains(button2, focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Tab_MovesFocus()
     {
         var button1 = new ButtonNode { Label = "1", IsFocused = true };
@@ -206,12 +207,12 @@ public class HStackNodeTests
 
         var result = await InputRouter.RouteInputAsync(node, new Hex1bKeyEvent(Hex1bKey.Tab, '\t', Hex1bModifiers.None), focusRing, routerState, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.False(button1.IsFocused);
-        Assert.True(button2.IsFocused);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsFalse(button1.IsFocused);
+        Assert.IsTrue(button2.IsFocused);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_ShiftTab_MovesFocusBackward()
     {
         var button1 = new ButtonNode { Label = "1", IsFocused = true };
@@ -229,11 +230,11 @@ public class HStackNodeTests
         // Shift-tab from button1 should wrap to button2
         await InputRouter.RouteInputAsync(node, new Hex1bKeyEvent(Hex1bKey.Tab, '\t', Hex1bModifiers.Shift), focusRing, routerState2, null, TestContext.Current.CancellationToken);
 
-        Assert.False(button1.IsFocused);
-        Assert.True(button2.IsFocused);
+        Assert.IsFalse(button1.IsFocused);
+        Assert.IsTrue(button2.IsFocused);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_DispatchesToFocusedChild()
     {
         var clicked = false;
@@ -248,14 +249,14 @@ public class HStackNodeTests
         // Use InputRouter to route input to the focused child
         await InputRouter.RouteInputAsync(node, new Hex1bKeyEvent(Hex1bKey.Enter, '\r', Hex1bModifiers.None), focusRing, routerState, null, TestContext.Current.CancellationToken);
 
-        Assert.True(clicked);
+        Assert.IsTrue(clicked);
     }
 
     #endregion
 
     #region Rendering Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Render_RendersAllChildren()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -285,7 +286,7 @@ public class HStackNodeTests
         Assert.Contains("Right", snapshot.GetScreenText());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_ChildrenAppearOnSameLine()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -318,7 +319,7 @@ public class HStackNodeTests
         Assert.Contains("CCC", line);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_InNarrowTerminal_TextWraps()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -352,7 +353,7 @@ public class HStackNodeTests
 
     #region Integration Tests with Hex1bApp
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_HStack_RendersMultipleChildren()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -383,12 +384,12 @@ public class HStackNodeTests
         await runTask;
 
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("Left"));
-        Assert.True(snapshot.ContainsText("|"));
-        Assert.True(snapshot.ContainsText("Right"));
+        Assert.IsTrue(snapshot.ContainsText("Left"));
+        Assert.IsTrue(snapshot.ContainsText("|"));
+        Assert.IsTrue(snapshot.ContainsText("Right"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_HStack_TabNavigatesThroughFocusables()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -420,11 +421,11 @@ public class HStackNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.False(button1Clicked);
-        Assert.True(button2Clicked);
+        Assert.IsFalse(button1Clicked);
+        Assert.IsTrue(button2Clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_HStack_InNarrowTerminal_StillWorks()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -455,12 +456,12 @@ public class HStackNodeTests
         await runTask;
 
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("A"));
-        Assert.True(snapshot.ContainsText("B"));
-        Assert.True(snapshot.ContainsText("C"));
+        Assert.IsTrue(snapshot.ContainsText("A"));
+        Assert.IsTrue(snapshot.ContainsText("B"));
+        Assert.IsTrue(snapshot.ContainsText("C"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_HStack_WithVStack_NestedLayouts()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -496,13 +497,13 @@ public class HStackNodeTests
         await runTask;
 
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("Left Top"));
-        Assert.True(snapshot.ContainsText("Left Bottom"));
-        Assert.True(snapshot.ContainsText("Right Top"));
-        Assert.True(snapshot.ContainsText("Right Bottom"));
+        Assert.IsTrue(snapshot.ContainsText("Left Top"));
+        Assert.IsTrue(snapshot.ContainsText("Left Bottom"));
+        Assert.IsTrue(snapshot.ContainsText("Right Top"));
+        Assert.IsTrue(snapshot.ContainsText("Right Bottom"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_HStack_WithMixedContent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -535,11 +536,11 @@ public class HStackNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("Hi", text);
-        Assert.True(clicked);
+        Assert.AreEqual("Hi", text);
+        Assert.IsTrue(clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_HStack_EmptyStack_DoesNotCrash()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -565,7 +566,7 @@ public class HStackNodeTests
         // Should complete without error - test is that we didn't throw
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_HStack_LongContentInNarrowTerminal_Wraps()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -595,10 +596,10 @@ public class HStackNodeTests
         await runTask;
 
         // Content wraps at terminal boundary - use captured snapshot
-        Assert.True(snapshot.ContainsText("VeryLongWord"));
+        Assert.IsTrue(snapshot.ContainsText("VeryLongWord"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_HStack_DynamicContent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -626,12 +627,12 @@ public class HStackNodeTests
         await runTask;
 
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("[A]"));
-        Assert.True(snapshot.ContainsText("[B]"));
-        Assert.True(snapshot.ContainsText("[C]"));
+        Assert.IsTrue(snapshot.ContainsText("[A]"));
+        Assert.IsTrue(snapshot.ContainsText("[B]"));
+        Assert.IsTrue(snapshot.ContainsText("[C]"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TabFromSingleFocusableVStackInHStack_BubblesUpToHStack()
     {
         // Scenario: HStack with children that are VStacks, each containing only one focusable.
@@ -667,10 +668,10 @@ public class HStackNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(rightButtonClicked, "Tab should have moved focus from List in left VStack to Button in right VStack");
+        Assert.IsTrue(rightButtonClicked, "Tab should have moved focus from List in left VStack to Button in right VStack");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_VStackWithMultipleFocusables_HandleTabInternally()
     {
         // Scenario: VStack with 2 focusables should handle Tab itself, not bubble up
@@ -702,11 +703,11 @@ public class HStackNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.False(button1Clicked);
-        Assert.True(button2Clicked, "Tab should have moved focus from Button 1 to Button 2 within VStack");
+        Assert.IsFalse(button1Clicked);
+        Assert.IsTrue(button2Clicked, "Tab should have moved focus from Button 1 to Button 2 within VStack");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_NestedVStackWithMultipleFocusables_TabEscapesAtBoundary()
     {
         // Scenario: VStack with 2 focusables nested inside an HStack.
@@ -752,12 +753,12 @@ public class HStackNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.False(listClicked);
-        Assert.False(addButtonClicked);
-        Assert.True(otherButtonClicked, "Tab at VStack boundary should escape to next HStack child");
+        Assert.IsFalse(listClicked);
+        Assert.IsFalse(addButtonClicked);
+        Assert.IsTrue(otherButtonClicked, "Tab at VStack boundary should escape to next HStack child");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_NestedVStackWithMultipleFocusables_ShiftTabEscapesAtBoundary()
     {
         // Scenario: Same as above but with Shift+Tab escaping at the first item.
@@ -796,7 +797,7 @@ public class HStackNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(listClicked, "Shift+Tab at first VStack item should escape back to previous HStack child");
+        Assert.IsTrue(listClicked, "Shift+Tab at first VStack item should escape back to previous HStack child");
     }
 
     #endregion

--- a/tests/Hex1b.Tests/Hex1b.Tests.csproj
+++ b/tests/Hex1b.Tests/Hex1b.Tests.csproj
@@ -1,24 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSTest.Sdk/4.2.3">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <!-- Suppress xUnit analyzer recommendations (not bugs):
-         xUnit1031: blocking task operations
-         xUnit1051: CancellationToken usage -->
-    <NoWarn>xUnit1031;xUnit1051</NoWarn>
     <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 
   <ItemGroup>
@@ -29,15 +21,10 @@
     <ProjectReference Include="..\..\src\Hex1b\Hex1b.csproj" />
   </ItemGroup>
 
-  <!-- 
-    Copy native interop library for PTY testing.
-    Uses a target instead of <None> items because the library may be built
-    during the Hex1b project build, after ItemGroup evaluation.
-  -->
   <Target Name="CopyNativeLibraryLinux" AfterTargets="Build" Condition="$([MSBuild]::IsOSPlatform('Linux')) and Exists('../../src/Hex1b/Terminal/runtimes/linux-x64/native/libhex1binterop.so')">
     <Copy SourceFiles="../../src/Hex1b/Terminal/runtimes/linux-x64/native/libhex1binterop.so" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" />
   </Target>
-  
+
   <Target Name="CopyNativeLibraryOsx" AfterTargets="Build" Condition="$([MSBuild]::IsOSPlatform('OSX')) and Exists('../../src/Hex1b/Terminal/runtimes/osx-arm64/native/libhex1binterop.dylib')">
     <Copy SourceFiles="../../src/Hex1b/Terminal/runtimes/osx-arm64/native/libhex1binterop.dylib" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" />
   </Target>
@@ -66,7 +53,6 @@
   </Target>
 
   <ItemGroup>
-    <Using Include="Xunit" />
     <Using Include="Hex1b.Automation" />
   </ItemGroup>
 

--- a/tests/Hex1b.Tests/Hex1bAppIntegrationTests.cs
+++ b/tests/Hex1b.Tests/Hex1bAppIntegrationTests.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel;
 using System.Threading.Tasks;
-using Xunit.Sdk;
+
 using Hex1b.Input;
 using Hex1b.Widgets;
 
@@ -9,9 +9,10 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Integration tests for the full Hex1bApp lifecycle using the virtual terminal.
 /// </summary>
+[TestClass]
 public class Hex1bAppIntegrationTests
 {
-    [Fact]
+    [TestMethod]
     public async Task App_EntersAndExitsAlternateScreen()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -36,7 +37,7 @@ public class Hex1bAppIntegrationTests
         // Test passed - app entered alternate screen and exited cleanly
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_RendersInitialContent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -57,10 +58,10 @@ public class Hex1bAppIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
         
-        Assert.True(snapshot.ContainsText("Hello World"));
+        Assert.IsTrue(snapshot.ContainsText("Hello World"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_RespondsToInput()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -92,10 +93,10 @@ public class Hex1bAppIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
         
-        Assert.Equal("Hi", text);
+        Assert.AreEqual("Hi", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_HandlesButtonClick()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -124,10 +125,10 @@ public class Hex1bAppIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
         
-        Assert.True(clicked);
+        Assert.IsTrue(clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_HandlesCancellation()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -155,7 +156,7 @@ public class Hex1bAppIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_RendersVStackLayout()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -183,12 +184,12 @@ public class Hex1bAppIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
         
-        Assert.True(snapshot.ContainsText("Line 1"));
-        Assert.True(snapshot.ContainsText("Line 2"));
-        Assert.True(snapshot.ContainsText("Line 3"));
+        Assert.IsTrue(snapshot.ContainsText("Line 1"));
+        Assert.IsTrue(snapshot.ContainsText("Line 2"));
+        Assert.IsTrue(snapshot.ContainsText("Line 3"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_TabNavigatesBetweenWidgets()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -222,11 +223,11 @@ public class Hex1bAppIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
         
-        Assert.Equal("a", text1);
-        Assert.Equal("b", text2);
+        Assert.AreEqual("a", text1);
+        Assert.AreEqual("b", text2);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_ListNavigationWorks()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -263,10 +264,10 @@ public class Hex1bAppIntegrationTests
         await runTask;
         
         // Verify via rendered output that third item is selected
-        Assert.True(snapshot.ContainsText("> Item 3"));
+        Assert.IsTrue(snapshot.ContainsText("> Item 3"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_DynamicStateUpdates()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -300,12 +301,12 @@ public class Hex1bAppIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
         
-        Assert.Equal(2, counter);
+        Assert.AreEqual(2, counter);
         // The last render should show the updated count
-        Assert.True(snapshot.ContainsText("Count: 2"));
+        Assert.IsTrue(snapshot.ContainsText("Count: 2"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_Dispose_CleansUp()
     {
         var workload = new Hex1bAppWorkloadAdapter();
@@ -330,7 +331,7 @@ public class Hex1bAppIntegrationTests
         app.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_Invalidate_TriggersRerender()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -348,7 +349,7 @@ public class Hex1bAppIntegrationTests
         
         // Wait for initial render
         await Task.Delay(50, TestContext.Current.CancellationToken);
-        Assert.True(terminal.CreateSnapshot().ContainsText("Count: 0"));
+        Assert.IsTrue(terminal.CreateSnapshot().ContainsText("Count: 0"));
         
         // Change state externally and invalidate
         counter = 42;
@@ -356,13 +357,13 @@ public class Hex1bAppIntegrationTests
         
         // Wait for re-render
         await Task.Delay(50, TestContext.Current.CancellationToken);
-        Assert.True(terminal.CreateSnapshot().ContainsText("Count: 42"));
+        Assert.IsTrue(terminal.CreateSnapshot().ContainsText("Count: 42"));
         
         cts.Cancel();
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_InvalidateMultipleTimes_CoalescesRerenders()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -399,8 +400,7 @@ public class Hex1bAppIntegrationTests
         
         // Should have coalesced - not 100 extra renders
         // Allow up to 20 extra renders to account for timing variations in CI
-        Assert.True(renderCount < initialRenderCount + 20, 
-            $"Expected coalesced renders, but got {renderCount - initialRenderCount} extra renders");
+        Assert.IsTrue(renderCount < initialRenderCount + 20, $"Expected coalesced renders, but got {renderCount - initialRenderCount} extra renders");
         
         // Exit the app
         await new Hex1bTerminalInputSequenceBuilder()
@@ -410,7 +410,7 @@ public class Hex1bAppIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_DefaultCtrlCExit_ExitsApp()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -441,7 +441,7 @@ public class Hex1bAppIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_DefaultCtrlCExitDisabled_DoesNotExit()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -493,7 +493,7 @@ public class Hex1bAppIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_UserCtrlCBinding_OverridesDefault()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -531,10 +531,10 @@ public class Hex1bAppIntegrationTests
             .ApplyAsync(terminal);
         
         // The custom handler should have been called
-        Assert.True(customHandlerCalled);
+        Assert.IsTrue(customHandlerCalled);
         
         // App should still be running (not exited by default binding)
-        Assert.False(runTask.IsCompleted);
+        Assert.IsFalse(runTask.IsCompleted);
         
         cts.Cancel();
         await runTask;

--- a/tests/Hex1b.Tests/Hex1bAppResizeRaceTests.cs
+++ b/tests/Hex1b.Tests/Hex1bAppResizeRaceTests.cs
@@ -5,9 +5,10 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class Hex1bAppResizeRaceTests
 {
-    [Fact]
+    [TestMethod]
     public async Task RenderFrame_WhenTerminalSizeChangesMidFrame_UsesCapturedFrameSize()
     {
         await using var workload = new RacingDimensionsWorkloadAdapter(

--- a/tests/Hex1b.Tests/Hex1bAppWorkloadAdapterBackpressureTests.cs
+++ b/tests/Hex1b.Tests/Hex1bAppWorkloadAdapterBackpressureTests.cs
@@ -10,9 +10,10 @@ namespace Hex1b.Tests;
 /// <see cref="Hex1bAppWorkloadAdapter"/>. The default is unbounded
 /// (back-compat), so most tests opt in via the constructor parameter.
 /// </summary>
+[TestClass]
 public class Hex1bAppWorkloadAdapterBackpressureTests
 {
-    [Fact]
+    [TestMethod]
     public void Write_OnUnboundedAdapter_NeverBlocks()
     {
         using var adapter = new Hex1bAppWorkloadAdapter();
@@ -20,10 +21,10 @@ public class Hex1bAppWorkloadAdapterBackpressureTests
         // the default unbounded channel.
         for (var i = 0; i < 1000; i++)
             adapter.Write("x");
-        Assert.Equal(1000, adapter.OutputQueueDepth);
+        Assert.AreEqual(1000, adapter.OutputQueueDepth);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Write_OnBoundedAdapter_BlocksProducerWhenFull()
     {
         using var adapter = new Hex1bAppWorkloadAdapter(maxQueuedOutputItems: 2);
@@ -31,7 +32,7 @@ public class Hex1bAppWorkloadAdapterBackpressureTests
         // Fill the channel to capacity.
         adapter.Write("a");
         adapter.Write("b");
-        Assert.Equal(2, adapter.OutputQueueDepth);
+        Assert.AreEqual(2, adapter.OutputQueueDepth);
 
         // Producer thread - third write must block until a slot frees.
         var producerStarted = new TaskCompletionSource();
@@ -46,18 +47,18 @@ public class Hex1bAppWorkloadAdapterBackpressureTests
         await producerStarted.Task;
         // Give the producer time to attempt the write and block on the channel.
         await Task.Delay(150);
-        Assert.False(producerDone.Task.IsCompleted, "Producer should be blocked while channel is full.");
+        Assert.IsFalse(producerDone.Task.IsCompleted, "Producer should be blocked while channel is full.");
 
         // Drain one item; producer should unblock and complete.
         var read = await adapter.TryReadOutputAsync(TimeSpan.FromSeconds(1));
-        Assert.True(read.HasValue);
+        Assert.IsTrue(read.HasValue);
 
         await producerDone.Task.WaitAsync(TimeSpan.FromSeconds(2));
         await producer;
-        Assert.Equal(2, adapter.OutputQueueDepth);
+        Assert.AreEqual(2, adapter.OutputQueueDepth);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Write_OnBoundedAdapter_ChannelCompletionUnblocksProducer()
     {
         using var adapter = new Hex1bAppWorkloadAdapter(maxQueuedOutputItems: 1);
@@ -67,7 +68,7 @@ public class Hex1bAppWorkloadAdapterBackpressureTests
         var producer = Task.Run(() => adapter.Write("b")); // blocks
 
         await Task.Delay(100);
-        Assert.False(producer.IsCompleted, "Producer should block until disposal unblocks it.");
+        Assert.IsFalse(producer.IsCompleted, "Producer should block until disposal unblocks it.");
 
         // Disposing completes the writer, which should unblock the blocked
         // write attempt without leaking resources or throwing out of the
@@ -76,10 +77,10 @@ public class Hex1bAppWorkloadAdapterBackpressureTests
         await producer.WaitAsync(TimeSpan.FromSeconds(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_NegativeMaxQueued_Throws()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
             new Hex1bAppWorkloadAdapter(maxQueuedOutputItems: -1));
     }
 }

--- a/tests/Hex1b.Tests/Hex1bMetricsTests.cs
+++ b/tests/Hex1b.Tests/Hex1bMetricsTests.cs
@@ -5,9 +5,10 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class Hex1bMetricsTests
 {
-    [Fact]
+    [TestMethod]
     public void Constructor_CreatesAllInstruments()
     {
         using var metrics = new Hex1bMetrics();
@@ -52,7 +53,7 @@ public class Hex1bMetricsTests
         }
     }
     
-    [Fact]
+    [TestMethod]
     public void Instances_AreIsolated()
     {
         using var metrics1 = new Hex1bMetrics();
@@ -89,18 +90,18 @@ public class Hex1bMetricsTests
         metrics2.FrameCount.Add(1);
         metrics2.FrameCount.Add(1);
         
-        Assert.Single(values1);
-        Assert.Equal(2, values2.Count);
+        TestSeq.Single(values1);
+        Assert.AreEqual(2, values2.Count);
     }
     
-    [Fact]
+    [TestMethod]
     public void Default_IsSingleton()
     {
-        Assert.Same(Hex1bMetrics.Default, Hex1bMetrics.Default);
-        Assert.NotNull(Hex1bMetrics.Default.Meter);
+        Assert.AreSame(Hex1bMetrics.Default, Hex1bMetrics.Default);
+        Assert.IsNotNull(Hex1bMetrics.Default.Meter);
     }
     
-    [Fact]
+    [TestMethod]
     public void FrameDuration_RecordsValues()
     {
         using var metrics = new Hex1bMetrics();
@@ -121,12 +122,12 @@ public class Hex1bMetricsTests
         metrics.FrameDuration.Record(16.5);
         metrics.FrameDuration.Record(8.2);
         
-        Assert.Equal(2, recorded.Count);
-        Assert.Equal(16.5, recorded[0]);
-        Assert.Equal(8.2, recorded[1]);
+        Assert.AreEqual(2, recorded.Count);
+        Assert.AreEqual(16.5, recorded[0]);
+        Assert.AreEqual(8.2, recorded[1]);
     }
     
-    [Fact]
+    [TestMethod]
     public void InputCount_RecordsWithTags()
     {
         using var metrics = new Hex1bMetrics();
@@ -155,13 +156,13 @@ public class Hex1bMetricsTests
         metrics.InputCount.Add(1, new KeyValuePair<string, object?>("type", "mouse"));
         metrics.InputCount.Add(1, new KeyValuePair<string, object?>("type", "resize"));
         
-        Assert.Equal(3, tagValues.Count);
-        Assert.Equal("key", tagValues[0]);
-        Assert.Equal("mouse", tagValues[1]);
-        Assert.Equal("resize", tagValues[2]);
+        Assert.AreEqual(3, tagValues.Count);
+        Assert.AreEqual("key", tagValues[0]);
+        Assert.AreEqual("mouse", tagValues[1]);
+        Assert.AreEqual("resize", tagValues[2]);
     }
     
-    [Fact]
+    [TestMethod]
     public void OutputCellsChanged_RecordsIntValues()
     {
         using var metrics = new Hex1bMetrics();
@@ -183,13 +184,13 @@ public class Hex1bMetricsTests
         metrics.OutputCellsChanged.Record(5);     // Incremental update
         metrics.OutputCellsChanged.Record(0);     // No changes
         
-        Assert.Equal(3, recorded.Count);
-        Assert.Equal(1920, recorded[0]);
-        Assert.Equal(5, recorded[1]);
-        Assert.Equal(0, recorded[2]);
+        Assert.AreEqual(3, recorded.Count);
+        Assert.AreEqual(1920, recorded[0]);
+        Assert.AreEqual(5, recorded[1]);
+        Assert.AreEqual(0, recorded[2]);
     }
     
-    [Fact]
+    [TestMethod]
     public void NoListener_DoesNotThrow()
     {
         // Verify metrics work without any listener attached (zero-cost path)
@@ -209,7 +210,7 @@ public class Hex1bMetricsTests
         metrics.TerminalInputEvents.Add(1, new KeyValuePair<string, object?>("type", "key"));
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Integration_MetricsRecordedDuringRender()
     {
         using var metrics = new Hex1bMetrics();
@@ -265,34 +266,34 @@ public class Hex1bMetricsTests
         
         await runTask;
         
-        Assert.True(Interlocked.Read(ref frameCount) > 0, "Expected at least one frame");
-        Assert.NotEmpty(frameDurations);
-        Assert.All(frameDurations, d => Assert.True(d > 0, $"Frame duration {d}ms should be > 0"));
-        Assert.NotEmpty(cellsCounts);
-        Assert.True(cellsCounts[0] > 0, "First frame should have changed cells");
+        Assert.IsTrue(Interlocked.Read(ref frameCount) > 0, "Expected at least one frame");
+        Assert.IsNotEmpty(frameDurations);
+        TestSeq.All(frameDurations, d => Assert.IsTrue(d > 0, $"Frame duration {d}ms should be > 0"));
+        Assert.IsNotEmpty(cellsCounts);
+        Assert.IsTrue(cellsCounts[0] > 0, "First frame should have changed cells");
     }
     
     // --- Per-node metrics tests ---
     
-    [Fact]
+    [TestMethod]
     public void PerNodeMetrics_DisabledByDefault()
     {
         using var metrics = new Hex1bMetrics();
-        Assert.Null(metrics.NodeMeasureDuration);
-        Assert.Null(metrics.NodeArrangeDuration);
-        Assert.Null(metrics.NodeRenderDuration);
-        Assert.Null(metrics.NodeReconcileDuration);
-        Assert.Null(metrics.SurfaceFlattenDuration);
-        Assert.Null(metrics.SurfaceCompositeDuration);
-        Assert.Null(metrics.SurfaceLayerCount);
-        Assert.Null(metrics.SurfaceLayerDuration);
+        Assert.IsNull(metrics.NodeMeasureDuration);
+        Assert.IsNull(metrics.NodeArrangeDuration);
+        Assert.IsNull(metrics.NodeRenderDuration);
+        Assert.IsNull(metrics.NodeReconcileDuration);
+        Assert.IsNull(metrics.SurfaceFlattenDuration);
+        Assert.IsNull(metrics.SurfaceCompositeDuration);
+        Assert.IsNull(metrics.SurfaceLayerCount);
+        Assert.IsNull(metrics.SurfaceLayerDuration);
     }
     
-    [Fact]
+    [TestMethod]
     public void PerNodeMetrics_CreatesInstrumentsWhenEnabled()
     {
         using var metrics = new Hex1bMetrics(options: new Hex1bMetricsOptions { EnablePerNodeMetrics = true });
-        Assert.NotNull(metrics.NodeMeasureDuration);
+        Assert.IsNotNull(metrics.NodeMeasureDuration);
         
         var instrumentNames = new List<string>();
         using var listener = new MeterListener();
@@ -316,14 +317,14 @@ public class Hex1bMetricsTests
         Assert.Contains("hex1b.surface.layer.duration", instrumentNames);
     }
     
-    [Fact]
+    [TestMethod]
     public void MetricName_FluentExtension_SetsProperty()
     {
         var widget = new TextBlockWidget("test").MetricName("sidebar");
-        Assert.Equal("sidebar", widget.MetricName);
+        Assert.AreEqual("sidebar", widget.MetricName);
     }
     
-    [Fact]
+    [TestMethod]
     public void MetricPath_AutoGenerated_UsesTypeAndIndex()
     {
         var parent = new VStackNode();
@@ -334,26 +335,26 @@ public class Hex1bMetricsTests
         Assert.Contains("TextBlock[2]", path);
     }
     
-    [Fact]
+    [TestMethod]
     public void MetricPath_WithUserName_UsesNameInsteadOfType()
     {
         var parent = new VStackNode { MetricName = "root" };
         var child = new TextBlockNode { Parent = parent, MetricName = "title", MetricChildIndex = 0 };
         
         var path = child.GetMetricPath();
-        Assert.Equal("root.title", path);
+        Assert.AreEqual("root.title", path);
     }
     
-    [Fact]
+    [TestMethod]
     public void MetricPath_Cached_ReturnsSameInstance()
     {
         var node = new TextBlockNode { MetricName = "test" };
         var path1 = node.GetMetricPath();
         var path2 = node.GetMetricPath();
-        Assert.Same(path1, path2);
+        Assert.AreSame(path1, path2);
     }
     
-    [Fact]
+    [TestMethod]
     public void MetricPath_InvalidatedOnNameChange()
     {
         var node = new TextBlockNode { MetricName = "old" };
@@ -363,21 +364,21 @@ public class Hex1bMetricsTests
         node.InvalidateMetricPath();
         var path2 = node.GetMetricPath();
         
-        Assert.NotEqual(path1, path2);
-        Assert.Equal("new", path2);
+        Assert.AreNotEqual(path1, path2);
+        Assert.AreEqual("new", path2);
     }
     
-    [Fact]
+    [TestMethod]
     public void MetricPath_Hierarchical_ComposesFromAncestors()
     {
         var root = new VStackNode { MetricName = "root" };
         var sidebar = new VStackNode { Parent = root, MetricName = "sidebar", MetricChildIndex = 0 };
         var table = new TextBlockNode { Parent = sidebar, MetricName = "orders", MetricChildIndex = 0 };
         
-        Assert.Equal("root.sidebar.orders", table.GetMetricPath());
+        Assert.AreEqual("root.sidebar.orders", table.GetMetricPath());
     }
     
-    [Fact]
+    [TestMethod]
     public void MetricPath_MixedAutoAndNamed()
     {
         var root = new VStackNode { MetricName = "root" };
@@ -385,10 +386,10 @@ public class Hex1bMetricsTests
         var leaf = new TextBlockNode { Parent = child, MetricName = "label", MetricChildIndex = 0 };
         
         var path = leaf.GetMetricPath();
-        Assert.Equal("root.HStack[1].label", path);
+        Assert.AreEqual("root.HStack[1].label", path);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Integration_PerNodeMetrics_RecordsDurations()
     {
         var options = new Hex1bMetricsOptions { EnablePerNodeMetrics = true };
@@ -445,14 +446,14 @@ public class Hex1bMetricsTests
         await runTask;
         
         // Should have per-node measurements with the metric paths
-        Assert.NotEmpty(nodePaths);
+        Assert.IsNotEmpty(nodePaths);
         // Verify at least the root and named children appear
-        Assert.Contains(nodePaths, p => p.Contains("root"));
-        Assert.Contains(nodePaths, p => p.Contains("title"));
-        Assert.Contains(nodePaths, p => p.Contains("body"));
+        Assert.IsTrue(nodePaths.Any(p => p.Contains("root")));
+        Assert.IsTrue(nodePaths.Any(p => p.Contains("title")));
+        Assert.IsTrue(nodePaths.Any(p => p.Contains("body")));
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Integration_PerNodeMetrics_DisabledByDefault_NoNodeMetricsEmitted()
     {
         // Default metrics — per-node NOT enabled
@@ -503,10 +504,10 @@ public class Hex1bMetricsTests
         await runTask;
         
         // No per-node metrics should have been emitted
-        Assert.Empty(nodeMetrics);
+        Assert.IsEmpty(nodeMetrics);
     }
 
-    [Fact]
+    [TestMethod]
     public void WithMetricsCallback_CreatesMetricsWithPerNodeEnabled()
     {
         // Regression: WithMetrics(configure) must flow options into ResolveMetrics
@@ -535,14 +536,14 @@ public class Hex1bMetricsTests
         using var metrics = new Hex1bMetrics(options: options);
 
         // Per-node instruments must have been created
-        Assert.NotNull(metrics.NodeMeasureDuration);
-        Assert.NotNull(metrics.NodeArrangeDuration);
-        Assert.NotNull(metrics.NodeRenderDuration);
-        Assert.NotNull(metrics.NodeReconcileDuration);
+        Assert.IsNotNull(metrics.NodeMeasureDuration);
+        Assert.IsNotNull(metrics.NodeArrangeDuration);
+        Assert.IsNotNull(metrics.NodeRenderDuration);
+        Assert.IsNotNull(metrics.NodeReconcileDuration);
 
         // Record a measurement to verify the instruments are functional
         metrics.NodeMeasureDuration!.Record(1.0, new KeyValuePair<string, object?>("node", "test.Widget"));
 
-        Assert.Contains(nodePaths, p => p.Contains("test.Widget"));
+        Assert.IsTrue(nodePaths.Any(p => p.Contains("test.Widget")));
     }
 }

--- a/tests/Hex1b.Tests/Hex1bNodeTests.cs
+++ b/tests/Hex1b.Tests/Hex1bNodeTests.cs
@@ -5,6 +5,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for Hex1bNode base class behavior.
 /// </summary>
+[TestClass]
 public class Hex1bNodeTests
 {
     /// <summary>
@@ -18,7 +19,7 @@ public class Hex1bNodeTests
 
     #region PreviousBounds Tracking Tests
 
-    [Fact]
+    [TestMethod]
     public void Arrange_FirstCall_PreviousBoundsIsEmpty()
     {
         var node = new TestNode();
@@ -27,11 +28,11 @@ public class Hex1bNodeTests
         node.Arrange(bounds);
 
         // Before first arrange, PreviousBounds should be the default empty rect
-        Assert.Equal(new Rect(0, 0, 0, 0), node.PreviousBounds);
-        Assert.Equal(bounds, node.Bounds);
+        Assert.AreEqual(new Rect(0, 0, 0, 0), node.PreviousBounds);
+        Assert.AreEqual(bounds, node.Bounds);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_SecondCall_PreviousBoundsHasFirstBounds()
     {
         var node = new TestNode();
@@ -41,11 +42,11 @@ public class Hex1bNodeTests
         node.Arrange(firstBounds);
         node.Arrange(secondBounds);
 
-        Assert.Equal(firstBounds, node.PreviousBounds);
-        Assert.Equal(secondBounds, node.Bounds);
+        Assert.AreEqual(firstBounds, node.PreviousBounds);
+        Assert.AreEqual(secondBounds, node.Bounds);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_MultipleCallsTracksPreviousBounds()
     {
         var node = new TestNode();
@@ -54,19 +55,19 @@ public class Hex1bNodeTests
         var bounds3 = new Rect(10, 10, 20, 10);
 
         node.Arrange(bounds1);
-        Assert.Equal(new Rect(0, 0, 0, 0), node.PreviousBounds);
-        Assert.Equal(bounds1, node.Bounds);
+        Assert.AreEqual(new Rect(0, 0, 0, 0), node.PreviousBounds);
+        Assert.AreEqual(bounds1, node.Bounds);
 
         node.Arrange(bounds2);
-        Assert.Equal(bounds1, node.PreviousBounds);
-        Assert.Equal(bounds2, node.Bounds);
+        Assert.AreEqual(bounds1, node.PreviousBounds);
+        Assert.AreEqual(bounds2, node.Bounds);
 
         node.Arrange(bounds3);
-        Assert.Equal(bounds2, node.PreviousBounds);
-        Assert.Equal(bounds3, node.Bounds);
+        Assert.AreEqual(bounds2, node.PreviousBounds);
+        Assert.AreEqual(bounds3, node.Bounds);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_SameBounds_PreviousBoundsEqualsCurrentBounds()
     {
         var node = new TestNode();
@@ -76,11 +77,11 @@ public class Hex1bNodeTests
         node.Arrange(bounds);
 
         // When arranged with the same bounds, previous equals current
-        Assert.Equal(bounds, node.PreviousBounds);
-        Assert.Equal(bounds, node.Bounds);
+        Assert.AreEqual(bounds, node.PreviousBounds);
+        Assert.AreEqual(bounds, node.Bounds);
     }
 
-    [Fact]
+    [TestMethod]
     public void InheritBoundsFromReplacedNode_SetsBoundsFromOldNode()
     {
         // Arrange - old node with established bounds
@@ -90,17 +91,17 @@ public class Hex1bNodeTests
         
         // New replacement node starts with empty bounds
         var newNode = new TestNode();
-        Assert.Equal(new Rect(0, 0, 0, 0), newNode.Bounds);
+        Assert.AreEqual(new Rect(0, 0, 0, 0), newNode.Bounds);
 
         // Act - inherit bounds from the replaced node
         newNode.InheritBoundsFromReplacedNode(oldNode);
 
         // Assert - Bounds is now the old node's bounds
         // When Arrange is called, this will become PreviousBounds
-        Assert.Equal(oldBounds, newNode.Bounds);
+        Assert.AreEqual(oldBounds, newNode.Bounds);
     }
 
-    [Fact]
+    [TestMethod]
     public void InheritBoundsFromReplacedNode_AllowsDirtyRegionClearing()
     {
         // This tests the scenario where a node is replaced with a smaller one
@@ -121,14 +122,14 @@ public class Hex1bNodeTests
 
         // Assert - PreviousBounds should be the inherited old bounds, not empty
         // This allows ClearDirtyRegions to know the full area that was occupied
-        Assert.Equal(oldBounds, newNode.PreviousBounds);
-        Assert.Equal(newBounds, newNode.Bounds);
+        Assert.AreEqual(oldBounds, newNode.PreviousBounds);
+        Assert.AreEqual(newBounds, newNode.Bounds);
         
         // The difference between these rects is what needs to be cleared
-        Assert.True(newNode.Bounds != newNode.PreviousBounds);
+        Assert.IsTrue(newNode.Bounds != newNode.PreviousBounds);
     }
 
-    [Fact]
+    [TestMethod]
     public void BoundsDidMove_WhenPositionChanges_ReturnsTrue()
     {
         var node = new TestNode();
@@ -138,10 +139,10 @@ public class Hex1bNodeTests
         var moved = node.Bounds.X != node.PreviousBounds.X || 
                     node.Bounds.Y != node.PreviousBounds.Y;
         
-        Assert.True(moved);
+        Assert.IsTrue(moved);
     }
 
-    [Fact]
+    [TestMethod]
     public void BoundsDidResize_WhenSizeChanges_ReturnsTrue()
     {
         var node = new TestNode();
@@ -151,14 +152,14 @@ public class Hex1bNodeTests
         var resized = node.Bounds.Width != node.PreviousBounds.Width || 
                       node.Bounds.Height != node.PreviousBounds.Height;
         
-        Assert.True(resized);
+        Assert.IsTrue(resized);
     }
 
     #endregion
 
     #region Orphaned Child Bounds Tests
 
-    [Fact]
+    [TestMethod]
     public void AddOrphanedChildBounds_AddsToList()
     {
         var node = new TestNode();
@@ -166,24 +167,24 @@ public class Hex1bNodeTests
         
         node.AddOrphanedChildBounds(orphanBounds);
         
-        Assert.NotNull(node.OrphanedChildBounds);
-        Assert.Single(node.OrphanedChildBounds);
-        Assert.Equal(orphanBounds, node.OrphanedChildBounds[0]);
+        Assert.IsNotNull(node.OrphanedChildBounds);
+        TestSeq.Single(node.OrphanedChildBounds);
+        Assert.AreEqual(orphanBounds, node.OrphanedChildBounds[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void AddOrphanedChildBounds_MarksDirty()
     {
         var node = new TestNode();
         node.ClearDirty(); // Start clean
-        Assert.False(node.IsDirty);
+        Assert.IsFalse(node.IsDirty);
         
         node.AddOrphanedChildBounds(new Rect(0, 5, 10, 1));
         
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void AddOrphanedChildBounds_IgnoresEmptyBounds()
     {
         var node = new TestNode();
@@ -192,85 +193,85 @@ public class Hex1bNodeTests
         node.AddOrphanedChildBounds(new Rect(5, 5, 0, 1));
         node.AddOrphanedChildBounds(new Rect(5, 5, 10, 0));
         
-        Assert.Null(node.OrphanedChildBounds);
+        Assert.IsNull(node.OrphanedChildBounds);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClearOrphanedChildBounds_ClearsList()
     {
         var node = new TestNode();
         node.AddOrphanedChildBounds(new Rect(0, 5, 10, 1));
         node.AddOrphanedChildBounds(new Rect(0, 6, 10, 1));
-        Assert.Equal(2, node.OrphanedChildBounds!.Count);
+        Assert.AreEqual(2, node.OrphanedChildBounds!.Count);
         
         node.ClearOrphanedChildBounds();
         
-        Assert.Empty(node.OrphanedChildBounds);
+        Assert.IsEmpty(node.OrphanedChildBounds);
     }
 
     #endregion
 
     #region Dirty Flag Tests
 
-    [Fact]
+    [TestMethod]
     public void NewNode_IsDirty()
     {
         var node = new TestNode();
 
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClearDirty_SetsIsDirtyToFalse()
     {
         var node = new TestNode();
-        Assert.True(node.IsDirty); // New node starts dirty
+        Assert.IsTrue(node.IsDirty); // New node starts dirty
 
         node.ClearDirty();
 
-        Assert.False(node.IsDirty);
+        Assert.IsFalse(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void MarkDirty_SetsIsDirtyToTrue()
     {
         var node = new TestNode();
         node.ClearDirty();
-        Assert.False(node.IsDirty);
+        Assert.IsFalse(node.IsDirty);
 
         node.MarkDirty();
 
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_WithDifferentBounds_MarksDirty()
     {
         var node = new TestNode();
         node.Arrange(new Rect(0, 0, 10, 5));
         node.ClearDirty();
-        Assert.False(node.IsDirty);
+        Assert.IsFalse(node.IsDirty);
 
         node.Arrange(new Rect(5, 5, 10, 5)); // Different position
 
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_WithSameBounds_DoesNotMarkDirty()
     {
         var node = new TestNode();
         var bounds = new Rect(0, 0, 10, 5);
         node.Arrange(bounds);
         node.ClearDirty();
-        Assert.False(node.IsDirty);
+        Assert.IsFalse(node.IsDirty);
 
         node.Arrange(bounds); // Same bounds
 
-        Assert.False(node.IsDirty);
+        Assert.IsFalse(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_WithDifferentSize_MarksDirty()
     {
         var node = new TestNode();
@@ -279,56 +280,56 @@ public class Hex1bNodeTests
 
         node.Arrange(new Rect(0, 0, 20, 10)); // Different size
 
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void DirtyFlag_CanBeMarkedAndClearedMultipleTimes()
     {
         var node = new TestNode();
         
         // Start dirty
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
         
         // Clear and verify
         node.ClearDirty();
-        Assert.False(node.IsDirty);
+        Assert.IsFalse(node.IsDirty);
         
         // Mark and verify
         node.MarkDirty();
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
         
         // Clear again
         node.ClearDirty();
-        Assert.False(node.IsDirty);
+        Assert.IsFalse(node.IsDirty);
         
         // Mark again
         node.MarkDirty();
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
     #endregion
 
     #region NeedsRender Tests
 
-    [Fact]
+    [TestMethod]
     public void NeedsRender_NewNode_ReturnsTrue()
     {
         var node = new TestNode();
 
-        Assert.True(node.NeedsRender());
+        Assert.IsTrue(node.NeedsRender());
     }
 
-    [Fact]
+    [TestMethod]
     public void NeedsRender_CleanNode_ReturnsFalse()
     {
         var node = new TestNode();
         node.ClearDirty();
 
-        Assert.False(node.NeedsRender());
+        Assert.IsFalse(node.NeedsRender());
     }
 
-    [Fact]
+    [TestMethod]
     public void NeedsRender_CleanNodeWithDirtyChild_ReturnsTrue()
     {
         var parent = new ContainerTestNode();
@@ -336,10 +337,10 @@ public class Hex1bNodeTests
         parent.Children.Add(child);
         parent.ClearDirty(); // Parent is clean
 
-        Assert.True(parent.NeedsRender());
+        Assert.IsTrue(parent.NeedsRender());
     }
 
-    [Fact]
+    [TestMethod]
     public void NeedsRender_CleanNodeWithCleanChild_ReturnsFalse()
     {
         var parent = new ContainerTestNode();
@@ -348,10 +349,10 @@ public class Hex1bNodeTests
         parent.ClearDirty();
         child.ClearDirty();
 
-        Assert.False(parent.NeedsRender());
+        Assert.IsFalse(parent.NeedsRender());
     }
 
-    [Fact]
+    [TestMethod]
     public void NeedsRender_DirtyNodeWithCleanChild_ReturnsTrue()
     {
         var parent = new ContainerTestNode();
@@ -360,10 +361,10 @@ public class Hex1bNodeTests
         child.ClearDirty();
         // Parent stays dirty
 
-        Assert.True(parent.NeedsRender());
+        Assert.IsTrue(parent.NeedsRender());
     }
 
-    [Fact]
+    [TestMethod]
     public void NeedsRender_DeepNestedDirtyNode_ReturnsTrue()
     {
         var root = new ContainerTestNode();
@@ -380,7 +381,7 @@ public class Hex1bNodeTests
         level2.ClearDirty();
         // leaf stays dirty
 
-        Assert.True(root.NeedsRender());
+        Assert.IsTrue(root.NeedsRender());
     }
 
     #endregion

--- a/tests/Hex1b.Tests/Hex1bRenderContextTests.cs
+++ b/tests/Hex1b.Tests/Hex1bRenderContextTests.cs
@@ -5,11 +5,12 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for Hex1bRenderContext functionality.
 /// </summary>
+[TestClass]
 public class Hex1bRenderContextTests
 {
     #region ClearRegion Tests
 
-    [Fact]
+    [TestMethod]
     public async Task ClearRegion_WritesSpacesToRegion()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -27,7 +28,7 @@ public class Hex1bRenderContextTests
             .WaitUntil(s => s.ContainsText("Hello World"), TimeSpan.FromSeconds(5))
             .Build()
             .ApplyAsync(terminal);
-        Assert.True(terminal.CreateSnapshot().ContainsText("Hello World"));
+        Assert.IsTrue(terminal.CreateSnapshot().ContainsText("Hello World"));
         
         // Clear the region where the text is
         context.ClearRegion(new Rect(5, 2, 11, 1));
@@ -37,10 +38,10 @@ public class Hex1bRenderContextTests
             .ApplyAsync(terminal);
         
         // Text should be gone (replaced with spaces)
-        Assert.False(terminal.CreateSnapshot().ContainsText("Hello World"));
+        Assert.IsFalse(terminal.CreateSnapshot().ContainsText("Hello World"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ClearRegion_MultipleRows()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -67,12 +68,12 @@ public class Hex1bRenderContextTests
             .ApplyAsync(terminal);
         
         var snapshot = terminal.CreateSnapshot();
-        Assert.False(snapshot.ContainsText("Line 0"));
-        Assert.False(snapshot.ContainsText("Line 1"));
-        Assert.False(snapshot.ContainsText("Line 2"));
+        Assert.IsFalse(snapshot.ContainsText("Line 0"));
+        Assert.IsFalse(snapshot.ContainsText("Line 1"));
+        Assert.IsFalse(snapshot.ContainsText("Line 2"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ClearRegion_PartialClear()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -94,10 +95,10 @@ public class Hex1bRenderContextTests
             .ApplyAsync(terminal);
         
         var line = terminal.CreateSnapshot().GetLine(0);
-        Assert.Equal("ABC    HIJ", line.Substring(0, 10));
+        Assert.AreEqual("ABC    HIJ", line.Substring(0, 10));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ClearRegion_ClampsToTerminalBounds()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -113,10 +114,10 @@ public class Hex1bRenderContextTests
             .ApplyAsync(terminal);
         
         // If we got here without exception, the clamping worked
-        Assert.True(true);
+        Assert.IsTrue(true);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ClearRegion_EmptyRect_DoesNothing()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -141,10 +142,10 @@ public class Hex1bRenderContextTests
             .WaitUntil(s => s.ContainsText("Should remain"), TimeSpan.FromSeconds(5))
             .Build()
             .ApplyAsync(terminal);
-        Assert.True(terminal.CreateSnapshot().ContainsText("Should remain"));
+        Assert.IsTrue(terminal.CreateSnapshot().ContainsText("Should remain"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ClearRegion_NegativePosition_ClampsToZero()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -166,7 +167,7 @@ public class Hex1bRenderContextTests
             .ApplyAsync(terminal);
         
         // Content at origin should be cleared
-        Assert.False(terminal.CreateSnapshot().ContainsText("Hello"));
+        Assert.IsFalse(terminal.CreateSnapshot().ContainsText("Hello"));
     }
 
     #endregion

--- a/tests/Hex1b.Tests/Hex1bTerminalAutomatorTests.cs
+++ b/tests/Hex1b.Tests/Hex1bTerminalAutomatorTests.cs
@@ -7,9 +7,10 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for <see cref="Hex1bTerminalAutomator"/>.
 /// </summary>
+[TestClass]
 public class Hex1bTerminalAutomatorTests
 {
-    [Fact]
+    [TestMethod]
     public async Task WaitUntilTextAsync_WaitsForText()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -23,14 +24,14 @@ public class Hex1bTerminalAutomatorTests
 
         await auto.WaitUntilTextAsync("Hello World");
 
-        Assert.Single(auto.CompletedSteps);
+        TestSeq.Single(auto.CompletedSteps);
         Assert.Contains("WaitUntilText(\"Hello World\")", auto.CompletedSteps[0].Description);
 
         await auto.Ctrl().KeyAsync(Hex1bKey.C);
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WaitUntilTextAsync_Timeout_ThrowsHex1bAutomationException()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -42,21 +43,21 @@ public class Hex1bTerminalAutomatorTests
         var runTask = terminal.RunAsync(TestContext.Current.CancellationToken);
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromMilliseconds(250));
 
-        var ex = await Assert.ThrowsAsync<Hex1bAutomationException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<Hex1bAutomationException>(async () =>
         {
             await auto.WaitUntilTextAsync("NonExistent");
         });
 
-        Assert.Equal(1, ex.FailedStepIndex);
+        Assert.AreEqual(1, ex.FailedStepIndex);
         Assert.Contains("WaitUntilText(\"NonExistent\")", ex.FailedStepDescription);
-        Assert.IsType<WaitUntilTimeoutException>(ex.InnerException);
-        Assert.NotNull(ex.TerminalSnapshot);
+        TestSeq.IsType<WaitUntilTimeoutException>(ex.InnerException);
+        Assert.IsNotNull(ex.TerminalSnapshot);
 
         await auto.Ctrl().KeyAsync(Hex1bKey.C);
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WaitUntilTextAsync_Timeout_ExceptionMessageContainsStepHistory()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -79,16 +80,16 @@ public class Hex1bTerminalAutomatorTests
         await auto.EnterAsync();
 
         // Now fail on a WaitUntil
-        var ex = await Assert.ThrowsAsync<Hex1bAutomationException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<Hex1bAutomationException>(async () =>
         {
             await auto.WaitUntilTextAsync("NonExistent", timeout: TimeSpan.FromMilliseconds(250));
         });
 
         // Verify step index reflects that 2 steps completed before the failure
-        Assert.Equal(3, ex.FailedStepIndex);
+        Assert.AreEqual(3, ex.FailedStepIndex);
 
         // Verify completed steps are captured
-        Assert.Equal(2, ex.CompletedSteps.Count);
+        Assert.AreEqual(2, ex.CompletedSteps.Count);
         Assert.Contains("WaitUntilText(\"Hello World\")", ex.CompletedSteps[0].Description);
         Assert.Contains("Key(Enter)", ex.CompletedSteps[1].Description);
 
@@ -103,16 +104,16 @@ public class Hex1bTerminalAutomatorTests
         Assert.Contains("Hello World", ex.Message);
 
         // Verify caller info
-        Assert.NotNull(ex.CallerFilePath);
+        Assert.IsNotNull(ex.CallerFilePath);
         Assert.Contains("Hex1bTerminalAutomatorTests.cs", ex.CallerFilePath);
-        Assert.True(ex.CallerLineNumber > 0);
+        Assert.IsTrue(ex.CallerLineNumber > 0);
 
         // Clean up
         await auto.Ctrl().KeyAsync(Hex1bKey.C);
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task EnterAsync_SendsEnterKey()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -138,14 +139,14 @@ public class Hex1bTerminalAutomatorTests
         // Give the app a moment to process
         await auto.WaitAsync(50);
 
-        Assert.True(enterPressed);
-        Assert.Equal(3, auto.CompletedSteps.Count);
+        Assert.IsTrue(enterPressed);
+        Assert.AreEqual(3, auto.CompletedSteps.Count);
 
         await auto.Ctrl().KeyAsync(Hex1bKey.C);
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TypeAsync_TypesText()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -173,14 +174,14 @@ public class Hex1bTerminalAutomatorTests
         await auto.TypeAsync("Hello");
         await auto.WaitUntilTextAsync("Hello");
 
-        Assert.Equal("Hello", typedText);
+        Assert.AreEqual("Hello", typedText);
         Assert.Contains("Type(\"Hello\")", auto.CompletedSteps[1].Description);
 
         await auto.Ctrl().KeyAsync(Hex1bKey.C);
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Ctrl_KeyAsync_SendsModifiedKey()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -210,7 +211,7 @@ public class Hex1bTerminalAutomatorTests
         Assert.Contains("Ctrl+", lastStep.Description);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WaitUntilAsync_WithCustomPredicate_Works()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -226,14 +227,14 @@ public class Hex1bTerminalAutomatorTests
             s => s.ContainsText("Count: 42"),
             description: "count to be 42");
 
-        Assert.Single(auto.CompletedSteps);
+        TestSeq.Single(auto.CompletedSteps);
         Assert.Contains("WaitUntil(\"count to be 42\")", auto.CompletedSteps[0].Description);
 
         await auto.Ctrl().KeyAsync(Hex1bKey.C);
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WaitUntilNoTextAsync_WaitsForTextToDisappear()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -261,14 +262,14 @@ public class Hex1bTerminalAutomatorTests
 
         await auto.WaitUntilNoTextAsync("Visible");
 
-        Assert.Equal(2, auto.CompletedSteps.Count);
+        Assert.AreEqual(2, auto.CompletedSteps.Count);
         Assert.Contains("WaitUntilNoText(\"Visible\")", auto.CompletedSteps[1].Description);
 
         await auto.Ctrl().KeyAsync(Hex1bKey.C);
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SequenceAsync_WithBuilderAction_ExecutesSequence()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -307,7 +308,7 @@ public class Hex1bTerminalAutomatorTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SequenceAsync_WithPrebuiltSequence_ExecutesSequence()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -343,7 +344,7 @@ public class Hex1bTerminalAutomatorTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CompletedSteps_TracksCallerInfo()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -358,16 +359,16 @@ public class Hex1bTerminalAutomatorTests
         await auto.WaitUntilTextAsync("Test");
 
         var step = auto.CompletedSteps[0];
-        Assert.NotNull(step.CallerFilePath);
+        Assert.IsNotNull(step.CallerFilePath);
         Assert.Contains("Hex1bTerminalAutomatorTests.cs", step.CallerFilePath);
-        Assert.True(step.CallerLineNumber > 0);
-        Assert.True(step.Elapsed >= TimeSpan.Zero);
+        Assert.IsTrue(step.CallerLineNumber > 0);
+        Assert.IsTrue(step.Elapsed >= TimeSpan.Zero);
 
         await auto.Ctrl().KeyAsync(Hex1bKey.C);
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AutomationException_TotalElapsed_SumsAllSteps()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -381,20 +382,19 @@ public class Hex1bTerminalAutomatorTests
 
         await auto.WaitUntilTextAsync("Hello", timeout: TimeSpan.FromSeconds(5));
 
-        var ex = await Assert.ThrowsAsync<Hex1bAutomationException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<Hex1bAutomationException>(async () =>
         {
             await auto.WaitUntilTextAsync("Never");
         });
 
         // TotalElapsed should be >= the timeout since the failing step waited that long
-        Assert.True(ex.TotalElapsed >= TimeSpan.FromMilliseconds(200),
-            $"TotalElapsed was {ex.TotalElapsed.TotalMilliseconds}ms, expected >= 200ms");
+        Assert.IsTrue(ex.TotalElapsed >= TimeSpan.FromMilliseconds(200), $"TotalElapsed was {ex.TotalElapsed.TotalMilliseconds}ms, expected >= 200ms");
 
         await auto.Ctrl().KeyAsync(Hex1bKey.C);
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CreateSnapshot_ReturnsCurrentState()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -409,13 +409,13 @@ public class Hex1bTerminalAutomatorTests
         await auto.WaitUntilTextAsync("Snapshot Test");
 
         using var snapshot = auto.CreateSnapshot();
-        Assert.True(snapshot.ContainsText("Snapshot Test"));
+        Assert.IsTrue(snapshot.ContainsText("Snapshot Test"));
 
         await auto.Ctrl().KeyAsync(Hex1bKey.C);
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WaitUntilAsync_WithPredicateExpression_CapturesExpression()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -427,7 +427,7 @@ public class Hex1bTerminalAutomatorTests
         var runTask = terminal.RunAsync(TestContext.Current.CancellationToken);
         var auto = new Hex1bTerminalAutomator(terminal, defaultTimeout: TimeSpan.FromMilliseconds(250));
 
-        var ex = await Assert.ThrowsAsync<Hex1bAutomationException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<Hex1bAutomationException>(async () =>
         {
             await auto.WaitUntilAsync(s => s.ContainsText("Nope"));
         });
@@ -439,7 +439,7 @@ public class Hex1bTerminalAutomatorTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MultipleModifiers_AreStackedCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -470,7 +470,7 @@ public class Hex1bTerminalAutomatorTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WaitAsync_PausesForDuration()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -485,9 +485,9 @@ public class Hex1bTerminalAutomatorTests
         await auto.WaitUntilTextAsync("Test");
         await auto.WaitAsync(50);
 
-        Assert.Equal(2, auto.CompletedSteps.Count);
+        Assert.AreEqual(2, auto.CompletedSteps.Count);
         Assert.Contains("Wait(50ms)", auto.CompletedSteps[1].Description);
-        Assert.True(auto.CompletedSteps[1].Elapsed >= TimeSpan.FromMilliseconds(40));
+        Assert.IsTrue(auto.CompletedSteps[1].Elapsed >= TimeSpan.FromMilliseconds(40));
 
         await auto.Ctrl().KeyAsync(Hex1bKey.C);
         await runTask;

--- a/tests/Hex1b.Tests/Hex1bTerminalBuilderTests.cs
+++ b/tests/Hex1b.Tests/Hex1bTerminalBuilderTests.cs
@@ -8,6 +8,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for the Hex1bTerminalBuilder.
 /// </summary>
+[TestClass]
 public class Hex1bTerminalBuilderTests
 {
     private static string GetTempRecordingPath()
@@ -26,16 +27,16 @@ public class Hex1bTerminalBuilderTests
         return await reader.ReadToEndAsync(ct);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CreateBuilder_ReturnsNewBuilderInstance()
     {
         var builder = Hex1bTerminal.CreateBuilder();
         
-        Assert.NotNull(builder);
-        Assert.IsType<Hex1bTerminalBuilder>(builder);
+        Assert.IsNotNull(builder);
+        TestSeq.IsType<Hex1bTerminalBuilder>(builder);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Build_WithWorkloadAdapter_CreatesTerminal()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -46,27 +47,27 @@ public class Hex1bTerminalBuilderTests
             .WithHeadless()
             .Build();
         
-        Assert.NotNull(terminal);
+        Assert.IsNotNull(terminal);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Build_WithoutWorkload_ThrowsInvalidOperationException()
     {
         var builder = Hex1bTerminal.CreateBuilder();
         
-        var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() => builder.Build());
         Assert.Contains("No workload configured", ex.Message);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithHeadless_ReturnsBuilder()
     {
         var result = Hex1bTerminal.CreateBuilder().WithHeadless();
         
-        Assert.IsType<Hex1bTerminalBuilder>(result);
+        TestSeq.IsType<Hex1bTerminalBuilder>(result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithHeadless_CreatesWorkingTerminal()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -78,11 +79,11 @@ public class Hex1bTerminalBuilderTests
             .Build();
         
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal(80, snapshot.Width);
-        Assert.Equal(24, snapshot.Height);
+        Assert.AreEqual(80, snapshot.Width);
+        Assert.AreEqual(24, snapshot.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithDimensions_SetsTerminalSize()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -94,46 +95,46 @@ public class Hex1bTerminalBuilderTests
             .Build();
         
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal(100, snapshot.Width);
-        Assert.Equal(50, snapshot.Height);
+        Assert.AreEqual(100, snapshot.Width);
+        Assert.AreEqual(50, snapshot.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithDimensions_InvalidWidth_ThrowsArgumentOutOfRangeException()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
             Hex1bTerminal.CreateBuilder().WithDimensions(0, 24));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithDimensions_InvalidHeight_ThrowsArgumentOutOfRangeException()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
             Hex1bTerminal.CreateBuilder().WithDimensions(80, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithWorkload_NullAdapter_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             Hex1bTerminal.CreateBuilder().WithWorkload(null!));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AddWorkloadFilter_NullFilter_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             Hex1bTerminal.CreateBuilder().AddWorkloadFilter(null!));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AddPresentationFilter_NullFilter_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             Hex1bTerminal.CreateBuilder().AddPresentationFilter(null!));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AddWorkloadFilter_AddsFilterToTerminal()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -146,10 +147,10 @@ public class Hex1bTerminalBuilderTests
             .Build();
         
         // Filter should have been notified of session start
-        Assert.True(filter.SessionStartCalled);
+        Assert.IsTrue(filter.SessionStartCalled);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RunAsync_WithRunCallback_ExecutesCallback()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -170,11 +171,11 @@ public class Hex1bTerminalBuilderTests
         await using var terminal = builder.Build();
         var exitCode = await terminal.RunAsync();
         
-        Assert.True(callbackExecuted);
-        Assert.Equal(42, exitCode);
+        Assert.IsTrue(callbackExecuted);
+        Assert.AreEqual(42, exitCode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RunAsync_WithCancellation_ThrowsOperationCanceledException()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -196,11 +197,10 @@ public class Hex1bTerminalBuilderTests
         // Cancel immediately
         cts.Cancel();
         
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(
-            () => terminal.RunAsync(cts.Token));
+        await Assert.ThrowsAsync<OperationCanceledException>(() => terminal.RunAsync(cts.Token));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Build_ThenRunAsync_BuildsAndRunsTerminal()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -220,11 +220,11 @@ public class Hex1bTerminalBuilderTests
         await using var terminal = builder.Build();
         var exitCode = await terminal.RunAsync();
         
-        Assert.True(callbackExecuted);
-        Assert.Equal(99, exitCode);
+        Assert.IsTrue(callbackExecuted);
+        Assert.AreEqual(99, exitCode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FluentApi_AllMethodsReturnBuilder()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -238,39 +238,39 @@ public class Hex1bTerminalBuilderTests
             .AddPresentationFilter(presentationFilter)
             .WithTimeProvider(TimeProvider.System);
         
-        Assert.IsType<Hex1bTerminalBuilder>(builder);
+        TestSeq.IsType<Hex1bTerminalBuilder>(builder);
     }
 
     // === WithHex1bApp Tests ===
 
-    [Fact]
+    [TestMethod]
     public async Task WithHex1bApp_NullConfigure_ThrowsArgumentNullException()
     {
         Func<RootContext, Hex1bWidget>? nullBuilder = null;
         
-        Assert.Throws<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             Hex1bTerminal.CreateBuilder().WithHex1bApp(nullBuilder!));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithHex1bApp_AsyncNullConfigure_ThrowsArgumentNullException()
     {
         Func<RootContext, Task<Hex1bWidget>>? nullBuilder = null;
         
-        Assert.Throws<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             Hex1bTerminal.CreateBuilder().WithHex1bApp(nullBuilder!));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithHex1bApp_ReturnsBuilder()
     {
         var result = Hex1bTerminal.CreateBuilder()
             .WithHex1bApp(ctx => ctx.Text("Hello"));
         
-        Assert.IsType<Hex1bTerminalBuilder>(result);
+        TestSeq.IsType<Hex1bTerminalBuilder>(result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithHex1bApp_CanBuild()
     {
         // Should not throw - uses explicit presentation
@@ -279,10 +279,10 @@ public class Hex1bTerminalBuilderTests
             .WithPresentation(new TestPresentationAdapter());
         
         using var terminal = builder.Build();
-        Assert.NotNull(terminal);
+        Assert.IsNotNull(terminal);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithHex1bApp_AsyncBuilder_CanRun()
     {
         var builderCalled = false;
@@ -302,11 +302,11 @@ public class Hex1bTerminalBuilderTests
         await using var terminal = builder.Build();
         var exitCode = await terminal.RunAsync(cts.Token);
         
-        Assert.True(builderCalled);
-        Assert.Equal(0, exitCode);
+        Assert.IsTrue(builderCalled);
+        Assert.AreEqual(0, exitCode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithHex1bApp_SyncBuilder_CanRun()
     {
         var builderCalled = false;
@@ -323,20 +323,20 @@ public class Hex1bTerminalBuilderTests
         await using var terminal = builder.Build();
         var exitCode = await terminal.RunAsync(cts.Token);
         
-        Assert.True(builderCalled);
-        Assert.Equal(0, exitCode);
+        Assert.IsTrue(builderCalled);
+        Assert.AreEqual(0, exitCode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithMouse_ReturnsBuilder()
     {
         var result = Hex1bTerminal.CreateBuilder()
             .WithMouse(true);
         
-        Assert.IsType<Hex1bTerminalBuilder>(result);
+        TestSeq.IsType<Hex1bTerminalBuilder>(result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithHex1bApp_FluentChain_Works()
     {
         var filter = new TestWorkloadFilter();
@@ -352,12 +352,12 @@ public class Hex1bTerminalBuilderTests
         await using var terminal = builder.Build();
         await terminal.RunAsync(cts.Token);
         
-        Assert.True(filter.SessionStartCalled);
+        Assert.IsTrue(filter.SessionStartCalled);
     }
 
     // === WithHex1bApp Capture Pattern Tests ===
 
-    [Fact]
+    [TestMethod]
     public async Task WithHex1bApp_CanCaptureApp()
     {
         Hex1bApp? capturedApp = null;
@@ -385,10 +385,10 @@ public class Hex1bTerminalBuilderTests
 
         await runTask;
 
-        Assert.NotNull(capturedApp);
+        Assert.IsNotNull(capturedApp);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithHex1bApp_CanSetTheme()
     {
         var pattern = new CellPatternSearcher().Find("Themed content");
@@ -412,7 +412,7 @@ public class Hex1bTerminalBuilderTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithHex1bApp_AsyncBuilderWithCapture_Works()
     {
         Hex1bApp? capturedApp = null;
@@ -444,27 +444,27 @@ public class Hex1bTerminalBuilderTests
 
         await runTask;
 
-        Assert.NotNull(capturedApp);
+        Assert.IsNotNull(capturedApp);
     }
 
     // === WithPtyProcess Tests ===
 
-    [Fact]
+    [TestMethod]
     public async Task WithPtyProcess_ReturnsBuilder()
     {
         var result = Hex1bTerminal.CreateBuilder().WithPtyProcess("dotnet", "--version");
         
-        Assert.IsType<Hex1bTerminalBuilder>(result);
+        TestSeq.IsType<Hex1bTerminalBuilder>(result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithPtyProcess_NullFileName_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             Hex1bTerminal.CreateBuilder().WithPtyProcess((string)null!));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithPtyProcess_OptionsOverload_ReturnsBuilder()
     {
         var result = Hex1bTerminal.CreateBuilder()
@@ -474,20 +474,20 @@ public class Hex1bTerminalBuilderTests
                 options.Arguments = ["--version"];
             });
         
-        Assert.IsType<Hex1bTerminalBuilder>(result);
+        TestSeq.IsType<Hex1bTerminalBuilder>(result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithPtyProcess_Options_NullConfigure_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             Hex1bTerminal.CreateBuilder().WithPtyProcess((Action<Hex1bTerminalProcessOptions>)null!));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithPtyProcess_Options_EmptyFileName_ThrowsInvalidOperationException()
     {
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() =>
             Hex1bTerminal.CreateBuilder()
                 .WithPtyProcess(options => { /* FileName not set */ })
                 .Build());
@@ -495,7 +495,7 @@ public class Hex1bTerminalBuilderTests
         Assert.Contains("FileName", ex.Message);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithPtyProcess_Options_CanSetEnvironment()
     {
         // Should not throw when setting environment variables
@@ -509,10 +509,10 @@ public class Hex1bTerminalBuilderTests
                 };
             });
         
-        Assert.NotNull(builder);
+        Assert.IsNotNull(builder);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithPtyProcess_Options_CanSetWorkingDirectory()
     {
         // Should not throw when setting working directory
@@ -523,10 +523,10 @@ public class Hex1bTerminalBuilderTests
                 options.WorkingDirectory = Path.GetTempPath();
             });
         
-        Assert.NotNull(builder);
+        Assert.IsNotNull(builder);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithPtyProcess_ExecutesProcess()
     {
         var pattern = new CellPatternSearcher().Find("Hello from test program");
@@ -552,10 +552,10 @@ public class Hex1bTerminalBuilderTests
 
         var exitCode = await runTask;
         
-        Assert.Equal(0, exitCode);
+        Assert.AreEqual(0, exitCode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithPtyProcess_InteractiveProcess_RespondsToInput()
     {
         var readyPattern = new CellPatternSearcher().Find("Ready");
@@ -581,27 +581,27 @@ public class Hex1bTerminalBuilderTests
 
         var exitCode = await runTask;
         
-        Assert.Equal(0, exitCode);
+        Assert.AreEqual(0, exitCode);
     }
 
     // === WithProcess (Standard .NET Process) Tests ===
 
-    [Fact]
+    [TestMethod]
     public async Task WithProcess_ReturnsBuilder()
     {
         var result = Hex1bTerminal.CreateBuilder().WithProcess("dotnet", "--version");
         
-        Assert.IsType<Hex1bTerminalBuilder>(result);
+        TestSeq.IsType<Hex1bTerminalBuilder>(result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithProcess_NullFileName_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             Hex1bTerminal.CreateBuilder().WithProcess((string)null!));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithProcess_ExecutesProcess()
     {
         // Inline C# echo script
@@ -627,30 +627,30 @@ public class Hex1bTerminalBuilderTests
 
         var exitCode = await runTask;
         
-        Assert.Equal(0, exitCode);
+        Assert.AreEqual(0, exitCode);
     }
 
     // === WithProcess(ProcessStartInfo) Tests ===
 
-    [Fact]
+    [TestMethod]
     public async Task WithProcess_ProcessStartInfo_ReturnsBuilder()
     {
         var startInfo = new ProcessStartInfo("dotnet", "--version");
         var builder = Hex1bTerminal.CreateBuilder()
             .WithProcess(startInfo);
         
-        Assert.NotNull(builder);
+        Assert.IsNotNull(builder);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithProcess_ProcessStartInfo_NullThrows()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             Hex1bTerminal.CreateBuilder()
                 .WithProcess((ProcessStartInfo)null!));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithProcess_ProcessStartInfo_AdapterCapturesOutput()
     {
         // Inline C# echo script
@@ -682,11 +682,11 @@ public class Hex1bTerminalBuilderTests
         var exitCode = await adapter.WaitForExitAsync();
         await adapter.DisposeAsync();
         
-        Assert.Equal(0, exitCode);
+        Assert.AreEqual(0, exitCode);
         Assert.Contains("AdapterTestOutput", output.ToString());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithProcess_ProcessStartInfo_ExecutesProcess()
     {
         // Inline C# echo script
@@ -719,10 +719,10 @@ public class Hex1bTerminalBuilderTests
 
         var exitCode = await runTask;
         
-        Assert.Equal(0, exitCode);
+        Assert.AreEqual(0, exitCode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithProcess_ProcessStartInfo_PreservesWorkingDirectory()
     {
         // Inline C# pwd script
@@ -756,10 +756,10 @@ public class Hex1bTerminalBuilderTests
 
         var exitCode = await runTask;
         
-        Assert.Equal(0, exitCode);
+        Assert.AreEqual(0, exitCode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithProcess_ProcessStartInfo_PreservesEnvironmentVariables()
     {
         // Inline C# env script
@@ -798,7 +798,7 @@ public class Hex1bTerminalBuilderTests
 
         var exitCode = await runTask;
         
-        Assert.Equal(0, exitCode);
+        Assert.AreEqual(0, exitCode);
     }
 
     // === Test Helpers ===
@@ -892,7 +892,7 @@ public class Hex1bTerminalBuilderTests
 
     // === Diagnostic Tests for PTY + Headless Investigation ===
 
-    [Fact]
+    [TestMethod]
     public async Task Diagnostic_EchoCommand_OutputAppearsInBuffer()
     {
         // Inline C# delay script that outputs a marker after a delay
@@ -952,7 +952,7 @@ public class Hex1bTerminalBuilderTests
             await Task.Delay(50, cts.Token);
         }
 
-        TestContext.Current.TestOutputHelper?.WriteLine(diagnosticOutput.ToString());
+        TestContext.Current?.WriteLine(diagnosticOutput.ToString());
 
         // Wait for process to complete
         var exitCode = 0;
@@ -966,14 +966,13 @@ public class Hex1bTerminalBuilderTests
             exitCode = await runTask;
         }
 
-        Assert.True(foundMarker, 
-            $"Expected to find 'DIAGNOSTIC_MARKER_12345' in screen buffer.\n" +
+        Assert.IsTrue(foundMarker, $"Expected to find 'DIAGNOSTIC_MARKER_12345' in screen buffer.\n" +
             $"Diagnostics:\n{diagnosticOutput}");
     }
 
     // === Recording and Optimization Tests ===
 
-    [Fact]
+    [TestMethod]
     public async Task WithAsciinemaRecording_ReturnsBuilder()
     {
         var tempFile = GetTempRecordingPath();
@@ -983,7 +982,7 @@ public class Hex1bTerminalBuilderTests
                 .WithHex1bApp(ctx => ctx.Text("Hello"))
                 .WithAsciinemaRecording(tempFile);
 
-            Assert.IsType<Hex1bTerminalBuilder>(result);
+            TestSeq.IsType<Hex1bTerminalBuilder>(result);
         }
         finally
         {
@@ -991,21 +990,21 @@ public class Hex1bTerminalBuilderTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithAsciinemaRecording_NullPath_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             Hex1bTerminal.CreateBuilder().WithAsciinemaRecording(null!));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithAsciinemaRecording_EmptyPath_ThrowsArgumentException()
     {
-        Assert.Throws<ArgumentException>(() =>
+        Assert.ThrowsExactly<ArgumentException>(() =>
             Hex1bTerminal.CreateBuilder().WithAsciinemaRecording(""));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithAsciinemaRecording_WithCapture_ReturnsBuilder()
     {
         var tempFile = GetTempRecordingPath();
@@ -1016,8 +1015,8 @@ public class Hex1bTerminalBuilderTests
                 .WithHex1bApp(ctx => ctx.Text("Hello"))
                 .WithAsciinemaRecording(tempFile, r => capturedRecorder = r);
 
-            Assert.IsType<Hex1bTerminalBuilder>(result);
-            Assert.NotNull(capturedRecorder);
+            TestSeq.IsType<Hex1bTerminalBuilder>(result);
+            Assert.IsNotNull(capturedRecorder);
         }
         finally
         {
@@ -1025,14 +1024,14 @@ public class Hex1bTerminalBuilderTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithAsciinemaRecording_WithCapture_NullCapture_ThrowsArgumentNullException()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             Hex1bTerminal.CreateBuilder().WithAsciinemaRecording("test.cast", (Action<AsciinemaRecorder>)null!));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithAsciinemaRecording_RecordsOutput()
     {
         var tempFile = GetTempRecordingPath();
@@ -1062,12 +1061,12 @@ public class Hex1bTerminalBuilderTests
 
                 await runTask;
 
-                Assert.NotNull(recorder);
+                Assert.IsNotNull(recorder);
                 await recorder.FlushAsync();
             }
 
             // Verify the recording file was created
-            Assert.True(File.Exists(tempFile), "Recording file should exist");
+            Assert.IsTrue(File.Exists(tempFile), "Recording file should exist");
             var content = await ReadAllTextSharedAsync(tempFile, TestContext.Current.CancellationToken);
             Assert.Contains("\"version\":2", content); // Asciinema v2 format
             Assert.Contains("Test Recording", content); // Title is present
@@ -1078,7 +1077,7 @@ public class Hex1bTerminalBuilderTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WithAsciinemaRecording_WithOptions_SetsRecorderOptions()
     {
         var tempFile = GetTempRecordingPath();
@@ -1096,11 +1095,11 @@ public class Hex1bTerminalBuilderTests
                     IdleTimeLimit = 5.0f
                 });
 
-            Assert.NotNull(recorder);
-            Assert.Equal("Custom Title", recorder.Options.Title);
-            Assert.Equal("test-command", recorder.Options.Command);
-            Assert.True(recorder.Options.CaptureInput);
-            Assert.Equal(5.0f, recorder.Options.IdleTimeLimit);
+            Assert.IsNotNull(recorder);
+            Assert.AreEqual("Custom Title", recorder.Options.Title);
+            Assert.AreEqual("test-command", recorder.Options.Command);
+            Assert.IsTrue(recorder.Options.CaptureInput);
+            Assert.AreEqual(5.0f, recorder.Options.IdleTimeLimit);
         }
         finally
         {
@@ -1108,7 +1107,7 @@ public class Hex1bTerminalBuilderTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FluentChain_WithRecordingAndFilters_Works()
     {
         var tempFile = GetTempRecordingPath();
@@ -1141,8 +1140,8 @@ public class Hex1bTerminalBuilderTests
             await runTask;
 
             // All filters should have been invoked
-            Assert.True(filter.SessionStartCalled, "Workload filter should be called");
-            Assert.NotNull(recorder);
+            Assert.IsTrue(filter.SessionStartCalled, "Workload filter should be called");
+            Assert.IsNotNull(recorder);
         }
         finally
         {
@@ -1152,40 +1151,40 @@ public class Hex1bTerminalBuilderTests
 
     // === WithAsciinemaPlayback Tests ===
 
-    [Fact]
+    [TestMethod]
     public void WithAsciinemaPlayback_NullFilePath_ThrowsArgumentException()
     {
-        Assert.Throws<ArgumentNullException>(() =>
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
             Hex1bTerminal.CreateBuilder().WithAsciinemaPlayback(null!));
     }
 
-    [Fact]
+    [TestMethod]
     public void WithAsciinemaPlayback_EmptyFilePath_ThrowsArgumentException()
     {
-        Assert.Throws<ArgumentException>(() =>
+        Assert.ThrowsExactly<ArgumentException>(() =>
             Hex1bTerminal.CreateBuilder().WithAsciinemaPlayback(""));
     }
 
-    [Fact]
+    [TestMethod]
     public void WithAsciinemaPlayback_ZeroSpeedMultiplier_ThrowsArgumentOutOfRangeException()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
             Hex1bTerminal.CreateBuilder().WithAsciinemaPlayback("file.cast", speedMultiplier: 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void WithAsciinemaPlayback_NegativeSpeedMultiplier_ThrowsArgumentOutOfRangeException()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
             Hex1bTerminal.CreateBuilder().WithAsciinemaPlayback("file.cast", speedMultiplier: -1.0));
     }
 
-    [Fact]
+    [TestMethod]
     public void WithAsciinemaPlayback_ReturnsBuilder()
     {
         var builder = Hex1bTerminal.CreateBuilder()
             .WithAsciinemaPlayback("/tmp/test.cast");
         
-        Assert.IsType<Hex1bTerminalBuilder>(builder);
+        TestSeq.IsType<Hex1bTerminalBuilder>(builder);
     }
 }

--- a/tests/Hex1b.Tests/Hex1bTerminalChildProcessTests.cs
+++ b/tests/Hex1b.Tests/Hex1bTerminalChildProcessTests.cs
@@ -8,9 +8,10 @@ namespace Hex1b.Tests;
 /// These tests require Linux (for PTY support via forkpty).
 /// Tests that require Linux use runtime checks to skip on other platforms.
 /// </summary>
+[TestClass]
 public class Hex1bTerminalChildProcessTests
 {
-    [Fact]
+    [TestMethod]
     public async Task WriteInput_BeforeStartCompletes_WaitsForPtyStartup()
     {
         var handle = new DelayedStartPtyHandle();
@@ -30,19 +31,19 @@ public class Hex1bTerminalChildProcessTests
         var writeTask = process.WriteInputAsync(Encoding.UTF8.GetBytes("hello"), cts.Token).AsTask();
 
         await Task.Delay(100, cts.Token);
-        Assert.False(writeTask.IsCompleted, "Input should wait until the PTY startup handshake completes.");
-        Assert.False(process.HasStarted);
+        Assert.IsFalse(writeTask.IsCompleted, "Input should wait until the PTY startup handshake completes.");
+        Assert.IsFalse(process.HasStarted);
 
         handle.CompleteStart();
 
         await startTask;
         await writeTask;
 
-        Assert.True(process.HasStarted);
-        Assert.Equal("hello", handle.LastWriteText);
+        Assert.IsTrue(process.HasStarted);
+        Assert.AreEqual("hello", handle.LastWriteText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task StartAsync_DoesNotInjectSyntheticEnterDuringInteractiveStartup()
     {
         var handle = new DelayedStartPtyHandle();
@@ -61,16 +62,16 @@ public class Hex1bTerminalChildProcessTests
 
         await process.StartAsync(cts.Token);
 
-        Assert.True(process.HasStarted);
-        Assert.Equal(0, handle.WriteCount);
+        Assert.IsTrue(process.HasStarted);
+        Assert.AreEqual(0, handle.WriteCount);
     }
 
     /// <summary>
     /// Verifies that when we launch bash with "tty" command, it reports
     /// a valid TTY device path (e.g., /dev/pts/X), proving a PTY is attached.
     /// </summary>
-    [Fact(Skip = "Flaky test - needs investigation")]
-    [Trait("Category", "Unix")]
+    [TestMethod, Ignore("Flaky test - needs investigation")]
+    [TestCategory("Unix")]
     public async Task BashWithTty_ReportsPtyDevice()
     {
         
@@ -115,17 +116,14 @@ public class Hex1bTerminalChildProcessTests
         
         // The tty command should output something like /dev/pts/0 or /dev/ttyp0
         Assert.Contains("/dev/", result);
-        Assert.True(
-            result.Contains("/dev/pts/") || result.Contains("/dev/tty"),
-            $"Expected PTY device path, got: {result}"
-        );
+        Assert.IsTrue(result.Contains("/dev/pts/") || result.Contains("/dev/tty"), $"Expected PTY device path, got: {result}");
     }
     
     /// <summary>
     /// Verifies that we can launch bash and it stays running at a prompt.
     /// </summary>
-    [Fact(Skip = "Flaky test - needs investigation")]
-    [Trait("Category", "Unix")]
+    [TestMethod, Ignore("Flaky test - needs investigation")]
+    [TestCategory("Unix")]
     public async Task BashInteractive_StaysAtPrompt()
     {
         
@@ -138,8 +136,8 @@ public class Hex1bTerminalChildProcessTests
         
         await process.StartAsync();
         
-        Assert.True(process.HasStarted);
-        Assert.True(process.ProcessId > 0, $"Expected positive PID, got {process.ProcessId}");
+        Assert.IsTrue(process.HasStarted);
+        Assert.IsTrue(process.ProcessId > 0, $"Expected positive PID, got {process.ProcessId}");
         
         // Read initial output (should include the tty path)
         var output = new StringBuilder();
@@ -175,7 +173,7 @@ public class Hex1bTerminalChildProcessTests
         Assert.Contains("/dev/", result);
         
         // Process should still be running (bash is waiting for input)
-        Assert.False(process.HasExited, "Process should still be running");
+        Assert.IsFalse(process.HasExited, "Process should still be running");
         
         // Send exit command
         await process.WriteInputAsync(Encoding.UTF8.GetBytes("exit\n"));
@@ -185,15 +183,15 @@ public class Hex1bTerminalChildProcessTests
         var exitCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
         var exitCode = await process.WaitForExitAsync(exitCts.Token);
         
-        Assert.True(process.HasExited);
-        Assert.Equal(0, exitCode);
+        Assert.IsTrue(process.HasExited);
+        Assert.AreEqual(0, exitCode);
     }
     
     /// <summary>
     /// Verifies that echo command works through the PTY.
     /// </summary>
-    [Fact(Skip = "Test hangs - needs investigation")]
-    [Trait("Category", "Unix")]
+    [TestMethod, Ignore("Test hangs - needs investigation")]
+    [TestCategory("Unix")]
     public async Task Echo_WritesToOutput()
     {
         await using var process = new Hex1bTerminalChildProcess(
@@ -233,15 +231,15 @@ public class Hex1bTerminalChildProcessTests
         // Wait for exit
         var exitCode = await process.WaitForExitAsync();
         
-        Assert.Equal(0, exitCode);
+        Assert.AreEqual(0, exitCode);
         Assert.Contains("Hello from PTY!", output.ToString());
     }
     
     /// <summary>
     /// Verifies that input can be written to the process and is echoed back.
     /// </summary>
-    [Fact]
-    [Trait("Category", "Unix")]
+    [TestMethod]
+    [TestCategory("Unix")]
     public async Task WriteInput_IsEchoedBack()
     {
         // Skip on non-Linux platforms - PTY support requires Linux
@@ -293,14 +291,14 @@ public class Hex1bTerminalChildProcessTests
         await process.WriteInputAsync(new byte[] { 0x04 });
         
         var exitCode = await process.WaitForExitAsync(CancellationToken.None);
-        Assert.Equal(0, exitCode);
+        Assert.AreEqual(0, exitCode);
     }
     
     /// <summary>
     /// Verifies that terminal resize works via SIGWINCH.
     /// </summary>
-    [Fact(Skip = "Flaky test - needs investigation")]
-    [Trait("Category", "Unix")]
+    [TestMethod, Ignore("Flaky test - needs investigation")]
+    [TestCategory("Unix")]
     public async Task Resize_UpdatesTerminalSize()
     {
         
@@ -379,8 +377,8 @@ public class Hex1bTerminalChildProcessTests
     /// <summary>
     /// Verifies that the process integrates with Hex1bTerminal as a workload adapter.
     /// </summary>
-    [Fact(Skip = "Flaky test - needs investigation")]
-    [Trait("Category", "Unix")]
+    [TestMethod, Ignore("Flaky test - needs investigation")]
+    [TestCategory("Unix")]
     public async Task Integration_WithHex1bTerminal()
     {
         
@@ -476,8 +474,8 @@ public class Hex1bTerminalChildProcessTests
     /// <summary>
     /// Verifies that killing the process works.
     /// </summary>
-    [Fact(Skip = "Flaky test - needs investigation")]
-    [Trait("Category", "Unix")]
+    [TestMethod, Ignore("Flaky test - needs investigation")]
+    [TestCategory("Unix")]
     public async Task Kill_TerminatesProcess()
     {
         
@@ -489,8 +487,8 @@ public class Hex1bTerminalChildProcessTests
         
         await process.StartAsync();
         
-        Assert.True(process.HasStarted);
-        Assert.False(process.HasExited);
+        Assert.IsTrue(process.HasStarted);
+        Assert.IsFalse(process.HasExited);
         
         // Give it a moment to start
         await Task.Delay(200);
@@ -502,16 +500,16 @@ public class Hex1bTerminalChildProcessTests
         var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
         var exitCode = await process.WaitForExitAsync(cts.Token);
         
-        Assert.True(process.HasExited);
+        Assert.IsTrue(process.HasExited);
         // SIGTERM (15) results in exit code 128 + 15 = 143
-        Assert.True(exitCode != 0, $"Expected non-zero exit code from killed process, got {exitCode}");
+        Assert.IsTrue(exitCode != 0, $"Expected non-zero exit code from killed process, got {exitCode}");
     }
     
     /// <summary>
     /// Verifies proper cleanup when disposing without waiting for exit.
     /// </summary>
-    [Fact]
-    [Trait("Category", "Unix")]
+    [TestMethod]
+    [TestCategory("Unix")]
     public async Task Dispose_CleansUpRunningProcess()
     {
         // Skip on non-Linux platforms - PTY support requires Linux
@@ -529,7 +527,7 @@ public class Hex1bTerminalChildProcessTests
             await process.StartAsync();
             pid = process.ProcessId;
             
-            Assert.True(pid > 0);
+            Assert.IsTrue(pid > 0);
             
             // Dispose without waiting
             await process.DisposeAsync();
@@ -541,7 +539,7 @@ public class Hex1bTerminalChildProcessTests
         // Verify process is gone (kill with signal 0 checks if process exists)
         // This will throw or return error if process doesn't exist
         var exists = ProcessExists(pid);
-        Assert.False(exists, $"Process {pid} should have been terminated");
+        Assert.IsFalse(exists, $"Process {pid} should have been terminated");
     }
     
     private static bool ProcessExists(int pid)
@@ -564,9 +562,9 @@ public class Hex1bTerminalChildProcessTests
     /// application that uses advanced terminal features (Unicode, 256 color, cursor positioning).
     /// This test is primarily for visual validation and is not intended to be kept long-term.
     /// </summary>
-    [Fact(Skip = "Stress test - run manually for visual validation")]
-    [Trait("Category", "Unix")]
-    [Trait("Category", "StressTest")]
+    [TestMethod, Ignore("Stress test - run manually for visual validation")]
+    [TestCategory("Unix")]
+    [TestCategory("StressTest")]
     public async Task StressTest_MapsciiViaInteractiveBash()
     {
         // Setup temp file for asciinema recording
@@ -731,7 +729,7 @@ public class Hex1bTerminalChildProcessTests
                 cornerDiagnostics.AppendLine($"  Row {row} first non-braille at column: {rowBlankStart}");
             }
             
-            TestContext.Current.TestOutputHelper?.WriteLine(cornerDiagnostics.ToString());
+            TestContext.Current?.WriteLine(cornerDiagnostics.ToString());
             
             // Check if all corners have braille characters
             var allCornersHaveBraille = IsBraille(topLeft) && IsBraille(topRight) && 
@@ -783,7 +781,7 @@ public class Hex1bTerminalChildProcessTests
             await TestCaptureHelper.CaptureCastAsync(recorder, "mapscii", TestContext.Current.CancellationToken);
             
             // Assert that we at least saw the map
-            Assert.True(mapLoaded, "Mapscii should have loaded and displayed the map");
+            Assert.IsTrue(mapLoaded, "Mapscii should have loaded and displayed the map");
         }
         finally
         {
@@ -799,9 +797,9 @@ public class Hex1bTerminalChildProcessTests
     /// braille graphs, cursor positioning).
     /// This test is primarily for visual validation and is not intended to be kept long-term.
     /// </summary>
-    [Fact(Skip = "Stress test - run manually for visual validation")]
-    [Trait("Category", "Unix")]
-    [Trait("Category", "StressTest")]
+    [TestMethod, Ignore("Stress test - run manually for visual validation")]
+    [TestCategory("Unix")]
+    [TestCategory("StressTest")]
     public async Task StressTest_BtopViaInteractiveBash()
     {
         // Setup temp file for asciinema recording
@@ -917,7 +915,7 @@ public class Hex1bTerminalChildProcessTests
             await TestCaptureHelper.CaptureCastAsync(recorder, "btop", TestContext.Current.CancellationToken);
             
             // Assert that we at least saw btop
-            Assert.True(btopLoaded, "Btop should have loaded and displayed the interface");
+            Assert.IsTrue(btopLoaded, "Btop should have loaded and displayed the interface");
         }
         finally
         {
@@ -933,9 +931,9 @@ public class Hex1bTerminalChildProcessTests
     /// Exercises cursor movement, Unicode art, and proper process termination handling.
     /// This test is primarily for visual validation and is not intended to be kept long-term.
     /// </summary>
-    [Fact(Skip = "Stress test - run manually for visual validation")]
-    [Trait("Category", "Unix")]
-    [Trait("Category", "StressTest")]
+    [TestMethod, Ignore("Stress test - run manually for visual validation")]
+    [TestCategory("Unix")]
+    [TestCategory("StressTest")]
     public async Task StressTest_SlSteamLocomotive()
     {
         // Setup temp file for asciinema recording
@@ -1035,8 +1033,8 @@ public class Hex1bTerminalChildProcessTests
             // Assert that sl ran successfully - the key assertion is detecting the locomotive
             // The exit code may vary: 0 if completed, -1 if killed due to timeout, or other values
             // depending on the system. The important thing is we saw the animation.
-            Assert.True(locomotiveDetected, "Should have detected locomotive ASCII art");
-            Assert.True(process.HasExited, "sl should have terminated (either naturally or killed)");
+            Assert.IsTrue(locomotiveDetected, "Should have detected locomotive ASCII art");
+            Assert.IsTrue(process.HasExited, "sl should have terminated (either naturally or killed)");
         }
         finally
         {
@@ -1055,10 +1053,10 @@ public class Hex1bTerminalChildProcessTests
     /// This test is primarily for visual validation and is not intended to be kept long-term.
     /// Requires Docker to be installed and running.
     /// </summary>
-    [Fact(Skip = "Stress test - run manually for visual validation")]
-    [Trait("Category", "Unix")]
-    [Trait("Category", "StressTest")]
-    [Trait("Category", "Docker")]
+    [TestMethod, Ignore("Stress test - run manually for visual validation")]
+    [TestCategory("Unix")]
+    [TestCategory("StressTest")]
+    [TestCategory("Docker")]
     public async Task StressTest_GlobeWithDockerAndMouse()
     {
         // Check if docker is available
@@ -1265,7 +1263,7 @@ public class Hex1bTerminalChildProcessTests
             await TestCaptureHelper.CaptureCastAsync(recorder, "globe", TestContext.Current.CancellationToken);
             
             // Assert success - we got through the whole workflow
-            Assert.True(globeStarted || buildComplete, "Globe workflow should have progressed");
+            Assert.IsTrue(globeStarted || buildComplete, "Globe workflow should have progressed");
         }
         finally
         {
@@ -1300,10 +1298,10 @@ public class Hex1bTerminalChildProcessTests
     /// This test is primarily for visual validation and is not intended to be kept long-term.
     /// Requires: tmux, telnet (for mapscii), docker (for globe), and git.
     /// </summary>
-    [Fact(Skip = "Stress test - run manually for visual validation")]
-    [Trait("Category", "Unix")]
-    [Trait("Category", "StressTest")]
-    [Trait("Category", "Docker")]
+    [TestMethod, Ignore("Stress test - run manually for visual validation")]
+    [TestCategory("Unix")]
+    [TestCategory("StressTest")]
+    [TestCategory("Docker")]
     public async Task StressTest_TmuxSplitGlobeAndMapscii()
     {
         // Check required tools
@@ -1444,7 +1442,7 @@ public class Hex1bTerminalChildProcessTests
             // Debug: Check what's in the buffer after tmux starts
             var tmuxSnapshot = terminal.CreateSnapshot();
             var fullText = tmuxSnapshot.GetScreenText();
-            TestContext.Current.TestOutputHelper?.WriteLine($"After tmux start, screen content (first 500 chars): {fullText[..Math.Min(500, fullText.Length)]}");
+            TestContext.Current?.WriteLine($"After tmux start, screen content (first 500 chars): {fullText[..Math.Min(500, fullText.Length)]}");
             
             // Check if tmux is running (should see status bar or fresh prompt)
             var hasTmuxStatusBar = tmuxSnapshot.ContainsText("[split_test]") ||
@@ -1453,7 +1451,7 @@ public class Hex1bTerminalChildProcessTests
             var hasOldContent = tmuxSnapshot.ContainsText("docker build") ||
                                 tmuxSnapshot.ContainsText("git clone");
             
-            TestContext.Current.TestOutputHelper?.WriteLine($"Has tmux status: {hasTmuxStatusBar}, Has old content: {hasOldContent}");
+            TestContext.Current?.WriteLine($"Has tmux status: {hasTmuxStatusBar}, Has old content: {hasOldContent}");
             
             // Step 5: Split pane vertically (creates left and right panes)
             // Ctrl+b % is the default key binding for vertical split
@@ -1571,8 +1569,8 @@ public class Hex1bTerminalChildProcessTests
             await TestCaptureHelper.CaptureCastAsync(recorder, "tmux-split", TestContext.Current.CancellationToken);
             
             // Assert that we saw content from both apps
-            Assert.True(mapsciiLoaded || hasMapContent, "Mapscii should have loaded in the right pane");
-            Assert.True(globeStarted || hasGlobeContent, "Globe should have started in the left pane");
+            Assert.IsTrue(mapsciiLoaded || hasMapContent, "Mapscii should have loaded in the right pane");
+            Assert.IsTrue(globeStarted || hasGlobeContent, "Globe should have started in the left pane");
         }
         finally
         {
@@ -1706,10 +1704,10 @@ public class Hex1bTerminalChildProcessTests
     /// This test is designed to capture the internal terminal state after a tmux split
     /// to help diagnose rendering glitches.
     /// </summary>
-    [Fact(Skip = "Diagnostic test - spawns PTY processes, slow, not suitable for CI")]
-    [Trait("Category", "Unix")]
-    [Trait("Category", "StressTest")]
-    [Trait("Category", "Diagnostic")]
+    [TestMethod, Ignore("Diagnostic test - spawns PTY processes, slow, not suitable for CI")]
+    [TestCategory("Unix")]
+    [TestCategory("StressTest")]
+    [TestCategory("Diagnostic")]
     public async Task Diagnostic_TmuxSplitScreen_CapturesTerminalState()
     {
         // Skip on non-Linux platforms - PTY support requires Linux
@@ -1788,7 +1786,7 @@ public class Hex1bTerminalChildProcessTests
             // Debug output
             var tmuxSnapshot = terminal.CreateSnapshot();
             var fullText = tmuxSnapshot.GetScreenText();
-            TestContext.Current.TestOutputHelper?.WriteLine($"After tmux start, screen content (first 500 chars): {fullText[..Math.Min(500, fullText.Length)]}");
+            TestContext.Current?.WriteLine($"After tmux start, screen content (first 500 chars): {fullText[..Math.Min(500, fullText.Length)]}");
             
             // Step 3: Split pane vertically with Ctrl+B %
             // Ctrl+B is the tmux prefix key (ASCII 0x02)
@@ -1805,7 +1803,7 @@ public class Hex1bTerminalChildProcessTests
             // Debug output after split
             var splitSnapshot = terminal.CreateSnapshot();
             var splitText = splitSnapshot.GetScreenText();
-            TestContext.Current.TestOutputHelper?.WriteLine($"After split, screen content (first 500 chars): {splitText[..Math.Min(500, splitText.Length)]}");
+            TestContext.Current?.WriteLine($"After split, screen content (first 500 chars): {splitText[..Math.Min(500, splitText.Length)]}");
             
             // Dump raw screen buffer info for debugging
             var buffer = terminal.GetScreenBuffer();
@@ -1836,7 +1834,7 @@ public class Hex1bTerminalChildProcessTests
                 diagnostics.AppendLine($"  [{midY},{x}]: '{cell.Character}' Fg={cell.Foreground} Bg={cell.Background} Seq={cell.Sequence}");
             }
             
-            TestContext.Current.TestOutputHelper?.WriteLine(diagnostics.ToString());
+            TestContext.Current?.WriteLine(diagnostics.ToString());
             
             // Step 4: Take additional snapshots after waiting
             await Task.Delay(500, TestContext.Current.CancellationToken);
@@ -1889,7 +1887,7 @@ public class Hex1bTerminalChildProcessTests
             
             // This test is primarily for diagnostic capture, not assertions
             // If we got this far, the capture was successful
-            Assert.True(true, "Diagnostic capture completed successfully");
+            Assert.IsTrue(true, "Diagnostic capture completed successfully");
         }
         finally
         {

--- a/tests/Hex1b.Tests/Hex1bTerminalInputSequenceTests.cs
+++ b/tests/Hex1b.Tests/Hex1bTerminalInputSequenceTests.cs
@@ -6,69 +6,70 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for the Hex1bTerminalInputSequenceBuilder and Hex1bTerminalInputSequence.
 /// </summary>
+[TestClass]
 public class Hex1bTestSequenceTests
 {
     #region Builder Basic Tests
 
-    [Fact]
+    [TestMethod]
     public void Build_EmptySequence_ReturnsEmptySequence()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder().Build();
         
-        Assert.Empty(sequence.Steps);
+        Assert.IsEmpty(sequence.Steps);
     }
 
-    [Fact]
+    [TestMethod]
     public void Key_AddsKeyInputStep()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
             .Key(Hex1bKey.A)
             .Build();
         
-        Assert.Single(sequence.Steps);
-        var step = Assert.IsType<KeyInputStep>(sequence.Steps[0]);
-        Assert.Equal(Hex1bKey.A, step.Key);
-        Assert.Equal("a", step.Text);
-        Assert.Equal(Hex1bModifiers.None, step.Modifiers);
+        TestSeq.Single(sequence.Steps);
+        var step = TestSeq.IsType<KeyInputStep>(sequence.Steps[0]);
+        Assert.AreEqual(Hex1bKey.A, step.Key);
+        Assert.AreEqual("a", step.Text);
+        Assert.AreEqual(Hex1bModifiers.None, step.Modifiers);
     }
 
-    [Fact]
+    [TestMethod]
     public void Shift_Key_AddsShiftModifier()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
             .Shift().Key(Hex1bKey.A)
             .Build();
         
-        var step = Assert.IsType<KeyInputStep>(sequence.Steps[0]);
-        Assert.Equal(Hex1bKey.A, step.Key);
-        Assert.Equal("A", step.Text);
-        Assert.Equal(Hex1bModifiers.Shift, step.Modifiers);
+        var step = TestSeq.IsType<KeyInputStep>(sequence.Steps[0]);
+        Assert.AreEqual(Hex1bKey.A, step.Key);
+        Assert.AreEqual("A", step.Text);
+        Assert.AreEqual(Hex1bModifiers.Shift, step.Modifiers);
     }
 
-    [Fact]
+    [TestMethod]
     public void Ctrl_Key_AddsControlModifier()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
             .Build();
         
-        var step = Assert.IsType<KeyInputStep>(sequence.Steps[0]);
-        Assert.Equal(Hex1bKey.C, step.Key);
-        Assert.Equal(Hex1bModifiers.Control, step.Modifiers);
+        var step = TestSeq.IsType<KeyInputStep>(sequence.Steps[0]);
+        Assert.AreEqual(Hex1bKey.C, step.Key);
+        Assert.AreEqual(Hex1bModifiers.Control, step.Modifiers);
     }
 
-    [Fact]
+    [TestMethod]
     public void Ctrl_Shift_Key_AddsCombinedModifiers()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Shift().Key(Hex1bKey.Z)
             .Build();
         
-        var step = Assert.IsType<KeyInputStep>(sequence.Steps[0]);
-        Assert.Equal(Hex1bModifiers.Control | Hex1bModifiers.Shift, step.Modifiers);
+        var step = TestSeq.IsType<KeyInputStep>(sequence.Steps[0]);
+        Assert.AreEqual(Hex1bModifiers.Control | Hex1bModifiers.Shift, step.Modifiers);
     }
 
-    [Fact]
+    [TestMethod]
     public void ModifiersResetAfterKey()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
@@ -76,53 +77,53 @@ public class Hex1bTestSequenceTests
             .Key(Hex1bKey.B)
             .Build();
         
-        var step1 = Assert.IsType<KeyInputStep>(sequence.Steps[0]);
-        var step2 = Assert.IsType<KeyInputStep>(sequence.Steps[1]);
+        var step1 = TestSeq.IsType<KeyInputStep>(sequence.Steps[0]);
+        var step2 = TestSeq.IsType<KeyInputStep>(sequence.Steps[1]);
         
-        Assert.Equal(Hex1bModifiers.Control, step1.Modifiers);
-        Assert.Equal(Hex1bModifiers.None, step2.Modifiers);
+        Assert.AreEqual(Hex1bModifiers.Control, step1.Modifiers);
+        Assert.AreEqual(Hex1bModifiers.None, step2.Modifiers);
     }
 
     #endregion
 
     #region Text Input Tests
 
-    [Fact]
+    [TestMethod]
     public void Type_AddsTextInputStep()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
             .Type("Hello")
             .Build();
         
-        Assert.Single(sequence.Steps);
-        var step = Assert.IsType<TextInputStep>(sequence.Steps[0]);
-        Assert.Equal("Hello", step.Text);
-        Assert.Equal(TimeSpan.Zero, step.DelayBetweenKeys);
+        TestSeq.Single(sequence.Steps);
+        var step = TestSeq.IsType<TextInputStep>(sequence.Steps[0]);
+        Assert.AreEqual("Hello", step.Text);
+        Assert.AreEqual(TimeSpan.Zero, step.DelayBetweenKeys);
     }
 
-    [Fact]
+    [TestMethod]
     public void FastType_AddsTextInputStepWithNoDelay()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
             .FastType("Test")
             .Build();
         
-        var step = Assert.IsType<TextInputStep>(sequence.Steps[0]);
-        Assert.Equal(TimeSpan.Zero, step.DelayBetweenKeys);
+        var step = TestSeq.IsType<TextInputStep>(sequence.Steps[0]);
+        Assert.AreEqual(TimeSpan.Zero, step.DelayBetweenKeys);
     }
 
-    [Fact]
+    [TestMethod]
     public void SlowType_AddsTextInputStepWithDefaultDelay()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
             .SlowType("Test")
             .Build();
         
-        var step = Assert.IsType<TextInputStep>(sequence.Steps[0]);
-        Assert.Equal(Hex1bTerminalInputSequenceOptions.Default.SlowTypeDelay, step.DelayBetweenKeys);
+        var step = TestSeq.IsType<TextInputStep>(sequence.Steps[0]);
+        Assert.AreEqual(Hex1bTerminalInputSequenceOptions.Default.SlowTypeDelay, step.DelayBetweenKeys);
     }
 
-    [Fact]
+    [TestMethod]
     public void SlowType_WithCustomDelay_UsesCustomDelay()
     {
         var delay = TimeSpan.FromMilliseconds(100);
@@ -130,86 +131,86 @@ public class Hex1bTestSequenceTests
             .SlowType("Test", delay)
             .Build();
         
-        var step = Assert.IsType<TextInputStep>(sequence.Steps[0]);
-        Assert.Equal(delay, step.DelayBetweenKeys);
+        var step = TestSeq.IsType<TextInputStep>(sequence.Steps[0]);
+        Assert.AreEqual(delay, step.DelayBetweenKeys);
     }
 
     #endregion
 
     #region Common Key Shortcuts Tests
 
-    [Fact]
+    [TestMethod]
     public void Enter_AddsEnterKeyStep()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder().Enter().Build();
         
-        var step = Assert.IsType<KeyInputStep>(sequence.Steps[0]);
-        Assert.Equal(Hex1bKey.Enter, step.Key);
+        var step = TestSeq.IsType<KeyInputStep>(sequence.Steps[0]);
+        Assert.AreEqual(Hex1bKey.Enter, step.Key);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tab_AddsTabKeyStep()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder().Tab().Build();
         
-        var step = Assert.IsType<KeyInputStep>(sequence.Steps[0]);
-        Assert.Equal(Hex1bKey.Tab, step.Key);
+        var step = TestSeq.IsType<KeyInputStep>(sequence.Steps[0]);
+        Assert.AreEqual(Hex1bKey.Tab, step.Key);
     }
 
-    [Fact]
+    [TestMethod]
     public void Escape_AddsEscapeKeyStep()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder().Escape().Build();
         
-        var step = Assert.IsType<KeyInputStep>(sequence.Steps[0]);
-        Assert.Equal(Hex1bKey.Escape, step.Key);
+        var step = TestSeq.IsType<KeyInputStep>(sequence.Steps[0]);
+        Assert.AreEqual(Hex1bKey.Escape, step.Key);
     }
 
-    [Fact]
+    [TestMethod]
     public void ArrowKeys_AddCorrectKeySteps()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
             .Up().Down().Left().Right()
             .Build();
         
-        Assert.Equal(4, sequence.Steps.Count);
-        Assert.Equal(Hex1bKey.UpArrow, ((KeyInputStep)sequence.Steps[0]).Key);
-        Assert.Equal(Hex1bKey.DownArrow, ((KeyInputStep)sequence.Steps[1]).Key);
-        Assert.Equal(Hex1bKey.LeftArrow, ((KeyInputStep)sequence.Steps[2]).Key);
-        Assert.Equal(Hex1bKey.RightArrow, ((KeyInputStep)sequence.Steps[3]).Key);
+        Assert.AreEqual(4, sequence.Steps.Count);
+        Assert.AreEqual(Hex1bKey.UpArrow, ((KeyInputStep)sequence.Steps[0]).Key);
+        Assert.AreEqual(Hex1bKey.DownArrow, ((KeyInputStep)sequence.Steps[1]).Key);
+        Assert.AreEqual(Hex1bKey.LeftArrow, ((KeyInputStep)sequence.Steps[2]).Key);
+        Assert.AreEqual(Hex1bKey.RightArrow, ((KeyInputStep)sequence.Steps[3]).Key);
     }
 
-    [Fact]
+    [TestMethod]
     public void Shift_Tab_AddsBackTab()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
             .Shift().Tab()
             .Build();
         
-        var step = Assert.IsType<KeyInputStep>(sequence.Steps[0]);
-        Assert.Equal(Hex1bKey.Tab, step.Key);
-        Assert.Equal(Hex1bModifiers.Shift, step.Modifiers);
+        var step = TestSeq.IsType<KeyInputStep>(sequence.Steps[0]);
+        Assert.AreEqual(Hex1bKey.Tab, step.Key);
+        Assert.AreEqual(Hex1bModifiers.Shift, step.Modifiers);
     }
 
     #endregion
 
     #region Mouse Input Tests
 
-    [Fact]
+    [TestMethod]
     public void MouseMoveTo_AddsMouseMoveStep()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
             .MouseMoveTo(10, 20)
             .Build();
         
-        var step = Assert.IsType<MouseInputStep>(sequence.Steps[0]);
-        Assert.Equal(MouseButton.None, step.Button);
-        Assert.Equal(MouseAction.Move, step.Action);
-        Assert.Equal(10, step.X);
-        Assert.Equal(20, step.Y);
+        var step = TestSeq.IsType<MouseInputStep>(sequence.Steps[0]);
+        Assert.AreEqual(MouseButton.None, step.Button);
+        Assert.AreEqual(MouseAction.Move, step.Action);
+        Assert.AreEqual(10, step.X);
+        Assert.AreEqual(20, step.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void MouseMove_AddsRelativeMove()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
@@ -217,12 +218,12 @@ public class Hex1bTestSequenceTests
             .MouseMove(5, -3)
             .Build();
         
-        var step = Assert.IsType<MouseInputStep>(sequence.Steps[1]);
-        Assert.Equal(15, step.X);
-        Assert.Equal(7, step.Y);
+        var step = TestSeq.IsType<MouseInputStep>(sequence.Steps[1]);
+        Assert.AreEqual(15, step.X);
+        Assert.AreEqual(7, step.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void Click_AddsDownAndUpSteps()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
@@ -230,29 +231,29 @@ public class Hex1bTestSequenceTests
             .Click()
             .Build();
         
-        Assert.Equal(3, sequence.Steps.Count);
-        var downStep = Assert.IsType<MouseInputStep>(sequence.Steps[1]);
-        var upStep = Assert.IsType<MouseInputStep>(sequence.Steps[2]);
+        Assert.AreEqual(3, sequence.Steps.Count);
+        var downStep = TestSeq.IsType<MouseInputStep>(sequence.Steps[1]);
+        var upStep = TestSeq.IsType<MouseInputStep>(sequence.Steps[2]);
         
-        Assert.Equal(MouseButton.Left, downStep.Button);
-        Assert.Equal(MouseAction.Down, downStep.Action);
-        Assert.Equal(MouseButton.Left, upStep.Button);
-        Assert.Equal(MouseAction.Up, upStep.Action);
+        Assert.AreEqual(MouseButton.Left, downStep.Button);
+        Assert.AreEqual(MouseAction.Down, downStep.Action);
+        Assert.AreEqual(MouseButton.Left, upStep.Button);
+        Assert.AreEqual(MouseAction.Up, upStep.Action);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClickAt_MovesToPositionAndClicks()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
             .ClickAt(15, 25)
             .Build();
         
-        var downStep = Assert.IsType<MouseInputStep>(sequence.Steps[0]);
-        Assert.Equal(15, downStep.X);
-        Assert.Equal(25, downStep.Y);
+        var downStep = TestSeq.IsType<MouseInputStep>(sequence.Steps[0]);
+        Assert.AreEqual(15, downStep.X);
+        Assert.AreEqual(25, downStep.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void DoubleClick_SetsClickCountTo2()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
@@ -260,11 +261,11 @@ public class Hex1bTestSequenceTests
             .DoubleClick()
             .Build();
         
-        var downStep = Assert.IsType<MouseInputStep>(sequence.Steps[1]);
-        Assert.Equal(2, downStep.ClickCount);
+        var downStep = TestSeq.IsType<MouseInputStep>(sequence.Steps[1]);
+        Assert.AreEqual(2, downStep.ClickCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void Drag_CreatesDownDragUpSequence()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
@@ -272,28 +273,28 @@ public class Hex1bTestSequenceTests
             .Build();
         
         // Drag creates: Down, Wait (10ms), Drag, Up = 4 steps
-        Assert.Equal(4, sequence.Steps.Count);
+        Assert.AreEqual(4, sequence.Steps.Count);
         
-        var downStep = Assert.IsType<MouseInputStep>(sequence.Steps[0]);
-        Assert.Equal(MouseAction.Down, downStep.Action);
-        Assert.Equal(10, downStep.X);
-        Assert.Equal(10, downStep.Y);
+        var downStep = TestSeq.IsType<MouseInputStep>(sequence.Steps[0]);
+        Assert.AreEqual(MouseAction.Down, downStep.Action);
+        Assert.AreEqual(10, downStep.X);
+        Assert.AreEqual(10, downStep.Y);
         
         // Step 1 is the wait step
-        Assert.IsType<WaitStep>(sequence.Steps[1]);
+        TestSeq.IsType<WaitStep>(sequence.Steps[1]);
         
-        var dragStep = Assert.IsType<MouseInputStep>(sequence.Steps[2]);
-        Assert.Equal(MouseAction.Drag, dragStep.Action);
-        Assert.Equal(20, dragStep.X);
-        Assert.Equal(15, dragStep.Y);
+        var dragStep = TestSeq.IsType<MouseInputStep>(sequence.Steps[2]);
+        Assert.AreEqual(MouseAction.Drag, dragStep.Action);
+        Assert.AreEqual(20, dragStep.X);
+        Assert.AreEqual(15, dragStep.Y);
         
-        var upStep = Assert.IsType<MouseInputStep>(sequence.Steps[3]);
-        Assert.Equal(MouseAction.Up, upStep.Action);
-        Assert.Equal(20, upStep.X);
-        Assert.Equal(15, upStep.Y);
+        var upStep = TestSeq.IsType<MouseInputStep>(sequence.Steps[3]);
+        Assert.AreEqual(MouseAction.Up, upStep.Action);
+        Assert.AreEqual(20, upStep.X);
+        Assert.AreEqual(15, upStep.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void Ctrl_Click_AddsControlModifier()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
@@ -301,42 +302,42 @@ public class Hex1bTestSequenceTests
             .Ctrl().Click()
             .Build();
         
-        var downStep = Assert.IsType<MouseInputStep>(sequence.Steps[1]);
-        Assert.Equal(Hex1bModifiers.Control, downStep.Modifiers);
+        var downStep = TestSeq.IsType<MouseInputStep>(sequence.Steps[1]);
+        Assert.AreEqual(Hex1bModifiers.Control, downStep.Modifiers);
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollUp_AddsScrollSteps()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
             .ScrollUp(3)
             .Build();
         
-        Assert.Equal(3, sequence.Steps.Count);
+        Assert.AreEqual(3, sequence.Steps.Count);
         foreach (var step in sequence.Steps)
         {
-            var mouseStep = Assert.IsType<MouseInputStep>(step);
-            Assert.Equal(MouseButton.ScrollUp, mouseStep.Button);
+            var mouseStep = TestSeq.IsType<MouseInputStep>(step);
+            Assert.AreEqual(MouseButton.ScrollUp, mouseStep.Button);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollDown_AddsScrollSteps()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
             .ScrollDown(2)
             .Build();
         
-        Assert.Equal(2, sequence.Steps.Count);
-        var mouseStep = Assert.IsType<MouseInputStep>(sequence.Steps[0]);
-        Assert.Equal(MouseButton.ScrollDown, mouseStep.Button);
+        Assert.AreEqual(2, sequence.Steps.Count);
+        var mouseStep = TestSeq.IsType<MouseInputStep>(sequence.Steps[0]);
+        Assert.AreEqual(MouseButton.ScrollDown, mouseStep.Button);
     }
 
     #endregion
 
     #region Wait Tests
 
-    [Fact]
+    [TestMethod]
     public void Wait_AddsWaitStep()
     {
         var duration = TimeSpan.FromMilliseconds(100);
@@ -344,26 +345,26 @@ public class Hex1bTestSequenceTests
             .Wait(duration)
             .Build();
         
-        var step = Assert.IsType<WaitStep>(sequence.Steps[0]);
-        Assert.Equal(duration, step.Duration);
+        var step = TestSeq.IsType<WaitStep>(sequence.Steps[0]);
+        Assert.AreEqual(duration, step.Duration);
     }
 
-    [Fact]
+    [TestMethod]
     public void Wait_Milliseconds_AddsWaitStep()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
             .Wait(50)
             .Build();
         
-        var step = Assert.IsType<WaitStep>(sequence.Steps[0]);
-        Assert.Equal(TimeSpan.FromMilliseconds(50), step.Duration);
+        var step = TestSeq.IsType<WaitStep>(sequence.Steps[0]);
+        Assert.AreEqual(TimeSpan.FromMilliseconds(50), step.Duration);
     }
 
     #endregion
 
     #region Complex Sequence Tests
 
-    [Fact]
+    [TestMethod]
     public void ComplexSequence_BuildsCorrectly()
     {
         var sequence = new Hex1bTerminalInputSequenceBuilder()
@@ -375,20 +376,20 @@ public class Hex1bTestSequenceTests
             .Enter()
             .Build();
         
-        Assert.Equal(6, sequence.Steps.Count);
-        Assert.IsType<TextInputStep>(sequence.Steps[0]);
-        Assert.IsType<WaitStep>(sequence.Steps[1]);
-        Assert.IsType<KeyInputStep>(sequence.Steps[2]);
-        Assert.IsType<KeyInputStep>(sequence.Steps[3]);
-        Assert.IsType<KeyInputStep>(sequence.Steps[4]);
-        Assert.IsType<KeyInputStep>(sequence.Steps[5]);
+        Assert.AreEqual(6, sequence.Steps.Count);
+        TestSeq.IsType<TextInputStep>(sequence.Steps[0]);
+        TestSeq.IsType<WaitStep>(sequence.Steps[1]);
+        TestSeq.IsType<KeyInputStep>(sequence.Steps[2]);
+        TestSeq.IsType<KeyInputStep>(sequence.Steps[3]);
+        TestSeq.IsType<KeyInputStep>(sequence.Steps[4]);
+        TestSeq.IsType<KeyInputStep>(sequence.Steps[5]);
     }
 
     #endregion
 
     #region Terminal Integration Tests
 
-    [Fact]
+    [TestMethod]
     public async Task ApplyAsync_SendsKeyEventsToTerminal()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -419,10 +420,10 @@ public class Hex1bTestSequenceTests
         cts.Cancel();
         await runTask;
         
-        Assert.Equal("Hello", textEntered);
+        Assert.AreEqual("Hello", textEntered);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ApplyAsync_SendsKeyboardShortcuts()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -460,10 +461,10 @@ public class Hex1bTestSequenceTests
         cts.Cancel();
         await runTask;
         
-        Assert.True(ctrlCPressed);
+        Assert.IsTrue(ctrlCPressed);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ApplyAsync_NavigatesWithArrowKeys()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -498,10 +499,10 @@ public class Hex1bTestSequenceTests
         await runTask;
         
         // Third item should be selected
-        Assert.True(snapshot.ContainsText("> Item 3"));
+        Assert.IsTrue(snapshot.ContainsText("> Item 3"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ApplyAsync_TabNavigatesBetweenWidgets()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -550,11 +551,11 @@ public class Hex1bTestSequenceTests
         cts.Cancel();
         await runTask;
         
-        Assert.Equal("First", text1);
-        Assert.Equal("Second", text2);
+        Assert.AreEqual("First", text1);
+        Assert.AreEqual("Second", text2);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ApplyAsync_WithoutAppRunning_DoesNotThrow()
     {
         using var workload = new Hex1bAppWorkloadAdapter();

--- a/tests/Hex1b.Tests/Hex1bTerminalScrollbackTests.cs
+++ b/tests/Hex1b.Tests/Hex1bTerminalScrollbackTests.cs
@@ -6,6 +6,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Integration tests for terminal scrollback buffer support.
 /// </summary>
+[TestClass]
 public class Hex1bTerminalScrollbackTests
 {
     private static Hex1bTerminal CreateTerminal(int width = 10, int height = 5, int scrollbackCapacity = 100, Action<ScrollbackRowEventArgs>? callback = null)
@@ -19,7 +20,7 @@ public class Hex1bTerminalScrollbackTests
         return builder.Build();
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollUp_CapturesRowInScrollback()
     {
         using var terminal = CreateTerminal(width: 10, height: 3);
@@ -27,18 +28,18 @@ public class Hex1bTerminalScrollbackTests
         // Fill 3 rows and then force a scroll by adding a 4th line
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("Line1\r\nLine2\r\nLine3\r\nLine4"));
 
-        Assert.NotNull(terminal.Scrollback);
-        Assert.Equal(1, terminal.Scrollback.Count);
+        Assert.IsNotNull(terminal.Scrollback);
+        Assert.AreEqual(1, terminal.Scrollback.Count);
 
         var lines = terminal.Scrollback.GetLines(1);
-        Assert.Equal("L", lines[0].Cells[0].Character);
-        Assert.Equal("i", lines[0].Cells[1].Character);
-        Assert.Equal("n", lines[0].Cells[2].Character);
-        Assert.Equal("e", lines[0].Cells[3].Character);
-        Assert.Equal("1", lines[0].Cells[4].Character);
+        Assert.AreEqual("L", lines[0].Cells[0].Character);
+        Assert.AreEqual("i", lines[0].Cells[1].Character);
+        Assert.AreEqual("n", lines[0].Cells[2].Character);
+        Assert.AreEqual("e", lines[0].Cells[3].Character);
+        Assert.AreEqual("1", lines[0].Cells[4].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollUp_MultipleRows_CapturesAllInOrder()
     {
         using var terminal = CreateTerminal(width: 10, height: 3);
@@ -46,14 +47,14 @@ public class Hex1bTerminalScrollbackTests
         // Write 5 lines into a 3-row terminal -> 2 rows scroll off
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("AAA\r\nBBB\r\nCCC\r\nDDD\r\nEEE"));
 
-        Assert.Equal(2, terminal.Scrollback!.Count);
+        Assert.AreEqual(2, terminal.Scrollback!.Count);
 
         var lines = terminal.Scrollback.GetLines(2);
-        Assert.Equal("A", lines[0].Cells[0].Character);
-        Assert.Equal("B", lines[1].Cells[0].Character);
+        Assert.AreEqual("A", lines[0].Cells[0].Character);
+        Assert.AreEqual("B", lines[1].Cells[0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollUp_InAlternateScreen_DoesNotCaptureScrollback()
     {
         using var terminal = CreateTerminal(width: 10, height: 3);
@@ -62,31 +63,31 @@ public class Hex1bTerminalScrollbackTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[?1049h"));
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("A\r\nB\r\nC\r\nD\r\nE"));
 
-        Assert.Equal(0, terminal.Scrollback!.Count);
+        Assert.AreEqual(0, terminal.Scrollback!.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollUp_ResumesAfterExitingAlternateScreen()
     {
         using var terminal = CreateTerminal(width: 10, height: 3);
 
         // Write some lines that scroll off in normal mode
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("X\r\nY\r\nZ\r\nW"));
-        Assert.Equal(1, terminal.Scrollback!.Count);
+        Assert.AreEqual(1, terminal.Scrollback!.Count);
 
         // Enter alternate screen — no scrollback
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[?1049h"));
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("A\r\nB\r\nC\r\nD"));
-        Assert.Equal(1, terminal.Scrollback.Count);
+        Assert.AreEqual(1, terminal.Scrollback.Count);
 
         // Exit alternate screen — scrollback resumes
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[?1049l"));
         // Original content restored (X, Y, Z, W from before) — scroll more
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\r\n\r\n\r\nQ"));
-        Assert.True(terminal.Scrollback.Count > 1);
+        Assert.IsTrue(terminal.Scrollback.Count > 1);
     }
 
-    [Fact]
+    [TestMethod]
     public void NoScrollback_WhenNotConfigured()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -98,24 +99,24 @@ public class Hex1bTerminalScrollbackTests
 
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("A\r\nB\r\nC\r\nD\r\nE"));
 
-        Assert.Null(terminal.Scrollback);
+        Assert.IsNull(terminal.Scrollback);
     }
 
-    [Fact]
+    [TestMethod]
     public void CSI3J_ClearsScrollbackBuffer()
     {
         using var terminal = CreateTerminal(width: 10, height: 3);
 
         // Scroll some lines off
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("A\r\nB\r\nC\r\nD\r\nE"));
-        Assert.True(terminal.Scrollback!.Count > 0);
+        Assert.IsTrue(terminal.Scrollback!.Count > 0);
 
         // Send CSI 3J (Erase Display with param 3)
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[3J"));
-        Assert.Equal(0, terminal.Scrollback.Count);
+        Assert.AreEqual(0, terminal.Scrollback.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Callback_InvokedWhenRowScrollsOff()
     {
         var callbackRows = new List<ScrollbackRowEventArgs>();
@@ -125,13 +126,13 @@ public class Hex1bTerminalScrollbackTests
 
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("AAA\r\nBBB\r\nCCC\r\nDDD"));
 
-        Assert.Single(callbackRows);
-        Assert.Equal(10, callbackRows[0].OriginalWidth);
-        Assert.Same(terminal, callbackRows[0].Terminal);
-        Assert.Equal("A", callbackRows[0].Cells.Span[0].Character);
+        TestSeq.Single(callbackRows);
+        Assert.AreEqual(10, callbackRows[0].OriginalWidth);
+        Assert.AreSame(terminal, callbackRows[0].Terminal);
+        Assert.AreEqual("A", callbackRows[0].Cells.Span[0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Callback_ReceivesMultipleRows()
     {
         var callbackRows = new List<ScrollbackRowEventArgs>();
@@ -141,12 +142,12 @@ public class Hex1bTerminalScrollbackTests
 
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("A\r\nB\r\nC\r\nD\r\nE"));
 
-        Assert.Equal(2, callbackRows.Count);
-        Assert.Equal("A", callbackRows[0].Cells.Span[0].Character);
-        Assert.Equal("B", callbackRows[1].Cells.Span[0].Character);
+        Assert.AreEqual(2, callbackRows.Count);
+        Assert.AreEqual("A", callbackRows[0].Cells.Span[0].Character);
+        Assert.AreEqual("B", callbackRows[1].Cells.Span[0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Snapshot_WithScrollbackLines_IncludesHistory()
     {
         using var terminal = CreateTerminal(width: 10, height: 3);
@@ -158,20 +159,20 @@ public class Hex1bTerminalScrollbackTests
         using var snapshot = terminal.CreateSnapshot(scrollbackLines: 2);
 
         // Total height = 2 scrollback + 3 visible
-        Assert.Equal(5, snapshot.Height);
-        Assert.Equal(2, snapshot.ScrollbackLineCount);
+        Assert.AreEqual(5, snapshot.Height);
+        Assert.AreEqual(2, snapshot.ScrollbackLineCount);
 
         // First two rows should be scrollback (AAA, BBB)
-        Assert.Equal("A", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("B", snapshot.GetCell(0, 1).Character);
+        Assert.AreEqual("A", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("B", snapshot.GetCell(0, 1).Character);
 
         // Visible area follows
-        Assert.Equal("C", snapshot.GetCell(0, 2).Character);
-        Assert.Equal("D", snapshot.GetCell(0, 3).Character);
-        Assert.Equal("E", snapshot.GetCell(0, 4).Character);
+        Assert.AreEqual("C", snapshot.GetCell(0, 2).Character);
+        Assert.AreEqual("D", snapshot.GetCell(0, 3).Character);
+        Assert.AreEqual("E", snapshot.GetCell(0, 4).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Snapshot_WithScrollbackLines_Zero_EqualsDefaultSnapshot()
     {
         using var terminal = CreateTerminal(width: 10, height: 3);
@@ -181,12 +182,12 @@ public class Hex1bTerminalScrollbackTests
         using var defaultSnapshot = terminal.CreateSnapshot();
         using var withZero = terminal.CreateSnapshot(scrollbackLines: 0);
 
-        Assert.Equal(defaultSnapshot.Width, withZero.Width);
-        Assert.Equal(defaultSnapshot.Height, withZero.Height);
-        Assert.Equal(0, withZero.ScrollbackLineCount);
+        Assert.AreEqual(defaultSnapshot.Width, withZero.Width);
+        Assert.AreEqual(defaultSnapshot.Height, withZero.Height);
+        Assert.AreEqual(0, withZero.ScrollbackLineCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void Snapshot_WithScrollbackWidth_CurrentTerminal_TruncatesToTerminalWidth()
     {
         using var terminal = CreateTerminal(width: 10, height: 3);
@@ -200,10 +201,10 @@ public class Hex1bTerminalScrollbackTests
         using var snapshot = terminal.CreateSnapshot(scrollbackLines: 1, scrollbackWidth: ScrollbackWidth.CurrentTerminal);
 
         // Snapshot width should be the current terminal width (5)
-        Assert.Equal(5, snapshot.Width);
+        Assert.AreEqual(5, snapshot.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void Snapshot_WithScrollbackWidth_Original_PreservesOriginalWidth()
     {
         using var terminal = CreateTerminal(width: 10, height: 3);
@@ -217,10 +218,10 @@ public class Hex1bTerminalScrollbackTests
         using var snapshot = terminal.CreateSnapshot(scrollbackLines: 1, scrollbackWidth: ScrollbackWidth.Original);
 
         // Snapshot width should be max of original scrollback width (10) and current terminal width (5)
-        Assert.Equal(10, snapshot.Width);
+        Assert.AreEqual(10, snapshot.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void Snapshot_VoidCell_FillsGapsWithSpecifiedCell()
     {
         using var terminal = CreateTerminal(width: 10, height: 3);
@@ -238,11 +239,11 @@ public class Hex1bTerminalScrollbackTests
             voidCell: voidCell);
 
         // Visible area is 5 wide, snapshot is 10 wide — columns 5-9 in visible rows should be void cell
-        Assert.Equal("·", snapshot.GetCell(5, snapshot.ScrollbackLineCount).Character);
-        Assert.Equal("·", snapshot.GetCell(9, snapshot.ScrollbackLineCount).Character);
+        Assert.AreEqual("·", snapshot.GetCell(5, snapshot.ScrollbackLineCount).Character);
+        Assert.AreEqual("·", snapshot.GetCell(9, snapshot.ScrollbackLineCount).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Snapshot_VoidCell_DefaultsToEmpty()
     {
         using var terminal = CreateTerminal(width: 10, height: 3);
@@ -255,10 +256,10 @@ public class Hex1bTerminalScrollbackTests
             scrollbackLines: 1,
             scrollbackWidth: ScrollbackWidth.Original);
 
-        Assert.Equal(" ", snapshot.GetCell(5, snapshot.ScrollbackLineCount).Character);
+        Assert.AreEqual(" ", snapshot.GetCell(5, snapshot.ScrollbackLineCount).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Snapshot_NoScrollbackConfigured_IgnoresScrollbackLines()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -272,25 +273,25 @@ public class Hex1bTerminalScrollbackTests
 
         // Even though we request scrollback lines, none are available
         using var snapshot = terminal.CreateSnapshot(scrollbackLines: 10);
-        Assert.Equal(3, snapshot.Height);
-        Assert.Equal(0, snapshot.ScrollbackLineCount);
+        Assert.AreEqual(3, snapshot.Height);
+        Assert.AreEqual(0, snapshot.ScrollbackLineCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void WithScrollback_ThrowsForZeroCapacity()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
             Hex1bTerminal.CreateBuilder().WithScrollback(0));
     }
 
-    [Fact]
+    [TestMethod]
     public void WithScrollback_ThrowsForNegativeCapacity()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() =>
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
             Hex1bTerminal.CreateBuilder().WithScrollback(-5));
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollbackRow_PreservesOriginalWidth()
     {
         using var terminal = CreateTerminal(width: 10, height: 3);
@@ -298,10 +299,10 @@ public class Hex1bTerminalScrollbackTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("A\r\nB\r\nC\r\nD"));
 
         var lines = terminal.Scrollback!.GetLines(1);
-        Assert.Equal(10, lines[0].OriginalWidth);
+        Assert.AreEqual(10, lines[0].OriginalWidth);
     }
 
-    [Fact]
+    [TestMethod]
     public void PartialScrollRegion_DoesNotCaptureScrollback()
     {
         using var terminal = CreateTerminal(width: 10, height: 5);
@@ -314,6 +315,6 @@ public class Hex1bTerminalScrollbackTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("A\r\nB\r\nC\r\nD\r\nE"));
 
         // Should not capture to scrollback since scroll region doesn't start at row 0
-        Assert.Equal(0, terminal.Scrollback!.Count);
+        Assert.AreEqual(0, terminal.Scrollback!.Count);
     }
 }

--- a/tests/Hex1b.Tests/Hex1bTerminalTests.cs
+++ b/tests/Hex1b.Tests/Hex1bTerminalTests.cs
@@ -8,6 +8,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for the Hex1bTerminal virtual terminal emulator.
 /// </summary>
+[TestClass]
 public class Hex1bTerminalTests
 {
     private sealed class QueuedInputPresentationAdapter : IHex1bTerminalPresentationAdapter
@@ -312,18 +313,18 @@ public class Hex1bTerminalTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Constructor_InitializesWithCorrectDimensions()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
 
         using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
         
-        Assert.Equal(80, terminal.Width);
-        Assert.Equal(24, terminal.Height);
+        Assert.AreEqual(80, terminal.Width);
+        Assert.AreEqual(24, terminal.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Constructor_InitializesWithEmptyScreen()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -331,10 +332,10 @@ public class Hex1bTerminalTests
         using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(10, 5).Build();
         
         var line = terminal.CreateSnapshot().GetLineTrimmed(0);
-        Assert.Equal("", line);
+        Assert.AreEqual("", line);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Constructor_WithResizedTerminalWidgetHandle_UsesHandleDimensionsForInitialWorkloadResize()
     {
         await using var presentation = new TerminalWidgetHandle(80, 24);
@@ -350,13 +351,13 @@ public class Hex1bTerminalTests
             Height = 24
         });
 
-        Assert.Equal(132, terminal.Width);
-        Assert.Equal(41, terminal.Height);
-        Assert.Equal(132, workload.ResizeWidth);
-        Assert.Equal(41, workload.ResizeHeight);
+        Assert.AreEqual(132, terminal.Width);
+        Assert.AreEqual(41, terminal.Height);
+        Assert.AreEqual(132, workload.ResizeWidth);
+        Assert.AreEqual(41, workload.ResizeHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void Dispose_SynchronouslyDisposesPresentationAndWorkload()
     {
         var presentation = new RecordingDisposePresentationAdapter();
@@ -372,11 +373,11 @@ public class Hex1bTerminalTests
 
         terminal.Dispose();
 
-        Assert.True(presentation.DisposeAsyncCalled);
-        Assert.True(workload.DisposeAsyncCalled);
+        Assert.IsTrue(presentation.DisposeAsyncCalled);
+        Assert.IsTrue(workload.DisposeAsyncCalled);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Write_PlacesTextAtCursor()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -391,14 +392,14 @@ public class Hex1bTerminalTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.Equal("Hello", snapshot.GetLineTrimmed(0));
-        Assert.Equal(5, snapshot.CursorX);
-        Assert.Equal(0, snapshot.CursorY);
+        Assert.AreEqual("Hello", snapshot.GetLineTrimmed(0));
+        Assert.AreEqual(5, snapshot.CursorX);
+        Assert.AreEqual(0, snapshot.CursorY);
     }
 
-    [Theory]
-    [InlineData("\x1b_Gi=123", ";OK\x1b\\")]
-    [InlineData("\x1b_Gi=123;OK\x1b", "\\")]
+    [TestMethod]
+    [DataRow("\x1b_Gi=123", ";OK\x1b\\")]
+    [DataRow("\x1b_Gi=123;OK\x1b", "\\")]
     public async Task PresentationInput_SplitKgpResponse_DoesNotEmitEscapeKeyEvent(string firstChunk, string secondChunk)
     {
         await using var presentation = new QueuedInputPresentationAdapter();
@@ -418,14 +419,14 @@ public class Hex1bTerminalTests
         var evt = await workload.InputEvents.ReadAsync(TestContext.Current.CancellationToken).AsTask()
             .WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        var keyEvent = Assert.IsType<Hex1bKeyEvent>(evt);
-        Assert.Equal(Hex1bKey.A, keyEvent.Key);
-        Assert.Equal("a", keyEvent.Text);
-        Assert.Equal(Hex1bModifiers.None, keyEvent.Modifiers);
-        Assert.False(workload.InputEvents.TryRead(out _));
+        var keyEvent = TestSeq.IsType<Hex1bKeyEvent>(evt);
+        Assert.AreEqual(Hex1bKey.A, keyEvent.Key);
+        Assert.AreEqual("a", keyEvent.Text);
+        Assert.AreEqual(Hex1bModifiers.None, keyEvent.Modifiers);
+        Assert.IsFalse(workload.InputEvents.TryRead(out _));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PresentationInput_SplitSs3Sequence_DoesNotEmitAltKeyEvent()
     {
         await using var presentation = new QueuedInputPresentationAdapter();
@@ -444,13 +445,13 @@ public class Hex1bTerminalTests
         var evt = await workload.InputEvents.ReadAsync(TestContext.Current.CancellationToken).AsTask()
             .WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
-        var keyEvent = Assert.IsType<Hex1bKeyEvent>(evt);
-        Assert.Equal(Hex1bKey.UpArrow, keyEvent.Key);
-        Assert.Equal(Hex1bModifiers.None, keyEvent.Modifiers);
-        Assert.False(workload.InputEvents.TryRead(out _));
+        var keyEvent = TestSeq.IsType<Hex1bKeyEvent>(evt);
+        Assert.AreEqual(Hex1bKey.UpArrow, keyEvent.Key);
+        Assert.AreEqual(Hex1bModifiers.None, keyEvent.Modifiers);
+        Assert.IsFalse(workload.InputEvents.TryRead(out _));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RunAsync_WhenPresentationInputPumpThrows_SurfacesTheFailure()
     {
         await using var presentation = new ThrowingInputPresentationAdapter(
@@ -464,15 +465,14 @@ public class Hex1bTerminalTests
             Height = 24
         });
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => terminal.RunAsync(TestContext.Current.CancellationToken));
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => terminal.RunAsync(TestContext.Current.CancellationToken));
 
         Assert.Contains("presentation input", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.NotNull(ex.InnerException);
+        Assert.IsNotNull(ex.InnerException);
         Assert.Contains("synthetic input failure", ex.InnerException!.Message);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RunAsync_WhenWorkloadWriteInputThrows_SurfacesTheFailure()
     {
         await using var presentation = new QueuedInputPresentationAdapter();
@@ -488,15 +488,14 @@ public class Hex1bTerminalTests
 
         presentation.EnqueueInput("x");
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => terminal.RunAsync(TestContext.Current.CancellationToken));
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => terminal.RunAsync(TestContext.Current.CancellationToken));
 
         Assert.Contains("presentation input", ex.Message, StringComparison.OrdinalIgnoreCase);
-        Assert.NotNull(ex.InnerException);
+        Assert.IsNotNull(ex.InnerException);
         Assert.Contains("synthetic shim send failure", ex.InnerException!.Message);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RunAsync_WhenCursorPositionResponseOverlapsTyping_SerializesWorkloadWrites()
     {
         await using var presentation = new QueuedInputPresentationAdapter();
@@ -517,19 +516,19 @@ public class Hex1bTerminalTests
         await workload.WaitForTwoWritesAsync()
             .WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
 
-        Assert.False(workload.ConcurrentWriteDetected);
+        Assert.IsFalse(workload.ConcurrentWriteDetected);
 
         var writes = workload.Writes;
-        Assert.Contains(writes, write => write.StartsWith("\x1b[", StringComparison.Ordinal) && write.EndsWith("R", StringComparison.Ordinal));
-        Assert.Contains(writes, write => write.Contains("abc", StringComparison.Ordinal));
+        Assert.IsTrue(writes.Any(write => write.StartsWith("\x1b[", StringComparison.Ordinal) && write.EndsWith("R", StringComparison.Ordinal)));
+        Assert.IsTrue(writes.Any(write => write.Contains("abc", StringComparison.Ordinal)));
 
         cts.Cancel();
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await runTask);
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await runTask);
     }
 
-    [Theory]
-    [InlineData("\x1b_Gi=123", ";OK\x1b\\")]
-    [InlineData("\x1b_Gi=123;OK\x1b", "\\")]
+    [TestMethod]
+    [DataRow("\x1b_Gi=123", ";OK\x1b\\")]
+    [DataRow("\x1b_Gi=123;OK\x1b", "\\")]
     public async Task AppInput_SplitKgpResponse_DoesNotTriggerEscapeBinding(string firstChunk, string secondChunk)
     {
         await using var presentation = new QueuedInputPresentationAdapter();
@@ -594,14 +593,14 @@ public class Hex1bTerminalTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.False(escapeTriggered);
-        Assert.True(snapshot.ContainsText("Normal key handled"));
+        Assert.IsFalse(escapeTriggered);
+        Assert.IsTrue(snapshot.ContainsText("Normal key handled"));
 
         cts.Cancel();
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PresentationInput_BareEscape_FlushedAfterTimeout()
     {
         await using var presentation = new QueuedInputPresentationAdapter();
@@ -621,12 +620,12 @@ public class Hex1bTerminalTests
         var evt = await workload.InputEvents.ReadAsync(TestContext.Current.CancellationToken).AsTask()
             .WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
 
-        var keyEvent = Assert.IsType<Hex1bKeyEvent>(evt);
-        Assert.Equal(Hex1bKey.Escape, keyEvent.Key);
-        Assert.Equal(Hex1bModifiers.None, keyEvent.Modifiers);
+        var keyEvent = TestSeq.IsType<Hex1bKeyEvent>(evt);
+        Assert.AreEqual(Hex1bKey.Escape, keyEvent.Key);
+        Assert.AreEqual(Hex1bModifiers.None, keyEvent.Modifiers);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PresentationInput_DoubleEscape_DoesNotKillEventPump()
     {
         await using var presentation = new QueuedInputPresentationAdapter();
@@ -652,15 +651,15 @@ public class Hex1bTerminalTests
         {
             var evt = await workload.InputEvents.ReadAsync(TestContext.Current.CancellationToken).AsTask()
                 .WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
-            events.Add(Assert.IsType<Hex1bKeyEvent>(evt));
+            events.Add(TestSeq.IsType<Hex1bKeyEvent>(evt));
         }
 
-        Assert.Equal(Hex1bKey.Escape, events[0].Key);
-        Assert.Equal(Hex1bKey.Escape, events[1].Key);
-        Assert.Equal(Hex1bKey.A, events[2].Key);
+        Assert.AreEqual(Hex1bKey.Escape, events[0].Key);
+        Assert.AreEqual(Hex1bKey.Escape, events[1].Key);
+        Assert.AreEqual(Hex1bKey.A, events[2].Key);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PresentationInput_CustomEscapeTimeout_UsesConfiguredValue()
     {
         await using var presentation = new QueuedInputPresentationAdapter();
@@ -679,11 +678,11 @@ public class Hex1bTerminalTests
         var evt = await workload.InputEvents.ReadAsync(TestContext.Current.CancellationToken).AsTask()
             .WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
 
-        var keyEvent = Assert.IsType<Hex1bKeyEvent>(evt);
-        Assert.Equal(Hex1bKey.Escape, keyEvent.Key);
+        var keyEvent = TestSeq.IsType<Hex1bKeyEvent>(evt);
+        Assert.AreEqual(Hex1bKey.Escape, keyEvent.Key);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PresentationInput_ZeroEscapeTimeout_DisablesFlush()
     {
         await using var presentation = new QueuedInputPresentationAdapter();
@@ -704,8 +703,7 @@ public class Hex1bTerminalTests
         await Task.Delay(150);
 
         // No event should have been dispatched
-        Assert.False(workload.InputEvents.TryRead(out _),
-            "With EscapeSequenceTimeout=Zero, bare ESC should stay buffered");
+        Assert.IsFalse(workload.InputEvents.TryRead(out _), "With EscapeSequenceTimeout=Zero, bare ESC should stay buffered");
 
         // Sending a continuation byte should produce the combined sequence (Alt+A)
         presentation.EnqueueInput("a");
@@ -713,12 +711,12 @@ public class Hex1bTerminalTests
         var evt = await workload.InputEvents.ReadAsync(TestContext.Current.CancellationToken).AsTask()
             .WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
 
-        var keyEvent = Assert.IsType<Hex1bKeyEvent>(evt);
-        Assert.Equal(Hex1bKey.A, keyEvent.Key);
-        Assert.Equal(Hex1bModifiers.Alt, keyEvent.Modifiers);
+        var keyEvent = TestSeq.IsType<Hex1bKeyEvent>(evt);
+        Assert.AreEqual(Hex1bKey.A, keyEvent.Key);
+        Assert.AreEqual(Hex1bModifiers.Alt, keyEvent.Modifiers);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AppInput_BareEscape_TriggersEscapeBinding()
     {
         await using var presentation = new QueuedInputPresentationAdapter();
@@ -768,13 +766,13 @@ public class Hex1bTerminalTests
 
         await escapeTriggered.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
 
-        Assert.True(escapeTriggered.Task.IsCompletedSuccessfully, "Escape binding should have fired from bare \\x1b");
+        Assert.IsTrue(escapeTriggered.Task.IsCompletedSuccessfully, "Escape binding should have fired from bare \\x1b");
 
         cts.Cancel();
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Write_HandlesNewlines()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -790,12 +788,12 @@ public class Hex1bTerminalTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.Equal("Line1", snapshot.GetLineTrimmed(0));
-        Assert.Equal("Line2", snapshot.GetLineTrimmed(1));
-        Assert.Equal("Line3", snapshot.GetLineTrimmed(2));
+        Assert.AreEqual("Line1", snapshot.GetLineTrimmed(0));
+        Assert.AreEqual("Line2", snapshot.GetLineTrimmed(1));
+        Assert.AreEqual("Line3", snapshot.GetLineTrimmed(2));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Write_WrapsAtEndOfLine()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -810,11 +808,11 @@ public class Hex1bTerminalTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.Equal("Hello", snapshot.GetLineTrimmed(0));
-        Assert.Equal("World", snapshot.GetLineTrimmed(1));
+        Assert.AreEqual("Hello", snapshot.GetLineTrimmed(0));
+        Assert.AreEqual("World", snapshot.GetLineTrimmed(1));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Clear_ResetsScreenAndCursor()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -833,12 +831,12 @@ public class Hex1bTerminalTests
             .Build()
             .ApplyAsync(terminal);
         
-        Assert.Equal("", terminal.CreateSnapshot().GetLineTrimmed(0));
-        Assert.Equal(0, terminal.CreateSnapshot().CursorX);
-        Assert.Equal(0, terminal.CreateSnapshot().CursorY);
+        Assert.AreEqual("", terminal.CreateSnapshot().GetLineTrimmed(0));
+        Assert.AreEqual(0, terminal.CreateSnapshot().CursorX);
+        Assert.AreEqual(0, terminal.CreateSnapshot().CursorY);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SetCursorPosition_MovesCursor()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -855,10 +853,10 @@ public class Hex1bTerminalTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         var line = snapshot.GetLine(2);
-        Assert.Equal('X', line[5]);
+        Assert.AreEqual('X', line[5]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SetCursorPosition_ClampsToBounds()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -871,25 +869,25 @@ public class Hex1bTerminalTests
             .Build()
             .ApplyAsync(terminal);
         
-        Assert.Equal(9, terminal.CreateSnapshot().CursorX);
-        Assert.Equal(4, terminal.CreateSnapshot().CursorY);
+        Assert.AreEqual(9, terminal.CreateSnapshot().CursorX);
+        Assert.AreEqual(4, terminal.CreateSnapshot().CursorY);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task EnterAlternateScreen_SetsFlag()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
 
         using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(20, 5).Build();
         
-        Assert.False(terminal.CreateSnapshot().InAlternateScreen);
+        Assert.IsFalse(terminal.CreateSnapshot().InAlternateScreen);
         
         terminal.EnterAlternateScreen();
         
-        Assert.True(terminal.CreateSnapshot().InAlternateScreen);
+        Assert.IsTrue(terminal.CreateSnapshot().InAlternateScreen);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ExitAlternateScreen_ClearsFlag()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -899,10 +897,10 @@ public class Hex1bTerminalTests
         
         terminal.ExitAlternateScreen();
         
-        Assert.False(terminal.CreateSnapshot().InAlternateScreen);
+        Assert.IsFalse(terminal.CreateSnapshot().InAlternateScreen);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ContainsText_FindsText()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -916,11 +914,11 @@ public class Hex1bTerminalTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.True(snapshot.ContainsText("World"));
-        Assert.False(snapshot.ContainsText("Foo"));
+        Assert.IsTrue(snapshot.ContainsText("World"));
+        Assert.IsFalse(snapshot.ContainsText("Foo"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindText_ReturnsPositions()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -937,12 +935,12 @@ public class Hex1bTerminalTests
         
         var results = snapshot.FindText("Hello");
         
-        Assert.Equal(2, results.Count);
-        Assert.Equal((0, 0), results[0]); // (Line, Column) = row 0, col 0
-        Assert.Equal((1, 0), results[1]); // (Line, Column) = row 1, col 0
+        Assert.AreEqual(2, results.Count);
+        Assert.AreEqual((0, 0), results[0]); // (Line, Column) = row 0, col 0
+        Assert.AreEqual((1, 0), results[1]); // (Line, Column) = row 1, col 0
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetNonEmptyLines_FiltersEmptyLines()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -959,12 +957,12 @@ public class Hex1bTerminalTests
         
         var lines = snapshot.GetNonEmptyLines().ToList();
         
-        Assert.Equal(2, lines.Count);
-        Assert.Equal("Line 1", lines[0]);
-        Assert.Equal("Line 3", lines[1]);
+        Assert.AreEqual(2, lines.Count);
+        Assert.AreEqual("Line 1", lines[0]);
+        Assert.AreEqual("Line 3", lines[1]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Resize_PreservesContent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -979,12 +977,12 @@ public class Hex1bTerminalTests
         
         terminal.Resize(40, 10);
         
-        Assert.Equal(40, terminal.Width);
-        Assert.Equal(10, terminal.Height);
-        Assert.Equal("Hello", terminal.CreateSnapshot().GetLineTrimmed(0));
+        Assert.AreEqual(40, terminal.Width);
+        Assert.AreEqual(10, terminal.Height);
+        Assert.AreEqual("Hello", terminal.CreateSnapshot().GetLineTrimmed(0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AnsiSequences_AreProcessedButNotDisplayed()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -999,10 +997,10 @@ public class Hex1bTerminalTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.Equal("Red Text", snapshot.GetLineTrimmed(0));
+        Assert.AreEqual("Red Text", snapshot.GetLineTrimmed(0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AnsiCursorPosition_MovesCursor()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1019,10 +1017,10 @@ public class Hex1bTerminalTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         var line = snapshot.GetLine(1); // 0-based
-        Assert.Equal('X', line[4]); // 0-based
+        Assert.AreEqual('X', line[4]); // 0-based
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AnsiClearScreen_ClearsBuffer()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1041,10 +1039,10 @@ public class Hex1bTerminalTests
             .Build()
             .ApplyAsync(terminal);
         
-        Assert.Equal("", terminal.CreateSnapshot().GetLineTrimmed(0));
+        Assert.AreEqual("", terminal.CreateSnapshot().GetLineTrimmed(0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetScreenBuffer_ReturnsCopyWithColors()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1059,14 +1057,14 @@ public class Hex1bTerminalTests
         
         var buffer = terminal.GetScreenBuffer();
         
-        Assert.Equal("R", buffer[0, 0].Character);
-        Assert.NotNull(buffer[0, 0].Foreground);
-        Assert.Equal(255, buffer[0, 0].Foreground!.Value.R);
-        Assert.Equal(0, buffer[0, 0].Foreground!.Value.G);
-        Assert.Equal(0, buffer[0, 0].Foreground!.Value.B);
+        Assert.AreEqual("R", buffer[0, 0].Character);
+        Assert.IsNotNull(buffer[0, 0].Foreground);
+        Assert.AreEqual(255, buffer[0, 0].Foreground!.Value.R);
+        Assert.AreEqual(0, buffer[0, 0].Foreground!.Value.G);
+        Assert.AreEqual(0, buffer[0, 0].Foreground!.Value.B);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AlternateScreenAnsiSequence_IsRecognized()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1078,33 +1076,33 @@ public class Hex1bTerminalTests
             .WaitUntil(s => s.InAlternateScreen, TimeSpan.FromSeconds(5))
             .Build()
             .ApplyAsync(terminal);
-        Assert.True(terminal.CreateSnapshot().InAlternateScreen);
+        Assert.IsTrue(terminal.CreateSnapshot().InAlternateScreen);
         
         workload.Write("\x1b[?1049l");
         await new Hex1bTerminalInputSequenceBuilder()
             .WaitUntil(s => !s.InAlternateScreen, TimeSpan.FromSeconds(5))
             .Build()
             .ApplyAsync(terminal);
-        Assert.False(terminal.CreateSnapshot().InAlternateScreen);
+        Assert.IsFalse(terminal.CreateSnapshot().InAlternateScreen);
     }
 
     #region Resize Behavior
 
-    [Fact]
+    [TestMethod]
     public async Task Constructor_SetsWorkloadDimensions()
     {
         // Workload dimensions are 0x0 before terminal is created
         using var workload = new Hex1bAppWorkloadAdapter();
-        Assert.Equal(0, workload.Width);
-        Assert.Equal(0, workload.Height);
+        Assert.AreEqual(0, workload.Width);
+        Assert.AreEqual(0, workload.Height);
         
         // Terminal sets workload dimensions during construction
         using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
-        Assert.Equal(80, workload.Width);
-        Assert.Equal(24, workload.Height);
+        Assert.AreEqual(80, workload.Width);
+        Assert.AreEqual(24, workload.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Constructor_DoesNotFireResizeEvent()
     {
         // This is critical: the initial dimension setup should NOT fire a resize event
@@ -1114,10 +1112,10 @@ public class Hex1bTerminalTests
         
         // Try to read from input channel - should be empty (no resize event)
         var hasEvent = workload.InputEvents.TryRead(out var evt);
-        Assert.False(hasEvent, "Constructor should not fire a resize event");
+        Assert.IsFalse(hasEvent, "Constructor should not fire a resize event");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ResizeAsync_AfterInitialization_FiresResizeEvent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1128,14 +1126,14 @@ public class Hex1bTerminalTests
         
         // This should fire a resize event
         var hasEvent = workload.InputEvents.TryRead(out var evt);
-        Assert.True(hasEvent, "ResizeAsync after init should fire a resize event");
+        Assert.IsTrue(hasEvent, "ResizeAsync after init should fire a resize event");
         
-        var resizeEvent = Assert.IsType<Hex1bResizeEvent>(evt);
-        Assert.Equal(100, resizeEvent.Width);
-        Assert.Equal(30, resizeEvent.Height);
+        var resizeEvent = TestSeq.IsType<Hex1bResizeEvent>(evt);
+        Assert.AreEqual(100, resizeEvent.Width);
+        Assert.AreEqual(30, resizeEvent.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ResizeAsync_SameDimensions_DoesNotFireEvent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1146,7 +1144,7 @@ public class Hex1bTerminalTests
         
         // Should NOT fire event (no change)
         var hasEvent = workload.InputEvents.TryRead(out _);
-        Assert.False(hasEvent, "ResizeAsync with same dimensions should not fire event");
+        Assert.IsFalse(hasEvent, "ResizeAsync with same dimensions should not fire event");
     }
 
     #endregion

--- a/tests/Hex1b.Tests/HexEditorSelectionTests.cs
+++ b/tests/Hex1b.Tests/HexEditorSelectionTests.cs
@@ -10,6 +10,7 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class HexEditorSelectionTests
 {
     private static Hex1bColor? ToCellColor(Hex1bColor color) => color.IsDefault ? null : color;
@@ -85,11 +86,11 @@ public class HexEditorSelectionTests
     // SECTION 1: Click cursor positioning — single byte selection
     // ═══════════════════════════════════════════════════════════
 
-    [Theory]
-    [InlineData(0)]
-    [InlineData(1)]
-    [InlineData(2)]
-    [InlineData(3)]
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(2)]
+    [DataRow(3)]
     public async Task Click_OnHexByte_PositionsCursorOnThatByte(int byteIndex)
     {
         // "ABCD" = 41 42 43 44 (all single-byte ASCII)
@@ -109,11 +110,11 @@ public class HexEditorSelectionTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(byteIndex, state.ByteCursorOffset);
-        Assert.Equal(byteIndex, state.Cursor.Position.Value); // ASCII = 1 byte per char
+        Assert.AreEqual(byteIndex, state.ByteCursorOffset);
+        Assert.AreEqual(byteIndex, state.Cursor.Position.Value); // ASCII = 1 byte per char
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Click_OnAsciiColumn_PositionsCursorOnCorrectByte()
     {
         // "ABCD" = 41 42 43 44, click on ASCII column for byte 2
@@ -137,17 +138,17 @@ public class HexEditorSelectionTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(2, state.ByteCursorOffset);
+        Assert.AreEqual(2, state.ByteCursorOffset);
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 2: Click on multi-byte characters — byte-level precision
     // ═══════════════════════════════════════════════════════════
 
-    [Theory]
-    [InlineData(0, 0)] // First byte of "é" (C3) → byte 0
-    [InlineData(1, 1)] // Second byte of "é" (A9) → byte 1
-    [InlineData(2, 2)] // "B" (42) → byte 2
+    [TestMethod]
+    [DataRow(0, 0)] // First byte of "é" (C3) → byte 0
+    [DataRow(1, 1)] // Second byte of "é" (A9) → byte 1
+    [DataRow(2, 2)] // "B" (42) → byte 2
     public async Task Click_OnMultiByteContent_SelectsCorrectByte(int byteIndex, int expectedByteOffset)
     {
         // "éB" = C3 A9 42 (3 bytes, 2 chars)
@@ -171,14 +172,14 @@ public class HexEditorSelectionTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(expectedByteOffset, state.ByteCursorOffset);
+        Assert.AreEqual(expectedByteOffset, state.ByteCursorOffset);
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 3: Arrow key navigation — byte-level movement
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public async Task ArrowRight_MovesOneByteAtATime_ThroughMultiByte()
     {
         // "é" = C3 A9 (2 bytes)
@@ -208,10 +209,10 @@ public class HexEditorSelectionTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(1, state.ByteCursorOffset);
+        Assert.AreEqual(1, state.ByteCursorOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ArrowLeft_MovesOneByteAtATime_ThroughMultiByte()
     {
         // "éB" = C3 A9 42 (3 bytes)
@@ -241,7 +242,7 @@ public class HexEditorSelectionTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(1, state.ByteCursorOffset);
+        Assert.AreEqual(1, state.ByteCursorOffset);
 
         // Left arrow to byte 0 (C3)
         var cursorAtByte0 = new CellPatternSearcher()
@@ -255,14 +256,14 @@ public class HexEditorSelectionTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(0, state.ByteCursorOffset);
+        Assert.AreEqual(0, state.ByteCursorOffset);
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 4: Shift+Arrow selection — byte-level selection
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public async Task ShiftRight_SelectsOneByteAtATime()
     {
         // "ABCD" = 41 42 43 44
@@ -292,11 +293,11 @@ public class HexEditorSelectionTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(state.Cursor.HasSelection);
-        Assert.Equal(1, state.ByteCursorOffset);
+        Assert.IsTrue(state.Cursor.HasSelection);
+        Assert.AreEqual(1, state.ByteCursorOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ShiftRight_MultiByte_MovesByteAndTracksOffset()
     {
         // "éB" = C3 A9 42 (3 bytes, 2 chars)
@@ -324,7 +325,7 @@ public class HexEditorSelectionTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(1, state.ByteCursorOffset);
+        Assert.AreEqual(1, state.ByteCursorOffset);
 
         // Shift+Right again — byte 2 = char 1 ('B'), now crosses char boundary = char-level selection
         await new Hex1bTerminalInputSequenceBuilder()
@@ -334,15 +335,15 @@ public class HexEditorSelectionTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(2, state.ByteCursorOffset);
-        Assert.True(state.Cursor.HasSelection, "selection should exist after crossing char boundary");
+        Assert.AreEqual(2, state.ByteCursorOffset);
+        Assert.IsTrue(state.Cursor.HasSelection, "selection should exist after crossing char boundary");
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 5: Click after navigation — ByteCursorOffset updates
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public async Task Click_AfterArrowNavigation_UpdatesByteCursorOffset()
     {
         // "ABCD" = 41 42 43 44
@@ -375,17 +376,17 @@ public class HexEditorSelectionTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(1, state.ByteCursorOffset);
+        Assert.AreEqual(1, state.ByteCursorOffset);
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 6: Invalid byte content — click and navigate
     // ═══════════════════════════════════════════════════════════
 
-    [Theory]
-    [InlineData(0)]
-    [InlineData(1)]
-    [InlineData(2)]
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(2)]
     public async Task Click_OnInvalidBytes_SelectsCorrectByte(int byteIndex)
     {
         // Raw invalid bytes: FE FF 80 (each 1 byte = 1 char)
@@ -410,10 +411,10 @@ public class HexEditorSelectionTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(byteIndex, state.ByteCursorOffset);
+        Assert.AreEqual(byteIndex, state.ByteCursorOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Navigate_ThroughInvalidBytes_VisitsEveryByte()
     {
         // FE FF 80 BF — 4 invalid bytes
@@ -443,14 +444,14 @@ public class HexEditorSelectionTests
                 .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         }
 
-        Assert.Equal(4, state.ByteCursorOffset);
+        Assert.AreEqual(4, state.ByteCursorOffset);
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 7: Hex input + cursor advance
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public async Task TypeHex_CommitsAndAdvancesToNextByte()
     {
         // "AB" = 41 42
@@ -480,15 +481,15 @@ public class HexEditorSelectionTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(1, state.ByteCursorOffset);
-        Assert.Equal(0xFF, state.Document.GetBytes().Span[0]);
+        Assert.AreEqual(1, state.ByteCursorOffset);
+        Assert.AreEqual(0xFF, state.Document.GetBytes().Span[0]);
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 8: Cursor highlight rendering — verify visual
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public async Task CursorHighlight_AppearOnBothHexAndAsciiColumns()
     {
         // "A" = 41 (1 byte)

--- a/tests/Hex1b.Tests/HexEditorViewRendererTests.cs
+++ b/tests/Hex1b.Tests/HexEditorViewRendererTests.cs
@@ -4,111 +4,112 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class HexEditorViewRendererTests
 {
     // ═══════════════════════════════════════════════════════════
     // SECTION 1: Layout calculation — fluid mode (no snap points)
     // ═══════════════════════════════════════════════════════════
 
-    [Theory]
-    [InlineData(15, 1)]   // Absolute minimum: "XXXXXXXX  XX  ." = 4*1+11=15
-    [InlineData(16, 1)]   // 1 byte still (4*2+11=19 needed for 2)
-    [InlineData(19, 2)]   // 4*2+11=19 → 2 bytes
-    [InlineData(22, 2)]   // 4*3+11=23 needed for 3
-    [InlineData(23, 3)]   // 4*3+11=23 → 3 bytes
-    [InlineData(27, 4)]   // 4*4+11=27 → 4 bytes
-    [InlineData(43, 8)]   // 4*8+11=43 → 8 bytes
-    [InlineData(75, 16)]  // 4*16+11=75 → 16 bytes
-    [InlineData(200, 16)] // Capped at MaxBytesPerRow=16
+    [TestMethod]
+    [DataRow(15, 1)]   // Absolute minimum: "XXXXXXXX  XX  ." = 4*1+11=15
+    [DataRow(16, 1)]   // 1 byte still (4*2+11=19 needed for 2)
+    [DataRow(19, 2)]   // 4*2+11=19 → 2 bytes
+    [DataRow(22, 2)]   // 4*3+11=23 needed for 3
+    [DataRow(23, 3)]   // 4*3+11=23 → 3 bytes
+    [DataRow(27, 4)]   // 4*4+11=27 → 4 bytes
+    [DataRow(43, 8)]   // 4*8+11=43 → 8 bytes
+    [DataRow(75, 16)]  // 4*16+11=75 → 16 bytes
+    [DataRow(200, 16)] // Capped at MaxBytesPerRow=16
     public void CalculateLayout_Fluid_ReturnsExpectedBytesPerRow(int width, int expectedBytes)
     {
         var renderer = new HexEditorViewRenderer(); // fluid (no snap points)
         var bytesPerRow = renderer.CalculateLayout(width);
 
-        Assert.Equal(expectedBytes, bytesPerRow);
+        Assert.AreEqual(expectedBytes, bytesPerRow);
     }
 
-    [Theory]
-    [InlineData(10)]  // Below absolute minimum (15)
-    [InlineData(14)]
+    [TestMethod]
+    [DataRow(10)]  // Below absolute minimum (15)
+    [DataRow(14)]
     public void CalculateLayout_BelowMinimum_Returns1Byte(int width)
     {
         var renderer = new HexEditorViewRenderer();
         var bytesPerRow = renderer.CalculateLayout(width);
-        Assert.Equal(1, bytesPerRow);
+        Assert.AreEqual(1, bytesPerRow);
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 2: Layout calculation — snap points
     // ═══════════════════════════════════════════════════════════
 
-    [Theory]
-    [InlineData(15, 1)]   // Only 1 fits → snap to 1
-    [InlineData(43, 8)]   // (43-11)/4=8 → snap to 8
-    [InlineData(44, 8)]   // still 8
-    [InlineData(75, 16)]  // (75-11)/4=16 → snap to 16
-    [InlineData(76, 16)]  // still 16
+    [TestMethod]
+    [DataRow(15, 1)]   // Only 1 fits → snap to 1
+    [DataRow(43, 8)]   // (43-11)/4=8 → snap to 8
+    [DataRow(44, 8)]   // still 8
+    [DataRow(75, 16)]  // (75-11)/4=16 → snap to 16
+    [DataRow(76, 16)]  // still 16
     public void CalculateLayout_StandardSnaps_SnapsCorrectly(int width, int expectedBytes)
     {
         var renderer = new HexEditorViewRenderer { SnapPoints = HexEditorViewRenderer.StandardSnaps };
         var bytesPerRow = renderer.CalculateLayout(width);
-        Assert.Equal(expectedBytes, bytesPerRow);
+        Assert.AreEqual(expectedBytes, bytesPerRow);
     }
 
-    [Theory]
-    [InlineData(15, 1)]
-    [InlineData(19, 2)]
-    [InlineData(23, 2)]   // 3 bytes fit but snap down to 2
-    [InlineData(27, 4)]   // 4*4+11=27
-    [InlineData(43, 8)]   // (43-11)/4=8 → snap to 8
-    [InlineData(44, 8)]
-    [InlineData(75, 16)]
+    [TestMethod]
+    [DataRow(15, 1)]
+    [DataRow(19, 2)]
+    [DataRow(23, 2)]   // 3 bytes fit but snap down to 2
+    [DataRow(27, 4)]   // 4*4+11=27
+    [DataRow(43, 8)]   // (43-11)/4=8 → snap to 8
+    [DataRow(44, 8)]
+    [DataRow(75, 16)]
     public void CalculateLayout_PowerOfTwoSnaps_SnapsCorrectly(int width, int expectedBytes)
     {
         var renderer = new HexEditorViewRenderer { SnapPoints = HexEditorViewRenderer.PowerOfTwoSnaps };
         var bytesPerRow = renderer.CalculateLayout(width);
-        Assert.Equal(expectedBytes, bytesPerRow);
+        Assert.AreEqual(expectedBytes, bytesPerRow);
     }
 
-    [Fact]
+    [TestMethod]
     public void CalculateLayout_CustomSnaps_RoundsToNearest()
     {
         var renderer = new HexEditorViewRenderer { SnapPoints = [1, 6, 12], MaxBytesPerRow = 12 };
         // width 35 → (35-11)/4=6 → snap to 6
         var bytes6 = renderer.CalculateLayout(35);
-        Assert.Equal(6, bytes6);
+        Assert.AreEqual(6, bytes6);
 
         // width 42 → (42-11)/4=7 → snap to 6 (7 > 6, 7 < 12)
         var bytes6b = renderer.CalculateLayout(42);
-        Assert.Equal(6, bytes6b);
+        Assert.AreEqual(6, bytes6b);
 
         // width 59 → (59-11)/4=12 → snap to 12
         var bytes12 = renderer.CalculateLayout(59);
-        Assert.Equal(12, bytes12);
+        Assert.AreEqual(12, bytes12);
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 3: Min/Max constraints
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void CalculateLayout_MinBytesPerRow_NeverGoesBelowMin()
     {
         var renderer = new HexEditorViewRenderer { MinBytesPerRow = 4 };
         // Even at narrow widths where only 2 fit, clamp to 4
         var bytesPerRow = renderer.CalculateLayout(19); // 2 bytes would fit
-        Assert.Equal(4, bytesPerRow);
+        Assert.AreEqual(4, bytesPerRow);
     }
 
-    [Fact]
+    [TestMethod]
     public void CalculateLayout_MaxBytesPerRow_CapsAtMax()
     {
         var renderer = new HexEditorViewRenderer { MaxBytesPerRow = 8 };
         var bytesPerRow = renderer.CalculateLayout(200); // 16+ would fit
-        Assert.Equal(8, bytesPerRow);
+        Assert.AreEqual(8, bytesPerRow);
     }
 
-    [Fact]
+    [TestMethod]
     public void CalculateLayout_SnapPointsWithMinMax_RespectsAll()
     {
         var renderer = new HexEditorViewRenderer
@@ -119,18 +120,18 @@ public class HexEditorViewRendererTests
         };
         // Very narrow: snap to 1, but min is 2 → 2
         var narrow = renderer.CalculateLayout(15);
-        Assert.Equal(2, narrow);
+        Assert.AreEqual(2, narrow);
 
         // Wide: would snap to 16, but max is 8 → 8
         var wide = renderer.CalculateLayout(200);
-        Assert.Equal(8, wide);
+        Assert.AreEqual(8, wide);
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 4: GetTotalLines depends on viewport width
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void GetTotalLines_WideViewport_FewerRows()
     {
         // 32 bytes of content
@@ -139,54 +140,53 @@ public class HexEditorViewRendererTests
 
         // At width 75 → 16 bytes/row → ceil(32/16)=2 rows
         var wideLines = renderer.GetTotalLines(doc, 75);
-        Assert.Equal(2, wideLines);
+        Assert.AreEqual(2, wideLines);
 
         // At width 43 → 8 bytes/row → ceil(32/8)=4 rows
         var narrowLines = renderer.GetTotalLines(doc, 43);
-        Assert.Equal(4, narrowLines);
+        Assert.AreEqual(4, narrowLines);
 
         // At width 15 → 1 byte/row → 32 rows
         var tinyLines = renderer.GetTotalLines(doc, 15);
-        Assert.Equal(32, tinyLines);
+        Assert.AreEqual(32, tinyLines);
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 5: GetMaxLineWidth never exceeds viewport (no h-scroll)
     // ═══════════════════════════════════════════════════════════
 
-    [Theory]
-    [InlineData(15)]
-    [InlineData(30)]
-    [InlineData(50)]
-    [InlineData(80)]
-    [InlineData(120)]
+    [TestMethod]
+    [DataRow(15)]
+    [DataRow(30)]
+    [DataRow(50)]
+    [DataRow(80)]
+    [DataRow(120)]
     public void GetMaxLineWidth_NeverExceedsViewportWidth(int viewportWidth)
     {
         var doc = new Hex1bDocument("Hello, World! This is a test of the hex editor.");
         var renderer = new HexEditorViewRenderer();
         var maxWidth = renderer.GetMaxLineWidth(doc, 1, 10, viewportWidth);
-        Assert.True(maxWidth <= viewportWidth,
-            $"Max line width {maxWidth} should not exceed viewport width {viewportWidth}");
+        Assert.IsTrue(maxWidth <= viewportWidth, $"Max line width {maxWidth} should not exceed viewport width {viewportWidth}");
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 6: Row format verification
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void CalculateLayout_MinimumWidth_ProducesExpectedFormat()
     {
         // "XXXXXXXX  XX  ." = 15 chars for 1 byte
         var renderer = new HexEditorViewRenderer();
         var bytesPerRow = renderer.CalculateLayout(15);
-        Assert.Equal(1, bytesPerRow);
+        Assert.AreEqual(1, bytesPerRow);
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 7: Fluid mode fills continuously
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void CalculateLayout_Fluid_BytesIncreaseGradually()
     {
         var renderer = new HexEditorViewRenderer();
@@ -194,12 +194,12 @@ public class HexEditorViewRendererTests
         for (int w = 15; w <= 80; w++)
         {
             var bytes = renderer.CalculateLayout(w);
-            Assert.True(bytes >= prev, $"Bytes should not decrease: was {prev} at width {w - 1}, got {bytes} at width {w}");
+            Assert.IsTrue(bytes >= prev, $"Bytes should not decrease: was {prev} at width {w - 1}, got {bytes} at width {w}");
             prev = bytes;
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void CalculateLayout_SnapPoints_BytesNeverBetweenSnaps()
     {
         var snaps = new[] { 1, 4, 8, 16 };
@@ -223,14 +223,14 @@ public class HexEditorViewRendererTests
         return (renderer, state);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandlesCharInput_IsTrue()
     {
         var renderer = new HexEditorViewRenderer();
-        Assert.True(renderer.HandlesCharInput);
+        Assert.IsTrue(renderer.HandlesCharInput);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleCharInput_FirstNibble_StoresPending()
     {
         var (renderer, state) = SetupHexInput("AB");
@@ -238,13 +238,13 @@ public class HexEditorViewRendererTests
 
         var consumed = renderer.HandleCharInput('4', state, ref nibble, 80);
 
-        Assert.True(consumed);
-        Assert.Equal('4', nibble);
+        Assert.IsTrue(consumed);
+        Assert.AreEqual('4', nibble);
         // Document unchanged — still "AB"
-        Assert.Equal("AB", state.Document.GetText());
+        Assert.AreEqual("AB", state.Document.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleCharInput_SecondNibble_CommitsByte()
     {
         var (renderer, state) = SetupHexInput("AB");
@@ -252,45 +252,45 @@ public class HexEditorViewRendererTests
 
         var consumed = renderer.HandleCharInput('A', state, ref nibble, 80);
 
-        Assert.True(consumed);
-        Assert.Null(nibble);
+        Assert.IsTrue(consumed);
+        Assert.IsNull(nibble);
         // Byte 0x4A = 'J' replaces 'A' at position 0, cursor advances to pos 1
-        Assert.Equal("JB", state.Document.GetText());
-        Assert.Equal(1, state.Cursor.Position.Value);
+        Assert.AreEqual("JB", state.Document.GetText());
+        Assert.AreEqual(1, state.Cursor.Position.Value);
     }
 
-    [Theory]
-    [InlineData('0')]
-    [InlineData('9')]
-    [InlineData('a')]
-    [InlineData('f')]
-    [InlineData('A')]
-    [InlineData('F')]
+    [TestMethod]
+    [DataRow('0')]
+    [DataRow('9')]
+    [DataRow('a')]
+    [DataRow('f')]
+    [DataRow('A')]
+    [DataRow('F')]
     public void HandleCharInput_HexChars_AreConsumed(char c)
     {
         var (renderer, state) = SetupHexInput("X");
         char? nibble = null;
 
-        Assert.True(renderer.HandleCharInput(c, state, ref nibble, 80));
-        Assert.Equal(c, nibble);
+        Assert.IsTrue(renderer.HandleCharInput(c, state, ref nibble, 80));
+        Assert.AreEqual(c, nibble);
     }
 
-    [Theory]
-    [InlineData('g')]
-    [InlineData('G')]
-    [InlineData('z')]
-    [InlineData(' ')]
-    [InlineData('!')]
+    [TestMethod]
+    [DataRow('g')]
+    [DataRow('G')]
+    [DataRow('z')]
+    [DataRow(' ')]
+    [DataRow('!')]
     public void HandleCharInput_NonHexChars_NotConsumed(char c)
     {
         var (renderer, state) = SetupHexInput("X");
         char? nibble = null;
 
-        Assert.False(renderer.HandleCharInput(c, state, ref nibble, 80));
-        Assert.Null(nibble);
+        Assert.IsFalse(renderer.HandleCharInput(c, state, ref nibble, 80));
+        Assert.IsNull(nibble);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleCharInput_NonHexChar_ClearsPendingNibble()
     {
         var (renderer, state) = SetupHexInput("X");
@@ -298,10 +298,10 @@ public class HexEditorViewRendererTests
 
         renderer.HandleCharInput('z', state, ref nibble, 80);
 
-        Assert.Null(nibble);
+        Assert.IsNull(nibble);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleCharInput_TwoNibbles_ProducesCorrectByteValue()
     {
         // 0xFF is not valid as a single UTF-8 byte → becomes replacement char
@@ -312,10 +312,10 @@ public class HexEditorViewRendererTests
         renderer.HandleCharInput('F', state, ref nibble, 80);
 
         // Single byte 0xFF is invalid UTF-8 → U+FFFD replacement
-        Assert.Equal('\uFFFD', state.Document.GetText()[0]);
+        Assert.AreEqual('\uFFFD', state.Document.GetText()[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleCharInput_AtEndOfDocument_InsertsNewByte()
     {
         var (renderer, state) = SetupHexInput("A");
@@ -327,10 +327,10 @@ public class HexEditorViewRendererTests
         renderer.HandleCharInput('2', state, ref nibble, 80);
 
         // 0x42 = 'B', appended after 'A'
-        Assert.Equal("AB", state.Document.GetText());
+        Assert.AreEqual("AB", state.Document.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleCharInput_CursorAdvancesAfterCommit()
     {
         var (renderer, state) = SetupHexInput("ABC");
@@ -339,17 +339,17 @@ public class HexEditorViewRendererTests
         // Edit first byte: 0x58 = 'X'
         renderer.HandleCharInput('5', state, ref nibble, 80);
         renderer.HandleCharInput('8', state, ref nibble, 80);
-        Assert.Equal(1, state.Cursor.Position.Value);
+        Assert.AreEqual(1, state.Cursor.Position.Value);
 
         // Edit second byte: 0x59 = 'Y'
         renderer.HandleCharInput('5', state, ref nibble, 80);
         renderer.HandleCharInput('9', state, ref nibble, 80);
-        Assert.Equal(2, state.Cursor.Position.Value);
+        Assert.AreEqual(2, state.Cursor.Position.Value);
 
-        Assert.Equal("XYC", state.Document.GetText());
+        Assert.AreEqual("XYC", state.Document.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleCharInput_LowercaseHex_WorksCorrectly()
     {
         // 0x41 = 'A' (valid ASCII byte)
@@ -359,10 +359,10 @@ public class HexEditorViewRendererTests
         renderer.HandleCharInput('4', state, ref nibble, 80);
         renderer.HandleCharInput('1', state, ref nibble, 80);
 
-        Assert.Equal('A', state.Document.GetText()[0]);
+        Assert.AreEqual('A', state.Document.GetText()[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleCharInput_ReadOnly_DoesNotConsume()
     {
         var (renderer, state) = SetupHexInput("X");
@@ -371,9 +371,9 @@ public class HexEditorViewRendererTests
 
         var consumed = renderer.HandleCharInput('4', state, ref nibble, 80);
 
-        Assert.False(consumed);
-        Assert.Null(nibble);
-        Assert.Equal("X", state.Document.GetText());
+        Assert.IsFalse(consumed);
+        Assert.IsNull(nibble);
+        Assert.AreEqual("X", state.Document.GetText());
     }
 
     // ═══════════════════════════════════════════════════════════
@@ -395,18 +395,18 @@ public class HexEditorViewRendererTests
         return node;
     }
 
-    [Fact]
+    [TestMethod]
     public void TextEditorRenderer_HandlesCharInput_IsFalse()
     {
         IEditorViewRenderer renderer = TextEditorViewRenderer.Instance;
-        Assert.False(renderer.HandlesCharInput);
+        Assert.IsFalse(renderer.HandlesCharInput);
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 10: Multi-byte byte-level editing
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void CommitByte_TwoByteChar_ReplacesFirstByte()
     {
         // © = C2 A9. Replace C2 with 41 → bytes become 41 A9.
@@ -420,10 +420,10 @@ public class HexEditorViewRendererTests
         var result = state.Document.GetText();
         // The bytes 41 A9 decoded as UTF-8: 'A' + invalid → "A\uFFFD"
         Assert.StartsWith("A", result);
-        Assert.Equal(2, result.Length); // 'A' + replacement char
+        Assert.AreEqual(2, result.Length); // 'A' + replacement char
     }
 
-    [Fact]
+    [TestMethod]
     public void CommitByte_TwoByteChar_ReplacesSecondByte()
     {
         // "A©" = bytes 41 C2 A9. Cursor at char 1 (©), byte offset = 1.
@@ -436,10 +436,10 @@ public class HexEditorViewRendererTests
         renderer.HandleCharInput('3', state, ref nibble, 80);
 
         // C3 A9 = é
-        Assert.Equal("Aé", state.Document.GetText());
+        Assert.AreEqual("Aé", state.Document.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void CommitByte_BOM_ReplaceFirstByte()
     {
         // BOM = EF BB BF. Replace EF with 00 → bytes 00 BB BF
@@ -451,11 +451,11 @@ public class HexEditorViewRendererTests
         renderer.HandleCharInput('0', state, ref nibble, 80);
 
         var result = state.Document.GetText();
-        Assert.Equal('\0', result[0]); // NUL byte
-        Assert.True(result.Length >= 2); // At least NUL + something from invalid bytes
+        Assert.AreEqual('\0', result[0]); // NUL byte
+        Assert.IsTrue(result.Length >= 2); // At least NUL + something from invalid bytes
     }
 
-    [Fact]
+    [TestMethod]
     public void CommitByte_AsciiChar_StillWorks()
     {
         // Verify ASCII editing still works with the new CommitByte
@@ -466,11 +466,11 @@ public class HexEditorViewRendererTests
         renderer.HandleCharInput('5', state, ref nibble, 80);
         renderer.HandleCharInput('8', state, ref nibble, 80);
 
-        Assert.Equal("XBC", state.Document.GetText());
-        Assert.Equal(1, state.Cursor.Position.Value); // Advanced past 'X'
+        Assert.AreEqual("XBC", state.Document.GetText());
+        Assert.AreEqual(1, state.Cursor.Position.Value); // Advanced past 'X'
     }
 
-    [Fact]
+    [TestMethod]
     public void CommitByte_ArbitraryByte_PreservedExactly()
     {
         // Typing 0xAA in the hex editor must produce exactly byte 0xAA in the document.
@@ -482,18 +482,18 @@ public class HexEditorViewRendererTests
         renderer.HandleCharInput('A', state, ref nibble, 80);
 
         var bytes = state.Document.GetBytes().ToArray();
-        Assert.Single(bytes);
-        Assert.Equal(0xAA, bytes[0]);
+        TestSeq.Single(bytes);
+        Assert.AreEqual(0xAA, bytes[0]);
     }
 
-    [Theory]
-    [InlineData(0x80)]  // Continuation byte
-    [InlineData(0xBF)]  // Continuation byte
-    [InlineData(0xC0)]  // Overlong
-    [InlineData(0xFE)]  // Invalid UTF-8
-    [InlineData(0xFF)]  // Invalid UTF-8
-    [InlineData(0x00)]  // Null byte
-    public void CommitByte_InvalidUtf8Byte_PreservedExactly(byte expected)
+    [TestMethod]
+    [DataRow(0x80)]  // Continuation byte
+    [DataRow(0xBF)]  // Continuation byte
+    [DataRow(0xC0)]  // Overlong
+    [DataRow(0xFE)]  // Invalid UTF-8
+    [DataRow(0xFF)]  // Invalid UTF-8
+    [DataRow(0x00)]  // Null byte
+    public void CommitByte_InvalidUtf8Byte_PreservedExactly(int expected)
     {
         var (renderer, state) = SetupHexInput("X");
         char? nibble = null;
@@ -504,11 +504,11 @@ public class HexEditorViewRendererTests
         renderer.HandleCharInput("0123456789ABCDEF"[lo], state, ref nibble, 80);
 
         var bytes = state.Document.GetBytes().ToArray();
-        Assert.Single(bytes);
-        Assert.Equal(expected, bytes[0]);
+        TestSeq.Single(bytes);
+        Assert.AreEqual((byte)expected, bytes[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void CommitByte_ByteAppendAtEnd_PreservedExactly()
     {
         // Append byte 0xAA at end of document
@@ -521,15 +521,15 @@ public class HexEditorViewRendererTests
         renderer.HandleCharInput('A', state, ref nibble, 80);
 
         var bytes = state.Document.GetBytes().ToArray();
-        Assert.Single(bytes);
-        Assert.Equal(0xAA, bytes[0]);
+        TestSeq.Single(bytes);
+        Assert.AreEqual(0xAA, bytes[0]);
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 11: HitTest with multi-byte characters
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void HitTest_ContinuationByte_MapsToSameChar()
     {
         // "©B" = bytes C2 A9 42. Clicking byte 1 (A9) should map to char 0 (©), not char 1
@@ -546,11 +546,11 @@ public class HexEditorViewRendererTests
         var hexCol1 = 10 + 3; // hex start (10) + 1 byte * 3 chars = col 13
         var result = renderer.HitTest(hexCol1, 0, state, 80, 10, 1, 0);
 
-        Assert.NotNull(result);
-        Assert.Equal(0, result.Value.Value); // Should map to char 0 (©), not char 1 (B)
+        Assert.IsNotNull(result);
+        Assert.AreEqual(0, result.Value.Value); // Should map to char 0 (©), not char 1 (B)
     }
 
-    [Fact]
+    [TestMethod]
     public void HitTest_BOMThirdByte_MapsToCharZero()
     {
         // "\uFEFFX" = bytes EF BB BF 58. Byte 2 (BF) should map to char 0 (BOM)
@@ -562,15 +562,15 @@ public class HexEditorViewRendererTests
         var hexCol2 = 9 + 6;
         var result = renderer.HitTest(hexCol2, 0, state, 80, 10, 1, 0);
 
-        Assert.NotNull(result);
-        Assert.Equal(0, result.Value.Value); // Char 0 (BOM), not char 2
+        Assert.IsNotNull(result);
+        Assert.AreEqual(0, result.Value.Value); // Char 0 (BOM), not char 2
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 12: Cross-editor resilience
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void SharedDoc_HexDeleteShrinks_TextEditorCursorClamped()
     {
         // Two EditorStates sharing one document
@@ -580,21 +580,21 @@ public class HexEditorViewRendererTests
 
         // Move text editor cursor to end
         textState.MoveToDocumentEnd();
-        Assert.Equal(11, textState.Cursor.Position.Value);
+        Assert.AreEqual(11, textState.Cursor.Position.Value);
 
         // Hex editor selects all and deletes (simulating via document)
         hexState.SelectAll();
         hexState.DeleteForward();
 
         // Document is now empty
-        Assert.Equal(0, doc.Length);
+        Assert.AreEqual(0, doc.Length);
 
         // Text editor clamps its cursor
         textState.ClampAllCursors();
-        Assert.Equal(0, textState.Cursor.Position.Value);
+        Assert.AreEqual(0, textState.Cursor.Position.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void SharedDoc_HexReplacesMultibyte_TextEditorSurvives()
     {
         // Document with BOM followed by text
@@ -606,7 +606,7 @@ public class HexEditorViewRendererTests
         textState.MoveCursor(CursorDirection.Right);
         textState.MoveCursor(CursorDirection.Right);
         textState.MoveCursor(CursorDirection.Right);
-        Assert.Equal(3, textState.Cursor.Position.Value);
+        Assert.AreEqual(3, textState.Cursor.Position.Value);
 
         // Hex editor replaces the BOM byte — this changes the BOM char
         // to potentially multiple replacement chars, shifting everything
@@ -620,19 +620,19 @@ public class HexEditorViewRendererTests
 
         // Cursor should still be valid (not throw)
         var pos = textState.Cursor.Position.Value;
-        Assert.True(pos >= 0 && pos <= doc.Length);
+        Assert.IsTrue(pos >= 0 && pos <= doc.Length);
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 13: Hex/ASCII column alignment
     // ═══════════════════════════════════════════════════════════
 
-    [Theory]
-    [InlineData(15)]    // 1 byte
-    [InlineData(19)]    // 2 bytes
-    [InlineData(27)]    // 4 bytes
-    [InlineData(43)]    // 8 bytes
-    [InlineData(75)]    // 16 bytes
+    [TestMethod]
+    [DataRow(15)]    // 1 byte
+    [DataRow(19)]    // 2 bytes
+    [DataRow(27)]    // 4 bytes
+    [DataRow(43)]    // 8 bytes
+    [DataRow(75)]    // 16 bytes
     public void ColumnMapping_AsciiColumnMatchesRenderedPosition(int viewportWidth)
     {
         var renderer = new HexEditorViewRenderer();
@@ -662,13 +662,11 @@ public class HexEditorViewRendererTests
             // Hex cell should contain the byte value
             var expectedHex = i.ToString("X2");
             var actualHex = line.Substring(hexCol, 2);
-            Assert.True(expectedHex == actualHex,
-                $"Byte {i}: hex at col {hexCol} should be '{expectedHex}' but got '{actualHex}'");
+            Assert.IsTrue(expectedHex == actualHex, $"Byte {i}: hex at col {hexCol} should be '{expectedHex}' but got '{actualHex}'");
 
             // ASCII cell should contain the corresponding letter
             var expectedAscii = (char)('a' + i);
-            Assert.True(expectedAscii == line[asciiCol],
-                $"Byte {i}: ASCII at col {asciiCol} should be '{expectedAscii}' but got '{line[asciiCol]}'");
+            Assert.IsTrue(expectedAscii == line[asciiCol], $"Byte {i}: ASCII at col {asciiCol} should be '{expectedAscii}' but got '{line[asciiCol]}'");
         }
     }
 
@@ -694,20 +692,20 @@ public class HexEditorViewRendererTests
     /// For any arbitrary byte written at position 0, the cursor must advance
     /// to byte 1 (not skip ahead due to UTF-8 re-encoding mismatch).
     /// </summary>
-    [Theory]
-    [InlineData(0x00)]
-    [InlineData(0x41)]  // 'A' — valid ASCII
-    [InlineData(0x7F)]  // DEL — valid ASCII
-    [InlineData(0x80)]  // Continuation byte
-    [InlineData(0xAA)]  // Continuation byte (the original bug)
-    [InlineData(0xBF)]  // Continuation byte
-    [InlineData(0xC0)]  // Overlong
-    [InlineData(0xC2)]  // Start of 2-byte seq (truncated)
-    [InlineData(0xE0)]  // Start of 3-byte seq (truncated)
-    [InlineData(0xF0)]  // Start of 4-byte seq (truncated)
-    [InlineData(0xFE)]  // Invalid
-    [InlineData(0xFF)]  // Invalid
-    public void CommitByte_CursorAdvancesToNextByte(byte byteValue)
+    [TestMethod]
+    [DataRow(0x00)]
+    [DataRow(0x41)]  // 'A' — valid ASCII
+    [DataRow(0x7F)]  // DEL — valid ASCII
+    [DataRow(0x80)]  // Continuation byte
+    [DataRow(0xAA)]  // Continuation byte (the original bug)
+    [DataRow(0xBF)]  // Continuation byte
+    [DataRow(0xC0)]  // Overlong
+    [DataRow(0xC2)]  // Start of 2-byte seq (truncated)
+    [DataRow(0xE0)]  // Start of 3-byte seq (truncated)
+    [DataRow(0xF0)]  // Start of 4-byte seq (truncated)
+    [DataRow(0xFE)]  // Invalid
+    [DataRow(0xFF)]  // Invalid
+    public void CommitByte_CursorAdvancesToNextByte(int byteValue)
     {
         // Start with "ABCD" (4 ASCII bytes), write byteValue at byte 0
         var doc = new Hex1bDocument("ABCD");
@@ -722,19 +720,19 @@ public class HexEditorViewRendererTests
 
         // The byte was written correctly
         var bytes = doc.GetBytes().ToArray();
-        Assert.Equal(byteValue, bytes[0]);
+        Assert.AreEqual(byteValue, bytes[0]);
 
         // Cursor should be at the char that owns byte 1, which is 'B' (unchanged)
         var map = new Utf8ByteMap(doc.GetBytes().Span);
         var (expectedCharIdx, _) = map.ByteToChar(1);
-        Assert.Equal(expectedCharIdx, state.Cursor.Position.Value);
+        Assert.AreEqual(expectedCharIdx, state.Cursor.Position.Value);
     }
 
     /// <summary>
     /// After writing an invalid byte, every subsequent byte should be reachable
     /// via sequential HitTest. Simulates clicking each hex cell in the first row.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void HitTest_AfterInvalidByteEdit_AllBytesReachable()
     {
         // Write 0xAA at byte 0 of "Hello" → bytes [AA 65 6C 6C 6F]
@@ -754,7 +752,7 @@ public class HexEditorViewRendererTests
             var hexCol = 10 + byteIdx * 3; // AddressWidth(8) + Sep(2) + byteIdx * 3
             var result = renderer.HitTest(hexCol, 0, state, 80, 10, 1, 0);
 
-            Assert.NotNull(result);
+            Assert.IsNotNull(result);
             // Map the char offset back to a byte to verify it's the right one
             var map = new Utf8ByteMap(doc.GetBytes().Span);
             var charIdx = result.Value.Value;
@@ -779,7 +777,7 @@ public class HexEditorViewRendererTests
     /// After writing multiple invalid bytes, cursor navigation via CommitByte
     /// visits each byte sequentially without skipping.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void CommitByte_SequentialEdits_CursorVisitsEveryByte()
     {
         // Start with 4-byte ASCII doc, replace each byte with an invalid byte
@@ -798,20 +796,20 @@ public class HexEditorViewRendererTests
             // Verify cursor is at the char owning byte i before edit
             var mapBefore = new Utf8ByteMap(doc.GetBytes().Span);
             var (expectedChar, _) = mapBefore.ByteToChar(i);
-            Assert.Equal(expectedChar, state.Cursor.Position.Value);
+            Assert.AreEqual(expectedChar, state.Cursor.Position.Value);
 
             renderer.HandleCharInput("0123456789ABCDEF"[hi], state, ref nibble, 80);
             renderer.HandleCharInput("0123456789ABCDEF"[lo], state, ref nibble, 80);
         }
 
         // All 4 bytes should be exactly what we typed
-        Assert.Equal(targetBytes, doc.GetBytes().ToArray());
+        TestSeq.AreEqual(targetBytes, doc.GetBytes().ToArray());
     }
 
     /// <summary>
     /// Multi-byte character followed by invalid byte: cursor must not skip the invalid byte.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void CommitByte_AfterMultibyteChar_CursorPositionCorrect()
     {
         // "©X" = bytes [C2 A9 58]. Replace byte 2 (X) with 0xBB
@@ -821,24 +819,24 @@ public class HexEditorViewRendererTests
 
         // Move cursor to char 1 (which is 'X', byte 2)
         state.MoveCursor(CursorDirection.Right);
-        Assert.Equal(1, state.Cursor.Position.Value);
+        Assert.AreEqual(1, state.Cursor.Position.Value);
 
         char? nibble = null;
         renderer.HandleCharInput('B', state, ref nibble, 80);
         renderer.HandleCharInput('B', state, ref nibble, 80);
 
         var bytes = doc.GetBytes().ToArray();
-        Assert.Equal(3, bytes.Length);
-        Assert.Equal(0xC2, bytes[0]); // © first byte unchanged
-        Assert.Equal(0xA9, bytes[1]); // © second byte unchanged
-        Assert.Equal(0xBB, bytes[2]); // replaced
+        Assert.AreEqual(3, bytes.Length);
+        Assert.AreEqual(0xC2, bytes[0]); // © first byte unchanged
+        Assert.AreEqual(0xA9, bytes[1]); // © second byte unchanged
+        Assert.AreEqual(0xBB, bytes[2]); // replaced
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 15: Byte-level navigation (HandleNavigation)
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void HandleNavigation_Right_MovesByOneByte()
     {
         // "é" = C3 A9 (2 bytes), cursor starts at byte 0 (char 0)
@@ -850,12 +848,12 @@ public class HexEditorViewRendererTests
         var renderer = new HexEditorViewRenderer();
         var handled = renderer.HandleNavigation(CursorDirection.Right, state, extend: false, 80);
 
-        Assert.True(handled);
-        Assert.Equal(1, state.ByteCursorOffset); // now at byte 1
-        Assert.Equal(0, state.Cursor.Position.Value); // byte 1 still maps to char 0 ("é")
+        Assert.IsTrue(handled);
+        Assert.AreEqual(1, state.ByteCursorOffset); // now at byte 1
+        Assert.AreEqual(0, state.Cursor.Position.Value); // byte 1 still maps to char 0 ("é")
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleNavigation_Right_TraversesAllBytesInMultiByteChar()
     {
         // "é" = C3 A9 (2 bytes)
@@ -868,19 +866,19 @@ public class HexEditorViewRendererTests
 
         // Move right 3 times: byte 0 → byte 1 → byte 2 (end)
         renderer.HandleNavigation(CursorDirection.Right, state, extend: false, 80);
-        Assert.Equal(1, state.ByteCursorOffset);
-        Assert.Equal(0, state.Cursor.Position.Value); // byte 1 → char 0
+        Assert.AreEqual(1, state.ByteCursorOffset);
+        Assert.AreEqual(0, state.Cursor.Position.Value); // byte 1 → char 0
 
         renderer.HandleNavigation(CursorDirection.Right, state, extend: false, 80);
-        Assert.Equal(2, state.ByteCursorOffset);
-        Assert.Equal(1, state.Cursor.Position.Value); // past "é" → doc.Length = 1
+        Assert.AreEqual(2, state.ByteCursorOffset);
+        Assert.AreEqual(1, state.Cursor.Position.Value); // past "é" → doc.Length = 1
 
         renderer.HandleNavigation(CursorDirection.Right, state, extend: false, 80);
-        Assert.Equal(2, state.ByteCursorOffset); // clamped at totalBytes
-        Assert.Equal(1, state.Cursor.Position.Value); // stays at end
+        Assert.AreEqual(2, state.ByteCursorOffset); // clamped at totalBytes
+        Assert.AreEqual(1, state.Cursor.Position.Value); // stays at end
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleNavigation_Left_MovesByOneByte()
     {
         // "AB" = 41 42 (2 bytes), cursor at byte 1 (char 1)
@@ -892,12 +890,12 @@ public class HexEditorViewRendererTests
         var renderer = new HexEditorViewRenderer();
         var handled = renderer.HandleNavigation(CursorDirection.Left, state, extend: false, 80);
 
-        Assert.True(handled);
-        Assert.Equal(0, state.ByteCursorOffset);
-        Assert.Equal(0, state.Cursor.Position.Value); // byte 0 = char 0
+        Assert.IsTrue(handled);
+        Assert.AreEqual(0, state.ByteCursorOffset);
+        Assert.AreEqual(0, state.Cursor.Position.Value); // byte 0 = char 0
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleNavigation_Right_ThreeByteChar_VisitsEachByte()
     {
         // "日" = E6 97 A5 (3 bytes)
@@ -909,19 +907,19 @@ public class HexEditorViewRendererTests
         var renderer = new HexEditorViewRenderer();
 
         renderer.HandleNavigation(CursorDirection.Right, state, extend: false, 80);
-        Assert.Equal(1, state.ByteCursorOffset);
-        Assert.Equal(0, state.Cursor.Position.Value); // byte 1 still maps to char 0
+        Assert.AreEqual(1, state.ByteCursorOffset);
+        Assert.AreEqual(0, state.Cursor.Position.Value); // byte 1 still maps to char 0
 
         renderer.HandleNavigation(CursorDirection.Right, state, extend: false, 80);
-        Assert.Equal(2, state.ByteCursorOffset);
-        Assert.Equal(0, state.Cursor.Position.Value); // byte 2 still maps to char 0
+        Assert.AreEqual(2, state.ByteCursorOffset);
+        Assert.AreEqual(0, state.Cursor.Position.Value); // byte 2 still maps to char 0
 
         renderer.HandleNavigation(CursorDirection.Right, state, extend: false, 80);
-        Assert.Equal(3, state.ByteCursorOffset);
-        Assert.Equal(1, state.Cursor.Position.Value); // byte 3 → past "日" → doc.Length = 1
+        Assert.AreEqual(3, state.ByteCursorOffset);
+        Assert.AreEqual(1, state.Cursor.Position.Value); // byte 3 → past "日" → doc.Length = 1
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleNavigation_UpDown_MovesByBytesPerRow()
     {
         // Create content that spans multiple hex rows at 80 columns
@@ -936,23 +934,23 @@ public class HexEditorViewRendererTests
         state.ByteCursorOffset = 0;
 
         // Down should move to byte 16 (row 1, col 0)
-        Assert.True(renderer.HandleNavigation(CursorDirection.Down, state, extend: false, 80));
-        Assert.Equal(16, state.ByteCursorOffset);
+        Assert.IsTrue(renderer.HandleNavigation(CursorDirection.Down, state, extend: false, 80));
+        Assert.AreEqual(16, state.ByteCursorOffset);
 
         // Down again should move to byte 32 (row 2, col 0)
         renderer.HandleNavigation(CursorDirection.Down, state, extend: false, 80);
-        Assert.Equal(32, state.ByteCursorOffset);
+        Assert.AreEqual(32, state.ByteCursorOffset);
 
         // Up should move back to byte 16 (row 1, col 0)
         renderer.HandleNavigation(CursorDirection.Up, state, extend: false, 80);
-        Assert.Equal(16, state.ByteCursorOffset);
+        Assert.AreEqual(16, state.ByteCursorOffset);
 
         // Up again should move back to byte 0 (row 0, col 0)
         renderer.HandleNavigation(CursorDirection.Up, state, extend: false, 80);
-        Assert.Equal(0, state.ByteCursorOffset);
+        Assert.AreEqual(0, state.ByteCursorOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleNavigation_Up_ClampsToZero()
     {
         var doc = new Hex1bDocument("ABCD");
@@ -962,10 +960,10 @@ public class HexEditorViewRendererTests
 
         // Up from first row should clamp to byte 0
         renderer.HandleNavigation(CursorDirection.Up, state, extend: false, 80);
-        Assert.Equal(0, state.ByteCursorOffset);
+        Assert.AreEqual(0, state.ByteCursorOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleNavigation_Down_ClampsToTotalBytes()
     {
         var doc = new Hex1bDocument("ABCD");
@@ -975,10 +973,10 @@ public class HexEditorViewRendererTests
 
         // Down from first row with only 4 bytes (< bytesPerRow) should clamp to end
         renderer.HandleNavigation(CursorDirection.Down, state, extend: false, 80);
-        Assert.Equal(4, state.ByteCursorOffset);
+        Assert.AreEqual(4, state.ByteCursorOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleNavigation_UpDown_PreservesColumnPosition()
     {
         // 48 bytes = 3 rows of 16 bytes at 80 columns
@@ -993,18 +991,18 @@ public class HexEditorViewRendererTests
 
         // Down should move to byte 21 (row 1, col 5)
         renderer.HandleNavigation(CursorDirection.Down, state, extend: false, 80);
-        Assert.Equal(21, state.ByteCursorOffset);
+        Assert.AreEqual(21, state.ByteCursorOffset);
 
         // Down again should move to byte 37 (row 2, col 5)
         renderer.HandleNavigation(CursorDirection.Down, state, extend: false, 80);
-        Assert.Equal(37, state.ByteCursorOffset);
+        Assert.AreEqual(37, state.ByteCursorOffset);
 
         // Up should return to byte 21
         renderer.HandleNavigation(CursorDirection.Up, state, extend: false, 80);
-        Assert.Equal(21, state.ByteCursorOffset);
+        Assert.AreEqual(21, state.ByteCursorOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleNavigation_Right_InvalidBytes_OneBytePerMove()
     {
         // Raw bytes: each invalid byte is 1 char
@@ -1016,19 +1014,19 @@ public class HexEditorViewRendererTests
         var renderer = new HexEditorViewRenderer();
 
         renderer.HandleNavigation(CursorDirection.Right, state, extend: false, 80);
-        Assert.Equal(1, state.ByteCursorOffset);
-        Assert.Equal(1, state.Cursor.Position.Value); // byte 1 → char 1
+        Assert.AreEqual(1, state.ByteCursorOffset);
+        Assert.AreEqual(1, state.Cursor.Position.Value); // byte 1 → char 1
 
         renderer.HandleNavigation(CursorDirection.Right, state, extend: false, 80);
-        Assert.Equal(2, state.ByteCursorOffset);
-        Assert.Equal(2, state.Cursor.Position.Value); // byte 2 → char 2
+        Assert.AreEqual(2, state.ByteCursorOffset);
+        Assert.AreEqual(2, state.Cursor.Position.Value); // byte 2 → char 2
 
         renderer.HandleNavigation(CursorDirection.Right, state, extend: false, 80);
-        Assert.Equal(3, state.ByteCursorOffset);
-        Assert.Equal(3, state.Cursor.Position.Value); // past end → doc.Length = 3
+        Assert.AreEqual(3, state.ByteCursorOffset);
+        Assert.AreEqual(3, state.Cursor.Position.Value); // past end → doc.Length = 3
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleNavigation_MixedContent_ByteByByte()
     {
         // "Aé" = 41 C3 A9 (3 bytes, 2 chars)
@@ -1041,21 +1039,21 @@ public class HexEditorViewRendererTests
 
         // byte 0 → byte 1 (C3, maps to char 1 'é')
         renderer.HandleNavigation(CursorDirection.Right, state, extend: false, 80);
-        Assert.Equal(1, state.ByteCursorOffset);
-        Assert.Equal(1, state.Cursor.Position.Value);
+        Assert.AreEqual(1, state.ByteCursorOffset);
+        Assert.AreEqual(1, state.Cursor.Position.Value);
 
         // byte 1 → byte 2 (A9, still char 1 'é')
         renderer.HandleNavigation(CursorDirection.Right, state, extend: false, 80);
-        Assert.Equal(2, state.ByteCursorOffset);
-        Assert.Equal(1, state.Cursor.Position.Value);
+        Assert.AreEqual(2, state.ByteCursorOffset);
+        Assert.AreEqual(1, state.Cursor.Position.Value);
 
         // byte 2 → byte 3 (past end)
         renderer.HandleNavigation(CursorDirection.Right, state, extend: false, 80);
-        Assert.Equal(3, state.ByteCursorOffset);
-        Assert.Equal(2, state.Cursor.Position.Value); // doc.Length = 2
+        Assert.AreEqual(3, state.ByteCursorOffset);
+        Assert.AreEqual(2, state.Cursor.Position.Value); // doc.Length = 2
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleNavigation_WithoutByteCursorOffset_DerivesFromCharPosition()
     {
         // "AB" = 41 42, cursor at char 1 (byte 1)
@@ -1067,7 +1065,7 @@ public class HexEditorViewRendererTests
         var renderer = new HexEditorViewRenderer();
         renderer.HandleNavigation(CursorDirection.Right, state, extend: false, 80);
 
-        Assert.Equal(2, state.ByteCursorOffset); // byte 1 → byte 2 (end)
-        Assert.Equal(2, state.Cursor.Position.Value); // doc.Length
+        Assert.AreEqual(2, state.ByteCursorOffset); // byte 1 → byte 2 (end)
+        Assert.AreEqual(2, state.Cursor.Position.Value); // doc.Length
     }
 }

--- a/tests/Hex1b.Tests/Hmp1/Hmp1AsyncCallbackTests.cs
+++ b/tests/Hex1b.Tests/Hmp1/Hmp1AsyncCallbackTests.cs
@@ -9,11 +9,12 @@ namespace Hex1b.Tests.Hmp1;
 /// self-dispose from a callback (no deadlock), and DisconnectedTask
 /// independence from slow user OnDisconnected handlers.
 /// </summary>
+[TestClass]
 public class Hmp1AsyncCallbackTests
 {
     private static readonly TimeSpan ShortTimeout = TimeSpan.FromSeconds(5);
 
-    [Fact]
+    [TestMethod]
     public async Task OnPeerJoined_Multicast_AllHandlersRunInOrder_EvenWhenFirstThrows()
     {
         var server = new Hmp1PresentationAdapter(80, 24);
@@ -54,13 +55,13 @@ public class Hmp1AsyncCallbackTests
 
         lock (calls)
         {
-            Assert.Equal(2, calls.Count);
-            Assert.Equal("first:joiner", calls[0]);
-            Assert.Equal("second:joiner", calls[1]);
+            Assert.AreEqual(2, calls.Count);
+            Assert.AreEqual("first:joiner", calls[0]);
+            Assert.AreEqual("second:joiner", calls[1]);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OnRoleChanged_SelfDisposeFromCallback_DoesNotDeadlock()
     {
         var server = new Hmp1PresentationAdapter(80, 24);
@@ -91,10 +92,10 @@ public class Hmp1AsyncCallbackTests
         await adapter.RequestPrimaryAsync(100, 30);
 
         var completed = await Task.WhenAny(disposed.Task, Task.Delay(ShortTimeout));
-        Assert.Same(disposed.Task, completed);
+        Assert.AreSame(disposed.Task, completed);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DisconnectedTask_CompletesBeforeSlowOnDisconnectedReturns()
     {
         var server = new Hmp1PresentationAdapter(80, 24);
@@ -129,7 +130,7 @@ public class Hmp1AsyncCallbackTests
         // runCallback relies on.
         await handlerEntered.Task.WaitAsync(ShortTimeout);
         await adapter.DisconnectedTask.WaitAsync(ShortTimeout);
-        Assert.False(slowGate.Task.IsCompleted, "Sanity: slow handler is still gated.");
+        Assert.IsFalse(slowGate.Task.IsCompleted, "Sanity: slow handler is still gated.");
 
         // Release the handler and finish disposal.
         slowGate.TrySetResult();
@@ -144,7 +145,7 @@ public class Hmp1AsyncCallbackTests
             if (predicate()) return;
             await Task.Delay(10);
         }
-        throw new Xunit.Sdk.XunitException($"Timed out waiting: {describeFailure()}");
+        throw new AssertFailedException($"Timed out waiting: {describeFailure()}");
     }
 
     private static (Stream S1, Stream S2) CreateFullDuplexPair()

--- a/tests/Hex1b.Tests/Hmp1/Hmp1ClientOptionsTests.cs
+++ b/tests/Hex1b.Tests/Hmp1/Hmp1ClientOptionsTests.cs
@@ -10,11 +10,12 @@ namespace Hex1b.Tests.Hmp1;
 /// plus the underlying <see cref="Hmp1WorkloadAdapter.OnConnected"/> and
 /// <see cref="Hmp1WorkloadAdapter.OnRemoteResized"/> async callbacks.
 /// </summary>
+[TestClass]
 public class Hmp1ClientOptionsTests
 {
     private static readonly TimeSpan ShortTimeout = TimeSpan.FromSeconds(5);
 
-    [Fact]
+    [TestMethod]
     public async Task Adapter_Connected_FiresOnceWithHandshakeState()
     {
         var server = new Hmp1PresentationAdapter(120, 36);
@@ -39,16 +40,16 @@ public class Hmp1ClientOptionsTests
         var handle = await addTask.WaitAsync(ShortTimeout);
         await using var handleDispose = handle;
 
-        Assert.Equal(1, connectedCount);
-        Assert.NotNull(captured);
-        Assert.False(string.IsNullOrEmpty(captured!.PeerId));
-        Assert.Null(captured.PrimaryPeerId);
-        Assert.Equal(120, captured.Width);
-        Assert.Equal(36, captured.Height);
-        Assert.Empty(captured.Peers);
+        Assert.AreEqual(1, connectedCount);
+        Assert.IsNotNull(captured);
+        Assert.IsFalse(string.IsNullOrEmpty(captured!.PeerId));
+        Assert.IsNull(captured.PrimaryPeerId);
+        Assert.AreEqual(120, captured.Width);
+        Assert.AreEqual(36, captured.Height);
+        Assert.IsEmpty(captured.Peers);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Adapter_RemoteResized_FiresWhenLocalPrimaryRequestsResize()
     {
         var server = new Hmp1PresentationAdapter(80, 24);
@@ -72,7 +73,7 @@ public class Hmp1ClientOptionsTests
         await using var handleDispose = handle;
 
         // Initial Hello dims must NOT have fired RemoteResized.
-        lock (resizes) { Assert.Empty(resizes); }
+        lock (resizes) { Assert.IsEmpty(resizes); }
 
         // Take primary at a new dim — RoleChange-driven resize from 80x24 to 110x35.
         await adapter.RequestPrimaryAsync(110, 35);
@@ -82,12 +83,12 @@ public class Hmp1ClientOptionsTests
 
         RemoteResizedEventArgs first;
         lock (resizes) { first = resizes[^1]; }
-        Assert.Equal(110, first.Width);
-        Assert.Equal(35, first.Height);
-        Assert.True(first.CausedByLocalPrimary, "Local peer was the new primary; CausedByLocalPrimary should be true.");
+        Assert.AreEqual(110, first.Width);
+        Assert.AreEqual(35, first.Height);
+        Assert.IsTrue(first.CausedByLocalPrimary, "Local peer was the new primary; CausedByLocalPrimary should be true.");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Adapter_RemoteResized_FiresOnPureResizeFrameWhilePrimary()
     {
         var server = new Hmp1PresentationAdapter(80, 24);
@@ -127,12 +128,12 @@ public class Hmp1ClientOptionsTests
 
         RemoteResizedEventArgs latest;
         lock (resizes) { latest = resizes[^1]; }
-        Assert.Equal(140, latest.Width);
-        Assert.Equal(45, latest.Height);
-        Assert.True(latest.CausedByLocalPrimary, "Local peer is the primary; CausedByLocalPrimary should be true.");
+        Assert.AreEqual(140, latest.Width);
+        Assert.AreEqual(45, latest.Height);
+        Assert.IsTrue(latest.CausedByLocalPrimary, "Local peer is the primary; CausedByLocalPrimary should be true.");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Adapter_RemoteResized_DoesNotFireWhenDimsUnchanged()
     {
         var server = new Hmp1PresentationAdapter(100, 30);
@@ -164,10 +165,10 @@ public class Hmp1ClientOptionsTests
         // Give the read pump a beat to process any in-flight frames.
         await Task.Delay(100);
 
-        lock (resizes) { Assert.Empty(resizes); }
+        lock (resizes) { Assert.IsEmpty(resizes); }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Builder_OptionsCallback_AllHooksFireForCorrespondingEvents()
     {
         var server = new Hmp1PresentationAdapter(80, 24);
@@ -231,10 +232,10 @@ public class Hmp1ClientOptionsTests
         await using var handleDispose = handle;
 
         await WaitUntilAsync(() => connectedCount == 1, ShortTimeout, () => "OnConnected never fired");
-        Assert.NotNull(capturedConnected);
-        Assert.False(string.IsNullOrEmpty(capturedConnected!.PeerId));
-        Assert.Equal(80, capturedConnected.Width);
-        Assert.Equal(24, capturedConnected.Height);
+        Assert.IsNotNull(capturedConnected);
+        Assert.IsFalse(string.IsNullOrEmpty(capturedConnected!.PeerId));
+        Assert.AreEqual(80, capturedConnected.Width);
+        Assert.AreEqual(24, capturedConnected.Height);
 
         // Add a second peer to drive PeerJoined.
         var (other1, other2) = CreateFullDuplexPair();
@@ -245,8 +246,8 @@ public class Hmp1ClientOptionsTests
         var otherHandle = await otherAddTask.WaitAsync(ShortTimeout);
 
         await WaitUntilAsync(() => peerJoinedCount >= 1, ShortTimeout, () => "OnPeerJoined never fired");
-        Assert.NotNull(capturedPeerJoined);
-        Assert.Equal("other-peer", capturedPeerJoined!.DisplayName);
+        Assert.IsNotNull(capturedPeerJoined);
+        Assert.AreEqual("other-peer", capturedPeerJoined!.DisplayName);
 
         // Have the other peer take primary at a new dim — drives OnRoleChanged
         // (for our viewer) and OnRemoteResized.
@@ -255,17 +256,17 @@ public class Hmp1ClientOptionsTests
 
         await WaitUntilAsync(() => roleChangedCount >= 1, ShortTimeout, () => "OnRoleChanged never fired");
         await WaitUntilAsync(() => remoteResizedCount >= 1, ShortTimeout, () => "OnRemoteResized never fired");
-        Assert.NotNull(lastRemoteResized);
-        Assert.Equal(120, lastRemoteResized!.Width);
-        Assert.Equal(40, lastRemoteResized.Height);
-        Assert.False(lastRemoteResized.CausedByLocalPrimary, "Other peer caused the resize, not us.");
+        Assert.IsNotNull(lastRemoteResized);
+        Assert.AreEqual(120, lastRemoteResized!.Width);
+        Assert.AreEqual(40, lastRemoteResized.Height);
+        Assert.IsFalse(lastRemoteResized.CausedByLocalPrimary, "Other peer caused the resize, not us.");
 
         // Disconnect the other peer to drive OnPeerLeft.
         await otherHandle.DisposeAsync();
         await otherAdapter.DisposeAsync();
 
         await WaitUntilAsync(() => peerLeftCount >= 1, ShortTimeout, () => "OnPeerLeft never fired");
-        Assert.NotNull(capturedPeerLeft);
+        Assert.IsNotNull(capturedPeerLeft);
 
         // Tear down our terminal — drives OnDisconnected.
         await ctsRun.CancelAsync();
@@ -274,7 +275,7 @@ public class Hmp1ClientOptionsTests
         await WaitUntilAsync(() => disconnectedCount >= 1, ShortTimeout, () => "OnDisconnected never fired");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Builder_OptionsCallback_NullHooksAreTolerated()
     {
         var server = new Hmp1PresentationAdapter(80, 24);
@@ -301,13 +302,13 @@ public class Hmp1ClientOptionsTests
         // No assertions on events — the goal is just to prove that calling
         // WithHmp1Stream(stream, opt => { ... }) with every event hook left
         // null doesn't throw during build, connect, or read-pump shutdown.
-        Assert.NotNull(handle);
+        Assert.IsNotNull(handle);
 
         await ctsRun.CancelAsync();
         try { await runTask.WaitAsync(ShortTimeout); } catch (OperationCanceledException) { }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Builder_OptionsCallback_NullConfigureSucceeds()
     {
         var server = new Hmp1PresentationAdapter(80, 24);
@@ -328,7 +329,7 @@ public class Hmp1ClientOptionsTests
         var handle = await addTask.WaitAsync(ShortTimeout);
         await using var handleDispose = handle;
 
-        Assert.NotNull(handle);
+        Assert.IsNotNull(handle);
 
         await ctsRun.CancelAsync();
         try { await runTask.WaitAsync(ShortTimeout); } catch (OperationCanceledException) { }
@@ -344,7 +345,7 @@ public class Hmp1ClientOptionsTests
             if (predicate()) return;
             await Task.Delay(10);
         }
-        throw new Xunit.Sdk.XunitException($"Timed out waiting: {describeFailure()}");
+        throw new AssertFailedException($"Timed out waiting: {describeFailure()}");
     }
 
     private static (Stream S1, Stream S2) CreateFullDuplexPair()

--- a/tests/Hex1b.Tests/Hmp1/Hmp1MultiHeadHarnessTests.cs
+++ b/tests/Hex1b.Tests/Hmp1/Hmp1MultiHeadHarnessTests.cs
@@ -2,8 +2,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO.Pipelines;
 using Hex1b;
-using Xunit.Sdk;
-using Xunit.v3;
+
 
 namespace Hex1b.Tests.Hmp1;
 
@@ -23,6 +22,7 @@ namespace Hex1b.Tests.Hmp1;
 /// all wire up end-to-end.
 /// </para>
 /// </summary>
+[TestClass]
 public class Hmp1MultiHeadHarnessTests
 {
     private static readonly TimeSpan ShortTimeout = TimeSpan.FromSeconds(5);
@@ -30,7 +30,7 @@ public class Hmp1MultiHeadHarnessTests
 
     // ---- Layer A: bare adapter pairs ----------------------------------
 
-    [Fact]
+    [TestMethod]
     public async Task RoundRobin_PrimaryHandoff_AllPeersConverge()
     {
         await using var harness = await BareHarness.CreateAsync(peerCount: 4);
@@ -50,7 +50,7 @@ public class Hmp1MultiHeadHarnessTests
 
             await peer.Adapter.RequestPrimaryAsync(cols, rows);
             var ok = await peer.Adapter.WaitForRoleAsync(primary: true, ShortTimeout, CancellationToken.None);
-            Assert.True(ok, $"Peer {i} did not become primary within timeout.");
+            Assert.IsTrue(ok, $"Peer {i} did not become primary within timeout.");
 
             await harness.WaitUntilAsync(
                 () => harness.Peers.All(p => p.Adapter.PrimaryPeerId == peer.Adapter.PeerId)
@@ -62,7 +62,7 @@ public class Hmp1MultiHeadHarnessTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ConcurrentTakeOver_AllPeersConvergeOnSomeWinner()
     {
         await using var harness = await BareHarness.CreateAsync(peerCount: 4);
@@ -90,11 +90,11 @@ public class Hmp1MultiHeadHarnessTests
             () => "Peers failed to converge on a single winner. " + harness.DescribeState());
 
         var winner = harness.Server.PrimaryPeerId;
-        Assert.NotNull(winner);
-        Assert.Contains(harness.Peers, p => p.Adapter.PeerId == winner);
+        Assert.IsNotNull(winner);
+        Assert.IsTrue(harness.Peers.Any(p => p.Adapter.PeerId == winner));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RequestPrimary_InterleavedWithPrimaryResize_ConvergesOnTakeover()
     {
         await using var harness = await BareHarness.CreateAsync(peerCount: 2);
@@ -147,7 +147,7 @@ public class Hmp1MultiHeadHarnessTests
             () => "Peers did not converge on challenger. " + harness.DescribeState());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PrimaryDisconnect_NoAutoPromotion()
     {
         await using var harness = await BareHarness.CreateAsync(peerCount: 3);
@@ -165,17 +165,17 @@ public class Hmp1MultiHeadHarnessTests
 
         // Remaining peers should also see PrimaryPeerId become null.
         var remaining = harness.Peers.Where(p => p.IsConnected).ToList();
-        Assert.NotEmpty(remaining);
+        Assert.IsNotEmpty(remaining);
         await harness.WaitUntilAsync(
             () => remaining.All(p => p.Adapter.PrimaryPeerId is null),
             ShortTimeout,
             () => "Remaining peers did not observe primary clear. " + harness.DescribeState());
 
         // No peer was auto-promoted.
-        Assert.All(remaining, p => Assert.False(p.Adapter.IsPrimary));
+        TestSeq.All(remaining, p => Assert.IsFalse(p.Adapter.IsPrimary));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RosterChurn_PeerCountsConverge()
     {
         await using var harness = await BareHarness.CreateAsync(peerCount: 1);
@@ -207,7 +207,7 @@ public class Hmp1MultiHeadHarnessTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WaitForRoleAsync_TimesOutWhenNotPromoted()
     {
         await using var harness = await BareHarness.CreateAsync(peerCount: 2);
@@ -216,10 +216,10 @@ public class Hmp1MultiHeadHarnessTests
         // time out within a short budget.
         var ok = await harness.Peers[0].Adapter.WaitForRoleAsync(
             primary: true, TimeSpan.FromMilliseconds(200), CancellationToken.None);
-        Assert.False(ok);
+        Assert.IsFalse(ok);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PrimaryResize_BroadcastsCurrentDimsToAllPeers()
     {
         await using var harness = await BareHarness.CreateAsync(peerCount: 3);
@@ -237,7 +237,7 @@ public class Hmp1MultiHeadHarnessTests
             () => "Resize broadcast did not converge. " + harness.DescribeState());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task StressLoop_Invariants_HoldThroughout()
     {
         var iterations = ParseEnvInt("HEX1B_MULTIHEAD_STRESS_ITERATIONS", defaultValue: 25);
@@ -289,7 +289,7 @@ public class Hmp1MultiHeadHarnessTests
             }
         }
 
-        Assert.True(failures.Count == 0, $"Stress run had {failures.Count} failures (seed {seed}):\n  " + string.Join("\n  ", failures));
+        Assert.IsTrue(failures.Count == 0, $"Stress run had {failures.Count} failures (seed {seed}):\n  " + string.Join("\n  ", failures));
 
         // Final convergence: every peer agrees on whoever the producer says is
         // primary. Per rubber-duck guidance, do not assert a specific winner —
@@ -313,7 +313,7 @@ public class Hmp1MultiHeadHarnessTests
 
     // ---- Layer B: one full Hex1bTerminal --------------------------------
 
-    [Fact]
+    [TestMethod]
     public async Task LayerB_Hex1bTerminalSmokeTest_DrivesHmp1WorkloadAdapter()
     {
         var server = new Hmp1PresentationAdapter(80, 24);
@@ -349,17 +349,17 @@ public class Hmp1MultiHeadHarnessTests
             ShortTimeout,
             () => "Hmp1 peer id never assigned.");
 
-        Assert.False(adapter.IsPrimary);
-        Assert.Null(adapter.PrimaryPeerId);
+        Assert.IsFalse(adapter.IsPrimary);
+        Assert.IsNull(adapter.PrimaryPeerId);
 
         // Take primary through the full Hex1bTerminal pipeline and verify it
         // reaches the producer's authoritative state.
         await adapter.RequestPrimaryAsync(110, 35);
         await adapter.WaitForRoleAsync(primary: true, ShortTimeout, CancellationToken.None);
 
-        Assert.Equal(adapter.PeerId, server.PrimaryPeerId);
-        Assert.Equal(110, server.Width);
-        Assert.Equal(35, server.Height);
+        Assert.AreEqual(adapter.PeerId, server.PrimaryPeerId);
+        Assert.AreEqual(110, server.Width);
+        Assert.AreEqual(35, server.Height);
 
         // Tear down cooperatively.
         await ctsRun.CancelAsync();
@@ -391,7 +391,7 @@ public class Hmp1MultiHeadHarnessTests
         }
         if (!predicate())
         {
-            throw new Xunit.Sdk.XunitException("Predicate failed: " + describeFailure());
+            throw new AssertFailedException("Predicate failed: " + describeFailure());
         }
     }
 

--- a/tests/Hex1b.Tests/Hmp1/Hmp1MultiHeadTests.cs
+++ b/tests/Hex1b.Tests/Hmp1/Hmp1MultiHeadTests.cs
@@ -9,26 +9,27 @@ namespace Hex1b.Tests.Hmp1;
 /// <see cref="Hmp1PresentationAdapter"/> via real <see cref="Hmp1WorkloadAdapter"/>
 /// clients; asserts state transitions are observed correctly across all peers.
 /// </summary>
+[TestClass]
 public class Hmp1MultiHeadTests
 {
     private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(5);
 
-    [Fact]
+    [TestMethod]
     public async Task FirstPeer_AttachesAsSecondary_NoPrimary()
     {
         await using var server = new Hmp1PresentationAdapter(80, 24);
         var (handle, client) = await ConnectAsync(server, displayName: "first");
 
-        Assert.False(client.IsPrimary);
-        Assert.Null(client.PrimaryPeerId);
-        Assert.Null(server.PrimaryPeerId);
-        Assert.NotEmpty(client.PeerId);
+        Assert.IsFalse(client.IsPrimary);
+        Assert.IsNull(client.PrimaryPeerId);
+        Assert.IsNull(server.PrimaryPeerId);
+        Assert.IsNotEmpty(client.PeerId);
 
         await handle.DisposeAsync();
         await client.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SecondaryResize_IsDropped_PtyUnchanged()
     {
         await using var server = new Hmp1PresentationAdapter(80, 24);
@@ -42,15 +43,15 @@ public class Hmp1MultiHeadTests
         // Give the producer a moment to (not) act on it.
         await Task.Delay(150);
 
-        Assert.False(resized, "Producer must not fire Resized for a non-primary peer's Resize.");
-        Assert.Equal(80, server.Width);
-        Assert.Equal(24, server.Height);
+        Assert.IsFalse(resized, "Producer must not fire Resized for a non-primary peer's Resize.");
+        Assert.AreEqual(80, server.Width);
+        Assert.AreEqual(24, server.Height);
 
         await handle.DisposeAsync();
         await client.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RequestPrimary_MakesCallerPrimary_ResizesPty()
     {
         await using var server = new Hmp1PresentationAdapter(80, 24);
@@ -61,19 +62,19 @@ public class Hmp1MultiHeadTests
 
         await client.RequestPrimaryAsync(120, 40);
         var ok = await client.WaitForRoleAsync(primary: true, TestTimeout, CancellationToken.None);
-        Assert.True(ok, "Expected to become primary within timeout.");
+        Assert.IsTrue(ok, "Expected to become primary within timeout.");
 
         var (w, h) = await resizeTcs.Task.WaitAsync(TestTimeout);
-        Assert.Equal(120, w);
-        Assert.Equal(40, h);
-        Assert.Equal(client.PeerId, server.PrimaryPeerId);
-        Assert.True(client.IsPrimary);
+        Assert.AreEqual(120, w);
+        Assert.AreEqual(40, h);
+        Assert.AreEqual(client.PeerId, server.PrimaryPeerId);
+        Assert.IsTrue(client.IsPrimary);
 
         await handle.DisposeAsync();
         await client.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SecondPeer_Joins_FirstPrimarySeesPeerJoin()
     {
         await using var server = new Hmp1PresentationAdapter(80, 24);
@@ -87,14 +88,14 @@ public class Hmp1MultiHeadTests
         var (handle2, client2) = await ConnectAsync(server, displayName: "beta");
 
         var join = await joinTcs.Task.WaitAsync(TestTimeout);
-        Assert.Equal(client2.PeerId, join.PeerId);
-        Assert.Equal("beta", join.DisplayName);
+        Assert.AreEqual(client2.PeerId, join.PeerId);
+        Assert.AreEqual("beta", join.DisplayName);
 
         // The newcomer sees the existing primary in its initial Hello roster + state.
-        Assert.Equal(client1.PeerId, client2.PrimaryPeerId);
-        Assert.False(client2.IsPrimary);
-        Assert.Single(client2.Peers);
-        Assert.Equal(client1.PeerId, client2.Peers[0].PeerId);
+        Assert.AreEqual(client1.PeerId, client2.PrimaryPeerId);
+        Assert.IsFalse(client2.IsPrimary);
+        TestSeq.Single(client2.Peers);
+        Assert.AreEqual(client1.PeerId, client2.Peers[0].PeerId);
 
         await handle1.DisposeAsync();
         await handle2.DisposeAsync();
@@ -102,7 +103,7 @@ public class Hmp1MultiHeadTests
         await client2.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SecondPeer_RequestsPrimary_RoleTransfersAcrossBothPeers()
     {
         await using var server = new Hmp1PresentationAdapter(80, 24);
@@ -122,20 +123,20 @@ public class Hmp1MultiHeadTests
         var r1 = await role1Tcs.Task.WaitAsync(TestTimeout);
         var r2 = await role2Tcs.Task.WaitAsync(TestTimeout);
 
-        Assert.Equal(client2.PeerId, r1.PrimaryPeerId);
-        Assert.Equal(client2.PeerId, r2.PrimaryPeerId);
-        Assert.Equal(140, r1.Width);
-        Assert.Equal(50, r1.Height);
-        Assert.True(r1.PreviouslyPrimary);
-        Assert.False(r1.NowPrimary);
-        Assert.False(r2.PreviouslyPrimary);
-        Assert.True(r2.NowPrimary);
+        Assert.AreEqual(client2.PeerId, r1.PrimaryPeerId);
+        Assert.AreEqual(client2.PeerId, r2.PrimaryPeerId);
+        Assert.AreEqual(140, r1.Width);
+        Assert.AreEqual(50, r1.Height);
+        Assert.IsTrue(r1.PreviouslyPrimary);
+        Assert.IsFalse(r1.NowPrimary);
+        Assert.IsFalse(r2.PreviouslyPrimary);
+        Assert.IsTrue(r2.NowPrimary);
 
-        Assert.False(client1.IsPrimary);
-        Assert.True(client2.IsPrimary);
-        Assert.Equal(client2.PeerId, server.PrimaryPeerId);
-        Assert.Equal(140, server.Width);
-        Assert.Equal(50, server.Height);
+        Assert.IsFalse(client1.IsPrimary);
+        Assert.IsTrue(client2.IsPrimary);
+        Assert.AreEqual(client2.PeerId, server.PrimaryPeerId);
+        Assert.AreEqual(140, server.Width);
+        Assert.AreEqual(50, server.Height);
 
         await handle1.DisposeAsync();
         await handle2.DisposeAsync();
@@ -143,7 +144,7 @@ public class Hmp1MultiHeadTests
         await client2.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PrimaryDisconnect_BroadcastsRoleChangeNullNoAutoPromotion()
     {
         await using var server = new Hmp1PresentationAdapter(80, 24);
@@ -164,21 +165,21 @@ public class Hmp1MultiHeadTests
         var roleChange = await roleChangedTcs.Task.WaitAsync(TestTimeout);
         var leave = await leaveTcs.Task.WaitAsync(TestTimeout);
 
-        Assert.Null(roleChange.PrimaryPeerId);
-        Assert.Equal("PrimaryDisconnected", roleChange.Reason);
-        Assert.Equal(client1.PeerId, leave.PeerId);
+        Assert.IsNull(roleChange.PrimaryPeerId);
+        Assert.AreEqual("PrimaryDisconnected", roleChange.Reason);
+        Assert.AreEqual(client1.PeerId, leave.PeerId);
 
-        Assert.Null(server.PrimaryPeerId);
-        Assert.False(client2.IsPrimary);
+        Assert.IsNull(server.PrimaryPeerId);
+        Assert.IsFalse(client2.IsPrimary);
         // PTY size remains at last-known (no auto-promotion).
-        Assert.Equal(100, server.Width);
-        Assert.Equal(30, server.Height);
+        Assert.AreEqual(100, server.Width);
+        Assert.AreEqual(30, server.Height);
 
         await handle2.DisposeAsync();
         await client2.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SecondaryDisconnect_NoRoleChange_OtherPeersUnaffected()
     {
         await using var server = new Hmp1PresentationAdapter(80, 24);
@@ -197,19 +198,19 @@ public class Hmp1MultiHeadTests
         await client2.DisposeAsync();
 
         var leave = await leaveTcs.Task.WaitAsync(TestTimeout);
-        Assert.Equal(client2.PeerId, leave.PeerId);
+        Assert.AreEqual(client2.PeerId, leave.PeerId);
 
         // Give events a moment to settle then verify no role change.
         await Task.Delay(100);
-        Assert.False(roleChanged, "Primary role change must not fire on secondary disconnect.");
-        Assert.True(client1.IsPrimary);
-        Assert.Equal(client1.PeerId, server.PrimaryPeerId);
+        Assert.IsFalse(roleChanged, "Primary role change must not fire on secondary disconnect.");
+        Assert.IsTrue(client1.IsPrimary);
+        Assert.AreEqual(client1.PeerId, server.PrimaryPeerId);
 
         await handle1.DisposeAsync();
         await client1.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RequestPrimary_WithZeroDims_FallsBackToLastKnownSize()
     {
         await using var server = new Hmp1PresentationAdapter(80, 24);
@@ -220,14 +221,14 @@ public class Hmp1MultiHeadTests
         await client.RequestPrimaryAsync(0, 0);
         await client.WaitForRoleAsync(primary: true, TestTimeout, CancellationToken.None);
 
-        Assert.Equal(80, server.Width);
-        Assert.Equal(24, server.Height);
+        Assert.AreEqual(80, server.Width);
+        Assert.AreEqual(24, server.Height);
 
         await handle.DisposeAsync();
         await client.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PrimaryResize_BroadcastsAndUpdatesPty()
     {
         await using var server = new Hmp1PresentationAdapter(80, 24);
@@ -243,10 +244,10 @@ public class Hmp1MultiHeadTests
         await client1.ResizeAsync(160, 50);
 
         var (w, h) = await resizeTcs.Task.WaitAsync(TestTimeout);
-        Assert.Equal(160, w);
-        Assert.Equal(50, h);
-        Assert.Equal(160, server.Width);
-        Assert.Equal(50, server.Height);
+        Assert.AreEqual(160, w);
+        Assert.AreEqual(50, h);
+        Assert.AreEqual(160, server.Width);
+        Assert.AreEqual(50, server.Height);
 
         await handle1.DisposeAsync();
         await handle2.DisposeAsync();

--- a/tests/Hex1b.Tests/Hmp1/Hmp1StateReplayCursorRegressionTests.cs
+++ b/tests/Hex1b.Tests/Hmp1/Hmp1StateReplayCursorRegressionTests.cs
@@ -36,11 +36,12 @@ namespace Hex1b.Tests.Hmp1;
 /// place the cursor).
 /// </para>
 /// </remarks>
+[TestClass]
 public class Hmp1StateReplayCursorRegressionTests
 {
     private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(5);
 
-    [Fact]
+    [TestMethod]
     public async Task StateSync_DoesNotEndWithTrailingNewline_SoCursorStaysWherePainterPutIt()
     {
         await using var server = new Hmp1PresentationAdapter(80, 24);
@@ -80,12 +81,12 @@ public class Hmp1StateReplayCursorRegressionTests
         await Hmp1Protocol.WriteClientHelloAsync(s2, displayName: "regression", defaultRole: null, cts.Token);
 
         var helloFrame = await Hmp1Protocol.ReadFrameAsync(s2, cts.Token)
-            ?? throw new Xunit.Sdk.XunitException("Server closed the stream before sending Hello.");
-        Assert.Equal(Hmp1FrameType.Hello, helloFrame.Type);
+            ?? throw new AssertFailedException("Server closed the stream before sending Hello.");
+        Assert.AreEqual(Hmp1FrameType.Hello, helloFrame.Type);
 
         var stateSyncFrame = await Hmp1Protocol.ReadFrameAsync(s2, cts.Token)
-            ?? throw new Xunit.Sdk.XunitException("Server closed the stream before sending StateSync.");
-        Assert.Equal(Hmp1FrameType.StateSync, stateSyncFrame.Type);
+            ?? throw new AssertFailedException("Server closed the stream before sending StateSync.");
+        Assert.AreEqual(Hmp1FrameType.StateSync, stateSyncFrame.Type);
 
         // Drain the AddClient task so any post-handshake observer doesn't
         // race with test teardown.
@@ -93,7 +94,7 @@ public class Hmp1StateReplayCursorRegressionTests
         await using var handleDispose = handle;
 
         var payload = stateSyncFrame.Payload;
-        Assert.False(payload.IsEmpty, "StateSync payload should carry the screen snapshot.");
+        Assert.IsFalse(payload.IsEmpty, "StateSync payload should carry the screen snapshot.");
 
         // Core regression assertion: a trailing \n (or \r\n) here would
         // scroll the cursor down one row past wherever the cursor-position
@@ -101,9 +102,7 @@ public class Hmp1StateReplayCursorRegressionTests
         // last byte explicitly so a future tweak that re-introduces
         // IncludeTrailingNewline = true fails this loud and clear.
         var lastByte = payload.Span[^1];
-        Assert.True(
-            lastByte != (byte)'\n',
-            $"StateSync payload ended with LF (0x0A). The cursor-position sequence emitted by ToAnsi "
+        Assert.IsTrue(lastByte != (byte)'\n', $"StateSync payload ended with LF (0x0A). The cursor-position sequence emitted by ToAnsi "
             + "would be invalidated by a trailing newline (cursor scrolls down one row). "
             + "If you re-enabled IncludeTrailingNewline = true in Hmp1PresentationAdapter, "
             + "PSReadLine and other readline-style consumers will mis-place the first "
@@ -115,7 +114,7 @@ public class Hmp1StateReplayCursorRegressionTests
         // branch. The exact form is `\x1b[{n}G` (column-only when we're on
         // the bottom row already) or `\x1b[{m}A\x1b[{n}G`. In either case
         // the trailing token is `G`.
-        Assert.Equal((byte)'G', lastByte);
+        Assert.AreEqual((byte)'G', lastByte);
     }
 
     private sealed class NullWorkloadAdapter : IHex1bTerminalWorkloadAdapter

--- a/tests/Hex1b.Tests/HyperlinkNodeTests.cs
+++ b/tests/Hex1b.Tests/HyperlinkNodeTests.cs
@@ -7,31 +7,32 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class HyperlinkNodeTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Measure_ReturnsTextWidth()
     {
         var node = new HyperlinkNode { Text = "Click here", Uri = "https://example.com" };
         
         var size = node.Measure(Constraints.Unbounded);
         
-        Assert.Equal(10, size.Width); // "Click here" is 10 characters
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(10, size.Width); // "Click here" is 10 characters
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_WithEmptyText_ReturnsZeroWidth()
     {
         var node = new HyperlinkNode { Text = "", Uri = "https://example.com" };
         
         var size = node.Measure(Constraints.Unbounded);
         
-        Assert.Equal(0, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_RespectsMaxConstraints()
     {
         var node = new HyperlinkNode { Text = "This is a very long hyperlink text", Uri = "https://example.com" };
@@ -39,18 +40,18 @@ public class HyperlinkNodeTests
         
         var size = node.Measure(constraints);
         
-        Assert.Equal(10, size.Width); // Clamped to max
+        Assert.AreEqual(10, size.Width); // Clamped to max
     }
 
-    [Fact]
+    [TestMethod]
     public async Task IsFocusable_ReturnsTrue()
     {
         var node = new HyperlinkNode();
         
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task IsFocused_WhenChanged_MarksDirty()
     {
         var node = new HyperlinkNode();
@@ -58,10 +59,10 @@ public class HyperlinkNodeTests
         
         node.IsFocused = true;
         
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task IsHovered_WhenChanged_MarksDirty()
     {
         var node = new HyperlinkNode();
@@ -69,10 +70,10 @@ public class HyperlinkNodeTests
         
         node.IsHovered = true;
         
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Text_WhenChanged_MarksDirty()
     {
         var node = new HyperlinkNode { Text = "Initial" };
@@ -80,10 +81,10 @@ public class HyperlinkNodeTests
         
         node.Text = "Changed";
         
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Uri_WhenChanged_MarksDirty()
     {
         var node = new HyperlinkNode { Uri = "https://old.com" };
@@ -91,10 +92,10 @@ public class HyperlinkNodeTests
         
         node.Uri = "https://new.com";
         
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Parameters_WhenChanged_MarksDirty()
     {
         var node = new HyperlinkNode { Parameters = "" };
@@ -102,10 +103,10 @@ public class HyperlinkNodeTests
         
         node.Parameters = "id=test";
         
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_OutputsOsc8Sequences()
     {
         var node = new HyperlinkNode 
@@ -132,7 +133,7 @@ public class HyperlinkNodeTests
         Assert.Contains("Link", snapshot.GetLineTrimmed(0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithParameters_IncludesParametersInSequence()
     {
         var node = new HyperlinkNode 
@@ -159,7 +160,7 @@ public class HyperlinkNodeTests
         Assert.Contains("Link", snapshot.GetLineTrimmed(0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Enter_TriggersClickAction()
     {
         var clicked = false;
@@ -173,11 +174,11 @@ public class HyperlinkNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Enter, '\r', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(clicked);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_OtherKey_DoesNotClick()
     {
         var clicked = false;
@@ -191,11 +192,11 @@ public class HyperlinkNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.A, 'a', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.NotHandled, result);
-        Assert.False(clicked);
+        Assert.AreEqual(InputResult.NotHandled, result);
+        Assert.IsFalse(clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_NullClickAction_DoesNotThrow()
     {
         var node = new HyperlinkNode 
@@ -209,58 +210,59 @@ public class HyperlinkNodeTests
         // With no ClickAction, no bindings are registered, so Enter falls through
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Enter, '\r', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
     }
 }
 
+[TestClass]
 public class HyperlinkWidgetTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Constructor_SetsTextAndUri()
     {
         var widget = new HyperlinkWidget("Click me", "https://example.com");
         
-        Assert.Equal("Click me", widget.Text);
-        Assert.Equal("https://example.com", widget.Uri);
+        Assert.AreEqual("Click me", widget.Text);
+        Assert.AreEqual("https://example.com", widget.Uri);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Parameters_SetsParameters()
     {
         var widget = new HyperlinkWidget("Link", "https://example.com")
             .Parameters("id=test");
         
-        Assert.Equal("id=test", widget.ParameterString);
+        Assert.AreEqual("id=test", widget.ParameterString);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Id_SetsIdParameter()
     {
         var widget = new HyperlinkWidget("Link", "https://example.com")
             .Id("unique123");
         
-        Assert.Equal("id=unique123", widget.ParameterString);
+        Assert.AreEqual("id=unique123", widget.ParameterString);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OnClick_SetsClickHandler()
     {
         var widget = new HyperlinkWidget("Link", "https://example.com")
             .OnClick(_ => { });
         
-        Assert.NotNull(widget.ClickHandler);
+        Assert.IsNotNull(widget.ClickHandler);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OnClick_Async_SetsClickHandler()
     {
         var widget = new HyperlinkWidget("Link", "https://example.com")
             .OnClick(async _ => { await Task.Delay(1); });
         
-        Assert.NotNull(widget.ClickHandler);
+        Assert.IsNotNull(widget.ClickHandler);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_CreatesNewNode()
     {
         var widget = new HyperlinkWidget("Link", "https://example.com");
@@ -268,13 +270,13 @@ public class HyperlinkWidgetTests
         
         var node = widget.ReconcileAsync(null, context).GetAwaiter().GetResult();
         
-        Assert.IsType<HyperlinkNode>(node);
+        TestSeq.IsType<HyperlinkNode>(node);
         var hyperlinkNode = (HyperlinkNode)node;
-        Assert.Equal("Link", hyperlinkNode.Text);
-        Assert.Equal("https://example.com", hyperlinkNode.Uri);
+        Assert.AreEqual("Link", hyperlinkNode.Text);
+        Assert.AreEqual("https://example.com", hyperlinkNode.Uri);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_ReusesExistingNode()
     {
         var widget = new HyperlinkWidget("Link", "https://example.com");
@@ -283,10 +285,10 @@ public class HyperlinkWidgetTests
         
         var node = widget.ReconcileAsync(existingNode, context).GetAwaiter().GetResult();
         
-        Assert.Same(existingNode, node);
+        Assert.AreSame(existingNode, node);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_UpdatesNodeProperties()
     {
         var widget = new HyperlinkWidget("New Text", "https://new.com")
@@ -302,23 +304,24 @@ public class HyperlinkWidgetTests
         var node = widget.ReconcileAsync(existingNode, context).GetAwaiter().GetResult();
         
         var hyperlinkNode = (HyperlinkNode)node;
-        Assert.Equal("New Text", hyperlinkNode.Text);
-        Assert.Equal("https://new.com", hyperlinkNode.Uri);
-        Assert.Equal("id=new", hyperlinkNode.Parameters);
+        Assert.AreEqual("New Text", hyperlinkNode.Text);
+        Assert.AreEqual("https://new.com", hyperlinkNode.Uri);
+        Assert.AreEqual("id=new", hyperlinkNode.Parameters);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetExpectedNodeType_ReturnsHyperlinkNode()
     {
         var widget = new HyperlinkWidget("Link", "https://example.com");
         
-        Assert.Equal(typeof(HyperlinkNode), widget.GetExpectedNodeType());
+        Assert.AreEqual(typeof(HyperlinkNode), widget.GetExpectedNodeType());
     }
 }
 
+[TestClass]
 public class HyperlinkIntegrationTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Integration_Hyperlink_RendersViaHex1bApp()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -342,10 +345,10 @@ public class HyperlinkIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("GitHub"));
+        Assert.IsTrue(snapshot.ContainsText("GitHub"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Hyperlink_Enter_TriggersAction()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -375,11 +378,11 @@ public class HyperlinkIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(clicked);
-        Assert.Equal("https://example.com", clickedUri);
+        Assert.IsTrue(clicked);
+        Assert.AreEqual("https://example.com", clickedUri);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_MultipleHyperlinks_TabNavigates()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -409,11 +412,11 @@ public class HyperlinkIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.False(link1Clicked);
-        Assert.True(link2Clicked);
+        Assert.IsFalse(link1Clicked);
+        Assert.IsTrue(link2Clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_HyperlinkWithButton_TabBetween()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -443,8 +446,8 @@ public class HyperlinkIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.False(linkClicked);
-        Assert.True(buttonClicked);
+        Assert.IsFalse(linkClicked);
+        Assert.IsTrue(buttonClicked);
     }
 }
 

--- a/tests/Hex1b.Tests/IconNodeTests.cs
+++ b/tests/Hex1b.Tests/IconNodeTests.cs
@@ -4,36 +4,37 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class IconNodeTests
 {
-    [Fact]
+    [TestMethod]
     public void Measure_SingleCharIcon_Returns1x1()
     {
         var node = new IconNode { Icon = "▶" };
         var size = node.Measure(new Constraints(0, 100, 0, 10));
         
-        Assert.Equal(1, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(1, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
     
-    [Fact]
+    [TestMethod]
     public void Measure_MultiCharIcon_ReturnsCorrectWidth()
     {
         var node = new IconNode { Icon = "[x]" };
         var size = node.Measure(new Constraints(0, 100, 0, 10));
         
-        Assert.Equal(3, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(3, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
     
-    [Fact]
+    [TestMethod]
     public void IsClickable_WithoutHandler_ReturnsFalse()
     {
         var node = new IconNode { Icon = "▶" };
-        Assert.False(node.IsClickable);
+        Assert.IsFalse(node.IsClickable);
     }
     
-    [Fact]
+    [TestMethod]
     public void IsClickable_WithHandler_ReturnsTrue()
     {
         var node = new IconNode 
@@ -41,10 +42,10 @@ public class IconNodeTests
             Icon = "▶",
             ClickCallback = _ => Task.CompletedTask
         };
-        Assert.True(node.IsClickable);
+        Assert.IsTrue(node.IsClickable);
     }
     
-    [Fact]
+    [TestMethod]
     public void ConfigureDefaultBindings_WithHandler_AddsMouseBinding()
     {
         var node = new IconNode 
@@ -56,10 +57,10 @@ public class IconNodeTests
         var builder = new InputBindingsBuilder();
         node.ConfigureDefaultBindings(builder);
         
-        Assert.NotEmpty(builder.MouseBindings);
+        Assert.IsNotEmpty(builder.MouseBindings);
     }
     
-    [Fact]
+    [TestMethod]
     public void ConfigureDefaultBindings_WithoutHandler_NoBindings()
     {
         var node = new IconNode { Icon = "▶" };
@@ -67,10 +68,10 @@ public class IconNodeTests
         var builder = new InputBindingsBuilder();
         node.ConfigureDefaultBindings(builder);
         
-        Assert.Empty(builder.MouseBindings);
+        Assert.IsEmpty(builder.MouseBindings);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_CreatesNewNode()
     {
         var widget = new IconWidget("▶");
@@ -78,11 +79,11 @@ public class IconNodeTests
         
         var node = await widget.ReconcileAsync(null, context);
         
-        Assert.IsType<IconNode>(node);
-        Assert.Equal("▶", ((IconNode)node).Icon);
+        TestSeq.IsType<IconNode>(node);
+        Assert.AreEqual("▶", ((IconNode)node).Icon);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_UpdatesExistingNode()
     {
         var existingNode = new IconNode { Icon = "▶" };
@@ -91,11 +92,11 @@ public class IconNodeTests
         
         var node = await widget.ReconcileAsync(existingNode, context);
         
-        Assert.Same(existingNode, node);
-        Assert.Equal("▼", ((IconNode)node).Icon);
+        Assert.AreSame(existingNode, node);
+        Assert.AreEqual("▼", ((IconNode)node).Icon);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_WithClickHandler_SetsCallback()
     {
         var widget = new IconWidget("▶").OnClick(_ => { });
@@ -104,16 +105,16 @@ public class IconNodeTests
         var node = await widget.ReconcileAsync(null, context);
         var iconNode = (IconNode)node;
         
-        Assert.NotNull(iconNode.ClickCallback);
+        Assert.IsNotNull(iconNode.ClickCallback);
     }
     
-    [Fact]
+    [TestMethod]
     public void Widget_OnClick_ReturnsNewWidgetWithHandler()
     {
         var widget = new IconWidget("▶");
         var withClick = widget.OnClick(_ => { });
         
-        Assert.NotSame(widget, withClick);
-        Assert.NotNull(withClick.ClickHandler);
+        Assert.AreNotSame(widget, withClick);
+        Assert.IsNotNull(withClick.ClickHandler);
     }
 }

--- a/tests/Hex1b.Tests/InfoBarWidgetTests.cs
+++ b/tests/Hex1b.Tests/InfoBarWidgetTests.cs
@@ -8,11 +8,12 @@ namespace Hex1b.Tests;
 /// Tests for InfoBarWidget rendering, theming, and composition.
 /// Uses full terminal stack testing as per writing-unit-tests skill.
 /// </summary>
+[TestClass]
 public class InfoBarWidgetTests
 {
     #region Basic Rendering Tests
 
-    [Fact]
+    [TestMethod]
     public async Task InfoBar_SingleSection_RendersText()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -32,10 +33,10 @@ public class InfoBarWidgetTests
 
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Ready"));
+        Assert.IsTrue(snapshot.ContainsText("Ready"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task InfoBar_MultipleSections_RendersAll()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -62,13 +63,13 @@ public class InfoBarWidgetTests
 
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Mode: Insert"));
-        Assert.True(snapshot.ContainsText("|"));
-        Assert.True(snapshot.ContainsText("UTF-8"));
-        Assert.True(snapshot.ContainsText("Ln 42"));
+        Assert.IsTrue(snapshot.ContainsText("Mode: Insert"));
+        Assert.IsTrue(snapshot.ContainsText("|"));
+        Assert.IsTrue(snapshot.ContainsText("UTF-8"));
+        Assert.IsTrue(snapshot.ContainsText("Ln 42"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task InfoBar_Divider_InsertsDividersBetweenSections()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -102,7 +103,7 @@ public class InfoBarWidgetTests
 
     #region Spacer Tests
 
-    [Fact]
+    [TestMethod]
     public async Task InfoBar_WithSpacer_PushesContentApart()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -127,15 +128,15 @@ public class InfoBarWidgetTests
 
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Left"));
-        Assert.True(snapshot.ContainsText("Right"));
+        Assert.IsTrue(snapshot.ContainsText("Left"));
+        Assert.IsTrue(snapshot.ContainsText("Right"));
     }
 
     #endregion
 
     #region Color Inversion Tests
 
-    [Fact]
+    [TestMethod]
     public async Task InfoBar_WithInvertColors_SwapsForegroundAndBackground()
     {
         var theme = new Hex1bTheme("Test")
@@ -162,11 +163,11 @@ public class InfoBarWidgetTests
         await runTask;
 
         // With inversion: white foreground becomes background, black background becomes foreground
-        Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 255, 255)), "Should have white background");
-        Assert.True(snapshot.HasForegroundColor(Hex1bColor.FromRgb(0, 0, 0)), "Should have black foreground");
+        Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 255, 255)), "Should have white background");
+        Assert.IsTrue(snapshot.HasForegroundColor(Hex1bColor.FromRgb(0, 0, 0)), "Should have black foreground");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task InfoBar_WithInvertColorsFalse_RendersText()
     {
         var theme = new Hex1bTheme("Test")
@@ -193,14 +194,14 @@ public class InfoBarWidgetTests
         await runTask;
 
         // Verify text renders (color assertions removed - they depend on terminal color capture which can be flaky)
-        Assert.True(snapshot.ContainsText("Normal"));
+        Assert.IsTrue(snapshot.ContainsText("Normal"));
     }
 
     #endregion
 
     #region Section Theme Tests
 
-    [Fact]
+    [TestMethod]
     public async Task InfoBar_SectionWithTheme_AppliesCustomColors()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -226,18 +227,18 @@ public class InfoBarWidgetTests
 
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Normal"));
-        Assert.True(snapshot.ContainsText("Error"));
+        Assert.IsTrue(snapshot.ContainsText("Normal"));
+        Assert.IsTrue(snapshot.ContainsText("Error"));
         // Error section should have custom colors
-        Assert.True(snapshot.HasForegroundColor(Hex1bColor.FromRgb(255, 0, 0)), "Should have red foreground for Error");
-        Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 255, 0)), "Should have yellow background for Error");
+        Assert.IsTrue(snapshot.HasForegroundColor(Hex1bColor.FromRgb(255, 0, 0)), "Should have red foreground for Error");
+        Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 255, 0)), "Should have yellow background for Error");
     }
 
     #endregion
 
     #region Layout Tests
 
-    [Fact]
+    [TestMethod]
     public async Task InfoBar_InVStack_PositionedCorrectly()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -261,14 +262,14 @@ public class InfoBarWidgetTests
 
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Main Content"));
-        Assert.True(snapshot.ContainsText("Status Bar"));
+        Assert.IsTrue(snapshot.ContainsText("Main Content"));
+        Assert.IsTrue(snapshot.ContainsText("Status Bar"));
     }
 
-    [Theory]
-    [InlineData(40, 5)]
-    [InlineData(80, 24)]
-    [InlineData(120, 40)]
+    [TestMethod]
+    [DataRow(40, 5)]
+    [DataRow(80, 24)]
+    [DataRow(120, 40)]
     public async Task InfoBar_VariousTerminalSizes_RendersCorrectly(int width, int height)
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -293,15 +294,15 @@ public class InfoBarWidgetTests
 
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Mode"));
-        Assert.True(snapshot.ContainsText("Ready"));
+        Assert.IsTrue(snapshot.ContainsText("Mode"));
+        Assert.IsTrue(snapshot.ContainsText("Ready"));
     }
 
     #endregion
 
     #region Theming Integration Tests
 
-    [Fact]
+    [TestMethod]
     public async Task InfoBar_WithInfoBarTheme_AppliesCorrectly()
     {
         var theme = Hex1bThemes.Default.Clone()
@@ -327,14 +328,14 @@ public class InfoBarWidgetTests
 
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Themed"));
+        Assert.IsTrue(snapshot.ContainsText("Themed"));
     }
 
     #endregion
 
     #region Widget Content Tests
 
-    [Fact]
+    [TestMethod]
     public async Task InfoBar_SectionWithWidgetContent_RendersWidget()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -360,8 +361,8 @@ public class InfoBarWidgetTests
 
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Status:"));
-        Assert.True(snapshot.ContainsText("OK"));
+        Assert.IsTrue(snapshot.ContainsText("Status:"));
+        Assert.IsTrue(snapshot.ContainsText("OK"));
     }
 
     #endregion

--- a/tests/Hex1b.Tests/InlineHintTests.cs
+++ b/tests/Hex1b.Tests/InlineHintTests.cs
@@ -10,6 +10,7 @@ namespace Hex1b.Tests;
 /// Tests for inline hints — virtual text rendered inline at document positions
 /// without modifying the document model.
 /// </summary>
+[TestClass]
 public class InlineHintTests
 {
     private static Hex1bColor? ToCellColor(Hex1bColor color) => color.IsDefault ? null : color;
@@ -39,7 +40,7 @@ public class InlineHintTests
 
     // ── IEditorSession state management tests ─────────────────────
 
-    [Fact]
+    [TestMethod]
     public void PushInlineHints_StoresHintsOnSession()
     {
         var doc = new Hex1bDocument("hello world");
@@ -55,12 +56,12 @@ public class InlineHintTests
 
         session.PushInlineHints(hints);
 
-        Assert.Equal(2, session.ActiveInlineHints.Count);
-        Assert.Equal(": string", session.ActiveInlineHints[0].Text);
-        Assert.Equal(" -> int", session.ActiveInlineHints[1].Text);
+        Assert.AreEqual(2, session.ActiveInlineHints.Count);
+        Assert.AreEqual(": string", session.ActiveInlineHints[0].Text);
+        Assert.AreEqual(" -> int", session.ActiveInlineHints[1].Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void PushInlineHints_ReplacesPreviousHints()
     {
         var doc = new Hex1bDocument("x = 5");
@@ -71,11 +72,11 @@ public class InlineHintTests
         session.PushInlineHints([new InlineHint(new DocumentPosition(1, 1), " (any)")]);
         session.PushInlineHints([new InlineHint(new DocumentPosition(1, 1), " (number)")]);
 
-        Assert.Single(session.ActiveInlineHints);
-        Assert.Equal(" (number)", session.ActiveInlineHints[0].Text);
+        TestSeq.Single(session.ActiveInlineHints);
+        Assert.AreEqual(" (number)", session.ActiveInlineHints[0].Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClearInlineHints_RemovesAllHints()
     {
         var doc = new Hex1bDocument("x = 5");
@@ -84,14 +85,14 @@ public class InlineHintTests
         var session = (IEditorSession)node;
 
         session.PushInlineHints([new InlineHint(new DocumentPosition(1, 1), " (int)")]);
-        Assert.Single(session.ActiveInlineHints);
+        TestSeq.Single(session.ActiveInlineHints);
 
         session.ClearInlineHints();
 
-        Assert.Empty(session.ActiveInlineHints);
+        Assert.IsEmpty(session.ActiveInlineHints);
     }
 
-    [Fact]
+    [TestMethod]
     public void ActiveInlineHints_InitiallyEmpty()
     {
         var doc = new Hex1bDocument("test");
@@ -99,12 +100,12 @@ public class InlineHintTests
         var node = new EditorNode { State = state };
         var session = (IEditorSession)node;
 
-        Assert.Empty(session.ActiveInlineHints);
+        Assert.IsEmpty(session.ActiveInlineHints);
     }
 
     // ── Visual rendering tests ────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task Render_InlineHint_AppearsAtCorrectPosition()
     {
         // "hello" with hint ": str" at column 6 (after 'o') → "hello: str"
@@ -127,24 +128,24 @@ public class InlineHintTests
         var snapshot = terminal.CreateSnapshot();
 
         // Verify original text is at expected positions
-        Assert.Equal("h", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("e", snapshot.GetCell(1, 0).Character);
-        Assert.Equal("l", snapshot.GetCell(2, 0).Character);
-        Assert.Equal("l", snapshot.GetCell(3, 0).Character);
-        Assert.Equal("o", snapshot.GetCell(4, 0).Character);
+        Assert.AreEqual("h", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("e", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("l", snapshot.GetCell(2, 0).Character);
+        Assert.AreEqual("l", snapshot.GetCell(3, 0).Character);
+        Assert.AreEqual("o", snapshot.GetCell(4, 0).Character);
 
         // Verify hint text follows immediately
-        Assert.Equal(":", snapshot.GetCell(5, 0).Character);
-        Assert.Equal(" ", snapshot.GetCell(6, 0).Character);
-        Assert.Equal("s", snapshot.GetCell(7, 0).Character);
-        Assert.Equal("t", snapshot.GetCell(8, 0).Character);
-        Assert.Equal("r", snapshot.GetCell(9, 0).Character);
+        Assert.AreEqual(":", snapshot.GetCell(5, 0).Character);
+        Assert.AreEqual(" ", snapshot.GetCell(6, 0).Character);
+        Assert.AreEqual("s", snapshot.GetCell(7, 0).Character);
+        Assert.AreEqual("t", snapshot.GetCell(8, 0).Character);
+        Assert.AreEqual("r", snapshot.GetCell(9, 0).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_InlineHint_ShiftsSubsequentTextRight()
     {
         // "ab" with hint "XX" at column 2 (before 'b') → "aXXb"
@@ -166,16 +167,16 @@ public class InlineHintTests
 
         var snapshot = terminal.CreateSnapshot();
 
-        Assert.Equal("a", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("X", snapshot.GetCell(1, 0).Character);
-        Assert.Equal("X", snapshot.GetCell(2, 0).Character);
-        Assert.Equal("b", snapshot.GetCell(3, 0).Character);
+        Assert.AreEqual("a", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("X", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("X", snapshot.GetCell(2, 0).Character);
+        Assert.AreEqual("b", snapshot.GetCell(3, 0).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_InlineHint_UsesThemeForegroundColor()
     {
         var (node, workload, terminal, context, theme) = CreateEditor("hello", 30, 3, focused: false);
@@ -201,8 +202,7 @@ public class InlineHintTests
         for (var x = 5; x <= 9; x++) // ": int" at columns 5-9
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(ColorEquals(expectedHintFg, cell.Foreground),
-                $"Hint column {x}: expected hint fg {expectedHintFg}, got {cell.Foreground}");
+            Assert.IsTrue(ColorEquals(expectedHintFg, cell.Foreground), $"Hint column {x}: expected hint fg {expectedHintFg}, got {cell.Foreground}");
         }
 
         // Original text should use editor foreground, not hint foreground
@@ -210,15 +210,14 @@ public class InlineHintTests
         for (var x = 0; x <= 4; x++) // "hello" at columns 0-4
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(ColorEquals(editorFg, cell.Foreground),
-                $"Text column {x}: expected editor fg {editorFg}, got {cell.Foreground}");
+            Assert.IsTrue(ColorEquals(editorFg, cell.Foreground), $"Text column {x}: expected editor fg {editorFg}, got {cell.Foreground}");
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_InlineHint_CustomDecorationOverridesTheme()
     {
         var customColor = Hex1bColor.FromRgb(255, 100, 0); // orange
@@ -247,15 +246,14 @@ public class InlineHintTests
         for (var x = 4; x <= 6; x++) // " OK" at columns 4-6
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(ColorEquals(expectedFg, cell.Foreground),
-                $"Hint column {x}: expected custom fg {expectedFg}, got {cell.Foreground}");
+            Assert.IsTrue(ColorEquals(expectedFg, cell.Foreground), $"Hint column {x}: expected custom fg {expectedFg}, got {cell.Foreground}");
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_MultipleHintsOnSameLine_AllRendered()
     {
         // "a b c" with hints after each: "a[X] b[Y] c"
@@ -279,19 +277,19 @@ public class InlineHintTests
 
         var snapshot = terminal.CreateSnapshot();
 
-        Assert.Equal("a", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("X", snapshot.GetCell(1, 0).Character);
-        Assert.Equal(" ", snapshot.GetCell(2, 0).Character);
-        Assert.Equal("b", snapshot.GetCell(3, 0).Character);
-        Assert.Equal("Y", snapshot.GetCell(4, 0).Character);
-        Assert.Equal(" ", snapshot.GetCell(5, 0).Character);
-        Assert.Equal("c", snapshot.GetCell(6, 0).Character);
+        Assert.AreEqual("a", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("X", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual(" ", snapshot.GetCell(2, 0).Character);
+        Assert.AreEqual("b", snapshot.GetCell(3, 0).Character);
+        Assert.AreEqual("Y", snapshot.GetCell(4, 0).Character);
+        Assert.AreEqual(" ", snapshot.GetCell(5, 0).Character);
+        Assert.AreEqual("c", snapshot.GetCell(6, 0).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_HintOnDifferentLines_RenderedOnCorrectLines()
     {
         var (node, workload, terminal, context, theme) = CreateEditor("abc\ndef", 30, 5, focused: false);
@@ -316,22 +314,22 @@ public class InlineHintTests
         var snapshot = terminal.CreateSnapshot();
 
         // Line 0: "abcX..."
-        Assert.Equal("a", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("b", snapshot.GetCell(1, 0).Character);
-        Assert.Equal("c", snapshot.GetCell(2, 0).Character);
-        Assert.Equal("X", snapshot.GetCell(3, 0).Character);
+        Assert.AreEqual("a", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("b", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("c", snapshot.GetCell(2, 0).Character);
+        Assert.AreEqual("X", snapshot.GetCell(3, 0).Character);
 
         // Line 1: "defY..."
-        Assert.Equal("d", snapshot.GetCell(0, 1).Character);
-        Assert.Equal("e", snapshot.GetCell(1, 1).Character);
-        Assert.Equal("f", snapshot.GetCell(2, 1).Character);
-        Assert.Equal("Y", snapshot.GetCell(3, 1).Character);
+        Assert.AreEqual("d", snapshot.GetCell(0, 1).Character);
+        Assert.AreEqual("e", snapshot.GetCell(1, 1).Character);
+        Assert.AreEqual("f", snapshot.GetCell(2, 1).Character);
+        Assert.AreEqual("Y", snapshot.GetCell(3, 1).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_HintAtStartOfLine_PrependedBeforeFirstChar()
     {
         // Hint at column 1 (before 'a') → "Xa"
@@ -353,15 +351,15 @@ public class InlineHintTests
 
         var snapshot = terminal.CreateSnapshot();
 
-        Assert.Equal("X", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("a", snapshot.GetCell(1, 0).Character);
-        Assert.Equal("b", snapshot.GetCell(2, 0).Character);
+        Assert.AreEqual("X", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("a", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("b", snapshot.GetCell(2, 0).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_HintPushedOverViewport_TextTruncatedCorrectly()
     {
         // Viewport only 10 chars wide. "abcde" + hint "XXXXX" at end = "abcdeXXXXX" exactly fills it
@@ -384,16 +382,16 @@ public class InlineHintTests
         var snapshot = terminal.CreateSnapshot();
 
         // Verify all 10 characters
-        Assert.Equal("a", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("e", snapshot.GetCell(4, 0).Character);
-        Assert.Equal("X", snapshot.GetCell(5, 0).Character);
-        Assert.Equal("X", snapshot.GetCell(9, 0).Character);
+        Assert.AreEqual("a", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("e", snapshot.GetCell(4, 0).Character);
+        Assert.AreEqual("X", snapshot.GetCell(5, 0).Character);
+        Assert.AreEqual("X", snapshot.GetCell(9, 0).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_NoHints_RendersNormally()
     {
         // Sanity check: without hints, text renders as expected
@@ -410,19 +408,19 @@ public class InlineHintTests
 
         var snapshot = terminal.CreateSnapshot();
 
-        Assert.Equal("h", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("e", snapshot.GetCell(1, 0).Character);
-        Assert.Equal("l", snapshot.GetCell(2, 0).Character);
-        Assert.Equal("l", snapshot.GetCell(3, 0).Character);
-        Assert.Equal("o", snapshot.GetCell(4, 0).Character);
-        Assert.Equal(" ", snapshot.GetCell(5, 0).Character);
-        Assert.Equal("w", snapshot.GetCell(6, 0).Character);
+        Assert.AreEqual("h", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("e", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("l", snapshot.GetCell(2, 0).Character);
+        Assert.AreEqual("l", snapshot.GetCell(3, 0).Character);
+        Assert.AreEqual("o", snapshot.GetCell(4, 0).Character);
+        Assert.AreEqual(" ", snapshot.GetCell(5, 0).Character);
+        Assert.AreEqual("w", snapshot.GetCell(6, 0).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_ClearHints_HintsDisappearOnRerender()
     {
         var (node, workload, terminal, context, theme) = CreateEditor("ab", 30, 3, focused: false);
@@ -462,14 +460,14 @@ public class InlineHintTests
 
         var snapshot = terminal.CreateSnapshot();
 
-        Assert.Equal("a", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("b", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("a", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("b", snapshot.GetCell(1, 0).Character);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_HintWithItalic_ThemeDefaultApplied()
     {
         // Default theme has IsItalic = true for inline hints
@@ -493,22 +491,20 @@ public class InlineHintTests
 
         // Verify hint text has italic attribute (theme default is italic=true)
         var hintIsItalic = theme.Get(InlineHintTheme.IsItalic);
-        Assert.True(hintIsItalic, "Default theme should have IsItalic=true for inline hints");
+        Assert.IsTrue(hintIsItalic, "Default theme should have IsItalic=true for inline hints");
 
         // Verify hint characters have the italic flag
         for (var x = 5; x <= 9; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(cell.IsItalic,
-                $"Hint column {x}: expected italic, but cell was not italic");
+            Assert.IsTrue(cell.IsItalic, $"Hint column {x}: expected italic, but cell was not italic");
         }
 
         // Original text should NOT be italic (no decoration applied)
         for (var x = 0; x <= 4; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.False(cell.IsItalic,
-                $"Text column {x}: should not be italic, but cell was italic");
+            Assert.IsFalse(cell.IsItalic, $"Text column {x}: should not be italic, but cell was italic");
         }
 
         workload.Dispose();

--- a/tests/Hex1b.Tests/InputBindingFluentApiTests.cs
+++ b/tests/Hex1b.Tests/InputBindingFluentApiTests.cs
@@ -7,6 +7,7 @@ namespace Hex1b.Tests;
 /// Tests for input bindings using the fluent API, ensuring all keys fire correctly
 /// after reconciliation has occurred.
 /// </summary>
+[TestClass]
 public class InputBindingFluentApiTests
 {
     /// <summary>
@@ -28,8 +29,8 @@ public class InputBindingFluentApiTests
         }
     }
 
-    [Theory]
-    [MemberData(nameof(AllHex1bKeys))]
+    [TestMethod]
+    [DynamicData(nameof(AllHex1bKeys))]
     public async Task InputBinding_FluentApi_FiresForAllKeys(Hex1bKey key)
     {
         // Arrange
@@ -86,15 +87,15 @@ public class InputBindingFluentApiTests
         await bindingFired.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
 
         // Verify the correct key was received
-        Assert.Equal(key, firedKey);
+        Assert.AreEqual(key, firedKey);
 
         // Clean up
         cts.Cancel();
         await runTask;
     }
 
-    [Theory]
-    [MemberData(nameof(AllHex1bKeys))]
+    [TestMethod]
+    [DynamicData(nameof(AllHex1bKeys))]
     public async Task InputBinding_FluentApi_WithCtrlModifier_FiresForAllKeys(Hex1bKey key)
     {
         // Arrange
@@ -147,8 +148,8 @@ public class InputBindingFluentApiTests
         await runTask;
     }
 
-    [Theory]
-    [MemberData(nameof(AllHex1bKeys))]
+    [TestMethod]
+    [DynamicData(nameof(AllHex1bKeys))]
     public async Task InputBinding_FluentApi_WithShiftModifier_FiresForAllKeys(Hex1bKey key)
     {
         // Arrange
@@ -201,7 +202,7 @@ public class InputBindingFluentApiTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task InputBinding_FluentApi_MultipleBindings_EachFiresCorrectly()
     {
         // Arrange
@@ -255,7 +256,7 @@ public class InputBindingFluentApiTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public void InputBinding_InputBindings_SetsConfiguratorOnWidget()
     {
         // Verify that InputBindings actually sets the configurator on the widget
@@ -271,20 +272,20 @@ public class InputBindingFluentApiTests
         // Check that BindingsConfigurator is set (internal property)
         var configuratorField = typeof(Hex1bWidget).GetProperty("BindingsConfigurator", 
             System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-        Assert.NotNull(configuratorField);
+        Assert.IsNotNull(configuratorField);
         
         var configurator = configuratorField!.GetValue(widget) as Action<InputBindingsBuilder>;
-        Assert.NotNull(configurator);
+        Assert.IsNotNull(configurator);
         
         // Invoke it and verify it runs
         var builder = new InputBindingsBuilder();
         configurator!(builder);
         
-        Assert.True(configured, "The configurator callback should have been invoked");
-        Assert.True(builder.Bindings.Count >= 1, "At least one binding should have been added");
+        Assert.IsTrue(configured, "The configurator callback should have been invoked");
+        Assert.IsTrue(builder.Bindings.Count >= 1, "At least one binding should have been added");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task InputBinding_DiagnosticTest_VerifyBindingsAreSet()
     {
         // This test verifies that user bindings configured via InputBindings work
@@ -333,7 +334,7 @@ public class InputBindingFluentApiTests
         await runTask;
     }
     
-    [Fact]
+    [TestMethod]
     public async Task InputBinding_DiagnosticTest_UserBindingWithCtrlCDisabled()
     {
         // Test with CTRL-C disabled to isolate user bindings
@@ -382,7 +383,7 @@ public class InputBindingFluentApiTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task InputBinding_FluentApi_ChordBinding_FiresOnSecondKey()
     {
         // Arrange
@@ -437,7 +438,7 @@ public class InputBindingFluentApiTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task InputBinding_ReconciliationPreservesBindings()
     {
         // Arrange - verify that bindings are preserved across reconciliation
@@ -485,7 +486,7 @@ public class InputBindingFluentApiTests
             .WaitUntil(_ => Volatile.Read(ref reconcileCount) >= 1, TimeSpan.FromSeconds(1), "initial reconciliation")
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
-        Assert.True(reconcileCount >= 1, "Expected at least one reconciliation");
+        Assert.IsTrue(reconcileCount >= 1, "Expected at least one reconciliation");
 
         // Fire binding before re-render
         await new Hex1bTerminalInputSequenceBuilder()
@@ -493,7 +494,7 @@ public class InputBindingFluentApiTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await firstBindingFired.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
-        Assert.Equal(1, bindingFireCount);
+        Assert.AreEqual(1, bindingFireCount);
 
         // Force a re-render by invalidating
         app.Invalidate();
@@ -501,7 +502,7 @@ public class InputBindingFluentApiTests
             .WaitUntil(_ => Volatile.Read(ref reconcileCount) >= 2, TimeSpan.FromSeconds(1), "reconciliation after invalidate")
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
-        Assert.True(reconcileCount >= 2, "Expected second reconciliation after invalidate");
+        Assert.IsTrue(reconcileCount >= 2, "Expected second reconciliation after invalidate");
 
         // Fire binding again after re-render
         await new Hex1bTerminalInputSequenceBuilder()
@@ -509,7 +510,7 @@ public class InputBindingFluentApiTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await secondBindingFired.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
-        Assert.Equal(2, bindingFireCount);
+        Assert.AreEqual(2, bindingFireCount);
 
         cts.Cancel();
         await runTask;

--- a/tests/Hex1b.Tests/InputBindingPrecedenceTests.cs
+++ b/tests/Hex1b.Tests/InputBindingPrecedenceTests.cs
@@ -28,11 +28,12 @@ namespace Hex1b.Tests;
 /// PRECEDENCE (no focused widget):
 /// 1. Global bindings only
 /// </summary>
+[TestClass]
 public class InputBindingPrecedenceTests
 {
     #region A. No Focused Widget - Global Bindings
 
-    [Fact]
+    [TestMethod]
     public async Task A1_NoFocus_GlobalBindingMatches_GlobalBindingFires()
     {
         // RULE: When no focused widget exists, global bindings are checked.
@@ -67,13 +68,13 @@ public class InputBindingPrecedenceTests
         await renderOccurred.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         await new Hex1bTerminalInputSequenceBuilder().Key(Hex1bKey.X).Wait(100).Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(globalBindingFired, "Global binding should fire when no focused widget exists");
+        Assert.IsTrue(globalBindingFired, "Global binding should fire when no focused widget exists");
 
         cts.Cancel();
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task A2_NoFocus_NoGlobalBindingForKey_NotHandled()
     {
         // RULE: When no binding matches and no focused widget, input is not handled.
@@ -108,13 +109,13 @@ public class InputBindingPrecedenceTests
         await renderOccurred.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         await new Hex1bTerminalInputSequenceBuilder().Key(Hex1bKey.Y).Wait(100).Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.False(anyBindingFired, "No binding should fire for unbound key");
+        Assert.IsFalse(anyBindingFired, "No binding should fire for unbound key");
 
         cts.Cancel();
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task A3_NoFocus_MultipleWidgetsDefineSameGlobalKey_LastWriteWins()
     {
         // RULE: Global bindings use last-write-wins semantics.
@@ -159,8 +160,8 @@ public class InputBindingPrecedenceTests
         await renderOccurred.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         await new Hex1bTerminalInputSequenceBuilder().Key(Hex1bKey.X).Wait(100).Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(childBindingFired, "Child (last reconciled) binding should fire");
-        Assert.False(parentBindingFired, "Parent binding should NOT fire (overridden by child)");
+        Assert.IsTrue(childBindingFired, "Child (last reconciled) binding should fire");
+        Assert.IsFalse(parentBindingFired, "Parent binding should NOT fire (overridden by child)");
 
         cts.Cancel();
         await runTask;
@@ -170,7 +171,7 @@ public class InputBindingPrecedenceTests
 
     #region B. Focused Widget - Precedence Chain
 
-    [Fact]
+    [TestMethod]
     public async Task B1_FocusedWidget_FocusBindingMatches_FocusBindingFires()
     {
         // RULE: Focus bindings are checked first when widget is focused.
@@ -208,13 +209,13 @@ public class InputBindingPrecedenceTests
         // Button should auto-focus as first focusable widget
         await new Hex1bTerminalInputSequenceBuilder().Key(Hex1bKey.X).Wait(100).Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(focusBindingFired, "Focus binding should fire when widget is focused");
+        Assert.IsTrue(focusBindingFired, "Focus binding should fire when widget is focused");
 
         cts.Cancel();
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task B2_FocusedWidget_NoFocusBinding_HandleInputHandles()
     {
         // RULE: If no focus binding matches, HandleInput is called on focused widget.
@@ -245,13 +246,13 @@ public class InputBindingPrecedenceTests
         // TextBox should auto-focus
         await new Hex1bTerminalInputSequenceBuilder().Key(Hex1bKey.A).Wait(100).Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal("a", textChanged);
+        Assert.AreEqual("a", textChanged);
 
         cts.Cancel();
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task B4_FocusedWidget_NothingHandles_GlobalBindingFires()
     {
         // RULE: If focus bindings and HandleInput chain don't handle, global bindings fire.
@@ -289,7 +290,7 @@ public class InputBindingPrecedenceTests
         // Button is focused, press Q (button doesn't handle it)
         await new Hex1bTerminalInputSequenceBuilder().Key(Hex1bKey.Q).Wait(100).Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(globalBindingFired, "Global binding should fire when focus chain doesn't handle");
+        Assert.IsTrue(globalBindingFired, "Global binding should fire when focus chain doesn't handle");
 
         cts.Cancel();
         await runTask;
@@ -299,7 +300,7 @@ public class InputBindingPrecedenceTests
 
     #region C. Focus Bindings Override Global
 
-    [Fact]
+    [TestMethod]
     public async Task C1_SameKeyFocusAndGlobal_WidgetFocused_FocusBindingFires()
     {
         // RULE: Focus bindings take precedence over global bindings for the same key.
@@ -344,14 +345,14 @@ public class InputBindingPrecedenceTests
         
         await new Hex1bTerminalInputSequenceBuilder().Key(Hex1bKey.X).Wait(100).Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(focusBindingFired, "Focus binding should fire");
-        Assert.False(globalBindingFired, "Global binding should NOT fire (overridden by focus)");
+        Assert.IsTrue(focusBindingFired, "Focus binding should fire");
+        Assert.IsFalse(globalBindingFired, "Global binding should NOT fire (overridden by focus)");
 
         cts.Cancel();
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task C2_SameKeyFocusAndGlobal_DifferentWidgetFocused_GlobalFires()
     {
         // RULE: When a different widget is focused, focus bindings don't apply.
@@ -401,8 +402,8 @@ public class InputBindingPrecedenceTests
             .Key(Hex1bKey.X).Wait(100)
             .Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.False(button1FocusBindingFired, "Button1's focus binding should NOT fire (not focused)");
-        Assert.True(globalBindingFired, "Global binding should fire as fallback");
+        Assert.IsFalse(button1FocusBindingFired, "Button1's focus binding should NOT fire (not focused)");
+        Assert.IsTrue(globalBindingFired, "Global binding should fire as fallback");
 
         cts.Cancel();
         await runTask;
@@ -412,7 +413,7 @@ public class InputBindingPrecedenceTests
 
     #region D. Global Binding Collection (Last-Write-Wins)
 
-    [Fact]
+    [TestMethod]
     public async Task D1_ParentDefinesKey_ChildRedefines_ChildWins()
     {
         // RULE: Last-write-wins for global bindings (child reconciled after parent).
@@ -457,14 +458,14 @@ public class InputBindingPrecedenceTests
         await renderOccurred.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         await new Hex1bTerminalInputSequenceBuilder().Key(Hex1bKey.X).Wait(100).Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(innerFired, "Inner (last reconciled) should win");
-        Assert.False(outerFired, "Outer should be overridden");
+        Assert.IsTrue(innerFired, "Inner (last reconciled) should win");
+        Assert.IsFalse(outerFired, "Outer should be overridden");
 
         cts.Cancel();
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task D2_DeeplyNestedWidget_OverridesRoot()
     {
         // RULE: Deeply nested widget's global binding overrides root's.
@@ -511,8 +512,8 @@ public class InputBindingPrecedenceTests
         await renderOccurred.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         await new Hex1bTerminalInputSequenceBuilder().Key(Hex1bKey.X).Wait(100).Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(deepFired, "Deepest (last reconciled) should win");
-        Assert.False(rootFired, "Root should be overridden");
+        Assert.IsTrue(deepFired, "Deepest (last reconciled) should win");
+        Assert.IsFalse(rootFired, "Root should be overridden");
 
         cts.Cancel();
         await runTask;
@@ -522,7 +523,7 @@ public class InputBindingPrecedenceTests
 
     #region E. Default App Bindings
 
-    [Fact]
+    [TestMethod]
     public async Task E1_DefaultCtrlC_NoOverride_AppStops()
     {
         // RULE: Default Ctrl+C binding stops the app.
@@ -552,10 +553,10 @@ public class InputBindingPrecedenceTests
         
         // App should stop within reasonable time
         var completed = await Task.WhenAny(runTask, Task.Delay(1000, TestContext.Current.CancellationToken)) == runTask;
-        Assert.True(completed, "App should stop when Ctrl+C is pressed");
+        Assert.IsTrue(completed, "App should stop when Ctrl+C is pressed");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task E2_UserGlobalBinding_OverridesDefaultCtrlC()
     {
         // RULE: User global bindings override default app bindings.
@@ -591,8 +592,8 @@ public class InputBindingPrecedenceTests
         
         await new Hex1bTerminalInputSequenceBuilder().Ctrl().Key(Hex1bKey.C).Wait(100).Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(userBindingFired, "User binding should fire");
-        Assert.False(runTask.IsCompleted, "App should NOT stop (user overrode Ctrl+C)");
+        Assert.IsTrue(userBindingFired, "User binding should fire");
+        Assert.IsFalse(runTask.IsCompleted, "App should NOT stop (user overrode Ctrl+C)");
 
         cts.Cancel();
         await runTask;
@@ -602,7 +603,7 @@ public class InputBindingPrecedenceTests
 
     #region F. Chord Bindings
 
-    [Fact]
+    [TestMethod]
     public async Task F1_FocusChordBinding_CompletesAndFires()
     {
         // RULE: Chord bindings work on focusable widgets.
@@ -642,13 +643,13 @@ public class InputBindingPrecedenceTests
             .Key(Hex1bKey.G).Wait(100)
             .Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(chordFired, "Chord should complete and fire");
+        Assert.IsTrue(chordFired, "Chord should complete and fire");
 
         cts.Cancel();
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task F2_GlobalChordBinding_CompletesAndFires()
     {
         // RULE: Chord bindings work on global level.
@@ -687,13 +688,13 @@ public class InputBindingPrecedenceTests
             .Key(Hex1bKey.G).Wait(100)
             .Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(chordFired, "Global chord should complete and fire");
+        Assert.IsTrue(chordFired, "Global chord should complete and fire");
 
         cts.Cancel();
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task F4_MidChord_EscapePressed_ChordCancelled()
     {
         // RULE: Escape cancels pending chord.
@@ -733,7 +734,7 @@ public class InputBindingPrecedenceTests
             .Key(Hex1bKey.G).Wait(100)
             .Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.False(chordFired, "Chord should be cancelled by Escape");
+        Assert.IsFalse(chordFired, "Chord should be cancelled by Escape");
 
         cts.Cancel();
         await runTask;
@@ -743,7 +744,7 @@ public class InputBindingPrecedenceTests
 
     #region H. API Behavior
 
-    [Fact]
+    [TestMethod]
     public async Task H1_InputBindings_OnNonFocusable_CreatesGlobalBindings()
     {
         // RULE: InputBindings on non-focusable widget creates global bindings.
@@ -778,13 +779,13 @@ public class InputBindingPrecedenceTests
         await renderOccurred.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         await new Hex1bTerminalInputSequenceBuilder().Key(Hex1bKey.X).Wait(100).Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(bindingFired, "VStack binding should fire as global binding");
+        Assert.IsTrue(bindingFired, "VStack binding should fire as global binding");
 
         cts.Cancel();
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task H2_InputBindings_OnFocusable_CreatesFocusBindings()
     {
         // RULE: InputBindings on focusable widget creates focus bindings.
@@ -826,7 +827,7 @@ public class InputBindingPrecedenceTests
             .Key(Hex1bKey.X).Wait(100)
             .Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.False(button1BindingFired, "Button1's focus binding should NOT fire when Button2 is focused");
+        Assert.IsFalse(button1BindingFired, "Button1's focus binding should NOT fire when Button2 is focused");
 
         cts.Cancel();
         await runTask;
@@ -836,7 +837,7 @@ public class InputBindingPrecedenceTests
 
     #region I. Tree Compositions
 
-    [Fact]
+    [TestMethod]
     public async Task I6_RescueWidgetWrapping_DoesNotBreakBindings()
     {
         // RULE: RescueWidget (enabled by default) should not prevent bindings from working.
@@ -876,7 +877,7 @@ public class InputBindingPrecedenceTests
         await renderOccurred.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         await new Hex1bTerminalInputSequenceBuilder().Key(Hex1bKey.X).Wait(100).Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(bindingFired, "Global binding should fire even with RescueWidget wrapping");
+        Assert.IsTrue(bindingFired, "Global binding should fire even with RescueWidget wrapping");
 
         cts.Cancel();
         await runTask;
@@ -886,7 +887,7 @@ public class InputBindingPrecedenceTests
 
     #region Ctrl Modifier Tests
 
-    [Fact]
+    [TestMethod]
     public async Task CtrlModifier_GlobalBinding_Fires()
     {
         // RULE: Ctrl+Key bindings work as global bindings.
@@ -921,13 +922,13 @@ public class InputBindingPrecedenceTests
         await renderOccurred.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         await new Hex1bTerminalInputSequenceBuilder().Ctrl().Key(Hex1bKey.X).Wait(100).Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(bindingFired, "Ctrl+X global binding should fire");
+        Assert.IsTrue(bindingFired, "Ctrl+X global binding should fire");
 
         cts.Cancel();
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CtrlModifier_FocusBinding_OverridesGlobal()
     {
         // RULE: Focus Ctrl+Key bindings override global Ctrl+Key bindings.
@@ -972,8 +973,8 @@ public class InputBindingPrecedenceTests
         
         await new Hex1bTerminalInputSequenceBuilder().Ctrl().Key(Hex1bKey.S).Wait(100).Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(focusBindingFired, "Focus Ctrl+S binding should fire");
-        Assert.False(globalBindingFired, "Global Ctrl+S should NOT fire");
+        Assert.IsTrue(focusBindingFired, "Focus Ctrl+S binding should fire");
+        Assert.IsFalse(globalBindingFired, "Global Ctrl+S should NOT fire");
 
         cts.Cancel();
         await runTask;
@@ -983,7 +984,7 @@ public class InputBindingPrecedenceTests
 
     #region Shift Modifier Tests
 
-    [Fact]
+    [TestMethod]
     public async Task ShiftModifier_GlobalBinding_Fires()
     {
         // RULE: Shift+Key bindings work as global bindings.
@@ -1018,7 +1019,7 @@ public class InputBindingPrecedenceTests
         await renderOccurred.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         await new Hex1bTerminalInputSequenceBuilder().Shift().Tab().Wait(100).Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(bindingFired, "Shift+Tab global binding should fire");
+        Assert.IsTrue(bindingFired, "Shift+Tab global binding should fire");
 
         cts.Cancel();
         await runTask;
@@ -1028,7 +1029,7 @@ public class InputBindingPrecedenceTests
 
     #region Modifier Combination Tests
 
-    [Fact]
+    [TestMethod]
     public void ModifierBuilder_CtrlThenShift_ProducesCombinedModifiers()
     {
         // RULE: Ctrl and Shift modifiers can be combined.
@@ -1038,13 +1039,13 @@ public class InputBindingPrecedenceTests
         var builder = new InputBindingsBuilder();
         builder.Ctrl().Shift().Key(Hex1bKey.LeftArrow).Action(() => { });
 
-        var binding = Assert.Single(builder.Bindings);
-        var step = Assert.Single(binding.Steps);
-        Assert.Equal(Hex1bKey.LeftArrow, step.Key);
-        Assert.Equal(Hex1bModifiers.Control | Hex1bModifiers.Shift, step.Modifiers);
+        var binding = TestSeq.Single(builder.Bindings);
+        var step = TestSeq.Single(binding.Steps);
+        Assert.AreEqual(Hex1bKey.LeftArrow, step.Key);
+        Assert.AreEqual(Hex1bModifiers.Control | Hex1bModifiers.Shift, step.Modifiers);
     }
 
-    [Fact]
+    [TestMethod]
     public void ModifierBuilder_ShiftThenCtrl_ProducesCombinedModifiers()
     {
         // RULE: Modifier order does not matter — both Shift().Ctrl() and Ctrl().Shift() yield the same combined step.
@@ -1054,13 +1055,13 @@ public class InputBindingPrecedenceTests
         var builder = new InputBindingsBuilder();
         builder.Shift().Ctrl().Key(Hex1bKey.RightArrow).Action(() => { });
 
-        var binding = Assert.Single(builder.Bindings);
-        var step = Assert.Single(binding.Steps);
-        Assert.Equal(Hex1bKey.RightArrow, step.Key);
-        Assert.Equal(Hex1bModifiers.Control | Hex1bModifiers.Shift, step.Modifiers);
+        var binding = TestSeq.Single(builder.Bindings);
+        var step = TestSeq.Single(binding.Steps);
+        Assert.AreEqual(Hex1bKey.RightArrow, step.Key);
+        Assert.AreEqual(Hex1bModifiers.Control | Hex1bModifiers.Shift, step.Modifiers);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CtrlShiftBinding_GlobalBinding_FiresEndToEnd()
     {
         // RULE: A Ctrl+Shift+Key binding declared via the fluent API
@@ -1094,7 +1095,7 @@ public class InputBindingPrecedenceTests
         await renderOccurred.Task.WaitAsync(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
         await new Hex1bTerminalInputSequenceBuilder().Ctrl().Shift().Key(Hex1bKey.LeftArrow).Wait(100).Capture("final").Build().ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(bindingFired, "Ctrl+Shift+LeftArrow global binding should fire end-to-end");
+        Assert.IsTrue(bindingFired, "Ctrl+Shift+LeftArrow global binding should fire end-to-end");
 
         cts.Cancel();
         await runTask;

--- a/tests/Hex1b.Tests/InputBindingRemapTests.cs
+++ b/tests/Hex1b.Tests/InputBindingRemapTests.cs
@@ -2,6 +2,7 @@ using Hex1b.Input;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class InputBindingRemapTests
 {
     private static readonly ActionId TestMoveUp = new("Test.MoveUp");
@@ -9,19 +10,19 @@ public class InputBindingRemapTests
     private static readonly ActionId TestActivate = new("Test.Activate");
     private static readonly ActionId TestUnregistered = new("Test.Unregistered");
 
-    [Fact]
+    [TestMethod]
     public void Triggers_SetsActionIdOnBinding()
     {
         var builder = new InputBindingsBuilder();
 
         builder.Key(Hex1bKey.UpArrow).Triggers(TestMoveUp, _ => { }, "Move up");
 
-        Assert.Single(builder.Bindings);
-        Assert.Equal(TestMoveUp, builder.Bindings[0].ActionId);
-        Assert.Equal("Move up", builder.Bindings[0].Description);
+        TestSeq.Single(builder.Bindings);
+        Assert.AreEqual(TestMoveUp, builder.Bindings[0].ActionId);
+        Assert.AreEqual("Move up", builder.Bindings[0].Description);
     }
 
-    [Fact]
+    [TestMethod]
     public void Triggers_RegistersHandlerInRegistry()
     {
         var builder = new InputBindingsBuilder();
@@ -31,11 +32,11 @@ public class InputBindingRemapTests
         // Verify handler is registered by creating a rebinding
         builder.Key(Hex1bKey.K).Triggers(TestMoveUp);
 
-        Assert.Equal(2, builder.Bindings.Count);
-        Assert.Equal(TestMoveUp, builder.Bindings[1].ActionId);
+        Assert.AreEqual(2, builder.Bindings.Count);
+        Assert.AreEqual(TestMoveUp, builder.Bindings[1].ActionId);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Triggers_RebindingResolvesCorrectHandler()
     {
         var builder = new InputBindingsBuilder();
@@ -53,10 +54,10 @@ public class InputBindingRemapTests
         var context = CreateMockContext();
         await builder.Bindings[1].ExecuteAsync(context);
 
-        Assert.True(handlerCalled);
+        Assert.IsTrue(handlerCalled);
     }
 
-    [Fact]
+    [TestMethod]
     public void Triggers_AsyncHandler_SetsActionIdAndRegisters()
     {
         var builder = new InputBindingsBuilder();
@@ -64,23 +65,23 @@ public class InputBindingRemapTests
         builder.Key(Hex1bKey.UpArrow).Triggers(TestMoveUp,
             _ => Task.CompletedTask, "Move up");
 
-        Assert.Equal(TestMoveUp, builder.Bindings[0].ActionId);
+        Assert.AreEqual(TestMoveUp, builder.Bindings[0].ActionId);
 
         // Verify rebinding works
         builder.Key(Hex1bKey.K).Triggers(TestMoveUp);
-        Assert.Equal(2, builder.Bindings.Count);
+        Assert.AreEqual(2, builder.Bindings.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Triggers_Unregistered_Throws()
     {
         var builder = new InputBindingsBuilder();
 
-        Assert.Throws<InvalidOperationException>(() =>
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
             builder.Key(Hex1bKey.K).Triggers(TestUnregistered));
     }
 
-    [Fact]
+    [TestMethod]
     public void Remove_ByActionId_RemovesAllMatchingBindings()
     {
         var builder = new InputBindingsBuilder();
@@ -91,11 +92,11 @@ public class InputBindingRemapTests
 
         builder.Remove(TestActivate);
 
-        Assert.Single(builder.Bindings);
-        Assert.Equal(TestMoveUp, builder.Bindings[0].ActionId);
+        TestSeq.Single(builder.Bindings);
+        Assert.AreEqual(TestMoveUp, builder.Bindings[0].ActionId);
     }
 
-    [Fact]
+    [TestMethod]
     public void Remove_ByActionId_PreservesRegistry()
     {
         var builder = new InputBindingsBuilder();
@@ -103,15 +104,15 @@ public class InputBindingRemapTests
         builder.Key(Hex1bKey.Enter).Triggers(TestActivate, _ => { }, "Activate");
         builder.Remove(TestActivate);
 
-        Assert.Empty(builder.Bindings);
+        Assert.IsEmpty(builder.Bindings);
 
         // Handler still in registry — can rebind
         builder.Key(Hex1bKey.K).Triggers(TestActivate);
-        Assert.Single(builder.Bindings);
-        Assert.Equal(TestActivate, builder.Bindings[0].ActionId);
+        TestSeq.Single(builder.Bindings);
+        Assert.AreEqual(TestActivate, builder.Bindings[0].ActionId);
     }
 
-    [Fact]
+    [TestMethod]
     public void Remove_ByActionId_RemovesMouseBindingsToo()
     {
         var builder = new InputBindingsBuilder();
@@ -121,11 +122,11 @@ public class InputBindingRemapTests
 
         builder.Remove(TestActivate);
 
-        Assert.Empty(builder.Bindings);
-        Assert.Empty(builder.MouseBindings);
+        Assert.IsEmpty(builder.Bindings);
+        Assert.IsEmpty(builder.MouseBindings);
     }
 
-    [Fact]
+    [TestMethod]
     public void Remove_ByActionId_UnknownId_IsNoOp()
     {
         var builder = new InputBindingsBuilder();
@@ -133,10 +134,10 @@ public class InputBindingRemapTests
 
         builder.Remove(TestUnregistered); // should not throw
 
-        Assert.Single(builder.Bindings);
+        TestSeq.Single(builder.Bindings);
     }
 
-    [Fact]
+    [TestMethod]
     public void RemoveAll_ClearsAllBindingTypes()
     {
         var builder = new InputBindingsBuilder();
@@ -148,12 +149,12 @@ public class InputBindingRemapTests
 
         builder.RemoveAll();
 
-        Assert.Empty(builder.Bindings);
-        Assert.Empty(builder.MouseBindings);
-        Assert.Empty(builder.CharacterBindings);
+        Assert.IsEmpty(builder.Bindings);
+        Assert.IsEmpty(builder.MouseBindings);
+        Assert.IsEmpty(builder.CharacterBindings);
     }
 
-    [Fact]
+    [TestMethod]
     public void RemoveAll_PreservesRegistry()
     {
         var builder = new InputBindingsBuilder();
@@ -163,10 +164,10 @@ public class InputBindingRemapTests
 
         // Can still rebind
         builder.Key(Hex1bKey.K).Triggers(TestActivate);
-        Assert.Single(builder.Bindings);
+        TestSeq.Single(builder.Bindings);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetBindings_ReturnsMatchingBindings()
     {
         var builder = new InputBindingsBuilder();
@@ -176,22 +177,22 @@ public class InputBindingRemapTests
         builder.Key(Hex1bKey.UpArrow).Triggers(TestMoveUp, _ => { }, "Move up");
 
         var activateBindings = builder.GetBindings(TestActivate);
-        Assert.Equal(2, activateBindings.Count);
+        Assert.AreEqual(2, activateBindings.Count);
 
         var moveUpBindings = builder.GetBindings(TestMoveUp);
-        Assert.Single(moveUpBindings);
+        TestSeq.Single(moveUpBindings);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetBindings_UnknownId_ReturnsEmpty()
     {
         var builder = new InputBindingsBuilder();
 
         var result = builder.GetBindings(TestUnregistered);
-        Assert.Empty(result);
+        Assert.IsEmpty(result);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetAllActionIds_ReturnsAllUniqueIds()
     {
         var builder = new InputBindingsBuilder();
@@ -202,21 +203,21 @@ public class InputBindingRemapTests
         builder.Key(Hex1bKey.DownArrow).Triggers(TestMoveDown, _ => { }, "Move down");
 
         var ids = builder.GetAllActionIds();
-        Assert.Equal(3, ids.Count);
+        Assert.AreEqual(3, ids.Count);
         Assert.Contains(TestActivate, ids);
         Assert.Contains(TestMoveUp, ids);
         Assert.Contains(TestMoveDown, ids);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetAllActionIds_Empty_ReturnsEmpty()
     {
         var builder = new InputBindingsBuilder();
         var ids = builder.GetAllActionIds();
-        Assert.Empty(ids);
+        Assert.IsEmpty(ids);
     }
 
-    [Fact]
+    [TestMethod]
     public void RemapPattern_RemoveThenBind_Works()
     {
         var builder = new InputBindingsBuilder();
@@ -232,14 +233,14 @@ public class InputBindingRemapTests
         builder.Remove(TestMoveDown);
         builder.Key(Hex1bKey.J).Triggers(TestMoveDown);
 
-        Assert.Equal(2, builder.Bindings.Count);
-        Assert.Equal(Hex1bKey.K, builder.Bindings[0].Steps[0].Key);
-        Assert.Equal(TestMoveUp, builder.Bindings[0].ActionId);
-        Assert.Equal(Hex1bKey.J, builder.Bindings[1].Steps[0].Key);
-        Assert.Equal(TestMoveDown, builder.Bindings[1].ActionId);
+        Assert.AreEqual(2, builder.Bindings.Count);
+        Assert.AreEqual(Hex1bKey.K, builder.Bindings[0].Steps[0].Key);
+        Assert.AreEqual(TestMoveUp, builder.Bindings[0].ActionId);
+        Assert.AreEqual(Hex1bKey.J, builder.Bindings[1].Steps[0].Key);
+        Assert.AreEqual(TestMoveDown, builder.Bindings[1].ActionId);
     }
 
-    [Fact]
+    [TestMethod]
     public void AliasPattern_BindWithoutRemove_KeepsBoth()
     {
         var builder = new InputBindingsBuilder();
@@ -249,53 +250,53 @@ public class InputBindingRemapTests
         // Alias: just Bind (don't Remove)
         builder.Key(Hex1bKey.K).Triggers(TestMoveUp);
 
-        Assert.Equal(2, builder.Bindings.Count);
-        Assert.Equal(Hex1bKey.UpArrow, builder.Bindings[0].Steps[0].Key);
-        Assert.Equal(Hex1bKey.K, builder.Bindings[1].Steps[0].Key);
-        Assert.All(builder.Bindings, b => Assert.Equal(TestMoveUp, b.ActionId));
+        Assert.AreEqual(2, builder.Bindings.Count);
+        Assert.AreEqual(Hex1bKey.UpArrow, builder.Bindings[0].Steps[0].Key);
+        Assert.AreEqual(Hex1bKey.K, builder.Bindings[1].Steps[0].Key);
+        TestSeq.All(builder.Bindings, b => Assert.AreEqual(TestMoveUp, b.ActionId));
     }
 
-    [Fact]
+    [TestMethod]
     public void MouseBinding_Triggers_SetsActionId()
     {
         var builder = new InputBindingsBuilder();
 
         builder.Mouse(MouseButton.Left).Triggers(TestActivate, _ => { }, "Click");
 
-        Assert.Single(builder.MouseBindings);
-        Assert.Equal(TestActivate, builder.MouseBindings[0].ActionId);
+        TestSeq.Single(builder.MouseBindings);
+        Assert.AreEqual(TestActivate, builder.MouseBindings[0].ActionId);
     }
 
-    [Fact]
+    [TestMethod]
     public void Action_WithoutTriggers_HasNullActionId()
     {
         var builder = new InputBindingsBuilder();
 
         builder.Key(Hex1bKey.Enter).Action(_ => { }, "Press enter");
 
-        Assert.Single(builder.Bindings);
-        Assert.Null(builder.Bindings[0].ActionId);
+        TestSeq.Single(builder.Bindings);
+        Assert.IsNull(builder.Bindings[0].ActionId);
     }
 
-    [Fact]
+    [TestMethod]
     public void ActionId_ToString_ReturnsValue()
     {
         var id = new ActionId("List.MoveUp");
-        Assert.Equal("List.MoveUp", id.ToString());
+        Assert.AreEqual("List.MoveUp", id.ToString());
     }
 
-    [Fact]
+    [TestMethod]
     public void ActionId_Equality_WorksCorrectly()
     {
         var id1 = new ActionId("List.MoveUp");
         var id2 = new ActionId("List.MoveUp");
         var id3 = new ActionId("List.MoveDown");
 
-        Assert.Equal(id1, id2);
-        Assert.NotEqual(id1, id3);
+        Assert.AreEqual(id1, id2);
+        Assert.AreNotEqual(id1, id3);
     }
 
-    [Fact]
+    [TestMethod]
     public void Triggers_FirstRegistrationWins()
     {
         var builder = new InputBindingsBuilder();
@@ -315,32 +316,32 @@ public class InputBindingRemapTests
         var context = CreateMockContext();
         builder.Bindings[2].ExecuteAsync(context).Wait();
 
-        Assert.True(firstHandlerCalled);
-        Assert.False(secondHandlerCalled);
+        Assert.IsTrue(firstHandlerCalled);
+        Assert.IsFalse(secondHandlerCalled);
     }
 
-    [Fact]
+    [TestMethod]
     public void Triggers_WithModifiers_PreservesModifiers()
     {
         var builder = new InputBindingsBuilder();
 
         builder.Ctrl().Key(Hex1bKey.A).Triggers(TestActivate, _ => { }, "Select all");
 
-        Assert.Single(builder.Bindings);
-        Assert.Equal(Hex1bModifiers.Control, builder.Bindings[0].Steps[0].Modifiers);
-        Assert.Equal(Hex1bKey.A, builder.Bindings[0].Steps[0].Key);
-        Assert.Equal(TestActivate, builder.Bindings[0].ActionId);
+        TestSeq.Single(builder.Bindings);
+        Assert.AreEqual(Hex1bModifiers.Control, builder.Bindings[0].Steps[0].Modifiers);
+        Assert.AreEqual(Hex1bKey.A, builder.Bindings[0].Steps[0].Key);
+        Assert.AreEqual(TestActivate, builder.Bindings[0].ActionId);
     }
 
-    [Fact]
+    [TestMethod]
     public void Triggers_WithGlobal_PreservesGlobalFlag()
     {
         var builder = new InputBindingsBuilder();
 
         builder.Key(Hex1bKey.F1).Global().Triggers(TestActivate, _ => { }, "Help");
 
-        Assert.True(builder.Bindings[0].IsGlobal);
-        Assert.Equal(TestActivate, builder.Bindings[0].ActionId);
+        Assert.IsTrue(builder.Bindings[0].IsGlobal);
+        Assert.AreEqual(TestActivate, builder.Bindings[0].ActionId);
     }
 
     private static InputBindingActionContext CreateMockContext()

--- a/tests/Hex1b.Tests/InputOverrideTests.cs
+++ b/tests/Hex1b.Tests/InputOverrideTests.cs
@@ -10,11 +10,12 @@ namespace Hex1b.Tests;
 /// Tests for the InputOverrideWidget, which provides centralized
 /// keybinding overrides for all descendant widgets of a specified type.
 /// </summary>
+[TestClass]
 public class InputOverrideTests
 {
     #region Unit Tests — Override application via reconciliation
 
-    [Fact]
+    [TestMethod]
     public async Task Override_AppliesTo_MatchingWidgetType()
     {
         // An InputOverride with Override<ListWidget> should affect ListWidget descendants.
@@ -31,22 +32,22 @@ public class InputOverrideTests
         var context = ReconcileContext.CreateRoot();
         var overrideNode = await overrideWidget.ReconcileAsync(null, context) as InputOverrideNode;
 
-        Assert.NotNull(overrideNode);
-        Assert.NotNull(overrideNode!.Child);
+        Assert.IsNotNull(overrideNode);
+        Assert.IsNotNull(overrideNode!.Child);
 
         // The override configurator should have been wired into the child's BindingsConfigurator
         // by ReconcileChildAsync. Invoke BuildBindings to trigger it.
         var childNode = overrideNode.Child!;
         var bindings = childNode.BuildBindings();
 
-        Assert.True(overrideCalled, "Override configurator should run during BuildBindings");
+        Assert.IsTrue(overrideCalled, "Override configurator should run during BuildBindings");
 
         // Verify MoveUp was removed by the override
         var actionIds = bindings.GetAllActionIds();
         Assert.DoesNotContain(ListWidget.MoveUp, actionIds);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Override_DoesNotApplyTo_NonMatchingWidgetType()
     {
         // An Override<ListWidget> should NOT affect a ButtonWidget.
@@ -68,7 +69,7 @@ public class InputOverrideTests
         Assert.Contains(ButtonWidget.Activate, actionIds);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Override_CascadesToDeepDescendants()
     {
         // An InputOverride wrapping a VStack containing a ListWidget should
@@ -89,13 +90,13 @@ public class InputOverrideTests
 
         // Walk down to find the ListNode
         var vstackNode = (overrideNode as InputOverrideNode)?.Child as VStackNode;
-        Assert.NotNull(vstackNode);
+        Assert.IsNotNull(vstackNode);
 
         var listNode = vstackNode!.Children.OfType<ListNode>().FirstOrDefault();
-        Assert.NotNull(listNode);
+        Assert.IsNotNull(listNode);
 
         var bindings = listNode!.BuildBindings();
-        Assert.True(overrideCalled, "Override should cascade to nested ListWidget");
+        Assert.IsTrue(overrideCalled, "Override should cascade to nested ListWidget");
 
         // MoveDown should have been removed
         var actionIds = bindings.GetAllActionIds();
@@ -104,7 +105,7 @@ public class InputOverrideTests
         Assert.Contains(ListWidget.MoveUp, actionIds);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Override_MultipleTypes_AppliesCorrectly()
     {
         // Override<ListWidget> and Override<ButtonWidget> should each apply to the correct type.
@@ -138,11 +139,11 @@ public class InputOverrideTests
         listNode.BuildBindings();
         buttonNode.BuildBindings();
 
-        Assert.True(listOverrideCalled);
-        Assert.True(buttonOverrideCalled);
+        Assert.IsTrue(listOverrideCalled);
+        Assert.IsTrue(buttonOverrideCalled);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Override_ChainedFluentCalls_AccumulateOverrides()
     {
         // Multiple Override<T> calls on the same InputOverrideWidget should all be present.
@@ -154,12 +155,12 @@ public class InputOverrideTests
         .Override<CheckboxWidget>(b => b.Remove(CheckboxWidget.ToggleActionId));
 
         // Both overrides should be in the dictionary
-        Assert.Equal(2, overrideWidget.Overrides.Count);
-        Assert.True(overrideWidget.Overrides.ContainsKey(typeof(ListWidget)));
-        Assert.True(overrideWidget.Overrides.ContainsKey(typeof(CheckboxWidget)));
+        Assert.AreEqual(2, overrideWidget.Overrides.Count);
+        Assert.IsTrue(overrideWidget.Overrides.ContainsKey(typeof(ListWidget)));
+        Assert.IsTrue(overrideWidget.Overrides.ContainsKey(typeof(CheckboxWidget)));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Override_SameType_LastWins()
     {
         // Calling Override<ListWidget> twice — second call should replace the first.
@@ -175,11 +176,11 @@ public class InputOverrideTests
         var listNode = (overrideNode as InputOverrideNode)?.Child as ListNode;
         listNode!.BuildBindings();
 
-        Assert.False(firstCalled, "First override should be replaced by second");
-        Assert.True(secondCalled, "Second override should be the one that runs");
+        Assert.IsFalse(firstCalled, "First override should be replaced by second");
+        Assert.IsTrue(secondCalled, "Second override should be the one that runs");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Override_RunsAfterWidgetInputBindings()
     {
         // Per-instance InputBindings should run BEFORE the override.
@@ -196,12 +197,12 @@ public class InputOverrideTests
         var listNode = (overrideNode as InputOverrideNode)?.Child as ListNode;
         listNode!.BuildBindings();
 
-        Assert.Equal(2, callOrder.Count);
-        Assert.Equal("per-instance", callOrder[0]);
-        Assert.Equal("override", callOrder[1]);
+        Assert.AreEqual(2, callOrder.Count);
+        Assert.AreEqual("per-instance", callOrder[0]);
+        Assert.AreEqual("override", callOrder[1]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Override_RebindingPattern_Works()
     {
         // The classic remap pattern: remove default, rebind to new key.
@@ -224,22 +225,22 @@ public class InputOverrideTests
 
         // There should be a binding for K with MoveUp action
         var moveUpBindings = bindings.GetBindings(ListWidget.MoveUp);
-        Assert.Single(moveUpBindings);
-        Assert.Equal(Hex1bKey.K, moveUpBindings[0].Steps[0].Key);
+        TestSeq.Single(moveUpBindings);
+        Assert.AreEqual(Hex1bKey.K, moveUpBindings[0].Steps[0].Key);
     }
 
     #endregion
 
     #region Unit Tests — Node pass-through behavior
 
-    [Fact]
+    [TestMethod]
     public void InputOverrideNode_IsFocusable_ReturnsFalse()
     {
         var node = new InputOverrideNode();
-        Assert.False(node.IsFocusable);
+        Assert.IsFalse(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public void InputOverrideNode_Measure_DelegatesToChild()
     {
         var node = new InputOverrideNode();
@@ -247,23 +248,23 @@ public class InputOverrideTests
         node.Child = child;
 
         var size = node.Measure(new Constraints(0, 100, 0, 10));
-        Assert.True(size.Width > 0);
+        Assert.IsTrue(size.Width > 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void InputOverrideNode_Measure_NoChild_ReturnsZero()
     {
         var node = new InputOverrideNode();
         var size = node.Measure(new Constraints(0, 100, 0, 10));
-        Assert.Equal(0, size.Width);
-        Assert.Equal(0, size.Height);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(0, size.Height);
     }
 
     #endregion
 
     #region Integration Tests — Full app pipeline
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Override_RebindsKeyForFocusedWidget()
     {
         // Full integration test: InputOverride rebinds ListWidget.MoveDown from DownArrow to J.
@@ -308,7 +309,7 @@ public class InputOverrideTests
 
     #region Nested InputOverride Tests
 
-    [Fact]
+    [TestMethod]
     public async Task NestedOverride_InnerWins_ForSameWidgetType()
     {
         // Nested InputOverrideWidgets — inner override should take precedence.
@@ -329,16 +330,16 @@ public class InputOverrideTests
         // Navigate to the list node
         var innerOverrideNode = (outerNode as InputOverrideNode)?.Child as InputOverrideNode;
         var listNode = innerOverrideNode?.Child as ListNode;
-        Assert.NotNull(listNode);
+        Assert.IsNotNull(listNode);
 
         listNode!.BuildBindings();
 
         // Inner override should win for the same type
-        Assert.True(innerCalled, "Inner override should run");
-        Assert.False(outerCalled, "Outer override should be replaced by inner for same type");
+        Assert.IsTrue(innerCalled, "Inner override should run");
+        Assert.IsFalse(outerCalled, "Outer override should be replaced by inner for same type");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NestedOverride_DifferentTypes_BothApply()
     {
         // Outer overrides ListWidget, inner overrides ButtonWidget — both should apply.
@@ -368,23 +369,23 @@ public class InputOverrideTests
         listNode.BuildBindings();
         buttonNode.BuildBindings();
 
-        Assert.True(listOverrideCalled, "Outer ListWidget override should cascade through inner");
-        Assert.True(buttonOverrideCalled, "Inner ButtonWidget override should apply");
+        Assert.IsTrue(listOverrideCalled, "Outer ListWidget override should cascade through inner");
+        Assert.IsTrue(buttonOverrideCalled, "Inner ButtonWidget override should apply");
     }
 
     #endregion
 
     #region Extension Method Tests
 
-    [Fact]
+    [TestMethod]
     public void ExtensionMethod_CreatesInputOverrideWidget()
     {
         // Verify the extension method creates an InputOverrideWidget with the correct content.
         var content = new ButtonWidget("OK");
         var widget = new InputOverrideWidget(content);
 
-        Assert.Equal(content, widget.Content);
-        Assert.Empty(widget.Overrides);
+        Assert.AreEqual(content, widget.Content);
+        Assert.IsEmpty(widget.Overrides);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/InputRouterTests.cs
+++ b/tests/Hex1b.Tests/InputRouterTests.cs
@@ -4,6 +4,7 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class InputRouterTests
 {
     /// <summary>
@@ -67,7 +68,7 @@ public class InputRouterTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInput_ToFocusedNode_RoutesSuccessfully()
     {
         // Arrange
@@ -87,13 +88,13 @@ public class InputRouterTests
         var result = await InputRouter.RouteInputAsync(container, keyEvent, focusRing, state, null, TestContext.Current.CancellationToken);
         
         // Assert
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Single(focusedNode.ReceivedInputs);
-        var receivedKeyEvent = Assert.IsType<Hex1bKeyEvent>(focusedNode.ReceivedInputs[0]);
-        Assert.Equal(Hex1bKey.A, receivedKeyEvent.Key);
+        Assert.AreEqual(InputResult.Handled, result);
+        TestSeq.Single(focusedNode.ReceivedInputs);
+        var receivedKeyEvent = TestSeq.IsType<Hex1bKeyEvent>(focusedNode.ReceivedInputs[0]);
+        Assert.AreEqual(Hex1bKey.A, receivedKeyEvent.Key);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInput_WithMatchingBinding_ExecutesBinding()
     {
         // Arrange
@@ -119,12 +120,12 @@ public class InputRouterTests
         var result = await InputRouter.RouteInputAsync(container, keyEvent, focusRing, state, null, TestContext.Current.CancellationToken);
         
         // Assert
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(bindingExecuted);
-        Assert.Empty(focusedNode.ReceivedInputs); // OnInput should not be called when binding matches
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(bindingExecuted);
+        Assert.IsEmpty(focusedNode.ReceivedInputs); // OnInput should not be called when binding matches
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInput_ChildBindingOverridesParentBinding()
     {
         // Arrange
@@ -156,12 +157,12 @@ public class InputRouterTests
         var result = await InputRouter.RouteInputAsync(container, keyEvent, focusRing, state, null, TestContext.Current.CancellationToken);
         
         // Assert
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(childBindingExecuted);
-        Assert.False(parentBindingExecuted); // Child binding should win
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(childBindingExecuted);
+        Assert.IsFalse(parentBindingExecuted); // Child binding should win
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInput_ParentBindingUsedWhenChildHasNone()
     {
         // Arrange
@@ -189,11 +190,11 @@ public class InputRouterTests
         var result = await InputRouter.RouteInputAsync(container, keyEvent, focusRing, state, null, TestContext.Current.CancellationToken);
         
         // Assert
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(parentBindingExecuted);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(parentBindingExecuted);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInput_NoFocusedNode_ReturnsNotHandled()
     {
         // Arrange
@@ -212,10 +213,10 @@ public class InputRouterTests
         var result = await InputRouter.RouteInputAsync(container, keyEvent, focusRing, state, null, TestContext.Current.CancellationToken);
         
         // Assert
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInput_NestedContainers_CollectsBindingsFromPath()
     {
         // Arrange - 3 levels: root -> middle -> focused
@@ -254,13 +255,13 @@ public class InputRouterTests
         var middleResult = await InputRouter.RouteInputAsync(rootContainer, middleKeyEvent, focusRing, state, null, TestContext.Current.CancellationToken);
         
         // Assert
-        Assert.Equal(InputResult.Handled, rootResult);
-        Assert.True(rootBindingExecuted);
-        Assert.Equal(InputResult.Handled, middleResult);
-        Assert.True(middleBindingExecuted);
+        Assert.AreEqual(InputResult.Handled, rootResult);
+        Assert.IsTrue(rootBindingExecuted);
+        Assert.AreEqual(InputResult.Handled, middleResult);
+        Assert.IsTrue(middleBindingExecuted);
     }
 
-    [Fact]
+    [TestMethod]
     public void InputBinding_Factory_CreatesCorrectBindings()
     {
         // Test InputBindingsBuilder creates correct key/modifier combinations
@@ -271,60 +272,57 @@ public class InputRouterTests
         
         var bindings = builder.Bindings;
         
-        Assert.Equal(3, bindings.Count);
+        Assert.AreEqual(3, bindings.Count);
         
         // Plain binding
-        Assert.Equal(Hex1bKey.A, bindings[0].Steps[0].Key);
-        Assert.Equal(Hex1bModifiers.None, bindings[0].Steps[0].Modifiers);
+        Assert.AreEqual(Hex1bKey.A, bindings[0].Steps[0].Key);
+        Assert.AreEqual(Hex1bModifiers.None, bindings[0].Steps[0].Modifiers);
         
         // Ctrl binding
-        Assert.Equal(Hex1bKey.S, bindings[1].Steps[0].Key);
-        Assert.Equal(Hex1bModifiers.Control, bindings[1].Steps[0].Modifiers);
+        Assert.AreEqual(Hex1bKey.S, bindings[1].Steps[0].Key);
+        Assert.AreEqual(Hex1bModifiers.Control, bindings[1].Steps[0].Modifiers);
         
         // Shift binding
-        Assert.Equal(Hex1bKey.Tab, bindings[2].Steps[0].Key);
-        Assert.Equal(Hex1bModifiers.Shift, bindings[2].Steps[0].Modifiers);
+        Assert.AreEqual(Hex1bKey.Tab, bindings[2].Steps[0].Key);
+        Assert.AreEqual(Hex1bModifiers.Shift, bindings[2].Steps[0].Modifiers);
     }
 
-    [Fact]
+    [TestMethod]
     public void Hex1bKeyEvent_Properties_ReturnCorrectValues()
     {
         var evt = new Hex1bKeyEvent(Hex1bKey.A, 'a', Hex1bModifiers.Control | Hex1bModifiers.Shift);
         
-        Assert.True(evt.Control);
-        Assert.True(evt.Shift);
-        Assert.False(evt.Alt);
-        Assert.True(evt.IsPrintable);
+        Assert.IsTrue(evt.Control);
+        Assert.IsTrue(evt.Shift);
+        Assert.IsFalse(evt.Alt);
+        Assert.IsTrue(evt.IsPrintable);
         
         var nonPrintable = new Hex1bKeyEvent(Hex1bKey.Enter, '\r', Hex1bModifiers.None);
-        Assert.False(nonPrintable.IsPrintable);
+        Assert.IsFalse(nonPrintable.IsPrintable);
     }
 
-    [Fact]
+    [TestMethod]
     public void KeyMapper_ToHex1bKey_MapsCorrectly()
     {
-        Assert.Equal(Hex1bKey.A, KeyMapper.ToHex1bKey(ConsoleKey.A));
-        Assert.Equal(Hex1bKey.Enter, KeyMapper.ToHex1bKey(ConsoleKey.Enter));
-        Assert.Equal(Hex1bKey.Escape, KeyMapper.ToHex1bKey(ConsoleKey.Escape));
-        Assert.Equal(Hex1bKey.Tab, KeyMapper.ToHex1bKey(ConsoleKey.Tab));
-        Assert.Equal(Hex1bKey.UpArrow, KeyMapper.ToHex1bKey(ConsoleKey.UpArrow));
-        Assert.Equal(Hex1bKey.F1, KeyMapper.ToHex1bKey(ConsoleKey.F1));
+        Assert.AreEqual(Hex1bKey.A, KeyMapper.ToHex1bKey(ConsoleKey.A));
+        Assert.AreEqual(Hex1bKey.Enter, KeyMapper.ToHex1bKey(ConsoleKey.Enter));
+        Assert.AreEqual(Hex1bKey.Escape, KeyMapper.ToHex1bKey(ConsoleKey.Escape));
+        Assert.AreEqual(Hex1bKey.Tab, KeyMapper.ToHex1bKey(ConsoleKey.Tab));
+        Assert.AreEqual(Hex1bKey.UpArrow, KeyMapper.ToHex1bKey(ConsoleKey.UpArrow));
+        Assert.AreEqual(Hex1bKey.F1, KeyMapper.ToHex1bKey(ConsoleKey.F1));
     }
 
-    [Fact]
+    [TestMethod]
     public void KeyMapper_ToHex1bModifiers_MapsCorrectly()
     {
-        Assert.Equal(Hex1bModifiers.None, KeyMapper.ToHex1bModifiers(false, false, false));
-        Assert.Equal(Hex1bModifiers.Shift, KeyMapper.ToHex1bModifiers(true, false, false));
-        Assert.Equal(Hex1bModifiers.Alt, KeyMapper.ToHex1bModifiers(false, true, false));
-        Assert.Equal(Hex1bModifiers.Control, KeyMapper.ToHex1bModifiers(false, false, true));
-        Assert.Equal(
-            Hex1bModifiers.Shift | Hex1bModifiers.Control,
-            KeyMapper.ToHex1bModifiers(true, false, true)
-        );
+        Assert.AreEqual(Hex1bModifiers.None, KeyMapper.ToHex1bModifiers(false, false, false));
+        Assert.AreEqual(Hex1bModifiers.Shift, KeyMapper.ToHex1bModifiers(true, false, false));
+        Assert.AreEqual(Hex1bModifiers.Alt, KeyMapper.ToHex1bModifiers(false, true, false));
+        Assert.AreEqual(Hex1bModifiers.Control, KeyMapper.ToHex1bModifiers(false, false, true));
+        Assert.AreEqual(Hex1bModifiers.Shift | Hex1bModifiers.Control, KeyMapper.ToHex1bModifiers(true, false, true));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInputToNode_TextBoxBackspace_DeletesAndPositionsCursor()
     {
         // Arrange
@@ -335,12 +333,12 @@ public class InputRouterTests
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Backspace, '\b', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal("hell", state.Text);
-        Assert.Equal(4, state.CursorPosition);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual("hell", state.Text);
+        Assert.AreEqual(4, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInputToNode_TextBoxDoubleBackspace_DeletesTwoCharacters()
     {
         // Arrange
@@ -352,13 +350,13 @@ public class InputRouterTests
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Backspace, '\b', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.Equal("hel", state.Text);
-        Assert.Equal(3, state.CursorPosition);
+        Assert.AreEqual("hel", state.Text);
+        Assert.AreEqual(3, state.CursorPosition);
     }
 
     #region CharacterBinding Tests
 
-    [Fact]
+    [TestMethod]
     public void CharacterBinding_MatchesPrintableText()
     {
         // Arrange
@@ -369,21 +367,21 @@ public class InputRouterTests
             "Insert text");
 
         // Act & Assert
-        Assert.True(binding.Matches("a"));
-        Assert.True(binding.Matches("Z"));
-        Assert.True(binding.Matches("5"));
-        Assert.True(binding.Matches(" "));
-        Assert.True(binding.Matches("😀"));  // Emoji as string works!
-        Assert.False(binding.Matches("\n"));
-        Assert.False(binding.Matches("\t"));
-        Assert.False(binding.Matches("\b"));
-        Assert.False(binding.Matches(""));
+        Assert.IsTrue(binding.Matches("a"));
+        Assert.IsTrue(binding.Matches("Z"));
+        Assert.IsTrue(binding.Matches("5"));
+        Assert.IsTrue(binding.Matches(" "));
+        Assert.IsTrue(binding.Matches("😀"));  // Emoji as string works!
+        Assert.IsFalse(binding.Matches("\n"));
+        Assert.IsFalse(binding.Matches("\t"));
+        Assert.IsFalse(binding.Matches("\b"));
+        Assert.IsFalse(binding.Matches(""));
         
         binding.Execute("X");
-        Assert.Equal("X", received);
+        Assert.AreEqual("X", received);
     }
 
-    [Fact]
+    [TestMethod]
     public void CharacterBinding_CustomPredicate_MatchesDigitsOnly()
     {
         // Arrange
@@ -394,17 +392,17 @@ public class InputRouterTests
             "Insert digit");
 
         // Act & Assert
-        Assert.True(binding.Matches("0"));
-        Assert.True(binding.Matches("9"));
-        Assert.False(binding.Matches("a"));
-        Assert.False(binding.Matches(" "));
-        Assert.False(binding.Matches("12"));  // Multiple digits don't match single-digit predicate
+        Assert.IsTrue(binding.Matches("0"));
+        Assert.IsTrue(binding.Matches("9"));
+        Assert.IsFalse(binding.Matches("a"));
+        Assert.IsFalse(binding.Matches(" "));
+        Assert.IsFalse(binding.Matches("12"));  // Multiple digits don't match single-digit predicate
         
         binding.Execute("7");
-        Assert.Equal("7", received);
+        Assert.AreEqual("7", received);
     }
 
-    [Fact]
+    [TestMethod]
     public void InputBindingsBuilder_AnyCharacter_CreatesCharacterBinding()
     {
         // Arrange
@@ -415,18 +413,18 @@ public class InputRouterTests
         builder.AnyCharacter().Action(text => received = text, "Type");
 
         // Assert
-        Assert.Single(builder.CharacterBindings);
-        Assert.Empty(builder.Bindings);  // Key bindings list should be empty
+        TestSeq.Single(builder.CharacterBindings);
+        Assert.IsEmpty(builder.Bindings);  // Key bindings list should be empty
         
         var binding = builder.CharacterBindings[0];
-        Assert.True(binding.Matches("a"));
-        Assert.True(binding.Matches("😀"));  // Emoji works
-        Assert.False(binding.Matches("\n"));
-        Assert.False(binding.Matches(""));
-        Assert.Equal("Type", binding.Description);
+        Assert.IsTrue(binding.Matches("a"));
+        Assert.IsTrue(binding.Matches("😀"));  // Emoji works
+        Assert.IsFalse(binding.Matches("\n"));
+        Assert.IsFalse(binding.Matches(""));
+        Assert.AreEqual("Type", binding.Description);
     }
 
-    [Fact]
+    [TestMethod]
     public void InputBindingsBuilder_Character_WithCustomPredicate()
     {
         // Arrange
@@ -437,16 +435,16 @@ public class InputRouterTests
         builder.Character(text => text.Length == 1 && char.IsLetter(text[0])).Action(text => received = text, "Letters only");
 
         // Assert
-        Assert.Single(builder.CharacterBindings);
+        TestSeq.Single(builder.CharacterBindings);
         
         var binding = builder.CharacterBindings[0];
-        Assert.True(binding.Matches("a"));
-        Assert.True(binding.Matches("Z"));
-        Assert.False(binding.Matches("5"));
-        Assert.False(binding.Matches(" "));
+        Assert.IsTrue(binding.Matches("a"));
+        Assert.IsTrue(binding.Matches("Z"));
+        Assert.IsFalse(binding.Matches("5"));
+        Assert.IsFalse(binding.Matches(" "));
     }
 
-    [Fact]
+    [TestMethod]
     public void InputBindingsBuilder_MixedBindings_KeyAndCharacter()
     {
         // Arrange
@@ -457,11 +455,11 @@ public class InputRouterTests
         builder.AnyCharacter().Action(_ => { }, "Type");
 
         // Assert
-        Assert.Single(builder.Bindings);
-        Assert.Single(builder.CharacterBindings);
+        TestSeq.Single(builder.Bindings);
+        TestSeq.Single(builder.CharacterBindings);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInputToNode_CharacterBinding_InsertsCharacter()
     {
         // Arrange
@@ -472,12 +470,12 @@ public class InputRouterTests
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.X, 'X', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal("helloX", state.Text);
-        Assert.Equal(6, state.CursorPosition);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual("helloX", state.Text);
+        Assert.AreEqual(6, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInputToNode_CharacterBinding_MultipleCharacters()
     {
         // Arrange
@@ -490,11 +488,11 @@ public class InputRouterTests
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.None, '!', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.Equal("Hi!", state.Text);
-        Assert.Equal(3, state.CursorPosition);
+        Assert.AreEqual("Hi!", state.Text);
+        Assert.AreEqual(3, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInputToNode_CharacterBinding_NotFocused_NotHandled()
     {
         // Arrange
@@ -505,11 +503,11 @@ public class InputRouterTests
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.X, 'X', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.Equal(InputResult.NotHandled, result);
-        Assert.Equal("hello", state.Text);  // Text unchanged
+        Assert.AreEqual(InputResult.NotHandled, result);
+        Assert.AreEqual("hello", state.Text);  // Text unchanged
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInputToNode_KeyBindingTakesPrecedence_OverCharacterBinding()
     {
         // Arrange - node with both a key binding for 'A' and a character binding
@@ -527,12 +525,12 @@ public class InputRouterTests
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.A, 'a', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
         // Assert - key binding should win
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(keyBindingCalled);
-        Assert.Equal("", textReceived);  // Character binding should not have been called
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(keyBindingCalled);
+        Assert.AreEqual("", textReceived);  // Character binding should not have been called
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInputToNode_CharacterBinding_FallsBackWhenNoKeyBinding()
     {
         // Arrange - node with key binding for Enter, but typing 'x'
@@ -550,12 +548,12 @@ public class InputRouterTests
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.X, 'x', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
         // Assert - character binding should handle it
-        Assert.Equal(InputResult.Handled, result);
-        Assert.False(enterPressed);
-        Assert.Equal("x", textReceived);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsFalse(enterPressed);
+        Assert.AreEqual("x", textReceived);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInputToNode_CharacterBinding_EmptyText_NotHandled()
     {
         // Arrange - key event with no text
@@ -571,11 +569,11 @@ public class InputRouterTests
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.F1, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
         // Assert - character binding should not match
-        Assert.Equal(InputResult.Handled, result);  // Handled by HandleInput fallback
-        Assert.Equal("", textReceived);
+        Assert.AreEqual(InputResult.Handled, result);  // Handled by HandleInput fallback
+        Assert.AreEqual("", textReceived);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInputToNode_CharacterBinding_FirstMatchWins()
     {
         // Arrange - multiple character bindings, first matching one wins
@@ -592,11 +590,11 @@ public class InputRouterTests
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.D5, '5', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal("digit", handler);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual("digit", handler);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInputToNode_CharacterBinding_SecondMatchWhenFirstFails()
     {
         // Arrange - digit binding first, but typing a letter
@@ -613,11 +611,11 @@ public class InputRouterTests
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.A, 'a', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal("any", handler);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual("any", handler);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInput_CharacterBinding_OnlyOnFocusedNode()
     {
         // Arrange - parent has character binding, child is focused
@@ -648,12 +646,12 @@ public class InputRouterTests
         var result = await InputRouter.RouteInputAsync(container, new Hex1bKeyEvent(Hex1bKey.X, 'x', Hex1bModifiers.None), focusRing, state, null, TestContext.Current.CancellationToken);
 
         // Assert - only child's character binding should fire (not parent's)
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal("x", childReceived);
-        Assert.Equal("", parentReceived);  // Parent's character binding should NOT have been called
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual("x", childReceived);
+        Assert.AreEqual("", parentReceived);  // Parent's character binding should NOT have been called
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInputToNode_CharacterBinding_Emoji()
     {
         // Arrange - emoji as a full string (not surrogate pair chars)
@@ -664,12 +662,12 @@ public class InputRouterTests
         var result = await InputRouter.RouteInputToNodeAsync(node, Hex1bKeyEvent.FromText("😀"), null, null, TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal("hello😀", state.Text);
-        Assert.Equal(7, state.CursorPosition);  // Emoji is 2 chars in UTF-16
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual("hello😀", state.Text);
+        Assert.AreEqual(7, state.CursorPosition);  // Emoji is 2 chars in UTF-16
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInputToNode_CharacterBinding_MultipleEmojis()
     {
         // Arrange
@@ -682,10 +680,10 @@ public class InputRouterTests
         await InputRouter.RouteInputToNodeAsync(node, Hex1bKeyEvent.FromText("🚀"), null, null, TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.Equal("👍🎉🚀", state.Text);
+        Assert.AreEqual("👍🎉🚀", state.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInputToNode_CharacterBinding_UnicodeCharacters()
     {
         // Arrange
@@ -699,11 +697,11 @@ public class InputRouterTests
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.None, '日', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.Equal("éñ中日", state.Text);
-        Assert.Equal(4, state.CursorPosition);
+        Assert.AreEqual("éñ中日", state.Text);
+        Assert.AreEqual(4, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RouteInputToNode_CharacterBinding_PastedText()
     {
         // Arrange - simulating paste of multiple characters at once
@@ -714,9 +712,9 @@ public class InputRouterTests
         var result = await InputRouter.RouteInputToNodeAsync(node, Hex1bKeyEvent.FromText("World!"), null, null, TestContext.Current.CancellationToken);
 
         // Assert
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal("Hello World!", state.Text);
-        Assert.Equal(12, state.CursorPosition);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual("Hello World!", state.Text);
+        Assert.AreEqual(12, state.CursorPosition);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/InputTokenizerTests.cs
+++ b/tests/Hex1b.Tests/InputTokenizerTests.cs
@@ -7,132 +7,133 @@ namespace Hex1b.Tests;
 /// Tests for input sequence tokenization using the unified AnsiTokenizer.
 /// These sequences are typically received from the terminal (keyboard/mouse input).
 /// </summary>
+[TestClass]
 public class InputTokenizerTests
 {
     // === SS3 Sequences (ESC O) ===
     
-    [Theory]
-    [InlineData("P", 'P')] // F1
-    [InlineData("Q", 'Q')] // F2
-    [InlineData("R", 'R')] // F3
-    [InlineData("S", 'S')] // F4
-    [InlineData("A", 'A')] // Up arrow (application mode)
-    [InlineData("B", 'B')] // Down arrow (application mode)
-    [InlineData("C", 'C')] // Right arrow (application mode)
-    [InlineData("D", 'D')] // Left arrow (application mode)
-    [InlineData("H", 'H')] // Home (application mode)
-    [InlineData("F", 'F')] // End (application mode)
+    [TestMethod]
+    [DataRow("P", 'P')] // F1
+    [DataRow("Q", 'Q')] // F2
+    [DataRow("R", 'R')] // F3
+    [DataRow("S", 'S')] // F4
+    [DataRow("A", 'A')] // Up arrow (application mode)
+    [DataRow("B", 'B')] // Down arrow (application mode)
+    [DataRow("C", 'C')] // Right arrow (application mode)
+    [DataRow("D", 'D')] // Left arrow (application mode)
+    [DataRow("H", 'H')] // Home (application mode)
+    [DataRow("F", 'F')] // End (application mode)
     public void Ss3Sequence_ParsesCorrectly(string charPart, char expectedChar)
     {
         var input = $"\x1bO{charPart}";
         var tokens = AnsiTokenizer.Tokenize(input);
         
-        var ss3Token = Assert.Single(tokens);
-        var token = Assert.IsType<Ss3Token>(ss3Token);
-        Assert.Equal(expectedChar, token.Character);
+        var ss3Token = TestSeq.Single(tokens);
+        var token = TestSeq.IsType<Ss3Token>(ss3Token);
+        Assert.AreEqual(expectedChar, token.Character);
     }
     
-    [Fact]
+    [TestMethod]
     public void Ss3Sequence_Serializes_RoundTrip()
     {
         var original = "\x1bOP"; // F1
         var tokens = AnsiTokenizer.Tokenize(original);
         var serialized = AnsiTokenSerializer.Serialize(tokens);
-        Assert.Equal(original, serialized);
+        Assert.AreEqual(original, serialized);
     }
     
     // === Special Key Sequences (ESC [ n ~) ===
     
-    [Theory]
-    [InlineData("2", 2, 1)]   // Insert
-    [InlineData("3", 3, 1)]   // Delete
-    [InlineData("5", 5, 1)]   // Page Up
-    [InlineData("6", 6, 1)]   // Page Down
-    [InlineData("15", 15, 1)] // F5
-    [InlineData("17", 17, 1)] // F6
-    [InlineData("18", 18, 1)] // F7
-    [InlineData("19", 19, 1)] // F8
-    [InlineData("20", 20, 1)] // F9
-    [InlineData("21", 21, 1)] // F10
-    [InlineData("23", 23, 1)] // F11
-    [InlineData("24", 24, 1)] // F12
+    [TestMethod]
+    [DataRow("2", 2, 1)]   // Insert
+    [DataRow("3", 3, 1)]   // Delete
+    [DataRow("5", 5, 1)]   // Page Up
+    [DataRow("6", 6, 1)]   // Page Down
+    [DataRow("15", 15, 1)] // F5
+    [DataRow("17", 17, 1)] // F6
+    [DataRow("18", 18, 1)] // F7
+    [DataRow("19", 19, 1)] // F8
+    [DataRow("20", 20, 1)] // F9
+    [DataRow("21", 21, 1)] // F10
+    [DataRow("23", 23, 1)] // F11
+    [DataRow("24", 24, 1)] // F12
     public void SpecialKeySequence_ParsesCorrectly(string keyCode, int expectedCode, int expectedMod)
     {
         var input = $"\x1b[{keyCode}~";
         var tokens = AnsiTokenizer.Tokenize(input);
         
-        var keyToken = Assert.Single(tokens);
-        var token = Assert.IsType<SpecialKeyToken>(keyToken);
-        Assert.Equal(expectedCode, token.KeyCode);
-        Assert.Equal(expectedMod, token.Modifiers);
+        var keyToken = TestSeq.Single(tokens);
+        var token = TestSeq.IsType<SpecialKeyToken>(keyToken);
+        Assert.AreEqual(expectedCode, token.KeyCode);
+        Assert.AreEqual(expectedMod, token.Modifiers);
     }
     
-    [Theory]
-    [InlineData("3;2", 3, 2)]  // Delete with Shift
-    [InlineData("3;5", 3, 5)]  // Delete with Ctrl
-    [InlineData("15;3", 15, 3)] // F5 with Alt
+    [TestMethod]
+    [DataRow("3;2", 3, 2)]  // Delete with Shift
+    [DataRow("3;5", 3, 5)]  // Delete with Ctrl
+    [DataRow("15;3", 15, 3)] // F5 with Alt
     public void SpecialKeySequence_WithModifiers_ParsesCorrectly(string params_, int expectedCode, int expectedMod)
     {
         var input = $"\x1b[{params_}~";
         var tokens = AnsiTokenizer.Tokenize(input);
         
-        var keyToken = Assert.Single(tokens);
-        var token = Assert.IsType<SpecialKeyToken>(keyToken);
-        Assert.Equal(expectedCode, token.KeyCode);
-        Assert.Equal(expectedMod, token.Modifiers);
+        var keyToken = TestSeq.Single(tokens);
+        var token = TestSeq.IsType<SpecialKeyToken>(keyToken);
+        Assert.AreEqual(expectedCode, token.KeyCode);
+        Assert.AreEqual(expectedMod, token.Modifiers);
     }
     
-    [Fact]
+    [TestMethod]
     public void SpecialKeySequence_Serializes_RoundTrip()
     {
         var original = "\x1b[15~"; // F5
         var tokens = AnsiTokenizer.Tokenize(original);
         var serialized = AnsiTokenSerializer.Serialize(tokens);
-        Assert.Equal(original, serialized);
+        Assert.AreEqual(original, serialized);
     }
     
-    [Fact]
+    [TestMethod]
     public void SpecialKeySequence_WithModifiers_Serializes_RoundTrip()
     {
         var original = "\x1b[3;5~"; // Delete with Ctrl
         var tokens = AnsiTokenizer.Tokenize(original);
         var serialized = AnsiTokenSerializer.Serialize(tokens);
-        Assert.Equal(original, serialized);
+        Assert.AreEqual(original, serialized);
     }
     
     // === Modified Home/End (xterm format: CSI 1;m H / CSI 1;m F) ===
     
-    [Theory]
-    [InlineData(2, Hex1bModifiers.Shift)]             // Shift+End
-    [InlineData(5, Hex1bModifiers.Control)]            // Ctrl+End
-    [InlineData(6, Hex1bModifiers.Control | Hex1bModifiers.Shift)] // Ctrl+Shift+End
+    [TestMethod]
+    [DataRow(2, Hex1bModifiers.Shift)]             // Shift+End
+    [DataRow(5, Hex1bModifiers.Control)]            // Ctrl+End
+    [DataRow(6, Hex1bModifiers.Control | Hex1bModifiers.Shift)] // Ctrl+Shift+End
     public void ModifiedEnd_XtermFormat_ParsesAsSpecialKeyWithModifiers(int modCode, Hex1bModifiers expectedMod)
     {
         // CSI 1;{mod}F = End with modifiers (xterm)
         var input = $"\x1b[1;{modCode}F";
         var tokens = AnsiTokenizer.Tokenize(input);
         
-        var keyToken = Assert.Single(tokens);
-        var token = Assert.IsType<SpecialKeyToken>(keyToken);
-        Assert.Equal(4, token.KeyCode); // 4 = End
-        Assert.Equal(modCode, token.Modifiers);
+        var keyToken = TestSeq.Single(tokens);
+        var token = TestSeq.IsType<SpecialKeyToken>(keyToken);
+        Assert.AreEqual(4, token.KeyCode); // 4 = End
+        Assert.AreEqual(modCode, token.Modifiers);
         
         // Verify the modifier decodes correctly through SpecialKeyTokenToKeyEvent
         // (indirectly: modifier code - 1 gives bits where bit0=Shift, bit1=Alt, bit2=Ctrl)
         var decodedBits = modCode - 1;
-        if (expectedMod.HasFlag(Hex1bModifiers.Shift)) Assert.NotEqual(0, decodedBits & 1);
-        if (expectedMod.HasFlag(Hex1bModifiers.Control)) Assert.NotEqual(0, decodedBits & 4);
+        if (expectedMod.HasFlag(Hex1bModifiers.Shift)) Assert.AreNotEqual(0, decodedBits & 1);
+        if (expectedMod.HasFlag(Hex1bModifiers.Control)) Assert.AreNotEqual(0, decodedBits & 4);
     }
     
-    [Fact]
+    [TestMethod]
     public void PlainEnd_CsiF_ParsesAsCursorMove()
     {
         // CSI F (no params) = Cursor Previous Line = End key
         var input = "\x1b[F";
         var tokens = AnsiTokenizer.Tokenize(input);
         
-        var token = Assert.Single(tokens);
-        Assert.IsType<CursorMoveToken>(token);
+        var token = TestSeq.Single(tokens);
+        TestSeq.IsType<CursorMoveToken>(token);
     }
 
     // === Modified F1-F4 (xterm "PC keyboard" format: CSI 1;m P/Q/R/S) ===
@@ -142,242 +143,242 @@ public class InputTokenizerTests
     // emit the CSI form ESC [ 1 ; {mod} <P/Q/R/S>. The corresponding F-key codes for
     // SpecialKeyToken are 11=F1, 12=F2, 13=F3, 14=F4 (matching the CSI ~ form).
 
-    [Theory]
-    [InlineData('P', 11)] // F1
-    [InlineData('Q', 12)] // F2
-    [InlineData('R', 13)] // F3
-    [InlineData('S', 14)] // F4
+    [TestMethod]
+    [DataRow('P', 11)] // F1
+    [DataRow('Q', 12)] // F2
+    [DataRow('R', 13)] // F3
+    [DataRow('S', 14)] // F4
     public void ModifiedFunctionKey_F1ThroughF4_XtermFormat_ParsesAsSpecialKey(char terminator, int expectedCode)
     {
         // CSI 1;5{P/Q/R/S} = F1-F4 with Ctrl
         var input = $"\x1b[1;5{terminator}";
         var tokens = AnsiTokenizer.Tokenize(input);
 
-        var token = Assert.Single(tokens);
-        var special = Assert.IsType<SpecialKeyToken>(token);
-        Assert.Equal(expectedCode, special.KeyCode);
-        Assert.Equal(5, special.Modifiers); // 5 = Ctrl
+        var token = TestSeq.Single(tokens);
+        var special = TestSeq.IsType<SpecialKeyToken>(token);
+        Assert.AreEqual(expectedCode, special.KeyCode);
+        Assert.AreEqual(5, special.Modifiers); // 5 = Ctrl
     }
 
-    [Theory]
-    [InlineData(2)]  // Shift
-    [InlineData(3)]  // Alt
-    [InlineData(4)]  // Alt+Shift
-    [InlineData(5)]  // Ctrl
-    [InlineData(6)]  // Ctrl+Shift
-    [InlineData(7)]  // Alt+Ctrl
-    [InlineData(8)]  // Alt+Ctrl+Shift
+    [TestMethod]
+    [DataRow(2)]  // Shift
+    [DataRow(3)]  // Alt
+    [DataRow(4)]  // Alt+Shift
+    [DataRow(5)]  // Ctrl
+    [DataRow(6)]  // Ctrl+Shift
+    [DataRow(7)]  // Alt+Ctrl
+    [DataRow(8)]  // Alt+Ctrl+Shift
     public void ModifiedFunctionKey_F1_AllXtermModifiers_Parse(int modCode)
     {
         var input = $"\x1b[1;{modCode}P";
         var tokens = AnsiTokenizer.Tokenize(input);
 
-        var token = Assert.Single(tokens);
-        var special = Assert.IsType<SpecialKeyToken>(token);
-        Assert.Equal(11, special.KeyCode); // F1
-        Assert.Equal(modCode, special.Modifiers);
+        var token = TestSeq.Single(tokens);
+        var special = TestSeq.IsType<SpecialKeyToken>(token);
+        Assert.AreEqual(11, special.KeyCode); // F1
+        Assert.AreEqual(modCode, special.Modifiers);
     }
 
-    [Fact]
+    [TestMethod]
     public void PlainCsiP_StillParsesAsDeleteCharacter()
     {
         // CSI P (no params or single param) = DCH; must NOT be misinterpreted as F1
         var tokens = AnsiTokenizer.Tokenize("\x1b[P");
-        Assert.IsType<DeleteCharacterToken>(Assert.Single(tokens));
+        TestSeq.IsType<DeleteCharacterToken>(TestSeq.Single(tokens));
 
         var tokens2 = AnsiTokenizer.Tokenize("\x1b[3P");
-        var dch = Assert.IsType<DeleteCharacterToken>(Assert.Single(tokens2));
-        Assert.Equal(3, dch.Count);
+        var dch = TestSeq.IsType<DeleteCharacterToken>(TestSeq.Single(tokens2));
+        Assert.AreEqual(3, dch.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void PlainCsiS_StillParsesAsScrollUp()
     {
         // CSI S (no params or single param) = SU; must NOT be misinterpreted as F4
         var tokens = AnsiTokenizer.Tokenize("\x1b[S");
-        Assert.IsType<ScrollUpToken>(Assert.Single(tokens));
+        TestSeq.IsType<ScrollUpToken>(TestSeq.Single(tokens));
 
         var tokens2 = AnsiTokenizer.Tokenize("\x1b[2S");
-        var su = Assert.IsType<ScrollUpToken>(Assert.Single(tokens2));
-        Assert.Equal(2, su.Count);
+        var su = TestSeq.IsType<ScrollUpToken>(TestSeq.Single(tokens2));
+        Assert.AreEqual(2, su.Count);
     }
 
     // === SGR Mouse Sequences (ESC [ < Cb ; Cx ; Cy M/m) ===
     
-    [Fact]
+    [TestMethod]
     public void SgrMouse_LeftClick_ParsesCorrectly()
     {
         var input = "\x1b[<0;10;5M"; // Left button press at (10,5) - 1-based
         var tokens = AnsiTokenizer.Tokenize(input);
         
-        var mouseToken = Assert.Single(tokens);
-        var token = Assert.IsType<SgrMouseToken>(mouseToken);
-        Assert.Equal(MouseButton.Left, token.Button);
-        Assert.Equal(MouseAction.Down, token.Action);
-        Assert.Equal(9, token.X);  // 0-based
-        Assert.Equal(4, token.Y);  // 0-based
-        Assert.Equal(Hex1bModifiers.None, token.Modifiers);
+        var mouseToken = TestSeq.Single(tokens);
+        var token = TestSeq.IsType<SgrMouseToken>(mouseToken);
+        Assert.AreEqual(MouseButton.Left, token.Button);
+        Assert.AreEqual(MouseAction.Down, token.Action);
+        Assert.AreEqual(9, token.X);  // 0-based
+        Assert.AreEqual(4, token.Y);  // 0-based
+        Assert.AreEqual(Hex1bModifiers.None, token.Modifiers);
     }
     
-    [Fact]
+    [TestMethod]
     public void SgrMouse_LeftRelease_ParsesCorrectly()
     {
         var input = "\x1b[<0;10;5m"; // Left button release at (10,5)
         var tokens = AnsiTokenizer.Tokenize(input);
         
-        var mouseToken = Assert.Single(tokens);
-        var token = Assert.IsType<SgrMouseToken>(mouseToken);
-        Assert.Equal(MouseButton.Left, token.Button);
-        Assert.Equal(MouseAction.Up, token.Action);
-        Assert.Equal(9, token.X);
-        Assert.Equal(4, token.Y);
+        var mouseToken = TestSeq.Single(tokens);
+        var token = TestSeq.IsType<SgrMouseToken>(mouseToken);
+        Assert.AreEqual(MouseButton.Left, token.Button);
+        Assert.AreEqual(MouseAction.Up, token.Action);
+        Assert.AreEqual(9, token.X);
+        Assert.AreEqual(4, token.Y);
     }
     
-    [Fact]
+    [TestMethod]
     public void SgrMouse_RightClick_ParsesCorrectly()
     {
         var input = "\x1b[<2;1;1M"; // Right button press
         var tokens = AnsiTokenizer.Tokenize(input);
         
-        var mouseToken = Assert.Single(tokens);
-        var token = Assert.IsType<SgrMouseToken>(mouseToken);
-        Assert.Equal(MouseButton.Right, token.Button);
-        Assert.Equal(MouseAction.Down, token.Action);
+        var mouseToken = TestSeq.Single(tokens);
+        var token = TestSeq.IsType<SgrMouseToken>(mouseToken);
+        Assert.AreEqual(MouseButton.Right, token.Button);
+        Assert.AreEqual(MouseAction.Down, token.Action);
     }
     
-    [Fact]
+    [TestMethod]
     public void SgrMouse_MiddleClick_ParsesCorrectly()
     {
         var input = "\x1b[<1;1;1M"; // Middle button press
         var tokens = AnsiTokenizer.Tokenize(input);
         
-        var mouseToken = Assert.Single(tokens);
-        var token = Assert.IsType<SgrMouseToken>(mouseToken);
-        Assert.Equal(MouseButton.Middle, token.Button);
+        var mouseToken = TestSeq.Single(tokens);
+        var token = TestSeq.IsType<SgrMouseToken>(mouseToken);
+        Assert.AreEqual(MouseButton.Middle, token.Button);
     }
     
-    [Fact]
+    [TestMethod]
     public void SgrMouse_ScrollUp_ParsesCorrectly()
     {
         var input = "\x1b[<64;1;1M"; // Scroll up
         var tokens = AnsiTokenizer.Tokenize(input);
         
-        var mouseToken = Assert.Single(tokens);
-        var token = Assert.IsType<SgrMouseToken>(mouseToken);
-        Assert.Equal(MouseButton.ScrollUp, token.Button);
+        var mouseToken = TestSeq.Single(tokens);
+        var token = TestSeq.IsType<SgrMouseToken>(mouseToken);
+        Assert.AreEqual(MouseButton.ScrollUp, token.Button);
     }
     
-    [Fact]
+    [TestMethod]
     public void SgrMouse_ScrollDown_ParsesCorrectly()
     {
         var input = "\x1b[<65;1;1M"; // Scroll down
         var tokens = AnsiTokenizer.Tokenize(input);
         
-        var mouseToken = Assert.Single(tokens);
-        var token = Assert.IsType<SgrMouseToken>(mouseToken);
-        Assert.Equal(MouseButton.ScrollDown, token.Button);
+        var mouseToken = TestSeq.Single(tokens);
+        var token = TestSeq.IsType<SgrMouseToken>(mouseToken);
+        Assert.AreEqual(MouseButton.ScrollDown, token.Button);
     }
     
-    [Fact]
+    [TestMethod]
     public void SgrMouse_WithShift_ParsesCorrectly()
     {
         var input = "\x1b[<4;1;1M"; // Left + Shift (0 + 4)
         var tokens = AnsiTokenizer.Tokenize(input);
         
-        var mouseToken = Assert.Single(tokens);
-        var token = Assert.IsType<SgrMouseToken>(mouseToken);
-        Assert.Equal(MouseButton.Left, token.Button);
-        Assert.True(token.Modifiers.HasFlag(Hex1bModifiers.Shift));
+        var mouseToken = TestSeq.Single(tokens);
+        var token = TestSeq.IsType<SgrMouseToken>(mouseToken);
+        Assert.AreEqual(MouseButton.Left, token.Button);
+        Assert.IsTrue(token.Modifiers.HasFlag(Hex1bModifiers.Shift));
     }
     
-    [Fact]
+    [TestMethod]
     public void SgrMouse_WithAlt_ParsesCorrectly()
     {
         var input = "\x1b[<8;1;1M"; // Left + Alt (0 + 8)
         var tokens = AnsiTokenizer.Tokenize(input);
         
-        var mouseToken = Assert.Single(tokens);
-        var token = Assert.IsType<SgrMouseToken>(mouseToken);
-        Assert.Equal(MouseButton.Left, token.Button);
-        Assert.True(token.Modifiers.HasFlag(Hex1bModifiers.Alt));
+        var mouseToken = TestSeq.Single(tokens);
+        var token = TestSeq.IsType<SgrMouseToken>(mouseToken);
+        Assert.AreEqual(MouseButton.Left, token.Button);
+        Assert.IsTrue(token.Modifiers.HasFlag(Hex1bModifiers.Alt));
     }
     
-    [Fact]
+    [TestMethod]
     public void SgrMouse_WithCtrl_ParsesCorrectly()
     {
         var input = "\x1b[<16;1;1M"; // Left + Ctrl (0 + 16)
         var tokens = AnsiTokenizer.Tokenize(input);
         
-        var mouseToken = Assert.Single(tokens);
-        var token = Assert.IsType<SgrMouseToken>(mouseToken);
-        Assert.Equal(MouseButton.Left, token.Button);
-        Assert.True(token.Modifiers.HasFlag(Hex1bModifiers.Control));
+        var mouseToken = TestSeq.Single(tokens);
+        var token = TestSeq.IsType<SgrMouseToken>(mouseToken);
+        Assert.AreEqual(MouseButton.Left, token.Button);
+        Assert.IsTrue(token.Modifiers.HasFlag(Hex1bModifiers.Control));
     }
     
-    [Fact]
+    [TestMethod]
     public void SgrMouse_Motion_ParsesCorrectly()
     {
         var input = "\x1b[<35;10;20M"; // Motion with no button (32 + 3=none)
         var tokens = AnsiTokenizer.Tokenize(input);
         
-        var mouseToken = Assert.Single(tokens);
-        var token = Assert.IsType<SgrMouseToken>(mouseToken);
-        Assert.Equal(MouseAction.Move, token.Action);
+        var mouseToken = TestSeq.Single(tokens);
+        var token = TestSeq.IsType<SgrMouseToken>(mouseToken);
+        Assert.AreEqual(MouseAction.Move, token.Action);
     }
     
-    [Fact]
+    [TestMethod]
     public void SgrMouse_Drag_ParsesCorrectly()
     {
         var input = "\x1b[<32;10;20M"; // Drag with left button (32 + 0)
         var tokens = AnsiTokenizer.Tokenize(input);
         
-        var mouseToken = Assert.Single(tokens);
-        var token = Assert.IsType<SgrMouseToken>(mouseToken);
-        Assert.Equal(MouseButton.Left, token.Button);
-        Assert.Equal(MouseAction.Drag, token.Action);
+        var mouseToken = TestSeq.Single(tokens);
+        var token = TestSeq.IsType<SgrMouseToken>(mouseToken);
+        Assert.AreEqual(MouseButton.Left, token.Button);
+        Assert.AreEqual(MouseAction.Drag, token.Action);
     }
     
-    [Fact]
+    [TestMethod]
     public void SgrMouse_Serializes_RoundTrip()
     {
         var original = "\x1b[<0;10;5M";
         var tokens = AnsiTokenizer.Tokenize(original);
         var serialized = AnsiTokenSerializer.Serialize(tokens);
-        Assert.Equal(original, serialized);
+        Assert.AreEqual(original, serialized);
     }
     
     // === Arrow Keys (CSI A/B/C/D) ===
     // These already work via CursorMoveToken but let's verify they still work
     
-    [Theory]
-    [InlineData("A", CursorMoveDirection.Up)]
-    [InlineData("B", CursorMoveDirection.Down)]
-    [InlineData("C", CursorMoveDirection.Forward)]
-    [InlineData("D", CursorMoveDirection.Back)]
+    [TestMethod]
+    [DataRow("A", CursorMoveDirection.Up)]
+    [DataRow("B", CursorMoveDirection.Down)]
+    [DataRow("C", CursorMoveDirection.Forward)]
+    [DataRow("D", CursorMoveDirection.Back)]
     public void ArrowKeys_ParseAsCursorMove(string direction, CursorMoveDirection expected)
     {
         var input = $"\x1b[{direction}";
         var tokens = AnsiTokenizer.Tokenize(input);
         
-        var moveToken = Assert.Single(tokens);
-        var token = Assert.IsType<CursorMoveToken>(moveToken);
-        Assert.Equal(expected, token.Direction);
-        Assert.Equal(1, token.Count);
+        var moveToken = TestSeq.Single(tokens);
+        var token = TestSeq.IsType<CursorMoveToken>(moveToken);
+        Assert.AreEqual(expected, token.Direction);
+        Assert.AreEqual(1, token.Count);
     }
     
     // === Mixed Input ===
     
-    [Fact]
+    [TestMethod]
     public void MixedInput_ParsesAllTokens()
     {
         // Simulate typing "hello" then pressing up arrow then clicking
         var input = "hello\x1b[A\x1b[<0;5;3M";
         var tokens = AnsiTokenizer.Tokenize(input);
         
-        Assert.Equal(3, tokens.Count);
-        Assert.IsType<TextToken>(tokens[0]);
-        Assert.Equal("hello", ((TextToken)tokens[0]).Text);
-        Assert.IsType<CursorMoveToken>(tokens[1]);
-        Assert.IsType<SgrMouseToken>(tokens[2]);
+        Assert.AreEqual(3, tokens.Count);
+        TestSeq.IsType<TextToken>(tokens[0]);
+        Assert.AreEqual("hello", ((TextToken)tokens[0]).Text);
+        TestSeq.IsType<CursorMoveToken>(tokens[1]);
+        TestSeq.IsType<SgrMouseToken>(tokens[2]);
     }
 }

--- a/tests/Hex1b.Tests/InteractableNodeTests.cs
+++ b/tests/Hex1b.Tests/InteractableNodeTests.cs
@@ -10,11 +10,12 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for InteractableNode and InteractableWidget.
 /// </summary>
+[TestClass]
 public class InteractableNodeTests
 {
     #region Measurement Tests
 
-    [Fact]
+    [TestMethod]
     public void Measure_DelegatesToChild()
     {
         var child = new ButtonNode { Label = "Hello" };
@@ -23,22 +24,22 @@ public class InteractableNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // ButtonNode: " Hello " = 2 + 5 = 7 (Phase 2 chip layout)
-        Assert.Equal(7, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(7, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_NullChild_ReturnsZero()
     {
         var node = new InteractableNode { Child = null };
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(0, size.Width);
-        Assert.Equal(0, size.Height);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(0, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_PassesConstraintsToChild()
     {
         var child = new ButtonNode { Label = "A Very Long Label" };
@@ -47,14 +48,14 @@ public class InteractableNodeTests
 
         var size = node.Measure(constraints);
 
-        Assert.True(size.Width <= 10);
+        Assert.IsTrue(size.Width <= 10);
     }
 
     #endregion
 
     #region Arrange Tests
 
-    [Fact]
+    [TestMethod]
     public void Arrange_DelegatesToChild()
     {
         var child = new ButtonNode { Label = "Test" };
@@ -63,11 +64,11 @@ public class InteractableNodeTests
 
         node.Arrange(bounds);
 
-        Assert.Equal(bounds, node.Bounds);
-        Assert.Equal(bounds, child.Bounds);
+        Assert.AreEqual(bounds, node.Bounds);
+        Assert.AreEqual(bounds, child.Bounds);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_NullChild_DoesNotThrow()
     {
         var node = new InteractableNode { Child = null };
@@ -75,22 +76,22 @@ public class InteractableNodeTests
 
         node.Arrange(bounds);
 
-        Assert.Equal(bounds, node.Bounds);
+        Assert.AreEqual(bounds, node.Bounds);
     }
 
     #endregion
 
     #region Focus Tests
 
-    [Fact]
+    [TestMethod]
     public void IsFocusable_ReturnsTrue()
     {
         var node = new InteractableNode();
 
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsFocused_SetTrue_InvokesFocusChangedCallback()
     {
         bool? focusState = null;
@@ -101,10 +102,10 @@ public class InteractableNodeTests
 
         node.IsFocused = true;
 
-        Assert.True(focusState);
+        Assert.IsTrue(focusState);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsFocused_SetFalse_InvokesFocusChangedCallback()
     {
         bool? focusState = null;
@@ -114,10 +115,10 @@ public class InteractableNodeTests
 
         node.IsFocused = false;
 
-        Assert.False(focusState);
+        Assert.IsFalse(focusState);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsFocused_SetSameValue_DoesNotInvokeCallback()
     {
         var callCount = 0;
@@ -128,10 +129,10 @@ public class InteractableNodeTests
 
         node.IsFocused = false; // Already false, no change
 
-        Assert.Equal(0, callCount);
+        Assert.AreEqual(0, callCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetFocusableNodes_ReturnsOnlySelf()
     {
         // Even with a focusable child, interactable captures focus
@@ -140,15 +141,15 @@ public class InteractableNodeTests
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Single(focusables);
-        Assert.Same(node, focusables[0]);
+        TestSeq.Single(focusables);
+        Assert.AreSame(node, focusables[0]);
     }
 
     #endregion
 
     #region Hover Tests
 
-    [Fact]
+    [TestMethod]
     public void IsHovered_SetTrue_InvokesHoverChangedCallback()
     {
         bool? hoverState = null;
@@ -159,10 +160,10 @@ public class InteractableNodeTests
 
         node.IsHovered = true;
 
-        Assert.True(hoverState);
+        Assert.IsTrue(hoverState);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsHovered_SetSameValue_DoesNotInvokeCallback()
     {
         var callCount = 0;
@@ -173,14 +174,14 @@ public class InteractableNodeTests
 
         node.IsHovered = false; // Already false
 
-        Assert.Equal(0, callCount);
+        Assert.AreEqual(0, callCount);
     }
 
     #endregion
 
     #region Input Handling Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Enter_TriggersClickAction()
     {
         var clicked = false;
@@ -196,11 +197,11 @@ public class InteractableNodeTests
             null, null,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(clicked);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Space_TriggersClickAction()
     {
         var clicked = false;
@@ -216,11 +217,11 @@ public class InteractableNodeTests
             null, null,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(clicked);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_NullClickAction_DoesNotThrow()
     {
         var node = new InteractableNode
@@ -235,10 +236,10 @@ public class InteractableNodeTests
             null, null,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_OtherKey_DoesNotClick()
     {
         var clicked = false;
@@ -254,29 +255,29 @@ public class InteractableNodeTests
             null, null,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.NotHandled, result);
-        Assert.False(clicked);
+        Assert.AreEqual(InputResult.NotHandled, result);
+        Assert.IsFalse(clicked);
     }
 
     #endregion
 
     #region HitTest Tests
 
-    [Fact]
+    [TestMethod]
     public void HitTestBounds_ReturnsBounds()
     {
         var node = new InteractableNode();
         var bounds = new Rect(5, 10, 20, 3);
         node.Arrange(bounds);
 
-        Assert.Equal(bounds, node.HitTestBounds);
+        Assert.AreEqual(bounds, node.HitTestBounds);
     }
 
     #endregion
 
     #region GetChildren Tests
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_WithChild_ReturnsChild()
     {
         var child = new ButtonNode { Label = "Child" };
@@ -284,25 +285,25 @@ public class InteractableNodeTests
 
         var children = node.GetChildren().ToList();
 
-        Assert.Single(children);
-        Assert.Same(child, children[0]);
+        TestSeq.Single(children);
+        Assert.AreSame(child, children[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_NullChild_ReturnsEmpty()
     {
         var node = new InteractableNode { Child = null };
 
         var children = node.GetChildren().ToList();
 
-        Assert.Empty(children);
+        Assert.IsEmpty(children);
     }
 
     #endregion
 
     #region Widget Reconciliation Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Widget_ReconcileAsync_CreatesNode()
     {
         var widget = new InteractableWidget(ic => new TextBlockWidget("Hello"));
@@ -310,12 +311,12 @@ public class InteractableNodeTests
 
         var node = await widget.ReconcileAsync(null, context);
 
-        Assert.IsType<InteractableNode>(node);
+        TestSeq.IsType<InteractableNode>(node);
         var interactable = (InteractableNode)node;
-        Assert.NotNull(interactable.Child);
+        Assert.IsNotNull(interactable.Child);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Widget_ReconcileAsync_ReusesExistingNode()
     {
         var widget = new InteractableWidget(ic => new TextBlockWidget("Hello"));
@@ -324,10 +325,10 @@ public class InteractableNodeTests
 
         var node = await widget.ReconcileAsync(existingNode, context);
 
-        Assert.Same(existingNode, node);
+        Assert.AreSame(existingNode, node);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Widget_ReconcileAsync_ContextReflectsNodeState()
     {
         bool? contextIsFocused = null;
@@ -342,10 +343,10 @@ public class InteractableNodeTests
 
         await widget.ReconcileAsync(existingNode, context);
 
-        Assert.True(contextIsFocused);
+        Assert.IsTrue(contextIsFocused);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Widget_ReconcileAsync_ContextDefaultsFalse()
     {
         bool? contextIsFocused = null;
@@ -360,11 +361,11 @@ public class InteractableNodeTests
 
         await widget.ReconcileAsync(null, context);
 
-        Assert.False(contextIsFocused);
-        Assert.False(contextIsHovered);
+        Assert.IsFalse(contextIsFocused);
+        Assert.IsFalse(contextIsHovered);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Widget_OnClick_WiresUpClickAction()
     {
         var widget = new InteractableWidget(ic => new TextBlockWidget("Hello"))
@@ -373,10 +374,10 @@ public class InteractableNodeTests
 
         var node = (InteractableNode)await widget.ReconcileAsync(null, context);
 
-        Assert.NotNull(node.ClickAction);
+        Assert.IsNotNull(node.ClickAction);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Widget_OnFocusChanged_WiresUpCallback()
     {
         bool? focusState = null;
@@ -386,12 +387,12 @@ public class InteractableNodeTests
 
         var node = (InteractableNode)await widget.ReconcileAsync(null, context);
 
-        Assert.NotNull(node.FocusChangedAction);
+        Assert.IsNotNull(node.FocusChangedAction);
         node.IsFocused = true;
-        Assert.True(focusState);
+        Assert.IsTrue(focusState);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Widget_OnHoverChanged_WiresUpCallback()
     {
         bool? hoverState = null;
@@ -401,25 +402,25 @@ public class InteractableNodeTests
 
         var node = (InteractableNode)await widget.ReconcileAsync(null, context);
 
-        Assert.NotNull(node.HoverChangedAction);
+        Assert.IsNotNull(node.HoverChangedAction);
         node.IsHovered = true;
-        Assert.True(hoverState);
+        Assert.IsTrue(hoverState);
     }
 
     #endregion
 
     #region Extension Method Tests
 
-    [Fact]
+    [TestMethod]
     public void Extensions_Interactable_CreatesWidget()
     {
         var ctx = new WidgetContext<VStackWidget>();
         var widget = ctx.Interactable(ic => new TextBlockWidget("Hello"));
 
-        Assert.IsType<InteractableWidget>(widget);
+        TestSeq.IsType<InteractableWidget>(widget);
     }
 
-    [Fact]
+    [TestMethod]
     public void Extensions_InteractableArray_CreatesWidgetWithVStack()
     {
         var ctx = new WidgetContext<VStackWidget>();
@@ -429,7 +430,7 @@ public class InteractableNodeTests
             new TextBlockWidget("Line 2"),
         });
 
-        Assert.IsType<InteractableWidget>(widget);
+        TestSeq.IsType<InteractableWidget>(widget);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/KgpCapabilityPropagationTests.cs
+++ b/tests/Hex1b.Tests/KgpCapabilityPropagationTests.cs
@@ -9,6 +9,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for KGP capability propagation through the surface render context and layer system.
 /// </summary>
+[TestClass]
 public class KgpCapabilityPropagationTests
 {
     private static readonly TerminalCapabilities KgpCapabilities = new()
@@ -19,29 +20,29 @@ public class KgpCapabilityPropagationTests
         Supports256Colors = true,
     };
 
-    [Fact]
+    [TestMethod]
     public void SurfaceRenderContext_DefaultCapabilities_AreModern()
     {
         var surface = new Surface(10, 5);
         var context = new SurfaceRenderContext(surface);
 
         // Default should be Modern (no KGP)
-        Assert.False(context.Capabilities.SupportsKgp);
-        Assert.False(context.Capabilities.SupportsSixel);
+        Assert.IsFalse(context.Capabilities.SupportsKgp);
+        Assert.IsFalse(context.Capabilities.SupportsSixel);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceRenderContext_SetCapabilities_AreReturned()
     {
         var surface = new Surface(10, 5);
         var context = new SurfaceRenderContext(surface);
         context.SetCapabilities(KgpCapabilities);
 
-        Assert.True(context.Capabilities.SupportsKgp);
-        Assert.True(context.Capabilities.SupportsSixel);
+        Assert.IsTrue(context.Capabilities.SupportsKgp);
+        Assert.IsTrue(context.Capabilities.SupportsSixel);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceRenderContext_RenderChild_PropagatesCapabilities()
     {
         var surface = new Surface(20, 10);
@@ -57,12 +58,12 @@ public class KgpCapabilityPropagationTests
 
         context.RenderChild(childNode);
 
-        Assert.NotNull(childCapabilities);
-        Assert.True(childCapabilities!.SupportsKgp);
-        Assert.True(childCapabilities.SupportsSixel);
+        Assert.IsNotNull(childCapabilities);
+        Assert.IsTrue(childCapabilities!.SupportsKgp);
+        Assert.IsTrue(childCapabilities.SupportsSixel);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceNode_PassesCapabilitiesToLayerContext()
     {
         TerminalCapabilities? layerCapabilities = null;
@@ -84,11 +85,11 @@ public class KgpCapabilityPropagationTests
 
         node.Render(context);
 
-        Assert.NotNull(layerCapabilities);
-        Assert.True(layerCapabilities!.SupportsKgp);
+        Assert.IsNotNull(layerCapabilities);
+        Assert.IsTrue(layerCapabilities!.SupportsKgp);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceNode_WithoutKgp_LayerBuilderSeesNoKgp()
     {
         TerminalCapabilities? layerCapabilities = null;
@@ -110,8 +111,8 @@ public class KgpCapabilityPropagationTests
 
         node.Render(context);
 
-        Assert.NotNull(layerCapabilities);
-        Assert.False(layerCapabilities!.SupportsKgp);
+        Assert.IsNotNull(layerCapabilities);
+        Assert.IsFalse(layerCapabilities!.SupportsKgp);
     }
 
     /// <summary>

--- a/tests/Hex1b.Tests/KgpCommandParserTests.cs
+++ b/tests/Hex1b.Tests/KgpCommandParserTests.cs
@@ -1,380 +1,381 @@
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class KgpCommandParserTests
 {
-    [Fact]
+    [TestMethod]
     public void Parse_EmptyString_ReturnsDefaults()
     {
         var cmd = KgpCommand.Parse("");
 
-        Assert.Equal(KgpAction.Transmit, cmd.Action);
-        Assert.Equal(KgpFormat.Rgba32, cmd.Format);
-        Assert.Equal(KgpTransmissionMedium.Direct, cmd.Medium);
-        Assert.Equal(0u, cmd.Width);
-        Assert.Equal(0u, cmd.Height);
-        Assert.Equal(0u, cmd.ImageId);
-        Assert.Equal(0u, cmd.ImageNumber);
-        Assert.Equal(0u, cmd.PlacementId);
-        Assert.Equal(0, cmd.Quiet);
-        Assert.Equal(0, cmd.MoreData);
-        Assert.Null(cmd.Compression);
-        Assert.Equal(0, cmd.ZIndex);
-        Assert.Equal(KgpDeleteTarget.All, cmd.DeleteTarget);
+        Assert.AreEqual(KgpAction.Transmit, cmd.Action);
+        Assert.AreEqual(KgpFormat.Rgba32, cmd.Format);
+        Assert.AreEqual(KgpTransmissionMedium.Direct, cmd.Medium);
+        Assert.AreEqual(0u, cmd.Width);
+        Assert.AreEqual(0u, cmd.Height);
+        Assert.AreEqual(0u, cmd.ImageId);
+        Assert.AreEqual(0u, cmd.ImageNumber);
+        Assert.AreEqual(0u, cmd.PlacementId);
+        Assert.AreEqual(0, cmd.Quiet);
+        Assert.AreEqual(0, cmd.MoreData);
+        Assert.IsNull(cmd.Compression);
+        Assert.AreEqual(0, cmd.ZIndex);
+        Assert.AreEqual(KgpDeleteTarget.All, cmd.DeleteTarget);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_NullString_ReturnsDefaults()
     {
         var cmd = KgpCommand.Parse(null!);
 
-        Assert.Equal(KgpAction.Transmit, cmd.Action);
+        Assert.AreEqual(KgpAction.Transmit, cmd.Action);
     }
 
     // --- Action parsing ---
 
-    [Theory]
-    [InlineData("a=t", KgpAction.Transmit)]
-    [InlineData("a=T", KgpAction.TransmitAndDisplay)]
-    [InlineData("a=q", KgpAction.Query)]
-    [InlineData("a=p", KgpAction.Put)]
-    [InlineData("a=d", KgpAction.Delete)]
-    [InlineData("a=f", KgpAction.AnimationFrame)]
-    [InlineData("a=a", KgpAction.AnimationControl)]
-    [InlineData("a=c", KgpAction.Compose)]
+    [TestMethod]
+    [DataRow("a=t", KgpAction.Transmit)]
+    [DataRow("a=T", KgpAction.TransmitAndDisplay)]
+    [DataRow("a=q", KgpAction.Query)]
+    [DataRow("a=p", KgpAction.Put)]
+    [DataRow("a=d", KgpAction.Delete)]
+    [DataRow("a=f", KgpAction.AnimationFrame)]
+    [DataRow("a=a", KgpAction.AnimationControl)]
+    [DataRow("a=c", KgpAction.Compose)]
     public void Parse_ActionKey_CorrectAction(string controlData, KgpAction expected)
     {
         var cmd = KgpCommand.Parse(controlData);
-        Assert.Equal(expected, cmd.Action);
+        Assert.AreEqual(expected, cmd.Action);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_InvalidAction_DefaultsToTransmit()
     {
         var cmd = KgpCommand.Parse("a=Z");
-        Assert.Equal(KgpAction.Transmit, cmd.Action);
+        Assert.AreEqual(KgpAction.Transmit, cmd.Action);
     }
 
     // --- Format parsing ---
 
-    [Theory]
-    [InlineData("f=24", KgpFormat.Rgb24)]
-    [InlineData("f=32", KgpFormat.Rgba32)]
-    [InlineData("f=100", KgpFormat.Png)]
+    [TestMethod]
+    [DataRow("f=24", KgpFormat.Rgb24)]
+    [DataRow("f=32", KgpFormat.Rgba32)]
+    [DataRow("f=100", KgpFormat.Png)]
     public void Parse_FormatKey_CorrectFormat(string controlData, KgpFormat expected)
     {
         var cmd = KgpCommand.Parse(controlData);
-        Assert.Equal(expected, cmd.Format);
+        Assert.AreEqual(expected, cmd.Format);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_InvalidFormat_DefaultsToRgba32()
     {
         var cmd = KgpCommand.Parse("f=99");
-        Assert.Equal(KgpFormat.Rgba32, cmd.Format);
+        Assert.AreEqual(KgpFormat.Rgba32, cmd.Format);
     }
 
     // --- Transmission medium ---
 
-    [Theory]
-    [InlineData("t=d", KgpTransmissionMedium.Direct)]
-    [InlineData("t=f", KgpTransmissionMedium.File)]
-    [InlineData("t=t", KgpTransmissionMedium.TempFile)]
-    [InlineData("t=s", KgpTransmissionMedium.SharedMemory)]
+    [TestMethod]
+    [DataRow("t=d", KgpTransmissionMedium.Direct)]
+    [DataRow("t=f", KgpTransmissionMedium.File)]
+    [DataRow("t=t", KgpTransmissionMedium.TempFile)]
+    [DataRow("t=s", KgpTransmissionMedium.SharedMemory)]
     public void Parse_MediumKey_CorrectMedium(string controlData, KgpTransmissionMedium expected)
     {
         var cmd = KgpCommand.Parse(controlData);
-        Assert.Equal(expected, cmd.Medium);
+        Assert.AreEqual(expected, cmd.Medium);
     }
 
     // --- Integer keys ---
 
-    [Fact]
+    [TestMethod]
     public void Parse_DimensionKeys_ParsedCorrectly()
     {
         var cmd = KgpCommand.Parse("s=100,v=200");
 
-        Assert.Equal(100u, cmd.Width);
-        Assert.Equal(200u, cmd.Height);
+        Assert.AreEqual(100u, cmd.Width);
+        Assert.AreEqual(200u, cmd.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ImageIdAndNumber_ParsedCorrectly()
     {
         var cmd = KgpCommand.Parse("i=42,I=7");
 
-        Assert.Equal(42u, cmd.ImageId);
-        Assert.Equal(7u, cmd.ImageNumber);
+        Assert.AreEqual(42u, cmd.ImageId);
+        Assert.AreEqual(7u, cmd.ImageNumber);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_PlacementId_ParsedCorrectly()
     {
         var cmd = KgpCommand.Parse("p=17");
-        Assert.Equal(17u, cmd.PlacementId);
+        Assert.AreEqual(17u, cmd.PlacementId);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_MoreDataKey_ParsedCorrectly()
     {
         var cmd = KgpCommand.Parse("m=1");
-        Assert.Equal(1, cmd.MoreData);
+        Assert.AreEqual(1, cmd.MoreData);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_QuietKey_ParsedCorrectly()
     {
         var cmd0 = KgpCommand.Parse("q=0");
-        Assert.Equal(0, cmd0.Quiet);
+        Assert.AreEqual(0, cmd0.Quiet);
 
         var cmd1 = KgpCommand.Parse("q=1");
-        Assert.Equal(1, cmd1.Quiet);
+        Assert.AreEqual(1, cmd1.Quiet);
 
         var cmd2 = KgpCommand.Parse("q=2");
-        Assert.Equal(2, cmd2.Quiet);
+        Assert.AreEqual(2, cmd2.Quiet);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_CompressionKey_ParsedCorrectly()
     {
         var cmd = KgpCommand.Parse("o=z");
-        Assert.Equal('z', cmd.Compression);
+        Assert.AreEqual('z', cmd.Compression);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_NoCompression_IsNull()
     {
         var cmd = KgpCommand.Parse("f=24");
-        Assert.Null(cmd.Compression);
+        Assert.IsNull(cmd.Compression);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_FileSizeAndOffset_ParsedCorrectly()
     {
         var cmd = KgpCommand.Parse("S=1024,O=512");
 
-        Assert.Equal(1024u, cmd.FileSize);
-        Assert.Equal(512u, cmd.FileOffset);
+        Assert.AreEqual(1024u, cmd.FileSize);
+        Assert.AreEqual(512u, cmd.FileOffset);
     }
 
     // --- Display keys ---
 
-    [Fact]
+    [TestMethod]
     public void Parse_SourceRectKeys_ParsedCorrectly()
     {
         var cmd = KgpCommand.Parse("x=10,y=20,w=100,h=200");
 
-        Assert.Equal(10u, cmd.SourceX);
-        Assert.Equal(20u, cmd.SourceY);
-        Assert.Equal(100u, cmd.SourceWidth);
-        Assert.Equal(200u, cmd.SourceHeight);
+        Assert.AreEqual(10u, cmd.SourceX);
+        Assert.AreEqual(20u, cmd.SourceY);
+        Assert.AreEqual(100u, cmd.SourceWidth);
+        Assert.AreEqual(200u, cmd.SourceHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_CellOffsetKeys_ParsedCorrectly()
     {
         var cmd = KgpCommand.Parse("X=3,Y=5");
 
-        Assert.Equal(3u, cmd.CellOffsetX);
-        Assert.Equal(5u, cmd.CellOffsetY);
+        Assert.AreEqual(3u, cmd.CellOffsetX);
+        Assert.AreEqual(5u, cmd.CellOffsetY);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_DisplaySizeKeys_ParsedCorrectly()
     {
         var cmd = KgpCommand.Parse("c=10,r=5");
 
-        Assert.Equal(10u, cmd.DisplayColumns);
-        Assert.Equal(5u, cmd.DisplayRows);
+        Assert.AreEqual(10u, cmd.DisplayColumns);
+        Assert.AreEqual(5u, cmd.DisplayRows);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_CursorMovementPolicy_ParsedCorrectly()
     {
         var cmd = KgpCommand.Parse("C=1");
-        Assert.Equal(1, cmd.CursorMovement);
+        Assert.AreEqual(1, cmd.CursorMovement);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_UnicodePlaceholder_ParsedCorrectly()
     {
         var cmd = KgpCommand.Parse("U=1");
-        Assert.Equal(1, cmd.UnicodePlaceholder);
+        Assert.AreEqual(1, cmd.UnicodePlaceholder);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ZIndex_ParsedCorrectly()
     {
         var cmdPos = KgpCommand.Parse("z=5");
-        Assert.Equal(5, cmdPos.ZIndex);
+        Assert.AreEqual(5, cmdPos.ZIndex);
 
         var cmdNeg = KgpCommand.Parse("z=-1");
-        Assert.Equal(-1, cmdNeg.ZIndex);
+        Assert.AreEqual(-1, cmdNeg.ZIndex);
     }
 
     // --- Relative placement keys ---
 
-    [Fact]
+    [TestMethod]
     public void Parse_RelativePlacementKeys_ParsedCorrectly()
     {
         var cmd = KgpCommand.Parse("P=10,Q=3,H=2,V=-1");
 
-        Assert.Equal(10u, cmd.ParentImageId);
-        Assert.Equal(3u, cmd.ParentPlacementId);
-        Assert.Equal(2, cmd.ParentOffsetH);
-        Assert.Equal(-1, cmd.ParentOffsetV);
+        Assert.AreEqual(10u, cmd.ParentImageId);
+        Assert.AreEqual(3u, cmd.ParentPlacementId);
+        Assert.AreEqual(2, cmd.ParentOffsetH);
+        Assert.AreEqual(-1, cmd.ParentOffsetV);
     }
 
     // --- Delete target ---
 
-    [Theory]
-    [InlineData("d=a", KgpDeleteTarget.All)]
-    [InlineData("d=A", KgpDeleteTarget.AllFreeData)]
-    [InlineData("d=i", KgpDeleteTarget.ById)]
-    [InlineData("d=I", KgpDeleteTarget.ByIdFreeData)]
-    [InlineData("d=n", KgpDeleteTarget.ByNumber)]
-    [InlineData("d=N", KgpDeleteTarget.ByNumberFreeData)]
-    [InlineData("d=c", KgpDeleteTarget.AtCursor)]
-    [InlineData("d=C", KgpDeleteTarget.AtCursorFreeData)]
-    [InlineData("d=p", KgpDeleteTarget.AtCell)]
-    [InlineData("d=P", KgpDeleteTarget.AtCellFreeData)]
-    [InlineData("d=q", KgpDeleteTarget.AtCellWithZIndex)]
-    [InlineData("d=Q", KgpDeleteTarget.AtCellWithZIndexFreeData)]
-    [InlineData("d=x", KgpDeleteTarget.ByColumn)]
-    [InlineData("d=X", KgpDeleteTarget.ByColumnFreeData)]
-    [InlineData("d=y", KgpDeleteTarget.ByRow)]
-    [InlineData("d=Y", KgpDeleteTarget.ByRowFreeData)]
-    [InlineData("d=z", KgpDeleteTarget.ByZIndex)]
-    [InlineData("d=Z", KgpDeleteTarget.ByZIndexFreeData)]
-    [InlineData("d=r", KgpDeleteTarget.ByRange)]
-    [InlineData("d=R", KgpDeleteTarget.ByRangeFreeData)]
-    [InlineData("d=f", KgpDeleteTarget.AnimationFrames)]
-    [InlineData("d=F", KgpDeleteTarget.AnimationFramesFreeData)]
+    [TestMethod]
+    [DataRow("d=a", KgpDeleteTarget.All)]
+    [DataRow("d=A", KgpDeleteTarget.AllFreeData)]
+    [DataRow("d=i", KgpDeleteTarget.ById)]
+    [DataRow("d=I", KgpDeleteTarget.ByIdFreeData)]
+    [DataRow("d=n", KgpDeleteTarget.ByNumber)]
+    [DataRow("d=N", KgpDeleteTarget.ByNumberFreeData)]
+    [DataRow("d=c", KgpDeleteTarget.AtCursor)]
+    [DataRow("d=C", KgpDeleteTarget.AtCursorFreeData)]
+    [DataRow("d=p", KgpDeleteTarget.AtCell)]
+    [DataRow("d=P", KgpDeleteTarget.AtCellFreeData)]
+    [DataRow("d=q", KgpDeleteTarget.AtCellWithZIndex)]
+    [DataRow("d=Q", KgpDeleteTarget.AtCellWithZIndexFreeData)]
+    [DataRow("d=x", KgpDeleteTarget.ByColumn)]
+    [DataRow("d=X", KgpDeleteTarget.ByColumnFreeData)]
+    [DataRow("d=y", KgpDeleteTarget.ByRow)]
+    [DataRow("d=Y", KgpDeleteTarget.ByRowFreeData)]
+    [DataRow("d=z", KgpDeleteTarget.ByZIndex)]
+    [DataRow("d=Z", KgpDeleteTarget.ByZIndexFreeData)]
+    [DataRow("d=r", KgpDeleteTarget.ByRange)]
+    [DataRow("d=R", KgpDeleteTarget.ByRangeFreeData)]
+    [DataRow("d=f", KgpDeleteTarget.AnimationFrames)]
+    [DataRow("d=F", KgpDeleteTarget.AnimationFramesFreeData)]
     public void Parse_DeleteTargetKey_CorrectTarget(string controlData, KgpDeleteTarget expected)
     {
         var cmd = KgpCommand.Parse($"a=d,{controlData}");
-        Assert.Equal(expected, cmd.DeleteTarget);
+        Assert.AreEqual(expected, cmd.DeleteTarget);
     }
 
     // --- Complex multi-key parsing ---
 
-    [Fact]
+    [TestMethod]
     public void Parse_FullTransmitAndDisplay_AllKeysParsed()
     {
         var cmd = KgpCommand.Parse("a=T,f=24,s=100,v=200,i=42,p=7,m=0,q=1,o=z,c=10,r=5,z=-1");
 
-        Assert.Equal(KgpAction.TransmitAndDisplay, cmd.Action);
-        Assert.Equal(KgpFormat.Rgb24, cmd.Format);
-        Assert.Equal(100u, cmd.Width);
-        Assert.Equal(200u, cmd.Height);
-        Assert.Equal(42u, cmd.ImageId);
-        Assert.Equal(7u, cmd.PlacementId);
-        Assert.Equal(0, cmd.MoreData);
-        Assert.Equal(1, cmd.Quiet);
-        Assert.Equal('z', cmd.Compression);
-        Assert.Equal(10u, cmd.DisplayColumns);
-        Assert.Equal(5u, cmd.DisplayRows);
-        Assert.Equal(-1, cmd.ZIndex);
+        Assert.AreEqual(KgpAction.TransmitAndDisplay, cmd.Action);
+        Assert.AreEqual(KgpFormat.Rgb24, cmd.Format);
+        Assert.AreEqual(100u, cmd.Width);
+        Assert.AreEqual(200u, cmd.Height);
+        Assert.AreEqual(42u, cmd.ImageId);
+        Assert.AreEqual(7u, cmd.PlacementId);
+        Assert.AreEqual(0, cmd.MoreData);
+        Assert.AreEqual(1, cmd.Quiet);
+        Assert.AreEqual('z', cmd.Compression);
+        Assert.AreEqual(10u, cmd.DisplayColumns);
+        Assert.AreEqual(5u, cmd.DisplayRows);
+        Assert.AreEqual(-1, cmd.ZIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_FullQueryCommand_AllKeysParsed()
     {
         var cmd = KgpCommand.Parse("i=31,s=1,v=1,a=q,t=d,f=24");
 
-        Assert.Equal(KgpAction.Query, cmd.Action);
-        Assert.Equal(31u, cmd.ImageId);
-        Assert.Equal(1u, cmd.Width);
-        Assert.Equal(1u, cmd.Height);
-        Assert.Equal(KgpTransmissionMedium.Direct, cmd.Medium);
-        Assert.Equal(KgpFormat.Rgb24, cmd.Format);
+        Assert.AreEqual(KgpAction.Query, cmd.Action);
+        Assert.AreEqual(31u, cmd.ImageId);
+        Assert.AreEqual(1u, cmd.Width);
+        Assert.AreEqual(1u, cmd.Height);
+        Assert.AreEqual(KgpTransmissionMedium.Direct, cmd.Medium);
+        Assert.AreEqual(KgpFormat.Rgb24, cmd.Format);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_DeleteWithPosition_AllKeysParsed()
     {
         var cmd = KgpCommand.Parse("a=d,d=p,x=3,y=4");
 
-        Assert.Equal(KgpAction.Delete, cmd.Action);
-        Assert.Equal(KgpDeleteTarget.AtCell, cmd.DeleteTarget);
-        Assert.Equal(3u, cmd.SourceX);
-        Assert.Equal(4u, cmd.SourceY);
+        Assert.AreEqual(KgpAction.Delete, cmd.Action);
+        Assert.AreEqual(KgpDeleteTarget.AtCell, cmd.DeleteTarget);
+        Assert.AreEqual(3u, cmd.SourceX);
+        Assert.AreEqual(4u, cmd.SourceY);
     }
 
     // --- Edge cases ---
 
-    [Fact]
+    [TestMethod]
     public void Parse_InvalidKeyValuePair_SkipsGracefully()
     {
         // Pairs without = or empty value should be skipped
         var cmd = KgpCommand.Parse("a=T,invalid,=bad,f=24");
 
-        Assert.Equal(KgpAction.TransmitAndDisplay, cmd.Action);
-        Assert.Equal(KgpFormat.Rgb24, cmd.Format);
+        Assert.AreEqual(KgpAction.TransmitAndDisplay, cmd.Action);
+        Assert.AreEqual(KgpFormat.Rgb24, cmd.Format);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_NonNumericValue_DefaultsToZero()
     {
         var cmd = KgpCommand.Parse("s=abc,v=xyz");
 
-        Assert.Equal(0u, cmd.Width);
-        Assert.Equal(0u, cmd.Height);
+        Assert.AreEqual(0u, cmd.Width);
+        Assert.AreEqual(0u, cmd.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_MaxUInt32_ParsedCorrectly()
     {
         var cmd = KgpCommand.Parse("i=4294967295");
-        Assert.Equal(4294967295u, cmd.ImageId);
+        Assert.AreEqual(4294967295u, cmd.ImageId);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_LargeNegativeZIndex_ParsedCorrectly()
     {
         var cmd = KgpCommand.Parse("z=-1073741824");
-        Assert.Equal(-1073741824, cmd.ZIndex);
+        Assert.AreEqual(-1073741824, cmd.ZIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_DuplicateKeys_LastWins()
     {
         var cmd = KgpCommand.Parse("i=1,i=2,i=3");
-        Assert.Equal(3u, cmd.ImageId);
+        Assert.AreEqual(3u, cmd.ImageId);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_UnknownKey_Ignored()
     {
         var cmd = KgpCommand.Parse("a=T,unknown=99,i=1");
 
-        Assert.Equal(KgpAction.TransmitAndDisplay, cmd.Action);
-        Assert.Equal(1u, cmd.ImageId);
+        Assert.AreEqual(KgpAction.TransmitAndDisplay, cmd.Action);
+        Assert.AreEqual(1u, cmd.ImageId);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_KeyWithNoValue_Skipped()
     {
         var cmd = KgpCommand.Parse("a=T,i=");
-        Assert.Equal(KgpAction.TransmitAndDisplay, cmd.Action);
-        Assert.Equal(0u, cmd.ImageId);
+        Assert.AreEqual(KgpAction.TransmitAndDisplay, cmd.Action);
+        Assert.AreEqual(0u, cmd.ImageId);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ChunkedContinuationMinimalKeys_ParsedCorrectly()
     {
         // Continuation chunks only need m and optionally q
         var cmd = KgpCommand.Parse("m=1");
-        Assert.Equal(1, cmd.MoreData);
-        Assert.Equal(KgpAction.Transmit, cmd.Action);
+        Assert.AreEqual(1, cmd.MoreData);
+        Assert.AreEqual(KgpAction.Transmit, cmd.Action);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_AnimationControlKeys_ParsedCorrectly()
     {
         var cmd = KgpCommand.Parse("a=a,i=3,s=3,v=5");
-        Assert.Equal(KgpAction.AnimationControl, cmd.Action);
-        Assert.Equal(3u, cmd.ImageId);
+        Assert.AreEqual(KgpAction.AnimationControl, cmd.Action);
+        Assert.AreEqual(3u, cmd.ImageId);
         // Note: 's' maps to AnimationState for animation control, but in our parser
         // it maps to Width. This is acceptable since the same key has different
         // semantics based on action type — the caller interprets based on Action.

--- a/tests/Hex1b.Tests/KgpComparerTokenTests.cs
+++ b/tests/Hex1b.Tests/KgpComparerTokenTests.cs
@@ -9,6 +9,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for KGP token emission from SurfaceComparer.ToTokens().
 /// </summary>
+[TestClass]
 public class KgpComparerTokenTests
 {
     private static readonly CellMetrics DefaultMetrics = new(10, 20);
@@ -40,7 +41,7 @@ public class KgpComparerTokenTests
 
     #region ToTokens KGP Emission
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_NewKgpImage_EmitsSequence()
     {
         var prev = new Surface(10, 5, DefaultMetrics);
@@ -53,10 +54,10 @@ public class KgpComparerTokenTests
         var tokens = SurfaceComparer.ToTokens(diff, curr);
 
         // Should contain at least one UnrecognizedSequenceToken with KGP payload
-        Assert.Contains(tokens, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("_G"));
+        Assert.IsTrue(tokens.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("_G")));
     }
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_KgpBelowText_EmittedBeforeTextTokens()
     {
         var prev = new Surface(10, 5, DefaultMetrics);
@@ -83,12 +84,12 @@ public class KgpComparerTokenTests
                 textIndex = i;
         }
 
-        Assert.True(kgpIndex >= 0, "Expected KGP token");
-        Assert.True(textIndex >= 0, "Expected text token");
-        Assert.True(kgpIndex < textIndex, "Below-text KGP should appear before text tokens");
+        Assert.IsTrue(kgpIndex >= 0, "Expected KGP token");
+        Assert.IsTrue(textIndex >= 0, "Expected text token");
+        Assert.IsTrue(kgpIndex < textIndex, "Below-text KGP should appear before text tokens");
     }
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_KgpAboveText_EmittedAfterTextTokens()
     {
         var prev = new Surface(10, 5, DefaultMetrics);
@@ -114,12 +115,12 @@ public class KgpComparerTokenTests
                 kgpIndex = i;
         }
 
-        Assert.True(textIndex >= 0, "Expected text token");
-        Assert.True(kgpIndex >= 0, "Expected KGP token");
-        Assert.True(kgpIndex > textIndex, "Above-text KGP should appear after text tokens");
+        Assert.IsTrue(textIndex >= 0, "Expected text token");
+        Assert.IsTrue(kgpIndex >= 0, "Expected KGP token");
+        Assert.IsTrue(kgpIndex > textIndex, "Above-text KGP should appear after text tokens");
     }
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_KgpUnchanged_NoDiff()
     {
         var kgpData = CreateKgpData();
@@ -132,10 +133,10 @@ public class KgpComparerTokenTests
         curr[1, 1] = new SurfaceCell(" ", null, null, Kgp: tracked);
 
         var diff = SurfaceComparer.Compare(prev, curr);
-        Assert.True(diff.IsEmpty);
+        Assert.IsTrue(diff.IsEmpty);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_KgpClipped_PlacementHasClipParams()
     {
         var prev = new Surface(10, 5, DefaultMetrics);
@@ -151,14 +152,14 @@ public class KgpComparerTokenTests
         // Placement token is separate from transmit — find the a=p token
         var placementToken = tokens.OfType<UnrecognizedSequenceToken>()
             .FirstOrDefault(t => t.Sequence.Contains("a=p"));
-        Assert.NotNull(placementToken);
+        Assert.IsNotNull(placementToken);
         Assert.Contains("x=10", placementToken!.Sequence);
         Assert.Contains("y=20", placementToken.Sequence);
         Assert.Contains("w=30", placementToken.Sequence);
         Assert.Contains("h=40", placementToken.Sequence);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_KgpImageChanged_EmitsNewPayload()
     {
         var kgp1 = CreateKgpData("image-A");
@@ -171,13 +172,13 @@ public class KgpComparerTokenTests
         curr[1, 1] = new SurfaceCell(" ", null, null, Kgp: Track(kgp2));
 
         var diff = SurfaceComparer.Compare(prev, curr);
-        Assert.False(diff.IsEmpty, "Different KGP content should produce a diff");
+        Assert.IsFalse(diff.IsEmpty, "Different KGP content should produce a diff");
 
         var tokens = SurfaceComparer.ToTokens(diff, curr);
-        Assert.Contains(tokens, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("_G"));
+        Assert.IsTrue(tokens.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("_G")));
     }
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_KgpWithPositionToken()
     {
         var prev = new Surface(10, 5, DefaultMetrics);
@@ -195,14 +196,14 @@ public class KgpComparerTokenTests
             .Select(p => p.i)
             .FirstOrDefault(-1);
         
-        Assert.True(kgpIdx > 0, "KGP should not be the first token");
-        Assert.IsType<CursorPositionToken>(tokens[kgpIdx - 1]);
+        Assert.IsTrue(kgpIdx > 0, "KGP should not be the first token");
+        TestSeq.IsType<CursorPositionToken>(tokens[kgpIdx - 1]);
         var pos = (CursorPositionToken)tokens[kgpIdx - 1];
-        Assert.Equal(3, pos.Row); // 1-based: row 2 → 3
-        Assert.Equal(4, pos.Column); // 1-based: col 3 → 4
+        Assert.AreEqual(3, pos.Row); // 1-based: row 2 → 3
+        Assert.AreEqual(4, pos.Column); // 1-based: col 3 → 4
     }
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_MultipleKgpPlacements_AllEmitted()
     {
         var prev = new Surface(20, 5, DefaultMetrics);
@@ -221,10 +222,10 @@ public class KgpComparerTokenTests
             .Where(t => t.Sequence.Contains("_G"))
             .ToList();
         
-        Assert.Equal(4, kgpTokens.Count); // 2 images × (transmit + placement)
+        Assert.AreEqual(4, kgpTokens.Count); // 2 images × (transmit + placement)
     }
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_KgpCellCoveredByText_TextRenderedOverKgp()
     {
         var prev = new Surface(10, 5, DefaultMetrics);
@@ -241,7 +242,7 @@ public class KgpComparerTokenTests
         var tokens = SurfaceComparer.ToTokens(diff, curr);
 
         // Text "T" should still be emitted since text overrides below-text KGP
-        Assert.Contains(tokens, t => t is TextToken tt && tt.Text == "T");
+        Assert.IsTrue(tokens.Any(t => t is TextToken tt && tt.Text == "T"));
     }
 
     #endregion
@@ -269,7 +270,7 @@ public class KgpComparerTokenTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize(escapeSequence));
     }
 
-    [Fact]
+    [TestMethod]
     public void SvgRoundTrip_KgpBelowText_ImageBelowTextInSvg()
     {
         var terminal = CreateTerminal();
@@ -292,7 +293,7 @@ public class KgpComparerTokenTests
         Assert.Contains(">i<", svg);
     }
 
-    [Fact]
+    [TestMethod]
     public void SvgRoundTrip_KgpAboveText_ImageAboveTextInSvg()
     {
         var terminal = CreateTerminal();
@@ -308,7 +309,7 @@ public class KgpComparerTokenTests
         Assert.Contains("<image", svg);
     }
 
-    [Fact]
+    [TestMethod]
     public void SvgRoundTrip_KgpZOrder_NegativeBeforePositive()
     {
         var terminal = CreateTerminal();
@@ -329,13 +330,14 @@ public class KgpComparerTokenTests
         
         // Both images should be in the SVG
         var imageCount = svg.Split("<image").Length - 1;
-        Assert.True(imageCount >= 2, $"Expected 2+ images in SVG, got {imageCount}");
+        Assert.IsTrue(imageCount >= 2, $"Expected 2+ images in SVG, got {imageCount}");
     }
 
     #endregion
 }
 
 // Temporary test class for KGP move scenario
+[TestClass]
 public class KgpMoveTests
 {
     private static readonly CellMetrics DefaultMetrics = new(10, 20);
@@ -365,7 +367,7 @@ public class KgpMoveTests
     private static TrackedObject<KgpCellData> Track(KgpCellData data)
         => new(data, _ => { });
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_KgpMoved_EmitsDeleteAndNewPlacement()
     {
         // Frame N: KGP at (2, 1)
@@ -388,7 +390,7 @@ public class KgpMoveTests
                     curr[5 + dx, 1 + dy] = new SurfaceCell(" ", null, null);
 
         var diff = SurfaceComparer.Compare(prev, curr);
-        Assert.False(diff.IsEmpty, "Moving KGP should produce a diff");
+        Assert.IsFalse(diff.IsEmpty, "Moving KGP should produce a diff");
 
         var tokens = SurfaceComparer.ToTokens(diff, curr, prev);
 
@@ -411,13 +413,13 @@ public class KgpMoveTests
         var deleteTokens = tokens.OfType<UnrecognizedSequenceToken>()
             .Where(t => t.Sequence.Contains("a=d"))
             .ToList();
-        Assert.True(deleteTokens.Count > 0, "Expected KGP delete command for moved image");
+        Assert.IsTrue(deleteTokens.Count > 0, "Expected KGP delete command for moved image");
 
         // 2. Should have a placement at the NEW position (row=2, col=6 in 1-based)
         var placementTokens = tokens.OfType<UnrecognizedSequenceToken>()
             .Where(t => t.Sequence.Contains("a=p"))
             .ToList();
-        Assert.True(placementTokens.Count > 0, "Expected KGP placement at new position");
+        Assert.IsTrue(placementTokens.Count > 0, "Expected KGP placement at new position");
 
         // 3. Should have a cursor position token before the placement pointing to (5,1) = row 2, col 6
         var cursorBeforePlacement = false;
@@ -432,16 +434,16 @@ public class KgpMoveTests
                 }
             }
         }
-        Assert.True(cursorBeforePlacement, "Expected cursor position (2, 6) before KGP placement tokens");
+        Assert.IsTrue(cursorBeforePlacement, "Expected cursor position (2, 6) before KGP placement tokens");
 
         // 4. Verify the transmit token has the correct image ID
         var transmitTokens = tokens.OfType<UnrecognizedSequenceToken>()
             .Where(t => t.Sequence.Contains("a=t"))
             .ToList();
-        Assert.True(transmitTokens.Count > 0, "Expected transmit token for image re-transmission");
+        Assert.IsTrue(transmitTokens.Count > 0, "Expected transmit token for image re-transmission");
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_KgpSurvivesCompositingAtDifferentOffsets()
     {
         // Simulate window drag: child surface has KGP, composited at different parent offsets
@@ -456,39 +458,39 @@ public class KgpMoveTests
         parentA.Composite(child, 5, 3);
 
         // Verify KGP landed at (5, 3) in parent
-        Assert.True(parentA[5, 3].HasKgp, "KGP should be at (5,3) in parentA after compositing");
-        Assert.Equal(kgpData.ImageId, parentA[5, 3].Kgp!.Data.ImageId);
+        Assert.IsTrue(parentA[5, 3].HasKgp, "KGP should be at (5,3) in parentA after compositing");
+        Assert.AreEqual(kgpData.ImageId, parentA[5, 3].Kgp!.Data.ImageId);
 
         // Frame N+1: composite same child at offset (8, 3) — window moved right
         var parentB = new Surface(30, 15, DefaultMetrics);
         parentB.Composite(child, 8, 3);
 
         // Verify KGP landed at (8, 3) in parent
-        Assert.True(parentB[8, 3].HasKgp, "KGP should be at (8,3) in parentB after compositing");
-        Assert.Equal(kgpData.ImageId, parentB[8, 3].Kgp!.Data.ImageId);
+        Assert.IsTrue(parentB[8, 3].HasKgp, "KGP should be at (8,3) in parentB after compositing");
+        Assert.AreEqual(kgpData.ImageId, parentB[8, 3].Kgp!.Data.ImageId);
 
         // Compare and verify tokens
         var diff = SurfaceComparer.Compare(parentA, parentB);
-        Assert.False(diff.IsEmpty, "Moving KGP via compositing should produce a diff");
+        Assert.IsFalse(diff.IsEmpty, "Moving KGP via compositing should produce a diff");
 
         var tokens = SurfaceComparer.ToTokens(diff, parentB, parentA);
 
         // Should have delete for old position + placement at new position
         var deleteTokens = tokens.OfType<UnrecognizedSequenceToken>()
             .Where(t => t.Sequence.Contains("a=d")).ToList();
-        Assert.True(deleteTokens.Count > 0, "Expected KGP delete for moved image");
+        Assert.IsTrue(deleteTokens.Count > 0, "Expected KGP delete for moved image");
 
         var placementTokens = tokens.OfType<UnrecognizedSequenceToken>()
             .Where(t => t.Sequence.Contains("a=p")).ToList();
-        Assert.True(placementTokens.Count > 0, "Expected KGP placement at new position");
+        Assert.IsTrue(placementTokens.Count > 0, "Expected KGP placement at new position");
 
         // Cursor should point to new position (8, 3) = row 4, col 9 (1-based)
         var cursorTokens = tokens.OfType<CursorPositionToken>()
             .Where(t => t.Row == 4 && t.Column == 9).ToList();
-        Assert.True(cursorTokens.Count > 0, "Expected cursor position (4, 9) for new KGP location");
+        Assert.IsTrue(cursorTokens.Count > 0, "Expected cursor position (4, 9) for new KGP location");
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_KgpSurvivesNestedCompositing()
     {
         // Simulate: KGP in window content → window surface → WindowPanel surface → root surface
@@ -503,28 +505,28 @@ public class KgpMoveTests
         windowPanel.Composite(windowContent, 3, 2);
 
         // Verify KGP at (3+1, 2+1) = (4, 3)
-        Assert.True(windowPanel[4, 3].HasKgp, "KGP should be at (4,3) after first compositing");
+        Assert.IsTrue(windowPanel[4, 3].HasKgp, "KGP should be at (4,3) after first compositing");
 
         // Level 3: WindowPanel composited at (0, 1) into root surface
         var root = new Surface(40, 20, DefaultMetrics);
         root.Composite(windowPanel, 0, 1);
 
         // Verify KGP at (0+4, 1+3) = (4, 4)
-        Assert.True(root[4, 4].HasKgp, "KGP should be at (4,4) after nested compositing");
-        Assert.NotNull(root[4, 4].Kgp?.Data.TransmitPayload);
-        Assert.Equal(kgpData.ImageId, root[4, 4].Kgp!.Data.ImageId);
+        Assert.IsTrue(root[4, 4].HasKgp, "KGP should be at (4,4) after nested compositing");
+        Assert.IsNotNull(root[4, 4].Kgp?.Data.TransmitPayload);
+        Assert.AreEqual(kgpData.ImageId, root[4, 4].Kgp!.Data.ImageId);
 
         // Verify the transmit payload survived all compositing steps
         var rootKgpData = root[4, 4].Kgp!.Data;
         var chunks = rootKgpData.BuildTransmitChunks();
-        Assert.True(chunks.Count > 0, "TransmitPayload should survive compositing (needed for emission)");
+        Assert.IsTrue(chunks.Count > 0, "TransmitPayload should survive compositing (needed for emission)");
     }
 
     /// <summary>
     /// Full round-trip test: Surface diff → tokens → serialize → Hex1bTerminal → verify placements.
     /// This exercises the exact bytes that would be sent to a real terminal during a window drag.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void RoundTrip_KgpMoveSequence_TerminalSeesCorrectPlacements()
     {
         // Create a 4-pixel RGBA test image (2x2)
@@ -567,7 +569,7 @@ public class KgpMoveTests
         frame2[5, 1] = new SurfaceCell(" ", null, null, Kgp: Track(kgpData2));
 
         var diff2 = SurfaceComparer.Compare(frame1, frame2);
-        Assert.False(diff2.IsEmpty, "Moving KGP should produce a diff");
+        Assert.IsFalse(diff2.IsEmpty, "Moving KGP should produce a diff");
 
         var tokens2 = SurfaceComparer.ToTokens(diff2, frame2, frame1);
         var bytes2 = Hex1b.Tokens.AnsiTokenUtf8Serializer.Serialize(tokens2);
@@ -576,8 +578,8 @@ public class KgpMoveTests
         var hasDelete = tokens2.OfType<UnrecognizedSequenceToken>().Any(t => t.Sequence.Contains("a=d"));
         var hasTransmit = tokens2.OfType<UnrecognizedSequenceToken>().Any(t => t.Sequence.Contains("a=t"));
         var hasPlacement = tokens2.OfType<UnrecognizedSequenceToken>().Any(t => t.Sequence.Contains("a=p"));
-        Assert.True(hasDelete, "Frame 2 should emit KGP delete");
-        Assert.True(hasTransmit || hasPlacement, "Frame 2 should emit KGP transmit or placement");
+        Assert.IsTrue(hasDelete, "Frame 2 should emit KGP delete");
+        Assert.IsTrue(hasTransmit || hasPlacement, "Frame 2 should emit KGP transmit or placement");
 
         // Feed frame 2 to terminal
         var text2 = System.Text.Encoding.UTF8.GetString(bytes2.ToArray());

--- a/tests/Hex1b.Tests/KgpConformanceTests.cs
+++ b/tests/Hex1b.Tests/KgpConformanceTests.cs
@@ -10,6 +10,7 @@ namespace Hex1b.Tests;
 /// Comprehensive conformance tests modeled on kitty's test suite patterns.
 /// Each test class covers a specific area of the KGP specification.
 /// </summary>
+[TestClass]
 public class KgpLoadConformanceTests
 {
     private static readonly TerminalCapabilities KgpCapabilities = new()
@@ -37,7 +38,7 @@ public class KgpLoadConformanceTests
     // Load conformance (based on kitty's test_load_images)
     // =============================================
 
-    [Fact]
+    [TestMethod]
     public void QueryLoad_ReturnsOk_DoesNotStoreImage()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -45,10 +46,10 @@ public class KgpLoadConformanceTests
 
         SendKgp(terminal, KgpTestHelper.BuildQueryCommand(imageId: 10, width: 2, height: 2));
 
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void SimpleLoad_Rgb24_StoresImage()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -56,15 +57,15 @@ public class KgpLoadConformanceTests
 
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 3, 3, KgpFormat.Rgb24));
 
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
         var img = terminal.KgpImageStore.GetImageById(1);
-        Assert.NotNull(img);
-        Assert.Equal(3u, img.Width);
-        Assert.Equal(3u, img.Height);
-        Assert.Equal(KgpFormat.Rgb24, img.Format);
+        Assert.IsNotNull(img);
+        Assert.AreEqual(3u, img.Width);
+        Assert.AreEqual(3u, img.Height);
+        Assert.AreEqual(KgpFormat.Rgb24, img.Format);
     }
 
-    [Fact]
+    [TestMethod]
     public void SimpleLoad_Rgba32_StoresImage()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -72,15 +73,15 @@ public class KgpLoadConformanceTests
 
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(2, 4, 4, KgpFormat.Rgba32));
 
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
         var img = terminal.KgpImageStore.GetImageById(2);
-        Assert.NotNull(img);
-        Assert.Equal(4u, img.Width);
-        Assert.Equal(4u, img.Height);
-        Assert.Equal(KgpFormat.Rgba32, img.Format);
+        Assert.IsNotNull(img);
+        Assert.AreEqual(4u, img.Width);
+        Assert.AreEqual(4u, img.Height);
+        Assert.AreEqual(KgpFormat.Rgba32, img.Format);
     }
 
-    [Fact]
+    [TestMethod]
     public void ChunkedLoad_FourChunks_AssemblesCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -88,22 +89,22 @@ public class KgpLoadConformanceTests
 
         // 10x10 RGBA = 400 bytes, chunk at 100 bytes → 4 chunks
         var chunks = KgpTestHelper.BuildChunkedTransmitCommands(1, 10, 10, chunkSize: 100);
-        Assert.Equal(4, chunks.Count);
+        Assert.AreEqual(4, chunks.Count);
 
         foreach (var chunk in chunks)
         {
             SendKgp(terminal, chunk);
         }
 
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
         var img = terminal.KgpImageStore.GetImageById(1);
-        Assert.NotNull(img);
-        Assert.Equal(10u, img.Width);
-        Assert.Equal(10u, img.Height);
-        Assert.Equal(400, img.Data.Length);
+        Assert.IsNotNull(img);
+        Assert.AreEqual(10u, img.Width);
+        Assert.AreEqual(10u, img.Height);
+        Assert.AreEqual(400, img.Data.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void ChunkedLoad_SingleChunk_m0_AssemblesCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -111,14 +112,14 @@ public class KgpLoadConformanceTests
 
         // Small image: 2x2 RGBA = 16 bytes, fits in one chunk
         var chunks = KgpTestHelper.BuildChunkedTransmitCommands(1, 2, 2, chunkSize: 4096);
-        Assert.Single(chunks);
+        TestSeq.Single(chunks);
 
         SendKgp(terminal, chunks[0]);
 
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void InterruptedChunkedLoad_DeleteAborts_ThenRetry()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -129,18 +130,18 @@ public class KgpLoadConformanceTests
         SendKgp(terminal, chunks[0]); // First chunk (m=1)
         SendKgp(terminal, chunks[1]); // Second chunk (m=1)
 
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount); // Not yet complete
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount); // Not yet complete
 
         // Delete aborts chunked transfer
         SendKgp(terminal, KgpTestHelper.BuildDeleteCommand('a'));
 
         // Now transmit a new image successfully
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(2, 2, 2));
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
-        Assert.NotNull(terminal.KgpImageStore.GetImageById(2));
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void LargeImage_Load_Succeeds()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -149,13 +150,13 @@ public class KgpLoadConformanceTests
         // 100x100 RGBA = 40,000 bytes
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 100, 100));
 
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
         var img = terminal.KgpImageStore.GetImageById(1);
-        Assert.NotNull(img);
-        Assert.Equal(40000, img.Data.Length);
+        Assert.IsNotNull(img);
+        Assert.AreEqual(40000, img.Data.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void LargeImage_ChunkedLoad_Succeeds()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -163,20 +164,20 @@ public class KgpLoadConformanceTests
 
         // 50x50 RGBA = 10,000 bytes, chunk at 2048
         var chunks = KgpTestHelper.BuildChunkedTransmitCommands(1, 50, 50, chunkSize: 2048);
-        Assert.True(chunks.Count >= 5); // Should be ~5 chunks
+        Assert.IsTrue(chunks.Count >= 5); // Should be ~5 chunks
 
         foreach (var chunk in chunks)
         {
             SendKgp(terminal, chunk);
         }
 
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
         var img = terminal.KgpImageStore.GetImageById(1);
-        Assert.NotNull(img);
-        Assert.Equal(10000, img.Data.Length);
+        Assert.IsNotNull(img);
+        Assert.AreEqual(10000, img.Data.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void InsufficientData_DoesNotStore()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -188,10 +189,10 @@ public class KgpLoadConformanceTests
         var cmd = KgpTestHelper.BuildCommand("a=t,f=32,s=10,v=10,i=1", data);
         SendKgp(terminal, cmd);
 
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void MultipleImages_DifferentIds_AllStored()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -201,13 +202,13 @@ public class KgpLoadConformanceTests
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(2, 3, 3));
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(3, 4, 4));
 
-        Assert.Equal(3, terminal.KgpImageStore.ImageCount);
-        Assert.NotNull(terminal.KgpImageStore.GetImageById(1));
-        Assert.NotNull(terminal.KgpImageStore.GetImageById(2));
-        Assert.NotNull(terminal.KgpImageStore.GetImageById(3));
+        Assert.AreEqual(3, terminal.KgpImageStore.ImageCount);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(2));
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(3));
     }
 
-    [Fact]
+    [TestMethod]
     public void ReplaceImage_SameId_UpdatesInPlace()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -215,17 +216,18 @@ public class KgpLoadConformanceTests
 
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 2, 2, KgpFormat.Rgb24));
         var img1 = terminal.KgpImageStore.GetImageById(1);
-        Assert.Equal(KgpFormat.Rgb24, img1!.Format);
+        Assert.AreEqual(KgpFormat.Rgb24, img1!.Format);
 
         // Replace with RGBA
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 3, 3, KgpFormat.Rgba32));
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
         var img2 = terminal.KgpImageStore.GetImageById(1);
-        Assert.Equal(KgpFormat.Rgba32, img2!.Format);
-        Assert.Equal(3u, img2.Width);
+        Assert.AreEqual(KgpFormat.Rgba32, img2!.Format);
+        Assert.AreEqual(3u, img2.Width);
     }
 }
 
+[TestClass]
 public class KgpResponseConformanceTests
 {
     private static readonly TerminalCapabilities KgpCapabilities = new()
@@ -253,7 +255,7 @@ public class KgpResponseConformanceTests
     // Response suppression (based on kitty's test_suppressing_gr_command_responses)
     // =============================================
 
-    [Fact]
+    [TestMethod]
     public void QuietZero_DefaultBehavior_ResponsesSent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -261,12 +263,12 @@ public class KgpResponseConformanceTests
 
         // q=0 (default) - responses should be sent
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 2, 2, quiet: 0));
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
         // Response should have been sent (can't easily capture async response,
         // but we verify the image was stored normally)
     }
 
-    [Fact]
+    [TestMethod]
     public void QuietOne_SuppressesOk_NotErrors()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -274,11 +276,11 @@ public class KgpResponseConformanceTests
 
         // q=1 - suppress OK but not errors
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 2, 2, quiet: 1));
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
         // OK was suppressed - image still stored
     }
 
-    [Fact]
+    [TestMethod]
     public void QuietTwo_SuppressesAll()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -286,10 +288,10 @@ public class KgpResponseConformanceTests
 
         // q=2 - suppress all responses including errors
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 2, 2, quiet: 2));
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void QuietOne_ChunkedTransfer_SuppressesOk()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -306,10 +308,10 @@ public class KgpResponseConformanceTests
         SendKgp(terminal, cmd1);
         SendKgp(terminal, cmd2);
 
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void ErrorResponse_InsufficientData_StillGenerated()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -320,10 +322,11 @@ public class KgpResponseConformanceTests
         var cmd = KgpTestHelper.BuildCommand("a=t,f=32,s=10,v=10,i=1", data);
         SendKgp(terminal, cmd);
 
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
     }
 }
 
+[TestClass]
 public class KgpPutConformanceTests
 {
     private static readonly TerminalCapabilities KgpCapabilities = new()
@@ -351,7 +354,7 @@ public class KgpPutConformanceTests
     // Image put conformance (based on kitty's test_image_put)
     // =============================================
 
-    [Fact]
+    [TestMethod]
     public void TransmitAndDisplay_DefaultDimensions_PlacesAtCursor()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -363,14 +366,14 @@ public class KgpPutConformanceTests
             displayColumns: 2, displayRows: 2));
 
         var placements = terminal.KgpPlacements;
-        Assert.Single(placements);
-        Assert.Equal(4, placements[0].Row);    // 0-based
-        Assert.Equal(9, placements[0].Column); // 0-based
-        Assert.Equal(2u, placements[0].DisplayColumns);
-        Assert.Equal(2u, placements[0].DisplayRows);
+        TestSeq.Single(placements);
+        Assert.AreEqual(4, placements[0].Row);    // 0-based
+        Assert.AreEqual(9, placements[0].Column); // 0-based
+        Assert.AreEqual(2u, placements[0].DisplayColumns);
+        Assert.AreEqual(2u, placements[0].DisplayRows);
     }
 
-    [Fact]
+    [TestMethod]
     public void TransmitAndDisplay_CursorMovesRight()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -386,7 +389,7 @@ public class KgpPutConformanceTests
         // This tests the spec's cursor movement behavior
     }
 
-    [Fact]
+    [TestMethod]
     public void TransmitAndDisplay_CursorMovementDisabled_NoMove()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -399,10 +402,10 @@ public class KgpPutConformanceTests
 
         // Cursor should not have moved (C=1)
         var placements = terminal.KgpPlacements;
-        Assert.Single(placements);
+        TestSeq.Single(placements);
     }
 
-    [Fact]
+    [TestMethod]
     public void TransmitAndDisplay_SourceRect_Stored()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -416,16 +419,16 @@ public class KgpPutConformanceTests
         SendKgp(terminal, cmd);
 
         var placements = terminal.KgpPlacements;
-        Assert.Single(placements);
-        Assert.Equal(2u, placements[0].SourceX);
-        Assert.Equal(3u, placements[0].SourceY);
-        Assert.Equal(4u, placements[0].SourceWidth);
-        Assert.Equal(5u, placements[0].SourceHeight);
-        Assert.Equal(3u, placements[0].DisplayColumns);
-        Assert.Equal(2u, placements[0].DisplayRows);
+        TestSeq.Single(placements);
+        Assert.AreEqual(2u, placements[0].SourceX);
+        Assert.AreEqual(3u, placements[0].SourceY);
+        Assert.AreEqual(4u, placements[0].SourceWidth);
+        Assert.AreEqual(5u, placements[0].SourceHeight);
+        Assert.AreEqual(3u, placements[0].DisplayColumns);
+        Assert.AreEqual(2u, placements[0].DisplayRows);
     }
 
-    [Fact]
+    [TestMethod]
     public void TransmitAndDisplay_CellOffsets_Stored()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -438,12 +441,12 @@ public class KgpPutConformanceTests
         SendKgp(terminal, cmd);
 
         var placements = terminal.KgpPlacements;
-        Assert.Single(placements);
-        Assert.Equal(5u, placements[0].CellOffsetX);
-        Assert.Equal(3u, placements[0].CellOffsetY);
+        TestSeq.Single(placements);
+        Assert.AreEqual(5u, placements[0].CellOffsetX);
+        Assert.AreEqual(3u, placements[0].CellOffsetY);
     }
 
-    [Fact]
+    [TestMethod]
     public void Put_ExistingImage_CreatesPlacement()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -455,14 +458,14 @@ public class KgpPutConformanceTests
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 1, displayColumns: 3, displayRows: 2));
 
         var placements = terminal.KgpPlacements;
-        Assert.Single(placements);
-        Assert.Equal(1u, placements[0].ImageId);
-        Assert.Equal(1u, placements[0].PlacementId);
-        Assert.Equal(2, placements[0].Row);
-        Assert.Equal(6, placements[0].Column);
+        TestSeq.Single(placements);
+        Assert.AreEqual(1u, placements[0].ImageId);
+        Assert.AreEqual(1u, placements[0].PlacementId);
+        Assert.AreEqual(2, placements[0].Row);
+        Assert.AreEqual(6, placements[0].Column);
     }
 
-    [Fact]
+    [TestMethod]
     public void Put_NonExistentImage_DoesNotCreatePlacement()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -470,10 +473,10 @@ public class KgpPutConformanceTests
 
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(999, placementId: 1));
 
-        Assert.Empty(terminal.KgpPlacements);
+        Assert.IsEmpty(terminal.KgpPlacements);
     }
 
-    [Fact]
+    [TestMethod]
     public void Put_MultiplePlacements_SameImage_AllTracked()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -490,11 +493,11 @@ public class KgpPutConformanceTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[10;10H"));
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 3, displayColumns: 4));
 
-        Assert.Equal(3, terminal.KgpPlacements.Count);
-        Assert.All(terminal.KgpPlacements, p => Assert.Equal(1u, p.ImageId));
+        Assert.AreEqual(3, terminal.KgpPlacements.Count);
+        TestSeq.All(terminal.KgpPlacements, p => Assert.AreEqual(1u, p.ImageId));
     }
 
-    [Fact]
+    [TestMethod]
     public void Put_ZIndex_NegativeUnderText()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -503,10 +506,10 @@ public class KgpPutConformanceTests
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 4, 4));
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, zIndex: -1));
 
-        Assert.Equal(-1, terminal.KgpPlacements[0].ZIndex);
+        Assert.AreEqual(-1, terminal.KgpPlacements[0].ZIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void Put_ZIndex_PositiveOverText()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -515,10 +518,10 @@ public class KgpPutConformanceTests
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 4, 4));
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, zIndex: 10));
 
-        Assert.Equal(10, terminal.KgpPlacements[0].ZIndex);
+        Assert.AreEqual(10, terminal.KgpPlacements[0].ZIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void Put_ReplacementByPlacementId_UpdatesPosition()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -528,20 +531,20 @@ public class KgpPutConformanceTests
 
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[1;1H"));
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 5, displayColumns: 2));
-        Assert.Equal(0, terminal.KgpPlacements[0].Row);
-        Assert.Equal(0, terminal.KgpPlacements[0].Column);
+        Assert.AreEqual(0, terminal.KgpPlacements[0].Row);
+        Assert.AreEqual(0, terminal.KgpPlacements[0].Column);
 
         // Replace at new position
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[10;20H"));
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 5, displayColumns: 3));
 
-        Assert.Single(terminal.KgpPlacements);
-        Assert.Equal(9, terminal.KgpPlacements[0].Row);
-        Assert.Equal(19, terminal.KgpPlacements[0].Column);
-        Assert.Equal(3u, terminal.KgpPlacements[0].DisplayColumns);
+        TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(9, terminal.KgpPlacements[0].Row);
+        Assert.AreEqual(19, terminal.KgpPlacements[0].Column);
+        Assert.AreEqual(3u, terminal.KgpPlacements[0].DisplayColumns);
     }
 
-    [Fact]
+    [TestMethod]
     public void Put_CursorMovementDisabled_C1()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -552,10 +555,11 @@ public class KgpPutConformanceTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[5;5H"));
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, displayColumns: 3, displayRows: 2, cursorMovement: 1));
 
-        Assert.Single(terminal.KgpPlacements);
+        TestSeq.Single(terminal.KgpPlacements);
     }
 }
 
+[TestClass]
 public class KgpImageNumberConformanceTests
 {
     private static readonly TerminalCapabilities KgpCapabilities = new()
@@ -583,7 +587,7 @@ public class KgpImageNumberConformanceTests
     // Image number conformance (based on kitty's test_gr_operations_with_numbers)
     // =============================================
 
-    [Fact]
+    [TestMethod]
     public void ImageNumber_AllocatesUniqueId()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -594,15 +598,15 @@ public class KgpImageNumberConformanceTests
         var cmd = KgpTestHelper.BuildCommand("a=t,f=32,s=2,v=2,I=7", data);
         SendKgp(terminal, cmd);
 
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
 
         // The terminal should have assigned a unique ID
         var img = terminal.KgpImageStore.GetImageByNumber(7);
-        Assert.NotNull(img);
-        Assert.True(img.ImageId > 0);
+        Assert.IsNotNull(img);
+        Assert.IsTrue(img.ImageId > 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void ImageNumber_MultipleImages_SameNumber_BothStored()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -617,10 +621,10 @@ public class KgpImageNumberConformanceTests
         SendKgp(terminal, cmd2);
 
         // Both images should be stored (different IDs but same number)
-        Assert.Equal(2, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(2, terminal.KgpImageStore.ImageCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void ImageNumber_NewestWins_ForPut()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -638,10 +642,10 @@ public class KgpImageNumberConformanceTests
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=p,I=5,c=2,r=2"));
 
         // Placement should exist
-        Assert.Single(terminal.KgpPlacements);
+        TestSeq.Single(terminal.KgpPlacements);
     }
 
-    [Fact]
+    [TestMethod]
     public void ImageNumber_Delete_RemovesNewest()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -653,7 +657,7 @@ public class KgpImageNumberConformanceTests
         var data2 = KgpTestHelper.CreatePixelData(3, 3, fillByte: 0xBB);
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=t,f=32,s=3,v=3,I=8", data2));
 
-        Assert.Equal(2, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(2, terminal.KgpImageStore.ImageCount);
 
         // Delete by number removes the newest
         SendKgp(terminal, KgpTestHelper.BuildDeleteCommand('n'));
@@ -663,10 +667,10 @@ public class KgpImageNumberConformanceTests
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=d,d=n,I=8"));
 
         // Should have removed at least one image
-        Assert.True(terminal.KgpImageStore.ImageCount < 2);
+        Assert.IsTrue(terminal.KgpImageStore.ImageCount < 2);
     }
 
-    [Fact]
+    [TestMethod]
     public void ImageNumber_ExplicitId_TakesPriority()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -679,11 +683,12 @@ public class KgpImageNumberConformanceTests
 
         // Explicit ID should be used
         var img = terminal.KgpImageStore.GetImageById(42);
-        Assert.NotNull(img);
-        Assert.Equal(42u, img.ImageId);
+        Assert.IsNotNull(img);
+        Assert.AreEqual(42u, img.ImageId);
     }
 }
 
+[TestClass]
 public class KgpDeleteConformanceTests
 {
     private static readonly TerminalCapabilities KgpCapabilities = new()
@@ -711,7 +716,7 @@ public class KgpDeleteConformanceTests
     // Deletion conformance
     // =============================================
 
-    [Fact]
+    [TestMethod]
     public void DeleteAll_NoFreeData_ClearsPlacementsOnly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -720,17 +725,17 @@ public class KgpDeleteConformanceTests
         SendKgp(terminal, KgpTestHelper.BuildTransmitAndDisplayCommand(1, 4, 4, displayColumns: 2));
         SendKgp(terminal, KgpTestHelper.BuildTransmitAndDisplayCommand(2, 4, 4, displayColumns: 2));
 
-        Assert.Equal(2, terminal.KgpPlacements.Count);
-        Assert.Equal(2, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
+        Assert.AreEqual(2, terminal.KgpImageStore.ImageCount);
 
         SendKgp(terminal, KgpTestHelper.BuildDeleteCommand('a'));
 
-        Assert.Empty(terminal.KgpPlacements);
+        Assert.IsEmpty(terminal.KgpPlacements);
         // d=a (lowercase) should keep image data
         // d=A (uppercase) should free image data
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteAll_FreeData_ClearsEverything()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -741,11 +746,11 @@ public class KgpDeleteConformanceTests
 
         SendKgp(terminal, KgpTestHelper.BuildDeleteCommand('A'));
 
-        Assert.Empty(terminal.KgpPlacements);
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteById_SpecificImage_LeavesOthers()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -757,11 +762,11 @@ public class KgpDeleteConformanceTests
 
         SendKgp(terminal, KgpTestHelper.BuildDeleteCommand('i', imageId: 2));
 
-        Assert.Equal(2, terminal.KgpPlacements.Count);
-        Assert.DoesNotContain(terminal.KgpPlacements, p => p.ImageId == 2);
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
+        Assert.IsFalse(terminal.KgpPlacements.Any(p => p.ImageId == 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteById_FreeData_RemovesImageToo()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -771,11 +776,11 @@ public class KgpDeleteConformanceTests
 
         SendKgp(terminal, KgpTestHelper.BuildDeleteCommand('I', imageId: 1));
 
-        Assert.Empty(terminal.KgpPlacements);
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteById_WithPlacementId_RemovesOnlyThat()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -790,18 +795,18 @@ public class KgpDeleteConformanceTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[10;10H"));
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 30));
 
-        Assert.Equal(3, terminal.KgpPlacements.Count);
+        Assert.AreEqual(3, terminal.KgpPlacements.Count);
 
         // Delete only placement 20
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=d,d=i,i=1,p=20"));
 
-        Assert.Equal(2, terminal.KgpPlacements.Count);
-        Assert.DoesNotContain(terminal.KgpPlacements, p => p.PlacementId == 20);
-        Assert.Contains(terminal.KgpPlacements, p => p.PlacementId == 10);
-        Assert.Contains(terminal.KgpPlacements, p => p.PlacementId == 30);
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
+        Assert.IsFalse(terminal.KgpPlacements.Any(p => p.PlacementId == 20));
+        Assert.IsTrue(terminal.KgpPlacements.Any(p => p.PlacementId == 10));
+        Assert.IsTrue(terminal.KgpPlacements.Any(p => p.PlacementId == 30));
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteAtCursor_RemovesIntersecting()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -816,17 +821,17 @@ public class KgpDeleteConformanceTests
         SendKgp(terminal, KgpTestHelper.BuildTransmitAndDisplayCommand(2, 4, 4,
             displayColumns: 2, displayRows: 2, cursorMovement: 1));
 
-        Assert.Equal(2, terminal.KgpPlacements.Count);
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
 
         // Move cursor inside first image
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[2;3H"));
         SendKgp(terminal, KgpTestHelper.BuildDeleteCommand('c'));
 
-        Assert.Single(terminal.KgpPlacements);
-        Assert.Equal(2u, terminal.KgpPlacements[0].ImageId);
+        TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(2u, terminal.KgpPlacements[0].ImageId);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteAtCell_RemovesIntersecting()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -839,10 +844,10 @@ public class KgpDeleteConformanceTests
         // Delete at cell (1-based per KGP spec): row 6, col 7 should be inside
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=d,d=p,x=7,y=6"));
 
-        Assert.Empty(terminal.KgpPlacements);
+        Assert.IsEmpty(terminal.KgpPlacements);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteByColumn_RemovesIntersecting()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -859,11 +864,11 @@ public class KgpDeleteConformanceTests
         // Delete by column 6 (1-based) - should hit first image (cols 4-6)
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=d,d=x,x=6"));
 
-        Assert.Single(terminal.KgpPlacements);
-        Assert.Equal(2u, terminal.KgpPlacements[0].ImageId);
+        TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(2u, terminal.KgpPlacements[0].ImageId);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteByRow_RemovesIntersecting()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -880,11 +885,11 @@ public class KgpDeleteConformanceTests
         // Delete by row 4 (1-based) - should hit first image (rows 2-4, 0-based)
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=d,d=y,y=4"));
 
-        Assert.Single(terminal.KgpPlacements);
-        Assert.Equal(2u, terminal.KgpPlacements[0].ImageId);
+        TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(2u, terminal.KgpPlacements[0].ImageId);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteByZIndex_RemovesMatchingOnly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -896,11 +901,11 @@ public class KgpDeleteConformanceTests
 
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=d,d=z,z=0"));
 
-        Assert.Equal(2, terminal.KgpPlacements.Count);
-        Assert.DoesNotContain(terminal.KgpPlacements, p => p.ZIndex == 0);
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
+        Assert.IsFalse(terminal.KgpPlacements.Any(p => p.ZIndex == 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void Delete_AbortsChunkedTransfer()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -915,10 +920,11 @@ public class KgpDeleteConformanceTests
 
         // New transfer should work fine
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(2, 2, 2));
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
     }
 }
 
+[TestClass]
 public class KgpScrollConformanceTests
 {
     private static readonly TerminalCapabilities KgpCapabilities = new()
@@ -946,7 +952,7 @@ public class KgpScrollConformanceTests
     // Scroll conformance (based on kitty's test_gr_scroll)
     // =============================================
 
-    [Fact]
+    [TestMethod]
     public void Scroll_PlacementRowDecreases()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -957,7 +963,7 @@ public class KgpScrollConformanceTests
         SendKgp(terminal, KgpTestHelper.BuildTransmitAndDisplayCommand(1, 4, 4,
             displayColumns: 2, displayRows: 1, cursorMovement: 1));
 
-        Assert.Equal(2, terminal.KgpPlacements[0].Row);
+        Assert.AreEqual(2, terminal.KgpPlacements[0].Row);
 
         // Move to last row and trigger scroll
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[5;1H"));
@@ -967,11 +973,11 @@ public class KgpScrollConformanceTests
         var placements = terminal.KgpPlacements;
         if (placements.Count > 0)
         {
-            Assert.Equal(1, placements[0].Row);
+            Assert.AreEqual(1, placements[0].Row);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Scroll_PlacementRemovedWhenScrolledOff()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -982,7 +988,7 @@ public class KgpScrollConformanceTests
         SendKgp(terminal, KgpTestHelper.BuildTransmitAndDisplayCommand(1, 4, 4,
             displayColumns: 2, displayRows: 1, cursorMovement: 1));
 
-        Assert.Equal(0, terminal.KgpPlacements[0].Row);
+        Assert.AreEqual(0, terminal.KgpPlacements[0].Row);
 
         // Scroll enough times to push it off screen
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[5;1H"));
@@ -991,10 +997,11 @@ public class KgpScrollConformanceTests
         // After scrolling off, placement should be removed
         var placements = terminal.KgpPlacements;
         // Either removed or row < 0
-        Assert.True(placements.Count == 0 || placements[0].Row < 0);
+        Assert.IsTrue(placements.Count == 0 || placements[0].Row < 0);
     }
 }
 
+[TestClass]
 public class KgpScreenInteractionConformanceTests
 {
     private static readonly TerminalCapabilities KgpCapabilities = new()
@@ -1023,7 +1030,7 @@ public class KgpScreenInteractionConformanceTests
     // "Interaction with other terminal actions")
     // =============================================
 
-    [Fact]
+    [TestMethod]
     public void ClearScreen_ED2_ClearsAllPlacements()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1039,7 +1046,7 @@ public class KgpScreenInteractionConformanceTests
         // ESC[2J is defined to clear all placements
     }
 
-    [Fact]
+    [TestMethod]
     public void Reset_RIS_ClearsAllKgpState()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1048,7 +1055,7 @@ public class KgpScreenInteractionConformanceTests
         SendKgp(terminal, KgpTestHelper.BuildTransmitAndDisplayCommand(1, 4, 4, displayColumns: 2));
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(2, 4, 4));
 
-        Assert.Equal(2, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(2, terminal.KgpImageStore.ImageCount);
 
         // RIS (Reset to Initial State)
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1bc"));
@@ -1057,7 +1064,7 @@ public class KgpScreenInteractionConformanceTests
         // Note: This documents the expected behavior
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseInLine_DoesNotAffectGraphics()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1072,10 +1079,10 @@ public class KgpScreenInteractionConformanceTests
         // Erase in line (EL) should NOT affect graphics per KGP spec
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[1;1H\x1b[K"));
 
-        Assert.Equal(placementsBefore, terminal.KgpPlacements.Count);
+        Assert.AreEqual(placementsBefore, terminal.KgpPlacements.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseInDisplay_ED0_FromBelowImage_DoesNotAffect()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1089,10 +1096,10 @@ public class KgpScreenInteractionConformanceTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[10;1H\x1b[J"));
 
         // Image above cursor should still exist
-        Assert.Single(terminal.KgpPlacements);
+        TestSeq.Single(terminal.KgpPlacements);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpCapability_Disabled_IgnoresCommands()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1109,10 +1116,10 @@ public class KgpScreenInteractionConformanceTests
 
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 4, 4));
 
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void MultipleOperations_InterleavedWithText_WorkCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1133,8 +1140,8 @@ public class KgpScreenInteractionConformanceTests
         // Write more text
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("!"));
 
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
-        Assert.Single(terminal.KgpPlacements);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+        TestSeq.Single(terminal.KgpPlacements);
     }
 }
 
@@ -1144,6 +1151,7 @@ public class KgpScreenInteractionConformanceTests
 /// <remarks>
 /// Adapts from: ghostty-org/ghostty src/terminal/kitty/graphics_command.zig
 /// </remarks>
+[TestClass]
 public class KgpGhosttyCommandParsingConformanceTests
 {
     private static readonly TerminalCapabilities KgpCapabilities = new()
@@ -1167,7 +1175,7 @@ public class KgpGhosttyCommandParsingConformanceTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize(escapeSequence));
     }
 
-    [Fact]
+    [TestMethod]
     public void NoControlData_OnlyPayload_ParsesAsTransmit()
     {
         // Empty control string with payload — should parse as default transmit
@@ -1175,58 +1183,58 @@ public class KgpGhosttyCommandParsingConformanceTests
         var cmd = KgpTestHelper.BuildCommand("", payload);
         var tokens = AnsiTokenizer.Tokenize(cmd);
 
-        var kgpToken = Assert.Single(tokens.OfType<KgpToken>());
-        Assert.Equal("", kgpToken.ControlData);
-        Assert.False(string.IsNullOrEmpty(kgpToken.Payload));
+        var kgpToken = TestSeq.Single(tokens.OfType<KgpToken>());
+        Assert.AreEqual("", kgpToken.ControlData);
+        Assert.IsFalse(string.IsNullOrEmpty(kgpToken.Payload));
 
         // When parsed, empty control data should produce defaults
         var parsed = KgpCommand.Parse("");
-        Assert.Equal(KgpAction.Transmit, parsed.Action);
-        Assert.Equal(KgpFormat.Rgba32, parsed.Format);
+        Assert.AreEqual(KgpAction.Transmit, parsed.Action);
+        Assert.AreEqual(KgpFormat.Rgba32, parsed.Format);
     }
 
-    [Fact]
+    [TestMethod]
     public void IgnoreUnknownKeys_LongKey()
     {
         // Multi-char keys like "hello=world" should be silently ignored
         var parsed = KgpCommand.Parse("f=24,s=10,v=20,hello=world");
-        Assert.Equal(KgpFormat.Rgb24, parsed.Format);
-        Assert.Equal(10u, parsed.Width);
-        Assert.Equal(20u, parsed.Height);
+        Assert.AreEqual(KgpFormat.Rgb24, parsed.Format);
+        Assert.AreEqual(10u, parsed.Width);
+        Assert.AreEqual(20u, parsed.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void IgnoreVeryLongValues_OverflowsGracefully()
     {
         // Enormous values that overflow uint should parse to 0 via TryParse failure
         var parsed = KgpCommand.Parse("f=24,s=10,v=2000000000000000000000000000000000000000");
-        Assert.Equal(KgpFormat.Rgb24, parsed.Format);
-        Assert.Equal(10u, parsed.Width);
-        Assert.Equal(0u, parsed.Height); // overflow → TryParse fails → default 0
+        Assert.AreEqual(KgpFormat.Rgb24, parsed.Format);
+        Assert.AreEqual(10u, parsed.Width);
+        Assert.AreEqual(0u, parsed.Height); // overflow → TryParse fails → default 0
     }
 
-    [Fact]
+    [TestMethod]
     public void NegativeZIndex_LargeValue()
     {
         var parsed = KgpCommand.Parse("a=p,i=1,z=-2000000000");
-        Assert.Equal(KgpAction.Put, parsed.Action);
-        Assert.Equal(1u, parsed.ImageId);
-        Assert.Equal(-2000000000, parsed.ZIndex);
+        Assert.AreEqual(KgpAction.Put, parsed.Action);
+        Assert.AreEqual(1u, parsed.ImageId);
+        Assert.AreEqual(-2000000000, parsed.ZIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void TransmissionIgnoresM_IfMediumIsNotDirect()
     {
         // Per Kitty spec, m= (more_chunks) is only meaningful for direct transmission
         var parsed = KgpCommand.Parse("a=t,t=t,m=1");
-        Assert.Equal(KgpAction.Transmit, parsed.Action);
-        Assert.Equal(KgpTransmissionMedium.TempFile, parsed.Medium);
+        Assert.AreEqual(KgpAction.Transmit, parsed.Action);
+        Assert.AreEqual(KgpTransmissionMedium.TempFile, parsed.Medium);
         // The parser stores m=1 regardless; the terminal ignores it for non-direct media.
         // We verify the parser at least doesn't crash and parses the medium correctly.
-        Assert.Equal(1, parsed.MoreData);
+        Assert.AreEqual(1, parsed.MoreData);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResponseEncoding_NoIdOrNumber_EmptyResponse()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1239,10 +1247,10 @@ public class KgpGhosttyCommandParsingConformanceTests
         SendKgp(terminal, cmd);
 
         // Image should be stored with auto-allocated ID
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResponseEncoding_OnlyImageId()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1251,13 +1259,13 @@ public class KgpGhosttyCommandParsingConformanceTests
         // Transmit with explicit ID, q=0 (send responses)
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(42, 2, 2, quiet: 0));
 
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
         var img = terminal.KgpImageStore.GetImageById(42);
-        Assert.NotNull(img);
-        Assert.Equal(42u, img.ImageId);
+        Assert.IsNotNull(img);
+        Assert.AreEqual(42u, img.ImageId);
     }
 
-    [Fact]
+    [TestMethod]
     public void ResponseEncoding_BothIdAndNumber()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1268,16 +1276,16 @@ public class KgpGhosttyCommandParsingConformanceTests
         var cmd = KgpTestHelper.BuildCommand("a=t,f=32,s=2,v=2,i=10,I=20", data);
         SendKgp(terminal, cmd);
 
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
         var img = terminal.KgpImageStore.GetImageById(10);
-        Assert.NotNull(img);
-        Assert.Equal(10u, img.ImageId);
-        Assert.Equal(20u, img.ImageNumber);
+        Assert.IsNotNull(img);
+        Assert.AreEqual(10u, img.ImageId);
+        Assert.AreEqual(20u, img.ImageNumber);
 
         // Also retrievable by number
         var imgByNum = terminal.KgpImageStore.GetImageByNumber(20);
-        Assert.NotNull(imgByNum);
-        Assert.Equal(10u, imgByNum.ImageId);
+        Assert.IsNotNull(imgByNum);
+        Assert.AreEqual(10u, imgByNum.ImageId);
     }
 }
 
@@ -1287,6 +1295,7 @@ public class KgpGhosttyCommandParsingConformanceTests
 /// <remarks>
 /// Adapts from: ghostty-org/ghostty src/terminal/kitty/graphics_storage.zig
 /// </remarks>
+[TestClass]
 public class KgpGhosttyDeleteConformanceTests
 {
     private static readonly TerminalCapabilities KgpCapabilities = new()
@@ -1310,7 +1319,7 @@ public class KgpGhosttyDeleteConformanceTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize(escapeSequence));
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteByRange_RemovesImagesInRange()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1322,17 +1331,17 @@ public class KgpGhosttyDeleteConformanceTests
         SendKgp(terminal, KgpTestHelper.BuildTransmitAndDisplayCommand(5, 4, 4, displayColumns: 2, cursorMovement: 1));
         SendKgp(terminal, KgpTestHelper.BuildTransmitAndDisplayCommand(6, 4, 4, displayColumns: 2, cursorMovement: 1));
 
-        Assert.Equal(4, terminal.KgpPlacements.Count);
+        Assert.AreEqual(4, terminal.KgpPlacements.Count);
 
         // Delete range: x=4,y=6 means IDs 4..6
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=d,d=r,x=4,y=6"));
 
         // Images 4,5,6 placements removed; image 3 remains
-        Assert.Single(terminal.KgpPlacements);
-        Assert.Equal(3u, terminal.KgpPlacements[0].ImageId);
+        TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(3u, terminal.KgpPlacements[0].ImageId);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteByRange_FreeData_ClearsCompletely()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1346,18 +1355,18 @@ public class KgpGhosttyDeleteConformanceTests
         // Delete range with free data (uppercase R)
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=d,d=R,x=4,y=6"));
 
-        Assert.Single(terminal.KgpPlacements);
-        Assert.Equal(3u, terminal.KgpPlacements[0].ImageId);
+        TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(3u, terminal.KgpPlacements[0].ImageId);
 
         // Image data for 4,5,6 should be freed
-        Assert.Null(terminal.KgpImageStore.GetImageById(4));
-        Assert.Null(terminal.KgpImageStore.GetImageById(5));
-        Assert.Null(terminal.KgpImageStore.GetImageById(6));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(4));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(5));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(6));
         // Image 3 data should remain
-        Assert.NotNull(terminal.KgpImageStore.GetImageById(3));
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(3));
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteByRange_InvalidRange_XGreaterThanY()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1366,16 +1375,16 @@ public class KgpGhosttyDeleteConformanceTests
         SendKgp(terminal, KgpTestHelper.BuildTransmitAndDisplayCommand(3, 4, 4, displayColumns: 2, cursorMovement: 1));
         SendKgp(terminal, KgpTestHelper.BuildTransmitAndDisplayCommand(4, 4, 4, displayColumns: 2, cursorMovement: 1));
 
-        Assert.Equal(2, terminal.KgpPlacements.Count);
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
 
         // Invalid range: x > y should be ignored
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=d,d=r,x=6,y=4"));
 
         // Nothing should be deleted
-        Assert.Equal(2, terminal.KgpPlacements.Count);
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteByRange_MissingXOrY_Invalid()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1384,18 +1393,18 @@ public class KgpGhosttyDeleteConformanceTests
         SendKgp(terminal, KgpTestHelper.BuildTransmitAndDisplayCommand(3, 4, 4, displayColumns: 2, cursorMovement: 1));
         SendKgp(terminal, KgpTestHelper.BuildTransmitAndDisplayCommand(4, 4, 4, displayColumns: 2, cursorMovement: 1));
 
-        Assert.Equal(2, terminal.KgpPlacements.Count);
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
 
         // Missing y= — x defaults to 0, so range is invalid
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=d,d=r,x=3"));
-        Assert.Equal(2, terminal.KgpPlacements.Count);
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
 
         // Missing x= — same
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=d,d=r,y=5"));
-        Assert.Equal(2, terminal.KgpPlacements.Count);
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteAtCellWithZIndex_RemovesMatchingZOnly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1411,16 +1420,16 @@ public class KgpGhosttyDeleteConformanceTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[5;5H"));
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(2, placementId: 2, displayColumns: 3, displayRows: 2, zIndex: 20));
 
-        Assert.Equal(2, terminal.KgpPlacements.Count);
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
 
         // Delete at cell (1-based: x=5,y=5) with z=10 — only z=10 placement removed
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=d,d=q,x=5,y=5,z=10"));
 
-        Assert.Single(terminal.KgpPlacements);
-        Assert.Equal(20, terminal.KgpPlacements[0].ZIndex);
+        TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(20, terminal.KgpPlacements[0].ZIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteIntersectingCursor_HitsMultiplePlacements()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1438,16 +1447,16 @@ public class KgpGhosttyDeleteConformanceTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[3;3H"));
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(3, placementId: 3, displayColumns: 4, displayRows: 3, cursorMovement: 1));
 
-        Assert.Equal(3, terminal.KgpPlacements.Count);
+        Assert.AreEqual(3, terminal.KgpPlacements.Count);
 
         // Move cursor inside the overlapping area and delete
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[4;4H"));
         SendKgp(terminal, KgpTestHelper.BuildDeleteCommand('c'));
 
-        Assert.Empty(terminal.KgpPlacements);
+        Assert.IsEmpty(terminal.KgpPlacements);
     }
 
-    [Fact]
+    [TestMethod]
     public void DeleteAll_PreservesStorageLimit()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1459,17 +1468,17 @@ public class KgpGhosttyDeleteConformanceTests
 
         // Delete all with free data
         SendKgp(terminal, KgpTestHelper.BuildDeleteCommand('A'));
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
-        Assert.Empty(terminal.KgpPlacements);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        Assert.IsEmpty(terminal.KgpPlacements);
 
         // Storage should still function — add new images after delete
         SendKgp(terminal, KgpTestHelper.BuildTransmitAndDisplayCommand(10, 4, 4, displayColumns: 2));
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
-        Assert.Single(terminal.KgpPlacements);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+        TestSeq.Single(terminal.KgpPlacements);
 
         SendKgp(terminal, KgpTestHelper.BuildTransmitAndDisplayCommand(11, 4, 4, displayColumns: 2));
-        Assert.Equal(2, terminal.KgpImageStore.ImageCount);
-        Assert.Equal(2, terminal.KgpPlacements.Count);
+        Assert.AreEqual(2, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
     }
 }
 
@@ -1479,6 +1488,7 @@ public class KgpGhosttyDeleteConformanceTests
 /// <remarks>
 /// Adapts from: ghostty-org/ghostty src/terminal/kitty/graphics_exec.zig
 /// </remarks>
+[TestClass]
 public class KgpGhosttyExecConformanceTests
 {
     private static readonly TerminalCapabilities KgpCapabilities = new()
@@ -1502,7 +1512,7 @@ public class KgpGhosttyExecConformanceTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize(escapeSequence));
     }
 
-    [Fact]
+    [TestMethod]
     public void ChunkedTransfer_QuietInheritsFromFinalChunk()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1523,13 +1533,13 @@ public class KgpGhosttyExecConformanceTests
         SendKgp(terminal, cmd2);
 
         // Image should be stored regardless of quiet mode
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
         var img = terminal.KgpImageStore.GetImageById(1);
-        Assert.NotNull(img);
-        Assert.Equal(4u, img.Width);
+        Assert.IsNotNull(img);
+        Assert.AreEqual(4u, img.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void ChunkedTransfer_QuietIncreasing()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1546,13 +1556,13 @@ public class KgpGhosttyExecConformanceTests
         SendKgp(terminal, KgpTestHelper.BuildCommand("m=1,q=1", chunk2));
         SendKgp(terminal, KgpTestHelper.BuildCommand("m=0,q=2", chunk3));
 
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
         var img = terminal.KgpImageStore.GetImageById(1);
-        Assert.NotNull(img);
-        Assert.Equal(24, img.Data.Length);
+        Assert.IsNotNull(img);
+        Assert.AreEqual(24, img.Data.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public void DefaultFormat_IsRgba()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1563,15 +1573,15 @@ public class KgpGhosttyExecConformanceTests
         var cmd = KgpTestHelper.BuildCommand("a=t,s=2,v=2,i=1", data);
         SendKgp(terminal, cmd);
 
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
         var img = terminal.KgpImageStore.GetImageById(1);
-        Assert.NotNull(img);
-        Assert.Equal(KgpFormat.Rgba32, img.Format);
-        Assert.Equal(2u, img.Width);
-        Assert.Equal(2u, img.Height);
+        Assert.IsNotNull(img);
+        Assert.AreEqual(KgpFormat.Rgba32, img.Format);
+        Assert.AreEqual(2u, img.Width);
+        Assert.AreEqual(2u, img.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void NoResponse_WithZeroIdAndNumber()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1583,10 +1593,10 @@ public class KgpGhosttyExecConformanceTests
         SendKgp(terminal, cmd);
 
         // Image should be stored (with auto-allocated ID)
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void ZeroPlacementId_CreatesNewEachTime()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1606,12 +1616,12 @@ public class KgpGhosttyExecConformanceTests
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, displayColumns: 2, displayRows: 1));
 
         // Each should create a separate placement (not replace)
-        Assert.Equal(3, terminal.KgpPlacements.Count);
-        Assert.All(terminal.KgpPlacements, p => Assert.Equal(1u, p.ImageId));
+        Assert.AreEqual(3, terminal.KgpPlacements.Count);
+        TestSeq.All(terminal.KgpPlacements, p => Assert.AreEqual(1u, p.ImageId));
 
         // Verify they're at different positions
         var rows = terminal.KgpPlacements.Select(p => p.Row).Distinct().Count();
-        Assert.Equal(3, rows);
+        Assert.AreEqual(3, rows);
     }
 }
 
@@ -1621,6 +1631,7 @@ public class KgpGhosttyExecConformanceTests
 /// <remarks>
 /// Adapts from: ghostty-org/ghostty src/terminal/kitty/graphics_image.zig
 /// </remarks>
+[TestClass]
 public class KgpGhosttyImageConformanceTests
 {
     private static readonly TerminalCapabilities KgpCapabilities = new()
@@ -1644,7 +1655,7 @@ public class KgpGhosttyImageConformanceTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize(escapeSequence));
     }
 
-    [Fact]
+    [TestMethod]
     public void ImageTooWide_Rejected()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1658,10 +1669,10 @@ public class KgpGhosttyImageConformanceTests
         SendKgp(terminal, cmd);
 
         // Should be rejected due to insufficient data
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void ImageTooTall_Rejected()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1673,10 +1684,10 @@ public class KgpGhosttyImageConformanceTests
         var cmd = KgpTestHelper.BuildCommand("a=t,f=32,s=1,v=100000,i=1", data);
         SendKgp(terminal, cmd);
 
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void ChunkedWithZeroInitialChunk_Succeeds()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1693,9 +1704,9 @@ public class KgpGhosttyImageConformanceTests
         var cmd2 = KgpTestHelper.BuildCommand("m=0", fullData);
         SendKgp(terminal, cmd2);
 
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
         var img = terminal.KgpImageStore.GetImageById(1);
-        Assert.NotNull(img);
-        Assert.Equal(16, img.Data.Length);
+        Assert.IsNotNull(img);
+        Assert.AreEqual(16, img.Data.Length);
     }
 }

--- a/tests/Hex1b.Tests/KgpImageCacheTests.cs
+++ b/tests/Hex1b.Tests/KgpImageCacheTests.cs
@@ -3,37 +3,38 @@ using System.Text;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class KgpImageCacheTests
 {
-    [Fact]
+    [TestMethod]
     public void AllocateImageId_ReturnsSequentialIds()
     {
         var cache = new KgpImageCache();
-        Assert.Equal(1u, cache.AllocateImageId());
-        Assert.Equal(2u, cache.AllocateImageId());
-        Assert.Equal(3u, cache.AllocateImageId());
+        Assert.AreEqual(1u, cache.AllocateImageId());
+        Assert.AreEqual(2u, cache.AllocateImageId());
+        Assert.AreEqual(3u, cache.AllocateImageId());
     }
 
-    [Fact]
+    [TestMethod]
     public void TryGetImageId_ReturnsFalse_WhenNotTransmitted()
     {
         var cache = new KgpImageCache();
         var hash = SHA256.HashData(new byte[] { 1, 2, 3 });
-        Assert.False(cache.TryGetImageId(hash, out _));
+        Assert.IsFalse(cache.TryGetImageId(hash, out _));
     }
 
-    [Fact]
+    [TestMethod]
     public void TryGetImageId_ReturnsTrue_AfterRegistration()
     {
         var cache = new KgpImageCache();
         var hash = SHA256.HashData(new byte[] { 1, 2, 3 });
         cache.RegisterTransmission(hash, 42);
 
-        Assert.True(cache.TryGetImageId(hash, out var imageId));
-        Assert.Equal(42u, imageId);
+        Assert.IsTrue(cache.TryGetImageId(hash, out var imageId));
+        Assert.AreEqual(42u, imageId);
     }
 
-    [Fact]
+    [TestMethod]
     public void DifferentContent_GetsDifferentEntries()
     {
         var cache = new KgpImageCache();
@@ -43,13 +44,13 @@ public class KgpImageCacheTests
         cache.RegisterTransmission(hash1, 1);
         cache.RegisterTransmission(hash2, 2);
 
-        Assert.True(cache.TryGetImageId(hash1, out var id1));
-        Assert.True(cache.TryGetImageId(hash2, out var id2));
-        Assert.Equal(1u, id1);
-        Assert.Equal(2u, id2);
+        Assert.IsTrue(cache.TryGetImageId(hash1, out var id1));
+        Assert.IsTrue(cache.TryGetImageId(hash2, out var id2));
+        Assert.AreEqual(1u, id1);
+        Assert.AreEqual(2u, id2);
     }
 
-    [Fact]
+    [TestMethod]
     public void Clear_RemovesAllEntries()
     {
         var cache = new KgpImageCache();
@@ -58,7 +59,7 @@ public class KgpImageCacheTests
 
         cache.Clear();
 
-        Assert.False(cache.TryGetImageId(hash, out _));
-        Assert.Equal(0, cache.Count);
+        Assert.IsFalse(cache.TryGetImageId(hash, out _));
+        Assert.AreEqual(0, cache.Count);
     }
 }

--- a/tests/Hex1b.Tests/KgpImageNodeTests.cs
+++ b/tests/Hex1b.Tests/KgpImageNodeTests.cs
@@ -8,6 +8,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for KgpImageWidget/KgpImageNode — the widget-tree API for KGP images.
 /// </summary>
+[TestClass]
 public class KgpImageNodeTests
 {
     private static byte[] CreateTestImage(int width = 4, int height = 4)
@@ -41,17 +42,17 @@ public class KgpImageNodeTests
 
     #region Widget Construction
 
-    [Fact]
+    [TestMethod]
     public void KgpImageWidget_DefaultZOrder_IsBelowText()
     {
         var widget = new KgpImageWidget(
             CreateTestImage(), 4, 4,
             new TextBlockWidget("fallback"));
 
-        Assert.Equal(KgpZOrder.BelowText, widget.ZOrder);
+        Assert.AreEqual(KgpZOrder.BelowText, widget.ZOrder);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpImageWidget_AboveText_SetsZOrder()
     {
         var widget = new KgpImageWidget(
@@ -59,10 +60,10 @@ public class KgpImageNodeTests
             new TextBlockWidget("fallback"))
             .AboveText();
 
-        Assert.Equal(KgpZOrder.AboveText, widget.ZOrder);
+        Assert.AreEqual(KgpZOrder.AboveText, widget.ZOrder);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpImageWidget_WithWidth_SetsWidth()
     {
         var widget = new KgpImageWidget(
@@ -70,10 +71,10 @@ public class KgpImageNodeTests
             new TextBlockWidget("fallback"))
             .Width(20);
 
-        Assert.Equal(20, widget.Width);
+        Assert.AreEqual(20, widget.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpImageWidget_WithHeight_SetsHeight()
     {
         var widget = new KgpImageWidget(
@@ -81,31 +82,31 @@ public class KgpImageNodeTests
             new TextBlockWidget("fallback"))
             .Height(10);
 
-        Assert.Equal(10, widget.Height);
+        Assert.AreEqual(10, widget.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpImageWidget_GetExpectedNodeType_ReturnsKgpImageNode()
     {
         var widget = new KgpImageWidget(
             CreateTestImage(), 4, 4,
             new TextBlockWidget("fallback"));
 
-        Assert.Equal(typeof(KgpImageNode), widget.GetExpectedNodeType());
+        Assert.AreEqual(typeof(KgpImageNode), widget.GetExpectedNodeType());
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpImage_BuilderFallback_CreatesFallbackWidget()
     {
         var ctx = new RootContext();
 
         var widget = ctx.KgpImage(CreateTestImage(), 4, 4, kgp => kgp.Text("fallback"));
 
-        var fallback = Assert.IsType<TextBlockWidget>(widget.Fallback);
-        Assert.Equal("fallback", fallback.Text);
+        var fallback = TestSeq.IsType<TextBlockWidget>(widget.Fallback);
+        Assert.AreEqual("fallback", fallback.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpImage_BuilderFallback_PreservesRequestedDimensions()
     {
         var ctx = new RootContext();
@@ -116,15 +117,15 @@ public class KgpImageNodeTests
             width: 20,
             height: 10);
 
-        Assert.Equal(20, widget.Width);
-        Assert.Equal(10, widget.Height);
+        Assert.AreEqual(20, widget.Width);
+        Assert.AreEqual(10, widget.Height);
     }
 
     #endregion
 
     #region Node MeasureCore
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithExplicitDimensions_ReturnsRequestedSize()
     {
         var node = new KgpImageNode
@@ -138,11 +139,11 @@ public class KgpImageNodeTests
         };
 
         var size = node.Measure(new Constraints(0, 80, 0, 24));
-        Assert.Equal(10, size.Width);
-        Assert.Equal(5, size.Height);
+        Assert.AreEqual(10, size.Width);
+        Assert.AreEqual(5, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithoutExplicitDimensions_ComputesFromPixels()
     {
         var node = new KgpImageNode
@@ -154,11 +155,11 @@ public class KgpImageNodeTests
         };
 
         var size = node.Measure(new Constraints(0, 80, 0, 24));
-        Assert.True(size.Width >= 4);
-        Assert.True(size.Height >= 3);
+        Assert.IsTrue(size.Width >= 4);
+        Assert.IsTrue(size.Height >= 3);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_RespectsConstraints()
     {
         var node = new KgpImageNode
@@ -172,15 +173,15 @@ public class KgpImageNodeTests
         };
 
         var size = node.Measure(new Constraints(0, 10, 0, 5));
-        Assert.True(size.Width <= 10);
-        Assert.True(size.Height <= 5);
+        Assert.IsTrue(size.Width <= 10);
+        Assert.IsTrue(size.Height <= 5);
     }
 
     #endregion
 
     #region Node Render
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithKgpSupport_EmitsKgpSequence()
     {
         var node = new KgpImageNode
@@ -212,10 +213,10 @@ public class KgpImageNodeTests
         // The KGP sequence was emitted through the workload adapter
         // Verify the terminal processed the output without errors
         var snapshot = terminal.CreateSnapshot();
-        Assert.NotNull(snapshot);
+        Assert.IsNotNull(snapshot);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithoutKgpSupport_RendersFallback()
     {
         var node = new KgpImageNode
@@ -244,10 +245,10 @@ public class KgpImageNodeTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.True(terminal.CreateSnapshot().ContainsText("No KGP"));
+        Assert.IsTrue(terminal.CreateSnapshot().ContainsText("No KGP"));
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_AboveText_UsesPositiveZIndex()
     {
         var node = new KgpImageNode
@@ -259,10 +260,10 @@ public class KgpImageNodeTests
         };
 
         // Verify the z-order is set correctly
-        Assert.Equal(KgpZOrder.AboveText, node.ZOrder);
+        Assert.AreEqual(KgpZOrder.AboveText, node.ZOrder);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_BelowText_UsesNegativeZIndex()
     {
         var node = new KgpImageNode
@@ -273,14 +274,14 @@ public class KgpImageNodeTests
             ZOrder = KgpZOrder.BelowText,
         };
 
-        Assert.Equal(KgpZOrder.BelowText, node.ZOrder);
+        Assert.AreEqual(KgpZOrder.BelowText, node.ZOrder);
     }
 
     #endregion
 
     #region Dirty Tracking
 
-    [Fact]
+    [TestMethod]
     public void ImageChange_MarksDirty()
     {
         var node = new KgpImageNode
@@ -295,10 +296,10 @@ public class KgpImageNodeTests
         node.ClearDirty();
 
         node.ImageData = CreateTestImage(4, 4);
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void ZOrderChange_MarksDirty()
     {
         var node = new KgpImageNode
@@ -314,14 +315,14 @@ public class KgpImageNodeTests
         node.ClearDirty();
 
         node.ZOrder = KgpZOrder.AboveText;
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
     #endregion
 
     #region Children
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_ReturnsFallback()
     {
         var fallback = new TextBlockNode { Text = "fb" };
@@ -334,11 +335,11 @@ public class KgpImageNodeTests
         };
 
         var children = node.GetChildren().ToList();
-        Assert.Single(children);
-        Assert.Same(fallback, children[0]);
+        TestSeq.Single(children);
+        Assert.AreSame(fallback, children[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_NoFallback_Empty()
     {
         var node = new KgpImageNode
@@ -349,24 +350,24 @@ public class KgpImageNodeTests
         };
 
         var children = node.GetChildren().ToList();
-        Assert.Empty(children);
+        Assert.IsEmpty(children);
     }
 
     #endregion
 
     #region Stretch Modes — Widget Construction
 
-    [Fact]
+    [TestMethod]
     public void KgpImageWidget_DefaultStretch_IsStretch()
     {
         var widget = new KgpImageWidget(
             CreateTestImage(), 4, 4,
             new TextBlockWidget("fallback"));
 
-        Assert.Equal(KgpImageStretch.Stretch, widget.Stretch);
+        Assert.AreEqual(KgpImageStretch.Stretch, widget.Stretch);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpImageWidget_Fit_SetsStretch()
     {
         var widget = new KgpImageWidget(
@@ -374,10 +375,10 @@ public class KgpImageNodeTests
             new TextBlockWidget("fallback"))
             .Fit();
 
-        Assert.Equal(KgpImageStretch.Fit, widget.Stretch);
+        Assert.AreEqual(KgpImageStretch.Fit, widget.Stretch);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpImageWidget_Fill_SetsStretch()
     {
         var widget = new KgpImageWidget(
@@ -385,10 +386,10 @@ public class KgpImageNodeTests
             new TextBlockWidget("fallback"))
             .Fill();
 
-        Assert.Equal(KgpImageStretch.Fill, widget.Stretch);
+        Assert.AreEqual(KgpImageStretch.Fill, widget.Stretch);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpImageWidget_Stretched_SetsStretch()
     {
         var widget = new KgpImageWidget(
@@ -396,10 +397,10 @@ public class KgpImageNodeTests
             new TextBlockWidget("fallback"))
             .Stretched();
 
-        Assert.Equal(KgpImageStretch.Stretch, widget.Stretch);
+        Assert.AreEqual(KgpImageStretch.Stretch, widget.Stretch);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpImageWidget_NaturalSize_SetsStretch()
     {
         var widget = new KgpImageWidget(
@@ -407,10 +408,10 @@ public class KgpImageNodeTests
             new TextBlockWidget("fallback"))
             .NaturalSize();
 
-        Assert.Equal(KgpImageStretch.None, widget.Stretch);
+        Assert.AreEqual(KgpImageStretch.None, widget.Stretch);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpImageWidget_WithStretch_SetsStretch()
     {
         var widget = new KgpImageWidget(
@@ -418,14 +419,14 @@ public class KgpImageNodeTests
             new TextBlockWidget("fallback"))
             .Stretch(KgpImageStretch.Fit);
 
-        Assert.Equal(KgpImageStretch.Fit, widget.Stretch);
+        Assert.AreEqual(KgpImageStretch.Fit, widget.Stretch);
     }
 
     #endregion
 
     #region Stretch Modes — MeasureCore (layout allocation)
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithFillHint_ExpandsToConstraints_RegardlessOfStretchMode()
     {
         // MeasureCore claims fill space for layout; Stretch mode only affects rendering.
@@ -444,12 +445,12 @@ public class KgpImageNodeTests
             node.HeightHint = SizeHint.Fill;
 
             var size = node.Measure(new Constraints(0, 60, 0, 20));
-            Assert.Equal(60, size.Width);
-            Assert.Equal(20, size.Height);
+            Assert.AreEqual(60, size.Width);
+            Assert.AreEqual(20, size.Height);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithoutFillHint_UsesNaturalSize_RegardlessOfStretchMode()
     {
         // 40x40 pixels → natural: 4 cols x 2 rows
@@ -466,12 +467,12 @@ public class KgpImageNodeTests
             };
 
             var size = node.Measure(new Constraints(0, 60, 0, 20));
-            Assert.Equal(4, size.Width);
-            Assert.Equal(2, size.Height);
+            Assert.AreEqual(4, size.Width);
+            Assert.AreEqual(2, size.Height);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_GuardsAgainstIntMaxValue()
     {
         var node = new KgpImageNode
@@ -488,57 +489,57 @@ public class KgpImageNodeTests
         // VStack first-pass uses int.MaxValue
         var size = node.Measure(new Constraints(0, int.MaxValue, 0, int.MaxValue));
         // Should fall back to natural size, not int.MaxValue
-        Assert.True(size.Width < 1000, $"Width {size.Width} should not be int.MaxValue");
-        Assert.True(size.Height < 1000, $"Height {size.Height} should not be int.MaxValue");
+        Assert.IsTrue(size.Width < 1000, $"Width {size.Width} should not be int.MaxValue");
+        Assert.IsTrue(size.Height < 1000, $"Height {size.Height} should not be int.MaxValue");
     }
 
     #endregion
 
     #region Stretch Modes — UniformToFill Clip Computation
 
-    [Fact]
+    [TestMethod]
     public void ComputeFillClip_WiderSource_CropsWidth()
     {
         // Source 400x200 (pixel aspect 2:1), display 10x10 cells
         // Display pixel equiv: 100x200 (ratio 0.5:1)
         // Source wider → crop width
         var (clipX, clipY, clipW, clipH) = KgpImageNode.ComputeFillClip(400, 200, 10, 10);
-        Assert.True(clipX > 0, "Should crop from sides");
-        Assert.Equal(0, clipY);
-        Assert.True(clipW < 400, $"clipW {clipW} should be less than full width 400");
-        Assert.Equal(200, clipH);
+        Assert.IsTrue(clipX > 0, "Should crop from sides");
+        Assert.AreEqual(0, clipY);
+        Assert.IsTrue(clipW < 400, $"clipW {clipW} should be less than full width 400");
+        Assert.AreEqual(200, clipH);
         // Centered
-        Assert.Equal((400 - clipW) / 2, clipX);
+        Assert.AreEqual((400 - clipW) / 2, clipX);
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputeFillClip_TallerSource_CropsHeight()
     {
         // Source 100x400 (pixel aspect 0.25:1), display 20x5 cells
         // Display pixel equiv: 200x100 (ratio 2:1)
         // Source taller → crop height
         var (clipX, clipY, clipW, clipH) = KgpImageNode.ComputeFillClip(100, 400, 20, 5);
-        Assert.Equal(0, clipX);
-        Assert.True(clipY > 0, "Should crop from top/bottom");
-        Assert.Equal(100, clipW);
-        Assert.True(clipH < 400, $"clipH {clipH} should be less than full height 400");
-        Assert.Equal((400 - clipH) / 2, clipY);
+        Assert.AreEqual(0, clipX);
+        Assert.IsTrue(clipY > 0, "Should crop from top/bottom");
+        Assert.AreEqual(100, clipW);
+        Assert.IsTrue(clipH < 400, $"clipH {clipH} should be less than full height 400");
+        Assert.AreEqual((400 - clipH) / 2, clipY);
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputeFillClip_MatchingAspect_NoCrop()
     {
         // Source 200x400 → natural 20x20 cells
         // Display at 20x20 cells → pixel equiv 200x400 → ratio 0.5
         // Source ratio = 200/400 = 0.5 → matches display → no crop
         var (clipX, clipY, clipW, clipH) = KgpImageNode.ComputeFillClip(200, 400, 20, 20);
-        Assert.Equal(0, clipX);
-        Assert.Equal(0, clipY);
-        Assert.Equal(0, clipW);
-        Assert.Equal(0, clipH);
+        Assert.AreEqual(0, clipX);
+        Assert.AreEqual(0, clipY);
+        Assert.AreEqual(0, clipW);
+        Assert.AreEqual(0, clipH);
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputeFillClip_SquareImageInWideDisplay_CropsHeight()
     {
         // Source 100x100 (square), display 40x5 cells
@@ -546,17 +547,17 @@ public class KgpImageNodeTests
         // Source pixel ratio: 1:1
         // Source is taller → crop height
         var (clipX, clipY, clipW, clipH) = KgpImageNode.ComputeFillClip(100, 100, 40, 5);
-        Assert.Equal(0, clipX);
-        Assert.True(clipY > 0, "Should crop height for wide display");
-        Assert.Equal(100, clipW);
-        Assert.True(clipH < 100);
+        Assert.AreEqual(0, clipX);
+        Assert.IsTrue(clipY > 0, "Should crop height for wide display");
+        Assert.AreEqual(100, clipW);
+        Assert.IsTrue(clipH < 100);
     }
 
     #endregion
 
     #region Stretch — Dirty Tracking
 
-    [Fact]
+    [TestMethod]
     public void StretchChange_MarksDirty()
     {
         var node = new KgpImageNode
@@ -572,10 +573,10 @@ public class KgpImageNodeTests
         node.ClearDirty();
 
         node.Stretch = KgpImageStretch.Fit;
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void StretchChange_SameValue_DoesNotMarkDirty()
     {
         var node = new KgpImageNode
@@ -591,52 +592,52 @@ public class KgpImageNodeTests
         node.ClearDirty();
 
         node.Stretch = KgpImageStretch.Stretch; // same value
-        Assert.False(node.IsDirty);
+        Assert.IsFalse(node.IsDirty);
     }
 
     #endregion
 
     #region Stretch — NaturalCellSize Helper
 
-    [Fact]
+    [TestMethod]
     public void NaturalCellSize_ComputesCorrectly()
     {
         // 100x200 pixels → (100+9)/10 = 10, (200+19)/20 = 10
         var (w, h) = KgpImageNode.NaturalCellSize(100, 200);
-        Assert.Equal(10, w);
-        Assert.Equal(10, h);
+        Assert.AreEqual(10, w);
+        Assert.AreEqual(10, h);
     }
 
-    [Fact]
+    [TestMethod]
     public void NaturalCellSize_MinimumOne()
     {
         var (w, h) = KgpImageNode.NaturalCellSize(1, 1);
-        Assert.Equal(1, w);
-        Assert.Equal(1, h);
+        Assert.AreEqual(1, w);
+        Assert.AreEqual(1, h);
     }
 
     #endregion
 
     #region Zero-bounds safety
 
-    [Fact]
+    [TestMethod]
     public void ComputeFillClip_ZeroCellDimensions_ReturnsZeroClip()
     {
         var (clipX, clipY, clipW, clipH) = KgpImageNode.ComputeFillClip(100, 100, 0, 0);
-        Assert.Equal(0, clipX);
-        Assert.Equal(0, clipY);
-        Assert.Equal(0, clipW);
-        Assert.Equal(0, clipH);
+        Assert.AreEqual(0, clipX);
+        Assert.AreEqual(0, clipY);
+        Assert.AreEqual(0, clipW);
+        Assert.AreEqual(0, clipH);
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputeFillClip_ZeroPixelDimensions_ReturnsZeroClip()
     {
         var (clipX, clipY, clipW, clipH) = KgpImageNode.ComputeFillClip(0, 0, 10, 10);
-        Assert.Equal(0, clipX);
-        Assert.Equal(0, clipY);
-        Assert.Equal(0, clipW);
-        Assert.Equal(0, clipH);
+        Assert.AreEqual(0, clipX);
+        Assert.AreEqual(0, clipY);
+        Assert.AreEqual(0, clipW);
+        Assert.AreEqual(0, clipH);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/KgpImageStoreTests.cs
+++ b/tests/Hex1b.Tests/KgpImageStoreTests.cs
@@ -1,6 +1,7 @@
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class KgpImageStoreTests
 {
     private static KgpImageData CreateImage(uint id, uint width = 2, uint height = 2, uint number = 0, byte fill = 0xFF)
@@ -11,7 +12,7 @@ public class KgpImageStoreTests
 
     // --- Basic store/retrieve ---
 
-    [Fact]
+    [TestMethod]
     public void StoreImage_StoresAndRetrieves()
     {
         var store = new KgpImageStore();
@@ -19,18 +20,18 @@ public class KgpImageStoreTests
 
         store.StoreImage(image);
 
-        Assert.Equal(1, store.ImageCount);
-        Assert.Same(image, store.GetImageById(1));
+        Assert.AreEqual(1, store.ImageCount);
+        Assert.AreSame(image, store.GetImageById(1));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetImageById_NonExistent_ReturnsNull()
     {
         var store = new KgpImageStore();
-        Assert.Null(store.GetImageById(999));
+        Assert.IsNull(store.GetImageById(999));
     }
 
-    [Fact]
+    [TestMethod]
     public void StoreImage_ReplacesSameId()
     {
         var store = new KgpImageStore();
@@ -40,11 +41,11 @@ public class KgpImageStoreTests
         store.StoreImage(image1);
         store.StoreImage(image2);
 
-        Assert.Equal(1, store.ImageCount);
-        Assert.Same(image2, store.GetImageById(1));
+        Assert.AreEqual(1, store.ImageCount);
+        Assert.AreSame(image2, store.GetImageById(1));
     }
 
-    [Fact]
+    [TestMethod]
     public void StoreImage_MultipleImages()
     {
         var store = new KgpImageStore();
@@ -52,25 +53,25 @@ public class KgpImageStoreTests
         store.StoreImage(CreateImage(2));
         store.StoreImage(CreateImage(3));
 
-        Assert.Equal(3, store.ImageCount);
-        Assert.NotNull(store.GetImageById(1));
-        Assert.NotNull(store.GetImageById(2));
-        Assert.NotNull(store.GetImageById(3));
+        Assert.AreEqual(3, store.ImageCount);
+        Assert.IsNotNull(store.GetImageById(1));
+        Assert.IsNotNull(store.GetImageById(2));
+        Assert.IsNotNull(store.GetImageById(3));
     }
 
     // --- Image numbers ---
 
-    [Fact]
+    [TestMethod]
     public void StoreImage_WithNumber_RetrievableByNumber()
     {
         var store = new KgpImageStore();
         var image = CreateImage(1, number: 42);
         store.StoreImage(image);
 
-        Assert.Same(image, store.GetImageByNumber(42));
+        Assert.AreSame(image, store.GetImageByNumber(42));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetImageByNumber_ReturnsNewest()
     {
         var store = new KgpImageStore();
@@ -80,51 +81,51 @@ public class KgpImageStoreTests
         store.StoreImage(image2);
 
         // GetImageByNumber returns the newest (last added)
-        Assert.Same(image2, store.GetImageByNumber(42));
+        Assert.AreSame(image2, store.GetImageByNumber(42));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetImageByNumber_NonExistent_ReturnsNull()
     {
         var store = new KgpImageStore();
-        Assert.Null(store.GetImageByNumber(999));
+        Assert.IsNull(store.GetImageByNumber(999));
     }
 
     // --- Removal ---
 
-    [Fact]
+    [TestMethod]
     public void RemoveImage_RemovesById()
     {
         var store = new KgpImageStore();
         store.StoreImage(CreateImage(1));
 
-        Assert.True(store.RemoveImage(1));
-        Assert.Equal(0, store.ImageCount);
-        Assert.Null(store.GetImageById(1));
+        Assert.IsTrue(store.RemoveImage(1));
+        Assert.AreEqual(0, store.ImageCount);
+        Assert.IsNull(store.GetImageById(1));
     }
 
-    [Fact]
+    [TestMethod]
     public void RemoveImage_NonExistent_ReturnsFalse()
     {
         var store = new KgpImageStore();
-        Assert.False(store.RemoveImage(999));
+        Assert.IsFalse(store.RemoveImage(999));
     }
 
-    [Fact]
+    [TestMethod]
     public void RemoveImageByNumber_RemovesNewest()
     {
         var store = new KgpImageStore();
         store.StoreImage(CreateImage(1, number: 42));
         store.StoreImage(CreateImage(2, number: 42));
 
-        Assert.True(store.RemoveImageByNumber(42));
-        Assert.Equal(1, store.ImageCount);
+        Assert.IsTrue(store.RemoveImageByNumber(42));
+        Assert.AreEqual(1, store.ImageCount);
         // Image 1 (first with number 42) should still exist
-        Assert.NotNull(store.GetImageById(1));
-        Assert.Null(store.GetImageById(2));
+        Assert.IsNotNull(store.GetImageById(1));
+        Assert.IsNull(store.GetImageById(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void RemoveImage_UpdatesNumberIndex()
     {
         var store = new KgpImageStore();
@@ -134,12 +135,12 @@ public class KgpImageStoreTests
         store.RemoveImage(2);
 
         // After removing image 2, the newest with number 42 is image 1
-        Assert.Same(store.GetImageById(1), store.GetImageByNumber(42));
+        Assert.AreSame(store.GetImageById(1), store.GetImageByNumber(42));
     }
 
     // --- Clear ---
 
-    [Fact]
+    [TestMethod]
     public void Clear_RemovesAll()
     {
         var store = new KgpImageStore();
@@ -148,13 +149,13 @@ public class KgpImageStoreTests
 
         store.Clear();
 
-        Assert.Equal(0, store.ImageCount);
-        Assert.Equal(0, store.TotalSize);
+        Assert.AreEqual(0, store.ImageCount);
+        Assert.AreEqual(0, store.TotalSize);
     }
 
     // --- ID allocation ---
 
-    [Fact]
+    [TestMethod]
     public void AllocateId_ReturnsUniqueIds()
     {
         var store = new KgpImageStore();
@@ -162,41 +163,41 @@ public class KgpImageStoreTests
         var id2 = store.AllocateId();
         var id3 = store.AllocateId();
 
-        Assert.NotEqual(id1, id2);
-        Assert.NotEqual(id2, id3);
-        Assert.True(id1 > 0);
+        Assert.AreNotEqual(id1, id2);
+        Assert.AreNotEqual(id2, id3);
+        Assert.IsTrue(id1 > 0);
     }
 
     // --- TotalSize tracking ---
 
-    [Fact]
+    [TestMethod]
     public void TotalSize_TracksCorrectly()
     {
         var store = new KgpImageStore();
 
         store.StoreImage(CreateImage(1, 2, 2)); // 2*2*4 = 16 bytes
-        Assert.Equal(16, store.TotalSize);
+        Assert.AreEqual(16, store.TotalSize);
 
         store.StoreImage(CreateImage(2, 3, 3)); // 3*3*4 = 36 bytes
-        Assert.Equal(52, store.TotalSize);
+        Assert.AreEqual(52, store.TotalSize);
 
         store.RemoveImage(1);
-        Assert.Equal(36, store.TotalSize);
+        Assert.AreEqual(36, store.TotalSize);
     }
 
-    [Fact]
+    [TestMethod]
     public void TotalSize_ReplacingImage_UpdatesCorrectly()
     {
         var store = new KgpImageStore();
         store.StoreImage(CreateImage(1, 2, 2)); // 16 bytes
         store.StoreImage(CreateImage(1, 3, 3)); // replace with 36 bytes
 
-        Assert.Equal(36, store.TotalSize);
+        Assert.AreEqual(36, store.TotalSize);
     }
 
     // --- Quota management ---
 
-    [Fact]
+    [TestMethod]
     public void StoreImage_ExceedsQuota_EvictsOldest()
     {
         var store = new KgpImageStore(quotaBytes: 32); // 32 bytes quota
@@ -205,15 +206,15 @@ public class KgpImageStoreTests
         store.StoreImage(CreateImage(2, 2, 2)); // 16 bytes, total 32 (at quota)
         store.StoreImage(CreateImage(3, 2, 2)); // 16 bytes, should evict image 1
 
-        Assert.Equal(2, store.ImageCount);
-        Assert.Null(store.GetImageById(1)); // evicted
-        Assert.NotNull(store.GetImageById(2));
-        Assert.NotNull(store.GetImageById(3));
+        Assert.AreEqual(2, store.ImageCount);
+        Assert.IsNull(store.GetImageById(1)); // evicted
+        Assert.IsNotNull(store.GetImageById(2));
+        Assert.IsNotNull(store.GetImageById(3));
     }
 
     // --- Chunked transfers ---
 
-    [Fact]
+    [TestMethod]
     public void ProcessChunk_SingleChunk_ReturnsCompleteImage()
     {
         var store = new KgpImageStore();
@@ -222,38 +223,38 @@ public class KgpImageStoreTests
 
         var result = store.ProcessChunk(cmd, data);
 
-        Assert.NotNull(result);
-        Assert.Equal(5u, result.ImageId);
-        Assert.Equal(data, result.Data);
-        Assert.False(store.IsChunkedTransferInProgress);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(5u, result.ImageId);
+        TestSeq.AreEqual(data, result.Data);
+        Assert.IsFalse(store.IsChunkedTransferInProgress);
     }
 
-    [Fact]
+    [TestMethod]
     public void ProcessChunk_MultipleChunks_AssemblesCorrectly()
     {
         var store = new KgpImageStore();
 
         var cmd1 = new KgpCommand { Width = 2, Height = 2, Format = KgpFormat.Rgba32, ImageId = 1, MoreData = 1 };
         var result1 = store.ProcessChunk(cmd1, new byte[] { 1, 2, 3, 4 });
-        Assert.Null(result1);
-        Assert.True(store.IsChunkedTransferInProgress);
+        Assert.IsNull(result1);
+        Assert.IsTrue(store.IsChunkedTransferInProgress);
 
         var cmd2 = new KgpCommand { MoreData = 1 };
         var result2 = store.ProcessChunk(cmd2, new byte[] { 5, 6, 7, 8 });
-        Assert.Null(result2);
+        Assert.IsNull(result2);
 
         var cmd3 = new KgpCommand { MoreData = 0 };
         var result3 = store.ProcessChunk(cmd3, new byte[] { 9, 10, 11, 12 });
-        Assert.NotNull(result3);
+        Assert.IsNotNull(result3);
 
-        Assert.Equal(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 }, result3.Data);
-        Assert.Equal(1u, result3.ImageId);
-        Assert.Equal(2u, result3.Width);
-        Assert.Equal(2u, result3.Height);
-        Assert.False(store.IsChunkedTransferInProgress);
+        TestSeq.AreEqual(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 }, result3.Data);
+        Assert.AreEqual(1u, result3.ImageId);
+        Assert.AreEqual(2u, result3.Width);
+        Assert.AreEqual(2u, result3.Height);
+        Assert.IsFalse(store.IsChunkedTransferInProgress);
     }
 
-    [Fact]
+    [TestMethod]
     public void ProcessChunk_NoImageId_AllocatesId()
     {
         var store = new KgpImageStore();
@@ -261,11 +262,11 @@ public class KgpImageStoreTests
 
         var result = store.ProcessChunk(cmd, new byte[] { 1, 2, 3, 4 });
 
-        Assert.NotNull(result);
-        Assert.True(result.ImageId > 0);
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.ImageId > 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void ProcessChunk_WithImageNumber_PreservesNumber()
     {
         var store = new KgpImageStore();
@@ -273,23 +274,23 @@ public class KgpImageStoreTests
 
         var result = store.ProcessChunk(cmd, new byte[] { 1, 2, 3, 4 });
 
-        Assert.NotNull(result);
-        Assert.Equal(93u, result.ImageNumber);
+        Assert.IsNotNull(result);
+        Assert.AreEqual(93u, result.ImageNumber);
     }
 
-    [Fact]
+    [TestMethod]
     public void AbortChunkedTransfer_ClearsState()
     {
         var store = new KgpImageStore();
         var cmd = new KgpCommand { Width = 2, Height = 2, Format = KgpFormat.Rgba32, ImageId = 1, MoreData = 1 };
         store.ProcessChunk(cmd, new byte[] { 1, 2, 3, 4 });
 
-        Assert.True(store.IsChunkedTransferInProgress);
+        Assert.IsTrue(store.IsChunkedTransferInProgress);
         store.AbortChunkedTransfer();
-        Assert.False(store.IsChunkedTransferInProgress);
+        Assert.IsFalse(store.IsChunkedTransferInProgress);
     }
 
-    [Fact]
+    [TestMethod]
     public void Clear_AbortsChunkedTransfer()
     {
         var store = new KgpImageStore();
@@ -297,77 +298,77 @@ public class KgpImageStoreTests
         store.ProcessChunk(cmd, new byte[] { 1, 2, 3, 4 });
 
         store.Clear();
-        Assert.False(store.IsChunkedTransferInProgress);
+        Assert.IsFalse(store.IsChunkedTransferInProgress);
     }
 
     // --- KgpImageData validation ---
 
-    [Fact]
+    [TestMethod]
     public void KgpImageData_IsDataSizeValid_CorrectSizeRgba()
     {
         var data = new byte[4]; // 1x1 RGBA = 4 bytes
         var image = new KgpImageData(1, 0, data, 1, 1, KgpFormat.Rgba32);
-        Assert.True(image.IsDataSizeValid());
+        Assert.IsTrue(image.IsDataSizeValid());
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpImageData_IsDataSizeValid_CorrectSizeRgb()
     {
         var data = new byte[3]; // 1x1 RGB = 3 bytes
         var image = new KgpImageData(1, 0, data, 1, 1, KgpFormat.Rgb24);
-        Assert.True(image.IsDataSizeValid());
+        Assert.IsTrue(image.IsDataSizeValid());
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpImageData_IsDataSizeValid_WrongSize()
     {
         var data = new byte[2]; // Too small for 1x1 RGBA
         var image = new KgpImageData(1, 0, data, 1, 1, KgpFormat.Rgba32);
-        Assert.False(image.IsDataSizeValid());
+        Assert.IsFalse(image.IsDataSizeValid());
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpImageData_IsDataSizeValid_PngAlwaysValidIfNonEmpty()
     {
         var data = new byte[] { 0x89, 0x50, 0x4E, 0x47 }; // PNG header bytes
         var image = new KgpImageData(1, 0, data, 0, 0, KgpFormat.Png);
-        Assert.True(image.IsDataSizeValid());
+        Assert.IsTrue(image.IsDataSizeValid());
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpImageData_Is4ByteAligned_Rgba()
     {
         var image = new KgpImageData(1, 0, new byte[4], 1, 1, KgpFormat.Rgba32);
-        Assert.True(image.Is4ByteAligned);
+        Assert.IsTrue(image.Is4ByteAligned);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpImageData_Is4ByteAligned_Rgb()
     {
         var image = new KgpImageData(1, 0, new byte[3], 1, 1, KgpFormat.Rgb24);
-        Assert.False(image.Is4ByteAligned);
+        Assert.IsFalse(image.Is4ByteAligned);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpImageData_ContentHash_DifferentData_DifferentHash()
     {
         var image1 = new KgpImageData(1, 0, new byte[] { 1, 2, 3, 4 }, 1, 1, KgpFormat.Rgba32);
         var image2 = new KgpImageData(2, 0, new byte[] { 5, 6, 7, 8 }, 1, 1, KgpFormat.Rgba32);
-        Assert.NotEqual(image1.ContentHash, image2.ContentHash);
+        Assert.AreNotEqual(image1.ContentHash, image2.ContentHash);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpImageData_ContentHash_SameData_SameHash()
     {
         var data = new byte[] { 1, 2, 3, 4 };
         var image1 = new KgpImageData(1, 0, (byte[])data.Clone(), 1, 1, KgpFormat.Rgba32);
         var image2 = new KgpImageData(2, 0, (byte[])data.Clone(), 1, 1, KgpFormat.Rgba32);
-        Assert.Equal(image1.ContentHash, image2.ContentHash);
+        TestSeq.AreEqual(image1.ContentHash, image2.ContentHash);
     }
 
     // --- Concurrent access ---
 
-    [Fact]
+    [TestMethod]
     public void ConcurrentAccess_DoesNotThrow()
     {
         var store = new KgpImageStore();

--- a/tests/Hex1b.Tests/KgpIntegrationTests.cs
+++ b/tests/Hex1b.Tests/KgpIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Hex1b.Tests;
 /// End-to-end integration tests for KGP support through the full Hex1bApp pipeline:
 /// KgpImageWidget → Hex1bApp → render → Hex1bTerminal → snapshot → SVG verification.
 /// </summary>
+[TestClass]
 public class KgpIntegrationTests
 {
     private static byte[] CreateTestImage(int width = 4, int height = 4)
@@ -38,7 +39,7 @@ public class KgpIntegrationTests
         return imageId == 0 ? 1u : imageId;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_KgpImageWidget_RendersToTerminal()
     {
         using var workload = new Hex1bAppWorkloadAdapter(new TerminalCapabilities
@@ -78,10 +79,10 @@ public class KgpIntegrationTests
         await runTask;
 
         // KGP-capable terminal should have processed the image
-        Assert.NotNull(snapshot);
+        Assert.IsNotNull(snapshot);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_KgpImageWidget_FallbackWhenNoKgpSupport()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -114,10 +115,10 @@ public class KgpIntegrationTests
 
         await runTask;
 
-        Assert.True(snapshot.ContainsText("[fallback]"));
+        Assert.IsTrue(snapshot.ContainsText("[fallback]"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_KgpInVStack_RendersWithOtherWidgets()
     {
         using var workload = new Hex1bAppWorkloadAdapter(new TerminalCapabilities
@@ -159,11 +160,11 @@ public class KgpIntegrationTests
 
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Title Line"));
-        Assert.True(snapshot.ContainsText("Footer Line"));
+        Assert.IsTrue(snapshot.ContainsText("Title Line"));
+        Assert.IsTrue(snapshot.ContainsText("Footer Line"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_KgpBelowText_RendersToTerminal()
     {
         using var workload = new Hex1bAppWorkloadAdapter(new TerminalCapabilities
@@ -203,10 +204,10 @@ public class KgpIntegrationTests
         await runTask;
 
         // KGP rendering through Hex1bApp confirmed by clean exit
-        Assert.NotNull(snapshot);
+        Assert.IsNotNull(snapshot);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_KgpAboveText_RendersToTerminal()
     {
         using var workload = new Hex1bAppWorkloadAdapter(new TerminalCapabilities
@@ -245,10 +246,10 @@ public class KgpIntegrationTests
 
         await runTask;
 
-        Assert.NotNull(snapshot);
+        Assert.IsNotNull(snapshot);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DirectRender_KgpBelowText_SvgContainsImage()
     {
         // Direct render path (non-surface) — KGP sequences go directly to terminal
@@ -290,7 +291,7 @@ public class KgpIntegrationTests
         Assert.Contains("<image", svg);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_MultipleKgpImages_AllRendered()
     {
         using var workload = new Hex1bAppWorkloadAdapter(new TerminalCapabilities
@@ -333,10 +334,10 @@ public class KgpIntegrationTests
         await runTask;
 
         // Both images should produce KGP placements in the terminal
-        Assert.NotNull(snapshot);
+        Assert.IsNotNull(snapshot);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_KgpImageWidget_RehydratesAfterResizeWhenTerminalLosesKgpState()
     {
         using var workload = new Hex1bAppWorkloadAdapter(new TerminalCapabilities
@@ -372,15 +373,15 @@ public class KgpIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         var placementsBefore = terminal.KgpPlacements;
-        Assert.NotEmpty(placementsBefore);
+        Assert.IsNotEmpty(placementsBefore);
         var initialImageId = placementsBefore.Select(p => p.ImageId).Distinct().Single();
 
         // Kitty-family terminals can invalidate both placements and image data on resize.
         // Clear the terminal-side KGP state first so this test proves the app fully rehydrates it.
         terminal.Resize(60, 15);
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=d,d=A,q=2"));
-        Assert.Empty(terminal.KgpPlacements);
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
 
         await workload.ResizeAsync(60, 15, TestContext.Current.CancellationToken);
 
@@ -394,16 +395,16 @@ public class KgpIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         var placementsAfter = terminal.KgpPlacements;
-        Assert.NotEmpty(placementsAfter);
+        Assert.IsNotEmpty(placementsAfter);
         var retransmittedImageId = placementsAfter.Select(p => p.ImageId).Distinct().Single();
-        Assert.NotEqual(initialImageId, retransmittedImageId);
+        Assert.AreNotEqual(initialImageId, retransmittedImageId);
 
         // Stop the app
         app.RequestStop();
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_KgpImageInVStack_SurvivesResize()
     {
         using var workload = new Hex1bAppWorkloadAdapter(new TerminalCapabilities
@@ -443,14 +444,14 @@ public class KgpIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         var placementsBefore = terminal.KgpPlacements;
-        Assert.NotEmpty(placementsBefore);
+        Assert.IsNotEmpty(placementsBefore);
         var initialImageId = placementsBefore.Select(p => p.ImageId).Distinct().Single();
 
         // Simulate a Kitty-style resize that invalidates terminal-side KGP state.
         terminal.Resize(80, 25);
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=d,d=A,q=2"));
-        Assert.Empty(terminal.KgpPlacements);
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
         await workload.ResizeAsync(80, 25, TestContext.Current.CancellationToken);
 
         await new Hex1bTerminalInputSequenceBuilder()
@@ -463,16 +464,16 @@ public class KgpIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         var placementsAfter = terminal.KgpPlacements;
-        Assert.NotEmpty(placementsAfter);
+        Assert.IsNotEmpty(placementsAfter);
         var retransmittedImageId = placementsAfter.Select(p => p.ImageId).Distinct().Single();
-        Assert.NotEqual(initialImageId, retransmittedImageId);
+        Assert.AreNotEqual(initialImageId, retransmittedImageId);
 
         // Stop the app
         app.RequestStop();
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_KgpImageWidget_MultipleResizeEventsBeforeRetransmit_OnlyBumpsImageEpochOnce()
     {
         using var workload = new Hex1bAppWorkloadAdapter(new TerminalCapabilities
@@ -508,18 +509,18 @@ public class KgpIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         var initialImageId = terminal.KgpPlacements.Select(p => p.ImageId).Distinct().Single();
-        Assert.Equal(ComputeExpectedImageId(imageData, 0), initialImageId);
+        Assert.AreEqual(ComputeExpectedImageId(imageData, 0), initialImageId);
 
         terminal.Resize(60, 15);
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=d,d=A,q=2"));
-        Assert.Empty(terminal.KgpPlacements);
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
         await workload.ResizeAsync(60, 15, TestContext.Current.CancellationToken);
 
         terminal.Resize(60, 14);
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=d,d=A,q=2"));
-        Assert.Empty(terminal.KgpPlacements);
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
         await workload.ResizeAsync(60, 14, TestContext.Current.CancellationToken);
 
         await new Hex1bTerminalInputSequenceBuilder()
@@ -533,13 +534,13 @@ public class KgpIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         var finalImageId = terminal.KgpPlacements.Select(p => p.ImageId).Distinct().Single();
-        Assert.Equal(ComputeExpectedImageId(imageData, 1), finalImageId);
+        Assert.AreEqual(ComputeExpectedImageId(imageData, 1), finalImageId);
 
         app.RequestStop();
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task App_KgpImageInVStack_ClipsToSurfaceBounds()
     {
         // Simulate a letterbox terminal where the KGP image would overflow
@@ -583,15 +584,14 @@ public class KgpIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         var placements = terminal.KgpPlacements;
-        Assert.NotEmpty(placements);
+        Assert.IsNotEmpty(placements);
 
         // Verify the placement doesn't overflow the terminal bounds.
         // The image should be clipped: it starts at row 3 (0-indexed) and the
         // bottom text is at row 7, so the image can be at most 4 rows tall.
         foreach (var p in placements)
         {
-            Assert.True(p.Row + (int)p.DisplayRows <= 8,
-                $"KGP placement at row {p.Row} with {p.DisplayRows} rows overflows terminal height 8 (bottom={p.Row + (int)p.DisplayRows})");
+            Assert.IsTrue(p.Row + (int)p.DisplayRows <= 8, $"KGP placement at row {p.Row} with {p.DisplayRows} rows overflows terminal height 8 (bottom={p.Row + (int)p.DisplayRows})");
         }
 
         app.RequestStop();

--- a/tests/Hex1b.Tests/KgpOcclusionIntegrationTests.cs
+++ b/tests/Hex1b.Tests/KgpOcclusionIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Hex1b.Tests;
 /// Integration tests for KGP occlusion through the full Hex1bApp pipeline:
 /// widget tree → render → registry → solver → tracker → terminal placement verification.
 /// </summary>
+[TestClass]
 public class KgpOcclusionIntegrationTests
 {
     private static byte[] CreateTestImage(int width = 8, int height = 8)
@@ -42,7 +43,7 @@ public class KgpOcclusionIntegrationTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize(escapeSequence));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WindowPanel_KgpBackground_NoWindows_FullImagePlaced()
     {
         using var workload = new Hex1bAppWorkloadAdapter(new TerminalCapabilities
@@ -85,12 +86,11 @@ public class KgpOcclusionIntegrationTests
         await runTask;
 
         // With no windows, the KGP image should be fully visible (1 placement)
-        Assert.NotNull(snapshot);
-        Assert.True(snapshot.KgpPlacements.Count >= 1,
-            $"Expected at least 1 KGP placement, got {snapshot.KgpPlacements.Count}");
+        Assert.IsNotNull(snapshot);
+        Assert.IsTrue(snapshot.KgpPlacements.Count >= 1, $"Expected at least 1 KGP placement, got {snapshot.KgpPlacements.Count}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WindowPanel_TextWindowOverKgpBackground_ImageShredded()
     {
         using var workload = new Hex1bAppWorkloadAdapter(new TerminalCapabilities
@@ -149,16 +149,15 @@ public class KgpOcclusionIntegrationTests
 
         await runTask;
 
-        Assert.True(windowOpened, "Window should have been opened");
-        Assert.NotNull(snapshot);
+        Assert.IsTrue(windowOpened, "Window should have been opened");
+        Assert.IsNotNull(snapshot);
 
         // With an occluding window, the image should be shredded into multiple placements
         // (up to 4 strips: top, bottom, left, right of the occluder)
-        Assert.True(snapshot.KgpPlacements.Count >= 2,
-            $"Expected at least 2 KGP placements (image shredded around window), got {snapshot.KgpPlacements.Count}");
+        Assert.IsTrue(snapshot.KgpPlacements.Count >= 2, $"Expected at least 2 KGP placements (image shredded around window), got {snapshot.KgpPlacements.Count}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WindowPanel_KgpInsideWindow_PlacedCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter(new TerminalCapabilities
@@ -217,15 +216,14 @@ public class KgpOcclusionIntegrationTests
 
         await runTask;
 
-        Assert.True(windowOpened, "Window should have been opened");
-        Assert.NotNull(snapshot);
+        Assert.IsTrue(windowOpened, "Window should have been opened");
+        Assert.IsNotNull(snapshot);
 
         // KGP image inside the window should have at least one placement
-        Assert.True(snapshot.KgpPlacements.Count >= 1,
-            $"Expected at least 1 KGP placement for image inside window, got {snapshot.KgpPlacements.Count}");
+        Assert.IsTrue(snapshot.KgpPlacements.Count >= 1, $"Expected at least 1 KGP placement for image inside window, got {snapshot.KgpPlacements.Count}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WindowPanel_MultipleKgpImages_BothRendered()
     {
         using var workload = new Hex1bAppWorkloadAdapter(new TerminalCapabilities
@@ -271,15 +269,14 @@ public class KgpOcclusionIntegrationTests
 
         await runTask;
 
-        Assert.NotNull(snapshot);
+        Assert.IsNotNull(snapshot);
 
         // Both images should have placements
         var imageIds = snapshot.KgpPlacements.Select(p => p.ImageId).Distinct().ToList();
-        Assert.True(imageIds.Count >= 2,
-            $"Expected at least 2 distinct image IDs, got {imageIds.Count}: [{string.Join(", ", imageIds)}]");
+        Assert.IsTrue(imageIds.Count >= 2, $"Expected at least 2 distinct image IDs, got {imageIds.Count}: [{string.Join(", ", imageIds)}]");
     }
 
-    [Fact]
+    [TestMethod]
     public void OcclusionSolver_FullPipeline_RegistryToFragments()
     {
         // Unit-level pipeline test: registry → solver → tracker → commands
@@ -290,20 +287,19 @@ public class KgpOcclusionIntegrationTests
         registry.RegisterImage(imageData, 5, 2);
         var fragments = KgpOcclusionSolver.ComputeFragments(registry);
 
-        Assert.Single(fragments);
-        Assert.Equal(42u, fragments[0].ImageId);
-        Assert.Equal(5, fragments[0].AbsoluteX);
-        Assert.Equal(2, fragments[0].AbsoluteY);
-        Assert.Equal(20, fragments[0].CellWidth);
-        Assert.Equal(10, fragments[0].CellHeight);
+        TestSeq.Single(fragments);
+        Assert.AreEqual(42u, fragments[0].ImageId);
+        Assert.AreEqual(5, fragments[0].AbsoluteX);
+        Assert.AreEqual(2, fragments[0].AbsoluteY);
+        Assert.AreEqual(20, fragments[0].CellWidth);
+        Assert.AreEqual(10, fragments[0].CellHeight);
 
         // Feed to tracker
         var tracker = new KgpPlacementTracker();
         var (before1, after1) = tracker.GenerateCommands(fragments);
 
         // Should have transmit + placement commands
-        Assert.True(before1.Count > 0 || after1.Count > 0,
-            "Frame 1 should produce transmit + place commands");
+        Assert.IsTrue(before1.Count > 0 || after1.Count > 0, "Frame 1 should produce transmit + place commands");
 
         // Frame 2: Same image with an occluder — should produce multiple fragments
         registry.Clear();
@@ -314,18 +310,15 @@ public class KgpOcclusionIntegrationTests
         var fragments2 = KgpOcclusionSolver.ComputeFragments(registry);
 
         // Occluder partially overlaps image — should produce multiple fragments
-        Assert.True(fragments2.Count > 1,
-            $"Expected multiple fragments with partial occlusion, got {fragments2.Count}");
+        Assert.IsTrue(fragments2.Count > 1, $"Expected multiple fragments with partial occlusion, got {fragments2.Count}");
 
         // Total visible area should be less than original
         var totalVisibleCells = fragments2.Sum(f => f.CellWidth * f.CellHeight);
-        Assert.True(totalVisibleCells < 20 * 10,
-            $"Visible area ({totalVisibleCells}) should be less than full image (200)");
+        Assert.IsTrue(totalVisibleCells < 20 * 10, $"Visible area ({totalVisibleCells}) should be less than full image (200)");
 
         // Feed to tracker — should produce delete + re-place commands
         var (before2, after2) = tracker.GenerateCommands(fragments2);
-        Assert.True(before2.Count > 0 || after2.Count > 0,
-            "Frame 2 should produce delete + re-place commands for changed fragments");
+        Assert.IsTrue(before2.Count > 0 || after2.Count > 0, "Frame 2 should produce delete + re-place commands for changed fragments");
 
         // Frame 3: Same fragments — no changes needed
         registry.Clear();
@@ -336,11 +329,11 @@ public class KgpOcclusionIntegrationTests
         var fragments3 = KgpOcclusionSolver.ComputeFragments(registry);
         var (before3, after3) = tracker.GenerateCommands(fragments3);
 
-        Assert.Empty(before3);
-        Assert.Empty(after3);
+        Assert.IsEmpty(before3);
+        Assert.IsEmpty(after3);
     }
 
-    [Fact]
+    [TestMethod]
     public void OcclusionSolver_ImageFullyCovered_NoFragments()
     {
         var imageData = MakeKgpData(10, 10, 5, 50, 50);
@@ -352,7 +345,7 @@ public class KgpOcclusionIntegrationTests
         registry.RegisterOccluder(0, 0, 50, 50);
 
         var fragments = KgpOcclusionSolver.ComputeFragments(registry);
-        Assert.Empty(fragments);
+        Assert.IsEmpty(fragments);
 
         // Tracker should delete the previously placed image
         var tracker = new KgpPlacementTracker();
@@ -366,11 +359,10 @@ public class KgpOcclusionIntegrationTests
 
         // Now send empty fragments — should produce delete command
         var (before, after) = tracker.GenerateCommands(fragments);
-        Assert.True(before.Count > 0,
-            "Fully occluded image should produce delete command");
+        Assert.IsTrue(before.Count > 0, "Fully occluded image should produce delete command");
     }
 
-    [Fact]
+    [TestMethod]
     public void OcclusionSolver_SameLayerImages_NoOcclusion()
     {
         var data1 = MakeKgpData(1, 10, 5, 50, 50);
@@ -385,12 +377,12 @@ public class KgpOcclusionIntegrationTests
         var fragments = KgpOcclusionSolver.ComputeFragments(registry);
 
         // Same layer = no occlusion, each image gets exactly 1 fragment
-        Assert.Equal(2, fragments.Count);
-        Assert.Contains(fragments, f => f.ImageId == 1);
-        Assert.Contains(fragments, f => f.ImageId == 2);
+        Assert.AreEqual(2, fragments.Count);
+        Assert.IsTrue(fragments.Any(f => f.ImageId == 1));
+        Assert.IsTrue(fragments.Any(f => f.ImageId == 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void OcclusionSolver_ClipCoordinates_MappedCorrectly()
     {
         // Image: 200x100 pixels displayed in 20x10 cells
@@ -405,48 +397,48 @@ public class KgpOcclusionIntegrationTests
         var fragments = KgpOcclusionSolver.ComputeFragments(registry);
 
         // Should produce 4 strips
-        Assert.Equal(4, fragments.Count);
+        Assert.AreEqual(4, fragments.Count);
 
         // Top strip: (0,0) 20x3 → clip (0,0) 200x30
         var top = fragments.First(f => f.AbsoluteY == 0);
-        Assert.Equal(0, top.AbsoluteX);
-        Assert.Equal(20, top.CellWidth);
-        Assert.Equal(3, top.CellHeight);
-        Assert.Equal(0, top.ClipX);
-        Assert.Equal(0, top.ClipY);
-        Assert.Equal(200, top.ClipW);
-        Assert.Equal(30, top.ClipH);
+        Assert.AreEqual(0, top.AbsoluteX);
+        Assert.AreEqual(20, top.CellWidth);
+        Assert.AreEqual(3, top.CellHeight);
+        Assert.AreEqual(0, top.ClipX);
+        Assert.AreEqual(0, top.ClipY);
+        Assert.AreEqual(200, top.ClipW);
+        Assert.AreEqual(30, top.ClipH);
 
         // Bottom strip: (0,7) 20x3 → clip (0,70) 200x30
         var bottom = fragments.First(f => f.AbsoluteY == 7);
-        Assert.Equal(0, bottom.AbsoluteX);
-        Assert.Equal(20, bottom.CellWidth);
-        Assert.Equal(3, bottom.CellHeight);
-        Assert.Equal(0, bottom.ClipX);
-        Assert.Equal(70, bottom.ClipY);
-        Assert.Equal(200, bottom.ClipW);
-        Assert.Equal(30, bottom.ClipH);
+        Assert.AreEqual(0, bottom.AbsoluteX);
+        Assert.AreEqual(20, bottom.CellWidth);
+        Assert.AreEqual(3, bottom.CellHeight);
+        Assert.AreEqual(0, bottom.ClipX);
+        Assert.AreEqual(70, bottom.ClipY);
+        Assert.AreEqual(200, bottom.ClipW);
+        Assert.AreEqual(30, bottom.ClipH);
 
         // Left strip: (0,3) 5x4 → clip (0,30) 50x40
         var left = fragments.First(f => f.AbsoluteX == 0 && f.AbsoluteY == 3);
-        Assert.Equal(5, left.CellWidth);
-        Assert.Equal(4, left.CellHeight);
-        Assert.Equal(0, left.ClipX);
-        Assert.Equal(30, left.ClipY);
-        Assert.Equal(50, left.ClipW);
-        Assert.Equal(40, left.ClipH);
+        Assert.AreEqual(5, left.CellWidth);
+        Assert.AreEqual(4, left.CellHeight);
+        Assert.AreEqual(0, left.ClipX);
+        Assert.AreEqual(30, left.ClipY);
+        Assert.AreEqual(50, left.ClipW);
+        Assert.AreEqual(40, left.ClipH);
 
         // Right strip: (15,3) 5x4 → clip (150,30) 50x40
         var right = fragments.First(f => f.AbsoluteX == 15 && f.AbsoluteY == 3);
-        Assert.Equal(5, right.CellWidth);
-        Assert.Equal(4, right.CellHeight);
-        Assert.Equal(150, right.ClipX);
-        Assert.Equal(30, right.ClipY);
-        Assert.Equal(50, right.ClipW);
-        Assert.Equal(40, right.ClipH);
+        Assert.AreEqual(5, right.CellWidth);
+        Assert.AreEqual(4, right.CellHeight);
+        Assert.AreEqual(150, right.ClipX);
+        Assert.AreEqual(30, right.ClipY);
+        Assert.AreEqual(50, right.ClipW);
+        Assert.AreEqual(40, right.ClipH);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MenuPopup_DoesNotOccludeBackgroundKgpImage()
     {
         using var workload = new Hex1bAppWorkloadAdapter(new TerminalCapabilities
@@ -495,9 +487,8 @@ public class KgpOcclusionIntegrationTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.NotNull(beforeMenu);
-        Assert.True(beforeMenu.KgpPlacements.Count >= 1,
-            $"Expected KGP placement before menu open, got {beforeMenu.KgpPlacements.Count}");
+        Assert.IsNotNull(beforeMenu);
+        Assert.IsTrue(beforeMenu.KgpPlacements.Count >= 1, $"Expected KGP placement before menu open, got {beforeMenu.KgpPlacements.Count}");
         var placementsBeforeMenu = beforeMenu.KgpPlacements.Count;
 
         // Open the File menu via Alt+F, then capture — image should still be visible
@@ -513,17 +504,15 @@ public class KgpOcclusionIntegrationTests
 
         await runTask;
 
-        Assert.NotNull(afterMenu);
-        Assert.True(afterMenu.KgpPlacements.Count >= 1,
-            $"Expected KGP placement with menu open, got {afterMenu.KgpPlacements.Count}");
+        Assert.IsNotNull(afterMenu);
+        Assert.IsTrue(afterMenu.KgpPlacements.Count >= 1, $"Expected KGP placement with menu open, got {afterMenu.KgpPlacements.Count}");
 
         // The menu popup should occlude part of the image, causing the occlusion
         // solver to slice it into more fragments than the original single placement.
-        Assert.True(afterMenu.KgpPlacements.Count > placementsBeforeMenu,
-            $"Expected image to be sliced by menu occluder: before={placementsBeforeMenu}, after={afterMenu.KgpPlacements.Count}");
+        Assert.IsTrue(afterMenu.KgpPlacements.Count > placementsBeforeMenu, $"Expected image to be sliced by menu occluder: before={placementsBeforeMenu}, after={afterMenu.KgpPlacements.Count}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WindowPanel_KgpWindowDragThenResize_WindowSurvives()
     {
         using var workload = new Hex1bAppWorkloadAdapter(new TerminalCapabilities
@@ -581,10 +570,10 @@ public class KgpOcclusionIntegrationTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(windowOpened, "Window should have been opened");
-        Assert.NotNull(beforeDrag);
-        Assert.True(beforeDrag.ContainsText("DragMe"), "Window title should be visible before drag");
-        Assert.True(beforeDrag.ContainsText("KGP-Content"), "Window content should be visible before drag");
+        Assert.IsTrue(windowOpened, "Window should have been opened");
+        Assert.IsNotNull(beforeDrag);
+        Assert.IsTrue(beforeDrag.ContainsText("DragMe"), "Window title should be visible before drag");
+        Assert.IsTrue(beforeDrag.ContainsText("KGP-Content"), "Window content should be visible before drag");
 
         // Drag the window title bar from center to a new position (move right 5, down 3)
         // Window is centered at roughly (20, 6) on 60x20, title bar is first row
@@ -595,17 +584,17 @@ public class KgpOcclusionIntegrationTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.NotNull(afterDrag);
-        Assert.True(afterDrag.ContainsText("DragMe"), "Window title should be visible after drag");
-        Assert.True(afterDrag.ContainsText("KGP-Content"), "Window content should be visible after drag");
+        Assert.IsNotNull(afterDrag);
+        Assert.IsTrue(afterDrag.ContainsText("DragMe"), "Window title should be visible after drag");
+        Assert.IsTrue(afterDrag.ContainsText("KGP-Content"), "Window content should be visible after drag");
         var imageIdBeforeResize = afterDrag.KgpPlacements.Select(p => p.ImageId).Distinct().Single();
 
         // Now resize the terminal by 1 row. Simulate a Kitty-style resize that
         // invalidates terminal-side KGP state so the app must fully rehydrate it.
         terminal.Resize(60, 19);
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=d,d=A,q=2"));
-        Assert.Empty(terminal.KgpPlacements);
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
         await workload.ResizeAsync(60, 19, TestContext.Current.CancellationToken);
 
         var afterResize = await new Hex1bTerminalInputSequenceBuilder()
@@ -621,25 +610,22 @@ public class KgpOcclusionIntegrationTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.NotNull(afterResize);
+        Assert.IsNotNull(afterResize);
 
         // The window should still be visible after resize!
-        Assert.True(afterResize.ContainsText("DragMe"),
-            $"Window title 'DragMe' should be visible after drag+resize. Screen content:\n{afterResize.GetText()}");
-        Assert.True(afterResize.ContainsText("KGP-Content"),
-            $"Window content 'KGP-Content' should be visible after drag+resize. Screen content:\n{afterResize.GetText()}");
+        Assert.IsTrue(afterResize.ContainsText("DragMe"), $"Window title 'DragMe' should be visible after drag+resize. Screen content:\n{afterResize.GetText()}");
+        Assert.IsTrue(afterResize.ContainsText("KGP-Content"), $"Window content 'KGP-Content' should be visible after drag+resize. Screen content:\n{afterResize.GetText()}");
 
         // KGP placements should exist after resize
-        Assert.True(afterResize.KgpPlacements.Count >= 1,
-            $"Expected KGP placement after drag+resize, got {afterResize.KgpPlacements.Count}");
+        Assert.IsTrue(afterResize.KgpPlacements.Count >= 1, $"Expected KGP placement after drag+resize, got {afterResize.KgpPlacements.Count}");
         var imageIdAfterResize = afterResize.KgpPlacements.Select(p => p.ImageId).Distinct().Single();
-        Assert.NotEqual(imageIdBeforeResize, imageIdAfterResize);
+        Assert.AreNotEqual(imageIdBeforeResize, imageIdAfterResize);
 
         app.RequestStop();
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WindowPanel_NonKgpWindowDragThenResize_WindowSurvives()
     {
         // Control test: same as above but without KGP image to isolate whether
@@ -691,7 +677,7 @@ public class KgpOcclusionIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(windowOpened);
+        Assert.IsTrue(windowOpened);
 
         // Drag then resize
         await new Hex1bTerminalInputSequenceBuilder()
@@ -710,17 +696,15 @@ public class KgpOcclusionIntegrationTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.NotNull(afterResize);
-        Assert.True(afterResize.ContainsText("DragMe"),
-            $"Window title should survive drag+resize (no KGP). Screen:\n{afterResize.GetText()}");
-        Assert.True(afterResize.ContainsText("PlainContent"),
-            $"Window content should survive drag+resize (no KGP). Screen:\n{afterResize.GetText()}");
+        Assert.IsNotNull(afterResize);
+        Assert.IsTrue(afterResize.ContainsText("DragMe"), $"Window title should survive drag+resize (no KGP). Screen:\n{afterResize.GetText()}");
+        Assert.IsTrue(afterResize.ContainsText("PlainContent"), $"Window content should survive drag+resize (no KGP). Screen:\n{afterResize.GetText()}");
 
         app.RequestStop();
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WindowPanel_KgpWindowDragCloseReopen_WindowRendersAgain()
     {
         using var workload = new Hex1bAppWorkloadAdapter(new TerminalCapabilities
@@ -806,9 +790,9 @@ public class KgpOcclusionIntegrationTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(1, openCount);
-        Assert.NotNull(initial);
-        Assert.True(initial.KgpPlacements.Count >= 1, "Expected KGP placement after initial open.");
+        Assert.AreEqual(1, openCount);
+        Assert.IsNotNull(initial);
+        Assert.IsTrue(initial.KgpPlacements.Count >= 1, "Expected KGP placement after initial open.");
 
         var afterDrag = await new Hex1bTerminalInputSequenceBuilder()
             .Drag(30, 7, 35, 10)
@@ -819,8 +803,8 @@ public class KgpOcclusionIntegrationTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.NotNull(afterDrag);
-        Assert.True(afterDrag.KgpPlacements.Count >= 1, "Expected KGP placement after drag.");
+        Assert.IsNotNull(afterDrag);
+        Assert.IsTrue(afterDrag.KgpPlacements.Count >= 1, "Expected KGP placement after drag.");
 
         var afterClose = await new Hex1bTerminalInputSequenceBuilder()
             .Key(Hex1bKey.X, Hex1bModifiers.Control)
@@ -832,10 +816,10 @@ public class KgpOcclusionIntegrationTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(1, closeCount);
-        Assert.NotNull(afterClose);
-        Assert.False(afterClose.ContainsText("DragMe"));
-        Assert.Empty(afterClose.KgpPlacements);
+        Assert.AreEqual(1, closeCount);
+        Assert.IsNotNull(afterClose);
+        Assert.IsFalse(afterClose.ContainsText("DragMe"));
+        Assert.IsEmpty(afterClose.KgpPlacements);
 
         var afterReopen = await new Hex1bTerminalInputSequenceBuilder()
             .Key(Hex1bKey.O, Hex1bModifiers.Control)
@@ -852,16 +836,15 @@ public class KgpOcclusionIntegrationTests
 
         await runTask;
 
-        Assert.Equal(2, openCount);
-        Assert.Equal(1, closeCount);
-        Assert.NotNull(afterReopen);
-        Assert.True(afterReopen.ContainsText("DragMe"));
-        Assert.True(afterReopen.ContainsText("KGP-Content"));
-        Assert.True(afterReopen.KgpPlacements.Count >= 1,
-            $"Expected KGP placement after reopen, got {afterReopen.KgpPlacements.Count}");
+        Assert.AreEqual(2, openCount);
+        Assert.AreEqual(1, closeCount);
+        Assert.IsNotNull(afterReopen);
+        Assert.IsTrue(afterReopen.ContainsText("DragMe"));
+        Assert.IsTrue(afterReopen.ContainsText("KGP-Content"));
+        Assert.IsTrue(afterReopen.KgpPlacements.Count >= 1, $"Expected KGP placement after reopen, got {afterReopen.KgpPlacements.Count}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ResizeFrame_WithKgp_DeletesPlacementsBeforeClear_ThenRetransmitsOnFollowUpFrame()
     {
         using var workload = new Hex1bAppWorkloadAdapter(new TerminalCapabilities
@@ -927,13 +910,13 @@ public class KgpOcclusionIntegrationTests
             new[] { "\x1b_Ga=t,", "\x1b_Ga=p,", $"\x1b_Ga=d,d=I,i={initialImageId},q=2\x1b\\" },
             TestContext.Current.CancellationToken);
 
-        Assert.Equal("\x1b_Ga=d,d=a,q=2\x1b\\", deleteText);
-        Assert.Equal("\x1b[0m\x1b[2J", clearText);
+        Assert.AreEqual("\x1b_Ga=d,d=a,q=2\x1b\\", deleteText);
+        Assert.AreEqual("\x1b[0m\x1b[2J", clearText);
         Assert.DoesNotContain("\x1b_Ga=d,d=i,", afterClearText);
         Assert.Contains("\x1b_Ga=t,", afterClearText);
         Assert.Contains("\x1b_Ga=p,", afterClearText);
         Assert.Contains($"\x1b_Ga=d,d=I,i={initialImageId},q=2\x1b\\", afterClearText);
-        Assert.NotEqual(initialImageId, ExtractFirstTransmitImageId(afterClearText));
+        Assert.AreNotEqual(initialImageId, ExtractFirstTransmitImageId(afterClearText));
 
         app.RequestStop();
         await runTask;
@@ -1019,17 +1002,17 @@ public class KgpOcclusionIntegrationTests
     private static uint ExtractFirstTransmitImageId(string text)
     {
         var transmitIndex = text.IndexOf("\x1b_Ga=t,", StringComparison.Ordinal);
-        Assert.True(transmitIndex >= 0, "Expected KGP output to contain a transmit sequence.");
+        Assert.IsTrue(transmitIndex >= 0, "Expected KGP output to contain a transmit sequence.");
 
         var index = text.IndexOf("i=", transmitIndex, StringComparison.Ordinal);
-        Assert.True(index >= 0, "Expected KGP transmit output to contain an image id.");
+        Assert.IsTrue(index >= 0, "Expected KGP transmit output to contain an image id.");
 
         index += 2;
         var end = index;
         while (end < text.Length && char.IsDigit(text[end]))
             end++;
 
-        Assert.True(end > index, "Expected KGP image id digits after `i=`.");
+        Assert.IsTrue(end > index, "Expected KGP image id digits after `i=`.");
         return uint.Parse(text[index..end], System.Globalization.CultureInfo.InvariantCulture);
     }
 }

--- a/tests/Hex1b.Tests/KgpOcclusionSolverTests.cs
+++ b/tests/Hex1b.Tests/KgpOcclusionSolverTests.cs
@@ -4,6 +4,7 @@ using Hex1b.Tokens;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class KgpOcclusionSolverTests
 {
     private static KgpCellData MakeKgpData(uint imageId, int cellW, int cellH, int pixelW = 100, int pixelH = 100)
@@ -18,7 +19,7 @@ public class KgpOcclusionSolverTests
             imageId, cellW, cellH, (uint)pixelW, (uint)pixelH, hash);
     }
 
-    [Fact]
+    [TestMethod]
     public void NoOccluders_ReturnsFullImage()
     {
         var registry = new KgpImageRegistry();
@@ -27,21 +28,21 @@ public class KgpOcclusionSolverTests
 
         var fragments = KgpOcclusionSolver.ComputeFragments(registry);
 
-        Assert.Single(fragments);
+        TestSeq.Single(fragments);
         var f = fragments[0];
-        Assert.Equal(1u, f.ImageId);
-        Assert.Equal(5, f.AbsoluteX);
-        Assert.Equal(5, f.AbsoluteY);
-        Assert.Equal(20, f.CellWidth);
-        Assert.Equal(10, f.CellHeight);
+        Assert.AreEqual(1u, f.ImageId);
+        Assert.AreEqual(5, f.AbsoluteX);
+        Assert.AreEqual(5, f.AbsoluteY);
+        Assert.AreEqual(20, f.CellWidth);
+        Assert.AreEqual(10, f.CellHeight);
         // No clip (original image had no clip)
-        Assert.Equal(0, f.ClipX);
-        Assert.Equal(0, f.ClipY);
-        Assert.Equal(0, f.ClipW);
-        Assert.Equal(0, f.ClipH);
+        Assert.AreEqual(0, f.ClipX);
+        Assert.AreEqual(0, f.ClipY);
+        Assert.AreEqual(0, f.ClipW);
+        Assert.AreEqual(0, f.ClipH);
     }
 
-    [Fact]
+    [TestMethod]
     public void FullyOccluded_ReturnsEmpty()
     {
         var registry = new KgpImageRegistry();
@@ -54,10 +55,10 @@ public class KgpOcclusionSolverTests
 
         var fragments = KgpOcclusionSolver.ComputeFragments(registry);
 
-        Assert.Empty(fragments);
+        Assert.IsEmpty(fragments);
     }
 
-    [Fact]
+    [TestMethod]
     public void PartialOcclusion_RightSide_ReturnsLeftStrip()
     {
         var registry = new KgpImageRegistry();
@@ -71,20 +72,20 @@ public class KgpOcclusionSolverTests
 
         var fragments = KgpOcclusionSolver.ComputeFragments(registry);
 
-        Assert.Single(fragments);
+        TestSeq.Single(fragments);
         var f = fragments[0];
-        Assert.Equal(0, f.AbsoluteX);
-        Assert.Equal(0, f.AbsoluteY);
-        Assert.Equal(10, f.CellWidth);
-        Assert.Equal(10, f.CellHeight);
+        Assert.AreEqual(0, f.AbsoluteX);
+        Assert.AreEqual(0, f.AbsoluteY);
+        Assert.AreEqual(10, f.CellWidth);
+        Assert.AreEqual(10, f.CellHeight);
         // Clip: left half of source image
-        Assert.Equal(0, f.ClipX);
-        Assert.Equal(0, f.ClipY);
-        Assert.Equal(100, f.ClipW); // 10/20 * 200 = 100
-        Assert.Equal(100, f.ClipH);
+        Assert.AreEqual(0, f.ClipX);
+        Assert.AreEqual(0, f.ClipY);
+        Assert.AreEqual(100, f.ClipW); // 10/20 * 200 = 100
+        Assert.AreEqual(100, f.ClipH);
     }
 
-    [Fact]
+    [TestMethod]
     public void PartialOcclusion_Center_ReturnsFourStrips()
     {
         var registry = new KgpImageRegistry();
@@ -98,31 +99,31 @@ public class KgpOcclusionSolverTests
 
         var fragments = KgpOcclusionSolver.ComputeFragments(registry);
 
-        Assert.Equal(4, fragments.Count);
+        Assert.AreEqual(4, fragments.Count);
 
         // Top strip: (0,0) 20x5
         var top = fragments.First(f => f.AbsoluteY == 0 && f.CellHeight == 5);
-        Assert.Equal(0, top.AbsoluteX);
-        Assert.Equal(20, top.CellWidth);
+        Assert.AreEqual(0, top.AbsoluteX);
+        Assert.AreEqual(20, top.CellWidth);
 
         // Bottom strip: (0,15) 20x5
         var bottom = fragments.First(f => f.AbsoluteY == 15);
-        Assert.Equal(0, bottom.AbsoluteX);
-        Assert.Equal(20, bottom.CellWidth);
-        Assert.Equal(5, bottom.CellHeight);
+        Assert.AreEqual(0, bottom.AbsoluteX);
+        Assert.AreEqual(20, bottom.CellWidth);
+        Assert.AreEqual(5, bottom.CellHeight);
 
         // Left strip: (0,5) 5x10
         var left = fragments.First(f => f.AbsoluteX == 0 && f.AbsoluteY == 5);
-        Assert.Equal(5, left.CellWidth);
-        Assert.Equal(10, left.CellHeight);
+        Assert.AreEqual(5, left.CellWidth);
+        Assert.AreEqual(10, left.CellHeight);
 
         // Right strip: (15,5) 5x10
         var right = fragments.First(f => f.AbsoluteX == 15 && f.AbsoluteY == 5);
-        Assert.Equal(5, right.CellWidth);
-        Assert.Equal(10, right.CellHeight);
+        Assert.AreEqual(5, right.CellWidth);
+        Assert.AreEqual(10, right.CellHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void MultipleOccluders_SubtractsAll()
     {
         var registry = new KgpImageRegistry();
@@ -138,15 +139,15 @@ public class KgpOcclusionSolverTests
         var fragments = KgpOcclusionSolver.ComputeFragments(registry);
 
         // Only the middle strip should remain: (10,0) 10x10
-        Assert.Single(fragments);
+        TestSeq.Single(fragments);
         var f = fragments[0];
-        Assert.Equal(10, f.AbsoluteX);
-        Assert.Equal(0, f.AbsoluteY);
-        Assert.Equal(10, f.CellWidth);
-        Assert.Equal(10, f.CellHeight);
+        Assert.AreEqual(10, f.AbsoluteX);
+        Assert.AreEqual(0, f.AbsoluteY);
+        Assert.AreEqual(10, f.CellWidth);
+        Assert.AreEqual(10, f.CellHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void SameLayerImages_NoOcclusion()
     {
         var registry = new KgpImageRegistry();
@@ -159,12 +160,12 @@ public class KgpOcclusionSolverTests
         var fragments = KgpOcclusionSolver.ComputeFragments(registry);
 
         // Both images should have single fragment (no mutual occlusion)
-        Assert.Equal(2, fragments.Count);
-        Assert.Contains(fragments, f => f.ImageId == 1);
-        Assert.Contains(fragments, f => f.ImageId == 2);
+        Assert.AreEqual(2, fragments.Count);
+        Assert.IsTrue(fragments.Any(f => f.ImageId == 1));
+        Assert.IsTrue(fragments.Any(f => f.ImageId == 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void ClipCoordinates_MapCorrectly()
     {
         var registry = new KgpImageRegistry();
@@ -183,20 +184,20 @@ public class KgpOcclusionSolverTests
 
         // Bottom strip: (0,5) 20x5, clipY = 5/10*200 = 100, clipH = 5/10*200 = 100
         var bottom = fragments.First(f => f.AbsoluteY == 5 && f.CellWidth == 20);
-        Assert.Equal(0, bottom.ClipX);
-        Assert.Equal(100, bottom.ClipY);
-        Assert.Equal(400, bottom.ClipW);
-        Assert.Equal(100, bottom.ClipH);
+        Assert.AreEqual(0, bottom.ClipX);
+        Assert.AreEqual(100, bottom.ClipY);
+        Assert.AreEqual(400, bottom.ClipW);
+        Assert.AreEqual(100, bottom.ClipH);
 
         // Right strip (in middle band): (10,0) 10x5
         var right = fragments.First(f => f.AbsoluteX == 10 && f.AbsoluteY == 0);
-        Assert.Equal(200, right.ClipX); // 10/20*400 = 200
-        Assert.Equal(0, right.ClipY);
-        Assert.Equal(200, right.ClipW); // 10/20*400 = 200
-        Assert.Equal(100, right.ClipH); // 5/10*200 = 100
+        Assert.AreEqual(200, right.ClipX); // 10/20*400 = 200
+        Assert.AreEqual(0, right.ClipY);
+        Assert.AreEqual(200, right.ClipW); // 10/20*400 = 200
+        Assert.AreEqual(100, right.ClipH); // 5/10*200 = 100
     }
 
-    [Fact]
+    [TestMethod]
     public void AlreadyClippedImage_ComposesClip()
     {
         var registry = new KgpImageRegistry();
@@ -215,22 +216,22 @@ public class KgpOcclusionSolverTests
 
         var fragments = KgpOcclusionSolver.ComputeFragments(registry);
 
-        Assert.Single(fragments);
+        TestSeq.Single(fragments);
         var f = fragments[0];
-        Assert.Equal(0, f.AbsoluteX);
-        Assert.Equal(0, f.AbsoluteY);
-        Assert.Equal(5, f.CellWidth);
-        Assert.Equal(10, f.CellHeight);
+        Assert.AreEqual(0, f.AbsoluteX);
+        Assert.AreEqual(0, f.AbsoluteY);
+        Assert.AreEqual(5, f.CellWidth);
+        Assert.AreEqual(10, f.CellHeight);
         // Composed clip: original (50,50,100,100) + left half (0-5 of 10 cells)
         // clipX = 50 + 0 * 100 / 10 = 50
         // clipW = 5 * 100 / 10 = 50
-        Assert.Equal(50, f.ClipX);
-        Assert.Equal(50, f.ClipY);
-        Assert.Equal(50, f.ClipW);
-        Assert.Equal(100, f.ClipH);
+        Assert.AreEqual(50, f.ClipX);
+        Assert.AreEqual(50, f.ClipY);
+        Assert.AreEqual(50, f.ClipW);
+        Assert.AreEqual(100, f.ClipH);
     }
 
-    [Fact]
+    [TestMethod]
     public void OccluderFullyOutside_NoChange()
     {
         var registry = new KgpImageRegistry();
@@ -243,12 +244,12 @@ public class KgpOcclusionSolverTests
 
         var fragments = KgpOcclusionSolver.ComputeFragments(registry);
 
-        Assert.Single(fragments);
-        Assert.Equal(10, fragments[0].CellWidth);
-        Assert.Equal(10, fragments[0].CellHeight);
+        TestSeq.Single(fragments);
+        Assert.AreEqual(10, fragments[0].CellWidth);
+        Assert.AreEqual(10, fragments[0].CellHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void MultipleImages_IndependentFragments()
     {
         var registry = new KgpImageRegistry();
@@ -266,35 +267,35 @@ public class KgpOcclusionSolverTests
 
         // Image 1 should be shredded (window 1 occluder at layer 1 > image layer 0)
         var img1Fragments = fragments.Where(f => f.ImageId == 1).ToList();
-        Assert.True(img1Fragments.Count >= 1); // At least the left strip
+        Assert.IsTrue(img1Fragments.Count >= 1); // At least the left strip
 
         // Image 2 should be full (no occluder above layer 1)
         var img2Fragments = fragments.Where(f => f.ImageId == 2).ToList();
-        Assert.Single(img2Fragments);
-        Assert.Equal(10, img2Fragments[0].CellWidth);
-        Assert.Equal(5, img2Fragments[0].CellHeight);
+        TestSeq.Single(img2Fragments);
+        Assert.AreEqual(10, img2Fragments[0].CellWidth);
+        Assert.AreEqual(5, img2Fragments[0].CellHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void SubtractRect_NoOverlap_ReturnsOriginal()
     {
         var rects = new List<Rect> { new(0, 0, 10, 10) };
         var result = KgpOcclusionSolver.SubtractFromAll(rects, new Rect(20, 20, 5, 5));
 
-        Assert.Single(result);
-        Assert.Equal(new Rect(0, 0, 10, 10), result[0]);
+        TestSeq.Single(result);
+        Assert.AreEqual(new Rect(0, 0, 10, 10), result[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void SubtractRect_FullOverlap_ReturnsEmpty()
     {
         var rects = new List<Rect> { new(5, 5, 10, 10) };
         var result = KgpOcclusionSolver.SubtractFromAll(rects, new Rect(0, 0, 20, 20));
 
-        Assert.Empty(result);
+        Assert.IsEmpty(result);
     }
 
-    [Fact]
+    [TestMethod]
     public void SubtractRect_PartialOverlap_ReturnsStrips()
     {
         // 10x10 rect, subtract center 4x4
@@ -302,19 +303,19 @@ public class KgpOcclusionSolverTests
         var result = KgpOcclusionSolver.SubtractFromAll(rects, new Rect(3, 3, 4, 4));
 
         // Should produce 4 strips
-        Assert.Equal(4, result.Count);
+        Assert.AreEqual(4, result.Count);
 
         // Top: (0,0) 10x3
-        Assert.Contains(result, r => r.X == 0 && r.Y == 0 && r.Width == 10 && r.Height == 3);
+        Assert.IsTrue(result.Any(r => r.X == 0 && r.Y == 0 && r.Width == 10 && r.Height == 3));
         // Bottom: (0,7) 10x3
-        Assert.Contains(result, r => r.X == 0 && r.Y == 7 && r.Width == 10 && r.Height == 3);
+        Assert.IsTrue(result.Any(r => r.X == 0 && r.Y == 7 && r.Width == 10 && r.Height == 3));
         // Left: (0,3) 3x4
-        Assert.Contains(result, r => r.X == 0 && r.Y == 3 && r.Width == 3 && r.Height == 4);
+        Assert.IsTrue(result.Any(r => r.X == 0 && r.Y == 3 && r.Width == 3 && r.Height == 4));
         // Right: (7,3) 3x4
-        Assert.Contains(result, r => r.X == 7 && r.Y == 3 && r.Width == 3 && r.Height == 4);
+        Assert.IsTrue(result.Any(r => r.X == 7 && r.Y == 3 && r.Width == 3 && r.Height == 4));
     }
 
-    [Fact]
+    [TestMethod]
     public void TrackerIntegration_FragmentsChangeOnDrag()
     {
         var tracker = new KgpPlacementTracker();
@@ -327,7 +328,7 @@ public class KgpOcclusionSolverTests
         };
         var (before1, _) = tracker.GenerateCommands(fragments1);
         // Should transmit + place
-        Assert.True(before1.Count > 0);
+        Assert.IsTrue(before1.Count > 0);
 
         // Frame 2: Same image, now occluded by window → 2 fragments
         var fragments2 = new List<KgpFragment>
@@ -337,12 +338,12 @@ public class KgpOcclusionSolverTests
         };
         var (before2, _) = tracker.GenerateCommands(fragments2);
         // Should reuse the image transmission and replace placement slots in place.
-        Assert.DoesNotContain(before2, t => t is UnrecognizedSequenceToken u && u.Sequence.Contains("a=t"));
-        Assert.DoesNotContain(before2, t => t is UnrecognizedSequenceToken u && u.Sequence.Contains("a=d"));
-        Assert.Equal(2, before2.OfType<UnrecognizedSequenceToken>().Count(u => u.Sequence.Contains("a=p")));
+        Assert.IsFalse(before2.Any(t => t is UnrecognizedSequenceToken u && u.Sequence.Contains("a=t")));
+        Assert.IsFalse(before2.Any(t => t is UnrecognizedSequenceToken u && u.Sequence.Contains("a=d")));
+        Assert.AreEqual(2, before2.OfType<UnrecognizedSequenceToken>().Count(u => u.Sequence.Contains("a=p")));
     }
 
-    [Fact]
+    [TestMethod]
     public void FragmentClips_TilePerfectly_WithNonIntegerPixelRatio()
     {
         // 128 pixels across 30 cells → 4.267 px/cell (non-integer ratio).
@@ -357,28 +358,28 @@ public class KgpOcclusionSolverTests
 
         var fragments = KgpOcclusionSolver.ComputeFragments(registry);
 
-        Assert.Equal(2, fragments.Count);
+        Assert.AreEqual(2, fragments.Count);
 
         var left = fragments.First(f => f.AbsoluteX == 0);
         var right = fragments.First(f => f.AbsoluteX == 20);
 
         // Left fragment: cells 0-9, right fragment: cells 20-29
-        Assert.Equal(10, left.CellWidth);
-        Assert.Equal(10, right.CellWidth);
+        Assert.AreEqual(10, left.CellWidth);
+        Assert.AreEqual(10, right.CellWidth);
 
         // Clip regions must tile: left.ClipX + left.ClipW == right.ClipX is NOT required
         // (they're non-adjacent fragments), but each must cover the correct pixel range.
         // Left: 0..10 cells → pixels 0..floor(10*128/30) = 0..42
-        Assert.Equal(0, left.ClipX);
-        Assert.Equal(42, left.ClipW); // floor(10*128/30)=42
+        Assert.AreEqual(0, left.ClipX);
+        Assert.AreEqual(42, left.ClipW); // floor(10*128/30)=42
 
         // Right: 20..30 cells → pixels floor(20*128/30)..floor(30*128/30) = 85..128
-        Assert.Equal(85, right.ClipX);  // floor(20*128/30)
-        Assert.Equal(43, right.ClipW);  // 128 - 85 = 43
+        Assert.AreEqual(85, right.ClipX);  // floor(20*128/30)
+        Assert.AreEqual(43, right.ClipW);  // 128 - 85 = 43
 
         // Verify Y clips tile perfectly too
-        Assert.Equal(0, left.ClipY);
-        Assert.Equal(64, left.ClipH); // full height, endpoint method: floor(15*64/15) - 0 = 64
+        Assert.AreEqual(0, left.ClipY);
+        Assert.AreEqual(64, left.ClipH); // full height, endpoint method: floor(15*64/15) - 0 = 64
 
         // The key property: adjacent fragments' clip regions must abut perfectly.
         // A center occluder produces 4 strips where top/left share a Y boundary.
@@ -388,7 +389,7 @@ public class KgpOcclusionSolverTests
         registry.RegisterOccluder(10, 5, 10, 5); // Center block
 
         var cFragments = KgpOcclusionSolver.ComputeFragments(registry);
-        Assert.Equal(4, cFragments.Count);
+        Assert.AreEqual(4, cFragments.Count);
 
         var cTop = cFragments.First(f => f.AbsoluteY == 0 && f.CellWidth == 30);
         var cLeft = cFragments.First(f => f.AbsoluteX == 0 && f.AbsoluteY == 5);
@@ -396,13 +397,13 @@ public class KgpOcclusionSolverTests
 
         // Top strip clipEnd Y must equal left/right strip clipStart Y
         var topEndY = cTop.ClipY + cTop.ClipH;
-        Assert.Equal(cLeft.ClipY, topEndY);
+        Assert.AreEqual(cLeft.ClipY, topEndY);
 
         // Left/right strip clipEnd Y must equal bottom strip clipStart Y
         var leftEndY = cLeft.ClipY + cLeft.ClipH;
-        Assert.Equal(cBottom.ClipY, leftEndY);
+        Assert.AreEqual(cBottom.ClipY, leftEndY);
 
         // Full height must be preserved
-        Assert.Equal(64, cTop.ClipH + cLeft.ClipH + cBottom.ClipH);
+        Assert.AreEqual(64, cTop.ClipH + cLeft.ClipH + cBottom.ClipH);
     }
 }

--- a/tests/Hex1b.Tests/KgpPerlinNoiseTests.cs
+++ b/tests/Hex1b.Tests/KgpPerlinNoiseTests.cs
@@ -6,6 +6,7 @@ namespace Hex1b.Tests;
 /// Complex KGP rendering tests using procedural Perlin noise images with
 /// cropped placements in a checkerboard tiling pattern.
 /// </summary>
+[TestClass]
 public class KgpPerlinNoiseTests
 {
     private const int TermWidth = 80;
@@ -30,7 +31,7 @@ public class KgpPerlinNoiseTests
     /// Each tile is a cropped region of the full-screen image, so the noise pattern
     /// is spatially continuous across tile boundaries.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void PerlinCheckerboard_FullScreen_GrayscaleAndBlueTiles()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -87,39 +88,39 @@ public class KgpPerlinNoiseTests
 
         // Verify all tiles were placed
         int expectedPlacements = tilesX * tilesY; // 240
-        Assert.Equal(expectedPlacements, snapshot.KgpPlacements.Count);
+        Assert.AreEqual(expectedPlacements, snapshot.KgpPlacements.Count);
 
         // Verify both images exist
-        Assert.True(snapshot.KgpImages.ContainsKey(1), "Grayscale image should be stored");
-        Assert.True(snapshot.KgpImages.ContainsKey(2), "Blue-tinted image should be stored");
+        Assert.IsTrue(snapshot.KgpImages.ContainsKey(1), "Grayscale image should be stored");
+        Assert.IsTrue(snapshot.KgpImages.ContainsKey(2), "Blue-tinted image should be stored");
 
         // Verify checkerboard pattern: alternating image IDs
         var topLeft = snapshot.KgpPlacements.First(p => p.Row == 0 && p.Column == 0);
         var topSecond = snapshot.KgpPlacements.First(p => p.Row == 0 && p.Column == TileCols);
-        Assert.Equal(1u, topLeft.ImageId);
-        Assert.Equal(2u, topSecond.ImageId);
+        Assert.AreEqual(1u, topLeft.ImageId);
+        Assert.AreEqual(2u, topSecond.ImageId);
 
         // Verify each tile has correct crop parameters
         foreach (var placement in snapshot.KgpPlacements)
         {
-            Assert.Equal((uint)TileCols, placement.DisplayColumns);
-            Assert.Equal((uint)TileRows, placement.DisplayRows);
-            Assert.Equal((uint)(placement.Column * CellW), placement.SourceX);
-            Assert.Equal((uint)(placement.Row * CellH), placement.SourceY);
-            Assert.Equal((uint)(TileCols * CellW), placement.SourceWidth);
-            Assert.Equal((uint)(TileRows * CellH), placement.SourceHeight);
+            Assert.AreEqual((uint)TileCols, placement.DisplayColumns);
+            Assert.AreEqual((uint)TileRows, placement.DisplayRows);
+            Assert.AreEqual((uint)(placement.Column * CellW), placement.SourceX);
+            Assert.AreEqual((uint)(placement.Row * CellH), placement.SourceY);
+            Assert.AreEqual((uint)(TileCols * CellW), placement.SourceWidth);
+            Assert.AreEqual((uint)(TileRows * CellH), placement.SourceHeight);
         }
 
         // Verify SVG has the expected number of <image> elements
         int imageCount = CountOccurrences(svg, "<image ");
-        Assert.Equal(expectedPlacements, imageCount);
+        Assert.AreEqual(expectedPlacements, imageCount);
     }
 
     /// <summary>
     /// Similar to the full checkerboard but with larger 8x4-cell tiles for a
     /// coarser pattern that's easier to visually verify.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void PerlinCheckerboard_LargeTiles_8x4()
     {
         const int largeTileCols = 8;
@@ -167,15 +168,15 @@ public class KgpPerlinNoiseTests
         var svg = snapshot.ToSvg();
         TestCaptureHelper.AttachSvg("kgp-perlin-checkerboard-large.svg", svg);
 
-        Assert.Equal(tilesX * tilesY, snapshot.KgpPlacements.Count);
-        Assert.Equal(tilesX * tilesY, CountOccurrences(svg, "<image "));
+        Assert.AreEqual(tilesX * tilesY, snapshot.KgpPlacements.Count);
+        Assert.AreEqual(tilesX * tilesY, CountOccurrences(svg, "<image "));
     }
 
     /// <summary>
     /// Verifies that cropped placements of the same image produce different BMP
     /// content in the SVG, confirming that cropping actually extracts different regions.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void PerlinCrop_DifferentRegions_ProduceDifferentBmpData()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -206,8 +207,8 @@ public class KgpPerlinNoiseTests
 
         // Extract both base64 data URIs and verify they differ
         var dataUris = ExtractDataUris(svg);
-        Assert.Equal(2, dataUris.Count);
-        Assert.NotEqual(dataUris[0], dataUris[1]);
+        Assert.AreEqual(2, dataUris.Count);
+        Assert.AreNotEqual(dataUris[0], dataUris[1]);
     }
 
     /// <summary>
@@ -216,7 +217,7 @@ public class KgpPerlinNoiseTests
     /// uses a different color tint on Perlin noise and a progressively lower z-index,
     /// so the top-left image is closest under the text and subsequent images stack behind.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void PerlinStaircase_OverlappingZOrder_WithTextOverlay()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -284,31 +285,30 @@ public class KgpPerlinNoiseTests
         TestCaptureHelper.AttachSvg("kgp-perlin-staircase-zorder.svg", svg);
 
         // Verify all 6 images were placed
-        Assert.Equal(tints.Length, snapshot.KgpPlacements.Count);
-        Assert.Equal(tints.Length, snapshot.KgpImages.Count);
+        Assert.AreEqual(tints.Length, snapshot.KgpPlacements.Count);
+        Assert.AreEqual(tints.Length, snapshot.KgpImages.Count);
 
         // Verify staircase positioning
         for (int i = 0; i < tints.Length; i++)
         {
             var p = snapshot.KgpPlacements[i];
-            Assert.Equal((uint)(i + 1), p.ImageId);
-            Assert.Equal(i * stepRows, p.Row);
-            Assert.Equal(i * stepCols, p.Column);
-            Assert.Equal(-(i + 1), p.ZIndex);
+            Assert.AreEqual((uint)(i + 1), p.ImageId);
+            Assert.AreEqual(i * stepRows, p.Row);
+            Assert.AreEqual(i * stepCols, p.Column);
+            Assert.AreEqual(-(i + 1), p.ZIndex);
         }
 
         // Verify z-order in SVG: images should be sorted by ZIndex ascending
         // (lowest z-index = furthest back = rendered first in SVG)
         var dataUris = ExtractDataUris(svg);
-        Assert.Equal(tints.Length, dataUris.Count);
+        Assert.AreEqual(tints.Length, dataUris.Count);
         // All data URIs should be distinct (different tint colors)
-        Assert.Equal(tints.Length, dataUris.Distinct().Count());
+        Assert.AreEqual(tints.Length, dataUris.Distinct().Count());
 
         // Verify text layer exists above images
         var imagesGroupEnd = svg.LastIndexOf("</g>", svg.IndexOf("class=\"terminal-text\""));
         var textGroupStart = svg.IndexOf("class=\"terminal-text\"");
-        Assert.True(textGroupStart > imagesGroupEnd,
-            "Text group should appear after images group in SVG");
+        Assert.IsTrue(textGroupStart > imagesGroupEnd, "Text group should appear after images group in SVG");
 
         // Verify the 'A' characters are in the text layer
         Assert.Contains(">A<", svg);

--- a/tests/Hex1b.Tests/KgpPlacementTrackerTests.cs
+++ b/tests/Hex1b.Tests/KgpPlacementTrackerTests.cs
@@ -9,6 +9,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for <see cref="KgpPlacementTracker"/> lifecycle management.
 /// </summary>
+[TestClass]
 public class KgpPlacementTrackerTests
 {
     private static readonly CellMetrics DefaultMetrics = new(10, 20);
@@ -46,7 +47,7 @@ public class KgpPlacementTrackerTests
         return surface;
     }
 
-    [Fact]
+    [TestMethod]
     public void FirstFrame_EmitsTransmitAndPlacement()
     {
         var tracker = new KgpPlacementTracker();
@@ -55,16 +56,16 @@ public class KgpPlacementTrackerTests
         var (before, after) = tracker.GenerateCommands(surface);
 
         // Below-text (z=-1) should be in beforeText
-        Assert.NotEmpty(before);
-        Assert.Empty(after);
+        Assert.IsNotEmpty(before);
+        Assert.IsEmpty(after);
 
         // Should have: cursor + transmit + placement
-        Assert.Contains(before, t => t is CursorPositionToken cp && cp.Row == 3 && cp.Column == 4);
-        Assert.Contains(before, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=t"));
-        Assert.Contains(before, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=p") && ust.Sequence.Contains("p=1"));
+        Assert.IsTrue(before.Any(t => t is CursorPositionToken cp && cp.Row == 3 && cp.Column == 4));
+        Assert.IsTrue(before.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=t")));
+        Assert.IsTrue(before.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=p") && ust.Sequence.Contains("p=1")));
     }
 
-    [Fact]
+    [TestMethod]
     public void SecondFrame_SamePosition_EmitsNothing()
     {
         var tracker = new KgpPlacementTracker();
@@ -77,11 +78,11 @@ public class KgpPlacementTrackerTests
         var (before, after) = tracker.GenerateCommands(surface);
 
         // Nothing changed — no tokens needed
-        Assert.Empty(before);
-        Assert.Empty(after);
+        Assert.IsEmpty(before);
+        Assert.IsEmpty(after);
     }
 
-    [Fact]
+    [TestMethod]
     public void SecondFrame_Move_ReusesTransmissionAndReplacesPlacement()
     {
         var tracker = new KgpPlacementTracker();
@@ -89,19 +90,19 @@ public class KgpPlacementTrackerTests
 
         // Frame 1 — first appearance
         var (before1, _) = tracker.GenerateCommands(surface1);
-        Assert.Contains(before1, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=t"));
+        Assert.IsTrue(before1.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=t")));
 
         // Frame 2 — moved to new position
         var surface2 = CreateSurfaceWithKgp(imageId: 42, x: 6, y: 2);
         var (before2, _) = tracker.GenerateCommands(surface2);
 
         // Should have placement replacement but NO delete and NO transmit
-        Assert.DoesNotContain(before2, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=d"));
-        Assert.Contains(before2, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=p") && ust.Sequence.Contains("p=1"));
-        Assert.DoesNotContain(before2, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=t"));
+        Assert.IsFalse(before2.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=d")));
+        Assert.IsTrue(before2.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=p") && ust.Sequence.Contains("p=1")));
+        Assert.IsFalse(before2.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=t")));
     }
 
-    [Fact]
+    [TestMethod]
     public void Move_ReusesPlacementId()
     {
         var tracker = new KgpPlacementTracker();
@@ -112,12 +113,12 @@ public class KgpPlacementTrackerTests
         // Frame 2 at (6, 2) — moved right
         var (before, _) = tracker.GenerateCommands(CreateSurfaceWithKgp(imageId: 42, x: 6, y: 2));
 
-        Assert.DoesNotContain(before, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=d"));
-        Assert.Contains(before, t => t is CursorPositionToken cp && cp.Row == 3 && cp.Column == 7);
-        Assert.Contains(before, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=p") && ust.Sequence.Contains("p=1"));
+        Assert.IsFalse(before.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=d")));
+        Assert.IsTrue(before.Any(t => t is CursorPositionToken cp && cp.Row == 3 && cp.Column == 7));
+        Assert.IsTrue(before.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=p") && ust.Sequence.Contains("p=1")));
     }
 
-    [Fact]
+    [TestMethod]
     public void Removal_EmitsDeleteOnly()
     {
         var tracker = new KgpPlacementTracker();
@@ -130,11 +131,11 @@ public class KgpPlacementTrackerTests
         var (before, _) = tracker.GenerateCommands(emptySurface);
 
         // Should have delete, no placement
-        Assert.Contains(before, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=d"));
-        Assert.DoesNotContain(before, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=p"));
+        Assert.IsTrue(before.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=d")));
+        Assert.IsFalse(before.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=p")));
     }
 
-    [Fact]
+    [TestMethod]
     public void ReappearanceAfterRemoval_RetransmitsImage()
     {
         var tracker = new KgpPlacementTracker();
@@ -145,11 +146,11 @@ public class KgpPlacementTrackerTests
 
         var (before, _) = tracker.GenerateCommands(surface);
 
-        Assert.Contains(before, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=t"));
-        Assert.Contains(before, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=p") && ust.Sequence.Contains("p=1"));
+        Assert.IsTrue(before.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=t")));
+        Assert.IsTrue(before.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=p") && ust.Sequence.Contains("p=1")));
     }
 
-    [Fact]
+    [TestMethod]
     public void ImageIdChange_FreesOldImageDataAndRetransmitsNewImage()
     {
         var tracker = new KgpPlacementTracker();
@@ -158,20 +159,20 @@ public class KgpPlacementTrackerTests
 
         var (before, _) = tracker.GenerateCommands(CreateSurfaceWithKgp(imageId: 43, x: 3, y: 2));
 
-        Assert.Contains(before, t => t is UnrecognizedSequenceToken ust &&
+        Assert.IsTrue(before.Any(t => t is UnrecognizedSequenceToken ust &&
             ust.Sequence.Contains("a=d") &&
             ust.Sequence.Contains("d=I") &&
-            ust.Sequence.Contains("i=42"));
-        Assert.Contains(before, t => t is UnrecognizedSequenceToken ust &&
+            ust.Sequence.Contains("i=42")));
+        Assert.IsTrue(before.Any(t => t is UnrecognizedSequenceToken ust &&
             ust.Sequence.Contains("a=t") &&
-            ust.Sequence.Contains("i=43"));
-        Assert.Contains(before, t => t is UnrecognizedSequenceToken ust &&
+            ust.Sequence.Contains("i=43")));
+        Assert.IsTrue(before.Any(t => t is UnrecognizedSequenceToken ust &&
             ust.Sequence.Contains("a=p") &&
             ust.Sequence.Contains("i=43") &&
-            ust.Sequence.Contains("p=1"));
+            ust.Sequence.Contains("p=1")));
     }
 
-    [Fact]
+    [TestMethod]
     public void AboveText_EmitsInAfterTextList()
     {
         var tracker = new KgpPlacementTracker();
@@ -180,12 +181,12 @@ public class KgpPlacementTrackerTests
         var (before, after) = tracker.GenerateCommands(surface);
 
         // Above-text (z=1) should be in afterText
-        Assert.Empty(before);
-        Assert.NotEmpty(after);
-        Assert.Contains(after, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=p") && ust.Sequence.Contains("p=1"));
+        Assert.IsEmpty(before);
+        Assert.IsNotEmpty(after);
+        Assert.IsTrue(after.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=p") && ust.Sequence.Contains("p=1")));
     }
 
-    [Fact]
+    [TestMethod]
     public void Reset_ForcesRetransmission()
     {
         var tracker = new KgpPlacementTracker();
@@ -199,10 +200,10 @@ public class KgpPlacementTrackerTests
 
         // Frame 2 — should re-transmit because reset cleared transmitted images
         var (before, _) = tracker.GenerateCommands(surface);
-        Assert.Contains(before, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=t"));
+        Assert.IsTrue(before.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=t")));
     }
 
-    [Fact]
+    [TestMethod]
     public void ResetPlacements_PreservesTransmissionCache()
     {
         var tracker = new KgpPlacementTracker();
@@ -214,11 +215,11 @@ public class KgpPlacementTrackerTests
 
         var (before, _) = tracker.GenerateCommands(surface);
 
-        Assert.DoesNotContain(before, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=t"));
-        Assert.Contains(before, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=p") && ust.Sequence.Contains("p=1"));
+        Assert.IsFalse(before.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=t")));
+        Assert.IsTrue(before.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=p") && ust.Sequence.Contains("p=1")));
     }
 
-    [Fact]
+    [TestMethod]
     public void MultipleImages_TrackedIndependently()
     {
         var tracker = new KgpPlacementTracker();
@@ -235,15 +236,15 @@ public class KgpPlacementTrackerTests
         surface2[15, 5] = new SurfaceCell(" ", null, null, Kgp: Track(CreateKgpData("img2", imageId: 20)));
         var (before, _) = tracker.GenerateCommands(surface2);
 
-        Assert.DoesNotContain(before, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=d"));
-        Assert.Contains(before, t => t is CursorPositionToken cp && cp.Row == 3 && cp.Column == 7);
-        Assert.Contains(before, t => t is UnrecognizedSequenceToken ust &&
+        Assert.IsFalse(before.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=d")));
+        Assert.IsTrue(before.Any(t => t is CursorPositionToken cp && cp.Row == 3 && cp.Column == 7));
+        Assert.IsTrue(before.Any(t => t is UnrecognizedSequenceToken ust &&
             ust.Sequence.Contains("a=p") &&
             ust.Sequence.Contains("i=10") &&
-            ust.Sequence.Contains("p=1"));
+            ust.Sequence.Contains("p=1")));
     }
 
-    [Fact]
+    [TestMethod]
     public void FragmentReduction_DeletesOnlySurplusPlacementId()
     {
         var tracker = new KgpPlacementTracker();
@@ -262,30 +263,30 @@ public class KgpPlacementTrackerTests
         };
         var (before, _) = tracker.GenerateCommands(frame2);
 
-        Assert.Contains(before, t => t is UnrecognizedSequenceToken ust &&
+        Assert.IsTrue(before.Any(t => t is UnrecognizedSequenceToken ust &&
             ust.Sequence.Contains("a=d") &&
             ust.Sequence.Contains("i=42") &&
-            ust.Sequence.Contains("p=2"));
-        Assert.DoesNotContain(before, t => t is UnrecognizedSequenceToken ust &&
+            ust.Sequence.Contains("p=2")));
+        Assert.IsFalse(before.Any(t => t is UnrecognizedSequenceToken ust &&
             ust.Sequence.Contains("a=d") &&
-            ust.Sequence.Contains("p=1"));
+            ust.Sequence.Contains("p=1")));
     }
 
-    [Fact]
+    [TestMethod]
     public void ActivePlacementCount_TracksCorrectly()
     {
         var tracker = new KgpPlacementTracker();
 
-        Assert.Equal(0, tracker.ActivePlacementCount);
+        Assert.AreEqual(0, tracker.ActivePlacementCount);
 
         tracker.GenerateCommands(CreateSurfaceWithKgp(imageId: 42, x: 3, y: 2));
-        Assert.Equal(1, tracker.ActivePlacementCount);
+        Assert.AreEqual(1, tracker.ActivePlacementCount);
 
         tracker.GenerateCommands(new Surface(30, 15, DefaultMetrics));
-        Assert.Equal(0, tracker.ActivePlacementCount);
+        Assert.AreEqual(0, tracker.ActivePlacementCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void RoundTrip_MoveSequence_TerminalDisplaysCorrectly()
     {
         // Full round-trip: Surface → KgpPlacementTracker → serialize → Hex1bTerminal
@@ -327,9 +328,9 @@ public class KgpPlacementTrackerTests
         tokens2.AddRange(after2);
 
         // Verify: no transmit on second frame (image already sent)
-        Assert.DoesNotContain(tokens2, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=t"));
-        Assert.DoesNotContain(tokens2, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=d"));
-        Assert.Contains(tokens2, t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=p") && ust.Sequence.Contains("p=1"));
+        Assert.IsFalse(tokens2.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=t")));
+        Assert.IsFalse(tokens2.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=d")));
+        Assert.IsTrue(tokens2.Any(t => t is UnrecognizedSequenceToken ust && ust.Sequence.Contains("a=p") && ust.Sequence.Contains("p=1")));
 
         var bytes2 = AnsiTokenUtf8Serializer.Serialize(tokens2);
         terminal.ApplyTokens(AnsiTokenizer.Tokenize(Encoding.UTF8.GetString(bytes2.ToArray())));

--- a/tests/Hex1b.Tests/KgpSurfaceCellTests.cs
+++ b/tests/Hex1b.Tests/KgpSurfaceCellTests.cs
@@ -10,6 +10,7 @@ namespace Hex1b.Tests;
 /// Tests for KGP (Kitty Graphics Protocol) support in surface cells,
 /// tracked object store, surface tracking, and surface comparer.
 /// </summary>
+[TestClass]
 public class KgpSurfaceCellTests
 {
     private static KgpCellData CreateKgpData(string imageContent = "test-image", int zIndex = -1)
@@ -28,78 +29,78 @@ public class KgpSurfaceCellTests
 
     #region SurfaceCell KGP
 
-    [Fact]
+    [TestMethod]
     public void SurfaceCell_WithKgp_HasKgpReturnsTrue()
     {
         var kgpData = CreateKgpData();
         var tracked = new TrackedObject<KgpCellData>(kgpData, _ => { });
         var cell = new SurfaceCell("", null, null, Kgp: tracked);
 
-        Assert.True(cell.HasKgp);
+        Assert.IsTrue(cell.HasKgp);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceCell_WithoutKgp_HasKgpReturnsFalse()
     {
         var cell = new SurfaceCell("A", null, null);
 
-        Assert.False(cell.HasKgp);
+        Assert.IsFalse(cell.HasKgp);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceCell_DefaultValues_KgpIsNull()
     {
         var cell = new SurfaceCell("A", null, null);
 
-        Assert.Null(cell.Kgp);
-        Assert.False(cell.HasKgp);
+        Assert.IsNull(cell.Kgp);
+        Assert.IsFalse(cell.HasKgp);
     }
 
     #endregion
 
     #region Surface KGP Count Tracking
 
-    [Fact]
+    [TestMethod]
     public void Surface_TracksKgpCount_IncrementOnSet()
     {
         var surface = new Surface(10, 5);
-        Assert.False(surface.HasKgp);
+        Assert.IsFalse(surface.HasKgp);
 
         var kgpData = CreateKgpData();
         var tracked = new TrackedObject<KgpCellData>(kgpData, _ => { });
         surface[0, 0] = new SurfaceCell("", null, null, Kgp: tracked);
 
-        Assert.True(surface.HasKgp);
+        Assert.IsTrue(surface.HasKgp);
     }
 
-    [Fact]
+    [TestMethod]
     public void Surface_TracksKgpCount_DecrementOnOverwrite()
     {
         var surface = new Surface(10, 5);
         var kgpData = CreateKgpData();
         var tracked = new TrackedObject<KgpCellData>(kgpData, _ => { });
         surface[0, 0] = new SurfaceCell("", null, null, Kgp: tracked);
-        Assert.True(surface.HasKgp);
+        Assert.IsTrue(surface.HasKgp);
 
         // Overwrite with non-KGP cell
         surface[0, 0] = new SurfaceCell("A", null, null);
-        Assert.False(surface.HasKgp);
+        Assert.IsFalse(surface.HasKgp);
     }
 
-    [Fact]
+    [TestMethod]
     public void Surface_Clear_ResetsKgpCount()
     {
         var surface = new Surface(10, 5);
         var kgpData = CreateKgpData();
         var tracked = new TrackedObject<KgpCellData>(kgpData, _ => { });
         surface[0, 0] = new SurfaceCell("", null, null, Kgp: tracked);
-        Assert.True(surface.HasKgp);
+        Assert.IsTrue(surface.HasKgp);
 
         surface.Clear();
-        Assert.False(surface.HasKgp);
+        Assert.IsFalse(surface.HasKgp);
     }
 
-    [Fact]
+    [TestMethod]
     public void Surface_TrySetCell_TracksKgpCount()
     {
         var surface = new Surface(10, 5);
@@ -107,10 +108,10 @@ public class KgpSurfaceCellTests
         var tracked = new TrackedObject<KgpCellData>(kgpData, _ => { });
         
         surface.TrySetCell(3, 2, new SurfaceCell("", null, null, Kgp: tracked));
-        Assert.True(surface.HasKgp);
+        Assert.IsTrue(surface.HasKgp);
     }
 
-    [Fact]
+    [TestMethod]
     public void Surface_Clone_PreservesKgpCount()
     {
         var surface = new Surface(10, 5);
@@ -119,14 +120,14 @@ public class KgpSurfaceCellTests
         surface[0, 0] = new SurfaceCell("", null, null, Kgp: tracked);
         
         var clone = surface.Clone();
-        Assert.True(clone.HasKgp);
+        Assert.IsTrue(clone.HasKgp);
     }
 
     #endregion
 
     #region TrackedObjectStore KGP
 
-    [Fact]
+    [TestMethod]
     public void TrackedObjectStore_GetOrCreateKgp_CreatesNewTrackedObject()
     {
         var store = new TrackedObjectStore();
@@ -134,12 +135,12 @@ public class KgpSurfaceCellTests
 
         var tracked = store.GetOrCreateKgp(kgpData);
 
-        Assert.NotNull(tracked);
-        Assert.Same(kgpData, tracked.Data);
-        Assert.Equal(1, store.KgpCount);
+        Assert.IsNotNull(tracked);
+        Assert.AreSame(kgpData, tracked.Data);
+        Assert.AreEqual(1, store.KgpCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void TrackedObjectStore_GetOrCreateKgp_DeduplicatesByHash()
     {
         var store = new TrackedObjectStore();
@@ -150,11 +151,11 @@ public class KgpSurfaceCellTests
         var tracked2 = store.GetOrCreateKgp(kgpData2);
 
         // Same tracked object returned for same hash
-        Assert.Same(tracked1, tracked2);
-        Assert.Equal(1, store.KgpCount);
+        Assert.AreSame(tracked1, tracked2);
+        Assert.AreEqual(1, store.KgpCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void TrackedObjectStore_GetOrCreateKgp_DifferentHashCreatesNew()
     {
         var store = new TrackedObjectStore();
@@ -164,47 +165,47 @@ public class KgpSurfaceCellTests
         var tracked1 = store.GetOrCreateKgp(kgpData1);
         var tracked2 = store.GetOrCreateKgp(kgpData2);
 
-        Assert.NotSame(tracked1, tracked2);
-        Assert.Equal(2, store.KgpCount);
+        Assert.AreNotSame(tracked1, tracked2);
+        Assert.AreEqual(2, store.KgpCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void TrackedObjectStore_GetOrCreateKgp_RefCounting()
     {
         var store = new TrackedObjectStore();
         var kgpData = CreateKgpData();
 
         var tracked = store.GetOrCreateKgp(kgpData);
-        Assert.Equal(1, store.KgpCount);
+        Assert.AreEqual(1, store.KgpCount);
 
         // Second reference
         var tracked2 = store.GetOrCreateKgp(kgpData);
-        Assert.Equal(1, store.KgpCount); // Still one unique object
+        Assert.AreEqual(1, store.KgpCount); // Still one unique object
 
         // Release both
         tracked.Release();
-        Assert.Equal(1, store.KgpCount); // Still tracked (refcount > 0)
+        Assert.AreEqual(1, store.KgpCount); // Still tracked (refcount > 0)
         tracked2.Release();
-        Assert.Equal(0, store.KgpCount); // Removed at zero refs
+        Assert.AreEqual(0, store.KgpCount); // Removed at zero refs
     }
 
-    [Fact]
+    [TestMethod]
     public void TrackedObjectStore_Clear_RemovesKgp()
     {
         var store = new TrackedObjectStore();
         store.GetOrCreateKgp(CreateKgpData("img1"));
         store.GetOrCreateKgp(CreateKgpData("img2"));
-        Assert.Equal(2, store.KgpCount);
+        Assert.AreEqual(2, store.KgpCount);
 
         store.Clear();
-        Assert.Equal(0, store.KgpCount);
+        Assert.AreEqual(0, store.KgpCount);
     }
 
     #endregion
 
     #region SurfaceComparer KGP
 
-    [Fact]
+    [TestMethod]
     public void SurfaceComparer_DetectsKgpChange()
     {
         var prev = new Surface(10, 5);
@@ -216,11 +217,11 @@ public class KgpSurfaceCellTests
 
         var diff = SurfaceComparer.Compare(prev, curr);
 
-        Assert.True(diff.ChangedCells.Count > 0);
-        Assert.Contains(diff.ChangedCells, c => c.X == 0 && c.Y == 0);
+        Assert.IsTrue(diff.ChangedCells.Count > 0);
+        Assert.IsTrue(diff.ChangedCells.Any(c => c.X == 0 && c.Y == 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceComparer_IgnoresIdenticalKgp()
     {
         var kgpData = CreateKgpData("same-image");
@@ -236,14 +237,14 @@ public class KgpSurfaceCellTests
         var diff = SurfaceComparer.Compare(prev, curr);
 
         // Same content hash → no change
-        Assert.DoesNotContain(diff.ChangedCells, c => c.X == 0 && c.Y == 0);
+        Assert.IsFalse(diff.ChangedCells.Any(c => c.X == 0 && c.Y == 0));
     }
 
     #endregion
 
     #region KgpCellData ZIndex
 
-    [Fact]
+    [TestMethod]
     public void KgpCellData_BuildPlacement_UsesZIndex()
     {
         var kgpData = CreateKgpData(zIndex: 5);
@@ -253,7 +254,7 @@ public class KgpSurfaceCellTests
         Assert.DoesNotContain("z=-1", payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpCellData_BuildPlacement_DefaultZIndexIsNegativeOne()
     {
         var kgpData = CreateKgpData();
@@ -262,7 +263,7 @@ public class KgpSurfaceCellTests
         Assert.Contains("z=-1", payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpCellData_BuildPlacement_PositiveZIndex()
     {
         var kgpData = CreateKgpData(zIndex: 3);
@@ -271,13 +272,13 @@ public class KgpSurfaceCellTests
         Assert.Contains("z=3", payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpCellData_WithClip_PreservesZIndex()
     {
         var kgpData = CreateKgpData(zIndex: 7);
         var clipped = kgpData.WithClip(10, 20, 30, 40, 2, 1);
 
-        Assert.Equal(7, clipped.ZIndex);
+        Assert.AreEqual(7, clipped.ZIndex);
         Assert.Contains("z=7", clipped.BuildPlacementPayload());
     }
 

--- a/tests/Hex1b.Tests/KgpSurfaceCompositingTests.cs
+++ b/tests/Hex1b.Tests/KgpSurfaceCompositingTests.cs
@@ -11,6 +11,7 @@ namespace Hex1b.Tests;
 /// Tests for KGP compositing across surfaces and layers,
 /// including clipping, z-ordering, and visibility tracking.
 /// </summary>
+[TestClass]
 public class KgpSurfaceCompositingTests
 {
     private static readonly CellMetrics DefaultMetrics = new(10, 20); // 10px wide, 20px tall
@@ -42,7 +43,7 @@ public class KgpSurfaceCompositingTests
 
     #region Surface.Composite KGP Clipping
 
-    [Fact]
+    [TestMethod]
     public void Composite_KgpImage_FitsInBounds_NoClipping()
     {
         var parent = new Surface(10, 5, DefaultMetrics);
@@ -54,12 +55,12 @@ public class KgpSurfaceCompositingTests
 
         parent.Composite(child, offsetX: 0, offsetY: 0);
 
-        Assert.True(parent[0, 0].HasKgp);
-        Assert.Equal(4, parent[0, 0].Kgp!.Data.WidthInCells);
-        Assert.Equal(2, parent[0, 0].Kgp!.Data.HeightInCells);
+        Assert.IsTrue(parent[0, 0].HasKgp);
+        Assert.AreEqual(4, parent[0, 0].Kgp!.Data.WidthInCells);
+        Assert.AreEqual(2, parent[0, 0].Kgp!.Data.HeightInCells);
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_KgpImage_ExtendsRight_ClipsWidth()
     {
         var parent = new Surface(6, 5, DefaultMetrics);
@@ -72,11 +73,11 @@ public class KgpSurfaceCompositingTests
 
         parent.Composite(child, offsetX: 3, offsetY: 0);
 
-        Assert.True(parent[3, 0].HasKgp);
-        Assert.Equal(3, parent[3, 0].Kgp!.Data.WidthInCells);
+        Assert.IsTrue(parent[3, 0].HasKgp);
+        Assert.AreEqual(3, parent[3, 0].Kgp!.Data.WidthInCells);
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_KgpImage_ExtendsDown_ClipsHeight()
     {
         var parent = new Surface(10, 3, DefaultMetrics);
@@ -89,11 +90,11 @@ public class KgpSurfaceCompositingTests
 
         parent.Composite(child, offsetX: 0, offsetY: 2);
 
-        Assert.True(parent[0, 2].HasKgp);
-        Assert.Equal(1, parent[0, 2].Kgp!.Data.HeightInCells);
+        Assert.IsTrue(parent[0, 2].HasKgp);
+        Assert.AreEqual(1, parent[0, 2].Kgp!.Data.HeightInCells);
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_KgpImage_CompletelyOutOfBounds_RemovesKgp()
     {
         var parent = new Surface(3, 3, DefaultMetrics);
@@ -108,10 +109,10 @@ public class KgpSurfaceCompositingTests
 
         // Cell at x=3 is out of bounds, so nothing should be written
         // The composite should handle this gracefully
-        Assert.False(parent[0, 0].HasKgp);
+        Assert.IsFalse(parent[0, 0].HasKgp);
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_KgpImage_PreservesZIndex()
     {
         var parent = new Surface(10, 5, DefaultMetrics);
@@ -123,10 +124,10 @@ public class KgpSurfaceCompositingTests
 
         parent.Composite(child, offsetX: 0, offsetY: 0);
 
-        Assert.Equal(5, parent[0, 0].Kgp!.Data.ZIndex);
+        Assert.AreEqual(5, parent[0, 0].Kgp!.Data.ZIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_KgpImage_ClippedPreservesZIndex()
     {
         var parent = new Surface(3, 3, DefaultMetrics);
@@ -138,11 +139,11 @@ public class KgpSurfaceCompositingTests
 
         parent.Composite(child, offsetX: 1, offsetY: 0);
 
-        Assert.True(parent[1, 0].HasKgp);
-        Assert.Equal(3, parent[1, 0].Kgp!.Data.ZIndex);
+        Assert.IsTrue(parent[1, 0].HasKgp);
+        Assert.AreEqual(3, parent[1, 0].Kgp!.Data.ZIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_KgpImage_ClippedByClipRect_ReanchorsVisibleRegion()
     {
         var parent = new Surface(10, 5, DefaultMetrics);
@@ -153,17 +154,17 @@ public class KgpSurfaceCompositingTests
 
         parent.Composite(child, offsetX: 0, offsetY: 0, clip: new Rect(2, 1, 8, 4));
 
-        Assert.False(parent[0, 0].HasKgp);
-        Assert.True(parent[2, 1].HasKgp);
-        Assert.Equal(4, parent[2, 1].Kgp!.Data.WidthInCells);
-        Assert.Equal(3, parent[2, 1].Kgp!.Data.HeightInCells);
-        Assert.Equal(20, parent[2, 1].Kgp!.Data.ClipX);
-        Assert.Equal(20, parent[2, 1].Kgp!.Data.ClipY);
-        Assert.Equal(40, parent[2, 1].Kgp!.Data.ClipW);
-        Assert.Equal(60, parent[2, 1].Kgp!.Data.ClipH);
+        Assert.IsFalse(parent[0, 0].HasKgp);
+        Assert.IsTrue(parent[2, 1].HasKgp);
+        Assert.AreEqual(4, parent[2, 1].Kgp!.Data.WidthInCells);
+        Assert.AreEqual(3, parent[2, 1].Kgp!.Data.HeightInCells);
+        Assert.AreEqual(20, parent[2, 1].Kgp!.Data.ClipX);
+        Assert.AreEqual(20, parent[2, 1].Kgp!.Data.ClipY);
+        Assert.AreEqual(40, parent[2, 1].Kgp!.Data.ClipW);
+        Assert.AreEqual(60, parent[2, 1].Kgp!.Data.ClipH);
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_KgpImage_WithNegativeOffset_ReanchorsVisibleRegion()
     {
         var parent = new Surface(10, 5, DefaultMetrics);
@@ -174,16 +175,16 @@ public class KgpSurfaceCompositingTests
 
         parent.Composite(child, offsetX: -2, offsetY: -1);
 
-        Assert.True(parent[0, 0].HasKgp);
-        Assert.Equal(4, parent[0, 0].Kgp!.Data.WidthInCells);
-        Assert.Equal(3, parent[0, 0].Kgp!.Data.HeightInCells);
-        Assert.Equal(20, parent[0, 0].Kgp!.Data.ClipX);
-        Assert.Equal(20, parent[0, 0].Kgp!.Data.ClipY);
-        Assert.Equal(40, parent[0, 0].Kgp!.Data.ClipW);
-        Assert.Equal(60, parent[0, 0].Kgp!.Data.ClipH);
+        Assert.IsTrue(parent[0, 0].HasKgp);
+        Assert.AreEqual(4, parent[0, 0].Kgp!.Data.WidthInCells);
+        Assert.AreEqual(3, parent[0, 0].Kgp!.Data.HeightInCells);
+        Assert.AreEqual(20, parent[0, 0].Kgp!.Data.ClipX);
+        Assert.AreEqual(20, parent[0, 0].Kgp!.Data.ClipY);
+        Assert.AreEqual(40, parent[0, 0].Kgp!.Data.ClipW);
+        Assert.AreEqual(60, parent[0, 0].Kgp!.Data.ClipH);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderChild_OccluderContent_IsClippedToVisibleCompositeRegion()
     {
         var parent = new Surface(12, 12, DefaultMetrics);
@@ -200,11 +201,11 @@ public class KgpSurfaceCompositingTests
 
         context.RenderChild(child);
 
-        var occluder = Assert.Single(registry.Occluders);
-        Assert.Equal(new Rect(0, 1, 6, 4), occluder.Bounds);
+        var occluder = TestSeq.Single(registry.Occluders);
+        Assert.AreEqual(new Rect(0, 1, 6, 4), occluder.Bounds);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderChild_HiddenNestedButtonRow_DoesNotRegisterOffscreenOccluder()
     {
         var parent = new Surface(20, 12, DefaultMetrics);
@@ -242,14 +243,14 @@ public class KgpSurfaceCompositingTests
 
         context.RenderChild(child);
 
-        Assert.DoesNotContain(registry.Occluders, o => o.Bounds.Y >= 5);
+        Assert.IsFalse(registry.Occluders.Any(o => o.Bounds.Y >= 5));
     }
 
     #endregion
 
     #region CompositeSurface KGP Layer Resolution
 
-    [Fact]
+    [TestMethod]
     public void CompositeSurface_KgpOnUpperLayer_OccludesLower()
     {
         var layer1 = new Surface(10, 5, DefaultMetrics);
@@ -265,10 +266,10 @@ public class KgpSurfaceCompositingTests
         composite.AddLayer(layer2);
 
         var resolved = composite.GetCell(2, 1);
-        Assert.True(resolved.HasKgp);
+        Assert.IsTrue(resolved.HasKgp);
     }
 
-    [Fact]
+    [TestMethod]
     public void CompositeSurface_TextOverKgp_TextWins()
     {
         var layer1 = new Surface(10, 5, DefaultMetrics);
@@ -284,11 +285,11 @@ public class KgpSurfaceCompositingTests
         composite.AddLayer(layer2);
 
         var resolved = composite.GetCell(2, 1);
-        Assert.Equal("X", resolved.Character);
-        Assert.False(resolved.HasKgp);
+        Assert.AreEqual("X", resolved.Character);
+        Assert.IsFalse(resolved.HasKgp);
     }
 
-    [Fact]
+    [TestMethod]
     public void CompositeSurface_TransparentAboveKgp_KgpShowsThrough()
     {
         var layer1 = new Surface(10, 5, DefaultMetrics);
@@ -304,10 +305,10 @@ public class KgpSurfaceCompositingTests
         composite.AddLayer(layer2);
 
         var resolved = composite.GetCell(2, 1);
-        Assert.True(resolved.HasKgp);
+        Assert.IsTrue(resolved.HasKgp);
     }
 
-    [Fact]
+    [TestMethod]
     public void CompositeSurface_KgpOnlyLayer_Preserved()
     {
         var layer = new Surface(10, 5, DefaultMetrics);
@@ -319,8 +320,8 @@ public class KgpSurfaceCompositingTests
         composite.AddLayer(layer);
 
         var resolved = composite.GetCell(0, 0);
-        Assert.True(resolved.HasKgp);
-        Assert.Equal(1u, resolved.Kgp!.Data.ImageId);
+        Assert.IsTrue(resolved.HasKgp);
+        Assert.AreEqual(1u, resolved.Kgp!.Data.ImageId);
     }
 
     private sealed class TestWritingNode(params (int X, int Y, string Text)[] writes) : Hex1bNode
@@ -341,23 +342,23 @@ public class KgpSurfaceCompositingTests
 
     #region KgpVisibility
 
-    [Fact]
+    [TestMethod]
     public void KgpVisibility_FullyVisible_SinglePlacement()
     {
         var kgpData = CreateKgpData(widthInCells: 4, heightInCells: 2, sourcePixelWidth: 40, sourcePixelHeight: 40);
         var tracked = Track(kgpData);
         var vis = new KgpVisibility(tracked, anchorX: 0, anchorY: 0, layerIndex: 0);
 
-        Assert.True(vis.IsFullyVisible);
-        Assert.False(vis.IsFullyOccluded);
+        Assert.IsTrue(vis.IsFullyVisible);
+        Assert.IsFalse(vis.IsFullyOccluded);
 
         var placements = vis.GeneratePlacements(DefaultMetrics);
-        Assert.Single(placements);
-        Assert.Equal(0, placements[0].CellX);
-        Assert.Equal(0, placements[0].CellY);
+        TestSeq.Single(placements);
+        Assert.AreEqual(0, placements[0].CellX);
+        Assert.AreEqual(0, placements[0].CellY);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpVisibility_FullyOccluded_NoPlacements()
     {
         var kgpData = CreateKgpData(widthInCells: 4, heightInCells: 2, sourcePixelWidth: 40, sourcePixelHeight: 40);
@@ -367,14 +368,14 @@ public class KgpSurfaceCompositingTests
         // Occlude the entire image
         vis.ApplyOcclusion(new Rect(0, 0, 4, 2), DefaultMetrics);
 
-        Assert.True(vis.IsFullyOccluded);
-        Assert.False(vis.IsFullyVisible);
+        Assert.IsTrue(vis.IsFullyOccluded);
+        Assert.IsFalse(vis.IsFullyVisible);
 
         var placements = vis.GeneratePlacements(DefaultMetrics);
-        Assert.Empty(placements);
+        Assert.IsEmpty(placements);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpVisibility_PartialOcclusion_ReducesVisibleRegions()
     {
         var kgpData = CreateKgpData(widthInCells: 4, heightInCells: 2, sourcePixelWidth: 40, sourcePixelHeight: 40);
@@ -384,12 +385,12 @@ public class KgpSurfaceCompositingTests
         // Occlude the right half of the image
         vis.ApplyOcclusion(new Rect(2, 0, 2, 2), DefaultMetrics);
 
-        Assert.False(vis.IsFullyVisible);
-        Assert.False(vis.IsFullyOccluded);
-        Assert.True(vis.VisibleRegions.Count >= 1);
+        Assert.IsFalse(vis.IsFullyVisible);
+        Assert.IsFalse(vis.IsFullyOccluded);
+        Assert.IsTrue(vis.VisibleRegions.Count >= 1);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpVisibility_OcclusionOutsideImage_NoEffect()
     {
         var kgpData = CreateKgpData(widthInCells: 4, heightInCells: 2, sourcePixelWidth: 40, sourcePixelHeight: 40);
@@ -399,15 +400,15 @@ public class KgpSurfaceCompositingTests
         // Occlude outside the image bounds
         vis.ApplyOcclusion(new Rect(10, 10, 5, 5), DefaultMetrics);
 
-        Assert.False(vis.IsFullyVisible); // ApplyOcclusion sets this to false
-        Assert.False(vis.IsFullyOccluded);
+        Assert.IsFalse(vis.IsFullyVisible); // ApplyOcclusion sets this to false
+        Assert.IsFalse(vis.IsFullyOccluded);
         
         var placements = vis.GeneratePlacements(DefaultMetrics);
         // Should still generate a placement for the visible region
-        Assert.True(placements.Count >= 1);
+        Assert.IsTrue(placements.Count >= 1);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpVisibility_CenterOcclusion_GeneratesMultipleRegions()
     {
         var kgpData = CreateKgpData(widthInCells: 10, heightInCells: 10, sourcePixelWidth: 100, sourcePixelHeight: 200);
@@ -417,12 +418,12 @@ public class KgpSurfaceCompositingTests
         // Occlude a 2x2 block in the center of the 10x10 image
         vis.ApplyOcclusion(new Rect(4, 4, 2, 2), DefaultMetrics);
 
-        Assert.False(vis.IsFullyOccluded);
+        Assert.IsFalse(vis.IsFullyOccluded);
         // Punching a hole in the center should create 4 regions (top, bottom, left, right)
-        Assert.True(vis.VisibleRegions.Count == 4);
+        Assert.IsTrue(vis.VisibleRegions.Count == 4);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpVisibility_PreservesZIndex()
     {
         var kgpData = CreateKgpData(widthInCells: 4, heightInCells: 2, zIndex: 5, sourcePixelWidth: 40, sourcePixelHeight: 40);
@@ -430,11 +431,11 @@ public class KgpSurfaceCompositingTests
         var vis = new KgpVisibility(tracked, anchorX: 0, anchorY: 0, layerIndex: 0);
 
         var placements = vis.GeneratePlacements(DefaultMetrics);
-        Assert.Single(placements);
-        Assert.Equal(5, placements[0].Data.ZIndex);
+        TestSeq.Single(placements);
+        Assert.AreEqual(5, placements[0].Data.ZIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpVisibility_PartialOcclusion_PlacementsPreserveZIndex()
     {
         var kgpData = CreateKgpData(widthInCells: 10, heightInCells: 10, zIndex: 3, sourcePixelWidth: 100, sourcePixelHeight: 200);
@@ -446,26 +447,26 @@ public class KgpSurfaceCompositingTests
         var placements = vis.GeneratePlacements(DefaultMetrics);
         foreach (var (data, _, _) in placements)
         {
-            Assert.Equal(3, data.ZIndex);
+            Assert.AreEqual(3, data.ZIndex);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void KgpVisibility_LayerIndex_Stored()
     {
         var kgpData = CreateKgpData();
         var tracked = Track(kgpData);
         var vis = new KgpVisibility(tracked, anchorX: 5, anchorY: 3, layerIndex: 7);
 
-        Assert.Equal(7, vis.LayerIndex);
-        Assert.Equal((5, 3), vis.AnchorPosition);
+        Assert.AreEqual(7, vis.LayerIndex);
+        Assert.AreEqual((5, 3), vis.AnchorPosition);
     }
 
     #endregion
 
     #region SurfaceLayerContext.CreateKgp
 
-    [Fact]
+    [TestMethod]
     public void SurfaceLayerContext_CreateKgp_FromCellData_ReturnsTrackedObject()
     {
         var store = new TrackedObjectStore();
@@ -479,11 +480,11 @@ public class KgpSurfaceCompositingTests
         var kgpData = CreateKgpData();
         var tracked = ctx.CreateKgp(kgpData);
 
-        Assert.NotNull(tracked);
-        Assert.Equal(kgpData.ImageId, tracked!.Data.ImageId);
+        Assert.IsNotNull(tracked);
+        Assert.AreEqual(kgpData.ImageId, tracked!.Data.ImageId);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceLayerContext_CreateKgp_NullStore_ReturnsNull()
     {
         var ctx = new Hex1b.Widgets.SurfaceLayerContext(
@@ -496,10 +497,10 @@ public class KgpSurfaceCompositingTests
         var kgpData = CreateKgpData();
         var tracked = ctx.CreateKgp(kgpData);
 
-        Assert.Null(tracked);
+        Assert.IsNull(tracked);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceLayerContext_CreateKgp_FromPixelData_ReturnsTrackedObject()
     {
         var store = new TrackedObjectStore();
@@ -514,10 +515,10 @@ public class KgpSurfaceCompositingTests
         var pixels = new byte[2 * 2 * 4];
         var tracked = ctx.CreateKgp(pixels, 2, 2);
 
-        Assert.NotNull(tracked);
+        Assert.IsNotNull(tracked);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceLayerContext_CreateKgp_FromPixelData_BelowText_NegativeZIndex()
     {
         var store = new TrackedObjectStore();
@@ -531,11 +532,11 @@ public class KgpSurfaceCompositingTests
         var pixels = new byte[2 * 2 * 4];
         var tracked = ctx.CreateKgp(pixels, 2, 2, KgpZOrder.BelowText);
 
-        Assert.NotNull(tracked);
-        Assert.True(tracked!.Data.ZIndex < 0);
+        Assert.IsNotNull(tracked);
+        Assert.IsTrue(tracked!.Data.ZIndex < 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceLayerContext_CreateKgp_FromPixelData_AboveText_PositiveZIndex()
     {
         var store = new TrackedObjectStore();
@@ -549,11 +550,11 @@ public class KgpSurfaceCompositingTests
         var pixels = new byte[2 * 2 * 4];
         var tracked = ctx.CreateKgp(pixels, 2, 2, KgpZOrder.AboveText);
 
-        Assert.NotNull(tracked);
-        Assert.True(tracked!.Data.ZIndex > 0);
+        Assert.IsNotNull(tracked);
+        Assert.IsTrue(tracked!.Data.ZIndex > 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceLayerContext_CreateKgp_Deduplicates()
     {
         var store = new TrackedObjectStore();
@@ -568,20 +569,20 @@ public class KgpSurfaceCompositingTests
         var tracked1 = ctx.CreateKgp(kgpData);
         var tracked2 = ctx.CreateKgp(kgpData);
 
-        Assert.NotNull(tracked1);
-        Assert.NotNull(tracked2);
-        Assert.Same(tracked1, tracked2);
+        Assert.IsNotNull(tracked1);
+        Assert.IsNotNull(tracked2);
+        Assert.AreSame(tracked1, tracked2);
     }
 
     #endregion
 
     #region Surface.Composite preserves KGP through cell operations
 
-    [Fact]
+    [TestMethod]
     public void Surface_HasKgp_TracksThroughComposite()
     {
         var parent = new Surface(10, 5, DefaultMetrics);
-        Assert.False(parent.HasKgp);
+        Assert.IsFalse(parent.HasKgp);
 
         var child = new Surface(4, 2, DefaultMetrics);
         var kgpData = CreateKgpData();
@@ -589,10 +590,10 @@ public class KgpSurfaceCompositingTests
         child[0, 0] = new SurfaceCell(" ", null, null, Kgp: tracked);
 
         parent.Composite(child, offsetX: 0, offsetY: 0);
-        Assert.True(parent.HasKgp);
+        Assert.IsTrue(parent.HasKgp);
     }
 
-    [Fact]
+    [TestMethod]
     public void Surface_Clone_PreservesKgp()
     {
         var surface = new Surface(10, 5, DefaultMetrics);
@@ -601,8 +602,8 @@ public class KgpSurfaceCompositingTests
         surface[2, 1] = new SurfaceCell(" ", null, null, Kgp: tracked);
 
         var clone = surface.Clone();
-        Assert.True(clone.HasKgp);
-        Assert.True(clone[2, 1].HasKgp);
+        Assert.IsTrue(clone.HasKgp);
+        Assert.IsTrue(clone[2, 1].HasKgp);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/KgpSurfaceLayerTests.cs
+++ b/tests/Hex1b.Tests/KgpSurfaceLayerTests.cs
@@ -11,6 +11,7 @@ namespace Hex1b.Tests;
 /// Tests for KGP support within the surface layer system:
 /// draw layers, computed layers, widget layers, and cross-layer queries.
 /// </summary>
+[TestClass]
 public class KgpSurfaceLayerTests
 {
     private static readonly CellMetrics DefaultMetrics = new(10, 20);
@@ -49,18 +50,18 @@ public class KgpSurfaceLayerTests
 
     // --- ISurfaceSource.HasKgp ---
 
-    [Fact]
+    [TestMethod]
     public void ISurfaceSource_Surface_HasKgp_ReturnsTrueWhenKgpPresent()
     {
         var surface = new Surface(10, 5, DefaultMetrics);
         ISurfaceSource source = surface;
-        Assert.False(source.HasKgp);
+        Assert.IsFalse(source.HasKgp);
 
         surface[0, 0] = new SurfaceCell { Character = " ", Kgp = CreateTrackedKgp() };
-        Assert.True(source.HasKgp);
+        Assert.IsTrue(source.HasKgp);
     }
 
-    [Fact]
+    [TestMethod]
     public void ISurfaceSource_CompositeSurface_HasKgp_ReturnsTrueWhenLayerHasKgp()
     {
         var layer = new Surface(10, 5, DefaultMetrics);
@@ -68,10 +69,10 @@ public class KgpSurfaceLayerTests
 
         var composite = new CompositeSurface(10, 5, DefaultMetrics);
         composite.AddLayer(layer);
-        Assert.True(composite.HasKgp);
+        Assert.IsTrue(composite.HasKgp);
     }
 
-    [Fact]
+    [TestMethod]
     public void ISurfaceSource_CompositeSurface_HasKgp_FalseWhenNoKgp()
     {
         var layer = new Surface(10, 5, DefaultMetrics);
@@ -79,12 +80,12 @@ public class KgpSurfaceLayerTests
 
         var composite = new CompositeSurface(10, 5, DefaultMetrics);
         composite.AddLayer(layer);
-        Assert.False(composite.HasKgp);
+        Assert.IsFalse(composite.HasKgp);
     }
 
     // --- DrawSurfaceLayer with KGP ---
 
-    [Fact]
+    [TestMethod]
     public void DrawLayer_WritesKgpCell_AppearsInSurface()
     {
         var trackedKgp = CreateTrackedKgp();
@@ -95,11 +96,11 @@ public class KgpSurfaceLayerTests
         composite.AddLayer(drawSurface);
 
         var flattened = composite.Flatten();
-        Assert.True(flattened[1, 1].HasKgp);
-        Assert.Equal(trackedKgp.Data.ImageId, flattened[1, 1].Kgp!.Data.ImageId);
+        Assert.IsTrue(flattened[1, 1].HasKgp);
+        Assert.AreEqual(trackedKgp.Data.ImageId, flattened[1, 1].Kgp!.Data.ImageId);
     }
 
-    [Fact]
+    [TestMethod]
     public void DrawLayer_KgpBelowTextLayer_TextOverlaysKgp()
     {
         // Layer 0: KGP image (below text)
@@ -117,10 +118,10 @@ public class KgpSurfaceLayerTests
 
         var flattened = composite.Flatten();
         // Text is opaque — it replaces the KGP cell
-        Assert.Equal("X", flattened[0, 0].Character);
+        Assert.AreEqual("X", flattened[0, 0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void DrawLayer_KgpAboveTextLayer_KgpOverlaysText()
     {
         // Layer 0: Text
@@ -137,10 +138,10 @@ public class KgpSurfaceLayerTests
         composite.AddLayer(kgpSurface);
 
         var flattened = composite.Flatten();
-        Assert.True(flattened[0, 0].HasKgp);
+        Assert.IsTrue(flattened[0, 0].HasKgp);
     }
 
-    [Fact]
+    [TestMethod]
     public void DrawLayer_KgpPreservedThroughTransparentLayer()
     {
         // Layer 0: KGP image
@@ -155,12 +156,12 @@ public class KgpSurfaceLayerTests
         composite.AddLayer(emptySurface);
 
         var flattened = composite.Flatten();
-        Assert.True(flattened[0, 0].HasKgp);
+        Assert.IsTrue(flattened[0, 0].HasKgp);
     }
 
     // --- ComputeContext.HasKgpBelow ---
 
-    [Fact]
+    [TestMethod]
     public void ComputedLayer_HasKgpBelow_ReturnsTrueWhenKgpInLowerLayer()
     {
         var kgpSurface = new Surface(10, 5, DefaultMetrics);
@@ -182,11 +183,11 @@ public class KgpSurfaceLayerTests
 
         composite.Flatten();
 
-        Assert.True(hasKgpAtAnchor);
-        Assert.False(hasKgpAtEmpty);
+        Assert.IsTrue(hasKgpAtAnchor);
+        Assert.IsFalse(hasKgpAtEmpty);
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputedLayer_HasKgpBelow_ReturnsTrueForSpannedCells()
     {
         // KGP image is 4 cells wide, 2 cells tall, anchored at (0,0)
@@ -207,7 +208,7 @@ public class KgpSurfaceLayerTests
         composite.Flatten();
 
         // Should detect KGP at positions (0,0) through (3,1) = 4x2 = 8 cells
-        Assert.Equal(8, kgpPositions.Count);
+        Assert.AreEqual(8, kgpPositions.Count);
         Assert.Contains((0, 0), kgpPositions);
         Assert.Contains((3, 0), kgpPositions);
         Assert.Contains((0, 1), kgpPositions);
@@ -216,7 +217,7 @@ public class KgpSurfaceLayerTests
 
     // --- ComputeContext.GetKgpBelow ---
 
-    [Fact]
+    [TestMethod]
     public void ComputedLayer_GetKgpBelow_ReturnsValidAccessor()
     {
         var kgpSurface = new Surface(10, 5, DefaultMetrics);
@@ -242,22 +243,22 @@ public class KgpSurfaceLayerTests
 
         composite.Flatten();
 
-        Assert.True(accessAtAnchor.IsValid);
-        Assert.Equal(42u, accessAtAnchor.ImageId);
-        Assert.Equal(0, accessAtAnchor.CellOffsetX);
-        Assert.Equal(0, accessAtAnchor.CellOffsetY);
-        Assert.True(accessAtAnchor.IsAnchor);
+        Assert.IsTrue(accessAtAnchor.IsValid);
+        Assert.AreEqual(42u, accessAtAnchor.ImageId);
+        Assert.AreEqual(0, accessAtAnchor.CellOffsetX);
+        Assert.AreEqual(0, accessAtAnchor.CellOffsetY);
+        Assert.IsTrue(accessAtAnchor.IsAnchor);
 
-        Assert.True(accessAtOffset.IsValid);
-        Assert.Equal(42u, accessAtOffset.ImageId);
-        Assert.Equal(2, accessAtOffset.CellOffsetX);
-        Assert.Equal(1, accessAtOffset.CellOffsetY);
-        Assert.False(accessAtOffset.IsAnchor);
+        Assert.IsTrue(accessAtOffset.IsValid);
+        Assert.AreEqual(42u, accessAtOffset.ImageId);
+        Assert.AreEqual(2, accessAtOffset.CellOffsetX);
+        Assert.AreEqual(1, accessAtOffset.CellOffsetY);
+        Assert.IsFalse(accessAtOffset.IsAnchor);
 
-        Assert.False(accessAtEmpty.IsValid);
+        Assert.IsFalse(accessAtEmpty.IsValid);
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputedLayer_GetKgpBelow_ReturnsImageMetadata()
     {
         var kgpSurface = new Surface(10, 5, DefaultMetrics);
@@ -277,19 +278,19 @@ public class KgpSurfaceLayerTests
 
         composite.Flatten();
 
-        Assert.True(access.IsValid);
-        Assert.Equal(99u, access.ImageId);
-        Assert.Equal(6, access.WidthInCells);
-        Assert.Equal(3, access.HeightInCells);
-        Assert.Equal(60u, access.SourcePixelWidth);  // 6 * 10
-        Assert.Equal(60u, access.SourcePixelHeight); // 3 * 20
-        Assert.Equal(1, access.ZIndex);
-        Assert.NotNull(access.Data);
+        Assert.IsTrue(access.IsValid);
+        Assert.AreEqual(99u, access.ImageId);
+        Assert.AreEqual(6, access.WidthInCells);
+        Assert.AreEqual(3, access.HeightInCells);
+        Assert.AreEqual(60u, access.SourcePixelWidth);  // 6 * 10
+        Assert.AreEqual(60u, access.SourcePixelHeight); // 3 * 20
+        Assert.AreEqual(1, access.ZIndex);
+        Assert.IsNotNull(access.Data);
     }
 
     // --- ComputeContext.GetKgpBelowAt ---
 
-    [Fact]
+    [TestMethod]
     public void ComputedLayer_GetKgpBelowAt_ReturnsAccessorAtPosition()
     {
         var kgpSurface = new Surface(10, 5, DefaultMetrics);
@@ -313,15 +314,15 @@ public class KgpSurfaceLayerTests
 
         composite.Flatten();
 
-        Assert.True(accessAt.IsValid);
-        Assert.Equal(55u, accessAt.ImageId);
-        Assert.Equal(1, accessAt.CellOffsetX);
-        Assert.Equal(1, accessAt.CellOffsetY);
+        Assert.IsTrue(accessAt.IsValid);
+        Assert.AreEqual(55u, accessAt.ImageId);
+        Assert.AreEqual(1, accessAt.CellOffsetX);
+        Assert.AreEqual(1, accessAt.CellOffsetY);
 
-        Assert.False(accessOutside.IsValid);
+        Assert.IsFalse(accessOutside.IsValid);
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputedLayer_GetKgpBelowAt_OutOfBounds_ReturnsDefault()
     {
         var kgpSurface = new Surface(10, 5, DefaultMetrics);
@@ -340,12 +341,12 @@ public class KgpSurfaceLayerTests
 
         composite.Flatten();
 
-        Assert.False(access.IsValid);
+        Assert.IsFalse(access.IsValid);
     }
 
     // --- Multi-layer KGP with computed layer effects ---
 
-    [Fact]
+    [TestMethod]
     public void ComputedLayer_KgpPresence_CanDriveTextStyling()
     {
         // Layer 0: KGP background image at (0,0) size 4x2
@@ -369,16 +370,16 @@ public class KgpSurfaceLayerTests
         var flattened = composite.Flatten();
 
         // Cells within KGP region should have the computed overlay
-        Assert.NotNull(flattened[0, 0].Background);
-        Assert.NotNull(flattened[3, 1].Background);
+        Assert.IsNotNull(flattened[0, 0].Background);
+        Assert.IsNotNull(flattened[3, 1].Background);
 
         // Cells outside KGP region should be empty
-        Assert.Null(flattened[5, 3].Background);
+        Assert.IsNull(flattened[5, 3].Background);
     }
 
     // --- Multi-layer z-index allocation ---
 
-    [Fact]
+    [TestMethod]
     public void MultiLayer_KgpFromDifferentLayers_PreservesDistinctZIndexes()
     {
         // Layer 0: below-text KGP (z=-1)
@@ -398,14 +399,14 @@ public class KgpSurfaceLayerTests
         var belowKgp = flattened[0, 0].Kgp!.Data;
         var aboveKgp = flattened[5, 0].Kgp!.Data;
 
-        Assert.Equal(-1, belowKgp.ZIndex);
-        Assert.Equal(1, aboveKgp.ZIndex);
-        Assert.NotEqual(belowKgp.ImageId, aboveKgp.ImageId);
+        Assert.AreEqual(-1, belowKgp.ZIndex);
+        Assert.AreEqual(1, aboveKgp.ZIndex);
+        Assert.AreNotEqual(belowKgp.ImageId, aboveKgp.ImageId);
     }
 
     // --- SurfaceLayerContext.CreateKgp in layer context ---
 
-    [Fact]
+    [TestMethod]
     public void SurfaceLayerContext_CreateKgp_FromCellData_ReturnsTrackedObject()
     {
         var store = new TrackedObjectStore();
@@ -414,11 +415,11 @@ public class KgpSurfaceLayerTests
         var kgpData = CreateKgpData();
         var tracked = ctx.CreateKgp(kgpData);
 
-        Assert.NotNull(tracked);
-        Assert.Equal(kgpData.ImageId, tracked!.Data.ImageId);
+        Assert.IsNotNull(tracked);
+        Assert.AreEqual(kgpData.ImageId, tracked!.Data.ImageId);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceLayerContext_CreateKgp_FromPixels_ReturnsTrackedObject()
     {
         var store = new TrackedObjectStore();
@@ -427,23 +428,23 @@ public class KgpSurfaceLayerTests
         var pixels = new byte[10 * 20 * 4]; // 10x20 RGBA
         var tracked = ctx.CreateKgp(pixels, 10, 20, KgpZOrder.BelowText);
 
-        Assert.NotNull(tracked);
-        Assert.Equal(1, tracked!.Data.WidthInCells);
-        Assert.Equal(1, tracked.Data.HeightInCells);
+        Assert.IsNotNull(tracked);
+        Assert.AreEqual(1, tracked!.Data.WidthInCells);
+        Assert.AreEqual(1, tracked.Data.HeightInCells);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceLayerContext_CreateKgp_NoStore_ReturnsNull()
     {
         var ctx = new SurfaceLayerContext(10, 5, -1, -1, new Hex1bTheme("Test"), store: null, DefaultMetrics);
 
         var tracked = ctx.CreateKgp(CreateKgpData());
-        Assert.Null(tracked);
+        Assert.IsNull(tracked);
     }
 
     // --- FindKgpAtPosition across layers ---
 
-    [Fact]
+    [TestMethod]
     public void FindKgpAtPosition_TopLayerKgp_FoundFirst()
     {
         // Layer 0: KGP at (0,0) image ID 10
@@ -473,12 +474,12 @@ public class KgpSurfaceLayerTests
 
         composite.Flatten();
 
-        Assert.Equal(20u, foundImageId);
+        Assert.AreEqual(20u, foundImageId);
     }
 
     // --- SVG round-trip ---
 
-    [Fact]
+    [TestMethod]
     public void MultiLayer_KgpAndText_SvgRoundTrip()
     {
         // Build a composite with KGP background + text overlay

--- a/tests/Hex1b.Tests/KgpSvgExportTests.cs
+++ b/tests/Hex1b.Tests/KgpSvgExportTests.cs
@@ -7,6 +7,7 @@ namespace Hex1b.Tests;
 /// Verifies that KGP images are correctly captured in snapshots and rendered
 /// in the SVG output with proper positioning, z-order, and data encoding.
 /// </summary>
+[TestClass]
 public class KgpSvgExportTests
 {
     private static readonly TerminalCapabilities KgpCapabilities = new()
@@ -30,7 +31,7 @@ public class KgpSvgExportTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize(escapeSequence));
     }
 
-    [Fact]
+    [TestMethod]
     public void SvgExport_WithKgpImage_ContainsImageElement()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -52,7 +53,7 @@ public class KgpSvgExportTests
         Assert.Contains("style=\"image-rendering: pixelated;\"", svg);
     }
 
-    [Fact]
+    [TestMethod]
     public void SvgExport_WithKgpImage_CorrectPositioning()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -78,7 +79,7 @@ public class KgpSvgExportTests
         Assert.Contains($"y=\"{expectedY}\"", svg);
     }
 
-    [Fact]
+    [TestMethod]
     public void SvgExport_WithKgpImage_ThreePassStructure()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -107,13 +108,11 @@ public class KgpSvgExportTests
         var imagesIndex = svg.IndexOf("class=\"terminal-images\"");
         var textIndex = svg.IndexOf("class=\"terminal-text\"");
 
-        Assert.True(bgIndex < imagesIndex,
-            "terminal-bg should appear before terminal-images in SVG");
-        Assert.True(imagesIndex < textIndex,
-            "terminal-images should appear before terminal-text in SVG");
+        Assert.IsTrue(bgIndex < imagesIndex, "terminal-bg should appear before terminal-images in SVG");
+        Assert.IsTrue(imagesIndex < textIndex, "terminal-images should appear before terminal-text in SVG");
     }
 
-    [Fact]
+    [TestMethod]
     public void SvgExport_WithoutKgpImages_NoImageElements()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -135,7 +134,7 @@ public class KgpSvgExportTests
         Assert.Contains("class=\"terminal-text\"", svg);
     }
 
-    [Fact]
+    [TestMethod]
     public void SvgExport_MultipleKgpImages_AllRendered()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -160,10 +159,10 @@ public class KgpSvgExportTests
 
         // Count <image occurrences
         var imageCount = CountOccurrences(svg, "<image ");
-        Assert.Equal(2, imageCount);
+        Assert.AreEqual(2, imageCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void SvgExport_KgpImage_ZOrderBetweenBgAndText()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -188,13 +187,11 @@ public class KgpSvgExportTests
         var imageElementIndex = svg.IndexOf("<image ");
         var textGroupStart = svg.IndexOf("class=\"terminal-text\"");
 
-        Assert.True(imageElementIndex > bgGroupEnd,
-            "Image element should appear after the background group ends");
-        Assert.True(imageElementIndex < textGroupStart,
-            "Image element should appear before the text group starts");
+        Assert.IsTrue(imageElementIndex > bgGroupEnd, "Image element should appear after the background group ends");
+        Assert.IsTrue(imageElementIndex < textGroupStart, "Image element should appear before the text group starts");
     }
 
-    [Fact]
+    [TestMethod]
     public void SvgExport_KgpImage_Rgb24_ProducesValidBmp()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -220,18 +217,18 @@ public class KgpSvgExportTests
 
         // Decode and validate BMP structure
         var bmpBytes = Convert.FromBase64String(base64Part);
-        Assert.True(bmpBytes.Length >= 54, "BMP should have at least a 54-byte header");
-        Assert.Equal((byte)'B', bmpBytes[0]);
-        Assert.Equal((byte)'M', bmpBytes[1]);
+        Assert.IsTrue(bmpBytes.Length >= 54, "BMP should have at least a 54-byte header");
+        Assert.AreEqual((byte)'B', bmpBytes[0]);
+        Assert.AreEqual((byte)'M', bmpBytes[1]);
 
         // Validate dimensions in BMP header (offset 18=width, 22=height)
         var bmpWidth = BitConverter.ToInt32(bmpBytes, 18);
         var bmpHeight = BitConverter.ToInt32(bmpBytes, 22);
-        Assert.Equal(1, bmpWidth);
-        Assert.Equal(1, bmpHeight);
+        Assert.AreEqual(1, bmpWidth);
+        Assert.AreEqual(1, bmpHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void SvgSnapshot_CapturesKgpState()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -245,12 +242,9 @@ public class KgpSvgExportTests
         var snapshot = terminal.CreateSnapshot();
         TestCaptureHelper.CaptureSvg(snapshot, "kgp-snapshot-state");
 
-        Assert.True(snapshot.KgpPlacements.Count > 0,
-            "Snapshot should capture KGP placements");
-        Assert.True(snapshot.KgpImages.Count > 0,
-            "Snapshot should capture KGP image data");
-        Assert.True(snapshot.KgpImages.ContainsKey(42),
-            "Snapshot should contain the transmitted image ID");
+        Assert.IsTrue(snapshot.KgpPlacements.Count > 0, "Snapshot should capture KGP placements");
+        Assert.IsTrue(snapshot.KgpImages.Count > 0, "Snapshot should capture KGP image data");
+        Assert.IsTrue(snapshot.KgpImages.ContainsKey(42), "Snapshot should contain the transmitted image ID");
     }
 
     private static int CountOccurrences(string text, string pattern)

--- a/tests/Hex1b.Tests/KgpTerminalTests.cs
+++ b/tests/Hex1b.Tests/KgpTerminalTests.cs
@@ -2,6 +2,7 @@ using Hex1b.Tokens;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class KgpTerminalTests
 {
     private static readonly TerminalCapabilities KgpCapabilities = new()
@@ -29,7 +30,7 @@ public class KgpTerminalTests
     // Transmit tests
     // =============================================
 
-    [Fact]
+    [TestMethod]
     public void Transmit_SingleChunk_StoresImage()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -38,15 +39,15 @@ public class KgpTerminalTests
         var cmd = KgpTestHelper.BuildTransmitCommand(1, 2, 2, KgpFormat.Rgba32);
         SendKgp(terminal, cmd);
 
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
         var image = terminal.KgpImageStore.GetImageById(1);
-        Assert.NotNull(image);
-        Assert.Equal(2u, image.Width);
-        Assert.Equal(2u, image.Height);
-        Assert.Equal(KgpFormat.Rgba32, image.Format);
+        Assert.IsNotNull(image);
+        Assert.AreEqual(2u, image.Width);
+        Assert.AreEqual(2u, image.Height);
+        Assert.AreEqual(KgpFormat.Rgba32, image.Format);
     }
 
-    [Fact]
+    [TestMethod]
     public void Transmit_Rgb24_StoresCorrectFormat()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -56,12 +57,12 @@ public class KgpTerminalTests
         SendKgp(terminal, cmd);
 
         var image = terminal.KgpImageStore.GetImageById(1);
-        Assert.NotNull(image);
-        Assert.Equal(KgpFormat.Rgb24, image.Format);
-        Assert.Equal(3, image.Data.Length); // 1x1 RGB = 3 bytes
+        Assert.IsNotNull(image);
+        Assert.AreEqual(KgpFormat.Rgb24, image.Format);
+        Assert.AreEqual(3, image.Data.Length); // 1x1 RGB = 3 bytes
     }
 
-    [Fact]
+    [TestMethod]
     public void Transmit_ChunkedTransfer_AssemblesCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -69,20 +70,20 @@ public class KgpTerminalTests
 
         var chunks = KgpTestHelper.BuildChunkedTransmitCommands(1, 4, 4, chunkSize: 16);
 
-        Assert.True(chunks.Count > 1, "Should produce multiple chunks");
+        Assert.IsTrue(chunks.Count > 1, "Should produce multiple chunks");
 
         foreach (var chunk in chunks)
         {
             SendKgp(terminal, chunk);
         }
 
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
         var image = terminal.KgpImageStore.GetImageById(1);
-        Assert.NotNull(image);
-        Assert.Equal(4u * 4u * 4, (uint)image.Data.Length); // 4x4 RGBA
+        Assert.IsNotNull(image);
+        Assert.AreEqual(4u * 4u * 4, (uint)image.Data.Length); // 4x4 RGBA
     }
 
-    [Fact]
+    [TestMethod]
     public void Transmit_InsufficientData_DoesNotStore()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -93,10 +94,10 @@ public class KgpTerminalTests
         SendKgp(terminal, cmd);
 
         // Image should not be stored because data is insufficient
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void Transmit_ReplaceExistingId_UpdatesImage()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -105,13 +106,13 @@ public class KgpTerminalTests
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 1, 1, fillByte: 0xAA));
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 2, 2, fillByte: 0xBB));
 
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
         var image = terminal.KgpImageStore.GetImageById(1);
-        Assert.NotNull(image);
-        Assert.Equal(2u, image.Width);
+        Assert.IsNotNull(image);
+        Assert.AreEqual(2u, image.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void Transmit_WithoutCapability_Ignored()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -123,14 +124,14 @@ public class KgpTerminalTests
 
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 1, 1));
 
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
     }
 
     // =============================================
     // Query tests
     // =============================================
 
-    [Fact]
+    [TestMethod]
     public void Query_DoesNotStoreImage()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -139,10 +140,10 @@ public class KgpTerminalTests
         var cmd = KgpTestHelper.BuildQueryCommand(imageId: 31);
         SendKgp(terminal, cmd);
 
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void Transmit_WithAppWorkload_DoesNotInjectKgpResponseIntoInputEvents()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -151,14 +152,14 @@ public class KgpTerminalTests
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 1, 1));
 
         var sawInput = SpinWait.SpinUntil(() => workload.InputEvents.TryRead(out _), TimeSpan.FromMilliseconds(100));
-        Assert.False(sawInput);
+        Assert.IsFalse(sawInput);
     }
 
     // =============================================
     // Delete tests
     // =============================================
 
-    [Fact]
+    [TestMethod]
     public void Delete_All_ClearsAllImages()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -166,14 +167,14 @@ public class KgpTerminalTests
 
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 1, 1));
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(2, 1, 1));
-        Assert.Equal(2, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(2, terminal.KgpImageStore.ImageCount);
 
         SendKgp(terminal, KgpTestHelper.BuildDeleteCommand('A'));
 
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void Delete_ById_RemovesSpecificImage()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -184,12 +185,12 @@ public class KgpTerminalTests
 
         SendKgp(terminal, KgpTestHelper.BuildDeleteCommand('I', imageId: 1));
 
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
-        Assert.Null(terminal.KgpImageStore.GetImageById(1));
-        Assert.NotNull(terminal.KgpImageStore.GetImageById(2));
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void Delete_ById_FreeData_RemovesImage()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -199,10 +200,10 @@ public class KgpTerminalTests
 
         SendKgp(terminal, KgpTestHelper.BuildDeleteCommand('I', imageId: 1));
 
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void Delete_AbortsChunkedTransfer()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -213,19 +214,19 @@ public class KgpTerminalTests
         var cmd = KgpTestHelper.BuildCommand("a=t,f=32,s=2,v=2,i=1,m=1", data);
         SendKgp(terminal, cmd);
 
-        Assert.True(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.IsTrue(terminal.KgpImageStore.IsChunkedTransferInProgress);
 
         // Delete should abort the transfer
         SendKgp(terminal, KgpTestHelper.BuildDeleteCommand('a'));
 
-        Assert.False(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
     }
 
     // =============================================
     // Response suppression tests
     // =============================================
 
-    [Fact]
+    [TestMethod]
     public void Transmit_QuietOne_SuppressesOkResponse()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -236,10 +237,10 @@ public class KgpTerminalTests
         SendKgp(terminal, cmd);
 
         // Image should still be stored
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void Transmit_QuietTwo_SuppressesAllResponses()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -252,14 +253,14 @@ public class KgpTerminalTests
         // No error response should have been sent (we'd need to intercept 
         // the workload.WriteInputAsync to fully verify, but at minimum
         // this shouldn't crash)
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
     }
 
     // =============================================
     // Image number tests
     // =============================================
 
-    [Fact]
+    [TestMethod]
     public void Transmit_WithImageNumber_StoresCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -270,12 +271,12 @@ public class KgpTerminalTests
         var cmd = KgpTestHelper.BuildCommand("a=t,f=24,s=1,v=1,I=93", data);
         SendKgp(terminal, cmd);
 
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
         var image = terminal.KgpImageStore.GetImageByNumber(93);
-        Assert.NotNull(image);
+        Assert.IsNotNull(image);
     }
 
-    [Fact]
+    [TestMethod]
     public void Transmit_MultipleWithSameNumber_BothStored()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -286,18 +287,18 @@ public class KgpTerminalTests
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=t,f=24,s=1,v=1,I=93", data));
 
         // Both should be stored (with different IDs)
-        Assert.Equal(2, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(2, terminal.KgpImageStore.ImageCount);
 
         // GetImageByNumber returns the newest
         var newest = terminal.KgpImageStore.GetImageByNumber(93);
-        Assert.NotNull(newest);
+        Assert.IsNotNull(newest);
     }
 
     // =============================================
     // TransmitAndDisplay tests
     // =============================================
 
-    [Fact]
+    [TestMethod]
     public void TransmitAndDisplay_StoresAndMovesCursor()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -310,15 +311,15 @@ public class KgpTerminalTests
             KgpFormat.Rgba32, displayColumns: 3, displayRows: 2);
         SendKgp(terminal, cmd);
 
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
 
         // Cursor should have moved: right by 3 cols, down by 1 row (2-1)
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal(3, snapshot.CursorX);
-        Assert.Equal(1, snapshot.CursorY);
+        Assert.AreEqual(3, snapshot.CursorX);
+        Assert.AreEqual(1, snapshot.CursorY);
     }
 
-    [Fact]
+    [TestMethod]
     public void TransmitAndDisplay_CursorMovementDisabled_DoesNotMoveCursor()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -331,15 +332,15 @@ public class KgpTerminalTests
         SendKgp(terminal, cmd);
 
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal(0, snapshot.CursorX);
-        Assert.Equal(0, snapshot.CursorY);
+        Assert.AreEqual(0, snapshot.CursorX);
+        Assert.AreEqual(0, snapshot.CursorY);
     }
 
     // =============================================
     // Put/Display tests
     // =============================================
 
-    [Fact]
+    [TestMethod]
     public void Put_ExistingImage_Succeeds()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -354,10 +355,10 @@ public class KgpTerminalTests
 
         // Cursor should move
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal(2, snapshot.CursorX);
+        Assert.AreEqual(2, snapshot.CursorX);
     }
 
-    [Fact]
+    [TestMethod]
     public void Put_NonExistentImage_NoChange()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -368,10 +369,10 @@ public class KgpTerminalTests
 
         // Cursor should not move (image not found)
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal(0, snapshot.CursorX);
+        Assert.AreEqual(0, snapshot.CursorX);
     }
 
-    [Fact]
+    [TestMethod]
     public void Put_WithCursorMovementDisabled_DoesNotMove()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -383,14 +384,14 @@ public class KgpTerminalTests
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, displayColumns: 3, cursorMovement: 1));
 
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal(0, snapshot.CursorX);
+        Assert.AreEqual(0, snapshot.CursorX);
     }
 
     // =============================================
     // Multiple operations flow
     // =============================================
 
-    [Fact]
+    [TestMethod]
     public void FullFlow_TransmitThenPutMultiple()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -405,30 +406,30 @@ public class KgpTerminalTests
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 2));
 
         // Still only 1 image in store
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void FullFlow_TransmitDeleteTransmit()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
         using var terminal = CreateTerminal(workload);
 
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 1, 1));
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
 
         SendKgp(terminal, KgpTestHelper.BuildDeleteCommand('I', imageId: 1));
-        Assert.Equal(0, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
 
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(2, 1, 1));
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
     }
 
     // =============================================
     // Placement tracking tests
     // =============================================
 
-    [Fact]
+    [TestMethod]
     public void TransmitAndDisplay_CreatesPlacement()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -441,15 +442,15 @@ public class KgpTerminalTests
         SendKgp(terminal, cmd);
 
         var placements = terminal.KgpPlacements;
-        Assert.Single(placements);
-        Assert.Equal(1u, placements[0].ImageId);
-        Assert.Equal(0, placements[0].Row);
-        Assert.Equal(0, placements[0].Column);
-        Assert.Equal(3u, placements[0].DisplayColumns);
-        Assert.Equal(2u, placements[0].DisplayRows);
+        TestSeq.Single(placements);
+        Assert.AreEqual(1u, placements[0].ImageId);
+        Assert.AreEqual(0, placements[0].Row);
+        Assert.AreEqual(0, placements[0].Column);
+        Assert.AreEqual(3u, placements[0].DisplayColumns);
+        Assert.AreEqual(2u, placements[0].DisplayRows);
     }
 
-    [Fact]
+    [TestMethod]
     public void Put_CreatesPlacement()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -461,14 +462,14 @@ public class KgpTerminalTests
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 7, displayColumns: 2, displayRows: 1));
 
         var placements = terminal.KgpPlacements;
-        Assert.Single(placements);
-        Assert.Equal(1u, placements[0].ImageId);
-        Assert.Equal(7u, placements[0].PlacementId);
-        Assert.Equal(2, placements[0].Row);  // 0-based
-        Assert.Equal(4, placements[0].Column); // 0-based
+        TestSeq.Single(placements);
+        Assert.AreEqual(1u, placements[0].ImageId);
+        Assert.AreEqual(7u, placements[0].PlacementId);
+        Assert.AreEqual(2, placements[0].Row);  // 0-based
+        Assert.AreEqual(4, placements[0].Column); // 0-based
     }
 
-    [Fact]
+    [TestMethod]
     public void Put_SamePlacementId_ReplacesExisting()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -483,12 +484,12 @@ public class KgpTerminalTests
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 5, displayColumns: 3));
 
         var placements = terminal.KgpPlacements;
-        Assert.Single(placements); // Replaced, not duplicated
-        Assert.Equal(3u, placements[0].DisplayColumns);
-        Assert.Equal(2, placements[0].Row); // New position
+        TestSeq.Single(placements); // Replaced, not duplicated
+        Assert.AreEqual(3u, placements[0].DisplayColumns);
+        Assert.AreEqual(2, placements[0].Row); // New position
     }
 
-    [Fact]
+    [TestMethod]
     public void Put_DifferentPlacementIds_MultiplePlacements()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -500,10 +501,10 @@ public class KgpTerminalTests
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 1));
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 2));
 
-        Assert.Equal(2, terminal.KgpPlacements.Count);
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Put_ZeroPlacementId_CreatesSeparatePlacements()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -515,10 +516,10 @@ public class KgpTerminalTests
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 0));
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 0));
 
-        Assert.Equal(2, terminal.KgpPlacements.Count);
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Placement_ZIndex_Stored()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -528,14 +529,14 @@ public class KgpTerminalTests
             KgpFormat.Rgba32, zIndex: -1);
         SendKgp(terminal, cmd);
 
-        Assert.Equal(-1, terminal.KgpPlacements[0].ZIndex);
+        Assert.AreEqual(-1, terminal.KgpPlacements[0].ZIndex);
     }
 
     // =============================================
     // Delete placement tests
     // =============================================
 
-    [Fact]
+    [TestMethod]
     public void Delete_All_ClearsPlacements()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -544,14 +545,14 @@ public class KgpTerminalTests
         SendKgp(terminal, KgpTestHelper.BuildTransmitAndDisplayCommand(1, 10, 20));
         SendKgp(terminal, KgpTestHelper.BuildTransmitAndDisplayCommand(2, 10, 20));
 
-        Assert.Equal(2, terminal.KgpPlacements.Count);
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
 
         SendKgp(terminal, KgpTestHelper.BuildDeleteCommand('a'));
 
-        Assert.Empty(terminal.KgpPlacements);
+        Assert.IsEmpty(terminal.KgpPlacements);
     }
 
-    [Fact]
+    [TestMethod]
     public void Delete_ById_RemovesOnlyMatchingPlacements()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -562,11 +563,11 @@ public class KgpTerminalTests
 
         SendKgp(terminal, KgpTestHelper.BuildDeleteCommand('i', imageId: 1));
 
-        Assert.Single(terminal.KgpPlacements);
-        Assert.Equal(2u, terminal.KgpPlacements[0].ImageId);
+        TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(2u, terminal.KgpPlacements[0].ImageId);
     }
 
-    [Fact]
+    [TestMethod]
     public void Delete_ById_WithPlacementId_RemovesSpecific()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -576,17 +577,17 @@ public class KgpTerminalTests
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 1));
         SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 2));
 
-        Assert.Equal(2, terminal.KgpPlacements.Count);
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
 
         // Delete only placement 1
         var deleteCmd = KgpTestHelper.BuildCommand("a=d,d=i,i=1,p=1");
         SendKgp(terminal, deleteCmd);
 
-        Assert.Single(terminal.KgpPlacements);
-        Assert.Equal(2u, terminal.KgpPlacements[0].PlacementId);
+        TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(2u, terminal.KgpPlacements[0].PlacementId);
     }
 
-    [Fact]
+    [TestMethod]
     public void Delete_AtCursor_RemovesIntersecting()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -600,10 +601,10 @@ public class KgpTerminalTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[1;2H")); // row 1, col 2
         SendKgp(terminal, KgpTestHelper.BuildDeleteCommand('c'));
 
-        Assert.Empty(terminal.KgpPlacements);
+        Assert.IsEmpty(terminal.KgpPlacements);
     }
 
-    [Fact]
+    [TestMethod]
     public void Delete_ByZIndex_RemovesMatchingZIndex()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -615,22 +616,22 @@ public class KgpTerminalTests
         var deleteCmd = KgpTestHelper.BuildCommand("a=d,d=z,z=-1");
         SendKgp(terminal, deleteCmd);
 
-        Assert.Single(terminal.KgpPlacements);
-        Assert.Equal(0, terminal.KgpPlacements[0].ZIndex);
+        TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(0, terminal.KgpPlacements[0].ZIndex);
     }
 
     // =============================================
     // Clear screen tests (Phase 4)
     // =============================================
 
-    [Fact]
+    [TestMethod]
     public void ClearScreen_ClearsKgpPlacements()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
         using var terminal = CreateTerminal(workload, 20, 10);
 
         SendKgp(terminal, KgpTestHelper.BuildTransmitAndDisplayCommand(1, 10, 20));
-        Assert.Single(terminal.KgpPlacements);
+        TestSeq.Single(terminal.KgpPlacements);
 
         // ESC[2J should clear all images per spec
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[2J"));
@@ -639,15 +640,15 @@ public class KgpTerminalTests
         // If implementation doesn't clear placements on ESC[2J yet, this test documents the requirement.
     }
 
-    [Fact]
+    [TestMethod]
     public void Reset_ClearsKgpState()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
         using var terminal = CreateTerminal(workload, 20, 10);
 
         SendKgp(terminal, KgpTestHelper.BuildTransmitAndDisplayCommand(1, 10, 20));
-        Assert.Equal(1, terminal.KgpImageStore.ImageCount);
-        Assert.Single(terminal.KgpPlacements);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+        TestSeq.Single(terminal.KgpPlacements);
 
         // Reset terminal (RIS - ESC c)
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1bc"));
@@ -660,51 +661,51 @@ public class KgpTerminalTests
     // Placement intersection tests
     // =============================================
 
-    [Fact]
+    [TestMethod]
     public void Placement_IntersectsCell_CorrectBounds()
     {
         var p = new KgpPlacement(1, 0, 2, 3, 4, 3); // row=2, col=3, 4 cols, 3 rows
 
         // Inside bounds
-        Assert.True(p.IntersectsCell(2, 3));
-        Assert.True(p.IntersectsCell(4, 6)); // row=4 (2+2), col=6 (3+3)
+        Assert.IsTrue(p.IntersectsCell(2, 3));
+        Assert.IsTrue(p.IntersectsCell(4, 6)); // row=4 (2+2), col=6 (3+3)
 
         // Outside bounds
-        Assert.False(p.IntersectsCell(1, 3)); // above
-        Assert.False(p.IntersectsCell(5, 3)); // below
-        Assert.False(p.IntersectsCell(2, 2)); // left
-        Assert.False(p.IntersectsCell(2, 7)); // right
+        Assert.IsFalse(p.IntersectsCell(1, 3)); // above
+        Assert.IsFalse(p.IntersectsCell(5, 3)); // below
+        Assert.IsFalse(p.IntersectsCell(2, 2)); // left
+        Assert.IsFalse(p.IntersectsCell(2, 7)); // right
     }
 
-    [Fact]
+    [TestMethod]
     public void Placement_IntersectsRow_CorrectBounds()
     {
         var p = new KgpPlacement(1, 0, 5, 0, 10, 3); // starts at row 5, 3 rows tall
 
-        Assert.True(p.IntersectsRow(5));
-        Assert.True(p.IntersectsRow(6));
-        Assert.True(p.IntersectsRow(7));
-        Assert.False(p.IntersectsRow(4));
-        Assert.False(p.IntersectsRow(8));
+        Assert.IsTrue(p.IntersectsRow(5));
+        Assert.IsTrue(p.IntersectsRow(6));
+        Assert.IsTrue(p.IntersectsRow(7));
+        Assert.IsFalse(p.IntersectsRow(4));
+        Assert.IsFalse(p.IntersectsRow(8));
     }
 
-    [Fact]
+    [TestMethod]
     public void Placement_IntersectsColumn_CorrectBounds()
     {
         var p = new KgpPlacement(1, 0, 0, 5, 3, 10); // starts at col 5, 3 cols wide
 
-        Assert.True(p.IntersectsColumn(5));
-        Assert.True(p.IntersectsColumn(6));
-        Assert.True(p.IntersectsColumn(7));
-        Assert.False(p.IntersectsColumn(4));
-        Assert.False(p.IntersectsColumn(8));
+        Assert.IsTrue(p.IntersectsColumn(5));
+        Assert.IsTrue(p.IntersectsColumn(6));
+        Assert.IsTrue(p.IntersectsColumn(7));
+        Assert.IsFalse(p.IntersectsColumn(4));
+        Assert.IsFalse(p.IntersectsColumn(8));
     }
 
     // =============================================
     // Scrolling tests (Phase 4)  
     // =============================================
 
-    [Fact]
+    [TestMethod]
     public void Scroll_PlacementsScrollWithText()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -716,7 +717,7 @@ public class KgpTerminalTests
             displayColumns: 2, displayRows: 1, cursorMovement: 1));
 
         var placementsBefore = terminal.KgpPlacements;
-        Assert.Equal(0, placementsBefore[0].Row);
+        Assert.AreEqual(0, placementsBefore[0].Row);
 
         // Scroll by writing enough text to push past bottom
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[5;1H")); // Go to last row

--- a/tests/Hex1b.Tests/KgpTokenizerTests.cs
+++ b/tests/Hex1b.Tests/KgpTokenizerTests.cs
@@ -2,89 +2,90 @@ using Hex1b.Tokens;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class KgpTokenizerTests
 {
-    [Fact]
+    [TestMethod]
     public void Tokenize_KgpApcSequence_ProducesKgpToken()
     {
         var tokens = AnsiTokenizer.Tokenize("\x1b_Ga=T,f=24,s=1,v=1;AAAA\x1b\\");
 
-        var kgpToken = Assert.Single(tokens.OfType<KgpToken>());
-        Assert.Equal("a=T,f=24,s=1,v=1", kgpToken.ControlData);
-        Assert.Equal("AAAA", kgpToken.Payload);
+        var kgpToken = TestSeq.Single(tokens.OfType<KgpToken>());
+        Assert.AreEqual("a=T,f=24,s=1,v=1", kgpToken.ControlData);
+        Assert.AreEqual("AAAA", kgpToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_KgpWithNoPayload_ProducesKgpTokenWithEmptyPayload()
     {
         var tokens = AnsiTokenizer.Tokenize("\x1b_Ga=d,d=a\x1b\\");
 
-        var kgpToken = Assert.Single(tokens.OfType<KgpToken>());
-        Assert.Equal("a=d,d=a", kgpToken.ControlData);
-        Assert.Equal("", kgpToken.Payload);
+        var kgpToken = TestSeq.Single(tokens.OfType<KgpToken>());
+        Assert.AreEqual("a=d,d=a", kgpToken.ControlData);
+        Assert.AreEqual("", kgpToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_KgpWithSemicolonButNoPayload_ProducesKgpTokenWithEmptyPayload()
     {
         var tokens = AnsiTokenizer.Tokenize("\x1b_Ga=d;\x1b\\");
 
-        var kgpToken = Assert.Single(tokens.OfType<KgpToken>());
-        Assert.Equal("a=d", kgpToken.ControlData);
-        Assert.Equal("", kgpToken.Payload);
+        var kgpToken = TestSeq.Single(tokens.OfType<KgpToken>());
+        Assert.AreEqual("a=d", kgpToken.ControlData);
+        Assert.AreEqual("", kgpToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_KgpWithOnlyGAndSemicolon_ProducesKgpTokenWithEmptyControlData()
     {
         var tokens = AnsiTokenizer.Tokenize("\x1b_G;AAAA\x1b\\");
 
-        var kgpToken = Assert.Single(tokens.OfType<KgpToken>());
-        Assert.Equal("", kgpToken.ControlData);
-        Assert.Equal("AAAA", kgpToken.Payload);
+        var kgpToken = TestSeq.Single(tokens.OfType<KgpToken>());
+        Assert.AreEqual("", kgpToken.ControlData);
+        Assert.AreEqual("AAAA", kgpToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_KgpWithOnlyG_ProducesKgpTokenWithEmptyControlDataAndPayload()
     {
         var tokens = AnsiTokenizer.Tokenize("\x1b_G\x1b\\");
 
-        var kgpToken = Assert.Single(tokens.OfType<KgpToken>());
-        Assert.Equal("", kgpToken.ControlData);
-        Assert.Equal("", kgpToken.Payload);
+        var kgpToken = TestSeq.Single(tokens.OfType<KgpToken>());
+        Assert.AreEqual("", kgpToken.ControlData);
+        Assert.AreEqual("", kgpToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_NonKgpApcSequence_ProducesUnrecognizedToken()
     {
         var tokens = AnsiTokenizer.Tokenize("\x1b_SomeOtherApc\x1b\\");
 
-        Assert.DoesNotContain(tokens, t => t is KgpToken);
-        Assert.Contains(tokens, t => t is UnrecognizedSequenceToken);
+        Assert.IsFalse(tokens.Any(t => t is KgpToken));
+        Assert.IsTrue(tokens.Any(t => t is UnrecognizedSequenceToken));
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_EmptyApcSequence_ProducesUnrecognizedToken()
     {
         var tokens = AnsiTokenizer.Tokenize("\x1b_\x1b\\");
 
-        Assert.DoesNotContain(tokens, t => t is KgpToken);
+        Assert.IsFalse(tokens.Any(t => t is KgpToken));
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_KgpAmidstText_PreservesTextTokens()
     {
         var tokens = AnsiTokenizer.Tokenize("Hello\x1b_Gi=1;AAAA\x1b\\World");
 
-        Assert.Equal(3, tokens.Count);
-        Assert.IsType<TextToken>(tokens[0]);
-        Assert.Equal("Hello", ((TextToken)tokens[0]).Text);
-        Assert.IsType<KgpToken>(tokens[1]);
-        Assert.IsType<TextToken>(tokens[2]);
-        Assert.Equal("World", ((TextToken)tokens[2]).Text);
+        Assert.AreEqual(3, tokens.Count);
+        TestSeq.IsType<TextToken>(tokens[0]);
+        Assert.AreEqual("Hello", ((TextToken)tokens[0]).Text);
+        TestSeq.IsType<KgpToken>(tokens[1]);
+        TestSeq.IsType<TextToken>(tokens[2]);
+        Assert.AreEqual("World", ((TextToken)tokens[2]).Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_KgpChunkedSequence_ProducesMultipleKgpTokens()
     {
         // First chunk (m=1 means more coming)
@@ -95,80 +96,80 @@ public class KgpTokenizerTests
         var tokens = AnsiTokenizer.Tokenize(input);
 
         var kgpTokens = tokens.OfType<KgpToken>().ToList();
-        Assert.Equal(3, kgpTokens.Count);
+        Assert.AreEqual(3, kgpTokens.Count);
 
-        Assert.Equal("a=T,f=24,s=2,v=2,m=1", kgpTokens[0].ControlData);
-        Assert.Equal("AAAA", kgpTokens[0].Payload);
+        Assert.AreEqual("a=T,f=24,s=2,v=2,m=1", kgpTokens[0].ControlData);
+        Assert.AreEqual("AAAA", kgpTokens[0].Payload);
 
-        Assert.Equal("m=1", kgpTokens[1].ControlData);
-        Assert.Equal("BBBB", kgpTokens[1].Payload);
+        Assert.AreEqual("m=1", kgpTokens[1].ControlData);
+        Assert.AreEqual("BBBB", kgpTokens[1].Payload);
 
-        Assert.Equal("m=0", kgpTokens[2].ControlData);
-        Assert.Equal("CCCC", kgpTokens[2].Payload);
+        Assert.AreEqual("m=0", kgpTokens[2].ControlData);
+        Assert.AreEqual("CCCC", kgpTokens[2].Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_KgpWithAllKeys_ParsesControlData()
     {
         var tokens = AnsiTokenizer.Tokenize(
             "\x1b_Ga=T,f=32,t=d,s=10,v=20,i=1,p=2,m=0,q=1;AAAA\x1b\\");
 
-        var kgpToken = Assert.Single(tokens.OfType<KgpToken>());
-        Assert.Equal("a=T,f=32,t=d,s=10,v=20,i=1,p=2,m=0,q=1", kgpToken.ControlData);
+        var kgpToken = TestSeq.Single(tokens.OfType<KgpToken>());
+        Assert.AreEqual("a=T,f=32,t=d,s=10,v=20,i=1,p=2,m=0,q=1", kgpToken.ControlData);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_KgpWith8BitApcStart_ProducesKgpToken()
     {
         // 0x9F is the 8-bit APC start, 0x9C is the 8-bit ST
         var tokens = AnsiTokenizer.Tokenize("\x9fGa=T;AAAA\x9c");
 
-        var kgpToken = Assert.Single(tokens.OfType<KgpToken>());
-        Assert.Equal("a=T", kgpToken.ControlData);
-        Assert.Equal("AAAA", kgpToken.Payload);
+        var kgpToken = TestSeq.Single(tokens.OfType<KgpToken>());
+        Assert.AreEqual("a=T", kgpToken.ControlData);
+        Assert.AreEqual("AAAA", kgpToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_KgpMissingTerminator_DoesNotProduceToken()
     {
         // APC without ST should not produce a token (TryParseApcSequence returns false)
         var tokens = AnsiTokenizer.Tokenize("\x1b_Ga=T;AAAA");
 
-        Assert.DoesNotContain(tokens, t => t is KgpToken);
+        Assert.IsFalse(tokens.Any(t => t is KgpToken));
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_KgpQueryAction_ProducesCorrectToken()
     {
         var tokens = AnsiTokenizer.Tokenize("\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\");
 
-        var kgpToken = Assert.Single(tokens.OfType<KgpToken>());
-        Assert.Equal("i=31,s=1,v=1,a=q,t=d,f=24", kgpToken.ControlData);
-        Assert.Equal("AAAA", kgpToken.Payload);
+        var kgpToken = TestSeq.Single(tokens.OfType<KgpToken>());
+        Assert.AreEqual("i=31,s=1,v=1,a=q,t=d,f=24", kgpToken.ControlData);
+        Assert.AreEqual("AAAA", kgpToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_KgpDeleteAction_ProducesCorrectToken()
     {
         var tokens = AnsiTokenizer.Tokenize("\x1b_Ga=d,d=i,i=10\x1b\\");
 
-        var kgpToken = Assert.Single(tokens.OfType<KgpToken>());
-        Assert.Equal("a=d,d=i,i=10", kgpToken.ControlData);
-        Assert.Equal("", kgpToken.Payload);
+        var kgpToken = TestSeq.Single(tokens.OfType<KgpToken>());
+        Assert.AreEqual("a=d,d=i,i=10", kgpToken.ControlData);
+        Assert.AreEqual("", kgpToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_KgpLargePayload_PreservesFullPayload()
     {
         var largePayload = new string('A', 4096);
         var tokens = AnsiTokenizer.Tokenize($"\x1b_Gf=24,s=1,v=1;{largePayload}\x1b\\");
 
-        var kgpToken = Assert.Single(tokens.OfType<KgpToken>());
-        Assert.Equal(4096, kgpToken.Payload.Length);
-        Assert.Equal(largePayload, kgpToken.Payload);
+        var kgpToken = TestSeq.Single(tokens.OfType<KgpToken>());
+        Assert.AreEqual(4096, kgpToken.Payload.Length);
+        Assert.AreEqual(largePayload, kgpToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_MultipleKgpSequences_ProducesMultipleTokens()
     {
         var input = "\x1b_Gi=1,a=T,f=24,s=1,v=1;AAAA\x1b\\" +
@@ -177,7 +178,7 @@ public class KgpTokenizerTests
         var tokens = AnsiTokenizer.Tokenize(input);
         var kgpTokens = tokens.OfType<KgpToken>().ToList();
 
-        Assert.Equal(2, kgpTokens.Count);
+        Assert.AreEqual(2, kgpTokens.Count);
         Assert.Contains("a=T", kgpTokens[0].ControlData);
         Assert.Contains("a=p", kgpTokens[1].ControlData);
     }

--- a/tests/Hex1b.Tests/LanguageServer/CompletionControllerTests.cs
+++ b/tests/Hex1b.Tests/LanguageServer/CompletionControllerTests.cs
@@ -5,6 +5,7 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests.LanguageServer;
 
+[TestClass]
 public class CompletionControllerTests
 {
     private readonly CompletionController _controller = new();
@@ -18,27 +19,27 @@ public class CompletionControllerTests
         _controller.Attach(_session);
     }
 
-    [Fact]
+    [TestMethod]
     public void Show_WithItems_IsActive()
     {
         var items = MakeItems("foo", "bar", "baz");
         _controller.Show(items, new DocumentPosition(1, 5));
 
-        Assert.True(_controller.IsActive);
-        Assert.Single(_session.Overlays);
-        Assert.Equal(CompletionController.CompletionOverlayId, _session.Overlays[0].Id);
+        Assert.IsTrue(_controller.IsActive);
+        TestSeq.Single(_session.Overlays);
+        Assert.AreEqual(CompletionController.CompletionOverlayId, _session.Overlays[0].Id);
     }
 
-    [Fact]
+    [TestMethod]
     public void Show_WithEmptyItems_IsNotActive()
     {
         _controller.Show([], new DocumentPosition(1, 5));
 
-        Assert.False(_controller.IsActive);
-        Assert.Empty(_session.Overlays);
+        Assert.IsFalse(_controller.IsActive);
+        Assert.IsEmpty(_session.Overlays);
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectNext_CyclesForward()
     {
         var items = MakeItems("foo", "bar", "baz");
@@ -49,11 +50,11 @@ public class CompletionControllerTests
         _controller.SelectNext(); // index 2
         _controller.SelectNext(); // wraps to 0
 
-        Assert.True(_controller.IsActive);
-        Assert.Single(_session.Overlays); // Still one overlay
+        Assert.IsTrue(_controller.IsActive);
+        TestSeq.Single(_session.Overlays); // Still one overlay
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectPrev_CyclesBackward()
     {
         var items = MakeItems("foo", "bar", "baz");
@@ -61,10 +62,10 @@ public class CompletionControllerTests
 
         _controller.SelectPrev(); // wraps to index 2
 
-        Assert.True(_controller.IsActive);
+        Assert.IsTrue(_controller.IsActive);
     }
 
-    [Fact]
+    [TestMethod]
     public void Accept_ReturnsSelectedLabel()
     {
         var items = MakeItems("foo", "bar", "baz");
@@ -73,11 +74,11 @@ public class CompletionControllerTests
         _controller.SelectNext(); // select "bar"
         var text = _controller.Accept();
 
-        Assert.Equal("bar", text);
-        Assert.False(_controller.IsActive);
+        Assert.AreEqual("bar", text);
+        Assert.IsFalse(_controller.IsActive);
     }
 
-    [Fact]
+    [TestMethod]
     public void Accept_ReturnsInsertText_WhenAvailable()
     {
         var items = new[]
@@ -88,24 +89,24 @@ public class CompletionControllerTests
 
         var text = _controller.Accept();
 
-        Assert.Equal("insertMe", text);
+        Assert.AreEqual("insertMe", text);
     }
 
-    [Fact]
+    [TestMethod]
     public void Filter_NarrowsItems()
     {
         var items = MakeItems("forEach", "find", "filter", "map", "reduce");
         _controller.Show(items, new DocumentPosition(1, 5));
-        Assert.True(_controller.IsActive);
+        Assert.IsTrue(_controller.IsActive);
 
         _controller.Filter("fi");
 
-        Assert.True(_controller.IsActive);
+        Assert.IsTrue(_controller.IsActive);
         var overlay = _session.Overlays[0];
-        Assert.Equal(2, overlay.Content.Count); // "find" and "filter"
+        Assert.AreEqual(2, overlay.Content.Count); // "find" and "filter"
     }
 
-    [Fact]
+    [TestMethod]
     public void Filter_DismissesWhenNoMatch()
     {
         var items = MakeItems("forEach", "find", "filter");
@@ -113,11 +114,11 @@ public class CompletionControllerTests
 
         _controller.Filter("xyz");
 
-        Assert.False(_controller.IsActive);
-        Assert.Empty(_session.Overlays);
+        Assert.IsFalse(_controller.IsActive);
+        Assert.IsEmpty(_session.Overlays);
     }
 
-    [Fact]
+    [TestMethod]
     public void Filter_IsCaseInsensitive()
     {
         var items = MakeItems("forEach", "Find", "FILTER");
@@ -125,12 +126,12 @@ public class CompletionControllerTests
 
         _controller.Filter("f");
 
-        Assert.True(_controller.IsActive);
+        Assert.IsTrue(_controller.IsActive);
         var overlay = _session.Overlays[0];
-        Assert.Equal(3, overlay.Content.Count); // All match case-insensitively
+        Assert.AreEqual(3, overlay.Content.Count); // All match case-insensitively
     }
 
-    [Fact]
+    [TestMethod]
     public void Accept_AfterFilter_StripsPrefix()
     {
         var items = MakeItems("forEach", "find", "filter");
@@ -140,10 +141,10 @@ public class CompletionControllerTests
         var text = _controller.Accept();
 
         // "find" minus the "fi" prefix already typed
-        Assert.Equal("nd", text);
+        Assert.AreEqual("nd", text);
     }
 
-    [Fact]
+    [TestMethod]
     public void Filter_UsesFilterTextWhenAvailable()
     {
         var items = new[]
@@ -156,12 +157,12 @@ public class CompletionControllerTests
 
         _controller.Filter("dis");
 
-        Assert.True(_controller.IsActive);
+        Assert.IsTrue(_controller.IsActive);
         var overlay = _session.Overlays[0];
-        Assert.Equal(2, overlay.Content.Count); // display() and dispose()
+        Assert.AreEqual(2, overlay.Content.Count); // display() and dispose()
     }
 
-    [Fact]
+    [TestMethod]
     public void Filter_ContainsFallback_MatchesSubstring()
     {
         var items = MakeItems("groupCollapsed", "groupEnd", "log", "warn");
@@ -169,37 +170,37 @@ public class CompletionControllerTests
 
         _controller.Filter("Coll");
 
-        Assert.True(_controller.IsActive);
+        Assert.IsTrue(_controller.IsActive);
         var overlay = _session.Overlays[0];
-        Assert.Single(overlay.Content); // "groupCollapsed" via Contains
+        TestSeq.Single(overlay.Content); // "groupCollapsed" via Contains
     }
 
-    [Fact]
+    [TestMethod]
     public void Dismiss_ClearsOverlay()
     {
         var items = MakeItems("foo", "bar");
         _controller.Show(items, new DocumentPosition(1, 5));
-        Assert.True(_controller.IsActive);
+        Assert.IsTrue(_controller.IsActive);
 
         _controller.Dismiss();
 
-        Assert.False(_controller.IsActive);
-        Assert.Empty(_session.Overlays);
+        Assert.IsFalse(_controller.IsActive);
+        Assert.IsEmpty(_session.Overlays);
     }
 
-    [Fact]
+    [TestMethod]
     public void Overlay_HasCorrectAnchor()
     {
         var items = MakeItems("method1");
         var anchor = new DocumentPosition(5, 10);
         _controller.Show(items, anchor);
 
-        Assert.Single(_session.Overlays);
-        Assert.Equal(anchor, _session.Overlays[0].AnchorPosition);
-        Assert.Equal(OverlayPlacement.Below, _session.Overlays[0].Placement);
+        TestSeq.Single(_session.Overlays);
+        Assert.AreEqual(anchor, _session.Overlays[0].AnchorPosition);
+        Assert.AreEqual(OverlayPlacement.Below, _session.Overlays[0].Placement);
     }
 
-    [Fact]
+    [TestMethod]
     public void Overlay_DoesNotDismissOnCursorMove()
     {
         var items = MakeItems("foo");
@@ -207,10 +208,10 @@ public class CompletionControllerTests
 
         // The completion overlay should NOT auto-dismiss on cursor move
         // (the controller manages its own lifecycle)
-        Assert.False(_session.Overlays[0].DismissOnCursorMove);
+        Assert.IsFalse(_session.Overlays[0].DismissOnCursorMove);
     }
 
-    [Fact]
+    [TestMethod]
     public void Overlay_ShowsKindIcons()
     {
         var items = new[]
@@ -222,7 +223,7 @@ public class CompletionControllerTests
         _controller.Show(items, new DocumentPosition(1, 1));
 
         var overlay = _session.Overlays[0];
-        Assert.Equal(3, overlay.Content.Count);
+        Assert.AreEqual(3, overlay.Content.Count);
         Assert.Contains("ƒ", overlay.Content[0].Text); // Method icon
         Assert.Contains("C", overlay.Content[1].Text);  // Class icon
         Assert.Contains("P", overlay.Content[2].Text);  // Property icon

--- a/tests/Hex1b.Tests/LanguageServer/DefinitionFeatureTests.cs
+++ b/tests/Hex1b.Tests/LanguageServer/DefinitionFeatureTests.cs
@@ -4,9 +4,10 @@ using Hex1b.LanguageServer.Protocol;
 
 namespace Hex1b.Tests.LanguageServer;
 
+[TestClass]
 public class DefinitionFeatureTests
 {
-    [Fact]
+    [TestMethod]
     public void LocationsToHighlights_WithMatchingUri_ConvertsToHighlights()
     {
         var locations = new[]
@@ -24,13 +25,13 @@ public class DefinitionFeatureTests
 
         var highlights = LanguageServerDecorationProvider.LocationsToHighlights(locations, "file:///test.cs");
 
-        Assert.Single(highlights);
-        Assert.Equal(new DocumentPosition(6, 11), highlights[0].Start); // 0-based -> 1-based
-        Assert.Equal(new DocumentPosition(6, 21), highlights[0].End);
-        Assert.Equal(RangeHighlightKind.ReadAccess, highlights[0].Kind);
+        TestSeq.Single(highlights);
+        Assert.AreEqual(new DocumentPosition(6, 11), highlights[0].Start); // 0-based -> 1-based
+        Assert.AreEqual(new DocumentPosition(6, 21), highlights[0].End);
+        Assert.AreEqual(RangeHighlightKind.ReadAccess, highlights[0].Kind);
     }
 
-    [Fact]
+    [TestMethod]
     public void LocationsToHighlights_WithDifferentUri_FiltersOut()
     {
         var locations = new[]
@@ -47,24 +48,24 @@ public class DefinitionFeatureTests
         };
 
         var highlights = LanguageServerDecorationProvider.LocationsToHighlights(locations, "file:///test.cs");
-        Assert.Empty(highlights);
+        Assert.IsEmpty(highlights);
     }
 
-    [Fact]
+    [TestMethod]
     public void LocationsToHighlights_Null_ReturnsEmpty()
     {
         var highlights = LanguageServerDecorationProvider.LocationsToHighlights(null, "file:///test.cs");
-        Assert.Empty(highlights);
+        Assert.IsEmpty(highlights);
     }
 
-    [Fact]
+    [TestMethod]
     public void LocationsToHighlights_EmptyArray_ReturnsEmpty()
     {
         var highlights = LanguageServerDecorationProvider.LocationsToHighlights([], "file:///test.cs");
-        Assert.Empty(highlights);
+        Assert.IsEmpty(highlights);
     }
 
-    [Fact]
+    [TestMethod]
     public void LocationsToHighlights_MultipleLocations_ConvertsMatchingOnly()
     {
         var locations = new[]
@@ -99,8 +100,8 @@ public class DefinitionFeatureTests
         };
 
         var highlights = LanguageServerDecorationProvider.LocationsToHighlights(locations, "file:///test.cs");
-        Assert.Equal(2, highlights.Count);
-        Assert.Equal(new DocumentPosition(2, 1), highlights[0].Start);
-        Assert.Equal(new DocumentPosition(11, 4), highlights[1].Start);
+        Assert.AreEqual(2, highlights.Count);
+        Assert.AreEqual(new DocumentPosition(2, 1), highlights[0].Start);
+        Assert.AreEqual(new DocumentPosition(11, 4), highlights[1].Start);
     }
 }

--- a/tests/Hex1b.Tests/LanguageServer/DocumentWorkspaceTests.cs
+++ b/tests/Hex1b.Tests/LanguageServer/DocumentWorkspaceTests.cs
@@ -8,6 +8,7 @@ namespace Hex1b.Tests.LanguageServer;
 /// Tests for <see cref="Hex1bDocumentWorkspace"/> — document management,
 /// file persistence, dirty tracking, server mapping, and provider resolution.
 /// </summary>
+[TestClass]
 public class DocumentWorkspaceTests : IDisposable
 {
     private readonly string _tempDir;
@@ -25,7 +26,7 @@ public class DocumentWorkspaceTests : IDisposable
 
     // ── Document management ──────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task OpenDocumentAsync_LoadsFileContent()
     {
         File.WriteAllText(Path.Combine(_tempDir, "test.cs"), "Hello, World!");
@@ -33,12 +34,12 @@ public class DocumentWorkspaceTests : IDisposable
         await using var workspace = new Hex1bDocumentWorkspace(_tempDir);
         var doc = await workspace.OpenDocumentAsync("test.cs");
 
-        Assert.Equal("Hello, World!", doc.GetText());
-        Assert.Equal(Path.Combine(_tempDir, "test.cs"), doc.FilePath);
-        Assert.False(doc.IsDirty);
+        Assert.AreEqual("Hello, World!", doc.GetText());
+        Assert.AreEqual(Path.Combine(_tempDir, "test.cs"), doc.FilePath);
+        Assert.IsFalse(doc.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OpenDocumentAsync_ReturnsSameInstanceForSamePath()
     {
         File.WriteAllText(Path.Combine(_tempDir, "test.cs"), "content");
@@ -47,32 +48,32 @@ public class DocumentWorkspaceTests : IDisposable
         var doc1 = await workspace.OpenDocumentAsync("test.cs");
         var doc2 = await workspace.OpenDocumentAsync("test.cs");
 
-        Assert.Same(doc1, doc2);
+        Assert.AreSame(doc1, doc2);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CreateDocument_WithPath_SetsFilePath()
     {
         await using var workspace = new Hex1bDocumentWorkspace(_tempDir);
         var doc = workspace.CreateDocument("initial", "new-file.cs");
 
-        Assert.Equal(Path.Combine(_tempDir, "new-file.cs"), doc.FilePath);
-        Assert.Equal("initial", doc.GetText());
+        Assert.AreEqual(Path.Combine(_tempDir, "new-file.cs"), doc.FilePath);
+        Assert.AreEqual("initial", doc.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CreateDocument_WithoutPath_HasNoFilePath()
     {
         await using var workspace = new Hex1bDocumentWorkspace(_tempDir);
         var doc = workspace.CreateDocument("in memory");
 
-        Assert.Null(doc.FilePath);
-        Assert.False(doc.IsDirty);
+        Assert.IsNull(doc.FilePath);
+        Assert.IsFalse(doc.IsDirty);
     }
 
     // ── Dirty tracking ───────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task IsDirty_TrueAfterEdit()
     {
         File.WriteAllText(Path.Combine(_tempDir, "test.cs"), "original");
@@ -80,14 +81,14 @@ public class DocumentWorkspaceTests : IDisposable
         await using var workspace = new Hex1bDocumentWorkspace(_tempDir);
         var doc = await workspace.OpenDocumentAsync("test.cs");
 
-        Assert.False(doc.IsDirty);
+        Assert.IsFalse(doc.IsDirty);
 
         doc.Apply(new InsertOperation(new DocumentOffset(0), "inserted "));
 
-        Assert.True(doc.IsDirty);
+        Assert.IsTrue(doc.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task IsDirty_FalseAfterSave()
     {
         File.WriteAllText(Path.Combine(_tempDir, "test.cs"), "original");
@@ -96,13 +97,13 @@ public class DocumentWorkspaceTests : IDisposable
         var doc = await workspace.OpenDocumentAsync("test.cs");
 
         doc.Apply(new InsertOperation(new DocumentOffset(0), "inserted "));
-        Assert.True(doc.IsDirty);
+        Assert.IsTrue(doc.IsDirty);
 
         await doc.SaveAsync();
-        Assert.False(doc.IsDirty);
+        Assert.IsFalse(doc.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SaveAsync_WritesToFile()
     {
         File.WriteAllText(Path.Combine(_tempDir, "test.cs"), "original");
@@ -114,19 +115,19 @@ public class DocumentWorkspaceTests : IDisposable
         await doc.SaveAsync();
 
         var saved = File.ReadAllText(Path.Combine(_tempDir, "test.cs"));
-        Assert.Equal("modified", saved);
+        Assert.AreEqual("modified", saved);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SaveAsync_ThrowsForInMemoryDocument()
     {
         await using var workspace = new Hex1bDocumentWorkspace(_tempDir);
         var doc = workspace.CreateDocument("no path");
 
-        await Assert.ThrowsAsync<InvalidOperationException>(() => doc.SaveAsync());
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => doc.SaveAsync());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SaveAllAsync_SavesDirtyDocuments()
     {
         File.WriteAllText(Path.Combine(_tempDir, "a.cs"), "aaa");
@@ -141,23 +142,23 @@ public class DocumentWorkspaceTests : IDisposable
 
         await workspace.SaveAllAsync();
 
-        Assert.Equal("AAA", File.ReadAllText(Path.Combine(_tempDir, "a.cs")));
-        Assert.Equal("bbb", File.ReadAllText(Path.Combine(_tempDir, "b.cs"))); // unchanged
-        Assert.False(a.IsDirty);
+        Assert.AreEqual("AAA", File.ReadAllText(Path.Combine(_tempDir, "a.cs")));
+        Assert.AreEqual("bbb", File.ReadAllText(Path.Combine(_tempDir, "b.cs"))); // unchanged
+        Assert.IsFalse(a.IsDirty);
     }
 
     // ── Language server mapping ──────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task MapLanguageServer_ThrowsForUnregisteredServer()
     {
         await using var workspace = new Hex1bDocumentWorkspace(_tempDir);
 
-        Assert.Throws<InvalidOperationException>(() =>
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
             workspace.MapLanguageServer("*.cs", "nonexistent"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetProvider_ResolvesServerByGlob()
     {
         var server = new TestLanguageServer();
@@ -174,10 +175,10 @@ public class DocumentWorkspaceTests : IDisposable
         var doc = await workspace.OpenDocumentAsync("test.cs");
         var provider = workspace.GetProvider(doc);
 
-        Assert.NotNull(provider);
+        Assert.IsNotNull(provider);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetProvider_ReturnsSameProviderForSameDocument()
     {
         var server = new TestLanguageServer();
@@ -195,10 +196,10 @@ public class DocumentWorkspaceTests : IDisposable
         var p1 = workspace.GetProvider(doc);
         var p2 = workspace.GetProvider(doc);
 
-        Assert.Same(p1, p2);
+        Assert.AreSame(p1, p2);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetProvider_ReturnsNullForUnmappedExtension()
     {
         File.WriteAllText(Path.Combine(_tempDir, "readme.txt"), "hello");
@@ -211,10 +212,10 @@ public class DocumentWorkspaceTests : IDisposable
         var doc = await workspace.OpenDocumentAsync("readme.txt");
         var provider = workspace.GetProvider(doc);
 
-        Assert.Null(provider);
+        Assert.IsNull(provider);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetProvider_ReturnsNullForInMemoryDocument()
     {
         await using var workspace = new Hex1bDocumentWorkspace(_tempDir);
@@ -222,12 +223,12 @@ public class DocumentWorkspaceTests : IDisposable
 
         var provider = workspace.GetProvider(doc);
 
-        Assert.Null(provider);
+        Assert.IsNull(provider);
     }
 
     // ── Dispose semantics ────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task DisposeAsync_ClearsDocuments()
     {
         File.WriteAllText(Path.Combine(_tempDir, "test.cs"), "content");
@@ -235,10 +236,10 @@ public class DocumentWorkspaceTests : IDisposable
         var workspace = new Hex1bDocumentWorkspace(_tempDir);
         await workspace.OpenDocumentAsync("test.cs");
 
-        Assert.Single(workspace.OpenDocuments);
+        TestSeq.Single(workspace.OpenDocuments);
 
         await workspace.DisposeAsync();
 
-        Assert.Empty(workspace.OpenDocuments);
+        Assert.IsEmpty(workspace.OpenDocuments);
     }
 }

--- a/tests/Hex1b.Tests/LanguageServer/FeatureIntegrationTests.cs
+++ b/tests/Hex1b.Tests/LanguageServer/FeatureIntegrationTests.cs
@@ -5,11 +5,12 @@ using Hex1b.LanguageServer.Protocol;
 
 namespace Hex1b.Tests.LanguageServer;
 
+[TestClass]
 public class FeatureIntegrationTests
 {
     // ── DocumentHighlight → RangeHighlight ───────────────────
 
-    [Fact]
+    [TestMethod]
     public void DocumentHighlightsToRangeHighlights_ConvertsPositions()
     {
         var highlights = new[]
@@ -27,12 +28,12 @@ public class FeatureIntegrationTests
 
         var result = LanguageServerDecorationProvider.DocumentHighlightsToRangeHighlights(highlights);
 
-        Assert.Single(result);
-        Assert.Equal(new DocumentPosition(1, 6), result[0].Start);
-        Assert.Equal(new DocumentPosition(1, 11), result[0].End);
+        TestSeq.Single(result);
+        Assert.AreEqual(new DocumentPosition(1, 6), result[0].Start);
+        Assert.AreEqual(new DocumentPosition(1, 11), result[0].End);
     }
 
-    [Fact]
+    [TestMethod]
     public void DocumentHighlightsToRangeHighlights_MapsKinds()
     {
         var highlights = new[]
@@ -45,23 +46,23 @@ public class FeatureIntegrationTests
 
         var result = LanguageServerDecorationProvider.DocumentHighlightsToRangeHighlights(highlights);
 
-        Assert.Equal(4, result.Count);
-        Assert.Equal(RangeHighlightKind.Default, result[0].Kind);
-        Assert.Equal(RangeHighlightKind.ReadAccess, result[1].Kind);
-        Assert.Equal(RangeHighlightKind.WriteAccess, result[2].Kind);
-        Assert.Equal(RangeHighlightKind.Default, result[3].Kind);
+        Assert.AreEqual(4, result.Count);
+        Assert.AreEqual(RangeHighlightKind.Default, result[0].Kind);
+        Assert.AreEqual(RangeHighlightKind.ReadAccess, result[1].Kind);
+        Assert.AreEqual(RangeHighlightKind.WriteAccess, result[2].Kind);
+        Assert.AreEqual(RangeHighlightKind.Default, result[3].Kind);
     }
 
-    [Fact]
+    [TestMethod]
     public void DocumentHighlightsToRangeHighlights_NullReturnsEmpty()
     {
         var result = LanguageServerDecorationProvider.DocumentHighlightsToRangeHighlights(null);
-        Assert.Empty(result);
+        Assert.IsEmpty(result);
     }
 
     // ── SignatureHelp → SignaturePanel ────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void SignatureHelpToPanel_ConvertsSingleSignature()
     {
         var help = new SignatureHelp
@@ -86,14 +87,14 @@ public class FeatureIntegrationTests
 
         var panel = LanguageServerDecorationProvider.SignatureHelpToPanel(help);
 
-        Assert.NotNull(panel);
-        Assert.Single(panel.Signatures);
-        Assert.Equal("void Foo(int x)", panel.Signatures[0].Label);
-        Assert.Single(panel.Signatures[0].Parameters);
-        Assert.Equal("int x", panel.Signatures[0].Parameters[0].Label);
+        Assert.IsNotNull(panel);
+        TestSeq.Single(panel.Signatures);
+        Assert.AreEqual("void Foo(int x)", panel.Signatures[0].Label);
+        TestSeq.Single(panel.Signatures[0].Parameters);
+        Assert.AreEqual("int x", panel.Signatures[0].Parameters[0].Label);
     }
 
-    [Fact]
+    [TestMethod]
     public void SignatureHelpToPanel_PreservesActiveParameter()
     {
         var help = new SignatureHelp
@@ -116,22 +117,22 @@ public class FeatureIntegrationTests
 
         var panel = LanguageServerDecorationProvider.SignatureHelpToPanel(help);
 
-        Assert.NotNull(panel);
-        Assert.Equal(0, panel.ActiveSignature);
-        Assert.Equal(1, panel.ActiveParameter);
+        Assert.IsNotNull(panel);
+        Assert.AreEqual(0, panel.ActiveSignature);
+        Assert.AreEqual(1, panel.ActiveParameter);
     }
 
-    [Fact]
+    [TestMethod]
     public void SignatureHelpToPanel_NullReturnsNull()
     {
-        Assert.Null(LanguageServerDecorationProvider.SignatureHelpToPanel(null));
-        Assert.Null(LanguageServerDecorationProvider.SignatureHelpToPanel(
+        Assert.IsNull(LanguageServerDecorationProvider.SignatureHelpToPanel(null));
+        Assert.IsNull(LanguageServerDecorationProvider.SignatureHelpToPanel(
             new SignatureHelp { Signatures = [] }));
     }
 
     // ── DocumentSymbol → BreadcrumbData ──────────────────────
 
-    [Fact]
+    [TestMethod]
     public void DocumentSymbolsToBreadcrumbs_ConvertsHierarchy()
     {
         var symbols = new[]
@@ -157,19 +158,19 @@ public class FeatureIntegrationTests
 
         var breadcrumbs = LanguageServerDecorationProvider.DocumentSymbolsToBreadcrumbs(symbols);
 
-        Assert.NotNull(breadcrumbs);
-        Assert.Single(breadcrumbs.Symbols);
-        Assert.Equal("MyClass", breadcrumbs.Symbols[0].Name);
-        Assert.Equal(BreadcrumbSymbolKind.Class, breadcrumbs.Symbols[0].Kind);
-        Assert.Equal(new DocumentPosition(1, 1), breadcrumbs.Symbols[0].Start);
-        Assert.Equal(new DocumentPosition(11, 1), breadcrumbs.Symbols[0].End);
-        Assert.NotNull(breadcrumbs.Symbols[0].Children);
-        Assert.Single(breadcrumbs.Symbols[0].Children!);
-        Assert.Equal("MyMethod", breadcrumbs.Symbols[0].Children![0].Name);
-        Assert.Equal(BreadcrumbSymbolKind.Method, breadcrumbs.Symbols[0].Children![0].Kind);
+        Assert.IsNotNull(breadcrumbs);
+        TestSeq.Single(breadcrumbs.Symbols);
+        Assert.AreEqual("MyClass", breadcrumbs.Symbols[0].Name);
+        Assert.AreEqual(BreadcrumbSymbolKind.Class, breadcrumbs.Symbols[0].Kind);
+        Assert.AreEqual(new DocumentPosition(1, 1), breadcrumbs.Symbols[0].Start);
+        Assert.AreEqual(new DocumentPosition(11, 1), breadcrumbs.Symbols[0].End);
+        Assert.IsNotNull(breadcrumbs.Symbols[0].Children);
+        TestSeq.Single(breadcrumbs.Symbols[0].Children!);
+        Assert.AreEqual("MyMethod", breadcrumbs.Symbols[0].Children![0].Name);
+        Assert.AreEqual(BreadcrumbSymbolKind.Method, breadcrumbs.Symbols[0].Children![0].Kind);
     }
 
-    [Fact]
+    [TestMethod]
     public void DocumentSymbolsToBreadcrumbs_MapsSymbolKinds()
     {
         var symbols = new[]
@@ -182,24 +183,24 @@ public class FeatureIntegrationTests
 
         var breadcrumbs = LanguageServerDecorationProvider.DocumentSymbolsToBreadcrumbs(symbols);
 
-        Assert.NotNull(breadcrumbs);
-        Assert.Equal(4, breadcrumbs.Symbols.Count);
-        Assert.Equal(BreadcrumbSymbolKind.Function, breadcrumbs.Symbols[0].Kind);
-        Assert.Equal(BreadcrumbSymbolKind.Interface, breadcrumbs.Symbols[1].Kind);
-        Assert.Equal(BreadcrumbSymbolKind.Enum, breadcrumbs.Symbols[2].Kind);
-        Assert.Equal(BreadcrumbSymbolKind.Struct, breadcrumbs.Symbols[3].Kind);
+        Assert.IsNotNull(breadcrumbs);
+        Assert.AreEqual(4, breadcrumbs.Symbols.Count);
+        Assert.AreEqual(BreadcrumbSymbolKind.Function, breadcrumbs.Symbols[0].Kind);
+        Assert.AreEqual(BreadcrumbSymbolKind.Interface, breadcrumbs.Symbols[1].Kind);
+        Assert.AreEqual(BreadcrumbSymbolKind.Enum, breadcrumbs.Symbols[2].Kind);
+        Assert.AreEqual(BreadcrumbSymbolKind.Struct, breadcrumbs.Symbols[3].Kind);
     }
 
-    [Fact]
+    [TestMethod]
     public void DocumentSymbolsToBreadcrumbs_NullReturnsNull()
     {
-        Assert.Null(LanguageServerDecorationProvider.DocumentSymbolsToBreadcrumbs(null));
-        Assert.Null(LanguageServerDecorationProvider.DocumentSymbolsToBreadcrumbs([]));
+        Assert.IsNull(LanguageServerDecorationProvider.DocumentSymbolsToBreadcrumbs(null));
+        Assert.IsNull(LanguageServerDecorationProvider.DocumentSymbolsToBreadcrumbs([]));
     }
 
     // ── FoldingRange → FoldingRegion ─────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void FoldingRangesToRegions_ConvertsToOneBased()
     {
         var ranges = new[]
@@ -210,14 +211,14 @@ public class FeatureIntegrationTests
 
         var regions = LanguageServerDecorationProvider.FoldingRangesToRegions(ranges);
 
-        Assert.Equal(2, regions.Count);
-        Assert.Equal(1, regions[0].StartLine);
-        Assert.Equal(6, regions[0].EndLine);
-        Assert.Equal(11, regions[1].StartLine);
-        Assert.Equal(21, regions[1].EndLine);
+        Assert.AreEqual(2, regions.Count);
+        Assert.AreEqual(1, regions[0].StartLine);
+        Assert.AreEqual(6, regions[0].EndLine);
+        Assert.AreEqual(11, regions[1].StartLine);
+        Assert.AreEqual(21, regions[1].EndLine);
     }
 
-    [Fact]
+    [TestMethod]
     public void FoldingRangesToRegions_MapsKinds()
     {
         var ranges = new[]
@@ -230,16 +231,16 @@ public class FeatureIntegrationTests
 
         var regions = LanguageServerDecorationProvider.FoldingRangesToRegions(ranges);
 
-        Assert.Equal(4, regions.Count);
-        Assert.Equal(FoldingRegionKind.Comment, regions[0].Kind);
-        Assert.Equal(FoldingRegionKind.Imports, regions[1].Kind);
-        Assert.Equal(FoldingRegionKind.Region, regions[2].Kind);
-        Assert.Equal(FoldingRegionKind.Region, regions[3].Kind);
+        Assert.AreEqual(4, regions.Count);
+        Assert.AreEqual(FoldingRegionKind.Comment, regions[0].Kind);
+        Assert.AreEqual(FoldingRegionKind.Imports, regions[1].Kind);
+        Assert.AreEqual(FoldingRegionKind.Region, regions[2].Kind);
+        Assert.AreEqual(FoldingRegionKind.Region, regions[3].Kind);
     }
 
     // ── InlayHint → InlineHint ───────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void InlayHintsToInlineHints_ConvertsPositions()
     {
         var hints = new[]
@@ -253,14 +254,14 @@ public class FeatureIntegrationTests
 
         var result = LanguageServerDecorationProvider.InlayHintsToInlineHints(hints);
 
-        Assert.Single(result);
-        Assert.Equal(new DocumentPosition(5, 11), result[0].Position);
-        Assert.Equal("string", result[0].Text);
+        TestSeq.Single(result);
+        Assert.AreEqual(new DocumentPosition(5, 11), result[0].Position);
+        Assert.AreEqual("string", result[0].Text);
     }
 
     // ── CodeLens → GutterDecoration ──────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void CodeLensToGutterDecorations_ConvertsCommandTitle()
     {
         var lenses = new[]
@@ -274,10 +275,10 @@ public class FeatureIntegrationTests
 
         var result = LanguageServerDecorationProvider.CodeLensToGutterDecorations(lenses);
 
-        Assert.Single(result);
-        Assert.Equal(4, result[0].Line);
-        Assert.Equal('5', result[0].Character);
-        Assert.Equal(GutterDecorationKind.Info, result[0].Kind);
+        TestSeq.Single(result);
+        Assert.AreEqual(4, result[0].Line);
+        Assert.AreEqual('5', result[0].Character);
+        Assert.AreEqual(GutterDecorationKind.Info, result[0].Kind);
     }
 
     // ── Helpers ──────────────────────────────────────────────

--- a/tests/Hex1b.Tests/LanguageServer/HierarchyFeatureTests.cs
+++ b/tests/Hex1b.Tests/LanguageServer/HierarchyFeatureTests.cs
@@ -2,11 +2,12 @@ using Hex1b.LanguageServer.Protocol;
 
 namespace Hex1b.Tests.LanguageServer;
 
+[TestClass]
 public class HierarchyFeatureTests
 {
     // ── SelectionRange ──────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void SelectionRange_HasRangeAndParent()
     {
         var inner = new SelectionRange
@@ -28,15 +29,15 @@ public class HierarchyFeatureTests
             Parent = inner,
         };
 
-        Assert.Equal(4, outer.Range.Start.Line);
-        Assert.NotNull(outer.Parent);
-        Assert.Equal(5, outer.Parent.Range.Start.Line);
-        Assert.Null(inner.Parent);
+        Assert.AreEqual(4, outer.Range.Start.Line);
+        Assert.IsNotNull(outer.Parent);
+        Assert.AreEqual(5, outer.Parent.Range.Start.Line);
+        Assert.IsNull(inner.Parent);
     }
 
     // ── CallHierarchyItem ───────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void CallHierarchyItem_HasExpectedProperties()
     {
         var item = new CallHierarchyItem
@@ -56,14 +57,14 @@ public class HierarchyFeatureTests
             },
         };
 
-        Assert.Equal("DoWork", item.Name);
-        Assert.Equal(12, item.Kind);
-        Assert.Equal("file:///src/worker.cs", item.Uri);
-        Assert.Equal(10, item.Range.Start.Line);
-        Assert.Equal(16, item.SelectionRange.Start.Character);
+        Assert.AreEqual("DoWork", item.Name);
+        Assert.AreEqual(12, item.Kind);
+        Assert.AreEqual("file:///src/worker.cs", item.Uri);
+        Assert.AreEqual(10, item.Range.Start.Line);
+        Assert.AreEqual(16, item.SelectionRange.Start.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void CallHierarchyIncomingCall_HasFromAndRanges()
     {
         var call = new CallHierarchyIncomingCall
@@ -86,12 +87,12 @@ public class HierarchyFeatureTests
             ],
         };
 
-        Assert.Equal("Caller", call.From.Name);
-        Assert.Single(call.FromRanges);
-        Assert.Equal(3, call.FromRanges[0].Start.Line);
+        Assert.AreEqual("Caller", call.From.Name);
+        TestSeq.Single(call.FromRanges);
+        Assert.AreEqual(3, call.FromRanges[0].Start.Line);
     }
 
-    [Fact]
+    [TestMethod]
     public void CallHierarchyOutgoingCall_HasToAndRanges()
     {
         var call = new CallHierarchyOutgoingCall
@@ -114,13 +115,13 @@ public class HierarchyFeatureTests
             ],
         };
 
-        Assert.Equal("Callee", call.To.Name);
-        Assert.Single(call.FromRanges);
+        Assert.AreEqual("Callee", call.To.Name);
+        TestSeq.Single(call.FromRanges);
     }
 
     // ── TypeHierarchyItem ───────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void TypeHierarchyItem_HasExpectedProperties()
     {
         var item = new TypeHierarchyItem
@@ -140,54 +141,54 @@ public class HierarchyFeatureTests
             },
         };
 
-        Assert.Equal("BaseClass", item.Name);
-        Assert.Equal(5, item.Kind);
-        Assert.Equal("file:///src/base.cs", item.Uri);
-        Assert.Equal(0, item.Range.Start.Line);
-        Assert.Equal(14, item.SelectionRange.Start.Character);
+        Assert.AreEqual("BaseClass", item.Name);
+        Assert.AreEqual(5, item.Kind);
+        Assert.AreEqual("file:///src/base.cs", item.Uri);
+        Assert.AreEqual(0, item.Range.Start.Line);
+        Assert.AreEqual(14, item.SelectionRange.Start.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void CallHierarchyItem_DefaultValues_AreEmpty()
     {
         var item = new CallHierarchyItem();
 
-        Assert.Equal("", item.Name);
-        Assert.Equal(0, item.Kind);
-        Assert.Equal("", item.Uri);
-        Assert.NotNull(item.Range);
-        Assert.NotNull(item.SelectionRange);
-        Assert.Null(item.Data);
+        Assert.AreEqual("", item.Name);
+        Assert.AreEqual(0, item.Kind);
+        Assert.AreEqual("", item.Uri);
+        Assert.IsNotNull(item.Range);
+        Assert.IsNotNull(item.SelectionRange);
+        Assert.IsNull(item.Data);
     }
 
-    [Fact]
+    [TestMethod]
     public void TypeHierarchyItem_DefaultValues_AreEmpty()
     {
         var item = new TypeHierarchyItem();
 
-        Assert.Equal("", item.Name);
-        Assert.Equal(0, item.Kind);
-        Assert.Equal("", item.Uri);
-        Assert.NotNull(item.Range);
-        Assert.NotNull(item.SelectionRange);
-        Assert.Null(item.Data);
+        Assert.AreEqual("", item.Name);
+        Assert.AreEqual(0, item.Kind);
+        Assert.AreEqual("", item.Uri);
+        Assert.IsNotNull(item.Range);
+        Assert.IsNotNull(item.SelectionRange);
+        Assert.IsNull(item.Data);
     }
 
-    [Fact]
+    [TestMethod]
     public void CallHierarchyIncomingCall_DefaultFromRanges_IsEmpty()
     {
         var call = new CallHierarchyIncomingCall();
 
-        Assert.NotNull(call.From);
-        Assert.Empty(call.FromRanges);
+        Assert.IsNotNull(call.From);
+        Assert.IsEmpty(call.FromRanges);
     }
 
-    [Fact]
+    [TestMethod]
     public void CallHierarchyOutgoingCall_DefaultFromRanges_IsEmpty()
     {
         var call = new CallHierarchyOutgoingCall();
 
-        Assert.NotNull(call.To);
-        Assert.Empty(call.FromRanges);
+        Assert.IsNotNull(call.To);
+        Assert.IsEmpty(call.FromRanges);
     }
 }

--- a/tests/Hex1b.Tests/LanguageServer/HoverFeatureTests.cs
+++ b/tests/Hex1b.Tests/LanguageServer/HoverFeatureTests.cs
@@ -6,9 +6,10 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests.LanguageServer;
 
+[TestClass]
 public class HoverFeatureTests
 {
-    [Fact]
+    [TestMethod]
     public void BuildHoverOverlay_WithPlainText_GeneratesCorrectOverlay()
     {
         var result = new HoverResult
@@ -18,13 +19,13 @@ public class HoverFeatureTests
 
         var overlay = LanguageServerDecorationProvider.BuildHoverOverlay(result, 3, 5);
 
-        Assert.NotNull(overlay);
-        Assert.Equal("lsp-hover", overlay.Id);
-        Assert.Single(overlay.Content);
-        Assert.Equal(" int x ", overlay.Content[0].Text);
+        Assert.IsNotNull(overlay);
+        Assert.AreEqual("lsp-hover", overlay.Id);
+        TestSeq.Single(overlay.Content);
+        Assert.AreEqual(" int x ", overlay.Content[0].Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildHoverOverlay_WithMultiLineContent_GeneratesMultipleLines()
     {
         var result = new HoverResult
@@ -38,22 +39,22 @@ public class HoverFeatureTests
 
         var overlay = LanguageServerDecorationProvider.BuildHoverOverlay(result, 1, 1);
 
-        Assert.NotNull(overlay);
-        Assert.Equal(3, overlay.Content.Count);
-        Assert.Equal(" void MyMethod() ", overlay.Content[0].Text);
-        Assert.Equal(" Does something useful ", overlay.Content[1].Text);
-        Assert.Equal(" Returns nothing ", overlay.Content[2].Text);
+        Assert.IsNotNull(overlay);
+        Assert.AreEqual(3, overlay.Content.Count);
+        Assert.AreEqual(" void MyMethod() ", overlay.Content[0].Text);
+        Assert.AreEqual(" Does something useful ", overlay.Content[1].Text);
+        Assert.AreEqual(" Returns nothing ", overlay.Content[2].Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildHoverOverlay_WithNullResult_ReturnsNull()
     {
         var overlay = LanguageServerDecorationProvider.BuildHoverOverlay(null, 1, 1);
 
-        Assert.Null(overlay);
+        Assert.IsNull(overlay);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildHoverOverlay_WithEmptyValue_ReturnsNull()
     {
         var result = new HoverResult
@@ -63,10 +64,10 @@ public class HoverFeatureTests
 
         var overlay = LanguageServerDecorationProvider.BuildHoverOverlay(result, 1, 1);
 
-        Assert.Null(overlay);
+        Assert.IsNull(overlay);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildHoverOverlay_WithWhitespaceValue_ReturnsNull()
     {
         var result = new HoverResult
@@ -76,10 +77,10 @@ public class HoverFeatureTests
 
         var overlay = LanguageServerDecorationProvider.BuildHoverOverlay(result, 1, 1);
 
-        Assert.Null(overlay);
+        Assert.IsNull(overlay);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildHoverOverlay_HasCorrectAnchorPosition()
     {
         var result = new HoverResult
@@ -89,11 +90,11 @@ public class HoverFeatureTests
 
         var overlay = LanguageServerDecorationProvider.BuildHoverOverlay(result, 10, 25);
 
-        Assert.NotNull(overlay);
-        Assert.Equal(new DocumentPosition(10, 25), overlay.AnchorPosition);
+        Assert.IsNotNull(overlay);
+        Assert.AreEqual(new DocumentPosition(10, 25), overlay.AnchorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildHoverOverlay_PlacesAboveAnchor()
     {
         var result = new HoverResult
@@ -103,11 +104,11 @@ public class HoverFeatureTests
 
         var overlay = LanguageServerDecorationProvider.BuildHoverOverlay(result, 1, 1);
 
-        Assert.NotNull(overlay);
-        Assert.Equal(OverlayPlacement.Above, overlay.Placement);
+        Assert.IsNotNull(overlay);
+        Assert.AreEqual(OverlayPlacement.Above, overlay.Placement);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildHoverOverlay_DismissesOnCursorMove()
     {
         var result = new HoverResult
@@ -117,11 +118,11 @@ public class HoverFeatureTests
 
         var overlay = LanguageServerDecorationProvider.BuildHoverOverlay(result, 1, 1);
 
-        Assert.NotNull(overlay);
-        Assert.True(overlay.DismissOnCursorMove);
+        Assert.IsNotNull(overlay);
+        Assert.IsTrue(overlay.DismissOnCursorMove);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildHoverOverlay_LinesHaveExpectedColors()
     {
         var result = new HoverResult
@@ -131,19 +132,19 @@ public class HoverFeatureTests
 
         var overlay = LanguageServerDecorationProvider.BuildHoverOverlay(result, 1, 1);
 
-        Assert.NotNull(overlay);
+        Assert.IsNotNull(overlay);
         var line = overlay.Content[0];
-        Assert.Equal(Hex1bColor.FromRgb(204, 204, 204), line.Foreground);
-        Assert.Equal(Hex1bColor.FromRgb(37, 37, 38), line.Background);
+        Assert.AreEqual(Hex1bColor.FromRgb(204, 204, 204), line.Foreground);
+        Assert.AreEqual(Hex1bColor.FromRgb(37, 37, 38), line.Background);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildHoverOverlay_NullContents_ReturnsNull()
     {
         var result = new HoverResult();
         // Contents defaults to new MarkupContent() with Value = ""
         var overlay = LanguageServerDecorationProvider.BuildHoverOverlay(result, 1, 1);
 
-        Assert.Null(overlay);
+        Assert.IsNull(overlay);
     }
 }

--- a/tests/Hex1b.Tests/LanguageServer/IncrementalSyncTests.cs
+++ b/tests/Hex1b.Tests/LanguageServer/IncrementalSyncTests.cs
@@ -3,18 +3,19 @@ using Hex1b.LanguageServer.Protocol;
 
 namespace Hex1b.Tests.LanguageServer;
 
+[TestClass]
 public class IncrementalSyncTests
 {
-    [Fact]
+    [TestMethod]
     public void TextDocumentContentChangeEvent_FullSync_HasNullRange()
     {
         var change = new TextDocumentContentChangeEvent { Text = "full text" };
-        Assert.Null(change.Range);
-        Assert.Null(change.RangeLength);
-        Assert.Equal("full text", change.Text);
+        Assert.IsNull(change.Range);
+        Assert.IsNull(change.RangeLength);
+        Assert.AreEqual("full text", change.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void TextDocumentContentChangeEvent_IncrementalSync_HasRange()
     {
         var change = new TextDocumentContentChangeEvent
@@ -27,15 +28,15 @@ public class IncrementalSyncTests
             Text = "replacement"
         };
 
-        Assert.NotNull(change.Range);
-        Assert.Equal(0, change.Range.Start.Line);
-        Assert.Equal(5, change.Range.Start.Character);
-        Assert.Equal(0, change.Range.End.Line);
-        Assert.Equal(10, change.Range.End.Character);
-        Assert.Equal("replacement", change.Text);
+        Assert.IsNotNull(change.Range);
+        Assert.AreEqual(0, change.Range.Start.Line);
+        Assert.AreEqual(5, change.Range.Start.Character);
+        Assert.AreEqual(0, change.Range.End.Line);
+        Assert.AreEqual(10, change.Range.End.Character);
+        Assert.AreEqual("replacement", change.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void TextDocumentContentChangeEvent_Serialization_RoundTrips()
     {
         var change = new TextDocumentContentChangeEvent
@@ -52,17 +53,17 @@ public class IncrementalSyncTests
         var json = JsonSerializer.Serialize(change);
         var deserialized = JsonSerializer.Deserialize<TextDocumentContentChangeEvent>(json);
 
-        Assert.NotNull(deserialized);
-        Assert.Equal("hello", deserialized.Text);
-        Assert.Equal(5, deserialized.RangeLength);
-        Assert.NotNull(deserialized.Range);
-        Assert.Equal(1, deserialized.Range.Start.Line);
-        Assert.Equal(0, deserialized.Range.Start.Character);
-        Assert.Equal(1, deserialized.Range.End.Line);
-        Assert.Equal(5, deserialized.Range.End.Character);
+        Assert.IsNotNull(deserialized);
+        Assert.AreEqual("hello", deserialized.Text);
+        Assert.AreEqual(5, deserialized.RangeLength);
+        Assert.IsNotNull(deserialized.Range);
+        Assert.AreEqual(1, deserialized.Range.Start.Line);
+        Assert.AreEqual(0, deserialized.Range.Start.Character);
+        Assert.AreEqual(1, deserialized.Range.End.Line);
+        Assert.AreEqual(5, deserialized.Range.End.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void TextDocumentContentChangeEvent_FullSync_Serialization_OmitsNullRange()
     {
         var options = new JsonSerializerOptions { DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull };
@@ -71,8 +72,8 @@ public class IncrementalSyncTests
         var json = JsonSerializer.Serialize(change, options);
         var doc = JsonDocument.Parse(json);
 
-        Assert.False(doc.RootElement.TryGetProperty("range", out _));
-        Assert.False(doc.RootElement.TryGetProperty("rangeLength", out _));
-        Assert.Equal("full content", doc.RootElement.GetProperty("text").GetString());
+        Assert.IsFalse(doc.RootElement.TryGetProperty("range", out _));
+        Assert.IsFalse(doc.RootElement.TryGetProperty("rangeLength", out _));
+        Assert.AreEqual("full content", doc.RootElement.GetProperty("text").GetString());
     }
 }

--- a/tests/Hex1b.Tests/LanguageServer/LspFeatureControllerTests.cs
+++ b/tests/Hex1b.Tests/LanguageServer/LspFeatureControllerTests.cs
@@ -4,6 +4,7 @@ using Hex1b.LanguageServer.Protocol;
 
 namespace Hex1b.Tests.LanguageServer;
 
+[TestClass]
 public class LspFeatureControllerTests
 {
     private sealed class MinimalExtension : ILanguageExtension
@@ -14,13 +15,13 @@ public class LspFeatureControllerTests
 
     // --- LspFeatureSet flag tests ---
 
-    [Fact]
+    [TestMethod]
     public void LspFeatureSet_None_HasValueZero()
     {
-        Assert.Equal(0, (int)LspFeatureSet.None);
+        Assert.AreEqual(0, (int)LspFeatureSet.None);
     }
 
-    [Fact]
+    [TestMethod]
     public void LspFeatureSet_IndividualFlags_AreDistinct()
     {
         var flags = new[]
@@ -49,125 +50,122 @@ public class LspFeatureControllerTests
         {
             for (var j = i + 1; j < flags.Length; j++)
             {
-                Assert.True((flags[i] & flags[j]) == 0,
-                    $"{flags[i]} and {flags[j]} should not overlap");
+                Assert.IsTrue((flags[i] & flags[j]) == 0, $"{flags[i]} and {flags[j]} should not overlap");
             }
         }
     }
 
-    [Theory]
-    [InlineData(LspFeatureSet.SemanticTokens)]
-    [InlineData(LspFeatureSet.Completion)]
-    [InlineData(LspFeatureSet.Diagnostics)]
-    [InlineData(LspFeatureSet.Hover)]
-    [InlineData(LspFeatureSet.Definition)]
-    [InlineData(LspFeatureSet.References)]
-    [InlineData(LspFeatureSet.Rename)]
-    [InlineData(LspFeatureSet.SignatureHelp)]
-    [InlineData(LspFeatureSet.CodeActions)]
-    [InlineData(LspFeatureSet.Formatting)]
-    [InlineData(LspFeatureSet.DocumentSymbol)]
-    [InlineData(LspFeatureSet.DocumentHighlight)]
-    [InlineData(LspFeatureSet.FoldingRange)]
-    [InlineData(LspFeatureSet.SelectionRange)]
-    [InlineData(LspFeatureSet.InlayHints)]
-    [InlineData(LspFeatureSet.CodeLens)]
-    [InlineData(LspFeatureSet.CallHierarchy)]
-    [InlineData(LspFeatureSet.TypeHierarchy)]
+    [TestMethod]
+    [DataRow(LspFeatureSet.SemanticTokens)]
+    [DataRow(LspFeatureSet.Completion)]
+    [DataRow(LspFeatureSet.Diagnostics)]
+    [DataRow(LspFeatureSet.Hover)]
+    [DataRow(LspFeatureSet.Definition)]
+    [DataRow(LspFeatureSet.References)]
+    [DataRow(LspFeatureSet.Rename)]
+    [DataRow(LspFeatureSet.SignatureHelp)]
+    [DataRow(LspFeatureSet.CodeActions)]
+    [DataRow(LspFeatureSet.Formatting)]
+    [DataRow(LspFeatureSet.DocumentSymbol)]
+    [DataRow(LspFeatureSet.DocumentHighlight)]
+    [DataRow(LspFeatureSet.FoldingRange)]
+    [DataRow(LspFeatureSet.SelectionRange)]
+    [DataRow(LspFeatureSet.InlayHints)]
+    [DataRow(LspFeatureSet.CodeLens)]
+    [DataRow(LspFeatureSet.CallHierarchy)]
+    [DataRow(LspFeatureSet.TypeHierarchy)]
     public void LspFeatureSet_All_IncludesFlag(LspFeatureSet flag)
     {
-        Assert.True((LspFeatureSet.All & flag) != 0,
-            $"All should include {flag}");
+        Assert.IsTrue((LspFeatureSet.All & flag) != 0, $"All should include {flag}");
     }
 
-    [Theory]
-    [InlineData(LspFeatureSet.Hover)]
-    [InlineData(LspFeatureSet.Completion)]
-    [InlineData(LspFeatureSet.Diagnostics)]
+    [TestMethod]
+    [DataRow(LspFeatureSet.Hover)]
+    [DataRow(LspFeatureSet.Completion)]
+    [DataRow(LspFeatureSet.Diagnostics)]
     public void LspFeatureSet_Combination_ExcludesRemovedFlag(LspFeatureSet excluded)
     {
         var combined = LspFeatureSet.All & ~excluded;
 
-        Assert.True((combined & excluded) == 0,
-            $"Combination should not include excluded flag {excluded}");
+        Assert.IsTrue((combined & excluded) == 0, $"Combination should not include excluded flag {excluded}");
     }
 
-    [Fact]
+    [TestMethod]
     public void LspFeatureSet_Combination_RetainsOtherFlags()
     {
         var combined = LspFeatureSet.All & ~LspFeatureSet.Hover;
 
-        Assert.True((combined & LspFeatureSet.Completion) != 0);
-        Assert.True((combined & LspFeatureSet.Definition) != 0);
-        Assert.True((combined & LspFeatureSet.SemanticTokens) != 0);
+        Assert.IsTrue((combined & LspFeatureSet.Completion) != 0);
+        Assert.IsTrue((combined & LspFeatureSet.Definition) != 0);
+        Assert.IsTrue((combined & LspFeatureSet.SemanticTokens) != 0);
     }
 
     // --- DefaultLanguageExtension tests ---
 
-    [Fact]
+    [TestMethod]
     public void DefaultExtension_EnablesAllFeatures()
     {
         var extension = new DefaultLanguageExtension("csharp");
 
-        Assert.Equal(LspFeatureSet.All, extension.EnabledFeatures);
+        Assert.AreEqual(LspFeatureSet.All, extension.EnabledFeatures);
     }
 
-    [Fact]
+    [TestMethod]
     public void DefaultExtension_HasCorrectLanguageId()
     {
         var extension = new DefaultLanguageExtension("python");
 
-        Assert.Equal("python", extension.LanguageId);
+        Assert.AreEqual("python", extension.LanguageId);
     }
 
-    [Fact]
+    [TestMethod]
     public void DefaultExtension_Singleton_HasPlaintextLanguageId()
     {
-        Assert.Equal("plaintext", DefaultLanguageExtension.Instance.LanguageId);
+        Assert.AreEqual("plaintext", DefaultLanguageExtension.Instance.LanguageId);
     }
 
     // --- LspFeatureController.IsEnabled tests ---
 
-    [Theory]
-    [InlineData(LspFeatureSet.SemanticTokens)]
-    [InlineData(LspFeatureSet.Completion)]
-    [InlineData(LspFeatureSet.Diagnostics)]
-    [InlineData(LspFeatureSet.Hover)]
-    [InlineData(LspFeatureSet.Definition)]
-    [InlineData(LspFeatureSet.References)]
-    [InlineData(LspFeatureSet.Rename)]
-    [InlineData(LspFeatureSet.SignatureHelp)]
-    [InlineData(LspFeatureSet.CodeActions)]
-    [InlineData(LspFeatureSet.Formatting)]
-    [InlineData(LspFeatureSet.DocumentSymbol)]
-    [InlineData(LspFeatureSet.DocumentHighlight)]
-    [InlineData(LspFeatureSet.FoldingRange)]
-    [InlineData(LspFeatureSet.SelectionRange)]
-    [InlineData(LspFeatureSet.InlayHints)]
-    [InlineData(LspFeatureSet.CodeLens)]
-    [InlineData(LspFeatureSet.CallHierarchy)]
-    [InlineData(LspFeatureSet.TypeHierarchy)]
+    [TestMethod]
+    [DataRow(LspFeatureSet.SemanticTokens)]
+    [DataRow(LspFeatureSet.Completion)]
+    [DataRow(LspFeatureSet.Diagnostics)]
+    [DataRow(LspFeatureSet.Hover)]
+    [DataRow(LspFeatureSet.Definition)]
+    [DataRow(LspFeatureSet.References)]
+    [DataRow(LspFeatureSet.Rename)]
+    [DataRow(LspFeatureSet.SignatureHelp)]
+    [DataRow(LspFeatureSet.CodeActions)]
+    [DataRow(LspFeatureSet.Formatting)]
+    [DataRow(LspFeatureSet.DocumentSymbol)]
+    [DataRow(LspFeatureSet.DocumentHighlight)]
+    [DataRow(LspFeatureSet.FoldingRange)]
+    [DataRow(LspFeatureSet.SelectionRange)]
+    [DataRow(LspFeatureSet.InlayHints)]
+    [DataRow(LspFeatureSet.CodeLens)]
+    [DataRow(LspFeatureSet.CallHierarchy)]
+    [DataRow(LspFeatureSet.TypeHierarchy)]
     public void IsEnabled_AllFeaturesEnabled_ReturnsTrueForEach(LspFeatureSet feature)
     {
         var extension = new MinimalExtension { EnabledFeatures = LspFeatureSet.All };
         var controller = new LspFeatureController(null!, extension);
 
-        Assert.True(controller.IsEnabled(feature));
+        Assert.IsTrue(controller.IsEnabled(feature));
     }
 
-    [Theory]
-    [InlineData(LspFeatureSet.Hover)]
-    [InlineData(LspFeatureSet.Completion)]
-    [InlineData(LspFeatureSet.Rename)]
+    [TestMethod]
+    [DataRow(LspFeatureSet.Hover)]
+    [DataRow(LspFeatureSet.Completion)]
+    [DataRow(LspFeatureSet.Rename)]
     public void IsEnabled_SpecificFeatureDisabled_ReturnsFalse(LspFeatureSet disabled)
     {
         var extension = new MinimalExtension { EnabledFeatures = LspFeatureSet.All & ~disabled };
         var controller = new LspFeatureController(null!, extension);
 
-        Assert.False(controller.IsEnabled(disabled));
+        Assert.IsFalse(controller.IsEnabled(disabled));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsEnabled_SpecificFeatureDisabled_OtherFeaturesStillEnabled()
     {
         var extension = new MinimalExtension
@@ -176,47 +174,47 @@ public class LspFeatureControllerTests
         };
         var controller = new LspFeatureController(null!, extension);
 
-        Assert.False(controller.IsEnabled(LspFeatureSet.Hover));
-        Assert.True(controller.IsEnabled(LspFeatureSet.Completion));
-        Assert.True(controller.IsEnabled(LspFeatureSet.Definition));
+        Assert.IsFalse(controller.IsEnabled(LspFeatureSet.Hover));
+        Assert.IsTrue(controller.IsEnabled(LspFeatureSet.Completion));
+        Assert.IsTrue(controller.IsEnabled(LspFeatureSet.Definition));
     }
 
-    [Theory]
-    [InlineData(LspFeatureSet.SemanticTokens)]
-    [InlineData(LspFeatureSet.Completion)]
-    [InlineData(LspFeatureSet.Hover)]
-    [InlineData(LspFeatureSet.CodeActions)]
+    [TestMethod]
+    [DataRow(LspFeatureSet.SemanticTokens)]
+    [DataRow(LspFeatureSet.Completion)]
+    [DataRow(LspFeatureSet.Hover)]
+    [DataRow(LspFeatureSet.CodeActions)]
     public void IsEnabled_None_ReturnsFalseForAll(LspFeatureSet feature)
     {
         var extension = new MinimalExtension { EnabledFeatures = LspFeatureSet.None };
         var controller = new LspFeatureController(null!, extension);
 
-        Assert.False(controller.IsEnabled(feature));
+        Assert.IsFalse(controller.IsEnabled(feature));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsEnabled_OnlyOneFeature_ReturnsTrueOnlyForThat()
     {
         var extension = new MinimalExtension { EnabledFeatures = LspFeatureSet.Hover };
         var controller = new LspFeatureController(null!, extension);
 
-        Assert.True(controller.IsEnabled(LspFeatureSet.Hover));
-        Assert.False(controller.IsEnabled(LspFeatureSet.Completion));
-        Assert.False(controller.IsEnabled(LspFeatureSet.Definition));
+        Assert.IsTrue(controller.IsEnabled(LspFeatureSet.Hover));
+        Assert.IsFalse(controller.IsEnabled(LspFeatureSet.Completion));
+        Assert.IsFalse(controller.IsEnabled(LspFeatureSet.Definition));
     }
 
-    [Fact]
+    [TestMethod]
     public void Extension_Property_ReturnsProvidedExtension()
     {
         var extension = new MinimalExtension { LanguageId = "rust" };
         var controller = new LspFeatureController(null!, extension);
 
-        Assert.Same(extension, controller.Extension);
+        Assert.AreSame(extension, controller.Extension);
     }
 
     // --- ILanguageExtension default implementation tests ---
 
-    [Fact]
+    [TestMethod]
     public void ILanguageExtension_DefaultFilterCompletions_ReturnsInput()
     {
         ILanguageExtension extension = new MinimalExtension();
@@ -228,10 +226,10 @@ public class LspFeatureControllerTests
 
         var result = extension.FilterCompletions(items);
 
-        Assert.Same(items, result);
+        Assert.AreSame(items, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void ILanguageExtension_DefaultFilterCodeActions_ReturnsInput()
     {
         ILanguageExtension extension = new MinimalExtension();
@@ -243,10 +241,10 @@ public class LspFeatureControllerTests
 
         var result = extension.FilterCodeActions(actions);
 
-        Assert.Same(actions, result);
+        Assert.AreSame(actions, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void ILanguageExtension_DefaultRenderHoverOverlay_ReturnsNull()
     {
         ILanguageExtension extension = new MinimalExtension();
@@ -255,16 +253,16 @@ public class LspFeatureControllerTests
 
         var result = extension.RenderHoverOverlay(hover, position);
 
-        Assert.Null(result);
+        Assert.IsNull(result);
     }
 
-    [Fact]
+    [TestMethod]
     public void ILanguageExtension_DefaultGetServerConfiguration_ReturnsNull()
     {
         ILanguageExtension extension = new MinimalExtension();
 
         var result = extension.GetServerConfiguration();
 
-        Assert.Null(result);
+        Assert.IsNull(result);
     }
 }

--- a/tests/Hex1b.Tests/LanguageServer/LspIntegrationTests.cs
+++ b/tests/Hex1b.Tests/LanguageServer/LspIntegrationTests.cs
@@ -8,7 +8,8 @@ namespace Hex1b.Tests.LanguageServer;
 /// End-to-end tests for the LSP integration pipeline:
 /// TestLanguageServer → JsonRpcTransport → LanguageServerClient → LanguageServerDecorationProvider
 /// </summary>
-public class LspIntegrationTests : IAsyncLifetime
+[TestClass]
+public class LspIntegrationTests
 {
     private const string DocUri = "file:///test.cs";
     private const string LangId = "csharp";
@@ -16,7 +17,8 @@ public class LspIntegrationTests : IAsyncLifetime
     private TestLanguageServer? _server;
     private LanguageServerClient? _client;
 
-    public async ValueTask InitializeAsync()
+    [TestInitialize]
+    public async Task InitializeAsync()
     {
         _server = new TestLanguageServer();
         _server.Start();
@@ -31,7 +33,8 @@ public class LspIntegrationTests : IAsyncLifetime
         await _client.StartAsync();
     }
 
-    public async ValueTask DisposeAsync()
+    [TestCleanup]
+    public async Task DisposeAsync()
     {
         if (_client != null)
         {
@@ -42,31 +45,31 @@ public class LspIntegrationTests : IAsyncLifetime
             await _server.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public void Initialize_ReturnsServerCapabilities()
     {
-        Assert.NotNull(_client!.ServerCapabilities);
-        Assert.NotNull(_client.ServerCapabilities!.SemanticTokensProvider);
-        Assert.NotNull(_client.ServerCapabilities.CompletionProvider);
+        Assert.IsNotNull(_client!.ServerCapabilities);
+        Assert.IsNotNull(_client.ServerCapabilities!.SemanticTokensProvider);
+        Assert.IsNotNull(_client.ServerCapabilities.CompletionProvider);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SemanticTokens_ReturnsTokensForKeywords()
     {
         await _client!.OpenDocumentAsync(DocUri, LangId, "public class Foo { }");
 
         var result = await _client.RequestSemanticTokensAsync(DocUri);
 
-        Assert.NotNull(result);
-        Assert.True(result!.Data.Length > 0, "Should return semantic tokens");
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result!.Data.Length > 0, "Should return semantic tokens");
 
-        Assert.Equal(0, result.Data[0]); // deltaLine
-        Assert.Equal(0, result.Data[1]); // deltaChar
-        Assert.Equal(6, result.Data[2]); // length of "public"
-        Assert.Equal(0, result.Data[3]); // tokenType = keyword
+        Assert.AreEqual(0, result.Data[0]); // deltaLine
+        Assert.AreEqual(0, result.Data[1]); // deltaChar
+        Assert.AreEqual(6, result.Data[2]); // length of "public"
+        Assert.AreEqual(0, result.Data[3]); // tokenType = keyword
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SemanticTokens_MapsToDecorationSpans()
     {
         var legend = new[] { "keyword", "type", "string", "comment", "number", "variable", "function", "namespace" };
@@ -75,15 +78,15 @@ public class LspIntegrationTests : IAsyncLifetime
         var result = await _client.RequestSemanticTokensAsync(DocUri);
         var spans = SemanticTokenMapper.MapTokens(result!.Data, legend);
 
-        Assert.True(spans.Count >= 2, "Should have spans for 'public' and 'class'");
+        Assert.IsTrue(spans.Count >= 2, "Should have spans for 'public' and 'class'");
 
         var first = spans[0];
-        Assert.Equal(1, first.Start.Line);
-        Assert.Equal(1, first.Start.Column);
-        Assert.Equal(7, first.End.Column); // "public" = 6 chars, end is exclusive
+        Assert.AreEqual(1, first.Start.Line);
+        Assert.AreEqual(1, first.Start.Column);
+        Assert.AreEqual(7, first.End.Column); // "public" = 6 chars, end is exclusive
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Diagnostics_ReceivedForTodoPattern()
     {
         var diagnosticsReceived = new TaskCompletionSource<JsonRpcResponse>();
@@ -96,17 +99,17 @@ public class LspIntegrationTests : IAsyncLifetime
         await _client.OpenDocumentAsync(DocUri, LangId, "// TODO: fix this");
 
         var result = await diagnosticsReceived.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.NotNull(result.Params);
+        Assert.IsNotNull(result.Params);
 
         var diagParams = System.Text.Json.JsonSerializer.Deserialize<PublishDiagnosticsParams>(
             result.Params!.Value.GetRawText());
-        Assert.NotNull(diagParams);
-        Assert.Single(diagParams!.Diagnostics);
-        Assert.Equal(2, diagParams.Diagnostics[0].Severity); // Warning
+        Assert.IsNotNull(diagParams);
+        TestSeq.Single(diagParams!.Diagnostics);
+        Assert.AreEqual(2, diagParams.Diagnostics[0].Severity); // Warning
         Assert.Contains("TODO", diagParams.Diagnostics[0].Message);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Diagnostics_MapToDecorationSpans()
     {
         var diagnosticsReceived = new TaskCompletionSource<JsonRpcResponse>();
@@ -123,27 +126,27 @@ public class LspIntegrationTests : IAsyncLifetime
             result.Params!.Value.GetRawText());
 
         var spans = DiagnosticMapper.MapDiagnostics(diagParams!.Diagnostics);
-        Assert.Single(spans);
+        TestSeq.Single(spans);
 
         var span = spans[0];
-        Assert.Equal(UnderlineStyle.Curly, span.Decoration.UnderlineStyle);
-        Assert.Equal(1, span.Start.Line);
+        Assert.AreEqual(UnderlineStyle.Curly, span.Decoration.UnderlineStyle);
+        Assert.AreEqual(1, span.Start.Line);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Completion_ReturnsItems()
     {
         await _client!.OpenDocumentAsync(DocUri, LangId, "var x = foo.");
 
         var result = await _client.RequestCompletionAsync(DocUri, 0, 12);
 
-        Assert.NotNull(result);
-        Assert.True(result!.Items.Length > 0);
-        Assert.Contains(result.Items, i => i.Label == "ToString");
-        Assert.Contains(result.Items, i => i.Label == "GetHashCode");
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result!.Items.Length > 0);
+        Assert.IsTrue(result.Items.Any(i => i.Label == "ToString"));
+        Assert.IsTrue(result.Items.Any(i => i.Label == "GetHashCode"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DocumentChange_UpdatesTokens()
     {
         await _client!.OpenDocumentAsync(DocUri, LangId, "var x = 1;");
@@ -152,8 +155,8 @@ public class LspIntegrationTests : IAsyncLifetime
         await _client.ChangeDocumentAsync(DocUri, "public static void Main() { }");
         var result2 = await _client.RequestSemanticTokensAsync(DocUri);
 
-        Assert.NotNull(result1);
-        Assert.NotNull(result2);
-        Assert.True(result2!.Data.Length > result1!.Data.Length);
+        Assert.IsNotNull(result1);
+        Assert.IsNotNull(result2);
+        Assert.IsTrue(result2!.Data.Length > result1!.Data.Length);
     }
 }

--- a/tests/Hex1b.Tests/LanguageServer/LspPipelineIntegrationTests.cs
+++ b/tests/Hex1b.Tests/LanguageServer/LspPipelineIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Hex1b.Tests.LanguageServer;
 /// Verifies feature gating, extension filtering, type conversions, and feature set
 /// combinations WITHOUT a real language server.
 /// </summary>
+[TestClass]
 public class LspPipelineIntegrationTests
 {
     // ── Helpers ──────────────────────────────────────────────
@@ -32,55 +33,55 @@ public class LspPipelineIntegrationTests
 
     // ── 1. Feature Controller Gating Tests ───────────────────
 
-    [Fact]
+    [TestMethod]
     public void Controller_DisabledFeature_ReturnsIsEnabledFalse()
     {
         var extension = new TestExtension(LspFeatureSet.All & ~LspFeatureSet.Hover);
         var controller = new LspFeatureController(null!, extension);
 
-        Assert.False(controller.IsEnabled(LspFeatureSet.Hover));
-        Assert.True(controller.IsEnabled(LspFeatureSet.Definition));
-        Assert.True(controller.IsEnabled(LspFeatureSet.Completion));
+        Assert.IsFalse(controller.IsEnabled(LspFeatureSet.Hover));
+        Assert.IsTrue(controller.IsEnabled(LspFeatureSet.Definition));
+        Assert.IsTrue(controller.IsEnabled(LspFeatureSet.Completion));
     }
 
-    [Fact]
+    [TestMethod]
     public void Controller_NoFeatures_AllDisabled()
     {
         var extension = new TestExtension(LspFeatureSet.None);
         var controller = new LspFeatureController(null!, extension);
 
-        Assert.False(controller.IsEnabled(LspFeatureSet.Hover));
-        Assert.False(controller.IsEnabled(LspFeatureSet.Definition));
-        Assert.False(controller.IsEnabled(LspFeatureSet.Completion));
-        Assert.False(controller.IsEnabled(LspFeatureSet.SemanticTokens));
+        Assert.IsFalse(controller.IsEnabled(LspFeatureSet.Hover));
+        Assert.IsFalse(controller.IsEnabled(LspFeatureSet.Definition));
+        Assert.IsFalse(controller.IsEnabled(LspFeatureSet.Completion));
+        Assert.IsFalse(controller.IsEnabled(LspFeatureSet.SemanticTokens));
     }
 
-    [Fact]
+    [TestMethod]
     public void Controller_AllFeatures_AllEnabled()
     {
         var extension = new TestExtension(LspFeatureSet.All);
         var controller = new LspFeatureController(null!, extension);
 
-        Assert.True(controller.IsEnabled(LspFeatureSet.Hover));
-        Assert.True(controller.IsEnabled(LspFeatureSet.Definition));
-        Assert.True(controller.IsEnabled(LspFeatureSet.Completion));
-        Assert.True(controller.IsEnabled(LspFeatureSet.SemanticTokens));
-        Assert.True(controller.IsEnabled(LspFeatureSet.InlayHints));
-        Assert.True(controller.IsEnabled(LspFeatureSet.CodeLens));
+        Assert.IsTrue(controller.IsEnabled(LspFeatureSet.Hover));
+        Assert.IsTrue(controller.IsEnabled(LspFeatureSet.Definition));
+        Assert.IsTrue(controller.IsEnabled(LspFeatureSet.Completion));
+        Assert.IsTrue(controller.IsEnabled(LspFeatureSet.SemanticTokens));
+        Assert.IsTrue(controller.IsEnabled(LspFeatureSet.InlayHints));
+        Assert.IsTrue(controller.IsEnabled(LspFeatureSet.CodeLens));
     }
 
-    [Fact]
+    [TestMethod]
     public void Controller_ExposesExtension()
     {
         var extension = new TestExtension(LspFeatureSet.All);
         var controller = new LspFeatureController(null!, extension);
 
-        Assert.Same(extension, controller.Extension);
+        Assert.AreSame(extension, controller.Extension);
     }
 
     // ── 2. Extension Filter Integration Tests ────────────────
 
-    [Fact]
+    [TestMethod]
     public void FilteringExtension_FiltersCompletions()
     {
         var extension = new FilteringExtension();
@@ -93,20 +94,20 @@ public class LspPipelineIntegrationTests
 
         var filtered = extension.FilterCompletions(items);
 
-        Assert.Equal(2, filtered.Count);
-        Assert.All(filtered, i => Assert.StartsWith("test", i.Label));
+        Assert.AreEqual(2, filtered.Count);
+        TestSeq.All(filtered, i => Assert.StartsWith("test", i.Label));
     }
 
-    [Fact]
+    [TestMethod]
     public void FilteringExtension_EmptyInput_ReturnsEmpty()
     {
         var extension = new FilteringExtension();
         var filtered = extension.FilterCompletions([]);
 
-        Assert.Empty(filtered);
+        Assert.IsEmpty(filtered);
     }
 
-    [Fact]
+    [TestMethod]
     public void FilteringExtension_NoMatches_ReturnsEmpty()
     {
         var extension = new FilteringExtension();
@@ -118,10 +119,10 @@ public class LspPipelineIntegrationTests
 
         var filtered = extension.FilterCompletions(items);
 
-        Assert.Empty(filtered);
+        Assert.IsEmpty(filtered);
     }
 
-    [Fact]
+    [TestMethod]
     public void DefaultExtension_PassthroughCompletions()
     {
         ILanguageExtension extension = DefaultLanguageExtension.Instance;
@@ -133,20 +134,20 @@ public class LspPipelineIntegrationTests
 
         var filtered = extension.FilterCompletions(items);
 
-        Assert.Same(items, filtered);
+        Assert.AreSame(items, filtered);
     }
 
-    [Fact]
+    [TestMethod]
     public void DefaultExtension_AllFeaturesEnabled()
     {
         var extension = DefaultLanguageExtension.Instance;
 
-        Assert.Equal(LspFeatureSet.All, extension.EnabledFeatures);
+        Assert.AreEqual(LspFeatureSet.All, extension.EnabledFeatures);
     }
 
     // ── 3. Full Pipeline Tests (LSP types → Foundation types) ─
 
-    [Fact]
+    [TestMethod]
     public void Pipeline_DocumentHighlights_ToRangeHighlights_EndToEnd()
     {
         var lspHighlights = new DocumentHighlight[]
@@ -173,17 +174,17 @@ public class LspPipelineIntegrationTests
 
         var rangeHighlights = LanguageServerDecorationProvider.DocumentHighlightsToRangeHighlights(lspHighlights);
 
-        Assert.Equal(2, rangeHighlights.Count);
+        Assert.AreEqual(2, rangeHighlights.Count);
         // 0-based → 1-based
-        Assert.Equal(new DocumentPosition(6, 11), rangeHighlights[0].Start);
-        Assert.Equal(new DocumentPosition(6, 16), rangeHighlights[0].End);
-        Assert.Equal(RangeHighlightKind.ReadAccess, rangeHighlights[0].Kind);
-        Assert.Equal(new DocumentPosition(11, 1), rangeHighlights[1].Start);
-        Assert.Equal(new DocumentPosition(11, 6), rangeHighlights[1].End);
-        Assert.Equal(RangeHighlightKind.WriteAccess, rangeHighlights[1].Kind);
+        Assert.AreEqual(new DocumentPosition(6, 11), rangeHighlights[0].Start);
+        Assert.AreEqual(new DocumentPosition(6, 16), rangeHighlights[0].End);
+        Assert.AreEqual(RangeHighlightKind.ReadAccess, rangeHighlights[0].Kind);
+        Assert.AreEqual(new DocumentPosition(11, 1), rangeHighlights[1].Start);
+        Assert.AreEqual(new DocumentPosition(11, 6), rangeHighlights[1].End);
+        Assert.AreEqual(RangeHighlightKind.WriteAccess, rangeHighlights[1].Kind);
     }
 
-    [Fact]
+    [TestMethod]
     public void Pipeline_DocumentHighlights_DefaultKind()
     {
         var lspHighlights = new DocumentHighlight[]
@@ -201,19 +202,19 @@ public class LspPipelineIntegrationTests
 
         var rangeHighlights = LanguageServerDecorationProvider.DocumentHighlightsToRangeHighlights(lspHighlights);
 
-        Assert.Single(rangeHighlights);
-        Assert.Equal(RangeHighlightKind.Default, rangeHighlights[0].Kind);
+        TestSeq.Single(rangeHighlights);
+        Assert.AreEqual(RangeHighlightKind.Default, rangeHighlights[0].Kind);
     }
 
-    [Fact]
+    [TestMethod]
     public void Pipeline_DocumentHighlights_NullInput_ReturnsEmpty()
     {
         var result = LanguageServerDecorationProvider.DocumentHighlightsToRangeHighlights(null);
 
-        Assert.Empty(result);
+        Assert.IsEmpty(result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Pipeline_FoldingRanges_ToFoldingRegions_EndToEnd()
     {
         var lspRanges = new FoldingRange[]
@@ -225,27 +226,27 @@ public class LspPipelineIntegrationTests
 
         var regions = LanguageServerDecorationProvider.FoldingRangesToRegions(lspRanges);
 
-        Assert.Equal(3, regions.Count);
-        Assert.Equal(1, regions[0].StartLine); // 0-based → 1-based
-        Assert.Equal(11, regions[0].EndLine);
-        Assert.Equal(FoldingRegionKind.Comment, regions[0].Kind);
-        Assert.Equal(16, regions[1].StartLine);
-        Assert.Equal(21, regions[1].EndLine);
-        Assert.Equal(FoldingRegionKind.Imports, regions[1].Kind);
-        Assert.Equal(26, regions[2].StartLine);
-        Assert.Equal(51, regions[2].EndLine);
-        Assert.Equal(FoldingRegionKind.Region, regions[2].Kind); // default
+        Assert.AreEqual(3, regions.Count);
+        Assert.AreEqual(1, regions[0].StartLine); // 0-based → 1-based
+        Assert.AreEqual(11, regions[0].EndLine);
+        Assert.AreEqual(FoldingRegionKind.Comment, regions[0].Kind);
+        Assert.AreEqual(16, regions[1].StartLine);
+        Assert.AreEqual(21, regions[1].EndLine);
+        Assert.AreEqual(FoldingRegionKind.Imports, regions[1].Kind);
+        Assert.AreEqual(26, regions[2].StartLine);
+        Assert.AreEqual(51, regions[2].EndLine);
+        Assert.AreEqual(FoldingRegionKind.Region, regions[2].Kind); // default
     }
 
-    [Fact]
+    [TestMethod]
     public void Pipeline_FoldingRanges_NullInput_ReturnsEmpty()
     {
         var result = LanguageServerDecorationProvider.FoldingRangesToRegions(null);
 
-        Assert.Empty(result);
+        Assert.IsEmpty(result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Pipeline_InlayHints_ToInlineHints_EndToEnd()
     {
         var lspHints = new InlayHint[]
@@ -264,14 +265,14 @@ public class LspPipelineIntegrationTests
 
         var inlineHints = LanguageServerDecorationProvider.InlayHintsToInlineHints(lspHints);
 
-        Assert.Equal(2, inlineHints.Count);
-        Assert.Equal(new DocumentPosition(4, 16), inlineHints[0].Position); // 0→1 based
-        Assert.Equal("string", inlineHints[0].Text);
-        Assert.Equal(new DocumentPosition(8, 1), inlineHints[1].Position);
-        Assert.Equal("int", inlineHints[1].Text);
+        Assert.AreEqual(2, inlineHints.Count);
+        Assert.AreEqual(new DocumentPosition(4, 16), inlineHints[0].Position); // 0→1 based
+        Assert.AreEqual("string", inlineHints[0].Text);
+        Assert.AreEqual(new DocumentPosition(8, 1), inlineHints[1].Position);
+        Assert.AreEqual("int", inlineHints[1].Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void Pipeline_InlayHints_ArrayLabel_ConcatenatesParts()
     {
         var labelParts = new[]
@@ -291,19 +292,19 @@ public class LspPipelineIntegrationTests
 
         var inlineHints = LanguageServerDecorationProvider.InlayHintsToInlineHints(lspHints);
 
-        Assert.Single(inlineHints);
-        Assert.Equal("param: int", inlineHints[0].Text);
+        TestSeq.Single(inlineHints);
+        Assert.AreEqual("param: int", inlineHints[0].Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void Pipeline_InlayHints_NullInput_ReturnsEmpty()
     {
         var result = LanguageServerDecorationProvider.InlayHintsToInlineHints(null);
 
-        Assert.Empty(result);
+        Assert.IsEmpty(result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Pipeline_DocumentSymbols_ToBreadcrumbs_EndToEnd()
     {
         var lspSymbols = new DocumentSymbol[]
@@ -345,35 +346,35 @@ public class LspPipelineIntegrationTests
 
         var breadcrumbs = LanguageServerDecorationProvider.DocumentSymbolsToBreadcrumbs(lspSymbols);
 
-        Assert.NotNull(breadcrumbs);
-        Assert.Single(breadcrumbs!.Symbols);
-        Assert.Equal("MyClass", breadcrumbs.Symbols[0].Name);
-        Assert.Equal(BreadcrumbSymbolKind.Class, breadcrumbs.Symbols[0].Kind);
-        Assert.Equal(new DocumentPosition(1, 1), breadcrumbs.Symbols[0].Start);
-        Assert.Equal(new DocumentPosition(51, 1), breadcrumbs.Symbols[0].End);
-        Assert.NotNull(breadcrumbs.Symbols[0].Children);
-        Assert.Single(breadcrumbs.Symbols[0].Children!);
-        Assert.Equal("DoWork", breadcrumbs.Symbols[0].Children![0].Name);
-        Assert.Equal(BreadcrumbSymbolKind.Method, breadcrumbs.Symbols[0].Children![0].Kind);
+        Assert.IsNotNull(breadcrumbs);
+        TestSeq.Single(breadcrumbs!.Symbols);
+        Assert.AreEqual("MyClass", breadcrumbs.Symbols[0].Name);
+        Assert.AreEqual(BreadcrumbSymbolKind.Class, breadcrumbs.Symbols[0].Kind);
+        Assert.AreEqual(new DocumentPosition(1, 1), breadcrumbs.Symbols[0].Start);
+        Assert.AreEqual(new DocumentPosition(51, 1), breadcrumbs.Symbols[0].End);
+        Assert.IsNotNull(breadcrumbs.Symbols[0].Children);
+        TestSeq.Single(breadcrumbs.Symbols[0].Children!);
+        Assert.AreEqual("DoWork", breadcrumbs.Symbols[0].Children![0].Name);
+        Assert.AreEqual(BreadcrumbSymbolKind.Method, breadcrumbs.Symbols[0].Children![0].Kind);
     }
 
-    [Fact]
+    [TestMethod]
     public void Pipeline_DocumentSymbols_NullInput_ReturnsNull()
     {
         var result = LanguageServerDecorationProvider.DocumentSymbolsToBreadcrumbs(null);
 
-        Assert.Null(result);
+        Assert.IsNull(result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Pipeline_DocumentSymbols_EmptyInput_ReturnsNull()
     {
         var result = LanguageServerDecorationProvider.DocumentSymbolsToBreadcrumbs([]);
 
-        Assert.Null(result);
+        Assert.IsNull(result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Pipeline_SignatureHelp_ToSignaturePanel_EndToEnd()
     {
         var lspHelp = new SignatureHelp
@@ -396,34 +397,34 @@ public class LspPipelineIntegrationTests
 
         var panel = LanguageServerDecorationProvider.SignatureHelpToPanel(lspHelp);
 
-        Assert.NotNull(panel);
-        Assert.Single(panel!.Signatures);
-        Assert.Equal("void Foo(int x, string y)", panel.Signatures[0].Label);
-        Assert.Equal(2, panel.Signatures[0].Parameters.Count);
-        Assert.Equal("int x", panel.Signatures[0].Parameters[0].Label);
-        Assert.Equal("string y", panel.Signatures[0].Parameters[1].Label);
-        Assert.Equal(0, panel.ActiveSignature);
-        Assert.Equal(1, panel.ActiveParameter);
+        Assert.IsNotNull(panel);
+        TestSeq.Single(panel!.Signatures);
+        Assert.AreEqual("void Foo(int x, string y)", panel.Signatures[0].Label);
+        Assert.AreEqual(2, panel.Signatures[0].Parameters.Count);
+        Assert.AreEqual("int x", panel.Signatures[0].Parameters[0].Label);
+        Assert.AreEqual("string y", panel.Signatures[0].Parameters[1].Label);
+        Assert.AreEqual(0, panel.ActiveSignature);
+        Assert.AreEqual(1, panel.ActiveParameter);
     }
 
-    [Fact]
+    [TestMethod]
     public void Pipeline_SignatureHelp_NullInput_ReturnsNull()
     {
         var result = LanguageServerDecorationProvider.SignatureHelpToPanel(null);
 
-        Assert.Null(result);
+        Assert.IsNull(result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Pipeline_SignatureHelp_EmptySignatures_ReturnsNull()
     {
         var result = LanguageServerDecorationProvider.SignatureHelpToPanel(
             new SignatureHelp { Signatures = [] });
 
-        Assert.Null(result);
+        Assert.IsNull(result);
     }
 
-    [Fact]
+    [TestMethod]
     public void Pipeline_SignatureHelp_NullActiveIndices_DefaultsToZero()
     {
         var lspHelp = new SignatureHelp
@@ -442,12 +443,12 @@ public class LspPipelineIntegrationTests
 
         var panel = LanguageServerDecorationProvider.SignatureHelpToPanel(lspHelp);
 
-        Assert.NotNull(panel);
-        Assert.Equal(0, panel!.ActiveSignature);
-        Assert.Equal(0, panel.ActiveParameter);
+        Assert.IsNotNull(panel);
+        Assert.AreEqual(0, panel!.ActiveSignature);
+        Assert.AreEqual(0, panel.ActiveParameter);
     }
 
-    [Fact]
+    [TestMethod]
     public void Pipeline_CodeLens_ToGutterDecorations_EndToEnd()
     {
         var lspLenses = new CodeLens[]
@@ -474,15 +475,15 @@ public class LspPipelineIntegrationTests
 
         var decorations = LanguageServerDecorationProvider.CodeLensToGutterDecorations(lspLenses);
 
-        Assert.Equal(2, decorations.Count);
-        Assert.Equal(5, decorations[0].Line); // 0-based → 1-based
-        Assert.Equal('3', decorations[0].Character); // first char of title
-        Assert.Equal(GutterDecorationKind.Info, decorations[0].Kind);
-        Assert.Equal(13, decorations[1].Line);
-        Assert.Equal('R', decorations[1].Character);
+        Assert.AreEqual(2, decorations.Count);
+        Assert.AreEqual(5, decorations[0].Line); // 0-based → 1-based
+        Assert.AreEqual('3', decorations[0].Character); // first char of title
+        Assert.AreEqual(GutterDecorationKind.Info, decorations[0].Kind);
+        Assert.AreEqual(13, decorations[1].Line);
+        Assert.AreEqual('R', decorations[1].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Pipeline_CodeLens_NullCommand_Skipped()
     {
         var lspLenses = new CodeLens[]
@@ -500,68 +501,68 @@ public class LspPipelineIntegrationTests
 
         var decorations = LanguageServerDecorationProvider.CodeLensToGutterDecorations(lspLenses);
 
-        Assert.Empty(decorations);
+        Assert.IsEmpty(decorations);
     }
 
-    [Fact]
+    [TestMethod]
     public void Pipeline_CodeLens_NullInput_ReturnsEmpty()
     {
         var result = LanguageServerDecorationProvider.CodeLensToGutterDecorations(null);
 
-        Assert.Empty(result);
+        Assert.IsEmpty(result);
     }
 
     // ── 4. Feature Set Combination Tests ─────────────────────
 
-    [Fact]
+    [TestMethod]
     public void FeatureSet_SelectiveDisable_WorksEndToEnd()
     {
         var features = LspFeatureSet.All & ~LspFeatureSet.Hover & ~LspFeatureSet.InlayHints;
         var extension = new TestExtension(features);
         var controller = new LspFeatureController(null!, extension);
 
-        Assert.False(controller.IsEnabled(LspFeatureSet.Hover));
-        Assert.False(controller.IsEnabled(LspFeatureSet.InlayHints));
-        Assert.True(controller.IsEnabled(LspFeatureSet.Completion));
-        Assert.True(controller.IsEnabled(LspFeatureSet.Definition));
-        Assert.True(controller.IsEnabled(LspFeatureSet.CodeActions));
-        Assert.True(controller.IsEnabled(LspFeatureSet.FoldingRange));
+        Assert.IsFalse(controller.IsEnabled(LspFeatureSet.Hover));
+        Assert.IsFalse(controller.IsEnabled(LspFeatureSet.InlayHints));
+        Assert.IsTrue(controller.IsEnabled(LspFeatureSet.Completion));
+        Assert.IsTrue(controller.IsEnabled(LspFeatureSet.Definition));
+        Assert.IsTrue(controller.IsEnabled(LspFeatureSet.CodeActions));
+        Assert.IsTrue(controller.IsEnabled(LspFeatureSet.FoldingRange));
     }
 
-    [Fact]
+    [TestMethod]
     public void FeatureSet_SingleFeatureEnabled()
     {
         var extension = new TestExtension(LspFeatureSet.Completion);
         var controller = new LspFeatureController(null!, extension);
 
-        Assert.True(controller.IsEnabled(LspFeatureSet.Completion));
-        Assert.False(controller.IsEnabled(LspFeatureSet.Hover));
-        Assert.False(controller.IsEnabled(LspFeatureSet.Definition));
-        Assert.False(controller.IsEnabled(LspFeatureSet.SemanticTokens));
+        Assert.IsTrue(controller.IsEnabled(LspFeatureSet.Completion));
+        Assert.IsFalse(controller.IsEnabled(LspFeatureSet.Hover));
+        Assert.IsFalse(controller.IsEnabled(LspFeatureSet.Definition));
+        Assert.IsFalse(controller.IsEnabled(LspFeatureSet.SemanticTokens));
     }
 
-    [Fact]
+    [TestMethod]
     public void FeatureSet_MultipleExplicitFeatures()
     {
         var features = LspFeatureSet.Hover | LspFeatureSet.Completion | LspFeatureSet.Definition;
         var extension = new TestExtension(features);
         var controller = new LspFeatureController(null!, extension);
 
-        Assert.True(controller.IsEnabled(LspFeatureSet.Hover));
-        Assert.True(controller.IsEnabled(LspFeatureSet.Completion));
-        Assert.True(controller.IsEnabled(LspFeatureSet.Definition));
-        Assert.False(controller.IsEnabled(LspFeatureSet.References));
-        Assert.False(controller.IsEnabled(LspFeatureSet.InlayHints));
-        Assert.False(controller.IsEnabled(LspFeatureSet.CodeLens));
+        Assert.IsTrue(controller.IsEnabled(LspFeatureSet.Hover));
+        Assert.IsTrue(controller.IsEnabled(LspFeatureSet.Completion));
+        Assert.IsTrue(controller.IsEnabled(LspFeatureSet.Definition));
+        Assert.IsFalse(controller.IsEnabled(LspFeatureSet.References));
+        Assert.IsFalse(controller.IsEnabled(LspFeatureSet.InlayHints));
+        Assert.IsFalse(controller.IsEnabled(LspFeatureSet.CodeLens));
     }
 
-    [Fact]
+    [TestMethod]
     public void FeatureSet_None_IsZero()
     {
-        Assert.Equal((LspFeatureSet)0, LspFeatureSet.None);
+        Assert.AreEqual((LspFeatureSet)0, LspFeatureSet.None);
     }
 
-    [Fact]
+    [TestMethod]
     public void FeatureSet_All_ContainsEveryFeature()
     {
         var allFeatures = new[]
@@ -588,9 +589,7 @@ public class LspPipelineIntegrationTests
 
         foreach (var feature in allFeatures)
         {
-            Assert.True(
-                (LspFeatureSet.All & feature) != 0,
-                $"LspFeatureSet.All should contain {feature}");
+            Assert.IsTrue((LspFeatureSet.All & feature) != 0, $"LspFeatureSet.All should contain {feature}");
         }
     }
 }

--- a/tests/Hex1b.Tests/LanguageServer/RealLanguageServerTests.cs
+++ b/tests/Hex1b.Tests/LanguageServer/RealLanguageServerTests.cs
@@ -10,7 +10,8 @@ namespace Hex1b.Tests.LanguageServer;
 /// Requires typescript-language-server to be installed:
 ///   npm install -g typescript-language-server typescript
 /// </summary>
-public class RealLanguageServerTests : IAsyncLifetime
+[TestClass]
+public class RealLanguageServerTests
 {
     private readonly string _workspacePath;
 
@@ -30,8 +31,10 @@ public class RealLanguageServerTests : IAsyncLifetime
         _workspacePath = "";
     }
 
-    public ValueTask InitializeAsync() => default;
-    public ValueTask DisposeAsync() => default;
+    [TestInitialize]
+    public Task InitializeAsync() => Task.CompletedTask;
+    [TestCleanup]
+    public Task DisposeAsync() => Task.CompletedTask;
 
     private static bool TypeScriptLsAvailable()
     {
@@ -50,7 +53,7 @@ public class RealLanguageServerTests : IAsyncLifetime
         catch { return false; }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TypeScriptLs_ReturnsSemanticTokens()
     {
         if (!TypeScriptLsAvailable() || !Directory.Exists(_workspacePath))
@@ -68,7 +71,7 @@ public class RealLanguageServerTests : IAsyncLifetime
         try
         {
             await client.StartAsync(cts.Token);
-            Assert.NotNull(client.ServerCapabilities);
+            Assert.IsNotNull(client.ServerCapabilities);
 
             var filePath = Path.Combine(_workspacePath, "TaskManager.ts");
             var fileUri = "file://" + filePath;
@@ -81,12 +84,12 @@ public class RealLanguageServerTests : IAsyncLifetime
 
             var tokens = await client.RequestSemanticTokensAsync(fileUri, cts.Token);
 
-            Assert.NotNull(tokens);
-            Assert.True(tokens!.Data.Length > 0, "Expected semantic tokens from typescript-language-server");
+            Assert.IsNotNull(tokens);
+            Assert.IsTrue(tokens!.Data.Length > 0, "Expected semantic tokens from typescript-language-server");
 
             // Verify token count is reasonable (TaskManager.ts should have 50+ tokens)
             var tokenCount = tokens.Data.Length / 5;
-            Assert.True(tokenCount > 20, $"Expected at least 20 semantic tokens, got {tokenCount}");
+            Assert.IsTrue(tokenCount > 20, $"Expected at least 20 semantic tokens, got {tokenCount}");
 
             await client.StopAsync();
         }
@@ -96,7 +99,7 @@ public class RealLanguageServerTests : IAsyncLifetime
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TypeScriptLs_ViaWorkspace_ReturnsTokens()
     {
         if (!TypeScriptLsAvailable() || !Directory.Exists(_workspacePath))
@@ -110,7 +113,7 @@ public class RealLanguageServerTests : IAsyncLifetime
 
         var doc = await workspace.OpenDocumentAsync("TaskManager.ts");
         var provider = workspace.GetProvider(doc);
-        Assert.NotNull(provider);
+        Assert.IsNotNull(provider);
 
         // Activate the provider with a minimal session
         var state = new EditorState(doc);
@@ -128,13 +131,13 @@ public class RealLanguageServerTests : IAsyncLifetime
                 break;
         }
 
-        Assert.NotNull(decorations);
-        Assert.True(decorations.Count > 0, "Expected semantic token decorations from typescript-language-server");
+        Assert.IsNotNull(decorations);
+        Assert.IsTrue(decorations.Count > 0, "Expected semantic token decorations from typescript-language-server");
 
         provider.Deactivate();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TypeScriptLs_ReturnsCompletions()
     {
         if (!TypeScriptLsAvailable() || !Directory.Exists(_workspacePath))
@@ -176,15 +179,15 @@ public class RealLanguageServerTests : IAsyncLifetime
                 }
             }
 
-            Assert.True(line >= 0, "Expected 'this.' in TaskManager.ts");
+            Assert.IsTrue(line >= 0, "Expected 'this.' in TaskManager.ts");
 
             var completions = await client.RequestCompletionAsync(fileUri, line, col, ct: cts.Token);
-            Assert.NotNull(completions);
-            Assert.True(completions!.Items.Length > 0, "Expected completions after 'this.'");
+            Assert.IsNotNull(completions);
+            Assert.IsTrue(completions!.Items.Length > 0, "Expected completions after 'this.'");
 
             // Should contain class members
             var labels = completions.Items.Select(i => i.Label).ToList();
-            Assert.Contains(labels, l => !string.IsNullOrEmpty(l));
+            Assert.IsTrue(labels.Any(l => !string.IsNullOrEmpty(l)));
 
             await client.StopAsync();
         }

--- a/tests/Hex1b.Tests/LanguageServer/WorkspaceTests.cs
+++ b/tests/Hex1b.Tests/LanguageServer/WorkspaceTests.cs
@@ -7,9 +7,10 @@ namespace Hex1b.Tests.LanguageServer;
 /// Tests for <see cref="Hex1bLanguageServerWorkspace"/> — server sharing,
 /// provider caching, and language inference.
 /// </summary>
+[TestClass]
 public class WorkspaceTests
 {
-    [Fact]
+    [TestMethod]
     public void GetProvider_ReturnsSameProviderForSameUri()
     {
         var server = new TestLanguageServer();
@@ -22,10 +23,10 @@ public class WorkspaceTests
         var provider1 = workspace.GetProvider("file:///test/File.cs", "csharp");
         var provider2 = workspace.GetProvider("file:///test/File.cs", "csharp");
 
-        Assert.Same(provider1, provider2);
+        Assert.AreSame(provider1, provider2);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetProvider_ReturnsDifferentProvidersForDifferentUris()
     {
         var server = new TestLanguageServer();
@@ -38,10 +39,10 @@ public class WorkspaceTests
         var provider1 = workspace.GetProvider("file:///test/A.cs", "csharp");
         var provider2 = workspace.GetProvider("file:///test/B.cs", "csharp");
 
-        Assert.NotSame(provider1, provider2);
+        Assert.AreNotSame(provider1, provider2);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetProvider_InfersLanguageFromExtension()
     {
         var server = new TestLanguageServer();
@@ -53,15 +54,15 @@ public class WorkspaceTests
 
         // .cs should infer "csharp"
         var provider = workspace.GetProvider("file:///test/File.cs");
-        Assert.NotNull(provider);
+        Assert.IsNotNull(provider);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetProvider_ThrowsForUnregisteredLanguage()
     {
         var workspace = new Hex1bLanguageServerWorkspace("/test");
 
-        Assert.Throws<InvalidOperationException>(() =>
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
             workspace.GetProvider("file:///test/file.rs", "rust"));
     }
 }

--- a/tests/Hex1b.Tests/LayoutNodeAnsiClippingTests.cs
+++ b/tests/Hex1b.Tests/LayoutNodeAnsiClippingTests.cs
@@ -1,12 +1,12 @@
 using Hex1b.Layout;
 using Hex1b.Nodes;
-using Xunit;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class LayoutNodeAnsiClippingTests
 {
-    [Fact]
+    [TestMethod]
     public void ClipString_RightClipsPrintableText_PreservesTrailingResetSuffix()
     {
         var node = new LayoutNode();
@@ -16,12 +16,12 @@ public class LayoutNodeAnsiClippingTests
 
         var (adjustedX, clipped) = node.ClipString(0, 0, text);
 
-        Assert.Equal(1, adjustedX);
-        Assert.Equal("\x1b[31mBCD\x1b[0m", clipped);
+        Assert.AreEqual(1, adjustedX);
+        Assert.AreEqual("\x1b[31mBCD\x1b[0m", clipped);
         AssertValidAnsiCsiSequences(clipped);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClipString_ClipsPlainText_DoesNotIntroduceAnsiCodes()
     {
         var node = new LayoutNode();
@@ -31,12 +31,12 @@ public class LayoutNodeAnsiClippingTests
 
         var (adjustedX, clipped) = node.ClipString(0, 0, text);
 
-        Assert.Equal(1, adjustedX);
-        Assert.Equal("BCD", clipped);
+        Assert.AreEqual(1, adjustedX);
+        Assert.AreEqual("BCD", clipped);
         Assert.DoesNotContain("\x1b[", clipped);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClipString_WideCharacter_DoesNotSplitEmoji()
     {
         var node = new LayoutNode();
@@ -48,11 +48,11 @@ public class LayoutNodeAnsiClippingTests
 
         var (adjustedX, clipped) = node.ClipString(0, 0, text);
 
-        Assert.Equal(0, adjustedX);
-        Assert.Equal("A😀B", clipped); // All fits
+        Assert.AreEqual(0, adjustedX);
+        Assert.AreEqual("A😀B", clipped); // All fits
     }
 
-    [Fact]
+    [TestMethod]
     public void ClipString_WideCharacterClippedOnRight_AddsPadding()
     {
         var node = new LayoutNode();
@@ -64,12 +64,12 @@ public class LayoutNodeAnsiClippingTests
 
         var (adjustedX, clipped) = node.ClipString(0, 0, text);
 
-        Assert.Equal(0, adjustedX);
+        Assert.AreEqual(0, adjustedX);
         // Should only include "A" and a space for padding since 😀 doesn't fit
-        Assert.Equal("A ", clipped);
+        Assert.AreEqual("A ", clipped);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClipString_WideCharacterClippedOnLeft_AddsPadding()
     {
         var node = new LayoutNode();
@@ -82,12 +82,12 @@ public class LayoutNodeAnsiClippingTests
 
         var (adjustedX, clipped) = node.ClipString(0, 0, text);
 
-        Assert.Equal(1, adjustedX);
+        Assert.AreEqual(1, adjustedX);
         // Should skip 😀 and add padding, then include B
-        Assert.Equal(" B", clipped);
+        Assert.AreEqual(" B", clipped);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClipString_CJKCharacters_HandledCorrectly()
     {
         var node = new LayoutNode();
@@ -99,11 +99,11 @@ public class LayoutNodeAnsiClippingTests
 
         var (adjustedX, clipped) = node.ClipString(0, 0, text);
 
-        Assert.Equal(0, adjustedX);
-        Assert.Equal("中文", clipped);
+        Assert.AreEqual(0, adjustedX);
+        Assert.AreEqual("中文", clipped);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClipString_CJKWithAnsi_PreservesEscapeCodes()
     {
         var node = new LayoutNode();
@@ -113,8 +113,8 @@ public class LayoutNodeAnsiClippingTests
 
         var (adjustedX, clipped) = node.ClipString(0, 0, text);
 
-        Assert.Equal(0, adjustedX);
-        Assert.Equal("\x1b[31m中文\x1b[0m", clipped);
+        Assert.AreEqual(0, adjustedX);
+        Assert.AreEqual("\x1b[31m中文\x1b[0m", clipped);
         AssertValidAnsiCsiSequences(clipped);
     }
 
@@ -125,7 +125,7 @@ public class LayoutNodeAnsiClippingTests
             if (text[i] != '\x1b')
                 continue;
 
-            Assert.True(i + 1 < text.Length, "Dangling ESC at end");
+            Assert.IsTrue(i + 1 < text.Length, "Dangling ESC at end");
 
             if (text[i + 1] != '[')
                 continue;
@@ -142,7 +142,7 @@ public class LayoutNodeAnsiClippingTests
                 }
             }
 
-            Assert.True(foundFinal, "Incomplete CSI sequence");
+            Assert.IsTrue(foundFinal, "Incomplete CSI sequence");
         }
     }
 }

--- a/tests/Hex1b.Tests/LayoutTests.cs
+++ b/tests/Hex1b.Tests/LayoutTests.cs
@@ -5,150 +5,151 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for layout primitives: Constraints, Size, Rect.
 /// </summary>
+[TestClass]
 public class LayoutTests
 {
     #region Size Tests
 
-    [Fact]
+    [TestMethod]
     public void Size_Constructor_SetsProperties()
     {
         var size = new Size(10, 20);
         
-        Assert.Equal(10, size.Width);
-        Assert.Equal(20, size.Height);
+        Assert.AreEqual(10, size.Width);
+        Assert.AreEqual(20, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Size_Zero_IsZero()
     {
-        Assert.Equal(0, Size.Zero.Width);
-        Assert.Equal(0, Size.Zero.Height);
+        Assert.AreEqual(0, Size.Zero.Width);
+        Assert.AreEqual(0, Size.Zero.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Size_Equality_Works()
     {
         var s1 = new Size(10, 20);
         var s2 = new Size(10, 20);
         var s3 = new Size(10, 30);
         
-        Assert.Equal(s1, s2);
-        Assert.NotEqual(s1, s3);
-        Assert.True(s1 == s2);
-        Assert.True(s1 != s3);
+        Assert.AreEqual(s1, s2);
+        Assert.AreNotEqual(s1, s3);
+        Assert.IsTrue(s1 == s2);
+        Assert.IsTrue(s1 != s3);
     }
 
     #endregion
 
     #region Rect Tests
 
-    [Fact]
+    [TestMethod]
     public void Rect_Constructor_SetsProperties()
     {
         var rect = new Rect(5, 10, 100, 50);
         
-        Assert.Equal(5, rect.X);
-        Assert.Equal(10, rect.Y);
-        Assert.Equal(100, rect.Width);
-        Assert.Equal(50, rect.Height);
+        Assert.AreEqual(5, rect.X);
+        Assert.AreEqual(10, rect.Y);
+        Assert.AreEqual(100, rect.Width);
+        Assert.AreEqual(50, rect.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Rect_Right_IsXPlusWidth()
     {
         var rect = new Rect(10, 0, 50, 20);
         
-        Assert.Equal(60, rect.Right);
+        Assert.AreEqual(60, rect.Right);
     }
 
-    [Fact]
+    [TestMethod]
     public void Rect_Bottom_IsYPlusHeight()
     {
         var rect = new Rect(0, 10, 20, 30);
         
-        Assert.Equal(40, rect.Bottom);
+        Assert.AreEqual(40, rect.Bottom);
     }
 
-    [Fact]
+    [TestMethod]
     public void Rect_Size_ReturnsCorrectSize()
     {
         var rect = new Rect(5, 5, 100, 50);
         
-        Assert.Equal(new Size(100, 50), rect.Size);
+        Assert.AreEqual(new Size(100, 50), rect.Size);
     }
 
-    [Fact]
+    [TestMethod]
     public void Rect_FromSize_CreatesRectAtOrigin()
     {
         var size = new Size(80, 24);
         var rect = Rect.FromSize(size);
         
-        Assert.Equal(0, rect.X);
-        Assert.Equal(0, rect.Y);
-        Assert.Equal(80, rect.Width);
-        Assert.Equal(24, rect.Height);
+        Assert.AreEqual(0, rect.X);
+        Assert.AreEqual(0, rect.Y);
+        Assert.AreEqual(80, rect.Width);
+        Assert.AreEqual(24, rect.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Rect_Equality_Works()
     {
         var r1 = new Rect(1, 2, 3, 4);
         var r2 = new Rect(1, 2, 3, 4);
         var r3 = new Rect(1, 2, 3, 5);
         
-        Assert.Equal(r1, r2);
-        Assert.NotEqual(r1, r3);
+        Assert.AreEqual(r1, r2);
+        Assert.AreNotEqual(r1, r3);
     }
 
     #endregion
 
     #region Constraints Tests
 
-    [Fact]
+    [TestMethod]
     public void Constraints_Constructor_SetsProperties()
     {
         var c = new Constraints(10, 100, 5, 50);
         
-        Assert.Equal(10, c.MinWidth);
-        Assert.Equal(100, c.MaxWidth);
-        Assert.Equal(5, c.MinHeight);
-        Assert.Equal(50, c.MaxHeight);
+        Assert.AreEqual(10, c.MinWidth);
+        Assert.AreEqual(100, c.MaxWidth);
+        Assert.AreEqual(5, c.MinHeight);
+        Assert.AreEqual(50, c.MaxHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constraints_Unbounded_HasMaxValues()
     {
         var c = Constraints.Unbounded;
         
-        Assert.Equal(0, c.MinWidth);
-        Assert.Equal(int.MaxValue, c.MaxWidth);
-        Assert.Equal(0, c.MinHeight);
-        Assert.Equal(int.MaxValue, c.MaxHeight);
+        Assert.AreEqual(0, c.MinWidth);
+        Assert.AreEqual(int.MaxValue, c.MaxWidth);
+        Assert.AreEqual(0, c.MinHeight);
+        Assert.AreEqual(int.MaxValue, c.MaxHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constraints_Tight_HasEqualMinMax()
     {
         var c = Constraints.Tight(80, 24);
         
-        Assert.Equal(80, c.MinWidth);
-        Assert.Equal(80, c.MaxWidth);
-        Assert.Equal(24, c.MinHeight);
-        Assert.Equal(24, c.MaxHeight);
+        Assert.AreEqual(80, c.MinWidth);
+        Assert.AreEqual(80, c.MaxWidth);
+        Assert.AreEqual(24, c.MinHeight);
+        Assert.AreEqual(24, c.MaxHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constraints_Loose_HasZeroMin()
     {
         var c = Constraints.Loose(80, 24);
         
-        Assert.Equal(0, c.MinWidth);
-        Assert.Equal(80, c.MaxWidth);
-        Assert.Equal(0, c.MinHeight);
-        Assert.Equal(24, c.MaxHeight);
+        Assert.AreEqual(0, c.MinWidth);
+        Assert.AreEqual(80, c.MaxWidth);
+        Assert.AreEqual(0, c.MinHeight);
+        Assert.AreEqual(24, c.MaxHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constraints_Constrain_ClampsToMin()
     {
         var c = new Constraints(10, 100, 10, 100);
@@ -156,11 +157,11 @@ public class LayoutTests
         
         var result = c.Constrain(size);
         
-        Assert.Equal(10, result.Width);
-        Assert.Equal(10, result.Height);
+        Assert.AreEqual(10, result.Width);
+        Assert.AreEqual(10, result.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constraints_Constrain_ClampsToMax()
     {
         var c = new Constraints(10, 100, 10, 100);
@@ -168,11 +169,11 @@ public class LayoutTests
         
         var result = c.Constrain(size);
         
-        Assert.Equal(100, result.Width);
-        Assert.Equal(100, result.Height);
+        Assert.AreEqual(100, result.Width);
+        Assert.AreEqual(100, result.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constraints_Constrain_PreservesWithinBounds()
     {
         var c = new Constraints(10, 100, 10, 100);
@@ -180,62 +181,62 @@ public class LayoutTests
         
         var result = c.Constrain(size);
         
-        Assert.Equal(50, result.Width);
-        Assert.Equal(50, result.Height);
+        Assert.AreEqual(50, result.Width);
+        Assert.AreEqual(50, result.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constraints_WithWidth_SetsFixedWidth()
     {
         var c = Constraints.Loose(100, 100);
         var result = c.WithWidth(50);
         
-        Assert.Equal(50, result.MinWidth);
-        Assert.Equal(50, result.MaxWidth);
-        Assert.Equal(0, result.MinHeight);
-        Assert.Equal(100, result.MaxHeight);
+        Assert.AreEqual(50, result.MinWidth);
+        Assert.AreEqual(50, result.MaxWidth);
+        Assert.AreEqual(0, result.MinHeight);
+        Assert.AreEqual(100, result.MaxHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constraints_WithHeight_SetsFixedHeight()
     {
         var c = Constraints.Loose(100, 100);
         var result = c.WithHeight(50);
         
-        Assert.Equal(0, result.MinWidth);
-        Assert.Equal(100, result.MaxWidth);
-        Assert.Equal(50, result.MinHeight);
-        Assert.Equal(50, result.MaxHeight);
+        Assert.AreEqual(0, result.MinWidth);
+        Assert.AreEqual(100, result.MaxWidth);
+        Assert.AreEqual(50, result.MinHeight);
+        Assert.AreEqual(50, result.MaxHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constraints_WithMaxWidth_ReducesMax()
     {
         var c = Constraints.Loose(100, 100);
         var result = c.WithMaxWidth(50);
         
-        Assert.Equal(0, result.MinWidth);
-        Assert.Equal(50, result.MaxWidth);
+        Assert.AreEqual(0, result.MinWidth);
+        Assert.AreEqual(50, result.MaxWidth);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constraints_WithMaxWidth_DoesNotIncrease()
     {
         var c = Constraints.Loose(50, 50);
         var result = c.WithMaxWidth(100);
         
-        Assert.Equal(50, result.MaxWidth);
+        Assert.AreEqual(50, result.MaxWidth);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constraints_Equality_Works()
     {
         var c1 = new Constraints(1, 2, 3, 4);
         var c2 = new Constraints(1, 2, 3, 4);
         var c3 = new Constraints(1, 2, 3, 5);
         
-        Assert.Equal(c1, c2);
-        Assert.NotEqual(c1, c3);
+        Assert.AreEqual(c1, c2);
+        Assert.AreNotEqual(c1, c3);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/LegendNodeTests.cs
+++ b/tests/Hex1b.Tests/LegendNodeTests.cs
@@ -5,6 +5,7 @@ using Hex1b.Surfaces;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class LegendNodeTests
 {
     private static LegendNode<ChartItem> CreateNode(
@@ -35,58 +36,58 @@ public class LegendNodeTests
 
     #region Measure Tests — Vertical
 
-    [Fact]
+    [TestMethod]
     public void Measure_Vertical_HeightEqualsItemCount()
     {
         var node = CreateNode(SampleData);
         var size = node.Measure(new Constraints(0, 40, 0, 30));
 
-        Assert.Equal(3, size.Height);
+        Assert.AreEqual(3, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_Vertical_WidthFitsLabels()
     {
         var node = CreateNode(SampleData);
         var size = node.Measure(Constraints.Unbounded);
 
         // "■ " (2) + longest label "Rust" (4) = 6 minimum
-        Assert.True(size.Width >= 6);
+        Assert.IsTrue(size.Width >= 6);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_Vertical_RespectsMaxHeight()
     {
         var node = CreateNode(SampleData);
         var size = node.Measure(new Constraints(0, 40, 0, 2));
 
-        Assert.True(size.Height <= 2);
+        Assert.IsTrue(size.Height <= 2);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_EmptyData_ReturnsZeroSize()
     {
         var node = CreateNode([]);
         var size = node.Measure(new Constraints(0, 40, 0, 30));
 
-        Assert.Equal(0, size.Width);
-        Assert.Equal(0, size.Height);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(0, size.Height);
     }
 
     #endregion
 
     #region Measure Tests — Horizontal
 
-    [Fact]
+    [TestMethod]
     public void Measure_Horizontal_HeightIsOne()
     {
         var node = CreateNode(SampleData, horizontal: true);
         var size = node.Measure(new Constraints(0, 100, 0, 30));
 
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_Horizontal_WidthAccommodatesAllItems()
     {
         var node = CreateNode(SampleData, horizontal: true);
@@ -94,14 +95,14 @@ public class LegendNodeTests
 
         // Each item: swatch(1) + space(1) + label. Plus spacing(2) between items.
         // "■ Go" (4) + "  " (2) + "■ Rust" (6) + "  " (2) + "■ C#" (4) = 18
-        Assert.True(size.Width >= 18);
+        Assert.IsTrue(size.Width >= 18);
     }
 
     #endregion
 
     #region Render Tests — Vertical
 
-    [Fact]
+    [TestMethod]
     public void Render_Vertical_ShowsLabels()
     {
         var node = CreateNode(SampleData);
@@ -113,31 +114,31 @@ public class LegendNodeTests
         Assert.Contains("C#", allText);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_Vertical_ShowsSwatchCharacter()
     {
         var node = CreateNode(SampleData);
         var (surface, _) = RenderNode(node, 40, 10);
 
         // First column should have swatch character ■
-        Assert.Equal("■", surface[0, 0].Character);
-        Assert.Equal("■", surface[0, 1].Character);
-        Assert.Equal("■", surface[0, 2].Character);
+        Assert.AreEqual("■", surface[0, 0].Character);
+        Assert.AreEqual("■", surface[0, 1].Character);
+        Assert.AreEqual("■", surface[0, 2].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_Vertical_SwatchHasForegroundColor()
     {
         var node = CreateNode(SampleData);
         var (surface, _) = RenderNode(node, 40, 10);
 
         // Swatch should use foreground color (not background)
-        Assert.NotNull(surface[0, 0].Foreground);
-        Assert.NotNull(surface[0, 1].Foreground);
-        Assert.NotNull(surface[0, 2].Foreground);
+        Assert.IsNotNull(surface[0, 0].Foreground);
+        Assert.IsNotNull(surface[0, 1].Foreground);
+        Assert.IsNotNull(surface[0, 2].Foreground);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_Vertical_DifferentSwatchColors()
     {
         var node = CreateNode(SampleData);
@@ -148,11 +149,11 @@ public class LegendNodeTests
         var color2 = surface[0, 2].Foreground;
 
         // All three segments should have different colors
-        Assert.NotEqual(color0, color1);
-        Assert.NotEqual(color1, color2);
+        Assert.AreNotEqual(color0, color1);
+        Assert.AreNotEqual(color1, color2);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_ShowValues_DisplaysValues()
     {
         var node = CreateNode(SampleData, showValues: true);
@@ -163,7 +164,7 @@ public class LegendNodeTests
         Assert.Contains("28", allText);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_ShowPercentages_DisplaysPercent()
     {
         var node = CreateNode(SampleData, showPercentages: true);
@@ -173,7 +174,7 @@ public class LegendNodeTests
         Assert.Contains("%", allText);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_ShowBoth_DisplaysValuesAndPercentages()
     {
         var node = CreateNode(SampleData, showValues: true, showPercentages: true);
@@ -184,7 +185,7 @@ public class LegendNodeTests
         Assert.Contains("%", allText);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_CustomFormatter_UsedInOutput()
     {
         var node = CreateNode(SampleData, showValues: true, valueFormatter: v => $"${v:F0}");
@@ -198,7 +199,7 @@ public class LegendNodeTests
 
     #region Render Tests — Horizontal
 
-    [Fact]
+    [TestMethod]
     public void Render_Horizontal_AllItemsOnOneRow()
     {
         var node = CreateNode(SampleData, horizontal: true);
@@ -210,17 +211,17 @@ public class LegendNodeTests
         Assert.Contains("C#", row);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_Horizontal_ShowsSwatches()
     {
         var node = CreateNode(SampleData, horizontal: true);
         var (surface, _) = RenderNode(node, 60, 1);
 
         // First character should be swatch
-        Assert.Equal("■", surface[0, 0].Character);
+        Assert.AreEqual("■", surface[0, 0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_Horizontal_WithPercentages()
     {
         var node = CreateNode(SampleData, showPercentages: true, horizontal: true);
@@ -234,7 +235,7 @@ public class LegendNodeTests
 
     #region Edge Cases
 
-    [Fact]
+    [TestMethod]
     public void Render_NullData_DoesNotCrash()
     {
         var node = new LegendNode<ChartItem>
@@ -252,7 +253,7 @@ public class LegendNodeTests
         // Should not throw
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_ZeroValues_Excluded()
     {
         var data = new ChartItem[]
@@ -269,7 +270,7 @@ public class LegendNodeTests
         Assert.DoesNotContain("Zero", allText);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_SingleItem_Works()
     {
         var node = CreateNode([new("Only", 100)]);
@@ -279,7 +280,7 @@ public class LegendNodeTests
         Assert.Contains("Only", allText);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_VeryNarrowWidth_DoesNotCrash()
     {
         var node = CreateNode(SampleData);

--- a/tests/Hex1b.Tests/LineFeedBandingTest.cs
+++ b/tests/Hex1b.Tests/LineFeedBandingTest.cs
@@ -1,11 +1,11 @@
 namespace Hex1b.Tests;
 
 using Hex1b.Tokens;
-using Xunit;
 
+[TestClass]
 public class LineFeedBandingTest
 {
-    [Fact]
+    [TestMethod]
     public void MapsciiPattern_CrLfCr_NoBlankLines()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -41,16 +41,16 @@ public class LineFeedBandingTest
         // Row 2: CCCCCCCCCC
         
         // Row 0 should have "AAAAAAAAAA"
-        Assert.True(snapshot.GetCell(0, 0).Character == "A", $"Expected 'A' at (0,0), got '{snapshot.GetCell(0, 0).Character}'{rowInfo}");
+        Assert.IsTrue(snapshot.GetCell(0, 0).Character == "A", $"Expected 'A' at (0,0), got '{snapshot.GetCell(0, 0).Character}'{rowInfo}");
         
         // Row 1 should have "BBBBBBBBBB" (consecutive, no banding!)
-        Assert.True(snapshot.GetCell(0, 1).Character == "B", $"Expected 'B' at (0,1), got '{snapshot.GetCell(0, 1).Character}'{rowInfo}");
+        Assert.IsTrue(snapshot.GetCell(0, 1).Character == "B", $"Expected 'B' at (0,1), got '{snapshot.GetCell(0, 1).Character}'{rowInfo}");
         
         // Row 2 should have "CCCCCCCCCC" (consecutive, no banding!)
-        Assert.True(snapshot.GetCell(0, 2).Character == "C", $"Expected 'C' at (0,2), got '{snapshot.GetCell(0, 2).Character}'{rowInfo}");
+        Assert.IsTrue(snapshot.GetCell(0, 2).Character == "C", $"Expected 'C' at (0,2), got '{snapshot.GetCell(0, 2).Character}'{rowInfo}");
     }
     
-    [Fact]
+    [TestMethod]
     public void DeferredWrap_WritingAtEndOfLine_DoesNotWrapUntilNextChar()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -60,17 +60,17 @@ public class LineFeedBandingTest
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("AAAAA"));
 
         // Cursor should be at last column (4), not wrapped to next line
-        Assert.Equal(4, terminal.CursorX);
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(4, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
         
         // Now write one more character - this should trigger the deferred wrap
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("B"));
         
         // After writing B, cursor should be at column 1 (or column 0 with pending wrap)
         // Actually B is at row 1, col 0, then cursor moves to col 1
-        Assert.Equal(1, terminal.CursorY); // Should be on row 1 now
+        Assert.AreEqual(1, terminal.CursorY); // Should be on row 1 now
         
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal("B", snapshot.GetCell(0, 1).Character); // B is on row 1
+        Assert.AreEqual("B", snapshot.GetCell(0, 1).Character); // B is on row 1
     }
 }

--- a/tests/Hex1b.Tests/LineWrappingTests.cs
+++ b/tests/Hex1b.Tests/LineWrappingTests.cs
@@ -3,117 +3,118 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class LineWrappingTests
 {
-    [Fact]
+    [TestMethod]
     public void WrapLine_ShortLine_NoWrap()
     {
         var result = TextEditorViewRenderer.WrapLine("Hello", 20);
 
-        Assert.Single(result);
-        Assert.Equal("Hello", result[0]);
+        TestSeq.Single(result);
+        Assert.AreEqual("Hello", result[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLine_LongLine_WrapsAtWordBoundary()
     {
         var result = TextEditorViewRenderer.WrapLine("Hello world this is a test", 12);
 
-        Assert.True(result.Count >= 2);
-        Assert.Equal("Hello world", result[0]);
+        Assert.IsTrue(result.Count >= 2);
+        Assert.AreEqual("Hello world", result[0]);
         Assert.StartsWith("this", result[1]);
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLine_NoSpaces_HardBreaks()
     {
         var result = TextEditorViewRenderer.WrapLine("ABCDEFGHIJKLMNO", 5);
 
-        Assert.Equal(3, result.Count);
-        Assert.Equal("ABCDE", result[0]);
-        Assert.Equal("FGHIJ", result[1]);
-        Assert.Equal("KLMNO", result[2]);
+        Assert.AreEqual(3, result.Count);
+        Assert.AreEqual("ABCDE", result[0]);
+        Assert.AreEqual("FGHIJ", result[1]);
+        Assert.AreEqual("KLMNO", result[2]);
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLine_MultipleWraps()
     {
         // 30 chars, viewport 10 => 3 segments
         var result = TextEditorViewRenderer.WrapLine("aaaa bbbb cccc dddd eeee ffff", 10);
 
-        Assert.True(result.Count >= 3);
+        Assert.IsTrue(result.Count >= 3);
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLine_ExactWidth_NoWrap()
     {
         var result = TextEditorViewRenderer.WrapLine("12345", 5);
 
-        Assert.Single(result);
-        Assert.Equal("12345", result[0]);
+        TestSeq.Single(result);
+        Assert.AreEqual("12345", result[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLine_EmptyLine_NoWrap()
     {
         var result = TextEditorViewRenderer.WrapLine("", 10);
 
-        Assert.Single(result);
-        Assert.Equal("", result[0]);
+        TestSeq.Single(result);
+        Assert.AreEqual("", result[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLine_ZeroWidth_ReturnsSingleSegment()
     {
         var result = TextEditorViewRenderer.WrapLine("Hello", 0);
 
-        Assert.Single(result);
-        Assert.Equal("Hello", result[0]);
+        TestSeq.Single(result);
+        Assert.AreEqual("Hello", result[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void EditorWidget_WordWrap_SetsProperty()
     {
         var doc = new Hex1bDocument("test");
         var state = new EditorState(doc);
         var widget = new EditorWidget(state).WordWrap();
-        Assert.True(widget.WordWrapValue);
+        Assert.IsTrue(widget.WordWrapValue);
     }
 
-    [Fact]
+    [TestMethod]
     public void EditorWidget_WordWrap_DefaultFalse()
     {
         var doc = new Hex1bDocument("test");
         var state = new EditorState(doc);
         var widget = new EditorWidget(state);
-        Assert.False(widget.WordWrapValue);
+        Assert.IsFalse(widget.WordWrapValue);
     }
 
-    [Fact]
+    [TestMethod]
     public void EditorWidget_WordWrap_CanDisable()
     {
         var doc = new Hex1bDocument("test");
         var state = new EditorState(doc);
         var widget = new EditorWidget(state).WordWrap(true).WordWrap(false);
-        Assert.False(widget.WordWrapValue);
+        Assert.IsFalse(widget.WordWrapValue);
     }
 
-    [Fact]
+    [TestMethod]
     public void EditorNode_WordWrap_DefaultFalse()
     {
         var node = new EditorNode();
-        Assert.False(node.WordWrap);
+        Assert.IsFalse(node.WordWrap);
     }
 
-    [Fact]
+    [TestMethod]
     public void EditorNode_WordWrap_CanBeSet()
     {
         var node = new EditorNode();
         node.WordWrap = true;
-        Assert.True(node.WordWrap);
+        Assert.IsTrue(node.WordWrap);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_WordWrap_SetsNodeProperty()
     {
         var doc = new Hex1bDocument("test");
@@ -123,10 +124,10 @@ public class LineWrappingTests
         var context = ReconcileContext.CreateRoot();
         var node = (EditorNode)await widget.ReconcileAsync(null, context);
 
-        Assert.True(node.WordWrap);
+        Assert.IsTrue(node.WordWrap);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_NoWordWrap_NodePropertyFalse()
     {
         var doc = new Hex1bDocument("test");
@@ -136,6 +137,6 @@ public class LineWrappingTests
         var context = ReconcileContext.CreateRoot();
         var node = (EditorNode)await widget.ReconcileAsync(null, context);
 
-        Assert.False(node.WordWrap);
+        Assert.IsFalse(node.WordWrap);
     }
 }

--- a/tests/Hex1b.Tests/ListNodeTests.cs
+++ b/tests/Hex1b.Tests/ListNodeTests.cs
@@ -10,6 +10,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Comprehensive tests for ListNode rendering and input handling.
 /// </summary>
+[TestClass]
 public class ListNodeTests
 {
     private static Hex1bRenderContext CreateContext(IHex1bAppTerminalWorkloadAdapter workload, Hex1bTheme? theme = null)
@@ -24,7 +25,7 @@ public class ListNodeTests
 
     #region Measurement Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_ReturnsCorrectSize()
     {
         var node = new ListNode 
@@ -35,42 +36,42 @@ public class ListNodeTests
         var size = node.Measure(Constraints.Unbounded);
         
         // Width = max item length + 2 (indicator), Height = item count
-        Assert.Equal(13, size.Width); // "Longer Item" = 11 + 2
-        Assert.Equal(3, size.Height);
+        Assert.AreEqual(13, size.Width); // "Longer Item" = 11 + 2
+        Assert.AreEqual(3, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_EmptyList_HasMinHeight()
     {
         var node = new ListNode { Items = [] };
         
         var size = node.Measure(Constraints.Unbounded);
         
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_SingleItem_IncludesIndicator()
     {
         var node = new ListNode { Items = CreateItems("Hello") };
         
         var size = node.Measure(Constraints.Unbounded);
         
-        Assert.Equal(7, size.Width); // "Hello" = 5 + 2 for indicator
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(7, size.Width); // "Hello" = 5 + 2 for indicator
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_RespectsMaxWidth()
     {
         var node = new ListNode { Items = CreateItems("Very Long Item Name") };
         
         var size = node.Measure(new Constraints(0, 10, 0, 100));
         
-        Assert.Equal(10, size.Width);
+        Assert.AreEqual(10, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_RespectsMaxHeight()
     {
         var node = new ListNode 
@@ -80,14 +81,14 @@ public class ListNodeTests
         
         var size = node.Measure(new Constraints(0, 100, 0, 3));
         
-        Assert.Equal(3, size.Height);
+        Assert.AreEqual(3, size.Height);
     }
 
     #endregion
 
     #region Arrange Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_SetsBounds()
     {
         var node = new ListNode { Items = CreateItems("Test") };
@@ -95,10 +96,10 @@ public class ListNodeTests
         
         node.Arrange(bounds);
         
-        Assert.Equal(bounds, node.Bounds);
+        Assert.AreEqual(bounds, node.Bounds);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_WithOffset_SetsBoundsWithOffset()
     {
         var node = new ListNode { Items = CreateItems("Test") };
@@ -106,15 +107,15 @@ public class ListNodeTests
         
         node.Arrange(bounds);
         
-        Assert.Equal(5, node.Bounds.X);
-        Assert.Equal(3, node.Bounds.Y);
+        Assert.AreEqual(5, node.Bounds.X);
+        Assert.AreEqual(3, node.Bounds.Y);
     }
 
     #endregion
 
     #region Rendering - Basic Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Render_ShowsAllItems()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -141,12 +142,12 @@ public class ListNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.True(snapshot.ContainsText("Item 1"));
-        Assert.True(snapshot.ContainsText("Item 2"));
-        Assert.True(snapshot.ContainsText("Item 3"));
+        Assert.IsTrue(snapshot.ContainsText("Item 1"));
+        Assert.IsTrue(snapshot.ContainsText("Item 2"));
+        Assert.IsTrue(snapshot.ContainsText("Item 3"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_EmptyList_RendersNothing()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -163,10 +164,10 @@ public class ListNodeTests
             .ApplyAsync(terminal);
         
         // Should not crash and output should be minimal
-        Assert.False(terminal.CreateSnapshot().ContainsText("Item"));
+        Assert.IsFalse(terminal.CreateSnapshot().ContainsText("Item"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_SingleItem_ShowsItem()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -185,14 +186,14 @@ public class ListNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.True(snapshot.ContainsText("Only Item"));
+        Assert.IsTrue(snapshot.ContainsText("Only Item"));
     }
 
     #endregion
 
     #region Rendering - Selection Indicator Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Render_SelectedItem_HasSelectedIndicator()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -211,10 +212,10 @@ public class ListNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.True(snapshot.ContainsText("> Item 1"));
+        Assert.IsTrue(snapshot.ContainsText("> Item 1"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_UnselectedItems_HaveUnselectedIndicator()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -233,10 +234,10 @@ public class ListNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.True(snapshot.ContainsText("  Item 2"));
+        Assert.IsTrue(snapshot.ContainsText("  Item 2"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_MiddleItemSelected_ShowsCorrectIndicators()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -260,12 +261,12 @@ public class ListNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.True(snapshot.ContainsText("  First"));
-        Assert.True(snapshot.ContainsText("> Second"));
-        Assert.True(snapshot.ContainsText("  Third"));
+        Assert.IsTrue(snapshot.ContainsText("  First"));
+        Assert.IsTrue(snapshot.ContainsText("> Second"));
+        Assert.IsTrue(snapshot.ContainsText("  Third"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_LastItemSelected_ShowsCorrectIndicators()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -289,16 +290,16 @@ public class ListNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.True(snapshot.ContainsText("  First"));
-        Assert.True(snapshot.ContainsText("  Second"));
-        Assert.True(snapshot.ContainsText("> Third"));
+        Assert.IsTrue(snapshot.ContainsText("  First"));
+        Assert.IsTrue(snapshot.ContainsText("  Second"));
+        Assert.IsTrue(snapshot.ContainsText("> Third"));
     }
 
     #endregion
 
     #region Rendering - Focus State Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Render_FocusedAndSelected_HasColorCodes()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -318,10 +319,10 @@ public class ListNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         // The output should contain colors for the focused+selected item
-        Assert.True(snapshot.HasForegroundColor() || snapshot.HasBackgroundColor() || snapshot.HasAttribute(CellAttributes.Reverse));
+        Assert.IsTrue(snapshot.HasForegroundColor() || snapshot.HasBackgroundColor() || snapshot.HasAttribute(CellAttributes.Reverse));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_NotFocused_SelectedItemHasIndicatorOnly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -340,14 +341,14 @@ public class ListNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.True(snapshot.ContainsText("> Item 1"));
+        Assert.IsTrue(snapshot.ContainsText("> Item 1"));
     }
 
     #endregion
 
     #region Rendering - Position Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithOffset_RendersAtCorrectPosition()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -366,10 +367,10 @@ public class ListNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.True(snapshot.ContainsText("Test Item"));
+        Assert.IsTrue(snapshot.ContainsText("Test Item"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_MultipleItems_RendersAllItems()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -396,16 +397,16 @@ public class ListNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.True(snapshot.ContainsText("Item A"));
-        Assert.True(snapshot.ContainsText("Item B"));
-        Assert.True(snapshot.ContainsText("Item C"));
+        Assert.IsTrue(snapshot.ContainsText("Item A"));
+        Assert.IsTrue(snapshot.ContainsText("Item B"));
+        Assert.IsTrue(snapshot.ContainsText("Item C"));
     }
 
     #endregion
 
     #region Rendering - Theming Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithCustomTheme_UsesCustomColors()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -428,12 +429,12 @@ public class ListNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         // Yellow foreground
-        Assert.True(snapshot.HasForegroundColor(Hex1bColor.FromRgb(255, 255, 0)));
+        Assert.IsTrue(snapshot.HasForegroundColor(Hex1bColor.FromRgb(255, 255, 0)));
         // Red background
-        Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 0, 0)));
+        Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 0, 0)));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithCustomIndicator_UsesCustomIndicator()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -453,10 +454,10 @@ public class ListNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.True(snapshot.ContainsText("► Item 1"));
+        Assert.IsTrue(snapshot.ContainsText("► Item 1"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithCustomUnselectedIndicator_UsesCustomIndicator()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -476,10 +477,10 @@ public class ListNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.True(snapshot.ContainsText("- Item 2"));
+        Assert.IsTrue(snapshot.ContainsText("- Item 2"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_RetroTheme_UsesTriangleIndicator()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -498,14 +499,14 @@ public class ListNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.True(snapshot.ContainsText("► Item 1"));
+        Assert.IsTrue(snapshot.ContainsText("► Item 1"));
     }
 
     #endregion
 
     #region Rendering - Narrow Terminal Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Render_NarrowTerminal_TruncatesItems()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -528,10 +529,10 @@ public class ListNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.True(snapshot.ContainsText("Very"));
+        Assert.IsTrue(snapshot.ContainsText("Very"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_MinimalWidth_StillRendersIndicator()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -550,56 +551,56 @@ public class ListNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.True(snapshot.ContainsText(">"));
+        Assert.IsTrue(snapshot.ContainsText(">"));
     }
 
     #endregion
 
     #region Input Handling - Navigation Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_DownArrow_MovesSelection()
     {
         var node = new ListNode { Items = CreateItems("Item 1", "Item 2", "Item 3"), SelectedIndex = 0, IsFocused = true };
         
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.DownArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
         
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(1, node.SelectedIndex);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(1, node.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_UpArrow_MovesSelection()
     {
         var node = new ListNode { Items = CreateItems("Item 1", "Item 2", "Item 3"), SelectedIndex = 2, IsFocused = true };
         
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.UpArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
         
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(1, node.SelectedIndex);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(1, node.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_DownArrow_WrapsAround()
     {
         var node = new ListNode { Items = CreateItems("Item 1", "Item 2"), SelectedIndex = 1, IsFocused = true };
         
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.DownArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
         
-        Assert.Equal(0, node.SelectedIndex);
+        Assert.AreEqual(0, node.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_UpArrow_WrapsAround()
     {
         var node = new ListNode { Items = CreateItems("Item 1", "Item 2"), SelectedIndex = 0, IsFocused = true };
         
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.UpArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
         
-        Assert.Equal(1, node.SelectedIndex);
+        Assert.AreEqual(1, node.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_MultipleDownArrows_NavigatesCorrectly()
     {
         var node = new ListNode { Items = CreateItems("A", "B", "C", "D"), SelectedIndex = 0, IsFocused = true };
@@ -608,10 +609,10 @@ public class ListNodeTests
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.DownArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.DownArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
         
-        Assert.Equal(3, node.SelectedIndex);
+        Assert.AreEqual(3, node.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_MultipleUpArrows_NavigatesCorrectly()
     {
         var node = new ListNode { Items = CreateItems("A", "B", "C", "D"), SelectedIndex = 3, IsFocused = true };
@@ -619,14 +620,14 @@ public class ListNodeTests
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.UpArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.UpArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
         
-        Assert.Equal(1, node.SelectedIndex);
+        Assert.AreEqual(1, node.SelectedIndex);
     }
 
     #endregion
 
     #region Input Handling - Activation Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Enter_InvokesOnItemActivated()
     {
         var node = new ListNode { Items = CreateItems("Item 1", "Item 2"), SelectedIndex = 1, IsFocused = true };
@@ -635,12 +636,12 @@ public class ListNodeTests
         
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Enter, '\r', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
         
-        Assert.Equal(InputResult.Handled, result);
-        Assert.NotNull(activatedItem);
-        Assert.Equal("Item 2", activatedItem);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsNotNull(activatedItem);
+        Assert.AreEqual("Item 2", activatedItem);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Space_InvokesOnItemActivated()
     {
         var node = new ListNode { Items = CreateItems("Item 1", "Item 2"), SelectedIndex = 0, IsFocused = true };
@@ -649,12 +650,12 @@ public class ListNodeTests
         
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Spacebar, ' ', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
         
-        Assert.Equal(InputResult.Handled, result);
-        Assert.NotNull(activatedItem);
-        Assert.Equal("Item 1", activatedItem);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsNotNull(activatedItem);
+        Assert.AreEqual("Item 1", activatedItem);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Enter_WithoutCallback_StillReturnsHandled()
     {
         var node = new ListNode { Items = CreateItems("Item 1"), SelectedIndex = 0, IsFocused = true };
@@ -662,10 +663,10 @@ public class ListNodeTests
         
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Enter, '\r', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
         
-        Assert.Equal(InputResult.Handled, result);
+        Assert.AreEqual(InputResult.Handled, result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Enter_OnEmptyList_ReturnsHandled()
     {
         var node = new ListNode { Items = [], IsFocused = true };
@@ -674,15 +675,15 @@ public class ListNodeTests
         
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Enter, '\r', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
         
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Null(activatedItem); // No item to activate
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsNull(activatedItem); // No item to activate
     }
 
     #endregion
 
     #region Input Handling - Selection Changed Callback Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_DownArrow_InvokesOnSelectionChanged()
     {
         var node = new ListNode { Items = CreateItems("Item 1", "Item 2"), SelectedIndex = 0, IsFocused = true };
@@ -691,11 +692,11 @@ public class ListNodeTests
         
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.DownArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
         
-        Assert.NotNull(selectedItem);
-        Assert.Equal("Item 2", selectedItem);
+        Assert.IsNotNull(selectedItem);
+        Assert.AreEqual("Item 2", selectedItem);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_UpArrow_InvokesOnSelectionChanged()
     {
         var node = new ListNode { Items = CreateItems("Item 1", "Item 2"), SelectedIndex = 1, IsFocused = true };
@@ -704,15 +705,15 @@ public class ListNodeTests
         
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.UpArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
         
-        Assert.NotNull(selectedItem);
-        Assert.Equal("Item 1", selectedItem);
+        Assert.IsNotNull(selectedItem);
+        Assert.AreEqual("Item 1", selectedItem);
     }
 
     #endregion
 
     #region Input Handling - Edge Cases
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_WhenNotFocused_BindingsStillExecute()
     {
         // Note: With the new input binding architecture, bindings execute at the node level
@@ -723,68 +724,68 @@ public class ListNodeTests
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.DownArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
         
         // Bindings execute regardless of focus state when using RouteInputToNode
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(1, node.SelectedIndex);  // Selection changed
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(1, node.SelectedIndex);  // Selection changed
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_OtherKey_DoesNotHandle()
     {
         var node = new ListNode { Items = CreateItems("Item 1", "Item 2"), IsFocused = true };
         
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.A, 'a', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
         
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Tab_DoesNotHandle()
     {
         var node = new ListNode { Items = CreateItems("Item 1", "Item 2"), IsFocused = true };
         
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Tab, '\t', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
         
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Escape_DoesNotHandle()
     {
         var node = new ListNode { Items = CreateItems("Item 1", "Item 2"), IsFocused = true };
         
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Escape, '\x1b', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
         
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
     }
 
     #endregion
 
     #region Focusability Tests
 
-    [Fact]
+    [TestMethod]
     public async Task IsFocusable_ReturnsTrue()
     {
         var node = new ListNode();
         
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_ReturnsSelf()
     {
         var node = new ListNode { Items = CreateItems("Test") };
         
         var focusables = node.GetFocusableNodes().ToList();
         
-        Assert.Single(focusables);
-        Assert.Same(node, focusables[0]);
+        TestSeq.Single(focusables);
+        Assert.AreSame(node, focusables[0]);
     }
 
     #endregion
 
     #region Integration Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_ListInApp_RendersCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -810,12 +811,12 @@ public class ListNodeTests
         await runTask;
         
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("Option A"));
-        Assert.True(snapshot.ContainsText("Option B"));
-        Assert.True(snapshot.ContainsText("Option C"));
+        Assert.IsTrue(snapshot.ContainsText("Option A"));
+        Assert.IsTrue(snapshot.ContainsText("Option B"));
+        Assert.IsTrue(snapshot.ContainsText("Option C"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_ListWithSelection_RendersIndicator()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -843,12 +844,12 @@ public class ListNodeTests
         await runTask;
         
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("> Second"));
-        Assert.True(snapshot.ContainsText("  First"));
-        Assert.True(snapshot.ContainsText("  Third"));
+        Assert.IsTrue(snapshot.ContainsText("> Second"));
+        Assert.IsTrue(snapshot.ContainsText("  First"));
+        Assert.IsTrue(snapshot.ContainsText("  Third"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_ListInBorder_RendersCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -876,12 +877,12 @@ public class ListNodeTests
         await runTask;
         
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("Item 1"));
-        Assert.True(snapshot.ContainsText("Item 2"));
-        Assert.True(snapshot.ContainsText("┌"));
+        Assert.IsTrue(snapshot.ContainsText("Item 1"));
+        Assert.IsTrue(snapshot.ContainsText("Item 2"));
+        Assert.IsTrue(snapshot.ContainsText("┌"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_ListReceivesFocus_HandlesInput()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -909,10 +910,10 @@ public class ListNodeTests
         await runTask;
         
         // After down arrow, second item should be selected
-        Assert.True(snapshot.ContainsText("> Item 2"));
+        Assert.IsTrue(snapshot.ContainsText("> Item 2"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_ListActivation_InvokesCallback()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -939,10 +940,10 @@ public class ListNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
         
-        Assert.Equal("Action 1", activatedAction);
+        Assert.AreEqual("Action 1", activatedAction);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_ListInVStack_RendersWithOtherElements()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -973,11 +974,11 @@ public class ListNodeTests
         await runTask;
         
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("Select an option:"));
-        Assert.True(snapshot.ContainsText("Menu Item"));
+        Assert.IsTrue(snapshot.ContainsText("Select an option:"));
+        Assert.IsTrue(snapshot.ContainsText("Menu Item"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_ListWithTheme_AppliesTheme()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1003,10 +1004,10 @@ public class ListNodeTests
         await runTask;
         
         // HighContrast theme uses "► " indicator - use captured snapshot
-        Assert.True(snapshot.ContainsText("► Themed Item"));
+        Assert.IsTrue(snapshot.ContainsText("► Themed Item"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_ListNavigationMultipleSteps_UpdatesSelection()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1035,10 +1036,10 @@ public class ListNodeTests
         await runTask;
         
         // Third item should be selected - use captured snapshot
-        Assert.True(snapshot.ContainsText("> Third"));
+        Assert.IsTrue(snapshot.ContainsText("> Third"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_ListInsideBorderWithOtherWidgets_RendersProperly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1070,18 +1071,18 @@ public class ListNodeTests
         await runTask;
         
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("Welcome"));
-        Assert.True(snapshot.ContainsText("Options"));
-        Assert.True(snapshot.ContainsText("Option A"));
-        Assert.True(snapshot.ContainsText("Option B"));
-        Assert.True(snapshot.ContainsText("OK"));
+        Assert.IsTrue(snapshot.ContainsText("Welcome"));
+        Assert.IsTrue(snapshot.ContainsText("Options"));
+        Assert.IsTrue(snapshot.ContainsText("Option A"));
+        Assert.IsTrue(snapshot.ContainsText("Option B"));
+        Assert.IsTrue(snapshot.ContainsText("OK"));
     }
 
     #endregion
 
     #region Mouse Click Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleMouseClick_SelectsClickedItem()
     {
         // Note: Mouse click is synchronous so it cannot fire async events.
@@ -1097,11 +1098,11 @@ public class ListNodeTests
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 5, 1, Hex1bModifiers.None);
         var result = node.HandleMouseClick(5, 1, mouseEvent);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(1, node.SelectedIndex);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(1, node.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleMouseClick_OutOfBounds_ReturnsNotHandled()
     {
         var node = new ListNode
@@ -1115,11 +1116,11 @@ public class ListNodeTests
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 5, 5, Hex1bModifiers.None);
         var result = node.HandleMouseClick(5, 5, mouseEvent);
 
-        Assert.Equal(InputResult.NotHandled, result);
-        Assert.Equal(0, node.SelectedIndex); // Unchanged
+        Assert.AreEqual(InputResult.NotHandled, result);
+        Assert.AreEqual(0, node.SelectedIndex); // Unchanged
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleMouseClick_NegativeY_ReturnsNotHandled()
     {
         var node = new ListNode
@@ -1130,14 +1131,14 @@ public class ListNodeTests
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 5, -1, Hex1bModifiers.None);
         var result = node.HandleMouseClick(5, -1, mouseEvent);
 
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
     }
 
     #endregion
 
     #region Mouse Wheel Scrolling Tests
 
-    [Fact]
+    [TestMethod]
     public async Task MouseWheelDown_MovesSelectionDown()
     {
         var node = new ListNode { Items = CreateItems("Item 1", "Item 2", "Item 3"), SelectedIndex = 0, IsFocused = true };
@@ -1147,15 +1148,15 @@ public class ListNodeTests
         // Create a mouse wheel down event via the binding system
         var builder = node.BuildBindings();
         var scrollDownBinding = builder.MouseBindings.FirstOrDefault(b => b.Button == MouseButton.ScrollDown);
-        Assert.NotNull(scrollDownBinding);
+        Assert.IsNotNull(scrollDownBinding);
         
         var ctx = new InputBindingActionContext(new FocusRing(), null, default);
         await scrollDownBinding!.ExecuteAsync(ctx);
         
-        Assert.Equal(1, node.SelectedIndex);
+        Assert.AreEqual(1, node.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MouseWheelUp_MovesSelectionUp()
     {
         var node = new ListNode { Items = CreateItems("Item 1", "Item 2", "Item 3"), SelectedIndex = 2, IsFocused = true };
@@ -1165,15 +1166,15 @@ public class ListNodeTests
         // Create a mouse wheel up event via the binding system
         var builder = node.BuildBindings();
         var scrollUpBinding = builder.MouseBindings.FirstOrDefault(b => b.Button == MouseButton.ScrollUp);
-        Assert.NotNull(scrollUpBinding);
+        Assert.IsNotNull(scrollUpBinding);
         
         var ctx = new InputBindingActionContext(new FocusRing(), null, default);
         await scrollUpBinding!.ExecuteAsync(ctx);
         
-        Assert.Equal(1, node.SelectedIndex);
+        Assert.AreEqual(1, node.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MouseWheelDown_WrapsAroundToFirstItem()
     {
         var node = new ListNode { Items = CreateItems("Item 1", "Item 2"), SelectedIndex = 1, IsFocused = true };
@@ -1182,16 +1183,16 @@ public class ListNodeTests
         
         var builder = node.BuildBindings();
         var scrollDownBinding = builder.MouseBindings.FirstOrDefault(b => b.Button == MouseButton.ScrollDown);
-        Assert.NotNull(scrollDownBinding);
+        Assert.IsNotNull(scrollDownBinding);
         
         var ctx = new InputBindingActionContext(new FocusRing(), null, default);
         await scrollDownBinding!.ExecuteAsync(ctx);
         
         // Should wrap around to first item
-        Assert.Equal(0, node.SelectedIndex);
+        Assert.AreEqual(0, node.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MouseWheelUp_WrapsAroundToLastItem()
     {
         var node = new ListNode { Items = CreateItems("Item 1", "Item 2"), SelectedIndex = 0, IsFocused = true };
@@ -1200,16 +1201,16 @@ public class ListNodeTests
         
         var builder = node.BuildBindings();
         var scrollUpBinding = builder.MouseBindings.FirstOrDefault(b => b.Button == MouseButton.ScrollUp);
-        Assert.NotNull(scrollUpBinding);
+        Assert.IsNotNull(scrollUpBinding);
         
         var ctx = new InputBindingActionContext(new FocusRing(), null, default);
         await scrollUpBinding!.ExecuteAsync(ctx);
         
         // Should wrap around to last item
-        Assert.Equal(1, node.SelectedIndex);
+        Assert.AreEqual(1, node.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MouseWheel_InvokesSelectionChangedEvent()
     {
         var node = new ListNode { Items = CreateItems("Item 1", "Item 2"), SelectedIndex = 0, IsFocused = true };
@@ -1225,15 +1226,15 @@ public class ListNodeTests
         var ctx = new InputBindingActionContext(new FocusRing(), null, default);
         await scrollDownBinding!.ExecuteAsync(ctx);
         
-        Assert.NotNull(selectedItem);
-        Assert.Equal("Item 2", selectedItem);
+        Assert.IsNotNull(selectedItem);
+        Assert.AreEqual("Item 2", selectedItem);
     }
 
     #endregion
 
     #region Viewport Scrolling Tests (Height-Constrained Container)
 
-    [Fact]
+    [TestMethod]
     public async Task ConstrainedList_HasCorrectViewportHeight()
     {
         var node = new ListNode 
@@ -1245,12 +1246,12 @@ public class ListNodeTests
         node.Measure(new Constraints(0, 100, 0, 3));
         node.Arrange(new Rect(0, 0, 20, 3));
         
-        Assert.Equal(3, node.ViewportHeight);
-        Assert.True(node.IsScrollable);
-        Assert.Equal(2, node.MaxScrollOffset); // 5 items - 3 viewport = 2
+        Assert.AreEqual(3, node.ViewportHeight);
+        Assert.IsTrue(node.IsScrollable);
+        Assert.AreEqual(2, node.MaxScrollOffset); // 5 items - 3 viewport = 2
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ConstrainedList_InitialScrollOffsetIsZero()
     {
         var node = new ListNode 
@@ -1261,10 +1262,10 @@ public class ListNodeTests
         node.Measure(new Constraints(0, 100, 0, 3));
         node.Arrange(new Rect(0, 0, 20, 3));
         
-        Assert.Equal(0, node.ScrollOffset);
+        Assert.AreEqual(0, node.ScrollOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ConstrainedList_NavigatingDown_ScrollsToRevealItem()
     {
         var node = new ListNode 
@@ -1277,17 +1278,17 @@ public class ListNodeTests
         node.Arrange(new Rect(0, 0, 20, 3));
         
         // Initially scroll offset is 0, showing items 0, 1, 2
-        Assert.Equal(0, node.ScrollOffset);
+        Assert.AreEqual(0, node.ScrollOffset);
         
         // Navigate down to item 3 (index 3)
         node.MoveDown();
         
         // Scroll offset should adjust to show item 3
-        Assert.Equal(3, node.SelectedIndex);
-        Assert.Equal(1, node.ScrollOffset); // Now showing items 1, 2, 3
+        Assert.AreEqual(3, node.SelectedIndex);
+        Assert.AreEqual(1, node.ScrollOffset); // Now showing items 1, 2, 3
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ConstrainedList_NavigatingUp_ScrollsToRevealItem()
     {
         var node = new ListNode 
@@ -1301,7 +1302,7 @@ public class ListNodeTests
         
         // The scroll offset should be adjusted to show selected item
         // With selection at 3 and viewport of 3, offset should be 1
-        Assert.Equal(1, node.ScrollOffset);
+        Assert.AreEqual(1, node.ScrollOffset);
         
         // Navigate up to first visible item
         node.MoveUp(); // Now at index 2
@@ -1309,11 +1310,11 @@ public class ListNodeTests
         node.MoveUp(); // Now at index 0
         
         // Scroll should adjust to show item 0
-        Assert.Equal(0, node.SelectedIndex);
-        Assert.Equal(0, node.ScrollOffset);
+        Assert.AreEqual(0, node.SelectedIndex);
+        Assert.AreEqual(0, node.ScrollOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ConstrainedList_NavigatingToEnd_ScrollsMaximally()
     {
         var node = new ListNode 
@@ -1329,10 +1330,10 @@ public class ListNodeTests
         node.SelectedIndex = 4;
         
         // Scroll offset should be at max (showing items 2, 3, 4)
-        Assert.Equal(2, node.ScrollOffset);
+        Assert.AreEqual(2, node.ScrollOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ConstrainedList_RendersOnlyVisibleItems()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1366,16 +1367,16 @@ public class ListNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         // Should show first 3 items
-        Assert.True(snapshot.ContainsText("Item 1"));
-        Assert.True(snapshot.ContainsText("Item 2"));
-        Assert.True(snapshot.ContainsText("Item 3"));
+        Assert.IsTrue(snapshot.ContainsText("Item 1"));
+        Assert.IsTrue(snapshot.ContainsText("Item 2"));
+        Assert.IsTrue(snapshot.ContainsText("Item 3"));
         
         // Should NOT show items 4 and 5 (they're outside viewport)
-        Assert.False(snapshot.ContainsText("Item 4"));
-        Assert.False(snapshot.ContainsText("Item 5"));
+        Assert.IsFalse(snapshot.ContainsText("Item 4"));
+        Assert.IsFalse(snapshot.ContainsText("Item 5"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ConstrainedList_AfterScrolling_RendersCorrectItems()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1409,16 +1410,16 @@ public class ListNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         // Should show items 3, 4, 5 (scroll offset = 2)
-        Assert.True(snapshot.ContainsText("Item 3"));
-        Assert.True(snapshot.ContainsText("Item 4"));
-        Assert.True(snapshot.ContainsText("Item 5"));
+        Assert.IsTrue(snapshot.ContainsText("Item 3"));
+        Assert.IsTrue(snapshot.ContainsText("Item 4"));
+        Assert.IsTrue(snapshot.ContainsText("Item 5"));
         
         // Should NOT show items 1 and 2
-        Assert.False(snapshot.ContainsText("Item 1"));
-        Assert.False(snapshot.ContainsText("Item 2"));
+        Assert.IsFalse(snapshot.ContainsText("Item 1"));
+        Assert.IsFalse(snapshot.ContainsText("Item 2"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ConstrainedList_MouseClickOnVisibleItem_SelectsCorrectItem()
     {
         var node = new ListNode 
@@ -1431,18 +1432,18 @@ public class ListNodeTests
         node.Arrange(new Rect(0, 0, 20, 3));
         
         // Verify scroll offset
-        Assert.Equal(1, node.ScrollOffset);
+        Assert.AreEqual(1, node.ScrollOffset);
         
         // Click on the third visible row (local Y = 2)
         // With scroll offset 1, this should select item at index 3 (1 + 2)
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 5, 2, Hex1bModifiers.None);
         var result = node.HandleMouseClick(5, 2, mouseEvent);
         
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(3, node.SelectedIndex);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(3, node.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ConstrainedList_WrapAroundNavigation_ScrollsCorrectly()
     {
         var node = new ListNode 
@@ -1457,11 +1458,11 @@ public class ListNodeTests
         // Navigate down from last item (should wrap to first)
         node.MoveDown();
         
-        Assert.Equal(0, node.SelectedIndex);
-        Assert.Equal(0, node.ScrollOffset); // Should scroll to show first item
+        Assert.AreEqual(0, node.SelectedIndex);
+        Assert.AreEqual(0, node.ScrollOffset); // Should scroll to show first item
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_ConstrainedListWithKeyboardNavigation_RevealsItems()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1491,11 +1492,11 @@ public class ListNodeTests
         await runTask;
         
         // Use the captured snapshot to verify - Date should be visible and selected
-        Assert.True(snapshot.ContainsText("Date"));
-        Assert.True(snapshot.ContainsText("> Date")); // Should be selected
+        Assert.IsTrue(snapshot.ContainsText("Date"));
+        Assert.IsTrue(snapshot.ContainsText("> Date")); // Should be selected
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_ConstrainedListWithMouseWheel_NavigatesCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1526,10 +1527,10 @@ public class ListNodeTests
         await runTask;
         
         // Use the captured snapshot - Date should be visible after scrolling
-        Assert.True(snapshot.ContainsText("Date"));
+        Assert.IsTrue(snapshot.ContainsText("Date"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task UnconstrainedList_IsNotScrollable()
     {
         var node = new ListNode 
@@ -1541,11 +1542,11 @@ public class ListNodeTests
         node.Measure(Constraints.Unbounded);
         node.Arrange(new Rect(0, 0, 20, 10)); // Viewport larger than items
         
-        Assert.False(node.IsScrollable);
-        Assert.Equal(0, node.MaxScrollOffset);
+        Assert.IsFalse(node.IsScrollable);
+        Assert.AreEqual(0, node.MaxScrollOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ConstrainedList_ScrollOffsetClampsOnItemsChange()
     {
         var node = new ListNode 
@@ -1558,17 +1559,17 @@ public class ListNodeTests
         node.Arrange(new Rect(0, 0, 20, 3));
         
         // Scroll offset should be 2 to show last item
-        Assert.Equal(2, node.ScrollOffset);
+        Assert.AreEqual(2, node.ScrollOffset);
         
         // Now reduce items - scroll offset should clamp
         node.Items = CreateItems("Item 1", "Item 2");
         node.Arrange(new Rect(0, 0, 20, 3));
         
         // With only 2 items and viewport of 3, max offset is 0
-        Assert.Equal(0, node.ScrollOffset);
+        Assert.AreEqual(0, node.ScrollOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_LongList_KeyboardNavigationScrollsCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1602,15 +1603,15 @@ public class ListNodeTests
         await runTask;
         
         // Item 15 should be selected and visible
-        Assert.True(snapshot.ContainsText("> Item 15"));
+        Assert.IsTrue(snapshot.ContainsText("> Item 15"));
         // Items around it should also be visible
-        Assert.True(snapshot.ContainsText("Item 14") || snapshot.ContainsText("Item 13"));
+        Assert.IsTrue(snapshot.ContainsText("Item 14") || snapshot.ContainsText("Item 13"));
         // Early items should NOT be visible (scrolled out)
-        Assert.False(snapshot.ContainsText("Item 01"));
-        Assert.False(snapshot.ContainsText("Item 02"));
+        Assert.IsFalse(snapshot.ContainsText("Item 01"));
+        Assert.IsFalse(snapshot.ContainsText("Item 02"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_LongList_MouseWheelScrollsThroughEntireList()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1643,12 +1644,12 @@ public class ListNodeTests
         await runTask;
         
         // Item 20 should be selected and visible
-        Assert.True(snapshot.ContainsText("> Item 20"));
+        Assert.IsTrue(snapshot.ContainsText("> Item 20"));
         // Early items should NOT be visible
-        Assert.False(snapshot.ContainsText("Item 01"));
+        Assert.IsFalse(snapshot.ContainsText("Item 01"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_MouseClickAfterScrolling_SelectsCorrectItem()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1686,7 +1687,7 @@ public class ListNodeTests
         // Selection verified by WaitUntil above - "> Item" was confirmed before Ctrl+C
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LongList_RendersOnlyVisibleItems()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1708,7 +1709,7 @@ public class ListNodeTests
         
         // Verify scroll offset is set to show selected item
         // With viewport of 10 and selection at 25, scroll should be 16 (25 - 10 + 1)
-        Assert.Equal(16, node.ScrollOffset);
+        Assert.AreEqual(16, node.ScrollOffset);
         
         node.Render(context);
         
@@ -1725,14 +1726,14 @@ public class ListNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         // Item 25 should be visible and selected
-        Assert.True(snapshot.ContainsText("> Item 25"));
+        Assert.IsTrue(snapshot.ContainsText("> Item 25"));
         
         // Items far outside the viewport should NOT be visible
-        Assert.False(snapshot.ContainsText("Item 00"));
-        Assert.False(snapshot.ContainsText("Item 49"));
+        Assert.IsFalse(snapshot.ContainsText("Item 00"));
+        Assert.IsFalse(snapshot.ContainsText("Item 49"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LongList_WrapAroundFromEnd_ScrollsToStart()
     {
         // Create a list of 50 items (0-indexed: items[0]="Item 00", items[49]="Item 49")
@@ -1748,20 +1749,20 @@ public class ListNodeTests
         node.Arrange(new Rect(0, 0, 40, 10));
         
         // Should be scrolled to show last item
-        Assert.Equal(40, node.ScrollOffset); // 50 items - 10 viewport = 40
+        Assert.AreEqual(40, node.ScrollOffset); // 50 items - 10 viewport = 40
         
         // Navigate down (should wrap to first item)
         node.MoveDown();
         
-        Assert.Equal(0, node.SelectedIndex);
-        Assert.Equal(0, node.ScrollOffset); // Should scroll back to start
+        Assert.AreEqual(0, node.SelectedIndex);
+        Assert.AreEqual(0, node.ScrollOffset); // Should scroll back to start
     }
 
     #endregion
 
     #region Splitter Resize Tests (List with dynamic container height)
 
-    [Fact]
+    [TestMethod]
     public async Task ListInVerticalSplitter_LastItemSelected_SplitterShrinks_SelectionStaysVisible()
     {
         // Create a long list
@@ -1784,14 +1785,14 @@ public class ListNodeTests
         splitterNode.Arrange(new Rect(0, 0, 40, 25));
         
         // Verify list has 15 rows
-        Assert.Equal(15, listNode.ViewportHeight);
+        Assert.AreEqual(15, listNode.ViewportHeight);
         
         // Select the last item in the list
         listNode.SetSelection(29);
-        Assert.Equal(29, listNode.SelectedIndex);
+        Assert.AreEqual(29, listNode.SelectedIndex);
         
         // Verify scroll offset to show item 29 (should scroll to 15 = 29 - 15 + 1)
-        Assert.Equal(15, listNode.ScrollOffset);
+        Assert.AreEqual(15, listNode.ScrollOffset);
         
         // Now shrink the splitter - move it up by 5 rows
         splitterNode.FirstSize = 10;
@@ -1801,16 +1802,16 @@ public class ListNodeTests
         splitterNode.Arrange(new Rect(0, 0, 40, 25));
         
         // Verify list now has 10 rows
-        Assert.Equal(10, listNode.ViewportHeight);
+        Assert.AreEqual(10, listNode.ViewportHeight);
         
         // The selected item (29) should still be visible
         // EnsureSelectionVisible should have adjusted scroll offset
         // Scroll offset should be at least 20 (29 - 10 + 1 = 20)
-        Assert.Equal(20, listNode.ScrollOffset);
-        Assert.Equal(29, listNode.SelectedIndex);
+        Assert.AreEqual(20, listNode.ScrollOffset);
+        Assert.AreEqual(29, listNode.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ListInVerticalSplitter_FirstItemSelected_SplitterShrinks_SelectionStaysVisible()
     {
         // Create a long list
@@ -1833,8 +1834,8 @@ public class ListNodeTests
         
         // Select the first item
         listNode.SetSelection(0);
-        Assert.Equal(0, listNode.SelectedIndex);
-        Assert.Equal(0, listNode.ScrollOffset);
+        Assert.AreEqual(0, listNode.SelectedIndex);
+        Assert.AreEqual(0, listNode.ScrollOffset);
         
         // Shrink the splitter
         splitterNode.FirstSize = 8;
@@ -1842,14 +1843,14 @@ public class ListNodeTests
         splitterNode.Arrange(new Rect(0, 0, 40, 20));
         
         // Verify list now has 8 rows
-        Assert.Equal(8, listNode.ViewportHeight);
+        Assert.AreEqual(8, listNode.ViewportHeight);
         
         // First item should still be visible at the top
-        Assert.Equal(0, listNode.ScrollOffset);
-        Assert.Equal(0, listNode.SelectedIndex);
+        Assert.AreEqual(0, listNode.ScrollOffset);
+        Assert.AreEqual(0, listNode.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ListInVerticalSplitter_MiddleItemSelected_SplitterShrinks_SelectionStaysVisible()
     {
         // Create a long list
@@ -1873,10 +1874,10 @@ public class ListNodeTests
         
         // Select a middle item (item 15)
         listNode.SetSelection(15);
-        Assert.Equal(15, listNode.SelectedIndex);
+        Assert.AreEqual(15, listNode.SelectedIndex);
         
         // Initial scroll offset should be 1 (to show items 1-15 in 15-row viewport)
-        Assert.Equal(1, listNode.ScrollOffset);
+        Assert.AreEqual(1, listNode.ScrollOffset);
         
         // Shrink the splitter significantly
         splitterNode.FirstSize = 6;
@@ -1884,15 +1885,15 @@ public class ListNodeTests
         splitterNode.Arrange(new Rect(0, 0, 40, 25));
         
         // Verify list now has 6 rows
-        Assert.Equal(6, listNode.ViewportHeight);
+        Assert.AreEqual(6, listNode.ViewportHeight);
         
         // Item 15 should still be visible
         // Scroll offset should be adjusted: 15 - 6 + 1 = 10
-        Assert.Equal(10, listNode.ScrollOffset);
-        Assert.Equal(15, listNode.SelectedIndex);
+        Assert.AreEqual(10, listNode.ScrollOffset);
+        Assert.AreEqual(15, listNode.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ListInVerticalSplitter_SelectionNearEnd_SplitterGrows_MoreItemsVisible()
     {
         // Create a long list
@@ -1916,10 +1917,10 @@ public class ListNodeTests
         
         // Select item near the end
         listNode.SetSelection(28);
-        Assert.Equal(28, listNode.SelectedIndex);
+        Assert.AreEqual(28, listNode.SelectedIndex);
         
         // Scroll offset should be 24 (28 - 5 + 1)
-        Assert.Equal(24, listNode.ScrollOffset);
+        Assert.AreEqual(24, listNode.ScrollOffset);
         
         // Grow the splitter
         splitterNode.FirstSize = 15;
@@ -1927,19 +1928,19 @@ public class ListNodeTests
         splitterNode.Arrange(new Rect(0, 0, 40, 25));
         
         // Verify list now has 15 rows
-        Assert.Equal(15, listNode.ViewportHeight);
+        Assert.AreEqual(15, listNode.ViewportHeight);
         
         // Scroll offset should be adjusted to show item 28 (28 - 15 + 1 = 14)
         // But it could also stay at a higher offset if selection is visible
-        Assert.True(listNode.ScrollOffset >= 14 && listNode.ScrollOffset <= 24);
-        Assert.Equal(28, listNode.SelectedIndex);
+        Assert.IsTrue(listNode.ScrollOffset >= 14 && listNode.ScrollOffset <= 24);
+        Assert.AreEqual(28, listNode.SelectedIndex);
         
         // Selection should still be within visible range
-        Assert.True(listNode.SelectedIndex >= listNode.ScrollOffset);
-        Assert.True(listNode.SelectedIndex < listNode.ScrollOffset + listNode.ViewportHeight);
+        Assert.IsTrue(listNode.SelectedIndex >= listNode.ScrollOffset);
+        Assert.IsTrue(listNode.SelectedIndex < listNode.ScrollOffset + listNode.ViewportHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ListBelowVerticalSplitter_LastItemSelected_SplitterMovesDown_SelectionStaysVisible()
     {
         // Create a long list
@@ -1961,11 +1962,11 @@ public class ListNodeTests
         splitterNode.Arrange(new Rect(0, 0, 40, 20));
         
         // Verify list has 14 rows (20 total - 5 top - 1 divider)
-        Assert.Equal(14, listNode.ViewportHeight);
+        Assert.AreEqual(14, listNode.ViewportHeight);
         
         // Select the last item
         listNode.SetSelection(29);
-        Assert.Equal(29, listNode.SelectedIndex);
+        Assert.AreEqual(29, listNode.SelectedIndex);
         
         // Now move splitter down (increase top size), shrinking list
         splitterNode.FirstSize = 12; // List now gets 20 - 12 - 1 = 7 rows
@@ -1973,15 +1974,15 @@ public class ListNodeTests
         splitterNode.Arrange(new Rect(0, 0, 40, 20));
         
         // Verify list now has 7 rows
-        Assert.Equal(7, listNode.ViewportHeight);
+        Assert.AreEqual(7, listNode.ViewportHeight);
         
         // Selected item (29) should still be visible
         // Scroll offset should be 23 (29 - 7 + 1)
-        Assert.Equal(23, listNode.ScrollOffset);
-        Assert.Equal(29, listNode.SelectedIndex);
+        Assert.AreEqual(23, listNode.ScrollOffset);
+        Assert.AreEqual(29, listNode.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ListBelowVerticalSplitter_FirstItemSelected_SplitterMovesDown_SelectionStaysVisible()
     {
         // Create a long list
@@ -2004,8 +2005,8 @@ public class ListNodeTests
         
         // Select the first item
         listNode.SetSelection(0);
-        Assert.Equal(0, listNode.SelectedIndex);
-        Assert.Equal(0, listNode.ScrollOffset);
+        Assert.AreEqual(0, listNode.SelectedIndex);
+        Assert.AreEqual(0, listNode.ScrollOffset);
         
         // Move splitter down, shrinking list
         splitterNode.FirstSize = 12;
@@ -2013,14 +2014,14 @@ public class ListNodeTests
         splitterNode.Arrange(new Rect(0, 0, 40, 20));
         
         // Verify list now has 7 rows
-        Assert.Equal(7, listNode.ViewportHeight);
+        Assert.AreEqual(7, listNode.ViewportHeight);
         
         // First item should still be visible
-        Assert.Equal(0, listNode.ScrollOffset);
-        Assert.Equal(0, listNode.SelectedIndex);
+        Assert.AreEqual(0, listNode.ScrollOffset);
+        Assert.AreEqual(0, listNode.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ListBelowVerticalSplitter_MiddleItemSelected_SplitterMovesDown_SelectionStaysVisible()
     {
         // Create a long list
@@ -2042,14 +2043,14 @@ public class ListNodeTests
         splitterNode.Arrange(new Rect(0, 0, 40, 20));
         
         // Verify list has 14 rows
-        Assert.Equal(14, listNode.ViewportHeight);
+        Assert.AreEqual(14, listNode.ViewportHeight);
         
         // Select a middle item (item 15)
         listNode.SetSelection(15);
-        Assert.Equal(15, listNode.SelectedIndex);
+        Assert.AreEqual(15, listNode.SelectedIndex);
         
         // Initial scroll offset should be 2 (to show items 2-15 in 14-row viewport)
-        Assert.Equal(2, listNode.ScrollOffset);
+        Assert.AreEqual(2, listNode.ScrollOffset);
         
         // Move splitter down significantly
         splitterNode.FirstSize = 14;
@@ -2057,19 +2058,19 @@ public class ListNodeTests
         splitterNode.Arrange(new Rect(0, 0, 40, 20));
         
         // Verify list now has 5 rows
-        Assert.Equal(5, listNode.ViewportHeight);
+        Assert.AreEqual(5, listNode.ViewportHeight);
         
         // Item 15 should still be visible
         // Scroll offset should be 11 (15 - 5 + 1)
-        Assert.Equal(11, listNode.ScrollOffset);
-        Assert.Equal(15, listNode.SelectedIndex);
+        Assert.AreEqual(11, listNode.ScrollOffset);
+        Assert.AreEqual(15, listNode.SelectedIndex);
     }
 
     #endregion
     
     #region InitialSelectedIndex Tests
 
-    [Fact]
+    [TestMethod]
     public async Task ListWidget_InitialSelectedIndex_SetsSelectionOnNewNode()
     {
         // Arrange
@@ -2080,11 +2081,11 @@ public class ListNodeTests
         var node = await widget.ReconcileAsync(null, context) as ListNode;
         
         // Assert
-        Assert.Equal(2, node!.SelectedIndex);
-        Assert.Equal("Cherry", node.SelectedText);
+        Assert.AreEqual(2, node!.SelectedIndex);
+        Assert.AreEqual("Cherry", node.SelectedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ListWidget_InitialSelectedIndex_ClampsToValidRange()
     {
         // Arrange - index out of bounds
@@ -2095,10 +2096,10 @@ public class ListNodeTests
         var node = await widget.ReconcileAsync(null, context) as ListNode;
         
         // Assert - should be clamped to last item
-        Assert.Equal(1, node!.SelectedIndex);
+        Assert.AreEqual(1, node!.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ListWidget_InitialSelectedIndex_DefaultsToZero()
     {
         // Arrange
@@ -2109,7 +2110,7 @@ public class ListNodeTests
         var node = await widget.ReconcileAsync(null, context) as ListNode;
         
         // Assert
-        Assert.Equal(0, node!.SelectedIndex);
+        Assert.AreEqual(0, node!.SelectedIndex);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/LoggerPanelTests.cs
+++ b/tests/Hex1b.Tests/LoggerPanelTests.cs
@@ -3,17 +3,18 @@ using Microsoft.Extensions.Logging;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class CircularBufferTests
 {
-    [Fact]
+    [TestMethod]
     public void Add_SingleItem_CountIsOne()
     {
         var buffer = new CircularBuffer<int>(10);
         buffer.Add(42);
-        Assert.Equal(1, buffer.Count);
+        Assert.AreEqual(1, buffer.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Add_ExceedsCapacity_CountClampsToCapacity()
     {
         var buffer = new CircularBuffer<int>(3);
@@ -22,10 +23,10 @@ public class CircularBufferTests
         buffer.Add(3);
         buffer.Add(4);
 
-        Assert.Equal(3, buffer.Count);
+        Assert.AreEqual(3, buffer.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Add_ExceedsCapacity_OldestItemsDropped()
     {
         var buffer = new CircularBuffer<int>(3);
@@ -35,10 +36,10 @@ public class CircularBufferTests
         buffer.Add(4);
 
         var items = buffer.GetItems(0, 3);
-        Assert.Equal([2, 3, 4], items);
+        TestSeq.AreEqual([2, 3, 4], items);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetItems_ReturnsCorrectRange()
     {
         var buffer = new CircularBuffer<int>(10);
@@ -46,20 +47,20 @@ public class CircularBufferTests
             buffer.Add(i);
 
         var items = buffer.GetItems(1, 3);
-        Assert.Equal([1, 2, 3], items);
+        TestSeq.AreEqual([1, 2, 3], items);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetItems_StartBeyondCount_ReturnsEmpty()
     {
         var buffer = new CircularBuffer<int>(10);
         buffer.Add(1);
 
         var items = buffer.GetItems(5, 3);
-        Assert.Empty(items);
+        Assert.IsEmpty(items);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetItems_CountExceedsAvailable_ClampsToAvailable()
     {
         var buffer = new CircularBuffer<int>(10);
@@ -67,10 +68,10 @@ public class CircularBufferTests
         buffer.Add(2);
 
         var items = buffer.GetItems(0, 100);
-        Assert.Equal(2, items.Count);
+        Assert.AreEqual(2, items.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Clear_ResetsCountToZero()
     {
         var buffer = new CircularBuffer<int>(10);
@@ -78,10 +79,10 @@ public class CircularBufferTests
         buffer.Add(2);
         buffer.Clear();
 
-        Assert.Equal(0, buffer.Count);
+        Assert.AreEqual(0, buffer.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void CollectionChanged_FiredOnAdd()
     {
         var buffer = new CircularBuffer<int>(10);
@@ -90,10 +91,10 @@ public class CircularBufferTests
 
         buffer.Add(1);
 
-        Assert.True(fired);
+        Assert.IsTrue(fired);
     }
 
-    [Fact]
+    [TestMethod]
     public void CollectionChanged_FiredOnClear()
     {
         var buffer = new CircularBuffer<int>(10);
@@ -103,10 +104,10 @@ public class CircularBufferTests
         buffer.CollectionChanged += (_, _) => fired = true;
         buffer.Clear();
 
-        Assert.True(fired);
+        Assert.IsTrue(fired);
     }
 
-    [Fact]
+    [TestMethod]
     public void Add_ThreadSafe_NoExceptions()
     {
         var buffer = new CircularBuffer<int>(100);
@@ -125,22 +126,23 @@ public class CircularBufferTests
         Task.WaitAll(tasks);
 
         // Buffer should have exactly capacity items (100)
-        Assert.Equal(100, buffer.Count);
+        Assert.AreEqual(100, buffer.Count);
     }
 }
 
+[TestClass]
 public class Hex1bLogStoreTests
 {
-    [Fact]
+    [TestMethod]
     public void CreateLogger_ReturnsLogger()
     {
         var store = new Hex1bLogStore();
         var logger = store.CreateLogger("TestCategory");
 
-        Assert.NotNull(logger);
+        Assert.IsNotNull(logger);
     }
 
-    [Fact]
+    [TestMethod]
     public void Logger_LogMessage_AppearsInBuffer()
     {
         var store = new Hex1bLogStore();
@@ -148,14 +150,14 @@ public class Hex1bLogStoreTests
 
         logger.LogInformation("Hello, World!");
 
-        Assert.Equal(1, store.Buffer.Count);
+        Assert.AreEqual(1, store.Buffer.Count);
         var items = store.Buffer.GetItems(0, 1);
-        Assert.Equal("Hello, World!", items[0].Message);
-        Assert.Equal("TestCategory", items[0].Category);
-        Assert.Equal(LogLevel.Information, items[0].Level);
+        Assert.AreEqual("Hello, World!", items[0].Message);
+        Assert.AreEqual("TestCategory", items[0].Category);
+        Assert.AreEqual(LogLevel.Information, items[0].Level);
     }
 
-    [Fact]
+    [TestMethod]
     public void Logger_MultipleCategories_AllAppearInBuffer()
     {
         var store = new Hex1bLogStore();
@@ -165,13 +167,13 @@ public class Hex1bLogStoreTests
         logger1.LogInformation("From A");
         logger2.LogWarning("From B");
 
-        Assert.Equal(2, store.Buffer.Count);
+        Assert.AreEqual(2, store.Buffer.Count);
         var items = store.Buffer.GetItems(0, 2);
-        Assert.Equal("Category.A", items[0].Category);
-        Assert.Equal("Category.B", items[1].Category);
+        Assert.AreEqual("Category.A", items[0].Category);
+        Assert.AreEqual("Category.B", items[1].Category);
     }
 
-    [Fact]
+    [TestMethod]
     public void DataSource_ReflectsBufferContents()
     {
         var store = new Hex1bLogStore();
@@ -181,32 +183,33 @@ public class Hex1bLogStoreTests
         logger.LogError("Entry 2");
 
         var count = store.DataSource.GetItemCountAsync().GetAwaiter().GetResult();
-        Assert.Equal(2, count);
+        Assert.AreEqual(2, count);
 
         var items = store.DataSource.GetItemsAsync(0, 2).GetAwaiter().GetResult();
-        Assert.Equal("Entry 1", items[0].Message);
-        Assert.Equal("Entry 2", items[1].Message);
+        Assert.AreEqual("Entry 1", items[0].Message);
+        Assert.AreEqual("Entry 2", items[1].Message);
     }
 
-    [Fact]
+    [TestMethod]
     public void Logger_IsEnabled_ReturnsTrueForAllLevels()
     {
         var store = new Hex1bLogStore();
         var logger = store.CreateLogger("Test");
 
-        Assert.True(logger.IsEnabled(LogLevel.Trace));
-        Assert.True(logger.IsEnabled(LogLevel.Debug));
-        Assert.True(logger.IsEnabled(LogLevel.Information));
-        Assert.True(logger.IsEnabled(LogLevel.Warning));
-        Assert.True(logger.IsEnabled(LogLevel.Error));
-        Assert.True(logger.IsEnabled(LogLevel.Critical));
-        Assert.False(logger.IsEnabled(LogLevel.None));
+        Assert.IsTrue(logger.IsEnabled(LogLevel.Trace));
+        Assert.IsTrue(logger.IsEnabled(LogLevel.Debug));
+        Assert.IsTrue(logger.IsEnabled(LogLevel.Information));
+        Assert.IsTrue(logger.IsEnabled(LogLevel.Warning));
+        Assert.IsTrue(logger.IsEnabled(LogLevel.Error));
+        Assert.IsTrue(logger.IsEnabled(LogLevel.Critical));
+        Assert.IsFalse(logger.IsEnabled(LogLevel.None));
     }
 }
 
+[TestClass]
 public class Hex1bLogTableDataSourceTests
 {
-    [Fact]
+    [TestMethod]
     public void GetItemCountAsync_ReturnsBufferCount()
     {
         var buffer = new CircularBuffer<Hex1bLogEntry>(100);
@@ -215,10 +218,10 @@ public class Hex1bLogTableDataSourceTests
         buffer.Add(new Hex1bLogEntry(DateTime.UtcNow, LogLevel.Information, "Test", "msg", default, null));
 
         var count = dataSource.GetItemCountAsync().GetAwaiter().GetResult();
-        Assert.Equal(1, count);
+        Assert.AreEqual(1, count);
     }
 
-    [Fact]
+    [TestMethod]
     public void CollectionChanged_ForwardedFromBuffer()
     {
         var buffer = new CircularBuffer<Hex1bLogEntry>(100);
@@ -228,10 +231,10 @@ public class Hex1bLogTableDataSourceTests
 
         buffer.Add(new Hex1bLogEntry(DateTime.UtcNow, LogLevel.Information, "Test", "msg", default, null));
 
-        Assert.True(fired);
+        Assert.IsTrue(fired);
     }
 
-    [Fact]
+    [TestMethod]
     public void Dispose_UnsubscribesFromBuffer()
     {
         var buffer = new CircularBuffer<Hex1bLogEntry>(100);
@@ -242,16 +245,17 @@ public class Hex1bLogTableDataSourceTests
         dataSource.Dispose();
         buffer.Add(new Hex1bLogEntry(DateTime.UtcNow, LogLevel.Information, "Test", "msg", default, null));
 
-        Assert.False(fired);
+        Assert.IsFalse(fired);
     }
 }
 
+[TestClass]
 public class LoggerPanelNodeTests
 {
-    [Fact]
+    [TestMethod]
     public void IsFollowing_DefaultsToTrue()
     {
         var node = new LoggerPanelNode();
-        Assert.True(node.IsFollowing);
+        Assert.IsTrue(node.IsFollowing);
     }
 }

--- a/tests/Hex1b.Tests/MarkdownBlockSpacingTests.cs
+++ b/tests/Hex1b.Tests/MarkdownBlockSpacingTests.cs
@@ -2,100 +2,101 @@ using Hex1b.Markdown;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class MarkdownBlockSpacingTests
 {
-    [Fact]
+    [TestMethod]
     public void NeedsSpacingBefore_FirstBlock_ReturnsFalse()
     {
         var block = new ParagraphBlock([], "Hello");
-        Assert.False(MarkdownWidgetRenderer.NeedsSpacingBefore(null, block));
+        Assert.IsFalse(MarkdownWidgetRenderer.NeedsSpacingBefore(null, block));
     }
 
-    [Fact]
+    [TestMethod]
     public void NeedsSpacingBefore_HeadingThenParagraph_ReturnsTrue()
     {
         var heading = new HeadingBlock(1, [], "Title");
         var paragraph = new ParagraphBlock([], "Text");
-        Assert.True(MarkdownWidgetRenderer.NeedsSpacingBefore(heading, paragraph));
+        Assert.IsTrue(MarkdownWidgetRenderer.NeedsSpacingBefore(heading, paragraph));
     }
 
-    [Fact]
+    [TestMethod]
     public void NeedsSpacingBefore_ParagraphThenParagraph_ReturnsTrue()
     {
         var p1 = new ParagraphBlock([], "First");
         var p2 = new ParagraphBlock([], "Second");
-        Assert.True(MarkdownWidgetRenderer.NeedsSpacingBefore(p1, p2));
+        Assert.IsTrue(MarkdownWidgetRenderer.NeedsSpacingBefore(p1, p2));
     }
 
-    [Fact]
+    [TestMethod]
     public void NeedsSpacingBefore_ParagraphThenHeading_ReturnsTrue()
     {
         var paragraph = new ParagraphBlock([], "Text");
         var heading = new HeadingBlock(1, [], "Title");
-        Assert.True(MarkdownWidgetRenderer.NeedsSpacingBefore(paragraph, heading));
+        Assert.IsTrue(MarkdownWidgetRenderer.NeedsSpacingBefore(paragraph, heading));
     }
 
-    [Fact]
+    [TestMethod]
     public void NeedsSpacingBefore_HeadingThenList_ReturnsTrue()
     {
         var heading = new HeadingBlock(1, [], "Title");
         var list = new ListBlock(false, 1, []);
-        Assert.True(MarkdownWidgetRenderer.NeedsSpacingBefore(heading, list));
+        Assert.IsTrue(MarkdownWidgetRenderer.NeedsSpacingBefore(heading, list));
     }
 
-    [Fact]
+    [TestMethod]
     public void NeedsSpacingBefore_ParagraphThenCodeBlock_ReturnsTrue()
     {
         var paragraph = new ParagraphBlock([], "Text");
         var code = new FencedCodeBlock("csharp", "var x = 1;", "csharp");
-        Assert.True(MarkdownWidgetRenderer.NeedsSpacingBefore(paragraph, code));
+        Assert.IsTrue(MarkdownWidgetRenderer.NeedsSpacingBefore(paragraph, code));
     }
 
-    [Fact]
+    [TestMethod]
     public void NeedsSpacingBefore_CodeBlockThenParagraph_ReturnsTrue()
     {
         var code = new FencedCodeBlock("csharp", "var x = 1;", "csharp");
         var paragraph = new ParagraphBlock([], "Text");
-        Assert.True(MarkdownWidgetRenderer.NeedsSpacingBefore(code, paragraph));
+        Assert.IsTrue(MarkdownWidgetRenderer.NeedsSpacingBefore(code, paragraph));
     }
 
-    [Fact]
+    [TestMethod]
     public void NeedsSpacingBefore_ParagraphThenBlockQuote_ReturnsTrue()
     {
         var paragraph = new ParagraphBlock([], "Text");
         var quote = new BlockQuoteBlock([new ParagraphBlock([], "Quoted")]);
-        Assert.True(MarkdownWidgetRenderer.NeedsSpacingBefore(paragraph, quote));
+        Assert.IsTrue(MarkdownWidgetRenderer.NeedsSpacingBefore(paragraph, quote));
     }
 
-    [Fact]
+    [TestMethod]
     public void NeedsSpacingBefore_HeadingThenHeading_ReturnsTrue()
     {
         var h1 = new HeadingBlock(1, [], "First");
         var h2 = new HeadingBlock(2, [], "Second");
-        Assert.True(MarkdownWidgetRenderer.NeedsSpacingBefore(h1, h2));
+        Assert.IsTrue(MarkdownWidgetRenderer.NeedsSpacingBefore(h1, h2));
     }
 
-    [Fact]
+    [TestMethod]
     public void NeedsSpacingBefore_ParagraphThenTable_ReturnsTrue()
     {
         var paragraph = new ParagraphBlock([], "Text");
         var table = new TableBlock([], [], []);
-        Assert.True(MarkdownWidgetRenderer.NeedsSpacingBefore(paragraph, table));
+        Assert.IsTrue(MarkdownWidgetRenderer.NeedsSpacingBefore(paragraph, table));
     }
 
-    [Fact]
+    [TestMethod]
     public void NeedsSpacingBefore_HeadingThenFencedCode_ReturnsTrue()
     {
         var heading = new HeadingBlock(1, [], "Title");
         var code = new FencedCodeBlock("", "x = 1", "");
-        Assert.True(MarkdownWidgetRenderer.NeedsSpacingBefore(heading, code));
+        Assert.IsTrue(MarkdownWidgetRenderer.NeedsSpacingBefore(heading, code));
     }
 
-    [Fact]
+    [TestMethod]
     public void NeedsSpacingBefore_HeadingThenIndentedCode_ReturnsTrue()
     {
         var heading = new HeadingBlock(1, [], "Title");
         var code = new IndentedCodeBlock("x = 1");
-        Assert.True(MarkdownWidgetRenderer.NeedsSpacingBefore(heading, code));
+        Assert.IsTrue(MarkdownWidgetRenderer.NeedsSpacingBefore(heading, code));
     }
 }

--- a/tests/Hex1b.Tests/MarkdownInlineRendererTests.cs
+++ b/tests/Hex1b.Tests/MarkdownInlineRendererTests.cs
@@ -3,26 +3,27 @@ using Hex1b.Theming;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class MarkdownInlineRendererTests
 {
     // ==========================================================================
     // FlattenInlines
     // ==========================================================================
 
-    [Fact]
+    [TestMethod]
     public void FlattenInlines_PlainText_SingleRun()
     {
         var inlines = new MarkdownInline[] { new TextInline("Hello world") };
         var runs = MarkdownInlineRenderer.FlattenInlines(inlines);
 
-        var run = Assert.Single(runs);
-        Assert.Equal("Hello world", run.Text);
-        Assert.Null(run.Foreground);
-        Assert.Null(run.Background);
-        Assert.Equal(CellAttributes.None, run.Attributes);
+        var run = TestSeq.Single(runs);
+        Assert.AreEqual("Hello world", run.Text);
+        Assert.IsNull(run.Foreground);
+        Assert.IsNull(run.Background);
+        Assert.AreEqual(CellAttributes.None, run.Attributes);
     }
 
-    [Fact]
+    [TestMethod]
     public void FlattenInlines_Bold_SetsBoldAttribute()
     {
         var inlines = new MarkdownInline[]
@@ -31,12 +32,12 @@ public class MarkdownInlineRendererTests
         };
         var runs = MarkdownInlineRenderer.FlattenInlines(inlines);
 
-        var run = Assert.Single(runs);
-        Assert.Equal("bold", run.Text);
-        Assert.True((run.Attributes & CellAttributes.Bold) != 0);
+        var run = TestSeq.Single(runs);
+        Assert.AreEqual("bold", run.Text);
+        Assert.IsTrue((run.Attributes & CellAttributes.Bold) != 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void FlattenInlines_Italic_SetsItalicAttribute()
     {
         var inlines = new MarkdownInline[]
@@ -45,12 +46,12 @@ public class MarkdownInlineRendererTests
         };
         var runs = MarkdownInlineRenderer.FlattenInlines(inlines);
 
-        var run = Assert.Single(runs);
-        Assert.Equal("italic", run.Text);
-        Assert.True((run.Attributes & CellAttributes.Italic) != 0);
+        var run = TestSeq.Single(runs);
+        Assert.AreEqual("italic", run.Text);
+        Assert.IsTrue((run.Attributes & CellAttributes.Italic) != 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void FlattenInlines_NestedBoldItalic_ComposesAttributes()
     {
         // ***bold italic***
@@ -62,50 +63,50 @@ public class MarkdownInlineRendererTests
         };
         var runs = MarkdownInlineRenderer.FlattenInlines(inlines);
 
-        var run = Assert.Single(runs);
-        Assert.Equal("both", run.Text);
-        Assert.True((run.Attributes & CellAttributes.Bold) != 0);
-        Assert.True((run.Attributes & CellAttributes.Italic) != 0);
+        var run = TestSeq.Single(runs);
+        Assert.AreEqual("both", run.Text);
+        Assert.IsTrue((run.Attributes & CellAttributes.Bold) != 0);
+        Assert.IsTrue((run.Attributes & CellAttributes.Italic) != 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void FlattenInlines_CodeSpan_SetsColorAndBackground()
     {
         var inlines = new MarkdownInline[] { new CodeInline("x = 0") };
         var runs = MarkdownInlineRenderer.FlattenInlines(inlines);
 
-        var run = Assert.Single(runs);
-        Assert.Equal("x = 0", run.Text);
-        Assert.NotNull(run.Foreground);
-        Assert.NotNull(run.Background);
+        var run = TestSeq.Single(runs);
+        Assert.AreEqual("x = 0", run.Text);
+        Assert.IsNotNull(run.Foreground);
+        Assert.IsNotNull(run.Background);
     }
 
-    [Fact]
+    [TestMethod]
     public void FlattenInlines_Link_SetsUnderlineColorAndUrl()
     {
         var inlines = new MarkdownInline[] { new LinkInline("click", "https://example.com") };
         var runs = MarkdownInlineRenderer.FlattenInlines(inlines);
 
-        var run = Assert.Single(runs);
-        Assert.Equal("click", run.Text);
-        Assert.True((run.Attributes & CellAttributes.Underline) != 0);
-        Assert.NotNull(run.Foreground);
-        Assert.Equal("https://example.com", run.Url);
+        var run = TestSeq.Single(runs);
+        Assert.AreEqual("click", run.Text);
+        Assert.IsTrue((run.Attributes & CellAttributes.Underline) != 0);
+        Assert.IsNotNull(run.Foreground);
+        Assert.AreEqual("https://example.com", run.Url);
     }
 
-    [Fact]
+    [TestMethod]
     public void FlattenInlines_Image_SetsAltTextWithBracketsAndUrl()
     {
         var inlines = new MarkdownInline[] { new ImageInline("logo", "img.png") };
         var runs = MarkdownInlineRenderer.FlattenInlines(inlines);
 
-        var run = Assert.Single(runs);
-        Assert.Equal("[logo]", run.Text);
-        Assert.True((run.Attributes & CellAttributes.Italic) != 0);
-        Assert.Equal("img.png", run.Url);
+        var run = TestSeq.Single(runs);
+        Assert.AreEqual("[logo]", run.Text);
+        Assert.IsTrue((run.Attributes & CellAttributes.Italic) != 0);
+        Assert.AreEqual("img.png", run.Url);
     }
 
-    [Fact]
+    [TestMethod]
     public void FlattenInlines_HardBreak_EmitsNewline()
     {
         var inlines = new MarkdownInline[]
@@ -116,13 +117,13 @@ public class MarkdownInlineRendererTests
         };
         var runs = MarkdownInlineRenderer.FlattenInlines(inlines);
 
-        Assert.Equal(3, runs.Count);
-        Assert.Equal("first", runs[0].Text);
-        Assert.Equal("\n", runs[1].Text);
-        Assert.Equal("second", runs[2].Text);
+        Assert.AreEqual(3, runs.Count);
+        Assert.AreEqual("first", runs[0].Text);
+        Assert.AreEqual("\n", runs[1].Text);
+        Assert.AreEqual("second", runs[2].Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void FlattenInlines_SoftBreak_EmitsSpace()
     {
         var inlines = new MarkdownInline[]
@@ -133,11 +134,11 @@ public class MarkdownInlineRendererTests
         };
         var runs = MarkdownInlineRenderer.FlattenInlines(inlines);
 
-        Assert.Equal(3, runs.Count);
-        Assert.Equal(" ", runs[1].Text);
+        Assert.AreEqual(3, runs.Count);
+        Assert.AreEqual(" ", runs[1].Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void FlattenInlines_MixedContent_ProducesMultipleRuns()
     {
         // "Hello **bold** and `code` here"
@@ -151,44 +152,44 @@ public class MarkdownInlineRendererTests
         };
         var runs = MarkdownInlineRenderer.FlattenInlines(inlines);
 
-        Assert.Equal(5, runs.Count);
-        Assert.Equal("Hello ", runs[0].Text);
-        Assert.Equal("bold", runs[1].Text);
-        Assert.True((runs[1].Attributes & CellAttributes.Bold) != 0);
-        Assert.Equal(" and ", runs[2].Text);
-        Assert.Equal("code", runs[3].Text);
-        Assert.NotNull(runs[3].Background); // code has bg
-        Assert.Equal(" here", runs[4].Text);
+        Assert.AreEqual(5, runs.Count);
+        Assert.AreEqual("Hello ", runs[0].Text);
+        Assert.AreEqual("bold", runs[1].Text);
+        Assert.IsTrue((runs[1].Attributes & CellAttributes.Bold) != 0);
+        Assert.AreEqual(" and ", runs[2].Text);
+        Assert.AreEqual("code", runs[3].Text);
+        Assert.IsNotNull(runs[3].Background); // code has bg
+        Assert.AreEqual(" here", runs[4].Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void FlattenInlines_WithBaseAttributes_AppliedToAll()
     {
         var inlines = new MarkdownInline[] { new TextInline("text") };
         var runs = MarkdownInlineRenderer.FlattenInlines(
             inlines, baseAttributes: CellAttributes.Bold);
 
-        var run = Assert.Single(runs);
-        Assert.True((run.Attributes & CellAttributes.Bold) != 0);
+        var run = TestSeq.Single(runs);
+        Assert.IsTrue((run.Attributes & CellAttributes.Bold) != 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void FlattenInlines_WithBaseForeground_AppliedToPlainText()
     {
         var fg = Hex1bColor.FromRgb(255, 0, 0);
         var inlines = new MarkdownInline[] { new TextInline("text") };
         var runs = MarkdownInlineRenderer.FlattenInlines(inlines, baseForeground: fg);
 
-        var run = Assert.Single(runs);
-        Assert.NotNull(run.Foreground);
-        Assert.Equal(255, run.Foreground!.Value.R);
+        var run = TestSeq.Single(runs);
+        Assert.IsNotNull(run.Foreground);
+        Assert.AreEqual(255, run.Foreground!.Value.R);
     }
 
     // ==========================================================================
     // SplitIntoWords
     // ==========================================================================
 
-    [Fact]
+    [TestMethod]
     public void SplitIntoWords_SingleWord_OneStyledWord()
     {
         var runs = new List<MarkdownTextRun>
@@ -197,14 +198,14 @@ public class MarkdownInlineRendererTests
         };
         var words = MarkdownInlineRenderer.SplitIntoWords(runs);
 
-        var word = Assert.Single(words);
-        Assert.Single(word.Fragments);
-        Assert.Equal("hello", word.Fragments[0].Text);
-        Assert.Equal(5, word.DisplayWidth);
-        Assert.False(word.PrecededBySpace);
+        var word = TestSeq.Single(words);
+        TestSeq.Single(word.Fragments);
+        Assert.AreEqual("hello", word.Fragments[0].Text);
+        Assert.AreEqual(5, word.DisplayWidth);
+        Assert.IsFalse(word.PrecededBySpace);
     }
 
-    [Fact]
+    [TestMethod]
     public void SplitIntoWords_TwoWordsInOneRun_TwoStyledWords()
     {
         var runs = new List<MarkdownTextRun>
@@ -213,14 +214,14 @@ public class MarkdownInlineRendererTests
         };
         var words = MarkdownInlineRenderer.SplitIntoWords(runs);
 
-        Assert.Equal(2, words.Count);
-        Assert.Equal("hello", words[0].Fragments[0].Text);
-        Assert.False(words[0].PrecededBySpace);
-        Assert.Equal("world", words[1].Fragments[0].Text);
-        Assert.True(words[1].PrecededBySpace);
+        Assert.AreEqual(2, words.Count);
+        Assert.AreEqual("hello", words[0].Fragments[0].Text);
+        Assert.IsFalse(words[0].PrecededBySpace);
+        Assert.AreEqual("world", words[1].Fragments[0].Text);
+        Assert.IsTrue(words[1].PrecededBySpace);
     }
 
-    [Fact]
+    [TestMethod]
     public void SplitIntoWords_PartialWordStyling_OneWordMultipleFragments()
     {
         // par**tial**ly → one word with 3 fragments
@@ -232,16 +233,16 @@ public class MarkdownInlineRendererTests
         };
         var words = MarkdownInlineRenderer.SplitIntoWords(runs);
 
-        var word = Assert.Single(words);
-        Assert.Equal(3, word.Fragments.Count);
-        Assert.Equal("par", word.Fragments[0].Text);
-        Assert.Equal("tial", word.Fragments[1].Text);
-        Assert.True((word.Fragments[1].Attributes & CellAttributes.Bold) != 0);
-        Assert.Equal("ly", word.Fragments[2].Text);
-        Assert.Equal(9, word.DisplayWidth);
+        var word = TestSeq.Single(words);
+        Assert.AreEqual(3, word.Fragments.Count);
+        Assert.AreEqual("par", word.Fragments[0].Text);
+        Assert.AreEqual("tial", word.Fragments[1].Text);
+        Assert.IsTrue((word.Fragments[1].Attributes & CellAttributes.Bold) != 0);
+        Assert.AreEqual("ly", word.Fragments[2].Text);
+        Assert.AreEqual(9, word.DisplayWidth);
     }
 
-    [Fact]
+    [TestMethod]
     public void SplitIntoWords_SpaceBetweenRuns_SeparateWords()
     {
         // "Hello **bold world** end"
@@ -253,16 +254,16 @@ public class MarkdownInlineRendererTests
         };
         var words = MarkdownInlineRenderer.SplitIntoWords(runs);
 
-        Assert.Equal(4, words.Count);
-        Assert.Equal("Hello", words[0].Fragments[0].Text);
-        Assert.Equal("bold", words[1].Fragments[0].Text);
-        Assert.True((words[1].Fragments[0].Attributes & CellAttributes.Bold) != 0);
-        Assert.Equal("world", words[2].Fragments[0].Text);
-        Assert.True((words[2].Fragments[0].Attributes & CellAttributes.Bold) != 0);
-        Assert.Equal("end", words[3].Fragments[0].Text);
+        Assert.AreEqual(4, words.Count);
+        Assert.AreEqual("Hello", words[0].Fragments[0].Text);
+        Assert.AreEqual("bold", words[1].Fragments[0].Text);
+        Assert.IsTrue((words[1].Fragments[0].Attributes & CellAttributes.Bold) != 0);
+        Assert.AreEqual("world", words[2].Fragments[0].Text);
+        Assert.IsTrue((words[2].Fragments[0].Attributes & CellAttributes.Bold) != 0);
+        Assert.AreEqual("end", words[3].Fragments[0].Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void SplitIntoWords_BoldWordPlusPlainPunctuation_OneWord()
     {
         // Hello **world**!
@@ -274,16 +275,16 @@ public class MarkdownInlineRendererTests
         };
         var words = MarkdownInlineRenderer.SplitIntoWords(runs);
 
-        Assert.Equal(2, words.Count);
-        Assert.Equal("Hello", words[0].Fragments[0].Text);
+        Assert.AreEqual(2, words.Count);
+        Assert.AreEqual("Hello", words[0].Fragments[0].Text);
         // "world" + "!" grouped into one word
-        Assert.Equal(2, words[1].Fragments.Count);
-        Assert.Equal("world", words[1].Fragments[0].Text);
-        Assert.Equal("!", words[1].Fragments[1].Text);
-        Assert.Equal(6, words[1].DisplayWidth);
+        Assert.AreEqual(2, words[1].Fragments.Count);
+        Assert.AreEqual("world", words[1].Fragments[0].Text);
+        Assert.AreEqual("!", words[1].Fragments[1].Text);
+        Assert.AreEqual(6, words[1].DisplayWidth);
     }
 
-    [Fact]
+    [TestMethod]
     public void SplitIntoWords_CodeSpan_NeverSplit()
     {
         // Code spans have background color and should not be split
@@ -293,12 +294,12 @@ public class MarkdownInlineRendererTests
         };
         var words = MarkdownInlineRenderer.SplitIntoWords(runs);
 
-        var word = Assert.Single(words);
-        Assert.Equal("int x = 0", word.Fragments[0].Text);
-        Assert.Equal(9, word.DisplayWidth);
+        var word = TestSeq.Single(words);
+        Assert.AreEqual("int x = 0", word.Fragments[0].Text);
+        Assert.AreEqual(9, word.DisplayWidth);
     }
 
-    [Fact]
+    [TestMethod]
     public void SplitIntoWords_NewlineRun_CreatesNewlineWord()
     {
         var runs = new List<MarkdownTextRun>
@@ -309,25 +310,25 @@ public class MarkdownInlineRendererTests
         };
         var words = MarkdownInlineRenderer.SplitIntoWords(runs);
 
-        Assert.Equal(3, words.Count);
-        Assert.Equal("first", words[0].Fragments[0].Text);
-        Assert.Equal("\n", words[1].Fragments[0].Text);
-        Assert.Equal("second", words[2].Fragments[0].Text);
+        Assert.AreEqual(3, words.Count);
+        Assert.AreEqual("first", words[0].Fragments[0].Text);
+        Assert.AreEqual("\n", words[1].Fragments[0].Text);
+        Assert.AreEqual("second", words[2].Fragments[0].Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void SplitIntoWords_EmptyRuns_EmptyResult()
     {
         var runs = new List<MarkdownTextRun>();
         var words = MarkdownInlineRenderer.SplitIntoWords(runs);
-        Assert.Empty(words);
+        Assert.IsEmpty(words);
     }
 
     // ==========================================================================
     // WrapLines
     // ==========================================================================
 
-    [Fact]
+    [TestMethod]
     public void WrapLines_ShortText_SingleLine()
     {
         var words = new List<StyledWord>
@@ -337,12 +338,12 @@ public class MarkdownInlineRendererTests
         };
         var lines = MarkdownInlineRenderer.WrapLines(words, 20);
 
-        var line = Assert.Single(lines);
+        var line = TestSeq.Single(lines);
         Assert.Contains("Hello", line);
         Assert.Contains("world", line);
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLines_WrapsAtWordBoundary()
     {
         // "Hello world" at width 8 → "Hello" / "world"
@@ -353,12 +354,12 @@ public class MarkdownInlineRendererTests
         };
         var lines = MarkdownInlineRenderer.WrapLines(words, 8);
 
-        Assert.Equal(2, lines.Count);
+        Assert.AreEqual(2, lines.Count);
         Assert.Contains("Hello", lines[0]);
         Assert.Contains("world", lines[1]);
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLines_OversizedWord_CharacterBreaks()
     {
         // "abcdefghij" at width 4 → "abcd" / "efgh" / "ij"
@@ -368,10 +369,10 @@ public class MarkdownInlineRendererTests
         };
         var lines = MarkdownInlineRenderer.WrapLines(words, 4);
 
-        Assert.True(lines.Count >= 2);
+        Assert.IsTrue(lines.Count >= 2);
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLines_BoldText_ContainsAnsiCodes()
     {
         var words = new List<StyledWord>
@@ -380,13 +381,13 @@ public class MarkdownInlineRendererTests
         };
         var lines = MarkdownInlineRenderer.WrapLines(words, 20);
 
-        var line = Assert.Single(lines);
+        var line = TestSeq.Single(lines);
         Assert.Contains("\x1b[1m", line);  // Bold on
         Assert.Contains("bold", line);
         Assert.Contains("\x1b[0m", line);  // Reset
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLines_MultiFragmentWord_AllFragmentsRendered()
     {
         // par**tial**ly as one word
@@ -400,14 +401,14 @@ public class MarkdownInlineRendererTests
         };
         var lines = MarkdownInlineRenderer.WrapLines(words, 20);
 
-        var line = Assert.Single(lines);
+        var line = TestSeq.Single(lines);
         Assert.Contains("par", line);
         Assert.Contains("tial", line);
         Assert.Contains("ly", line);
         Assert.Contains("\x1b[1m", line); // Bold for "tial"
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLines_ExplicitNewline_ForcesLineBreak()
     {
         var words = new List<StyledWord>
@@ -418,24 +419,24 @@ public class MarkdownInlineRendererTests
         };
         var lines = MarkdownInlineRenderer.WrapLines(words, 80);
 
-        Assert.Equal(2, lines.Count);
+        Assert.AreEqual(2, lines.Count);
         Assert.Contains("first", lines[0]);
         Assert.Contains("second", lines[1]);
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLines_EmptyInput_SingleEmptyLine()
     {
         var lines = MarkdownInlineRenderer.WrapLines([], 20);
-        var line = Assert.Single(lines);
-        Assert.Equal("", line);
+        var line = TestSeq.Single(lines);
+        Assert.AreEqual("", line);
     }
 
     // ==========================================================================
     // RenderFragmentsToAnsi
     // ==========================================================================
 
-    [Fact]
+    [TestMethod]
     public void RenderFragmentsToAnsi_PlainText_NoAnsi()
     {
         var fragments = new MarkdownTextRun[]
@@ -443,10 +444,10 @@ public class MarkdownInlineRendererTests
             new("hello", null, null, CellAttributes.None)
         };
         var result = MarkdownInlineRenderer.RenderFragmentsToAnsi(fragments);
-        Assert.Equal("hello", result);
+        Assert.AreEqual("hello", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderFragmentsToAnsi_BoldText_WrappedInSgr()
     {
         var fragments = new MarkdownTextRun[]
@@ -459,7 +460,7 @@ public class MarkdownInlineRendererTests
         Assert.EndsWith("\x1b[0m", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderFragmentsToAnsi_ItalicText_WrappedInSgr()
     {
         var fragments = new MarkdownTextRun[]
@@ -471,7 +472,7 @@ public class MarkdownInlineRendererTests
         Assert.Contains("italic", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderFragmentsToAnsi_BoldAndItalic_BothCodes()
     {
         var fragments = new MarkdownTextRun[]
@@ -483,7 +484,7 @@ public class MarkdownInlineRendererTests
         Assert.Contains("\x1b[3m", result); // Italic
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderFragmentsToAnsi_ForegroundColor_EmitsRgb()
     {
         var fg = Hex1bColor.FromRgb(255, 128, 0);
@@ -495,7 +496,7 @@ public class MarkdownInlineRendererTests
         Assert.Contains("\x1b[38;2;255;128;0m", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderFragmentsToAnsi_BackgroundColor_EmitsRgb()
     {
         var bg = Hex1bColor.FromRgb(50, 50, 50);
@@ -507,7 +508,7 @@ public class MarkdownInlineRendererTests
         Assert.Contains("\x1b[48;2;50;50;50m", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderFragmentsToAnsi_AdjacentSameStyle_NoExtraResets()
     {
         var fragments = new MarkdownTextRun[]
@@ -520,7 +521,7 @@ public class MarkdownInlineRendererTests
         Assert.Contains("hello world", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderFragmentsToAnsi_StyleTransition_ResetsAndReapplies()
     {
         var fragments = new MarkdownTextRun[]
@@ -535,28 +536,28 @@ public class MarkdownInlineRendererTests
         Assert.Contains("\x1b[0m", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderFragmentsToAnsi_Empty_EmptyString()
     {
         var result = MarkdownInlineRenderer.RenderFragmentsToAnsi([]);
-        Assert.Equal("", result);
+        Assert.AreEqual("", result);
     }
 
     // ==========================================================================
     // RenderLines (full pipeline)
     // ==========================================================================
 
-    [Fact]
+    [TestMethod]
     public void RenderLines_PlainParagraph_SingleLine()
     {
         var inlines = new MarkdownInline[] { new TextInline("Hello world") };
         var lines = MarkdownInlineRenderer.RenderLines(inlines, 80);
 
-        var line = Assert.Single(lines);
-        Assert.Equal("Hello world", line);
+        var line = TestSeq.Single(lines);
+        Assert.AreEqual("Hello world", line);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderLines_BoldInParagraph_ContainsAnsi()
     {
         var inlines = new MarkdownInline[]
@@ -567,12 +568,12 @@ public class MarkdownInlineRendererTests
         };
         var lines = MarkdownInlineRenderer.RenderLines(inlines, 80);
 
-        var line = Assert.Single(lines);
+        var line = TestSeq.Single(lines);
         Assert.Contains("\x1b[1m", line);
         Assert.Contains("bold", line);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderLines_WrappingPreservesStyle()
     {
         // "Hello **bold text** end" at width 12
@@ -586,10 +587,10 @@ public class MarkdownInlineRendererTests
         };
         var lines = MarkdownInlineRenderer.RenderLines(inlines, 12);
 
-        Assert.True(lines.Count >= 2, $"Expected 2+ lines, got {lines.Count}");
+        Assert.IsTrue(lines.Count >= 2, $"Expected 2+ lines, got {lines.Count}");
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderLines_HeadingWithBaseFg_AppliesColor()
     {
         var fg = Hex1bColor.FromRgb(100, 200, 255);
@@ -597,22 +598,22 @@ public class MarkdownInlineRendererTests
         var lines = MarkdownInlineRenderer.RenderLines(
             inlines, 80, baseForeground: fg, baseAttributes: CellAttributes.Bold);
 
-        var line = Assert.Single(lines);
+        var line = TestSeq.Single(lines);
         Assert.Contains("\x1b[1m", line);  // Bold
         Assert.Contains("\x1b[38;2;100;200;255m", line);  // Heading color
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderLines_ZeroWidth_EmptyLine()
     {
         var inlines = new MarkdownInline[] { new TextInline("text") };
         var lines = MarkdownInlineRenderer.RenderLines(inlines, 0);
 
-        var line = Assert.Single(lines);
-        Assert.Equal("", line);
+        var line = TestSeq.Single(lines);
+        Assert.AreEqual("", line);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderLines_MultiWordLink_EachWordStyled()
     {
         var inlines = new MarkdownInline[]
@@ -621,13 +622,13 @@ public class MarkdownInlineRendererTests
         };
         var lines = MarkdownInlineRenderer.RenderLines(inlines, 80);
 
-        var line = Assert.Single(lines);
+        var line = TestSeq.Single(lines);
         Assert.Contains("click", line);
         Assert.Contains("here", line);
         Assert.Contains("\x1b[4m", line);  // Underline
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderLines_MultiWordLink_SpaceBetweenWordsIsUnderlined()
     {
         var inlines = new MarkdownInline[]
@@ -638,12 +639,12 @@ public class MarkdownInlineRendererTests
         var words = MarkdownInlineRenderer.SplitIntoWords(runs);
         var result = MarkdownInlineRenderer.WrapLinesWithLinks(words, 80);
 
-        var line = Assert.Single(result.Lines);
+        var line = TestSeq.Single(result.Lines);
 
         // The space between "click" and "here" should be styled as part of the link.
         // Strip all ANSI escapes (SGR and OSC 8) and verify plain text is "click here"
         var plain = System.Text.RegularExpressions.Regex.Replace(line, @"\x1b(\[[^a-zA-Z]*[a-zA-Z]|\][^\x1b]*\x1b\\)", "");
-        Assert.Equal("click here", plain);
+        Assert.AreEqual("click here", plain);
 
         // The OSC 8 hyperlink should NOT be closed and reopened between words.
         // With continuous styling, there's only one OSC 8 open + one close.
@@ -651,11 +652,11 @@ public class MarkdownInlineRendererTests
         var osc8End = "\x1b]8;;\x1b\\";
         var startCount = CountOccurrences(line, osc8Start);
         var endCount = CountOccurrences(line, osc8End);
-        Assert.Equal(1, startCount);
-        Assert.Equal(1, endCount);
+        Assert.AreEqual(1, startCount);
+        Assert.AreEqual(1, endCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLinesWithLinks_MultiWordLink_SpaceHasLinkId()
     {
         var inlines = new MarkdownInline[]
@@ -669,12 +670,12 @@ public class MarkdownInlineRendererTests
         var result = MarkdownInlineRenderer.WrapLinesWithLinks(words, 80);
 
         // The link region width should include the space (5 + 1 + 4 = 10)
-        var link = Assert.Single(result.LinkRegions);
-        Assert.Equal("click here", link.Text);
-        Assert.Equal(10, link.DisplayWidth); // "click" + space + "here"
+        var link = TestSeq.Single(result.LinkRegions);
+        Assert.AreEqual("click here", link.Text);
+        Assert.AreEqual(10, link.DisplayWidth); // "click" + space + "here"
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLinesWithLinks_MultiWordLink_FocusHighlightsSpace()
     {
         var inlines = new MarkdownInline[]
@@ -687,7 +688,7 @@ public class MarkdownInlineRendererTests
 
         // Render with focus on this link
         var result = MarkdownInlineRenderer.WrapLinesWithLinks(words, 80, focusedLinkId: linkId);
-        var line = Assert.Single(result.Lines);
+        var line = TestSeq.Single(result.Lines);
 
         // Bold is applied for focus. There should be no style gap between "click" and "here".
         // Count reset codes — if the space inherits link styling, we won't see
@@ -715,7 +716,7 @@ public class MarkdownInlineRendererTests
         return count;
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderLines_CodeSpanNotSplit()
     {
         // Code span "int x = 0" at width 6 should not split on spaces
@@ -724,15 +725,15 @@ public class MarkdownInlineRendererTests
         var words = MarkdownInlineRenderer.SplitIntoWords(runs);
 
         // Should be a single word (code spans are atomic)
-        var word = Assert.Single(words);
-        Assert.Equal("int x", word.Fragments[0].Text);
+        var word = TestSeq.Single(words);
+        Assert.AreEqual("int x", word.Fragments[0].Text);
     }
 
     // ==========================================================================
     // OSC 8 Clickable Links
     // ==========================================================================
 
-    [Fact]
+    [TestMethod]
     public void RenderFragmentsToAnsi_LinkFragment_EmitsOsc8()
     {
         var fragments = new MarkdownTextRun[]
@@ -747,7 +748,7 @@ public class MarkdownInlineRendererTests
         Assert.Contains("\x1b]8;;\x1b\\", result);  // OSC 8 end
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderFragmentsToAnsi_PlainThenLink_TransitionsOsc8()
     {
         var fragments = new MarkdownTextRun[]
@@ -765,19 +766,19 @@ public class MarkdownInlineRendererTests
         var startIdx = result.IndexOf(osc8Start);
         var endIdx = result.IndexOf(osc8End, startIdx);
 
-        Assert.True(startIdx >= 0, "OSC 8 start sequence not found");
-        Assert.True(endIdx > startIdx, "OSC 8 end sequence not found after start");
+        Assert.IsTrue(startIdx >= 0, "OSC 8 start sequence not found");
+        Assert.IsTrue(endIdx > startIdx, "OSC 8 end sequence not found after start");
 
         // "Hello" should be before OSC 8 start
         var helloIdx = result.IndexOf("Hello");
-        Assert.True(helloIdx < startIdx, "Hello should be before OSC 8 start");
+        Assert.IsTrue(helloIdx < startIdx, "Hello should be before OSC 8 start");
 
         // "world" should be after OSC 8 end
         var worldIdx = result.IndexOf("world");
-        Assert.True(worldIdx > endIdx, "world should be after OSC 8 end");
+        Assert.IsTrue(worldIdx > endIdx, "world should be after OSC 8 end");
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderFragmentsToAnsi_AdjacentLinkFragments_ShareOsc8()
     {
         // Two fragments with same URL should share the OSC 8 wrapper
@@ -798,10 +799,10 @@ public class MarkdownInlineRendererTests
             count++;
             idx += osc8Start.Length;
         }
-        Assert.Equal(1, count);
+        Assert.AreEqual(1, count);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderFragmentsToAnsi_DifferentUrls_SeparateOsc8()
     {
         var fragments = new MarkdownTextRun[]
@@ -815,7 +816,7 @@ public class MarkdownInlineRendererTests
         Assert.Contains("\x1b]8;;https://second.com\x1b\\", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderFragmentsToAnsi_NoUrl_NoOsc8()
     {
         var fragments = new MarkdownTextRun[]
@@ -827,7 +828,7 @@ public class MarkdownInlineRendererTests
         Assert.DoesNotContain("\x1b]8", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderLines_Link_ContainsOsc8()
     {
         var inlines = new MarkdownInline[]
@@ -838,13 +839,13 @@ public class MarkdownInlineRendererTests
         };
         var lines = MarkdownInlineRenderer.RenderLines(inlines, 80);
 
-        var line = Assert.Single(lines);
+        var line = TestSeq.Single(lines);
         Assert.Contains("\x1b]8;;https://example.com\x1b\\", line);
         Assert.Contains("example", line);
         Assert.Contains("\x1b]8;;\x1b\\", line);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderLines_MultiWordLink_WrappedLines_EachHasOsc8()
     {
         // "click here" at width 8 should wrap — each line should have its own OSC 8
@@ -854,7 +855,7 @@ public class MarkdownInlineRendererTests
         };
         var lines = MarkdownInlineRenderer.RenderLines(inlines, 8);
 
-        Assert.Equal(2, lines.Count);
+        Assert.AreEqual(2, lines.Count);
         // Each line should have its own OSC 8 start and end
         foreach (var line in lines)
         {
@@ -863,20 +864,20 @@ public class MarkdownInlineRendererTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void FlattenInlines_PlainText_NoUrl()
     {
         var inlines = new MarkdownInline[] { new TextInline("hello") };
         var runs = MarkdownInlineRenderer.FlattenInlines(inlines);
 
-        Assert.Null(Assert.Single(runs).Url);
+        Assert.IsNull(TestSeq.Single(runs).Url);
     }
 
     // ==========================================================================
     // HangingIndent
     // ==========================================================================
 
-    [Fact]
+    [TestMethod]
     public void WrapLinesWithLinks_HangingIndent_FirstLineFullWidth()
     {
         var runs = MarkdownInlineRenderer.FlattenInlines(
@@ -886,10 +887,10 @@ public class MarkdownInlineRendererTests
         var lines = result.Lines;
 
         // Should produce multiple lines
-        Assert.True(lines.Count >= 2, $"Expected wrapping, got {lines.Count} lines");
+        Assert.IsTrue(lines.Count >= 2, $"Expected wrapping, got {lines.Count} lines");
 
         // First line uses full width
-        Assert.True(DisplayWidth.GetStringWidth(lines[0]) <= 15);
+        Assert.IsTrue(DisplayWidth.GetStringWidth(lines[0]) <= 15);
 
         // Continuation lines have 2-char space prefix (after ANSI reset codes)
         // The raw ANSI string may have escape codes before the spaces, but
@@ -897,11 +898,11 @@ public class MarkdownInlineRendererTests
         for (int i = 1; i < lines.Count; i++)
         {
             var lineWidth = DisplayWidth.GetStringWidth(lines[i]);
-            Assert.True(lineWidth <= 15, $"Line {i} exceeds maxWidth: {lineWidth}");
+            Assert.IsTrue(lineWidth <= 15, $"Line {i} exceeds maxWidth: {lineWidth}");
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLinesWithLinks_HangingIndent_ContinuationReducedWidth()
     {
         // "1. " = 3 chars indent; maxWidth=12 → continuation lines use 9 chars
@@ -911,17 +912,17 @@ public class MarkdownInlineRendererTests
         var result = MarkdownInlineRenderer.WrapLinesWithLinks(words, 12, hangingIndent: 3);
         var lines = result.Lines;
 
-        Assert.True(lines.Count >= 2, $"Expected wrapping, got {lines.Count} lines");
+        Assert.IsTrue(lines.Count >= 2, $"Expected wrapping, got {lines.Count} lines");
 
         // Each line should not exceed maxWidth
         foreach (var line in lines)
         {
             var w = DisplayWidth.GetStringWidth(line);
-            Assert.True(w <= 12, $"Line exceeds maxWidth 12: width={w}");
+            Assert.IsTrue(w <= 12, $"Line exceeds maxWidth 12: width={w}");
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLinesWithLinks_NoHangingIndent_DefaultBehavior()
     {
         var runs = MarkdownInlineRenderer.FlattenInlines([new TextInline("one two three four")]);
@@ -930,14 +931,14 @@ public class MarkdownInlineRendererTests
         var resultDefault = MarkdownInlineRenderer.WrapLinesWithLinks(words, 10);
 
         // With hangingIndent=0, behavior should be identical to default
-        Assert.Equal(result0.Lines.Count, resultDefault.Lines.Count);
+        Assert.AreEqual(result0.Lines.Count, resultDefault.Lines.Count);
         for (int i = 0; i < result0.Lines.Count; i++)
         {
-            Assert.Equal(result0.Lines[i], resultDefault.Lines[i]);
+            Assert.AreEqual(result0.Lines[i], resultDefault.Lines[i]);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLinesWithLinks_HangingIndent_LongFirstWord_CharacterBreaks()
     {
         // "• " (2 chars) + "Accessibility" (13 chars) = 15 > maxWidth 14
@@ -950,14 +951,13 @@ public class MarkdownInlineRendererTests
 
         // First line should have the marker AND some of the word (not marker alone)
         var firstLineWidth = DisplayWidth.GetStringWidth(lines[0]);
-        Assert.True(firstLineWidth > 2,
-            $"First line should have marker + partial word, not marker alone. Width={firstLineWidth}");
+        Assert.IsTrue(firstLineWidth > 2, $"First line should have marker + partial word, not marker alone. Width={firstLineWidth}");
 
         // All lines fit within maxWidth
         foreach (var line in lines)
         {
             var w = DisplayWidth.GetStringWidth(line);
-            Assert.True(w <= 14, $"Line exceeds maxWidth: width={w}");
+            Assert.IsTrue(w <= 14, $"Line exceeds maxWidth: width={w}");
         }
     }
 
@@ -965,7 +965,7 @@ public class MarkdownInlineRendererTests
     // ContinuationPrefix
     // ==========================================================================
 
-    [Fact]
+    [TestMethod]
     public void WrapLinesWithLinks_ContinuationPrefix_AppearsOnAllWrappedLines()
     {
         // Simulate block quote: "│ " prefix on first inline, hanging indent 2, continuation prefix "│ "
@@ -976,7 +976,7 @@ public class MarkdownInlineRendererTests
             words, 15, hangingIndent: 2, continuationPrefix: "│ ");
         var lines = result.Lines;
 
-        Assert.True(lines.Count >= 2, $"Expected wrapping, got {lines.Count} lines");
+        Assert.IsTrue(lines.Count >= 2, $"Expected wrapping, got {lines.Count} lines");
 
         // Every line (including continuation) should start with "│ "
         foreach (var line in lines)
@@ -986,7 +986,7 @@ public class MarkdownInlineRendererTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLinesWithLinks_ContinuationPrefix_LinesRespectMaxWidth()
     {
         var runs = MarkdownInlineRenderer.FlattenInlines(
@@ -999,11 +999,11 @@ public class MarkdownInlineRendererTests
         foreach (var line in lines)
         {
             var w = DisplayWidth.GetStringWidth(line);
-            Assert.True(w <= 12, $"Line exceeds maxWidth 12: width={w}");
+            Assert.IsTrue(w <= 12, $"Line exceeds maxWidth 12: width={w}");
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLinesWithLinks_NoContinuationPrefix_UsesSpaces()
     {
         // Without continuation prefix, continuation lines should use spaces (existing behavior)
@@ -1014,14 +1014,14 @@ public class MarkdownInlineRendererTests
             words, 15, hangingIndent: 2, continuationPrefix: null);
         var lines = result.Lines;
 
-        Assert.True(lines.Count >= 2, $"Expected wrapping, got {lines.Count} lines");
+        Assert.IsTrue(lines.Count >= 2, $"Expected wrapping, got {lines.Count} lines");
 
         // Continuation lines should start with spaces, not "│ "
         for (int i = 1; i < lines.Count; i++)
         {
             var stripped = StripAnsi(lines[i]);
             Assert.StartsWith("  ", stripped);
-            Assert.False(stripped.StartsWith("│"), $"Line {i} should not start with │");
+            Assert.IsFalse(stripped.StartsWith("│"), $"Line {i} should not start with │");
         }
     }
 
@@ -1034,7 +1034,7 @@ public class MarkdownInlineRendererTests
     // Strikethrough
     // ==========================================================================
 
-    [Fact]
+    [TestMethod]
     public void FlattenInlines_Strikethrough_SetsStrikethroughAttribute()
     {
         var inlines = new MarkdownInline[]
@@ -1044,12 +1044,12 @@ public class MarkdownInlineRendererTests
 
         var runs = MarkdownInlineRenderer.FlattenInlines(inlines);
 
-        Assert.Single(runs);
-        Assert.Equal("deleted", runs[0].Text);
-        Assert.True(runs[0].Attributes.HasFlag(CellAttributes.Strikethrough));
+        TestSeq.Single(runs);
+        Assert.AreEqual("deleted", runs[0].Text);
+        Assert.IsTrue(runs[0].Attributes.HasFlag(CellAttributes.Strikethrough));
     }
 
-    [Fact]
+    [TestMethod]
     public void FlattenInlines_StrikethroughWithBold_CombinesAttributes()
     {
         var inlines = new MarkdownInline[]
@@ -1061,13 +1061,13 @@ public class MarkdownInlineRendererTests
 
         var runs = MarkdownInlineRenderer.FlattenInlines(inlines);
 
-        Assert.Single(runs);
-        Assert.Equal("bold+strike", runs[0].Text);
-        Assert.True(runs[0].Attributes.HasFlag(CellAttributes.Strikethrough));
-        Assert.True(runs[0].Attributes.HasFlag(CellAttributes.Bold));
+        TestSeq.Single(runs);
+        Assert.AreEqual("bold+strike", runs[0].Text);
+        Assert.IsTrue(runs[0].Attributes.HasFlag(CellAttributes.Strikethrough));
+        Assert.IsTrue(runs[0].Attributes.HasFlag(CellAttributes.Bold));
     }
 
-    [Fact]
+    [TestMethod]
     public void FlattenInlines_StrikethroughContainingLink_ExtractsLink()
     {
         var inlines = new MarkdownInline[]
@@ -1079,9 +1079,9 @@ public class MarkdownInlineRendererTests
 
         var runs = MarkdownInlineRenderer.FlattenInlines(inlines);
 
-        Assert.Single(runs);
-        Assert.Equal("click", runs[0].Text);
-        Assert.Equal("https://example.com", runs[0].Url);
-        Assert.True(runs[0].Attributes.HasFlag(CellAttributes.Underline));
+        TestSeq.Single(runs);
+        Assert.AreEqual("click", runs[0].Text);
+        Assert.AreEqual("https://example.com", runs[0].Url);
+        Assert.IsTrue(runs[0].Attributes.HasFlag(CellAttributes.Underline));
     }
 }

--- a/tests/Hex1b.Tests/MarkdownIntegrationTests.cs
+++ b/tests/Hex1b.Tests/MarkdownIntegrationTests.cs
@@ -5,9 +5,10 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class MarkdownIntegrationTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Markdown_RendersHeading()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -30,7 +31,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_RendersParagraph()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -53,7 +54,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_RendersFencedCode()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -76,7 +77,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_FencedCode_MultiLine_ShowsAllLines()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -99,7 +100,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_FencedCode_HasBorderWithLanguageTitle()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -122,7 +123,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_IndentedCode_RendersAsEditor()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -145,7 +146,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_RendersBlockQuote()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -168,7 +169,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_BlockQuoteWraps_WithBarOnEveryLine()
     {
         // Use a narrow terminal so the block quote text must wrap
@@ -201,7 +202,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_RendersList()
     {
         var source = "- Alpha\n- Beta\n- Gamma";
@@ -226,7 +227,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_RendersComplexDocument()
     {
         var source = """
@@ -268,7 +269,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_HeadingThenParagraph_HasBlankLineBetween()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -297,7 +298,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_ParagraphThenList_HasBlankLineBetween()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -327,7 +328,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_CodeBlockHasSpacingAround()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -357,7 +358,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_ImageOnlyParagraph_WithLoader_RendersKgpImage()
     {
         // Create a 2x2 red RGBA image (16 bytes)
@@ -390,7 +391,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_ImageOnlyParagraph_LoaderReturnsNull_FallsBackToText()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -415,7 +416,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_ImageInMixedParagraph_NoLoader_RendersAsInlineText()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -439,7 +440,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_ImageOnlyParagraph_NoLoader_RendersAsText()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -463,7 +464,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_ImageLoader_ReceivesCorrectUri()
     {
         Uri? capturedUri = null;
@@ -494,12 +495,12 @@ public class MarkdownIntegrationTests
 
         await runTask;
 
-        Assert.NotNull(capturedUri);
-        Assert.Equal("./images/sunset.png", capturedUri!.OriginalString);
-        Assert.Equal("Sunset", capturedAlt);
+        Assert.IsNotNull(capturedUri);
+        Assert.AreEqual("./images/sunset.png", capturedUri!.OriginalString);
+        Assert.AreEqual("Sunset", capturedAlt);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_InScrollPanel_Scrollable()
     {
         // Generate enough content to exceed viewport
@@ -526,7 +527,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_WithOnBlockHandler_OverridesHeading()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -551,7 +552,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_WithOnBlockHandler_DefaultChaining()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -579,7 +580,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_InBorder_RendersCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -606,7 +607,7 @@ public class MarkdownIntegrationTests
     // Phase 2: Styled inline rendering integration tests
     // ==========================================================================
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_BoldText_RendersBold()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -637,7 +638,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_ItalicText_RendersItalic()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -667,7 +668,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_InlineCode_HasBackground()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -696,7 +697,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_MixedInlines_AllStyled()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -737,7 +738,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_HeadingWithBold_ComposesStyles()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -770,7 +771,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_Link_HasHyperlinkData()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -805,7 +806,7 @@ public class MarkdownIntegrationTests
     // List Wrapping Tests
     // ==========================================================================
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_BulletList_WrapsWithHangingIndent()
     {
         // Terminal is 30 chars wide — "• " takes 2 chars, text wraps at 28
@@ -838,14 +839,14 @@ public class MarkdownIntegrationTests
         Assert.Contains("This", screenText);
 
         var lines = screenText.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-        Assert.True(lines.Length >= 2, $"Expected at least 2 lines for wrapped text, got {lines.Length}. Screen:\n{screenText}");
+        Assert.IsTrue(lines.Length >= 2, $"Expected at least 2 lines for wrapped text, got {lines.Length}. Screen:\n{screenText}");
 
         // Second line starts with spaces (hanging indent)
         var secondLine = lines[1];
-        Assert.True(secondLine.StartsWith("  "), $"Continuation line should be indented. Got: '{secondLine}'");
+        Assert.IsTrue(secondLine.StartsWith("  "), $"Continuation line should be indented. Got: '{secondLine}'");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_OrderedList_WrapsWithHangingIndent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -874,20 +875,20 @@ public class MarkdownIntegrationTests
         await runTask;
 
         var lines = screenText.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-        Assert.True(lines.Length >= 2, $"Expected at least 2 lines. Screen:\n{screenText}");
+        Assert.IsTrue(lines.Length >= 2, $"Expected at least 2 lines. Screen:\n{screenText}");
 
         // First line starts with "1. "
         Assert.StartsWith("1.", lines[0].TrimEnd());
 
         // Second line indented by 3 chars (length of "1. ")
-        Assert.True(lines[1].StartsWith("   "), $"Continuation should indent 3 chars. Got: '{lines[1]}'");
+        Assert.IsTrue(lines[1].StartsWith("   "), $"Continuation should indent 3 chars. Got: '{lines[1]}'");
     }
 
     // ==========================================================================
     // Focus Navigation Integration Tests
     // ==========================================================================
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_FocusableLinks_TabMovesToFirstLink()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -920,7 +921,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_FocusableLinks_TabCyclesThroughLinks()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -973,7 +974,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_FocusableLinks_EnterActivatesLink()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1009,11 +1010,11 @@ public class MarkdownIntegrationTests
 
         await runTask;
 
-        Assert.Equal("https://example.com", activatedUrl);
-        Assert.Equal("here", activatedText);
+        Assert.AreEqual("https://example.com", activatedUrl);
+        Assert.AreEqual("here", activatedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_FocusableLinks_OnLinkActivatedReceivesCorrectKind()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1047,10 +1048,10 @@ public class MarkdownIntegrationTests
 
         await runTask;
 
-        Assert.Equal(Events.MarkdownLinkKind.External, receivedKind);
+        Assert.AreEqual(Events.MarkdownLinkKind.External, receivedKind);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_NotFocusable_TabDoesNotFocusLinks()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1083,22 +1084,22 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Theory]
-    [InlineData("Getting Started", "getting-started")]
-    [InlineData("Hello World", "hello-world")]
-    [InlineData("  Spaces  Around  ", "--spaces--around--")]
-    [InlineData("ALL CAPS HEADING", "all-caps-heading")]
-    [InlineData("Special!@#Characters$%", "specialcharacters")]
-    [InlineData("hyphen-ated", "hyphen-ated")]
-    [InlineData("Mix 123 Numbers", "mix-123-numbers")]
-    [InlineData("", "")]
+    [TestMethod]
+    [DataRow("Getting Started", "getting-started")]
+    [DataRow("Hello World", "hello-world")]
+    [DataRow("  Spaces  Around  ", "--spaces--around--")]
+    [DataRow("ALL CAPS HEADING", "all-caps-heading")]
+    [DataRow("Special!@#Characters$%", "specialcharacters")]
+    [DataRow("hyphen-ated", "hyphen-ated")]
+    [DataRow("Mix 123 Numbers", "mix-123-numbers")]
+    [DataRow("", "")]
     public void GenerateSlug_ProducesGitHubStyleSlug(string input, string expected)
     {
         var slug = MarkdownWidgetRenderer.GenerateSlug(input);
-        Assert.Equal(expected, slug);
+        Assert.AreEqual(expected, slug);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_NestedList_RendersWithAlternateBullets()
     {
         var md = "- Item 1\n  - Nested A\n  - Nested B\n- Item 2";
@@ -1130,14 +1131,14 @@ public class MarkdownIntegrationTests
         await runTask;
 
         // Top-level items use "•", nested items use "◦"
-        Assert.NotNull(snapshot);
-        Assert.True(snapshot.ContainsText("•"), "Top-level bullet (•) should be present");
-        Assert.True(snapshot.ContainsText("◦"), "Nested bullet (◦) should be present");
-        Assert.True(snapshot.ContainsText("Nested A"), "Nested item A should be present");
-        Assert.True(snapshot.ContainsText("Item 2"), "Second top-level item should be present");
+        Assert.IsNotNull(snapshot);
+        Assert.IsTrue(snapshot.ContainsText("•"), "Top-level bullet (•) should be present");
+        Assert.IsTrue(snapshot.ContainsText("◦"), "Nested bullet (◦) should be present");
+        Assert.IsTrue(snapshot.ContainsText("Nested A"), "Nested item A should be present");
+        Assert.IsTrue(snapshot.ContainsText("Item 2"), "Second top-level item should be present");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_IntraDocumentLink_ScrollsToHeading()
     {
         // Build a tall document: link at top, target heading far below
@@ -1206,11 +1207,11 @@ public class MarkdownIntegrationTests
 
         await runTask;
 
-        Assert.Equal("#target-heading", activatedUrl);
-        Assert.Equal(Events.MarkdownLinkKind.IntraDocument, activatedKind);
+        Assert.AreEqual("#target-heading", activatedUrl);
+        Assert.AreEqual(Events.MarkdownLinkKind.IntraDocument, activatedKind);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_IntraDocumentLink_ScrollsToHeading_WhenAlreadyScrolled()
     {
         var lines = new List<string>
@@ -1281,7 +1282,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_FocusedLink_ArrowKeysScrollDocument()
     {
         var lines = new List<string> { "## Top", "" };
@@ -1340,7 +1341,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_Table_RendersWithGridLines()
     {
         var markdown = "| Name | Value |\n|------|-------|\n| Foo  | 42    |\n| Bar  | 99    |";
@@ -1389,7 +1390,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_AcceptsIHex1bDocument()
     {
         var doc = new Hex1bDocument("# Document Heading\n\nParagraph from document.");
@@ -1414,7 +1415,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_DocumentUpdatesReflected()
     {
         var doc = new Hex1bDocument("# Before");
@@ -1454,7 +1455,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_MouseScrollOverCodeBlock_ScrollsParentPanel()
     {
         // Build markdown with enough content to require scrolling, including a code block.
@@ -1506,7 +1507,7 @@ public class MarkdownIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Markdown_MouseScrollOverFocusableLink_ScrollsParentPanel()
     {
         var lines = new List<string>

--- a/tests/Hex1b.Tests/MarkdownLinkRegionTests.cs
+++ b/tests/Hex1b.Tests/MarkdownLinkRegionTests.cs
@@ -5,13 +5,14 @@ using Hex1b.Theming;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class MarkdownLinkRegionTests
 {
     // ==========================================================================
     // LinkRegionInfo from WrapResult
     // ==========================================================================
 
-    [Fact]
+    [TestMethod]
     public void WrapLinesWithLinks_SingleLink_ReturnsLinkRegion()
     {
         var inlines = new MarkdownInline[]
@@ -22,15 +23,15 @@ public class MarkdownLinkRegionTests
 
         var result = MarkdownInlineRenderer.RenderLinesWithLinks(inlines, 40);
 
-        var region = Assert.Single(result.LinkRegions);
-        Assert.Equal("https://example.com", region.Url);
-        Assert.Equal("example", region.Text);
-        Assert.Equal(0, region.LineIndex);
-        Assert.Equal(6, region.ColumnOffset); // "Visit " is 6 chars
-        Assert.Equal(7, region.DisplayWidth); // "example" is 7 chars
+        var region = TestSeq.Single(result.LinkRegions);
+        Assert.AreEqual("https://example.com", region.Url);
+        Assert.AreEqual("example", region.Text);
+        Assert.AreEqual(0, region.LineIndex);
+        Assert.AreEqual(6, region.ColumnOffset); // "Visit " is 6 chars
+        Assert.AreEqual(7, region.DisplayWidth); // "example" is 7 chars
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLinesWithLinks_MultipleLinks_ReturnsAllRegions()
     {
         var inlines = new MarkdownInline[]
@@ -43,20 +44,20 @@ public class MarkdownLinkRegionTests
 
         var result = MarkdownInlineRenderer.RenderLinesWithLinks(inlines, 40);
 
-        Assert.Equal(2, result.LinkRegions.Count);
+        Assert.AreEqual(2, result.LinkRegions.Count);
 
-        Assert.Equal("https://a.com", result.LinkRegions[0].Url);
-        Assert.Equal("here", result.LinkRegions[0].Text);
-        Assert.Equal(0, result.LinkRegions[0].LineIndex);
-        Assert.Equal(4, result.LinkRegions[0].ColumnOffset); // "See " is 4
+        Assert.AreEqual("https://a.com", result.LinkRegions[0].Url);
+        Assert.AreEqual("here", result.LinkRegions[0].Text);
+        Assert.AreEqual(0, result.LinkRegions[0].LineIndex);
+        Assert.AreEqual(4, result.LinkRegions[0].ColumnOffset); // "See " is 4
 
-        Assert.Equal("https://b.com", result.LinkRegions[1].Url);
-        Assert.Equal("there", result.LinkRegions[1].Text);
-        Assert.Equal(0, result.LinkRegions[1].LineIndex);
-        Assert.Equal(13, result.LinkRegions[1].ColumnOffset); // "See here and " is 13
+        Assert.AreEqual("https://b.com", result.LinkRegions[1].Url);
+        Assert.AreEqual("there", result.LinkRegions[1].Text);
+        Assert.AreEqual(0, result.LinkRegions[1].LineIndex);
+        Assert.AreEqual(13, result.LinkRegions[1].ColumnOffset); // "See here and " is 13
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLinesWithLinks_LinkAtLineStart_HasZeroOffset()
     {
         var inlines = new MarkdownInline[]
@@ -67,12 +68,12 @@ public class MarkdownLinkRegionTests
 
         var result = MarkdownInlineRenderer.RenderLinesWithLinks(inlines, 40);
 
-        var region = Assert.Single(result.LinkRegions);
-        Assert.Equal(0, region.ColumnOffset);
-        Assert.Equal(0, region.LineIndex);
+        var region = TestSeq.Single(result.LinkRegions);
+        Assert.AreEqual(0, region.ColumnOffset);
+        Assert.AreEqual(0, region.LineIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLinesWithLinks_LinkWrapsToNextLine_PositionTracked()
     {
         // "aaaa " (5) + link "click" (5) = 10, but width=8 forces wrap
@@ -84,13 +85,13 @@ public class MarkdownLinkRegionTests
 
         var result = MarkdownInlineRenderer.RenderLinesWithLinks(inlines, 8);
 
-        Assert.Equal(2, result.Lines.Count);
-        var region = Assert.Single(result.LinkRegions);
-        Assert.Equal(1, region.LineIndex); // wrapped to line 1
-        Assert.Equal(0, region.ColumnOffset); // starts at column 0 on new line
+        Assert.AreEqual(2, result.Lines.Count);
+        var region = TestSeq.Single(result.LinkRegions);
+        Assert.AreEqual(1, region.LineIndex); // wrapped to line 1
+        Assert.AreEqual(0, region.ColumnOffset); // starts at column 0 on new line
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLinesWithLinks_MultiWordLink_AllWordsTracked()
     {
         var inlines = new MarkdownInline[]
@@ -100,14 +101,14 @@ public class MarkdownLinkRegionTests
 
         var result = MarkdownInlineRenderer.RenderLinesWithLinks(inlines, 40);
 
-        var region = Assert.Single(result.LinkRegions);
-        Assert.Equal("https://example.com", region.Url);
-        Assert.Equal("click here for info", region.Text);
-        Assert.Equal(0, region.LineIndex);
-        Assert.Equal(0, region.ColumnOffset);
+        var region = TestSeq.Single(result.LinkRegions);
+        Assert.AreEqual("https://example.com", region.Url);
+        Assert.AreEqual("click here for info", region.Text);
+        Assert.AreEqual(0, region.LineIndex);
+        Assert.AreEqual(0, region.ColumnOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLinesWithLinks_NoLinks_EmptyLinkRegions()
     {
         var inlines = new MarkdownInline[]
@@ -117,10 +118,10 @@ public class MarkdownLinkRegionTests
 
         var result = MarkdownInlineRenderer.RenderLinesWithLinks(inlines, 40);
 
-        Assert.Empty(result.LinkRegions);
+        Assert.IsEmpty(result.LinkRegions);
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLinesWithLinks_ImageInline_TrackedAsLinkRegion()
     {
         var inlines = new MarkdownInline[]
@@ -131,12 +132,12 @@ public class MarkdownLinkRegionTests
 
         var result = MarkdownInlineRenderer.RenderLinesWithLinks(inlines, 40);
 
-        var region = Assert.Single(result.LinkRegions);
-        Assert.Equal("https://example.com/logo.png", region.Url);
-        Assert.Equal("[logo]", region.Text);
+        var region = TestSeq.Single(result.LinkRegions);
+        Assert.AreEqual("https://example.com/logo.png", region.Url);
+        Assert.AreEqual("[logo]", region.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLinesWithLinks_LinkIds_SequentialPerLink()
     {
         var inlines = new MarkdownInline[]
@@ -148,12 +149,12 @@ public class MarkdownLinkRegionTests
 
         var result = MarkdownInlineRenderer.RenderLinesWithLinks(inlines, 40);
 
-        Assert.Equal(2, result.LinkRegions.Count);
-        Assert.Equal(0, result.LinkRegions[0].LinkId);
-        Assert.Equal(1, result.LinkRegions[1].LinkId);
+        Assert.AreEqual(2, result.LinkRegions.Count);
+        Assert.AreEqual(0, result.LinkRegions[0].LinkId);
+        Assert.AreEqual(1, result.LinkRegions[1].LinkId);
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLinesWithLinks_SameUrlDifferentLinks_SeparateRegions()
     {
         var inlines = new MarkdownInline[]
@@ -165,16 +166,16 @@ public class MarkdownLinkRegionTests
 
         var result = MarkdownInlineRenderer.RenderLinesWithLinks(inlines, 40);
 
-        Assert.Equal(2, result.LinkRegions.Count);
+        Assert.AreEqual(2, result.LinkRegions.Count);
         // They have different LinkIds even though same URL
-        Assert.NotEqual(result.LinkRegions[0].LinkId, result.LinkRegions[1].LinkId);
+        Assert.AreNotEqual(result.LinkRegions[0].LinkId, result.LinkRegions[1].LinkId);
     }
 
     // ==========================================================================
     // Focus Highlight Rendering
     // ==========================================================================
 
-    [Fact]
+    [TestMethod]
     public void WrapLinesWithLinks_FocusedLink_ReverseVideoApplied()
     {
         var inlines = new MarkdownInline[]
@@ -189,13 +190,13 @@ public class MarkdownLinkRegionTests
         var focused = MarkdownInlineRenderer.RenderLinesWithLinks(inlines, 40, focusedLinkId: 0);
 
         // The focused version should have different ANSI codes for the link
-        Assert.NotEqual(normal.Lines[0], focused.Lines[0]);
+        Assert.AreNotEqual(normal.Lines[0], focused.Lines[0]);
         // Both should contain "example" text
         Assert.Contains("example", normal.Lines[0]);
         Assert.Contains("example", focused.Lines[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void WrapLinesWithLinks_NonFocusedLink_NormalRendering()
     {
         var inlines = new MarkdownInline[]
@@ -210,49 +211,49 @@ public class MarkdownLinkRegionTests
         var focused = MarkdownInlineRenderer.RenderLinesWithLinks(inlines, 40, focusedLinkId: 0);
 
         // Both render to one line, but the focused one has different styling for first link
-        Assert.NotEqual(normal.Lines[0], focused.Lines[0]);
+        Assert.AreNotEqual(normal.Lines[0], focused.Lines[0]);
     }
 
     // ==========================================================================
     // MarkdownLinkKind Classification
     // ==========================================================================
 
-    [Theory]
-    [InlineData("https://example.com", MarkdownLinkKind.External)]
-    [InlineData("http://example.com", MarkdownLinkKind.External)]
-    [InlineData("HTTPS://EXAMPLE.COM", MarkdownLinkKind.External)]
-    [InlineData("#heading-slug", MarkdownLinkKind.IntraDocument)]
-    [InlineData("#", MarkdownLinkKind.IntraDocument)]
-    [InlineData("mailto:user@example.com", MarkdownLinkKind.Custom)]
-    [InlineData("command:doSomething", MarkdownLinkKind.Custom)]
-    [InlineData("ftp://files.example.com", MarkdownLinkKind.Custom)]
+    [TestMethod]
+    [DataRow("https://example.com", MarkdownLinkKind.External)]
+    [DataRow("http://example.com", MarkdownLinkKind.External)]
+    [DataRow("HTTPS://EXAMPLE.COM", MarkdownLinkKind.External)]
+    [DataRow("#heading-slug", MarkdownLinkKind.IntraDocument)]
+    [DataRow("#", MarkdownLinkKind.IntraDocument)]
+    [DataRow("mailto:user@example.com", MarkdownLinkKind.Custom)]
+    [DataRow("command:doSomething", MarkdownLinkKind.Custom)]
+    [DataRow("ftp://files.example.com", MarkdownLinkKind.Custom)]
     public void ClassifyUrl_ReturnsCorrectKind(string url, MarkdownLinkKind expectedKind)
     {
         var kind = MarkdownLinkActivatedEventArgs.ClassifyUrl(url);
-        Assert.Equal(expectedKind, kind);
+        Assert.AreEqual(expectedKind, kind);
     }
 
     // ==========================================================================
     // MarkdownLinkRegionNode
     // ==========================================================================
 
-    [Fact]
+    [TestMethod]
     public void MarkdownLinkRegionNode_IsFocusable()
     {
         var node = new MarkdownLinkRegionNode();
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public void MarkdownLinkRegionNode_IsFocused_MarksDirty()
     {
         var node = new MarkdownLinkRegionNode();
 
         node.IsFocused = true;
-        Assert.True(node.IsFocused);
+        Assert.IsTrue(node.IsFocused);
     }
 
-    [Fact]
+    [TestMethod]
     public void MarkdownLinkRegionNode_Properties_StoreValues()
     {
         var node = new MarkdownLinkRegionNode
@@ -265,19 +266,19 @@ public class MarkdownLinkRegionTests
             LinkDisplayWidth = 7
         };
 
-        Assert.Equal("https://example.com", node.Url);
-        Assert.Equal("example", node.LinkText);
-        Assert.Equal(42, node.LinkId);
-        Assert.Equal(3, node.LineIndex);
-        Assert.Equal(10, node.ColumnOffset);
-        Assert.Equal(7, node.LinkDisplayWidth);
+        Assert.AreEqual("https://example.com", node.Url);
+        Assert.AreEqual("example", node.LinkText);
+        Assert.AreEqual(42, node.LinkId);
+        Assert.AreEqual(3, node.LineIndex);
+        Assert.AreEqual(10, node.ColumnOffset);
+        Assert.AreEqual(7, node.LinkDisplayWidth);
     }
 
     // ==========================================================================
     // LinkId propagation through pipeline
     // ==========================================================================
 
-    [Fact]
+    [TestMethod]
     public void FlattenInlines_Links_AssignSequentialLinkIds()
     {
         var inlines = new MarkdownInline[]
@@ -294,13 +295,13 @@ public class MarkdownLinkRegionTests
 
         // Find runs with LinkIds
         var linkRuns = runs.Where(r => r.LinkId >= 0).ToList();
-        Assert.Equal(3, linkRuns.Count);
-        Assert.Equal(0, linkRuns[0].LinkId);
-        Assert.Equal(1, linkRuns[1].LinkId);
-        Assert.Equal(2, linkRuns[2].LinkId);
+        Assert.AreEqual(3, linkRuns.Count);
+        Assert.AreEqual(0, linkRuns[0].LinkId);
+        Assert.AreEqual(1, linkRuns[1].LinkId);
+        Assert.AreEqual(2, linkRuns[2].LinkId);
     }
 
-    [Fact]
+    [TestMethod]
     public void FlattenInlines_NonLinks_HaveNegativeLinkId()
     {
         var inlines = new MarkdownInline[]
@@ -314,11 +315,11 @@ public class MarkdownLinkRegionTests
 
         foreach (var run in runs)
         {
-            Assert.Equal(-1, run.LinkId);
+            Assert.AreEqual(-1, run.LinkId);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void SplitIntoWords_LinkId_Propagated()
     {
         var runs = new List<MarkdownTextRun>
@@ -331,17 +332,17 @@ public class MarkdownLinkRegionTests
         var words = MarkdownInlineRenderer.SplitIntoWords(runs);
 
         // "Hello" (no link), "click" (link 0), "here" (link 0)
-        Assert.True(words.Count >= 3);
+        Assert.IsTrue(words.Count >= 3);
 
         var clickWord = words.First(w => w.Fragments.Any(f => f.Text == "click"));
-        Assert.Equal(0, clickWord.Fragments[0].LinkId);
-        Assert.Equal("https://example.com", clickWord.Fragments[0].Url);
+        Assert.AreEqual(0, clickWord.Fragments[0].LinkId);
+        Assert.AreEqual("https://example.com", clickWord.Fragments[0].Url);
 
         var hereWord = words.First(w => w.Fragments.Any(f => f.Text == "here"));
-        Assert.Equal(0, hereWord.Fragments[0].LinkId);
+        Assert.AreEqual(0, hereWord.Fragments[0].LinkId);
     }
 
-    [Fact]
+    [TestMethod]
     public void MarkdownTextBlockNode_GetFocusableNodes_YieldsTwoLinks()
     {
         // Arrange: create a text block node with 2 links
@@ -351,20 +352,20 @@ public class MarkdownLinkRegionTests
         // Parse inline AST from markdown
         var doc = MarkdownParser.Parse("See [first](https://a.com) and [second](https://b.com)");
         var paragraph = doc.Blocks[0] as ParagraphBlock;
-        Assert.NotNull(paragraph);
+        Assert.IsNotNull(paragraph);
         node.ReconcileLinkRegions(paragraph!.Inlines);
 
         // Act
         var focusables = node.GetFocusableNodes().ToList();
 
         // Assert
-        Assert.Equal(2, focusables.Count);
-        Assert.All(focusables, f => Assert.IsType<MarkdownLinkRegionNode>(f));
+        Assert.AreEqual(2, focusables.Count);
+        TestSeq.All(focusables, f => TestSeq.IsType<MarkdownLinkRegionNode>(f));
         var link0 = (MarkdownLinkRegionNode)focusables[0];
         var link1 = (MarkdownLinkRegionNode)focusables[1];
-        Assert.Equal("https://a.com", link0.Url);
-        Assert.Equal("https://b.com", link1.Url);
-        Assert.Equal(0, link0.LinkId);
-        Assert.Equal(1, link1.LinkId);
+        Assert.AreEqual("https://a.com", link0.Url);
+        Assert.AreEqual("https://b.com", link1.Url);
+        Assert.AreEqual(0, link0.LinkId);
+        Assert.AreEqual(1, link1.LinkId);
     }
 }

--- a/tests/Hex1b.Tests/MarkdownNodeTests.cs
+++ b/tests/Hex1b.Tests/MarkdownNodeTests.cs
@@ -5,97 +5,98 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class MarkdownNodeTests
 {
     // --- Measure ---
 
-    [Fact]
+    [TestMethod]
     public void Measure_EmptySource_ReturnsZeroSize()
     {
         var node = new MarkdownNode { Source = "" };
         node.BuildWidgetTree(); // Trigger parse
         var size = node.Measure(new Constraints(0, 80, 0, 24));
-        Assert.Equal(0, size.Height);
+        Assert.AreEqual(0, size.Height);
     }
 
     // --- Default Renderers ---
 
-    [Fact]
+    [TestMethod]
     public void BuildWidgetTree_Heading_ProducesVStackWithTextBlock()
     {
         var node = new MarkdownNode { Source = "# Hello" };
         var widget = node.BuildWidgetTree();
 
-        var vstack = Assert.IsType<VStackWidget>(widget);
-        Assert.Single(vstack.Children);
+        var vstack = TestSeq.IsType<VStackWidget>(widget);
+        TestSeq.Single(vstack.Children);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildWidgetTree_Paragraph_ProducesMarkdownTextBlock()
     {
         var node = new MarkdownNode { Source = "Hello world" };
         var widget = node.BuildWidgetTree();
 
-        var vstack = Assert.IsType<VStackWidget>(widget);
-        var mdTextBlock = Assert.IsType<MarkdownTextBlockWidget>(Assert.Single(vstack.Children));
+        var vstack = TestSeq.IsType<VStackWidget>(widget);
+        var mdTextBlock = TestSeq.IsType<MarkdownTextBlockWidget>(TestSeq.Single(vstack.Children));
         // Verify the inlines contain the text
-        var textInline = Assert.IsType<TextInline>(Assert.Single(mdTextBlock.Inlines));
-        Assert.Equal("Hello world", textInline.Text);
+        var textInline = TestSeq.IsType<TextInline>(TestSeq.Single(mdTextBlock.Inlines));
+        Assert.AreEqual("Hello world", textInline.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildWidgetTree_FencedCode_ProducesBorder()
     {
         var node = new MarkdownNode { Source = "```\ncode\n```" };
         var widget = node.BuildWidgetTree();
 
-        var vstack = Assert.IsType<VStackWidget>(widget);
-        Assert.IsType<BorderWidget>(Assert.Single(vstack.Children));
+        var vstack = TestSeq.IsType<VStackWidget>(widget);
+        TestSeq.IsType<BorderWidget>(TestSeq.Single(vstack.Children));
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildWidgetTree_BlockQuote_ProducesMarkdownTextBlock()
     {
         var node = new MarkdownNode { Source = "> Quote text" };
         var widget = node.BuildWidgetTree();
 
-        var vstack = Assert.IsType<VStackWidget>(widget);
-        Assert.IsType<MarkdownTextBlockWidget>(Assert.Single(vstack.Children));
+        var vstack = TestSeq.IsType<VStackWidget>(widget);
+        TestSeq.IsType<MarkdownTextBlockWidget>(TestSeq.Single(vstack.Children));
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildWidgetTree_UnorderedList_ProducesNestedVStack()
     {
         var node = new MarkdownNode { Source = "- Item 1\n- Item 2" };
         var widget = node.BuildWidgetTree();
 
-        var vstack = Assert.IsType<VStackWidget>(widget);
-        var listStack = Assert.IsType<VStackWidget>(Assert.Single(vstack.Children));
-        Assert.Equal(2, listStack.Children.Count);
+        var vstack = TestSeq.IsType<VStackWidget>(widget);
+        var listStack = TestSeq.IsType<VStackWidget>(TestSeq.Single(vstack.Children));
+        Assert.AreEqual(2, listStack.Children.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildWidgetTree_ThematicBreak_ProducesSeparator()
     {
         var node = new MarkdownNode { Source = "---" };
         var widget = node.BuildWidgetTree();
 
-        var vstack = Assert.IsType<VStackWidget>(widget);
-        Assert.IsType<SeparatorWidget>(Assert.Single(vstack.Children));
+        var vstack = TestSeq.IsType<VStackWidget>(widget);
+        TestSeq.IsType<SeparatorWidget>(TestSeq.Single(vstack.Children));
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildWidgetTree_EmptySource_ProducesEmptyTextBlock()
     {
         var node = new MarkdownNode { Source = "" };
         var widget = node.BuildWidgetTree();
 
-        Assert.IsType<TextBlockWidget>(widget);
+        TestSeq.IsType<TextBlockWidget>(widget);
     }
 
     // --- Caching ---
 
-    [Fact]
+    [TestMethod]
     public void BuildWidgetTree_SameSource_DoesNotReparse()
     {
         var node = new MarkdownNode { Source = "# Hello" };
@@ -103,28 +104,28 @@ public class MarkdownNodeTests
         var widget2 = node.BuildWidgetTree();
 
         // Both should produce structurally equivalent widgets
-        Assert.IsType<VStackWidget>(widget1);
-        Assert.IsType<VStackWidget>(widget2);
+        TestSeq.IsType<VStackWidget>(widget1);
+        TestSeq.IsType<VStackWidget>(widget2);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildWidgetTree_ChangedSource_Reparses()
     {
         var node = new MarkdownNode { Source = "# Hello" };
         var widget1 = node.BuildWidgetTree();
-        Assert.IsType<VStackWidget>(widget1);
+        TestSeq.IsType<VStackWidget>(widget1);
 
         node.Source = "New paragraph";
         var widget2 = node.BuildWidgetTree();
-        var vstack = Assert.IsType<VStackWidget>(widget2);
-        var mdTextBlock = Assert.IsType<MarkdownTextBlockWidget>(Assert.Single(vstack.Children));
-        var textInline = Assert.IsType<TextInline>(Assert.Single(mdTextBlock.Inlines));
-        Assert.Equal("New paragraph", textInline.Text);
+        var vstack = TestSeq.IsType<VStackWidget>(widget2);
+        var mdTextBlock = TestSeq.IsType<MarkdownTextBlockWidget>(TestSeq.Single(vstack.Children));
+        var textInline = TestSeq.IsType<TextInline>(TestSeq.Single(mdTextBlock.Inlines));
+        Assert.AreEqual("New paragraph", textInline.Text);
     }
 
     // --- OnBlock Handler ---
 
-    [Fact]
+    [TestMethod]
     public void BuildWidgetTree_WithOnBlockHandler_OverridesDefault()
     {
         var node = new MarkdownNode { Source = "# Hello" };
@@ -134,12 +135,12 @@ public class MarkdownNodeTests
                  (ctx, block) => new TextBlockWidget($"CUSTOM: {block.Text}"))));
 
         var widget = node.BuildWidgetTree();
-        var vstack = Assert.IsType<VStackWidget>(widget);
-        var text = Assert.IsType<TextBlockWidget>(Assert.Single(vstack.Children));
-        Assert.Equal("CUSTOM: Hello", text.Text);
+        var vstack = TestSeq.IsType<VStackWidget>(widget);
+        var text = TestSeq.IsType<TextBlockWidget>(TestSeq.Single(vstack.Children));
+        Assert.AreEqual("CUSTOM: Hello", text.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildWidgetTree_WithOnBlockHandler_DefaultChaining()
     {
         var node = new MarkdownNode { Source = "# Hello" };
@@ -159,18 +160,18 @@ public class MarkdownNodeTests
                  })));
 
         var widget = node.BuildWidgetTree();
-        var outerVStack = Assert.IsType<VStackWidget>(widget);
-        var wrappedVStack = Assert.IsType<VStackWidget>(Assert.Single(outerVStack.Children));
-        Assert.Equal(3, wrappedVStack.Children.Count);
+        var outerVStack = TestSeq.IsType<VStackWidget>(widget);
+        var wrappedVStack = TestSeq.IsType<VStackWidget>(TestSeq.Single(outerVStack.Children));
+        Assert.AreEqual(3, wrappedVStack.Children.Count);
 
-        var before = Assert.IsType<TextBlockWidget>(wrappedVStack.Children[0]);
-        Assert.Equal("BEFORE", before.Text);
+        var before = TestSeq.IsType<TextBlockWidget>(wrappedVStack.Children[0]);
+        Assert.AreEqual("BEFORE", before.Text);
 
-        var after = Assert.IsType<TextBlockWidget>(wrappedVStack.Children[2]);
-        Assert.Equal("AFTER", after.Text);
+        var after = TestSeq.IsType<TextBlockWidget>(wrappedVStack.Children[2]);
+        Assert.AreEqual("AFTER", after.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildWidgetTree_MultipleHandlers_LastRegisteredCalledFirst()
     {
         var node = new MarkdownNode { Source = "# Hello" };
@@ -198,36 +199,36 @@ public class MarkdownNodeTests
 
         node.BuildWidgetTree();
 
-        Assert.Equal(["B", "A"], callOrder);
+        TestSeq.AreEqual(["B", "A"], callOrder);
     }
 
     // --- Widget Record ---
 
-    [Fact]
+    [TestMethod]
     public void MarkdownWidget_OnBlock_ReturnsNewInstance()
     {
         var widget = new MarkdownWidget("# Hello");
         var modified = widget.OnBlock<HeadingBlock>((ctx, block) =>
             new TextBlockWidget("custom"));
 
-        Assert.NotSame(widget, modified);
-        Assert.Empty(widget.BlockHandlers);
-        Assert.Single(modified.BlockHandlers);
+        Assert.AreNotSame(widget, modified);
+        Assert.IsEmpty(widget.BlockHandlers);
+        TestSeq.Single(modified.BlockHandlers);
     }
 
-    [Fact]
+    [TestMethod]
     public void MarkdownWidget_OnBlock_ChainMultipleTypes()
     {
         var widget = new MarkdownWidget("# Hello")
             .OnBlock<HeadingBlock>((ctx, block) => new TextBlockWidget("h"))
             .OnBlock<ParagraphBlock>((ctx, block) => new TextBlockWidget("p"));
 
-        Assert.Equal(2, widget.BlockHandlers.Count);
+        Assert.AreEqual(2, widget.BlockHandlers.Count);
     }
 
     // --- Complex Documents ---
 
-    [Fact]
+    [TestMethod]
     public void BuildWidgetTree_ComplexDocument_ProducesCorrectStructure()
     {
         var source = """
@@ -250,7 +251,7 @@ public class MarkdownNodeTests
         var node = new MarkdownNode { Source = source };
         var widget = node.BuildWidgetTree();
 
-        var vstack = Assert.IsType<VStackWidget>(widget);
-        Assert.True(vstack.Children.Count >= 6, $"Expected ≥6 children, got {vstack.Children.Count}");
+        var vstack = TestSeq.IsType<VStackWidget>(widget);
+        Assert.IsTrue(vstack.Children.Count >= 6, $"Expected ≥6 children, got {vstack.Children.Count}");
     }
 }

--- a/tests/Hex1b.Tests/MarkdownParserTests.cs
+++ b/tests/Hex1b.Tests/MarkdownParserTests.cs
@@ -2,354 +2,355 @@ using Hex1b.Markdown;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class MarkdownParserTests
 {
     // --- Empty / minimal input ---
 
-    [Fact]
+    [TestMethod]
     public void Parse_EmptyString_ReturnsEmptyDocument()
     {
         var doc = MarkdownParser.Parse("");
-        Assert.Empty(doc.Blocks);
+        Assert.IsEmpty(doc.Blocks);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_NullString_ReturnsEmptyDocument()
     {
         var doc = MarkdownParser.Parse((string)null!);
-        Assert.Empty(doc.Blocks);
+        Assert.IsEmpty(doc.Blocks);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_BlankLines_ReturnsEmptyDocument()
     {
         var doc = MarkdownParser.Parse("\n\n\n");
-        Assert.Empty(doc.Blocks);
+        Assert.IsEmpty(doc.Blocks);
     }
 
     // --- Headings ---
 
-    [Theory]
-    [InlineData("# H1", 1, "H1")]
-    [InlineData("## H2", 2, "H2")]
-    [InlineData("### H3", 3, "H3")]
-    [InlineData("#### H4", 4, "H4")]
-    [InlineData("##### H5", 5, "H5")]
-    [InlineData("###### H6", 6, "H6")]
+    [TestMethod]
+    [DataRow("# H1", 1, "H1")]
+    [DataRow("## H2", 2, "H2")]
+    [DataRow("### H3", 3, "H3")]
+    [DataRow("#### H4", 4, "H4")]
+    [DataRow("##### H5", 5, "H5")]
+    [DataRow("###### H6", 6, "H6")]
     public void Parse_Heading_ReturnsCorrectLevel(string input, int expectedLevel, string expectedText)
     {
         var doc = MarkdownParser.Parse(input);
 
-        var heading = Assert.Single(doc.Blocks);
-        var h = Assert.IsType<HeadingBlock>(heading);
-        Assert.Equal(expectedLevel, h.Level);
-        Assert.Equal(expectedText, h.Text);
+        var heading = TestSeq.Single(doc.Blocks);
+        var h = TestSeq.IsType<HeadingBlock>(heading);
+        Assert.AreEqual(expectedLevel, h.Level);
+        Assert.AreEqual(expectedText, h.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_HeadingWithClosingHashes_StripsTrailingHashes()
     {
         var doc = MarkdownParser.Parse("## Hello ##");
-        var h = Assert.IsType<HeadingBlock>(Assert.Single(doc.Blocks));
-        Assert.Equal("Hello", h.Text);
+        var h = TestSeq.IsType<HeadingBlock>(TestSeq.Single(doc.Blocks));
+        Assert.AreEqual("Hello", h.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_HeadingNoSpace_NotAHeading()
     {
         var doc = MarkdownParser.Parse("#NotAHeading");
-        var block = Assert.Single(doc.Blocks);
-        Assert.IsType<ParagraphBlock>(block);
+        var block = TestSeq.Single(doc.Blocks);
+        TestSeq.IsType<ParagraphBlock>(block);
     }
 
     // --- Paragraphs ---
 
-    [Fact]
+    [TestMethod]
     public void Parse_SimpleParagraph_ReturnsParagraphBlock()
     {
         var doc = MarkdownParser.Parse("Hello world");
-        var p = Assert.IsType<ParagraphBlock>(Assert.Single(doc.Blocks));
-        Assert.Equal("Hello world", p.Text);
+        var p = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(doc.Blocks));
+        Assert.AreEqual("Hello world", p.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_MultiLineParagraph_JoinsLines()
     {
         var doc = MarkdownParser.Parse("Line one\nLine two");
-        var p = Assert.IsType<ParagraphBlock>(Assert.Single(doc.Blocks));
-        Assert.Equal("Line one Line two", p.Text);
+        var p = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(doc.Blocks));
+        Assert.AreEqual("Line one Line two", p.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_TwoParagraphs_SeparatedByBlankLine()
     {
         var doc = MarkdownParser.Parse("First para\n\nSecond para");
-        Assert.Equal(2, doc.Blocks.Count);
-        Assert.IsType<ParagraphBlock>(doc.Blocks[0]);
-        Assert.IsType<ParagraphBlock>(doc.Blocks[1]);
+        Assert.AreEqual(2, doc.Blocks.Count);
+        TestSeq.IsType<ParagraphBlock>(doc.Blocks[0]);
+        TestSeq.IsType<ParagraphBlock>(doc.Blocks[1]);
     }
 
     // --- Fenced Code Blocks ---
 
-    [Fact]
+    [TestMethod]
     public void Parse_FencedCodeBlock_Backticks()
     {
         var input = "```\ncode here\n```";
         var doc = MarkdownParser.Parse(input);
-        var code = Assert.IsType<FencedCodeBlock>(Assert.Single(doc.Blocks));
-        Assert.Equal("", code.Language);
-        Assert.Equal("code here", code.Content);
+        var code = TestSeq.IsType<FencedCodeBlock>(TestSeq.Single(doc.Blocks));
+        Assert.AreEqual("", code.Language);
+        Assert.AreEqual("code here", code.Content);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_FencedCodeBlock_WithLanguage()
     {
         var input = "```csharp\nvar x = 1;\n```";
         var doc = MarkdownParser.Parse(input);
-        var code = Assert.IsType<FencedCodeBlock>(Assert.Single(doc.Blocks));
-        Assert.Equal("csharp", code.Language);
-        Assert.Equal("var x = 1;", code.Content);
+        var code = TestSeq.IsType<FencedCodeBlock>(TestSeq.Single(doc.Blocks));
+        Assert.AreEqual("csharp", code.Language);
+        Assert.AreEqual("var x = 1;", code.Content);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_FencedCodeBlock_Tildes()
     {
         var input = "~~~\ncode\n~~~";
         var doc = MarkdownParser.Parse(input);
-        var code = Assert.IsType<FencedCodeBlock>(Assert.Single(doc.Blocks));
-        Assert.Equal("code", code.Content);
+        var code = TestSeq.IsType<FencedCodeBlock>(TestSeq.Single(doc.Blocks));
+        Assert.AreEqual("code", code.Content);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_FencedCodeBlock_MultipleLines()
     {
         var input = "```\nline 1\nline 2\nline 3\n```";
         var doc = MarkdownParser.Parse(input);
-        var code = Assert.IsType<FencedCodeBlock>(Assert.Single(doc.Blocks));
-        Assert.Equal("line 1\nline 2\nline 3", code.Content);
+        var code = TestSeq.IsType<FencedCodeBlock>(TestSeq.Single(doc.Blocks));
+        Assert.AreEqual("line 1\nline 2\nline 3", code.Content);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_FencedCodeBlock_UnclosedTreatsRestAsCode()
     {
         var input = "```\ncode\nmore code";
         var doc = MarkdownParser.Parse(input);
-        var code = Assert.IsType<FencedCodeBlock>(Assert.Single(doc.Blocks));
-        Assert.Equal("code\nmore code", code.Content);
+        var code = TestSeq.IsType<FencedCodeBlock>(TestSeq.Single(doc.Blocks));
+        Assert.AreEqual("code\nmore code", code.Content);
     }
 
     // --- Indented Code Blocks ---
 
-    [Fact]
+    [TestMethod]
     public void Parse_IndentedCodeBlock_FourSpaces()
     {
         var input = "    code line";
         var doc = MarkdownParser.Parse(input);
-        var code = Assert.IsType<IndentedCodeBlock>(Assert.Single(doc.Blocks));
-        Assert.Equal("code line", code.Content);
+        var code = TestSeq.IsType<IndentedCodeBlock>(TestSeq.Single(doc.Blocks));
+        Assert.AreEqual("code line", code.Content);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_IndentedCodeBlock_MultipleLines()
     {
         var input = "    line 1\n    line 2";
         var doc = MarkdownParser.Parse(input);
-        var code = Assert.IsType<IndentedCodeBlock>(Assert.Single(doc.Blocks));
-        Assert.Equal("line 1\nline 2", code.Content);
+        var code = TestSeq.IsType<IndentedCodeBlock>(TestSeq.Single(doc.Blocks));
+        Assert.AreEqual("line 1\nline 2", code.Content);
     }
 
     // --- Block Quotes ---
 
-    [Fact]
+    [TestMethod]
     public void Parse_BlockQuote_Simple()
     {
         var input = "> Hello";
         var doc = MarkdownParser.Parse(input);
-        var bq = Assert.IsType<BlockQuoteBlock>(Assert.Single(doc.Blocks));
-        var p = Assert.IsType<ParagraphBlock>(Assert.Single(bq.Children));
-        Assert.Equal("Hello", p.Text);
+        var bq = TestSeq.IsType<BlockQuoteBlock>(TestSeq.Single(doc.Blocks));
+        var p = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(bq.Children));
+        Assert.AreEqual("Hello", p.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_BlockQuote_MultipleLines()
     {
         var input = "> Line 1\n> Line 2";
         var doc = MarkdownParser.Parse(input);
-        var bq = Assert.IsType<BlockQuoteBlock>(Assert.Single(doc.Blocks));
-        var p = Assert.IsType<ParagraphBlock>(Assert.Single(bq.Children));
-        Assert.Equal("Line 1 Line 2", p.Text);
+        var bq = TestSeq.IsType<BlockQuoteBlock>(TestSeq.Single(doc.Blocks));
+        var p = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(bq.Children));
+        Assert.AreEqual("Line 1 Line 2", p.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_BlockQuote_Nested()
     {
         var input = "> > Nested";
         var doc = MarkdownParser.Parse(input);
-        var outer = Assert.IsType<BlockQuoteBlock>(Assert.Single(doc.Blocks));
-        var inner = Assert.IsType<BlockQuoteBlock>(Assert.Single(outer.Children));
-        var p = Assert.IsType<ParagraphBlock>(Assert.Single(inner.Children));
-        Assert.Equal("Nested", p.Text);
+        var outer = TestSeq.IsType<BlockQuoteBlock>(TestSeq.Single(doc.Blocks));
+        var inner = TestSeq.IsType<BlockQuoteBlock>(TestSeq.Single(outer.Children));
+        var p = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(inner.Children));
+        Assert.AreEqual("Nested", p.Text);
     }
 
     // --- Unordered Lists ---
 
-    [Fact]
+    [TestMethod]
     public void Parse_UnorderedList_Dashes()
     {
         var input = "- Item 1\n- Item 2\n- Item 3";
         var doc = MarkdownParser.Parse(input);
-        var list = Assert.IsType<ListBlock>(Assert.Single(doc.Blocks));
-        Assert.False(list.IsOrdered);
-        Assert.Equal(3, list.Items.Count);
+        var list = TestSeq.IsType<ListBlock>(TestSeq.Single(doc.Blocks));
+        Assert.IsFalse(list.IsOrdered);
+        Assert.AreEqual(3, list.Items.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_UnorderedList_Asterisks()
     {
         var input = "* Item 1\n* Item 2";
         var doc = MarkdownParser.Parse(input);
-        var list = Assert.IsType<ListBlock>(Assert.Single(doc.Blocks));
-        Assert.False(list.IsOrdered);
-        Assert.Equal(2, list.Items.Count);
+        var list = TestSeq.IsType<ListBlock>(TestSeq.Single(doc.Blocks));
+        Assert.IsFalse(list.IsOrdered);
+        Assert.AreEqual(2, list.Items.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_UnorderedList_ItemContent()
     {
         var input = "- Hello world";
         var doc = MarkdownParser.Parse(input);
-        var list = Assert.IsType<ListBlock>(Assert.Single(doc.Blocks));
-        var item = Assert.Single(list.Items);
-        var p = Assert.IsType<ParagraphBlock>(Assert.Single(item.Children));
-        Assert.Equal("Hello world", p.Text);
+        var list = TestSeq.IsType<ListBlock>(TestSeq.Single(doc.Blocks));
+        var item = TestSeq.Single(list.Items);
+        var p = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(item.Children));
+        Assert.AreEqual("Hello world", p.Text);
     }
 
     // --- Ordered Lists ---
 
-    [Fact]
+    [TestMethod]
     public void Parse_OrderedList()
     {
         var input = "1. First\n2. Second\n3. Third";
         var doc = MarkdownParser.Parse(input);
-        var list = Assert.IsType<ListBlock>(Assert.Single(doc.Blocks));
-        Assert.True(list.IsOrdered);
-        Assert.Equal(1, list.StartNumber);
-        Assert.Equal(3, list.Items.Count);
+        var list = TestSeq.IsType<ListBlock>(TestSeq.Single(doc.Blocks));
+        Assert.IsTrue(list.IsOrdered);
+        Assert.AreEqual(1, list.StartNumber);
+        Assert.AreEqual(3, list.Items.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_OrderedList_CustomStartNumber()
     {
         var input = "3. Third\n4. Fourth";
         var doc = MarkdownParser.Parse(input);
-        var list = Assert.IsType<ListBlock>(Assert.Single(doc.Blocks));
-        Assert.True(list.IsOrdered);
-        Assert.Equal(3, list.StartNumber);
+        var list = TestSeq.IsType<ListBlock>(TestSeq.Single(doc.Blocks));
+        Assert.IsTrue(list.IsOrdered);
+        Assert.AreEqual(3, list.StartNumber);
     }
 
     // --- Thematic Breaks ---
 
-    [Theory]
-    [InlineData("---")]
-    [InlineData("***")]
-    [InlineData("___")]
-    [InlineData("- - -")]
-    [InlineData("* * *")]
-    [InlineData("____")]
+    [TestMethod]
+    [DataRow("---")]
+    [DataRow("***")]
+    [DataRow("___")]
+    [DataRow("- - -")]
+    [DataRow("* * *")]
+    [DataRow("____")]
     public void Parse_ThematicBreak(string input)
     {
         var doc = MarkdownParser.Parse(input);
-        Assert.IsType<ThematicBreakBlock>(Assert.Single(doc.Blocks));
+        TestSeq.IsType<ThematicBreakBlock>(TestSeq.Single(doc.Blocks));
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ThematicBreak_TwoCharsNotEnough()
     {
         var doc = MarkdownParser.Parse("--");
-        Assert.IsNotType<ThematicBreakBlock>(Assert.Single(doc.Blocks));
+        Assert.IsNotInstanceOfType<ThematicBreakBlock>(TestSeq.Single(doc.Blocks));
     }
 
     // --- Inline Parsing ---
 
-    [Fact]
+    [TestMethod]
     public void ParseInlines_PlainText()
     {
         var inlines = MarkdownParser.ParseInlines("Hello world");
-        var text = Assert.IsType<TextInline>(Assert.Single(inlines));
-        Assert.Equal("Hello world", text.Text);
+        var text = TestSeq.IsType<TextInline>(TestSeq.Single(inlines));
+        Assert.AreEqual("Hello world", text.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void ParseInlines_Bold()
     {
         var inlines = MarkdownParser.ParseInlines("**bold**");
-        var em = Assert.IsType<EmphasisInline>(Assert.Single(inlines));
-        Assert.True(em.IsStrong);
-        var text = Assert.IsType<TextInline>(Assert.Single(em.Children));
-        Assert.Equal("bold", text.Text);
+        var em = TestSeq.IsType<EmphasisInline>(TestSeq.Single(inlines));
+        Assert.IsTrue(em.IsStrong);
+        var text = TestSeq.IsType<TextInline>(TestSeq.Single(em.Children));
+        Assert.AreEqual("bold", text.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void ParseInlines_Italic()
     {
         var inlines = MarkdownParser.ParseInlines("*italic*");
-        var em = Assert.IsType<EmphasisInline>(Assert.Single(inlines));
-        Assert.False(em.IsStrong);
-        var text = Assert.IsType<TextInline>(Assert.Single(em.Children));
-        Assert.Equal("italic", text.Text);
+        var em = TestSeq.IsType<EmphasisInline>(TestSeq.Single(inlines));
+        Assert.IsFalse(em.IsStrong);
+        var text = TestSeq.IsType<TextInline>(TestSeq.Single(em.Children));
+        Assert.AreEqual("italic", text.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void ParseInlines_CodeSpan()
     {
         var inlines = MarkdownParser.ParseInlines("`code`");
-        var code = Assert.IsType<CodeInline>(Assert.Single(inlines));
-        Assert.Equal("code", code.Code);
+        var code = TestSeq.IsType<CodeInline>(TestSeq.Single(inlines));
+        Assert.AreEqual("code", code.Code);
     }
 
-    [Fact]
+    [TestMethod]
     public void ParseInlines_Link()
     {
         var inlines = MarkdownParser.ParseInlines("[click](https://example.com)");
-        var link = Assert.IsType<LinkInline>(Assert.Single(inlines));
-        Assert.Equal("click", link.Text);
-        Assert.Equal("https://example.com", link.Url);
+        var link = TestSeq.IsType<LinkInline>(TestSeq.Single(inlines));
+        Assert.AreEqual("click", link.Text);
+        Assert.AreEqual("https://example.com", link.Url);
     }
 
-    [Fact]
+    [TestMethod]
     public void ParseInlines_LinkWithTitle()
     {
         var inlines = MarkdownParser.ParseInlines("[click](https://example.com \"Title\")");
-        var link = Assert.IsType<LinkInline>(Assert.Single(inlines));
-        Assert.Equal("click", link.Text);
-        Assert.Equal("https://example.com", link.Url);
-        Assert.Equal("Title", link.Title);
+        var link = TestSeq.IsType<LinkInline>(TestSeq.Single(inlines));
+        Assert.AreEqual("click", link.Text);
+        Assert.AreEqual("https://example.com", link.Url);
+        Assert.AreEqual("Title", link.Title);
     }
 
-    [Fact]
+    [TestMethod]
     public void ParseInlines_Image()
     {
         var inlines = MarkdownParser.ParseInlines("![alt text](image.png)");
-        var image = Assert.IsType<ImageInline>(Assert.Single(inlines));
-        Assert.Equal("alt text", image.AltText);
-        Assert.Equal("image.png", image.Url);
+        var image = TestSeq.IsType<ImageInline>(TestSeq.Single(inlines));
+        Assert.AreEqual("alt text", image.AltText);
+        Assert.AreEqual("image.png", image.Url);
     }
 
-    [Fact]
+    [TestMethod]
     public void ParseInlines_MixedContent()
     {
         var inlines = MarkdownParser.ParseInlines("Hello **bold** and `code` here");
-        Assert.Equal(5, inlines.Count);
-        Assert.IsType<TextInline>(inlines[0]);
-        Assert.IsType<EmphasisInline>(inlines[1]);
-        Assert.IsType<TextInline>(inlines[2]);
-        Assert.IsType<CodeInline>(inlines[3]);
-        Assert.IsType<TextInline>(inlines[4]);
+        Assert.AreEqual(5, inlines.Count);
+        TestSeq.IsType<TextInline>(inlines[0]);
+        TestSeq.IsType<EmphasisInline>(inlines[1]);
+        TestSeq.IsType<TextInline>(inlines[2]);
+        TestSeq.IsType<CodeInline>(inlines[3]);
+        TestSeq.IsType<TextInline>(inlines[4]);
     }
 
     // --- Complex documents ---
 
-    [Fact]
+    [TestMethod]
     public void Parse_MixedDocument_AllBlockTypes()
     {
         var input = """
@@ -377,28 +378,28 @@ public class MarkdownParserTests
         var doc = MarkdownParser.Parse(input);
 
         // Verify we got all expected block types
-        Assert.IsType<HeadingBlock>(doc.Blocks[0]);
-        Assert.IsType<ParagraphBlock>(doc.Blocks[1]);
-        Assert.IsType<FencedCodeBlock>(doc.Blocks[2]);
-        Assert.IsType<BlockQuoteBlock>(doc.Blocks[3]);
-        Assert.IsType<ListBlock>(doc.Blocks[4]);
-        Assert.IsType<ListBlock>(doc.Blocks[5]);
-        Assert.IsType<ThematicBreakBlock>(doc.Blocks[6]);
-        Assert.IsType<ParagraphBlock>(doc.Blocks[7]);
+        TestSeq.IsType<HeadingBlock>(doc.Blocks[0]);
+        TestSeq.IsType<ParagraphBlock>(doc.Blocks[1]);
+        TestSeq.IsType<FencedCodeBlock>(doc.Blocks[2]);
+        TestSeq.IsType<BlockQuoteBlock>(doc.Blocks[3]);
+        TestSeq.IsType<ListBlock>(doc.Blocks[4]);
+        TestSeq.IsType<ListBlock>(doc.Blocks[5]);
+        TestSeq.IsType<ThematicBreakBlock>(doc.Blocks[6]);
+        TestSeq.IsType<ParagraphBlock>(doc.Blocks[7]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_BlockQuoteWithCode_NestedCorrectly()
     {
         var input = "> ```\n> code\n> ```";
         var doc = MarkdownParser.Parse(input);
-        var bq = Assert.IsType<BlockQuoteBlock>(Assert.Single(doc.Blocks));
-        Assert.IsType<FencedCodeBlock>(Assert.Single(bq.Children));
+        var bq = TestSeq.IsType<BlockQuoteBlock>(TestSeq.Single(doc.Blocks));
+        TestSeq.IsType<FencedCodeBlock>(TestSeq.Single(bq.Children));
     }
 
     // --- ReadOnlyMemory overload ---
 
-    [Fact]
+    [TestMethod]
     public void Parse_ReadOnlyMemory_ProducesEquivalentResult()
     {
         var source = "# Hello\n\nWorld";
@@ -407,392 +408,391 @@ public class MarkdownParserTests
         var docFromString = MarkdownParser.Parse(source);
         var docFromMemory = MarkdownParser.Parse(memory);
 
-        Assert.Equal(docFromString.Blocks.Count, docFromMemory.Blocks.Count);
+        Assert.AreEqual(docFromString.Blocks.Count, docFromMemory.Blocks.Count);
     }
 
     // --- Edge cases ---
 
-    [Fact]
+    [TestMethod]
     public void Parse_NoTrailingNewline_HandledCorrectly()
     {
         var doc = MarkdownParser.Parse("# Hello");
-        var h = Assert.IsType<HeadingBlock>(Assert.Single(doc.Blocks));
-        Assert.Equal("Hello", h.Text);
+        var h = TestSeq.IsType<HeadingBlock>(TestSeq.Single(doc.Blocks));
+        Assert.AreEqual("Hello", h.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_OnlyWhitespace_ReturnsEmpty()
     {
         var doc = MarkdownParser.Parse("   \n   \n   ");
-        Assert.Empty(doc.Blocks);
+        Assert.IsEmpty(doc.Blocks);
     }
 
     // --- Diagnostic: nested list parsing ---
 
-    [Fact]
+    [TestMethod]
     public void Parse_NestedList_ProducesNestedStructure()
     {
         var md = "- Item 1\n  - Nested A\n  - Nested B\n- Item 2";
         var doc = MarkdownParser.Parse(md);
 
-        var list = Assert.IsType<ListBlock>(Assert.Single(doc.Blocks));
-        Assert.Equal(2, list.Items.Count);
+        var list = TestSeq.IsType<ListBlock>(TestSeq.Single(doc.Blocks));
+        Assert.AreEqual(2, list.Items.Count);
 
         // Item 1 should have a paragraph + nested list
         var item1 = list.Items[0];
-        Assert.True(item1.Children.Count >= 2,
-            $"Expected paragraph + nested list, got {item1.Children.Count} children: " +
+        Assert.IsTrue(item1.Children.Count >= 2, $"Expected paragraph + nested list, got {item1.Children.Count} children: " +
             string.Join(", ", item1.Children.Select(c => c.GetType().Name)));
 
         var nestedList = item1.Children.OfType<ListBlock>().FirstOrDefault();
-        Assert.NotNull(nestedList);
-        Assert.Equal(2, nestedList.Items.Count);
+        Assert.IsNotNull(nestedList);
+        Assert.AreEqual(2, nestedList.Items.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_NestedList_ThreeLevels()
     {
         var md = "- Level 0\n  - Level 1\n    - Level 2";
         var doc = MarkdownParser.Parse(md);
 
-        var list = Assert.IsType<ListBlock>(Assert.Single(doc.Blocks));
+        var list = TestSeq.IsType<ListBlock>(TestSeq.Single(doc.Blocks));
         var item0 = list.Items[0];
 
         var level1List = item0.Children.OfType<ListBlock>().FirstOrDefault();
-        Assert.NotNull(level1List);
+        Assert.IsNotNull(level1List);
 
         var level1Item = level1List.Items[0];
         var level2List = level1Item.Children.OfType<ListBlock>().FirstOrDefault();
-        Assert.NotNull(level2List);
-        Assert.Single(level2List.Items);
+        Assert.IsNotNull(level2List);
+        TestSeq.Single(level2List.Items);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_NestedOrderedInUnordered()
     {
         var md = "- Item\n  1. First\n  2. Second";
         var doc = MarkdownParser.Parse(md);
 
-        var list = Assert.IsType<ListBlock>(Assert.Single(doc.Blocks));
+        var list = TestSeq.IsType<ListBlock>(TestSeq.Single(doc.Blocks));
         var item = list.Items[0];
 
         var orderedList = item.Children.OfType<ListBlock>().FirstOrDefault();
-        Assert.NotNull(orderedList);
-        Assert.True(orderedList.IsOrdered);
-        Assert.Equal(2, orderedList.Items.Count);
+        Assert.IsNotNull(orderedList);
+        Assert.IsTrue(orderedList.IsOrdered);
+        Assert.AreEqual(2, orderedList.Items.Count);
     }
 
     // ==========================================================================
     // Strikethrough parsing
     // ==========================================================================
 
-    [Fact]
+    [TestMethod]
     public void Parse_Strikethrough_ProducesStrikethroughInline()
     {
         var doc = MarkdownParser.Parse("~~deleted~~");
-        var para = Assert.IsType<ParagraphBlock>(Assert.Single(doc.Blocks));
-        var strike = Assert.IsType<StrikethroughInline>(Assert.Single(para.Inlines));
-        var text = Assert.IsType<TextInline>(Assert.Single(strike.Children));
-        Assert.Equal("deleted", text.Text);
+        var para = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(doc.Blocks));
+        var strike = TestSeq.IsType<StrikethroughInline>(TestSeq.Single(para.Inlines));
+        var text = TestSeq.IsType<TextInline>(TestSeq.Single(strike.Children));
+        Assert.AreEqual("deleted", text.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_StrikethroughInSentence_PreservesContext()
     {
         var doc = MarkdownParser.Parse("This is ~~old~~ text");
-        var para = Assert.IsType<ParagraphBlock>(Assert.Single(doc.Blocks));
-        Assert.Equal(3, para.Inlines.Count);
-        Assert.IsType<TextInline>(para.Inlines[0]);
-        Assert.IsType<StrikethroughInline>(para.Inlines[1]);
-        Assert.IsType<TextInline>(para.Inlines[2]);
+        var para = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(doc.Blocks));
+        Assert.AreEqual(3, para.Inlines.Count);
+        TestSeq.IsType<TextInline>(para.Inlines[0]);
+        TestSeq.IsType<StrikethroughInline>(para.Inlines[1]);
+        TestSeq.IsType<TextInline>(para.Inlines[2]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_SingleTilde_NotStrikethrough()
     {
         var doc = MarkdownParser.Parse("~not strike~");
-        var para = Assert.IsType<ParagraphBlock>(Assert.Single(doc.Blocks));
+        var para = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(doc.Blocks));
         // Should be plain text, not strikethrough
-        Assert.All(para.Inlines, i => Assert.IsType<TextInline>(i));
+        TestSeq.All(para.Inlines, i => TestSeq.IsType<TextInline>(i));
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_StrikethroughWithBold_NestsCorrectly()
     {
         var doc = MarkdownParser.Parse("~~**both**~~");
-        var para = Assert.IsType<ParagraphBlock>(Assert.Single(doc.Blocks));
-        var strike = Assert.IsType<StrikethroughInline>(Assert.Single(para.Inlines));
-        var emphasis = Assert.IsType<EmphasisInline>(Assert.Single(strike.Children));
-        Assert.True(emphasis.IsStrong);
+        var para = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(doc.Blocks));
+        var strike = TestSeq.IsType<StrikethroughInline>(TestSeq.Single(para.Inlines));
+        var emphasis = TestSeq.IsType<EmphasisInline>(TestSeq.Single(strike.Children));
+        Assert.IsTrue(emphasis.IsStrong);
     }
 
     // ==========================================================================
     // Task list parsing
     // ==========================================================================
 
-    [Fact]
+    [TestMethod]
     public void Parse_UncheckedTaskItem_SetsIsCheckedFalse()
     {
         var doc = MarkdownParser.Parse("- [ ] Todo item");
-        var list = Assert.IsType<ListBlock>(Assert.Single(doc.Blocks));
-        var item = Assert.Single(list.Items);
-        Assert.False(item.IsChecked);
+        var list = TestSeq.IsType<ListBlock>(TestSeq.Single(doc.Blocks));
+        var item = TestSeq.Single(list.Items);
+        Assert.IsFalse(item.IsChecked);
         // The checkbox prefix should be stripped from the text
-        var para = Assert.IsType<ParagraphBlock>(Assert.Single(item.Children));
-        var text = Assert.IsType<TextInline>(Assert.Single(para.Inlines));
-        Assert.Equal("Todo item", text.Text);
+        var para = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(item.Children));
+        var text = TestSeq.IsType<TextInline>(TestSeq.Single(para.Inlines));
+        Assert.AreEqual("Todo item", text.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_CheckedTaskItem_SetsIsCheckedTrue()
     {
         var doc = MarkdownParser.Parse("- [x] Done item");
-        var list = Assert.IsType<ListBlock>(Assert.Single(doc.Blocks));
-        var item = Assert.Single(list.Items);
-        Assert.True(item.IsChecked);
+        var list = TestSeq.IsType<ListBlock>(TestSeq.Single(doc.Blocks));
+        var item = TestSeq.Single(list.Items);
+        Assert.IsTrue(item.IsChecked);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_CheckedUppercaseX_SetsIsCheckedTrue()
     {
         var doc = MarkdownParser.Parse("- [X] Also done");
-        var list = Assert.IsType<ListBlock>(Assert.Single(doc.Blocks));
-        Assert.True(list.Items[0].IsChecked);
+        var list = TestSeq.IsType<ListBlock>(TestSeq.Single(doc.Blocks));
+        Assert.IsTrue(list.Items[0].IsChecked);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_NormalListItem_HasNullIsChecked()
     {
         var doc = MarkdownParser.Parse("- Normal item");
-        var list = Assert.IsType<ListBlock>(Assert.Single(doc.Blocks));
-        Assert.Null(list.Items[0].IsChecked);
+        var list = TestSeq.IsType<ListBlock>(TestSeq.Single(doc.Blocks));
+        Assert.IsNull(list.Items[0].IsChecked);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_MixedTaskAndNormalList()
     {
         var doc = MarkdownParser.Parse("- [x] Done\n- [ ] Todo\n- Normal");
-        var list = Assert.IsType<ListBlock>(Assert.Single(doc.Blocks));
-        Assert.Equal(3, list.Items.Count);
-        Assert.True(list.Items[0].IsChecked);
-        Assert.False(list.Items[1].IsChecked);
-        Assert.Null(list.Items[2].IsChecked);
+        var list = TestSeq.IsType<ListBlock>(TestSeq.Single(doc.Blocks));
+        Assert.AreEqual(3, list.Items.Count);
+        Assert.IsTrue(list.Items[0].IsChecked);
+        Assert.IsFalse(list.Items[1].IsChecked);
+        Assert.IsNull(list.Items[2].IsChecked);
     }
 
     // ==========================================================================
     // GFM Table parsing
     // ==========================================================================
 
-    [Fact]
+    [TestMethod]
     public void Parse_SimpleTable_ProducesTableBlock()
     {
         var doc = MarkdownParser.Parse("| A | B |\n|---|---|\n| 1 | 2 |");
-        var table = Assert.IsType<TableBlock>(Assert.Single(doc.Blocks));
-        Assert.Equal(2, table.Alignments.Count);
-        Assert.Equal(2, table.HeaderCells.Count);
-        Assert.Single(table.Rows);
+        var table = TestSeq.IsType<TableBlock>(TestSeq.Single(doc.Blocks));
+        Assert.AreEqual(2, table.Alignments.Count);
+        Assert.AreEqual(2, table.HeaderCells.Count);
+        TestSeq.Single(table.Rows);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_TableAlignment_DetectsCorrectly()
     {
         var doc = MarkdownParser.Parse("| L | C | R | N |\n|:---|:---:|---:|---|\n| a | b | c | d |");
-        var table = Assert.IsType<TableBlock>(Assert.Single(doc.Blocks));
-        Assert.Equal(TableColumnAlignment.Left, table.Alignments[0]);
-        Assert.Equal(TableColumnAlignment.Center, table.Alignments[1]);
-        Assert.Equal(TableColumnAlignment.Right, table.Alignments[2]);
-        Assert.Equal(TableColumnAlignment.None, table.Alignments[3]);
+        var table = TestSeq.IsType<TableBlock>(TestSeq.Single(doc.Blocks));
+        Assert.AreEqual(TableColumnAlignment.Left, table.Alignments[0]);
+        Assert.AreEqual(TableColumnAlignment.Center, table.Alignments[1]);
+        Assert.AreEqual(TableColumnAlignment.Right, table.Alignments[2]);
+        Assert.AreEqual(TableColumnAlignment.None, table.Alignments[3]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_TableHeaderContent_ParsesInlines()
     {
         var doc = MarkdownParser.Parse("| **Bold** | `code` |\n|---|---|\n| x | y |");
-        var table = Assert.IsType<TableBlock>(Assert.Single(doc.Blocks));
-        Assert.IsType<EmphasisInline>(table.HeaderCells[0][0]);
-        Assert.IsType<CodeInline>(table.HeaderCells[1][0]);
+        var table = TestSeq.IsType<TableBlock>(TestSeq.Single(doc.Blocks));
+        TestSeq.IsType<EmphasisInline>(table.HeaderCells[0][0]);
+        TestSeq.IsType<CodeInline>(table.HeaderCells[1][0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_TableMultipleRows()
     {
         var doc = MarkdownParser.Parse("| H |\n|---|\n| A |\n| B |\n| C |");
-        var table = Assert.IsType<TableBlock>(Assert.Single(doc.Blocks));
-        Assert.Equal(3, table.Rows.Count);
+        var table = TestSeq.IsType<TableBlock>(TestSeq.Single(doc.Blocks));
+        Assert.AreEqual(3, table.Rows.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_TableEndedByBlankLine()
     {
         var doc = MarkdownParser.Parse("| H |\n|---|\n| A |\n\nParagraph");
-        Assert.Equal(2, doc.Blocks.Count);
-        Assert.IsType<TableBlock>(doc.Blocks[0]);
-        Assert.IsType<ParagraphBlock>(doc.Blocks[1]);
+        Assert.AreEqual(2, doc.Blocks.Count);
+        TestSeq.IsType<TableBlock>(doc.Blocks[0]);
+        TestSeq.IsType<ParagraphBlock>(doc.Blocks[1]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_TableWithoutLeadingPipes()
     {
         var doc = MarkdownParser.Parse("A | B\n---|---\n1 | 2");
-        var table = Assert.IsType<TableBlock>(Assert.Single(doc.Blocks));
-        Assert.Equal(2, table.Alignments.Count);
+        var table = TestSeq.IsType<TableBlock>(TestSeq.Single(doc.Blocks));
+        Assert.AreEqual(2, table.Alignments.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_TablePadsShortRows()
     {
         var doc = MarkdownParser.Parse("| A | B | C |\n|---|---|---|\n| 1 |");
-        var table = Assert.IsType<TableBlock>(Assert.Single(doc.Blocks));
-        Assert.Equal(3, table.Rows[0].Count); // padded to 3
+        var table = TestSeq.IsType<TableBlock>(TestSeq.Single(doc.Blocks));
+        Assert.AreEqual(3, table.Rows[0].Count); // padded to 3
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_NotATable_MissingDelimiter()
     {
         var doc = MarkdownParser.Parse("| A | B |\n| 1 | 2 |");
         // Without delimiter row, this should be paragraphs, not a table
-        Assert.DoesNotContain(doc.Blocks, b => b is TableBlock);
+        Assert.IsFalse(doc.Blocks.Any(b => b is TableBlock));
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_TableWithEscapedPipe()
     {
         var doc = MarkdownParser.Parse("| A |\n|---|\n| a\\|b |");
-        var table = Assert.IsType<TableBlock>(Assert.Single(doc.Blocks));
+        var table = TestSeq.IsType<TableBlock>(TestSeq.Single(doc.Blocks));
         var cellInlines = table.Rows[0][0];
-        var text = Assert.IsType<TextInline>(Assert.Single(cellInlines));
-        Assert.Equal("a|b", text.Text);
+        var text = TestSeq.IsType<TextInline>(TestSeq.Single(cellInlines));
+        Assert.AreEqual("a|b", text.Text);
     }
 
     // ==========================================================================
     // Reference-style links
     // ==========================================================================
 
-    [Fact]
+    [TestMethod]
     public void Parse_ReferenceLink_ResolvesToLinkInline()
     {
         var doc = MarkdownParser.Parse("Click [here][link1]\n\n[link1]: https://example.com");
-        var para = Assert.IsType<ParagraphBlock>(Assert.Single(doc.Blocks));
-        Assert.Equal(2, para.Inlines.Count);
-        var link = Assert.IsType<LinkInline>(para.Inlines[1]);
-        Assert.Equal("here", link.Text);
-        Assert.Equal("https://example.com", link.Url);
+        var para = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(doc.Blocks));
+        Assert.AreEqual(2, para.Inlines.Count);
+        var link = TestSeq.IsType<LinkInline>(para.Inlines[1]);
+        Assert.AreEqual("here", link.Text);
+        Assert.AreEqual("https://example.com", link.Url);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ReferenceLink_CaseInsensitive()
     {
         var doc = MarkdownParser.Parse("[Click][LINK]\n\n[link]: https://example.com");
-        var para = Assert.IsType<ParagraphBlock>(Assert.Single(doc.Blocks));
-        var link = Assert.IsType<LinkInline>(para.Inlines[0]);
-        Assert.Equal("https://example.com", link.Url);
+        var para = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(doc.Blocks));
+        var link = TestSeq.IsType<LinkInline>(para.Inlines[0]);
+        Assert.AreEqual("https://example.com", link.Url);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ReferenceLink_CollapsedForm()
     {
         // [text][] means ref = text
         var doc = MarkdownParser.Parse("[example][]\n\n[example]: https://example.com");
-        var para = Assert.IsType<ParagraphBlock>(Assert.Single(doc.Blocks));
-        var link = Assert.IsType<LinkInline>(para.Inlines[0]);
-        Assert.Equal("example", link.Text);
-        Assert.Equal("https://example.com", link.Url);
+        var para = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(doc.Blocks));
+        var link = TestSeq.IsType<LinkInline>(para.Inlines[0]);
+        Assert.AreEqual("example", link.Text);
+        Assert.AreEqual("https://example.com", link.Url);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ReferenceLink_ShortcutForm()
     {
         // [text] with no following brackets
         var doc = MarkdownParser.Parse("[example]\n\n[example]: https://example.com");
-        var para = Assert.IsType<ParagraphBlock>(Assert.Single(doc.Blocks));
-        var link = Assert.IsType<LinkInline>(para.Inlines[0]);
-        Assert.Equal("example", link.Text);
-        Assert.Equal("https://example.com", link.Url);
+        var para = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(doc.Blocks));
+        var link = TestSeq.IsType<LinkInline>(para.Inlines[0]);
+        Assert.AreEqual("example", link.Text);
+        Assert.AreEqual("https://example.com", link.Url);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ReferenceLink_WithTitle()
     {
         var doc = MarkdownParser.Parse("[click][ref]\n\n[ref]: https://example.com \"My Title\"");
-        var para = Assert.IsType<ParagraphBlock>(Assert.Single(doc.Blocks));
-        var link = Assert.IsType<LinkInline>(para.Inlines[0]);
-        Assert.Equal("https://example.com", link.Url);
-        Assert.Equal("My Title", link.Title);
+        var para = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(doc.Blocks));
+        var link = TestSeq.IsType<LinkInline>(para.Inlines[0]);
+        Assert.AreEqual("https://example.com", link.Url);
+        Assert.AreEqual("My Title", link.Title);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ReferenceLink_DefinitionNotRendered()
     {
         var doc = MarkdownParser.Parse("Text\n\n[ref]: https://example.com");
         // Only the paragraph should remain; definition is consumed
-        Assert.Single(doc.Blocks);
-        Assert.IsType<ParagraphBlock>(doc.Blocks[0]);
+        TestSeq.Single(doc.Blocks);
+        TestSeq.IsType<ParagraphBlock>(doc.Blocks[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ReferenceLink_MultipleDefinitions()
     {
         var doc = MarkdownParser.Parse(
             "[a][ref1] and [b][ref2]\n\n[ref1]: https://one.com\n[ref2]: https://two.com");
-        var para = Assert.IsType<ParagraphBlock>(Assert.Single(doc.Blocks));
-        var link1 = Assert.IsType<LinkInline>(para.Inlines[0]);
-        var link2 = Assert.IsType<LinkInline>(para.Inlines[2]);
-        Assert.Equal("https://one.com", link1.Url);
-        Assert.Equal("https://two.com", link2.Url);
+        var para = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(doc.Blocks));
+        var link1 = TestSeq.IsType<LinkInline>(para.Inlines[0]);
+        var link2 = TestSeq.IsType<LinkInline>(para.Inlines[2]);
+        Assert.AreEqual("https://one.com", link1.Url);
+        Assert.AreEqual("https://two.com", link2.Url);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ReferenceLink_UndefinedRef_NotParsedAsLink()
     {
         var doc = MarkdownParser.Parse("[text][undefined]");
-        var para = Assert.IsType<ParagraphBlock>(Assert.Single(doc.Blocks));
+        var para = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(doc.Blocks));
         // Should NOT produce a LinkInline — treated as plain text
-        Assert.DoesNotContain(para.Inlines, i => i is LinkInline);
+        Assert.IsFalse(para.Inlines.Any(i => i is LinkInline));
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ReferenceLink_FirstDefinitionWins()
     {
         var doc = MarkdownParser.Parse("[click][ref]\n\n[ref]: https://first.com\n[ref]: https://second.com");
-        var para = Assert.IsType<ParagraphBlock>(Assert.Single(doc.Blocks));
-        var link = Assert.IsType<LinkInline>(para.Inlines[0]);
-        Assert.Equal("https://first.com", link.Url);
+        var para = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(doc.Blocks));
+        var link = TestSeq.IsType<LinkInline>(para.Inlines[0]);
+        Assert.AreEqual("https://first.com", link.Url);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ReferenceLink_AngleBracketUrl()
     {
         var doc = MarkdownParser.Parse("[click][ref]\n\n[ref]: <https://example.com>");
-        var para = Assert.IsType<ParagraphBlock>(Assert.Single(doc.Blocks));
-        var link = Assert.IsType<LinkInline>(para.Inlines[0]);
-        Assert.Equal("https://example.com", link.Url);
+        var para = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(doc.Blocks));
+        var link = TestSeq.IsType<LinkInline>(para.Inlines[0]);
+        Assert.AreEqual("https://example.com", link.Url);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ReferenceImage_ResolvesToImageInline()
     {
         var doc = MarkdownParser.Parse("![logo][img]\n\n[img]: https://example.com/logo.png");
-        var para = Assert.IsType<ParagraphBlock>(Assert.Single(doc.Blocks));
-        var image = Assert.IsType<ImageInline>(para.Inlines[0]);
-        Assert.Equal("logo", image.AltText);
-        Assert.Equal("https://example.com/logo.png", image.Url);
+        var para = TestSeq.IsType<ParagraphBlock>(TestSeq.Single(doc.Blocks));
+        var image = TestSeq.IsType<ImageInline>(para.Inlines[0]);
+        Assert.AreEqual("logo", image.AltText);
+        Assert.AreEqual("https://example.com/logo.png", image.Url);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_ReferenceLink_InHeading()
     {
         var doc = MarkdownParser.Parse("# [Click here][ref]\n\n[ref]: https://example.com");
-        var heading = Assert.IsType<HeadingBlock>(Assert.Single(doc.Blocks));
-        var link = Assert.IsType<LinkInline>(heading.Inlines[0]);
-        Assert.Equal("https://example.com", link.Url);
+        var heading = TestSeq.IsType<HeadingBlock>(TestSeq.Single(doc.Blocks));
+        var link = TestSeq.IsType<LinkInline>(heading.Inlines[0]);
+        Assert.AreEqual("https://example.com", link.Url);
     }
 
-    [Fact]
+    [TestMethod]
     public void Parse_LinkDefinitions_StoredOnDocument()
     {
         var doc = MarkdownParser.Parse("[ref]: https://example.com \"Title\"");
-        Assert.True(doc.LinkDefinitions.ContainsKey("ref"));
-        Assert.Equal("https://example.com", doc.LinkDefinitions["ref"].Url);
-        Assert.Equal("Title", doc.LinkDefinitions["ref"].Title);
+        Assert.IsTrue(doc.LinkDefinitions.ContainsKey("ref"));
+        Assert.AreEqual("https://example.com", doc.LinkDefinitions["ref"].Url);
+        Assert.AreEqual("Title", doc.LinkDefinitions["ref"].Title);
     }
 }

--- a/tests/Hex1b.Tests/MenuBarIntegrationTests.cs
+++ b/tests/Hex1b.Tests/MenuBarIntegrationTests.cs
@@ -9,6 +9,7 @@ namespace Hex1b.Tests;
 /// These tests verify the full keyboard and mouse navigation patterns
 /// for menus, submenus, and menu item activation.
 /// </summary>
+[TestClass]
 public class MenuBarIntegrationTests
 {
     #region Helper Methods
@@ -103,7 +104,7 @@ public class MenuBarIntegrationTests
     
     #region Menu Bar Focus and Opening
     
-    [Fact]
+    [TestMethod]
     public async Task MenuBar_EnterKey_OpensFirstMenu()
     {
         // Arrange
@@ -129,7 +130,7 @@ public class MenuBarIntegrationTests
         // WaitUntil already verified File menu items (New, Open) are visible
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuBar_DownArrow_OpensMenu()
     {
         // Arrange
@@ -155,7 +156,7 @@ public class MenuBarIntegrationTests
         // WaitUntil already verified the menu opened with New and Open visible
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuBar_AltF_OpensFileMenu()
     {
         // Arrange
@@ -181,7 +182,7 @@ public class MenuBarIntegrationTests
         // WaitUntil already verified the menu opened with New and Open visible
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuBar_AltE_OpensEditMenu()
     {
         // Arrange
@@ -207,7 +208,7 @@ public class MenuBarIntegrationTests
         // WaitUntil already verified the menu opened with Undo and Redo visible
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuBar_RightArrow_NavigatesToNextMenu()
     {
         // Arrange
@@ -234,7 +235,7 @@ public class MenuBarIntegrationTests
         // WaitUntil already verified Edit menu items (Undo, Copy) are visible
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuBar_LeftArrow_NavigatesToPreviousMenu()
     {
         // Arrange
@@ -267,7 +268,7 @@ public class MenuBarIntegrationTests
     
     #region Menu Item Navigation and Activation
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItem_DownArrow_NavigatesToNextItem()
     {
         // Arrange
@@ -296,7 +297,7 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - "Open" action should have been triggered
-        Assert.Equal("File > Open", lastAction);
+        Assert.AreEqual("File > Open", lastAction);
     }
     
     /// <summary>
@@ -324,7 +325,7 @@ public class MenuBarIntegrationTests
         return false;
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItem_Tab_NavigatesToNextItem()
     {
         // Arrange
@@ -353,10 +354,10 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - "Open" action should have been triggered
-        Assert.Equal("File > Open", lastAction);
+        Assert.AreEqual("File > Open", lastAction);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItem_UpArrow_NavigatesToPreviousItem()
     {
         // Arrange
@@ -386,10 +387,10 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert
-        Assert.Equal("File > Open", lastAction);
+        Assert.AreEqual("File > Open", lastAction);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItem_Enter_ActivatesItemAndClosesMenu()
     {
         // Arrange
@@ -416,11 +417,11 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - Action was triggered and menu closed
-        Assert.Equal("File > New", lastAction);
-        Assert.False(terminal.CreateSnapshot().ContainsText("Open")); // Menu closed
+        Assert.AreEqual("File > New", lastAction);
+        Assert.IsFalse(terminal.CreateSnapshot().ContainsText("Open")); // Menu closed
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItem_Spacebar_ActivatesItem()
     {
         // Arrange
@@ -447,10 +448,10 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert
-        Assert.Equal("File > New", lastAction);
+        Assert.AreEqual("File > New", lastAction);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItem_Escape_ClosesMenuWithoutActivating()
     {
         // Arrange
@@ -478,10 +479,10 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - No action should have been triggered
-        Assert.Equal("", lastAction);
+        Assert.AreEqual("", lastAction);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItem_LeftArrow_ClosesMenu()
     {
         // Arrange
@@ -508,11 +509,11 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - Menu should be closed, no action triggered
-        Assert.Equal("", lastAction);
-        Assert.False(terminal.CreateSnapshot().ContainsText("Open"));
+        Assert.AreEqual("", lastAction);
+        Assert.IsFalse(terminal.CreateSnapshot().ContainsText("Open"));
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItem_UpArrowOnFirstItem_ClosesMenu()
     {
         // Arrange
@@ -539,11 +540,11 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - Menu should be closed, no action triggered
-        Assert.Equal("", lastAction);
-        Assert.False(terminal.CreateSnapshot().ContainsText("Open"));
+        Assert.AreEqual("", lastAction);
+        Assert.IsFalse(terminal.CreateSnapshot().ContainsText("Open"));
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItem_UpArrowOnNonFirstItem_NavigatesPrevious()
     {
         // Arrange
@@ -572,10 +573,10 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - "New" should have been activated
-        Assert.Equal("File > New", lastAction);
+        Assert.AreEqual("File > New", lastAction);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItem_UpArrowOnFirstItem_FocusStaysOnMenuTrigger()
     {
         // Arrange
@@ -607,7 +608,7 @@ public class MenuBarIntegrationTests
         // proving focus stayed on Edit menu after Up arrow closed it
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItem_AcceleratorKey_ActivatesItem()
     {
         // Arrange
@@ -634,14 +635,14 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert
-        Assert.Equal("File > Open", lastAction);
+        Assert.AreEqual("File > Open", lastAction);
     }
     
     #endregion
     
     #region Submenu Navigation
     
-    [Fact]
+    [TestMethod]
     public async Task Submenu_RightArrow_OpensSubmenu()
     {
         // Arrange
@@ -671,11 +672,11 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - Submenu items should be visible (use captured snapshot)
-        Assert.True(snapshot.ContainsText("Doc1.txt"));
-        Assert.True(snapshot.ContainsText("Doc2.txt"));
+        Assert.IsTrue(snapshot.ContainsText("Doc1.txt"));
+        Assert.IsTrue(snapshot.ContainsText("Doc2.txt"));
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Submenu_Enter_OpensSubmenu()
     {
         // Arrange
@@ -704,7 +705,7 @@ public class MenuBarIntegrationTests
         // WaitUntil already verified the submenu opened with Doc1.txt visible
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Submenu_LeftArrow_ClosesSubmenuReturnsToParent()
     {
         // Arrange
@@ -735,7 +736,7 @@ public class MenuBarIntegrationTests
         // WaitUntil already verified the submenu closed and parent menu is still visible
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Submenu_LeftArrow_FocusReturnsToSubmenuTrigger()
     {
         // Arrange
@@ -768,10 +769,10 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - Submenu should be open again, proving focus was on "Recent" (use captured snapshot)
-        Assert.True(snapshot.ContainsText("Doc1.txt")); // Submenu is open
+        Assert.IsTrue(snapshot.ContainsText("Doc1.txt")); // Submenu is open
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Submenu_ActivateItem_ClosesAllMenus()
     {
         // Arrange
@@ -802,17 +803,17 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert
-        Assert.Equal("File > Recent > Doc1.txt", lastAction);
+        Assert.AreEqual("File > Recent > Doc1.txt", lastAction);
         // All menus should be closed
-        Assert.False(snapshot.ContainsText("Doc1.txt"));
-        Assert.False(snapshot.ContainsText("Save"));
+        Assert.IsFalse(snapshot.ContainsText("Doc1.txt"));
+        Assert.IsFalse(snapshot.ContainsText("Save"));
     }
     
     #endregion
     
     #region Mouse Navigation
     
-    [Fact]
+    [TestMethod]
     public async Task Menu_ClickOnTrigger_OpensMenu()
     {
         // Arrange
@@ -838,7 +839,7 @@ public class MenuBarIntegrationTests
         // WaitUntil already verified the menu opened with New and Open visible
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Menu_ClickOnItem_ActivatesItem()
     {
         // Arrange
@@ -866,10 +867,10 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - Should have activated some item (position may vary)
-        Assert.NotEqual("", lastAction);
+        Assert.AreNotEqual("", lastAction);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Menu_ClickAwayOnBackdrop_ClosesMenu()
     {
         // Arrange
@@ -897,11 +898,11 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - No action should be triggered, menu should be closed
-        Assert.Equal("", lastAction);
-        Assert.False(terminal.CreateSnapshot().ContainsText("Save"));
+        Assert.AreEqual("", lastAction);
+        Assert.IsFalse(terminal.CreateSnapshot().ContainsText("Save"));
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Menu_ClickAwayThenClickAnotherMenu_Works()
     {
         // Arrange
@@ -942,7 +943,7 @@ public class MenuBarIntegrationTests
     
     #region Disabled Items
     
-    [Fact]
+    [TestMethod]
     public async Task DisabledItem_Enter_DoesNotActivate()
     {
         // Arrange
@@ -973,10 +974,10 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - Action should NOT have been triggered for disabled item
-        Assert.NotEqual("File > Save As", lastAction);
+        Assert.AreNotEqual("File > Save As", lastAction);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Menu_OnlyDisabledItems_UpArrowClosesMenu()
     {
         // Arrange - Menu with only a disabled item (like "No terminals" in EmbeddedTerminalDemo)
@@ -1017,11 +1018,10 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - Menu should be closed (no "No items" text visible)
-        Assert.False(capture.ContainsText("(No items)"), 
-            $"Menu should have closed after Up arrow. Screen contents:\n{capture.GetText()}");
+        Assert.IsFalse(capture.ContainsText("(No items)"), $"Menu should have closed after Up arrow. Screen contents:\n{capture.GetText()}");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Menu_OnlyDisabledItems_LeftArrowNavigatesToPreviousMenu()
     {
         // Arrange - Menu with only a disabled item
@@ -1062,15 +1062,14 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - Should now be in File menu
-        Assert.True(capture.ContainsText("New"), 
-            $"Should have navigated to File menu. Screen contents:\n{capture.GetText()}");
+        Assert.IsTrue(capture.ContainsText("New"), $"Should have navigated to File menu. Screen contents:\n{capture.GetText()}");
     }
     
     #endregion
     
     #region Focus Restoration
     
-    [Fact]
+    [TestMethod]
     public async Task Menu_AfterClose_FocusRestoresToMenuBar()
     {
         // Arrange
@@ -1104,7 +1103,7 @@ public class MenuBarIntegrationTests
     
     #region Complex Workflows
     
-    [Fact]
+    [TestMethod]
     public async Task CompleteWorkflow_NavigateMultipleMenusAndActivateItems()
     {
         // Arrange
@@ -1152,7 +1151,7 @@ public class MenuBarIntegrationTests
     
     #region Focus Debugging Tests
     
-    [Fact]
+    [TestMethod]
     public async Task Debug_BackdropFocusDelegation_ToMenuItems()
     {
         // Arrange - Create the node hierarchy manually
@@ -1170,7 +1169,7 @@ public class MenuBarIntegrationTests
         var focusables = backdropNode.GetFocusableNodes().ToList();
         
         // Assert - Should include backdrop and menu items
-        Assert.True(focusables.Count >= 3, $"Expected at least 3 focusables (backdrop + 2 items), got {focusables.Count}");
+        Assert.IsTrue(focusables.Count >= 3, $"Expected at least 3 focusables (backdrop + 2 items), got {focusables.Count}");
         Assert.Contains(menuItemNode1, focusables);
         Assert.Contains(menuItemNode2, focusables);
         
@@ -1178,10 +1177,10 @@ public class MenuBarIntegrationTests
         backdropNode.IsFocused = true;
         
         // Assert - Focus should have been delegated to first menu item
-        Assert.True(menuItemNode1.IsFocused, "First menu item should have focus after setting backdrop focus");
+        Assert.IsTrue(menuItemNode1.IsFocused, "First menu item should have focus after setting backdrop focus");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Debug_FirstMenuItem_HasFocus_WhenMenuOpens()
     {
         // This test verifies that when a menu opens, the first menu item automatically gets focus
@@ -1216,13 +1215,13 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
         
         // Assert - Focus should be on the first MenuItemNode
-        Assert.True(focusableCount > 0, $"Expected focusables in the ring, got {focusableCount}");
-        Assert.NotNull(focusedAfterMenuOpen);
-        Assert.IsType<MenuItemNode>(focusedAfterMenuOpen);
-        Assert.Equal("New", ((MenuItemNode)focusedAfterMenuOpen).Label);
+        Assert.IsTrue(focusableCount > 0, $"Expected focusables in the ring, got {focusableCount}");
+        Assert.IsNotNull(focusedAfterMenuOpen);
+        TestSeq.IsType<MenuItemNode>(focusedAfterMenuOpen);
+        Assert.AreEqual("New", ((MenuItemNode)focusedAfterMenuOpen).Label);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Debug_DownArrow_MovesFocus_WhenMenuOpen()
     {
         // This test checks if Down arrow moves focus from "New" to "Open"
@@ -1275,9 +1274,8 @@ public class MenuBarIntegrationTests
         // Check which nodes have IsFocused = true
         var focusedNodes = focusablesAfter.Where(f => f.focused).ToList();
         
-        Assert.NotNull(focusedAfterDownArrow);
-        Assert.True(focusedAfterMenuOpen != focusedAfterDownArrow, 
-            $"Focus didn't move. Before Down: {focusedAfterMenuOpenLabel}, After Down: {focusedAfterDownArrowLabel}. " +
+        Assert.IsNotNull(focusedAfterDownArrow);
+        Assert.IsTrue(focusedAfterMenuOpen != focusedAfterDownArrow, $"Focus didn't move. Before Down: {focusedAfterMenuOpenLabel}, After Down: {focusedAfterDownArrowLabel}. " +
             $"LastFocusChange: {app.LastFocusChange ?? "null"}. " +
             $"LastPathDebug: {app.LastPathDebug ?? "null"}. " +
             $"Focusables BEFORE: [{string.Join(", ", focusablesBefore.Select(f => f.type + (f.label != null ? ":" + f.label : "")))}]. " +
@@ -1297,7 +1295,7 @@ public class MenuBarIntegrationTests
     /// - The submenu content is rendered (text exists)
     /// - The first submenu item receives focus (has black background color)
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Submenu_RightArrow_OpensSubmenuAndFocusesFirstItem()
     {
         // Arrange
@@ -1374,7 +1372,7 @@ public class MenuBarIntegrationTests
     
     #region Cross-Menu Navigation (Arrow Keys Navigate Between Menus While Open)
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItem_RightArrow_OpensNextMenuWhenNoSubmenu()
     {
         // Arrange - When on a leaf menu item (no children), Right arrow should
@@ -1403,11 +1401,11 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - Edit menu should be open (use captured snapshot)
-        Assert.True(snapshot.ContainsText("Undo"), "Edit menu should be visible");
-        Assert.False(snapshot.ContainsText("Save"), "File menu should be closed");
+        Assert.IsTrue(snapshot.ContainsText("Undo"), "Edit menu should be visible");
+        Assert.IsFalse(snapshot.ContainsText("Save"), "File menu should be closed");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItem_LeftArrow_OpensPreviousMenuWhenNoSubmenu()
     {
         // Arrange - When on a leaf menu item (no children), Left arrow should
@@ -1437,7 +1435,7 @@ public class MenuBarIntegrationTests
         // WaitUntil already verified File menu (New, Open) is visible after Left arrow
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItem_RightArrow_WrapsAroundToFirstMenu()
     {
         // Arrange - When on the last menu (Help), Right arrow should wrap to File
@@ -1466,7 +1464,7 @@ public class MenuBarIntegrationTests
         // WaitUntil already verified the File menu opened after wrapping
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItem_LeftArrow_WrapsAroundToLastMenu()
     {
         // Arrange - When on the first menu (File), Left arrow should wrap to Help
@@ -1494,11 +1492,11 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - Help menu should be open
-        Assert.True(snapshot.ContainsText("About"), "Help menu should be visible after wrap");
-        Assert.False(snapshot.ContainsText("Save"), "File menu should be closed");
+        Assert.IsTrue(snapshot.ContainsText("About"), "Help menu should be visible after wrap");
+        Assert.IsFalse(snapshot.ContainsText("Save"), "File menu should be closed");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItem_RightArrow_ThenActivateItem_Works()
     {
         // Arrange - Navigate across menus with arrow keys, then activate an item
@@ -1528,10 +1526,10 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - Redo action should have been triggered
-        Assert.Equal("Edit > Redo", lastAction);
+        Assert.AreEqual("Edit > Redo", lastAction);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItem_MultipleRightArrows_NavigatesAcrossMenus()
     {
         // Arrange - Press Right multiple times to navigate File -> Edit -> Help
@@ -1561,12 +1559,12 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - Help menu should be open
-        Assert.True(snapshot.ContainsText("About"), "Help menu should be visible");
-        Assert.False(snapshot.ContainsText("Save"), "File menu should be closed");
-        Assert.False(snapshot.ContainsText("Paste"), "Edit menu should be closed");
+        Assert.IsTrue(snapshot.ContainsText("About"), "Help menu should be visible");
+        Assert.IsFalse(snapshot.ContainsText("Save"), "File menu should be closed");
+        Assert.IsFalse(snapshot.ContainsText("Paste"), "Edit menu should be closed");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItem_RightArrow_FromMiddleOfMenu_OpensNextMenu()
     {
         // Arrange - Navigate down within a menu first, then Right should still work
@@ -1596,11 +1594,11 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - Edit menu should be open (use captured snapshot)
-        Assert.True(snapshot.ContainsText("Undo"), "Edit menu should be visible");
-        Assert.False(snapshot.ContainsText("Save"), "File menu should be closed");
+        Assert.IsTrue(snapshot.ContainsText("Undo"), "Edit menu should be visible");
+        Assert.IsFalse(snapshot.ContainsText("Save"), "File menu should be closed");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task SubmenuTrigger_LeftArrow_OpensPreviousMenu()
     {
         // Arrange - When focused on a submenu trigger (like "Recent" in File menu),
@@ -1631,11 +1629,11 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - Help menu should be open (not File menu)
-        Assert.True(snapshot.ContainsText("About"), "Help menu should be visible");
-        Assert.False(snapshot.ContainsText("Save"), "File menu should be closed");
+        Assert.IsTrue(snapshot.ContainsText("About"), "Help menu should be visible");
+        Assert.IsFalse(snapshot.ContainsText("Save"), "File menu should be closed");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task SubmenuTrigger_RightArrow_OpensSubmenu()
     {
         // Arrange - When focused on a submenu trigger, Right arrow should open the submenu
@@ -1665,15 +1663,15 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - Recent submenu should be open (use captured snapshot)
-        Assert.True(snapshot.ContainsText("Doc1.txt"), "Recent submenu should be visible");
-        Assert.True(snapshot.ContainsText("Doc2.txt"), "Recent submenu should be visible");
+        Assert.IsTrue(snapshot.ContainsText("Doc1.txt"), "Recent submenu should be visible");
+        Assert.IsTrue(snapshot.ContainsText("Doc2.txt"), "Recent submenu should be visible");
     }
     
     #endregion
     
     #region Global Bindings
     
-    [Fact]
+    [TestMethod]
     public async Task MenuBar_AltF_WorksWhenTextBoxFocused()
     {
         // Arrange - This tests global bindings: menu accelerators should work
@@ -1713,11 +1711,11 @@ public class MenuBarIntegrationTests
         await StopAppAsync(app, runTask);
 
         // Assert - File menu should be open
-        Assert.True(snapshot.ContainsText("New"), "File menu item 'New' should be visible");
-        Assert.True(snapshot.ContainsText("Open"), "File menu item 'Open' should be visible");
+        Assert.IsTrue(snapshot.ContainsText("New"), "File menu item 'New' should be visible");
+        Assert.IsTrue(snapshot.ContainsText("Open"), "File menu item 'Open' should be visible");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuBar_AltE_WorksWhenButtonFocused()
     {
         // Arrange - Alt+E should open Edit menu even when a Button is focused

--- a/tests/Hex1b.Tests/MenuContextTests.cs
+++ b/tests/Hex1b.Tests/MenuContextTests.cs
@@ -3,116 +3,117 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class MenuContextTests
 {
-    [Fact]
+    [TestMethod]
     public void ParseAccelerator_NoAmpersand_ReturnsOriginalLabel()
     {
         var (displayLabel, accelerator, index) = MenuContext.ParseAccelerator("File");
         
-        Assert.Equal("File", displayLabel);
-        Assert.Null(accelerator);
-        Assert.Equal(-1, index);
+        Assert.AreEqual("File", displayLabel);
+        Assert.IsNull(accelerator);
+        Assert.AreEqual(-1, index);
     }
     
-    [Fact]
+    [TestMethod]
     public void ParseAccelerator_WithAmpersand_ExtractsAccelerator()
     {
         var (displayLabel, accelerator, index) = MenuContext.ParseAccelerator("&File");
         
-        Assert.Equal("File", displayLabel);
-        Assert.Equal('F', accelerator);
-        Assert.Equal(0, index);
+        Assert.AreEqual("File", displayLabel);
+        Assert.AreEqual('F', accelerator);
+        Assert.AreEqual(0, index);
     }
     
-    [Fact]
+    [TestMethod]
     public void ParseAccelerator_AmpersandInMiddle_ExtractsAccelerator()
     {
         var (displayLabel, accelerator, index) = MenuContext.ParseAccelerator("Save &As");
         
-        Assert.Equal("Save As", displayLabel);
-        Assert.Equal('A', accelerator);
-        Assert.Equal(5, index);
+        Assert.AreEqual("Save As", displayLabel);
+        Assert.AreEqual('A', accelerator);
+        Assert.AreEqual(5, index);
     }
     
-    [Fact]
+    [TestMethod]
     public void ParseAccelerator_DoubleAmpersand_RendersLiteralAmpersand()
     {
         var (displayLabel, accelerator, index) = MenuContext.ParseAccelerator("Tom && Jerry");
         
-        Assert.Equal("Tom & Jerry", displayLabel);
-        Assert.Null(accelerator);
-        Assert.Equal(-1, index);
+        Assert.AreEqual("Tom & Jerry", displayLabel);
+        Assert.IsNull(accelerator);
+        Assert.AreEqual(-1, index);
     }
     
-    [Fact]
+    [TestMethod]
     public void ParseAccelerator_AmpersandAtEnd_NoAccelerator()
     {
         var (displayLabel, accelerator, index) = MenuContext.ParseAccelerator("Test&");
         
-        Assert.Equal("Test", displayLabel);
-        Assert.Null(accelerator);
-        Assert.Equal(-1, index);
+        Assert.AreEqual("Test", displayLabel);
+        Assert.IsNull(accelerator);
+        Assert.AreEqual(-1, index);
     }
     
-    [Fact]
+    [TestMethod]
     public void ParseAccelerator_LowercaseLetter_ConvertsToUppercase()
     {
         var (displayLabel, accelerator, index) = MenuContext.ParseAccelerator("&open");
         
-        Assert.Equal("open", displayLabel);
-        Assert.Equal('O', accelerator);
-        Assert.Equal(0, index);
+        Assert.AreEqual("open", displayLabel);
+        Assert.AreEqual('O', accelerator);
+        Assert.AreEqual(0, index);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuItem_CreatedWithLabel()
     {
         var ctx = new MenuContext();
         var item = ctx.MenuItem("Open");
         
-        Assert.Equal("Open", item.Label);
-        Assert.False(item.IsDisabled);
-        Assert.Null(item.ActivatedHandler);
+        Assert.AreEqual("Open", item.Label);
+        Assert.IsFalse(item.IsDisabled);
+        Assert.IsNull(item.ActivatedHandler);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuItem_Disabled_SetsIsDisabled()
     {
         var ctx = new MenuContext();
         var item = ctx.MenuItem("Undo").Disabled();
         
-        Assert.True(item.IsDisabled);
+        Assert.IsTrue(item.IsDisabled);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuItem_Disabled_CanBeToggled()
     {
         var ctx = new MenuContext();
         var item = ctx.MenuItem("Undo").Disabled(true).Disabled(false);
         
-        Assert.False(item.IsDisabled);
+        Assert.IsFalse(item.IsDisabled);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuItem_OnActivated_SetsHandler()
     {
         var ctx = new MenuContext();
         var item = ctx.MenuItem("Open").OnActivated(_ => { });
         
-        Assert.NotNull(item.ActivatedHandler);
+        Assert.IsNotNull(item.ActivatedHandler);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuItem_NoAccelerator_DisablesAutoAccelerator()
     {
         var ctx = new MenuContext();
         var item = ctx.MenuItem("Open").NoAccelerator();
         
-        Assert.True(item.DisableAccelerator);
+        Assert.IsTrue(item.DisableAccelerator);
     }
     
-    [Fact]
+    [TestMethod]
     public void Menu_CreatedWithChildren()
     {
         var ctx = new MenuContext();
@@ -123,15 +124,15 @@ public class MenuContextTests
             m.MenuItem("Quit")
         ]);
         
-        Assert.Equal("File", menu.Label);
-        Assert.Equal(4, menu.Children.Count);
-        Assert.IsType<MenuItemWidget>(menu.Children[0]);
-        Assert.IsType<MenuItemWidget>(menu.Children[1]);
-        Assert.IsType<MenuSeparatorWidget>(menu.Children[2]);
-        Assert.IsType<MenuItemWidget>(menu.Children[3]);
+        Assert.AreEqual("File", menu.Label);
+        Assert.AreEqual(4, menu.Children.Count);
+        TestSeq.IsType<MenuItemWidget>(menu.Children[0]);
+        TestSeq.IsType<MenuItemWidget>(menu.Children[1]);
+        TestSeq.IsType<MenuSeparatorWidget>(menu.Children[2]);
+        TestSeq.IsType<MenuItemWidget>(menu.Children[3]);
     }
     
-    [Fact]
+    [TestMethod]
     public void Menu_NestedSubmenus()
     {
         var ctx = new MenuContext();
@@ -143,20 +144,20 @@ public class MenuContextTests
             ])
         ]);
         
-        Assert.Equal(2, menu.Children.Count);
-        Assert.IsType<MenuItemWidget>(menu.Children[0]);
+        Assert.AreEqual(2, menu.Children.Count);
+        TestSeq.IsType<MenuItemWidget>(menu.Children[0]);
         
-        var submenu = Assert.IsType<MenuWidget>(menu.Children[1]);
-        Assert.Equal("Recent", submenu.Label);
-        Assert.Equal(2, submenu.Children.Count);
+        var submenu = TestSeq.IsType<MenuWidget>(menu.Children[1]);
+        Assert.AreEqual("Recent", submenu.Label);
+        Assert.AreEqual(2, submenu.Children.Count);
     }
     
-    [Fact]
+    [TestMethod]
     public void Separator_CreatedEmpty()
     {
         var ctx = new MenuContext();
         var separator = ctx.Separator();
         
-        Assert.IsType<MenuSeparatorWidget>(separator);
+        TestSeq.IsType<MenuSeparatorWidget>(separator);
     }
 }

--- a/tests/Hex1b.Tests/MenuNodeTests.cs
+++ b/tests/Hex1b.Tests/MenuNodeTests.cs
@@ -7,9 +7,10 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class MenuNodeTests
 {
-    [Fact]
+    [TestMethod]
     public void MenuPopupNode_ConfiguresUpDownBindings()
     {
         // Arrange
@@ -30,7 +31,7 @@ public class MenuNodeTests
         var bindings = builder.Build();
         
         // Assert
-        Assert.NotEmpty(bindings);
+        Assert.IsNotEmpty(bindings);
         
         // Check that UpArrow and DownArrow bindings exist
         var upArrowBinding = bindings.FirstOrDefault(b => 
@@ -43,11 +44,11 @@ public class MenuNodeTests
             b.Steps[0].Key == Hex1bKey.DownArrow && 
             b.Steps[0].Modifiers == Hex1bModifiers.None);
             
-        Assert.NotNull(upArrowBinding);
-        Assert.NotNull(downArrowBinding);
+        Assert.IsNotNull(upArrowBinding);
+        Assert.IsNotNull(downArrowBinding);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task InputRouter_FindsMenuPopupBindings_WhenChildIsFocused()
     {
         // Arrange - simulate the tree structure when a menu is open
@@ -88,10 +89,10 @@ public class MenuNodeTests
         var result = await InputRouter.RouteInputAsync(zstack, keyEvent, focusRing, state, cancellationToken: TestContext.Current.CancellationToken);
         
         // Assert - the binding should be found and handled
-        Assert.Equal(InputResult.Handled, result);
+        Assert.AreEqual(InputResult.Handled, result);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItemNode_DownArrow_MovesFocusToNextItem()
     {
         // Arrange - set up a popup with two menu items
@@ -131,8 +132,8 @@ public class MenuNodeTests
         focusRing.Rebuild(zstack);
         
         // Verify initial state
-        Assert.Equal(2, focusRing.Focusables.Count);
-        Assert.Equal(menuItem1, focusRing.FocusedNode);
+        Assert.AreEqual(2, focusRing.Focusables.Count);
+        Assert.AreEqual(menuItem1, focusRing.FocusedNode);
         
         // Act - route a down arrow key
         var keyEvent = new Hex1bKeyEvent(Hex1bKey.DownArrow, '\0', Hex1bModifiers.None);
@@ -141,13 +142,13 @@ public class MenuNodeTests
         var result = await InputRouter.RouteInputAsync(zstack, keyEvent, focusRing, state, cancellationToken: TestContext.Current.CancellationToken);
         
         // Assert - focus should have moved to the second item
-        Assert.Equal(InputResult.Handled, result);
-        Assert.False(menuItem1.IsFocused, "First item should no longer be focused");
-        Assert.True(menuItem2.IsFocused, "Second item should now be focused");
-        Assert.Equal(menuItem2, focusRing.FocusedNode);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsFalse(menuItem1.IsFocused, "First item should no longer be focused");
+        Assert.IsTrue(menuItem2.IsFocused, "Second item should now be focused");
+        Assert.AreEqual(menuItem2, focusRing.FocusedNode);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuItemNode_Measure_ReturnsCorrectSize()
     {
         var node = new MenuItemNode { Label = "Open", RenderWidth = 20 };
@@ -155,11 +156,11 @@ public class MenuNodeTests
         
         var size = node.Measure(constraints);
         
-        Assert.Equal(20, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(20, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuItemNode_Measure_UsesLabelLengthWhenNoRenderWidth()
     {
         var node = new MenuItemNode { Label = "Open", RenderWidth = 0 };
@@ -167,27 +168,27 @@ public class MenuNodeTests
         
         var size = node.Measure(constraints);
         
-        Assert.Equal(6, size.Width); // "Open" + 2 padding
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(6, size.Width); // "Open" + 2 padding
+        Assert.AreEqual(1, size.Height);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuItemNode_IsFocusable_WhenNotDisabled()
     {
         var node = new MenuItemNode { Label = "Open", IsDisabled = false };
         
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuItemNode_NotFocusable_WhenDisabled()
     {
         var node = new MenuItemNode { Label = "Open", IsDisabled = true };
         
-        Assert.False(node.IsFocusable);
+        Assert.IsFalse(node.IsFocusable);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuItemNode_IsFocused_MarksDirty()
     {
         var node = new MenuItemNode { Label = "Open" };
@@ -195,10 +196,10 @@ public class MenuNodeTests
         
         node.IsFocused = true;
         
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuSeparatorNode_Measure_ReturnsOneRowHeight()
     {
         var node = new MenuSeparatorNode { RenderWidth = 20 };
@@ -206,64 +207,64 @@ public class MenuNodeTests
         
         var size = node.Measure(constraints);
         
-        Assert.Equal(20, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(20, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuSeparatorNode_NotFocusable()
     {
         var node = new MenuSeparatorNode();
         
-        Assert.False(node.IsFocusable);
+        Assert.IsFalse(node.IsFocusable);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuSeparatorNode_FallbackFocusable_WhenSet()
     {
         var node = new MenuSeparatorNode { IsFallbackFocusable = true };
         
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuSeparatorNode_FallbackFocusable_DefaultsFalse()
     {
         var node = new MenuSeparatorNode();
         
-        Assert.False(node.IsFallbackFocusable);
-        Assert.False(node.IsFocusable);
+        Assert.IsFalse(node.IsFallbackFocusable);
+        Assert.IsFalse(node.IsFocusable);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuItemNode_Disabled_NotFocusable()
     {
         var node = new MenuItemNode { Label = "Test", IsDisabled = true };
         
-        Assert.False(node.IsFocusable);
+        Assert.IsFalse(node.IsFocusable);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuItemNode_Disabled_FallbackFocusable_WhenSet()
     {
         var node = new MenuItemNode { Label = "Test", IsDisabled = true, IsFallbackFocusable = true };
         
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuItemNode_Enabled_AlwaysFocusable()
     {
         var node = new MenuItemNode { Label = "Test", IsDisabled = false };
         
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
         
         // IsFallbackFocusable shouldn't affect enabled items
         node.IsFallbackFocusable = true;
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuNode_Measure_ReturnsLabelWidth()
     {
         var node = new MenuNode { Label = "File" };
@@ -271,43 +272,43 @@ public class MenuNodeTests
         
         var size = node.Measure(constraints);
         
-        Assert.Equal(6, size.Width); // "File" + 2 padding
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(6, size.Width); // "File" + 2 padding
+        Assert.AreEqual(1, size.Height);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuNode_IsFocusable()
     {
         var node = new MenuNode { Label = "File" };
         
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuNode_ManagesChildFocus()
     {
         var node = new MenuNode { Label = "File" };
         
-        Assert.True(node.ManagesChildFocus);
+        Assert.IsTrue(node.ManagesChildFocus);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuBarNode_ManagesChildFocus()
     {
         var node = new MenuBarNode();
         
-        Assert.True(node.ManagesChildFocus);
+        Assert.IsTrue(node.ManagesChildFocus);
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuBarNode_NotFocusable()
     {
         var node = new MenuBarNode();
         
-        Assert.False(node.IsFocusable);
+        Assert.IsFalse(node.IsFocusable);
     }
     
-    [Fact]
+    [TestMethod]
     public void BackdropNode_FocusDelegation_SetsChildFocus()
     {
         // Arrange - simulate the tree structure when a menu is open
@@ -337,18 +338,18 @@ public class MenuNodeTests
         anchoredNode.Parent = backdropNode;
         
         // Initially, nothing is focused
-        Assert.False(menuItem1.IsFocused);
-        Assert.False(menuItem2.IsFocused);
+        Assert.IsFalse(menuItem1.IsFocused);
+        Assert.IsFalse(menuItem2.IsFocused);
         
         // Act - Set focus on BackdropNode (what ZStack does)
         backdropNode.IsFocused = true;
         
         // Assert - Focus should delegate to first focusable child (menuItem1)
-        Assert.True(menuItem1.IsFocused);
-        Assert.False(menuItem2.IsFocused);
+        Assert.IsTrue(menuItem1.IsFocused);
+        Assert.IsFalse(menuItem2.IsFocused);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task InputRouter_EnterKey_ActivatesMenuItem_WhenMenuItemIsFocused()
     {
         // Arrange - simulate full tree with ZStack → BackdropNode → AnchoredNode → MenuPopupNode → MenuItemNode
@@ -388,7 +389,7 @@ public class MenuNodeTests
         
         // Verify menuItem1 is in focus ring and is focused
         Assert.Contains(menuItem1, focusRing.Focusables);
-        Assert.Equal(menuItem1, focusRing.FocusedNode);
+        Assert.AreEqual(menuItem1, focusRing.FocusedNode);
         
         // Act - Route Enter key
         var keyEvent = new Hex1bKeyEvent(Hex1bKey.Enter, '\r', Hex1bModifiers.None);
@@ -397,11 +398,11 @@ public class MenuNodeTests
         var result = await InputRouter.RouteInputAsync(zstack, keyEvent, focusRing, state);
         
         // Assert
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(activated, "ActivatedAction should have been called");
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(activated, "ActivatedAction should have been called");
     }
     
-    [Fact]
+    [TestMethod]
     public void MenuNode_InMenuBar_ConfiguresLeftRightBindings()
     {
         // Arrange
@@ -436,12 +437,12 @@ public class MenuNodeTests
             b.Steps[0].Key == Hex1bKey.DownArrow && 
             b.Steps[0].Modifiers == Hex1bModifiers.None);
             
-        Assert.NotNull(leftBinding);
-        Assert.NotNull(rightBinding);
-        Assert.NotNull(downBinding);
+        Assert.IsNotNull(leftBinding);
+        Assert.IsNotNull(rightBinding);
+        Assert.IsNotNull(downBinding);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuNode_InMenuBar_RightArrow_FocusesNextMenu()
     {
         // Arrange - simulate the full tree with VStack -> MenuBar -> MenuNodes
@@ -464,14 +465,14 @@ public class MenuNodeTests
         menuBar.Measure(Constraints.Unbounded);
         
         // Verify MenuNodes are populated
-        Assert.Equal(2, menuBar.MenuNodes.Count);
+        Assert.AreEqual(2, menuBar.MenuNodes.Count);
         
         var menu1 = menuBar.MenuNodes[0];
         var menu2 = menuBar.MenuNodes[1];
         
         // Verify Parent is set
-        Assert.Same(menuBar, menu1.Parent);
-        Assert.Same(menuBar, menu2.Parent);
+        Assert.AreSame(menuBar, menu1.Parent);
+        Assert.AreSame(menuBar, menu2.Parent);
         
         // Build focus ring from the vstack
         var focusRing = new FocusRing();
@@ -483,7 +484,7 @@ public class MenuNodeTests
         
         // Verify menu1 gets initial focus
         focusRing.EnsureFocus();
-        Assert.True(menu1.IsFocused, "menu1 should be initially focused");
+        Assert.IsTrue(menu1.IsFocused, "menu1 should be initially focused");
         
         // Verify bindings are configured correctly
         var builder = new InputBindingsBuilder();
@@ -493,7 +494,7 @@ public class MenuNodeTests
         var rightBinding = bindings.FirstOrDefault(b => 
             b.Steps.Count == 1 && 
             b.Steps[0].Key == Hex1bKey.RightArrow);
-        Assert.NotNull(rightBinding);
+        Assert.IsNotNull(rightBinding);
         
         // Act - press right arrow via InputRouter
         var keyEvent = new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None);
@@ -501,12 +502,12 @@ public class MenuNodeTests
         var result = await InputRouter.RouteInputAsync(vstack, keyEvent, focusRing, state);
         
         // Assert
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(menu2.IsFocused, $"menu2 should be focused. Focused node: {focusRing.FocusedNode?.GetType().Name}");
-        Assert.False(menu1.IsFocused, "menu1 should not be focused");
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(menu2.IsFocused, $"menu2 should be focused. Focused node: {focusRing.FocusedNode?.GetType().Name}");
+        Assert.IsFalse(menu1.IsFocused, "menu1 should not be focused");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuNode_InMenuBar_LeftArrow_FocusesPreviousMenu()
     {
         // Arrange - simulate the full tree with VStack -> MenuBar -> MenuNodes
@@ -537,7 +538,7 @@ public class MenuNodeTests
         
         // Start with menu2 focused
         focusRing.Focus(menu2);
-        Assert.True(menu2.IsFocused, "menu2 should be initially focused");
+        Assert.IsTrue(menu2.IsFocused, "menu2 should be initially focused");
         
         // Act - press left arrow via InputRouter
         var keyEvent = new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None);
@@ -545,9 +546,9 @@ public class MenuNodeTests
         var result = await InputRouter.RouteInputAsync(vstack, keyEvent, focusRing, state);
         
         // Assert
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(menu1.IsFocused, "menu1 should be focused");
-        Assert.False(menu2.IsFocused, "menu2 should not be focused");
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(menu1.IsFocused, "menu1 should be focused");
+        Assert.IsFalse(menu2.IsFocused, "menu2 should not be focused");
     }
     
     #region Accelerator Underline Rendering Tests
@@ -592,7 +593,7 @@ public class MenuNodeTests
         return false;
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuNode_InMenuBar_Normal_ShowsAcceleratorUnderline()
     {
         // Arrange
@@ -625,10 +626,10 @@ public class MenuNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         // Assert - 'F' should be underlined
-        Assert.True(HasCellWithUnderline(snapshot, 'F'), "Accelerator 'F' should be underlined in normal state");
+        Assert.IsTrue(HasCellWithUnderline(snapshot, 'F'), "Accelerator 'F' should be underlined in normal state");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuNode_InMenuBar_Focused_ShowsAcceleratorUnderline()
     {
         // Arrange
@@ -661,10 +662,10 @@ public class MenuNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         // Assert - 'F' should still be underlined when focused
-        Assert.True(HasCellWithUnderline(snapshot, 'F'), "Accelerator 'F' should be underlined when focused");
+        Assert.IsTrue(HasCellWithUnderline(snapshot, 'F'), "Accelerator 'F' should be underlined when focused");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuNode_InMenuBar_Selected_ShowsAcceleratorUnderline()
     {
         // Arrange
@@ -697,10 +698,10 @@ public class MenuNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         // Assert - 'F' should still be underlined when selected
-        Assert.True(HasCellWithUnderline(snapshot, 'F'), "Accelerator 'F' should be underlined when selected");
+        Assert.IsTrue(HasCellWithUnderline(snapshot, 'F'), "Accelerator 'F' should be underlined when selected");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuNode_InMenuBar_Hovered_ShowsAcceleratorUnderline()
     {
         // Arrange
@@ -734,10 +735,10 @@ public class MenuNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         // Assert - 'F' should still be underlined when hovered
-        Assert.True(HasCellWithUnderline(snapshot, 'F'), "Accelerator 'F' should be underlined when hovered");
+        Assert.IsTrue(HasCellWithUnderline(snapshot, 'F'), "Accelerator 'F' should be underlined when hovered");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuNode_InMenuBar_Open_ShowsAcceleratorUnderline()
     {
         // Arrange
@@ -770,10 +771,10 @@ public class MenuNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         // Assert - 'F' should still be underlined when open
-        Assert.True(HasCellWithUnderline(snapshot, 'F'), "Accelerator 'F' should be underlined when open");
+        Assert.IsTrue(HasCellWithUnderline(snapshot, 'F'), "Accelerator 'F' should be underlined when open");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItemNode_Normal_ShowsAcceleratorUnderline()
     {
         // Arrange
@@ -802,10 +803,10 @@ public class MenuNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         // Assert - 'O' should be underlined
-        Assert.True(HasCellWithUnderline(snapshot, 'O'), "Accelerator 'O' should be underlined in normal state");
+        Assert.IsTrue(HasCellWithUnderline(snapshot, 'O'), "Accelerator 'O' should be underlined in normal state");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItemNode_Focused_ShowsAcceleratorUnderline()
     {
         // Arrange
@@ -834,10 +835,10 @@ public class MenuNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         // Assert - 'O' should still be underlined when focused
-        Assert.True(HasCellWithUnderline(snapshot, 'O'), "Accelerator 'O' should be underlined when focused");
+        Assert.IsTrue(HasCellWithUnderline(snapshot, 'O'), "Accelerator 'O' should be underlined when focused");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItemNode_Hovered_ShowsAcceleratorUnderline()
     {
         // Arrange
@@ -866,10 +867,10 @@ public class MenuNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         // Assert - 'O' should still be underlined when hovered
-        Assert.True(HasCellWithUnderline(snapshot, 'O'), "Accelerator 'O' should be underlined when hovered");
+        Assert.IsTrue(HasCellWithUnderline(snapshot, 'O'), "Accelerator 'O' should be underlined when hovered");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MenuItemNode_Disabled_DoesNotShowAcceleratorUnderline()
     {
         // Arrange
@@ -898,7 +899,7 @@ public class MenuNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         // Assert - 'O' should NOT be underlined when disabled (accelerators are not available for disabled items)
-        Assert.False(HasCellWithUnderline(snapshot, 'O'), "Accelerator 'O' should NOT be underlined when disabled");
+        Assert.IsFalse(HasCellWithUnderline(snapshot, 'O'), "Accelerator 'O' should NOT be underlined when disabled");
     }
     
     #endregion

--- a/tests/Hex1b.Tests/MouseBindingTests.cs
+++ b/tests/Hex1b.Tests/MouseBindingTests.cs
@@ -4,9 +4,10 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class MouseBindingTests
 {
-    [Fact]
+    [TestMethod]
     public void MouseBinding_MatchesCorrectEvent()
     {
         var binding = new MouseBinding(
@@ -20,11 +21,11 @@ public class MouseBindingTests
         var matchingEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 10, Hex1bModifiers.None);
         var nonMatchingEvent = new Hex1bMouseEvent(MouseButton.Right, MouseAction.Down, 10, 10, Hex1bModifiers.None);
         
-        Assert.True(binding.Matches(matchingEvent));
-        Assert.False(binding.Matches(nonMatchingEvent));
+        Assert.IsTrue(binding.Matches(matchingEvent));
+        Assert.IsFalse(binding.Matches(nonMatchingEvent));
     }
     
-    [Fact]
+    [TestMethod]
     public async Task MouseBinding_Execute_InvokesHandler()
     {
         var executed = false;
@@ -39,10 +40,10 @@ public class MouseBindingTests
         var actionContext = new InputBindingActionContext(new FocusRing());
         await binding.ExecuteAsync(actionContext);
         
-        Assert.True(executed);
+        Assert.IsTrue(executed);
     }
     
-    [Fact]
+    [TestMethod]
     public void MouseBinding_WithModifiers_MatchesCorrectly()
     {
         var binding = new MouseBinding(
@@ -56,24 +57,24 @@ public class MouseBindingTests
         var ctrlClick = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 10, Hex1bModifiers.Control);
         var plainClick = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 10, Hex1bModifiers.None);
         
-        Assert.True(binding.Matches(ctrlClick));
-        Assert.False(binding.Matches(plainClick));
+        Assert.IsTrue(binding.Matches(ctrlClick));
+        Assert.IsFalse(binding.Matches(plainClick));
     }
     
-    [Fact]
+    [TestMethod]
     public void InputBindingsBuilder_Mouse_AddsBinding()
     {
         var builder = new InputBindingsBuilder();
         
         builder.Mouse(MouseButton.Left).Action(_ => { return Task.CompletedTask; }, "Click");
         
-        Assert.Single(builder.MouseBindings);
-        Assert.Equal(MouseButton.Left, builder.MouseBindings[0].Button);
-        Assert.Equal(MouseAction.Down, builder.MouseBindings[0].Action);
-        Assert.Equal("Click", builder.MouseBindings[0].Description);
+        TestSeq.Single(builder.MouseBindings);
+        Assert.AreEqual(MouseButton.Left, builder.MouseBindings[0].Button);
+        Assert.AreEqual(MouseAction.Down, builder.MouseBindings[0].Action);
+        Assert.AreEqual("Click", builder.MouseBindings[0].Description);
     }
     
-    [Fact]
+    [TestMethod]
     public void InputBindingsBuilder_Mouse_WithModifiers()
     {
         var builder = new InputBindingsBuilder();
@@ -81,10 +82,10 @@ public class MouseBindingTests
         builder.Mouse(MouseButton.Left).Ctrl().Action(_ => Task.CompletedTask, "Ctrl+Click");
         
         var binding = builder.MouseBindings[0];
-        Assert.Equal(Hex1bModifiers.Control, binding.Modifiers);
+        Assert.AreEqual(Hex1bModifiers.Control, binding.Modifiers);
     }
     
-    [Fact]
+    [TestMethod]
     public void InputBindingsBuilder_Mouse_OnRelease()
     {
         var builder = new InputBindingsBuilder();
@@ -92,10 +93,10 @@ public class MouseBindingTests
         builder.Mouse(MouseButton.Left).OnRelease().Action(_ => Task.CompletedTask, "Release");
         
         var binding = builder.MouseBindings[0];
-        Assert.Equal(MouseAction.Up, binding.Action);
+        Assert.AreEqual(MouseAction.Up, binding.Action);
     }
     
-    [Fact]
+    [TestMethod]
     public void InputBindingsBuilder_BuildsMultipleMouseBindings()
     {
         var builder = new InputBindingsBuilder();
@@ -104,25 +105,26 @@ public class MouseBindingTests
         builder.Mouse(MouseButton.Right).Ctrl().Action(_ => Task.CompletedTask, "Ctrl+Right");
         builder.Mouse(MouseButton.Middle).OnRelease().Action(_ => Task.CompletedTask, "Middle Release");
         
-        Assert.Equal(3, builder.MouseBindings.Count);
+        Assert.AreEqual(3, builder.MouseBindings.Count);
         
-        Assert.Equal(MouseButton.Left, builder.MouseBindings[0].Button);
-        Assert.Equal(MouseAction.Down, builder.MouseBindings[0].Action);
-        Assert.Equal(Hex1bModifiers.None, builder.MouseBindings[0].Modifiers);
+        Assert.AreEqual(MouseButton.Left, builder.MouseBindings[0].Button);
+        Assert.AreEqual(MouseAction.Down, builder.MouseBindings[0].Action);
+        Assert.AreEqual(Hex1bModifiers.None, builder.MouseBindings[0].Modifiers);
         
-        Assert.Equal(MouseButton.Right, builder.MouseBindings[1].Button);
-        Assert.Equal(MouseAction.Down, builder.MouseBindings[1].Action);
-        Assert.Equal(Hex1bModifiers.Control, builder.MouseBindings[1].Modifiers);
+        Assert.AreEqual(MouseButton.Right, builder.MouseBindings[1].Button);
+        Assert.AreEqual(MouseAction.Down, builder.MouseBindings[1].Action);
+        Assert.AreEqual(Hex1bModifiers.Control, builder.MouseBindings[1].Modifiers);
         
-        Assert.Equal(MouseButton.Middle, builder.MouseBindings[2].Button);
-        Assert.Equal(MouseAction.Up, builder.MouseBindings[2].Action);
-        Assert.Equal(Hex1bModifiers.None, builder.MouseBindings[2].Modifiers);
+        Assert.AreEqual(MouseButton.Middle, builder.MouseBindings[2].Button);
+        Assert.AreEqual(MouseAction.Up, builder.MouseBindings[2].Action);
+        Assert.AreEqual(Hex1bModifiers.None, builder.MouseBindings[2].Modifiers);
     }
 }
 
+[TestClass]
 public class DoubleClickBindingTests
 {
-    [Fact]
+    [TestMethod]
     public void MouseBinding_WithClickCount_MatchesCorrectEvent()
     {
         var binding = new MouseBinding(
@@ -135,18 +137,18 @@ public class DoubleClickBindingTests
         
         // Single click should NOT match a double-click binding
         var singleClick = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 10, Hex1bModifiers.None, ClickCount: 1);
-        Assert.False(binding.Matches(singleClick));
+        Assert.IsFalse(binding.Matches(singleClick));
         
         // Double click should match
         var doubleClick = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 10, Hex1bModifiers.None, ClickCount: 2);
-        Assert.True(binding.Matches(doubleClick));
+        Assert.IsTrue(binding.Matches(doubleClick));
         
         // Triple click should also match (>= 2)
         var tripleClick = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 10, Hex1bModifiers.None, ClickCount: 3);
-        Assert.True(binding.Matches(tripleClick));
+        Assert.IsTrue(binding.Matches(tripleClick));
     }
     
-    [Fact]
+    [TestMethod]
     public void MouseBinding_SingleClick_MatchesAllClickCounts()
     {
         var binding = new MouseBinding(
@@ -162,12 +164,12 @@ public class DoubleClickBindingTests
         var doubleClick = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 10, Hex1bModifiers.None, ClickCount: 2);
         var tripleClick = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 10, Hex1bModifiers.None, ClickCount: 3);
         
-        Assert.True(binding.Matches(singleClick));
-        Assert.True(binding.Matches(doubleClick));
-        Assert.True(binding.Matches(tripleClick));
+        Assert.IsTrue(binding.Matches(singleClick));
+        Assert.IsTrue(binding.Matches(doubleClick));
+        Assert.IsTrue(binding.Matches(tripleClick));
     }
     
-    [Fact]
+    [TestMethod]
     public void MouseBinding_TripleClick_RequiresThreeClicks()
     {
         var binding = new MouseBinding(
@@ -182,12 +184,12 @@ public class DoubleClickBindingTests
         var doubleClick = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 10, Hex1bModifiers.None, ClickCount: 2);
         var tripleClick = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 10, Hex1bModifiers.None, ClickCount: 3);
         
-        Assert.False(binding.Matches(singleClick));
-        Assert.False(binding.Matches(doubleClick));
-        Assert.True(binding.Matches(tripleClick));
+        Assert.IsFalse(binding.Matches(singleClick));
+        Assert.IsFalse(binding.Matches(doubleClick));
+        Assert.IsTrue(binding.Matches(tripleClick));
     }
     
-    [Fact]
+    [TestMethod]
     public void InputBindingsBuilder_DoubleClick_SetsClickCount()
     {
         var builder = new InputBindingsBuilder();
@@ -195,10 +197,10 @@ public class DoubleClickBindingTests
         builder.Mouse(MouseButton.Left).DoubleClick().Action(_ => Task.CompletedTask, "Double-click");
         
         var binding = builder.MouseBindings[0];
-        Assert.Equal(2, binding.ClickCount);
+        Assert.AreEqual(2, binding.ClickCount);
     }
     
-    [Fact]
+    [TestMethod]
     public void InputBindingsBuilder_TripleClick_SetsClickCount()
     {
         var builder = new InputBindingsBuilder();
@@ -206,10 +208,10 @@ public class DoubleClickBindingTests
         builder.Mouse(MouseButton.Left).TripleClick().Action(_ => Task.CompletedTask, "Triple-click");
         
         var binding = builder.MouseBindings[0];
-        Assert.Equal(3, binding.ClickCount);
+        Assert.AreEqual(3, binding.ClickCount);
     }
     
-    [Fact]
+    [TestMethod]
     public void InputBindingsBuilder_DoubleClick_WithModifiers()
     {
         var builder = new InputBindingsBuilder();
@@ -217,71 +219,72 @@ public class DoubleClickBindingTests
         builder.Mouse(MouseButton.Left).Ctrl().DoubleClick().Action(_ => Task.CompletedTask, "Ctrl+Double-click");
         
         var binding = builder.MouseBindings[0];
-        Assert.Equal(Hex1bModifiers.Control, binding.Modifiers);
-        Assert.Equal(2, binding.ClickCount);
+        Assert.AreEqual(Hex1bModifiers.Control, binding.Modifiers);
+        Assert.AreEqual(2, binding.ClickCount);
         
         // Should match Ctrl+double-click
         var ctrlDoubleClick = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 10, Hex1bModifiers.Control, ClickCount: 2);
-        Assert.True(binding.Matches(ctrlDoubleClick));
+        Assert.IsTrue(binding.Matches(ctrlDoubleClick));
         
         // Should NOT match plain double-click
         var plainDoubleClick = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 10, Hex1bModifiers.None, ClickCount: 2);
-        Assert.False(binding.Matches(plainDoubleClick));
+        Assert.IsFalse(binding.Matches(plainDoubleClick));
     }
     
-    [Fact]
+    [TestMethod]
     public void Hex1bMouseEvent_ClickCount_DefaultsToOne()
     {
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 10, Hex1bModifiers.None);
-        Assert.Equal(1, mouseEvent.ClickCount);
+        Assert.AreEqual(1, mouseEvent.ClickCount);
     }
     
-    [Fact]
+    [TestMethod]
     public void Hex1bMouseEvent_IsDoubleClick_ReturnsTrueForClickCountTwo()
     {
         var singleClick = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 10, Hex1bModifiers.None, ClickCount: 1);
         var doubleClick = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 10, Hex1bModifiers.None, ClickCount: 2);
         var tripleClick = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 10, Hex1bModifiers.None, ClickCount: 3);
         
-        Assert.False(singleClick.IsDoubleClick);
-        Assert.True(doubleClick.IsDoubleClick);
-        Assert.False(tripleClick.IsDoubleClick);
+        Assert.IsFalse(singleClick.IsDoubleClick);
+        Assert.IsTrue(doubleClick.IsDoubleClick);
+        Assert.IsFalse(tripleClick.IsDoubleClick);
     }
     
-    [Fact]
+    [TestMethod]
     public void Hex1bMouseEvent_IsTripleClick_ReturnsTrueForClickCountThree()
     {
         var singleClick = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 10, Hex1bModifiers.None, ClickCount: 1);
         var doubleClick = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 10, Hex1bModifiers.None, ClickCount: 2);
         var tripleClick = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 10, Hex1bModifiers.None, ClickCount: 3);
         
-        Assert.False(singleClick.IsTripleClick);
-        Assert.False(doubleClick.IsTripleClick);
-        Assert.True(tripleClick.IsTripleClick);
+        Assert.IsFalse(singleClick.IsTripleClick);
+        Assert.IsFalse(doubleClick.IsTripleClick);
+        Assert.IsTrue(tripleClick.IsTripleClick);
     }
     
-    [Fact]
+    [TestMethod]
     public void Hex1bMouseEvent_WithClickCount_CreatesNewEvent()
     {
         var original = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 5, 10, Hex1bModifiers.Control);
         var modified = original.WithClickCount(2);
         
         // Original should be unchanged
-        Assert.Equal(1, original.ClickCount);
+        Assert.AreEqual(1, original.ClickCount);
         
         // Modified should have new click count but same other properties
-        Assert.Equal(2, modified.ClickCount);
-        Assert.Equal(MouseButton.Left, modified.Button);
-        Assert.Equal(MouseAction.Down, modified.Action);
-        Assert.Equal(5, modified.X);
-        Assert.Equal(10, modified.Y);
-        Assert.Equal(Hex1bModifiers.Control, modified.Modifiers);
+        Assert.AreEqual(2, modified.ClickCount);
+        Assert.AreEqual(MouseButton.Left, modified.Button);
+        Assert.AreEqual(MouseAction.Down, modified.Action);
+        Assert.AreEqual(5, modified.X);
+        Assert.AreEqual(10, modified.Y);
+        Assert.AreEqual(Hex1bModifiers.Control, modified.Modifiers);
     }
 }
 
+[TestClass]
 public class FocusRingHitTestTests
 {
-    [Fact]
+    [TestMethod]
     public void HitTest_ReturnsNodeAtPosition()
     {
         var button = new ButtonNode { Label = "Test" };
@@ -293,14 +296,14 @@ public class FocusRingHitTestTests
         
         // Hit inside bounds
         var hit = focusRing.HitTest(7, 5);
-        Assert.Same(button, hit);
+        Assert.AreSame(button, hit);
         
         // Miss - outside bounds
         var miss = focusRing.HitTest(0, 0);
-        Assert.Null(miss);
+        Assert.IsNull(miss);
     }
     
-    [Fact]
+    [TestMethod]
     public void HitTest_ReturnsTopmostNode_WhenOverlapping()
     {
         // Create a VStack with two buttons
@@ -320,21 +323,21 @@ public class FocusRingHitTestTests
         
         // Hit test on button1's row
         var hit1 = focusRing.HitTest(5, 0);
-        Assert.Same(button1, hit1);
+        Assert.AreSame(button1, hit1);
         
         // Hit test on button2's row
         var hit2 = focusRing.HitTest(5, 1);
-        Assert.Same(button2, hit2);
+        Assert.AreSame(button2, hit2);
     }
     
-    [Fact]
+    [TestMethod]
     public void HitTest_ReturnsNull_WhenNoFocusables()
     {
         var focusRing = new FocusRing();
         focusRing.Rebuild(null);
         
         var hit = focusRing.HitTest(5, 5);
-        Assert.Null(hit);
+        Assert.IsNull(hit);
     }
     
     // Simple test container that returns children as focusables
@@ -363,69 +366,70 @@ public class FocusRingHitTestTests
     }
 }
 
+[TestClass]
 public class HoverStateTests
 {
-    [Fact]
+    [TestMethod]
     public void IsHovered_DefaultsToFalse()
     {
         var button = new ButtonNode { Label = "Test" };
-        Assert.False(button.IsHovered);
+        Assert.IsFalse(button.IsHovered);
     }
     
-    [Fact]
+    [TestMethod]
     public void IsHovered_CanBeSet()
     {
         var button = new ButtonNode { Label = "Test" };
         button.IsHovered = true;
-        Assert.True(button.IsHovered);
+        Assert.IsTrue(button.IsHovered);
         
         button.IsHovered = false;
-        Assert.False(button.IsHovered);
+        Assert.IsFalse(button.IsHovered);
     }
     
-    [Fact]
+    [TestMethod]
     public void TextBoxNode_IsHovered_CanBeSet()
     {
         var textBox = new TextBoxNode { State = new TextBoxState { Text = "Hello" } };
-        Assert.False(textBox.IsHovered);
+        Assert.IsFalse(textBox.IsHovered);
         
         textBox.IsHovered = true;
-        Assert.True(textBox.IsHovered);
+        Assert.IsTrue(textBox.IsHovered);
     }
     
-    [Fact]
+    [TestMethod]
     public void ListNode_IsHovered_CanBeSet()
     {
         var list = new ListNode { Items = ["Item 1", "Item 2"] };
-        Assert.False(list.IsHovered);
+        Assert.IsFalse(list.IsHovered);
         
         list.IsHovered = true;
-        Assert.True(list.IsHovered);
+        Assert.IsTrue(list.IsHovered);
     }
     
-    [Fact]
+    [TestMethod]
     public void ToggleSwitchNode_IsHovered_CanBeSet()
     {
         var toggle = new ToggleSwitchNode { Options = ["A", "B"] };
-        Assert.False(toggle.IsHovered);
+        Assert.IsFalse(toggle.IsHovered);
         
         toggle.IsHovered = true;
-        Assert.True(toggle.IsHovered);
+        Assert.IsTrue(toggle.IsHovered);
     }
     
-    [Fact]
+    [TestMethod]
     public void NonFocusableNode_IsHovered_ReturnsFalse()
     {
         // Create a simple non-focusable node
         var textBlock = new TextBlockNode { Text = "Hello" };
-        Assert.False(textBlock.IsHovered);
+        Assert.IsFalse(textBlock.IsHovered);
         
         // Setting should be ignored (default implementation does nothing)
         textBlock.IsHovered = true;
-        Assert.False(textBlock.IsHovered);
+        Assert.IsFalse(textBlock.IsHovered);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MouseStepBuilder_TriggersActionId_AliasesPreviouslyRegisteredHandler()
     {
         // Mirror of the AgenticPromptDemo Ctrl+wheel scenario: a widget's
@@ -447,40 +451,39 @@ public class HoverStateTests
         // User aliases it to Ctrl+ScrollUp without re-supplying the handler.
         bindings.Mouse(MouseButton.ScrollUp).Ctrl().Triggers(actionId);
 
-        Assert.Equal(2, bindings.MouseBindings.Count);
+        Assert.AreEqual(2, bindings.MouseBindings.Count);
 
         var plainBinding = bindings.MouseBindings[0];
         var ctrlBinding = bindings.MouseBindings[1];
 
-        Assert.Equal(actionId, plainBinding.ActionId);
-        Assert.Equal(actionId, ctrlBinding.ActionId);
-        Assert.Equal(Hex1bModifiers.None, plainBinding.Modifiers);
-        Assert.Equal(Hex1bModifiers.Control, ctrlBinding.Modifiers);
-        Assert.Equal("Scroll up", ctrlBinding.Description);
+        Assert.AreEqual(actionId, plainBinding.ActionId);
+        Assert.AreEqual(actionId, ctrlBinding.ActionId);
+        Assert.AreEqual(Hex1bModifiers.None, plainBinding.Modifiers);
+        Assert.AreEqual(Hex1bModifiers.Control, ctrlBinding.Modifiers);
+        Assert.AreEqual("Scroll up", ctrlBinding.Description);
 
         var ctx = new InputBindingActionContext(new FocusRing());
         var plainEvent = new Hex1bMouseEvent(MouseButton.ScrollUp, MouseAction.Down, 0, 0, Hex1bModifiers.None);
         var ctrlEvent = new Hex1bMouseEvent(MouseButton.ScrollUp, MouseAction.Down, 0, 0, Hex1bModifiers.Control);
 
-        Assert.True(plainBinding.Matches(plainEvent));
-        Assert.False(plainBinding.Matches(ctrlEvent));
-        Assert.True(ctrlBinding.Matches(ctrlEvent));
-        Assert.False(ctrlBinding.Matches(plainEvent));
+        Assert.IsTrue(plainBinding.Matches(plainEvent));
+        Assert.IsFalse(plainBinding.Matches(ctrlEvent));
+        Assert.IsTrue(ctrlBinding.Matches(ctrlEvent));
+        Assert.IsFalse(ctrlBinding.Matches(plainEvent));
 
         await plainBinding.ExecuteAsync(ctx);
         await ctrlBinding.ExecuteAsync(ctx);
 
-        Assert.Equal(2, invocations);
+        Assert.AreEqual(2, invocations);
     }
 
-    [Fact]
+    [TestMethod]
     public void MouseStepBuilder_TriggersActionId_ThrowsWhenActionUnregistered()
     {
         var bindings = new InputBindingsBuilder();
         var unregistered = new ActionId("Test.NotRegistered");
 
-        var ex = Assert.Throws<InvalidOperationException>(
-            () => bindings.Mouse(MouseButton.ScrollUp).Ctrl().Triggers(unregistered));
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() => bindings.Mouse(MouseButton.ScrollUp).Ctrl().Triggers(unregistered));
         Assert.Contains(unregistered.Value, ex.Message);
     }
 }

--- a/tests/Hex1b.Tests/MouseCursorFlickerTests.cs
+++ b/tests/Hex1b.Tests/MouseCursorFlickerTests.cs
@@ -19,6 +19,7 @@ namespace Hex1b.Tests;
 /// between <c>?2026h</c> and <c>?2026l</c> and paint atomically; non-supporting
 /// terminals ignore the sequences.
 /// </summary>
+[TestClass]
 public class MouseCursorFlickerTests
 {
     /// <summary>
@@ -68,7 +69,7 @@ public class MouseCursorFlickerTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RenderFrame_WithMouseEnabled_WrapsHideShowInSynchronizedUpdate()
     {
         var recorder = new CursorTokenRecorder();
@@ -121,9 +122,9 @@ public class MouseCursorFlickerTests
             var begin = tokens.Select((t, i) => (t, i)).FirstOrDefault(x => x.t.Mode == 2026 && x.t.Enable);
             var end = tokens.Select((t, i) => (t, i)).LastOrDefault(x => x.t.Mode == 2026 && !x.t.Enable);
 
-            Assert.NotNull(begin.t);
-            Assert.NotNull(end.t);
-            Assert.True(begin.i < end.i, "Begin sync-update token must precede end token.");
+            Assert.IsNotNull(begin.t);
+            Assert.IsNotNull(end.t);
+            Assert.IsTrue(begin.i < end.i, "Begin sync-update token must precede end token.");
 
             // Every hide/show cursor token between begin and end must lie inside
             // the synchronized region — that is what makes the hide → cells →
@@ -131,9 +132,7 @@ public class MouseCursorFlickerTests
             for (var i = 0; i < tokens.Count; i++)
             {
                 if (tokens[i].Mode != 25) continue;
-                Assert.True(
-                    i > begin.i && i < end.i,
-                    $"Cursor visibility token at index {i} (Enable={tokens[i].Enable}) must be inside the synchronized-update region [{begin.i}..{end.i}], not outside it.");
+                Assert.IsTrue(i > begin.i && i < end.i, $"Cursor visibility token at index {i} (Enable={tokens[i].Enable}) must be inside the synchronized-update region [{begin.i}..{end.i}], not outside it.");
             }
         }
         finally
@@ -146,7 +145,7 @@ public class MouseCursorFlickerTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RenderFrame_SynchronizedUpdate_BeginAndEndAreBalanced()
     {
         var recorder = new CursorTokenRecorder();
@@ -193,8 +192,8 @@ public class MouseCursorFlickerTests
 
             // Each render frame must emit a balanced begin/end pair so the
             // terminal never gets stuck buffering output indefinitely.
-            Assert.Equal(beginCount, endCount);
-            Assert.True(beginCount >= 3, $"Expected at least 3 sync-update frames, got {beginCount}.");
+            Assert.AreEqual(beginCount, endCount);
+            Assert.IsTrue(beginCount >= 3, $"Expected at least 3 sync-update frames, got {beginCount}.");
         }
         finally
         {

--- a/tests/Hex1b.Tests/MouseParserTests.cs
+++ b/tests/Hex1b.Tests/MouseParserTests.cs
@@ -2,168 +2,169 @@ using Hex1b.Input;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class MouseParserTests
 {
-    [Fact]
+    [TestMethod]
     public void TryParseSgr_MouseMove_ParsesCorrectly()
     {
         // Mouse move at position (10, 5) - SGR format: \e[<35;11;6M (1-based coords)
         // 35 = 32 (motion) + 3 (no button)
         var result = MouseParser.TryParseSgr("35;11;6M", out var evt);
         
-        Assert.True(result);
-        Assert.NotNull(evt);
-        Assert.Equal(MouseButton.None, evt.Button);
-        Assert.Equal(MouseAction.Move, evt.Action);
-        Assert.Equal(10, evt.X); // 0-based
-        Assert.Equal(5, evt.Y);  // 0-based
-        Assert.Equal(Hex1bModifiers.None, evt.Modifiers);
+        Assert.IsTrue(result);
+        Assert.IsNotNull(evt);
+        Assert.AreEqual(MouseButton.None, evt.Button);
+        Assert.AreEqual(MouseAction.Move, evt.Action);
+        Assert.AreEqual(10, evt.X); // 0-based
+        Assert.AreEqual(5, evt.Y);  // 0-based
+        Assert.AreEqual(Hex1bModifiers.None, evt.Modifiers);
     }
     
-    [Fact]
+    [TestMethod]
     public void TryParseSgr_LeftButtonDown_ParsesCorrectly()
     {
         // Left button down at (1, 1) - SGR format: \e[<0;2;2M
         var result = MouseParser.TryParseSgr("0;2;2M", out var evt);
         
-        Assert.True(result);
-        Assert.NotNull(evt);
-        Assert.Equal(MouseButton.Left, evt.Button);
-        Assert.Equal(MouseAction.Down, evt.Action);
-        Assert.Equal(1, evt.X);
-        Assert.Equal(1, evt.Y);
+        Assert.IsTrue(result);
+        Assert.IsNotNull(evt);
+        Assert.AreEqual(MouseButton.Left, evt.Button);
+        Assert.AreEqual(MouseAction.Down, evt.Action);
+        Assert.AreEqual(1, evt.X);
+        Assert.AreEqual(1, evt.Y);
     }
     
-    [Fact]
+    [TestMethod]
     public void TryParseSgr_LeftButtonUp_ParsesCorrectly()
     {
         // Left button up at (1, 1) - SGR format: \e[<0;2;2m (lowercase m = release)
         var result = MouseParser.TryParseSgr("0;2;2m", out var evt);
         
-        Assert.True(result);
-        Assert.NotNull(evt);
-        Assert.Equal(MouseButton.Left, evt.Button);
-        Assert.Equal(MouseAction.Up, evt.Action);
+        Assert.IsTrue(result);
+        Assert.IsNotNull(evt);
+        Assert.AreEqual(MouseButton.Left, evt.Button);
+        Assert.AreEqual(MouseAction.Up, evt.Action);
     }
     
-    [Fact]
+    [TestMethod]
     public void TryParseSgr_RightButtonDown_ParsesCorrectly()
     {
         // Right button = 2
         var result = MouseParser.TryParseSgr("2;5;10M", out var evt);
         
-        Assert.True(result);
-        Assert.NotNull(evt);
-        Assert.Equal(MouseButton.Right, evt.Button);
-        Assert.Equal(MouseAction.Down, evt.Action);
-        Assert.Equal(4, evt.X);
-        Assert.Equal(9, evt.Y);
+        Assert.IsTrue(result);
+        Assert.IsNotNull(evt);
+        Assert.AreEqual(MouseButton.Right, evt.Button);
+        Assert.AreEqual(MouseAction.Down, evt.Action);
+        Assert.AreEqual(4, evt.X);
+        Assert.AreEqual(9, evt.Y);
     }
     
-    [Fact]
+    [TestMethod]
     public void TryParseSgr_MiddleButtonDown_ParsesCorrectly()
     {
         // Middle button = 1
         var result = MouseParser.TryParseSgr("1;5;10M", out var evt);
         
-        Assert.True(result);
-        Assert.NotNull(evt);
-        Assert.Equal(MouseButton.Middle, evt.Button);
-        Assert.Equal(MouseAction.Down, evt.Action);
+        Assert.IsTrue(result);
+        Assert.IsNotNull(evt);
+        Assert.AreEqual(MouseButton.Middle, evt.Button);
+        Assert.AreEqual(MouseAction.Down, evt.Action);
     }
     
-    [Fact]
+    [TestMethod]
     public void TryParseSgr_ScrollUp_ParsesCorrectly()
     {
         // Scroll up = 64 (scroll bit) + 0 (up)
         var result = MouseParser.TryParseSgr("64;10;5M", out var evt);
         
-        Assert.True(result);
-        Assert.NotNull(evt);
-        Assert.Equal(MouseButton.ScrollUp, evt.Button);
-        Assert.Equal(MouseAction.Down, evt.Action);
+        Assert.IsTrue(result);
+        Assert.IsNotNull(evt);
+        Assert.AreEqual(MouseButton.ScrollUp, evt.Button);
+        Assert.AreEqual(MouseAction.Down, evt.Action);
     }
     
-    [Fact]
+    [TestMethod]
     public void TryParseSgr_ScrollDown_ParsesCorrectly()
     {
         // Scroll down = 64 (scroll bit) + 1 (down)
         var result = MouseParser.TryParseSgr("65;10;5M", out var evt);
         
-        Assert.True(result);
-        Assert.NotNull(evt);
-        Assert.Equal(MouseButton.ScrollDown, evt.Button);
-        Assert.Equal(MouseAction.Down, evt.Action);
+        Assert.IsTrue(result);
+        Assert.IsNotNull(evt);
+        Assert.AreEqual(MouseButton.ScrollDown, evt.Button);
+        Assert.AreEqual(MouseAction.Down, evt.Action);
     }
     
-    [Fact]
+    [TestMethod]
     public void TryParseSgr_LeftDrag_ParsesCorrectly()
     {
         // Left button drag = 32 (motion) + 0 (left button)
         var result = MouseParser.TryParseSgr("32;15;20M", out var evt);
         
-        Assert.True(result);
-        Assert.NotNull(evt);
-        Assert.Equal(MouseButton.Left, evt.Button);
-        Assert.Equal(MouseAction.Drag, evt.Action);
-        Assert.Equal(14, evt.X);
-        Assert.Equal(19, evt.Y);
+        Assert.IsTrue(result);
+        Assert.IsNotNull(evt);
+        Assert.AreEqual(MouseButton.Left, evt.Button);
+        Assert.AreEqual(MouseAction.Drag, evt.Action);
+        Assert.AreEqual(14, evt.X);
+        Assert.AreEqual(19, evt.Y);
     }
     
-    [Fact]
+    [TestMethod]
     public void TryParseSgr_WithShiftModifier_ParsesCorrectly()
     {
         // Left button + Shift = 0 + 4
         var result = MouseParser.TryParseSgr("4;5;5M", out var evt);
         
-        Assert.True(result);
-        Assert.NotNull(evt);
-        Assert.Equal(MouseButton.Left, evt.Button);
-        Assert.Equal(Hex1bModifiers.Shift, evt.Modifiers);
+        Assert.IsTrue(result);
+        Assert.IsNotNull(evt);
+        Assert.AreEqual(MouseButton.Left, evt.Button);
+        Assert.AreEqual(Hex1bModifiers.Shift, evt.Modifiers);
     }
     
-    [Fact]
+    [TestMethod]
     public void TryParseSgr_WithAltModifier_ParsesCorrectly()
     {
         // Left button + Alt = 0 + 8
         var result = MouseParser.TryParseSgr("8;5;5M", out var evt);
         
-        Assert.True(result);
-        Assert.NotNull(evt);
-        Assert.Equal(MouseButton.Left, evt.Button);
-        Assert.Equal(Hex1bModifiers.Alt, evt.Modifiers);
+        Assert.IsTrue(result);
+        Assert.IsNotNull(evt);
+        Assert.AreEqual(MouseButton.Left, evt.Button);
+        Assert.AreEqual(Hex1bModifiers.Alt, evt.Modifiers);
     }
     
-    [Fact]
+    [TestMethod]
     public void TryParseSgr_WithControlModifier_ParsesCorrectly()
     {
         // Left button + Ctrl = 0 + 16
         var result = MouseParser.TryParseSgr("16;5;5M", out var evt);
         
-        Assert.True(result);
-        Assert.NotNull(evt);
-        Assert.Equal(MouseButton.Left, evt.Button);
-        Assert.Equal(Hex1bModifiers.Control, evt.Modifiers);
+        Assert.IsTrue(result);
+        Assert.IsNotNull(evt);
+        Assert.AreEqual(MouseButton.Left, evt.Button);
+        Assert.AreEqual(Hex1bModifiers.Control, evt.Modifiers);
     }
     
-    [Fact]
+    [TestMethod]
     public void TryParseSgr_InvalidSequence_ReturnsFalse()
     {
-        Assert.False(MouseParser.TryParseSgr("invalid", out _));
-        Assert.False(MouseParser.TryParseSgr("", out _));
-        Assert.False(MouseParser.TryParseSgr("1;2M", out _)); // Missing y
-        Assert.False(MouseParser.TryParseSgr("1;2;3X", out _)); // Wrong terminator
+        Assert.IsFalse(MouseParser.TryParseSgr("invalid", out _));
+        Assert.IsFalse(MouseParser.TryParseSgr("", out _));
+        Assert.IsFalse(MouseParser.TryParseSgr("1;2M", out _)); // Missing y
+        Assert.IsFalse(MouseParser.TryParseSgr("1;2;3X", out _)); // Wrong terminator
     }
     
-    [Fact]
+    [TestMethod]
     public void TryParseSgr_LargeCoordinates_ParsesCorrectly()
     {
         // SGR mode supports coordinates > 223 (unlike legacy modes)
         var result = MouseParser.TryParseSgr("0;300;200M", out var evt);
         
-        Assert.True(result);
-        Assert.NotNull(evt);
-        Assert.Equal(299, evt.X); // 0-based
-        Assert.Equal(199, evt.Y);
+        Assert.IsTrue(result);
+        Assert.IsNotNull(evt);
+        Assert.AreEqual(299, evt.X); // 0-based
+        Assert.AreEqual(199, evt.Y);
     }
 }

--- a/tests/Hex1b.Tests/MouseProtocolModeTests.cs
+++ b/tests/Hex1b.Tests/MouseProtocolModeTests.cs
@@ -9,99 +9,100 @@ namespace Hex1b.Tests;
 /// from child processes.
 /// Inspired by psmux's test_vt100_mouse.rs.
 /// </summary>
+[TestClass]
 public class MouseProtocolModeTests
 {
-    [Fact]
+    [TestMethod]
     public void Tokenize_MousePressRelease_Enable()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[?1000h");
 
-        var token = Assert.Single(result);
-        var pm = Assert.IsType<PrivateModeToken>(token);
-        Assert.Equal(1000, pm.Mode);
-        Assert.True(pm.Enable);
+        var token = TestSeq.Single(result);
+        var pm = TestSeq.IsType<PrivateModeToken>(token);
+        Assert.AreEqual(1000, pm.Mode);
+        Assert.IsTrue(pm.Enable);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_MousePressRelease_Disable()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[?1000l");
 
-        var token = Assert.Single(result);
-        var pm = Assert.IsType<PrivateModeToken>(token);
-        Assert.Equal(1000, pm.Mode);
-        Assert.False(pm.Enable);
+        var token = TestSeq.Single(result);
+        var pm = TestSeq.IsType<PrivateModeToken>(token);
+        Assert.AreEqual(1000, pm.Mode);
+        Assert.IsFalse(pm.Enable);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_MouseButtonMotion_Enable()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[?1002h");
 
-        var token = Assert.Single(result);
-        var pm = Assert.IsType<PrivateModeToken>(token);
-        Assert.Equal(1002, pm.Mode);
-        Assert.True(pm.Enable);
+        var token = TestSeq.Single(result);
+        var pm = TestSeq.IsType<PrivateModeToken>(token);
+        Assert.AreEqual(1002, pm.Mode);
+        Assert.IsTrue(pm.Enable);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_MouseAnyMotion_Enable()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[?1003h");
 
-        var token = Assert.Single(result);
-        var pm = Assert.IsType<PrivateModeToken>(token);
-        Assert.Equal(1003, pm.Mode);
-        Assert.True(pm.Enable);
+        var token = TestSeq.Single(result);
+        var pm = TestSeq.IsType<PrivateModeToken>(token);
+        Assert.AreEqual(1003, pm.Mode);
+        Assert.IsTrue(pm.Enable);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_MouseSgrEncoding_Enable()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[?1006h");
 
-        var token = Assert.Single(result);
-        var pm = Assert.IsType<PrivateModeToken>(token);
-        Assert.Equal(1006, pm.Mode);
-        Assert.True(pm.Enable);
+        var token = TestSeq.Single(result);
+        var pm = TestSeq.IsType<PrivateModeToken>(token);
+        Assert.AreEqual(1006, pm.Mode);
+        Assert.IsTrue(pm.Enable);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_MouseSgrEncoding_Disable()
     {
         var result = AnsiTokenizer.Tokenize("\x1b[?1006l");
 
-        var token = Assert.Single(result);
-        var pm = Assert.IsType<PrivateModeToken>(token);
-        Assert.Equal(1006, pm.Mode);
-        Assert.False(pm.Enable);
+        var token = TestSeq.Single(result);
+        var pm = TestSeq.IsType<PrivateModeToken>(token);
+        Assert.AreEqual(1006, pm.Mode);
+        Assert.IsFalse(pm.Enable);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_FullMouseEnableSequence_ReturnsAllFourTokens()
     {
         // This is the full sequence MouseParser.EnableMouseTracking sends
         var result = AnsiTokenizer.Tokenize(
             "\x1b[?1000h\x1b[?1002h\x1b[?1003h\x1b[?1006h");
 
-        Assert.Equal(4, result.Count);
+        Assert.AreEqual(4, result.Count);
 
         var modes = result.Cast<PrivateModeToken>().Select(t => t.Mode).ToList();
-        Assert.Equal([1000, 1002, 1003, 1006], modes);
-        Assert.All(result.Cast<PrivateModeToken>(), t => Assert.True(t.Enable));
+        TestSeq.AreEqual([1000, 1002, 1003, 1006], modes);
+        TestSeq.All(result.Cast<PrivateModeToken>(), t => Assert.IsTrue(t.Enable));
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_FullMouseDisableSequence_ReturnsAllFourTokensReversed()
     {
         // This is the full sequence MouseParser.DisableMouseTracking sends
         var result = AnsiTokenizer.Tokenize(
             "\x1b[?1006l\x1b[?1003l\x1b[?1002l\x1b[?1000l");
 
-        Assert.Equal(4, result.Count);
+        Assert.AreEqual(4, result.Count);
 
         var modes = result.Cast<PrivateModeToken>().Select(t => t.Mode).ToList();
-        Assert.Equal([1006, 1003, 1002, 1000], modes);
-        Assert.All(result.Cast<PrivateModeToken>(), t => Assert.False(t.Enable));
+        TestSeq.AreEqual([1006, 1003, 1002, 1000], modes);
+        TestSeq.All(result.Cast<PrivateModeToken>(), t => Assert.IsFalse(t.Enable));
     }
 }

--- a/tests/Hex1b.Tests/MultiCursorPerformanceTests.cs
+++ b/tests/Hex1b.Tests/MultiCursorPerformanceTests.cs
@@ -17,7 +17,8 @@ namespace Hex1b.Tests;
 ///
 /// The fix: batch all piece tree mutations, call RebuildCaches() once at the end.
 /// </summary>
-[Collection("CPU-Intensive")]
+[DoNotParallelize]
+[TestClass]
 public class MultiCursorPerformanceTests
 {
     /// <summary>
@@ -67,19 +68,19 @@ public class MultiCursorPerformanceTests
         return (state, placed);
     }
 
-    [Fact]
+    [TestMethod]
     public void MultiCursorReplace_70Cursors_100KLines_Correctness()
     {
         // Smaller doc for correctness check (faster in CI)
         var (state, cursorCount) = SetupMultiCursorScenario(
             lineCount: 1000, cursorCount: 70, targetWord: "TARGET");
 
-        Assert.Equal(70, cursorCount);
+        Assert.AreEqual(70, cursorCount);
 
         // Verify all cursors have selections
         foreach (var cursor in state.Cursors)
         {
-            Assert.True(cursor.HasSelection, "Each cursor should have a selection");
+            Assert.IsTrue(cursor.HasSelection, "Each cursor should have a selection");
         }
 
         // Replace all selections with "X"
@@ -97,28 +98,28 @@ public class MultiCursorPerformanceTests
                 replacedCount++;
         }
 
-        Assert.Equal(70, replacedCount);
+        Assert.AreEqual(70, replacedCount);
 
         // Verify cursors are valid
         foreach (var cursor in state.Cursors)
         {
-            Assert.True(cursor.Position.Value >= 0);
-            Assert.True(cursor.Position.Value <= state.Document.Length);
-            Assert.False(cursor.HasSelection, "Selections should be cleared after replace");
+            Assert.IsTrue(cursor.Position.Value >= 0);
+            Assert.IsTrue(cursor.Position.Value <= state.Document.Length);
+            Assert.IsFalse(cursor.HasSelection, "Selections should be cleared after replace");
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void MultiCursorReplace_70Cursors_100KLines_Performance()
     {
         var (state, cursorCount) = SetupMultiCursorScenario(
             lineCount: 100_000, cursorCount: 70, targetWord: "TARGET");
 
-        Assert.Equal(70, cursorCount);
+        Assert.AreEqual(70, cursorCount);
 
         // Warm up: verify document is ready
-        Assert.True(state.Document.Length > 0);
-        Assert.True(state.Document.LineCount >= 100_000);
+        Assert.IsTrue(state.Document.Length > 0);
+        Assert.IsTrue(state.Document.LineCount >= 100_000);
 
         // Measure the replace operation
         var sw = Stopwatch.StartNew();
@@ -130,20 +131,19 @@ public class MultiCursorPerformanceTests
 
         // With batch mode: single RebuildCaches call, typically <100ms.
         // Use 500ms threshold for CI headroom.
-        Assert.True(ms < 500,
-            $"Multi-cursor replace with {cursorCount} cursors on 100K-line doc " +
+        Assert.IsTrue(ms < 500, $"Multi-cursor replace with {cursorCount} cursors on 100K-line doc " +
             $"took {ms}ms — expected <500ms. " +
             $"This likely means RebuildCaches is being called per-cursor instead of once.");
     }
 
-    [Fact]
+    [TestMethod]
     public void MultiCursorReplace_200Cursors_100KLines_Performance()
     {
         // Stress test: 200 cursors (simulates large find-and-replace)
         var (state, cursorCount) = SetupMultiCursorScenario(
             lineCount: 100_000, cursorCount: 200, targetWord: "TARGET");
 
-        Assert.True(cursorCount >= 190); // May be slightly less due to line spacing
+        Assert.IsTrue(cursorCount >= 190); // May be slightly less due to line spacing
 
         var sw = Stopwatch.StartNew();
         state.InsertText("REPLACEMENT");
@@ -152,12 +152,11 @@ public class MultiCursorPerformanceTests
         var ms = sw.ElapsedMilliseconds;
 
         // With batch mode: single RebuildCaches call, typically <100ms.
-        Assert.True(ms < 500,
-            $"Multi-cursor replace with {cursorCount} cursors on 100K-line doc " +
+        Assert.IsTrue(ms < 500, $"Multi-cursor replace with {cursorCount} cursors on 100K-line doc " +
             $"took {ms}ms — expected <500ms.");
     }
 
-    [Fact]
+    [TestMethod]
     public void MultiCursorDelete_70Cursors_100KLines_Performance()
     {
         // Test deletion (Backspace with selections = delete selected text)
@@ -169,12 +168,11 @@ public class MultiCursorPerformanceTests
         sw.Stop();
 
         var ms = sw.ElapsedMilliseconds;
-        Assert.True(ms < 500,
-            $"Multi-cursor delete with {cursorCount} cursors on 100K-line doc " +
+        Assert.IsTrue(ms < 500, $"Multi-cursor delete with {cursorCount} cursors on 100K-line doc " +
             $"took {ms}ms — expected <500ms.");
     }
 
-    [Fact]
+    [TestMethod]
     public void MultiCursorInsert_70Cursors_NoSelection_100KLines_Performance()
     {
         // Test insertion without selection (just 70 cursor positions, type a char)
@@ -193,12 +191,11 @@ public class MultiCursorPerformanceTests
         sw.Stop();
 
         var ms = sw.ElapsedMilliseconds;
-        Assert.True(ms < 500,
-            $"Multi-cursor insert with {cursorCount} cursors on 100K-line doc " +
+        Assert.IsTrue(ms < 500, $"Multi-cursor insert with {cursorCount} cursors on 100K-line doc " +
             $"took {ms}ms — expected <500ms.");
     }
 
-    [Fact]
+    [TestMethod]
     public void SingleCursorReplace_100KLines_Baseline()
     {
         // Baseline: single cursor should be fast regardless
@@ -210,14 +207,13 @@ public class MultiCursorPerformanceTests
         sw.Stop();
 
         var ms = sw.ElapsedMilliseconds;
-        Assert.True(ms < 500,
-            $"Single-cursor replace on 100K-line doc took {ms}ms — expected <500ms.");
+        Assert.IsTrue(ms < 500, $"Single-cursor replace on 100K-line doc took {ms}ms — expected <500ms.");
     }
 
     /// <summary>
     /// Directly measures RebuildCaches cost to quantify the per-cursor overhead.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void RebuildCaches_100KLineDoc_MeasureSingleCallCost()
     {
         var sb = new StringBuilder(100_000 * 60);
@@ -238,11 +234,10 @@ public class MultiCursorPerformanceTests
 
         // A single rebuild should be <100ms. Multiplied by 70 cursors = ~7 seconds.
         // This test documents the cost to help reason about batching gains.
-        Assert.True(singleRebuildMs < 500,
-            $"Single Apply (including RebuildCaches) took {singleRebuildMs}ms");
+        Assert.IsTrue(singleRebuildMs < 500, $"Single Apply (including RebuildCaches) took {singleRebuildMs}ms");
     }
 
-    [Fact]
+    [TestMethod]
     public void MultiCursorUndo_70Cursors_100KLines_Performance()
     {
         var (state, cursorCount) = SetupMultiCursorScenario(
@@ -258,14 +253,13 @@ public class MultiCursorPerformanceTests
         sw.Stop();
 
         var ms = sw.ElapsedMilliseconds;
-        Assert.True(ms < 500,
-            $"Undo of 70-cursor replace on 100K-line doc took {ms}ms — expected <500ms.");
+        Assert.IsTrue(ms < 500, $"Undo of 70-cursor replace on 100K-line doc took {ms}ms — expected <500ms.");
 
         // Verify undo restored the text
         Assert.Contains("TARGET", state.Document.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public void MultiCursorRedo_70Cursors_100KLines_Performance()
     {
         var (state, cursorCount) = SetupMultiCursorScenario(
@@ -280,13 +274,12 @@ public class MultiCursorPerformanceTests
         sw.Stop();
 
         var ms = sw.ElapsedMilliseconds;
-        Assert.True(ms < 500,
-            $"Redo of 70-cursor replace on 100K-line doc took {ms}ms — expected <500ms.");
+        Assert.IsTrue(ms < 500, $"Redo of 70-cursor replace on 100K-line doc took {ms}ms — expected <500ms.");
     }
 
     // ── Single-keystroke performance tests (post lazy-cache optimization) ──
 
-    [Fact]
+    [TestMethod]
     public void SingleKeystroke_100KLineFile_CompletesUnderThreshold()
     {
         // Build a 100K-line document (~5MB)
@@ -323,11 +316,10 @@ public class MultiCursorPerformanceTests
         // With lazy text + per-line reading, single keystroke avoids full text materialization
         // Previously ~30-50ms with full RebuildCaches; now ~10-15ms (byte assembly + line starts scan).
         // A regression to per-edit full materialization would push the minimum above 50ms.
-        Assert.True(minMs < 50,
-            $"Single keystroke on 100K-line doc took {minMs:F1}ms (min of {iterations}) — expected <50ms.");
+        Assert.IsTrue(minMs < 50, $"Single keystroke on 100K-line doc took {minMs:F1}ms (min of {iterations}) — expected <50ms.");
     }
 
-    [Fact]
+    [TestMethod]
     public void SingleKeystroke_DoesNotRebuildFullText()
     {
         // Build a 100K-line document
@@ -364,11 +356,10 @@ public class MultiCursorPerformanceTests
         }
 
         // Edit + render of visible lines should be <50ms total
-        Assert.True(minMs < 50,
-            $"Edit + render-visible-lines on 100K-line doc took {minMs:F1}ms (min of {iterations}) — expected <50ms.");
+        Assert.IsTrue(minMs < 50, $"Edit + render-visible-lines on 100K-line doc took {minMs:F1}ms (min of {iterations}) — expected <50ms.");
     }
 
-    [Fact]
+    [TestMethod]
     public void GetLineText_ReadsFromPiecesNotCachedText()
     {
         // Verify that GetLineText doesn't trigger full text materialization
@@ -389,11 +380,10 @@ public class MultiCursorPerformanceTests
         sw.Stop();
 
         Assert.StartsWith("Line ", lineText);
-        Assert.True(sw.Elapsed.TotalMilliseconds < 5,
-            $"GetLineText on 10K-line doc took {sw.Elapsed.TotalMilliseconds:F1}ms — expected <5ms.");
+        Assert.IsTrue(sw.Elapsed.TotalMilliseconds < 5, $"GetLineText on 10K-line doc took {sw.Elapsed.TotalMilliseconds:F1}ms — expected <5ms.");
     }
 
-    [Fact]
+    [TestMethod]
     public void OffsetToPosition_BinarySearch_Fast()
     {
         // Verify O(log L) OffsetToPosition on large doc
@@ -415,7 +405,6 @@ public class MultiCursorPerformanceTests
 
         var ms = sw.Elapsed.TotalMilliseconds;
         // 10K binary searches on 100K-entry list should be <10ms
-        Assert.True(ms < 50,
-            $"10K OffsetToPosition calls took {ms:F1}ms — expected <50ms.");
+        Assert.IsTrue(ms < 50, $"10K OffsetToPosition calls took {ms:F1}ms — expected <50ms.");
     }
 }

--- a/tests/Hex1b.Tests/Muxer/MuxerAdapterTests.cs
+++ b/tests/Hex1b.Tests/Muxer/MuxerAdapterTests.cs
@@ -5,9 +5,10 @@ using Hex1b.Tokens;
 
 namespace Hex1b.Tests.Muxer;
 
+[TestClass]
 public class MuxerAdapterTests
 {
-    [Fact]
+    [TestMethod]
     public async Task ClientServer_HelloAndStateSync_ReceivedByClient()
     {
         var (stream1, stream2) = CreateFullDuplexPair();
@@ -16,13 +17,13 @@ public class MuxerAdapterTests
         var client = Hmp1TestHelpers.NewClient(stream2);
 
         var (handle, _) = await ConnectPairAsync(server, stream1, client);
-        Assert.True(handle.IsConnected);
+        Assert.IsTrue(handle.IsConnected);
 
         await handle.DisposeAsync();
         await client.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task IntegrationTest_ServerSendsOutput_ClientReceivesIt()
     {
         var (stream1, stream2) = CreateFullDuplexPair();
@@ -31,8 +32,8 @@ public class MuxerAdapterTests
         var client = Hmp1TestHelpers.NewClient(stream2);
         var (handle, _) = await ConnectPairAsync(server, stream1, client);
 
-        Assert.Equal(80, client.RemoteWidth);
-        Assert.Equal(24, client.RemoteHeight);
+        Assert.AreEqual(80, client.RemoteWidth);
+        Assert.AreEqual(24, client.RemoteHeight);
 
         var outputData = "Hello from server!"u8.ToArray();
         await server.WriteOutputAsync(outputData);
@@ -40,13 +41,13 @@ public class MuxerAdapterTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         var received = await client.ReadOutputAsync(cts.Token);
 
-        Assert.Equal(outputData, received.ToArray());
+        TestSeq.AreEqual(outputData, received.ToArray());
 
         await handle.DisposeAsync();
         await client.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task IntegrationTest_ClientSendsInput_ServerReceivesIt()
     {
         var (stream1, stream2) = CreateFullDuplexPair();
@@ -61,13 +62,13 @@ public class MuxerAdapterTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         var received = await server.ReadInputAsync(cts.Token);
 
-        Assert.Equal(inputData, received.ToArray());
+        TestSeq.AreEqual(inputData, received.ToArray());
 
         await handle.DisposeAsync();
         await client.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task IntegrationTest_ClientSendsResize_ServerFires()
     {
         var (stream1, stream2) = CreateFullDuplexPair();
@@ -85,16 +86,16 @@ public class MuxerAdapterTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         var (newWidth, newHeight) = await resizeTcs.Task.WaitAsync(cts.Token);
 
-        Assert.Equal(120, newWidth);
-        Assert.Equal(40, newHeight);
-        Assert.Equal(120, server.Width);
-        Assert.Equal(40, server.Height);
+        Assert.AreEqual(120, newWidth);
+        Assert.AreEqual(40, newHeight);
+        Assert.AreEqual(120, server.Width);
+        Assert.AreEqual(40, server.Height);
 
         await handle.DisposeAsync();
         await client.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task IntegrationTest_MultipleClients_AllReceiveOutput()
     {
         var (stream1a, stream1b) = CreateFullDuplexPair();
@@ -107,7 +108,7 @@ public class MuxerAdapterTests
         var (handle1, _) = await ConnectPairAsync(server, stream1a, client1);
         var (handle2, _) = await ConnectPairAsync(server, stream2a, client2);
 
-        Assert.Equal(2, server.ClientCount);
+        Assert.AreEqual(2, server.ClientCount);
 
         var outputData = "broadcast!"u8.ToArray();
         await server.WriteOutputAsync(outputData);
@@ -117,8 +118,8 @@ public class MuxerAdapterTests
         var received1 = await client1.ReadOutputAsync(cts.Token);
         var received2 = await client2.ReadOutputAsync(cts.Token);
 
-        Assert.Equal(outputData, received1.ToArray());
-        Assert.Equal(outputData, received2.ToArray());
+        TestSeq.AreEqual(outputData, received1.ToArray());
+        TestSeq.AreEqual(outputData, received2.ToArray());
 
         await handle1.DisposeAsync();
         await handle2.DisposeAsync();
@@ -126,7 +127,7 @@ public class MuxerAdapterTests
         await client2.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task IntegrationTest_ClientDisconnect_ServerContinues()
     {
         var (stream1a, stream1b) = CreateFullDuplexPair();
@@ -139,7 +140,7 @@ public class MuxerAdapterTests
         var (handle1, _) = await ConnectPairAsync(server, stream1a, client1);
         var (handle2, _) = await ConnectPairAsync(server, stream2a, client2);
 
-        Assert.Equal(2, server.ClientCount);
+        Assert.AreEqual(2, server.ClientCount);
 
         await handle1.DisposeAsync();
         await client1.DisposeAsync();
@@ -152,13 +153,13 @@ public class MuxerAdapterTests
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         var received = await client2.ReadOutputAsync(cts.Token);
 
-        Assert.Equal(outputData, received.ToArray());
+        TestSeq.AreEqual(outputData, received.ToArray());
 
         await handle2.DisposeAsync();
         await client2.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task StateReplay_EmitsTrackedPrivateModesOnReconnect()
     {
         // The presentation adapter rebuilds the screen state for a new viewer
@@ -211,7 +212,7 @@ public class MuxerAdapterTests
         await client.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task StateReplay_OmitsDefaultModes()
     {
         // A pristine terminal should produce a StateSync without DECSETs
@@ -249,7 +250,7 @@ public class MuxerAdapterTests
         await client.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task StateReplay_AlternateScreenIsEnteredBeforeCellRepaint()
     {
         // When a workload has switched to the alternate screen (TUI like
@@ -278,14 +279,14 @@ public class MuxerAdapterTests
         var altIndex = stateSync.IndexOf("\x1b[?1049h", StringComparison.Ordinal);
         var clearIndex = stateSync.IndexOf("\x1b[2J", StringComparison.Ordinal);
 
-        Assert.True(altIndex >= 0, "Alt-screen DECSET 1049h must be emitted when the workload is on the alt screen.");
-        Assert.True(clearIndex > altIndex, "Alt-screen DECSET must come before the clear-screen sequence.");
+        Assert.IsTrue(altIndex >= 0, "Alt-screen DECSET 1049h must be emitted when the workload is on the alt screen.");
+        Assert.IsTrue(clearIndex > altIndex, "Alt-screen DECSET must come before the clear-screen sequence.");
 
         await handle.DisposeAsync();
         await client.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Hmp1WorkloadAdapter_Disconnected_FiredOnStreamClose()
     {
         var (stream1, stream2) = CreateFullDuplexPair();
@@ -324,7 +325,7 @@ public class MuxerAdapterTests
         return (handle, client);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ConnectAsync_ReadPumpSurvivesHandshakeCtTimeout()
     {
         // Regression sentinel for the "handshake CT cascades into read-pump" foot-gun
@@ -352,7 +353,7 @@ public class MuxerAdapterTests
 
         using var readCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         var received = await client.ReadOutputAsync(readCts.Token);
-        Assert.Equal(data, received.ToArray());
+        TestSeq.AreEqual(data, received.ToArray());
 
         await handle.DisposeAsync();
         await client.DisposeAsync();

--- a/tests/Hex1b.Tests/Muxer/MuxerProtocolTests.cs
+++ b/tests/Hex1b.Tests/Muxer/MuxerProtocolTests.cs
@@ -6,9 +6,10 @@ using Hex1b;
 
 namespace Hex1b.Tests.Muxer;
 
+[TestClass]
 public class Hmp1ProtocolTests
 {
-    [Fact]
+    [TestMethod]
     public async Task WriteFrameAsync_ReadFrameAsync_RoundTrip()
     {
         var (clientStream, serverStream) = CreateStreamPair();
@@ -18,12 +19,12 @@ public class Hmp1ProtocolTests
 
         var frame = await Hmp1Protocol.ReadFrameAsync(clientStream);
 
-        Assert.NotNull(frame);
-        Assert.Equal(Hmp1FrameType.Output, frame.Value.Type);
-        Assert.Equal(payload, frame.Value.Payload.ToArray());
+        Assert.IsNotNull(frame);
+        Assert.AreEqual(Hmp1FrameType.Output, frame.Value.Type);
+        TestSeq.AreEqual(payload, frame.Value.Payload.ToArray());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WriteFrameAsync_EmptyPayload_RoundTrips()
     {
         var (clientStream, serverStream) = CreateStreamPair();
@@ -32,12 +33,12 @@ public class Hmp1ProtocolTests
 
         var frame = await Hmp1Protocol.ReadFrameAsync(clientStream);
 
-        Assert.NotNull(frame);
-        Assert.Equal(Hmp1FrameType.Exit, frame.Value.Type);
-        Assert.True(frame.Value.Payload.IsEmpty);
+        Assert.IsNotNull(frame);
+        Assert.AreEqual(Hmp1FrameType.Exit, frame.Value.Type);
+        Assert.IsTrue(frame.Value.Payload.IsEmpty);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadFrameAsync_ClosedStream_ReturnsNull()
     {
         var (clientStream, serverStream) = CreateStreamPair();
@@ -46,10 +47,10 @@ public class Hmp1ProtocolTests
 
         var frame = await Hmp1Protocol.ReadFrameAsync(clientStream);
 
-        Assert.Null(frame);
+        Assert.IsNull(frame);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WriteHelloAsync_ParseHello_RoundTrip()
     {
         var (clientStream, serverStream) = CreateStreamPair();
@@ -58,16 +59,16 @@ public class Hmp1ProtocolTests
 
         var frame = await Hmp1Protocol.ReadFrameAsync(clientStream);
 
-        Assert.NotNull(frame);
-        Assert.Equal(Hmp1FrameType.Hello, frame.Value.Type);
+        Assert.IsNotNull(frame);
+        Assert.AreEqual(Hmp1FrameType.Hello, frame.Value.Type);
 
         var hello = Hmp1Protocol.ParseHello(frame.Value.Payload);
-        Assert.Equal(Hmp1Protocol.Version, hello.Version);
-        Assert.Equal(120, hello.Width);
-        Assert.Equal(40, hello.Height);
+        Assert.AreEqual(Hmp1Protocol.Version, hello.Version);
+        Assert.AreEqual(120, hello.Width);
+        Assert.AreEqual(40, hello.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WriteResizeAsync_ParseResize_RoundTrip()
     {
         var (clientStream, serverStream) = CreateStreamPair();
@@ -76,15 +77,15 @@ public class Hmp1ProtocolTests
 
         var frame = await Hmp1Protocol.ReadFrameAsync(clientStream);
 
-        Assert.NotNull(frame);
-        Assert.Equal(Hmp1FrameType.Resize, frame.Value.Type);
+        Assert.IsNotNull(frame);
+        Assert.AreEqual(Hmp1FrameType.Resize, frame.Value.Type);
 
         var (width, height) = Hmp1Protocol.ParseResize(frame.Value.Payload);
-        Assert.Equal(132, width);
-        Assert.Equal(50, height);
+        Assert.AreEqual(132, width);
+        Assert.AreEqual(50, height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WriteExitAsync_ParseExitCode_RoundTrip()
     {
         var (clientStream, serverStream) = CreateStreamPair();
@@ -93,14 +94,14 @@ public class Hmp1ProtocolTests
 
         var frame = await Hmp1Protocol.ReadFrameAsync(clientStream);
 
-        Assert.NotNull(frame);
-        Assert.Equal(Hmp1FrameType.Exit, frame.Value.Type);
+        Assert.IsNotNull(frame);
+        Assert.AreEqual(Hmp1FrameType.Exit, frame.Value.Type);
 
         var exitCode = Hmp1Protocol.ParseExitCode(frame.Value.Payload);
-        Assert.Equal(42, exitCode);
+        Assert.AreEqual(42, exitCode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MultipleFrames_ReadInOrder()
     {
         var (clientStream, serverStream) = CreateStreamPair();
@@ -113,28 +114,28 @@ public class Hmp1ProtocolTests
         var frame2 = await Hmp1Protocol.ReadFrameAsync(clientStream);
         var frame3 = await Hmp1Protocol.ReadFrameAsync(clientStream);
 
-        Assert.Equal("first", Encoding.UTF8.GetString(frame1!.Value.Payload.Span));
-        Assert.Equal("second", Encoding.UTF8.GetString(frame2!.Value.Payload.Span));
-        Assert.Equal("third", Encoding.UTF8.GetString(frame3!.Value.Payload.Span));
+        Assert.AreEqual("first", Encoding.UTF8.GetString(frame1!.Value.Payload.Span));
+        Assert.AreEqual("second", Encoding.UTF8.GetString(frame2!.Value.Payload.Span));
+        Assert.AreEqual("third", Encoding.UTF8.GetString(frame3!.Value.Payload.Span));
     }
 
-    [Fact]
+    [TestMethod]
     public void ParseHello_WrongVersion_Throws()
     {
         var json = """{"version":99,"width":80,"height":24}"""u8.ToArray();
 
-        Assert.Throws<InvalidOperationException>(() => Hmp1Protocol.ParseHello(json));
+        Assert.ThrowsExactly<InvalidOperationException>(() => Hmp1Protocol.ParseHello(json));
     }
 
-    [Fact]
+    [TestMethod]
     public void ParseResize_ShortPayload_Throws()
     {
         var shortPayload = new byte[4]; // Need 8
 
-        Assert.Throws<InvalidOperationException>(() => Hmp1Protocol.ParseResize(shortPayload));
+        Assert.ThrowsExactly<InvalidOperationException>(() => Hmp1Protocol.ParseResize(shortPayload));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AllFrameTypes_RoundTrip()
     {
         var (clientStream, serverStream) = CreateStreamPair();
@@ -154,12 +155,12 @@ public class Hmp1ProtocolTests
         var f5 = await Hmp1Protocol.ReadFrameAsync(clientStream);
         var f6 = await Hmp1Protocol.ReadFrameAsync(clientStream);
 
-        Assert.Equal(Hmp1FrameType.Hello, f1!.Value.Type);
-        Assert.Equal(Hmp1FrameType.StateSync, f2!.Value.Type);
-        Assert.Equal(Hmp1FrameType.Output, f3!.Value.Type);
-        Assert.Equal(Hmp1FrameType.Input, f4!.Value.Type);
-        Assert.Equal(Hmp1FrameType.Resize, f5!.Value.Type);
-        Assert.Equal(Hmp1FrameType.Exit, f6!.Value.Type);
+        Assert.AreEqual(Hmp1FrameType.Hello, f1!.Value.Type);
+        Assert.AreEqual(Hmp1FrameType.StateSync, f2!.Value.Type);
+        Assert.AreEqual(Hmp1FrameType.Output, f3!.Value.Type);
+        Assert.AreEqual(Hmp1FrameType.Input, f4!.Value.Type);
+        Assert.AreEqual(Hmp1FrameType.Resize, f5!.Value.Type);
+        Assert.AreEqual(Hmp1FrameType.Exit, f6!.Value.Type);
     }
 
     /// <summary>

--- a/tests/Hex1b.Tests/NanoExploratoryTests.cs
+++ b/tests/Hex1b.Tests/NanoExploratoryTests.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 namespace Hex1b.Tests;
 
 /// <summary>
-/// Custom xUnit Fact attribute that skips Unix PTY exploratory tests on Windows
+/// Custom TestMethod attribute that skips Unix PTY exploratory tests on Windows
 /// or when the required shell/tool is unavailable.
 /// </summary>
 public sealed class UnixPtyFactAttribute : TestMethodAttribute

--- a/tests/Hex1b.Tests/NanoExploratoryTests.cs
+++ b/tests/Hex1b.Tests/NanoExploratoryTests.cs
@@ -7,33 +7,44 @@ namespace Hex1b.Tests;
 /// Custom xUnit Fact attribute that skips Unix PTY exploratory tests on Windows
 /// or when the required shell/tool is unavailable.
 /// </summary>
-public sealed class UnixPtyFactAttribute : FactAttribute
+public sealed class UnixPtyFactAttribute : TestMethodAttribute
 {
     private static readonly bool s_bashAvailable = CheckCommandAvailable("bash", "--version");
     private static readonly bool s_nanoAvailable = CheckCommandAvailable("nano", "--version");
 
-    public UnixPtyFactAttribute(
-        bool requiresNano = false,
-        [System.Runtime.CompilerServices.CallerFilePath] string? sourceFilePath = null,
-        [System.Runtime.CompilerServices.CallerLineNumber] int sourceLineNumber = -1)
-        : base(sourceFilePath, sourceLineNumber)
+    private readonly string? _skipReason;
+
+    public UnixPtyFactAttribute(bool requiresNano = false)
     {
         if (OperatingSystem.IsWindows())
         {
-            Skip = "Requires Unix PTY behavior; skip on Windows.";
+            _skipReason = "Requires Unix PTY behavior; skip on Windows.";
             return;
         }
 
         if (!s_bashAvailable)
         {
-            Skip = "bash is not available on this machine.";
+            _skipReason = "bash is not available on this machine.";
             return;
         }
 
         if (requiresNano && !s_nanoAvailable)
         {
-            Skip = "nano is not available on this machine.";
+            _skipReason = "nano is not available on this machine.";
         }
+    }
+
+    public override Task<TestResult[]> ExecuteAsync(ITestMethod testMethod)
+    {
+        if (_skipReason is not null)
+        {
+            return Task.FromResult<TestResult[]>([new TestResult
+            {
+                Outcome = UnitTestOutcome.Inconclusive,
+                TestFailureException = new AssertInconclusiveException(_skipReason),
+            }]);
+        }
+        return base.ExecuteAsync(testMethod);
     }
 
     private static bool CheckCommandAvailable(string command, string versionArg)
@@ -78,6 +89,7 @@ public sealed class UnixPtyFactAttribute : FactAttribute
 /// 2. Or if it's a rendering issue in TerminalNode
 /// </para>
 /// </remarks>
+[TestClass]
 public class NanoExploratoryTests
 {
     /// <summary>
@@ -267,7 +279,7 @@ public class NanoExploratoryTests
     /// This test helps us understand what the buffer looks like after nano starts.
     /// Expected: Nano header at top, empty edit area, help at bottom.
     /// </remarks>
-    [Fact(Skip = "Exploratory test - run manually")]
+    [TestMethod, Ignore("Exploratory test - run manually")]
     public async Task Nano_InitialScreen_ShowsCorrectLayout()
     {
         // Arrange
@@ -306,7 +318,7 @@ public class NanoExploratoryTests
     /// This is the key test - we type "hello" and see if it appears in the correct location.
     /// The bug is that typed text appears to overwrite the header bar.
     /// </remarks>
-    [Fact(Skip = "Exploratory test - run manually")]
+    [TestMethod, Ignore("Exploratory test - run manually")]
     public async Task Nano_TypeText_AppearsInEditArea()
     {
         // Arrange
@@ -363,7 +375,7 @@ public class NanoExploratoryTests
     /// Exploratory test: Test origin mode behavior in isolation.
     /// Origin mode works correctly - row 1 in origin mode maps to scroll_top.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void OriginMode_PositionsRelativeToScrollRegion()
     {
         // Create terminal
@@ -388,7 +400,7 @@ public class NanoExploratoryTests
         var row0 = GetRowText(buffer, 0);
         var row2 = GetRowText(buffer, 2);
         
-        Assert.Equal("Title at row 0", row0);
+        Assert.AreEqual("Title at row 0", row0);
         Assert.Contains("Edit area text", row2);
         
         static string GetRowText(TerminalCell[,] buffer, int row)
@@ -446,8 +458,7 @@ public class NanoExploratoryTests
         var row4Text = GetRowText(buffer, 4);
         
         // Throw diagnostics if assertion fails
-        Assert.True(row4Text.Contains("Hello at row 5"), 
-            $"Expected row 4 to contain 'Hello at row 5', but got:\n{sb}");
+        Assert.IsTrue(row4Text.Contains("Hello at row 5"), $"Expected row 4 to contain 'Hello at row 5', but got:\n{sb}");
         
         static string GetRowText(TerminalCell[,] buffer, int row)
         {
@@ -531,10 +542,8 @@ public class NanoExploratoryTests
         
         // Verify nano's UI is in the correct positions
         // Title should be at row 0 and should contain "nano" or "GNU"
-        Assert.True(
-            row0.Contains("nano", StringComparison.OrdinalIgnoreCase) || 
-            row0.Contains("GNU", StringComparison.OrdinalIgnoreCase),
-            $"Expected row 0 to contain nano title, but got:\n{sb}");
+        Assert.IsTrue(row0.Contains("nano", StringComparison.OrdinalIgnoreCase) || 
+            row0.Contains("GNU", StringComparison.OrdinalIgnoreCase), $"Expected row 0 to contain nano title, but got:\n{sb}");
         
         static string GetRowText(TerminalCell[,] buffer, int row)
         {
@@ -555,7 +564,7 @@ public class NanoExploratoryTests
     /// Nano uses scroll regions (DECSTBM) to limit scrolling to the edit area.
     /// If scroll regions aren't handled correctly, content might render in wrong places.
     /// </remarks>
-    [Fact(Skip = "Exploratory test - run manually")]
+    [TestMethod, Ignore("Exploratory test - run manually")]
     public async Task Nano_ScrollRegion_IsRespected()
     {
         // Arrange
@@ -592,7 +601,7 @@ public class NanoExploratoryTests
     /// <summary>
     /// Quick test to verify bash works correctly (baseline).
     /// </summary>
-    [Fact(Skip = "Exploratory test - run manually")]
+    [TestMethod, Ignore("Exploratory test - run manually")]
     public async Task Bash_Echo_WorksCorrectly()
     {
         // Arrange

--- a/tests/Hex1b.Tests/NavigatorStateTests.cs
+++ b/tests/Hex1b.Tests/NavigatorStateTests.cs
@@ -4,23 +4,24 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class NavigatorStateTests
 {
     private static NavigatorRoute CreateRoute(string id) =>
         new(id, nav => new TextBlockWidget($"Screen: {id}"));
 
-    [Fact]
+    [TestMethod]
     public void Constructor_InitializesWithRootRoute()
     {
         var root = CreateRoute("home");
         var navigator = new NavigatorState(root);
 
-        Assert.Equal("home", navigator.CurrentRoute.Id);
-        Assert.Equal(1, navigator.Depth);
-        Assert.False(navigator.CanGoBack);
+        Assert.AreEqual("home", navigator.CurrentRoute.Id);
+        Assert.AreEqual(1, navigator.Depth);
+        Assert.IsFalse(navigator.CanGoBack);
     }
 
-    [Fact]
+    [TestMethod]
     public void Push_AddsRouteToStack()
     {
         var root = CreateRoute("home");
@@ -28,12 +29,12 @@ public class NavigatorStateTests
 
         navigator.Push(CreateRoute("details"));
 
-        Assert.Equal("details", navigator.CurrentRoute.Id);
-        Assert.Equal(2, navigator.Depth);
-        Assert.True(navigator.CanGoBack);
+        Assert.AreEqual("details", navigator.CurrentRoute.Id);
+        Assert.AreEqual(2, navigator.Depth);
+        Assert.IsTrue(navigator.CanGoBack);
     }
 
-    [Fact]
+    [TestMethod]
     public void Push_WithIdAndBuilder_AddsRouteToStack()
     {
         var root = CreateRoute("home");
@@ -41,11 +42,11 @@ public class NavigatorStateTests
 
         navigator.Push("details", nav => new TextBlockWidget("Details"));
 
-        Assert.Equal("details", navigator.CurrentRoute.Id);
-        Assert.Equal(2, navigator.Depth);
+        Assert.AreEqual("details", navigator.CurrentRoute.Id);
+        Assert.AreEqual(2, navigator.Depth);
     }
 
-    [Fact]
+    [TestMethod]
     public void Pop_RemovesTopRoute()
     {
         var root = CreateRoute("home");
@@ -55,12 +56,12 @@ public class NavigatorStateTests
 
         var result = navigator.Pop();
 
-        Assert.True(result);
-        Assert.Equal("details", navigator.CurrentRoute.Id);
-        Assert.Equal(2, navigator.Depth);
+        Assert.IsTrue(result);
+        Assert.AreEqual("details", navigator.CurrentRoute.Id);
+        Assert.AreEqual(2, navigator.Depth);
     }
 
-    [Fact]
+    [TestMethod]
     public void Pop_AtRoot_ReturnsFalse()
     {
         var root = CreateRoute("home");
@@ -68,12 +69,12 @@ public class NavigatorStateTests
 
         var result = navigator.Pop();
 
-        Assert.False(result);
-        Assert.Equal("home", navigator.CurrentRoute.Id);
-        Assert.Equal(1, navigator.Depth);
+        Assert.IsFalse(result);
+        Assert.AreEqual("home", navigator.CurrentRoute.Id);
+        Assert.AreEqual(1, navigator.Depth);
     }
 
-    [Fact]
+    [TestMethod]
     public void PopToRoot_ClearsAllButRoot()
     {
         var root = CreateRoute("home");
@@ -84,12 +85,12 @@ public class NavigatorStateTests
 
         navigator.PopToRoot();
 
-        Assert.Equal("home", navigator.CurrentRoute.Id);
-        Assert.Equal(1, navigator.Depth);
-        Assert.False(navigator.CanGoBack);
+        Assert.AreEqual("home", navigator.CurrentRoute.Id);
+        Assert.AreEqual(1, navigator.Depth);
+        Assert.IsFalse(navigator.CanGoBack);
     }
 
-    [Fact]
+    [TestMethod]
     public void Replace_SwapsCurrentRoute()
     {
         var root = CreateRoute("home");
@@ -98,11 +99,11 @@ public class NavigatorStateTests
 
         navigator.Replace(CreateRoute("redirect"));
 
-        Assert.Equal("redirect", navigator.CurrentRoute.Id);
-        Assert.Equal(2, navigator.Depth); // Still 2 - replaced, not added
+        Assert.AreEqual("redirect", navigator.CurrentRoute.Id);
+        Assert.AreEqual(2, navigator.Depth); // Still 2 - replaced, not added
     }
 
-    [Fact]
+    [TestMethod]
     public void Replace_WithIdAndBuilder_SwapsCurrentRoute()
     {
         var root = CreateRoute("home");
@@ -111,11 +112,11 @@ public class NavigatorStateTests
 
         navigator.Replace("redirect", nav => new TextBlockWidget("Redirect"));
 
-        Assert.Equal("redirect", navigator.CurrentRoute.Id);
-        Assert.Equal(2, navigator.Depth);
+        Assert.AreEqual("redirect", navigator.CurrentRoute.Id);
+        Assert.AreEqual(2, navigator.Depth);
     }
 
-    [Fact]
+    [TestMethod]
     public void Reset_ClearsStackAndSetsNewRoot()
     {
         var root = CreateRoute("home");
@@ -125,12 +126,12 @@ public class NavigatorStateTests
 
         navigator.Reset(CreateRoute("new-home"));
 
-        Assert.Equal("new-home", navigator.CurrentRoute.Id);
-        Assert.Equal(1, navigator.Depth);
-        Assert.False(navigator.CanGoBack);
+        Assert.AreEqual("new-home", navigator.CurrentRoute.Id);
+        Assert.AreEqual(1, navigator.Depth);
+        Assert.IsFalse(navigator.CanGoBack);
     }
 
-    [Fact]
+    [TestMethod]
     public void OnNavigated_FiresOnPush()
     {
         var root = CreateRoute("home");
@@ -140,10 +141,10 @@ public class NavigatorStateTests
 
         navigator.Push(CreateRoute("details"));
 
-        Assert.True(eventFired);
+        Assert.IsTrue(eventFired);
     }
 
-    [Fact]
+    [TestMethod]
     public void OnNavigated_FiresOnPop()
     {
         var root = CreateRoute("home");
@@ -154,10 +155,10 @@ public class NavigatorStateTests
 
         navigator.Pop();
 
-        Assert.True(eventFired);
+        Assert.IsTrue(eventFired);
     }
 
-    [Fact]
+    [TestMethod]
     public void OnNavigated_FiresOnPopToRoot()
     {
         var root = CreateRoute("home");
@@ -169,10 +170,10 @@ public class NavigatorStateTests
 
         navigator.PopToRoot();
 
-        Assert.True(eventFired);
+        Assert.IsTrue(eventFired);
     }
 
-    [Fact]
+    [TestMethod]
     public void WizardFlow_PushThenPopToRoot()
     {
         var root = CreateRoute("home");
@@ -182,15 +183,15 @@ public class NavigatorStateTests
         navigator.Push(CreateRoute("wizard-step-1"));
         navigator.Push(CreateRoute("wizard-step-2"));
         navigator.Push(CreateRoute("wizard-step-3"));
-        Assert.Equal(4, navigator.Depth);
+        Assert.AreEqual(4, navigator.Depth);
 
         // Complete wizard - go back to home
         navigator.PopToRoot();
-        Assert.Equal("home", navigator.CurrentRoute.Id);
-        Assert.False(navigator.CanGoBack);
+        Assert.AreEqual("home", navigator.CurrentRoute.Id);
+        Assert.IsFalse(navigator.CanGoBack);
     }
 
-    [Fact]
+    [TestMethod]
     public void DrillDown_CanNavigateBackStepByStep()
     {
         var root = CreateRoute("home");
@@ -202,15 +203,15 @@ public class NavigatorStateTests
         navigator.Push(CreateRoute("details"));
 
         // Navigate back step by step
-        Assert.True(navigator.Pop());
-        Assert.Equal("item", navigator.CurrentRoute.Id);
+        Assert.IsTrue(navigator.Pop());
+        Assert.AreEqual("item", navigator.CurrentRoute.Id);
 
-        Assert.True(navigator.Pop());
-        Assert.Equal("category", navigator.CurrentRoute.Id);
+        Assert.IsTrue(navigator.Pop());
+        Assert.AreEqual("category", navigator.CurrentRoute.Id);
 
-        Assert.True(navigator.Pop());
-        Assert.Equal("home", navigator.CurrentRoute.Id);
+        Assert.IsTrue(navigator.Pop());
+        Assert.AreEqual("home", navigator.CurrentRoute.Id);
 
-        Assert.False(navigator.Pop()); // Can't go back further
+        Assert.IsFalse(navigator.Pop()); // Can't go back further
     }
 }

--- a/tests/Hex1b.Tests/NavigatorWidgetHoistedStateTests.cs
+++ b/tests/Hex1b.Tests/NavigatorWidgetHoistedStateTests.cs
@@ -10,12 +10,13 @@ namespace Hex1b.Tests;
 /// <see cref="IStatefulWidget{TSelf, TState}"/> contract. Mirrors the suite
 /// already in place for <see cref="TextBoxWidget"/>.
 /// </summary>
+[TestClass]
 public class NavigatorWidgetHoistedStateTests
 {
     private static NavigatorRoute CreateRoute(string id) =>
         new(id, _ => new TextBlockWidget($"Screen: {id}"));
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_HoistedState_RoutesParentInstanceIntoNode()
     {
         var state = new NavigatorState(CreateRoute("home"));
@@ -25,11 +26,11 @@ public class NavigatorWidgetHoistedStateTests
 
         var node = (NavigatorNode)await new NavigatorWidget(state).ReconcileAsync(null, context);
 
-        Assert.Same(state, node.State);
-        Assert.Equal("home", node.State.CurrentRoute.Id);
+        Assert.AreSame(state, node.State);
+        Assert.AreEqual("home", node.State.CurrentRoute.Id);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_HoistedState_PreservedAcrossReconciles()
     {
         var state = new NavigatorState(CreateRoute("home"));
@@ -38,16 +39,16 @@ public class NavigatorWidgetHoistedStateTests
         context.IsNew = true;
 
         var node = (NavigatorNode)await new NavigatorWidget(state).ReconcileAsync(null, context);
-        Assert.Same(state, node.State);
+        Assert.AreSame(state, node.State);
 
         context.IsNew = false;
         var node2 = (NavigatorNode)await new NavigatorWidget(state).ReconcileAsync(node, context);
 
-        Assert.Same(node, node2);
-        Assert.Same(state, node2.State);
+        Assert.AreSame(node, node2);
+        Assert.AreSame(state, node2.State);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_HoistedState_ParentMutationVisibleAfterReconcile()
     {
         var state = new NavigatorState(CreateRoute("home"));
@@ -56,7 +57,7 @@ public class NavigatorWidgetHoistedStateTests
         context.IsNew = true;
 
         var node = (NavigatorNode)await new NavigatorWidget(state).ReconcileAsync(null, context);
-        Assert.Equal("home", node.State.CurrentRoute.Id);
+        Assert.AreEqual("home", node.State.CurrentRoute.Id);
 
         // Parent pushes a new route from outside the widget tree, then
         // reconciles. The node should observe the new current route.
@@ -65,11 +66,11 @@ public class NavigatorWidgetHoistedStateTests
         context.IsNew = false;
         await new NavigatorWidget(state).ReconcileAsync(node, context);
 
-        Assert.Equal("details", node.State.CurrentRoute.Id);
-        Assert.Equal(2, node.State.Depth);
+        Assert.AreEqual("details", node.State.CurrentRoute.Id);
+        Assert.AreEqual(2, node.State.Depth);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_HoistedState_PeerInstancesAreIndependent()
     {
         var stateA = new NavigatorState(CreateRoute("home-a"));
@@ -83,12 +84,12 @@ public class NavigatorWidgetHoistedStateTests
 
         stateA.Push(CreateRoute("nested"));
 
-        Assert.Equal("nested", nodeA.State.CurrentRoute.Id);
-        Assert.Equal("home-b", nodeB.State.CurrentRoute.Id);
-        Assert.NotSame(nodeA.State, nodeB.State);
+        Assert.AreEqual("nested", nodeA.State.CurrentRoute.Id);
+        Assert.AreEqual("home-b", nodeB.State.CurrentRoute.Id);
+        Assert.AreNotSame(nodeA.State, nodeB.State);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_FluentState_OverridesCtorState()
     {
         // The fluent .State(...) overload must replace whatever state was
@@ -102,7 +103,7 @@ public class NavigatorWidgetHoistedStateTests
         context.IsNew = true;
         var node = (NavigatorNode)await widget.ReconcileAsync(null, context);
 
-        Assert.Same(hoistedState, node.State);
-        Assert.Equal("hoist-home", node.State.CurrentRoute.Id);
+        Assert.AreSame(hoistedState, node.State);
+        Assert.AreEqual("hoist-home", node.State.CurrentRoute.Id);
     }
 }

--- a/tests/Hex1b.Tests/NotificationCardNodeTests.cs
+++ b/tests/Hex1b.Tests/NotificationCardNodeTests.cs
@@ -10,9 +10,10 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for NotificationCardNode rendering and behavior.
 /// </summary>
+[TestClass]
 public class NotificationCardNodeTests
 {
-    [Fact]
+    [TestMethod]
     public void NotificationCardNode_Measure_ReturnsReasonableSize()
     {
         var notification = new Notification("Test Title", "Test body text");
@@ -26,11 +27,11 @@ public class NotificationCardNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // Should have non-zero dimensions
-        Assert.True(size.Width > 0, "Width should be positive");
-        Assert.True(size.Height > 0, "Height should be positive");
+        Assert.IsTrue(size.Width > 0, "Width should be positive");
+        Assert.IsTrue(size.Height > 0, "Height should be positive");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NotificationCardNode_WithAction_CreatesChildrenViaReconciliation()
     {
         var notification = new Notification("Title", "Body")
@@ -44,12 +45,12 @@ public class NotificationCardNodeTests
         var node = (NotificationCardNode)await cardWidget.ReconcileAsync(null, context);
 
         // Verify children were created
-        Assert.NotNull(node.DismissButton);
-        Assert.NotNull(node.ActionButton);
-        Assert.Equal("View Details", node.ActionButton.PrimaryLabel);
+        Assert.IsNotNull(node.DismissButton);
+        Assert.IsNotNull(node.ActionButton);
+        Assert.AreEqual("View Details", node.ActionButton.PrimaryLabel);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NotificationCardNode_WithAction_MeasuresWithChildren()
     {
         var notification = new Notification("Title", "Body")
@@ -65,10 +66,10 @@ public class NotificationCardNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // With title + body + action + progress, should have reasonable height
-        Assert.True(size.Height >= 3, $"Height should be at least 3, was {size.Height}");
+        Assert.IsTrue(size.Height >= 3, $"Height should be at least 3, was {size.Height}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NotificationCardNode_Children_ContainsButtonsAfterReconciliation()
     {
         var notification = new Notification("Title", "Body")
@@ -83,12 +84,12 @@ public class NotificationCardNodeTests
 
         // GetChildren should return the button nodes
         var children = node.GetChildren().ToList();
-        Assert.NotEmpty(children);
-        Assert.Contains(children, c => c is ButtonNode);
-        Assert.Contains(children, c => c is SplitButtonNode);
+        Assert.IsNotEmpty(children);
+        Assert.IsTrue(children.Any(c => c is ButtonNode));
+        Assert.IsTrue(children.Any(c => c is SplitButtonNode));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NotificationCardNode_DismissButton_AlwaysCreated()
     {
         // Even without primary action, dismiss button should exist
@@ -100,11 +101,11 @@ public class NotificationCardNodeTests
         var context = ReconcileContext.CreateRoot();
         var node = (NotificationCardNode)await cardWidget.ReconcileAsync(null, context);
 
-        Assert.NotNull(node.DismissButton);
-        Assert.Null(node.ActionButton); // No action button without primary action
+        Assert.IsNotNull(node.DismissButton);
+        Assert.IsNull(node.ActionButton); // No action button without primary action
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NotificationCard_RendersActionButtonLabel()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -148,11 +149,11 @@ public class NotificationCardNodeTests
         await runTask;
 
         // Verify notification content and action button are visible
-        Assert.True(snapshot.ContainsText("Test Alert"), "Should show notification title");
-        Assert.True(snapshot.ContainsText("View Details"), "Should show action button label");
+        Assert.IsTrue(snapshot.ContainsText("Test Alert"), "Should show notification title");
+        Assert.IsTrue(snapshot.ContainsText("View Details"), "Should show action button label");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NotificationCard_SplitButtonDropdown_OpensSuccessfully()
     {
         // This test verifies that the dropdown on a SplitButton inside a NotificationCard
@@ -215,7 +216,7 @@ public class NotificationCardNodeTests
         await runTask;
 
         // Verify notification was actually posted
-        Assert.True(notificationPosted, "Notification should have been posted");
+        Assert.IsTrue(notificationPosted, "Notification should have been posted");
         
         // Verify no "popup host" exception was thrown - the parent chain is correctly set up
         if (caughtException != null)
@@ -224,7 +225,7 @@ public class NotificationCardNodeTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NotificationPanel_AltN_TogglesDrawer()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -272,12 +273,12 @@ public class NotificationCardNodeTests
 
         await runTask;
 
-        Assert.True(notificationPosted, "Notification should have been posted");
+        Assert.IsTrue(notificationPosted, "Notification should have been posted");
         // Drawer should show "Notifications (1)" header
-        Assert.True(snapshot.ContainsText("Notifications (1)"), "Drawer should show notification count");
+        Assert.IsTrue(snapshot.ContainsText("Notifications (1)"), "Drawer should show notification count");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NotificationIcon_OutsidePanel_CanAccessNotifications()
     {
         // This test verifies the core architectural requirement:
@@ -349,16 +350,16 @@ public class NotificationCardNodeTests
         await runTask;
 
         // Verify no exception was thrown accessing notifications
-        Assert.Null(caughtException);
+        Assert.IsNull(caughtException);
         
         // Verify notification was actually posted
-        Assert.True(notificationPosted, "Notification handler should have been called");
+        Assert.IsTrue(notificationPosted, "Notification handler should have been called");
         
         // Verify notification appears on screen
-        Assert.True(snapshot.ContainsText("Test Alert"), "Notification should appear");
+        Assert.IsTrue(snapshot.ContainsText("Test Alert"), "Notification should appear");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NotificationIcon_Click_TogglesRegisteredPanel()
     {
         // Verifies that clicking NotificationIcon toggles the panel visibility
@@ -415,12 +416,10 @@ public class NotificationCardNodeTests
         await runTask;
 
         // Drawer should be visible with notification count header
-        Assert.True(
-            snapshot.ContainsText("Notifications (1)") || snapshot.ContainsText("Notifications(1)"),
-            $"Drawer should show with count. Screen:\n{snapshot}");
+        Assert.IsTrue(snapshot.ContainsText("Notifications (1)") || snapshot.ContainsText("Notifications(1)"), $"Drawer should show with count. Screen:\n{snapshot}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NotificationDrawer_ClickOutside_CollapsesDrawer()
     {
         // Verifies that clicking outside the drawer collapses it
@@ -483,12 +482,10 @@ public class NotificationCardNodeTests
         await runTask;
 
         // Drawer should have collapsed - "Notifications (1)" header should be gone
-        Assert.False(
-            snapshot.ContainsText("Notifications (1)"),
-            $"Drawer should have collapsed after clicking outside. Screen:\n{snapshot.GetText()}");
+        Assert.IsFalse(snapshot.ContainsText("Notifications (1)"), $"Drawer should have collapsed after clicking outside. Screen:\n{snapshot.GetText()}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NotificationCard_DrawerMode_HidesProgressBar()
     {
         // Verifies that notifications in the drawer don't show progress bars
@@ -543,17 +540,15 @@ public class NotificationCardNodeTests
         await runTask;
 
         // The notification should be visible in the drawer
-        Assert.True(snapshot.ContainsText("Drawer Test"),
-            $"Drawer view should show notification. Screen:\n{snapshot.GetText()}");
-        Assert.True(snapshot.ContainsText("Notifications (1)"),
-            "Drawer header should be visible");
+        Assert.IsTrue(snapshot.ContainsText("Drawer Test"), $"Drawer view should show notification. Screen:\n{snapshot.GetText()}");
+        Assert.IsTrue(snapshot.ContainsText("Notifications (1)"), "Drawer header should be visible");
         
         // The test validates that ShowProgressBar=false is applied to drawer cards
         // by checking that the drawer renders correctly without the progress bar row
         // (which would cause layout issues if not handled properly)
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NotificationDrawer_ClickOnCardButton_DismissesNotification()
     {
         // Verifies that clicking on the dismiss button inside a drawer card works
@@ -618,8 +613,7 @@ public class NotificationCardNodeTests
         var hitTestDebug = app.LastHitTestDebug ?? "no debug info";
 
         // Notification should be dismissed - header should show 0 or drawer should close
-        Assert.False(snapshot.ContainsText("Dismiss Test"),
-            $"Notification should have been dismissed.\nHitTest: {hitTestDebug}\nScreen:\n{snapshot.GetText()}");
+        Assert.IsFalse(snapshot.ContainsText("Dismiss Test"), $"Notification should have been dismissed.\nHitTest: {hitTestDebug}\nScreen:\n{snapshot.GetText()}");
     }
 }
 
@@ -627,6 +621,7 @@ public class NotificationCardNodeTests
 /// <summary>
 /// Tests for notification panel hit testing behavior.
 /// </summary>
+[TestClass]
 public class NotificationPanelHitTestTests
 {
     /// <summary>
@@ -634,7 +629,7 @@ public class NotificationPanelHitTestTests
     /// clicking on notification cards should NOT pass through to the content below.
     /// The drawer should have priority in hit testing.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task NotificationPanel_DrawerExpanded_BlocksHitTestToContentBelow()
     {
         // Arrange - Create a notification panel with buttons underneath
@@ -704,18 +699,16 @@ public class NotificationPanelHitTestTests
 
         // The content button should NOT have been clicked
         // Focus should stay on drawer elements, not pass through to content
-        Assert.False(contentButtonClicked,
-            $"Content button should NOT be clicked when drawer is expanded. Screen:\n{snapshot}");
+        Assert.IsFalse(contentButtonClicked, $"Content button should NOT be clicked when drawer is expanded. Screen:\n{snapshot}");
         
         // The drawer should still be visible
-        Assert.True(snapshot.ContainsText("Notifications"),
-            $"Drawer should still be visible. Screen:\n{snapshot}");
+        Assert.IsTrue(snapshot.ContainsText("Notifications"), $"Drawer should still be visible. Screen:\n{snapshot}");
     }
 
     /// <summary>
     /// Test that when drawer is collapsed, content buttons are accessible.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task NotificationPanel_DrawerCollapsed_ContentIsAccessible()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -763,14 +756,13 @@ public class NotificationPanelHitTestTests
         await runTask;
 
         // Content button should be clicked when drawer is collapsed
-        Assert.True(contentButtonClicked,
-            $"Content button SHOULD be clickable when drawer is collapsed. Screen:\n{snapshot}");
+        Assert.IsTrue(contentButtonClicked, $"Content button SHOULD be clickable when drawer is collapsed. Screen:\n{snapshot}");
     }
 
     /// <summary>
     /// Test that floating notifications have priority over content.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task NotificationPanel_FloatingNotification_HasPriorityOverContent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -818,9 +810,7 @@ public class NotificationPanelHitTestTests
         await runTask;
 
         // Floating notification should be visible on top
-        Assert.True(snapshot.ContainsText("Alert"),
-            $"Floating notification should be visible. Screen:\n{snapshot.GetDisplayText()}");
-        Assert.True(snapshot.ContainsText("Important message"),
-            $"Notification body should be visible. Screen:\n{snapshot.GetDisplayText()}");
+        Assert.IsTrue(snapshot.ContainsText("Alert"), $"Floating notification should be visible. Screen:\n{snapshot.GetDisplayText()}");
+        Assert.IsTrue(snapshot.ContainsText("Important message"), $"Notification body should be visible. Screen:\n{snapshot.GetDisplayText()}");
     }
 }

--- a/tests/Hex1b.Tests/Osc7CwdTests.cs
+++ b/tests/Hex1b.Tests/Osc7CwdTests.cs
@@ -8,68 +8,69 @@ namespace Hex1b.Tests;
 /// Emitted by bash, zsh, fish, and PowerShell to announce the shell's CWD.
 /// Inspired by psmux's test_vt100_screen.rs OSC 7 tests.
 /// </summary>
+[TestClass]
 public class Osc7CwdTests
 {
-    [Fact]
+    [TestMethod]
     public void Tokenize_Osc7_WithBelTerminator_ReturnsOscToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b]7;file:///home/user/project\x07");
 
-        var token = Assert.Single(result);
-        var oscToken = Assert.IsType<OscToken>(token);
-        Assert.Equal("7", oscToken.Command);
-        Assert.Equal("file:///home/user/project", oscToken.Payload);
+        var token = TestSeq.Single(result);
+        var oscToken = TestSeq.IsType<OscToken>(token);
+        Assert.AreEqual("7", oscToken.Command);
+        Assert.AreEqual("file:///home/user/project", oscToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_Osc7_WithStTerminator_ReturnsOscToken()
     {
         var result = AnsiTokenizer.Tokenize("\x1b]7;file:///tmp/test\x1b\\");
 
-        var token = Assert.Single(result);
-        var oscToken = Assert.IsType<OscToken>(token);
-        Assert.Equal("7", oscToken.Command);
-        Assert.Equal("file:///tmp/test", oscToken.Payload);
+        var token = TestSeq.Single(result);
+        var oscToken = TestSeq.IsType<OscToken>(token);
+        Assert.AreEqual("7", oscToken.Command);
+        Assert.AreEqual("file:///tmp/test", oscToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_Osc7_WithHostname_ReturnsFullUri()
     {
         var result = AnsiTokenizer.Tokenize("\x1b]7;file://myhost/home/user\x07");
 
-        var token = Assert.Single(result);
-        var oscToken = Assert.IsType<OscToken>(token);
-        Assert.Equal("7", oscToken.Command);
-        Assert.Equal("file://myhost/home/user", oscToken.Payload);
+        var token = TestSeq.Single(result);
+        var oscToken = TestSeq.IsType<OscToken>(token);
+        Assert.AreEqual("7", oscToken.Command);
+        Assert.AreEqual("file://myhost/home/user", oscToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_Osc7_WithPercentEncoding_PreservesRawUri()
     {
         // Tokenizer should preserve the raw URI; decoding is the consumer's job
         var result = AnsiTokenizer.Tokenize("\x1b]7;file:///home/user/my%20project\x07");
 
-        var token = Assert.Single(result);
-        var oscToken = Assert.IsType<OscToken>(token);
-        Assert.Equal("7", oscToken.Command);
-        Assert.Equal("file:///home/user/my%20project", oscToken.Payload);
+        var token = TestSeq.Single(result);
+        var oscToken = TestSeq.IsType<OscToken>(token);
+        Assert.AreEqual("7", oscToken.Command);
+        Assert.AreEqual("file:///home/user/my%20project", oscToken.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tokenize_Osc7_DoesNotInterfereWithOsc0()
     {
         // OSC 7 followed by OSC 0 — both should parse independently
         var result = AnsiTokenizer.Tokenize(
             "\x1b]7;file:///tmp\x07\x1b]0;My Title\x07");
 
-        Assert.Equal(2, result.Count);
+        Assert.AreEqual(2, result.Count);
 
-        var osc7 = Assert.IsType<OscToken>(result[0]);
-        Assert.Equal("7", osc7.Command);
-        Assert.Equal("file:///tmp", osc7.Payload);
+        var osc7 = TestSeq.IsType<OscToken>(result[0]);
+        Assert.AreEqual("7", osc7.Command);
+        Assert.AreEqual("file:///tmp", osc7.Payload);
 
-        var osc0 = Assert.IsType<OscToken>(result[1]);
-        Assert.Equal("0", osc0.Command);
-        Assert.Equal("My Title", osc0.Payload);
+        var osc0 = TestSeq.IsType<OscToken>(result[1]);
+        Assert.AreEqual("0", osc0.Command);
+        Assert.AreEqual("My Title", osc0.Payload);
     }
 }

--- a/tests/Hex1b.Tests/Osc8HyperlinkTests.cs
+++ b/tests/Hex1b.Tests/Osc8HyperlinkTests.cs
@@ -9,11 +9,12 @@ namespace Hex1b.Tests;
 /// Tests for OSC 8 hyperlink support, including both low-level terminal parsing
 /// and high-level HyperlinkWidget integration with Hex1bApp.
 /// </summary>
+[TestClass]
 public class Osc8HyperlinkTests
 {
     #region Low-Level OSC 8 Parsing Tests
 
-    [Fact]
+    [TestMethod]
     public async Task ProcessOutput_WithOsc8Sequence_CreatesHyperlinkData()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -26,17 +27,17 @@ public class Osc8HyperlinkTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]8;;\x1b\\")); // End hyperlink
         
         // Should track the hyperlink data
-        Assert.Equal(1, terminal.TrackedHyperlinkCount);
-        Assert.True(terminal.ContainsHyperlinkData());
+        Assert.AreEqual(1, terminal.TrackedHyperlinkCount);
+        Assert.IsTrue(terminal.ContainsHyperlinkData());
         
         // The cells with "Link Text" should have the hyperlink data
         var hyperlinkData = terminal.GetHyperlinkDataAt(0, 0);
-        Assert.NotNull(hyperlinkData);
-        Assert.Equal("https://example.com", hyperlinkData.Uri);
-        Assert.Equal("", hyperlinkData.Parameters);
+        Assert.IsNotNull(hyperlinkData);
+        Assert.AreEqual("https://example.com", hyperlinkData.Uri);
+        Assert.AreEqual("", hyperlinkData.Parameters);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ProcessOutput_WithOsc8UsingBel_CreatesHyperlinkData()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -47,14 +48,14 @@ public class Osc8HyperlinkTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("Click here"));
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]8;;\x07")); // End hyperlink
         
-        Assert.Equal(1, terminal.TrackedHyperlinkCount);
+        Assert.AreEqual(1, terminal.TrackedHyperlinkCount);
         
         var hyperlinkData = terminal.GetHyperlinkDataAt(0, 0);
-        Assert.NotNull(hyperlinkData);
-        Assert.Equal("https://example.org", hyperlinkData.Uri);
+        Assert.IsNotNull(hyperlinkData);
+        Assert.AreEqual("https://example.org", hyperlinkData.Uri);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ProcessOutput_WithOsc8WithParameters_StoresParameters()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -66,12 +67,12 @@ public class Osc8HyperlinkTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]8;;\x1b\\"));
         
         var hyperlinkData = terminal.GetHyperlinkDataAt(0, 0);
-        Assert.NotNull(hyperlinkData);
-        Assert.Equal("https://example.com/path", hyperlinkData.Uri);
-        Assert.Equal("id=test123", hyperlinkData.Parameters);
+        Assert.IsNotNull(hyperlinkData);
+        Assert.AreEqual("https://example.com/path", hyperlinkData.Uri);
+        Assert.AreEqual("id=test123", hyperlinkData.Parameters);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ProcessOutput_EndOsc8_ReleasesHyperlink()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -82,9 +83,9 @@ public class Osc8HyperlinkTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("Link"));
         
         // Verify hyperlink exists
-        Assert.Equal(1, terminal.TrackedHyperlinkCount);
+        Assert.AreEqual(1, terminal.TrackedHyperlinkCount);
         var linkData1 = terminal.GetHyperlinkDataAt(0, 0);
-        Assert.NotNull(linkData1);
+        Assert.IsNotNull(linkData1);
         
         // End hyperlink
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]8;;\x1b\\"));
@@ -94,14 +95,14 @@ public class Osc8HyperlinkTests
         
         // The plain text should not have hyperlink
         var linkData2 = terminal.GetHyperlinkDataAt(5, 0);
-        Assert.Null(linkData2);
+        Assert.IsNull(linkData2);
         
         // But the original link text should still have it
         var linkData3 = terminal.GetHyperlinkDataAt(0, 0);
-        Assert.NotNull(linkData3);
+        Assert.IsNotNull(linkData3);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TrackedHyperlink_WhenCellOverwritten_ReleasesReference()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -112,16 +113,16 @@ public class Osc8HyperlinkTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("Link"));
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]8;;\x1b\\"));
         
-        Assert.Equal(1, terminal.TrackedHyperlinkCount);
+        Assert.AreEqual(1, terminal.TrackedHyperlinkCount);
         
         // Overwrite the cells
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[1;1HXXXXXXXX"));
         
         // Hyperlink data should be released (refcount reached 0)
-        Assert.Equal(0, terminal.TrackedHyperlinkCount);
+        Assert.AreEqual(0, terminal.TrackedHyperlinkCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TrackedHyperlink_Deduplication_ReusesSameObject()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -139,15 +140,15 @@ public class Osc8HyperlinkTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]8;;\x1b\\"));
         
         // Should still only have one unique tracked object
-        Assert.Equal(1, terminal.TrackedHyperlinkCount);
+        Assert.AreEqual(1, terminal.TrackedHyperlinkCount);
         
         // Both link texts should reference the same object
         var link1 = terminal.GetHyperlinkDataAt(0, 0);
         var link2 = terminal.GetHyperlinkDataAt(6, 0);
-        Assert.Same(link1, link2);
+        Assert.AreSame(link1, link2);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TrackedHyperlink_RefCount_IncreasesWithDeduplication()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -159,13 +160,13 @@ public class Osc8HyperlinkTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]8;;\x1b\\"));
         
         var trackedLink = terminal.GetTrackedHyperlinkAt(0, 0);
-        Assert.NotNull(trackedLink);
+        Assert.IsNotNull(trackedLink);
         
         // RefCount should be 4 (one for each character: L, i, n, k)
-        Assert.Equal(4, trackedLink.RefCount);
+        Assert.AreEqual(4, trackedLink.RefCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TrackedHyperlink_DifferentParameters_CreatesSeparateObjects()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -181,16 +182,16 @@ public class Osc8HyperlinkTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]8;;\x1b\\"));
         
         // Should have two unique tracked objects
-        Assert.Equal(2, terminal.TrackedHyperlinkCount);
+        Assert.AreEqual(2, terminal.TrackedHyperlinkCount);
         
         var link1 = terminal.GetHyperlinkDataAt(0, 0);
         var link2 = terminal.GetHyperlinkDataAt(1, 0);
-        Assert.NotSame(link1, link2);
-        Assert.Equal("id=1", link1!.Parameters);
-        Assert.Equal("id=2", link2!.Parameters);
+        Assert.AreNotSame(link1, link2);
+        Assert.AreEqual("id=1", link1!.Parameters);
+        Assert.AreEqual("id=2", link2!.Parameters);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ProcessOutput_MultilineHyperlink_TracksAcrossRows()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -207,13 +208,13 @@ public class Osc8HyperlinkTests
         var link1 = terminal.GetHyperlinkDataAt(0, 0);
         var link2 = terminal.GetHyperlinkDataAt(0, 1);
         
-        Assert.NotNull(link1);
-        Assert.NotNull(link2);
-        Assert.Same(link1, link2);
-        Assert.Equal("https://example.com", link1.Uri);
+        Assert.IsNotNull(link1);
+        Assert.IsNotNull(link2);
+        Assert.AreSame(link1, link2);
+        Assert.AreEqual("https://example.com", link1.Uri);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ProcessOutput_NestedHyperlinks_ReplacesWithNewLink()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -230,19 +231,19 @@ public class Osc8HyperlinkTests
         
         // First character should have first link
         var link1 = terminal.GetHyperlinkDataAt(0, 0);
-        Assert.NotNull(link1);
-        Assert.Equal("https://first.com", link1.Uri);
+        Assert.IsNotNull(link1);
+        Assert.AreEqual("https://first.com", link1.Uri);
         
         // Second character should have second link
         var link2 = terminal.GetHyperlinkDataAt(1, 0);
-        Assert.NotNull(link2);
-        Assert.Equal("https://second.com", link2.Uri);
+        Assert.IsNotNull(link2);
+        Assert.AreEqual("https://second.com", link2.Uri);
         
         // Should have two tracked objects
-        Assert.Equal(2, terminal.TrackedHyperlinkCount);
+        Assert.AreEqual(2, terminal.TrackedHyperlinkCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WorkloadAdapter_WithOsc8_TerminalReceivesHyperlinkData()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -259,15 +260,15 @@ public class Osc8HyperlinkTests
             .Build()
             .ApplyAsync(terminal);
         
-        Assert.Equal(1, terminal.TrackedHyperlinkCount);
-        Assert.True(terminal.ContainsHyperlinkData());
+        Assert.AreEqual(1, terminal.TrackedHyperlinkCount);
+        Assert.IsTrue(terminal.ContainsHyperlinkData());
         
         var linkData = terminal.GetHyperlinkDataAt(0, 0);
-        Assert.NotNull(linkData);
-        Assert.Equal("https://example.com", linkData.Uri);
+        Assert.IsNotNull(linkData);
+        Assert.AreEqual("https://example.com", linkData.Uri);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ProcessOutput_ComplexUri_PreservesAllCharacters()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -280,15 +281,15 @@ public class Osc8HyperlinkTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b]8;;\x1b\\"));
         
         var linkData = terminal.GetHyperlinkDataAt(0, 0);
-        Assert.NotNull(linkData);
-        Assert.Equal(uri, linkData.Uri);
+        Assert.IsNotNull(linkData);
+        Assert.AreEqual(uri, linkData.Uri);
     }
 
     #endregion
 
     #region HyperlinkWidget Integration Tests with Snapshots
 
-    [Fact]
+    [TestMethod]
     public async Task HyperlinkWidget_SingleLink_RendersWithOsc8()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -316,11 +317,11 @@ public class Osc8HyperlinkTests
         TestSvgHelper.Capture(snapshot, "hyperlink-single");
 
         // Verify the link text is rendered
-        Assert.True(snapshot.ContainsText("Visit GitHub"));
-        Assert.True(snapshot.ContainsText("Click the link below"));
+        Assert.IsTrue(snapshot.ContainsText("Visit GitHub"));
+        Assert.IsTrue(snapshot.ContainsText("Click the link below"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HyperlinkWidget_MultipleLinks_AllRenderCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -351,13 +352,13 @@ public class Osc8HyperlinkTests
         TestSvgHelper.Capture(snapshot, "hyperlink-multiple");
 
         // Verify all links are rendered
-        Assert.True(snapshot.ContainsText("GitHub"));
-        Assert.True(snapshot.ContainsText("Documentation"));
-        Assert.True(snapshot.ContainsText("Examples"));
-        Assert.True(snapshot.ContainsText("API Reference"));
+        Assert.IsTrue(snapshot.ContainsText("GitHub"));
+        Assert.IsTrue(snapshot.ContainsText("Documentation"));
+        Assert.IsTrue(snapshot.ContainsText("Examples"));
+        Assert.IsTrue(snapshot.ContainsText("API Reference"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HyperlinkWidget_InHStack_RendersInline()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -391,12 +392,12 @@ public class Osc8HyperlinkTests
         TestSvgHelper.Capture(snapshot, "hyperlink-inline");
 
         // Verify inline layout
-        Assert.True(snapshot.ContainsText("[Home]"));
-        Assert.True(snapshot.ContainsText("[Docs]"));
-        Assert.True(snapshot.ContainsText("[GitHub]"));
+        Assert.IsTrue(snapshot.ContainsText("[Home]"));
+        Assert.IsTrue(snapshot.ContainsText("[Docs]"));
+        Assert.IsTrue(snapshot.ContainsText("[GitHub]"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HyperlinkWidget_InBorder_RendersWithFrame()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -428,12 +429,12 @@ public class Osc8HyperlinkTests
         TestSvgHelper.Capture(snapshot, "hyperlink-bordered");
 
         // Verify content
-        Assert.True(snapshot.ContainsText("Resources"));
-        Assert.True(snapshot.ContainsText("Project Repository"));
-        Assert.True(snapshot.ContainsText("Issue Tracker"));
+        Assert.IsTrue(snapshot.ContainsText("Resources"));
+        Assert.IsTrue(snapshot.ContainsText("Project Repository"));
+        Assert.IsTrue(snapshot.ContainsText("Issue Tracker"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HyperlinkWidget_WithClickHandler_TracksClicks()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -463,11 +464,11 @@ public class Osc8HyperlinkTests
         await runTask;
 
         // Assert the click handlers were invoked
-        Assert.Equal("https://example.com", clickedUri);
-        Assert.Equal(2, clickCount);
+        Assert.AreEqual("https://example.com", clickedUri);
+        Assert.AreEqual(2, clickCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HyperlinkWidget_TabNavigation_FocusesLinks()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -507,10 +508,10 @@ public class Osc8HyperlinkTests
         var snapshot = terminal.CreateSnapshot();
         TestSvgHelper.Capture(snapshot, "hyperlink-navigation");
 
-        Assert.Equal("https://third.com", lastClickedUri);
+        Assert.AreEqual("https://third.com", lastClickedUri);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HyperlinkWidget_MixedWithButtons_InterleavedCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -545,11 +546,11 @@ public class Osc8HyperlinkTests
         await runTask;
 
         // Assert the handlers were invoked
-        Assert.True(linkClicked, "Link click handler should have been invoked");
-        Assert.True(buttonClicked, "Button click handler should have been invoked");
+        Assert.IsTrue(linkClicked, "Link click handler should have been invoked");
+        Assert.IsTrue(buttonClicked, "Button click handler should have been invoked");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HyperlinkWidget_ComplexUrls_RendersCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -579,13 +580,13 @@ public class Osc8HyperlinkTests
 
         TestSvgHelper.Capture(snapshot, "hyperlink-complex-urls");
 
-        Assert.True(snapshot.ContainsText("Search Results"));
-        Assert.True(snapshot.ContainsText("Wikipedia Section"));
-        Assert.True(snapshot.ContainsText("File Protocol"));
-        Assert.True(snapshot.ContainsText("Mailto Link"));
+        Assert.IsTrue(snapshot.ContainsText("Search Results"));
+        Assert.IsTrue(snapshot.ContainsText("Wikipedia Section"));
+        Assert.IsTrue(snapshot.ContainsText("File Protocol"));
+        Assert.IsTrue(snapshot.ContainsText("Mailto Link"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HyperlinkWidget_NarrowTerminal_TextTruncates()
     {
         // Very narrow terminal - hyperlink text should be truncated
@@ -614,12 +615,12 @@ public class Osc8HyperlinkTests
         TestSvgHelper.Capture(snapshot, "hyperlink-narrow-terminal");
 
         // The text should be truncated, so full text should NOT be present
-        Assert.False(snapshot.ContainsText("Very Long Hyperlink Text That Should Truncate"));
+        Assert.IsFalse(snapshot.ContainsText("Very Long Hyperlink Text That Should Truncate"));
         // But partial text should be visible
-        Assert.True(snapshot.ContainsText("Very"));
+        Assert.IsTrue(snapshot.ContainsText("Very"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HyperlinkWidget_InSplitter_ClippedByPane()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -654,13 +655,13 @@ public class Osc8HyperlinkTests
         TestSvgHelper.Capture(snapshot, "hyperlink-splitter-clipping");
 
         // Right pane should be fully visible
-        Assert.True(snapshot.ContainsText("Right Pane"));
-        Assert.True(snapshot.ContainsText("Right Link"));
+        Assert.IsTrue(snapshot.ContainsText("Right Pane"));
+        Assert.IsTrue(snapshot.ContainsText("Right Link"));
         // Left pane text should be clipped (partial visibility)
-        Assert.True(snapshot.ContainsText("Left"));
+        Assert.IsTrue(snapshot.ContainsText("Left"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HyperlinkWidget_InScrollView_PartiallyVisible()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -694,7 +695,7 @@ public class Osc8HyperlinkTests
         // WaitUntil already verified links are visible after scrolling
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HyperlinkWidget_InBorderWithSmallSize_Clipped()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -723,12 +724,12 @@ public class Osc8HyperlinkTests
         TestSvgHelper.Capture(snapshot, "hyperlink-border-clipped");
 
         // Border title should be visible
-        Assert.True(snapshot.ContainsText("Tiny"));
+        Assert.IsTrue(snapshot.ContainsText("Tiny"));
         // Full hyperlink text should NOT be visible (clipped)
-        Assert.False(snapshot.ContainsText("exceeds the border"));
+        Assert.IsFalse(snapshot.ContainsText("exceeds the border"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HyperlinkWidget_MultipleInHStack_WrapsOrClips()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -761,11 +762,11 @@ public class Osc8HyperlinkTests
         TestSvgHelper.Capture(snapshot, "hyperlink-hstack-overflow");
 
         // First links should be visible
-        Assert.True(snapshot.ContainsText("[GitHub]"));
+        Assert.IsTrue(snapshot.ContainsText("[GitHub]"));
         // Later links may be clipped depending on terminal width
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HyperlinkWidget_EmptyText_RendersNothing()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -793,11 +794,11 @@ public class Osc8HyperlinkTests
 
         TestSvgHelper.Capture(snapshot, "hyperlink-empty-text");
 
-        Assert.True(snapshot.ContainsText("Before"));
-        Assert.True(snapshot.ContainsText("After"));
+        Assert.IsTrue(snapshot.ContainsText("Before"));
+        Assert.IsTrue(snapshot.ContainsText("After"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HyperlinkWidget_SpecialCharactersInText_RendersCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -827,14 +828,14 @@ public class Osc8HyperlinkTests
 
         TestSvgHelper.Capture(snapshot, "hyperlink-special-chars");
 
-        Assert.True(snapshot.ContainsText("angle"));
-        Assert.True(snapshot.ContainsText("quotes"));
-        Assert.True(snapshot.ContainsText("apostrophes"));
-        Assert.True(snapshot.ContainsText("ampersand"));
-        Assert.True(snapshot.ContainsText("日本語"));
+        Assert.IsTrue(snapshot.ContainsText("angle"));
+        Assert.IsTrue(snapshot.ContainsText("quotes"));
+        Assert.IsTrue(snapshot.ContainsText("apostrophes"));
+        Assert.IsTrue(snapshot.ContainsText("ampersand"));
+        Assert.IsTrue(snapshot.ContainsText("日本語"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HyperlinkWidget_WithParameters_PreservesId()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -862,11 +863,11 @@ public class Osc8HyperlinkTests
 
         TestSvgHelper.Capture(snapshot, "hyperlink-with-id");
 
-        Assert.True(snapshot.ContainsText("Part 1 of"));
-        Assert.True(snapshot.ContainsText("the same link"));
+        Assert.IsTrue(snapshot.ContainsText("Part 1 of"));
+        Assert.IsTrue(snapshot.ContainsText("the same link"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HyperlinkWidget_InsideLayoutWithClipping_PreservesHyperlinkData()
     {
         // Test that OSC 8 hyperlink tracking works correctly when content is clipped by a layout provider
@@ -910,15 +911,15 @@ public class Osc8HyperlinkTests
             if (cell.HasHyperlinkData)
             {
                 foundHyperlink = true;
-                Assert.Equal("https://example.com/clipped", cell.HyperlinkData!.Uri);
+                Assert.AreEqual("https://example.com/clipped", cell.HyperlinkData!.Uri);
                 break;
             }
         }
         
-        Assert.True(foundHyperlink, "Should find at least one cell with hyperlink data in the clipped area");
+        Assert.IsTrue(foundHyperlink, "Should find at least one cell with hyperlink data in the clipped area");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HyperlinkWidget_InsideVStackWithConstrainedWidth_TracksHyperlinkPerCell()
     {
         // Test that a hyperlink inside a VStack with constrained width has hyperlink data for each visible cell
@@ -959,10 +960,10 @@ public class Osc8HyperlinkTests
         }
         
         // Should have hyperlink data for each character in "Link ABC" (8 chars)
-        Assert.Equal(linkText.Length, hyperlinkCellCount);
+        Assert.AreEqual(linkText.Length, hyperlinkCellCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HyperlinkWidget_WithTextOverflowWrap_WrapsAcrossMultipleLines()
     {
         // Test that a hyperlink with TextOverflow.Wrap wraps properly across multiple lines
@@ -1008,15 +1009,13 @@ public class Osc8HyperlinkTests
         
         // The text "This is a very long hyperlink that should wrap to multiple lines" (63 chars)
         // in a 20-column terminal should wrap to at least 4 lines
-        Assert.True(rowsWithHyperlink.Count >= 3, 
-            $"Expected hyperlink to span at least 3 rows, but found {rowsWithHyperlink.Count} rows: [{string.Join(", ", rowsWithHyperlink)}]");
+        Assert.IsTrue(rowsWithHyperlink.Count >= 3, $"Expected hyperlink to span at least 3 rows, but found {rowsWithHyperlink.Count} rows: [{string.Join(", ", rowsWithHyperlink)}]");
         
         // Verify the first row contains "This is a very"
-        Assert.True(snapshot.ContainsText("This is a very") || snapshot.ContainsText("This"), 
-            "First line should contain start of hyperlink text");
+        Assert.IsTrue(snapshot.ContainsText("This is a very") || snapshot.ContainsText("This"), "First line should contain start of hyperlink text");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HyperlinkWidget_WithTextOverflowWrap_AllWrappedLinesHaveOsc8()
     {
         // Verify that each wrapped line of a hyperlink emits OSC 8 sequences
@@ -1060,15 +1059,14 @@ public class Osc8HyperlinkTests
         
         // "First Second Third Fourth" = 25 characters, but word-wrapping may not include
         // trailing spaces on lines. Should have at least 20 characters with hyperlink data.
-        Assert.True(hyperlinkCellCount >= 20, 
-            $"Expected at least 20 cells with hyperlink data, found {hyperlinkCellCount}");
+        Assert.IsTrue(hyperlinkCellCount >= 20, $"Expected at least 20 cells with hyperlink data, found {hyperlinkCellCount}");
     }
 
     #endregion
 
     #region SVG Group Class Tests
 
-    [Fact]
+    [TestMethod]
     public async Task SvgOutput_HyperlinkCells_HaveGroupClass()
     {
         // Cells with the same hyperlink should have the same group class in the SVG output
@@ -1085,7 +1083,7 @@ public class Osc8HyperlinkTests
         Assert.Contains("class=\"cell link-0\"", svg);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SvgOutput_MultipleSameHyperlinks_ShareGroupClass()
     {
         // Multiple cells with the same hyperlink share the same TrackedObject,
@@ -1101,10 +1099,10 @@ public class Osc8HyperlinkTests
         
         // Count how many cells have the link-0 class - should be 5 (for A, B, C, D, E)
         var cellGroupCount = System.Text.RegularExpressions.Regex.Matches(svg, @"class=""cell link-0""").Count;
-        Assert.Equal(5, cellGroupCount);
+        Assert.AreEqual(5, cellGroupCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SvgOutput_DifferentHyperlinks_HaveDifferentGroupClasses()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1123,7 +1121,7 @@ public class Osc8HyperlinkTests
         Assert.Contains("link-1", svg);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SvgOutput_CellsWithoutHyperlink_HaveNoGroupClass()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1140,7 +1138,7 @@ public class Osc8HyperlinkTests
         Assert.DoesNotContain("link-", svg);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SvgOutput_ContainsHighlightCssClass()
     {
         // SVG should include CSS for highlighting cell groups
@@ -1155,7 +1153,7 @@ public class Osc8HyperlinkTests
         Assert.Contains(".cell.highlight", svg);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SvgOutput_CellsHaveDataAttributes()
     {
         // Each cell group should have data-x and data-y attributes

--- a/tests/Hex1b.Tests/OscTitleSequenceTests.cs
+++ b/tests/Hex1b.Tests/OscTitleSequenceTests.cs
@@ -5,11 +5,12 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for OSC 0/1/2 (title/icon) and OSC 22/23 (title stack push/pop) sequences.
 /// </summary>
+[TestClass]
 public class OscTitleSequenceTests
 {
     #region OSC 0 - Set Both Title and Icon
 
-    [Fact]
+    [TestMethod]
     public async Task Osc0_SetsBothWindowTitleAndIconName()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -27,11 +28,11 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal("My Terminal Title", terminal.WindowTitle);
-        Assert.Equal("My Terminal Title", terminal.IconName);
+        Assert.AreEqual("My Terminal Title", terminal.WindowTitle);
+        Assert.AreEqual("My Terminal Title", terminal.IconName);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Osc0_WithStTerminator_SetsBothTitleAndIcon()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -49,11 +50,11 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal("Title With ST", terminal.WindowTitle);
-        Assert.Equal("Title With ST", terminal.IconName);
+        Assert.AreEqual("Title With ST", terminal.WindowTitle);
+        Assert.AreEqual("Title With ST", terminal.IconName);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Osc0_FiresBothEvents()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -75,11 +76,11 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal("Event Test", capturedTitle);
-        Assert.Equal("Event Test", capturedIcon);
+        Assert.AreEqual("Event Test", capturedTitle);
+        Assert.AreEqual("Event Test", capturedIcon);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Osc0_EmptyTitle_SetsEmptyString()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -96,7 +97,7 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal("Initial Title", terminal.WindowTitle);
+        Assert.AreEqual("Initial Title", terminal.WindowTitle);
 
         // Now clear it
         workload.Write("\x1b]0;\x07");
@@ -105,15 +106,15 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal("", terminal.WindowTitle);
-        Assert.Equal("", terminal.IconName);
+        Assert.AreEqual("", terminal.WindowTitle);
+        Assert.AreEqual("", terminal.IconName);
     }
 
     #endregion
 
     #region OSC 1 - Set Icon Name Only
 
-    [Fact]
+    [TestMethod]
     public async Task Osc1_SetsIconNameOnly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -137,11 +138,11 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal("Initial", terminal.WindowTitle); // Unchanged
-        Assert.Equal("Icon Only", terminal.IconName);
+        Assert.AreEqual("Initial", terminal.WindowTitle); // Unchanged
+        Assert.AreEqual("Icon Only", terminal.IconName);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Osc1_FiresOnlyIconEvent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -162,15 +163,15 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal(0, titleEventCount); // Title should not fire
-        Assert.Equal(1, iconEventCount);
+        Assert.AreEqual(0, titleEventCount); // Title should not fire
+        Assert.AreEqual(1, iconEventCount);
     }
 
     #endregion
 
     #region OSC 2 - Set Window Title Only
 
-    [Fact]
+    [TestMethod]
     public async Task Osc2_SetsWindowTitleOnly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -194,11 +195,11 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal("Title Only", terminal.WindowTitle);
-        Assert.Equal("Initial", terminal.IconName); // Unchanged
+        Assert.AreEqual("Title Only", terminal.WindowTitle);
+        Assert.AreEqual("Initial", terminal.IconName); // Unchanged
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Osc2_FiresOnlyTitleEvent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -219,15 +220,15 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal(1, titleEventCount);
-        Assert.Equal(0, iconEventCount); // Icon should not fire
+        Assert.AreEqual(1, titleEventCount);
+        Assert.AreEqual(0, iconEventCount); // Icon should not fire
     }
 
     #endregion
 
     #region OSC 22/23 - Title Stack
 
-    [Fact]
+    [TestMethod]
     public async Task Osc22_PushesCurrentTitleOntoStack()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -244,7 +245,7 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal("Original", terminal.WindowTitle);
+        Assert.AreEqual("Original", terminal.WindowTitle);
 
         // Push current title onto stack
         workload.Write("\x1b]22;\x07");
@@ -254,10 +255,10 @@ public class OscTitleSequenceTests
             .ApplyAsync(terminal);
 
         // Title should still be the same after push
-        Assert.Equal("Original", terminal.WindowTitle);
+        Assert.AreEqual("Original", terminal.WindowTitle);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Osc23_PopsAndRestoresTitle()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -288,7 +289,7 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal("New Title", terminal.WindowTitle);
+        Assert.AreEqual("New Title", terminal.WindowTitle);
 
         // Pop - should restore to "Original"
         workload.Write("\x1b]23;\x07");
@@ -297,11 +298,11 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal("Original", terminal.WindowTitle);
-        Assert.Equal("Original", terminal.IconName);
+        Assert.AreEqual("Original", terminal.WindowTitle);
+        Assert.AreEqual("Original", terminal.IconName);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Osc22_23_StackIsIndependentOfDirectTitleChanges()
     {
         // This tests the key behavior: OSC 0/1/2 do NOT affect the stack
@@ -333,7 +334,7 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal("vim", terminal.WindowTitle);
+        Assert.AreEqual("vim", terminal.WindowTitle);
 
         // Pop: Stack=[], Current="bash" (restored from stack, NOT "vim")
         workload.Write("\x1b]23;\x07");
@@ -342,10 +343,10 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal("bash", terminal.WindowTitle);
+        Assert.AreEqual("bash", terminal.WindowTitle);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Osc22_23_MultipleStackLevels()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -370,7 +371,7 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal("vim", terminal.WindowTitle);
+        Assert.AreEqual("vim", terminal.WindowTitle);
 
         // Push level 2
         workload.Write("\x1b]22;\x07");
@@ -380,7 +381,7 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal(":help", terminal.WindowTitle);
+        Assert.AreEqual(":help", terminal.WindowTitle);
 
         // Pop level 2 -> vim
         workload.Write("\x1b]23;\x07");
@@ -389,7 +390,7 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal("vim", terminal.WindowTitle);
+        Assert.AreEqual("vim", terminal.WindowTitle);
 
         // Pop level 1 -> shell
         workload.Write("\x1b]23;\x07");
@@ -398,10 +399,10 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal("shell", terminal.WindowTitle);
+        Assert.AreEqual("shell", terminal.WindowTitle);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Osc23_OnEmptyStack_IsIgnored()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -426,10 +427,10 @@ public class OscTitleSequenceTests
             .ApplyAsync(terminal);
 
         // Title should remain unchanged
-        Assert.Equal("Current", terminal.WindowTitle);
+        Assert.AreEqual("Current", terminal.WindowTitle);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Osc22_WithPayload_PushesAndSetsNewTitle()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -454,7 +455,7 @@ public class OscTitleSequenceTests
             .ApplyAsync(terminal);
 
         // Current should be the new title
-        Assert.Equal("New After Push", terminal.WindowTitle);
+        Assert.AreEqual("New After Push", terminal.WindowTitle);
 
         // Pop should restore to original
         workload.Write("\x1b]23;\x07");
@@ -463,14 +464,14 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal("Original", terminal.WindowTitle);
+        Assert.AreEqual("Original", terminal.WindowTitle);
     }
 
     #endregion
 
     #region Event Deduplication
 
-    [Fact]
+    [TestMethod]
     public async Task TitleEvent_NotFiredWhenTitleUnchanged()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -490,7 +491,7 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal(1, titleEventCount);
+        Assert.AreEqual(1, titleEventCount);
 
         // Set same title again
         workload.Write("\x1b]2;Same Title\x07");
@@ -500,14 +501,14 @@ public class OscTitleSequenceTests
             .ApplyAsync(terminal);
 
         // Should not fire again
-        Assert.Equal(1, titleEventCount);
+        Assert.AreEqual(1, titleEventCount);
     }
 
     #endregion
 
     #region Special Characters
 
-    [Fact]
+    [TestMethod]
     public async Task Title_WithSpecialCharacters_IsPreserved()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -524,10 +525,10 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal("~/Code/project - vim [+]", terminal.WindowTitle);
+        Assert.AreEqual("~/Code/project - vim [+]", terminal.WindowTitle);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Title_WithUnicode_IsPreserved()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -544,14 +545,14 @@ public class OscTitleSequenceTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal("📁 Project - 日本語", terminal.WindowTitle);
+        Assert.AreEqual("📁 Project - 日本語", terminal.WindowTitle);
     }
 
     #endregion
 
     #region Initial State
 
-    [Fact]
+    [TestMethod]
     public void Terminal_InitialTitleIsEmpty()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -561,8 +562,8 @@ public class OscTitleSequenceTests
             .WithDimensions(80, 24)
             .Build();
 
-        Assert.Equal("", terminal.WindowTitle);
-        Assert.Equal("", terminal.IconName);
+        Assert.AreEqual("", terminal.WindowTitle);
+        Assert.AreEqual("", terminal.IconName);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/OverlayEnhancementTests.cs
+++ b/tests/Hex1b.Tests/OverlayEnhancementTests.cs
@@ -4,9 +4,10 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class OverlayEnhancementTests
 {
-    [Fact]
+    [TestMethod]
     public void OverlaySegment_Construction_SetsProperties()
     {
         var seg = new OverlaySegment("hello", Hex1bColor.Red, Hex1bColor.Blue)
@@ -15,24 +16,24 @@ public class OverlayEnhancementTests
             IsItalic = true
         };
 
-        Assert.Equal("hello", seg.Text);
-        Assert.Equal(Hex1bColor.Red, seg.Foreground);
-        Assert.Equal(Hex1bColor.Blue, seg.Background);
-        Assert.True(seg.IsBold);
-        Assert.True(seg.IsItalic);
+        Assert.AreEqual("hello", seg.Text);
+        Assert.AreEqual(Hex1bColor.Red, seg.Foreground);
+        Assert.AreEqual(Hex1bColor.Blue, seg.Background);
+        Assert.IsTrue(seg.IsBold);
+        Assert.IsTrue(seg.IsItalic);
     }
 
-    [Fact]
+    [TestMethod]
     public void OverlaySegment_Defaults_NoStyling()
     {
         var seg = new OverlaySegment("plain");
-        Assert.Null(seg.Foreground);
-        Assert.Null(seg.Background);
-        Assert.False(seg.IsBold);
-        Assert.False(seg.IsItalic);
+        Assert.IsNull(seg.Foreground);
+        Assert.IsNull(seg.Background);
+        Assert.IsFalse(seg.IsBold);
+        Assert.IsFalse(seg.IsItalic);
     }
 
-    [Fact]
+    [TestMethod]
     public void OverlayLine_WithSegments_HasRichContent()
     {
         var line = new OverlayLine("full text")
@@ -44,84 +45,84 @@ public class OverlayEnhancementTests
             ]
         };
 
-        Assert.NotNull(line.Segments);
-        Assert.Equal(2, line.Segments.Count);
+        Assert.IsNotNull(line.Segments);
+        Assert.AreEqual(2, line.Segments.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void OverlayLine_WithoutSegments_UsesTextProperty()
     {
         var line = new OverlayLine("simple text", Hex1bColor.White);
-        Assert.Null(line.Segments);
-        Assert.Equal("simple text", line.Text);
+        Assert.IsNull(line.Segments);
+        Assert.AreEqual("simple text", line.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void EditorOverlay_MaxWidth_SetsConstraint()
     {
         var overlay = new EditorOverlay(
             "test", new DocumentPosition(1, 1), OverlayPlacement.Below, [])
         { MaxWidth = 40 };
 
-        Assert.Equal(40, overlay.MaxWidth);
+        Assert.AreEqual(40, overlay.MaxWidth);
     }
 
-    [Fact]
+    [TestMethod]
     public void EditorOverlay_MaxHeight_SetsConstraint()
     {
         var overlay = new EditorOverlay(
             "test", new DocumentPosition(1, 1), OverlayPlacement.Below, [])
         { MaxHeight = 10 };
 
-        Assert.Equal(10, overlay.MaxHeight);
+        Assert.AreEqual(10, overlay.MaxHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void EditorOverlay_Title_SetsProperty()
     {
         var overlay = new EditorOverlay(
             "test", new DocumentPosition(1, 1), OverlayPlacement.Below, [])
         { Title = "Hover Info" };
 
-        Assert.Equal("Hover Info", overlay.Title);
+        Assert.AreEqual("Hover Info", overlay.Title);
     }
 
-    [Fact]
+    [TestMethod]
     public void EditorOverlay_Defaults_NullConstraints()
     {
         var overlay = new EditorOverlay(
             "test", new DocumentPosition(1, 1), OverlayPlacement.Below, []);
 
-        Assert.Null(overlay.MaxWidth);
-        Assert.Null(overlay.MaxHeight);
-        Assert.Null(overlay.Title);
+        Assert.IsNull(overlay.MaxWidth);
+        Assert.IsNull(overlay.MaxHeight);
+        Assert.IsNull(overlay.Title);
     }
 
-    [Fact]
+    [TestMethod]
     public void OverlayTheme_HasExpectedDefaults()
     {
         var bg = OverlayTheme.BackgroundColor.DefaultValue();
         var fg = OverlayTheme.ForegroundColor.DefaultValue();
         var border = OverlayTheme.BorderColor.DefaultValue();
 
-        Assert.NotEqual(Hex1bColor.Default, bg);
-        Assert.NotEqual(Hex1bColor.Default, fg);
-        Assert.NotEqual(Hex1bColor.Default, border);
+        Assert.AreNotEqual(Hex1bColor.Default, bg);
+        Assert.AreNotEqual(Hex1bColor.Default, fg);
+        Assert.AreNotEqual(Hex1bColor.Default, border);
     }
 
-    [Fact]
+    [TestMethod]
     public void OverlaySegment_RecordEquality()
     {
         var a = new OverlaySegment("text", Hex1bColor.Red);
         var b = new OverlaySegment("text", Hex1bColor.Red);
-        Assert.Equal(a, b);
+        Assert.AreEqual(a, b);
     }
 
-    [Fact]
+    [TestMethod]
     public void OverlaySegment_RecordInequality()
     {
         var a = new OverlaySegment("text", Hex1bColor.Red);
         var b = new OverlaySegment("text", Hex1bColor.Blue);
-        Assert.NotEqual(a, b);
+        Assert.AreNotEqual(a, b);
     }
 }

--- a/tests/Hex1b.Tests/PaddingNodeTests.cs
+++ b/tests/Hex1b.Tests/PaddingNodeTests.cs
@@ -8,11 +8,12 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for PaddingNode and PaddingWidget.
 /// </summary>
+[TestClass]
 public class PaddingNodeTests
 {
     #region Measurement Tests
 
-    [Fact]
+    [TestMethod]
     public void Measure_AddsPaddingToChildSize()
     {
         var child = new ButtonNode { Label = "OK" };
@@ -22,22 +23,22 @@ public class PaddingNodeTests
 
         // ButtonNode: " OK " = 4 wide, 1 tall
         // With padding: 4 + 2 + 3 = 9 wide, 1 + 1 + 1 = 3 tall
-        Assert.Equal(4 + 5, size.Width);
-        Assert.Equal(1 + 2, size.Height);
+        Assert.AreEqual(4 + 5, size.Width);
+        Assert.AreEqual(1 + 2, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_NullChild_ReturnsPaddingOnly()
     {
         var node = new PaddingNode { Child = null, Left = 2, Right = 3, Top = 1, Bottom = 4 };
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(5, size.Width);
-        Assert.Equal(5, size.Height);
+        Assert.AreEqual(5, size.Width);
+        Assert.AreEqual(5, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_ZeroPadding_MatchesChild()
     {
         var child = new ButtonNode { Label = "Test" };
@@ -46,10 +47,10 @@ public class PaddingNodeTests
         var childSize = child.Measure(Constraints.Unbounded);
         var paddedSize = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(childSize, paddedSize);
+        Assert.AreEqual(childSize, paddedSize);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_SubtractsPaddingFromConstraints()
     {
         var child = new ButtonNode { Label = "A Very Long Label That Should Be Constrained" };
@@ -58,10 +59,10 @@ public class PaddingNodeTests
         var size = node.Measure(new Constraints(0, 20, 0, 10));
 
         // Max width 20 - 10 padding = 10 for child, then +10 back = capped at 20
-        Assert.True(size.Width <= 20);
+        Assert.IsTrue(size.Width <= 20);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_LargePaddingExceedingConstraints_ClampsToZero()
     {
         var child = new ButtonNode { Label = "Hi" };
@@ -70,15 +71,15 @@ public class PaddingNodeTests
         // Child constraints should be clamped to 0, not go negative
         var size = node.Measure(new Constraints(0, 10, 0, 10));
 
-        Assert.True(size.Width <= 10);
-        Assert.True(size.Height <= 10);
+        Assert.IsTrue(size.Width <= 10);
+        Assert.IsTrue(size.Height <= 10);
     }
 
     #endregion
 
     #region Arrange Tests
 
-    [Fact]
+    [TestMethod]
     public void Arrange_OffsetsChildByPadding()
     {
         var child = new ButtonNode { Label = "OK" };
@@ -87,28 +88,28 @@ public class PaddingNodeTests
 
         node.Arrange(new Rect(10, 20, 30, 10));
 
-        Assert.Equal(new Rect(10, 20, 30, 10), node.Bounds);
-        Assert.Equal(13, child.Bounds.X);  // 10 + 3
-        Assert.Equal(21, child.Bounds.Y);  // 20 + 1
-        Assert.Equal(25, child.Bounds.Width);  // 30 - 3 - 2
-        Assert.Equal(8, child.Bounds.Height);  // 10 - 1 - 1
+        Assert.AreEqual(new Rect(10, 20, 30, 10), node.Bounds);
+        Assert.AreEqual(13, child.Bounds.X);  // 10 + 3
+        Assert.AreEqual(21, child.Bounds.Y);  // 20 + 1
+        Assert.AreEqual(25, child.Bounds.Width);  // 30 - 3 - 2
+        Assert.AreEqual(8, child.Bounds.Height);  // 10 - 1 - 1
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_NullChild_DoesNotThrow()
     {
         var node = new PaddingNode { Child = null, Left = 1, Right = 1, Top = 1, Bottom = 1 };
 
         node.Arrange(new Rect(0, 0, 10, 5));
 
-        Assert.Equal(new Rect(0, 0, 10, 5), node.Bounds);
+        Assert.AreEqual(new Rect(0, 0, 10, 5), node.Bounds);
     }
 
     #endregion
 
     #region Focus Tests
 
-    [Fact]
+    [TestMethod]
     public void GetFocusableNodes_DelegatesToChild()
     {
         var child = new ButtonNode { Label = "Focusable" };
@@ -116,25 +117,25 @@ public class PaddingNodeTests
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Single(focusables);
-        Assert.Same(child, focusables[0]);
+        TestSeq.Single(focusables);
+        Assert.AreSame(child, focusables[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetFocusableNodes_NullChild_ReturnsEmpty()
     {
         var node = new PaddingNode { Child = null };
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Empty(focusables);
+        Assert.IsEmpty(focusables);
     }
 
     #endregion
 
     #region GetChildren Tests
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_WithChild_ReturnsChild()
     {
         var child = new ButtonNode { Label = "Child" };
@@ -142,23 +143,23 @@ public class PaddingNodeTests
 
         var children = node.GetChildren().ToList();
 
-        Assert.Single(children);
-        Assert.Same(child, children[0]);
+        TestSeq.Single(children);
+        Assert.AreSame(child, children[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_NullChild_ReturnsEmpty()
     {
         var node = new PaddingNode { Child = null };
 
-        Assert.Empty(node.GetChildren());
+        Assert.IsEmpty(node.GetChildren());
     }
 
     #endregion
 
     #region Widget Reconciliation Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Widget_ReconcileAsync_CreatesNode()
     {
         var widget = new PaddingWidget(2, 3, 1, 1, new TextBlockWidget("Hello"));
@@ -166,15 +167,15 @@ public class PaddingNodeTests
 
         var node = await widget.ReconcileAsync(null, context);
 
-        var padding = Assert.IsType<PaddingNode>(node);
-        Assert.Equal(2, padding.Left);
-        Assert.Equal(3, padding.Right);
-        Assert.Equal(1, padding.Top);
-        Assert.Equal(1, padding.Bottom);
-        Assert.NotNull(padding.Child);
+        var padding = TestSeq.IsType<PaddingNode>(node);
+        Assert.AreEqual(2, padding.Left);
+        Assert.AreEqual(3, padding.Right);
+        Assert.AreEqual(1, padding.Top);
+        Assert.AreEqual(1, padding.Bottom);
+        Assert.IsNotNull(padding.Child);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Widget_ReconcileAsync_ReusesExistingNode()
     {
         var widget = new PaddingWidget(1, 1, 1, 1, new TextBlockWidget("Hello"));
@@ -183,10 +184,10 @@ public class PaddingNodeTests
 
         var node = await widget.ReconcileAsync(existingNode, context);
 
-        Assert.Same(existingNode, node);
+        Assert.AreSame(existingNode, node);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Widget_ReconcileAsync_UpdatesPaddingValues()
     {
         var widget1 = new PaddingWidget(1, 1, 1, 1, new TextBlockWidget("Hello"));
@@ -196,62 +197,62 @@ public class PaddingNodeTests
         var widget2 = new PaddingWidget(5, 10, 2, 3, new TextBlockWidget("Hello"));
         await widget2.ReconcileAsync(node, context);
 
-        Assert.Equal(5, node.Left);
-        Assert.Equal(10, node.Right);
-        Assert.Equal(2, node.Top);
-        Assert.Equal(3, node.Bottom);
+        Assert.AreEqual(5, node.Left);
+        Assert.AreEqual(10, node.Right);
+        Assert.AreEqual(2, node.Top);
+        Assert.AreEqual(3, node.Bottom);
     }
 
     #endregion
 
     #region Extension Method Tests
 
-    [Fact]
+    [TestMethod]
     public void Extensions_Padding_FourSides_CreatesWidget()
     {
         var ctx = new WidgetContext<VStackWidget>();
         var widget = ctx.Padding(1, 2, 3, 4, new TextBlockWidget("Hello"));
 
-        Assert.Equal(1, widget.Left);
-        Assert.Equal(2, widget.Right);
-        Assert.Equal(3, widget.Top);
-        Assert.Equal(4, widget.Bottom);
+        Assert.AreEqual(1, widget.Left);
+        Assert.AreEqual(2, widget.Right);
+        Assert.AreEqual(3, widget.Top);
+        Assert.AreEqual(4, widget.Bottom);
     }
 
-    [Fact]
+    [TestMethod]
     public void Extensions_Padding_Uniform_CreatesWidget()
     {
         var ctx = new WidgetContext<VStackWidget>();
         var widget = ctx.Padding(3, new TextBlockWidget("Hello"));
 
-        Assert.Equal(3, widget.Left);
-        Assert.Equal(3, widget.Right);
-        Assert.Equal(3, widget.Top);
-        Assert.Equal(3, widget.Bottom);
+        Assert.AreEqual(3, widget.Left);
+        Assert.AreEqual(3, widget.Right);
+        Assert.AreEqual(3, widget.Top);
+        Assert.AreEqual(3, widget.Bottom);
     }
 
-    [Fact]
+    [TestMethod]
     public void Extensions_Padding_HorizontalVertical_CreatesWidget()
     {
         var ctx = new WidgetContext<VStackWidget>();
         var widget = ctx.Padding(2, 1, new TextBlockWidget("Hello"));
 
-        Assert.Equal(2, widget.Left);
-        Assert.Equal(2, widget.Right);
-        Assert.Equal(1, widget.Top);
-        Assert.Equal(1, widget.Bottom);
+        Assert.AreEqual(2, widget.Left);
+        Assert.AreEqual(2, widget.Right);
+        Assert.AreEqual(1, widget.Top);
+        Assert.AreEqual(1, widget.Bottom);
     }
 
-    [Fact]
+    [TestMethod]
     public void Extensions_Padding_Builder_CreatesWidget()
     {
         var ctx = new WidgetContext<VStackWidget>();
         var widget = ctx.Padding(1, 1, 0, 0, p => p.Text("Indented"));
 
-        Assert.IsType<PaddingWidget>(widget);
+        TestSeq.IsType<PaddingWidget>(widget);
     }
 
-    [Fact]
+    [TestMethod]
     public void Extensions_Padding_ArrayBuilder_CreatesVStack()
     {
         var ctx = new WidgetContext<VStackWidget>();
@@ -261,7 +262,7 @@ public class PaddingNodeTests
             p.Text("Line 2"),
         });
 
-        Assert.IsType<PaddingWidget>(widget);
+        TestSeq.IsType<PaddingWidget>(widget);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/PastableWidgetTests.cs
+++ b/tests/Hex1b.Tests/PastableWidgetTests.cs
@@ -9,6 +9,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for PastableWidget/PastableNode container that intercepts paste events.
 /// </summary>
+[TestClass]
 public class PastableWidgetTests
 {
     /// <summary>
@@ -40,7 +41,7 @@ public class PastableWidgetTests
         return ctx;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Pastable_InterceptsPaste()
     {
         // Focused child doesn't handle paste → PastableNode receives it
@@ -61,12 +62,12 @@ public class PastableWidgetTests
         var result = await InputRouter.RouteInputAsync(
             node, new Hex1bPasteEvent(paste), focusRing, new InputRouterState());
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal("intercepted", receivedText);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual("intercepted", receivedText);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Pastable_ChildHandlesFirst()
     {
         // Focused child handles paste → PastableNode NOT called
@@ -87,12 +88,12 @@ public class PastableWidgetTests
         await InputRouter.RouteInputAsync(
             node, new Hex1bPasteEvent(paste), focusRing, new InputRouterState());
 
-        Assert.False(pastableWasCalled);
-        Assert.Single(child.ReceivedPastes);
+        Assert.IsFalse(pastableWasCalled);
+        TestSeq.Single(child.ReceivedPastes);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Pastable_OnPasteCallback()
     {
         var child = new TestFocusableNode { IsFocused = true, ShouldHandlePaste = false };
@@ -112,11 +113,11 @@ public class PastableWidgetTests
         await InputRouter.RouteInputAsync(
             node, new Hex1bPasteEvent(paste), focusRing, new InputRouterState());
 
-        Assert.Equal("callback data", receivedText);
+        Assert.AreEqual("callback data", receivedText);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Pastable_ReadChunks_MultipleChunks()
     {
         var child = new TestFocusableNode { IsFocused = true, ShouldHandlePaste = false };
@@ -145,14 +146,14 @@ public class PastableWidgetTests
         await InputRouter.RouteInputAsync(
             node, new Hex1bPasteEvent(paste), focusRing, new InputRouterState());
 
-        Assert.Equal(3, chunks.Count);
-        Assert.Equal("chunk1", chunks[0]);
-        Assert.Equal("chunk2", chunks[1]);
-        Assert.Equal("chunk3", chunks[2]);
+        Assert.AreEqual(3, chunks.Count);
+        Assert.AreEqual("chunk1", chunks[0]);
+        Assert.AreEqual("chunk2", chunks[1]);
+        Assert.AreEqual("chunk3", chunks[2]);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Pastable_ReadLines_StreamsLines()
     {
         var child = new TestFocusableNode { IsFocused = true, ShouldHandlePaste = false };
@@ -176,14 +177,14 @@ public class PastableWidgetTests
         await InputRouter.RouteInputAsync(
             node, new Hex1bPasteEvent(paste), focusRing, new InputRouterState());
 
-        Assert.Equal(3, lines.Count);
-        Assert.Equal("line1", lines[0]);
-        Assert.Equal("line2", lines[1]);
-        Assert.Equal("line3", lines[2]);
+        Assert.AreEqual(3, lines.Count);
+        Assert.AreEqual("line1", lines[0]);
+        Assert.AreEqual("line2", lines[1]);
+        Assert.AreEqual("line3", lines[2]);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Pastable_NoPasteHandler_NotHandled()
     {
         var child = new TestFocusableNode { IsFocused = true, ShouldHandlePaste = false };
@@ -202,11 +203,11 @@ public class PastableWidgetTests
         var result = await InputRouter.RouteInputAsync(
             node, new Hex1bPasteEvent(paste), focusRing, new InputRouterState());
 
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Pastable_NestedPastable_InnerTakesPrecedence()
     {
         // root (outer Pastable) -> inner (inner Pastable) -> focused child
@@ -236,12 +237,12 @@ public class PastableWidgetTests
         await InputRouter.RouteInputAsync(
             outer, new Hex1bPasteEvent(paste), focusRing, new InputRouterState());
 
-        Assert.Equal("inner wins", innerReceived);
-        Assert.False(outerCalled);
+        Assert.AreEqual("inner wins", innerReceived);
+        Assert.IsFalse(outerCalled);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Pastable_MaxSize_CancelsPaste()
     {
         var child = new TestFocusableNode { IsFocused = true, ShouldHandlePaste = false };
@@ -287,11 +288,11 @@ public class PastableWidgetTests
 
         await routeTask;
 
-        Assert.True(wasCancelled);
+        Assert.IsTrue(wasCancelled);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Pastable_Timeout_CancelsPaste()
     {
         var child = new TestFocusableNode { IsFocused = true, ShouldHandlePaste = false };
@@ -333,11 +334,11 @@ public class PastableWidgetTests
         // Don't complete the paste — let timeout fire
         await routeTask;
 
-        Assert.True(wasCancelled);
+        Assert.IsTrue(wasCancelled);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Pastable_CancelDuringStream()
     {
         var child = new TestFocusableNode { IsFocused = true, ShouldHandlePaste = false };
@@ -379,30 +380,30 @@ public class PastableWidgetTests
 
         await routeTask;
 
-        Assert.True(paste.IsCancelled);
-        Assert.True(chunksRead.Count >= 2);
-        Assert.Equal("chunk1", chunksRead[0]);
-        Assert.Equal("chunk2", chunksRead[1]);
+        Assert.IsTrue(paste.IsCancelled);
+        Assert.IsTrue(chunksRead.Count >= 2);
+        Assert.AreEqual("chunk1", chunksRead[0]);
+        Assert.AreEqual("chunk2", chunksRead[1]);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Pastable_TotalCharactersWritten_Tracked()
     {
         var paste = new PasteContext();
-        Assert.Equal(0, paste.TotalCharactersWritten);
+        Assert.AreEqual(0, paste.TotalCharactersWritten);
 
         paste.TryWrite("hello");
-        Assert.Equal(5, paste.TotalCharactersWritten);
+        Assert.AreEqual(5, paste.TotalCharactersWritten);
 
         paste.TryWrite(" world");
-        Assert.Equal(11, paste.TotalCharactersWritten);
+        Assert.AreEqual(11, paste.TotalCharactersWritten);
 
         paste.Complete();
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Pastable_Widget_ReconcilesToNode()
     {
         // Verify the widget creates the correct node type
@@ -412,24 +413,24 @@ public class PastableWidgetTests
             .MaxSize(1000)
             .Timeout(TimeSpan.FromSeconds(30));
 
-        Assert.NotNull(widget.PasteHandler);
-        Assert.Equal(1000, widget.MaxPasteSize);
-        Assert.Equal(TimeSpan.FromSeconds(30), widget.PasteTimeout);
+        Assert.IsNotNull(widget.PasteHandler);
+        Assert.AreEqual(1000, widget.MaxPasteSize);
+        Assert.AreEqual(TimeSpan.FromSeconds(30), widget.PasteTimeout);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Pastable_Widget_FluentApi()
     {
         // Verify fluent API methods return correct widget type
         var widget = new PastableWidget(new TextBlockWidget("test"));
         
         var withPaste = widget.OnPaste(e => { });
-        Assert.NotNull(withPaste.PasteHandler);
+        Assert.IsNotNull(withPaste.PasteHandler);
 
         var withMax = widget.MaxSize(500);
-        Assert.Equal(500, withMax.MaxPasteSize);
+        Assert.AreEqual(500, withMax.MaxPasteSize);
 
         var withTimeout = widget.Timeout(TimeSpan.FromMinutes(1));
-        Assert.Equal(TimeSpan.FromMinutes(1), withTimeout.PasteTimeout);
+        Assert.AreEqual(TimeSpan.FromMinutes(1), withTimeout.PasteTimeout);
     }
 }

--- a/tests/Hex1b.Tests/PasteContextTests.cs
+++ b/tests/Hex1b.Tests/PasteContextTests.cs
@@ -2,9 +2,10 @@ using Hex1b.Input;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class PasteContextTests
 {
-    [Fact]
+    [TestMethod]
     public async Task ReadToEnd_SmallText_ReturnsFullText()
     {
         await using var ctx = new PasteContext();
@@ -12,20 +13,20 @@ public class PasteContextTests
         ctx.Complete();
 
         var text = await ctx.ReadToEndAsync();
-        Assert.Equal("hello", text);
+        Assert.AreEqual("hello", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadToEnd_EmptyPaste_ReturnsEmptyString()
     {
         await using var ctx = new PasteContext();
         ctx.Complete();
 
         var text = await ctx.ReadToEndAsync();
-        Assert.Equal("", text);
+        Assert.AreEqual("", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadToEnd_SingleChar_ReturnsSingleChar()
     {
         await using var ctx = new PasteContext();
@@ -33,10 +34,10 @@ public class PasteContextTests
         ctx.Complete();
 
         var text = await ctx.ReadToEndAsync();
-        Assert.Equal("x", text);
+        Assert.AreEqual("x", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadToEnd_MultiLine_PreservesNewlines()
     {
         await using var ctx = new PasteContext();
@@ -44,10 +45,10 @@ public class PasteContextTests
         ctx.Complete();
 
         var text = await ctx.ReadToEndAsync();
-        Assert.Equal("line1\nline2\r\nline3\ttab", text);
+        Assert.AreEqual("line1\nline2\r\nline3\ttab", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadToEnd_UnicodeEmoji_PreservesContent()
     {
         await using var ctx = new PasteContext();
@@ -55,21 +56,20 @@ public class PasteContextTests
         ctx.Complete();
 
         var text = await ctx.ReadToEndAsync();
-        Assert.Equal("hello 🌍 世界 🎉", text);
+        Assert.AreEqual("hello 🌍 世界 🎉", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadToEnd_ExceedsMaxBytes_Throws()
     {
         await using var ctx = new PasteContext();
         ctx.TryWrite(new string('a', 100));
         ctx.Complete();
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            () => ctx.ReadToEndAsync(maxCharacters: 50));
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => ctx.ReadToEndAsync(maxCharacters: 50));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadToEnd_MultipleChunks_ConcatenatesAll()
     {
         await using var ctx = new PasteContext();
@@ -79,10 +79,10 @@ public class PasteContextTests
         ctx.Complete();
 
         var text = await ctx.ReadToEndAsync();
-        Assert.Equal("hello world!", text);
+        Assert.AreEqual("hello world!", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadChunks_ReceivesIncrementally()
     {
         await using var ctx = new PasteContext();
@@ -99,13 +99,13 @@ public class PasteContextTests
             chunks.Add(chunk);
         }
 
-        Assert.Equal(3, chunks.Count);
-        Assert.Equal("chunk1", chunks[0]);
-        Assert.Equal("chunk2", chunks[1]);
-        Assert.Equal("chunk3", chunks[2]);
+        Assert.AreEqual(3, chunks.Count);
+        Assert.AreEqual("chunk1", chunks[0]);
+        Assert.AreEqual("chunk2", chunks[1]);
+        Assert.AreEqual("chunk3", chunks[2]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadLines_SplitsCorrectly()
     {
         await using var ctx = new PasteContext();
@@ -118,13 +118,13 @@ public class PasteContextTests
             lines.Add(line);
         }
 
-        Assert.Equal(3, lines.Count);
-        Assert.Equal("line1", lines[0]);
-        Assert.Equal("line2", lines[1]);
-        Assert.Equal("line3", lines[2]);
+        Assert.AreEqual(3, lines.Count);
+        Assert.AreEqual("line1", lines[0]);
+        Assert.AreEqual("line2", lines[1]);
+        Assert.AreEqual("line3", lines[2]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadLines_HandlesCarriageReturnLineFeed()
     {
         await using var ctx = new PasteContext();
@@ -137,13 +137,13 @@ public class PasteContextTests
             lines.Add(line);
         }
 
-        Assert.Equal(3, lines.Count);
-        Assert.Equal("line1", lines[0]);
-        Assert.Equal("line2", lines[1]);
-        Assert.Equal("line3", lines[2]);
+        Assert.AreEqual(3, lines.Count);
+        Assert.AreEqual("line1", lines[0]);
+        Assert.AreEqual("line2", lines[1]);
+        Assert.AreEqual("line3", lines[2]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CopyToAsync_WritesToStream()
     {
         await using var ctx = new PasteContext();
@@ -156,10 +156,10 @@ public class PasteContextTests
         ms.Position = 0;
         using var reader = new StreamReader(ms);
         var text = await reader.ReadToEndAsync();
-        Assert.Equal("hello world", text);
+        Assert.AreEqual("hello world", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SaveToFile_CreatesFile()
     {
         var tempPath = Path.GetTempFileName();
@@ -172,7 +172,7 @@ public class PasteContextTests
             await ctx.SaveToFileAsync(tempPath);
 
             var content = await File.ReadAllTextAsync(tempPath);
-            Assert.Equal("file content", content);
+            Assert.AreEqual("file content", content);
         }
         finally
         {
@@ -180,7 +180,7 @@ public class PasteContextTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Cancel_StopsReading()
     {
         await using var ctx = new PasteContext();
@@ -194,21 +194,21 @@ public class PasteContextTests
         }
 
         // Should get at most the chunk that was written before cancel
-        Assert.True(chunks.Count <= 1);
+        Assert.IsTrue(chunks.Count <= 1);
     }
 
-    [Fact]
+    [TestMethod]
     public void Cancel_SignalsCancellationToken()
     {
         var ctx = new PasteContext();
         try
         {
-            Assert.False(ctx.CancellationToken.IsCancellationRequested);
+            Assert.IsFalse(ctx.CancellationToken.IsCancellationRequested);
 
             ctx.Cancel();
 
-            Assert.True(ctx.CancellationToken.IsCancellationRequested);
-            Assert.True(ctx.IsCancelled);
+            Assert.IsTrue(ctx.CancellationToken.IsCancellationRequested);
+            Assert.IsTrue(ctx.IsCancelled);
         }
         finally
         {
@@ -216,19 +216,19 @@ public class PasteContextTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Completed_SignaledOnComplete()
     {
         await using var ctx = new PasteContext();
-        Assert.False(ctx.IsCompleted);
+        Assert.IsFalse(ctx.IsCompleted);
 
         ctx.Complete();
 
         await ctx.Completed; // Should not hang
-        Assert.True(ctx.IsCompleted);
+        Assert.IsTrue(ctx.IsCompleted);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Completed_SignaledOnCancel()
     {
         await using var ctx = new PasteContext();
@@ -236,46 +236,46 @@ public class PasteContextTests
         ctx.Cancel();
 
         await ctx.Completed; // Should not hang
-        Assert.True(ctx.IsCancelled);
+        Assert.IsTrue(ctx.IsCancelled);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Dispose_CompletesContext()
     {
         var ctx = new PasteContext();
         await ctx.DisposeAsync();
 
-        Assert.True(ctx.IsCancelled);
+        Assert.IsTrue(ctx.IsCancelled);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WriteAsync_AfterCancel_ReturnsFalse()
     {
         await using var ctx = new PasteContext();
         ctx.Cancel();
 
         var written = await ctx.WriteAsync("should not write");
-        Assert.False(written);
+        Assert.IsFalse(written);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WriteAsync_AfterComplete_ReturnsFalse()
     {
         await using var ctx = new PasteContext();
         ctx.Complete();
 
         var written = await ctx.WriteAsync("should not write");
-        Assert.False(written);
+        Assert.IsFalse(written);
     }
 
-    [Fact]
+    [TestMethod]
     public void TryWrite_AfterCancel_ReturnsFalse()
     {
         var ctx = new PasteContext();
         try
         {
             ctx.Cancel();
-            Assert.False(ctx.TryWrite("should not write"));
+            Assert.IsFalse(ctx.TryWrite("should not write"));
         }
         finally
         {
@@ -283,27 +283,27 @@ public class PasteContextTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Cancel_Idempotent()
     {
         await using var ctx = new PasteContext();
         ctx.Cancel();
         ctx.Cancel(); // Should not throw
 
-        Assert.True(ctx.IsCancelled);
+        Assert.IsTrue(ctx.IsCancelled);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Complete_Idempotent()
     {
         await using var ctx = new PasteContext();
         ctx.Complete();
         ctx.Complete(); // Should not throw
 
-        Assert.True(ctx.IsCompleted);
+        Assert.IsTrue(ctx.IsCompleted);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Invalidate_CalledWhenProvided()
     {
         int invalidateCount = 0;
@@ -312,10 +312,10 @@ public class PasteContextTests
         ctx.Invalidate();
         ctx.Invalidate();
 
-        Assert.Equal(2, invalidateCount);
+        Assert.AreEqual(2, invalidateCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadToEnd_CancelledDuringRead_ThrowsOrReturnsPartial()
     {
         await using var ctx = new PasteContext();
@@ -333,7 +333,7 @@ public class PasteContextTests
         {
             var text = await ctx.ReadToEndAsync();
             // If it returns, it should have the data written before cancel
-            Assert.Equal("hello", text);
+            Assert.AreEqual("hello", text);
         }
         catch (OperationCanceledException)
         {
@@ -341,7 +341,7 @@ public class PasteContextTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadChunks_StreamsAsDataArrives()
     {
         await using var ctx = new PasteContext();
@@ -363,12 +363,12 @@ public class PasteContextTests
 
         await readTask;
 
-        Assert.Equal(2, receivedChunks.Count);
-        Assert.Equal("chunk1", receivedChunks[0]);
-        Assert.Equal("chunk2", receivedChunks[1]);
+        Assert.AreEqual(2, receivedChunks.Count);
+        Assert.AreEqual("chunk1", receivedChunks[0]);
+        Assert.AreEqual("chunk2", receivedChunks[1]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadLines_AcrossChunks_MergesCorrectly()
     {
         await using var ctx = new PasteContext();
@@ -384,8 +384,8 @@ public class PasteContextTests
             lines.Add(line);
         }
 
-        Assert.Equal(2, lines.Count);
-        Assert.Equal("hello", lines[0]);
-        Assert.Equal("world", lines[1]);
+        Assert.AreEqual(2, lines.Count);
+        Assert.AreEqual("hello", lines[0]);
+        Assert.AreEqual("world", lines[1]);
     }
 }

--- a/tests/Hex1b.Tests/PasteLineEndingTests.cs
+++ b/tests/Hex1b.Tests/PasteLineEndingTests.cs
@@ -8,6 +8,7 @@ namespace Hex1b.Tests;
 /// Verifies that \n, \r\n, and \r are all recognized as line separators.
 /// Inspired by psmux's paste line-ending normalization tests.
 /// </summary>
+[TestClass]
 public class PasteLineEndingTests
 {
     private static async Task<List<string>> ReadPasteLinesAsync(string pasteContent)
@@ -36,64 +37,64 @@ public class PasteLineEndingTests
         while (workload.InputEvents.TryRead(out var evt))
             events.Add(evt);
 
-        var paste = Assert.IsType<Hex1bPasteEvent>(Assert.Single(events));
+        var paste = TestSeq.IsType<Hex1bPasteEvent>(TestSeq.Single(events));
         var lines = new List<string>();
         await foreach (var line in paste.Paste.ReadLinesAsync())
             lines.Add(line);
         return lines;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadLines_LfSeparator_SplitsCorrectly()
     {
         var lines = await ReadPasteLinesAsync("line1\nline2\nline3");
 
-        Assert.Equal(3, lines.Count);
-        Assert.Equal("line1", lines[0]);
-        Assert.Equal("line2", lines[1]);
-        Assert.Equal("line3", lines[2]);
+        Assert.AreEqual(3, lines.Count);
+        Assert.AreEqual("line1", lines[0]);
+        Assert.AreEqual("line2", lines[1]);
+        Assert.AreEqual("line3", lines[2]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadLines_CrLfSeparator_SplitsCorrectly()
     {
         var lines = await ReadPasteLinesAsync("line1\r\nline2\r\nline3");
 
-        Assert.Equal(3, lines.Count);
-        Assert.Equal("line1", lines[0]);
-        Assert.Equal("line2", lines[1]);
-        Assert.Equal("line3", lines[2]);
+        Assert.AreEqual(3, lines.Count);
+        Assert.AreEqual("line1", lines[0]);
+        Assert.AreEqual("line2", lines[1]);
+        Assert.AreEqual("line3", lines[2]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadLines_CrSeparator_SplitsCorrectly()
     {
         var lines = await ReadPasteLinesAsync("line1\rline2\rline3");
 
-        Assert.Equal(3, lines.Count);
-        Assert.Equal("line1", lines[0]);
-        Assert.Equal("line2", lines[1]);
-        Assert.Equal("line3", lines[2]);
+        Assert.AreEqual(3, lines.Count);
+        Assert.AreEqual("line1", lines[0]);
+        Assert.AreEqual("line2", lines[1]);
+        Assert.AreEqual("line3", lines[2]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadLines_MixedLineEndings_SplitsCorrectly()
     {
         var lines = await ReadPasteLinesAsync("a\nb\r\nc\rd");
 
-        Assert.Equal(4, lines.Count);
-        Assert.Equal("a", lines[0]);
-        Assert.Equal("b", lines[1]);
-        Assert.Equal("c", lines[2]);
-        Assert.Equal("d", lines[3]);
+        Assert.AreEqual(4, lines.Count);
+        Assert.AreEqual("a", lines[0]);
+        Assert.AreEqual("b", lines[1]);
+        Assert.AreEqual("c", lines[2]);
+        Assert.AreEqual("d", lines[3]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadLines_NoLineEndings_ReturnsSingleLine()
     {
         var lines = await ReadPasteLinesAsync("no newlines here");
 
-        Assert.Single(lines);
-        Assert.Equal("no newlines here", lines[0]);
+        TestSeq.Single(lines);
+        Assert.AreEqual("no newlines here", lines[0]);
     }
 }

--- a/tests/Hex1b.Tests/PasteRoutingTests.cs
+++ b/tests/Hex1b.Tests/PasteRoutingTests.cs
@@ -8,6 +8,7 @@ namespace Hex1b.Tests;
 /// Phase 2: Verify paste events reach focused nodes, bubble to ancestors,
 /// and Escape cancellation works.
 /// </summary>
+[TestClass]
 public class PasteRoutingTests
 {
     /// <summary>
@@ -86,7 +87,7 @@ public class PasteRoutingTests
 
     // --- Routing tests ---
 
-    [Fact]
+    [TestMethod]
     public async Task Routing_PasteToFocusedNode()
     {
         var (root, focused, focusRing, state) = SetupSimpleTree();
@@ -96,14 +97,14 @@ public class PasteRoutingTests
         var result = await InputRouter.RouteInputAsync(
             root, new Hex1bPasteEvent(paste), focusRing, state);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Single(focused.ReceivedPastes);
+        Assert.AreEqual(InputResult.Handled, result);
+        TestSeq.Single(focused.ReceivedPastes);
         var text = await focused.ReceivedPastes[0].Paste.ReadToEndAsync();
-        Assert.Equal("pasted text", text);
+        Assert.AreEqual("pasted text", text);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Routing_PasteBubblesToAncestor()
     {
         var (root, focused, focusRing, state) = SetupSimpleTree();
@@ -114,15 +115,15 @@ public class PasteRoutingTests
         var result = await InputRouter.RouteInputAsync(
             root, new Hex1bPasteEvent(paste), focusRing, state);
 
-        Assert.Equal(InputResult.Handled, result);
+        Assert.AreEqual(InputResult.Handled, result);
         // Focused got the event first but returned NotHandled
-        Assert.Single(focused.ReceivedPastes);
+        TestSeq.Single(focused.ReceivedPastes);
         // Parent got the event second and handled it
-        Assert.Single(root.ReceivedPastes);
+        TestSeq.Single(root.ReceivedPastes);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Routing_PasteBubblesMultipleLevels()
     {
         // root -> middle -> focused (3 levels)
@@ -144,15 +145,15 @@ public class PasteRoutingTests
         var result = await InputRouter.RouteInputAsync(
             root, new Hex1bPasteEvent(paste), focusRing, state);
 
-        Assert.Equal(InputResult.Handled, result);
+        Assert.AreEqual(InputResult.Handled, result);
         // All three got the event
-        Assert.Single(focused.ReceivedPastes);
-        Assert.Single(middle.ReceivedPastes);
-        Assert.Single(root.ReceivedPastes);
+        TestSeq.Single(focused.ReceivedPastes);
+        TestSeq.Single(middle.ReceivedPastes);
+        TestSeq.Single(root.ReceivedPastes);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Routing_NoPasteHandler_NotHandled()
     {
         var (root, focused, focusRing, state) = SetupSimpleTree();
@@ -163,11 +164,11 @@ public class PasteRoutingTests
         var result = await InputRouter.RouteInputAsync(
             root, new Hex1bPasteEvent(paste), focusRing, state);
 
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Routing_PasteWhileNothingFocused()
     {
         // No focused node
@@ -193,7 +194,7 @@ public class PasteRoutingTests
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Routing_HandlePasteAsync_DefaultNotHandled()
     {
         // Verify Hex1bNode base class returns NotHandled by default
@@ -202,11 +203,11 @@ public class PasteRoutingTests
 
         var result = await node.HandlePasteAsync(new Hex1bPasteEvent(paste));
 
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Routing_MultiplePastesSequential()
     {
         var (root, focused, focusRing, state) = SetupSimpleTree();
@@ -216,25 +217,25 @@ public class PasteRoutingTests
         var paste1 = CreateTestPasteContext("first");
         var result1 = await InputRouter.RouteInputAsync(
             root, new Hex1bPasteEvent(paste1), focusRing, state);
-        Assert.Equal(InputResult.Handled, result1);
+        Assert.AreEqual(InputResult.Handled, result1);
 
         // Second paste
         var paste2 = CreateTestPasteContext("second");
         var result2 = await InputRouter.RouteInputAsync(
             root, new Hex1bPasteEvent(paste2), focusRing, state);
-        Assert.Equal(InputResult.Handled, result2);
+        Assert.AreEqual(InputResult.Handled, result2);
 
-        Assert.Equal(2, focused.ReceivedPastes.Count);
+        Assert.AreEqual(2, focused.ReceivedPastes.Count);
         var text1 = await focused.ReceivedPastes[0].Paste.ReadToEndAsync();
         var text2 = await focused.ReceivedPastes[1].Paste.ReadToEndAsync();
-        Assert.Equal("first", text1);
-        Assert.Equal("second", text2);
+        Assert.AreEqual("first", text1);
+        Assert.AreEqual("second", text2);
 
         await paste1.DisposeAsync();
         await paste2.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Routing_FocusedNodeHandles_AncestorNotCalled()
     {
         var (root, focused, focusRing, state) = SetupSimpleTree();
@@ -245,12 +246,12 @@ public class PasteRoutingTests
         await InputRouter.RouteInputAsync(
             root, new Hex1bPasteEvent(paste), focusRing, state);
 
-        Assert.Single(focused.ReceivedPastes);
-        Assert.Empty(root.ReceivedPastes); // should NOT have received the event
+        TestSeq.Single(focused.ReceivedPastes);
+        Assert.IsEmpty(root.ReceivedPastes); // should NOT have received the event
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Routing_PasteContext_IsCompleted_AfterRead()
     {
         var (root, focused, focusRing, state) = SetupSimpleTree();
@@ -261,7 +262,7 @@ public class PasteRoutingTests
             root, new Hex1bPasteEvent(paste), focusRing, state);
 
         // The paste was completed at creation (Complete() called)
-        Assert.True(paste.IsCompleted);
+        Assert.IsTrue(paste.IsCompleted);
         await paste.DisposeAsync();
     }
 }

--- a/tests/Hex1b.Tests/PasteStreamingTests.cs
+++ b/tests/Hex1b.Tests/PasteStreamingTests.cs
@@ -9,6 +9,7 @@ namespace Hex1b.Tests;
 /// These tests verify that SpecialKeyToken(200/201) markers are correctly detected
 /// and paste data is streamed through a PasteContext.
 /// </summary>
+[TestClass]
 public class PasteStreamingTests
 {
     /// <summary>
@@ -40,7 +41,7 @@ public class PasteStreamingTests
         return events;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SmallPaste_EmitsPasteEvent()
     {
         var tokens = new AnsiToken[]
@@ -52,13 +53,13 @@ public class PasteStreamingTests
 
         var events = await DispatchTokensAsync(tokens);
 
-        var pasteEvent = Assert.Single(events);
-        var paste = Assert.IsType<Hex1bPasteEvent>(pasteEvent);
+        var pasteEvent = TestSeq.Single(events);
+        var paste = TestSeq.IsType<Hex1bPasteEvent>(pasteEvent);
         var text = await paste.Paste.ReadToEndAsync();
-        Assert.Equal("hello", text);
+        Assert.AreEqual("hello", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task EmptyPaste_EmitsPasteEventWithEmptyText()
     {
         var tokens = new AnsiToken[]
@@ -69,13 +70,13 @@ public class PasteStreamingTests
 
         var events = await DispatchTokensAsync(tokens);
 
-        var pasteEvent = Assert.Single(events);
-        var paste = Assert.IsType<Hex1bPasteEvent>(pasteEvent);
+        var pasteEvent = TestSeq.Single(events);
+        var paste = TestSeq.IsType<Hex1bPasteEvent>(pasteEvent);
         var text = await paste.Paste.ReadToEndAsync();
-        Assert.Equal("", text);
+        Assert.AreEqual("", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SingleCharPaste_EmitsPasteEvent()
     {
         var tokens = new AnsiToken[]
@@ -87,12 +88,12 @@ public class PasteStreamingTests
 
         var events = await DispatchTokensAsync(tokens);
 
-        var paste = Assert.IsType<Hex1bPasteEvent>(Assert.Single(events));
+        var paste = TestSeq.IsType<Hex1bPasteEvent>(TestSeq.Single(events));
         var text = await paste.Paste.ReadToEndAsync();
-        Assert.Equal("x", text);
+        Assert.AreEqual("x", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MultiLinePaste_PreservesNewlines()
     {
         var tokens = new AnsiToken[]
@@ -109,12 +110,12 @@ public class PasteStreamingTests
 
         var events = await DispatchTokensAsync(tokens);
 
-        var paste = Assert.IsType<Hex1bPasteEvent>(Assert.Single(events));
+        var paste = TestSeq.IsType<Hex1bPasteEvent>(TestSeq.Single(events));
         var text = await paste.Paste.ReadToEndAsync();
-        Assert.Equal("line1\nline2\r\nline3", text);
+        Assert.AreEqual("line1\nline2\r\nline3", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PasteWithTabs_PreservesTabs()
     {
         var tokens = new AnsiToken[]
@@ -128,12 +129,12 @@ public class PasteStreamingTests
 
         var events = await DispatchTokensAsync(tokens);
 
-        var paste = Assert.IsType<Hex1bPasteEvent>(Assert.Single(events));
+        var paste = TestSeq.IsType<Hex1bPasteEvent>(TestSeq.Single(events));
         var text = await paste.Paste.ReadToEndAsync();
-        Assert.Equal("col1\tcol2", text);
+        Assert.AreEqual("col1\tcol2", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NonPasteInputDuringPaste_DispatchedNormally()
     {
         // Mouse event during paste should still be dispatched as normal
@@ -148,17 +149,17 @@ public class PasteStreamingTests
         var events = await DispatchTokensAsync(tokens);
 
         // Should have both the paste event and the mouse event
-        Assert.Equal(2, events.Count);
-        Assert.IsType<Hex1bPasteEvent>(events[0]);
-        Assert.IsType<Hex1bMouseEvent>(events[1]);
+        Assert.AreEqual(2, events.Count);
+        TestSeq.IsType<Hex1bPasteEvent>(events[0]);
+        TestSeq.IsType<Hex1bMouseEvent>(events[1]);
 
         // Paste should have the text data only
         var paste = (Hex1bPasteEvent)events[0];
         var text = await paste.Paste.ReadToEndAsync();
-        Assert.Equal("paste data", text);
+        Assert.AreEqual("paste data", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NormalInput_NotAffectedByPasteSupport()
     {
         // Regular text input (not bracketed) should still work as before
@@ -170,11 +171,11 @@ public class PasteStreamingTests
 
         var events = await DispatchTokensAsync(tokens);
 
-        Assert.Equal(2, events.Count);
-        Assert.All(events, e => Assert.IsType<Hex1bKeyEvent>(e));
+        Assert.AreEqual(2, events.Count);
+        TestSeq.All(events, e => TestSeq.IsType<Hex1bKeyEvent>(e));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MultipleChunks_StreamedCorrectly()
     {
         var tokens = new AnsiToken[]
@@ -188,12 +189,12 @@ public class PasteStreamingTests
 
         var events = await DispatchTokensAsync(tokens);
 
-        var paste = Assert.IsType<Hex1bPasteEvent>(Assert.Single(events));
+        var paste = TestSeq.IsType<Hex1bPasteEvent>(TestSeq.Single(events));
         var text = await paste.Paste.ReadToEndAsync();
-        Assert.Equal("chunk1chunk2chunk3", text);
+        Assert.AreEqual("chunk1chunk2chunk3", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PasteFollowedByNormalInput()
     {
         var tokens = new AnsiToken[]
@@ -206,16 +207,16 @@ public class PasteStreamingTests
 
         var events = await DispatchTokensAsync(tokens);
 
-        Assert.Equal(2, events.Count);
-        var paste = Assert.IsType<Hex1bPasteEvent>(events[0]);
+        Assert.AreEqual(2, events.Count);
+        var paste = TestSeq.IsType<Hex1bPasteEvent>(events[0]);
         var text = await paste.Paste.ReadToEndAsync();
-        Assert.Equal("pasted", text);
+        Assert.AreEqual("pasted", text);
 
-        var keyEvent = Assert.IsType<Hex1bKeyEvent>(events[1]);
-        Assert.Equal("typed", keyEvent.Text);
+        var keyEvent = TestSeq.IsType<Hex1bKeyEvent>(events[1]);
+        Assert.AreEqual("typed", keyEvent.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NormalInputFollowedByPaste()
     {
         var tokens = new AnsiToken[]
@@ -228,12 +229,12 @@ public class PasteStreamingTests
 
         var events = await DispatchTokensAsync(tokens);
 
-        Assert.Equal(2, events.Count);
-        Assert.IsType<Hex1bKeyEvent>(events[0]);
-        Assert.IsType<Hex1bPasteEvent>(events[1]);
+        Assert.AreEqual(2, events.Count);
+        TestSeq.IsType<Hex1bKeyEvent>(events[0]);
+        TestSeq.IsType<Hex1bPasteEvent>(events[1]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TwoConsecutivePastes_TwoSeparateEvents()
     {
         var tokens = new AnsiToken[]
@@ -248,15 +249,15 @@ public class PasteStreamingTests
 
         var events = await DispatchTokensAsync(tokens);
 
-        Assert.Equal(2, events.Count);
-        var paste1 = Assert.IsType<Hex1bPasteEvent>(events[0]);
-        var paste2 = Assert.IsType<Hex1bPasteEvent>(events[1]);
+        Assert.AreEqual(2, events.Count);
+        var paste1 = TestSeq.IsType<Hex1bPasteEvent>(events[0]);
+        var paste2 = TestSeq.IsType<Hex1bPasteEvent>(events[1]);
 
-        Assert.Equal("first", await paste1.Paste.ReadToEndAsync());
-        Assert.Equal("second", await paste2.Paste.ReadToEndAsync());
+        Assert.AreEqual("first", await paste1.Paste.ReadToEndAsync());
+        Assert.AreEqual("second", await paste2.Paste.ReadToEndAsync());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LargePaste_StreamsCorrectly()
     {
         // 1MB paste — should stream without issues
@@ -270,12 +271,12 @@ public class PasteStreamingTests
 
         var events = await DispatchTokensAsync(tokens);
 
-        var paste = Assert.IsType<Hex1bPasteEvent>(Assert.Single(events));
+        var paste = TestSeq.IsType<Hex1bPasteEvent>(TestSeq.Single(events));
         var text = await paste.Paste.ReadToEndAsync(maxCharacters: 2 * 1024 * 1024);
-        Assert.Equal(1024 * 1024, text.Length);
+        Assert.AreEqual(1024 * 1024, text.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PasteContext_IsCompleted_AfterEndMarker()
     {
         var tokens = new AnsiToken[]
@@ -287,12 +288,12 @@ public class PasteStreamingTests
 
         var events = await DispatchTokensAsync(tokens);
 
-        var paste = Assert.IsType<Hex1bPasteEvent>(Assert.Single(events));
-        Assert.True(paste.Paste.IsCompleted);
+        var paste = TestSeq.IsType<Hex1bPasteEvent>(TestSeq.Single(events));
+        Assert.IsTrue(paste.Paste.IsCompleted);
         await paste.Paste.Completed; // Should not hang
     }
 
-    [Fact]
+    [TestMethod]
     public void EnterTuiMode_EnablesBracketedPaste_WhenSupported()
     {
         var caps = new TerminalCapabilities
@@ -305,14 +306,14 @@ public class PasteStreamingTests
         workload.EnterTuiMode();
 
         // Read the output to verify the bracketed paste enable sequence was written
-        Assert.True(workload.Capabilities.SupportsBracketedPaste);
+        Assert.IsTrue(workload.Capabilities.SupportsBracketedPaste);
 
         // Drain the output channel and check for the mode 2004 sequence
         var output = DrainOutputText(workload);
         Assert.Contains("\x1b[?2004h", output);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExitTuiMode_DisablesBracketedPaste_WhenSupported()
     {
         var caps = new TerminalCapabilities
@@ -330,7 +331,7 @@ public class PasteStreamingTests
         Assert.Contains("\x1b[?2004l", output);
     }
 
-    [Fact]
+    [TestMethod]
     public void EnterTuiMode_NoBracketedPaste_WhenNotSupported()
     {
         var caps = new TerminalCapabilities
@@ -356,7 +357,7 @@ public class PasteStreamingTests
         return sb.ToString();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task UnicodeInPaste_PreservedCorrectly()
     {
         var tokens = new AnsiToken[]
@@ -368,12 +369,12 @@ public class PasteStreamingTests
 
         var events = await DispatchTokensAsync(tokens);
 
-        var paste = Assert.IsType<Hex1bPasteEvent>(Assert.Single(events));
+        var paste = TestSeq.IsType<Hex1bPasteEvent>(TestSeq.Single(events));
         var text = await paste.Paste.ReadToEndAsync();
-        Assert.Equal("こんにちは 🌍 café", text);
+        Assert.AreEqual("こんにちは 🌍 café", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PasteReadLines_AcrossTokenBoundaries()
     {
         // Line break split across two TextTokens
@@ -387,15 +388,15 @@ public class PasteStreamingTests
 
         var events = await DispatchTokensAsync(tokens);
 
-        var paste = Assert.IsType<Hex1bPasteEvent>(Assert.Single(events));
+        var paste = TestSeq.IsType<Hex1bPasteEvent>(TestSeq.Single(events));
         var lines = new List<string>();
         await foreach (var line in paste.Paste.ReadLinesAsync())
         {
             lines.Add(line);
         }
 
-        Assert.Equal(2, lines.Count);
-        Assert.Equal("hello world", lines[0]);
-        Assert.Equal("bye", lines[1]);
+        Assert.AreEqual(2, lines.Count);
+        Assert.AreEqual("hello world", lines[0]);
+        Assert.AreEqual("bye", lines[1]);
     }
 }

--- a/tests/Hex1b.Tests/PerTerminalStrategyTests.cs
+++ b/tests/Hex1b.Tests/PerTerminalStrategyTests.cs
@@ -18,6 +18,7 @@ namespace Hex1b.Tests;
 /// round-trip stability, cursor tracking, bottom-fill vs cursor-anchored positioning,
 /// and saved cursor (DECSC) reflow behavior.
 /// </remarks>
+[TestClass]
 public class PerTerminalStrategyTests
 {
     #region Helper Methods
@@ -69,7 +70,7 @@ public class PerTerminalStrategyTests
     /// <summary>
     /// Alacritty merges soft-wrapped rows when the terminal is widened.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Alacritty_NarrowToWider_MergesSoftWrappedRows()
     {
         using var terminal = CreateTerminal(AlacrittyReflowStrategy.Instance, 5, 3);
@@ -78,14 +79,14 @@ public class PerTerminalStrategyTests
         terminal.Resize(10, 3);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
-        Assert.Equal("", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
     /// Alacritty splits long lines when the terminal is narrowed.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Alacritty_WiderToNarrow_SplitsRows()
     {
         using var terminal = CreateTerminal(AlacrittyReflowStrategy.Instance, 10, 5);
@@ -94,14 +95,14 @@ public class PerTerminalStrategyTests
         terminal.Resize(5, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDE", snap.GetLine(0).TrimEnd());
-        Assert.Equal("FGHIJ", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDE", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("FGHIJ", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
     /// Alacritty does not merge hard-wrapped (newline-separated) lines.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Alacritty_HardWrappedLines_NotMerged()
     {
         using var terminal = CreateTerminal(AlacrittyReflowStrategy.Instance, 10, 5);
@@ -110,14 +111,14 @@ public class PerTerminalStrategyTests
         terminal.Resize(20, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("Hello", snap.GetLine(0).TrimEnd());
-        Assert.Equal("World", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("Hello", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("World", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
     /// Alacritty does NOT reflow content in the alternate screen buffer.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Alacritty_AlternateScreen_NoReflow()
     {
         int width = 5, height = 3;
@@ -134,13 +135,13 @@ public class PerTerminalStrategyTests
 
         var result = AlacrittyReflowStrategy.Instance.Reflow(context);
 
-        Assert.Equal("ABCDE", GetRowText(result.ScreenRows[0]));
+        Assert.AreEqual("ABCDE", GetRowText(result.ScreenRows[0]));
     }
 
     /// <summary>
     /// Alacritty round-trips: narrow then widen restores original content.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Alacritty_RoundTrip_NarrowAndRestore()
     {
         using var terminal = CreateTerminal(AlacrittyReflowStrategy.Instance, 10, 5);
@@ -150,34 +151,34 @@ public class PerTerminalStrategyTests
         terminal.Resize(10, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
-        Assert.Equal("", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
     /// Alacritty tracks cursor position correctly through reflow.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Alacritty_CursorPosition_TrackedCorrectly()
     {
         using var terminal = CreateTerminal(AlacrittyReflowStrategy.Instance, 5, 5);
         terminal.ApplyTokens([new TextToken("ABCDEFGH")]);
 
         var snap1 = terminal.CreateSnapshot();
-        Assert.Equal(3, snap1.CursorX);
-        Assert.Equal(1, snap1.CursorY);
+        Assert.AreEqual(3, snap1.CursorX);
+        Assert.AreEqual(1, snap1.CursorY);
 
         terminal.Resize(10, 5);
 
         var snap2 = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGH", snap2.GetLine(0).TrimEnd());
+        Assert.AreEqual("ABCDEFGH", snap2.GetLine(0).TrimEnd());
     }
 
     /// <summary>
     /// Alacritty uses bottom-fill: when narrowing pushes content down, the screen
     /// shows the bottom of the buffer and cursor shifts upward.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Alacritty_BottomFill_ContentPushedUp()
     {
         int width = 10, height = 3;
@@ -198,8 +199,7 @@ public class PerTerminalStrategyTests
         var result = AlacrittyReflowStrategy.Instance.Reflow(context);
 
         // Bottom-fill: cursor Y should be pushed toward the top of visible screen
-        Assert.True(result.CursorY <= 1,
-            $"Bottom-fill should push cursor toward top; got CursorY={result.CursorY}");
+        Assert.IsTrue(result.CursorY <= 1, $"Bottom-fill should push cursor toward top; got CursorY={result.CursorY}");
     }
 
     #endregion
@@ -211,7 +211,7 @@ public class PerTerminalStrategyTests
     /// <summary>
     /// Windows Terminal merges soft-wrapped rows when widened.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void WindowsTerminal_NarrowToWider_MergesSoftWrappedRows()
     {
         using var terminal = CreateTerminal(WindowsTerminalReflowStrategy.Instance, 5, 3);
@@ -220,14 +220,14 @@ public class PerTerminalStrategyTests
         terminal.Resize(10, 3);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
-        Assert.Equal("", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
     /// Windows Terminal splits rows when narrowed.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void WindowsTerminal_WiderToNarrow_SplitsRows()
     {
         using var terminal = CreateTerminal(WindowsTerminalReflowStrategy.Instance, 10, 5);
@@ -236,14 +236,14 @@ public class PerTerminalStrategyTests
         terminal.Resize(5, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDE", snap.GetLine(0).TrimEnd());
-        Assert.Equal("FGHIJ", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDE", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("FGHIJ", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
     /// Windows Terminal does not merge hard-wrapped lines.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void WindowsTerminal_HardWrappedLines_NotMerged()
     {
         using var terminal = CreateTerminal(WindowsTerminalReflowStrategy.Instance, 10, 5);
@@ -252,14 +252,14 @@ public class PerTerminalStrategyTests
         terminal.Resize(20, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("Hello", snap.GetLine(0).TrimEnd());
-        Assert.Equal("World", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("Hello", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("World", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
     /// Windows Terminal does NOT reflow content in the alternate screen buffer.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void WindowsTerminal_AlternateScreen_NoReflow()
     {
         int width = 5, height = 3;
@@ -276,13 +276,13 @@ public class PerTerminalStrategyTests
 
         var result = WindowsTerminalReflowStrategy.Instance.Reflow(context);
 
-        Assert.Equal("ABCDE", GetRowText(result.ScreenRows[0]));
+        Assert.AreEqual("ABCDE", GetRowText(result.ScreenRows[0]));
     }
 
     /// <summary>
     /// Windows Terminal round-trips: narrow then widen restores original content.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void WindowsTerminal_RoundTrip_NarrowAndRestore()
     {
         using var terminal = CreateTerminal(WindowsTerminalReflowStrategy.Instance, 10, 5);
@@ -292,34 +292,34 @@ public class PerTerminalStrategyTests
         terminal.Resize(10, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
-        Assert.Equal("", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
     /// Windows Terminal tracks cursor position correctly through reflow.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void WindowsTerminal_CursorPosition_TrackedCorrectly()
     {
         using var terminal = CreateTerminal(WindowsTerminalReflowStrategy.Instance, 5, 5);
         terminal.ApplyTokens([new TextToken("ABCDEFGH")]);
 
         var snap1 = terminal.CreateSnapshot();
-        Assert.Equal(3, snap1.CursorX);
-        Assert.Equal(1, snap1.CursorY);
+        Assert.AreEqual(3, snap1.CursorX);
+        Assert.AreEqual(1, snap1.CursorY);
 
         terminal.Resize(10, 5);
 
         var snap2 = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGH", snap2.GetLine(0).TrimEnd());
+        Assert.AreEqual("ABCDEFGH", snap2.GetLine(0).TrimEnd());
     }
 
     /// <summary>
     /// Windows Terminal uses bottom-fill: when narrowing pushes content down, the
     /// screen shows the bottom and cursor shifts upward.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void WindowsTerminal_BottomFill_ContentPushedUp()
     {
         int width = 10, height = 3;
@@ -337,8 +337,7 @@ public class PerTerminalStrategyTests
 
         var result = WindowsTerminalReflowStrategy.Instance.Reflow(context);
 
-        Assert.True(result.CursorY <= 1,
-            $"Bottom-fill should push cursor toward top; got CursorY={result.CursorY}");
+        Assert.IsTrue(result.CursorY <= 1, $"Bottom-fill should push cursor toward top; got CursorY={result.CursorY}");
     }
 
     #endregion
@@ -350,7 +349,7 @@ public class PerTerminalStrategyTests
     /// <summary>
     /// Kitty merges soft-wrapped rows when widened.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Kitty_NarrowToWider_MergesSoftWrappedRows()
     {
         using var terminal = CreateTerminal(KittyReflowStrategy.Instance, 5, 5);
@@ -359,13 +358,13 @@ public class PerTerminalStrategyTests
         terminal.Resize(10, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
     }
 
     /// <summary>
     /// Kitty splits rows when narrowed.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Kitty_WiderToNarrow_SplitsRows()
     {
         using var terminal = CreateTerminal(KittyReflowStrategy.Instance, 10, 5);
@@ -374,14 +373,14 @@ public class PerTerminalStrategyTests
         terminal.Resize(5, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDE", snap.GetLine(0).TrimEnd());
-        Assert.Equal("FGHIJ", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDE", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("FGHIJ", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
     /// Kitty does not merge hard-wrapped lines.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Kitty_HardWrappedLines_NotMerged()
     {
         using var terminal = CreateTerminal(KittyReflowStrategy.Instance, 10, 5);
@@ -390,14 +389,14 @@ public class PerTerminalStrategyTests
         terminal.Resize(20, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("Hello", snap.GetLine(0).TrimEnd());
-        Assert.Equal("World", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("Hello", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("World", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
     /// Kitty does NOT reflow content in the alternate screen buffer.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Kitty_AlternateScreen_NoReflow()
     {
         int width = 5, height = 3;
@@ -414,13 +413,13 @@ public class PerTerminalStrategyTests
 
         var result = KittyReflowStrategy.Instance.Reflow(context);
 
-        Assert.Equal("ABCDE", GetRowText(result.ScreenRows[0]));
+        Assert.AreEqual("ABCDE", GetRowText(result.ScreenRows[0]));
     }
 
     /// <summary>
     /// Kitty round-trips: narrow then widen restores original content.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Kitty_RoundTrip_NarrowAndRestore()
     {
         using var terminal = CreateTerminal(KittyReflowStrategy.Instance, 10, 5);
@@ -430,13 +429,13 @@ public class PerTerminalStrategyTests
         terminal.Resize(10, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
     }
 
     /// <summary>
     /// Kitty tracks cursor position correctly through reflow.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Kitty_CursorPosition_TrackedCorrectly()
     {
         using var terminal = CreateTerminal(KittyReflowStrategy.Instance, 5, 5, scrollback: 5);
@@ -446,16 +445,16 @@ public class PerTerminalStrategyTests
         terminal.Resize(10, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
-        Assert.Equal(5, snap.CursorX);
-        Assert.Equal(0, snap.CursorY);
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual(5, snap.CursorX);
+        Assert.AreEqual(0, snap.CursorY);
     }
 
     /// <summary>
     /// Kitty anchors the cursor to its visual row: the cursor stays at the same
     /// screen row position rather than shifting to the bottom.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Kitty_CursorAnchored_StaysOnVisualRow()
     {
         int width = 10, height = 5;
@@ -478,15 +477,15 @@ public class PerTerminalStrategyTests
         var alacrittyResult = AlacrittyReflowStrategy.Instance.Reflow(context);
 
         // Kitty anchors: cursor stays at visual row 2
-        Assert.Equal(2, kittyResult.CursorY);
+        Assert.AreEqual(2, kittyResult.CursorY);
         // Alacritty bottom-fills: cursor shifts differently
-        Assert.NotEqual(kittyResult.CursorY, alacrittyResult.CursorY);
+        Assert.AreNotEqual(kittyResult.CursorY, alacrittyResult.CursorY);
     }
 
     /// <summary>
     /// Kitty does NOT reflow the saved cursor (DECSC) — returns null.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Kitty_SavedCursor_NotReflowed()
     {
         int width = 5, height = 5;
@@ -506,8 +505,8 @@ public class PerTerminalStrategyTests
 
         var result = KittyReflowStrategy.Instance.Reflow(context);
 
-        Assert.Null(result.NewSavedCursorX);
-        Assert.Null(result.NewSavedCursorY);
+        Assert.IsNull(result.NewSavedCursorX);
+        Assert.IsNull(result.NewSavedCursorY);
     }
 
     #endregion
@@ -519,7 +518,7 @@ public class PerTerminalStrategyTests
     /// <summary>
     /// WezTerm merges soft-wrapped rows when widened.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void WezTerm_NarrowToWider_MergesSoftWrappedRows()
     {
         using var terminal = CreateTerminal(WezTermReflowStrategy.Instance, 5, 5);
@@ -528,13 +527,13 @@ public class PerTerminalStrategyTests
         terminal.Resize(10, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
     }
 
     /// <summary>
     /// WezTerm splits rows when narrowed.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void WezTerm_WiderToNarrow_SplitsRows()
     {
         using var terminal = CreateTerminal(WezTermReflowStrategy.Instance, 10, 5);
@@ -543,14 +542,14 @@ public class PerTerminalStrategyTests
         terminal.Resize(5, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDE", snap.GetLine(0).TrimEnd());
-        Assert.Equal("FGHIJ", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDE", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("FGHIJ", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
     /// WezTerm does not merge hard-wrapped lines.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void WezTerm_HardWrappedLines_NotMerged()
     {
         using var terminal = CreateTerminal(WezTermReflowStrategy.Instance, 10, 5);
@@ -559,14 +558,14 @@ public class PerTerminalStrategyTests
         terminal.Resize(20, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("Hello", snap.GetLine(0).TrimEnd());
-        Assert.Equal("World", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("Hello", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("World", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
     /// WezTerm does NOT reflow content in the alternate screen buffer.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void WezTerm_AlternateScreen_NoReflow()
     {
         int width = 5, height = 3;
@@ -583,13 +582,13 @@ public class PerTerminalStrategyTests
 
         var result = WezTermReflowStrategy.Instance.Reflow(context);
 
-        Assert.Equal("ABCDE", GetRowText(result.ScreenRows[0]));
+        Assert.AreEqual("ABCDE", GetRowText(result.ScreenRows[0]));
     }
 
     /// <summary>
     /// WezTerm round-trips: narrow then widen restores original content.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void WezTerm_RoundTrip_NarrowAndRestore()
     {
         using var terminal = CreateTerminal(WezTermReflowStrategy.Instance, 10, 5);
@@ -599,13 +598,13 @@ public class PerTerminalStrategyTests
         terminal.Resize(10, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
     }
 
     /// <summary>
     /// WezTerm tracks cursor position correctly through reflow.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void WezTerm_CursorPosition_TrackedCorrectly()
     {
         using var terminal = CreateTerminal(WezTermReflowStrategy.Instance, 5, 5, scrollback: 5);
@@ -615,15 +614,15 @@ public class PerTerminalStrategyTests
         terminal.Resize(10, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
-        Assert.Equal(5, snap.CursorX);
-        Assert.Equal(0, snap.CursorY);
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual(5, snap.CursorX);
+        Assert.AreEqual(0, snap.CursorY);
     }
 
     /// <summary>
     /// WezTerm anchors the cursor to its visual row (same as Kitty behavior).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void WezTerm_CursorAnchored_StaysOnVisualRow()
     {
         int width = 10, height = 5;
@@ -645,14 +644,14 @@ public class PerTerminalStrategyTests
         var alacrittyResult = AlacrittyReflowStrategy.Instance.Reflow(context);
 
         // WezTerm anchors: cursor stays at visual row 2
-        Assert.Equal(2, wezResult.CursorY);
-        Assert.NotEqual(wezResult.CursorY, alacrittyResult.CursorY);
+        Assert.AreEqual(2, wezResult.CursorY);
+        Assert.AreNotEqual(wezResult.CursorY, alacrittyResult.CursorY);
     }
 
     /// <summary>
     /// WezTerm does NOT reflow the saved cursor (DECSC) — returns null.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void WezTerm_SavedCursor_NotReflowed()
     {
         int width = 5, height = 5;
@@ -672,8 +671,8 @@ public class PerTerminalStrategyTests
 
         var result = WezTermReflowStrategy.Instance.Reflow(context);
 
-        Assert.Null(result.NewSavedCursorX);
-        Assert.Null(result.NewSavedCursorY);
+        Assert.IsNull(result.NewSavedCursorX);
+        Assert.IsNull(result.NewSavedCursorY);
     }
 
     #endregion
@@ -685,7 +684,7 @@ public class PerTerminalStrategyTests
     /// <summary>
     /// VTE merges soft-wrapped rows when widened.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Vte_NarrowToWider_MergesSoftWrappedRows()
     {
         using var terminal = CreateTerminal(VteReflowStrategy.Instance, 5, 5);
@@ -694,13 +693,13 @@ public class PerTerminalStrategyTests
         terminal.Resize(10, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
     }
 
     /// <summary>
     /// VTE splits rows when narrowed.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Vte_WiderToNarrow_SplitsRows()
     {
         using var terminal = CreateTerminal(VteReflowStrategy.Instance, 10, 5);
@@ -709,14 +708,14 @@ public class PerTerminalStrategyTests
         terminal.Resize(5, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDE", snap.GetLine(0).TrimEnd());
-        Assert.Equal("FGHIJ", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDE", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("FGHIJ", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
     /// VTE does not merge hard-wrapped lines.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Vte_HardWrappedLines_NotMerged()
     {
         using var terminal = CreateTerminal(VteReflowStrategy.Instance, 10, 5);
@@ -725,14 +724,14 @@ public class PerTerminalStrategyTests
         terminal.Resize(20, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("Hello", snap.GetLine(0).TrimEnd());
-        Assert.Equal("World", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("Hello", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("World", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
     /// VTE does NOT reflow content in the alternate screen buffer.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Vte_AlternateScreen_NoReflow()
     {
         int width = 5, height = 3;
@@ -749,13 +748,13 @@ public class PerTerminalStrategyTests
 
         var result = VteReflowStrategy.Instance.Reflow(context);
 
-        Assert.Equal("ABCDE", GetRowText(result.ScreenRows[0]));
+        Assert.AreEqual("ABCDE", GetRowText(result.ScreenRows[0]));
     }
 
     /// <summary>
     /// VTE round-trips: narrow then widen restores original content.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Vte_RoundTrip_NarrowAndRestore()
     {
         using var terminal = CreateTerminal(VteReflowStrategy.Instance, 10, 5);
@@ -765,13 +764,13 @@ public class PerTerminalStrategyTests
         terminal.Resize(10, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
     }
 
     /// <summary>
     /// VTE tracks cursor position correctly through reflow.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Vte_CursorPosition_TrackedCorrectly()
     {
         using var terminal = CreateTerminal(VteReflowStrategy.Instance, 5, 5, scrollback: 5);
@@ -781,15 +780,15 @@ public class PerTerminalStrategyTests
         terminal.Resize(10, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
-        Assert.Equal(5, snap.CursorX);
-        Assert.Equal(0, snap.CursorY);
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual(5, snap.CursorX);
+        Assert.AreEqual(0, snap.CursorY);
     }
 
     /// <summary>
     /// VTE anchors the cursor to its visual row.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Vte_CursorAnchored_StaysOnVisualRow()
     {
         int width = 10, height = 5;
@@ -810,15 +809,15 @@ public class PerTerminalStrategyTests
         var vteResult = VteReflowStrategy.Instance.Reflow(context);
         var alacrittyResult = AlacrittyReflowStrategy.Instance.Reflow(context);
 
-        Assert.Equal(2, vteResult.CursorY);
-        Assert.NotEqual(vteResult.CursorY, alacrittyResult.CursorY);
+        Assert.AreEqual(2, vteResult.CursorY);
+        Assert.AreNotEqual(vteResult.CursorY, alacrittyResult.CursorY);
     }
 
     /// <summary>
     /// VTE reflowed the saved cursor (DECSC) position on resize — it tracks to the
     /// same character position after reflow.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Vte_SavedCursor_ReflowedOnResize()
     {
         int width = 5, height = 5;
@@ -838,17 +837,17 @@ public class PerTerminalStrategyTests
 
         var result = VteReflowStrategy.Instance.Reflow(context);
 
-        Assert.NotNull(result.NewSavedCursorX);
-        Assert.NotNull(result.NewSavedCursorY);
+        Assert.IsNotNull(result.NewSavedCursorX);
+        Assert.IsNotNull(result.NewSavedCursorY);
         // 'F' was at (0,1) in width-5, maps to (5,0) in width-10
-        Assert.Equal(5, result.NewSavedCursorX!.Value);
-        Assert.Equal(0, result.NewSavedCursorY!.Value);
+        Assert.AreEqual(5, result.NewSavedCursorX!.Value);
+        Assert.AreEqual(0, result.NewSavedCursorY!.Value);
     }
 
     /// <summary>
     /// VTE saved cursor tracks to the correct character position after narrowing.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Vte_SavedCursor_TracksCharacterPosition()
     {
         int width = 10, height = 3;
@@ -867,8 +866,8 @@ public class PerTerminalStrategyTests
 
         var result = VteReflowStrategy.Instance.Reflow(context);
 
-        Assert.Equal(2, result.NewSavedCursorX);
-        Assert.Equal(1, result.NewSavedCursorY);
+        Assert.AreEqual(2, result.NewSavedCursorX);
+        Assert.AreEqual(1, result.NewSavedCursorY);
     }
 
     #endregion
@@ -880,7 +879,7 @@ public class PerTerminalStrategyTests
     /// <summary>
     /// Ghostty merges soft-wrapped rows when widened.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Ghostty_NarrowToWider_MergesSoftWrappedRows()
     {
         using var terminal = CreateTerminal(GhosttyReflowStrategy.Instance, 5, 5);
@@ -889,13 +888,13 @@ public class PerTerminalStrategyTests
         terminal.Resize(10, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
     }
 
     /// <summary>
     /// Ghostty splits rows when narrowed.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Ghostty_WiderToNarrow_SplitsRows()
     {
         using var terminal = CreateTerminal(GhosttyReflowStrategy.Instance, 10, 5);
@@ -904,14 +903,14 @@ public class PerTerminalStrategyTests
         terminal.Resize(5, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDE", snap.GetLine(0).TrimEnd());
-        Assert.Equal("FGHIJ", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDE", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("FGHIJ", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
     /// Ghostty does not merge hard-wrapped lines.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Ghostty_HardWrappedLines_NotMerged()
     {
         using var terminal = CreateTerminal(GhosttyReflowStrategy.Instance, 10, 5);
@@ -920,14 +919,14 @@ public class PerTerminalStrategyTests
         terminal.Resize(20, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("Hello", snap.GetLine(0).TrimEnd());
-        Assert.Equal("World", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("Hello", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("World", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
     /// Ghostty does NOT reflow content in the alternate screen buffer.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Ghostty_AlternateScreen_NoReflow()
     {
         int width = 5, height = 3;
@@ -944,13 +943,13 @@ public class PerTerminalStrategyTests
 
         var result = GhosttyReflowStrategy.Instance.Reflow(context);
 
-        Assert.Equal("ABCDE", GetRowText(result.ScreenRows[0]));
+        Assert.AreEqual("ABCDE", GetRowText(result.ScreenRows[0]));
     }
 
     /// <summary>
     /// Ghostty round-trips: narrow then widen restores original content.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Ghostty_RoundTrip_NarrowAndRestore()
     {
         using var terminal = CreateTerminal(GhosttyReflowStrategy.Instance, 10, 5);
@@ -960,13 +959,13 @@ public class PerTerminalStrategyTests
         terminal.Resize(10, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
     }
 
     /// <summary>
     /// Ghostty tracks cursor position correctly through reflow.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Ghostty_CursorPosition_TrackedCorrectly()
     {
         using var terminal = CreateTerminal(GhosttyReflowStrategy.Instance, 5, 5, scrollback: 5);
@@ -976,15 +975,15 @@ public class PerTerminalStrategyTests
         terminal.Resize(10, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
-        Assert.Equal(5, snap.CursorX);
-        Assert.Equal(0, snap.CursorY);
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual(5, snap.CursorX);
+        Assert.AreEqual(0, snap.CursorY);
     }
 
     /// <summary>
     /// Ghostty anchors the cursor to its visual row.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Ghostty_CursorAnchored_StaysOnVisualRow()
     {
         int width = 10, height = 5;
@@ -1005,14 +1004,14 @@ public class PerTerminalStrategyTests
         var ghosttyResult = GhosttyReflowStrategy.Instance.Reflow(context);
         var alacrittyResult = AlacrittyReflowStrategy.Instance.Reflow(context);
 
-        Assert.Equal(2, ghosttyResult.CursorY);
-        Assert.NotEqual(ghosttyResult.CursorY, alacrittyResult.CursorY);
+        Assert.AreEqual(2, ghosttyResult.CursorY);
+        Assert.AreNotEqual(ghosttyResult.CursorY, alacrittyResult.CursorY);
     }
 
     /// <summary>
     /// Ghostty reflowed the saved cursor (DECSC) position on resize.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Ghostty_SavedCursor_ReflowedOnResize()
     {
         int width = 5, height = 5;
@@ -1032,16 +1031,16 @@ public class PerTerminalStrategyTests
 
         var result = GhosttyReflowStrategy.Instance.Reflow(context);
 
-        Assert.NotNull(result.NewSavedCursorX);
-        Assert.NotNull(result.NewSavedCursorY);
-        Assert.Equal(5, result.NewSavedCursorX!.Value);
-        Assert.Equal(0, result.NewSavedCursorY!.Value);
+        Assert.IsNotNull(result.NewSavedCursorX);
+        Assert.IsNotNull(result.NewSavedCursorY);
+        Assert.AreEqual(5, result.NewSavedCursorX!.Value);
+        Assert.AreEqual(0, result.NewSavedCursorY!.Value);
     }
 
     /// <summary>
     /// Ghostty saved cursor tracks to the correct character position after narrowing.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Ghostty_SavedCursor_TracksCharacterPosition()
     {
         int width = 10, height = 3;
@@ -1059,8 +1058,8 @@ public class PerTerminalStrategyTests
 
         var result = GhosttyReflowStrategy.Instance.Reflow(context);
 
-        Assert.Equal(2, result.NewSavedCursorX);
-        Assert.Equal(1, result.NewSavedCursorY);
+        Assert.AreEqual(2, result.NewSavedCursorX);
+        Assert.AreEqual(1, result.NewSavedCursorY);
     }
 
     #endregion
@@ -1072,7 +1071,7 @@ public class PerTerminalStrategyTests
     /// <summary>
     /// Foot merges soft-wrapped rows when widened.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Foot_NarrowToWider_MergesSoftWrappedRows()
     {
         using var terminal = CreateTerminal(FootReflowStrategy.Instance, 5, 5);
@@ -1081,13 +1080,13 @@ public class PerTerminalStrategyTests
         terminal.Resize(10, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
     }
 
     /// <summary>
     /// Foot splits rows when narrowed.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Foot_WiderToNarrow_SplitsRows()
     {
         using var terminal = CreateTerminal(FootReflowStrategy.Instance, 10, 5);
@@ -1096,14 +1095,14 @@ public class PerTerminalStrategyTests
         terminal.Resize(5, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDE", snap.GetLine(0).TrimEnd());
-        Assert.Equal("FGHIJ", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDE", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("FGHIJ", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
     /// Foot does not merge hard-wrapped lines.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Foot_HardWrappedLines_NotMerged()
     {
         using var terminal = CreateTerminal(FootReflowStrategy.Instance, 10, 5);
@@ -1112,14 +1111,14 @@ public class PerTerminalStrategyTests
         terminal.Resize(20, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("Hello", snap.GetLine(0).TrimEnd());
-        Assert.Equal("World", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("Hello", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("World", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
     /// Foot does NOT reflow content in the alternate screen buffer.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Foot_AlternateScreen_NoReflow()
     {
         int width = 5, height = 3;
@@ -1136,13 +1135,13 @@ public class PerTerminalStrategyTests
 
         var result = FootReflowStrategy.Instance.Reflow(context);
 
-        Assert.Equal("ABCDE", GetRowText(result.ScreenRows[0]));
+        Assert.AreEqual("ABCDE", GetRowText(result.ScreenRows[0]));
     }
 
     /// <summary>
     /// Foot round-trips: narrow then widen restores original content.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Foot_RoundTrip_NarrowAndRestore()
     {
         using var terminal = CreateTerminal(FootReflowStrategy.Instance, 10, 5);
@@ -1152,13 +1151,13 @@ public class PerTerminalStrategyTests
         terminal.Resize(10, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
     }
 
     /// <summary>
     /// Foot tracks cursor position correctly through reflow.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Foot_CursorPosition_TrackedCorrectly()
     {
         using var terminal = CreateTerminal(FootReflowStrategy.Instance, 5, 5, scrollback: 5);
@@ -1168,15 +1167,15 @@ public class PerTerminalStrategyTests
         terminal.Resize(10, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
-        Assert.Equal(5, snap.CursorX);
-        Assert.Equal(0, snap.CursorY);
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual(5, snap.CursorX);
+        Assert.AreEqual(0, snap.CursorY);
     }
 
     /// <summary>
     /// Foot anchors the cursor to its visual row.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Foot_CursorAnchored_StaysOnVisualRow()
     {
         int width = 10, height = 5;
@@ -1197,14 +1196,14 @@ public class PerTerminalStrategyTests
         var footResult = FootReflowStrategy.Instance.Reflow(context);
         var alacrittyResult = AlacrittyReflowStrategy.Instance.Reflow(context);
 
-        Assert.Equal(2, footResult.CursorY);
-        Assert.NotEqual(footResult.CursorY, alacrittyResult.CursorY);
+        Assert.AreEqual(2, footResult.CursorY);
+        Assert.AreNotEqual(footResult.CursorY, alacrittyResult.CursorY);
     }
 
     /// <summary>
     /// Foot reflowed the saved cursor (DECSC) position on resize.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Foot_SavedCursor_ReflowedOnResize()
     {
         int width = 5, height = 5;
@@ -1224,16 +1223,16 @@ public class PerTerminalStrategyTests
 
         var result = FootReflowStrategy.Instance.Reflow(context);
 
-        Assert.NotNull(result.NewSavedCursorX);
-        Assert.NotNull(result.NewSavedCursorY);
-        Assert.Equal(5, result.NewSavedCursorX!.Value);
-        Assert.Equal(0, result.NewSavedCursorY!.Value);
+        Assert.IsNotNull(result.NewSavedCursorX);
+        Assert.IsNotNull(result.NewSavedCursorY);
+        Assert.AreEqual(5, result.NewSavedCursorX!.Value);
+        Assert.AreEqual(0, result.NewSavedCursorY!.Value);
     }
 
     /// <summary>
     /// Foot saved cursor tracks to the correct character position after narrowing.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Foot_SavedCursor_TracksCharacterPosition()
     {
         int width = 10, height = 3;
@@ -1251,8 +1250,8 @@ public class PerTerminalStrategyTests
 
         var result = FootReflowStrategy.Instance.Reflow(context);
 
-        Assert.Equal(2, result.NewSavedCursorX);
-        Assert.Equal(1, result.NewSavedCursorY);
+        Assert.AreEqual(2, result.NewSavedCursorX);
+        Assert.AreEqual(1, result.NewSavedCursorY);
     }
 
     #endregion
@@ -1264,7 +1263,7 @@ public class PerTerminalStrategyTests
     /// <summary>
     /// Xterm does NOT reflow: content is cropped when narrowed, not re-wrapped.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Xterm_NoReflow_ContentCropped()
     {
         using var terminal = CreateTerminal(XtermReflowStrategy.Instance, 10, 3);
@@ -1273,14 +1272,14 @@ public class PerTerminalStrategyTests
         terminal.Resize(5, 3);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDE", snap.GetLine(0).TrimEnd());
-        Assert.Equal("", snap.GetLine(1).TrimEnd()); // No overflow — content is cropped
+        Assert.AreEqual("ABCDE", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("", snap.GetLine(1).TrimEnd()); // No overflow — content is cropped
     }
 
     /// <summary>
     /// Xterm ignores SoftWrap flags — they are not processed for reflow.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Xterm_NoReflow_SoftWrapIgnored()
     {
         int width = 5, height = 3;
@@ -1298,8 +1297,8 @@ public class PerTerminalStrategyTests
         var result = XtermReflowStrategy.Instance.Reflow(context);
 
         // Soft-wrapped rows should NOT be merged — xterm does not reflow
-        Assert.Equal("ABCDE", GetRowText(result.ScreenRows[0]));
-        Assert.Equal("FGHIJ", GetRowText(result.ScreenRows[1]));
+        Assert.AreEqual("ABCDE", GetRowText(result.ScreenRows[0]));
+        Assert.AreEqual("FGHIJ", GetRowText(result.ScreenRows[1]));
     }
 
     #endregion
@@ -1311,7 +1310,7 @@ public class PerTerminalStrategyTests
     /// <summary>
     /// iTerm2 does NOT reflow: content is cropped when narrowed, not re-wrapped.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void ITerm2_NoReflow_ContentCropped()
     {
         using var terminal = CreateTerminal(ITerm2ReflowStrategy.Instance, 10, 3);
@@ -1320,14 +1319,14 @@ public class PerTerminalStrategyTests
         terminal.Resize(5, 3);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDE", snap.GetLine(0).TrimEnd());
-        Assert.Equal("", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDE", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
     /// iTerm2 ignores SoftWrap flags — they are not processed for reflow.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void ITerm2_NoReflow_SoftWrapIgnored()
     {
         int width = 5, height = 3;
@@ -1344,8 +1343,8 @@ public class PerTerminalStrategyTests
 
         var result = ITerm2ReflowStrategy.Instance.Reflow(context);
 
-        Assert.Equal("ABCDE", GetRowText(result.ScreenRows[0]));
-        Assert.Equal("FGHIJ", GetRowText(result.ScreenRows[1]));
+        Assert.AreEqual("ABCDE", GetRowText(result.ScreenRows[0]));
+        Assert.AreEqual("FGHIJ", GetRowText(result.ScreenRows[1]));
     }
 
     #endregion

--- a/tests/Hex1b.Tests/PickerIntegrationTests.cs
+++ b/tests/Hex1b.Tests/PickerIntegrationTests.cs
@@ -8,9 +8,10 @@ namespace Hex1b.Tests;
 /// These tests verify the full lifecycle of the picker popup including
 /// opening, selecting, and dismissing via various methods.
 /// </summary>
+[TestClass]
 public class PickerIntegrationTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Picker_EnterKey_OpensPopup()
     {
         // Arrange & Act
@@ -34,11 +35,11 @@ public class PickerIntegrationTests
         await runTask;
 
         // Assert - The popup should have opened showing all items
-        Assert.True(snapshot.ContainsText("Banana"));
-        Assert.True(snapshot.ContainsText("Cherry"));
+        Assert.IsTrue(snapshot.ContainsText("Banana"));
+        Assert.IsTrue(snapshot.ContainsText("Cherry"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Picker_SelectItem_ClosesPopupAndUpdatesSelection()
     {
         // Arrange
@@ -69,12 +70,12 @@ public class PickerIntegrationTests
         await runTask;
 
         // Assert
-        Assert.Equal("Banana", selectedText);
+        Assert.AreEqual("Banana", selectedText);
         // The picker should now show "Banana ▼" and the popup should be closed
-        Assert.True(snapshot.ContainsText("Banana"));
+        Assert.IsTrue(snapshot.ContainsText("Banana"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Picker_EscapeKey_ClosesPopupWithoutChangingSelection()
     {
         // Arrange
@@ -105,12 +106,12 @@ public class PickerIntegrationTests
         await runTask;
 
         // Assert - Selection should not have changed
-        Assert.Equal(0, selectionChangedCount);
+        Assert.AreEqual(0, selectionChangedCount);
         // The picker should still show "Apple ▼"
-        Assert.True(snapshot.ContainsText("Apple"));
+        Assert.IsTrue(snapshot.ContainsText("Apple"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Picker_ClickAwayOnBackdrop_ClosesPopupWithoutChangingSelection()
     {
         // Arrange
@@ -144,12 +145,12 @@ public class PickerIntegrationTests
         await runTask;
 
         // Assert - Selection should not have changed
-        Assert.Equal(0, selectionChangedCount);
+        Assert.AreEqual(0, selectionChangedCount);
         // The picker should still show "Apple ▼"
-        Assert.True(snapshot.ContainsText("Apple"));
+        Assert.IsTrue(snapshot.ContainsText("Apple"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Picker_ClickOnPopupContent_DoesNotDismiss()
     {
         // Arrange
@@ -184,15 +185,11 @@ public class PickerIntegrationTests
             }
         }
 
-        Assert.True(
-            popupApple.HasValue,
-            $"Expected to find the popup's selected Apple item.\nScreen:\n{popupSnapshot.GetText()}");
+        Assert.IsTrue(popupApple.HasValue, $"Expected to find the popup's selected Apple item.\nScreen:\n{popupSnapshot.GetText()}");
 
         var popupBorderX = popupApple.Value.Column;
         var popupBorderY = popupApple.Value.Line - 1;
-        Assert.True(
-            popupBorderY >= 0,
-            $"Expected popup border row above selected item.\nScreen:\n{popupSnapshot.GetText()}");
+        Assert.IsTrue(popupBorderY >= 0, $"Expected popup border row above selected item.\nScreen:\n{popupSnapshot.GetText()}");
 
         // Click the popup border itself. If that click wrongly dismisses the popup, the
         // subsequent Enter will reopen it instead of selecting the focused item.
@@ -211,11 +208,11 @@ public class PickerIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(finalSnapshot.ContainsText("Apple ▼"));
-        Assert.False(finalSnapshot.ContainsText("Cherry"));
+        Assert.IsTrue(finalSnapshot.ContainsText("Apple ▼"));
+        Assert.IsFalse(finalSnapshot.ContainsText("Cherry"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Picker_DownArrow_OpensPopupWithNextItemSelected()
     {
         // Arrange
@@ -244,10 +241,10 @@ public class PickerIntegrationTests
         await runTask;
 
         // Assert
-        Assert.Equal("Banana", selectedText);
+        Assert.AreEqual("Banana", selectedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Picker_UpArrow_OpensPopupWithPreviousItemSelected()
     {
         // Arrange - Start with Cherry selected (index 2)
@@ -276,10 +273,10 @@ public class PickerIntegrationTests
         await runTask;
 
         // Assert
-        Assert.Equal("Banana", selectedText);
+        Assert.AreEqual("Banana", selectedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Picker_PopupOpened_FocusMovesToList()
     {
         // Arrange & Act
@@ -306,10 +303,10 @@ public class PickerIntegrationTests
         await runTask;
 
         // Assert - If we got here, the list received focus and responded to Down arrow
-        Assert.True(snapshot.ContainsText("> Banana"));
+        Assert.IsTrue(snapshot.ContainsText("> Banana"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Picker_PopupDismissed_FocusRestoresToPicker()
     {
         // Arrange & Act
@@ -338,11 +335,11 @@ public class PickerIntegrationTests
         await runTask;
 
         // Assert - Focus was restored and picker could be reopened
-        Assert.True(snapshot.ContainsText("Banana"));
-        Assert.True(snapshot.ContainsText("Cherry"));
+        Assert.IsTrue(snapshot.ContainsText("Banana"));
+        Assert.IsTrue(snapshot.ContainsText("Cherry"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Picker_MultiplePickersOnScreen_TabNavigatesBetweenThem()
     {
         // Arrange
@@ -388,11 +385,11 @@ public class PickerIntegrationTests
         await runTask;
 
         // Assert
-        Assert.Equal("Banana", selectedFruit);
-        Assert.Equal("Green", selectedColor);
+        Assert.AreEqual("Banana", selectedFruit);
+        Assert.AreEqual("Green", selectedColor);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Picker_StackedPickers_OpenedDropdown_DoesNotBleedSiblingChipBackground()
     {
         // Reproduces the bug where a Picker dropdown's transparent inner cells
@@ -456,8 +453,7 @@ public class PickerIntegrationTests
                 break;
             }
         }
-        Assert.True(popupBanana.HasValue,
-            $"Expected to find Banana inside the popup body.\nScreen:\n{snapshot.GetText()}");
+        Assert.IsTrue(popupBanana.HasValue, $"Expected to find Banana inside the popup body.\nScreen:\n{snapshot.GetText()}");
 
         // The dropdown wraps a ListWidget in a BorderWidget. The "Banana"
         // text starts after the border (col -1) and the unselected indicator
@@ -501,9 +497,7 @@ public class PickerIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(
-            leakedCells.Count == 0,
-            $"Sibling picker chip background ({siblingChipBg}) bled through the open dropdown at {leakedCells.Count} cell(s): " +
+        Assert.IsTrue(leakedCells.Count == 0, $"Sibling picker chip background ({siblingChipBg}) bled through the open dropdown at {leakedCells.Count} cell(s): " +
             string.Join(", ", leakedCells.Take(10).Select(c => $"({c.X},{c.Y})")) +
             $".\nScreen:\n{snapshot.GetText()}");
     }

--- a/tests/Hex1b.Tests/PickerNodeTests.cs
+++ b/tests/Hex1b.Tests/PickerNodeTests.cs
@@ -4,22 +4,23 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class PickerNodeTests
 {
-    [Fact]
+    [TestMethod]
     public async Task PickerNode_InitialState_HasCorrectDefaults()
     {
         // Arrange & Act
         var node = new PickerNode();
         
         // Assert
-        Assert.Empty(node.Items);
-        Assert.Equal(0, node.SelectedIndex);
-        Assert.Equal("", node.SelectedText);
-        Assert.Null(node.SelectionChangedAction);
+        Assert.IsEmpty(node.Items);
+        Assert.AreEqual(0, node.SelectedIndex);
+        Assert.AreEqual("", node.SelectedText);
+        Assert.IsNull(node.SelectionChangedAction);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task PickerNode_WithItems_ReturnsCorrectSelectedText()
     {
         // Arrange
@@ -30,10 +31,10 @@ public class PickerNodeTests
         };
         
         // Act & Assert
-        Assert.Equal("Banana", node.SelectedText);
+        Assert.AreEqual("Banana", node.SelectedText);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task PickerNode_SelectedIndex_ClampsToValidRange()
     {
         // Arrange
@@ -44,10 +45,10 @@ public class PickerNodeTests
         };
         
         // Assert - SelectedText should return empty since index is invalid
-        Assert.Equal("", node.SelectedText);
+        Assert.AreEqual("", node.SelectedText);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task PickerNode_EmptyItems_ReturnsEmptySelectedText()
     {
         // Arrange
@@ -58,10 +59,10 @@ public class PickerNodeTests
         };
         
         // Assert
-        Assert.Equal("", node.SelectedText);
+        Assert.AreEqual("", node.SelectedText);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task PickerWidget_Reconcile_CreatesPickerNode()
     {
         // Arrange
@@ -72,13 +73,13 @@ public class PickerNodeTests
         var node = await widget.ReconcileAsync(null, context) as PickerNode;
         
         // Assert
-        Assert.NotNull(node);
-        Assert.Equal(["Apple", "Banana", "Cherry"], node.Items);
-        Assert.Equal(0, node.SelectedIndex);
-        Assert.Equal("Apple", node.SelectedText);
+        Assert.IsNotNull(node);
+        TestSeq.AreEqual(["Apple", "Banana", "Cherry"], node.Items);
+        Assert.AreEqual(0, node.SelectedIndex);
+        Assert.AreEqual("Apple", node.SelectedText);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task PickerWidget_Reconcile_PreservesExistingSelection()
     {
         // Arrange
@@ -92,12 +93,12 @@ public class PickerNodeTests
         var reconciledNode = await widget2.ReconcileAsync(node, context) as PickerNode;
         
         // Assert - Selection should be preserved
-        Assert.Same(node, reconciledNode);
-        Assert.Equal(2, reconciledNode!.SelectedIndex);
-        Assert.Equal("Cherry", reconciledNode.SelectedText);
+        Assert.AreSame(node, reconciledNode);
+        Assert.AreEqual(2, reconciledNode!.SelectedIndex);
+        Assert.AreEqual("Cherry", reconciledNode.SelectedText);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task PickerWidget_Reconcile_ClampsSelectionWhenItemsReduced()
     {
         // Arrange
@@ -111,11 +112,11 @@ public class PickerNodeTests
         var reconciledNode = await widget2.ReconcileAsync(node, context) as PickerNode;
         
         // Assert - Selection should be clamped to last valid index
-        Assert.Equal(2, reconciledNode!.SelectedIndex);
-        Assert.Equal("Cherry", reconciledNode.SelectedText);
+        Assert.AreEqual(2, reconciledNode!.SelectedIndex);
+        Assert.AreEqual("Cherry", reconciledNode.SelectedText);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task PickerWidget_WithInitialSelection_SetsCorrectIndex()
     {
         // Arrange
@@ -126,11 +127,11 @@ public class PickerNodeTests
         var node = await widget.ReconcileAsync(null, context) as PickerNode;
         
         // Assert
-        Assert.Equal(1, node!.SelectedIndex);
-        Assert.Equal("Banana", node.SelectedText);
+        Assert.AreEqual(1, node!.SelectedIndex);
+        Assert.AreEqual("Banana", node.SelectedText);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task PickerWidget_OnSelectionChanged_SetsHandler()
     {
         // Arrange
@@ -142,10 +143,10 @@ public class PickerNodeTests
         var node = await widget.ReconcileAsync(null, context) as PickerNode;
         
         // Assert
-        Assert.NotNull(node!.SelectionChangedAction);
+        Assert.IsNotNull(node!.SelectionChangedAction);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task PickerNode_ContentChild_IsCreated()
     {
         // Arrange & Act (via reconciliation)
@@ -154,11 +155,11 @@ public class PickerNodeTests
         var node = widget.ReconcileAsync(null, context).GetAwaiter().GetResult() as PickerNode;
         
         // Assert - ContentChild should be a ButtonNode (from the button we build internally)
-        Assert.NotNull(node!.ContentChild);
-        Assert.IsType<ButtonNode>(node.ContentChild);
+        Assert.IsNotNull(node!.ContentChild);
+        TestSeq.IsType<ButtonNode>(node.ContentChild);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task PickerNode_IsFocusable_ReturnsFalse_ButContentChildIsFocusable()
     {
         // Arrange
@@ -168,9 +169,9 @@ public class PickerNodeTests
         
         // Assert - PickerNode itself is NOT focusable (focus passes through to content child)
         // This ensures the input router continues into GetChildren() to find the ButtonNode
-        Assert.False(node!.IsFocusable);
+        Assert.IsFalse(node!.IsFocusable);
         
         // But the content child (ButtonNode) IS focusable
-        Assert.True(node.ContentChild!.IsFocusable);
+        Assert.IsTrue(node.ContentChild!.IsFocusable);
     }
 }

--- a/tests/Hex1b.Tests/PrebuiltBindingTests.cs
+++ b/tests/Hex1b.Tests/PrebuiltBindingTests.cs
@@ -11,6 +11,7 @@ namespace Hex1b.Tests;
 /// <see cref="CharacterBinding"/>, and <see cref="DragBinding"/> instances. Covers issue
 /// <see href="https://github.com/mitchdenny/hex1b/issues/292">#292</see>.
 /// </summary>
+[TestClass]
 public class PrebuiltBindingTests
 {
     /// <summary>
@@ -36,39 +37,39 @@ public class PrebuiltBindingTests
 
     #region 1. Null guards
 
-    [Fact]
+    [TestMethod]
     public void Add_NullInputBinding_ThrowsArgumentNullException()
     {
         var builder = new InputBindingsBuilder();
-        Assert.Throws<ArgumentNullException>(() => builder.Add((InputBinding)null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => builder.Add((InputBinding)null!));
     }
 
-    [Fact]
+    [TestMethod]
     public void Add_NullMouseBinding_ThrowsArgumentNullException()
     {
         var builder = new InputBindingsBuilder();
-        Assert.Throws<ArgumentNullException>(() => builder.Add((MouseBinding)null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => builder.Add((MouseBinding)null!));
     }
 
-    [Fact]
+    [TestMethod]
     public void Add_NullCharacterBinding_ThrowsArgumentNullException()
     {
         var builder = new InputBindingsBuilder();
-        Assert.Throws<ArgumentNullException>(() => builder.Add((CharacterBinding)null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => builder.Add((CharacterBinding)null!));
     }
 
-    [Fact]
+    [TestMethod]
     public void Add_NullDragBinding_ThrowsArgumentNullException()
     {
         var builder = new InputBindingsBuilder();
-        Assert.Throws<ArgumentNullException>(() => builder.Add((DragBinding)null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => builder.Add((DragBinding)null!));
     }
 
     #endregion
 
     #region 2. Round-trip via the public Bindings/MouseBindings/etc. lists
 
-    [Fact]
+    [TestMethod]
     public void Add_PrebuiltInputBinding_AppearsInBindingsList()
     {
         var builder = new InputBindingsBuilder();
@@ -79,14 +80,14 @@ public class PrebuiltBindingTests
 
         builder.Add(binding);
 
-        var actual = Assert.Single(builder.Bindings);
-        Assert.Same(binding, actual);
-        Assert.Empty(builder.MouseBindings);
-        Assert.Empty(builder.CharacterBindings);
-        Assert.Empty(builder.DragBindings);
+        var actual = TestSeq.Single(builder.Bindings);
+        Assert.AreSame(binding, actual);
+        Assert.IsEmpty(builder.MouseBindings);
+        Assert.IsEmpty(builder.CharacterBindings);
+        Assert.IsEmpty(builder.DragBindings);
     }
 
-    [Fact]
+    [TestMethod]
     public void Add_PrebuiltMouseBinding_AppearsInMouseBindingsList()
     {
         var builder = new InputBindingsBuilder();
@@ -94,11 +95,11 @@ public class PrebuiltBindingTests
 
         builder.Add(binding);
 
-        var actual = Assert.Single(builder.MouseBindings);
-        Assert.Same(binding, actual);
+        var actual = TestSeq.Single(builder.MouseBindings);
+        Assert.AreSame(binding, actual);
     }
 
-    [Fact]
+    [TestMethod]
     public void Add_PrebuiltCharacterBinding_AppearsInCharacterBindingsList()
     {
         var builder = new InputBindingsBuilder();
@@ -106,11 +107,11 @@ public class PrebuiltBindingTests
 
         builder.Add(binding);
 
-        var actual = Assert.Single(builder.CharacterBindings);
-        Assert.Same(binding, actual);
+        var actual = TestSeq.Single(builder.CharacterBindings);
+        Assert.AreSame(binding, actual);
     }
 
-    [Fact]
+    [TestMethod]
     public void Add_PrebuiltDragBinding_AppearsInDragBindingsList()
     {
         var builder = new InputBindingsBuilder();
@@ -122,15 +123,15 @@ public class PrebuiltBindingTests
 
         builder.Add(binding);
 
-        var actual = Assert.Single(builder.DragBindings);
-        Assert.Same(binding, actual);
+        var actual = TestSeq.Single(builder.DragBindings);
+        Assert.AreSame(binding, actual);
     }
 
     #endregion
 
     #region 3. End-to-end routing through Add(prebuilt)
 
-    [Fact]
+    [TestMethod]
     public async Task Add_PrebuiltCtrlShiftInputBinding_FiresEndToEnd()
     {
         // RULE: A Ctrl+Shift+Key binding constructed externally and registered via
@@ -167,7 +168,7 @@ public class PrebuiltBindingTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(bindingFired, "Prebuilt Ctrl+Shift+LeftArrow binding should fire end-to-end");
+        Assert.IsTrue(bindingFired, "Prebuilt Ctrl+Shift+LeftArrow binding should fire end-to-end");
 
         cts.Cancel();
         await runTask;
@@ -177,7 +178,7 @@ public class PrebuiltBindingTests
 
     #region 4. Constructor parameter flow-through
 
-    [Fact]
+    [TestMethod]
     public void InputBinding_ConstructedWithActionId_ExposesActionId()
     {
         var actionId = new ActionId("Test.Foo");
@@ -188,11 +189,11 @@ public class PrebuiltBindingTests
             isGlobal: false,
             actionId: actionId);
 
-        Assert.Equal(actionId, binding.ActionId);
-        Assert.False(binding.OverridesCapture);
+        Assert.AreEqual(actionId, binding.ActionId);
+        Assert.IsFalse(binding.OverridesCapture);
     }
 
-    [Fact]
+    [TestMethod]
     public void InputBinding_ConstructedWithOverridesCapture_ExposesFlag()
     {
         var binding = new InputBinding(
@@ -203,11 +204,11 @@ public class PrebuiltBindingTests
             actionId: null,
             overridesCapture: true);
 
-        Assert.True(binding.OverridesCapture);
-        Assert.Null(binding.ActionId);
+        Assert.IsTrue(binding.OverridesCapture);
+        Assert.IsNull(binding.ActionId);
     }
 
-    [Fact]
+    [TestMethod]
     public void MouseBinding_ConstructedWithActionId_ExposesActionId()
     {
         var actionId = new ActionId("Test.Click");
@@ -219,10 +220,10 @@ public class PrebuiltBindingTests
             "click",
             actionId);
 
-        Assert.Equal(actionId, binding.ActionId);
+        Assert.AreEqual(actionId, binding.ActionId);
     }
 
-    [Fact]
+    [TestMethod]
     public void CharacterBinding_ConstructedWithActionId_ExposesActionId()
     {
         var actionId = new ActionId("Test.Type");
@@ -232,10 +233,10 @@ public class PrebuiltBindingTests
             "type",
             actionId);
 
-        Assert.Equal(actionId, binding.ActionId);
+        Assert.AreEqual(actionId, binding.ActionId);
     }
 
-    [Fact]
+    [TestMethod]
     public void DragBinding_ConstructedWithActionId_ExposesActionId()
     {
         var actionId = new ActionId("Test.Drag");
@@ -246,14 +247,14 @@ public class PrebuiltBindingTests
             "drag",
             actionId);
 
-        Assert.Equal(actionId, binding.ActionId);
+        Assert.AreEqual(actionId, binding.ActionId);
     }
 
     #endregion
 
     #region 5. ActionId enables Remove(ActionId) for prebuilt bindings
 
-    [Fact]
+    [TestMethod]
     public void Remove_ByActionId_RemovesPrebuiltMouseBinding()
     {
         var builder = new InputBindingsBuilder();
@@ -261,14 +262,14 @@ public class PrebuiltBindingTests
         var binding = new MouseBinding(MouseButton.Left, MouseAction.Down, Hex1bModifiers.None, () => { }, "click", actionId);
 
         builder.Add(binding);
-        Assert.Single(builder.MouseBindings);
+        TestSeq.Single(builder.MouseBindings);
 
         builder.Remove(actionId);
 
-        Assert.Empty(builder.MouseBindings);
+        Assert.IsEmpty(builder.MouseBindings);
     }
 
-    [Fact]
+    [TestMethod]
     public void Remove_ByActionId_RemovesPrebuiltInputBinding()
     {
         var builder = new InputBindingsBuilder();
@@ -276,18 +277,18 @@ public class PrebuiltBindingTests
         var binding = new InputBinding([new KeyStep(Hex1bKey.A)], () => { }, "foo", false, actionId);
 
         builder.Add(binding);
-        Assert.Single(builder.Bindings);
+        TestSeq.Single(builder.Bindings);
 
         builder.Remove(actionId);
 
-        Assert.Empty(builder.Bindings);
+        Assert.IsEmpty(builder.Bindings);
     }
 
     #endregion
 
     #region 6. End-to-end OverridesCapture flag honored
 
-    [Fact]
+    [TestMethod]
     public async Task Add_PrebuiltOverridesCaptureBinding_FiresWhenCaptured()
     {
         // RULE: A prebuilt InputBinding constructed with overridesCapture: true must
@@ -355,7 +356,7 @@ public class PrebuiltBindingTests
 
     #region 7. End-to-end character binding via Add(prebuilt)
 
-    [Fact]
+    [TestMethod]
     public async Task Add_PrebuiltCharacterBinding_FiresOnTextInput()
     {
         // RULE: A CharacterBinding constructed externally and registered via
@@ -383,15 +384,15 @@ public class PrebuiltBindingTests
             null,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal("x", received);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual("x", received);
     }
 
     #endregion
 
     #region 8. End-to-end drag binding via Add(prebuilt)
 
-    [Fact]
+    [TestMethod]
     public void Add_PrebuiltDragBinding_FactoryInvokedByStartDrag()
     {
         // RULE: A DragBinding constructed externally and registered via
@@ -418,18 +419,18 @@ public class PrebuiltBindingTests
         var builder = new InputBindingsBuilder();
         builder.Add(binding);
 
-        var added = Assert.Single(builder.DragBindings);
-        Assert.True(added.Matches(new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 0, 0, Hex1bModifiers.None, ClickCount: 1)));
+        var added = TestSeq.Single(builder.DragBindings);
+        Assert.IsTrue(added.Matches(new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 0, 0, Hex1bModifiers.None, ClickCount: 1)));
         added.StartDrag(7, 11);
 
-        Assert.Equal((7, 11), startedAt);
+        Assert.AreEqual((7, 11), startedAt);
     }
 
     #endregion
 
     #region 9. Conflict detection still applies to prebuilt globals
 
-    [Fact]
+    [TestMethod]
     public async Task Add_PrebuiltGlobalBinding_ConflictingDefaultGlobal_Throws()
     {
         // RULE: When two global bindings claim the same first key step, the input
@@ -472,7 +473,7 @@ public class PrebuiltBindingTests
         await new Hex1bTerminalInputSequenceBuilder().Key(Hex1bKey.X).Wait(100).Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () => await runTask);
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () => await runTask);
         Assert.Contains("Global binding conflict", ex.Message);
 
         cts.Cancel();
@@ -482,7 +483,7 @@ public class PrebuiltBindingTests
 
     #region 10. Defensive copy of Steps
 
-    [Fact]
+    [TestMethod]
     public void InputBinding_StepsListMutatedAfterConstruction_DoesNotAffectBinding()
     {
         // RULE: InputBinding must defensively copy its steps list so that callers
@@ -499,16 +500,16 @@ public class PrebuiltBindingTests
         steps.Clear();
         steps.Add(new KeyStep(Hex1bKey.RightArrow, Hex1bModifiers.None));
 
-        var step = Assert.Single(binding.Steps);
-        Assert.Equal(Hex1bKey.LeftArrow, step.Key);
-        Assert.Equal(Hex1bModifiers.Control | Hex1bModifiers.Shift, step.Modifiers);
+        var step = TestSeq.Single(binding.Steps);
+        Assert.AreEqual(Hex1bKey.LeftArrow, step.Key);
+        Assert.AreEqual(Hex1bModifiers.Control | Hex1bModifiers.Shift, step.Modifiers);
     }
 
     #endregion
 
     #region 11. ActionId via ctor does NOT register for Triggers(actionId) rebinding
 
-    [Fact]
+    [TestMethod]
     public void Triggers_ByActionId_AfterAddPrebuiltOnly_ThrowsInvalidOperation()
     {
         // RULE: An ActionId supplied via the InputBinding ctor identifies the binding
@@ -531,10 +532,10 @@ public class PrebuiltBindingTests
         builder.Add(prebuilt);
 
         // Sanity check: the binding is queryable by its ActionId for inspection/removal.
-        Assert.Single(builder.GetBindings(actionId));
+        TestSeq.Single(builder.GetBindings(actionId));
 
         // But the rebinding registry was NOT seeded, so Triggers(actionId) fails predictably.
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() =>
             builder.Key(Hex1bKey.B).Triggers(actionId));
         Assert.Contains(actionId.Value, ex.Message);
         Assert.Contains("has not been registered", ex.Message);

--- a/tests/Hex1b.Tests/ProgressIntegrationTests.cs
+++ b/tests/Hex1b.Tests/ProgressIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Hex1b.Tests;
 /// Integration tests for the Progress widget using Hex1bApp.
 /// Tests various scenarios, layout conditions, and exports SVG, HTML, ANSI, and asciinema recordings.
 /// </summary>
+[TestClass]
 public class ProgressIntegrationTests : IDisposable
 {
     private readonly List<string> _tempFiles = new();
@@ -31,7 +32,7 @@ public class ProgressIntegrationTests : IDisposable
 
     #region Basic Rendering Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Progress_RendersBasicDeterminateBar()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -57,11 +58,10 @@ public class ProgressIntegrationTests : IDisposable
         await runTask;
 
         // Verify the progress bar characters are present
-        Assert.True(snapshot.ContainsText("█") || snapshot.ContainsText("░"), 
-            "Progress bar should contain filled or empty characters");
+        Assert.IsTrue(snapshot.ContainsText("█") || snapshot.ContainsText("░"), "Progress bar should contain filled or empty characters");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Progress_RendersZeroPercent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -87,7 +87,7 @@ public class ProgressIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Progress_Renders100Percent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -113,7 +113,7 @@ public class ProgressIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Progress_RendersCustomRange()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -139,7 +139,7 @@ public class ProgressIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Progress_RendersNegativeRange()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -165,7 +165,7 @@ public class ProgressIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Progress_RendersIndeterminate()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -195,7 +195,7 @@ public class ProgressIntegrationTests : IDisposable
 
     #region Layout Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Progress_FillsAvailableWidth()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -221,7 +221,7 @@ public class ProgressIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Progress_RespectsFixedWidth()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -247,7 +247,7 @@ public class ProgressIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Progress_InHStackWithFill()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -276,7 +276,7 @@ public class ProgressIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Progress_MultipleInVStack()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -310,7 +310,7 @@ public class ProgressIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Progress_InBorder()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -339,11 +339,11 @@ public class ProgressIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Theory]
-    [InlineData(40)]
-    [InlineData(60)]
-    [InlineData(80)]
-    [InlineData(120)]
+    [TestMethod]
+    [DataRow(40)]
+    [DataRow(60)]
+    [DataRow(80)]
+    [DataRow(120)]
     public async Task Progress_RespondsToTerminalWidth(int width)
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -373,7 +373,7 @@ public class ProgressIntegrationTests : IDisposable
 
     #region Dynamic Update Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Progress_UpdatesDynamically()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -408,7 +408,7 @@ public class ProgressIntegrationTests : IDisposable
         var snapshot = terminal.CreateSnapshot();
         TestCaptureHelper.Capture(snapshot, "progress-dynamic-update");
 
-        Assert.True(snapshot.ContainsText("Progress: 100%"));
+        Assert.IsTrue(snapshot.ContainsText("Progress: 100%"));
 
         cts.Cancel();
         await runTask;
@@ -418,7 +418,7 @@ public class ProgressIntegrationTests : IDisposable
 
     #region Theming Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Progress_RespectsCustomTheme()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -458,7 +458,7 @@ public class ProgressIntegrationTests : IDisposable
 
     #region Asciinema Recording Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Progress_RecordsAnimatedIndeterminate()
     {
         var tempFile = GetTempFile();
@@ -503,7 +503,7 @@ public class ProgressIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Progress_RecordsDownloadSimulation()
     {
         var tempFile = GetTempFile();
@@ -581,7 +581,7 @@ public class ProgressIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Progress_RecordsMultipleProgressBars()
     {
         var tempFile = GetTempFile();
@@ -661,7 +661,7 @@ public class ProgressIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Progress_RecordsResizeScenario()
     {
         var tempFile = GetTempFile();

--- a/tests/Hex1b.Tests/ProgressNodeTests.cs
+++ b/tests/Hex1b.Tests/ProgressNodeTests.cs
@@ -6,9 +6,10 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class ProgressNodeTests
 {
-    [Fact]
+    [TestMethod]
     public void Measure_FillsAvailableWidth()
     {
         // Arrange
@@ -19,11 +20,11 @@ public class ProgressNodeTests
         var size = node.Measure(constraints);
 
         // Assert
-        Assert.Equal(80, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(80, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_RespectsMinWidth()
     {
         // Arrange
@@ -34,11 +35,11 @@ public class ProgressNodeTests
         var size = node.Measure(constraints);
 
         // Assert
-        Assert.Equal(80, size.Width); // Should fill available width
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(80, size.Width); // Should fill available width
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_UnboundedWidth_UsesDefaultWidth()
     {
         // Arrange
@@ -49,11 +50,11 @@ public class ProgressNodeTests
         var size = node.Measure(constraints);
 
         // Assert
-        Assert.Equal(20, size.Width); // Default width when unbounded
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(20, size.Width); // Default width when unbounded
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Reconcile_PreservesNodeOnSameType()
     {
         // Arrange
@@ -66,11 +67,11 @@ public class ProgressNodeTests
         var node2 = widget2.ReconcileAsync(node1, context).GetAwaiter().GetResult();
 
         // Assert
-        Assert.Same(node1, node2);
-        Assert.Equal(75, ((ProgressNode)node2).Value);
+        Assert.AreSame(node1, node2);
+        Assert.AreEqual(75, ((ProgressNode)node2).Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void Reconcile_MarksDirtyOnValueChange()
     {
         // Arrange
@@ -85,10 +86,10 @@ public class ProgressNodeTests
         widget2.ReconcileAsync(node, context).GetAwaiter().GetResult();
 
         // Assert
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void Reconcile_MarksDirtyOnMinimumChange()
     {
         // Arrange
@@ -103,10 +104,10 @@ public class ProgressNodeTests
         widget2.ReconcileAsync(node, context).GetAwaiter().GetResult();
 
         // Assert
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void Reconcile_MarksDirtyOnMaximumChange()
     {
         // Arrange
@@ -121,10 +122,10 @@ public class ProgressNodeTests
         widget2.ReconcileAsync(node, context).GetAwaiter().GetResult();
 
         // Assert
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void Reconcile_MarksDirtyOnIndeterminateChange()
     {
         // Arrange
@@ -139,10 +140,10 @@ public class ProgressNodeTests
         widget2.ReconcileAsync(node, context).GetAwaiter().GetResult();
 
         // Assert
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void Reconcile_DoesNotMarkDirtyWhenUnchanged()
     {
         // Arrange
@@ -157,76 +158,76 @@ public class ProgressNodeTests
         widget2.ReconcileAsync(node, context).GetAwaiter().GetResult();
 
         // Assert
-        Assert.False(node.IsDirty);
+        Assert.IsFalse(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetExpectedNodeType_ReturnsProgressNode()
     {
         // Arrange
         var widget = new ProgressWidget();
 
         // Act & Assert
-        Assert.Equal(typeof(ProgressNode), widget.GetExpectedNodeType());
+        Assert.AreEqual(typeof(ProgressNode), widget.GetExpectedNodeType());
     }
 
-    [Fact]
+    [TestMethod]
     public void IsFocusable_ReturnsFalse()
     {
         // Arrange
         var node = new ProgressNode();
 
         // Assert
-        Assert.False(node.IsFocusable);
+        Assert.IsFalse(node.IsFocusable);
     }
 
-    [Theory]
-    [InlineData(0, 0, 100, 0.0)]
-    [InlineData(50, 0, 100, 0.5)]
-    [InlineData(100, 0, 100, 1.0)]
-    [InlineData(25, 0, 100, 0.25)]
-    [InlineData(-25, -50, 50, 0.25)]
-    [InlineData(0, -100, 100, 0.5)]
+    [TestMethod]
+    [DataRow(0, 0, 100, 0.0)]
+    [DataRow(50, 0, 100, 0.5)]
+    [DataRow(100, 0, 100, 1.0)]
+    [DataRow(25, 0, 100, 0.25)]
+    [DataRow(-25, -50, 50, 0.25)]
+    [DataRow(0, -100, 100, 0.5)]
     public void DeterminateMode_CalculatesPercentageCorrectly(double value, double min, double max, double expectedPercentage)
     {
         // This is a logic test - we verify the percentage calculation
         var range = max - min;
         var actualPercentage = range > 0 ? Math.Clamp((value - min) / range, 0.0, 1.0) : 0.0;
         
-        Assert.Equal(expectedPercentage, actualPercentage, precision: 5);
+        Assert.AreEqual(expectedPercentage, actualPercentage, delta: 5);
     }
 
-    [Fact]
+    [TestMethod]
     public void IndeterminateMode_SetsIsIndeterminate()
     {
         // Arrange & Act
         var widget = new ProgressWidget { IsIndeterminate = true };
 
         // Assert
-        Assert.True(widget.IsIndeterminate);
+        Assert.IsTrue(widget.IsIndeterminate);
     }
 
-    [Fact]
+    [TestMethod]
     public void IndeterminateMode_SetsDefaultRedrawDelay()
     {
         // Arrange & Act
         var widget = new ProgressWidget { IsIndeterminate = true };
 
         // Assert - should auto-schedule redraws
-        Assert.Equal(ProgressWidget.DefaultAnimationInterval, widget.GetEffectiveRedrawDelay());
+        Assert.AreEqual(ProgressWidget.DefaultAnimationInterval, widget.GetEffectiveRedrawDelay());
     }
 
-    [Fact]
+    [TestMethod]
     public void DeterminateMode_DoesNotSetRedrawDelay()
     {
         // Arrange & Act
         var widget = new ProgressWidget { Value = 50 };
 
         // Assert - no auto-redraw for determinate progress
-        Assert.Null(widget.GetEffectiveRedrawDelay());
+        Assert.IsNull(widget.GetEffectiveRedrawDelay());
     }
 
-    [Fact]
+    [TestMethod]
     public void IndeterminateNode_MeasuresCorrectly()
     {
         // Arrange
@@ -237,13 +238,13 @@ public class ProgressNodeTests
         var size = node.Measure(constraints);
         
         // Assert - should still measure like a normal progress bar
-        Assert.Equal(20, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(20, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
     #region Visual Rendering Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Render_ZeroPercent_ShowsAllEmpty()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -271,7 +272,7 @@ public class ProgressNodeTests
         Assert.DoesNotContain("█", line);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_HundredPercent_ShowsAllFilled()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -299,7 +300,7 @@ public class ProgressNodeTests
         Assert.DoesNotContain("░", line);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_FiftyPercent_ShowsHalfFilled()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -327,7 +328,7 @@ public class ProgressNodeTests
         Assert.Contains("░░░░░░░░░░", line);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithHalfCellPrecision_ShowsHalfCharacter()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -361,7 +362,7 @@ public class ProgressNodeTests
         Assert.Contains("██", line); // 2 full blocks
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithHalfCellPrecision_17_5Percent_ShowsThreeFullOneHalf()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -393,7 +394,7 @@ public class ProgressNodeTests
         Assert.Contains("▐", line);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithHalfCellPrecision_2_5Percent_ShowsOnlyHalf()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -426,7 +427,7 @@ public class ProgressNodeTests
         Assert.DoesNotContain("██", line);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithHalfCellPrecision_ZeroPercent_NoHalfChar()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -457,7 +458,7 @@ public class ProgressNodeTests
         Assert.DoesNotContain("▌", line);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithCustomFilledCharacter_UsesThemedChar()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -488,7 +489,7 @@ public class ProgressNodeTests
         Assert.Contains("·", line);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithBrailleCharacters_DisplaysBraille()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -524,15 +525,15 @@ public class ProgressNodeTests
         Assert.Contains("⢀", line);
     }
 
-    [Theory]
-    [InlineData(0, 0)]
-    [InlineData(10, 1)]
-    [InlineData(20, 2)]
-    [InlineData(30, 3)]
-    [InlineData(50, 5)]
-    [InlineData(70, 7)]
-    [InlineData(90, 9)]
-    [InlineData(100, 10)]
+    [TestMethod]
+    [DataRow(0, 0)]
+    [DataRow(10, 1)]
+    [DataRow(20, 2)]
+    [DataRow(30, 3)]
+    [DataRow(50, 5)]
+    [DataRow(70, 7)]
+    [DataRow(90, 9)]
+    [DataRow(100, 10)]
     public void Render_DeterminatePercentages_CalculatesCorrectFilledWidth(int percent, int expectedFilledCells)
     {
         // Test the fill calculation logic directly
@@ -540,16 +541,16 @@ public class ProgressNodeTests
         var percentage = percent / 100.0;
         var filledWidth = (int)Math.Round(percentage * width);
         
-        Assert.Equal(expectedFilledCells, filledWidth);
+        Assert.AreEqual(expectedFilledCells, filledWidth);
     }
 
-    [Theory]
-    [InlineData(5, 0, true)]   // 5% of 10 = 0.5 = 0 full + half
-    [InlineData(15, 1, true)]  // 15% of 10 = 1.5 = 1 full + half
-    [InlineData(25, 2, true)]  // 25% of 10 = 2.5 = 2 full + half
-    [InlineData(30, 3, false)] // 30% of 10 = 3.0 = 3 full + no half
-    [InlineData(50, 5, false)] // 50% of 10 = 5.0 = 5 full + no half
-    [InlineData(55, 5, true)]  // 55% of 10 = 5.5 = 5 full + half
+    [TestMethod]
+    [DataRow(5, 0, true)]   // 5% of 10 = 0.5 = 0 full + half
+    [DataRow(15, 1, true)]  // 15% of 10 = 1.5 = 1 full + half
+    [DataRow(25, 2, true)]  // 25% of 10 = 2.5 = 2 full + half
+    [DataRow(30, 3, false)] // 30% of 10 = 3.0 = 3 full + no half
+    [DataRow(50, 5, false)] // 50% of 10 = 5.0 = 5 full + no half
+    [DataRow(55, 5, true)]  // 55% of 10 = 5.5 = 5 full + half
     public void Render_HalfCellPrecision_CalculatesCorrectly(int percent, int expectedFullCells, bool expectedHalfCell)
     {
         var width = 10;
@@ -558,11 +559,11 @@ public class ProgressNodeTests
         var filledWidth = (int)(halfCellUnits / 2);
         var hasHalfCell = ((int)halfCellUnits % 2) == 1;
         
-        Assert.Equal(expectedFullCells, filledWidth);
-        Assert.Equal(expectedHalfCell, hasHalfCell);
+        Assert.AreEqual(expectedFullCells, filledWidth);
+        Assert.AreEqual(expectedHalfCell, hasHalfCell);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_CustomRange_NegativeToPositive_RendersCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();

--- a/tests/Hex1b.Tests/QrCodeNodeTests.cs
+++ b/tests/Hex1b.Tests/QrCodeNodeTests.cs
@@ -8,11 +8,12 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for QrCodeNode rendering and measurement.
 /// </summary>
+[TestClass]
 public class QrCodeNodeTests
 {
     #region Measurement Tests
 
-    [Fact]
+    [TestMethod]
     public void Measure_ReturnsCorrectSizeForUrl()
     {
         var node = new QrCodeNode { Data = "https://github.com/mitchdenny/hex1b" };
@@ -20,24 +21,24 @@ public class QrCodeNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // QR code for this URL should be non-zero
-        Assert.True(size.Width > 0, "Width should be greater than 0");
-        Assert.True(size.Height > 0, "Height should be greater than 0");
+        Assert.IsTrue(size.Width > 0, "Width should be greater than 0");
+        Assert.IsTrue(size.Height > 0, "Height should be greater than 0");
         // Width is doubled (2 chars per module) so width = height * 2
-        Assert.Equal(size.Height * 2, size.Width);
+        Assert.AreEqual(size.Height * 2, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_EmptyData_ReturnsZeroSize()
     {
         var node = new QrCodeNode { Data = "" };
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(0, size.Width);
-        Assert.Equal(0, size.Height);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(0, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithQuietZone_IncludesQuietZoneInSize()
     {
         var nodeWithoutQuietZone = new QrCodeNode { Data = "test", QuietZone = 0 };
@@ -48,26 +49,26 @@ public class QrCodeNodeTests
 
         // With quiet zone should be larger by 2 * quietZone (both sides)
         // Width is doubled (2 chars per module), so quiet zone adds 2 * 2 * 2 = 8 chars
-        Assert.Equal(sizeWithout.Width + 8, sizeWith.Width);
-        Assert.Equal(sizeWithout.Height + 4, sizeWith.Height);
+        Assert.AreEqual(sizeWithout.Width + 8, sizeWith.Width);
+        Assert.AreEqual(sizeWithout.Height + 4, sizeWith.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_RespectsMaxWidthConstraint()
     {
         var node = new QrCodeNode { Data = "test" };
 
         var size = node.Measure(new Constraints(0, 10, 0, 10));
 
-        Assert.True(size.Width <= 10, $"Width {size.Width} should be <= 10");
-        Assert.True(size.Height <= 10, $"Height {size.Height} should be <= 10");
+        Assert.IsTrue(size.Width <= 10, $"Width {size.Width} should be <= 10");
+        Assert.IsTrue(size.Height <= 10, $"Height {size.Height} should be <= 10");
     }
 
     #endregion
 
     #region Property Tests
 
-    [Fact]
+    [TestMethod]
     public void Data_WhenChanged_MarksNodeDirty()
     {
         var node = new QrCodeNode { Data = "initial" };
@@ -75,10 +76,10 @@ public class QrCodeNodeTests
 
         node.Data = "changed";
 
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void QuietZone_WhenChanged_MarksNodeDirty()
     {
         var node = new QrCodeNode { QuietZone = 1 };
@@ -86,22 +87,22 @@ public class QrCodeNodeTests
 
         node.QuietZone = 2;
 
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void QuietZone_NegativeValue_ClampsToZero()
     {
         var node = new QrCodeNode { QuietZone = -5 };
 
-        Assert.Equal(0, node.QuietZone);
+        Assert.AreEqual(0, node.QuietZone);
     }
 
     #endregion
 
     #region Widget Reconciliation Tests
 
-    [Fact]
+    [TestMethod]
     public void QrCodeWidget_Reconcile_CreatesNewNode()
     {
         var widget = new QrCodeWidget("https://example.com");
@@ -109,13 +110,13 @@ public class QrCodeNodeTests
 
         var node = widget.ReconcileAsync(null, context).GetAwaiter().GetResult();
 
-        Assert.IsType<QrCodeNode>(node);
+        TestSeq.IsType<QrCodeNode>(node);
         var qrNode = (QrCodeNode)node;
-        Assert.Equal("https://example.com", qrNode.Data);
-        Assert.Equal(1, qrNode.QuietZone); // Default quiet zone
+        Assert.AreEqual("https://example.com", qrNode.Data);
+        Assert.AreEqual(1, qrNode.QuietZone); // Default quiet zone
     }
 
-    [Fact]
+    [TestMethod]
     public void QrCodeWidget_Reconcile_UpdatesExistingNode()
     {
         var widget = new QrCodeWidget("https://example.com", QuietZone: 0);
@@ -124,12 +125,12 @@ public class QrCodeNodeTests
 
         var node = widget.ReconcileAsync(existingNode, context).GetAwaiter().GetResult();
 
-        Assert.Same(existingNode, node);
-        Assert.Equal("https://example.com", existingNode.Data);
-        Assert.Equal(0, existingNode.QuietZone);
+        Assert.AreSame(existingNode, node);
+        Assert.AreEqual("https://example.com", existingNode.Data);
+        Assert.AreEqual(0, existingNode.QuietZone);
     }
 
-    [Fact]
+    [TestMethod]
     public void QrCodeWidget_Reconcile_MarksNodeDirtyWhenDataChanges()
     {
         var widget = new QrCodeWidget("new-data");
@@ -139,7 +140,7 @@ public class QrCodeNodeTests
 
         widget.ReconcileAsync(existingNode, context).GetAwaiter().GetResult();
 
-        Assert.True(existingNode.IsDirty);
+        Assert.IsTrue(existingNode.IsDirty);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/RangeHighlightTests.cs
+++ b/tests/Hex1b.Tests/RangeHighlightTests.cs
@@ -10,6 +10,7 @@ namespace Hex1b.Tests;
 /// Tests for range highlights — temporary background-colored document ranges
 /// used for search results, symbol occurrences, and definition flashes.
 /// </summary>
+[TestClass]
 public class RangeHighlightTests
 {
     private static Hex1bColor? ToCellColor(Hex1bColor color) => color.IsDefault ? null : color;
@@ -39,7 +40,7 @@ public class RangeHighlightTests
 
     // ── State management tests ────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void PushRangeHighlights_StoresHighlightsOnSession()
     {
         var doc = new Hex1bDocument("hello world");
@@ -54,10 +55,10 @@ public class RangeHighlightTests
         };
 
         session.PushRangeHighlights(highlights);
-        Assert.Equal(2, session.ActiveRangeHighlights.Count);
+        Assert.AreEqual(2, session.ActiveRangeHighlights.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void PushRangeHighlights_ReplacesPrevious()
     {
         var doc = new Hex1bDocument("test");
@@ -68,11 +69,11 @@ public class RangeHighlightTests
         session.PushRangeHighlights([new RangeHighlight(new DocumentPosition(1, 1), new DocumentPosition(1, 3))]);
         session.PushRangeHighlights([new RangeHighlight(new DocumentPosition(1, 2), new DocumentPosition(1, 4))]);
 
-        Assert.Single(session.ActiveRangeHighlights);
-        Assert.Equal(2, session.ActiveRangeHighlights[0].Start.Column);
+        TestSeq.Single(session.ActiveRangeHighlights);
+        Assert.AreEqual(2, session.ActiveRangeHighlights[0].Start.Column);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClearRangeHighlights_RemovesAll()
     {
         var doc = new Hex1bDocument("test");
@@ -83,10 +84,10 @@ public class RangeHighlightTests
         session.PushRangeHighlights([new RangeHighlight(new DocumentPosition(1, 1), new DocumentPosition(1, 5))]);
         session.ClearRangeHighlights();
 
-        Assert.Empty(session.ActiveRangeHighlights);
+        Assert.IsEmpty(session.ActiveRangeHighlights);
     }
 
-    [Fact]
+    [TestMethod]
     public void ActiveRangeHighlights_InitiallyEmpty()
     {
         var doc = new Hex1bDocument("test");
@@ -94,12 +95,12 @@ public class RangeHighlightTests
         var node = new EditorNode { State = state };
         var session = (IEditorSession)node;
 
-        Assert.Empty(session.ActiveRangeHighlights);
+        Assert.IsEmpty(session.ActiveRangeHighlights);
     }
 
     // ── Visual rendering tests ────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task Render_DefaultHighlight_AppliesThemeBackgroundColor()
     {
         var (node, workload, terminal, context, theme) = CreateEditor("hello world", 20, 3);
@@ -126,8 +127,7 @@ public class RangeHighlightTests
         for (var x = 0; x <= 4; x++) // "hello" at columns 0-4
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(ColorEquals(expectedBg, cell.Background),
-                $"Column {x}: expected highlight bg {expectedBg}, got {cell.Background}");
+            Assert.IsTrue(ColorEquals(expectedBg, cell.Background), $"Column {x}: expected highlight bg {expectedBg}, got {cell.Background}");
         }
 
         // Non-highlighted cells should have editor background
@@ -135,15 +135,14 @@ public class RangeHighlightTests
         for (var x = 6; x <= 10; x++) // "world" at columns 6-10
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(ColorEquals(editorBg, cell.Background),
-                $"Column {x}: expected editor bg, got {cell.Background}");
+            Assert.IsTrue(ColorEquals(editorBg, cell.Background), $"Column {x}: expected editor bg, got {cell.Background}");
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_ReadAccessHighlight_UsesReadAccessColor()
     {
         var (node, workload, terminal, context, theme) = CreateEditor("abc def", 20, 3);
@@ -168,15 +167,14 @@ public class RangeHighlightTests
         for (var x = 0; x <= 2; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(ColorEquals(expectedBg, cell.Background),
-                $"Column {x}: expected read-access bg {expectedBg}, got {cell.Background}");
+            Assert.IsTrue(ColorEquals(expectedBg, cell.Background), $"Column {x}: expected read-access bg {expectedBg}, got {cell.Background}");
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WriteAccessHighlight_UsesWriteAccessColor()
     {
         var (node, workload, terminal, context, theme) = CreateEditor("abc def", 20, 3);
@@ -201,15 +199,14 @@ public class RangeHighlightTests
         for (var x = 4; x <= 6; x++) // "def" at columns 4-6
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(ColorEquals(expectedBg, cell.Background),
-                $"Column {x}: expected write-access bg {expectedBg}, got {cell.Background}");
+            Assert.IsTrue(ColorEquals(expectedBg, cell.Background), $"Column {x}: expected write-access bg {expectedBg}, got {cell.Background}");
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_ExplicitBackgroundColor_OverridesKindDefault()
     {
         var customBg = Hex1bColor.FromRgb(200, 50, 50);
@@ -235,15 +232,14 @@ public class RangeHighlightTests
         for (var x = 0; x <= 3; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(ColorEquals(expectedBg, cell.Background),
-                $"Column {x}: expected custom bg {expectedBg}, got {cell.Background}");
+            Assert.IsTrue(ColorEquals(expectedBg, cell.Background), $"Column {x}: expected custom bg {expectedBg}, got {cell.Background}");
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_MultiLineHighlight_SpansCorrectly()
     {
         var (node, workload, terminal, context, theme) = CreateEditor("abc\ndef\nghi", 20, 5);
@@ -277,24 +273,19 @@ public class RangeHighlightTests
         var snapshot = terminal.CreateSnapshot();
 
         // Line 0: 'a' no highlight, 'b' and 'c' highlighted
-        Assert.True(ColorEquals(editorBg, snapshot.GetCell(0, 0).Background),
-            $"Line 0 col 0: should not be highlighted");
-        Assert.True(ColorEquals(expectedBg, snapshot.GetCell(1, 0).Background),
-            $"Line 0 col 1: should be highlighted");
-        Assert.True(ColorEquals(expectedBg, snapshot.GetCell(2, 0).Background),
-            $"Line 0 col 2: should be highlighted");
+        Assert.IsTrue(ColorEquals(editorBg, snapshot.GetCell(0, 0).Background), $"Line 0 col 0: should not be highlighted");
+        Assert.IsTrue(ColorEquals(expectedBg, snapshot.GetCell(1, 0).Background), $"Line 0 col 1: should be highlighted");
+        Assert.IsTrue(ColorEquals(expectedBg, snapshot.GetCell(2, 0).Background), $"Line 0 col 2: should be highlighted");
 
         // Line 1: 'd' and 'e' highlighted (columns 1-2), 'f' not
-        Assert.True(ColorEquals(expectedBg, snapshot.GetCell(0, 1).Background),
-            $"Line 1 col 0: should be highlighted");
-        Assert.True(ColorEquals(expectedBg, snapshot.GetCell(1, 1).Background),
-            $"Line 1 col 1: should be highlighted");
+        Assert.IsTrue(ColorEquals(expectedBg, snapshot.GetCell(0, 1).Background), $"Line 1 col 0: should be highlighted");
+        Assert.IsTrue(ColorEquals(expectedBg, snapshot.GetCell(1, 1).Background), $"Line 1 col 1: should be highlighted");
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_ClearedHighlights_BackgroundReverts()
     {
         var (node, workload, terminal, context, theme) = CreateEditor("test", 20, 3);
@@ -338,8 +329,7 @@ public class RangeHighlightTests
         for (var x = 0; x <= 3; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(ColorEquals(editorBg, cell.Background),
-                $"Column {x}: expected editor bg after clear, got {cell.Background}");
+            Assert.IsTrue(ColorEquals(editorBg, cell.Background), $"Column {x}: expected editor bg after clear, got {cell.Background}");
         }
 
         workload.Dispose();

--- a/tests/Hex1b.Tests/RemoteTerminalWorkloadAdapterTests.cs
+++ b/tests/Hex1b.Tests/RemoteTerminalWorkloadAdapterTests.cs
@@ -6,11 +6,11 @@ using Hex1b;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
-using Xunit;
 
 namespace Hex1b.Tests;
 
-public class RemoteTerminalWorkloadAdapterTests : IAsyncLifetime
+[TestClass]
+public class RemoteTerminalWorkloadAdapterTests
 {
     private WebApplication? _server;
     private int _port;
@@ -19,13 +19,15 @@ public class RemoteTerminalWorkloadAdapterTests : IAsyncLifetime
     // Signal so the server handler stays alive until test cleanup
     private readonly TaskCompletionSource _serverDone = new();
 
-    public async ValueTask InitializeAsync()
+    [TestInitialize]
+    public async Task InitializeAsync()
     {
         _port = Random.Shared.Next(19000, 19999);
         _server = await StartMockServerAsync(_port);
     }
 
-    public async ValueTask DisposeAsync()
+    [TestCleanup]
+    public async Task DisposeAsync()
     {
         // Signal server handlers to exit
         _serverDone.TrySetResult();
@@ -44,30 +46,30 @@ public class RemoteTerminalWorkloadAdapterTests : IAsyncLifetime
 
     private Uri WsUri => new($"ws://localhost:{_port}/ws/attach");
 
-    [Fact]
+    [TestMethod]
     public async Task Constructor_WithValidUri_CreatesAdapter()
     {
         await using var adapter = new RemoteTerminalWorkloadAdapter(new Uri("ws://localhost:9999/ws/attach"));
-        Assert.NotNull(adapter);
+        Assert.IsNotNull(adapter);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_WithNullUri_ThrowsArgumentNull()
     {
-        Assert.Throws<ArgumentNullException>(() => new RemoteTerminalWorkloadAdapter(null!));
+        Assert.ThrowsExactly<ArgumentNullException>(() => new RemoteTerminalWorkloadAdapter(null!));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ConnectAsync_ReceivesHandshake_SetsRemoteDimensions()
     {
         await using var adapter = new RemoteTerminalWorkloadAdapter(WsUri);
         await adapter.ConnectAsync(CancellationToken.None);
 
-        Assert.Equal(120, adapter.RemoteWidth);
-        Assert.Equal(30, adapter.RemoteHeight);
+        Assert.AreEqual(120, adapter.RemoteWidth);
+        Assert.AreEqual(30, adapter.RemoteHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ConnectAsync_ClaimsLeadership()
     {
         await using var adapter = new RemoteTerminalWorkloadAdapter(WsUri);
@@ -80,10 +82,10 @@ public class RemoteTerminalWorkloadAdapterTests : IAsyncLifetime
         // The adapter sends {"type":"lead"} after handshake
         var msg = await ReceiveTextAsync(serverWs);
         using var doc = JsonDocument.Parse(msg);
-        Assert.Equal("lead", doc.RootElement.GetProperty("type").GetString());
+        Assert.AreEqual("lead", doc.RootElement.GetProperty("type").GetString());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadOutputAsync_ReceivesBinaryFrames_ReturnsData()
     {
         await using var adapter = new RemoteTerminalWorkloadAdapter(WsUri);
@@ -106,10 +108,10 @@ public class RemoteTerminalWorkloadAdapterTests : IAsyncLifetime
         // Read from adapter
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         var received = await adapter.ReadOutputAsync(cts.Token);
-        Assert.Equal("Hello from remote!", Encoding.UTF8.GetString(received.Span));
+        Assert.AreEqual("Hello from remote!", Encoding.UTF8.GetString(received.Span));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WriteInputAsync_SendsBinaryFrameToServer()
     {
         await using var adapter = new RemoteTerminalWorkloadAdapter(WsUri);
@@ -128,11 +130,11 @@ public class RemoteTerminalWorkloadAdapterTests : IAsyncLifetime
         // Verify server received it as binary
         var buffer = new byte[4096];
         var result = await serverWs.ReceiveAsync(buffer, CancellationToken.None);
-        Assert.Equal(WebSocketMessageType.Binary, result.MessageType);
-        Assert.Equal("ls -la\n", Encoding.UTF8.GetString(buffer, 0, result.Count));
+        Assert.AreEqual(WebSocketMessageType.Binary, result.MessageType);
+        Assert.AreEqual("ls -la\n", Encoding.UTF8.GetString(buffer, 0, result.Count));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ResizeAsync_SendsJsonResizeFrame()
     {
         await using var adapter = new RemoteTerminalWorkloadAdapter(WsUri);
@@ -150,12 +152,12 @@ public class RemoteTerminalWorkloadAdapterTests : IAsyncLifetime
         // Verify server received JSON resize
         var msg = await ReceiveTextAsync(serverWs);
         using var doc = JsonDocument.Parse(msg);
-        Assert.Equal("resize", doc.RootElement.GetProperty("type").GetString());
-        Assert.Equal(200, doc.RootElement.GetProperty("cols").GetInt32());
-        Assert.Equal(50, doc.RootElement.GetProperty("rows").GetInt32());
+        Assert.AreEqual("resize", doc.RootElement.GetProperty("type").GetString());
+        Assert.AreEqual(200, doc.RootElement.GetProperty("cols").GetInt32());
+        Assert.AreEqual(50, doc.RootElement.GetProperty("rows").GetInt32());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Disconnected_FiredWhenServerCloses()
     {
         await using var adapter = new RemoteTerminalWorkloadAdapter(WsUri);
@@ -172,10 +174,10 @@ public class RemoteTerminalWorkloadAdapterTests : IAsyncLifetime
 
         // Wait for Disconnected event
         await Task.WhenAny(disconnectedFired.Task, Task.Delay(TimeSpan.FromSeconds(5)));
-        Assert.True(disconnectedFired.Task.IsCompletedSuccessfully, "Disconnected event should fire when server closes");
+        Assert.IsTrue(disconnectedFired.Task.IsCompletedSuccessfully, "Disconnected event should fire when server closes");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadOutputAsync_ReturnsInitialScreenData()
     {
         await using var adapter = new RemoteTerminalWorkloadAdapter(WsUri);
@@ -184,10 +186,10 @@ public class RemoteTerminalWorkloadAdapterTests : IAsyncLifetime
         // The mock server sends initial data "Welcome" in the handshake
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
         var first = await adapter.ReadOutputAsync(cts.Token);
-        Assert.Equal("Welcome", Encoding.UTF8.GetString(first.Span));
+        Assert.AreEqual("Welcome", Encoding.UTF8.GetString(first.Span));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ExitFrame_TriggersDisconnect()
     {
         await using var adapter = new RemoteTerminalWorkloadAdapter(WsUri);
@@ -208,7 +210,7 @@ public class RemoteTerminalWorkloadAdapterTests : IAsyncLifetime
             Encoding.UTF8.GetBytes(exitJson), WebSocketMessageType.Text, true, CancellationToken.None);
 
         await Task.WhenAny(disconnectedFired.Task, Task.Delay(TimeSpan.FromSeconds(5)));
-        Assert.True(disconnectedFired.Task.IsCompletedSuccessfully, "Exit frame should trigger Disconnected");
+        Assert.IsTrue(disconnectedFired.Task.IsCompletedSuccessfully, "Exit frame should trigger Disconnected");
     }
 
     // --- Mock WebSocket Server ---

--- a/tests/Hex1b.Tests/RenderCachingTests.cs
+++ b/tests/Hex1b.Tests/RenderCachingTests.cs
@@ -8,11 +8,12 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for the render caching infrastructure.
 /// </summary>
+[TestClass]
 public class RenderCachingTests
 {
     #region Cache Mechanics
 
-    [Fact]
+    [TestMethod]
     public void RenderChild_WhenDirty_RendersAndCaches()
     {
         // Arrange
@@ -22,20 +23,20 @@ public class RenderCachingTests
         node.Measure(new Constraints(0, 20, 0, 5));
         node.Arrange(new Rect(0, 0, 20, 1));
         
-        Assert.True(node.IsDirty);
-        Assert.Null(node.CachedSurface);
+        Assert.IsTrue(node.IsDirty);
+        Assert.IsNull(node.CachedSurface);
         
         // Act
         context.RenderChild(node);
         
         // Assert
-        Assert.NotNull(node.CachedSurface);
-        Assert.Equal(node.Bounds, node.CachedBounds);
-        Assert.Equal(1, context.CacheMisses);
-        Assert.Equal(0, context.CacheHits);
+        Assert.IsNotNull(node.CachedSurface);
+        Assert.AreEqual(node.Bounds, node.CachedBounds);
+        Assert.AreEqual(1, context.CacheMisses);
+        Assert.AreEqual(0, context.CacheHits);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderChild_WhenCleanWithCache_UsesCachedSurface()
     {
         // Arrange
@@ -54,11 +55,11 @@ public class RenderCachingTests
         context.RenderChild(node);
         
         // Assert
-        Assert.Equal(1, context.CacheHits);
-        Assert.Equal(0, context.CacheMisses);
+        Assert.AreEqual(1, context.CacheHits);
+        Assert.AreEqual(0, context.CacheMisses);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderChild_WhenDescendantMarkedDirty_ParentCacheMisses()
     {
         // Arrange
@@ -75,7 +76,7 @@ public class RenderCachingTests
         child.ClearDirty();
         context.ResetCacheStats();
         context.RenderChild(parent);
-        Assert.Equal(1, context.CacheHits);
+        Assert.AreEqual(1, context.CacheHits);
 
         // Mark only child dirty (parent IsDirty remains false)
         child.MarkDirty();
@@ -85,11 +86,11 @@ public class RenderCachingTests
         context.RenderChild(parent);
 
         // Assert
-        Assert.Equal(0, context.CacheHits);
-        Assert.Equal(1, context.CacheMisses);
+        Assert.AreEqual(0, context.CacheHits);
+        Assert.AreEqual(1, context.CacheMisses);
     }
 
-    [Fact]
+    [TestMethod]
     public void MarkDirty_InvalidatesCache()
     {
         // Arrange
@@ -100,17 +101,17 @@ public class RenderCachingTests
         node.Arrange(new Rect(0, 0, 20, 1));
         
         context.RenderChild(node);
-        Assert.NotNull(node.CachedSurface);
+        Assert.IsNotNull(node.CachedSurface);
         
         // Act
         node.MarkDirty();
         
         // Assert
-        Assert.Null(node.CachedSurface);
-        Assert.True(node.IsDirty);
+        Assert.IsNull(node.CachedSurface);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderChild_WhenBoundsChange_InvalidatesCache()
     {
         // Arrange
@@ -131,11 +132,11 @@ public class RenderCachingTests
         context.RenderChild(node);
         
         // Assert - cache miss because bounds changed
-        Assert.Equal(0, context.CacheHits);
-        Assert.Equal(1, context.CacheMisses);
+        Assert.AreEqual(0, context.CacheHits);
+        Assert.AreEqual(1, context.CacheMisses);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderChild_WhenCachingDisabled_AlwaysRenders()
     {
         // Arrange
@@ -153,11 +154,11 @@ public class RenderCachingTests
         context.RenderChild(node);
         
         // Assert - no cache stats when disabled
-        Assert.Equal(0, context.CacheHits);
-        Assert.Equal(0, context.CacheMisses);
+        Assert.AreEqual(0, context.CacheHits);
+        Assert.AreEqual(0, context.CacheMisses);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderChild_WhenCachePredicateReturnsFalse_ForcesMiss()
     {
         // Arrange
@@ -184,13 +185,13 @@ public class RenderCachingTests
         context.RenderChild(node);
 
         // Assert
-        Assert.Same(node, seenNode);
-        Assert.Same(context, seenRenderContext);
-        Assert.Equal(0, context.CacheHits);
-        Assert.Equal(1, context.CacheMisses);
+        Assert.AreSame(node, seenNode);
+        Assert.AreSame(context, seenRenderContext);
+        Assert.AreEqual(0, context.CacheHits);
+        Assert.AreEqual(1, context.CacheMisses);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReconcileChild_WhenWidgetUsesCachedExtension_PropagatesPredicate()
     {
         // Arrange
@@ -202,18 +203,18 @@ public class RenderCachingTests
         var node = await context.ReconcileChildAsync(null, widget, parent);
 
         // Assert
-        Assert.NotNull(node);
+        Assert.IsNotNull(node);
         var predicate = node!.CachePredicate;
-        Assert.NotNull(predicate);
+        Assert.IsNotNull(predicate);
         var renderContext = new SurfaceRenderContext(new Surface(1, 1));
-        Assert.False(predicate!(new RenderCacheContext(node, renderContext)));
+        Assert.IsFalse(predicate!(new RenderCacheContext(node, renderContext)));
     }
 
     #endregion
 
     #region Cache Content Verification
 
-    [Fact]
+    [TestMethod]
     public void CachedSurface_ContainsRenderedContent()
     {
         // Arrange
@@ -228,14 +229,14 @@ public class RenderCachingTests
         
         // Assert - cached surface should have the text
         var cached = node.CachedSurface!;
-        Assert.Equal('H', cached[0, 0].Character[0]);
-        Assert.Equal('e', cached[1, 0].Character[0]);
-        Assert.Equal('l', cached[2, 0].Character[0]);
-        Assert.Equal('l', cached[3, 0].Character[0]);
-        Assert.Equal('o', cached[4, 0].Character[0]);
+        Assert.AreEqual('H', cached[0, 0].Character[0]);
+        Assert.AreEqual('e', cached[1, 0].Character[0]);
+        Assert.AreEqual('l', cached[2, 0].Character[0]);
+        Assert.AreEqual('l', cached[3, 0].Character[0]);
+        Assert.AreEqual('o', cached[4, 0].Character[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderChild_WithCache_ProducesSameOutput()
     {
         // Arrange
@@ -259,7 +260,7 @@ public class RenderCachingTests
         {
             for (int x = 0; x < 20; x++)
             {
-                Assert.Equal(surface1[x, y].Character, surface2[x, y].Character);
+                Assert.AreEqual(surface1[x, y].Character, surface2[x, y].Character);
             }
         }
     }
@@ -268,7 +269,7 @@ public class RenderCachingTests
 
     #region Container Caching
 
-    [Fact]
+    [TestMethod]
     public void VStackNode_WithRenderChild_CachesChildren()
     {
         // Arrange
@@ -288,14 +289,14 @@ public class RenderCachingTests
         // Assert - children should have cached surfaces after VStack uses RenderChild
         // Note: This test will fail until we migrate VStackNode to use RenderChild
         // For now, just verify the VStack renders correctly
-        Assert.Equal('L', surface[0, 0].Character[0]);
+        Assert.AreEqual('L', surface[0, 0].Character[0]);
     }
 
     #endregion
 
     #region Edge Cases
 
-    [Fact]
+    [TestMethod]
     public void RenderChild_WithNullNode_DoesNotThrow()
     {
         // Arrange
@@ -306,7 +307,7 @@ public class RenderCachingTests
         context.RenderChild(null!);
     }
 
-    [Fact]
+    [TestMethod]
     public void RenderChild_WithZeroBounds_DoesNotCache()
     {
         // Arrange
@@ -320,10 +321,10 @@ public class RenderCachingTests
         context.RenderChild(node);
         
         // Assert - zero-sized nodes shouldn't cache
-        Assert.Null(node.CachedSurface);
+        Assert.IsNull(node.CachedSurface);
     }
 
-    [Fact]
+    [TestMethod]
     public void MultipleRenders_TracksCacheStats()
     {
         // Arrange
@@ -340,8 +341,8 @@ public class RenderCachingTests
         // First frame - all misses
         context.RenderChild(node1);
         context.RenderChild(node2);
-        Assert.Equal(2, context.CacheMisses);
-        Assert.Equal(0, context.CacheHits);
+        Assert.AreEqual(2, context.CacheMisses);
+        Assert.AreEqual(0, context.CacheHits);
         
         // Clear dirty flags
         node1.ClearDirty();
@@ -351,11 +352,11 @@ public class RenderCachingTests
         // Second frame - all hits
         context.RenderChild(node1);
         context.RenderChild(node2);
-        Assert.Equal(0, context.CacheMisses);
-        Assert.Equal(2, context.CacheHits);
+        Assert.AreEqual(0, context.CacheMisses);
+        Assert.AreEqual(2, context.CacheHits);
     }
 
-    [Fact]
+    [TestMethod]
     public void MultiFrame_Simulation_CachingImprovesCacheHitRate()
     {
         // Arrange - create a realistic widget tree
@@ -375,7 +376,7 @@ public class RenderCachingTests
         // Frame 1: Cold cache (all misses expected)
         context.ResetCacheStats();
         context.RenderChild(root);
-        Assert.True(context.CacheMisses > 0, "Frame 1 should have cache misses");
+        Assert.IsTrue(context.CacheMisses > 0, "Frame 1 should have cache misses");
         totalMisses += context.CacheMisses;
         totalHits += context.CacheHits;
         
@@ -394,7 +395,7 @@ public class RenderCachingTests
             context.RenderChild(root);
             
             // With all nodes clean, we should get cache hits
-            Assert.True(context.CacheHits >= 0, $"Frame {frame} should be able to use cache");
+            Assert.IsTrue(context.CacheHits >= 0, $"Frame {frame} should be able to use cache");
             totalMisses += context.CacheMisses;
             totalHits += context.CacheHits;
         }
@@ -422,7 +423,7 @@ public class RenderCachingTests
         
         // Assert - overall hit rate should be > 0 (caching provides benefit)
         var hitRate = (double)totalHits / (totalHits + totalMisses) * 100;
-        Assert.True(totalHits > 0, $"Expected some cache hits across 20 frames. Hits={totalHits}, Misses={totalMisses}");
+        Assert.IsTrue(totalHits > 0, $"Expected some cache hits across 20 frames. Hits={totalHits}, Misses={totalMisses}");
     }
 
     #endregion

--- a/tests/Hex1b.Tests/RenderOptimizationTests.cs
+++ b/tests/Hex1b.Tests/RenderOptimizationTests.cs
@@ -7,9 +7,10 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for render optimization - verifying that clean nodes are not re-rendered.
 /// </summary>
+[TestClass]
 public class RenderOptimizationTests
 {
-    [Fact]
+    [TestMethod]
     public async Task SameWidgetInstance_ShouldNotReRender()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -37,10 +38,10 @@ public class RenderOptimizationTests
         await runTask;
 
         // Same widget instance = same node = clean = only initial render
-        Assert.Equal(1, renderCount);
+        Assert.AreEqual(1, renderCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TextBlock_WithChangingText_ShouldReRender()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -78,7 +79,7 @@ public class RenderOptimizationTests
         // The WaitUntil above already verified "Counter: 3" was displayed
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TextBlock_WithSameText_ShouldNotReRender()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -107,10 +108,10 @@ public class RenderOptimizationTests
         await runTask;
 
         // Both widgets have same content each frame - only initial render
-        Assert.Equal(1, renderCount);
+        Assert.AreEqual(1, renderCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MixedTree_StaticAndDynamic_AllNodesRenderEveryFrame()
     {
         // In Surface mode, all nodes render every frame to the surface.
@@ -150,12 +151,12 @@ public class RenderOptimizationTests
 
         // In Surface mode, static widgets render every frame (optimization is at diff level)
         // Counter goes 1, 2, 3 = 3 frames plus possible initial frame
-        Assert.True(staticRenderCount >= 3, $"Expected at least 3 renders, got {staticRenderCount}");
+        Assert.IsTrue(staticRenderCount >= 3, $"Expected at least 3 renders, got {staticRenderCount}");
         
         // Dynamic text verified by WaitUntil above - "Counter: 3" was confirmed before Ctrl+C
     }
 
-    [Fact]
+    [TestMethod]
     public async Task VStack_IndexBasedReconciliation_CreatesNewNodeWhenWidgetMoves()
     {
         // Verifies that VStack's index-based reconciliation correctly creates new nodes
@@ -204,14 +205,14 @@ public class RenderOptimizationTests
         // Frame 2: testWidget at index 0 → same node reused  
         // Frame 3: testWidget at index 1 → new node (because VStack uses index-based reconciliation)
         // Frame 4: Ctrl+C triggers another frame (testWidget still at index 1, reused)
-        Assert.Equal(4, reconcileDetails.Count);
-        Assert.True(reconcileDetails[0].isNewNode);  // Frame 1: new
-        Assert.False(reconcileDetails[1].isNewNode); // Frame 2: reused
-        Assert.True(reconcileDetails[2].isNewNode);  // Frame 3: new (widget moved to index 1)
-        Assert.False(reconcileDetails[3].isNewNode); // Frame 4: reused
+        Assert.AreEqual(4, reconcileDetails.Count);
+        Assert.IsTrue(reconcileDetails[0].isNewNode);  // Frame 1: new
+        Assert.IsFalse(reconcileDetails[1].isNewNode); // Frame 2: reused
+        Assert.IsTrue(reconcileDetails[2].isNewNode);  // Frame 3: new (widget moved to index 1)
+        Assert.IsFalse(reconcileDetails[3].isNewNode); // Frame 4: reused
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SingleFrame_RendersNewNode()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -245,12 +246,12 @@ public class RenderOptimizationTests
         await runTask;
 
         // After first frame and Ctrl+C frame, verify node state
-        Assert.NotNull(capturedNode);
-        Assert.Equal(2, reconcileCount); // Initial + Ctrl+C frame
-        Assert.Equal(1, renderCount); // Node is clean on second frame, so only 1 render
+        Assert.IsNotNull(capturedNode);
+        Assert.AreEqual(2, reconcileCount); // Initial + Ctrl+C frame
+        Assert.AreEqual(1, renderCount); // Node is clean on second frame, so only 1 render
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NodeWithChangedBounds_ShouldReRender()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -295,10 +296,10 @@ public class RenderOptimizationTests
         // - Frame 1: testWidget at index 0 → new TestWidgetNode created → rendered (1)
         // - Frame 2 (after 'a'): testWidget at index 0 → same node reused → clean → NOT rendered (1)  
         // - Frame 3 (after 'b'): testWidget at index 1 → NEW TestWidgetNode created → rendered (2)
-        Assert.Equal(2, renderCount);
+        Assert.AreEqual(2, renderCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MouseCursorMove_WithNativeCursor_ShouldNotCauseExtraRenders()
     {
         // This test verifies that mouse cursor movement using the terminal's native cursor
@@ -334,10 +335,10 @@ public class RenderOptimizationTests
         // With native terminal cursor, mouse movement should NOT trigger extra renders.
         // The widget should only render once (initial frame) since we use the terminal's
         // native cursor instead of drawing a colored block that overwrites content.
-        Assert.Equal(1, renderCount);
+        Assert.AreEqual(1, renderCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SplitterDrag_ShouldReRenderSplitterAndChildren()
     {
         // When dragging the splitter, FirstSize changes and the splitter should be marked dirty
@@ -378,10 +379,10 @@ public class RenderOptimizationTests
 
         // The widget in the right pane should re-render when the splitter moves
         // because its bounds change: initial render (1) + after drag moves bounds (2)
-        Assert.True(rightPaneRenderCount >= 2, $"Expected at least 2 renders but got {rightPaneRenderCount}. Splitter drag should trigger re-render.");
+        Assert.IsTrue(rightPaneRenderCount >= 2, $"Expected at least 2 renders but got {rightPaneRenderCount}. Splitter drag should trigger re-render.");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SplitterDrag_DividerShouldReRenderAtNewPosition()
     {
         // The splitter divider itself should re-render at its new position when dragged.
@@ -429,10 +430,10 @@ public class RenderOptimizationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(dividerMoved, "Divider should have moved to new position after drag");
+        Assert.IsTrue(dividerMoved, "Divider should have moved to new position after drag");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TerminalResize_Enlarge_ShouldNotCrash()
     {
         // Verifies that enlarging the terminal doesn't cause an index out of bounds exception
@@ -446,11 +447,11 @@ public class RenderOptimizationTests
         
         // Verify new dimensions
         var snapshot = terminal.CreateSnapshot();
-        Assert.Equal(120, snapshot.Width);
-        Assert.Equal(40, snapshot.Height);
+        Assert.AreEqual(120, snapshot.Width);
+        Assert.AreEqual(40, snapshot.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TerminalResize_ShouldTriggerFullReRender()
     {
         // When the terminal is resized, all nodes should re-render
@@ -477,10 +478,10 @@ public class RenderOptimizationTests
         await runTask;
 
         // Should render twice: initial render + after resize
-        Assert.True(renderCount >= 2, $"Expected at least 2 renders but got {renderCount}. Resize should trigger full re-render.");
+        Assert.IsTrue(renderCount >= 2, $"Expected at least 2 renders but got {renderCount}. Resize should trigger full re-render.");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ButtonHoverInPanel_ShouldPreserveBackgroundColor()
     {
         // This test verifies that when a button inside a panel becomes hovered,
@@ -529,8 +530,7 @@ public class RenderOptimizationTests
         // Check columns 15-40 on row 1 - these should still have the panel background
         var mismatches = finalSnapshot.FindMismatchedBackgrounds(15, 1, 25, 1, panelBgColor);
         
-        Assert.True(mismatches.Count == 0,
-            $"Expected cells to the right of button to have panel background color {panelBgColor}, " +
+        Assert.IsTrue(mismatches.Count == 0, $"Expected cells to the right of button to have panel background color {panelBgColor}, " +
             $"but found {mismatches.Count} cells with wrong background.\n" +
             $"Background visualization:\n{finalSnapshot.VisualizeBackgroundColors(0, 0, 40, 5, panelBgColor)}\n" +
             $"Mismatched cells: {string.Join(", ", mismatches.Select(m => $"({m.X},{m.Y})={m.ActualBackground?.ToString() ?? "null"}"))}");

--- a/tests/Hex1b.Tests/RescueNodeTests.cs
+++ b/tests/Hex1b.Tests/RescueNodeTests.cs
@@ -5,11 +5,12 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class RescueNodeTests
 {
     #region RescueNode Basic Tests
 
-    [Fact]
+    [TestMethod]
     public async Task RescueNode_NoError_MeasuresChild()
     {
         var child = new TextBlockNode { Text = "Hello" };
@@ -17,11 +18,11 @@ public class RescueNodeTests
 
         var size = node.Measure(new Constraints(0, 100, 0, 50));
 
-        Assert.Equal(5, size.Width); // "Hello" is 5 characters
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(5, size.Width); // "Hello" is 5 characters
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RescueNode_NoError_ArrangesChild()
     {
         var child = new TextBlockNode { Text = "Hello" };
@@ -30,11 +31,11 @@ public class RescueNodeTests
         node.Measure(new Constraints(0, 100, 0, 50));
         node.Arrange(new Rect(10, 20, 100, 50));
 
-        Assert.Equal(10, child.Bounds.X);
-        Assert.Equal(20, child.Bounds.Y);
+        Assert.AreEqual(10, child.Bounds.X);
+        Assert.AreEqual(20, child.Bounds.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RescueNode_NoError_RendersChild()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -52,14 +53,14 @@ public class RescueNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(snapshot.ContainsText("Hello"));
+        Assert.IsTrue(snapshot.ContainsText("Hello"));
     }
 
     #endregion
 
     #region Exception Catching Tests
 
-    [Fact]
+    [TestMethod]
     public async Task RescueNode_MeasureThrows_CapturesError()
     {
         var throwingChild = new ThrowingNode { ThrowOnMeasure = true };
@@ -72,12 +73,12 @@ public class RescueNodeTests
         // This should not throw - the error should be captured
         node.Measure(new Constraints(0, 100, 0, 50));
 
-        Assert.True(node.HasError);
-        Assert.NotNull(node.Exception);
-        Assert.Equal(RescueErrorPhase.Measure, node.ErrorPhase);
+        Assert.IsTrue(node.HasError);
+        Assert.IsNotNull(node.Exception);
+        Assert.AreEqual(RescueErrorPhase.Measure, node.ErrorPhase);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RescueNode_ArrangeThrows_CapturesError()
     {
         var throwingChild = new ThrowingNode { ThrowOnArrange = true };
@@ -92,11 +93,11 @@ public class RescueNodeTests
         // This should not throw - the error should be captured
         node.Arrange(new Rect(0, 0, 100, 50));
 
-        Assert.True(node.HasError);
-        Assert.Equal(RescueErrorPhase.Arrange, node.ErrorPhase);
+        Assert.IsTrue(node.HasError);
+        Assert.AreEqual(RescueErrorPhase.Arrange, node.ErrorPhase);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RescueNode_RenderThrows_CapturesError()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -120,15 +121,15 @@ public class RescueNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(node.HasError);
-        Assert.Equal(RescueErrorPhase.Render, node.ErrorPhase);
+        Assert.IsTrue(node.HasError);
+        Assert.AreEqual(RescueErrorPhase.Render, node.ErrorPhase);
     }
 
     #endregion
 
     #region Fallback Rendering Tests
 
-    [Fact]
+    [TestMethod]
     public async Task RescueNode_AfterError_RendersFallback()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -151,10 +152,10 @@ public class RescueNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
         // Should show error message
-        Assert.True(snapshot.ContainsText("UNHANDLED EXCEPTION"));
+        Assert.IsTrue(snapshot.ContainsText("UNHANDLED EXCEPTION"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RescueNode_CustomFallback_UsesCustomBuilder()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -181,10 +182,10 @@ public class RescueNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
         // Should show custom error message
-        Assert.True(snapshot.ContainsText("Custom error: Test exception"));
+        Assert.IsTrue(snapshot.ContainsText("Custom error: Test exception"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RescueNode_ShowDetailsTrue_IncludesStackTrace()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -207,10 +208,10 @@ public class RescueNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
         // Should show stack trace in details mode
-        Assert.True(snapshot.ContainsText("Stack Trace"));
+        Assert.IsTrue(snapshot.ContainsText("Stack Trace"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RescueNode_ShowDetailsFalse_ShowsFriendlyMessage()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -233,15 +234,15 @@ public class RescueNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
         // Should show friendly message without details
-        Assert.True(snapshot.ContainsText("Something went wrong"));
-        Assert.False(snapshot.ContainsText("Stack Trace"));
+        Assert.IsTrue(snapshot.ContainsText("Something went wrong"));
+        Assert.IsFalse(snapshot.ContainsText("Stack Trace"));
     }
 
     #endregion
 
     #region Focus Navigation Tests
 
-    [Fact]
+    [TestMethod]
     public async Task RescueNode_NoError_GetsFocusableNodesFromChild()
     {
         var button = new ButtonNode { Label = "Click me" };
@@ -249,11 +250,11 @@ public class RescueNodeTests
 
         var focusable = node.GetFocusableNodes().ToList();
 
-        Assert.Single(focusable);
-        Assert.Same(button, focusable[0]);
+        TestSeq.Single(focusable);
+        Assert.AreSame(button, focusable[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RescueNode_AfterError_ReturnsEmptyFocusableNodes()
     {
         var button = new ButtonNode { Label = "Click me" };
@@ -268,14 +269,14 @@ public class RescueNodeTests
         // No fallback child is set, so no focusable nodes
         var focusable = node.GetFocusableNodes().ToList();
 
-        Assert.Empty(focusable);
+        Assert.IsEmpty(focusable);
     }
 
     #endregion
 
     #region RescueWidget Tests
 
-    [Fact]
+    [TestMethod]
     public async Task RescueWidget_Reconcile_CreatesRescueNode()
     {
         var childWidget = new TextBlockWidget("Test");
@@ -284,10 +285,10 @@ public class RescueNodeTests
         var context = ReconcileContext.CreateRoot();
         var node = widget.ReconcileAsync(null, context).GetAwaiter().GetResult();
 
-        Assert.IsType<RescueNode>(node);
+        TestSeq.IsType<RescueNode>(node);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RescueWidget_Reconcile_ReusesExistingNode()
     {
         var childWidget = new TextBlockWidget("Test");
@@ -297,10 +298,10 @@ public class RescueNodeTests
         var node1 = widget.ReconcileAsync(null, context).GetAwaiter().GetResult() as RescueNode;
         var node2 = widget.ReconcileAsync(node1, context).GetAwaiter().GetResult() as RescueNode;
 
-        Assert.Same(node1, node2);
+        Assert.AreSame(node1, node2);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RescueWidget_WhenInErrorState_ReconcilesFallbackInstead()
     {
         var childWidget = new TextBlockWidget("Test");
@@ -316,22 +317,22 @@ public class RescueNodeTests
         var node2 = widget.ReconcileAsync(node, context).GetAwaiter().GetResult() as RescueNode;
 
         // Should have fallback child, not main child
-        Assert.NotNull(node2?.FallbackChild);
+        Assert.IsNotNull(node2?.FallbackChild);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RescueWidget_GetExpectedNodeType_ReturnsRescueNode()
     {
         var widget = new RescueWidget(new TextBlockWidget("Test"));
 
-        Assert.Equal(typeof(RescueNode), widget.GetExpectedNodeType());
+        Assert.AreEqual(typeof(RescueNode), widget.GetExpectedNodeType());
     }
 
     #endregion
 
     #region Event Handler Tests
 
-    [Fact]
+    [TestMethod]
     public async Task RescueWidget_OnRescue_CalledWhenErrorCaptured()
     {
         var capturedArgs = (RescueEventArgs?)null;
@@ -346,12 +347,12 @@ public class RescueNodeTests
         var exception = new InvalidOperationException("Test error");
         node!.CaptureErrorAsync(exception, RescueErrorPhase.Render).GetAwaiter().GetResult();
 
-        Assert.NotNull(capturedArgs);
-        Assert.Same(exception, capturedArgs.Exception);
-        Assert.Equal(RescueErrorPhase.Render, capturedArgs.Phase);
+        Assert.IsNotNull(capturedArgs);
+        Assert.AreSame(exception, capturedArgs.Exception);
+        Assert.AreEqual(RescueErrorPhase.Render, capturedArgs.Phase);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RescueWidget_OnReset_CalledAfterReset()
     {
         var capturedArgs = (RescueResetEventArgs?)null;
@@ -369,26 +370,26 @@ public class RescueNodeTests
         // Reset
         await node.ResetAsync();
 
-        Assert.NotNull(capturedArgs);
-        Assert.Same(exception, capturedArgs.Exception);
-        Assert.Equal(RescueErrorPhase.Measure, capturedArgs.Phase);
-        Assert.False(node.HasError); // Should be cleared
+        Assert.IsNotNull(capturedArgs);
+        Assert.AreSame(exception, capturedArgs.Exception);
+        Assert.AreEqual(RescueErrorPhase.Measure, capturedArgs.Phase);
+        Assert.IsFalse(node.HasError); // Should be cleared
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RescueWidget_WithFallback_UsesCustomFallback()
     {
         var widget = new RescueWidget(new TextBlockWidget("Test"))
             .Fallback(rescue => new TextBlockWidget($"Error: {rescue.Exception?.Message}"));
 
-        Assert.NotNull(widget.FallbackBuilder);
+        Assert.IsNotNull(widget.FallbackBuilder);
     }
 
     #endregion
 
     #region Integration Tests
 
-    [Fact]
+    [TestMethod]
     public async Task RescueNode_AfterReset_ResumesNormalRendering()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -403,7 +404,7 @@ public class RescueNodeTests
 
         // First measure throws
         node.Measure(new Constraints(0, 100, 0, 50));
-        Assert.True(node.HasError);
+        Assert.IsTrue(node.HasError);
 
         // Reset and try again
         node.Reset();
@@ -414,10 +415,10 @@ public class RescueNodeTests
         node.Measure(new Constraints(0, 100, 0, 50));
 
         // State should still be clear after successful operation
-        Assert.False(node.HasError);
+        Assert.IsFalse(node.HasError);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RescueWidget_ChainedWithOtherWidgets_WorksCorrectly()
     {
         var innerWidget = new TextBlockWidget("Content");
@@ -428,26 +429,26 @@ public class RescueNodeTests
         var context = ReconcileContext.CreateRoot();
         var node = borderedWidget.ReconcileAsync(null, context).GetAwaiter().GetResult() as BorderNode;
 
-        Assert.NotNull(node);
-        Assert.IsType<RescueNode>(node?.Child);
+        Assert.IsNotNull(node);
+        TestSeq.IsType<RescueNode>(node?.Child);
     }
 
     #endregion
 
     #region RescueContext Tests
 
-    [Fact]
+    [TestMethod]
     public async Task RescueContext_ExposesExceptionInfo()
     {
         var exception = new ArgumentException("Test arg");
 
         var ctx = new RescueContext(exception, RescueErrorPhase.Arrange, () => { });
 
-        Assert.Same(exception, ctx.Exception);
-        Assert.Equal(RescueErrorPhase.Arrange, ctx.ErrorPhase);
+        Assert.AreSame(exception, ctx.Exception);
+        Assert.AreEqual(RescueErrorPhase.Arrange, ctx.ErrorPhase);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RescueContext_Reset_InvokesCallback()
     {
         var resetCalled = false;
@@ -455,7 +456,7 @@ public class RescueNodeTests
 
         ctx.Reset();
 
-        Assert.True(resetCalled);
+        Assert.IsTrue(resetCalled);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/ResponsiveNodeTests.cs
+++ b/tests/Hex1b.Tests/ResponsiveNodeTests.cs
@@ -8,6 +8,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for ResponsiveNode layout, rendering, and condition evaluation.
 /// </summary>
+[TestClass]
 public class ResponsiveNodeTests
 {
     private static Hex1bRenderContext CreateContext(IHex1bAppTerminalWorkloadAdapter workload)
@@ -15,7 +16,7 @@ public class ResponsiveNodeTests
         return new Hex1bRenderContext(workload);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_FirstMatchingCondition_ReturnsChildSize()
     {
         var node = new ResponsiveNode
@@ -35,12 +36,12 @@ public class ResponsiveNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // Should measure the "Visible" text (7 chars)
-        Assert.Equal(7, size.Width);
-        Assert.Equal(1, size.Height);
-        Assert.Equal(1, node.ActiveBranchIndex);
+        Assert.AreEqual(7, size.Width);
+        Assert.AreEqual(1, size.Height);
+        Assert.AreEqual(1, node.ActiveBranchIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_FirstConditionTrue_SelectsFirst()
     {
         var node = new ResponsiveNode
@@ -59,11 +60,11 @@ public class ResponsiveNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(5, size.Width); // "First"
-        Assert.Equal(0, node.ActiveBranchIndex);
+        Assert.AreEqual(5, size.Width); // "First"
+        Assert.AreEqual(0, node.ActiveBranchIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_NoMatchingCondition_ReturnsZero()
     {
         var node = new ResponsiveNode
@@ -82,12 +83,12 @@ public class ResponsiveNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(0, size.Width);
-        Assert.Equal(0, size.Height);
-        Assert.Equal(-1, node.ActiveBranchIndex);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(0, size.Height);
+        Assert.AreEqual(-1, node.ActiveBranchIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_EmptyBranches_ReturnsZero()
     {
         var node = new ResponsiveNode
@@ -98,12 +99,12 @@ public class ResponsiveNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(0, size.Width);
-        Assert.Equal(0, size.Height);
-        Assert.Equal(-1, node.ActiveBranchIndex);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(0, size.Height);
+        Assert.AreEqual(-1, node.ActiveBranchIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_RespectsConstraints()
     {
         var node = new ResponsiveNode
@@ -120,11 +121,11 @@ public class ResponsiveNodeTests
 
         var size = node.Measure(new Constraints(0, 10, 0, 5));
 
-        Assert.True(size.Width <= 10);
-        Assert.True(size.Height <= 5);
+        Assert.IsTrue(size.Width <= 10);
+        Assert.IsTrue(size.Height <= 5);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_ActiveChildGetsFullBounds()
     {
         var child1 = new TextBlockNode { Text = "Hidden" };
@@ -144,11 +145,11 @@ public class ResponsiveNodeTests
         node.Arrange(bounds);
 
         // Only the active child should have bounds set
-        Assert.Equal(bounds, child2.Bounds);
-        Assert.Equal(bounds, node.Bounds);
+        Assert.AreEqual(bounds, child2.Bounds);
+        Assert.AreEqual(bounds, node.Bounds);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_OnlyRendersActiveChild()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -183,7 +184,7 @@ public class ResponsiveNodeTests
         Assert.DoesNotContain("Hidden", screenText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_NoMatchingCondition_RendersNothing()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -214,7 +215,7 @@ public class ResponsiveNodeTests
         Assert.DoesNotContain("Hidden", screenText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_ConditionReceivesAvailableSize()
     {
         int receivedWidth = 0;
@@ -233,11 +234,11 @@ public class ResponsiveNodeTests
 
         node.Measure(new Constraints(0, 100, 0, 50));
 
-        Assert.Equal(100, receivedWidth);
-        Assert.Equal(50, receivedHeight);
+        Assert.AreEqual(100, receivedWidth);
+        Assert.AreEqual(50, receivedHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_WidthBasedCondition_SelectsCorrectBranch()
     {
         var node = new ResponsiveNode
@@ -258,18 +259,18 @@ public class ResponsiveNodeTests
 
         // Wide layout
         node.Measure(new Constraints(0, 120, 0, 30));
-        Assert.Equal(0, node.ActiveBranchIndex);
+        Assert.AreEqual(0, node.ActiveBranchIndex);
 
         // Medium layout
         node.Measure(new Constraints(0, 80, 0, 30));
-        Assert.Equal(1, node.ActiveBranchIndex);
+        Assert.AreEqual(1, node.ActiveBranchIndex);
 
         // Narrow layout
         node.Measure(new Constraints(0, 40, 0, 30));
-        Assert.Equal(2, node.ActiveBranchIndex);
+        Assert.AreEqual(2, node.ActiveBranchIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_ReturnsOnlyActiveChildFocusables()
     {
         var button1 = new ButtonNode { Label = "Hidden" };
@@ -289,12 +290,12 @@ public class ResponsiveNodeTests
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Single(focusables);
+        TestSeq.Single(focusables);
         Assert.Contains(button2, focusables);
         Assert.DoesNotContain(button1, focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_NoMatchingCondition_ReturnsEmpty()
     {
         var button = new ButtonNode { Label = "Hidden" };
@@ -310,10 +311,10 @@ public class ResponsiveNodeTests
         node.Measure(Constraints.Unbounded);
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Empty(focusables);
+        Assert.IsEmpty(focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_PassesToActiveChild()
     {
         var clicked = false;
@@ -342,11 +343,11 @@ public class ResponsiveNodeTests
         // Use InputRouter to route input to the focused child
         var result = await InputRouter.RouteInputAsync(node, new Hex1bKeyEvent(Hex1bKey.Enter, '\r', Hex1bModifiers.None), focusRing, routerState, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(clicked);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_NoActiveChild_ReturnsFalse()
     {
         var node = new ResponsiveNode
@@ -364,18 +365,18 @@ public class ResponsiveNodeTests
         node.Measure(Constraints.Unbounded);
         var result = node.HandleInput(new Hex1bKeyEvent(Hex1bKey.A, 'A', Hex1bModifiers.None));
 
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task IsFocusable_ReturnsFalse()
     {
         var node = new ResponsiveNode();
 
-        Assert.False(node.IsFocusable);
+        Assert.IsFalse(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ActiveChild_ReturnsCorrectNode()
     {
         var child1 = new TextBlockNode { Text = "First" };
@@ -392,10 +393,10 @@ public class ResponsiveNodeTests
 
         node.Measure(Constraints.Unbounded);
 
-        Assert.Same(child2, node.ActiveChild);
+        Assert.AreSame(child2, node.ActiveChild);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ActiveChild_NoMatch_ReturnsNull()
     {
         var node = new ResponsiveNode
@@ -412,10 +413,10 @@ public class ResponsiveNodeTests
 
         node.Measure(Constraints.Unbounded);
 
-        Assert.Null(node.ActiveChild);
+        Assert.IsNull(node.ActiveChild);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NestedResponsive_WorksCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -459,7 +460,7 @@ public class ResponsiveNodeTests
         Assert.Contains("Inner", snapshot.GetScreenText());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Responsive_WithOtherwiseFallback_ShowsFallback()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -496,7 +497,7 @@ public class ResponsiveNodeTests
 
     #region Integration Tests with Fluent API
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Responsive_WideLayout_ShowsWideContent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -522,11 +523,11 @@ public class ResponsiveNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Wide View: Full Details"));
-        Assert.False(snapshot.ContainsText("Compact"));
+        Assert.IsTrue(snapshot.ContainsText("Wide View: Full Details"));
+        Assert.IsFalse(snapshot.ContainsText("Compact"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Responsive_NarrowLayout_ShowsNarrowContent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -552,11 +553,11 @@ public class ResponsiveNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Compact View"));
-        Assert.False(snapshot.ContainsText("Wide View"));
+        Assert.IsTrue(snapshot.ContainsText("Compact View"));
+        Assert.IsFalse(snapshot.ContainsText("Wide View"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Responsive_ThreeTiers_SelectsCorrectTier()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -584,12 +585,12 @@ public class ResponsiveNodeTests
         await runTask;
 
         // 75 width should match Medium tier
-        Assert.True(snapshot.ContainsText("Medium"));
-        Assert.False(snapshot.ContainsText("Large"));
-        Assert.False(snapshot.ContainsText("Small"));
+        Assert.IsTrue(snapshot.ContainsText("Medium"));
+        Assert.IsFalse(snapshot.ContainsText("Large"));
+        Assert.IsFalse(snapshot.ContainsText("Small"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Responsive_WhenWidth_ConditionWorks()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -616,11 +617,11 @@ public class ResponsiveNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Wide"));
-        Assert.False(snapshot.ContainsText("Very Wide"));
+        Assert.IsTrue(snapshot.ContainsText("Wide"));
+        Assert.IsFalse(snapshot.ContainsText("Very Wide"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Responsive_WithFullCondition_UsesWidthAndHeight()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -646,10 +647,10 @@ public class ResponsiveNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Large Screen"));
+        Assert.IsTrue(snapshot.ContainsText("Large Screen"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Responsive_InsideBorder_ReceivesConstrainedSize()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -678,11 +679,11 @@ public class ResponsiveNodeTests
         await runTask;
 
         // Border takes 2 columns, so inner space is 48, which is < 100
-        Assert.True(snapshot.ContainsText("Narrow"));
-        Assert.True(snapshot.ContainsText("Container"));
+        Assert.IsTrue(snapshot.ContainsText("Narrow"));
+        Assert.IsTrue(snapshot.ContainsText("Container"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Responsive_WithFocusableChildren_FocusWorks()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -710,10 +711,10 @@ public class ResponsiveNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(clicked);
+        Assert.IsTrue(clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Responsive_WithTextBox_InputWorks()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -742,10 +743,10 @@ public class ResponsiveNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("Responsive input", text);
+        Assert.AreEqual("Responsive input", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Responsive_InVStack_RendersCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -775,12 +776,12 @@ public class ResponsiveNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Header"));
-        Assert.True(snapshot.ContainsText("Wide Content"));
-        Assert.True(snapshot.ContainsText("Footer"));
+        Assert.IsTrue(snapshot.ContainsText("Header"));
+        Assert.IsTrue(snapshot.ContainsText("Wide Content"));
+        Assert.IsTrue(snapshot.ContainsText("Footer"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Responsive_NoMatchingConditions_RendersNothing()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -807,11 +808,11 @@ public class ResponsiveNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.False(terminal.CreateSnapshot().ContainsText("Very Wide"));
-        Assert.False(terminal.CreateSnapshot().ContainsText("Wide"));
+        Assert.IsFalse(terminal.CreateSnapshot().ContainsText("Very Wide"));
+        Assert.IsFalse(terminal.CreateSnapshot().ContainsText("Wide"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Responsive_WithList_NavigationWorks()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -841,10 +842,10 @@ public class ResponsiveNodeTests
         await runTask;
 
         // Verify second item is selected via rendered output
-        Assert.True(snapshot.ContainsText("> Item 2"));
+        Assert.IsTrue(snapshot.ContainsText("> Item 2"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Responsive_DifferentLayoutsForDifferentWidgets()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -881,11 +882,11 @@ public class ResponsiveNodeTests
         await runTask;
 
         // Wide layout uses HStack
-        Assert.True(snapshot.ContainsText("Left Panel"));
-        Assert.True(snapshot.ContainsText("Right Panel"));
+        Assert.IsTrue(snapshot.ContainsText("Left Panel"));
+        Assert.IsTrue(snapshot.ContainsText("Right Panel"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Responsive_NarrowFallsBackToVStack()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -922,11 +923,11 @@ public class ResponsiveNodeTests
         await runTask;
 
         // Narrow layout uses VStack
-        Assert.True(snapshot.ContainsText("Top Panel"));
-        Assert.True(snapshot.ContainsText("Bottom Panel"));
+        Assert.IsTrue(snapshot.ContainsText("Top Panel"));
+        Assert.IsTrue(snapshot.ContainsText("Bottom Panel"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Responsive_InSplitter_WorksCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -956,11 +957,11 @@ public class ResponsiveNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Wide Left"));
-        Assert.True(snapshot.ContainsText("Right Panel"));
+        Assert.IsTrue(snapshot.ContainsText("Wide Left"));
+        Assert.IsTrue(snapshot.ContainsText("Right Panel"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Responsive_WithState_AccessesStateCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -986,7 +987,7 @@ public class ResponsiveNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Hello from state"));
+        Assert.IsTrue(snapshot.ContainsText("Hello from state"));
     }
 
     #endregion

--- a/tests/Hex1b.Tests/ScrollPanelNodeTests.cs
+++ b/tests/Hex1b.Tests/ScrollPanelNodeTests.cs
@@ -10,6 +10,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Comprehensive tests for ScrollPanelNode layout, rendering, scrolling, and focus handling.
 /// </summary>
+[TestClass]
 public class ScrollPanelNodeTests
 {
     private static Hex1bRenderContext CreateContext(IHex1bAppTerminalWorkloadAdapter workload, Hex1bTheme? theme = null)
@@ -39,17 +40,17 @@ public class ScrollPanelNodeTests
 
     #region ScrollPanelNode Internal State Tests
 
-    [Fact]
+    [TestMethod]
     public async Task ScrollNode_InitialState_IsZero()
     {
         var node = new ScrollPanelNode();
 
-        Assert.Equal(0, node.Offset);
-        Assert.Equal(0, node.ContentSize);
-        Assert.Equal(0, node.ViewportSize);
+        Assert.AreEqual(0, node.Offset);
+        Assert.AreEqual(0, node.ContentSize);
+        Assert.AreEqual(0, node.ViewportSize);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ScrollNode_IsScrollable_WhenContentExceedsViewport()
     {
         var node = new ScrollPanelNode
@@ -61,10 +62,10 @@ public class ScrollPanelNodeTests
         node.Arrange(new Rect(0, 0, 40, 10));
 
         // After arrange, ContentSize and ViewportSize should be set
-        Assert.True(node.ContentSize > node.ViewportSize);
+        Assert.IsTrue(node.ContentSize > node.ViewportSize);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ScrollNode_MaxOffset_IsCorrect()
     {
         var node = new ScrollPanelNode
@@ -76,14 +77,14 @@ public class ScrollPanelNodeTests
         node.Arrange(new Rect(0, 0, 40, 10));
 
         // MaxOffset = ContentSize - ViewportSize = 25 - 10 = 15
-        Assert.Equal(15, node.ContentSize - node.ViewportSize);
+        Assert.AreEqual(15, node.ContentSize - node.ViewportSize);
     }
 
     #endregion
 
     #region Measurement Tests - Vertical Scroll
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_Vertical_ContentSmallerThanViewport_ReturnsFitSize()
     {
         var node = new ScrollPanelNode
@@ -96,11 +97,11 @@ public class ScrollPanelNodeTests
         var size = node.Measure(new Constraints(0, 30, 0, 20));
 
         // Content is 5 lines, viewport allows 20, so no need for full space
-        Assert.True(size.Height <= 20);
-        Assert.Equal(5, node.ContentSize);
+        Assert.IsTrue(size.Height <= 20);
+        Assert.AreEqual(5, node.ContentSize);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_Vertical_ContentLargerThanViewport_UsesConstraints()
     {
         var node = new ScrollPanelNode
@@ -112,11 +113,11 @@ public class ScrollPanelNodeTests
 
         var size = node.Measure(new Constraints(0, 30, 0, 20));
 
-        Assert.Equal(20, size.Height);
-        Assert.Equal(50, node.ContentSize);
+        Assert.AreEqual(20, size.Height);
+        Assert.AreEqual(50, node.ContentSize);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_Vertical_IncludesScrollbarWidth()
     {
         var child = new TextBlockNode { Text = "Content" };
@@ -141,10 +142,10 @@ public class ScrollPanelNodeTests
         var size = scrollableNode.Measure(new Constraints(0, 30, 0, 20));
 
         // Width should include space for scrollbar
-        Assert.True(size.Width > 0);
+        Assert.IsTrue(size.Width > 0);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_Vertical_NoScrollbar_DoesNotIncludeScrollbarWidth()
     {
         var child = new TextBlockNode { Text = "Content" };
@@ -158,14 +159,14 @@ public class ScrollPanelNodeTests
         var size = node.Measure(new Constraints(0, 30, 0, 20));
 
         // Width should be just content width
-        Assert.Equal(7, size.Width);
+        Assert.AreEqual(7, size.Width);
     }
 
     #endregion
 
     #region Measurement Tests - Horizontal Scroll
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_Horizontal_ContentWiderThanViewport_UsesConstraints()
     {
         var node = new ScrollPanelNode
@@ -177,10 +178,10 @@ public class ScrollPanelNodeTests
 
         var size = node.Measure(new Constraints(0, 40, 0, 10));
 
-        Assert.Equal(40, size.Width);
+        Assert.AreEqual(40, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_Horizontal_IncludesScrollbarHeight()
     {
         var node = new ScrollPanelNode
@@ -193,14 +194,14 @@ public class ScrollPanelNodeTests
         var size = node.Measure(new Constraints(0, 20, 0, 10));
 
         // Height should include scrollbar (1)
-        Assert.True(size.Height >= 2);
+        Assert.IsTrue(size.Height >= 2);
     }
 
     #endregion
 
     #region Arrange Tests - Vertical Scroll
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_Vertical_SetsViewportSize()
     {
         var node = new ScrollPanelNode
@@ -213,10 +214,10 @@ public class ScrollPanelNodeTests
         node.Measure(new Constraints(0, 30, 0, 10));
         node.Arrange(new Rect(0, 0, 30, 10));
 
-        Assert.Equal(10, node.ViewportSize);
+        Assert.AreEqual(10, node.ViewportSize);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_Vertical_ChildPositionedWithOffset()
     {
         var child = CreateTallContent(20);
@@ -235,10 +236,10 @@ public class ScrollPanelNodeTests
         node.Arrange(new Rect(0, 0, 30, 10));
 
         // Child should be positioned above the viewport by the offset
-        Assert.Equal(-5, child.Bounds.Y);
+        Assert.AreEqual(-5, child.Bounds.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_Vertical_ClampsOffsetToMaxOffset()
     {
         var node = new ScrollPanelNode
@@ -255,14 +256,14 @@ public class ScrollPanelNodeTests
         node.SetOffset(100);
 
         // Should be clamped to max (20 - 10 = 10)
-        Assert.Equal(10, node.Offset);
+        Assert.AreEqual(10, node.Offset);
     }
 
     #endregion
 
     #region Arrange Tests - Horizontal Scroll
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_Horizontal_SetsViewportSize()
     {
         var node = new ScrollPanelNode
@@ -276,10 +277,10 @@ public class ScrollPanelNodeTests
         node.Arrange(new Rect(0, 0, 30, 10));
 
         // Viewport width is 30 (minus scrollbar height doesn't affect width)
-        Assert.Equal(30, node.ViewportSize);
+        Assert.AreEqual(30, node.ViewportSize);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_Horizontal_ChildPositionedWithOffset()
     {
         var child = CreateWideContent(20);
@@ -298,14 +299,14 @@ public class ScrollPanelNodeTests
         node.Arrange(new Rect(0, 0, 30, 10));
 
         // Child should be positioned to the left of the viewport by the offset
-        Assert.Equal(-10, child.Bounds.X);
+        Assert.AreEqual(-10, child.Bounds.X);
     }
 
     #endregion
 
     #region Rendering Tests - Vertical Scrollbar
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Vertical_ShowsScrollbar_WhenContentExceedsViewport()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -331,7 +332,7 @@ public class ScrollPanelNodeTests
         Assert.Contains("▉", terminal.CreateSnapshot().GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Vertical_ShowsThumbAndTrack()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -354,14 +355,14 @@ public class ScrollPanelNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(snapshot.ContainsText("│"), "Should show track");
-        Assert.True(snapshot.ContainsText("▉"), "Should show thumb");
+        Assert.IsTrue(snapshot.ContainsText("│"), "Should show track");
+        Assert.IsTrue(snapshot.ContainsText("▉"), "Should show thumb");
         // No arrows in the new minimal style
         Assert.DoesNotContain("▲", snapshot.GetText());
         Assert.DoesNotContain("▼", snapshot.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Vertical_NoScrollbar_WhenContentFitsViewport()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -389,7 +390,7 @@ public class ScrollPanelNodeTests
         Assert.DoesNotContain("▉", snapshot.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Vertical_ClipsContentBeyondViewport()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -430,7 +431,7 @@ public class ScrollPanelNodeTests
         Assert.DoesNotContain("Line 6", snapshot.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Vertical_WhenScrolled_ShowsOffsetContent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -489,7 +490,7 @@ public class ScrollPanelNodeTests
 
     #region Rendering Tests - Horizontal Scrollbar
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Horizontal_ShowsScrollbar_WhenContentExceedsViewport()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -515,7 +516,7 @@ public class ScrollPanelNodeTests
         Assert.Contains("■", terminal.CreateSnapshot().GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Horizontal_ShowsThumbAndTrack()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -548,7 +549,7 @@ public class ScrollPanelNodeTests
 
     #region Theming Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithCustomThumbColor_AppliesColor()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -575,10 +576,10 @@ public class ScrollPanelNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
         // Cyan foreground color should be applied
-        Assert.True(snapshot.HasForegroundColor(Hex1bColor.Cyan));
+        Assert.IsTrue(snapshot.HasForegroundColor(Hex1bColor.Cyan));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WhenFocused_UsesFocusedThumbColor()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -606,22 +607,22 @@ public class ScrollPanelNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
         // Yellow foreground color should be applied
-        Assert.True(snapshot.HasForegroundColor(Hex1bColor.Yellow));
+        Assert.IsTrue(snapshot.HasForegroundColor(Hex1bColor.Yellow));
     }
 
     #endregion
 
     #region Focus Tests
 
-    [Fact]
+    [TestMethod]
     public async Task IsFocusable_ReturnsTrue()
     {
         var node = new ScrollPanelNode();
 
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_IncludesSelfFirst()
     {
         var node = new ScrollPanelNode
@@ -631,10 +632,10 @@ public class ScrollPanelNodeTests
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Same(node, focusables[0]);
+        Assert.AreSame(node, focusables[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_IncludesChildFocusables()
     {
         var button = new ButtonNode { Label = "Button" };
@@ -648,7 +649,7 @@ public class ScrollPanelNodeTests
         Assert.Contains(button, focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SetInitialFocus_FocusesSelf()
     {
         var button = new ButtonNode { Label = "Button" };
@@ -659,15 +660,15 @@ public class ScrollPanelNodeTests
 
         node.SetInitialFocus();
 
-        Assert.True(node.IsFocused);
-        Assert.False(button.IsFocused);
+        Assert.IsTrue(node.IsFocused);
+        Assert.IsFalse(button.IsFocused);
     }
 
     #endregion
 
     #region Input Handling - Vertical Scroll
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_DownArrow_WhenFocused_ScrollsDown()
     {
         var node = new ScrollPanelNode
@@ -681,11 +682,11 @@ public class ScrollPanelNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.DownArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(1, node.Offset);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(1, node.Offset);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_UpArrow_WhenFocused_ScrollsUp()
     {
         var node = new ScrollPanelNode
@@ -700,11 +701,11 @@ public class ScrollPanelNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.UpArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(4, node.Offset);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(4, node.Offset);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_PageDown_WhenFocused_ScrollsByViewportSize()
     {
         var node = new ScrollPanelNode
@@ -718,11 +719,11 @@ public class ScrollPanelNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.PageDown, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(9, node.Offset); // ViewportSize - 1
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(9, node.Offset); // ViewportSize - 1
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Home_WhenFocused_ScrollsToStart()
     {
         var node = new ScrollPanelNode
@@ -737,11 +738,11 @@ public class ScrollPanelNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Home, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(0, node.Offset);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(0, node.Offset);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_End_WhenFocused_ScrollsToEnd()
     {
         var node = new ScrollPanelNode
@@ -755,11 +756,11 @@ public class ScrollPanelNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.End, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(40, node.Offset); // ContentSize - ViewportSize = 50 - 10
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(40, node.Offset); // ContentSize - ViewportSize = 50 - 10
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_DownArrow_ScrollsRegardlessOfPanelFocus()
     {
         // The ScrollPanelNode no longer guards its scroll handlers with an IsFocused check.
@@ -777,15 +778,15 @@ public class ScrollPanelNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.DownArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(1, node.Offset);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(1, node.Offset);
     }
 
     #endregion
 
     #region Input Handling - Horizontal Scroll
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_RightArrow_WhenFocused_ScrollsRight()
     {
         var node = new ScrollPanelNode
@@ -799,11 +800,11 @@ public class ScrollPanelNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(1, node.Offset);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(1, node.Offset);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_LeftArrow_WhenFocused_ScrollsLeft()
     {
         var node = new ScrollPanelNode
@@ -818,11 +819,11 @@ public class ScrollPanelNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(9, node.Offset);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(9, node.Offset);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Horizontal_UpDownArrows_DoNotScroll()
     {
         var node = new ScrollPanelNode
@@ -837,15 +838,15 @@ public class ScrollPanelNodeTests
         // Up/down arrows match bindings but don't scroll horizontal
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.UpArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(0, node.Offset); // No scroll
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(0, node.Offset); // No scroll
     }
 
     #endregion
 
     #region OnScroll Event Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_DownArrow_FiresScrollEvent()
     {
         ScrollChangedEventArgs? receivedArgs = null;
@@ -862,12 +863,12 @@ public class ScrollPanelNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.DownArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.NotNull(receivedArgs);
-        Assert.Equal(1, receivedArgs!.Offset);
-        Assert.Equal(0, receivedArgs.PreviousOffset);
+        Assert.IsNotNull(receivedArgs);
+        Assert.AreEqual(1, receivedArgs!.Offset);
+        Assert.AreEqual(0, receivedArgs.PreviousOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ScrollEvent_ProvidesCorrectStateInfo()
     {
         ScrollChangedEventArgs? receivedArgs = null;
@@ -886,18 +887,18 @@ public class ScrollPanelNodeTests
         // Scroll down one more
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.DownArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.NotNull(receivedArgs);
-        Assert.Equal(21, receivedArgs!.Offset);
-        Assert.Equal(20, receivedArgs.PreviousOffset);
-        Assert.Equal(50, receivedArgs.ContentSize);
-        Assert.Equal(10, receivedArgs.ViewportSize);
-        Assert.Equal(40, receivedArgs.MaxOffset);
-        Assert.True(receivedArgs.IsScrollable);
-        Assert.False(receivedArgs.IsAtStart);
-        Assert.False(receivedArgs.IsAtEnd);
+        Assert.IsNotNull(receivedArgs);
+        Assert.AreEqual(21, receivedArgs!.Offset);
+        Assert.AreEqual(20, receivedArgs.PreviousOffset);
+        Assert.AreEqual(50, receivedArgs.ContentSize);
+        Assert.AreEqual(10, receivedArgs.ViewportSize);
+        Assert.AreEqual(40, receivedArgs.MaxOffset);
+        Assert.IsTrue(receivedArgs.IsScrollable);
+        Assert.IsFalse(receivedArgs.IsAtStart);
+        Assert.IsFalse(receivedArgs.IsAtEnd);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ScrollEvent_IsAtStart_WhenAtTop()
     {
         ScrollChangedEventArgs? receivedArgs = null;
@@ -916,13 +917,13 @@ public class ScrollPanelNodeTests
         // Scroll up to start
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.UpArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.NotNull(receivedArgs);
-        Assert.Equal(0, receivedArgs!.Offset);
-        Assert.True(receivedArgs.IsAtStart);
-        Assert.False(receivedArgs.IsAtEnd);
+        Assert.IsNotNull(receivedArgs);
+        Assert.AreEqual(0, receivedArgs!.Offset);
+        Assert.IsTrue(receivedArgs.IsAtStart);
+        Assert.IsFalse(receivedArgs.IsAtEnd);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ScrollEvent_IsAtEnd_WhenAtBottom()
     {
         ScrollChangedEventArgs? receivedArgs = null;
@@ -941,17 +942,17 @@ public class ScrollPanelNodeTests
         // Scroll down to end
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.DownArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.NotNull(receivedArgs);
-        Assert.Equal(40, receivedArgs!.Offset);
-        Assert.False(receivedArgs.IsAtStart);
-        Assert.True(receivedArgs.IsAtEnd);
+        Assert.IsNotNull(receivedArgs);
+        Assert.AreEqual(40, receivedArgs!.Offset);
+        Assert.IsFalse(receivedArgs.IsAtStart);
+        Assert.IsTrue(receivedArgs.IsAtEnd);
     }
 
     #endregion
 
     #region ILayoutProvider Tests
 
-    [Fact]
+    [TestMethod]
     public async Task ShouldRenderAt_WithinViewport_ReturnsTrue()
     {
         var node = new ScrollPanelNode
@@ -962,10 +963,10 @@ public class ScrollPanelNodeTests
         node.Measure(Constraints.Tight(40, 10));
         node.Arrange(new Rect(5, 5, 40, 10));
 
-        Assert.True(node.ShouldRenderAt(10, 10)); // Within viewport
+        Assert.IsTrue(node.ShouldRenderAt(10, 10)); // Within viewport
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ShouldRenderAt_OutsideViewport_ReturnsFalse()
     {
         var node = new ScrollPanelNode
@@ -976,10 +977,10 @@ public class ScrollPanelNodeTests
         node.Measure(Constraints.Tight(40, 10));
         node.Arrange(new Rect(5, 5, 40, 10));
 
-        Assert.False(node.ShouldRenderAt(10, 20)); // Below viewport (Y >= 15)
+        Assert.IsFalse(node.ShouldRenderAt(10, 20)); // Below viewport (Y >= 15)
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ClipString_ClipsHorizontally()
     {
         var node = new ScrollPanelNode
@@ -992,10 +993,10 @@ public class ScrollPanelNodeTests
 
         var (adjustedX, clippedText) = node.ClipString(0, 0, "This is a very long line of text");
 
-        Assert.True(clippedText.Length <= 10);
+        Assert.IsTrue(clippedText.Length <= 10);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ClipString_OutsideVerticalBounds_ReturnsEmpty()
     {
         var node = new ScrollPanelNode
@@ -1008,14 +1009,14 @@ public class ScrollPanelNodeTests
 
         var (_, clippedText) = node.ClipString(0, 15, "Text outside viewport");
 
-        Assert.Equal("", clippedText);
+        Assert.AreEqual("", clippedText);
     }
 
     #endregion
 
     #region Integration Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_VScroll_RendersCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1061,7 +1062,7 @@ public class ScrollPanelNodeTests
         Assert.Contains("▉", snapshot.GetText());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_VScroll_ScrollsWithArrowKeys()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1099,10 +1100,10 @@ public class ScrollPanelNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal(3, lastOffset);
+        Assert.AreEqual(3, lastOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_VScrollWithButton_FocusNavigation()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1133,10 +1134,10 @@ public class ScrollPanelNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(buttonClicked);
+        Assert.IsTrue(buttonClicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_VScrollInsideSplitter_Works()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1177,7 +1178,7 @@ public class ScrollPanelNodeTests
         // WaitUntil already verified both Left Side and Scrollable content are visible
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_HScroll_RendersCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1215,7 +1216,7 @@ public class ScrollPanelNodeTests
         Assert.Contains("■", snapshot.GetText());  // Horizontal uses ■
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_HScroll_InsideBorder_ClipsCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1265,7 +1266,7 @@ public class ScrollPanelNodeTests
         foreach (var line in lines)
         {
             // Each line should be at most 30 characters (terminal width)
-            Assert.True(line.Length <= 30, $"Line too long: '{line}' ({line.Length} chars)");
+            Assert.IsTrue(line.Length <= 30, $"Line too long: '{line}' ({line.Length} chars)");
         }
         
         // The scrollable content should be clipped - <<<END>>> should not be visible
@@ -1314,7 +1315,7 @@ public class ScrollPanelNodeTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GlobalPageDown_ScrollsPanel_WhenFocusIsOnSibling()
     {
         // Arrange: ScrollPanel with a global PageDown binding, plus a sibling focusable that owns focus.
@@ -1341,8 +1342,8 @@ public class ScrollPanelNodeTests
         focusRing.Focus(sibling);
 
         // Sanity: focus is on the sibling, not the panel.
-        Assert.False(scrollPanel.IsFocused);
-        Assert.True(sibling.IsFocused);
+        Assert.IsFalse(scrollPanel.IsFocused);
+        Assert.IsTrue(sibling.IsFocused);
 
         var state = new InputRouterState();
 
@@ -1356,11 +1357,11 @@ public class ScrollPanelNodeTests
             TestContext.Current.CancellationToken);
 
         // Assert: global binding fired, panel scrolled by ViewportSize - 1.
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(9, scrollPanel.Offset);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(9, scrollPanel.Offset);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GlobalPageUp_ScrollsPanel_WhenFocusIsOnSibling()
     {
         var scrollPanel = new ScrollPanelNode
@@ -1395,11 +1396,11 @@ public class ScrollPanelNodeTests
             null,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(21, scrollPanel.Offset); // 30 - (10 - 1)
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(21, scrollPanel.Offset); // 30 - (10 - 1)
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PageDown_BubblesUp_FromFocusableDescendant_ToScrollPanelAncestor()
     {
         // Regression for the second symptom of issue #296: when a focusable descendant of a
@@ -1443,9 +1444,9 @@ public class ScrollPanelNodeTests
         focusRing.Rebuild(scrollPanel);
         focusRing.Focus(focusableChild);
 
-        Assert.False(scrollPanel.IsFocused, "Panel should not own focus directly when descendant is focused");
-        Assert.True(focusableChild.IsFocused);
-        Assert.True(scrollPanel.MaxOffset > 0, "Panel must be scrollable for this test to be meaningful");
+        Assert.IsFalse(scrollPanel.IsFocused, "Panel should not own focus directly when descendant is focused");
+        Assert.IsTrue(focusableChild.IsFocused);
+        Assert.IsTrue(scrollPanel.MaxOffset > 0, "Panel must be scrollable for this test to be meaningful");
 
         var state = new InputRouterState();
 
@@ -1457,11 +1458,11 @@ public class ScrollPanelNodeTests
             null,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(scrollPanel.Offset > 0, $"Expected panel to scroll via bubble-up, but Offset is {scrollPanel.Offset}");
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(scrollPanel.Offset > 0, $"Expected panel to scroll via bubble-up, but Offset is {scrollPanel.Offset}");
     }
 
-    [Fact]
+    [TestMethod]
     public void OffsetSetter_ClampsToValidRange()
     {
         var node = new ScrollPanelNode
@@ -1473,16 +1474,16 @@ public class ScrollPanelNodeTests
         node.Arrange(new Rect(0, 0, 40, 10));
 
         node.Offset = -100;
-        Assert.Equal(0, node.Offset);
+        Assert.AreEqual(0, node.Offset);
 
         node.Offset = 9999;
-        Assert.Equal(node.MaxOffset, node.Offset);
+        Assert.AreEqual(node.MaxOffset, node.Offset);
 
         node.Offset = 5;
-        Assert.Equal(5, node.Offset);
+        Assert.AreEqual(5, node.Offset);
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollByPage_AdvancesByViewportMinusOne()
     {
         var node = new ScrollPanelNode
@@ -1494,19 +1495,19 @@ public class ScrollPanelNodeTests
         node.Arrange(new Rect(0, 0, 40, 10));
 
         node.ScrollByPage(1);
-        Assert.Equal(9, node.Offset);  // ViewportSize (10) - 1
+        Assert.AreEqual(9, node.Offset);  // ViewportSize (10) - 1
 
         node.ScrollByPage(1);
-        Assert.Equal(18, node.Offset);
+        Assert.AreEqual(18, node.Offset);
 
         node.ScrollByPage(-1);
-        Assert.Equal(9, node.Offset);
+        Assert.AreEqual(9, node.Offset);
 
         node.ScrollByPage(2);
-        Assert.Equal(27, node.Offset); // direction can be larger magnitudes
+        Assert.AreEqual(27, node.Offset); // direction can be larger magnitudes
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollBy_AppliesRelativeOffset()
     {
         var node = new ScrollPanelNode
@@ -1518,20 +1519,20 @@ public class ScrollPanelNodeTests
         node.Arrange(new Rect(0, 0, 40, 10));
 
         node.ScrollBy(5);
-        Assert.Equal(5, node.Offset);
+        Assert.AreEqual(5, node.Offset);
 
         node.ScrollBy(-2);
-        Assert.Equal(3, node.Offset);
+        Assert.AreEqual(3, node.Offset);
 
         // Large positive scroll clamps to MaxOffset; the public API is overflow-safe.
         node.ScrollBy(int.MaxValue);
-        Assert.Equal(node.MaxOffset, node.Offset);
+        Assert.AreEqual(node.MaxOffset, node.Offset);
 
         node.ScrollBy(int.MinValue);
-        Assert.Equal(0, node.Offset);
+        Assert.AreEqual(0, node.Offset);
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollToTop_SetsOffsetToZero()
     {
         var node = new ScrollPanelNode
@@ -1545,10 +1546,10 @@ public class ScrollPanelNodeTests
 
         node.ScrollToTop();
 
-        Assert.Equal(0, node.Offset);
+        Assert.AreEqual(0, node.Offset);
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollToBottom_SetsOffsetToMaxOffset()
     {
         var node = new ScrollPanelNode
@@ -1562,11 +1563,11 @@ public class ScrollPanelNodeTests
 
         node.ScrollToBottom();
 
-        Assert.Equal(node.MaxOffset, node.Offset);
-        Assert.Equal(40, node.Offset); // 50 content - 10 viewport
+        Assert.AreEqual(node.MaxOffset, node.Offset);
+        Assert.AreEqual(40, node.Offset); // 50 content - 10 viewport
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ProgrammaticScroll_DoesNotFire_OnScrollEvent()
     {
         // Public scroll API has no InputBindingActionContext to attach to the event args.
@@ -1587,7 +1588,7 @@ public class ScrollPanelNodeTests
         node.ScrollToTop();
         node.ScrollToBottom();
 
-        Assert.Null(received);
+        Assert.IsNull(received);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/ScrollbackBufferTests.cs
+++ b/tests/Hex1b.Tests/ScrollbackBufferTests.cs
@@ -5,6 +5,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Unit tests for the ScrollbackBuffer circular buffer data structure.
 /// </summary>
+[TestClass]
 public class ScrollbackBufferTests
 {
     private static ScrollbackBuffer CreateBuffer(int capacity = 5)
@@ -22,31 +23,31 @@ public class ScrollbackBufferTests
         return cells;
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_ThrowsForZeroCapacity()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new ScrollbackBuffer(0));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new ScrollbackBuffer(0));
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_ThrowsForNegativeCapacity()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new ScrollbackBuffer(-1));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new ScrollbackBuffer(-1));
     }
 
-    [Fact]
+    [TestMethod]
     public void Push_WithinCapacity_IncrementsCount()
     {
         var buffer = CreateBuffer(5);
 
         buffer.Push(MakeRow("A"), 10, DateTimeOffset.UtcNow);
-        Assert.Equal(1, buffer.Count);
+        Assert.AreEqual(1, buffer.Count);
 
         buffer.Push(MakeRow("B"), 10, DateTimeOffset.UtcNow);
-        Assert.Equal(2, buffer.Count);
+        Assert.AreEqual(2, buffer.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Push_AtCapacity_CountDoesNotExceedCapacity()
     {
         var buffer = CreateBuffer(3);
@@ -54,10 +55,10 @@ public class ScrollbackBufferTests
         for (int i = 0; i < 5; i++)
             buffer.Push(MakeRow($"{i}"), 10, DateTimeOffset.UtcNow);
 
-        Assert.Equal(3, buffer.Count);
+        Assert.AreEqual(3, buffer.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Push_AtCapacity_ReturnsEvictedRow()
     {
         var buffer = CreateBuffer(2);
@@ -66,13 +67,13 @@ public class ScrollbackBufferTests
         var evicted2 = buffer.Push(MakeRow("B"), 10, DateTimeOffset.UtcNow);
         var evicted3 = buffer.Push(MakeRow("C"), 10, DateTimeOffset.UtcNow);
 
-        Assert.Null(evicted1);
-        Assert.Null(evicted2);
-        Assert.NotNull(evicted3);
-        Assert.Equal("A", evicted3.Value.Cells[0].Character);
+        Assert.IsNull(evicted1);
+        Assert.IsNull(evicted2);
+        Assert.IsNotNull(evicted3);
+        Assert.AreEqual("A", evicted3.Value.Cells[0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetLines_ReturnsOldestToNewest()
     {
         var buffer = CreateBuffer(5);
@@ -83,13 +84,13 @@ public class ScrollbackBufferTests
 
         var lines = buffer.GetLines(3);
 
-        Assert.Equal(3, lines.Length);
-        Assert.Equal("A", lines[0].Cells[0].Character);
-        Assert.Equal("B", lines[1].Cells[0].Character);
-        Assert.Equal("C", lines[2].Cells[0].Character);
+        Assert.AreEqual(3, lines.Length);
+        Assert.AreEqual("A", lines[0].Cells[0].Character);
+        Assert.AreEqual("B", lines[1].Cells[0].Character);
+        Assert.AreEqual("C", lines[2].Cells[0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetLines_AfterEviction_ReturnsCorrectOrder()
     {
         var buffer = CreateBuffer(3);
@@ -102,13 +103,13 @@ public class ScrollbackBufferTests
 
         var lines = buffer.GetLines(3);
 
-        Assert.Equal(3, lines.Length);
-        Assert.Equal("C", lines[0].Cells[0].Character);
-        Assert.Equal("D", lines[1].Cells[0].Character);
-        Assert.Equal("E", lines[2].Cells[0].Character);
+        Assert.AreEqual(3, lines.Length);
+        Assert.AreEqual("C", lines[0].Cells[0].Character);
+        Assert.AreEqual("D", lines[1].Cells[0].Character);
+        Assert.AreEqual("E", lines[2].Cells[0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetLines_RequestMoreThanAvailable_ReturnsAvailable()
     {
         var buffer = CreateBuffer(5);
@@ -118,12 +119,12 @@ public class ScrollbackBufferTests
 
         var lines = buffer.GetLines(10);
 
-        Assert.Equal(2, lines.Length);
-        Assert.Equal("A", lines[0].Cells[0].Character);
-        Assert.Equal("B", lines[1].Cells[0].Character);
+        Assert.AreEqual(2, lines.Length);
+        Assert.AreEqual("A", lines[0].Cells[0].Character);
+        Assert.AreEqual("B", lines[1].Cells[0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetLines_RequestFewerThanAvailable_ReturnsMostRecent()
     {
         var buffer = CreateBuffer(5);
@@ -134,41 +135,41 @@ public class ScrollbackBufferTests
 
         var lines = buffer.GetLines(2);
 
-        Assert.Equal(2, lines.Length);
-        Assert.Equal("B", lines[0].Cells[0].Character);
-        Assert.Equal("C", lines[1].Cells[0].Character);
+        Assert.AreEqual(2, lines.Length);
+        Assert.AreEqual("B", lines[0].Cells[0].Character);
+        Assert.AreEqual("C", lines[1].Cells[0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetLines_ZeroCount_ReturnsEmpty()
     {
         var buffer = CreateBuffer(5);
         buffer.Push(MakeRow("A"), 10, DateTimeOffset.UtcNow);
 
         var lines = buffer.GetLines(0);
-        Assert.Empty(lines);
+        Assert.IsEmpty(lines);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetLines_NegativeCount_ReturnsEmpty()
     {
         var buffer = CreateBuffer(5);
         buffer.Push(MakeRow("A"), 10, DateTimeOffset.UtcNow);
 
         var lines = buffer.GetLines(-1);
-        Assert.Empty(lines);
+        Assert.IsEmpty(lines);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetLines_EmptyBuffer_ReturnsEmpty()
     {
         var buffer = CreateBuffer(5);
 
         var lines = buffer.GetLines(5);
-        Assert.Empty(lines);
+        Assert.IsEmpty(lines);
     }
 
-    [Fact]
+    [TestMethod]
     public void Clear_EmptiesBuffer()
     {
         var buffer = CreateBuffer(5);
@@ -178,19 +179,19 @@ public class ScrollbackBufferTests
 
         buffer.Clear();
 
-        Assert.Equal(0, buffer.Count);
-        Assert.Empty(buffer.GetLines(10));
+        Assert.AreEqual(0, buffer.Count);
+        Assert.IsEmpty(buffer.GetLines(10));
     }
 
-    [Fact]
+    [TestMethod]
     public void Clear_OnEmptyBuffer_DoesNotThrow()
     {
         var buffer = CreateBuffer(5);
         buffer.Clear(); // Should not throw
-        Assert.Equal(0, buffer.Count);
+        Assert.AreEqual(0, buffer.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Push_PreservesOriginalWidth()
     {
         var buffer = CreateBuffer(5);
@@ -199,11 +200,11 @@ public class ScrollbackBufferTests
         buffer.Push(MakeRow("B", 120), 120, DateTimeOffset.UtcNow);
 
         var lines = buffer.GetLines(2);
-        Assert.Equal(80, lines[0].OriginalWidth);
-        Assert.Equal(120, lines[1].OriginalWidth);
+        Assert.AreEqual(80, lines[0].OriginalWidth);
+        Assert.AreEqual(120, lines[1].OriginalWidth);
     }
 
-    [Fact]
+    [TestMethod]
     public void Push_PreservesTimestamp()
     {
         var buffer = CreateBuffer(5);
@@ -212,13 +213,13 @@ public class ScrollbackBufferTests
         buffer.Push(MakeRow("A"), 10, ts);
 
         var lines = buffer.GetLines(1);
-        Assert.Equal(ts, lines[0].Timestamp);
+        Assert.AreEqual(ts, lines[0].Timestamp);
     }
 
-    [Fact]
+    [TestMethod]
     public void Capacity_ReturnsConfiguredValue()
     {
         var buffer = CreateBuffer(42);
-        Assert.Equal(42, buffer.Capacity);
+        Assert.AreEqual(42, buffer.Capacity);
     }
 }

--- a/tests/Hex1b.Tests/ScrollbackRenderingDemo.cs
+++ b/tests/Hex1b.Tests/ScrollbackRenderingDemo.cs
@@ -7,9 +7,10 @@ namespace Hex1b.Tests;
 /// Generates sample SVG and HTML files demonstrating scrollback rendering.
 /// Run with: dotnet test --filter "FullyQualifiedName~ScrollbackRenderingDemo"
 /// </summary>
+[TestClass]
 public class ScrollbackRenderingDemo
 {
-    [Fact]
+    [TestMethod]
     public void GenerateScrollbackDemo()
     {
         // Create a terminal with scrollback enabled
@@ -44,8 +45,8 @@ public class ScrollbackRenderingDemo
         // Create snapshot with 10 scrollback lines
         using var snapshot = terminal.CreateSnapshot(scrollbackLines: 10);
 
-        Assert.Equal(10, snapshot.ScrollbackLineCount);
-        Assert.Equal(34, snapshot.Height); // 10 scrollback + 24 visible
+        Assert.AreEqual(10, snapshot.ScrollbackLineCount);
+        Assert.AreEqual(34, snapshot.Height); // 10 scrollback + 24 visible
 
         // Write SVG output
         var svgContent = snapshot.ToSvg();

--- a/tests/Hex1b.Tests/ScrollbarNodeTests.cs
+++ b/tests/Hex1b.Tests/ScrollbarNodeTests.cs
@@ -9,6 +9,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for ScrollbarNode and ScrollbarWidget.
 /// </summary>
+[TestClass]
 public class ScrollbarNodeTests
 {
     private static Hex1bRenderContext CreateContext(IHex1bAppTerminalWorkloadAdapter workload, Hex1bTheme? theme = null)
@@ -18,20 +19,20 @@ public class ScrollbarNodeTests
 
     #region Basic State Tests
 
-    [Fact]
+    [TestMethod]
     public void ScrollbarNode_InitialState_HasDefaultValues()
     {
         var node = new ScrollbarNode();
 
-        Assert.Equal(ScrollOrientation.Vertical, node.Orientation);
-        Assert.Equal(100, node.ContentSize);
-        Assert.Equal(50, node.ViewportSize);
-        Assert.Equal(0, node.Offset);
-        Assert.True(node.IsScrollable);
-        Assert.Equal(50, node.MaxOffset);
+        Assert.AreEqual(ScrollOrientation.Vertical, node.Orientation);
+        Assert.AreEqual(100, node.ContentSize);
+        Assert.AreEqual(50, node.ViewportSize);
+        Assert.AreEqual(0, node.Offset);
+        Assert.IsTrue(node.IsScrollable);
+        Assert.AreEqual(50, node.MaxOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollbarNode_IsScrollable_FalseWhenViewportExceedsContent()
     {
         var node = new ScrollbarNode
@@ -40,51 +41,51 @@ public class ScrollbarNodeTests
             ViewportSize = 20
         };
 
-        Assert.False(node.IsScrollable);
-        Assert.Equal(0, node.MaxOffset);
+        Assert.IsFalse(node.IsScrollable);
+        Assert.AreEqual(0, node.MaxOffset);
     }
 
-    [Fact]
+    [TestMethod]
     public void ScrollbarNode_IsFocusable_OnlyWhenScrollable()
     {
         var scrollable = new ScrollbarNode { ContentSize = 100, ViewportSize = 50 };
         var notScrollable = new ScrollbarNode { ContentSize = 10, ViewportSize = 50 };
 
-        Assert.True(scrollable.IsFocusable);
-        Assert.False(notScrollable.IsFocusable);
+        Assert.IsTrue(scrollable.IsFocusable);
+        Assert.IsFalse(notScrollable.IsFocusable);
     }
 
     #endregion
 
     #region Measure Tests
 
-    [Fact]
+    [TestMethod]
     public void Measure_VerticalScrollbar_Returns1Width()
     {
         var node = new ScrollbarNode { Orientation = ScrollOrientation.Vertical };
 
         var size = node.Measure(new Constraints(0, 100, 0, 50));
 
-        Assert.Equal(1, size.Width);
-        Assert.Equal(50, size.Height);
+        Assert.AreEqual(1, size.Width);
+        Assert.AreEqual(50, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_HorizontalScrollbar_Returns1Height()
     {
         var node = new ScrollbarNode { Orientation = ScrollOrientation.Horizontal };
 
         var size = node.Measure(new Constraints(0, 50, 0, 100));
 
-        Assert.Equal(50, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(50, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
     #endregion
 
     #region Widget Reconciliation Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Widget_Reconcile_CreatesScrollbarNode()
     {
         var widget = new ScrollbarWidget(ScrollOrientation.Vertical, 200, 50, 25);
@@ -92,15 +93,15 @@ public class ScrollbarNodeTests
 
         var node = await widget.ReconcileAsync(null, context);
 
-        Assert.IsType<ScrollbarNode>(node);
+        TestSeq.IsType<ScrollbarNode>(node);
         var scrollbar = (ScrollbarNode)node;
-        Assert.Equal(ScrollOrientation.Vertical, scrollbar.Orientation);
-        Assert.Equal(200, scrollbar.ContentSize);
-        Assert.Equal(50, scrollbar.ViewportSize);
-        Assert.Equal(25, scrollbar.Offset);
+        Assert.AreEqual(ScrollOrientation.Vertical, scrollbar.Orientation);
+        Assert.AreEqual(200, scrollbar.ContentSize);
+        Assert.AreEqual(50, scrollbar.ViewportSize);
+        Assert.AreEqual(25, scrollbar.Offset);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Widget_Reconcile_UpdatesExistingNode()
     {
         var widget = new ScrollbarWidget(ScrollOrientation.Horizontal, 300, 100, 50);
@@ -109,14 +110,14 @@ public class ScrollbarNodeTests
 
         var node = await widget.ReconcileAsync(existing, context);
 
-        Assert.Same(existing, node);
-        Assert.Equal(ScrollOrientation.Horizontal, existing.Orientation);
-        Assert.Equal(300, existing.ContentSize);
-        Assert.Equal(100, existing.ViewportSize);
-        Assert.Equal(50, existing.Offset);
+        Assert.AreSame(existing, node);
+        Assert.AreEqual(ScrollOrientation.Horizontal, existing.Orientation);
+        Assert.AreEqual(300, existing.ContentSize);
+        Assert.AreEqual(100, existing.ViewportSize);
+        Assert.AreEqual(50, existing.Offset);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Widget_OnScroll_HandlerIsCalled()
     {
         var receivedOffset = -1;
@@ -126,45 +127,45 @@ public class ScrollbarNodeTests
 
         var node = (ScrollbarNode)await widget.ReconcileAsync(null, context);
         
-        Assert.NotNull(node.ScrollHandler);
+        Assert.IsNotNull(node.ScrollHandler);
         await node.ScrollHandler(25);
         
-        Assert.Equal(25, receivedOffset);
+        Assert.AreEqual(25, receivedOffset);
     }
 
     #endregion
 
     #region Extension Method Tests
 
-    [Fact]
+    [TestMethod]
     public void VScrollbar_CreatesVerticalScrollbar()
     {
         var ctx = new WidgetContext<VStackWidget>();
         var widget = ctx.VScrollbar(200, 50, 10);
 
-        Assert.Equal(ScrollOrientation.Vertical, widget.Orientation);
-        Assert.Equal(200, widget.ContentSize);
-        Assert.Equal(50, widget.ViewportSize);
-        Assert.Equal(10, widget.Offset);
+        Assert.AreEqual(ScrollOrientation.Vertical, widget.Orientation);
+        Assert.AreEqual(200, widget.ContentSize);
+        Assert.AreEqual(50, widget.ViewportSize);
+        Assert.AreEqual(10, widget.Offset);
     }
 
-    [Fact]
+    [TestMethod]
     public void HScrollbar_CreatesHorizontalScrollbar()
     {
         var ctx = new WidgetContext<HStackWidget>();
         var widget = ctx.HScrollbar(300, 100, 25);
 
-        Assert.Equal(ScrollOrientation.Horizontal, widget.Orientation);
-        Assert.Equal(300, widget.ContentSize);
-        Assert.Equal(100, widget.ViewportSize);
-        Assert.Equal(25, widget.Offset);
+        Assert.AreEqual(ScrollOrientation.Horizontal, widget.Orientation);
+        Assert.AreEqual(300, widget.ContentSize);
+        Assert.AreEqual(100, widget.ViewportSize);
+        Assert.AreEqual(25, widget.Offset);
     }
 
     #endregion
 
     #region Render Tests
 
-    [Fact]
+    [TestMethod]
     public void Render_VerticalScrollbar_DoesNotThrow()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -183,11 +184,11 @@ public class ScrollbarNodeTests
         node.Arrange(new Rect(0, 0, 1, 10));
         
         // Should not throw
-        var ex = Record.Exception(() => node.Render(context));
-        Assert.Null(ex);
+        var ex = TestSeq.RecordException(() => node.Render(context));
+        Assert.IsNull(ex);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_HorizontalScrollbar_DoesNotThrow()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -206,11 +207,11 @@ public class ScrollbarNodeTests
         node.Arrange(new Rect(0, 0, 10, 1));
         
         // Should not throw
-        var ex = Record.Exception(() => node.Render(context));
-        Assert.Null(ex);
+        var ex = TestSeq.RecordException(() => node.Render(context));
+        Assert.IsNull(ex);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_NotScrollable_DoesNotThrow()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -227,8 +228,8 @@ public class ScrollbarNodeTests
         node.Arrange(new Rect(0, 0, 1, 10));
         
         // Should not throw even when not scrollable
-        var ex = Record.Exception(() => node.Render(context));
-        Assert.Null(ex);
+        var ex = TestSeq.RecordException(() => node.Render(context));
+        Assert.IsNull(ex);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/SelectionPanelEndToEndTests.cs
+++ b/tests/Hex1b.Tests/SelectionPanelEndToEndTests.cs
@@ -26,6 +26,7 @@ namespace Hex1b.Tests;
 ///       ScrollPanel mid-drag.</item>
 /// </list>
 /// </remarks>
+[TestClass]
 public class SelectionPanelEndToEndTests
 {
     // ------------------------------------------------------------------
@@ -211,12 +212,12 @@ public class SelectionPanelEndToEndTests
     // Category A — Keyboard, single-screen
     // ------------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public async Task Keyboard_LineSelect_BufferTopToBufferBottom_CopiesAllVisibleLines()
     {
         await using var h = await BuildPlainHarnessAsync(FixedContent5Rows, 30, 8);
         var panel = h.FindPanel();
-        Assert.NotNull(panel);
+        Assert.IsNotNull(panel);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Key(Hex1bKey.F12)
@@ -230,22 +231,20 @@ public class SelectionPanelEndToEndTests
             .Build()
             .ApplyAsync(h.Terminal, TestContext.Current.CancellationToken);
 
-        var text = Assert.Single(h.CopiedTexts);
-        Assert.Equal(
-            "AAAAA-BBBBB-CCCCC-DDDDD\n" +
+        var text = TestSeq.Single(h.CopiedTexts);
+        Assert.AreEqual("AAAAA-BBBBB-CCCCC-DDDDD\n" +
             "EEEEE-FFFFF-GGGGG-HHHHH\n" +
             "IIIII-JJJJJ-KKKKK-LLLLL\n" +
             "MMMMM-NNNNN-OOOOO-PPPPP\n" +
-            "QQQQQ-RRRRR-SSSSS-TTTTT",
-            text);
+            "QQQQQ-RRRRR-SSSSS-TTTTT", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Keyboard_LineSelect_SingleLineAtCursor_CopiesThatLine()
     {
         await using var h = await BuildPlainHarnessAsync(FixedContent5Rows, 30, 8);
         var panel = h.FindPanel();
-        Assert.NotNull(panel);
+        Assert.IsNotNull(panel);
 
         // F12 enters copy mode at panel-local bottom (row Bounds.Height-1
         // = 7 here, an empty row). Navigate to a known content row first
@@ -266,15 +265,15 @@ public class SelectionPanelEndToEndTests
             .Build()
             .ApplyAsync(h.Terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal("QQQQQ-RRRRR-SSSSS-TTTTT", Assert.Single(h.CopiedTexts));
+        Assert.AreEqual("QQQQQ-RRRRR-SSSSS-TTTTT", TestSeq.Single(h.CopiedTexts));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Keyboard_CharSelect_PartialFirstAndLastRow_CopiesStreamSubstring()
     {
         await using var h = await BuildPlainHarnessAsync(FixedContent5Rows, 30, 8);
         var panel = h.FindPanel();
-        Assert.NotNull(panel);
+        Assert.IsNotNull(panel);
 
         // F12 → G (row 0, col 0) → Right×6 (row 0, col 6) → V (start char
         // selection here) → Down (row 1) → Right×4 (row 1, col 10) → Y.
@@ -295,18 +294,16 @@ public class SelectionPanelEndToEndTests
             .Build()
             .ApplyAsync(h.Terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(
-            "BBBBB-CCCCC-DDDDD\n" +
-            "EEEEE-FFFFF",
-            Assert.Single(h.CopiedTexts));
+        Assert.AreEqual("BBBBB-CCCCC-DDDDD\n" +
+            "EEEEE-FFFFF", TestSeq.Single(h.CopiedTexts));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Keyboard_BlockSelect_RectangleAcrossRows_CopiesRectangleText()
     {
         await using var h = await BuildPlainHarnessAsync(FixedContent5Rows, 30, 8);
         var panel = h.FindPanel();
-        Assert.NotNull(panel);
+        Assert.IsNotNull(panel);
 
         // F12 → G (row 0,col 0) → Right×6 → Alt+V (block mode start at
         // (0,6)) → Down×2 → Right×4 (cursor at (2,10)) → Y.
@@ -328,17 +325,17 @@ public class SelectionPanelEndToEndTests
             .Build()
             .ApplyAsync(h.Terminal, TestContext.Current.CancellationToken);
 
-        var args = Assert.Single(h.CopyEvents);
-        Assert.Equal(SelectionMode.Block, args.Mode);
-        Assert.Equal("BBBBB\nFFFFF\nJJJJJ", Harness.Norm(args.Text));
+        var args = TestSeq.Single(h.CopyEvents);
+        Assert.AreEqual(SelectionMode.Block, args.Mode);
+        Assert.AreEqual("BBBBB\nFFFFF\nJJJJJ", Harness.Norm(args.Text));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Keyboard_Cancel_NoCopyDelivered_AndExitsCopyMode()
     {
         await using var h = await BuildPlainHarnessAsync(FixedContent5Rows, 30, 8);
         var panel = h.FindPanel();
-        Assert.NotNull(panel);
+        Assert.IsNotNull(panel);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Key(Hex1bKey.F12)
@@ -351,11 +348,11 @@ public class SelectionPanelEndToEndTests
             .Build()
             .ApplyAsync(h.Terminal, TestContext.Current.CancellationToken);
 
-        Assert.Empty(h.CopiedTexts);
-        Assert.False(panel!.HasSelection);
+        Assert.IsEmpty(h.CopiedTexts);
+        Assert.IsFalse(panel!.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Keyboard_F12_GlobalRouting_FiresEvenWhenSiblingHasFocus()
     {
         // Sibling TextBox owns focus by default (last-rendered focusable in
@@ -364,7 +361,7 @@ public class SelectionPanelEndToEndTests
         await using var h = await BuildScrollHarnessAsync(
             FixedContent5Rows, 30, 12, includeFocusedSibling: true);
         var panel = h.FindPanel();
-        Assert.NotNull(panel);
+        Assert.IsNotNull(panel);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Key(Hex1bKey.F12)
@@ -373,19 +370,19 @@ public class SelectionPanelEndToEndTests
             .Build()
             .ApplyAsync(h.Terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(panel!.IsInCopyMode);
+        Assert.IsTrue(panel!.IsInCopyMode);
     }
 
     // ------------------------------------------------------------------
     // Category B — Mouse, single-screen
     // ------------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public async Task Mouse_Drag_CharSelect_AcrossOneRow_CopiesText()
     {
         await using var h = await BuildPlainHarnessAsync(FixedContent5Rows, 30, 8);
         var panel = h.FindPanel();
-        Assert.NotNull(panel);
+        Assert.IsNotNull(panel);
 
         // Drag from (0, 0) to (10, 0) — char mode, single row, cells 0..10.
         // Row 0 content cells 0..10 = "AAAAA-BBBBB"
@@ -399,15 +396,15 @@ public class SelectionPanelEndToEndTests
             .Build()
             .ApplyAsync(h.Terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal("AAAAA-BBBBB", Assert.Single(h.CopiedTexts));
+        Assert.AreEqual("AAAAA-BBBBB", TestSeq.Single(h.CopiedTexts));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Mouse_CtrlDrag_LineSelect_AcrossThreeRows_CopiesAllRows()
     {
         await using var h = await BuildPlainHarnessAsync(FixedContent5Rows, 30, 8);
         var panel = h.FindPanel();
-        Assert.NotNull(panel);
+        Assert.IsNotNull(panel);
 
         // Ctrl+drag from (5, 1) to (15, 3) — line mode, rows 1..3 full.
         await new Hex1bTerminalInputSequenceBuilder()
@@ -422,21 +419,19 @@ public class SelectionPanelEndToEndTests
             .Build()
             .ApplyAsync(h.Terminal, TestContext.Current.CancellationToken);
 
-        var args = Assert.Single(h.CopyEvents);
-        Assert.Equal(SelectionMode.Line, args.Mode);
-        Assert.Equal(
-            "EEEEE-FFFFF-GGGGG-HHHHH\n" +
+        var args = TestSeq.Single(h.CopyEvents);
+        Assert.AreEqual(SelectionMode.Line, args.Mode);
+        Assert.AreEqual("EEEEE-FFFFF-GGGGG-HHHHH\n" +
             "IIIII-JJJJJ-KKKKK-LLLLL\n" +
-            "MMMMM-NNNNN-OOOOO-PPPPP",
-            Harness.Norm(args.Text));
+            "MMMMM-NNNNN-OOOOO-PPPPP", Harness.Norm(args.Text));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Mouse_AltDrag_BlockSelect_AcrossRowsAndCols_CopiesRectangle()
     {
         await using var h = await BuildPlainHarnessAsync(FixedContent5Rows, 30, 8);
         var panel = h.FindPanel();
-        Assert.NotNull(panel);
+        Assert.IsNotNull(panel);
 
         // Alt+drag from (6, 0) to (10, 2) — block, cols 6..10, rows 0..2.
         //   row 0 cells 6..10 = "BBBBB"
@@ -454,10 +449,10 @@ public class SelectionPanelEndToEndTests
             .Build()
             .ApplyAsync(h.Terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal("BBBBB\nFFFFF\nJJJJJ", Assert.Single(h.CopiedTexts));
+        Assert.AreEqual("BBBBB\nFFFFF\nJJJJJ", TestSeq.Single(h.CopiedTexts));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Mouse_Drag_ThenKeyboardRefine_ThenCommit_CopiesExtendedSelection()
     {
         // Proves the mouse→keyboard handoff: drag installs keyboard
@@ -465,7 +460,7 @@ public class SelectionPanelEndToEndTests
         // selection commands.
         await using var h = await BuildPlainHarnessAsync(FixedContent5Rows, 30, 8);
         var panel = h.FindPanel();
-        Assert.NotNull(panel);
+        Assert.IsNotNull(panel);
 
         // Initial mouse selection: char-mode drag from (0,0) to (4,0)
         // (cells 0..4 of row 0).
@@ -489,17 +484,15 @@ public class SelectionPanelEndToEndTests
         // Char-mode stream from (0,0) to (1,end-of-row):
         //   row 0 cells 0..end = "AAAAA-BBBBB-CCCCC-DDDDD"
         //   row 1 cells 0..end = "EEEEE-FFFFF-GGGGG-HHHHH"
-        Assert.Equal(
-            "AAAAA-BBBBB-CCCCC-DDDDD\n" +
-            "EEEEE-FFFFF-GGGGG-HHHHH",
-            Assert.Single(h.CopiedTexts));
+        Assert.AreEqual("AAAAA-BBBBB-CCCCC-DDDDD\n" +
+            "EEEEE-FFFFF-GGGGG-HHHHH", TestSeq.Single(h.CopiedTexts));
     }
 
     // ------------------------------------------------------------------
     // Category C — Keyboard, scroll-spanning (content > viewport)
     // ------------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public async Task Keyboard_LineSelect_BufferTopToBottom_CopiesAll30Rows_WhenContentExceedsViewport()
     {
         // 30 rows of content inside a 10-row viewport. The selection must
@@ -508,7 +501,7 @@ public class SelectionPanelEndToEndTests
         var content = Build30RowContent();
         await using var h = await BuildScrollHarnessAsync(content, 40, 10);
         var panel = h.FindPanel();
-        Assert.NotNull(panel);
+        Assert.IsNotNull(panel);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Key(Hex1bKey.F12)
@@ -523,16 +516,16 @@ public class SelectionPanelEndToEndTests
             .Build()
             .ApplyAsync(h.Terminal, TestContext.Current.CancellationToken);
 
-        var text = Assert.Single(h.CopiedTexts);
+        var text = TestSeq.Single(h.CopiedTexts);
         var lines = text.Split('\n');
-        Assert.Equal(30, lines.Length);
+        Assert.AreEqual(30, lines.Length);
         for (int i = 0; i < 30; i++)
         {
-            Assert.Equal($"Row{i:00}-payload-rest-here", lines[i]);
+            Assert.AreEqual($"Row{i:00}-payload-rest-here", lines[i]);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Keyboard_LineSelect_PageDownFromTop_CopiesPageWorthOfRows()
     {
         // Line mode + PageDown: selection extends by PageRows (=20) lines,
@@ -541,7 +534,7 @@ public class SelectionPanelEndToEndTests
         var content = Build30RowContent();
         await using var h = await BuildScrollHarnessAsync(content, 40, 10);
         var panel = h.FindPanel();
-        Assert.NotNull(panel);
+        Assert.IsNotNull(panel);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Key(Hex1bKey.F12)
@@ -558,12 +551,12 @@ public class SelectionPanelEndToEndTests
             .Build()
             .ApplyAsync(h.Terminal, TestContext.Current.CancellationToken);
 
-        var text = Assert.Single(h.CopiedTexts);
+        var text = TestSeq.Single(h.CopiedTexts);
         var lines = text.Split('\n');
         // PageRows=20 takes cursor from 0 to 20, inclusive both ends → 21 rows.
-        Assert.Equal(21, lines.Length);
-        Assert.Equal("Row00-payload-rest-here", lines[0]);
-        Assert.Equal("Row20-payload-rest-here", lines[^1]);
+        Assert.AreEqual(21, lines.Length);
+        Assert.AreEqual("Row00-payload-rest-here", lines[0]);
+        Assert.AreEqual("Row20-payload-rest-here", lines[^1]);
         // Row 9 was the last row of the initial viewport — proves we crossed it.
         Assert.Contains("Row10-payload-rest-here", lines);
         Assert.Contains("Row15-payload-rest-here", lines);
@@ -572,7 +565,7 @@ public class SelectionPanelEndToEndTests
         Assert.DoesNotContain("Row29-payload-rest-here", lines);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Keyboard_PreScrolledViewport_LineSelect_BufferBottomToTop_CopiesAllUpward()
     {
         // Pre-scroll the ScrollPanel to the bottom so the visible viewport
@@ -584,8 +577,8 @@ public class SelectionPanelEndToEndTests
         await using var h = await BuildScrollHarnessAsync(content, 40, 10);
         var scroll = h.FindScrollPanel();
         var panel = h.FindPanel();
-        Assert.NotNull(scroll);
-        Assert.NotNull(panel);
+        Assert.IsNotNull(scroll);
+        Assert.IsNotNull(panel);
 
         scroll!.ScrollToBottom();
         h.App.Invalidate();
@@ -606,18 +599,18 @@ public class SelectionPanelEndToEndTests
             .Build()
             .ApplyAsync(h.Terminal, TestContext.Current.CancellationToken);
 
-        var text = Assert.Single(h.CopiedTexts);
+        var text = TestSeq.Single(h.CopiedTexts);
         var lines = text.Split('\n');
-        Assert.Equal(30, lines.Length);
-        Assert.Equal("Row00-payload-rest-here", lines[0]);
-        Assert.Equal("Row29-payload-rest-here", lines[^1]);
+        Assert.AreEqual(30, lines.Length);
+        Assert.AreEqual("Row00-payload-rest-here", lines[0]);
+        Assert.AreEqual("Row29-payload-rest-here", lines[^1]);
     }
 
     // ------------------------------------------------------------------
     // Category D — Mouse, wheel-during-drag scroll-spanning
     // ------------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public async Task Mouse_CtrlDrag_ThenScrollDownDuringDrag_CopiesContentBeyondInitialViewport()
     {
         // Ctrl+drag = line mode so each "row passed under the mouse" lands
@@ -630,9 +623,9 @@ public class SelectionPanelEndToEndTests
         await using var h = await BuildScrollHarnessAsync(content, 40, 10);
         var scroll = h.FindScrollPanel();
         var panel = h.FindPanel();
-        Assert.NotNull(scroll);
-        Assert.NotNull(panel);
-        Assert.Equal(0, scroll!.Offset);
+        Assert.IsNotNull(scroll);
+        Assert.IsNotNull(panel);
+        Assert.AreEqual(0, scroll!.Offset);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().MouseMoveTo(5, 1)
@@ -654,24 +647,23 @@ public class SelectionPanelEndToEndTests
             .Build()
             .ApplyAsync(h.Terminal, TestContext.Current.CancellationToken);
 
-        var args = Assert.Single(h.CopyEvents);
-        Assert.Equal(SelectionMode.Line, args.Mode);
+        var args = TestSeq.Single(h.CopyEvents);
+        Assert.AreEqual(SelectionMode.Line, args.Mode);
 
         var lines = Harness.Norm(args.Text).Split('\n');
         // Anchor row was 1. Cursor row landed at panel.CursorRow at
         // commit time (>= 4 because scroll added rows). Line mode payload
         // is rows [1..cursorRow] inclusive in panel-local coords.
-        Assert.True(lines.Length >= 4,
-            $"Expected at least 4 lines (anchor row 1 + scroll-extended), got {lines.Length}: {args.Text}");
-        Assert.Equal("Row01-payload-rest-here", lines[0]);
+        Assert.IsTrue(lines.Length >= 4, $"Expected at least 4 lines (anchor row 1 + scroll-extended), got {lines.Length}: {args.Text}");
+        Assert.AreEqual("Row01-payload-rest-here", lines[0]);
         // Must include rows that were OFF-SCREEN at drag start (viewport
         // showed rows 0..9, so row 10+ counts as scrolled-into-view).
-        Assert.Contains(lines, l => l.StartsWith("Row10-", StringComparison.Ordinal));
+        Assert.IsTrue(lines.Any(l => l.StartsWith("Row10-", StringComparison.Ordinal)));
         // And must NOT include rows above the anchor.
-        Assert.DoesNotContain(lines, l => l.StartsWith("Row00-", StringComparison.Ordinal));
+        Assert.IsFalse(lines.Any(l => l.StartsWith("Row00-", StringComparison.Ordinal)));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Mouse_CtrlDrag_ThenScrollUpDuringDrag_CopiesContentAboveInitialViewport()
     {
         // Pre-scroll to the bottom so the viewport shows rows ~20..29.
@@ -683,8 +675,8 @@ public class SelectionPanelEndToEndTests
         await using var h = await BuildScrollHarnessAsync(content, 40, 10);
         var scroll = h.FindScrollPanel();
         var panel = h.FindPanel();
-        Assert.NotNull(scroll);
-        Assert.NotNull(panel);
+        Assert.IsNotNull(scroll);
+        Assert.IsNotNull(panel);
 
         scroll!.ScrollToBottom();
         h.App.Invalidate();
@@ -719,16 +711,15 @@ public class SelectionPanelEndToEndTests
             .Build()
             .ApplyAsync(h.Terminal, TestContext.Current.CancellationToken);
 
-        var args = Assert.Single(h.CopyEvents);
-        Assert.Equal(SelectionMode.Line, args.Mode);
+        var args = TestSeq.Single(h.CopyEvents);
+        Assert.AreEqual(SelectionMode.Line, args.Mode);
 
         var lines = Harness.Norm(args.Text).Split('\n');
-        Assert.True(lines.Length >= 2,
-            $"Expected at least 2 lines after scroll-up extension, got {lines.Length}: {args.Text}");
+        Assert.IsTrue(lines.Length >= 2, $"Expected at least 2 lines after scroll-up extension, got {lines.Length}: {args.Text}");
         // Bottom of the selection is the original mouse-down panel-local
         // row (anchor). Selection extended UPWARD from there into rows
         // above the initial viewport.
-        Assert.Equal($"Row{initialAnchorRow:00}-payload-rest-here", lines[^1]);
+        Assert.AreEqual($"Row{initialAnchorRow:00}-payload-rest-here", lines[^1]);
         // Top row index must be SMALLER than the row currently under the
         // mouse (because we scrolled up after grab, bringing higher rows
         // under the cursor than were originally there).
@@ -736,7 +727,6 @@ public class SelectionPanelEndToEndTests
         // first line should be "RowNN-..." with NN < initialAnchorRow.
         Assert.StartsWith("Row", firstRowLabel, StringComparison.Ordinal);
         var firstRowNumber = int.Parse(firstRowLabel.Substring(3, 2));
-        Assert.True(firstRowNumber < initialAnchorRow,
-            $"Expected scroll-up to extend selection to a row above {initialAnchorRow}, got {firstRowLabel}");
+        Assert.IsTrue(firstRowNumber < initialAnchorRow, $"Expected scroll-up to extend selection to a row above {initialAnchorRow}, got {firstRowLabel}");
     }
 }

--- a/tests/Hex1b.Tests/SelectionPanelMouseDragIntegrationTests.cs
+++ b/tests/Hex1b.Tests/SelectionPanelMouseDragIntegrationTests.cs
@@ -14,6 +14,7 @@ namespace Hex1b.Tests;
 /// drags inside the demo-style layout where SelectionPanel is a non-focusable
 /// descendant of a focusable ScrollPanel.
 /// </summary>
+[TestClass]
 public class SelectionPanelMouseDragIntegrationTests
 {
     private static (Hex1bAppWorkloadAdapter workload, Hex1bTerminal terminal, Hex1bApp app,
@@ -75,14 +76,14 @@ public class SelectionPanelMouseDragIntegrationTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LeftDrag_OverPanelContent_EntersCopyMode_AndAnchorsAtDownPosition()
     {
         var (workload, terminal, app, panel, _) = Setup();
         using var _w = workload; using var _t = terminal; using var _a = app;
 
-        Assert.NotNull(panel);
-        Assert.False(panel.IsInCopyMode);
+        Assert.IsNotNull(panel);
+        Assert.IsFalse(panel.IsInCopyMode);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Drag(fromX: 2, fromY: 1, toX: 7, toY: 3)
@@ -91,22 +92,22 @@ public class SelectionPanelMouseDragIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(panel.IsInCopyMode);
-        Assert.True(panel.HasSelection);
-        Assert.Equal(SelectionMode.Character, panel.CursorSelectionMode);
-        Assert.Equal(1, panel.AnchorRow);
-        Assert.Equal(2, panel.AnchorCol);
-        Assert.Equal(3, panel.CursorRow);
-        Assert.Equal(7, panel.CursorCol);
+        Assert.IsTrue(panel.IsInCopyMode);
+        Assert.IsTrue(panel.HasSelection);
+        Assert.AreEqual(SelectionMode.Character, panel.CursorSelectionMode);
+        Assert.AreEqual(1, panel.AnchorRow);
+        Assert.AreEqual(2, panel.AnchorCol);
+        Assert.AreEqual(3, panel.CursorRow);
+        Assert.AreEqual(7, panel.CursorCol);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LeftClick_WithoutMovement_DoesNotEnterCopyMode()
     {
         var (workload, terminal, app, panel, _) = Setup();
         using var _w = workload; using var _t = terminal; using var _a = app;
 
-        Assert.NotNull(panel);
+        Assert.IsNotNull(panel);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .ClickAt(5, 2)
@@ -114,16 +115,16 @@ public class SelectionPanelMouseDragIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.False(panel.IsInCopyMode);
+        Assert.IsFalse(panel.IsInCopyMode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ShiftDrag_StartsLineSelection()
     {
         var (workload, terminal, app, panel, _) = Setup();
         using var _w = workload; using var _t = terminal; using var _a = app;
 
-        Assert.NotNull(panel);
+        Assert.IsNotNull(panel);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Shift().Drag(fromX: 3, fromY: 1, toX: 6, toY: 2)
@@ -132,8 +133,8 @@ public class SelectionPanelMouseDragIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(panel.IsInCopyMode);
-        Assert.Equal(SelectionMode.Line, panel.CursorSelectionMode);
+        Assert.IsTrue(panel.IsInCopyMode);
+        Assert.AreEqual(SelectionMode.Line, panel.CursorSelectionMode);
     }
 
     /// <summary>
@@ -144,13 +145,13 @@ public class SelectionPanelMouseDragIntegrationTests
     /// OS-level selection, so Ctrl+drag is the cross-platform reliable
     /// modifier.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task CtrlDrag_StartsLineSelection()
     {
         var (workload, terminal, app, panel, _) = Setup();
         using var _w = workload; using var _t = terminal; using var _a = app;
 
-        Assert.NotNull(panel);
+        Assert.IsNotNull(panel);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Drag(fromX: 3, fromY: 1, toX: 6, toY: 2)
@@ -159,8 +160,8 @@ public class SelectionPanelMouseDragIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(panel.IsInCopyMode);
-        Assert.Equal(SelectionMode.Line, panel.CursorSelectionMode);
+        Assert.IsTrue(panel.IsInCopyMode);
+        Assert.AreEqual(SelectionMode.Line, panel.CursorSelectionMode);
     }
 
     /// <summary>
@@ -170,7 +171,7 @@ public class SelectionPanelMouseDragIntegrationTests
     /// click misses the scrollbar so the framework falls through and arms the
     /// SelectionPanel's bubble drag.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task LeftDrag_OverPanelInsideScrollPanel_EntersCopyMode()
     {
         var workload = new Hex1bAppWorkloadAdapter();
@@ -203,8 +204,8 @@ public class SelectionPanelMouseDragIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         var panel = FindPanel(app);
-        Assert.NotNull(panel);
-        Assert.False(panel!.IsInCopyMode);
+        Assert.IsNotNull(panel);
+        Assert.IsFalse(panel!.IsInCopyMode);
 
         // Drag in the middle of the content (away from the scrollbar at the
         // far right edge).
@@ -215,8 +216,8 @@ public class SelectionPanelMouseDragIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(panel.IsInCopyMode);
-        Assert.True(panel.HasSelection);
+        Assert.IsTrue(panel.IsInCopyMode);
+        Assert.IsTrue(panel.HasSelection);
     }
 
     /// <summary>
@@ -227,7 +228,7 @@ public class SelectionPanelMouseDragIntegrationTests
     /// scrollbar, and the focus ring containing focusables on both sides of
     /// the splitter plus the InfoBar wrapper.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task LeftDrag_OverPanelInDemoStyleLayout_EntersCopyMode()
     {
         var workload = new Hex1bAppWorkloadAdapter();
@@ -276,7 +277,7 @@ public class SelectionPanelMouseDragIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         var panel = FindPanel(app);
-        Assert.NotNull(panel);
+        Assert.IsNotNull(panel);
 
         // Drag in the middle of the LEFT side (transcript area).
         await new Hex1bTerminalInputSequenceBuilder()
@@ -286,7 +287,7 @@ public class SelectionPanelMouseDragIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(panel!.IsInCopyMode);
+        Assert.IsTrue(panel!.IsInCopyMode);
     }
 
     /// <summary>
@@ -297,7 +298,7 @@ public class SelectionPanelMouseDragIntegrationTests
     /// path the right-click would route through normal hit-testing and
     /// miss the non-focusable SelectionPanel.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task RightClick_AfterDragSelection_CommitsCopy_AndExitsCopyMode()
     {
         var workload = new Hex1bAppWorkloadAdapter();
@@ -327,7 +328,7 @@ public class SelectionPanelMouseDragIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         var panel = FindPanel(app);
-        Assert.NotNull(panel);
+        Assert.IsNotNull(panel);
 
         // Drag to enter copy mode and create a selection.
         await new Hex1bTerminalInputSequenceBuilder()
@@ -337,8 +338,8 @@ public class SelectionPanelMouseDragIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(panel!.IsInCopyMode);
-        Assert.True(panel.HasSelection);
+        Assert.IsTrue(panel!.IsInCopyMode);
+        Assert.IsTrue(panel.HasSelection);
 
         // Right-click anywhere within the panel commits the copy.
         await new Hex1bTerminalInputSequenceBuilder()
@@ -348,10 +349,10 @@ public class SelectionPanelMouseDragIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.NotNull(captured);
-        Assert.False(string.IsNullOrEmpty(captured!.Text));
-        Assert.False(panel.IsInCopyMode);
-        Assert.False(panel.HasSelection);
+        Assert.IsNotNull(captured);
+        Assert.IsFalse(string.IsNullOrEmpty(captured!.Text));
+        Assert.IsFalse(panel.IsInCopyMode);
+        Assert.IsFalse(panel.HasSelection);
     }
 
     /// <summary>
@@ -365,7 +366,7 @@ public class SelectionPanelMouseDragIntegrationTests
     /// user start a selection on visible content and drag it onto content
     /// that was off-screen at drag-start.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task WheelDuringDrag_ScrollsContainer_AndExtendsSelectionToNewlyVisibleContent()
     {
         var workload = new Hex1bAppWorkloadAdapter();
@@ -397,10 +398,10 @@ public class SelectionPanelMouseDragIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         var panel = FindPanel(app);
-        Assert.NotNull(panel);
+        Assert.IsNotNull(panel);
         var scroll = FindScrollPanel(app);
-        Assert.NotNull(scroll);
-        Assert.Equal(0, scroll!.Offset);
+        Assert.IsNotNull(scroll);
+        Assert.AreEqual(0, scroll!.Offset);
 
         // Press at terminal row 1 (panel-local row 1, since not scrolled yet)
         // and drag to row 3 to enter copy mode with an active drag.
@@ -414,9 +415,9 @@ public class SelectionPanelMouseDragIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(panel!.IsInCopyMode);
-        Assert.Equal(1, panel.AnchorRow);
-        Assert.Equal(3, panel.CursorRow);
+        Assert.IsTrue(panel!.IsInCopyMode);
+        Assert.AreEqual(1, panel.AnchorRow);
+        Assert.AreEqual(3, panel.CursorRow);
 
         // Mouse stays at terminal row 3. Scroll the wheel to bring later
         // content into view — the SelectionPanel slides up, and the cell
@@ -428,19 +429,16 @@ public class SelectionPanelMouseDragIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(scroll!.Offset > 0,
-            $"ScrollPanel.Offset expected > 0 after wheel-down, got {scroll.Offset}");
-        Assert.True(panel.CursorRow > 3,
-            $"panel.CursorRow expected > 3 (anchor row + extension into newly-visible content), got {panel.CursorRow}");
+        Assert.IsTrue(scroll!.Offset > 0, $"ScrollPanel.Offset expected > 0 after wheel-down, got {scroll.Offset}");
+        Assert.IsTrue(panel.CursorRow > 3, $"panel.CursorRow expected > 3 (anchor row + extension into newly-visible content), got {panel.CursorRow}");
         // Anchor unchanged — selection EXTENDS, not moves.
-        Assert.Equal(1, panel.AnchorRow);
+        Assert.AreEqual(1, panel.AnchorRow);
         // Cursor must extend at least as far as the original mouseY (3) plus
         // some scroll-driven offset, proving that scroll-during-drag actually
         // brought new content under the mouse and the synthetic drag-move
         // followed it. Exact value depends on input batching / coalescing
         // ordering between scroll ticks and is not part of the contract.
-        Assert.True(panel.CursorRow >= 3 + 3,
-            $"panel.CursorRow expected >= 6 (mouseY + at least one scroll tick), got {panel.CursorRow}");
+        Assert.IsTrue(panel.CursorRow >= 3 + 3, $"panel.CursorRow expected >= 6 (mouseY + at least one scroll tick), got {panel.CursorRow}");
 
         // Releasing the mouse leaves copy mode active for keyboard refinement.
         await new Hex1bTerminalInputSequenceBuilder()
@@ -449,8 +447,8 @@ public class SelectionPanelMouseDragIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(panel.IsInCopyMode);
-        Assert.True(panel.HasSelection);
+        Assert.IsTrue(panel.IsInCopyMode);
+        Assert.IsTrue(panel.HasSelection);
     }
 
     private static ScrollPanelNode? FindScrollPanel(Hex1bApp app)
@@ -479,7 +477,7 @@ public class SelectionPanelMouseDragIntegrationTests
     /// the guard, the detached SelectionPanel would enter copy mode and
     /// start mutating selection state on a node nothing is rendering.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task PendingBubbleDrag_NodeUnmountedBeforeFirstMove_DoesNotActivateStaleDrag()
     {
         var workload = new Hex1bAppWorkloadAdapter();
@@ -522,8 +520,8 @@ public class SelectionPanelMouseDragIntegrationTests
                 .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
             var originalPanel = FindPanel(app);
-            Assert.NotNull(originalPanel);
-            Assert.False(originalPanel!.IsInCopyMode, "panel must start outside copy mode");
+            Assert.IsNotNull(originalPanel);
+            Assert.IsFalse(originalPanel!.IsInCopyMode, "panel must start outside copy mode");
 
             // Step 1: mouse Down arms the pending bubble drag for the
             // SelectionPanel (the click hits the non-focusable container).
@@ -536,8 +534,7 @@ public class SelectionPanelMouseDragIntegrationTests
 
             // Pending bubble drag is armed but NOT activated yet (no Move
             // has arrived). Panel still not in copy mode.
-            Assert.False(originalPanel.IsInCopyMode,
-                "Down alone must not enter copy mode (bubble drag activates on Move)");
+            Assert.IsFalse(originalPanel.IsInCopyMode, "Down alone must not enter copy mode (bubble drag activates on Move)");
 
             // Step 2: rebuild the tree without the SelectionPanel. Wait
             // for the panel to actually leave the live node tree before
@@ -569,10 +566,8 @@ public class SelectionPanelMouseDragIntegrationTests
             // been pushed into copy mode behind our backs. Pre-fix this
             // would be true (handler.OnMove invoked → EnterCopyMode +
             // anchor + cursor mutation on a node nobody renders).
-            Assert.False(originalPanel.IsInCopyMode,
-                "Stale pending drag must not enter copy mode on a detached panel");
-            Assert.False(originalPanel.HasSelection,
-                "Stale pending drag must not start a selection on a detached panel");
+            Assert.IsFalse(originalPanel.IsInCopyMode, "Stale pending drag must not enter copy mode on a detached panel");
+            Assert.IsFalse(originalPanel.HasSelection, "Stale pending drag must not start a selection on a detached panel");
 
             // Sanity: app is still alive and accepting input after the
             // sequence (no crash from operating on stale state).
@@ -582,7 +577,7 @@ public class SelectionPanelMouseDragIntegrationTests
                 .Build()
                 .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-            Assert.True(snapshot.ContainsText("PANEL REMOVED"));
+            Assert.IsTrue(snapshot.ContainsText("PANEL REMOVED"));
         }
         finally
         {

--- a/tests/Hex1b.Tests/SelectionPanelNodeTests.cs
+++ b/tests/Hex1b.Tests/SelectionPanelNodeTests.cs
@@ -11,13 +11,14 @@ namespace Hex1b.Tests;
 /// copy mode, cursor / anchor state inside copy mode, and the rendered
 /// inversion overlay.
 /// </summary>
+[TestClass]
 public class SelectionPanelNodeTests
 {
     // ------------------------------------------------------------------
     // Pass-through tests (outside copy mode)
     // ------------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Measure_ReturnsChildSize()
     {
         var child = new TextBlockNode { Text = "Hello" };
@@ -25,22 +26,22 @@ public class SelectionPanelNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(5, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(5, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithNoChild_ReturnsZero()
     {
         var node = new SelectionPanelNode { Child = null };
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(0, size.Width);
-        Assert.Equal(0, size.Height);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(0, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_ForwardsRectToChild()
     {
         var child = new TextBlockNode { Text = "Hi" };
@@ -50,19 +51,19 @@ public class SelectionPanelNodeTests
         node.Measure(Constraints.Unbounded);
         node.Arrange(rect);
 
-        Assert.Equal(rect, child.Bounds);
-        Assert.Equal(rect, node.Bounds);
+        Assert.AreEqual(rect, child.Bounds);
+        Assert.AreEqual(rect, node.Bounds);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsFocusable_IsFalse()
     {
         var node = new SelectionPanelNode();
 
-        Assert.False(node.IsFocusable);
+        Assert.IsFalse(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetFocusableNodes_ReturnsChildFocusables()
     {
         var child = new TextBoxNode { Text = "x" };
@@ -70,11 +71,11 @@ public class SelectionPanelNodeTests
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Single(focusables);
-        Assert.Same(child, focusables[0]);
+        TestSeq.Single(focusables);
+        Assert.AreSame(child, focusables[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_ReturnsChild()
     {
         var child = new TextBlockNode { Text = "x" };
@@ -82,11 +83,11 @@ public class SelectionPanelNodeTests
 
         var children = node.GetChildren().ToList();
 
-        Assert.Single(children);
-        Assert.Same(child, children[0]);
+        TestSeq.Single(children);
+        Assert.AreSame(child, children[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsFocused_SetterForwardsToChild()
     {
         var child = new TextBoxNode { Text = "" };
@@ -94,14 +95,14 @@ public class SelectionPanelNodeTests
 
         node.IsFocused = true;
 
-        Assert.True(child.IsFocused);
+        Assert.IsTrue(child.IsFocused);
     }
 
     // ------------------------------------------------------------------
     // SnapshotText (selection-driven)
     // ------------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void SnapshotText_NoSelection_ReturnsEmpty()
     {
         var node = new SelectionPanelNode { Child = new TextBlockNode { Text = "Hello" } };
@@ -109,17 +110,17 @@ public class SelectionPanelNodeTests
         node.Arrange(new Rect(0, 0, 5, 1));
 
         // No anchor set → empty.
-        Assert.Equal(string.Empty, node.SnapshotText());
+        Assert.AreEqual(string.Empty, node.SnapshotText());
     }
 
-    [Fact]
+    [TestMethod]
     public void SnapshotText_NoChild_ReturnsEmpty()
     {
         var node = new SelectionPanelNode { Child = null };
-        Assert.Equal(string.Empty, node.SnapshotText());
+        Assert.AreEqual(string.Empty, node.SnapshotText());
     }
 
-    [Fact]
+    [TestMethod]
     public void SnapshotText_CharacterSelection_OnSingleRow_ReturnsRangeText()
     {
         var painter = new PaintingTestNode();
@@ -133,10 +134,10 @@ public class SelectionPanelNodeTests
         node.StartOrToggleSelection(SelectionMode.Character);
         node.SetCursor(2, 8);
 
-        Assert.Equal("CCCCCC", node.SnapshotText());
+        Assert.AreEqual("CCCCCC", node.SnapshotText());
     }
 
-    [Fact]
+    [TestMethod]
     public void SnapshotText_LineSelection_ReturnsFullRows()
     {
         var painter = new PaintingTestNode();
@@ -149,12 +150,10 @@ public class SelectionPanelNodeTests
         node.StartOrToggleSelection(SelectionMode.Line);
         node.SetCursor(5, 0);
 
-        Assert.Equal(
-            "CCCCCCCCCCCC\nDDDDDDDDDDDD\nEEEEEEEEEEEE\nFFFFFFFFFFFF",
-            node.SnapshotText().Replace("\r\n", "\n"));
+        Assert.AreEqual("CCCCCCCCCCCC\nDDDDDDDDDDDD\nEEEEEEEEEEEE\nFFFFFFFFFFFF", node.SnapshotText().Replace("\r\n", "\n"));
     }
 
-    [Fact]
+    [TestMethod]
     public void SnapshotText_BlockSelection_ReturnsRectangle()
     {
         var painter = new PaintingTestNode();
@@ -167,12 +166,10 @@ public class SelectionPanelNodeTests
         node.StartOrToggleSelection(SelectionMode.Block);
         node.SetCursor(5, 8);
 
-        Assert.Equal(
-            "CCCCCC\nDDDDDD\nEEEEEE\nFFFFFF",
-            node.SnapshotText().Replace("\r\n", "\n"));
+        Assert.AreEqual("CCCCCC\nDDDDDD\nEEEEEE\nFFFFFF", node.SnapshotText().Replace("\r\n", "\n"));
     }
 
-    [Fact]
+    [TestMethod]
     public void SnapshotText_CharacterSelection_OverManyRows_StreamsLikeTerminal()
     {
         var painter = new PaintingTestNode();
@@ -189,16 +186,14 @@ public class SelectionPanelNodeTests
         node.StartOrToggleSelection(SelectionMode.Character);
         node.SetCursor(5, 8);
 
-        Assert.Equal(
-            "CCCCCCCCC\nDDDDDDDDDDDD\nEEEEEEEEEEEE\nFFFFFFFFF",
-            node.SnapshotText().Replace("\r\n", "\n"));
+        Assert.AreEqual("CCCCCCCCC\nDDDDDDDDDDDD\nEEEEEEEEEEEE\nFFFFFFFFF", node.SnapshotText().Replace("\r\n", "\n"));
     }
 
     // ------------------------------------------------------------------
     // EnterCopyMode / ExitCopyMode / cursor + anchor state
     // ------------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void EnterCopyMode_StartsAtBottomLeft_AndClearsAnchor()
     {
         var node = new SelectionPanelNode { Child = new TextBlockNode { Text = "x" } };
@@ -207,14 +202,14 @@ public class SelectionPanelNodeTests
 
         node.EnterCopyMode();
 
-        Assert.True(node.IsInCopyMode);
-        Assert.Equal(7, node.CursorRow);
-        Assert.Equal(0, node.CursorCol);
-        Assert.False(node.HasSelection);
-        Assert.Equal(SelectionMode.Character, node.CursorSelectionMode);
+        Assert.IsTrue(node.IsInCopyMode);
+        Assert.AreEqual(7, node.CursorRow);
+        Assert.AreEqual(0, node.CursorCol);
+        Assert.IsFalse(node.HasSelection);
+        Assert.AreEqual(SelectionMode.Character, node.CursorSelectionMode);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExitCopyMode_ClearsAllState()
     {
         var node = new SelectionPanelNode { Child = new TextBlockNode { Text = "x" } };
@@ -225,11 +220,11 @@ public class SelectionPanelNodeTests
 
         node.ExitCopyMode();
 
-        Assert.False(node.IsInCopyMode);
-        Assert.False(node.HasSelection);
+        Assert.IsFalse(node.IsInCopyMode);
+        Assert.IsFalse(node.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_ClampsToBounds()
     {
         var node = new SelectionPanelNode { Child = new TextBlockNode { Text = "x" } };
@@ -240,15 +235,15 @@ public class SelectionPanelNodeTests
         node.SetCursor(0, 0);
 
         node.MoveCursor(-100, -100);
-        Assert.Equal(0, node.CursorRow);
-        Assert.Equal(0, node.CursorCol);
+        Assert.AreEqual(0, node.CursorRow);
+        Assert.AreEqual(0, node.CursorCol);
 
         node.MoveCursor(100, 100);
-        Assert.Equal(4, node.CursorRow);
-        Assert.Equal(9, node.CursorCol);
+        Assert.AreEqual(4, node.CursorRow);
+        Assert.AreEqual(9, node.CursorCol);
     }
 
-    [Fact]
+    [TestMethod]
     public void StartOrToggleSelection_FirstCall_SetsAnchorAtCursor()
     {
         var node = new SelectionPanelNode { Child = new TextBlockNode { Text = "x" } };
@@ -259,13 +254,13 @@ public class SelectionPanelNodeTests
 
         node.StartOrToggleSelection(SelectionMode.Character);
 
-        Assert.True(node.HasSelection);
-        Assert.Equal(2, node.AnchorRow);
-        Assert.Equal(3, node.AnchorCol);
-        Assert.Equal(SelectionMode.Character, node.CursorSelectionMode);
+        Assert.IsTrue(node.HasSelection);
+        Assert.AreEqual(2, node.AnchorRow);
+        Assert.AreEqual(3, node.AnchorCol);
+        Assert.AreEqual(SelectionMode.Character, node.CursorSelectionMode);
     }
 
-    [Fact]
+    [TestMethod]
     public void StartOrToggleSelection_SameMode_ClearsSelection()
     {
         var node = new SelectionPanelNode { Child = new TextBlockNode { Text = "x" } };
@@ -277,10 +272,10 @@ public class SelectionPanelNodeTests
 
         node.StartOrToggleSelection(SelectionMode.Character);
 
-        Assert.False(node.HasSelection);
+        Assert.IsFalse(node.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void StartOrToggleSelection_DifferentMode_KeepsAnchorChangesMode()
     {
         var node = new SelectionPanelNode { Child = new TextBlockNode { Text = "x" } };
@@ -292,17 +287,17 @@ public class SelectionPanelNodeTests
 
         node.StartOrToggleSelection(SelectionMode.Block);
 
-        Assert.True(node.HasSelection);
-        Assert.Equal(2, node.AnchorRow);
-        Assert.Equal(3, node.AnchorCol);
-        Assert.Equal(SelectionMode.Block, node.CursorSelectionMode);
+        Assert.IsTrue(node.HasSelection);
+        Assert.AreEqual(2, node.AnchorRow);
+        Assert.AreEqual(3, node.AnchorCol);
+        Assert.AreEqual(SelectionMode.Block, node.CursorSelectionMode);
     }
 
     // ------------------------------------------------------------------
     // ConfigureDefaultBindings
     // ------------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void ConfigureDefaultBindings_NoHandler_RegistersNoBinding()
     {
         var node = new SelectionPanelNode { Child = new TextBlockNode { Text = "x" } };
@@ -310,10 +305,10 @@ public class SelectionPanelNodeTests
 
         node.ConfigureDefaultBindings(bindings);
 
-        Assert.Empty(bindings.Bindings);
+        Assert.IsEmpty(bindings.Bindings);
     }
 
-    [Fact]
+    [TestMethod]
     public void ConfigureDefaultBindings_WithHandler_RegistersGlobalEntry_AndCaptureOverrideActions()
     {
         var node = new SelectionPanelNode
@@ -327,27 +322,26 @@ public class SelectionPanelNodeTests
 
         // Exactly one global binding — the F12 entry.
         var globals = bindings.Bindings.Where(b => b.IsGlobal).ToList();
-        Assert.Single(globals);
+        TestSeq.Single(globals);
         var entry = globals[0];
-        Assert.Equal(SelectionPanelWidget.EnterCopyMode, entry.ActionId);
-        Assert.Equal(Hex1bKey.F12, entry.Steps[0].Key);
+        Assert.AreEqual(SelectionPanelWidget.EnterCopyMode, entry.ActionId);
+        Assert.AreEqual(Hex1bKey.F12, entry.Steps[0].Key);
 
         // Every other binding is a capture-override.
         var captureOverrides = bindings.Bindings.Where(b => !b.IsGlobal).ToList();
-        Assert.NotEmpty(captureOverrides);
-        Assert.All(captureOverrides, b => Assert.True(b.OverridesCapture,
-            $"Non-global binding {b.ActionId} should be a capture-override binding."));
+        Assert.IsNotEmpty(captureOverrides);
+        TestSeq.All(captureOverrides, b => Assert.IsTrue(b.OverridesCapture, $"Non-global binding {b.ActionId} should be a capture-override binding."));
 
         // Spot-check key bindings exist.
-        Assert.Contains(captureOverrides, b => b.Steps[0].Key == Hex1bKey.UpArrow && b.ActionId == SelectionPanelWidget.CopyModeUp);
-        Assert.Contains(captureOverrides, b => b.Steps[0].Key == Hex1bKey.DownArrow && b.ActionId == SelectionPanelWidget.CopyModeDown);
-        Assert.Contains(captureOverrides, b => b.Steps[0].Key == Hex1bKey.Y && b.ActionId == SelectionPanelWidget.CopyModeCopy);
-        Assert.Contains(captureOverrides, b => b.Steps[0].Key == Hex1bKey.Enter && b.ActionId == SelectionPanelWidget.CopyModeCopy);
-        Assert.Contains(captureOverrides, b => b.Steps[0].Key == Hex1bKey.Escape && b.ActionId == SelectionPanelWidget.CopyModeCancel);
-        Assert.Contains(captureOverrides, b => b.Steps[0].Key == Hex1bKey.V && b.Steps[0].Modifiers == Hex1bModifiers.None && b.ActionId == SelectionPanelWidget.CopyModeStartSelection);
+        Assert.IsTrue(captureOverrides.Any(b => b.Steps[0].Key == Hex1bKey.UpArrow && b.ActionId == SelectionPanelWidget.CopyModeUp));
+        Assert.IsTrue(captureOverrides.Any(b => b.Steps[0].Key == Hex1bKey.DownArrow && b.ActionId == SelectionPanelWidget.CopyModeDown));
+        Assert.IsTrue(captureOverrides.Any(b => b.Steps[0].Key == Hex1bKey.Y && b.ActionId == SelectionPanelWidget.CopyModeCopy));
+        Assert.IsTrue(captureOverrides.Any(b => b.Steps[0].Key == Hex1bKey.Enter && b.ActionId == SelectionPanelWidget.CopyModeCopy));
+        Assert.IsTrue(captureOverrides.Any(b => b.Steps[0].Key == Hex1bKey.Escape && b.ActionId == SelectionPanelWidget.CopyModeCancel));
+        Assert.IsTrue(captureOverrides.Any(b => b.Steps[0].Key == Hex1bKey.V && b.Steps[0].Modifiers == Hex1bModifiers.None && b.ActionId == SelectionPanelWidget.CopyModeStartSelection));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task EnterCopyMode_BindingHandler_SetsCopyMode_AndCapturesInput()
     {
         var node = new SelectionPanelNode
@@ -365,11 +359,11 @@ public class SelectionPanelNodeTests
         var focusRing = new FocusRing();
         await entry.ExecuteAsync(new InputBindingActionContext(focusRing));
 
-        Assert.True(node.IsInCopyMode);
-        Assert.Same(node, focusRing.CapturedNode);
+        Assert.IsTrue(node.IsInCopyMode);
+        Assert.AreSame(node, focusRing.CapturedNode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CopyAction_WithSelection_InvokesHandler_ExitsCopyMode_ReleasesCapture()
     {
         string? captured = null;
@@ -394,12 +388,12 @@ public class SelectionPanelNodeTests
         focusRing.CaptureInput(node);
         await copy.ExecuteAsync(new InputBindingActionContext(focusRing));
 
-        Assert.Equal("Hello", captured);
-        Assert.False(node.IsInCopyMode);
-        Assert.Null(focusRing.CapturedNode);
+        Assert.AreEqual("Hello", captured);
+        Assert.IsFalse(node.IsInCopyMode);
+        Assert.IsNull(focusRing.CapturedNode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CopyAction_WithoutSelection_DoesNothing()
     {
         bool handlerCalled = false;
@@ -420,13 +414,13 @@ public class SelectionPanelNodeTests
         focusRing.CaptureInput(node);
         await copy.ExecuteAsync(new InputBindingActionContext(focusRing));
 
-        Assert.False(handlerCalled);
+        Assert.IsFalse(handlerCalled);
         // Still in copy mode (Y/Enter without selection is a no-op).
-        Assert.True(node.IsInCopyMode);
-        Assert.Same(node, focusRing.CapturedNode);
+        Assert.IsTrue(node.IsInCopyMode);
+        Assert.AreSame(node, focusRing.CapturedNode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CancelAction_ExitsCopyMode_WithoutInvokingHandler()
     {
         bool handlerCalled = false;
@@ -448,12 +442,12 @@ public class SelectionPanelNodeTests
         focusRing.CaptureInput(node);
         await cancel.ExecuteAsync(new InputBindingActionContext(focusRing));
 
-        Assert.False(handlerCalled);
-        Assert.False(node.IsInCopyMode);
-        Assert.Null(focusRing.CapturedNode);
+        Assert.IsFalse(handlerCalled);
+        Assert.IsFalse(node.IsInCopyMode);
+        Assert.IsNull(focusRing.CapturedNode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task EnterCopyMode_WhileAlreadyInCopyMode_IsNoOp()
     {
         var node = new SelectionPanelNode
@@ -474,17 +468,17 @@ public class SelectionPanelNodeTests
         await entry.ExecuteAsync(new InputBindingActionContext(new FocusRing()));
 
         // Re-entry guarded — selection state preserved.
-        Assert.True(node.IsInCopyMode);
-        Assert.Equal(2, node.CursorRow);
-        Assert.Equal(3, node.CursorCol);
-        Assert.True(node.HasSelection);
+        Assert.IsTrue(node.IsInCopyMode);
+        Assert.AreEqual(2, node.CursorRow);
+        Assert.AreEqual(3, node.CursorCol);
+        Assert.IsTrue(node.HasSelection);
     }
 
     // ------------------------------------------------------------------
     // Render: cursor + selection inversion overlay
     // ------------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Render_NotInCopyMode_PassesThroughChild_NoInversion()
     {
         var painter = new PaintingTestNode();
@@ -500,15 +494,14 @@ public class SelectionPanelNodeTests
         {
             for (int x = 0; x < 12; x++)
             {
-                Assert.True(surface.TryGetCell(x, y, out var cell));
-                Assert.Equal(((char)('A' + y)).ToString(), cell.Character);
-                Assert.False(cell.Attributes.HasFlag(CellAttributes.Reverse),
-                    $"Cell ({x},{y}) should not be inverted outside copy mode.");
+                Assert.IsTrue(surface.TryGetCell(x, y, out var cell));
+                Assert.AreEqual(((char)('A' + y)).ToString(), cell.Character);
+                Assert.IsFalse(cell.Attributes.HasFlag(CellAttributes.Reverse), $"Cell ({x},{y}) should not be inverted outside copy mode.");
             }
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_InCopyMode_NoSelection_InvertsCursorCellOnly()
     {
         var painter = new PaintingTestNode();
@@ -526,14 +519,14 @@ public class SelectionPanelNodeTests
         {
             for (int x = 0; x < 12; x++)
             {
-                Assert.True(surface.TryGetCell(x, y, out var cell));
+                Assert.IsTrue(surface.TryGetCell(x, y, out var cell));
                 bool expectInverted = (x == 5 && y == 3);
-                Assert.Equal(expectInverted, cell.Attributes.HasFlag(CellAttributes.Reverse));
+                Assert.AreEqual(expectInverted, cell.Attributes.HasFlag(CellAttributes.Reverse));
             }
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_BlockSelection_InvertsRectangleRegion()
     {
         var painter = new PaintingTestNode();
@@ -553,14 +546,14 @@ public class SelectionPanelNodeTests
         {
             for (int x = 0; x < 12; x++)
             {
-                Assert.True(surface.TryGetCell(x, y, out var cell));
+                Assert.IsTrue(surface.TryGetCell(x, y, out var cell));
                 bool inside = y >= 2 && y <= 5 && x >= 3 && x <= 8;
-                Assert.Equal(inside, cell.Attributes.HasFlag(CellAttributes.Reverse));
+                Assert.AreEqual(inside, cell.Attributes.HasFlag(CellAttributes.Reverse));
             }
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_LineSelection_InvertsFullRows()
     {
         var painter = new PaintingTestNode();
@@ -580,14 +573,14 @@ public class SelectionPanelNodeTests
         {
             for (int x = 0; x < 12; x++)
             {
-                Assert.True(surface.TryGetCell(x, y, out var cell));
+                Assert.IsTrue(surface.TryGetCell(x, y, out var cell));
                 bool inside = y >= 2 && y <= 4;
-                Assert.Equal(inside, cell.Attributes.HasFlag(CellAttributes.Reverse));
+                Assert.AreEqual(inside, cell.Attributes.HasFlag(CellAttributes.Reverse));
             }
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_CharacterSelection_InvertsStreamRegion()
     {
         var painter = new PaintingTestNode();
@@ -610,12 +603,12 @@ public class SelectionPanelNodeTests
         {
             for (int x = 0; x < 12; x++)
             {
-                Assert.True(surface.TryGetCell(x, y, out var cell));
+                Assert.IsTrue(surface.TryGetCell(x, y, out var cell));
                 bool inside =
                     (y == 2 && x >= 3) ||
                     (y > 2 && y < 5) ||
                     (y == 5 && x <= 8);
-                Assert.Equal(inside, cell.Attributes.HasFlag(CellAttributes.Reverse));
+                Assert.AreEqual(inside, cell.Attributes.HasFlag(CellAttributes.Reverse));
             }
         }
     }
@@ -643,7 +636,7 @@ public class SelectionPanelNodeTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void ConfigureDefaultBindings_WithHandler_RegistersFourDragBindings()
     {
         var node = new SelectionPanelNode
@@ -655,8 +648,8 @@ public class SelectionPanelNodeTests
 
         node.ConfigureDefaultBindings(bindings);
 
-        Assert.Equal(4, bindings.DragBindings.Count);
-        Assert.All(bindings.DragBindings, b => Assert.Equal(MouseButton.Left, b.Button));
+        Assert.AreEqual(4, bindings.DragBindings.Count);
+        TestSeq.All(bindings.DragBindings, b => Assert.AreEqual(MouseButton.Left, b.Button));
 
         var modifierSets = bindings.DragBindings.Select(b => b.Modifiers).ToHashSet();
         Assert.Contains(Hex1bModifiers.None, modifierSets);
@@ -665,7 +658,7 @@ public class SelectionPanelNodeTests
         Assert.Contains(Hex1bModifiers.Alt, modifierSets);
     }
 
-    [Fact]
+    [TestMethod]
     public void ConfigureDefaultBindings_WithoutHandler_RegistersNoDragBindings()
     {
         var node = new SelectionPanelNode
@@ -676,10 +669,10 @@ public class SelectionPanelNodeTests
 
         node.ConfigureDefaultBindings(bindings);
 
-        Assert.Empty(bindings.DragBindings);
+        Assert.IsEmpty(bindings.DragBindings);
     }
 
-    [Fact]
+    [TestMethod]
     public void DragBinding_StartDrag_EntersCopyMode_AnchorsCursor_StartsCharacterSelection()
     {
         var node = SetupArrangedNode(width: 20, height: 5);
@@ -688,17 +681,17 @@ public class SelectionPanelNodeTests
         // Drag begins at local (4, 2) within the node's surface.
         var handler = dragBinding.StartDrag(4, 2);
 
-        Assert.True(node.IsInCopyMode);
-        Assert.Equal(2, node.CursorRow);
-        Assert.Equal(4, node.CursorCol);
-        Assert.True(node.HasSelection);
-        Assert.Equal(2, node.AnchorRow);
-        Assert.Equal(4, node.AnchorCol);
-        Assert.Equal(SelectionMode.Character, node.CursorSelectionMode);
-        Assert.False(handler.IsEmpty);
+        Assert.IsTrue(node.IsInCopyMode);
+        Assert.AreEqual(2, node.CursorRow);
+        Assert.AreEqual(4, node.CursorCol);
+        Assert.IsTrue(node.HasSelection);
+        Assert.AreEqual(2, node.AnchorRow);
+        Assert.AreEqual(4, node.AnchorCol);
+        Assert.AreEqual(SelectionMode.Character, node.CursorSelectionMode);
+        Assert.IsFalse(handler.IsEmpty);
     }
 
-    [Fact]
+    [TestMethod]
     public void DragBinding_OnMove_UpdatesCursorRelativeToAnchor()
     {
         var node = SetupArrangedNode(width: 20, height: 10);
@@ -712,14 +705,14 @@ public class SelectionPanelNodeTests
 
         handler.OnMove?.Invoke(ctx, 5, 2);
 
-        Assert.True(node.IsInCopyMode);
-        Assert.Equal(1, node.AnchorRow);
-        Assert.Equal(3, node.AnchorCol);
-        Assert.Equal(3, node.CursorRow);
-        Assert.Equal(8, node.CursorCol);
+        Assert.IsTrue(node.IsInCopyMode);
+        Assert.AreEqual(1, node.AnchorRow);
+        Assert.AreEqual(3, node.AnchorCol);
+        Assert.AreEqual(3, node.CursorRow);
+        Assert.AreEqual(8, node.CursorCol);
     }
 
-    [Fact]
+    [TestMethod]
     public void DragBinding_OnMove_ClampsToNodeBounds()
     {
         var node = SetupArrangedNode(width: 10, height: 5);
@@ -731,11 +724,11 @@ public class SelectionPanelNodeTests
 
         handler.OnMove?.Invoke(ctx, 100, 100);
 
-        Assert.Equal(4, node.CursorRow);
-        Assert.Equal(9, node.CursorCol);
+        Assert.AreEqual(4, node.CursorRow);
+        Assert.AreEqual(9, node.CursorCol);
     }
 
-    [Fact]
+    [TestMethod]
     public void DragBinding_OnEnd_InstallsKeyboardCapture()
     {
         var node = SetupArrangedNode(width: 20, height: 5);
@@ -745,11 +738,11 @@ public class SelectionPanelNodeTests
         var handler = dragBinding.StartDrag(2, 1);
         handler.OnEnd?.Invoke(new InputBindingActionContext(focusRing));
 
-        Assert.True(node.IsInCopyMode);
-        Assert.Same(node, focusRing.CapturedNode);
+        Assert.IsTrue(node.IsInCopyMode);
+        Assert.AreSame(node, focusRing.CapturedNode);
     }
 
-    [Fact]
+    [TestMethod]
     public void ShiftDrag_StartsLineSelection()
     {
         var node = SetupArrangedNode(width: 20, height: 5);
@@ -757,12 +750,12 @@ public class SelectionPanelNodeTests
 
         dragBinding.StartDrag(4, 2);
 
-        Assert.True(node.IsInCopyMode);
-        Assert.Equal(SelectionMode.Line, node.CursorSelectionMode);
-        Assert.True(node.HasSelection);
+        Assert.IsTrue(node.IsInCopyMode);
+        Assert.AreEqual(SelectionMode.Line, node.CursorSelectionMode);
+        Assert.IsTrue(node.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void AltDrag_StartsBlockSelection()
     {
         var node = SetupArrangedNode(width: 20, height: 5);
@@ -770,12 +763,12 @@ public class SelectionPanelNodeTests
 
         dragBinding.StartDrag(4, 2);
 
-        Assert.True(node.IsInCopyMode);
-        Assert.Equal(SelectionMode.Block, node.CursorSelectionMode);
-        Assert.True(node.HasSelection);
+        Assert.IsTrue(node.IsInCopyMode);
+        Assert.AreEqual(SelectionMode.Block, node.CursorSelectionMode);
+        Assert.IsTrue(node.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void DragBinding_NegativeLocalCoordinates_ClampToZero()
     {
         // When SelectionPanel is inside a scrolled ScrollPanel, Bounds.Y can be
@@ -785,14 +778,14 @@ public class SelectionPanelNodeTests
 
         dragBinding.StartDrag(-3, -2);
 
-        Assert.True(node.IsInCopyMode);
-        Assert.Equal(0, node.CursorRow);
-        Assert.Equal(0, node.CursorCol);
-        Assert.Equal(0, node.AnchorRow);
-        Assert.Equal(0, node.AnchorCol);
+        Assert.IsTrue(node.IsInCopyMode);
+        Assert.AreEqual(0, node.CursorRow);
+        Assert.AreEqual(0, node.CursorCol);
+        Assert.AreEqual(0, node.AnchorRow);
+        Assert.AreEqual(0, node.AnchorCol);
     }
 
-    [Fact]
+    [TestMethod]
     public void DragBinding_OnMove_TracksMouseAfterBoundsShift()
     {
         // When an enclosing ScrollPanel scrolls mid-drag, this node's Bounds.Y
@@ -815,8 +808,8 @@ public class SelectionPanelNodeTests
         // Initial drag-move at terminal (5, 10): cursor at panel-local (5, 10).
         var ctxBefore = new InputBindingActionContext(new FocusRing(), mouseX: 5, mouseY: 10);
         handler.OnMove?.Invoke(ctxBefore, 0, 0);
-        Assert.Equal(10, node.CursorRow);
-        Assert.Equal(5, node.CursorCol);
+        Assert.AreEqual(10, node.CursorRow);
+        Assert.AreEqual(5, node.CursorCol);
 
         // Simulate scroll: panel slides up by 3 rows (Bounds.Y goes from 0 to -3).
         node.Arrange(new Rect(0, -3, 20, 50));
@@ -825,8 +818,8 @@ public class SelectionPanelNodeTests
         // cell under the mouse is now panel-local row 13 (10 - (-3)).
         var ctxAfter = new InputBindingActionContext(new FocusRing(), mouseX: 5, mouseY: 10);
         handler.OnMove?.Invoke(ctxAfter, 0, 0);
-        Assert.Equal(13, node.CursorRow);
-        Assert.Equal(5, node.CursorCol);
+        Assert.AreEqual(13, node.CursorRow);
+        Assert.AreEqual(5, node.CursorCol);
     }
 
     private static SelectionPanelNode SetupArrangedNode(int width, int height)
@@ -846,7 +839,7 @@ public class SelectionPanelNodeTests
     // BuildCopyEventArgs: rich payload with bounds + per-node breakdown.
     // ------------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void BuildCopyEventArgs_NoSelection_ReturnsEmptyPayload()
     {
         var node = new SelectionPanelNode { Child = new TextBlockNode { Text = "Hello" } };
@@ -856,13 +849,13 @@ public class SelectionPanelNodeTests
 
         var args = node.BuildCopyEventArgs();
 
-        Assert.Equal(string.Empty, args.Text);
-        Assert.Equal(Rect.Zero, args.PanelBounds);
-        Assert.Equal(Rect.Zero, args.TerminalBounds);
-        Assert.Empty(args.Nodes);
+        Assert.AreEqual(string.Empty, args.Text);
+        Assert.AreEqual(Rect.Zero, args.PanelBounds);
+        Assert.AreEqual(Rect.Zero, args.TerminalBounds);
+        Assert.IsEmpty(args.Nodes);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildCopyEventArgs_BlockSelection_ProducesExactBoundsAndIntersections()
     {
         // Layout: SelectionPanel at (10, 5) wraps a TextBlock that fills it.
@@ -877,17 +870,17 @@ public class SelectionPanelNodeTests
 
         var args = node.BuildCopyEventArgs();
 
-        Assert.Equal(SelectionMode.Block, args.Mode);
-        Assert.Equal(new Rect(2, 0, 4, 1), args.PanelBounds);
-        Assert.Equal(new Rect(12, 5, 4, 1), args.TerminalBounds);
+        Assert.AreEqual(SelectionMode.Block, args.Mode);
+        Assert.AreEqual(new Rect(2, 0, 4, 1), args.PanelBounds);
+        Assert.AreEqual(new Rect(12, 5, 4, 1), args.TerminalBounds);
 
         // The TextBlock child fills the panel so its bounds intersect.
-        var textEntry = Assert.Single(args.Nodes, n => n.Node is TextBlockNode);
-        Assert.True(textEntry.IntersectionInTerminal == new Rect(12, 5, 4, 1));
-        Assert.False(textEntry.IsFullySelected); // only 4 of 10 cols selected
+        var textEntry = TestSeq.Single(args.Nodes, n => n.Node is TextBlockNode);
+        Assert.IsTrue(textEntry.IntersectionInTerminal == new Rect(12, 5, 4, 1));
+        Assert.IsFalse(textEntry.IsFullySelected); // only 4 of 10 cols selected
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildCopyEventArgs_LineSelection_FullsRowsAreFullySelected()
     {
         // VStack with three single-row TextBlocks; line-select all three.
@@ -908,16 +901,16 @@ public class SelectionPanelNodeTests
 
         var args = node.BuildCopyEventArgs();
 
-        Assert.Equal(SelectionMode.Line, args.Mode);
-        Assert.Equal(new Rect(0, 0, 3, 3), args.PanelBounds);
+        Assert.AreEqual(SelectionMode.Line, args.Mode);
+        Assert.AreEqual(new Rect(0, 0, 3, 3), args.PanelBounds);
 
         // All three TextBlocks should be fully selected (each is one full row).
         var leafEntries = args.Nodes.Where(n => n.Node is TextBlockNode).ToList();
-        Assert.Equal(3, leafEntries.Count);
-        Assert.All(leafEntries, e => Assert.True(e.IsFullySelected));
+        Assert.AreEqual(3, leafEntries.Count);
+        TestSeq.All(leafEntries, e => Assert.IsTrue(e.IsFullySelected));
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildCopyEventArgs_LineSelection_PartialRowSpan_OnlyIntersectingNodesIncluded()
     {
         var t1 = new TextBlockNode { Text = "AAA" };
@@ -937,17 +930,17 @@ public class SelectionPanelNodeTests
 
         var args = node.BuildCopyEventArgs();
 
-        Assert.Equal(new Rect(0, 1, 3, 1), args.PanelBounds);
+        Assert.AreEqual(new Rect(0, 1, 3, 1), args.PanelBounds);
 
         var leafEntries = args.Nodes.Where(n => n.Node is TextBlockNode).ToList();
-        var single = Assert.Single(leafEntries);
-        Assert.Same(t2, single.Node);
-        Assert.True(single.IsFullySelected);
-        Assert.Equal(new Rect(0, 1, 3, 1), single.IntersectionInTerminal);
-        Assert.Equal(new Rect(0, 0, 3, 1), single.IntersectionInNode);
+        var single = TestSeq.Single(leafEntries);
+        Assert.AreSame(t2, single.Node);
+        Assert.IsTrue(single.IsFullySelected);
+        Assert.AreEqual(new Rect(0, 1, 3, 1), single.IntersectionInTerminal);
+        Assert.AreEqual(new Rect(0, 0, 3, 1), single.IntersectionInNode);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildCopyEventArgs_TerminalBounds_TranslatedByPanelOrigin()
     {
         var node = new SelectionPanelNode { Child = new TextBlockNode { Text = "Hello" } };
@@ -961,11 +954,11 @@ public class SelectionPanelNodeTests
 
         var args = node.BuildCopyEventArgs();
 
-        Assert.Equal(new Rect(0, 0, 5, 1), args.PanelBounds);
-        Assert.Equal(new Rect(20, 30, 5, 1), args.TerminalBounds);
+        Assert.AreEqual(new Rect(0, 0, 5, 1), args.PanelBounds);
+        Assert.AreEqual(new Rect(20, 30, 5, 1), args.TerminalBounds);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildCopyEventArgs_BlockSelection_PartialNodeReportsCorrectIntersectionInNode()
     {
         // TextBlock at (10, 10). Selection cuts off the last 2 columns.
@@ -981,13 +974,13 @@ public class SelectionPanelNodeTests
 
         var args = node.BuildCopyEventArgs();
 
-        var entry = Assert.Single(args.Nodes, n => n.Node is TextBlockNode);
-        Assert.False(entry.IsFullySelected);
-        Assert.Equal(new Rect(0, 0, 8, 1), entry.IntersectionInNode);
-        Assert.Equal(new Rect(10, 10, 8, 1), entry.IntersectionInTerminal);
+        var entry = TestSeq.Single(args.Nodes, n => n.Node is TextBlockNode);
+        Assert.IsFalse(entry.IsFullySelected);
+        Assert.AreEqual(new Rect(0, 0, 8, 1), entry.IntersectionInNode);
+        Assert.AreEqual(new Rect(10, 10, 8, 1), entry.IntersectionInTerminal);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildCopyEventArgs_StreamSelection_NodeOnStartRowBeforeStartColumn_IsExcluded()
     {
         // Three single-row siblings on row 0: [LEFT][MIDDLE][RIGHT]
@@ -1023,21 +1016,21 @@ public class SelectionPanelNodeTests
         var args = node.BuildCopyEventArgs();
 
         // bbox spans full panel width across all 3 rows
-        Assert.Equal(new Rect(0, 0, 9, 3), args.PanelBounds);
+        Assert.AreEqual(new Rect(0, 0, 9, 3), args.PanelBounds);
 
         // LEFT (cols 0..2 on row 0) must be filtered out — start-row
         // selected cells start at col 6.
-        Assert.DoesNotContain(args.Nodes, n => ReferenceEquals(n.Node, left));
+        Assert.IsFalse(args.Nodes.Any(n => ReferenceEquals(n.Node, left)));
 
         // MIDDLE (cols 3..5 on row 0) is also entirely before col 6
         // and must be filtered out.
-        Assert.DoesNotContain(args.Nodes, n => ReferenceEquals(n.Node, middle));
+        Assert.IsFalse(args.Nodes.Any(n => ReferenceEquals(n.Node, middle)));
 
         // RIGHT (cols 6..8 on row 0) is at/after col 6 — included.
-        Assert.Contains(args.Nodes, n => ReferenceEquals(n.Node, right));
+        Assert.IsTrue(args.Nodes.Any(n => ReferenceEquals(n.Node, right)));
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildCopyEventArgs_StreamSelection_StartRowNodeReportsClippedIntersection()
     {
         // Single TextBlock spanning the full width of row 0; stream
@@ -1061,22 +1054,22 @@ public class SelectionPanelNodeTests
 
         var args = node.BuildCopyEventArgs();
 
-        var startEntry = Assert.Single(args.Nodes, n => ReferenceEquals(n.Node, startRowText));
+        var startEntry = TestSeq.Single(args.Nodes, n => ReferenceEquals(n.Node, startRowText));
         // Start-row selection runs from col 4 to end-of-row (col 7), so
         // 4 cells wide starting at col 4. In node-local coords that is
         // (4, 0, 4, 1).
-        Assert.Equal(new Rect(4, 0, 4, 1), startEntry.IntersectionInNode);
-        Assert.Equal(new Rect(4, 0, 4, 1), startEntry.IntersectionInTerminal);
-        Assert.False(startEntry.IsFullySelected);
+        Assert.AreEqual(new Rect(4, 0, 4, 1), startEntry.IntersectionInNode);
+        Assert.AreEqual(new Rect(4, 0, 4, 1), startEntry.IntersectionInTerminal);
+        Assert.IsFalse(startEntry.IsFullySelected);
 
-        var endEntry = Assert.Single(args.Nodes, n => ReferenceEquals(n.Node, nextRowText));
+        var endEntry = TestSeq.Single(args.Nodes, n => ReferenceEquals(n.Node, nextRowText));
         // End-row selection runs from col 0 to col 1 inclusive → 2 wide.
-        Assert.Equal(new Rect(0, 0, 2, 1), endEntry.IntersectionInNode);
-        Assert.Equal(new Rect(0, 1, 2, 1), endEntry.IntersectionInTerminal);
-        Assert.False(endEntry.IsFullySelected);
+        Assert.AreEqual(new Rect(0, 0, 2, 1), endEntry.IntersectionInNode);
+        Assert.AreEqual(new Rect(0, 1, 2, 1), endEntry.IntersectionInTerminal);
+        Assert.IsFalse(endEntry.IsFullySelected);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildCopyEventArgs_StreamSelection_MiddleRowNode_IsFullySelected()
     {
         // Three single-row TextBlocks. Stream from (row 0, col 1) to
@@ -1102,27 +1095,27 @@ public class SelectionPanelNodeTests
 
         var args = node.BuildCopyEventArgs();
 
-        var middleEntry = Assert.Single(args.Nodes, n => ReferenceEquals(n.Node, t1));
-        Assert.True(middleEntry.IsFullySelected);
-        Assert.Equal(new Rect(0, 0, 3, 1), middleEntry.IntersectionInNode);
-        Assert.Equal(new Rect(0, 1, 3, 1), middleEntry.IntersectionInTerminal);
+        var middleEntry = TestSeq.Single(args.Nodes, n => ReferenceEquals(n.Node, t1));
+        Assert.IsTrue(middleEntry.IsFullySelected);
+        Assert.AreEqual(new Rect(0, 0, 3, 1), middleEntry.IntersectionInNode);
+        Assert.AreEqual(new Rect(0, 1, 3, 1), middleEntry.IntersectionInTerminal);
 
         // Start-row node only partially selected (cols 1..2).
-        var startEntry = Assert.Single(args.Nodes, n => ReferenceEquals(n.Node, t0));
-        Assert.False(startEntry.IsFullySelected);
-        Assert.Equal(new Rect(1, 0, 2, 1), startEntry.IntersectionInNode);
+        var startEntry = TestSeq.Single(args.Nodes, n => ReferenceEquals(n.Node, t0));
+        Assert.IsFalse(startEntry.IsFullySelected);
+        Assert.AreEqual(new Rect(1, 0, 2, 1), startEntry.IntersectionInNode);
 
         // End-row node only partially selected (cols 0..1).
-        var endEntry = Assert.Single(args.Nodes, n => ReferenceEquals(n.Node, t2));
-        Assert.False(endEntry.IsFullySelected);
-        Assert.Equal(new Rect(0, 0, 2, 1), endEntry.IntersectionInNode);
+        var endEntry = TestSeq.Single(args.Nodes, n => ReferenceEquals(n.Node, t2));
+        Assert.IsFalse(endEntry.IsFullySelected);
+        Assert.AreEqual(new Rect(0, 0, 2, 1), endEntry.IntersectionInNode);
     }
 
     // ------------------------------------------------------------------
     // Right-click commit binding.
     // ------------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void ConfigureDefaultBindings_WithHandler_RegistersRightClickMouseBinding()
     {
         var node = new SelectionPanelNode
@@ -1137,11 +1130,11 @@ public class SelectionPanelNodeTests
         var mouseCommit = bindings.MouseBindings
             .Where(b => b.Button == MouseButton.Right && b.OverridesCapture)
             .ToList();
-        Assert.Single(mouseCommit);
-        Assert.Equal(SelectionPanelWidget.CopyModeMouseCommit, mouseCommit[0].ActionId);
+        TestSeq.Single(mouseCommit);
+        Assert.AreEqual(SelectionPanelWidget.CopyModeMouseCommit, mouseCommit[0].ActionId);
     }
 
-    [Fact]
+    [TestMethod]
     public void ConfigureDefaultBindings_WithoutHandler_DoesNotRegisterRightClickMouseBinding()
     {
         var node = new SelectionPanelNode { Child = new TextBlockNode { Text = "Hello" } };
@@ -1149,10 +1142,10 @@ public class SelectionPanelNodeTests
         var bindings = new InputBindingsBuilder();
         node.ConfigureDefaultBindings(bindings);
 
-        Assert.Empty(bindings.MouseBindings);
+        Assert.IsEmpty(bindings.MouseBindings);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RightClickCommit_WithSelection_InvokesHandler_ExitsCopyMode_ReleasesCapture()
     {
         SelectionPanelCopyEventArgs? captured = null;
@@ -1178,14 +1171,14 @@ public class SelectionPanelNodeTests
         focusRing.CaptureInput(node);
         await rightClick.ExecuteAsync(new InputBindingActionContext(focusRing));
 
-        Assert.NotNull(captured);
-        Assert.Equal("Hello", captured!.Text);
-        Assert.Equal(SelectionMode.Block, captured.Mode);
-        Assert.False(node.IsInCopyMode);
-        Assert.Null(focusRing.CapturedNode);
+        Assert.IsNotNull(captured);
+        Assert.AreEqual("Hello", captured!.Text);
+        Assert.AreEqual(SelectionMode.Block, captured.Mode);
+        Assert.IsFalse(node.IsInCopyMode);
+        Assert.IsNull(focusRing.CapturedNode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RightClickCommit_WithoutSelection_IsNoOp()
     {
         bool handlerCalled = false;
@@ -1209,13 +1202,13 @@ public class SelectionPanelNodeTests
         focusRing.CaptureInput(node);
         await rightClick.ExecuteAsync(new InputBindingActionContext(focusRing));
 
-        Assert.False(handlerCalled);
+        Assert.IsFalse(handlerCalled);
         // Stays in copy mode and keeps capture (matches Y/Enter no-op semantics).
-        Assert.True(node.IsInCopyMode);
-        Assert.Same(node, focusRing.CapturedNode);
+        Assert.IsTrue(node.IsInCopyMode);
+        Assert.AreSame(node, focusRing.CapturedNode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RightClickCommit_OutsideCopyMode_IsNoOp()
     {
         bool handlerCalled = false;
@@ -1234,15 +1227,15 @@ public class SelectionPanelNodeTests
 
         await rightClick.ExecuteAsync(new InputBindingActionContext(new FocusRing()));
 
-        Assert.False(handlerCalled);
-        Assert.False(node.IsInCopyMode);
+        Assert.IsFalse(handlerCalled);
+        Assert.IsFalse(node.IsInCopyMode);
     }
 
     // ------------------------------------------------------------------
     // OnCopy overloads on the widget pass through the args correctly.
     // ------------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public async Task OnCopy_StringOverload_ReceivesText()
     {
         string? received = null;
@@ -1253,10 +1246,10 @@ public class SelectionPanelNodeTests
             "TheText", SelectionMode.Character, Rect.Zero, Rect.Zero, []);
         await widget.CopyHandler!(args);
 
-        Assert.Equal("TheText", received);
+        Assert.AreEqual("TheText", received);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OnCopy_ArgsOverload_ReceivesFullPayload()
     {
         SelectionPanelCopyEventArgs? received = null;
@@ -1267,7 +1260,7 @@ public class SelectionPanelNodeTests
             "X", SelectionMode.Line, new Rect(1, 2, 3, 4), new Rect(5, 6, 7, 8), []);
         await widget.CopyHandler!(args);
 
-        Assert.Same(args, received);
+        Assert.AreSame(args, received);
     }
 
     // ------------------------------------------------------------------
@@ -1279,7 +1272,7 @@ public class SelectionPanelNodeTests
     //   4. Block / Character selections clip correctly at viewport edges.
     // ------------------------------------------------------------------
 
-    [Fact]
+    [TestMethod]
     public void Render_WithParentClipNarrowerThanBounds_OnlyClipRegionPainted()
     {
         // Panel is 12 wide × 20 rows tall (PaintingTestNode paints rows
@@ -1308,8 +1301,8 @@ public class SelectionPanelNodeTests
         {
             for (int x = 0; x < 12; x++)
             {
-                Assert.True(surface.TryGetCell(x, y, out var cell));
-                Assert.Equal(((char)('A' + y)).ToString(), cell.Character);
+                Assert.IsTrue(surface.TryGetCell(x, y, out var cell));
+                Assert.AreEqual(((char)('A' + y)).ToString(), cell.Character);
             }
         }
 
@@ -1321,7 +1314,7 @@ public class SelectionPanelNodeTests
             AssertRowUntouched(surface, y, "below parent clip");
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_LineSelection_SpanningOffscreenAndOnscreen_OnlyVisibleRowsInverted()
     {
         // 20-row panel; parent clip exposes terminal rows 5..10. Line
@@ -1351,9 +1344,8 @@ public class SelectionPanelNodeTests
         {
             for (int x = 0; x < 12; x++)
             {
-                Assert.True(surface.TryGetCell(x, y, out var cell));
-                Assert.True(cell.Attributes.HasFlag(CellAttributes.Reverse),
-                    $"Cell ({x},{y}) inside visible selection should be inverted.");
+                Assert.IsTrue(surface.TryGetCell(x, y, out var cell));
+                Assert.IsTrue(cell.Attributes.HasFlag(CellAttributes.Reverse), $"Cell ({x},{y}) inside visible selection should be inverted.");
             }
         }
 
@@ -1366,7 +1358,7 @@ public class SelectionPanelNodeTests
             AssertRowUntouched(surface, y, "below parent clip");
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_NoSelection_CursorOffscreen_NoInversion()
     {
         // Cursor at panel-local (0, 0), but parent clip exposes only
@@ -1392,14 +1384,13 @@ public class SelectionPanelNodeTests
         {
             for (int x = 0; x < 12; x++)
             {
-                Assert.True(surface.TryGetCell(x, y, out var cell));
-                Assert.False(cell.Attributes.HasFlag(CellAttributes.Reverse),
-                    $"Cell ({x},{y}) should not be inverted (cursor is off-clip).");
+                Assert.IsTrue(surface.TryGetCell(x, y, out var cell));
+                Assert.IsFalse(cell.Attributes.HasFlag(CellAttributes.Reverse), $"Cell ({x},{y}) should not be inverted (cursor is off-clip).");
             }
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_BlockSelection_ClippedAtRightViewportEdge()
     {
         // Panel 20 cols × 8 rows. Parent clip exposes only the LEFT
@@ -1429,9 +1420,8 @@ public class SelectionPanelNodeTests
         {
             for (int x = 3; x <= 11; x++)
             {
-                Assert.True(surface.TryGetCell(x, y, out var cell));
-                Assert.True(cell.Attributes.HasFlag(CellAttributes.Reverse),
-                    $"Cell ({x},{y}) inside visible block selection should be inverted.");
+                Assert.IsTrue(surface.TryGetCell(x, y, out var cell));
+                Assert.IsTrue(cell.Attributes.HasFlag(CellAttributes.Reverse), $"Cell ({x},{y}) inside visible block selection should be inverted.");
             }
         }
 
@@ -1440,8 +1430,8 @@ public class SelectionPanelNodeTests
         {
             for (int x = 12; x < 20; x++)
             {
-                Assert.True(surface.TryGetCell(x, y, out var cell));
-                Assert.Equal(SurfaceCells.Empty, cell);
+                Assert.IsTrue(surface.TryGetCell(x, y, out var cell));
+                Assert.AreEqual(SurfaceCells.Empty, cell);
             }
         }
 
@@ -1449,13 +1439,12 @@ public class SelectionPanelNodeTests
         // be painted (visible) yet NOT inverted.
         for (int x = 0; x <= 2; x++)
         {
-            Assert.True(surface.TryGetCell(x, 1, out var cell));
-            Assert.False(cell.Attributes.HasFlag(CellAttributes.Reverse),
-                $"Cell ({x},1) left of block selection should not be inverted.");
+            Assert.IsTrue(surface.TryGetCell(x, 1, out var cell));
+            Assert.IsFalse(cell.Attributes.HasFlag(CellAttributes.Reverse), $"Cell ({x},1) left of block selection should not be inverted.");
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_NegativeBoundsY_RendersAndInvertsOnlyBottomSlice()
     {
         // Panel scrolled so that Bounds.Y = -5: panel-local row 0 sits
@@ -1488,8 +1477,8 @@ public class SelectionPanelNodeTests
         {
             for (int x = 0; x < 12; x++)
             {
-                Assert.True(surface.TryGetCell(x, y, out var cell));
-                Assert.Equal(((char)('A' + 5 + y)).ToString(), cell.Character);
+                Assert.IsTrue(surface.TryGetCell(x, y, out var cell));
+                Assert.AreEqual(((char)('A' + 5 + y)).ToString(), cell.Character);
             }
         }
 
@@ -1499,13 +1488,13 @@ public class SelectionPanelNodeTests
             bool inSelection = y >= 1 && y <= 6;
             for (int x = 0; x < 12; x++)
             {
-                Assert.True(surface.TryGetCell(x, y, out var cell));
-                Assert.Equal(inSelection, cell.Attributes.HasFlag(CellAttributes.Reverse));
+                Assert.IsTrue(surface.TryGetCell(x, y, out var cell));
+                Assert.AreEqual(inSelection, cell.Attributes.HasFlag(CellAttributes.Reverse));
             }
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_PanelEntirelyOffscreen_LeavesParentSurfaceUntouched()
     {
         // Panel sits entirely above the parent clip — TryIntersectRect
@@ -1535,10 +1524,9 @@ public class SelectionPanelNodeTests
     {
         for (int x = 0; x < surface.Width; x++)
         {
-            Assert.True(surface.TryGetCell(x, y, out var cell));
-            Assert.Equal(SurfaceCells.Empty, cell);
-            Assert.False(cell.Attributes.HasFlag(CellAttributes.Reverse),
-                $"Cell ({x},{y}) should not be inverted ({reason}).");
+            Assert.IsTrue(surface.TryGetCell(x, y, out var cell));
+            Assert.AreEqual(SurfaceCells.Empty, cell);
+            Assert.IsFalse(cell.Attributes.HasFlag(CellAttributes.Reverse), $"Cell ({x},{y}) should not be inverted ({reason}).");
         }
     }
 }

--- a/tests/Hex1b.Tests/SgrHiddenStrikethroughTests.cs
+++ b/tests/Hex1b.Tests/SgrHiddenStrikethroughTests.cs
@@ -8,6 +8,7 @@ namespace Hex1b.Tests;
 /// and with combined attributes (bold + hidden + strikethrough).
 /// Inspired by psmux's test_issue155_sgr_attrs.rs and test_issue155_rendering.rs.
 /// </summary>
+[TestClass]
 public class SgrHiddenStrikethroughTests
 {
     private sealed class TestTerminal : IDisposable
@@ -34,7 +35,7 @@ public class SgrHiddenStrikethroughTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Sgr9_SetsStrikethrough_OnSubsequentCells()
     {
         using var t = new TestTerminal();
@@ -44,25 +45,24 @@ public class SgrHiddenStrikethroughTests
         for (int i = 0; i < 3; i++)
         {
             var cell = snap.GetCell(i, 0);
-            Assert.True(cell.Attributes.HasFlag(CellAttributes.Strikethrough),
-                $"Cell {i} should have strikethrough");
+            Assert.IsTrue(cell.Attributes.HasFlag(CellAttributes.Strikethrough), $"Cell {i} should have strikethrough");
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Sgr29_ClearsStrikethrough()
     {
         using var t = new TestTerminal();
         t.Write("\x1b[9mab\x1b[29mcd");
 
         var snap = t.Terminal.CreateSnapshot();
-        Assert.True(snap.GetCell(0, 0).Attributes.HasFlag(CellAttributes.Strikethrough));
-        Assert.True(snap.GetCell(1, 0).Attributes.HasFlag(CellAttributes.Strikethrough));
-        Assert.False(snap.GetCell(2, 0).Attributes.HasFlag(CellAttributes.Strikethrough));
-        Assert.False(snap.GetCell(3, 0).Attributes.HasFlag(CellAttributes.Strikethrough));
+        Assert.IsTrue(snap.GetCell(0, 0).Attributes.HasFlag(CellAttributes.Strikethrough));
+        Assert.IsTrue(snap.GetCell(1, 0).Attributes.HasFlag(CellAttributes.Strikethrough));
+        Assert.IsFalse(snap.GetCell(2, 0).Attributes.HasFlag(CellAttributes.Strikethrough));
+        Assert.IsFalse(snap.GetCell(3, 0).Attributes.HasFlag(CellAttributes.Strikethrough));
     }
 
-    [Fact]
+    [TestMethod]
     public void Sgr8_SetsHidden_OnSubsequentCells()
     {
         using var t = new TestTerminal();
@@ -72,25 +72,24 @@ public class SgrHiddenStrikethroughTests
         for (int i = 0; i < 6; i++)
         {
             var cell = snap.GetCell(i, 0);
-            Assert.True(cell.Attributes.HasFlag(CellAttributes.Hidden),
-                $"Cell {i} should have hidden attribute");
+            Assert.IsTrue(cell.Attributes.HasFlag(CellAttributes.Hidden), $"Cell {i} should have hidden attribute");
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Sgr28_ClearsHidden()
     {
         using var t = new TestTerminal();
         t.Write("\x1b[8mab\x1b[28mcd");
 
         var snap = t.Terminal.CreateSnapshot();
-        Assert.True(snap.GetCell(0, 0).Attributes.HasFlag(CellAttributes.Hidden));
-        Assert.True(snap.GetCell(1, 0).Attributes.HasFlag(CellAttributes.Hidden));
-        Assert.False(snap.GetCell(2, 0).Attributes.HasFlag(CellAttributes.Hidden));
-        Assert.False(snap.GetCell(3, 0).Attributes.HasFlag(CellAttributes.Hidden));
+        Assert.IsTrue(snap.GetCell(0, 0).Attributes.HasFlag(CellAttributes.Hidden));
+        Assert.IsTrue(snap.GetCell(1, 0).Attributes.HasFlag(CellAttributes.Hidden));
+        Assert.IsFalse(snap.GetCell(2, 0).Attributes.HasFlag(CellAttributes.Hidden));
+        Assert.IsFalse(snap.GetCell(3, 0).Attributes.HasFlag(CellAttributes.Hidden));
     }
 
-    [Fact]
+    [TestMethod]
     public void Sgr0_ResetsBothHiddenAndStrikethrough()
     {
         using var t = new TestTerminal();
@@ -100,16 +99,16 @@ public class SgrHiddenStrikethroughTests
 
         // First 2 cells: both hidden and strikethrough
         var cellA = snap.GetCell(0, 0);
-        Assert.True(cellA.Attributes.HasFlag(CellAttributes.Hidden));
-        Assert.True(cellA.Attributes.HasFlag(CellAttributes.Strikethrough));
+        Assert.IsTrue(cellA.Attributes.HasFlag(CellAttributes.Hidden));
+        Assert.IsTrue(cellA.Attributes.HasFlag(CellAttributes.Strikethrough));
 
         // After SGR 0 reset: neither
         var cellC = snap.GetCell(2, 0);
-        Assert.False(cellC.Attributes.HasFlag(CellAttributes.Hidden));
-        Assert.False(cellC.Attributes.HasFlag(CellAttributes.Strikethrough));
+        Assert.IsFalse(cellC.Attributes.HasFlag(CellAttributes.Hidden));
+        Assert.IsFalse(cellC.Attributes.HasFlag(CellAttributes.Strikethrough));
     }
 
-    [Fact]
+    [TestMethod]
     public void CombinedBoldHiddenStrikethrough_AllActive()
     {
         using var t = new TestTerminal();
@@ -118,12 +117,12 @@ public class SgrHiddenStrikethroughTests
         var snap = t.Terminal.CreateSnapshot();
         var cell = snap.GetCell(0, 0);
 
-        Assert.True(cell.Attributes.HasFlag(CellAttributes.Bold));
-        Assert.True(cell.Attributes.HasFlag(CellAttributes.Hidden));
-        Assert.True(cell.Attributes.HasFlag(CellAttributes.Strikethrough));
+        Assert.IsTrue(cell.Attributes.HasFlag(CellAttributes.Bold));
+        Assert.IsTrue(cell.Attributes.HasFlag(CellAttributes.Hidden));
+        Assert.IsTrue(cell.Attributes.HasFlag(CellAttributes.Strikethrough));
     }
 
-    [Fact]
+    [TestMethod]
     public void HiddenCell_PreservesCharacterContent()
     {
         using var t = new TestTerminal();
@@ -132,12 +131,12 @@ public class SgrHiddenStrikethroughTests
         var snap = t.Terminal.CreateSnapshot();
 
         // The cell should still store the character even though it's hidden
-        Assert.Equal("A", snap.GetCell(0, 0).Character);
-        Assert.Equal("B", snap.GetCell(1, 0).Character);
-        Assert.Equal("C", snap.GetCell(2, 0).Character);
+        Assert.AreEqual("A", snap.GetCell(0, 0).Character);
+        Assert.AreEqual("B", snap.GetCell(1, 0).Character);
+        Assert.AreEqual("C", snap.GetCell(2, 0).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void StrikethroughCell_PreservesCharacterContent()
     {
         using var t = new TestTerminal();
@@ -146,8 +145,8 @@ public class SgrHiddenStrikethroughTests
         var snap = t.Terminal.CreateSnapshot();
 
         // Strikethrough cells show actual content (unlike hidden which renders as spaces)
-        Assert.Equal("X", snap.GetCell(0, 0).Character);
-        Assert.Equal("Y", snap.GetCell(1, 0).Character);
-        Assert.Equal("Z", snap.GetCell(2, 0).Character);
+        Assert.AreEqual("X", snap.GetCell(0, 0).Character);
+        Assert.AreEqual("Y", snap.GetCell(1, 0).Character);
+        Assert.AreEqual("Z", snap.GetCell(2, 0).Character);
     }
 }

--- a/tests/Hex1b.Tests/SgrTokenFastPathTests.cs
+++ b/tests/Hex1b.Tests/SgrTokenFastPathTests.cs
@@ -1,61 +1,61 @@
 using System.Text;
 using Hex1b.Tokens;
-using Xunit;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class SgrTokenFastPathTests
 {
-    [Fact]
+    [TestMethod]
     public void GetSgrTokenFromBytes_EmptySpan_ReturnsReset()
     {
         var token = AnsiTokenCache.GetSgrTokenFromBytes(ReadOnlySpan<byte>.Empty);
-        Assert.Same(SgrToken.Reset, token);
+        Assert.AreSame(SgrToken.Reset, token);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetSgrTokenFromBytes_RoundTripsParameters()
     {
         ReadOnlySpan<byte> bytes = "38;2;255;128;64"u8;
         var token = AnsiTokenCache.GetSgrTokenFromBytes(bytes);
 
-        Assert.Equal("38;2;255;128;64", token.Parameters);
-        Assert.NotNull(token.PreformattedBytes);
-        Assert.Equal(bytes.ToArray(), token.PreformattedBytes!);
+        Assert.AreEqual("38;2;255;128;64", token.Parameters);
+        Assert.IsNotNull(token.PreformattedBytes);
+        TestSeq.AreEqual(bytes.ToArray(), token.PreformattedBytes!);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetSgrTokenFromBytes_SecondCallReturnsCachedInstance()
     {
         ReadOnlySpan<byte> bytes = "1;31"u8;
         var first = AnsiTokenCache.GetSgrTokenFromBytes(bytes);
         var second = AnsiTokenCache.GetSgrTokenFromBytes(bytes);
-        Assert.Same(first, second);
+        Assert.AreSame(first, second);
     }
 
-    [Fact]
+    [TestMethod]
     public void SgrToken_EqualityIgnoresPreformattedBytes()
     {
         var plain = new SgrToken("31");
         var withBytes = new SgrToken("31") { PreformattedBytes = "31"u8.ToArray() };
-        Assert.Equal(plain, withBytes);
-        Assert.Equal(plain.GetHashCode(), withBytes.GetHashCode());
+        Assert.AreEqual(plain, withBytes);
+        Assert.AreEqual(plain.GetHashCode(), withBytes.GetHashCode());
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_UsesPreformattedBytes_WhenAvailable()
     {
         var token = new SgrToken("ignored-on-fast-path") { PreformattedBytes = "31"u8.ToArray() };
         var bytes = AnsiTokenUtf8Serializer.Serialize(new[] { token });
         // Should emit "\x1b[31m" using the PreformattedBytes, not the Parameters string.
-        Assert.Equal("\x1b[31m", Encoding.UTF8.GetString(bytes.Span));
+        Assert.AreEqual("\x1b[31m", Encoding.UTF8.GetString(bytes.Span));
     }
 
-    [Fact]
+    [TestMethod]
     public void Serialize_FallsBackToParameters_WhenPreformattedBytesNull()
     {
         var token = new SgrToken("1;38;2;255;0;0");
         var bytes = AnsiTokenUtf8Serializer.Serialize(new[] { token });
-        Assert.Equal("\x1b[1;38;2;255;0;0m", Encoding.UTF8.GetString(bytes.Span));
+        Assert.AreEqual("\x1b[1;38;2;255;0;0m", Encoding.UTF8.GetString(bytes.Span));
     }
 }

--- a/tests/Hex1b.Tests/SignaturePanelTests.cs
+++ b/tests/Hex1b.Tests/SignaturePanelTests.cs
@@ -9,6 +9,7 @@ namespace Hex1b.Tests;
 /// <see cref="SignatureParameterInfo"/>, and their integration with
 /// <see cref="IEditorSession"/> on <see cref="EditorNode"/>.
 /// </summary>
+[TestClass]
 public class SignaturePanelTests
 {
     private static IEditorSession CreateSession(string text = "test")
@@ -21,7 +22,7 @@ public class SignaturePanelTests
 
     // ── SignaturePanel construction ──────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void SignaturePanel_SingleSignature_StoresCorrectly()
     {
         var panel = new SignaturePanel([
@@ -30,13 +31,13 @@ public class SignaturePanelTests
             ])
         ]);
 
-        Assert.Single(panel.Signatures);
-        Assert.Equal("void Foo(int x)", panel.Signatures[0].Label);
-        Assert.Single(panel.Signatures[0].Parameters);
-        Assert.Equal("int x", panel.Signatures[0].Parameters[0].Label);
+        TestSeq.Single(panel.Signatures);
+        Assert.AreEqual("void Foo(int x)", panel.Signatures[0].Label);
+        TestSeq.Single(panel.Signatures[0].Parameters);
+        Assert.AreEqual("int x", panel.Signatures[0].Parameters[0].Label);
     }
 
-    [Fact]
+    [TestMethod]
     public void SignaturePanel_MultipleOverloads_StoresAll()
     {
         var panel = new SignaturePanel([
@@ -50,23 +51,23 @@ public class SignaturePanelTests
             new SignaturePanelEntry("void Foo()", [])
         ]);
 
-        Assert.Equal(3, panel.Signatures.Count);
-        Assert.Single(panel.Signatures[0].Parameters);
-        Assert.Equal(2, panel.Signatures[1].Parameters.Count);
-        Assert.Empty(panel.Signatures[2].Parameters);
+        Assert.AreEqual(3, panel.Signatures.Count);
+        TestSeq.Single(panel.Signatures[0].Parameters);
+        Assert.AreEqual(2, panel.Signatures[1].Parameters.Count);
+        Assert.IsEmpty(panel.Signatures[2].Parameters);
     }
 
-    [Fact]
+    [TestMethod]
     public void SignaturePanel_ActiveSignatureDefault_IsZero()
     {
         var panel = new SignaturePanel([
             new SignaturePanelEntry("void Foo()", [])
         ]);
 
-        Assert.Equal(0, panel.ActiveSignature);
+        Assert.AreEqual(0, panel.ActiveSignature);
     }
 
-    [Fact]
+    [TestMethod]
     public void SignaturePanel_ActiveParameterDefault_IsZero()
     {
         var panel = new SignaturePanel([
@@ -75,10 +76,10 @@ public class SignaturePanelTests
             ])
         ]);
 
-        Assert.Equal(0, panel.ActiveParameter);
+        Assert.AreEqual(0, panel.ActiveParameter);
     }
 
-    [Fact]
+    [TestMethod]
     public void SignaturePanel_WithActiveSignature_PreservesValue()
     {
         var panel = new SignaturePanel([
@@ -88,10 +89,10 @@ public class SignaturePanelTests
             ])
         ]) { ActiveSignature = 1 };
 
-        Assert.Equal(1, panel.ActiveSignature);
+        Assert.AreEqual(1, panel.ActiveSignature);
     }
 
-    [Fact]
+    [TestMethod]
     public void SignaturePanel_WithActiveParameter_PreservesValue()
     {
         var panel = new SignaturePanel([
@@ -101,32 +102,32 @@ public class SignaturePanelTests
             ])
         ]) { ActiveParameter = 1 };
 
-        Assert.Equal(1, panel.ActiveParameter);
+        Assert.AreEqual(1, panel.ActiveParameter);
     }
 
     // ── SignaturePanelEntry ──────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void SignaturePanelEntry_WithDocumentation_StoresValue()
     {
         var entry = new SignaturePanelEntry("void Save(string path)", [
             new SignatureParameterInfo("string path")
         ]) { Documentation = "Saves the document to disk." };
 
-        Assert.Equal("Saves the document to disk.", entry.Documentation);
+        Assert.AreEqual("Saves the document to disk.", entry.Documentation);
     }
 
-    [Fact]
+    [TestMethod]
     public void SignaturePanelEntry_WithoutDocumentation_IsNull()
     {
         var entry = new SignaturePanelEntry("void Foo()", []);
 
-        Assert.Null(entry.Documentation);
+        Assert.IsNull(entry.Documentation);
     }
 
     // ── SignatureParameterInfo ───────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void SignatureParameterInfo_WithDocumentation_StoresValue()
     {
         var param = new SignatureParameterInfo("string path")
@@ -134,21 +135,21 @@ public class SignaturePanelTests
             Documentation = "The file path to save to."
         };
 
-        Assert.Equal("string path", param.Label);
-        Assert.Equal("The file path to save to.", param.Documentation);
+        Assert.AreEqual("string path", param.Label);
+        Assert.AreEqual("The file path to save to.", param.Documentation);
     }
 
-    [Fact]
+    [TestMethod]
     public void SignatureParameterInfo_WithoutDocumentation_IsNull()
     {
         var param = new SignatureParameterInfo("int count");
 
-        Assert.Null(param.Documentation);
+        Assert.IsNull(param.Documentation);
     }
 
     // ── IEditorSession integration ───────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void ShowSignaturePanel_ThenDismiss_ClearsPanel()
     {
         var session = CreateSession();
@@ -166,7 +167,7 @@ public class SignaturePanelTests
         session.DismissSignaturePanel();
     }
 
-    [Fact]
+    [TestMethod]
     public void ShowSignaturePanel_CalledTwice_ReplacesPanel()
     {
         var session = CreateSession();
@@ -188,7 +189,7 @@ public class SignaturePanelTests
 
     // ── Record equality ──────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public void SignaturePanel_RecordEquality_EqualWhenSameListReference()
     {
         var signatures = new List<SignaturePanelEntry>
@@ -199,10 +200,10 @@ public class SignaturePanelTests
         var a = new SignaturePanel(signatures) { ActiveSignature = 0, ActiveParameter = 0 };
         var b = new SignaturePanel(signatures) { ActiveSignature = 0, ActiveParameter = 0 };
 
-        Assert.Equal(a, b);
+        Assert.AreEqual(a, b);
     }
 
-    [Fact]
+    [TestMethod]
     public void SignaturePanel_RecordEquality_NotEqualWhenDifferentActiveParam()
     {
         var signatures = new List<SignaturePanelEntry>
@@ -216,24 +217,24 @@ public class SignaturePanelTests
         var a = new SignaturePanel(signatures) { ActiveParameter = 0 };
         var b = new SignaturePanel(signatures) { ActiveParameter = 1 };
 
-        Assert.NotEqual(a, b);
+        Assert.AreNotEqual(a, b);
     }
 
-    [Fact]
+    [TestMethod]
     public void SignaturePanelEntry_RecordEquality_EqualWhenSameValues()
     {
         var a = new SignaturePanelEntry("void Foo()", []) { Documentation = "docs" };
         var b = new SignaturePanelEntry("void Foo()", []) { Documentation = "docs" };
 
-        Assert.Equal(a, b);
+        Assert.AreEqual(a, b);
     }
 
-    [Fact]
+    [TestMethod]
     public void SignatureParameterInfo_RecordEquality_EqualWhenSameValues()
     {
         var a = new SignatureParameterInfo("int x") { Documentation = "the value" };
         var b = new SignatureParameterInfo("int x") { Documentation = "the value" };
 
-        Assert.Equal(a, b);
+        Assert.AreEqual(a, b);
     }
 }

--- a/tests/Hex1b.Tests/SixelEncoderTests.cs
+++ b/tests/Hex1b.Tests/SixelEncoderTests.cs
@@ -9,11 +9,12 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for <see cref="SixelEncoder"/> and round-trip verification with <see cref="SixelDecoder"/>.
 /// </summary>
+[TestClass]
 public class SixelEncoderTests
 {
     #region T1: Encoder/Decoder Round-Trip Tests
 
-    [Fact]
+    [TestMethod]
     public void T1_1_SolidColor_RoundTrip()
     {
         // Single solid red color
@@ -22,15 +23,15 @@ public class SixelEncoderTests
         var encoded = SixelEncoder.Encode(buffer);
         var decoded = SixelDecoder.Decode(encoded);
         
-        Assert.NotNull(decoded);
-        Assert.Equal(10, decoded.Width);
-        Assert.Equal(12, decoded.Height);
+        Assert.IsNotNull(decoded);
+        Assert.AreEqual(10, decoded.Width);
+        Assert.AreEqual(12, decoded.Height);
         
         // Check center pixel is red (allowing for quantization)
         AssertPixelSimilar(decoded, 5, 6, 255, 0, 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void T1_2_TwoColors_RoundTrip()
     {
         // Left half red, right half blue
@@ -46,12 +47,12 @@ public class SixelEncoderTests
         var encoded = SixelEncoder.Encode(buffer);
         var decoded = SixelDecoder.Decode(encoded);
         
-        Assert.NotNull(decoded);
+        Assert.IsNotNull(decoded);
         AssertPixelSimilar(decoded, 2, 6, 255, 0, 0);   // Left half - red
         AssertPixelSimilar(decoded, 15, 6, 0, 0, 255);  // Right half - blue
     }
 
-    [Fact]
+    [TestMethod]
     public void T1_3_FullPaletteUsage()
     {
         // Create image with 256 distinct colors
@@ -71,13 +72,13 @@ public class SixelEncoderTests
         var encoded = SixelEncoder.Encode(buffer);
         var decoded = SixelDecoder.Decode(encoded);
         
-        Assert.NotNull(decoded);
-        Assert.Equal(16, decoded.Width);
+        Assert.IsNotNull(decoded);
+        Assert.AreEqual(16, decoded.Width);
         // Height may be padded to band boundary (multiple of 6)
-        Assert.True(decoded.Height >= 16);
+        Assert.IsTrue(decoded.Height >= 16);
     }
 
-    [Fact]
+    [TestMethod]
     public void T1_4_Gradient_Quantization()
     {
         // Horizontal red gradient
@@ -94,15 +95,15 @@ public class SixelEncoderTests
         var encoded = SixelEncoder.Encode(buffer);
         var decoded = SixelDecoder.Decode(encoded);
         
-        Assert.NotNull(decoded);
+        Assert.IsNotNull(decoded);
         
         // Left should be dark, right should be bright
         var leftPixel = GetPixel(decoded, 5, 6);
         var rightPixel = GetPixel(decoded, 94, 6);
-        Assert.True(rightPixel.r > leftPixel.r, "Gradient should go from dark to bright");
+        Assert.IsTrue(rightPixel.r > leftPixel.r, "Gradient should go from dark to bright");
     }
 
-    [Fact]
+    [TestMethod]
     public void T1_5_ScatteredTransparency()
     {
         // Checkerboard of opaque and transparent pixels
@@ -120,18 +121,18 @@ public class SixelEncoderTests
         var encoded = SixelEncoder.Encode(buffer);
         var decoded = SixelDecoder.Decode(encoded);
         
-        Assert.NotNull(decoded);
+        Assert.IsNotNull(decoded);
         
         // Check opaque pixel
         var opaquePixel = GetPixel(decoded, 0, 0);
-        Assert.Equal(255, opaquePixel.a);
+        Assert.AreEqual(255, opaquePixel.a);
         
         // Check transparent pixel
         var transparentPixel = GetPixel(decoded, 1, 0);
-        Assert.Equal(0, transparentPixel.a);
+        Assert.AreEqual(0, transparentPixel.a);
     }
 
-    [Fact]
+    [TestMethod]
     public void T1_6_ContiguousTransparency()
     {
         // Top half opaque, bottom half transparent
@@ -146,17 +147,17 @@ public class SixelEncoderTests
         var encoded = SixelEncoder.Encode(buffer);
         var decoded = SixelDecoder.Decode(encoded);
         
-        Assert.NotNull(decoded);
+        Assert.IsNotNull(decoded);
         
         // Top should be green
         AssertPixelSimilar(decoded, 10, 2, 0, 255, 0);
         
         // Bottom should be transparent
         var bottomPixel = GetPixel(decoded, 10, 10);
-        Assert.Equal(0, bottomPixel.a);
+        Assert.AreEqual(0, bottomPixel.a);
     }
 
-    [Fact]
+    [TestMethod]
     public void T1_7_SinglePixel()
     {
         var buffer = CreateSolidBuffer(1, 1, Rgba32.FromRgb(128, 128, 128));
@@ -164,13 +165,13 @@ public class SixelEncoderTests
         var encoded = SixelEncoder.Encode(buffer);
         var decoded = SixelDecoder.Decode(encoded);
         
-        Assert.NotNull(decoded);
-        Assert.Equal(1, decoded.Width);
+        Assert.IsNotNull(decoded);
+        Assert.AreEqual(1, decoded.Width);
         // Height will be padded to band boundary (6)
-        Assert.True(decoded.Height >= 1);
+        Assert.IsTrue(decoded.Height >= 1);
     }
 
-    [Fact]
+    [TestMethod]
     public void T1_8_SingleRow()
     {
         var buffer = new SixelPixelBuffer(50, 1);
@@ -180,11 +181,11 @@ public class SixelEncoderTests
         var encoded = SixelEncoder.Encode(buffer);
         var decoded = SixelDecoder.Decode(encoded);
         
-        Assert.NotNull(decoded);
-        Assert.Equal(50, decoded.Width);
+        Assert.IsNotNull(decoded);
+        Assert.AreEqual(50, decoded.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void T1_9_SingleColumn()
     {
         var buffer = new SixelPixelBuffer(1, 50);
@@ -194,11 +195,11 @@ public class SixelEncoderTests
         var encoded = SixelEncoder.Encode(buffer);
         var decoded = SixelDecoder.Decode(encoded);
         
-        Assert.NotNull(decoded);
-        Assert.True(decoded.Height >= 50);
+        Assert.IsNotNull(decoded);
+        Assert.IsTrue(decoded.Height >= 50);
     }
 
-    [Fact]
+    [TestMethod]
     public void T1_10_LargeImage()
     {
         // 100x100 should work (though we won't test 1000x1000 for speed)
@@ -207,13 +208,13 @@ public class SixelEncoderTests
         var encoded = SixelEncoder.Encode(buffer);
         var decoded = SixelDecoder.Decode(encoded);
         
-        Assert.NotNull(decoded);
-        Assert.Equal(100, decoded.Width);
+        Assert.IsNotNull(decoded);
+        Assert.AreEqual(100, decoded.Width);
         // Height may be padded to band boundary (multiple of 6)
-        Assert.True(decoded.Height >= 100);
+        Assert.IsTrue(decoded.Height >= 100);
     }
 
-    [Fact]
+    [TestMethod]
     public void T1_11_NonMultipleOf6Height()
     {
         // Height 10 is not a multiple of 6 (band size)
@@ -222,12 +223,12 @@ public class SixelEncoderTests
         var encoded = SixelEncoder.Encode(buffer);
         var decoded = SixelDecoder.Decode(encoded);
         
-        Assert.NotNull(decoded);
-        Assert.Equal(20, decoded.Width);
-        Assert.True(decoded.Height >= 10);
+        Assert.IsNotNull(decoded);
+        Assert.AreEqual(20, decoded.Width);
+        Assert.IsTrue(decoded.Height >= 10);
     }
 
-    [Fact]
+    [TestMethod]
     public void T1_12_WideImage()
     {
         // Very wide image
@@ -236,15 +237,15 @@ public class SixelEncoderTests
         var encoded = SixelEncoder.Encode(buffer);
         var decoded = SixelDecoder.Decode(encoded);
         
-        Assert.NotNull(decoded);
-        Assert.Equal(500, decoded.Width);
+        Assert.IsNotNull(decoded);
+        Assert.AreEqual(500, decoded.Width);
     }
 
     #endregion
 
     #region Encoder Format Tests
 
-    [Fact]
+    [TestMethod]
     public void Encode_ContainsDcsHeader()
     {
         var buffer = CreateSolidBuffer(10, 6, Rgba32.FromRgb(255, 0, 0));
@@ -254,7 +255,7 @@ public class SixelEncoderTests
         Assert.Contains("q", encoded);        // Sixel introducer
     }
 
-    [Fact]
+    [TestMethod]
     public void Encode_ContainsStringTerminator()
     {
         var buffer = CreateSolidBuffer(10, 6, Rgba32.FromRgb(255, 0, 0));
@@ -263,7 +264,7 @@ public class SixelEncoderTests
         Assert.EndsWith("\x1b\\", encoded); // ST
     }
 
-    [Fact]
+    [TestMethod]
     public void Encode_ContainsColorDefinitions()
     {
         var buffer = CreateSolidBuffer(10, 6, Rgba32.FromRgb(255, 0, 0));
@@ -273,7 +274,7 @@ public class SixelEncoderTests
         Assert.Contains("#0;2;", encoded);
     }
 
-    [Fact]
+    [TestMethod]
     public void Encode_ContainsRasterAttributes()
     {
         var buffer = CreateSolidBuffer(20, 12, Rgba32.FromRgb(0, 255, 0));
@@ -283,7 +284,7 @@ public class SixelEncoderTests
         Assert.Contains("\"1;1;20;12", encoded);
     }
 
-    [Fact]
+    [TestMethod]
     public void Encode_UsesRleForLongRuns()
     {
         // Solid color should produce RLE sequences
@@ -294,7 +295,7 @@ public class SixelEncoderTests
         Assert.Contains("!", encoded);
     }
 
-    [Fact]
+    [TestMethod]
     public void Encode_AllTransparent_ReturnsMinimalSixel()
     {
         var buffer = new SixelPixelBuffer(10, 10);
@@ -310,7 +311,7 @@ public class SixelEncoderTests
 
     #region SixelPixelBuffer Tests
 
-    [Fact]
+    [TestMethod]
     public void SixelPixelBuffer_Crop_ReturnsCorrectRegion()
     {
         var buffer = new SixelPixelBuffer(20, 20);
@@ -322,13 +323,13 @@ public class SixelEncoderTests
         
         var cropped = buffer.Crop(5, 5, 10, 10);
         
-        Assert.Equal(10, cropped.Width);
-        Assert.Equal(10, cropped.Height);
-        Assert.Equal(Rgba32.FromRgb(255, 0, 0), cropped[0, 0]);
-        Assert.Equal(Rgba32.FromRgb(255, 0, 0), cropped[9, 9]);
+        Assert.AreEqual(10, cropped.Width);
+        Assert.AreEqual(10, cropped.Height);
+        Assert.AreEqual(Rgba32.FromRgb(255, 0, 0), cropped[0, 0]);
+        Assert.AreEqual(Rgba32.FromRgb(255, 0, 0), cropped[9, 9]);
     }
 
-    [Fact]
+    [TestMethod]
     public void SixelPixelBuffer_Crop_ClampsToValidBounds()
     {
         var buffer = new SixelPixelBuffer(10, 10);
@@ -339,52 +340,52 @@ public class SixelEncoderTests
         // Request region that extends past bounds
         var cropped = buffer.Crop(5, 5, 20, 20);
         
-        Assert.Equal(5, cropped.Width);
-        Assert.Equal(5, cropped.Height);
+        Assert.AreEqual(5, cropped.Width);
+        Assert.AreEqual(5, cropped.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void SixelPixelBuffer_GetPixelOrTransparent_ReturnsTransparentForOutOfBounds()
     {
         var buffer = new SixelPixelBuffer(10, 10);
         buffer[5, 5] = Rgba32.FromRgb(255, 0, 0);
         
-        Assert.Equal(Rgba32.Transparent, buffer.GetPixelOrTransparent(-1, 5));
-        Assert.Equal(Rgba32.Transparent, buffer.GetPixelOrTransparent(5, -1));
-        Assert.Equal(Rgba32.Transparent, buffer.GetPixelOrTransparent(10, 5));
-        Assert.Equal(Rgba32.Transparent, buffer.GetPixelOrTransparent(5, 10));
-        Assert.Equal(Rgba32.FromRgb(255, 0, 0), buffer.GetPixelOrTransparent(5, 5));
+        Assert.AreEqual(Rgba32.Transparent, buffer.GetPixelOrTransparent(-1, 5));
+        Assert.AreEqual(Rgba32.Transparent, buffer.GetPixelOrTransparent(5, -1));
+        Assert.AreEqual(Rgba32.Transparent, buffer.GetPixelOrTransparent(10, 5));
+        Assert.AreEqual(Rgba32.Transparent, buffer.GetPixelOrTransparent(5, 10));
+        Assert.AreEqual(Rgba32.FromRgb(255, 0, 0), buffer.GetPixelOrTransparent(5, 5));
     }
 
     #endregion
 
     #region T2: PixelRect Tests
 
-    [Fact]
+    [TestMethod]
     public void T2_1_PixelRect_Properties()
     {
         var rect = new PixelRect(10, 20, 30, 40);
         
-        Assert.Equal(10, rect.X);
-        Assert.Equal(20, rect.Y);
-        Assert.Equal(30, rect.Width);
-        Assert.Equal(40, rect.Height);
-        Assert.Equal(40, rect.Right);
-        Assert.Equal(60, rect.Bottom);
-        Assert.Equal(1200, rect.Area);
-        Assert.False(rect.IsEmpty);
+        Assert.AreEqual(10, rect.X);
+        Assert.AreEqual(20, rect.Y);
+        Assert.AreEqual(30, rect.Width);
+        Assert.AreEqual(40, rect.Height);
+        Assert.AreEqual(40, rect.Right);
+        Assert.AreEqual(60, rect.Bottom);
+        Assert.AreEqual(1200, rect.Area);
+        Assert.IsFalse(rect.IsEmpty);
     }
 
-    [Fact]
+    [TestMethod]
     public void T2_2_PixelRect_IsEmpty()
     {
-        Assert.True(new PixelRect(0, 0, 0, 10).IsEmpty);
-        Assert.True(new PixelRect(0, 0, 10, 0).IsEmpty);
-        Assert.True(new PixelRect(0, 0, -5, 10).IsEmpty);
-        Assert.False(new PixelRect(0, 0, 1, 1).IsEmpty);
+        Assert.IsTrue(new PixelRect(0, 0, 0, 10).IsEmpty);
+        Assert.IsTrue(new PixelRect(0, 0, 10, 0).IsEmpty);
+        Assert.IsTrue(new PixelRect(0, 0, -5, 10).IsEmpty);
+        Assert.IsFalse(new PixelRect(0, 0, 1, 1).IsEmpty);
     }
 
-    [Fact]
+    [TestMethod]
     public void T2_3_PixelRect_Intersect_Overlapping()
     {
         var a = new PixelRect(0, 0, 20, 20);
@@ -392,13 +393,13 @@ public class SixelEncoderTests
         
         var intersection = a.Intersect(b);
         
-        Assert.Equal(10, intersection.X);
-        Assert.Equal(10, intersection.Y);
-        Assert.Equal(10, intersection.Width);
-        Assert.Equal(10, intersection.Height);
+        Assert.AreEqual(10, intersection.X);
+        Assert.AreEqual(10, intersection.Y);
+        Assert.AreEqual(10, intersection.Width);
+        Assert.AreEqual(10, intersection.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void T2_4_PixelRect_Intersect_NoOverlap()
     {
         var a = new PixelRect(0, 0, 10, 10);
@@ -406,10 +407,10 @@ public class SixelEncoderTests
         
         var intersection = a.Intersect(b);
         
-        Assert.True(intersection.IsEmpty);
+        Assert.IsTrue(intersection.IsEmpty);
     }
 
-    [Fact]
+    [TestMethod]
     public void T2_5_PixelRect_Intersect_Contained()
     {
         var outer = new PixelRect(0, 0, 100, 100);
@@ -417,35 +418,35 @@ public class SixelEncoderTests
         
         var intersection = outer.Intersect(inner);
         
-        Assert.Equal(inner, intersection);
+        Assert.AreEqual(inner, intersection);
     }
 
-    [Fact]
+    [TestMethod]
     public void T2_6_PixelRect_Contains_Point()
     {
         var rect = new PixelRect(10, 10, 20, 20);
         
-        Assert.True(rect.Contains(10, 10));   // Top-left corner
-        Assert.True(rect.Contains(29, 29));   // Bottom-right (exclusive edge -1)
-        Assert.True(rect.Contains(20, 20));   // Center
-        Assert.False(rect.Contains(9, 10));   // Left of
-        Assert.False(rect.Contains(30, 10));  // Right edge (exclusive)
-        Assert.False(rect.Contains(10, 30));  // Bottom edge (exclusive)
+        Assert.IsTrue(rect.Contains(10, 10));   // Top-left corner
+        Assert.IsTrue(rect.Contains(29, 29));   // Bottom-right (exclusive edge -1)
+        Assert.IsTrue(rect.Contains(20, 20));   // Center
+        Assert.IsFalse(rect.Contains(9, 10));   // Left of
+        Assert.IsFalse(rect.Contains(30, 10));  // Right edge (exclusive)
+        Assert.IsFalse(rect.Contains(10, 30));  // Bottom edge (exclusive)
     }
 
-    [Fact]
+    [TestMethod]
     public void T2_7_PixelRect_Contains_Rect()
     {
         var outer = new PixelRect(0, 0, 100, 100);
         var inner = new PixelRect(25, 25, 50, 50);
         var partial = new PixelRect(50, 50, 100, 100);
         
-        Assert.True(outer.Contains(inner));
-        Assert.False(outer.Contains(partial));
-        Assert.False(inner.Contains(outer));
+        Assert.IsTrue(outer.Contains(inner));
+        Assert.IsFalse(outer.Contains(partial));
+        Assert.IsFalse(inner.Contains(outer));
     }
 
-    [Fact]
+    [TestMethod]
     public void T2_8_PixelRect_Subtract_NoOverlap()
     {
         var rect = new PixelRect(0, 0, 10, 10);
@@ -453,11 +454,11 @@ public class SixelEncoderTests
         
         var fragments = rect.Subtract(hole);
         
-        Assert.Single(fragments);
-        Assert.Equal(rect, fragments[0]);
+        TestSeq.Single(fragments);
+        Assert.AreEqual(rect, fragments[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void T2_9_PixelRect_Subtract_CenterHole()
     {
         // 10x10 rectangle with 4x4 hole in center
@@ -467,14 +468,14 @@ public class SixelEncoderTests
         var fragments = rect.Subtract(hole);
         
         // Should produce 4 fragments: top, bottom, left, right
-        Assert.Equal(4, fragments.Count);
+        Assert.AreEqual(4, fragments.Count);
         
         // Verify total area equals original minus hole
         var totalArea = fragments.Sum(f => f.Area);
-        Assert.Equal(rect.Area - hole.Area, totalArea);
+        Assert.AreEqual(rect.Area - hole.Area, totalArea);
     }
 
-    [Fact]
+    [TestMethod]
     public void T2_10_PixelRect_Subtract_EdgeHole()
     {
         var rect = new PixelRect(0, 0, 10, 10);
@@ -483,12 +484,12 @@ public class SixelEncoderTests
         var fragments = rect.Subtract(hole);
         
         // Should produce 2 fragments: bottom and right
-        Assert.Equal(2, fragments.Count);
+        Assert.AreEqual(2, fragments.Count);
         var totalArea = fragments.Sum(f => f.Area);
-        Assert.Equal(rect.Area - hole.Area, totalArea);
+        Assert.AreEqual(rect.Area - hole.Area, totalArea);
     }
 
-    [Fact]
+    [TestMethod]
     public void T2_11_PixelRect_Subtract_FullyCovered()
     {
         var rect = new PixelRect(5, 5, 10, 10);
@@ -496,14 +497,14 @@ public class SixelEncoderTests
         
         var fragments = rect.Subtract(hole);
         
-        Assert.Empty(fragments);
+        Assert.IsEmpty(fragments);
     }
 
     #endregion
 
     #region T3: Fragment and Visibility Tests
 
-    [Fact]
+    [TestMethod]
     public void T3_1_Fragment_SingleRegion()
     {
         var buffer = new SixelPixelBuffer(20, 20);
@@ -514,15 +515,15 @@ public class SixelEncoderTests
         var regions = new[] { new PixelRect(5, 5, 10, 10) };
         var fragments = buffer.Fragment(regions);
         
-        Assert.Single(fragments);
-        Assert.Equal(new PixelRect(5, 5, 10, 10), fragments[0].Region);
-        Assert.Equal(10, fragments[0].Buffer.Width);
-        Assert.Equal(10, fragments[0].Buffer.Height);
+        TestSeq.Single(fragments);
+        Assert.AreEqual(new PixelRect(5, 5, 10, 10), fragments[0].Region);
+        Assert.AreEqual(10, fragments[0].Buffer.Width);
+        Assert.AreEqual(10, fragments[0].Buffer.Height);
         // First pixel should be from (5,5) in original
-        Assert.Equal(Rgba32.FromRgb(50, 50, 0), fragments[0].Buffer[0, 0]);
+        Assert.AreEqual(Rgba32.FromRgb(50, 50, 0), fragments[0].Buffer[0, 0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void T3_2_Fragment_MultipleRegions()
     {
         var buffer = new SixelPixelBuffer(30, 30);
@@ -540,15 +541,15 @@ public class SixelEncoderTests
         
         var fragments = buffer.Fragment(regions);
         
-        Assert.Equal(4, fragments.Count);
-        Assert.All(fragments, f =>
+        Assert.AreEqual(4, fragments.Count);
+        TestSeq.All(fragments, f =>
         {
-            Assert.Equal(10, f.Buffer.Width);
-            Assert.Equal(10, f.Buffer.Height);
+            Assert.AreEqual(10, f.Buffer.Width);
+            Assert.AreEqual(10, f.Buffer.Height);
         });
     }
 
-    [Fact]
+    [TestMethod]
     public void T3_3_Fragment_EmptyRegionSkipped()
     {
         var buffer = new SixelPixelBuffer(20, 20);
@@ -562,10 +563,10 @@ public class SixelEncoderTests
         
         var fragments = buffer.Fragment(regions);
         
-        Assert.Equal(2, fragments.Count);
+        Assert.AreEqual(2, fragments.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void T3_4_Fragment_RegionClampedToBounds()
     {
         var buffer = new SixelPixelBuffer(10, 10);
@@ -573,24 +574,24 @@ public class SixelEncoderTests
         var regions = new[] { new PixelRect(5, 5, 100, 100) }; // Extends way past bounds
         var fragments = buffer.Fragment(regions);
         
-        Assert.Single(fragments);
-        Assert.Equal(new PixelRect(5, 5, 5, 5), fragments[0].Region);
-        Assert.Equal(5, fragments[0].Buffer.Width);
-        Assert.Equal(5, fragments[0].Buffer.Height);
+        TestSeq.Single(fragments);
+        Assert.AreEqual(new PixelRect(5, 5, 5, 5), fragments[0].Region);
+        Assert.AreEqual(5, fragments[0].Buffer.Width);
+        Assert.AreEqual(5, fragments[0].Buffer.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void T3_5_ComputeVisibleRegions_NoOcclusions()
     {
         var buffer = new SixelPixelBuffer(100, 60);
         
         var visible = buffer.ComputeVisibleRegions(Array.Empty<PixelRect>());
         
-        Assert.Single(visible);
-        Assert.Equal(new PixelRect(0, 0, 100, 60), visible[0]);
+        TestSeq.Single(visible);
+        Assert.AreEqual(new PixelRect(0, 0, 100, 60), visible[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void T3_6_ComputeVisibleRegions_CenterOcclusion()
     {
         var buffer = new SixelPixelBuffer(100, 60);
@@ -598,12 +599,12 @@ public class SixelEncoderTests
         
         var visible = buffer.ComputeVisibleRegions(new[] { occlusion });
         
-        Assert.Equal(4, visible.Count);
+        Assert.AreEqual(4, visible.Count);
         var totalArea = visible.Sum(r => r.Area);
-        Assert.Equal(100 * 60 - 50 * 30, totalArea);
+        Assert.AreEqual(100 * 60 - 50 * 30, totalArea);
     }
 
-    [Fact]
+    [TestMethod]
     public void T3_7_ComputeVisibleRegions_FullyOccluded()
     {
         var buffer = new SixelPixelBuffer(50, 50);
@@ -611,10 +612,10 @@ public class SixelEncoderTests
         
         var visible = buffer.ComputeVisibleRegions(new[] { occlusion });
         
-        Assert.Empty(visible);
+        Assert.IsEmpty(visible);
     }
 
-    [Fact]
+    [TestMethod]
     public void T3_8_ComputeVisibleRegions_MultipleOcclusions()
     {
         var buffer = new SixelPixelBuffer(100, 60);
@@ -627,18 +628,18 @@ public class SixelEncoderTests
         var visible = buffer.ComputeVisibleRegions(occlusions);
         
         // Multiple fragments expected
-        Assert.True(visible.Count >= 2);
+        Assert.IsTrue(visible.Count >= 2);
         // No visible region should overlap with occlusions
         foreach (var region in visible)
         {
             foreach (var occ in occlusions)
             {
-                Assert.True(region.Intersect(occ).IsEmpty);
+                Assert.IsTrue(region.Intersect(occ).IsEmpty);
             }
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void T3_9_FragmentAndEncode_RoundTrip()
     {
         // Create a gradient buffer
@@ -664,9 +665,9 @@ public class SixelEncoderTests
             var encoded = SixelEncoder.Encode(fragmentBuffer);
             var decoded = SixelDecoder.Decode(encoded);
             
-            Assert.NotNull(decoded);
-            Assert.Equal(fragmentBuffer.Width, decoded.Width);
-            Assert.True(decoded.Height >= fragmentBuffer.Height);
+            Assert.IsNotNull(decoded);
+            Assert.AreEqual(fragmentBuffer.Width, decoded.Width);
+            Assert.IsTrue(decoded.Height >= fragmentBuffer.Height);
         }
     }
 
@@ -674,58 +675,58 @@ public class SixelEncoderTests
 
     #region T4: CellMetrics Tests
 
-    [Fact]
+    [TestMethod]
     public void T4_1_CellMetrics_Default()
     {
         var metrics = CellMetrics.Default;
         
-        Assert.Equal(10, metrics.PixelWidth);
-        Assert.Equal(20, metrics.PixelHeight);
+        Assert.AreEqual(10, metrics.PixelWidth);
+        Assert.AreEqual(20, metrics.PixelHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void T4_2_CellMetrics_CellToPixel()
     {
         var metrics = new CellMetrics(10, 20);
         
         var pixelRect = metrics.CellToPixel(5, 3, 10, 5);
         
-        Assert.Equal(50, pixelRect.X);    // 5 * 10
-        Assert.Equal(60, pixelRect.Y);    // 3 * 20
-        Assert.Equal(100, pixelRect.Width);  // 10 * 10
-        Assert.Equal(100, pixelRect.Height); // 5 * 20
+        Assert.AreEqual(50, pixelRect.X);    // 5 * 10
+        Assert.AreEqual(60, pixelRect.Y);    // 3 * 20
+        Assert.AreEqual(100, pixelRect.Width);  // 10 * 10
+        Assert.AreEqual(100, pixelRect.Height); // 5 * 20
     }
 
-    [Fact]
+    [TestMethod]
     public void T4_3_CellMetrics_PixelToCellSpan()
     {
         var metrics = new CellMetrics(10, 20);
         
         // Exact multiple
         var (w1, h1) = metrics.PixelToCellSpan(100, 60);
-        Assert.Equal(10, w1);
-        Assert.Equal(3, h1);
+        Assert.AreEqual(10, w1);
+        Assert.AreEqual(3, h1);
         
         // Rounds up
         var (w2, h2) = metrics.PixelToCellSpan(101, 61);
-        Assert.Equal(11, w2);
-        Assert.Equal(4, h2);
+        Assert.AreEqual(11, w2);
+        Assert.AreEqual(4, h2);
     }
 
-    [Fact]
+    [TestMethod]
     public void T4_4_CellMetrics_PixelToCell()
     {
         var metrics = new CellMetrics(10, 20);
         
         var cellRect = metrics.PixelToCell(new PixelRect(50, 60, 100, 100));
         
-        Assert.Equal(5, cellRect.X);   // 50 / 10
-        Assert.Equal(3, cellRect.Y);   // 60 / 20
-        Assert.Equal(10, cellRect.Width);  // 100 / 10
-        Assert.Equal(5, cellRect.Height);  // 100 / 20
+        Assert.AreEqual(5, cellRect.X);   // 50 / 10
+        Assert.AreEqual(3, cellRect.Y);   // 60 / 20
+        Assert.AreEqual(10, cellRect.Width);  // 100 / 10
+        Assert.AreEqual(5, cellRect.Height);  // 100 / 20
     }
 
-    [Fact]
+    [TestMethod]
     public void T4_5_CellMetrics_RoundTrip()
     {
         var metrics = new CellMetrics(8, 16);
@@ -735,10 +736,10 @@ public class SixelEncoderTests
         var pixel = metrics.CellToPixel(originalCell);
         var backToCell = metrics.PixelToCell(pixel);
         
-        Assert.Equal(originalCell.X, backToCell.X);
-        Assert.Equal(originalCell.Y, backToCell.Y);
-        Assert.Equal(originalCell.Width, backToCell.Width);
-        Assert.Equal(originalCell.Height, backToCell.Height);
+        Assert.AreEqual(originalCell.X, backToCell.X);
+        Assert.AreEqual(originalCell.Y, backToCell.Y);
+        Assert.AreEqual(originalCell.Width, backToCell.Width);
+        Assert.AreEqual(originalCell.Height, backToCell.Height);
     }
 
     #endregion
@@ -768,10 +769,10 @@ public class SixelEncoderTests
     {
         var (r, g, b, a) = GetPixel(image, x, y);
         
-        Assert.True(a > 0, $"Pixel at ({x}, {y}) should not be transparent");
-        Assert.True(Math.Abs(r - expectedR) <= tolerance, $"Red at ({x}, {y}): expected ~{expectedR}, got {r}");
-        Assert.True(Math.Abs(g - expectedG) <= tolerance, $"Green at ({x}, {y}): expected ~{expectedG}, got {g}");
-        Assert.True(Math.Abs(b - expectedB) <= tolerance, $"Blue at ({x}, {y}): expected ~{expectedB}, got {b}");
+        Assert.IsTrue(a > 0, $"Pixel at ({x}, {y}) should not be transparent");
+        Assert.IsTrue(Math.Abs(r - expectedR) <= tolerance, $"Red at ({x}, {y}): expected ~{expectedR}, got {r}");
+        Assert.IsTrue(Math.Abs(g - expectedG) <= tolerance, $"Green at ({x}, {y}): expected ~{expectedG}, got {g}");
+        Assert.IsTrue(Math.Abs(b - expectedB) <= tolerance, $"Blue at ({x}, {y}): expected ~{expectedB}, got {b}");
     }
 
     #endregion
@@ -780,25 +781,26 @@ public class SixelEncoderTests
 /// <summary>
 /// Tests for sixel visibility and fragment generation.
 /// </summary>
+[TestClass]
 public class SixelVisibilityTests
 {
     private readonly TrackedObjectStore _store = new();
 
     #region SixelVisibility Tests
 
-    [Fact]
+    [TestMethod]
     public void SixelVisibility_InitiallyFullyVisible()
     {
         var sixelRef = CreateTestSixel(100, 60); // 100x60 pixels = 10x3 cells at 10x20 metrics
         var visibility = new SixelVisibility(sixelRef, 5, 5, 0);
         
-        Assert.True(visibility.IsFullyVisible);
-        Assert.False(visibility.IsFullyOccluded);
-        Assert.False(visibility.IsFragmented);
-        Assert.Single(visibility.VisibleRegions);
+        Assert.IsTrue(visibility.IsFullyVisible);
+        Assert.IsFalse(visibility.IsFullyOccluded);
+        Assert.IsFalse(visibility.IsFragmented);
+        TestSeq.Single(visibility.VisibleRegions);
     }
 
-    [Fact]
+    [TestMethod]
     public void SixelVisibility_ApplyOcclusion_PartiallyOccludes()
     {
         var sixelRef = CreateTestSixel(100, 60);
@@ -809,13 +811,13 @@ public class SixelVisibilityTests
         var occlusion = new Hex1b.Layout.Rect(4, 1, 2, 1);
         visibility.ApplyOcclusion(occlusion, metrics);
         
-        Assert.False(visibility.IsFullyVisible);
-        Assert.False(visibility.IsFullyOccluded);
+        Assert.IsFalse(visibility.IsFullyVisible);
+        Assert.IsFalse(visibility.IsFullyOccluded);
         // Should have 4 fragments: top, bottom, left, right of occlusion
-        Assert.Equal(4, visibility.VisibleRegions.Count);
+        Assert.AreEqual(4, visibility.VisibleRegions.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void SixelVisibility_ApplyOcclusion_FullyOccludes()
     {
         var sixelRef = CreateTestSixel(100, 60);
@@ -826,11 +828,11 @@ public class SixelVisibilityTests
         var occlusion = new Hex1b.Layout.Rect(0, 0, 10, 3);
         visibility.ApplyOcclusion(occlusion, metrics);
         
-        Assert.True(visibility.IsFullyOccluded);
-        Assert.Empty(visibility.VisibleRegions);
+        Assert.IsTrue(visibility.IsFullyOccluded);
+        Assert.IsEmpty(visibility.VisibleRegions);
     }
 
-    [Fact]
+    [TestMethod]
     public void SixelVisibility_ApplyOcclusion_NoOverlap_NoChange()
     {
         var sixelRef = CreateTestSixel(100, 60);
@@ -841,11 +843,11 @@ public class SixelVisibilityTests
         var occlusion = new Hex1b.Layout.Rect(20, 20, 5, 5);
         visibility.ApplyOcclusion(occlusion, metrics);
         
-        Assert.True(visibility.IsFullyVisible);
-        Assert.Single(visibility.VisibleRegions);
+        Assert.IsTrue(visibility.IsFullyVisible);
+        TestSeq.Single(visibility.VisibleRegions);
     }
 
-    [Fact]
+    [TestMethod]
     public void SixelVisibility_GenerateFragments_FullyVisible_SingleFragment()
     {
         var sixelRef = CreateTestSixel(100, 60);
@@ -854,12 +856,12 @@ public class SixelVisibilityTests
         
         var fragments = visibility.GenerateFragments(metrics);
         
-        Assert.Single(fragments);
-        Assert.Equal((5, 3), fragments[0].CellPosition);
-        Assert.True(fragments[0].IsComplete);
+        TestSeq.Single(fragments);
+        Assert.AreEqual((5, 3), fragments[0].CellPosition);
+        Assert.IsTrue(fragments[0].IsComplete);
     }
 
-    [Fact]
+    [TestMethod]
     public void SixelVisibility_GenerateFragments_Occluded_MultipleFragments()
     {
         var sixelRef = CreateTestSixel(100, 60);
@@ -872,15 +874,15 @@ public class SixelVisibilityTests
         
         var fragments = visibility.GenerateFragments(metrics);
         
-        Assert.True(fragments.Count >= 2);
-        Assert.All(fragments, f => Assert.False(f.IsComplete));
+        Assert.IsTrue(fragments.Count >= 2);
+        TestSeq.All(fragments, f => Assert.IsFalse(f.IsComplete));
     }
 
     #endregion
 
     #region CompositeSurface.GetSixelFragments Tests
 
-    [Fact]
+    [TestMethod]
     public void GetSixelFragments_NoSixels_ReturnsEmpty()
     {
         var composite = new CompositeSurface(80, 24);
@@ -890,10 +892,10 @@ public class SixelVisibilityTests
         
         var fragments = composite.GetSixelFragments();
         
-        Assert.Empty(fragments);
+        Assert.IsEmpty(fragments);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetSixelFragments_UnoccludedSixel_SingleFragment()
     {
         var metrics = new CellMetrics(10, 20);
@@ -908,11 +910,11 @@ public class SixelVisibilityTests
         
         var fragments = composite.GetSixelFragments();
         
-        Assert.Single(fragments);
-        Assert.Equal((5, 3), fragments[0].CellPosition);
+        TestSeq.Single(fragments);
+        Assert.AreEqual((5, 3), fragments[0].CellPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetSixelFragments_PartiallyOccluded_MultipleFragments()
     {
         var metrics = new CellMetrics(10, 20);
@@ -934,10 +936,10 @@ public class SixelVisibilityTests
         var fragments = composite.GetSixelFragments();
         
         // Should have multiple fragments due to occlusion
-        Assert.True(fragments.Count >= 2);
+        Assert.IsTrue(fragments.Count >= 2);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetSixelFragments_FullyOccluded_ReturnsEmpty()
     {
         var metrics = new CellMetrics(10, 20);
@@ -958,10 +960,10 @@ public class SixelVisibilityTests
         
         var fragments = composite.GetSixelFragments();
         
-        Assert.Empty(fragments);
+        Assert.IsEmpty(fragments);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetSixelFragments_MultipleSixels_ReturnsAll()
     {
         var metrics = new CellMetrics(10, 20);
@@ -978,38 +980,38 @@ public class SixelVisibilityTests
         
         var fragments = composite.GetSixelFragments();
         
-        Assert.Equal(2, fragments.Count);
+        Assert.AreEqual(2, fragments.Count);
     }
 
     #endregion
 
     #region SixelFragment Tests
 
-    [Fact]
+    [TestMethod]
     public void SixelFragment_Complete_ReturnsOriginalPayload()
     {
         var sixelRef = CreateTestSixel(100, 60);
         var fragment = SixelFragment.Complete(sixelRef.Data, 0, 0);
         
-        Assert.True(fragment.IsComplete);
-        Assert.Equal(sixelRef.Data.Payload, fragment.GetPayload());
+        Assert.IsTrue(fragment.IsComplete);
+        Assert.AreEqual(sixelRef.Data.Payload, fragment.GetPayload());
     }
 
-    [Fact]
+    [TestMethod]
     public void SixelFragment_Cropped_ReencodesPayload()
     {
         var sixelRef = CreateTestSixel(100, 60);
         var fragment = new SixelFragment(sixelRef.Data, 0, 0, new PixelRect(10, 10, 50, 30));
         
-        Assert.False(fragment.IsComplete);
+        Assert.IsFalse(fragment.IsComplete);
         
         var payload = fragment.GetPayload();
-        Assert.NotNull(payload);
-        Assert.NotEqual(sixelRef.Data.Payload, payload);
+        Assert.IsNotNull(payload);
+        Assert.AreNotEqual(sixelRef.Data.Payload, payload);
         Assert.Contains("\x1bP", payload); // Valid sixel start
     }
 
-    [Fact]
+    [TestMethod]
     public void SixelFragment_GetCellSpan_CalculatesCorrectly()
     {
         var sixelRef = CreateTestSixel(100, 60);
@@ -1018,15 +1020,15 @@ public class SixelVisibilityTests
         
         var (width, height) = fragment.GetCellSpan(metrics);
         
-        Assert.Equal(6, width);  // ceil(55/10)
-        Assert.Equal(2, height); // ceil(35/20)
+        Assert.AreEqual(6, width);  // ceil(55/10)
+        Assert.AreEqual(2, height); // ceil(35/20)
     }
 
     #endregion
 
     #region T5: Computed Cell Sixel Access Tests
 
-    [Fact]
+    [TestMethod]
     public void T5_1_HasSixelBelow_ReturnsTrueWhenSixelPresent()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1056,7 +1058,7 @@ public class SixelVisibilityTests
         Assert.Contains(true, results);
     }
 
-    [Fact]
+    [TestMethod]
     public void T5_2_HasSixelBelow_ReturnsFalseWhenNoSixel()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1079,11 +1081,11 @@ public class SixelVisibilityTests
         
         _ = composite.GetCell(10, 10);
         
-        Assert.NotNull(result);
-        Assert.False(result.Value);
+        Assert.IsNotNull(result);
+        Assert.IsFalse(result.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void T5_3_GetSixelBelow_ReturnsValidPixelData()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1112,19 +1114,19 @@ public class SixelVisibilityTests
         
         _ = composite.GetCell(5, 5);
         
-        Assert.NotNull(access);
-        Assert.True(access.Value.IsValid);
-        Assert.Equal(10, access.Value.PixelWidth);
-        Assert.Equal(20, access.Value.PixelHeight);
+        Assert.IsNotNull(access);
+        Assert.IsTrue(access.Value.IsValid);
+        Assert.AreEqual(10, access.Value.PixelWidth);
+        Assert.AreEqual(20, access.Value.PixelHeight);
         
         // Check pixel value (should be red, with quantization tolerance)
         var pixel = access.Value.GetPixel(0, 0);
-        Assert.True(pixel.R > 240, $"Expected R ~255, got {pixel.R}"); // Allow sixel quantization error
-        Assert.True(pixel.G < 15, $"Expected G ~0, got {pixel.G}");
-        Assert.True(pixel.B < 15, $"Expected B ~0, got {pixel.B}");
+        Assert.IsTrue(pixel.R > 240, $"Expected R ~255, got {pixel.R}"); // Allow sixel quantization error
+        Assert.IsTrue(pixel.G < 15, $"Expected G ~0, got {pixel.G}");
+        Assert.IsTrue(pixel.B < 15, $"Expected B ~0, got {pixel.B}");
     }
 
-    [Fact]
+    [TestMethod]
     public void T5_4_PixelCoordinatesMapCorrectlyToCellPosition()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1154,18 +1156,18 @@ public class SixelVisibilityTests
         
         _ = composite.GetCell(2, 1);
         
-        Assert.NotNull(access);
-        Assert.True(access.Value.IsValid);
+        Assert.IsNotNull(access);
+        Assert.IsTrue(access.Value.IsValid);
         
         // Pixel at (0,0) in cell (2,1) should be global pixel (20, 20)
         var pixel = access.Value.GetPixel(0, 0);
         // Due to sixel color quantization, values may differ slightly
         // Original would be R=20, G=20
-        Assert.True(pixel.R > 10 && pixel.R < 30, $"Expected R ~20, got {pixel.R}");
-        Assert.True(pixel.G > 10 && pixel.G < 30, $"Expected G ~20, got {pixel.G}");
+        Assert.IsTrue(pixel.R > 10 && pixel.R < 30, $"Expected R ~20, got {pixel.R}");
+        Assert.IsTrue(pixel.G > 10 && pixel.G < 30, $"Expected G ~20, got {pixel.G}");
     }
 
-    [Fact]
+    [TestMethod]
     public void T5_5_SixelPixelAccess_WithTint_AppliesTintCorrectly()
     {
         var buffer = new SixelPixelBuffer(10, 20);
@@ -1178,16 +1180,16 @@ public class SixelVisibilityTests
         
         var tintedBuffer = access.WithTint(new Rgba32(255, 0, 0, 255), 0.5f);
         
-        Assert.NotNull(tintedBuffer);
+        Assert.IsNotNull(tintedBuffer);
         
         // Result should be blend: 100 * 0.5 + 255 * 0.5 = 177.5 for R
         var resultPixel = tintedBuffer[5, 10];
-        Assert.True(resultPixel.R > 170 && resultPixel.R < 185, $"Expected R ~177, got {resultPixel.R}");
-        Assert.True(resultPixel.G > 45 && resultPixel.G < 55, $"Expected G ~50, got {resultPixel.G}");
-        Assert.True(resultPixel.B > 45 && resultPixel.B < 55, $"Expected B ~50, got {resultPixel.B}");
+        Assert.IsTrue(resultPixel.R > 170 && resultPixel.R < 185, $"Expected R ~177, got {resultPixel.R}");
+        Assert.IsTrue(resultPixel.G > 45 && resultPixel.G < 55, $"Expected G ~50, got {resultPixel.G}");
+        Assert.IsTrue(resultPixel.B > 45 && resultPixel.B < 55, $"Expected B ~50, got {resultPixel.B}");
     }
 
-    [Fact]
+    [TestMethod]
     public void T5_6_SixelPixelAccess_WithBrightness_AdjustsValues()
     {
         var buffer = new SixelPixelBuffer(10, 20);
@@ -1201,15 +1203,15 @@ public class SixelVisibilityTests
         // Reduce brightness by half
         var dimmedBuffer = access.WithBrightness(0.5f);
         
-        Assert.NotNull(dimmedBuffer);
+        Assert.IsNotNull(dimmedBuffer);
         
         var resultPixel = dimmedBuffer[5, 10];
-        Assert.Equal(50, resultPixel.R);
-        Assert.Equal(50, resultPixel.G);
-        Assert.Equal(50, resultPixel.B);
+        Assert.AreEqual(50, resultPixel.R);
+        Assert.AreEqual(50, resultPixel.G);
+        Assert.AreEqual(50, resultPixel.B);
     }
 
-    [Fact]
+    [TestMethod]
     public void T5_7_GetSixelBelowAt_ReturnsDataForDifferentPosition()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1239,11 +1241,11 @@ public class SixelVisibilityTests
         
         _ = composite.GetCell(20, 10);
         
-        Assert.NotNull(access);
-        Assert.True(access.Value.IsValid);
+        Assert.IsNotNull(access);
+        Assert.IsTrue(access.Value.IsValid);
     }
 
-    [Fact]
+    [TestMethod]
     public void T5_8_SixelPixelAccess_TransparentPixels_HandledCorrectly()
     {
         var buffer = new SixelPixelBuffer(10, 20);
@@ -1262,16 +1264,16 @@ public class SixelVisibilityTests
         var metrics = new CellMetrics(10, 20);
         var access = new SixelPixelAccess(buffer, 0, 0, metrics);
         
-        Assert.True(access.HasVisiblePixels());
+        Assert.IsTrue(access.HasVisiblePixels());
         
         var transparentPixel = access.GetPixel(0, 0);
-        Assert.Equal(0, transparentPixel.A);
+        Assert.AreEqual(0, transparentPixel.A);
         
         var opaquePixel = access.GetPixel(5, 0);
-        Assert.Equal(255, opaquePixel.A);
+        Assert.AreEqual(255, opaquePixel.A);
     }
 
-    [Fact]
+    [TestMethod]
     public void T5_9_SixelPixelAccess_OutOfBoundsPixel_ReturnsTransparent()
     {
         var buffer = new SixelPixelBuffer(10, 20);
@@ -1282,10 +1284,10 @@ public class SixelVisibilityTests
         
         // Query beyond buffer bounds
         var pixel = access.GetPixel(100, 100);
-        Assert.Equal(0, pixel.A);
+        Assert.AreEqual(0, pixel.A);
     }
 
-    [Fact]
+    [TestMethod]
     public void T5_10_GetSixelBelow_InvalidAccessor_WhenNoSixel()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1305,18 +1307,18 @@ public class SixelVisibilityTests
         
         _ = composite.GetCell(5, 5);
         
-        Assert.False(access.IsValid);
+        Assert.IsFalse(access.IsValid);
         
         // GetPixel on invalid accessor should return transparent
         var pixel = access.GetPixel(0, 0);
-        Assert.Equal(0, pixel.A);
+        Assert.AreEqual(0, pixel.A);
     }
 
     #endregion
 
     #region T6: Token Generation Sixel Tests
 
-    [Fact]
+    [TestMethod]
     public void T6_1_SingleSixel_CorrectCursorPositionAndSequence()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1329,19 +1331,19 @@ public class SixelVisibilityTests
         
         var tokens = SurfaceComparer.SixelFragmentsToTokens(composite);
         
-        Assert.Equal(2, tokens.Count); // CursorPosition + sixel sequence
-        Assert.IsType<CursorPositionToken>(tokens[0]);
-        Assert.IsType<UnrecognizedSequenceToken>(tokens[1]); // Raw DCS sequence
+        Assert.AreEqual(2, tokens.Count); // CursorPosition + sixel sequence
+        TestSeq.IsType<CursorPositionToken>(tokens[0]);
+        TestSeq.IsType<UnrecognizedSequenceToken>(tokens[1]); // Raw DCS sequence
         
         var cursorToken = (CursorPositionToken)tokens[0];
-        Assert.Equal(6, cursorToken.Row);    // 1-based: 5 + 1
-        Assert.Equal(6, cursorToken.Column); // 1-based: 5 + 1
+        Assert.AreEqual(6, cursorToken.Row);    // 1-based: 5 + 1
+        Assert.AreEqual(6, cursorToken.Column); // 1-based: 5 + 1
         
         var sequenceToken = (UnrecognizedSequenceToken)tokens[1];
         Assert.StartsWith("\x1bP", sequenceToken.Sequence); // Payload already includes DCS wrapper
     }
 
-    [Fact]
+    [TestMethod]
     public void T6_2_FragmentedSixel_MultipleCursorPositionsAndSequences()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1362,17 +1364,17 @@ public class SixelVisibilityTests
         var tokens = SurfaceComparer.SixelFragmentsToTokens(composite);
         
         // Should have multiple fragments (each with cursor + sixel sequence)
-        Assert.True(tokens.Count >= 4, $"Expected at least 4 tokens, got {tokens.Count}");
+        Assert.IsTrue(tokens.Count >= 4, $"Expected at least 4 tokens, got {tokens.Count}");
         
         // Verify alternating pattern: cursor, sixel, cursor, sixel, ...
         for (var i = 0; i < tokens.Count; i += 2)
         {
-            Assert.IsType<CursorPositionToken>(tokens[i]);
-            Assert.IsType<UnrecognizedSequenceToken>(tokens[i + 1]); // Raw DCS sequence
+            TestSeq.IsType<CursorPositionToken>(tokens[i]);
+            TestSeq.IsType<UnrecognizedSequenceToken>(tokens[i + 1]); // Raw DCS sequence
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void T6_3_SixelUnchanged_NotReEmittedWithDiff()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1390,10 +1392,10 @@ public class SixelVisibilityTests
         var tokens = SurfaceComparer.CompositeToTokens(composite, previous);
         
         // No sixels in either, so no sixel tokens
-        Assert.All(tokens, t => Assert.IsNotType<DcsToken>(t));
+        TestSeq.All(tokens, t => Assert.IsNotInstanceOfType<DcsToken>(t));
     }
 
-    [Fact]
+    [TestMethod]
     public void T6_4_SixelAndTextMixed_BothInOutput()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1408,16 +1410,16 @@ public class SixelVisibilityTests
         
         // Should have text tokens
         var textTokens = tokens.OfType<TextToken>().ToList();
-        Assert.Contains(textTokens, t => t.Text == "T");
+        Assert.IsTrue(textTokens.Any(t => t.Text == "T"));
         
         // Should have sixel token(s) - raw DCS sequence containing sixel data
         var sixelTokens = tokens.OfType<UnrecognizedSequenceToken>()
             .Where(t => t.Sequence.Contains("0;1;0q")) // Sixel header pattern
             .ToList();
-        Assert.NotEmpty(sixelTokens);
+        Assert.IsNotEmpty(sixelTokens);
     }
 
-    [Fact]
+    [TestMethod]
     public void T6_5_MultipleSixelsAtDifferentPositions()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1431,16 +1433,16 @@ public class SixelVisibilityTests
         var tokens = SurfaceComparer.SixelFragmentsToTokens(composite);
         
         // Each sixel gets cursor + dcs
-        Assert.Equal(4, tokens.Count);
+        Assert.AreEqual(4, tokens.Count);
         
         var cursor1 = (CursorPositionToken)tokens[0];
         var cursor2 = (CursorPositionToken)tokens[2];
         
         // Different positions
-        Assert.NotEqual(cursor1.Row, cursor2.Row);
+        Assert.AreNotEqual(cursor1.Row, cursor2.Row);
     }
 
-    [Fact]
+    [TestMethod]
     public void T6_6_FullyOccludedSixel_NoTokensGenerated()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1459,10 +1461,10 @@ public class SixelVisibilityTests
         
         var tokens = SurfaceComparer.SixelFragmentsToTokens(composite);
         
-        Assert.Empty(tokens);
+        Assert.IsEmpty(tokens);
     }
 
-    [Fact]
+    [TestMethod]
     public void T6_7_CompositeToAnsiString_IncludesSixelPayload()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1479,7 +1481,7 @@ public class SixelVisibilityTests
         Assert.Contains("\x1b\\", ansiString); // ST terminator
     }
 
-    [Fact]
+    [TestMethod]
     public void T6_8_EmptyComposite_NoSixelTokens()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1491,14 +1493,14 @@ public class SixelVisibilityTests
         
         var tokens = SurfaceComparer.SixelFragmentsToTokens(composite);
         
-        Assert.Empty(tokens);
+        Assert.IsEmpty(tokens);
     }
 
     #endregion
 
     #region T7: Edge Cases and Multiple Sixel Tests
 
-    [Fact]
+    [TestMethod]
     public void T7_1_SixelVsSixelOcclusion_UpperLayerWins()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1521,14 +1523,14 @@ public class SixelVisibilityTests
         // Should have fragments from both sixels
         // Lower sixel should be fragmented around upper sixel
         // Upper sixel should be complete or minimal fragmentation
-        Assert.True(fragments.Count >= 2);
+        Assert.IsTrue(fragments.Count >= 2);
         
         // Find the upper sixel's fragment(s) - should be at position (3, 0)
         var upperFragments = fragments.Where(f => f.CellPosition.X >= 3).ToList();
-        Assert.NotEmpty(upperFragments);
+        Assert.IsNotEmpty(upperFragments);
     }
 
-    [Fact]
+    [TestMethod]
     public void T7_2_TwoSixelsSameLayer_NoOcclusion()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1543,11 +1545,11 @@ public class SixelVisibilityTests
         var fragments = composite.GetSixelFragments();
         
         // Both sixels should be complete (no occlusion from same layer)
-        Assert.Equal(2, fragments.Count);
-        Assert.True(fragments.All(f => f.IsComplete));
+        Assert.AreEqual(2, fragments.Count);
+        Assert.IsTrue(fragments.All(f => f.IsComplete));
     }
 
-    [Fact]
+    [TestMethod]
     public void T7_3_SixelFullyHiddenByUpperSixel()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1569,11 +1571,11 @@ public class SixelVisibilityTests
         // Lower sixel at (2, 1) + 2x1 cells = covers cells (2-3, 1)
         // Upper sixel at (0, 0) + 10x3 cells = covers cells (0-9, 0-2)
         // So lower is completely inside upper's coverage
-        Assert.Single(fragments);
-        Assert.Equal((0, 0), fragments[0].CellPosition);
+        TestSeq.Single(fragments);
+        Assert.AreEqual((0, 0), fragments[0].CellPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public void T7_4_SixelAtNegativeOffset_Clipped()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1591,12 +1593,12 @@ public class SixelVisibilityTests
         // For now, just verify no crash and fragment positions are valid
         foreach (var fragment in fragments)
         {
-            Assert.True(fragment.CellPosition.X >= 0, "Fragment X should be >= 0");
-            Assert.True(fragment.CellPosition.Y >= 0, "Fragment Y should be >= 0");
+            Assert.IsTrue(fragment.CellPosition.X >= 0, "Fragment X should be >= 0");
+            Assert.IsTrue(fragment.CellPosition.Y >= 0, "Fragment Y should be >= 0");
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void T7_5_ManySixels_PerformanceReasonable()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1619,7 +1621,7 @@ public class SixelVisibilityTests
         var fragments = composite.GetSixelFragments();
         
         // Each sixel should be present
-        Assert.True(fragments.Count >= 100);
+        Assert.IsTrue(fragments.Count >= 100);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/SixelNodeTests.cs
+++ b/tests/Hex1b.Tests/SixelNodeTests.cs
@@ -12,6 +12,7 @@ namespace Hex1b.Tests;
 /// Unit tests for SixelNode.
 /// Sixel support is controlled via TerminalCapabilities, not static state.
 /// </summary>
+[TestClass]
 public class SixelNodeTests
 {
     /// <summary>
@@ -38,7 +39,7 @@ public class SixelNodeTests
             Supports256Colors = true
         });
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_WithRequestedDimensions_ReturnsRequestedSize()
     {
         var node = new SixelNode
@@ -49,11 +50,11 @@ public class SixelNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(50, size.Width);
-        Assert.Equal(25, size.Height);
+        Assert.AreEqual(50, size.Width);
+        Assert.AreEqual(25, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_WithoutRequestedDimensions_ReturnsDefaultSize()
     {
         var node = new SixelNode();
@@ -61,11 +62,11 @@ public class SixelNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // Default size is 40x20
-        Assert.Equal(40, size.Width);
-        Assert.Equal(20, size.Height);
+        Assert.AreEqual(40, size.Width);
+        Assert.AreEqual(20, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_WithFallback_ReturnsFallbackSize()
     {
         var fallbackNode = new TextBlockNode { Text = "Fallback text" };
@@ -77,10 +78,10 @@ public class SixelNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // Should return the larger of sixel or fallback size
-        Assert.True(size.Width > 0);
+        Assert.IsTrue(size.Width > 0);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithSixelSupport_RendersImageData()
     {
         var node = new SixelNode();
@@ -100,10 +101,10 @@ public class SixelNodeTests
             .WaitUntil(s => s.ContainsText("[No image data]"), TimeSpan.FromSeconds(5))
             .Build()
             .ApplyAsync(terminal);
-        Assert.True(terminal.CreateSnapshot().ContainsText("[No image data]"));
+        Assert.IsTrue(terminal.CreateSnapshot().ContainsText("[No image data]"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithoutSixelSupport_RendersFallback()
     {
         var node = new SixelNode
@@ -126,10 +127,10 @@ public class SixelNodeTests
             .WaitUntil(s => s.ContainsText("Fallback content"), TimeSpan.FromSeconds(5))
             .Build()
             .ApplyAsync(terminal);
-        Assert.True(terminal.CreateSnapshot().ContainsText("Fallback content"));
+        Assert.IsTrue(terminal.CreateSnapshot().ContainsText("Fallback content"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithoutSixelSupport_NoFallback_ShowsPlaceholder()
     {
         var node = new SixelNode();
@@ -148,10 +149,10 @@ public class SixelNodeTests
             .WaitUntil(s => s.ContainsText("[Sixel not supported]"), TimeSpan.FromSeconds(5))
             .Build()
             .ApplyAsync(terminal);
-        Assert.True(terminal.CreateSnapshot().ContainsText("[Sixel not supported]"));
+        Assert.IsTrue(terminal.CreateSnapshot().ContainsText("[Sixel not supported]"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_WithFallback_ReturnsFallbackFocusables()
     {
         var buttonNode = new ButtonNode { Label = "Test" };
@@ -167,7 +168,7 @@ public class SixelNodeTests
         Assert.Contains(buttonNode, focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_WhenShowingFallback_DelegatesToFallback()
     {
         var clickedCount = 0;
@@ -189,11 +190,11 @@ public class SixelNodeTests
         var enterEvent = new Hex1bKeyEvent(Hex1bKey.Enter, '\r', Hex1bModifiers.None);
         var result = await InputRouter.RouteInputAsync(node, enterEvent, focusRing, routerState, null, TestContext.Current.CancellationToken);
         
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(1, clickedCount);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(1, clickedCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithSixelData_OutputsSixelSequence()
     {
         var node = new SixelNode
@@ -212,15 +213,15 @@ public class SixelNodeTests
             .ApplyAsync(terminal);
         
         // Sixel data should be tracked in the terminal
-        Assert.True(terminal.ContainsSixelData());
+        Assert.IsTrue(terminal.ContainsSixelData());
         
         // The origin cell should have the Sixel data
         var sixelData = terminal.GetSixelDataAt(0, 0);
-        Assert.NotNull(sixelData);
+        Assert.IsNotNull(sixelData);
         Assert.Contains("#0;2;100;0;0#0~~~~~~", sixelData.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithPreformattedSixelData_OutputsAsIs()
     {
         // Data already has DCS header
@@ -247,15 +248,15 @@ public class SixelNodeTests
             .ApplyAsync(terminal);
         
         // Should be tracked as a single Sixel object
-        Assert.Equal(1, terminal.TrackedSixelCount);
+        Assert.AreEqual(1, terminal.TrackedSixelCount);
         
         // The tracked data should contain the original payload
         var trackedSixel = terminal.GetSixelDataAt(0, 0);
-        Assert.NotNull(trackedSixel);
+        Assert.IsNotNull(trackedSixel);
         Assert.Contains("#0;2;100;0;0#0~~~~~~", trackedSixel.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithSmpteColorBars_ProducesSvgWithEmbeddedImage()
     {
         // SMPTE color bars: White, Yellow, Cyan, Green, Magenta, Red, Blue
@@ -311,10 +312,10 @@ public class SixelNodeTests
         // Verify SVG contains an embedded image
         Assert.Contains("<image", svg);
         Assert.Contains("data:image/bmp;base64,", svg);
-        Assert.True(terminal.ContainsSixelData());
+        Assert.IsTrue(terminal.ContainsSixelData());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithColorGrid_ProducesSvgWithEmbeddedImage()
     {
         // 3x3 grid of colors - easy to verify each color block
@@ -371,10 +372,10 @@ public class SixelNodeTests
         TestCaptureHelper.AttachSvg("sixel-color-grid-reference.svg", referenceSvg);
         
         Assert.Contains("<image", svg);
-        Assert.True(terminal.ContainsSixelData());
+        Assert.IsTrue(terminal.ContainsSixelData());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithGrayscaleGradient_ProducesSvgWithEmbeddedImage()
     {
         // Horizontal grayscale gradient - black on left to white on right
@@ -431,7 +432,7 @@ public class SixelNodeTests
         Assert.Contains("data:image/bmp;base64,", svg);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithRgbGradients_ProducesSvgWithEmbeddedImage()
     {
         // Three horizontal bands: R gradient, G gradient, B gradient
@@ -485,10 +486,10 @@ public class SixelNodeTests
         TestCaptureHelper.AttachSvg("sixel-rgb-gradients-reference.svg", referenceSvg);
         
         Assert.Contains("<image", svg);
-        Assert.True(terminal.ContainsSixelData());
+        Assert.IsTrue(terminal.ContainsSixelData());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithCheckerboard_ProducesSvgWithEmbeddedImage()
     {
         // Checkerboard pattern - easy to verify alignment and scaling
@@ -545,7 +546,7 @@ public class SixelNodeTests
         Assert.Contains("data:image/bmp;base64,", svg);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithRegistrationMarks_ProducesSvgWithEmbeddedImage()
     {
         // Registration marks with center crosshair and colored corners
@@ -599,6 +600,6 @@ public class SixelNodeTests
         TestCaptureHelper.AttachSvg("sixel-registration-marks-reference.svg", referenceSvg);
         
         Assert.Contains("<image", svg);
-        Assert.True(terminal.ContainsSixelData());
+        Assert.IsTrue(terminal.ContainsSixelData());
     }
 }

--- a/tests/Hex1b.Tests/SixelScalingIntegrationTests.cs
+++ b/tests/Hex1b.Tests/SixelScalingIntegrationTests.cs
@@ -40,8 +40,8 @@ public class SixelScalingIntegrationTests
         { 12, 24, "large" }     // Large font
     };
 
-    [Theory(Skip = "Sixel is experimental and tracking in Surface mode differs from Legacy mode")]
-    [MemberData(nameof(CellDimensions))]
+    [TestMethod, Ignore("Sixel is experimental and tracking in Surface mode differs from Legacy mode")]
+    [DynamicData(nameof(CellDimensions))]
     public async Task SmpteColorBars_RendersCorrectlyAtScale(int cellWidth, int cellHeight, string scaleName)
     {
         // Generate SMPTE color bar pattern (70x30 pixels = 7 bars)
@@ -105,8 +105,8 @@ public class SixelScalingIntegrationTests
         await runTask;
         
         // Verify cell dimensions are correct
-        Assert.Equal(cellWidth, snapshot.CellPixelWidth);
-        Assert.Equal(cellHeight, snapshot.CellPixelHeight);
+        Assert.AreEqual(cellWidth, snapshot.CellPixelWidth);
+        Assert.AreEqual(cellHeight, snapshot.CellPixelHeight);
         
         // Capture all formats using infrastructure
         TestCaptureHelper.Capture(snapshot, $"sixel-smpte-{scaleName}-{cellWidth}x{cellHeight}");
@@ -117,8 +117,8 @@ public class SixelScalingIntegrationTests
         TestCaptureHelper.AttachSvg($"sixel-smpte-{scaleName}-reference.svg", refSvg);
     }
 
-    [Theory(Skip = "Sixel is experimental and tracking in Surface mode differs from Legacy mode")]
-    [MemberData(nameof(CellDimensions))]
+    [TestMethod, Ignore("Sixel is experimental and tracking in Surface mode differs from Legacy mode")]
+    [DynamicData(nameof(CellDimensions))]
     public async Task Checkerboard_RendersCorrectlyAtScale(int cellWidth, int cellHeight, string scaleName)
     {
         // Generate checkerboard pattern (64x48 pixels with 8x8 squares)
@@ -176,8 +176,8 @@ public class SixelScalingIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
         
-        Assert.Equal(cellWidth, snapshot.CellPixelWidth);
-        Assert.Equal(cellHeight, snapshot.CellPixelHeight);
+        Assert.AreEqual(cellWidth, snapshot.CellPixelWidth);
+        Assert.AreEqual(cellHeight, snapshot.CellPixelHeight);
         
         TestCaptureHelper.Capture(snapshot, $"sixel-checkerboard-{scaleName}-{cellWidth}x{cellHeight}");
         

--- a/tests/Hex1b.Tests/SliderIntegrationTests.cs
+++ b/tests/Hex1b.Tests/SliderIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Hex1b.Tests;
 /// Integration tests for the Slider widget using Hex1bApp.
 /// Tests various scenarios, layout conditions, and exports SVG, HTML, ANSI, and asciinema recordings.
 /// </summary>
+[TestClass]
 public class SliderIntegrationTests : IDisposable
 {
     private readonly List<string> _tempFiles = new();
@@ -31,7 +32,7 @@ public class SliderIntegrationTests : IDisposable
 
     #region Basic Rendering Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_RendersBasicSlider()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -57,11 +58,10 @@ public class SliderIntegrationTests : IDisposable
         await runTask;
 
         // Verify the slider track and handle are present
-        Assert.True(snapshot.ContainsText("─") || snapshot.ContainsText("█"),
-            "Slider should contain track or handle characters");
+        Assert.IsTrue(snapshot.ContainsText("─") || snapshot.ContainsText("█"), "Slider should contain track or handle characters");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_RendersAtMinimum()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -87,7 +87,7 @@ public class SliderIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_RendersAtMaximum()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -113,7 +113,7 @@ public class SliderIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_RendersCustomRange()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -139,7 +139,7 @@ public class SliderIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_RendersWithStep()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -169,7 +169,7 @@ public class SliderIntegrationTests : IDisposable
 
     #region Layout Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_FillsAvailableWidth()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -195,7 +195,7 @@ public class SliderIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_RespectsFixedWidth()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -221,7 +221,7 @@ public class SliderIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_InHStackWithLabel()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -250,7 +250,7 @@ public class SliderIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_MultipleInVStack()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -284,7 +284,7 @@ public class SliderIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_InBorder()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -311,11 +311,11 @@ public class SliderIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Theory]
-    [InlineData(40)]
-    [InlineData(60)]
-    [InlineData(80)]
-    [InlineData(120)]
+    [TestMethod]
+    [DataRow(40)]
+    [DataRow(60)]
+    [DataRow(80)]
+    [DataRow(120)]
     public async Task Slider_RespondsToTerminalWidth(int width)
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -345,7 +345,7 @@ public class SliderIntegrationTests : IDisposable
 
     #region Keyboard Navigation Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_ArrowKeysChangeValue()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -373,10 +373,10 @@ public class SliderIntegrationTests : IDisposable
 
         await runTask;
 
-        Assert.True(currentValue > 50, $"Expected value > 50, got {currentValue}");
+        Assert.IsTrue(currentValue > 50, $"Expected value > 50, got {currentValue}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_HomeEndJumpToExtremes()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -404,10 +404,10 @@ public class SliderIntegrationTests : IDisposable
 
         await runTask;
 
-        Assert.Equal(100, currentValue);
+        Assert.AreEqual(100, currentValue);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_TabNavigatesToNextWidget()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -434,14 +434,14 @@ public class SliderIntegrationTests : IDisposable
 
         await runTask;
 
-        Assert.True(buttonClicked);
+        Assert.IsTrue(buttonClicked);
     }
 
     #endregion
 
     #region Value Changed Callback Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_CallbackTriggeredOnChange()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -474,15 +474,15 @@ public class SliderIntegrationTests : IDisposable
 
         await runTask;
 
-        Assert.Equal(2, callbackCount);
-        Assert.True(lastPercentage > 0.5);
+        Assert.AreEqual(2, callbackCount);
+        Assert.IsTrue(lastPercentage > 0.5);
     }
 
     #endregion
 
     #region Theming Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_RespectsCustomTheme()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -522,7 +522,7 @@ public class SliderIntegrationTests : IDisposable
 
     #region Asciinema Recording Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_RecordsInteraction()
     {
         var tempFile = GetTempFile();
@@ -621,7 +621,7 @@ public class SliderIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_RecordsMultipleSliders()
     {
         var tempFile = GetTempFile();
@@ -710,7 +710,7 @@ public class SliderIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_RecordsResizeScenario()
     {
         var tempFile = GetTempFile();
@@ -787,7 +787,7 @@ public class SliderIntegrationTests : IDisposable
 
     #region Mouse Drag Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_MouseDragChangesValue()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -815,10 +815,10 @@ public class SliderIntegrationTests : IDisposable
         await runTask;
 
         // Just verify no crash during drag - actual value change is tested manually
-        Assert.NotNull(snapshot);
+        Assert.IsNotNull(snapshot);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_MouseClickSetsValue()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -849,14 +849,14 @@ public class SliderIntegrationTests : IDisposable
 
         // Click should set value via OnValueChanged event
         // Note: Mouse click invokes the input binding which fires the event
-        Assert.True(currentValue >= 0, $"Value should be set, got {currentValue}");
+        Assert.IsTrue(currentValue >= 0, $"Value should be set, got {currentValue}");
     }
 
     #endregion
 
     #region Double-Width Character Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_DoubleWidthThumbCharacterRendersWithoutArtifacts()
     {
         // Use a double-width CJK character as the thumb to test for rendering artifacts
@@ -890,7 +890,7 @@ public class SliderIntegrationTests : IDisposable
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
         // Verify initial render contains the double-width character
-        Assert.True(snapshot.ContainsText("⾠"), "Slider should contain the double-width thumb character");
+        Assert.IsTrue(snapshot.ContainsText("⾠"), "Slider should contain the double-width thumb character");
 
         // Move slider and check for artifacts (no stray characters left behind)
         await new Hex1bTerminalInputSequenceBuilder()
@@ -909,7 +909,7 @@ public class SliderIntegrationTests : IDisposable
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_DoubleWidthThumbDragDoesNotLeaveArtifacts()
     {
         // Test that dragging a slider with a double-width thumb doesn't leave visual artifacts
@@ -958,11 +958,10 @@ public class SliderIntegrationTests : IDisposable
         var sliderLine = snapshot.GetLine(1);
         var thumbCount = sliderLine.Count(c => c == doubleWidthThumb);
         
-        Assert.True(thumbCount <= 1, 
-            $"Expected at most 1 thumb character, found {thumbCount}. Line: '{sliderLine}'");
+        Assert.IsTrue(thumbCount <= 1, $"Expected at most 1 thumb character, found {thumbCount}. Line: '{sliderLine}'");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_InsideBorder_BorderEdgesAreAligned()
     {
         // Test that a slider inside a border doesn't cause the border edges to misalign
@@ -1011,22 +1010,20 @@ public class SliderIntegrationTests : IDisposable
         var topRightDisplayCol = GetDisplayColumnOfLastChar(topLine, '┐');
         var bottomRightDisplayCol = GetDisplayColumnOfLastChar(bottomLine, '┘');
         
-        Assert.True(topRightDisplayCol >= 0, $"Top border should have right corner. Line: '{topLine}'");
-        Assert.True(bottomRightDisplayCol >= 0, $"Bottom border should have right corner. Line: '{bottomLine}'");
-        Assert.True(topRightDisplayCol == bottomRightDisplayCol, 
-            $"Border right edges should be aligned by display column. Top corner at column {topRightDisplayCol}, bottom corner at column {bottomRightDisplayCol}.\nTop: '{topLine}'\nBottom: '{bottomLine}'");
+        Assert.IsTrue(topRightDisplayCol >= 0, $"Top border should have right corner. Line: '{topLine}'");
+        Assert.IsTrue(bottomRightDisplayCol >= 0, $"Bottom border should have right corner. Line: '{bottomLine}'");
+        Assert.IsTrue(topRightDisplayCol == bottomRightDisplayCol, $"Border right edges should be aligned by display column. Top corner at column {topRightDisplayCol}, bottom corner at column {bottomRightDisplayCol}.\nTop: '{topLine}'\nBottom: '{bottomLine}'");
         
         // Check middle lines with vertical bars
         var middleLines = lines.Where(l => l.Contains('│') && !l.Contains('┌') && !l.Contains('└')).ToList();
         foreach (var middleLine in middleLines)
         {
             var rightBarDisplayCol = GetDisplayColumnOfLastChar(middleLine, '│');
-            Assert.True(topRightDisplayCol == rightBarDisplayCol,
-                $"Middle border should align with corners by display column. Expected column {topRightDisplayCol}, got {rightBarDisplayCol}.\nLine: '{middleLine}'");
+            Assert.IsTrue(topRightDisplayCol == rightBarDisplayCol, $"Middle border should align with corners by display column. Expected column {topRightDisplayCol}, got {rightBarDisplayCol}.\nLine: '{middleLine}'");
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Slider_InsideBorder_WithDoubleWidthThumb_BorderEdgesAreAligned()
     {
         // Test that a slider with double-width thumb inside a border doesn't cause misalignment
@@ -1081,18 +1078,16 @@ public class SliderIntegrationTests : IDisposable
         var topRightDisplayCol = GetDisplayColumnOfLastChar(topLine, '┐');
         var bottomRightDisplayCol = GetDisplayColumnOfLastChar(bottomLine, '┘');
         
-        Assert.True(topRightDisplayCol >= 0, $"Top border should have right corner. Line: '{topLine}'");
-        Assert.True(bottomRightDisplayCol >= 0, $"Bottom border should have right corner. Line: '{bottomLine}'");
-        Assert.True(topRightDisplayCol == bottomRightDisplayCol, 
-            $"Border right edges should be aligned with double-width thumb. Top corner at column {topRightDisplayCol}, bottom corner at column {bottomRightDisplayCol}.\nTop: '{topLine}'\nBottom: '{bottomLine}'");
+        Assert.IsTrue(topRightDisplayCol >= 0, $"Top border should have right corner. Line: '{topLine}'");
+        Assert.IsTrue(bottomRightDisplayCol >= 0, $"Bottom border should have right corner. Line: '{bottomLine}'");
+        Assert.IsTrue(topRightDisplayCol == bottomRightDisplayCol, $"Border right edges should be aligned with double-width thumb. Top corner at column {topRightDisplayCol}, bottom corner at column {bottomRightDisplayCol}.\nTop: '{topLine}'\nBottom: '{bottomLine}'");
         
         // Check middle lines with vertical bars
         var middleLines = lines.Where(l => l.Contains('│') && !l.Contains('┌') && !l.Contains('└')).ToList();
         foreach (var middleLine in middleLines)
         {
             var rightBarDisplayCol = GetDisplayColumnOfLastChar(middleLine, '│');
-            Assert.True(topRightDisplayCol == rightBarDisplayCol,
-                $"Middle border should align with corners. Expected column {topRightDisplayCol}, got {rightBarDisplayCol}.\nLine: '{middleLine}'");
+            Assert.IsTrue(topRightDisplayCol == rightBarDisplayCol, $"Middle border should align with corners. Expected column {topRightDisplayCol}, got {rightBarDisplayCol}.\nLine: '{middleLine}'");
         }
     }
 

--- a/tests/Hex1b.Tests/SliderNodeTests.cs
+++ b/tests/Hex1b.Tests/SliderNodeTests.cs
@@ -10,11 +10,12 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Unit tests for SliderNode measurement, rendering, and input handling.
 /// </summary>
+[TestClass]
 public class SliderNodeTests
 {
     #region Measurement Tests
 
-    [Fact]
+    [TestMethod]
     public void Measure_FillsAvailableWidth()
     {
         var node = new SliderNode { Value = 50, Maximum = 100 };
@@ -22,11 +23,11 @@ public class SliderNodeTests
 
         var size = node.Measure(constraints);
 
-        Assert.Equal(80, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(80, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_RespectsMinWidth()
     {
         var node = new SliderNode { Value = 50, Maximum = 100 };
@@ -34,11 +35,11 @@ public class SliderNodeTests
 
         var size = node.Measure(constraints);
 
-        Assert.Equal(80, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(80, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_UnboundedWidth_UsesDefaultWidth()
     {
         var node = new SliderNode { Value = 50, Maximum = 100 };
@@ -46,15 +47,15 @@ public class SliderNodeTests
 
         var size = node.Measure(constraints);
 
-        Assert.Equal(20, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(20, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
     #endregion
 
     #region Reconciliation Tests
 
-    [Fact]
+    [TestMethod]
     public void Reconcile_PreservesNodeOnSameType()
     {
         var widget1 = new SliderWidget { InitialValue = 25, Maximum = 100 };
@@ -69,12 +70,12 @@ public class SliderNodeTests
         context2.IsNew = false; // Existing node
         var node2 = widget2.ReconcileAsync(node1, context2).GetAwaiter().GetResult();
 
-        Assert.Same(node1, node2);
+        Assert.AreSame(node1, node2);
         // Value should be preserved (not changed to 75) because state is owned by node
-        Assert.Equal(25, ((SliderNode)node2).Value);
+        Assert.AreEqual(25, ((SliderNode)node2).Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void Reconcile_AppliesInitialValueOnNewNode()
     {
         var widget = new SliderWidget { InitialValue = 42, Minimum = 0, Maximum = 100 };
@@ -83,10 +84,10 @@ public class SliderNodeTests
 
         var node = widget.ReconcileAsync(null, context).GetAwaiter().GetResult() as SliderNode;
 
-        Assert.Equal(42, node!.Value);
+        Assert.AreEqual(42, node!.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void Reconcile_ClampsValueToRange()
     {
         var widget1 = new SliderWidget { InitialValue = 150, Minimum = 0, Maximum = 100 };
@@ -95,10 +96,10 @@ public class SliderNodeTests
 
         var node = widget1.ReconcileAsync(null, context).GetAwaiter().GetResult() as SliderNode;
 
-        Assert.Equal(100, node!.Value); // Clamped to max
+        Assert.AreEqual(100, node!.Value); // Clamped to max
     }
 
-    [Fact]
+    [TestMethod]
     public void Reconcile_MarksDirtyOnMinimumChange()
     {
         var widget1 = new SliderWidget { InitialValue = 50, Minimum = 0, Maximum = 100 };
@@ -110,10 +111,10 @@ public class SliderNodeTests
 
         widget2.ReconcileAsync(node, context).GetAwaiter().GetResult();
 
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void Reconcile_MarksDirtyOnMaximumChange()
     {
         var widget1 = new SliderWidget { InitialValue = 50, Maximum = 100 };
@@ -125,10 +126,10 @@ public class SliderNodeTests
 
         widget2.ReconcileAsync(node, context).GetAwaiter().GetResult();
 
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void Reconcile_MarksDirtyOnStepChange()
     {
         var widget1 = new SliderWidget { InitialValue = 50, Step = 5 };
@@ -140,10 +141,10 @@ public class SliderNodeTests
 
         widget2.ReconcileAsync(node, context).GetAwaiter().GetResult();
 
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void Reconcile_DoesNotMarkDirtyWhenUnchanged()
     {
         var widget1 = new SliderWidget { InitialValue = 50, Maximum = 100 };
@@ -155,30 +156,30 @@ public class SliderNodeTests
 
         widget2.ReconcileAsync(node, context).GetAwaiter().GetResult();
 
-        Assert.False(node.IsDirty);
+        Assert.IsFalse(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetExpectedNodeType_ReturnsSliderNode()
     {
         var widget = new SliderWidget();
 
-        Assert.Equal(typeof(SliderNode), widget.GetExpectedNodeType());
+        Assert.AreEqual(typeof(SliderNode), widget.GetExpectedNodeType());
     }
 
     #endregion
 
     #region Focus Tests
 
-    [Fact]
+    [TestMethod]
     public void IsFocusable_ReturnsTrue()
     {
         var node = new SliderNode();
 
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsFocused_WhenSet_MarksDirty()
     {
         var node = new SliderNode();
@@ -186,10 +187,10 @@ public class SliderNodeTests
 
         node.IsFocused = true;
 
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsFocused_WhenSetToSameValue_DoesNotMarkDirty()
     {
         var node = new SliderNode { IsFocused = true };
@@ -197,21 +198,21 @@ public class SliderNodeTests
 
         node.IsFocused = true;
 
-        Assert.False(node.IsDirty);
+        Assert.IsFalse(node.IsDirty);
     }
 
     #endregion
 
     #region Percentage Calculation Tests
 
-    [Theory]
-    [InlineData(0, 0, 100, 0.0)]
-    [InlineData(50, 0, 100, 0.5)]
-    [InlineData(100, 0, 100, 1.0)]
-    [InlineData(25, 0, 100, 0.25)]
-    [InlineData(-25, -50, 50, 0.25)]
-    [InlineData(0, -100, 100, 0.5)]
-    [InlineData(5, 0, 10, 0.5)]
+    [TestMethod]
+    [DataRow(0, 0, 100, 0.0)]
+    [DataRow(50, 0, 100, 0.5)]
+    [DataRow(100, 0, 100, 1.0)]
+    [DataRow(25, 0, 100, 0.25)]
+    [DataRow(-25, -50, 50, 0.25)]
+    [DataRow(0, -100, 100, 0.5)]
+    [DataRow(5, 0, 10, 0.5)]
     public void Percentage_CalculatesCorrectly(double value, double min, double max, double expectedPercentage)
     {
         var node = new SliderNode
@@ -221,10 +222,10 @@ public class SliderNodeTests
             Maximum = max
         };
 
-        Assert.Equal(expectedPercentage, node.Percentage, precision: 5);
+        Assert.AreEqual(expectedPercentage, node.Percentage, delta: 5);
     }
 
-    [Fact]
+    [TestMethod]
     public void Percentage_EqualMinMax_ReturnsZero()
     {
         var node = new SliderNode
@@ -234,14 +235,14 @@ public class SliderNodeTests
             Maximum = 50
         };
 
-        Assert.Equal(0.0, node.Percentage);
+        Assert.AreEqual(0.0, node.Percentage);
     }
 
     #endregion
 
     #region Input Handling Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_RightArrow_IncreasesValue()
     {
         var node = new SliderNode
@@ -258,11 +259,11 @@ public class SliderNodeTests
             null, null,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(node.Value > 50);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(node.Value > 50);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_LeftArrow_DecreasesValue()
     {
         var node = new SliderNode
@@ -279,11 +280,11 @@ public class SliderNodeTests
             null, null,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(node.Value < 50);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(node.Value < 50);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_UpArrow_IncreasesValue()
     {
         var node = new SliderNode
@@ -300,11 +301,11 @@ public class SliderNodeTests
             null, null,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(node.Value > 50);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(node.Value > 50);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_DownArrow_DecreasesValue()
     {
         var node = new SliderNode
@@ -321,11 +322,11 @@ public class SliderNodeTests
             null, null,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(node.Value < 50);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(node.Value < 50);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Home_JumpsToMinimum()
     {
         var node = new SliderNode
@@ -342,11 +343,11 @@ public class SliderNodeTests
             null, null,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(10, node.Value);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(10, node.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_End_JumpsToMaximum()
     {
         var node = new SliderNode
@@ -363,11 +364,11 @@ public class SliderNodeTests
             null, null,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(80, node.Value);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(80, node.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_PageUp_IncreasesBy10Percent()
     {
         var node = new SliderNode
@@ -385,11 +386,11 @@ public class SliderNodeTests
             null, null,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(60, node.Value);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(60, node.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_PageDown_DecreasesBy10Percent()
     {
         var node = new SliderNode
@@ -407,11 +408,11 @@ public class SliderNodeTests
             null, null,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(40, node.Value);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(40, node.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_RightArrow_ClampsToMax()
     {
         var node = new SliderNode
@@ -429,11 +430,11 @@ public class SliderNodeTests
             null, null,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(100, node.Value);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(100, node.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_LeftArrow_ClampsToMin()
     {
         var node = new SliderNode
@@ -451,11 +452,11 @@ public class SliderNodeTests
             null, null,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(0, node.Value);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(0, node.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_WithStep_SnapsToStepValues()
     {
         var node = new SliderNode
@@ -473,10 +474,10 @@ public class SliderNodeTests
             null, null,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(10, node.Value);
+        Assert.AreEqual(10, node.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_ValueChangedCallback_IsCalled()
     {
         var callbackInvoked = false;
@@ -502,11 +503,11 @@ public class SliderNodeTests
             null, null,
             TestContext.Current.CancellationToken);
 
-        Assert.True(callbackInvoked);
-        Assert.Equal(50, previousValue);
+        Assert.IsTrue(callbackInvoked);
+        Assert.AreEqual(50, previousValue);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_OtherKey_NotHandled()
     {
         var node = new SliderNode
@@ -523,41 +524,41 @@ public class SliderNodeTests
             null, null,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.NotHandled, result);
-        Assert.Equal(50, node.Value);
+        Assert.AreEqual(InputResult.NotHandled, result);
+        Assert.AreEqual(50, node.Value);
     }
 
     #endregion
 
     #region Widget Event Handler Tests
 
-    [Fact]
+    [TestMethod]
     public void OnValueChanged_SyncHandler_ReturnsNewWidget()
     {
         var widget = new SliderWidget();
 
         var newWidget = widget.OnValueChanged(_ => { });
 
-        Assert.NotSame(widget, newWidget);
-        Assert.NotNull(newWidget.ValueChangedHandler);
+        Assert.AreNotSame(widget, newWidget);
+        Assert.IsNotNull(newWidget.ValueChangedHandler);
     }
 
-    [Fact]
+    [TestMethod]
     public void OnValueChanged_AsyncHandler_ReturnsNewWidget()
     {
         var widget = new SliderWidget();
 
         var newWidget = widget.OnValueChanged(async args => await Task.Delay(1));
 
-        Assert.NotSame(widget, newWidget);
-        Assert.NotNull(newWidget.ValueChangedHandler);
+        Assert.AreNotSame(widget, newWidget);
+        Assert.IsNotNull(newWidget.ValueChangedHandler);
     }
 
     #endregion
 
     #region Layout Tests
 
-    [Fact]
+    [TestMethod]
     public void Arrange_SetsBounds()
     {
         var node = new SliderNode();
@@ -565,7 +566,7 @@ public class SliderNodeTests
 
         node.Arrange(bounds);
 
-        Assert.Equal(bounds, node.Bounds);
+        Assert.AreEqual(bounds, node.Bounds);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/SoftWrapTrackingTests.cs
+++ b/tests/Hex1b.Tests/SoftWrapTrackingTests.cs
@@ -5,9 +5,10 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for the SoftWrap cell attribute tracking during terminal operations.
 /// </summary>
+[TestClass]
 public class SoftWrapTrackingTests
 {
-    [Fact]
+    [TestMethod]
     public void WriteToEndOfLine_SetsSoftWrapOnLastCell()
     {
         // Arrange: 5-column terminal
@@ -21,15 +22,14 @@ public class SoftWrapTrackingTests
         // Assert: Last cell of row 0 should have SoftWrap (it was the wrap point)
         var snapshot = terminal.CreateSnapshot();
         var lastCell = snapshot.GetCell(4, 0); // col 4 (0-based), row 0
-        Assert.Equal("E", lastCell.Character);
-        Assert.True((lastCell.Attributes & CellAttributes.SoftWrap) != 0,
-            "Last cell of wrapped row should have SoftWrap attribute");
+        Assert.AreEqual("E", lastCell.Character);
+        Assert.IsTrue((lastCell.Attributes & CellAttributes.SoftWrap) != 0, "Last cell of wrapped row should have SoftWrap attribute");
 
         // Row 1 should have F and no SoftWrap on its last occupied cell
-        Assert.Equal("F", snapshot.GetCell(0, 1).Character);
+        Assert.AreEqual("F", snapshot.GetCell(0, 1).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExplicitLineFeed_DoesNotSetSoftWrap()
     {
         // Arrange: 10-column terminal
@@ -44,14 +44,13 @@ public class SoftWrapTrackingTests
         // Assert: Last cell of row 0 should NOT have SoftWrap
         var snapshot = terminal.CreateSnapshot();
         var lastCell = snapshot.GetCell(9, 0); // last column
-        Assert.True((lastCell.Attributes & CellAttributes.SoftWrap) == 0,
-            "Row ending with explicit LF should not have SoftWrap");
+        Assert.IsTrue((lastCell.Attributes & CellAttributes.SoftWrap) == 0, "Row ending with explicit LF should not have SoftWrap");
         // Also verify the content is correct (World on row 1)
-        Assert.Equal("Hello", snapshot.GetLine(0).TrimEnd());
-        Assert.Equal("World", snapshot.GetLine(1).TrimEnd());
+        Assert.AreEqual("Hello", snapshot.GetLine(0).TrimEnd());
+        Assert.AreEqual("World", snapshot.GetLine(1).TrimEnd());
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseLine_ClearsSoftWrap()
     {
         // Arrange: 5-column terminal, write to wrap
@@ -64,7 +63,7 @@ public class SoftWrapTrackingTests
 
         // Verify wrap is set
         var snap1 = terminal.CreateSnapshot();
-        Assert.True((snap1.GetCell(4, 0).Attributes & CellAttributes.SoftWrap) != 0);
+        Assert.IsTrue((snap1.GetCell(4, 0).Attributes & CellAttributes.SoftWrap) != 0);
 
         // Act: Move cursor to row 0 and erase entire line (CSI 2K)
         terminal.ApplyTokens([
@@ -74,11 +73,10 @@ public class SoftWrapTrackingTests
 
         // Assert: SoftWrap should be cleared
         var snap2 = terminal.CreateSnapshot();
-        Assert.True((snap2.GetCell(4, 0).Attributes & CellAttributes.SoftWrap) == 0,
-            "Erase line should clear SoftWrap");
+        Assert.IsTrue((snap2.GetCell(4, 0).Attributes & CellAttributes.SoftWrap) == 0, "Erase line should clear SoftWrap");
     }
 
-    [Fact]
+    [TestMethod]
     public void OverwriteLastCell_ClearsSoftWrapWhenNotWrapping()
     {
         // Arrange: 5-column terminal, write to wrap
@@ -91,7 +89,7 @@ public class SoftWrapTrackingTests
 
         // Verify wrap is set
         var snap1 = terminal.CreateSnapshot();
-        Assert.True((snap1.GetCell(4, 0).Attributes & CellAttributes.SoftWrap) != 0);
+        Assert.IsTrue((snap1.GetCell(4, 0).Attributes & CellAttributes.SoftWrap) != 0);
 
         // Act: Move cursor to col 5 of row 0 and overwrite (no wrap occurs)
         terminal.ApplyTokens([
@@ -102,10 +100,10 @@ public class SoftWrapTrackingTests
         // Assert: The cell was overwritten. Since this write triggers another wrap,
         // SoftWrap should still be set.
         var snap2 = terminal.CreateSnapshot();
-        Assert.Equal("X", snap2.GetCell(4, 0).Character);
+        Assert.AreEqual("X", snap2.GetCell(4, 0).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void SoftWrap_TravelsWithScrollUp()
     {
         // Arrange: 5-column, 3-row terminal with scrollback
@@ -126,11 +124,10 @@ public class SoftWrapTrackingTests
 
         // Screen row 0's last cell should have SoftWrap (it wrapped)
         var screenRow0Last = snapshot.GetCell(4, 0);
-        Assert.True((screenRow0Last.Attributes & CellAttributes.SoftWrap) != 0,
-            "Screen row that wrapped should retain SoftWrap");
+        Assert.IsTrue((screenRow0Last.Attributes & CellAttributes.SoftWrap) != 0, "Screen row that wrapped should retain SoftWrap");
     }
 
-    [Fact]
+    [TestMethod]
     public void MultipleWraps_AllSetSoftWrap()
     {
         // Arrange: 3-column terminal
@@ -144,19 +141,16 @@ public class SoftWrapTrackingTests
         var snapshot = terminal.CreateSnapshot();
 
         // Row 0: ABC (soft-wrapped)
-        Assert.True((snapshot.GetCell(2, 0).Attributes & CellAttributes.SoftWrap) != 0,
-            "Row 0 last cell should have SoftWrap");
+        Assert.IsTrue((snapshot.GetCell(2, 0).Attributes & CellAttributes.SoftWrap) != 0, "Row 0 last cell should have SoftWrap");
 
         // Row 1: DEF (soft-wrapped)
-        Assert.True((snapshot.GetCell(2, 1).Attributes & CellAttributes.SoftWrap) != 0,
-            "Row 1 last cell should have SoftWrap");
+        Assert.IsTrue((snapshot.GetCell(2, 1).Attributes & CellAttributes.SoftWrap) != 0, "Row 1 last cell should have SoftWrap");
 
         // Row 2: GHI (not wrapped — content ends here)
-        Assert.True((snapshot.GetCell(2, 2).Attributes & CellAttributes.SoftWrap) == 0,
-            "Last row should not have SoftWrap (no continuation)");
+        Assert.IsTrue((snapshot.GetCell(2, 2).Attributes & CellAttributes.SoftWrap) == 0, "Last row should not have SoftWrap (no continuation)");
     }
 
-    [Fact]
+    [TestMethod]
     public void EraseDisplay_ClearsSoftWrap()
     {
         // Arrange
@@ -168,18 +162,17 @@ public class SoftWrapTrackingTests
 
         // Verify wrap is set
         var snap1 = terminal.CreateSnapshot();
-        Assert.True((snap1.GetCell(4, 0).Attributes & CellAttributes.SoftWrap) != 0);
+        Assert.IsTrue((snap1.GetCell(4, 0).Attributes & CellAttributes.SoftWrap) != 0);
 
         // Act: Clear entire display (CSI 2J)
         terminal.ApplyTokens([new ClearScreenToken(ClearMode.All)]);
 
         // Assert
         var snap2 = terminal.CreateSnapshot();
-        Assert.True((snap2.GetCell(4, 0).Attributes & CellAttributes.SoftWrap) == 0,
-            "Erase display should clear SoftWrap");
+        Assert.IsTrue((snap2.GetCell(4, 0).Attributes & CellAttributes.SoftWrap) == 0, "Erase display should clear SoftWrap");
     }
 
-    [Fact]
+    [TestMethod]
     public void ExactFill_NoWrap_NoSoftWrap()
     {
         // Arrange: Write exactly 5 chars to a 5-column terminal
@@ -194,7 +187,6 @@ public class SoftWrapTrackingTests
         // Assert: No SoftWrap yet because wrap hasn't actually fired
         // (it's just pending)
         var snapshot = terminal.CreateSnapshot();
-        Assert.True((snapshot.GetCell(4, 0).Attributes & CellAttributes.SoftWrap) == 0,
-            "Pending wrap (no next char) should not set SoftWrap");
+        Assert.IsTrue((snapshot.GetCell(4, 0).Attributes & CellAttributes.SoftWrap) == 0, "Pending wrap (no next char) should not set SoftWrap");
     }
 }

--- a/tests/Hex1b.Tests/SpinnerNodeTests.cs
+++ b/tests/Hex1b.Tests/SpinnerNodeTests.cs
@@ -8,99 +8,100 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Unit tests for SpinnerNode layout, rendering, and frame selection.
 /// </summary>
+[TestClass]
 public class SpinnerNodeTests
 {
-    [Fact]
+    [TestMethod]
     public void SpinnerStyle_Dots_HasCorrectFrameCount()
     {
-        Assert.Equal(10, SpinnerStyle.Dots.Frames.Count);
+        Assert.AreEqual(10, SpinnerStyle.Dots.Frames.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerStyle_Line_HasCorrectFrameCount()
     {
-        Assert.Equal(4, SpinnerStyle.Line.Frames.Count);
+        Assert.AreEqual(4, SpinnerStyle.Line.Frames.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerStyle_GetFrame_WrapsCorrectly()
     {
         var style = SpinnerStyle.Line; // 4 frames: | / - \
 
-        Assert.Equal("|", style.GetFrame(0));
-        Assert.Equal("/", style.GetFrame(1));
-        Assert.Equal("-", style.GetFrame(2));
-        Assert.Equal("\\", style.GetFrame(3));
-        Assert.Equal("|", style.GetFrame(4)); // Wraps back to 0
-        Assert.Equal("/", style.GetFrame(5));
+        Assert.AreEqual("|", style.GetFrame(0));
+        Assert.AreEqual("/", style.GetFrame(1));
+        Assert.AreEqual("-", style.GetFrame(2));
+        Assert.AreEqual("\\", style.GetFrame(3));
+        Assert.AreEqual("|", style.GetFrame(4)); // Wraps back to 0
+        Assert.AreEqual("/", style.GetFrame(5));
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerStyle_GetFrame_HandlesNegativeIndex()
     {
         var style = SpinnerStyle.Line; // 4 frames
 
-        Assert.Equal("\\", style.GetFrame(-1)); // Last frame
-        Assert.Equal("-", style.GetFrame(-2));
+        Assert.AreEqual("\\", style.GetFrame(-1)); // Last frame
+        Assert.AreEqual("-", style.GetFrame(-2));
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerStyle_AutoReverse_PingPongsCorrectly()
     {
         var style = SpinnerStyle.Bounce; // 8 frames with auto-reverse
 
         // Forward: 0,1,2,3,4,5,6,7
-        Assert.Equal("▁", style.GetFrame(0));
-        Assert.Equal("▂", style.GetFrame(1));
-        Assert.Equal("█", style.GetFrame(7));
+        Assert.AreEqual("▁", style.GetFrame(0));
+        Assert.AreEqual("▂", style.GetFrame(1));
+        Assert.AreEqual("█", style.GetFrame(7));
 
         // Reverse: 6,5,4,3,2,1
-        Assert.Equal("▇", style.GetFrame(8));  // Mirrors frame 6
-        Assert.Equal("▆", style.GetFrame(9));  // Mirrors frame 5
-        Assert.Equal("▂", style.GetFrame(13)); // Mirrors frame 1
+        Assert.AreEqual("▇", style.GetFrame(8));  // Mirrors frame 6
+        Assert.AreEqual("▆", style.GetFrame(9));  // Mirrors frame 5
+        Assert.AreEqual("▂", style.GetFrame(13)); // Mirrors frame 1
 
         // Back to start
-        Assert.Equal("▁", style.GetFrame(14)); // Back to frame 0
+        Assert.AreEqual("▁", style.GetFrame(14)); // Back to frame 0
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerStyle_CustomStyle_CanBeCreated()
     {
         var custom = new SpinnerStyle("A", "B", "C");
 
-        Assert.Equal(3, custom.Frames.Count);
-        Assert.Equal(TimeSpan.FromMilliseconds(80), custom.Interval);
-        Assert.False(custom.AutoReverse);
+        Assert.AreEqual(3, custom.Frames.Count);
+        Assert.AreEqual(TimeSpan.FromMilliseconds(80), custom.Interval);
+        Assert.IsFalse(custom.AutoReverse);
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerStyle_CustomStyleWithInterval_CanBeCreated()
     {
         var custom = new SpinnerStyle(TimeSpan.FromMilliseconds(200), "X", "Y");
 
-        Assert.Equal(2, custom.Frames.Count);
-        Assert.Equal(TimeSpan.FromMilliseconds(200), custom.Interval);
+        Assert.AreEqual(2, custom.Frames.Count);
+        Assert.AreEqual(TimeSpan.FromMilliseconds(200), custom.Interval);
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerStyle_CustomStyleWithAutoReverse_CanBeCreated()
     {
         var custom = new SpinnerStyle(TimeSpan.FromMilliseconds(100), autoReverse: true, "1", "2", "3");
 
-        Assert.True(custom.AutoReverse);
-        Assert.Equal("1", custom.GetFrame(0));
-        Assert.Equal("3", custom.GetFrame(2));
-        Assert.Equal("2", custom.GetFrame(3)); // Reversing
-        Assert.Equal("1", custom.GetFrame(4)); // Back to start
+        Assert.IsTrue(custom.AutoReverse);
+        Assert.AreEqual("1", custom.GetFrame(0));
+        Assert.AreEqual("3", custom.GetFrame(2));
+        Assert.AreEqual("2", custom.GetFrame(3)); // Reversing
+        Assert.AreEqual("1", custom.GetFrame(4)); // Back to start
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerStyle_EmptyFrames_ThrowsArgumentException()
     {
-        Assert.Throws<ArgumentException>(() => new SpinnerStyle());
+        Assert.ThrowsExactly<ArgumentException>(() => new SpinnerStyle());
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerNode_Measure_ReturnsSingleCharWidth()
     {
         var node = new SpinnerNode { Style = SpinnerStyle.Dots };
@@ -109,10 +110,10 @@ public class SpinnerNodeTests
         var size = node.Measure(new Constraints(0, 100, 0, 100));
 
         // Note: Width depends on resolved style, which defaults to Dots
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerWidget_Reconcile_CreatesSpinnerNode()
     {
         var widget = new SpinnerWidget { FrameIndex = 5 };
@@ -120,13 +121,13 @@ public class SpinnerNodeTests
 
         var node = widget.ReconcileAsync(null, context).GetAwaiter().GetResult();
 
-        Assert.IsType<SpinnerNode>(node);
+        TestSeq.IsType<SpinnerNode>(node);
         var spinnerNode = (SpinnerNode)node;
-        Assert.Equal(5, spinnerNode.ExplicitFrameIndex);
-        Assert.Null(spinnerNode.Style); // Uses theme default
+        Assert.AreEqual(5, spinnerNode.ExplicitFrameIndex);
+        Assert.IsNull(spinnerNode.Style); // Uses theme default
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerWidget_Reconcile_UpdatesExistingNode()
     {
         var existingNode = new SpinnerNode { ExplicitFrameIndex = 0 };
@@ -135,12 +136,12 @@ public class SpinnerNodeTests
 
         var node = widget.ReconcileAsync(existingNode, context).GetAwaiter().GetResult();
 
-        Assert.Same(existingNode, node);
-        Assert.Equal(3, existingNode.ExplicitFrameIndex);
-        Assert.Same(SpinnerStyle.Arrow, existingNode.Style);
+        Assert.AreSame(existingNode, node);
+        Assert.AreEqual(3, existingNode.ExplicitFrameIndex);
+        Assert.AreSame(SpinnerStyle.Arrow, existingNode.Style);
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerWidget_Reconcile_MarksDirtyOnFrameChange()
     {
         var widget1 = new SpinnerWidget { FrameIndex = 0 };
@@ -152,10 +153,10 @@ public class SpinnerNodeTests
 
         widget2.ReconcileAsync(node, context).GetAwaiter().GetResult();
 
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerWidget_Reconcile_MarksDirtyOnStyleChange()
     {
         var widget1 = new SpinnerWidget { Style = SpinnerStyle.Dots };
@@ -167,10 +168,10 @@ public class SpinnerNodeTests
 
         widget2.ReconcileAsync(node, context).GetAwaiter().GetResult();
 
-        Assert.True(node.IsDirty);
+        Assert.IsTrue(node.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerWidget_TimeBasedMode_HasNullFrameIndex()
     {
         var widget = new SpinnerWidget(); // No FrameIndex set
@@ -178,82 +179,82 @@ public class SpinnerNodeTests
 
         var node = widget.ReconcileAsync(null, context).GetAwaiter().GetResult() as SpinnerNode;
 
-        Assert.Null(node!.ExplicitFrameIndex); // Time-based mode
+        Assert.IsNull(node!.ExplicitFrameIndex); // Time-based mode
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerNode_GetTimeUntilNextFrame_ReturnsPositiveValue()
     {
         var node = new SpinnerNode { Style = SpinnerStyle.Dots };
 
         var timeUntilNext = node.GetTimeUntilNextFrame();
 
-        Assert.True(timeUntilNext.TotalMilliseconds > 0);
-        Assert.True(timeUntilNext.TotalMilliseconds <= SpinnerStyle.Dots.Interval.TotalMilliseconds);
+        Assert.IsTrue(timeUntilNext.TotalMilliseconds > 0);
+        Assert.IsTrue(timeUntilNext.TotalMilliseconds <= SpinnerStyle.Dots.Interval.TotalMilliseconds);
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerNode_GetTimeUntilNextFrame_ManualMode_ReturnsMaxValue()
     {
         var node = new SpinnerNode { Style = SpinnerStyle.Dots, ExplicitFrameIndex = 0 };
 
         var timeUntilNext = node.GetTimeUntilNextFrame();
 
-        Assert.Equal(TimeSpan.MaxValue, timeUntilNext);
+        Assert.AreEqual(TimeSpan.MaxValue, timeUntilNext);
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerStyle_BuiltInStyles_HaveCorrectIntervals()
     {
-        Assert.Equal(TimeSpan.FromMilliseconds(100), SpinnerStyle.Line.Interval);
-        Assert.Equal(TimeSpan.FromMilliseconds(80), SpinnerStyle.Dots.Interval);
-        Assert.Equal(TimeSpan.FromMilliseconds(120), SpinnerStyle.Circle.Interval);
+        Assert.AreEqual(TimeSpan.FromMilliseconds(100), SpinnerStyle.Line.Interval);
+        Assert.AreEqual(TimeSpan.FromMilliseconds(80), SpinnerStyle.Dots.Interval);
+        Assert.AreEqual(TimeSpan.FromMilliseconds(120), SpinnerStyle.Circle.Interval);
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerStyle_BuiltInStyles_HaveCorrectAutoReverse()
     {
-        Assert.False(SpinnerStyle.Dots.AutoReverse);
-        Assert.False(SpinnerStyle.Line.AutoReverse);
-        Assert.False(SpinnerStyle.Arrow.AutoReverse);
-        Assert.True(SpinnerStyle.Bounce.AutoReverse);
-        Assert.True(SpinnerStyle.GrowHorizontal.AutoReverse);
-        Assert.True(SpinnerStyle.GrowVertical.AutoReverse);
+        Assert.IsFalse(SpinnerStyle.Dots.AutoReverse);
+        Assert.IsFalse(SpinnerStyle.Line.AutoReverse);
+        Assert.IsFalse(SpinnerStyle.Arrow.AutoReverse);
+        Assert.IsTrue(SpinnerStyle.Bounce.AutoReverse);
+        Assert.IsTrue(SpinnerStyle.GrowHorizontal.AutoReverse);
+        Assert.IsTrue(SpinnerStyle.GrowVertical.AutoReverse);
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerStyle_MultiCharStyles_HaveCorrectFrames()
     {
-        Assert.Equal(8, SpinnerStyle.BouncingBall.Frames.Count);
-        Assert.Equal(6, SpinnerStyle.LoadingBar.Frames.Count);
-        Assert.Equal(6, SpinnerStyle.Segments.Frames.Count);
+        Assert.AreEqual(8, SpinnerStyle.BouncingBall.Frames.Count);
+        Assert.AreEqual(6, SpinnerStyle.LoadingBar.Frames.Count);
+        Assert.AreEqual(6, SpinnerStyle.Segments.Frames.Count);
 
-        Assert.Equal("[●    ]", SpinnerStyle.BouncingBall.GetFrame(0));
-        Assert.Equal("[     ]", SpinnerStyle.LoadingBar.GetFrame(0));
-        Assert.Equal("▱▱▱▱▱", SpinnerStyle.Segments.GetFrame(0));
+        Assert.AreEqual("[●    ]", SpinnerStyle.BouncingBall.GetFrame(0));
+        Assert.AreEqual("[     ]", SpinnerStyle.LoadingBar.GetFrame(0));
+        Assert.AreEqual("▱▱▱▱▱", SpinnerStyle.Segments.GetFrame(0));
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerTheme_DefaultStyle_IsDots()
     {
         var theme = new Hex1bTheme("Test").Lock();
         var style = theme.Get(SpinnerTheme.Style);
 
-        Assert.Same(SpinnerStyle.Dots, style);
+        Assert.AreSame(SpinnerStyle.Dots, style);
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerTheme_DefaultColors_AreDefault()
     {
         var theme = new Hex1bTheme("Test").Lock();
         var fg = theme.Get(SpinnerTheme.ForegroundColor);
         var bg = theme.Get(SpinnerTheme.BackgroundColor);
 
-        Assert.True(fg.IsDefault);
-        Assert.True(bg.IsDefault);
+        Assert.IsTrue(fg.IsDefault);
+        Assert.IsTrue(bg.IsDefault);
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerTheme_CanOverrideStyle()
     {
         var theme = new Hex1bTheme("Test")
@@ -262,47 +263,47 @@ public class SpinnerNodeTests
         
         var style = theme.Get(SpinnerTheme.Style);
 
-        Assert.Same(SpinnerStyle.Arrow, style);
+        Assert.AreSame(SpinnerStyle.Arrow, style);
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerWidget_TimeBasedMode_SetsDefaultRedrawDelay()
     {
         // Arrange & Act - time-based mode (no explicit frame)
         var widget = new SpinnerWidget();
 
         // Assert - should auto-schedule redraws based on default style interval
-        Assert.Equal(SpinnerStyle.Dots.Interval, widget.GetEffectiveRedrawDelay());
+        Assert.AreEqual(SpinnerStyle.Dots.Interval, widget.GetEffectiveRedrawDelay());
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerWidget_WithExplicitStyle_SetsRedrawDelayFromStyle()
     {
         // Arrange & Act
         var widget = new SpinnerWidget { Style = SpinnerStyle.Circle }; // 120ms interval
 
         // Assert
-        Assert.Equal(SpinnerStyle.Circle.Interval, widget.GetEffectiveRedrawDelay());
+        Assert.AreEqual(SpinnerStyle.Circle.Interval, widget.GetEffectiveRedrawDelay());
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerWidget_ManualFrameMode_NoRedrawDelay()
     {
         // Arrange & Act - manual frame control
         var widget = new SpinnerWidget { FrameIndex = 5 };
 
         // Assert - no auto-redraw for manual mode
-        Assert.Null(widget.GetEffectiveRedrawDelay());
+        Assert.IsNull(widget.GetEffectiveRedrawDelay());
     }
 
-    [Fact]
+    [TestMethod]
     public void SpinnerWidget_ExplicitRedrawDelay_OverridesDefault()
     {
         // Arrange & Act
         var widget = new SpinnerWidget { RedrawDelay = TimeSpan.FromMilliseconds(200) };
 
         // Assert - explicit value should be used
-        Assert.Equal(TimeSpan.FromMilliseconds(200), widget.RedrawDelay);
+        Assert.AreEqual(TimeSpan.FromMilliseconds(200), widget.RedrawDelay);
     }
 }
 

--- a/tests/Hex1b.Tests/SplitButtonIntegrationTests.cs
+++ b/tests/Hex1b.Tests/SplitButtonIntegrationTests.cs
@@ -29,6 +29,7 @@ namespace Hex1b.Tests;
 ///      primary action.
 ///   7. Escape dismisses the popup without invoking any secondary action.
 /// </summary>
+[TestClass]
 public class SplitButtonIntegrationTests
 {
     /// <summary>
@@ -47,7 +48,7 @@ public class SplitButtonIntegrationTests
             .SecondaryAction("Option B", e => onOptionB?.Invoke(e));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SplitButton_InitialRender_ShowsPrimaryLabelAndDropdownArrow()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -72,16 +73,16 @@ public class SplitButtonIntegrationTests
         // region 4 [divider, space, arrow, trailing pad]). The leading and
         // trailing chip pads are part of the chip body, so cell 0 and cell
         // 11 are spaces.
-        Assert.Equal(" ", snapshot.GetCell(0, 0).Character);
-        Assert.Equal(" ", snapshot.GetCell(11, 0).Character);
+        Assert.AreEqual(" ", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual(" ", snapshot.GetCell(11, 0).Character);
         // The divider sits at cell 8 (just past the primary region).
-        Assert.Equal("│", snapshot.GetCell(8, 0).Character);
+        Assert.AreEqual("│", snapshot.GetCell(8, 0).Character);
         // The dropdown arrow sits at cell 10 (between the divider's trailing
         // pad and the chip's trailing pad).
-        Assert.Equal("▼", snapshot.GetCell(10, 0).Character);
+        Assert.AreEqual("▼", snapshot.GetCell(10, 0).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SplitButton_Focused_PaintsFocusedChipBackground()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -111,15 +112,15 @@ public class SplitButtonIntegrationTests
         // shade so the dropdown target reads as distinct.
         for (var x = 0; x <= 7; x++)
         {
-            Assert.Equal(expectedPrimaryBg, snapshot.GetCell(x, 0).Background);
+            Assert.AreEqual(expectedPrimaryBg, snapshot.GetCell(x, 0).Background);
         }
         for (var x = 8; x <= 11; x++)
         {
-            Assert.Equal(expectedArrowBg, snapshot.GetCell(x, 0).Background);
+            Assert.AreEqual(expectedArrowBg, snapshot.GetCell(x, 0).Background);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SplitButton_Unfocused_PaintsRestingChipBackground()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -151,15 +152,15 @@ public class SplitButtonIntegrationTests
         // arrow background (a half-shade darker than the primary chip).
         for (var x = 0; x <= 7; x++)
         {
-            Assert.Equal(expectedPrimaryBg, snapshot.GetCell(x, 1).Background);
+            Assert.AreEqual(expectedPrimaryBg, snapshot.GetCell(x, 1).Background);
         }
         for (var x = 8; x <= 11; x++)
         {
-            Assert.Equal(expectedArrowBg, snapshot.GetCell(x, 1).Background);
+            Assert.AreEqual(expectedArrowBg, snapshot.GetCell(x, 1).Background);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SplitButton_DownArrow_OpensDropdownWithBothOptionsVisible()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -180,12 +181,11 @@ public class SplitButtonIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Option A"));
-        Assert.True(snapshot.ContainsText("Option B"));
+        Assert.IsTrue(snapshot.ContainsText("Option A"));
+        Assert.IsTrue(snapshot.ContainsText("Option B"));
         // ListWidget marks the active item with a "> " selection indicator —
         // Option A is pre-selected when the dropdown opens.
-        Assert.True(snapshot.ContainsText("> Option A"),
-            $"Expected Option A to be the initially selected item.\nScreen:\n{snapshot.GetText()}");
+        Assert.IsTrue(snapshot.ContainsText("> Option A"), $"Expected Option A to be the initially selected item.\nScreen:\n{snapshot.GetText()}");
     }
 
     /// <summary>
@@ -194,7 +194,7 @@ public class SplitButtonIntegrationTests
     /// B. The popup must respond to DownArrow so the user can navigate to
     /// secondary actions other than the first.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task SplitButton_DropdownOpen_DownArrow_MovesSelectionToOptionB()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -217,14 +217,13 @@ public class SplitButtonIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("> Option B"));
+        Assert.IsTrue(snapshot.ContainsText("> Option B"));
         // Option A should no longer be the active selection — the indicator
         // moved with the down-arrow press.
-        Assert.False(snapshot.ContainsText("> Option A"),
-            $"Expected the selection indicator to advance off Option A.\nScreen:\n{snapshot.GetText()}");
+        Assert.IsFalse(snapshot.ContainsText("> Option A"), $"Expected the selection indicator to advance off Option A.\nScreen:\n{snapshot.GetText()}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SplitButton_DropdownOpen_EnterOnFirstItem_FiresOptionAHandler()
     {
         var optionACount = 0;
@@ -254,16 +253,16 @@ public class SplitButtonIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal(1, optionACount);
-        Assert.Equal(0, optionBCount);
-        Assert.Equal(0, primaryCount);
+        Assert.AreEqual(1, optionACount);
+        Assert.AreEqual(0, optionBCount);
+        Assert.AreEqual(0, primaryCount);
     }
 
     /// <summary>
     /// Once the bug is fixed, navigating Down + Enter inside the popup must
     /// fire the second secondary action — not the first.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task SplitButton_DropdownOpen_DownThenEnter_FiresOptionBHandler()
     {
         var optionACount = 0;
@@ -297,14 +296,14 @@ public class SplitButtonIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal(1, optionBCount);
-        Assert.Equal(0, optionACount);
-        Assert.Equal(0, primaryCount);
-        Assert.NotNull(optionBArgs);
-        Assert.NotNull(optionBArgs!.Widget);
+        Assert.AreEqual(1, optionBCount);
+        Assert.AreEqual(0, optionACount);
+        Assert.AreEqual(0, primaryCount);
+        Assert.IsNotNull(optionBArgs);
+        Assert.IsNotNull(optionBArgs!.Widget);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SplitButton_PrimaryAction_FiresOnEnter_WithoutOpeningDropdown()
     {
         var optionACount = 0;
@@ -331,12 +330,12 @@ public class SplitButtonIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal(1, primaryCount);
-        Assert.Equal(0, optionACount);
-        Assert.Equal(0, optionBCount);
+        Assert.AreEqual(1, primaryCount);
+        Assert.AreEqual(0, optionACount);
+        Assert.AreEqual(0, optionBCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SplitButton_DropdownOpen_Escape_DismissesWithoutFiringHandlers()
     {
         var optionACount = 0;
@@ -369,14 +368,14 @@ public class SplitButtonIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal(0, optionACount);
-        Assert.Equal(0, optionBCount);
-        Assert.Equal(0, primaryCount);
-        Assert.False(snapshot.ContainsText("Option A"));
-        Assert.False(snapshot.ContainsText("Option B"));
+        Assert.AreEqual(0, optionACount);
+        Assert.AreEqual(0, optionBCount);
+        Assert.AreEqual(0, primaryCount);
+        Assert.IsFalse(snapshot.ContainsText("Option A"));
+        Assert.IsFalse(snapshot.ContainsText("Option B"));
         // The primary chip should still be visible after the dismiss.
-        Assert.True(snapshot.ContainsText("Action"));
-        Assert.True(snapshot.ContainsText("▼"));
+        Assert.IsTrue(snapshot.ContainsText("Action"));
+        Assert.IsTrue(snapshot.ContainsText("▼"));
     }
 
     /// <summary>
@@ -398,7 +397,7 @@ public class SplitButtonIntegrationTests
     ///   • Focus returns to the SplitButton — pressing Enter once more fires
     ///     the primary action without re-opening the dropdown.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task SplitButton_FullScenario_OpensDropdown_NavigatesDown_FiresOptionB_ThenPrimary()
     {
         var optionACount = 0;
@@ -428,23 +427,23 @@ public class SplitButtonIntegrationTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(initialSnapshot.ContainsText("Action"));
-        Assert.True(initialSnapshot.ContainsText("▼"));
-        Assert.Equal(" ", initialSnapshot.GetCell(0, 0).Character);
-        Assert.Equal(" ", initialSnapshot.GetCell(11, 0).Character);
-        Assert.Equal("│", initialSnapshot.GetCell(8, 0).Character);
-        Assert.Equal("▼", initialSnapshot.GetCell(10, 0).Character);
+        Assert.IsTrue(initialSnapshot.ContainsText("Action"));
+        Assert.IsTrue(initialSnapshot.ContainsText("▼"));
+        Assert.AreEqual(" ", initialSnapshot.GetCell(0, 0).Character);
+        Assert.AreEqual(" ", initialSnapshot.GetCell(11, 0).Character);
+        Assert.AreEqual("│", initialSnapshot.GetCell(8, 0).Character);
+        Assert.AreEqual("▼", initialSnapshot.GetCell(10, 0).Character);
 
         var theme = new Hex1bTheme("Test");
         var expectedPrimaryBg = theme.Get(ButtonTheme.FocusedBackgroundColor);
         var expectedArrowBg = theme.Get(SplitButtonTheme.FocusedArrowBackgroundColor);
         for (var x = 0; x <= 7; x++)
         {
-            Assert.Equal(expectedPrimaryBg, initialSnapshot.GetCell(x, 0).Background);
+            Assert.AreEqual(expectedPrimaryBg, initialSnapshot.GetCell(x, 0).Background);
         }
         for (var x = 8; x <= 11; x++)
         {
-            Assert.Equal(expectedArrowBg, initialSnapshot.GetCell(x, 0).Background);
+            Assert.AreEqual(expectedArrowBg, initialSnapshot.GetCell(x, 0).Background);
         }
 
         // Phase 2 — open dropdown, navigate down, activate Option B,
@@ -467,17 +466,17 @@ public class SplitButtonIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal(1, optionBCount);
-        Assert.Equal(0, optionACount);
-        Assert.Equal(1, primaryCount);
-        Assert.NotNull(optionBArgs);
-        Assert.NotNull(optionBArgs!.Widget);
+        Assert.AreEqual(1, optionBCount);
+        Assert.AreEqual(0, optionACount);
+        Assert.AreEqual(1, primaryCount);
+        Assert.IsNotNull(optionBArgs);
+        Assert.IsNotNull(optionBArgs!.Widget);
 
         // The chip is back on screen with no popup overlay.
-        Assert.True(finalSnapshot.ContainsText("Action"));
-        Assert.True(finalSnapshot.ContainsText("▼"));
-        Assert.False(finalSnapshot.ContainsText("Option A"));
-        Assert.False(finalSnapshot.ContainsText("Option B"));
+        Assert.IsTrue(finalSnapshot.ContainsText("Action"));
+        Assert.IsTrue(finalSnapshot.ContainsText("▼"));
+        Assert.IsFalse(finalSnapshot.ContainsText("Option A"));
+        Assert.IsFalse(finalSnapshot.ContainsText("Option B"));
     }
 
     /// <summary>
@@ -485,7 +484,7 @@ public class SplitButtonIntegrationTests
     /// chip — same layout as ButtonNode, no divider, no arrow, and no
     /// secondary-affordance tint anywhere on the chip.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task SplitButton_NoSecondaryActions_RendersUniformChipWithoutDivider()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -506,11 +505,11 @@ public class SplitButtonIntegrationTests
         await runTask;
 
         // Chip body is " Action " — 8 cells, no divider, no arrow.
-        Assert.True(snapshot.ContainsText("Action"));
-        Assert.False(snapshot.ContainsText("▼"));
-        Assert.False(snapshot.ContainsText("│"));
-        Assert.Equal(" ", snapshot.GetCell(0, 0).Character);
-        Assert.Equal(" ", snapshot.GetCell(7, 0).Character);
+        Assert.IsTrue(snapshot.ContainsText("Action"));
+        Assert.IsFalse(snapshot.ContainsText("▼"));
+        Assert.IsFalse(snapshot.ContainsText("│"));
+        Assert.AreEqual(" ", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual(" ", snapshot.GetCell(7, 0).Character);
         // The whole chip should be on the focused primary background — no
         // arrow tint anywhere.
         var theme = new Hex1bTheme("Test");
@@ -518,12 +517,12 @@ public class SplitButtonIntegrationTests
         var arrowBg = theme.Get(SplitButtonTheme.FocusedArrowBackgroundColor);
         for (var x = 0; x <= 7; x++)
         {
-            Assert.Equal(primaryBg, snapshot.GetCell(x, 0).Background);
+            Assert.AreEqual(primaryBg, snapshot.GetCell(x, 0).Background);
         }
-        Assert.NotEqual(arrowBg, snapshot.GetCell(7, 0).Background);
+        Assert.AreNotEqual(arrowBg, snapshot.GetCell(7, 0).Background);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SplitButton_StackedSplitButtons_OpenedDropdown_DoesNotBleedSiblingChipBackground()
     {
         // Companion to PickerIntegrationTests.Picker_StackedPickers_OpenedDropdown_DoesNotBleedSiblingChipBackground.
@@ -591,8 +590,7 @@ public class SplitButtonIntegrationTests
                 break;
             }
         }
-        Assert.True(popupOptionA.HasValue,
-            $"Expected to find Option A inside the popup body.\nScreen:\n{snapshot.GetText()}");
+        Assert.IsTrue(popupOptionA.HasValue, $"Expected to find Option A inside the popup body.\nScreen:\n{snapshot.GetText()}");
 
         var popupLeft = popupOptionA.Value.Column - 3;  // border + indicator
         var popupTop = popupOptionA.Value.Line - 1;     // border above first item
@@ -622,9 +620,7 @@ public class SplitButtonIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(
-            leakedCells.Count == 0,
-            $"Sibling SplitButton chip background ({siblingChipBg}) bled through the open dropdown at {leakedCells.Count} cell(s): " +
+        Assert.IsTrue(leakedCells.Count == 0, $"Sibling SplitButton chip background ({siblingChipBg}) bled through the open dropdown at {leakedCells.Count} cell(s): " +
             string.Join(", ", leakedCells.Take(10).Select(c => $"({c.X},{c.Y})")) +
             $".\nScreen:\n{snapshot.GetText()}");
     }

--- a/tests/Hex1b.Tests/SplitButtonNodeTests.cs
+++ b/tests/Hex1b.Tests/SplitButtonNodeTests.cs
@@ -9,9 +9,10 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for SplitButtonNode rendering and behavior.
 /// </summary>
+[TestClass]
 public class SplitButtonNodeTests
 {
-    [Fact]
+    [TestMethod]
     public async Task SplitButton_RendersWithLabel()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -41,7 +42,7 @@ public class SplitButtonNodeTests
         Assert.Contains("Action", line);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SplitButton_SecondaryActions_ShowsDropdownArrow()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -74,7 +75,7 @@ public class SplitButtonNodeTests
         Assert.Contains("▼", line);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SplitButton_WithoutSecondaryActions_NoDropdownArrow()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -105,7 +106,7 @@ public class SplitButtonNodeTests
         Assert.DoesNotContain("▼", line);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_ReturnsCorrectSize()
     {
         var node = new SplitButtonNode { PrimaryLabel = "Test" };
@@ -113,11 +114,11 @@ public class SplitButtonNodeTests
         var size = node.Measure(Constraints.Unbounded);
         
         // " Test " = 6 chars (2 for chip padding + 4 for label)
-        Assert.Equal(6, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(6, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_CJKCharacters_CorrectSize()
     {
         var node = new SplitButtonNode { PrimaryLabel = "汉字かな한글" };
@@ -125,11 +126,11 @@ public class SplitButtonNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // " 汉字かな한글 " = 2 (chip padding) + 6 (CJK chars) * 2 (width) = 14
-        Assert.Equal(14, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(14, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_SecondaryActions_IncludesArrow()
     {
         var node = new SplitButtonNode 
@@ -142,14 +143,14 @@ public class SplitButtonNodeTests
         
         // " Test │ ▼ " = 10 cells (label 4 + chip pads 2 + arrow region 4
         // [divider, space, arrow, trailing pad]).
-        Assert.Equal(10, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(10, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsFocusable_ReturnsTrue()
     {
         var node = new SplitButtonNode();
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
 }

--- a/tests/Hex1b.Tests/SplitterNodeTests.cs
+++ b/tests/Hex1b.Tests/SplitterNodeTests.cs
@@ -9,6 +9,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Comprehensive tests for SplitterNode layout, rendering, resizing, and focus handling.
 /// </summary>
+[TestClass]
 public class SplitterNodeTests
 {
     private static Hex1bRenderContext CreateContext(IHex1bAppTerminalWorkloadAdapter workload, Hex1bTheme? theme = null)
@@ -18,7 +19,7 @@ public class SplitterNodeTests
 
     #region Measurement Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_ReturnsCorrectSize()
     {
         var left = new TextBlockNode { Text = "Left Pane" };
@@ -28,10 +29,10 @@ public class SplitterNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // Width = LeftWidth (10) + divider (3) + right content width (10)
-        Assert.Equal(23, size.Width);
+        Assert.AreEqual(23, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_WithNoChildren_ReturnsMinimalSize()
     {
         var node = new SplitterNode { Left = null, Right = null, LeftWidth = 20 };
@@ -39,10 +40,10 @@ public class SplitterNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // Just LeftWidth + divider width
-        Assert.Equal(23, size.Width); // 20 + 3
+        Assert.AreEqual(23, size.Width); // 20 + 3
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_RespectsConstraints()
     {
         var left = new TextBlockNode { Text = "Very long left content" };
@@ -51,11 +52,11 @@ public class SplitterNodeTests
 
         var size = node.Measure(new Constraints(0, 30, 0, 10));
 
-        Assert.True(size.Width <= 30);
-        Assert.True(size.Height <= 10);
+        Assert.IsTrue(size.Width <= 30);
+        Assert.IsTrue(size.Height <= 10);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_HeightIsMaxOfBothPanes()
     {
         var left = new VStackNode
@@ -71,14 +72,14 @@ public class SplitterNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(3, size.Height); // Height of left pane
+        Assert.AreEqual(3, size.Height); // Height of left pane
     }
 
     #endregion
 
     #region Arrange Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_LeftPaneGetsLeftWidth()
     {
         var left = new TextBlockNode { Text = "Left" };
@@ -88,11 +89,11 @@ public class SplitterNodeTests
         node.Measure(Constraints.Unbounded);
         node.Arrange(new Rect(0, 0, 50, 10));
 
-        Assert.Equal(0, left.Bounds.X);
-        Assert.Equal(15, left.Bounds.Width);
+        Assert.AreEqual(0, left.Bounds.X);
+        Assert.AreEqual(15, left.Bounds.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_RightPaneGetsRemainingWidth()
     {
         var left = new TextBlockNode { Text = "Left" };
@@ -103,12 +104,12 @@ public class SplitterNodeTests
         node.Arrange(new Rect(0, 0, 50, 10));
 
         // Right pane starts after left + divider (15 + 3 = 18)
-        Assert.Equal(18, right.Bounds.X);
+        Assert.AreEqual(18, right.Bounds.X);
         // Right pane gets remaining width (50 - 15 - 3 = 32)
-        Assert.Equal(32, right.Bounds.Width);
+        Assert.AreEqual(32, right.Bounds.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_WithOffset_PositionsCorrectly()
     {
         var left = new TextBlockNode { Text = "Left" };
@@ -118,13 +119,13 @@ public class SplitterNodeTests
         node.Measure(Constraints.Unbounded);
         node.Arrange(new Rect(5, 3, 40, 8));
 
-        Assert.Equal(5, left.Bounds.X);
-        Assert.Equal(3, left.Bounds.Y);
-        Assert.Equal(18, right.Bounds.X); // 5 + 10 + 3
-        Assert.Equal(3, right.Bounds.Y);
+        Assert.AreEqual(5, left.Bounds.X);
+        Assert.AreEqual(3, left.Bounds.Y);
+        Assert.AreEqual(18, right.Bounds.X); // 5 + 10 + 3
+        Assert.AreEqual(3, right.Bounds.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_BothPanesGetFullHeight()
     {
         var left = new TextBlockNode { Text = "Left" };
@@ -134,15 +135,15 @@ public class SplitterNodeTests
         node.Measure(Constraints.Unbounded);
         node.Arrange(new Rect(0, 0, 40, 8));
 
-        Assert.Equal(8, left.Bounds.Height);
-        Assert.Equal(8, right.Bounds.Height);
+        Assert.AreEqual(8, left.Bounds.Height);
+        Assert.AreEqual(8, right.Bounds.Height);
     }
 
     #endregion
 
     #region Rendering - Divider Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Render_ShowsDivider()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -167,10 +168,10 @@ public class SplitterNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(snapshot.ContainsText("│"));
+        Assert.IsTrue(snapshot.ContainsText("│"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_ShowsLeftContent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -194,10 +195,10 @@ public class SplitterNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(snapshot.ContainsText("Left Pane Content"));
+        Assert.IsTrue(snapshot.ContainsText("Left Pane Content"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_ShowsRightContent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -221,10 +222,10 @@ public class SplitterNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(snapshot.ContainsText("Right Pane Content"));
+        Assert.IsTrue(snapshot.ContainsText("Right Pane Content"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_DividerSpansFullHeight()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -255,14 +256,14 @@ public class SplitterNodeTests
         var dividerCount = screenText.Split("│").Length - 1;
         var leftArrowCount = screenText.Split("←").Length - 1;
         var rightArrowCount = screenText.Split("→").Length - 1;
-        Assert.Equal(5, dividerCount + leftArrowCount + rightArrowCount);
+        Assert.AreEqual(5, dividerCount + leftArrowCount + rightArrowCount);
     }
 
     #endregion
 
     #region Rendering - Theming Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithCustomDividerColor_AppliesColor()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -289,10 +290,10 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
         // Cyan is RGB(0, 255, 255)
-        Assert.True(snapshot.HasForegroundColor(Hex1bColor.FromRgb(0, 255, 255)));
+        Assert.IsTrue(snapshot.HasForegroundColor(Hex1bColor.FromRgb(0, 255, 255)));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithCustomDividerCharacter_UsesCustomCharacter()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -318,10 +319,10 @@ public class SplitterNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(snapshot.ContainsText("║"));
+        Assert.IsTrue(snapshot.ContainsText("║"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WhenFocused_ShowsThumbIndicators()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -347,22 +348,22 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
         // When focused, should show braille thumb indicators on divider
-        Assert.True(snapshot.ContainsText("⣿"));
+        Assert.IsTrue(snapshot.ContainsText("⣿"));
     }
 
     #endregion
 
     #region Focus Tests
 
-    [Fact]
+    [TestMethod]
     public async Task IsFocusable_ReturnsTrue()
     {
         var node = new SplitterNode();
 
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_IncludesSelf()
     {
         var node = new SplitterNode
@@ -376,7 +377,7 @@ public class SplitterNodeTests
         Assert.Contains(node, focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_IncludesLeftPaneFocusables()
     {
         var button = new ButtonNode { Label = "Click" };
@@ -391,7 +392,7 @@ public class SplitterNodeTests
         Assert.Contains(button, focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_IncludesRightPaneFocusables()
     {
         var textBox = new TextBoxNode { State = new TextBoxState() };
@@ -406,7 +407,7 @@ public class SplitterNodeTests
         Assert.Contains(textBox, focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_OrdersLeftThenSplitterThenRight()
     {
         var leftButton = new ButtonNode { Label = "Left" };
@@ -419,13 +420,13 @@ public class SplitterNodeTests
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Equal(3, focusables.Count);
-        Assert.Same(leftButton, focusables[0]);
-        Assert.Same(node, focusables[1]); // Splitter itself
-        Assert.Same(rightButton, focusables[2]);
+        Assert.AreEqual(3, focusables.Count);
+        Assert.AreSame(leftButton, focusables[0]);
+        Assert.AreSame(node, focusables[1]); // Splitter itself
+        Assert.AreSame(rightButton, focusables[2]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SetInitialFocus_FocusesFirstFocusable()
     {
         var leftButton = new ButtonNode { Label = "Left" };
@@ -438,15 +439,15 @@ public class SplitterNodeTests
 
         node.SetInitialFocus();
 
-        Assert.True(leftButton.IsFocused);
-        Assert.False(rightButton.IsFocused);
+        Assert.IsTrue(leftButton.IsFocused);
+        Assert.IsFalse(rightButton.IsFocused);
     }
 
     #endregion
 
     #region Input Handling - Resize Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_LeftArrow_WhenFocused_DecreasesLeftWidth()
     {
         var node = new SplitterNode
@@ -462,11 +463,11 @@ public class SplitterNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(18, node.LeftWidth);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(18, node.LeftWidth);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_RightArrow_WhenFocused_IncreasesLeftWidth()
     {
         var node = new SplitterNode
@@ -482,11 +483,11 @@ public class SplitterNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(22, node.LeftWidth);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(22, node.LeftWidth);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_LeftArrow_RespectsMinLeftWidth()
     {
         var node = new SplitterNode
@@ -503,10 +504,10 @@ public class SplitterNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(5, node.LeftWidth); // Clamped to MinLeftWidth
+        Assert.AreEqual(5, node.LeftWidth); // Clamped to MinLeftWidth
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_RightArrow_RespectsMaxWidth()
     {
         var node = new SplitterNode
@@ -523,10 +524,10 @@ public class SplitterNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.True(node.LeftWidth <= 42);
+        Assert.IsTrue(node.LeftWidth <= 42);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_NotFocused_DoesNotResize()
     {
         var node = new SplitterNode
@@ -542,14 +543,14 @@ public class SplitterNodeTests
         // Arrow keys won't resize when not focused
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(20, node.LeftWidth);
+        Assert.AreEqual(20, node.LeftWidth);
     }
 
     #endregion
 
     #region Input Handling - Tab Navigation Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Tab_MovesFocusToNextFocusable()
     {
         var leftButton = new ButtonNode { Label = "Left", IsFocused = true };
@@ -568,11 +569,11 @@ public class SplitterNodeTests
         await InputRouter.RouteInputAsync(node, new Hex1bKeyEvent(Hex1bKey.Tab, '\t', Hex1bModifiers.None), focusRing, routerState, null, TestContext.Current.CancellationToken);
 
         // Focus moves from left button to splitter itself
-        Assert.False(leftButton.IsFocused);
-        Assert.True(node.IsFocused);
+        Assert.IsFalse(leftButton.IsFocused);
+        Assert.IsTrue(node.IsFocused);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_ShiftTab_MovesFocusToPreviousFocusable()
     {
         var leftButton = new ButtonNode { Label = "Left" };
@@ -591,11 +592,11 @@ public class SplitterNodeTests
         await InputRouter.RouteInputAsync(node, new Hex1bKeyEvent(Hex1bKey.Tab, '\t', Hex1bModifiers.Shift), focusRing, routerState2, null, TestContext.Current.CancellationToken);
 
         // Focus moves from right button to splitter
-        Assert.False(rightButton.IsFocused);
-        Assert.True(node.IsFocused);
+        Assert.IsFalse(rightButton.IsFocused);
+        Assert.IsTrue(node.IsFocused);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Tab_WrapsAround()
     {
         var leftButton = new ButtonNode { Label = "Left" };
@@ -614,11 +615,11 @@ public class SplitterNodeTests
         await InputRouter.RouteInputAsync(node, new Hex1bKeyEvent(Hex1bKey.Tab, '\t', Hex1bModifiers.None), focusRing, routerState, null, TestContext.Current.CancellationToken);
 
         // Focus wraps from right button to left button
-        Assert.True(leftButton.IsFocused);
-        Assert.False(rightButton.IsFocused);
+        Assert.IsTrue(leftButton.IsFocused);
+        Assert.IsFalse(rightButton.IsFocused);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Escape_JumpsToFirstFocusable()
     {
         var leftButton = new ButtonNode { Label = "Left" };
@@ -632,16 +633,16 @@ public class SplitterNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Escape, '\x1b', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(leftButton.IsFocused);
-        Assert.False(rightButton.IsFocused);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(leftButton.IsFocused);
+        Assert.IsFalse(rightButton.IsFocused);
     }
 
     #endregion
 
     #region Input Handling - Child Input Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Enter_PassesToFocusedChild()
     {
         var clicked = false;
@@ -666,11 +667,11 @@ public class SplitterNodeTests
         // Use InputRouter to route input to the focused child
         var result = await InputRouter.RouteInputAsync(node, new Hex1bKeyEvent(Hex1bKey.Enter, '\r', Hex1bModifiers.None), focusRing, routerState, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(clicked);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Typing_PassesToFocusedTextBox()
     {
         var textBoxState = new TextBoxState();
@@ -696,14 +697,14 @@ public class SplitterNodeTests
         await InputRouter.RouteInputAsync(node, new Hex1bKeyEvent(Hex1bKey.B, 'b', Hex1bModifiers.None), focusRing, routerState, null, TestContext.Current.CancellationToken);
         await InputRouter.RouteInputAsync(node, new Hex1bKeyEvent(Hex1bKey.C, 'c', Hex1bModifiers.None), focusRing, routerState, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("abc", textBoxState.Text);
+        Assert.AreEqual("abc", textBoxState.Text);
     }
 
     #endregion
 
     #region Integration Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Splitter_RendersCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -732,12 +733,12 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Left Content"));
-        Assert.True(snapshot.ContainsText("Right Content"));
-        Assert.True(snapshot.ContainsText("│"));
+        Assert.IsTrue(snapshot.ContainsText("Left Content"));
+        Assert.IsTrue(snapshot.ContainsText("Right Content"));
+        Assert.IsTrue(snapshot.ContainsText("│"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_SplitterWithVStackPanes_RendersCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -766,13 +767,13 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Left 1"));
-        Assert.True(snapshot.ContainsText("Left 2"));
-        Assert.True(snapshot.ContainsText("Right 1"));
-        Assert.True(snapshot.ContainsText("Right 2"));
+        Assert.IsTrue(snapshot.ContainsText("Left 1"));
+        Assert.IsTrue(snapshot.ContainsText("Left 2"));
+        Assert.IsTrue(snapshot.ContainsText("Right 1"));
+        Assert.IsTrue(snapshot.ContainsText("Right 2"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_SplitterWithButtons_HandlesFocus()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -802,10 +803,10 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(leftClicked);
+        Assert.IsTrue(leftClicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_SplitterNavigation_TabSwitchesFocus()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -835,10 +836,10 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(rightClicked);
+        Assert.IsTrue(rightClicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_SplitterResize_ArrowKeysWork()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -877,7 +878,7 @@ public class SplitterNodeTests
         // Test passes if no exceptions were thrown and WaitUntil conditions were met.
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_SplitterWithList_HandlesNavigation()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -911,10 +912,10 @@ public class SplitterNodeTests
         await runTask;
 
         // Verify second item is selected via rendered output
-        Assert.True(snapshot.ContainsText("> Item 2"));
+        Assert.IsTrue(snapshot.ContainsText("> Item 2"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_SplitterWithTextBox_HandlesTyping()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -944,10 +945,10 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("Hello Splitter", text);
+        Assert.AreEqual("Hello Splitter", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_SplitterInsideBorder_RendersCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -978,17 +979,17 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Split View"));
-        Assert.True(snapshot.ContainsText("Left"));
-        Assert.True(snapshot.ContainsText("Right"));
-        Assert.True(snapshot.ContainsText("┌"));
+        Assert.IsTrue(snapshot.ContainsText("Split View"));
+        Assert.IsTrue(snapshot.ContainsText("Left"));
+        Assert.IsTrue(snapshot.ContainsText("Right"));
+        Assert.IsTrue(snapshot.ContainsText("┌"));
     }
 
     #endregion
 
     #region Vertical Splitter - Measurement Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_Vertical_ReturnsCorrectSize()
     {
         var top = new TextBlockNode { Text = "Top Pane" };
@@ -1004,12 +1005,12 @@ public class SplitterNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // Height = FirstSize (5) + divider (1) + bottom content height (1)
-        Assert.Equal(7, size.Height);
+        Assert.AreEqual(7, size.Height);
         // Width should be max of top and bottom
-        Assert.Equal(11, size.Width); // "Bottom Pane" is 11 chars
+        Assert.AreEqual(11, size.Width); // "Bottom Pane" is 11 chars
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_Vertical_WithNoChildren_ReturnsMinimalSize()
     {
         var node = new SplitterNode 
@@ -1023,10 +1024,10 @@ public class SplitterNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // Just FirstSize + divider height
-        Assert.Equal(11, size.Height); // 10 + 1
+        Assert.AreEqual(11, size.Height); // 10 + 1
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_Vertical_RespectsConstraints()
     {
         var top = new TextBlockNode { Text = "Top" };
@@ -1041,10 +1042,10 @@ public class SplitterNodeTests
 
         var size = node.Measure(new Constraints(0, 20, 0, 10));
 
-        Assert.True(size.Height <= 10);
+        Assert.IsTrue(size.Height <= 10);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_Vertical_WidthIsMaxOfBothPanes()
     {
         var top = new HStackNode
@@ -1067,14 +1068,14 @@ public class SplitterNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // Width of top pane ("Wide" + "Content" + "Here" = 15)
-        Assert.Equal(15, size.Width);
+        Assert.AreEqual(15, size.Width);
     }
 
     #endregion
 
     #region Vertical Splitter - Arrange Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_Vertical_FirstPaneGetsFirstSizeHeight()
     {
         var top = new TextBlockNode { Text = "Top" };
@@ -1090,11 +1091,11 @@ public class SplitterNodeTests
         node.Measure(Constraints.Unbounded);
         node.Arrange(new Rect(0, 0, 50, 20));
 
-        Assert.Equal(0, top.Bounds.Y);
-        Assert.Equal(8, top.Bounds.Height);
+        Assert.AreEqual(0, top.Bounds.Y);
+        Assert.AreEqual(8, top.Bounds.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_Vertical_SecondPaneGetsRemainingHeight()
     {
         var top = new TextBlockNode { Text = "Top" };
@@ -1111,12 +1112,12 @@ public class SplitterNodeTests
         node.Arrange(new Rect(0, 0, 50, 20));
 
         // Bottom pane starts after top + divider (8 + 1 = 9)
-        Assert.Equal(9, bottom.Bounds.Y);
+        Assert.AreEqual(9, bottom.Bounds.Y);
         // Bottom pane gets remaining height (20 - 8 - 1 = 11)
-        Assert.Equal(11, bottom.Bounds.Height);
+        Assert.AreEqual(11, bottom.Bounds.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_Vertical_WithOffset_PositionsCorrectly()
     {
         var top = new TextBlockNode { Text = "Top" };
@@ -1132,13 +1133,13 @@ public class SplitterNodeTests
         node.Measure(Constraints.Unbounded);
         node.Arrange(new Rect(5, 3, 40, 15));
 
-        Assert.Equal(5, top.Bounds.X);
-        Assert.Equal(3, top.Bounds.Y);
-        Assert.Equal(5, bottom.Bounds.X);
-        Assert.Equal(9, bottom.Bounds.Y); // 3 + 5 + 1
+        Assert.AreEqual(5, top.Bounds.X);
+        Assert.AreEqual(3, top.Bounds.Y);
+        Assert.AreEqual(5, bottom.Bounds.X);
+        Assert.AreEqual(9, bottom.Bounds.Y); // 3 + 5 + 1
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_Vertical_BothPanesGetFullWidth()
     {
         var top = new TextBlockNode { Text = "Top" };
@@ -1154,15 +1155,15 @@ public class SplitterNodeTests
         node.Measure(Constraints.Unbounded);
         node.Arrange(new Rect(0, 0, 40, 15));
 
-        Assert.Equal(40, top.Bounds.Width);
-        Assert.Equal(40, bottom.Bounds.Width);
+        Assert.AreEqual(40, top.Bounds.Width);
+        Assert.AreEqual(40, bottom.Bounds.Width);
     }
 
     #endregion
 
     #region Vertical Splitter - Rendering Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Vertical_ShowsHorizontalDivider()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1188,10 +1189,10 @@ public class SplitterNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(snapshot.ContainsText("─"));
+        Assert.IsTrue(snapshot.ContainsText("─"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Vertical_ShowsTopContent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1216,10 +1217,10 @@ public class SplitterNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(snapshot.ContainsText("Top Content"));
+        Assert.IsTrue(snapshot.ContainsText("Top Content"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Vertical_ShowsBottomContent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1244,10 +1245,10 @@ public class SplitterNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(snapshot.ContainsText("Bottom Content"));
+        Assert.IsTrue(snapshot.ContainsText("Bottom Content"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Vertical_WhenFocused_ShowsThumbIndicators()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1274,14 +1275,14 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
         // When focused, should show braille thumb indicators on divider
-        Assert.True(snapshot.ContainsText("⠶"));
+        Assert.IsTrue(snapshot.ContainsText("⠶"));
     }
 
     #endregion
 
     #region Vertical Splitter - Input Handling Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Vertical_UpArrow_WhenFocused_DecreasesFirstSize()
     {
         var node = new SplitterNode
@@ -1298,11 +1299,11 @@ public class SplitterNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.UpArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(8, node.FirstSize);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(8, node.FirstSize);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Vertical_DownArrow_WhenFocused_IncreasesFirstSize()
     {
         var node = new SplitterNode
@@ -1319,11 +1320,11 @@ public class SplitterNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.DownArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(12, node.FirstSize);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(12, node.FirstSize);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Vertical_UpArrow_RespectsMinFirstSize()
     {
         var node = new SplitterNode
@@ -1341,10 +1342,10 @@ public class SplitterNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.UpArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(5, node.FirstSize); // Clamped to MinFirstSize
+        Assert.AreEqual(5, node.FirstSize); // Clamped to MinFirstSize
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Vertical_DownArrow_RespectsMaxHeight()
     {
         var node = new SplitterNode
@@ -1362,10 +1363,10 @@ public class SplitterNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.DownArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.True(node.FirstSize <= 14);
+        Assert.IsTrue(node.FirstSize <= 14);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Vertical_LeftRightArrows_DoNotResize()
     {
         var node = new SplitterNode
@@ -1383,11 +1384,11 @@ public class SplitterNodeTests
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
         // Binding matches and executes, but action checks orientation and does nothing
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(10, node.FirstSize);  // Size unchanged
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(10, node.FirstSize);  // Size unchanged
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Horizontal_UpDownArrows_DoNotResize()
     {
         var node = new SplitterNode
@@ -1405,15 +1406,15 @@ public class SplitterNodeTests
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.UpArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
         // Binding matches and executes, but action checks orientation and does nothing
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(20, node.FirstSize);  // Size unchanged
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(20, node.FirstSize);  // Size unchanged
     }
 
     #endregion
 
     #region Vertical Splitter - Integration Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_VSplitter_RendersCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1442,12 +1443,12 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Top Content"));
-        Assert.True(snapshot.ContainsText("Bottom Content"));
-        Assert.True(snapshot.ContainsText("─")); // Horizontal divider
+        Assert.IsTrue(snapshot.ContainsText("Top Content"));
+        Assert.IsTrue(snapshot.ContainsText("Bottom Content"));
+        Assert.IsTrue(snapshot.ContainsText("─")); // Horizontal divider
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_VSplitterWithVStackPanes_RendersCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1476,13 +1477,13 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Top 1"));
-        Assert.True(snapshot.ContainsText("Top 2"));
-        Assert.True(snapshot.ContainsText("Bottom 1"));
-        Assert.True(snapshot.ContainsText("Bottom 2"));
+        Assert.IsTrue(snapshot.ContainsText("Top 1"));
+        Assert.IsTrue(snapshot.ContainsText("Top 2"));
+        Assert.IsTrue(snapshot.ContainsText("Bottom 1"));
+        Assert.IsTrue(snapshot.ContainsText("Bottom 2"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_VSplitterWithButtons_HandlesFocus()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1512,10 +1513,10 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(topClicked);
+        Assert.IsTrue(topClicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_VSplitterNavigation_TabSwitchesFocus()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1545,10 +1546,10 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(bottomClicked);
+        Assert.IsTrue(bottomClicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_VSplitterResize_ArrowKeysWork()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1580,11 +1581,11 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Top"));
-        Assert.True(snapshot.ContainsText("Bottom"));
+        Assert.IsTrue(snapshot.ContainsText("Top"));
+        Assert.IsTrue(snapshot.ContainsText("Bottom"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_VSplitterInsideBorder_RendersCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1615,13 +1616,13 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Vertical Split"));
-        Assert.True(snapshot.ContainsText("Top"));
-        Assert.True(snapshot.ContainsText("Bottom"));
-        Assert.True(snapshot.ContainsText("┌"));
+        Assert.IsTrue(snapshot.ContainsText("Vertical Split"));
+        Assert.IsTrue(snapshot.ContainsText("Top"));
+        Assert.IsTrue(snapshot.ContainsText("Bottom"));
+        Assert.IsTrue(snapshot.ContainsText("┌"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_NestedSplitters_HorizontalInsideVertical()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1654,9 +1655,9 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Top-Left"));
-        Assert.True(snapshot.ContainsText("Top-Right"));
-        Assert.True(snapshot.ContainsText("Bottom"));
+        Assert.IsTrue(snapshot.ContainsText("Top-Left"));
+        Assert.IsTrue(snapshot.ContainsText("Top-Right"));
+        Assert.IsTrue(snapshot.ContainsText("Bottom"));
     }
 
     #endregion
@@ -1669,7 +1670,7 @@ public class SplitterNodeTests
     /// by the VStack. This tests that VStack doesn't register Tab bindings when an ancestor
     /// (like Splitter) has ManagesChildFocus = true.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Integration_TabFromListInVStackInsideSplitter_MovesFocusToNextPane()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1702,14 +1703,14 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(rightButtonClicked, "Tab should have moved focus from List through Splitter to Right Button");
+        Assert.IsTrue(rightButtonClicked, "Tab should have moved focus from List through Splitter to Right Button");
     }
 
     /// <summary>
     /// Regression test: Same as above but with multiple buttons in left pane VStack.
     /// Focus order: First -> Second -> Splitter -> Right
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Integration_TabFromSecondButtonInVStackInsideSplitter_MovesFocusToNextPane()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1742,13 +1743,13 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(rightButtonClicked, "Tab should have moved focus from Second Button through Splitter to Right Button");
+        Assert.IsTrue(rightButtonClicked, "Tab should have moved focus from Second Button through Splitter to Right Button");
     }
 
     /// <summary>
     /// Regression test: Shift+Tab should also bubble up to Splitter for reverse navigation.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Integration_ShiftTabFromButtonInsideSplitter_MovesFocusToPreviousPane()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1781,14 +1782,14 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(leftButtonClicked, "Shift+Tab should have moved focus back to Left Button");
+        Assert.IsTrue(leftButtonClicked, "Shift+Tab should have moved focus back to Left Button");
     }
 
     /// <summary>
     /// Regression test: Deeply nested structure - VStack inside Panel inside Splitter.
     /// Tab should still bubble up to the Splitter.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Integration_TabFromWidgetInDeepNesting_BubblesUpToSplitter()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1828,24 +1829,24 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(rightButtonClicked, "Tab should bubble up from deeply nested List to Splitter");
+        Assert.IsTrue(rightButtonClicked, "Tab should bubble up from deeply nested List to Splitter");
     }
 
     #endregion
 
     #region Drag Binding Tests
 
-    [Fact]
+    [TestMethod]
     public async Task ConfigureDefaultBindings_IncludesDragBinding()
     {
         var node = new SplitterNode();
         var builder = node.BuildBindings();
 
-        Assert.Single(builder.DragBindings);
-        Assert.Equal(MouseButton.Left, builder.DragBindings[0].Button);
+        TestSeq.Single(builder.DragBindings);
+        Assert.AreEqual(MouseButton.Left, builder.DragBindings[0].Button);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DragBinding_Matches_LeftMouseDown()
     {
         var node = new SplitterNode();
@@ -1854,10 +1855,10 @@ public class SplitterNodeTests
 
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 5, Hex1bModifiers.None);
         
-        Assert.True(dragBinding.Matches(mouseEvent));
+        Assert.IsTrue(dragBinding.Matches(mouseEvent));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DragBinding_DoesNotMatch_RightMouseDown()
     {
         var node = new SplitterNode();
@@ -1866,10 +1867,10 @@ public class SplitterNodeTests
 
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Right, MouseAction.Down, 10, 5, Hex1bModifiers.None);
         
-        Assert.False(dragBinding.Matches(mouseEvent));
+        Assert.IsFalse(dragBinding.Matches(mouseEvent));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DragBinding_DoesNotMatch_MouseMove()
     {
         var node = new SplitterNode();
@@ -1878,10 +1879,10 @@ public class SplitterNodeTests
 
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Move, 10, 5, Hex1bModifiers.None);
         
-        Assert.False(dragBinding.Matches(mouseEvent));
+        Assert.IsFalse(dragBinding.Matches(mouseEvent));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DragHandler_OnMove_Horizontal_UpdatesFirstSize()
     {
         var node = new SplitterNode
@@ -1904,10 +1905,10 @@ public class SplitterNodeTests
         // Move 10 pixels to the right
         handler.OnMove?.Invoke(new InputBindingActionContext(new FocusRing()), 10, 0);
 
-        Assert.Equal(30, node.FirstSize); // 20 + 10
+        Assert.AreEqual(30, node.FirstSize); // 20 + 10
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DragHandler_OnMove_Horizontal_RespectsMinSize()
     {
         var node = new SplitterNode
@@ -1927,10 +1928,10 @@ public class SplitterNodeTests
         // Try to move 15 pixels to the left (beyond min)
         handler.OnMove?.Invoke(new InputBindingActionContext(new FocusRing()), -15, 0);
 
-        Assert.Equal(10, node.FirstSize); // Clamped to MinFirstSize
+        Assert.AreEqual(10, node.FirstSize); // Clamped to MinFirstSize
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DragHandler_OnMove_Horizontal_RespectsMaxSize()
     {
         var node = new SplitterNode
@@ -1950,10 +1951,10 @@ public class SplitterNodeTests
         // Try to move far to the right (beyond max)
         handler.OnMove?.Invoke(new InputBindingActionContext(new FocusRing()), 50, 0);
 
-        Assert.Equal(52, node.FirstSize); // Clamped to max
+        Assert.AreEqual(52, node.FirstSize); // Clamped to max
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DragHandler_OnMove_Vertical_UpdatesFirstSize()
     {
         var node = new SplitterNode
@@ -1973,10 +1974,10 @@ public class SplitterNodeTests
         // Move 5 pixels down
         handler.OnMove?.Invoke(new InputBindingActionContext(new FocusRing()), 0, 5);
 
-        Assert.Equal(15, node.FirstSize); // 10 + 5
+        Assert.AreEqual(15, node.FirstSize); // 10 + 5
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DragHandler_OnMove_CapturesStartSize()
     {
         var node = new SplitterNode
@@ -1997,7 +1998,7 @@ public class SplitterNodeTests
         handler.OnMove?.Invoke(new InputBindingActionContext(new FocusRing()), 5, 0);  // 20 + 5 = 25
         handler.OnMove?.Invoke(new InputBindingActionContext(new FocusRing()), 10, 0); // 20 + 10 = 30 (not 25 + 10 = 35)
 
-        Assert.Equal(30, node.FirstSize);
+        Assert.AreEqual(30, node.FirstSize);
     }
 
     #endregion
@@ -2009,7 +2010,7 @@ public class SplitterNodeTests
     /// The inner splitter should NOT call SetInitialFocus because its parent (outer splitter)
     /// has ManagesChildFocus = true.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Integration_NestedSplitters_InnerSplitterDoesNotOverrideFocus()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -2048,13 +2049,13 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(outerLeftClicked, "Initial focus should be on Outer Left button, not Inner Left");
+        Assert.IsTrue(outerLeftClicked, "Initial focus should be on Outer Left button, not Inner Left");
     }
 
     /// <summary>
     /// Regression test: Similar to above but with vertical splitters nested inside horizontal.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Integration_NestedVSplitterInHSplitter_OuterGetsInitialFocus()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -2087,13 +2088,13 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(outerLeftClicked, "Initial focus should be on Outer Left button");
+        Assert.IsTrue(outerLeftClicked, "Initial focus should be on Outer Left button");
     }
 
     /// <summary>
     /// Regression test: Three levels of nested splitters - only the root should set focus.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Integration_TripleNestedSplitters_OnlyRootSetsFocus()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -2130,14 +2131,14 @@ public class SplitterNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(level1Clicked, "Initial focus should be on Level 1 button (first focusable at root level)");
+        Assert.IsTrue(level1Clicked, "Initial focus should be on Level 1 button (first focusable at root level)");
     }
 
     /// <summary>
     /// Regression test: Directly verify that nested splitter nodes do not have IsFocused=true
     /// when they shouldn't. The inner splitter's divider should NOT appear focused.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task DirectReconcile_NestedSplitters_OnlyOuterFirstFocusableIsFocused()
     {
         // Build widgets manually - outer splitter with inner splitter in second pane
@@ -2159,7 +2160,7 @@ public class SplitterNodeTests
         context.IsNew = true;
         var rootNode = outerSplitter.ReconcileAsync(null, context).GetAwaiter().GetResult() as SplitterNode;
 
-        Assert.NotNull(rootNode);
+        Assert.IsNotNull(rootNode);
 
         // Find all the splitter nodes and buttons
         var outerButtonNode = rootNode.First?.GetFocusableNodes().OfType<ButtonNode>().FirstOrDefault();
@@ -2170,25 +2171,24 @@ public class SplitterNodeTests
         var layoutNode = rootNode.Second as LayoutNode;
         var actualInnerSplitter = layoutNode?.Child as SplitterNode;
 
-        Assert.NotNull(outerButtonNode);
-        Assert.NotNull(actualInnerSplitter);
+        Assert.IsNotNull(outerButtonNode);
+        Assert.IsNotNull(actualInnerSplitter);
 
         // The outer button should be focused (it's first in the focus order)
-        Assert.True(outerButtonNode.IsFocused, "Outer button should be focused");
+        Assert.IsTrue(outerButtonNode.IsFocused, "Outer button should be focused");
         
         // The inner splitter itself should NOT be focused
-        Assert.False(actualInnerSplitter.IsFocused, 
-            "Inner splitter should NOT be focused - only one element should have focus at a time");
+        Assert.IsFalse(actualInnerSplitter.IsFocused, "Inner splitter should NOT be focused - only one element should have focus at a time");
         
         // The outer splitter should NOT be focused either (it's not first focusable)
-        Assert.False(rootNode.IsFocused, "Outer splitter should not be focused (button is first)");
+        Assert.IsFalse(rootNode.IsFocused, "Outer splitter should not be focused (button is first)");
     }
 
     /// <summary>
     /// Regression test: Nested splitters with NO interactive children - only one should be focused.
     /// This was the original bug: both splitter dividers would render as focused.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task DirectReconcile_NestedSplittersNoButtons_OnlyOneSplitterFocused()
     {
         // Build widgets with ONLY text (no buttons) - splitters are the only focusables
@@ -2208,26 +2208,25 @@ public class SplitterNodeTests
         context.IsNew = true;
         var rootNode = outerSplitter.ReconcileAsync(null, context).GetAwaiter().GetResult() as SplitterNode;
 
-        Assert.NotNull(rootNode);
+        Assert.IsNotNull(rootNode);
 
         // Get the inner splitter node
         var layoutNode = rootNode.Second as LayoutNode;
         var innerSplitterNode = layoutNode?.Child as SplitterNode;
 
-        Assert.NotNull(innerSplitterNode);
+        Assert.IsNotNull(innerSplitterNode);
 
         // Count how many nodes have IsFocused = true
         var allFocusables = rootNode.GetFocusableNodes().ToList();
         var focusedCount = allFocusables.Count(n => n.IsFocused);
 
-        Assert.Equal(1, focusedCount);
+        Assert.AreEqual(1, focusedCount);
         
         // The outer splitter should be focused (it's first in its own focus order)
-        Assert.True(rootNode.IsFocused, "Outer splitter should be focused (first focusable)");
+        Assert.IsTrue(rootNode.IsFocused, "Outer splitter should be focused (first focusable)");
         
         // The inner splitter should NOT be focused
-        Assert.False(innerSplitterNode.IsFocused, 
-            "Inner splitter should NOT be focused - this was the original bug!");
+        Assert.IsFalse(innerSplitterNode.IsFocused, "Inner splitter should NOT be focused - this was the original bug!");
     }
 
     #endregion
@@ -2243,7 +2242,7 @@ public class SplitterNodeTests
     /// and each pane having VStack with 7 lines of text, lines 7+ should be clipped and NOT
     /// appear in the bottom pane area.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Integration_NestedSplitters_ContentDoesNotOverflowIntoBelowPane()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -2297,25 +2296,23 @@ public class SplitterNodeTests
         await runTask;
         
         // Verify top pane content is visible
-        Assert.True(snapshot.ContainsText("Top-Left"), "Top-Left pane header should be visible");
-        Assert.True(snapshot.ContainsText("Top-Right"), "Top-Right pane header should be visible");
+        Assert.IsTrue(snapshot.ContainsText("Top-Left"), "Top-Left pane header should be visible");
+        Assert.IsTrue(snapshot.ContainsText("Top-Right"), "Top-Right pane header should be visible");
         
         // Verify bottom pane content is visible
-        Assert.True(snapshot.ContainsText("Bottom Pane"), "Bottom pane header should be visible");
+        Assert.IsTrue(snapshot.ContainsText("Bottom Pane"), "Bottom pane header should be visible");
         
         // BUG CHECK: Overflow content should NOT be visible
         // These lines are beyond the topHeight (6) and should be clipped
-        Assert.False(snapshot.ContainsText("OVERFLOW-TL"), 
-            "Top-Left overflow content should be clipped and not visible in bottom pane area");
-        Assert.False(snapshot.ContainsText("OVERFLOW-TR"), 
-            "Top-Right overflow content should be clipped and not visible in bottom pane area");
+        Assert.IsFalse(snapshot.ContainsText("OVERFLOW-TL"), "Top-Left overflow content should be clipped and not visible in bottom pane area");
+        Assert.IsFalse(snapshot.ContainsText("OVERFLOW-TR"), "Top-Right overflow content should be clipped and not visible in bottom pane area");
     }
 
     /// <summary>
     /// Regression test: Horizontal splitter content should be clipped when panes are sized too narrow.
     /// Text that exceeds the pane width should not overflow into the adjacent pane.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Integration_HorizontalSplitter_ContentDoesNotOverflowIntoRightPane()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -2353,20 +2350,19 @@ public class SplitterNodeTests
         var screenText = snapshot.GetScreenText();
         
         // Verify basic content is visible
-        Assert.True(snapshot.ContainsText("Left"), "Left pane header should be visible");
-        Assert.True(snapshot.ContainsText("Right Pane"), "Right pane header should be visible");
+        Assert.IsTrue(snapshot.ContainsText("Left"), "Left pane header should be visible");
+        Assert.IsTrue(snapshot.ContainsText("Right Pane"), "Right pane header should be visible");
         
         // The long text should be truncated at the left pane boundary (10 chars)
         // It should NOT overflow past the divider into the right pane area
         // Check that the full overflow text is NOT visible
-        Assert.False(snapshot.ContainsText("LONG_TEXT_THAT_OVERFLOWS_LEFT_PANE"),
-            "Full overflow text should be clipped, not visible in right pane area");
+        Assert.IsFalse(snapshot.ContainsText("LONG_TEXT_THAT_OVERFLOWS_LEFT_PANE"), "Full overflow text should be clipped, not visible in right pane area");
     }
 
     /// <summary>
     /// Unit test: Verify that SplitterNode clips child content when rendering.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Render_Horizontal_ClipsLeftPaneContent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -2400,17 +2396,16 @@ public class SplitterNodeTests
         var screenText = snapshot.GetScreenText();
 
         // The full text should NOT be visible
-        Assert.False(screenText.Contains("OVERFLOW_TEXT_THAT_IS_MUCH_LONGER_THAN_10_CHARS"),
-            "Left pane content should be clipped to LeftWidth");
+        Assert.IsFalse(screenText.Contains("OVERFLOW_TEXT_THAT_IS_MUCH_LONGER_THAN_10_CHARS"), "Left pane content should be clipped to LeftWidth");
         
         // Right pane content should be visible
-        Assert.True(snapshot.ContainsText("Right"), "Right pane content should be visible");
+        Assert.IsTrue(snapshot.ContainsText("Right"), "Right pane content should be visible");
     }
 
     /// <summary>
     /// Unit test: Verify that SplitterNode clips child content in the vertical direction.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Render_Vertical_ClipsTopPaneContent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -2448,18 +2443,16 @@ public class SplitterNodeTests
         var snapshot = terminal.CreateSnapshot();
 
         // Lines 1-3 should be visible
-        Assert.True(snapshot.ContainsText("Line 1"), "Line 1 should be visible in top pane");
-        Assert.True(snapshot.ContainsText("Line 2"), "Line 2 should be visible in top pane");
-        Assert.True(snapshot.ContainsText("Line 3"), "Line 3 should be visible in top pane");
+        Assert.IsTrue(snapshot.ContainsText("Line 1"), "Line 1 should be visible in top pane");
+        Assert.IsTrue(snapshot.ContainsText("Line 2"), "Line 2 should be visible in top pane");
+        Assert.IsTrue(snapshot.ContainsText("Line 3"), "Line 3 should be visible in top pane");
         
         // Overflow lines should NOT be visible (clipped)
-        Assert.False(snapshot.ContainsText("OVERFLOW_LINE_4"),
-            "Line 4 should be clipped - it exceeds top pane height");
-        Assert.False(snapshot.ContainsText("OVERFLOW_LINE_5"),
-            "Line 5 should be clipped - it exceeds top pane height");
+        Assert.IsFalse(snapshot.ContainsText("OVERFLOW_LINE_4"), "Line 4 should be clipped - it exceeds top pane height");
+        Assert.IsFalse(snapshot.ContainsText("OVERFLOW_LINE_5"), "Line 5 should be clipped - it exceeds top pane height");
         
         // Bottom pane content should be visible
-        Assert.True(snapshot.ContainsText("Bottom"), "Bottom pane content should be visible");
+        Assert.IsTrue(snapshot.ContainsText("Bottom"), "Bottom pane content should be visible");
     }
 
     /// <summary>
@@ -2470,7 +2463,7 @@ public class SplitterNodeTests
     /// This tests the exact scenario from the docs: VSplitter containing a horizontal Splitter
     /// in its top pane, where the inner splitter's panes have VStack content.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Integration_NestedSplitters_ResizingInnerDoesNotCauseOverflow()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -2535,7 +2528,7 @@ public class SplitterNodeTests
     /// This reproduces the exact issue: when the right pane becomes very narrow,
     /// the wrapped text needs more vertical space than available, potentially overflowing.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Integration_NestedSplitters_WrappingTextDoesNotOverflowWhenDraggedExtreme()
     {
         using var workload = new Hex1bAppWorkloadAdapter();

--- a/tests/Hex1b.Tests/StatePanelIntegrationTests.cs
+++ b/tests/Hex1b.Tests/StatePanelIntegrationTests.cs
@@ -6,12 +6,13 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class StatePanelIntegrationTests
 {
     /// <summary>
     /// Full widget → reconcile → measure → arrange → render cycle.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task FullCycle_StatePanelWithText_RendersCorrectly()
     {
         var stateKey = new object();
@@ -23,7 +24,7 @@ public class StatePanelIntegrationTests
 
         // Measure
         var size = node.Measure(new Constraints(0, 40, 0, 5));
-        Assert.True(size.Width > 0);
+        Assert.IsTrue(size.Width > 0);
 
         // Arrange
         node.Arrange(new Rect(0, 0, 40, 1));
@@ -41,7 +42,7 @@ public class StatePanelIntegrationTests
     /// <summary>
     /// Items reorder in VStack under StatePanel scope → nodes swap correctly.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Reorder_InVStack_NodesSwapCorrectly()
     {
         var keyRoot = new object();
@@ -79,15 +80,15 @@ public class StatePanelIntegrationTests
         var vstack2 = (VStackNode)root2.Child!;
 
         // Identity preserved across reorder
-        Assert.Same(nodeC, vstack2.Children[0]);
-        Assert.Same(nodeA, vstack2.Children[1]);
-        Assert.Same(nodeB, vstack2.Children[2]);
+        Assert.AreSame(nodeC, vstack2.Children[0]);
+        Assert.AreSame(nodeA, vstack2.Children[1]);
+        Assert.AreSame(nodeB, vstack2.Children[2]);
     }
 
     /// <summary>
     /// Item insertion and deletion: new nodes created, old nodes swept.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task InsertAndDelete_NodesCreatedAndSwept()
     {
         var keyRoot = new object();
@@ -105,7 +106,7 @@ public class StatePanelIntegrationTests
 
         var root = (StatePanelNode)await widget1.ReconcileAsync(null, context);
         var nodeA = root.NestedStatePanels[keyA];
-        Assert.Equal(2, root.NestedStatePanels.Count);
+        Assert.AreEqual(2, root.NestedStatePanels.Count);
 
         // Frame 2: A, C (B removed, C added)
         var widget2 = new StatePanelWidget(keyRoot, sp =>
@@ -117,16 +118,16 @@ public class StatePanelIntegrationTests
         await widget2.ReconcileAsync(root, context);
 
         // A preserved, B removed, C new
-        Assert.Equal(2, root.NestedStatePanels.Count);
-        Assert.Same(nodeA, root.NestedStatePanels[keyA]);
-        Assert.True(root.NestedStatePanels.ContainsKey(keyC));
-        Assert.False(root.NestedStatePanels.ContainsKey(keyB));
+        Assert.AreEqual(2, root.NestedStatePanels.Count);
+        Assert.AreSame(nodeA, root.NestedStatePanels[keyA]);
+        Assert.IsTrue(root.NestedStatePanels.ContainsKey(keyC));
+        Assert.IsFalse(root.NestedStatePanels.ContainsKey(keyB));
     }
 
     /// <summary>
     /// Render after reorder produces correct output at new positions.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Reorder_ThenRender_ShowsCorrectTextAtNewPositions()
     {
         var keyRoot = new object();
@@ -170,7 +171,7 @@ public class StatePanelIntegrationTests
     /// <summary>
     /// Standalone StatePanel (no ancestor) with same key reuses node.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Standalone_SameKey_ReusesNode()
     {
         var stateKey = new object();
@@ -180,7 +181,7 @@ public class StatePanelIntegrationTests
         var node1 = await widget.ReconcileAsync(null, context);
         var node2 = await widget.ReconcileAsync(node1, context);
 
-        Assert.Same(node1, node2);
+        Assert.AreSame(node1, node2);
     }
 
     private static string GetRowText(Surface surface, int row)

--- a/tests/Hex1b.Tests/StatePanelNodeTests.cs
+++ b/tests/Hex1b.Tests/StatePanelNodeTests.cs
@@ -5,11 +5,12 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class StatePanelNodeTests
 {
     // --- Layout pass-through tests ---
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithChild_DelegatesToChild()
     {
         var child = new ButtonNode { Label = "OK" };
@@ -18,22 +19,22 @@ public class StatePanelNodeTests
         var size = node.Measure(new Constraints(0, 50, 0, 10));
 
         // ButtonNode measures its label; just verify we get a non-zero size
-        Assert.True(size.Width > 0);
-        Assert.True(size.Height > 0);
+        Assert.IsTrue(size.Width > 0);
+        Assert.IsTrue(size.Height > 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithoutChild_ReturnsConstrainedZero()
     {
         var node = new StatePanelNode { StateKey = new object(), Child = null };
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(0, size.Width);
-        Assert.Equal(0, size.Height);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(0, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_PassesThroughToChild()
     {
         var child = new ButtonNode { Label = "OK" };
@@ -43,13 +44,13 @@ public class StatePanelNodeTests
         var rect = new Rect(5, 10, 30, 3);
         node.Arrange(rect);
 
-        Assert.Equal(rect, node.Bounds);
-        Assert.Equal(rect, child.Bounds);
+        Assert.AreEqual(rect, node.Bounds);
+        Assert.AreEqual(rect, child.Bounds);
     }
 
     // --- Focus pass-through tests ---
 
-    [Fact]
+    [TestMethod]
     public void GetFocusableNodes_DelegatesToChild()
     {
         var button = new ButtonNode { Label = "OK" };
@@ -57,21 +58,21 @@ public class StatePanelNodeTests
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Single(focusables);
-        Assert.Same(button, focusables[0]);
+        TestSeq.Single(focusables);
+        Assert.AreSame(button, focusables[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetFocusableNodes_WithoutChild_ReturnsEmpty()
     {
         var node = new StatePanelNode { StateKey = new object(), Child = null };
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Empty(focusables);
+        Assert.IsEmpty(focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_WithChild_ReturnsSingletonList()
     {
         var child = new TextBlockNode();
@@ -79,23 +80,23 @@ public class StatePanelNodeTests
 
         var children = node.GetChildren();
 
-        Assert.Single(children);
-        Assert.Same(child, children[0]);
+        TestSeq.Single(children);
+        Assert.AreSame(child, children[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_WithoutChild_ReturnsEmpty()
     {
         var node = new StatePanelNode { StateKey = new object(), Child = null };
 
         var children = node.GetChildren();
 
-        Assert.Empty(children);
+        Assert.IsEmpty(children);
     }
 
     // --- Mark-and-sweep tests ---
 
-    [Fact]
+    [TestMethod]
     public void SweepUnvisited_RemovesUnvisitedKeys()
     {
         var node = new StatePanelNode { StateKey = new object() };
@@ -111,11 +112,11 @@ public class StatePanelNodeTests
         node.MarkVisited(keyA);
         node.SweepUnvisited();
 
-        Assert.True(node.NestedStatePanels.ContainsKey(keyA));
-        Assert.False(node.NestedStatePanels.ContainsKey(keyB));
+        Assert.IsTrue(node.NestedStatePanels.ContainsKey(keyA));
+        Assert.IsFalse(node.NestedStatePanels.ContainsKey(keyB));
     }
 
-    [Fact]
+    [TestMethod]
     public void SweepUnvisited_ClearsVisitedSetForNextFrame()
     {
         var node = new StatePanelNode { StateKey = new object() };
@@ -130,12 +131,12 @@ public class StatePanelNodeTests
         // keyA should be removed
         node.SweepUnvisited();
 
-        Assert.False(node.NestedStatePanels.ContainsKey(keyA));
+        Assert.IsFalse(node.NestedStatePanels.ContainsKey(keyA));
     }
 
     // --- Identity-based reconciliation tests ---
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_SameStateKey_ReusesSameNode()
     {
         var stateKey = new object();
@@ -145,11 +146,11 @@ public class StatePanelNodeTests
         var node1 = await widget.ReconcileAsync(null, context);
         var node2 = await widget.ReconcileAsync(node1, context);
 
-        Assert.IsType<StatePanelNode>(node1);
-        Assert.Same(node1, node2);
+        TestSeq.IsType<StatePanelNode>(node1);
+        Assert.AreSame(node1, node2);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_DifferentStateKey_Standalone_CreatesNewNode()
     {
         var keyA = new object();
@@ -163,11 +164,11 @@ public class StatePanelNodeTests
         var widgetB = new StatePanelWidget(keyB, sp => new TextBlockWidget("B"));
         var node2 = await widgetB.ReconcileAsync(node1, context);
 
-        Assert.IsType<StatePanelNode>(node2);
-        Assert.NotSame(node1, node2);
+        TestSeq.IsType<StatePanelNode>(node2);
+        Assert.AreNotSame(node1, node2);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_NestedStatePanels_IdentitySurvivesPositionSwap()
     {
         var keyRoot = new object();
@@ -187,8 +188,8 @@ public class StatePanelNodeTests
         var nodeA = vstack1.Children[0];
         var nodeB = vstack1.Children[1];
 
-        Assert.IsType<StatePanelNode>(nodeA);
-        Assert.IsType<StatePanelNode>(nodeB);
+        TestSeq.IsType<StatePanelNode>(nodeA);
+        TestSeq.IsType<StatePanelNode>(nodeB);
 
         // Frame 2: swap order — VStack [ SP(B), SP(A) ]
         var widget2 = new StatePanelWidget(keyRoot, sp =>
@@ -201,11 +202,11 @@ public class StatePanelNodeTests
         var vstack2 = (VStackNode)rootNode2.Child!;
 
         // Identity preserved: nodes swapped correctly
-        Assert.Same(nodeB, vstack2.Children[0]);
-        Assert.Same(nodeA, vstack2.Children[1]);
+        Assert.AreSame(nodeB, vstack2.Children[0]);
+        Assert.AreSame(nodeA, vstack2.Children[1]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_NestedStatePanels_RemovedKeyGetSwept()
     {
         var keyRoot = new object();
@@ -221,7 +222,7 @@ public class StatePanelNodeTests
             ]));
 
         var rootNode = (StatePanelNode)await widget1.ReconcileAsync(null, context);
-        Assert.Equal(2, rootNode.NestedStatePanels.Count);
+        Assert.AreEqual(2, rootNode.NestedStatePanels.Count);
 
         // Frame 2: only A remains
         var widget2 = new StatePanelWidget(keyRoot, sp =>
@@ -232,12 +233,12 @@ public class StatePanelNodeTests
         await widget2.ReconcileAsync(rootNode, context);
 
         // B should be swept
-        Assert.Single(rootNode.NestedStatePanels);
-        Assert.True(rootNode.NestedStatePanels.ContainsKey(keyA));
-        Assert.False(rootNode.NestedStatePanels.ContainsKey(keyB));
+        TestSeq.Single(rootNode.NestedStatePanels);
+        Assert.IsTrue(rootNode.NestedStatePanels.ContainsKey(keyA));
+        Assert.IsFalse(rootNode.NestedStatePanels.ContainsKey(keyB));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_NestedStatePanels_NewKeyCreatesNewNode()
     {
         var keyRoot = new object();
@@ -263,12 +264,12 @@ public class StatePanelNodeTests
 
         await widget2.ReconcileAsync(rootNode, context);
 
-        Assert.Equal(2, rootNode.NestedStatePanels.Count);
-        Assert.Same(nodeA, rootNode.NestedStatePanels[keyA]);
-        Assert.True(rootNode.NestedStatePanels.ContainsKey(keyC));
+        Assert.AreEqual(2, rootNode.NestedStatePanels.Count);
+        Assert.AreSame(nodeA, rootNode.NestedStatePanels[keyA]);
+        Assert.IsTrue(rootNode.NestedStatePanels.ContainsKey(keyC));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_NodeHasCorrectStateKey()
     {
         var stateKey = new object();
@@ -277,18 +278,18 @@ public class StatePanelNodeTests
         var context = ReconcileContext.CreateRoot();
         var node = (StatePanelNode)await widget.ReconcileAsync(null, context);
 
-        Assert.Same(stateKey, node.StateKey);
+        Assert.AreSame(stateKey, node.StateKey);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_GetExpectedNodeType_ReturnsStatePanelNode()
     {
         var widget = new StatePanelWidget(new object(), _ => new TextBlockWidget("x"));
 
-        Assert.Equal(typeof(StatePanelNode), widget.GetExpectedNodeType());
+        Assert.AreEqual(typeof(StatePanelNode), widget.GetExpectedNodeType());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_ChildWidgetIsReconciled()
     {
         var stateKey = new object();
@@ -297,13 +298,13 @@ public class StatePanelNodeTests
 
         var node = (StatePanelNode)await widget.ReconcileAsync(null, context);
 
-        Assert.NotNull(node.Child);
-        Assert.IsType<TextBlockNode>(node.Child);
+        Assert.IsNotNull(node.Child);
+        TestSeq.IsType<TextBlockNode>(node.Child);
     }
 
     // --- Extension method tests ---
 
-    [Fact]
+    [TestMethod]
     public void Extension_StatePanel_SingleChild_CreatesWidget()
     {
         var ctx = new WidgetContext<VStackWidget>();
@@ -311,21 +312,21 @@ public class StatePanelNodeTests
 
         var widget = ctx.StatePanel(stateKey, sp => sp.Text("hello"));
 
-        Assert.IsType<StatePanelWidget>(widget);
-        Assert.Same(stateKey, widget.StateKey);
+        TestSeq.IsType<StatePanelWidget>(widget);
+        Assert.AreSame(stateKey, widget.StateKey);
     }
 
     // --- Registry uses reference equality ---
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_RegistryUsesReferenceEquality_NotValueEquality()
     {
         var keyRoot = new object();
         // Two strings that are value-equal but reference-different
         var keyA = new string("item-1".ToCharArray());
         var keyB = new string("item-1".ToCharArray());
-        Assert.Equal(keyA, keyB);
-        Assert.False(ReferenceEquals(keyA, keyB));
+        Assert.AreEqual(keyA, keyB);
+        Assert.IsFalse(ReferenceEquals(keyA, keyB));
 
         var context = ReconcileContext.CreateRoot();
 
@@ -338,6 +339,6 @@ public class StatePanelNodeTests
         var rootNode = (StatePanelNode)await widget.ReconcileAsync(null, context);
 
         // Both should be separate entries despite value equality
-        Assert.Equal(2, rootNode.NestedStatePanels.Count);
+        Assert.AreEqual(2, rootNode.NestedStatePanels.Count);
     }
 }

--- a/tests/Hex1b.Tests/SurfaceComparerUnderlineDiffTests.cs
+++ b/tests/Hex1b.Tests/SurfaceComparerUnderlineDiffTests.cs
@@ -11,9 +11,10 @@ namespace Hex1b.Tests;
 /// in its underline state was treated as unchanged - the diff would skip it
 /// and the host terminal would keep displaying stale underline state.
 /// </summary>
+[TestClass]
 public class SurfaceComparerUnderlineDiffTests
 {
-    [Fact]
+    [TestMethod]
     public void Compare_CellWithChangedUnderlineStyleOnly_IsIncludedInDiff()
     {
         var previous = new Surface(1, 1);
@@ -30,11 +31,11 @@ public class SurfaceComparerUnderlineDiffTests
 
         var diff = SurfaceComparer.Compare(previous, current);
 
-        Assert.Single(diff.ChangedCells);
-        Assert.Equal(UnderlineStyle.Curly, diff.ChangedCells[0].Cell.UnderlineStyle);
+        TestSeq.Single(diff.ChangedCells);
+        Assert.AreEqual(UnderlineStyle.Curly, diff.ChangedCells[0].Cell.UnderlineStyle);
     }
 
-    [Fact]
+    [TestMethod]
     public void Compare_CellWithChangedUnderlineColorOnly_IsIncludedInDiff()
     {
         var previous = new Surface(1, 1);
@@ -52,11 +53,11 @@ public class SurfaceComparerUnderlineDiffTests
 
         var diff = SurfaceComparer.Compare(previous, current);
 
-        Assert.Single(diff.ChangedCells);
-        Assert.Equal(Hex1bColor.Blue, diff.ChangedCells[0].Cell.UnderlineColor);
+        TestSeq.Single(diff.ChangedCells);
+        Assert.AreEqual(Hex1bColor.Blue, diff.ChangedCells[0].Cell.UnderlineColor);
     }
 
-    [Fact]
+    [TestMethod]
     public void Compare_CellWithIdenticalUnderlineState_IsNotInDiff()
     {
         var previous = new Surface(1, 1);
@@ -74,6 +75,6 @@ public class SurfaceComparerUnderlineDiffTests
 
         var diff = SurfaceComparer.Compare(previous, current);
 
-        Assert.Empty(diff.ChangedCells);
+        Assert.IsEmpty(diff.ChangedCells);
     }
 }

--- a/tests/Hex1b.Tests/SurfaceFastPathTests.cs
+++ b/tests/Hex1b.Tests/SurfaceFastPathTests.cs
@@ -12,77 +12,78 @@ namespace Hex1b.Tests;
 /// Conversely, when both surfaces remain in the simple lane, the diff output
 /// must be identical to the slow path.
 /// </summary>
+[TestClass]
 public class SurfaceFastPathTests
 {
-    [Fact]
+    [TestMethod]
     public void NewSurface_HasFastPathEligibleTrue()
     {
         var surface = new Surface(4, 2);
-        Assert.True(surface.IsFastPathEligible);
+        Assert.IsTrue(surface.IsFastPathEligible);
     }
 
-    [Fact]
+    [TestMethod]
     public void SimpleAsciiWrite_KeepsFastPathEligible()
     {
         var surface = new Surface(4, 2);
         surface[0, 0] = new SurfaceCell("A", Hex1bColor.White, Hex1bColor.Black);
         surface.WriteText(1, 0, "BCD", Hex1bColor.White, Hex1bColor.Black);
-        Assert.True(surface.IsFastPathEligible);
+        Assert.IsTrue(surface.IsFastPathEligible);
     }
 
-    [Theory]
-    [InlineData("e\u0301")]   // combining acute => grapheme length > 1
+    [TestMethod]
+    [DataRow("e\u0301")]   // combining acute => grapheme length > 1
     public void MultiCodePointGrapheme_MarksComplex(string grapheme)
     {
         var surface = new Surface(4, 1);
         surface[0, 0] = new SurfaceCell(grapheme, null, null);
-        Assert.False(surface.IsFastPathEligible);
+        Assert.IsFalse(surface.IsFastPathEligible);
     }
 
-    [Fact]
+    [TestMethod]
     public void UnderlineStyle_MarksComplex()
     {
         var surface = new Surface(4, 1);
         surface[0, 0] = new SurfaceCell(
             "A", Hex1bColor.White, Hex1bColor.Black,
             UnderlineStyle: UnderlineStyle.Single);
-        Assert.False(surface.IsFastPathEligible);
+        Assert.IsFalse(surface.IsFastPathEligible);
     }
 
-    [Fact]
+    [TestMethod]
     public void UnderlineColor_MarksComplex()
     {
         var surface = new Surface(4, 1);
         surface[0, 0] = new SurfaceCell(
             "A", Hex1bColor.White, Hex1bColor.Black,
             UnderlineColor: Hex1bColor.Red);
-        Assert.False(surface.IsFastPathEligible);
+        Assert.IsFalse(surface.IsFastPathEligible);
     }
 
-    [Fact]
+    [TestMethod]
     public void WideCharacter_MarksComplex()
     {
         var surface = new Surface(4, 1);
         // "あ" is a wide CJK char with DisplayWidth=2.
         surface.WriteText(0, 0, "あ", Hex1bColor.White, Hex1bColor.Black);
-        Assert.False(surface.IsFastPathEligible);
+        Assert.IsFalse(surface.IsFastPathEligible);
     }
 
-    [Fact]
+    [TestMethod]
     public void Clear_ResetsFastPathFlag()
     {
         var surface = new Surface(4, 1);
         surface[0, 0] = new SurfaceCell(
             "A", Hex1bColor.White, Hex1bColor.Black,
             UnderlineStyle: UnderlineStyle.Single);
-        Assert.False(surface.IsFastPathEligible);
+        Assert.IsFalse(surface.IsFastPathEligible);
 
         surface.Clear();
 
-        Assert.True(surface.IsFastPathEligible);
+        Assert.IsTrue(surface.IsFastPathEligible);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClearWithComplexCell_LeavesFlagSet()
     {
         var surface = new Surface(4, 1);
@@ -92,24 +93,24 @@ public class SurfaceFastPathTests
 
         surface.Clear(complex);
 
-        Assert.False(surface.IsFastPathEligible);
+        Assert.IsFalse(surface.IsFastPathEligible);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClearWithSimpleCell_KeepsFlagClear()
     {
         var surface = new Surface(4, 1);
         surface[0, 0] = new SurfaceCell(
             "A", Hex1bColor.White, Hex1bColor.Black,
             UnderlineStyle: UnderlineStyle.Single);
-        Assert.False(surface.IsFastPathEligible);
+        Assert.IsFalse(surface.IsFastPathEligible);
 
         surface.Clear(new SurfaceCell(" ", null, Hex1bColor.Black));
 
-        Assert.True(surface.IsFastPathEligible);
+        Assert.IsTrue(surface.IsFastPathEligible);
     }
 
-    [Fact]
+    [TestMethod]
     public void Compare_FastPath_ProducesIdenticalDiffToSlowPath()
     {
         // Two surfaces filled with simple ASCII content; both are fast-eligible.
@@ -129,8 +130,8 @@ public class SurfaceFastPathTests
             }
         }
 
-        Assert.True(prev.IsFastPathEligible);
-        Assert.True(curr.IsFastPathEligible);
+        Assert.IsTrue(prev.IsFastPathEligible);
+        Assert.IsTrue(curr.IsFastPathEligible);
 
         var diff = SurfaceComparer.Compare(prev, curr);
 
@@ -141,16 +142,16 @@ public class SurfaceFastPathTests
                 if ((x + y) % 2 != 0)
                     expected.Add((x, y, "b"));
 
-        Assert.Equal(expected.Count, diff.ChangedCells.Count);
+        Assert.AreEqual(expected.Count, diff.ChangedCells.Count);
         for (var i = 0; i < expected.Count; i++)
         {
-            Assert.Equal(expected[i].X, diff.ChangedCells[i].X);
-            Assert.Equal(expected[i].Y, diff.ChangedCells[i].Y);
-            Assert.Equal(expected[i].Char, diff.ChangedCells[i].Cell.Character);
+            Assert.AreEqual(expected[i].X, diff.ChangedCells[i].X);
+            Assert.AreEqual(expected[i].Y, diff.ChangedCells[i].Y);
+            Assert.AreEqual(expected[i].Char, diff.ChangedCells[i].Cell.Character);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Compare_MixedEligibility_FallsBackToSlowPathAndStillDetectsUnderlineChange()
     {
         // prev has only a plain cell; curr has an underline-changed cell.
@@ -165,32 +166,32 @@ public class SurfaceFastPathTests
             "A", Hex1bColor.White, Hex1bColor.Black,
             UnderlineStyle: UnderlineStyle.Single);
 
-        Assert.True(prev.IsFastPathEligible);
-        Assert.False(curr.IsFastPathEligible);
+        Assert.IsTrue(prev.IsFastPathEligible);
+        Assert.IsFalse(curr.IsFastPathEligible);
 
         var diff = SurfaceComparer.Compare(prev, curr);
 
-        Assert.Single(diff.ChangedCells);
-        Assert.Equal(UnderlineStyle.Single, diff.ChangedCells[0].Cell.UnderlineStyle);
+        TestSeq.Single(diff.ChangedCells);
+        Assert.AreEqual(UnderlineStyle.Single, diff.ChangedCells[0].Cell.UnderlineStyle);
     }
 
-    [Fact]
+    [TestMethod]
     public void CompareToEmpty_FastPath_MatchesSlowPath()
     {
         var surface = new Surface(4, 2);
         surface[0, 0] = new SurfaceCell("A", Hex1bColor.White, Hex1bColor.Black);
         surface[3, 1] = new SurfaceCell("Z", Hex1bColor.White, Hex1bColor.Red);
 
-        Assert.True(surface.IsFastPathEligible);
+        Assert.IsTrue(surface.IsFastPathEligible);
 
         var diff = SurfaceComparer.CompareToEmpty(surface);
 
-        Assert.Equal(2, diff.ChangedCells.Count);
-        Assert.Equal(0, diff.ChangedCells[0].X);
-        Assert.Equal(0, diff.ChangedCells[0].Y);
-        Assert.Equal("A", diff.ChangedCells[0].Cell.Character);
-        Assert.Equal(3, diff.ChangedCells[1].X);
-        Assert.Equal(1, diff.ChangedCells[1].Y);
-        Assert.Equal("Z", diff.ChangedCells[1].Cell.Character);
+        Assert.AreEqual(2, diff.ChangedCells.Count);
+        Assert.AreEqual(0, diff.ChangedCells[0].X);
+        Assert.AreEqual(0, diff.ChangedCells[0].Y);
+        Assert.AreEqual("A", diff.ChangedCells[0].Cell.Character);
+        Assert.AreEqual(3, diff.ChangedCells[1].X);
+        Assert.AreEqual(1, diff.ChangedCells[1].Y);
+        Assert.AreEqual("Z", diff.ChangedCells[1].Cell.Character);
     }
 }

--- a/tests/Hex1b.Tests/SurfaceNodeTests.cs
+++ b/tests/Hex1b.Tests/SurfaceNodeTests.cs
@@ -6,9 +6,10 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class SurfaceNodeTests
 {
-    [Fact]
+    [TestMethod]
     public void Measure_WithFillHints_ReturnsMaxConstraints()
     {
         var node = new SurfaceNode
@@ -20,11 +21,11 @@ public class SurfaceNodeTests
 
         var size = node.Measure(Constraints.Loose(80, 24));
 
-        Assert.Equal(80, size.Width);
-        Assert.Equal(24, size.Height);
+        Assert.AreEqual(80, size.Width);
+        Assert.AreEqual(24, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithFixedHints_ReturnsFixedSize()
     {
         var node = new SurfaceNode
@@ -36,11 +37,11 @@ public class SurfaceNodeTests
 
         var size = node.Measure(Constraints.Loose(80, 24));
 
-        Assert.Equal(40, size.Width);
-        Assert.Equal(10, size.Height);
+        Assert.AreEqual(40, size.Width);
+        Assert.AreEqual(10, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithFixedHints_ClampsToConstraints()
     {
         var node = new SurfaceNode
@@ -52,11 +53,11 @@ public class SurfaceNodeTests
 
         var size = node.Measure(Constraints.Loose(80, 24));
 
-        Assert.Equal(80, size.Width); // Clamped to max
-        Assert.Equal(24, size.Height); // Clamped to max
+        Assert.AreEqual(80, size.Width); // Clamped to max
+        Assert.AreEqual(24, size.Height); // Clamped to max
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_WithNoLayers_DoesNotThrow()
     {
         var node = new SurfaceNode { LayerBuilder = _ => [] };
@@ -69,7 +70,7 @@ public class SurfaceNodeTests
         node.Render(context);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_WithNullLayerBuilder_DoesNotThrow()
     {
         var node = new SurfaceNode { LayerBuilder = null };
@@ -82,7 +83,7 @@ public class SurfaceNodeTests
         node.Render(context);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_WithZeroSizeBounds_DoesNotThrow()
     {
         var node = new SurfaceNode { LayerBuilder = _ => [new SourceSurfaceLayer(new Surface(1, 1), 0, 0)] };
@@ -95,7 +96,7 @@ public class SurfaceNodeTests
         node.Render(context);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_SingleStaticLayer_WritesToContext()
     {
         // Create a surface with some content
@@ -114,14 +115,14 @@ public class SurfaceNodeTests
         node.Render(context);
 
         // Check that content was written
-        Assert.Equal("H", targetSurface[0, 0].Character);
-        Assert.Equal("e", targetSurface[1, 0].Character);
-        Assert.Equal("l", targetSurface[2, 0].Character);
-        Assert.Equal("l", targetSurface[3, 0].Character);
-        Assert.Equal("o", targetSurface[4, 0].Character);
+        Assert.AreEqual("H", targetSurface[0, 0].Character);
+        Assert.AreEqual("e", targetSurface[1, 0].Character);
+        Assert.AreEqual("l", targetSurface[2, 0].Character);
+        Assert.AreEqual("l", targetSurface[3, 0].Character);
+        Assert.AreEqual("o", targetSurface[4, 0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_LayerWithOffset_PositionsCorrectly()
     {
         var sourceSurface = new Surface(3, 1);
@@ -139,12 +140,12 @@ public class SurfaceNodeTests
         node.Render(context);
 
         // Content should be at offset position
-        Assert.Equal("A", targetSurface[5, 2].Character);
-        Assert.Equal("B", targetSurface[6, 2].Character);
-        Assert.Equal("C", targetSurface[7, 2].Character);
+        Assert.AreEqual("A", targetSurface[5, 2].Character);
+        Assert.AreEqual("B", targetSurface[6, 2].Character);
+        Assert.AreEqual("C", targetSurface[7, 2].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_DrawLayer_ExecutesCallback()
     {
         var drawWasCalled = false;
@@ -164,11 +165,11 @@ public class SurfaceNodeTests
 
         node.Render(context);
 
-        Assert.True(drawWasCalled);
-        Assert.Equal("D", targetSurface[0, 0].Character);
+        Assert.IsTrue(drawWasCalled);
+        Assert.AreEqual("D", targetSurface[0, 0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_ComputedLayer_ExecutesForEachCell()
     {
         // Create a computed layer that makes all cells 'X'
@@ -188,12 +189,12 @@ public class SurfaceNodeTests
         {
             for (int x = 0; x < 3; x++)
             {
-                Assert.Equal("X", targetSurface[x, y].Character);
+                Assert.AreEqual("X", targetSurface[x, y].Character);
             }
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_MultipleLayers_CompositesInOrder()
     {
         // Background layer with 'A' everywhere
@@ -218,14 +219,14 @@ public class SurfaceNodeTests
 
         node.Render(context);
 
-        Assert.Equal("A", targetSurface[0, 0].Character);
-        Assert.Equal("A", targetSurface[1, 0].Character);
-        Assert.Equal("B", targetSurface[2, 0].Character); // Foreground overwrites
-        Assert.Equal("A", targetSurface[3, 0].Character);
-        Assert.Equal("A", targetSurface[4, 0].Character);
+        Assert.AreEqual("A", targetSurface[0, 0].Character);
+        Assert.AreEqual("A", targetSurface[1, 0].Character);
+        Assert.AreEqual("B", targetSurface[2, 0].Character); // Foreground overwrites
+        Assert.AreEqual("A", targetSurface[3, 0].Character);
+        Assert.AreEqual("A", targetSurface[4, 0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_ComputedLayerCanQueryBelow()
     {
         // Base layer with 'A'
@@ -256,12 +257,12 @@ public class SurfaceNodeTests
         node.Render(context);
 
         // All cells should be replaced with 'X' since the computed layer could see the base
-        Assert.Equal("X", targetSurface[0, 0].Character);
-        Assert.Equal("X", targetSurface[1, 0].Character);
-        Assert.Equal("X", targetSurface[2, 0].Character);
+        Assert.AreEqual("X", targetSurface[0, 0].Character);
+        Assert.AreEqual("X", targetSurface[1, 0].Character);
+        Assert.AreEqual("X", targetSurface[2, 0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceLayerContext_ProvidesCorrectDimensions()
     {
         int capturedWidth = 0, capturedHeight = 0;
@@ -282,11 +283,11 @@ public class SurfaceNodeTests
 
         node.Render(context);
 
-        Assert.Equal(40, capturedWidth);
-        Assert.Equal(12, capturedHeight);
+        Assert.AreEqual(40, capturedWidth);
+        Assert.AreEqual(12, capturedHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceLayerContext_ProvidesTheme()
     {
         Hex1bTheme? capturedTheme = null;
@@ -307,10 +308,10 @@ public class SurfaceNodeTests
 
         node.Render(context);
 
-        Assert.NotNull(capturedTheme);
+        Assert.IsNotNull(capturedTheme);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_CellWithColor_WritesWithAnsiCodes()
     {
         var sourceSurface = new Surface(1, 1);
@@ -329,18 +330,18 @@ public class SurfaceNodeTests
 
         // The cell should have colors applied
         var cell = targetSurface[0, 0];
-        Assert.Equal("X", cell.Character);
-        Assert.Equal(Hex1bColor.Red, cell.Foreground);
-        Assert.Equal(Hex1bColor.Blue, cell.Background);
+        Assert.AreEqual("X", cell.Character);
+        Assert.AreEqual(Hex1bColor.Red, cell.Foreground);
+        Assert.AreEqual(Hex1bColor.Blue, cell.Background);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_ReturnsEmpty()
     {
         var node = new SurfaceNode();
 
         var children = node.GetChildren().ToList();
 
-        Assert.Empty(children);
+        Assert.IsEmpty(children);
     }
 }

--- a/tests/Hex1b.Tests/SurfaceRenderContextTests.cs
+++ b/tests/Hex1b.Tests/SurfaceRenderContextTests.cs
@@ -9,11 +9,12 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for <see cref="SurfaceRenderContext"/>.
 /// </summary>
+[TestClass]
 public class SurfaceRenderContextTests
 {
     #region Basic Writing
 
-    [Fact]
+    [TestMethod]
     public void Write_PlainText_WritesAtCursorPosition()
     {
         var surface = new Surface(80, 24);
@@ -22,14 +23,14 @@ public class SurfaceRenderContextTests
         context.SetCursorPosition(5, 10);
         context.Write("Hello");
         
-        Assert.Equal("H", surface[5, 10].Character);
-        Assert.Equal("e", surface[6, 10].Character);
-        Assert.Equal("l", surface[7, 10].Character);
-        Assert.Equal("l", surface[8, 10].Character);
-        Assert.Equal("o", surface[9, 10].Character);
+        Assert.AreEqual("H", surface[5, 10].Character);
+        Assert.AreEqual("e", surface[6, 10].Character);
+        Assert.AreEqual("l", surface[7, 10].Character);
+        Assert.AreEqual("l", surface[8, 10].Character);
+        Assert.AreEqual("o", surface[9, 10].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Write_AdvancesCursor()
     {
         var surface = new Surface(80, 24);
@@ -39,11 +40,11 @@ public class SurfaceRenderContextTests
         context.Write("ABC");
         context.Write("DEF");
         
-        Assert.Equal("A", surface[0, 0].Character);
-        Assert.Equal("D", surface[3, 0].Character);
+        Assert.AreEqual("A", surface[0, 0].Character);
+        Assert.AreEqual("D", surface[3, 0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteClipped_PlainText_WritesAtSpecifiedPosition()
     {
         var surface = new Surface(80, 24);
@@ -51,18 +52,18 @@ public class SurfaceRenderContextTests
         
         context.WriteClipped(10, 5, "World");
         
-        Assert.Equal("W", surface[10, 5].Character);
-        Assert.Equal("o", surface[11, 5].Character);
-        Assert.Equal("r", surface[12, 5].Character);
-        Assert.Equal("l", surface[13, 5].Character);
-        Assert.Equal("d", surface[14, 5].Character);
+        Assert.AreEqual("W", surface[10, 5].Character);
+        Assert.AreEqual("o", surface[11, 5].Character);
+        Assert.AreEqual("r", surface[12, 5].Character);
+        Assert.AreEqual("l", surface[13, 5].Character);
+        Assert.AreEqual("d", surface[14, 5].Character);
     }
 
     #endregion
 
     #region ANSI Parsing - Colors
 
-    [Fact]
+    [TestMethod]
     public void Write_WithForegroundColor_ParsesAndApplies()
     {
         var surface = new Surface(80, 24);
@@ -73,14 +74,14 @@ public class SurfaceRenderContextTests
         context.Write("\x1b[38;2;255;0;0mRed");
         
         var cell = surface[0, 0];
-        Assert.Equal("R", cell.Character);
-        Assert.NotNull(cell.Foreground);
-        Assert.Equal(255, cell.Foreground.Value.R);
-        Assert.Equal(0, cell.Foreground.Value.G);
-        Assert.Equal(0, cell.Foreground.Value.B);
+        Assert.AreEqual("R", cell.Character);
+        Assert.IsNotNull(cell.Foreground);
+        Assert.AreEqual(255, cell.Foreground.Value.R);
+        Assert.AreEqual(0, cell.Foreground.Value.G);
+        Assert.AreEqual(0, cell.Foreground.Value.B);
     }
 
-    [Fact]
+    [TestMethod]
     public void Write_WithBackgroundColor_ParsesAndApplies()
     {
         var surface = new Surface(80, 24);
@@ -91,14 +92,14 @@ public class SurfaceRenderContextTests
         context.Write("\x1b[48;2;0;0;255mBlue");
         
         var cell = surface[0, 0];
-        Assert.Equal("B", cell.Character);
-        Assert.NotNull(cell.Background);
-        Assert.Equal(0, cell.Background.Value.R);
-        Assert.Equal(0, cell.Background.Value.G);
-        Assert.Equal(255, cell.Background.Value.B);
+        Assert.AreEqual("B", cell.Character);
+        Assert.IsNotNull(cell.Background);
+        Assert.AreEqual(0, cell.Background.Value.R);
+        Assert.AreEqual(0, cell.Background.Value.G);
+        Assert.AreEqual(255, cell.Background.Value.B);
     }
 
-    [Fact]
+    [TestMethod]
     public void Write_WithReset_ClearsColors()
     {
         var surface = new Surface(80, 24);
@@ -108,13 +109,13 @@ public class SurfaceRenderContextTests
         context.Write("\x1b[38;2;255;0;0mR\x1b[0mN");
         
         // First character has red foreground
-        Assert.NotNull(surface[0, 0].Foreground);
+        Assert.IsNotNull(surface[0, 0].Foreground);
         
         // Second character should have no foreground (reset)
-        Assert.Null(surface[1, 0].Foreground);
+        Assert.IsNull(surface[1, 0].Foreground);
     }
 
-    [Fact]
+    [TestMethod]
     public void Write_256Color_ParsesCorrectly()
     {
         var surface = new Surface(80, 24);
@@ -125,14 +126,14 @@ public class SurfaceRenderContextTests
         context.Write("\x1b[38;5;2mG");
         
         var cell = surface[0, 0];
-        Assert.NotNull(cell.Foreground);
+        Assert.IsNotNull(cell.Foreground);
         // Basic green from 16-color palette
-        Assert.Equal(0, cell.Foreground.Value.R);
-        Assert.Equal(128, cell.Foreground.Value.G);
-        Assert.Equal(0, cell.Foreground.Value.B);
+        Assert.AreEqual(0, cell.Foreground.Value.R);
+        Assert.AreEqual(128, cell.Foreground.Value.G);
+        Assert.AreEqual(0, cell.Foreground.Value.B);
     }
 
-    [Fact]
+    [TestMethod]
     public void Write_BasicColors_ParsesCorrectly()
     {
         var surface = new Surface(80, 24);
@@ -143,11 +144,11 @@ public class SurfaceRenderContextTests
         context.Write("\x1b[31mR");
         
         var cell = surface[0, 0];
-        Assert.NotNull(cell.Foreground);
-        Assert.Equal(128, cell.Foreground.Value.R); // Basic red
+        Assert.IsNotNull(cell.Foreground);
+        Assert.AreEqual(128, cell.Foreground.Value.R); // Basic red
     }
 
-    [Fact]
+    [TestMethod]
     public void Write_BrightColors_ParsesCorrectly()
     {
         var surface = new Surface(80, 24);
@@ -158,15 +159,15 @@ public class SurfaceRenderContextTests
         context.Write("\x1b[91mR");
         
         var cell = surface[0, 0];
-        Assert.NotNull(cell.Foreground);
-        Assert.Equal(255, cell.Foreground.Value.R); // Bright red
+        Assert.IsNotNull(cell.Foreground);
+        Assert.AreEqual(255, cell.Foreground.Value.R); // Bright red
     }
 
     #endregion
 
     #region ANSI Parsing - Attributes
 
-    [Fact]
+    [TestMethod]
     public void Write_BoldAttribute_ParsesAndApplies()
     {
         var surface = new Surface(80, 24);
@@ -176,10 +177,10 @@ public class SurfaceRenderContextTests
         context.Write("\x1b[1mBold");
         
         var cell = surface[0, 0];
-        Assert.True((cell.Attributes & CellAttributes.Bold) != 0);
+        Assert.IsTrue((cell.Attributes & CellAttributes.Bold) != 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void Write_ItalicAttribute_ParsesAndApplies()
     {
         var surface = new Surface(80, 24);
@@ -189,10 +190,10 @@ public class SurfaceRenderContextTests
         context.Write("\x1b[3mItalic");
         
         var cell = surface[0, 0];
-        Assert.True((cell.Attributes & CellAttributes.Italic) != 0);
+        Assert.IsTrue((cell.Attributes & CellAttributes.Italic) != 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void Write_UnderlineAttribute_ParsesAndApplies()
     {
         var surface = new Surface(80, 24);
@@ -202,10 +203,10 @@ public class SurfaceRenderContextTests
         context.Write("\x1b[4mUnderline");
         
         var cell = surface[0, 0];
-        Assert.True((cell.Attributes & CellAttributes.Underline) != 0);
+        Assert.IsTrue((cell.Attributes & CellAttributes.Underline) != 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void Write_MultipleAttributes_ParsesAndApplies()
     {
         var surface = new Surface(80, 24);
@@ -216,12 +217,12 @@ public class SurfaceRenderContextTests
         context.Write("\x1b[1;3;4mStyled");
         
         var cell = surface[0, 0];
-        Assert.True((cell.Attributes & CellAttributes.Bold) != 0);
-        Assert.True((cell.Attributes & CellAttributes.Italic) != 0);
-        Assert.True((cell.Attributes & CellAttributes.Underline) != 0);
+        Assert.IsTrue((cell.Attributes & CellAttributes.Bold) != 0);
+        Assert.IsTrue((cell.Attributes & CellAttributes.Italic) != 0);
+        Assert.IsTrue((cell.Attributes & CellAttributes.Underline) != 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void Write_AttributeReset_ClearsAttributes()
     {
         var surface = new Surface(80, 24);
@@ -231,17 +232,17 @@ public class SurfaceRenderContextTests
         context.Write("\x1b[1mB\x1b[0mN");
         
         // First character is bold
-        Assert.True((surface[0, 0].Attributes & CellAttributes.Bold) != 0);
+        Assert.IsTrue((surface[0, 0].Attributes & CellAttributes.Bold) != 0);
         
         // Second character is not bold
-        Assert.Equal(CellAttributes.None, surface[1, 0].Attributes);
+        Assert.AreEqual(CellAttributes.None, surface[1, 0].Attributes);
     }
 
     #endregion
 
     #region Wide Characters
 
-    [Fact]
+    [TestMethod]
     public void Write_WideCharacter_OccupiesTwoCells()
     {
         var surface = new Surface(80, 24);
@@ -251,22 +252,22 @@ public class SurfaceRenderContextTests
         context.Write("你好");
         
         // First character
-        Assert.Equal("你", surface[0, 0].Character);
-        Assert.Equal(2, surface[0, 0].DisplayWidth);
+        Assert.AreEqual("你", surface[0, 0].Character);
+        Assert.AreEqual(2, surface[0, 0].DisplayWidth);
         
         // Continuation cell
-        Assert.Equal(0, surface[1, 0].DisplayWidth);
+        Assert.AreEqual(0, surface[1, 0].DisplayWidth);
         
         // Second character
-        Assert.Equal("好", surface[2, 0].Character);
-        Assert.Equal(2, surface[2, 0].DisplayWidth);
+        Assert.AreEqual("好", surface[2, 0].Character);
+        Assert.AreEqual(2, surface[2, 0].DisplayWidth);
     }
 
     #endregion
 
     #region Clear Operations
 
-    [Fact]
+    [TestMethod]
     public void Clear_FillsSurfaceWithSpaces()
     {
         var surface = new Surface(10, 5);
@@ -283,12 +284,12 @@ public class SurfaceRenderContextTests
         {
             for (var x = 0; x < 10; x++)
             {
-                Assert.Equal(" ", surface[x, y].Character);
+                Assert.AreEqual(" ", surface[x, y].Character);
             }
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void ClearRegion_FillsRectWithSpaces()
     {
         var surface = new Surface(20, 10);
@@ -305,20 +306,20 @@ public class SurfaceRenderContextTests
         {
             for (var x = 5; x < 10; x++)
             {
-                Assert.Equal(" ", surface[x, y].Character);
+                Assert.AreEqual(" ", surface[x, y].Character);
             }
         }
         
         // Outside region should still be X
-        Assert.Equal("X", surface[0, 0].Character);
-        Assert.Equal("X", surface[15, 8].Character);
+        Assert.AreEqual("X", surface[0, 0].Character);
+        Assert.AreEqual("X", surface[15, 8].Character);
     }
 
     #endregion
 
     #region Complex Sequences
 
-    [Fact]
+    [TestMethod]
     public void Write_ColorAndText_MixedSequence()
     {
         var surface = new Surface(80, 24);
@@ -329,19 +330,19 @@ public class SurfaceRenderContextTests
         context.Write("\x1b[38;2;255;0;0mHello\x1b[0m \x1b[38;2;0;0;255mWorld\x1b[0m");
         
         // "Hello" should be red
-        Assert.Equal("H", surface[0, 0].Character);
-        Assert.Equal(255, surface[0, 0].Foreground!.Value.R);
+        Assert.AreEqual("H", surface[0, 0].Character);
+        Assert.AreEqual(255, surface[0, 0].Foreground!.Value.R);
         
         // Space should have no color
-        Assert.Equal(" ", surface[5, 0].Character);
-        Assert.Null(surface[5, 0].Foreground);
+        Assert.AreEqual(" ", surface[5, 0].Character);
+        Assert.IsNull(surface[5, 0].Foreground);
         
         // "World" should be blue
-        Assert.Equal("W", surface[6, 0].Character);
-        Assert.Equal(255, surface[6, 0].Foreground!.Value.B);
+        Assert.AreEqual("W", surface[6, 0].Character);
+        Assert.AreEqual(255, surface[6, 0].Foreground!.Value.B);
     }
 
-    [Fact]
+    [TestMethod]
     public void Write_SkipsOscSequences()
     {
         var surface = new Surface(80, 24);
@@ -352,13 +353,13 @@ public class SurfaceRenderContextTests
         context.Write("\x1b]8;;http://example.com\x1b\\Link\x1b]8;;\x1b\\");
         
         // Should see "Link" without the OSC sequences
-        Assert.Equal("L", surface[0, 0].Character);
-        Assert.Equal("i", surface[1, 0].Character);
-        Assert.Equal("n", surface[2, 0].Character);
-        Assert.Equal("k", surface[3, 0].Character);
+        Assert.AreEqual("L", surface[0, 0].Character);
+        Assert.AreEqual("i", surface[1, 0].Character);
+        Assert.AreEqual("n", surface[2, 0].Character);
+        Assert.AreEqual("k", surface[3, 0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Write_SkipsFrameMarkers()
     {
         var surface = new Surface(80, 24);
@@ -368,14 +369,14 @@ public class SurfaceRenderContextTests
         context.SetCursorPosition(0, 0);
         context.Write("\x1b_HEX1BAPP:FRAME:BEGIN\x1b\\Hello");
         
-        Assert.Equal("H", surface[0, 0].Character);
+        Assert.AreEqual("H", surface[0, 0].Character);
     }
 
     #endregion
 
     #region Clipping
 
-    [Fact]
+    [TestMethod]
     public void WriteClipped_WithLayoutProvider_RespectsClipping()
     {
         var surface = new Surface(80, 24);
@@ -392,7 +393,7 @@ public class SurfaceRenderContextTests
         // Text should be clipped to start at x=5
         // This depends on the ClipString implementation
         // For now, verify the call was made with clipping context set
-        Assert.NotNull(context.CurrentLayoutProvider);
+        Assert.IsNotNull(context.CurrentLayoutProvider);
     }
 
     private class TestLayoutProvider : ILayoutProvider
@@ -431,41 +432,41 @@ public class SurfaceRenderContextTests
 
     #region Properties
 
-    [Fact]
+    [TestMethod]
     public void Width_ReturnsSurfaceWidth()
     {
         var surface = new Surface(100, 50);
         var context = new SurfaceRenderContext(surface);
         
-        Assert.Equal(100, context.Width);
+        Assert.AreEqual(100, context.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void Height_ReturnsSurfaceHeight()
     {
         var surface = new Surface(100, 50);
         var context = new SurfaceRenderContext(surface);
         
-        Assert.Equal(50, context.Height);
+        Assert.AreEqual(50, context.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Theme_DefaultsToDefaultTheme()
     {
         var surface = new Surface(80, 24);
         var context = new SurfaceRenderContext(surface);
         
-        Assert.NotNull(context.Theme);
+        Assert.IsNotNull(context.Theme);
     }
 
-    [Fact]
+    [TestMethod]
     public void Theme_CanBeSet()
     {
         var surface = new Surface(80, 24);
         var customTheme = Hex1bThemes.Ocean;
         var context = new SurfaceRenderContext(surface, customTheme);
         
-        Assert.Same(customTheme, context.Theme);
+        Assert.AreSame(customTheme, context.Theme);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/SurfaceTests.cs
+++ b/tests/Hex1b.Tests/SurfaceTests.cs
@@ -8,73 +8,74 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for <see cref="SurfaceCell"/> record struct.
 /// </summary>
+[TestClass]
 public class SurfaceCellTests
 {
     #region Construction and Equality
 
-    [Fact]
+    [TestMethod]
     public void SurfaceCell_DefaultValues_AreCorrect()
     {
         var cell = new SurfaceCell("A", null, null);
         
-        Assert.Equal("A", cell.Character);
-        Assert.Null(cell.Foreground);
-        Assert.Null(cell.Background);
-        Assert.Equal(CellAttributes.None, cell.Attributes);
-        Assert.Equal(1, cell.DisplayWidth);
-        Assert.Null(cell.Sixel);
-        Assert.Null(cell.Hyperlink);
+        Assert.AreEqual("A", cell.Character);
+        Assert.IsNull(cell.Foreground);
+        Assert.IsNull(cell.Background);
+        Assert.AreEqual(CellAttributes.None, cell.Attributes);
+        Assert.AreEqual(1, cell.DisplayWidth);
+        Assert.IsNull(cell.Sixel);
+        Assert.IsNull(cell.Hyperlink);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceCell_WithColors_StoresCorrectly()
     {
         var fg = Hex1bColor.Red;
         var bg = Hex1bColor.Blue;
         var cell = new SurfaceCell("X", fg, bg, CellAttributes.Bold);
         
-        Assert.Equal("X", cell.Character);
-        Assert.Equal(fg, cell.Foreground);
-        Assert.Equal(bg, cell.Background);
-        Assert.Equal(CellAttributes.Bold, cell.Attributes);
+        Assert.AreEqual("X", cell.Character);
+        Assert.AreEqual(fg, cell.Foreground);
+        Assert.AreEqual(bg, cell.Background);
+        Assert.AreEqual(CellAttributes.Bold, cell.Attributes);
     }
 
-    [Fact]
+    [TestMethod]
     public void SurfaceCell_Equality_WorksCorrectly()
     {
         var cell1 = new SurfaceCell("A", Hex1bColor.Red, null, CellAttributes.Bold, 1);
         var cell2 = new SurfaceCell("A", Hex1bColor.Red, null, CellAttributes.Bold, 1);
         var cell3 = new SurfaceCell("B", Hex1bColor.Red, null, CellAttributes.Bold, 1);
         
-        Assert.Equal(cell1, cell2);
-        Assert.NotEqual(cell1, cell3);
+        Assert.AreEqual(cell1, cell2);
+        Assert.AreNotEqual(cell1, cell3);
     }
 
     #endregion
 
     #region Properties
 
-    [Fact]
+    [TestMethod]
     public void IsContinuation_WhenDisplayWidthIsZero_ReturnsTrue()
     {
         var continuation = new SurfaceCell("", null, null, DisplayWidth: 0);
         var normal = new SurfaceCell("A", null, null, DisplayWidth: 1);
         
-        Assert.True(continuation.IsContinuation);
-        Assert.False(normal.IsContinuation);
+        Assert.IsTrue(continuation.IsContinuation);
+        Assert.IsFalse(normal.IsContinuation);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsWide_WhenDisplayWidthIsTwo_ReturnsTrue()
     {
         var wide = new SurfaceCell("日", null, null, DisplayWidth: 2);
         var normal = new SurfaceCell("A", null, null, DisplayWidth: 1);
         
-        Assert.True(wide.IsWide);
-        Assert.False(normal.IsWide);
+        Assert.IsTrue(wide.IsWide);
+        Assert.IsFalse(normal.IsWide);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsTransparent_WhenBothColorsNull_ReturnsTrue()
     {
         var transparent = new SurfaceCell("A", null, null);
@@ -82,67 +83,67 @@ public class SurfaceCellTests
         var withBg = new SurfaceCell("A", null, Hex1bColor.Blue);
         var withBoth = new SurfaceCell("A", Hex1bColor.Red, Hex1bColor.Blue);
         
-        Assert.True(transparent.IsTransparent);
-        Assert.False(withFg.IsTransparent);
-        Assert.False(withBg.IsTransparent);
-        Assert.False(withBoth.IsTransparent);
+        Assert.IsTrue(transparent.IsTransparent);
+        Assert.IsFalse(withFg.IsTransparent);
+        Assert.IsFalse(withBg.IsTransparent);
+        Assert.IsFalse(withBoth.IsTransparent);
     }
 
-    [Fact]
+    [TestMethod]
     public void HasTransparentBackground_WhenBackgroundNull_ReturnsTrue()
     {
         var transparentBg = new SurfaceCell("A", Hex1bColor.Red, null);
         var opaqueBg = new SurfaceCell("A", null, Hex1bColor.Blue);
         
-        Assert.True(transparentBg.HasTransparentBackground);
-        Assert.False(opaqueBg.HasTransparentBackground);
+        Assert.IsTrue(transparentBg.HasTransparentBackground);
+        Assert.IsFalse(opaqueBg.HasTransparentBackground);
     }
 
     #endregion
 
     #region With Methods
 
-    [Fact]
+    [TestMethod]
     public void WithForeground_CreatesNewCellWithUpdatedForeground()
     {
         var original = new SurfaceCell("A", null, Hex1bColor.Blue, CellAttributes.Bold);
         var updated = original.WithForeground(Hex1bColor.Red);
         
-        Assert.Null(original.Foreground);
-        Assert.Equal(Hex1bColor.Red, updated.Foreground);
-        Assert.Equal(original.Background, updated.Background);
-        Assert.Equal(original.Attributes, updated.Attributes);
+        Assert.IsNull(original.Foreground);
+        Assert.AreEqual(Hex1bColor.Red, updated.Foreground);
+        Assert.AreEqual(original.Background, updated.Background);
+        Assert.AreEqual(original.Attributes, updated.Attributes);
     }
 
-    [Fact]
+    [TestMethod]
     public void WithBackground_CreatesNewCellWithUpdatedBackground()
     {
         var original = new SurfaceCell("A", Hex1bColor.Red, null, CellAttributes.Bold);
         var updated = original.WithBackground(Hex1bColor.Blue);
         
-        Assert.Null(original.Background);
-        Assert.Equal(Hex1bColor.Blue, updated.Background);
-        Assert.Equal(original.Foreground, updated.Foreground);
+        Assert.IsNull(original.Background);
+        Assert.AreEqual(Hex1bColor.Blue, updated.Background);
+        Assert.AreEqual(original.Foreground, updated.Foreground);
     }
 
-    [Fact]
+    [TestMethod]
     public void WithAttributes_CreatesNewCellWithUpdatedAttributes()
     {
         var original = new SurfaceCell("A", null, null, CellAttributes.Bold);
         var updated = original.WithAttributes(CellAttributes.Italic);
         
-        Assert.Equal(CellAttributes.Bold, original.Attributes);
-        Assert.Equal(CellAttributes.Italic, updated.Attributes);
+        Assert.AreEqual(CellAttributes.Bold, original.Attributes);
+        Assert.AreEqual(CellAttributes.Italic, updated.Attributes);
     }
 
-    [Fact]
+    [TestMethod]
     public void WithAddedAttributes_CombinesAttributes()
     {
         var original = new SurfaceCell("A", null, null, CellAttributes.Bold);
         var updated = original.WithAddedAttributes(CellAttributes.Italic);
         
-        Assert.Equal(CellAttributes.Bold, original.Attributes);
-        Assert.Equal(CellAttributes.Bold | CellAttributes.Italic, updated.Attributes);
+        Assert.AreEqual(CellAttributes.Bold, original.Attributes);
+        Assert.AreEqual(CellAttributes.Bold | CellAttributes.Italic, updated.Attributes);
     }
 
     #endregion
@@ -151,72 +152,74 @@ public class SurfaceCellTests
 /// <summary>
 /// Tests for <see cref="SurfaceCells"/> static class.
 /// </summary>
+[TestClass]
 public class SurfaceCellsTests
 {
-    [Fact]
+    [TestMethod]
     public void Empty_IsUnwrittenMarkerWithNoColors()
     {
         var empty = SurfaceCells.Empty;
         
         // Empty uses a special unwritten marker character to distinguish from written spaces
-        Assert.Equal(SurfaceCells.UnwrittenMarker, empty.Character);
-        Assert.Null(empty.Foreground);
-        Assert.Null(empty.Background);
-        Assert.Equal(CellAttributes.None, empty.Attributes);
-        Assert.Equal(1, empty.DisplayWidth);
+        Assert.AreEqual(SurfaceCells.UnwrittenMarker, empty.Character);
+        Assert.IsNull(empty.Foreground);
+        Assert.IsNull(empty.Background);
+        Assert.AreEqual(CellAttributes.None, empty.Attributes);
+        Assert.AreEqual(1, empty.DisplayWidth);
     }
 
-    [Fact]
+    [TestMethod]
     public void Continuation_HasZeroDisplayWidth()
     {
         var continuation = SurfaceCells.Continuation;
         
-        Assert.Equal(string.Empty, continuation.Character);
-        Assert.Equal(0, continuation.DisplayWidth);
-        Assert.True(continuation.IsContinuation);
+        Assert.AreEqual(string.Empty, continuation.Character);
+        Assert.AreEqual(0, continuation.DisplayWidth);
+        Assert.IsTrue(continuation.IsContinuation);
     }
 
-    [Fact]
+    [TestMethod]
     public void Char_CreatesCorrectCell()
     {
         var cell = SurfaceCells.Char('X', Hex1bColor.Red, Hex1bColor.Blue, CellAttributes.Bold);
         
-        Assert.Equal("X", cell.Character);
-        Assert.Equal(Hex1bColor.Red, cell.Foreground);
-        Assert.Equal(Hex1bColor.Blue, cell.Background);
-        Assert.Equal(CellAttributes.Bold, cell.Attributes);
-        Assert.Equal(1, cell.DisplayWidth);
+        Assert.AreEqual("X", cell.Character);
+        Assert.AreEqual(Hex1bColor.Red, cell.Foreground);
+        Assert.AreEqual(Hex1bColor.Blue, cell.Background);
+        Assert.AreEqual(CellAttributes.Bold, cell.Attributes);
+        Assert.AreEqual(1, cell.DisplayWidth);
     }
 
-    [Fact]
+    [TestMethod]
     public void Space_WithBackground_CreatesSpaceCell()
     {
         var cell = SurfaceCells.Space(Hex1bColor.Blue);
         
-        Assert.Equal(" ", cell.Character);
-        Assert.Null(cell.Foreground);
-        Assert.Equal(Hex1bColor.Blue, cell.Background);
+        Assert.AreEqual(" ", cell.Character);
+        Assert.IsNull(cell.Foreground);
+        Assert.AreEqual(Hex1bColor.Blue, cell.Background);
     }
 }
 
 /// <summary>
 /// Tests for <see cref="Surface"/> class.
 /// </summary>
+[TestClass]
 public class SurfaceTests
 {
     #region Construction
 
-    [Fact]
+    [TestMethod]
     public void Constructor_WithValidDimensions_CreatesSurface()
     {
         var surface = new Surface(80, 24);
         
-        Assert.Equal(80, surface.Width);
-        Assert.Equal(24, surface.Height);
-        Assert.Equal(80 * 24, surface.CellCount);
+        Assert.AreEqual(80, surface.Width);
+        Assert.AreEqual(24, surface.Height);
+        Assert.AreEqual(80 * 24, surface.CellCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_InitializesAllCellsToEmpty()
     {
         var surface = new Surface(10, 5);
@@ -225,45 +228,45 @@ public class SurfaceTests
         {
             for (var x = 0; x < surface.Width; x++)
             {
-                Assert.Equal(SurfaceCells.Empty, surface[x, y]);
+                Assert.AreEqual(SurfaceCells.Empty, surface[x, y]);
             }
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_WithZeroWidth_Throws()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new Surface(0, 10));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new Surface(0, 10));
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_WithZeroHeight_Throws()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new Surface(10, 0));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new Surface(10, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_WithNegativeDimensions_Throws()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new Surface(-1, 10));
-        Assert.Throws<ArgumentOutOfRangeException>(() => new Surface(10, -1));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new Surface(-1, 10));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new Surface(10, -1));
     }
 
     #endregion
 
     #region Indexer
 
-    [Fact]
+    [TestMethod]
     public void Indexer_Get_ReturnsCorrectCell()
     {
         var surface = new Surface(10, 5);
         var cell = new SurfaceCell("X", Hex1bColor.Red, null);
         surface[3, 2] = cell;
         
-        Assert.Equal(cell, surface[3, 2]);
+        Assert.AreEqual(cell, surface[3, 2]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Indexer_Set_UpdatesCell()
     {
         var surface = new Surface(10, 5);
@@ -271,25 +274,25 @@ public class SurfaceTests
         
         surface[5, 3] = cell;
         
-        Assert.Equal(cell, surface[5, 3]);
+        Assert.AreEqual(cell, surface[5, 3]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Indexer_OutOfBounds_Throws()
     {
         var surface = new Surface(10, 5);
         
-        Assert.Throws<ArgumentOutOfRangeException>(() => surface[-1, 0]);
-        Assert.Throws<ArgumentOutOfRangeException>(() => surface[0, -1]);
-        Assert.Throws<ArgumentOutOfRangeException>(() => surface[10, 0]);
-        Assert.Throws<ArgumentOutOfRangeException>(() => surface[0, 5]);
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => surface[-1, 0]);
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => surface[0, -1]);
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => surface[10, 0]);
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => surface[0, 5]);
     }
 
     #endregion
 
     #region TryGetCell / TrySetCell
 
-    [Fact]
+    [TestMethod]
     public void TryGetCell_InBounds_ReturnsTrueAndCell()
     {
         var surface = new Surface(10, 5);
@@ -298,22 +301,22 @@ public class SurfaceTests
         
         var result = surface.TryGetCell(2, 1, out var retrieved);
         
-        Assert.True(result);
-        Assert.Equal(cell, retrieved);
+        Assert.IsTrue(result);
+        Assert.AreEqual(cell, retrieved);
     }
 
-    [Fact]
+    [TestMethod]
     public void TryGetCell_OutOfBounds_ReturnsFalse()
     {
         var surface = new Surface(10, 5);
         
-        Assert.False(surface.TryGetCell(-1, 0, out _));
-        Assert.False(surface.TryGetCell(10, 0, out _));
-        Assert.False(surface.TryGetCell(0, -1, out _));
-        Assert.False(surface.TryGetCell(0, 5, out _));
+        Assert.IsFalse(surface.TryGetCell(-1, 0, out _));
+        Assert.IsFalse(surface.TryGetCell(10, 0, out _));
+        Assert.IsFalse(surface.TryGetCell(0, -1, out _));
+        Assert.IsFalse(surface.TryGetCell(0, 5, out _));
     }
 
-    [Fact]
+    [TestMethod]
     public void TrySetCell_InBounds_ReturnsTrueAndSetsCell()
     {
         var surface = new Surface(10, 5);
@@ -321,50 +324,50 @@ public class SurfaceTests
         
         var result = surface.TrySetCell(4, 2, cell);
         
-        Assert.True(result);
-        Assert.Equal(cell, surface[4, 2]);
+        Assert.IsTrue(result);
+        Assert.AreEqual(cell, surface[4, 2]);
     }
 
-    [Fact]
+    [TestMethod]
     public void TrySetCell_OutOfBounds_ReturnsFalse()
     {
         var surface = new Surface(10, 5);
         var cell = new SurfaceCell("C", null, null);
         
-        Assert.False(surface.TrySetCell(-1, 0, cell));
-        Assert.False(surface.TrySetCell(10, 0, cell));
+        Assert.IsFalse(surface.TrySetCell(-1, 0, cell));
+        Assert.IsFalse(surface.TrySetCell(10, 0, cell));
     }
 
     #endregion
 
     #region IsInBounds
 
-    [Fact]
+    [TestMethod]
     public void IsInBounds_ValidPositions_ReturnsTrue()
     {
         var surface = new Surface(10, 5);
         
-        Assert.True(surface.IsInBounds(0, 0));
-        Assert.True(surface.IsInBounds(9, 4));
-        Assert.True(surface.IsInBounds(5, 2));
+        Assert.IsTrue(surface.IsInBounds(0, 0));
+        Assert.IsTrue(surface.IsInBounds(9, 4));
+        Assert.IsTrue(surface.IsInBounds(5, 2));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsInBounds_InvalidPositions_ReturnsFalse()
     {
         var surface = new Surface(10, 5);
         
-        Assert.False(surface.IsInBounds(-1, 0));
-        Assert.False(surface.IsInBounds(0, -1));
-        Assert.False(surface.IsInBounds(10, 0));
-        Assert.False(surface.IsInBounds(0, 5));
+        Assert.IsFalse(surface.IsInBounds(-1, 0));
+        Assert.IsFalse(surface.IsInBounds(0, -1));
+        Assert.IsFalse(surface.IsInBounds(10, 0));
+        Assert.IsFalse(surface.IsInBounds(0, 5));
     }
 
     #endregion
 
     #region Clear
 
-    [Fact]
+    [TestMethod]
     public void Clear_ResetsAllCellsToEmpty()
     {
         var surface = new Surface(5, 3);
@@ -377,12 +380,12 @@ public class SurfaceTests
         {
             for (var x = 0; x < surface.Width; x++)
             {
-                Assert.Equal(SurfaceCells.Empty, surface[x, y]);
+                Assert.AreEqual(SurfaceCells.Empty, surface[x, y]);
             }
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Clear_WithCell_FillsWithSpecifiedCell()
     {
         var surface = new Surface(5, 3);
@@ -394,7 +397,7 @@ public class SurfaceTests
         {
             for (var x = 0; x < surface.Width; x++)
             {
-                Assert.Equal(fillCell, surface[x, y]);
+                Assert.AreEqual(fillCell, surface[x, y]);
             }
         }
     }
@@ -403,7 +406,7 @@ public class SurfaceTests
 
     #region Fill
 
-    [Fact]
+    [TestMethod]
     public void Fill_Region_FillsCorrectCells()
     {
         var surface = new Surface(10, 5);
@@ -417,17 +420,17 @@ public class SurfaceTests
         {
             for (var x = 2; x < 5; x++)
             {
-                Assert.Equal(fillCell, surface[x, y]);
+                Assert.AreEqual(fillCell, surface[x, y]);
             }
         }
         
         // Check surrounding cells remain empty
-        Assert.Equal(SurfaceCells.Empty, surface[0, 0]);
-        Assert.Equal(SurfaceCells.Empty, surface[1, 1]);
-        Assert.Equal(SurfaceCells.Empty, surface[5, 1]);
+        Assert.AreEqual(SurfaceCells.Empty, surface[0, 0]);
+        Assert.AreEqual(SurfaceCells.Empty, surface[1, 1]);
+        Assert.AreEqual(SurfaceCells.Empty, surface[5, 1]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Fill_RegionOutsideBounds_ClipsCorrectly()
     {
         var surface = new Surface(5, 5);
@@ -437,32 +440,32 @@ public class SurfaceTests
         surface.Fill(region, fillCell);
         
         // Only cells within bounds should be filled
-        Assert.Equal(fillCell, surface[0, 0]);
-        Assert.Equal(fillCell, surface[2, 2]);
-        Assert.Equal(SurfaceCells.Empty, surface[3, 0]);
-        Assert.Equal(SurfaceCells.Empty, surface[0, 3]);
+        Assert.AreEqual(fillCell, surface[0, 0]);
+        Assert.AreEqual(fillCell, surface[2, 2]);
+        Assert.AreEqual(SurfaceCells.Empty, surface[3, 0]);
+        Assert.AreEqual(SurfaceCells.Empty, surface[0, 3]);
     }
 
     #endregion
 
     #region WriteText - Basic
 
-    [Fact]
+    [TestMethod]
     public void WriteText_SimpleAscii_WritesCorrectly()
     {
         var surface = new Surface(20, 5);
         
         surface.WriteText(0, 0, "Hello");
         
-        Assert.Equal("H", surface[0, 0].Character);
-        Assert.Equal("e", surface[1, 0].Character);
-        Assert.Equal("l", surface[2, 0].Character);
-        Assert.Equal("l", surface[3, 0].Character);
-        Assert.Equal("o", surface[4, 0].Character);
-        Assert.Equal(SurfaceCells.UnwrittenMarker, surface[5, 0].Character); // Unchanged (unwritten)
+        Assert.AreEqual("H", surface[0, 0].Character);
+        Assert.AreEqual("e", surface[1, 0].Character);
+        Assert.AreEqual("l", surface[2, 0].Character);
+        Assert.AreEqual("l", surface[3, 0].Character);
+        Assert.AreEqual("o", surface[4, 0].Character);
+        Assert.AreEqual(SurfaceCells.UnwrittenMarker, surface[5, 0].Character); // Unchanged (unwritten)
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteText_WithColors_AppliesColors()
     {
         var surface = new Surface(20, 5);
@@ -471,100 +474,100 @@ public class SurfaceTests
         
         surface.WriteText(0, 0, "AB", fg, bg);
         
-        Assert.Equal(fg, surface[0, 0].Foreground);
-        Assert.Equal(bg, surface[0, 0].Background);
-        Assert.Equal(fg, surface[1, 0].Foreground);
-        Assert.Equal(bg, surface[1, 0].Background);
+        Assert.AreEqual(fg, surface[0, 0].Foreground);
+        Assert.AreEqual(bg, surface[0, 0].Background);
+        Assert.AreEqual(fg, surface[1, 0].Foreground);
+        Assert.AreEqual(bg, surface[1, 0].Background);
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteText_WithAttributes_AppliesAttributes()
     {
         var surface = new Surface(20, 5);
         
         surface.WriteText(0, 0, "Bold", null, null, CellAttributes.Bold);
         
-        Assert.Equal(CellAttributes.Bold, surface[0, 0].Attributes);
-        Assert.Equal(CellAttributes.Bold, surface[3, 0].Attributes);
+        Assert.AreEqual(CellAttributes.Bold, surface[0, 0].Attributes);
+        Assert.AreEqual(CellAttributes.Bold, surface[3, 0].Attributes);
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteText_ReturnsColumnsWritten()
     {
         var surface = new Surface(20, 5);
         
         var written = surface.WriteText(0, 0, "Hello");
         
-        Assert.Equal(5, written);
+        Assert.AreEqual(5, written);
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteText_EmptyString_ReturnsZero()
     {
         var surface = new Surface(20, 5);
         
         var written = surface.WriteText(0, 0, "");
         
-        Assert.Equal(0, written);
+        Assert.AreEqual(0, written);
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteText_NullString_ReturnsZero()
     {
         var surface = new Surface(20, 5);
         
         var written = surface.WriteText(0, 0, null!);
         
-        Assert.Equal(0, written);
+        Assert.AreEqual(0, written);
     }
 
     #endregion
 
     #region WriteText - Clipping
 
-    [Fact]
+    [TestMethod]
     public void WriteText_ClipsAtRightEdge()
     {
         var surface = new Surface(5, 1);
         
         var written = surface.WriteText(0, 0, "HelloWorld");
         
-        Assert.Equal(5, written);
-        Assert.Equal("H", surface[0, 0].Character);
-        Assert.Equal("o", surface[4, 0].Character);
+        Assert.AreEqual(5, written);
+        Assert.AreEqual("H", surface[0, 0].Character);
+        Assert.AreEqual("o", surface[4, 0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteText_StartingOutsideRight_WritesNothing()
     {
         var surface = new Surface(5, 1);
         
         var written = surface.WriteText(10, 0, "Hello");
         
-        Assert.Equal(0, written);
+        Assert.AreEqual(0, written);
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteText_StartingOutsideTop_WritesNothing()
     {
         var surface = new Surface(20, 5);
         
         var written = surface.WriteText(0, -1, "Hello");
         
-        Assert.Equal(0, written);
+        Assert.AreEqual(0, written);
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteText_StartingOutsideBottom_WritesNothing()
     {
         var surface = new Surface(20, 5);
         
         var written = surface.WriteText(0, 5, "Hello");
         
-        Assert.Equal(0, written);
+        Assert.AreEqual(0, written);
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteText_StartingNegativeX_SkipsClippedChars()
     {
         var surface = new Surface(10, 1);
@@ -572,28 +575,28 @@ public class SurfaceTests
         surface.WriteText(-2, 0, "Hello");
         
         // "He" should be clipped, "llo" should be visible starting at x=0
-        Assert.Equal("l", surface[0, 0].Character);
-        Assert.Equal("l", surface[1, 0].Character);
-        Assert.Equal("o", surface[2, 0].Character);
+        Assert.AreEqual("l", surface[0, 0].Character);
+        Assert.AreEqual("l", surface[1, 0].Character);
+        Assert.AreEqual("o", surface[2, 0].Character);
     }
 
     #endregion
 
     #region WriteText - Wide Characters
 
-    [Fact]
+    [TestMethod]
     public void WriteText_WideCharacter_SetsContinuation()
     {
         var surface = new Surface(10, 1);
         
         surface.WriteText(0, 0, "日");
         
-        Assert.Equal("日", surface[0, 0].Character);
-        Assert.Equal(2, surface[0, 0].DisplayWidth);
-        Assert.True(surface[1, 0].IsContinuation);
+        Assert.AreEqual("日", surface[0, 0].Character);
+        Assert.AreEqual(2, surface[0, 0].DisplayWidth);
+        Assert.IsTrue(surface[1, 0].IsContinuation);
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteText_WideCharacterSequence_HandlesCorrectly()
     {
         var surface = new Surface(10, 1);
@@ -601,30 +604,30 @@ public class SurfaceTests
         surface.WriteText(0, 0, "日本");
         
         // First character
-        Assert.Equal("日", surface[0, 0].Character);
-        Assert.True(surface[1, 0].IsContinuation);
+        Assert.AreEqual("日", surface[0, 0].Character);
+        Assert.IsTrue(surface[1, 0].IsContinuation);
         // Second character
-        Assert.Equal("本", surface[2, 0].Character);
-        Assert.True(surface[3, 0].IsContinuation);
+        Assert.AreEqual("本", surface[2, 0].Character);
+        Assert.IsTrue(surface[3, 0].IsContinuation);
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteText_MixedWidthCharacters_HandlesCorrectly()
     {
         var surface = new Surface(10, 1);
         
         surface.WriteText(0, 0, "A日B");
         
-        Assert.Equal("A", surface[0, 0].Character);
-        Assert.Equal(1, surface[0, 0].DisplayWidth);
-        Assert.Equal("日", surface[1, 0].Character);
-        Assert.Equal(2, surface[1, 0].DisplayWidth);
-        Assert.True(surface[2, 0].IsContinuation);
-        Assert.Equal("B", surface[3, 0].Character);
-        Assert.Equal(1, surface[3, 0].DisplayWidth);
+        Assert.AreEqual("A", surface[0, 0].Character);
+        Assert.AreEqual(1, surface[0, 0].DisplayWidth);
+        Assert.AreEqual("日", surface[1, 0].Character);
+        Assert.AreEqual(2, surface[1, 0].DisplayWidth);
+        Assert.IsTrue(surface[2, 0].IsContinuation);
+        Assert.AreEqual("B", surface[3, 0].Character);
+        Assert.AreEqual(1, surface[3, 0].DisplayWidth);
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteText_WideCharacterAtEdge_ClipsWithSpace()
     {
         var surface = new Surface(4, 1);  // Only 4 columns - "日" won't fit after "ABC"
@@ -632,59 +635,59 @@ public class SurfaceTests
         // "ABC" takes 3 columns, "日" would need 2 more but only 1 remains
         surface.WriteText(0, 0, "ABC日");
         
-        Assert.Equal("A", surface[0, 0].Character);
-        Assert.Equal("B", surface[1, 0].Character);
-        Assert.Equal("C", surface[2, 0].Character);
+        Assert.AreEqual("A", surface[0, 0].Character);
+        Assert.AreEqual("B", surface[1, 0].Character);
+        Assert.AreEqual("C", surface[2, 0].Character);
         // Wide char doesn't fully fit, remaining space filled with space
-        Assert.Equal(" ", surface[3, 0].Character);
+        Assert.AreEqual(" ", surface[3, 0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteText_Emoji_HandlesAsWideCharacter()
     {
         var surface = new Surface(10, 1);
         
         surface.WriteText(0, 0, "😀");
         
-        Assert.Equal("😀", surface[0, 0].Character);
-        Assert.Equal(2, surface[0, 0].DisplayWidth);
-        Assert.True(surface[1, 0].IsContinuation);
+        Assert.AreEqual("😀", surface[0, 0].Character);
+        Assert.AreEqual(2, surface[0, 0].DisplayWidth);
+        Assert.IsTrue(surface[1, 0].IsContinuation);
     }
 
     #endregion
 
     #region WriteChar
 
-    [Fact]
+    [TestMethod]
     public void WriteChar_InBounds_WritesAndReturnsTrue()
     {
         var surface = new Surface(10, 5);
         
         var result = surface.WriteChar(3, 2, 'X', Hex1bColor.Red, Hex1bColor.Blue, CellAttributes.Bold);
         
-        Assert.True(result);
-        Assert.Equal("X", surface[3, 2].Character);
-        Assert.Equal(Hex1bColor.Red, surface[3, 2].Foreground);
-        Assert.Equal(Hex1bColor.Blue, surface[3, 2].Background);
-        Assert.Equal(CellAttributes.Bold, surface[3, 2].Attributes);
+        Assert.IsTrue(result);
+        Assert.AreEqual("X", surface[3, 2].Character);
+        Assert.AreEqual(Hex1bColor.Red, surface[3, 2].Foreground);
+        Assert.AreEqual(Hex1bColor.Blue, surface[3, 2].Background);
+        Assert.AreEqual(CellAttributes.Bold, surface[3, 2].Attributes);
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteChar_OutOfBounds_ReturnsFalse()
     {
         var surface = new Surface(10, 5);
         
-        Assert.False(surface.WriteChar(-1, 0, 'X'));
-        Assert.False(surface.WriteChar(10, 0, 'X'));
-        Assert.False(surface.WriteChar(0, -1, 'X'));
-        Assert.False(surface.WriteChar(0, 5, 'X'));
+        Assert.IsFalse(surface.WriteChar(-1, 0, 'X'));
+        Assert.IsFalse(surface.WriteChar(10, 0, 'X'));
+        Assert.IsFalse(surface.WriteChar(0, -1, 'X'));
+        Assert.IsFalse(surface.WriteChar(0, 5, 'X'));
     }
 
     #endregion
 
     #region Composite
 
-    [Fact]
+    [TestMethod]
     public void Composite_CopiesCellsToDestination()
     {
         var dest = new Surface(10, 5);
@@ -695,12 +698,12 @@ public class SurfaceTests
         
         dest.Composite(src, 2, 1);
         
-        Assert.Equal("A", dest[2, 1].Character);
-        Assert.Equal("B", dest[3, 1].Character);
-        Assert.Equal("C", dest[4, 1].Character);
+        Assert.AreEqual("A", dest[2, 1].Character);
+        Assert.AreEqual("B", dest[3, 1].Character);
+        Assert.AreEqual("C", dest[4, 1].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_WithOffset_PlacesCorrectly()
     {
         var dest = new Surface(10, 5);
@@ -710,11 +713,11 @@ public class SurfaceTests
         
         dest.Composite(src, 5, 3);
         
-        Assert.Equal("1", dest[5, 3].Character);
-        Assert.Equal("2", dest[6, 4].Character);
+        Assert.AreEqual("1", dest[5, 3].Character);
+        Assert.AreEqual("2", dest[6, 4].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_ClipsToDestinationBounds()
     {
         var dest = new Surface(5, 5);
@@ -727,12 +730,12 @@ public class SurfaceTests
         dest.Composite(src, 4, 0);
         
         // Only one column should be visible
-        Assert.Equal("X", dest[4, 0].Character);
-        Assert.Equal("X", dest[4, 1].Character);
-        Assert.Equal("X", dest[4, 2].Character);
+        Assert.AreEqual("X", dest[4, 0].Character);
+        Assert.AreEqual("X", dest[4, 1].Character);
+        Assert.AreEqual("X", dest[4, 2].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_TransparentBackground_ShowsDestinationBackground()
     {
         var dest = new Surface(10, 5);
@@ -744,12 +747,12 @@ public class SurfaceTests
         dest.Composite(src, 2, 1);
         
         var result = dest[3, 2];
-        Assert.Equal("X", result.Character);
-        Assert.Equal(Hex1bColor.Red, result.Foreground);
-        Assert.Equal(Hex1bColor.Blue, result.Background); // From destination
+        Assert.AreEqual("X", result.Character);
+        Assert.AreEqual(Hex1bColor.Red, result.Foreground);
+        Assert.AreEqual(Hex1bColor.Blue, result.Background); // From destination
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_WithClipRect_OnlyAffectsClippedRegion()
     {
         var dest = new Surface(10, 5);
@@ -762,22 +765,22 @@ public class SurfaceTests
         dest.Composite(src, 0, 0, clip);
         
         // Only cells within clip should be affected
-        Assert.Equal("X", dest[2, 1].Character);
-        Assert.Equal("X", dest[3, 1].Character);
-        Assert.Equal("X", dest[2, 2].Character);
-        Assert.Equal("X", dest[3, 2].Character);
+        Assert.AreEqual("X", dest[2, 1].Character);
+        Assert.AreEqual("X", dest[3, 1].Character);
+        Assert.AreEqual("X", dest[2, 2].Character);
+        Assert.AreEqual("X", dest[3, 2].Character);
         
         // Cells outside clip should be empty
-        Assert.Equal(SurfaceCells.Empty, dest[0, 0]);
-        Assert.Equal(SurfaceCells.Empty, dest[1, 1]);
-        Assert.Equal(SurfaceCells.Empty, dest[4, 1]);
+        Assert.AreEqual(SurfaceCells.Empty, dest[0, 0]);
+        Assert.AreEqual(SurfaceCells.Empty, dest[1, 1]);
+        Assert.AreEqual(SurfaceCells.Empty, dest[4, 1]);
     }
 
     #endregion
 
     #region Clone and Span
 
-    [Fact]
+    [TestMethod]
     public void Clone_CreatesIndependentCopy()
     {
         var original = new Surface(5, 3);
@@ -786,11 +789,11 @@ public class SurfaceTests
         var clone = original.Clone();
         clone[2, 1] = new SurfaceCell("Y", Hex1bColor.Blue, null);
         
-        Assert.Equal("X", original[2, 1].Character);
-        Assert.Equal("Y", clone[2, 1].Character);
+        Assert.AreEqual("X", original[2, 1].Character);
+        Assert.AreEqual("Y", clone[2, 1].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void AsSpan_ReturnsAllCells()
     {
         var surface = new Surface(3, 2);
@@ -799,12 +802,12 @@ public class SurfaceTests
         
         var span = surface.AsSpan();
         
-        Assert.Equal(6, span.Length);
-        Assert.Equal("A", span[0].Character);
-        Assert.Equal("B", span[5].Character); // Row-major: [2, 1] = 1*3 + 2 = 5
+        Assert.AreEqual(6, span.Length);
+        Assert.AreEqual("A", span[0].Character);
+        Assert.AreEqual("B", span[5].Character); // Row-major: [2, 1] = 1*3 + 2 = 5
     }
 
-    [Fact]
+    [TestMethod]
     public void GetRow_ReturnsCorrectRow()
     {
         var surface = new Surface(5, 3);
@@ -812,42 +815,42 @@ public class SurfaceTests
         
         var row = surface.GetRow(1);
         
-        Assert.Equal(5, row.Length);
-        Assert.Equal("H", row[0].Character);
-        Assert.Equal("o", row[4].Character);
+        Assert.AreEqual(5, row.Length);
+        Assert.AreEqual("H", row[0].Character);
+        Assert.AreEqual("o", row[4].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetRow_OutOfBounds_Throws()
     {
         var surface = new Surface(5, 3);
         
-        Assert.Throws<ArgumentOutOfRangeException>(() => surface.GetRow(-1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => surface.GetRow(3));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => surface.GetRow(-1));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => surface.GetRow(3));
     }
 
     #endregion
 
     #region CellMetrics
 
-    [Fact]
+    [TestMethod]
     public void Constructor_WithoutMetrics_UsesDefault()
     {
         var surface = new Surface(10, 10);
         
-        Assert.Equal(CellMetrics.Default, surface.CellMetrics);
+        Assert.AreEqual(CellMetrics.Default, surface.CellMetrics);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_WithMetrics_StoresMetrics()
     {
         var metrics = new CellMetrics(8, 16);
         var surface = new Surface(10, 10, metrics);
         
-        Assert.Equal(metrics, surface.CellMetrics);
+        Assert.AreEqual(metrics, surface.CellMetrics);
     }
 
-    [Fact]
+    [TestMethod]
     public void Clone_PreservesMetrics()
     {
         var metrics = new CellMetrics(12, 24);
@@ -855,19 +858,19 @@ public class SurfaceTests
         
         var clone = surface.Clone();
         
-        Assert.Equal(metrics, clone.CellMetrics);
+        Assert.AreEqual(metrics, clone.CellMetrics);
     }
 
-    [Fact]
+    [TestMethod]
     public void HasSixels_WhenNoSixels_ReturnsFalse()
     {
         var surface = new Surface(10, 10);
         surface.WriteText(0, 0, "Hello");
         
-        Assert.False(surface.HasSixels);
+        Assert.IsFalse(surface.HasSixels);
     }
 
-    [Fact]
+    [TestMethod]
     public void HasSixels_WhenSixelsPresent_ReturnsTrue()
     {
         var surface = new Surface(10, 10);
@@ -877,10 +880,10 @@ public class SurfaceTests
         
         surface[0, 0] = sixelCell;
         
-        Assert.True(surface.HasSixels);
+        Assert.IsTrue(surface.HasSixels);
     }
 
-    [Fact]
+    [TestMethod]
     public void HasSixels_WhenSixelRemoved_ReturnsFalse()
     {
         var surface = new Surface(10, 10);
@@ -889,13 +892,13 @@ public class SurfaceTests
         var sixelCell = new SurfaceCell(" ", null, null, Sixel: sixelRef);
         
         surface[0, 0] = sixelCell;
-        Assert.True(surface.HasSixels);
+        Assert.IsTrue(surface.HasSixels);
         
         surface[0, 0] = SurfaceCells.Empty;
-        Assert.False(surface.HasSixels);
+        Assert.IsFalse(surface.HasSixels);
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_WithMatchingMetrics_Succeeds()
     {
         var metrics = new CellMetrics(8, 16);
@@ -915,7 +918,7 @@ public class SurfaceTests
         target.Composite(source, 5, 5);
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_WithMismatchedMetrics_NoSixels_Succeeds()
     {
         var target = new Surface(20, 20, new CellMetrics(10, 20));
@@ -925,7 +928,7 @@ public class SurfaceTests
         target.Composite(source, 0, 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_WithMismatchedMetrics_WithSixels_Throws()
     {
         var target = new Surface(20, 20, new CellMetrics(10, 20));
@@ -937,11 +940,11 @@ public class SurfaceTests
         var sixelCell = new SurfaceCell(" ", null, null, Sixel: sixelRef);
         source[0, 0] = sixelCell;
         
-        var ex = Assert.Throws<InvalidOperationException>(() => target.Composite(source, 0, 0));
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() => target.Composite(source, 0, 0));
         Assert.Contains("CellMetrics differ", ex.Message);
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_SixelExtendsRightEdge_ClipsSixel()
     {
         var metrics = new CellMetrics(10, 20);
@@ -964,15 +967,15 @@ public class SurfaceTests
         
         // The sixel should be clipped to fit within bounds
         var resultCell = target[9, 0];
-        Assert.True(resultCell.HasSixel);
-        Assert.NotNull(resultCell.Sixel);
+        Assert.IsTrue(resultCell.HasSixel);
+        Assert.IsNotNull(resultCell.Sixel);
         
         // Clipped sixel should only span 1 cell (10 pixels) instead of 2 (20 pixels)
-        Assert.Equal(1, resultCell.Sixel.Data.WidthInCells);
-        Assert.Equal(10, resultCell.Sixel.Data.PixelWidth);
+        Assert.AreEqual(1, resultCell.Sixel.Data.WidthInCells);
+        Assert.AreEqual(10, resultCell.Sixel.Data.PixelWidth);
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_SixelExtendsBottomEdge_ClipsSixel()
     {
         var metrics = new CellMetrics(10, 20);
@@ -994,15 +997,15 @@ public class SurfaceTests
         target.Composite(source, 0, 9);
         
         var resultCell = target[0, 9];
-        Assert.True(resultCell.HasSixel);
-        Assert.NotNull(resultCell.Sixel);
+        Assert.IsTrue(resultCell.HasSixel);
+        Assert.IsNotNull(resultCell.Sixel);
         
         // Clipped sixel should only span 1 cell (20 pixels) instead of 2 (40 pixels)
-        Assert.Equal(1, resultCell.Sixel.Data.HeightInCells);
-        Assert.Equal(20, resultCell.Sixel.Data.PixelHeight);
+        Assert.AreEqual(1, resultCell.Sixel.Data.HeightInCells);
+        Assert.AreEqual(20, resultCell.Sixel.Data.PixelHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_SixelExtendsBothEdges_ClipsBothDimensions()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1024,17 +1027,17 @@ public class SurfaceTests
         target.Composite(source, 8, 8);
         
         var resultCell = target[8, 8];
-        Assert.True(resultCell.HasSixel);
-        Assert.NotNull(resultCell.Sixel);
+        Assert.IsTrue(resultCell.HasSixel);
+        Assert.IsNotNull(resultCell.Sixel);
         
         // Clipped sixel should span 2x2 cells
-        Assert.Equal(2, resultCell.Sixel.Data.WidthInCells);
-        Assert.Equal(2, resultCell.Sixel.Data.HeightInCells);
-        Assert.Equal(20, resultCell.Sixel.Data.PixelWidth);
-        Assert.Equal(40, resultCell.Sixel.Data.PixelHeight);
+        Assert.AreEqual(2, resultCell.Sixel.Data.WidthInCells);
+        Assert.AreEqual(2, resultCell.Sixel.Data.HeightInCells);
+        Assert.AreEqual(20, resultCell.Sixel.Data.PixelWidth);
+        Assert.AreEqual(40, resultCell.Sixel.Data.PixelHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_SixelFitsWithinBounds_NoClipping()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1056,15 +1059,15 @@ public class SurfaceTests
         target.Composite(source, 0, 0);
         
         var resultCell = target[0, 0];
-        Assert.True(resultCell.HasSixel);
+        Assert.IsTrue(resultCell.HasSixel);
         
         // Original sixel should be preserved (same reference)
-        Assert.Same(sixelRef, resultCell.Sixel);
-        Assert.Equal(2, resultCell.Sixel!.Data.WidthInCells);
-        Assert.Equal(20, resultCell.Sixel.Data.PixelWidth);
+        Assert.AreSame(sixelRef, resultCell.Sixel);
+        Assert.AreEqual(2, resultCell.Sixel!.Data.WidthInCells);
+        Assert.AreEqual(20, resultCell.Sixel.Data.PixelWidth);
     }
 
-    [Fact]
+    [TestMethod]
     public void Composite_SixelCompletelyOutsideBounds_RemovedFromCell()
     {
         var metrics = new CellMetrics(10, 20);
@@ -1084,7 +1087,7 @@ public class SurfaceTests
         // Nothing should be placed in target
         for (int y = 0; y < 10; y++)
             for (int x = 0; x < 10; x++)
-                Assert.False(target[x, y].HasSixel);
+                Assert.IsFalse(target[x, y].HasSixel);
     }
 
     #endregion
@@ -1093,32 +1096,33 @@ public class SurfaceTests
 /// <summary>
 /// Tests for <see cref="CompositeSurface"/> class.
 /// </summary>
+[TestClass]
 public class CompositeSurfaceTests
 {
     #region Construction
 
-    [Fact]
+    [TestMethod]
     public void Constructor_WithValidDimensions_CreatesCompositeSurface()
     {
         var composite = new CompositeSurface(80, 24);
         
-        Assert.Equal(80, composite.Width);
-        Assert.Equal(24, composite.Height);
-        Assert.Equal(0, composite.LayerCount);
+        Assert.AreEqual(80, composite.Width);
+        Assert.AreEqual(24, composite.Height);
+        Assert.AreEqual(0, composite.LayerCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_WithZeroDimensions_Throws()
     {
-        Assert.Throws<ArgumentOutOfRangeException>(() => new CompositeSurface(0, 10));
-        Assert.Throws<ArgumentOutOfRangeException>(() => new CompositeSurface(10, 0));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new CompositeSurface(0, 10));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new CompositeSurface(10, 0));
     }
 
     #endregion
 
     #region AddLayer
 
-    [Fact]
+    [TestMethod]
     public void AddLayer_IncreasesLayerCount()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1126,13 +1130,13 @@ public class CompositeSurfaceTests
         var layer2 = new Surface(5, 5);
         
         composite.AddLayer(layer1, 0, 0);
-        Assert.Equal(1, composite.LayerCount);
+        Assert.AreEqual(1, composite.LayerCount);
         
         composite.AddLayer(layer2, 2, 2);
-        Assert.Equal(2, composite.LayerCount);
+        Assert.AreEqual(2, composite.LayerCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void Clear_RemovesAllLayers()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1141,24 +1145,24 @@ public class CompositeSurfaceTests
         
         composite.Clear();
         
-        Assert.Equal(0, composite.LayerCount);
+        Assert.AreEqual(0, composite.LayerCount);
     }
 
     #endregion
 
     #region GetCell
 
-    [Fact]
+    [TestMethod]
     public void GetCell_NoLayers_ReturnsEmpty()
     {
         var composite = new CompositeSurface(10, 10);
         
         var cell = composite.GetCell(5, 5);
         
-        Assert.Equal(SurfaceCells.Empty, cell);
+        Assert.AreEqual(SurfaceCells.Empty, cell);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetCell_SingleLayer_ReturnsCellFromLayer()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1167,11 +1171,11 @@ public class CompositeSurfaceTests
         
         composite.AddLayer(layer, 0, 0);
         
-        Assert.Equal("X", composite.GetCell(2, 2).Character);
-        Assert.Equal(Hex1bColor.Red, composite.GetCell(2, 2).Foreground);
+        Assert.AreEqual("X", composite.GetCell(2, 2).Character);
+        Assert.AreEqual(Hex1bColor.Red, composite.GetCell(2, 2).Foreground);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetCell_WithOffset_ReturnsCorrectCell()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1181,24 +1185,24 @@ public class CompositeSurfaceTests
         composite.AddLayer(layer, 5, 5);
         
         // Layer starts at (5, 5), so layer[0,0] is at composite[5,5]
-        Assert.Equal("A", composite.GetCell(5, 5).Character);
-        Assert.Equal(SurfaceCells.Empty, composite.GetCell(0, 0));
+        Assert.AreEqual("A", composite.GetCell(5, 5).Character);
+        Assert.AreEqual(SurfaceCells.Empty, composite.GetCell(0, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void GetCell_OutOfBounds_Throws()
     {
         var composite = new CompositeSurface(10, 10);
         
-        Assert.Throws<ArgumentOutOfRangeException>(() => composite.GetCell(-1, 0));
-        Assert.Throws<ArgumentOutOfRangeException>(() => composite.GetCell(10, 0));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => composite.GetCell(-1, 0));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => composite.GetCell(10, 0));
     }
 
     #endregion
 
     #region Layer Ordering
 
-    [Fact]
+    [TestMethod]
     public void GetCell_OverlappingLayers_TopLayerWins()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1213,11 +1217,11 @@ public class CompositeSurfaceTests
         composite.AddLayer(top, 0, 0);     // Added second = top
         
         var cell = composite.GetCell(2, 2);
-        Assert.Equal("T", cell.Character);
-        Assert.Equal(Hex1bColor.Red, cell.Foreground);
+        Assert.AreEqual("T", cell.Character);
+        Assert.AreEqual(Hex1bColor.Red, cell.Foreground);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetCell_TransparentTopLayer_ShowsBottomBackground()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1232,12 +1236,12 @@ public class CompositeSurfaceTests
         composite.AddLayer(top, 0, 0);
         
         var cell = composite.GetCell(2, 2);
-        Assert.Equal("X", cell.Character);
-        Assert.Equal(Hex1bColor.Red, cell.Foreground);
-        Assert.Equal(Hex1bColor.Blue, cell.Background);  // From bottom layer
+        Assert.AreEqual("X", cell.Character);
+        Assert.AreEqual(Hex1bColor.Red, cell.Foreground);
+        Assert.AreEqual(Hex1bColor.Blue, cell.Background);  // From bottom layer
     }
 
-    [Fact]
+    [TestMethod]
     public void GetCell_PartiallyOverlappingLayers_ResolvesCorrectly()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1251,30 +1255,30 @@ public class CompositeSurfaceTests
         composite.AddLayer(layer1, 0, 0);
         composite.AddLayer(layer2, 3, 3);  // Overlaps from (3,3) to (5,5)
         
-        Assert.Equal("1", composite.GetCell(0, 0).Character);  // Only layer1
-        Assert.Equal("1", composite.GetCell(2, 2).Character);  // Only layer1
-        Assert.Equal("2", composite.GetCell(3, 3).Character);  // layer2 on top
-        Assert.Equal("2", composite.GetCell(5, 5).Character);  // Only layer2
-        Assert.Equal(SurfaceCells.Empty, composite.GetCell(6, 6));  // No layers
+        Assert.AreEqual("1", composite.GetCell(0, 0).Character);  // Only layer1
+        Assert.AreEqual("1", composite.GetCell(2, 2).Character);  // Only layer1
+        Assert.AreEqual("2", composite.GetCell(3, 3).Character);  // layer2 on top
+        Assert.AreEqual("2", composite.GetCell(5, 5).Character);  // Only layer2
+        Assert.AreEqual(SurfaceCells.Empty, composite.GetCell(6, 6));  // No layers
     }
 
     #endregion
 
     #region Flatten
 
-    [Fact]
+    [TestMethod]
     public void Flatten_NoLayers_ReturnsEmptySurface()
     {
         var composite = new CompositeSurface(5, 5);
         
         var result = composite.Flatten();
         
-        Assert.Equal(5, result.Width);
-        Assert.Equal(5, result.Height);
-        Assert.Equal(SurfaceCells.Empty, result[0, 0]);
+        Assert.AreEqual(5, result.Width);
+        Assert.AreEqual(5, result.Height);
+        Assert.AreEqual(SurfaceCells.Empty, result[0, 0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Flatten_SingleLayer_CopiesContent()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1284,12 +1288,12 @@ public class CompositeSurfaceTests
         composite.AddLayer(layer, 2, 3);
         var result = composite.Flatten();
         
-        Assert.Equal("H", result[2, 3].Character);
-        Assert.Equal("o", result[6, 3].Character);
-        Assert.Equal(Hex1bColor.Red, result[2, 3].Foreground);
+        Assert.AreEqual("H", result[2, 3].Character);
+        Assert.AreEqual("o", result[6, 3].Character);
+        Assert.AreEqual(Hex1bColor.Red, result[2, 3].Foreground);
     }
 
-    [Fact]
+    [TestMethod]
     public void Flatten_MultipleLayers_CompositesCorrectly()
     {
         var composite = new CompositeSurface(10, 5);
@@ -1306,14 +1310,14 @@ public class CompositeSurfaceTests
         var result = composite.Flatten();
         
         // Background visible outside content
-        Assert.Equal(Hex1bColor.DarkGray, result[0, 0].Background);
+        Assert.AreEqual(Hex1bColor.DarkGray, result[0, 0].Background);
         
         // Content visible at offset
-        Assert.Equal("T", result[2, 1].Character);
-        Assert.Equal(Hex1bColor.Blue, result[2, 1].Background);
+        Assert.AreEqual("T", result[2, 1].Character);
+        Assert.AreEqual(Hex1bColor.Blue, result[2, 1].Background);
     }
 
-    [Fact]
+    [TestMethod]
     public void Flatten_ReturnsIndependentSurface()
     {
         var composite = new CompositeSurface(5, 5);
@@ -1327,14 +1331,14 @@ public class CompositeSurfaceTests
         layer[2, 2] = new SurfaceCell("B", null, null);
         
         // Result should be unchanged
-        Assert.Equal("A", result[2, 2].Character);
+        Assert.AreEqual("A", result[2, 2].Character);
     }
 
     #endregion
 
     #region Nested Composition
 
-    [Fact]
+    [TestMethod]
     public void GetCell_NestedCompositeSurface_ResolvesRecursively()
     {
         // Create an inner composite
@@ -1349,11 +1353,11 @@ public class CompositeSurfaceTests
         
         // Inner layer[1,1] is at inner[2,2] is at outer[4,4]
         var cell = outer.GetCell(4, 4);
-        Assert.Equal("I", cell.Character);
-        Assert.Equal(Hex1bColor.Green, cell.Foreground);
+        Assert.AreEqual("I", cell.Character);
+        Assert.AreEqual(Hex1bColor.Green, cell.Foreground);
     }
 
-    [Fact]
+    [TestMethod]
     public void Flatten_NestedCompositeSurface_FlattensAll()
     {
         var inner = new CompositeSurface(5, 5);
@@ -1370,16 +1374,16 @@ public class CompositeSurfaceTests
         
         var result = outer.Flatten();
         
-        Assert.Equal(Hex1bColor.Gray, result[0, 0].Background);  // Background
-        Assert.Equal("I", result[3, 3].Character);  // Inner content
-        Assert.Equal("r", result[7, 3].Character);  // "Inner" at offset
+        Assert.AreEqual(Hex1bColor.Gray, result[0, 0].Background);  // Background
+        Assert.AreEqual("I", result[3, 3].Character);  // Inner content
+        Assert.AreEqual("r", result[7, 3].Character);  // "Inner" at offset
     }
 
     #endregion
 
     #region ISurfaceSource Interface
 
-    [Fact]
+    [TestMethod]
     public void TryGetCell_InBounds_ReturnsTrueAndCell()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1389,40 +1393,40 @@ public class CompositeSurfaceTests
         
         var result = composite.TryGetCell(2, 2, out var cell);
         
-        Assert.True(result);
-        Assert.Equal("X", cell.Character);
+        Assert.IsTrue(result);
+        Assert.AreEqual("X", cell.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void TryGetCell_OutOfBounds_ReturnsFalse()
     {
         var composite = new CompositeSurface(10, 10);
         
-        Assert.False(composite.TryGetCell(-1, 0, out _));
-        Assert.False(composite.TryGetCell(10, 0, out _));
+        Assert.IsFalse(composite.TryGetCell(-1, 0, out _));
+        Assert.IsFalse(composite.TryGetCell(10, 0, out _));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsInBounds_ValidPositions_ReturnsTrue()
     {
         var composite = new CompositeSurface(10, 10);
         
-        Assert.True(composite.IsInBounds(0, 0));
-        Assert.True(composite.IsInBounds(9, 9));
-        Assert.True(composite.IsInBounds(5, 5));
+        Assert.IsTrue(composite.IsInBounds(0, 0));
+        Assert.IsTrue(composite.IsInBounds(9, 9));
+        Assert.IsTrue(composite.IsInBounds(5, 5));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsInBounds_InvalidPositions_ReturnsFalse()
     {
         var composite = new CompositeSurface(10, 10);
         
-        Assert.False(composite.IsInBounds(-1, 0));
-        Assert.False(composite.IsInBounds(10, 0));
-        Assert.False(composite.IsInBounds(0, 10));
+        Assert.IsFalse(composite.IsInBounds(-1, 0));
+        Assert.IsFalse(composite.IsInBounds(10, 0));
+        Assert.IsFalse(composite.IsInBounds(0, 10));
     }
 
-    [Fact]
+    [TestMethod]
     public void Surface_Composite_AcceptsCompositeSurface()
     {
         var dest = new Surface(10, 10);
@@ -1435,41 +1439,41 @@ public class CompositeSurfaceTests
         // Composite a CompositeSurface onto a Surface
         dest.Composite(composite, 2, 2);
         
-        Assert.Equal("T", dest[2, 2].Character);
-        Assert.Equal("t", dest[5, 2].Character);
-        Assert.Equal(Hex1bColor.Red, dest[2, 2].Foreground);
+        Assert.AreEqual("T", dest[2, 2].Character);
+        Assert.AreEqual("t", dest[5, 2].Character);
+        Assert.AreEqual(Hex1bColor.Red, dest[2, 2].Foreground);
     }
 
     #endregion
 
     #region CellMetrics
 
-    [Fact]
+    [TestMethod]
     public void Constructor_WithoutMetrics_UsesDefault()
     {
         var composite = new CompositeSurface(10, 10);
         
-        Assert.Equal(CellMetrics.Default, composite.CellMetrics);
+        Assert.AreEqual(CellMetrics.Default, composite.CellMetrics);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_WithMetrics_StoresMetrics()
     {
         var metrics = new CellMetrics(8, 16);
         var composite = new CompositeSurface(10, 10, metrics);
         
-        Assert.Equal(metrics, composite.CellMetrics);
+        Assert.AreEqual(metrics, composite.CellMetrics);
     }
 
-    [Fact]
+    [TestMethod]
     public void HasSixels_WhenNoLayers_ReturnsFalse()
     {
         var composite = new CompositeSurface(10, 10);
         
-        Assert.False(composite.HasSixels);
+        Assert.IsFalse(composite.HasSixels);
     }
 
-    [Fact]
+    [TestMethod]
     public void HasSixels_WhenLayerWithSixels_ReturnsTrue()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1482,10 +1486,10 @@ public class CompositeSurfaceTests
         
         composite.AddLayer(layer, 0, 0);
         
-        Assert.True(composite.HasSixels);
+        Assert.IsTrue(composite.HasSixels);
     }
 
-    [Fact]
+    [TestMethod]
     public void AddLayer_WithMatchingMetrics_Succeeds()
     {
         var metrics = new CellMetrics(8, 16);
@@ -1499,10 +1503,10 @@ public class CompositeSurfaceTests
         
         // Should not throw
         composite.AddLayer(layer, 0, 0);
-        Assert.Equal(1, composite.LayerCount);
+        Assert.AreEqual(1, composite.LayerCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void AddLayer_WithMismatchedMetrics_NoSixels_Succeeds()
     {
         var composite = new CompositeSurface(20, 20, new CellMetrics(10, 20));
@@ -1510,10 +1514,10 @@ public class CompositeSurfaceTests
         
         // No sixels - should succeed
         composite.AddLayer(layer, 0, 0);
-        Assert.Equal(1, composite.LayerCount);
+        Assert.AreEqual(1, composite.LayerCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void AddLayer_WithMismatchedMetrics_WithSixels_Throws()
     {
         var composite = new CompositeSurface(20, 20, new CellMetrics(10, 20));
@@ -1524,7 +1528,7 @@ public class CompositeSurfaceTests
         var sixelCell = new SurfaceCell(" ", null, null, Sixel: sixelRef);
         layer[0, 0] = sixelCell;
         
-        var ex = Assert.Throws<InvalidOperationException>(() => composite.AddLayer(layer, 0, 0));
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() => composite.AddLayer(layer, 0, 0));
         Assert.Contains("CellMetrics differ", ex.Message);
     }
 
@@ -1534,21 +1538,22 @@ public class CompositeSurfaceTests
 /// <summary>
 /// Tests for computed cells in <see cref="CompositeSurface"/>.
 /// </summary>
+[TestClass]
 public class ComputedCellTests
 {
     #region Basic Computed Cells
 
-    [Fact]
+    [TestMethod]
     public void AddComputedLayer_CreatesLayerWithCompute()
     {
         var composite = new CompositeSurface(10, 10);
         
         composite.AddComputedLayer(5, 5, ctx => new SurfaceCell("C", Hex1bColor.Red, null), 0, 0);
         
-        Assert.Equal(1, composite.LayerCount);
+        Assert.AreEqual(1, composite.LayerCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputedLayer_ReturnsComputedCells()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1556,12 +1561,12 @@ public class ComputedCellTests
         composite.AddComputedLayer(5, 5, ctx => 
             new SurfaceCell($"{ctx.X},{ctx.Y}", Hex1bColor.Green, null), 0, 0);
         
-        Assert.Equal("0,0", composite.GetCell(0, 0).Character);
-        Assert.Equal("2,3", composite.GetCell(2, 3).Character);
-        Assert.Equal(Hex1bColor.Green, composite.GetCell(0, 0).Foreground);
+        Assert.AreEqual("0,0", composite.GetCell(0, 0).Character);
+        Assert.AreEqual("2,3", composite.GetCell(2, 3).Character);
+        Assert.AreEqual(Hex1bColor.Green, composite.GetCell(0, 0).Foreground);
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputedLayer_WithOffset_ComputesAtCorrectPosition()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1571,22 +1576,22 @@ public class ComputedCellTests
             new SurfaceCell("X", Hex1bColor.Blue, null), 3, 3);
         
         // Outside computed layer bounds
-        Assert.Equal(SurfaceCells.Empty, composite.GetCell(0, 0));
-        Assert.Equal(SurfaceCells.Empty, composite.GetCell(2, 2));
+        Assert.AreEqual(SurfaceCells.Empty, composite.GetCell(0, 0));
+        Assert.AreEqual(SurfaceCells.Empty, composite.GetCell(2, 2));
         
         // Inside computed layer bounds
-        Assert.Equal("X", composite.GetCell(3, 3).Character);
-        Assert.Equal("X", composite.GetCell(7, 7).Character);
+        Assert.AreEqual("X", composite.GetCell(3, 3).Character);
+        Assert.AreEqual("X", composite.GetCell(7, 7).Character);
         
         // Just outside computed layer
-        Assert.Equal(SurfaceCells.Empty, composite.GetCell(8, 8));
+        Assert.AreEqual(SurfaceCells.Empty, composite.GetCell(8, 8));
     }
 
     #endregion
 
     #region GetBelow
 
-    [Fact]
+    [TestMethod]
     public void GetBelow_ReturnsContentFromLayerBelow()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1604,12 +1609,12 @@ public class ComputedCellTests
         }, 0, 0);
         
         var cell = composite.GetCell(5, 5);
-        Assert.Equal("X", cell.Character);
-        Assert.Equal(Hex1bColor.White, cell.Foreground);
-        Assert.Equal(Hex1bColor.Blue, cell.Background);  // From layer below
+        Assert.AreEqual("X", cell.Character);
+        Assert.AreEqual(Hex1bColor.White, cell.Foreground);
+        Assert.AreEqual(Hex1bColor.Blue, cell.Background);  // From layer below
     }
 
-    [Fact]
+    [TestMethod]
     public void GetBelow_WithMultipleLayers_CompositesAllBelow()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1632,13 +1637,13 @@ public class ComputedCellTests
         }, 0, 0);
         
         // At (2, 2): green from layer1 (on top of red from layer0)
-        Assert.Equal(Hex1bColor.Green, composite.GetCell(2, 2).Background);
+        Assert.AreEqual(Hex1bColor.Green, composite.GetCell(2, 2).Background);
         
         // At (7, 7): red from layer0 (layer1 doesn't cover this)
-        Assert.Equal(Hex1bColor.Red, composite.GetCell(7, 7).Background);
+        Assert.AreEqual(Hex1bColor.Red, composite.GetCell(7, 7).Background);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetBelowAt_ReturnsContentAtDifferentPosition()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1658,16 +1663,16 @@ public class ComputedCellTests
         
         // Any position should have the content from (5, 5) below
         var result = composite.GetCell(0, 0);
-        Assert.Equal("B", result.Character);
-        Assert.Equal(Hex1bColor.Red, result.Foreground);
-        Assert.Equal(Hex1bColor.Blue, result.Background);
+        Assert.AreEqual("B", result.Character);
+        Assert.AreEqual(Hex1bColor.Red, result.Foreground);
+        Assert.AreEqual(Hex1bColor.Blue, result.Background);
     }
 
     #endregion
 
     #region GetAdjacent
 
-    [Fact]
+    [TestMethod]
     public void GetAdjacent_ReturnsNeighborCell()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1685,12 +1690,12 @@ public class ComputedCellTests
         }, 0, 0);
         
         // Cell at (0, 0) should have character from below at (1, 0) = "B"
-        Assert.Equal("B", composite.GetCell(0, 0).Character);
-        Assert.Equal("C", composite.GetCell(1, 0).Character);
-        Assert.Equal("D", composite.GetCell(2, 0).Character);
+        Assert.AreEqual("B", composite.GetCell(0, 0).Character);
+        Assert.AreEqual("C", composite.GetCell(1, 0).Character);
+        Assert.AreEqual("D", composite.GetCell(2, 0).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetAdjacent_OnMixedLayer_ReturnsStaticNeighbor()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1707,11 +1712,11 @@ public class ComputedCellTests
         // other cells on the same layer. The GetBelowAt test above covers the main use case.
         
         // Verify the static layer is accessible
-        Assert.Equal("H", composite.GetCell(0, 0).Character);
-        Assert.Equal("e", composite.GetCell(1, 0).Character);
+        Assert.AreEqual("H", composite.GetCell(0, 0).Character);
+        Assert.AreEqual("e", composite.GetCell(1, 0).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetAdjacent_OutOfBounds_ReturnsEmpty()
     {
         var composite = new CompositeSurface(5, 5);
@@ -1726,14 +1731,14 @@ public class ComputedCellTests
         
         // At x=0, there's no cell to the left, should return empty (unwritten marker)
         var result = composite.GetCell(0, 0);
-        Assert.Equal(SurfaceCells.UnwrittenMarker, result.Character);  // Empty cell uses unwritten marker
+        Assert.AreEqual(SurfaceCells.UnwrittenMarker, result.Character);  // Empty cell uses unwritten marker
     }
 
     #endregion
 
     #region Cycle Detection
 
-    [Fact]
+    [TestMethod]
     public void ComputedCell_SelfReference_ReturnsFallback()
     {
         var composite = new CompositeSurface(5, 5);
@@ -1748,10 +1753,10 @@ public class ComputedCellTests
         
         // Should not throw and should return a value
         var result = composite.GetCell(2, 2);
-        Assert.Equal("X", result.Character);
+        Assert.AreEqual("X", result.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputedCell_MutualReference_ReturnsFallback()
     {
         var composite = new CompositeSurface(10, 5);
@@ -1766,18 +1771,18 @@ public class ComputedCellTests
         
         // At x=9, the cell to the right is out of bounds (empty/unwritten marker)
         var rightmost = composite.GetCell(9, 0);
-        Assert.Equal($"[{SurfaceCells.UnwrittenMarker}]", rightmost.Character);  // Empty cell has unwritten marker
+        Assert.AreEqual($"[{SurfaceCells.UnwrittenMarker}]", rightmost.Character);  // Empty cell has unwritten marker
         
         // At x=8, it reads from x=9
         var cell8 = composite.GetCell(8, 0);
-        Assert.Equal($"[[{SurfaceCells.UnwrittenMarker}]]", cell8.Character);
+        Assert.AreEqual($"[[{SurfaceCells.UnwrittenMarker}]]", cell8.Character);
     }
 
     #endregion
 
     #region CellEffects
 
-    [Fact]
+    [TestMethod]
     public void DropShadow_DarkensBackground()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1793,13 +1798,13 @@ public class ComputedCellTests
         var cell = composite.GetCell(5, 5);
         
         // White (255, 255, 255) darkened by 50% = (127, 127, 127)
-        Assert.NotNull(cell.Background);
-        Assert.Equal(127, cell.Background.Value.R);
-        Assert.Equal(127, cell.Background.Value.G);
-        Assert.Equal(127, cell.Background.Value.B);
+        Assert.IsNotNull(cell.Background);
+        Assert.AreEqual(127, cell.Background.Value.R);
+        Assert.AreEqual(127, cell.Background.Value.G);
+        Assert.AreEqual(127, cell.Background.Value.B);
     }
 
-    [Fact]
+    [TestMethod]
     public void Tint_AppliesColorOverlay()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1818,13 +1823,13 @@ public class ComputedCellTests
         // R: 255 * 0.5 + 255 * 0.5 = 255
         // G: 255 * 0.5 + 0 * 0.5 = 127
         // B: 255 * 0.5 + 0 * 0.5 = 127
-        Assert.NotNull(cell.Background);
-        Assert.Equal(255, cell.Background.Value.R);
-        Assert.Equal(127, cell.Background.Value.G);
-        Assert.Equal(127, cell.Background.Value.B);
+        Assert.IsNotNull(cell.Background);
+        Assert.AreEqual(255, cell.Background.Value.R);
+        Assert.AreEqual(127, cell.Background.Value.G);
+        Assert.AreEqual(127, cell.Background.Value.B);
     }
 
-    [Fact]
+    [TestMethod]
     public void Passthrough_ReturnsCellBelow()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1838,12 +1843,12 @@ public class ComputedCellTests
         composite.AddComputedLayer(10, 10, CellEffects.Passthrough(), 0, 0);
         
         var cell = composite.GetCell(5, 5);
-        Assert.Equal("X", cell.Character);
-        Assert.Equal(Hex1bColor.Red, cell.Foreground);
-        Assert.Equal(Hex1bColor.Blue, cell.Background);
+        Assert.AreEqual("X", cell.Character);
+        Assert.AreEqual(Hex1bColor.Red, cell.Foreground);
+        Assert.AreEqual(Hex1bColor.Blue, cell.Background);
     }
 
-    [Fact]
+    [TestMethod]
     public void Conditional_AppliesCorrectEffect()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1864,15 +1869,15 @@ public class ComputedCellTests
         var evenCell = composite.GetCell(0, 0);  // 0+0=0, even
         var oddCell = composite.GetCell(1, 0);   // 1+0=1, odd
         
-        Assert.Equal(127, evenCell.Background!.Value.R);  // Darkened
-        Assert.Equal(255, oddCell.Background!.Value.R);   // Unchanged
+        Assert.AreEqual(127, evenCell.Background!.Value.R);  // Darkened
+        Assert.AreEqual(255, oddCell.Background!.Value.R);   // Unchanged
     }
 
     #endregion
 
     #region Flatten with Computed Cells
 
-    [Fact]
+    [TestMethod]
     public void Flatten_IncludesComputedCells()
     {
         var composite = new CompositeSurface(5, 5);
@@ -1888,12 +1893,12 @@ public class ComputedCellTests
         
         var result = composite.Flatten();
         
-        Assert.Equal("C", result[2, 2].Character);
-        Assert.Equal(Hex1bColor.White, result[2, 2].Foreground);
-        Assert.Equal(Hex1bColor.Blue, result[2, 2].Background);
+        Assert.AreEqual("C", result[2, 2].Character);
+        Assert.AreEqual(Hex1bColor.White, result[2, 2].Foreground);
+        Assert.AreEqual(Hex1bColor.Blue, result[2, 2].Background);
     }
 
-    [Fact]
+    [TestMethod]
     public void Flatten_ComputedLayerAtOffset_PositionsCorrectly()
     {
         var composite = new CompositeSurface(10, 10);
@@ -1905,15 +1910,15 @@ public class ComputedCellTests
         var result = composite.Flatten();
         
         // Outside computed region
-        Assert.Equal(SurfaceCells.Empty, result[0, 0]);
-        Assert.Equal(SurfaceCells.Empty, result[3, 3]);
+        Assert.AreEqual(SurfaceCells.Empty, result[0, 0]);
+        Assert.AreEqual(SurfaceCells.Empty, result[3, 3]);
         
         // Inside computed region
-        Assert.Equal("X", result[4, 4].Character);
-        Assert.Equal("X", result[6, 6].Character);
+        Assert.AreEqual("X", result[4, 4].Character);
+        Assert.AreEqual("X", result[6, 6].Character);
         
         // Just outside
-        Assert.Equal(SurfaceCells.Empty, result[7, 7]);
+        Assert.AreEqual(SurfaceCells.Empty, result[7, 7]);
     }
 
     #endregion
@@ -1922,25 +1927,26 @@ public class ComputedCellTests
 /// <summary>
 /// Tests for <see cref="SurfaceDiff"/> and <see cref="SurfaceComparer"/>.
 /// </summary>
+[TestClass]
 public class SurfaceDiffTests
 {
     #region SurfaceDiff Construction
 
-    [Fact]
+    [TestMethod]
     public void SurfaceDiff_Empty_HasNoChangedCells()
     {
         var diff = SurfaceDiff.Empty;
 
-        Assert.True(diff.IsEmpty);
-        Assert.Equal(0, diff.Count);
-        Assert.Empty(diff.ChangedCells);
+        Assert.IsTrue(diff.IsEmpty);
+        Assert.AreEqual(0, diff.Count);
+        Assert.IsEmpty(diff.ChangedCells);
     }
 
     #endregion
 
     #region SurfaceComparer.Compare
 
-    [Fact]
+    [TestMethod]
     public void Compare_IdenticalSurfaces_ReturnsEmptyDiff()
     {
         var surface1 = new Surface(5, 5);
@@ -1951,10 +1957,10 @@ public class SurfaceDiffTests
 
         var diff = SurfaceComparer.Compare(surface1, surface2);
 
-        Assert.True(diff.IsEmpty);
+        Assert.IsTrue(diff.IsEmpty);
     }
 
-    [Fact]
+    [TestMethod]
     public void Compare_SingleCellChanged_ReturnsOneCellInDiff()
     {
         var previous = new Surface(5, 5);
@@ -1966,13 +1972,13 @@ public class SurfaceDiffTests
 
         var diff = SurfaceComparer.Compare(previous, current);
 
-        Assert.Equal(1, diff.Count);
-        Assert.Equal(2, diff.ChangedCells[0].X);
-        Assert.Equal(2, diff.ChangedCells[0].Y);
-        Assert.Equal("B", diff.ChangedCells[0].Cell.Character);
+        Assert.AreEqual(1, diff.Count);
+        Assert.AreEqual(2, diff.ChangedCells[0].X);
+        Assert.AreEqual(2, diff.ChangedCells[0].Y);
+        Assert.AreEqual("B", diff.ChangedCells[0].Cell.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Compare_MultipleCellsChanged_ReturnsSortedByRowThenColumn()
     {
         var previous = new Surface(5, 5);
@@ -1986,16 +1992,16 @@ public class SurfaceDiffTests
 
         var diff = SurfaceComparer.Compare(previous, current);
 
-        Assert.Equal(4, diff.Count);
+        Assert.AreEqual(4, diff.Count);
         
         // Should be sorted by Y then X
-        Assert.Equal((0, 0), (diff.ChangedCells[0].X, diff.ChangedCells[0].Y)); // Z
-        Assert.Equal((2, 1), (diff.ChangedCells[1].X, diff.ChangedCells[1].Y)); // W
-        Assert.Equal((3, 1), (diff.ChangedCells[2].X, diff.ChangedCells[2].Y)); // X
-        Assert.Equal((1, 2), (diff.ChangedCells[3].X, diff.ChangedCells[3].Y)); // Y
+        Assert.AreEqual((0, 0), (diff.ChangedCells[0].X, diff.ChangedCells[0].Y)); // Z
+        Assert.AreEqual((2, 1), (diff.ChangedCells[1].X, diff.ChangedCells[1].Y)); // W
+        Assert.AreEqual((3, 1), (diff.ChangedCells[2].X, diff.ChangedCells[2].Y)); // X
+        Assert.AreEqual((1, 2), (diff.ChangedCells[3].X, diff.ChangedCells[3].Y)); // Y
     }
 
-    [Fact]
+    [TestMethod]
     public void Compare_ColorChange_DetectsAsChange()
     {
         var previous = new Surface(3, 3);
@@ -2006,11 +2012,11 @@ public class SurfaceDiffTests
 
         var diff = SurfaceComparer.Compare(previous, current);
 
-        Assert.Equal(1, diff.Count);
-        Assert.Equal(Hex1bColor.Blue, diff.ChangedCells[0].Cell.Foreground);
+        Assert.AreEqual(1, diff.Count);
+        Assert.AreEqual(Hex1bColor.Blue, diff.ChangedCells[0].Cell.Foreground);
     }
 
-    [Fact]
+    [TestMethod]
     public void Compare_AttributeChange_DetectsAsChange()
     {
         var previous = new Surface(3, 3);
@@ -2021,20 +2027,20 @@ public class SurfaceDiffTests
 
         var diff = SurfaceComparer.Compare(previous, current);
 
-        Assert.Equal(1, diff.Count);
-        Assert.Equal(CellAttributes.Bold, diff.ChangedCells[0].Cell.Attributes);
+        Assert.AreEqual(1, diff.Count);
+        Assert.AreEqual(CellAttributes.Bold, diff.ChangedCells[0].Cell.Attributes);
     }
 
-    [Fact]
+    [TestMethod]
     public void Compare_DifferentSizes_ThrowsArgumentException()
     {
         var surface1 = new Surface(5, 5);
         var surface2 = new Surface(3, 3);
 
-        Assert.Throws<ArgumentException>(() => SurfaceComparer.Compare(surface1, surface2));
+        Assert.ThrowsExactly<ArgumentException>(() => SurfaceComparer.Compare(surface1, surface2));
     }
 
-    [Fact]
+    [TestMethod]
     public void CompareToEmpty_NonEmptySurface_ReturnsAllNonEmptyCells()
     {
         var surface = new Surface(3, 3);
@@ -2043,42 +2049,42 @@ public class SurfaceDiffTests
 
         var diff = SurfaceComparer.CompareToEmpty(surface);
 
-        Assert.Equal(2, diff.Count);
+        Assert.AreEqual(2, diff.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void CompareToEmpty_EmptySurface_ReturnsEmptyDiff()
     {
         var surface = new Surface(3, 3);
 
         var diff = SurfaceComparer.CompareToEmpty(surface);
 
-        Assert.True(diff.IsEmpty);
+        Assert.IsTrue(diff.IsEmpty);
     }
 
-    [Fact]
+    [TestMethod]
     public void CreateFullDiff_ReturnsAllCells()
     {
         var surface = new Surface(3, 3);
 
         var diff = SurfaceComparer.CreateFullDiff(surface);
 
-        Assert.Equal(9, diff.Count);
+        Assert.AreEqual(9, diff.Count);
     }
 
     #endregion
 
     #region SurfaceComparer.ToTokens
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_EmptyDiff_ReturnsEmptyList()
     {
         var tokens = SurfaceComparer.ToTokens(SurfaceDiff.Empty);
 
-        Assert.Empty(tokens);
+        Assert.IsEmpty(tokens);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_SingleCell_GeneratesPositionAndText()
     {
         var previous = new Surface(5, 5);
@@ -2089,11 +2095,11 @@ public class SurfaceDiffTests
         var tokens = SurfaceComparer.ToTokens(diff);
 
         // Should have: CursorPosition, SGR (for reset), Text
-        Assert.Contains(tokens, t => t is CursorPositionToken pos && pos.Row == 4 && pos.Column == 3); // 1-based
-        Assert.Contains(tokens, t => t is TextToken txt && txt.Text == "X");
+        Assert.IsTrue(tokens.Any(t => t is CursorPositionToken pos && pos.Row == 4 && pos.Column == 3)); // 1-based
+        Assert.IsTrue(tokens.Any(t => t is TextToken txt && txt.Text == "X"));
     }
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_ConsecutiveCellsOnRow_OmitsExtraCursorPositions()
     {
         var previous = new Surface(10, 1);
@@ -2107,12 +2113,12 @@ public class SurfaceDiffTests
 
         // Should only have 1 cursor position for the start
         var cursorPositions = tokens.OfType<CursorPositionToken>().ToList();
-        Assert.Single(cursorPositions);
-        Assert.Equal(1, cursorPositions[0].Row);
-        Assert.Equal(1, cursorPositions[0].Column);
+        TestSeq.Single(cursorPositions);
+        Assert.AreEqual(1, cursorPositions[0].Row);
+        Assert.AreEqual(1, cursorPositions[0].Column);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_CellWithColors_GeneratesSgrWithColors()
     {
         var previous = new Surface(5, 5);
@@ -2123,13 +2129,13 @@ public class SurfaceDiffTests
         var tokens = SurfaceComparer.ToTokens(diff);
 
         var sgr = tokens.OfType<SgrToken>().FirstOrDefault();
-        Assert.NotNull(sgr);
+        Assert.IsNotNull(sgr);
         // Should contain foreground (38;2;255;0;0) and background (48;2;0;0;255)
         Assert.Contains("38;2;255;0;0", sgr.Parameters);
         Assert.Contains("48;2;0;0;255", sgr.Parameters);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_CellWithBoldAttribute_GeneratesSgrWithBold()
     {
         var previous = new Surface(5, 5);
@@ -2140,12 +2146,12 @@ public class SurfaceDiffTests
         var tokens = SurfaceComparer.ToTokens(diff);
 
         var sgr = tokens.OfType<SgrToken>().FirstOrDefault();
-        Assert.NotNull(sgr);
+        Assert.IsNotNull(sgr);
         // Bold is SGR code 1
         Assert.Contains("1", sgr.Parameters.Split(';'));
     }
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_SameAttributesConsecutive_DoesNotRepeatSgr()
     {
         var previous = new Surface(10, 1);
@@ -2159,10 +2165,10 @@ public class SurfaceDiffTests
 
         // Only 1 SGR token needed since all cells have same attributes
         var sgrTokens = tokens.OfType<SgrToken>().ToList();
-        Assert.Single(sgrTokens);
+        TestSeq.Single(sgrTokens);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_WideCharacter_SkipsContinuationCell()
     {
         var previous = new Surface(10, 1);
@@ -2174,11 +2180,11 @@ public class SurfaceDiffTests
 
         // Should only have one text token with "你", not the continuation
         var textTokens = tokens.OfType<TextToken>().ToList();
-        Assert.Single(textTokens);
-        Assert.Equal("你", textTokens[0].Text);
+        TestSeq.Single(textTokens);
+        Assert.AreEqual("你", textTokens[0].Text);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_WideCharacter_AdvancesCursorCorrectly()
     {
         var previous = new Surface(10, 1);
@@ -2191,22 +2197,22 @@ public class SurfaceDiffTests
         // Should only have 1 cursor position (at start)
         // Because after "你" (width 2), cursor is at 2, which is where "好" is
         var cursorPositions = tokens.OfType<CursorPositionToken>().ToList();
-        Assert.Single(cursorPositions);
+        TestSeq.Single(cursorPositions);
     }
 
     #endregion
 
     #region SurfaceComparer.ToAnsiString
 
-    [Fact]
+    [TestMethod]
     public void ToAnsiString_EmptyDiff_ReturnsEmptyString()
     {
         var result = SurfaceComparer.ToAnsiString(SurfaceDiff.Empty);
 
-        Assert.Equal(string.Empty, result);
+        Assert.AreEqual(string.Empty, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToAnsiString_SingleCell_ContainsCorrectSequences()
     {
         var previous = new Surface(5, 5);
@@ -2222,7 +2228,7 @@ public class SurfaceDiffTests
         Assert.Contains("X", result);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToAnsiString_CellWithRed_ContainsColorSequence()
     {
         var previous = new Surface(3, 3);
@@ -2240,7 +2246,7 @@ public class SurfaceDiffTests
 
     #region SGR Parameter Generation
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_MultipleAttributes_CombinesInSingleSgr()
     {
         var previous = new Surface(3, 3);
@@ -2251,13 +2257,13 @@ public class SurfaceDiffTests
         var tokens = SurfaceComparer.ToTokens(diff);
 
         var sgr = tokens.OfType<SgrToken>().FirstOrDefault();
-        Assert.NotNull(sgr);
+        Assert.IsNotNull(sgr);
         var parts = sgr.Parameters.Split(';');
         Assert.Contains("1", parts); // Bold
         Assert.Contains("4", parts); // Underline
     }
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_AttributeTurnedOff_ResetsFirst()
     {
         // Simulate state where we're transitioning from bold to no-bold
@@ -2271,13 +2277,13 @@ public class SurfaceDiffTests
         var tokens = SurfaceComparer.ToTokens(diff);
 
         var sgrTokens = tokens.OfType<SgrToken>().ToList();
-        Assert.True(sgrTokens.Count >= 2); // At least 2: one for bold, one for reset
+        Assert.IsTrue(sgrTokens.Count >= 2); // At least 2: one for bold, one for reset
         
         // Second SGR should start with reset (0)
         Assert.StartsWith("0", sgrTokens[1].Parameters);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_ItalicAttribute_UsesSgrCode3()
     {
         var previous = new Surface(3, 3);
@@ -2288,11 +2294,11 @@ public class SurfaceDiffTests
         var tokens = SurfaceComparer.ToTokens(diff);
 
         var sgr = tokens.OfType<SgrToken>().FirstOrDefault();
-        Assert.NotNull(sgr);
+        Assert.IsNotNull(sgr);
         Assert.Contains("3", sgr.Parameters.Split(';'));
     }
 
-    [Fact]
+    [TestMethod]
     public void ToTokens_StrikethroughAttribute_UsesSgrCode9()
     {
         var previous = new Surface(3, 3);
@@ -2303,7 +2309,7 @@ public class SurfaceDiffTests
         var tokens = SurfaceComparer.ToTokens(diff);
 
         var sgr = tokens.OfType<SgrToken>().FirstOrDefault();
-        Assert.NotNull(sgr);
+        Assert.IsNotNull(sgr);
         Assert.Contains("9", sgr.Parameters.Split(';'));
     }
 

--- a/tests/Hex1b.Tests/TabPanelNodeTests.cs
+++ b/tests/Hex1b.Tests/TabPanelNodeTests.cs
@@ -9,11 +9,12 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for TabPanelNode layout, rendering, tab switching, and keyboard navigation.
 /// </summary>
+[TestClass]
 public class TabPanelNodeTests
 {
     #region Basic Rendering Tests
 
-    [Fact]
+    [TestMethod]
     public async Task TabPanel_Renders_TabBar_And_Content()
     {
         // Arrange
@@ -41,19 +42,19 @@ public class TabPanelNodeTests
         await runTask;
 
         // Assert - Tab bar shows both tabs, content shows first tab
-        Assert.True(snapshot.ContainsText("Tab One"), "Should show first tab title");
-        Assert.True(snapshot.ContainsText("Tab Two"), "Should show second tab title");
-        Assert.True(snapshot.ContainsText("Content One"), "Should show first tab content");
-        Assert.False(snapshot.ContainsText("Content Two"), "Should not show second tab content");
+        Assert.IsTrue(snapshot.ContainsText("Tab One"), "Should show first tab title");
+        Assert.IsTrue(snapshot.ContainsText("Tab Two"), "Should show second tab title");
+        Assert.IsTrue(snapshot.ContainsText("Content One"), "Should show first tab content");
+        Assert.IsFalse(snapshot.ContainsText("Content Two"), "Should not show second tab content");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TabPanel_WideTabTitle_UsesDisplayWidthForSelectedIndicator()
     {
         // Arrange
         const string title = "한국어 제목";
         var expectedTabWidth = DisplayWidth.GetStringWidth(title) + 2;
-        Assert.True(expectedTabWidth > title.Length + 2, "Test title must contain wide characters.");
+        Assert.IsTrue(expectedTabWidth > title.Length + 2, "Test title must contain wide characters.");
 
         using var workload = new Hex1bAppWorkloadAdapter();
         using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(40, 8).Build();
@@ -78,13 +79,13 @@ public class TabPanelNodeTests
         // Assert - the selected-tab indicator spans the full display width of the wide title.
         for (var x = 0; x < expectedTabWidth; x++)
         {
-            Assert.Equal("▁", snapshot.GetCell(x, 0).Character);
+            Assert.AreEqual("▁", snapshot.GetCell(x, 0).Character);
         }
 
-        Assert.NotEqual("▁", snapshot.GetCell(expectedTabWidth, 0).Character);
+        Assert.AreNotEqual("▁", snapshot.GetCell(expectedTabWidth, 0).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TabPanel_AltRight_SwitchesToNextTab()
     {
         // Arrange
@@ -114,11 +115,11 @@ public class TabPanelNodeTests
         await runTask;
 
         // Assert - Should now show second tab content
-        Assert.True(snapshot.ContainsText("Content Two"), "Should show second tab content after Alt+Right");
-        Assert.False(snapshot.ContainsText("Content One"), "Should not show first tab content after switch");
+        Assert.IsTrue(snapshot.ContainsText("Content Two"), "Should show second tab content after Alt+Right");
+        Assert.IsFalse(snapshot.ContainsText("Content One"), "Should not show first tab content after switch");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TabPanel_AltLeft_SwitchesToPreviousTab()
     {
         // Arrange
@@ -151,14 +152,14 @@ public class TabPanelNodeTests
         await runTask;
 
         // Assert - Should now show first tab content
-        Assert.True(snapshot.ContainsText("Content One"), "Should show first tab content after Alt+Left");
+        Assert.IsTrue(snapshot.ContainsText("Content One"), "Should show first tab content after Alt+Left");
     }
 
     #endregion
 
     #region Orientation Tests
 
-    [Fact]
+    [TestMethod]
     public async Task TabPanel_InVStack_FirstPosition_TabsOnTop()
     {
         // Arrange
@@ -190,7 +191,7 @@ public class TabPanelNodeTests
         Assert.Contains("TopTab", line1);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TabPanel_WithTabsOnBottom_TabsRenderAtBottom()
     {
         // Arrange
@@ -228,14 +229,14 @@ public class TabPanelNodeTests
                 break;
             }
         }
-        Assert.True(found, "Tab should be in bottom half of screen");
+        Assert.IsTrue(found, "Tab should be in bottom half of screen");
     }
 
     #endregion
 
     #region Selection Changed Event Tests
 
-    [Fact]
+    [TestMethod]
     public async Task TabPanel_OnSelectionChanged_FiresWhenTabSwitches()
     {
         // Arrange
@@ -271,15 +272,15 @@ public class TabPanelNodeTests
         await runTask;
 
         // Assert
-        Assert.True(selectionChangedFired, "Selection changed event should fire");
-        Assert.Equal(1, newIndex);
+        Assert.IsTrue(selectionChangedFired, "Selection changed event should fire");
+        Assert.AreEqual(1, newIndex);
     }
 
     #endregion
 
     #region Tab Wrapping Tests
 
-    [Fact]
+    [TestMethod]
     public async Task TabPanel_AltRight_OnLastTab_WrapsToFirst()
     {
         // Arrange
@@ -312,14 +313,14 @@ public class TabPanelNodeTests
         await runTask;
 
         // Assert - Should wrap to first tab
-        Assert.True(snapshot.ContainsText("Content One"), "Should wrap to first tab");
+        Assert.IsTrue(snapshot.ContainsText("Content One"), "Should wrap to first tab");
     }
 
     #endregion
 
     #region Selector Dropdown Tests
 
-    [Fact]
+    [TestMethod]
     public async Task TabPanel_SelectorDropdown_AppearsNearTabBar()
     {
         // Arrange - Create a demo-like layout with menu bar, splitter, and tab panel
@@ -372,7 +373,7 @@ public class TabPanelNodeTests
 
         // Find the ▼ selector button position
         var selectorPosition = FindTextPosition(initialSnapshot, "▼");
-        Assert.True(selectorPosition.HasValue, "Should find selector button ▼ in the rendered output");
+        Assert.IsTrue(selectorPosition.HasValue, "Should find selector button ▼ in the rendered output");
         
         var (selectorX, selectorY) = selectorPosition!.Value;
         
@@ -391,16 +392,15 @@ public class TabPanelNodeTests
         var dropdownPosition = FindTextPosition(afterClickSnapshot, "Document1.cs", startAfterRow: selectorY);
         
         // The dropdown should contain all tab titles in a list format
-        Assert.True(afterClickSnapshot.ContainsText("Document1.cs"), "Dropdown should contain Document1.cs");
-        Assert.True(afterClickSnapshot.ContainsText("Document2.cs"), "Dropdown should contain Document2.cs");
-        Assert.True(afterClickSnapshot.ContainsText("README.md"), "Dropdown should contain README.md");
+        Assert.IsTrue(afterClickSnapshot.ContainsText("Document1.cs"), "Dropdown should contain Document1.cs");
+        Assert.IsTrue(afterClickSnapshot.ContainsText("Document2.cs"), "Dropdown should contain Document2.cs");
+        Assert.IsTrue(afterClickSnapshot.ContainsText("README.md"), "Dropdown should contain README.md");
         
         // The dropdown should appear close to the selector (within 5 rows)
         if (dropdownPosition.HasValue)
         {
             var dropdownY = dropdownPosition.Value.y;
-            Assert.True(dropdownY <= selectorY + 5, 
-                $"Dropdown should appear near selector (y={selectorY}), but appeared at y={dropdownY}");
+            Assert.IsTrue(dropdownY <= selectorY + 5, $"Dropdown should appear near selector (y={selectorY}), but appeared at y={dropdownY}");
         }
     }
 
@@ -433,7 +433,7 @@ public class TabPanelNodeTests
 
     #region Dynamic Tab Content Tests
 
-    [Fact]
+    [TestMethod]
     public async Task TabPanel_DynamicallyAddingTab_UpdatesContent()
     {
         // Arrange - Simulate the demo pattern with external state
@@ -471,7 +471,7 @@ public class TabPanelNodeTests
             .Capture("initial")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-        Assert.True(snapshot1.ContainsText("No documents"), "Should show empty state initially");
+        Assert.IsTrue(snapshot1.ContainsText("No documents"), "Should show empty state initially");
 
         // Add a document (simulate what happens when user clicks in tree)
         openDocs.Add(("File1.cs", "Content of File1"));
@@ -483,8 +483,8 @@ public class TabPanelNodeTests
             .Capture("afterAdd1")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-        Assert.True(snapshot2.ContainsText("File1.cs"), "Should show first tab");
-        Assert.True(snapshot2.ContainsText("Content of File1"), "Should show first file content");
+        Assert.IsTrue(snapshot2.ContainsText("File1.cs"), "Should show first tab");
+        Assert.IsTrue(snapshot2.ContainsText("Content of File1"), "Should show first file content");
 
         // Add another document and select it
         openDocs.Add(("File2.cs", "Content of File2"));
@@ -497,13 +497,13 @@ public class TabPanelNodeTests
             .Ctrl().Key(Hex1bKey.C)
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-        Assert.True(snapshot3.ContainsText("File2.cs"), "Should show second tab");
-        Assert.True(snapshot3.ContainsText("Content of File2"), "Should show second file content");
+        Assert.IsTrue(snapshot3.ContainsText("File2.cs"), "Should show second tab");
+        Assert.IsTrue(snapshot3.ContainsText("Content of File2"), "Should show second file content");
 
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TabPanel_TreeDoubleClick_UpdatesContent_WithoutExplicitInvalidate()
     {
         // This test replicates the actual demo pattern where:
@@ -574,13 +574,13 @@ public class TabPanelNodeTests
             .Capture("initial")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-        Assert.True(snapshot1.ContainsText("No documents"), "Should show empty state initially");
-        Assert.False(activatedCalled, "OnActivated should not be called yet");
-        Assert.False(clickedCalled, "OnClicked should not be called yet");
+        Assert.IsTrue(snapshot1.ContainsText("No documents"), "Should show empty state initially");
+        Assert.IsFalse(activatedCalled, "OnActivated should not be called yet");
+        Assert.IsFalse(clickedCalled, "OnClicked should not be called yet");
 
         // Find File1.cs position in the tree - it should be at row 0
         var file1Pos = FindTextPosition(snapshot1, "File1.cs");
-        Assert.True(file1Pos.HasValue, "Should find File1.cs in tree");
+        Assert.IsTrue(file1Pos.HasValue, "Should find File1.cs in tree");
 
         // First try a single click to verify mouse routing works
         var snapshot2 = await new Hex1bTerminalInputSequenceBuilder()
@@ -591,7 +591,7 @@ public class TabPanelNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(clickedCalled, $"OnClicked should have been called by click at ({file1Pos.Value.x}, {file1Pos.Value.y})");
+        Assert.IsTrue(clickedCalled, $"OnClicked should have been called by click at ({file1Pos.Value.x}, {file1Pos.Value.y})");
 
         // Now double-click to activate
         var snapshot3 = await new Hex1bTerminalInputSequenceBuilder()
@@ -602,9 +602,9 @@ public class TabPanelNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(activatedCalled, "OnActivated should have been called by double-click");
-        Assert.Single(openDocs);
-        Assert.Equal("File1.cs", openDocs[0].Name);
+        Assert.IsTrue(activatedCalled, "OnActivated should have been called by double-click");
+        TestSeq.Single(openDocs);
+        Assert.AreEqual("File1.cs", openDocs[0].Name);
 
         // Now verify content update
         var snapshot4 = await new Hex1bTerminalInputSequenceBuilder()
@@ -614,13 +614,13 @@ public class TabPanelNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.True(snapshot4.ContainsText("File1.cs"), "Tab should show File1.cs");
-        Assert.True(snapshot4.ContainsText("Content of File 1"), "Content area should show file content");
+        Assert.IsTrue(snapshot4.ContainsText("File1.cs"), "Tab should show File1.cs");
+        Assert.IsTrue(snapshot4.ContainsText("Content of File 1"), "Content area should show file content");
 
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TabPanel_SwitchingTabs_UpdatesContent()
     {
         // Simple test: TabPanel with two tabs, switch between them
@@ -651,8 +651,8 @@ public class TabPanelNodeTests
             .Capture("initial")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-        Assert.True(snapshot1.ContainsText("Content One"), "Should show Tab One content initially");
-        Assert.False(snapshot1.ContainsText("Content Two"), "Should not show Tab Two content initially");
+        Assert.IsTrue(snapshot1.ContainsText("Content One"), "Should show Tab One content initially");
+        Assert.IsFalse(snapshot1.ContainsText("Content Two"), "Should not show Tab Two content initially");
 
         // Press Alt+Right to switch to Tab Two
         var snapshot2 = await new Hex1bTerminalInputSequenceBuilder()
@@ -664,13 +664,13 @@ public class TabPanelNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
         // THIS IS THE BUG: Content Two should be visible, Content One should not
-        Assert.True(snapshot2.ContainsText("Content Two"), "Should show Tab Two content after switch");
-        Assert.False(snapshot2.ContainsText("Content One"), "Should not show Tab One content after switch");
+        Assert.IsTrue(snapshot2.ContainsText("Content Two"), "Should show Tab Two content after switch");
+        Assert.IsFalse(snapshot2.ContainsText("Content One"), "Should not show Tab One content after switch");
 
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TabPanel_SwitchingTabs_WithVScrollAndWrap_UpdatesContent()
     {
         // Test with VScroll and Wrap - matches the demo's structure
@@ -709,8 +709,8 @@ public class TabPanelNodeTests
             .Capture("initial")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-        Assert.True(snapshot1.ContainsText("Content One"), "Should show Tab One content initially");
-        Assert.False(snapshot1.ContainsText("Content Two"), "Should not show Tab Two content initially");
+        Assert.IsTrue(snapshot1.ContainsText("Content One"), "Should show Tab One content initially");
+        Assert.IsFalse(snapshot1.ContainsText("Content Two"), "Should not show Tab Two content initially");
 
         // Press Alt+Right to switch to Tab Two
         var snapshot2 = await new Hex1bTerminalInputSequenceBuilder()
@@ -722,13 +722,13 @@ public class TabPanelNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
         // Content Two should be visible
-        Assert.True(snapshot2.ContainsText("Content Two"), "Should show Tab Two content after switch");
-        Assert.False(snapshot2.ContainsText("Content One"), "Should not show Tab One content after switch");
+        Assert.IsTrue(snapshot2.ContainsText("Content Two"), "Should show Tab Two content after switch");
+        Assert.IsFalse(snapshot2.ContainsText("Content One"), "Should not show Tab One content after switch");
 
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TabPanel_SwitchingTabs_WithResponsive_UpdatesContent()
     {
         // Test with Responsive widget wrapping the TabPanel - matches the demo's exact structure
@@ -769,8 +769,8 @@ public class TabPanelNodeTests
             .Capture("initial")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-        Assert.True(snapshot1.ContainsText("Content One"), "Should show Tab One content initially");
-        Assert.False(snapshot1.ContainsText("Content Two"), "Should not show Tab Two content initially");
+        Assert.IsTrue(snapshot1.ContainsText("Content One"), "Should show Tab One content initially");
+        Assert.IsFalse(snapshot1.ContainsText("Content Two"), "Should not show Tab Two content initially");
 
         // Press Alt+Right to switch to Tab Two
         var snapshot2 = await new Hex1bTerminalInputSequenceBuilder()
@@ -782,13 +782,13 @@ public class TabPanelNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
         // Content Two should be visible
-        Assert.True(snapshot2.ContainsText("Content Two"), "Should show Tab Two content after switch");
-        Assert.False(snapshot2.ContainsText("Content One"), "Should not show Tab One content after switch");
+        Assert.IsTrue(snapshot2.ContainsText("Content Two"), "Should show Tab Two content after switch");
+        Assert.IsFalse(snapshot2.ContainsText("Content One"), "Should not show Tab One content after switch");
 
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TabPanel_InSplitter_SwitchingTabs_UpdatesContent()
     {
         // Test with Splitter + Responsive + TabPanel - full demo structure
@@ -836,7 +836,7 @@ public class TabPanelNodeTests
             .Capture("initial")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-        Assert.True(snapshot1.ContainsText("Content One"), "Should show Tab One content initially");
+        Assert.IsTrue(snapshot1.ContainsText("Content One"), "Should show Tab One content initially");
 
         // Press Alt+Right to switch to Tab Two
         // Note: TabPanel's Alt+Right binding only works when TabPanel or its content is focused
@@ -850,7 +850,7 @@ public class TabPanelNodeTests
         // Try clicking on Tab Two instead (this should work regardless of focus)
         // Find Tab Two position
         var tabTwoPos = FindTextPosition(snapshot2, "Tab Two");
-        Assert.True(tabTwoPos.HasValue, "Should find Tab Two in tab bar");
+        Assert.IsTrue(tabTwoPos.HasValue, "Should find Tab Two in tab bar");
         
         var snapshot3 = await new Hex1bTerminalInputSequenceBuilder()
             .MouseMoveTo(tabTwoPos.Value.x + 2, tabTwoPos.Value.y)
@@ -866,15 +866,13 @@ public class TabPanelNodeTests
         
         // Content Two should be visible after clicking on Tab Two
         // This verifies the content area actually updated, not just that both texts exist somewhere
-        Assert.True(snapshot3.ContainsText("Content Two"), 
-            $"Should show Tab Two content after clicking tab.\nTerminal state:\n{fullState}");
-        Assert.False(snapshot3.ContainsText("Content One"), 
-            $"Should not show Tab One content after switch.\nTerminal state:\n{fullState}");
+        Assert.IsTrue(snapshot3.ContainsText("Content Two"), $"Should show Tab Two content after clicking tab.\nTerminal state:\n{fullState}");
+        Assert.IsFalse(snapshot3.ContainsText("Content One"), $"Should not show Tab One content after switch.\nTerminal state:\n{fullState}");
 
         await runTask;
     }
 
-    [Fact(Skip = "Tree double-click in splitter is a separate issue - needs investigation")]
+    [TestMethod, Ignore("Tree double-click in splitter is a separate issue - needs investigation")]
     public async Task TabPanel_TreeInSplitter_DoubleClickUpdatesContent()
     {
         // This test more closely mirrors the TabPanelDemo structure
@@ -940,11 +938,11 @@ public class TabPanelNodeTests
             .Capture("initial")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-        Assert.True(snapshot1.ContainsText("No documents"), "Should show empty state initially");
+        Assert.IsTrue(snapshot1.ContainsText("No documents"), "Should show empty state initially");
 
         // Find File1.cs position - should be in the left pane
         var file1Pos = FindTextPosition(snapshot1, "File1.cs");
-        Assert.True(file1Pos.HasValue, "Should find File1.cs in tree");
+        Assert.IsTrue(file1Pos.HasValue, "Should find File1.cs in tree");
 
         // Click in the middle of the filename (add offset from start)
         var clickX = file1Pos.Value.x + 3; // Click on "e1" part of File1.cs
@@ -959,9 +957,9 @@ public class TabPanelNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(activatedCalled, $"OnActivated should have been called by double-click at ({clickX}, {clickY})");
-        Assert.Single(openDocs);
-        Assert.Equal("File1.cs", openDocs[0].Name);
+        Assert.IsTrue(activatedCalled, $"OnActivated should have been called by double-click at ({clickX}, {clickY})");
+        TestSeq.Single(openDocs);
+        Assert.AreEqual("File1.cs", openDocs[0].Name);
 
         // Now wait for content update
         var snapshot3 = await new Hex1bTerminalInputSequenceBuilder()
@@ -971,8 +969,8 @@ public class TabPanelNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(snapshot3.ContainsText("File1.cs"), "Tab should show File1.cs");
-        Assert.True(snapshot3.ContainsText("Content of File 1"), "Content area should show file content");
+        Assert.IsTrue(snapshot3.ContainsText("File1.cs"), "Tab should show File1.cs");
+        Assert.IsTrue(snapshot3.ContainsText("Content of File 1"), "Content area should show file content");
 
         await runTask;
     }
@@ -981,7 +979,7 @@ public class TabPanelNodeTests
 
     #region Tab Bar Scrolling Tests
 
-    [Fact]
+    [TestMethod]
     public async Task TabPanel_ManyTabs_NewlySelectedTab_ScrollsIntoView()
     {
         // Arrange - Create many tabs so they overflow the tab bar
@@ -1017,7 +1015,7 @@ public class TabPanelNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(snapshot1.ContainsText("Tab1"), "Tab1 should be visible initially");
+        Assert.IsTrue(snapshot1.ContainsText("Tab1"), "Tab1 should be visible initially");
         
         // Navigate right multiple times to get to Tab8 (which should scroll into view)
         var snapshot2 = await new Hex1bTerminalInputSequenceBuilder()
@@ -1036,11 +1034,11 @@ public class TabPanelNodeTests
         await runTask;
 
         // Assert - Tab8 should be visible in the tab bar (scrolled into view) and its content shown
-        Assert.True(snapshot2.ContainsText("Tab8"), "Tab8 should be visible in tab bar after selection");
-        Assert.True(snapshot2.ContainsText("Content 8"), "Tab8 content should be displayed");
+        Assert.IsTrue(snapshot2.ContainsText("Tab8"), "Tab8 should be visible in tab bar after selection");
+        Assert.IsTrue(snapshot2.ContainsText("Content 8"), "Tab8 content should be displayed");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TabPanel_MouseWheelOnTabBar_ScrollsTabs()
     {
         // Arrange - Create many tabs so they overflow the tab bar
@@ -1074,7 +1072,7 @@ public class TabPanelNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
         // Verify FirstTab visible, later tabs likely not visible due to narrow width
-        Assert.True(snapshot1.ContainsText("FirstTab"), "FirstTab should be visible initially");
+        Assert.IsTrue(snapshot1.ContainsText("FirstTab"), "FirstTab should be visible initially");
         
         // Mouse wheel down (scroll right) on the tab bar (row 0)
         var snapshot2 = await new Hex1bTerminalInputSequenceBuilder()
@@ -1089,16 +1087,16 @@ public class TabPanelNodeTests
 
         // Assert - Later tabs should now be visible (scrolled into view)
         // The content should still show FirstTab's content (we didn't change selection)
-        Assert.True(snapshot2.ContainsText("Content First"), "Content should still show first tab (selection unchanged)");
+        Assert.IsTrue(snapshot2.ContainsText("Content First"), "Content should still show first tab (selection unchanged)");
         
         // At least one of the later tabs should be visible after scrolling
         var laterTabsVisible = snapshot2.ContainsText("FourthTab") || 
                                snapshot2.ContainsText("FifthTab") || 
                                snapshot2.ContainsText("SixthTab");
-        Assert.True(laterTabsVisible, "Later tabs should be visible after mouse wheel scroll");
+        Assert.IsTrue(laterTabsVisible, "Later tabs should be visible after mouse wheel scroll");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TabPanel_AddingNewTab_ScrollsToShowIt()
     {
         // Arrange - Start with many tabs, then add one more
@@ -1143,8 +1141,8 @@ public class TabPanelNodeTests
         await runTask;
 
         // Assert - The new tab should be visible and selected
-        Assert.True(snapshot2.ContainsText("NewTab"), "Newly added tab should be visible");
-        Assert.True(snapshot2.ContainsText("Content of NewTab"), "Newly added tab content should be displayed");
+        Assert.IsTrue(snapshot2.ContainsText("NewTab"), "Newly added tab should be visible");
+        Assert.IsTrue(snapshot2.ContainsText("Content of NewTab"), "Newly added tab content should be displayed");
     }
 
     #endregion

--- a/tests/Hex1b.Tests/TableClippingTests.cs
+++ b/tests/Hex1b.Tests/TableClippingTests.cs
@@ -9,13 +9,14 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for table clipping when inside a window that is resized.
 /// </summary>
+[TestClass]
 public class TableClippingTests
 {
     /// <summary>
     /// When a window containing a table is resized so the table is clipped,
     /// the table borders should NOT render outside the window border.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Table_InsideResizedWindow_ClippedToWindowBounds()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -111,7 +112,7 @@ public class TableClippingTests
 
         await runTask;
         
-        Assert.False(clippingFailed, $"Table content rendered outside window bounds.\n{diagnostics}");
+        Assert.IsFalse(clippingFailed, $"Table content rendered outside window bounds.\n{diagnostics}");
     }
     
     private record Employee(int Id, string Name, string Department);

--- a/tests/Hex1b.Tests/TableIntegrationTests.cs
+++ b/tests/Hex1b.Tests/TableIntegrationTests.cs
@@ -11,6 +11,7 @@ namespace Hex1b.Tests;
 /// Tests cover focus highlighting, selection, select-all, fill width,
 /// compact vs full mode, and mouse interaction.
 /// </summary>
+[TestClass]
 public class TableIntegrationTests
 {
     private static readonly Hex1bColor FocusedRowBg = Hex1bColor.FromRgb(50, 50, 50);
@@ -41,7 +42,7 @@ public class TableIntegrationTests
 
     #region Focus Row Background Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Table_FocusedRow_HasBackgroundColor()
     {
         // Verify that focusing a row renders the FocusedRowBackground color
@@ -78,12 +79,11 @@ public class TableIntegrationTests
 
         var snapshot = terminal.CreateSnapshot();
         var text = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Focused row test ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(text);
+        TestContext.Current?.WriteLine("=== Focused row test ===");
+        TestContext.Current?.WriteLine(text);
 
         // The focused row should have the FocusedRowBackground color applied
-        Assert.True(snapshot.HasBackgroundColor(FocusedRowBg),
-            $"Focused row should have background color RGB(50,50,50). Screen:\n{text}");
+        Assert.IsTrue(snapshot.HasBackgroundColor(FocusedRowBg), $"Focused row should have background color RGB(50,50,50). Screen:\n{text}");
 
         // Also verify focus bars (┃) are present
         Assert.Contains("┃", text);
@@ -95,7 +95,7 @@ public class TableIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_FocusedRow_MovingDown_BackgroundFollowsFocus()
     {
         // Verify that the background color moves when focus changes via arrow key
@@ -137,13 +137,12 @@ public class TableIntegrationTests
 
         var snapshot = terminal.CreateSnapshot();
         var text = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== After moving focus down ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(text);
+        TestContext.Current?.WriteLine("=== After moving focus down ===");
+        TestContext.Current?.WriteLine(text);
 
         // Focus should be on Employee 3
-        Assert.Equal("Employee 3", focusedKey);
-        Assert.True(snapshot.HasBackgroundColor(FocusedRowBg),
-            "Focused row background should be present after moving focus");
+        Assert.AreEqual("Employee 3", focusedKey);
+        Assert.IsTrue(snapshot.HasBackgroundColor(FocusedRowBg), "Focused row background should be present after moving focus");
 
         // Verify the focus indicator is on the correct row
         Assert.Contains("> Employee 3", text);
@@ -155,7 +154,7 @@ public class TableIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_MouseClickOnRow_ShowsFocusBackground()
     {
         // Verify clicking on a row shows focused background
@@ -198,14 +197,13 @@ public class TableIntegrationTests
 
         var snapshot = terminal.CreateSnapshot();
         var text = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== After mouse click ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(text);
-        TestContext.Current.TestOutputHelper?.WriteLine($"Focused key: {focusedKey}");
+        TestContext.Current?.WriteLine("=== After mouse click ===");
+        TestContext.Current?.WriteLine(text);
+        TestContext.Current?.WriteLine($"Focused key: {focusedKey}");
 
         // Focus should have changed and background should be visible
-        Assert.NotNull(focusedKey);
-        Assert.True(snapshot.HasBackgroundColor(FocusedRowBg),
-            $"Clicked row should have focused background. Focus: {focusedKey}\nScreen:\n{text}");
+        Assert.IsNotNull(focusedKey);
+        Assert.IsTrue(snapshot.HasBackgroundColor(FocusedRowBg), $"Clicked row should have focused background. Focus: {focusedKey}\nScreen:\n{text}");
         Assert.Contains("┃", text); // Focus bars
 
         await new Hex1bTerminalInputSequenceBuilder()
@@ -219,7 +217,7 @@ public class TableIntegrationTests
 
     #region Selection Column Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Table_SelectionColumn_SpaceTogglesCheckbox()
     {
         // Verify Space key toggles selection and shows selected background
@@ -259,7 +257,7 @@ public class TableIntegrationTests
 
         var beforeSnapshot = terminal.CreateSnapshot();
         Assert.Contains("▢", beforeSnapshot.GetScreenText());
-        Assert.Equal(0, data.Count(e => e.IsSelected));
+        Assert.AreEqual(0, data.Count(e => e.IsSelected));
 
         // Press Space to select the focused row
         await new Hex1bTerminalInputSequenceBuilder()
@@ -270,17 +268,16 @@ public class TableIntegrationTests
 
         var afterSnapshot = terminal.CreateSnapshot();
         var afterText = afterSnapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== After Space ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(afterText);
+        TestContext.Current?.WriteLine("=== After Space ===");
+        TestContext.Current?.WriteLine(afterText);
 
         // First row should now be selected
-        Assert.Equal(1, data.Count(e => e.IsSelected));
-        Assert.True(data[0].IsSelected, "Employee 1 should be selected");
+        Assert.AreEqual(1, data.Count(e => e.IsSelected));
+        Assert.IsTrue(data[0].IsSelected, "Employee 1 should be selected");
         Assert.Contains("▣", afterText);
 
         // Row is both focused AND selected; focused bg takes priority
-        Assert.True(afterSnapshot.HasBackgroundColor(FocusedRowBg),
-            "Focused+selected row should show focused background color (focus wins)");
+        Assert.IsTrue(afterSnapshot.HasBackgroundColor(FocusedRowBg), "Focused+selected row should show focused background color (focus wins)");
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -289,7 +286,7 @@ public class TableIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_SelectionColumn_HeaderCheckboxSelectsAllRows()
     {
         // Verify that clicking the header checkbox selects all rows
@@ -330,7 +327,7 @@ public class TableIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(0, data.Count(e => e.IsSelected));
+        Assert.AreEqual(0, data.Count(e => e.IsSelected));
 
         // Click on the header checkbox
         // Layout: y=0 top border, y=1 header row
@@ -343,12 +340,12 @@ public class TableIntegrationTests
 
         var afterSnapshot = terminal.CreateSnapshot();
         var afterText = afterSnapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== After header click ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(afterText);
-        TestContext.Current.TestOutputHelper?.WriteLine($"Selected: {data.Count(e => e.IsSelected)} / {data.Count}");
+        TestContext.Current?.WriteLine("=== After header click ===");
+        TestContext.Current?.WriteLine(afterText);
+        TestContext.Current?.WriteLine($"Selected: {data.Count(e => e.IsSelected)} / {data.Count}");
 
         // ALL rows should now be selected
-        Assert.Equal(5, data.Count(e => e.IsSelected));
+        Assert.AreEqual(5, data.Count(e => e.IsSelected));
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -357,7 +354,7 @@ public class TableIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_SelectionColumn_HeaderCheckboxDeselectsAllRows()
     {
         // Verify header checkbox deselects all when all are already selected
@@ -398,7 +395,7 @@ public class TableIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(5, data.Count(e => e.IsSelected));
+        Assert.AreEqual(5, data.Count(e => e.IsSelected));
 
         // Click header checkbox to deselect all
         await new Hex1bTerminalInputSequenceBuilder()
@@ -409,12 +406,12 @@ public class TableIntegrationTests
 
         var afterSnapshot = terminal.CreateSnapshot();
         var afterText = afterSnapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== After deselect all ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(afterText);
-        TestContext.Current.TestOutputHelper?.WriteLine($"Selected: {data.Count(e => e.IsSelected)} / {data.Count}");
+        TestContext.Current?.WriteLine("=== After deselect all ===");
+        TestContext.Current?.WriteLine(afterText);
+        TestContext.Current?.WriteLine($"Selected: {data.Count(e => e.IsSelected)} / {data.Count}");
 
         // ALL rows should now be deselected
-        Assert.Equal(0, data.Count(e => e.IsSelected));
+        Assert.AreEqual(0, data.Count(e => e.IsSelected));
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -423,7 +420,7 @@ public class TableIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_SelectionColumn_CtrlA_SelectsAllWithoutExplicitCallback()
     {
         // Verify Ctrl+A selects all even without explicit SelectAllCallback
@@ -461,7 +458,7 @@ public class TableIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(0, data.Count(e => e.IsSelected));
+        Assert.AreEqual(0, data.Count(e => e.IsSelected));
 
         // Ctrl+A to select all
         await new Hex1bTerminalInputSequenceBuilder()
@@ -472,12 +469,12 @@ public class TableIntegrationTests
 
         var afterSnapshot = terminal.CreateSnapshot();
         var afterText = afterSnapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== After Ctrl+A ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(afterText);
-        TestContext.Current.TestOutputHelper?.WriteLine($"Selected: {data.Count(e => e.IsSelected)} / {data.Count}");
+        TestContext.Current?.WriteLine("=== After Ctrl+A ===");
+        TestContext.Current?.WriteLine(afterText);
+        TestContext.Current?.WriteLine($"Selected: {data.Count(e => e.IsSelected)} / {data.Count}");
 
         // All rows should be selected
-        Assert.Equal(5, data.Count(e => e.IsSelected));
+        Assert.AreEqual(5, data.Count(e => e.IsSelected));
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -486,7 +483,7 @@ public class TableIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_SelectionColumn_MouseClickCheckboxTogglesRow()
     {
         // Verify clicking on checkbox area toggles selection for that row
@@ -533,11 +530,11 @@ public class TableIntegrationTests
 
         var snapshot = terminal.CreateSnapshot();
         var text = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== After checkbox click ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(text);
+        TestContext.Current?.WriteLine("=== After checkbox click ===");
+        TestContext.Current?.WriteLine(text);
 
-        Assert.Equal(1, data.Count(e => e.IsSelected));
-        Assert.True(data[0].IsSelected, "First employee should be selected after click");
+        Assert.AreEqual(1, data.Count(e => e.IsSelected));
+        Assert.IsTrue(data[0].IsSelected, "First employee should be selected after click");
 
         // Click a second row checkbox
         await new Hex1bTerminalInputSequenceBuilder()
@@ -546,7 +543,7 @@ public class TableIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(2, data.Count(e => e.IsSelected));
+        Assert.AreEqual(2, data.Count(e => e.IsSelected));
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -559,7 +556,7 @@ public class TableIntegrationTests
 
     #region Fill Width Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Table_FillWidthWithFillColumn_ExpandsToContainerWidth()
     {
         // Verify FillWidth works when at least one column uses SizeHint.Fill
@@ -596,19 +593,18 @@ public class TableIntegrationTests
 
         var snapshot = terminal.CreateSnapshot();
         var text = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Fill Width with Fill column ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(text);
+        TestContext.Current?.WriteLine("=== Fill Width with Fill column ===");
+        TestContext.Current?.WriteLine(text);
 
         // The table should span the full terminal width (80 columns)
         // Check that the top border extends close to the full width
         var lines = text.Split('\n');
         var topBorder = lines.FirstOrDefault(l => l.Contains("┌") && l.Contains("┐"));
-        Assert.NotNull(topBorder);
+        Assert.IsNotNull(topBorder);
         
         // The border should reach near the full width
         var trimmed = topBorder!.TrimEnd();
-        Assert.True(trimmed.Length >= 75,
-            $"Table should fill most of the terminal width (80). Top border length: {trimmed.Length}");
+        Assert.IsTrue(trimmed.Length >= 75, $"Table should fill most of the terminal width (80). Top border length: {trimmed.Length}");
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -617,7 +613,7 @@ public class TableIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_FillWidthWithAllFixedColumns_DoesNotExpandColumns()
     {
         // Verify that FillWidth with all Fixed columns does NOT expand the columns
@@ -655,15 +651,15 @@ public class TableIntegrationTests
 
         var snapshot = terminal.CreateSnapshot();
         var text = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Fill Width with all fixed columns ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(text);
+        TestContext.Current?.WriteLine("=== Fill Width with all fixed columns ===");
+        TestContext.Current?.WriteLine(text);
 
         // With FillWidth + all Fixed, the actual table content width should be
         // 15 + 12 + 6 + borders (4 vertical bars = 4) = 37 chars
         // The scrollbar (if any) would be at 37, not at column 80
         var lines = text.Split('\n');
         var topBorder = lines.FirstOrDefault(l => l.Contains("┌") && l.Contains("┐"));
-        Assert.NotNull(topBorder);
+        Assert.IsNotNull(topBorder);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -676,7 +672,7 @@ public class TableIntegrationTests
 
     #region Compact vs Full Mode Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Table_CompactMode_NoRowSeparators()
     {
         // Verify compact mode does not render horizontal separators between rows
@@ -710,8 +706,8 @@ public class TableIntegrationTests
 
         var snapshot = terminal.CreateSnapshot();
         var text = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Compact mode ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(text);
+        TestContext.Current?.WriteLine("=== Compact mode ===");
+        TestContext.Current?.WriteLine(text);
 
         var lines = text.Split('\n');
 
@@ -724,9 +720,9 @@ public class TableIntegrationTests
             if (lines[i].Contains("Employee 3")) emp3Line = i;
         }
 
-        Assert.True(emp1Line >= 0 && emp3Line >= 0, "Both Employee 1 and 3 should be visible");
+        Assert.IsTrue(emp1Line >= 0 && emp3Line >= 0, "Both Employee 1 and 3 should be visible");
         // In compact mode, 3 rows = 3 lines apart (rows 1, 2, 3)
-        Assert.Equal(2, emp3Line - emp1Line);
+        Assert.AreEqual(2, emp3Line - emp1Line);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -735,7 +731,7 @@ public class TableIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_FullMode_HasRowSeparators()
     {
         // Verify full mode renders horizontal separators between rows
@@ -769,8 +765,8 @@ public class TableIntegrationTests
 
         var snapshot = terminal.CreateSnapshot();
         var text = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Full mode ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(text);
+        TestContext.Current?.WriteLine("=== Full mode ===");
+        TestContext.Current?.WriteLine(text);
 
         var lines = text.Split('\n');
 
@@ -783,9 +779,9 @@ public class TableIntegrationTests
             if (lines[i].Contains("Employee 3")) emp3Line = i;
         }
 
-        Assert.True(emp1Line >= 0 && emp3Line >= 0, "Both Employee 1 and 3 should be visible");
+        Assert.IsTrue(emp1Line >= 0 && emp3Line >= 0, "Both Employee 1 and 3 should be visible");
         // In full mode, 3 rows = row + sep + row + sep + row = 4 lines between first and third
-        Assert.Equal(4, emp3Line - emp1Line);
+        Assert.AreEqual(4, emp3Line - emp1Line);
 
         // Verify separators exist between rows (├ or ┤ characters)
         int separatorCount = 0;
@@ -794,7 +790,7 @@ public class TableIntegrationTests
             if (lines[i].Contains("├") || lines[i].Contains("┤"))
                 separatorCount++;
         }
-        Assert.Equal(2, separatorCount);
+        Assert.AreEqual(2, separatorCount);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -807,7 +803,7 @@ public class TableIntegrationTests
 
     #region Combined Focus + Selection Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Table_FocusedSelected_BothStatesVisible()
     {
         // When a row is both focused and selected, the focused background should win
@@ -848,14 +844,13 @@ public class TableIntegrationTests
 
         var snapshot = terminal.CreateSnapshot();
         var text = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Focus + Selected ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(text);
+        TestContext.Current?.WriteLine("=== Focus + Selected ===");
+        TestContext.Current?.WriteLine(text);
 
-        Assert.True(data[0].IsSelected, "Employee 1 should be selected");
+        Assert.IsTrue(data[0].IsSelected, "Employee 1 should be selected");
 
         // Focused row takes priority, so we should see FocusedRowBg
-        Assert.True(snapshot.HasBackgroundColor(FocusedRowBg),
-            "Focused+selected row should show focused background");
+        Assert.IsTrue(snapshot.HasBackgroundColor(FocusedRowBg), "Focused+selected row should show focused background");
 
         // Move focus down - unfocused selected row should show Selected bg
         await new Hex1bTerminalInputSequenceBuilder()
@@ -866,13 +861,12 @@ public class TableIntegrationTests
 
         var afterMoveSnapshot = terminal.CreateSnapshot();
         var afterMoveText = afterMoveSnapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== After moving focus away ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(afterMoveText);
+        TestContext.Current?.WriteLine("=== After moving focus away ===");
+        TestContext.Current?.WriteLine(afterMoveText);
 
         // Now Employee 1 is selected but not focused, Employee 2 is focused but not selected
         // Focus background should still be visible, selection indicated by checkbox only
-        Assert.True(afterMoveSnapshot.HasBackgroundColor(FocusedRowBg),
-            "Focused row (Employee 2) should have focused background");
+        Assert.IsTrue(afterMoveSnapshot.HasBackgroundColor(FocusedRowBg), "Focused row (Employee 2) should have focused background");
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -881,7 +875,7 @@ public class TableIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_MultipleSelected_AllShowBackground()
     {
         // Verify multiple selected rows all show the selected background
@@ -926,16 +920,15 @@ public class TableIntegrationTests
 
         var snapshot = terminal.CreateSnapshot();
         var text = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Multiple selected ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(text);
+        TestContext.Current?.WriteLine("=== Multiple selected ===");
+        TestContext.Current?.WriteLine(text);
 
         // 3 rows selected
-        Assert.Equal(3, data.Count(e => e.IsSelected));
-        Assert.True(data[0].IsSelected && data[1].IsSelected && data[2].IsSelected);
+        Assert.AreEqual(3, data.Count(e => e.IsSelected));
+        Assert.IsTrue(data[0].IsSelected && data[1].IsSelected && data[2].IsSelected);
 
         // Focus background should be present, selection indicated by checkbox only
-        Assert.True(snapshot.HasBackgroundColor(FocusedRowBg),
-            "Focus row should show focused background");
+        Assert.IsTrue(snapshot.HasBackgroundColor(FocusedRowBg), "Focus row should show focused background");
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -948,10 +941,10 @@ public class TableIntegrationTests
 
     #region Terminal Size Tests
 
-    [Theory]
-    [InlineData(40, 10)]
-    [InlineData(60, 15)]
-    [InlineData(100, 30)]
+    [TestMethod]
+    [DataRow(40, 10)]
+    [DataRow(60, 15)]
+    [DataRow(100, 30)]
     public async Task Table_VariousTerminalSizes_RendersCorrectly(int width, int height)
     {
         // Verify table renders without errors at various terminal sizes
@@ -988,8 +981,8 @@ public class TableIntegrationTests
 
         var snapshot = terminal.CreateSnapshot();
         var text = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine($"=== {width}x{height} ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(text);
+        TestContext.Current?.WriteLine($"=== {width}x{height} ===");
+        TestContext.Current?.WriteLine(text);
 
         // Table should have borders and data
         Assert.Contains("Employee 1", text);
@@ -1009,7 +1002,7 @@ public class TableIntegrationTests
 
     #region Scrolling + Focus Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Table_ScrollToBottom_FocusBackgroundStillVisible()
     {
         // Verify focus background is visible after scrolling to bottom of table
@@ -1051,14 +1044,13 @@ public class TableIntegrationTests
 
         var snapshot = terminal.CreateSnapshot();
         var text = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== After scroll to bottom ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(text);
-        TestContext.Current.TestOutputHelper?.WriteLine($"Focused: {focusedKey}");
+        TestContext.Current?.WriteLine("=== After scroll to bottom ===");
+        TestContext.Current?.WriteLine(text);
+        TestContext.Current?.WriteLine($"Focused: {focusedKey}");
 
         // Focus should be on the last employee and background should be visible
-        Assert.Equal("Employee 30", focusedKey);
-        Assert.True(snapshot.HasBackgroundColor(FocusedRowBg),
-            "Focused row at bottom should have background color");
+        Assert.AreEqual("Employee 30", focusedKey);
+        Assert.IsTrue(snapshot.HasBackgroundColor(FocusedRowBg), "Focused row at bottom should have background color");
         Assert.Contains("┃", text); // Focus bars
 
         await new Hex1bTerminalInputSequenceBuilder()
@@ -1068,7 +1060,7 @@ public class TableIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_HomeAndEnd_FocusNavigatesCorrectly()
     {
         // Navigate Home/End and verify focus and background
@@ -1108,7 +1100,7 @@ public class TableIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal("Employee 20", focusedKey);
+        Assert.AreEqual("Employee 20", focusedKey);
 
         // Navigate back to Home
         await new Hex1bTerminalInputSequenceBuilder()
@@ -1120,12 +1112,11 @@ public class TableIntegrationTests
 
         var snapshot = terminal.CreateSnapshot();
         var text = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== After Home ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(text);
+        TestContext.Current?.WriteLine("=== After Home ===");
+        TestContext.Current?.WriteLine(text);
 
-        Assert.Equal("Employee 1", focusedKey);
-        Assert.True(snapshot.HasBackgroundColor(FocusedRowBg),
-            "Focused row should have background after Home");
+        Assert.AreEqual("Employee 1", focusedKey);
+        Assert.IsTrue(snapshot.HasBackgroundColor(FocusedRowBg), "Focused row should have background after Home");
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -1138,7 +1129,7 @@ public class TableIntegrationTests
 
     #region Selection + Select All with FillHeight
 
-    [Fact]
+    [TestMethod]
     public async Task Table_SelectAllThenDeselectAll_Roundtrip()
     {
         // Verify select all then deselect all works as a complete roundtrip
@@ -1182,12 +1173,12 @@ public class TableIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(5, data.Count(e => e.IsSelected));
+        Assert.AreEqual(5, data.Count(e => e.IsSelected));
 
         var selectAllSnapshot = terminal.CreateSnapshot();
         var selectAllText = selectAllSnapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== After Select All ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(selectAllText);
+        TestContext.Current?.WriteLine("=== After Select All ===");
+        TestContext.Current?.WriteLine(selectAllText);
 
         // All checkboxes should show ▣
         Assert.Contains("▣", selectAllText);
@@ -1201,12 +1192,12 @@ public class TableIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(0, data.Count(e => e.IsSelected));
+        Assert.AreEqual(0, data.Count(e => e.IsSelected));
 
         var deselectAllSnapshot = terminal.CreateSnapshot();
         var deselectAllText = deselectAllSnapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== After Deselect All ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(deselectAllText);
+        TestContext.Current?.WriteLine("=== After Deselect All ===");
+        TestContext.Current?.WriteLine(deselectAllText);
 
         Assert.Contains("▢", deselectAllText);
 
@@ -1221,7 +1212,7 @@ public class TableIntegrationTests
 
     #region WindowingDemo-Specific Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Table_WindowingDemoConfig_FillWidthExpandsNameColumn()
     {
         // Reproduce the demo's table config: Name=Fill, Role=Fixed(12), Age=Fixed(6), Status=Fixed(10)
@@ -1269,18 +1260,17 @@ public class TableIntegrationTests
 
         var snapshot = terminal.CreateSnapshot();
         var text = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Demo config with Fill Width ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(text);
+        TestContext.Current?.WriteLine("=== Demo config with Fill Width ===");
+        TestContext.Current?.WriteLine(text);
 
         // The table should use full 65 width
         var lines = text.Split('\n');
         var topBorder = lines.FirstOrDefault(l => l.Contains("┌") && l.Contains("┐"));
-        Assert.NotNull(topBorder);
+        Assert.IsNotNull(topBorder);
         
         var trimmed = topBorder!.TrimEnd();
         // The table should span at least 60 chars (accounting for possible padding)
-        Assert.True(trimmed.Length >= 60,
-            $"Table should fill most of the 65-wide container. Top border length: {trimmed.Length}");
+        Assert.IsTrue(trimmed.Length >= 60, $"Table should fill most of the 65-wide container. Top border length: {trimmed.Length}");
 
         // Verify the Name column got more than the fixed 18 it would normally get
         // The header "Name" text should be visible in a wider cell
@@ -1295,7 +1285,7 @@ public class TableIntegrationTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_WindowingDemoConfig_SelectionWithFocus()
     {
         // Full demo-like test: table with selection, focus, compact mode, fill width
@@ -1350,8 +1340,7 @@ public class TableIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         var initialSnapshot = terminal.CreateSnapshot();
-        Assert.True(initialSnapshot.HasBackgroundColor(FocusedRowBg),
-            "Initial focused row should have background");
+        Assert.IsTrue(initialSnapshot.HasBackgroundColor(FocusedRowBg), "Initial focused row should have background");
 
         // Step 2: Select first two rows
         await new Hex1bTerminalInputSequenceBuilder()
@@ -1362,12 +1351,11 @@ public class TableIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(2, data.Count(e => e.IsSelected));
+        Assert.AreEqual(2, data.Count(e => e.IsSelected));
 
         var afterSelectSnapshot = terminal.CreateSnapshot();
         // Focus background should be present, selection indicated by checkbox only
-        Assert.True(afterSelectSnapshot.HasBackgroundColor(FocusedRowBg),
-            "Bob (focused) should have focused background");
+        Assert.IsTrue(afterSelectSnapshot.HasBackgroundColor(FocusedRowBg), "Bob (focused) should have focused background");
 
         // Step 3: Ctrl+A to select all
         await new Hex1bTerminalInputSequenceBuilder()
@@ -1376,12 +1364,12 @@ public class TableIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(5, data.Count(e => e.IsSelected));
+        Assert.AreEqual(5, data.Count(e => e.IsSelected));
 
         var allSelectedSnapshot = terminal.CreateSnapshot();
         var allSelectedText = allSelectedSnapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== All selected ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(allSelectedText);
+        TestContext.Current?.WriteLine("=== All selected ===");
+        TestContext.Current?.WriteLine(allSelectedText);
         Assert.Contains("▣", allSelectedText);
 
         // Step 4: Ctrl+A again to deselect all
@@ -1391,7 +1379,7 @@ public class TableIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal(0, data.Count(e => e.IsSelected));
+        Assert.AreEqual(0, data.Count(e => e.IsSelected));
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)

--- a/tests/Hex1b.Tests/TableNodeTests.cs
+++ b/tests/Hex1b.Tests/TableNodeTests.cs
@@ -5,7 +5,6 @@ using Hex1b.Input;
 using Hex1b.Layout;
 using Hex1b.Nodes;
 using Hex1b.Widgets;
-using Xunit;
 
 namespace Hex1b.Tests;
 
@@ -18,21 +17,22 @@ internal class SelectableItem
     public bool IsSelected { get; set; }
 }
 
+[TestClass]
 public class TableNodeTests
 {
     #region Construction & Basics
 
-    [Fact]
+    [TestMethod]
     public void Node_DefaultState_HasNoRows()
     {
         var node = new TableNode<string>();
         
-        Assert.Null(node.Data);
-        Assert.Null(node.HeaderBuilder);
-        Assert.Null(node.RowBuilder);
+        Assert.IsNull(node.Data);
+        Assert.IsNull(node.HeaderBuilder);
+        Assert.IsNull(node.RowBuilder);
     }
 
-    [Fact]
+    [TestMethod]
     public void Node_WithData_HasCorrectRowCount()
     {
         var data = new[] { "A", "B", "C" };
@@ -43,14 +43,14 @@ public class TableNodeTests
             RowBuilder = (r, item, _) => [r.Cell(item)]
         };
         
-        Assert.Equal(3, node.Data!.Count);
+        Assert.AreEqual(3, node.Data!.Count);
     }
 
     #endregion
 
     #region Column Count Validation
 
-    [Fact]
+    [TestMethod]
     public void Validation_HeaderRowMismatch_Throws()
     {
         var data = new[] { "Item1" };
@@ -61,7 +61,7 @@ public class TableNodeTests
             RowBuilder = (r, item, _) => [r.Cell(item)] // 1 column - mismatch!
         };
 
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() =>
             node.Measure(new Constraints(0, 80, 0, 24)));
 
         Assert.Contains("column count mismatch", ex.Message, StringComparison.OrdinalIgnoreCase);
@@ -69,7 +69,7 @@ public class TableNodeTests
         Assert.Contains("row 0 has 1", ex.Message);
     }
 
-    [Fact]
+    [TestMethod]
     public void Validation_FooterMismatch_Throws()
     {
         var data = new[] { "Item1" };
@@ -81,14 +81,14 @@ public class TableNodeTests
             FooterBuilder = f => [f.Cell("A"), f.Cell("B")] // 2 columns - mismatch!
         };
 
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() =>
             node.Measure(new Constraints(0, 80, 0, 24)));
 
         Assert.Contains("column count mismatch", ex.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("footer", ex.Message);
     }
 
-    [Fact]
+    [TestMethod]
     public void Validation_ZeroColumns_Throws()
     {
         var node = new TableNode<string>
@@ -98,13 +98,13 @@ public class TableNodeTests
             RowBuilder = (r, item, _) => []
         };
 
-        var ex = Assert.Throws<InvalidOperationException>(() =>
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() =>
             node.Measure(new Constraints(0, 80, 0, 24)));
 
         Assert.Contains("at least one column", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
-    [Fact]
+    [TestMethod]
     public void Validation_MatchingColumns_DoesNotThrow()
     {
         var data = new[] { "A", "B" };
@@ -118,15 +118,15 @@ public class TableNodeTests
 
         var size = node.Measure(new Constraints(0, 80, 0, 24));
         
-        Assert.True(size.Width > 0);
-        Assert.True(size.Height > 0);
+        Assert.IsTrue(size.Width > 0);
+        Assert.IsTrue(size.Height > 0);
     }
 
     #endregion
 
     #region Measurement
 
-    [Fact]
+    [TestMethod]
     public void Measure_ReturnsCorrectHeight_ForBasicTable()
     {
         var data = new[] { "A", "B", "C" };
@@ -140,10 +140,10 @@ public class TableNodeTests
         var size = node.Measure(new Constraints(0, 40, 0, 24));
 
         // Height = top border (1) + header (1) + separator (1) + 3 rows (3) + bottom border (1) = 7
-        Assert.Equal(7, size.Height);
+        Assert.AreEqual(7, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_ReturnsCorrectHeight_WithFooter()
     {
         var data = new[] { "A", "B" };
@@ -158,10 +158,10 @@ public class TableNodeTests
         var size = node.Measure(new Constraints(0, 40, 0, 24));
 
         // Height = top (1) + header (1) + sep (1) + 2 rows (2) + sep (1) + footer (1) + bottom (1) = 8
-        Assert.Equal(8, size.Height);
+        Assert.AreEqual(8, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_UsesConstraintWidth()
     {
         var node = new TableNode<string>
@@ -174,10 +174,10 @@ public class TableNodeTests
 
         var size = node.Measure(new Constraints(0, 60, 0, 24));
 
-        Assert.Equal(60, size.Width);
+        Assert.AreEqual(60, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_NullData_ShowsEmptyState()
     {
         var node = new TableNode<string>
@@ -190,10 +190,10 @@ public class TableNodeTests
         var size = node.Measure(new Constraints(0, 40, 0, 24));
 
         // Height = top (1) + header (1) + sep (1) + 1 empty row (1) + bottom (1) = 5
-        Assert.Equal(5, size.Height);
+        Assert.AreEqual(5, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_EmptyData_AddsEmptyStateHeight()
     {
         var node = new TableNode<string>
@@ -206,14 +206,14 @@ public class TableNodeTests
         var size = node.Measure(new Constraints(0, 40, 0, 24));
 
         // Height = top (1) + header (1) + sep (1) + empty message (1) + bottom (1) = 5
-        Assert.Equal(5, size.Height);
+        Assert.AreEqual(5, size.Height);
     }
 
     #endregion
 
     #region Widget API
 
-    [Fact]
+    [TestMethod]
     public void Widget_FluentApi_ConfiguresCorrectly()
     {
         var data = new[] { "A", "B" };
@@ -225,14 +225,14 @@ public class TableNodeTests
             .Footer(f => [f.Cell("End")])
             .Focus(1);  // Use key-based focus
 
-        Assert.Same(data, widget.Data);
-        Assert.NotNull(widget.HeaderBuilder);
-        Assert.NotNull(widget.RowBuilder);
-        Assert.NotNull(widget.FooterBuilder);
-        Assert.Equal(1, widget.FocusedKey);
+        Assert.AreSame(data, widget.Data);
+        Assert.IsNotNull(widget.HeaderBuilder);
+        Assert.IsNotNull(widget.RowBuilder);
+        Assert.IsNotNull(widget.FooterBuilder);
+        Assert.AreEqual(1, widget.FocusedKey);
     }
 
-    [Fact]
+    [TestMethod]
     public void Widget_WithEmpty_ConfiguresEmptyBuilder()
     {
         var ctx = new RootContext();
@@ -242,45 +242,45 @@ public class TableNodeTests
             .Row((r, item, _) => [r.Cell(item)])
             .Empty(e => e.Text("No items"));
 
-        Assert.NotNull(widget.EmptyBuilder);
+        Assert.IsNotNull(widget.EmptyBuilder);
     }
 
     #endregion
 
     #region Cell Extensions
 
-    [Fact]
+    [TestMethod]
     public void TableCell_Fixed_SetsWidth()
     {
         var cell = new TableHeaderContext().Cell("Test").Fixed(15);
         
-        Assert.NotNull(cell.Width);
-        Assert.True(cell.Width.Value.IsFixed);
-        Assert.Equal(15, cell.Width.Value.FixedValue);
+        Assert.IsNotNull(cell.Width);
+        Assert.IsTrue(cell.Width.Value.IsFixed);
+        Assert.AreEqual(15, cell.Width.Value.FixedValue);
     }
 
-    [Fact]
+    [TestMethod]
     public void TableCell_Fill_SetsWidth()
     {
         var cell = new TableHeaderContext().Cell("Test").Fill();
         
-        Assert.NotNull(cell.Width);
-        Assert.True(cell.Width.Value.IsFill);
+        Assert.IsNotNull(cell.Width);
+        Assert.IsTrue(cell.Width.Value.IsFill);
     }
 
-    [Fact]
+    [TestMethod]
     public void TableCell_AlignRight_SetsAlignment()
     {
         var cell = new TableHeaderContext().Cell("Test").AlignRight();
         
-        Assert.Equal(Alignment.Right, cell.Alignment);
+        Assert.AreEqual(Alignment.Right, cell.Alignment);
     }
 
     #endregion
 
     #region Reconciliation
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_CreatesNewNode()
     {
         var widget = new TableWidget<string>
@@ -295,10 +295,10 @@ public class TableNodeTests
 
         var node = await widget.ReconcileAsync(null, context);
 
-        Assert.IsType<TableNode<string>>(node);
+        TestSeq.IsType<TableNode<string>>(node);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_ReusesExistingNode()
     {
         var existingNode = new TableNode<string>();
@@ -313,10 +313,10 @@ public class TableNodeTests
 
         var node = await widget.ReconcileAsync(existingNode, context);
 
-        Assert.Same(existingNode, node);
+        Assert.AreSame(existingNode, node);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_UpdatesNodeData()
     {
         var existingNode = new TableNode<string> { Data = ["Old"] };
@@ -331,14 +331,14 @@ public class TableNodeTests
         var context = ReconcileContext.CreateRoot();
         var node = await widget.ReconcileAsync(existingNode, context);
 
-        Assert.Same(newData, ((TableNode<string>)node).Data);
+        Assert.AreSame(newData, ((TableNode<string>)node).Data);
     }
 
     #endregion
 
     #region Row Navigation Bindings
 
-    [Fact]
+    [TestMethod]
     public async Task DownArrow_KeyBinding_MovesFocusToNextRow()
     {
         // Create a table with enough data to scroll
@@ -357,19 +357,19 @@ public class TableNodeTests
         node.Arrange(new Rect(0, 0, 40, 10));
         
         // Verify initial state
-        Assert.Equal(0, node.FocusedKey);
-        Assert.Equal(0, node.ScrollOffset);
+        Assert.AreEqual(0, node.FocusedKey);
+        Assert.AreEqual(0, node.ScrollOffset);
 
         // Simulate key press using InputRouter
         node.IsFocused = true;
         var keyEvent = new Hex1bKeyEvent(Hex1bKey.DownArrow, '\0', Hex1bModifiers.None);
         var result = await Input.InputRouter.RouteInputToNodeAsync(node, keyEvent);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(1, node.FocusedKey); // Focus moved to row 1
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(1, node.FocusedKey); // Focus moved to row 1
     }
 
-    [Fact]
+    [TestMethod]
     public async Task DownArrow_AtBottomOfViewport_ScrollsToKeepFocusVisible()
     {
         var data = Enumerable.Range(1, 50).Select(i => $"Row {i}").ToArray();
@@ -388,7 +388,7 @@ public class TableNodeTests
         // With 10 height, we have about 6-7 data rows visible
         // If focused row is at the bottom edge and we press Down,
         // the view should scroll to keep the new focused row visible
-        Assert.Equal(0, node.ScrollOffset);
+        Assert.AreEqual(0, node.ScrollOffset);
 
         node.IsFocused = true;
         
@@ -401,10 +401,10 @@ public class TableNodeTests
         }
 
         // After moving focus past the visible area, scroll should have adjusted
-        Assert.True(node.ScrollOffset > 0, "Table should have scrolled to keep focus visible");
+        Assert.IsTrue(node.ScrollOffset > 0, "Table should have scrolled to keep focus visible");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PageDown_KeyBinding_MovesFocusByPage()
     {
         var data = Enumerable.Range(1, 50).Select(i => $"Row {i}").ToArray();
@@ -425,14 +425,14 @@ public class TableNodeTests
         var keyEvent = new Hex1bKeyEvent(Hex1bKey.PageDown, '\0', Hex1bModifiers.None);
         var result = await Input.InputRouter.RouteInputToNodeAsync(node, keyEvent);
 
-        Assert.Equal(InputResult.Handled, result);
+        Assert.AreEqual(InputResult.Handled, result);
         
         // Focus should have moved by approximately one page
         var focusedIndex = (int)node.FocusedKey!;
-        Assert.True(focusedIndex > 3, $"PageDown should move focus by multiple rows, but focus is at {focusedIndex}");
+        Assert.IsTrue(focusedIndex > 3, $"PageDown should move focus by multiple rows, but focus is at {focusedIndex}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Home_KeyBinding_MovesFocusToFirstRow()
     {
         var data = Enumerable.Range(1, 50).Select(i => $"Row {i}").ToArray();
@@ -452,12 +452,12 @@ public class TableNodeTests
         var keyEvent = new Hex1bKeyEvent(Hex1bKey.Home, '\0', Hex1bModifiers.None);
         var result = await Input.InputRouter.RouteInputToNodeAsync(node, keyEvent);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(0, node.FocusedKey); // Focus moved to first row
-        Assert.Equal(0, node.ScrollOffset); // Scrolled to show first row
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(0, node.FocusedKey); // Focus moved to first row
+        Assert.AreEqual(0, node.ScrollOffset); // Scrolled to show first row
     }
 
-    [Fact]
+    [TestMethod]
     public async Task End_KeyBinding_MovesFocusToLastRow()
     {
         var data = Enumerable.Range(1, 50).Select(i => $"Row {i}").ToArray();
@@ -477,16 +477,16 @@ public class TableNodeTests
         var keyEvent = new Hex1bKeyEvent(Hex1bKey.End, '\0', Hex1bModifiers.None);
         var result = await Input.InputRouter.RouteInputToNodeAsync(node, keyEvent);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(49, node.FocusedKey); // Focus moved to last row (index 49)
-        Assert.True(node.ScrollOffset > 0, "Table should have scrolled to show last row");
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(49, node.FocusedKey); // Focus moved to last row (index 49)
+        Assert.IsTrue(node.ScrollOffset > 0, "Table should have scrolled to show last row");
     }
 
     #endregion
 
     #region Selection Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Space_KeyBinding_TogglesSelection()
     {
         var data = Enumerable.Range(1, 10).Select(i => new SelectableItem { Name = $"Row {i}" }).ToList();
@@ -508,23 +508,23 @@ public class TableNodeTests
         node.IsFocused = true;
         
         // Initially no selection
-        Assert.False(data[2].IsSelected);
+        Assert.IsFalse(data[2].IsSelected);
 
         // Press Space to select
         var keyEvent = new Hex1bKeyEvent(Hex1bKey.Spacebar, ' ', Hex1bModifiers.None);
         var result = await Input.InputRouter.RouteInputToNodeAsync(node, keyEvent);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(data[2].IsSelected);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(data[2].IsSelected);
 
         // Press Space again to deselect
         result = await Input.InputRouter.RouteInputToNodeAsync(node, keyEvent);
         
-        Assert.Equal(InputResult.Handled, result);
-        Assert.False(data[2].IsSelected);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsFalse(data[2].IsSelected);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CtrlA_KeyBinding_SelectsAllRows()
     {
         var data = Enumerable.Range(1, 10).Select(i => new SelectableItem { Name = $"Row {i}" }).ToList();
@@ -549,11 +549,11 @@ public class TableNodeTests
         var keyEvent = new Hex1bKeyEvent(Hex1bKey.A, 'a', Hex1bModifiers.Control);
         var result = await Input.InputRouter.RouteInputToNodeAsync(node, keyEvent);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(10, data.Count(item => item.IsSelected)); // All 10 rows selected
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(10, data.Count(item => item.IsSelected)); // All 10 rows selected
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ShiftDown_KeyBinding_ExtendsSelection()
     {
         var data = Enumerable.Range(1, 10).Select(i => new SelectableItem { Name = $"Row {i}" }).ToList();
@@ -579,11 +579,11 @@ public class TableNodeTests
         await Input.InputRouter.RouteInputToNodeAsync(node, keyEvent);
         await Input.InputRouter.RouteInputToNodeAsync(node, keyEvent);
 
-        Assert.Equal(3, data.Count(item => item.IsSelected)); // Rows 3, 4, 5 selected
-        Assert.Equal("Row 5", node.FocusedKey); // Focus moved to row 5
+        Assert.AreEqual(3, data.Count(item => item.IsSelected)); // Rows 3, 4, 5 selected
+        Assert.AreEqual("Row 5", node.FocusedKey); // Focus moved to row 5
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ShiftEnd_KeyBinding_SelectsToLastRow()
     {
         var data = Enumerable.Range(1, 10).Select(i => new SelectableItem { Name = $"Row {i}" }).ToList();
@@ -608,11 +608,11 @@ public class TableNodeTests
         var keyEvent = new Hex1bKeyEvent(Hex1bKey.End, '\0', Hex1bModifiers.Shift);
         await Input.InputRouter.RouteInputToNodeAsync(node, keyEvent);
 
-        Assert.Equal(5, data.Count(item => item.IsSelected)); // Rows 6, 7, 8, 9, 10 selected
-        Assert.Equal("Row 10", node.FocusedKey); // Focus at last row
+        Assert.AreEqual(5, data.Count(item => item.IsSelected)); // Rows 6, 7, 8, 9, 10 selected
+        Assert.AreEqual("Row 10", node.FocusedKey); // Focus at last row
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SelectionChangedCallback_IsCalled()
     {
         var data = Enumerable.Range(1, 10).Select(i => new SelectableItem { Name = $"Row {i}" }).ToList();
@@ -645,12 +645,12 @@ public class TableNodeTests
         var keyEvent = new Hex1bKeyEvent(Hex1bKey.Spacebar, ' ', Hex1bModifiers.None);
         await Input.InputRouter.RouteInputToNodeAsync(node, keyEvent);
 
-        Assert.NotNull(lastChangedItem);
-        Assert.Equal("Row 1", lastChangedItem.Name);
-        Assert.True(lastChangedState);
+        Assert.IsNotNull(lastChangedItem);
+        Assert.AreEqual("Row 1", lastChangedItem.Name);
+        Assert.IsTrue(lastChangedState);
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectionColumn_CellNodesAreArrangedCorrectly()
     {
         var data = new[] { "Item1", "Item2" };
@@ -670,15 +670,15 @@ public class TableNodeTests
         var headerRowNodeField = typeof(TableNode<string>).GetField("_headerRowNode", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         var headerRowNode = (TableRowNode?)headerRowNodeField?.GetValue(node);
         
-        Assert.NotNull(headerRowNode);
+        Assert.IsNotNull(headerRowNode);
         // The row node should have children (border, selection column, cell content, border)
-        Assert.True(headerRowNode.Children.Count > 0, "Header row node should have children");
+        Assert.IsTrue(headerRowNode.Children.Count > 0, "Header row node should have children");
         
         // The header row itself should be arranged at the correct position
-        Assert.True(headerRowNode.Bounds.Width > 0, "Header row should have a width");
+        Assert.IsTrue(headerRowNode.Bounds.Width > 0, "Header row should have a width");
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectionColumn_RendersSeparators()
     {
         var data = new[] { "Item1" };
@@ -703,25 +703,25 @@ public class TableNodeTests
         var char0 = surface[0, 1].Character;
         var char4 = surface[4, 1].Character;
         
-        TestContext.Current.TestOutputHelper?.WriteLine($"char[0,1]='{char0}' char[4,1]='{char4}'");
+        TestContext.Current?.WriteLine($"char[0,1]='{char0}' char[4,1]='{char4}'");
         
         // Build header row text for debugging - show each position
         var headerRow = new System.Text.StringBuilder();
         for (int x = 0; x < 15; x++)
         {
             var c = surface[x, 1].Character;
-            TestContext.Current.TestOutputHelper?.WriteLine($"  [{x}] = '{c}' (len={c?.Length ?? -1})");
+            TestContext.Current?.WriteLine($"  [{x}] = '{c}' (len={c?.Length ?? -1})");
             headerRow.Append(c);
         }
-        TestContext.Current.TestOutputHelper?.WriteLine($"Header row (first 15): '{headerRow}'");
+        TestContext.Current?.WriteLine($"Header row (first 15): '{headerRow}'");
         
         // Check that we have the selection column separator at position 4
         // Expected: │ ▢ │Name...
-        Assert.True(char0 == "│", $"Expected left border '│' at position 0, got '{char0}'"); // Left border
-        Assert.True(char4 == "│", $"Expected separator '│' at position 4, got '{char4}'"); // Selection column separator
+        Assert.IsTrue(char0 == "│", $"Expected left border '│' at position 0, got '{char0}'"); // Left border
+        Assert.IsTrue(char4 == "│", $"Expected separator '│' at position 4, got '{char4}'"); // Selection column separator
     }
 
-    [Fact]
+    [TestMethod]
     public void ColumnBorders_AlignAcrossHeaderRowsAndFooter()
     {
         // Arrange - table with multiple columns and alignment
@@ -764,7 +764,7 @@ public class TableNodeTests
             {
                 row.Append(surface[x, y].Character ?? " ");
             }
-            TestContext.Current.TestOutputHelper?.WriteLine($"Row {y}: '{row}'");
+            TestContext.Current?.WriteLine($"Row {y}: '{row}'");
         }
 
         // Expected column borders at positions:
@@ -774,46 +774,46 @@ public class TableNodeTests
         // 26: after Qty (5 chars) │ (right border)
         
         // Check top border has correct separators
-        Assert.Equal("┌", surface[0, 0].Character);
-        Assert.Equal("┬", surface[11, 0].Character);
-        Assert.Equal("┬", surface[20, 0].Character);
+        Assert.AreEqual("┌", surface[0, 0].Character);
+        Assert.AreEqual("┬", surface[11, 0].Character);
+        Assert.AreEqual("┬", surface[20, 0].Character);
         
         // Check header row (y=1) has vertical borders at correct positions
-        Assert.Equal("│", surface[0, 1].Character);
-        Assert.Equal("│", surface[11, 1].Character);
-        Assert.Equal("│", surface[20, 1].Character);
+        Assert.AreEqual("│", surface[0, 1].Character);
+        Assert.AreEqual("│", surface[11, 1].Character);
+        Assert.AreEqual("│", surface[20, 1].Character);
         
         // Check header separator (y=2) has correct crosses
-        Assert.Equal("├", surface[0, 2].Character);
-        Assert.Equal("┼", surface[11, 2].Character);
-        Assert.Equal("┼", surface[20, 2].Character);
+        Assert.AreEqual("├", surface[0, 2].Character);
+        Assert.AreEqual("┼", surface[11, 2].Character);
+        Assert.AreEqual("┼", surface[20, 2].Character);
         
         // Check data row 1 (y=3) has vertical borders at same positions
-        Assert.Equal("│", surface[0, 3].Character);
-        Assert.Equal("│", surface[11, 3].Character);
-        Assert.Equal("│", surface[20, 3].Character);
+        Assert.AreEqual("│", surface[0, 3].Character);
+        Assert.AreEqual("│", surface[11, 3].Character);
+        Assert.AreEqual("│", surface[20, 3].Character);
         
         // Check data row 2 (y=4) has vertical borders at same positions
-        Assert.Equal("│", surface[0, 4].Character);
-        Assert.Equal("│", surface[11, 4].Character);
-        Assert.Equal("│", surface[20, 4].Character);
+        Assert.AreEqual("│", surface[0, 4].Character);
+        Assert.AreEqual("│", surface[11, 4].Character);
+        Assert.AreEqual("│", surface[20, 4].Character);
         
         // Check footer separator (y=5) has correct crosses
-        Assert.Equal("├", surface[0, 5].Character);
-        Assert.Equal("┼", surface[11, 5].Character);
-        Assert.Equal("┼", surface[20, 5].Character);
+        Assert.AreEqual("├", surface[0, 5].Character);
+        Assert.AreEqual("┼", surface[11, 5].Character);
+        Assert.AreEqual("┼", surface[20, 5].Character);
         
         // Check footer row (y=6) has vertical borders at same positions
-        Assert.Equal("│", surface[0, 6].Character);
-        Assert.Equal("│", surface[11, 6].Character);
-        Assert.Equal("│", surface[20, 6].Character);
+        Assert.AreEqual("│", surface[0, 6].Character);
+        Assert.AreEqual("│", surface[11, 6].Character);
+        Assert.AreEqual("│", surface[20, 6].Character);
     }
 
     #endregion
 
     #region Integration Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TableWithKeyboardScroll_WorksEndToEnd()
     {
         // Arrange - create a full Hex1bApp with a table
@@ -821,7 +821,7 @@ public class TableNodeTests
         
         // Create recording path
         var recordingPath = Path.Combine(Path.GetTempPath(), $"table_scroll_test_{DateTime.Now:yyyyMMdd_HHmmss}.cast");
-        TestContext.Current.TestOutputHelper?.WriteLine($"Recording to: {recordingPath}");
+        TestContext.Current?.WriteLine($"Recording to: {recordingPath}");
         
         using var terminal = Hex1bTerminal.CreateBuilder()
             .WithWorkload(workload)
@@ -863,10 +863,10 @@ public class TableNodeTests
         await runTask;
         
         // Output for debugging
-        TestContext.Current.TestOutputHelper?.WriteLine("=== FINAL SCREEN ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(finalText);
-        TestContext.Current.TestOutputHelper?.WriteLine($"\nAsciinema recording saved to: {recordingPath}");
-        TestContext.Current.TestOutputHelper?.WriteLine("Play with: asciinema play " + recordingPath);
+        TestContext.Current?.WriteLine("=== FINAL SCREEN ===");
+        TestContext.Current?.WriteLine(finalText);
+        TestContext.Current?.WriteLine($"\nAsciinema recording saved to: {recordingPath}");
+        TestContext.Current?.WriteLine("Play with: asciinema play " + recordingPath);
         
         bool product1Visible = finalText.Contains("Product 1\n") || finalText.Contains("Product 1 ") || 
                                (finalText.Contains("Product 1") && !finalText.Contains("Product 1"[..9] + "0")); // Avoid matching Product 10-19
@@ -876,8 +876,8 @@ public class TableNodeTests
         var lines = finalText.Split('\n');
         bool hasExactProduct1 = lines.Any(l => l.Contains("Product 1 ") || l.Trim().EndsWith("Product 1"));
         
-        TestContext.Current.TestOutputHelper?.WriteLine($"Product 1 visible (exact): {hasExactProduct1}");
-        TestContext.Current.TestOutputHelper?.WriteLine($"Product 20 visible: {product20Visible}");
+        TestContext.Current?.WriteLine($"Product 1 visible (exact): {hasExactProduct1}");
+        TestContext.Current?.WriteLine($"Product 20 visible: {product20Visible}");
 
         // If scrolling worked, Product 1 should be scrolled out and Product 20 should be visible
         // In a 10-row terminal with header+footer, we have about 5 data rows visible.
@@ -885,7 +885,7 @@ public class TableNodeTests
         // So we should NOT see Product 1 anymore, but we SHOULD see around Product 13-18
         
         // For now, let's just verify the table rendered
-        Assert.True(finalText.Contains("Product"), "Table should contain Product text");
+        Assert.IsTrue(finalText.Contains("Product"), "Table should contain Product text");
         
         // This is the key assertion - if scrolling doesn't work, Product 1 will still be visible
         // and Product 20 will not be visible
@@ -897,10 +897,10 @@ public class TableNodeTests
         }
         
         // Positive assertion - scrolling worked!
-        Assert.True(product20Visible, $"Product 20 should be visible after scrolling. Recording: {recordingPath}");
+        Assert.IsTrue(product20Visible, $"Product 20 should be visible after scrolling. Recording: {recordingPath}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TableInVStackWithButtons_ScrollingWorks()
     {
         // Test that table scrolling works when embedded in VStack with other focusable widgets
@@ -942,13 +942,13 @@ public class TableNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         // Verify table has focus (should be first focusable)
-        Assert.NotNull(app.FocusedNode);
+        Assert.IsNotNull(app.FocusedNode);
         Assert.Contains("TableNode", app.FocusedNode.GetType().Name);
 
         // Initial state: Product 1 visible, Product 20 not visible
         var initialSnapshot = terminal.CreateSnapshot();
-        Assert.True(initialSnapshot.ContainsText("Product 1"));
-        Assert.False(initialSnapshot.ContainsText("Product 20"));
+        Assert.IsTrue(initialSnapshot.ContainsText("Product 1"));
+        Assert.IsFalse(initialSnapshot.ContainsText("Product 20"));
 
         // Send PageDown twice to scroll
         await new Hex1bTerminalInputSequenceBuilder()
@@ -970,8 +970,7 @@ public class TableNodeTests
                                      afterText.Contains("Product 21") ||
                                      afterText.Contains("Product 25");
 
-        Assert.True(product1Gone || laterProductsVisible, 
-            $"Scrolling should have changed visible products. Screen:\n{afterText}");
+        Assert.IsTrue(product1Gone || laterProductsVisible, $"Scrolling should have changed visible products. Screen:\n{afterText}");
 
         // Exit
         await new Hex1bTerminalInputSequenceBuilder()
@@ -982,7 +981,7 @@ public class TableNodeTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TableFocus_CanReceiveKeyboardInput()
     {
         // This test verifies the table is focusable and receives input
@@ -1035,14 +1034,14 @@ public class TableNodeTests
         Assert.Contains("Product", screenText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_SelectionColumn_SpaceTogglesSelection()
     {
         // Test that pressing Space toggles selection of the focused row
         using var workload = new Hex1bAppWorkloadAdapter();
         
         var recordingPath = Path.Combine(Path.GetTempPath(), $"table_selection_test_{DateTime.Now:yyyyMMdd_HHmmss}.cast");
-        TestContext.Current.TestOutputHelper?.WriteLine($"Recording to: {recordingPath}");
+        TestContext.Current?.WriteLine($"Recording to: {recordingPath}");
         
         using var terminal = Hex1bTerminal.CreateBuilder()
             .WithWorkload(workload)
@@ -1087,13 +1086,13 @@ public class TableNodeTests
         // Capture initial state
         var initialSnapshot = terminal.CreateSnapshot();
         var initialText = initialSnapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Initial State ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(initialText);
-        TestContext.Current.TestOutputHelper?.WriteLine($"Focus: {focusedKey}, Selected: {products.Count(p => p.IsSelected)}");
+        TestContext.Current?.WriteLine("=== Initial State ===");
+        TestContext.Current?.WriteLine(initialText);
+        TestContext.Current?.WriteLine($"Focus: {focusedKey}, Selected: {products.Count(p => p.IsSelected)}");
         
         // Initial state - first row focused, no selection
         Assert.Contains("▢", initialText); // Unchecked checkbox (▢)
-        Assert.Equal(0, products.Count(p => p.IsSelected));
+        Assert.AreEqual(0, products.Count(p => p.IsSelected));
 
         // Press Space to toggle selection
         await new Hex1bTerminalInputSequenceBuilder()
@@ -1104,13 +1103,13 @@ public class TableNodeTests
 
         var afterSpaceSnapshot = terminal.CreateSnapshot();
         var afterSpaceText = afterSpaceSnapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== After Space ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(afterSpaceText);
-        TestContext.Current.TestOutputHelper?.WriteLine($"Focus: {focusedKey}, Selected: {products.Count(p => p.IsSelected)}");
+        TestContext.Current?.WriteLine("=== After Space ===");
+        TestContext.Current?.WriteLine(afterSpaceText);
+        TestContext.Current?.WriteLine($"Focus: {focusedKey}, Selected: {products.Count(p => p.IsSelected)}");
 
         // After Space, first row should be selected
         Assert.Contains("▣", afterSpaceText); // Checked checkbox (▣)
-        Assert.Equal(1, products.Count(p => p.IsSelected));
+        Assert.AreEqual(1, products.Count(p => p.IsSelected));
 
         // Navigate down and select that row too
         await new Hex1bTerminalInputSequenceBuilder()
@@ -1122,12 +1121,12 @@ public class TableNodeTests
 
         var afterDownSpaceSnapshot = terminal.CreateSnapshot();
         var afterDownSpaceText = afterDownSpaceSnapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== After Down+Space ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(afterDownSpaceText);
-        TestContext.Current.TestOutputHelper?.WriteLine($"Focus: {focusedKey}, Selected: {products.Count(p => p.IsSelected)}");
+        TestContext.Current?.WriteLine("=== After Down+Space ===");
+        TestContext.Current?.WriteLine(afterDownSpaceText);
+        TestContext.Current?.WriteLine($"Focus: {focusedKey}, Selected: {products.Count(p => p.IsSelected)}");
 
         // Now two rows should be selected
-        Assert.Equal(2, products.Count(p => p.IsSelected));
+        Assert.AreEqual(2, products.Count(p => p.IsSelected));
 
         // Exit
         await new Hex1bTerminalInputSequenceBuilder()
@@ -1137,17 +1136,17 @@ public class TableNodeTests
 
         await runTask;
         
-        TestContext.Current.TestOutputHelper?.WriteLine($"\nRecording: {recordingPath}");
+        TestContext.Current?.WriteLine($"\nRecording: {recordingPath}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_SelectionColumn_MouseClickTogglesSelection()
     {
         // Test that clicking on checkbox toggles selection
         using var workload = new Hex1bAppWorkloadAdapter();
         
         var recordingPath = Path.Combine(Path.GetTempPath(), $"table_mouse_selection_test_{DateTime.Now:yyyyMMdd_HHmmss}.cast");
-        TestContext.Current.TestOutputHelper?.WriteLine($"Recording to: {recordingPath}");
+        TestContext.Current?.WriteLine($"Recording to: {recordingPath}");
         
         using var terminal = Hex1bTerminal.CreateBuilder()
             .WithWorkload(workload)
@@ -1199,12 +1198,12 @@ public class TableNodeTests
         // Capture initial state
         var initialSnapshot = terminal.CreateSnapshot();
         var initialText = initialSnapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Initial State ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(initialText);
-        TestContext.Current.TestOutputHelper?.WriteLine($"Focus: {focusedKey}, Selected: {products.Count(p => p.IsSelected)}");
+        TestContext.Current?.WriteLine("=== Initial State ===");
+        TestContext.Current?.WriteLine(initialText);
+        TestContext.Current?.WriteLine($"Focus: {focusedKey}, Selected: {products.Count(p => p.IsSelected)}");
         
         // Initial state - no selection
-        Assert.Equal(0, products.Count(p => p.IsSelected));
+        Assert.AreEqual(0, products.Count(p => p.IsSelected));
 
         // Click on the checkbox of the first data row
         // Table structure: │ ▢ │> Laptop...
@@ -1216,7 +1215,7 @@ public class TableNodeTests
         
         // Let's try clicking more towards the center of the checkbox area
         // Position X=2 should be right in the middle of " ▢ "
-        TestContext.Current.TestOutputHelper?.WriteLine($"Clicking at (2, 3) - should be on checkbox of first data row");
+        TestContext.Current?.WriteLine($"Clicking at (2, 3) - should be on checkbox of first data row");
         
         await new Hex1bTerminalInputSequenceBuilder()
             .ClickAt(2, 3)  // Click on checkbox of first data row
@@ -1226,24 +1225,24 @@ public class TableNodeTests
 
         var afterClickSnapshot = terminal.CreateSnapshot();
         var afterClickText = afterClickSnapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== After Mouse Click on Checkbox ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(afterClickText);
-        TestContext.Current.TestOutputHelper?.WriteLine($"Focus: {focusedKey}, Selected: {products.Count(p => p.IsSelected)}");
+        TestContext.Current?.WriteLine("=== After Mouse Click on Checkbox ===");
+        TestContext.Current?.WriteLine(afterClickText);
+        TestContext.Current?.WriteLine($"Focus: {focusedKey}, Selected: {products.Count(p => p.IsSelected)}");
 
         // After click on checkbox, first row should be selected
         // If this fails, the mouse event might not be reaching the table
         var selectedCount = products.Count(p => p.IsSelected);
         if (selectedCount == 0)
         {
-            TestContext.Current.TestOutputHelper?.WriteLine("FAIL: Selection is still empty after click");
-            TestContext.Current.TestOutputHelper?.WriteLine("This could mean:");
-            TestContext.Current.TestOutputHelper?.WriteLine("  1. HitTest didn't find the table node");
-            TestContext.Current.TestOutputHelper?.WriteLine("  2. Mouse binding didn't match");
-            TestContext.Current.TestOutputHelper?.WriteLine("  3. HandleRowClick didn't process the click correctly");
-            TestContext.Current.TestOutputHelper?.WriteLine($"\nRecording saved to: {recordingPath}");
+            TestContext.Current?.WriteLine("FAIL: Selection is still empty after click");
+            TestContext.Current?.WriteLine("This could mean:");
+            TestContext.Current?.WriteLine("  1. HitTest didn't find the table node");
+            TestContext.Current?.WriteLine("  2. Mouse binding didn't match");
+            TestContext.Current?.WriteLine("  3. HandleRowClick didn't process the click correctly");
+            TestContext.Current?.WriteLine($"\nRecording saved to: {recordingPath}");
         }
         
-        Assert.Equal(1, selectedCount);
+        Assert.AreEqual(1, selectedCount);
 
         // Exit
         await new Hex1bTerminalInputSequenceBuilder()
@@ -1253,7 +1252,7 @@ public class TableNodeTests
 
         await runTask;
         
-        TestContext.Current.TestOutputHelper?.WriteLine($"\nRecording: {recordingPath}");
+        TestContext.Current?.WriteLine($"\nRecording: {recordingPath}");
     }
 
     #endregion
@@ -1299,7 +1298,7 @@ public class TableNodeTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AsyncDataSource_NavigateDown_LoadsDataForNextRange()
     {
         // Arrange
@@ -1333,9 +1332,9 @@ public class TableNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         
         // Initial load should have been requested
-        Assert.NotEmpty(dataSource.LoadRequests);
+        Assert.IsNotEmpty(dataSource.LoadRequests);
         var initialRequest = dataSource.LoadRequests[0];
-        Assert.Equal(0, initialRequest.Start);
+        Assert.AreEqual(0, initialRequest.Start);
         
         // Navigate down repeatedly to reach beyond initial cache (50 items)
         var builder = new Hex1bTerminalInputSequenceBuilder();
@@ -1349,15 +1348,14 @@ public class TableNodeTests
         await runTask;
         
         // Should have loaded more data when we navigated beyond initial range
-        Assert.True(dataSource.LoadRequests.Count > 1, 
-            $"Expected additional data loads when navigating beyond cache. Only had {dataSource.LoadRequests.Count} load(s)");
+        Assert.IsTrue(dataSource.LoadRequests.Count > 1, $"Expected additional data loads when navigating beyond cache. Only had {dataSource.LoadRequests.Count} load(s)");
         
         // Focus should be on a row beyond the initial 50
-        Assert.NotNull(focusedKey);
-        TestContext.Current.TestOutputHelper?.WriteLine($"Final focus: {focusedKey}");
+        Assert.IsNotNull(focusedKey);
+        TestContext.Current?.WriteLine($"Final focus: {focusedKey}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AsyncDataSource_NavigateToEnd_LoadsLastPage()
     {
         // Arrange
@@ -1397,16 +1395,15 @@ public class TableNodeTests
         
         // Should have loaded data for the end of the list
         var lastRequest = dataSource.LoadRequests[^1];
-        TestContext.Current.TestOutputHelper?.WriteLine($"Last load request: start={lastRequest.Start}, count={lastRequest.Count}");
-        Assert.True(lastRequest.Start > 400, 
-            $"Expected load request near end of list (>400), got start={lastRequest.Start}");
+        TestContext.Current?.WriteLine($"Last load request: start={lastRequest.Start}, count={lastRequest.Count}");
+        Assert.IsTrue(lastRequest.Start > 400, $"Expected load request near end of list (>400), got start={lastRequest.Start}");
         
         // Focus should be on the last item
-        TestContext.Current.TestOutputHelper?.WriteLine($"Final focus: {focusedKey}");
-        Assert.Equal("Item 00500", focusedKey);
+        TestContext.Current?.WriteLine($"Final focus: {focusedKey}");
+        Assert.AreEqual("Item 00500", focusedKey);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AsyncDataSource_NavigateDownThenUp_MaintainsCorrectFocus()
     {
         // Arrange
@@ -1449,7 +1446,7 @@ public class TableNodeTests
         await downBuilder.Build().ApplyAsync(terminal, TestContext.Current.CancellationToken);
         
         var focusAfterDown = focusedKey;
-        TestContext.Current.TestOutputHelper?.WriteLine($"Focus after 60 downs: {focusAfterDown}");
+        TestContext.Current?.WriteLine($"Focus after 60 downs: {focusAfterDown}");
         
         // Now navigate up 5 rows
         var upBuilder = new Hex1bTerminalInputSequenceBuilder();
@@ -1460,7 +1457,7 @@ public class TableNodeTests
         await upBuilder.Build().ApplyAsync(terminal, TestContext.Current.CancellationToken);
         
         var focusAfterUp = focusedKey;
-        TestContext.Current.TestOutputHelper?.WriteLine($"Focus after 5 ups: {focusAfterUp}");
+        TestContext.Current?.WriteLine($"Focus after 5 ups: {focusAfterUp}");
         
         // Now navigate down again - this should work
         var downAgainBuilder = new Hex1bTerminalInputSequenceBuilder();
@@ -1474,16 +1471,16 @@ public class TableNodeTests
         await runTask;
         
         var finalFocus = focusedKey;
-        TestContext.Current.TestOutputHelper?.WriteLine($"Final focus: {finalFocus}");
-        TestContext.Current.TestOutputHelper?.WriteLine($"Focus history count: {focusHistory.Count}");
+        TestContext.Current?.WriteLine($"Final focus: {finalFocus}");
+        TestContext.Current?.WriteLine($"Focus history count: {focusHistory.Count}");
         
         // Verify focus movements
-        Assert.Equal("Item 00061", focusAfterDown);
-        Assert.Equal("Item 00056", focusAfterUp);
-        Assert.Equal("Item 00061", finalFocus);
+        Assert.AreEqual("Item 00061", focusAfterDown);
+        Assert.AreEqual("Item 00056", focusAfterUp);
+        Assert.AreEqual("Item 00061", finalFocus);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AsyncDataSource_InitialRender_SetsFocusToFirstRow()
     {
         // Arrange - async data source with NO initial focus (null)
@@ -1521,11 +1518,11 @@ public class TableNodeTests
         await runTask;
         
         // Assert - focus should be automatically set to first row
-        TestContext.Current.TestOutputHelper?.WriteLine($"Final focus: {focusedKey}");
-        Assert.Equal("Item 00001", focusedKey);
+        TestContext.Current?.WriteLine($"Final focus: {focusedKey}");
+        Assert.AreEqual("Item 00001", focusedKey);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AsyncDataSource_AfterRender_ShowsFocusBarsOnFirstRow()
     {
         // Arrange - async data source with NO initial focus (null)
@@ -1563,8 +1560,8 @@ public class TableNodeTests
         // Capture the screen
         var snapshot = terminal.CreateSnapshot();
         var screenText = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Screen after stabilization ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(screenText);
+        TestContext.Current?.WriteLine("=== Screen after stabilization ===");
+        TestContext.Current?.WriteLine(screenText);
         
         // Check for focus bars (thick vertical borders ┃) on the first data row
         // The focused row should have ┃ characters instead of │
@@ -1579,11 +1576,10 @@ public class TableNodeTests
         await runTask;
         
         // Assert
-        Assert.True(hasFocusBars, 
-            $"Expected focus bars (┃) on first row. Focus key: {focusedKey}\nScreen:\n{screenText}");
+        Assert.IsTrue(hasFocusBars, $"Expected focus bars (┃) on first row. Focus key: {focusedKey}\nScreen:\n{screenText}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task AsyncDataSource_ClickOnRow_ShowsFocusBarsAfterClick()
     {
         // Arrange - async data source 
@@ -1621,9 +1617,9 @@ public class TableNodeTests
         // Capture screen before click
         var beforeSnapshot = terminal.CreateSnapshot();
         var beforeText = beforeSnapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Before click ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(beforeText);
-        TestContext.Current.TestOutputHelper?.WriteLine($"Focus before click: {focusedKey}");
+        TestContext.Current?.WriteLine("=== Before click ===");
+        TestContext.Current?.WriteLine(beforeText);
+        TestContext.Current?.WriteLine($"Focus before click: {focusedKey}");
         
         // Click on row 5 (approximately y=6: top border + header + separator + rows 1-3)
         await new Hex1bTerminalInputSequenceBuilder()
@@ -1635,9 +1631,9 @@ public class TableNodeTests
         // Capture screen after click
         var afterSnapshot = terminal.CreateSnapshot();
         var afterText = afterSnapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== After click ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(afterText);
-        TestContext.Current.TestOutputHelper?.WriteLine($"Focus after click: {focusedKey}");
+        TestContext.Current?.WriteLine("=== After click ===");
+        TestContext.Current?.WriteLine(afterText);
+        TestContext.Current?.WriteLine($"Focus after click: {focusedKey}");
         
         // Check for focus bars on the clicked row
         // Focus should have moved, and we should see ┃ on the new focused row
@@ -1652,8 +1648,7 @@ public class TableNodeTests
         await runTask;
         
         // Assert
-        Assert.True(hasFocusBars, 
-            $"Expected focus bars (┃) after click. Focus key: {focusedKey}\nScreen after click:\n{afterText}");
+        Assert.IsTrue(hasFocusBars, $"Expected focus bars (┃) after click. Focus key: {focusedKey}\nScreen after click:\n{afterText}");
     }
 
     #endregion
@@ -1747,7 +1742,7 @@ public class TableNodeTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task VirtualizedScroll_SetFocusToRowOutsideCache_UsesIndexLookup()
     {
         // Arrange
@@ -1788,7 +1783,7 @@ public class TableNodeTests
         Assert.Contains("Row 500", dataSource.IndexLookupKeys);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task VirtualizedScroll_DataSourceWithoutIndexLookup_DoesNotScrollToRowOutsideCache()
     {
         // Arrange - data source without GetIndexForKey should NOT scroll to out-of-cache row
@@ -1835,7 +1830,7 @@ public class TableNodeTests
 
     #region Focus Scroll and Click Handler Bug Fixes
 
-    [Fact]
+    [TestMethod]
     public async Task Focus_ExternalSetToRowOffScreen_ScrollsToMakeRowVisible()
     {
         // This tests the fix for: when setting FocusKey externally via TableWidget.Focus(key),
@@ -1873,8 +1868,8 @@ public class TableNodeTests
         // Capture screen to see what's visible initially
         var snapshotInitial = terminal.CreateSnapshot();
         var textInitial = snapshotInitial.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine($"=== Initial screen (focus Item 001) ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(textInitial);
+        TestContext.Current?.WriteLine($"=== Initial screen (focus Item 001) ===");
+        TestContext.Current?.WriteLine(textInitial);
         
         // Initially, should see Item 001 and possibly a few more
         Assert.Contains("Item 001", textInitial);
@@ -1903,8 +1898,8 @@ public class TableNodeTests
         // Capture the screen to verify
         var snapshot = terminal.CreateSnapshot();
         var text = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine($"=== After Focus(Item 050) ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(text);
+        TestContext.Current?.WriteLine($"=== After Focus(Item 050) ===");
+        TestContext.Current?.WriteLine(text);
         
         // Row 50 should now be visible in the rendered output
         Assert.Contains("Item 050", text);
@@ -1921,7 +1916,7 @@ public class TableNodeTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Click_AfterScrollingInVirtualizedTable_ReturnsCorrectRowData()
     {
         // This tests the fix for: clicking rows after scrolling in a virtualized table
@@ -1974,9 +1969,9 @@ public class TableNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         
         var snapshotBeforeClick = terminal.CreateSnapshot();
-        TestContext.Current.TestOutputHelper?.WriteLine($"=== After navigation ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(snapshotBeforeClick.GetScreenText());
-        TestContext.Current.TestOutputHelper?.WriteLine($"Focus before click: {focusedKey}");
+        TestContext.Current?.WriteLine($"=== After navigation ===");
+        TestContext.Current?.WriteLine(snapshotBeforeClick.GetScreenText());
+        TestContext.Current?.WriteLine($"Focus before click: {focusedKey}");
         
         // Now click on the first visible row (which should be around row 50)
         // The click handler should correctly map this to the right data
@@ -1988,17 +1983,16 @@ public class TableNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         
         var snapshotAfter = terminal.CreateSnapshot();
-        TestContext.Current.TestOutputHelper?.WriteLine($"=== After click ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(snapshotAfter.GetScreenText());
-        TestContext.Current.TestOutputHelper?.WriteLine($"Focus after click: {focusedKey}");
+        TestContext.Current?.WriteLine($"=== After click ===");
+        TestContext.Current?.WriteLine(snapshotAfter.GetScreenText());
+        TestContext.Current?.WriteLine($"Focus after click: {focusedKey}");
         
         // The focused key should NOT be null - click should have set focus
-        Assert.NotNull(focusedKey);
+        Assert.IsNotNull(focusedKey);
         
         // The focused key should be around row 50 (the first visible row after navigation)
         // and should contain "Item 0" (since we're looking at items 50+)
-        Assert.True(focusedKey?.ToString()?.StartsWith("Item 0") == true,
-            $"Expected focus to be on an item starting with 'Item 0', but got: {focusedKey}");
+        Assert.IsTrue(focusedKey?.ToString()?.StartsWith("Item 0") == true, $"Expected focus to be on an item starting with 'Item 0', but got: {focusedKey}");
         
         // Exit
         await new Hex1bTerminalInputSequenceBuilder()
@@ -2013,7 +2007,7 @@ public class TableNodeTests
     
     #region Table Focus Indicator Tests
 
-    [Fact(Skip = "Feature not yet implemented - table-level focus indicator")]
+    [TestMethod, Ignore("Feature not yet implemented - table-level focus indicator")]
     public async Task Table_WhenFocused_ShouldShowTableLevelFocusIndicator()
     {
         // Arrange - table with focusable rows
@@ -2048,8 +2042,8 @@ public class TableNodeTests
         
         var snapshot = terminal.CreateSnapshot();
         var screenText = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Table with focus ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(screenText);
+        TestContext.Current?.WriteLine("=== Table with focus ===");
+        TestContext.Current?.WriteLine(screenText);
         
         // Exit
         await new Hex1bTerminalInputSequenceBuilder()
@@ -2074,15 +2068,14 @@ public class TableNodeTests
             screenText.Contains("┃┃");   // Some other focus indicator
             
         // Note: This test is expected to FAIL until we implement table-level focus indicator
-        Assert.True(hasTableFocusIndicator, 
-            $"Expected table-level focus indicator when table is focused.\nScreen:\n{screenText}");
+        Assert.IsTrue(hasTableFocusIndicator, $"Expected table-level focus indicator when table is focused.\nScreen:\n{screenText}");
     }
 
     #endregion
     
     #region Table Border Rendering Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Table_FullMode_ShouldHaveRightTeeOnRowSeparators()
     {
         // Arrange - table in Full mode should have ┤ at right edge of row separators
@@ -2114,8 +2107,8 @@ public class TableNodeTests
         
         var snapshot = terminal.CreateSnapshot();
         var screenText = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Table in Full mode ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(screenText);
+        TestContext.Current?.WriteLine("=== Table in Full mode ===");
+        TestContext.Current?.WriteLine(screenText);
         
         // Exit
         await new Hex1bTerminalInputSequenceBuilder()
@@ -2139,11 +2132,10 @@ public class TableNodeTests
         
         bool hasRightTee = screenText.Contains("┤");
         
-        Assert.True(hasRightTee, 
-            $"Expected right tee (┤) characters at right edge of row separators in Full mode.\nScreen:\n{screenText}");
+        Assert.IsTrue(hasRightTee, $"Expected right tee (┤) characters at right edge of row separators in Full mode.\nScreen:\n{screenText}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LargeTable_Virtualized_ShouldHaveCorrectBorders()
     {
         // Arrange - large virtualized table should still have correct borders
@@ -2176,8 +2168,8 @@ public class TableNodeTests
         
         var snapshot = terminal.CreateSnapshot();
         var screenText = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Large virtualized table ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(screenText);
+        TestContext.Current?.WriteLine("=== Large virtualized table ===");
+        TestContext.Current?.WriteLine(screenText);
         
         // Exit
         await new Hex1bTerminalInputSequenceBuilder()
@@ -2208,11 +2200,10 @@ public class TableNodeTests
         if (!hasLeftTee) errors.Add("Missing left tee (├) on header separator");
         if (!hasRightTee) errors.Add("Missing right tee (┤) on header separator");
         
-        Assert.True(errors.Count == 0, 
-            $"Border issues found:\n{string.Join("\n", errors)}\n\nScreen:\n{screenText}");
+        Assert.IsTrue(errors.Count == 0, $"Border issues found:\n{string.Join("\n", errors)}\n\nScreen:\n{screenText}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LargeTable_FullMode_RowSeparatorsShouldHaveRightTee()
     {
         // Arrange - large virtualized table in Full mode with row separators
@@ -2246,8 +2237,8 @@ public class TableNodeTests
         
         var snapshot = terminal.CreateSnapshot();
         var screenText = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Large table in Full mode ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(screenText);
+        TestContext.Current?.WriteLine("=== Large table in Full mode ===");
+        TestContext.Current?.WriteLine(screenText);
         
         // Exit
         await new Hex1bTerminalInputSequenceBuilder()
@@ -2278,17 +2269,16 @@ public class TableNodeTests
                 completeSeperatorLines++;
         }
         
-        TestContext.Current.TestOutputHelper?.WriteLine($"Left tee (├) count: {leftTeeCount}");
-        TestContext.Current.TestOutputHelper?.WriteLine($"Right tee (┤) count: {rightTeeCount}");
-        TestContext.Current.TestOutputHelper?.WriteLine($"Complete separator lines (both ├ and ┤): {completeSeperatorLines}");
+        TestContext.Current?.WriteLine($"Left tee (├) count: {leftTeeCount}");
+        TestContext.Current?.WriteLine($"Right tee (┤) count: {rightTeeCount}");
+        TestContext.Current?.WriteLine($"Complete separator lines (both ├ and ┤): {completeSeperatorLines}");
         
         // Each separator line should have both left and right tees
-        Assert.Equal(leftTeeCount, completeSeperatorLines);
-        Assert.True(completeSeperatorLines > 1, 
-            $"Expected multiple complete row separators in Full mode, found {completeSeperatorLines}.\nScreen:\n{screenText}");
+        Assert.AreEqual(leftTeeCount, completeSeperatorLines);
+        Assert.IsTrue(completeSeperatorLines > 1, $"Expected multiple complete row separators in Full mode, found {completeSeperatorLines}.\nScreen:\n{screenText}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LargeTable_FullMode_MultiColumn_RowSeparatorsShouldHaveRightTee()
     {
         // Arrange - large virtualized table in Full mode with multiple columns
@@ -2333,8 +2323,8 @@ public class TableNodeTests
         
         var snapshot = terminal.CreateSnapshot();
         var screenText = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Large multi-column table in Full mode ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(screenText);
+        TestContext.Current?.WriteLine("=== Large multi-column table in Full mode ===");
+        TestContext.Current?.WriteLine(screenText);
         
         // Exit
         await new Hex1bTerminalInputSequenceBuilder()
@@ -2350,13 +2340,13 @@ public class TableNodeTests
         var lines = screenText.Split('\n');
         var separatorLines = lines.Where(l => l.Contains("├") && l.Contains("─") && l.Contains("┼")).ToList();
         
-        TestContext.Current.TestOutputHelper?.WriteLine($"\nFound {separatorLines.Count} separator lines:");
+        TestContext.Current?.WriteLine($"\nFound {separatorLines.Count} separator lines:");
         
         var linesWithWrongEnding = new List<string>();
         foreach (var line in separatorLines)
         {
             var trimmed = line.TrimEnd();
-            TestContext.Current.TestOutputHelper?.WriteLine($"  Ends with: '{trimmed[^1]}' - {trimmed[^20..]}");
+            TestContext.Current?.WriteLine($"  Ends with: '{trimmed[^1]}' - {trimmed[^20..]}");
             
             // Separator lines should have ┤ as the table's right border
             // With scrollbar: ends with ┤││ or ┤▉│ (TeeLeft + scrollbar track + scrollbar border)
@@ -2382,12 +2372,11 @@ public class TableNodeTests
             }
         }
         
-        Assert.True(linesWithWrongEnding.Count == 0, 
-            $"Found {linesWithWrongEnding.Count} separator lines with incorrect ending.\n" +
+        Assert.IsTrue(linesWithWrongEnding.Count == 0, $"Found {linesWithWrongEnding.Count} separator lines with incorrect ending.\n" +
             $"First bad line: {linesWithWrongEnding.FirstOrDefault()}\n\nScreen:\n{screenText}");
     }
 
-        [Fact]
+        [TestMethod]
     public async Task Table_WithLargeAsyncDataSource_ShouldShowScrollbar()
     {
         // Arrange - simulate 10k items
@@ -2439,10 +2428,10 @@ public class TableNodeTests
         var hasScrollbar = lines.Any(line => 
             line.Length > 0 && scrollbarChars.Contains(line[^1]));
         
-        Assert.True(hasScrollbar, $"Expected scrollbar in rightmost column.\n\nScreen:\n{screenText}");
+        Assert.IsTrue(hasScrollbar, $"Expected scrollbar in rightmost column.\n\nScreen:\n{screenText}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_WithLargeSyncDataSource_ShouldShowScrollbar()
     {
         // Arrange - 10k items with synchronous data (IReadOnlyList)
@@ -2493,7 +2482,7 @@ public class TableNodeTests
         Assert.Contains("┃", screenText, StringComparison.Ordinal);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_WindowingDemoConfig_ScrollbarAdjacentToFixedColumns()
     {
         // Reproduces the exact bug seen in the WindowingDemo sample:
@@ -2549,8 +2538,8 @@ public class TableNodeTests
 
         var snapshot = terminal.CreateSnapshot();
         var screenText = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== WindowingDemo-style table with scrollbar ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(screenText);
+        TestContext.Current?.WriteLine("=== WindowingDemo-style table with scrollbar ===");
+        TestContext.Current?.WriteLine(screenText);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -2561,38 +2550,37 @@ public class TableNodeTests
         // Parse separator to verify column widths match demo definitions exactly
         var lines = screenText.Split('\n');
         var separator = lines.FirstOrDefault(l => l.Contains('├') && l.Contains('┼'));
-        Assert.NotNull(separator);
+        Assert.IsNotNull(separator);
 
         var inner = separator.TrimEnd();
         int leftIdx = inner.IndexOf('├');
         int rightIdx = inner.LastIndexOf('┤');
-        Assert.True(leftIdx >= 0 && rightIdx > leftIdx, $"Could not parse separator: {separator}");
+        Assert.IsTrue(leftIdx >= 0 && rightIdx > leftIdx, $"Could not parse separator: {separator}");
 
         var columnSection = inner[(leftIdx + 1)..rightIdx];
         var columnParts = columnSection.Split('┼');
-        Assert.True(columnParts.Length >= 4, $"Expected at least 4 column parts, got {columnParts.Length}. Separator: {separator}");
+        Assert.IsTrue(columnParts.Length >= 4, $"Expected at least 4 column parts, got {columnParts.Length}. Separator: {separator}");
 
         // Fixed(18), Fixed(12), Fixed(6), Fixed(10) — must be exact
-        Assert.Equal(18, columnParts[0].Length);
-        Assert.Equal(12, columnParts[1].Length);
-        Assert.Equal(6, columnParts[2].Length);
-        Assert.Equal(10, columnParts[3].Length);
+        Assert.AreEqual(18, columnParts[0].Length);
+        Assert.AreEqual(12, columnParts[1].Length);
+        Assert.AreEqual(6, columnParts[2].Length);
+        Assert.AreEqual(10, columnParts[3].Length);
 
         // Scrollbar must be adjacent — no gap between columns and scrollbar
         var topBorder = lines.FirstOrDefault(l => l.Contains('┌'));
-        Assert.NotNull(topBorder);
+        Assert.IsNotNull(topBorder);
         Assert.DoesNotContain("┬ ", topBorder.TrimEnd());
 
         // Table content width = 18+12+6+10 cols + 5 borders + 2 scrollbar = 53
         var trimmedBorder = topBorder.TrimEnd();
-        Assert.Equal(53, trimmedBorder.Length);
+        Assert.AreEqual(53, trimmedBorder.Length);
 
         // Scrollbar thumb must be present
-        Assert.True(screenText.Contains('▉') || screenText.Contains('┃'),
-            $"Expected scrollbar thumb.\n\nScreen:\n{screenText}");
+        Assert.IsTrue(screenText.Contains('▉') || screenText.Contains('┃'), $"Expected scrollbar thumb.\n\nScreen:\n{screenText}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_WindowingDemoConfig_TallWindow_NoScrollbarSameWidths()
     {
         // Same column config as demo but with a tall window (no scrollbar needed).
@@ -2645,8 +2633,8 @@ public class TableNodeTests
 
         var snapshot = terminal.CreateSnapshot();
         var screenText = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== WindowingDemo-style table without scrollbar ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(screenText);
+        TestContext.Current?.WriteLine("=== WindowingDemo-style table without scrollbar ===");
+        TestContext.Current?.WriteLine(screenText);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -2657,20 +2645,20 @@ public class TableNodeTests
         // Parse separator to verify column widths are identical to scrollbar case
         var lines = screenText.Split('\n');
         var separator = lines.FirstOrDefault(l => l.Contains('├') && l.Contains('┼'));
-        Assert.NotNull(separator);
+        Assert.IsNotNull(separator);
 
         var inner = separator.TrimEnd();
         int leftIdx = inner.IndexOf('├');
         int rightIdx = inner.LastIndexOf('┤');
         var columnSection = inner[(leftIdx + 1)..rightIdx];
         var columnParts = columnSection.Split('┼');
-        Assert.True(columnParts.Length >= 4, $"Expected at least 4 column parts. Separator: {separator}");
+        Assert.IsTrue(columnParts.Length >= 4, $"Expected at least 4 column parts. Separator: {separator}");
 
         // Same exact widths as scrollbar case: Fixed(18), Fixed(12), Fixed(6), Fixed(10)
-        Assert.Equal(18, columnParts[0].Length);
-        Assert.Equal(12, columnParts[1].Length);
-        Assert.Equal(6, columnParts[2].Length);
-        Assert.Equal(10, columnParts[3].Length);
+        Assert.AreEqual(18, columnParts[0].Length);
+        Assert.AreEqual(12, columnParts[1].Length);
+        Assert.AreEqual(6, columnParts[2].Length);
+        Assert.AreEqual(10, columnParts[3].Length);
 
         // No scrollbar present
         Assert.DoesNotContain("┃", screenText);
@@ -2678,12 +2666,12 @@ public class TableNodeTests
 
         // Table content width = 18+12+6+10 cols + 5 borders = 51 (no scrollbar)
         var topBorder = lines.FirstOrDefault(l => l.Contains('┌'));
-        Assert.NotNull(topBorder);
+        Assert.IsNotNull(topBorder);
         var trimmedBorder = topBorder.TrimEnd();
-        Assert.Equal(51, trimmedBorder.Length);
+        Assert.AreEqual(51, trimmedBorder.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_AllFixedColumns_ScrollbarAdjacentToContent()
     {
         // Arrange - table with all Fixed-width columns that needs a scrollbar.
@@ -2726,8 +2714,8 @@ public class TableNodeTests
 
         var snapshot = terminal.CreateSnapshot();
         var screenText = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Table with all fixed columns + scrollbar ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(screenText);
+        TestContext.Current?.WriteLine("=== Table with all fixed columns + scrollbar ===");
+        TestContext.Current?.WriteLine(screenText);
 
         // Exit
         await new Hex1bTerminalInputSequenceBuilder()
@@ -2741,7 +2729,7 @@ public class TableNodeTests
         // Incorrect: ┌────────────┬──────────┬─────┬          ─┐  (gap between columns and scrollbar)
         var lines = screenText.Split('\n');
         var topBorder = lines.FirstOrDefault(l => l.Contains('┌'));
-        Assert.NotNull(topBorder);
+        Assert.IsNotNull(topBorder);
 
         // The top border should NOT have spaces between border characters
         // A gap manifests as spaces between ┬ and ─┐
@@ -2749,11 +2737,10 @@ public class TableNodeTests
         Assert.DoesNotContain("┬ ", borderContent);
 
         // Also verify the scrollbar thumb is present (table is scrollable)
-        Assert.True(screenText.Contains('▉') || screenText.Contains('┃'),
-            $"Expected scrollbar thumb character in output.\n\nScreen:\n{screenText}");
+        Assert.IsTrue(screenText.Contains('▉') || screenText.Contains('┃'), $"Expected scrollbar thumb character in output.\n\nScreen:\n{screenText}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_FixedColumnsWithoutScrollbar_ColumnWidthsMatchDefinitions()
     {
         // When a table has few rows (no scrollbar needed), fixed columns should have
@@ -2792,8 +2779,8 @@ public class TableNodeTests
 
         var snapshot = terminal.CreateSnapshot();
         var screenText = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Fixed columns without scrollbar ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(screenText);
+        TestContext.Current?.WriteLine("=== Fixed columns without scrollbar ===");
+        TestContext.Current?.WriteLine(screenText);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -2805,29 +2792,29 @@ public class TableNodeTests
         // The separator line looks like: ├────────────┼──────────┼─────┤
         var lines = screenText.Split('\n');
         var separator = lines.FirstOrDefault(l => l.Contains('├') && l.Contains('┼'));
-        Assert.NotNull(separator);
+        Assert.IsNotNull(separator);
 
         // Extract column widths by splitting on ┼ (cross) characters
         // Strip left ├ and right ┤
         var inner = separator.TrimEnd();
         int leftIdx = inner.IndexOf('├');
         int rightIdx = inner.LastIndexOf('┤');
-        Assert.True(leftIdx >= 0 && rightIdx > leftIdx, $"Could not parse separator: {separator}");
+        Assert.IsTrue(leftIdx >= 0 && rightIdx > leftIdx, $"Could not parse separator: {separator}");
 
         var columnSection = inner[(leftIdx + 1)..rightIdx];
         var columnParts = columnSection.Split('┼');
-        Assert.Equal(3, columnParts.Length);
+        Assert.AreEqual(3, columnParts.Length);
 
         // Each column width should match the Fixed hint
-        Assert.Equal(12, columnParts[0].Length); // Fixed(12)
-        Assert.Equal(10, columnParts[1].Length); // Fixed(10)
-        Assert.Equal(5, columnParts[2].Length);  // Fixed(5)
+        Assert.AreEqual(12, columnParts[0].Length); // Fixed(12)
+        Assert.AreEqual(10, columnParts[1].Length); // Fixed(10)
+        Assert.AreEqual(5, columnParts[2].Length);  // Fixed(5)
 
         // No scrollbar should be present
         Assert.DoesNotContain("┃", screenText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_FixedColumnsWithScrollbar_ColumnWidthsSameAsWithout()
     {
         // CRITICAL: Fixed column widths must be identical regardless of whether a scrollbar
@@ -2869,8 +2856,8 @@ public class TableNodeTests
 
         var snapshot = terminal.CreateSnapshot();
         var screenText = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Fixed columns with scrollbar ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(screenText);
+        TestContext.Current?.WriteLine("=== Fixed columns with scrollbar ===");
+        TestContext.Current?.WriteLine(screenText);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -2882,32 +2869,31 @@ public class TableNodeTests
         // Note the ┼─┤ at end is scrollbar column joining character
         var lines = screenText.Split('\n');
         var separator = lines.FirstOrDefault(l => l.Contains('├') && l.Contains('┼'));
-        Assert.NotNull(separator);
+        Assert.IsNotNull(separator);
 
         // Extract the section between ├ and the last ┤, but note the scrollbar adds
         // an extra section at the end. Split on ┼.
         var inner = separator.TrimEnd();
         int leftIdx = inner.IndexOf('├');
         int rightIdx = inner.LastIndexOf('┤');
-        Assert.True(leftIdx >= 0 && rightIdx > leftIdx, $"Could not parse separator: {separator}");
+        Assert.IsTrue(leftIdx >= 0 && rightIdx > leftIdx, $"Could not parse separator: {separator}");
 
         var columnSection = inner[(leftIdx + 1)..rightIdx];
         var columnParts = columnSection.Split('┼');
 
         // With scrollbar: 3 data columns + 1 scrollbar track section = 4 parts (or 3 + ┤ via scrollbar)
         // The first 3 should match Fixed widths exactly
-        Assert.True(columnParts.Length >= 3, $"Expected at least 3 column sections, got {columnParts.Length}. Separator: {separator}");
+        Assert.IsTrue(columnParts.Length >= 3, $"Expected at least 3 column sections, got {columnParts.Length}. Separator: {separator}");
 
-        Assert.Equal(12, columnParts[0].Length); // Fixed(12) - same as without scrollbar
-        Assert.Equal(10, columnParts[1].Length); // Fixed(10) - same as without scrollbar
-        Assert.Equal(5, columnParts[2].Length);  // Fixed(5) - same as without scrollbar
+        Assert.AreEqual(12, columnParts[0].Length); // Fixed(12) - same as without scrollbar
+        Assert.AreEqual(10, columnParts[1].Length); // Fixed(10) - same as without scrollbar
+        Assert.AreEqual(5, columnParts[2].Length);  // Fixed(5) - same as without scrollbar
 
         // Scrollbar thumb should be present
-        Assert.True(screenText.Contains('▉') || screenText.Contains('┃'),
-            $"Expected scrollbar thumb character.\n\nScreen:\n{screenText}");
+        Assert.IsTrue(screenText.Contains('▉') || screenText.Contains('┃'), $"Expected scrollbar thumb character.\n\nScreen:\n{screenText}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_MixedFixedAndFillColumns_FillAbsorbsRemainingSpace()
     {
         // When a table has a mix of Fixed and Fill columns, the Fill column should
@@ -2949,8 +2935,8 @@ public class TableNodeTests
 
         var snapshot = terminal.CreateSnapshot();
         var screenText = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Mixed Fixed+Fill columns with scrollbar ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(screenText);
+        TestContext.Current?.WriteLine("=== Mixed Fixed+Fill columns with scrollbar ===");
+        TestContext.Current?.WriteLine(screenText);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -2961,7 +2947,7 @@ public class TableNodeTests
         // Parse separator to verify Fixed columns are exactly their defined widths
         var lines = screenText.Split('\n');
         var separator = lines.FirstOrDefault(l => l.Contains('├') && l.Contains('┼'));
-        Assert.NotNull(separator);
+        Assert.IsNotNull(separator);
 
         var inner = separator.TrimEnd();
         int leftIdx = inner.IndexOf('├');
@@ -2970,27 +2956,26 @@ public class TableNodeTests
         var columnParts = columnSection.Split('┼');
 
         // Should have at least 3 data column parts
-        Assert.True(columnParts.Length >= 3, $"Expected at least 3 column sections. Separator: {separator}");
+        Assert.IsTrue(columnParts.Length >= 3, $"Expected at least 3 column sections. Separator: {separator}");
 
         // Fixed(15) column must be exactly 15
-        Assert.Equal(15, columnParts[0].Length);
+        Assert.AreEqual(15, columnParts[0].Length);
         // Fill column absorbs remaining width - just check it's > 0
-        Assert.True(columnParts[1].Length > 0, "Fill column should have non-zero width");
+        Assert.IsTrue(columnParts[1].Length > 0, "Fill column should have non-zero width");
         // Fixed(8) column must be exactly 8
-        Assert.Equal(8, columnParts[2].Length);
+        Assert.AreEqual(8, columnParts[2].Length);
 
         // Fill column should expand to absorb space (with scrollbar, total = 60)
         // borders: 4 (|col|col|col|), scrollbar: 2, fixed: 15+8=23 → fill ≈ 31
-        Assert.True(columnParts[1].Length > 20,
-            $"Fill column should absorb remaining space, got width={columnParts[1].Length}");
+        Assert.IsTrue(columnParts[1].Length > 20, $"Fill column should absorb remaining space, got width={columnParts[1].Length}");
 
         // Verify no gap - top border should have no spaces between border chars
         var topBorder = lines.FirstOrDefault(l => l.Contains('┌'));
-        Assert.NotNull(topBorder);
+        Assert.IsNotNull(topBorder);
         Assert.DoesNotContain("┬ ", topBorder.TrimEnd());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_AllFillColumns_WithScrollbar_NoGap()
     {
         // All Fill columns should expand to fill the available width, and the scrollbar
@@ -3030,8 +3015,8 @@ public class TableNodeTests
 
         var snapshot = terminal.CreateSnapshot();
         var screenText = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== All Fill columns with scrollbar ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(screenText);
+        TestContext.Current?.WriteLine("=== All Fill columns with scrollbar ===");
+        TestContext.Current?.WriteLine(screenText);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -3042,16 +3027,16 @@ public class TableNodeTests
         // Top border should end with ┬─┐ (scrollbar connection) with no gap
         var lines = screenText.Split('\n');
         var topBorder = lines.FirstOrDefault(l => l.Contains('┌'));
-        Assert.NotNull(topBorder);
+        Assert.IsNotNull(topBorder);
         Assert.DoesNotContain("┬ ", topBorder.TrimEnd());
 
         // With Fill columns, the table should fill the entire width (50 chars)
         // So the right edge of the top border should be at position 49
         var trimmedBorder = topBorder.TrimEnd();
-        Assert.Equal(50, trimmedBorder.Length);
+        Assert.AreEqual(50, trimmedBorder.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_FixedColumnsNarrowWidth_ScrollbarStillAdjacentWhenTableFillsWidth()
     {
         // When the terminal is narrow enough that fixed columns + scrollbar fill almost
@@ -3092,8 +3077,8 @@ public class TableNodeTests
 
         var snapshot = terminal.CreateSnapshot();
         var screenText = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Fixed columns narrow terminal ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(screenText);
+        TestContext.Current?.WriteLine("=== Fixed columns narrow terminal ===");
+        TestContext.Current?.WriteLine(screenText);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -3106,17 +3091,17 @@ public class TableNodeTests
         // Scrollbar must be at position 30 (adjacent to columns), not position 35.
         var lines = screenText.Split('\n');
         var topBorder = lines.FirstOrDefault(l => l.Contains('┌'));
-        Assert.NotNull(topBorder);
+        Assert.IsNotNull(topBorder);
         
         var trimmedBorder = topBorder.TrimEnd();
         // Table content width = 10+8+6 (cols) + 4 (borders |c|c|c|) + 2 (scrollbar) = 30
-        Assert.Equal(30, trimmedBorder.Length);
+        Assert.AreEqual(30, trimmedBorder.Length);
         
         // Should NOT have any space before ┐
-        Assert.False(trimmedBorder.Contains(' '), $"Top border should have no spaces: [{trimmedBorder}]");
+        Assert.IsFalse(trimmedBorder.Contains(' '), $"Top border should have no spaces: [{trimmedBorder}]");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_FixedColumnsWideTerminal_ScrollbarNotAtFarRightEdge()
     {
         // When the terminal is much wider than the table content, the scrollbar should
@@ -3155,8 +3140,8 @@ public class TableNodeTests
 
         var snapshot = terminal.CreateSnapshot();
         var screenText = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Fixed columns in wide terminal ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(screenText);
+        TestContext.Current?.WriteLine("=== Fixed columns in wide terminal ===");
+        TestContext.Current?.WriteLine(screenText);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -3168,22 +3153,21 @@ public class TableNodeTests
         // The top border + scrollbar should be 21 chars, NOT 100 chars.
         var lines = screenText.Split('\n');
         var topBorder = lines.FirstOrDefault(l => l.Contains('┌'));
-        Assert.NotNull(topBorder);
+        Assert.IsNotNull(topBorder);
 
         var trimmedBorder = topBorder.TrimEnd();
         // Should be much smaller than terminal width
-        Assert.True(trimmedBorder.Length < 50,
-            $"Table should not stretch to terminal width. Border length={trimmedBorder.Length}, terminal=100.\nBorder: [{trimmedBorder}]");
+        Assert.IsTrue(trimmedBorder.Length < 50, $"Table should not stretch to terminal width. Border length={trimmedBorder.Length}, terminal=100.\nBorder: [{trimmedBorder}]");
 
         // Exact width check: 8+8 columns + 3 borders + 2 scrollbar = 21
-        Assert.Equal(21, trimmedBorder.Length);
+        Assert.AreEqual(21, trimmedBorder.Length);
     }
 
     #endregion
 
     #region Fill Height Tests
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithFillHeight_ExpandsToConstraintHeight()
     {
         // A table with only 2 data rows should still measure to the full
@@ -3201,10 +3185,10 @@ public class TableNodeTests
 
         // Without Fill the height would be 6 (top + header + sep + 2 rows + bottom).
         // With Fill it must expand to the constraint max height (24).
-        Assert.Equal(24, size.Height);
+        Assert.AreEqual(24, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithFillHeight_EmptyData_ExpandsToConstraintHeight()
     {
         var node = new TableNode<string>
@@ -3217,10 +3201,10 @@ public class TableNodeTests
 
         var size = node.Measure(new Constraints(0, 40, 0, 20));
 
-        Assert.Equal(20, size.Height);
+        Assert.AreEqual(20, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithoutFillHeight_UsesContentHeight()
     {
         // Baseline: without Fill, the table should use content-based height.
@@ -3235,10 +3219,10 @@ public class TableNodeTests
         var size = node.Measure(new Constraints(0, 40, 0, 24));
 
         // top (1) + header (1) + sep (1) + 2 rows (2) + bottom (1) = 6
-        Assert.Equal(6, size.Height);
+        Assert.AreEqual(6, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_FillInVStack_BottomBorderAtScreenBottom()
     {
         // Integration test: a table with .Fill() inside a VStack should render
@@ -3278,16 +3262,16 @@ public class TableNodeTests
 
         var snapshot = terminal.CreateSnapshot();
         var text = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Fill height test ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(text);
+        TestContext.Current?.WriteLine("=== Fill height test ===");
+        TestContext.Current?.WriteLine(text);
 
         // The bottom-right corner character '┘' must be on the last row
         var bottomRight = snapshot.GetCell(termWidth - 1, termHeight - 1);
-        Assert.Equal("┘", bottomRight.Character);
+        Assert.AreEqual("┘", bottomRight.Character);
 
         // The bottom-left corner '└' must also be on the last row
         var bottomLeft = snapshot.GetCell(0, termHeight - 1);
-        Assert.Equal("└", bottomLeft.Character);
+        Assert.AreEqual("└", bottomLeft.Character);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -3296,7 +3280,7 @@ public class TableNodeTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Table_EmptyData_FillHeight_NoColumnSeparatorsInFillRows()
     {
         // When there's no data and FillHeight is set, fill rows should NOT render
@@ -3335,8 +3319,8 @@ public class TableNodeTests
 
         var snapshot = terminal.CreateSnapshot();
         var text = snapshot.GetScreenText();
-        TestContext.Current.TestOutputHelper?.WriteLine("=== Empty table fill height test ===");
-        TestContext.Current.TestOutputHelper?.WriteLine(text);
+        TestContext.Current?.WriteLine("=== Empty table fill height test ===");
+        TestContext.Current?.WriteLine(text);
 
         // Rows below the "No data" row (rows 4..8 with 0-indexed: header separator at row 2, 
         // "No data" at row 3, fill rows at 4+, bottom border at 9) should NOT have column
@@ -3353,7 +3337,7 @@ public class TableNodeTests
                 if (cell.Character == "│")
                     verticalBarCount++;
             }
-            Assert.Equal(0, verticalBarCount);
+            Assert.AreEqual(0, verticalBarCount);
         }
 
         await new Hex1bTerminalInputSequenceBuilder()

--- a/tests/Hex1b.Tests/TableVisualRegressionTests.cs
+++ b/tests/Hex1b.Tests/TableVisualRegressionTests.cs
@@ -14,6 +14,7 @@ namespace Hex1b.Tests;
 /// created on first run. Review the generated baseline files before committing.
 /// </para>
 /// </remarks>
+[TestClass]
 public class TableVisualRegressionTests
 {
     private static bool ShouldUpdateBaselines => 
@@ -21,8 +22,8 @@ public class TableVisualRegressionTests
     
     #region Structure Tests
     
-    [Theory]
-    [MemberData(nameof(TableVisualTestCases.StructureCases), MemberType = typeof(TableVisualTestCases))]
+    [TestMethod]
+    [DynamicData(nameof(TableVisualTestCases.StructureCases), typeof(TableVisualTestCases))]
     public async Task Structure_MatchesBaseline(TableVisualTestCase testCase)
     {
         var result = await TableVisualTestHelper.RenderAndCompareAsync(
@@ -34,8 +35,8 @@ public class TableVisualRegressionTests
         {
             // Output for debugging
             var (_, text) = await TableVisualTestHelper.RenderTableAsync(testCase, TestContext.Current.CancellationToken);
-            TestContext.Current.TestOutputHelper?.WriteLine("Rendered output:");
-            TestContext.Current.TestOutputHelper?.WriteLine(text);
+            TestContext.Current?.WriteLine("Rendered output:");
+            TestContext.Current?.WriteLine(text);
             
             if (result.StartsWith("BASELINE CREATED"))
             {
@@ -51,8 +52,8 @@ public class TableVisualRegressionTests
     
     #region Selection Tests
     
-    [Theory]
-    [MemberData(nameof(TableVisualTestCases.SelectionCases), MemberType = typeof(TableVisualTestCases))]
+    [TestMethod]
+    [DynamicData(nameof(TableVisualTestCases.SelectionCases), typeof(TableVisualTestCases))]
     public async Task Selection_MatchesBaseline(TableVisualTestCase testCase)
     {
         var result = await TableVisualTestHelper.RenderAndCompareAsync(
@@ -63,8 +64,8 @@ public class TableVisualRegressionTests
         if (result != null)
         {
             var (_, text) = await TableVisualTestHelper.RenderTableAsync(testCase, TestContext.Current.CancellationToken);
-            TestContext.Current.TestOutputHelper?.WriteLine("Rendered output:");
-            TestContext.Current.TestOutputHelper?.WriteLine(text);
+            TestContext.Current?.WriteLine("Rendered output:");
+            TestContext.Current?.WriteLine(text);
             Assert.Fail(result);
         }
     }
@@ -73,8 +74,8 @@ public class TableVisualRegressionTests
     
     #region Async Loading Tests
     
-    [Theory]
-    [MemberData(nameof(TableVisualTestCases.AsyncCases), MemberType = typeof(TableVisualTestCases))]
+    [TestMethod]
+    [DynamicData(nameof(TableVisualTestCases.AsyncCases), typeof(TableVisualTestCases))]
     public async Task Async_MatchesBaseline(TableVisualTestCase testCase)
     {
         // Note: Async tests use sync data for baseline capture.
@@ -87,8 +88,8 @@ public class TableVisualRegressionTests
         if (result != null)
         {
             var (_, text) = await TableVisualTestHelper.RenderTableAsync(testCase, TestContext.Current.CancellationToken);
-            TestContext.Current.TestOutputHelper?.WriteLine("Rendered output:");
-            TestContext.Current.TestOutputHelper?.WriteLine(text);
+            TestContext.Current?.WriteLine("Rendered output:");
+            TestContext.Current?.WriteLine(text);
             Assert.Fail(result);
         }
     }
@@ -97,8 +98,8 @@ public class TableVisualRegressionTests
     
     #region Row Focus Tests
     
-    [Theory]
-    [MemberData(nameof(TableVisualTestCases.FocusCases), MemberType = typeof(TableVisualTestCases))]
+    [TestMethod]
+    [DynamicData(nameof(TableVisualTestCases.FocusCases), typeof(TableVisualTestCases))]
     public async Task Focus_MatchesBaseline(TableVisualTestCase testCase)
     {
         var result = await TableVisualTestHelper.RenderAndCompareAsync(
@@ -109,8 +110,8 @@ public class TableVisualRegressionTests
         if (result != null)
         {
             var (_, text) = await TableVisualTestHelper.RenderTableAsync(testCase, TestContext.Current.CancellationToken);
-            TestContext.Current.TestOutputHelper?.WriteLine("Rendered output:");
-            TestContext.Current.TestOutputHelper?.WriteLine(text);
+            TestContext.Current?.WriteLine("Rendered output:");
+            TestContext.Current?.WriteLine(text);
             Assert.Fail(result);
         }
     }
@@ -119,8 +120,8 @@ public class TableVisualRegressionTests
     
     #region Table Focus Indicator Tests
     
-    [Theory]
-    [MemberData(nameof(TableVisualTestCases.TableFocusCases), MemberType = typeof(TableVisualTestCases))]
+    [TestMethod]
+    [DynamicData(nameof(TableVisualTestCases.TableFocusCases), typeof(TableVisualTestCases))]
     public async Task TableFocus_MatchesBaseline(TableVisualTestCase testCase)
     {
         var result = await TableVisualTestHelper.RenderAndCompareAsync(
@@ -131,8 +132,8 @@ public class TableVisualRegressionTests
         if (result != null)
         {
             var (_, text) = await TableVisualTestHelper.RenderTableAsync(testCase, TestContext.Current.CancellationToken);
-            TestContext.Current.TestOutputHelper?.WriteLine("Rendered output:");
-            TestContext.Current.TestOutputHelper?.WriteLine(text);
+            TestContext.Current?.WriteLine("Rendered output:");
+            TestContext.Current?.WriteLine(text);
             Assert.Fail(result);
         }
     }

--- a/tests/Hex1b.Tests/TerminalAnsiRenderingTests.cs
+++ b/tests/Hex1b.Tests/TerminalAnsiRenderingTests.cs
@@ -8,9 +8,10 @@ namespace Hex1b.Tests;
 /// Tests for ANSI rendering of terminal snapshots and regions.
 /// ANSI outputs are attached to test results and can be viewed with `cat`.
 /// </summary>
+[TestClass]
 public class TerminalAnsiRenderingTests
 {
-    [Fact]
+    [TestMethod]
     public async Task RenderFullSnapshot_ProducesAnsi()
     {
         // Arrange
@@ -46,7 +47,7 @@ public class TerminalAnsiRenderingTests
         var ansi = snapshot.ToAnsi();
 
         // Assert
-        Assert.NotEmpty(ansi);
+        Assert.IsNotEmpty(ansi);
         // ANSI output should contain escape sequences
         Assert.Contains("\x1b[", ansi);
         // Should have cursor up to move back after scrolling
@@ -62,7 +63,7 @@ public class TerminalAnsiRenderingTests
         TestCaptureHelper.AttachFile("full-snapshot.ansi", ansi);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RenderWithColors_ProducesCorrectColorCodes()
     {
         // Arrange
@@ -100,7 +101,7 @@ public class TerminalAnsiRenderingTests
         TestCaptureHelper.AttachFile("colored.ansi", ansi);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RenderArbitraryRegion_ProducesAnsi()
     {
         // Arrange
@@ -135,7 +136,7 @@ public class TerminalAnsiRenderingTests
         var ansi = region.ToAnsi();
 
         // Assert
-        Assert.NotEmpty(ansi);
+        Assert.IsNotEmpty(ansi);
         Assert.Contains("\x1b[", ansi);
 
         // Attach ANSI to test output
@@ -146,7 +147,7 @@ public class TerminalAnsiRenderingTests
         TestCaptureHelper.AttachFile("arbitrary-region-full.ansi", fullAnsi);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RenderWithClearScreen_IncludesClearAndHome()
     {
         // Arrange
@@ -179,7 +180,7 @@ public class TerminalAnsiRenderingTests
         TestCaptureHelper.AttachFile("clear-screen.ansi", ansi);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RenderWithTextAttributes_IncludesSgrCodes()
     {
         // Arrange
@@ -211,14 +212,14 @@ public class TerminalAnsiRenderingTests
         var ansi = snapshot.ToAnsi();
 
         // Assert - should contain SGR codes
-        Assert.NotEmpty(ansi);
+        Assert.IsNotEmpty(ansi);
         Assert.Contains("\x1b[", ansi);
 
         // Attach ANSI to test output
         TestCaptureHelper.AttachFile("text-attributes.ansi", ansi);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToAnsi_EmptyRegion_ReturnsValidAnsi()
     {
         // Arrange - Create a simple snapshot with just spaces
@@ -231,7 +232,7 @@ public class TerminalAnsiRenderingTests
         var ansi = snapshot.ToAnsi();
 
         // Assert - Even an empty snapshot should produce valid ANSI
-        Assert.NotNull(ansi);
+        Assert.IsNotNull(ansi);
         // Should end with reset
         Assert.Contains("\x1b[0m", ansi);
 
@@ -239,7 +240,7 @@ public class TerminalAnsiRenderingTests
         TestCaptureHelper.AttachFile("empty.ansi", ansi);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ToAnsi_WithCursorPosition_PositionsCursor()
     {
         // Arrange
@@ -267,7 +268,7 @@ public class TerminalAnsiRenderingTests
         var ansi = snapshot.ToAnsi(new TerminalAnsiOptions { IncludeCursorPosition = true });
 
         // Assert - The ANSI output should position the cursor
-        Assert.NotEmpty(ansi);
+        Assert.IsNotEmpty(ansi);
         // Cursor position uses horizontal absolute (G) command
         Assert.Contains("\x1b[", ansi);
         Assert.Contains("G", ansi);
@@ -276,7 +277,7 @@ public class TerminalAnsiRenderingTests
         TestCaptureHelper.AttachFile("cursor-position.ansi", ansi);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Capture_IncludesAnsiFile()
     {
         // Arrange
@@ -300,6 +301,6 @@ public class TerminalAnsiRenderingTests
 
         // Assert - verify the files were created (xUnit context attachments)
         // The actual file creation is verified by the Capture() call not throwing
-        Assert.True(true);
+        Assert.IsTrue(true);
     }
 }

--- a/tests/Hex1b.Tests/TerminalAnsiRenderingTests.cs
+++ b/tests/Hex1b.Tests/TerminalAnsiRenderingTests.cs
@@ -299,7 +299,7 @@ public class TerminalAnsiRenderingTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        // Assert - verify the files were created (xUnit context attachments)
+        // Assert - verify the files were created (MSTest result-file attachments)
         // The actual file creation is verified by the Capture() call not throwing
         Assert.IsTrue(true);
     }

--- a/tests/Hex1b.Tests/TerminalCopyModeTests.cs
+++ b/tests/Hex1b.Tests/TerminalCopyModeTests.cs
@@ -6,6 +6,7 @@ namespace Hex1b.Tests;
 /// Tests for copy mode on TerminalWidgetHandle — output queuing, enter/exit lifecycle,
 /// selection integration, and text extraction.
 /// </summary>
+[TestClass]
 public class TerminalCopyModeTests
 {
     private static TerminalWidgetHandle CreateHandle(int width = 80, int height = 24)
@@ -28,40 +29,40 @@ public class TerminalCopyModeTests
         };
     }
 
-    [Fact]
+    [TestMethod]
     public void EnterCopyMode_SetsIsInCopyMode()
     {
         var handle = CreateHandle();
-        Assert.False(handle.IsInCopyMode);
+        Assert.IsFalse(handle.IsInCopyMode);
         
         handle.EnterCopyMode();
-        Assert.True(handle.IsInCopyMode);
+        Assert.IsTrue(handle.IsInCopyMode);
     }
 
-    [Fact]
+    [TestMethod]
     public void EnterCopyMode_CreatesSelection()
     {
         var handle = CreateHandle(80, 24);
         handle.EnterCopyMode();
         
-        Assert.NotNull(handle.Selection);
+        Assert.IsNotNull(handle.Selection);
         // Cursor should be at terminal's current cursor position (0,0 for fresh handle)
-        Assert.Equal(0, handle.Selection!.Cursor.Row);
-        Assert.Equal(0, handle.Selection.Cursor.Column);
+        Assert.AreEqual(0, handle.Selection!.Cursor.Row);
+        Assert.AreEqual(0, handle.Selection.Cursor.Column);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExitCopyMode_ClearsState()
     {
         var handle = CreateHandle();
         handle.EnterCopyMode();
         handle.ExitCopyMode();
         
-        Assert.False(handle.IsInCopyMode);
-        Assert.Null(handle.Selection);
+        Assert.IsFalse(handle.IsInCopyMode);
+        Assert.IsNull(handle.Selection);
     }
 
-    [Fact]
+    [TestMethod]
     public void EnterCopyMode_DoubleEntry_NoOp()
     {
         var handle = CreateHandle();
@@ -69,17 +70,17 @@ public class TerminalCopyModeTests
         var selection1 = handle.Selection;
         
         handle.EnterCopyMode(); // should be no-op
-        Assert.Same(selection1, handle.Selection);
+        Assert.AreSame(selection1, handle.Selection);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OutputQueuing_WhenInCopyMode_DoesNotApplyToBuffer()
     {
         var handle = CreateHandle(10, 5);
         
         // Write initial content
         await handle.WriteOutputWithImpactsAsync(MakeCellImpacts("Hello", row: 0));
-        Assert.Equal("H", handle.GetCell(0, 0).Character);
+        Assert.AreEqual("H", handle.GetCell(0, 0).Character);
         
         // Enter copy mode
         handle.EnterCopyMode();
@@ -88,10 +89,10 @@ public class TerminalCopyModeTests
         await handle.WriteOutputWithImpactsAsync(MakeCellImpacts("World", row: 0));
         
         // Buffer should still show original content
-        Assert.Equal("H", handle.GetCell(0, 0).Character);
+        Assert.AreEqual("H", handle.GetCell(0, 0).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OutputQueuing_OnExit_FlushesQueuedOutput()
     {
         var handle = CreateHandle(10, 5);
@@ -106,11 +107,11 @@ public class TerminalCopyModeTests
         // Exit copy mode — queued output should be flushed
         handle.ExitCopyMode();
         
-        Assert.Equal("W", handle.GetCell(0, 0).Character);
-        Assert.Equal("o", handle.GetCell(1, 0).Character);
+        Assert.AreEqual("W", handle.GetCell(0, 0).Character);
+        Assert.AreEqual("o", handle.GetCell(1, 0).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OutputQueuing_MultipleChunks_AllFlushedInOrder()
     {
         var handle = CreateHandle(10, 5);
@@ -122,11 +123,11 @@ public class TerminalCopyModeTests
         handle.ExitCopyMode();
         
         // Second write should overwrite first
-        Assert.Equal("B", handle.GetCell(0, 0).Character);
-        Assert.Equal("B", handle.GetCell(1, 0).Character);
+        Assert.AreEqual("B", handle.GetCell(0, 0).Character);
+        Assert.AreEqual("B", handle.GetCell(1, 0).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void CopyModeChanged_FiredOnEnterAndExit()
     {
         var handle = CreateHandle();
@@ -136,12 +137,12 @@ public class TerminalCopyModeTests
         handle.EnterCopyMode();
         handle.ExitCopyMode();
         
-        Assert.Equal(2, events.Count);
-        Assert.True(events[0]);   // enter
-        Assert.False(events[1]);  // exit
+        Assert.AreEqual(2, events.Count);
+        Assert.IsTrue(events[0]);   // enter
+        Assert.IsFalse(events[1]);  // exit
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CopySelection_ExtractsTextAndExits()
     {
         var handle = CreateHandle(10, 3);
@@ -164,12 +165,12 @@ public class TerminalCopyModeTests
         
         var result = handle.CopySelection();
         
-        Assert.Equal("Hello!", result);
-        Assert.Equal("Hello!", copiedText);
-        Assert.False(handle.IsInCopyMode);
+        Assert.AreEqual("Hello!", result);
+        Assert.AreEqual("Hello!", copiedText);
+        Assert.IsFalse(handle.IsInCopyMode);
     }
 
-    [Fact]
+    [TestMethod]
     public void CopySelection_NoSelection_ReturnsNull()
     {
         var handle = CreateHandle();
@@ -177,19 +178,19 @@ public class TerminalCopyModeTests
         // Don't start selection
         
         var result = handle.CopySelection();
-        Assert.Null(result);
-        Assert.False(handle.IsInCopyMode);
+        Assert.IsNull(result);
+        Assert.IsFalse(handle.IsInCopyMode);
     }
 
-    [Fact]
+    [TestMethod]
     public void VirtualBufferHeight_ReturnsScrollbackPlusScreen()
     {
         var handle = CreateHandle(80, 24);
         // No scrollback configured (no terminal attached), so scrollback count = 0
-        Assert.Equal(24, handle.VirtualBufferHeight);
+        Assert.AreEqual(24, handle.VirtualBufferHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetVirtualCell_ScreenRegion_ReturnsCorrectCell()
     {
         var handle = CreateHandle(10, 5);
@@ -197,42 +198,42 @@ public class TerminalCopyModeTests
         
         // Screen rows start at scrollbackCount (0 when no terminal attached)
         var cell = handle.GetVirtualCell(2, 0);
-        Assert.NotNull(cell);
-        Assert.Equal("A", cell!.Value.Character);
+        Assert.IsNotNull(cell);
+        Assert.AreEqual("A", cell!.Value.Character);
         
         var cell2 = handle.GetVirtualCell(2, 2);
-        Assert.NotNull(cell2);
-        Assert.Equal("C", cell2!.Value.Character);
+        Assert.IsNotNull(cell2);
+        Assert.AreEqual("C", cell2!.Value.Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetVirtualCell_OutOfBounds_ReturnsNull()
     {
         var handle = CreateHandle(10, 5);
         
-        Assert.Null(handle.GetVirtualCell(-1, 0));
-        Assert.Null(handle.GetVirtualCell(0, -1));
-        Assert.Null(handle.GetVirtualCell(0, 10)); // width = 10
-        Assert.Null(handle.GetVirtualCell(5, 0));  // height = 5
+        Assert.IsNull(handle.GetVirtualCell(-1, 0));
+        Assert.IsNull(handle.GetVirtualCell(0, -1));
+        Assert.IsNull(handle.GetVirtualCell(0, 10)); // width = 10
+        Assert.IsNull(handle.GetVirtualCell(5, 0));  // height = 5
     }
 
-    [Fact]
+    [TestMethod]
     public void CopyModeCursorPosition_WhenNotInCopyMode_ReturnsNull()
     {
         var handle = CreateHandle();
-        Assert.Null(handle.CopyModeCursorPosition);
+        Assert.IsNull(handle.CopyModeCursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public void CopyModeCursorPosition_WhenInCopyMode_ReturnsCursorPos()
     {
         var handle = CreateHandle(80, 24);
         handle.EnterCopyMode();
         
         var pos = handle.CopyModeCursorPosition;
-        Assert.NotNull(pos);
+        Assert.IsNotNull(pos);
         // Fresh handle has cursor at (0,0)
-        Assert.Equal(0, pos!.Value.Row);
-        Assert.Equal(0, pos.Value.Column);
+        Assert.AreEqual(0, pos!.Value.Row);
+        Assert.AreEqual(0, pos.Value.Column);
     }
 }

--- a/tests/Hex1b.Tests/TerminalFilterTests.cs
+++ b/tests/Hex1b.Tests/TerminalFilterTests.cs
@@ -4,9 +4,10 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for the terminal filter system.
 /// </summary>
+[TestClass]
 public class TerminalFilterTests
 {
-    [Fact]
+    [TestMethod]
     public async Task WorkloadFilter_ReceivesSessionStart()
     {
         // Arrange
@@ -24,12 +25,12 @@ public class TerminalFilterTests
         using var terminal = new Hex1bTerminal(options);
 
         // Assert
-        Assert.True(filter.SessionStarted);
-        Assert.Equal(80, filter.Width);
-        Assert.Equal(24, filter.Height);
+        Assert.IsTrue(filter.SessionStarted);
+        Assert.AreEqual(80, filter.Width);
+        Assert.AreEqual(24, filter.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WorkloadFilter_ReceivesOutput()
     {
         // Arrange
@@ -52,11 +53,11 @@ public class TerminalFilterTests
             .ApplyAsync(terminal);
 
         // Assert
-        Assert.Single(filter.OutputChunks);
+        TestSeq.Single(filter.OutputChunks);
         Assert.Contains("Hello, World!", filter.OutputChunks[0]);
     }
 
-    [Fact(Skip = "Frame complete notification currently only fires on channel close, not on drain. See issue with PumpWorkloadOutputAsync design.")]
+    [TestMethod, Ignore("Frame complete notification currently only fires on channel close, not on drain. See issue with PumpWorkloadOutputAsync design.")]
     public async Task WorkloadFilter_ReceivesFrameComplete()
     {
         // Arrange
@@ -89,10 +90,10 @@ public class TerminalFilterTests
             .ApplyAsync(terminal);
 
         // Assert - FrameComplete should have been called when channel drained after Frame 1
-        Assert.True(filter.FrameCompleteCount > 0, $"Expected FrameCompleteCount > 0, but got {filter.FrameCompleteCount}. OutputChunks: {filter.OutputChunks.Count}");
+        Assert.IsTrue(filter.FrameCompleteCount > 0, $"Expected FrameCompleteCount > 0, but got {filter.FrameCompleteCount}. OutputChunks: {filter.OutputChunks.Count}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WorkloadFilter_ReceivesSessionEnd()
     {
         // Arrange
@@ -111,10 +112,10 @@ public class TerminalFilterTests
         terminal.Dispose();
 
         // Assert
-        Assert.True(filter.SessionEnded);
+        Assert.IsTrue(filter.SessionEnded);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PresentationFilter_ReceivesSessionStart()
     {
         // Arrange
@@ -132,10 +133,10 @@ public class TerminalFilterTests
         using var terminal = new Hex1bTerminal(options);
 
         // Assert
-        Assert.True(filter.SessionStarted);
+        Assert.IsTrue(filter.SessionStarted);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TerminalOptions_ValidatesWorkloadAdapter()
     {
         // Arrange
@@ -147,25 +148,25 @@ public class TerminalFilterTests
         };
 
         // Act & Assert
-        Assert.Throws<ArgumentNullException>(() => new Hex1bTerminal(options));
+        Assert.ThrowsExactly<ArgumentNullException>(() => new Hex1bTerminal(options));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TerminalOptions_Constructor_SetsDefaults()
     {
         // Act
         var options = new Hex1bTerminalOptions();
 
         // Assert
-        Assert.Equal(80, options.Width);
-        Assert.Equal(24, options.Height);
-        Assert.Null(options.WorkloadAdapter);
-        Assert.Null(options.PresentationAdapter);
-        Assert.Empty(options.WorkloadFilters);
-        Assert.Empty(options.PresentationFilters);
+        Assert.AreEqual(80, options.Width);
+        Assert.AreEqual(24, options.Height);
+        Assert.IsNull(options.WorkloadAdapter);
+        Assert.IsNull(options.PresentationAdapter);
+        Assert.IsEmpty(options.WorkloadFilters);
+        Assert.IsEmpty(options.PresentationFilters);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MultipleFilters_AllReceiveEvents()
     {
         // Arrange
@@ -190,13 +191,13 @@ public class TerminalFilterTests
             .ApplyAsync(terminal);
 
         // Assert
-        Assert.True(filter1.SessionStarted);
-        Assert.True(filter2.SessionStarted);
-        Assert.Single(filter1.OutputChunks);
-        Assert.Single(filter2.OutputChunks);
+        Assert.IsTrue(filter1.SessionStarted);
+        Assert.IsTrue(filter2.SessionStarted);
+        TestSeq.Single(filter1.OutputChunks);
+        TestSeq.Single(filter2.OutputChunks);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TokenBasedFilters_UsesApplyTokensPath()
     {
         // Arrange
@@ -219,7 +220,7 @@ public class TerminalFilterTests
             .ApplyAsync(terminal);
 
         // Assert
-        Assert.Single(filter.OutputChunks);
+        TestSeq.Single(filter.OutputChunks);
         Assert.Contains("Hello", filter.OutputChunks[0]);
         Assert.Contains("Red", filter.OutputChunks[0]);
         Assert.Contains("World", filter.OutputChunks[0]);
@@ -230,7 +231,7 @@ public class TerminalFilterTests
             .Capture("final")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-        Assert.Equal("HelloRedWorld", snapshot.GetLine(0).TrimEnd());
+        Assert.AreEqual("HelloRedWorld", snapshot.GetLine(0).TrimEnd());
     }
 
     // Test helpers

--- a/tests/Hex1b.Tests/TerminalMouseSelectionTests.cs
+++ b/tests/Hex1b.Tests/TerminalMouseSelectionTests.cs
@@ -6,6 +6,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for mouse-driven text selection on TerminalWidgetHandle.
 /// </summary>
+[TestClass]
 public class TerminalMouseSelectionTests
 {
     private static TerminalWidgetHandle CreateHandle(int width = 80, int height = 24)
@@ -28,7 +29,7 @@ public class TerminalMouseSelectionTests
         await handle.WriteOutputWithImpactsAsync(tokens);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MouseSelect_DownOnly_DoesNotEnterCopyMode()
     {
         var handle = CreateHandle(20, 5);
@@ -37,10 +38,10 @@ public class TerminalMouseSelectionTests
         handle.MouseSelect(2, 0, MouseAction.Down, SelectionMode.Character);
         
         // Single click without drag should NOT enter copy mode
-        Assert.False(handle.IsInCopyMode);
+        Assert.IsFalse(handle.IsInCopyMode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MouseSelect_DownThenDrag_EntersCopyModeAndStartsSelection()
     {
         var handle = CreateHandle(20, 5);
@@ -49,13 +50,13 @@ public class TerminalMouseSelectionTests
         handle.MouseSelect(2, 0, MouseAction.Down, SelectionMode.Character);
         handle.MouseSelect(5, 0, MouseAction.Drag, SelectionMode.Character);
         
-        Assert.True(handle.IsInCopyMode);
-        Assert.NotNull(handle.Selection);
-        Assert.True(handle.Selection!.IsSelecting);
-        Assert.Equal(SelectionMode.Character, handle.Selection.Mode);
+        Assert.IsTrue(handle.IsInCopyMode);
+        Assert.IsNotNull(handle.Selection);
+        Assert.IsTrue(handle.Selection!.IsSelecting);
+        Assert.AreEqual(SelectionMode.Character, handle.Selection.Mode);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MouseSelect_Drag_ExtendsSelection()
     {
         var handle = CreateHandle(20, 5);
@@ -66,11 +67,11 @@ public class TerminalMouseSelectionTests
         
         var sel = handle.Selection!;
         // Anchor at (0,0), cursor at (0,4)
-        Assert.Equal(0, sel.Start.Column);
-        Assert.Equal(4, sel.Cursor.Column);
+        Assert.AreEqual(0, sel.Start.Column);
+        Assert.AreEqual(4, sel.Cursor.Column);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MouseSelect_MultiRow_CharacterMode()
     {
         var handle = CreateHandle(20, 5);
@@ -81,8 +82,8 @@ public class TerminalMouseSelectionTests
         handle.MouseSelect(3, 1, MouseAction.Drag, SelectionMode.Character);
         
         var sel = handle.Selection!;
-        Assert.Equal(0, sel.Start.Row);
-        Assert.Equal(1, sel.End.Row);
+        Assert.AreEqual(0, sel.Start.Row);
+        Assert.AreEqual(1, sel.End.Row);
         
         // Extract text
         var text = sel.ExtractText(handle.GetVirtualCell, handle.Width);
@@ -90,7 +91,7 @@ public class TerminalMouseSelectionTests
         Assert.Contains("Line", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MouseSelect_LineMode_SelectsFullRows()
     {
         var handle = CreateHandle(20, 5);
@@ -102,15 +103,15 @@ public class TerminalMouseSelectionTests
         handle.MouseSelect(2, 1, MouseAction.Drag, SelectionMode.Line);
         
         var sel = handle.Selection!;
-        Assert.Equal(SelectionMode.Line, sel.Mode);
+        Assert.AreEqual(SelectionMode.Line, sel.Mode);
         // Line mode selects full rows regardless of column
-        Assert.True(sel.IsCellSelected(0, 0));
-        Assert.True(sel.IsCellSelected(0, 3));
-        Assert.True(sel.IsCellSelected(1, 0));
-        Assert.False(sel.IsCellSelected(2, 0));
+        Assert.IsTrue(sel.IsCellSelected(0, 0));
+        Assert.IsTrue(sel.IsCellSelected(0, 3));
+        Assert.IsTrue(sel.IsCellSelected(1, 0));
+        Assert.IsFalse(sel.IsCellSelected(2, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MouseSelect_BlockMode_SelectsRectangle()
     {
         var handle = CreateHandle(20, 5);
@@ -122,16 +123,16 @@ public class TerminalMouseSelectionTests
         handle.MouseSelect(3, 2, MouseAction.Drag, SelectionMode.Block);
         
         var sel = handle.Selection!;
-        Assert.Equal(SelectionMode.Block, sel.Mode);
+        Assert.AreEqual(SelectionMode.Block, sel.Mode);
         // Block: columns 1-3, rows 0-2
-        Assert.True(sel.IsCellSelected(0, 1));
-        Assert.True(sel.IsCellSelected(1, 2));
-        Assert.True(sel.IsCellSelected(2, 3));
-        Assert.False(sel.IsCellSelected(0, 0)); // column 0 outside
-        Assert.False(sel.IsCellSelected(0, 4)); // column 4 outside
+        Assert.IsTrue(sel.IsCellSelected(0, 1));
+        Assert.IsTrue(sel.IsCellSelected(1, 2));
+        Assert.IsTrue(sel.IsCellSelected(2, 3));
+        Assert.IsFalse(sel.IsCellSelected(0, 0)); // column 0 outside
+        Assert.IsFalse(sel.IsCellSelected(0, 4)); // column 4 outside
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MouseSelect_Up_KeepsSelectionActive()
     {
         var handle = CreateHandle(20, 5);
@@ -142,11 +143,11 @@ public class TerminalMouseSelectionTests
         handle.MouseSelect(4, 0, MouseAction.Up, SelectionMode.Character);
         
         // Selection should still be active after mouse up
-        Assert.True(handle.IsInCopyMode);
-        Assert.True(handle.Selection!.IsSelecting);
+        Assert.IsTrue(handle.IsInCopyMode);
+        Assert.IsTrue(handle.Selection!.IsSelecting);
     }
 
-    [Fact]
+    [TestMethod]
     public void MouseSelect_DragWhenAlreadyInCopyMode_SetsNewSelection()
     {
         var handle = CreateHandle(20, 5);
@@ -156,12 +157,12 @@ public class TerminalMouseSelectionTests
         handle.MouseSelect(5, 2, MouseAction.Down, SelectionMode.Character);
         handle.MouseSelect(8, 2, MouseAction.Drag, SelectionMode.Character);
         
-        Assert.True(handle.Selection!.IsSelecting);
-        Assert.Equal(2, handle.Selection.Anchor.Row);
-        Assert.Equal(5, handle.Selection.Anchor.Column);
+        Assert.IsTrue(handle.Selection!.IsSelecting);
+        Assert.AreEqual(2, handle.Selection.Anchor.Row);
+        Assert.AreEqual(5, handle.Selection.Anchor.Column);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MouseSelect_CopySelection_ExtractsCorrectText()
     {
         var handle = CreateHandle(20, 5);
@@ -176,11 +177,11 @@ public class TerminalMouseSelectionTests
         
         var result = handle.CopySelection();
         
-        Assert.Equal("World", result);
-        Assert.Equal("World", copiedText);
+        Assert.AreEqual("World", result);
+        Assert.AreEqual("World", copiedText);
     }
 
-    [Fact]
+    [TestMethod]
     public void MouseSelect_ClampsToBufferBounds()
     {
         var handle = CreateHandle(10, 5);
@@ -189,9 +190,9 @@ public class TerminalMouseSelectionTests
         handle.MouseSelect(100, 100, MouseAction.Down, SelectionMode.Character);
         handle.MouseSelect(100, 100, MouseAction.Drag, SelectionMode.Character);
         
-        Assert.True(handle.IsInCopyMode);
+        Assert.IsTrue(handle.IsInCopyMode);
         var pos = handle.Selection!.Cursor;
-        Assert.True(pos.Column < handle.Width);
-        Assert.True(pos.Row < handle.VirtualBufferHeight);
+        Assert.IsTrue(pos.Column < handle.Width);
+        Assert.IsTrue(pos.Row < handle.VirtualBufferHeight);
     }
 }

--- a/tests/Hex1b.Tests/TerminalNodeScrollbackTests.cs
+++ b/tests/Hex1b.Tests/TerminalNodeScrollbackTests.cs
@@ -9,6 +9,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for terminal scrollback support in TerminalNode and TerminalWidgetHandle.
 /// </summary>
+[TestClass]
 public class TerminalNodeScrollbackTests
 {
     // Helper to create AppliedToken for PrivateMode sequences
@@ -17,24 +18,24 @@ public class TerminalNodeScrollbackTests
 
     #region TerminalWidgetHandle - Alternate Screen Tracking
 
-    [Fact]
+    [TestMethod]
     public void Handle_InAlternateScreen_DefaultsFalse()
     {
         var handle = new TerminalWidgetHandle(80, 24);
-        Assert.False(handle.InAlternateScreen);
+        Assert.IsFalse(handle.InAlternateScreen);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Handle_PrivateMode1049Enable_SetsInAlternateScreen()
     {
         var handle = new TerminalWidgetHandle(80, 24);
 
         await handle.WriteOutputWithImpactsAsync([PrivateModeApplied(1049, true)]);
 
-        Assert.True(handle.InAlternateScreen);
+        Assert.IsTrue(handle.InAlternateScreen);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Handle_PrivateMode1049Disable_ClearsInAlternateScreen()
     {
         var handle = new TerminalWidgetHandle(80, 24);
@@ -42,29 +43,29 @@ public class TerminalNodeScrollbackTests
         await handle.WriteOutputWithImpactsAsync([PrivateModeApplied(1049, true)]);
         await handle.WriteOutputWithImpactsAsync([PrivateModeApplied(1049, false)]);
 
-        Assert.False(handle.InAlternateScreen);
+        Assert.IsFalse(handle.InAlternateScreen);
     }
 
     #endregion
 
     #region TerminalWidgetHandle - Scrollback Access
 
-    [Fact]
+    [TestMethod]
     public void Handle_ScrollbackCount_ReturnsZeroWithoutTerminal()
     {
         var handle = new TerminalWidgetHandle(80, 24);
-        Assert.Equal(0, handle.ScrollbackCount);
+        Assert.AreEqual(0, handle.ScrollbackCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void Handle_GetScrollbackSnapshot_ReturnsEmptyWithoutTerminal()
     {
         var handle = new TerminalWidgetHandle(80, 24);
         var rows = handle.GetScrollbackSnapshot(100);
-        Assert.Empty(rows);
+        Assert.IsEmpty(rows);
     }
 
-    [Fact]
+    [TestMethod]
     public void Handle_ScrollbackCount_ReturnsCountWhenTerminalHasScrollback()
     {
         var handle = new TerminalWidgetHandle(80, 24);
@@ -72,10 +73,10 @@ public class TerminalNodeScrollbackTests
         SetTerminalOnHandle(handle, terminal);
         PopulateScrollback(terminal, 50);
 
-        Assert.True(handle.ScrollbackCount > 0);
+        Assert.IsTrue(handle.ScrollbackCount > 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void Handle_GetScrollbackSnapshot_ReturnsRowsWhenTerminalHasScrollback()
     {
         var handle = new TerminalWidgetHandle(80, 24);
@@ -84,26 +85,26 @@ public class TerminalNodeScrollbackTests
         PopulateScrollback(terminal, 50);
 
         var rows = handle.GetScrollbackSnapshot(100);
-        Assert.NotEmpty(rows);
+        Assert.IsNotEmpty(rows);
     }
 
     #endregion
 
     #region TerminalNode - Scrollback Offset
 
-    [Fact]
+    [TestMethod]
     public void ScrollbackOffset_DefaultsToZero()
     {
         var node = new TerminalNode();
-        Assert.Equal(0, node.ScrollbackOffset);
-        Assert.False(node.IsInScrollbackMode);
+        Assert.AreEqual(0, node.ScrollbackOffset);
+        Assert.IsFalse(node.IsInScrollbackMode);
     }
 
     #endregion
 
     #region TerminalNode - Input Interception
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_WhenInScrollbackMode_SnapsToLiveAndForwardsKeyboard()
     {
         var handle = CreateRunningHandle();
@@ -111,18 +112,18 @@ public class TerminalNodeScrollbackTests
 
         // Manually set scrollback offset to simulate being in scrollback mode
         SetScrollbackOffset(node, 5);
-        Assert.True(node.IsInScrollbackMode);
+        Assert.IsTrue(node.IsInScrollbackMode);
 
         var keyEvent = new Hex1bKeyEvent(Hex1bKey.A, "a", Hex1bModifiers.None);
         var result = node.HandleInput(keyEvent);
 
         // Should snap back to live view and forward the key
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(0, node.ScrollbackOffset);
-        Assert.False(node.IsInScrollbackMode);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(0, node.ScrollbackOffset);
+        Assert.IsFalse(node.IsInScrollbackMode);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_WhenNotInScrollbackMode_ForwardsKeyboard()
     {
         var handle = CreateRunningHandle();
@@ -132,10 +133,10 @@ public class TerminalNodeScrollbackTests
         var result = node.HandleInput(keyEvent);
 
         // Should return Handled (forwarded to terminal)
-        Assert.Equal(InputResult.Handled, result);
+        Assert.AreEqual(InputResult.Handled, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_MouseEvent_WhenInScrollbackMode_StillForwarded()
     {
         var handle = CreateRunningHandle();
@@ -147,14 +148,14 @@ public class TerminalNodeScrollbackTests
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 5, 5, Hex1bModifiers.None);
         var result = node.HandleInput(mouseEvent);
 
-        Assert.Equal(InputResult.Handled, result);
+        Assert.AreEqual(InputResult.Handled, result);
     }
 
     #endregion
 
     #region TerminalNode - Mouse Scroll Routing
 
-    [Fact]
+    [TestMethod]
     public async Task HandleMouseClick_ScrollWheel_WhenMouseTrackingEnabled_ForwardsToChild()
     {
         var handle = CreateRunningHandle();
@@ -167,10 +168,10 @@ public class TerminalNodeScrollbackTests
         var result = node.HandleMouseClick(5, 5, scrollEvent);
 
         // When child has mouse tracking, scroll events are forwarded
-        Assert.Equal(InputResult.Handled, result);
+        Assert.AreEqual(InputResult.Handled, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleMouseClick_ScrollWheel_WhenNoMouseTracking_ReturnsNotHandled()
     {
         var handle = CreateRunningHandle();
@@ -180,10 +181,10 @@ public class TerminalNodeScrollbackTests
         var result = node.HandleMouseClick(5, 5, scrollEvent);
 
         // Scroll events should return NotHandled so input binding system handles them
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleMouseClick_NonScroll_WhenNoMouseTracking_ForwardsToChild()
     {
         var handle = CreateRunningHandle();
@@ -193,10 +194,10 @@ public class TerminalNodeScrollbackTests
         var result = node.HandleMouseClick(5, 5, clickEvent);
 
         // Non-scroll mouse events are forwarded
-        Assert.Equal(InputResult.Handled, result);
+        Assert.AreEqual(InputResult.Handled, result);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleMouseClick_ScrollDown_WhenNoMouseTracking_ReturnsNotHandled()
     {
         var handle = CreateRunningHandle();
@@ -205,14 +206,14 @@ public class TerminalNodeScrollbackTests
         var scrollEvent = new Hex1bMouseEvent(MouseButton.ScrollDown, MouseAction.Down, 5, 5, Hex1bModifiers.None);
         var result = node.HandleMouseClick(5, 5, scrollEvent);
 
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
     }
 
     #endregion
 
     #region TerminalNode - ConfigureDefaultBindings
 
-    [Fact]
+    [TestMethod]
     public void ConfigureDefaultBindings_RegistersAllScrollbackActions()
     {
         var node = new TerminalNode();
@@ -228,7 +229,7 @@ public class TerminalNodeScrollbackTests
         Assert.Contains(TerminalWidget.ScrollToBottom, actionIds);
     }
 
-    [Fact]
+    [TestMethod]
     public void ConfigureDefaultBindings_RegistersMouseScrollBindings()
     {
         var node = new TerminalNode();
@@ -236,11 +237,11 @@ public class TerminalNodeScrollbackTests
         node.ConfigureDefaultBindings(bindings);
 
         var mouseBindings = bindings.MouseBindings;
-        Assert.Contains(mouseBindings, b => b.Button == MouseButton.ScrollUp);
-        Assert.Contains(mouseBindings, b => b.Button == MouseButton.ScrollDown);
+        Assert.IsTrue(mouseBindings.Any(b => b.Button == MouseButton.ScrollUp));
+        Assert.IsTrue(mouseBindings.Any(b => b.Button == MouseButton.ScrollDown));
     }
 
-    [Fact]
+    [TestMethod]
     public void ConfigureDefaultBindings_HasKeyboardBindingsForScrollback()
     {
         var node = new TerminalNode();
@@ -248,29 +249,29 @@ public class TerminalNodeScrollbackTests
         node.ConfigureDefaultBindings(bindings);
 
         // Should have 6 keyboard bindings (ScrollUpLine, ScrollDownLine, ScrollUpPage, ScrollDownPage, ScrollToTop, ScrollToBottom)
-        Assert.True(bindings.Bindings.Count >= 6, $"Expected at least 6 key bindings, got {bindings.Bindings.Count}");
+        Assert.IsTrue(bindings.Bindings.Count >= 6, $"Expected at least 6 key bindings, got {bindings.Bindings.Count}");
     }
 
     #endregion
 
     #region TerminalWidget - ActionId Names
 
-    [Fact]
+    [TestMethod]
     public void ActionIds_FollowNamingConvention()
     {
-        Assert.Equal("TerminalWidget.ScrollUpLine", TerminalWidget.ScrollUpLine.Value);
-        Assert.Equal("TerminalWidget.ScrollDownLine", TerminalWidget.ScrollDownLine.Value);
-        Assert.Equal("TerminalWidget.ScrollUpPage", TerminalWidget.ScrollUpPage.Value);
-        Assert.Equal("TerminalWidget.ScrollDownPage", TerminalWidget.ScrollDownPage.Value);
-        Assert.Equal("TerminalWidget.ScrollToTop", TerminalWidget.ScrollToTop.Value);
-        Assert.Equal("TerminalWidget.ScrollToBottom", TerminalWidget.ScrollToBottom.Value);
+        Assert.AreEqual("TerminalWidget.ScrollUpLine", TerminalWidget.ScrollUpLine.Value);
+        Assert.AreEqual("TerminalWidget.ScrollDownLine", TerminalWidget.ScrollDownLine.Value);
+        Assert.AreEqual("TerminalWidget.ScrollUpPage", TerminalWidget.ScrollUpPage.Value);
+        Assert.AreEqual("TerminalWidget.ScrollDownPage", TerminalWidget.ScrollDownPage.Value);
+        Assert.AreEqual("TerminalWidget.ScrollToTop", TerminalWidget.ScrollToTop.Value);
+        Assert.AreEqual("TerminalWidget.ScrollToBottom", TerminalWidget.ScrollToBottom.Value);
     }
 
     #endregion
 
     #region Hex1bTerminal - Scrollback Access
 
-    [Fact]
+    [TestMethod]
     public void Terminal_ScrollbackCount_ReturnsZeroWhenNotEnabled()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -280,19 +281,19 @@ public class TerminalNodeScrollbackTests
             .WithDimensions(80, 24)
             .Build();
 
-        Assert.Equal(0, terminal.ScrollbackCount);
+        Assert.AreEqual(0, terminal.ScrollbackCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void Terminal_ScrollbackCount_ReturnsCountWhenEnabled()
     {
         var terminal = CreateTerminalWithScrollback(80, 24, scrollbackCapacity: 100);
         PopulateScrollback(terminal, 50);
 
-        Assert.True(terminal.ScrollbackCount > 0);
+        Assert.IsTrue(terminal.ScrollbackCount > 0);
     }
 
-    [Fact]
+    [TestMethod]
     public void Terminal_GetScrollbackRows_ReturnsEmptyWhenNotEnabled()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -303,27 +304,27 @@ public class TerminalNodeScrollbackTests
             .Build();
 
         var rows = terminal.GetScrollbackRows(100);
-        Assert.Empty(rows);
+        Assert.IsEmpty(rows);
     }
 
-    [Fact]
+    [TestMethod]
     public void Terminal_GetScrollbackRows_ReturnsRowsWhenEnabled()
     {
         var terminal = CreateTerminalWithScrollback(80, 24, scrollbackCapacity: 100);
         PopulateScrollback(terminal, 50);
 
         var rows = terminal.GetScrollbackRows(100);
-        Assert.NotEmpty(rows);
+        Assert.IsNotEmpty(rows);
     }
 
-    [Fact]
+    [TestMethod]
     public void Terminal_GetScrollbackRows_RespectsCountLimit()
     {
         var terminal = CreateTerminalWithScrollback(80, 24, scrollbackCapacity: 100);
         PopulateScrollback(terminal, 50);
 
         var rows = terminal.GetScrollbackRows(5);
-        Assert.True(rows.Length <= 5);
+        Assert.IsTrue(rows.Length <= 5);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/TerminalReflowTests.cs
+++ b/tests/Hex1b.Tests/TerminalReflowTests.cs
@@ -6,11 +6,12 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for the terminal reflow engine — re-wrapping soft-wrapped lines on resize.
 /// </summary>
+[TestClass]
 public class TerminalReflowTests
 {
     #region Basic Reflow
 
-    [Fact]
+    [TestMethod]
     public void Reflow_NarrowToWider_MergesSoftWrappedRows()
     {
         // Arrange: 5-column terminal with xterm reflow
@@ -23,19 +24,19 @@ public class TerminalReflowTests
         terminal.ApplyTokens([new TextToken("ABCDEFGHIJ")]);
 
         var snap1 = terminal.CreateSnapshot();
-        Assert.Equal("ABCDE", snap1.GetLine(0).TrimEnd());
-        Assert.Equal("FGHIJ", snap1.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDE", snap1.GetLine(0).TrimEnd());
+        Assert.AreEqual("FGHIJ", snap1.GetLine(1).TrimEnd());
 
         // Act: Resize to 10 columns
         terminal.Resize(10, 3);
 
         // Assert: Should merge into 1 row
         var snap2 = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap2.GetLine(0).TrimEnd());
-        Assert.Equal("", snap2.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap2.GetLine(0).TrimEnd());
+        Assert.AreEqual("", snap2.GetLine(1).TrimEnd());
     }
 
-    [Fact]
+    [TestMethod]
     public void Reflow_WiderToNarrow_SplitsSoftWrappedRows()
     {
         // Arrange: 10-column terminal with xterm reflow
@@ -48,7 +49,7 @@ public class TerminalReflowTests
         terminal.ApplyTokens([new TextToken("ABCDEFGHIJ")]);
 
         var snap1 = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap1.GetLine(0).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap1.GetLine(0).TrimEnd());
 
         // Act: Resize to 5 columns — now the "J" triggers wrap back, 
         // but the 10 chars need to re-wrap to 5-wide
@@ -56,11 +57,11 @@ public class TerminalReflowTests
 
         // Assert: Should split into 2 rows
         var snap2 = terminal.CreateSnapshot();
-        Assert.Equal("ABCDE", snap2.GetLine(0).TrimEnd());
-        Assert.Equal("FGHIJ", snap2.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDE", snap2.GetLine(0).TrimEnd());
+        Assert.AreEqual("FGHIJ", snap2.GetLine(1).TrimEnd());
     }
 
-    [Fact]
+    [TestMethod]
     public void Reflow_HardWrappedLines_NotMerged()
     {
         // Arrange: 10-column terminal with xterm reflow
@@ -77,11 +78,11 @@ public class TerminalReflowTests
         terminal.Resize(20, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("Hello", snap.GetLine(0).TrimEnd());
-        Assert.Equal("World", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("Hello", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("World", snap.GetLine(1).TrimEnd());
     }
 
-    [Fact]
+    [TestMethod]
     public void Reflow_NoReflowStrategy_CropsOnly()
     {
         // Arrange: 10-column terminal with NO reflow
@@ -98,11 +99,11 @@ public class TerminalReflowTests
 
         // Assert: First 5 chars visible, rest cropped (not re-wrapped)
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDE", snap.GetLine(0).TrimEnd());
-        Assert.Equal("", snap.GetLine(1).TrimEnd()); // No overflow to row 1
+        Assert.AreEqual("ABCDE", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("", snap.GetLine(1).TrimEnd()); // No overflow to row 1
     }
 
-    [Fact]
+    [TestMethod]
     public void Reflow_SameWidth_NoChange()
     {
         var adapter = new HeadlessPresentationAdapter(10, 3).WithReflow(AlacrittyReflowStrategy.Instance);
@@ -114,10 +115,10 @@ public class TerminalReflowTests
         terminal.Resize(10, 3);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("Hello", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("Hello", snap.GetLine(0).TrimEnd());
     }
 
-    [Fact]
+    [TestMethod]
     public void Reflow_MultipleWraps_RewrapCorrectly()
     {
         // Arrange: 3-column terminal
@@ -133,15 +134,15 @@ public class TerminalReflowTests
         terminal.Resize(9, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHI", snap.GetLine(0).TrimEnd());
-        Assert.Equal("", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDEFGHI", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("", snap.GetLine(1).TrimEnd());
     }
 
     #endregion
 
     #region Scrollback Promotion/Demotion
 
-    [Fact]
+    [TestMethod]
     public void Reflow_NarrowingPushesRowsToScrollback()
     {
         // Arrange: 10-col, 3-row terminal with scrollback
@@ -165,10 +166,10 @@ public class TerminalReflowTests
         // 10 chars at 5 cols = 2 rows per line. 3 lines = 6 rows. Screen = 3. Scrollback gets 3.
         var screenLine0 = snap.GetLine(0).TrimEnd();
         var screenLine2 = snap.GetLine(2).TrimEnd();
-        Assert.False(string.IsNullOrEmpty(screenLine0), "Screen should have content after narrowing");
+        Assert.IsFalse(string.IsNullOrEmpty(screenLine0), "Screen should have content after narrowing");
     }
 
-    [Fact]
+    [TestMethod]
     public void Reflow_WideningPullsRowsFromScrollback()
     {
         // Arrange: 5-col, 3-row terminal with scrollback, xterm reflow
@@ -183,22 +184,22 @@ public class TerminalReflowTests
 
         // Verify some content is on screen
         var snap1 = terminal.CreateSnapshot();
-        Assert.False(string.IsNullOrEmpty(snap1.GetLine(0).TrimEnd()));
+        Assert.IsFalse(string.IsNullOrEmpty(snap1.GetLine(0).TrimEnd()));
 
         // Act: Resize to 10 — 20 chars at width 10 = 2 rows. Should pull from scrollback.
         terminal.Resize(10, 3);
 
         // Assert: All content should be visible on screen (2 rows of 10)
         var snap2 = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap2.GetLine(0).TrimEnd());
-        Assert.Equal("KLMNOPQRST", snap2.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap2.GetLine(0).TrimEnd());
+        Assert.AreEqual("KLMNOPQRST", snap2.GetLine(1).TrimEnd());
     }
 
     #endregion
 
     #region Cursor Preservation
 
-    [Fact]
+    [TestMethod]
     public void Reflow_CursorPositionPreserved()
     {
         // Arrange: 5-col terminal with xterm reflow
@@ -211,8 +212,8 @@ public class TerminalReflowTests
         terminal.ApplyTokens([new TextToken("ABCDEFGH")]);
 
         var snap1 = terminal.CreateSnapshot();
-        Assert.Equal(3, snap1.CursorX); // After "FGH", cursor at col 3
-        Assert.Equal(1, snap1.CursorY); // Row 1
+        Assert.AreEqual(3, snap1.CursorX); // After "FGH", cursor at col 3
+        Assert.AreEqual(1, snap1.CursorY); // Row 1
 
         // Act: Resize to 10 columns — "ABCDEFGH" fits in 1 row
         terminal.Resize(10, 5);
@@ -220,14 +221,14 @@ public class TerminalReflowTests
         var snap2 = terminal.CreateSnapshot();
         // Cursor should be at position 8 (after "ABCDEFGH") in the single row
         // That's col 8, row 0
-        Assert.Equal("ABCDEFGH", snap2.GetLine(0).TrimEnd());
+        Assert.AreEqual("ABCDEFGH", snap2.GetLine(0).TrimEnd());
     }
 
     #endregion
 
     #region Edge Cases
 
-    [Fact]
+    [TestMethod]
     public void Reflow_EmptyScreen_HandlesGracefully()
     {
         var adapter = new HeadlessPresentationAdapter(10, 3).WithReflow(AlacrittyReflowStrategy.Instance);
@@ -239,10 +240,10 @@ public class TerminalReflowTests
         terminal.Resize(20, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("", snap.GetLine(0).TrimEnd());
     }
 
-    [Fact]
+    [TestMethod]
     public void Reflow_AbsolutePositioning_BreaksChain()
     {
         // Arrange: 5-col terminal with xterm reflow (clears SoftWrap on CUP)
@@ -257,8 +258,8 @@ public class TerminalReflowTests
 
         // Verify soft-wraps are set
         var snap1 = terminal.CreateSnapshot();
-        Assert.True((snap1.GetCell(4, 0).Attributes & CellAttributes.SoftWrap) != 0, "Row 0 should have SoftWrap");
-        Assert.True((snap1.GetCell(4, 1).Attributes & CellAttributes.SoftWrap) != 0, "Row 1 should have SoftWrap");
+        Assert.IsTrue((snap1.GetCell(4, 0).Attributes & CellAttributes.SoftWrap) != 0, "Row 0 should have SoftWrap");
+        Assert.IsTrue((snap1.GetCell(4, 1).Attributes & CellAttributes.SoftWrap) != 0, "Row 1 should have SoftWrap");
 
         // Now write one more char to move to row 3, then CUP from row 3
         // This clears SoftWrap on the row the cursor departs from (row 3)
@@ -269,8 +270,7 @@ public class TerminalReflowTests
 
         // Rows 0 and 1 should still have SoftWrap (CUP clears departure row, not arbitrary rows)
         var snap2 = terminal.CreateSnapshot();
-        Assert.True((snap2.GetCell(4, 0).Attributes & CellAttributes.SoftWrap) != 0,
-            "Row 0 SoftWrap should be preserved (CUP clears departure row only)");
+        Assert.IsTrue((snap2.GetCell(4, 0).Attributes & CellAttributes.SoftWrap) != 0, "Row 0 SoftWrap should be preserved (CUP clears departure row only)");
 
         // Now write content on row 0 that overwrites the SoftWrap cell
         terminal.ApplyTokens([
@@ -290,11 +290,10 @@ public class TerminalReflowTests
         // At width 15, the content should be:
         // "ABCDX" + "FGHIJ" + "KLMNO" were originally on rows 0-2
         // But CUP broke things up, so exact layout depends on which SoftWraps survived
-        Assert.False(string.IsNullOrEmpty(snap4.GetLine(0).TrimEnd()),
-            "Content should be present after reflow");
+        Assert.IsFalse(string.IsNullOrEmpty(snap4.GetLine(0).TrimEnd()), "Content should be present after reflow");
     }
 
-    [Fact]
+    [TestMethod]
     public void Reflow_KittyStrategy_AnchorsCursorRow()
     {
         // Arrange: 5-col, 5-row terminal with kitty reflow
@@ -311,10 +310,10 @@ public class TerminalReflowTests
 
         // Assert: Content should be present (exact cursor row behavior is kitty-specific)
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGH", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("ABCDEFGH", snap.GetLine(0).TrimEnd());
     }
 
-    [Fact]
+    [TestMethod]
     public void Reflow_SoftWrapAttributeSetCorrectlyAfterReflow()
     {
         // Arrange: 10-col terminal
@@ -330,25 +329,23 @@ public class TerminalReflowTests
         terminal.Resize(5, 3);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDE", snap.GetLine(0).TrimEnd());
-        Assert.Equal("FGHIJ", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDE", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("FGHIJ", snap.GetLine(1).TrimEnd());
 
         // The last cell of row 0 should have SoftWrap (it continues to row 1)
         var lastCellRow0 = snap.GetCell(4, 0);
-        Assert.True((lastCellRow0.Attributes & CellAttributes.SoftWrap) != 0,
-            "After reflow to narrower width, new wrap points should have SoftWrap");
+        Assert.IsTrue((lastCellRow0.Attributes & CellAttributes.SoftWrap) != 0, "After reflow to narrower width, new wrap points should have SoftWrap");
 
         // Last cell of row 1 should NOT have SoftWrap (content ends here)
         var lastCellRow1 = snap.GetCell(4, 1);
-        Assert.True((lastCellRow1.Attributes & CellAttributes.SoftWrap) == 0,
-            "Last row of content should not have SoftWrap");
+        Assert.IsTrue((lastCellRow1.Attributes & CellAttributes.SoftWrap) == 0, "Last row of content should not have SoftWrap");
     }
 
     #endregion
 
     #region Strategy Comparison
 
-    [Fact]
+    [TestMethod]
     public void Reflow_XtermVsKitty_DivergeWithMidScreenCursor()
     {
         // When NARROWING, soft-wrapped rows split into more rows, pushing content
@@ -391,14 +388,12 @@ public class TerminalReflowTests
 
         // Xterm bottom-fills: screen shows rows 11-15, cursor at row 0 (clamped)
         // Kitty anchors cursor: screen shows rows 7-11, cursor stays at row 1
-        Assert.Equal(0, xtermResult.CursorY);
-        Assert.Equal(1, kittyResult.CursorY);
-        Assert.NotEqual(xtermResult.CursorY, kittyResult.CursorY);
+        Assert.AreEqual(0, xtermResult.CursorY);
+        Assert.AreEqual(1, kittyResult.CursorY);
+        Assert.AreNotEqual(xtermResult.CursorY, kittyResult.CursorY);
 
         // Verify screen content actually differs
-        Assert.NotEqual(
-            GetRowText(xtermResult.ScreenRows[0]),
-            GetRowText(kittyResult.ScreenRows[0]));
+        Assert.AreNotEqual(GetRowText(xtermResult.ScreenRows[0]), GetRowText(kittyResult.ScreenRows[0]));
     }
 
     private static string GetRowText(TerminalCell[] row)
@@ -413,7 +408,7 @@ public class TerminalReflowTests
 
     #region Round-Trip Resize
 
-    [Fact]
+    [TestMethod]
     public void Reflow_NarrowThenWiden_RestoresOriginalContent()
     {
         // Arrange: 10-column terminal with two lines of content
@@ -425,8 +420,8 @@ public class TerminalReflowTests
         terminal.ApplyTokens([new TextToken("ABCDEFGHIJ"), ControlCharacterToken.LineFeed, ControlCharacterToken.CarriageReturn, new TextToken("1234567890")]);
 
         var original = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", original.GetLine(0).TrimEnd());
-        Assert.Equal("1234567890", original.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", original.GetLine(0).TrimEnd());
+        Assert.AreEqual("1234567890", original.GetLine(1).TrimEnd());
 
         // Act: Narrow to 5, then widen back to 10
         terminal.Resize(5, 5);
@@ -434,12 +429,12 @@ public class TerminalReflowTests
 
         // Assert: Content should be restored exactly
         var restored = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", restored.GetLine(0).TrimEnd());
-        Assert.Equal("1234567890", restored.GetLine(1).TrimEnd());
-        Assert.Equal("", restored.GetLine(2).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", restored.GetLine(0).TrimEnd());
+        Assert.AreEqual("1234567890", restored.GetLine(1).TrimEnd());
+        Assert.AreEqual("", restored.GetLine(2).TrimEnd());
     }
 
-    [Fact]
+    [TestMethod]
     public void Reflow_WidenThenNarrow_RestoresOriginalContent()
     {
         // Arrange: 5-column terminal with wrapped content
@@ -451,8 +446,8 @@ public class TerminalReflowTests
         terminal.ApplyTokens([new TextToken("ABCDEFGHIJ")]);
 
         var original = terminal.CreateSnapshot();
-        Assert.Equal("ABCDE", original.GetLine(0).TrimEnd());
-        Assert.Equal("FGHIJ", original.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDE", original.GetLine(0).TrimEnd());
+        Assert.AreEqual("FGHIJ", original.GetLine(1).TrimEnd());
 
         // Act: Widen to 10, then narrow back to 5
         terminal.Resize(10, 5);
@@ -460,12 +455,12 @@ public class TerminalReflowTests
 
         // Assert: Content should be restored exactly
         var restored = terminal.CreateSnapshot();
-        Assert.Equal("ABCDE", restored.GetLine(0).TrimEnd());
-        Assert.Equal("FGHIJ", restored.GetLine(1).TrimEnd());
-        Assert.Equal("", restored.GetLine(2).TrimEnd());
+        Assert.AreEqual("ABCDE", restored.GetLine(0).TrimEnd());
+        Assert.AreEqual("FGHIJ", restored.GetLine(1).TrimEnd());
+        Assert.AreEqual("", restored.GetLine(2).TrimEnd());
     }
 
-    [Fact]
+    [TestMethod]
     public void Reflow_MultipleResizeCycles_ContentStaysConsistent()
     {
         // Arrange: 10-column terminal
@@ -484,16 +479,16 @@ public class TerminalReflowTests
 
         // Assert: Should return to original layout
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
-        Assert.Equal("KLMNOPQRST", snap.GetLine(1).TrimEnd());
-        Assert.Equal("", snap.GetLine(2).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("KLMNOPQRST", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("", snap.GetLine(2).TrimEnd());
     }
 
     #endregion
 
     #region Alternate Screen Buffer
 
-    [Fact]
+    [TestMethod]
     public void Reflow_InAlternateScreen_DoesNotReflow()
     {
         // Arrange: Terminal with reflow enabled, enter alt screen
@@ -511,7 +506,7 @@ public class TerminalReflowTests
 
         // Verify alt screen content before resize
         var snap1 = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap1.GetLine(0).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap1.GetLine(0).TrimEnd());
 
         // Act: Resize while in alt screen — should crop, not reflow
         terminal.Resize(5, 5);
@@ -519,12 +514,12 @@ public class TerminalReflowTests
         // Assert: Content should be cropped (not reflowed)
         var snap2 = terminal.CreateSnapshot();
         // In crop mode, the first 5 chars survive, the rest are lost
-        Assert.Equal("ABCDE", snap2.GetLine(0).TrimEnd());
+        Assert.AreEqual("ABCDE", snap2.GetLine(0).TrimEnd());
         // Second row should NOT have "FGHIJ" (that would be reflow behavior)
-        Assert.Equal("", snap2.GetLine(1).TrimEnd());
+        Assert.AreEqual("", snap2.GetLine(1).TrimEnd());
     }
 
-    [Fact]
+    [TestMethod]
     public void Reflow_AlternateScreenExit_NormalBufferReflowsCorrectly()
     {
         // Arrange: Write to main buffer, enter alt screen, resize, exit alt screen
@@ -544,15 +539,15 @@ public class TerminalReflowTests
 
         // Verify main buffer content is back
         var snap1 = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap1.GetLine(0).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap1.GetLine(0).TrimEnd());
 
         // Act: Resize in normal mode — should reflow
         terminal.Resize(5, 5);
 
         // Assert: Reflow should work normally
         var snap2 = terminal.CreateSnapshot();
-        Assert.Equal("ABCDE", snap2.GetLine(0).TrimEnd());
-        Assert.Equal("FGHIJ", snap2.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABCDE", snap2.GetLine(0).TrimEnd());
+        Assert.AreEqual("FGHIJ", snap2.GetLine(1).TrimEnd());
     }
 
     #endregion

--- a/tests/Hex1b.Tests/TerminalRegionPatternMatchTests.cs
+++ b/tests/Hex1b.Tests/TerminalRegionPatternMatchTests.cs
@@ -5,35 +5,36 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for the regex pattern matching functionality on terminal regions.
 /// </summary>
+[TestClass]
 public class TerminalRegionPatternMatchTests
 {
     #region TextMatch Tests
 
-    [Fact]
+    [TestMethod]
     public async Task TextMatch_HasCorrectProperties()
     {
         var match = new TextMatch(Line: 2, StartColumn: 5, EndColumn: 10, Text: "Hello");
         
-        Assert.Equal(2, match.Line);
-        Assert.Equal(5, match.StartColumn);
-        Assert.Equal(10, match.EndColumn);
-        Assert.Equal("Hello", match.Text);
-        Assert.Equal(5, match.Length);
+        Assert.AreEqual(2, match.Line);
+        Assert.AreEqual(5, match.StartColumn);
+        Assert.AreEqual(10, match.EndColumn);
+        Assert.AreEqual("Hello", match.Text);
+        Assert.AreEqual(5, match.Length);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TextMatch_LengthCalculation()
     {
         var match = new TextMatch(Line: 0, StartColumn: 0, EndColumn: 15, Text: "test expression");
         
-        Assert.Equal(15, match.Length);
+        Assert.AreEqual(15, match.Length);
     }
 
     #endregion
 
     #region FindPattern Tests
 
-    [Fact]
+    [TestMethod]
     public async Task FindPattern_FindsSimplePattern()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -50,14 +51,14 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var matches = snapshot.FindPattern(@"Test");
         
-        Assert.Single(matches);
-        Assert.Equal(1, matches[0].Line);
-        Assert.Equal(0, matches[0].StartColumn);
-        Assert.Equal(4, matches[0].EndColumn);
-        Assert.Equal("Test", matches[0].Text);
+        TestSeq.Single(matches);
+        Assert.AreEqual(1, matches[0].Line);
+        Assert.AreEqual(0, matches[0].StartColumn);
+        Assert.AreEqual(4, matches[0].EndColumn);
+        Assert.AreEqual("Test", matches[0].Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindPattern_FindsMultipleMatchesOnSameLine()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -72,14 +73,14 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var matches = snapshot.FindPattern(@"cat");
         
-        Assert.Equal(2, matches.Count);
-        Assert.Equal(0, matches[0].StartColumn);
-        Assert.Equal(3, matches[0].EndColumn);
-        Assert.Equal(16, matches[1].StartColumn);
-        Assert.Equal(19, matches[1].EndColumn);
+        Assert.AreEqual(2, matches.Count);
+        Assert.AreEqual(0, matches[0].StartColumn);
+        Assert.AreEqual(3, matches[0].EndColumn);
+        Assert.AreEqual(16, matches[1].StartColumn);
+        Assert.AreEqual(19, matches[1].EndColumn);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindPattern_FindsMatchesAcrossMultipleLines()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -96,12 +97,12 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var matches = snapshot.FindPattern(@"Error");
         
-        Assert.Equal(2, matches.Count);
-        Assert.Equal(0, matches[0].Line);
-        Assert.Equal(2, matches[1].Line);
+        Assert.AreEqual(2, matches.Count);
+        Assert.AreEqual(0, matches[0].Line);
+        Assert.AreEqual(2, matches[1].Line);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindPattern_UsesRegexOptions()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -117,15 +118,15 @@ public class TerminalRegionPatternMatchTests
         
         // Case sensitive (default) - should not match
         var matches = snapshot.FindPattern(@"hello");
-        Assert.Empty(matches);
+        Assert.IsEmpty(matches);
         
         // Case insensitive - should match
         var matchesIgnoreCase = snapshot.FindPattern(@"hello", RegexOptions.IgnoreCase);
-        Assert.Single(matchesIgnoreCase);
-        Assert.Equal("Hello", matchesIgnoreCase[0].Text);
+        TestSeq.Single(matchesIgnoreCase);
+        Assert.AreEqual("Hello", matchesIgnoreCase[0].Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindPattern_WithCompiledRegex()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -141,12 +142,12 @@ public class TerminalRegionPatternMatchTests
         var regex = new Regex(@"\d+");
         var matches = snapshot.FindPattern(regex);
         
-        Assert.Single(matches);
-        Assert.Equal("12345", matches[0].Text);
-        Assert.Equal(7, matches[0].StartColumn);
+        TestSeq.Single(matches);
+        Assert.AreEqual("12345", matches[0].Text);
+        Assert.AreEqual(7, matches[0].StartColumn);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindPattern_ReturnsEmptyListWhenNoMatch()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -161,10 +162,10 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var matches = snapshot.FindPattern(@"NotFound");
         
-        Assert.Empty(matches);
+        Assert.IsEmpty(matches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindPattern_MatchesComplexRegex()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -180,16 +181,16 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var matches = snapshot.FindPattern(@"\w+@\w+\.\w+");
         
-        Assert.Equal(2, matches.Count);
-        Assert.Equal("user@example.com", matches[0].Text);
-        Assert.Equal("admin@test.org", matches[1].Text);
+        Assert.AreEqual(2, matches.Count);
+        Assert.AreEqual("user@example.com", matches[0].Text);
+        Assert.AreEqual("admin@test.org", matches[1].Text);
     }
 
     #endregion
 
     #region FindFirstPattern Tests
 
-    [Fact]
+    [TestMethod]
     public async Task FindFirstPattern_ReturnsFirstMatch()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -205,12 +206,12 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var match = snapshot.FindFirstPattern(@"match");
         
-        Assert.NotNull(match);
-        Assert.Equal(0, match.Value.Line);
-        Assert.Equal(6, match.Value.StartColumn);
+        Assert.IsNotNull(match);
+        Assert.AreEqual(0, match.Value.Line);
+        Assert.AreEqual(6, match.Value.StartColumn);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindFirstPattern_ReturnsNullWhenNoMatch()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -225,10 +226,10 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var match = snapshot.FindFirstPattern(@"NotFound");
         
-        Assert.Null(match);
+        Assert.IsNull(match);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindFirstPattern_WithRegexOptions()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -243,11 +244,11 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var match = snapshot.FindFirstPattern(@"hello", RegexOptions.IgnoreCase);
         
-        Assert.NotNull(match);
-        Assert.Equal("HELLO", match.Value.Text);
+        Assert.IsNotNull(match);
+        Assert.AreEqual("HELLO", match.Value.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindFirstPattern_WithCompiledRegex()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -263,15 +264,15 @@ public class TerminalRegionPatternMatchTests
         var regex = new Regex(@"\$[\d.]+");
         var match = snapshot.FindFirstPattern(regex);
         
-        Assert.NotNull(match);
-        Assert.Equal("$99.99", match.Value.Text);
+        Assert.IsNotNull(match);
+        Assert.AreEqual("$99.99", match.Value.Text);
     }
 
     #endregion
 
     #region GetTextAt Tests
 
-    [Fact]
+    [TestMethod]
     public async Task GetTextAt_ReturnsTextAtCoordinates()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -286,10 +287,10 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var text = snapshot.GetTextAt(line: 0, startColumn: 6, endColumn: 11);
         
-        Assert.Equal("World", text);
+        Assert.AreEqual("World", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetTextAt_WithTextMatch()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -304,13 +305,13 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var match = snapshot.FindFirstPattern(@"\d+");
         
-        Assert.NotNull(match);
+        Assert.IsNotNull(match);
         var text = snapshot.GetTextAt(match.Value);
         
-        Assert.Equal("12345", text);
+        Assert.AreEqual("12345", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetTextAt_ReturnsEmptyForInvalidLine()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -325,10 +326,10 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var text = snapshot.GetTextAt(line: 100, startColumn: 0, endColumn: 5);
         
-        Assert.Equal("", text);
+        Assert.AreEqual("", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetTextAt_ClampsToValidRange()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -348,7 +349,7 @@ public class TerminalRegionPatternMatchTests
         Assert.StartsWith("World", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetTextAt_HandlesNegativeStart()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -365,14 +366,14 @@ public class TerminalRegionPatternMatchTests
         var text = snapshot.GetTextAt(line: 0, startColumn: -5, endColumn: 5);
         
         // Should start at 0
-        Assert.Equal("Hello", text);
+        Assert.AreEqual("Hello", text);
     }
 
     #endregion
 
     #region ContainsPattern Tests
 
-    [Fact]
+    [TestMethod]
     public async Task ContainsPattern_ReturnsTrueWhenPatternExists()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -385,11 +386,11 @@ public class TerminalRegionPatternMatchTests
             .Capture("final")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-        Assert.True(snapshot.ContainsPattern(@"Error"));
-        Assert.True(snapshot.ContainsPattern(@"went \w+"));
+        Assert.IsTrue(snapshot.ContainsPattern(@"Error"));
+        Assert.IsTrue(snapshot.ContainsPattern(@"went \w+"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ContainsPattern_ReturnsFalseWhenPatternNotExists()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -402,11 +403,11 @@ public class TerminalRegionPatternMatchTests
             .Capture("final")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-        Assert.False(snapshot.ContainsPattern(@"Error"));
-        Assert.False(snapshot.ContainsPattern(@"\d{5}"));
+        Assert.IsFalse(snapshot.ContainsPattern(@"Error"));
+        Assert.IsFalse(snapshot.ContainsPattern(@"\d{5}"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ContainsPattern_WithRegexOptions()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -419,11 +420,11 @@ public class TerminalRegionPatternMatchTests
             .Capture("final")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-        Assert.False(snapshot.ContainsPattern(@"success"));
-        Assert.True(snapshot.ContainsPattern(@"success", RegexOptions.IgnoreCase));
+        Assert.IsFalse(snapshot.ContainsPattern(@"success"));
+        Assert.IsTrue(snapshot.ContainsPattern(@"success", RegexOptions.IgnoreCase));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ContainsPattern_WithCompiledRegex()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -437,14 +438,14 @@ public class TerminalRegionPatternMatchTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var regex = new Regex(@"\d+\.\d+\.\d+");
-        Assert.True(snapshot.ContainsPattern(regex));
+        Assert.IsTrue(snapshot.ContainsPattern(regex));
     }
 
     #endregion
 
     #region Integration Tests with Regions
 
-    [Fact]
+    [TestMethod]
     public async Task FindPattern_WorksWithRegions()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -465,13 +466,13 @@ public class TerminalRegionPatternMatchTests
         
         var matches = region.FindPattern(@"\d+");
         
-        Assert.Equal(2, matches.Count);
+        Assert.AreEqual(2, matches.Count);
         // Coordinates are relative to the region, not the full snapshot
-        Assert.Equal(0, matches[0].Line);
-        Assert.Equal(1, matches[1].Line);
+        Assert.AreEqual(0, matches[0].Line);
+        Assert.AreEqual(1, matches[1].Line);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetTextAt_WorksWithRegions()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -489,14 +490,14 @@ public class TerminalRegionPatternMatchTests
         var region = snapshot.GetRegion(new Hex1b.Layout.Rect(8, 1, 10, 2));
         
         var text = region.GetTextAt(0, 0, 3);
-        Assert.Equal("BBB", text);
+        Assert.AreEqual("BBB", text);
     }
 
     #endregion
 
     #region Use Case: Extract Data from Terminal
 
-    [Fact]
+    [TestMethod]
     public async Task UseCase_ExtractValueFromLabel()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -514,15 +515,15 @@ public class TerminalRegionPatternMatchTests
         
         // Find and extract the progress value
         var progressMatch = snapshot.FindFirstPattern(@"Progress: (\d+)%");
-        Assert.NotNull(progressMatch);
+        Assert.IsNotNull(progressMatch);
         
         // Extract just the number using a separate regex
         var numberMatch = snapshot.FindFirstPattern(@"(?<=Progress: )\d+");
-        Assert.NotNull(numberMatch);
-        Assert.Equal("75", numberMatch.Value.Text);
+        Assert.IsNotNull(numberMatch);
+        Assert.AreEqual("75", numberMatch.Value.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task UseCase_FindAllErrors()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -540,7 +541,7 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var errors = snapshot.FindPattern(@"\[ERROR\].*");
         
-        Assert.Equal(2, errors.Count);
+        Assert.AreEqual(2, errors.Count);
         Assert.Contains("File not found", errors[0].Text);
         Assert.Contains("Connection failed", errors[1].Text);
     }
@@ -549,41 +550,41 @@ public class TerminalRegionPatternMatchTests
 
     #region MultiLineTextMatch Tests
 
-    [Fact]
+    [TestMethod]
     public async Task MultiLineTextMatch_HasCorrectProperties()
     {
         var match = new MultiLineTextMatch(StartLine: 2, StartColumn: 5, EndLine: 4, EndColumn: 10, Text: "Hello\nWorld\nTest");
         
-        Assert.Equal(2, match.StartLine);
-        Assert.Equal(5, match.StartColumn);
-        Assert.Equal(4, match.EndLine);
-        Assert.Equal(10, match.EndColumn);
-        Assert.Equal("Hello\nWorld\nTest", match.Text);
+        Assert.AreEqual(2, match.StartLine);
+        Assert.AreEqual(5, match.StartColumn);
+        Assert.AreEqual(4, match.EndLine);
+        Assert.AreEqual(10, match.EndColumn);
+        Assert.AreEqual("Hello\nWorld\nTest", match.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MultiLineTextMatch_IsMultiLine_TrueForMultipleLines()
     {
         var match = new MultiLineTextMatch(StartLine: 0, StartColumn: 0, EndLine: 2, EndColumn: 5, Text: "abc\ndef\nghi");
         
-        Assert.True(match.IsMultiLine);
-        Assert.Equal(3, match.LineCount);
+        Assert.IsTrue(match.IsMultiLine);
+        Assert.AreEqual(3, match.LineCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MultiLineTextMatch_IsMultiLine_FalseForSingleLine()
     {
         var match = new MultiLineTextMatch(StartLine: 1, StartColumn: 0, EndLine: 1, EndColumn: 5, Text: "Hello");
         
-        Assert.False(match.IsMultiLine);
-        Assert.Equal(1, match.LineCount);
+        Assert.IsFalse(match.IsMultiLine);
+        Assert.AreEqual(1, match.LineCount);
     }
 
     #endregion
 
     #region FindMultiLinePattern Tests
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_FindsSingleLinePattern()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -600,16 +601,16 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var matches = snapshot.FindMultiLinePattern(@"Test");
         
-        Assert.Single(matches);
-        Assert.Equal(1, matches[0].StartLine);
-        Assert.Equal(1, matches[0].EndLine);
-        Assert.Equal(0, matches[0].StartColumn);
-        Assert.Equal(4, matches[0].EndColumn);
-        Assert.Equal("Test", matches[0].Text);
-        Assert.False(matches[0].IsMultiLine);
+        TestSeq.Single(matches);
+        Assert.AreEqual(1, matches[0].StartLine);
+        Assert.AreEqual(1, matches[0].EndLine);
+        Assert.AreEqual(0, matches[0].StartColumn);
+        Assert.AreEqual(4, matches[0].EndColumn);
+        Assert.AreEqual("Test", matches[0].Text);
+        Assert.IsFalse(matches[0].IsMultiLine);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_MatchesAcrossLines()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -627,15 +628,15 @@ public class TerminalRegionPatternMatchTests
         // Use trimLines: true to avoid matching trailing whitespace padding
         var matches = snapshot.FindMultiLinePattern(@"here\nEnd", RegexOptions.None, trimLines: true);
         
-        Assert.Single(matches);
-        Assert.Equal(0, matches[0].StartLine);
-        Assert.Equal(1, matches[0].EndLine);
-        Assert.True(matches[0].IsMultiLine);
+        TestSeq.Single(matches);
+        Assert.AreEqual(0, matches[0].StartLine);
+        Assert.AreEqual(1, matches[0].EndLine);
+        Assert.IsTrue(matches[0].IsMultiLine);
         Assert.Contains("here", matches[0].Text);
         Assert.Contains("End", matches[0].Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_MatchesMultipleLinesWithSingleline()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -654,14 +655,14 @@ public class TerminalRegionPatternMatchTests
         // Use Singleline option so . matches newlines
         var matches = snapshot.FindMultiLinePattern(@"BEGIN.*?END", RegexOptions.Singleline);
         
-        Assert.Single(matches);
-        Assert.Equal(0, matches[0].StartLine);
-        Assert.Equal(3, matches[0].EndLine);
-        Assert.True(matches[0].IsMultiLine);
-        Assert.Equal(4, matches[0].LineCount);
+        TestSeq.Single(matches);
+        Assert.AreEqual(0, matches[0].StartLine);
+        Assert.AreEqual(3, matches[0].EndLine);
+        Assert.IsTrue(matches[0].IsMultiLine);
+        Assert.AreEqual(4, matches[0].LineCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_FindsMultipleMultiLineMatches()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -681,12 +682,12 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var matches = snapshot.FindMultiLinePattern(@"<div>.*?</div>", RegexOptions.Singleline);
         
-        Assert.Equal(2, matches.Count);
-        Assert.True(matches[0].IsMultiLine);
-        Assert.True(matches[1].IsMultiLine);
+        Assert.AreEqual(2, matches.Count);
+        Assert.IsTrue(matches[0].IsMultiLine);
+        Assert.IsTrue(matches[1].IsMultiLine);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_WithNewlineInPattern()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -704,12 +705,12 @@ public class TerminalRegionPatternMatchTests
         // Match explicit newline pattern
         var matches = snapshot.FindMultiLinePattern(@"Line 1\s*\nLine 2");
         
-        Assert.Single(matches);
-        Assert.Equal(0, matches[0].StartLine);
-        Assert.Equal(1, matches[0].EndLine);
+        TestSeq.Single(matches);
+        Assert.AreEqual(0, matches[0].StartLine);
+        Assert.AreEqual(1, matches[0].EndLine);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_MatchesEntireContent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -726,12 +727,12 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var matches = snapshot.FindMultiLinePattern(@"^AAA.*CCC", RegexOptions.Singleline);
         
-        Assert.Single(matches);
-        Assert.Equal(0, matches[0].StartLine);
-        Assert.Equal(2, matches[0].EndLine);
+        TestSeq.Single(matches);
+        Assert.AreEqual(0, matches[0].StartLine);
+        Assert.AreEqual(2, matches[0].EndLine);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_ReturnsEmptyForNoMatch()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -746,10 +747,10 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var matches = snapshot.FindMultiLinePattern(@"NotFound\nAnywhere");
         
-        Assert.Empty(matches);
+        Assert.IsEmpty(matches);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_WithCompiledRegex()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -767,11 +768,11 @@ public class TerminalRegionPatternMatchTests
         var regex = new Regex(@"Start.*End", RegexOptions.Singleline);
         var matches = snapshot.FindMultiLinePattern(regex);
         
-        Assert.Single(matches);
-        Assert.True(matches[0].IsMultiLine);
+        TestSeq.Single(matches);
+        Assert.IsTrue(matches[0].IsMultiLine);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_MatchingJsonStructure()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -789,12 +790,12 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var matches = snapshot.FindMultiLinePattern(@"\{[^}]+\}", RegexOptions.Singleline);
         
-        Assert.Single(matches);
-        Assert.Equal(0, matches[0].StartLine);
-        Assert.Equal(3, matches[0].EndLine);
+        TestSeq.Single(matches);
+        Assert.AreEqual(0, matches[0].StartLine);
+        Assert.AreEqual(3, matches[0].EndLine);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_MatchingCodeBlock()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -811,8 +812,8 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var matches = snapshot.FindMultiLinePattern(@"function.*?\}", RegexOptions.Singleline);
         
-        Assert.Single(matches);
-        Assert.True(matches[0].IsMultiLine);
+        TestSeq.Single(matches);
+        Assert.IsTrue(matches[0].IsMultiLine);
         Assert.Contains("function", matches[0].Text);
         Assert.Contains("return", matches[0].Text);
     }
@@ -821,7 +822,7 @@ public class TerminalRegionPatternMatchTests
 
     #region FindFirstMultiLinePattern Tests
 
-    [Fact]
+    [TestMethod]
     public async Task FindFirstMultiLinePattern_ReturnsFirstMatch()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -839,12 +840,12 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var match = snapshot.FindFirstMultiLinePattern(@"Block.*?End", RegexOptions.Singleline);
         
-        Assert.NotNull(match);
-        Assert.Equal(0, match.Value.StartLine);
+        Assert.IsNotNull(match);
+        Assert.AreEqual(0, match.Value.StartLine);
         Assert.Contains("Block 1", match.Value.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindFirstMultiLinePattern_ReturnsNullForNoMatch()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -859,10 +860,10 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var match = snapshot.FindFirstMultiLinePattern(@"NotFound\nPattern");
         
-        Assert.Null(match);
+        Assert.IsNull(match);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindFirstMultiLinePattern_WithRegexOptions()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -879,11 +880,11 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var match = snapshot.FindFirstMultiLinePattern(@"start.*end", RegexOptions.Singleline | RegexOptions.IgnoreCase);
         
-        Assert.NotNull(match);
-        Assert.True(match.Value.IsMultiLine);
+        Assert.IsNotNull(match);
+        Assert.IsTrue(match.Value.IsMultiLine);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindFirstMultiLinePattern_WithCompiledRegex()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -902,16 +903,16 @@ public class TerminalRegionPatternMatchTests
         // Use trimLines: true to avoid matching trailing whitespace padding
         var match = snapshot.FindFirstMultiLinePattern(regex, trimLines: true);
         
-        Assert.NotNull(match);
-        Assert.Equal(0, match.Value.StartLine);
-        Assert.Equal(2, match.Value.EndLine);
+        Assert.IsNotNull(match);
+        Assert.AreEqual(0, match.Value.StartLine);
+        Assert.AreEqual(2, match.Value.EndLine);
     }
 
     #endregion
 
     #region ContainsMultiLinePattern Tests
 
-    [Fact]
+    [TestMethod]
     public async Task ContainsMultiLinePattern_ReturnsTrueWhenPatternExists()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -926,10 +927,10 @@ public class TerminalRegionPatternMatchTests
             .Capture("final")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-        Assert.True(snapshot.ContainsMultiLinePattern(@"Header.*Footer", RegexOptions.Singleline));
+        Assert.IsTrue(snapshot.ContainsMultiLinePattern(@"Header.*Footer", RegexOptions.Singleline));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ContainsMultiLinePattern_ReturnsFalseWhenPatternNotExists()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -942,10 +943,10 @@ public class TerminalRegionPatternMatchTests
             .Capture("final")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-        Assert.False(snapshot.ContainsMultiLinePattern(@"NotFound\nPattern"));
+        Assert.IsFalse(snapshot.ContainsMultiLinePattern(@"NotFound\nPattern"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ContainsMultiLinePattern_WithCompiledRegex()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -961,14 +962,14 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var regex = new Regex(@"Line1\nLine2");
         // Use trimLines: true to avoid matching trailing whitespace padding
-        Assert.True(snapshot.ContainsMultiLinePattern(regex, trimLines: true));
+        Assert.IsTrue(snapshot.ContainsMultiLinePattern(regex, trimLines: true));
     }
 
     #endregion
 
     #region GetMultiLineTextAt Tests
 
-    [Fact]
+    [TestMethod]
     public async Task GetMultiLineTextAt_ReturnsSingleLineText()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -983,10 +984,10 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var text = snapshot.GetMultiLineTextAt(startLine: 0, startColumn: 6, endLine: 0, endColumn: 11);
         
-        Assert.Equal("World", text);
+        Assert.AreEqual("World", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetMultiLineTextAt_ReturnsMultiLineText()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1007,7 +1008,7 @@ public class TerminalRegionPatternMatchTests
         Assert.Contains("\n", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetMultiLineTextAt_WithMultiLineTextMatch()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1024,17 +1025,17 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var match = snapshot.FindFirstMultiLinePattern(@"START.*END", RegexOptions.Singleline);
         
-        Assert.NotNull(match);
+        Assert.IsNotNull(match);
         // The match.Text property already contains the matched text
         Assert.StartsWith("START", match.Value.Text);
         Assert.EndsWith("END", match.Value.Text);
         
         // GetMultiLineTextAt works with raw terminal coordinates (untrimmed)
         // For multi-line matches, use match.Text directly
-        Assert.Equal(match.Value.Text, match.Value.Text.Trim());
+        Assert.AreEqual(match.Value.Text, match.Value.Text.Trim());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetMultiLineTextAt_ReturnsEmptyForInvalidLine()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1049,10 +1050,10 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var text = snapshot.GetMultiLineTextAt(startLine: 100, startColumn: 0, endLine: 101, endColumn: 5);
         
-        Assert.Equal("", text);
+        Assert.AreEqual("", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetMultiLineTextAt_ClampsToValidRange()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1080,7 +1081,7 @@ public class TerminalRegionPatternMatchTests
 
     #region Multi-Line Edge Cases
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_EmptyLines()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1098,12 +1099,12 @@ public class TerminalRegionPatternMatchTests
         // Use trimLines: true to avoid matching trailing whitespace padding
         var matches = snapshot.FindMultiLinePattern(@"Start\n\nEnd", trimLines: true);
         
-        Assert.Single(matches);
-        Assert.Equal(0, matches[0].StartLine);
-        Assert.Equal(2, matches[0].EndLine);
+        TestSeq.Single(matches);
+        Assert.AreEqual(0, matches[0].StartLine);
+        Assert.AreEqual(2, matches[0].EndLine);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_MatchAtStartOfRegion()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1120,12 +1121,12 @@ public class TerminalRegionPatternMatchTests
         // Use trimLines: true to avoid matching trailing whitespace padding
         var matches = snapshot.FindMultiLinePattern(@"^ABC\nDEF", trimLines: true);
         
-        Assert.Single(matches);
-        Assert.Equal(0, matches[0].StartLine);
-        Assert.Equal(0, matches[0].StartColumn);
+        TestSeq.Single(matches);
+        Assert.AreEqual(0, matches[0].StartLine);
+        Assert.AreEqual(0, matches[0].StartColumn);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_MatchAtEndOfRegion()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1143,12 +1144,12 @@ public class TerminalRegionPatternMatchTests
         // Use trimLines: true to avoid matching trailing whitespace padding
         var matches = snapshot.FindMultiLinePattern(@"YYY\nZZZ", trimLines: true);
         
-        Assert.Single(matches);
-        Assert.Equal(1, matches[0].StartLine);
-        Assert.Equal(2, matches[0].EndLine);
+        TestSeq.Single(matches);
+        Assert.AreEqual(1, matches[0].StartLine);
+        Assert.AreEqual(2, matches[0].EndLine);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_OverlappingPatterns()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1166,10 +1167,10 @@ public class TerminalRegionPatternMatchTests
         var matches = snapshot.FindMultiLinePattern(@"AB");
         
         // Should find 4 matches (2 per line)
-        Assert.Equal(4, matches.Count);
+        Assert.AreEqual(4, matches.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_SpecialRegexCharacters()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1186,11 +1187,11 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var matches = snapshot.FindMultiLinePattern(@"\[ERROR\].*Main\(\)", RegexOptions.Singleline);
         
-        Assert.Single(matches);
-        Assert.True(matches[0].IsMultiLine);
+        TestSeq.Single(matches);
+        Assert.IsTrue(matches[0].IsMultiLine);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_ZeroLengthMatches()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1208,13 +1209,13 @@ public class TerminalRegionPatternMatchTests
         var matches = snapshot.FindMultiLinePattern(@"^", RegexOptions.Multiline);
         
         // Each line should have a match at position 0
-        Assert.True(matches.Count >= 2);
-        Assert.Equal(0, matches[0].StartColumn);
-        Assert.Equal(0, matches[0].EndColumn); // Zero-length match
-        Assert.Equal("", matches[0].Text);
+        Assert.IsTrue(matches.Count >= 2);
+        Assert.AreEqual(0, matches[0].StartColumn);
+        Assert.AreEqual(0, matches[0].EndColumn); // Zero-length match
+        Assert.AreEqual("", matches[0].Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_UnicodeContent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1231,11 +1232,11 @@ public class TerminalRegionPatternMatchTests
         // Use Singleline so . matches newlines and spans the content
         var matches = snapshot.FindMultiLinePattern(@"世界.*мир", RegexOptions.Singleline);
         
-        Assert.Single(matches);
-        Assert.True(matches[0].IsMultiLine);
+        TestSeq.Single(matches);
+        Assert.IsTrue(matches[0].IsMultiLine);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_CaptureGroups()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1253,7 +1254,7 @@ public class TerminalRegionPatternMatchTests
         // Use trimLines: true to avoid matching trailing whitespace padding
         var matches = snapshot.FindMultiLinePattern(regex, trimLines: true);
         
-        Assert.Single(matches);
+        TestSeq.Single(matches);
         Assert.Contains("John", matches[0].Text);
         Assert.Contains("30", matches[0].Text);
     }
@@ -1262,7 +1263,7 @@ public class TerminalRegionPatternMatchTests
 
     #region Multi-Line Use Cases
 
-    [Fact]
+    [TestMethod]
     public async Task UseCase_ExtractStackTrace()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1280,13 +1281,13 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var match = snapshot.FindFirstMultiLinePattern(@"Error:.*?at Main\(\)", RegexOptions.Singleline);
         
-        Assert.NotNull(match);
-        Assert.Equal(4, match.Value.LineCount);
+        Assert.IsNotNull(match);
+        Assert.AreEqual(4, match.Value.LineCount);
         Assert.Contains("NullReferenceException", match.Value.Text);
         Assert.Contains("Method1", match.Value.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task UseCase_ExtractLogBlock()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1303,10 +1304,10 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         var matches = snapshot.FindMultiLinePattern(@"\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] INFO:.*");
         
-        Assert.Equal(2, matches.Count);
+        Assert.AreEqual(2, matches.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task UseCase_WaitForMultiLineOutput()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1324,10 +1325,10 @@ public class TerminalRegionPatternMatchTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         // Check for complete build output
-        Assert.True(snapshot.ContainsMultiLinePattern(@"Build started.*Build succeeded", RegexOptions.Singleline));
+        Assert.IsTrue(snapshot.ContainsMultiLinePattern(@"Build started.*Build succeeded", RegexOptions.Singleline));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task UseCase_ExtractTableData()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1346,11 +1347,11 @@ public class TerminalRegionPatternMatchTests
         // Match table from header to last row - \s* handles any trailing whitespace
         var match = snapshot.FindFirstMultiLinePattern(@"\|\s*Name.*\|\s*Item2\s*\|\s*200\s*\|", RegexOptions.Singleline);
         
-        Assert.NotNull(match);
-        Assert.Equal(4, match.Value.LineCount);
+        Assert.IsNotNull(match);
+        Assert.AreEqual(4, match.Value.LineCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindPattern_MatchesUnicodeCheckAndCross()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1369,12 +1370,12 @@ public class TerminalRegionPatternMatchTests
         var regex = new Regex(@"\[\d+ (?:✔|✘:\d+)\] \$ ", RegexOptions.Multiline);
         var matches = snapshot.FindPattern(regex);
         
-        Assert.Equal(2, matches.Count);
-        Assert.Equal("[1 ✔] $ ", matches[0].Text);
-        Assert.Equal("[1 ✘:127] $ ", matches[1].Text);
+        Assert.AreEqual(2, matches.Count);
+        Assert.AreEqual("[1 ✔] $ ", matches[0].Text);
+        Assert.AreEqual("[1 ✘:127] $ ", matches[1].Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_MatchesUnicodeCheckAndCross_WithTrailingSpace()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1393,12 +1394,12 @@ public class TerminalRegionPatternMatchTests
         var regex = new Regex(@"\[\d+ (?:✔|✘:\d+)\] \$ ", RegexOptions.Multiline);
         var matches = snapshot.FindMultiLinePattern(regex);
         
-        Assert.Equal(2, matches.Count);
-        Assert.Equal("[1 ✔] $ ", matches[0].Text);
-        Assert.Equal("[1 ✘:127] $ ", matches[1].Text);
+        Assert.AreEqual(2, matches.Count);
+        Assert.AreEqual("[1 ✔] $ ", matches[0].Text);
+        Assert.AreEqual("[1 ✘:127] $ ", matches[1].Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_WithCustomLineSeparator()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1417,13 +1418,13 @@ public class TerminalRegionPatternMatchTests
         // Use custom separator " | " between lines
         var matches = snapshot.FindMultiLinePattern(@"Line1 \| Line2 \| Line3", trimLines: true, lineSeparator: " | ");
         
-        Assert.Single(matches);
+        TestSeq.Single(matches);
         Assert.Contains("Line1", matches[0].Text);
         Assert.Contains("Line2", matches[0].Text);
         Assert.Contains("Line3", matches[0].Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_WithNoLineSeparator_ConcatenatesDirectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1442,11 +1443,11 @@ public class TerminalRegionPatternMatchTests
         // Use null separator to concatenate lines directly
         var matches = snapshot.FindMultiLinePattern(@"ABCDEFGHI", trimLines: true, lineSeparator: null);
         
-        Assert.Single(matches);
-        Assert.Equal("ABCDEFGHI", matches[0].Text);
+        TestSeq.Single(matches);
+        Assert.AreEqual("ABCDEFGHI", matches[0].Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FindMultiLinePattern_WithEmptyLineSeparator_ConcatenatesDirectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1464,8 +1465,8 @@ public class TerminalRegionPatternMatchTests
         // Use empty string separator to concatenate lines directly
         var matches = snapshot.FindMultiLinePattern(@"HelloWorld", trimLines: true, lineSeparator: "");
         
-        Assert.Single(matches);
-        Assert.Equal("HelloWorld", matches[0].Text);
+        TestSeq.Single(matches);
+        Assert.AreEqual("HelloWorld", matches[0].Text);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/TerminalResizeTimingTests.cs
+++ b/tests/Hex1b.Tests/TerminalResizeTimingTests.cs
@@ -11,6 +11,7 @@ namespace Hex1b.Tests;
 /// These tests focus on the race condition where resize events occur
 /// before the PTY process has started.
 /// </summary>
+[TestClass]
 public class TerminalResizeTimingTests
 {
     private const string StartupMarker = "HEX1B_TERMINAL_READY";
@@ -19,7 +20,7 @@ public class TerminalResizeTimingTests
     /// Verifies that when ResizeAsync is called before StartAsync,
     /// the PTY still starts with the correct dimensions.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ResizeAsync_CalledBeforeStart_PtyStartsWithUpdatedDimensions()
     {
         // Arrange
@@ -34,8 +35,8 @@ public class TerminalResizeTimingTests
         await childProcess.StartAsync(TestContext.Current.CancellationToken);
         
         // Assert - Check the process dimensions
-        Assert.Equal(148, childProcess.Width);
-        Assert.Equal(36, childProcess.Height);
+        Assert.AreEqual(148, childProcess.Width);
+        Assert.AreEqual(36, childProcess.Height);
         
         // Clean up
         childProcess.Kill();
@@ -46,7 +47,7 @@ public class TerminalResizeTimingTests
     /// Verifies that TerminalWidgetHandle.Resize fires the Resized event
     /// which should propagate to the Hex1bTerminal.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void TerminalWidgetHandle_Resize_FiresResizedEvent()
     {
         // Arrange
@@ -66,18 +67,18 @@ public class TerminalResizeTimingTests
         handle.Resize(148, 36);
         
         // Assert
-        Assert.Equal(1, resizedCount);
-        Assert.Equal(148, resizedWidth);
-        Assert.Equal(36, resizedHeight);
-        Assert.Equal(148, handle.Width);
-        Assert.Equal(36, handle.Height);
+        Assert.AreEqual(1, resizedCount);
+        Assert.AreEqual(148, resizedWidth);
+        Assert.AreEqual(36, resizedHeight);
+        Assert.AreEqual(148, handle.Width);
+        Assert.AreEqual(36, handle.Height);
     }
     
     /// <summary>
     /// Verifies the complete flow: TerminalNode.Arrange resizes handle,
     /// which should propagate through Hex1bTerminal to the PTY.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task TerminalNode_Arrange_PropagatesResizeToPty()
     {
         // Arrange - Create terminal with widget handle
@@ -107,9 +108,9 @@ public class TerminalResizeTimingTests
             node.Arrange(new Rect(0, 0, 148, 36));
             
             // Assert
-            Assert.True(resizeCount > 0, "Resize event should have fired");
-            Assert.Equal(148, handle.Width);
-            Assert.Equal(36, handle.Height);
+            Assert.IsTrue(resizeCount > 0, "Resize event should have fired");
+            Assert.AreEqual(148, handle.Width);
+            Assert.AreEqual(36, handle.Height);
         }
         finally
         {
@@ -122,7 +123,7 @@ public class TerminalResizeTimingTests
     /// Tests that output from a terminal is received even after handle resize.
     /// This simulates the scenario where a second terminal is created and resized.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Terminal_AfterResize_ReceivesOutput()
     {
         // Arrange
@@ -145,7 +146,7 @@ public class TerminalResizeTimingTests
             handle.Resize(148, 36);
             
             // Assert
-            Assert.True(outputReceived, "Should have received output from the shell.");
+            Assert.IsTrue(outputReceived, "Should have received output from the shell.");
             
             // Check that the buffer has content
             var (buffer, bufferWidth, bufferHeight) = handle.GetScreenBufferSnapshot();
@@ -161,7 +162,7 @@ public class TerminalResizeTimingTests
                 }
             }
             
-            Assert.True(hasContent, "Buffer should contain shell output.");
+            Assert.IsTrue(hasContent, "Buffer should contain shell output.");
         }
         finally
         {
@@ -174,7 +175,7 @@ public class TerminalResizeTimingTests
     /// Tests that TerminalNode correctly subscribes to OutputReceived
     /// and marks itself dirty when output arrives.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task TerminalNode_WhenBound_ReceivesOutputAndMarksDirty()
     {
         // Arrange
@@ -204,9 +205,8 @@ public class TerminalResizeTimingTests
             await WaitForTerminalStateAsync(handle, TerminalState.Running, GetStartupTimeout(), TestContext.Current.CancellationToken);
             
             // Assert
-            Assert.True(invalidateCalled, "Invalidate callback should have been called when output arrived");
-            Assert.True(node.HasPendingOutput || handle.State == TerminalState.Running, 
-                "Node should have pending output or terminal should be running");
+            Assert.IsTrue(invalidateCalled, "Invalidate callback should have been called when output arrived");
+            Assert.IsTrue(node.HasPendingOutput || handle.State == TerminalState.Running, "Node should have pending output or terminal should be running");
         }
         finally
         {
@@ -220,7 +220,7 @@ public class TerminalResizeTimingTests
     /// This test simulates the exact scenario of switching between terminals
     /// to verify the second terminal receives output correctly.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task SecondTerminal_WhenSwitchedTo_ReceivesAndDisplaysOutput()
     {
         // Arrange - Create two terminals
@@ -253,7 +253,7 @@ public class TerminalResizeTimingTests
             
             // Verify first terminal works
             bool terminal1HasContent = HasNonEmptyContent(handle1);
-            Assert.True(terminal1HasContent, "First terminal should have content");
+            Assert.IsTrue(terminal1HasContent, "First terminal should have content");
             
             // Now switch to second terminal (simulates what reconciliation does)
             node.Unbind();
@@ -275,9 +275,8 @@ public class TerminalResizeTimingTests
             // Assert - Second terminal should have content
             bool terminal2HasContent = HasNonEmptyContent(handle2);
             
-            Assert.True(terminal2HasContent, 
-                $"Second terminal should have content. State={handle2.State}, Width={handle2.Width}, Height={handle2.Height}");
-            Assert.True(invalidateCalled, "Invalidate should have been called for second terminal");
+            Assert.IsTrue(terminal2HasContent, $"Second terminal should have content. State={handle2.State}, Width={handle2.Width}, Height={handle2.Height}");
+            Assert.IsTrue(invalidateCalled, "Invalidate should have been called for second terminal");
         }
         finally
         {
@@ -455,7 +454,7 @@ public class TerminalResizeTimingTests
     /// This test simulates the EXACT scenario in EmbeddedTerminalDemo where
     /// terminals are created within a Hex1bApp and switched via UI.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task FullIntegration_SecondTerminal_ShowsOutput()
     {
         // This test uses a headless Hex1bApp with embedded terminals
@@ -562,7 +561,7 @@ public class TerminalResizeTimingTests
             var handle1 = terminals[0].handle;
             await WaitForTerminalContentAsync(handle1, GetStartupTimeout(), TestContext.Current.CancellationToken);
             bool terminal1HasContent = HasNonEmptyContent(handle1);
-            Assert.True(terminal1HasContent, "First terminal should have content");
+            Assert.IsTrue(terminal1HasContent, "First terminal should have content");
             
             // Create second terminal
             AddTerminal();
@@ -579,11 +578,10 @@ public class TerminalResizeTimingTests
             bool terminal2HasContent = HasNonEmptyContent(handle2);
             
             // Also check the handle's state
-            TestContext.Current.SendDiagnosticMessage($"Terminal 2 state: {handle2.State}");
-            TestContext.Current.SendDiagnosticMessage($"Terminal 2 dimensions: {handle2.Width}x{handle2.Height}");
+            TestContext.Current?.WriteLine($"Terminal 2 state: {handle2.State}");
+            TestContext.Current?.WriteLine($"Terminal 2 dimensions: {handle2.Width}x{handle2.Height}");
             
-            Assert.True(terminal2HasContent, 
-                $"Second terminal should have content. State={handle2.State}, " +
+            Assert.IsTrue(terminal2HasContent, $"Second terminal should have content. State={handle2.State}, " +
                 $"Width={handle2.Width}, Height={handle2.Height}");
         }
         finally

--- a/tests/Hex1b.Tests/TerminalSelectionTests.cs
+++ b/tests/Hex1b.Tests/TerminalSelectionTests.cs
@@ -4,111 +4,112 @@ namespace Hex1b.Tests;
 /// Tests for the TerminalSelection model — coordinate math, selection modes,
 /// text extraction with soft wraps and wide characters.
 /// </summary>
+[TestClass]
 public class TerminalSelectionTests
 {
-    [Fact]
+    [TestMethod]
     public void BufferPosition_CompareTo_OrdersByRowThenColumn()
     {
         var a = new BufferPosition(0, 0);
         var b = new BufferPosition(0, 5);
         var c = new BufferPosition(1, 0);
         
-        Assert.True(a < b);
-        Assert.True(b < c);
-        Assert.True(a < c);
-        Assert.False(c < a);
+        Assert.IsTrue(a < b);
+        Assert.IsTrue(b < c);
+        Assert.IsTrue(a < c);
+        Assert.IsFalse(c < a);
     }
 
-    [Fact]
+    [TestMethod]
     public void BufferPosition_Equality()
     {
         var a = new BufferPosition(3, 7);
         var b = new BufferPosition(3, 7);
-        Assert.Equal(a, b);
+        Assert.AreEqual(a, b);
     }
 
-    [Fact]
+    [TestMethod]
     public void Selection_InitialState_NotSelecting()
     {
         var sel = new TerminalSelection(new BufferPosition(5, 10));
-        Assert.False(sel.IsSelecting);
-        Assert.Equal(new BufferPosition(5, 10), sel.Cursor);
+        Assert.IsFalse(sel.IsSelecting);
+        Assert.AreEqual(new BufferPosition(5, 10), sel.Cursor);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_UpdatesCursorPosition()
     {
         var sel = new TerminalSelection(new BufferPosition(0, 0));
         sel.MoveCursor(new BufferPosition(3, 5));
-        Assert.Equal(new BufferPosition(3, 5), sel.Cursor);
+        Assert.AreEqual(new BufferPosition(3, 5), sel.Cursor);
     }
 
-    [Fact]
+    [TestMethod]
     public void StartSelection_SetsAnchorAndSelecting()
     {
         var sel = new TerminalSelection(new BufferPosition(0, 0));
         sel.MoveCursor(new BufferPosition(2, 3));
         sel.StartSelection(SelectionMode.Character);
         
-        Assert.True(sel.IsSelecting);
-        Assert.Equal(new BufferPosition(2, 3), sel.Anchor);
-        Assert.Equal(SelectionMode.Character, sel.Mode);
+        Assert.IsTrue(sel.IsSelecting);
+        Assert.AreEqual(new BufferPosition(2, 3), sel.Anchor);
+        Assert.AreEqual(SelectionMode.Character, sel.Mode);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClearSelection_StopsSelecting()
     {
         var sel = new TerminalSelection(new BufferPosition(0, 0));
         sel.StartSelection();
-        Assert.True(sel.IsSelecting);
+        Assert.IsTrue(sel.IsSelecting);
         
         sel.ClearSelection();
-        Assert.False(sel.IsSelecting);
+        Assert.IsFalse(sel.IsSelecting);
     }
 
-    [Fact]
+    [TestMethod]
     public void Start_End_NormalizedRegardlessOfDirection()
     {
         var sel = new TerminalSelection(new BufferPosition(5, 10));
         sel.StartSelection();
         sel.MoveCursor(new BufferPosition(2, 3)); // cursor before anchor
         
-        Assert.Equal(new BufferPosition(2, 3), sel.Start);
-        Assert.Equal(new BufferPosition(5, 10), sel.End);
+        Assert.AreEqual(new BufferPosition(2, 3), sel.Start);
+        Assert.AreEqual(new BufferPosition(5, 10), sel.End);
     }
 
-    [Fact]
+    [TestMethod]
     public void ToggleMode_SwitchesBetweenModes()
     {
         var sel = new TerminalSelection(new BufferPosition(0, 0));
         sel.StartSelection(SelectionMode.Character);
         
         sel.ToggleMode(SelectionMode.Line);
-        Assert.Equal(SelectionMode.Line, sel.Mode);
+        Assert.AreEqual(SelectionMode.Line, sel.Mode);
         
         // Toggle same mode goes back to character
         sel.ToggleMode(SelectionMode.Line);
-        Assert.Equal(SelectionMode.Character, sel.Mode);
+        Assert.AreEqual(SelectionMode.Character, sel.Mode);
     }
 
     // === IsCellSelected tests ===
 
-    [Fact]
+    [TestMethod]
     public void IsCellSelected_Character_SingleRow()
     {
         var sel = new TerminalSelection(new BufferPosition(3, 2));
         sel.StartSelection(SelectionMode.Character);
         sel.MoveCursor(new BufferPosition(3, 7));
         
-        Assert.False(sel.IsCellSelected(3, 1));
-        Assert.True(sel.IsCellSelected(3, 2));
-        Assert.True(sel.IsCellSelected(3, 5));
-        Assert.True(sel.IsCellSelected(3, 7));
-        Assert.False(sel.IsCellSelected(3, 8));
-        Assert.False(sel.IsCellSelected(2, 5));
+        Assert.IsFalse(sel.IsCellSelected(3, 1));
+        Assert.IsTrue(sel.IsCellSelected(3, 2));
+        Assert.IsTrue(sel.IsCellSelected(3, 5));
+        Assert.IsTrue(sel.IsCellSelected(3, 7));
+        Assert.IsFalse(sel.IsCellSelected(3, 8));
+        Assert.IsFalse(sel.IsCellSelected(2, 5));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsCellSelected_Character_MultipleRows()
     {
         var sel = new TerminalSelection(new BufferPosition(1, 5));
@@ -116,37 +117,37 @@ public class TerminalSelectionTests
         sel.MoveCursor(new BufferPosition(3, 3));
         
         // Row 1: from column 5 to end
-        Assert.False(sel.IsCellSelected(1, 4));
-        Assert.True(sel.IsCellSelected(1, 5));
-        Assert.True(sel.IsCellSelected(1, 79));
+        Assert.IsFalse(sel.IsCellSelected(1, 4));
+        Assert.IsTrue(sel.IsCellSelected(1, 5));
+        Assert.IsTrue(sel.IsCellSelected(1, 79));
         
         // Row 2: fully selected
-        Assert.True(sel.IsCellSelected(2, 0));
-        Assert.True(sel.IsCellSelected(2, 79));
+        Assert.IsTrue(sel.IsCellSelected(2, 0));
+        Assert.IsTrue(sel.IsCellSelected(2, 79));
         
         // Row 3: from start to column 3
-        Assert.True(sel.IsCellSelected(3, 0));
-        Assert.True(sel.IsCellSelected(3, 3));
-        Assert.False(sel.IsCellSelected(3, 4));
+        Assert.IsTrue(sel.IsCellSelected(3, 0));
+        Assert.IsTrue(sel.IsCellSelected(3, 3));
+        Assert.IsFalse(sel.IsCellSelected(3, 4));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsCellSelected_Line_SelectsEntireRows()
     {
         var sel = new TerminalSelection(new BufferPosition(2, 5));
         sel.StartSelection(SelectionMode.Line);
         sel.MoveCursor(new BufferPosition(4, 10));
         
-        Assert.False(sel.IsCellSelected(1, 0));
-        Assert.True(sel.IsCellSelected(2, 0));
-        Assert.True(sel.IsCellSelected(2, 79));
-        Assert.True(sel.IsCellSelected(3, 0));
-        Assert.True(sel.IsCellSelected(4, 0));
-        Assert.True(sel.IsCellSelected(4, 79));
-        Assert.False(sel.IsCellSelected(5, 0));
+        Assert.IsFalse(sel.IsCellSelected(1, 0));
+        Assert.IsTrue(sel.IsCellSelected(2, 0));
+        Assert.IsTrue(sel.IsCellSelected(2, 79));
+        Assert.IsTrue(sel.IsCellSelected(3, 0));
+        Assert.IsTrue(sel.IsCellSelected(4, 0));
+        Assert.IsTrue(sel.IsCellSelected(4, 79));
+        Assert.IsFalse(sel.IsCellSelected(5, 0));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsCellSelected_Block_SelectsRectangle()
     {
         var sel = new TerminalSelection(new BufferPosition(1, 3));
@@ -154,22 +155,22 @@ public class TerminalSelectionTests
         sel.MoveCursor(new BufferPosition(4, 8));
         
         // Inside rectangle
-        Assert.True(sel.IsCellSelected(1, 3));
-        Assert.True(sel.IsCellSelected(2, 5));
-        Assert.True(sel.IsCellSelected(4, 8));
+        Assert.IsTrue(sel.IsCellSelected(1, 3));
+        Assert.IsTrue(sel.IsCellSelected(2, 5));
+        Assert.IsTrue(sel.IsCellSelected(4, 8));
         
         // Outside rectangle
-        Assert.False(sel.IsCellSelected(1, 2));
-        Assert.False(sel.IsCellSelected(2, 9));
-        Assert.False(sel.IsCellSelected(0, 5));
-        Assert.False(sel.IsCellSelected(5, 5));
+        Assert.IsFalse(sel.IsCellSelected(1, 2));
+        Assert.IsFalse(sel.IsCellSelected(2, 9));
+        Assert.IsFalse(sel.IsCellSelected(0, 5));
+        Assert.IsFalse(sel.IsCellSelected(5, 5));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsCellSelected_WhenNotSelecting_ReturnsFalse()
     {
         var sel = new TerminalSelection(new BufferPosition(3, 5));
-        Assert.False(sel.IsCellSelected(3, 5));
+        Assert.IsFalse(sel.IsCellSelected(3, 5));
     }
 
     // === ExtractText tests ===
@@ -180,7 +181,7 @@ public class TerminalSelectionTests
         return new TerminalCell(ch, null, null, attrs);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtractText_Character_SingleRow()
     {
         // Buffer: "Hello World     " (row 0, 16 wide)
@@ -192,10 +193,10 @@ public class TerminalSelectionTests
         sel.MoveCursor(new BufferPosition(0, 10));
 
         var text = sel.ExtractText(GetCell, 16);
-        Assert.Equal("Hello World", text);
+        Assert.AreEqual("Hello World", text);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtractText_Character_MultipleRows_NoSoftWrap()
     {
         var rows = new[] { "Line one   ", "Line two   " };
@@ -208,10 +209,10 @@ public class TerminalSelectionTests
 
         var text = sel.ExtractText(GetCell, 11);
         // No soft wrap → newline between rows, trailing spaces trimmed
-        Assert.Equal("Line one" + Environment.NewLine + "Line two", text);
+        Assert.AreEqual("Line one" + Environment.NewLine + "Line two", text);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtractText_Character_WithSoftWrap_JoinsRows()
     {
         // Row 0 has soft wrap at position 9 (last cell), row 1 continues
@@ -236,10 +237,10 @@ public class TerminalSelectionTests
 
         var text = sel.ExtractText(GetCell, 10);
         // Soft wrap → no newline between rows
-        Assert.Equal("This is a long line", text);
+        Assert.AreEqual("This is a long line", text);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtractText_Line_SelectsFullRows()
     {
         var rows = new[] { "AAA   ", "BBB   ", "CCC   " };
@@ -251,10 +252,10 @@ public class TerminalSelectionTests
         sel.MoveCursor(new BufferPosition(1, 0));
 
         var text = sel.ExtractText(GetCell, 6);
-        Assert.Equal("AAA" + Environment.NewLine + "BBB", text);
+        Assert.AreEqual("AAA" + Environment.NewLine + "BBB", text);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtractText_Block_SelectsRectangle()
     {
         var rows = new[] { "ABCDEF", "GHIJKL", "MNOPQR" };
@@ -266,18 +267,18 @@ public class TerminalSelectionTests
         sel.MoveCursor(new BufferPosition(2, 3));
 
         var text = sel.ExtractText(GetCell, 6);
-        Assert.Equal("BCD" + Environment.NewLine + "HIJ" + Environment.NewLine + "NOP", text);
+        Assert.AreEqual("BCD" + Environment.NewLine + "HIJ" + Environment.NewLine + "NOP", text);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtractText_WhenNotSelecting_ReturnsNull()
     {
         var sel = new TerminalSelection(new BufferPosition(0, 0));
         var text = sel.ExtractText((_, _) => MakeCell("A"), 10);
-        Assert.Null(text);
+        Assert.IsNull(text);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtractText_SkipsWidePaddingCells()
     {
         // Simulate a wide character: "W" at column 0, empty string at column 1 (padding)
@@ -298,6 +299,6 @@ public class TerminalSelectionTests
         sel.MoveCursor(new BufferPosition(0, 2));
 
         var text = sel.ExtractText(GetCell, 3);
-        Assert.Equal("Ｗx", text);
+        Assert.AreEqual("Ｗx", text);
     }
 }

--- a/tests/Hex1b.Tests/TerminalSvgRenderingTests.cs
+++ b/tests/Hex1b.Tests/TerminalSvgRenderingTests.cs
@@ -8,9 +8,10 @@ namespace Hex1b.Tests;
 /// Tests for SVG rendering of terminal snapshots and regions.
 /// SVG outputs are attached to test results for visual inspection.
 /// </summary>
+[TestClass]
 public class TerminalSvgRenderingTests
 {
-    [Fact]
+    [TestMethod]
     public async Task RenderFullSnapshot_ProducesSvg()
     {
         // Arrange
@@ -49,7 +50,7 @@ public class TerminalSvgRenderingTests
         var svg = snapshot.ToSvg();
 
         // Assert
-        Assert.NotEmpty(svg);
+        Assert.IsNotEmpty(svg);
         Assert.Contains("<svg", svg);
         Assert.Contains("</svg>", svg);
         Assert.Contains("<text", svg); // Should have text elements
@@ -59,7 +60,7 @@ public class TerminalSvgRenderingTests
         TestCaptureHelper.AttachSvg("full-snapshot.svg", svg);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RenderArbitraryRegion_ProducesSvg()
     {
         // Arrange
@@ -97,7 +98,7 @@ public class TerminalSvgRenderingTests
         var svg = region.ToSvg();
 
         // Assert
-        Assert.NotEmpty(svg);
+        Assert.IsNotEmpty(svg);
         Assert.Contains("<svg", svg);
         Assert.Contains("</svg>", svg);
         // The region should have text elements for the content
@@ -111,7 +112,7 @@ public class TerminalSvgRenderingTests
         TestCaptureHelper.AttachSvg("arbitrary-region-full.svg", fullSvg);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RenderButtonControl_ProducesSvg()
     {
         // Arrange
@@ -146,14 +147,14 @@ public class TerminalSvgRenderingTests
 
         // Find the button by searching for its text and extracting a region around it
         var buttonLocations = snapshot.FindText("Submit Form");
-        Assert.NotEmpty(buttonLocations);
+        Assert.IsNotEmpty(buttonLocations);
         var (line, column) = buttonLocations[0];
         // Button format is "[ Submit Form ]" so expand the region
         var buttonRegion = snapshot.GetRegion(new Rect(column - 2, line, 18, 1));
         var buttonSvg = buttonRegion.ToSvg();
 
         // Assert
-        Assert.NotEmpty(buttonSvg);
+        Assert.IsNotEmpty(buttonSvg);
         Assert.Contains("<svg", buttonSvg);
         Assert.Contains("</svg>", buttonSvg);
         Assert.Contains("<text", buttonSvg); // Should have text elements
@@ -163,7 +164,7 @@ public class TerminalSvgRenderingTests
         TestCaptureHelper.AttachSvg("button-control-full.svg", snapshot.ToSvg());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RenderWithCursor_ShowsCursorPosition()
     {
         // Arrange
@@ -193,14 +194,14 @@ public class TerminalSvgRenderingTests
         var svg = snapshot.ToSvg();
 
         // Assert - cursor should be rendered
-        Assert.NotEmpty(svg);
+        Assert.IsNotEmpty(svg);
         Assert.Contains("cursor", svg);
 
         // Attach SVG to test output
         TestCaptureHelper.AttachSvg("cursor-demo.svg", svg);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RenderWithCustomOptions_AppliesSettings()
     {
         // Arrange

--- a/tests/Hex1b.Tests/TerminalWidgetHandleTitleTests.cs
+++ b/tests/Hex1b.Tests/TerminalWidgetHandleTitleTests.cs
@@ -5,24 +5,25 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for OSC title sequences in TerminalWidgetHandle.
 /// </summary>
+[TestClass]
 public class TerminalWidgetHandleTitleTests
 {
     // Helper to create AppliedToken for OSC sequences (no cell impacts)
     private static AppliedToken OscApplied(string command, string payload = "")
         => AppliedToken.WithNoCellImpacts(new OscToken(command, "", payload), 0, 0, 0, 0);
 
-    [Fact]
+    [TestMethod]
     public async Task Osc0_SetsBothTitleAndIcon()
     {
         var handle = new TerminalWidgetHandle(80, 24);
         
         await handle.WriteOutputWithImpactsAsync([OscApplied("0", "Test Title")]);
         
-        Assert.Equal("Test Title", handle.WindowTitle);
-        Assert.Equal("Test Title", handle.IconName);
+        Assert.AreEqual("Test Title", handle.WindowTitle);
+        Assert.AreEqual("Test Title", handle.IconName);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Osc1_SetsIconOnly()
     {
         var handle = new TerminalWidgetHandle(80, 24);
@@ -33,11 +34,11 @@ public class TerminalWidgetHandleTitleTests
         // Then set icon only
         await handle.WriteOutputWithImpactsAsync([OscApplied("1", "Icon")]);
         
-        Assert.Equal("Initial", handle.WindowTitle); // Unchanged
-        Assert.Equal("Icon", handle.IconName);
+        Assert.AreEqual("Initial", handle.WindowTitle); // Unchanged
+        Assert.AreEqual("Icon", handle.IconName);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Osc2_SetsTitleOnly()
     {
         var handle = new TerminalWidgetHandle(80, 24);
@@ -48,11 +49,11 @@ public class TerminalWidgetHandleTitleTests
         // Then set title only
         await handle.WriteOutputWithImpactsAsync([OscApplied("2", "Title")]);
         
-        Assert.Equal("Title", handle.WindowTitle);
-        Assert.Equal("Initial", handle.IconName); // Unchanged
+        Assert.AreEqual("Title", handle.WindowTitle);
+        Assert.AreEqual("Initial", handle.IconName); // Unchanged
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Osc22_23_PushPop()
     {
         var handle = new TerminalWidgetHandle(80, 24);
@@ -66,15 +67,15 @@ public class TerminalWidgetHandleTitleTests
         // Change
         await handle.WriteOutputWithImpactsAsync([OscApplied("0", "Changed")]);
         
-        Assert.Equal("Changed", handle.WindowTitle);
+        Assert.AreEqual("Changed", handle.WindowTitle);
         
         // Pop
         await handle.WriteOutputWithImpactsAsync([OscApplied("23", "")]);
         
-        Assert.Equal("Original", handle.WindowTitle);
+        Assert.AreEqual("Original", handle.WindowTitle);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task WindowTitleChanged_EventFires()
     {
         var handle = new TerminalWidgetHandle(80, 24);
@@ -84,10 +85,10 @@ public class TerminalWidgetHandleTitleTests
         
         await handle.WriteOutputWithImpactsAsync([OscApplied("2", "Event Test")]);
         
-        Assert.Equal("Event Test", captured);
+        Assert.AreEqual("Event Test", captured);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task IconNameChanged_EventFires()
     {
         var handle = new TerminalWidgetHandle(80, 24);
@@ -97,10 +98,10 @@ public class TerminalWidgetHandleTitleTests
         
         await handle.WriteOutputWithImpactsAsync([OscApplied("1", "Icon Event")]);
         
-        Assert.Equal("Icon Event", captured);
+        Assert.AreEqual("Icon Event", captured);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task TitleChange_DoesNotFireWhenUnchanged()
     {
         var handle = new TerminalWidgetHandle(80, 24);
@@ -111,24 +112,24 @@ public class TerminalWidgetHandleTitleTests
         // Set first time
         await handle.WriteOutputWithImpactsAsync([OscApplied("2", "Same")]);
         
-        Assert.Equal(1, eventCount);
+        Assert.AreEqual(1, eventCount);
         
         // Set same again
         await handle.WriteOutputWithImpactsAsync([OscApplied("2", "Same")]);
         
-        Assert.Equal(1, eventCount); // Should not increment
+        Assert.AreEqual(1, eventCount); // Should not increment
     }
     
-    [Fact]
+    [TestMethod]
     public void InitialState_TitleAndIconAreEmpty()
     {
         var handle = new TerminalWidgetHandle(80, 24);
         
-        Assert.Equal("", handle.WindowTitle);
-        Assert.Equal("", handle.IconName);
+        Assert.AreEqual("", handle.WindowTitle);
+        Assert.AreEqual("", handle.IconName);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Osc22_WithPayload_PushesAndSets()
     {
         var handle = new TerminalWidgetHandle(80, 24);
@@ -139,15 +140,15 @@ public class TerminalWidgetHandleTitleTests
         // Push with new title
         await handle.WriteOutputWithImpactsAsync([OscApplied("22", "New Title")]);
         
-        Assert.Equal("New Title", handle.WindowTitle);
+        Assert.AreEqual("New Title", handle.WindowTitle);
         
         // Pop should restore
         await handle.WriteOutputWithImpactsAsync([OscApplied("23", "")]);
         
-        Assert.Equal("Original", handle.WindowTitle);
+        Assert.AreEqual("Original", handle.WindowTitle);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Osc23_EmptyStack_IsIgnored()
     {
         var handle = new TerminalWidgetHandle(80, 24);
@@ -159,6 +160,6 @@ public class TerminalWidgetHandleTitleTests
         await handle.WriteOutputWithImpactsAsync([OscApplied("23", "")]);
         
         // Should remain unchanged
-        Assert.Equal("Current", handle.WindowTitle);
+        Assert.AreEqual("Current", handle.WindowTitle);
     }
 }

--- a/tests/Hex1b.Tests/TerminalWidgetIntegrationTests.cs
+++ b/tests/Hex1b.Tests/TerminalWidgetIntegrationTests.cs
@@ -22,6 +22,7 @@ namespace Hex1b.Tests;
 /// - TerminalWidgetHandle: We inject cell impacts directly to simulate terminal output
 /// </para>
 /// </remarks>
+[TestClass]
 public class TerminalWidgetIntegrationTests
 {
     /// <summary>
@@ -200,7 +201,7 @@ public class TerminalWidgetIntegrationTests
         }
     }
     
-    [Fact]
+    [TestMethod]
     public async Task EmbeddedTerminal_InitialRender_ShowsBorder()
     {
         // Arrange
@@ -215,7 +216,7 @@ public class TerminalWidgetIntegrationTests
         Assert.Contains("Inner Terminal", screen);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task EmbeddedTerminal_InjectText_ShowsInWidget()
     {
         // Arrange
@@ -233,7 +234,7 @@ public class TerminalWidgetIntegrationTests
         Assert.Contains("Hello from inner terminal", screen);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task EmbeddedTerminal_ClearLine_ClearsContent()
     {
         // Arrange
@@ -253,7 +254,7 @@ public class TerminalWidgetIntegrationTests
         Assert.DoesNotContain("FIRST LINE", screen);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task EmbeddedTerminal_AnimationFrame_ClearsOldContent()
     {
         // Arrange
@@ -272,10 +273,10 @@ public class TerminalWidgetIntegrationTests
         // Assert - There should only be ONE train visible, not a ghost trail
         var screen = ctx.GetScreenText();
         var trainCount = CountOccurrences(screen, "[TRAIN]");
-        Assert.Equal(1, trainCount);
+        Assert.AreEqual(1, trainCount);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task EmbeddedTerminal_RapidOutput_FinalFrameRendered()
     {
         // Arrange
@@ -302,7 +303,7 @@ public class TerminalWidgetIntegrationTests
         Assert.DoesNotContain("Frame 1", screen);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task EmbeddedTerminal_ClearScreen_ClearsAllContent()
     {
         // Arrange
@@ -332,7 +333,7 @@ public class TerminalWidgetIntegrationTests
     /// Simulates the 'sl' steam locomotive animation pattern.
     /// The train should move across the screen without leaving ghost trails.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task EmbeddedTerminal_TrainAnimation_NoGhostTrails()
     {
         // Arrange
@@ -358,7 +359,7 @@ public class TerminalWidgetIntegrationTests
         // Assert - Should only see ONE train
         var screen = ctx.GetScreenText();
         var trainCount = CountOccurrences(screen, "<=====>");
-        Assert.Equal(1, trainCount);
+        Assert.AreEqual(1, trainCount);
     }
     
     private static int CountOccurrences(string text, string pattern)
@@ -376,7 +377,7 @@ public class TerminalWidgetIntegrationTests
     /// <summary>
     /// Tests that a focused TerminalNode captures all input including Ctrl+C.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void TerminalNode_WhenFocusedAndRunning_CapturesAllInput()
     {
         // Arrange
@@ -392,14 +393,14 @@ public class TerminalWidgetIntegrationTests
         node.IsFocused = true;
         
         // Handle is NotStarted by default, so should not capture
-        Assert.Equal(TerminalState.NotStarted, handle.State);
-        Assert.Null(focusRing.CapturedNode);
+        Assert.AreEqual(TerminalState.NotStarted, handle.State);
+        Assert.IsNull(focusRing.CapturedNode);
     }
     
     /// <summary>
     /// Tests that an unfocused TerminalNode does not capture input.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void TerminalNode_WhenNotFocused_DoesNotCaptureInput()
     {
         // Arrange
@@ -414,13 +415,13 @@ public class TerminalWidgetIntegrationTests
         node.IsFocused = false;
         
         // Act & Assert
-        Assert.Null(focusRing.CapturedNode);
+        Assert.IsNull(focusRing.CapturedNode);
     }
     
     /// <summary>
     /// Tests that a TerminalNode without a handle does not capture input.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void TerminalNode_WhenNoHandle_DoesNotCaptureInput()
     {
         // Arrange
@@ -433,13 +434,13 @@ public class TerminalWidgetIntegrationTests
         node.IsFocused = true;
         
         // Act & Assert
-        Assert.Null(focusRing.CapturedNode);
+        Assert.IsNull(focusRing.CapturedNode);
     }
     
     /// <summary>
     /// Tests that Ctrl+C is forwarded to the focused terminal instead of triggering the app's default exit.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task FocusedTerminal_CtrlC_ForwardedToTerminal()
     {
         // Arrange - Create a terminal handle and track if input was received
@@ -464,22 +465,22 @@ public class TerminalWidgetIntegrationTests
         node.IsFocused = true;
         
         // Verify the state was set and capture happened
-        Assert.Equal(TerminalState.Running, handle.State);
-        Assert.Same(node, focusRing.CapturedNode);
+        Assert.AreEqual(TerminalState.Running, handle.State);
+        Assert.AreSame(node, focusRing.CapturedNode);
         
         // Act - Simulate Ctrl+C key event
         var ctrlCEvent = new Hex1bKeyEvent(Hex1bKey.C, '\x03', Hex1bModifiers.Control);
         var result = node.HandleInput(ctrlCEvent);
         
         // Assert - The node should handle the input (forward it to the terminal)
-        Assert.Equal(InputResult.Handled, result);
+        Assert.AreEqual(InputResult.Handled, result);
     }
     
     /// <summary>
     /// Tests that the InputRouter correctly routes Ctrl+C to a captured node
     /// before checking bindings.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task InputRouter_FocusedTerminal_ReceivesInputBeforeBindings()
     {
         // Arrange
@@ -509,8 +510,8 @@ public class TerminalWidgetIntegrationTests
         terminalNode.Parent = rootNode;
         
         // Verify preconditions
-        Assert.Same(terminalNode, focusRing.CapturedNode);
-        Assert.True(terminalNode.IsFocused, "Terminal should be focused");
+        Assert.AreSame(terminalNode, focusRing.CapturedNode);
+        Assert.IsTrue(terminalNode.IsFocused, "Terminal should be focused");
         
         // Act - Route a Ctrl+C through the InputRouter
         var ctrlCEvent = new Hex1bKeyEvent(Hex1bKey.C, '\x03', Hex1bModifiers.Control);
@@ -524,7 +525,7 @@ public class TerminalWidgetIntegrationTests
             requestStop: null);
         
         // Assert
-        Assert.Equal(InputResult.Handled, result);
-        Assert.False(ctrlCTriggered, "Root's Ctrl+C binding should NOT have been triggered because TerminalNode captures all input");
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsFalse(ctrlCTriggered, "Root's Ctrl+C binding should NOT have been triggered because TerminalNode captures all input");
     }
 }

--- a/tests/Hex1b.Tests/TerminalWidgetSizeAlignmentTests.cs
+++ b/tests/Hex1b.Tests/TerminalWidgetSizeAlignmentTests.cs
@@ -11,6 +11,7 @@ namespace Hex1b.Tests;
 /// at the initial WithDimensions() size (e.g., 80x24) instead of the actual
 /// layout bounds (e.g., 120x40), causing rendering glitches for full-screen apps.
 /// </summary>
+[TestClass]
 public class TerminalWidgetSizeAlignmentTests
 {
     /// <summary>
@@ -18,7 +19,7 @@ public class TerminalWidgetSizeAlignmentTests
     /// all components should agree on dimensions. This test verifies the dimension
     /// chain: handle → terminal → workload (child process).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task AllComponents_ShouldAgreeOnDimensions_AfterStartupAndArrange()
     {
         // Simulate: terminal created at 80x24, widget laid out at 120x40
@@ -54,7 +55,7 @@ public class TerminalWidgetSizeAlignmentTests
         {
             await Task.Delay(10);
         }
-        Assert.Equal(TerminalState.Running, handle.State);
+        Assert.AreEqual(TerminalState.Running, handle.State);
 
         // Simulate what ArrangeCore does: resize the handle to layout bounds
         handle.Resize(LayoutWidth, LayoutHeight);
@@ -63,10 +64,10 @@ public class TerminalWidgetSizeAlignmentTests
         await Task.Delay(100);
 
         // Verify ALL components agree on the new dimensions
-        Assert.Equal(LayoutWidth, handle.Width);
-        Assert.Equal(LayoutHeight, handle.Height);
-        Assert.Equal(LayoutWidth, terminal.Width);
-        Assert.Equal(LayoutHeight, terminal.Height);
+        Assert.AreEqual(LayoutWidth, handle.Width);
+        Assert.AreEqual(LayoutHeight, handle.Height);
+        Assert.AreEqual(LayoutWidth, terminal.Width);
+        Assert.AreEqual(LayoutHeight, terminal.Height);
 
         // Clean up
         cts.Cancel();
@@ -80,7 +81,7 @@ public class TerminalWidgetSizeAlignmentTests
     /// This test creates a real PTY process to check if the workload's stored
     /// dimensions match after resize.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task WorkloadDimensions_ShouldMatchLayout_AfterResize()
     {
         const int InitialWidth = 80;
@@ -116,8 +117,8 @@ public class TerminalWidgetSizeAlignmentTests
         var workload = terminal.Workload;
         if (workload is Hex1bTerminalChildProcess childProcess)
         {
-            Assert.Equal(LayoutWidth, childProcess.Width);
-            Assert.Equal(LayoutHeight, childProcess.Height);
+            Assert.AreEqual(LayoutWidth, childProcess.Width);
+            Assert.AreEqual(LayoutHeight, childProcess.Height);
         }
 
         cts.Cancel();
@@ -130,7 +131,7 @@ public class TerminalWidgetSizeAlignmentTests
     /// propagates to the terminal and workload dimensions.
     /// This simulates the case where ArrangeCore runs first (race won by UI thread).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ResizeBeforeStart_ShouldPropagateToAllComponents()
     {
         const int InitialWidth = 80;
@@ -150,8 +151,8 @@ public class TerminalWidgetSizeAlignmentTests
         handle.Resize(LayoutWidth, LayoutHeight);
         
         // Verify terminal got the resize
-        Assert.Equal(LayoutWidth, terminal.Width);
-        Assert.Equal(LayoutHeight, terminal.Height);
+        Assert.AreEqual(LayoutWidth, terminal.Width);
+        Assert.AreEqual(LayoutHeight, terminal.Height);
         
         // Now start
         var runTask = Task.Run(async () =>
@@ -165,10 +166,10 @@ public class TerminalWidgetSizeAlignmentTests
             await Task.Delay(10);
 
         // Dimensions should still match after startup
-        Assert.Equal(LayoutWidth, handle.Width);
-        Assert.Equal(LayoutHeight, handle.Height);
-        Assert.Equal(LayoutWidth, terminal.Width);
-        Assert.Equal(LayoutHeight, terminal.Height);
+        Assert.AreEqual(LayoutWidth, handle.Width);
+        Assert.AreEqual(LayoutHeight, handle.Height);
+        Assert.AreEqual(LayoutWidth, terminal.Width);
+        Assert.AreEqual(LayoutHeight, terminal.Height);
 
         cts.Cancel();
         try { await runTask; } catch { }
@@ -180,7 +181,7 @@ public class TerminalWidgetSizeAlignmentTests
     /// Creates a TerminalNode, arranges it at different bounds than the handle's
     /// initial size, and verifies the handle gets resized.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void ArrangeCore_ResizesHandle_ToMatchLayoutBounds()
     {
         var handle = new TerminalWidgetHandle(80, 24);
@@ -197,15 +198,15 @@ public class TerminalWidgetSizeAlignmentTests
         // First arrange at 120x40 (simulates first layout pass)
         node.Arrange(new Rect(0, 0, 120, 40));
         
-        Assert.Equal(120, handle.Width);
-        Assert.Equal(40, handle.Height);
+        Assert.AreEqual(120, handle.Width);
+        Assert.AreEqual(40, handle.Height);
     }
     
     /// <summary>
     /// Tests that ArrangeCore resizes the handle even when terminal is NotStarted
     /// and a fallback child exists. This was previously broken (early return skipped resize).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void ArrangeCore_ResizesHandle_EvenWhenShowingFallback()
     {
         var handle = new TerminalWidgetHandle(80, 24);
@@ -223,8 +224,8 @@ public class TerminalWidgetSizeAlignmentTests
         node.Arrange(new Rect(0, 0, 120, 40));
         
         // Handle should be resized even though fallback is shown
-        Assert.Equal(120, handle.Width);
-        Assert.Equal(40, handle.Height);
+        Assert.AreEqual(120, handle.Width);
+        Assert.AreEqual(40, handle.Height);
     }
 
     /// <summary>
@@ -234,7 +235,7 @@ public class TerminalWidgetSizeAlignmentTests
     /// - Widget arranged at larger size
     /// - Verifies that after a brief settle, dimensions are consistent
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ScrollbackDemoPattern_DimensionsShouldConverge()
     {
         const int InitialWidth = 80;
@@ -270,10 +271,10 @@ public class TerminalWidgetSizeAlignmentTests
         await Task.Delay(200);
 
         // ALL dimensions should agree on the layout size
-        Assert.Equal(LayoutWidth, handle.Width);
-        Assert.Equal(LayoutHeight, handle.Height);
-        Assert.Equal(LayoutWidth, terminal.Width);
-        Assert.Equal(LayoutHeight, terminal.Height);
+        Assert.AreEqual(LayoutWidth, handle.Width);
+        Assert.AreEqual(LayoutHeight, handle.Height);
+        Assert.AreEqual(LayoutWidth, terminal.Width);
+        Assert.AreEqual(LayoutHeight, terminal.Height);
 
         cts.Cancel();
         await terminal.DisposeAsync();

--- a/tests/Hex1b.Tests/TestCaptureHelper.cs
+++ b/tests/Hex1b.Tests/TestCaptureHelper.cs
@@ -130,7 +130,7 @@ public static class TestCaptureHelper
 
     /// <summary>
     /// Attaches an SVG string to the test context as a proper test attachment.
-    /// In xUnit v3, attachments are recorded in test results XML/JSON.
+    /// MSTest stores attachments as test result files alongside the test run output.
     /// Also writes to disk for easy viewing.
     /// </summary>
     /// <param name="name">The filename for the SVG (should include .svg extension). Must be unique within a test.</param>
@@ -148,7 +148,7 @@ public static class TestCaptureHelper
     /// <param name="content">The file content.</param>
     public static void AttachFile(string name, string content)
     {
-        // Attach to xUnit test context - will throw if name is duplicate
+        // Attach to MSTest test context - will throw if name is duplicate
         { var __tmp = System.IO.Path.Combine(System.IO.Path.GetTempPath(), name); System.IO.File.WriteAllText(__tmp, content); TestContext.Current?.AddResultFile(__tmp); }
 
         // Build path: TestResults/{type}/{TestClass}_{TestName}_{attachment}

--- a/tests/Hex1b.Tests/TestCaptureHelper.cs
+++ b/tests/Hex1b.Tests/TestCaptureHelper.cs
@@ -149,15 +149,15 @@ public static class TestCaptureHelper
     public static void AttachFile(string name, string content)
     {
         // Attach to xUnit test context - will throw if name is duplicate
-        TestContext.Current.AddAttachment(name, content);
+        { var __tmp = System.IO.Path.Combine(System.IO.Path.GetTempPath(), name); System.IO.File.WriteAllText(__tmp, content); TestContext.Current?.AddResultFile(__tmp); }
 
         // Build path: TestResults/{type}/{TestClass}_{TestName}_{attachment}
         var testContext = TestContext.Current;
-        var testClass = testContext.Test?.TestCase?.TestClassName ?? "UnknownClass";
-        var testMethodName = testContext.Test?.TestCase?.TestMethod?.MethodName ?? "UnknownMethod";
+        var testClass = testContext.FullyQualifiedTestClassName ?? "UnknownClass";
+        var testMethodName = testContext.TestName ?? "UnknownMethod";
         
         // Get test display name which includes theory parameters
-        var testDisplayName = testContext.Test?.TestDisplayName ?? testMethodName;
+        var testDisplayName = testContext.TestName ?? testMethodName;
         
         // Extract just the method part with parameters if it's a theory
         var methodWithParams = testDisplayName;

--- a/tests/Hex1b.Tests/TestSvgHelper.cs
+++ b/tests/Hex1b.Tests/TestSvgHelper.cs
@@ -103,7 +103,7 @@ public static class TestSvgHelper
 
     /// <summary>
     /// Attaches an SVG string to the test context as a proper test attachment.
-    /// In xUnit v3, attachments are recorded in test results XML/JSON.
+    /// MSTest stores attachments as test result files alongside the test run output.
     /// Also writes to disk for easy viewing.
     /// </summary>
     /// <param name="name">The filename for the SVG (should include .svg extension). Must be unique within a test.</param>
@@ -121,7 +121,7 @@ public static class TestSvgHelper
     /// <param name="content">The file content.</param>
     public static void AttachFile(string name, string content)
     {
-        // Attach to xUnit test context - will throw if name is duplicate
+        // Attach to MSTest test context - will throw if name is duplicate
         { var __tmp = System.IO.Path.Combine(System.IO.Path.GetTempPath(), name); System.IO.File.WriteAllText(__tmp, content); TestContext.Current?.AddResultFile(__tmp); }
 
         // Build path: TestResults/{type}/{TestClass}_{TestName}_{attachment}

--- a/tests/Hex1b.Tests/TestSvgHelper.cs
+++ b/tests/Hex1b.Tests/TestSvgHelper.cs
@@ -122,15 +122,15 @@ public static class TestSvgHelper
     public static void AttachFile(string name, string content)
     {
         // Attach to xUnit test context - will throw if name is duplicate
-        TestContext.Current.AddAttachment(name, content);
+        { var __tmp = System.IO.Path.Combine(System.IO.Path.GetTempPath(), name); System.IO.File.WriteAllText(__tmp, content); TestContext.Current?.AddResultFile(__tmp); }
 
         // Build path: TestResults/{type}/{TestClass}_{TestName}_{attachment}
         var testContext = TestContext.Current;
-        var testClass = testContext.Test?.TestCase?.TestClassName ?? "UnknownClass";
-        var testMethodName = testContext.Test?.TestCase?.TestMethod?.MethodName ?? "UnknownMethod";
+        var testClass = testContext.FullyQualifiedTestClassName ?? "UnknownClass";
+        var testMethodName = testContext.TestName ?? "UnknownMethod";
         
         // Get test display name which includes theory parameters
-        var testDisplayName = testContext.Test?.TestDisplayName ?? testMethodName;
+        var testDisplayName = testContext.TestName ?? testMethodName;
         
         // Extract just the method part with parameters if it's a theory
         var methodWithParams = testDisplayName;

--- a/tests/Hex1b.Tests/TestWidgetTests.cs
+++ b/tests/Hex1b.Tests/TestWidgetTests.cs
@@ -4,13 +4,13 @@ using System.Threading;
 using System.Threading.Tasks;
 using Hex1b;
 using Hex1b.Widgets;
-using Xunit;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class TestWidgetTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Test_FluentCallbacks_WorkWithHex1bApp()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -65,9 +65,9 @@ public class TestWidgetTests
         // With render optimization:
         // - First cycle: new node → dirty → rendered
         // - Second cycle: same node reused → not dirty → NOT rendered (optimization skips clean nodes)
-        Assert.NotNull(initialNode);
-        Assert.Equal([1, 1], reconcileCounts); // Two cycles, each widget starts at count 1
-        Assert.Same(initialNode, lastExistingNode); // Second reconcile receives the node from first cycle
-        Assert.Equal([1], renderCounts); // With render optimization, clean nodes don't re-render
+        Assert.IsNotNull(initialNode);
+        TestSeq.AreEqual([1, 1], reconcileCounts); // Two cycles, each widget starts at count 1
+        Assert.AreSame(initialNode, lastExistingNode); // Second reconcile receives the node from first cycle
+        TestSeq.AreEqual([1], renderCounts); // With render optimization, clean nodes don't re-render
     }
 }

--- a/tests/Hex1b.Tests/TextBlockNodeTests.cs
+++ b/tests/Hex1b.Tests/TextBlockNodeTests.cs
@@ -7,57 +7,58 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for TextBlockNode rendering using Hex1bTerminal.
 /// </summary>
+[TestClass]
 public class TextBlockNodeTests
 {
     #region Measurement Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_ReturnsCorrectSize()
     {
         var node = new TextBlockNode { Text = "Hello World" };
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(11, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(11, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_EmptyText_ReturnsZeroWidth()
     {
         var node = new TextBlockNode { Text = "" };
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(0, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_RespectsMaxWidthConstraint()
     {
         var node = new TextBlockNode { Text = "This is a very long text that exceeds constraints" };
 
         var size = node.Measure(new Constraints(0, 10, 0, 5));
 
-        Assert.Equal(10, size.Width);
+        Assert.AreEqual(10, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_RespectsMinWidthConstraint()
     {
         var node = new TextBlockNode { Text = "Hi" };
 
         var size = node.Measure(new Constraints(10, 20, 0, 5));
 
-        Assert.Equal(10, size.Width);
+        Assert.AreEqual(10, size.Width);
     }
 
     #endregion
 
     #region Wrapping Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_WithWrap_CalculatesMultipleLines()
     {
         var node = new TextBlockNode 
@@ -70,11 +71,11 @@ public class TextBlockNodeTests
         var size = node.Measure(new Constraints(0, 10, 0, int.MaxValue));
 
         // "Hello" (5), "World from" (10), "Hex1b" (5) - needs multiple lines
-        Assert.True(size.Height > 1, $"Expected height > 1, got {size.Height}");
-        Assert.True(size.Width <= 10, $"Expected width <= 10, got {size.Width}");
+        Assert.IsTrue(size.Height > 1, $"Expected height > 1, got {size.Height}");
+        Assert.IsTrue(size.Width <= 10, $"Expected width <= 10, got {size.Width}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_WithWrap_SingleLineWhenFits()
     {
         var node = new TextBlockNode 
@@ -85,11 +86,11 @@ public class TextBlockNodeTests
 
         var size = node.Measure(new Constraints(0, 40, 0, int.MaxValue));
 
-        Assert.Equal(1, size.Height);
-        Assert.Equal(5, size.Width);
+        Assert.AreEqual(1, size.Height);
+        Assert.AreEqual(5, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_WithWrap_UnboundedWidth_SingleLine()
     {
         var node = new TextBlockNode 
@@ -100,11 +101,11 @@ public class TextBlockNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(1, size.Height);
-        Assert.Equal(45, size.Width);
+        Assert.AreEqual(1, size.Height);
+        Assert.AreEqual(45, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_WithWrap_PrefersWordBoundaries()
     {
         var node = new TextBlockNode
@@ -116,11 +117,11 @@ public class TextBlockNodeTests
         // Width 7 can't fit "Hello w" without splitting "world", so it should wrap at the space.
         var size = node.Measure(new Constraints(0, 7, 0, int.MaxValue));
 
-        Assert.Equal(2, size.Height);
-        Assert.True(size.Width <= 7, $"Expected width <= 7, got {size.Width}");
+        Assert.AreEqual(2, size.Height);
+        Assert.IsTrue(size.Width <= 7, $"Expected width <= 7, got {size.Width}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_WithEllipsis_RespectsMaxWidth()
     {
         var node = new TextBlockNode 
@@ -131,11 +132,11 @@ public class TextBlockNodeTests
 
         var size = node.Measure(new Constraints(0, 10, 0, 5));
 
-        Assert.Equal(10, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(10, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_WithOverflow_IgnoresConstraint()
     {
         var node = new TextBlockNode 
@@ -147,15 +148,15 @@ public class TextBlockNodeTests
         // Default behavior - width is clamped but not reduced naturally
         var size = node.Measure(new Constraints(0, 5, 0, 5));
 
-        Assert.Equal(5, size.Width);  // Clamped by Constrain()
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(5, size.Width);  // Clamped by Constrain()
+        Assert.AreEqual(1, size.Height);
     }
 
     #endregion
 
     #region Rendering Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WritesTextToTerminal()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -171,10 +172,10 @@ public class TextBlockNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal("Hello World", snapshot.GetLineTrimmed(0));
+        Assert.AreEqual("Hello World", snapshot.GetLineTrimmed(0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_EmptyText_WritesNothing()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -189,10 +190,10 @@ public class TextBlockNodeTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal("", terminal.CreateSnapshot().GetLineTrimmed(0));
+        Assert.AreEqual("", terminal.CreateSnapshot().GetLineTrimmed(0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_SpecialCharacters_RendersCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -208,10 +209,10 @@ public class TextBlockNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal("Hello → World ← Test", snapshot.GetLineTrimmed(0));
+        Assert.AreEqual("Hello → World ← Test", snapshot.GetLineTrimmed(0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_InNarrowTerminal_TextIsTruncatedByTerminalWidth()
     {
         // Terminal is only 10 chars wide - text will wrap/truncate at terminal boundary
@@ -229,12 +230,12 @@ public class TextBlockNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
         // The first line should contain the first 10 characters
-        Assert.Equal("This is a ", snapshot.GetLine(0));
+        Assert.AreEqual("This is a ", snapshot.GetLine(0));
         // The rest wraps to the next line (terminal behavior, not widget)
-        Assert.Equal("long text", snapshot.GetLineTrimmed(1));
+        Assert.AreEqual("long text", snapshot.GetLineTrimmed(1));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_AtSpecificPosition_WritesAtCursorPosition()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -253,10 +254,10 @@ public class TextBlockNodeTests
 
         // Check that text appears at the right position
         var line = snapshot.GetLine(3);
-        Assert.Equal("     Positioned", line.TrimEnd());
+        Assert.AreEqual("     Positioned", line.TrimEnd());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_VeryLongText_WrapsAtTerminalEdge()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -274,16 +275,16 @@ public class TextBlockNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
         // First 20 chars on line 0
-        Assert.Equal("ABCDEFGHIJKLMNOPQRST", snapshot.GetLine(0));
+        Assert.AreEqual("ABCDEFGHIJKLMNOPQRST", snapshot.GetLine(0));
         // Remaining chars on line 1
-        Assert.Equal("UVWXYZ", snapshot.GetLineTrimmed(1));
+        Assert.AreEqual("UVWXYZ", snapshot.GetLineTrimmed(1));
     }
 
     #endregion
 
     #region Clipping Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithLayoutProvider_ClipsToClipRect()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -312,10 +313,10 @@ public class TextBlockNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         // Text should be clipped to 10 characters
-        Assert.Equal("Hello Worl", snapshot.GetLineTrimmed(0));
+        Assert.AreEqual("Hello Worl", snapshot.GetLineTrimmed(0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithLayoutProvider_ClipsWhenStartingOutsideClipRect()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -344,10 +345,10 @@ public class TextBlockNodeTests
         
         // Only chars from index 5-14 should appear (FGHIJKLMNO), at positions 5-14
         var line = snapshot.GetLine(0);
-        Assert.Equal("     FGHIJKLMNO", line.Substring(0, 15));
+        Assert.AreEqual("     FGHIJKLMNO", line.Substring(0, 15));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithLayoutProviderOverflow_DoesNotClip()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -374,10 +375,10 @@ public class TextBlockNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         // Full text should appear (no clipping)
-        Assert.Equal("Hello World", snapshot.GetLineTrimmed(0));
+        Assert.AreEqual("Hello World", snapshot.GetLineTrimmed(0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithoutLayoutProvider_DoesNotClip()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -396,14 +397,14 @@ public class TextBlockNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         // Full text should appear
-        Assert.Equal("Hello World", snapshot.GetLineTrimmed(0));
+        Assert.AreEqual("Hello World", snapshot.GetLineTrimmed(0));
     }
 
     #endregion
 
     #region Layout Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_SetsBounds()
     {
         var node = new TextBlockNode { Text = "Test" };
@@ -411,36 +412,36 @@ public class TextBlockNodeTests
 
         node.Arrange(bounds);
 
-        Assert.Equal(bounds, node.Bounds);
+        Assert.AreEqual(bounds, node.Bounds);
     }
 
     #endregion
 
     #region Focus and Input Tests
 
-    [Fact]
+    [TestMethod]
     public async Task IsFocusable_ReturnsFalse()
     {
         var node = new TextBlockNode { Text = "Test" };
 
-        Assert.False(node.IsFocusable);
+        Assert.IsFalse(node.IsFocusable);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_AlwaysReturnsFalse()
     {
         var node = new TextBlockNode { Text = "Test" };
 
         var result = node.HandleInput(new Hex1bKeyEvent(Hex1bKey.A, 'a', Hex1bModifiers.None));
 
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
     }
 
     #endregion
 
     #region Integration Tests with Hex1bApp
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TextBlockWidget_RendersViaHex1bApp()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -461,10 +462,10 @@ public class TextBlockNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Integration Test"));
+        Assert.IsTrue(snapshot.ContainsText("Integration Test"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_MultipleTextBlocks_InVStack_RenderOnSeparateLines()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -495,25 +496,25 @@ public class TextBlockNodeTests
         await runTask;
 
         // Use the captured snapshot for assertions (app has exited, alternate screen restored)
-        Assert.True(snapshot.ContainsText("First Line"));
-        Assert.True(snapshot.ContainsText("Second Line"));
-        Assert.True(snapshot.ContainsText("Third Line"));
+        Assert.IsTrue(snapshot.ContainsText("First Line"));
+        Assert.IsTrue(snapshot.ContainsText("Second Line"));
+        Assert.IsTrue(snapshot.ContainsText("Third Line"));
 
         // Verify they appear at different positions
         var firstPositions = snapshot.FindText("First Line");
         var secondPositions = snapshot.FindText("Second Line");
         var thirdPositions = snapshot.FindText("Third Line");
 
-        Assert.Single(firstPositions);
-        Assert.Single(secondPositions);
-        Assert.Single(thirdPositions);
+        TestSeq.Single(firstPositions);
+        TestSeq.Single(secondPositions);
+        TestSeq.Single(thirdPositions);
 
         // Each should be on a different line
-        Assert.NotEqual(firstPositions[0].Line, secondPositions[0].Line);
-        Assert.NotEqual(secondPositions[0].Line, thirdPositions[0].Line);
+        Assert.AreNotEqual(firstPositions[0].Line, secondPositions[0].Line);
+        Assert.AreNotEqual(secondPositions[0].Line, thirdPositions[0].Line);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TextBlock_WithStateChange_UpdatesOnReRender()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -548,10 +549,10 @@ public class TextBlockNodeTests
         await runTask;
 
         // The button was clicked, counter was incremented. May be higher than 2 due to Ctrl+C triggering exit render.
-        Assert.True(counter >= 2, $"Expected counter >= 2 but was {counter}");
+        Assert.IsTrue(counter >= 2, $"Expected counter >= 2 but was {counter}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TextBlock_InNarrowTerminal_RendersCorrectly()
     {
         // Very narrow terminal - 15 chars wide
@@ -583,12 +584,12 @@ public class TextBlockNodeTests
 
         // Use captured snapshot for assertions
         // "Short" should fit on its line
-        Assert.True(snapshot.ContainsText("Short"));
+        Assert.IsTrue(snapshot.ContainsText("Short"));
         // Long text will wrap at terminal edge
-        Assert.True(snapshot.ContainsText("A longer text h"));
+        Assert.IsTrue(snapshot.ContainsText("A longer text h"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TextBlock_WithDynamicState_ShowsCurrentValue()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -616,10 +617,10 @@ public class TextBlockNodeTests
         await runTask;
 
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("Hello from State"));
+        Assert.IsTrue(snapshot.ContainsText("Hello from State"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TextBlock_EmptyString_DoesNotCrash()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -644,7 +645,7 @@ public class TextBlockNodeTests
         // Should complete without error (test passes if no exception thrown)
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TextBlock_UnicodeContent_RendersCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -669,8 +670,8 @@ public class TextBlockNodeTests
         await runTask;
 
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("日本語テスト"));
-        Assert.True(snapshot.ContainsText("🎉"));
+        Assert.IsTrue(snapshot.ContainsText("日本語テスト"));
+        Assert.IsTrue(snapshot.ContainsText("🎉"));
     }
 
     #endregion

--- a/tests/Hex1b.Tests/TextBoxHoistedStateRenderTests.cs
+++ b/tests/Hex1b.Tests/TextBoxHoistedStateRenderTests.cs
@@ -20,9 +20,10 @@ namespace Hex1b.Tests;
 /// input gesture (button click), and asserting the rendered surface
 /// reflects the new value.
 /// </summary>
+[TestClass]
 public class TextBoxHoistedStateRenderTests
 {
-    [Fact]
+    [TestMethod]
     public async Task HoistedState_TextMutatedFromButtonHandler_RendersOnScreen()
     {
         // ── ARRANGE ────────────────────────────────────────────────────
@@ -73,8 +74,7 @@ public class TextBoxHoistedStateRenderTests
 
         // ── ASSERT ─────────────────────────────────────────────────────
         // The new value rendered.
-        Assert.True(snapshot.ContainsText("BRAVO"),
-            "Hoisted state mutation from button handler should render on screen.");
+        Assert.IsTrue(snapshot.ContainsText("BRAVO"), "Hoisted state mutation from button handler should render on screen.");
 
         // And the old value did NOT linger. This is the stronger of the
         // two assertions: a render-skip bug would leave "alpha" on the
@@ -82,11 +82,10 @@ public class TextBoxHoistedStateRenderTests
         // TextBoxWidget's hoisted-state branch overwrites the buffer
         // wholesale, the only way "alpha" survives is if the cells were
         // never re-painted.
-        Assert.False(snapshot.ContainsText("alpha"),
-            "Stale text from before the mutation should have been overwritten.");
+        Assert.IsFalse(snapshot.ContainsText("alpha"), "Stale text from before the mutation should have been overwritten.");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HoistedState_RepeatedMutationsAllRender()
     {
         // The Version counter is monotonic. Multiple in-flight mutations
@@ -131,15 +130,13 @@ public class TextBoxHoistedStateRenderTests
 
         await runTask;
 
-        Assert.Equal(3, clickCount);
-        Assert.True(snapshot.ContainsText("step-3"));
-        Assert.False(snapshot.ContainsText("step-1"),
-            "Earlier values should have been overwritten on each render.");
-        Assert.False(snapshot.ContainsText("step-2"),
-            "Earlier values should have been overwritten on each render.");
+        Assert.AreEqual(3, clickCount);
+        Assert.IsTrue(snapshot.ContainsText("step-3"));
+        Assert.IsFalse(snapshot.ContainsText("step-1"), "Earlier values should have been overwritten on each render.");
+        Assert.IsFalse(snapshot.ContainsText("step-2"), "Earlier values should have been overwritten on each render.");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HoistedState_UserTypingStillWorksAfterParentMutation()
     {
         // Mixing the two paths (parent mutation + user keystroke) is the
@@ -187,7 +184,7 @@ public class TextBoxHoistedStateRenderTests
 
         await runTask;
 
-        Assert.Equal("/help me", state.Text);
-        Assert.True(snapshot.ContainsText("/help me"));
+        Assert.AreEqual("/help me", state.Text);
+        Assert.IsTrue(snapshot.ContainsText("/help me"));
     }
 }

--- a/tests/Hex1b.Tests/TextBoxNativeCursorRestoreTests.cs
+++ b/tests/Hex1b.Tests/TextBoxNativeCursorRestoreTests.cs
@@ -9,9 +9,10 @@ namespace Hex1b.Tests;
 /// still be restored to the TextBox even though the TextBox's own cursor coordinates
 /// did not change since the previous frame.
 /// </summary>
+[TestClass]
 public class TextBoxNativeCursorRestoreTests
 {
-    [Fact]
+    [TestMethod]
     public async Task FocusedTextBox_AfterSiblingRepaint_NativeCursorReturnsToTextBox()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -49,7 +50,7 @@ public class TextBoxNativeCursorRestoreTests
         // i.e. the second visible row), not on the activity row (row 0).
         // The exact column depends on the default theme's left bracket width but
         // the row should be 1.
-        Assert.Equal(1, snapshot1.CursorY);
+        Assert.AreEqual(1, snapshot1.CursorY);
 
         // Mutate the activity row (same width) and force a re-render.
         activity = "Loaded....";
@@ -69,7 +70,7 @@ public class TextBoxNativeCursorRestoreTests
         // RenderFrameWithSurface() rewrote cells on the activity row (row 0),
         // moving the hardware cursor there. Without the fix, snapshot2.CursorY
         // is 0 (the activity row); with the fix it's still 1 (the TextBox row).
-        Assert.Equal(snapshot1.CursorY, snapshot2.CursorY);
-        Assert.Equal(snapshot1.CursorX, snapshot2.CursorX);
+        Assert.AreEqual(snapshot1.CursorY, snapshot2.CursorY);
+        Assert.AreEqual(snapshot1.CursorX, snapshot2.CursorX);
     }
 }

--- a/tests/Hex1b.Tests/TextBoxNodeTests.cs
+++ b/tests/Hex1b.Tests/TextBoxNodeTests.cs
@@ -9,11 +9,12 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for TextBoxNode rendering and input handling.
 /// </summary>
+[TestClass]
 public class TextBoxNodeTests
 {
     #region Measurement Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_ReturnsCorrectSize()
     {
         var node = new TextBoxNode { Text = "hello" };
@@ -21,11 +22,11 @@ public class TextBoxNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // Bracketless inline render: "hello" = 5 chars
-        Assert.Equal(5, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(5, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_EmptyText_HasMinWidth()
     {
         var node = new TextBoxNode { Text = "" };
@@ -33,10 +34,10 @@ public class TextBoxNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // Empty text still measures 1 so the cursor cell is visible.
-        Assert.Equal(1, size.Width);
+        Assert.AreEqual(1, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_LongText_MeasuresFullWidth()
     {
         var node = new TextBoxNode { Text = "This is a very long text input" };
@@ -44,21 +45,21 @@ public class TextBoxNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // 30 chars
-        Assert.Equal(30, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(30, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_RespectsMaxWidthConstraint()
     {
         var node = new TextBoxNode { Text = "Long text here" };
 
         var size = node.Measure(new Constraints(0, 10, 0, 5));
 
-        Assert.Equal(10, size.Width);
+        Assert.AreEqual(10, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_WithEmoji_CalculatesDisplayWidth()
     {
         // "😀" is 2 cells wide
@@ -67,10 +68,10 @@ public class TextBoxNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // 2 display width for emoji
-        Assert.Equal(2, size.Width);
+        Assert.AreEqual(2, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_WithCJK_CalculatesDisplayWidth()
     {
         // "中文" is 4 cells wide (2 + 2)
@@ -79,10 +80,10 @@ public class TextBoxNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // 4 display width
-        Assert.Equal(4, size.Width);
+        Assert.AreEqual(4, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_MixedAsciiAndEmoji_CalculatesDisplayWidth()
     {
         // "Hi😀" = 2 + 2 = 4 cells
@@ -90,10 +91,10 @@ public class TextBoxNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(4, size.Width);
+        Assert.AreEqual(4, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_FamilyEmoji_TreatedAsTwoColumns()
     {
         // "👨‍👩‍👧" is a ZWJ sequence but displays as one emoji (2 cells)
@@ -101,14 +102,14 @@ public class TextBoxNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(2, size.Width);
+        Assert.AreEqual(2, size.Width);
     }
 
     #endregion
 
     #region Rendering Tests - Unfocused State
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Unfocused_ShowsBrackets()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -134,7 +135,7 @@ public class TextBoxNodeTests
         Assert.DoesNotContain("[test]", snapshot.GetLineTrimmed(0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Unfocused_EmptyText_ShowsEmptyBrackets()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -160,7 +161,7 @@ public class TextBoxNodeTests
         Assert.DoesNotContain("]", snapshot.GetLineTrimmed(0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Unfocused_LongText_RendersCompletely()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -188,7 +189,7 @@ public class TextBoxNodeTests
 
     #region Rendering Tests - Focused State with Cursor
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Focused_ShowsCursor()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -217,10 +218,10 @@ public class TextBoxNodeTests
         Assert.Contains("b", snapshot.GetLineTrimmed(0));
         Assert.Contains("c", snapshot.GetLineTrimmed(0));
         // ScreenCursorX should be set to the display width of text before cursor (1 char + bracket)
-        Assert.True(node.ScreenCursorX >= 0, "ScreenCursorX should be set for line caret");
+        Assert.IsTrue(node.ScreenCursorX >= 0, "ScreenCursorX should be set for line caret");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Focused_CursorAtStart_HighlightsFirstChar()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -245,10 +246,10 @@ public class TextBoxNodeTests
         
         // Line caret: text renders normally, native cursor is at position 0
         Assert.Contains("hello", snapshot.GetLineTrimmed(0));
-        Assert.True(node.ScreenCursorX >= 0, "ScreenCursorX should be set for line caret");
+        Assert.IsTrue(node.ScreenCursorX >= 0, "ScreenCursorX should be set for line caret");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Focused_CursorAtEnd_ShowsCursorSpace()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -272,10 +273,10 @@ public class TextBoxNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         // Line caret: native cursor should be positioned after "test"
-        Assert.True(node.ScreenCursorX >= 0, "ScreenCursorX should be set for line caret at end");
+        Assert.IsTrue(node.ScreenCursorX >= 0, "ScreenCursorX should be set for line caret at end");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Focused_EmptyText_ShowsCursorSpace()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -301,14 +302,14 @@ public class TextBoxNodeTests
 
         Assert.DoesNotContain("[", snapshot.GetLineTrimmed(0));
         Assert.DoesNotContain("]", snapshot.GetLineTrimmed(0));
-        Assert.True(node.ScreenCursorX >= 0, "ScreenCursorX should be set for line caret in empty text box");
+        Assert.IsTrue(node.ScreenCursorX >= 0, "ScreenCursorX should be set for line caret in empty text box");
     }
 
     #endregion
 
     #region Rendering Tests - Selection
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithSelection_HighlightsSelectedText()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -330,13 +331,13 @@ public class TextBoxNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
         // Should have ANSI codes for selection highlighting
-        Assert.True(snapshot.HasForegroundColor() || snapshot.HasBackgroundColor() || snapshot.HasAttribute(CellAttributes.Reverse));
+        Assert.IsTrue(snapshot.HasForegroundColor() || snapshot.HasBackgroundColor() || snapshot.HasAttribute(CellAttributes.Reverse));
         // The text should still be present
         Assert.Contains("hello", snapshot.GetLineTrimmed(0));
         Assert.Contains("world", snapshot.GetLineTrimmed(0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithSelection_InMiddle_HighlightsCorrectPortion()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -359,14 +360,14 @@ public class TextBoxNodeTests
         // Should contain the full text
         Assert.Contains("abcdefgh", snapshot.GetLineTrimmed(0));
         // Should have selection ANSI codes
-        Assert.True(snapshot.HasForegroundColor() || snapshot.HasBackgroundColor() || snapshot.HasAttribute(CellAttributes.Reverse));
+        Assert.IsTrue(snapshot.HasForegroundColor() || snapshot.HasBackgroundColor() || snapshot.HasAttribute(CellAttributes.Reverse));
     }
 
     #endregion
 
     #region Input Handling Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_WhenFocused_UpdatesState()
     {
         var node = new TextBoxNode { Text = "hello", IsFocused = true };
@@ -374,22 +375,22 @@ public class TextBoxNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.X, 'X', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal("helloX", node.Text);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual("helloX", node.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_WhenNotFocused_DoesNotHandle()
     {
         var node = new TextBoxNode { Text = "hello", IsFocused = false };
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.X, 'X', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.NotHandled, result);
-        Assert.Equal("hello", node.Text);
+        Assert.AreEqual(InputResult.NotHandled, result);
+        Assert.AreEqual("hello", node.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Backspace_DeletesCharacter()
     {
         var node = new TextBoxNode { Text = "hello", IsFocused = true };
@@ -397,11 +398,11 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Backspace, '\b', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("hell", node.Text);
-        Assert.Equal(4, node.State.CursorPosition);
+        Assert.AreEqual("hell", node.Text);
+        Assert.AreEqual(4, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Delete_DeletesCharacterAhead()
     {
         var node = new TextBoxNode { Text = "hello", IsFocused = true };
@@ -409,11 +410,11 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Delete, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("ello", node.Text);
-        Assert.Equal(0, node.State.CursorPosition);
+        Assert.AreEqual("ello", node.Text);
+        Assert.AreEqual(0, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_LeftArrow_MovesCursorLeft()
     {
         var node = new TextBoxNode { Text = "hello", IsFocused = true };
@@ -421,10 +422,10 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(2, node.State.CursorPosition);
+        Assert.AreEqual(2, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_RightArrow_MovesCursorRight()
     {
         var node = new TextBoxNode { Text = "hello", IsFocused = true };
@@ -432,10 +433,10 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(4, node.State.CursorPosition);
+        Assert.AreEqual(4, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Home_MovesCursorToStart()
     {
         var node = new TextBoxNode { Text = "hello", IsFocused = true };
@@ -443,10 +444,10 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Home, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(0, node.State.CursorPosition);
+        Assert.AreEqual(0, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_End_MovesCursorToEnd()
     {
         var node = new TextBoxNode { Text = "hello", IsFocused = true };
@@ -454,10 +455,10 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.End, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(5, node.State.CursorPosition);
+        Assert.AreEqual(5, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_CtrlLeftArrow_MovesToPreviousWord()
     {
         var node = new TextBoxNode { Text = "hello world", IsFocused = true };
@@ -465,10 +466,10 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.Control), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(6, node.State.CursorPosition); // Start of "world"
+        Assert.AreEqual(6, node.State.CursorPosition); // Start of "world"
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_CtrlRightArrow_MovesToNextWord()
     {
         var node = new TextBoxNode { Text = "hello world", IsFocused = true };
@@ -476,10 +477,10 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.Control), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(6, node.State.CursorPosition); // Start of "world"
+        Assert.AreEqual(6, node.State.CursorPosition); // Start of "world"
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_CtrlLeftArrow_AtStart_StaysAtStart()
     {
         var node = new TextBoxNode { Text = "hello world", IsFocused = true };
@@ -487,10 +488,10 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.Control), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(0, node.State.CursorPosition);
+        Assert.AreEqual(0, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_CtrlRightArrow_AtEnd_StaysAtEnd()
     {
         var node = new TextBoxNode { Text = "hello world", IsFocused = true };
@@ -498,10 +499,10 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.Control), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(11, node.State.CursorPosition);
+        Assert.AreEqual(11, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_CtrlLeftArrow_ClearsSelectionFirst()
     {
         var node = new TextBoxNode { Text = "hello world", IsFocused = true };
@@ -510,11 +511,11 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.Control), null, null, TestContext.Current.CancellationToken);
 
-        Assert.False(node.State.HasSelection);
-        Assert.Equal(0, node.State.CursorPosition); // Moved to start of "hello" (from selection start)
+        Assert.IsFalse(node.State.HasSelection);
+        Assert.AreEqual(0, node.State.CursorPosition); // Moved to start of "hello" (from selection start)
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_CtrlShiftLeftArrow_SelectsToPreviousWord()
     {
         var node = new TextBoxNode { Text = "hello world", IsFocused = true };
@@ -522,12 +523,12 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.Control | Hex1bModifiers.Shift), null, null, TestContext.Current.CancellationToken);
 
-        Assert.True(node.State.HasSelection);
-        Assert.Equal(11, node.State.SelectionAnchor);
-        Assert.Equal(6, node.State.CursorPosition); // Start of "world"
+        Assert.IsTrue(node.State.HasSelection);
+        Assert.AreEqual(11, node.State.SelectionAnchor);
+        Assert.AreEqual(6, node.State.CursorPosition); // Start of "world"
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_CtrlShiftRightArrow_SelectsToNextWord()
     {
         var node = new TextBoxNode { Text = "hello world", IsFocused = true };
@@ -535,12 +536,12 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.Control | Hex1bModifiers.Shift), null, null, TestContext.Current.CancellationToken);
 
-        Assert.True(node.State.HasSelection);
-        Assert.Equal(0, node.State.SelectionAnchor);
-        Assert.Equal(6, node.State.CursorPosition); // Start of "world"
+        Assert.IsTrue(node.State.HasSelection);
+        Assert.AreEqual(0, node.State.SelectionAnchor);
+        Assert.AreEqual(6, node.State.CursorPosition); // Start of "world"
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_CtrlShiftLeftArrow_ExtendsExistingSelection()
     {
         var node = new TextBoxNode { Text = "hello world", IsFocused = true };
@@ -550,12 +551,12 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.Control | Hex1bModifiers.Shift), null, null, TestContext.Current.CancellationToken);
 
-        Assert.True(node.State.HasSelection);
-        Assert.Equal(11, node.State.SelectionAnchor); // anchor unchanged
-        Assert.Equal(6, node.State.CursorPosition);   // jumped to previous word boundary
+        Assert.IsTrue(node.State.HasSelection);
+        Assert.AreEqual(11, node.State.SelectionAnchor); // anchor unchanged
+        Assert.AreEqual(6, node.State.CursorPosition);   // jumped to previous word boundary
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_CtrlShiftLeftArrow_AtStart_StaysAtStart()
     {
         var node = new TextBoxNode { Text = "hello world", IsFocused = true };
@@ -563,12 +564,12 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.Control | Hex1bModifiers.Shift), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(0, node.State.CursorPosition);
+        Assert.AreEqual(0, node.State.CursorPosition);
         // Anchor was set on entry (at position 0); selection range is empty.
-        Assert.False(node.State.HasSelection);
+        Assert.IsFalse(node.State.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_CtrlShiftRightArrow_AtEnd_StaysAtEnd()
     {
         var node = new TextBoxNode { Text = "hello world", IsFocused = true };
@@ -576,11 +577,11 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.Control | Hex1bModifiers.Shift), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(11, node.State.CursorPosition);
-        Assert.False(node.State.HasSelection);
+        Assert.AreEqual(11, node.State.CursorPosition);
+        Assert.IsFalse(node.State.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void ConfigureDefaultBindings_RegistersSelectWordActions()
     {
         // The rebinding contract requires that SelectWordLeft/SelectWordRight
@@ -590,11 +591,11 @@ public class TextBoxNodeTests
         var bindings = new InputBindingsBuilder();
         node.ConfigureDefaultBindings(bindings);
 
-        Assert.NotEmpty(bindings.GetBindings(TextBoxWidget.SelectWordLeft));
-        Assert.NotEmpty(bindings.GetBindings(TextBoxWidget.SelectWordRight));
+        Assert.IsNotEmpty(bindings.GetBindings(TextBoxWidget.SelectWordLeft));
+        Assert.IsNotEmpty(bindings.GetBindings(TextBoxWidget.SelectWordRight));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_CtrlBackspace_DeletesPreviousWord()
     {
         var node = new TextBoxNode { Text = "hello world", IsFocused = true };
@@ -602,11 +603,11 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Backspace, '\0', Hex1bModifiers.Control), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("hello ", node.Text);
-        Assert.Equal(6, node.State.CursorPosition);
+        Assert.AreEqual("hello ", node.Text);
+        Assert.AreEqual(6, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_CtrlDelete_DeletesNextWord()
     {
         var node = new TextBoxNode { Text = "hello world", IsFocused = true };
@@ -614,11 +615,11 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Delete, '\0', Hex1bModifiers.Control), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("world", node.Text);
-        Assert.Equal(0, node.State.CursorPosition);
+        Assert.AreEqual("world", node.Text);
+        Assert.AreEqual(0, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_CtrlBackspace_AtStart_DoesNothing()
     {
         var node = new TextBoxNode { Text = "hello", IsFocused = true };
@@ -626,11 +627,11 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Backspace, '\0', Hex1bModifiers.Control), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("hello", node.Text);
-        Assert.Equal(0, node.State.CursorPosition);
+        Assert.AreEqual("hello", node.Text);
+        Assert.AreEqual(0, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_CtrlDelete_AtEnd_DoesNothing()
     {
         var node = new TextBoxNode { Text = "hello", IsFocused = true };
@@ -638,11 +639,11 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Delete, '\0', Hex1bModifiers.Control), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("hello", node.Text);
-        Assert.Equal(5, node.State.CursorPosition);
+        Assert.AreEqual("hello", node.Text);
+        Assert.AreEqual(5, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_CtrlBackspace_WithSelection_DeletesSelection()
     {
         var node = new TextBoxNode { Text = "hello world", IsFocused = true };
@@ -651,11 +652,11 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Backspace, '\0', Hex1bModifiers.Control), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("hello ", node.Text);
-        Assert.False(node.State.HasSelection);
+        Assert.AreEqual("hello ", node.Text);
+        Assert.IsFalse(node.State.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_ShiftLeftArrow_CreatesSelection()
     {
         var node = new TextBoxNode { Text = "hello", IsFocused = true };
@@ -663,12 +664,12 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.Shift), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(2, node.State.CursorPosition);
-        Assert.True(node.State.HasSelection);
-        Assert.Equal(3, node.State.SelectionAnchor);
+        Assert.AreEqual(2, node.State.CursorPosition);
+        Assert.IsTrue(node.State.HasSelection);
+        Assert.AreEqual(3, node.State.SelectionAnchor);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_CtrlA_SelectsAll()
     {
         var node = new TextBoxNode { Text = "hello", IsFocused = true };
@@ -676,28 +677,28 @@ public class TextBoxNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.A, 'a', Hex1bModifiers.Control), null, null, TestContext.Current.CancellationToken);
 
-        Assert.True(node.State.HasSelection);
-        Assert.Equal(0, node.State.SelectionAnchor);
-        Assert.Equal(5, node.State.CursorPosition);
+        Assert.IsTrue(node.State.HasSelection);
+        Assert.AreEqual(0, node.State.SelectionAnchor);
+        Assert.AreEqual(5, node.State.CursorPosition);
     }
 
     #endregion
 
     #region Focus Tests
 
-    [Fact]
+    [TestMethod]
     public async Task IsFocusable_ReturnsTrue()
     {
         var node = new TextBoxNode();
 
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
 
     #endregion
 
     #region Mouse Click Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleMouseClick_PositionsCursorAtClickLocation()
     {
         var node = new TextBoxNode { Text = "hello" };
@@ -709,11 +710,11 @@ public class TextBoxNodeTests
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 3, 0, Hex1bModifiers.None, ClickCount: 1);
         var result = node.HandleMouseClick(3, 0, mouseEvent);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(3, node.State.CursorPosition);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(3, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleMouseClick_AtStart_PositionsCursorAtZero()
     {
         var node = new TextBoxNode { Text = "hello" };
@@ -724,11 +725,11 @@ public class TextBoxNodeTests
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 0, 0, Hex1bModifiers.None, ClickCount: 1);
         var result = node.HandleMouseClick(0, 0, mouseEvent);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(0, node.State.CursorPosition);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(0, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleMouseClick_AtEnd_PositionsCursorAtEnd()
     {
         var node = new TextBoxNode { Text = "hello" };
@@ -739,11 +740,11 @@ public class TextBoxNodeTests
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 6, 0, Hex1bModifiers.None, ClickCount: 1);
         var result = node.HandleMouseClick(6, 0, mouseEvent);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(5, node.State.CursorPosition);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(5, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleMouseClick_OnBracket_PositionsCursorAtStart()
     {
         // Brackets are gone — this test now just confirms clicking at column 0
@@ -755,11 +756,11 @@ public class TextBoxNodeTests
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 0, 0, Hex1bModifiers.None, ClickCount: 1);
         var result = node.HandleMouseClick(0, 0, mouseEvent);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(0, node.State.CursorPosition);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(0, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleMouseClick_ClearsSelection()
     {
         var node = new TextBoxNode { Text = "hello" };
@@ -767,16 +768,16 @@ public class TextBoxNodeTests
         node.IsFocused = true;
         node.Arrange(new Rect(0, 0, 10, 1));
 
-        Assert.True(node.State.HasSelection);
+        Assert.IsTrue(node.State.HasSelection);
 
         // Click anywhere - should clear selection
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 3, 0, Hex1bModifiers.None, ClickCount: 1);
         node.HandleMouseClick(3, 0, mouseEvent);
 
-        Assert.False(node.State.HasSelection);
+        Assert.IsFalse(node.State.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleMouseClick_DoubleClick_NotHandledByHandleMouseClick()
     {
         var node = new TextBoxNode { Text = "hello" };
@@ -787,10 +788,10 @@ public class TextBoxNodeTests
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 3, 0, Hex1bModifiers.None, ClickCount: 2);
         var result = node.HandleMouseClick(3, 0, mouseEvent);
 
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleMouseClick_RightClick_NotHandled()
     {
         var node = new TextBoxNode { Text = "hello" };
@@ -801,10 +802,10 @@ public class TextBoxNodeTests
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Right, MouseAction.Down, 3, 0, Hex1bModifiers.None, ClickCount: 1);
         var result = node.HandleMouseClick(3, 0, mouseEvent);
 
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleMouseClick_WithEmoji_PositionsCorrectly()
     {
         // "😀ab" - emoji is 2 cells wide
@@ -818,11 +819,11 @@ public class TextBoxNodeTests
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 3, 0, Hex1bModifiers.None, ClickCount: 1);
         var result = node.HandleMouseClick(3, 0, mouseEvent);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(3, node.State.CursorPosition);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(3, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleMouseClick_OnWideChar_PositionsBasedOnMidpoint()
     {
         // Click on first half of emoji should position before it
@@ -833,19 +834,19 @@ public class TextBoxNodeTests
         // Click at localX=0 (first half of emoji)
         var mouseEvent1 = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 0, 0, Hex1bModifiers.None, ClickCount: 1);
         node.HandleMouseClick(0, 0, mouseEvent1);
-        Assert.Equal(0, node.State.CursorPosition); // Before emoji
+        Assert.AreEqual(0, node.State.CursorPosition); // Before emoji
 
         // Click at localX=1 (second half of emoji) — past the midpoint
         var mouseEvent2 = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 1, 0, Hex1bModifiers.None, ClickCount: 1);
         node.HandleMouseClick(1, 0, mouseEvent2);
-        Assert.Equal(2, node.State.CursorPosition); // After emoji (emoji is 2 chars in string)
+        Assert.AreEqual(2, node.State.CursorPosition); // After emoji (emoji is 2 chars in string)
     }
 
     #endregion
 
     #region Layout Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_SetsBounds()
     {
         var node = new TextBoxNode { Text = "test" };
@@ -853,14 +854,14 @@ public class TextBoxNodeTests
 
         node.Arrange(bounds);
 
-        Assert.Equal(bounds, node.Bounds);
+        Assert.AreEqual(bounds, node.Bounds);
     }
 
     #endregion
 
     #region Integration Tests with Hex1bApp
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TextBox_RendersViaHex1bApp()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -890,10 +891,10 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Initial Text"));
+        Assert.IsTrue(snapshot.ContainsText("Initial Text"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TextBox_ReceivesInput()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -921,10 +922,10 @@ public class TextBoxNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("Hello", capturedText);
+        Assert.AreEqual("Hello", capturedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TextBox_InNarrowTerminal_StillWorks()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -953,10 +954,10 @@ public class TextBoxNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("ShortX", capturedText);
+        Assert.AreEqual("ShortX", capturedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TextBox_TabBetweenMultiple()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -989,11 +990,11 @@ public class TextBoxNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("AB", text1);
-        Assert.Equal("XY", text2);
+        Assert.AreEqual("AB", text1);
+        Assert.AreEqual("XY", text2);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TextBox_BackspaceWorks()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1023,10 +1024,10 @@ public class TextBoxNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("te", text);
+        Assert.AreEqual("te", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TextBox_CursorNavigationWorks()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1057,10 +1058,10 @@ public class TextBoxNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("aXbc", text);
+        Assert.AreEqual("aXbc", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TextBox_SpecialCharactersWork()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1088,10 +1089,10 @@ public class TextBoxNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("@!#", text);
+        Assert.AreEqual("@!#", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TextBox_LongTextInNarrowTerminal_ScrollsToShowCursor()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1125,14 +1126,14 @@ public class TextBoxNodeTests
         await runTask;
 
         // With viewport scrolling, the end of the text is visible with cursor
-        Assert.True(snapshot.ContainsText("extHere"));
+        Assert.IsTrue(snapshot.ContainsText("extHere"));
     }
 
     #endregion
 
     #region Uncontrolled Mode Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TextBox_UncontrolledMode_PreservesStateAcrossRerenders()
     {
         // Regression test: TextBox with no state argument should preserve typed content
@@ -1168,10 +1169,10 @@ public class TextBoxNodeTests
         await runTask;
 
         // The typed text should be visible in the terminal output
-        Assert.True(snapshot.ContainsText("Hello"));
+        Assert.IsTrue(snapshot.ContainsText("Hello"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TextBox_UncontrolledMode_MultipleTextBoxes_IndependentState()
     {
         // Each uncontrolled TextBox should have its own independent state
@@ -1209,11 +1210,11 @@ public class TextBoxNodeTests
         await runTask;
 
         // Both texts should be visible
-        Assert.True(snapshot.ContainsText("AA"));
-        Assert.True(snapshot.ContainsText("BB"));
+        Assert.IsTrue(snapshot.ContainsText("AA"));
+        Assert.IsTrue(snapshot.ContainsText("BB"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_TextBox_ControlledMode_StillWorks()
     {
         // Controlled mode with onTextChanged callback
@@ -1244,14 +1245,14 @@ public class TextBoxNodeTests
         await runTask;
 
         // The external state should be updated
-        Assert.Equal("InitialX", text);
+        Assert.AreEqual("InitialX", text);
     }
 
     #endregion
 
     #region Run-First Pattern Integration Tests
 
-    [Fact]
+    [TestMethod]
     public async Task RunFirst_Button_RendersAndExits()
     {
         // Test with Button (also focusable) to isolate the issue
@@ -1280,10 +1281,10 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Click Me"));
+        Assert.IsTrue(snapshot.ContainsText("Click Me"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RunFirst_TextBox_RendersWithoutInput()
     {
         // Simplest case: TextBox renders, no input, just Ctrl+C to exit
@@ -1314,10 +1315,10 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Initial"));
+        Assert.IsTrue(snapshot.ContainsText("Initial"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RunFirst_TextBox_SingleCharacterInput()
     {
         // One character typed into TextBox
@@ -1344,10 +1345,10 @@ public class TextBoxNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("a", capturedText);
+        Assert.AreEqual("a", capturedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RunFirst_TextBox_TypeMultipleChars()
     {
         // Type multiple chars using Type() method
@@ -1374,10 +1375,10 @@ public class TextBoxNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("Hello", capturedText);
+        Assert.AreEqual("Hello", capturedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RunFirst_ButtonThenTextBox_TabToTextBox()
     {
         // Button has initial focus, then Tab to TextBox
@@ -1409,10 +1410,10 @@ public class TextBoxNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("x", capturedText);
+        Assert.AreEqual("x", capturedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RunFirst_TwoButtons_TabBetweenThem()
     {
         // Two buttons, Tab between them, no TextBox involved
@@ -1443,11 +1444,11 @@ public class TextBoxNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.False(button1Clicked);
-        Assert.True(button2Clicked);
+        Assert.IsFalse(button1Clicked);
+        Assert.IsTrue(button2Clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RunFirst_ButtonThenTextBox_JustTabThenExit()
     {
         // Button first, Tab to TextBox, but don't type - just exit
@@ -1479,10 +1480,10 @@ public class TextBoxNodeTests
         await runTask;
 
         // Use captured snapshot
-        Assert.True(snapshot.ContainsText("pre-filled"));
+        Assert.IsTrue(snapshot.ContainsText("pre-filled"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RunFirst_TextBoxInVStack_NoFocusChange()
     {
         // TextBox in VStack, has initial focus, just exit without any interaction
@@ -1514,10 +1515,10 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("test-value"));
+        Assert.IsTrue(snapshot.ContainsText("test-value"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RunFirst_ButtonInVStack_Works()
     {
         // Button in VStack, has initial focus
@@ -1548,10 +1549,10 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Click Me"));
+        Assert.IsTrue(snapshot.ContainsText("Click Me"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RunFirst_TextBoxInVStack_RendersAndExits()
     {
         // TextBox in VStack, verify it renders and Ctrl+C exits properly
@@ -1582,14 +1583,14 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("test"));
+        Assert.IsTrue(snapshot.ContainsText("test"));
     }
 
     #endregion
 
     #region Viewport Scrolling Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Viewport_CursorAtEnd_ShowsTailOfText()
     {
         // Terminal width 15 → bracket viewport = 13 chars
@@ -1618,10 +1619,10 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("ijklmnopqrst"));
+        Assert.IsTrue(snapshot.ContainsText("ijklmnopqrst"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Viewport_HomeKey_ScrollsToStart()
     {
         // Type long text, then press Home — should scroll to show start
@@ -1650,10 +1651,10 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("abcdefghijklmno"));
+        Assert.IsTrue(snapshot.ContainsText("abcdefghijklmno"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Viewport_ShortText_NoScrolling()
     {
         // Text fits in viewport — no scrolling needed
@@ -1679,10 +1680,10 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("hello"));
+        Assert.IsTrue(snapshot.ContainsText("hello"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Viewport_TypePastEnd_ScrollsRight()
     {
         // Start with empty textbox in narrow terminal, type characters past the viewport width
@@ -1711,360 +1712,360 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("ijkl"));
+        Assert.IsTrue(snapshot.ContainsText("ijkl"));
     }
 
     #endregion
 
     #region Multiline State Tests
 
-    [Fact]
+    [TestMethod]
     public async Task State_GetLineCount_SingleLine()
     {
         var state = new TextBoxState { Text = "hello world" };
-        Assert.Equal(1, state.GetLineCount());
+        Assert.AreEqual(1, state.GetLineCount());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_GetLineCount_MultipleLines()
     {
         var state = new TextBoxState { Text = "line1\nline2\nline3" };
-        Assert.Equal(3, state.GetLineCount());
+        Assert.AreEqual(3, state.GetLineCount());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_GetLineCount_EmptyString()
     {
         var state = new TextBoxState { Text = "" };
-        Assert.Equal(1, state.GetLineCount());
+        Assert.AreEqual(1, state.GetLineCount());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_GetLineCount_TrailingNewline()
     {
         var state = new TextBoxState { Text = "line1\n" };
-        Assert.Equal(2, state.GetLineCount());
+        Assert.AreEqual(2, state.GetLineCount());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_GetLineStartOffset_FirstLine()
     {
         var state = new TextBoxState { Text = "abc\ndef\nghi" };
-        Assert.Equal(0, state.GetLineStartOffset(0));
+        Assert.AreEqual(0, state.GetLineStartOffset(0));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_GetLineStartOffset_SecondLine()
     {
         var state = new TextBoxState { Text = "abc\ndef\nghi" };
-        Assert.Equal(4, state.GetLineStartOffset(1));
+        Assert.AreEqual(4, state.GetLineStartOffset(1));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_GetLineStartOffset_ThirdLine()
     {
         var state = new TextBoxState { Text = "abc\ndef\nghi" };
-        Assert.Equal(8, state.GetLineStartOffset(2));
+        Assert.AreEqual(8, state.GetLineStartOffset(2));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_GetLineLength_MiddleLine()
     {
         var state = new TextBoxState { Text = "abc\ndefg\nhi" };
-        Assert.Equal(4, state.GetLineLength(1)); // "defg"
+        Assert.AreEqual(4, state.GetLineLength(1)); // "defg"
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_GetLineLength_LastLine()
     {
         var state = new TextBoxState { Text = "abc\ndefg\nhi" };
-        Assert.Equal(2, state.GetLineLength(2)); // "hi"
+        Assert.AreEqual(2, state.GetLineLength(2)); // "hi"
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_OffsetToLineColumn_FirstLine()
     {
         var state = new TextBoxState { Text = "abc\ndef\nghi" };
-        Assert.Equal((0, 2), state.OffsetToLineColumn(2)); // 'c'
+        Assert.AreEqual((0, 2), state.OffsetToLineColumn(2)); // 'c'
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_OffsetToLineColumn_SecondLine()
     {
         var state = new TextBoxState { Text = "abc\ndef\nghi" };
-        Assert.Equal((1, 1), state.OffsetToLineColumn(5)); // 'e'
+        Assert.AreEqual((1, 1), state.OffsetToLineColumn(5)); // 'e'
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_OffsetToLineColumn_AtNewline()
     {
         var state = new TextBoxState { Text = "abc\ndef" };
-        Assert.Equal((0, 3), state.OffsetToLineColumn(3)); // just before '\n'
+        Assert.AreEqual((0, 3), state.OffsetToLineColumn(3)); // just before '\n'
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_OffsetToLineColumn_AfterNewline()
     {
         var state = new TextBoxState { Text = "abc\ndef" };
-        Assert.Equal((1, 0), state.OffsetToLineColumn(4)); // start of "def"
+        Assert.AreEqual((1, 0), state.OffsetToLineColumn(4)); // start of "def"
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_LineColumnToOffset_Roundtrip()
     {
         var state = new TextBoxState { Text = "abc\ndef\nghi" };
         var (line, col) = state.OffsetToLineColumn(5);
-        Assert.Equal(5, state.LineColumnToOffset(line, col));
+        Assert.AreEqual(5, state.LineColumnToOffset(line, col));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_LineColumnToOffset_ClampsColumn()
     {
         var state = new TextBoxState { Text = "abc\nd" };
         // Column 10 on line 1 ("d") should clamp to offset 5 (end of "d")
-        Assert.Equal(5, state.LineColumnToOffset(1, 10));
+        Assert.AreEqual(5, state.LineColumnToOffset(1, 10));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_GetLineText()
     {
         var state = new TextBoxState { Text = "abc\ndefg\nhi" };
-        Assert.Equal("defg", state.GetLineText(1));
+        Assert.AreEqual("defg", state.GetLineText(1));
     }
 
     #endregion
 
     #region Multiline Vertical Navigation Tests
 
-    [Fact]
+    [TestMethod]
     public async Task State_MoveUp_MovesToPreviousLine()
     {
         var state = new TextBoxState { Text = "abc\ndef\nghi", IsMultiline = true };
         state.CursorPosition = 5; // 'e' on line 1
         state.MoveUp();
-        Assert.Equal((0, 1), state.OffsetToLineColumn(state.CursorPosition)); // 'b' on line 0
+        Assert.AreEqual((0, 1), state.OffsetToLineColumn(state.CursorPosition)); // 'b' on line 0
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_MoveDown_MovesToNextLine()
     {
         var state = new TextBoxState { Text = "abc\ndef\nghi", IsMultiline = true };
         state.CursorPosition = 1; // 'b' on line 0
         state.MoveDown();
-        Assert.Equal((1, 1), state.OffsetToLineColumn(state.CursorPosition)); // 'e' on line 1
+        Assert.AreEqual((1, 1), state.OffsetToLineColumn(state.CursorPosition)); // 'e' on line 1
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_MoveUp_OnFirstLine_StaysOnFirstLine()
     {
         var state = new TextBoxState { Text = "abc\ndef", IsMultiline = true };
         state.CursorPosition = 2;
         state.MoveUp();
-        Assert.Equal(2, state.CursorPosition);
+        Assert.AreEqual(2, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_MoveDown_OnLastLine_StaysOnLastLine()
     {
         var state = new TextBoxState { Text = "abc\ndef", IsMultiline = true };
         state.CursorPosition = 5;
         state.MoveDown();
-        Assert.Equal(5, state.CursorPosition);
+        Assert.AreEqual(5, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_MoveUp_ClampsToShorterLine()
     {
         var state = new TextBoxState { Text = "ab\nabcdef\ngh", IsMultiline = true };
         state.CursorPosition = 8; // 'e' (col 5) on "abcdef"
         state.MoveUp();
         // Line 0 "ab" has length 2, so column clamps to 2 (end of "ab")
-        Assert.Equal(2, state.CursorPosition);
+        Assert.AreEqual(2, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_MoveDown_PreservesPreferredColumn()
     {
         var state = new TextBoxState { Text = "abcdef\nab\nabcdef", IsMultiline = true };
         state.CursorPosition = 5; // col 5 on "abcdef"
         state.MoveDown(); // moves to "ab", clamped to col 2
-        Assert.Equal((1, 2), state.OffsetToLineColumn(state.CursorPosition));
+        Assert.AreEqual((1, 2), state.OffsetToLineColumn(state.CursorPosition));
         state.MoveDown(); // moves to "abcdef", restores to col 5
-        Assert.Equal((2, 5), state.OffsetToLineColumn(state.CursorPosition));
+        Assert.AreEqual((2, 5), state.OffsetToLineColumn(state.CursorPosition));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_MoveUp_WithShift_CreatesSelection()
     {
         var state = new TextBoxState { Text = "abc\ndef", IsMultiline = true };
         state.CursorPosition = 5; // 'e' on line 1
         state.MoveUp(extend: true);
-        Assert.True(state.HasSelection);
-        Assert.Equal(5, state.SelectionAnchor);
-        Assert.Equal(1, state.CursorPosition); // 'b' on line 0
+        Assert.IsTrue(state.HasSelection);
+        Assert.AreEqual(5, state.SelectionAnchor);
+        Assert.AreEqual(1, state.CursorPosition); // 'b' on line 0
     }
 
     #endregion
 
     #region Multiline Enter Key Tests
 
-    [Fact]
+    [TestMethod]
     public async Task State_InsertNewline_InsertsAtCursor()
     {
         var state = new TextBoxState { Text = "abcdef", IsMultiline = true };
         state.CursorPosition = 3;
         state.InsertNewline();
-        Assert.Equal("abc\ndef", state.Text);
-        Assert.Equal(4, state.CursorPosition);
+        Assert.AreEqual("abc\ndef", state.Text);
+        Assert.AreEqual(4, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_InsertNewline_AtStart()
     {
         var state = new TextBoxState { Text = "abc", IsMultiline = true };
         state.CursorPosition = 0;
         state.InsertNewline();
-        Assert.Equal("\nabc", state.Text);
-        Assert.Equal(1, state.CursorPosition);
+        Assert.AreEqual("\nabc", state.Text);
+        Assert.AreEqual(1, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_InsertNewline_AtEnd()
     {
         var state = new TextBoxState { Text = "abc", IsMultiline = true };
         state.CursorPosition = 3;
         state.InsertNewline();
-        Assert.Equal("abc\n", state.Text);
-        Assert.Equal(4, state.CursorPosition);
+        Assert.AreEqual("abc\n", state.Text);
+        Assert.AreEqual(4, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_InsertNewline_DeletesSelection()
     {
         var state = new TextBoxState { Text = "abcdef", IsMultiline = true };
         state.SelectionAnchor = 1;
         state.CursorPosition = 4;
         state.InsertNewline();
-        Assert.Equal("a\nef", state.Text);
-        Assert.Equal(2, state.CursorPosition);
+        Assert.AreEqual("a\nef", state.Text);
+        Assert.AreEqual(2, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Enter_InMultilineMode_InsertsNewline()
     {
         var state = new TextBoxState { Text = "abc", IsMultiline = true };
         state.CursorPosition = 3;
         var handled = state.HandleInput(new Hex1bKeyEvent(Hex1bKey.Enter, '\r', Hex1bModifiers.None));
-        Assert.True(handled);
-        Assert.Equal("abc\n", state.Text);
+        Assert.IsTrue(handled);
+        Assert.AreEqual("abc\n", state.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Enter_InSingleLineMode_NotHandled()
     {
         var state = new TextBoxState { Text = "abc", IsMultiline = false };
         state.CursorPosition = 3;
         var handled = state.HandleInput(new Hex1bKeyEvent(Hex1bKey.Enter, '\r', Hex1bModifiers.None));
-        Assert.False(handled);
-        Assert.Equal("abc", state.Text);
+        Assert.IsFalse(handled);
+        Assert.AreEqual("abc", state.Text);
     }
 
     #endregion
 
     #region Multiline Home/End Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Home_MultilineMode_GoesToLineStart()
     {
         var state = new TextBoxState { Text = "abc\ndef\nghi", IsMultiline = true };
         state.CursorPosition = 6; // 'f' on line 1
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.Home, '\0', Hex1bModifiers.None));
-        Assert.Equal(4, state.CursorPosition); // start of "def"
+        Assert.AreEqual(4, state.CursorPosition); // start of "def"
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_End_MultilineMode_GoesToLineEnd()
     {
         var state = new TextBoxState { Text = "abc\ndef\nghi", IsMultiline = true };
         state.CursorPosition = 4; // 'd' on line 1
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.End, '\0', Hex1bModifiers.None));
-        Assert.Equal(7, state.CursorPosition); // end of "def"
+        Assert.AreEqual(7, state.CursorPosition); // end of "def"
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_CtrlHome_MultilineMode_GoesToDocumentStart()
     {
         var state = new TextBoxState { Text = "abc\ndef\nghi", IsMultiline = true };
         state.CursorPosition = 9; // 'h' on line 2
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.Home, '\0', Hex1bModifiers.Control));
-        Assert.Equal(0, state.CursorPosition);
+        Assert.AreEqual(0, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_CtrlEnd_MultilineMode_GoesToDocumentEnd()
     {
         var state = new TextBoxState { Text = "abc\ndef\nghi", IsMultiline = true };
         state.CursorPosition = 0;
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.End, '\0', Hex1bModifiers.Control));
-        Assert.Equal(11, state.CursorPosition);
+        Assert.AreEqual(11, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Home_SingleLineMode_GoesToDocumentStart()
     {
         var state = new TextBoxState { Text = "hello", IsMultiline = false };
         state.CursorPosition = 3;
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.Home, '\0', Hex1bModifiers.None));
-        Assert.Equal(0, state.CursorPosition);
+        Assert.AreEqual(0, state.CursorPosition);
     }
 
     #endregion
 
     #region Multiline Up/Down Arrow Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_UpArrow_MultilineMode_MovesUp()
     {
         var state = new TextBoxState { Text = "abc\ndef", IsMultiline = true };
         state.CursorPosition = 5; // 'e'
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.UpArrow, '\0', Hex1bModifiers.None));
-        Assert.Equal(1, state.CursorPosition); // 'b'
+        Assert.AreEqual(1, state.CursorPosition); // 'b'
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_DownArrow_MultilineMode_MovesDown()
     {
         var state = new TextBoxState { Text = "abc\ndef", IsMultiline = true };
         state.CursorPosition = 1; // 'b'
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.DownArrow, '\0', Hex1bModifiers.None));
-        Assert.Equal(5, state.CursorPosition); // 'e'
+        Assert.AreEqual(5, state.CursorPosition); // 'e'
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_UpArrow_SingleLineMode_NotHandled()
     {
         var state = new TextBoxState { Text = "abc\ndef", IsMultiline = false };
         state.CursorPosition = 5;
         var handled = state.HandleInput(new Hex1bKeyEvent(Hex1bKey.UpArrow, '\0', Hex1bModifiers.None));
-        Assert.False(handled);
-        Assert.Equal(5, state.CursorPosition);
+        Assert.IsFalse(handled);
+        Assert.AreEqual(5, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_DownArrow_SingleLineMode_NotHandled()
     {
         var state = new TextBoxState { Text = "abc\ndef", IsMultiline = false };
         state.CursorPosition = 1;
         var handled = state.HandleInput(new Hex1bKeyEvent(Hex1bKey.DownArrow, '\0', Hex1bModifiers.None));
-        Assert.False(handled);
-        Assert.Equal(1, state.CursorPosition);
+        Assert.IsFalse(handled);
+        Assert.AreEqual(1, state.CursorPosition);
     }
 
     #endregion
 
     #region Multiline Node Integration Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Multiline_EnterInsertsNewline()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -2091,10 +2092,10 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("hello\nworld", capturedText);
+        Assert.AreEqual("hello\nworld", capturedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Multiline_RendersMultipleLines()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -2121,12 +2122,12 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("line1"));
-        Assert.True(snapshot.ContainsText("line2"));
-        Assert.True(snapshot.ContainsText("line3"));
+        Assert.IsTrue(snapshot.ContainsText("line1"));
+        Assert.IsTrue(snapshot.ContainsText("line2"));
+        Assert.IsTrue(snapshot.ContainsText("line3"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Multiline_UpDownArrowNavigation()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -2153,10 +2154,10 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("abcX\ndef", capturedText);
+        Assert.AreEqual("abcX\ndef", capturedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Multiline_WordWrap_WrapsLongLine()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -2189,11 +2190,11 @@ public class TextBoxNodeTests
         await runTask;
 
         // Both parts of the wrapped text should be visible
-        Assert.True(snapshot.ContainsText("hello"));
-        Assert.True(snapshot.ContainsText("sentence"));
+        Assert.IsTrue(snapshot.ContainsText("hello"));
+        Assert.IsTrue(snapshot.ContainsText("sentence"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Multiline_DefaultTextBox_StillSingleLine()
     {
         // Verify that a default TextBox (no Multiline()) still works as single-line
@@ -2222,10 +2223,10 @@ public class TextBoxNodeTests
         await runTask;
 
         // Should still have brackets for single-line
-        Assert.True(snapshot.ContainsText("hello"));
+        Assert.IsTrue(snapshot.ContainsText("hello"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Multiline_VerticalScrolling()
     {
         // Test vertical scrolling when content exceeds visible height
@@ -2254,66 +2255,66 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("line7"));
+        Assert.IsTrue(snapshot.ContainsText("line7"));
         // line1 should NOT be visible (it's scrolled off)
-        Assert.False(snapshot.ContainsText("line1"));
+        Assert.IsFalse(snapshot.ContainsText("line1"));
     }
 
     #endregion
 
     #region MaxLines Tests
 
-    [Fact]
+    [TestMethod]
     public async Task State_InsertNewline_RespectsMaxLines()
     {
         var state = new TextBoxState { Text = "abc\ndef", IsMultiline = true, MaxLines = 2 };
         state.CursorPosition = 3;
         state.InsertNewline();
         // Should not insert — already at 2 lines
-        Assert.Equal("abc\ndef", state.Text);
-        Assert.Equal(3, state.CursorPosition);
+        Assert.AreEqual("abc\ndef", state.Text);
+        Assert.AreEqual(3, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_InsertNewline_AllowedBelowMaxLines()
     {
         var state = new TextBoxState { Text = "abc", IsMultiline = true, MaxLines = 3 };
         state.CursorPosition = 3;
         state.InsertNewline();
-        Assert.Equal("abc\n", state.Text);
-        Assert.Equal(4, state.CursorPosition);
+        Assert.AreEqual("abc\n", state.Text);
+        Assert.AreEqual(4, state.CursorPosition);
         // Now at 2 lines, can still add one more
         state.InsertNewline();
-        Assert.Equal("abc\n\n", state.Text);
+        Assert.AreEqual("abc\n\n", state.Text);
         // Now at 3 lines, should block further
         state.InsertNewline();
-        Assert.Equal("abc\n\n", state.Text);
+        Assert.AreEqual("abc\n\n", state.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task State_InsertNewline_NoLimit_WhenMaxLinesNull()
     {
         var state = new TextBoxState { Text = "a\nb\nc", IsMultiline = true, MaxLines = null };
         state.CursorPosition = 5;
         state.InsertNewline();
-        Assert.Equal("a\nb\nc\n", state.Text);
+        Assert.AreEqual("a\nb\nc\n", state.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Enter_RespectsMaxLines()
     {
         var state = new TextBoxState { Text = "line1\nline2\nline3", IsMultiline = true, MaxLines = 3 };
         state.CursorPosition = 5;
         var handled = state.HandleInput(new Hex1bKeyEvent(Hex1bKey.Enter, '\r', Hex1bModifiers.None));
-        Assert.True(handled); // Input is consumed even if newline is blocked
-        Assert.Equal("line1\nline2\nline3", state.Text); // No change
+        Assert.IsTrue(handled); // Input is consumed even if newline is blocked
+        Assert.AreEqual("line1\nline2\nline3", state.Text); // No change
     }
 
     #endregion
 
     #region MoveDown/MoveUp Creates New Line Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_MoveDown_OnLastLine_CreatesNewLine()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -2340,10 +2341,10 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("hello\n", capturedText);
+        Assert.AreEqual("hello\n", capturedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_MoveDown_OnLastLine_WithMaxLines_Blocked()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -2370,10 +2371,10 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("line1\nline2", capturedText);
+        Assert.AreEqual("line1\nline2", capturedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_MoveDown_NotOnLastLine_NavigatesNormally()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -2406,10 +2407,10 @@ public class TextBoxNodeTests
         await runTask;
 
         // Text should have X inserted on line 1, no new lines created
-        Assert.Equal("abc\nXdef\nghi", capturedText);
+        Assert.AreEqual("abc\nXdef\nghi", capturedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_MoveUp_OnFirstLine_IsNoOp()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -2440,7 +2441,7 @@ public class TextBoxNodeTests
         Assert.DoesNotContain("\n", capturedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_MaxLines_BlocksEnterAtLimit()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -2472,7 +2473,7 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("a\nb\ncd", capturedText);
+        Assert.AreEqual("a\nb\ncd", capturedText);
     }
 
     #endregion
@@ -2492,7 +2493,7 @@ public class TextBoxNodeTests
     //     and does NOT use per-line horizontal scrolling
     // ────────────────────────────────────────────────────────────────────────
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_MultilineNoWrap_LongLinesTruncatedToViewportWidth()
     {
         // A multiline text box (no word wrap) in a narrow terminal should
@@ -2526,14 +2527,14 @@ public class TextBoxNodeTests
         await runTask;
 
         // "short" fits within viewport — should be fully visible
-        Assert.True(snapshot.ContainsText("short"));
+        Assert.IsTrue(snapshot.ContainsText("short"));
         // The long line starts with "abcdefghijklmno" (15 chars) — that prefix should be visible
-        Assert.True(snapshot.ContainsText("abcdefghijklmno"));
+        Assert.IsTrue(snapshot.ContainsText("abcdefghijklmno"));
         // Characters beyond the viewport (e.g. "pqrstuvwxyz") should NOT appear
-        Assert.False(snapshot.ContainsText("qrstuvwxyz"));
+        Assert.IsFalse(snapshot.ContainsText("qrstuvwxyz"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_MultilineNoWrap_CursorLineScrollsHorizontally()
     {
         // When the cursor is on a long line and moved to the end, the viewport
@@ -2570,10 +2571,10 @@ public class TextBoxNodeTests
 
         // The cursor line should have scrolled to show the end of the alphabet.
         // The tail "xyz" must be visible because the cursor is at the end.
-        Assert.True(snapshot.ContainsText("xyz"));
+        Assert.IsTrue(snapshot.ContainsText("xyz"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_MultilineNoWrap_NonCursorLineSnapsToStart()
     {
         // When the cursor moves away from a long line to a different line,
@@ -2613,14 +2614,14 @@ public class TextBoxNodeTests
         await runTask;
 
         // Line 0 ("short") should be visible since the cursor is there now
-        Assert.True(snapshot.ContainsText("short"));
+        Assert.IsTrue(snapshot.ContainsText("short"));
         // Line 1 should have snapped back to start — "abcdef" prefix visible
-        Assert.True(snapshot.ContainsText("abcdef"));
+        Assert.IsTrue(snapshot.ContainsText("abcdef"));
         // The tail of line 1 should NOT be visible anymore since cursor left that line
-        Assert.False(snapshot.ContainsText("xyz"));
+        Assert.IsFalse(snapshot.ContainsText("xyz"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_MultilineNoWrap_EachLineHasIndependentViewport()
     {
         // With multiple long lines, only the cursor line scrolls. Other lines
@@ -2658,12 +2659,12 @@ public class TextBoxNodeTests
         await runTask;
 
         // Line 0 (A line): cursor not here → shows from start "AAAAAAAAAAAAAAA" (15 As)
-        Assert.True(snapshot.ContainsText("AAAAAAAAAAAAAAA"));
+        Assert.IsTrue(snapshot.ContainsText("AAAAAAAAAAAAAAA"));
         // Line 2 (C line): cursor not here → shows from start "CCCCCCCCCCCCCCC" (15 Cs)
-        Assert.True(snapshot.ContainsText("CCCCCCCCCCCCCCC"));
+        Assert.IsTrue(snapshot.ContainsText("CCCCCCCCCCCCCCC"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_MultilineNoWrap_ShortLinesUnaffected()
     {
         // Lines that fit entirely within the viewport width should be rendered
@@ -2694,12 +2695,12 @@ public class TextBoxNodeTests
         await runTask;
 
         // All short lines should be fully visible regardless of cursor position
-        Assert.True(snapshot.ContainsText("hi"));
-        Assert.True(snapshot.ContainsText("there"));
-        Assert.True(snapshot.ContainsText("world"));
+        Assert.IsTrue(snapshot.ContainsText("hi"));
+        Assert.IsTrue(snapshot.ContainsText("there"));
+        Assert.IsTrue(snapshot.ContainsText("world"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_MultilineNoWrap_TypingScrollsCursorLineOnly()
     {
         // When typing at the end of a long line, the cursor line should scroll
@@ -2733,13 +2734,13 @@ public class TextBoxNodeTests
         await runTask;
 
         // Line 0 "top" is short and cursor isn't there → fully visible
-        Assert.True(snapshot.ContainsText("top"));
+        Assert.IsTrue(snapshot.ContainsText("top"));
         // Line 1 cursor is at end after typing Xs → should show the end portion
         // The beginning "bottom" should have scrolled off if the line is long enough
-        Assert.True(snapshot.ContainsText("XXXX")); // end of the typed text visible
+        Assert.IsTrue(snapshot.ContainsText("XXXX")); // end of the typed text visible
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_MultilineWithWrap_NotAffectedByPerLineViewport()
     {
         // Word-wrapped multiline mode should NOT use per-line horizontal scrolling.
@@ -2771,16 +2772,16 @@ public class TextBoxNodeTests
 
         // With word wrap, all text should be visible across multiple visual lines.
         // The words wrap at boundaries so all content appears on screen.
-        Assert.True(snapshot.ContainsText("hello"));
-        Assert.True(snapshot.ContainsText("overflow"));
-        Assert.True(snapshot.ContainsText("here"));
+        Assert.IsTrue(snapshot.ContainsText("hello"));
+        Assert.IsTrue(snapshot.ContainsText("overflow"));
+        Assert.IsTrue(snapshot.ContainsText("here"));
     }
 
     #endregion
 
     #region Multiline Preferred Column Navigation Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Multiline_UpDown_PreservesColumnAcrossShortLine()
     {
         // When navigating up/down between long lines via a short intermediate line,
@@ -2834,10 +2835,10 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("Hello World!\nShort\nAnother Log!", capturedText);
+        Assert.AreEqual("Hello World!\nShort\nAnother Log!", capturedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Multiline_LeftArrowClearsPreferredColumn()
     {
         // After pressing Left/Right, the preferred column should be reset so that
@@ -2888,10 +2889,10 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("ABCEFGHIJ\nabcdefghij", capturedText);
+        Assert.AreEqual("ABCEFGHIJ\nabcdefghij", capturedText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_Multiline_TypingClearsPreferredColumn()
     {
         // After typing a character, the preferred column should be reset so that
@@ -2943,7 +2944,7 @@ public class TextBoxNodeTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("ACDEF\nXabcdef", capturedText);
+        Assert.AreEqual("ACDEF\nXabcdef", capturedText);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/TextBoxPasteTests.cs
+++ b/tests/Hex1b.Tests/TextBoxPasteTests.cs
@@ -7,6 +7,7 @@ namespace Hex1b.Tests;
 /// Verifies that bracketed paste inserts text at cursor, replaces selection,
 /// strips newlines for single-line boxes, and fires TextChanged callbacks.
 /// </summary>
+[TestClass]
 public class TextBoxPasteTests
 {
     private static PasteContext CreatePaste(string text)
@@ -17,7 +18,7 @@ public class TextBoxPasteTests
         return ctx;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Paste_InsertsAtCursor()
     {
         var node = new TextBoxNode { Text = "abcd" };
@@ -26,13 +27,13 @@ public class TextBoxPasteTests
 
         var result = await node.HandlePasteAsync(new Hex1bPasteEvent(paste));
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal("abXYcd", node.Text);
-        Assert.Equal(4, node.State.CursorPosition); // after "XY"
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual("abXYcd", node.Text);
+        Assert.AreEqual(4, node.State.CursorPosition); // after "XY"
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Paste_InsertsAtEnd()
     {
         var node = new TextBoxNode { Text = "hello" };
@@ -41,12 +42,12 @@ public class TextBoxPasteTests
 
         await node.HandlePasteAsync(new Hex1bPasteEvent(paste));
 
-        Assert.Equal("hello world", node.Text);
-        Assert.Equal(11, node.State.CursorPosition);
+        Assert.AreEqual("hello world", node.Text);
+        Assert.AreEqual(11, node.State.CursorPosition);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Paste_InsertsAtStart()
     {
         var node = new TextBoxNode { Text = "world" };
@@ -55,12 +56,12 @@ public class TextBoxPasteTests
 
         await node.HandlePasteAsync(new Hex1bPasteEvent(paste));
 
-        Assert.Equal("hello world", node.Text);
-        Assert.Equal(6, node.State.CursorPosition);
+        Assert.AreEqual("hello world", node.Text);
+        Assert.AreEqual(6, node.State.CursorPosition);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Paste_ReplacesSelection()
     {
         var node = new TextBoxNode { Text = "hello world" };
@@ -71,12 +72,12 @@ public class TextBoxPasteTests
 
         await node.HandlePasteAsync(new Hex1bPasteEvent(paste));
 
-        Assert.Equal("hello earth", node.Text);
-        Assert.Equal(11, node.State.CursorPosition);
+        Assert.AreEqual("hello earth", node.Text);
+        Assert.AreEqual(11, node.State.CursorPosition);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Paste_EmptyString_NoChange()
     {
         var node = new TextBoxNode { Text = "hello" };
@@ -85,13 +86,13 @@ public class TextBoxPasteTests
 
         var result = await node.HandlePasteAsync(new Hex1bPasteEvent(paste));
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal("hello", node.Text);
-        Assert.Equal(3, node.State.CursorPosition);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual("hello", node.Text);
+        Assert.AreEqual(3, node.State.CursorPosition);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Paste_MultiLine_NewlinesReplacedWithSpaces()
     {
         var node = new TextBoxNode { Text = "" };
@@ -100,11 +101,11 @@ public class TextBoxPasteTests
 
         await node.HandlePasteAsync(new Hex1bPasteEvent(paste));
 
-        Assert.Equal("line1 line2 line3", node.Text);
+        Assert.AreEqual("line1 line2 line3", node.Text);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Paste_Unicode_InsertedCorrectly()
     {
         var node = new TextBoxNode { Text = "abc" };
@@ -113,11 +114,11 @@ public class TextBoxPasteTests
 
         await node.HandlePasteAsync(new Hex1bPasteEvent(paste));
 
-        Assert.Equal("abcこんにちは 🌍", node.Text);
+        Assert.AreEqual("abcこんにちは 🌍", node.Text);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Paste_LargeText_Inserted()
     {
         var node = new TextBoxNode { Text = "" };
@@ -127,12 +128,12 @@ public class TextBoxPasteTests
 
         await node.HandlePasteAsync(new Hex1bPasteEvent(paste));
 
-        Assert.Equal(10_000, node.Text.Length);
-        Assert.Equal(10_000, node.State.CursorPosition);
+        Assert.AreEqual(10_000, node.Text.Length);
+        Assert.AreEqual(10_000, node.State.CursorPosition);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Paste_FiresTextChangedCallback()
     {
         string? callbackOldText = null;
@@ -149,8 +150,8 @@ public class TextBoxPasteTests
 
         await node.HandlePasteAsync(new Hex1bPasteEvent(paste));
 
-        Assert.Equal("old", callbackOldText);
-        Assert.Equal("oldnew", callbackNewText);
+        Assert.AreEqual("old", callbackOldText);
+        Assert.AreEqual("oldnew", callbackNewText);
         await paste.DisposeAsync();
     }
 }

--- a/tests/Hex1b.Tests/TextBoxPredictionTests.cs
+++ b/tests/Hex1b.Tests/TextBoxPredictionTests.cs
@@ -9,6 +9,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for the inline predictive-completion behavior of <see cref="TextBoxNode"/>.
 /// </summary>
+[TestClass]
 public class TextBoxPredictionTests
 {
     private static TextBoxNode CreateNode(
@@ -46,7 +47,7 @@ public class TextBoxPredictionTests
 
     private static Hex1bKeyEvent CharKey(char ch) => new((Hex1bKey)char.ToUpperInvariant(ch), ch, Hex1bModifiers.None);
 
-    [Fact]
+    [TestMethod]
     public async Task Typing_AtEndOfBuffer_TriggersPredictor()
     {
         var calls = 0;
@@ -72,12 +73,12 @@ public class TextBoxPredictionTests
 
         var prediction = await WaitForPredictionAsync(node, TimeSpan.FromSeconds(2));
 
-        Assert.Equal("world", prediction);
-        Assert.True(seen.Contains("hello"), $"Predictor never saw 'hello'. text='{node.Text}' seen=[{string.Join(",", seen)}] calls={calls}");
-        Assert.True(calls >= 1);
+        Assert.AreEqual("world", prediction);
+        Assert.IsTrue(seen.Contains("hello"), $"Predictor never saw 'hello'. text='{node.Text}' seen=[{string.Join(", ", seen)}] calls={calls}");
+        Assert.IsTrue(calls >= 1);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Typing_WithCursorInMiddle_DoesNotTriggerPredictor()
     {
         var calls = 0;
@@ -94,89 +95,89 @@ public class TextBoxPredictionTests
 
         await Task.Delay(100, TestContext.Current.CancellationToken);
 
-        Assert.Equal(0, calls);
-        Assert.Null(node.CurrentPrediction);
+        Assert.AreEqual(0, calls);
+        Assert.IsNull(node.CurrentPrediction);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task LeftArrow_ClearsActivePrediction()
     {
         var node = CreateNode((_, _) => Task.FromResult<string?>("xyz"));
         await InputRouter.RouteInputToNodeAsync(node, CharKey('a'), null, null, TestContext.Current.CancellationToken);
         await WaitForPredictionAsync(node, TimeSpan.FromSeconds(2));
 
-        Assert.Equal("xyz", node.CurrentPrediction);
+        Assert.AreEqual("xyz", node.CurrentPrediction);
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Null(node.CurrentPrediction);
+        Assert.IsNull(node.CurrentPrediction);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Backspace_ClearsActivePrediction()
     {
         var node = CreateNode((_, _) => Task.FromResult<string?>("xyz"));
         await InputRouter.RouteInputToNodeAsync(node, CharKey('a'), null, null, TestContext.Current.CancellationToken);
         await WaitForPredictionAsync(node, TimeSpan.FromSeconds(2));
-        Assert.Equal("xyz", node.CurrentPrediction);
+        Assert.AreEqual("xyz", node.CurrentPrediction);
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Backspace, '\b', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Null(node.CurrentPrediction);
+        Assert.IsNull(node.CurrentPrediction);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task FocusLoss_ClearsActivePrediction()
     {
         var node = CreateNode((_, _) => Task.FromResult<string?>("xyz"));
         await InputRouter.RouteInputToNodeAsync(node, CharKey('a'), null, null, TestContext.Current.CancellationToken);
         await WaitForPredictionAsync(node, TimeSpan.FromSeconds(2));
-        Assert.Equal("xyz", node.CurrentPrediction);
+        Assert.AreEqual("xyz", node.CurrentPrediction);
 
         node.IsFocused = false;
 
-        Assert.Null(node.CurrentPrediction);
+        Assert.IsNull(node.CurrentPrediction);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task MouseClick_ClearsActivePrediction()
     {
         var node = CreateNode((_, _) => Task.FromResult<string?>("xyz"));
         await InputRouter.RouteInputToNodeAsync(node, CharKey('a'), null, null, TestContext.Current.CancellationToken);
         await WaitForPredictionAsync(node, TimeSpan.FromSeconds(2));
-        Assert.Equal("xyz", node.CurrentPrediction);
+        Assert.AreEqual("xyz", node.CurrentPrediction);
 
         node.Arrange(new Rect(0, 0, 10, 1));
         node.HandleMouseClick(0, 0, new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 0, 0, Hex1bModifiers.None, ClickCount: 1));
 
-        Assert.Null(node.CurrentPrediction);
+        Assert.IsNull(node.CurrentPrediction);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Escape_WithActivePrediction_IsConsumed_AndClears()
     {
         var node = CreateNode((_, _) => Task.FromResult<string?>("xyz"));
         await InputRouter.RouteInputToNodeAsync(node, CharKey('a'), null, null, TestContext.Current.CancellationToken);
         await WaitForPredictionAsync(node, TimeSpan.FromSeconds(2));
-        Assert.Equal("xyz", node.CurrentPrediction);
+        Assert.AreEqual("xyz", node.CurrentPrediction);
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Escape, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Null(node.CurrentPrediction);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsNull(node.CurrentPrediction);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Escape_WithoutActivePrediction_IsNotConsumed()
     {
         var node = CreateNode();
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Escape, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RightArrow_WithActivePrediction_AcceptsAndFiresChange()
     {
         var node = CreateNode((_, _) => Task.FromResult<string?>("world"));
@@ -196,20 +197,20 @@ public class TextBoxPredictionTests
         await InputRouter.RouteInputToNodeAsync(node, CharKey('o'), null, null, TestContext.Current.CancellationToken);
 
         await WaitForPredictionAsync(node, TimeSpan.FromSeconds(2));
-        Assert.Equal("world", node.CurrentPrediction);
+        Assert.AreEqual("world", node.CurrentPrediction);
 
         var typingChanges = changes;
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("helloworld", node.Text);
-        Assert.Equal(node.Text.Length, node.State.CursorPosition);
-        Assert.Null(node.CurrentPrediction);
-        Assert.Equal(typingChanges + 1, changes);
-        Assert.Equal("helloworld", lastNew);
+        Assert.AreEqual("helloworld", node.Text);
+        Assert.AreEqual(node.Text.Length, node.State.CursorPosition);
+        Assert.IsNull(node.CurrentPrediction);
+        Assert.AreEqual(typingChanges + 1, changes);
+        Assert.AreEqual("helloworld", lastNew);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RightArrow_WithoutPrediction_MovesCursor()
     {
         var node = new TextBoxNode { Text = "abc", IsFocused = true };
@@ -217,10 +218,10 @@ public class TextBoxPredictionTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(2, node.State.CursorPosition);
+        Assert.AreEqual(2, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task StaleAsyncResult_IsDiscarded()
     {
         // The predictor deliberately *ignores* the cancellation token. The
@@ -249,10 +250,10 @@ public class TextBoxPredictionTests
         // tied to the stale snapshot ("a!") must never become the active
         // prediction. Only the value tied to the live snapshot ("ab!")
         // is allowed.
-        Assert.Equal("ab!", prediction);
+        Assert.AreEqual("ab!", prediction);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Debounce_CoalescesRapidKeystrokesIntoSingleCall()
     {
         var calls = 0;
@@ -276,12 +277,12 @@ public class TextBoxPredictionTests
 
         await WaitForPredictionAsync(node, TimeSpan.FromSeconds(2));
 
-        Assert.Equal(1, calls);
-        Assert.Equal("abc", lastSeen);
-        Assert.Equal("abc!", node.CurrentPrediction);
+        Assert.AreEqual(1, calls);
+        Assert.AreEqual("abc", lastSeen);
+        Assert.AreEqual("abc!", node.CurrentPrediction);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Multiline_NeverPopulatesPrediction()
     {
         var calls = 0;
@@ -298,11 +299,11 @@ public class TextBoxPredictionTests
 
         await Task.Delay(100, TestContext.Current.CancellationToken);
 
-        Assert.Null(node.CurrentPrediction);
-        Assert.Equal(0, calls);
+        Assert.IsNull(node.CurrentPrediction);
+        Assert.AreEqual(0, calls);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PredictWidget_Reconciles_PredictorOntoNode()
     {
         var widget = new TextBoxWidget("hello").Predict((_, _) => Task.FromResult<string?>("ignored"));
@@ -312,11 +313,11 @@ public class TextBoxPredictionTests
 
         await widget.ReconcileAsync(node, ctx);
 
-        Assert.NotNull(node.Predictor);
-        Assert.Equal(TimeSpan.Zero, node.PredictionDebounce);
+        Assert.IsNotNull(node.Predictor);
+        Assert.AreEqual(TimeSpan.Zero, node.PredictionDebounce);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PredictWidget_WithDebounce_FlowsDebounceOntoNode()
     {
         var widget = new TextBoxWidget("hello").Predict((_, _) => Task.FromResult<string?>("ignored"), TimeSpan.FromMilliseconds(123));
@@ -326,6 +327,6 @@ public class TextBoxPredictionTests
 
         await widget.ReconcileAsync(node, ctx);
 
-        Assert.Equal(TimeSpan.FromMilliseconds(123), node.PredictionDebounce);
+        Assert.AreEqual(TimeSpan.FromMilliseconds(123), node.PredictionDebounce);
     }
 }

--- a/tests/Hex1b.Tests/TextBoxStateTests.cs
+++ b/tests/Hex1b.Tests/TextBoxStateTests.cs
@@ -6,19 +6,20 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for TextBoxState input handling.
 /// </summary>
+[TestClass]
 public class TextBoxStateTests
 {
-    [Fact]
+    [TestMethod]
     public void InitialState_IsEmpty()
     {
         var state = new TextBoxState();
         
-        Assert.Equal("", state.Text);
-        Assert.Equal(0, state.CursorPosition);
-        Assert.False(state.HasSelection);
+        Assert.AreEqual("", state.Text);
+        Assert.AreEqual(0, state.CursorPosition);
+        Assert.IsFalse(state.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_CharacterKey_InsertsText()
     {
         var state = new TextBoxState();
@@ -26,128 +27,128 @@ public class TextBoxStateTests
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.H, 'h', Hex1bModifiers.None));
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.I, 'i', Hex1bModifiers.None));
         
-        Assert.Equal("hi", state.Text);
-        Assert.Equal(2, state.CursorPosition);
+        Assert.AreEqual("hi", state.Text);
+        Assert.AreEqual(2, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_Backspace_DeletesBeforeCursor()
     {
         var state = new TextBoxState { Text = "hello", CursorPosition = 5 };
         
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.Backspace, '\b', Hex1bModifiers.None));
         
-        Assert.Equal("hell", state.Text);
-        Assert.Equal(4, state.CursorPosition);
+        Assert.AreEqual("hell", state.Text);
+        Assert.AreEqual(4, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_Backspace_AtStart_DoesNothing()
     {
         var state = new TextBoxState { Text = "hello", CursorPosition = 0 };
         
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.Backspace, '\b', Hex1bModifiers.None));
         
-        Assert.Equal("hello", state.Text);
-        Assert.Equal(0, state.CursorPosition);
+        Assert.AreEqual("hello", state.Text);
+        Assert.AreEqual(0, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_Delete_DeletesAtCursor()
     {
         var state = new TextBoxState { Text = "hello", CursorPosition = 0 };
         
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.Delete, '\0', Hex1bModifiers.None));
         
-        Assert.Equal("ello", state.Text);
-        Assert.Equal(0, state.CursorPosition);
+        Assert.AreEqual("ello", state.Text);
+        Assert.AreEqual(0, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_Delete_AtEnd_DoesNothing()
     {
         var state = new TextBoxState { Text = "hello", CursorPosition = 5 };
         
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.Delete, '\0', Hex1bModifiers.None));
         
-        Assert.Equal("hello", state.Text);
-        Assert.Equal(5, state.CursorPosition);
+        Assert.AreEqual("hello", state.Text);
+        Assert.AreEqual(5, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_LeftArrow_MovesCursorLeft()
     {
         var state = new TextBoxState { Text = "hello", CursorPosition = 3 };
         
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None));
         
-        Assert.Equal(2, state.CursorPosition);
+        Assert.AreEqual(2, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_LeftArrow_AtStart_StaysAtStart()
     {
         var state = new TextBoxState { Text = "hello", CursorPosition = 0 };
         
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None));
         
-        Assert.Equal(0, state.CursorPosition);
+        Assert.AreEqual(0, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_RightArrow_MovesCursorRight()
     {
         var state = new TextBoxState { Text = "hello", CursorPosition = 2 };
         
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None));
         
-        Assert.Equal(3, state.CursorPosition);
+        Assert.AreEqual(3, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_RightArrow_AtEnd_StaysAtEnd()
     {
         var state = new TextBoxState { Text = "hello", CursorPosition = 5 };
         
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None));
         
-        Assert.Equal(5, state.CursorPosition);
+        Assert.AreEqual(5, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_Home_MovesCursorToStart()
     {
         var state = new TextBoxState { Text = "hello", CursorPosition = 3 };
         
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.Home, '\0', Hex1bModifiers.None));
         
-        Assert.Equal(0, state.CursorPosition);
+        Assert.AreEqual(0, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_End_MovesCursorToEnd()
     {
         var state = new TextBoxState { Text = "hello", CursorPosition = 0 };
         
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.End, '\0', Hex1bModifiers.None));
         
-        Assert.Equal(5, state.CursorPosition);
+        Assert.AreEqual(5, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_ShiftLeftArrow_StartsSelection()
     {
         var state = new TextBoxState { Text = "hello", CursorPosition = 3 };
         
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.Shift));
         
-        Assert.True(state.HasSelection);
-        Assert.Equal(2, state.CursorPosition);
-        Assert.Equal(2, state.SelectionStart);
-        Assert.Equal(3, state.SelectionEnd);
+        Assert.IsTrue(state.HasSelection);
+        Assert.AreEqual(2, state.CursorPosition);
+        Assert.AreEqual(2, state.SelectionStart);
+        Assert.AreEqual(3, state.SelectionEnd);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_ShiftRightArrow_ExtendsSelection()
     {
         var state = new TextBoxState { Text = "hello", CursorPosition = 1 };
@@ -155,36 +156,36 @@ public class TextBoxStateTests
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.Shift));
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.Shift));
         
-        Assert.True(state.HasSelection);
-        Assert.Equal(3, state.CursorPosition);
-        Assert.Equal(1, state.SelectionStart);
-        Assert.Equal(3, state.SelectionEnd);
-        Assert.Equal("el", state.SelectedText);
+        Assert.IsTrue(state.HasSelection);
+        Assert.AreEqual(3, state.CursorPosition);
+        Assert.AreEqual(1, state.SelectionStart);
+        Assert.AreEqual(3, state.SelectionEnd);
+        Assert.AreEqual("el", state.SelectedText);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_LeftArrow_WithSelection_MovesToSelectionStart()
     {
         var state = new TextBoxState { Text = "hello", CursorPosition = 4, SelectionAnchor = 1 };
         
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None));
         
-        Assert.False(state.HasSelection);
-        Assert.Equal(1, state.CursorPosition);
+        Assert.IsFalse(state.HasSelection);
+        Assert.AreEqual(1, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_RightArrow_WithSelection_MovesToSelectionEnd()
     {
         var state = new TextBoxState { Text = "hello", CursorPosition = 1, SelectionAnchor = 4 };
         
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None));
         
-        Assert.False(state.HasSelection);
-        Assert.Equal(4, state.CursorPosition);
+        Assert.IsFalse(state.HasSelection);
+        Assert.AreEqual(4, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_Backspace_WithSelection_DeletesSelection()
     {
         var state = new TextBoxState { Text = "hello world", CursorPosition = 8, SelectionAnchor = 5 };
@@ -192,112 +193,112 @@ public class TextBoxStateTests
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.Backspace, '\b', Hex1bModifiers.None));
         
         // Selection from 5 to 8 is " wo", so "hello world" becomes "hellorld"
-        Assert.Equal("hellorld", state.Text);
-        Assert.Equal(5, state.CursorPosition);
-        Assert.False(state.HasSelection);
+        Assert.AreEqual("hellorld", state.Text);
+        Assert.AreEqual(5, state.CursorPosition);
+        Assert.IsFalse(state.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_Delete_WithSelection_DeletesSelection()
     {
         var state = new TextBoxState { Text = "hello world", CursorPosition = 3, SelectionAnchor = 8 };
         
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.Delete, '\0', Hex1bModifiers.None));
         
-        Assert.Equal("helrld", state.Text);
-        Assert.Equal(3, state.CursorPosition);
-        Assert.False(state.HasSelection);
+        Assert.AreEqual("helrld", state.Text);
+        Assert.AreEqual(3, state.CursorPosition);
+        Assert.IsFalse(state.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_Type_WithSelection_ReplacesSelection()
     {
         var state = new TextBoxState { Text = "hello world", CursorPosition = 6, SelectionAnchor = 11 };
         
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.X, 'X', Hex1bModifiers.None));
         
-        Assert.Equal("hello X", state.Text);
-        Assert.Equal(7, state.CursorPosition);
-        Assert.False(state.HasSelection);
+        Assert.AreEqual("hello X", state.Text);
+        Assert.AreEqual(7, state.CursorPosition);
+        Assert.IsFalse(state.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_CtrlA_SelectsAll()
     {
         var state = new TextBoxState { Text = "hello world", CursorPosition = 3 };
         
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.A, 'a', Hex1bModifiers.Control));
         
-        Assert.True(state.HasSelection);
-        Assert.Equal(0, state.SelectionStart);
-        Assert.Equal(11, state.SelectionEnd);
-        Assert.Equal("hello world", state.SelectedText);
+        Assert.IsTrue(state.HasSelection);
+        Assert.AreEqual(0, state.SelectionStart);
+        Assert.AreEqual(11, state.SelectionEnd);
+        Assert.AreEqual("hello world", state.SelectedText);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_CtrlA_OnEmptyText_DoesNothing()
     {
         var state = new TextBoxState { Text = "", CursorPosition = 0 };
         
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.A, 'a', Hex1bModifiers.Control));
         
-        Assert.False(state.HasSelection);
+        Assert.IsFalse(state.HasSelection);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_ShiftHome_SelectsToStart()
     {
         var state = new TextBoxState { Text = "hello world", CursorPosition = 6 };
         
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.Home, '\0', Hex1bModifiers.Shift));
         
-        Assert.True(state.HasSelection);
-        Assert.Equal(0, state.SelectionStart);
-        Assert.Equal(6, state.SelectionEnd);
+        Assert.IsTrue(state.HasSelection);
+        Assert.AreEqual(0, state.SelectionStart);
+        Assert.AreEqual(6, state.SelectionEnd);
     }
 
-    [Fact]
+    [TestMethod]
     public void HandleInput_ShiftEnd_SelectsToEnd()
     {
         var state = new TextBoxState { Text = "hello world", CursorPosition = 3 };
         
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.End, '\0', Hex1bModifiers.Shift));
         
-        Assert.True(state.HasSelection);
-        Assert.Equal(3, state.SelectionStart);
-        Assert.Equal(11, state.SelectionEnd);
+        Assert.IsTrue(state.HasSelection);
+        Assert.AreEqual(3, state.SelectionStart);
+        Assert.AreEqual(11, state.SelectionEnd);
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectAll_SetsCorrectAnchorAndCursor()
     {
         var state = new TextBoxState { Text = "hello", CursorPosition = 2 };
         
         state.SelectAll();
         
-        Assert.Equal(0, state.SelectionAnchor);
-        Assert.Equal(5, state.CursorPosition);
+        Assert.AreEqual(0, state.SelectionAnchor);
+        Assert.AreEqual(5, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClearSelection_RemovesSelection()
     {
         var state = new TextBoxState { Text = "hello", CursorPosition = 4, SelectionAnchor = 1 };
         
         state.ClearSelection();
         
-        Assert.False(state.HasSelection);
-        Assert.Null(state.SelectionAnchor);
+        Assert.IsFalse(state.HasSelection);
+        Assert.IsNull(state.SelectionAnchor);
     }
 
-    [Fact]
+    [TestMethod]
     public void InsertInMiddle_InsertsCorrectly()
     {
         var state = new TextBoxState { Text = "hllo", CursorPosition = 1 };
         
         state.HandleInput(new Hex1bKeyEvent(Hex1bKey.E, 'e', Hex1bModifiers.None));
         
-        Assert.Equal("hello", state.Text);
-        Assert.Equal(2, state.CursorPosition);
+        Assert.AreEqual("hello", state.Text);
+        Assert.AreEqual(2, state.CursorPosition);
     }
 }

--- a/tests/Hex1b.Tests/TextBoxWidgetTests.cs
+++ b/tests/Hex1b.Tests/TextBoxWidgetTests.cs
@@ -2,9 +2,10 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class TextBoxWidgetTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_NewNode_WithInitialText_PlacesCursorAtEnd()
     {
         var context = ReconcileContext.CreateRoot();
@@ -13,18 +14,18 @@ public class TextBoxWidgetTests
         var widget = new TextBoxWidget("hello");
         var node = (TextBoxNode)await widget.ReconcileAsync(null, context);
 
-        Assert.Equal("hello", node.Text);
-        Assert.Equal("hello".Length, node.State.CursorPosition);
+        Assert.AreEqual("hello", node.Text);
+        Assert.AreEqual("hello".Length, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_ExternalTextChange_PlacesCursorAtEnd()
     {
         var context = ReconcileContext.CreateRoot();
         context.IsNew = true;
 
         var node = (TextBoxNode)await new TextBoxWidget("hello").ReconcileAsync(null, context);
-        Assert.Equal("hello".Length, node.State.CursorPosition);
+        Assert.AreEqual("hello".Length, node.State.CursorPosition);
 
         // Move cursor away from the end, then simulate an external programmatic text update.
         node.State.CursorPosition = 2;
@@ -32,11 +33,11 @@ public class TextBoxWidgetTests
         context.IsNew = false;
         await new TextBoxWidget("hello world").ReconcileAsync(node, context);
 
-        Assert.Equal("hello world", node.Text);
-        Assert.Equal("hello world".Length, node.State.CursorPosition);
+        Assert.AreEqual("hello world", node.Text);
+        Assert.AreEqual("hello world".Length, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_ControlledSync_DoesNotResetCursorWhenTextAlreadyMatchesState()
     {
         var context = ReconcileContext.CreateRoot();
@@ -52,10 +53,10 @@ public class TextBoxWidgetTests
         context.IsNew = false;
         await new TextBoxWidget("heXllo").ReconcileAsync(node, context);
 
-        Assert.Equal(3, node.State.CursorPosition);
+        Assert.AreEqual(3, node.State.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_HoistedState_RoutesParentInstanceIntoNode()
     {
         var context = ReconcileContext.CreateRoot();
@@ -66,11 +67,11 @@ public class TextBoxWidgetTests
 
         // The node must be backed by the exact instance the parent supplied —
         // not a copy — so subsequent parent mutations are observed.
-        Assert.Same(state, node.State);
-        Assert.Equal("initial", node.Text);
+        Assert.AreSame(state, node.State);
+        Assert.AreEqual("initial", node.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_HoistedState_PreservedAcrossReconciles()
     {
         var context = ReconcileContext.CreateRoot();
@@ -78,18 +79,18 @@ public class TextBoxWidgetTests
 
         var state = new TextBoxState("first");
         var node = (TextBoxNode)await new TextBoxWidget().State(state).ReconcileAsync(null, context);
-        Assert.Same(state, node.State);
+        Assert.AreSame(state, node.State);
 
         // A new widget instance pointing at the same state must NOT replace
         // the state instance on the node.
         context.IsNew = false;
         var node2 = (TextBoxNode)await new TextBoxWidget().State(state).ReconcileAsync(node, context);
 
-        Assert.Same(node, node2);
-        Assert.Same(state, node2.State);
+        Assert.AreSame(node, node2);
+        Assert.AreSame(state, node2.State);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_HoistedState_ParentMutationVisibleAfterReconcile()
     {
         var context = ReconcileContext.CreateRoot();
@@ -97,7 +98,7 @@ public class TextBoxWidgetTests
 
         var state = new TextBoxState("hello");
         var node = (TextBoxNode)await new TextBoxWidget().State(state).ReconcileAsync(null, context);
-        Assert.Equal("hello", node.Text);
+        Assert.AreEqual("hello", node.Text);
 
         // Parent rewrites the state from outside the widget tree, then
         // reconciles. The node should observe the new text — and a render
@@ -108,10 +109,10 @@ public class TextBoxWidgetTests
         context.IsNew = false;
         await new TextBoxWidget().State(state).ReconcileAsync(node, context);
 
-        Assert.Equal("world", node.Text);
+        Assert.AreEqual("world", node.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_HoistedState_PeerInstancesAreIndependent()
     {
         var context = ReconcileContext.CreateRoot();
@@ -126,11 +127,11 @@ public class TextBoxWidgetTests
         // Each node should have its own state — mutating one must not
         // affect the other.
         stateA.Text = "alpha-2";
-        Assert.Equal("alpha-2", nodeA.Text);
-        Assert.Equal("beta", nodeB.Text);
+        Assert.AreEqual("alpha-2", nodeA.Text);
+        Assert.AreEqual("beta", nodeB.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_HoistedStateAndCtorText_Throws()
     {
         var context = ReconcileContext.CreateRoot();
@@ -139,30 +140,31 @@ public class TextBoxWidgetTests
         var state = new TextBoxState("from-state");
         var widget = new TextBoxWidget("from-ctor").State(state);
 
-        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () =>
             await widget.ReconcileAsync(null, context));
     }
 }
 
+[TestClass]
 public class TextBoxStateHoistedTests
 {
-    [Fact]
+    [TestMethod]
     public void DefaultCtor_ProducesEmptyState()
     {
         var state = new TextBoxState();
-        Assert.Equal(string.Empty, state.Text);
-        Assert.Equal(0, state.CursorPosition);
+        Assert.AreEqual(string.Empty, state.Text);
+        Assert.AreEqual(0, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public void InitialTextCtor_ClampsCursorToEnd()
     {
         var state = new TextBoxState("hello");
-        Assert.Equal("hello", state.Text);
-        Assert.Equal(5, state.CursorPosition);
+        Assert.AreEqual("hello", state.Text);
+        Assert.AreEqual(5, state.CursorPosition);
     }
 
-    [Fact]
+    [TestMethod]
     public void TextSetter_BumpsVersion()
     {
         var state = new TextBoxState("hello");
@@ -170,10 +172,10 @@ public class TextBoxStateHoistedTests
 
         state.Text = "world";
         var v1 = ReadVersion(state);
-        Assert.True(v1 > v0);
+        Assert.IsTrue(v1 > v0);
     }
 
-    [Fact]
+    [TestMethod]
     public void TextSetter_NoOp_DoesNotBumpVersion()
     {
         var state = new TextBoxState("hello");
@@ -181,40 +183,40 @@ public class TextBoxStateHoistedTests
 
         // Same value — no mutation, no version bump.
         state.Text = "hello";
-        Assert.Equal(v0, ReadVersion(state));
+        Assert.AreEqual(v0, ReadVersion(state));
     }
 
-    [Fact]
+    [TestMethod]
     public void CursorSetter_BumpsVersion()
     {
         var state = new TextBoxState("hello");
         var v0 = ReadVersion(state);
 
         state.CursorPosition = 2;
-        Assert.True(ReadVersion(state) > v0);
+        Assert.IsTrue(ReadVersion(state) > v0);
     }
 
-    [Fact]
+    [TestMethod]
     public void DefaultWidthHint_IsFill_SoTextBoxExpandsByDefault()
     {
         // The bare widget reports Fill so HStack/VStack hand it the remaining
         // space without callers having to chain .FillWidth() on every textbox.
         var widget = new TextBoxWidget("hello");
-        Assert.Null(widget.WidthHint);
-        Assert.Equal(Hex1b.Layout.SizeHint.Fill, widget.DefaultWidthHint);
+        Assert.IsNull(widget.WidthHint);
+        Assert.AreEqual(Hex1b.Layout.SizeHint.Fill, widget.DefaultWidthHint);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExplicitWidthHint_OverridesDefault()
     {
         // ContentWidth/FixedWidth/etc. set WidthHint, which always wins over
         // the per-widget default.
         var widget = new TextBoxWidget("hello").ContentWidth();
-        Assert.Equal(Hex1b.Layout.SizeHint.Content, widget.WidthHint);
-        Assert.Equal(Hex1b.Layout.SizeHint.Fill, widget.DefaultWidthHint);
+        Assert.AreEqual(Hex1b.Layout.SizeHint.Content, widget.WidthHint);
+        Assert.AreEqual(Hex1b.Layout.SizeHint.Fill, widget.DefaultWidthHint);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_PropagatesFillDefault_ToNode()
     {
         var context = ReconcileContext.CreateRoot();
@@ -227,10 +229,10 @@ public class TextBoxStateHoistedTests
         // happens in Hex1bApp's central reconcile path. Simulate that step.
         node.WidthHint = widget.WidthHint ?? widget.DefaultWidthHint;
 
-        Assert.Equal(Hex1b.Layout.SizeHint.Fill, node.WidthHint);
+        Assert.AreEqual(Hex1b.Layout.SizeHint.Fill, node.WidthHint);
     }
 
-    [Fact]
+    [TestMethod]
     public void TextBoxInHStack_GetsRemainingWidth_ByDefault()
     {
         // Build an HStack with a fixed-width label and a bare TextBox; arrange
@@ -248,7 +250,7 @@ public class TextBoxStateHoistedTests
 
         hstack.Arrange(new Hex1b.Layout.Rect(0, 0, 40, 1));
 
-        Assert.Equal(34, hstack.Children[1].Bounds.Width);
+        Assert.AreEqual(34, hstack.Children[1].Bounds.Width);
     }
 
     private static long ReadVersion(TextBoxState state)

--- a/tests/Hex1b.Tests/TextDecorationTests.cs
+++ b/tests/Hex1b.Tests/TextDecorationTests.cs
@@ -11,6 +11,7 @@ namespace Hex1b.Tests;
 /// Verifies that <see cref="ITextDecorationProvider"/> decorations are correctly
 /// applied as foreground/background colors in rendered editor cells.
 /// </summary>
+[TestClass]
 public class TextDecorationTests
 {
     private static Hex1bColor? ToCellColor(Hex1bColor color) => color.IsDefault ? null : color;
@@ -48,7 +49,7 @@ public class TextDecorationTests
         return (node, workload, terminal, context, theme);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Decoration_ForegroundColor_AppliedToDecoratedCells()
     {
         var decorationColor = Hex1bColor.FromRgb(86, 156, 214); // keyword blue
@@ -79,8 +80,7 @@ public class TextDecorationTests
         for (var x = 0; x <= 2; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(ColorEquals(expectedFg, cell.Foreground),
-                $"Column {x}: expected fg {expectedFg}, got {cell.Foreground}");
+            Assert.IsTrue(ColorEquals(expectedFg, cell.Foreground), $"Column {x}: expected fg {expectedFg}, got {cell.Foreground}");
         }
 
         // " " at column 3 and "x" at column 4 should have default editor fg
@@ -88,15 +88,14 @@ public class TextDecorationTests
         for (var x = 3; x <= 4; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(ColorEquals(editorFg, cell.Foreground),
-                $"Column {x}: expected editor fg, got {cell.Foreground}");
+            Assert.IsTrue(ColorEquals(editorFg, cell.Foreground), $"Column {x}: expected editor fg, got {cell.Foreground}");
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Decoration_BackgroundColor_AppliedToDecoratedCells()
     {
         var bgColor = Hex1bColor.FromRgb(100, 50, 50); // reddish background
@@ -124,21 +123,19 @@ public class TextDecorationTests
         for (var x = 0; x <= 2; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(ColorEquals(expectedBg, cell.Background),
-                $"Column {x}: expected bg {expectedBg}, got {cell.Background}");
+            Assert.IsTrue(ColorEquals(expectedBg, cell.Background), $"Column {x}: expected bg {expectedBg}, got {cell.Background}");
         }
 
         // Column 3+ should have default editor bg
         var editorBg = ToCellColor(theme.Get(EditorTheme.BackgroundColor));
         var undecorated = snapshot.GetCell(4, 0);
-        Assert.True(ColorEquals(editorBg, undecorated.Background),
-            $"Column 4: expected editor bg {editorBg}, got {undecorated.Background}");
+        Assert.IsTrue(ColorEquals(editorBg, undecorated.Background), $"Column 4: expected editor bg {editorBg}, got {undecorated.Background}");
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Decoration_CursorOverridesDecoration_CursorColorWins()
     {
         var decorationColor = Hex1bColor.FromRgb(86, 156, 214);
@@ -175,25 +172,22 @@ public class TextDecorationTests
 
         // Cursor cell should have cursor colors, NOT decoration colors
         var cursorCell = snapshot.GetCell(0, 0);
-        Assert.True(ColorEquals(cursorFg, cursorCell.Foreground),
-            $"Cursor cell: expected cursor fg, got {cursorCell.Foreground}");
-        Assert.True(ColorEquals(cursorBg, cursorCell.Background),
-            $"Cursor cell: expected cursor bg, got {cursorCell.Background}");
+        Assert.IsTrue(ColorEquals(cursorFg, cursorCell.Foreground), $"Cursor cell: expected cursor fg, got {cursorCell.Foreground}");
+        Assert.IsTrue(ColorEquals(cursorBg, cursorCell.Background), $"Cursor cell: expected cursor bg, got {cursorCell.Background}");
 
         // Non-cursor decorated cells should have decoration color
         var expectedDecFg = ToCellColor(decorationColor);
         for (var x = 1; x <= 4; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(ColorEquals(expectedDecFg, cell.Foreground),
-                $"Column {x}: expected decoration fg {expectedDecFg}, got {cell.Foreground}");
+            Assert.IsTrue(ColorEquals(expectedDecFg, cell.Foreground), $"Column {x}: expected decoration fg {expectedDecFg}, got {cell.Foreground}");
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Decoration_MultipleProviders_HigherPriorityWins()
     {
         var lowColor = Hex1bColor.FromRgb(100, 100, 100); // gray
@@ -252,23 +246,21 @@ public class TextDecorationTests
         for (var x = 0; x <= 2; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(ColorEquals(expectedHigh, cell.Foreground),
-                $"Column {x}: expected high priority fg {expectedHigh}, got {cell.Foreground}");
+            Assert.IsTrue(ColorEquals(expectedHigh, cell.Foreground), $"Column {x}: expected high priority fg {expectedHigh}, got {cell.Foreground}");
         }
 
         // Columns 3-4 ("lo") should have low priority gray
         for (var x = 3; x <= 4; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(ColorEquals(expectedLow, cell.Foreground),
-                $"Column {x}: expected low priority fg {expectedLow}, got {cell.Foreground}");
+            Assert.IsTrue(ColorEquals(expectedLow, cell.Foreground), $"Column {x}: expected low priority fg {expectedLow}, got {cell.Foreground}");
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Decoration_ThemeElement_ResolvesFromTheme()
     {
         var provider = new StaticDecorationProvider([
@@ -295,15 +287,14 @@ public class TextDecorationTests
         for (var x = 0; x <= 4; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(ColorEquals(expectedFg, cell.Foreground),
-                $"Column {x}: expected keyword fg {expectedFg}, got {cell.Foreground}");
+            Assert.IsTrue(ColorEquals(expectedFg, cell.Foreground), $"Column {x}: expected keyword fg {expectedFg}, got {cell.Foreground}");
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Decoration_MultiLine_DecoratesAcrossLines()
     {
         var color = Hex1bColor.FromRgb(206, 145, 120); // string brown
@@ -331,28 +322,26 @@ public class TextDecorationTests
         var editorFg = ToCellColor(theme.Get(EditorTheme.ForegroundColor));
 
         // Line 1: column 0 ('a') = no decoration, columns 1-4 ('bcde') = decorated
-        Assert.True(ColorEquals(editorFg, snapshot.GetCell(0, 0).Foreground), "Line 1 col 0 should be editor fg");
+        Assert.IsTrue(ColorEquals(editorFg, snapshot.GetCell(0, 0).Foreground), "Line 1 col 0 should be editor fg");
         for (var x = 1; x <= 4; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(ColorEquals(expectedFg, cell.Foreground),
-                $"Line 1 col {x}: expected decoration fg, got {cell.Foreground}");
+            Assert.IsTrue(ColorEquals(expectedFg, cell.Foreground), $"Line 1 col {x}: expected decoration fg, got {cell.Foreground}");
         }
 
         // Line 2: columns 0-2 ('fgh') = decorated, columns 3-4 ('ij') = no decoration
         for (var x = 0; x <= 2; x++)
         {
             var cell = snapshot.GetCell(x, 1);
-            Assert.True(ColorEquals(expectedFg, cell.Foreground),
-                $"Line 2 col {x}: expected decoration fg, got {cell.Foreground}");
+            Assert.IsTrue(ColorEquals(expectedFg, cell.Foreground), $"Line 2 col {x}: expected decoration fg, got {cell.Foreground}");
         }
-        Assert.True(ColorEquals(editorFg, snapshot.GetCell(3, 1).Foreground), "Line 2 col 3 should be editor fg");
+        Assert.IsTrue(ColorEquals(editorFg, snapshot.GetCell(3, 1).Foreground), "Line 2 col 3 should be editor fg");
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Decoration_NoDecorations_RendersSameAsWithout()
     {
         // Empty provider should render identically to no provider
@@ -375,17 +364,15 @@ public class TextDecorationTests
         for (var x = 0; x <= 10; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(ColorEquals(editorFg, cell.Foreground),
-                $"Column {x}: expected editor fg, got {cell.Foreground}");
-            Assert.True(ColorEquals(editorBg, cell.Background),
-                $"Column {x}: expected editor bg, got {cell.Background}");
+            Assert.IsTrue(ColorEquals(editorFg, cell.Foreground), $"Column {x}: expected editor fg, got {cell.Foreground}");
+            Assert.IsTrue(ColorEquals(editorBg, cell.Background), $"Column {x}: expected editor bg, got {cell.Background}");
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Decoration_ForegroundAndBackground_BothApplied()
     {
         var fgColor = Hex1bColor.FromRgb(255, 255, 0);  // yellow
@@ -417,10 +404,8 @@ public class TextDecorationTests
         for (var x = 0; x <= 2; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(ColorEquals(expectedFg, cell.Foreground),
-                $"Column {x}: expected fg {expectedFg}, got {cell.Foreground}");
-            Assert.True(ColorEquals(expectedBg, cell.Background),
-                $"Column {x}: expected bg {expectedBg}, got {cell.Background}");
+            Assert.IsTrue(ColorEquals(expectedFg, cell.Foreground), $"Column {x}: expected fg {expectedFg}, got {cell.Foreground}");
+            Assert.IsTrue(ColorEquals(expectedBg, cell.Background), $"Column {x}: expected bg {expectedBg}, got {cell.Background}");
         }
 
         workload.Dispose();

--- a/tests/Hex1b.Tests/TextDecorationUnderlineTests.cs
+++ b/tests/Hex1b.Tests/TextDecorationUnderlineTests.cs
@@ -9,6 +9,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for underline decoration rendering and terminal capability fallback.
 /// </summary>
+[TestClass]
 public class TextDecorationUnderlineTests
 {
     private static Hex1bColor? ToCellColor(Hex1bColor color) => color.IsDefault ? null : color;
@@ -44,7 +45,7 @@ public class TextDecorationUnderlineTests
         return (node, workload, terminal, context, theme);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Decoration_CurlyUnderline_AppliedToDecoratedCells()
     {
         var ulColor = Hex1bColor.FromRgb(255, 0, 0); // red error underline
@@ -76,20 +77,19 @@ public class TextDecorationUnderlineTests
         for (var x = 0; x <= 2; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.Equal(UnderlineStyle.Curly, cell.UnderlineStyle);
-            Assert.True(ColorEquals(ToCellColor(ulColor), cell.UnderlineColor),
-                $"Column {x}: expected underline color {ulColor}, got {cell.UnderlineColor}");
+            Assert.AreEqual(UnderlineStyle.Curly, cell.UnderlineStyle);
+            Assert.IsTrue(ColorEquals(ToCellColor(ulColor), cell.UnderlineColor), $"Column {x}: expected underline color {ulColor}, got {cell.UnderlineColor}");
         }
 
         // Column 4 ("o") should not have underline
         var normalCell = snapshot.GetCell(4, 0);
-        Assert.Equal(UnderlineStyle.None, normalCell.UnderlineStyle);
+        Assert.AreEqual(UnderlineStyle.None, normalCell.UnderlineStyle);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Decoration_SingleUnderline_AppliedToDecoratedCells()
     {
         var provider = new StaticDecorationProvider([
@@ -116,17 +116,17 @@ public class TextDecorationUnderlineTests
         for (var x = 0; x <= 2; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(cell.IsUnderline, $"Column {x}: expected underline");
+            Assert.IsTrue(cell.IsUnderline, $"Column {x}: expected underline");
         }
 
         // " " at column 3 should not be underlined
-        Assert.False(snapshot.GetCell(3, 0).IsUnderline);
+        Assert.IsFalse(snapshot.GetCell(3, 0).IsUnderline);
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Decoration_UnderlineWithForeground_BothApplied()
     {
         var fgColor = Hex1bColor.FromRgb(86, 156, 214);
@@ -159,18 +159,16 @@ public class TextDecorationUnderlineTests
         for (var x = 0; x <= 2; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(ColorEquals(ToCellColor(fgColor), cell.Foreground),
-                $"Column {x}: expected fg {fgColor}, got {cell.Foreground}");
-            Assert.Equal(UnderlineStyle.Curly, cell.UnderlineStyle);
-            Assert.True(ColorEquals(ToCellColor(ulColor), cell.UnderlineColor),
-                $"Column {x}: expected underline color {ulColor}, got {cell.UnderlineColor}");
+            Assert.IsTrue(ColorEquals(ToCellColor(fgColor), cell.Foreground), $"Column {x}: expected fg {fgColor}, got {cell.Foreground}");
+            Assert.AreEqual(UnderlineStyle.Curly, cell.UnderlineStyle);
+            Assert.IsTrue(ColorEquals(ToCellColor(ulColor), cell.UnderlineColor), $"Column {x}: expected underline color {ulColor}, got {cell.UnderlineColor}");
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Decoration_UnderlineColorThemeElement_ResolvesFromTheme()
     {
         var provider = new StaticDecorationProvider([
@@ -201,16 +199,15 @@ public class TextDecorationUnderlineTests
         for (var x = 0; x <= 4; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.Equal(UnderlineStyle.Curly, cell.UnderlineStyle);
-            Assert.True(ColorEquals(expectedUlColor, cell.UnderlineColor),
-                $"Column {x}: expected underline color {expectedUlColor}, got {cell.UnderlineColor}");
+            Assert.AreEqual(UnderlineStyle.Curly, cell.UnderlineStyle);
+            Assert.IsTrue(ColorEquals(expectedUlColor, cell.UnderlineColor), $"Column {x}: expected underline color {expectedUlColor}, got {cell.UnderlineColor}");
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Decoration_DottedUnderline_AppliedCorrectly()
     {
         var provider = new StaticDecorationProvider([
@@ -236,14 +233,14 @@ public class TextDecorationUnderlineTests
         for (var x = 0; x <= 3; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.Equal(UnderlineStyle.Dotted, cell.UnderlineStyle);
+            Assert.AreEqual(UnderlineStyle.Dotted, cell.UnderlineStyle);
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Decoration_DashedUnderline_AppliedCorrectly()
     {
         var provider = new StaticDecorationProvider([
@@ -269,14 +266,14 @@ public class TextDecorationUnderlineTests
         for (var x = 0; x <= 3; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.Equal(UnderlineStyle.Dashed, cell.UnderlineStyle);
+            Assert.AreEqual(UnderlineStyle.Dashed, cell.UnderlineStyle);
         }
 
         workload.Dispose();
         terminal.Dispose();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Decoration_FallbackToSingleUnderline_WhenStyledUnsupported()
     {
         var provider = new StaticDecorationProvider([
@@ -305,7 +302,7 @@ public class TextDecorationUnderlineTests
         for (var x = 0; x <= 2; x++)
         {
             var cell = snapshot.GetCell(x, 0);
-            Assert.True(cell.IsUnderline, $"Column {x}: expected underline (fallback from curly to single)");
+            Assert.IsTrue(cell.IsUnderline, $"Column {x}: expected underline (fallback from curly to single)");
         }
 
         workload.Dispose();

--- a/tests/Hex1b.Tests/TextEditorMultiByteTests.cs
+++ b/tests/Hex1b.Tests/TextEditorMultiByteTests.cs
@@ -9,9 +9,10 @@ namespace Hex1b.Tests;
 /// Unicode characters (surrogate pairs, combining marks, etc.).
 /// Verifies grapheme-wise cursor movement and correct rendering without U+FFFD corruption.
 /// </summary>
+[TestClass]
 public class TextEditorMultiByteTests
 {
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Right_SkipsOverSurrogatePair()
     {
         // 😀 is U+1F600 — a surrogate pair (2 C# chars)
@@ -19,22 +20,22 @@ public class TextEditorMultiByteTests
         var state = new EditorState(doc);
 
         // Cursor starts at 0 ('A')
-        Assert.Equal(0, state.Cursor.Position.Value);
+        Assert.AreEqual(0, state.Cursor.Position.Value);
 
         // Move right: should land after 'A', before 😀
         state.MoveCursor(CursorDirection.Right);
-        Assert.Equal(1, state.Cursor.Position.Value);
+        Assert.AreEqual(1, state.Cursor.Position.Value);
 
         // Move right: should skip the entire surrogate pair (2 C# chars), land after 😀
         state.MoveCursor(CursorDirection.Right);
-        Assert.Equal(3, state.Cursor.Position.Value); // 1 + 2 (surrogate pair length)
+        Assert.AreEqual(3, state.Cursor.Position.Value); // 1 + 2 (surrogate pair length)
 
         // Move right: should land after 'B'
         state.MoveCursor(CursorDirection.Right);
-        Assert.Equal(4, state.Cursor.Position.Value);
+        Assert.AreEqual(4, state.Cursor.Position.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Left_SkipsOverSurrogatePair()
     {
         var doc = new Hex1bDocument("A😀B");
@@ -42,22 +43,22 @@ public class TextEditorMultiByteTests
 
         // Start at end
         state.Cursor.Position = new DocumentOffset(doc.Length); // 4
-        Assert.Equal(4, state.Cursor.Position.Value);
+        Assert.AreEqual(4, state.Cursor.Position.Value);
 
         // Move left: land before 'B'
         state.MoveCursor(CursorDirection.Left);
-        Assert.Equal(3, state.Cursor.Position.Value);
+        Assert.AreEqual(3, state.Cursor.Position.Value);
 
         // Move left: skip entire surrogate pair, land before 😀
         state.MoveCursor(CursorDirection.Left);
-        Assert.Equal(1, state.Cursor.Position.Value);
+        Assert.AreEqual(1, state.Cursor.Position.Value);
 
         // Move left: land at start
         state.MoveCursor(CursorDirection.Left);
-        Assert.Equal(0, state.Cursor.Position.Value);
+        Assert.AreEqual(0, state.Cursor.Position.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Right_HandlesAccentedCharacters()
     {
         // 'é' (U+00E9) is a single C# char (2 UTF-8 bytes but 1 UTF-16 code unit)
@@ -65,32 +66,32 @@ public class TextEditorMultiByteTests
         var state = new EditorState(doc);
 
         state.MoveCursor(CursorDirection.Right); // c
-        Assert.Equal(1, state.Cursor.Position.Value);
+        Assert.AreEqual(1, state.Cursor.Position.Value);
         state.MoveCursor(CursorDirection.Right); // a
-        Assert.Equal(2, state.Cursor.Position.Value);
+        Assert.AreEqual(2, state.Cursor.Position.Value);
         state.MoveCursor(CursorDirection.Right); // f
-        Assert.Equal(3, state.Cursor.Position.Value);
+        Assert.AreEqual(3, state.Cursor.Position.Value);
         state.MoveCursor(CursorDirection.Right); // é
-        Assert.Equal(4, state.Cursor.Position.Value);
+        Assert.AreEqual(4, state.Cursor.Position.Value);
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_Right_HandlesMultipleEmoji()
     {
         // Two emoji, each a surrogate pair (2 C# chars each)
         var doc = new Hex1bDocument("🚀🎉");
         var state = new EditorState(doc);
 
-        Assert.Equal(0, state.Cursor.Position.Value);
+        Assert.AreEqual(0, state.Cursor.Position.Value);
 
         state.MoveCursor(CursorDirection.Right);
-        Assert.Equal(2, state.Cursor.Position.Value); // past first emoji
+        Assert.AreEqual(2, state.Cursor.Position.Value); // past first emoji
 
         state.MoveCursor(CursorDirection.Right);
-        Assert.Equal(4, state.Cursor.Position.Value); // past second emoji
+        Assert.AreEqual(4, state.Cursor.Position.Value); // past second emoji
     }
 
-    [Fact]
+    [TestMethod]
     public void MoveCursor_DoesNotLandInsideSurrogatePair()
     {
         // "X😀Y" — moving right from X should never land at position 2 (inside the surrogate pair)
@@ -113,7 +114,7 @@ public class TextEditorMultiByteTests
         Assert.Contains(4, positions);
     }
 
-    [Fact]
+    [TestMethod]
     public void SelectRight_OverSurrogatePair_SelectsWholeCharacter()
     {
         var doc = new Hex1bDocument("A😀B");
@@ -121,21 +122,21 @@ public class TextEditorMultiByteTests
 
         // Move to position 1 (before 😀)
         state.MoveCursor(CursorDirection.Right);
-        Assert.Equal(1, state.Cursor.Position.Value);
+        Assert.AreEqual(1, state.Cursor.Position.Value);
 
         // Select right — should select the entire emoji
         state.MoveCursor(CursorDirection.Right, extend: true);
-        Assert.Equal(3, state.Cursor.Position.Value);
-        Assert.True(state.Cursor.HasSelection);
-        Assert.Equal(1, state.Cursor.SelectionStart.Value);
-        Assert.Equal(3, state.Cursor.SelectionEnd.Value);
+        Assert.AreEqual(3, state.Cursor.Position.Value);
+        Assert.IsTrue(state.Cursor.HasSelection);
+        Assert.AreEqual(1, state.Cursor.SelectionStart.Value);
+        Assert.AreEqual(3, state.Cursor.SelectionEnd.Value);
 
         // The selected text should be the emoji, not a broken surrogate
         var selectedText = doc.GetText(new DocumentRange(state.Cursor.SelectionStart, state.Cursor.SelectionEnd));
-        Assert.Equal("😀", selectedText);
+        Assert.AreEqual("😀", selectedText);
     }
 
-    [Fact]
+    [TestMethod]
     public void HexEditorNavigation_AfterViewSwitch_WorksCorrectly()
     {
         // Simulates switching from text to hex view — ByteCursorOffset should be null
@@ -145,15 +146,15 @@ public class TextEditorMultiByteTests
 
         // Move right in text mode (clears ByteCursorOffset)
         state.MoveCursor(CursorDirection.Right);
-        Assert.Null(state.ByteCursorOffset);
-        Assert.Equal(1, state.Cursor.Position.Value);
+        Assert.IsNull(state.ByteCursorOffset);
+        Assert.AreEqual(1, state.Cursor.Position.Value);
 
         // Now simulate hex navigation — HandleNavigation should work
         var hexRenderer = new HexEditorViewRenderer();
         var handled = hexRenderer.HandleNavigation(CursorDirection.Right, state, extend: false, 80);
-        Assert.True(handled);
+        Assert.IsTrue(handled);
 
         // ByteCursorOffset should now be set
-        Assert.NotNull(state.ByteCursorOffset);
+        Assert.IsNotNull(state.ByteCursorOffset);
     }
 }

--- a/tests/Hex1b.Tests/ThemePanelIntegrationTests.cs
+++ b/tests/Hex1b.Tests/ThemePanelIntegrationTests.cs
@@ -14,6 +14,7 @@ namespace Hex1b.Tests;
 /// 
 /// Test outputs include SVG, HTML, and ANSI evidence files for visual verification.
 /// </summary>
+[TestClass]
 public class ThemePanelIntegrationTests : IDisposable
 {
     private readonly List<string> _tempFiles = new();
@@ -39,7 +40,7 @@ public class ThemePanelIntegrationTests : IDisposable
     /// Verifies that button theme customizations inside ThemePanel are applied,
     /// while buttons outside remain with default styling.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanel_ScopesButtonColors_OnlyInsidePanel()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -80,14 +81,13 @@ public class ThemePanelIntegrationTests : IDisposable
         await runTask;
 
         // The themed button should have the custom blue background
-        Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(0, 100, 200)),
-            "Themed button should have blue background");
+        Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(0, 100, 200)), "Themed button should have blue background");
     }
 
     /// <summary>
     /// Verifies focused button appearance is correctly themed inside ThemePanel.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanel_AppliesFocusedButtonTheme()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -118,8 +118,7 @@ public class ThemePanelIntegrationTests : IDisposable
         await runTask;
 
         // The focused button should have red background (custom focused color)
-        Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 0, 0)),
-            "Focused button inside ThemePanel should have red background");
+        Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 0, 0)), "Focused button inside ThemePanel should have red background");
     }
 
     #endregion
@@ -129,7 +128,7 @@ public class ThemePanelIntegrationTests : IDisposable
     /// <summary>
     /// Verifies TextBox cursor and selection colors are themed inside ThemePanel.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanel_ScopesTextBoxColors()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -164,8 +163,7 @@ public class ThemePanelIntegrationTests : IDisposable
 
         // Line caret: cursor colors are not rendered as part of the text output.
         // The native terminal cursor handles the caret. Verify textbox content is visible.
-        Assert.True(snapshot.ContainsText("Themed Cursor"),
-            "Themed TextBox content should be visible");
+        Assert.IsTrue(snapshot.ContainsText("Themed Cursor"), "Themed TextBox content should be visible");
     }
 
     #endregion
@@ -175,7 +173,7 @@ public class ThemePanelIntegrationTests : IDisposable
     /// <summary>
     /// Verifies List selection colors are themed inside ThemePanel.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanel_ScopesListColors()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -211,8 +209,7 @@ public class ThemePanelIntegrationTests : IDisposable
         await runTask;
 
         // The selected list item should have green background
-        Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(0, 200, 0)),
-            "Selected list item inside ThemePanel should have green background");
+        Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(0, 200, 0)), "Selected list item inside ThemePanel should have green background");
     }
 
     #endregion
@@ -222,7 +219,7 @@ public class ThemePanelIntegrationTests : IDisposable
     /// <summary>
     /// Verifies Border colors are themed inside ThemePanel.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanel_ScopesBorderColors()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -256,8 +253,7 @@ public class ThemePanelIntegrationTests : IDisposable
         await runTask;
 
         // Should have both default gray and themed orange borders
-        Assert.True(snapshot.HasForegroundColor(Hex1bColor.FromRgb(255, 165, 0)),
-            "Themed border should have orange color");
+        Assert.IsTrue(snapshot.HasForegroundColor(Hex1bColor.FromRgb(255, 165, 0)), "Themed border should have orange color");
     }
 
     #endregion
@@ -267,7 +263,7 @@ public class ThemePanelIntegrationTests : IDisposable
     /// <summary>
     /// Verifies Progress bar colors are themed inside ThemePanel.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanel_ScopesProgressColors()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -305,8 +301,7 @@ public class ThemePanelIntegrationTests : IDisposable
         await runTask;
 
         // The themed progress should have green filled color
-        Assert.True(snapshot.HasForegroundColor(Hex1bColor.FromRgb(0, 255, 0)),
-            "Themed progress bar should have green filled color");
+        Assert.IsTrue(snapshot.HasForegroundColor(Hex1bColor.FromRgb(0, 255, 0)), "Themed progress bar should have green filled color");
     }
 
     #endregion
@@ -316,7 +311,7 @@ public class ThemePanelIntegrationTests : IDisposable
     /// <summary>
     /// Verifies that nested ThemePanels apply their themes cumulatively.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanel_NestedPanels_ApplyThemesCumulatively()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -357,17 +352,15 @@ public class ThemePanelIntegrationTests : IDisposable
         await runTask;
 
         // Should have both blue and red buttons
-        Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(0, 0, 200)),
-            "Outer ThemePanel buttons should be blue");
-        Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(200, 0, 0)),
-            "Inner ThemePanel button should be red");
+        Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(0, 0, 200)), "Outer ThemePanel buttons should be blue");
+        Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(200, 0, 0)), "Inner ThemePanel button should be red");
     }
 
     /// <summary>
     /// Verifies nested ThemePanels work exactly as shown in the documentation example.
     /// This matches themepanel-nested.cs snippet: outer cyan text, inner yellow text, back to cyan.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanel_NestedDocExample_CyanYellowCyan()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -416,36 +409,33 @@ public class ThemePanelIntegrationTests : IDisposable
                 outerLine2 = y;
         }
 
-        Assert.NotNull(outerLine1);
-        Assert.NotNull(innerLine);
-        Assert.NotNull(outerLine2);
+        Assert.IsNotNull(outerLine1);
+        Assert.IsNotNull(innerLine);
+        Assert.IsNotNull(outerLine2);
 
         // Check the foreground colors on the first character of each text line
         // Find where "Outer" starts on each line
         var line1 = snapshot.GetLine(outerLine1.Value);
         var col1 = line1.IndexOf("Outer");
         var cell1 = snapshot.GetCell(col1, outerLine1.Value);
-        Assert.True(cell1.Foreground is not null && cell1.Foreground.Value.R == 0 && cell1.Foreground.Value.G == 255 && cell1.Foreground.Value.B == 255,
-            $"First 'Outer theme - Cyan' should have cyan foreground, got {cell1.Foreground}");
+        Assert.IsTrue(cell1.Foreground is not null && cell1.Foreground.Value.R == 0 && cell1.Foreground.Value.G == 255 && cell1.Foreground.Value.B == 255, $"First 'Outer theme - Cyan' should have cyan foreground, got {cell1.Foreground}");
 
         var lineInner = snapshot.GetLine(innerLine.Value);
         var colInner = lineInner.IndexOf("Inner");
         var cellInner = snapshot.GetCell(colInner, innerLine.Value);
-        Assert.True(cellInner.Foreground is not null && cellInner.Foreground.Value.R == 255 && cellInner.Foreground.Value.G == 255 && cellInner.Foreground.Value.B == 0,
-            $"'Inner theme - Yellow' should have yellow foreground, got {cellInner.Foreground}");
+        Assert.IsTrue(cellInner.Foreground is not null && cellInner.Foreground.Value.R == 255 && cellInner.Foreground.Value.G == 255 && cellInner.Foreground.Value.B == 0, $"'Inner theme - Yellow' should have yellow foreground, got {cellInner.Foreground}");
 
         var line2 = snapshot.GetLine(outerLine2.Value);
         var col2 = line2.IndexOf("Back");
         var cell2 = snapshot.GetCell(col2, outerLine2.Value);
-        Assert.True(cell2.Foreground is not null && cell2.Foreground.Value.R == 0 && cell2.Foreground.Value.G == 255 && cell2.Foreground.Value.B == 255,
-            $"'Back to outer - Cyan' should have cyan foreground, got {cell2.Foreground}");
+        Assert.IsTrue(cell2.Foreground is not null && cell2.Foreground.Value.R == 0 && cell2.Foreground.Value.G == 255 && cell2.Foreground.Value.B == 255, $"'Back to outer - Cyan' should have cyan foreground, got {cell2.Foreground}");
     }
 
     /// <summary>
     /// Verifies nested ThemePanels can combine themes (cumulative inheritance).
     /// This matches themepanel-nesting.cs snippet: outer sets foreground cyan, inner adds background.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanel_NestedDocExample_CumulativeThemes()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -492,32 +482,28 @@ public class ThemePanelIntegrationTests : IDisposable
                 outerLine2 = y;
         }
 
-        Assert.NotNull(outerLine1);
-        Assert.NotNull(combinedLine);
-        Assert.NotNull(outerLine2);
+        Assert.IsNotNull(outerLine1);
+        Assert.IsNotNull(combinedLine);
+        Assert.IsNotNull(outerLine2);
 
         // Check colors on the text cells
         var line1 = snapshot.GetLine(outerLine1.Value);
         var col1 = line1.IndexOf("Outer");
         var cell1 = snapshot.GetCell(col1, outerLine1.Value);
-        Assert.True(cell1.Foreground is not null && cell1.Foreground.Value.R == 0 && cell1.Foreground.Value.G == 255 && cell1.Foreground.Value.B == 255,
-            $"First outer row should have cyan foreground, got {cell1.Foreground}");
+        Assert.IsTrue(cell1.Foreground is not null && cell1.Foreground.Value.R == 0 && cell1.Foreground.Value.G == 255 && cell1.Foreground.Value.B == 255, $"First outer row should have cyan foreground, got {cell1.Foreground}");
 
         var lineCombined = snapshot.GetLine(combinedLine.Value);
         var colCombined = lineCombined.IndexOf("Both");
         var cellCombined = snapshot.GetCell(colCombined, combinedLine.Value);
         // Combined row should have cyan foreground inherited from outer
-        Assert.True(cellCombined.Foreground is not null && cellCombined.Foreground.Value.R == 0 && cellCombined.Foreground.Value.G == 255 && cellCombined.Foreground.Value.B == 255,
-            $"Combined row should inherit cyan foreground from outer, got {cellCombined.Foreground}");
+        Assert.IsTrue(cellCombined.Foreground is not null && cellCombined.Foreground.Value.R == 0 && cellCombined.Foreground.Value.G == 255 && cellCombined.Foreground.Value.B == 255, $"Combined row should inherit cyan foreground from outer, got {cellCombined.Foreground}");
         // Combined row should have dark blue background from inner
-        Assert.True(cellCombined.Background is not null && cellCombined.Background.Value.R == 0 && cellCombined.Background.Value.G == 0 && cellCombined.Background.Value.B == 139,
-            $"Combined row should have dark blue background from inner ThemePanel, got {cellCombined.Background}");
+        Assert.IsTrue(cellCombined.Background is not null && cellCombined.Background.Value.R == 0 && cellCombined.Background.Value.G == 0 && cellCombined.Background.Value.B == 139, $"Combined row should have dark blue background from inner ThemePanel, got {cellCombined.Background}");
 
         var line2 = snapshot.GetLine(outerLine2.Value);
         var col2 = line2.IndexOf("Only");
         var cell2 = snapshot.GetCell(col2, outerLine2.Value);
-        Assert.True(cell2.Foreground is not null && cell2.Foreground.Value.R == 0 && cell2.Foreground.Value.G == 255 && cell2.Foreground.Value.B == 255,
-            $"Second outer row should have cyan foreground, got {cell2.Foreground}");
+        Assert.IsTrue(cell2.Foreground is not null && cell2.Foreground.Value.R == 0 && cell2.Foreground.Value.G == 255 && cell2.Foreground.Value.B == 255, $"Second outer row should have cyan foreground, got {cell2.Foreground}");
     }
 
     #endregion
@@ -527,7 +513,7 @@ public class ThemePanelIntegrationTests : IDisposable
     /// <summary>
     /// Verifies ThemePanel works correctly inside VStack.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanel_InsideVStack_AppliesTheme()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -558,14 +544,13 @@ public class ThemePanelIntegrationTests : IDisposable
 
         await runTask;
 
-        Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(128, 0, 128)),
-            "ThemePanel button should have purple background");
+        Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(128, 0, 128)), "ThemePanel button should have purple background");
     }
 
     /// <summary>
     /// Verifies ThemePanel works correctly inside HStack.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanel_InsideHStack_AppliesTheme()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -598,14 +583,13 @@ public class ThemePanelIntegrationTests : IDisposable
 
         await runTask;
 
-        Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(0, 128, 0)),
-            "ThemePanel button should have green background");
+        Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(0, 128, 0)), "ThemePanel button should have green background");
     }
 
     /// <summary>
     /// Verifies ThemePanel works correctly inside Border.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanel_InsideBorder_AppliesTheme()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -637,14 +621,13 @@ public class ThemePanelIntegrationTests : IDisposable
 
         await runTask;
 
-        Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 128, 0)),
-            "ThemePanel button inside border should have orange background");
+        Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 128, 0)), "ThemePanel button inside border should have orange background");
     }
 
     /// <summary>
     /// Verifies ThemePanel works correctly inside VScroll container.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanel_InsideVScroll_AppliesTheme()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -679,14 +662,13 @@ public class ThemePanelIntegrationTests : IDisposable
 
         await runTask;
 
-        Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(0, 200, 200)),
-            "ThemePanel buttons inside scroll should have cyan background");
+        Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(0, 200, 200)), "ThemePanel buttons inside scroll should have cyan background");
     }
 
     /// <summary>
     /// Verifies ThemePanel works correctly inside Splitter.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanel_InsideSplitter_AppliesTheme()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -728,8 +710,7 @@ public class ThemePanelIntegrationTests : IDisposable
         await runTask;
 
         // The left button is focused, so it should have magenta FocusedBackgroundColor
-        Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(200, 0, 200)),
-            "Left pane button should have magenta focused background");
+        Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(200, 0, 200)), "Left pane button should have magenta focused background");
         // Right pane button is NOT focused, so we can't assert on BackgroundColor
         // as unfocused buttons don't show background by default
     }
@@ -741,7 +722,7 @@ public class ThemePanelIntegrationTests : IDisposable
     /// <summary>
     /// Verifies that a cached theme can be used with ThemePanel.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanel_WithCachedTheme_WorksCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -777,8 +758,7 @@ public class ThemePanelIntegrationTests : IDisposable
 
         await runTask;
 
-        Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(30, 60, 120)),
-            "Buttons should use cached theme's blue background");
+        Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(30, 60, 120)), "Buttons should use cached theme's blue background");
     }
 
     /// <summary>
@@ -788,7 +768,7 @@ public class ThemePanelIntegrationTests : IDisposable
     /// This test is currently flaky when run with other tests due to what appears
     /// to be a test isolation issue. It passes reliably when run in isolation.
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanel_PassthroughTheme_HasNoEffect()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -817,8 +797,7 @@ public class ThemePanelIntegrationTests : IDisposable
         await runTask;
 
         // Default focused button is white background
-        Assert.True(snapshot.HasBackgroundColor(Hex1bColor.White),
-            "Button with passthrough theme should use default styling");
+        Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.White), "Button with passthrough theme should use default styling");
     }
 
     #endregion
@@ -836,11 +815,11 @@ public class ThemePanelIntegrationTests : IDisposable
     /// <summary>
     /// Verifies ThemePanel works correctly at various terminal widths.
     /// </summary>
-    [Theory]
-    [InlineData(40)]
-    [InlineData(60)]
-    [InlineData(80)]
-    [InlineData(120)]
+    [TestMethod]
+    [DataRow(40)]
+    [DataRow(60)]
+    [DataRow(80)]
+    [DataRow(120)]
     public async Task ThemePanel_RespondsToTerminalWidth(int width)
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -870,8 +849,7 @@ public class ThemePanelIntegrationTests : IDisposable
 
         await runTask;
 
-        Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(0, 128, 255)),
-            $"ThemePanel button should have blue background at width {width}");
+        Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(0, 128, 255)), $"ThemePanel button should have blue background at width {width}");
     }
 
     #endregion
@@ -881,7 +859,7 @@ public class ThemePanelIntegrationTests : IDisposable
     /// <summary>
     /// Records an asciinema demonstration of ThemePanel scope boundaries.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanel_RecordsScopeBoundaryDemo()
     {
         var tempFile = GetTempFile();
@@ -964,7 +942,7 @@ public class ThemePanelIntegrationTests : IDisposable
     /// <summary>
     /// Records an asciinema demonstration of nested ThemePanels.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanel_RecordsNestedPanelDemo()
     {
         var tempFile = GetTempFile();
@@ -1055,7 +1033,7 @@ public class ThemePanelIntegrationTests : IDisposable
     /// <summary>
     /// Demonstrates a realistic dashboard with themed sections.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanel_Dashboard_WithThemedSections()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1128,16 +1106,14 @@ public class ThemePanelIntegrationTests : IDisposable
         await runTask;
 
         // Verify multiple themed sections
-        Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(50, 50, 80)),
-            "Sidebar list should have dark purple selection");
-        Assert.True(snapshot.HasForegroundColor(Hex1bColor.FromRgb(100, 200, 100)),
-            "Header border should have green color");
+        Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(50, 50, 80)), "Sidebar list should have dark purple selection");
+        Assert.IsTrue(snapshot.HasForegroundColor(Hex1bColor.FromRgb(100, 200, 100)), "Header border should have green color");
     }
 
     /// <summary>
     /// Demonstrates a form with validation-themed fields.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ThemePanel_Form_WithValidationThemes()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1194,8 +1170,8 @@ public class ThemePanelIntegrationTests : IDisposable
 
         await runTask;
 
-        Assert.True(snapshot.ContainsText("valid_user"), "Form should contain valid username");
-        Assert.True(snapshot.ContainsText("invalid-email"), "Form should contain invalid email");
+        Assert.IsTrue(snapshot.ContainsText("valid_user"), "Form should contain valid username");
+        Assert.IsTrue(snapshot.ContainsText("invalid-email"), "Form should contain invalid email");
     }
 
     #endregion

--- a/tests/Hex1b.Tests/ThemePanelNodeTests.cs
+++ b/tests/Hex1b.Tests/ThemePanelNodeTests.cs
@@ -9,6 +9,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Unit tests for ThemePanelNode layout, rendering, and theme application.
 /// </summary>
+[TestClass]
 public class ThemePanelNodeTests
 {
     private static Hex1bRenderContext CreateContext(IHex1bAppTerminalWorkloadAdapter workload, Hex1bTheme? theme = null)
@@ -18,7 +19,7 @@ public class ThemePanelNodeTests
 
     #region Measure Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_ReturnsChildSize()
     {
         var child = new TextBlockNode { Text = "Hello World" };
@@ -31,22 +32,22 @@ public class ThemePanelNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // ThemePanel doesn't add any size - just passes through child size
-        Assert.Equal(11, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(11, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_WithNoChild_ReturnsZero()
     {
         var node = new ThemePanelNode { Child = null };
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(0, size.Width);
-        Assert.Equal(0, size.Height);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(0, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_RespectsConstraints()
     {
         var child = new TextBlockNode { Text = "This is a long text that should be constrained" };
@@ -58,11 +59,11 @@ public class ThemePanelNodeTests
 
         var size = node.Measure(new Constraints(0, 10, 0, 5));
 
-        Assert.True(size.Width <= 10);
-        Assert.True(size.Height <= 5);
+        Assert.IsTrue(size.Width <= 10);
+        Assert.IsTrue(size.Height <= 5);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_WithVStackChild_ReturnsCorrectSize()
     {
         var vstack = new VStackNode
@@ -78,15 +79,15 @@ public class ThemePanelNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(6, size.Width); // "Line X".Length
-        Assert.Equal(3, size.Height);
+        Assert.AreEqual(6, size.Width); // "Line X".Length
+        Assert.AreEqual(3, size.Height);
     }
 
     #endregion
 
     #region Arrange Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_ChildGetsFullBounds()
     {
         var child = new TextBlockNode { Text = "Test" };
@@ -97,10 +98,10 @@ public class ThemePanelNodeTests
         node.Arrange(bounds);
 
         // Child should have exact same bounds as ThemePanel
-        Assert.Equal(bounds, child.Bounds);
+        Assert.AreEqual(bounds, child.Bounds);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_SetsBounds()
     {
         var node = new ThemePanelNode 
@@ -112,26 +113,26 @@ public class ThemePanelNodeTests
 
         node.Arrange(bounds);
 
-        Assert.Equal(bounds, node.Bounds);
+        Assert.AreEqual(bounds, node.Bounds);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_WithNoChild_DoesNotThrow()
     {
         var node = new ThemePanelNode { Child = null };
         var bounds = new Rect(0, 0, 20, 5);
 
-        var exception = Record.Exception(() => node.Arrange(bounds));
+        var exception = TestSeq.RecordException(() => node.Arrange(bounds));
 
-        Assert.Null(exception);
-        Assert.Equal(bounds, node.Bounds);
+        Assert.IsNull(exception);
+        Assert.AreEqual(bounds, node.Bounds);
     }
 
     #endregion
 
     #region Render Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Render_RendersChildContent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -156,7 +157,7 @@ public class ThemePanelNodeTests
         Assert.Contains("ThemePanel Content", snapshot.GetScreenText());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_AppliesThemeMutation()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -187,12 +188,11 @@ public class ThemePanelNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(mutatedThemeCaptured, "ThemeMutator should be called during render");
-        Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 0, 0)),
-            "Button should have red background from mutated theme");
+        Assert.IsTrue(mutatedThemeCaptured, "ThemeMutator should be called during render");
+        Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 0, 0)), "Button should have red background from mutated theme");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_RestoresOriginalTheme()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -218,10 +218,10 @@ public class ThemePanelNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
         // After render, context.Theme should be restored to original
-        Assert.Same(originalTheme, context.Theme);
+        Assert.AreSame(originalTheme, context.Theme);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithNullMutator_RendersNormally()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -246,7 +246,7 @@ public class ThemePanelNodeTests
         Assert.Contains("No Mutator", snapshot.GetScreenText());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_WithNoChild_DoesNotThrow()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -255,12 +255,12 @@ public class ThemePanelNodeTests
 
         var node = new ThemePanelNode { Child = null, ThemeMutator = t => t };
 
-        var exception = Record.Exception(() => node.Render(context));
+        var exception = TestSeq.RecordException(() => node.Render(context));
 
-        Assert.Null(exception);
+        Assert.IsNull(exception);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_CachedTheme_IsUsed()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -286,15 +286,14 @@ public class ThemePanelNodeTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(0, 0, 255)),
-            "Button should use cached theme's blue background");
+        Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(0, 0, 255)), "Button should use cached theme's blue background");
     }
 
     #endregion
 
     #region Focus Tests
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_ReturnsFocusableChildren()
     {
         var button = new ButtonNode { Label = "Click" };
@@ -302,11 +301,11 @@ public class ThemePanelNodeTests
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Single(focusables);
+        TestSeq.Single(focusables);
         Assert.Contains(button, focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_WithNonFocusableChild_ReturnsEmpty()
     {
         var textBlock = new TextBlockNode { Text = "Not focusable" };
@@ -314,20 +313,20 @@ public class ThemePanelNodeTests
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Empty(focusables);
+        Assert.IsEmpty(focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_WithNoChild_ReturnsEmpty()
     {
         var node = new ThemePanelNode { Child = null };
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Empty(focusables);
+        Assert.IsEmpty(focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_WithNestedContainers_FindsAllFocusables()
     {
         var textBox = new TextBoxNode { State = new TextBoxState() };
@@ -340,24 +339,24 @@ public class ThemePanelNodeTests
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Equal(2, focusables.Count);
+        Assert.AreEqual(2, focusables.Count);
         Assert.Contains(textBox, focusables);
         Assert.Contains(button, focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task IsFocusable_ReturnsFalse()
     {
         var node = new ThemePanelNode();
 
-        Assert.False(node.IsFocusable);
+        Assert.IsFalse(node.IsFocusable);
     }
 
     #endregion
 
     #region GetChildren Tests
 
-    [Fact]
+    [TestMethod]
     public async Task GetChildren_ReturnsChild()
     {
         var child = new TextBlockNode { Text = "Child" };
@@ -365,25 +364,25 @@ public class ThemePanelNodeTests
 
         var children = node.GetChildren().ToList();
 
-        Assert.Single(children);
-        Assert.Same(child, children[0]);
+        TestSeq.Single(children);
+        Assert.AreSame(child, children[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetChildren_WithNoChild_ReturnsEmpty()
     {
         var node = new ThemePanelNode { Child = null };
 
         var children = node.GetChildren().ToList();
 
-        Assert.Empty(children);
+        Assert.IsEmpty(children);
     }
 
     #endregion
 
     #region Input Handling Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_PassesToChild()
     {
         var clicked = false;
@@ -409,25 +408,25 @@ public class ThemePanelNodeTests
             null, 
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.True(clicked);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsTrue(clicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_WithNoChild_ReturnsFalse()
     {
         var node = new ThemePanelNode { Child = null };
 
         var result = node.HandleInput(new Hex1bKeyEvent(Hex1bKey.A, 'A', Hex1bModifiers.None));
 
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
     }
 
     #endregion
 
     #region Reconciliation Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_CreatesNewNode_WhenNoExisting()
     {
         var widget = new ThemePanelWidget(t => t, new TextBlockWidget("Test"));
@@ -435,13 +434,13 @@ public class ThemePanelNodeTests
 
         var node = widget.ReconcileAsync(null, context).GetAwaiter().GetResult();
 
-        Assert.IsType<ThemePanelNode>(node);
+        TestSeq.IsType<ThemePanelNode>(node);
         var themePanelNode = (ThemePanelNode)node;
-        Assert.NotNull(themePanelNode.Child);
-        Assert.IsType<TextBlockNode>(themePanelNode.Child);
+        Assert.IsNotNull(themePanelNode.Child);
+        TestSeq.IsType<TextBlockNode>(themePanelNode.Child);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_ReusesExistingNode()
     {
         var existingNode = new ThemePanelNode 
@@ -454,10 +453,10 @@ public class ThemePanelNodeTests
 
         var node = widget.ReconcileAsync(existingNode, context).GetAwaiter().GetResult();
 
-        Assert.Same(existingNode, node);
+        Assert.AreSame(existingNode, node);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_UpdatesThemeMutator()
     {
         var existingNode = new ThemePanelNode 
@@ -471,10 +470,10 @@ public class ThemePanelNodeTests
 
         widget.ReconcileAsync(existingNode, context).GetAwaiter().GetResult();
 
-        Assert.Same(newMutator, existingNode.ThemeMutator);
+        Assert.AreSame(newMutator, existingNode.ThemeMutator);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_UpdatesChild()
     {
         var existingNode = new ThemePanelNode 
@@ -487,15 +486,15 @@ public class ThemePanelNodeTests
 
         widget.ReconcileAsync(existingNode, context).GetAwaiter().GetResult();
 
-        Assert.IsType<TextBlockNode>(existingNode.Child);
-        Assert.Equal("New", ((TextBlockNode)existingNode.Child!).Text);
+        TestSeq.IsType<TextBlockNode>(existingNode.Child);
+        Assert.AreEqual("New", ((TextBlockNode)existingNode.Child!).Text);
     }
 
     #endregion
 
     #region Nested ThemePanel Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Render_NestedThemePanels_ApplyThemesCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -533,8 +532,7 @@ public class ThemePanelNodeTests
             .Capture("final")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-        Assert.True(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 0, 0)),
-            "Inner button should have red background from inner ThemePanel");
+        Assert.IsTrue(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 0, 0)), "Inner button should have red background from inner ThemePanel");
     }
 
     #endregion

--- a/tests/Hex1b.Tests/ThemingExhibitRepro.cs
+++ b/tests/Hex1b.Tests/ThemingExhibitRepro.cs
@@ -10,6 +10,7 @@ namespace Hex1b.Tests;
 /// Tests to reproduce the issue where a TextBox shows as focused (with cursor)
 /// even when it doesn't have focus. This replicates the structure of the ThemingExhibit.
 /// </summary>
+[TestClass]
 public class ThemingExhibitRepro
 {
     /// <summary>
@@ -18,7 +19,7 @@ public class ThemingExhibitRepro
     ///   ├─ Panel (left) → VStack → List (has initial focus)
     ///   └─ Layout (right) → Panel → VStack → TextBox (should NOT show cursor)
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task TextBox_InSplitterRightPane_ShouldNotShowCursor_WhenListHasFocus()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -96,8 +97,7 @@ public class ThemingExhibitRepro
         // The cursor colors should NOT appear in the rendering output when TextBox is unfocused
         var hasCursorBg = snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 255, 255));
         
-        Assert.False(hasCursorBg, 
-            $"TextBox should NOT have cursor colors when unfocused.");
+        Assert.IsFalse(hasCursorBg, $"TextBox should NOT have cursor colors when unfocused.");
     }
 
     /// <summary>
@@ -107,7 +107,7 @@ public class ThemingExhibitRepro
     /// This test documents the issue - the actual fix is in ReconcileContext
     /// which now tracks the full ancestor chain.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void NodeParentLinks_NotSetDuringReconcile_ExplainsTheBug()
     {
         // This test demonstrates what was happening during reconciliation:
@@ -131,16 +131,16 @@ public class ThemingExhibitRepro
         //    would only see: nestedLayout -> null
         //    because nestedLayout.Parent hasn't been set yet!
         
-        Assert.Null(layout.Parent); // Demonstrates that Parent is not set during child reconcile
-        Assert.Null(nestedLayout.Parent);  // Same issue
+        Assert.IsNull(layout.Parent); // Demonstrates that Parent is not set during child reconcile
+        Assert.IsNull(nestedLayout.Parent);  // Same issue
         
         // After reconcile would complete, parents would be set:
         nestedLayout.Parent = layout;
         layout.Parent = splitter;
         
         // Now the tree is correct:
-        Assert.Equal(layout, nestedLayout.Parent);
-        Assert.Equal(splitter, layout.Parent);
+        Assert.AreEqual(layout, nestedLayout.Parent);
+        Assert.AreEqual(splitter, layout.Parent);
         
         // The FIX: ReconcileContext now stores the full ancestor chain internally,
         // so ParentManagesFocus() can traverse the full ancestry without relying on node.Parent.
@@ -150,7 +150,7 @@ public class ThemingExhibitRepro
     /// This test verifies the actual bug is fixed: when we use ParentManagesFocus(),
     /// it can traverse the full ancestry to find SplitterNode even during reconciliation.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void BugFixed_ParentManagesFocus_FindsSplitterThroughAncestorChain()
     {
         // The fix stores the full parent chain in ReconcileContext,
@@ -158,14 +158,14 @@ public class ThemingExhibitRepro
         // This is tested by the integration test 
         // TextBox_InSplitterRightPane_ShouldNotShowCursor_WhenListHasFocus
         
-        Assert.True(true, "See integration test for verification");
+        Assert.IsTrue(true, "See integration test for verification");
     }
 
     /// <summary>
     /// Verify that when a TextBox has focus (which it gets by default as the first focusable widget),
     /// the cursor colors are rendered. This test uses text-based waiting which is more reliable.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task TextBox_WhenNotFocused_ShouldNotRenderCursorColors()
     {
         // Arrange
@@ -202,15 +202,14 @@ public class ThemingExhibitRepro
         // Assert - The cursor background color (white) should NOT be present because TextBox doesn't have focus.
         // The List has focus, not the TextBox.
         var snapshot = terminal.CreateSnapshot();
-        Assert.False(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 255, 255)),
-            "TextBox should NOT have cursor colors when it doesn't have focus (List has focus)");
+        Assert.IsFalse(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 255, 255)), "TextBox should NOT have cursor colors when it doesn't have focus (List has focus)");
     }
 
     /// <summary>
     /// Verify that when a TextBox has focus, rendering DOES include cursor colors at the cursor position.
     /// Uses full Hex1bApp integration for reliable behavior.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task TextBox_WhenFocused_ShouldRenderCursorColors()
     {
         // Arrange
@@ -234,14 +233,14 @@ public class ThemingExhibitRepro
 
         // Assert - Line caret: text should be visible without block cursor highlighting.
         // The native terminal cursor (bar) handles the caret instead.
-        Assert.True(snapshot.ContainsText("test"), "TextBox content should be visible when focused");
+        Assert.IsTrue(snapshot.ContainsText("test"), "TextBox content should be visible when focused");
     }
 
     /// <summary>
     /// Full integration test: create the ThemingExhibit-like structure via Hex1bApp
     /// and verify focus is correctly assigned.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Integration_ThemingExhibitStructure_ListHasFocus_TextBoxDoesNot()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -319,7 +318,6 @@ public class ThemingExhibitRepro
         
         // The cursor background (white by default: 255,255,255) should NOT appear
         // if the TextBox is correctly unfocused
-        Assert.False(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 255, 255)),
-            $"TextBox should NOT render cursor colors when another widget (List) has focus.");
+        Assert.IsFalse(snapshot.HasBackgroundColor(Hex1bColor.FromRgb(255, 255, 255)), $"TextBox should NOT render cursor colors when another widget (List) has focus.");
     }
 }

--- a/tests/Hex1b.Tests/TileCacheTests.cs
+++ b/tests/Hex1b.Tests/TileCacheTests.cs
@@ -45,9 +45,10 @@ internal class SlowTileDataSource : ITileDataSource
     }
 }
 
+[TestClass]
 public class TileCacheTests
 {
-    [Fact]
+    [TestMethod]
     public void GetTiles_EmptyCache_ReturnsDefaultTiles()
     {
         var ds = new SlowTileDataSource(TimeSpan.FromSeconds(10));
@@ -60,12 +61,12 @@ public class TileCacheTests
         {
             for (int x = 0; x < 3; x++)
             {
-                Assert.Null(tiles[x, y].Content);
+                Assert.IsNull(tiles[x, y].Content);
             }
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void GetTiles_NeverBlocks()
     {
         var ds = new SlowTileDataSource(TimeSpan.FromSeconds(30));
@@ -76,10 +77,10 @@ public class TileCacheTests
         var tiles = cache.GetTiles(0, 0, 10, 10);
         sw.Stop();
 
-        Assert.True(sw.ElapsedMilliseconds < 100, $"GetTiles took {sw.ElapsedMilliseconds}ms — should be instant");
+        Assert.IsTrue(sw.ElapsedMilliseconds < 100, $"GetTiles took {sw.ElapsedMilliseconds}ms — should be instant");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetTiles_AfterBackgroundFetch_ReturnsCachedTiles()
     {
         var ds = new SlowTileDataSource(TimeSpan.FromMilliseconds(10));
@@ -93,14 +94,14 @@ public class TileCacheTests
 
         // Second call — should have cached tiles
         var tiles = cache.GetTiles(0, 0, 2, 2);
-        Assert.NotNull(tiles[0, 0].Content);
-        Assert.Equal("0,0", tiles[0, 0].Content);
-        Assert.Equal("1,0", tiles[1, 0].Content);
-        Assert.Equal("0,1", tiles[0, 1].Content);
-        Assert.Equal("1,1", tiles[1, 1].Content);
+        Assert.IsNotNull(tiles[0, 0].Content);
+        Assert.AreEqual("0,0", tiles[0, 0].Content);
+        Assert.AreEqual("1,0", tiles[1, 0].Content);
+        Assert.AreEqual("0,1", tiles[0, 1].Content);
+        Assert.AreEqual("1,1", tiles[1, 1].Content);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TilesAvailable_FiresAfterBackgroundFetch()
     {
         var ds = new SlowTileDataSource(TimeSpan.FromMilliseconds(10));
@@ -112,10 +113,10 @@ public class TileCacheTests
 
         // Notification fires immediately after fetch completes (no debounce)
         var completed = await Task.WhenAny(notified.Task, Task.Delay(500));
-        Assert.Same(notified.Task, completed);
+        Assert.AreSame(notified.Task, completed);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task CancelledFetch_StillCachesTiles()
     {
         var ds = new SlowTileDataSource(TimeSpan.FromMilliseconds(50));
@@ -136,13 +137,13 @@ public class TileCacheTests
 
         // Second region must be cached
         var tiles = cache.GetTiles(100, 100, 2, 2);
-        Assert.Equal("100", tiles[0, 0].Content);
+        Assert.AreEqual("100", tiles[0, 0].Content);
 
         // First region might also be cached (if data source returned before
         // cancellation was checked) — this is the key behavioral change
     }
 
-    [Fact]
+    [TestMethod]
     public async Task NewFetch_CancelsPreviousFetch()
     {
         var ds = new SlowTileDataSource(TimeSpan.FromMilliseconds(200));
@@ -160,10 +161,10 @@ public class TileCacheTests
 
         // Second region should be cached
         var tiles = cache.GetTiles(100, 100, 2, 2);
-        Assert.Equal("100", tiles[0, 0].Content);
+        Assert.AreEqual("100", tiles[0, 0].Content);
     }
 
-    [Fact]
+    [TestMethod]
     public void Clear_RemovesAllCachedTiles()
     {
         var ds = new TestTileDataSource();
@@ -177,26 +178,26 @@ public class TileCacheTests
 
         // Verify cached
         var tiles = cache.GetTiles(0, 0, 2, 2);
-        Assert.NotNull(tiles[0, 0].Content);
+        Assert.IsNotNull(tiles[0, 0].Content);
 
         // Clear
         cache.Clear();
 
         // Should be empty again
         tiles = cache.GetTiles(0, 0, 2, 2);
-        Assert.Null(tiles[0, 0].Content);
+        Assert.IsNull(tiles[0, 0].Content);
     }
 
-    [Fact]
+    [TestMethod]
     public void TileSize_DelegatesToDataSource()
     {
         var ds = new TestTileDataSource();
         using var cache = new TileCache(ds);
 
-        Assert.Equal(new Size(3, 1), cache.TileSize);
+        Assert.AreEqual(new Size(3, 1), cache.TileSize);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Eviction_RemovesLruTilesWhenOverCapacity()
     {
         var ds = new TestTileDataSource();
@@ -217,11 +218,10 @@ public class TileCacheTests
                 if (tiles[x, y].Content != null) cachedCount++;
 
         // Some tiles should have survived eviction (the 4 most recent)
-        Assert.True(cachedCount <= 4 || cachedCount == 9,
-            $"Expected ≤4 cached tiles after eviction or 9 if re-fetched, got {cachedCount}");
+        Assert.IsTrue(cachedCount <= 4 || cachedCount == 9, $"Expected ≤4 cached tiles after eviction or 9 if re-fetched, got {cachedCount}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RequestFetch_SameRegion_DoesNotCancelInFlight()
     {
         var ds = new SlowTileDataSource(TimeSpan.FromMilliseconds(100));
@@ -242,9 +242,9 @@ public class TileCacheTests
 
         // Tiles should be cached — the repeated calls didn't cancel the fetch
         var tiles = cache.GetTiles(0, 0, 2, 2);
-        Assert.NotNull(tiles[0, 0].Content);
+        Assert.IsNotNull(tiles[0, 0].Content);
 
         // Should have only triggered ONE fetch, not three
-        Assert.Equal(1, ds.FetchCount);
+        Assert.AreEqual(1, ds.FetchCount);
     }
 }

--- a/tests/Hex1b.Tests/TilePanelNodeTests.cs
+++ b/tests/Hex1b.Tests/TilePanelNodeTests.cs
@@ -39,9 +39,10 @@ internal class TestTileDataSource : ITileDataSource
     }
 }
 
+[TestClass]
 public class TilePanelNodeTests
 {
-    [Fact]
+    [TestMethod]
     public void EffectiveTileWidth_ZoomLevel0_ReturnsBaseSize()
     {
         var ds = new TestTileDataSource();
@@ -51,11 +52,11 @@ public class TilePanelNodeTests
         };
         node.SetDataSource(ds);
 
-        Assert.Equal(3, node.EffectiveTileWidth);
-        Assert.Equal(1, node.EffectiveTileHeight);
+        Assert.AreEqual(3, node.EffectiveTileWidth);
+        Assert.AreEqual(1, node.EffectiveTileHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void EffectiveTileWidth_ZoomLevel1_DoubleSize()
     {
         var ds = new TestTileDataSource();
@@ -65,11 +66,11 @@ public class TilePanelNodeTests
         };
         node.SetDataSource(ds);
 
-        Assert.Equal(6, node.EffectiveTileWidth);
-        Assert.Equal(2, node.EffectiveTileHeight);
+        Assert.AreEqual(6, node.EffectiveTileWidth);
+        Assert.AreEqual(2, node.EffectiveTileHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void EffectiveTileWidth_ZoomLevel2_QuadrupleSize()
     {
         var ds = new TestTileDataSource();
@@ -79,11 +80,11 @@ public class TilePanelNodeTests
         };
         node.SetDataSource(ds);
 
-        Assert.Equal(12, node.EffectiveTileWidth);
-        Assert.Equal(4, node.EffectiveTileHeight);
+        Assert.AreEqual(12, node.EffectiveTileWidth);
+        Assert.AreEqual(4, node.EffectiveTileHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetVisibleTileRange_CenteredAtOrigin_ReturnsCorrectRange()
     {
         var ds = new TestTileDataSource();
@@ -100,16 +101,16 @@ public class TilePanelNodeTests
         var (tileX, tileY, tilesWide, tilesTall) = node.GetVisibleTileRange();
 
         // With 30 chars wide, 3 chars/tile = 10 tiles + 2 = 12
-        Assert.Equal(12, tilesWide);
+        Assert.AreEqual(12, tilesWide);
         // With 10 rows, 1 char/tile = 10 tiles + 2 = 12
-        Assert.Equal(12, tilesTall);
+        Assert.AreEqual(12, tilesTall);
         // Camera at origin, viewport is 30 wide, tile is 3 wide
         // startTileX = floor(0 - 30/(2*3)) = floor(-5) = -5
-        Assert.Equal(-5, tileX);
-        Assert.Equal(-5, tileY);
+        Assert.AreEqual(-5, tileX);
+        Assert.AreEqual(-5, tileY);
     }
 
-    [Fact]
+    [TestMethod]
     public void TileToScreen_AtCameraCenter_ReturnsViewportCenter()
     {
         var ds = new TestTileDataSource();
@@ -125,11 +126,11 @@ public class TilePanelNodeTests
         var (screenX, screenY) = node.TileToScreen(0, 0);
 
         // Camera at origin, tile at origin → center of viewport
-        Assert.Equal(40, screenX);
-        Assert.Equal(12, screenY);
+        Assert.AreEqual(40, screenX);
+        Assert.AreEqual(12, screenY);
     }
 
-    [Fact]
+    [TestMethod]
     public void TileToScreen_OffsetFromCamera_ReturnsCorrectScreenPosition()
     {
         var ds = new TestTileDataSource();
@@ -144,15 +145,15 @@ public class TilePanelNodeTests
 
         // Tile at (5, 3) should be at center since camera is at (5, 3)
         var (screenX, screenY) = node.TileToScreen(5, 3);
-        Assert.Equal(40, screenX);
-        Assert.Equal(12, screenY);
+        Assert.AreEqual(40, screenX);
+        Assert.AreEqual(12, screenY);
 
         // Tile at (6, 3) should be 3 chars to the right (tileWidth = 3)
         var (screenX2, _) = node.TileToScreen(6, 3);
-        Assert.Equal(43, screenX2);
+        Assert.AreEqual(43, screenX2);
     }
 
-    [Fact]
+    [TestMethod]
     public void Reconcile_PreservesNode()
     {
         var ds = new TestTileDataSource();
@@ -163,14 +164,14 @@ public class TilePanelNodeTests
         var node1 = widget1.ReconcileAsync(null, context).GetAwaiter().GetResult();
         var node2 = widget2.ReconcileAsync(node1, context).GetAwaiter().GetResult();
 
-        Assert.Same(node1, node2);
+        Assert.AreSame(node1, node2);
         var tileNode = (TilePanelNode)node2;
-        Assert.Equal(5, tileNode.CameraX);
-        Assert.Equal(3, tileNode.CameraY);
-        Assert.Equal(1, tileNode.ZoomLevel);
+        Assert.AreEqual(5, tileNode.CameraX);
+        Assert.AreEqual(3, tileNode.CameraY);
+        Assert.AreEqual(1, tileNode.ZoomLevel);
     }
 
-    [Fact]
+    [TestMethod]
     public void Reconcile_CameraChange_MarksDirty()
     {
         var ds = new TestTileDataSource();
@@ -184,10 +185,10 @@ public class TilePanelNodeTests
 
         widget2.ReconcileAsync(node1, context).GetAwaiter().GetResult();
 
-        Assert.True(tileNode.IsDirty);
+        Assert.IsTrue(tileNode.IsDirty);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildContent_WithNoPois_ReturnsInteractable()
     {
         var ds = new TestTileDataSource();
@@ -204,10 +205,10 @@ public class TilePanelNodeTests
         var content = node.BuildContent();
 
         // With no POIs, content is just the Interactable wrapping SurfaceWidget
-        Assert.IsType<InteractableWidget>(content);
+        TestSeq.IsType<InteractableWidget>(content);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildContent_WithPois_ReturnsZStack()
     {
         var ds = new TestTileDataSource();
@@ -223,15 +224,15 @@ public class TilePanelNodeTests
 
         var content = node.BuildContent();
 
-        Assert.IsType<ZStackWidget>(content);
+        TestSeq.IsType<ZStackWidget>(content);
         var zstack = (ZStackWidget)content;
         // ZStack with tile layer + float POI children
-        Assert.Equal(2, zstack.Children.Count);
-        Assert.IsType<InteractableWidget>(zstack.Children[0]);
-        Assert.IsType<FloatWidget>(zstack.Children[1]);
+        Assert.AreEqual(2, zstack.Children.Count);
+        TestSeq.IsType<InteractableWidget>(zstack.Children[0]);
+        TestSeq.IsType<FloatWidget>(zstack.Children[1]);
     }
 
-    [Fact]
+    [TestMethod]
     public void BuildContent_PoiOutsideViewport_IsExcluded()
     {
         var ds = new TestTileDataSource();
@@ -248,21 +249,22 @@ public class TilePanelNodeTests
         var content = node.BuildContent();
 
         // Far-away POI should be excluded, returning just the interactable
-        Assert.IsType<InteractableWidget>(content);
+        TestSeq.IsType<InteractableWidget>(content);
     }
 
-    [Fact]
+    [TestMethod]
     public void TilePanelNode_IsNotDirectlyFocusable()
     {
         // TilePanelNode delegates focus to the InteractableNode it wraps the surface in
         var node = new TilePanelNode();
-        Assert.False(node.IsFocusable);
+        Assert.IsFalse(node.IsFocusable);
     }
 }
 
+[TestClass]
 public class TilePanelFocusTests
 {
-    [Fact]
+    [TestMethod]
     public void TilePanelNode_InVStack_InteractableReceivesFocus()
     {
         var ds = new TestTileDataSource();
@@ -287,22 +289,23 @@ public class TilePanelFocusTests
             }
         }
 
-        Assert.NotNull(tilePanelNode);
+        Assert.IsNotNull(tilePanelNode);
 
         // The InteractableNode inside TilePanelNode should be focusable and receive focus
         var focusables = tilePanelNode.GetFocusableNodes().ToList();
-        Assert.True(focusables.Count > 0, "TilePanelNode should have focusable descendants");
-        Assert.IsType<InteractableNode>(focusables[0]);
-        Assert.True(focusables[0].IsFocused, "InteractableNode should receive focus");
+        Assert.IsTrue(focusables.Count > 0, "TilePanelNode should have focusable descendants");
+        TestSeq.IsType<InteractableNode>(focusables[0]);
+        Assert.IsTrue(focusables[0].IsFocused, "InteractableNode should receive focus");
 
         // Verify PanCallback is wired
-        Assert.NotNull(tilePanelNode.PanCallback);
+        Assert.IsNotNull(tilePanelNode.PanCallback);
     }
 }
 
+[TestClass]
 public class TilePanelIntegrationTests
 {
-    [Fact]
+    [TestMethod]
     public async Task TilePanel_ArrowKey_PansCamera()
     {
         var cameraX = 0.0;
@@ -343,12 +346,12 @@ public class TilePanelIntegrationTests
 
         await runTask;
 
-        Assert.True(panCount > 0, "Pan handler should have been called");
-        Assert.Equal(1.0, cameraX);
-        Assert.Equal(0.0, cameraY);
+        Assert.IsTrue(panCount > 0, "Pan handler should have been called");
+        Assert.AreEqual(1.0, cameraX);
+        Assert.AreEqual(0.0, cameraY);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TilePanel_PlusKey_Zooms()
     {
         var zoomLevel = 0;
@@ -385,11 +388,11 @@ public class TilePanelIntegrationTests
 
         await runTask;
 
-        Assert.True(zoomCount > 0, "Zoom handler should have been called");
-        Assert.Equal(1, zoomLevel);
+        Assert.IsTrue(zoomCount > 0, "Zoom handler should have been called");
+        Assert.AreEqual(1, zoomLevel);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TilePanel_MouseScroll_Zooms()
     {
         var cameraX = 0.0;
@@ -439,8 +442,8 @@ public class TilePanelIntegrationTests
 
         await runTask;
 
-        Assert.True(zoomCount > 0, "Zoom handler should have been called");
-        Assert.Equal(1, zoomLevel);
+        Assert.IsTrue(zoomCount > 0, "Zoom handler should have been called");
+        Assert.AreEqual(1, zoomLevel);
     }
 
     /// <summary>
@@ -459,9 +462,9 @@ public class TilePanelIntegrationTests
     /// don't show persistent placeholder dots due to cache eviction thrashing.
     /// The TileCache must auto-expand when the viewport requires more tiles than the max.
     /// </summary>
-    [Theory]
-    [InlineData(200, 55)]  // 202 * 57 = 11,514 tiles — exceeds 10,000
-    [InlineData(250, 60)]  // 252 * 62 = 15,624 tiles — well over limit
+    [TestMethod]
+    [DataRow(200, 55)]  // 202 * 57 = 11,514 tiles — exceeds 10,000
+    [DataRow(250, 60)]  // 252 * 62 = 15,624 tiles — well over limit
     public async Task DrawTiles_LargeViewport_NoEvictionThrashing(int width, int height)
     {
         var ds = new SingleCellTileSource();
@@ -490,8 +493,7 @@ public class TilePanelIntegrationTests
                 if (surface2[x, y].Character == "·")
                     placeholderCount++;
 
-        Assert.True(placeholderCount == 0,
-            $"Viewport {width}x{height}: Found {placeholderCount} placeholder '·' cells — " +
+        Assert.IsTrue(placeholderCount == 0, $"Viewport {width}x{height}: Found {placeholderCount} placeholder '·' cells — " +
             $"cache eviction is thrashing (viewport needs {(width + 2) * (height + 2)} tiles, " +
             $"which exceeds default MaxCachedTiles)");
     }
@@ -501,15 +503,15 @@ public class TilePanelIntegrationTests
     /// with tile content and leaves no unwritten or placeholder cells.
     /// Tests multiple viewport widths to catch rounding/alignment issues.
     /// </summary>
-    [Theory]
-    [InlineData(39)]
-    [InlineData(40)]
-    [InlineData(41)]
-    [InlineData(79)]
-    [InlineData(80)]
-    [InlineData(81)]
-    [InlineData(100)]
-    [InlineData(120)]
+    [TestMethod]
+    [DataRow(39)]
+    [DataRow(40)]
+    [DataRow(41)]
+    [DataRow(79)]
+    [DataRow(80)]
+    [DataRow(81)]
+    [DataRow(100)]
+    [DataRow(120)]
     public async Task DrawTiles_AllWidths_NoPlaceholderCells(int width)
     {
         // Use a 1x1 tile source that always returns content synchronously
@@ -548,10 +550,8 @@ public class TilePanelIntegrationTests
             }
         }
 
-        Assert.True(unwrittenCount == 0, 
-            $"Width={width}: Found {unwrittenCount} unwritten cells (should be 0 after cache is populated)");
-        Assert.True(placeholderCount == 0, 
-            $"Width={width}: Found {placeholderCount} placeholder '·' cells (should be 0 after cache is populated)");
+        Assert.IsTrue(unwrittenCount == 0, $"Width={width}: Found {unwrittenCount} unwritten cells (should be 0 after cache is populated)");
+        Assert.IsTrue(placeholderCount == 0, $"Width={width}: Found {placeholderCount} placeholder '·' cells (should be 0 after cache is populated)");
     }
 }
 

--- a/tests/Hex1b.Tests/ToggleSwitchNodeTests.cs
+++ b/tests/Hex1b.Tests/ToggleSwitchNodeTests.cs
@@ -10,11 +10,12 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for ToggleSwitchNode rendering and input handling.
 /// </summary>
+[TestClass]
 public class ToggleSwitchNodeTests
 {
     #region Measurement Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_ReturnsCorrectSize_ThreeOptions()
     {
         var node = new ToggleSwitchNode
@@ -25,11 +26,11 @@ public class ToggleSwitchNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // Per-option chips: " Manual " (8) + " Auto " (6) + " Delayed " (9) = 23
-        Assert.Equal(23, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(23, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_EmptyOptions_ReturnsZeroWidth()
     {
         var node = new ToggleSwitchNode
@@ -39,11 +40,11 @@ public class ToggleSwitchNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(0, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_SingleOption_ReturnsCorrectSize()
     {
         var node = new ToggleSwitchNode
@@ -54,11 +55,11 @@ public class ToggleSwitchNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // " Only " = 1 + 4 + 1 = 6
-        Assert.Equal(6, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(6, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_TwoOptions_ReturnsCorrectSize()
     {
         var node = new ToggleSwitchNode
@@ -69,11 +70,11 @@ public class ToggleSwitchNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // " On " (4) + " Off " (5) = 9
-        Assert.Equal(9, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(9, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_CJKCharacters_CorrectSize()
     {
         var node = new ToggleSwitchNode
@@ -84,11 +85,11 @@ public class ToggleSwitchNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // Per-option chips: " 汉字 " (6) + " Auto " (6) + " 한글 " (6) = 18
-        Assert.Equal(18, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(18, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_RespectsMaxWidthConstraint()
     {
         var node = new ToggleSwitchNode
@@ -98,14 +99,14 @@ public class ToggleSwitchNodeTests
 
         var size = node.Measure(new Constraints(0, 20, 0, 5));
 
-        Assert.Equal(20, size.Width);
+        Assert.AreEqual(20, size.Width);
     }
 
     #endregion
 
     #region Rendering Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Unfocused_ShowsOptions()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -132,7 +133,7 @@ public class ToggleSwitchNodeTests
         Assert.Contains("C", line);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_Focused_ContainsAnsiCodes()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -155,10 +156,10 @@ public class ToggleSwitchNodeTests
             .Capture("final")
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
-        Assert.True(snapshot.HasForegroundColor() || snapshot.HasBackgroundColor() || snapshot.HasAttribute(CellAttributes.Reverse));
+        Assert.IsTrue(snapshot.HasForegroundColor() || snapshot.HasBackgroundColor() || snapshot.HasAttribute(CellAttributes.Reverse));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_FocusedAndUnfocused_ProduceDifferentOutput()
     {
         using var focusedWorkload = new Hex1bAppWorkloadAdapter();
@@ -200,7 +201,7 @@ public class ToggleSwitchNodeTests
 
         // Focused toggle should have different styling (colors or attributes)
         var focusedMatch = focusedTerminal.CreateSnapshot().SearchPattern(pattern).First;
-        Assert.NotNull(focusedMatch);
+        Assert.IsNotNull(focusedMatch);
         
         var focusedCells = focusedMatch.Cells;
         var focusedHasStyling = focusedCells.Any(c => 
@@ -208,10 +209,10 @@ public class ToggleSwitchNodeTests
             c.Cell.Foreground.HasValue || 
             c.Cell.Background.HasValue);
         
-        Assert.True(focusedHasStyling, "Focused toggle should have styling applied");
+        Assert.IsTrue(focusedHasStyling, "Focused toggle should have styling applied");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_EmptyOptions_DoesNotThrow()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -225,12 +226,12 @@ public class ToggleSwitchNodeTests
         };
         node.Arrange(new Rect(0, 0, 40, 1));
 
-        var exception = Record.Exception(() => node.Render(context));
+        var exception = TestSeq.RecordException(() => node.Render(context));
 
-        Assert.Null(exception);
+        Assert.IsNull(exception);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_UnselectedOption_PaintsUnselectedBackground()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -257,14 +258,14 @@ public class ToggleSwitchNodeTests
         // sit on the unselected background.
         for (var x = 4; x <= 8; x++)
         {
-            Assert.Equal(expectedUnselectedBg, snapshot.GetCell(x, 0).Background);
+            Assert.AreEqual(expectedUnselectedBg, snapshot.GetCell(x, 0).Background);
         }
-        Assert.Equal("O", snapshot.GetCell(5, 0).Character);
-        Assert.Equal("f", snapshot.GetCell(6, 0).Character);
-        Assert.Equal("f", snapshot.GetCell(7, 0).Character);
+        Assert.AreEqual("O", snapshot.GetCell(5, 0).Character);
+        Assert.AreEqual("f", snapshot.GetCell(6, 0).Character);
+        Assert.AreEqual("f", snapshot.GetCell(7, 0).Character);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_FocusedSelectedOption_PaintsFocusedSelectedBackground()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -292,15 +293,15 @@ public class ToggleSwitchNodeTests
         // Chip 0 ("On", selected, focused) — every cell sits on the focused selected background.
         for (var x = 0; x <= 3; x++)
         {
-            Assert.Equal(expectedSelectedBg, snapshot.GetCell(x, 0).Background);
+            Assert.AreEqual(expectedSelectedBg, snapshot.GetCell(x, 0).Background);
         }
-        Assert.Equal("O", snapshot.GetCell(1, 0).Character);
-        Assert.Equal("n", snapshot.GetCell(2, 0).Character);
+        Assert.AreEqual("O", snapshot.GetCell(1, 0).Character);
+        Assert.AreEqual("n", snapshot.GetCell(2, 0).Character);
 
         // Chip 1 ("Off", unselected) — sits on the unselected background.
         for (var x = 4; x <= 8; x++)
         {
-            Assert.Equal(expectedUnselectedBg, snapshot.GetCell(x, 0).Background);
+            Assert.AreEqual(expectedUnselectedBg, snapshot.GetCell(x, 0).Background);
         }
     }
 
@@ -308,7 +309,7 @@ public class ToggleSwitchNodeTests
 
     #region Input Handling Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_RightArrow_MovesToNextOption()
     {
         var node = new ToggleSwitchNode
@@ -320,11 +321,11 @@ public class ToggleSwitchNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(1, node.SelectedIndex);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(1, node.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_LeftArrow_MovesToPreviousOption()
     {
         var node = new ToggleSwitchNode
@@ -336,11 +337,11 @@ public class ToggleSwitchNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(1, node.SelectedIndex);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(1, node.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_RightArrow_WrapsToFirstOption()
     {
         var node = new ToggleSwitchNode
@@ -352,11 +353,11 @@ public class ToggleSwitchNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(0, node.SelectedIndex);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(0, node.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_LeftArrow_WrapsToLastOption()
     {
         var node = new ToggleSwitchNode
@@ -368,11 +369,11 @@ public class ToggleSwitchNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.LeftArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(2, node.SelectedIndex);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(2, node.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_OtherKey_NotHandled()
     {
         var node = new ToggleSwitchNode
@@ -384,11 +385,11 @@ public class ToggleSwitchNodeTests
 
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.Enter, '\r', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.NotHandled, result);
-        Assert.Equal(0, node.SelectedIndex);
+        Assert.AreEqual(InputResult.NotHandled, result);
+        Assert.AreEqual(0, node.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_WhenNotFocused_BindingsStillExecute()
     {
         // Note: With the new input binding architecture, bindings execute at the node level
@@ -403,11 +404,11 @@ public class ToggleSwitchNodeTests
         var result = await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
         // Bindings execute regardless of focus state when using RouteInputToNode
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(1, node.SelectedIndex);  // Selection changed
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(1, node.SelectedIndex);  // Selection changed
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_SelectionChanged_CallsCallback()
     {
         var callbackInvoked = false;
@@ -431,28 +432,28 @@ public class ToggleSwitchNodeTests
 
         await InputRouter.RouteInputToNodeAsync(node, new Hex1bKeyEvent(Hex1bKey.RightArrow, '\0', Hex1bModifiers.None), null, null, TestContext.Current.CancellationToken);
 
-        Assert.True(callbackInvoked);
-        Assert.Equal(1, callbackIndex);
-        Assert.Equal("Auto", callbackValue);
+        Assert.IsTrue(callbackInvoked);
+        Assert.AreEqual(1, callbackIndex);
+        Assert.AreEqual("Auto", callbackValue);
     }
 
     #endregion
 
     #region Focus Tests
 
-    [Fact]
+    [TestMethod]
     public async Task IsFocusable_ReturnsTrue()
     {
         var node = new ToggleSwitchNode();
 
-        Assert.True(node.IsFocusable);
+        Assert.IsTrue(node.IsFocusable);
     }
 
     #endregion
 
     #region Layout Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_SetsBounds()
     {
         var node = new ToggleSwitchNode
@@ -463,14 +464,14 @@ public class ToggleSwitchNodeTests
 
         node.Arrange(bounds);
 
-        Assert.Equal(bounds, node.Bounds);
+        Assert.AreEqual(bounds, node.Bounds);
     }
 
     #endregion
 
     #region State Tests
 
-    [Fact]
+    [TestMethod]
     public async Task SelectedOption_ReturnsCorrectValue()
     {
         var node = new ToggleSwitchNode
@@ -479,10 +480,10 @@ public class ToggleSwitchNodeTests
             SelectedIndex = 1
         };
 
-        Assert.Equal("Auto", node.SelectedOption);
+        Assert.AreEqual("Auto", node.SelectedOption);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SelectedOption_EmptyOptions_ReturnsNull()
     {
         var node = new ToggleSwitchNode
@@ -490,14 +491,14 @@ public class ToggleSwitchNodeTests
             Options = []
         };
 
-        Assert.Null(node.SelectedOption);
+        Assert.IsNull(node.SelectedOption);
     }
 
     #endregion
 
     #region Integration Tests with Hex1bApp
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_ToggleSwitch_RendersViaHex1bApp()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -524,12 +525,12 @@ public class ToggleSwitchNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Manual"));
-        Assert.True(snapshot.ContainsText("Auto"));
-        Assert.True(snapshot.ContainsText("Delayed"));
+        Assert.IsTrue(snapshot.ContainsText("Manual"));
+        Assert.IsTrue(snapshot.ContainsText("Auto"));
+        Assert.IsTrue(snapshot.ContainsText("Delayed"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_ToggleSwitch_ArrowNavigates()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -557,10 +558,10 @@ public class ToggleSwitchNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("On", selectedOption);
+        Assert.AreEqual("On", selectedOption);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_ToggleSwitch_MultipleNavigations()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -588,10 +589,10 @@ public class ToggleSwitchNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("High", selectedOption);
+        Assert.AreEqual("High", selectedOption);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_ToggleSwitch_WithOtherWidgets_TabNavigates()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -622,11 +623,11 @@ public class ToggleSwitchNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("B", selectedOption);
-        Assert.True(buttonClicked);
+        Assert.AreEqual("B", selectedOption);
+        Assert.IsTrue(buttonClicked);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_ToggleSwitch_CallbackTriggered()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -654,14 +655,14 @@ public class ToggleSwitchNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("Mode2", lastSelectedValue);
+        Assert.AreEqual("Mode2", lastSelectedValue);
     }
 
     #endregion
 
     #region Mouse Click Tests
 
-    [Fact]
+    [TestMethod]
     public async Task HandleMouseClick_SelectsClickedOption()
     {
         // Layout: " Manual  Auto  Delayed " — per-option chips:
@@ -677,11 +678,11 @@ public class ToggleSwitchNodeTests
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 10, 0, Hex1bModifiers.None);
         var result = node.HandleMouseClick(10, 0, mouseEvent);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(1, node.SelectedIndex);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(1, node.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleMouseClick_FirstOption_SelectsIndex0()
     {
         // Layout: " On  Off " — chip 0 covers cells 0-3, chip 1 covers cells 4-8
@@ -697,11 +698,11 @@ public class ToggleSwitchNodeTests
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 1, 0, Hex1bModifiers.None);
         var result = node.HandleMouseClick(1, 0, mouseEvent);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(0, node.SelectedIndex);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(0, node.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleMouseClick_OnLeadingPadding_SelectsFirstOption()
     {
         // Padding cells are part of their owning chip, so clicking the
@@ -718,11 +719,11 @@ public class ToggleSwitchNodeTests
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 0, 0, Hex1bModifiers.None);
         var result = node.HandleMouseClick(0, 0, mouseEvent);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(0, node.SelectedIndex);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(0, node.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleMouseClick_CJKCharacters_UsesDisplayWidth()
     {
         // Layout: " 汉字  Off " — chip 0 covers cells 0-5 because
@@ -738,11 +739,11 @@ public class ToggleSwitchNodeTests
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 4, 0, Hex1bModifiers.None);
         var result = node.HandleMouseClick(4, 0, mouseEvent);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal(0, node.SelectedIndex);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual(0, node.SelectedIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleMouseClick_PastLastChip_ReturnsNotHandled()
     {
         var node = new ToggleSwitchNode
@@ -756,10 +757,10 @@ public class ToggleSwitchNodeTests
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 12, 0, Hex1bModifiers.None);
         var result = node.HandleMouseClick(12, 0, mouseEvent);
 
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleMouseClick_EmptyOptions_ReturnsNotHandled()
     {
         var node = new ToggleSwitchNode
@@ -772,7 +773,7 @@ public class ToggleSwitchNodeTests
         var mouseEvent = new Hex1bMouseEvent(MouseButton.Left, MouseAction.Down, 5, 0, Hex1bModifiers.None);
         var result = node.HandleMouseClick(5, 0, mouseEvent);
 
-        Assert.Equal(InputResult.NotHandled, result);
+        Assert.AreEqual(InputResult.NotHandled, result);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/TrackedObjectTests.cs
+++ b/tests/Hex1b.Tests/TrackedObjectTests.cs
@@ -5,9 +5,10 @@ using Hex1b.Tokens;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class TrackedObjectTests
 {
-    [Fact]
+    [TestMethod]
     public async Task ApplyTokens_WithSixelSequence_CreatesSixelData()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -17,16 +18,16 @@ public class TrackedObjectTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1bPq#0;2;100;0;0#0~~~~~~\x1b\\"));
         
         // Should track the Sixel data
-        Assert.Equal(1, terminal.TrackedSixelCount);
-        Assert.True(terminal.ContainsSixelData());
+        Assert.AreEqual(1, terminal.TrackedSixelCount);
+        Assert.IsTrue(terminal.ContainsSixelData());
         
         // The origin cell should have the Sixel data
         var sixelData = terminal.GetSixelDataAt(0, 0);
-        Assert.NotNull(sixelData);
+        Assert.IsNotNull(sixelData);
         Assert.Contains("#0;2;100;0;0#0~~~~~~", sixelData.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ApplyTokens_WithCursorPositionThenSixel_CreatesSixelData()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -36,16 +37,16 @@ public class TrackedObjectTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[1;1H\x1bPq#0;2;100;0;0#0~~~~~~\x1b\\"));
         
         // Should track the Sixel data
-        Assert.Equal(1, terminal.TrackedSixelCount);
-        Assert.True(terminal.ContainsSixelData());
+        Assert.AreEqual(1, terminal.TrackedSixelCount);
+        Assert.IsTrue(terminal.ContainsSixelData());
         
         // The origin cell should have the Sixel data
         var sixelData = terminal.GetSixelDataAt(0, 0);
-        Assert.NotNull(sixelData);
+        Assert.IsNotNull(sixelData);
         Assert.Contains("#0;2;100;0;0#0~~~~~~", sixelData.Payload);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WorkloadAdapter_WithSixel_TerminalReceivesSixelData()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -62,11 +63,11 @@ public class TrackedObjectTests
             .ApplyAsync(terminal);
         
         // Should track the Sixel data
-        Assert.Equal(1, terminal.TrackedSixelCount);
-        Assert.True(terminal.ContainsSixelData());
+        Assert.AreEqual(1, terminal.TrackedSixelCount);
+        Assert.IsTrue(terminal.ContainsSixelData());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WorkloadAdapter_SeparateWrites_TerminalReceivesSixelData()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -83,11 +84,11 @@ public class TrackedObjectTests
             .ApplyAsync(terminal);
         
         // Should track the Sixel data
-        Assert.Equal(1, terminal.TrackedSixelCount);
-        Assert.True(terminal.ContainsSixelData());
+        Assert.AreEqual(1, terminal.TrackedSixelCount);
+        Assert.IsTrue(terminal.ContainsSixelData());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WorkloadAdapter_WriteTokensWithBytes_WithSixel_UnrecognizedDcs_IsTracked()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -109,11 +110,11 @@ public class TrackedObjectTests
             .Build()
             .ApplyAsync(terminal);
 
-        Assert.Equal(1, terminal.TrackedSixelCount);
-        Assert.True(terminal.ContainsSixelData());
+        Assert.AreEqual(1, terminal.TrackedSixelCount);
+        Assert.IsTrue(terminal.ContainsSixelData());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RenderContext_WithSixel_TerminalReceivesSixelData()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -131,11 +132,11 @@ public class TrackedObjectTests
             .ApplyAsync(terminal);
         
         // Should track the Sixel data
-        Assert.True(terminal.ContainsSixelData());
-        Assert.Equal(1, terminal.TrackedSixelCount);
+        Assert.IsTrue(terminal.ContainsSixelData());
+        Assert.AreEqual(1, terminal.TrackedSixelCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TrackedSixel_WhenCellOverwritten_ReleasesReference()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -143,16 +144,16 @@ public class TrackedObjectTests
         
         // Process a Sixel sequence
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1bPq#0;2;100;0;0#0~~~~~~\x1b\\"));
-        Assert.Equal(1, terminal.TrackedSixelCount);
+        Assert.AreEqual(1, terminal.TrackedSixelCount);
         
         // Overwrite the cell with text
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[1;1HXXXXXXXX"));
         
         // Sixel data should be released (refcount reached 0)
-        Assert.Equal(0, terminal.TrackedSixelCount);
+        Assert.AreEqual(0, terminal.TrackedSixelCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TrackedSixel_Deduplication_ReusesSameObject()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -164,15 +165,15 @@ public class TrackedObjectTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1bPq#0;2;100;0;0#0~~~~~~\x1b\\"));
         
         // Should still only have one unique tracked object
-        Assert.Equal(1, terminal.TrackedSixelCount);
+        Assert.AreEqual(1, terminal.TrackedSixelCount);
         
         // Both cells should reference the same object
         var sixel1 = terminal.GetSixelDataAt(0, 0);
         var sixel2 = terminal.GetSixelDataAt(0, 1);
-        Assert.Same(sixel1, sixel2);
+        Assert.AreSame(sixel1, sixel2);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TrackedSixel_RefCount_IncreasesWithDeduplication()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -184,9 +185,9 @@ public class TrackedObjectTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1bPq#0;2;100;0;0#0~~~~~~\x1b\\"));
         
         var trackedSixel = terminal.GetTrackedSixelAt(0, 0);
-        Assert.NotNull(trackedSixel);
+        Assert.IsNotNull(trackedSixel);
         
         // RefCount should be 2 (one for each cell)
-        Assert.Equal(2, trackedSixel.RefCount);
+        Assert.AreEqual(2, trackedSixel.RefCount);
     }
 }

--- a/tests/Hex1b.Tests/TreeCascadeSelectionTests.cs
+++ b/tests/Hex1b.Tests/TreeCascadeSelectionTests.cs
@@ -7,27 +7,28 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for TreeWidget cascade selection functionality.
 /// </summary>
+[TestClass]
 public class TreeCascadeSelectionTests
 {
     #region ComputeSelectionState Tests
 
-    [Fact]
+    [TestMethod]
     public void ComputeSelectionState_LeafNode_ReturnsSelectedWhenSelected()
     {
         var node = new TreeItemNode { Label = "Leaf", IsSelected = true };
         
-        Assert.Equal(TreeSelectionState.Selected, node.ComputeSelectionState());
+        Assert.AreEqual(TreeSelectionState.Selected, node.ComputeSelectionState());
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputeSelectionState_LeafNode_ReturnsNoneWhenNotSelected()
     {
         var node = new TreeItemNode { Label = "Leaf", IsSelected = false };
         
-        Assert.Equal(TreeSelectionState.None, node.ComputeSelectionState());
+        Assert.AreEqual(TreeSelectionState.None, node.ComputeSelectionState());
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputeSelectionState_ParentWithAllChildrenSelected_ReturnsSelected()
     {
         var parent = new TreeItemNode
@@ -39,10 +40,10 @@ public class TreeCascadeSelectionTests
             ]
         };
         
-        Assert.Equal(TreeSelectionState.Selected, parent.ComputeSelectionState());
+        Assert.AreEqual(TreeSelectionState.Selected, parent.ComputeSelectionState());
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputeSelectionState_ParentWithNoChildrenSelected_ReturnsNone()
     {
         var parent = new TreeItemNode
@@ -54,10 +55,10 @@ public class TreeCascadeSelectionTests
             ]
         };
         
-        Assert.Equal(TreeSelectionState.None, parent.ComputeSelectionState());
+        Assert.AreEqual(TreeSelectionState.None, parent.ComputeSelectionState());
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputeSelectionState_ParentWithSomeChildrenSelected_ReturnsIndeterminate()
     {
         var parent = new TreeItemNode
@@ -69,10 +70,10 @@ public class TreeCascadeSelectionTests
             ]
         };
         
-        Assert.Equal(TreeSelectionState.Indeterminate, parent.ComputeSelectionState());
+        Assert.AreEqual(TreeSelectionState.Indeterminate, parent.ComputeSelectionState());
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputeSelectionState_GrandparentWithIndeterminateChild_ReturnsIndeterminate()
     {
         var grandparent = new TreeItemNode
@@ -90,10 +91,10 @@ public class TreeCascadeSelectionTests
             ]
         };
         
-        Assert.Equal(TreeSelectionState.Indeterminate, grandparent.ComputeSelectionState());
+        Assert.AreEqual(TreeSelectionState.Indeterminate, grandparent.ComputeSelectionState());
     }
 
-    [Fact]
+    [TestMethod]
     public void ComputeSelectionState_DeepTree_AllSelected_ReturnsSelected()
     {
         var root = new TreeItemNode
@@ -116,14 +117,14 @@ public class TreeCascadeSelectionTests
             ]
         };
         
-        Assert.Equal(TreeSelectionState.Selected, root.ComputeSelectionState());
+        Assert.AreEqual(TreeSelectionState.Selected, root.ComputeSelectionState());
     }
 
     #endregion
 
     #region SetSelectionCascade Tests
 
-    [Fact]
+    [TestMethod]
     public void SetSelectionCascade_SelectsAllDescendants()
     {
         var parent = new TreeItemNode
@@ -145,13 +146,13 @@ public class TreeCascadeSelectionTests
         
         parent.SetSelectionCascade(true);
         
-        Assert.True(parent.IsSelected);
-        Assert.True(parent.Children[0].IsSelected);
-        Assert.True(parent.Children[0].Children[0].IsSelected);
-        Assert.True(parent.Children[1].IsSelected);
+        Assert.IsTrue(parent.IsSelected);
+        Assert.IsTrue(parent.Children[0].IsSelected);
+        Assert.IsTrue(parent.Children[0].Children[0].IsSelected);
+        Assert.IsTrue(parent.Children[1].IsSelected);
     }
 
-    [Fact]
+    [TestMethod]
     public void SetSelectionCascade_DeselectsAllDescendants()
     {
         var parent = new TreeItemNode
@@ -173,17 +174,17 @@ public class TreeCascadeSelectionTests
         
         parent.SetSelectionCascade(false);
         
-        Assert.False(parent.IsSelected);
-        Assert.False(parent.Children[0].IsSelected);
-        Assert.False(parent.Children[0].Children[0].IsSelected);
-        Assert.False(parent.Children[1].IsSelected);
+        Assert.IsFalse(parent.IsSelected);
+        Assert.IsFalse(parent.Children[0].IsSelected);
+        Assert.IsFalse(parent.Children[0].Children[0].IsSelected);
+        Assert.IsFalse(parent.Children[1].IsSelected);
     }
 
     #endregion
 
     #region ToggleSelectionAsync Tests
 
-    [Fact]
+    [TestMethod]
     public async Task ToggleSelectionAsync_WithCascade_SelectsAllChildren()
     {
         var widget = new TreeWidget([
@@ -197,7 +198,7 @@ public class TreeCascadeSelectionTests
         var node = await widget.ReconcileAsync(null, context) as TreeNode;
         
         // Initially nothing selected
-        Assert.Equal(TreeSelectionState.None, node!.Items[0].ComputeSelectionState());
+        Assert.AreEqual(TreeSelectionState.None, node!.Items[0].ComputeSelectionState());
         
         // Toggle selection on parent
         var focusRing = new FocusRing();
@@ -205,13 +206,13 @@ public class TreeCascadeSelectionTests
         await node.ToggleSelectionAsync(node.Items[0], ctx);
         
         // All should be selected
-        Assert.True(node.Items[0].IsSelected);
-        Assert.True(node.Items[0].Children[0].IsSelected);
-        Assert.True(node.Items[0].Children[1].IsSelected);
-        Assert.Equal(TreeSelectionState.Selected, node.Items[0].ComputeSelectionState());
+        Assert.IsTrue(node.Items[0].IsSelected);
+        Assert.IsTrue(node.Items[0].Children[0].IsSelected);
+        Assert.IsTrue(node.Items[0].Children[1].IsSelected);
+        Assert.AreEqual(TreeSelectionState.Selected, node.Items[0].ComputeSelectionState());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ToggleSelectionAsync_WithCascade_DeselectingChildMakesParentIndeterminate()
     {
         var widget = new TreeWidget([
@@ -229,20 +230,20 @@ public class TreeCascadeSelectionTests
         var ctx = new InputBindingActionContext(focusRing, null, default);
         await node!.ToggleSelectionAsync(node.Items[0], ctx);
         
-        Assert.Equal(TreeSelectionState.Selected, node.Items[0].ComputeSelectionState());
+        Assert.AreEqual(TreeSelectionState.Selected, node.Items[0].ComputeSelectionState());
         
         // Now deselect one child
         await node.ToggleSelectionAsync(node.Items[0].Children[0], ctx);
         
         // Child 1 should be deselected
-        Assert.False(node.Items[0].Children[0].IsSelected);
+        Assert.IsFalse(node.Items[0].Children[0].IsSelected);
         // Child 2 should still be selected
-        Assert.True(node.Items[0].Children[1].IsSelected);
+        Assert.IsTrue(node.Items[0].Children[1].IsSelected);
         // Parent should show indeterminate
-        Assert.Equal(TreeSelectionState.Indeterminate, node.Items[0].ComputeSelectionState());
+        Assert.AreEqual(TreeSelectionState.Indeterminate, node.Items[0].ComputeSelectionState());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ToggleSelectionAsync_CascadesSelection()
     {
         var widget = new TreeWidget([
@@ -261,28 +262,28 @@ public class TreeCascadeSelectionTests
         await node!.ToggleSelectionAsync(node.Items[0], ctx);
         
         // Parent and all children should be selected (cascade)
-        Assert.True(node.Items[0].IsSelected);
-        Assert.True(node.Items[0].Children[0].IsSelected);
-        Assert.True(node.Items[0].Children[1].IsSelected);
+        Assert.IsTrue(node.Items[0].IsSelected);
+        Assert.IsTrue(node.Items[0].Children[0].IsSelected);
+        Assert.IsTrue(node.Items[0].Children[1].IsSelected);
     }
 
     #endregion
 
     #region Widget API Tests
 
-    [Fact]
+    [TestMethod]
     public void MultiSelect_EnablesMultiSelectAndCascade()
     {
         var widget = new TreeWidget([]).MultiSelect();
         
-        Assert.True(widget.IsMultiSelect);
+        Assert.IsTrue(widget.IsMultiSelect);
     }
 
     #endregion
 
     #region Integration Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_CascadeSelection_RendersIndeterminateCheckbox()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -313,17 +314,14 @@ public class TreeCascadeSelectionTests
         await runTask;
 
         // Parent should show indeterminate checkbox ▤
-        Assert.True(snapshot.ContainsText("▤"), 
-            $"Should show indeterminate checkbox. Output:\n{snapshot.GetDisplayText()}");
+        Assert.IsTrue(snapshot.ContainsText("▤"), $"Should show indeterminate checkbox. Output:\n{snapshot.GetDisplayText()}");
         // Child 1 should show checked ▣
-        Assert.True(snapshot.ContainsText("▣"), 
-            "Should show checked checkbox for selected child");
+        Assert.IsTrue(snapshot.ContainsText("▣"), "Should show checked checkbox for selected child");
         // Child 2 should show unchecked ▢
-        Assert.True(snapshot.ContainsText("▢"), 
-            "Should show unchecked checkbox for unselected child");
+        Assert.IsTrue(snapshot.ContainsText("▢"), "Should show unchecked checkbox for unselected child");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_CascadeSelection_SpaceSelectsAllChildren()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -357,10 +355,10 @@ public class TreeCascadeSelectionTests
         // All items should show checked ▣ - count occurrences
         var text = snapshot.GetDisplayText();
         var checkedCount = text.Split("▣").Length - 1;
-        Assert.Equal(3, checkedCount); // Parent + 2 children
+        Assert.AreEqual(3, checkedCount); // Parent + 2 children
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_MouseClick_OnCheckbox_TogglesSelection()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -396,7 +394,7 @@ public class TreeCascadeSelectionTests
         Assert.Contains("▣", text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_MouseClick_OutsideCheckbox_DoesNotToggleSelection()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -430,10 +428,10 @@ public class TreeCascadeSelectionTests
         // No items should be selected (checkboxes still all unchecked)
         var text = snapshot.GetDisplayText();
         var checkedCount = text.Split("▣").Length - 1;
-        Assert.Equal(0, checkedCount);
+        Assert.AreEqual(0, checkedCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_MouseClick_OnExpandIndicator_TogglesExpand()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -464,7 +462,7 @@ public class TreeCascadeSelectionTests
             .Build()
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         
-        Assert.True(beforeSnapshot.ContainsText("Child 1"), "Children should be visible initially");
+        Assert.IsTrue(beforeSnapshot.ContainsText("Child 1"), "Children should be visible initially");
         
         // Click on the expand indicator (x=0-1 for root item, where ▼ is)
         var afterSnapshot = await new Hex1bTerminalInputSequenceBuilder()
@@ -477,8 +475,8 @@ public class TreeCascadeSelectionTests
         await runTask;
 
         // Children should now be hidden (collapsed)
-        Assert.True(afterSnapshot.ContainsText("Parent"), "Parent should still be visible");
-        Assert.False(afterSnapshot.ContainsText("Child 1"), "Children should be hidden after clicking expand indicator");
+        Assert.IsTrue(afterSnapshot.ContainsText("Parent"), "Parent should still be visible");
+        Assert.IsFalse(afterSnapshot.ContainsText("Child 1"), "Children should be hidden after clicking expand indicator");
     }
 
     #endregion

--- a/tests/Hex1b.Tests/TreeGuideAlignmentTests.cs
+++ b/tests/Hex1b.Tests/TreeGuideAlignmentTests.cs
@@ -7,9 +7,10 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests specifically for tree guide line alignment issues.
 /// </summary>
+[TestClass]
 public class TreeGuideAlignmentTests
 {
-    [Fact]
+    [TestMethod]
     public async Task Tree_IsLastAtDepth_ComputedCorrectly()
     {
         // Unit test to verify IsLastAtDepth is computed correctly
@@ -26,39 +27,39 @@ public class TreeGuideAlignmentTests
         var node = await widget.ReconcileAsync(null, context) as TreeNode;
         
         // Verify flattened items
-        Assert.Equal(4, node!.FlattenedItems.Count);
+        Assert.AreEqual(4, node!.FlattenedItems.Count);
         
         // Root (depth=0, last=true at depth 0)
         var root = node.FlattenedItems[0];
-        Assert.Equal("Root", root.Node.Label);
-        Assert.Equal(0, root.Depth);
-        Assert.True(root.Node.IsLastChild); // Only root
-        Assert.Equal([true], root.IsLastAtDepth);
+        Assert.AreEqual("Root", root.Node.Label);
+        Assert.AreEqual(0, root.Depth);
+        Assert.IsTrue(root.Node.IsLastChild); // Only root
+        TestSeq.AreEqual([true], root.IsLastAtDepth);
         
         // Child 1 (depth=1, NOT last at depth 1)
         var child1 = node.FlattenedItems[1];
-        Assert.Equal("Child 1", child1.Node.Label);
-        Assert.Equal(1, child1.Depth);
-        Assert.False(child1.Node.IsLastChild); // Child 2 follows
-        Assert.Equal([true, false], child1.IsLastAtDepth);
+        Assert.AreEqual("Child 1", child1.Node.Label);
+        Assert.AreEqual(1, child1.Depth);
+        Assert.IsFalse(child1.Node.IsLastChild); // Child 2 follows
+        TestSeq.AreEqual([true, false], child1.IsLastAtDepth);
         
         // Grandchild (depth=2, last at depth 2, but Child 1 is NOT last at depth 1)
         var grandchild = node.FlattenedItems[2];
-        Assert.Equal("Grandchild", grandchild.Node.Label);
-        Assert.Equal(2, grandchild.Depth);
-        Assert.True(grandchild.Node.IsLastChild); // Only child of Child 1
+        Assert.AreEqual("Grandchild", grandchild.Node.Label);
+        Assert.AreEqual(2, grandchild.Depth);
+        Assert.IsTrue(grandchild.Node.IsLastChild); // Only child of Child 1
         // Key assertion: IsLastAtDepth[1] should be FALSE because Child 1 has siblings
-        Assert.Equal([true, false, true], grandchild.IsLastAtDepth);
+        TestSeq.AreEqual([true, false, true], grandchild.IsLastAtDepth);
         
         // Child 2 (depth=1, IS last at depth 1)
         var child2 = node.FlattenedItems[3];
-        Assert.Equal("Child 2", child2.Node.Label);
-        Assert.Equal(1, child2.Depth);
-        Assert.True(child2.Node.IsLastChild);
-        Assert.Equal([true, true], child2.IsLastAtDepth);
+        Assert.AreEqual("Child 2", child2.Node.Label);
+        Assert.AreEqual(1, child2.Depth);
+        Assert.IsTrue(child2.Node.IsLastChild);
+        TestSeq.AreEqual([true, true], child2.IsLastAtDepth);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Tree_GuideLines_VerticalAlignment_NestedStructure()
     {
         // Create a tree structure that should show:
@@ -115,8 +116,7 @@ public class TreeGuideAlignmentTests
         // │  └─   Grandchild   <-- vertical bar should connect
         // └─   Child 2
         
-        Assert.True(snapshot.ContainsText("│"), 
-            $"Should contain vertical guide line. Actual output:\n{output}");
+        Assert.IsTrue(snapshot.ContainsText("│"), $"Should contain vertical guide line. Actual output:\n{output}");
         
         // Find the Grandchild line and verify vertical bar exists
         var grandchildLine = -1;
@@ -129,7 +129,7 @@ public class TreeGuideAlignmentTests
             }
         }
         
-        Assert.True(grandchildLine > 0, $"Should find Grandchild line. Output:\n{output}");
+        Assert.IsTrue(grandchildLine > 0, $"Should find Grandchild line. Output:\n{output}");
         
         var gcLineContent = snapshot.GetLine(grandchildLine);
         // The vertical bar should be at the start of the line (column 0)
@@ -137,7 +137,7 @@ public class TreeGuideAlignmentTests
         // $"Grandchild line should start with vertical bar. Line content: [{gcLineContent}]\nFull output:\n{output}"
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Tree_GuideLines_MultipleRoots_NoVerticalForSingleRoot()
     {
         // Single root - no vertical lines needed at depth 0
@@ -180,7 +180,7 @@ public class TreeGuideAlignmentTests
         }
         
         // Verify structure
-        Assert.True(snapshot.ContainsText("├─"), $"Should have branch marker. Output:\n{output}");
-        Assert.True(snapshot.ContainsText("└─"), $"Should have last branch marker. Output:\n{output}");
+        Assert.IsTrue(snapshot.ContainsText("├─"), $"Should have branch marker. Output:\n{output}");
+        Assert.IsTrue(snapshot.ContainsText("└─"), $"Should have last branch marker. Output:\n{output}");
     }
 }

--- a/tests/Hex1b.Tests/TreeIntegrationTests.cs
+++ b/tests/Hex1b.Tests/TreeIntegrationTests.cs
@@ -7,6 +7,7 @@ namespace Hex1b.Tests;
 /// Comprehensive integration tests for TreeWidget keyboard navigation, mouse interaction,
 /// rendering in borders, clipping, and visual output verification.
 /// </summary>
+[TestClass]
 public class TreeIntegrationTests
 {
     #region Test Matrix Constants
@@ -87,7 +88,7 @@ public class TreeIntegrationTests
 
     #region Basic Rendering Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_RendersWithCorrectStructure()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -106,16 +107,16 @@ public class TreeIntegrationTests
         await runTask;
 
         // Verify tree structure
-        Assert.True(snapshot.ContainsText("📁 Root"));
-        Assert.True(snapshot.ContainsText("📄 Child 1"));
-        Assert.True(snapshot.ContainsText("📄 Child 2"));
-        Assert.True(snapshot.ContainsText("📄 Child 3"));
+        Assert.IsTrue(snapshot.ContainsText("📁 Root"));
+        Assert.IsTrue(snapshot.ContainsText("📄 Child 1"));
+        Assert.IsTrue(snapshot.ContainsText("📄 Child 2"));
+        Assert.IsTrue(snapshot.ContainsText("📄 Child 3"));
         
         // Verify expand indicator is shown for expanded root
-        Assert.True(snapshot.ContainsText(ExpandedIndicator));
+        Assert.IsTrue(snapshot.ContainsText(ExpandedIndicator));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_RendersGuideLines_Unicode()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -134,11 +135,10 @@ public class TreeIntegrationTests
         await runTask;
 
         // Verify Unicode guide lines are present
-        Assert.True(snapshot.ContainsText(UnicodeBranch) || snapshot.ContainsText(UnicodeLastBranch), 
-            "Should contain Unicode branch characters");
+        Assert.IsTrue(snapshot.ContainsText(UnicodeBranch) || snapshot.ContainsText(UnicodeLastBranch), "Should contain Unicode branch characters");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_RendersGuideLines_Ascii()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -163,11 +163,10 @@ public class TreeIntegrationTests
         await runTask;
 
         // Verify ASCII guide lines are present
-        Assert.True(snapshot.ContainsText(AsciiBranch) || snapshot.ContainsText(AsciiLastBranch),
-            "Should contain ASCII branch characters");
+        Assert.IsTrue(snapshot.ContainsText(AsciiBranch) || snapshot.ContainsText(AsciiLastBranch), "Should contain ASCII branch characters");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_CollapsedItem_HidesChildren()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -189,16 +188,16 @@ public class TreeIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Root"));
-        Assert.False(snapshot.ContainsText("Hidden Child"), "Collapsed items should hide children");
-        Assert.True(snapshot.ContainsText(CollapsedIndicator), "Should show collapsed indicator");
+        Assert.IsTrue(snapshot.ContainsText("Root"));
+        Assert.IsFalse(snapshot.ContainsText("Hidden Child"), "Collapsed items should hide children");
+        Assert.IsTrue(snapshot.ContainsText(CollapsedIndicator), "Should show collapsed indicator");
     }
 
     #endregion
 
     #region Keyboard Navigation Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_DownArrow_MovesToNextItem()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -219,10 +218,10 @@ public class TreeIntegrationTests
         await runTask;
 
         // A1 should now be focused (visually highlighted)
-        Assert.True(IsFocused(snapshot, "A1"), "A1 should be focused after Down arrow");
+        Assert.IsTrue(IsFocused(snapshot, "A1"), "A1 should be focused after Down arrow");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_UpArrow_MovesToPreviousItem()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -248,10 +247,10 @@ public class TreeIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(IsFocused(snapshot, "A1"), "A1 should be focused after Up arrow");
+        Assert.IsTrue(IsFocused(snapshot, "A1"), "A1 should be focused after Up arrow");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_DownArrow_WrapsToFirst()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -277,10 +276,10 @@ public class TreeIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(IsFocused(snapshot, "Item 1"), "Should wrap to first item");
+        Assert.IsTrue(IsFocused(snapshot, "Item 1"), "Should wrap to first item");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_UpArrow_WrapsToLast()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -304,10 +303,10 @@ public class TreeIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(IsFocused(snapshot, "Item 3"), "Should wrap to last item");
+        Assert.IsTrue(IsFocused(snapshot, "Item 3"), "Should wrap to last item");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_RightArrow_ExpandsCollapsedItem()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -337,11 +336,11 @@ public class TreeIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Child"), "Child should be visible after expand");
-        Assert.True(snapshot.ContainsText(ExpandedIndicator), "Should show expanded indicator");
+        Assert.IsTrue(snapshot.ContainsText("Child"), "Child should be visible after expand");
+        Assert.IsTrue(snapshot.ContainsText(ExpandedIndicator), "Should show expanded indicator");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_LeftArrow_CollapsesExpandedItem()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -371,11 +370,11 @@ public class TreeIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.False(snapshot.ContainsText("Child"), "Child should be hidden after collapse");
-        Assert.True(snapshot.ContainsText(CollapsedIndicator), "Should show collapsed indicator");
+        Assert.IsFalse(snapshot.ContainsText("Child"), "Child should be hidden after collapse");
+        Assert.IsTrue(snapshot.ContainsText(CollapsedIndicator), "Should show collapsed indicator");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_RightArrow_OnExpandedItem_MovesToFirstChild()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -400,10 +399,10 @@ public class TreeIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(IsFocused(snapshot, "First Child"), "First Child should be focused");
+        Assert.IsTrue(IsFocused(snapshot, "First Child"), "First Child should be focused");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_LeftArrow_OnChild_MovesToParent()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -428,10 +427,10 @@ public class TreeIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(IsFocused(snapshot, "Parent"), "Parent should be focused");
+        Assert.IsTrue(IsFocused(snapshot, "Parent"), "Parent should be focused");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_Enter_ActivatesItem()
     {
         var activatedLabel = "";
@@ -456,14 +455,14 @@ public class TreeIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("Item 2", activatedLabel);
+        Assert.AreEqual("Item 2", activatedLabel);
     }
 
     #endregion
 
     #region Multi-Select Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_MultiSelect_SpaceTogglesSelection()
     {
         var selectedCount = 0;
@@ -497,12 +496,12 @@ public class TreeIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal(2, selectedCount);
+        Assert.AreEqual(2, selectedCount);
         // Should have checked boxes for selected items
-        Assert.True(snapshot.ContainsText(CheckboxChecked), "Should show checked checkbox");
+        Assert.IsTrue(snapshot.ContainsText(CheckboxChecked), "Should show checked checkbox");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_MultiSelect_SpaceTogglesOff()
     {
         var selectedCount = 0;
@@ -533,10 +532,10 @@ public class TreeIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal(0, selectedCount);
+        Assert.AreEqual(0, selectedCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_MultiSelect_RendersCheckboxes()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -557,15 +556,15 @@ public class TreeIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText(CheckboxUnchecked), "Should show unchecked checkbox");
-        Assert.True(snapshot.ContainsText(CheckboxChecked), "Should show checked checkbox");
+        Assert.IsTrue(snapshot.ContainsText(CheckboxUnchecked), "Should show unchecked checkbox");
+        Assert.IsTrue(snapshot.ContainsText(CheckboxChecked), "Should show checked checkbox");
     }
 
     #endregion
 
     #region Mouse Interaction Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_MouseClick_SelectsItem()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -593,14 +592,14 @@ public class TreeIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(IsFocused(snapshot, "Item 2"), "Item 2 should be focused after click");
+        Assert.IsTrue(IsFocused(snapshot, "Item 2"), "Item 2 should be focused after click");
     }
 
     #endregion
 
     #region Border Containment Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_InBorder_RendersCorrectly()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -626,17 +625,17 @@ public class TreeIntegrationTests
         await runTask;
 
         // Verify border is present
-        Assert.True(snapshot.ContainsText("My Tree"), "Border title should be visible");
-        Assert.True(snapshot.ContainsText("┌") || snapshot.ContainsText("╭"), "Border top-left corner should be visible");
-        Assert.True(snapshot.ContainsText("┐") || snapshot.ContainsText("╮"), "Border top-right corner should be visible");
+        Assert.IsTrue(snapshot.ContainsText("My Tree"), "Border title should be visible");
+        Assert.IsTrue(snapshot.ContainsText("┌") || snapshot.ContainsText("╭"), "Border top-left corner should be visible");
+        Assert.IsTrue(snapshot.ContainsText("┐") || snapshot.ContainsText("╮"), "Border top-right corner should be visible");
         
         // Verify tree content is inside
-        Assert.True(snapshot.ContainsText("Root"));
-        Assert.True(snapshot.ContainsText("Child 1"));
-        Assert.True(snapshot.ContainsText("Child 2"));
+        Assert.IsTrue(snapshot.ContainsText("Root"));
+        Assert.IsTrue(snapshot.ContainsText("Child 1"));
+        Assert.IsTrue(snapshot.ContainsText("Child 2"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_InBorder_BorderCornersAtCorrectPositions()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -661,8 +660,7 @@ public class TreeIntegrationTests
 
         // Check top-left corner at (0,0)
         var topLeft = snapshot.GetCell(0, 0);
-        Assert.True(topLeft.Character == "┌" || topLeft.Character == "╭", 
-            $"Top-left should be border corner, got '{topLeft.Character}'");
+        Assert.IsTrue(topLeft.Character == "┌" || topLeft.Character == "╭", $"Top-left should be border corner, got '{topLeft.Character}'");
         
         // Check top-right corner (find the right edge)
         var positions = snapshot.FindText("┐");
@@ -670,10 +668,10 @@ public class TreeIntegrationTests
         {
             positions = snapshot.FindText("╮");
         }
-        Assert.NotEmpty(positions);
+        Assert.IsNotEmpty(positions);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_InNestedBorders_RendersCorrectly()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -698,16 +696,16 @@ public class TreeIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Outer"));
-        Assert.True(snapshot.ContainsText("Inner"));
-        Assert.True(snapshot.ContainsText("Deep Item"));
+        Assert.IsTrue(snapshot.ContainsText("Outer"));
+        Assert.IsTrue(snapshot.ContainsText("Inner"));
+        Assert.IsTrue(snapshot.ContainsText("Deep Item"));
     }
 
     #endregion
 
     #region Clipping Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_Clipping_LongLabelsTruncated()
     {
         var longLabel = "This is a very long label that should be clipped when rendered in a narrow container";
@@ -732,12 +730,12 @@ public class TreeIntegrationTests
         await runTask;
 
         // The full label should NOT appear (it should be clipped)
-        Assert.False(snapshot.ContainsText("narrow container"), "Long text should be clipped");
+        Assert.IsFalse(snapshot.ContainsText("narrow container"), "Long text should be clipped");
         // But the beginning should be visible
-        Assert.True(snapshot.ContainsText("This is"), "Beginning of text should be visible");
+        Assert.IsTrue(snapshot.ContainsText("This is"), "Beginning of text should be visible");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_Clipping_ContentStaysWithinBorder()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -771,18 +769,18 @@ public class TreeIntegrationTests
 
         // Find the position of "Right Side" - it should be in the right panel
         var rightPositions = snapshot.FindText("Right");
-        Assert.NotEmpty(rightPositions);
+        Assert.IsNotEmpty(rightPositions);
         var (rightLine, rightColumn) = rightPositions[0];
         
         // The right content should be past column 20 (the left panel's width)
-        Assert.True(rightColumn >= 18, $"Right content should be in right panel, but was at column {rightColumn}");
+        Assert.IsTrue(rightColumn >= 18, $"Right content should be in right panel, but was at column {rightColumn}");
     }
 
     #endregion
 
     #region Tab Navigation Between Trees
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_TabNavigatesBetweenMultipleTrees()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -826,17 +824,17 @@ public class TreeIntegrationTests
         await runTask;
 
         // Left tree should have focus initially
-        Assert.True(IsFocused(captureLeft, "Left Item 1"), "Left Item 1 should be initially focused");
+        Assert.IsTrue(IsFocused(captureLeft, "Left Item 1"), "Left Item 1 should be initially focused");
         
         // After Tab, right tree should have focus
-        Assert.True(IsFocused(captureRight, "Right Item 1"), "Right Item 1 should be focused after Tab");
+        Assert.IsTrue(IsFocused(captureRight, "Right Item 1"), "Right Item 1 should be focused after Tab");
     }
 
     #endregion
 
     #region Deep Tree Navigation
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_DeepNavigation_TraversesAllLevels()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -861,10 +859,10 @@ public class TreeIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(IsFocused(snapshot, "Level 4"), "Level 4 should be focused after navigating down");
+        Assert.IsTrue(IsFocused(snapshot, "Level 4"), "Level 4 should be focused after navigating down");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_DeepNavigation_LeftArrowNavigatesToParent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -895,18 +893,18 @@ public class TreeIntegrationTests
         await runTask;
 
         // Level 4 has no children, so Left moves to parent Level 3
-        Assert.True(IsFocused(snapshot, "Level 3"), "Level 3 should be focused after Left from Level 4 (move to parent)");
+        Assert.IsTrue(IsFocused(snapshot, "Level 3"), "Level 3 should be focused after Left from Level 4 (move to parent)");
     }
 
     #endregion
 
     #region Guide Style Verification
 
-    [Theory]
-    [InlineData("├─ ", "└─ ", "│  ", "├─", "└─")]  // Unicode (default)
-    [InlineData("+- ", "\\- ", "|  ", "+-", "\\-")]  // ASCII
-    [InlineData("┣━ ", "┗━ ", "┃  ", "┣━", "┗━")]  // Bold
-    [InlineData("╠═ ", "╚═ ", "║  ", "╠═", "╚═")]  // Double
+    [TestMethod]
+    [DataRow("├─ ", "└─ ", "│  ", "├─", "└─")]  // Unicode (default)
+    [DataRow("+- ", "\\- ", "|  ", "+-", "\\-")]  // ASCII
+    [DataRow("┣━ ", "┗━ ", "┃  ", "┣━", "┗━")]  // Bold
+    [DataRow("╠═ ", "╚═ ", "║  ", "╠═", "╚═")]  // Double
     public async Task Tree_GuideTheme_RendersCorrectCharacters(
         string branch, string lastBranch, string vertical, 
         string expectedBranch, string expectedLastBranch)
@@ -938,15 +936,14 @@ public class TreeIntegrationTests
         await runTask;
 
         // At least one of branch or lastBranch should be present
-        Assert.True(snapshot.ContainsText(expectedBranch) || snapshot.ContainsText(expectedLastBranch),
-            $"Should contain guide characters ('{expectedBranch}' or '{expectedLastBranch}')");
+        Assert.IsTrue(snapshot.ContainsText(expectedBranch) || snapshot.ContainsText(expectedLastBranch), $"Should contain guide characters ('{expectedBranch}' or '{expectedLastBranch}')");
     }
 
     #endregion
 
     #region Expand/Collapse Event Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_OnExpanded_FiresEvent()
     {
         var expandedLabel = "";
@@ -978,10 +975,10 @@ public class TreeIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("Parent", expandedLabel);
+        Assert.AreEqual("Parent", expandedLabel);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_OnCollapsed_FiresEvent()
     {
         var collapsedLabel = "";
@@ -1013,10 +1010,10 @@ public class TreeIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("Parent", collapsedLabel);
+        Assert.AreEqual("Parent", collapsedLabel);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_OnExpanding_AsyncLazyLoadsChildren()
     {
         var loadCalled = new TaskCompletionSource<bool>();
@@ -1034,10 +1031,10 @@ public class TreeIntegrationTests
         var treeNode = await treeWidget.ReconcileAsync(null, context) as TreeNode;
         
         // Verify initial state
-        Assert.True(treeNode!.Items[0].HasChildren, "HasChildren should be true");
-        Assert.NotNull(treeNode.Items[0].SourceWidget?.ExpandingAsyncHandler);
-        Assert.Empty(treeNode.Items[0].Children);
-        Assert.Single(treeNode.FlattenedItems); // Only Parent
+        Assert.IsTrue(treeNode!.Items[0].HasChildren, "HasChildren should be true");
+        Assert.IsNotNull(treeNode.Items[0].SourceWidget?.ExpandingAsyncHandler);
+        Assert.IsEmpty(treeNode.Items[0].Children);
+        TestSeq.Single(treeNode.FlattenedItems); // Only Parent
         
         // Expand - this starts async work in background
         var focusRing = new FocusRing();
@@ -1046,23 +1043,23 @@ public class TreeIntegrationTests
         
         // Wait for the async handler to be called (with timeout)
         var wasLoaded = await loadCalled.Task.WaitAsync(TimeSpan.FromSeconds(5));
-        Assert.True(wasLoaded, "OnExpanding handler should have been called");
+        Assert.IsTrue(wasLoaded, "OnExpanding handler should have been called");
         
         // Wait a bit more for the children to be loaded
         await Task.Delay(100);
         
         // Verify expanded state
-        Assert.True(treeNode.Items[0].IsExpanded, "Should be expanded");
-        Assert.Single(treeNode.Items[0].Children);
-        Assert.Equal("LazyChild", treeNode.Items[0].Children[0].Label);
-        Assert.Equal(2, treeNode.FlattenedItems.Count); // Parent + LazyChild
+        Assert.IsTrue(treeNode.Items[0].IsExpanded, "Should be expanded");
+        TestSeq.Single(treeNode.Items[0].Children);
+        Assert.AreEqual("LazyChild", treeNode.Items[0].Children[0].Label);
+        Assert.AreEqual(2, treeNode.FlattenedItems.Count); // Parent + LazyChild
     }
 
     #endregion
 
     #region Initial State Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_FirstItemFocusedOnRender()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -1085,10 +1082,10 @@ public class TreeIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(IsFocused(snapshot, "First"), "First item should be initially focused");
+        Assert.IsTrue(IsFocused(snapshot, "First"), "First item should be initially focused");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_PreExpandedItems_ShowChildren()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -1111,14 +1108,14 @@ public class TreeIntegrationTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.True(snapshot.ContainsText("Visible Child"), "Pre-expanded item should show children");
+        Assert.IsTrue(snapshot.ContainsText("Visible Child"), "Pre-expanded item should show children");
     }
 
     #endregion
 
     #region Border Rendering Investigation
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_BorderRendering_Investigation()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1171,22 +1168,22 @@ public class TreeIntegrationTests
         await runTask;
 
         // Verify borders are present and correctly rendered
-        Assert.True(snapshot.ContainsText("📂 Files"), "Left border title should be visible");
-        Assert.True(snapshot.ContainsText("✅ Select"), "Right border title should be visible");
+        Assert.IsTrue(snapshot.ContainsText("📂 Files"), "Left border title should be visible");
+        Assert.IsTrue(snapshot.ContainsText("✅ Select"), "Right border title should be visible");
         
         // Verify that borders are correctly aligned at cell level
         // The two borders should be at columns 49 and 50 on line 7 (Pictures line)
         var leftBorderCell = snapshot.GetCell(49, 7);
         var rightBorderCell = snapshot.GetCell(50, 7);
-        Assert.Equal("│", leftBorderCell.Character);
-        Assert.Equal("│", rightBorderCell.Character);
+        Assert.AreEqual("│", leftBorderCell.Character);
+        Assert.AreEqual("│", rightBorderCell.Character);
     }
 
     #endregion
 
     #region Async Expansion Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_AsyncExpansion_ShowsChildrenAfterLoad()
     {
         var loadCompleted = new TaskCompletionSource<bool>();
@@ -1233,8 +1230,7 @@ public class TreeIntegrationTests
         var initialText = initialSnapshot.GetScreenText();
         
         // Check if there's a focus indicator and collapsed indicator
-        Assert.True(initialSnapshot.ContainsText("▶") || initialSnapshot.ContainsText("Parent"), 
-            $"Initial screen should show Parent. Screen:\n{initialText}");
+        Assert.IsTrue(initialSnapshot.ContainsText("▶") || initialSnapshot.ContainsText("Parent"), $"Initial screen should show Parent. Screen:\n{initialText}");
 
         // Press Tab to ensure tree has focus, then Right arrow to expand
         await new Hex1bTerminalInputSequenceBuilder()
@@ -1278,15 +1274,15 @@ public class TreeIntegrationTests
         await runTask;
 
         // Debug info
-        Assert.True(childrenReturned == 2, $"Handler should have returned 2 children, got {childrenReturned}");
+        Assert.IsTrue(childrenReturned == 2, $"Handler should have returned 2 children, got {childrenReturned}");
 
         // Verify children are now visible
-        Assert.True(finalSnapshot.ContainsText("▼"), $"Parent should show expanded indicator. Screen:\n{finalText}");
-        Assert.True(finalSnapshot.ContainsText("Child1"), $"Child1 should be visible after expansion. Screen:\n{finalText}");
-        Assert.True(finalSnapshot.ContainsText("Child2"), $"Child2 should be visible after expansion. Screen:\n{finalText}");
+        Assert.IsTrue(finalSnapshot.ContainsText("▼"), $"Parent should show expanded indicator. Screen:\n{finalText}");
+        Assert.IsTrue(finalSnapshot.ContainsText("Child1"), $"Child1 should be visible after expansion. Screen:\n{finalText}");
+        Assert.IsTrue(finalSnapshot.ContainsText("Child2"), $"Child2 should be visible after expansion. Screen:\n{finalText}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Tree_AsyncExpansion_ShowsSpinnerDuringLoad()
     {
         var loadStarted = new TaskCompletionSource<bool>();
@@ -1376,8 +1372,7 @@ public class TreeIntegrationTests
         var spinnerChars = new[] { "⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏" };
         var spinnerSeen = spinnerFramesSeen.Any(frame => spinnerChars.Any(c => frame.Contains(c)));
         
-        Assert.True(spinnerSeen, 
-            $"Should have seen spinner animation during load. Frames captured:\n{string.Join("\n---\n", spinnerFramesSeen)}");
+        Assert.IsTrue(spinnerSeen, $"Should have seen spinner animation during load. Frames captured:\n{string.Join("\n---\n", spinnerFramesSeen)}");
     }
 
     #endregion

--- a/tests/Hex1b.Tests/TreeNodeTests.cs
+++ b/tests/Hex1b.Tests/TreeNodeTests.cs
@@ -10,6 +10,7 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for TreeNode and TreeItemNode behavior.
 /// </summary>
+[TestClass]
 public class TreeNodeTests
 {
     #region Helper Methods
@@ -45,68 +46,68 @@ public class TreeNodeTests
 
     #region Reconciliation Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_CreatesTreeNode()
     {
         var widget = CreateSimpleTree();
         
         var node = await ReconcileTreeAsync(widget);
         
-        Assert.NotNull(node);
-        Assert.IsType<TreeNode>(node);
+        Assert.IsNotNull(node);
+        TestSeq.IsType<TreeNode>(node);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_CreatesCorrectItemCount()
     {
         var widget = CreateSimpleTree();
         
         var node = await ReconcileTreeAsync(widget);
         
-        Assert.Equal(2, node.Items.Count); // 2 root items
-        Assert.Equal(2, node.Items[0].Children.Count); // Root 1 has 2 children
-        Assert.Single(node.Items[0].Children[1].Children); // Child 1.2 has 1 grandchild
+        Assert.AreEqual(2, node.Items.Count); // 2 root items
+        Assert.AreEqual(2, node.Items[0].Children.Count); // Root 1 has 2 children
+        TestSeq.Single(node.Items[0].Children[1].Children); // Child 1.2 has 1 grandchild
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_SetsLabelsCorrectly()
     {
         var widget = CreateSimpleTree();
         
         var node = await ReconcileTreeAsync(widget);
         
-        Assert.Equal("Root 1", node.Items[0].Label);
-        Assert.Equal("Root 2", node.Items[1].Label);
-        Assert.Equal("Child 1.1", node.Items[0].Children[0].Label);
+        Assert.AreEqual("Root 1", node.Items[0].Label);
+        Assert.AreEqual("Root 2", node.Items[1].Label);
+        Assert.AreEqual("Child 1.1", node.Items[0].Children[0].Label);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_SetsIsExpandedCorrectly()
     {
         var widget = CreateSimpleTree();
         
         var node = await ReconcileTreeAsync(widget);
         
-        Assert.True(node.Items[0].IsExpanded); // Root 1 is expanded
-        Assert.False(node.Items[1].IsExpanded); // Root 2 is not expanded
+        Assert.IsTrue(node.Items[0].IsExpanded); // Root 1 is expanded
+        Assert.IsFalse(node.Items[1].IsExpanded); // Root 2 is not expanded
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_SetsIsLastChildCorrectly()
     {
         var widget = CreateSimpleTree();
         
         var node = await ReconcileTreeAsync(widget);
         
-        Assert.False(node.Items[0].IsLastChild); // Root 1 is not last
-        Assert.True(node.Items[1].IsLastChild); // Root 2 is last
+        Assert.IsFalse(node.Items[0].IsLastChild); // Root 1 is not last
+        Assert.IsTrue(node.Items[1].IsLastChild); // Root 2 is last
     }
 
     #endregion
 
     #region Flattened View Tests
 
-    [Fact]
+    [TestMethod]
     public async Task RebuildFlattenedView_IncludesExpandedItems()
     {
         var widget = CreateSimpleTree();
@@ -114,10 +115,10 @@ public class TreeNodeTests
         
         // Root 1 is expanded, should show: Root 1, Child 1.1, Child 1.2, Root 2
         // (Grandchild not shown because Child 1.2 is not expanded)
-        Assert.Equal(4, node.FlattenedItems.Count);
+        Assert.AreEqual(4, node.FlattenedItems.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RebuildFlattenedView_ExcludesCollapsedChildren()
     {
         var widget = new TreeWidget([
@@ -130,26 +131,26 @@ public class TreeNodeTests
         
         var node = await ReconcileTreeAsync(widget);
         
-        Assert.Single(node.FlattenedItems); // Only Root visible
+        TestSeq.Single(node.FlattenedItems); // Only Root visible
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RebuildFlattenedView_SetsDepthCorrectly()
     {
         var widget = CreateSimpleTree();
         var node = await ReconcileTreeAsync(widget);
         
-        Assert.Equal(0, node.FlattenedItems[0].Depth); // Root 1
-        Assert.Equal(1, node.FlattenedItems[1].Depth); // Child 1.1
-        Assert.Equal(1, node.FlattenedItems[2].Depth); // Child 1.2
-        Assert.Equal(0, node.FlattenedItems[3].Depth); // Root 2
+        Assert.AreEqual(0, node.FlattenedItems[0].Depth); // Root 1
+        Assert.AreEqual(1, node.FlattenedItems[1].Depth); // Child 1.1
+        Assert.AreEqual(1, node.FlattenedItems[2].Depth); // Child 1.2
+        Assert.AreEqual(0, node.FlattenedItems[3].Depth); // Root 2
     }
 
     #endregion
 
     #region Measure Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_ReturnsCorrectHeight()
     {
         var widget = CreateSimpleTree();
@@ -158,10 +159,10 @@ public class TreeNodeTests
         var size = node.Measure(Constraints.Unbounded);
         
         // 4 visible items
-        Assert.Equal(4, size.Height);
+        Assert.AreEqual(4, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_ReturnsCorrectWidth()
     {
         var widget = new TreeWidget([
@@ -173,10 +174,10 @@ public class TreeNodeTests
         var size = node.Measure(Constraints.Unbounded);
         
         // Width = indicator (2) + longest label
-        Assert.True(size.Width >= "Much Longer Label".Length + 2);
+        Assert.IsTrue(size.Width >= "Much Longer Label".Length + 2);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_EmptyTree_ReturnsZeroHeight()
     {
         var widget = new TreeWidget([]);
@@ -184,10 +185,10 @@ public class TreeNodeTests
         
         var size = node.Measure(Constraints.Unbounded);
         
-        Assert.Equal(0, size.Height);
+        Assert.AreEqual(0, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_IncludesGuideWidth()
     {
         var widget = new TreeWidget([
@@ -208,38 +209,38 @@ public class TreeNodeTests
         var size = node.Measure(Constraints.Unbounded);
         
         // Grandchild at depth 2 should add 6 chars for guides (2 levels * 3 chars each)
-        Assert.True(size.Width >= "Grandchild".Length + 2 + 6);
+        Assert.IsTrue(size.Width >= "Grandchild".Length + 2 + 6);
     }
 
     #endregion
 
     #region Focus Navigation Tests
 
-    [Fact]
+    [TestMethod]
     public async Task FirstItem_HasInitialFocus()
     {
         var widget = CreateSimpleTree();
         var node = await ReconcileTreeAsync(widget);
         
-        Assert.True(node.FlattenedItems[0].Node.IsFocused);
-        Assert.False(node.FlattenedItems[1].Node.IsFocused);
+        Assert.IsTrue(node.FlattenedItems[0].Node.IsFocused);
+        Assert.IsFalse(node.FlattenedItems[1].Node.IsFocused);
     }
 
     #endregion
 
     #region Multi-Select Tests
 
-    [Fact]
+    [TestMethod]
     public async Task MultiSelect_SetsToggleSelectCallback()
     {
         var widget = CreateSimpleTree().MultiSelect();
         var node = await ReconcileTreeAsync(widget);
         
         // All items should have ToggleSelectCallback set
-        Assert.NotNull(node.Items[0].ToggleSelectCallback);
+        Assert.IsNotNull(node.Items[0].ToggleSelectCallback);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetSelectedItems_ReturnsSelectedItems()
     {
         var widget = new TreeWidget([
@@ -250,15 +251,15 @@ public class TreeNodeTests
         
         var selected = node.GetSelectedItems();
         
-        Assert.Single(selected);
-        Assert.Equal("Selected", selected[0].Label);
+        TestSeq.Single(selected);
+        Assert.AreEqual("Selected", selected[0].Label);
     }
 
     #endregion
 
     #region Icon Tests
 
-    [Fact]
+    [TestMethod]
     public async Task TreeItem_WithIcon_SetsIconProperty()
     {
         var widget = new TreeWidget([
@@ -266,27 +267,27 @@ public class TreeNodeTests
         ]);
         var node = await ReconcileTreeAsync(widget);
         
-        Assert.Equal("📁", node.Items[0].Icon);
+        Assert.AreEqual("📁", node.Items[0].Icon);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetDisplayText_WithIcon_IncludesIcon()
     {
         var item = new TreeItemNode { Label = "Test", Icon = "📁" };
         
         var displayText = item.GetDisplayText();
         
-        Assert.Equal("📁 Test", displayText);
+        Assert.AreEqual("📁 Test", displayText);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task GetDisplayText_WithoutIcon_ReturnsLabel()
     {
         var item = new TreeItemNode { Label = "Test" };
         
         var displayText = item.GetDisplayText();
         
-        Assert.Equal("Test", displayText);
+        Assert.AreEqual("Test", displayText);
     }
 
     #endregion
@@ -297,7 +298,7 @@ public class TreeNodeTests
 
     #region TreeItemWidget Fluent API Tests
 
-    [Fact]
+    [TestMethod]
     public void TreeItemWidget_FluentApi_ChainsCorrectly()
     {
         var item = new TreeItemWidget("Test")
@@ -306,15 +307,15 @@ public class TreeNodeTests
             .Selected(true)
             .Data("user-data");
         
-        Assert.Equal("Test", item.Label);
-        Assert.Equal("📁", item.IconValue);
-        Assert.True(item.IsExpanded);
-        Assert.True(item.IsSelected);
-        Assert.Equal("user-data", item.DataValue);
-        Assert.Equal(typeof(string), item.DataType);
+        Assert.AreEqual("Test", item.Label);
+        Assert.AreEqual("📁", item.IconValue);
+        Assert.IsTrue(item.IsExpanded);
+        Assert.IsTrue(item.IsSelected);
+        Assert.AreEqual("user-data", item.DataValue);
+        Assert.AreEqual(typeof(string), item.DataType);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TreeItemNode_GetData_ReturnsTypedData()
     {
         var widget = new TreeWidget([
@@ -327,10 +328,10 @@ public class TreeNodeTests
         var itemNode = node!.Items[0];
         var data = itemNode.GetData<string>();
         
-        Assert.Equal("my-data", data);
+        Assert.AreEqual("my-data", data);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TreeItemNode_GetData_ThrowsOnTypeMismatch()
     {
         var widget = new TreeWidget([
@@ -342,10 +343,10 @@ public class TreeNodeTests
         
         var itemNode = node!.Items[0];
         
-        Assert.Throws<InvalidCastException>(() => itemNode.GetData<int>());
+        Assert.ThrowsExactly<InvalidCastException>(() => itemNode.GetData<int>());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TreeItemNode_TryGetData_ReturnsFalseOnTypeMismatch()
     {
         var widget = new TreeWidget([
@@ -357,61 +358,61 @@ public class TreeNodeTests
         
         var itemNode = node!.Items[0];
         
-        Assert.False(itemNode.TryGetData<int>(out _));
-        Assert.True(itemNode.TryGetData<string>(out var data));
-        Assert.Equal("string-data", data);
+        Assert.IsFalse(itemNode.TryGetData<int>(out _));
+        Assert.IsTrue(itemNode.TryGetData<string>(out var data));
+        Assert.AreEqual("string-data", data);
     }
 
-    [Fact]
+    [TestMethod]
     public void TreeItemWidget_WithChildren_SetsHasChildren()
     {
         var child = new TreeItemWidget("Child");
         var parent = new TreeItemWidget("Parent").Children(child);
         
-        Assert.True(parent.HasChildren);
-        Assert.Single(parent.ChildItems);
+        Assert.IsTrue(parent.HasChildren);
+        TestSeq.Single(parent.ChildItems);
     }
 
-    [Fact]
+    [TestMethod]
     public void TreeItemWidget_OnExpanding_SetsHasChildren()
     {
         var item = new TreeItemWidget("Lazy")
             .OnExpanding(_ => [new TreeItemWidget("Loaded")]);
         
-        Assert.True(item.HasChildren);
-        Assert.NotNull(item.ExpandingHandler);
+        Assert.IsTrue(item.HasChildren);
+        Assert.IsNotNull(item.ExpandingHandler);
     }
 
     #endregion
 
     #region CanExpand Tests
 
-    [Fact]
+    [TestMethod]
     public void TreeItemNode_CanExpand_TrueWhenHasChildren()
     {
         var node = new TreeItemNode { HasChildren = true };
-        Assert.True(node.CanExpand);
+        Assert.IsTrue(node.CanExpand);
     }
 
-    [Fact]
+    [TestMethod]
     public void TreeItemNode_CanExpand_TrueWhenHasActualChildren()
     {
         var node = new TreeItemNode { Children = [new TreeItemNode { Label = "Child" }] };
-        Assert.True(node.CanExpand);
+        Assert.IsTrue(node.CanExpand);
     }
 
-    [Fact]
+    [TestMethod]
     public void TreeItemNode_CanExpand_FalseWhenNoChildren()
     {
         var node = new TreeItemNode();
-        Assert.False(node.CanExpand);
+        Assert.IsFalse(node.CanExpand);
     }
 
     #endregion
 
     #region Input Binding Tests
 
-    [Fact]
+    [TestMethod]
     public async Task TreeNode_HasInputBindings()
     {
         var widget = CreateSimpleTree();
@@ -421,10 +422,10 @@ public class TreeNodeTests
         var bindings = builder.Build();
         
         // Should have Up, Down, Left, Right, Enter, Space bindings at minimum
-        Assert.True(bindings.Count >= 6, $"Expected at least 6 bindings, got {bindings.Count}");
+        Assert.IsTrue(bindings.Count >= 6, $"Expected at least 6 bindings, got {bindings.Count}");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TreeNode_Expand_ChangesIsExpanded()
     {
         var widget = new TreeWidget([
@@ -435,8 +436,8 @@ public class TreeNodeTests
         var node = await ReconcileTreeAsync(widget);
         
         // Initially collapsed
-        Assert.False(node.Items[0].IsExpanded);
-        Assert.Single(node.FlattenedItems); // Only Parent visible
+        Assert.IsFalse(node.Items[0].IsExpanded);
+        TestSeq.Single(node.FlattenedItems); // Only Parent visible
         
         // Toggle expand
         var focusRing = new FocusRing();
@@ -444,11 +445,11 @@ public class TreeNodeTests
         await node.ToggleExpandAsync(node.Items[0], ctx);
         
         // Now expanded
-        Assert.True(node.Items[0].IsExpanded);
-        Assert.Equal(2, node.FlattenedItems.Count); // Parent and Child visible
+        Assert.IsTrue(node.Items[0].IsExpanded);
+        Assert.AreEqual(2, node.FlattenedItems.Count); // Parent and Child visible
     }
 
-    [Fact]
+    [TestMethod]
     public async Task TreeNode_Collapse_ChangesIsExpanded()
     {
         var widget = new TreeWidget([
@@ -459,8 +460,8 @@ public class TreeNodeTests
         var node = await ReconcileTreeAsync(widget);
         
         // Initially expanded
-        Assert.True(node.Items[0].IsExpanded);
-        Assert.Equal(2, node.FlattenedItems.Count); // Parent and Child visible
+        Assert.IsTrue(node.Items[0].IsExpanded);
+        Assert.AreEqual(2, node.FlattenedItems.Count); // Parent and Child visible
         
         // Toggle collapse
         var focusRing = new FocusRing();
@@ -468,8 +469,8 @@ public class TreeNodeTests
         await node.ToggleExpandAsync(node.Items[0], ctx);
         
         // Now collapsed
-        Assert.False(node.Items[0].IsExpanded);
-        Assert.Single(node.FlattenedItems); // Only Parent visible
+        Assert.IsFalse(node.Items[0].IsExpanded);
+        TestSeq.Single(node.FlattenedItems); // Only Parent visible
     }
 
     #endregion

--- a/tests/Hex1b.Tests/UnicodeBorderAlignmentTests.cs
+++ b/tests/Hex1b.Tests/UnicodeBorderAlignmentTests.cs
@@ -22,6 +22,7 @@ namespace Hex1b.Tests;
 /// 2. Render to the terminal once per category (not per character)
 /// 3. Verify the right border column is consistent across all rows
 /// </summary>
+[TestClass]
 public class UnicodeBorderAlignmentTests
 {
     private const int TerminalWidth = 80;
@@ -281,8 +282,7 @@ public class UnicodeBorderAlignmentTests
             var details = string.Join("\n", borderPositions.Select(p => 
                 $"  Line {p.lineNum}: border at column {p.column}"));
             
-            Assert.Fail(
-                $"Border misalignment detected for '{charDescription}' (char: {testChar})\n" +
+            Assert.Fail($"Border misalignment detected for '{charDescription}' (char: {testChar})\n" +
                 $"Expected all borders at column {expectedPosition}, but found:\n{details}\n\n" +
                 $"Screen:\n{snapshot.GetText()}");
         }
@@ -446,8 +446,7 @@ public class UnicodeBorderAlignmentTests
             var details = string.Join("\n", misaligned.Select(p => 
                 $"  Line {p.lineNum} (col {p.column}): {p.lineContent.Substring(0, Math.Min(50, p.lineContent.Length))}..."));
             
-            Assert.Fail(
-                $"Border misalignment in '{categoryName}'\n" +
+            Assert.Fail($"Border misalignment in '{categoryName}'\n" +
                 $"Expected all borders at column {expectedPosition}\n\n" +
                 $"Failed characters:\n{string.Join("\n", failedChars)}\n\n" +
                 $"Misaligned lines:\n{details}\n\n" +
@@ -474,13 +473,13 @@ public class UnicodeBorderAlignmentTests
     
     #region Category Tests
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_AsciiCharacters_AlignCorrectly()
     {
         await AssertBorderAlignmentBatchAsync(AsciiChars, "ASCII", TestContext.Current.CancellationToken);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_KnownProblematicChars_AlignCorrectly()
     {
         // This is the most important test - these are characters that have been
@@ -488,103 +487,103 @@ public class UnicodeBorderAlignmentTests
         await AssertBorderAlignmentBatchAsync(KnownProblematicChars, "Known Problematic", TestContext.Current.CancellationToken);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_SimpleEmoji_AlignCorrectly()
     {
         await AssertBorderAlignmentBatchAsync(SimpleEmoji, "Simple Emoji", TestContext.Current.CancellationToken);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_SkinToneEmoji_AlignCorrectly()
     {
         await AssertBorderAlignmentBatchAsync(SkinToneEmoji, "Skin Tone Emoji", TestContext.Current.CancellationToken);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_ZwjEmoji_AlignCorrectly()
     {
         await AssertBorderAlignmentBatchAsync(ZwjEmoji, "ZWJ Emoji", TestContext.Current.CancellationToken);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_FlagEmoji_AlignCorrectly()
     {
         await AssertBorderAlignmentBatchAsync(FlagEmoji, "Flag Emoji", TestContext.Current.CancellationToken);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_CjkCharacters_AlignCorrectly()
     {
         await AssertBorderAlignmentBatchAsync(CjkChars, "CJK", TestContext.Current.CancellationToken);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_CombiningCharacters_AlignCorrectly()
     {
         await AssertBorderAlignmentBatchAsync(CombiningChars, "Combining Characters", TestContext.Current.CancellationToken);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_KeycapEmoji_AlignCorrectly()
     {
         await AssertBorderAlignmentBatchAsync(KeycapEmoji, "Keycap Emoji", TestContext.Current.CancellationToken);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_VariationSelectors_AlignCorrectly()
     {
         await AssertBorderAlignmentBatchAsync(VariationSelectors, "Variation Selectors", TestContext.Current.CancellationToken);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_BoxDrawing_AlignCorrectly()
     {
         await AssertBorderAlignmentBatchAsync(BoxDrawing, "Box Drawing", TestContext.Current.CancellationToken);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_MathSymbols_AlignCorrectly()
     {
         await AssertBorderAlignmentBatchAsync(MathSymbols, "Math Symbols", TestContext.Current.CancellationToken);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_CurrencySymbols_AlignCorrectly()
     {
         await AssertBorderAlignmentBatchAsync(CurrencySymbols, "Currency Symbols", TestContext.Current.CancellationToken);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_GreekLetters_AlignCorrectly()
     {
         await AssertBorderAlignmentBatchAsync(GreekLetters, "Greek Letters", TestContext.Current.CancellationToken);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_FullWidthCharacters_AlignCorrectly()
     {
         await AssertBorderAlignmentBatchAsync(FullWidthChars, "Full Width", TestContext.Current.CancellationToken);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_HalfWidthKatakana_AlignCorrectly()
     {
         await AssertBorderAlignmentBatchAsync(HalfWidthKatakana, "Half Width Katakana", TestContext.Current.CancellationToken);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_ThaiCharacters_AlignCorrectly()
     {
         await AssertBorderAlignmentBatchAsync(ThaiChars, "Thai", TestContext.Current.CancellationToken);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_ArabicCharacters_AlignCorrectly()
     {
         await AssertBorderAlignmentBatchAsync(ArabicChars, "Arabic", TestContext.Current.CancellationToken);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_HebrewCharacters_AlignCorrectly()
     {
         await AssertBorderAlignmentBatchAsync(HebrewChars, "Hebrew", TestContext.Current.CancellationToken);
@@ -594,7 +593,7 @@ public class UnicodeBorderAlignmentTests
     
     #region Mixed Content Tests
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_MixedAsciiAndEmoji_AlignCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -635,7 +634,7 @@ public class UnicodeBorderAlignmentTests
         AssertRightBorderAligned(snapshot, "Mixed ASCII and Emoji", "mixed");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_MultipleEmojiPerLine_AlignCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -676,7 +675,7 @@ public class UnicodeBorderAlignmentTests
         AssertRightBorderAligned(snapshot, "Multiple Emoji Per Line", "multiple emoji");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_CjkMixedWithAscii_AlignCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -721,7 +720,7 @@ public class UnicodeBorderAlignmentTests
     
     #region Edge Cases
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_EmptyString_AlignCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -762,7 +761,7 @@ public class UnicodeBorderAlignmentTests
         AssertRightBorderAligned(snapshot, "Empty String", "empty");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_OnlySpaces_AlignCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -802,7 +801,7 @@ public class UnicodeBorderAlignmentTests
         AssertRightBorderAligned(snapshot, "Only Spaces", "spaces");
     }
     
-    [Fact]
+    [TestMethod]
     public async Task BorderAlignment_LongTextWithEmoji_AlignCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -851,22 +850,22 @@ public class UnicodeBorderAlignmentTests
     /// Tests a range of Unicode codepoints for border alignment.
     /// Uses batch testing - all characters in a range are tested in a single render.
     /// </summary>
-    [Theory]
-    [InlineData(0x0080, 0x00FF, "Latin-1 Supplement")]           // Accented chars, symbols
-    [InlineData(0x0100, 0x017F, "Latin Extended-A")]             // European Latin
-    [InlineData(0x0370, 0x03FF, "Greek and Coptic")]             // Greek
-    [InlineData(0x0400, 0x04FF, "Cyrillic")]                     // Russian, etc.
-    [InlineData(0x2000, 0x206F, "General Punctuation")]          // Special spaces, dashes
-    [InlineData(0x2190, 0x21FF, "Arrows")]                       // Arrow symbols
-    [InlineData(0x2200, 0x22FF, "Mathematical Operators")]       // Math symbols
-    [InlineData(0x2300, 0x23FF, "Miscellaneous Technical")]      // Technical symbols
-    [InlineData(0x2500, 0x257F, "Box Drawing")]                  // Box chars
-    [InlineData(0x2580, 0x259F, "Block Elements")]               // Block chars
-    [InlineData(0x25A0, 0x25FF, "Geometric Shapes")]             // Shapes
-    [InlineData(0x2600, 0x26FF, "Miscellaneous Symbols")]        // Misc symbols
-    [InlineData(0x2700, 0x27BF, "Dingbats")]                     // Dingbats
-    [InlineData(0x3000, 0x303F, "CJK Symbols and Punctuation")]  // CJK punctuation
-    [InlineData(0x4E00, 0x4E50, "CJK Unified Ideographs (sample)")] // CJK chars (sample)
+    [TestMethod]
+    [DataRow(0x0080, 0x00FF, "Latin-1 Supplement")]           // Accented chars, symbols
+    [DataRow(0x0100, 0x017F, "Latin Extended-A")]             // European Latin
+    [DataRow(0x0370, 0x03FF, "Greek and Coptic")]             // Greek
+    [DataRow(0x0400, 0x04FF, "Cyrillic")]                     // Russian, etc.
+    [DataRow(0x2000, 0x206F, "General Punctuation")]          // Special spaces, dashes
+    [DataRow(0x2190, 0x21FF, "Arrows")]                       // Arrow symbols
+    [DataRow(0x2200, 0x22FF, "Mathematical Operators")]       // Math symbols
+    [DataRow(0x2300, 0x23FF, "Miscellaneous Technical")]      // Technical symbols
+    [DataRow(0x2500, 0x257F, "Box Drawing")]                  // Box chars
+    [DataRow(0x2580, 0x259F, "Block Elements")]               // Block chars
+    [DataRow(0x25A0, 0x25FF, "Geometric Shapes")]             // Shapes
+    [DataRow(0x2600, 0x26FF, "Miscellaneous Symbols")]        // Misc symbols
+    [DataRow(0x2700, 0x27BF, "Dingbats")]                     // Dingbats
+    [DataRow(0x3000, 0x303F, "CJK Symbols and Punctuation")]  // CJK punctuation
+    [DataRow(0x4E00, 0x4E50, "CJK Unified Ideographs (sample)")] // CJK chars (sample)
     public async Task BorderAlignment_UnicodeRange_AlignCorrectly(
         int startCodepoint, 
         int endCodepoint, 
@@ -910,7 +909,7 @@ public class UnicodeBorderAlignmentTests
     
     #region Debug Tests
     
-    [Fact]
+    [TestMethod]
     public async Task Debug_VariationSelectorEmoji_CellStorage()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -953,13 +952,13 @@ public class UnicodeBorderAlignmentTests
         // Cell 2: "" (continuation cell for ⚠️)
         // Cell 3: B (width 1)
         
-        Assert.Equal("A", snapshot.GetCell(0, 0).Character);
-        Assert.Equal("⚠️", snapshot.GetCell(1, 0).Character);  // Full emoji with VS16
-        Assert.Equal("", snapshot.GetCell(2, 0).Character);    // Continuation
-        Assert.Equal("B", snapshot.GetCell(3, 0).Character);
+        Assert.AreEqual("A", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("⚠️", snapshot.GetCell(1, 0).Character);  // Full emoji with VS16
+        Assert.AreEqual("", snapshot.GetCell(2, 0).Character);    // Continuation
+        Assert.AreEqual("B", snapshot.GetCell(3, 0).Character);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Debug_DesktopComputerEmoji_CellStorage()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1002,16 +1001,16 @@ public class UnicodeBorderAlignmentTests
         // Cell 2: "" (continuation cell for 🖥️)
         // Cell 3: B (width 1)
         
-        Assert.Equal("A", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("A", snapshot.GetCell(0, 0).Character);
         // Check that cell 1 is the full emoji with VS16, not just the base character
         var cell1 = snapshot.GetCell(1, 0).Character;
         _output.WriteLine($"Cell1 codepoints: {string.Join("+", cell1?.EnumerateRunes().Select(r => $"U+{r.Value:X4}") ?? [])}");
-        Assert.True(cell1?.Contains("\uFE0F") ?? false, $"Expected VS16 (FE0F) in cell 1, got: {cell1}");
-        Assert.Equal("", snapshot.GetCell(2, 0).Character);    // Continuation
-        Assert.Equal("B", snapshot.GetCell(3, 0).Character);
+        Assert.IsTrue(cell1?.Contains("\uFE0F") ?? false, $"Expected VS16 (FE0F) in cell 1, got: {cell1}");
+        Assert.AreEqual("", snapshot.GetCell(2, 0).Character);    // Continuation
+        Assert.AreEqual("B", snapshot.GetCell(3, 0).Character);
     }
     
-    [Fact]
+    [TestMethod]
     public async Task Debug_BorderAlignment_CellPositions()
     {
         const int width = 20;
@@ -1070,7 +1069,7 @@ public class UnicodeBorderAlignmentTests
         
         // Now check specific assertions
         // Row 0 is top border (┌───┐)
-        Assert.Equal("┐", snapshot.GetCell(rightBorderColumn, 0).Character);
+        Assert.AreEqual("┐", snapshot.GetCell(rightBorderColumn, 0).Character);
         
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }
@@ -1078,11 +1077,11 @@ public class UnicodeBorderAlignmentTests
     
     #endregion
     
-    private readonly ITestOutputHelper _output;
-    
-    public UnicodeBorderAlignmentTests(ITestOutputHelper output)
+    private readonly TestContextOutput _output = new();
+
+    private sealed class TestContextOutput
     {
-        _output = output;
+        public void WriteLine(string message) => System.Console.WriteLine(message);
     }
 
     #region Grapheme Cluster Regression Tests
@@ -1091,7 +1090,7 @@ public class UnicodeBorderAlignmentTests
     /// Regression test for the grapheme cluster bug where emoji with variation selectors
     /// were split into separate cells, causing border misalignment.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Surface_EmojiWithVariationSelector_GraphemeClusterKeptTogether()
     {
         // Regression test: emoji with VS16 should occupy 2 cells (main + continuation)
@@ -1103,17 +1102,17 @@ public class UnicodeBorderAlignmentTests
         context.Write("🖥️");  // U+1F5A5 + U+FE0F (desktop computer with variation selector)
         
         // Cell 0 should have the complete emoji (including VS16)
-        Assert.Equal("🖥️", surface[0, 0].Character);
-        Assert.Equal(2, surface[0, 0].DisplayWidth);
+        Assert.AreEqual("🖥️", surface[0, 0].Character);
+        Assert.AreEqual(2, surface[0, 0].DisplayWidth);
         
         // Cell 1 should be a continuation cell
-        Assert.True(surface[1, 0].IsContinuation);
+        Assert.IsTrue(surface[1, 0].IsContinuation);
     }
     
     /// <summary>
     /// Regression test: border at column 29 should not be affected by emoji in content.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void Surface_BorderWithEmoji_RightBorderAtCorrectPosition()
     {
         var surface = new Surfaces.Surface(40, 10);
@@ -1137,8 +1136,8 @@ public class UnicodeBorderAlignmentTests
         context.Write("Test 🖥️ char");  // Text with VS16 emoji
         
         // Right border should still be at column 29
-        Assert.Equal("│", surface[0, 2].Character);   // Left border
-        Assert.Equal("│", surface[29, 2].Character);  // Right border
+        Assert.AreEqual("│", surface[0, 2].Character);   // Left border
+        Assert.AreEqual("│", surface[29, 2].Character);  // Right border
     }
     
     #endregion
@@ -1173,7 +1172,7 @@ public class UnicodeBorderAlignmentTests
     /// <summary>
     /// Integration test: border with emoji content renders correctly.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task BorderWithEmojiContent_RightBorderAligned()
     {
         const int width = 30;
@@ -1205,10 +1204,10 @@ public class UnicodeBorderAlignmentTests
         var rightBorderColumn = width - 1;  // Column 29
         
         // All rows should have the border at column 29
-        Assert.Equal("┐", snapshot.GetCell(rightBorderColumn, 0).Character);  // top border
-        Assert.Equal("│", snapshot.GetCell(rightBorderColumn, 1).Character);  // Plain ASCII line
-        Assert.Equal("│", snapshot.GetCell(rightBorderColumn, 2).Character);  // 🖥️ line - key test
-        Assert.Equal("│", snapshot.GetCell(rightBorderColumn, 3).Character);  // After line
+        Assert.AreEqual("┐", snapshot.GetCell(rightBorderColumn, 0).Character);  // top border
+        Assert.AreEqual("│", snapshot.GetCell(rightBorderColumn, 1).Character);  // Plain ASCII line
+        Assert.AreEqual("│", snapshot.GetCell(rightBorderColumn, 2).Character);  // 🖥️ line - key test
+        Assert.AreEqual("│", snapshot.GetCell(rightBorderColumn, 3).Character);  // After line
         
         cts.Cancel();
         try { await runTask; } catch (OperationCanceledException) { }

--- a/tests/Hex1b.Tests/UpstreamReflowTests.cs
+++ b/tests/Hex1b.Tests/UpstreamReflowTests.cs
@@ -58,6 +58,7 @@ namespace Hex1b.Tests;
 ///   reflow behavior. Tests derived from it are marked accordingly.</item>
 /// </list>
 /// </remarks>
+[TestClass]
 public class UpstreamReflowTests
 {
     #region Kitty Compatibility
@@ -92,7 +93,7 @@ public class UpstreamReflowTests
     /// of whether they originally had SoftWrap. SoftWrap only controls whether ADJACENT
     /// rows are joined into the same logical line.
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Kitty_NarrowHardWrappedLine_SplitsCorrectly()
     {
         var adapter = new HeadlessPresentationAdapter(5, 5).WithReflow(KittyReflowStrategy.Instance);
@@ -108,9 +109,9 @@ public class UpstreamReflowTests
         terminal.Resize(4, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("1234", snap.GetLine(0).TrimEnd());
-        Assert.Equal("5", snap.GetLine(1).TrimEnd());
-        Assert.Equal("", snap.GetLine(2).TrimEnd());
+        Assert.AreEqual("1234", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("5", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("", snap.GetLine(2).TrimEnd());
     }
 
     /// <summary>
@@ -137,7 +138,7 @@ public class UpstreamReflowTests
     /// 5. Resize to (10, 3): 25 chars at width 10 = "0000011111" + "2222233333" + "44444" = 3 rows.
     /// 6. Screen is 3 rows, so all fit with no scrollback.
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Kitty_WidenMergesPairs_5x5to10()
     {
         var adapter = new HeadlessPresentationAdapter(5, 5).WithReflow(KittyReflowStrategy.Instance);
@@ -153,9 +154,9 @@ public class UpstreamReflowTests
         terminal.Resize(10, 3);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("0000011111", snap.GetLine(0).TrimEnd());
-        Assert.Equal("2222233333", snap.GetLine(1).TrimEnd());
-        Assert.Equal("44444", snap.GetLine(2).TrimEnd());
+        Assert.AreEqual("0000011111", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("2222233333", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("44444", snap.GetLine(2).TrimEnd());
     }
 
     /// <summary>
@@ -185,7 +186,7 @@ public class UpstreamReflowTests
     /// <b>Additional assertion:</b> kitty asserts <c>before == at()</c> meaning the full text
     /// (including scrollback) is preserved exactly. We validate the visible screen portion.
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Kitty_NarrowTo2_PreservesFullContent()
     {
         var adapter = new HeadlessPresentationAdapter(5, 5).WithReflow(KittyReflowStrategy.Instance);
@@ -200,11 +201,11 @@ public class UpstreamReflowTests
         terminal.Resize(2, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("88", snap.GetLine(0).TrimEnd());
-        Assert.Equal("88", snap.GetLine(1).TrimEnd());
-        Assert.Equal("89", snap.GetLine(2).TrimEnd());
-        Assert.Equal("99", snap.GetLine(3).TrimEnd());
-        Assert.Equal("99", snap.GetLine(4).TrimEnd());
+        Assert.AreEqual("88", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("88", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("89", snap.GetLine(2).TrimEnd());
+        Assert.AreEqual("99", snap.GetLine(3).TrimEnd());
+        Assert.AreEqual("99", snap.GetLine(4).TrimEnd());
     }
 
     /// <summary>
@@ -232,7 +233,7 @@ public class UpstreamReflowTests
     ///    - Logical line 1: "bb" → 1 row
     /// 7. Total 3 content rows + 2 empty = 5 rows
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Kitty_NarrowSoftWrappedLine_SplitsCorrectly()
     {
         var adapter = new HeadlessPresentationAdapter(5, 5).WithReflow(KittyReflowStrategy.Instance);
@@ -248,10 +249,10 @@ public class UpstreamReflowTests
         terminal.Resize(3, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("aaa", snap.GetLine(0).TrimEnd());
-        Assert.Equal("aa", snap.GetLine(1).TrimEnd());
-        Assert.Equal("bb", snap.GetLine(2).TrimEnd());
-        Assert.Equal("", snap.GetLine(3).TrimEnd());
+        Assert.AreEqual("aaa", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("aa", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("bb", snap.GetLine(2).TrimEnd());
+        Assert.AreEqual("", snap.GetLine(3).TrimEnd());
     }
 
     /// <summary>
@@ -280,7 +281,7 @@ public class UpstreamReflowTests
     /// 4. Resize to cols=4: "123" is 3 chars, fits in 4-wide. No wrapping needed.
     /// 5. All logical lines stay same number of rows → cursor.y unchanged.
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Kitty_CursorYStable_WhenNarrowingShortLines()
     {
         var adapter = new HeadlessPresentationAdapter(5, 5).WithReflow(KittyReflowStrategy.Instance);
@@ -296,7 +297,7 @@ public class UpstreamReflowTests
         terminal.Resize(4, 5);
 
         var snapAfter = terminal.CreateSnapshot();
-        Assert.Equal(yBefore, snapAfter.CursorY);
+        Assert.AreEqual(yBefore, snapAfter.CursorY);
     }
 
     /// <summary>
@@ -322,7 +323,7 @@ public class UpstreamReflowTests
     ///    Cursor at (3, 5) — on the row with "|||"
     /// 3. Resize to (7, 10): rewrap to 7-wide, cursor should still be on a row containing "|"
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Kitty_CursorTracksContent_WhenWidening()
     {
         var adapter = new HeadlessPresentationAdapter(5, 8).WithReflow(KittyReflowStrategy.Instance);
@@ -376,7 +377,7 @@ public class UpstreamReflowTests
     /// <b>Note:</b> We test this at the strategy level (not terminal integration) to match
     /// Alacritty's direct grid manipulation. This tests the algorithm more precisely.
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Alacritty_ShrinkReflow_5to2()
     {
         int oldWidth = 5;
@@ -392,21 +393,18 @@ public class UpstreamReflowTests
         var result = AlacrittyReflowStrategy.Instance.Reflow(context);
 
         // Alacritty: total_lines = 3 (2 scrollback + 1 screen)
-        Assert.True(result.ScrollbackRows.Length == 2,
-            $"Expected 2 scrollback rows, got {result.ScrollbackRows.Length}");
+        Assert.IsTrue(result.ScrollbackRows.Length == 2, $"Expected 2 scrollback rows, got {result.ScrollbackRows.Length}");
 
         // Scrollback[0] = "12" with SoftWrap on last cell
-        Assert.Equal("12", GetRowText(result.ScrollbackRows[0].Cells));
-        Assert.True(HasSoftWrap(result.ScrollbackRows[0].Cells),
-            "Scrollback row 0 should have SoftWrap (content continues)");
+        Assert.AreEqual("12", GetRowText(result.ScrollbackRows[0].Cells));
+        Assert.IsTrue(HasSoftWrap(result.ScrollbackRows[0].Cells), "Scrollback row 0 should have SoftWrap (content continues)");
 
         // Scrollback[1] = "34" with SoftWrap on last cell
-        Assert.Equal("34", GetRowText(result.ScrollbackRows[1].Cells));
-        Assert.True(HasSoftWrap(result.ScrollbackRows[1].Cells),
-            "Scrollback row 1 should have SoftWrap (content continues)");
+        Assert.AreEqual("34", GetRowText(result.ScrollbackRows[1].Cells));
+        Assert.IsTrue(HasSoftWrap(result.ScrollbackRows[1].Cells), "Scrollback row 1 should have SoftWrap (content continues)");
 
         // Screen[0] = "5"
-        Assert.Equal("5", GetRowText(result.ScreenRows[0]));
+        Assert.AreEqual("5", GetRowText(result.ScreenRows[0]));
     }
 
     /// <summary>
@@ -425,7 +423,7 @@ public class UpstreamReflowTests
     /// 2. Then resize to 2: "1234" logical line is "12" + "34", plus "5" = 3 total rows
     /// 3. Same final state as direct 5→2 shrink. This proves reflow is idempotent across steps.
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Alacritty_ShrinkReflowTwice_5to4to2()
     {
         var adapter = new HeadlessPresentationAdapter(5, 1).WithReflow(AlacrittyReflowStrategy.Instance);
@@ -440,7 +438,7 @@ public class UpstreamReflowTests
         terminal.Resize(2, 1);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("5", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("5", snap.GetLine(0).TrimEnd());
     }
 
     /// <summary>
@@ -464,7 +462,7 @@ public class UpstreamReflowTests
     /// 3. WrapLogicalLine at width 3: "123" = 1 row (no SoftWrap needed)
     /// 4. Row 1 becomes empty.
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Alacritty_GrowReflow_MergesWrappedRows()
     {
         int oldWidth = 2;
@@ -481,8 +479,8 @@ public class UpstreamReflowTests
 
         var result = AlacrittyReflowStrategy.Instance.Reflow(context);
 
-        Assert.Equal("123", GetRowText(result.ScreenRows[0]));
-        Assert.Equal("", GetRowText(result.ScreenRows[1]));
+        Assert.AreEqual("123", GetRowText(result.ScreenRows[0]));
+        Assert.AreEqual("", GetRowText(result.ScreenRows[1]));
     }
 
     /// <summary>
@@ -503,7 +501,7 @@ public class UpstreamReflowTests
     /// 2. All three rows form ONE logical line: ['1','2','3','4','5','6']
     /// 3. WrapLogicalLine at width 6: "123456" = 1 row. Rows 1,2 become empty.
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Alacritty_GrowReflowMultiline_MergesAll()
     {
         int oldWidth = 2;
@@ -521,9 +519,9 @@ public class UpstreamReflowTests
 
         var result = AlacrittyReflowStrategy.Instance.Reflow(context);
 
-        Assert.Equal("123456", GetRowText(result.ScreenRows[0]));
-        Assert.Equal("", GetRowText(result.ScreenRows[1]));
-        Assert.Equal("", GetRowText(result.ScreenRows[2]));
+        Assert.AreEqual("123456", GetRowText(result.ScreenRows[0]));
+        Assert.AreEqual("", GetRowText(result.ScreenRows[1]));
+        Assert.AreEqual("", GetRowText(result.ScreenRows[2]));
     }
 
     /// <summary>
@@ -541,7 +539,7 @@ public class UpstreamReflowTests
     /// The SoftWrap flag on "2" is preserved, and "3" stays on its own row.
     /// Our NoReflow / default crop behavior should produce this.
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Alacritty_GrowReflowDisabled_DoesNotMerge()
     {
         // No reflow enabled — uses default crop behavior
@@ -555,8 +553,8 @@ public class UpstreamReflowTests
         terminal.Resize(3, 2);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("12", snap.GetLine(0).TrimEnd());
-        Assert.Equal("3", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("12", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("3", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
@@ -575,7 +573,7 @@ public class UpstreamReflowTests
     /// Without reflow, shrinking from 5→2 just keeps the first 2 chars.
     /// Chars 3-5 are lost (cropped). Total remains 1 row.
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Alacritty_ShrinkReflowDisabled_CropsOnly()
     {
         var adapter = new HeadlessPresentationAdapter(5, 1);
@@ -588,7 +586,7 @@ public class UpstreamReflowTests
         terminal.Resize(2, 1);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("12", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("12", snap.GetLine(0).TrimEnd());
     }
 
     #endregion
@@ -607,10 +605,10 @@ public class UpstreamReflowTests
     /// test (5→4→2 == 5→2) and is a universal expectation for correct reflow.
     /// Without this property, users would see different content depending on resize history.
     /// </remarks>
-    [Theory]
-    [InlineData(5, 3)]  // narrow then narrow more
-    [InlineData(5, 2)]  // narrow to 2
-    [InlineData(3, 7)]  // narrow then widen past original
+    [TestMethod]
+    [DataRow(5, 3)]  // narrow then narrow more
+    [DataRow(5, 2)]  // narrow to 2
+    [DataRow(3, 7)]  // narrow then widen past original
     public void ReflowIsConsistent_AcrossMultipleResizeSteps(int intermediateWidth, int finalWidth)
     {
         // Direct resize
@@ -636,7 +634,7 @@ public class UpstreamReflowTests
 
         for (int i = 0; i < 3; i++)
         {
-            Assert.Equal(directSnap.GetLine(i).TrimEnd(), multiSnap.GetLine(i).TrimEnd());
+            Assert.AreEqual(directSnap.GetLine(i).TrimEnd(), multiSnap.GetLine(i).TrimEnd());
         }
     }
 
@@ -650,10 +648,10 @@ public class UpstreamReflowTests
     /// the right margin) should be merged when the terminal widens.
     /// Validated against both kitty and Alacritty behavior.
     /// </remarks>
-    [Theory]
-    [InlineData(10)]
-    [InlineData(20)]
-    [InlineData(80)]
+    [TestMethod]
+    [DataRow(10)]
+    [DataRow(20)]
+    [DataRow(80)]
     public void HardWrappedLines_NeverMerge_AnyWidth(int newWidth)
     {
         var adapter = new HeadlessPresentationAdapter(5, 5).WithReflow(AlacrittyReflowStrategy.Instance);
@@ -666,9 +664,9 @@ public class UpstreamReflowTests
         terminal.Resize(newWidth, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("abc", snap.GetLine(0).TrimEnd());
-        Assert.Equal("def", snap.GetLine(1).TrimEnd());
-        Assert.Equal("ghi", snap.GetLine(2).TrimEnd());
+        Assert.AreEqual("abc", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("def", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("ghi", snap.GetLine(2).TrimEnd());
     }
 
     /// <summary>
@@ -680,11 +678,11 @@ public class UpstreamReflowTests
     /// Kitty asserts this with <c>self.ae(before, at())</c> in test_resize (~line 338).
     /// Alacritty asserts it implicitly via <c>shrink_reflow_twice</c>.
     /// </remarks>
-    [Theory]
-    [InlineData(10, 5)]   // halve
-    [InlineData(10, 3)]   // to 3
-    [InlineData(10, 1)]   // extreme narrow
-    [InlineData(10, 7)]   // partial narrow
+    [TestMethod]
+    [DataRow(10, 5)]   // halve
+    [DataRow(10, 3)]   // to 3
+    [DataRow(10, 1)]   // extreme narrow
+    [DataRow(10, 7)]   // partial narrow
     public void RoundTrip_NarrowAndRestore_PreservesContent(int originalWidth, int narrowWidth)
     {
         string content = new string('X', originalWidth);
@@ -701,7 +699,7 @@ public class UpstreamReflowTests
         terminal.Resize(originalWidth, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal(content, snap.GetLine(0).TrimEnd());
+        Assert.AreEqual(content, snap.GetLine(0).TrimEnd());
     }
 
     #endregion
@@ -721,8 +719,8 @@ public class UpstreamReflowTests
     // terminal integration runner — they test strategy-level behavior directly and
     // would need a separate test method.
 
-    [Theory]
-    [MemberData(nameof(GetFixtureIds))]
+    [TestMethod]
+    [DynamicData(nameof(GetFixtureIds))]
     public void Fixture_ScreenContentMatches(string fixtureId)
     {
         var fixture = LoadFixture(fixtureId);
@@ -787,7 +785,7 @@ public class UpstreamReflowTests
         {
             string expected = fixture.Expected.ScreenLines[i];
             string actual = snap.GetLine(i).TrimEnd();
-            Assert.Equal(expected, actual);
+            Assert.AreEqual(expected, actual);
         }
     }
 

--- a/tests/Hex1b.Tests/Utf8ByteMapTests.cs
+++ b/tests/Hex1b.Tests/Utf8ByteMapTests.cs
@@ -3,184 +3,185 @@ using System.Text;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class Utf8ByteMapTests
 {
     // ═══════════════════════════════════════════════════════════
     // SECTION 1: Construction and TotalBytes
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void EmptyString_ZeroBytes()
     {
         var map = new Utf8ByteMap("");
-        Assert.Equal(0, map.TotalBytes);
-        Assert.Equal(0, map.CharCount);
+        Assert.AreEqual(0, map.TotalBytes);
+        Assert.AreEqual(0, map.CharCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void AsciiString_ByteCountEqualsCharCount()
     {
         var map = new Utf8ByteMap("Hello");
-        Assert.Equal(5, map.TotalBytes);
-        Assert.Equal(5, map.CharCount);
+        Assert.AreEqual(5, map.TotalBytes);
+        Assert.AreEqual(5, map.CharCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void TwoByte_CharCountDiffersFromByteCount()
     {
         // © = C2 A9 (2 bytes)
         var map = new Utf8ByteMap("©");
-        Assert.Equal(2, map.TotalBytes);
-        Assert.Equal(1, map.CharCount);
+        Assert.AreEqual(2, map.TotalBytes);
+        Assert.AreEqual(1, map.CharCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void ThreeByte_BOM()
     {
         // BOM U+FEFF = EF BB BF (3 bytes)
         var map = new Utf8ByteMap("\uFEFF");
-        Assert.Equal(3, map.TotalBytes);
-        Assert.Equal(1, map.CharCount);
+        Assert.AreEqual(3, map.TotalBytes);
+        Assert.AreEqual(1, map.CharCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void MixedContent_CorrectTotalBytes()
     {
         // "A©" = 41 C2 A9 = 3 bytes, 2 chars
         var map = new Utf8ByteMap("A©");
-        Assert.Equal(3, map.TotalBytes);
-        Assert.Equal(2, map.CharCount);
+        Assert.AreEqual(3, map.TotalBytes);
+        Assert.AreEqual(2, map.CharCount);
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 2: ByteToChar
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void ByteToChar_AsciiString_OneToOneMapping()
     {
         var map = new Utf8ByteMap("ABC");
-        Assert.Equal((0, 0), map.ByteToChar(0));
-        Assert.Equal((1, 0), map.ByteToChar(1));
-        Assert.Equal((2, 0), map.ByteToChar(2));
+        Assert.AreEqual((0, 0), map.ByteToChar(0));
+        Assert.AreEqual((1, 0), map.ByteToChar(1));
+        Assert.AreEqual((2, 0), map.ByteToChar(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void ByteToChar_TwoByteChar_BothBytesMappedCorrectly()
     {
         // © = C2 A9
         var map = new Utf8ByteMap("©");
-        Assert.Equal((0, 0), map.ByteToChar(0)); // C2 → char 0, byte 0 within char
-        Assert.Equal((0, 1), map.ByteToChar(1)); // A9 → char 0, byte 1 within char
+        Assert.AreEqual((0, 0), map.ByteToChar(0)); // C2 → char 0, byte 0 within char
+        Assert.AreEqual((0, 1), map.ByteToChar(1)); // A9 → char 0, byte 1 within char
     }
 
-    [Fact]
+    [TestMethod]
     public void ByteToChar_ThreeByteBOM_AllThreeBytesMapped()
     {
         // BOM = EF BB BF
         var map = new Utf8ByteMap("\uFEFF");
-        Assert.Equal((0, 0), map.ByteToChar(0)); // EF → char 0, byte 0
-        Assert.Equal((0, 1), map.ByteToChar(1)); // BB → char 0, byte 1
-        Assert.Equal((0, 2), map.ByteToChar(2)); // BF → char 0, byte 2
+        Assert.AreEqual((0, 0), map.ByteToChar(0)); // EF → char 0, byte 0
+        Assert.AreEqual((0, 1), map.ByteToChar(1)); // BB → char 0, byte 1
+        Assert.AreEqual((0, 2), map.ByteToChar(2)); // BF → char 0, byte 2
     }
 
-    [Fact]
+    [TestMethod]
     public void ByteToChar_MixedContent_CorrectMapping()
     {
         // "A©B" = 41 C2 A9 42
         var map = new Utf8ByteMap("A©B");
 
-        Assert.Equal((0, 0), map.ByteToChar(0)); // 41 → 'A'
-        Assert.Equal((1, 0), map.ByteToChar(1)); // C2 → '©', byte 0
-        Assert.Equal((1, 1), map.ByteToChar(2)); // A9 → '©', byte 1
-        Assert.Equal((2, 0), map.ByteToChar(3)); // 42 → 'B'
+        Assert.AreEqual((0, 0), map.ByteToChar(0)); // 41 → 'A'
+        Assert.AreEqual((1, 0), map.ByteToChar(1)); // C2 → '©', byte 0
+        Assert.AreEqual((1, 1), map.ByteToChar(2)); // A9 → '©', byte 1
+        Assert.AreEqual((2, 0), map.ByteToChar(3)); // 42 → 'B'
     }
 
-    [Fact]
+    [TestMethod]
     public void ByteToChar_BOMThenAscii_CrossesBoundary()
     {
         // "\uFEFFHi" = EF BB BF 48 69
         var map = new Utf8ByteMap("\uFEFFHi");
-        Assert.Equal((0, 0), map.ByteToChar(0)); // EF
-        Assert.Equal((0, 1), map.ByteToChar(1)); // BB
-        Assert.Equal((0, 2), map.ByteToChar(2)); // BF
-        Assert.Equal((1, 0), map.ByteToChar(3)); // 48 → 'H'
-        Assert.Equal((2, 0), map.ByteToChar(4)); // 69 → 'i'
+        Assert.AreEqual((0, 0), map.ByteToChar(0)); // EF
+        Assert.AreEqual((0, 1), map.ByteToChar(1)); // BB
+        Assert.AreEqual((0, 2), map.ByteToChar(2)); // BF
+        Assert.AreEqual((1, 0), map.ByteToChar(3)); // 48 → 'H'
+        Assert.AreEqual((2, 0), map.ByteToChar(4)); // 69 → 'i'
     }
 
-    [Fact]
+    [TestMethod]
     public void ByteToChar_OutOfRange_Throws()
     {
         var map = new Utf8ByteMap("A");
-        Assert.Throws<ArgumentOutOfRangeException>(() => map.ByteToChar(-1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => map.ByteToChar(1));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => map.ByteToChar(-1));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => map.ByteToChar(1));
     }
 
-    [Fact]
+    [TestMethod]
     public void ByteToChar_EmptyString_Throws()
     {
         var map = new Utf8ByteMap("");
-        Assert.Throws<ArgumentOutOfRangeException>(() => map.ByteToChar(0));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => map.ByteToChar(0));
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 3: CharToByteStart / CharByteLength
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void CharToByteStart_AsciiString_Sequential()
     {
         var map = new Utf8ByteMap("ABC");
-        Assert.Equal(0, map.CharToByteStart(0));
-        Assert.Equal(1, map.CharToByteStart(1));
-        Assert.Equal(2, map.CharToByteStart(2));
+        Assert.AreEqual(0, map.CharToByteStart(0));
+        Assert.AreEqual(1, map.CharToByteStart(1));
+        Assert.AreEqual(2, map.CharToByteStart(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void CharToByteStart_MixedContent_SkipsMultibyte()
     {
         // "A©B" = 41 C2 A9 42
         var map = new Utf8ByteMap("A©B");
-        Assert.Equal(0, map.CharToByteStart(0)); // 'A' at byte 0
-        Assert.Equal(1, map.CharToByteStart(1)); // '©' at byte 1
-        Assert.Equal(3, map.CharToByteStart(2)); // 'B' at byte 3
+        Assert.AreEqual(0, map.CharToByteStart(0)); // 'A' at byte 0
+        Assert.AreEqual(1, map.CharToByteStart(1)); // '©' at byte 1
+        Assert.AreEqual(3, map.CharToByteStart(2)); // 'B' at byte 3
     }
 
-    [Fact]
+    [TestMethod]
     public void CharByteLength_AsciiChars_AllOne()
     {
         var map = new Utf8ByteMap("Hi");
-        Assert.Equal(1, map.CharByteLength(0));
-        Assert.Equal(1, map.CharByteLength(1));
+        Assert.AreEqual(1, map.CharByteLength(0));
+        Assert.AreEqual(1, map.CharByteLength(1));
     }
 
-    [Fact]
+    [TestMethod]
     public void CharByteLength_TwoByteChar_ReturnsTwo()
     {
         var map = new Utf8ByteMap("©");
-        Assert.Equal(2, map.CharByteLength(0));
+        Assert.AreEqual(2, map.CharByteLength(0));
     }
 
-    [Fact]
+    [TestMethod]
     public void CharByteLength_ThreeByteChar_ReturnsThree()
     {
         var map = new Utf8ByteMap("\uFEFF");
-        Assert.Equal(3, map.CharByteLength(0));
+        Assert.AreEqual(3, map.CharByteLength(0));
     }
 
-    [Fact]
+    [TestMethod]
     public void CharToByteStart_OutOfRange_Throws()
     {
         var map = new Utf8ByteMap("A");
-        Assert.Throws<ArgumentOutOfRangeException>(() => map.CharToByteStart(-1));
-        Assert.Throws<ArgumentOutOfRangeException>(() => map.CharToByteStart(1));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => map.CharToByteStart(-1));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => map.CharToByteStart(1));
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 4: Byte slice extraction via CharToByteStart + CharByteLength
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void CharByteSlice_AsciiChar_ReturnsSingleByte()
     {
         var text = "ABC";
@@ -190,11 +191,11 @@ public class Utf8ByteMapTests
         var start = map.CharToByteStart(1);
         var len = map.CharByteLength(1);
         var bytes = allBytes.AsSpan(start, len);
-        Assert.Equal(1, bytes.Length);
-        Assert.Equal((byte)'B', bytes[0]);
+        Assert.AreEqual(1, bytes.Length);
+        Assert.AreEqual((byte)'B', bytes[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void CharByteSlice_TwoByteChar_ReturnsBothBytes()
     {
         var text = "©";
@@ -204,12 +205,12 @@ public class Utf8ByteMapTests
         var start = map.CharToByteStart(0);
         var len = map.CharByteLength(0);
         var bytes = allBytes.AsSpan(start, len);
-        Assert.Equal(2, bytes.Length);
-        Assert.Equal(0xC2, bytes[0]);
-        Assert.Equal(0xA9, bytes[1]);
+        Assert.AreEqual(2, bytes.Length);
+        Assert.AreEqual(0xC2, bytes[0]);
+        Assert.AreEqual(0xA9, bytes[1]);
     }
 
-    [Fact]
+    [TestMethod]
     public void CharByteSlice_BOM_ReturnsThreeBytes()
     {
         var text = "\uFEFF";
@@ -219,42 +220,42 @@ public class Utf8ByteMapTests
         var start = map.CharToByteStart(0);
         var len = map.CharByteLength(0);
         var bytes = allBytes.AsSpan(start, len);
-        Assert.Equal(3, bytes.Length);
-        Assert.Equal(0xEF, bytes[0]);
-        Assert.Equal(0xBB, bytes[1]);
-        Assert.Equal(0xBF, bytes[2]);
+        Assert.AreEqual(3, bytes.Length);
+        Assert.AreEqual(0xEF, bytes[0]);
+        Assert.AreEqual(0xBB, bytes[1]);
+        Assert.AreEqual(0xBF, bytes[2]);
     }
 
     // ═══════════════════════════════════════════════════════════
     // SECTION 5: Roundtrip consistency
     // ═══════════════════════════════════════════════════════════
 
-    [Theory]
-    [InlineData("Hello, World!")]
-    [InlineData("A©B")]
-    [InlineData("\uFEFFHello")]
-    [InlineData("café")]
-    [InlineData("")]
+    [TestMethod]
+    [DataRow("Hello, World!")]
+    [DataRow("A©B")]
+    [DataRow("\uFEFFHello")]
+    [DataRow("café")]
+    [DataRow("")]
     public void Roundtrip_EveryByte_MapsToValidChar(string text)
     {
         var map = new Utf8ByteMap(text);
         var allBytes = Encoding.UTF8.GetBytes(text);
-        Assert.Equal(allBytes.Length, map.TotalBytes);
+        Assert.AreEqual(allBytes.Length, map.TotalBytes);
 
         for (var b = 0; b < map.TotalBytes; b++)
         {
             var (charIdx, byteWithin) = map.ByteToChar(b);
-            Assert.True(charIdx >= 0 && charIdx < map.CharCount);
-            Assert.True(byteWithin >= 0 && byteWithin < map.CharByteLength(charIdx));
-            Assert.Equal(b, map.CharToByteStart(charIdx) + byteWithin);
+            Assert.IsTrue(charIdx >= 0 && charIdx < map.CharCount);
+            Assert.IsTrue(byteWithin >= 0 && byteWithin < map.CharByteLength(charIdx));
+            Assert.AreEqual(b, map.CharToByteStart(charIdx) + byteWithin);
         }
     }
 
-    [Theory]
-    [InlineData("Hello, World!")]
-    [InlineData("A©B")]
-    [InlineData("\uFEFFHello")]
-    [InlineData("café")]
+    [TestMethod]
+    [DataRow("Hello, World!")]
+    [DataRow("A©B")]
+    [DataRow("\uFEFFHello")]
+    [DataRow("café")]
     public void Roundtrip_EveryChar_ByteStartPlusLengthCoversRange(string text)
     {
         var map = new Utf8ByteMap(text);
@@ -268,8 +269,8 @@ public class Utf8ByteMapTests
             for (var b = start; b < start + len; b++)
             {
                 var (charIdx, byteWithin) = map.ByteToChar(b);
-                Assert.Equal(c, charIdx);
-                Assert.Equal(b - start, byteWithin);
+                Assert.AreEqual(c, charIdx);
+                Assert.AreEqual(b - start, byteWithin);
             }
         }
     }
@@ -278,110 +279,110 @@ public class Utf8ByteMapTests
     // SECTION 6: Raw byte constructor — invalid UTF-8
     // ═══════════════════════════════════════════════════════════
 
-    [Fact]
+    [TestMethod]
     public void RawBytes_SingleInvalidByte_OneCharOneSourceByte()
     {
         // 0xAA is an invalid continuation byte → 1 replacement char consuming 1 source byte
         var map = new Utf8ByteMap(new byte[] { 0xAA });
-        Assert.Equal(1, map.TotalBytes);
-        Assert.Equal(1, map.CharCount);
-        Assert.Equal(0, map.CharToByteStart(0));
-        Assert.Equal(1, map.CharByteLength(0));
+        Assert.AreEqual(1, map.TotalBytes);
+        Assert.AreEqual(1, map.CharCount);
+        Assert.AreEqual(0, map.CharToByteStart(0));
+        Assert.AreEqual(1, map.CharByteLength(0));
     }
 
-    [Fact]
+    [TestMethod]
     public void RawBytes_InvalidByteThenAscii_EachByteIsOneChar()
     {
         // [0xAA, 0x20, 0x48] → 3 chars, each 1 source byte
         var bytes = new byte[] { 0xAA, 0x20, 0x48 };
         var map = new Utf8ByteMap(bytes);
 
-        Assert.Equal(3, map.TotalBytes);
-        Assert.Equal(3, map.CharCount);
+        Assert.AreEqual(3, map.TotalBytes);
+        Assert.AreEqual(3, map.CharCount);
 
         for (int i = 0; i < 3; i++)
         {
-            Assert.Equal(i, map.CharToByteStart(i));
-            Assert.Equal(1, map.CharByteLength(i));
+            Assert.AreEqual(i, map.CharToByteStart(i));
+            Assert.AreEqual(1, map.CharByteLength(i));
             var (charIdx, byteWithin) = map.ByteToChar(i);
-            Assert.Equal(i, charIdx);
-            Assert.Equal(0, byteWithin);
+            Assert.AreEqual(i, charIdx);
+            Assert.AreEqual(0, byteWithin);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void RawBytes_InvalidByteAfterValidMultibyte_CorrectMapping()
     {
         // © = C2 A9 (valid 2-byte), then 0xBB (invalid), then 'X' (41)
         var bytes = new byte[] { 0xC2, 0xA9, 0xBB, 0x41 };
         var map = new Utf8ByteMap(bytes);
 
-        Assert.Equal(4, map.TotalBytes);
-        Assert.Equal(3, map.CharCount);
+        Assert.AreEqual(4, map.TotalBytes);
+        Assert.AreEqual(3, map.CharCount);
 
         // Char 0: © at bytes 0-1 (2 source bytes)
-        Assert.Equal(0, map.CharToByteStart(0));
-        Assert.Equal(2, map.CharByteLength(0));
+        Assert.AreEqual(0, map.CharToByteStart(0));
+        Assert.AreEqual(2, map.CharByteLength(0));
 
         // Char 1: replacement at byte 2 (1 source byte)
-        Assert.Equal(2, map.CharToByteStart(1));
-        Assert.Equal(1, map.CharByteLength(1));
+        Assert.AreEqual(2, map.CharToByteStart(1));
+        Assert.AreEqual(1, map.CharByteLength(1));
 
         // Char 2: 'X' at byte 3 (1 source byte)
-        Assert.Equal(3, map.CharToByteStart(2));
-        Assert.Equal(1, map.CharByteLength(2));
+        Assert.AreEqual(3, map.CharToByteStart(2));
+        Assert.AreEqual(1, map.CharByteLength(2));
     }
 
-    [Fact]
+    [TestMethod]
     public void RawBytes_TruncatedMultibyte_ConsumesAvailableBytes()
     {
         // 0xC2 alone is a truncated 2-byte sequence → 1 replacement char, 1 source byte
         var bytes = new byte[] { 0xC2 };
         var map = new Utf8ByteMap(bytes);
 
-        Assert.Equal(1, map.TotalBytes);
-        Assert.Equal(1, map.CharCount);
-        Assert.Equal(0, map.CharToByteStart(0));
-        Assert.Equal(1, map.CharByteLength(0));
+        Assert.AreEqual(1, map.TotalBytes);
+        Assert.AreEqual(1, map.CharCount);
+        Assert.AreEqual(0, map.CharToByteStart(0));
+        Assert.AreEqual(1, map.CharByteLength(0));
     }
 
-    [Fact]
+    [TestMethod]
     public void RawBytes_AllInvalidBytes_EachIsOneChar()
     {
         // All continuation bytes without leaders
         var bytes = new byte[] { 0x80, 0x90, 0xA0, 0xBF, 0xFE, 0xFF };
         var map = new Utf8ByteMap(bytes);
 
-        Assert.Equal(6, map.TotalBytes);
-        Assert.Equal(6, map.CharCount);
+        Assert.AreEqual(6, map.TotalBytes);
+        Assert.AreEqual(6, map.CharCount);
 
         for (int i = 0; i < 6; i++)
         {
-            Assert.Equal(i, map.CharToByteStart(i));
-            Assert.Equal(1, map.CharByteLength(i));
+            Assert.AreEqual(i, map.CharToByteStart(i));
+            Assert.AreEqual(1, map.CharByteLength(i));
         }
     }
 
-    [Theory]
-    [InlineData(0x00)]
-    [InlineData(0x41)]
-    [InlineData(0x7F)]
-    [InlineData(0x80)]
-    [InlineData(0xAA)]
-    [InlineData(0xBF)]
-    [InlineData(0xC0)]
-    [InlineData(0xFE)]
-    [InlineData(0xFF)]
-    public void RawBytes_AnySingleByte_ProducesExactlyOneChar(byte b)
+    [TestMethod]
+    [DataRow(0x00)]
+    [DataRow(0x41)]
+    [DataRow(0x7F)]
+    [DataRow(0x80)]
+    [DataRow(0xAA)]
+    [DataRow(0xBF)]
+    [DataRow(0xC0)]
+    [DataRow(0xFE)]
+    [DataRow(0xFF)]
+    public void RawBytes_AnySingleByte_ProducesExactlyOneChar(int b)
     {
-        var map = new Utf8ByteMap(new byte[] { b });
-        Assert.Equal(1, map.TotalBytes);
-        Assert.Equal(1, map.CharCount);
-        Assert.Equal(0, map.CharToByteStart(0));
-        Assert.Equal(1, map.CharByteLength(0));
+        var map = new Utf8ByteMap(new byte[] { (byte)b });
+        Assert.AreEqual(1, map.TotalBytes);
+        Assert.AreEqual(1, map.CharCount);
+        Assert.AreEqual(0, map.CharToByteStart(0));
+        Assert.AreEqual(1, map.CharByteLength(0));
     }
 
-    [Fact]
+    [TestMethod]
     public void RawBytes_ByteToChar_EveryByteNavigable()
     {
         // Mixed valid and invalid: [0xAA, 0xC2, 0xA9, 0xBB, 0x41]
@@ -389,15 +390,14 @@ public class Utf8ByteMapTests
         var bytes = new byte[] { 0xAA, 0xC2, 0xA9, 0xBB, 0x41 };
         var map = new Utf8ByteMap(bytes);
 
-        Assert.Equal(5, map.TotalBytes);
-        Assert.Equal(4, map.CharCount);
+        Assert.AreEqual(5, map.TotalBytes);
+        Assert.AreEqual(4, map.CharCount);
 
         // Every single byte maps to a char and can be reached
         for (int b = 0; b < map.TotalBytes; b++)
         {
             var (charIdx, _) = map.ByteToChar(b);
-            Assert.True(charIdx >= 0 && charIdx < map.CharCount,
-                $"Byte {b} (0x{bytes[b]:X2}) should map to a valid char index, got {charIdx}");
+            Assert.IsTrue(charIdx >= 0 && charIdx < map.CharCount, $"Byte {b} (0x{bytes[b]:X2}) should map to a valid char index, got {charIdx}");
         }
     }
 }

--- a/tests/Hex1b.Tests/VStackNodeTests.cs
+++ b/tests/Hex1b.Tests/VStackNodeTests.cs
@@ -7,11 +7,12 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Integration tests for VStackNode layout and focus management.
 /// </summary>
+[TestClass]
 public class VStackNodeTests
 {
     #region Measurement Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_SumsChildHeights()
     {
         var node = new VStackNode
@@ -26,10 +27,10 @@ public class VStackNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(3, size.Height);
+        Assert.AreEqual(3, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_TakesMaxWidth()
     {
         var node = new VStackNode
@@ -44,21 +45,21 @@ public class VStackNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(18, size.Width);
+        Assert.AreEqual(18, size.Width);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_EmptyChildren_ReturnsZeroSize()
     {
         var node = new VStackNode { Children = new List<Hex1bNode>() };
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(0, size.Width);
-        Assert.Equal(0, size.Height);
+        Assert.AreEqual(0, size.Width);
+        Assert.AreEqual(0, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Measure_RespectsMaxConstraints()
     {
         var node = new VStackNode
@@ -72,15 +73,15 @@ public class VStackNodeTests
 
         var size = node.Measure(new Constraints(0, 20, 0, 1));
 
-        Assert.Equal(20, size.Width);
-        Assert.Equal(1, size.Height);
+        Assert.AreEqual(20, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
     #endregion
 
     #region Arrange Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_PositionsChildrenVertically()
     {
         var child1 = new TextBlockNode { Text = "Line 1" };
@@ -90,11 +91,11 @@ public class VStackNodeTests
         node.Measure(Constraints.Tight(80, 24));
         node.Arrange(new Rect(0, 0, 80, 24));
 
-        Assert.Equal(0, child1.Bounds.Y);
-        Assert.Equal(1, child2.Bounds.Y);
+        Assert.AreEqual(0, child1.Bounds.Y);
+        Assert.AreEqual(1, child2.Bounds.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_WithFillHints_DistributesSpace()
     {
         var child1 = new TextBlockNode { Text = "Fixed" };
@@ -108,12 +109,12 @@ public class VStackNodeTests
         node.Arrange(new Rect(0, 0, 80, 10));
 
         // First child should be content-sized (1 line)
-        Assert.Equal(1, child1.Bounds.Height);
+        Assert.AreEqual(1, child1.Bounds.Height);
         // Second child should fill remaining space
-        Assert.Equal(9, child2.Bounds.Height);
+        Assert.AreEqual(9, child2.Bounds.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_WithFixedHints_UsesExactSize()
     {
         var child1 = new TextBlockNode { Text = "Fixed", HeightHint = SizeHint.Fixed(3) };
@@ -126,11 +127,11 @@ public class VStackNodeTests
         node.Measure(Constraints.Tight(80, 20));
         node.Arrange(new Rect(0, 0, 80, 20));
 
-        Assert.Equal(3, child1.Bounds.Height);
-        Assert.Equal(5, child2.Bounds.Height);
+        Assert.AreEqual(3, child1.Bounds.Height);
+        Assert.AreEqual(5, child2.Bounds.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_WithMixedHints_DistributesCorrectly()
     {
         var child1 = new TextBlockNode { Text = "Fixed", HeightHint = SizeHint.Fixed(2) };
@@ -144,13 +145,13 @@ public class VStackNodeTests
         node.Measure(Constraints.Tight(80, 12));
         node.Arrange(new Rect(0, 0, 80, 12));
 
-        Assert.Equal(2, child1.Bounds.Height);
+        Assert.AreEqual(2, child1.Bounds.Height);
         // Remaining 10 units split between 2 fill children
-        Assert.Equal(5, child2.Bounds.Height);
-        Assert.Equal(5, child3.Bounds.Height);
+        Assert.AreEqual(5, child2.Bounds.Height);
+        Assert.AreEqual(5, child3.Bounds.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Arrange_AtOffset_PositionsChildrenCorrectly()
     {
         var child1 = new TextBlockNode { Text = "Line 1" };
@@ -160,17 +161,17 @@ public class VStackNodeTests
         node.Measure(Constraints.Unbounded);
         node.Arrange(new Rect(5, 10, 30, 20));
 
-        Assert.Equal(5, child1.Bounds.X);
-        Assert.Equal(10, child1.Bounds.Y);
-        Assert.Equal(5, child2.Bounds.X);
-        Assert.Equal(11, child2.Bounds.Y);
+        Assert.AreEqual(5, child1.Bounds.X);
+        Assert.AreEqual(10, child1.Bounds.Y);
+        Assert.AreEqual(5, child2.Bounds.X);
+        Assert.AreEqual(11, child2.Bounds.Y);
     }
 
     #endregion
 
     #region Focus Tests
 
-    [Fact]
+    [TestMethod]
     public async Task GetFocusableNodes_FindsAllFocusable()
     {
         var textBox1 = new TextBoxNode();
@@ -185,13 +186,13 @@ public class VStackNodeTests
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Equal(3, focusables.Count);
+        Assert.AreEqual(3, focusables.Count);
         Assert.Contains(textBox1, focusables);
         Assert.Contains(button, focusables);
         Assert.Contains(textBox2, focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Tab_MovesFocus()
     {
         var textBox1 = new TextBoxNode { IsFocused = true };
@@ -209,12 +210,12 @@ public class VStackNodeTests
 
         var result = await InputRouter.RouteInputAsync(node, new Hex1bKeyEvent(Hex1bKey.Tab, '\t', Hex1bModifiers.None), focusRing, routerState, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.False(textBox1.IsFocused);
-        Assert.True(textBox2.IsFocused);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.IsFalse(textBox1.IsFocused);
+        Assert.IsTrue(textBox2.IsFocused);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_ShiftTab_MovesFocusBackward()
     {
         var textBox1 = new TextBoxNode { IsFocused = false };
@@ -232,11 +233,11 @@ public class VStackNodeTests
         // textBox2 starts focused at index 1, shift-tab moves back to index 0
         await InputRouter.RouteInputAsync(node, new Hex1bKeyEvent(Hex1bKey.Tab, '\t', Hex1bModifiers.Shift), focusRing, routerState2, null, TestContext.Current.CancellationToken);
 
-        Assert.True(textBox1.IsFocused);
-        Assert.False(textBox2.IsFocused);
+        Assert.IsTrue(textBox1.IsFocused);
+        Assert.IsFalse(textBox2.IsFocused);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_DispatchesToFocusedChild()
     {
         var textBox = new TextBoxNode { Text = "hello", IsFocused = true };
@@ -251,10 +252,10 @@ public class VStackNodeTests
         // Use InputRouter to route input to the focused child
         await InputRouter.RouteInputAsync(node, new Hex1bKeyEvent(Hex1bKey.X, 'X', Hex1bModifiers.None), focusRing, routerState, null, TestContext.Current.CancellationToken);
 
-        Assert.Equal("helloX", textBox.Text);
+        Assert.AreEqual("helloX", textBox.Text);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task HandleInput_Tab_WrapsAroundToFirst()
     {
         var button1 = new ButtonNode { Label = "1", IsFocused = false };
@@ -272,15 +273,15 @@ public class VStackNodeTests
         // button2 starts focused at index 1, one Tab wraps to index 0
         await InputRouter.RouteInputAsync(node, new Hex1bKeyEvent(Hex1bKey.Tab, '\t', Hex1bModifiers.None), focusRing, routerState2, null, TestContext.Current.CancellationToken);
 
-        Assert.True(button1.IsFocused);
-        Assert.False(button2.IsFocused);
+        Assert.IsTrue(button1.IsFocused);
+        Assert.IsFalse(button2.IsFocused);
     }
 
     #endregion
 
     #region Rendering Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Render_RendersAllChildren()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -310,7 +311,7 @@ public class VStackNodeTests
         Assert.Contains("Second", snapshot.GetScreenText());
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_ChildrenAppearOnDifferentLines()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -349,7 +350,7 @@ public class VStackNodeTests
             .ApplyAsync(terminal);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Render_InNarrowTerminal_TextClipsAtEdge()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -375,16 +376,16 @@ public class VStackNodeTests
         await runTask;
         
         // Text clips at terminal edge (not wraps)
-        Assert.Equal("LongTextHe", snapshot.GetLineTrimmed(0));
+        Assert.AreEqual("LongTextHe", snapshot.GetLineTrimmed(0));
         // Second line should be empty (no wrapping)
-        Assert.Equal("", snapshot.GetLineTrimmed(1));
+        Assert.AreEqual("", snapshot.GetLineTrimmed(1));
     }
 
     #endregion
 
     #region Integration Tests with Hex1bApp
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_VStack_RendersMultipleChildren()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -415,12 +416,12 @@ public class VStackNodeTests
         await runTask;
 
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("Header"));
-        Assert.True(snapshot.ContainsText("Body Content"));
-        Assert.True(snapshot.ContainsText("Footer"));
+        Assert.IsTrue(snapshot.ContainsText("Header"));
+        Assert.IsTrue(snapshot.ContainsText("Body Content"));
+        Assert.IsTrue(snapshot.ContainsText("Footer"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_VStack_TabNavigatesThroughFocusables()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -461,12 +462,12 @@ public class VStackNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("1", text1);
-        Assert.Equal("2", text2);
-        Assert.Equal("3", text3);
+        Assert.AreEqual("1", text1);
+        Assert.AreEqual("2", text2);
+        Assert.AreEqual("3", text3);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_VStack_ShiftTabNavigatesBackward()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -499,11 +500,11 @@ public class VStackNodeTests
             .ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
         await runTask;
 
-        Assert.Equal("A", text1);
-        Assert.Equal("", text2);
+        Assert.AreEqual("A", text1);
+        Assert.AreEqual("", text2);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_VStack_InNarrowTerminal_StillWorks()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -534,12 +535,12 @@ public class VStackNodeTests
         await runTask;
 
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("Short"));
-        Assert.True(snapshot.ContainsText("Medium text"));
-        Assert.True(snapshot.ContainsText("Very long text"));
+        Assert.IsTrue(snapshot.ContainsText("Short"));
+        Assert.IsTrue(snapshot.ContainsText("Medium text"));
+        Assert.IsTrue(snapshot.ContainsText("Very long text"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_VStack_WithMixedContent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -574,11 +575,11 @@ public class VStackNodeTests
         await runTask;
 
         // Use captured snapshot for assertions
-        Assert.True(clicked);
-        Assert.True(snapshot.ContainsText("Title"));
+        Assert.IsTrue(clicked);
+        Assert.IsTrue(snapshot.ContainsText("Title"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_VStack_NestedVStacks()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -612,13 +613,13 @@ public class VStackNodeTests
         await runTask;
 
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("Outer 1"));
-        Assert.True(snapshot.ContainsText("Inner 1"));
-        Assert.True(snapshot.ContainsText("Inner 2"));
-        Assert.True(snapshot.ContainsText("Outer 2"));
+        Assert.IsTrue(snapshot.ContainsText("Outer 1"));
+        Assert.IsTrue(snapshot.ContainsText("Inner 1"));
+        Assert.IsTrue(snapshot.ContainsText("Inner 2"));
+        Assert.IsTrue(snapshot.ContainsText("Outer 2"));
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_VStack_EmptyStack_DoesNotCrash()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -644,7 +645,7 @@ public class VStackNodeTests
         // Test passes if we get here without throwing
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Integration_VStack_DynamicContent()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -672,16 +673,16 @@ public class VStackNodeTests
         await runTask;
 
         // Use captured snapshot for assertions
-        Assert.True(snapshot.ContainsText("Item 1"));
-        Assert.True(snapshot.ContainsText("Item 2"));
-        Assert.True(snapshot.ContainsText("Item 3"));
+        Assert.IsTrue(snapshot.ContainsText("Item 1"));
+        Assert.IsTrue(snapshot.ContainsText("Item 2"));
+        Assert.IsTrue(snapshot.ContainsText("Item 3"));
     }
 
     #endregion
 
     #region Orphan Tracking Tests
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_FewerChildren_TracksOrphanedBounds()
     {
         // Arrange - create a VStack with 5 children
@@ -696,8 +697,8 @@ public class VStackNodeTests
         
         var context = ReconcileContext.CreateRoot();
         var node = initialWidget.ReconcileAsync(null, context).GetAwaiter().GetResult() as VStackNode;
-        Assert.NotNull(node);
-        Assert.Equal(5, node.Children.Count);
+        Assert.IsNotNull(node);
+        Assert.AreEqual(5, node.Children.Count);
         
         // Set up bounds for each child (simulating what Arrange would do)
         node.Arrange(new Rect(0, 0, 50, 5));
@@ -719,20 +720,20 @@ public class VStackNodeTests
         var reconciledNode = fewerWidget.ReconcileAsync(node, context).GetAwaiter().GetResult() as VStackNode;
         
         // Assert - orphaned bounds should be tracked
-        Assert.Same(node, reconciledNode); // Same node reused
-        Assert.Single(reconciledNode!.Children);
-        Assert.NotNull(reconciledNode.OrphanedChildBounds);
-        Assert.Equal(4, reconciledNode.OrphanedChildBounds.Count); // Children 1-4 were orphaned
-        Assert.True(reconciledNode.IsDirty); // Should be marked dirty
+        Assert.AreSame(node, reconciledNode); // Same node reused
+        TestSeq.Single(reconciledNode!.Children);
+        Assert.IsNotNull(reconciledNode.OrphanedChildBounds);
+        Assert.AreEqual(4, reconciledNode.OrphanedChildBounds.Count); // Children 1-4 were orphaned
+        Assert.IsTrue(reconciledNode.IsDirty); // Should be marked dirty
         
         // Verify the orphaned bounds match the old children's positions
-        Assert.Equal(new Rect(0, 1, 50, 1), reconciledNode.OrphanedChildBounds[0]);
-        Assert.Equal(new Rect(0, 2, 50, 1), reconciledNode.OrphanedChildBounds[1]);
-        Assert.Equal(new Rect(0, 3, 50, 1), reconciledNode.OrphanedChildBounds[2]);
-        Assert.Equal(new Rect(0, 4, 50, 1), reconciledNode.OrphanedChildBounds[3]);
+        Assert.AreEqual(new Rect(0, 1, 50, 1), reconciledNode.OrphanedChildBounds[0]);
+        Assert.AreEqual(new Rect(0, 2, 50, 1), reconciledNode.OrphanedChildBounds[1]);
+        Assert.AreEqual(new Rect(0, 3, 50, 1), reconciledNode.OrphanedChildBounds[2]);
+        Assert.AreEqual(new Rect(0, 4, 50, 1), reconciledNode.OrphanedChildBounds[3]);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Reconcile_SameOrMoreChildren_NoOrphanedBounds()
     {
         // Arrange - create a VStack with 2 children
@@ -744,7 +745,7 @@ public class VStackNodeTests
         
         var context = ReconcileContext.CreateRoot();
         var node = initialWidget.ReconcileAsync(null, context).GetAwaiter().GetResult() as VStackNode;
-        Assert.NotNull(node);
+        Assert.IsNotNull(node);
         node.Arrange(new Rect(0, 0, 50, 2));
         
         // Act - reconcile with same number of children
@@ -756,7 +757,7 @@ public class VStackNodeTests
         var reconciledNode = sameWidget.ReconcileAsync(node, context).GetAwaiter().GetResult() as VStackNode;
         
         // Assert - no orphaned bounds
-        Assert.Null(reconciledNode!.OrphanedChildBounds);
+        Assert.IsNull(reconciledNode!.OrphanedChildBounds);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/VteGhosttyReflowTests.cs
+++ b/tests/Hex1b.Tests/VteGhosttyReflowTests.cs
@@ -17,6 +17,7 @@ namespace Hex1b.Tests;
 /// <para><b>Key difference from Kitty/Xterm:</b> VTE and Ghostty reflow the DECSC saved cursor
 /// position alongside the primary cursor. Kitty and Xterm do not.</para>
 /// </remarks>
+[TestClass]
 public class VteGhosttyReflowTests
 {
     #region Helper Methods
@@ -72,7 +73,7 @@ public class VteGhosttyReflowTests
     /// Cursor on '2' at (0,1). Resize to cols=10.
     /// Logical line "1ABCD2EFGH" re-wraps to one row. Cursor moves to (5,0).
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Ghostty_ResizeMoreCols_ReflowFitsFullWidth()
     {
         using var terminal = CreateTerminal(GhosttyReflowStrategy.Instance, 5, 5, scrollback: 5);
@@ -86,17 +87,17 @@ public class VteGhosttyReflowTests
         // Move cursor to '2' at (0,1)
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[2;1H")); // Move to row 2, col 1 = '2'
 
-        Assert.Equal(0, terminal.CursorX);
-        Assert.Equal(1, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorX);
+        Assert.AreEqual(1, terminal.CursorY);
 
         terminal.Resize(10, 5);
 
         // After reflow: "1ABCD2EFGH" becomes one row, cursor on '2' moves to (5,0)
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("1ABCD2EFGH", snap.GetLine(0).TrimEnd());
-        Assert.Equal("3IJKL", snap.GetLine(1).TrimEnd());
-        Assert.Equal(5, snap.CursorX);
-        Assert.Equal(0, snap.CursorY);
+        Assert.AreEqual("1ABCD2EFGH", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("3IJKL", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual(5, snap.CursorX);
+        Assert.AreEqual(0, snap.CursorY);
     }
 
     /// <summary>
@@ -110,7 +111,7 @@ public class VteGhosttyReflowTests
     /// Cursor on '3' at (0,2). Resize to cols=10.
     /// Logical line "1ABCD2EFGH" re-wraps to one row at width 10. Cursor on '3' stays on '3'.
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Ghostty_ResizeMoreCols_ReflowEndsInNewline()
     {
         using var terminal = CreateTerminal(GhosttyReflowStrategy.Instance, 6, 5, scrollback: 5);
@@ -122,17 +123,17 @@ public class VteGhosttyReflowTests
         // Move cursor to '3' at row 3 col 1 (which is screen row 2, col 0 in 0-based)
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[3;1H"));
 
-        Assert.Equal(0, terminal.CursorX);
-        Assert.Equal(2, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorX);
+        Assert.AreEqual(2, terminal.CursorY);
 
         terminal.Resize(10, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("1ABCD2EFGH", snap.GetLine(0).TrimEnd());
-        Assert.Equal("3IJKL", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("1ABCD2EFGH", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("3IJKL", snap.GetLine(1).TrimEnd());
         // Cursor on '3' moved from row 2 to row 1
-        Assert.Equal(0, snap.CursorX);
-        Assert.Equal(1, snap.CursorY);
+        Assert.AreEqual(0, snap.CursorX);
+        Assert.AreEqual(1, snap.CursorY);
     }
 
     /// <summary>
@@ -146,7 +147,7 @@ public class VteGhosttyReflowTests
     /// Resize to cols=7. "1ABCD2EFGH" → "1ABCD2E" (soft) + "FGH" → 2 rows.
     /// Cursor on '2' was at cell offset 5, maps to (5,0).
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Ghostty_ResizeMoreCols_ForcesMoreWrapping()
     {
         using var terminal = CreateTerminal(GhosttyReflowStrategy.Instance, 5, 5, scrollback: 5);
@@ -161,11 +162,11 @@ public class VteGhosttyReflowTests
         terminal.Resize(7, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("1ABCD2E", snap.GetLine(0).TrimEnd());
-        Assert.Equal("FGH", snap.GetLine(1).TrimEnd());
-        Assert.Equal("3IJKL", snap.GetLine(2).TrimEnd());
-        Assert.Equal(5, snap.CursorX);
-        Assert.Equal(0, snap.CursorY);
+        Assert.AreEqual("1ABCD2E", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("FGH", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("3IJKL", snap.GetLine(2).TrimEnd());
+        Assert.AreEqual(5, snap.CursorX);
+        Assert.AreEqual(0, snap.CursorY);
     }
 
     /// <summary>
@@ -179,7 +180,7 @@ public class VteGhosttyReflowTests
     /// Cursor on '3' at (0,2). Resize to cols=15. All one row.
     /// Cursor on '3' was at cell offset 10, maps to (10,0).
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Ghostty_ResizeMoreCols_UnwrapsMultipleTimes()
     {
         using var terminal = CreateTerminal(GhosttyReflowStrategy.Instance, 5, 5, scrollback: 5);
@@ -189,15 +190,15 @@ public class VteGhosttyReflowTests
         // Move cursor to '3' at (0,2)
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[3;1H"));
 
-        Assert.Equal(0, terminal.CursorX);
-        Assert.Equal(2, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorX);
+        Assert.AreEqual(2, terminal.CursorY);
 
         terminal.Resize(15, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("1ABCD2EFGH3IJKL", snap.GetLine(0).TrimEnd());
-        Assert.Equal(10, snap.CursorX);
-        Assert.Equal(0, snap.CursorY);
+        Assert.AreEqual("1ABCD2EFGH3IJKL", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual(10, snap.CursorX);
+        Assert.AreEqual(0, snap.CursorY);
     }
 
     /// <summary>
@@ -211,7 +212,7 @@ public class VteGhosttyReflowTests
     /// Resize to cols=3. 15 chars → 5 rows at width 3.
     /// Screen shows: "3IJ" "KL4" "ABC" "D5E" "FGH"
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Ghostty_ResizeLessCols_ReflowPreviouslyWrapped()
     {
         using var terminal = CreateTerminal(GhosttyReflowStrategy.Instance, 5, 5, scrollback: 5);
@@ -221,11 +222,11 @@ public class VteGhosttyReflowTests
         terminal.Resize(3, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("3IJ", snap.GetLine(0).TrimEnd());
-        Assert.Equal("KL4", snap.GetLine(1).TrimEnd());
-        Assert.Equal("ABC", snap.GetLine(2).TrimEnd());
-        Assert.Equal("D5E", snap.GetLine(3).TrimEnd());
-        Assert.Equal("FGH", snap.GetLine(4).TrimEnd());
+        Assert.AreEqual("3IJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("KL4", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("ABC", snap.GetLine(2).TrimEnd());
+        Assert.AreEqual("D5E", snap.GetLine(3).TrimEnd());
+        Assert.AreEqual("FGH", snap.GetLine(4).TrimEnd());
     }
 
     /// <summary>
@@ -239,7 +240,7 @@ public class VteGhosttyReflowTests
     /// Cursor at (1,2) on 'E'. Resize to cols=3. Each line is hard-wrapped (no merging).
     /// The hard-wrapped lines stay as separate logical lines. Cursor stays at (1,2).
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Ghostty_ResizeLessCols_ReflowWithScrollback()
     {
         using var terminal = CreateTerminal(GhosttyReflowStrategy.Instance, 5, 3, scrollback: 5);
@@ -247,20 +248,20 @@ public class VteGhosttyReflowTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("1A\r\n2B\r\n3C\r\n4D\r\n5E"));
 
         // Cursor should be after "5E" at col 2, row 2
-        Assert.Equal(2, terminal.CursorX);
-        Assert.Equal(2, terminal.CursorY);
+        Assert.AreEqual(2, terminal.CursorX);
+        Assert.AreEqual(2, terminal.CursorY);
 
         terminal.Resize(3, 3);
 
         // Content is short enough that no re-wrapping needed (each line < 3 chars).
         // Cursor should still be at (2, 2) on 'E' row.
-        Assert.Equal(2, terminal.CursorX);
-        Assert.Equal(2, terminal.CursorY);
+        Assert.AreEqual(2, terminal.CursorX);
+        Assert.AreEqual(2, terminal.CursorY);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("3C", snap.GetLine(0).TrimEnd());
-        Assert.Equal("4D", snap.GetLine(1).TrimEnd());
-        Assert.Equal("5E", snap.GetLine(2).TrimEnd());
+        Assert.AreEqual("3C", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("4D", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("5E", snap.GetLine(2).TrimEnd());
     }
 
     /// <summary>
@@ -279,7 +280,7 @@ public class VteGhosttyReflowTests
     /// Cursor was on 'H' at cell offset 4*5+4=24. At width 3: row=24/3=8, col=24%3=0.
     /// Screen (rows=3): shows rows 6-8: "CD5", "EFG", "H". Cursor at (0, 2).
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Ghostty_ResizeLessCols_PreviouslyWrappedWithScrollback()
     {
         using var terminal = CreateTerminal(GhosttyReflowStrategy.Instance, 5, 3, scrollback: 2);
@@ -288,15 +289,15 @@ public class VteGhosttyReflowTests
 
         // After writing 25 chars at width 5: 5 rows, screen shows last 3.
         // Cursor wraps to end of content. After pending wrap, cursor is at col 4 row 4 (last screen row = 2)
-        Assert.Equal(4, terminal.CursorX);
-        Assert.Equal(2, terminal.CursorY);
+        Assert.AreEqual(4, terminal.CursorX);
+        Assert.AreEqual(2, terminal.CursorY);
 
         terminal.Resize(3, 3);
 
         var snap = terminal.CreateSnapshot();
         // Cursor was on 'H' (last char), should track to its new position
-        Assert.Equal(0, snap.CursorX);
-        Assert.Equal(2, snap.CursorY);
+        Assert.AreEqual(0, snap.CursorX);
+        Assert.AreEqual(2, snap.CursorY);
     }
 
     #endregion
@@ -314,7 +315,7 @@ public class VteGhosttyReflowTests
     /// Resize to cols=5. "12345" is only 5 chars so stays on one row. "67890" same.
     /// Saved cursor should be at (4,0) — same position since the line fits.
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Vte_SavedCursor_TracksCharacterAfterNarrowResize()
     {
         using var terminal = CreateTerminal(VteReflowStrategy.Instance, 10, 5, scrollback: 5);
@@ -323,8 +324,8 @@ public class VteGhosttyReflowTests
 
         // Move cursor to '5' at (4,0) and save
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[1;5H")); // row 1, col 5 = (4, 0)
-        Assert.Equal(4, terminal.CursorX);
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(4, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
         terminal.ApplyTokens([SaveCursorToken.Dec]);
 
         // Move cursor away
@@ -334,11 +335,11 @@ public class VteGhosttyReflowTests
 
         // Restore saved cursor and check — should still be on '5'
         terminal.ApplyTokens([RestoreCursorToken.Dec]);
-        Assert.Equal(4, terminal.CursorX);
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(4, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("12345", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("12345", snap.GetLine(0).TrimEnd());
     }
 
     /// <summary>
@@ -353,7 +354,7 @@ public class VteGhosttyReflowTests
     /// After reflow: "ABCDEFGHIJ" becomes one row. 'F' is at (5,0).
     /// Restore and verify.
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Vte_SavedCursor_TracksCharacterAfterWiderResize()
     {
         using var terminal = CreateTerminal(VteReflowStrategy.Instance, 5, 5, scrollback: 5);
@@ -362,8 +363,8 @@ public class VteGhosttyReflowTests
 
         // Move cursor to 'F' at (0,1) and save
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[2;1H"));
-        Assert.Equal(0, terminal.CursorX);
-        Assert.Equal(1, terminal.CursorY);
+        Assert.AreEqual(0, terminal.CursorX);
+        Assert.AreEqual(1, terminal.CursorY);
         terminal.ApplyTokens([SaveCursorToken.Dec]);
 
         // Write more content on a new line
@@ -374,11 +375,11 @@ public class VteGhosttyReflowTests
 
         // Restore saved cursor — should be at (5, 0) where 'F' now is
         terminal.ApplyTokens([RestoreCursorToken.Dec]);
-        Assert.Equal(5, terminal.CursorX);
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(5, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("ABCDEFGHIJ", snap.GetLine(0).TrimEnd());
     }
 
     /// <summary>
@@ -393,7 +394,7 @@ public class VteGhosttyReflowTests
     /// Kitty: saved cursor stays at original (0,1) — NOT reflowed.
     /// VTE: saved cursor moves to (5,0) — reflowed.
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Vte_SavedCursor_DiffersFromKitty()
     {
         // Build the same context for both strategies
@@ -415,15 +416,15 @@ public class VteGhosttyReflowTests
 
         // VTE strategy reflowed the saved cursor
         var vteResult = VteReflowStrategy.Instance.Reflow(context);
-        Assert.NotNull(vteResult.NewSavedCursorX);
-        Assert.NotNull(vteResult.NewSavedCursorY);
-        Assert.Equal(5, vteResult.NewSavedCursorX!.Value);
-        Assert.Equal(0, vteResult.NewSavedCursorY!.Value);
+        Assert.IsNotNull(vteResult.NewSavedCursorX);
+        Assert.IsNotNull(vteResult.NewSavedCursorY);
+        Assert.AreEqual(5, vteResult.NewSavedCursorX!.Value);
+        Assert.AreEqual(0, vteResult.NewSavedCursorY!.Value);
 
         // Kitty strategy does NOT reflow the saved cursor
         var kittyResult = KittyReflowStrategy.Instance.Reflow(context);
-        Assert.Null(kittyResult.NewSavedCursorX);
-        Assert.Null(kittyResult.NewSavedCursorY);
+        Assert.IsNull(kittyResult.NewSavedCursorX);
+        Assert.IsNull(kittyResult.NewSavedCursorY);
     }
 
     /// <summary>
@@ -433,7 +434,7 @@ public class VteGhosttyReflowTests
     /// <b>Provenance:</b> Verification that <see cref="GhosttyReflowStrategy"/> produces
     /// identical saved cursor behavior to <see cref="VteReflowStrategy"/>.
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Ghostty_SavedCursor_MatchesVteBehavior()
     {
         int width = 5, height = 5;
@@ -455,10 +456,10 @@ public class VteGhosttyReflowTests
         var vteResult = VteReflowStrategy.Instance.Reflow(context);
         var ghosttyResult = GhosttyReflowStrategy.Instance.Reflow(context);
 
-        Assert.Equal(vteResult.NewSavedCursorX, ghosttyResult.NewSavedCursorX);
-        Assert.Equal(vteResult.NewSavedCursorY, ghosttyResult.NewSavedCursorY);
-        Assert.Equal(vteResult.CursorX, ghosttyResult.CursorX);
-        Assert.Equal(vteResult.CursorY, ghosttyResult.CursorY);
+        Assert.AreEqual(vteResult.NewSavedCursorX, ghosttyResult.NewSavedCursorX);
+        Assert.AreEqual(vteResult.NewSavedCursorY, ghosttyResult.NewSavedCursorY);
+        Assert.AreEqual(vteResult.CursorX, ghosttyResult.CursorX);
+        Assert.AreEqual(vteResult.CursorY, ghosttyResult.CursorY);
     }
 
     #endregion
@@ -474,7 +475,7 @@ public class VteGhosttyReflowTests
     /// <b>Setup:</b> "Hello\nWorld" (hard-wrapped via newlines). Resize wider.
     /// The two lines must remain separate.
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Vte_HardWrappedLines_NotMerged()
     {
         using var terminal = CreateTerminal(VteReflowStrategy.Instance, 10, 5, scrollback: 5);
@@ -484,8 +485,8 @@ public class VteGhosttyReflowTests
         terminal.Resize(20, 5);
 
         var snap = terminal.CreateSnapshot();
-        Assert.Equal("Hello", snap.GetLine(0).TrimEnd());
-        Assert.Equal("World", snap.GetLine(1).TrimEnd());
+        Assert.AreEqual("Hello", snap.GetLine(0).TrimEnd());
+        Assert.AreEqual("World", snap.GetLine(1).TrimEnd());
     }
 
     /// <summary>
@@ -499,7 +500,7 @@ public class VteGhosttyReflowTests
     /// Resize to cols=10. Line is still "ABCDE" (no soft-wrap to join).
     /// Saved cursor should be at (4,0).
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void Vte_SavedCursorAtEOL_StaysAtEOL()
     {
         using var terminal = CreateTerminal(VteReflowStrategy.Instance, 5, 5, scrollback: 5);
@@ -517,8 +518,8 @@ public class VteGhosttyReflowTests
 
         // Restore and verify cursor is still on 'E'
         terminal.ApplyTokens([RestoreCursorToken.Dec]);
-        Assert.Equal(4, terminal.CursorX);
-        Assert.Equal(0, terminal.CursorY);
+        Assert.AreEqual(4, terminal.CursorX);
+        Assert.AreEqual(0, terminal.CursorY);
     }
 
     #endregion
@@ -528,25 +529,25 @@ public class VteGhosttyReflowTests
     /// <summary>
     /// VTE strategy sets ShouldClearSoftWrapOnAbsolutePosition to true.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void VteStrategy_ShouldClearSoftWrapOnAbsolutePosition_IsTrue()
     {
-        Assert.True(VteReflowStrategy.Instance.ShouldClearSoftWrapOnAbsolutePosition);
+        Assert.IsTrue(VteReflowStrategy.Instance.ShouldClearSoftWrapOnAbsolutePosition);
     }
 
     /// <summary>
     /// Ghostty strategy sets ShouldClearSoftWrapOnAbsolutePosition to true.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void GhosttyStrategy_ShouldClearSoftWrapOnAbsolutePosition_IsTrue()
     {
-        Assert.True(GhosttyReflowStrategy.Instance.ShouldClearSoftWrapOnAbsolutePosition);
+        Assert.IsTrue(GhosttyReflowStrategy.Instance.ShouldClearSoftWrapOnAbsolutePosition);
     }
 
     /// <summary>
     /// VTE does not reflow alternate screen buffer.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void VteStrategy_AlternateScreen_NoReflow()
     {
         int width = 5, height = 3;
@@ -564,13 +565,13 @@ public class VteGhosttyReflowTests
         var result = VteReflowStrategy.Instance.Reflow(context);
 
         // No reflow in alt screen — content is cropped/extended, not re-wrapped
-        Assert.Equal("ABCDE", GetRowText(result.ScreenRows[0]));
+        Assert.AreEqual("ABCDE", GetRowText(result.ScreenRows[0]));
     }
 
     /// <summary>
     /// Ghostty does not reflow alternate screen buffer.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void GhosttyStrategy_AlternateScreen_NoReflow()
     {
         int width = 5, height = 3;
@@ -587,7 +588,7 @@ public class VteGhosttyReflowTests
 
         var result = GhosttyReflowStrategy.Instance.Reflow(context);
 
-        Assert.Equal("ABCDE", GetRowText(result.ScreenRows[0]));
+        Assert.AreEqual("ABCDE", GetRowText(result.ScreenRows[0]));
     }
 
     #endregion
@@ -597,7 +598,7 @@ public class VteGhosttyReflowTests
     /// <summary>
     /// When reflowSavedCursor is false, saved cursor fields are null in result.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void ReflowHelper_NoSavedCursorReflow_ReturnsNull()
     {
         int width = 5, height = 3;
@@ -615,14 +616,14 @@ public class VteGhosttyReflowTests
 
         var result = ReflowHelper.PerformReflow(context, preserveCursorRow: true, reflowSavedCursor: false);
 
-        Assert.Null(result.NewSavedCursorX);
-        Assert.Null(result.NewSavedCursorY);
+        Assert.IsNull(result.NewSavedCursorX);
+        Assert.IsNull(result.NewSavedCursorY);
     }
 
     /// <summary>
     /// When reflowSavedCursor is true but saved cursor is null, result fields are null.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void ReflowHelper_SavedCursorNull_ReturnsNull()
     {
         int width = 5, height = 3;
@@ -639,8 +640,8 @@ public class VteGhosttyReflowTests
 
         var result = ReflowHelper.PerformReflow(context, preserveCursorRow: true, reflowSavedCursor: true);
 
-        Assert.Null(result.NewSavedCursorX);
-        Assert.Null(result.NewSavedCursorY);
+        Assert.IsNull(result.NewSavedCursorX);
+        Assert.IsNull(result.NewSavedCursorY);
     }
 
     /// <summary>
@@ -654,7 +655,7 @@ public class VteGhosttyReflowTests
     /// Primary cursor at (0,1), saved cursor at (2,0) on 'C'.
     /// Resize to width 10: "ABCDEFGHIJ". 'C' moves to (2,0).
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void ReflowHelper_SavedCursor_TracksOnWiden()
     {
         int width = 5, height = 3;
@@ -672,11 +673,11 @@ public class VteGhosttyReflowTests
 
         var result = ReflowHelper.PerformReflow(context, preserveCursorRow: true, reflowSavedCursor: true);
 
-        Assert.Equal(2, result.NewSavedCursorX);
-        Assert.Equal(0, result.NewSavedCursorY);
+        Assert.AreEqual(2, result.NewSavedCursorX);
+        Assert.AreEqual(0, result.NewSavedCursorY);
 
         // Verify content
-        Assert.Equal("ABCDEFGHIJ", GetRowText(result.ScreenRows[0]));
+        Assert.AreEqual("ABCDEFGHIJ", GetRowText(result.ScreenRows[0]));
     }
 
     /// <summary>
@@ -687,7 +688,7 @@ public class VteGhosttyReflowTests
     /// Saved cursor at (2,1) = 'H' in "ABCDE" + "FGHIJ". Cell offset = 1*5+2 = 7.
     /// At width 10: row=7/10=0, col=7%10=7. Saved cursor → (7,0).
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void ReflowHelper_SavedCursor_TracksSecondRowOnWiden()
     {
         int width = 5, height = 3;
@@ -705,8 +706,8 @@ public class VteGhosttyReflowTests
 
         var result = ReflowHelper.PerformReflow(context, preserveCursorRow: true, reflowSavedCursor: true);
 
-        Assert.Equal(7, result.NewSavedCursorX);
-        Assert.Equal(0, result.NewSavedCursorY);
+        Assert.AreEqual(7, result.NewSavedCursorX);
+        Assert.AreEqual(0, result.NewSavedCursorY);
     }
 
     /// <summary>
@@ -717,7 +718,7 @@ public class VteGhosttyReflowTests
     /// "ABCDEFGHIJ" at width 10, saved cursor at (7,0) = 'H'.
     /// Resize to width 5: "ABCDE" + "FGHIJ". Cell offset 7: row=7/5=1, col=7%5=2. → (2,1) = 'H'.
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public void ReflowHelper_SavedCursor_TracksOnNarrow()
     {
         int width = 10, height = 3;
@@ -735,17 +736,17 @@ public class VteGhosttyReflowTests
 
         var result = ReflowHelper.PerformReflow(context, preserveCursorRow: true, reflowSavedCursor: true);
 
-        Assert.Equal(2, result.NewSavedCursorX);
-        Assert.Equal(1, result.NewSavedCursorY);
+        Assert.AreEqual(2, result.NewSavedCursorX);
+        Assert.AreEqual(1, result.NewSavedCursorY);
 
-        Assert.Equal("ABCDE", GetRowText(result.ScreenRows[0]));
-        Assert.Equal("FGHIJ", GetRowText(result.ScreenRows[1]));
+        Assert.AreEqual("ABCDE", GetRowText(result.ScreenRows[0]));
+        Assert.AreEqual("FGHIJ", GetRowText(result.ScreenRows[1]));
     }
 
     /// <summary>
     /// Same-size resize returns saved cursor unchanged.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public void ReflowHelper_SameSize_SavedCursorUnchanged()
     {
         int width = 5, height = 3;
@@ -763,8 +764,8 @@ public class VteGhosttyReflowTests
 
         var result = ReflowHelper.PerformReflow(context, preserveCursorRow: true, reflowSavedCursor: true);
 
-        Assert.Equal(3, result.NewSavedCursorX);
-        Assert.Equal(1, result.NewSavedCursorY);
+        Assert.AreEqual(3, result.NewSavedCursorX);
+        Assert.AreEqual(1, result.NewSavedCursorY);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/WaitUntilTimeoutTests.cs
+++ b/tests/Hex1b.Tests/WaitUntilTimeoutTests.cs
@@ -7,9 +7,10 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for WaitUntilTimeoutException diagnostics.
 /// </summary>
+[TestClass]
 public class WaitUntilTimeoutTests
 {
-    [Fact]
+    [TestMethod]
     public async Task WaitUntil_Timeout_ThrowsWaitUntilTimeoutException()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -18,7 +19,7 @@ public class WaitUntilTimeoutTests
             .WithDimensions(40, 10)
             .Build();
 
-        var ex = await Assert.ThrowsAsync<WaitUntilTimeoutException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<WaitUntilTimeoutException>(async () =>
         {
             await new Hex1bTerminalInputSequenceBuilder()
                 .WaitUntil(s => s.ContainsText("This text will never appear"), TimeSpan.FromMilliseconds(250))
@@ -27,10 +28,10 @@ public class WaitUntilTimeoutTests
         });
 
         // Should still be catchable as TimeoutException
-        Assert.IsAssignableFrom<TimeoutException>(ex);
+        TestSeq.IsType<TimeoutException>(ex);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WaitUntil_Timeout_MessageContainsPredicateExpression()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -39,7 +40,7 @@ public class WaitUntilTimeoutTests
             .WithDimensions(40, 10)
             .Build();
 
-        var ex = await Assert.ThrowsAsync<WaitUntilTimeoutException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<WaitUntilTimeoutException>(async () =>
         {
             await new Hex1bTerminalInputSequenceBuilder()
                 .WaitUntil(s => s.ContainsText("NonExistent"), TimeSpan.FromMilliseconds(250))
@@ -52,7 +53,7 @@ public class WaitUntilTimeoutTests
         Assert.Contains("ContainsText(\"NonExistent\")", ex.ConditionDescription);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WaitUntil_Timeout_MessageContainsExplicitDescription()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -61,7 +62,7 @@ public class WaitUntilTimeoutTests
             .WithDimensions(40, 10)
             .Build();
 
-        var ex = await Assert.ThrowsAsync<WaitUntilTimeoutException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<WaitUntilTimeoutException>(async () =>
         {
             await new Hex1bTerminalInputSequenceBuilder()
                 .WaitUntil(s => s.ContainsText("Nope"), TimeSpan.FromMilliseconds(250), "my custom description")
@@ -71,10 +72,10 @@ public class WaitUntilTimeoutTests
 
         // Explicit description should take priority over predicate expression
         Assert.Contains("my custom description", ex.Message);
-        Assert.Equal("my custom description", ex.ConditionDescription);
+        Assert.AreEqual("my custom description", ex.ConditionDescription);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WaitUntil_Timeout_MessageContainsCallerLocation()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -83,7 +84,7 @@ public class WaitUntilTimeoutTests
             .WithDimensions(40, 10)
             .Build();
 
-        var ex = await Assert.ThrowsAsync<WaitUntilTimeoutException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<WaitUntilTimeoutException>(async () =>
         {
             await new Hex1bTerminalInputSequenceBuilder()
                 .WaitUntil(s => s.ContainsText("Nope"), TimeSpan.FromMilliseconds(250))
@@ -93,12 +94,12 @@ public class WaitUntilTimeoutTests
 
         // Should contain the test file name and a line number
         Assert.Contains("WaitUntilTimeoutTests.cs", ex.Message);
-        Assert.NotNull(ex.CallerFilePath);
+        Assert.IsNotNull(ex.CallerFilePath);
         Assert.Contains("WaitUntilTimeoutTests.cs", ex.CallerFilePath);
-        Assert.True(ex.CallerLineNumber > 0);
+        Assert.IsTrue(ex.CallerLineNumber > 0);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WaitUntil_Timeout_MessageContainsFullTerminalGrid()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -121,7 +122,7 @@ public class WaitUntilTimeoutTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        var ex = await Assert.ThrowsAsync<WaitUntilTimeoutException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<WaitUntilTimeoutException>(async () =>
         {
             await new Hex1bTerminalInputSequenceBuilder()
                 .WaitUntil(s => s.ContainsText("Nope"), TimeSpan.FromMilliseconds(250))
@@ -142,7 +143,7 @@ public class WaitUntilTimeoutTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WaitUntil_Timeout_ExposesTerminalSnapshot()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -165,7 +166,7 @@ public class WaitUntilTimeoutTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        var ex = await Assert.ThrowsAsync<WaitUntilTimeoutException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<WaitUntilTimeoutException>(async () =>
         {
             await new Hex1bTerminalInputSequenceBuilder()
                 .WaitUntil(s => s.ContainsText("Nope"), TimeSpan.FromMilliseconds(250))
@@ -174,10 +175,10 @@ public class WaitUntilTimeoutTests
         });
 
         // Exception should expose the snapshot as a structured property
-        Assert.NotNull(ex.TerminalSnapshot);
-        Assert.Equal(40, ex.TerminalSnapshot.Width);
-        Assert.Equal(10, ex.TerminalSnapshot.Height);
-        Assert.True(ex.TerminalSnapshot.ContainsText("Snapshot Test"));
+        Assert.IsNotNull(ex.TerminalSnapshot);
+        Assert.AreEqual(40, ex.TerminalSnapshot.Width);
+        Assert.AreEqual(10, ex.TerminalSnapshot.Height);
+        Assert.IsTrue(ex.TerminalSnapshot.ContainsText("Snapshot Test"));
 
         // Clean exit
         await new Hex1bTerminalInputSequenceBuilder()
@@ -187,7 +188,7 @@ public class WaitUntilTimeoutTests
         await runTask;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WaitUntil_Timeout_MessageContainsTimeoutDuration()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -197,7 +198,7 @@ public class WaitUntilTimeoutTests
             .Build();
 
         var timeout = TimeSpan.FromMilliseconds(250);
-        var ex = await Assert.ThrowsAsync<WaitUntilTimeoutException>(async () =>
+        var ex = await Assert.ThrowsExactlyAsync<WaitUntilTimeoutException>(async () =>
         {
             await new Hex1bTerminalInputSequenceBuilder()
                 .WaitUntil(s => s.ContainsText("Nope"), timeout)
@@ -206,6 +207,6 @@ public class WaitUntilTimeoutTests
         });
 
         Assert.Contains(timeout.ToString(), ex.Message);
-        Assert.Equal(timeout, ex.Timeout);
+        Assert.AreEqual(timeout, ex.Timeout);
     }
 }

--- a/tests/Hex1b.Tests/WebSocketPresentationAdapterTests.cs
+++ b/tests/Hex1b.Tests/WebSocketPresentationAdapterTests.cs
@@ -2,9 +2,10 @@ using System.Net.WebSockets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class WebSocketPresentationAdapterTests
 {
-    [Fact]
+    [TestMethod]
     public void Resize_WithInvalidTracePath_DoesNotThrow()
     {
         using var webSocket = new StubWebSocket();
@@ -20,8 +21,8 @@ public class WebSocketPresentationAdapterTests
 
             adapter.Resize(120, 40, 9, 18, 9.5);
 
-            Assert.Equal(120, adapter.Width);
-            Assert.Equal(40, adapter.Height);
+            Assert.AreEqual(120, adapter.Width);
+            Assert.AreEqual(40, adapter.Height);
         }
         finally
         {

--- a/tests/Hex1b.Tests/WidgetLayerTests.cs
+++ b/tests/Hex1b.Tests/WidgetLayerTests.cs
@@ -6,9 +6,10 @@ using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class WidgetLayerTests
 {
-    [Fact]
+    [TestMethod]
     public void Render_WidgetLayer_RendersTextBlockToSurface()
     {
         var node = new SurfaceNode
@@ -22,14 +23,14 @@ public class WidgetLayerTests
 
         node.Render(context);
 
-        Assert.Equal("H", surface[0, 0].Character);
-        Assert.Equal("e", surface[1, 0].Character);
-        Assert.Equal("l", surface[2, 0].Character);
-        Assert.Equal("l", surface[3, 0].Character);
-        Assert.Equal("o", surface[4, 0].Character);
+        Assert.AreEqual("H", surface[0, 0].Character);
+        Assert.AreEqual("e", surface[1, 0].Character);
+        Assert.AreEqual("l", surface[2, 0].Character);
+        Assert.AreEqual("l", surface[3, 0].Character);
+        Assert.AreEqual("o", surface[4, 0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_WidgetLayer_PreservesNodeStateAcrossFrames()
     {
         // Render twice with the same widget — should not throw and should reuse node state
@@ -45,11 +46,11 @@ public class WidgetLayerTests
         var surface2 = new Surface(80, 24);
         node.Render(new SurfaceRenderContext(surface2));
 
-        Assert.Equal("T", surface2[0, 0].Character);
-        Assert.Equal("e", surface2[1, 0].Character);
+        Assert.AreEqual("T", surface2[0, 0].Character);
+        Assert.AreEqual("e", surface2[1, 0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_WidgetLayerWithComputedLayer_CompositesCorrectly()
     {
         // Widget layer on bottom, computed layer on top that replaces all content with 'X'
@@ -75,11 +76,11 @@ public class WidgetLayerTests
         // "Hello" should be replaced with "XXXXX"
         for (int i = 0; i < 5; i++)
         {
-            Assert.Equal("X", surface[i, 0].Character);
+            Assert.AreEqual("X", surface[i, 0].Character);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_MultipleWidgetLayers_CompositesInOrder()
     {
         var node = new SurfaceNode
@@ -96,11 +97,11 @@ public class WidgetLayerTests
         node.Render(new SurfaceRenderContext(surface));
 
         // Top layer "BB" should overwrite first 2 chars of "AAAA"
-        Assert.Equal("B", surface[0, 0].Character);
-        Assert.Equal("B", surface[1, 0].Character);
+        Assert.AreEqual("B", surface[0, 0].Character);
+        Assert.AreEqual("B", surface[1, 0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_WidgetLayerChangingWidget_UpdatesContent()
     {
         string text = "First";
@@ -112,7 +113,7 @@ public class WidgetLayerTests
 
         var surface1 = new Surface(80, 24);
         node.Render(new SurfaceRenderContext(surface1));
-        Assert.Equal("F", surface1[0, 0].Character);
+        Assert.AreEqual("F", surface1[0, 0].Character);
 
         // Change the widget tree
         text = "Second";
@@ -120,10 +121,10 @@ public class WidgetLayerTests
 
         var surface2 = new Surface(80, 24);
         node.Render(new SurfaceRenderContext(surface2));
-        Assert.Equal("S", surface2[0, 0].Character);
+        Assert.AreEqual("S", surface2[0, 0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_WidgetLayerAtOffset_WritesAtCorrectPosition()
     {
         // SurfaceNode positioned at (5, 2) in the target
@@ -138,11 +139,11 @@ public class WidgetLayerTests
 
         node.Render(context);
 
-        Assert.Equal("H", surface[5, 2].Character);
-        Assert.Equal("i", surface[6, 2].Character);
+        Assert.AreEqual("H", surface[5, 2].Character);
+        Assert.AreEqual("i", surface[6, 2].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_WidgetLayerBelowStaticLayer_CompositesCorrectly()
     {
         // Widget layer as background, static source layer on top
@@ -163,13 +164,13 @@ public class WidgetLayerTests
         node.Render(new SurfaceRenderContext(surface));
 
         // "ZZ" overlay should replace first 2 chars
-        Assert.Equal("Z", surface[0, 0].Character);
-        Assert.Equal("Z", surface[1, 0].Character);
+        Assert.AreEqual("Z", surface[0, 0].Character);
+        Assert.AreEqual("Z", surface[1, 0].Character);
         // Remaining should be from widget layer
-        Assert.Equal("l", surface[2, 0].Character);
+        Assert.AreEqual("l", surface[2, 0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_EmptyWidgetTree_DoesNotThrow()
     {
         // VStack with no children — should render without crashing
@@ -186,7 +187,7 @@ public class WidgetLayerTests
         node.Render(context);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_WidgetLayerRemovedBetweenFrames_CleansUpStaleState()
     {
         // Frame 1: two widget layers
@@ -209,11 +210,11 @@ public class WidgetLayerTests
         var surface2 = new Surface(80, 24);
         node.Render(new SurfaceRenderContext(surface2));
 
-        Assert.Equal("O", surface2[0, 0].Character);
-        Assert.Equal("n", surface2[1, 0].Character);
+        Assert.AreEqual("O", surface2[0, 0].Character);
+        Assert.AreEqual("n", surface2[1, 0].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_WidgetLayerWithVStack_RendersMultiLineLayout()
     {
         var node = new SurfaceNode
@@ -228,12 +229,12 @@ public class WidgetLayerTests
         var surface = new Surface(80, 24);
         node.Render(new SurfaceRenderContext(surface));
 
-        Assert.Equal("L", surface[0, 0].Character);
-        Assert.Equal("L", surface[0, 1].Character);
-        Assert.Equal("2", surface[4, 1].Character);
+        Assert.AreEqual("L", surface[0, 0].Character);
+        Assert.AreEqual("L", surface[0, 1].Character);
+        Assert.AreEqual("2", surface[4, 1].Character);
     }
 
-    [Fact]
+    [TestMethod]
     public void Render_WidgetLayerComputedLayerReadsWidgetContent()
     {
         // Computed layer reads widget layer content and transforms foreground
@@ -256,9 +257,9 @@ public class WidgetLayerTests
         node.Render(new SurfaceRenderContext(surface));
 
         // Characters from widget layer, foreground replaced by computed layer
-        Assert.Equal("T", surface[0, 0].Character);
-        Assert.Equal(tintColor, surface[0, 0].Foreground);
-        Assert.Equal("e", surface[1, 0].Character);
-        Assert.Equal(tintColor, surface[1, 0].Foreground);
+        Assert.AreEqual("T", surface[0, 0].Character);
+        Assert.AreEqual(tintColor, surface[0, 0].Foreground);
+        Assert.AreEqual("e", surface[1, 0].Character);
+        Assert.AreEqual(tintColor, surface[1, 0].Foreground);
     }
 }

--- a/tests/Hex1b.Tests/WidgetOnPasteTests.cs
+++ b/tests/Hex1b.Tests/WidgetOnPasteTests.cs
@@ -8,6 +8,7 @@ namespace Hex1b.Tests;
 /// Tests for OnPaste fluent methods on widgets (Phase 5).
 /// Verifies that custom paste handlers override default behavior.
 /// </summary>
+[TestClass]
 public class WidgetOnPasteTests
 {
     private static PasteContext CreatePaste(string text)
@@ -18,7 +19,7 @@ public class WidgetOnPasteTests
         return ctx;
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OnPaste_OverridesDefault()
     {
         // With OnPaste set, default text insertion should NOT happen
@@ -33,14 +34,14 @@ public class WidgetOnPasteTests
 
         var result = await node.HandlePasteAsync(new Hex1bPasteEvent(paste));
 
-        Assert.Equal(InputResult.Handled, result);
-        Assert.Equal("custom", customReceived);
+        Assert.AreEqual(InputResult.Handled, result);
+        Assert.AreEqual("custom", customReceived);
         // Text should NOT have been modified by default handler
-        Assert.Equal("original", node.Text);
+        Assert.AreEqual("original", node.Text);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OnPaste_ReceivesPasteContext()
     {
         PasteContext? receivedContext = null;
@@ -54,11 +55,11 @@ public class WidgetOnPasteTests
 
         await node.HandlePasteAsync(new Hex1bPasteEvent(paste));
 
-        Assert.Same(paste, receivedContext);
+        Assert.AreSame(paste, receivedContext);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OnPaste_CanReadToEnd()
     {
         string? result = null;
@@ -71,11 +72,11 @@ public class WidgetOnPasteTests
 
         await node.HandlePasteAsync(new Hex1bPasteEvent(paste));
 
-        Assert.Equal("hello world", result);
+        Assert.AreEqual("hello world", result);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OnPaste_CanCancel()
     {
         var node = new TextBoxNode();
@@ -90,11 +91,11 @@ public class WidgetOnPasteTests
 
         await node.HandlePasteAsync(new Hex1bPasteEvent(paste));
 
-        Assert.True(paste.IsCancelled);
+        Assert.IsTrue(paste.IsCancelled);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OnPaste_WithoutHandler_DefaultBehavior()
     {
         // Without OnPaste, default text insertion should happen
@@ -105,23 +106,23 @@ public class WidgetOnPasteTests
 
         await node.HandlePasteAsync(new Hex1bPasteEvent(paste));
 
-        Assert.Equal("inserted", node.Text);
+        Assert.AreEqual("inserted", node.Text);
         await paste.DisposeAsync();
     }
 
-    [Fact]
+    [TestMethod]
     public void Widget_OnPaste_FluentApi()
     {
         var widget = new TextBoxWidget("test");
 
         var withPaste = widget.OnPaste(async e => await e.Paste.ReadToEndAsync());
-        Assert.NotNull(withPaste.PasteHandler);
+        Assert.IsNotNull(withPaste.PasteHandler);
 
         var withSyncPaste = widget.OnPaste(e => { });
-        Assert.NotNull(withSyncPaste.PasteHandler);
+        Assert.IsNotNull(withSyncPaste.PasteHandler);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task Widget_OnPaste_WiredThroughReconciliation()
     {
         bool handlerCalled = false;
@@ -136,16 +137,16 @@ public class WidgetOnPasteTests
         var context = ReconcileContext.CreateRoot();
         var node = await widget.ReconcileAsync(null, context) as TextBoxNode;
 
-        Assert.NotNull(node);
-        Assert.NotNull(node!.CustomPasteAction);
+        Assert.IsNotNull(node);
+        Assert.IsNotNull(node!.CustomPasteAction);
 
         // Invoke the handler
         var paste = CreatePaste("test");
         await node.HandlePasteAsync(new Hex1bPasteEvent(paste));
 
-        Assert.True(handlerCalled);
+        Assert.IsTrue(handlerCalled);
         // Default insert should NOT have happened since custom handler was set
-        Assert.Equal("test", node.Text); // original text unchanged
+        Assert.AreEqual("test", node.Text); // original text unchanged
         await paste.DisposeAsync();
     }
 }

--- a/tests/Hex1b.Tests/WindowBorderBleedThroughTests.cs
+++ b/tests/Hex1b.Tests/WindowBorderBleedThroughTests.cs
@@ -52,6 +52,7 @@ namespace Hex1b.Tests;
 /// The same issue affects horizontal borders in <c>RenderHorizontalEdge()</c>.
 /// </para>
 /// </remarks>
+[TestClass]
 public class WindowBorderBleedThroughTests
 {
     /// <summary>
@@ -107,7 +108,7 @@ public class WindowBorderBleedThroughTests
     ///   <item>We check a non-zero number of overlap cells (non-vacuous assertion).</item>
     /// </list>
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public async Task WindowBorder_OverlappingContentWithBackground_BorderBackgroundDoesNotBleed()
     {
         // ── Arrange ──────────────────────────────────────────────────────────
@@ -238,14 +239,13 @@ public class WindowBorderBleedThroughTests
         // and NOT covered by Window A (which starts at col 12).
         {
             var sanityCell = snapshot.GetCell(wbContentLeft, wbContentTop);
-            Assert.True(sanityCell.Background.HasValue,
-                $"Sanity check failed: Window B content cell at ({wbContentLeft},{wbContentTop}) " +
+            Assert.IsTrue(sanityCell.Background.HasValue, $"Sanity check failed: Window B content cell at ({wbContentLeft},{wbContentTop}) " +
                 $"should have a background color but has none.\n" +
                 $"Cell: '{sanityCell.Character}'\n" +
                 $"Screen:\n{DumpScreen(snapshot, terminalHeight, terminalWidth)}");
-            Assert.Equal(WindowBContentBackground.R, sanityCell.Background.Value.R);
-            Assert.Equal(WindowBContentBackground.G, sanityCell.Background.Value.G);
-            Assert.Equal(WindowBContentBackground.B, sanityCell.Background.Value.B);
+            Assert.AreEqual(WindowBContentBackground.R, sanityCell.Background.Value.R);
+            Assert.AreEqual(WindowBContentBackground.G, sanityCell.Background.Value.G);
+            Assert.AreEqual(WindowBContentBackground.B, sanityCell.Background.Value.B);
         }
 
         // Now check every border cell of Window A that falls within Window B's content area.
@@ -316,8 +316,7 @@ public class WindowBorderBleedThroughTests
 
         // Sanity check 2: We must have checked a non-zero number of cells.
         // If this fails, our overlap geometry is wrong and the test is vacuous.
-        Assert.True(checkedCellCount > 0,
-            $"No overlap cells were checked! Verify test geometry.\n" +
+        Assert.IsTrue(checkedCellCount > 0, $"No overlap cells were checked! Verify test geometry.\n" +
             $"Window A borders: top={windowAAbsY}, bottom={windowAAbsY + windowAHeight - 1}, " +
             $"left={windowAAbsX}, right={windowAAbsX + windowAWidth - 1}\n" +
             $"Window B content: top={wbContentTop}, bottom={wbContentBottom}, " +
@@ -378,7 +377,7 @@ public class WindowBorderBleedThroughTests
     ///   The title bar's distinct background should only apply to the INNER area.
     /// </code>
     /// </remarks>
-    [Fact]
+    [TestMethod]
     public async Task WindowBorder_TitleBarRow_HasUniformBorderBackground()
     {
         const int terminalWidth = 60;
@@ -496,7 +495,7 @@ public class WindowBorderBleedThroughTests
             .OrderByDescending(g => g.Count())
             .ToList();
 
-        Assert.True(bgGroups.Count > 0, "No border cells with background color found");
+        Assert.IsTrue(bgGroups.Count > 0, "No border cells with background color found");
 
         var expectedBg = bgGroups[0].Key;
 

--- a/tests/Hex1b.Tests/WindowFocusIntegrationTests.cs
+++ b/tests/Hex1b.Tests/WindowFocusIntegrationTests.cs
@@ -8,13 +8,14 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Integration tests for window focus behavior.
 /// </summary>
+[TestClass]
 public class WindowFocusIntegrationTests
 {
     /// <summary>
     /// Tests the real scenario: MenuBar + WindowPanel + StatusBar layout.
     /// Opens a window via menu, then verifies ALT-F opens the menu again.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task MenuBar_KeyboardShortcuts_WorkAfterWindowOpened()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -84,7 +85,7 @@ public class WindowFocusIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         // Verify: Menu opened (New Window is visible)
-        Assert.Equal(0, menuItemActivatedCount); // Menu just opened, nothing activated yet
+        Assert.AreEqual(0, menuItemActivatedCount); // Menu just opened, nothing activated yet
         
         // Step 2: Press Enter to activate New Window (first item is focused)
         await new Hex1bTerminalInputSequenceBuilder()
@@ -94,8 +95,8 @@ public class WindowFocusIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         // Verify: Window opened and menu item was activated
-        Assert.True(windowOpened, "Window should have been opened");
-        Assert.Equal(1, menuItemActivatedCount); // One menu item activated
+        Assert.IsTrue(windowOpened, "Window should have been opened");
+        Assert.AreEqual(1, menuItemActivatedCount); // One menu item activated
         
         // Step 3: NOW THE KEY TEST - Can we still use ALT-F to open menu while window is open?
         string? step3State = null;
@@ -126,8 +127,8 @@ public class WindowFocusIntegrationTests
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
         // Step 5: Verify Exit was activated (proves keyboard navigation worked)
-        Assert.Equal(2, menuItemActivatedCount);
-        Assert.Equal("Exit clicked", statusText);
+        Assert.AreEqual(2, menuItemActivatedCount);
+        Assert.AreEqual("Exit clicked", statusText);
 
         // Cleanup
         await new Hex1bTerminalInputSequenceBuilder()
@@ -145,7 +146,7 @@ public class WindowFocusIntegrationTests
     /// InputRouter.BuildPathToFocused finds MenuNode first (depth-first), so DownArrow
     /// routes to MenuNode's binding (OpenMenu no-op) instead of MenuPopupNode's binding (FocusNext).
     /// </summary>
-    [Fact(Skip = "MenuBarNode.SetFocus creates stale IsFocused on MenuNode that confuses InputRouter when popup is open")]
+    [TestMethod, Ignore("MenuBarNode.SetFocus creates stale IsFocused on MenuNode that confuses InputRouter when popup is open")]
     public async Task MenuBar_ArrowNavigation_WorksWithWindowOpen()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -209,7 +210,7 @@ public class WindowFocusIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal("Item 1", activatedItems[0]);
+        Assert.AreEqual("Item 1", activatedItems[0]);
 
         await new Hex1bTerminalInputSequenceBuilder()
             .Ctrl().Key(Hex1bKey.C)
@@ -221,7 +222,7 @@ public class WindowFocusIntegrationTests
 
 
 
-    [Fact]
+    [TestMethod]
     public async Task OpeningSecondWindow_FocusesSecondWindow()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -277,11 +278,11 @@ public class WindowFocusIntegrationTests
         await runTask;
 
         // Window 2 should be closed (it was active), Window 1 should still be open
-        Assert.True(window2Closed, $"Window 2 should have been closed by ESC (it was the active window). W1Closed={window1Closed}, W2Closed={window2Closed}. FocusPath={InputRouter.LastPathDebug}");
-        Assert.False(window1Closed, "Window 1 should NOT have been closed (it was not the active window)");
+        Assert.IsTrue(window2Closed, $"Window 2 should have been closed by ESC (it was the active window). W1Closed={window1Closed}, W2Closed={window2Closed}. FocusPath={InputRouter.LastPathDebug}");
+        Assert.IsFalse(window1Closed, "Window 1 should NOT have been closed (it was not the active window)");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ClickingWindow_MakesItActive_EscapeClosesCorrectWindow()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -342,11 +343,11 @@ public class WindowFocusIntegrationTests
         await runTask;
 
         // Window 1 should be closed (we clicked on it), Window 2 should still be open
-        Assert.True(window1Closed, "Window 1 should have been closed by ESC (we clicked on it to focus it)");
-        Assert.False(window2Closed, "Window 2 should NOT have been closed");
+        Assert.IsTrue(window1Closed, "Window 1 should have been closed by ESC (we clicked on it to focus it)");
+        Assert.IsFalse(window2Closed, "Window 2 should NOT have been closed");
     }
 
-    [Fact]
+    [TestMethod]
     public async Task OpeningWindowsViaMenu_SecondWindowGetsEscaped()
     {
         // This test mimics the actual user scenario - opening windows via menu bar
@@ -420,15 +421,15 @@ public class WindowFocusIntegrationTests
         var focusPath = InputRouter.LastPathDebug;
         
         // Window 2 should be closed (it was active), Window 1 should still be open
-        Assert.True(window2Closed, $"Window 2 should have been closed by ESC. W1Closed={window1Closed}, W2Closed={window2Closed}. FocusPath={focusPath}");
-        Assert.False(window1Closed, $"Window 1 should NOT have been closed. FocusPath={focusPath}");
+        Assert.IsTrue(window2Closed, $"Window 2 should have been closed by ESC. W1Closed={window1Closed}, W2Closed={window2Closed}. FocusPath={focusPath}");
+        Assert.IsFalse(window1Closed, $"Window 1 should NOT have been closed. FocusPath={focusPath}");
     }
 
     /// <summary>
     /// Tests that a frameless window (NoTitleBar) opened from a menu can be closed with Escape.
     /// This is the exact scenario reported as broken in the WindowingDemo.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task FramelessWindow_OpenedViaMenu_ClosesWithEscape()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -480,7 +481,7 @@ public class WindowFocusIntegrationTests
 
         await runTask;
 
-        Assert.True(windowClosed, $"Frameless window should have been closed by ESC. FocusPath={InputRouter.LastPathDebug}");
+        Assert.IsTrue(windowClosed, $"Frameless window should have been closed by ESC. FocusPath={InputRouter.LastPathDebug}");
     }
 
     /// <summary>
@@ -488,7 +489,7 @@ public class WindowFocusIntegrationTests
     /// This matches the exact widget tree structure of the WindowingDemo sample app:
     /// VStack → NotificationPanel(VStack(MenuBar, ..., WindowPanel))
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Window_OpenedViaMenu_WithNotificationPanel_ClosesWithEscape()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -543,7 +544,7 @@ public class WindowFocusIntegrationTests
 
         await runTask;
 
-        Assert.True(windowClosed, $"Window should have been closed by ESC with NotificationPanel wrapper. FocusPath={InputRouter.LastPathDebug}");
+        Assert.IsTrue(windowClosed, $"Window should have been closed by ESC with NotificationPanel wrapper. FocusPath={InputRouter.LastPathDebug}");
     }
 
     /// <summary>
@@ -551,7 +552,7 @@ public class WindowFocusIntegrationTests
     /// .Background(), .Unbounded(), .Fill() and NotificationPanel wrapping.
     /// Verifies that a window opened via menu receives focus and can be closed with Escape.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Window_ExactDemoTree_ReceivesFocusAndClosesWithEscape()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -618,8 +619,7 @@ public class WindowFocusIntegrationTests
 
         await runTask;
 
-        Assert.True(windowClosed,
-            $"Window should have been closed by ESC. FocusPathBeforeEsc={focusPathAtEscape}, FocusPathAfterEsc={InputRouter.LastPathDebug}");
+        Assert.IsTrue(windowClosed, $"Window should have been closed by ESC. FocusPathBeforeEsc={focusPathAtEscape}, FocusPathAfterEsc={InputRouter.LastPathDebug}");
     }
 
     /// <summary>
@@ -627,7 +627,7 @@ public class WindowFocusIntegrationTests
     /// its first focusable child (TextBox), so typing works immediately.
     /// Also proves Escape closes the window.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task Window_OpenedViaMenu_TextBoxReceivesFocus_CanTypeImmediately()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -682,7 +682,7 @@ public class WindowFocusIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(windowOpen, "Window should be open");
+        Assert.IsTrue(windowOpen, "Window should be open");
 
         // Type immediately — if focus is correct, text should appear in the TextBox
         await new Hex1bTerminalInputSequenceBuilder()
@@ -691,7 +691,7 @@ public class WindowFocusIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal("Hello", typedText);
+        Assert.AreEqual("Hello", typedText);
 
         // Escape closes the window
         await new Hex1bTerminalInputSequenceBuilder()
@@ -703,14 +703,14 @@ public class WindowFocusIntegrationTests
 
         await runTask;
 
-        Assert.False(windowOpen, "Window should have been closed by Escape");
+        Assert.IsFalse(windowOpen, "Window should have been closed by Escape");
     }
 
     /// <summary>
     /// When two windows are open and the top one is closed, focus should
     /// return to the underlying window's first content focusable.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ClosingTopWindow_FocusReturnsToUnderlyingWindow()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -777,7 +777,7 @@ public class WindowFocusIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(windowAOpen);
+        Assert.IsTrue(windowAOpen);
 
         // Type into Window A to prove it has focus
         await new Hex1bTerminalInputSequenceBuilder()
@@ -786,7 +786,7 @@ public class WindowFocusIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal("AAA", textA);
+        Assert.AreEqual("AAA", textA);
 
         // Open Window B via menu (click to avoid keyboard focus issues)
         await new Hex1bTerminalInputSequenceBuilder()
@@ -797,7 +797,7 @@ public class WindowFocusIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(windowBOpen);
+        Assert.IsTrue(windowBOpen);
 
         // Type into Window B to prove it has focus
         await new Hex1bTerminalInputSequenceBuilder()
@@ -806,7 +806,7 @@ public class WindowFocusIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal("BBB", textB);
+        Assert.AreEqual("BBB", textB);
 
         // Close Window B with Escape — focus should return to Window A
         // Wait for Window 2 title to disappear (proves render completed with focus restored)
@@ -816,8 +816,8 @@ public class WindowFocusIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.False(windowBOpen);
-        Assert.True(windowAOpen);
+        Assert.IsFalse(windowBOpen);
+        Assert.IsTrue(windowAOpen);
 
         // Type more — should go into Window A (focus restored)
         await new Hex1bTerminalInputSequenceBuilder()
@@ -829,14 +829,14 @@ public class WindowFocusIntegrationTests
 
         await runTask;
 
-        Assert.Equal("AAAX", textA);
+        Assert.AreEqual("AAAX", textA);
     }
 
     /// <summary>
     /// Tests cascade close: open 3 windows, close each in turn, focus returns
     /// to the next one in z-order each time.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task CascadeClose_ThreeWindows_FocusFollowsZOrder()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -894,7 +894,7 @@ public class WindowFocusIntegrationTests
                 .ApplyAsync(terminal, TestContext.Current.CancellationToken);
         }
 
-        Assert.True(windowOpen[0] && windowOpen[1] && windowOpen[2]);
+        Assert.IsTrue(windowOpen[0] && windowOpen[1] && windowOpen[2]);
 
         // Close Win3 → focus should go to Win2
         // Wait for visual state change (Win3 title gone) to ensure render loop has
@@ -907,7 +907,7 @@ public class WindowFocusIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.Equal("2", texts[1]);
+        Assert.AreEqual("2", texts[1]);
 
         // Close Win2 → focus should go to Win1
         await new Hex1bTerminalInputSequenceBuilder()
@@ -921,14 +921,14 @@ public class WindowFocusIntegrationTests
 
         await runTask;
 
-        Assert.Equal("1", texts[0]);
+        Assert.AreEqual("1", texts[0]);
     }
 
     /// <summary>
     /// When the last window is closed, focus should return to the background
     /// (e.g., MenuBar or first focusable in the main content).
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ClosingLastWindow_FocusReturnsToBackground()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -975,7 +975,7 @@ public class WindowFocusIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(windowOpen);
+        Assert.IsTrue(windowOpen);
 
         // Close with Escape — last window, app should not hang
         await new Hex1bTerminalInputSequenceBuilder()
@@ -987,13 +987,13 @@ public class WindowFocusIntegrationTests
 
         await runTask;
 
-        Assert.False(windowOpen);
+        Assert.IsFalse(windowOpen);
     }
 
     /// <summary>
     /// Closing a modal window returns focus to the non-modal window underneath.
     /// </summary>
-    [Fact]
+    [TestMethod]
     public async Task ClosingModalWindow_FocusReturnsToNonModal()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
@@ -1058,7 +1058,7 @@ public class WindowFocusIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(baseWindowOpen);
+        Assert.IsTrue(baseWindowOpen);
 
         // Type to prove base window has focus
         await new Hex1bTerminalInputSequenceBuilder()
@@ -1077,7 +1077,7 @@ public class WindowFocusIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.True(modalOpen);
+        Assert.IsTrue(modalOpen);
 
         // Close modal with Escape
         // Wait for "Confirm" title to disappear (proves render completed with focus restored)
@@ -1087,8 +1087,8 @@ public class WindowFocusIntegrationTests
             .Build()
             .ApplyAsync(terminal, TestContext.Current.CancellationToken);
 
-        Assert.False(modalOpen);
-        Assert.True(baseWindowOpen);
+        Assert.IsFalse(modalOpen);
+        Assert.IsTrue(baseWindowOpen);
 
         // Type into base window — should work if focus was restored
         await new Hex1bTerminalInputSequenceBuilder()
@@ -1100,6 +1100,6 @@ public class WindowFocusIntegrationTests
 
         await runTask;
 
-        Assert.Equal("ABCD", baseText);
+        Assert.AreEqual("ABCD", baseText);
     }
 }

--- a/tests/Hex1b.Tests/WindowManagerTests.cs
+++ b/tests/Hex1b.Tests/WindowManagerTests.cs
@@ -6,9 +6,10 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for WindowManager functionality using the fluent WindowHandle API.
 /// </summary>
+[TestClass]
 public class WindowManagerTests
 {
-    [Fact]
+    [TestMethod]
     public void Open_AddsWindowToManager()
     {
         var manager = new WindowManager();
@@ -19,14 +20,14 @@ public class WindowManagerTests
         
         var entry = manager.Open(handle);
 
-        Assert.NotNull(entry);
-        Assert.Equal("Test Window", entry.Title);
-        Assert.Equal(40, entry.Width);
-        Assert.Equal(15, entry.Height);
-        Assert.Equal(1, manager.Count);
+        Assert.IsNotNull(entry);
+        Assert.AreEqual("Test Window", entry.Title);
+        Assert.AreEqual(40, entry.Width);
+        Assert.AreEqual(15, entry.Height);
+        Assert.AreEqual(1, manager.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Open_WithSameHandle_ReturnsSameEntry()
     {
         var manager = new WindowManager();
@@ -37,11 +38,11 @@ public class WindowManagerTests
         var entry1 = manager.Open(handle);
         var entry2 = manager.Open(handle);
 
-        Assert.Same(entry1, entry2);
-        Assert.Equal(1, manager.Count);
+        Assert.AreSame(entry1, entry2);
+        Assert.AreEqual(1, manager.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Close_RemovesWindow()
     {
         var manager = new WindowManager();
@@ -52,12 +53,12 @@ public class WindowManagerTests
 
         var result = manager.Close(entry);
 
-        Assert.True(result);
-        Assert.Equal(0, manager.Count);
-        Assert.False(manager.IsOpen(handle));
+        Assert.IsTrue(result);
+        Assert.AreEqual(0, manager.Count);
+        Assert.IsFalse(manager.IsOpen(handle));
     }
 
-    [Fact]
+    [TestMethod]
     public void Close_ByHandle_RemovesWindow()
     {
         var manager = new WindowManager();
@@ -68,11 +69,11 @@ public class WindowManagerTests
 
         var result = manager.Close(handle);
 
-        Assert.True(result);
-        Assert.Equal(0, manager.Count);
+        Assert.IsTrue(result);
+        Assert.AreEqual(0, manager.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Close_InvokesOnCloseCallback()
     {
         var manager = new WindowManager();
@@ -85,10 +86,10 @@ public class WindowManagerTests
         manager.Open(handle);
         manager.Close(handle);
 
-        Assert.True(callbackInvoked);
+        Assert.IsTrue(callbackInvoked);
     }
 
-    [Fact]
+    [TestMethod]
     public void CloseAll_RemovesAllWindows()
     {
         var manager = new WindowManager();
@@ -102,10 +103,10 @@ public class WindowManagerTests
 
         manager.CloseAll();
 
-        Assert.Equal(0, manager.Count);
+        Assert.AreEqual(0, manager.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void CloseAll_InvokesAllCallbacks()
     {
         var manager = new WindowManager();
@@ -122,10 +123,10 @@ public class WindowManagerTests
         manager.Open(h2);
         manager.CloseAll();
 
-        Assert.Equal(2, callbackCount);
+        Assert.AreEqual(2, callbackCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void BringToFront_UpdatesZOrder()
     {
         var manager = new WindowManager();
@@ -136,16 +137,16 @@ public class WindowManagerTests
         var entry2 = manager.Open(h2);
 
         // Initially entry2 should have higher z-index
-        Assert.True(entry2.ZIndex > entry1.ZIndex);
+        Assert.IsTrue(entry2.ZIndex > entry1.ZIndex);
 
         // Bring entry1 to front
         manager.BringToFront(entry1);
 
         // Now entry1 should have higher z-index
-        Assert.True(entry1.ZIndex > entry2.ZIndex);
+        Assert.IsTrue(entry1.ZIndex > entry2.ZIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void ActiveWindow_ReturnsTopmostWindow()
     {
         var manager = new WindowManager();
@@ -155,14 +156,14 @@ public class WindowManagerTests
         var entry1 = manager.Open(h1);
         var entry2 = manager.Open(h2);
 
-        Assert.Same(entry2, manager.ActiveWindow);
+        Assert.AreSame(entry2, manager.ActiveWindow);
 
         manager.BringToFront(entry1);
 
-        Assert.Same(entry1, manager.ActiveWindow);
+        Assert.AreSame(entry1, manager.ActiveWindow);
     }
 
-    [Fact]
+    [TestMethod]
     public void ActiveWindow_PrefersModalWindow()
     {
         var manager = new WindowManager();
@@ -173,29 +174,29 @@ public class WindowManagerTests
         var modalWindow = manager.Open(modalHandle);
 
         // Modal should be active even though it was opened second
-        Assert.Same(modalWindow, manager.ActiveWindow);
+        Assert.AreSame(modalWindow, manager.ActiveWindow);
 
         // Even after bringing normal to front, modal should still be active
         manager.BringToFront(normalWindow);
-        Assert.Same(modalWindow, manager.ActiveWindow);
+        Assert.AreSame(modalWindow, manager.ActiveWindow);
     }
 
-    [Fact]
+    [TestMethod]
     public void HasModalWindow_ReturnsTrueWhenModalExists()
     {
         var manager = new WindowManager();
-        Assert.False(manager.HasModalWindow);
+        Assert.IsFalse(manager.HasModalWindow);
 
         var normalHandle = manager.Window(_ => new TextBlockWidget("Normal")).Title("Normal");
         manager.Open(normalHandle);
-        Assert.False(manager.HasModalWindow);
+        Assert.IsFalse(manager.HasModalWindow);
 
         var modalHandle = manager.Window(_ => new TextBlockWidget("Modal")).Title("Modal").Modal();
         manager.Open(modalHandle);
-        Assert.True(manager.HasModalWindow);
+        Assert.IsTrue(manager.HasModalWindow);
     }
 
-    [Fact]
+    [TestMethod]
     public void Get_ReturnsEntryByHandle()
     {
         var manager = new WindowManager();
@@ -204,10 +205,10 @@ public class WindowManagerTests
 
         var found = manager.Get(handle);
 
-        Assert.Same(entry, found);
+        Assert.AreSame(entry, found);
     }
 
-    [Fact]
+    [TestMethod]
     public void Get_ReturnsNullForUnknownHandle()
     {
         var manager = new WindowManager();
@@ -215,10 +216,10 @@ public class WindowManagerTests
 
         var found = manager.Get(handle);
 
-        Assert.Null(found);
+        Assert.IsNull(found);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsOpen_ReturnsTrueForOpenWindow()
     {
         var manager = new WindowManager();
@@ -227,11 +228,11 @@ public class WindowManagerTests
         
         manager.Open(handle);
 
-        Assert.True(manager.IsOpen(handle));
-        Assert.False(manager.IsOpen(otherHandle));
+        Assert.IsTrue(manager.IsOpen(handle));
+        Assert.IsFalse(manager.IsOpen(otherHandle));
     }
 
-    [Fact]
+    [TestMethod]
     public void All_ReturnsWindowsInZOrder()
     {
         var manager = new WindowManager();
@@ -245,14 +246,14 @@ public class WindowManagerTests
 
         var all = manager.All;
 
-        Assert.Equal(3, all.Count);
+        Assert.AreEqual(3, all.Count);
         // Should be in z-order (entry1 first, entry3 last)
-        Assert.Same(entry1, all[0]);
-        Assert.Same(entry2, all[1]);
-        Assert.Same(entry3, all[2]);
+        Assert.AreSame(entry1, all[0]);
+        Assert.AreSame(entry2, all[1]);
+        Assert.AreSame(entry3, all[2]);
     }
 
-    [Fact]
+    [TestMethod]
     public void Changed_EventRaisedOnOpen()
     {
         var manager = new WindowManager();
@@ -262,10 +263,10 @@ public class WindowManagerTests
         var handle = manager.Window(_ => new TextBlockWidget("Hello")).Title("Test");
         manager.Open(handle);
 
-        Assert.True(eventRaised);
+        Assert.IsTrue(eventRaised);
     }
 
-    [Fact]
+    [TestMethod]
     public void Changed_EventRaisedOnClose()
     {
         var manager = new WindowManager();
@@ -277,10 +278,10 @@ public class WindowManagerTests
 
         manager.Close(entry);
 
-        Assert.True(eventRaised);
+        Assert.IsTrue(eventRaised);
     }
 
-    [Fact]
+    [TestMethod]
     public void Changed_EventRaisedOnBringToFront()
     {
         var manager = new WindowManager();
@@ -292,10 +293,10 @@ public class WindowManagerTests
 
         manager.BringToFront(entry);
 
-        Assert.True(eventRaised);
+        Assert.IsTrue(eventRaised);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowEntry_CloseMethod_ClosesWindow()
     {
         var manager = new WindowManager();
@@ -304,10 +305,10 @@ public class WindowManagerTests
 
         entry.Close();
 
-        Assert.Equal(0, manager.Count);
+        Assert.AreEqual(0, manager.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowEntry_BringToFrontMethod_UpdatesZOrder()
     {
         var manager = new WindowManager();
@@ -319,10 +320,10 @@ public class WindowManagerTests
 
         entry1.BringToFront();
 
-        Assert.True(entry1.ZIndex > entry2.ZIndex);
+        Assert.IsTrue(entry1.ZIndex > entry2.ZIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void BringToFront_InvokesOnActivatedCallback()
     {
         var manager = new WindowManager();
@@ -341,10 +342,10 @@ public class WindowManagerTests
         activated = false;
         entry2.BringToFront();
 
-        Assert.True(activated);
+        Assert.IsTrue(activated);
     }
 
-    [Fact]
+    [TestMethod]
     public void BringToFront_InvokesOnDeactivatedCallback()
     {
         var manager = new WindowManager();
@@ -367,10 +368,10 @@ public class WindowManagerTests
         deactivated = false;
         entry2.BringToFront();
 
-        Assert.True(deactivated);
+        Assert.IsTrue(deactivated);
     }
 
-    [Fact]
+    [TestMethod]
     public void BringToFront_DoesNotInvokeCallbacks_WhenAlreadyActive()
     {
         var manager = new WindowManager();
@@ -386,12 +387,12 @@ public class WindowManagerTests
         entry.BringToFront();
         entry.BringToFront();
 
-        Assert.Equal(0, activatedCount);
+        Assert.AreEqual(0, activatedCount);
     }
 
     #region Title Bar and Actions Tests
 
-    [Fact]
+    [TestMethod]
     public void NoTitleBar_SetsShowTitleBarFalse()
     {
         var manager = new WindowManager();
@@ -401,10 +402,10 @@ public class WindowManagerTests
         
         var entry = manager.Open(handle);
 
-        Assert.False(entry.ShowTitleBar);
+        Assert.IsFalse(entry.ShowTitleBar);
     }
 
-    [Fact]
+    [TestMethod]
     public void DefaultRightTitleActions_HasCloseButton()
     {
         var manager = new WindowManager();
@@ -414,11 +415,11 @@ public class WindowManagerTests
         
         var entry = manager.Open(handle);
 
-        Assert.Single(entry.RightTitleBarActions);
-        Assert.Equal("×", entry.RightTitleBarActions[0].Icon);
+        TestSeq.Single(entry.RightTitleBarActions);
+        Assert.AreEqual("×", entry.RightTitleBarActions[0].Icon);
     }
 
-    [Fact]
+    [TestMethod]
     public void RightTitleActions_SetsCustomActions()
     {
         var manager = new WindowManager();
@@ -432,12 +433,12 @@ public class WindowManagerTests
         
         var entry = manager.Open(handle);
 
-        Assert.Equal(2, entry.RightTitleBarActions.Count);
-        Assert.Equal("?", entry.RightTitleBarActions[0].Icon);
-        Assert.Equal("×", entry.RightTitleBarActions[1].Icon);
+        Assert.AreEqual(2, entry.RightTitleBarActions.Count);
+        Assert.AreEqual("?", entry.RightTitleBarActions[0].Icon);
+        Assert.AreEqual("×", entry.RightTitleBarActions[1].Icon);
     }
 
-    [Fact]
+    [TestMethod]
     public void EscapeBehavior_SetsCorrectly()
     {
         var manager = new WindowManager();
@@ -448,27 +449,27 @@ public class WindowManagerTests
         
         var entry = manager.Open(handle);
 
-        Assert.Equal(WindowEscapeBehavior.Ignore, entry.EscapeBehavior);
+        Assert.AreEqual(WindowEscapeBehavior.Ignore, entry.EscapeBehavior);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowAction_Close_CreatesCloseAction()
     {
         var closeAction = WindowAction.Close();
 
-        Assert.Equal("×", closeAction.Icon);
-        Assert.Equal("Close", closeAction.Tooltip);
+        Assert.AreEqual("×", closeAction.Icon);
+        Assert.AreEqual("Close", closeAction.Tooltip);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowAction_Close_WithCustomIcon_CreatesAction()
     {
         var closeAction = WindowAction.Close("X");
 
-        Assert.Equal("X", closeAction.Icon);
+        Assert.AreEqual("X", closeAction.Icon);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowActionContext_Close_ClosesWindow()
     {
         var manager = new WindowManager();
@@ -479,14 +480,14 @@ public class WindowManagerTests
 
         context.Close();
 
-        Assert.False(manager.IsOpen(handle));
+        Assert.IsFalse(manager.IsOpen(handle));
     }
 
     #endregion
 
     #region Drag/Position Update Tests
 
-    [Fact]
+    [TestMethod]
     public void UpdatePosition_ChangesEntryPosition()
     {
         var manager = new WindowManager();
@@ -498,11 +499,11 @@ public class WindowManagerTests
 
         manager.UpdatePosition(entry, 20, 15);
 
-        Assert.Equal(20, entry.X);
-        Assert.Equal(15, entry.Y);
+        Assert.AreEqual(20, entry.X);
+        Assert.AreEqual(15, entry.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void UpdatePosition_RaisesChangedEvent()
     {
         var manager = new WindowManager();
@@ -515,10 +516,10 @@ public class WindowManagerTests
 
         manager.UpdatePosition(entry, 50, 25);
 
-        Assert.Equal(1, changedCount);
+        Assert.AreEqual(1, changedCount);
     }
 
-    [Fact]
+    [TestMethod]
     public void UpdatePosition_AllowsNegativeValues()
     {
         // Negative values might be valid during drag before clamping
@@ -528,15 +529,15 @@ public class WindowManagerTests
 
         manager.UpdatePosition(entry, -5, -3);
 
-        Assert.Equal(-5, entry.X);
-        Assert.Equal(-3, entry.Y);
+        Assert.AreEqual(-5, entry.X);
+        Assert.AreEqual(-3, entry.Y);
     }
 
     #endregion
 
     #region Modal Result Tests
 
-    [Fact]
+    [TestMethod]
     public void OnResult_InvokesCallbackWithValue()
     {
         var manager = new WindowManager();
@@ -554,11 +555,11 @@ public class WindowManagerTests
         manager.Open(handle);
         handle.CloseWithResult("test result");
 
-        Assert.Equal("test result", receivedValue);
-        Assert.False(wasCancelled);
+        Assert.AreEqual("test result", receivedValue);
+        Assert.IsFalse(wasCancelled);
     }
 
-    [Fact]
+    [TestMethod]
     public void OnResult_InvokesCallbackWithCancelledWhenClosedWithoutResult()
     {
         var manager = new WindowManager();
@@ -574,10 +575,10 @@ public class WindowManagerTests
         var entry = manager.Open(handle);
         entry.Close(); // Close without result
 
-        Assert.True(wasCancelled);
+        Assert.IsTrue(wasCancelled);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowHandle_Cancel_SignalsCancellation()
     {
         var manager = new WindowManager();
@@ -595,12 +596,12 @@ public class WindowManagerTests
         manager.Open(handle);
         handle.Cancel(); // Explicit cancellation
 
-        Assert.True(wasCancelled);
-        Assert.Null(receivedValue);
-        Assert.Equal(0, manager.Count);
+        Assert.IsTrue(wasCancelled);
+        Assert.IsNull(receivedValue);
+        Assert.AreEqual(0, manager.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void CloseWithResult_AlsoClosesWindow()
     {
         var manager = new WindowManager();
@@ -613,25 +614,25 @@ public class WindowManagerTests
 
         entry.CloseWithResult("done");
 
-        Assert.Null(manager.Get(handle));
-        Assert.Equal(0, manager.Count);
+        Assert.IsNull(manager.Get(handle));
+        Assert.AreEqual(0, manager.Count);
     }
 
     #endregion
 
     #region Fluent WindowHandle API Tests
 
-    [Fact]
+    [TestMethod]
     public void Window_CreatesWindowHandle()
     {
         var manager = new WindowManager();
 
         var handle = manager.Window(w => new TextBlockWidget("Hello"));
 
-        Assert.NotNull(handle);
+        Assert.IsNotNull(handle);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowHandle_Title_SetsTitle()
     {
         var manager = new WindowManager();
@@ -641,10 +642,10 @@ public class WindowManagerTests
 
         var entry = manager.Open(handle);
 
-        Assert.Equal("My Window", entry.Title);
+        Assert.AreEqual("My Window", entry.Title);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowHandle_Size_SetsDimensions()
     {
         var manager = new WindowManager();
@@ -655,11 +656,11 @@ public class WindowManagerTests
 
         var entry = manager.Open(handle);
 
-        Assert.Equal(60, entry.Width);
-        Assert.Equal(30, entry.Height);
+        Assert.AreEqual(60, entry.Width);
+        Assert.AreEqual(30, entry.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowHandle_Position_SetsCoordinates()
     {
         var manager = new WindowManager();
@@ -670,11 +671,11 @@ public class WindowManagerTests
 
         var entry = manager.Open(handle);
 
-        Assert.Equal(10, entry.X);
-        Assert.Equal(20, entry.Y);
+        Assert.AreEqual(10, entry.X);
+        Assert.AreEqual(20, entry.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowHandle_Modal_SetsIsModal()
     {
         var manager = new WindowManager();
@@ -685,11 +686,11 @@ public class WindowManagerTests
 
         var entry = manager.Open(handle);
 
-        Assert.True(entry.IsModal);
-        Assert.True(manager.HasModalWindow);
+        Assert.IsTrue(entry.IsModal);
+        Assert.IsTrue(manager.HasModalWindow);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowHandle_Resizable_SetsResizableWithConstraints()
     {
         var manager = new WindowManager();
@@ -700,14 +701,14 @@ public class WindowManagerTests
 
         var entry = manager.Open(handle);
 
-        Assert.True(entry.IsResizable);
-        Assert.Equal(20, entry.MinWidth);
-        Assert.Equal(10, entry.MinHeight);
-        Assert.Equal(100, entry.MaxWidth);
-        Assert.Equal(50, entry.MaxHeight);
+        Assert.IsTrue(entry.IsResizable);
+        Assert.AreEqual(20, entry.MinWidth);
+        Assert.AreEqual(10, entry.MinHeight);
+        Assert.AreEqual(100, entry.MaxWidth);
+        Assert.AreEqual(50, entry.MaxHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowHandle_NoTitleBar_HidesTitleBar()
     {
         var manager = new WindowManager();
@@ -717,10 +718,10 @@ public class WindowManagerTests
 
         var entry = manager.Open(handle);
 
-        Assert.False(entry.ShowTitleBar);
+        Assert.IsFalse(entry.ShowTitleBar);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowHandle_OnClose_SetsCallback()
     {
         var manager = new WindowManager();
@@ -733,10 +734,10 @@ public class WindowManagerTests
         var entry = manager.Open(handle);
         manager.Close(handle);
 
-        Assert.True(callbackInvoked);
+        Assert.IsTrue(callbackInvoked);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowHandle_LeftTitleActions_SetsActions()
     {
         var manager = new WindowManager();
@@ -750,12 +751,12 @@ public class WindowManagerTests
 
         var entry = manager.Open(handle);
 
-        Assert.Equal(2, entry.LeftTitleBarActions.Count);
-        Assert.Equal("📌", entry.LeftTitleBarActions[0].Icon);
-        Assert.Equal("📋", entry.LeftTitleBarActions[1].Icon);
+        Assert.AreEqual(2, entry.LeftTitleBarActions.Count);
+        Assert.AreEqual("📌", entry.LeftTitleBarActions[0].Icon);
+        Assert.AreEqual("📋", entry.LeftTitleBarActions[1].Icon);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowHandle_RightTitleActions_SetsActions()
     {
         var manager = new WindowManager();
@@ -769,12 +770,12 @@ public class WindowManagerTests
 
         var entry = manager.Open(handle);
 
-        Assert.Equal(2, entry.RightTitleBarActions.Count);
-        Assert.Equal("?", entry.RightTitleBarActions[0].Icon);
-        Assert.Equal("×", entry.RightTitleBarActions[1].Icon);
+        Assert.AreEqual(2, entry.RightTitleBarActions.Count);
+        Assert.AreEqual("?", entry.RightTitleBarActions[0].Icon);
+        Assert.AreEqual("×", entry.RightTitleBarActions[1].Icon);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowHandle_DefaultRightTitleActions_HasCloseButton()
     {
         var manager = new WindowManager();
@@ -784,11 +785,11 @@ public class WindowManagerTests
 
         var entry = manager.Open(handle);
 
-        Assert.Single(entry.RightTitleBarActions);
-        Assert.Equal("×", entry.RightTitleBarActions[0].Icon);
+        TestSeq.Single(entry.RightTitleBarActions);
+        Assert.AreEqual("×", entry.RightTitleBarActions[0].Icon);
     }
 
-    [Fact]
+    [TestMethod]
     public void Open_WindowHandle_BringsToFrontIfAlreadyOpen()
     {
         var manager = new WindowManager();
@@ -799,11 +800,11 @@ public class WindowManagerTests
         var entry1 = manager.Open(handle);
         var entry2 = manager.Open(handle);
 
-        Assert.Same(entry1, entry2);
-        Assert.Equal(1, manager.Count);
+        Assert.AreSame(entry1, entry2);
+        Assert.AreEqual(1, manager.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Close_WindowHandle_RemovesWindow()
     {
         var manager = new WindowManager();
@@ -814,12 +815,12 @@ public class WindowManagerTests
         manager.Open(handle);
         var result = manager.Close(handle);
 
-        Assert.True(result);
-        Assert.Equal(0, manager.Count);
-        Assert.False(manager.IsOpen(handle));
+        Assert.IsTrue(result);
+        Assert.AreEqual(0, manager.Count);
+        Assert.IsFalse(manager.IsOpen(handle));
     }
 
-    [Fact]
+    [TestMethod]
     public void IsOpen_WindowHandle_ReturnsCorrectState()
     {
         var manager = new WindowManager();
@@ -827,16 +828,16 @@ public class WindowManagerTests
         var handle = manager.Window(w => new TextBlockWidget("Hello"))
             .Title("Test");
 
-        Assert.False(manager.IsOpen(handle));
+        Assert.IsFalse(manager.IsOpen(handle));
 
         manager.Open(handle);
-        Assert.True(manager.IsOpen(handle));
+        Assert.IsTrue(manager.IsOpen(handle));
 
         manager.Close(handle);
-        Assert.False(manager.IsOpen(handle));
+        Assert.IsFalse(manager.IsOpen(handle));
     }
 
-    [Fact]
+    [TestMethod]
     public void Get_WindowHandle_ReturnsEntry()
     {
         var manager = new WindowManager();
@@ -844,15 +845,15 @@ public class WindowManagerTests
         var handle = manager.Window(w => new TextBlockWidget("Hello"))
             .Title("Test");
 
-        Assert.Null(manager.Get(handle));
+        Assert.IsNull(manager.Get(handle));
 
         var opened = manager.Open(handle);
         var got = manager.Get(handle);
 
-        Assert.Same(opened, got);
+        Assert.AreSame(opened, got);
     }
 
-    [Fact]
+    [TestMethod]
     public void BringToFront_WindowHandle_BringsToFront()
     {
         var manager = new WindowManager();
@@ -864,15 +865,15 @@ public class WindowManagerTests
         var entry2 = manager.Open(handle2);
 
         // entry2 is now active (last opened)
-        Assert.Same(entry2, manager.ActiveWindow);
+        Assert.AreSame(entry2, manager.ActiveWindow);
 
         // Bring entry1 to front
         manager.BringToFront(handle1);
 
-        Assert.Same(entry1, manager.ActiveWindow);
+        Assert.AreSame(entry1, manager.ActiveWindow);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowContentContext_ProvidesWindowProperty()
     {
         var manager = new WindowManager();
@@ -890,10 +891,10 @@ public class WindowManagerTests
         // Build content explicitly to trigger the content builder
         // This simulates what happens during reconciliation
         var windowContext = new WindowContentContext<Hex1bWidget>(handle);
-        Assert.Same(handle, windowContext.Window);
+        Assert.AreSame(handle, windowContext.Window);
     }
 
-    [Fact]
+    [TestMethod]
     public void CloseAll_ClearsHandleMappings()
     {
         var manager = new WindowManager();
@@ -906,9 +907,9 @@ public class WindowManagerTests
 
         manager.CloseAll();
 
-        Assert.False(manager.IsOpen(handle1));
-        Assert.False(manager.IsOpen(handle2));
-        Assert.Equal(0, manager.Count);
+        Assert.IsFalse(manager.IsOpen(handle1));
+        Assert.IsFalse(manager.IsOpen(handle2));
+        Assert.AreEqual(0, manager.Count);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/WindowNodeTests.cs
+++ b/tests/Hex1b.Tests/WindowNodeTests.cs
@@ -7,11 +7,12 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for WindowNode measurement, arrangement, and rendering.
 /// </summary>
+[TestClass]
 public class WindowNodeTests
 {
     #region Measurement Tests
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithEntry_ReturnsEntrySize()
     {
         var manager = new WindowManager();
@@ -24,11 +25,11 @@ public class WindowNodeTests
 
         var size = node.Measure(Constraints.Unbounded);
 
-        Assert.Equal(50, size.Width);
-        Assert.Equal(20, size.Height);
+        Assert.AreEqual(50, size.Width);
+        Assert.AreEqual(20, size.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithSmallEntry_EnforcesMinimumSize()
     {
         var manager = new WindowManager();
@@ -42,11 +43,11 @@ public class WindowNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // Minimum size is 10x5 for border + title bar
-        Assert.True(size.Width >= 10);
-        Assert.True(size.Height >= 5);
+        Assert.IsTrue(size.Width >= 10);
+        Assert.IsTrue(size.Height >= 5);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_RespectsConstraints()
     {
         var manager = new WindowManager();
@@ -59,15 +60,15 @@ public class WindowNodeTests
 
         var size = node.Measure(new Constraints(0, 60, 0, 30));
 
-        Assert.True(size.Width <= 60);
-        Assert.True(size.Height <= 30);
+        Assert.IsTrue(size.Width <= 60);
+        Assert.IsTrue(size.Height <= 30);
     }
 
     #endregion
 
     #region Arrangement Tests
 
-    [Fact]
+    [TestMethod]
     public void Arrange_SetsNodeBounds()
     {
         var manager = new WindowManager();
@@ -81,13 +82,13 @@ public class WindowNodeTests
 
         node.Arrange(new Rect(10, 5, 40, 15));
 
-        Assert.Equal(10, node.Bounds.X);
-        Assert.Equal(5, node.Bounds.Y);
-        Assert.Equal(40, node.Bounds.Width);
-        Assert.Equal(15, node.Bounds.Height);
+        Assert.AreEqual(10, node.Bounds.X);
+        Assert.AreEqual(5, node.Bounds.Y);
+        Assert.AreEqual(40, node.Bounds.Width);
+        Assert.AreEqual(15, node.Bounds.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_PositionsContentInInnerArea()
     {
         var content = new TextBlockNode { Text = "Content" };
@@ -104,15 +105,15 @@ public class WindowNodeTests
         // Content should be inside the window (accounting for border and title bar)
         // X: 10 + 1 = 11 (inside left border)
         // Y: 5 + 2 = 7 (below top border and title bar)
-        Assert.Equal(11, content.Bounds.X);
-        Assert.Equal(7, content.Bounds.Y);
+        Assert.AreEqual(11, content.Bounds.X);
+        Assert.AreEqual(7, content.Bounds.Y);
     }
 
     #endregion
 
     #region Focus Tests
 
-    [Fact]
+    [TestMethod]
     public void GetFocusableNodes_ReturnsWindowNodeAndContentFocusables()
     {
         var button = new ButtonNode { Label = "Click Me" };
@@ -127,12 +128,12 @@ public class WindowNodeTests
         var focusables = node.GetFocusableNodes().ToList();
 
         // WindowNode itself is focusable (first) plus the button (second)
-        Assert.Equal(2, focusables.Count);
-        Assert.Same(node, focusables[0]);
-        Assert.Same(button, focusables[1]);
+        Assert.AreEqual(2, focusables.Count);
+        Assert.AreSame(node, focusables[0]);
+        Assert.AreSame(button, focusables[1]);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetFocusableNodes_WithNoContent_ReturnsWindowNodeOnly()
     {
         var manager = new WindowManager();
@@ -145,15 +146,15 @@ public class WindowNodeTests
         var focusables = node.GetFocusableNodes().ToList();
 
         // WindowNode itself is focusable
-        Assert.Single(focusables);
-        Assert.Same(node, focusables[0]);
+        TestSeq.Single(focusables);
+        Assert.AreSame(node, focusables[0]);
     }
 
     #endregion
 
     #region ClipRect Tests
 
-    [Fact]
+    [TestMethod]
     public void ClipRect_ReturnsInnerContentArea()
     {
         var manager = new WindowManager();
@@ -173,17 +174,17 @@ public class WindowNodeTests
         // Y: 5 + 2 = 7 (accounting for border and title bar)
         // Width: 40 - 2 = 38
         // Height: 15 - 3 = 12 (accounting for borders and title bar)
-        Assert.Equal(11, clipRect.X);
-        Assert.Equal(7, clipRect.Y);
-        Assert.Equal(38, clipRect.Width);
-        Assert.Equal(12, clipRect.Height);
+        Assert.AreEqual(11, clipRect.X);
+        Assert.AreEqual(7, clipRect.Y);
+        Assert.AreEqual(38, clipRect.Width);
+        Assert.AreEqual(12, clipRect.Height);
     }
 
     #endregion
 
     #region GetChildren Tests
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_ReturnsContent()
     {
         var content = new TextBlockNode { Text = "Hello" };
@@ -196,11 +197,11 @@ public class WindowNodeTests
 
         var children = node.GetChildren().ToList();
 
-        Assert.Single(children);
-        Assert.Same(content, children[0]);
+        TestSeq.Single(children);
+        Assert.AreSame(content, children[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_WithNoContent_ReturnsEmpty()
     {
         var manager = new WindowManager();
@@ -212,42 +213,42 @@ public class WindowNodeTests
 
         var children = node.GetChildren().ToList();
 
-        Assert.Empty(children);
+        Assert.IsEmpty(children);
     }
 
     #endregion
 
     #region Property Tests
 
-    [Fact]
+    [TestMethod]
     public void IsActive_DefaultsFalse()
     {
         var node = new WindowNode();
 
-        Assert.False(node.IsActive);
+        Assert.IsFalse(node.IsActive);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsModal_DefaultsFalse()
     {
         var node = new WindowNode();
 
-        Assert.False(node.IsModal);
+        Assert.IsFalse(node.IsModal);
     }
 
-    [Fact]
+    [TestMethod]
     public void IsResizable_DefaultsFalse()
     {
         var node = new WindowNode();
 
-        Assert.False(node.IsResizable);
+        Assert.IsFalse(node.IsResizable);
     }
 
     #endregion
 
     #region SyncFocusIndex Tests
 
-    [Fact]
+    [TestMethod]
     public void SyncFocusIndex_BringsWindowToFront_WhenChildIsFocused()
     {
         var manager = new WindowManager();
@@ -272,17 +273,17 @@ public class WindowNodeTests
         node2.Content = content2;
 
         // Initially, window 2 should have higher z-index
-        Assert.True(entry2.ZIndex > entry1.ZIndex);
+        Assert.IsTrue(entry2.ZIndex > entry1.ZIndex);
 
         // Simulate focusing a child of window 1 - this triggers SyncFocusIndex
         button1.IsFocused = true;
         node1.SyncFocusIndex();
 
         // Now window 1 should have higher z-index
-        Assert.True(entry1.ZIndex > entry2.ZIndex);
+        Assert.IsTrue(entry1.ZIndex > entry2.ZIndex);
     }
 
-    [Fact]
+    [TestMethod]
     public void SyncFocusIndex_DoesNothing_WhenNoChildIsFocused()
     {
         var manager = new WindowManager();
@@ -303,48 +304,48 @@ public class WindowNodeTests
         // SyncFocusIndex with no focused child should not change z-order
         node.SyncFocusIndex();
 
-        Assert.Equal(initialZ1, entry1.ZIndex);
-        Assert.Equal(initialZ2, entry2.ZIndex);
+        Assert.AreEqual(initialZ1, entry1.ZIndex);
+        Assert.AreEqual(initialZ2, entry2.ZIndex);
     }
 
     #endregion
 
     #region Phase 3: Title Bar and Actions Tests
 
-    [Fact]
+    [TestMethod]
     public void ShowTitleBar_DefaultsToTrue()
     {
         var node = new WindowNode();
 
-        Assert.True(node.ShowTitleBar);
+        Assert.IsTrue(node.ShowTitleBar);
     }
 
-    [Fact]
+    [TestMethod]
     public void RightTitleBarActions_DefaultsToCloseAction()
     {
         var node = new WindowNode();
 
-        Assert.Single(node.RightTitleBarActions);
-        Assert.Equal("×", node.RightTitleBarActions[0].Icon);
+        TestSeq.Single(node.RightTitleBarActions);
+        Assert.AreEqual("×", node.RightTitleBarActions[0].Icon);
     }
 
-    [Fact]
+    [TestMethod]
     public void LeftTitleBarActions_DefaultsToEmpty()
     {
         var node = new WindowNode();
 
-        Assert.Empty(node.LeftTitleBarActions);
+        Assert.IsEmpty(node.LeftTitleBarActions);
     }
 
-    [Fact]
+    [TestMethod]
     public void EscapeBehavior_DefaultsToClose()
     {
         var node = new WindowNode();
 
-        Assert.Equal(WindowEscapeBehavior.Close, node.EscapeBehavior);
+        Assert.AreEqual(WindowEscapeBehavior.Close, node.EscapeBehavior);
     }
 
-    [Fact]
+    [TestMethod]
     public void Measure_WithNoTitleBar_HasSmallerMinimumHeight()
     {
         var manager = new WindowManager();
@@ -359,11 +360,11 @@ public class WindowNodeTests
         var size = node.Measure(Constraints.Unbounded);
 
         // Minimum height without title bar is 3 (top border, content, bottom border)
-        Assert.Equal(10, size.Width);
-        Assert.True(size.Height >= 3);
+        Assert.AreEqual(10, size.Width);
+        Assert.IsTrue(size.Height >= 3);
     }
 
-    [Fact]
+    [TestMethod]
     public void ClipRect_WithNoTitleBar_StartsAtY1()
     {
         var manager = new WindowManager();
@@ -380,12 +381,12 @@ public class WindowNodeTests
         var clipRect = node.ClipRect;
 
         // Without title bar: Y is bounds.Y + 1 (just border)
-        Assert.Equal(1, clipRect.Y);
-        Assert.Equal(38, clipRect.Width);
-        Assert.Equal(8, clipRect.Height); // 10 - 2 (borders only)
+        Assert.AreEqual(1, clipRect.Y);
+        Assert.AreEqual(38, clipRect.Width);
+        Assert.AreEqual(8, clipRect.Height); // 10 - 2 (borders only)
     }
 
-    [Fact]
+    [TestMethod]
     public void ClipRect_WithTitleBar_HasContentOffset()
     {
         var manager = new WindowManager();
@@ -401,17 +402,17 @@ public class WindowNodeTests
         var clipRect = node.ClipRect;
 
         // Title bar + border: Y is bounds.Y + 2
-        Assert.Equal(11, clipRect.X);
-        Assert.Equal(7, clipRect.Y);
-        Assert.Equal(38, clipRect.Width);
-        Assert.Equal(12, clipRect.Height);
+        Assert.AreEqual(11, clipRect.X);
+        Assert.AreEqual(7, clipRect.Y);
+        Assert.AreEqual(38, clipRect.Width);
+        Assert.AreEqual(12, clipRect.Height);
     }
 
     #endregion
 
     #region Phase 4: Drag Tests
 
-    [Fact]
+    [TestMethod]
     public void IsInTitleBar_ReturnsTrue_ForValidTitleBarPosition()
     {
         var manager = new WindowManager();
@@ -430,10 +431,10 @@ public class WindowNodeTests
         
         // The IsInTitleBar method is private, so we test via ConfigureDefaultBindings behavior
         // We can't directly test it, but we can verify the drag triggers only in title bar
-        Assert.True(true); // Placeholder - actual drag tests need integration testing
+        Assert.IsTrue(true); // Placeholder - actual drag tests need integration testing
     }
 
-    [Fact]
+    [TestMethod]
     public void NoTitleBar_DisablesTitleBarDrag()
     {
         var manager = new WindowManager();
@@ -449,14 +450,14 @@ public class WindowNodeTests
 
         // With no title bar, there's no area to drag
         // The window should still be focusable but not draggable
-        Assert.False(node.ShowTitleBar);
+        Assert.IsFalse(node.ShowTitleBar);
     }
 
     #endregion
 
     #region Phase 5: Resize Tests
 
-    [Fact]
+    [TestMethod]
     public void IsResizable_CanBeSetToTrue()
     {
         var manager = new WindowManager();
@@ -467,10 +468,10 @@ public class WindowNodeTests
         
         var node = new WindowNode { Entry = entry, IsResizable = true };
 
-        Assert.True(node.IsResizable);
+        Assert.IsTrue(node.IsResizable);
     }
 
-    [Fact]
+    [TestMethod]
     public void Entry_HasMinMaxConstraints()
     {
         var manager = new WindowManager();
@@ -479,13 +480,13 @@ public class WindowNodeTests
             .Resizable(minWidth: 20, minHeight: 10, maxWidth: 100, maxHeight: 50);
         var entry = manager.Open(handle);
 
-        Assert.Equal(20, entry.MinWidth);
-        Assert.Equal(10, entry.MinHeight);
-        Assert.Equal(100, entry.MaxWidth);
-        Assert.Equal(50, entry.MaxHeight);
+        Assert.AreEqual(20, entry.MinWidth);
+        Assert.AreEqual(10, entry.MinHeight);
+        Assert.AreEqual(100, entry.MaxWidth);
+        Assert.AreEqual(50, entry.MaxHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void Entry_MinConstraints_HaveDefaults()
     {
         var manager = new WindowManager();
@@ -494,14 +495,14 @@ public class WindowNodeTests
         var entry = manager.Open(handle);
 
         // Default min values
-        Assert.Equal(10, entry.MinWidth);
-        Assert.Equal(5, entry.MinHeight);
+        Assert.AreEqual(10, entry.MinWidth);
+        Assert.AreEqual(5, entry.MinHeight);
         // Max values default to null (unbounded)
-        Assert.Null(entry.MaxWidth);
-        Assert.Null(entry.MaxHeight);
+        Assert.IsNull(entry.MaxWidth);
+        Assert.IsNull(entry.MaxHeight);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowManager_UpdateSize_AppliesMinConstraints()
     {
         var manager = new WindowManager();
@@ -515,11 +516,11 @@ public class WindowNodeTests
         manager.UpdateSize(entry, 10, 5);
 
         // Should be constrained to minimum
-        Assert.Equal(20, entry.Width);
-        Assert.Equal(15, entry.Height);
+        Assert.AreEqual(20, entry.Width);
+        Assert.AreEqual(15, entry.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowManager_UpdateSize_AppliesMaxConstraints()
     {
         var manager = new WindowManager();
@@ -533,11 +534,11 @@ public class WindowNodeTests
         manager.UpdateSize(entry, 100, 80);
 
         // Should be constrained to maximum
-        Assert.Equal(60, entry.Width);
-        Assert.Equal(40, entry.Height);
+        Assert.AreEqual(60, entry.Width);
+        Assert.AreEqual(40, entry.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowManager_UpdateSize_AllowsSizeWithinConstraints()
     {
         var manager = new WindowManager();
@@ -550,11 +551,11 @@ public class WindowNodeTests
         // Resize within allowed range
         manager.UpdateSize(entry, 40, 25);
 
-        Assert.Equal(40, entry.Width);
-        Assert.Equal(25, entry.Height);
+        Assert.AreEqual(40, entry.Width);
+        Assert.AreEqual(25, entry.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowManager_UpdateSize_RaisesChangedEvent()
     {
         var manager = new WindowManager();
@@ -567,7 +568,7 @@ public class WindowNodeTests
 
         manager.UpdateSize(entry, 60, 40);
 
-        Assert.Equal(1, changedCount);
+        Assert.AreEqual(1, changedCount);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/WindowPanelNodeTests.cs
+++ b/tests/Hex1b.Tests/WindowPanelNodeTests.cs
@@ -7,33 +7,34 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for WindowPanelNode layout and window management.
 /// </summary>
+[TestClass]
 public class WindowPanelNodeTests
 {
     #region Basic Tests
 
-    [Fact]
+    [TestMethod]
     public void Constructor_InitializesWindowManager()
     {
         var node = new WindowPanelNode();
 
-        Assert.NotNull(node.Windows);
-        Assert.Equal(0, node.Windows.Count);
+        Assert.IsNotNull(node.Windows);
+        Assert.AreEqual(0, node.Windows.Count);
     }
 
-    [Fact]
+    [TestMethod]
     public void Constructor_InitializesEmptyWindowNodes()
     {
         var node = new WindowPanelNode();
 
-        Assert.NotNull(node.WindowNodes);
-        Assert.Empty(node.WindowNodes);
+        Assert.IsNotNull(node.WindowNodes);
+        Assert.IsEmpty(node.WindowNodes);
     }
 
     #endregion
 
     #region Measurement Tests
 
-    [Fact]
+    [TestMethod]
     public void Measure_FillsAvailableSpace()
     {
         var node = new WindowPanelNode();
@@ -41,15 +42,15 @@ public class WindowPanelNodeTests
         var size = node.Measure(new Constraints(0, 80, 0, 24));
 
         // WindowPanel fills available space
-        Assert.Equal(80, size.Width);
-        Assert.Equal(24, size.Height);
+        Assert.AreEqual(80, size.Width);
+        Assert.AreEqual(24, size.Height);
     }
 
     #endregion
 
     #region Arrangement Tests
 
-    [Fact]
+    [TestMethod]
     public void Arrange_SetsBoundsOnNode()
     {
         var node = new WindowPanelNode();
@@ -57,13 +58,13 @@ public class WindowPanelNodeTests
 
         node.Arrange(new Rect(0, 0, 80, 24));
 
-        Assert.Equal(0, node.Bounds.X);
-        Assert.Equal(0, node.Bounds.Y);
-        Assert.Equal(80, node.Bounds.Width);
-        Assert.Equal(24, node.Bounds.Height);
+        Assert.AreEqual(0, node.Bounds.X);
+        Assert.AreEqual(0, node.Bounds.Y);
+        Assert.AreEqual(80, node.Bounds.Width);
+        Assert.AreEqual(24, node.Bounds.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_CentersWindowsWithNoPosition()
     {
         var node = new WindowPanelNode();
@@ -80,11 +81,11 @@ public class WindowPanelNodeTests
         node.Arrange(new Rect(0, 0, 80, 24));
 
         // Window should be centered: (80-40)/2 = 20, (24-15)/2 = 4
-        Assert.Equal(20, windowNode.Bounds.X);
-        Assert.Equal(4, windowNode.Bounds.Y);
+        Assert.AreEqual(20, windowNode.Bounds.X);
+        Assert.AreEqual(4, windowNode.Bounds.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_UsesSpecifiedPosition()
     {
         var node = new WindowPanelNode();
@@ -100,11 +101,11 @@ public class WindowPanelNodeTests
 
         node.Arrange(new Rect(0, 0, 80, 24));
 
-        Assert.Equal(5, windowNode.Bounds.X);
-        Assert.Equal(3, windowNode.Bounds.Y);
+        Assert.AreEqual(5, windowNode.Bounds.X);
+        Assert.AreEqual(3, windowNode.Bounds.Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void Arrange_ClampsWindowToPanelBounds()
     {
         var node = new WindowPanelNode();
@@ -124,25 +125,25 @@ public class WindowPanelNodeTests
         // Should be clamped to fit within bounds
         // X should be max 80-30 = 50
         // Y should be max 24-10 = 14
-        Assert.True(windowNode.Bounds.X <= 50);
-        Assert.True(windowNode.Bounds.Y <= 14);
+        Assert.IsTrue(windowNode.Bounds.X <= 50);
+        Assert.IsTrue(windowNode.Bounds.Y <= 14);
     }
 
     #endregion
 
     #region Focus Tests
 
-    [Fact]
+    [TestMethod]
     public void GetFocusableNodes_WithNoWindows_ReturnsEmpty()
     {
         var node = new WindowPanelNode();
 
         var focusables = node.GetFocusableNodes().ToList();
 
-        Assert.Empty(focusables);
+        Assert.IsEmpty(focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetFocusableNodes_WithModalWindow_OnlyReturnsModalFocusables()
     {
         var node = new WindowPanelNode();
@@ -160,12 +161,12 @@ public class WindowPanelNodeTests
         var focusables = node.GetFocusableNodes().ToList();
 
         // Should contain modal window node and its button only
-        Assert.Equal(2, focusables.Count);
+        Assert.AreEqual(2, focusables.Count);
         Assert.Contains(windowNode, focusables);
         Assert.Contains(windowButton, focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetFocusableNodes_WithNonModalWindows_ReturnsWindowFocusables()
     {
         var node = new WindowPanelNode();
@@ -182,7 +183,7 @@ public class WindowPanelNodeTests
         var focusables = node.GetFocusableNodes().ToList();
 
         // Should contain window node itself and window button
-        Assert.Equal(2, focusables.Count);
+        Assert.AreEqual(2, focusables.Count);
         Assert.Contains(windowNode, focusables);
         Assert.Contains(windowButton, focusables);
     }
@@ -191,7 +192,7 @@ public class WindowPanelNodeTests
 
     #region GetChildren Tests
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_ReturnsWindows()
     {
         var node = new WindowPanelNode();
@@ -204,11 +205,11 @@ public class WindowPanelNodeTests
 
         var children = node.GetChildren().ToList();
 
-        Assert.Single(children);
-        Assert.Same(windowNode, children[0]);
+        TestSeq.Single(children);
+        Assert.AreSame(windowNode, children[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetChildren_WithNoContent_ReturnsOnlyWindows()
     {
         var node = new WindowPanelNode();
@@ -221,36 +222,36 @@ public class WindowPanelNodeTests
 
         var children = node.GetChildren().ToList();
 
-        Assert.Single(children);
-        Assert.Same(windowNode, children[0]);
+        TestSeq.Single(children);
+        Assert.AreSame(windowNode, children[0]);
     }
 
     #endregion
 
     #region IWindowHost Tests
 
-    [Fact]
+    [TestMethod]
     public void ImplementsIWindowHost()
     {
         var node = new WindowPanelNode();
 
-        Assert.IsAssignableFrom<IWindowHost>(node);
+        TestSeq.IsType<IWindowHost>(node);
     }
 
-    [Fact]
+    [TestMethod]
     public void Windows_IsSameAsWindowManager()
     {
         var node = new WindowPanelNode();
         var host = (IWindowHost)node;
 
-        Assert.Same(node.Windows, host.Windows);
+        Assert.AreSame(node.Windows, host.Windows);
     }
 
     #endregion
 
     #region Phase 6: Modal Dialog Tests
 
-    [Fact]
+    [TestMethod]
     public void GetFocusableNodes_WithNestedModals_ReturnsOnlyTopmostModalFocusables()
     {
         var node = new WindowPanelNode();
@@ -278,14 +279,14 @@ public class WindowPanelNodeTests
         var focusables = node.GetFocusableNodes().ToList();
 
         // Should contain only the topmost (last) modal's focusables
-        Assert.Equal(2, focusables.Count);
+        Assert.AreEqual(2, focusables.Count);
         Assert.Contains(modal2Node, focusables);
         Assert.Contains(modal2Button, focusables);
         Assert.DoesNotContain(modal1Node, focusables);
         Assert.DoesNotContain(modal1Button, focusables);
     }
 
-    [Fact]
+    [TestMethod]
     public void GetFocusableNodes_ClosingTopModal_ExposesModalBelow()
     {
         var node = new WindowPanelNode();
@@ -317,7 +318,7 @@ public class WindowPanelNodeTests
         var focusables = node.GetFocusableNodes().ToList();
 
         // Now modal 1 should be accessible
-        Assert.Equal(2, focusables.Count);
+        Assert.AreEqual(2, focusables.Count);
         Assert.Contains(modal1Node, focusables);
         Assert.Contains(modal1Button, focusables);
     }

--- a/tests/Hex1b.Tests/WindowPositionTests.cs
+++ b/tests/Hex1b.Tests/WindowPositionTests.cs
@@ -5,13 +5,14 @@ namespace Hex1b.Tests;
 /// <summary>
 /// Tests for WindowPositionSpec positioning calculations.
 /// </summary>
+[TestClass]
 public class WindowPositionTests
 {
     private readonly Rect _panelBounds = new(0, 0, 100, 50);
     private const int WindowWidth = 40;
     private const int WindowHeight = 20;
 
-    [Fact]
+    [TestMethod]
     public void Center_PositionsInMiddle()
     {
         var spec = WindowPositionSpec.Center;
@@ -19,172 +20,172 @@ public class WindowPositionTests
         var (x, y) = spec.Calculate(_panelBounds, WindowWidth, WindowHeight);
 
         // Center: (100-40)/2 = 30, (50-20)/2 = 15
-        Assert.Equal(30, x);
-        Assert.Equal(15, y);
+        Assert.AreEqual(30, x);
+        Assert.AreEqual(15, y);
     }
 
-    [Fact]
+    [TestMethod]
     public void TopLeft_PositionsAtOrigin()
     {
         var spec = WindowPositionSpec.TopLeft;
 
         var (x, y) = spec.Calculate(_panelBounds, WindowWidth, WindowHeight);
 
-        Assert.Equal(0, x);
-        Assert.Equal(0, y);
+        Assert.AreEqual(0, x);
+        Assert.AreEqual(0, y);
     }
 
-    [Fact]
+    [TestMethod]
     public void TopRight_PositionsAtTopRight()
     {
         var spec = WindowPositionSpec.TopRight;
 
         var (x, y) = spec.Calculate(_panelBounds, WindowWidth, WindowHeight);
 
-        Assert.Equal(60, x); // 100 - 40
-        Assert.Equal(0, y);
+        Assert.AreEqual(60, x); // 100 - 40
+        Assert.AreEqual(0, y);
     }
 
-    [Fact]
+    [TestMethod]
     public void BottomLeft_PositionsAtBottomLeft()
     {
         var spec = WindowPositionSpec.BottomLeft;
 
         var (x, y) = spec.Calculate(_panelBounds, WindowWidth, WindowHeight);
 
-        Assert.Equal(0, x);
-        Assert.Equal(30, y); // 50 - 20
+        Assert.AreEqual(0, x);
+        Assert.AreEqual(30, y); // 50 - 20
     }
 
-    [Fact]
+    [TestMethod]
     public void BottomRight_PositionsAtBottomRight()
     {
         var spec = WindowPositionSpec.BottomRight;
 
         var (x, y) = spec.Calculate(_panelBounds, WindowWidth, WindowHeight);
 
-        Assert.Equal(60, x); // 100 - 40
-        Assert.Equal(30, y); // 50 - 20
+        Assert.AreEqual(60, x); // 100 - 40
+        Assert.AreEqual(30, y); // 50 - 20
     }
 
-    [Fact]
+    [TestMethod]
     public void CenterTop_CentersHorizontallyAtTop()
     {
         var spec = new WindowPositionSpec(WindowPosition.CenterTop);
 
         var (x, y) = spec.Calculate(_panelBounds, WindowWidth, WindowHeight);
 
-        Assert.Equal(30, x); // (100-40)/2
-        Assert.Equal(0, y);
+        Assert.AreEqual(30, x); // (100-40)/2
+        Assert.AreEqual(0, y);
     }
 
-    [Fact]
+    [TestMethod]
     public void CenterBottom_CentersHorizontallyAtBottom()
     {
         var spec = new WindowPositionSpec(WindowPosition.CenterBottom);
 
         var (x, y) = spec.Calculate(_panelBounds, WindowWidth, WindowHeight);
 
-        Assert.Equal(30, x); // (100-40)/2
-        Assert.Equal(30, y); // 50 - 20
+        Assert.AreEqual(30, x); // (100-40)/2
+        Assert.AreEqual(30, y); // 50 - 20
     }
 
-    [Fact]
+    [TestMethod]
     public void CenterLeft_CentersVerticallyAtLeft()
     {
         var spec = new WindowPositionSpec(WindowPosition.CenterLeft);
 
         var (x, y) = spec.Calculate(_panelBounds, WindowWidth, WindowHeight);
 
-        Assert.Equal(0, x);
-        Assert.Equal(15, y); // (50-20)/2
+        Assert.AreEqual(0, x);
+        Assert.AreEqual(15, y); // (50-20)/2
     }
 
-    [Fact]
+    [TestMethod]
     public void CenterRight_CentersVerticallyAtRight()
     {
         var spec = new WindowPositionSpec(WindowPosition.CenterRight);
 
         var (x, y) = spec.Calculate(_panelBounds, WindowWidth, WindowHeight);
 
-        Assert.Equal(60, x); // 100 - 40
-        Assert.Equal(15, y); // (50-20)/2
+        Assert.AreEqual(60, x); // 100 - 40
+        Assert.AreEqual(15, y); // (50-20)/2
     }
 
-    [Fact]
+    [TestMethod]
     public void Absolute_UsesExplicitCoordinates()
     {
         var spec = new WindowPositionSpec(WindowPosition.Absolute);
 
         var (x, y) = spec.Calculate(_panelBounds, WindowWidth, WindowHeight, absoluteX: 25, absoluteY: 10);
 
-        Assert.Equal(25, x);
-        Assert.Equal(10, y);
+        Assert.AreEqual(25, x);
+        Assert.AreEqual(10, y);
     }
 
-    [Fact]
+    [TestMethod]
     public void WithOffset_AppliesOffset()
     {
         var spec = new WindowPositionSpec(WindowPosition.Center, OffsetX: 5, OffsetY: -3);
 
         var (x, y) = spec.Calculate(_panelBounds, WindowWidth, WindowHeight);
 
-        Assert.Equal(35, x); // 30 + 5
-        Assert.Equal(12, y); // 15 - 3
+        Assert.AreEqual(35, x); // 30 + 5
+        Assert.AreEqual(12, y); // 15 - 3
     }
 
-    [Fact]
+    [TestMethod]
     public void CenterWithOffset_AppliesOffset()
     {
         var spec = WindowPositionSpec.CenterWithOffset(10, 5);
 
         var (x, y) = spec.Calculate(_panelBounds, WindowWidth, WindowHeight);
 
-        Assert.Equal(40, x); // 30 + 10
-        Assert.Equal(20, y); // 15 + 5
+        Assert.AreEqual(40, x); // 30 + 10
+        Assert.AreEqual(20, y); // 15 + 5
     }
 
-    [Fact]
+    [TestMethod]
     public void ClampsToLeftBound()
     {
         var spec = new WindowPositionSpec(WindowPosition.Center, OffsetX: -100);
 
         var (x, y) = spec.Calculate(_panelBounds, WindowWidth, WindowHeight);
 
-        Assert.Equal(0, x); // Clamped to 0
+        Assert.AreEqual(0, x); // Clamped to 0
     }
 
-    [Fact]
+    [TestMethod]
     public void ClampsToRightBound()
     {
         var spec = new WindowPositionSpec(WindowPosition.Center, OffsetX: 100);
 
         var (x, y) = spec.Calculate(_panelBounds, WindowWidth, WindowHeight);
 
-        Assert.Equal(60, x); // Clamped to 100 - 40
+        Assert.AreEqual(60, x); // Clamped to 100 - 40
     }
 
-    [Fact]
+    [TestMethod]
     public void ClampsToTopBound()
     {
         var spec = new WindowPositionSpec(WindowPosition.Center, OffsetY: -100);
 
         var (x, y) = spec.Calculate(_panelBounds, WindowWidth, WindowHeight);
 
-        Assert.Equal(0, y); // Clamped to 0
+        Assert.AreEqual(0, y); // Clamped to 0
     }
 
-    [Fact]
+    [TestMethod]
     public void ClampsToBottomBound()
     {
         var spec = new WindowPositionSpec(WindowPosition.Center, OffsetY: 100);
 
         var (x, y) = spec.Calculate(_panelBounds, WindowWidth, WindowHeight);
 
-        Assert.Equal(30, y); // Clamped to 50 - 20
+        Assert.AreEqual(30, y); // Clamped to 50 - 20
     }
 
-    [Fact]
+    [TestMethod]
     public void WithNonZeroPanelOrigin_PositionsCorrectly()
     {
         var panelBounds = new Rect(10, 5, 100, 50);
@@ -193,11 +194,11 @@ public class WindowPositionTests
         var (x, y) = spec.Calculate(panelBounds, WindowWidth, WindowHeight);
 
         // Center relative to panel origin: 10 + (100-40)/2 = 40, 5 + (50-20)/2 = 20
-        Assert.Equal(40, x);
-        Assert.Equal(20, y);
+        Assert.AreEqual(40, x);
+        Assert.AreEqual(20, y);
     }
 
-    [Fact]
+    [TestMethod]
     public void TopLeft_WithNonZeroOrigin_PositionsAtPanelOrigin()
     {
         var panelBounds = new Rect(10, 5, 100, 50);
@@ -205,11 +206,11 @@ public class WindowPositionTests
 
         var (x, y) = spec.Calculate(panelBounds, WindowWidth, WindowHeight);
 
-        Assert.Equal(10, x);
-        Assert.Equal(5, y);
+        Assert.AreEqual(10, x);
+        Assert.AreEqual(5, y);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowLargerThanPanel_ClampsToOrigin()
     {
         var smallPanel = new Rect(0, 0, 30, 15);
@@ -220,7 +221,7 @@ public class WindowPositionTests
         // Window is larger than panel, so it should clamp to origin
         // Max x = 0 + 30 - 40 = -10, clamped to 0
         // Max y = 0 + 15 - 20 = -5, clamped to 0
-        Assert.Equal(0, x);
-        Assert.Equal(0, y);
+        Assert.AreEqual(0, x);
+        Assert.AreEqual(0, y);
     }
 }

--- a/tests/Hex1b.Tests/WindowsPtyDisposeTests.cs
+++ b/tests/Hex1b.Tests/WindowsPtyDisposeTests.cs
@@ -18,27 +18,26 @@ namespace Hex1b.Tests;
 /// of ReadThreadProc/WriteThreadProc. The cached copy remains valid and correctly
 /// reflects cancellation even after the source is disposed.
 /// </summary>
+[TestClass]
 public class WindowsPtyDisposeTests
 {
     private static string ResolveShimPath()
     {
-        Assert.True(
-            WindowsPtyShimLocator.TryResolve(out var path),
-            "Expected PTY shim to be resolvable via WindowsPtyShimLocator");
+        Assert.IsTrue(WindowsPtyShimLocator.TryResolve(out var path), "Expected PTY shim to be resolvable via WindowsPtyShimLocator");
         return path;
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowsPtyShimLocator_WithExplicitPath_ResolvesOverride()
     {
         using var workspace = TestWorkspace.Create("pty_shim_locator");
         var shimFile = workspace.CreateFile("hex1bpty.exe", string.Empty);
 
-        Assert.True(WindowsPtyShimLocator.TryResolve(shimFile.FullName, out var resolvedPath));
-        Assert.Equal(shimFile.FullName, resolvedPath, ignoreCase: true);
+        Assert.IsTrue(WindowsPtyShimLocator.TryResolve(shimFile.FullName, out var resolvedPath));
+        Assert.AreEqual(shimFile.FullName, resolvedPath, ignoreCase: true);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowsPtyShimLocator_WithPackagedRuntimePath_ResolvesShim()
     {
         using var workspace = TestWorkspace.Create("pty_shim_locator_packaged");
@@ -49,11 +48,11 @@ public class WindowsPtyDisposeTests
         var shimPath = Path.Combine(runtimeDirectory, "hex1bpty.exe");
         File.WriteAllText(shimPath, string.Empty);
 
-        Assert.True(WindowsPtyShimLocator.TryResolveFromBaseDirectory(baseDirectory, explicitPath: null, out var resolvedPath));
-        Assert.Equal(shimPath, resolvedPath, ignoreCase: true);
+        Assert.IsTrue(WindowsPtyShimLocator.TryResolveFromBaseDirectory(baseDirectory, explicitPath: null, out var resolvedPath));
+        Assert.AreEqual(shimPath, resolvedPath, ignoreCase: true);
     }
 
-    [Fact]
+    [TestMethod]
     public void WindowsPtySocketPaths_CreateSocketPath_UsesPrivateSocketDirectory()
     {
         using var workspace = TestWorkspace.Create("pty_socket_dir");
@@ -69,7 +68,7 @@ public class WindowsPtyDisposeTests
 
             Assert.StartsWith(overrideDirectory, socketPath, StringComparison.OrdinalIgnoreCase);
             Assert.EndsWith(".socket", socketPath, StringComparison.OrdinalIgnoreCase);
-            Assert.True(Directory.Exists(overrideDirectory));
+            Assert.IsTrue(Directory.Exists(overrideDirectory));
         }
         finally
         {
@@ -78,23 +77,23 @@ public class WindowsPtyDisposeTests
         }
     }
 
-    [Theory]
-    [InlineData("cmd.exe", new[] { "/c", "echo hi" }, false)]
-    [InlineData("cmd.exe", new[] { "/k", "echo hi" }, true)]
-    [InlineData("powershell.exe", new[] { "-NoLogo", "-NoProfile" }, true)]
-    [InlineData("powershell.exe", new[] { "-NoLogo", "-Command", "Write-Output hi" }, false)]
-    [InlineData("pwsh.exe", new[] { "-NoExit", "-Command", "Write-Output hi" }, true)]
+    [TestMethod]
+    [DataRow("cmd.exe", new[] { "/c", "echo hi" }, false)]
+    [DataRow("cmd.exe", new[] { "/k", "echo hi" }, true)]
+    [DataRow("powershell.exe", new[] { "-NoLogo", "-NoProfile" }, true)]
+    [DataRow("powershell.exe", new[] { "-NoLogo", "-Command", "Write-Output hi" }, false)]
+    [DataRow("pwsh.exe", new[] { "-NoExit", "-Command", "Write-Output hi" }, true)]
     public void WindowsPtyShellHeuristics_RecognizesInteractiveWarmupScenarios(
         string fileName,
         string[] arguments,
         bool expected)
     {
         var actual = WindowsPtyShellHeuristics.RequiresPromptWarmup(fileName, arguments);
-        Assert.Equal(expected, actual);
+        Assert.AreEqual(expected, actual);
     }
 
-    [Fact]
-    [Trait("Category", "Windows")]
+    [TestMethod]
+    [TestCategory("Windows")]
     public async Task WithPtyProcess_WhenShimBinaryAvailable_UsesWindowsPtyShim()
     {
         if (!OperatingSystem.IsWindows())
@@ -120,11 +119,11 @@ public class WindowsPtyDisposeTests
 
         var runTask = terminal.RunAsync(TestContext.Current.CancellationToken);
         var exitCode = await runTask.WaitAsync(TimeSpan.FromSeconds(20), TestContext.Current.CancellationToken);
-        Assert.Equal(17, exitCode);
+        Assert.AreEqual(17, exitCode);
     }
 
-    [Fact]
-    [Trait("Category", "Windows")]
+    [TestMethod]
+    [TestCategory("Windows")]
     public async Task WithPtyProcess_WhenShimAvailable_StreamsOutputInputAndResize()
     {
         if (!OperatingSystem.IsWindows())
@@ -145,7 +144,7 @@ public class WindowsPtyDisposeTests
                 shimPath));
 
         await process.StartAsync(TestContext.Current.CancellationToken);
-        Assert.Equal("WindowsShimPtyHandle", GetActivePtyHandleTypeName(process));
+        Assert.AreEqual("WindowsShimPtyHandle", GetActivePtyHandleTypeName(process));
 
         var startup = await ReadUntilContainsAsync(
             process,
@@ -176,11 +175,11 @@ public class WindowsPtyDisposeTests
 
         await process.WriteInputAsync(Encoding.UTF8.GetBytes("exit\r\n"), TestContext.Current.CancellationToken);
         var exitCode = await process.WaitForExitAsync(TestContext.Current.CancellationToken);
-        Assert.Equal(0, exitCode);
+        Assert.AreEqual(0, exitCode);
     }
 
-    [Fact]
-    [Trait("Category", "Windows")]
+    [TestMethod]
+    [TestCategory("Windows")]
     public async Task DirectPtyProcess_DisposeAsync_TerminatesChildProcess()
     {
         if (!OperatingSystem.IsWindows())
@@ -198,7 +197,7 @@ public class WindowsPtyDisposeTests
 
         await process.StartAsync(TestContext.Current.CancellationToken);
         var pid = process.ProcessId;
-        Assert.True(pid > 0, "Expected the PTY child process to start.");
+        Assert.IsTrue(pid > 0, "Expected the PTY child process to start.");
 
         await process.DisposeAsync();
 
@@ -208,11 +207,11 @@ public class WindowsPtyDisposeTests
             await Task.Delay(50, timeoutCts.Token);
         }
 
-        Assert.False(IsProcessRunning(pid), $"Process {pid} should have terminated after dispose.");
+        Assert.IsFalse(IsProcessRunning(pid), $"Process {pid} should have terminated after dispose.");
     }
 
-    [Fact]
-    [Trait("Category", "Windows")]
+    [TestMethod]
+    [TestCategory("Windows")]
     public async Task Hex1bPtyHost_MismatchedLaunchToken_IsRejectedAndLogged()
     {
         if (!OperatingSystem.IsWindows())
@@ -243,7 +242,7 @@ public class WindowsPtyDisposeTests
             process.StartInfo.ArgumentList.Add("--logfile");
             process.StartInfo.ArgumentList.Add(logPath);
 
-            Assert.True(process.Start(), "Failed to launch hex1bpty.exe.");
+            Assert.IsTrue(process.Start(), "Failed to launch hex1bpty.exe.");
 
             using var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
             await ConnectWithRetriesAsync(
@@ -269,15 +268,15 @@ public class WindowsPtyDisposeTests
                 TestContext.Current.CancellationToken);
 
             var frame = await WindowsPtyShimProtocol.ReadFrameAsync(stream, TestContext.Current.CancellationToken);
-            Assert.NotNull(frame);
-            Assert.Equal(WindowsPtyShimFrameType.Error, frame.Value.Type);
+            Assert.IsNotNull(frame);
+            Assert.AreEqual(WindowsPtyShimFrameType.Error, frame.Value.Type);
 
             var error = WindowsPtyShimProtocol.ReadJson<WindowsPtyShimErrorResponse>(frame.Value.Payload);
             Assert.Contains("token", error.Message, StringComparison.OrdinalIgnoreCase);
 
             await process.WaitForExitAsync(TestContext.Current.CancellationToken);
-            Assert.Equal(1, process.ExitCode);
-            Assert.True(File.Exists(logPath));
+            Assert.AreEqual(1, process.ExitCode);
+            Assert.IsTrue(File.Exists(logPath));
 
             var logContents = await ReadAllTextSharedAsync(logPath, TestContext.Current.CancellationToken);
             Assert.Contains("Rejected PTY launch request", logContents, StringComparison.OrdinalIgnoreCase);
@@ -288,8 +287,8 @@ public class WindowsPtyDisposeTests
         }
     }
 
-    [Fact]
-    [Trait("Category", "Windows")]
+    [TestMethod]
+    [TestCategory("Windows")]
     public async Task Hex1bPtyHost_InvalidLogfilePath_DoesNotPreventStartup()
     {
         if (!OperatingSystem.IsWindows())
@@ -320,7 +319,7 @@ public class WindowsPtyDisposeTests
             process.StartInfo.ArgumentList.Add("--logfile");
             process.StartInfo.ArgumentList.Add(invalidLogPath);
 
-            Assert.True(process.Start(), "Failed to launch hex1bpty.exe.");
+            Assert.IsTrue(process.Start(), "Failed to launch hex1bpty.exe.");
 
             using var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
             await ConnectWithRetriesAsync(
@@ -346,14 +345,14 @@ public class WindowsPtyDisposeTests
                 TestContext.Current.CancellationToken);
 
             var frame = await WindowsPtyShimProtocol.ReadFrameAsync(stream, TestContext.Current.CancellationToken);
-            Assert.NotNull(frame);
-            Assert.Equal(WindowsPtyShimFrameType.Error, frame.Value.Type);
+            Assert.IsNotNull(frame);
+            Assert.AreEqual(WindowsPtyShimFrameType.Error, frame.Value.Type);
 
             var error = WindowsPtyShimProtocol.ReadJson<WindowsPtyShimErrorResponse>(frame.Value.Payload);
             Assert.Contains("token", error.Message, StringComparison.OrdinalIgnoreCase);
 
             await process.WaitForExitAsync(TestContext.Current.CancellationToken);
-            Assert.Equal(1, process.ExitCode);
+            Assert.AreEqual(1, process.ExitCode);
         }
         finally
         {
@@ -361,8 +360,8 @@ public class WindowsPtyDisposeTests
         }
     }
 
-    [Fact]
-    [Trait("Category", "Windows")]
+    [TestMethod]
+    [TestCategory("Windows")]
     public async Task Hex1bPtyHost_ClientDisconnect_ShutsDownHelperProcess()
     {
         if (!OperatingSystem.IsWindows())
@@ -390,7 +389,7 @@ public class WindowsPtyDisposeTests
             process.StartInfo.ArgumentList.Add("--token");
             process.StartInfo.ArgumentList.Add("expected-launch-token");
 
-            Assert.True(process.Start(), "Failed to launch hex1bpty.exe.");
+            Assert.IsTrue(process.Start(), "Failed to launch hex1bpty.exe.");
 
             using var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
             await ConnectWithRetriesAsync(
@@ -417,8 +416,8 @@ public class WindowsPtyDisposeTests
                     TestContext.Current.CancellationToken);
 
                 var frame = await WindowsPtyShimProtocol.ReadFrameAsync(stream, TestContext.Current.CancellationToken);
-                Assert.NotNull(frame);
-                Assert.Equal(WindowsPtyShimFrameType.Started, frame.Value.Type);
+                Assert.IsNotNull(frame);
+                Assert.AreEqual(WindowsPtyShimFrameType.Started, frame.Value.Type);
 
                 socket.Shutdown(SocketShutdown.Both);
             }
@@ -426,7 +425,7 @@ public class WindowsPtyDisposeTests
             await process.WaitForExitAsync(TestContext.Current.CancellationToken)
                 .WaitAsync(TimeSpan.FromSeconds(20), TestContext.Current.CancellationToken);
 
-            Assert.True(process.HasExited, "hex1bpty.exe should exit when its client disconnects.");
+            Assert.IsTrue(process.HasExited, "hex1bpty.exe should exit when its client disconnects.");
         }
         finally
         {
@@ -438,8 +437,8 @@ public class WindowsPtyDisposeTests
     /// Rapidly disposing a PTY terminal while the child process is still running
     /// must not throw ObjectDisposedException on background threads.
     /// </summary>
-    [Fact]
-    [Trait("Category", "Windows")]
+    [TestMethod]
+    [TestCategory("Windows")]
     public async Task DisposeAsync_WhileProcessRunning_DoesNotThrowObjectDisposedException()
     {
         if (!OperatingSystem.IsWindows())
@@ -489,7 +488,7 @@ public class WindowsPtyDisposeTests
                 .Where(ex => ex is ObjectDisposedException)
                 .ToList();
 
-            Assert.Empty(odeExceptions);
+            Assert.IsEmpty(odeExceptions);
         }
         finally
         {
@@ -611,8 +610,8 @@ public class WindowsPtyDisposeTests
     /// Disposing a PTY terminal after the child process has exited naturally
     /// should complete without exceptions.
     /// </summary>
-    [Fact]
-    [Trait("Category", "Windows")]
+    [TestMethod]
+    [TestCategory("Windows")]
     public async Task DisposeAsync_AfterProcessExit_CompletesCleanly()
     {
         if (!OperatingSystem.IsWindows())
@@ -634,18 +633,18 @@ public class WindowsPtyDisposeTests
             await Task.Delay(100, cts.Token);
 
         // Dispose after process has exited — should not throw
-        var exception = await Record.ExceptionAsync(async () =>
+        var exception = await TestSeq.RecordExceptionAsync(async () =>
             await terminal.DisposeAsync());
 
-        Assert.Null(exception);
+        Assert.IsNull(exception);
     }
 
     /// <summary>
     /// Rapidly creating and disposing PTY terminals in sequence must not
     /// leak unhandled exceptions from thread cleanup.
     /// </summary>
-    [Fact]
-    [Trait("Category", "Windows")]
+    [TestMethod]
+    [TestCategory("Windows")]
     public async Task RapidCreateDispose_DoesNotLeakExceptions()
     {
         if (!OperatingSystem.IsWindows())
@@ -679,7 +678,7 @@ public class WindowsPtyDisposeTests
             // Wait for any lingering thread exceptions
             await Task.Delay(500);
 
-            Assert.Empty(unhandledExceptions);
+            Assert.IsEmpty(unhandledExceptions);
         }
         finally
         {
@@ -691,8 +690,8 @@ public class WindowsPtyDisposeTests
     /// Direct mode should continue to use the in-process WindowsPtyHandle even when
     /// a proxy path is configured but unavailable.
     /// </summary>
-    [Fact]
-    [Trait("Category", "Windows")]
+    [TestMethod]
+    [TestCategory("Windows")]
     public async Task WithPtyProcess_DirectMode_UsesInProcessPty_WhenShimPathIsMissing()
     {
         if (!OperatingSystem.IsWindows())
@@ -718,11 +717,11 @@ public class WindowsPtyDisposeTests
 
         var runTask = terminal.RunAsync(TestContext.Current.CancellationToken);
         var exitCode = await runTask.WaitAsync(TimeSpan.FromSeconds(20), TestContext.Current.CancellationToken);
-        Assert.Equal(23, exitCode);
+        Assert.AreEqual(23, exitCode);
     }
 
-    [Fact]
-    [Trait("Category", "Windows")]
+    [TestMethod]
+    [TestCategory("Windows")]
     public async Task WithPtyProcess_MissingRequiredShim_ThrowsInsteadOfFallingBack()
     {
         if (!OperatingSystem.IsWindows())
@@ -742,8 +741,7 @@ public class WindowsPtyDisposeTests
                 WindowsPtyMode.RequireProxy,
                 missingShimPath));
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            () => process.StartAsync(TestContext.Current.CancellationToken));
+        var ex = await Assert.ThrowsExactlyAsync<InvalidOperationException>(() => process.StartAsync(TestContext.Current.CancellationToken));
 
         Assert.Contains("required", ex.Message, StringComparison.OrdinalIgnoreCase);
     }

--- a/tests/Hex1b.Tool.Tests/AttachTuiAppTests.cs
+++ b/tests/Hex1b.Tool.Tests/AttachTuiAppTests.cs
@@ -2,13 +2,14 @@ using Hex1b.Tool.Commands.Terminal;
 
 namespace Hex1b.Tool.Tests;
 
+[TestClass]
 public class AttachTuiAppTests
 {
-    [Theory]
-    [InlineData(true, true, true, true)]
-    [InlineData(true, false, true, false)]
-    [InlineData(true, false, false, true)]
-    [InlineData(false, true, true, false)]
+    [TestMethod]
+    [DataRow(true, true, true, true)]
+    [DataRow(true, false, true, false)]
+    [DataRow(true, false, false, true)]
+    [DataRow(false, true, true, false)]
     public void ShouldSendResizeForDisplayChange_RespectsLeaderAndInitialResize(
         bool isLeader,
         bool initialResizeRequested,
@@ -20,10 +21,10 @@ public class AttachTuiAppTests
             initialResizeRequested,
             isInitialSessionStart);
 
-        Assert.Equal(expected, shouldSend);
+        Assert.AreEqual(expected, shouldSend);
     }
 
-    [Fact]
+    [TestMethod]
     public void CalculateResizeTarget_SubtractsAttachChromeFromDisplay()
     {
         var target = AttachTuiApp.CalculateResizeTarget(
@@ -32,19 +33,19 @@ public class AttachTuiAppTests
             remoteWidth: 120,
             remoteHeight: 30);
 
-        Assert.Equal((Width: 78, Height: 20), target);
+        Assert.AreEqual((Width: 78, Height: 20), target);
     }
 
-    [Fact]
+    [TestMethod]
     public void CalculateResizeTarget_UnchangedOrTooSmall_ReturnsNull()
     {
-        Assert.Null(AttachTuiApp.CalculateResizeTarget(
+        Assert.IsNull(AttachTuiApp.CalculateResizeTarget(
             displayWidth: 82,
             displayHeight: 24,
             remoteWidth: 80,
             remoteHeight: 20));
 
-        Assert.Null(AttachTuiApp.CalculateResizeTarget(
+        Assert.IsNull(AttachTuiApp.CalculateResizeTarget(
             displayWidth: 2,
             displayHeight: 4,
             remoteWidth: 80,

--- a/tests/Hex1b.Tool.Tests/Hex1b.Tool.Tests.csproj
+++ b/tests/Hex1b.Tool.Tests/Hex1b.Tool.Tests.csproj
@@ -1,27 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="MSTest.Sdk/4.2.3">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>xUnit1031;xUnit1051</NoWarn>
     <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Hex1b.Tool\Hex1b.Tool.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Using Include="Xunit" />
   </ItemGroup>
 
 </Project>

--- a/tests/Hex1b.Tool.Tests/OutputFormatterTests.cs
+++ b/tests/Hex1b.Tool.Tests/OutputFormatterTests.cs
@@ -2,9 +2,10 @@ using Hex1b.Tool.Infrastructure;
 
 namespace Hex1b.Tool.Tests;
 
+[TestClass]
 public class OutputFormatterTests
 {
-    [Fact]
+    [TestMethod]
     public void WriteTable_CalculatesColumnWidths()
     {
         var formatter = new OutputFormatter();
@@ -19,7 +20,7 @@ public class OutputFormatterTests
         });
 
         var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-        Assert.Equal(3, lines.Length); // header + 2 rows
+        Assert.AreEqual(3, lines.Length); // header + 2 rows
 
         // Header columns should be padded to widest value
         Assert.Contains("NAME", lines[0]);
@@ -28,10 +29,10 @@ public class OutputFormatterTests
         // Values should be aligned with header
         var nameStartInHeader = lines[0].IndexOf("NAME", StringComparison.Ordinal);
         var nameStartInRow = lines[2].IndexOf("a-longer-name", StringComparison.Ordinal);
-        Assert.Equal(nameStartInHeader, nameStartInRow);
+        Assert.AreEqual(nameStartInHeader, nameStartInRow);
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteTable_JsonMode_ProducesNoOutput()
     {
         var formatter = new OutputFormatter { JsonMode = true };
@@ -42,10 +43,10 @@ public class OutputFormatterTests
                 [["1"]]);
         });
 
-        Assert.Empty(output.Trim());
+        Assert.IsEmpty(output.Trim());
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteJson_ProducesFormattedJson()
     {
         var formatter = new OutputFormatter { JsonMode = true };
@@ -58,7 +59,7 @@ public class OutputFormatterTests
         Assert.Contains("\"count\": 42", output);
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteLine_NormalMode_WritesOutput()
     {
         var formatter = new OutputFormatter();
@@ -67,10 +68,10 @@ public class OutputFormatterTests
             formatter.WriteLine("hello world");
         });
 
-        Assert.Equal("hello world", output.Trim());
+        Assert.AreEqual("hello world", output.Trim());
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteLine_JsonMode_SuppressesOutput()
     {
         var formatter = new OutputFormatter { JsonMode = true };
@@ -79,10 +80,10 @@ public class OutputFormatterTests
             formatter.WriteLine("hello world");
         });
 
-        Assert.Empty(output.Trim());
+        Assert.IsEmpty(output.Trim());
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteError_AlwaysWritesToStdErr()
     {
         var formatter = new OutputFormatter { JsonMode = true };
@@ -91,10 +92,10 @@ public class OutputFormatterTests
             formatter.WriteError("something went wrong");
         });
 
-        Assert.Equal("something went wrong", errorOutput.Trim());
+        Assert.AreEqual("something went wrong", errorOutput.Trim());
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteTable_EmptyRows_WritesHeaderOnly()
     {
         var formatter = new OutputFormatter();
@@ -104,11 +105,11 @@ public class OutputFormatterTests
         });
 
         var lines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-        Assert.Single(lines);
+        Assert.HasCount(1, lines);
         Assert.Contains("COL1", lines[0]);
     }
 
-    [Fact]
+    [TestMethod]
     public void WriteTable_ColumnsAligned_WithTwoSpaceSeparator()
     {
         var formatter = new OutputFormatter();

--- a/tests/Hex1b.Tool.Tests/RecordingProtocolTests.cs
+++ b/tests/Hex1b.Tool.Tests/RecordingProtocolTests.cs
@@ -4,9 +4,10 @@ using System.Text.Json;
 
 namespace Hex1b.Tool.Tests;
 
+[TestClass]
 public class RecordingProtocolTests
 {
-    [Fact]
+    [TestMethod]
     public async Task RecordStart_StartsRecordingAndCreatesFile()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -28,35 +29,35 @@ public class RecordingProtocolTests
             var startResponse = await SendRawRequestAsync(socketPath,
                 $$$"""{"method":"record-start","filePath":"{{{outputPath.Replace("\\", "\\\\")}}}","title":"Test Recording"}""");
 
-            Assert.True(startResponse.GetProperty("success").GetBoolean(), GetError(startResponse));
-            Assert.True(startResponse.GetProperty("recording").GetBoolean());
-            Assert.Equal(outputPath, startResponse.GetProperty("recordingPath").GetString());
+            Assert.IsTrue(startResponse.GetProperty("success").GetBoolean(), GetError(startResponse));
+            Assert.IsTrue(startResponse.GetProperty("recording").GetBoolean());
+            Assert.AreEqual(outputPath, startResponse.GetProperty("recordingPath").GetString());
 
             // Check status
             var statusResponse = await SendRawRequestAsync(socketPath, """{"method":"record-status"}""");
-            Assert.True(statusResponse.GetProperty("success").GetBoolean());
-            Assert.True(statusResponse.GetProperty("recording").GetBoolean());
+            Assert.IsTrue(statusResponse.GetProperty("success").GetBoolean());
+            Assert.IsTrue(statusResponse.GetProperty("recording").GetBoolean());
 
             // Info should also reflect recording status
             var infoResponse = await SendRawRequestAsync(socketPath, """{"method":"info"}""");
-            Assert.True(infoResponse.GetProperty("success").GetBoolean());
-            Assert.True(infoResponse.GetProperty("recording").GetBoolean());
+            Assert.IsTrue(infoResponse.GetProperty("success").GetBoolean());
+            Assert.IsTrue(infoResponse.GetProperty("recording").GetBoolean());
 
             // Stop recording
             var stopResponse = await SendRawRequestAsync(socketPath, """{"method":"record-stop"}""");
-            Assert.True(stopResponse.GetProperty("success").GetBoolean(), GetError(stopResponse));
-            Assert.False(stopResponse.GetProperty("recording").GetBoolean());
-            Assert.Equal(outputPath, stopResponse.GetProperty("recordingPath").GetString());
+            Assert.IsTrue(stopResponse.GetProperty("success").GetBoolean(), GetError(stopResponse));
+            Assert.IsFalse(stopResponse.GetProperty("recording").GetBoolean());
+            Assert.AreEqual(outputPath, stopResponse.GetProperty("recordingPath").GetString());
 
             // File should exist and be valid asciicast v2
-            Assert.True(File.Exists(outputPath));
+            Assert.IsTrue(File.Exists(outputPath));
             var lines = await File.ReadAllLinesAsync(outputPath);
-            Assert.True(lines.Length >= 1);
+            Assert.IsTrue(lines.Length >= 1);
 
             using var header = JsonDocument.Parse(lines[0]);
-            Assert.Equal(2, header.RootElement.GetProperty("version").GetInt32());
-            Assert.Equal(80, header.RootElement.GetProperty("width").GetInt32());
-            Assert.Equal(24, header.RootElement.GetProperty("height").GetInt32());
+            Assert.AreEqual(2, header.RootElement.GetProperty("version").GetInt32());
+            Assert.AreEqual(80, header.RootElement.GetProperty("width").GetInt32());
+            Assert.AreEqual(24, header.RootElement.GetProperty("height").GetInt32());
         }
         finally
         {
@@ -64,7 +65,7 @@ public class RecordingProtocolTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RecordStart_WhenAlreadyRecording_ReturnsError()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -85,11 +86,11 @@ public class RecordingProtocolTests
         {
             var response1 = await SendRawRequestAsync(socketPath,
                 $$$"""{"method":"record-start","filePath":"{{{outputPath1.Replace("\\", "\\\\")}}}"}""");
-            Assert.True(response1.GetProperty("success").GetBoolean());
+            Assert.IsTrue(response1.GetProperty("success").GetBoolean());
 
             var response2 = await SendRawRequestAsync(socketPath,
                 $$$"""{"method":"record-start","filePath":"{{{outputPath2.Replace("\\", "\\\\")}}}"}""");
-            Assert.False(response2.GetProperty("success").GetBoolean());
+            Assert.IsFalse(response2.GetProperty("success").GetBoolean());
             Assert.Contains("Already recording", response2.GetProperty("error").GetString());
 
             await SendRawRequestAsync(socketPath, """{"method":"record-stop"}""");
@@ -101,7 +102,7 @@ public class RecordingProtocolTests
         }
     }
 
-    [Fact]
+    [TestMethod]
     public async Task RecordStop_WhenNotRecording_ReturnsError()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -117,7 +118,7 @@ public class RecordingProtocolTests
         await WaitForSocketAsync(socketPath);
 
         var response = await SendRawRequestAsync(socketPath, """{"method":"record-stop"}""");
-        Assert.False(response.GetProperty("success").GetBoolean());
+        Assert.IsFalse(response.GetProperty("success").GetBoolean());
         Assert.Contains("Not currently recording", response.GetProperty("error").GetString());
     }
 

--- a/tests/Hex1b.Tool.Tests/SvgToPngConverterTests.cs
+++ b/tests/Hex1b.Tool.Tests/SvgToPngConverterTests.cs
@@ -3,6 +3,7 @@ using SkiaSharp;
 
 namespace Hex1b.Tool.Tests;
 
+[TestClass]
 public class SvgToPngConverterTests
 {
     private const string MinimalSvg = """
@@ -15,77 +16,77 @@ public class SvgToPngConverterTests
 
     // --- Color Parsing ---
 
-    [Fact]
+    [TestMethod]
     public void ParseSvgColor_HexColor_ReturnsCorrectColor()
     {
         var color = SvgToPngConverter.ParseSvgColor("#ff6b6b");
-        Assert.Equal(new SKColor(255, 107, 107), color);
+        Assert.AreEqual(new SKColor(255, 107, 107), color);
     }
 
-    [Fact]
+    [TestMethod]
     public void ParseSvgColor_ShortHexColor_ReturnsCorrectColor()
     {
         var color = SvgToPngConverter.ParseSvgColor("#fff");
-        Assert.Equal(new SKColor(255, 255, 255), color);
+        Assert.AreEqual(new SKColor(255, 255, 255), color);
     }
 
-    [Fact]
+    [TestMethod]
     public void ParseSvgColor_RgbColor_ReturnsCorrectColor()
     {
         var color = SvgToPngConverter.ParseSvgColor("rgb(78,201,176)");
-        Assert.Equal(new SKColor(78, 201, 176), color);
+        Assert.AreEqual(new SKColor(78, 201, 176), color);
     }
 
-    [Fact]
+    [TestMethod]
     public void ParseSvgColor_RgbColorWithSpaces_ReturnsCorrectColor()
     {
         var color = SvgToPngConverter.ParseSvgColor("rgb( 78 , 201 , 176 )");
-        Assert.Equal(new SKColor(78, 201, 176), color);
+        Assert.AreEqual(new SKColor(78, 201, 176), color);
     }
 
-    [Fact]
+    [TestMethod]
     public void ParseSvgColor_InvalidColor_Throws()
     {
-        Assert.ThrowsAny<Exception>(() => SvgToPngConverter.ParseSvgColor("not-a-color"));
+        Assert.Throws<Exception>(() => SvgToPngConverter.ParseSvgColor("not-a-color"));
     }
 
     // --- SVG Text Extraction ---
 
-    [Fact]
+    [TestMethod]
     public void ExtractTextElements_ParsesTextPosition()
     {
         var (textElements, _, _, _, _) = SvgToPngConverter.ExtractTextElements(MinimalSvg);
 
-        Assert.Single(textElements);
-        Assert.Equal(5.0f, textElements[0].X);
-        Assert.Equal(20.0f, textElements[0].Y);
+        Assert.HasCount(1, textElements);
+        Assert.AreEqual(5.0f, textElements[0].X);
+        Assert.AreEqual(20.0f, textElements[0].Y);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtractTextElements_ParsesFillColor()
     {
         var (textElements, _, _, _, _) = SvgToPngConverter.ExtractTextElements(MinimalSvg);
 
-        Assert.Equal("#d4d4d4", textElements[0].Fill);
+        Assert.AreEqual("#d4d4d4", textElements[0].Fill);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtractTextElements_ParsesTextContent()
     {
         var (textElements, _, _, _, _) = SvgToPngConverter.ExtractTextElements(MinimalSvg);
 
-        Assert.Equal("Hello", textElements[0].Content);
+        Assert.AreEqual("Hello", textElements[0].Content);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtractTextElements_ParsesFontSize()
     {
         var (_, _, fontSize, _, _) = SvgToPngConverter.ExtractTextElements(MinimalSvg);
 
-        Assert.Equal(14f, fontSize);
+        Assert.AreEqual(14f, fontSize);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtractTextElements_DefaultsFontSizeTo14()
     {
         var svgNoStyle = """
@@ -95,19 +96,19 @@ public class SvgToPngConverterTests
             """;
 
         var (_, _, fontSize, _, _) = SvgToPngConverter.ExtractTextElements(svgNoStyle);
-        Assert.Equal(14f, fontSize);
+        Assert.AreEqual(14f, fontSize);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtractTextElements_ParsesDimensions()
     {
         var (_, _, _, width, height) = SvgToPngConverter.ExtractTextElements(MinimalSvg);
 
-        Assert.Equal(200, width);
-        Assert.Equal(40, height);
+        Assert.AreEqual(200, width);
+        Assert.AreEqual(40, height);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtractTextElements_StripsTextFromBackgroundSvg()
     {
         var (_, bgSvg, _, _, _) = SvgToPngConverter.ExtractTextElements(MinimalSvg);
@@ -116,7 +117,7 @@ public class SvgToPngConverterTests
         Assert.Contains("<rect", bgSvg);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtractTextElements_ParsesStyleAttribute()
     {
         var svg = """
@@ -131,7 +132,7 @@ public class SvgToPngConverterTests
         Assert.Contains("font-style:italic", textElements[0].Style);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtractTextElements_HandlesRgbFillColor()
     {
         var svg = """
@@ -141,10 +142,10 @@ public class SvgToPngConverterTests
             """;
 
         var (textElements, _, _, _, _) = SvgToPngConverter.ExtractTextElements(svg);
-        Assert.Equal("rgb(78,201,176)", textElements[0].Fill);
+        Assert.AreEqual("rgb(78,201,176)", textElements[0].Fill);
     }
 
-    [Fact]
+    [TestMethod]
     public void ExtractTextElements_HandlesMultipleTextElements()
     {
         var svg = """
@@ -157,69 +158,69 @@ public class SvgToPngConverterTests
 
         var (textElements, _, _, _, _) = SvgToPngConverter.ExtractTextElements(svg);
 
-        Assert.Equal(3, textElements.Count);
-        Assert.Equal("A", textElements[0].Content);
-        Assert.Equal("B", textElements[1].Content);
-        Assert.Equal("C", textElements[2].Content);
+        Assert.AreEqual(3, textElements.Count);
+        Assert.AreEqual("A", textElements[0].Content);
+        Assert.AreEqual("B", textElements[1].Content);
+        Assert.AreEqual("C", textElements[2].Content);
     }
 
     // --- Embedded Font ---
 
-    [Fact]
+    [TestMethod]
     public void EnsureEmbeddedFontExtracted_ReturnsFontPath()
     {
         var path = SvgToPngConverter.EnsureEmbeddedFontExtracted();
 
-        Assert.True(File.Exists(path));
+        Assert.IsTrue(File.Exists(path));
         Assert.EndsWith("CaskaydiaCoveNerdFontMono-Regular.ttf", path);
     }
 
-    [Fact]
+    [TestMethod]
     public void LoadEmbeddedTypeface_ReturnsNonNull()
     {
         using var typeface = SvgToPngConverter.LoadEmbeddedTypeface();
 
-        Assert.NotNull(typeface);
-        Assert.True(typeface.GlyphCount > 10000, $"Expected Nerd Font with many glyphs, got {typeface.GlyphCount}");
+        Assert.IsNotNull(typeface);
+        Assert.IsTrue(typeface.GlyphCount > 10000, $"Expected Nerd Font with many glyphs, got {typeface.GlyphCount}");
     }
 
-    [Fact]
+    [TestMethod]
     public void LoadEmbeddedTypeface_ContainsNerdFontGlyphs()
     {
         using var typeface = SvgToPngConverter.LoadEmbeddedTypeface()!;
 
         // Nerd Font PUA codepoints
-        Assert.NotEqual(0, typeface.GetGlyph(0xE0A0)); // git branch
-        Assert.NotEqual(0, typeface.GetGlyph(0xE0B0)); // powerline arrow
-        Assert.NotEqual(0, typeface.GetGlyph(0xF489)); // terminal icon
+        Assert.AreNotEqual(0, typeface.GetGlyph(0xE0A0)); // git branch
+        Assert.AreNotEqual(0, typeface.GetGlyph(0xE0B0)); // powerline arrow
+        Assert.AreNotEqual(0, typeface.GetGlyph(0xF489)); // terminal icon
     }
 
     // --- Full Conversion ---
 
-    [Fact]
+    [TestMethod]
     public void Convert_ProducesValidPng()
     {
         var pngBytes = SvgToPngConverter.Convert(MinimalSvg);
 
-        Assert.NotEmpty(pngBytes);
+        Assert.IsNotEmpty(pngBytes);
         // PNG magic bytes
-        Assert.Equal((byte)0x89, pngBytes[0]);
-        Assert.Equal((byte)0x50, pngBytes[1]); // P
-        Assert.Equal((byte)0x4E, pngBytes[2]); // N
-        Assert.Equal((byte)0x47, pngBytes[3]); // G
+        Assert.AreEqual((byte)0x89, pngBytes[0]);
+        Assert.AreEqual((byte)0x50, pngBytes[1]); // P
+        Assert.AreEqual((byte)0x4E, pngBytes[2]); // N
+        Assert.AreEqual((byte)0x47, pngBytes[3]); // G
     }
 
-    [Fact]
+    [TestMethod]
     public void Convert_ProducesCorrectDimensions()
     {
         var pngBytes = SvgToPngConverter.Convert(MinimalSvg);
 
         using var bmp = SKBitmap.Decode(pngBytes);
-        Assert.Equal(200, bmp.Width);
-        Assert.Equal(40, bmp.Height);
+        Assert.AreEqual(200, bmp.Width);
+        Assert.AreEqual(40, bmp.Height);
     }
 
-    [Fact]
+    [TestMethod]
     public void Convert_RendersBackgroundColor()
     {
         var pngBytes = SvgToPngConverter.Convert(MinimalSvg);
@@ -227,10 +228,10 @@ public class SvgToPngConverterTests
         using var bmp = SKBitmap.Decode(pngBytes);
         // Center pixel should be the background color #1e1e1e
         var pixel = bmp.GetPixel(100, 35);
-        Assert.Equal(new SKColor(30, 30, 30), pixel);
+        Assert.AreEqual(new SKColor(30, 30, 30), pixel);
     }
 
-    [Fact]
+    [TestMethod]
     public void Convert_WithRgbColors_DoesNotThrow()
     {
         var svg = """
@@ -242,10 +243,10 @@ public class SvgToPngConverterTests
             """;
 
         var pngBytes = SvgToPngConverter.Convert(svg);
-        Assert.NotEmpty(pngBytes);
+        Assert.IsNotEmpty(pngBytes);
     }
 
-    [Fact]
+    [TestMethod]
     public void Convert_WithNerdFontGlyphs_ProducesOutput()
     {
         var glyph = "\ue0a0";
@@ -258,10 +259,10 @@ public class SvgToPngConverterTests
             """, glyph);
 
         var pngBytes = SvgToPngConverter.Convert(svg);
-        Assert.NotEmpty(pngBytes);
+        Assert.IsNotEmpty(pngBytes);
     }
 
-    [Fact]
+    [TestMethod]
     public void Convert_WithBoldStyle_ProducesOutput()
     {
         var svg = """
@@ -272,10 +273,10 @@ public class SvgToPngConverterTests
             """;
 
         var pngBytes = SvgToPngConverter.Convert(svg);
-        Assert.NotEmpty(pngBytes);
+        Assert.IsNotEmpty(pngBytes);
     }
 
-    [Fact]
+    [TestMethod]
     public void Convert_WithItalicStyle_ProducesOutput()
     {
         var svg = """
@@ -286,10 +287,10 @@ public class SvgToPngConverterTests
             """;
 
         var pngBytes = SvgToPngConverter.Convert(svg);
-        Assert.NotEmpty(pngBytes);
+        Assert.IsNotEmpty(pngBytes);
     }
 
-    [Fact]
+    [TestMethod]
     public void Convert_WithDimStyle_ProducesOutput()
     {
         var svg = """
@@ -300,6 +301,6 @@ public class SvgToPngConverterTests
             """;
 
         var pngBytes = SvgToPngConverter.Convert(svg);
-        Assert.NotEmpty(pngBytes);
+        Assert.IsNotEmpty(pngBytes);
     }
 }

--- a/tests/Hex1b.Tool.Tests/TerminalDiscoveryTests.cs
+++ b/tests/Hex1b.Tool.Tests/TerminalDiscoveryTests.cs
@@ -2,9 +2,10 @@ using Hex1b.Tool.Infrastructure;
 
 namespace Hex1b.Tool.Tests;
 
+[TestClass]
 public class TerminalDiscoveryTests
 {
-    [Fact]
+    [TestMethod]
     public void Scan_DiagnosticsSocket_ParsesAsTui()
     {
         using var dir = new TempSocketDirectory();
@@ -13,13 +14,13 @@ public class TerminalDiscoveryTests
         var discovery = new TerminalDiscovery(dir.Path);
         var terminals = discovery.Scan();
 
-        Assert.Single(terminals);
-        Assert.Equal("12345", terminals[0].Id);
-        Assert.Equal("tui", terminals[0].Type);
+        Assert.HasCount(1, terminals);
+        Assert.AreEqual("12345", terminals[0].Id);
+        Assert.AreEqual("tui", terminals[0].Type);
         Assert.EndsWith(".diagnostics.socket", terminals[0].SocketPath);
     }
 
-    [Fact]
+    [TestMethod]
     public void Scan_TerminalSocket_ParsesAsHost()
     {
         using var dir = new TempSocketDirectory();
@@ -28,12 +29,12 @@ public class TerminalDiscoveryTests
         var discovery = new TerminalDiscovery(dir.Path);
         var terminals = discovery.Scan();
 
-        Assert.Single(terminals);
-        Assert.Equal("67890", terminals[0].Id);
-        Assert.Equal("host", terminals[0].Type);
+        Assert.HasCount(1, terminals);
+        Assert.AreEqual("67890", terminals[0].Id);
+        Assert.AreEqual("host", terminals[0].Type);
     }
 
-    [Fact]
+    [TestMethod]
     public void Scan_MixedSocketTypes_ReturnsBoth()
     {
         using var dir = new TempSocketDirectory();
@@ -43,12 +44,12 @@ public class TerminalDiscoveryTests
         var discovery = new TerminalDiscovery(dir.Path);
         var terminals = discovery.Scan();
 
-        Assert.Equal(2, terminals.Count);
-        Assert.Contains(terminals, t => t.Id == "111" && t.Type == "tui");
-        Assert.Contains(terminals, t => t.Id == "222" && t.Type == "host");
+        Assert.AreEqual(2, terminals.Count);
+        Assert.IsTrue(terminals.Any(t => t.Id == "111" && t.Type == "tui"));
+        Assert.IsTrue(terminals.Any(t => t.Id == "222" && t.Type == "host"));
     }
 
-    [Fact]
+    [TestMethod]
     public void Scan_UnknownSocketPattern_Ignored()
     {
         using var dir = new TempSocketDirectory();
@@ -59,11 +60,11 @@ public class TerminalDiscoveryTests
         var discovery = new TerminalDiscovery(dir.Path);
         var terminals = discovery.Scan();
 
-        Assert.Single(terminals);
-        Assert.Equal("12345", terminals[0].Id);
+        Assert.HasCount(1, terminals);
+        Assert.AreEqual("12345", terminals[0].Id);
     }
 
-    [Fact]
+    [TestMethod]
     public void Scan_EmptyDirectory_ReturnsEmpty()
     {
         using var dir = new TempSocketDirectory();
@@ -71,16 +72,16 @@ public class TerminalDiscoveryTests
 
         var terminals = discovery.Scan();
 
-        Assert.Empty(terminals);
+        Assert.IsEmpty(terminals);
     }
 
-    [Fact]
+    [TestMethod]
     public void Scan_NonexistentDirectory_ReturnsEmpty()
     {
         var discovery = new TerminalDiscovery("/tmp/nonexistent-hex1b-test-" + Guid.NewGuid());
         var terminals = discovery.Scan();
 
-        Assert.Empty(terminals);
+        Assert.IsEmpty(terminals);
     }
 
     private sealed class TempSocketDirectory : IDisposable

--- a/tests/Hex1b.Tool.Tests/TerminalHostPlatformDefaultsTests.cs
+++ b/tests/Hex1b.Tool.Tests/TerminalHostPlatformDefaultsTests.cs
@@ -2,50 +2,51 @@ using Hex1b.Tool.Hosting;
 
 namespace Hex1b.Tool.Tests;
 
+[TestClass]
 public class TerminalHostPlatformDefaultsTests
 {
-    [Fact]
+    [TestMethod]
     public void GetDefaultCommandLine_ReturnsPlatformAppropriateShell()
     {
         var commandLine = TerminalHostPlatformDefaults.GetDefaultCommandLine();
 
-        Assert.NotEmpty(commandLine);
+        Assert.IsNotEmpty(commandLine);
 
         if (OperatingSystem.IsWindows())
         {
-            Assert.Equal("powershell.exe", commandLine[0], ignoreCase: true);
+            Assert.AreEqual("powershell.exe", commandLine[0], ignoreCase: true);
             Assert.Contains("-NoLogo", commandLine, StringComparer.OrdinalIgnoreCase);
             Assert.Contains("-NoProfile", commandLine, StringComparer.OrdinalIgnoreCase);
         }
         else
         {
-            Assert.Equal("/bin/bash", commandLine[0]);
-            Assert.Single(commandLine);
+            Assert.AreEqual("/bin/bash", commandLine[0]);
+            Assert.HasCount(1, commandLine);
         }
     }
 
-    [Fact]
+    [TestMethod]
     public void TerminalHostConfig_DefaultsMatchPlatformShell()
     {
         var config = new TerminalHostConfig();
         var expected = TerminalHostPlatformDefaults.GetDefaultCommandLine();
 
-        Assert.Equal(expected[0], config.Command);
-        Assert.Equal(expected.Skip(1), config.Arguments);
+        Assert.AreEqual(expected[0], config.Command);
+        TestSeq.AreEqual(expected.Skip(1), config.Arguments);
     }
 
-    [Fact]
+    [TestMethod]
     public void NormalizeCommandLine_AddsStablePowerShellArgs_WhenNoArgumentsProvided()
     {
         var normalized = TerminalHostPlatformDefaults.NormalizeCommandLine(["pwsh.exe"]);
 
         if (OperatingSystem.IsWindows())
         {
-            Assert.Equal(["pwsh.exe", "-NoLogo", "-NoProfile"], normalized);
+            TestSeq.AreEqual(["pwsh.exe", "-NoLogo", "-NoProfile"], normalized);
         }
         else
         {
-            Assert.Equal(["pwsh.exe"], normalized);
+            TestSeq.AreEqual(["pwsh.exe"], normalized);
         }
     }
 }

--- a/tests/Hex1b.Tool.Tests/TerminalIdResolverTests.cs
+++ b/tests/Hex1b.Tool.Tests/TerminalIdResolverTests.cs
@@ -2,20 +2,21 @@ using Hex1b.Tool.Infrastructure;
 
 namespace Hex1b.Tool.Tests;
 
+[TestClass]
 public class TerminalIdResolverTests
 {
-    [Fact]
+    [TestMethod]
     public void Resolve_NoTerminals_ReturnsError()
     {
         var resolver = CreateResolver([]);
 
         var result = resolver.Resolve("123");
 
-        Assert.False(result.Success);
+        Assert.IsFalse(result.Success);
         Assert.Contains("No terminals found", result.Error);
     }
 
-    [Fact]
+    [TestMethod]
     public void Resolve_ExactMatch_ReturnsTerminal()
     {
         var resolver = CreateResolver([
@@ -24,15 +25,15 @@ public class TerminalIdResolverTests
 
         var result = resolver.Resolve("12345");
 
-        Assert.True(result.Success);
-        Assert.Equal("12345", result.Id);
-        Assert.NotNull(result.SocketPath);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual("12345", result.Id);
+        Assert.IsNotNull(result.SocketPath);
         Assert.EndsWith(".diagnostics.socket", result.SocketPath);
-        Assert.Equal("tui", result.Type);
-        Assert.Null(result.Error);
+        Assert.AreEqual("tui", result.Type);
+        Assert.IsNull(result.Error);
     }
 
-    [Fact]
+    [TestMethod]
     public void Resolve_PrefixMatch_ReturnsTerminal()
     {
         var resolver = CreateResolver([
@@ -42,11 +43,11 @@ public class TerminalIdResolverTests
 
         var result = resolver.Resolve("123");
 
-        Assert.True(result.Success);
-        Assert.Equal("12345", result.Id);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual("12345", result.Id);
     }
 
-    [Fact]
+    [TestMethod]
     public void Resolve_AmbiguousPrefix_ReturnsError()
     {
         var resolver = CreateResolver([
@@ -56,13 +57,13 @@ public class TerminalIdResolverTests
 
         var result = resolver.Resolve("123");
 
-        Assert.False(result.Success);
+        Assert.IsFalse(result.Success);
         Assert.Contains("Ambiguous", result.Error);
         Assert.Contains("12345", result.Error);
         Assert.Contains("12399", result.Error);
     }
 
-    [Fact]
+    [TestMethod]
     public void Resolve_NoMatch_ReturnsError()
     {
         var resolver = CreateResolver([
@@ -71,11 +72,11 @@ public class TerminalIdResolverTests
 
         var result = resolver.Resolve("999");
 
-        Assert.False(result.Success);
+        Assert.IsFalse(result.Success);
         Assert.Contains("No terminal found matching '999'", result.Error);
     }
 
-    [Fact]
+    [TestMethod]
     public void Resolve_CaseInsensitive_MatchesPrefix()
     {
         var resolver = CreateResolver([
@@ -84,8 +85,8 @@ public class TerminalIdResolverTests
 
         var result = resolver.Resolve("abc");
 
-        Assert.True(result.Success);
-        Assert.Equal("ABC123", result.Id);
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual("ABC123", result.Id);
     }
 
     /// <summary>

--- a/tests/Shared/TestSeq.cs
+++ b/tests/Shared/TestSeq.cs
@@ -1,15 +1,14 @@
 // Copyright (c) Hex1b contributors. Licensed under the MIT license.
 //
-// Repo-wide test helper that bridges xUnit's `Assert.Equal(coll, coll)` semantics
-// (sequence equality) to MSTest. MSTest's own `Assert.AreEqual` uses
-// `EqualityComparer<T>.Default` which on collection types collapses to reference
-// equality, while `CollectionAssert.AreEqual` requires `ICollection` rather than
-// `IEnumerable<T>`. `TestSeq` papers over both: it materialises both sides via
-// `ToList()` and delegates to `CollectionAssert`.
+// Repo-wide test helpers that provide sequence-equality assertions and a few
+// other value-returning shims on top of MSTest. MSTest's own Assert.AreEqual
+// uses EqualityComparer<T>.Default which on collection types collapses to
+// reference equality, and CollectionAssert.AreEqual requires ICollection
+// rather than IEnumerable<T>. TestSeq materialises both sides via ToList()
+// and delegates to CollectionAssert so collection comparisons "just work".
 //
-// The xunit -> mstest codemod (`eng/codemod/xunit_to_mstest.py`) rewrites
-// `Assert.Equal(a, b)` to `TestSeq.AreEqual(a, b)` whenever either argument
-// looks like a collection literal, LINQ chain, or collection-typed expression.
+// Linked into every *.Tests project via Directory.Build.props so the source
+// of truth lives once at tests/Shared/TestSeq.cs.
 
 using System.Collections.Generic;
 using System.Linq;
@@ -19,16 +18,23 @@ namespace Hex1b.Testing;
 
 internal static class TestSeq
 {
+    /// <summary>
+    /// Sequence-equality assertion over <see cref="IEnumerable{T}"/>. Materialises
+    /// both sides via <c>ToList()</c> and delegates to <see cref="CollectionAssert.AreEqual(System.Collections.ICollection, System.Collections.ICollection, string)"/>.
+    /// </summary>
     public static void AreEqual<T>(IEnumerable<T>? expected, IEnumerable<T>? actual, string? message = null)
         => CollectionAssert.AreEqual(expected?.ToList(), actual?.ToList(), message ?? string.Empty);
 
+    /// <summary>
+    /// Sequence-inequality assertion over <see cref="IEnumerable{T}"/>.
+    /// </summary>
     public static void AreNotEqual<T>(IEnumerable<T>? notExpected, IEnumerable<T>? actual, string? message = null)
         => CollectionAssert.AreNotEqual(notExpected?.ToList(), actual?.ToList(), message ?? string.Empty);
 
     /// <summary>
-    /// xUnit's <c>Assert.Single(coll)</c> returns the single element. MSTest's
-    /// <c>Assert.HasCount(1, coll)</c> returns void, so the codemod routes
-    /// `var x = Assert.Single(coll)` to `var x = TestSeq.Single(coll)`.
+    /// Assert that <paramref name="source"/> contains exactly one element, and return it.
+    /// MSTest's <c>Assert.HasCount(1, coll)</c> returns <see langword="void"/>, so this helper
+    /// wraps it and returns the single element so callers can assign / chain off it.
     /// </summary>
     public static T Single<T>(IEnumerable<T> source)
     {
@@ -37,10 +43,9 @@ internal static class TestSeq
     }
 
     /// <summary>
-    /// xUnit's <c>Assert.IsType&lt;T&gt;(value)</c> returns the cast value.
-    /// MSTest's <c>Assert.IsInstanceOfType&lt;T&gt;(value)</c> returns void,
-    /// so the codemod routes `var x = Assert.IsType&lt;T&gt;(v)` to
-    /// `var x = TestSeq.IsType&lt;T&gt;(v)`.
+    /// Assert that <paramref name="value"/> is of type <typeparamref name="T"/>, and return
+    /// the cast value. MSTest's <c>Assert.IsInstanceOfType&lt;T&gt;(value)</c> returns
+    /// <see langword="void"/>, so this helper wraps it and returns the cast value.
     /// </summary>
     public static T IsType<T>(object? value)
     {
@@ -49,8 +54,8 @@ internal static class TestSeq
     }
 
     /// <summary>
-    /// xUnit's <c>Assert.Single(coll, predicate)</c>: assert exactly one
-    /// matching element exists, and return it.
+    /// Assert that exactly one element of <paramref name="source"/> matches
+    /// <paramref name="predicate"/>, and return that element.
     /// </summary>
     public static T Single<T>(IEnumerable<T> source, Func<T, bool> predicate)
     {
@@ -60,8 +65,8 @@ internal static class TestSeq
     }
 
     /// <summary>
-    /// xUnit's <c>Assert.All(coll, action)</c>. MSTest has no equivalent;
-    /// emulate by invoking the assertion action for every element.
+    /// Apply <paramref name="action"/> to every element of <paramref name="source"/>.
+    /// Useful for asserting that every element satisfies some property.
     /// </summary>
     public static void All<T>(IEnumerable<T> source, Action<T> action)
     {
@@ -72,9 +77,8 @@ internal static class TestSeq
     }
 
     /// <summary>
-    /// xUnit's <c>Assert.Collection(coll, e1, e2, ...)</c>: assert the
-    /// collection has exactly <c>elementInspectors.Length</c> items, then
-    /// apply each inspector to the matching element by index.
+    /// Assert that <paramref name="source"/> contains exactly <paramref name="elementInspectors"/>.Length
+    /// items, then apply each inspector to the matching element by index.
     /// </summary>
     public static void Collection<T>(IEnumerable<T> source, params Action<T>[] elementInspectors)
     {
@@ -86,7 +90,7 @@ internal static class TestSeq
         }
     }
 
-    /// <summary>xUnit's <c>Assert.InRange(value, low, high)</c>.</summary>
+    /// <summary>Assert that <paramref name="actual"/> is within the inclusive range [<paramref name="low"/>, <paramref name="high"/>].</summary>
     public static void InRange<T>(T actual, T low, T high) where T : IComparable<T>
     {
         Assert.IsTrue(
@@ -94,7 +98,7 @@ internal static class TestSeq
             $"Expected {actual} to be in range [{low}, {high}].");
     }
 
-    /// <summary>xUnit's <c>Assert.Matches(pattern, input)</c>.</summary>
+    /// <summary>Assert that <paramref name="input"/> matches the regex <paramref name="pattern"/>.</summary>
     public static void Matches(string pattern, string? input)
     {
         Assert.IsNotNull(input);
@@ -103,13 +107,14 @@ internal static class TestSeq
             $"Expected input to match pattern '{pattern}'. Actual: {input}");
     }
 
-    /// <summary>xUnit's <c>Record.Exception(action)</c> — capture an exception or return null.</summary>
+    /// <summary>Run <paramref name="action"/> and return any thrown exception, or <see langword="null"/> if it completes.</summary>
     public static Exception? RecordException(Action action)
     {
         try { action(); return null; }
         catch (Exception ex) { return ex; }
     }
 
+    /// <summary>Async counterpart of <see cref="RecordException(Action)"/>.</summary>
     public static async Task<Exception?> RecordExceptionAsync(Func<Task> action)
     {
         try { await action(); return null; }
@@ -118,9 +123,10 @@ internal static class TestSeq
 }
 
 /// <summary>
-/// xUnit-style TheoryData shim. MSTest's <c>[DynamicData]</c> consumes
-/// <c>IEnumerable&lt;object[]&gt;</c>, so this acts as a drop-in replacement
-/// for xUnit's <c>TheoryData&lt;T&gt;</c> via collection-initializer syntax.
+/// Strongly-typed row collection consumed by <c>[DynamicData]</c>. Inherits
+/// from <c>List&lt;object?[]&gt;</c> so MSTest sees each row as a parameter
+/// tuple, and exposes a typed <c>Add</c> overload so test classes can use
+/// collection-initializer syntax.
 /// </summary>
 public sealed class TheoryData<T> : List<object?[]>
 {


### PR DESCRIPTION
## Summary

Migrates all five test projects from **xUnit v3** to **MSTest 4** (`MSTest.Sdk/4.2.3`) running on **Microsoft.Testing.Platform (MTP)** in `OutputType=Exe` mode.

- **7941 / 7941 tests pass** locally (149 across the small projects + 7792 in `Hex1b.Tests`, 24 skipped, 0 failures).
- Both `dotnet test` and `dotnet run --project tests/...` work as test entry points (MTP exe mode is the new default via `global.json`).

## What changed

### New / moved files
- `tests/Shared/TestSeq.cs` — repo-wide bridge helpers (`AreEqual` deep collection equality, value-returning `Single` / `IsType`, `All`, `Collection`, `InRange`, `Matches`, `RecordException[Async]`, and `TheoryData<T1..T4>` for `[DynamicData]`). Linked into every `*.Tests` project via `Directory.Build.props`.
- `global.json` — `{ "test": { "runner": "Microsoft.Testing.Platform" } }` so `dotnet test` invokes MTP, not VSTest.
- `eng/scripts/xunit_to_mstest.py` was an internal codemod; the source-of-truth converted code is what's committed here.

### Test-project csproj changes (all 5)
- `<Project Sdk="MSTest.Sdk/4.2.3">`, `<OutputType>Exe</OutputType>`, drop xUnit `PackageReference`s.
- `Hex1b.Tests.csproj` preserves all native-lib copy `<Target>`s, the `Microsoft.AspNetCore.App` framework reference, and the `Hex1b.Automation` global using.

### Conversions across ~260 test files (most via codemod, balance hand-fixed)
- `[Fact]` → `[TestMethod]`, `[Theory]/[InlineData]` → `[TestMethod]/[DataRow]`
- `[Trait]` → `[TestCategory]`; `[MemberData]` → `[DynamicData]`
- `Assert.Equal/True/False/Null/NotNull` → `Assert.AreEqual/IsTrue/IsFalse/IsNull/IsNotNull`; `Assert.Throws[Async]<T>` → `Assert.ThrowsExactly[Async]<T>`
- `Assert.Single` / `Assert.IsType<T>` (return values in xUnit, void in MSTest) → `TestSeq.Single` / `TestSeq.IsType` so the captured values still work
- `IAsyncLifetime` → `[TestInitialize]/[TestCleanup]` async pairs
- `[Collection]/[CollectionDefinition]` → `[DoNotParallelize]` on the affected classes
- `ITestOutputHelper` ctor injection → `TestContext.Current?.WriteLine(...)`
- Custom `FactAttribute` subclasses (`DockerAvailableFact`, `UnixPtyFact`) re-ported as `TestMethodAttribute` subclasses overriding `ExecuteAsync` (returning `Task<TestResult[]>`) with `Inconclusive` outcome via `AssertInconclusiveException`.

### `Directory.Build.props`
- Suppresses `MSTESTEXP`, `CS8602/CS8604`, `MSTEST0014/0030/0032/0057` for test projects (rationale in inline comments).
- Globally `<Using Include="Hex1b.Testing" />` for test projects so `TestSeq` is namespace-imported.

### CI (`.github/workflows/build-deploy.yml`, `daily-tests.yml`)
- MTP doesn't accept the legacy VSTest flags directly on `dotnet test`. Translated:
  - `--logger "trx;LogFileName=foo.trx"` → `-- --report-trx --report-trx-filename foo.trx`
  - `--results-directory ./X` and `--filter "X"` moved after the `--` separator (MTP-native).
- Output `.trx` files land in `./TestResults/` with the same filenames, so the existing `dorny/test-reporter@v1` (`reporter: dotnet-trx`) step keeps working.

### Docs / samples updated to MSTest examples
- `CONTRIBUTING.md`, `AGENTS.md`, `src/content/guide/testing.md`, `src/content/guide/mcp-server.md`
- `.github/skills/{writing-unit-tests,test-fixer,widget-creator}/SKILL.md`
- Sample content strings in `samples/AccordionDemo/Program.cs` and `samples/SharedEditor/Program.cs`

## Verification asks for this PR

This PR is primarily intended to confirm that under MSTest + MTP:

- [ ] All four `dotnet test` invocations in `build-deploy.yml` finish green on CI.
- [ ] `.trx` files are produced under `./TestResults/` with expected names.
- [ ] The `dorny/test-reporter` "Test Results (…)" check renders correctly.
- [ ] The `test-results-${{ runner.os }}` artifact uploads the TRX files.
- [ ] `daily-tests.yml` still filters out `EditorFuzzTests` correctly under the MTP `--filter` flag.

## Notes

- No `xunit*` `PackageReference` remains anywhere; verified with `grep` across all `*.csproj`/`*.props`/`*.targets` files.
- The repo has no `Directory.Packages.props` (no central package management), so there were no central-version references to remove.
- Parallelism deliberately left at MSTest's defaults (`ClassLevel`, `Workers = ProcessorCount`). Methodlevel parallel only buys ~5% on `Hex1b.Tests` because that suite is wall-clock-dominated by render-loop / input-pump waits rather than CPU; left as a future tweak.