### PR TITLE
Remove unused [DoNotParallelize] from test classes

### DIFF
--- a/tests/Hex1b.Tests/DiagnosticShellIntegrationTests.cs
+++ b/tests/Hex1b.Tests/DiagnosticShellIntegrationTests.cs
@@ -31,7 +31,6 @@ namespace Hex1b.Tests;
 /// - TerminalWidgetHandle: Bridges inner terminal output to outer app rendering
 /// </para>
 /// </remarks>
-[DoNotParallelize]
 [TestClass]
 public class DiagnosticShellIntegrationTests
 {

--- a/tests/Hex1b.Tests/Documents/PieceTableStressTests.cs
+++ b/tests/Hex1b.Tests/Documents/PieceTableStressTests.cs
@@ -7,7 +7,6 @@ namespace Hex1b.Tests.Documents;
 /// These tests exercise patterns that produce many small pieces and verify
 /// the document remains consistent after complex operation sequences.
 /// </summary>
-[DoNotParallelize]
 [TestClass]
 public class PieceTableStressTests
 {

--- a/tests/Hex1b.Tests/EditorFuzzTests.cs
+++ b/tests/Hex1b.Tests/EditorFuzzTests.cs
@@ -24,7 +24,6 @@ namespace Hex1b.Tests;
 ///   [114] InsertChar 'x' (docLen=4, cursor=3)
 ///   ...
 /// </summary>
-[DoNotParallelize]
 [TestClass]
 public class EditorFuzzTests
 {

--- a/tests/Hex1b.Tests/MultiCursorPerformanceTests.cs
+++ b/tests/Hex1b.Tests/MultiCursorPerformanceTests.cs
@@ -17,7 +17,6 @@ namespace Hex1b.Tests;
 ///
 /// The fix: batch all piece tree mutations, call RebuildCaches() once at the end.
 /// </summary>
-[DoNotParallelize]
 [TestClass]
 public class MultiCursorPerformanceTests
 {


### PR DESCRIPTION
Removes `[DoNotParallelize]` from four test classes that don't actually need it. These classes don't mutate process-global state, so the attribute was unnecessary noise and was preventing them from running in parallel with other test classes under the default class-level parallelism scope.

**Classes updated:**
- `DiagnosticShellIntegrationTests`
- `Documents.PieceTableStressTests`
- `EditorFuzzTests`
- `MultiCursorPerformanceTests`

No behavioral change; just lets MSTest schedule these classes alongside others.