### PR TITLE
Migrate custom TestMethodAttribute subclasses to ConditionBaseAttribute

### DIFF
--- a/tests/Hex1b.Tests/DockerContainerIntegrationTests.cs
+++ b/tests/Hex1b.Tests/DockerContainerIntegrationTests.cs
@@ -3,28 +3,21 @@ using Hex1b.Automation;
 namespace Hex1b.Tests;
 
 /// <summary>
-/// Custom TestMethod attribute that marks a test inconclusive when Docker with Linux containers is not available.
+/// Condition attribute that skips a test when Docker with Linux containers is not available.
 /// </summary>
-public sealed class DockerAvailableFactAttribute : TestMethodAttribute
+public sealed class DockerAvailableConditionAttribute : ConditionBaseAttribute
 {
     private static readonly string? s_skipReason = GetSkipReason();
 
-    public DockerAvailableFactAttribute()
+    public DockerAvailableConditionAttribute()
+        : base(ConditionMode.Include)
     {
+        IgnoreMessage = s_skipReason;
     }
 
-    public override Task<TestResult[]> ExecuteAsync(ITestMethod testMethod)
-    {
-        if (s_skipReason is not null)
-        {
-            return Task.FromResult<TestResult[]>([new TestResult
-            {
-                Outcome = UnitTestOutcome.Inconclusive,
-                TestFailureException = new AssertInconclusiveException(s_skipReason),
-            }]);
-        }
-        return base.ExecuteAsync(testMethod);
-    }
+    public override bool IsConditionMet => s_skipReason is null;
+
+    public override string GroupName => nameof(DockerAvailableConditionAttribute);
 
     private static string? GetSkipReason()
     {
@@ -87,9 +80,11 @@ public sealed class DockerAvailableFactAttribute : TestMethodAttribute
     }
 }
 
+[TestClass]
 public class DockerContainerIntegrationTests
 {
-    [DockerAvailableFact]
+    [TestMethod]
+    [DockerAvailableCondition]
     public async Task WithDockerContainer_RunsShellInContainer()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -127,7 +122,8 @@ public class DockerContainerIntegrationTests
         await runTask;
     }
 
-    [DockerAvailableFact]
+    [TestMethod]
+    [DockerAvailableCondition]
     public async Task WithDockerContainer_EnvironmentVariablesPassedToContainer()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()
@@ -165,7 +161,8 @@ public class DockerContainerIntegrationTests
         await runTask;
     }
 
-    [DockerAvailableFact]
+    [TestMethod]
+    [DockerAvailableCondition]
     public async Task WithDockerContainer_ContainerRemovedAfterDispose()
     {
         string containerName = $"hex1b-test-dispose-{Guid.NewGuid():N}"[..32];
@@ -211,7 +208,8 @@ public class DockerContainerIntegrationTests
         Assert.DoesNotContain(containerName, output);
     }
 
-    [DockerAvailableFact]
+    [TestMethod]
+    [DockerAvailableCondition]
     public async Task WithDockerContainer_DefaultOptions_UsesDefaultImage()
     {
         await using var terminal = Hex1bTerminal.CreateBuilder()

--- a/tests/Hex1b.Tests/NanoExploratoryTests.cs
+++ b/tests/Hex1b.Tests/NanoExploratoryTests.cs
@@ -4,47 +4,46 @@ using System.Diagnostics;
 namespace Hex1b.Tests;
 
 /// <summary>
-/// Custom TestMethod attribute that skips Unix PTY exploratory tests on Windows
+/// Condition attribute that skips Unix PTY exploratory tests on Windows
 /// or when the required shell/tool is unavailable.
 /// </summary>
-public sealed class UnixPtyFactAttribute : TestMethodAttribute
+public sealed class UnixPtyConditionAttribute : ConditionBaseAttribute
 {
     private static readonly bool s_bashAvailable = CheckCommandAvailable("bash", "--version");
     private static readonly bool s_nanoAvailable = CheckCommandAvailable("nano", "--version");
 
-    private readonly string? _skipReason;
+    private readonly bool _isConditionMet;
 
-    public UnixPtyFactAttribute(bool requiresNano = false)
+    public UnixPtyConditionAttribute(bool requiresNano = false)
+        : base(ConditionMode.Include)
+    {
+        var skipReason = ComputeSkipReason(requiresNano);
+        _isConditionMet = skipReason is null;
+        IgnoreMessage = skipReason;
+    }
+
+    public override bool IsConditionMet => _isConditionMet;
+
+    public override string GroupName => nameof(UnixPtyConditionAttribute);
+
+    private static string? ComputeSkipReason(bool requiresNano)
     {
         if (OperatingSystem.IsWindows())
         {
-            _skipReason = "Requires Unix PTY behavior; skip on Windows.";
-            return;
+            return "Requires Unix PTY behavior; skip on Windows.";
         }
 
         if (!s_bashAvailable)
         {
-            _skipReason = "bash is not available on this machine.";
-            return;
+            return "bash is not available on this machine.";
         }
 
         if (requiresNano && !s_nanoAvailable)
         {
-            _skipReason = "nano is not available on this machine.";
+            return "nano is not available on this machine.";
         }
-    }
 
-    public override Task<TestResult[]> ExecuteAsync(ITestMethod testMethod)
-    {
-        if (_skipReason is not null)
-        {
-            return Task.FromResult<TestResult[]>([new TestResult
-            {
-                Outcome = UnitTestOutcome.Inconclusive,
-                TestFailureException = new AssertInconclusiveException(_skipReason),
-            }]);
-        }
-        return base.ExecuteAsync(testMethod);
+        return null;
     }
 
     private static bool CheckCommandAvailable(string command, string versionArg)
@@ -419,7 +418,8 @@ public class NanoExploratoryTests
     /// PTY test: Use printf to test escape sequence handling through the PTY pipeline.
     /// This tests if the full PTY -> Hex1bTerminal -> TerminalWidgetHandle pipeline works.
     /// </summary>
-    [UnixPtyFact]
+    [TestMethod]
+    [UnixPtyCondition]
     public async Task Pty_Printf_RendersCorrectly()
     {
         // Arrange
@@ -475,7 +475,8 @@ public class NanoExploratoryTests
     /// <summary>
     /// PTY test: Nano buffer content diagnostic.
     /// </summary>
-    [UnixPtyFact(true)]
+    [TestMethod]
+    [UnixPtyCondition(true)]
     public async Task Nano_BufferContent_Diagnostic()
     {
         // Arrange


### PR DESCRIPTION
Migrates two custom `TestMethodAttribute` subclasses to `ConditionBaseAttribute`, the modern MSTest pattern for conditional test skipping.

**Before** — bespoke `TestMethodAttribute` subclasses returned `Inconclusive` results when a precondition wasn't met:
```csharp
public sealed class DockerAvailableFactAttribute : TestMethodAttribute
{
    public override Task<TestResult[]> ExecuteAsync(ITestMethod testMethod)
    {
        if (s_skipReason is not null) { return inconclusive; }
        return base.ExecuteAsync(testMethod);
    }
}
```

**After** — composable condition attributes report proper `Skipped` outcome via `IgnoreMessage`:
```csharp
public sealed class DockerAvailableConditionAttribute : ConditionBaseAttribute
{
    public DockerAvailableConditionAttribute() : base(ConditionMode.Include)
    {
        IgnoreMessage = GetSkipReason();
    }

    public override bool IsConditionMet => GetSkipReason() is null;
    public override string GroupName => nameof(DockerAvailableConditionAttribute);
}
```

Tests now use `[TestMethod] [DockerAvailableCondition]` (or `[UnixPtyCondition]`) instead of `[DockerAvailableFact]` / `[UnixPtyFact]`.

**Benefits**
- Proper `Skipped` outcome in test reports instead of `Inconclusive`
- Composable with other condition attributes
- Aligns with the recommended MSTest pattern

**Files**
- `tests/Hex1b.Tests/DockerContainerIntegrationTests.cs`
- `tests/Hex1b.Tests/NanoExploratoryTests.cs`