### PR TITLE
Fix console input problem: support localized Windows console input encodings

### DIFF
--- a/src/Hex1b/ConsolePresentationAdapter.cs
+++ b/src/Hex1b/ConsolePresentationAdapter.cs
@@ -32,6 +32,8 @@ public sealed class ConsolePresentationAdapter : IHex1bTerminalPresentationAdapt
     private ITerminalReflowProvider _reflowStrategy;
     private TerminalCapabilities _capabilities;
     private byte[] _prefetchedInput = [];
+    private Encoding? _inputEncoding;
+    private Decoder? _inputDecoder;
     private bool _kgpProbeCompleted;
     private bool _backgroundProbeCompleted;
     private bool _reflowEnabled;
@@ -177,33 +179,90 @@ public sealed class ConsolePresentationAdapter : IHex1bTerminalPresentationAdapt
     {
         if (_disposed) return ReadOnlyMemory<byte>.Empty;
 
-        if (_prefetchedInput.Length > 0)
-        {
-            var prefetched = _prefetchedInput;
-            _prefetchedInput = [];
-            return prefetched;
-        }
-
         using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct, _disposeCts.Token);
         
         var buffer = new byte[256];
         
         try
         {
-            var bytesRead = await _driver.ReadAsync(buffer, linkedCts.Token);
-            
-            if (bytesRead == 0)
+            if (_prefetchedInput.Length > 0)
             {
-                // EOF or cancelled
-                return ReadOnlyMemory<byte>.Empty;
+                var prefetched = _prefetchedInput;
+                _prefetchedInput = [];
+                var result = NormalizeInputToUtf8(prefetched);
+                if (!result.IsEmpty)
+                {
+                    return result;
+                }
             }
-            
-            var result = buffer.AsMemory(0, bytesRead);
-            return result;
+
+            while (!linkedCts.Token.IsCancellationRequested)
+            {
+                var bytesRead = await _driver.ReadAsync(buffer, linkedCts.Token);
+
+                if (bytesRead == 0)
+                {
+                    // EOF or cancelled
+                    return ReadOnlyMemory<byte>.Empty;
+                }
+
+                var result = NormalizeInputToUtf8(buffer.AsSpan(0, bytesRead));
+                if (!result.IsEmpty)
+                {
+                    return result;
+                }
+            }
+
+            return ReadOnlyMemory<byte>.Empty;
         }
         catch (OperationCanceledException)
         {
             return ReadOnlyMemory<byte>.Empty;
+        }
+    }
+
+    private ReadOnlyMemory<byte> NormalizeInputToUtf8(ReadOnlySpan<byte> input)
+    {
+        var encoding = _driver.InputEncoding;
+        if (IsUtf8(encoding))
+        {
+            return input.ToArray();
+        }
+
+        if (_inputDecoder is null || !IsSameEncoding(_inputEncoding, encoding))
+        {
+            _inputEncoding = encoding;
+            _inputDecoder = encoding.GetDecoder();
+        }
+
+        var chars = new char[encoding.GetMaxCharCount(input.Length)];
+        var charCount = _inputDecoder.GetChars(input, chars, flush: false);
+        if (charCount == 0)
+        {
+            return ReadOnlyMemory<byte>.Empty;
+        }
+
+        return Encoding.UTF8.GetBytes(new string(chars, 0, charCount));
+    }
+
+    private static bool IsUtf8(Encoding encoding)
+        => encoding.CodePage == Encoding.UTF8.CodePage ||
+           string.Equals(GetBodyNameOrNull(encoding), Encoding.UTF8.BodyName, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsSameEncoding(Encoding? left, Encoding right)
+        => left is not null &&
+           left.CodePage == right.CodePage &&
+           string.Equals(GetBodyNameOrNull(left), GetBodyNameOrNull(right), StringComparison.OrdinalIgnoreCase);
+
+    private static string? GetBodyNameOrNull(Encoding encoding)
+    {
+        try
+        {
+            return encoding.BodyName;
+        }
+        catch (NotSupportedException)
+        {
+            return null;
         }
     }
 

--- a/src/Hex1b/IConsoleDriver.cs
+++ b/src/Hex1b/IConsoleDriver.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace Hex1b;
 
 /// <summary>
@@ -23,6 +25,11 @@ internal interface IConsoleDriver : IDisposable
     /// </summary>
     void ExitRawMode();
     
+    /// <summary>
+    /// Encoding used by bytes returned from <see cref="ReadAsync"/>.
+    /// </summary>
+    Encoding InputEncoding { get; }
+
     /// <summary>
     /// Check if data is available to read without blocking.
     /// </summary>

--- a/src/Hex1b/UnixConsoleDriver.cs
+++ b/src/Hex1b/UnixConsoleDriver.cs
@@ -1,5 +1,6 @@
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Text;
 
 namespace Hex1b;
 
@@ -91,6 +92,7 @@ internal sealed class UnixConsoleDriver : IConsoleDriver
     
     public int Width => Console.WindowWidth;
     public int Height => Console.WindowHeight;
+    public Encoding InputEncoding => Console.InputEncoding;
     
     public event Action<int, int>? Resized;
     

--- a/src/Hex1b/WindowsConsoleDriver.cs
+++ b/src/Hex1b/WindowsConsoleDriver.cs
@@ -175,6 +175,7 @@ internal sealed class WindowsConsoleDriver : IConsoleDriver
     
     public int Width => GetWindowSize().width;
     public int Height => GetWindowSize().height;
+    public Encoding InputEncoding => Encoding.UTF8;
     
     public event Action<int, int>? Resized;
     
@@ -954,7 +955,7 @@ internal sealed class WindowsConsoleDriver : IConsoleDriver
     [DllImport("kernel32.dll", SetLastError = true)]
     private static extern uint WaitForSingleObject(nint hHandle, uint dwMilliseconds);
     
-    [DllImport("kernel32.dll", SetLastError = true)]
+    [DllImport("kernel32.dll", EntryPoint = "ReadConsoleInputW", SetLastError = true)]
     private static extern bool ReadConsoleInput(
         nint hConsoleInput,
         [Out] INPUT_RECORD[] lpBuffer,

--- a/tests/Hex1b.Tests/ConsolePresentationAdapterTests.cs
+++ b/tests/Hex1b.Tests/ConsolePresentationAdapterTests.cs
@@ -1,4 +1,6 @@
 using System.Text;
+using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace Hex1b.Tests;
 
@@ -63,6 +65,19 @@ public class ConsolePresentationAdapterTests
     }
 
     [TestMethod]
+    public void WindowsConsoleDriver_ReadConsoleInputImport_UsesUnicodeEntryPoint()
+    {
+        var method = typeof(WindowsConsoleDriver).GetMethod(
+            "ReadConsoleInput",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        var attribute = method?.GetCustomAttribute<DllImportAttribute>();
+
+        Assert.IsNotNull(attribute);
+        Assert.AreEqual("ReadConsoleInputW", attribute.EntryPoint);
+    }
+
+    [TestMethod]
     public async Task Constructor_OnUnsupportedPlatform_ThrowsPlatformNotSupportedException()
     {
         // This test verifies the factory pattern works correctly
@@ -93,7 +108,7 @@ public class ConsolePresentationAdapterTests
             }
         }
     }
-    
+
     [TestMethod]
     public void UnixConsoleDriver_OnlyAvailableOnUnixPlatforms()
     {
@@ -190,6 +205,124 @@ public class ConsolePresentationAdapterTests
         Assert.IsTrue(adapter.Capabilities.SupportsKgp);
         Assert.AreEqual("abc", Encoding.ASCII.GetString(input.Span));
     }
+
+    [TestMethod]
+    public async Task ReadInputAsync_WhenConsoleInputEncodingIsLatin1_ConvertsInputBytesToUtf8()
+    {
+        using var driver = new FakeConsoleDriver([0xE9])
+        {
+            InputEncoding = Encoding.Latin1
+        };
+        await using var adapter = new ConsolePresentationAdapter(driver);
+
+        var input = await adapter.ReadInputAsync(TestContext.Current.CancellationToken);
+
+        Assert.AreEqual("é", Encoding.UTF8.GetString(input.Span));
+    }
+
+    [TestMethod]
+    public async Task ReadInputAsync_WhenProbePreservesLatin1Input_ConvertsPrefetchedBytesToUtf8()
+    {
+        var probeResponse = Encoding.ASCII.GetBytes("\x1b_Gi=2147483647;OK\x1b\\");
+        var inputBytes = probeResponse.Concat(new byte[] { 0xE9 }).ToArray();
+        using var driver = new FakeConsoleDriver(inputBytes)
+        {
+            InputEncoding = Encoding.Latin1
+        };
+        await using var adapter = new ConsolePresentationAdapter(
+            driver,
+            kgpProbeTimeout: TimeSpan.FromMilliseconds(25));
+
+        await adapter.EnterRawModeAsync(TestContext.Current.CancellationToken);
+        var input = await adapter.ReadInputAsync(TestContext.Current.CancellationToken);
+
+        Assert.AreEqual("é", Encoding.UTF8.GetString(input.Span));
+    }
+
+    [TestMethod]
+    public async Task ReadInputAsync_WhenProbePreservesSplitGb2312Input_ConvertsPrefetchedBytesWithNextRead()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        var gb2312 = Encoding.GetEncoding(936);
+        var probeResponse = Encoding.ASCII.GetBytes("\x1b_Gi=2147483647;OK\x1b\\");
+        var firstRead = probeResponse.Concat(new byte[] { 0xB2 }).ToArray();
+        using var driver = FakeConsoleDriver.FromByteChunks(gb2312, firstRead, [0xE2, 0xCA, 0xD4]);
+        await using var adapter = new ConsolePresentationAdapter(
+            driver,
+            kgpProbeTimeout: TimeSpan.FromMilliseconds(25));
+
+        await adapter.EnterRawModeAsync(TestContext.Current.CancellationToken);
+        var input = await adapter.ReadInputAsync(TestContext.Current.CancellationToken);
+
+        Assert.AreEqual("测试", Encoding.UTF8.GetString(input.Span));
+    }
+
+    [TestMethod]
+    public async Task ReadInputAsync_WhenConsoleInputEncodingIsGb2312AndReadSplitsCharacter_ConvertsInputBytesToUtf8()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        var gb2312 = Encoding.GetEncoding(936);
+        using var driver = FakeConsoleDriver.FromByteChunks(gb2312, [0xB2], [0xE2, 0xCA, 0xD4]);
+        await using var adapter = new ConsolePresentationAdapter(driver);
+
+        var input = await adapter.ReadInputAsync(TestContext.Current.CancellationToken);
+
+        Assert.AreEqual("测试", Encoding.UTF8.GetString(input.Span));
+    }
+
+    [TestMethod]
+    [DataRow(936, "测试")]
+    [DataRow(932, "テスト")]
+    [DataRow(950, "測試")]
+    [DataRow(949, "테스트")]
+    [DataRow(1200, "測試")]
+    [DataRow(1201, "測試")]
+    public async Task ReadInputAsync_WhenConsoleInputEncodingIsMultibyteAndReadsSplitEveryByte_ConvertsInputBytesToUtf8(
+        int codePage,
+        string text)
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        var encoding = Encoding.GetEncoding(codePage);
+        using var driver = FakeConsoleDriver.FromByteChunks(
+            encoding,
+            SplitEveryByte(encoding.GetBytes(text)));
+        await using var adapter = new ConsolePresentationAdapter(driver);
+
+        var decoded = new StringBuilder();
+        while (driver.DataAvailable)
+        {
+            var input = await adapter.ReadInputAsync(TestContext.Current.CancellationToken);
+            decoded.Append(Encoding.UTF8.GetString(input.Span));
+        }
+
+        Assert.AreEqual(text, decoded.ToString());
+    }
+
+    [TestMethod]
+    public async Task ReadInputAsync_WhenConsoleInputEncodingIsUtf8_KeepsInputBytesAsUtf8()
+    {
+        var expected = Encoding.UTF8.GetBytes("é");
+        using var driver = new FakeConsoleDriver(expected)
+        {
+            InputEncoding = Encoding.UTF8
+        };
+        await using var adapter = new ConsolePresentationAdapter(driver);
+
+        var input = await adapter.ReadInputAsync(TestContext.Current.CancellationToken);
+
+        CollectionAssert.AreEqual(expected, input.ToArray());
+    }
+
+    private static byte[][] SplitEveryByte(byte[] bytes)
+    {
+        var chunks = new byte[bytes.Length][];
+        for (var i = 0; i < bytes.Length; i++)
+        {
+            chunks[i] = [bytes[i]];
+        }
+
+        return chunks;
+    }
 }
 
 [TestClass]
@@ -272,11 +405,33 @@ internal sealed class FakeConsoleDriver : IConsoleDriver
         }
     }
 
+    public FakeConsoleDriver(byte[] readChunk)
+    {
+        _readChunks.Enqueue(readChunk);
+    }
+
+    public static FakeConsoleDriver FromByteChunks(Encoding inputEncoding, params byte[][] readChunks)
+    {
+        var driver = new FakeConsoleDriver
+        {
+            InputEncoding = inputEncoding
+        };
+
+        foreach (var chunk in readChunks)
+        {
+            driver._readChunks.Enqueue(chunk);
+        }
+
+        return driver;
+    }
+
     public bool DataAvailable => _readChunks.Count > 0;
 
     public int Width => 80;
 
     public int Height => 24;
+
+    public Encoding InputEncoding { get; init; } = Console.InputEncoding;
 
     public string WrittenText => Encoding.ASCII.GetString(_written.ToArray());
 


### PR DESCRIPTION
## Problem

On Windows, Hex1b could display corrupted text when users typed non-ASCII characters in terminals.

For example, CJK input entered through PowerShell could be rendered as garbled text instead of the original characters.

Given code below:

```fsharp
let mutable inputContent = ""

let content () =
    TextBoxWidget(inputContent).OnTextChanged(fun e -> inputContent <- e.NewText).FillWidth()


let widgetTree =
    TabPanelWidget(
        [| TabItemWidget(
               "测试用内容",
               fun ctx ->
                   seq {
                       TextBlockWidget("请输入文字:")
                       content ()
                   }
           ) |]
    )

let app = new Hex1bApp(fun ctx -> widgetTree :> Hex1bWidget)
```

And it looks like

<img alt="before" src="https://github.com/user-attachments/assets/fdedd4d9-124d-4c92-befa-3932f215d3c2" />

## Root Cause

Hex1b treated presentation input bytes as UTF-8 at the terminal boundary. That assumption was not always valid for console input coming from the host environment.

There were two related issues:

1. The console presentation adapter did not normalize non-UTF-8 input bytes into UTF-8 before passing them into the rest of Hex1b.
2. The Windows console driver imported `ReadConsoleInput` without explicitly binding to the Unicode entry point. In localized Windows environments, this could allow console input records to be affected by the active ANSI code page instead of preserving Unicode characters. 

## Fix

The fix makes console input encoding explicit and normalizes presentation input to UTF-8 at the adapter boundary.

- Added an `InputEncoding` contract to `IConsoleDriver`.
- Made `ConsolePresentationAdapter` convert non-UTF-8 input bytes to UTF-8 using the driver-provided encoding.
- Preserved decoder state across reads so split multibyte characters are decoded correctly.
- Changed the decoder path to use a single `GetChars` call, avoiding double-advancing state for multibyte encodings.
- Explicitly bound the Windows console import to `ReadConsoleInputW`.
- Kept `WindowsConsoleDriver` marked as UTF-8 because it now produces Unicode-derived UTF-8 bytes internally.
- Added regression coverage for Latin-1, GB2312, Shift-JIS, Big5, Korean 949, UTF-16LE, UTF-16BE, UTF-8 passthrough, and prefetched KGP input.

The branch now preserves the existing UTF-8 behavior while correctly handling localized Windows console input encodings.

## Effect

<img alt="after" src="https://github.com/user-attachments/assets/72cfd4b2-c5ba-4e38-8960-5c252255fc63" />
