### PR TITLE
Dispatch baseline-bump from build-deploy after release create

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -718,6 +718,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      actions: write  # so the post-release step can dispatch baseline-bump.yml
 
     steps:
       - name: Checkout code
@@ -867,6 +868,23 @@ jobs:
             --title "v${PACKAGE_VERSION}" \
             --notes-file /tmp/release_notes.md \
             ./artifacts/*.nupkg
+
+      - name: Dispatch baseline-bump workflow
+        # The release above is created via GITHUB_TOKEN, so the resulting
+        # `release: published` event will NOT cascade to other workflows
+        # (events triggered by GITHUB_TOKEN don't start new workflow runs).
+        # workflow_dispatch is one of the documented exceptions, so we kick
+        # baseline-bump.yml explicitly here. Runs against the default branch
+        # so the latest bump rules and rewrite script are used regardless of
+        # which release/X.Y branch shipped this release.
+        if: needs.version.outputs.kind == 'release' && steps.check-package.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PACKAGE_VERSION: ${{ needs.version.outputs.version }}
+        run: |
+          gh workflow run baseline-bump.yml \
+            --ref "${{ github.event.repository.default_branch }}" \
+            -f version="${PACKAGE_VERSION}"
 
   deploy-production:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

Yesterday's `v0.164.0` release shipped fine, but `baseline-bump.yml` never started — the bumper has to be kicked by hand. Root cause: `gh release create` in `deploy-production` runs as `github-actions[bot]` using the workflow's `GITHUB_TOKEN`, and [events triggered by `GITHUB_TOKEN` do not cascade to other workflow runs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow). `gh run list --event release` for that release is empty even though the release was published successfully.

`workflow_dispatch` is one of the two documented exceptions to that rule, so the simplest fix is to dispatch the bumper explicitly right after the release is created.

## Change

A new `Dispatch baseline-bump workflow` step in `build-deploy.yml`'s `deploy-production` job, gated on the same `kind == 'release' && check-package.outputs.exists == 'false'` condition as the release-create step. It runs:

```bash
gh workflow run baseline-bump.yml \
  --ref "${{ github.event.repository.default_branch }}" \
  -f version="${PACKAGE_VERSION}"
```

Pinning `--ref` to the default branch means future stable releases on any `release/X.Y` always use the latest bump rules, regardless of which release branch shipped them. Also adds `actions: write` to the job's permissions so the dispatch is allowed.

## Repo-setting note (already applied)

Two prerequisites for `baseline-bump.yml` itself were not in code:
- `Settings -> Actions -> General -> Allow GitHub Actions to create and approve pull requests` had to be enabled (toggled via the API; `default_workflow_permissions` was left at `read`).
- The `baseline-bump` label was created so `gh pr create --label baseline-bump` succeeds first try.

I verified the end-to-end flow by manually dispatching against the just-shipped `0.164.0`; the bumper opened PRs #362 (release/0.164) and #363 (main) as expected.