### PR TITLE
Fix xterm-safe KgpDemo window activation

### DIFF
--- a/samples/KgpDemo/Program.cs
+++ b/samples/KgpDemo/Program.cs
@@ -162,7 +162,6 @@ void OpenXtermSafeImageWindow(
         .Title($"xterm.js Safe - {name}")
         .Size(46, 22)
         .Resizable()
-        .Modal()
         .Position(WindowPositionSpec.Center);
 
     e.Windows.Open(window);


### PR DESCRIPTION
## Summary

- treat xterm.js-safe KGP previews as normal floating windows
- allow overlapping preview windows to be activated by clicking their body, title bar, or border
- reserve modal behavior for windows that intentionally block interaction with underlying content

## Validation

- `dotnet build samples/KgpDemo/KgpDemo.csproj --no-restore`