### PR TITLE
Fix remaining wide-character display width problems

### DIFF
--- a/src/Hex1b/DisplayWidth.cs
+++ b/src/Hex1b/DisplayWidth.cs
@@ -450,6 +450,15 @@ public static class DisplayWidth
     }
 
     /// <summary>
+    /// Pads a string to a target terminal display width.
+    /// </summary>
+    internal static string PadRightByDisplayWidth(string text, int targetWidth)
+    {
+        var width = GetStringWidth(text);
+        return width >= targetWidth ? text : text + new string(' ', targetWidth - width);
+    }
+
+    /// <summary>
     /// Slices a string by display width columns, returning the substring that fits.
     /// </summary>
     /// <param name="text">The text to slice.</param>

--- a/src/Hex1b/Nodes/AccordionNode.cs
+++ b/src/Hex1b/Nodes/AccordionNode.cs
@@ -349,7 +349,7 @@ public sealed class AccordionNode : Hex1bNode, ILayoutProvider
         {
             var action = section.LeftActions[iconIdx];
             var iconText = ResolveActionIcon(action, sectionIndex, expandedChevron, collapsedChevron);
-            var iconWidth = iconText.Length;
+            var iconWidth = DisplayWidth.GetStringWidth(iconText);
             _iconHitRegions.Add((x, iconWidth, sectionIndex, iconIdx, true, action));
             context.WriteClipped(x, y, $"{fgCode}{bgCode}{iconText} {resetToGlobal}");
             x += iconWidth + 1;
@@ -361,18 +361,19 @@ public sealed class AccordionNode : Hex1bNode, ILayoutProvider
         var rightIconsWidth = 0;
         foreach (var action in section.RightActions)
         {
-            rightIconsWidth += ResolveActionIcon(action, sectionIndex, expandedChevron, collapsedChevron).Length + 1;
+            rightIconsWidth += DisplayWidth.GetStringWidth(
+                ResolveActionIcon(action, sectionIndex, expandedChevron, collapsedChevron)) + 1;
         }
         maxTitleWidth -= rightIconsWidth;
 
         var title = section.Title;
-        if (title.Length > maxTitleWidth && maxTitleWidth > 0)
+        if (DisplayWidth.GetStringWidth(title) > maxTitleWidth && maxTitleWidth > 0)
         {
-            title = title[..(maxTitleWidth - 1)] + "…";
+            title = DisplayWidth.SliceByDisplayWidth(title, 0, maxTitleWidth - 1).text + "…";
         }
 
         context.WriteClipped(x, y, $"{fgCode}{bgCode}{title}{resetToGlobal}");
-        x += title.Length;
+        x += DisplayWidth.GetStringWidth(title);
 
         // Fill remaining space before right actions
         var rightIconsStartX = header.X + header.Width - rightIconsWidth;
@@ -388,7 +389,7 @@ public sealed class AccordionNode : Hex1bNode, ILayoutProvider
         {
             var action = section.RightActions[iconIdx];
             var iconText = ResolveActionIcon(action, sectionIndex, expandedChevron, collapsedChevron);
-            var iconWidth = iconText.Length;
+            var iconWidth = DisplayWidth.GetStringWidth(iconText);
             context.WriteClipped(x, y, $"{fgCode}{bgCode} {iconText}{resetToGlobal}");
             x += 1; // space before icon
             _iconHitRegions.Add((x, iconWidth, sectionIndex, iconIdx, false, action));

--- a/src/Hex1b/Nodes/BarChartNode.cs
+++ b/src/Hex1b/Nodes/BarChartNode.cs
@@ -51,7 +51,7 @@ public sealed class BarChartNode<T> : Hex1bNode
 
         // Calculate layout regions
         var titleHeight = Title is not null ? 1 : 0;
-        var labelWidth = resolved.Categories.Max(c => c.Label.Length) + 1;
+        var labelWidth = resolved.Categories.Max(c => DisplayWidth.GetStringWidth(c.Label)) + 1;
         labelWidth = Math.Min(labelWidth, width / 3); // Cap at 1/3 of width
         var valueWidth = ShowValues ? 8 : 0;
         var barWidth = width - labelWidth - valueWidth;
@@ -434,7 +434,7 @@ public sealed class BarChartNode<T> : Hex1bNode
         // Title
         if (Title is not null && titleHeight > 0)
         {
-            var titleX = Math.Max(0, (totalWidth - Title.Length) / 2);
+            var titleX = Math.Max(0, (totalWidth - DisplayWidth.GetStringWidth(Title)) / 2);
             WriteText(surface, titleX, 0, Title, labelColor);
         }
 
@@ -470,8 +470,8 @@ public sealed class BarChartNode<T> : Hex1bNode
 
             // Label (left-aligned, truncated)
             var label = data.Categories[catIdx].Label;
-            if (label.Length > labelWidth - 1)
-                label = label[..(labelWidth - 1)];
+            if (DisplayWidth.GetStringWidth(label) > labelWidth - 1)
+                label = DisplayWidth.SliceByDisplayWidth(label, 0, labelWidth - 1).text;
             // Center label vertically within the bar's rows
             var labelY = catY + rowsPerCategory / 2;
             WriteText(surface, 0, labelY, label, labelColor);
@@ -491,7 +491,7 @@ public sealed class BarChartNode<T> : Hex1bNode
                     ? "100%"
                     : formatter(displayValue);
                 var valX = labelWidth + barWidth + 1;
-                if (valX + text.Length <= totalWidth)
+                if (valX + DisplayWidth.GetStringWidth(text) <= totalWidth)
                     WriteText(surface, valX, labelY, text, valueColor);
             }
         }
@@ -499,12 +499,7 @@ public sealed class BarChartNode<T> : Hex1bNode
 
     private static void WriteText(Surface surface, int x, int y, string text, Hex1bColor color)
     {
-        if (y < 0 || y >= surface.Height) return;
-        for (int i = 0; i < text.Length && x + i < surface.Width; i++)
-        {
-            if (x + i < 0) continue;
-            surface[x + i, y] = new SurfaceCell(text[i].ToString(), color, null);
-        }
+        surface.WriteText(x, y, text, color);
     }
 
     private static Hex1bColor[] ResolveSeriesColors(IReadOnlyList<string> seriesNames, Hex1bTheme theme)

--- a/src/Hex1b/Nodes/BreakdownChartNode.cs
+++ b/src/Hex1b/Nodes/BreakdownChartNode.cs
@@ -73,7 +73,7 @@ public sealed class BreakdownChartNode<T> : Hex1bNode
         if (Title is not null && titleHeight > 0)
         {
             var labelColor = Hex1bColor.FromRgb(200, 200, 200);
-            var titleX = Math.Max(0, (width - Title.Length) / 2);
+            var titleX = Math.Max(0, (width - DisplayWidth.GetStringWidth(Title)) / 2);
             WriteText(surface, titleX, 0, Title, labelColor);
         }
 
@@ -137,12 +137,7 @@ public sealed class BreakdownChartNode<T> : Hex1bNode
 
     private static void WriteText(Surface surface, int x, int y, string text, Hex1bColor color)
     {
-        if (y < 0 || y >= surface.Height) return;
-        for (int i = 0; i < text.Length && x + i < surface.Width; i++)
-        {
-            if (x + i < 0) continue;
-            surface[x + i, y] = new SurfaceCell(text[i].ToString(), color, null);
-        }
+        surface.WriteText(x, y, text, color);
     }
 
     private static Hex1bColor[] ResolveColors(int count)

--- a/src/Hex1b/Nodes/ColumnChartNode.cs
+++ b/src/Hex1b/Nodes/ColumnChartNode.cs
@@ -448,7 +448,7 @@ public sealed class ColumnChartNode<T> : Hex1bNode
         // Title
         if (Title is not null && titleHeight > 0)
         {
-            var titleX = Math.Max(0, (totalWidth - Title.Length) / 2);
+            var titleX = Math.Max(0, (totalWidth - DisplayWidth.GetStringWidth(Title)) / 2);
             WriteText(surface, titleX, 0, Title, labelColor);
         }
 
@@ -465,10 +465,10 @@ public sealed class ColumnChartNode<T> : Hex1bNode
             var catX = i * (categoryWidth + spacing);
             var label = data.Categories[i].Label;
             // Truncate label to category width
-            if (label.Length > categoryWidth)
-                label = label[..categoryWidth];
+            if (DisplayWidth.GetStringWidth(label) > categoryWidth)
+                label = DisplayWidth.SliceByDisplayWidth(label, 0, categoryWidth).text;
             // Center label under column
-            var labelX = catX + Math.Max(0, (categoryWidth - label.Length) / 2);
+            var labelX = catX + Math.Max(0, (categoryWidth - DisplayWidth.GetStringWidth(label)) / 2);
             WriteText(surface, labelX, labelY, label, labelColor);
         }
 
@@ -493,9 +493,9 @@ public sealed class ColumnChartNode<T> : Hex1bNode
                 var text = Mode == ChartLayout.Stacked100
                     ? "100%"
                     : formatter(displayValue);
-                if (text.Length > categoryWidth)
-                    text = text[..categoryWidth];
-                var textX = catX + Math.Max(0, (categoryWidth - text.Length) / 2);
+                if (DisplayWidth.GetStringWidth(text) > categoryWidth)
+                    text = DisplayWidth.SliceByDisplayWidth(text, 0, categoryWidth).text;
+                var textX = catX + Math.Max(0, (categoryWidth - DisplayWidth.GetStringWidth(text)) / 2);
                 WriteText(surface, textX, valuesY, text, valueColor);
             }
         }
@@ -503,12 +503,7 @@ public sealed class ColumnChartNode<T> : Hex1bNode
 
     private static void WriteText(Surface surface, int x, int y, string text, Hex1bColor color)
     {
-        if (y < 0 || y >= surface.Height) return;
-        for (int i = 0; i < text.Length && x + i < surface.Width; i++)
-        {
-            if (x + i < 0) continue;
-            surface[x + i, y] = new SurfaceCell(text[i].ToString(), color, null);
-        }
+        surface.WriteText(x, y, text, color);
     }
 
     private static Hex1bColor[] ResolveSeriesColors(IReadOnlyList<string> seriesNames, Hex1bTheme theme)

--- a/src/Hex1b/Nodes/DonutChartNode.cs
+++ b/src/Hex1b/Nodes/DonutChartNode.cs
@@ -79,7 +79,7 @@ public sealed class DonutChartNode<T> : Hex1bNode
         if (Title is not null && titleHeight > 0)
         {
             var labelColor = Hex1bColor.FromRgb(200, 200, 200);
-            var titleX = Math.Max(0, (width - Title.Length) / 2);
+            var titleX = Math.Max(0, (width - DisplayWidth.GetStringWidth(Title)) / 2);
             WriteText(surface, titleX, 0, Title, labelColor);
         }
 
@@ -206,12 +206,7 @@ public sealed class DonutChartNode<T> : Hex1bNode
 
     private static void WriteText(Surface surface, int x, int y, string text, Hex1bColor color)
     {
-        if (y < 0 || y >= surface.Height) return;
-        for (int i = 0; i < text.Length && x + i < surface.Width; i++)
-        {
-            if (x + i < 0) continue;
-            surface[x + i, y] = new SurfaceCell(text[i].ToString(), color, null);
-        }
+        surface.WriteText(x, y, text, color);
     }
 
     /// <summary>

--- a/src/Hex1b/Nodes/LegendNode.cs
+++ b/src/Hex1b/Nodes/LegendNode.cs
@@ -125,7 +125,7 @@ public sealed class LegendNode<T> : Hex1bNode
             // Label
             var x = 2;
             WriteText(surface, x, y, item.Label, labelColor);
-            x += item.Label.Length;
+            x += DisplayWidth.GetStringWidth(item.Label);
 
             // Suffix (value / percentage)
             var suffix = FormatSuffix(item);
@@ -162,19 +162,11 @@ public sealed class LegendNode<T> : Hex1bNode
             x++;
 
             // Label
-            for (int c = 0; c < item.Label.Length && x < width; c++)
-            {
-                surface[x, 0] = new SurfaceCell(item.Label[c].ToString(), labelColor, null);
-                x++;
-            }
+            x += surface.WriteText(x, 0, item.Label, labelColor);
 
             // Suffix
             var suffix = FormatSuffix(item);
-            for (int c = 0; c < suffix.Length && x < width; c++)
-            {
-                surface[x, 0] = new SurfaceCell(suffix[c].ToString(), dimColor, null);
-                x++;
-            }
+            x += surface.WriteText(x, 0, suffix, dimColor);
         }
     }
 
@@ -206,7 +198,7 @@ public sealed class LegendNode<T> : Hex1bNode
     private int MeasureItemWidth(LegendItem item)
     {
         // swatch(1) + space(1) + label + suffix
-        return 2 + item.Label.Length + FormatSuffix(item).Length;
+        return 2 + DisplayWidth.GetStringWidth(item.Label) + DisplayWidth.GetStringWidth(FormatSuffix(item));
     }
 
     private List<LegendItem> ResolveItems()
@@ -236,12 +228,7 @@ public sealed class LegendNode<T> : Hex1bNode
 
     private static void WriteText(Surface surface, int x, int y, string text, Hex1bColor color)
     {
-        if (y < 0 || y >= surface.Height) return;
-        for (int i = 0; i < text.Length && x + i < surface.Width; i++)
-        {
-            if (x + i < 0) continue;
-            surface[x + i, y] = new SurfaceCell(text[i].ToString(), color, null);
-        }
+        surface.WriteText(x, y, text, color);
     }
 
     private static Hex1bColor[] ResolveColors(int count)

--- a/src/Hex1b/Nodes/ListNode.cs
+++ b/src/Hex1b/Nodes/ListNode.cs
@@ -1024,7 +1024,7 @@ public class ListNode<T> : Hex1bNode, ILayoutProvider
             {
                 for (int i = 0; i < _cachedItems.Count; i++)
                 {
-                    var len = (_cachedItems[i]?.ToString()?.Length ?? 0) + 2;
+                    var len = DisplayWidth.GetStringWidth(_cachedItems[i]?.ToString() ?? string.Empty) + 2;
                     if (len > maxWidth) maxWidth = len;
                 }
             }
@@ -1036,7 +1036,7 @@ public class ListNode<T> : Hex1bNode, ILayoutProvider
             maxWidth = 0;
             for (int i = 0; i < Items.Count; i++)
             {
-                var len = (Items[i]?.ToString()?.Length ?? 0) + 2; // "> " indicator
+                var len = DisplayWidth.GetStringWidth(Items[i]?.ToString() ?? string.Empty) + 2; // "> " indicator
                 if (len > maxWidth) maxWidth = len;
             }
         }

--- a/src/Hex1b/Nodes/MenuItemNode.cs
+++ b/src/Hex1b/Nodes/MenuItemNode.cs
@@ -316,7 +316,7 @@ public sealed class MenuItemNode : Hex1bNode
     protected override Size MeasureCore(Constraints constraints)
     {
         // Item uses the render width set by parent, or label length + padding
-        var width = RenderWidth > 0 ? RenderWidth : Label.Length + 2;
+        var width = RenderWidth > 0 ? RenderWidth : DisplayWidth.GetStringWidth(Label) + 2;
         return constraints.Constrain(new Size(width, 1));
     }
 
@@ -328,7 +328,7 @@ public sealed class MenuItemNode : Hex1bNode
         var width = RenderWidth > 0 ? RenderWidth : Bounds.Width;
         
         // Pad the label to fill the width
-        var paddedLabel = Label.PadRight(width);
+        var paddedLabel = DisplayWidth.PadRightByDisplayWidth(Label, width);
         
         var accelUnderline = theme.Get(MenuItemTheme.AcceleratorUnderline);
         

--- a/src/Hex1b/Nodes/MenuNode.cs
+++ b/src/Hex1b/Nodes/MenuNode.cs
@@ -386,7 +386,7 @@ public sealed class MenuNode : Hex1bNode, ILayoutProvider
             return constraints.Constrain(new Size(RenderWidth, 1));
         }
         
-        var width = Label.Length + 2; // Padding on each side
+        var width = DisplayWidth.GetStringWidth(Label) + 2; // Padding on each side
         return constraints.Constrain(new Size(width, 1));
     }
 
@@ -454,7 +454,7 @@ public sealed class MenuNode : Hex1bNode, ILayoutProvider
         
         // Format: "Label" + padding + indicator
         var labelWithIndicator = Label + indicator;
-        var paddedLabel = labelWithIndicator.PadRight(width);
+        var paddedLabel = DisplayWidth.PadRightByDisplayWidth(labelWithIndicator, width);
         var accelUnderline = theme.Get(MenuItemTheme.AcceleratorUnderline);
         
         // Use IsSelected for styling in submenus (focus navigates, selection highlights)

--- a/src/Hex1b/Nodes/MenuPopupNode.cs
+++ b/src/Hex1b/Nodes/MenuPopupNode.cs
@@ -189,11 +189,11 @@ public sealed class MenuPopupNode : Hex1bNode, ILayoutProvider
             switch (child)
             {
                 case MenuItemWidget item:
-                    _contentWidth = Math.Max(_contentWidth, item.Label.Length);
+                    _contentWidth = Math.Max(_contentWidth, DisplayWidth.GetStringWidth(item.Label));
                     contentHeight++;
                     break;
                 case MenuWidget submenu:
-                    _contentWidth = Math.Max(_contentWidth, submenu.Label.Length + indicator.Length);
+                    _contentWidth = Math.Max(_contentWidth, DisplayWidth.GetStringWidth(submenu.Label) + DisplayWidth.GetStringWidth(indicator));
                     contentHeight++;
                     break;
                 case MenuSeparatorWidget:

--- a/src/Hex1b/Nodes/NotificationCardNode.cs
+++ b/src/Hex1b/Nodes/NotificationCardNode.cs
@@ -321,7 +321,7 @@ public sealed class NotificationCardNode : Hex1bNode
             {
                 if (currentY >= y + height - 1 - (ShowProgressBar && Notification?.TimeoutDuration != null ? 1 : 0) - (ActionButton != null ? 1 : 0)) break;
 
-                var paddedLine = line.PadRight(contentWidth - 2);
+                var paddedLine = DisplayWidth.PadRightByDisplayWidth(line, contentWidth - 2);
                 context.WriteClipped(x, currentY, $"{cardBgFgAnsi}{globalBgAnsi}{leftEdge}{bodyFgAnsi}{cardBgAnsi} {paddedLine} {cardBgFgAnsi}{globalBgAnsi}{rightEdge}{resetCodes}");
                 currentY++;
             }
@@ -420,7 +420,7 @@ public sealed class NotificationCardNode : Hex1bNode
             {
                 currentLine = word;
             }
-            else if (currentLine.Length + 1 + word.Length <= maxWidth)
+            else if (DisplayWidth.GetStringWidth(currentLine) + 1 + DisplayWidth.GetStringWidth(word) <= maxWidth)
             {
                 currentLine += " " + word;
             }

--- a/src/Hex1b/Nodes/ScatterChartNode.cs
+++ b/src/Hex1b/Nodes/ScatterChartNode.cs
@@ -131,7 +131,7 @@ public class ScatterChartNode<T> : Hex1bNode
         // Title
         if (Title is not null && titleHeight > 0)
         {
-            var titleX = Math.Max(0, (width - Title.Length) / 2);
+            var titleX = Math.Max(0, (width - DisplayWidth.GetStringWidth(Title)) / 2);
             WriteText(surface, titleX, 0, Title, Hex1bColor.FromRgb(200, 200, 200));
         }
 
@@ -143,7 +143,7 @@ public class ScatterChartNode<T> : Hex1bNode
             for (int i = series.Count - 1; i >= 0; i--)
             {
                 var label = $" ● {series[i].Name}";
-                legendX -= label.Length;
+                legendX -= DisplayWidth.GetStringWidth(label);
                 if (legendX < chartLeft) break;
                 WriteText(surface, legendX, legendY, label, colors[i]);
             }
@@ -212,12 +212,7 @@ public class ScatterChartNode<T> : Hex1bNode
 
     private static void WriteText(Surface surface, int x, int y, string text, Hex1bColor color)
     {
-        if (y < 0 || y >= surface.Height) return;
-        for (int i = 0; i < text.Length && x + i < surface.Width; i++)
-        {
-            if (x + i < 0) continue;
-            surface[x + i, y] = new SurfaceCell(text[i].ToString(), color, null);
-        }
+        surface.WriteText(x, y, text, color);
     }
 
     #endregion

--- a/src/Hex1b/Nodes/TableNode.cs
+++ b/src/Hex1b/Nodes/TableNode.cs
@@ -2472,15 +2472,13 @@ public class TableNode<TRow> : Hex1bNode, ILayoutProvider, IDisposable
             var text = cell.Text ?? "";
             int width = _columnWidths[col];
 
-            // Truncate or pad text to fit column width
-            if (text.Length > width)
+            // Truncate or pad text to fit column display width.
+            if (DisplayWidth.GetStringWidth(text) > width)
             {
-                text = text[..(width - 1)] + "…";
+                text = DisplayWidth.SliceByDisplayWidth(text, 0, Math.Max(0, width - 1)).text + "…";
             }
-            else
-            {
-                text = text.PadRight(width);
-            }
+
+            text = PadRightByDisplayWidth(text, width);
 
             sb.Append(text);
 

--- a/src/Hex1b/Nodes/TimeSeriesChartNode.cs
+++ b/src/Hex1b/Nodes/TimeSeriesChartNode.cs
@@ -125,7 +125,7 @@ public class TimeSeriesChartNode<T> : Hex1bNode
         // Title
         if (Title is not null && titleHeight > 0)
         {
-            var titleX = Math.Max(0, (width - Title.Length) / 2);
+            var titleX = Math.Max(0, (width - DisplayWidth.GetStringWidth(Title)) / 2);
             WriteText(surface, titleX, 0, Title, Hex1bColor.FromRgb(200, 200, 200));
         }
 
@@ -437,12 +437,7 @@ public class TimeSeriesChartNode<T> : Hex1bNode
 
     private static void WriteText(Surface surface, int x, int y, string text, Hex1bColor color)
     {
-        if (y < 0 || y >= surface.Height) return;
-        for (int i = 0; i < text.Length && x + i < surface.Width; i++)
-        {
-            if (x + i < 0) continue;
-            surface[x + i, y] = new SurfaceCell(text[i].ToString(), color, null);
-        }
+        surface.WriteText(x, y, text, color);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/AccordionNodeTests.cs
+++ b/tests/Hex1b.Tests/AccordionNodeTests.cs
@@ -1,6 +1,7 @@
 using Hex1b.Input;
 using Hex1b.Layout;
 using Hex1b.Nodes;
+using Hex1b.Surfaces;
 using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
@@ -164,6 +165,28 @@ public class AccordionNodeTests
         // 2 headers (2 rows) + 10 remaining / 2 expanded = 5 each
         // Verify via GetChildren - content nodes would have bounds if set
         Assert.AreEqual(2, node.SectionCount);
+    }
+
+    [TestMethod]
+    public void RenderHeader_WideCharacterRightAction_UsesDisplayWidth()
+    {
+        var action = new AccordionSectionActionBuilder().Icon("搜");
+        var node = new AccordionNode();
+        node.SetSections([
+            new AccordionNode.SectionInfo("播放", [], [action])
+        ]);
+        node.Measure(new Constraints(0, 8, 0, 1));
+        node.Arrange(new Rect(0, 0, 8, 1));
+
+        var surface = new Surface(8, 1);
+        node.Render(new SurfaceRenderContext(surface));
+
+        Assert.AreEqual("播", surface[0, 0].Character);
+        Assert.IsTrue(surface[1, 0].IsContinuation);
+        Assert.AreEqual("放", surface[2, 0].Character);
+        Assert.IsTrue(surface[3, 0].IsContinuation);
+        Assert.AreEqual("搜", surface[6, 0].Character);
+        Assert.IsTrue(surface[7, 0].IsContinuation);
     }
 
     [TestMethod]

--- a/tests/Hex1b.Tests/LegendNodeTests.cs
+++ b/tests/Hex1b.Tests/LegendNodeTests.cs
@@ -56,6 +56,16 @@ public class LegendNodeTests
     }
 
     [TestMethod]
+    public void Measure_Vertical_WideCharacterLabels_UsesDisplayWidth()
+    {
+        var node = CreateNode([new("播放", 10)]);
+        var size = node.Measure(Constraints.Unbounded);
+
+        Assert.AreEqual(6, size.Width); // "■ " (2) + CJK label width (4)
+        Assert.AreEqual(1, size.Height);
+    }
+
+    [TestMethod]
     public void Measure_Vertical_RespectsMaxHeight()
     {
         var node = CreateNode(SampleData);
@@ -124,6 +134,20 @@ public class LegendNodeTests
         Assert.AreEqual("■", surface[0, 0].Character);
         Assert.AreEqual("■", surface[0, 1].Character);
         Assert.AreEqual("■", surface[0, 2].Character);
+    }
+
+    [TestMethod]
+    public void Render_Vertical_WideCharacterLabel_WritesContinuationCells()
+    {
+        var node = CreateNode([new("播放", 10)]);
+        var (surface, _) = RenderNode(node, 20, 2);
+
+        Assert.AreEqual("播", surface[2, 0].Character);
+        Assert.AreEqual(2, surface[2, 0].DisplayWidth);
+        Assert.IsTrue(surface[3, 0].IsContinuation);
+        Assert.AreEqual("放", surface[4, 0].Character);
+        Assert.AreEqual(2, surface[4, 0].DisplayWidth);
+        Assert.IsTrue(surface[5, 0].IsContinuation);
     }
 
     [TestMethod]

--- a/tests/Hex1b.Tests/ListNodeTests.cs
+++ b/tests/Hex1b.Tests/ListNodeTests.cs
@@ -62,6 +62,17 @@ public class ListNodeTests
     }
 
     [TestMethod]
+    public void Measure_WideCharacterItems_UsesDisplayWidth()
+    {
+        var node = new ListNode { Items = CreateItems("播放", "搜索") };
+
+        var size = node.Measure(Constraints.Unbounded);
+
+        Assert.AreEqual(6, size.Width); // CJK label width 4 + 2 for indicator
+        Assert.AreEqual(2, size.Height);
+    }
+
+    [TestMethod]
     public async Task Measure_RespectsMaxWidth()
     {
         var node = new ListNode { Items = CreateItems("Very Long Item Name") };

--- a/tests/Hex1b.Tests/MenuNodeTests.cs
+++ b/tests/Hex1b.Tests/MenuNodeTests.cs
@@ -171,6 +171,18 @@ public class MenuNodeTests
         Assert.AreEqual(6, size.Width); // "Open" + 2 padding
         Assert.AreEqual(1, size.Height);
     }
+
+    [TestMethod]
+    public void MenuItemNode_Measure_WideCharacterLabel_UsesDisplayWidth()
+    {
+        var node = new MenuItemNode { Label = "播放", RenderWidth = 0 };
+        var constraints = new Constraints(0, 100, 0, 10);
+
+        var size = node.Measure(constraints);
+
+        Assert.AreEqual(6, size.Width); // CJK label width 4 + 2 padding
+        Assert.AreEqual(1, size.Height);
+    }
     
     [TestMethod]
     public void MenuItemNode_IsFocusable_WhenNotDisabled()
@@ -274,6 +286,38 @@ public class MenuNodeTests
         
         Assert.AreEqual(6, size.Width); // "File" + 2 padding
         Assert.AreEqual(1, size.Height);
+    }
+
+    [TestMethod]
+    public void MenuNode_Measure_WideCharacterLabel_UsesDisplayWidth()
+    {
+        var node = new MenuNode { Label = "媒体" };
+        var constraints = new Constraints(0, 100, 0, 10);
+
+        var size = node.Measure(constraints);
+
+        Assert.AreEqual(6, size.Width); // CJK label width 4 + 2 padding
+        Assert.AreEqual(1, size.Height);
+    }
+
+    [TestMethod]
+    public void MenuPopupNode_Measure_WideCharacterItems_UsesDisplayWidth()
+    {
+        var item = new MenuItemWidget("播放");
+        var submenu = new MenuWidget("搜索", []);
+        var ownerNode = new MenuNode
+        {
+            Label = "媒体",
+            Children = [item, submenu],
+            ChildAccelerators = [(item, null, -1), (submenu, null, -1)]
+        };
+        var popupNode = new MenuPopupNode { OwnerNode = ownerNode };
+        var constraints = new Constraints(0, 100, 0, 10);
+
+        var size = popupNode.Measure(constraints);
+
+        Assert.AreEqual(10, size.Width); // submenu label width 4 + indicator width 2 + padding 2 + border 2
+        Assert.AreEqual(4, size.Height);
     }
     
     [TestMethod]

--- a/tests/Hex1b.Tests/NotificationCardNodeTests.cs
+++ b/tests/Hex1b.Tests/NotificationCardNodeTests.cs
@@ -2,6 +2,7 @@ using Hex1b;
 using Hex1b.Input;
 using Hex1b.Layout;
 using Hex1b.Nodes;
+using Hex1b.Surfaces;
 using Hex1b.Theming;
 using Hex1b.Widgets;
 
@@ -29,6 +30,28 @@ public class NotificationCardNodeTests
         // Should have non-zero dimensions
         Assert.IsTrue(size.Width > 0, "Width should be positive");
         Assert.IsTrue(size.Height > 0, "Height should be positive");
+    }
+
+    [TestMethod]
+    public void NotificationCardNode_Render_WideCharacterBody_PreservesRightBorder()
+    {
+        var node = new NotificationCardNode
+        {
+            Notification = new Notification("Title", "播放"),
+            Title = "Title",
+            Body = "播放"
+        };
+        var size = node.Measure(Constraints.Unbounded);
+        node.Arrange(new Rect(0, 0, size.Width, size.Height));
+
+        var surface = new Surface(size.Width, size.Height);
+        node.Render(new SurfaceRenderContext(surface));
+
+        Assert.AreEqual("播", surface[2, 2].Character);
+        Assert.IsTrue(surface[3, 2].IsContinuation);
+        Assert.AreEqual("放", surface[4, 2].Character);
+        Assert.IsTrue(surface[5, 2].IsContinuation);
+        Assert.AreEqual("▌", surface[size.Width - 1, 2].Character);
     }
 
     [TestMethod]

--- a/tests/Hex1b.Tests/ScatterChartNodeTests.cs
+++ b/tests/Hex1b.Tests/ScatterChartNodeTests.cs
@@ -1,0 +1,33 @@
+using Hex1b.Layout;
+using Hex1b.Nodes;
+using Hex1b.Surfaces;
+
+namespace Hex1b.Tests;
+
+[TestClass]
+public class ScatterChartNodeTests
+{
+    [TestMethod]
+    public void Render_TitleWithWideCharacters_UsesDisplayWidth()
+    {
+        var node = new ScatterChartNode<Point>
+        {
+            Data = [new Point(0, 0), new Point(1, 1)],
+            XSelector = p => p.X,
+            YSelector = p => p.Y,
+            Title = "播放",
+        };
+        node.Measure(new Constraints(0, 12, 0, 8));
+        node.Arrange(new Rect(0, 0, 12, 8));
+
+        var surface = new Surface(12, 8);
+        node.Render(new SurfaceRenderContext(surface));
+
+        Assert.AreEqual("播", surface[4, 0].Character);
+        Assert.IsTrue(surface[5, 0].IsContinuation);
+        Assert.AreEqual("放", surface[6, 0].Character);
+        Assert.IsTrue(surface[7, 0].IsContinuation);
+    }
+
+    private sealed record Point(double X, double Y);
+}


### PR DESCRIPTION
## Problem

#322 fixed the original wide-character layout problems in button-like controls and tab rendering.

While testing the TabPanel selector dropdown with CJK tab titles, I found the same class of width bug in the dropdown content. The dropdown itself is backed by a list node, and `ListNode` was still measuring item text with raw string length instead of terminal display width.

After checking other nodes with similar text measurement or padding logic, the same issue also existed in several list-like, menu-like, table, notification, accordion, and chart rendering paths.

For example, CJK text could be measured as 2 UTF-16 chars even though it occupies 4 terminal cells. That could make popups too narrow, move right-side content into the wrong column, truncate table cells incorrectly, or leave borders and continuation cells misaligned.

## Root Cause

Some rendering and measurement code still used APIs that count code units rather than terminal cells:

* `string.Length`
* `PadRight(...)`
* manual `for` loops that wrote one `char` per terminal cell
* truncation logic based on string indices instead of display columns

That works for ASCII, but not for wide Unicode text. The existing `DisplayWidth` and `Surface.WriteText(...)` helpers already handle terminal cell width and continuation cells correctly, but these nodes were not consistently using them.

## Fix

The fix continues the display-width cleanup from #322 across the remaining affected nodes.

* Added `DisplayWidth.PadRightByDisplayWidth(...)` for padding strings to a target terminal display width.
* Updated list and menu measurement to use `DisplayWidth.GetStringWidth(...)`.
* Updated menu popup padding to use display-width-aware padding.
* Updated table cell truncation and padding to slice by display width before adding ellipsis.
* Updated legend rendering to use `Surface.WriteText(...)` so wide labels write continuation cells correctly.
* Updated chart title/value/label paths to use display width instead of raw string length.
* Updated accordion header layout so wide section titles and right-side actions share the row correctly.
* Updated notification card body rendering so wide text does not overwrite or misplace the right border.
* Added regression coverage for wide-character labels in list, menu, popup, legend, table/chart-adjacent rendering, accordion, and notification card paths.

The branch preserves the behavior fixed in #322 while extending the same terminal display-width handling to other widgets that render user-visible text.

## Effect

The TabPanel selector dropdown now sizes correctly for wide-character tab titles, and the same fix pattern is applied to other text-heavy nodes that had similar assumptions.

Wide-character labels now will occupy their real terminal cell width when measuring, padding, truncating, and rendering. This prevents narrow popups, shifted action columns, incorrect table truncation, and broken right borders.