### PR TITLE
Fix modal pointer isolation in window panels

### DIFF
--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -1714,7 +1714,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         if (!node.Bounds.Contains(x, y)) return null;
         
         // Check children in reverse order (last = topmost)
-        var children = node.GetChildren().ToList();
+        var children = node.GetInputChildren().ToList();
         for (int i = children.Count - 1; i >= 0; i--)
         {
             var hit = FindNodeAt(children[i], x, y, skipDragOverlay);
@@ -2043,7 +2043,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
     }
 
     /// <summary>
-    /// Walks the full node tree to find drag bindings owned by nodes other
+    /// Walks the active input tree to find drag bindings owned by nodes other
     /// than <paramref name="hitNode"/> whose <see cref="Hex1bNode.HitTestBounds"/>
     /// contains the click point. Stores the deepest match in
     /// <see cref="_pendingBubbleDrag"/> so it can be activated on the first
@@ -2109,7 +2109,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
             path.Add(node);
         }
 
-        foreach (var child in node.GetChildren())
+        foreach (var child in node.GetInputChildren())
         {
             CollectMouseHitPath(child, x, y, path);
         }
@@ -2129,7 +2129,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         // reconciled the candidate node out of the tree. Activating a
         // drag handler on a detached node would operate on stale Bounds
         // and never receive a clean drag-end.
-        if (_rootNode is null || !ContainsNode(_rootNode, node))
+        if (_rootNode is null || !ContainsInputNode(_rootNode, node))
         {
             return;
         }
@@ -2187,7 +2187,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         // current tree (e.g. the user's content rebuild dropped it between
         // events), the Parent chain may still reach a detached subtree. Bail
         // and clear stale drag state so we don't dispatch into orphaned nodes.
-        if (_rootNode is null || !ContainsNode(_rootNode, dragNode))
+        if (_rootNode is null || !ContainsInputNode(_rootNode, dragNode))
         {
             _activeDragHandler = null;
             _activeDragNode = null;
@@ -2241,12 +2241,12 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         dragHandler.OnMove?.Invoke(dragContext, deltaX, deltaY);
     }
 
-    private static bool ContainsNode(Hex1bNode root, Hex1bNode target)
+    private static bool ContainsInputNode(Hex1bNode root, Hex1bNode target)
     {
         if (ReferenceEquals(root, target)) return true;
-        foreach (var child in root.GetChildren())
+        foreach (var child in root.GetInputChildren())
         {
-            if (ContainsNode(child, target)) return true;
+            if (ContainsInputNode(child, target)) return true;
         }
         return false;
     }

--- a/src/Hex1b/Input/FocusRing.cs
+++ b/src/Hex1b/Input/FocusRing.cs
@@ -106,23 +106,23 @@ public sealed class FocusRing
         }
         
         // Stale-capture cleanup: if the captured node has been removed from the
-        // tree (e.g. reconciliation replaced it, or a panel containing it was
-        // unmounted) input would otherwise be permanently routed to a node that
-        // is no longer being measured/arranged/rendered. The captured node can
-        // be a non-focusable container (e.g. SelectionPanelNode in copy mode),
-        // so a focus-ring lookup is not enough — walk the whole tree.
-        if (_capturedNode != null && (root == null || !ContainsNode(root, _capturedNode)))
+        // active input tree (e.g. reconciliation replaced it, its panel was
+        // unmounted, or a modal excluded its subtree) input would otherwise be
+        // permanently routed to an inaccessible node. The captured node can be
+        // a non-focusable container (e.g. SelectionPanelNode in copy mode), so
+        // a focus-ring lookup is not enough.
+        if (_capturedNode != null && (root == null || !ContainsInputNode(root, _capturedNode)))
         {
             _capturedNode = null;
         }
     }
 
-    private static bool ContainsNode(Hex1bNode root, Hex1bNode target)
+    private static bool ContainsInputNode(Hex1bNode root, Hex1bNode target)
     {
         if (ReferenceEquals(root, target)) return true;
-        foreach (var child in root.GetChildren())
+        foreach (var child in root.GetInputChildren())
         {
-            if (ContainsNode(child, target)) return true;
+            if (ContainsInputNode(child, target)) return true;
         }
         return false;
     }

--- a/src/Hex1b/Input/InputRouter.cs
+++ b/src/Hex1b/Input/InputRouter.cs
@@ -443,7 +443,7 @@ public static class InputRouter
         }
 
         // Check children
-        foreach (var child in node.GetChildren())
+        foreach (var child in node.GetInputChildren())
         {
             if (BuildPathRecursive(child, path))
             {
@@ -468,7 +468,7 @@ public static class InputRouter
         path.Add(node);
         
         // Traverse to first child (depth-first) to build a path through the tree
-        var children = node.GetChildren().ToList();
+        var children = node.GetInputChildren().ToList();
         if (children.Count > 0)
         {
             BuildPathWithBindings(children[0], path);
@@ -610,7 +610,7 @@ public static class InputRouter
         }
         
         // Recurse into children
-        foreach (var child in node.GetChildren())
+        foreach (var child in node.GetInputChildren())
         {
             CollectCaptureOverrideBindings(child, bindings);
         }
@@ -663,7 +663,7 @@ public static class InputRouter
         }
         
         // Recurse into children
-        foreach (var child in node.GetChildren())
+        foreach (var child in node.GetInputChildren())
         {
             CollectGlobalBindingsExcluding(child, bindings, excludeNode);
         }
@@ -705,7 +705,7 @@ public static class InputRouter
         }
         
         // Recurse into children
-        foreach (var child in node.GetChildren())
+        foreach (var child in node.GetInputChildren())
         {
             CollectGlobalBindings(child, bindings);
         }

--- a/src/Hex1b/Nodes/Hex1bNode.cs
+++ b/src/Hex1b/Nodes/Hex1bNode.cs
@@ -542,10 +542,16 @@ public abstract class Hex1bNode
     }
 
     /// <summary>
-    /// Gets the direct children of this node. Used for input routing and tree traversal.
+    /// Gets the direct children of this node for structural tree traversal.
     /// Container nodes should override this to return their children.
     /// </summary>
     public virtual IEnumerable<Hex1bNode> GetChildren() => [];
+
+    /// <summary>
+    /// Gets the direct children that currently participate in input routing.
+    /// Defaults to all structural children.
+    /// </summary>
+    internal virtual IEnumerable<Hex1bNode> GetInputChildren() => GetChildren();
 
     /// <summary>
     /// Gets the bounds used for mouse hit testing.

--- a/src/Hex1b/Nodes/WindowPanelNode.cs
+++ b/src/Hex1b/Nodes/WindowPanelNode.cs
@@ -539,8 +539,7 @@ public sealed class WindowPanelNode : Hex1bNode, IWindowHost, ILayoutProvider
     }
 
     /// <summary>
-    /// Gets the direct children of this container for input routing.
-    /// Scrollbars are returned LAST so they are hit-tested FIRST (reverse order in InputRouter).
+    /// Gets all direct children in render order.
     /// </summary>
     public override IEnumerable<Hex1bNode> GetChildren()
     {
@@ -553,5 +552,20 @@ public sealed class WindowPanelNode : Hex1bNode, IWindowHost, ILayoutProvider
         // Scrollbars last = hit-tested first (InputRouter processes in reverse)
         if (_horizontalScrollbar != null) yield return _horizontalScrollbar;
         if (_verticalScrollbar != null) yield return _verticalScrollbar;
+    }
+
+    internal override IEnumerable<Hex1bNode> GetInputChildren()
+    {
+        var modal = WindowNodes.LastOrDefault(w => w.IsModal);
+        if (modal != null)
+        {
+            yield return modal;
+            yield break;
+        }
+
+        foreach (var child in GetChildren())
+        {
+            yield return child;
+        }
     }
 }

--- a/tests/Hex1b.Tests/WindowModalPointerIntegrationTests.cs
+++ b/tests/Hex1b.Tests/WindowModalPointerIntegrationTests.cs
@@ -1,0 +1,118 @@
+using Hex1b.Automation;
+using Hex1b.Input;
+using Hex1b.Layout;
+using Hex1b.Nodes;
+using Hex1b.Widgets;
+
+namespace Hex1b.Tests;
+
+[TestClass]
+public class WindowModalPointerIntegrationTests
+{
+    [TestMethod]
+    public async Task ModalWindow_ExposedBackgroundWindow_BlocksMoveResizeAndActivation()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithHeadless()
+            .WithMouse()
+            .WithDimensions(80, 24)
+            .Build();
+
+        WindowEntry? background = null;
+        WindowEntry? modal = null;
+        var backgroundActivationCount = 0;
+        var modalClickCount = 0;
+
+        using var app = new Hex1bApp(
+            ctx => ctx.VStack(outer =>
+            [
+                outer.Button("Open windows").OnClick(e =>
+                {
+                    var backgroundHandle = e.Windows.Window(w => w.Text("Background content"))
+                        .Title("Background")
+                        .Size(40, 12)
+                        .Position(2, 3)
+                        .Resizable()
+                        .OnActivated(() => backgroundActivationCount++);
+                    background = e.Windows.Open(backgroundHandle);
+
+                    var modalHandle = e.Windows.Window(w =>
+                            w.Button("Modal action").OnClick(_ => modalClickCount++))
+                        .Title("Modal")
+                        .Size(20, 7)
+                        .Position(20, 8)
+                        .Modal()
+                        .Resizable();
+                    modal = e.Windows.Open(modalHandle);
+                }),
+                outer.WindowPanel().Height(SizeHint.Fill)
+            ]),
+            new Hex1bAppOptions { WorkloadAdapter = workload });
+
+        var runTask = app.RunAsync(TestContext.Current.CancellationToken);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(s => s.ContainsText("Open windows"), TimeSpan.FromSeconds(5),
+                "window launcher rendered")
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(s => background?.Node != null
+                    && modal?.Node != null
+                    && s.ContainsText("Background")
+                    && s.ContainsText("Modal action"),
+                TimeSpan.FromSeconds(5), "background and modal windows rendered")
+            .Build()
+            .ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+        Assert.IsNotNull(background);
+        Assert.IsNotNull(modal);
+        Assert.IsNotNull(background.Node);
+        Assert.IsNotNull(modal.Node);
+
+        var initialBackgroundX = background.X;
+        var initialBackgroundY = background.Y;
+        var initialBackgroundWidth = background.Width;
+        var initialBackgroundHeight = background.Height;
+        var initialBackgroundZIndex = background.ZIndex;
+        var backgroundBounds = background.Node.Bounds;
+        var modalButton = TestSeq.Single(modal.Node.Content!.GetFocusableNodes().OfType<ButtonNode>());
+        var modalButtonHitBounds = modalButton.HitTestBounds;
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Drag(
+                backgroundBounds.Right - 1,
+                backgroundBounds.Bottom - 1,
+                backgroundBounds.Right + 2,
+                backgroundBounds.Bottom + 1)
+            .Drag(
+                backgroundBounds.X + 5,
+                backgroundBounds.Y + 1,
+                backgroundBounds.X + 9,
+                backgroundBounds.Y + 3)
+            .ClickAt(backgroundBounds.X + 5, backgroundBounds.Y + 1)
+            .ClickAt(
+                modalButtonHitBounds.X + modalButtonHitBounds.Width / 2,
+                modalButtonHitBounds.Y + modalButtonHitBounds.Height / 2)
+            .WaitUntil(_ => modalClickCount == 1, TimeSpan.FromSeconds(2),
+                "modal button remains interactive")
+            .Build()
+            .ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(initialBackgroundX, background.X, "Modal should block moving the background window.");
+        Assert.AreEqual(initialBackgroundY, background.Y, "Modal should block moving the background window.");
+        Assert.AreEqual(initialBackgroundWidth, background.Width, "Modal should block resizing the background window.");
+        Assert.AreEqual(initialBackgroundHeight, background.Height, "Modal should block resizing the background window.");
+        Assert.AreEqual(initialBackgroundZIndex, background.ZIndex, "Modal should block activating the background window.");
+        Assert.AreEqual(0, backgroundActivationCount);
+        Assert.AreSame(modal, background.Manager.ActiveWindow);
+        Assert.AreEqual(1, modalClickCount);
+
+        await new Hex1bTerminalInputSequenceBuilder()
+            .Ctrl().Key(Hex1bKey.C)
+            .Build()
+            .ApplyAsync(terminal, TestContext.Current.CancellationToken);
+
+        await runTask;
+    }
+}

--- a/tests/Hex1b.Tests/WindowPanelNodeTests.cs
+++ b/tests/Hex1b.Tests/WindowPanelNodeTests.cs
@@ -167,6 +167,26 @@ public class WindowPanelNodeTests
     }
 
     [TestMethod]
+    public void GetInputChildren_WithNestedModals_ReturnsOnlyTopmostModal()
+    {
+        var node = new WindowPanelNode
+        {
+            BackgroundNode = new TextBlockNode { Text = "Background" }
+        };
+        var normalWindow = new WindowNode();
+        var firstModal = new WindowNode { IsModal = true };
+        var topModal = new WindowNode { IsModal = true };
+        node.WindowNodes.Add(normalWindow);
+        node.WindowNodes.Add(firstModal);
+        node.WindowNodes.Add(topModal);
+
+        var inputChildren = node.GetInputChildren().ToList();
+
+        var inputChild = TestSeq.Single(inputChildren);
+        Assert.AreSame(topModal, inputChild);
+    }
+
+    [TestMethod]
     public void GetFocusableNodes_WithNonModalWindows_ReturnsWindowFocusables()
     {
         var node = new WindowPanelNode();


### PR DESCRIPTION
## Summary
- add a modal-aware input subtree separate from structural child traversal
- route bubble-drag hit testing, pointer target lookup, focus capture, and input routing through the active subtree
- prevent exposed background windows from moving, resizing, or activating while preserving modal interaction and SelectionPanel bubble drags
- add unit and full-stack regression coverage

## Testing
- `dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj --no-restore` (7,958 passed, 24 skipped)

Fixes #408