### PR TITLE
Enable package validation with a bot-maintained baseline

### DIFF
--- a/.github/workflows/baseline-bump.yml
+++ b/.github/workflows/baseline-bump.yml
@@ -1,0 +1,134 @@
+name: Bump package validation baseline
+
+# After a stable vX.Y.Z release ships, rewrite the bot-managed
+# <PackageValidationBaselineVersion> block in src/Hex1b/Hex1b.csproj and open
+# follow-up PR(s):
+#   * Always against release/X.Y (so the next patch on that line validates
+#     against X.Y.Z).
+#   * Against main only when X.Y is the highest-minor-of-the-highest-major
+#     across every stable vX.Y.Z tag (i.e. this release is the "latest
+#     line"). When a new release/X.Y branch is later cut from main, the
+#     first beta on that branch inherits whatever baseline main carried —
+#     no extra branching required here.
+#
+# Alpha / beta builds are not tagged and don't create GH releases, so they
+# never trigger this workflow. The version-input on workflow_dispatch lets
+# humans re-run the bumper against a known-good tag if a PR was closed by
+# mistake or the original run failed mid-flight.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Stable version to bump baseline to (e.g. 1.0.1). Omit to use the latest stable git tag.'
+        required: false
+        default: ''
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: baseline-bump
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve target version
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --quiet
+
+          if [[ "$EVENT_NAME" == "release" ]]; then
+            RAW="$RELEASE_TAG"
+          elif [[ -n "$INPUT_VERSION" ]]; then
+            RAW="$INPUT_VERSION"
+          else
+            # Pick the highest stable tag.
+            RAW="$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' \
+              | grep -Ev '-' \
+              | sed -E 's/^v//' \
+              | sort -t. -k1,1n -k2,2n -k3,3n \
+              | tail -n1)"
+            if [[ -z "$RAW" ]]; then
+              echo "::notice::No stable tags exist; nothing to bump."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            RAW="v$RAW"
+          fi
+
+          VERSION="${RAW#v}"
+          if [[ ! "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "::notice::Tag '$RAW' is not a stable vX.Y.Z; skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          MAJOR="${BASH_REMATCH[1]}"
+          MINOR="${BASH_REMATCH[2]}"
+
+          # Decide whether main should also get the bump: only when X.Y is the
+          # highest minor of the highest major across all stable tags. We
+          # include the current VERSION in the comparison so a brand-new line
+          # released right now still counts as the latest.
+          HIGHEST_MAJOR="$( { git tag -l 'v[0-9]*.[0-9]*.[0-9]*' | grep -Ev '-' | sed -E 's/^v//'; echo "$VERSION"; } \
+            | awk -F. '{print $1}' | sort -n | tail -n1)"
+          HIGHEST_MINOR_OF_HIGHEST_MAJOR="$( { git tag -l "v${HIGHEST_MAJOR}.*.*" | grep -Ev '-' | sed -E "s/^v${HIGHEST_MAJOR}\\.//"; \
+              [[ "$MAJOR" == "$HIGHEST_MAJOR" ]] && echo "${MINOR}.0" || true; } \
+            | awk -F. '{print $1}' | sort -n | tail -n1)"
+
+          BUMP_MAIN="false"
+          if [[ "$MAJOR" == "$HIGHEST_MAJOR" && "$MINOR" == "$HIGHEST_MINOR_OF_HIGHEST_MAJOR" ]]; then
+            BUMP_MAIN="true"
+          fi
+
+          echo "Resolved version : $VERSION"
+          echo "Release branch   : release/${MAJOR}.${MINOR}"
+          echo "Highest major    : $HIGHEST_MAJOR"
+          echo "Highest minor    : $HIGHEST_MINOR_OF_HIGHEST_MAJOR"
+          echo "Bump main?       : $BUMP_MAIN"
+
+          {
+            echo "skip=false"
+            echo "version=$VERSION"
+            echo "major=$MAJOR"
+            echo "minor=$MINOR"
+            echo "bump_main=$BUMP_MAIN"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Configure git identity
+        if: steps.resolve.outputs.skip != 'true'
+        run: |
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Bump release/X.Y baseline
+        if: steps.resolve.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION:  ${{ steps.resolve.outputs.version }}
+          MAJOR:    ${{ steps.resolve.outputs.major }}
+          MINOR:    ${{ steps.resolve.outputs.minor }}
+        run: ./eng/scripts/bump-package-validation-baseline.sh "release/${MAJOR}.${MINOR}" "$VERSION"
+
+      - name: Bump main baseline
+        if: steps.resolve.outputs.skip != 'true' && steps.resolve.outputs.bump_main == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION:  ${{ steps.resolve.outputs.version }}
+        run: ./eng/scripts/bump-package-validation-baseline.sh main "$VERSION"

--- a/eng/scripts/bump-package-validation-baseline.sh
+++ b/eng/scripts/bump-package-validation-baseline.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Rewrites the bot-managed <PackageValidationBaselineVersion> block in
+# src/Hex1b/Hex1b.csproj on $BRANCH and opens (or updates) a PR that bumps it
+# to $VERSION. Idempotent: if the file on $BRANCH already pins to $VERSION the
+# script exits 0 without touching git or the PR.
+#
+# Inputs:
+#   $1 BRANCH  — the base branch to PR into (e.g. main, release/1.0)
+#   $2 VERSION — the stable X.Y.Z to set as the baseline
+#
+# Requires: gh CLI authenticated as a user/bot with PR-write on the repo.
+
+set -euo pipefail
+
+BRANCH="${1:?branch required}"
+VERSION="${2:?version required}"
+
+CSPROJ="src/Hex1b/Hex1b.csproj"
+BEGIN_MARKER="<!-- BEGIN: bot-managed baseline -->"
+END_MARKER="<!-- END: bot-managed baseline -->"
+
+if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+  echo "::notice::Branch '$BRANCH' does not exist on origin; skipping."
+  exit 0
+fi
+
+# Branch name for the PR: stable per (base-branch, version) so re-runs update
+# the same PR instead of fanning out duplicates. Slashes in BRANCH are
+# flattened so the bot branch is always a single path segment.
+BRANCH_SLUG="${BRANCH//\//-}"
+PR_BRANCH="bot/baseline-bump/${BRANCH_SLUG}-to-${VERSION}"
+
+WORKTREE="$(mktemp -d)"
+trap 'rm -rf "$WORKTREE"' EXIT
+
+git worktree add --detach "$WORKTREE" "origin/$BRANCH"
+pushd "$WORKTREE" >/dev/null
+
+if [[ ! -f "$CSPROJ" ]]; then
+  echo "::notice::$CSPROJ not present on $BRANCH; skipping."
+  popd >/dev/null
+  exit 0
+fi
+
+if ! grep -qF "$BEGIN_MARKER" "$CSPROJ" || ! grep -qF "$END_MARKER" "$CSPROJ"; then
+  echo "::error::bot-managed baseline block not found in $CSPROJ on $BRANCH."
+  exit 1
+fi
+
+# Detect the current pinned version inside the block (if any) to short-circuit
+# noop runs.
+CURRENT="$(awk -v b="$BEGIN_MARKER" -v e="$END_MARKER" '
+  $0 ~ b {in_block=1; next}
+  $0 ~ e {in_block=0}
+  in_block {print}
+' "$CSPROJ" \
+  | grep -oE '<PackageValidationBaselineVersion>[^<]+</PackageValidationBaselineVersion>' \
+  | head -n1 \
+  | sed -E 's@</?PackageValidationBaselineVersion>@@g' || true)"
+
+if [[ "$CURRENT" == "$VERSION" ]]; then
+  echo "Baseline on $BRANCH already pinned to $VERSION; nothing to do."
+  popd >/dev/null
+  exit 0
+fi
+
+# Rewrite the block. We replace every line strictly between the markers with
+# a single active baseline element, preserving the leading indentation of the
+# BEGIN marker so the diff stays minimal.
+INDENT="$(grep -n -F "$BEGIN_MARKER" "$CSPROJ" | head -n1 | cut -d: -f1)"
+INDENT_PREFIX="$(awk -v ln="$INDENT" 'NR==ln {match($0, /^[[:space:]]*/); print substr($0, 1, RLENGTH); exit}' "$CSPROJ")"
+
+python3 - "$CSPROJ" "$BEGIN_MARKER" "$END_MARKER" "$INDENT_PREFIX" "$VERSION" <<'PY'
+import sys, pathlib
+path, begin, end, indent, version = sys.argv[1:]
+text = pathlib.Path(path).read_text()
+lines = text.splitlines(keepends=True)
+out = []
+inside = False
+replaced = False
+for line in lines:
+    if not inside and begin in line:
+        out.append(line)
+        inside = True
+        continue
+    if inside and end in line:
+        if not replaced:
+            out.append(f"{indent}<PackageValidationBaselineVersion>{version}</PackageValidationBaselineVersion>\n")
+            replaced = True
+        out.append(line)
+        inside = False
+        continue
+    if inside:
+        # Drop existing block contents.
+        continue
+    out.append(line)
+pathlib.Path(path).write_text("".join(out))
+PY
+
+if git diff --quiet -- "$CSPROJ"; then
+  echo "Rewrite produced no diff on $BRANCH; nothing to commit."
+  popd >/dev/null
+  exit 0
+fi
+
+git checkout -B "$PR_BRANCH"
+git add "$CSPROJ"
+git commit -m "ci: bump PackageValidationBaselineVersion to $VERSION on $BRANCH"
+git push --force-with-lease origin "$PR_BRANCH"
+
+PR_TITLE="Bump package validation baseline to $VERSION on $BRANCH"
+PR_BODY=$(cat <<EOF
+Automated bump of \`<PackageValidationBaselineVersion>\` in \`src/Hex1b/Hex1b.csproj\` to **$VERSION**, triggered by the publication of a stable release on \`$BRANCH\`.
+
+* Previous baseline: \`${CURRENT:-<none>}\`
+* New baseline: \`$VERSION\`
+
+Merging this PR makes the next build on \`$BRANCH\` validate the public API against the \`Hex1b\` $VERSION package on nuget.org. See \`.github/workflows/baseline-bump.yml\` for the bump rules.
+EOF
+)
+
+if EXISTING_PR=$(gh pr view "$PR_BRANCH" --json number --jq .number 2>/dev/null); then
+  echo "PR #$EXISTING_PR already exists for $PR_BRANCH; force-push above updated it."
+else
+  gh pr create \
+    --base "$BRANCH" \
+    --head "$PR_BRANCH" \
+    --title "$PR_TITLE" \
+    --body "$PR_BODY" \
+    --label baseline-bump || gh pr create \
+      --base "$BRANCH" \
+      --head "$PR_BRANCH" \
+      --title "$PR_TITLE" \
+      --body "$PR_BODY"
+fi
+
+popd >/dev/null

--- a/eng/scripts/bump-package-validation-baseline.sh
+++ b/eng/scripts/bump-package-validation-baseline.sh
@@ -24,11 +24,10 @@ if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
   exit 0
 fi
 
-# Branch name for the PR: stable per (base-branch, version) so re-runs update
-# the same PR instead of fanning out duplicates. Slashes in BRANCH are
-# flattened so the bot branch is always a single path segment.
+# Branch-name slug. Slashes in BRANCH are flattened so the bot head ref is
+# always a single path segment. The full head ref name is chosen later based
+# on whether we are reusing an existing open PR.
 BRANCH_SLUG="${BRANCH//\//-}"
-PR_BRANCH="bot/baseline-bump/${BRANCH_SLUG}-to-${VERSION}"
 
 WORKTREE="$(mktemp -d)"
 trap 'rm -rf "$WORKTREE"' EXIT
@@ -103,6 +102,26 @@ if git diff --quiet -- "$CSPROJ"; then
   exit 0
 fi
 
+# If an open bump PR is already targeting $BRANCH, reuse its head ref so the
+# existing PR is updated in place. Otherwise mint a fresh, version-suffixed
+# head ref to avoid colliding with any previously closed/merged bump PR that
+# may have been opened against the same target branch.
+EXISTING_HEAD="$(gh pr list \
+  --base "$BRANCH" \
+  --state open \
+  --json number,headRefName \
+  --jq "[.[] | select(.headRefName | startswith(\"bot/baseline-bump/${BRANCH_SLUG}\"))][0].headRefName // empty" \
+  2>/dev/null || true)"
+
+if [[ -n "$EXISTING_HEAD" ]]; then
+  PR_BRANCH="$EXISTING_HEAD"
+  REUSED_PR="true"
+  echo "Reusing existing open bump PR head '$PR_BRANCH' targeting $BRANCH."
+else
+  PR_BRANCH="bot/baseline-bump/${BRANCH_SLUG}-to-${VERSION}"
+  REUSED_PR="false"
+fi
+
 git checkout -B "$PR_BRANCH"
 git add "$CSPROJ"
 git commit -m "ci: bump PackageValidationBaselineVersion to $VERSION on $BRANCH"
@@ -119,8 +138,10 @@ Merging this PR makes the next build on \`$BRANCH\` validate the public API agai
 EOF
 )
 
-if EXISTING_PR=$(gh pr view "$PR_BRANCH" --json number --jq .number 2>/dev/null); then
-  echo "PR #$EXISTING_PR already exists for $PR_BRANCH; force-push above updated it."
+if [[ "$REUSED_PR" == "true" ]]; then
+  # Refresh the title/body so a stale "to 0.163.0" PR now reads "to 0.164.0".
+  gh pr edit "$PR_BRANCH" --title "$PR_TITLE" --body "$PR_BODY"
+  echo "Updated existing PR for $PR_BRANCH (force-push above already refreshed the diff)."
 else
   gh pr create \
     --base "$BRANCH" \

--- a/src/Hex1b/Hex1b.csproj
+++ b/src/Hex1b/Hex1b.csproj
@@ -39,6 +39,21 @@
     <!-- Additional Package Settings -->
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
+
+    <!--
+      Public-surface validation. PackageValidationBaselineVersion lives in the
+      bot-managed block below and is rewritten by .github/workflows/baseline-bump.yml
+      after every stable release (see that workflow for the full rules). Until
+      the first stable release ships the baseline element is absent, so we only
+      get intra-package framework-compat checks; once it appears, breaking-API
+      changes against the published baseline surface as build errors locally
+      and in CI. To deliberately ship a breaking change, comment the element
+      out for the spike and let the bot restore it on the next release.
+    -->
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <!-- BEGIN: bot-managed baseline -->
+    <!-- <PackageValidationBaselineVersion>X.Y.Z</PackageValidationBaselineVersion> -->
+    <!-- END: bot-managed baseline -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Hex1b/Hex1b.csproj
+++ b/src/Hex1b/Hex1b.csproj
@@ -52,7 +52,7 @@
     -->
     <EnablePackageValidation>true</EnablePackageValidation>
     <!-- BEGIN: bot-managed baseline -->
-    <!-- <PackageValidationBaselineVersion>X.Y.Z</PackageValidationBaselineVersion> -->
+    <PackageValidationBaselineVersion>0.163.0</PackageValidationBaselineVersion>
     <!-- END: bot-managed baseline -->
   </PropertyGroup>
 


### PR DESCRIPTION
Catches accidental public-API breaks in `Hex1b` against the last stable release on nuget.org, without forcing contributors to know or set anything locally. The baseline lives in source so the agent loop and `dotnet build` surface breaks the same way CI does.

## Approach

- **`src/Hex1b/Hex1b.csproj`** — turns on `<EnablePackageValidation>true</EnablePackageValidation>` and adds a `BEGIN: bot-managed baseline` / `END: bot-managed baseline` comment block. Seeded with `<PackageValidationBaselineVersion>0.163.0</PackageValidationBaselineVersion>` (the current latest stable on nuget.org).
- **`.github/workflows/baseline-bump.yml`** (new) — triggers on `release: published` (plus `workflow_dispatch` with an optional `version` input). Parses the published `vX.Y.Z`, then:
  - Always opens a PR against `release/X.Y` bumping the baseline to `X.Y.Z`.
  - Opens a PR against `main` only when `X.Y` is the highest-minor-of-the-highest-major across all stable tags (i.e. the release is on the latest line). New `release/X.Y` branches cut from main inherit whatever baseline main had, so first betas need no special handling.
- **`eng/scripts/bump-package-validation-baseline.sh`** (new) — does the rewrite inside a worktree of the target branch: short-circuits if the file already pins to the target version, otherwise a small Python step rewrites only the lines between the BEGIN/END markers, commits, force-pushes a stable `bot/baseline-bump/<branch>-to-X.Y.Z` branch, and opens (or, on re-run, updates) the PR via `gh`.

## Things worth a careful look

- Alpha and beta builds are never tagged and never create GitHub Releases, so they can't trigger the bumper. Verified by inspecting the existing `Create GitHub Release` step (gated on `kind == 'release'`).
- The rewrite is idempotent and produces a one-line diff. Smoke-tested locally going from the placeholder → `0.163.0` → `0.163.1` against a copy of the csproj.
- The release pipeline fails loudly on a validation regression: pack steps are plain `dotnet pack` invocations with the default `bash -eo pipefail` shell, no `continue-on-error` and no `|| true`, and the publish / `gh release create` steps run with the default `if: success()`.
- To deliberately ship a breaking change, comment out the active `<PackageValidationBaselineVersion>` line for the spike; the bot will restore it on the next stable release.

## Out of scope

- Enabling package validation on `Hex1b.McpServer` and `Hex1b.Tool` (the BEGIN/END convention extends trivially when we want to).
- Suppressing specific diff diagnostics; we will deal with those case by case.