### PR TITLE
Make KGP command parsing action-aware

### DIFF
--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -6380,7 +6380,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             return;
         }
 
-        switch (command!)
+        switch (command)
         {
             case KgpParsedCommand.Transmit transmit:
                 ProcessKgpTransmit(transmit.Transmission, transmit.Quiet, token.Payload);

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -6376,7 +6376,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
 
         if (!KgpCommandParser.TryParse(token.ControlData, out var command, out var failure))
         {
-            ProcessKgpParseFailure(failure!);
+            ProcessKgpParseFailure(failure, token.ControlData);
             return;
         }
 
@@ -6404,15 +6404,18 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         }
     }
 
-    private void ProcessKgpParseFailure(KgpCommandParser.Failure failure)
+    private void ProcessKgpParseFailure(
+        KgpCommandParser.Failure failure,
+        string controlData)
     {
         if (failure.Action == KgpAction.Delete)
             return;
 
+        var reason = failure.FormatReason(controlData.AsSpan());
         SendKgpResponse(
             failure.ImageId,
             failure.ImageNumber,
-            $"EINVAL:{failure.Reason}",
+            $"EINVAL:{reason}",
             (int)failure.Quiet);
     }
 

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -6374,39 +6374,62 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         if (!Capabilities.SupportsKgp)
             return;
 
-        var command = KgpCommand.Parse(token.ControlData);
-
-        switch (command.Action)
+        if (!KgpCommandParser.TryParse(token.ControlData, out var command, out var failure))
         {
-            case KgpAction.Transmit:
-                ProcessKgpTransmit(command, token.Payload);
+            ProcessKgpParseFailure(failure!);
+            return;
+        }
+
+        switch (command!)
+        {
+            case KgpParsedCommand.Transmit transmit:
+                ProcessKgpTransmit(transmit.Transmission, transmit.Quiet, token.Payload);
                 break;
-            case KgpAction.TransmitAndDisplay:
-                ProcessKgpTransmitAndDisplay(command, token.Payload);
+            case KgpParsedCommand.TransmitAndDisplay transmitAndDisplay:
+                ProcessKgpTransmitAndDisplay(transmitAndDisplay, token.Payload);
                 break;
-            case KgpAction.Query:
-                ProcessKgpQuery(command, token.Payload);
+            case KgpParsedCommand.Query query:
+                ProcessKgpQuery(query.Transmission, query.Quiet, token.Payload);
                 break;
-            case KgpAction.Put:
-                ProcessKgpPut(command);
+            case KgpParsedCommand.Put put:
+                ProcessKgpPut(put.Display, put.Quiet);
                 break;
-            case KgpAction.Delete:
-                ProcessKgpDelete(command);
+            case KgpParsedCommand.Delete delete:
+                ProcessKgpDelete(delete.Selector);
+                break;
+            case KgpParsedCommand.AnimationFrame:
+            case KgpParsedCommand.AnimationControl:
+            case KgpParsedCommand.Compose:
                 break;
         }
     }
 
-    private void ProcessKgpTransmit(KgpCommand command, string base64Payload)
+    private void ProcessKgpParseFailure(KgpCommandParser.Failure failure)
+    {
+        if (failure.Action == KgpAction.Delete)
+            return;
+
+        SendKgpResponse(
+            failure.ImageId,
+            failure.ImageNumber,
+            $"EINVAL:{failure.Reason}",
+            (int)failure.Quiet);
+    }
+
+    private void ProcessKgpTransmit(
+        KgpParsedCommand.TransmissionData command,
+        KgpParsedCommand.QuietMode quiet,
+        string base64Payload)
     {
         var decodedData = DecodeKgpPayload(base64Payload);
 
-        if (command.MoreData == 1 || _kgpImageStore.IsChunkedTransferInProgress)
+        if (command.MoreData || _kgpImageStore.IsChunkedTransferInProgress)
         {
             var image = _kgpImageStore.ProcessChunk(command, decodedData);
             if (image is not null)
             {
                 _kgpImageStore.StoreImage(image);
-                SendKgpResponse(image.ImageId, image.ImageNumber, "OK", command.Quiet);
+                SendKgpResponse(image.ImageId, image.ImageNumber, "OK", (int)quiet);
             }
             return;
         }
@@ -6429,44 +6452,44 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         {
             SendKgpResponse(imageId, imageNumber,
                 $"ENODATA:Insufficient image data: {decodedData.Length} < {expectedSize}",
-                command.Quiet);
+                (int)quiet);
             return;
         }
 
         var newImage = new KgpImageData(imageId, imageNumber, decodedData,
             command.Width, command.Height, command.Format);
         _kgpImageStore.StoreImage(newImage);
-        SendKgpResponse(imageId, imageNumber, "OK", command.Quiet);
+        SendKgpResponse(imageId, imageNumber, "OK", (int)quiet);
     }
 
-    private void ProcessKgpTransmitAndDisplay(KgpCommand command, string base64Payload)
+    private void ProcessKgpTransmitAndDisplay(
+        KgpParsedCommand.TransmitAndDisplay command,
+        string base64Payload)
     {
-        // First transmit (create a modified command with Transmit action)
-        var transmitCmd = KgpCommand.Parse(
-            $"a=t,f={(int)command.Format},s={command.Width},v={command.Height}," +
-            $"i={command.ImageId},I={command.ImageNumber},m={command.MoreData}," +
-            $"q={command.Quiet}" +
-            (command.Compression.HasValue ? $",o={command.Compression}" : ""));
-        ProcessKgpTransmit(transmitCmd, base64Payload);
+        ProcessKgpTransmit(command.Transmission, command.Quiet, base64Payload);
 
         // Then place the image
-        var imageId = command.ImageId;
-        if (imageId == 0 && command.ImageNumber > 0)
+        var imageId = command.Transmission.ImageId;
+        if (imageId == 0 && command.Transmission.ImageNumber > 0)
         {
-            var img = _kgpImageStore.GetImageByNumber(command.ImageNumber);
+            var img = _kgpImageStore.GetImageByNumber(command.Transmission.ImageNumber);
             if (img is not null)
                 imageId = img.ImageId;
         }
 
         if (imageId > 0)
         {
-            var cols = command.DisplayColumns > 0 ? (int)command.DisplayColumns : 1;
-            var rows = command.DisplayRows > 0 ? (int)command.DisplayRows : 1;
+            var cols = command.Display.Columns > 0 ? (int)command.Display.Columns : 1;
+            var rows = command.Display.Rows > 0 ? (int)command.Display.Rows : 1;
 
-            CreateKgpPlacement(imageId, command.PlacementId,
-                (uint)cols, (uint)rows, command);
+            CreateKgpPlacement(
+                imageId,
+                command.Display.PlacementId,
+                (uint)cols,
+                (uint)rows,
+                command.Display);
 
-            if (command.CursorMovement == 0)
+            if (!command.Display.SuppressCursorMovement)
             {
                 _cursorX = Math.Min(_cursorX + cols, _width - 1);
                 for (int r = 1; r < rows; r++)
@@ -6478,7 +6501,10 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         }
     }
 
-    private void ProcessKgpQuery(KgpCommand command, string base64Payload)
+    private void ProcessKgpQuery(
+        KgpParsedCommand.TransmissionData command,
+        KgpParsedCommand.QuietMode quiet,
+        string base64Payload)
     {
         var decodedData = DecodeKgpPayload(base64Payload);
         var expectedSize = GetExpectedKgpDataSize(command);
@@ -6487,15 +6513,17 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         {
             SendKgpResponse(command.ImageId, command.ImageNumber,
                 $"ENODATA:Insufficient image data: {decodedData.Length} < {expectedSize}",
-                command.Quiet);
+                (int)quiet);
             return;
         }
 
         // Query succeeds but does NOT store the image
-        SendKgpResponse(command.ImageId, command.ImageNumber, "OK", command.Quiet);
+        SendKgpResponse(command.ImageId, command.ImageNumber, "OK", (int)quiet);
     }
 
-    private void ProcessKgpPut(KgpCommand command)
+    private void ProcessKgpPut(
+        KgpParsedCommand.DisplayData command,
+        KgpParsedCommand.QuietMode quiet)
     {
         var imageId = command.ImageId;
         KgpImageData? image = null;
@@ -6507,18 +6535,18 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
 
         if (image is null)
         {
-            SendKgpResponse(imageId, command.ImageNumber, "ENOENT:Image not found", command.Quiet);
+            SendKgpResponse(imageId, command.ImageNumber, "ENOENT:Image not found", (int)quiet);
             return;
         }
 
         // Create placement and move cursor
-        var cols = command.DisplayColumns > 0 ? (int)command.DisplayColumns : 1;
-        var rows = command.DisplayRows > 0 ? (int)command.DisplayRows : 1;
+        var cols = command.Columns > 0 ? (int)command.Columns : 1;
+        var rows = command.Rows > 0 ? (int)command.Rows : 1;
 
         CreateKgpPlacement(image.ImageId, command.PlacementId,
             (uint)cols, (uint)rows, command);
 
-        if (command.CursorMovement == 0)
+        if (!command.SuppressCursorMovement)
         {
             _cursorX = Math.Min(_cursorX + cols, _width - 1);
             for (int r = 1; r < rows; r++)
@@ -6528,78 +6556,73 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             }
         }
 
-        SendKgpResponse(image.ImageId, image.ImageNumber, "OK", command.Quiet);
+        SendKgpResponse(image.ImageId, image.ImageNumber, "OK", (int)quiet);
     }
 
-    private void ProcessKgpDelete(KgpCommand command)
+    private void ProcessKgpDelete(KgpParsedCommand.DeleteSelector selector)
     {
-        switch (command.DeleteTarget)
+        switch (selector)
         {
-            case KgpDeleteTarget.All:
+            case KgpParsedCommand.DeleteSelector.All { FreeData: false }:
                 _kgpPlacements.Clear();
                 break;
-            case KgpDeleteTarget.AllFreeData:
+            case KgpParsedCommand.DeleteSelector.All { FreeData: true }:
                 _kgpPlacements.Clear();
                 _kgpImageStore.Clear();
                 break;
-            case KgpDeleteTarget.ById:
-                if (command.ImageId > 0)
+            case KgpParsedCommand.DeleteSelector.ById { FreeData: false } byId:
+                if (byId.ImageId > 0)
                 {
-                    if (command.PlacementId > 0)
-                        _kgpPlacements.RemoveAll(p => p.ImageId == command.ImageId && p.PlacementId == command.PlacementId);
+                    if (byId.PlacementId > 0)
+                        _kgpPlacements.RemoveAll(p => p.ImageId == byId.ImageId && p.PlacementId == byId.PlacementId);
                     else
-                        _kgpPlacements.RemoveAll(p => p.ImageId == command.ImageId);
+                        _kgpPlacements.RemoveAll(p => p.ImageId == byId.ImageId);
                 }
                 break;
-            case KgpDeleteTarget.ByIdFreeData:
-                if (command.ImageId > 0)
+            case KgpParsedCommand.DeleteSelector.ById { FreeData: true } byId:
+                if (byId.ImageId > 0)
                 {
-                    if (command.PlacementId > 0)
-                        _kgpPlacements.RemoveAll(p => p.ImageId == command.ImageId && p.PlacementId == command.PlacementId);
+                    if (byId.PlacementId > 0)
+                        _kgpPlacements.RemoveAll(p => p.ImageId == byId.ImageId && p.PlacementId == byId.PlacementId);
                     else
-                        _kgpPlacements.RemoveAll(p => p.ImageId == command.ImageId);
-                    _kgpImageStore.RemoveImage(command.ImageId);
+                        _kgpPlacements.RemoveAll(p => p.ImageId == byId.ImageId);
+                    _kgpImageStore.RemoveImage(byId.ImageId);
                 }
                 break;
-            case KgpDeleteTarget.ByNumber:
-            case KgpDeleteTarget.ByNumberFreeData:
-                if (command.ImageNumber > 0)
+            case KgpParsedCommand.DeleteSelector.ByNumber byNumber:
+                if (byNumber.ImageNumber > 0)
                 {
-                    var img = _kgpImageStore.GetImageByNumber(command.ImageNumber);
+                    var img = _kgpImageStore.GetImageByNumber(byNumber.ImageNumber);
                     if (img is not null)
                         _kgpPlacements.RemoveAll(p => p.ImageId == img.ImageId);
-                    _kgpImageStore.RemoveImageByNumber(command.ImageNumber);
+                    _kgpImageStore.RemoveImageByNumber(byNumber.ImageNumber);
                 }
                 break;
-            case KgpDeleteTarget.AtCursor:
-            case KgpDeleteTarget.AtCursorFreeData:
+            case KgpParsedCommand.DeleteSelector.AtCursor:
                 _kgpPlacements.RemoveAll(p => p.IntersectsCell(_cursorY, _cursorX));
                 break;
-            case KgpDeleteTarget.AtCell:
-            case KgpDeleteTarget.AtCellFreeData:
-                _kgpPlacements.RemoveAll(p => p.IntersectsCell((int)command.SourceY - 1, (int)command.SourceX - 1));
+            case KgpParsedCommand.DeleteSelector.AnimationFrames:
                 break;
-            case KgpDeleteTarget.ByColumn:
-            case KgpDeleteTarget.ByColumnFreeData:
-                _kgpPlacements.RemoveAll(p => p.IntersectsColumn((int)command.SourceX - 1));
+            case KgpParsedCommand.DeleteSelector.AtCell atCell:
+                _kgpPlacements.RemoveAll(p => p.IntersectsCell((int)atCell.Y - 1, (int)atCell.X - 1));
                 break;
-            case KgpDeleteTarget.ByRow:
-            case KgpDeleteTarget.ByRowFreeData:
-                _kgpPlacements.RemoveAll(p => p.IntersectsRow((int)command.SourceY - 1));
+            case KgpParsedCommand.DeleteSelector.ByColumn column:
+                _kgpPlacements.RemoveAll(p => p.IntersectsColumn((int)column.Column - 1));
                 break;
-            case KgpDeleteTarget.ByZIndex:
-            case KgpDeleteTarget.ByZIndexFreeData:
-                _kgpPlacements.RemoveAll(p => p.ZIndex == command.ZIndex);
+            case KgpParsedCommand.DeleteSelector.ByRow row:
+                _kgpPlacements.RemoveAll(p => p.IntersectsRow((int)row.Row - 1));
                 break;
-            case KgpDeleteTarget.ByRange:
-            case KgpDeleteTarget.ByRangeFreeData:
+            case KgpParsedCommand.DeleteSelector.ByZIndex zIndex:
+                _kgpPlacements.RemoveAll(p => p.ZIndex == zIndex.ZIndex);
+                break;
+            case KgpParsedCommand.DeleteSelector.ByRange range:
             {
-                var lo = command.SourceX;
-                var hi = command.SourceY;
+                var lo = range.FirstImageId;
+                var hi = range.LastImageId;
                 if (lo > 0 && hi > 0 && lo <= hi)
                 {
                     _kgpPlacements.RemoveAll(p => p.ImageId >= lo && p.ImageId <= hi);
-                    if (command.DeleteTarget == KgpDeleteTarget.ByRangeFreeData)
+                    if (range.FreeData)
                     {
                         for (uint id = lo; id <= hi; id++)
                             _kgpImageStore.RemoveImage(id);
@@ -6607,12 +6630,11 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 }
                 break;
             }
-            case KgpDeleteTarget.AtCellWithZIndex:
-            case KgpDeleteTarget.AtCellWithZIndexFreeData:
+            case KgpParsedCommand.DeleteSelector.AtCellWithZIndex atCellWithZ:
             {
-                var cellRow = (int)command.SourceY - 1;
-                var cellCol = (int)command.SourceX - 1;
-                var targetZ = command.ZIndex;
+                var cellRow = (int)atCellWithZ.Y - 1;
+                var cellCol = (int)atCellWithZ.X - 1;
+                var targetZ = atCellWithZ.ZIndex;
                 _kgpPlacements.RemoveAll(p => p.IntersectsCell(cellRow, cellCol) && p.ZIndex == targetZ);
                 break;
             }
@@ -6622,7 +6644,12 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         _kgpImageStore.AbortChunkedTransfer();
     }
 
-    private void CreateKgpPlacement(uint imageId, uint placementId, uint cols, uint rows, KgpCommand command)
+    private void CreateKgpPlacement(
+        uint imageId,
+        uint placementId,
+        uint cols,
+        uint rows,
+        KgpParsedCommand.DisplayData command)
     {
         // If same image+placement combo exists, replace it
         if (placementId > 0)
@@ -6634,10 +6661,13 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             imageId, placementId,
             _cursorY, _cursorX,
             cols, rows,
-            command.SourceX, command.SourceY,
-            command.SourceWidth, command.SourceHeight,
+            command.SourceX,
+            command.SourceY,
+            command.SourceWidth,
+            command.SourceHeight,
             command.ZIndex,
-            command.CellOffsetX, command.CellOffsetY);
+            command.CellOffsetX,
+            command.CellOffsetY);
 
         _kgpPlacements.Add(placement);
     }
@@ -6690,7 +6720,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         }
     }
 
-    private static long GetExpectedKgpDataSize(KgpCommand command)
+    private static long GetExpectedKgpDataSize(KgpParsedCommand.TransmissionData command)
     {
         if (command.Format == KgpFormat.Png)
             return 0; // PNG size is variable

--- a/src/Hex1b/Kgp/KgpCommand.cs
+++ b/src/Hex1b/Kgp/KgpCommand.cs
@@ -236,7 +236,7 @@ public sealed class KgpCommand
                 $"Invalid KGP control data: {failure.FormatReason(controlData.AsSpan())}");
         }
 
-        return FromParsed(command!);
+        return FromParsed(command);
     }
 
     internal KgpParsedCommand.TransmissionData ToTransmissionData()

--- a/src/Hex1b/Kgp/KgpCommand.cs
+++ b/src/Hex1b/Kgp/KgpCommand.cs
@@ -157,6 +157,9 @@ public sealed class KgpCommand
     /// <summary>Whether more chunked data follows (m key). 0=last/only, 1=more.</summary>
     public int MoreData { get; init; }
 
+    /// <summary>Usage-hint bitmask supplied by the client (N key).</summary>
+    public uint UsageHints { get; init; }
+
     // --- Display keys ---
 
     /// <summary>Left edge of source rectangle in pixels (x key).</summary>
@@ -222,242 +225,229 @@ public sealed class KgpCommand
     /// </summary>
     /// <param name="controlData">Comma-separated key=value pairs (e.g., "a=T,f=24,s=10,v=20,i=1").</param>
     /// <returns>A parsed <see cref="KgpCommand"/> with defaults for unspecified keys.</returns>
+    /// <exception cref="FormatException">
+    /// <paramref name="controlData"/> contains malformed or invalid KGP control data.
+    /// </exception>
     public static KgpCommand Parse(string controlData)
     {
-        if (string.IsNullOrEmpty(controlData))
-            return new KgpCommand();
+        if (!KgpCommandParser.TryParse(controlData, out var command, out var failure))
+            throw new FormatException($"Invalid KGP control data: {failure!.Reason}");
 
-        var cmd = new KgpCommand();
-        var action = KgpAction.Transmit;
-        var format = KgpFormat.Rgba32;
-        var medium = KgpTransmissionMedium.Direct;
-        var deleteTarget = KgpDeleteTarget.All;
-        int quiet = 0;
-        uint width = 0, height = 0, fileSize = 0, fileOffset = 0;
-        uint imageId = 0, imageNumber = 0, placementId = 0;
-        char? compression = null;
-        int moreData = 0;
-        uint sourceX = 0, sourceY = 0, sourceWidth = 0, sourceHeight = 0;
-        uint cellOffsetX = 0, cellOffsetY = 0;
-        uint displayColumns = 0, displayRows = 0;
-        int cursorMovement = 0, unicodePlaceholder = 0, zIndex = 0;
-        uint parentImageId = 0, parentPlacementId = 0;
-        int parentOffsetH = 0, parentOffsetV = 0;
-        int animationState = 0;
-        uint loopCount = 0;
+        return FromParsed(command!);
+    }
 
-        foreach (var pair in controlData.Split(','))
+    internal KgpParsedCommand.TransmissionData ToTransmissionData()
+        => new(
+            Format,
+            Medium,
+            Width,
+            Height,
+            FileSize,
+            FileOffset,
+            ImageId,
+            ImageNumber,
+            PlacementId,
+            Compression == 'z'
+                ? KgpParsedCommand.CompressionMode.Zlib
+                : KgpParsedCommand.CompressionMode.None,
+            MoreData != 0,
+            UsageHints);
+
+    internal static KgpCommand FromParsed(KgpParsedCommand command)
+    {
+        return command switch
         {
-            var eqIndex = pair.IndexOf('=');
-            if (eqIndex < 1 || eqIndex >= pair.Length - 1)
-                continue;
+            KgpParsedCommand.Transmit transmit => CreateCompatibilityCommand(
+                KgpAction.Transmit,
+                transmit.Quiet,
+                transmission: transmit.Transmission),
+            KgpParsedCommand.TransmitAndDisplay transmitAndDisplay => CreateCompatibilityCommand(
+                KgpAction.TransmitAndDisplay,
+                transmitAndDisplay.Quiet,
+                transmission: transmitAndDisplay.Transmission,
+                display: transmitAndDisplay.Display),
+            KgpParsedCommand.Query query => CreateCompatibilityCommand(
+                KgpAction.Query,
+                query.Quiet,
+                transmission: query.Transmission),
+            KgpParsedCommand.Put put => CreateCompatibilityCommand(
+                KgpAction.Put,
+                put.Quiet,
+                display: put.Display),
+            KgpParsedCommand.Delete delete => CreateCompatibilityCommand(
+                KgpAction.Delete,
+                delete.Quiet,
+                delete: delete.Selector),
+            KgpParsedCommand.AnimationFrame animationFrame => CreateCompatibilityCommand(
+                KgpAction.AnimationFrame,
+                animationFrame.Quiet,
+                transmission: animationFrame.Transmission,
+                animationFrame: animationFrame.Frame),
+            KgpParsedCommand.AnimationControl animationControl => CreateCompatibilityCommand(
+                KgpAction.AnimationControl,
+                animationControl.Quiet,
+                animationControl: animationControl.Control),
+            KgpParsedCommand.Compose compose => CreateCompatibilityCommand(
+                KgpAction.Compose,
+                compose.Quiet,
+                composition: compose.Composition),
+            _ => throw new InvalidOperationException(
+                $"Unsupported parsed KGP command type: {command.GetType().Name}."),
+        };
+    }
 
-            var key = pair[..eqIndex];
-            var value = pair[(eqIndex + 1)..];
+    private static KgpCommand CreateCompatibilityCommand(
+        KgpAction action,
+        KgpParsedCommand.QuietMode quiet,
+        KgpParsedCommand.TransmissionData? transmission = null,
+        KgpParsedCommand.DisplayData? display = null,
+        KgpParsedCommand.DeleteSelector? delete = null,
+        KgpParsedCommand.AnimationFrameData? animationFrame = null,
+        KgpParsedCommand.AnimationControlData? animationControl = null,
+        KgpParsedCommand.CompositionData? composition = null)
+    {
+        var transmissionData = transmission.GetValueOrDefault();
+        var displayData = display.GetValueOrDefault();
+        var deleteData = ProjectDelete(delete);
+        var animationFrameData = animationFrame.GetValueOrDefault();
+        var animationControlData = animationControl.GetValueOrDefault();
+        var compositionData = composition.GetValueOrDefault();
 
-            switch (key)
-            {
-                case "a":
-                    action = ParseAction(value);
-                    break;
-                case "q":
-                    _ = int.TryParse(value, out quiet);
-                    break;
-                case "f":
-                    format = ParseFormat(value);
-                    break;
-                case "t":
-                    medium = ParseMedium(value);
-                    break;
-                case "s":
-                    _ = uint.TryParse(value, out width);
-                    break;
-                case "v":
-                    _ = uint.TryParse(value, out height);
-                    break;
-                case "S":
-                    _ = uint.TryParse(value, out fileSize);
-                    break;
-                case "O":
-                    _ = uint.TryParse(value, out fileOffset);
-                    break;
-                case "i":
-                    _ = uint.TryParse(value, out imageId);
-                    break;
-                case "I":
-                    _ = uint.TryParse(value, out imageNumber);
-                    break;
-                case "p":
-                    _ = uint.TryParse(value, out placementId);
-                    break;
-                case "o":
-                    compression = value.Length > 0 ? value[0] : null;
-                    break;
-                case "m":
-                    _ = int.TryParse(value, out moreData);
-                    break;
-                case "x":
-                    _ = uint.TryParse(value, out sourceX);
-                    break;
-                case "y":
-                    _ = uint.TryParse(value, out sourceY);
-                    break;
-                case "w":
-                    _ = uint.TryParse(value, out sourceWidth);
-                    break;
-                case "h":
-                    _ = uint.TryParse(value, out sourceHeight);
-                    break;
-                case "X":
-                    _ = uint.TryParse(value, out cellOffsetX);
-                    break;
-                case "Y":
-                    _ = uint.TryParse(value, out cellOffsetY);
-                    break;
-                case "c":
-                    _ = uint.TryParse(value, out displayColumns);
-                    break;
-                case "r":
-                    _ = uint.TryParse(value, out displayRows);
-                    break;
-                case "C":
-                    _ = int.TryParse(value, out cursorMovement);
-                    break;
-                case "U":
-                    _ = int.TryParse(value, out unicodePlaceholder);
-                    break;
-                case "z":
-                    _ = int.TryParse(value, out zIndex);
-                    break;
-                case "P":
-                    _ = uint.TryParse(value, out parentImageId);
-                    break;
-                case "Q":
-                    _ = uint.TryParse(value, out parentPlacementId);
-                    break;
-                case "H":
-                    _ = int.TryParse(value, out parentOffsetH);
-                    break;
-                case "V":
-                    _ = int.TryParse(value, out parentOffsetV);
-                    break;
-                case "d":
-                    deleteTarget = ParseDeleteTarget(value);
-                    break;
-            }
-        }
+        var imageId = transmission?.ImageId
+            ?? display?.ImageId
+            ?? deleteData.ImageId
+            ?? animationControl?.ImageId
+            ?? composition?.ImageId
+            ?? 0;
+        var imageNumber = transmission?.ImageNumber
+            ?? display?.ImageNumber
+            ?? deleteData.ImageNumber
+            ?? animationControl?.ImageNumber
+            ?? composition?.ImageNumber
+            ?? 0;
+        var placementId = transmission?.PlacementId
+            ?? display?.PlacementId
+            ?? deleteData.PlacementId
+            ?? animationControl?.PlacementId
+            ?? composition?.PlacementId
+            ?? 0;
 
         return new KgpCommand
         {
             Action = action,
-            Quiet = quiet,
-            Format = format,
-            Medium = medium,
-            Width = width,
-            Height = height,
-            FileSize = fileSize,
-            FileOffset = fileOffset,
+            Quiet = (int)quiet,
+            Format = transmission?.Format ?? KgpFormat.Rgba32,
+            Medium = transmission?.Medium ?? KgpTransmissionMedium.Direct,
+            Width = transmissionData.Width,
+            Height = transmissionData.Height,
+            FileSize = transmissionData.FileSize,
+            FileOffset = transmissionData.FileOffset,
             ImageId = imageId,
             ImageNumber = imageNumber,
             PlacementId = placementId,
-            Compression = compression,
-            MoreData = moreData,
-            SourceX = sourceX,
-            SourceY = sourceY,
-            SourceWidth = sourceWidth,
-            SourceHeight = sourceHeight,
-            CellOffsetX = cellOffsetX,
-            CellOffsetY = cellOffsetY,
-            DisplayColumns = displayColumns,
-            DisplayRows = displayRows,
-            CursorMovement = cursorMovement,
-            UnicodePlaceholder = unicodePlaceholder,
-            ZIndex = zIndex,
-            ParentImageId = parentImageId,
-            ParentPlacementId = parentPlacementId,
-            ParentOffsetH = parentOffsetH,
-            ParentOffsetV = parentOffsetV,
-            DeleteTarget = deleteTarget,
-            AnimationState = animationState,
-            LoopCount = loopCount,
+            Compression = transmission?.Compression == KgpParsedCommand.CompressionMode.Zlib
+                ? 'z'
+                : null,
+            MoreData = transmission?.MoreData == true ? 1 : 0,
+            UsageHints = transmissionData.UsageHints,
+            SourceX = display?.SourceX
+                ?? deleteData.SourceX
+                ?? animationFrame?.X
+                ?? composition?.DestinationX
+                ?? 0,
+            SourceY = display?.SourceY
+                ?? deleteData.SourceY
+                ?? animationFrame?.Y
+                ?? composition?.DestinationY
+                ?? 0,
+            SourceWidth = display?.SourceWidth
+                ?? composition?.Width
+                ?? 0,
+            SourceHeight = display?.SourceHeight
+                ?? composition?.Height
+                ?? 0,
+            CellOffsetX = display?.CellOffsetX
+                ?? (animationFrame is not null
+                    ? animationFrameData.Composition == KgpParsedCommand.CompositionMode.Overwrite
+                        ? 1u
+                        : 0u
+                    : (uint?)null)
+                ?? composition?.SourceX
+                ?? 0,
+            CellOffsetY = display?.CellOffsetY
+                ?? animationFrame?.BackgroundColor
+                ?? composition?.SourceY
+                ?? 0,
+            DisplayColumns = display?.Columns
+                ?? animationFrame?.BaseFrameNumber
+                ?? animationControl?.CurrentFrameNumber
+                ?? composition?.DestinationFrameNumber
+                ?? 0,
+            DisplayRows = display?.Rows
+                ?? deleteData.FrameNumber
+                ?? animationFrame?.EditFrameNumber
+                ?? animationControl?.AffectedFrameNumber
+                ?? composition?.SourceFrameNumber
+                ?? 0,
+            CursorMovement = display is not null
+                ? displayData.SuppressCursorMovement ? 1 : 0
+                : composition is not null
+                    ? compositionData.Composition == KgpParsedCommand.CompositionMode.Overwrite ? 1 : 0
+                    : 0,
+            UnicodePlaceholder = display?.UnicodePlaceholder == true ? 1 : 0,
+            ZIndex = display?.ZIndex
+                ?? deleteData.ZIndex
+                ?? animationFrame?.Gap
+                ?? animationControl?.Gap
+                ?? 0,
+            ParentImageId = displayData.ParentImageId,
+            ParentPlacementId = displayData.ParentPlacementId,
+            ParentOffsetH = displayData.ParentOffsetHorizontal,
+            ParentOffsetV = displayData.ParentOffsetVertical,
+            DeleteTarget = delete?.Target ?? KgpDeleteTarget.All,
+            AnimationState = animationControl is null
+                ? 0
+                : animationControlData.State switch
+                {
+                    KgpParsedCommand.AnimationPlaybackState.Stopped => 1,
+                    KgpParsedCommand.AnimationPlaybackState.Loading => 2,
+                    KgpParsedCommand.AnimationPlaybackState.Running => 3,
+                    _ => 0,
+                },
+            LoopCount = animationControlData.LoopCount,
         };
     }
 
-    private static KgpAction ParseAction(string value)
+    private static (
+        uint? ImageId,
+        uint? ImageNumber,
+        uint? PlacementId,
+        uint? SourceX,
+        uint? SourceY,
+        int? ZIndex,
+        uint? FrameNumber) ProjectDelete(KgpParsedCommand.DeleteSelector? delete)
     {
-        if (value.Length != 1)
-            return KgpAction.Transmit;
-
-        return value[0] switch
+        return delete switch
         {
-            't' => KgpAction.Transmit,
-            'T' => KgpAction.TransmitAndDisplay,
-            'q' => KgpAction.Query,
-            'p' => KgpAction.Put,
-            'd' => KgpAction.Delete,
-            'f' => KgpAction.AnimationFrame,
-            'a' => KgpAction.AnimationControl,
-            'c' => KgpAction.Compose,
-            _ => KgpAction.Transmit,
-        };
-    }
-
-    private static KgpFormat ParseFormat(string value)
-    {
-        return value switch
-        {
-            "24" => KgpFormat.Rgb24,
-            "32" => KgpFormat.Rgba32,
-            "100" => KgpFormat.Png,
-            _ => KgpFormat.Rgba32,
-        };
-    }
-
-    private static KgpTransmissionMedium ParseMedium(string value)
-    {
-        if (value.Length != 1)
-            return KgpTransmissionMedium.Direct;
-
-        return value[0] switch
-        {
-            'd' => KgpTransmissionMedium.Direct,
-            'f' => KgpTransmissionMedium.File,
-            't' => KgpTransmissionMedium.TempFile,
-            's' => KgpTransmissionMedium.SharedMemory,
-            _ => KgpTransmissionMedium.Direct,
-        };
-    }
-
-    private static KgpDeleteTarget ParseDeleteTarget(string value)
-    {
-        if (value.Length != 1)
-            return KgpDeleteTarget.All;
-
-        return value[0] switch
-        {
-            'a' => KgpDeleteTarget.All,
-            'A' => KgpDeleteTarget.AllFreeData,
-            'i' => KgpDeleteTarget.ById,
-            'I' => KgpDeleteTarget.ByIdFreeData,
-            'n' => KgpDeleteTarget.ByNumber,
-            'N' => KgpDeleteTarget.ByNumberFreeData,
-            'c' => KgpDeleteTarget.AtCursor,
-            'C' => KgpDeleteTarget.AtCursorFreeData,
-            'p' => KgpDeleteTarget.AtCell,
-            'P' => KgpDeleteTarget.AtCellFreeData,
-            'q' => KgpDeleteTarget.AtCellWithZIndex,
-            'Q' => KgpDeleteTarget.AtCellWithZIndexFreeData,
-            'x' => KgpDeleteTarget.ByColumn,
-            'X' => KgpDeleteTarget.ByColumnFreeData,
-            'y' => KgpDeleteTarget.ByRow,
-            'Y' => KgpDeleteTarget.ByRowFreeData,
-            'z' => KgpDeleteTarget.ByZIndex,
-            'Z' => KgpDeleteTarget.ByZIndexFreeData,
-            'r' => KgpDeleteTarget.ByRange,
-            'R' => KgpDeleteTarget.ByRangeFreeData,
-            'f' => KgpDeleteTarget.AnimationFrames,
-            'F' => KgpDeleteTarget.AnimationFramesFreeData,
-            _ => KgpDeleteTarget.All,
+            KgpParsedCommand.DeleteSelector.ById byId
+                => (byId.ImageId, null, byId.PlacementId, null, null, null, null),
+            KgpParsedCommand.DeleteSelector.ByNumber byNumber
+                => (null, byNumber.ImageNumber, byNumber.PlacementId, null, null, null, null),
+            KgpParsedCommand.DeleteSelector.AnimationFrames frames
+                => (frames.ImageId, frames.ImageNumber, null, null, null, null, frames.FrameNumber),
+            KgpParsedCommand.DeleteSelector.AtCell atCell
+                => (null, null, null, atCell.X, atCell.Y, null, null),
+            KgpParsedCommand.DeleteSelector.AtCellWithZIndex atCellWithZ
+                => (null, null, null, atCellWithZ.X, atCellWithZ.Y, atCellWithZ.ZIndex, null),
+            KgpParsedCommand.DeleteSelector.ByRange range
+                => (null, null, null, range.FirstImageId, range.LastImageId, null, null),
+            KgpParsedCommand.DeleteSelector.ByColumn column
+                => (null, null, null, column.Column, null, null, null),
+            KgpParsedCommand.DeleteSelector.ByRow row
+                => (null, null, null, null, row.Row, null, null),
+            KgpParsedCommand.DeleteSelector.ByZIndex zIndex
+                => (null, null, null, null, null, zIndex.ZIndex, null),
+            _ => (null, null, null, null, null, null, null),
         };
     }
 }

--- a/src/Hex1b/Kgp/KgpCommand.cs
+++ b/src/Hex1b/Kgp/KgpCommand.cs
@@ -231,7 +231,10 @@ public sealed class KgpCommand
     public static KgpCommand Parse(string controlData)
     {
         if (!KgpCommandParser.TryParse(controlData, out var command, out var failure))
-            throw new FormatException($"Invalid KGP control data: {failure!.Reason}");
+        {
+            throw new FormatException(
+                $"Invalid KGP control data: {failure.FormatReason(controlData.AsSpan())}");
+        }
 
         return FromParsed(command!);
     }

--- a/src/Hex1b/Kgp/KgpCommandParser.cs
+++ b/src/Hex1b/Kgp/KgpCommandParser.cs
@@ -1,277 +1,392 @@
-using System.Globalization;
-
 namespace Hex1b;
 
 internal static class KgpCommandParser
 {
-    internal sealed record Failure(
-        string Reason,
+    internal enum ErrorCode
+    {
+        None,
+        EmptyControlPair,
+        MalformedControlPair,
+        InvalidControlKey,
+        MissingValue,
+        InvalidDelimiter,
+        InvalidAction,
+        InvalidDeleteTarget,
+        InvalidTransmissionMedium,
+        InvalidCompression,
+        InvalidImageFormat,
+        InvalidSignedInteger,
+        InvalidUnsignedInteger,
+    }
+
+    internal readonly record struct Failure(
+        ErrorCode Code,
+        char Key,
+        int Position,
+        int ValueStart,
+        int ValueLength,
         KgpAction? Action,
         uint ImageId,
         uint ImageNumber,
         uint PlacementId,
-        KgpParsedCommand.QuietMode Quiet);
+        KgpParsedCommand.QuietMode Quiet)
+    {
+        internal string FormatReason(ReadOnlySpan<char> controlData)
+        {
+            var value = GetValue(controlData);
+            return Code switch
+            {
+                ErrorCode.EmptyControlPair
+                    => $"Empty control pair at position {Position}.",
+                ErrorCode.MalformedControlPair
+                    => $"Malformed control pair '{value.ToString()}'.",
+                ErrorCode.InvalidControlKey
+                    => $"Invalid control key '{Key}'.",
+                ErrorCode.MissingValue
+                    => $"Missing value for control key '{Key}'.",
+                ErrorCode.InvalidDelimiter
+                    => $"Invalid delimiter in value for control key '{Key}'.",
+                ErrorCode.InvalidAction
+                    => $"Invalid action value '{value.ToString()}'.",
+                ErrorCode.InvalidDeleteTarget
+                    => $"Invalid delete target '{value.ToString()}'.",
+                ErrorCode.InvalidTransmissionMedium
+                    => $"Invalid transmission medium '{value.ToString()}'.",
+                ErrorCode.InvalidCompression
+                    => $"Invalid compression value '{value.ToString()}'.",
+                ErrorCode.InvalidImageFormat
+                    => $"Invalid image format '{value.ToString()}'.",
+                ErrorCode.InvalidSignedInteger
+                    => $"Invalid signed integer '{value.ToString()}' for control key '{Key}'.",
+                ErrorCode.InvalidUnsignedInteger
+                    => $"Invalid unsigned integer '{value.ToString()}' for control key '{Key}'.",
+                _ => "Invalid KGP control data.",
+            };
+        }
 
-    private readonly record struct ControlPair(char Key, string Value);
+        private ReadOnlySpan<char> GetValue(ReadOnlySpan<char> controlData)
+        {
+            if (ValueStart < 0 ||
+                ValueLength < 0 ||
+                ValueStart > controlData.Length - ValueLength)
+            {
+                return [];
+            }
+
+            return controlData.Slice(ValueStart, ValueLength);
+        }
+    }
+
+    private enum ValidationResult
+    {
+        Unknown,
+        Valid,
+        Invalid,
+    }
+
+    private readonly record struct ParseError(
+        ErrorCode Code,
+        char Key,
+        int Position,
+        int ValueStart,
+        int ValueLength);
+
+    private struct ControlSlot
+    {
+        internal int ValueStart;
+        internal int ValueLength;
+
+        internal readonly bool IsPresent => ValueLength > 0;
+    }
 
     internal static bool TryParse(
         string? controlData,
         out KgpParsedCommand? command,
-        out Failure? failure)
+        out Failure failure)
+        => TryParse(controlData.AsSpan(), out command, out failure);
+
+    internal static bool TryParse(
+        ReadOnlySpan<char> controlData,
+        out KgpParsedCommand? command,
+        out Failure failure)
     {
-        var pairs = new List<ControlPair>();
-        var grammarError = ParsePairs(controlData, pairs);
-        var context = RecoverContext(pairs);
-        var recoveredAction = RecoverAction(pairs);
+        Span<ControlSlot> slots = stackalloc ControlSlot[52];
+        slots.Clear();
 
-        if (grammarError is not null)
+        var firstError = default(ParseError);
+        var hasActionControl = false;
+        if (!controlData.IsEmpty)
+        {
+            ScanControlData(
+                controlData,
+                slots,
+                ref firstError,
+                ref hasActionControl);
+        }
+
+        var action = HasValue(slots, 'a')
+            ? ReadAction(controlData, slots)
+            : hasActionControl
+                ? (KgpAction?)null
+                : KgpAction.Transmit;
+        var imageId = ReadUInt32(controlData, slots, 'i');
+        var imageNumber = ReadUInt32(controlData, slots, 'I');
+        var placementId = ReadUInt32(controlData, slots, 'p');
+        var quiet = ToQuietMode(ReadUInt32(controlData, slots, 'q'));
+
+        if (firstError.Code != ErrorCode.None)
         {
             command = null;
-            failure = CreateFailure(grammarError, recoveredAction, context);
+            failure = new Failure(
+                firstError.Code,
+                firstError.Key,
+                firstError.Position,
+                firstError.ValueStart,
+                firstError.ValueLength,
+                action,
+                imageId,
+                imageNumber,
+                placementId,
+                quiet);
             return false;
         }
 
-        if (!TryResolveAction(pairs, out var action, out var actionError))
-        {
-            command = null;
-            failure = CreateFailure(actionError!, null, context);
-            return false;
-        }
-
-        var values = new Dictionary<char, string>();
-        foreach (var pair in pairs)
-        {
-            if (!TryValidateKnownValue(pair, out var validationError))
-            {
-                command = null;
-                failure = CreateFailure(validationError!, action, context);
-                return false;
-            }
-
-            values[pair.Key] = pair.Value;
-        }
-
-        var quiet = ParseQuiet(values);
-        command = action switch
+        command = action!.Value switch
         {
             KgpAction.Transmit => new KgpParsedCommand.Transmit(
-                ParseTransmission(values),
+                ParseTransmission(controlData, slots),
                 quiet),
             KgpAction.TransmitAndDisplay => new KgpParsedCommand.TransmitAndDisplay(
-                ParseTransmission(values),
-                ParseDisplay(values),
+                ParseTransmission(controlData, slots),
+                ParseDisplay(controlData, slots),
                 quiet),
             KgpAction.Query => new KgpParsedCommand.Query(
-                ParseTransmission(values),
+                ParseTransmission(controlData, slots),
                 quiet),
             KgpAction.Put => new KgpParsedCommand.Put(
-                ParseDisplay(values),
+                ParseDisplay(controlData, slots),
                 quiet),
             KgpAction.Delete => new KgpParsedCommand.Delete(
-                ParseDelete(values),
+                ParseDelete(controlData, slots),
                 quiet),
             KgpAction.AnimationFrame => new KgpParsedCommand.AnimationFrame(
-                ParseTransmission(values),
-                ParseAnimationFrame(values),
+                ParseTransmission(controlData, slots),
+                ParseAnimationFrame(controlData, slots),
                 quiet),
             KgpAction.AnimationControl => new KgpParsedCommand.AnimationControl(
-                ParseAnimationControl(values),
+                ParseAnimationControl(controlData, slots),
                 quiet),
             KgpAction.Compose => new KgpParsedCommand.Compose(
-                ParseComposition(values),
+                ParseComposition(controlData, slots),
                 quiet),
-            _ => throw new InvalidOperationException($"Unsupported KGP action: {action}."),
+            _ => throw new InvalidOperationException(
+                $"Unsupported KGP action: {action.Value}."),
         };
-        failure = null;
+        failure = default;
         return true;
     }
 
-    private static string? ParsePairs(string? controlData, List<ControlPair> pairs)
+    private static void ScanControlData(
+        ReadOnlySpan<char> controlData,
+        Span<ControlSlot> slots,
+        ref ParseError firstError,
+        ref bool hasActionControl)
     {
-        if (string.IsNullOrEmpty(controlData))
-            return null;
+        var pairStart = 0;
+        var pairIndex = 0;
 
-        string? firstError = null;
-        var parts = controlData.Split(',');
-        for (var index = 0; index < parts.Length; index++)
+        while (pairStart <= controlData.Length)
         {
-            var part = parts[index];
-            if (part.Length == 0)
-            {
-                firstError ??= $"Empty control pair at position {index}.";
-                continue;
-            }
+            var remaining = controlData[pairStart..];
+            var commaIndex = remaining.IndexOf(',');
+            var pairLength = commaIndex >= 0
+                ? commaIndex
+                : remaining.Length;
 
-            var equalsIndex = part.IndexOf('=');
-            if (equalsIndex != 1 || part.LastIndexOf('=') != equalsIndex)
-            {
-                firstError ??= $"Malformed control pair '{part}'.";
-                continue;
-            }
+            ParsePair(
+                controlData,
+                pairStart,
+                pairLength,
+                pairIndex,
+                slots,
+                ref firstError,
+                ref hasActionControl);
 
-            var key = part[0];
-            if (!IsAsciiLetter(key))
-            {
-                firstError ??= $"Invalid control key '{key}'.";
-                continue;
-            }
+            if (commaIndex < 0)
+                break;
 
-            var value = part[2..];
-            if (value.Length == 0)
-            {
-                firstError ??= $"Missing value for control key '{key}'.";
-                continue;
-            }
-
-            if (value.Contains(';', StringComparison.Ordinal))
-            {
-                firstError ??= $"Invalid delimiter in value for control key '{key}'.";
-                continue;
-            }
-
-            pairs.Add(new ControlPair(key, value));
+            pairStart += pairLength + 1;
+            pairIndex++;
         }
-
-        return firstError;
     }
 
-    private static bool TryResolveAction(
-        List<ControlPair> pairs,
-        out KgpAction action,
-        out string? error)
+    private static void ParsePair(
+        ReadOnlySpan<char> controlData,
+        int pairStart,
+        int pairLength,
+        int pairIndex,
+        Span<ControlSlot> slots,
+        ref ParseError firstError,
+        ref bool hasActionControl)
     {
-        action = KgpAction.Transmit;
-        foreach (var pair in pairs)
+        if (pairLength == 0)
         {
-            if (pair.Key != 'a')
-                continue;
-
-            if (!TryParseAction(pair.Value, out action))
-            {
-                error = $"Invalid action value '{pair.Value}'.";
-                return false;
-            }
+            RecordFirstError(
+                ref firstError,
+                ErrorCode.EmptyControlPair,
+                key: default,
+                pairIndex,
+                pairStart,
+                pairLength);
+            return;
         }
 
-        error = null;
-        return true;
-    }
-
-    private static KgpAction? RecoverAction(List<ControlPair> pairs)
-    {
-        var action = KgpAction.Transmit;
-        foreach (var pair in pairs)
+        var pair = controlData.Slice(pairStart, pairLength);
+        var equalsIndex = pair.IndexOf('=');
+        if (equalsIndex != 1 || pair[(equalsIndex + 1)..].IndexOf('=') >= 0)
         {
-            if (pair.Key != 'a')
-                continue;
-
-            if (!TryParseAction(pair.Value, out action))
-                return null;
+            RecordFirstError(
+                ref firstError,
+                ErrorCode.MalformedControlPair,
+                key: default,
+                pairIndex,
+                pairStart,
+                pairLength);
+            return;
         }
 
-        return action;
-    }
-
-    private static (
-        uint ImageId,
-        uint ImageNumber,
-        uint PlacementId,
-        KgpParsedCommand.QuietMode Quiet) RecoverContext(List<ControlPair> pairs)
-    {
-        uint imageId = 0;
-        uint imageNumber = 0;
-        uint placementId = 0;
-        var quiet = KgpParsedCommand.QuietMode.Normal;
-
-        foreach (var pair in pairs)
+        var key = pair[0];
+        if (!IsAsciiLetter(key))
         {
-            if (!TryParseUInt32(pair.Value, out var value))
-                continue;
-
-            switch (pair.Key)
-            {
-                case 'i':
-                    imageId = value;
-                    break;
-                case 'I':
-                    imageNumber = value;
-                    break;
-                case 'p':
-                    placementId = value;
-                    break;
-                case 'q':
-                    quiet = ToQuietMode(value);
-                    break;
-            }
+            RecordFirstError(
+                ref firstError,
+                ErrorCode.InvalidControlKey,
+                key,
+                pairIndex,
+                pairStart,
+                pairLength);
+            return;
         }
 
-        return (imageId, imageNumber, placementId, quiet);
+        if (key == 'a')
+            hasActionControl = true;
+
+        var valueStart = pairStart + 2;
+        var valueLength = pairLength - 2;
+        if (valueLength == 0)
+        {
+            RecordFirstError(
+                ref firstError,
+                ErrorCode.MissingValue,
+                key,
+                pairIndex,
+                valueStart,
+                valueLength);
+            return;
+        }
+
+        var value = controlData.Slice(valueStart, valueLength);
+        if (value.IndexOf(';') >= 0)
+        {
+            RecordFirstError(
+                ref firstError,
+                ErrorCode.InvalidDelimiter,
+                key,
+                pairIndex,
+                valueStart,
+                valueLength);
+            return;
+        }
+
+        var validation = ValidateKnownValue(key, value, out var errorCode);
+        if (validation == ValidationResult.Unknown)
+            return;
+
+        if (validation == ValidationResult.Invalid)
+        {
+            RecordFirstError(
+                ref firstError,
+                errorCode,
+                key,
+                pairIndex,
+                valueStart,
+                valueLength);
+            return;
+        }
+
+        ref var slot = ref slots[GetKeyIndex(key)];
+        slot.ValueStart = valueStart;
+        slot.ValueLength = valueLength;
     }
 
-    private static Failure CreateFailure(
-        string reason,
-        KgpAction? action,
-        (
-            uint ImageId,
-            uint ImageNumber,
-            uint PlacementId,
-            KgpParsedCommand.QuietMode Quiet) context)
-        => new(
-            reason,
-            action,
-            context.ImageId,
-            context.ImageNumber,
-            context.PlacementId,
-            context.Quiet);
-
-    private static bool TryValidateKnownValue(
-        ControlPair pair,
-        out string? error)
+    private static void RecordFirstError(
+        ref ParseError firstError,
+        ErrorCode code,
+        char key,
+        int position,
+        int valueStart,
+        int valueLength)
     {
-        switch (pair.Key)
+        if (firstError.Code != ErrorCode.None)
+            return;
+
+        firstError = new ParseError(
+            code,
+            key,
+            position,
+            valueStart,
+            valueLength);
+    }
+
+    private static ValidationResult ValidateKnownValue(
+        char key,
+        ReadOnlySpan<char> value,
+        out ErrorCode errorCode)
+    {
+        switch (key)
         {
             case 'a':
-                if (!TryParseAction(pair.Value, out _))
+                if (!TryParseAction(value, out _))
                 {
-                    error = $"Invalid action value '{pair.Value}'.";
-                    return false;
+                    errorCode = ErrorCode.InvalidAction;
+                    return ValidationResult.Invalid;
                 }
                 break;
             case 'd':
-                if (!TryParseDeleteTarget(pair.Value, out _))
+                if (!TryParseDeleteTarget(value, out _))
                 {
-                    error = $"Invalid delete target '{pair.Value}'.";
-                    return false;
+                    errorCode = ErrorCode.InvalidDeleteTarget;
+                    return ValidationResult.Invalid;
                 }
                 break;
             case 't':
-                if (!TryParseMedium(pair.Value, out _))
+                if (!TryParseMedium(value, out _))
                 {
-                    error = $"Invalid transmission medium '{pair.Value}'.";
-                    return false;
+                    errorCode = ErrorCode.InvalidTransmissionMedium;
+                    return ValidationResult.Invalid;
                 }
                 break;
             case 'o':
-                if (!string.Equals(pair.Value, "z", StringComparison.Ordinal))
+                if (value.Length != 1 || value[0] != 'z')
                 {
-                    error = $"Invalid compression value '{pair.Value}'.";
-                    return false;
+                    errorCode = ErrorCode.InvalidCompression;
+                    return ValidationResult.Invalid;
                 }
                 break;
             case 'f':
-                if (!TryParseFormat(pair.Value, out _))
+                if (!TryParseFormat(value, out _))
                 {
-                    error = $"Invalid image format '{pair.Value}'.";
-                    return false;
+                    errorCode = ErrorCode.InvalidImageFormat;
+                    return ValidationResult.Invalid;
                 }
                 break;
             case 'z':
             case 'H':
             case 'V':
-                if (!TryParseInt32(pair.Value, out _))
+                if (!TryParseInt32(value, out _))
                 {
-                    error = $"Invalid signed integer '{pair.Value}' for control key '{pair.Key}'.";
-                    return false;
+                    errorCode = ErrorCode.InvalidSignedInteger;
+                    return ValidationResult.Invalid;
                 }
                 break;
             case 'q':
@@ -296,21 +411,20 @@ internal static class KgpCommandParser
             case 'U':
             case 'P':
             case 'Q':
-                if (!TryParseUInt32(pair.Value, out _))
+                if (!TryParseUInt32(value, out _))
                 {
-                    error = $"Invalid unsigned integer '{pair.Value}' for control key '{pair.Key}'.";
-                    return false;
+                    errorCode = ErrorCode.InvalidUnsignedInteger;
+                    return ValidationResult.Invalid;
                 }
                 break;
+            default:
+                errorCode = ErrorCode.None;
+                return ValidationResult.Unknown;
         }
 
-        error = null;
-        return true;
+        errorCode = ErrorCode.None;
+        return ValidationResult.Valid;
     }
-
-    private static KgpParsedCommand.QuietMode ParseQuiet(
-        IReadOnlyDictionary<char, string> values)
-        => ToQuietMode(ReadUInt32(values, 'q'));
 
     private static KgpParsedCommand.QuietMode ToQuietMode(uint value)
         => value switch
@@ -321,50 +435,53 @@ internal static class KgpCommandParser
         };
 
     private static KgpParsedCommand.TransmissionData ParseTransmission(
-        IReadOnlyDictionary<char, string> values)
+        ReadOnlySpan<char> controlData,
+        ReadOnlySpan<ControlSlot> slots)
         => new(
-            ReadFormat(values),
-            ReadMedium(values),
-            ReadUInt32(values, 's'),
-            ReadUInt32(values, 'v'),
-            ReadUInt32(values, 'S'),
-            ReadUInt32(values, 'O'),
-            ReadUInt32(values, 'i'),
-            ReadUInt32(values, 'I'),
-            ReadUInt32(values, 'p'),
-            values.ContainsKey('o')
+            ReadFormat(controlData, slots),
+            ReadMedium(controlData, slots),
+            ReadUInt32(controlData, slots, 's'),
+            ReadUInt32(controlData, slots, 'v'),
+            ReadUInt32(controlData, slots, 'S'),
+            ReadUInt32(controlData, slots, 'O'),
+            ReadUInt32(controlData, slots, 'i'),
+            ReadUInt32(controlData, slots, 'I'),
+            ReadUInt32(controlData, slots, 'p'),
+            HasValue(slots, 'o')
                 ? KgpParsedCommand.CompressionMode.Zlib
                 : KgpParsedCommand.CompressionMode.None,
-            ReadUInt32(values, 'm') != 0,
-            ReadUInt32(values, 'N'));
+            ReadUInt32(controlData, slots, 'm') != 0,
+            ReadUInt32(controlData, slots, 'N'));
 
     private static KgpParsedCommand.DisplayData ParseDisplay(
-        IReadOnlyDictionary<char, string> values)
+        ReadOnlySpan<char> controlData,
+        ReadOnlySpan<ControlSlot> slots)
         => new(
-            ReadUInt32(values, 'i'),
-            ReadUInt32(values, 'I'),
-            ReadUInt32(values, 'p'),
-            ReadUInt32(values, 'x'),
-            ReadUInt32(values, 'y'),
-            ReadUInt32(values, 'w'),
-            ReadUInt32(values, 'h'),
-            ReadUInt32(values, 'X'),
-            ReadUInt32(values, 'Y'),
-            ReadUInt32(values, 'c'),
-            ReadUInt32(values, 'r'),
-            ReadUInt32(values, 'C') == 1,
-            ReadUInt32(values, 'U') != 0,
-            ReadInt32(values, 'z'),
-            ReadUInt32(values, 'P'),
-            ReadUInt32(values, 'Q'),
-            ReadInt32(values, 'H'),
-            ReadInt32(values, 'V'));
+            ReadUInt32(controlData, slots, 'i'),
+            ReadUInt32(controlData, slots, 'I'),
+            ReadUInt32(controlData, slots, 'p'),
+            ReadUInt32(controlData, slots, 'x'),
+            ReadUInt32(controlData, slots, 'y'),
+            ReadUInt32(controlData, slots, 'w'),
+            ReadUInt32(controlData, slots, 'h'),
+            ReadUInt32(controlData, slots, 'X'),
+            ReadUInt32(controlData, slots, 'Y'),
+            ReadUInt32(controlData, slots, 'c'),
+            ReadUInt32(controlData, slots, 'r'),
+            ReadUInt32(controlData, slots, 'C') == 1,
+            ReadUInt32(controlData, slots, 'U') != 0,
+            ReadInt32(controlData, slots, 'z'),
+            ReadUInt32(controlData, slots, 'P'),
+            ReadUInt32(controlData, slots, 'Q'),
+            ReadInt32(controlData, slots, 'H'),
+            ReadInt32(controlData, slots, 'V'));
 
     private static KgpParsedCommand.DeleteSelector ParseDelete(
-        IReadOnlyDictionary<char, string> values)
+        ReadOnlySpan<char> controlData,
+        ReadOnlySpan<ControlSlot> slots)
     {
-        var target = values.TryGetValue('d', out var rawTarget)
-            ? rawTarget[0]
+        var target = HasValue(slots, 'd')
+            ? ReadValue(controlData, slots, 'd')[0]
             : 'a';
 
         return target switch
@@ -373,291 +490,419 @@ internal static class KgpCommandParser
             'A' => new KgpParsedCommand.DeleteSelector.All(true),
             'i' => new KgpParsedCommand.DeleteSelector.ById(
                 false,
-                ReadUInt32(values, 'i'),
-                ReadUInt32(values, 'p')),
+                ReadUInt32(controlData, slots, 'i'),
+                ReadUInt32(controlData, slots, 'p')),
             'I' => new KgpParsedCommand.DeleteSelector.ById(
                 true,
-                ReadUInt32(values, 'i'),
-                ReadUInt32(values, 'p')),
+                ReadUInt32(controlData, slots, 'i'),
+                ReadUInt32(controlData, slots, 'p')),
             'n' => new KgpParsedCommand.DeleteSelector.ByNumber(
                 false,
-                ReadUInt32(values, 'I'),
-                ReadUInt32(values, 'p')),
+                ReadUInt32(controlData, slots, 'I'),
+                ReadUInt32(controlData, slots, 'p')),
             'N' => new KgpParsedCommand.DeleteSelector.ByNumber(
                 true,
-                ReadUInt32(values, 'I'),
-                ReadUInt32(values, 'p')),
+                ReadUInt32(controlData, slots, 'I'),
+                ReadUInt32(controlData, slots, 'p')),
             'c' => new KgpParsedCommand.DeleteSelector.AtCursor(false),
             'C' => new KgpParsedCommand.DeleteSelector.AtCursor(true),
             'f' => new KgpParsedCommand.DeleteSelector.AnimationFrames(
                 false,
-                ReadUInt32(values, 'i'),
-                ReadUInt32(values, 'I'),
-                ReadUInt32(values, 'r')),
+                ReadUInt32(controlData, slots, 'i'),
+                ReadUInt32(controlData, slots, 'I'),
+                ReadUInt32(controlData, slots, 'r')),
             'F' => new KgpParsedCommand.DeleteSelector.AnimationFrames(
                 true,
-                ReadUInt32(values, 'i'),
-                ReadUInt32(values, 'I'),
-                ReadUInt32(values, 'r')),
+                ReadUInt32(controlData, slots, 'i'),
+                ReadUInt32(controlData, slots, 'I'),
+                ReadUInt32(controlData, slots, 'r')),
             'p' => new KgpParsedCommand.DeleteSelector.AtCell(
                 false,
-                ReadUInt32(values, 'x'),
-                ReadUInt32(values, 'y')),
+                ReadUInt32(controlData, slots, 'x'),
+                ReadUInt32(controlData, slots, 'y')),
             'P' => new KgpParsedCommand.DeleteSelector.AtCell(
                 true,
-                ReadUInt32(values, 'x'),
-                ReadUInt32(values, 'y')),
+                ReadUInt32(controlData, slots, 'x'),
+                ReadUInt32(controlData, slots, 'y')),
             'q' => new KgpParsedCommand.DeleteSelector.AtCellWithZIndex(
                 false,
-                ReadUInt32(values, 'x'),
-                ReadUInt32(values, 'y'),
-                ReadInt32(values, 'z')),
+                ReadUInt32(controlData, slots, 'x'),
+                ReadUInt32(controlData, slots, 'y'),
+                ReadInt32(controlData, slots, 'z')),
             'Q' => new KgpParsedCommand.DeleteSelector.AtCellWithZIndex(
                 true,
-                ReadUInt32(values, 'x'),
-                ReadUInt32(values, 'y'),
-                ReadInt32(values, 'z')),
+                ReadUInt32(controlData, slots, 'x'),
+                ReadUInt32(controlData, slots, 'y'),
+                ReadInt32(controlData, slots, 'z')),
             'r' => new KgpParsedCommand.DeleteSelector.ByRange(
                 false,
-                ReadUInt32(values, 'x'),
-                ReadUInt32(values, 'y')),
+                ReadUInt32(controlData, slots, 'x'),
+                ReadUInt32(controlData, slots, 'y')),
             'R' => new KgpParsedCommand.DeleteSelector.ByRange(
                 true,
-                ReadUInt32(values, 'x'),
-                ReadUInt32(values, 'y')),
+                ReadUInt32(controlData, slots, 'x'),
+                ReadUInt32(controlData, slots, 'y')),
             'x' => new KgpParsedCommand.DeleteSelector.ByColumn(
                 false,
-                ReadUInt32(values, 'x')),
+                ReadUInt32(controlData, slots, 'x')),
             'X' => new KgpParsedCommand.DeleteSelector.ByColumn(
                 true,
-                ReadUInt32(values, 'x')),
+                ReadUInt32(controlData, slots, 'x')),
             'y' => new KgpParsedCommand.DeleteSelector.ByRow(
                 false,
-                ReadUInt32(values, 'y')),
+                ReadUInt32(controlData, slots, 'y')),
             'Y' => new KgpParsedCommand.DeleteSelector.ByRow(
                 true,
-                ReadUInt32(values, 'y')),
+                ReadUInt32(controlData, slots, 'y')),
             'z' => new KgpParsedCommand.DeleteSelector.ByZIndex(
                 false,
-                ReadInt32(values, 'z')),
+                ReadInt32(controlData, slots, 'z')),
             'Z' => new KgpParsedCommand.DeleteSelector.ByZIndex(
                 true,
-                ReadInt32(values, 'z')),
-            _ => throw new InvalidOperationException($"Unsupported KGP delete target: {target}."),
+                ReadInt32(controlData, slots, 'z')),
+            _ => throw new InvalidOperationException(
+                $"Unsupported KGP delete target: {target}."),
         };
     }
 
     private static KgpParsedCommand.AnimationFrameData ParseAnimationFrame(
-        IReadOnlyDictionary<char, string> values)
+        ReadOnlySpan<char> controlData,
+        ReadOnlySpan<ControlSlot> slots)
         => new(
-            ReadUInt32(values, 'x'),
-            ReadUInt32(values, 'y'),
-            ReadUInt32(values, 'c'),
-            ReadUInt32(values, 'r'),
-            ReadInt32(values, 'z'),
-            ReadUInt32(values, 'X') == 1
+            ReadUInt32(controlData, slots, 'x'),
+            ReadUInt32(controlData, slots, 'y'),
+            ReadUInt32(controlData, slots, 'c'),
+            ReadUInt32(controlData, slots, 'r'),
+            ReadInt32(controlData, slots, 'z'),
+            ReadUInt32(controlData, slots, 'X') == 1
                 ? KgpParsedCommand.CompositionMode.Overwrite
                 : KgpParsedCommand.CompositionMode.AlphaBlend,
-            ReadUInt32(values, 'Y'));
+            ReadUInt32(controlData, slots, 'Y'));
 
     private static KgpParsedCommand.AnimationControlData ParseAnimationControl(
-        IReadOnlyDictionary<char, string> values)
+        ReadOnlySpan<char> controlData,
+        ReadOnlySpan<ControlSlot> slots)
         => new(
-            ReadUInt32(values, 'i'),
-            ReadUInt32(values, 'I'),
-            ReadUInt32(values, 'p'),
-            ReadUInt32(values, 's') switch
+            ReadUInt32(controlData, slots, 'i'),
+            ReadUInt32(controlData, slots, 'I'),
+            ReadUInt32(controlData, slots, 'p'),
+            ReadUInt32(controlData, slots, 's') switch
             {
                 1 => KgpParsedCommand.AnimationPlaybackState.Stopped,
                 2 => KgpParsedCommand.AnimationPlaybackState.Loading,
                 3 => KgpParsedCommand.AnimationPlaybackState.Running,
                 _ => KgpParsedCommand.AnimationPlaybackState.None,
             },
-            ReadUInt32(values, 'v'),
-            ReadUInt32(values, 'c'),
-            ReadUInt32(values, 'r'),
-            ReadInt32(values, 'z'));
+            ReadUInt32(controlData, slots, 'v'),
+            ReadUInt32(controlData, slots, 'c'),
+            ReadUInt32(controlData, slots, 'r'),
+            ReadInt32(controlData, slots, 'z'));
 
     private static KgpParsedCommand.CompositionData ParseComposition(
-        IReadOnlyDictionary<char, string> values)
+        ReadOnlySpan<char> controlData,
+        ReadOnlySpan<ControlSlot> slots)
         => new(
-            ReadUInt32(values, 'i'),
-            ReadUInt32(values, 'I'),
-            ReadUInt32(values, 'p'),
-            ReadUInt32(values, 'c'),
-            ReadUInt32(values, 'r'),
-            ReadUInt32(values, 'x'),
-            ReadUInt32(values, 'y'),
-            ReadUInt32(values, 'w'),
-            ReadUInt32(values, 'h'),
-            ReadUInt32(values, 'X'),
-            ReadUInt32(values, 'Y'),
-            ReadUInt32(values, 'C') == 0
+            ReadUInt32(controlData, slots, 'i'),
+            ReadUInt32(controlData, slots, 'I'),
+            ReadUInt32(controlData, slots, 'p'),
+            ReadUInt32(controlData, slots, 'c'),
+            ReadUInt32(controlData, slots, 'r'),
+            ReadUInt32(controlData, slots, 'x'),
+            ReadUInt32(controlData, slots, 'y'),
+            ReadUInt32(controlData, slots, 'w'),
+            ReadUInt32(controlData, slots, 'h'),
+            ReadUInt32(controlData, slots, 'X'),
+            ReadUInt32(controlData, slots, 'Y'),
+            ReadUInt32(controlData, slots, 'C') == 0
                 ? KgpParsedCommand.CompositionMode.AlphaBlend
                 : KgpParsedCommand.CompositionMode.Overwrite);
 
-    private static KgpFormat ReadFormat(IReadOnlyDictionary<char, string> values)
+    private static KgpAction ReadAction(
+        ReadOnlySpan<char> controlData,
+        ReadOnlySpan<ControlSlot> slots)
     {
-        if (!values.TryGetValue('f', out var value))
+        if (!HasValue(slots, 'a'))
+            return KgpAction.Transmit;
+
+        _ = TryParseAction(
+            ReadValue(controlData, slots, 'a'),
+            out var action);
+        return action;
+    }
+
+    private static KgpFormat ReadFormat(
+        ReadOnlySpan<char> controlData,
+        ReadOnlySpan<ControlSlot> slots)
+    {
+        if (!HasValue(slots, 'f'))
             return KgpFormat.Rgba32;
 
-        _ = TryParseFormat(value, out var format);
+        _ = TryParseFormat(
+            ReadValue(controlData, slots, 'f'),
+            out var format);
         return format;
     }
 
     private static KgpTransmissionMedium ReadMedium(
-        IReadOnlyDictionary<char, string> values)
+        ReadOnlySpan<char> controlData,
+        ReadOnlySpan<ControlSlot> slots)
     {
-        if (!values.TryGetValue('t', out var value))
+        if (!HasValue(slots, 't'))
             return KgpTransmissionMedium.Direct;
 
-        _ = TryParseMedium(value, out var medium);
+        _ = TryParseMedium(
+            ReadValue(controlData, slots, 't'),
+            out var medium);
         return medium;
     }
 
     private static uint ReadUInt32(
-        IReadOnlyDictionary<char, string> values,
+        ReadOnlySpan<char> controlData,
+        ReadOnlySpan<ControlSlot> slots,
         char key)
     {
-        if (!values.TryGetValue(key, out var value))
+        if (!HasValue(slots, key))
             return 0;
 
-        _ = TryParseUInt32(value, out var result);
+        _ = TryParseUInt32(
+            ReadValue(controlData, slots, key),
+            out var result);
         return result;
     }
 
     private static int ReadInt32(
-        IReadOnlyDictionary<char, string> values,
+        ReadOnlySpan<char> controlData,
+        ReadOnlySpan<ControlSlot> slots,
         char key)
     {
-        if (!values.TryGetValue(key, out var value))
+        if (!HasValue(slots, key))
             return 0;
 
-        _ = TryParseInt32(value, out var result);
+        _ = TryParseInt32(
+            ReadValue(controlData, slots, key),
+            out var result);
         return result;
     }
 
-    private static bool TryParseAction(string value, out KgpAction action)
+    private static bool HasValue(
+        ReadOnlySpan<ControlSlot> slots,
+        char key)
+        => slots[GetKeyIndex(key)].IsPresent;
+
+    private static ReadOnlySpan<char> ReadValue(
+        ReadOnlySpan<char> controlData,
+        ReadOnlySpan<ControlSlot> slots,
+        char key)
     {
-        action = value switch
-        {
-            "t" => KgpAction.Transmit,
-            "T" => KgpAction.TransmitAndDisplay,
-            "q" => KgpAction.Query,
-            "p" => KgpAction.Put,
-            "d" => KgpAction.Delete,
-            "f" => KgpAction.AnimationFrame,
-            "a" => KgpAction.AnimationControl,
-            "c" => KgpAction.Compose,
-            _ => default,
-        };
-        return value is "t" or "T" or "q" or "p" or "d" or "f" or "a" or "c";
+        ref readonly var slot = ref slots[GetKeyIndex(key)];
+        return slot.IsPresent
+            ? controlData.Slice(slot.ValueStart, slot.ValueLength)
+            : [];
     }
 
-    private static bool TryParseFormat(string value, out KgpFormat format)
+    private static bool TryParseAction(
+        ReadOnlySpan<char> value,
+        out KgpAction action)
     {
-        format = value switch
+        if (value.Length != 1)
         {
-            "24" => KgpFormat.Rgb24,
-            "32" => KgpFormat.Rgba32,
-            "100" => KgpFormat.Png,
+            action = default;
+            return false;
+        }
+
+        action = value[0] switch
+        {
+            't' => KgpAction.Transmit,
+            'T' => KgpAction.TransmitAndDisplay,
+            'q' => KgpAction.Query,
+            'p' => KgpAction.Put,
+            'd' => KgpAction.Delete,
+            'f' => KgpAction.AnimationFrame,
+            'a' => KgpAction.AnimationControl,
+            'c' => KgpAction.Compose,
             _ => default,
         };
-        return value is "24" or "32" or "100";
+        return value[0] is 't' or 'T' or 'q' or 'p' or 'd' or 'f' or 'a' or 'c';
+    }
+
+    private static bool TryParseFormat(
+        ReadOnlySpan<char> value,
+        out KgpFormat format)
+    {
+        if (value.SequenceEqual("24"))
+        {
+            format = KgpFormat.Rgb24;
+            return true;
+        }
+
+        if (value.SequenceEqual("32"))
+        {
+            format = KgpFormat.Rgba32;
+            return true;
+        }
+
+        if (value.SequenceEqual("100"))
+        {
+            format = KgpFormat.Png;
+            return true;
+        }
+
+        format = default;
+        return false;
     }
 
     private static bool TryParseMedium(
-        string value,
+        ReadOnlySpan<char> value,
         out KgpTransmissionMedium medium)
     {
-        medium = value switch
+        if (value.Length != 1)
         {
-            "d" => KgpTransmissionMedium.Direct,
-            "f" => KgpTransmissionMedium.File,
-            "t" => KgpTransmissionMedium.TempFile,
-            "s" => KgpTransmissionMedium.SharedMemory,
+            medium = default;
+            return false;
+        }
+
+        medium = value[0] switch
+        {
+            'd' => KgpTransmissionMedium.Direct,
+            'f' => KgpTransmissionMedium.File,
+            't' => KgpTransmissionMedium.TempFile,
+            's' => KgpTransmissionMedium.SharedMemory,
             _ => default,
         };
-        return value is "d" or "f" or "t" or "s";
+        return value[0] is 'd' or 'f' or 't' or 's';
     }
 
     private static bool TryParseDeleteTarget(
-        string value,
+        ReadOnlySpan<char> value,
         out KgpDeleteTarget target)
     {
-        target = value switch
+        if (value.Length != 1)
         {
-            "a" => KgpDeleteTarget.All,
-            "A" => KgpDeleteTarget.AllFreeData,
-            "i" => KgpDeleteTarget.ById,
-            "I" => KgpDeleteTarget.ByIdFreeData,
-            "n" => KgpDeleteTarget.ByNumber,
-            "N" => KgpDeleteTarget.ByNumberFreeData,
-            "c" => KgpDeleteTarget.AtCursor,
-            "C" => KgpDeleteTarget.AtCursorFreeData,
-            "p" => KgpDeleteTarget.AtCell,
-            "P" => KgpDeleteTarget.AtCellFreeData,
-            "q" => KgpDeleteTarget.AtCellWithZIndex,
-            "Q" => KgpDeleteTarget.AtCellWithZIndexFreeData,
-            "x" => KgpDeleteTarget.ByColumn,
-            "X" => KgpDeleteTarget.ByColumnFreeData,
-            "y" => KgpDeleteTarget.ByRow,
-            "Y" => KgpDeleteTarget.ByRowFreeData,
-            "z" => KgpDeleteTarget.ByZIndex,
-            "Z" => KgpDeleteTarget.ByZIndexFreeData,
-            "r" => KgpDeleteTarget.ByRange,
-            "R" => KgpDeleteTarget.ByRangeFreeData,
-            "f" => KgpDeleteTarget.AnimationFrames,
-            "F" => KgpDeleteTarget.AnimationFramesFreeData,
+            target = default;
+            return false;
+        }
+
+        target = value[0] switch
+        {
+            'a' => KgpDeleteTarget.All,
+            'A' => KgpDeleteTarget.AllFreeData,
+            'i' => KgpDeleteTarget.ById,
+            'I' => KgpDeleteTarget.ByIdFreeData,
+            'n' => KgpDeleteTarget.ByNumber,
+            'N' => KgpDeleteTarget.ByNumberFreeData,
+            'c' => KgpDeleteTarget.AtCursor,
+            'C' => KgpDeleteTarget.AtCursorFreeData,
+            'p' => KgpDeleteTarget.AtCell,
+            'P' => KgpDeleteTarget.AtCellFreeData,
+            'q' => KgpDeleteTarget.AtCellWithZIndex,
+            'Q' => KgpDeleteTarget.AtCellWithZIndexFreeData,
+            'x' => KgpDeleteTarget.ByColumn,
+            'X' => KgpDeleteTarget.ByColumnFreeData,
+            'y' => KgpDeleteTarget.ByRow,
+            'Y' => KgpDeleteTarget.ByRowFreeData,
+            'z' => KgpDeleteTarget.ByZIndex,
+            'Z' => KgpDeleteTarget.ByZIndexFreeData,
+            'r' => KgpDeleteTarget.ByRange,
+            'R' => KgpDeleteTarget.ByRangeFreeData,
+            'f' => KgpDeleteTarget.AnimationFrames,
+            'F' => KgpDeleteTarget.AnimationFramesFreeData,
             _ => default,
         };
-        return value is
-            "a" or "A" or "i" or "I" or "n" or "N" or "c" or "C" or
-            "p" or "P" or "q" or "Q" or "x" or "X" or "y" or "Y" or
-            "z" or "Z" or "r" or "R" or "f" or "F";
+        return value[0] is
+            'a' or 'A' or 'i' or 'I' or 'n' or 'N' or 'c' or 'C' or
+            'p' or 'P' or 'q' or 'Q' or 'x' or 'X' or 'y' or 'Y' or
+            'z' or 'Z' or 'r' or 'R' or 'f' or 'F';
     }
 
-    private static bool TryParseUInt32(string value, out uint result)
+    private static bool TryParseUInt32(
+        ReadOnlySpan<char> value,
+        out uint result)
     {
-        if (value.Length == 0 || !value.All(IsAsciiDigit))
+        if (value.IsEmpty)
         {
             result = 0;
             return false;
         }
 
-        return uint.TryParse(
-            value,
-            NumberStyles.None,
-            CultureInfo.InvariantCulture,
-            out result);
-    }
-
-    private static bool TryParseInt32(string value, out int result)
-    {
-        var digits = value;
-        if (value[0] == '-')
+        uint parsed = 0;
+        foreach (var character in value)
         {
-            if (value.Length == 1)
+            if (!IsAsciiDigit(character))
             {
                 result = 0;
                 return false;
             }
 
-            digits = value[1..];
+            var digit = (uint)(character - '0');
+            if (parsed > (uint.MaxValue - digit) / 10)
+            {
+                result = 0;
+                return false;
+            }
+
+            parsed = (parsed * 10) + digit;
         }
 
-        if (digits.Length == 0 || !digits.All(IsAsciiDigit))
+        result = parsed;
+        return true;
+    }
+
+    private static bool TryParseInt32(
+        ReadOnlySpan<char> value,
+        out int result)
+    {
+        if (value.IsEmpty)
         {
             result = 0;
             return false;
         }
 
-        return int.TryParse(
-            value,
-            NumberStyles.AllowLeadingSign,
-            CultureInfo.InvariantCulture,
-            out result);
+        var negative = value[0] == '-';
+        var digits = negative ? value[1..] : value;
+        if (digits.IsEmpty)
+        {
+            result = 0;
+            return false;
+        }
+
+        var limit = negative
+            ? (uint)int.MaxValue + 1
+            : int.MaxValue;
+        uint parsed = 0;
+        foreach (var character in digits)
+        {
+            if (!IsAsciiDigit(character))
+            {
+                result = 0;
+                return false;
+            }
+
+            var digit = (uint)(character - '0');
+            if (parsed > (limit - digit) / 10)
+            {
+                result = 0;
+                return false;
+            }
+
+            parsed = (parsed * 10) + digit;
+        }
+
+        if (!negative)
+        {
+            result = (int)parsed;
+            return true;
+        }
+
+        result = parsed == (uint)int.MaxValue + 1
+            ? int.MinValue
+            : -(int)parsed;
+        return true;
     }
+
+    private static int GetKeyIndex(char key)
+        => key is >= 'a' and <= 'z'
+            ? key - 'a'
+            : 26 + key - 'A';
 
     private static bool IsAsciiLetter(char value)
         => value is >= 'a' and <= 'z' or >= 'A' and <= 'Z';

--- a/src/Hex1b/Kgp/KgpCommandParser.cs
+++ b/src/Hex1b/Kgp/KgpCommandParser.cs
@@ -1,0 +1,667 @@
+using System.Globalization;
+
+namespace Hex1b;
+
+internal static class KgpCommandParser
+{
+    internal sealed record Failure(
+        string Reason,
+        KgpAction? Action,
+        uint ImageId,
+        uint ImageNumber,
+        uint PlacementId,
+        KgpParsedCommand.QuietMode Quiet);
+
+    private readonly record struct ControlPair(char Key, string Value);
+
+    internal static bool TryParse(
+        string? controlData,
+        out KgpParsedCommand? command,
+        out Failure? failure)
+    {
+        var pairs = new List<ControlPair>();
+        var grammarError = ParsePairs(controlData, pairs);
+        var context = RecoverContext(pairs);
+        var recoveredAction = RecoverAction(pairs);
+
+        if (grammarError is not null)
+        {
+            command = null;
+            failure = CreateFailure(grammarError, recoveredAction, context);
+            return false;
+        }
+
+        if (!TryResolveAction(pairs, out var action, out var actionError))
+        {
+            command = null;
+            failure = CreateFailure(actionError!, null, context);
+            return false;
+        }
+
+        var values = new Dictionary<char, string>();
+        foreach (var pair in pairs)
+        {
+            if (!TryValidateKnownValue(pair, out var validationError))
+            {
+                command = null;
+                failure = CreateFailure(validationError!, action, context);
+                return false;
+            }
+
+            values[pair.Key] = pair.Value;
+        }
+
+        var quiet = ParseQuiet(values);
+        command = action switch
+        {
+            KgpAction.Transmit => new KgpParsedCommand.Transmit(
+                ParseTransmission(values),
+                quiet),
+            KgpAction.TransmitAndDisplay => new KgpParsedCommand.TransmitAndDisplay(
+                ParseTransmission(values),
+                ParseDisplay(values),
+                quiet),
+            KgpAction.Query => new KgpParsedCommand.Query(
+                ParseTransmission(values),
+                quiet),
+            KgpAction.Put => new KgpParsedCommand.Put(
+                ParseDisplay(values),
+                quiet),
+            KgpAction.Delete => new KgpParsedCommand.Delete(
+                ParseDelete(values),
+                quiet),
+            KgpAction.AnimationFrame => new KgpParsedCommand.AnimationFrame(
+                ParseTransmission(values),
+                ParseAnimationFrame(values),
+                quiet),
+            KgpAction.AnimationControl => new KgpParsedCommand.AnimationControl(
+                ParseAnimationControl(values),
+                quiet),
+            KgpAction.Compose => new KgpParsedCommand.Compose(
+                ParseComposition(values),
+                quiet),
+            _ => throw new InvalidOperationException($"Unsupported KGP action: {action}."),
+        };
+        failure = null;
+        return true;
+    }
+
+    private static string? ParsePairs(string? controlData, List<ControlPair> pairs)
+    {
+        if (string.IsNullOrEmpty(controlData))
+            return null;
+
+        string? firstError = null;
+        var parts = controlData.Split(',');
+        for (var index = 0; index < parts.Length; index++)
+        {
+            var part = parts[index];
+            if (part.Length == 0)
+            {
+                firstError ??= $"Empty control pair at position {index}.";
+                continue;
+            }
+
+            var equalsIndex = part.IndexOf('=');
+            if (equalsIndex != 1 || part.LastIndexOf('=') != equalsIndex)
+            {
+                firstError ??= $"Malformed control pair '{part}'.";
+                continue;
+            }
+
+            var key = part[0];
+            if (!IsAsciiLetter(key))
+            {
+                firstError ??= $"Invalid control key '{key}'.";
+                continue;
+            }
+
+            var value = part[2..];
+            if (value.Length == 0)
+            {
+                firstError ??= $"Missing value for control key '{key}'.";
+                continue;
+            }
+
+            if (value.Contains(';', StringComparison.Ordinal))
+            {
+                firstError ??= $"Invalid delimiter in value for control key '{key}'.";
+                continue;
+            }
+
+            pairs.Add(new ControlPair(key, value));
+        }
+
+        return firstError;
+    }
+
+    private static bool TryResolveAction(
+        List<ControlPair> pairs,
+        out KgpAction action,
+        out string? error)
+    {
+        action = KgpAction.Transmit;
+        foreach (var pair in pairs)
+        {
+            if (pair.Key != 'a')
+                continue;
+
+            if (!TryParseAction(pair.Value, out action))
+            {
+                error = $"Invalid action value '{pair.Value}'.";
+                return false;
+            }
+        }
+
+        error = null;
+        return true;
+    }
+
+    private static KgpAction? RecoverAction(List<ControlPair> pairs)
+    {
+        var action = KgpAction.Transmit;
+        foreach (var pair in pairs)
+        {
+            if (pair.Key != 'a')
+                continue;
+
+            if (!TryParseAction(pair.Value, out action))
+                return null;
+        }
+
+        return action;
+    }
+
+    private static (
+        uint ImageId,
+        uint ImageNumber,
+        uint PlacementId,
+        KgpParsedCommand.QuietMode Quiet) RecoverContext(List<ControlPair> pairs)
+    {
+        uint imageId = 0;
+        uint imageNumber = 0;
+        uint placementId = 0;
+        var quiet = KgpParsedCommand.QuietMode.Normal;
+
+        foreach (var pair in pairs)
+        {
+            if (!TryParseUInt32(pair.Value, out var value))
+                continue;
+
+            switch (pair.Key)
+            {
+                case 'i':
+                    imageId = value;
+                    break;
+                case 'I':
+                    imageNumber = value;
+                    break;
+                case 'p':
+                    placementId = value;
+                    break;
+                case 'q':
+                    quiet = ToQuietMode(value);
+                    break;
+            }
+        }
+
+        return (imageId, imageNumber, placementId, quiet);
+    }
+
+    private static Failure CreateFailure(
+        string reason,
+        KgpAction? action,
+        (
+            uint ImageId,
+            uint ImageNumber,
+            uint PlacementId,
+            KgpParsedCommand.QuietMode Quiet) context)
+        => new(
+            reason,
+            action,
+            context.ImageId,
+            context.ImageNumber,
+            context.PlacementId,
+            context.Quiet);
+
+    private static bool TryValidateKnownValue(
+        ControlPair pair,
+        out string? error)
+    {
+        switch (pair.Key)
+        {
+            case 'a':
+                if (!TryParseAction(pair.Value, out _))
+                {
+                    error = $"Invalid action value '{pair.Value}'.";
+                    return false;
+                }
+                break;
+            case 'd':
+                if (!TryParseDeleteTarget(pair.Value, out _))
+                {
+                    error = $"Invalid delete target '{pair.Value}'.";
+                    return false;
+                }
+                break;
+            case 't':
+                if (!TryParseMedium(pair.Value, out _))
+                {
+                    error = $"Invalid transmission medium '{pair.Value}'.";
+                    return false;
+                }
+                break;
+            case 'o':
+                if (!string.Equals(pair.Value, "z", StringComparison.Ordinal))
+                {
+                    error = $"Invalid compression value '{pair.Value}'.";
+                    return false;
+                }
+                break;
+            case 'f':
+                if (!TryParseFormat(pair.Value, out _))
+                {
+                    error = $"Invalid image format '{pair.Value}'.";
+                    return false;
+                }
+                break;
+            case 'z':
+            case 'H':
+            case 'V':
+                if (!TryParseInt32(pair.Value, out _))
+                {
+                    error = $"Invalid signed integer '{pair.Value}' for control key '{pair.Key}'.";
+                    return false;
+                }
+                break;
+            case 'q':
+            case 's':
+            case 'v':
+            case 'S':
+            case 'O':
+            case 'i':
+            case 'I':
+            case 'p':
+            case 'm':
+            case 'N':
+            case 'x':
+            case 'y':
+            case 'w':
+            case 'h':
+            case 'X':
+            case 'Y':
+            case 'c':
+            case 'r':
+            case 'C':
+            case 'U':
+            case 'P':
+            case 'Q':
+                if (!TryParseUInt32(pair.Value, out _))
+                {
+                    error = $"Invalid unsigned integer '{pair.Value}' for control key '{pair.Key}'.";
+                    return false;
+                }
+                break;
+        }
+
+        error = null;
+        return true;
+    }
+
+    private static KgpParsedCommand.QuietMode ParseQuiet(
+        IReadOnlyDictionary<char, string> values)
+        => ToQuietMode(ReadUInt32(values, 'q'));
+
+    private static KgpParsedCommand.QuietMode ToQuietMode(uint value)
+        => value switch
+        {
+            0 => KgpParsedCommand.QuietMode.Normal,
+            1 => KgpParsedCommand.QuietMode.SuppressSuccess,
+            _ => KgpParsedCommand.QuietMode.SuppressAll,
+        };
+
+    private static KgpParsedCommand.TransmissionData ParseTransmission(
+        IReadOnlyDictionary<char, string> values)
+        => new(
+            ReadFormat(values),
+            ReadMedium(values),
+            ReadUInt32(values, 's'),
+            ReadUInt32(values, 'v'),
+            ReadUInt32(values, 'S'),
+            ReadUInt32(values, 'O'),
+            ReadUInt32(values, 'i'),
+            ReadUInt32(values, 'I'),
+            ReadUInt32(values, 'p'),
+            values.ContainsKey('o')
+                ? KgpParsedCommand.CompressionMode.Zlib
+                : KgpParsedCommand.CompressionMode.None,
+            ReadUInt32(values, 'm') != 0,
+            ReadUInt32(values, 'N'));
+
+    private static KgpParsedCommand.DisplayData ParseDisplay(
+        IReadOnlyDictionary<char, string> values)
+        => new(
+            ReadUInt32(values, 'i'),
+            ReadUInt32(values, 'I'),
+            ReadUInt32(values, 'p'),
+            ReadUInt32(values, 'x'),
+            ReadUInt32(values, 'y'),
+            ReadUInt32(values, 'w'),
+            ReadUInt32(values, 'h'),
+            ReadUInt32(values, 'X'),
+            ReadUInt32(values, 'Y'),
+            ReadUInt32(values, 'c'),
+            ReadUInt32(values, 'r'),
+            ReadUInt32(values, 'C') == 1,
+            ReadUInt32(values, 'U') != 0,
+            ReadInt32(values, 'z'),
+            ReadUInt32(values, 'P'),
+            ReadUInt32(values, 'Q'),
+            ReadInt32(values, 'H'),
+            ReadInt32(values, 'V'));
+
+    private static KgpParsedCommand.DeleteSelector ParseDelete(
+        IReadOnlyDictionary<char, string> values)
+    {
+        var target = values.TryGetValue('d', out var rawTarget)
+            ? rawTarget[0]
+            : 'a';
+
+        return target switch
+        {
+            'a' => new KgpParsedCommand.DeleteSelector.All(false),
+            'A' => new KgpParsedCommand.DeleteSelector.All(true),
+            'i' => new KgpParsedCommand.DeleteSelector.ById(
+                false,
+                ReadUInt32(values, 'i'),
+                ReadUInt32(values, 'p')),
+            'I' => new KgpParsedCommand.DeleteSelector.ById(
+                true,
+                ReadUInt32(values, 'i'),
+                ReadUInt32(values, 'p')),
+            'n' => new KgpParsedCommand.DeleteSelector.ByNumber(
+                false,
+                ReadUInt32(values, 'I'),
+                ReadUInt32(values, 'p')),
+            'N' => new KgpParsedCommand.DeleteSelector.ByNumber(
+                true,
+                ReadUInt32(values, 'I'),
+                ReadUInt32(values, 'p')),
+            'c' => new KgpParsedCommand.DeleteSelector.AtCursor(false),
+            'C' => new KgpParsedCommand.DeleteSelector.AtCursor(true),
+            'f' => new KgpParsedCommand.DeleteSelector.AnimationFrames(
+                false,
+                ReadUInt32(values, 'i'),
+                ReadUInt32(values, 'I'),
+                ReadUInt32(values, 'r')),
+            'F' => new KgpParsedCommand.DeleteSelector.AnimationFrames(
+                true,
+                ReadUInt32(values, 'i'),
+                ReadUInt32(values, 'I'),
+                ReadUInt32(values, 'r')),
+            'p' => new KgpParsedCommand.DeleteSelector.AtCell(
+                false,
+                ReadUInt32(values, 'x'),
+                ReadUInt32(values, 'y')),
+            'P' => new KgpParsedCommand.DeleteSelector.AtCell(
+                true,
+                ReadUInt32(values, 'x'),
+                ReadUInt32(values, 'y')),
+            'q' => new KgpParsedCommand.DeleteSelector.AtCellWithZIndex(
+                false,
+                ReadUInt32(values, 'x'),
+                ReadUInt32(values, 'y'),
+                ReadInt32(values, 'z')),
+            'Q' => new KgpParsedCommand.DeleteSelector.AtCellWithZIndex(
+                true,
+                ReadUInt32(values, 'x'),
+                ReadUInt32(values, 'y'),
+                ReadInt32(values, 'z')),
+            'r' => new KgpParsedCommand.DeleteSelector.ByRange(
+                false,
+                ReadUInt32(values, 'x'),
+                ReadUInt32(values, 'y')),
+            'R' => new KgpParsedCommand.DeleteSelector.ByRange(
+                true,
+                ReadUInt32(values, 'x'),
+                ReadUInt32(values, 'y')),
+            'x' => new KgpParsedCommand.DeleteSelector.ByColumn(
+                false,
+                ReadUInt32(values, 'x')),
+            'X' => new KgpParsedCommand.DeleteSelector.ByColumn(
+                true,
+                ReadUInt32(values, 'x')),
+            'y' => new KgpParsedCommand.DeleteSelector.ByRow(
+                false,
+                ReadUInt32(values, 'y')),
+            'Y' => new KgpParsedCommand.DeleteSelector.ByRow(
+                true,
+                ReadUInt32(values, 'y')),
+            'z' => new KgpParsedCommand.DeleteSelector.ByZIndex(
+                false,
+                ReadInt32(values, 'z')),
+            'Z' => new KgpParsedCommand.DeleteSelector.ByZIndex(
+                true,
+                ReadInt32(values, 'z')),
+            _ => throw new InvalidOperationException($"Unsupported KGP delete target: {target}."),
+        };
+    }
+
+    private static KgpParsedCommand.AnimationFrameData ParseAnimationFrame(
+        IReadOnlyDictionary<char, string> values)
+        => new(
+            ReadUInt32(values, 'x'),
+            ReadUInt32(values, 'y'),
+            ReadUInt32(values, 'c'),
+            ReadUInt32(values, 'r'),
+            ReadInt32(values, 'z'),
+            ReadUInt32(values, 'X') == 1
+                ? KgpParsedCommand.CompositionMode.Overwrite
+                : KgpParsedCommand.CompositionMode.AlphaBlend,
+            ReadUInt32(values, 'Y'));
+
+    private static KgpParsedCommand.AnimationControlData ParseAnimationControl(
+        IReadOnlyDictionary<char, string> values)
+        => new(
+            ReadUInt32(values, 'i'),
+            ReadUInt32(values, 'I'),
+            ReadUInt32(values, 'p'),
+            ReadUInt32(values, 's') switch
+            {
+                1 => KgpParsedCommand.AnimationPlaybackState.Stopped,
+                2 => KgpParsedCommand.AnimationPlaybackState.Loading,
+                3 => KgpParsedCommand.AnimationPlaybackState.Running,
+                _ => KgpParsedCommand.AnimationPlaybackState.None,
+            },
+            ReadUInt32(values, 'v'),
+            ReadUInt32(values, 'c'),
+            ReadUInt32(values, 'r'),
+            ReadInt32(values, 'z'));
+
+    private static KgpParsedCommand.CompositionData ParseComposition(
+        IReadOnlyDictionary<char, string> values)
+        => new(
+            ReadUInt32(values, 'i'),
+            ReadUInt32(values, 'I'),
+            ReadUInt32(values, 'p'),
+            ReadUInt32(values, 'c'),
+            ReadUInt32(values, 'r'),
+            ReadUInt32(values, 'x'),
+            ReadUInt32(values, 'y'),
+            ReadUInt32(values, 'w'),
+            ReadUInt32(values, 'h'),
+            ReadUInt32(values, 'X'),
+            ReadUInt32(values, 'Y'),
+            ReadUInt32(values, 'C') == 0
+                ? KgpParsedCommand.CompositionMode.AlphaBlend
+                : KgpParsedCommand.CompositionMode.Overwrite);
+
+    private static KgpFormat ReadFormat(IReadOnlyDictionary<char, string> values)
+    {
+        if (!values.TryGetValue('f', out var value))
+            return KgpFormat.Rgba32;
+
+        _ = TryParseFormat(value, out var format);
+        return format;
+    }
+
+    private static KgpTransmissionMedium ReadMedium(
+        IReadOnlyDictionary<char, string> values)
+    {
+        if (!values.TryGetValue('t', out var value))
+            return KgpTransmissionMedium.Direct;
+
+        _ = TryParseMedium(value, out var medium);
+        return medium;
+    }
+
+    private static uint ReadUInt32(
+        IReadOnlyDictionary<char, string> values,
+        char key)
+    {
+        if (!values.TryGetValue(key, out var value))
+            return 0;
+
+        _ = TryParseUInt32(value, out var result);
+        return result;
+    }
+
+    private static int ReadInt32(
+        IReadOnlyDictionary<char, string> values,
+        char key)
+    {
+        if (!values.TryGetValue(key, out var value))
+            return 0;
+
+        _ = TryParseInt32(value, out var result);
+        return result;
+    }
+
+    private static bool TryParseAction(string value, out KgpAction action)
+    {
+        action = value switch
+        {
+            "t" => KgpAction.Transmit,
+            "T" => KgpAction.TransmitAndDisplay,
+            "q" => KgpAction.Query,
+            "p" => KgpAction.Put,
+            "d" => KgpAction.Delete,
+            "f" => KgpAction.AnimationFrame,
+            "a" => KgpAction.AnimationControl,
+            "c" => KgpAction.Compose,
+            _ => default,
+        };
+        return value is "t" or "T" or "q" or "p" or "d" or "f" or "a" or "c";
+    }
+
+    private static bool TryParseFormat(string value, out KgpFormat format)
+    {
+        format = value switch
+        {
+            "24" => KgpFormat.Rgb24,
+            "32" => KgpFormat.Rgba32,
+            "100" => KgpFormat.Png,
+            _ => default,
+        };
+        return value is "24" or "32" or "100";
+    }
+
+    private static bool TryParseMedium(
+        string value,
+        out KgpTransmissionMedium medium)
+    {
+        medium = value switch
+        {
+            "d" => KgpTransmissionMedium.Direct,
+            "f" => KgpTransmissionMedium.File,
+            "t" => KgpTransmissionMedium.TempFile,
+            "s" => KgpTransmissionMedium.SharedMemory,
+            _ => default,
+        };
+        return value is "d" or "f" or "t" or "s";
+    }
+
+    private static bool TryParseDeleteTarget(
+        string value,
+        out KgpDeleteTarget target)
+    {
+        target = value switch
+        {
+            "a" => KgpDeleteTarget.All,
+            "A" => KgpDeleteTarget.AllFreeData,
+            "i" => KgpDeleteTarget.ById,
+            "I" => KgpDeleteTarget.ByIdFreeData,
+            "n" => KgpDeleteTarget.ByNumber,
+            "N" => KgpDeleteTarget.ByNumberFreeData,
+            "c" => KgpDeleteTarget.AtCursor,
+            "C" => KgpDeleteTarget.AtCursorFreeData,
+            "p" => KgpDeleteTarget.AtCell,
+            "P" => KgpDeleteTarget.AtCellFreeData,
+            "q" => KgpDeleteTarget.AtCellWithZIndex,
+            "Q" => KgpDeleteTarget.AtCellWithZIndexFreeData,
+            "x" => KgpDeleteTarget.ByColumn,
+            "X" => KgpDeleteTarget.ByColumnFreeData,
+            "y" => KgpDeleteTarget.ByRow,
+            "Y" => KgpDeleteTarget.ByRowFreeData,
+            "z" => KgpDeleteTarget.ByZIndex,
+            "Z" => KgpDeleteTarget.ByZIndexFreeData,
+            "r" => KgpDeleteTarget.ByRange,
+            "R" => KgpDeleteTarget.ByRangeFreeData,
+            "f" => KgpDeleteTarget.AnimationFrames,
+            "F" => KgpDeleteTarget.AnimationFramesFreeData,
+            _ => default,
+        };
+        return value is
+            "a" or "A" or "i" or "I" or "n" or "N" or "c" or "C" or
+            "p" or "P" or "q" or "Q" or "x" or "X" or "y" or "Y" or
+            "z" or "Z" or "r" or "R" or "f" or "F";
+    }
+
+    private static bool TryParseUInt32(string value, out uint result)
+    {
+        if (value.Length == 0 || !value.All(IsAsciiDigit))
+        {
+            result = 0;
+            return false;
+        }
+
+        return uint.TryParse(
+            value,
+            NumberStyles.None,
+            CultureInfo.InvariantCulture,
+            out result);
+    }
+
+    private static bool TryParseInt32(string value, out int result)
+    {
+        var digits = value;
+        if (value[0] == '-')
+        {
+            if (value.Length == 1)
+            {
+                result = 0;
+                return false;
+            }
+
+            digits = value[1..];
+        }
+
+        if (digits.Length == 0 || !digits.All(IsAsciiDigit))
+        {
+            result = 0;
+            return false;
+        }
+
+        return int.TryParse(
+            value,
+            NumberStyles.AllowLeadingSign,
+            CultureInfo.InvariantCulture,
+            out result);
+    }
+
+    private static bool IsAsciiLetter(char value)
+        => value is >= 'a' and <= 'z' or >= 'A' and <= 'Z';
+
+    private static bool IsAsciiDigit(char value)
+        => value is >= '0' and <= '9';
+}

--- a/src/Hex1b/Kgp/KgpCommandParser.cs
+++ b/src/Hex1b/Kgp/KgpCommandParser.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Hex1b;
 
 internal static class KgpCommandParser
@@ -115,13 +117,13 @@ internal static class KgpCommandParser
 
     internal static bool TryParse(
         string? controlData,
-        out KgpParsedCommand? command,
+        [NotNullWhen(true)] out KgpParsedCommand? command,
         out Failure failure)
         => TryParse(controlData.AsSpan(), out command, out failure);
 
     internal static bool TryParse(
         ReadOnlySpan<char> controlData,
-        out KgpParsedCommand? command,
+        [NotNullWhen(true)] out KgpParsedCommand? command,
         out Failure failure)
     {
         Span<ControlSlot> slots = stackalloc ControlSlot[52];

--- a/src/Hex1b/Kgp/KgpCommandParser.cs
+++ b/src/Hex1b/Kgp/KgpCommandParser.cs
@@ -91,6 +91,20 @@ internal static class KgpCommandParser
         int ValueStart,
         int ValueLength);
 
+    private struct ErrorCandidates
+    {
+        internal ParseError Grammar;
+        internal ParseError Action;
+        internal ParseError Validation;
+
+        internal readonly ParseError Preferred
+            => Grammar.Code != ErrorCode.None
+                ? Grammar
+                : Action.Code != ErrorCode.None
+                    ? Action
+                    : Validation;
+    }
+
     private struct ControlSlot
     {
         internal int ValueStart;
@@ -113,14 +127,14 @@ internal static class KgpCommandParser
         Span<ControlSlot> slots = stackalloc ControlSlot[52];
         slots.Clear();
 
-        var firstError = default(ParseError);
+        var errors = default(ErrorCandidates);
         var hasActionControl = false;
         if (!controlData.IsEmpty)
         {
             ScanControlData(
                 controlData,
                 slots,
-                ref firstError,
+                ref errors,
                 ref hasActionControl);
         }
 
@@ -133,16 +147,17 @@ internal static class KgpCommandParser
         var imageNumber = ReadUInt32(controlData, slots, 'I');
         var placementId = ReadUInt32(controlData, slots, 'p');
         var quiet = ToQuietMode(ReadUInt32(controlData, slots, 'q'));
+        var error = errors.Preferred;
 
-        if (firstError.Code != ErrorCode.None)
+        if (error.Code != ErrorCode.None)
         {
             command = null;
             failure = new Failure(
-                firstError.Code,
-                firstError.Key,
-                firstError.Position,
-                firstError.ValueStart,
-                firstError.ValueLength,
+                error.Code,
+                error.Key,
+                error.Position,
+                error.ValueStart,
+                error.ValueLength,
                 action,
                 imageId,
                 imageNumber,
@@ -189,7 +204,7 @@ internal static class KgpCommandParser
     private static void ScanControlData(
         ReadOnlySpan<char> controlData,
         Span<ControlSlot> slots,
-        ref ParseError firstError,
+        ref ErrorCandidates errors,
         ref bool hasActionControl)
     {
         var pairStart = 0;
@@ -209,7 +224,7 @@ internal static class KgpCommandParser
                 pairLength,
                 pairIndex,
                 slots,
-                ref firstError,
+                ref errors,
                 ref hasActionControl);
 
             if (commaIndex < 0)
@@ -226,13 +241,13 @@ internal static class KgpCommandParser
         int pairLength,
         int pairIndex,
         Span<ControlSlot> slots,
-        ref ParseError firstError,
+        ref ErrorCandidates errors,
         ref bool hasActionControl)
     {
         if (pairLength == 0)
         {
             RecordFirstError(
-                ref firstError,
+                ref errors.Grammar,
                 ErrorCode.EmptyControlPair,
                 key: default,
                 pairIndex,
@@ -246,7 +261,7 @@ internal static class KgpCommandParser
         if (equalsIndex != 1 || pair[(equalsIndex + 1)..].IndexOf('=') >= 0)
         {
             RecordFirstError(
-                ref firstError,
+                ref errors.Grammar,
                 ErrorCode.MalformedControlPair,
                 key: default,
                 pairIndex,
@@ -259,7 +274,7 @@ internal static class KgpCommandParser
         if (!IsAsciiLetter(key))
         {
             RecordFirstError(
-                ref firstError,
+                ref errors.Grammar,
                 ErrorCode.InvalidControlKey,
                 key,
                 pairIndex,
@@ -276,7 +291,7 @@ internal static class KgpCommandParser
         if (valueLength == 0)
         {
             RecordFirstError(
-                ref firstError,
+                ref errors.Grammar,
                 ErrorCode.MissingValue,
                 key,
                 pairIndex,
@@ -289,7 +304,7 @@ internal static class KgpCommandParser
         if (value.IndexOf(';') >= 0)
         {
             RecordFirstError(
-                ref firstError,
+                ref errors.Grammar,
                 ErrorCode.InvalidDelimiter,
                 key,
                 pairIndex,
@@ -304,13 +319,26 @@ internal static class KgpCommandParser
 
         if (validation == ValidationResult.Invalid)
         {
-            RecordFirstError(
-                ref firstError,
-                errorCode,
-                key,
-                pairIndex,
-                valueStart,
-                valueLength);
+            if (key == 'a')
+            {
+                RecordFirstError(
+                    ref errors.Action,
+                    errorCode,
+                    key,
+                    pairIndex,
+                    valueStart,
+                    valueLength);
+            }
+            else
+            {
+                RecordFirstError(
+                    ref errors.Validation,
+                    errorCode,
+                    key,
+                    pairIndex,
+                    valueStart,
+                    valueLength);
+            }
             return;
         }
 

--- a/src/Hex1b/Kgp/KgpImageStore.cs
+++ b/src/Hex1b/Kgp/KgpImageStore.cs
@@ -19,7 +19,7 @@ public sealed class KgpImageStore
     // Chunked transfer state
     private uint _chunkedImageId;
     private uint _chunkedImageNumber;
-    private KgpCommand? _chunkedCommand;
+    private KgpParsedCommand.TransmissionData? _chunkedCommand;
     private readonly List<byte> _chunkedData = new();
 
     /// <summary>
@@ -191,31 +191,37 @@ public sealed class KgpImageStore
     /// or null if more chunks are expected.
     /// </returns>
     public KgpImageData? ProcessChunk(KgpCommand command, byte[] decodedData)
+        => ProcessChunk(command.ToTransmissionData(), decodedData);
+
+    internal KgpImageData? ProcessChunk(
+        KgpParsedCommand.TransmissionData transmission,
+        byte[] decodedData)
     {
         lock (_lock)
         {
             if (_chunkedCommand is null)
             {
                 // First chunk — save the command metadata
-                _chunkedCommand = command;
-                _chunkedImageId = command.ImageId;
-                _chunkedImageNumber = command.ImageNumber;
+                _chunkedCommand = transmission;
+                _chunkedImageId = transmission.ImageId;
+                _chunkedImageNumber = transmission.ImageNumber;
             }
 
             _chunkedData.AddRange(decodedData);
 
-            if (command.MoreData == 0)
+            if (!transmission.MoreData)
             {
                 // Final chunk — assemble the complete image
                 var completeData = _chunkedData.ToArray();
                 var imageId = _chunkedImageId > 0 ? _chunkedImageId : AllocateIdUnsafe();
+                var chunkedCommand = _chunkedCommand.Value;
                 var image = new KgpImageData(
                     imageId,
                     _chunkedImageNumber,
                     completeData,
-                    _chunkedCommand.Width,
-                    _chunkedCommand.Height,
-                    _chunkedCommand.Format);
+                    chunkedCommand.Width,
+                    chunkedCommand.Height,
+                    chunkedCommand.Format);
 
                 AbortChunkedTransferUnsafe();
                 return image;

--- a/src/Hex1b/Kgp/KgpParsedCommand.cs
+++ b/src/Hex1b/Kgp/KgpParsedCommand.cs
@@ -1,0 +1,233 @@
+namespace Hex1b;
+
+internal abstract record KgpParsedCommand(KgpParsedCommand.QuietMode Quiet)
+{
+    internal enum QuietMode
+    {
+        Normal,
+        SuppressSuccess,
+        SuppressAll,
+    }
+
+    internal enum CompressionMode
+    {
+        None,
+        Zlib,
+    }
+
+    internal enum CompositionMode
+    {
+        AlphaBlend,
+        Overwrite,
+    }
+
+    internal enum AnimationPlaybackState
+    {
+        None,
+        Stopped,
+        Loading,
+        Running,
+    }
+
+    internal sealed record Transmit(
+        TransmissionData Transmission,
+        QuietMode Quiet) : KgpParsedCommand(Quiet);
+
+    internal sealed record TransmitAndDisplay(
+        TransmissionData Transmission,
+        DisplayData Display,
+        QuietMode Quiet) : KgpParsedCommand(Quiet);
+
+    internal sealed record Query(
+        TransmissionData Transmission,
+        QuietMode Quiet) : KgpParsedCommand(Quiet);
+
+    internal sealed record Put(
+        DisplayData Display,
+        QuietMode Quiet) : KgpParsedCommand(Quiet);
+
+    internal sealed record Delete(
+        DeleteSelector Selector,
+        QuietMode Quiet) : KgpParsedCommand(Quiet);
+
+    internal sealed record AnimationFrame(
+        TransmissionData Transmission,
+        AnimationFrameData Frame,
+        QuietMode Quiet) : KgpParsedCommand(Quiet);
+
+    internal sealed record AnimationControl(
+        AnimationControlData Control,
+        QuietMode Quiet) : KgpParsedCommand(Quiet);
+
+    internal sealed record Compose(
+        CompositionData Composition,
+        QuietMode Quiet) : KgpParsedCommand(Quiet);
+
+    internal readonly record struct TransmissionData(
+        KgpFormat Format,
+        KgpTransmissionMedium Medium,
+        uint Width,
+        uint Height,
+        uint FileSize,
+        uint FileOffset,
+        uint ImageId,
+        uint ImageNumber,
+        uint PlacementId,
+        CompressionMode Compression,
+        bool MoreData,
+        uint UsageHints);
+
+    internal readonly record struct DisplayData(
+        uint ImageId,
+        uint ImageNumber,
+        uint PlacementId,
+        uint SourceX,
+        uint SourceY,
+        uint SourceWidth,
+        uint SourceHeight,
+        uint CellOffsetX,
+        uint CellOffsetY,
+        uint Columns,
+        uint Rows,
+        bool SuppressCursorMovement,
+        bool UnicodePlaceholder,
+        int ZIndex,
+        uint ParentImageId,
+        uint ParentPlacementId,
+        int ParentOffsetHorizontal,
+        int ParentOffsetVertical);
+
+    internal readonly record struct AnimationFrameData(
+        uint X,
+        uint Y,
+        uint BaseFrameNumber,
+        uint EditFrameNumber,
+        int Gap,
+        CompositionMode Composition,
+        uint BackgroundColor);
+
+    internal readonly record struct AnimationControlData(
+        uint ImageId,
+        uint ImageNumber,
+        uint PlacementId,
+        AnimationPlaybackState State,
+        uint LoopCount,
+        uint CurrentFrameNumber,
+        uint AffectedFrameNumber,
+        int Gap);
+
+    internal readonly record struct CompositionData(
+        uint ImageId,
+        uint ImageNumber,
+        uint PlacementId,
+        uint DestinationFrameNumber,
+        uint SourceFrameNumber,
+        uint DestinationX,
+        uint DestinationY,
+        uint Width,
+        uint Height,
+        uint SourceX,
+        uint SourceY,
+        CompositionMode Composition);
+
+    internal abstract record DeleteSelector(bool DeleteImageData)
+    {
+        internal abstract KgpDeleteTarget Target { get; }
+
+        internal sealed record All(bool FreeData) : DeleteSelector(FreeData)
+        {
+            internal override KgpDeleteTarget Target
+                => FreeData ? KgpDeleteTarget.AllFreeData : KgpDeleteTarget.All;
+        }
+
+        internal sealed record ById(
+            bool FreeData,
+            uint ImageId,
+            uint PlacementId) : DeleteSelector(FreeData)
+        {
+            internal override KgpDeleteTarget Target
+                => FreeData ? KgpDeleteTarget.ByIdFreeData : KgpDeleteTarget.ById;
+        }
+
+        internal sealed record ByNumber(
+            bool FreeData,
+            uint ImageNumber,
+            uint PlacementId) : DeleteSelector(FreeData)
+        {
+            internal override KgpDeleteTarget Target
+                => FreeData ? KgpDeleteTarget.ByNumberFreeData : KgpDeleteTarget.ByNumber;
+        }
+
+        internal sealed record AtCursor(bool FreeData) : DeleteSelector(FreeData)
+        {
+            internal override KgpDeleteTarget Target
+                => FreeData ? KgpDeleteTarget.AtCursorFreeData : KgpDeleteTarget.AtCursor;
+        }
+
+        internal sealed record AnimationFrames(
+            bool FreeData,
+            uint ImageId,
+            uint ImageNumber,
+            uint FrameNumber) : DeleteSelector(FreeData)
+        {
+            internal override KgpDeleteTarget Target
+                => FreeData
+                    ? KgpDeleteTarget.AnimationFramesFreeData
+                    : KgpDeleteTarget.AnimationFrames;
+        }
+
+        internal sealed record AtCell(
+            bool FreeData,
+            uint X,
+            uint Y) : DeleteSelector(FreeData)
+        {
+            internal override KgpDeleteTarget Target
+                => FreeData ? KgpDeleteTarget.AtCellFreeData : KgpDeleteTarget.AtCell;
+        }
+
+        internal sealed record AtCellWithZIndex(
+            bool FreeData,
+            uint X,
+            uint Y,
+            int ZIndex) : DeleteSelector(FreeData)
+        {
+            internal override KgpDeleteTarget Target
+                => FreeData
+                    ? KgpDeleteTarget.AtCellWithZIndexFreeData
+                    : KgpDeleteTarget.AtCellWithZIndex;
+        }
+
+        internal sealed record ByRange(
+            bool FreeData,
+            uint FirstImageId,
+            uint LastImageId) : DeleteSelector(FreeData)
+        {
+            internal override KgpDeleteTarget Target
+                => FreeData ? KgpDeleteTarget.ByRangeFreeData : KgpDeleteTarget.ByRange;
+        }
+
+        internal sealed record ByColumn(
+            bool FreeData,
+            uint Column) : DeleteSelector(FreeData)
+        {
+            internal override KgpDeleteTarget Target
+                => FreeData ? KgpDeleteTarget.ByColumnFreeData : KgpDeleteTarget.ByColumn;
+        }
+
+        internal sealed record ByRow(
+            bool FreeData,
+            uint Row) : DeleteSelector(FreeData)
+        {
+            internal override KgpDeleteTarget Target
+                => FreeData ? KgpDeleteTarget.ByRowFreeData : KgpDeleteTarget.ByRow;
+        }
+
+        internal sealed record ByZIndex(
+            bool FreeData,
+            int ZIndex) : DeleteSelector(FreeData)
+        {
+            internal override KgpDeleteTarget Target
+                => FreeData ? KgpDeleteTarget.ByZIndexFreeData : KgpDeleteTarget.ByZIndex;
+        }
+    }
+}

--- a/tests/Hex1b.Tests/KgpCommandParserTests.cs
+++ b/tests/Hex1b.Tests/KgpCommandParserTests.cs
@@ -1,38 +1,22 @@
-
 namespace Hex1b.Tests;
 
 [TestClass]
 public class KgpCommandParserTests
 {
     [TestMethod]
-    public void Parse_EmptyString_ReturnsDefaults()
+    public void Parse_EmptyOrNullControlData_ReturnsDefaultTransmit()
     {
-        var cmd = KgpCommand.Parse("");
+        var empty = KgpCommand.Parse("");
+        var nullValue = KgpCommand.Parse(null!);
 
-        Assert.AreEqual(KgpAction.Transmit, cmd.Action);
-        Assert.AreEqual(KgpFormat.Rgba32, cmd.Format);
-        Assert.AreEqual(KgpTransmissionMedium.Direct, cmd.Medium);
-        Assert.AreEqual(0u, cmd.Width);
-        Assert.AreEqual(0u, cmd.Height);
-        Assert.AreEqual(0u, cmd.ImageId);
-        Assert.AreEqual(0u, cmd.ImageNumber);
-        Assert.AreEqual(0u, cmd.PlacementId);
-        Assert.AreEqual(0, cmd.Quiet);
-        Assert.AreEqual(0, cmd.MoreData);
-        Assert.IsNull(cmd.Compression);
-        Assert.AreEqual(0, cmd.ZIndex);
-        Assert.AreEqual(KgpDeleteTarget.All, cmd.DeleteTarget);
+        Assert.AreEqual(KgpAction.Transmit, empty.Action);
+        Assert.AreEqual(KgpFormat.Rgba32, empty.Format);
+        Assert.AreEqual(KgpTransmissionMedium.Direct, empty.Medium);
+        Assert.AreEqual(0, empty.Quiet);
+        Assert.AreEqual(0, empty.MoreData);
+        Assert.AreEqual(0u, empty.UsageHints);
+        Assert.AreEqual(KgpAction.Transmit, nullValue.Action);
     }
-
-    [TestMethod]
-    public void Parse_NullString_ReturnsDefaults()
-    {
-        var cmd = KgpCommand.Parse(null!);
-
-        Assert.AreEqual(KgpAction.Transmit, cmd.Action);
-    }
-
-    // --- Action parsing ---
 
     [TestMethod]
     [DataRow("a=t", KgpAction.Transmit)]
@@ -43,341 +27,611 @@ public class KgpCommandParserTests
     [DataRow("a=f", KgpAction.AnimationFrame)]
     [DataRow("a=a", KgpAction.AnimationControl)]
     [DataRow("a=c", KgpAction.Compose)]
-    public void Parse_ActionKey_CorrectAction(string controlData, KgpAction expected)
+    [DataRow("i=1,a=p,p=2", KgpAction.Put)]
+    public void Parse_ActionValue_ReturnsExpectedAction(
+        string controlData,
+        KgpAction expected)
     {
-        var cmd = KgpCommand.Parse(controlData);
-        Assert.AreEqual(expected, cmd.Action);
+        var command = KgpCommand.Parse(controlData);
+
+        Assert.AreEqual(expected, command.Action);
     }
 
     [TestMethod]
-    public void Parse_InvalidAction_DefaultsToTransmit()
+    public void Parse_TransmissionKeys_ReturnsTypedTransmission()
     {
-        var cmd = KgpCommand.Parse("a=Z");
-        Assert.AreEqual(KgpAction.Transmit, cmd.Action);
-    }
+        var parsed = ParseTyped<KgpParsedCommand.Transmit>(
+            "a=t,q=1,f=24,t=s,s=10,v=20,S=30,O=40,i=50,I=60,p=70,o=z,m=1,N=3");
 
-    // --- Format parsing ---
+        Assert.AreEqual(KgpParsedCommand.QuietMode.SuppressSuccess, parsed.Quiet);
+        Assert.AreEqual(KgpFormat.Rgb24, parsed.Transmission.Format);
+        Assert.AreEqual(KgpTransmissionMedium.SharedMemory, parsed.Transmission.Medium);
+        Assert.AreEqual(10u, parsed.Transmission.Width);
+        Assert.AreEqual(20u, parsed.Transmission.Height);
+        Assert.AreEqual(30u, parsed.Transmission.FileSize);
+        Assert.AreEqual(40u, parsed.Transmission.FileOffset);
+        Assert.AreEqual(50u, parsed.Transmission.ImageId);
+        Assert.AreEqual(60u, parsed.Transmission.ImageNumber);
+        Assert.AreEqual(70u, parsed.Transmission.PlacementId);
+        Assert.AreEqual(KgpParsedCommand.CompressionMode.Zlib, parsed.Transmission.Compression);
+        Assert.IsTrue(parsed.Transmission.MoreData);
+        Assert.AreEqual(3u, parsed.Transmission.UsageHints);
 
-    [TestMethod]
-    [DataRow("f=24", KgpFormat.Rgb24)]
-    [DataRow("f=32", KgpFormat.Rgba32)]
-    [DataRow("f=100", KgpFormat.Png)]
-    public void Parse_FormatKey_CorrectFormat(string controlData, KgpFormat expected)
-    {
-        var cmd = KgpCommand.Parse(controlData);
-        Assert.AreEqual(expected, cmd.Format);
-    }
-
-    [TestMethod]
-    public void Parse_InvalidFormat_DefaultsToRgba32()
-    {
-        var cmd = KgpCommand.Parse("f=99");
-        Assert.AreEqual(KgpFormat.Rgba32, cmd.Format);
-    }
-
-    // --- Transmission medium ---
-
-    [TestMethod]
-    [DataRow("t=d", KgpTransmissionMedium.Direct)]
-    [DataRow("t=f", KgpTransmissionMedium.File)]
-    [DataRow("t=t", KgpTransmissionMedium.TempFile)]
-    [DataRow("t=s", KgpTransmissionMedium.SharedMemory)]
-    public void Parse_MediumKey_CorrectMedium(string controlData, KgpTransmissionMedium expected)
-    {
-        var cmd = KgpCommand.Parse(controlData);
-        Assert.AreEqual(expected, cmd.Medium);
-    }
-
-    // --- Integer keys ---
-
-    [TestMethod]
-    public void Parse_DimensionKeys_ParsedCorrectly()
-    {
-        var cmd = KgpCommand.Parse("s=100,v=200");
-
-        Assert.AreEqual(100u, cmd.Width);
-        Assert.AreEqual(200u, cmd.Height);
+        var compatibility = KgpCommand.Parse(
+            "a=t,q=1,f=24,t=s,s=10,v=20,S=30,O=40,i=50,I=60,p=70,o=z,m=1,N=3");
+        Assert.AreEqual(3u, compatibility.UsageHints);
+        Assert.AreEqual('z', compatibility.Compression);
     }
 
     [TestMethod]
-    public void Parse_ImageIdAndNumber_ParsedCorrectly()
+    public void Parse_QueryKeys_ReturnsTypedTransmissionWithoutChangingAction()
     {
-        var cmd = KgpCommand.Parse("i=42,I=7");
+        var parsed = ParseTyped<KgpParsedCommand.Query>(
+            "i=31,s=1,v=1,a=q,t=d,f=24,N=1");
 
-        Assert.AreEqual(42u, cmd.ImageId);
-        Assert.AreEqual(7u, cmd.ImageNumber);
+        Assert.AreEqual(31u, parsed.Transmission.ImageId);
+        Assert.AreEqual(1u, parsed.Transmission.Width);
+        Assert.AreEqual(1u, parsed.Transmission.Height);
+        Assert.AreEqual(KgpTransmissionMedium.Direct, parsed.Transmission.Medium);
+        Assert.AreEqual(KgpFormat.Rgb24, parsed.Transmission.Format);
+        Assert.AreEqual(1u, parsed.Transmission.UsageHints);
     }
 
     [TestMethod]
-    public void Parse_PlacementId_ParsedCorrectly()
+    public void Parse_TransmitAndDisplayKeys_ReturnsSeparateTypedComponents()
     {
-        var cmd = KgpCommand.Parse("p=17");
-        Assert.AreEqual(17u, cmd.PlacementId);
+        var parsed = ParseTyped<KgpParsedCommand.TransmitAndDisplay>(
+            "a=T,f=24,t=d,s=100,v=200,S=300,O=400,i=42,I=43,p=7,o=z,m=1,N=1," +
+            "x=10,y=20,w=30,h=40,X=3,Y=5,c=6,r=8,C=1,U=1,z=-9,P=11,Q=12,H=-13,V=14");
+
+        Assert.AreEqual(100u, parsed.Transmission.Width);
+        Assert.AreEqual(200u, parsed.Transmission.Height);
+        Assert.AreEqual(1u, parsed.Transmission.UsageHints);
+        Assert.AreEqual(42u, parsed.Display.ImageId);
+        Assert.AreEqual(43u, parsed.Display.ImageNumber);
+        Assert.AreEqual(7u, parsed.Display.PlacementId);
+        Assert.AreEqual(10u, parsed.Display.SourceX);
+        Assert.AreEqual(20u, parsed.Display.SourceY);
+        Assert.AreEqual(30u, parsed.Display.SourceWidth);
+        Assert.AreEqual(40u, parsed.Display.SourceHeight);
+        Assert.AreEqual(3u, parsed.Display.CellOffsetX);
+        Assert.AreEqual(5u, parsed.Display.CellOffsetY);
+        Assert.AreEqual(6u, parsed.Display.Columns);
+        Assert.AreEqual(8u, parsed.Display.Rows);
+        Assert.IsTrue(parsed.Display.SuppressCursorMovement);
+        Assert.IsTrue(parsed.Display.UnicodePlaceholder);
+        Assert.AreEqual(-9, parsed.Display.ZIndex);
+        Assert.AreEqual(11u, parsed.Display.ParentImageId);
+        Assert.AreEqual(12u, parsed.Display.ParentPlacementId);
+        Assert.AreEqual(-13, parsed.Display.ParentOffsetHorizontal);
+        Assert.AreEqual(14, parsed.Display.ParentOffsetVertical);
     }
 
     [TestMethod]
-    public void Parse_MoreDataKey_ParsedCorrectly()
+    public void Parse_PutKeys_ReturnsTypedDisplay()
     {
-        var cmd = KgpCommand.Parse("m=1");
-        Assert.AreEqual(1, cmd.MoreData);
+        var parsed = ParseTyped<KgpParsedCommand.Put>(
+            "a=p,i=1,I=2,p=3,x=4,y=5,w=6,h=7,X=8,Y=9,c=10,r=11,C=2,U=3," +
+            "z=-12,P=13,Q=14,H=-15,V=16");
+
+        Assert.AreEqual(1u, parsed.Display.ImageId);
+        Assert.AreEqual(2u, parsed.Display.ImageNumber);
+        Assert.AreEqual(3u, parsed.Display.PlacementId);
+        Assert.AreEqual(4u, parsed.Display.SourceX);
+        Assert.AreEqual(5u, parsed.Display.SourceY);
+        Assert.AreEqual(6u, parsed.Display.SourceWidth);
+        Assert.AreEqual(7u, parsed.Display.SourceHeight);
+        Assert.AreEqual(8u, parsed.Display.CellOffsetX);
+        Assert.AreEqual(9u, parsed.Display.CellOffsetY);
+        Assert.AreEqual(10u, parsed.Display.Columns);
+        Assert.AreEqual(11u, parsed.Display.Rows);
+        Assert.IsFalse(parsed.Display.SuppressCursorMovement);
+        Assert.IsTrue(parsed.Display.UnicodePlaceholder);
+        Assert.AreEqual(-12, parsed.Display.ZIndex);
+        Assert.AreEqual(13u, parsed.Display.ParentImageId);
+        Assert.AreEqual(14u, parsed.Display.ParentPlacementId);
+        Assert.AreEqual(-15, parsed.Display.ParentOffsetHorizontal);
+        Assert.AreEqual(16, parsed.Display.ParentOffsetVertical);
     }
 
     [TestMethod]
-    public void Parse_QuietKey_ParsedCorrectly()
+    [DataRow("a", KgpDeleteTarget.All)]
+    [DataRow("A", KgpDeleteTarget.AllFreeData)]
+    [DataRow("i", KgpDeleteTarget.ById)]
+    [DataRow("I", KgpDeleteTarget.ByIdFreeData)]
+    [DataRow("n", KgpDeleteTarget.ByNumber)]
+    [DataRow("N", KgpDeleteTarget.ByNumberFreeData)]
+    [DataRow("c", KgpDeleteTarget.AtCursor)]
+    [DataRow("C", KgpDeleteTarget.AtCursorFreeData)]
+    [DataRow("f", KgpDeleteTarget.AnimationFrames)]
+    [DataRow("F", KgpDeleteTarget.AnimationFramesFreeData)]
+    [DataRow("p", KgpDeleteTarget.AtCell)]
+    [DataRow("P", KgpDeleteTarget.AtCellFreeData)]
+    [DataRow("q", KgpDeleteTarget.AtCellWithZIndex)]
+    [DataRow("Q", KgpDeleteTarget.AtCellWithZIndexFreeData)]
+    [DataRow("r", KgpDeleteTarget.ByRange)]
+    [DataRow("R", KgpDeleteTarget.ByRangeFreeData)]
+    [DataRow("x", KgpDeleteTarget.ByColumn)]
+    [DataRow("X", KgpDeleteTarget.ByColumnFreeData)]
+    [DataRow("y", KgpDeleteTarget.ByRow)]
+    [DataRow("Y", KgpDeleteTarget.ByRowFreeData)]
+    [DataRow("z", KgpDeleteTarget.ByZIndex)]
+    [DataRow("Z", KgpDeleteTarget.ByZIndexFreeData)]
+    public void Parse_DeleteTarget_ReturnsExpectedCompatibilityTarget(
+        string target,
+        KgpDeleteTarget expected)
     {
-        var cmd0 = KgpCommand.Parse("q=0");
-        Assert.AreEqual(0, cmd0.Quiet);
+        var command = KgpCommand.Parse($"a=d,d={target}");
 
-        var cmd1 = KgpCommand.Parse("q=1");
-        Assert.AreEqual(1, cmd1.Quiet);
-
-        var cmd2 = KgpCommand.Parse("q=2");
-        Assert.AreEqual(2, cmd2.Quiet);
+        Assert.AreEqual(expected, command.DeleteTarget);
     }
 
     [TestMethod]
-    public void Parse_CompressionKey_ParsedCorrectly()
+    public void Parse_DeleteSelectors_ReturnTypedOperands()
     {
-        var cmd = KgpCommand.Parse("o=z");
-        Assert.AreEqual('z', cmd.Compression);
+        var byId = ParseDeleteSelector<KgpParsedCommand.DeleteSelector.ById>(
+            "a=d,d=I,i=10,p=11");
+        Assert.IsTrue(byId.FreeData);
+        Assert.AreEqual(10u, byId.ImageId);
+        Assert.AreEqual(11u, byId.PlacementId);
+
+        var byNumber = ParseDeleteSelector<KgpParsedCommand.DeleteSelector.ByNumber>(
+            "a=d,d=n,I=12,p=13");
+        Assert.IsFalse(byNumber.FreeData);
+        Assert.AreEqual(12u, byNumber.ImageNumber);
+        Assert.AreEqual(13u, byNumber.PlacementId);
+
+        var atCell = ParseDeleteSelector<KgpParsedCommand.DeleteSelector.AtCell>(
+            "a=d,d=P,x=14,y=15");
+        Assert.IsTrue(atCell.FreeData);
+        Assert.AreEqual(14u, atCell.X);
+        Assert.AreEqual(15u, atCell.Y);
+
+        var atCellWithZ = ParseDeleteSelector<KgpParsedCommand.DeleteSelector.AtCellWithZIndex>(
+            "a=d,d=q,x=16,y=17,z=-18");
+        Assert.AreEqual(16u, atCellWithZ.X);
+        Assert.AreEqual(17u, atCellWithZ.Y);
+        Assert.AreEqual(-18, atCellWithZ.ZIndex);
+
+        var column = ParseDeleteSelector<KgpParsedCommand.DeleteSelector.ByColumn>(
+            "a=d,d=X,x=19");
+        Assert.IsTrue(column.FreeData);
+        Assert.AreEqual(19u, column.Column);
+
+        var row = ParseDeleteSelector<KgpParsedCommand.DeleteSelector.ByRow>(
+            "a=d,d=y,y=20");
+        Assert.AreEqual(20u, row.Row);
+
+        var zIndex = ParseDeleteSelector<KgpParsedCommand.DeleteSelector.ByZIndex>(
+            "a=d,d=Z,z=-21");
+        Assert.IsTrue(zIndex.FreeData);
+        Assert.AreEqual(-21, zIndex.ZIndex);
     }
 
     [TestMethod]
-    public void Parse_NoCompression_IsNull()
+    public void Parse_DeleteFrame_UsesRAsFrameNumberAndPreservesCompatibility()
     {
-        var cmd = KgpCommand.Parse("f=24");
-        Assert.IsNull(cmd.Compression);
+        var parsed = ParseTyped<KgpParsedCommand.Delete>("a=d,d=F,i=3,I=4,r=5");
+        var selector = TestSeq.IsType<KgpParsedCommand.DeleteSelector.AnimationFrames>(
+            parsed.Selector);
+
+        Assert.IsTrue(selector.FreeData);
+        Assert.AreEqual(3u, selector.ImageId);
+        Assert.AreEqual(4u, selector.ImageNumber);
+        Assert.AreEqual(5u, selector.FrameNumber);
+
+        var compatibility = KgpCommand.Parse("a=d,d=F,i=3,I=4,r=5");
+        Assert.AreEqual(5u, compatibility.DisplayRows);
     }
 
     [TestMethod]
-    public void Parse_FileSizeAndOffset_ParsedCorrectly()
+    public void Parse_DeleteRange_UsesXAndYAndDoesNotReinterpretR()
     {
-        var cmd = KgpCommand.Parse("S=1024,O=512");
+        var parsed = ParseTyped<KgpParsedCommand.Delete>(
+            "a=d,d=R,x=10,y=20,r=99");
+        var selector = TestSeq.IsType<KgpParsedCommand.DeleteSelector.ByRange>(
+            parsed.Selector);
 
-        Assert.AreEqual(1024u, cmd.FileSize);
-        Assert.AreEqual(512u, cmd.FileOffset);
-    }
+        Assert.IsTrue(selector.FreeData);
+        Assert.AreEqual(10u, selector.FirstImageId);
+        Assert.AreEqual(20u, selector.LastImageId);
 
-    // --- Display keys ---
-
-    [TestMethod]
-    public void Parse_SourceRectKeys_ParsedCorrectly()
-    {
-        var cmd = KgpCommand.Parse("x=10,y=20,w=100,h=200");
-
-        Assert.AreEqual(10u, cmd.SourceX);
-        Assert.AreEqual(20u, cmd.SourceY);
-        Assert.AreEqual(100u, cmd.SourceWidth);
-        Assert.AreEqual(200u, cmd.SourceHeight);
+        var compatibility = KgpCommand.Parse("a=d,d=R,x=10,y=20,r=99");
+        Assert.AreEqual(10u, compatibility.SourceX);
+        Assert.AreEqual(20u, compatibility.SourceY);
+        Assert.AreEqual(0u, compatibility.DisplayRows);
     }
 
     [TestMethod]
-    public void Parse_CellOffsetKeys_ParsedCorrectly()
+    public void Parse_AnimationFrameKeys_ReturnsActionSpecificMeanings()
     {
-        var cmd = KgpCommand.Parse("X=3,Y=5");
+        var parsed = ParseTyped<KgpParsedCommand.AnimationFrame>(
+            "a=f,f=32,t=d,s=100,v=200,S=300,O=400,i=5,I=6,p=7,o=z,m=1,N=1," +
+            "x=8,y=9,c=10,r=11,z=-12,X=1,Y=4278190335");
 
-        Assert.AreEqual(3u, cmd.CellOffsetX);
-        Assert.AreEqual(5u, cmd.CellOffsetY);
+        Assert.AreEqual(100u, parsed.Transmission.Width);
+        Assert.AreEqual(200u, parsed.Transmission.Height);
+        Assert.AreEqual(1u, parsed.Transmission.UsageHints);
+        Assert.AreEqual(8u, parsed.Frame.X);
+        Assert.AreEqual(9u, parsed.Frame.Y);
+        Assert.AreEqual(10u, parsed.Frame.BaseFrameNumber);
+        Assert.AreEqual(11u, parsed.Frame.EditFrameNumber);
+        Assert.AreEqual(-12, parsed.Frame.Gap);
+        Assert.AreEqual(KgpParsedCommand.CompositionMode.Overwrite, parsed.Frame.Composition);
+        Assert.AreEqual(4278190335u, parsed.Frame.BackgroundColor);
+
+        var compatibility = KgpCommand.Parse(
+            "a=f,s=100,v=200,x=8,y=9,c=10,r=11,z=-12,X=1,Y=4278190335");
+        Assert.AreEqual(10u, compatibility.DisplayColumns);
+        Assert.AreEqual(11u, compatibility.DisplayRows);
+        Assert.AreEqual(-12, compatibility.ZIndex);
+        Assert.AreEqual(1u, compatibility.CellOffsetX);
+        Assert.AreEqual(4278190335u, compatibility.CellOffsetY);
     }
 
     [TestMethod]
-    public void Parse_DisplaySizeKeys_ParsedCorrectly()
+    public void Parse_AnimationControlKeys_DoNotPopulateImageDimensions()
     {
-        var cmd = KgpCommand.Parse("c=10,r=5");
+        var parsed = ParseTyped<KgpParsedCommand.AnimationControl>(
+            "a=a,i=3,I=4,p=5,s=3,v=6,c=7,r=8,z=-9");
 
-        Assert.AreEqual(10u, cmd.DisplayColumns);
-        Assert.AreEqual(5u, cmd.DisplayRows);
+        Assert.AreEqual(3u, parsed.Control.ImageId);
+        Assert.AreEqual(4u, parsed.Control.ImageNumber);
+        Assert.AreEqual(5u, parsed.Control.PlacementId);
+        Assert.AreEqual(KgpParsedCommand.AnimationPlaybackState.Running, parsed.Control.State);
+        Assert.AreEqual(6u, parsed.Control.LoopCount);
+        Assert.AreEqual(7u, parsed.Control.CurrentFrameNumber);
+        Assert.AreEqual(8u, parsed.Control.AffectedFrameNumber);
+        Assert.AreEqual(-9, parsed.Control.Gap);
+
+        var compatibility = KgpCommand.Parse("a=a,i=3,s=3,v=6,c=7,r=8,z=-9");
+        Assert.AreEqual(3, compatibility.AnimationState);
+        Assert.AreEqual(6u, compatibility.LoopCount);
+        Assert.AreEqual(0u, compatibility.Width);
+        Assert.AreEqual(0u, compatibility.Height);
+        Assert.AreEqual(7u, compatibility.DisplayColumns);
+        Assert.AreEqual(8u, compatibility.DisplayRows);
+        Assert.AreEqual(-9, compatibility.ZIndex);
     }
 
     [TestMethod]
-    public void Parse_CursorMovementPolicy_ParsedCorrectly()
+    public void Parse_UnknownAnimationState_RemainsExplicitNoOp()
     {
-        var cmd = KgpCommand.Parse("C=1");
-        Assert.AreEqual(1, cmd.CursorMovement);
+        var parsed = ParseTyped<KgpParsedCommand.AnimationControl>("a=a,s=4294967295");
+
+        Assert.AreEqual(KgpParsedCommand.AnimationPlaybackState.None, parsed.Control.State);
+        Assert.AreEqual(0, KgpCommand.Parse("a=a,s=4294967295").AnimationState);
     }
 
     [TestMethod]
-    public void Parse_UnicodePlaceholder_ParsedCorrectly()
+    public void Parse_CompositionKeys_ReturnsActionSpecificMeanings()
     {
-        var cmd = KgpCommand.Parse("U=1");
-        Assert.AreEqual(1, cmd.UnicodePlaceholder);
+        var parsed = ParseTyped<KgpParsedCommand.Compose>(
+            "a=c,i=1,I=2,p=3,c=4,r=5,x=6,y=7,w=8,h=9,X=10,Y=11,C=2");
+
+        Assert.AreEqual(1u, parsed.Composition.ImageId);
+        Assert.AreEqual(2u, parsed.Composition.ImageNumber);
+        Assert.AreEqual(3u, parsed.Composition.PlacementId);
+        Assert.AreEqual(4u, parsed.Composition.DestinationFrameNumber);
+        Assert.AreEqual(5u, parsed.Composition.SourceFrameNumber);
+        Assert.AreEqual(6u, parsed.Composition.DestinationX);
+        Assert.AreEqual(7u, parsed.Composition.DestinationY);
+        Assert.AreEqual(8u, parsed.Composition.Width);
+        Assert.AreEqual(9u, parsed.Composition.Height);
+        Assert.AreEqual(10u, parsed.Composition.SourceX);
+        Assert.AreEqual(11u, parsed.Composition.SourceY);
+        Assert.AreEqual(KgpParsedCommand.CompositionMode.Overwrite, parsed.Composition.Composition);
     }
 
     [TestMethod]
-    public void Parse_ZIndex_ParsedCorrectly()
+    public void Parse_InapplicableKnownKeys_AreValidatedButNotExposed()
     {
-        var cmdPos = KgpCommand.Parse("z=5");
-        Assert.AreEqual(5, cmdPos.ZIndex);
+        var parsed = ParseTyped<KgpParsedCommand.Put>("a=p,f=24,t=s,s=7,v=8,N=1,i=9");
 
-        var cmdNeg = KgpCommand.Parse("z=-1");
-        Assert.AreEqual(-1, cmdNeg.ZIndex);
-    }
+        Assert.AreEqual(9u, parsed.Display.ImageId);
+        var compatibility = KgpCommand.Parse("a=p,f=24,t=s,s=7,v=8,N=1,i=9");
+        Assert.AreEqual(KgpFormat.Rgba32, compatibility.Format);
+        Assert.AreEqual(KgpTransmissionMedium.Direct, compatibility.Medium);
+        Assert.AreEqual(0u, compatibility.Width);
+        Assert.AreEqual(0u, compatibility.Height);
+        Assert.AreEqual(0u, compatibility.UsageHints);
 
-    // --- Relative placement keys ---
-
-    [TestMethod]
-    public void Parse_RelativePlacementKeys_ParsedCorrectly()
-    {
-        var cmd = KgpCommand.Parse("P=10,Q=3,H=2,V=-1");
-
-        Assert.AreEqual(10u, cmd.ParentImageId);
-        Assert.AreEqual(3u, cmd.ParentPlacementId);
-        Assert.AreEqual(2, cmd.ParentOffsetH);
-        Assert.AreEqual(-1, cmd.ParentOffsetV);
-    }
-
-    // --- Delete target ---
-
-    [TestMethod]
-    [DataRow("d=a", KgpDeleteTarget.All)]
-    [DataRow("d=A", KgpDeleteTarget.AllFreeData)]
-    [DataRow("d=i", KgpDeleteTarget.ById)]
-    [DataRow("d=I", KgpDeleteTarget.ByIdFreeData)]
-    [DataRow("d=n", KgpDeleteTarget.ByNumber)]
-    [DataRow("d=N", KgpDeleteTarget.ByNumberFreeData)]
-    [DataRow("d=c", KgpDeleteTarget.AtCursor)]
-    [DataRow("d=C", KgpDeleteTarget.AtCursorFreeData)]
-    [DataRow("d=p", KgpDeleteTarget.AtCell)]
-    [DataRow("d=P", KgpDeleteTarget.AtCellFreeData)]
-    [DataRow("d=q", KgpDeleteTarget.AtCellWithZIndex)]
-    [DataRow("d=Q", KgpDeleteTarget.AtCellWithZIndexFreeData)]
-    [DataRow("d=x", KgpDeleteTarget.ByColumn)]
-    [DataRow("d=X", KgpDeleteTarget.ByColumnFreeData)]
-    [DataRow("d=y", KgpDeleteTarget.ByRow)]
-    [DataRow("d=Y", KgpDeleteTarget.ByRowFreeData)]
-    [DataRow("d=z", KgpDeleteTarget.ByZIndex)]
-    [DataRow("d=Z", KgpDeleteTarget.ByZIndexFreeData)]
-    [DataRow("d=r", KgpDeleteTarget.ByRange)]
-    [DataRow("d=R", KgpDeleteTarget.ByRangeFreeData)]
-    [DataRow("d=f", KgpDeleteTarget.AnimationFrames)]
-    [DataRow("d=F", KgpDeleteTarget.AnimationFramesFreeData)]
-    public void Parse_DeleteTargetKey_CorrectTarget(string controlData, KgpDeleteTarget expected)
-    {
-        var cmd = KgpCommand.Parse($"a=d,{controlData}");
-        Assert.AreEqual(expected, cmd.DeleteTarget);
-    }
-
-    // --- Complex multi-key parsing ---
-
-    [TestMethod]
-    public void Parse_FullTransmitAndDisplay_AllKeysParsed()
-    {
-        var cmd = KgpCommand.Parse("a=T,f=24,s=100,v=200,i=42,p=7,m=0,q=1,o=z,c=10,r=5,z=-1");
-
-        Assert.AreEqual(KgpAction.TransmitAndDisplay, cmd.Action);
-        Assert.AreEqual(KgpFormat.Rgb24, cmd.Format);
-        Assert.AreEqual(100u, cmd.Width);
-        Assert.AreEqual(200u, cmd.Height);
-        Assert.AreEqual(42u, cmd.ImageId);
-        Assert.AreEqual(7u, cmd.PlacementId);
-        Assert.AreEqual(0, cmd.MoreData);
-        Assert.AreEqual(1, cmd.Quiet);
-        Assert.AreEqual('z', cmd.Compression);
-        Assert.AreEqual(10u, cmd.DisplayColumns);
-        Assert.AreEqual(5u, cmd.DisplayRows);
-        Assert.AreEqual(-1, cmd.ZIndex);
+        Assert.ThrowsExactly<FormatException>(() => KgpCommand.Parse("a=p,f=99"));
     }
 
     [TestMethod]
-    public void Parse_FullQueryCommand_AllKeysParsed()
+    public void Parse_MinimalContinuations_RemainRepresentable()
     {
-        var cmd = KgpCommand.Parse("i=31,s=1,v=1,a=q,t=d,f=24");
+        var transmit = ParseTyped<KgpParsedCommand.Transmit>("m=1,q=1");
+        var animationFrame = ParseTyped<KgpParsedCommand.AnimationFrame>("a=f,m=0,q=2");
 
-        Assert.AreEqual(KgpAction.Query, cmd.Action);
-        Assert.AreEqual(31u, cmd.ImageId);
-        Assert.AreEqual(1u, cmd.Width);
-        Assert.AreEqual(1u, cmd.Height);
-        Assert.AreEqual(KgpTransmissionMedium.Direct, cmd.Medium);
-        Assert.AreEqual(KgpFormat.Rgb24, cmd.Format);
+        Assert.IsTrue(transmit.Transmission.MoreData);
+        Assert.AreEqual(KgpParsedCommand.QuietMode.SuppressSuccess, transmit.Quiet);
+        Assert.IsFalse(animationFrame.Transmission.MoreData);
+        Assert.AreEqual(KgpParsedCommand.QuietMode.SuppressAll, animationFrame.Quiet);
     }
 
     [TestMethod]
-    public void Parse_DeleteWithPosition_AllKeysParsed()
+    public void Parse_QuietAndBooleanLikeControls_UseKittyCompatiblePolicies()
     {
-        var cmd = KgpCommand.Parse("a=d,d=p,x=3,y=4");
+        var quiet = ParseTyped<KgpParsedCommand.Transmit>("q=4294967295,m=2");
+        var display = ParseTyped<KgpParsedCommand.Put>("a=p,C=2,U=2");
+        var frame = ParseTyped<KgpParsedCommand.AnimationFrame>("a=f,X=2");
+        var composition = ParseTyped<KgpParsedCommand.Compose>("a=c,C=2");
 
-        Assert.AreEqual(KgpAction.Delete, cmd.Action);
-        Assert.AreEqual(KgpDeleteTarget.AtCell, cmd.DeleteTarget);
-        Assert.AreEqual(3u, cmd.SourceX);
-        Assert.AreEqual(4u, cmd.SourceY);
-    }
-
-    // --- Edge cases ---
-
-    [TestMethod]
-    public void Parse_InvalidKeyValuePair_SkipsGracefully()
-    {
-        // Pairs without = or empty value should be skipped
-        var cmd = KgpCommand.Parse("a=T,invalid,=bad,f=24");
-
-        Assert.AreEqual(KgpAction.TransmitAndDisplay, cmd.Action);
-        Assert.AreEqual(KgpFormat.Rgb24, cmd.Format);
+        Assert.AreEqual(KgpParsedCommand.QuietMode.SuppressAll, quiet.Quiet);
+        Assert.IsTrue(quiet.Transmission.MoreData);
+        Assert.IsFalse(display.Display.SuppressCursorMovement);
+        Assert.IsTrue(display.Display.UnicodePlaceholder);
+        Assert.AreEqual(KgpParsedCommand.CompositionMode.AlphaBlend, frame.Frame.Composition);
+        Assert.AreEqual(
+            KgpParsedCommand.CompositionMode.Overwrite,
+            composition.Composition.Composition);
     }
 
     [TestMethod]
-    public void Parse_NonNumericValue_DefaultsToZero()
+    public void Parse_DuplicateValidKeys_LastValueWins()
     {
-        var cmd = KgpCommand.Parse("s=abc,v=xyz");
+        var command = KgpCommand.Parse("a=t,a=p,i=1,i=2,i=3");
 
-        Assert.AreEqual(0u, cmd.Width);
-        Assert.AreEqual(0u, cmd.Height);
+        Assert.AreEqual(KgpAction.Put, command.Action);
+        Assert.AreEqual(3u, command.ImageId);
     }
 
     [TestMethod]
-    public void Parse_MaxUInt32_ParsedCorrectly()
+    public void Parse_DuplicateWithInvalidOccurrence_RejectsWholeCommand()
     {
-        var cmd = KgpCommand.Parse("i=4294967295");
-        Assert.AreEqual(4294967295u, cmd.ImageId);
+        Assert.ThrowsExactly<FormatException>(() => KgpCommand.Parse("a=t,i=bad,i=2"));
+        Assert.ThrowsExactly<FormatException>(() => KgpCommand.Parse("a=t,f=99,f=24"));
+        Assert.ThrowsExactly<FormatException>(() => KgpCommand.Parse("a=d,d=?,d=a"));
     }
 
     [TestMethod]
-    public void Parse_LargeNegativeZIndex_ParsedCorrectly()
+    public void Parse_UnknownSingleAlphabeticKey_IsIgnored()
     {
-        var cmd = KgpCommand.Parse("z=-1073741824");
-        Assert.AreEqual(-1073741824, cmd.ZIndex);
+        var command = KgpCommand.Parse("a=T,e=future,i=1");
+
+        Assert.AreEqual(KgpAction.TransmitAndDisplay, command.Action);
+        Assert.AreEqual(1u, command.ImageId);
     }
 
     [TestMethod]
-    public void Parse_DuplicateKeys_LastWins()
+    [DataRow("a=T,unknown=99,i=1")]
+    [DataRow("a=T,1=2")]
+    [DataRow("a=T,i")]
+    [DataRow("a=T,=2")]
+    [DataRow("a=T,i=")]
+    [DataRow("a=T,i=1=2")]
+    [DataRow(",a=T")]
+    [DataRow("a=T,")]
+    [DataRow("a=T,,i=1")]
+    [DataRow("a=T;i=1")]
+    [DataRow("a=T,i=1;payload")]
+    public void Parse_MalformedGrammar_RejectsCommand(string controlData)
     {
-        var cmd = KgpCommand.Parse("i=1,i=2,i=3");
-        Assert.AreEqual(3u, cmd.ImageId);
+        Assert.ThrowsExactly<FormatException>(() => KgpCommand.Parse(controlData));
     }
 
     [TestMethod]
-    public void Parse_UnknownKey_Ignored()
+    [DataRow("a=Z")]
+    [DataRow("a=tt")]
+    [DataRow("f=0")]
+    [DataRow("f=99")]
+    [DataRow("t=x")]
+    [DataRow("t=dd")]
+    [DataRow("o=x")]
+    [DataRow("o=zz")]
+    [DataRow("a=d,d=?")]
+    [DataRow("a=d,d=aa")]
+    public void Parse_InvalidEnumeratedControl_RejectsCommand(string controlData)
     {
-        var cmd = KgpCommand.Parse("a=T,unknown=99,i=1");
+        var failure = ParseFailure(controlData);
 
-        Assert.AreEqual(KgpAction.TransmitAndDisplay, cmd.Action);
-        Assert.AreEqual(1u, cmd.ImageId);
+        Assert.ThrowsExactly<FormatException>(() => KgpCommand.Parse(controlData));
+        Assert.IsFalse(string.IsNullOrWhiteSpace(failure.Reason));
     }
 
     [TestMethod]
-    public void Parse_KeyWithNoValue_Skipped()
+    public void Parse_AllUnsignedControls_AcceptUInt32Boundaries()
     {
-        var cmd = KgpCommand.Parse("a=T,i=");
-        Assert.AreEqual(KgpAction.TransmitAndDisplay, cmd.Action);
-        Assert.AreEqual(0u, cmd.ImageId);
+        foreach (var (prefix, key) in UnsignedControlContexts())
+        {
+            ParseSuccess($"{prefix},{key}=0");
+            ParseSuccess($"{prefix},{key}=4294967295");
+        }
     }
 
     [TestMethod]
-    public void Parse_ChunkedContinuationMinimalKeys_ParsedCorrectly()
+    public void Parse_AllSignedControls_AcceptInt32Boundaries()
     {
-        // Continuation chunks only need m and optionally q
-        var cmd = KgpCommand.Parse("m=1");
-        Assert.AreEqual(1, cmd.MoreData);
-        Assert.AreEqual(KgpAction.Transmit, cmd.Action);
+        foreach (var (prefix, key) in SignedControlContexts())
+        {
+            ParseSuccess($"{prefix},{key}=-2147483648");
+            ParseSuccess($"{prefix},{key}=2147483647");
+        }
     }
 
     [TestMethod]
-    public void Parse_AnimationControlKeys_ParsedCorrectly()
+    public void Parse_AllUnsignedControls_RejectMalformedAndOverflowValues()
     {
-        var cmd = KgpCommand.Parse("a=a,i=3,s=3,v=5");
-        Assert.AreEqual(KgpAction.AnimationControl, cmd.Action);
-        Assert.AreEqual(3u, cmd.ImageId);
-        // Note: 's' maps to AnimationState for animation control, but in our parser
-        // it maps to Width. This is acceptable since the same key has different
-        // semantics based on action type — the caller interprets based on Action.
+        var invalidValues = new[]
+        {
+            "",
+            "abc",
+            "-1",
+            "+1",
+            " 1",
+            "1 ",
+            "0x1",
+            "1.0",
+            "4294967296",
+        };
+
+        foreach (var (prefix, key) in UnsignedControlContexts())
+        {
+            foreach (var value in invalidValues)
+                ParseFailure($"{prefix},{key}={value}");
+        }
     }
+
+    [TestMethod]
+    public void Parse_AllSignedControls_RejectMalformedAndOverflowValues()
+    {
+        var invalidValues = new[]
+        {
+            "",
+            "abc",
+            "+1",
+            " 1",
+            "1 ",
+            "0x1",
+            "1.0",
+            "-2147483649",
+            "2147483648",
+        };
+
+        foreach (var (prefix, key) in SignedControlContexts())
+        {
+            foreach (var value in invalidValues)
+                ParseFailure($"{prefix},{key}={value}");
+        }
+    }
+
+    [TestMethod]
+    public void TryParse_FailurePreservesRecoverableContext()
+    {
+        var nonDelete = ParseFailure("a=t,i=7,I=8,p=9,q=2,f=99");
+        var delete = ParseFailure("i=10,a=d,q=1,d=?,I=11,p=12");
+
+        Assert.AreEqual(KgpAction.Transmit, nonDelete.Action);
+        Assert.AreEqual(7u, nonDelete.ImageId);
+        Assert.AreEqual(8u, nonDelete.ImageNumber);
+        Assert.AreEqual(9u, nonDelete.PlacementId);
+        Assert.AreEqual(KgpParsedCommand.QuietMode.SuppressAll, nonDelete.Quiet);
+
+        Assert.AreEqual(KgpAction.Delete, delete.Action);
+        Assert.AreEqual(10u, delete.ImageId);
+        Assert.AreEqual(11u, delete.ImageNumber);
+        Assert.AreEqual(12u, delete.PlacementId);
+        Assert.AreEqual(KgpParsedCommand.QuietMode.SuppressSuccess, delete.Quiet);
+    }
+
+    private static TCommand ParseTyped<TCommand>(string controlData)
+        where TCommand : KgpParsedCommand
+    {
+        var success = KgpCommandParser.TryParse(
+            controlData,
+            out var command,
+            out var failure);
+
+        Assert.IsTrue(success, failure?.Reason);
+        Assert.IsNotNull(command);
+        Assert.IsNull(failure);
+        return TestSeq.IsType<TCommand>(command);
+    }
+
+    private static TSelector ParseDeleteSelector<TSelector>(string controlData)
+        where TSelector : KgpParsedCommand.DeleteSelector
+    {
+        var command = ParseTyped<KgpParsedCommand.Delete>(controlData);
+        return TestSeq.IsType<TSelector>(command.Selector);
+    }
+
+    private static KgpCommandParser.Failure ParseFailure(string controlData)
+    {
+        var success = KgpCommandParser.TryParse(
+            controlData,
+            out var command,
+            out var failure);
+
+        Assert.IsFalse(success, $"Expected parsing to fail: {controlData}");
+        Assert.IsNull(command);
+        Assert.IsNotNull(failure);
+        return failure;
+    }
+
+    private static void ParseSuccess(string controlData)
+    {
+        var success = KgpCommandParser.TryParse(
+            controlData,
+            out var command,
+            out var failure);
+
+        Assert.IsTrue(success, $"{controlData}: {failure?.Reason}");
+        Assert.IsNotNull(command);
+    }
+
+    private static (string Prefix, string Key)[] UnsignedControlContexts()
+        =>
+        [
+            ("a=t", "q"),
+            ("a=t", "s"),
+            ("a=t", "v"),
+            ("a=t", "S"),
+            ("a=t", "O"),
+            ("a=t", "i"),
+            ("a=t", "I"),
+            ("a=t", "p"),
+            ("a=t", "m"),
+            ("a=t", "N"),
+            ("a=p", "i"),
+            ("a=p", "I"),
+            ("a=p", "p"),
+            ("a=p", "x"),
+            ("a=p", "y"),
+            ("a=p", "w"),
+            ("a=p", "h"),
+            ("a=p", "X"),
+            ("a=p", "Y"),
+            ("a=p", "c"),
+            ("a=p", "r"),
+            ("a=p", "C"),
+            ("a=p", "U"),
+            ("a=p", "P"),
+            ("a=p", "Q"),
+            ("a=d,d=f", "i"),
+            ("a=d,d=f", "I"),
+            ("a=d,d=i", "p"),
+            ("a=d,d=p", "x"),
+            ("a=d,d=p", "y"),
+            ("a=d,d=f", "r"),
+            ("a=f", "s"),
+            ("a=f", "v"),
+            ("a=f", "x"),
+            ("a=f", "y"),
+            ("a=f", "c"),
+            ("a=f", "r"),
+            ("a=f", "X"),
+            ("a=f", "Y"),
+            ("a=a", "i"),
+            ("a=a", "I"),
+            ("a=a", "p"),
+            ("a=a", "s"),
+            ("a=a", "v"),
+            ("a=a", "c"),
+            ("a=a", "r"),
+            ("a=c", "i"),
+            ("a=c", "I"),
+            ("a=c", "p"),
+            ("a=c", "c"),
+            ("a=c", "r"),
+            ("a=c", "x"),
+            ("a=c", "y"),
+            ("a=c", "w"),
+            ("a=c", "h"),
+            ("a=c", "X"),
+            ("a=c", "Y"),
+            ("a=c", "C"),
+        ];
+
+    private static (string Prefix, string Key)[] SignedControlContexts()
+        =>
+        [
+            ("a=p", "z"),
+            ("a=p", "H"),
+            ("a=p", "V"),
+            ("a=d,d=z", "z"),
+            ("a=f", "z"),
+            ("a=a", "z"),
+        ];
 }

--- a/tests/Hex1b.Tests/KgpCommandParserTests.cs
+++ b/tests/Hex1b.Tests/KgpCommandParserTests.cs
@@ -435,6 +435,29 @@ public class KgpCommandParserTests
     }
 
     [TestMethod]
+    public void TryParse_MixedErrors_UsesApprovedDiagnosticPrecedence()
+    {
+        const string grammarAndValidation = "f=99,broken";
+        const string actionAndValidation = "f=99,a=Z";
+
+        var grammarFailure = ParseFailure(grammarAndValidation);
+        var actionFailure = ParseFailure(actionAndValidation);
+
+        Assert.AreEqual(
+            KgpCommandParser.ErrorCode.MalformedControlPair,
+            grammarFailure.Code);
+        Assert.AreEqual(
+            "Malformed control pair 'broken'.",
+            grammarFailure.FormatReason(grammarAndValidation.AsSpan()));
+        Assert.AreEqual(
+            KgpCommandParser.ErrorCode.InvalidAction,
+            actionFailure.Code);
+        Assert.AreEqual(
+            "Invalid action value 'Z'.",
+            actionFailure.FormatReason(actionAndValidation.AsSpan()));
+    }
+
+    [TestMethod]
     public void Parse_AllUnsignedControls_AcceptUInt32Boundaries()
     {
         foreach (var (prefix, key) in UnsignedControlContexts())

--- a/tests/Hex1b.Tests/KgpCommandParserTests.cs
+++ b/tests/Hex1b.Tests/KgpCommandParserTests.cs
@@ -3,6 +3,8 @@ namespace Hex1b.Tests;
 [TestClass]
 public class KgpCommandParserTests
 {
+    public TestContext TestContext { get; set; } = null!;
+
     [TestMethod]
     public void Parse_EmptyOrNullControlData_ReturnsDefaultTransmit()
     {
@@ -428,7 +430,8 @@ public class KgpCommandParserTests
         var failure = ParseFailure(controlData);
 
         Assert.ThrowsExactly<FormatException>(() => KgpCommand.Parse(controlData));
-        Assert.IsFalse(string.IsNullOrWhiteSpace(failure.Reason));
+        Assert.IsFalse(
+            string.IsNullOrWhiteSpace(failure.FormatReason(controlData.AsSpan())));
     }
 
     [TestMethod]
@@ -502,6 +505,8 @@ public class KgpCommandParserTests
     {
         var nonDelete = ParseFailure("a=t,i=7,I=8,p=9,q=2,f=99");
         var delete = ParseFailure("i=10,a=d,q=1,d=?,I=11,p=12");
+        var invalidThenDelete = ParseFailure("a=x,a=d,d=?");
+        var deleteThenInvalid = ParseFailure("a=d,a=x");
 
         Assert.AreEqual(KgpAction.Transmit, nonDelete.Action);
         Assert.AreEqual(7u, nonDelete.ImageId);
@@ -514,6 +519,37 @@ public class KgpCommandParserTests
         Assert.AreEqual(11u, delete.ImageNumber);
         Assert.AreEqual(12u, delete.PlacementId);
         Assert.AreEqual(KgpParsedCommand.QuietMode.SuppressSuccess, delete.Quiet);
+        Assert.AreEqual(KgpAction.Delete, invalidThenDelete.Action);
+        Assert.AreEqual(KgpAction.Delete, deleteThenInvalid.Action);
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void TryParse_RepeatedCommands_StaysWithinAllocationBudget()
+    {
+        const int iterations = 10_000;
+        const string validControlData =
+            "a=T,f=24,t=d,s=100,v=200,S=300,O=400,i=42,p=7,m=0,q=1,N=1," +
+            "x=10,y=20,w=30,h=40,X=3,Y=5,c=6,r=8,C=1,U=1,z=-9,P=11,Q=12,H=-13,V=14";
+        const string invalidDeleteControlData = "a=d,d=f,i=42,r=bad,q=1";
+
+        var validBytes = MeasureParserAllocations(
+            validControlData,
+            expectedSuccess: true,
+            iterations);
+        var invalidDeleteBytes = MeasureParserAllocations(
+            invalidDeleteControlData,
+            expectedSuccess: false,
+            iterations);
+
+        TestContext.WriteLine(
+            $"Valid parse: {validBytes} bytes total, {(double)validBytes / iterations:F2} bytes/op.");
+        TestContext.WriteLine(
+            $"Invalid delete parse: {invalidDeleteBytes} bytes total, " +
+            $"{(double)invalidDeleteBytes / iterations:F2} bytes/op.");
+
+        Assert.IsLessThanOrEqualTo(256L, validBytes / iterations);
+        Assert.AreEqual(0L, invalidDeleteBytes);
     }
 
     private static TCommand ParseTyped<TCommand>(string controlData)
@@ -524,9 +560,11 @@ public class KgpCommandParserTests
             out var command,
             out var failure);
 
-        Assert.IsTrue(success, failure?.Reason);
+        Assert.IsTrue(
+            success,
+            success ? null : failure.FormatReason(controlData.AsSpan()));
         Assert.IsNotNull(command);
-        Assert.IsNull(failure);
+        Assert.AreEqual(KgpCommandParser.ErrorCode.None, failure.Code);
         return TestSeq.IsType<TCommand>(command);
     }
 
@@ -546,7 +584,7 @@ public class KgpCommandParserTests
 
         Assert.IsFalse(success, $"Expected parsing to fail: {controlData}");
         Assert.IsNull(command);
-        Assert.IsNotNull(failure);
+        Assert.AreNotEqual(KgpCommandParser.ErrorCode.None, failure.Code);
         return failure;
     }
 
@@ -557,8 +595,50 @@ public class KgpCommandParserTests
             out var command,
             out var failure);
 
-        Assert.IsTrue(success, $"{controlData}: {failure?.Reason}");
+        Assert.IsTrue(
+            success,
+            success ? null : $"{controlData}: {failure.FormatReason(controlData.AsSpan())}");
         Assert.IsNotNull(command);
+    }
+
+    private static long MeasureParserAllocations(
+        string controlData,
+        bool expectedSuccess,
+        int iterations)
+    {
+        for (var i = 0; i < 1_000; i++)
+        {
+            var success = KgpCommandParser.TryParse(
+                controlData,
+                out _,
+                out _);
+            Assert.AreEqual(expectedSuccess, success);
+        }
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var successfulParses = 0;
+        KgpParsedCommand? lastCommand = null;
+        var lastFailure = default(KgpCommandParser.Failure);
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < iterations; i++)
+        {
+            if (KgpCommandParser.TryParse(
+                controlData,
+                out lastCommand,
+                out lastFailure))
+            {
+                successfulParses++;
+            }
+        }
+
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+        Assert.AreEqual(expectedSuccess ? iterations : 0, successfulParses);
+        GC.KeepAlive(lastCommand);
+        GC.KeepAlive(lastFailure);
+        return allocated;
     }
 
     private static (string Prefix, string Key)[] UnsignedControlContexts()

--- a/tests/Hex1b.Tests/KgpConformanceTests.cs
+++ b/tests/Hex1b.Tests/KgpConformanceTests.cs
@@ -1194,23 +1194,17 @@ public class KgpGhosttyCommandParsingConformanceTests
     }
 
     [TestMethod]
-    public void IgnoreUnknownKeys_LongKey()
+    public void RejectUnknownKeys_LongKey()
     {
-        // Multi-char keys like "hello=world" should be silently ignored
-        var parsed = KgpCommand.Parse("f=24,s=10,v=20,hello=world");
-        Assert.AreEqual(KgpFormat.Rgb24, parsed.Format);
-        Assert.AreEqual(10u, parsed.Width);
-        Assert.AreEqual(20u, parsed.Height);
+        Assert.ThrowsExactly<FormatException>(
+            () => KgpCommand.Parse("f=24,s=10,v=20,hello=world"));
     }
 
     [TestMethod]
-    public void IgnoreVeryLongValues_OverflowsGracefully()
+    public void RejectVeryLongValues_ThatOverflowUInt32()
     {
-        // Enormous values that overflow uint should parse to 0 via TryParse failure
-        var parsed = KgpCommand.Parse("f=24,s=10,v=2000000000000000000000000000000000000000");
-        Assert.AreEqual(KgpFormat.Rgb24, parsed.Format);
-        Assert.AreEqual(10u, parsed.Width);
-        Assert.AreEqual(0u, parsed.Height); // overflow → TryParse fails → default 0
+        Assert.ThrowsExactly<FormatException>(
+            () => KgpCommand.Parse("f=24,s=10,v=2000000000000000000000000000000000000000"));
     }
 
     [TestMethod]

--- a/tests/Hex1b.Tests/KgpTerminalTests.cs
+++ b/tests/Hex1b.Tests/KgpTerminalTests.cs
@@ -305,6 +305,8 @@ public class KgpTerminalTests
     [DataRow("a=d,d=f,r=bad")]
     [DataRow("d=p,x=1,y=4294967296,a=d")]
     [DataRow("a=d,d=q,x=1,y=2,z=2147483648")]
+    [DataRow("a=x,a=d,d=?")]
+    [DataRow("a=d,a=x")]
     public void InvalidDeleteControl_IsNoResponseSafeNoOp(string controlData)
     {
         var workload = new RecordingWorkloadAdapter();

--- a/tests/Hex1b.Tests/KgpTerminalTests.cs
+++ b/tests/Hex1b.Tests/KgpTerminalTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Hex1b.Tokens;
 
 namespace Hex1b.Tests;
@@ -12,7 +13,10 @@ public class KgpTerminalTests
         Supports256Colors = true,
     };
 
-    private static Hex1bTerminal CreateTerminal(Hex1bAppWorkloadAdapter workload, int width = 80, int height = 24)
+    private static Hex1bTerminal CreateTerminal(
+        IHex1bTerminalWorkloadAdapter workload,
+        int width = 80,
+        int height = 24)
     {
         return Hex1bTerminal.CreateBuilder()
             .WithWorkload(workload)
@@ -254,6 +258,88 @@ public class KgpTerminalTests
         // the workload.WriteInputAsync to fully verify, but at minimum
         // this shouldn't crash)
         Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+    }
+
+    [TestMethod]
+    public void InvalidTransmitControl_EmitsEinvalWithRecoveredIdentity()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+
+        SendKgp(terminal, "\x1b_Ga=t,i=7,I=8,p=9,q=1,f=99\x1b\\");
+
+        Assert.AreEqual(
+            "\x1b_Gi=7,I=8;EINVAL:Invalid image format '99'.\x1b\\",
+            workload.ReadResponse());
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        Assert.IsEmpty(terminal.KgpPlacements);
+    }
+
+    [TestMethod]
+    public void InvalidAction_EmitsEinval()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+
+        SendKgp(terminal, "\x1b_Ga=Z,i=4\x1b\\");
+
+        Assert.AreEqual(
+            "\x1b_Gi=4;EINVAL:Invalid action value 'Z'.\x1b\\",
+            workload.ReadResponse());
+    }
+
+    [TestMethod]
+    public void InvalidNonDeleteControl_QuietTwoSuppressesEinval()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+
+        SendKgp(terminal, "\x1b_Ga=t,i=7,q=2,f=99\x1b\\");
+
+        workload.AssertNoResponse();
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+    }
+
+    [TestMethod]
+    [DataRow("a=d,d=?")]
+    [DataRow("a=d,d=f,r=bad")]
+    [DataRow("d=p,x=1,y=4294967296,a=d")]
+    [DataRow("a=d,d=q,x=1,y=2,z=2147483648")]
+    public void InvalidDeleteControl_IsNoResponseSafeNoOp(string controlData)
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildTransmitCommand(
+                imageId: 1,
+                width: 1,
+                height: 1,
+                quiet: 2));
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+
+        SendKgp(terminal, $"\x1b_G{controlData},i=1\x1b\\");
+
+        workload.AssertNoResponse();
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
+    }
+
+    [TestMethod]
+    [DataRow("a=f,i=1,s=1,v=1")]
+    [DataRow("a=a,i=1,s=3,v=1")]
+    [DataRow("a=c,i=1,c=1,r=1")]
+    public void ValidUnimplementedAnimationAction_IsTypedNoOp(string controlData)
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+
+        SendKgp(terminal, $"\x1b_G{controlData}\x1b\\");
+
+        workload.AssertNoResponse();
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        Assert.IsEmpty(terminal.KgpPlacements);
     }
 
     // =============================================
@@ -726,5 +812,73 @@ public class KgpTerminalTests
         // After scroll, placement row should decrease by 1 (scrolled up)
         // Note: This test documents the expected behavior - implementation
         // may need to handle placement scrolling in the scroll logic
+    }
+
+    private sealed class RecordingWorkloadAdapter : IHex1bTerminalWorkloadAdapter
+    {
+        private readonly Queue<byte[]> _responses = new();
+        private readonly object _lock = new();
+
+        public event Action? Disconnected
+        {
+            add { }
+            remove { }
+        }
+
+        public ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(CancellationToken ct = default)
+            => ValueTask.FromResult(ReadOnlyMemory<byte>.Empty);
+
+        public ValueTask WriteInputAsync(
+            ReadOnlyMemory<byte> data,
+            CancellationToken ct = default)
+        {
+            lock (_lock)
+            {
+                _responses.Enqueue(data.ToArray());
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask ResizeAsync(
+            int width,
+            int height,
+            CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync()
+            => ValueTask.CompletedTask;
+
+        public string ReadResponse()
+        {
+            byte[]? response = null;
+            var received = SpinWait.SpinUntil(
+                () =>
+                {
+                    lock (_lock)
+                    {
+                        return _responses.TryDequeue(out response);
+                    }
+                },
+                TimeSpan.FromSeconds(1));
+
+            Assert.IsTrue(received, "Expected a KGP protocol response.");
+            return Encoding.UTF8.GetString(response!);
+        }
+
+        public void AssertNoResponse()
+        {
+            var received = SpinWait.SpinUntil(
+                () =>
+                {
+                    lock (_lock)
+                    {
+                        return _responses.Count > 0;
+                    }
+                },
+                TimeSpan.FromMilliseconds(100));
+
+            Assert.IsFalse(received, "Expected no KGP protocol response.");
+        }
     }
 }

--- a/tests/Hex1b.Tests/KgpTokenizerTests.cs
+++ b/tests/Hex1b.Tests/KgpTokenizerTests.cs
@@ -16,6 +16,16 @@ public class KgpTokenizerTests
     }
 
     [TestMethod]
+    public void Tokenize_KgpWithInvalidSemanticControls_StillProducesKgpToken()
+    {
+        var tokens = AnsiTokenizer.Tokenize("\x1b_Ga=invalid,f=99;AAAA\x1b\\");
+
+        var kgpToken = TestSeq.Single(tokens.OfType<KgpToken>());
+        Assert.AreEqual("a=invalid,f=99", kgpToken.ControlData);
+        Assert.AreEqual("AAAA", kgpToken.Payload);
+    }
+
+    [TestMethod]
     public void Tokenize_KgpWithNoPayload_ProducesKgpTokenWithEmptyPayload()
     {
         var tokens = AnsiTokenizer.Tokenize("\x1b_Ga=d,d=a\x1b\\");


### PR DESCRIPTION
## Summary
- parse KGP controls into internal action-specific command records while preserving the public `KgpCommand` compatibility surface
- validate grammar, numeric ranges, actions, formats, media, compression, delete selectors, duplicates, and unknown-key policy; represent usage hint `N`
- dispatch typed commands without reparsing and apply contextual parse-failure response policy, including no-response malformed deletes
- parse control data with `ReadOnlySpan<char>` and a stack-allocated fixed-slot table, avoiding split/substrings/list/dictionary/LINQ intermediates
- keep parse failures as structured value data and format reasons only when an exception or non-delete `EINVAL` is actually emitted
- preserve approved diagnostic precedence after the full scan: grammar errors, then invalid action, then other known-value validation
- add exhaustive parser, tokenizer-boundary, compatibility, terminal-dispatch, diagnostic-precedence, and allocation-regression coverage

## Allocation evidence
Warmed 10,000-iteration measurements using `GC.GetAllocatedBytesForCurrentThread`:

| Scenario | Before | After | Change |
|---|---:|---:|---:|
| Valid transmit-and-display parse | 7,752 B/op | 136 B/op | 57x lower (98.2% reduction) |
| Malformed no-response delete parse | 1,248 B/op | 0 B/op | eliminated |

The remaining valid-path allocation is the required typed command result.

## Validation
- Focused KGP suite: 177 passed
- `Hex1b.Tests`: 7,956 passed, 24 skipped
- `Hex1b.Analyzers.Tests`: 67 passed
- `Hex1b.McpServer.Tests`: 6 passed
- `Hex1b.Tool.Tests`: 58 passed
- `Hex1b.Tool` build: succeeded with 0 warnings

Closes #397