### PR TITLE
Add WithPlaceholderWorkload for stacked terminal workloads

### DIFF
--- a/samples/PlaceholderDemo/PlaceholderDemo.csproj
+++ b/samples/PlaceholderDemo/PlaceholderDemo.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <PublishAot>true</PublishAot>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hex1b\Hex1b.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/PlaceholderDemo/Program.cs
+++ b/samples/PlaceholderDemo/Program.cs
@@ -68,4 +68,12 @@ await using var terminal = Hex1bTerminal.CreateBuilder()
     })
     .Build();
 
-await terminal.RunAsync(lifetime.Token);
+try
+{
+    await terminal.RunAsync(lifetime.Token);
+}
+catch (OperationCanceledException) when (lifetime.IsCancellationRequested)
+{
+    // Normal shutdown via Q / Ctrl-C — swallow the cancellation so the
+    // process exits cleanly instead of dumping a stack trace.
+}

--- a/samples/PlaceholderDemo/Program.cs
+++ b/samples/PlaceholderDemo/Program.cs
@@ -18,6 +18,12 @@ var socketPath = args.Length > 0
     : Path.Combine(Path.GetTempPath(), "hex1b-placeholder.sock");
 
 using var lifetime = new CancellationTokenSource();
+Console.CancelKeyPress += (_, e) =>
+{
+    e.Cancel = true;
+    lifetime.Cancel();
+};
+
 var status = "Waiting for producer at " + socketPath;
 Hex1bApp? placeholderApp = null;
 

--- a/samples/PlaceholderDemo/Program.cs
+++ b/samples/PlaceholderDemo/Program.cs
@@ -19,6 +19,7 @@ var socketPath = args.Length > 0
 
 using var lifetime = new CancellationTokenSource();
 var status = "Waiting for producer at " + socketPath;
+Hex1bApp? placeholderApp = null;
 
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithMouse()
@@ -31,6 +32,7 @@ await using var terminal = Hex1bTerminal.CreateBuilder()
             OnAttemptFailed = e =>
             {
                 status = $"Attempt {e.AttemptNumber} failed: {e.Error.GetType().Name}. Retrying in {e.NextDelay.TotalMilliseconds:0} ms…";
+                placeholderApp?.Invalidate();
             },
         }),
         opts =>
@@ -38,22 +40,26 @@ await using var terminal = Hex1bTerminal.CreateBuilder()
             opts.DisplayName = "placeholder-demo";
             opts.DefaultRole = Hmp1Role.Secondary;
         })
-    .WithPlaceholderHex1bApp((app, _) => ctx =>
-        ctx.Center(
-            ctx.VStack(v =>
-            [
-                v.Text("PTY not connected"),
-                v.Text(""),
-                v.Text(status),
-                v.Text(""),
-                v.Text("Press Q to quit"),
-            ]))
-        .Fill()
-        .InputBindings(b => b.Key(Hex1b.Input.Hex1bKey.Q).Action(_ =>
-        {
-            app.RequestStop();
-            lifetime.Cancel();
-        }, "Quit")))
+    .WithPlaceholderHex1bApp((app, _) =>
+    {
+        placeholderApp = app;
+        return ctx =>
+            ctx.Center(
+                ctx.VStack(v =>
+                [
+                    v.Text("PTY not connected"),
+                    v.Text(""),
+                    v.Text(status),
+                    v.Text(""),
+                    v.Text("Press Q to quit"),
+                ]))
+            .Fill()
+            .InputBindings(b => b.Key(Hex1b.Input.Hex1bKey.Q).Action(_ =>
+            {
+                app.RequestStop();
+                lifetime.Cancel();
+            }, "Quit"));
+    })
     .Build();
 
 await terminal.RunAsync(lifetime.Token);

--- a/samples/PlaceholderDemo/Program.cs
+++ b/samples/PlaceholderDemo/Program.cs
@@ -46,7 +46,7 @@ await using var terminal = Hex1bTerminal.CreateBuilder()
             opts.DisplayName = "placeholder-demo";
             opts.DefaultRole = Hmp1Role.Secondary;
         })
-    .WithPlaceholderHex1bApp((app, _) =>
+    .WithPlaceholderHex1bApp(app =>
     {
         placeholderApp = app;
         return ctx =>

--- a/samples/PlaceholderDemo/Program.cs
+++ b/samples/PlaceholderDemo/Program.cs
@@ -1,3 +1,4 @@
+#pragma warning disable HEX1B002 // Placeholder workload API is experimental — sample exercises experimental API.
 using System.Diagnostics;
 using Hex1b;
 using Hex1b.Input;

--- a/samples/PlaceholderDemo/Program.cs
+++ b/samples/PlaceholderDemo/Program.cs
@@ -170,7 +170,6 @@ static async Task<int> RunClientAsync(string sockPath)
 
     // Outer TUI: a thin frame around the embedded terminal.
     await using var outer = Hex1bTerminal.CreateBuilder()
-        .WithMouse()
         .WithHex1bApp(_ => { }, app =>
         {
             outerApp = app;

--- a/samples/PlaceholderDemo/Program.cs
+++ b/samples/PlaceholderDemo/Program.cs
@@ -1,0 +1,59 @@
+using Hex1b;
+using Hex1b.Widgets;
+
+// Demonstrates WithPlaceholderWorkload: the terminal runs a placeholder
+// Hex1bApp ("PTY not connected — Q to quit") until an HMP1 producer appears
+// at the configured UDS path, then swaps to the live producer. When the
+// producer goes away the placeholder comes back.
+//
+// Usage:
+//   1. In one terminal, start a producer:
+//        dotnet run --project samples/MuxerDemo -- --server /tmp/hex1b-placeholder.sock
+//   2. In another terminal, start this client (any order works — the client
+//      will wait for the socket to appear):
+//        dotnet run --project samples/PlaceholderDemo
+
+var socketPath = args.Length > 0
+    ? args[0]
+    : Path.Combine(Path.GetTempPath(), "hex1b-placeholder.sock");
+
+using var lifetime = new CancellationTokenSource();
+var status = "Waiting for producer at " + socketPath;
+
+await using var terminal = Hex1bTerminal.CreateBuilder()
+    .WithMouse()
+    .WithHmp1Client(
+        Hmp1Transports.RetryingUnixSocket(socketPath, new RetryPolicy
+        {
+            InitialDelay = TimeSpan.FromMilliseconds(200),
+            MaxDelay = TimeSpan.FromSeconds(2),
+            Multiplier = 1.5,
+            OnAttemptFailed = e =>
+            {
+                status = $"Attempt {e.AttemptNumber} failed: {e.Error.GetType().Name}. Retrying in {e.NextDelay.TotalMilliseconds:0} ms…";
+            },
+        }),
+        opts =>
+        {
+            opts.DisplayName = "placeholder-demo";
+            opts.DefaultRole = Hmp1Role.Secondary;
+        })
+    .WithPlaceholderHex1bApp((app, _) => ctx =>
+        ctx.Center(
+            ctx.VStack(v =>
+            [
+                v.Text("PTY not connected"),
+                v.Text(""),
+                v.Text(status),
+                v.Text(""),
+                v.Text("Press Q to quit"),
+            ]))
+        .Fill()
+        .InputBindings(b => b.Key(Hex1b.Input.Hex1bKey.Q).Action(_ =>
+        {
+            app.RequestStop();
+            lifetime.Cancel();
+        }, "Quit")))
+    .Build();
+
+await terminal.RunAsync(lifetime.Token);

--- a/samples/PlaceholderDemo/Program.cs
+++ b/samples/PlaceholderDemo/Program.cs
@@ -1,79 +1,220 @@
+using System.Diagnostics;
 using Hex1b;
+using Hex1b.Input;
 using Hex1b.Widgets;
 
-// Demonstrates WithPlaceholderWorkload: the terminal runs a placeholder
-// Hex1bApp ("PTY not connected — Q to quit") until an HMP1 producer appears
-// at the configured UDS path, then swaps to the live producer. When the
-// producer goes away the placeholder comes back.
+// PlaceholderDemo
 //
-// Usage:
-//   1. In one terminal, start a producer:
-//        dotnet run --project samples/MuxerDemo -- --server /tmp/hex1b-placeholder.sock
-//   2. In another terminal, start this client (any order works — the client
-//      will wait for the socket to appear):
-//        dotnet run --project samples/PlaceholderDemo
+// Self-contained demo of WithPlaceholderHex1bApp embedded inside a TUI.
+//
+// Architecture:
+//   * Outer Hex1bTerminal = a TUI (Hex1bApp) that frames an embedded
+//     TerminalWidget.
+//   * Inner Hex1bTerminal = an HMP1 client (the "primary" workload),
+//     decorated with WithPlaceholderHex1bApp(...) so that while the
+//     producer's UDS server isn't reachable, the embedded widget
+//     renders the placeholder UI ("Press R to launch shell"). When the
+//     producer becomes reachable, the placeholder swaps out for the live
+//     shell stream. When the shell exits, the OnDisconnect resume policy
+//     puts the placeholder back so the user can relaunch.
+//
+// Modes (selected via argv):
+//   --server <sockpath>   Run a PTY shell (bash/pwsh) and expose it over
+//                         HMP1 on the given UDS path. Exits when shell exits.
+//   (default)             Launch the TUI. Auto-discovers a temp socket path
+//                         and spawns itself as the server when the user
+//                         presses R in the placeholder.
 
-var socketPath = args.Length > 0
-    ? args[0]
-    : Path.Combine(Path.GetTempPath(), "hex1b-placeholder.sock");
-
-using var lifetime = new CancellationTokenSource();
-Console.CancelKeyPress += (_, e) =>
+if (args.Length >= 2 && args[0] == "--server")
 {
-    e.Cancel = true;
-    lifetime.Cancel();
-};
-
-var status = "Waiting for producer at " + socketPath;
-Hex1bApp? placeholderApp = null;
-
-await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithMouse()
-    .WithHmp1Client(
-        Hmp1Transports.RetryingUnixSocket(socketPath, new RetryPolicy
-        {
-            InitialDelay = TimeSpan.FromMilliseconds(200),
-            MaxDelay = TimeSpan.FromSeconds(2),
-            Multiplier = 1.5,
-            OnAttemptFailed = e =>
-            {
-                status = $"Attempt {e.AttemptNumber} failed: {e.Error.GetType().Name}. Retrying in {e.NextDelay.TotalMilliseconds:0} ms…";
-                placeholderApp?.Invalidate();
-            },
-        }),
-        opts =>
-        {
-            opts.DisplayName = "placeholder-demo";
-            opts.DefaultRole = Hmp1Role.Secondary;
-        })
-    .WithPlaceholderHex1bApp(app =>
-    {
-        placeholderApp = app;
-        return ctx =>
-            ctx.Center(
-                ctx.VStack(v =>
-                [
-                    v.Text("PTY not connected"),
-                    v.Text(""),
-                    v.Text(status),
-                    v.Text(""),
-                    v.Text("Press Q to quit"),
-                ]))
-            .Fill()
-            .InputBindings(b => b.Key(Hex1b.Input.Hex1bKey.Q).Action(_ =>
-            {
-                app.RequestStop();
-                lifetime.Cancel();
-            }, "Quit"));
-    })
-    .Build();
-
-try
-{
-    await terminal.RunAsync(lifetime.Token);
+    return await RunServerAsync(args[1]);
 }
-catch (OperationCanceledException) when (lifetime.IsCancellationRequested)
+
+var sockPath = args.Length >= 1
+    ? args[0]
+    : Path.Combine(Path.GetTempPath(), $"hex1b-placeholder-{Environment.ProcessId}.sock");
+
+return await RunClientAsync(sockPath);
+
+static async Task<int> RunServerAsync(string sockPath)
 {
-    // Normal shutdown via Q / Ctrl-C — swallow the cancellation so the
-    // process exits cleanly instead of dumping a stack trace.
+    try { File.Delete(sockPath); } catch { }
+
+    await using var terminal = Hex1bTerminal.CreateBuilder()
+        .WithPtyProcess(options =>
+        {
+            options.FileName = GetShell();
+            if (OperatingSystem.IsWindows())
+                options.WindowsPtyMode = WindowsPtyMode.RequireProxy;
+        })
+        .WithHmp1UdsServer(sockPath)
+        .Build();
+
+    try
+    {
+        await terminal.RunAsync();
+    }
+    finally
+    {
+        try { File.Delete(sockPath); } catch { }
+    }
+
+    return 0;
+}
+
+static async Task<int> RunClientAsync(string sockPath)
+{
+    using var lifetime = new CancellationTokenSource();
+    Console.CancelKeyPress += (_, e) =>
+    {
+        e.Cancel = true;
+        lifetime.Cancel();
+    };
+
+    Process? shellProc = null;
+    Hex1bApp? placeholderApp = null;
+    Hex1bApp? outerApp = null;
+    var status = "Press R to launch the shell.";
+
+    void UpdateStatusFromShellState()
+    {
+        if (shellProc is null)
+        {
+            status = "Press R to launch the shell.";
+        }
+        else if (shellProc.HasExited)
+        {
+            status = $"Shell exited (code {shellProc.ExitCode}). Press R to relaunch.";
+        }
+        else
+        {
+            status = "Connecting to shell…";
+        }
+
+        placeholderApp?.Invalidate();
+    }
+
+    void LaunchShellServer()
+    {
+        if (shellProc is { HasExited: false }) return;
+
+        var self = Environment.ProcessPath
+            ?? throw new InvalidOperationException("Cannot resolve current process path to relaunch as server.");
+
+        var psi = new ProcessStartInfo(self)
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        psi.ArgumentList.Add("--server");
+        psi.ArgumentList.Add(sockPath);
+
+        var proc = Process.Start(psi)
+            ?? throw new InvalidOperationException("Process.Start returned null.");
+        proc.EnableRaisingEvents = true;
+        proc.Exited += (_, _) => UpdateStatusFromShellState();
+
+        shellProc = proc;
+        UpdateStatusFromShellState();
+    }
+
+    // Inner terminal: HMP1 client (primary) decorated with a placeholder
+    // Hex1bApp. The output is surfaced to the outer TUI via WithTerminalWidget,
+    // so what the outer sees is whichever side (placeholder or shell) is
+    // currently active.
+    var innerTerminal = Hex1bTerminal.CreateBuilder()
+        .WithDimensions(80, 24)
+        .WithHmp1Client(
+            Hmp1Transports.RetryingUnixSocket(sockPath, new RetryPolicy
+            {
+                InitialDelay = TimeSpan.FromMilliseconds(150),
+                MaxDelay = TimeSpan.FromSeconds(1),
+                Multiplier = 1.5,
+                OnAttemptFailed = _ => UpdateStatusFromShellState(),
+            }),
+            opts =>
+            {
+                opts.DisplayName = "placeholder-demo";
+                opts.DefaultRole = Hmp1Role.Secondary;
+            })
+        .WithPlaceholderHex1bApp(app =>
+        {
+            placeholderApp = app;
+            return ctx =>
+                ctx.Center(
+                    ctx.VStack(v =>
+                    [
+                        v.Text("Shell not connected"),
+                        v.Text(""),
+                        v.Text(status),
+                        v.Text(""),
+                        v.Text("R = launch shell · Q = quit"),
+                        v.Text("(While shell is live, type `exit` to return here.)"),
+                    ]))
+                .Fill()
+                .InputBindings(b =>
+                {
+                    b.Key(Hex1bKey.R).Action(_ => LaunchShellServer(), "Launch shell");
+                    b.Key(Hex1bKey.Q).Action(_ =>
+                    {
+                        try { lifetime.Cancel(); } catch { }
+                    }, "Quit");
+                });
+        })
+        .WithTerminalWidget(out var termHandle)
+        .Build();
+
+    var innerTask = innerTerminal.RunAsync(lifetime.Token);
+
+    // Outer TUI: a thin frame around the embedded terminal.
+    await using var outer = Hex1bTerminal.CreateBuilder()
+        .WithMouse()
+        .WithHex1bApp(_ => { }, app =>
+        {
+            outerApp = app;
+            return ctx =>
+                ctx.Border(
+                    ctx.Terminal(termHandle).Fill())
+                .Title($"PlaceholderDemo · {sockPath}")
+                .Fill();
+        })
+        .Build();
+
+    try
+    {
+        await outer.RunAsync(lifetime.Token);
+    }
+    catch (OperationCanceledException) when (lifetime.IsCancellationRequested)
+    {
+        // Normal shutdown via Ctrl-C.
+    }
+    finally
+    {
+        try { lifetime.Cancel(); } catch { }
+
+        try { await innerTask.ConfigureAwait(false); }
+        catch (OperationCanceledException) { }
+        catch { /* swallow on shutdown */ }
+
+        await innerTerminal.DisposeAsync();
+
+        if (shellProc is { HasExited: false } running)
+        {
+            try { running.Kill(entireProcessTree: true); } catch { }
+            try { await running.WaitForExitAsync(); } catch { }
+        }
+    }
+
+    return 0;
+}
+
+static string GetShell()
+{
+    if (OperatingSystem.IsWindows())
+        return "pwsh.exe";
+
+    var shell = Environment.GetEnvironmentVariable("SHELL");
+    return !string.IsNullOrEmpty(shell) ? shell : "bash";
 }

--- a/samples/PlaceholderDemo/Program.cs
+++ b/samples/PlaceholderDemo/Program.cs
@@ -170,7 +170,7 @@ static async Task<int> RunClientAsync(string sockPath)
 
     // Outer TUI: a thin frame around the embedded terminal.
     await using var outer = Hex1bTerminal.CreateBuilder()
-        .WithHex1bApp(_ => { }, app =>
+        .WithHex1bApp(o => o.EnableMouse = true, app =>
         {
             outerApp = app;
             return ctx =>
@@ -179,6 +179,7 @@ static async Task<int> RunClientAsync(string sockPath)
                 .Title($"PlaceholderDemo · {sockPath}")
                 .Fill();
         })
+        .WithMouse()
         .Build();
 
     try

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -280,13 +280,23 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         {
             // Default: create console terminal using new architecture
             var presentation = new ConsolePresentationAdapter(enableMouse: _mouseEnabled);
-            var workload = new Hex1bAppWorkloadAdapter(presentation);
+            var workload = new Hex1bAppWorkloadAdapter(presentation) { EnableMouse = _mouseEnabled };
             _ownedTerminal = new Hex1bTerminal(new Hex1bTerminalOptions
             {
                 PresentationAdapter = presentation,
                 WorkloadAdapter = workload
             });
             _adapter = workload;
+        }
+
+        // Propagate the app's mouse-enabled option into a pre-built Hex1bAppWorkloadAdapter
+        // so it doesn't emit DECSET 1003h/1006h in EnterTuiMode unless this app actually
+        // wants mouse input. Important for embedded scenarios (e.g. placeholder inside a
+        // TerminalWidget) where those bytes would otherwise flip the host's mouse-tracking
+        // flag and persist after the placeholder is swapped out.
+        if (_adapter is Hex1bAppWorkloadAdapter appAdapter)
+        {
+            appAdapter.EnableMouse = _mouseEnabled;
         }
         
         var initialTheme = options.ThemeProvider?.Invoke() ?? options.Theme;

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -494,6 +494,19 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         {
             workloadAdapter.DiagnosticTreeProvider = this;
             _diagnosticTimingEnabled = workloadAdapter.DiagnosticTimingEnabled;
+            // Wire IRepaintableWorkloadAdapter: when an outer multiplexer
+            // (e.g. PlaceholderWorkloadAdapter) tells us the surrounding
+            // terminal state was reset out from under us, flip _isFirstFrame
+            // and invalidate so the next frame is a full repaint.
+            workloadAdapter.SetRepaintRequestHandler(() =>
+            {
+                _isFirstFrame = true;
+                _lastRenderedCursorX = -1;
+                _lastRenderedCursorY = -1;
+                _lastRenderedCursorVisible = false;
+                _lastRenderedCursorNode = null;
+                Invalidate();
+            });
         }
         
         _context.EnterAlternateScreen();
@@ -672,6 +685,14 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         {
             // Always exit alternate buffer, even on error
             _context.ExitAlternateScreen();
+
+            // Drop the repaint handler so we don't keep this app alive via
+            // the workload adapter's delegate slot if RunAsync is restarted
+            // or the host swaps adapters.
+            if (_adapter is Hex1bAppWorkloadAdapter wa)
+            {
+                wa.SetRepaintRequestHandler(null);
+            }
         }
     }
 

--- a/src/Hex1b/Hex1bAppWorkloadAdapter.cs
+++ b/src/Hex1b/Hex1bAppWorkloadAdapter.cs
@@ -79,6 +79,22 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
     internal bool DiagnosticTimingEnabled { get; set; }
 
     /// <summary>
+    /// When true, <see cref="EnterTuiMode"/> emits the DECSET sequences to enable mouse
+    /// tracking (1003) and SGR coordinates (1006), and <see cref="ExitTuiMode"/> emits
+    /// the matching DECRST sequences. When false (default) the mouse-enable bytes are
+    /// suppressed even if <see cref="TerminalCapabilities.SupportsMouse"/> is true.
+    /// <para>
+    /// This is important when the adapter is composed inside a host terminal
+    /// (for example, as the placeholder inside a <c>TerminalWidget</c>) — unconditional
+    /// mouse-enable would flip the host's mouse-tracking flag, which would then forward
+    /// host mouse events into the embedded workload even after a later swap that has
+    /// no opportunity to emit a DECRST.
+    /// </para>
+    /// Set by <see cref="Hex1bApp"/> from its <see cref="Hex1bAppOptions.EnableMouse"/>.
+    /// </summary>
+    public bool EnableMouse { get; set; }
+
+    /// <summary>
     /// Creates a new app workload adapter.
     /// </summary>
     /// <param name="capabilities">Terminal capabilities. If null, defaults with full support.</param>
@@ -410,7 +426,7 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
         var sb = new StringBuilder();
         sb.Append("\x1b[?1049h");  // Enter alternate screen
         sb.Append("\x1b[?25l");    // Hide cursor
-        if (Capabilities.SupportsMouse)
+        if (EnableMouse && Capabilities.SupportsMouse)
         {
             sb.Append("\x1b[?1003h");  // Enable mouse tracking
             sb.Append("\x1b[?1006h");  // SGR mouse mode
@@ -435,7 +451,7 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
         {
             sb.Append("\x1b[?2004l");  // Disable bracketed paste mode
         }
-        if (Capabilities.SupportsMouse)
+        if (EnableMouse && Capabilities.SupportsMouse)
         {
             sb.Append("\x1b[?1006l");  // Disable SGR mouse mode
             sb.Append("\x1b[?1003l");  // Disable mouse tracking

--- a/src/Hex1b/Hex1bAppWorkloadAdapter.cs
+++ b/src/Hex1b/Hex1bAppWorkloadAdapter.cs
@@ -34,7 +34,7 @@ namespace Hex1b;
 /// await app.RunAsync();
 /// </code>
 /// </example>
-public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, IHex1bTerminalTokenWorkloadAdapter, IDisposable
+public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, IHex1bTerminalTokenWorkloadAdapter, IRepaintableWorkloadAdapter, IDisposable
 {
     private readonly Channel<WorkloadOutputItem> _outputChannel;
     private readonly Channel<Hex1bEvent> _inputChannel;
@@ -53,6 +53,24 @@ public sealed class Hex1bAppWorkloadAdapter : IHex1bAppTerminalWorkloadAdapter, 
     /// Set by Hex1bApp when it starts running.
     /// </summary>
     internal Diagnostics.IDiagnosticTreeProvider? DiagnosticTreeProvider { get; set; }
+
+    // Callback installed by Hex1bApp.RunAsync so an outer multiplexer
+    // (e.g. PlaceholderWorkloadAdapter) can ask the app to drop diff
+    // state and emit a full screen on the next frame. Null until the
+    // owning Hex1bApp has started running.
+    private Action? _repaintRequestHandler;
+
+    /// <summary>
+    /// Installs the callback invoked by <see cref="RequestFullRepaint"/>.
+    /// Owned by <see cref="Hex1bApp"/>; set once when the app starts and
+    /// cleared on dispose. Internal because the wiring is between the
+    /// adapter and its owning Hex1bApp — external callers should go
+    /// through <see cref="IRepaintableWorkloadAdapter.RequestFullRepaint"/>.
+    /// </summary>
+    internal void SetRepaintRequestHandler(Action? handler) => _repaintRequestHandler = handler;
+
+    /// <inheritdoc />
+    public void RequestFullRepaint() => _repaintRequestHandler?.Invoke();
     
     /// <summary>
     /// When true, Hex1bApp collects per-node timing metrics during reconcile and render.

--- a/src/Hex1b/Hex1bTerminalBuilder.cs
+++ b/src/Hex1b/Hex1bTerminalBuilder.cs
@@ -1426,6 +1426,21 @@ public sealed class Hex1bTerminalBuilder
         _workloadFactory = factory;
         _workloadAdapter = null;
     }
+
+    // Accessors used by builder extensions that wrap the existing workload
+    // (e.g. WithPlaceholderWorkload). Internal so they remain implementation
+    // details of the Hex1b assembly.
+
+    internal IHex1bTerminalWorkloadAdapter? GetConfiguredWorkloadAdapter() => _workloadAdapter;
+
+    internal Func<IHex1bTerminalPresentationAdapter?, Hex1bTerminalBuildContext>? GetConfiguredWorkloadFactory()
+        => _workloadFactory;
+
+    internal void ClearConfiguredWorkload()
+    {
+        _workloadAdapter = null;
+        _workloadFactory = null;
+    }
 }
 
 /// <summary>

--- a/src/Hex1b/Hmp1/Hmp1BuilderExtensions.cs
+++ b/src/Hex1b/Hmp1/Hmp1BuilderExtensions.cs
@@ -334,4 +334,128 @@ public static class Hmp1Transports
         await socket.ConnectAsync(endpoint, ct).ConfigureAwait(false);
         return new System.Net.Sockets.NetworkStream(socket, ownsSocket: true);
     }
+
+    /// <summary>
+    /// Returns a stream factory that connects to a Unix domain socket, retrying
+    /// with bounded exponential backoff until the socket file appears and
+    /// <see cref="System.Net.Sockets.Socket.ConnectAsync(System.Net.EndPoint,CancellationToken)"/>
+    /// succeeds, or until the supplied <see cref="CancellationToken"/> is cancelled.
+    /// </summary>
+    /// <param name="path">UDS path to connect to.</param>
+    /// <param name="policy">Optional retry policy. Defaults to
+    /// <see cref="RetryPolicy.DefaultUnixSocket"/>.</param>
+    /// <remarks>
+    /// <para>
+    /// Designed for use with <see cref="Hmp1BuilderExtensions.WithHmp1Client(Hex1bTerminalBuilder, Func{CancellationToken, Task{Stream}})"/>
+    /// when the producer might not yet be listening at terminal startup time
+    /// (see also <see cref="PlaceholderWorkloadAdapter"/>).
+    /// </para>
+    /// <para>
+    /// The retry policy's <see cref="RetryPolicy.OnAttemptFailed"/> hook is invoked
+    /// per failed attempt with the attempt index, the next delay, and the
+    /// underlying exception, so a placeholder UI can surface "retrying in N s"
+    /// messaging.
+    /// </para>
+    /// </remarks>
+    public static Func<CancellationToken, Task<Stream>> RetryingUnixSocket(
+        string path,
+        RetryPolicy? policy = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        var pol = policy ?? RetryPolicy.DefaultUnixSocket;
+
+        return async ct =>
+        {
+            var attempt = 0;
+            var delay = pol.InitialDelay;
+
+            while (true)
+            {
+                ct.ThrowIfCancellationRequested();
+                attempt++;
+
+                Exception? error = null;
+                try
+                {
+                    if (File.Exists(path))
+                    {
+                        return await ConnectUnixSocket(path, ct).ConfigureAwait(false);
+                    }
+                    error = new FileNotFoundException($"UDS file '{path}' does not exist yet.", path);
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    error = ex;
+                }
+
+                if (pol.MaxAttempts > 0 && attempt >= pol.MaxAttempts)
+                {
+                    throw new IOException(
+                        $"RetryingUnixSocket gave up after {attempt} attempts connecting to '{path}'.",
+                        error);
+                }
+
+                pol.OnAttemptFailed?.Invoke(new RetryAttemptFailedEventArgs(attempt, delay, error!));
+
+                try
+                {
+                    await Task.Delay(delay, ct).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                {
+                    throw;
+                }
+
+                var nextMs = (long)(delay.TotalMilliseconds * pol.Multiplier);
+                if (nextMs > pol.MaxDelay.TotalMilliseconds)
+                {
+                    nextMs = (long)pol.MaxDelay.TotalMilliseconds;
+                }
+                delay = TimeSpan.FromMilliseconds(Math.Max(1, nextMs));
+            }
+        };
+    }
 }
+
+/// <summary>
+/// Backoff policy used by retrying transports such as
+/// <see cref="Hmp1Transports.RetryingUnixSocket(string, RetryPolicy?)"/>.
+/// </summary>
+public sealed class RetryPolicy
+{
+    /// <summary>Initial delay before the second attempt.</summary>
+    public TimeSpan InitialDelay { get; init; } = TimeSpan.FromMilliseconds(200);
+
+    /// <summary>Maximum delay between attempts.</summary>
+    public TimeSpan MaxDelay { get; init; } = TimeSpan.FromSeconds(2);
+
+    /// <summary>Multiplier applied to the delay after each failed attempt.</summary>
+    public double Multiplier { get; init; } = 1.5;
+
+    /// <summary>
+    /// Maximum number of attempts before giving up. Zero means infinite (the
+    /// default) — retries continue until the supplied <see cref="CancellationToken"/>
+    /// is cancelled.
+    /// </summary>
+    public int MaxAttempts { get; init; } = 0;
+
+    /// <summary>
+    /// Optional hook invoked after each failed attempt (before the delay).
+    /// </summary>
+    public Action<RetryAttemptFailedEventArgs>? OnAttemptFailed { get; init; }
+
+    /// <summary>
+    /// Reasonable defaults for waiting on a UDS producer to come online:
+    /// 200 ms initial, 1.5× backoff, capped at 2 s, infinite attempts.
+    /// </summary>
+    public static RetryPolicy DefaultUnixSocket { get; } = new();
+}
+
+/// <summary>
+/// Carries information about a single failed retry attempt.
+/// </summary>
+public sealed record RetryAttemptFailedEventArgs(int AttemptNumber, TimeSpan NextDelay, Exception Error);

--- a/src/Hex1b/Hmp1/Hmp1WorkloadAdapter.cs
+++ b/src/Hex1b/Hmp1/Hmp1WorkloadAdapter.cs
@@ -28,7 +28,7 @@ namespace Hex1b;
 /// <see cref="IHmp1ConnectionHandle.OnPeerLeft"/> to drive UX state.
 /// </para>
 /// </remarks>
-public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1ConnectionHandle
+public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1ConnectionHandle, IConnectableWorkloadAdapter
 {
     private readonly Hmp1ClientOptions _options;
     private readonly string _localDisplayName;
@@ -48,6 +48,14 @@ public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1Co
     // consumers (e.g. WithHmp1Client's runCallback) don't get coupled to
     // user-handler duration. See WaitForDisconnectAsync.
     private readonly TaskCompletionSource _disconnectedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    // Completed once the handshake (ClientHello → Hello → StateSync) has
+    // succeeded. Surfaced via IConnectableWorkloadAdapter so multiplexing
+    // wrappers (PlaceholderWorkloadAdapter) can react without HMP1-specific
+    // coupling. Never faults — connect failures during ConnectAsync are
+    // surfaced through the usual exception channel and leave this task
+    // pending; callers then rely on DisconnectedTask for the disconnect path.
+    private readonly TaskCompletionSource _connectedTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     /// <summary>
     /// Creates a muxer workload adapter from the supplied options bag.
@@ -218,6 +226,19 @@ public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1Co
     public Task DisconnectedTask => _disconnectedTcs.Task;
 
     /// <summary>
+    /// Completes when the HMP1 handshake (ClientHello → Hello → StateSync)
+    /// has succeeded and the read pump has been started. Implements
+    /// <see cref="IConnectableWorkloadAdapter.ConnectedTask"/>.
+    /// </summary>
+    public Task ConnectedTask => _connectedTcs.Task;
+
+    /// <summary>
+    /// True after the handshake completes and before the transport disconnects.
+    /// Implements <see cref="IConnectableWorkloadAdapter.IsConnected"/>.
+    /// </summary>
+    public bool IsConnected => _connectedTcs.Task.IsCompletedSuccessfully && !_disconnectedTcs.Task.IsCompleted;
+
+    /// <summary>
     /// Connects to the server, sends ClientHello, reads Hello and StateSync,
     /// and starts the background read pump.
     /// </summary>
@@ -290,6 +311,13 @@ public sealed class Hmp1WorkloadAdapter : IHex1bTerminalWorkloadAdapter, IHmp1Co
         // owned by DisposeAsync (and DisposeAsync alone) via _readCts.
         _readCts = new CancellationTokenSource();
         _readTask = Task.Run(() => ReadPumpAsync(_readCts.Token));
+
+        // Surface "handshake complete" to IConnectableWorkloadAdapter consumers
+        // (e.g. PlaceholderWorkloadAdapter) before invoking the user's
+        // OnConnected callback. This ordering matches DisconnectedTask, which
+        // also fires before the user's OnDisconnected callback so framework
+        // wrappers don't get coupled to user-handler duration.
+        _connectedTcs.TrySetResult();
 
         // Snapshot connected-state under the lock, raise the event without
         // holding it. Handlers run on the connecting thread and are

--- a/src/Hex1b/IConnectableWorkloadAdapter.cs
+++ b/src/Hex1b/IConnectableWorkloadAdapter.cs
@@ -1,0 +1,43 @@
+namespace Hex1b;
+
+/// <summary>
+/// Optional capability marker for <see cref="IHex1bTerminalWorkloadAdapter"/> implementations
+/// whose output cannot start until an asynchronous "connected" milestone is reached
+/// (e.g. an HMP1 handshake completes, a WebSocket opens, a remote stream is negotiated).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Used by <see cref="PlaceholderWorkloadAdapter"/> and the
+/// <c>WithPlaceholderWorkload</c> family of builder extensions to determine
+/// when to swap from a placeholder workload to the real primary.
+/// </para>
+/// <para>
+/// A workload that is ready to produce output as soon as it is constructed
+/// (a child process, a Hex1bApp, an Asciinema file) does <em>not</em> need
+/// to implement this interface — the placeholder adapter will treat such
+/// workloads as connected on the first non-empty <see cref="IHex1bTerminalWorkloadAdapter.ReadOutputAsync"/>
+/// return.
+/// </para>
+/// </remarks>
+public interface IConnectableWorkloadAdapter
+{
+    /// <summary>
+    /// Completes when the workload's connect / handshake step has finished and it
+    /// is ready to emit output. Never faults — connect failures should still leave
+    /// this task pending so callers can rely on
+    /// <see cref="DisconnectedTask"/> for the disconnect path.
+    /// </summary>
+    Task ConnectedTask { get; }
+
+    /// <summary>
+    /// Completes when the workload has disconnected (transport closed,
+    /// remote hung up, or local disposal). Never faults.
+    /// </summary>
+    Task DisconnectedTask { get; }
+
+    /// <summary>
+    /// True after <see cref="ConnectedTask"/> has completed and the
+    /// transport has not yet disconnected.
+    /// </summary>
+    bool IsConnected { get; }
+}

--- a/src/Hex1b/IRepaintableWorkloadAdapter.cs
+++ b/src/Hex1b/IRepaintableWorkloadAdapter.cs
@@ -1,0 +1,33 @@
+namespace Hex1b;
+
+/// <summary>
+/// Optional capability marker for <see cref="IHex1bTerminalWorkloadAdapter"/> implementations
+/// that maintain an internal "last frame painted" diff cache and can be asked
+/// to drop it so the next frame is emitted in full.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implemented by <see cref="Hex1bAppWorkloadAdapter"/>: when the surrounding terminal's
+/// screen state has been reset out from under the app (e.g. by
+/// <see cref="PlaceholderWorkloadAdapter"/> swapping workloads and synthesising a
+/// reset sequence), the app's diff cache no longer reflects the actual on-screen state.
+/// Calling <see cref="RequestFullRepaint"/> tells the app to behave as if the next
+/// frame is the first frame.
+/// </para>
+/// <para>
+/// Workloads whose output is fully replayed by the producer on (re)connect — HMP1's
+/// StateSync frame is the canonical case — do not need this capability.
+/// </para>
+/// </remarks>
+public interface IRepaintableWorkloadAdapter
+{
+    /// <summary>
+    /// Discards any cached diff state and requests that the workload's next frame
+    /// be emitted as a full screen repaint.
+    /// </summary>
+    /// <remarks>
+    /// Safe to call from any thread. May invalidate the workload immediately so the
+    /// repaint actually happens without waiting for the next external state change.
+    /// </remarks>
+    void RequestFullRepaint();
+}

--- a/src/Hex1b/PlaceholderWorkloadAdapter.cs
+++ b/src/Hex1b/PlaceholderWorkloadAdapter.cs
@@ -1,3 +1,5 @@
+#pragma warning disable HEX1B002 // PlaceholderResumePolicy is experimental — internal usage is allowed.
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 namespace Hex1b;
@@ -428,6 +430,7 @@ internal sealed class PlaceholderWorkloadAdapter : IHex1bTerminalWorkloadAdapter
 /// Controls what happens when the primary workload disconnects after having
 /// been active.
 /// </summary>
+[Experimental("HEX1B002", UrlFormat = "https://github.com/hex1b/hex1b/blob/main/docs/experimental/placeholder.md")]
 public enum PlaceholderResumePolicy
 {
     /// <summary>

--- a/src/Hex1b/PlaceholderWorkloadAdapter.cs
+++ b/src/Hex1b/PlaceholderWorkloadAdapter.cs
@@ -38,7 +38,7 @@ internal sealed class PlaceholderWorkloadAdapter : IHex1bTerminalWorkloadAdapter
     private static readonly ReadOnlyMemory<byte> ResetSequence =
         Encoding.ASCII.GetBytes("\u001bc\u001b[?1049l\u001b[2J\u001b[H");
 
-    private readonly IHex1bTerminalWorkloadAdapter _primary;
+    private IHex1bTerminalWorkloadAdapter _primary;
     private readonly IHex1bTerminalWorkloadAdapter _placeholder;
     private readonly Func<CancellationToken, Task<int>>? _placeholderRun;
     private readonly PlaceholderResumePolicy _resumePolicy;
@@ -102,6 +102,68 @@ internal sealed class PlaceholderWorkloadAdapter : IHex1bTerminalWorkloadAdapter
 
     /// <summary>The currently-active child (test hook).</summary>
     internal IHex1bTerminalWorkloadAdapter ActiveChild => Volatile.Read(ref _active);
+
+    /// <summary>
+    /// Replace the primary workload with a freshly-built instance. Used by
+    /// the builder layer to recover from one-shot adapters (e.g.
+    /// <see cref="Hmp1WorkloadAdapter"/>, whose read pump dies on
+    /// disconnect) so the wrapper can reconnect on subsequent attempts.
+    /// </summary>
+    /// <remarks>
+    /// Tears down the previous primary watcher, unsubscribes its
+    /// <see cref="IHex1bTerminalWorkloadAdapter.Disconnected"/> handler,
+    /// disposes it (best-effort), then installs the replacement, propagates
+    /// the last-known dimensions, and starts a fresh watcher. Active-child
+    /// state is left alone — if the wrapper was already showing the
+    /// placeholder (the typical case after a disconnect) it stays there
+    /// until the new primary signals connected.
+    /// </remarks>
+    internal async ValueTask ReplacePrimaryAsync(
+        IHex1bTerminalWorkloadAdapter newPrimary,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(newPrimary);
+        if (_disposed) return;
+
+        IHex1bTerminalWorkloadAdapter oldPrimary;
+        CancellationTokenSource? oldWatcherCts;
+        Task? oldWatcherTask;
+        bool needResize;
+        int width, height;
+
+        lock (_swapLock)
+        {
+            if (_disposed) return;
+            oldPrimary = _primary;
+            oldWatcherCts = _watcherCts;
+            oldWatcherTask = _watcherTask;
+            _primary = newPrimary;
+            _watcherCts = new CancellationTokenSource();
+            needResize = _hasSize;
+            width = _lastWidth;
+            height = _lastHeight;
+        }
+
+        oldPrimary.Disconnected -= OnPrimaryDisconnectedEvent;
+        if (oldWatcherCts is not null)
+        {
+            try { oldWatcherCts.Cancel(); } catch { }
+            try { if (oldWatcherTask is not null) await oldWatcherTask.ConfigureAwait(false); }
+            catch (OperationCanceledException) { }
+            catch { }
+            oldWatcherCts.Dispose();
+        }
+        await SafeDisposeAsync(oldPrimary).ConfigureAwait(false);
+
+        newPrimary.Disconnected += OnPrimaryDisconnectedEvent;
+        if (needResize)
+        {
+            try { await newPrimary.ResizeAsync(width, height, ct).ConfigureAwait(false); }
+            catch { }
+        }
+
+        _watcherTask = Task.Run(() => WatchPrimaryAsync(_watcherCts!.Token));
+    }
 
     public event Action? Disconnected;
 

--- a/src/Hex1b/PlaceholderWorkloadAdapter.cs
+++ b/src/Hex1b/PlaceholderWorkloadAdapter.cs
@@ -1,0 +1,334 @@
+using System.Text;
+
+namespace Hex1b;
+
+/// <summary>
+/// Multiplexes two child <see cref="IHex1bTerminalWorkloadAdapter"/>s onto a
+/// single workload slot — a <em>placeholder</em> that owns the screen until
+/// the <em>primary</em> signals it is ready, then a hand-off back to the
+/// placeholder when (or if) the primary disconnects.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Constructed by <see cref="PlaceholderWorkloadBuilderExtensions.WithPlaceholderWorkload(Hex1bTerminalBuilder, Action{Hex1bTerminalBuilder}, PlaceholderResumePolicy)"/>
+/// and friends; not intended to be instantiated directly.
+/// </para>
+/// <para>
+/// "Ready" is detected via <see cref="IConnectableWorkloadAdapter.ConnectedTask"/>
+/// when the primary opts into that contract. Otherwise the primary is treated
+/// as ready as soon as it produces its first non-empty
+/// <see cref="IHex1bTerminalWorkloadAdapter.ReadOutputAsync"/> result.
+/// </para>
+/// <para>
+/// On every swap a synthetic terminal-reset sequence (RIS + leave alt-screen +
+/// clear + cursor-home) is prepended to the now-active child's bytes so the
+/// downstream parser drops modes / SGR / scroll-region / alt-screen state
+/// from the previous occupant. If the new active is an <see cref="IRepaintableWorkloadAdapter"/>
+/// (e.g. a <see cref="Hex1bAppWorkloadAdapter"/>) <see cref="IRepaintableWorkloadAdapter.RequestFullRepaint"/>
+/// is also invoked so it discards diff state.
+/// </para>
+/// </remarks>
+internal sealed class PlaceholderWorkloadAdapter : IHex1bTerminalWorkloadAdapter
+{
+    // Hard-reset sequence prepended to each swapped-in child's first frame.
+    //   ESC c            - RIS, full reset (modes, attrs, scroll regions, alt-screen)
+    //   ESC[?1049l       - defensive: leave alternate screen if RIS handler missed it
+    //   ESC[2J           - clear screen
+    //   ESC[H            - cursor home
+    private static readonly ReadOnlyMemory<byte> ResetSequence =
+        Encoding.ASCII.GetBytes("\u001bc\u001b[?1049l\u001b[2J\u001b[H");
+
+    private readonly IHex1bTerminalWorkloadAdapter _primary;
+    private readonly IHex1bTerminalWorkloadAdapter _placeholder;
+    private readonly PlaceholderResumePolicy _resumePolicy;
+    private readonly object _swapLock = new();
+
+    private IHex1bTerminalWorkloadAdapter _active;
+    private CancellationTokenSource _swapCts = new();
+    private bool _resetPending;
+    private bool _disposed;
+
+    private int _lastWidth;
+    private int _lastHeight;
+    private bool _hasSize;
+
+    private CancellationTokenSource? _watcherCts;
+    private Task? _watcherTask;
+
+    public PlaceholderWorkloadAdapter(
+        IHex1bTerminalWorkloadAdapter primary,
+        IHex1bTerminalWorkloadAdapter placeholder,
+        PlaceholderResumePolicy resumePolicy)
+    {
+        _primary = primary ?? throw new ArgumentNullException(nameof(primary));
+        _placeholder = placeholder ?? throw new ArgumentNullException(nameof(placeholder));
+        _resumePolicy = resumePolicy;
+        _active = placeholder;
+
+        _primary.Disconnected += OnPrimaryDisconnectedEvent;
+
+        _watcherCts = new CancellationTokenSource();
+        _watcherTask = Task.Run(() => WatchPrimaryAsync(_watcherCts.Token));
+    }
+
+    /// <summary>The currently-active child (test hook).</summary>
+    internal IHex1bTerminalWorkloadAdapter ActiveChild => Volatile.Read(ref _active);
+
+    public event Action? Disconnected;
+
+    public async ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(CancellationToken ct = default)
+    {
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            // Drain a queued reset sequence first so it lands ahead of the
+            // new child's first bytes. Reset is short — single chunk is fine.
+            CancellationTokenSource swapCts;
+            IHex1bTerminalWorkloadAdapter active;
+            bool emitReset;
+            lock (_swapLock)
+            {
+                active = _active;
+                swapCts = _swapCts;
+                emitReset = _resetPending;
+                _resetPending = false;
+            }
+
+            if (emitReset)
+            {
+                if (active is IRepaintableWorkloadAdapter repaintable)
+                {
+                    repaintable.RequestFullRepaint();
+                }
+                return ResetSequence;
+            }
+
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, swapCts.Token);
+            try
+            {
+                var data = await active.ReadOutputAsync(linked.Token).ConfigureAwait(false);
+
+                // If a swap happened while we were awaiting, drop these bytes
+                // — they belong to the now-inactive child and would mix into
+                // the new child's screen.
+                if (!ReferenceEquals(Volatile.Read(ref _active), active))
+                {
+                    continue;
+                }
+
+                if (data.IsEmpty)
+                {
+                    // EOF on the active child. If that's the primary and the
+                    // resume policy allows it, fall back to the placeholder
+                    // and keep going. Otherwise propagate EOF upstream.
+                    if (ReferenceEquals(active, _primary)
+                        && _resumePolicy == PlaceholderResumePolicy.OnDisconnect)
+                    {
+                        SwapTo(_placeholder);
+                        continue;
+                    }
+
+                    Disconnected?.Invoke();
+                    return ReadOnlyMemory<byte>.Empty;
+                }
+
+                return data;
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                // Swap fired — loop and read from the new active.
+                continue;
+            }
+        }
+    }
+
+    public ValueTask WriteInputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+    {
+        return Volatile.Read(ref _active).WriteInputAsync(data, ct);
+    }
+
+    public async ValueTask ResizeAsync(int width, int height, CancellationToken ct = default)
+    {
+        lock (_swapLock)
+        {
+            _lastWidth = width;
+            _lastHeight = height;
+            _hasSize = true;
+        }
+
+        // Fan out so an inactive child's layout stays in sync with host TTY
+        // dims and renders correctly the moment it becomes active.
+        await _placeholder.ResizeAsync(width, height, ct).ConfigureAwait(false);
+        await _primary.ResizeAsync(width, height, ct).ConfigureAwait(false);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        _primary.Disconnected -= OnPrimaryDisconnectedEvent;
+
+        if (_watcherCts is { } wcts)
+        {
+            wcts.Cancel();
+            try
+            {
+                if (_watcherTask is { } wt) await wt.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { }
+            wcts.Dispose();
+        }
+
+        lock (_swapLock)
+        {
+            _swapCts.Cancel();
+            _swapCts.Dispose();
+        }
+
+        await SafeDisposeAsync(_placeholder).ConfigureAwait(false);
+        await SafeDisposeAsync(_primary).ConfigureAwait(false);
+    }
+
+    private static async ValueTask SafeDisposeAsync(IAsyncDisposable d)
+    {
+        try { await d.DisposeAsync().ConfigureAwait(false); }
+        catch { /* swallow — we're tearing down */ }
+    }
+
+    private async Task WatchPrimaryAsync(CancellationToken ct)
+    {
+        try
+        {
+            if (_primary is IConnectableWorkloadAdapter connectable)
+            {
+                // Wait for either explicit ready signal or cancellation.
+                using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                var connectedTask = connectable.ConnectedTask;
+                var cancelTask = Task.Delay(Timeout.Infinite, linked.Token);
+                var winner = await Task.WhenAny(connectedTask, cancelTask).ConfigureAwait(false);
+                if (winner == cancelTask) return;
+
+                SwapTo(_primary);
+
+                // Now wait for disconnect to potentially swap back.
+                var disconnectTask = connectable.DisconnectedTask;
+                var winner2 = await Task.WhenAny(disconnectTask, cancelTask).ConfigureAwait(false);
+                if (winner2 == cancelTask) return;
+
+                if (_resumePolicy == PlaceholderResumePolicy.OnDisconnect)
+                {
+                    SwapTo(_placeholder);
+                }
+                else
+                {
+                    Disconnected?.Invoke();
+                }
+            }
+            // For non-IConnectableWorkloadAdapter primaries the swap is
+            // driven implicitly by ReadPrimaryProbeAsync below.
+            else
+            {
+                await ProbePrimaryFirstByteAsync(ct).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) { }
+    }
+
+    // Fallback "first byte = ready" probe for primaries that don't implement
+    // IConnectableWorkloadAdapter. Reads from the primary in the background;
+    // when it returns its first non-empty chunk we swap it in and re-queue
+    // those bytes by routing them through ReadOutputAsync's normal path.
+    //
+    // Implementation note: rather than buffering the chunk (which would force
+    // ReadOutputAsync to drain a side-queue), we simply observe the primary
+    // by polling `IsCompleted` style — except `ReadOutputAsync` doesn't have
+    // that. For v1 the simple approach is: don't probe. Treat the primary as
+    // immediately-ready if it doesn't expose `IConnectableWorkloadAdapter`,
+    // i.e. swap straight to it. Most non-handshaking workloads (child PTY,
+    // Hex1bApp) are in fact ready at construction, so this matches expectations.
+    private Task ProbePrimaryFirstByteAsync(CancellationToken ct)
+    {
+        SwapTo(_primary);
+        return Task.CompletedTask;
+    }
+
+    private void OnPrimaryDisconnectedEvent()
+    {
+        // Belt-and-braces alongside ConnectedTask/DisconnectedTask: some
+        // adapters expose Disconnected without IConnectableWorkloadAdapter.
+        if (_resumePolicy == PlaceholderResumePolicy.OnDisconnect
+            && ReferenceEquals(Volatile.Read(ref _active), _primary))
+        {
+            SwapTo(_placeholder);
+        }
+    }
+
+    private void SwapTo(IHex1bTerminalWorkloadAdapter target)
+    {
+        CancellationTokenSource oldCts;
+        bool changed;
+        bool needResize;
+        int width, height;
+
+        lock (_swapLock)
+        {
+            if (_disposed) return;
+            if (ReferenceEquals(_active, target))
+            {
+                return;
+            }
+            _active = target;
+            _resetPending = true;
+            oldCts = _swapCts;
+            _swapCts = new CancellationTokenSource();
+            changed = true;
+            needResize = _hasSize;
+            width = _lastWidth;
+            height = _lastHeight;
+        }
+
+        if (changed)
+        {
+            try { oldCts.Cancel(); } catch { }
+            oldCts.Dispose();
+
+            // Make sure the newly-active child has the current host dimensions
+            // even if it was constructed before we knew the size, so its first
+            // post-RIS frame is sized correctly.
+            if (needResize)
+            {
+                _ = Task.Run(async () =>
+                {
+                    try
+                    {
+                        await target.ResizeAsync(width, height).ConfigureAwait(false);
+                    }
+                    catch { /* swallow — best effort */ }
+                });
+            }
+        }
+    }
+}
+
+/// <summary>
+/// Controls what happens when the primary workload disconnects after having
+/// been active.
+/// </summary>
+public enum PlaceholderResumePolicy
+{
+    /// <summary>
+    /// Swap back to the placeholder workload and keep the terminal alive.
+    /// Suits scenarios where the primary may reconnect (e.g. an HMP1 producer
+    /// is restarted, or a UDS path is re-bound).
+    /// </summary>
+    OnDisconnect = 0,
+
+    /// <summary>
+    /// Treat primary disconnect as terminal disconnect — surface
+    /// <see cref="IHex1bTerminalWorkloadAdapter.Disconnected"/> upstream and
+    /// stop. Matches the pre-placeholder behaviour of bare HMP1 / PTY workloads.
+    /// </summary>
+    OneShot = 1,
+}

--- a/src/Hex1b/PlaceholderWorkloadAdapter.cs
+++ b/src/Hex1b/PlaceholderWorkloadAdapter.cs
@@ -40,6 +40,7 @@ internal sealed class PlaceholderWorkloadAdapter : IHex1bTerminalWorkloadAdapter
 
     private readonly IHex1bTerminalWorkloadAdapter _primary;
     private readonly IHex1bTerminalWorkloadAdapter _placeholder;
+    private readonly Func<CancellationToken, Task<int>>? _placeholderRun;
     private readonly PlaceholderResumePolicy _resumePolicy;
     private readonly object _swapLock = new();
 
@@ -55,13 +56,26 @@ internal sealed class PlaceholderWorkloadAdapter : IHex1bTerminalWorkloadAdapter
     private CancellationTokenSource? _watcherCts;
     private Task? _watcherTask;
 
+    private CancellationTokenSource? _placeholderRunCts;
+    private Task? _placeholderRunTask;
+
     public PlaceholderWorkloadAdapter(
         IHex1bTerminalWorkloadAdapter primary,
         IHex1bTerminalWorkloadAdapter placeholder,
         PlaceholderResumePolicy resumePolicy)
+        : this(primary, placeholder, placeholderRun: null, resumePolicy)
+    {
+    }
+
+    public PlaceholderWorkloadAdapter(
+        IHex1bTerminalWorkloadAdapter primary,
+        IHex1bTerminalWorkloadAdapter placeholder,
+        Func<CancellationToken, Task<int>>? placeholderRun,
+        PlaceholderResumePolicy resumePolicy)
     {
         _primary = primary ?? throw new ArgumentNullException(nameof(primary));
         _placeholder = placeholder ?? throw new ArgumentNullException(nameof(placeholder));
+        _placeholderRun = placeholderRun;
         _resumePolicy = resumePolicy;
         _active = placeholder;
 
@@ -69,6 +83,21 @@ internal sealed class PlaceholderWorkloadAdapter : IHex1bTerminalWorkloadAdapter
 
         _watcherCts = new CancellationTokenSource();
         _watcherTask = Task.Run(() => WatchPrimaryAsync(_watcherCts.Token));
+
+        // Drive the placeholder's "run" loop (typically a Hex1bApp.RunAsync) so
+        // it actually produces frames into its workload adapter — otherwise the
+        // adapter's output channel stays empty and ReadOutputAsync would block
+        // forever waiting on a child that has nothing to say.
+        if (_placeholderRun is { } run)
+        {
+            _placeholderRunCts = new CancellationTokenSource();
+            _placeholderRunTask = Task.Run(async () =>
+            {
+                try { await run(_placeholderRunCts.Token).ConfigureAwait(false); }
+                catch (OperationCanceledException) { }
+                catch { /* swallow — we're a background helper */ }
+            });
+        }
     }
 
     /// <summary>The currently-active child (test hook).</summary>
@@ -161,6 +190,16 @@ internal sealed class PlaceholderWorkloadAdapter : IHex1bTerminalWorkloadAdapter
         // dims and renders correctly the moment it becomes active.
         await _placeholder.ResizeAsync(width, height, ct).ConfigureAwait(false);
         await _primary.ResizeAsync(width, height, ct).ConfigureAwait(false);
+
+        // For Hex1bApp-style children, the very first resize sets dimensions
+        // but doesn't fire a Hex1bResizeEvent (treated as initial setup). Without
+        // that wake-up the app's render loop sleeps after its inaugural 0x0
+        // frame and the user never sees the placeholder UI. Forcing a repaint
+        // here invalidates the app and wakes the loop so it re-renders at the
+        // newly-known dimensions. Safe for child-process style children that
+        // don't implement IRepaintableWorkloadAdapter.
+        if (_placeholder is IRepaintableWorkloadAdapter ph) ph.RequestFullRepaint();
+        if (_primary is IRepaintableWorkloadAdapter pr) pr.RequestFullRepaint();
     }
 
     public async ValueTask DisposeAsync()
@@ -179,6 +218,17 @@ internal sealed class PlaceholderWorkloadAdapter : IHex1bTerminalWorkloadAdapter
             }
             catch (OperationCanceledException) { }
             wcts.Dispose();
+        }
+
+        if (_placeholderRunCts is { } pcts)
+        {
+            pcts.Cancel();
+            try
+            {
+                if (_placeholderRunTask is { } pt) await pt.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { }
+            pcts.Dispose();
         }
 
         lock (_swapLock)

--- a/src/Hex1b/PlaceholderWorkloadBuilderExtensions.cs
+++ b/src/Hex1b/PlaceholderWorkloadBuilderExtensions.cs
@@ -1,0 +1,133 @@
+namespace Hex1b;
+
+/// <summary>
+/// Builder extensions for configuring a placeholder workload that drives the
+/// terminal until the real ("primary") workload signals it is ready.
+/// </summary>
+public static class PlaceholderWorkloadBuilderExtensions
+{
+    /// <summary>
+    /// Wraps the already-configured workload (the <em>primary</em>) with a
+    /// <see cref="PlaceholderWorkloadAdapter"/> that initially streams from
+    /// the <em>placeholder</em> workload built by <paramref name="configurePlaceholder"/>,
+    /// then swaps to the primary once it is ready.
+    /// </summary>
+    /// <param name="builder">The terminal builder whose primary workload is being decorated.</param>
+    /// <param name="configurePlaceholder">
+    /// Configures the placeholder using a fresh <see cref="Hex1bTerminalBuilder"/>.
+    /// Only workload-shaped configuration is honoured (e.g. <c>WithHex1bApp</c>);
+    /// presentation, mouse, scrollback and filter settings on the inner builder
+    /// are ignored — the outer terminal owns those.
+    /// </param>
+    /// <param name="resumePolicy">
+    /// What to do if the primary workload disconnects after going active.
+    /// Defaults to <see cref="PlaceholderResumePolicy.OnDisconnect"/>.
+    /// </param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when no primary workload has been configured on
+    /// <paramref name="builder"/> before this call.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// The placeholder is treated as the source of truth for the screen until
+    /// the primary's <see cref="IConnectableWorkloadAdapter.ConnectedTask"/>
+    /// completes (or the primary first appears, for non-connectable workloads).
+    /// On each swap a terminal-reset sequence is prepended to the new active's
+    /// bytes so the parser drops modes / SGR / scroll-region / alt-screen state
+    /// from the previous occupant.
+    /// </para>
+    /// <para>
+    /// This must be called <strong>after</strong> the primary workload has been
+    /// configured (e.g. via <c>WithHmp1UdsClient</c>, <c>WithShellProcess</c>,
+    /// <c>WithHex1bApp</c>, etc.). Calling it earlier throws.
+    /// </para>
+    /// </remarks>
+    public static Hex1bTerminalBuilder WithPlaceholderWorkload(
+        this Hex1bTerminalBuilder builder,
+        Action<Hex1bTerminalBuilder> configurePlaceholder,
+        PlaceholderResumePolicy resumePolicy = PlaceholderResumePolicy.OnDisconnect)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configurePlaceholder);
+
+        var primaryFactory = builder.GetConfiguredWorkloadFactory();
+        var primaryAdapter = builder.GetConfiguredWorkloadAdapter();
+
+        if (primaryFactory is null && primaryAdapter is null)
+        {
+            throw new InvalidOperationException(
+                "WithPlaceholderWorkload must be called after the primary workload has been configured " +
+                "(e.g. WithHmp1UdsClient, WithShellProcess, WithHex1bApp).");
+        }
+
+        // Build the placeholder eagerly through its own builder so callers
+        // can use the standard With* vocabulary; we only need the resulting
+        // workload adapter — presentation/scrollback/etc. on the inner
+        // builder are ignored on purpose.
+        var placeholderBuilder = new Hex1bTerminalBuilder();
+        configurePlaceholder(placeholderBuilder);
+
+        var placeholderFactory = placeholderBuilder.GetConfiguredWorkloadFactory();
+        var placeholderAdapterDirect = placeholderBuilder.GetConfiguredWorkloadAdapter();
+
+        if (placeholderFactory is null && placeholderAdapterDirect is null)
+        {
+            throw new InvalidOperationException(
+                "WithPlaceholderWorkload's configurePlaceholder callback must configure a workload on the inner builder.");
+        }
+
+        builder.ClearConfiguredWorkload();
+        builder.SetWorkloadFactory(presentation =>
+        {
+            IHex1bTerminalWorkloadAdapter primary;
+            Func<CancellationToken, Task<int>>? primaryRun = null;
+            if (primaryFactory != null)
+            {
+                var ctx = primaryFactory(presentation);
+                primary = ctx.WorkloadAdapter;
+                primaryRun = ctx.RunCallback;
+            }
+            else
+            {
+                primary = primaryAdapter!;
+            }
+
+            IHex1bTerminalWorkloadAdapter placeholder;
+            if (placeholderFactory != null)
+            {
+                // Placeholder shouldn't see the outer presentation adapter — it
+                // doesn't drive the screen directly; it produces bytes consumed
+                // by PlaceholderWorkloadAdapter.
+                var ctx = placeholderFactory(null);
+                placeholder = ctx.WorkloadAdapter;
+            }
+            else
+            {
+                placeholder = placeholderAdapterDirect!;
+            }
+
+            var wrapped = new PlaceholderWorkloadAdapter(primary, placeholder, resumePolicy);
+            return new Hex1bTerminalBuildContext(wrapped, primaryRun);
+        });
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Convenience overload that configures a <see cref="Hex1bApp"/> as the placeholder.
+    /// </summary>
+    /// <param name="builder">The terminal builder whose primary workload is being decorated.</param>
+    /// <param name="configure">A standard <c>WithHex1bApp</c>-shaped configuration callback.</param>
+    /// <param name="resumePolicy">
+    /// What to do if the primary workload disconnects after going active.
+    /// Defaults to <see cref="PlaceholderResumePolicy.OnDisconnect"/>.
+    /// </param>
+    public static Hex1bTerminalBuilder WithPlaceholderHex1bApp(
+        this Hex1bTerminalBuilder builder,
+        Func<Hex1bApp, Hex1bAppOptions, Func<RootContext, Hex1b.Widgets.Hex1bWidget>> configure,
+        PlaceholderResumePolicy resumePolicy = PlaceholderResumePolicy.OnDisconnect)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        return builder.WithPlaceholderWorkload(b => b.WithHex1bApp(configure), resumePolicy);
+    }
+}

--- a/src/Hex1b/PlaceholderWorkloadBuilderExtensions.cs
+++ b/src/Hex1b/PlaceholderWorkloadBuilderExtensions.cs
@@ -1,9 +1,12 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Hex1b;
 
 /// <summary>
 /// Builder extensions for configuring a placeholder workload that drives the
 /// terminal until the real ("primary") workload signals it is ready.
 /// </summary>
+[Experimental("HEX1B002", UrlFormat = "https://github.com/hex1b/hex1b/blob/main/docs/experimental/placeholder.md")]
 public static class PlaceholderWorkloadBuilderExtensions
 {
     /// <summary>

--- a/src/Hex1b/PlaceholderWorkloadBuilderExtensions.cs
+++ b/src/Hex1b/PlaceholderWorkloadBuilderExtensions.cs
@@ -109,7 +109,29 @@ public static class PlaceholderWorkloadBuilderExtensions
             }
 
             var wrapped = new PlaceholderWorkloadAdapter(primary, placeholder, placeholderRun, resumePolicy);
-            return new Hex1bTerminalBuildContext(wrapped, primaryRun);
+
+            // Compose a terminal-level run callback. The primary's own run
+            // callback (e.g. HMP1's "wait until DisconnectedTask") returns
+            // when the primary goes away — but under OnDisconnect we want
+            // the terminal to *stay alive* so the wrapper can swap back to
+            // the placeholder. Keep waiting on ct in that case; only ct
+            // cancellation tears down the terminal. Under OneShot, primary
+            // disconnect propagates as terminal exit (legacy behaviour).
+            Func<CancellationToken, Task<int>>? composedRun = primaryRun is null
+                ? null
+                : async ct =>
+                {
+                    var exit = await primaryRun(ct).ConfigureAwait(false);
+                    if (resumePolicy == PlaceholderResumePolicy.OnDisconnect
+                        && !ct.IsCancellationRequested)
+                    {
+                        try { await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false); }
+                        catch (OperationCanceledException) { }
+                    }
+                    return exit;
+                };
+
+            return new Hex1bTerminalBuildContext(wrapped, composedRun);
         });
 
         return builder;

--- a/src/Hex1b/PlaceholderWorkloadBuilderExtensions.cs
+++ b/src/Hex1b/PlaceholderWorkloadBuilderExtensions.cs
@@ -93,6 +93,7 @@ public static class PlaceholderWorkloadBuilderExtensions
             }
 
             IHex1bTerminalWorkloadAdapter placeholder;
+            Func<CancellationToken, Task<int>>? placeholderRun = null;
             if (placeholderFactory != null)
             {
                 // Placeholder shouldn't see the outer presentation adapter — it
@@ -100,13 +101,14 @@ public static class PlaceholderWorkloadBuilderExtensions
                 // by PlaceholderWorkloadAdapter.
                 var ctx = placeholderFactory(null);
                 placeholder = ctx.WorkloadAdapter;
+                placeholderRun = ctx.RunCallback;
             }
             else
             {
                 placeholder = placeholderAdapterDirect!;
             }
 
-            var wrapped = new PlaceholderWorkloadAdapter(primary, placeholder, resumePolicy);
+            var wrapped = new PlaceholderWorkloadAdapter(primary, placeholder, placeholderRun, resumePolicy);
             return new Hex1bTerminalBuildContext(wrapped, primaryRun);
         });
 

--- a/src/Hex1b/PlaceholderWorkloadBuilderExtensions.cs
+++ b/src/Hex1b/PlaceholderWorkloadBuilderExtensions.cs
@@ -111,25 +111,63 @@ public static class PlaceholderWorkloadBuilderExtensions
             var wrapped = new PlaceholderWorkloadAdapter(primary, placeholder, placeholderRun, resumePolicy);
 
             // Compose a terminal-level run callback. The primary's own run
-            // callback (e.g. HMP1's "wait until DisconnectedTask") returns
-            // when the primary goes away — but under OnDisconnect we want
-            // the terminal to *stay alive* so the wrapper can swap back to
-            // the placeholder. Keep waiting on ct in that case; only ct
-            // cancellation tears down the terminal. Under OneShot, primary
-            // disconnect propagates as terminal exit (legacy behaviour).
-            Func<CancellationToken, Task<int>>? composedRun = primaryRun is null
-                ? null
-                : async ct =>
+            // callback (e.g. HMP1's "ConnectAsync then await DisconnectedTask")
+            // returns the moment the producer goes away — but most workload
+            // adapters (HMP1 included) are one-shot and can't be reconnected
+            // on the same instance. Under OnDisconnect we therefore rebuild
+            // the primary via its factory and hand the fresh instance to the
+            // wrapper, which re-runs its connected/disconnected watcher and
+            // re-streams output from the new primary as soon as it connects.
+            // Loop terminates only when ct is cancelled (Q / Ctrl-C) or the
+            // resume policy is OneShot.
+            Func<CancellationToken, Task<int>>? composedRun;
+            if (primaryRun is null)
+            {
+                composedRun = null;
+            }
+            else if (resumePolicy == PlaceholderResumePolicy.OneShot
+                     || primaryFactory is null)
+            {
+                // OneShot: legacy "primary disconnect = terminal exit".
+                // Or no factory available (caller passed a pre-built adapter,
+                // not a factory) — we have no way to rebuild, so behave as
+                // OneShot regardless of policy.
+                composedRun = primaryRun;
+            }
+            else
+            {
+                var currentRun = primaryRun;
+                composedRun = async ct =>
                 {
-                    var exit = await primaryRun(ct).ConfigureAwait(false);
-                    if (resumePolicy == PlaceholderResumePolicy.OnDisconnect
-                        && !ct.IsCancellationRequested)
+                    var lastExit = 0;
+                    while (true)
                     {
-                        try { await Task.Delay(Timeout.Infinite, ct).ConfigureAwait(false); }
-                        catch (OperationCanceledException) { }
+                        try
+                        {
+                            lastExit = await currentRun(ct).ConfigureAwait(false);
+                        }
+                        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+                        {
+                            throw;
+                        }
+                        catch
+                        {
+                            // Connect / read failures bubble out of primaryRun;
+                            // swallow them so the placeholder UI keeps running
+                            // and the next rebuild gets a chance to reconnect.
+                        }
+
+                        if (ct.IsCancellationRequested) break;
+
+                        // Rebuild the primary and hand it to the wrapper.
+                        var newCtx = primaryFactory(presentation);
+                        await wrapped.ReplacePrimaryAsync(newCtx.WorkloadAdapter, ct)
+                            .ConfigureAwait(false);
+                        currentRun = newCtx.RunCallback ?? (_ => Task.FromResult(0));
                     }
-                    return exit;
+                    return lastExit;
                 };
+            }
 
             return new Hex1bTerminalBuildContext(wrapped, composedRun);
         });
@@ -142,16 +180,19 @@ public static class PlaceholderWorkloadBuilderExtensions
     /// </summary>
     /// <param name="builder">The terminal builder whose primary workload is being decorated.</param>
     /// <param name="configure">A standard <c>WithHex1bApp</c>-shaped configuration callback.</param>
+    /// <param name="configureOptions">Optional <see cref="Hex1bAppOptions"/> configurator.</param>
     /// <param name="resumePolicy">
     /// What to do if the primary workload disconnects after going active.
     /// Defaults to <see cref="PlaceholderResumePolicy.OnDisconnect"/>.
     /// </param>
     public static Hex1bTerminalBuilder WithPlaceholderHex1bApp(
         this Hex1bTerminalBuilder builder,
-        Func<Hex1bApp, Hex1bAppOptions, Func<RootContext, Hex1b.Widgets.Hex1bWidget>> configure,
+        Func<Hex1bApp, Func<RootContext, Hex1b.Widgets.Hex1bWidget>> configure,
+        Action<Hex1bAppOptions>? configureOptions = null,
         PlaceholderResumePolicy resumePolicy = PlaceholderResumePolicy.OnDisconnect)
     {
         ArgumentNullException.ThrowIfNull(configure);
-        return builder.WithPlaceholderWorkload(b => b.WithHex1bApp(configure), resumePolicy);
+        var opts = configureOptions ?? (_ => { });
+        return builder.WithPlaceholderWorkload(b => b.WithHex1bApp(opts, configure), resumePolicy);
     }
 }

--- a/src/Hex1b/TerminalWidgetHandle.cs
+++ b/src/Hex1b/TerminalWidgetHandle.cs
@@ -321,6 +321,22 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
     }
     
     /// <summary>
+    /// Handles RIS (Reset to Initial State, ESC c) — clears terminal state that
+    /// influences input forwarding. Mirrors the contract of the underlying terminal:
+    /// after RIS no DECSET modes from the previous workload are still in effect.
+    /// Without this, a placeholder workload that enabled mouse tracking (or alt-screen)
+    /// would leave those flags latched even after a swap that prepends RIS.
+    /// </summary>
+    private void HandleRisToken()
+    {
+        _mouseTrackingEnabled = false;
+        _sgrMouseModeEnabled = false;
+        _inAlternateScreen = false;
+        _cursorVisible = true;
+        _cursorShape = CursorShape.Default;
+    }
+    
+    /// <summary>
     /// Handles private mode tokens to track mouse and cursor state changes.
     /// </summary>
     private void HandlePrivateModeToken(PrivateModeToken pm)
@@ -601,6 +617,8 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
                 {
                     if (applied.Token is PrivateModeToken pm)
                         HandlePrivateModeToken(pm);
+                    else if (applied.Token is RisToken)
+                        HandleRisToken();
                     else if (applied.Token is CursorShapeToken cst)
                         HandleCursorShapeToken(cst);
                     else if (applied.Token is OscToken osc)
@@ -626,6 +644,10 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
                 if (applied.Token is PrivateModeToken pm)
                 {
                     HandlePrivateModeToken(pm);
+                }
+                else if (applied.Token is RisToken)
+                {
+                    HandleRisToken();
                 }
                 else if (applied.Token is CursorShapeToken cst)
                 {

--- a/tests/Hex1b.Tests/Hex1bAppWorkloadAdapterMouseModeTests.cs
+++ b/tests/Hex1b.Tests/Hex1bAppWorkloadAdapterMouseModeTests.cs
@@ -1,0 +1,84 @@
+using System.Text;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Regression tests for <see cref="Hex1bAppWorkloadAdapter"/>'s TUI mode sequences,
+/// specifically that mouse-enable bytes are only emitted when <see cref="Hex1bAppWorkloadAdapter.EnableMouse"/>
+/// is set. This matters for embedded usage (e.g. an app used as a <c>WithPlaceholderHex1bApp</c>):
+/// unconditional mouse-enable would flip the host's <c>TerminalWidgetHandle._mouseTrackingEnabled</c>
+/// and leak host mouse events into the embedded workload after a swap.
+/// </summary>
+[TestClass]
+public class Hex1bAppWorkloadAdapterMouseModeTests
+{
+    private static string Drain(Hex1bAppWorkloadAdapter adapter)
+    {
+        var sb = new StringBuilder();
+        while (adapter.TryReadOutput(out var data))
+        {
+            sb.Append(Encoding.UTF8.GetString(data.Span));
+        }
+        return sb.ToString();
+    }
+
+    [TestMethod]
+    public void EnterTuiMode_DoesNotEmitMouseEnable_WhenEnableMouseIsFalse()
+    {
+        var adapter = new Hex1bAppWorkloadAdapter();
+        Assert.IsFalse(adapter.EnableMouse, "Precondition: EnableMouse defaults to false.");
+
+        adapter.EnterTuiMode();
+        var output = Drain(adapter);
+
+        StringAssert.Contains(output, "\x1b[?1049h", "Should still enter alternate screen.");
+        Assert.IsFalse(output.Contains("\x1b[?1003h"),
+            "Mouse-enable DECSET 1003h must not be emitted when EnableMouse is false. " +
+            "Otherwise an embedded host TerminalWidgetHandle will latch mouse-tracking on and forward host mouse events to the workload.");
+        Assert.IsFalse(output.Contains("\x1b[?1006h"),
+            "SGR mouse mode DECSET 1006h must not be emitted when EnableMouse is false.");
+    }
+
+    [TestMethod]
+    public void EnterTuiMode_EmitsMouseEnable_WhenEnableMouseIsTrue()
+    {
+        var adapter = new Hex1bAppWorkloadAdapter { EnableMouse = true };
+
+        adapter.EnterTuiMode();
+        var output = Drain(adapter);
+
+        StringAssert.Contains(output, "\x1b[?1003h");
+        StringAssert.Contains(output, "\x1b[?1006h");
+    }
+
+    [TestMethod]
+    public void ExitTuiMode_DoesNotEmitMouseDisable_WhenEnableMouseIsFalse()
+    {
+        var adapter = new Hex1bAppWorkloadAdapter();
+        adapter.EnterTuiMode();
+        _ = Drain(adapter);
+
+        adapter.ExitTuiMode();
+        var output = Drain(adapter);
+
+        Assert.IsFalse(output.Contains("\x1b[?1003l"),
+            "Mouse-disable should not be emitted when mouse was never enabled.");
+        Assert.IsFalse(output.Contains("\x1b[?1006l"),
+            "SGR mouse-disable should not be emitted when mouse was never enabled.");
+        StringAssert.Contains(output, "\x1b[?1049l", "Should still exit alternate screen.");
+    }
+
+    [TestMethod]
+    public void ExitTuiMode_EmitsMouseDisable_WhenEnableMouseIsTrue()
+    {
+        var adapter = new Hex1bAppWorkloadAdapter { EnableMouse = true };
+        adapter.EnterTuiMode();
+        _ = Drain(adapter);
+
+        adapter.ExitTuiMode();
+        var output = Drain(adapter);
+
+        StringAssert.Contains(output, "\x1b[?1003l");
+        StringAssert.Contains(output, "\x1b[?1006l");
+    }
+}

--- a/tests/Hex1b.Tests/PlaceholderWorkloadAdapterTests.cs
+++ b/tests/Hex1b.Tests/PlaceholderWorkloadAdapterTests.cs
@@ -1,3 +1,4 @@
+#pragma warning disable HEX1B002 // Placeholder workload API is experimental — testing experimental API.
 using System.Text;
 using System.Threading.Channels;
 using Hex1b;

--- a/tests/Hex1b.Tests/PlaceholderWorkloadAdapterTests.cs
+++ b/tests/Hex1b.Tests/PlaceholderWorkloadAdapterTests.cs
@@ -1,0 +1,240 @@
+using System.Text;
+using System.Threading.Channels;
+using Hex1b;
+using Xunit;
+
+namespace Hex1b.Tests;
+
+public class PlaceholderWorkloadAdapterTests
+{
+    [Fact]
+    public async Task ReadOutputAsync_StartsFromPlaceholder_BeforePrimaryConnects()
+    {
+        var primary = new FakeConnectableAdapter();
+        var placeholder = new FakeAdapter();
+        placeholder.EnqueueOutput("PLACEHOLDER"u8.ToArray());
+
+        await using var adapter = new PlaceholderWorkloadAdapter(
+            primary, placeholder, PlaceholderResumePolicy.OnDisconnect);
+
+        var data = await adapter.ReadOutputAsync(TestCancel());
+        Assert.Equal("PLACEHOLDER", Encoding.UTF8.GetString(data.Span));
+        Assert.Same(placeholder, adapter.ActiveChild);
+    }
+
+    [Fact]
+    public async Task ReadOutputAsync_OnPrimaryConnected_PrependsResetThenStreamsPrimary()
+    {
+        var primary = new FakeConnectableAdapter();
+        var placeholder = new FakeAdapter();
+        primary.EnqueueOutput("PRIMARY"u8.ToArray());
+
+        await using var adapter = new PlaceholderWorkloadAdapter(
+            primary, placeholder, PlaceholderResumePolicy.OnDisconnect);
+
+        primary.SignalConnected();
+
+        // First read after swap should be the reset sequence: ESC c + ESC[?1049l + ESC[2J + ESC[H.
+        var first = await adapter.ReadOutputAsync(TestCancel());
+        AssertContainsSequence(first, new byte[] { 0x1b, (byte)'c' });
+        AssertContainsSequence(first, "\x1b[?1049l"u8);
+
+        var second = await adapter.ReadOutputAsync(TestCancel());
+        Assert.Equal("PRIMARY"u8.ToArray(), second.ToArray());
+        Assert.Same(primary, adapter.ActiveChild);
+    }
+
+    [Fact]
+    public async Task ReadOutputAsync_OnPrimaryDisconnect_ReturnsToPlaceholder_WhenPolicyOnDisconnect()
+    {
+        var primary = new FakeConnectableAdapter();
+        var placeholder = new FakeAdapter();
+        primary.EnqueueOutput("HI"u8.ToArray());
+
+        await using var adapter = new PlaceholderWorkloadAdapter(
+            primary, placeholder, PlaceholderResumePolicy.OnDisconnect);
+
+        primary.SignalConnected();
+        _ = await adapter.ReadOutputAsync(TestCancel()); // reset
+        _ = await adapter.ReadOutputAsync(TestCancel()); // "HI"
+
+        primary.SignalDisconnected();
+        // Reset for swap-back to placeholder.
+        var resetBack = await adapter.ReadOutputAsync(TestCancel());
+        AssertContainsSequence(resetBack, new byte[] { 0x1b, (byte)'c' });
+
+        // Enqueue placeholder content only after the swap-back so the read
+        // above can't race-consume it from the placeholder channel before
+        // the swap completed.
+        placeholder.EnqueueOutput("BACK"u8.ToArray());
+        var placeholderAgain = await adapter.ReadOutputAsync(TestCancel());
+        Assert.Equal("BACK"u8.ToArray(), placeholderAgain.ToArray());
+        Assert.Same(placeholder, adapter.ActiveChild);
+    }
+
+    [Fact]
+    public async Task ReadOutputAsync_OneShotPolicy_StopsOnPrimaryDisconnect()
+    {
+        var primary = new FakeConnectableAdapter();
+        var placeholder = new FakeAdapter();
+        primary.EnqueueOutput("HI"u8.ToArray());
+
+        await using var adapter = new PlaceholderWorkloadAdapter(
+            primary, placeholder, PlaceholderResumePolicy.OneShot);
+
+        var disconnected = false;
+        adapter.Disconnected += () => disconnected = true;
+
+        primary.SignalConnected();
+        _ = await adapter.ReadOutputAsync(TestCancel()); // reset
+        _ = await adapter.ReadOutputAsync(TestCancel()); // "HI"
+        primary.CompleteOutput();
+        primary.SignalDisconnected();
+
+        var trailing = await adapter.ReadOutputAsync(TestCancel());
+        Assert.True(trailing.IsEmpty);
+        Assert.True(disconnected);
+    }
+
+    [Fact]
+    public async Task WriteInputAsync_OnlyDeliveredToActiveChild()
+    {
+        var primary = new FakeConnectableAdapter();
+        var placeholder = new FakeAdapter();
+
+        await using var adapter = new PlaceholderWorkloadAdapter(
+            primary, placeholder, PlaceholderResumePolicy.OnDisconnect);
+
+        await adapter.WriteInputAsync(new byte[] { 1 });
+        Assert.Equal(1, placeholder.WrittenInputCount);
+        Assert.Equal(0, primary.WrittenInputCount);
+
+        primary.EnqueueOutput("X"u8.ToArray());
+        primary.SignalConnected();
+        _ = await adapter.ReadOutputAsync(TestCancel()); // reset
+        _ = await adapter.ReadOutputAsync(TestCancel()); // X — confirms swap
+
+        await adapter.WriteInputAsync(new byte[] { 2 });
+        Assert.Equal(1, placeholder.WrittenInputCount);
+        Assert.Equal(1, primary.WrittenInputCount);
+    }
+
+    [Fact]
+    public async Task ResizeAsync_FansOutToBothChildren()
+    {
+        var primary = new FakeConnectableAdapter();
+        var placeholder = new FakeAdapter();
+        await using var adapter = new PlaceholderWorkloadAdapter(
+            primary, placeholder, PlaceholderResumePolicy.OnDisconnect);
+
+        await adapter.ResizeAsync(100, 40);
+        Assert.Equal((100, 40), placeholder.LastResize);
+        Assert.Equal((100, 40), primary.LastResize);
+    }
+
+    [Fact]
+    public async Task SwapToRepaintable_InvokesRequestFullRepaint()
+    {
+        var primary = new RepaintablePrimary();
+        var placeholder = new FakeAdapter();
+        await using var adapter = new PlaceholderWorkloadAdapter(
+            primary, placeholder, PlaceholderResumePolicy.OnDisconnect);
+
+        primary.EnqueueOutput("X"u8.ToArray());
+        primary.SignalConnected();
+        _ = await adapter.ReadOutputAsync(TestCancel()); // reset (and triggers repaint)
+
+        Assert.Equal(1, primary.RepaintRequests);
+    }
+
+    private static CancellationToken TestCancel() =>
+        new CancellationTokenSource(TimeSpan.FromSeconds(5)).Token;
+
+    private static void AssertContainsSequence(ReadOnlyMemory<byte> haystack, ReadOnlySpan<byte> needle)
+    {
+        var hs = haystack.ToArray();
+        for (var i = 0; i + needle.Length <= hs.Length; i++)
+        {
+            if (hs.AsSpan(i, needle.Length).SequenceEqual(needle)) return;
+        }
+        Assert.Fail($"Byte sequence not found. Haystack ({hs.Length} bytes): " +
+            string.Join(' ', hs.Select(b => b.ToString("x2"))) +
+            $"; Needle ({needle.Length} bytes): " +
+            string.Join(' ', needle.ToArray().Select(b => b.ToString("x2"))));
+    }
+
+    // ---- fakes ----
+
+    private class FakeAdapter : IHex1bTerminalWorkloadAdapter
+    {
+        private readonly Channel<ReadOnlyMemory<byte>> _out =
+            Channel.CreateUnbounded<ReadOnlyMemory<byte>>();
+
+        public int WrittenInputCount;
+        public (int, int)? LastResize;
+
+        public event Action? Disconnected;
+
+        public void EnqueueOutput(byte[] bytes) => _out.Writer.TryWrite(bytes);
+        public void CompleteOutput() => _out.Writer.TryComplete();
+
+        public virtual async ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(CancellationToken ct = default)
+        {
+            try
+            {
+                return await _out.Reader.ReadAsync(ct).ConfigureAwait(false);
+            }
+            catch (ChannelClosedException)
+            {
+                return ReadOnlyMemory<byte>.Empty;
+            }
+        }
+
+        public ValueTask WriteInputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+        {
+            Interlocked.Increment(ref WrittenInputCount);
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask ResizeAsync(int width, int height, CancellationToken ct = default)
+        {
+            LastResize = (width, height);
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _out.Writer.TryComplete();
+            return ValueTask.CompletedTask;
+        }
+
+        protected void RaiseDisconnected() => Disconnected?.Invoke();
+    }
+
+    private class FakeConnectableAdapter : FakeAdapter, IConnectableWorkloadAdapter
+    {
+        private readonly TaskCompletionSource _connected =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource _disconnected =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task ConnectedTask => _connected.Task;
+        public Task DisconnectedTask => _disconnected.Task;
+        public bool IsConnected =>
+            _connected.Task.IsCompletedSuccessfully && !_disconnected.Task.IsCompleted;
+
+        public void SignalConnected() => _connected.TrySetResult();
+
+        public void SignalDisconnected()
+        {
+            _disconnected.TrySetResult();
+            RaiseDisconnected();
+        }
+    }
+
+    private sealed class RepaintablePrimary : FakeConnectableAdapter, IRepaintableWorkloadAdapter
+    {
+        public int RepaintRequests;
+        public void RequestFullRepaint() => Interlocked.Increment(ref RepaintRequests);
+    }
+}

--- a/tests/Hex1b.Tests/PlaceholderWorkloadAdapterTests.cs
+++ b/tests/Hex1b.Tests/PlaceholderWorkloadAdapterTests.cs
@@ -147,6 +147,43 @@ public class PlaceholderWorkloadAdapterTests
         Assert.Equal(1, primary.RepaintRequests);
     }
 
+    [Fact]
+    public async Task ResizeAsync_RequestsRepaintOnRepaintableChildren()
+    {
+        var primary = new RepaintablePrimary();
+        var placeholder = new RepaintablePlaceholder();
+        await using var adapter = new PlaceholderWorkloadAdapter(
+            primary, placeholder, PlaceholderResumePolicy.OnDisconnect);
+
+        await adapter.ResizeAsync(120, 30);
+
+        Assert.Equal(1, placeholder.RepaintRequests);
+        Assert.Equal(1, primary.RepaintRequests);
+    }
+
+    [Fact]
+    public async Task PlaceholderRunCallback_IsInvoked_WhenSupplied()
+    {
+        var primary = new FakeConnectableAdapter();
+        var placeholder = new FakeAdapter();
+        var ranTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        Func<CancellationToken, Task<int>> placeholderRun = async ct =>
+        {
+            ranTcs.TrySetResult();
+            try { await Task.Delay(Timeout.Infinite, ct); }
+            catch (OperationCanceledException) { }
+            return 0;
+        };
+
+        await using (var adapter = new PlaceholderWorkloadAdapter(
+            primary, placeholder, placeholderRun, PlaceholderResumePolicy.OnDisconnect))
+        {
+            // Run callback should fire shortly after construction.
+            await ranTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
     private static CancellationToken TestCancel() =>
         new CancellationTokenSource(TimeSpan.FromSeconds(5)).Token;
 
@@ -233,6 +270,12 @@ public class PlaceholderWorkloadAdapterTests
     }
 
     private sealed class RepaintablePrimary : FakeConnectableAdapter, IRepaintableWorkloadAdapter
+    {
+        public int RepaintRequests;
+        public void RequestFullRepaint() => Interlocked.Increment(ref RepaintRequests);
+    }
+
+    private sealed class RepaintablePlaceholder : FakeAdapter, IRepaintableWorkloadAdapter
     {
         public int RepaintRequests;
         public void RequestFullRepaint() => Interlocked.Increment(ref RepaintRequests);

--- a/tests/Hex1b.Tests/PlaceholderWorkloadAdapterTests.cs
+++ b/tests/Hex1b.Tests/PlaceholderWorkloadAdapterTests.cs
@@ -1,13 +1,14 @@
 using System.Text;
 using System.Threading.Channels;
 using Hex1b;
-using Xunit;
+using Hex1b.Testing;
 
 namespace Hex1b.Tests;
 
+[TestClass]
 public class PlaceholderWorkloadAdapterTests
 {
-    [Fact]
+    [TestMethod]
     public async Task ReadOutputAsync_StartsFromPlaceholder_BeforePrimaryConnects()
     {
         var primary = new FakeConnectableAdapter();
@@ -18,11 +19,11 @@ public class PlaceholderWorkloadAdapterTests
             primary, placeholder, PlaceholderResumePolicy.OnDisconnect);
 
         var data = await adapter.ReadOutputAsync(TestCancel());
-        Assert.Equal("PLACEHOLDER", Encoding.UTF8.GetString(data.Span));
-        Assert.Same(placeholder, adapter.ActiveChild);
+        Assert.AreEqual("PLACEHOLDER", Encoding.UTF8.GetString(data.Span));
+        Assert.AreSame(placeholder, adapter.ActiveChild);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadOutputAsync_OnPrimaryConnected_PrependsResetThenStreamsPrimary()
     {
         var primary = new FakeConnectableAdapter();
@@ -40,11 +41,11 @@ public class PlaceholderWorkloadAdapterTests
         AssertContainsSequence(first, "\x1b[?1049l"u8);
 
         var second = await adapter.ReadOutputAsync(TestCancel());
-        Assert.Equal("PRIMARY"u8.ToArray(), second.ToArray());
-        Assert.Same(primary, adapter.ActiveChild);
+        TestSeq.AreEqual("PRIMARY"u8.ToArray(), second.ToArray());
+        Assert.AreSame(primary, adapter.ActiveChild);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadOutputAsync_OnPrimaryDisconnect_ReturnsToPlaceholder_WhenPolicyOnDisconnect()
     {
         var primary = new FakeConnectableAdapter();
@@ -68,11 +69,11 @@ public class PlaceholderWorkloadAdapterTests
         // the swap completed.
         placeholder.EnqueueOutput("BACK"u8.ToArray());
         var placeholderAgain = await adapter.ReadOutputAsync(TestCancel());
-        Assert.Equal("BACK"u8.ToArray(), placeholderAgain.ToArray());
-        Assert.Same(placeholder, adapter.ActiveChild);
+        TestSeq.AreEqual("BACK"u8.ToArray(), placeholderAgain.ToArray());
+        Assert.AreSame(placeholder, adapter.ActiveChild);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ReadOutputAsync_OneShotPolicy_StopsOnPrimaryDisconnect()
     {
         var primary = new FakeConnectableAdapter();
@@ -92,11 +93,11 @@ public class PlaceholderWorkloadAdapterTests
         primary.SignalDisconnected();
 
         var trailing = await adapter.ReadOutputAsync(TestCancel());
-        Assert.True(trailing.IsEmpty);
-        Assert.True(disconnected);
+        Assert.IsTrue(trailing.IsEmpty);
+        Assert.IsTrue(disconnected);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task WriteInputAsync_OnlyDeliveredToActiveChild()
     {
         var primary = new FakeConnectableAdapter();
@@ -106,8 +107,8 @@ public class PlaceholderWorkloadAdapterTests
             primary, placeholder, PlaceholderResumePolicy.OnDisconnect);
 
         await adapter.WriteInputAsync(new byte[] { 1 });
-        Assert.Equal(1, placeholder.WrittenInputCount);
-        Assert.Equal(0, primary.WrittenInputCount);
+        Assert.AreEqual(1, placeholder.WrittenInputCount);
+        Assert.AreEqual(0, primary.WrittenInputCount);
 
         primary.EnqueueOutput("X"u8.ToArray());
         primary.SignalConnected();
@@ -115,11 +116,11 @@ public class PlaceholderWorkloadAdapterTests
         _ = await adapter.ReadOutputAsync(TestCancel()); // X — confirms swap
 
         await adapter.WriteInputAsync(new byte[] { 2 });
-        Assert.Equal(1, placeholder.WrittenInputCount);
-        Assert.Equal(1, primary.WrittenInputCount);
+        Assert.AreEqual(1, placeholder.WrittenInputCount);
+        Assert.AreEqual(1, primary.WrittenInputCount);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ResizeAsync_FansOutToBothChildren()
     {
         var primary = new FakeConnectableAdapter();
@@ -128,11 +129,11 @@ public class PlaceholderWorkloadAdapterTests
             primary, placeholder, PlaceholderResumePolicy.OnDisconnect);
 
         await adapter.ResizeAsync(100, 40);
-        Assert.Equal((100, 40), placeholder.LastResize);
-        Assert.Equal((100, 40), primary.LastResize);
+        Assert.AreEqual((100, 40), placeholder.LastResize);
+        Assert.AreEqual((100, 40), primary.LastResize);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task SwapToRepaintable_InvokesRequestFullRepaint()
     {
         var primary = new RepaintablePrimary();
@@ -144,10 +145,10 @@ public class PlaceholderWorkloadAdapterTests
         primary.SignalConnected();
         _ = await adapter.ReadOutputAsync(TestCancel()); // reset (and triggers repaint)
 
-        Assert.Equal(1, primary.RepaintRequests);
+        Assert.AreEqual(1, primary.RepaintRequests);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task ResizeAsync_RequestsRepaintOnRepaintableChildren()
     {
         var primary = new RepaintablePrimary();
@@ -157,11 +158,11 @@ public class PlaceholderWorkloadAdapterTests
 
         await adapter.ResizeAsync(120, 30);
 
-        Assert.Equal(1, placeholder.RepaintRequests);
-        Assert.Equal(1, primary.RepaintRequests);
+        Assert.AreEqual(1, placeholder.RepaintRequests);
+        Assert.AreEqual(1, primary.RepaintRequests);
     }
 
-    [Fact]
+    [TestMethod]
     public async Task PlaceholderRunCallback_IsInvoked_WhenSupplied()
     {
         var primary = new FakeConnectableAdapter();

--- a/tests/Hex1b.Tests/TerminalWidgetHandleMouseStateTests.cs
+++ b/tests/Hex1b.Tests/TerminalWidgetHandleMouseStateTests.cs
@@ -1,0 +1,53 @@
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Regression tests for terminal-state flags on <see cref="TerminalWidgetHandle"/>
+/// that gate input forwarding to the embedded workload (mouse tracking, alt-screen).
+/// Focus: RIS (ESC c) must clear those flags, so a workload swap that prepends
+/// RIS leaves the handle in a clean state for the new active child.
+/// </summary>
+[TestClass]
+public class TerminalWidgetHandleMouseStateTests
+{
+    private static AppliedToken Applied(AnsiToken token)
+        => AppliedToken.WithNoCellImpacts(token, 0, 0, 0, 0);
+
+    [TestMethod]
+    public async Task PrivateMode1003Enable_FlipsMouseTrackingEnabled()
+    {
+        var handle = new TerminalWidgetHandle(80, 24);
+
+        Assert.IsFalse(handle.MouseTrackingEnabled);
+
+        await handle.WriteOutputWithImpactsAsync([Applied(new PrivateModeToken(1003, true))]);
+
+        Assert.IsTrue(handle.MouseTrackingEnabled);
+    }
+
+    [TestMethod]
+    public async Task RisToken_ResetsMouseTrackingEnabled()
+    {
+        var handle = new TerminalWidgetHandle(80, 24);
+        await handle.WriteOutputWithImpactsAsync([Applied(new PrivateModeToken(1003, true))]);
+        Assert.IsTrue(handle.MouseTrackingEnabled, "Precondition: workload enabled mouse tracking.");
+
+        await handle.WriteOutputWithImpactsAsync([Applied(RisToken.Instance)]);
+
+        Assert.IsFalse(handle.MouseTrackingEnabled,
+            "RIS must reset mouse tracking — otherwise a placeholder that enabled mouse will leak forwarding to the next workload after a swap.");
+    }
+
+    [TestMethod]
+    public async Task RisToken_ResetsAlternateScreen()
+    {
+        var handle = new TerminalWidgetHandle(80, 24);
+        await handle.WriteOutputWithImpactsAsync([Applied(new PrivateModeToken(1049, true))]);
+        Assert.IsTrue(handle.InAlternateScreen);
+
+        await handle.WriteOutputWithImpactsAsync([Applied(RisToken.Instance)]);
+
+        Assert.IsFalse(handle.InAlternateScreen);
+    }
+}


### PR DESCRIPTION
Adds a `WithPlaceholderWorkload` extension on `Hex1bTerminalBuilder` that lets a terminal stack two workloads: a primary (e.g. an HMP1 client waiting for a server to connect, a process that may not have started yet, etc.) and a placeholder that takes over the terminal whenever the primary is not connected. When the primary connects, the placeholder is swapped out; when it disconnects, the placeholder swaps back in. The convenience overload `WithPlaceholderHex1bApp(...)` lets the placeholder be a fully interactive `Hex1bApp` micro UI.

`samples/PlaceholderDemo` exercises the feature end-to-end. In one binary it runs either a UDS-exposed PTY shell (`--server <sock>`) or a TUI client that connects to it (default). The client wraps a `TerminalWidget` whose workload is an HMP1 client over UDS with a `Hex1bApp` placeholder. Press `R` to spawn the server (the placeholder swaps out as the shell appears), `exit` in the shell to drop back to the placeholder, and `Q` to quit.

### Composition

```
┌─────────────────────────────────────────┐
│ outer Hex1bTerminal (WithMouse)         │
│  └─ Hex1bApp (TUI: Border + Terminal)   │
│      └─ TerminalWidget(handle)          │
│          └─ inner Hex1bTerminal         │
│              └─ WithPlaceholderWorkload │
│                  ├─ primary: HMP1 client│
│                  └─ placeholder: Hex1bApp│
└─────────────────────────────────────────┘
```

### `WithPlaceholderWorkload` semantics

* **Swap on connect / disconnect.** `PlaceholderWorkloadAdapter` fans output from whichever child is currently active. On every swap it prepends a synthetic terminal-reset sequence (`RIS` + leave alt-screen + clear + cursor-home) so the downstream parser drops modes / SGR / scroll-region state from the previous child.
* **Resume policies.** `PlaceholderResumePolicy.OnDisconnect` (default) keeps the terminal alive when the primary disconnects, swaps the placeholder back in, and rebuilds the primary so it can reconnect. `PlaceholderResumePolicy.OneShot` treats primary disconnect as terminal exit (legacy behaviour). Rebuild requires a primary *factory*; passing a pre-built adapter falls back to OneShot regardless of policy.
* **Input fan-in.** Only the active child receives input. Resize events are broadcast to both so the inactive child stays sized correctly for its next activation.
* **Disconnect signalling.** Layered as `event Disconnected` (workload contract), `Task DisconnectedTask` (framework), `Func OnDisconnected` (user callback). `DisconnectedTask` fires before the user callback so the framework's swap doesn't block on user code.

### Mouse-state correctness for stacked workloads

While polishing the demo I hit a real footgun in the embedded-workload path: anything inside the shell that wants mouse (vim, htop, fzf, lazygit, ...) emits `DECSET 1003h`, which the inner `TerminalWidgetHandle` parses and latches as `_mouseTrackingEnabled = true`. From that moment on, any host mouse motion gets SGR-encoded and dumped into the embedded workload — visible as garbage on a bash prompt the moment the mouse-aware app exits. The same path applies to the new placeholder: a `Hex1bApp` placeholder always emitted `?1003h` in `EnterTuiMode` whenever its capabilities advertised mouse support, latching the host handle's flag even though the app may not have wanted mouse input.

This PR fixes the leak in two layers and re-enables mouse on the sample:

1. **`Hex1bAppWorkloadAdapter` now has an `EnableMouse` property.** `EnterTuiMode` / `ExitTuiMode` only emit the mouse `DECSET` / `DECRST` pair when it is true. `Hex1bApp` propagates `options.EnableMouse` onto a `Hex1bAppWorkloadAdapter` it owns or that the user passed in, so a placeholder built without `.WithMouse()` no longer pollutes the host handle's tracking state.
2. **`TerminalWidgetHandle` now treats `RIS` (`ESC c`) as a state reset** for `_mouseTrackingEnabled`, `_sgrMouseModeEnabled`, `_inAlternateScreen`, `_cursorVisible` and `_cursorShape`. `PlaceholderWorkloadAdapter` already prepends `RIS` on every swap; this makes the embedded handle match the post-`RIS` contract of the underlying terminal, so a workload that turned mouse on doesn't pollute the next one.

With these in place, the sample re-enables `.WithMouse()` on the outer terminal and `EnableMouse = true` on the outer `Hex1bApp`. The full chain is now state-driven: host TTY in SGR mouse mode → outer Hex1bApp routes mouse events → `TerminalNode` → `TerminalWidgetHandle.SendEventAsync`, which forwards only when the embedded workload has actually enabled mouse tracking and stops the moment it disables it (or a swap issues `RIS`).

### Tests

* `PlaceholderWorkloadAdapterTests` (9 tests): placeholder-first read, swap-on-connect with `RIS` reset, swap-back-on-disconnect under `OnDisconnect`, `OneShot` stops on disconnect, input fanout to active child only, resize fanout to both, `RequestFullRepaint` on swap and on resize for repaintable adapters, placeholder run callback invocation.
* `Hex1bAppWorkloadAdapterMouseModeTests` (4 tests): `EnterTuiMode` / `ExitTuiMode` emit mouse `DECSET` / `DECRST` iff `EnableMouse` is true; alt-screen sequences are unaffected.
* `TerminalWidgetHandleMouseStateTests` (3 tests): mouse-tracking enable on `?1003h`; `RIS` clears mouse tracking and alt-screen.

Full suite: 7806 / 7832 pass, 24 skipped, 2 unrelated CommandPalette flakes that clear on rerun.

### Commits

```
PlaceholderDemo: enable mouse on outer terminal and Hex1bApp
Gate Hex1bAppWorkloadAdapter mouse-enable bytes on EnableMouse
Migrate PlaceholderWorkloadAdapterTests from xUnit to MSTest
Rework PlaceholderDemo into self-contained shell-over-UDS TUI
Rebuild primary on disconnect so placeholder demo can reconnect
Keep terminal alive after primary disconnect under OnDisconnect policy
Swallow OCE on PlaceholderDemo shutdown
Add Ctrl-C handling to PlaceholderDemo
Fix placeholder demo: drive placeholder RunCallback and wake on resize
Add WithPlaceholderWorkload for swappable terminal workloads
```