### PR TITLE
Enable method-level test parallelism

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -43,6 +43,7 @@
   -->
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
     <Compile Include="$(MSBuildThisFileDirectory)tests\Shared\TestSeq.cs" Link="Shared\TestSeq.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)tests\Shared\MSTestSettings.cs" Link="Shared\MSTestSettings.cs" />
     <Using Include="Hex1b.Testing" />
   </ItemGroup>
 

--- a/tests/Hex1b.Tests/AnimationTimerTests.cs
+++ b/tests/Hex1b.Tests/AnimationTimerTests.cs
@@ -2,6 +2,7 @@ namespace Hex1b.Tests;
 
 using Hex1b.Animation;
 
+[DoNotParallelize]
 [TestClass]
 public class AnimationTimerTests
 {

--- a/tests/Hex1b.Tests/Flow/FlowRunnerResizeHarnessTests.cs
+++ b/tests/Hex1b.Tests/Flow/FlowRunnerResizeHarnessTests.cs
@@ -23,6 +23,7 @@ namespace Hex1b.Tests.Flow;
 /// resize-handling discipline without being noised up by the inner app's
 /// continuous render output.
 /// </remarks>
+[DoNotParallelize]
 [TestClass]
 public class FlowRunnerResizeHarnessTests
 {

--- a/tests/Hex1b.Tests/TestCaptureHelper.cs
+++ b/tests/Hex1b.Tests/TestCaptureHelper.cs
@@ -148,17 +148,15 @@ public static class TestCaptureHelper
     /// <param name="content">The file content.</param>
     public static void AttachFile(string name, string content)
     {
-        // Attach to MSTest test context - will throw if name is duplicate
-        { var __tmp = System.IO.Path.Combine(System.IO.Path.GetTempPath(), name); System.IO.File.WriteAllText(__tmp, content); TestContext.Current?.AddResultFile(__tmp); }
-
         // Build path: TestResults/{type}/{TestClass}_{TestName}_{attachment}
         var testContext = TestContext.Current;
-        var testClass = testContext.FullyQualifiedTestClassName ?? "UnknownClass";
-        var testMethodName = testContext.TestName ?? "UnknownMethod";
-        
-        // Get test display name which includes theory parameters
-        var testDisplayName = testContext.TestName ?? testMethodName;
-        
+        var testClass = testContext?.FullyQualifiedTestClassName ?? "UnknownClass";
+        var testMethodName = testContext?.TestName ?? "UnknownMethod";
+
+        // Get test display name which includes theory parameters (TestName by itself
+        // is just the bare method name for parameterized tests).
+        var testDisplayName = testContext?.TestDisplayName ?? testMethodName;
+
         // Extract just the method part with parameters if it's a theory
         var methodWithParams = testDisplayName;
         if (methodWithParams.Contains('.'))
@@ -169,6 +167,24 @@ public static class TestCaptureHelper
         // Sanitize for filesystem
         var sanitizedClass = SanitizeFileName(testClass);
         var sanitizedMethod = SanitizeFileName(methodWithParams);
+
+        // Flatten: {TestClass}_{TestMethod}_{attachment}. This name must be unique across
+        // every concurrently running test so the temp-path write below does not collide
+        // when MSTest parallelizes tests across classes (or data rows within a class).
+        // If sanitization stripped or truncated characters that distinguish data rows of
+        // a parameterized test, append a short stable hash to keep paths unique.
+        var uniqueMethod = sanitizedMethod;
+        if (sanitizedMethod != methodWithParams)
+        {
+            uniqueMethod = $"{sanitizedMethod}_{ShortHash(methodWithParams)}";
+        }
+        var flattenedName = $"{sanitizedClass}_{uniqueMethod}_{name}";
+
+        // Attach to MSTest test context (writes a copy to the temp dir under the unique
+        // flattened name so parallel tests writing the same logical attachment do not race).
+        var tempPath = Path.Combine(Path.GetTempPath(), flattenedName);
+        File.WriteAllText(tempPath, content);
+        testContext?.AddResultFile(tempPath);
 
         // Determine output subdirectory based on file type
         var extension = Path.GetExtension(name).ToLowerInvariant();
@@ -185,11 +201,20 @@ public static class TestCaptureHelper
         var assemblyDir = Path.GetDirectoryName(typeof(TestCaptureHelper).Assembly.Location)!;
         var outputDir = Path.Combine(assemblyDir, "TestResults", subDir);
         Directory.CreateDirectory(outputDir);
-        
-        // Flatten: {TestClass}_{TestMethod}_{attachment}
-        var flattenedName = $"{sanitizedClass}_{sanitizedMethod}_{name}";
+
         var filePath = Path.Combine(outputDir, flattenedName);
         File.WriteAllText(filePath, content);
+    }
+
+    /// <summary>
+    /// Returns the first 8 hex characters of a SHA256 hash of <paramref name="value"/>.
+    /// Used to disambiguate file paths for parameterized test data rows whose identifying
+    /// characters (parentheses, commas, quotes, etc.) are stripped by the file-name sanitizer.
+    /// </summary>
+    private static string ShortHash(string value)
+    {
+        var bytes = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexString(bytes, 0, 4).ToLowerInvariant();
     }
 
     /// <summary>

--- a/tests/Hex1b.Tests/TestSvgHelper.cs
+++ b/tests/Hex1b.Tests/TestSvgHelper.cs
@@ -121,17 +121,15 @@ public static class TestSvgHelper
     /// <param name="content">The file content.</param>
     public static void AttachFile(string name, string content)
     {
-        // Attach to MSTest test context - will throw if name is duplicate
-        { var __tmp = System.IO.Path.Combine(System.IO.Path.GetTempPath(), name); System.IO.File.WriteAllText(__tmp, content); TestContext.Current?.AddResultFile(__tmp); }
-
         // Build path: TestResults/{type}/{TestClass}_{TestName}_{attachment}
         var testContext = TestContext.Current;
-        var testClass = testContext.FullyQualifiedTestClassName ?? "UnknownClass";
-        var testMethodName = testContext.TestName ?? "UnknownMethod";
-        
-        // Get test display name which includes theory parameters
-        var testDisplayName = testContext.TestName ?? testMethodName;
-        
+        var testClass = testContext?.FullyQualifiedTestClassName ?? "UnknownClass";
+        var testMethodName = testContext?.TestName ?? "UnknownMethod";
+
+        // Get test display name which includes theory parameters (TestName by itself
+        // is just the bare method name for parameterized tests).
+        var testDisplayName = testContext?.TestDisplayName ?? testMethodName;
+
         // Extract just the method part with parameters if it's a theory
         var methodWithParams = testDisplayName;
         if (methodWithParams.Contains('.'))
@@ -142,6 +140,24 @@ public static class TestSvgHelper
         // Sanitize for filesystem
         var sanitizedClass = SanitizeFileName(testClass);
         var sanitizedMethod = SanitizeFileName(methodWithParams);
+
+        // Flatten: {TestClass}_{TestMethod}_{attachment}. This name must be unique across
+        // every concurrently running test so the temp-path write below does not collide
+        // when MSTest parallelizes tests across classes (or data rows within a class).
+        // If sanitization stripped or truncated characters that distinguish data rows of
+        // a parameterized test, append a short stable hash to keep paths unique.
+        var uniqueMethod = sanitizedMethod;
+        if (sanitizedMethod != methodWithParams)
+        {
+            uniqueMethod = $"{sanitizedMethod}_{ShortHash(methodWithParams)}";
+        }
+        var flattenedName = $"{sanitizedClass}_{uniqueMethod}_{name}";
+
+        // Attach to MSTest test context (writes a copy to the temp dir under the unique
+        // flattened name so parallel tests writing the same logical attachment do not race).
+        var tempPath = Path.Combine(Path.GetTempPath(), flattenedName);
+        File.WriteAllText(tempPath, content);
+        testContext?.AddResultFile(tempPath);
 
         // Determine output subdirectory based on file type
         var extension = Path.GetExtension(name).ToLowerInvariant();
@@ -157,11 +173,21 @@ public static class TestSvgHelper
         var assemblyDir = Path.GetDirectoryName(typeof(TestSvgHelper).Assembly.Location)!;
         var outputDir = Path.Combine(assemblyDir, "TestResults", subDir);
         Directory.CreateDirectory(outputDir);
-        
-        // Flatten: {TestClass}_{TestMethod}_{attachment}
-        var flattenedName = $"{sanitizedClass}_{sanitizedMethod}_{name}";
+
         var filePath = Path.Combine(outputDir, flattenedName);
         File.WriteAllText(filePath, content);
+    }
+
+    /// <summary>
+    /// Returns the first 8 hex characters of a SHA256 hash of <paramref name="value"/>.
+    /// Used to disambiguate file paths for parameterized test data rows whose identifying
+    /// characters (parentheses, commas, quotes, etc.) are stripped/escaped by the file-name
+    /// sanitizer or truncated by its 200-character cap.
+    /// </summary>
+    private static string ShortHash(string value)
+    {
+        var bytes = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexString(bytes, 0, 4).ToLowerInvariant();
     }
 
     /// <summary>

--- a/tests/Hex1b.Tests/TreeIntegrationTests.cs
+++ b/tests/Hex1b.Tests/TreeIntegrationTests.cs
@@ -7,6 +7,7 @@ namespace Hex1b.Tests;
 /// Comprehensive integration tests for TreeWidget keyboard navigation, mouse interaction,
 /// rendering in borders, clipping, and visual output verification.
 /// </summary>
+[DoNotParallelize]
 [TestClass]
 public class TreeIntegrationTests
 {

--- a/tests/Hex1b.Tests/WindowsPtyDisposeTests.cs
+++ b/tests/Hex1b.Tests/WindowsPtyDisposeTests.cs
@@ -18,6 +18,7 @@ namespace Hex1b.Tests;
 /// of ReadThreadProc/WriteThreadProc. The cached copy remains valid and correctly
 /// reflects cancellation even after the source is disposed.
 /// </summary>
+[DoNotParallelize]
 [TestClass]
 public class WindowsPtyDisposeTests
 {

--- a/tests/Hex1b.Tool.Tests/OutputFormatterTests.cs
+++ b/tests/Hex1b.Tool.Tests/OutputFormatterTests.cs
@@ -2,6 +2,7 @@ using Hex1b.Tool.Infrastructure;
 
 namespace Hex1b.Tool.Tests;
 
+[DoNotParallelize]
 [TestClass]
 public class OutputFormatterTests
 {

--- a/tests/Hex1b.Tool.Tests/RecordingProtocolTests.cs
+++ b/tests/Hex1b.Tool.Tests/RecordingProtocolTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 
 namespace Hex1b.Tool.Tests;
 
+[DoNotParallelize]
 [TestClass]
 public class RecordingProtocolTests
 {

--- a/tests/Shared/MSTestSettings.cs
+++ b/tests/Shared/MSTestSettings.cs
@@ -1,0 +1,1 @@
+[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]


### PR DESCRIPTION
Enables assembly-wide `[Parallelize(Scope = ExecutionScope.MethodLevel)]` for every `*.Tests` project. **Drops Hex1b.Tests wall-clock from ~7 minutes to ~30 seconds** on a hot build.

## How

A shared `tests/Shared/MSTestSettings.cs` containing only `[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]` is linked into every `.Tests` project via `Directory.Build.props`, mirroring the existing pattern used for `TestSeq.cs`.

## Supporting changes

### Helper refactors (parallel-safe attachments)
- **`TestCaptureHelper` / `TestSvgHelper`** — file attachments now write to a flattened `{TestClass}_{TestMethod}_{name}` path with a short SHA256 suffix when sanitization strips characters that distinguish data rows of a parameterized test. Prevents temp-path collisions when two parallel data rows try to write the same logical attachment.

### `[DoNotParallelize]` on classes that mutate process-global state
| Class | Why |
|---|---|
| `OutputFormatterTests` | Mutates `Console.Out` via `Console.SetOut` |
| `RecordingProtocolTests` | Shares one diagnostics socket path across tests |
| `WindowsPtyDisposeTests` | One test mutates env var `HEX1B_PTY_SHIM_SOCKET_DIR` process-wide; leaked into a sibling test and produced a too-long Unix socket path |
| `FlowRunnerResizeHarnessTests` | Tight ms-scale timing windows around resize events |
| `AnimationTimerTests` / `TreeIntegrationTests` | Defensive — contain timing-sensitive tests measured in tens of ms |

## Validation

All 5 test projects pass: 7 985 tests, 0 failures.

## Known follow-up

A small number of integration tests with tight wall-clock waits (`Tree_AsyncExpansion_ShowsChildrenAfterLoad` is the most visible) can still flake under heavy parallel CPU load even with `[DoNotParallelize]` on the class, because the flake is an inherent race between the test's inner `Wait(100ms)` and the async work it depends on — not an in-class concurrency issue. These tests pass reliably in isolation. Marking this PR as a draft so the maintainer can decide whether to harden those tests' internal waits before enabling, or to merge and address as follow-up. **In ~20 runs of the full Hex1b.Tests suite I saw this one test flake ~5×.**

## Dependencies

Builds cleanly against `main` as-is. The companion PRs #368 (drop unused `[DoNotParallelize]`) and #369 (migrate to `ConditionBaseAttribute`) are independent and can land in any order.