### PR TITLE
Fix: dispatch Ctrl+A–Z as key events on Unix

### DIFF
--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -1060,7 +1060,14 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         {
             '\r' or '\n' => new Hex1bKeyEvent(Hex1bKey.Enter, token.Character, Hex1bModifiers.None),
             '\t' => new Hex1bKeyEvent(Hex1bKey.Tab, token.Character, Hex1bModifiers.None),
+            // \b (0x08) and DEL (0x7F) are both treated as Backspace. The \b case also falls
+            // inside the Ctrl+A–Z range below, so it must come first.
             '\x7f' or '\b' => new Hex1bKeyEvent(Hex1bKey.Backspace, token.Character, Hex1bModifiers.None),
+            // Ctrl+A (\x01) through Ctrl+Z (\x1A): map to Hex1bKey.A–Z with Control modifier so
+            // that chord bindings like Ctrl+B can fire. The Enter/Tab/Backspace arms above have
+            // already claimed \x0A, \x0D, \x09, and \x08, so those are never reached here.
+            char c when c is >= '\x01' and <= '\x1a' =>
+                new Hex1bKeyEvent((Hex1bKey)((int)Hex1bKey.A + (c - '\x01')), c, Hex1bModifiers.Control),
             _ => null
         };
     }


### PR DESCRIPTION
## Problem

On Linux/macOS, `ControlCharToKeyEvent` only handled \r, \n, \t, and backspace. All other control characters (including \x02 = Ctrl+B) fell to the `_ => null` arm and were silently dropped. This means any hex1b input binding that uses a Ctrl+letter chord (e.g., `Ctrl+B D` for detach in `aspire terminal attach`) **never fired on Linux/macOS**.

On Windows the `ReadConsoleInput` path delivers structured key events so this was not an issue there.

## Fix

Add a catch-all arm for \x01–\x1A that maps each byte to the corresponding `Hex1bKey` (A–Z) with `Hex1bModifiers.Control`. The existing Enter/Tab/Backspace arms are evaluated first, so their characters (\x08, \x09, \x0A, \x0D) are unaffected.