### PR TITLE
Fix KGP image identity and replacement semantics

### DIFF
--- a/src/Hex1b/Automation/Hex1bTerminalSnapshot.cs
+++ b/src/Hex1b/Automation/Hex1bTerminalSnapshot.cs
@@ -47,20 +47,9 @@ public sealed class Hex1bTerminalSnapshot : IHex1bTerminalRegion, IDisposable
         CellPixelWidth = terminal.Capabilities.CellPixelWidth;
         CellPixelHeight = terminal.Capabilities.CellPixelHeight;
 
-        // Capture KGP placements and their image data
-        var placements = terminal.KgpPlacements;
-        KgpPlacements = placements;
-        var images = new Dictionary<uint, KgpImageData>();
-        foreach (var placement in placements)
-        {
-            if (!images.ContainsKey(placement.ImageId))
-            {
-                var imageData = terminal.KgpImageStore.GetImageById(placement.ImageId);
-                if (imageData is not null)
-                    images[placement.ImageId] = imageData;
-            }
-        }
-        KgpImages = images;
+        var kgp = terminal.CaptureKgpSnapshot();
+        KgpPlacements = kgp.Placements;
+        KgpImages = kgp.Images;
 
         // Get scrollback rows if requested
         ScrollbackRow[] scrollbackRows = [];

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -6408,8 +6408,11 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         KgpCommandParser.Failure failure,
         string controlData)
     {
-        if (failure.Action == KgpAction.Delete)
+        if (failure.Action == KgpAction.Delete &&
+            failure.Code != KgpCommandParser.ErrorCode.ConflictingImageIdentity)
+        {
             return;
+        }
 
         var reason = failure.FormatReason(controlData.AsSpan());
         SendKgpResponse(
@@ -6419,7 +6422,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             (int)failure.Quiet);
     }
 
-    private void ProcessKgpTransmit(
+    private KgpImageData? ProcessKgpTransmit(
         KgpParsedCommand.TransmissionData command,
         KgpParsedCommand.QuietMode quiet,
         string base64Payload)
@@ -6428,79 +6431,114 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
 
         if (command.MoreData || _kgpImageStore.IsChunkedTransferInProgress)
         {
-            var image = _kgpImageStore.ProcessChunk(command, decodedData);
-            if (image is not null)
-            {
-                _kgpImageStore.StoreImage(image);
-                SendKgpResponse(image.ImageId, image.ImageNumber, "OK", (int)quiet);
-            }
-            return;
-        }
+            var completed = _kgpImageStore.ProcessChunkAndStore(command, decodedData);
+            if (completed is null)
+                return null;
 
-        // Single-chunk transmit
-        var imageId = command.ImageId;
-        var imageNumber = command.ImageNumber;
-
-        if (imageId == 0 && imageNumber > 0)
-        {
-            imageId = _kgpImageStore.AllocateId();
-        }
-        else if (imageId == 0)
-        {
-            imageId = _kgpImageStore.AllocateId();
+            return CompleteKgpTransmit(
+                completed.Value.Transmission,
+                completed.Value.Store,
+                quiet);
         }
 
         var expectedSize = GetExpectedKgpDataSize(command);
         if (expectedSize > 0 && decodedData.Length < expectedSize)
         {
-            SendKgpResponse(imageId, imageNumber,
+            SendKgpTransmissionResponse(command, null,
                 $"ENODATA:Insufficient image data: {decodedData.Length} < {expectedSize}",
-                (int)quiet);
-            return;
+                quiet);
+            return null;
         }
 
-        var newImage = new KgpImageData(imageId, imageNumber, decodedData,
-            command.Width, command.Height, command.Format);
-        _kgpImageStore.StoreImage(newImage);
-        SendKgpResponse(imageId, imageNumber, "OK", (int)quiet);
+        var stored = _kgpImageStore.StoreImage(command, decodedData);
+        return CompleteKgpTransmit(command, stored, quiet);
     }
 
     private void ProcessKgpTransmitAndDisplay(
         KgpParsedCommand.TransmitAndDisplay command,
         string base64Payload)
     {
-        ProcessKgpTransmit(command.Transmission, command.Quiet, base64Payload);
+        var image = ProcessKgpTransmit(
+            command.Transmission,
+            command.Quiet,
+            base64Payload);
+        if (image is null)
+            return;
 
-        // Then place the image
-        var imageId = command.Transmission.ImageId;
-        if (imageId == 0 && command.Transmission.ImageNumber > 0)
+        var cols = command.Display.Columns > 0 ? (int)command.Display.Columns : 1;
+        var rows = command.Display.Rows > 0 ? (int)command.Display.Rows : 1;
+        var placementId = command.Transmission.IdentityKind ==
+            KgpParsedCommand.ImageIdentityKind.Anonymous
+                ? 0
+                : command.Display.PlacementId;
+
+        CreateKgpPlacement(
+            image.ImageId,
+            placementId,
+            (uint)cols,
+            (uint)rows,
+            command.Display);
+
+        if (!command.Display.SuppressCursorMovement)
         {
-            var img = _kgpImageStore.GetImageByNumber(command.Transmission.ImageNumber);
-            if (img is not null)
-                imageId = img.ImageId;
-        }
-
-        if (imageId > 0)
-        {
-            var cols = command.Display.Columns > 0 ? (int)command.Display.Columns : 1;
-            var rows = command.Display.Rows > 0 ? (int)command.Display.Rows : 1;
-
-            CreateKgpPlacement(
-                imageId,
-                command.Display.PlacementId,
-                (uint)cols,
-                (uint)rows,
-                command.Display);
-
-            if (!command.Display.SuppressCursorMovement)
+            _cursorX = Math.Min(_cursorX + cols, _width - 1);
+            for (int r = 1; r < rows; r++)
             {
-                _cursorX = Math.Min(_cursorX + cols, _width - 1);
-                for (int r = 1; r < rows; r++)
+                if (_cursorY < _height - 1)
+                    _cursorY++;
+            }
+        }
+    }
+
+    private KgpImageData CompleteKgpTransmit(
+        KgpParsedCommand.TransmissionData transmission,
+        KgpImageStore.StoreResult stored,
+        KgpParsedCommand.QuietMode quiet)
+    {
+        if (stored.Relocation is { } relocation)
+        {
+            for (var i = 0; i < _kgpPlacements.Count; i++)
+            {
+                if (_kgpPlacements[i].ImageId == relocation.PreviousId)
                 {
-                    if (_cursorY < _height - 1)
-                        _cursorY++;
+                    // Replace rather than mutate so existing snapshots keep
+                    // their original placement-to-image identity.
+                    _kgpPlacements[i] = _kgpPlacements[i].WithImageId(relocation.CurrentId);
                 }
             }
+        }
+
+        if (stored.Replaced)
+            _kgpPlacements.RemoveAll(p => p.ImageId == stored.Image.ImageId);
+
+        SendKgpTransmissionResponse(transmission, stored.Image, "OK", quiet);
+        return stored.Image;
+    }
+
+    private void SendKgpTransmissionResponse(
+        KgpParsedCommand.TransmissionData transmission,
+        KgpImageData? storedImage,
+        string message,
+        KgpParsedCommand.QuietMode quiet)
+    {
+        switch (transmission.IdentityKind)
+        {
+            case KgpParsedCommand.ImageIdentityKind.Anonymous:
+                return;
+            case KgpParsedCommand.ImageIdentityKind.ExplicitId:
+                SendKgpResponse(
+                    transmission.ImageId,
+                    0,
+                    message,
+                    (int)quiet);
+                break;
+            case KgpParsedCommand.ImageIdentityKind.Number:
+                SendKgpResponse(
+                    storedImage?.ImageId ?? 0,
+                    transmission.ImageNumber,
+                    message,
+                    (int)quiet);
+                break;
         }
     }
 
@@ -6532,7 +6570,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         KgpImageData? image = null;
 
         if (imageId > 0)
-            image = _kgpImageStore.GetImageById(imageId);
+            image = _kgpImageStore.GetImageByClientId(imageId);
         else if (command.ImageNumber > 0)
             image = _kgpImageStore.GetImageByNumber(command.ImageNumber);
 

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -6636,23 +6636,14 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 _kgpPlacements.Clear();
                 _kgpImageStore.Clear();
                 break;
-            case KgpParsedCommand.DeleteSelector.ById { FreeData: false } byId:
-                if (byId.ImageId > 0)
+            case KgpParsedCommand.DeleteSelector.ById byId:
+                if (byId.ImageId > 0 &&
+                    _kgpImageStore.SelectAddressableImage(byId.ImageId, byId.FreeData))
                 {
                     if (byId.PlacementId > 0)
                         _kgpPlacements.RemoveAll(p => p.ImageId == byId.ImageId && p.PlacementId == byId.PlacementId);
                     else
                         _kgpPlacements.RemoveAll(p => p.ImageId == byId.ImageId);
-                }
-                break;
-            case KgpParsedCommand.DeleteSelector.ById { FreeData: true } byId:
-                if (byId.ImageId > 0)
-                {
-                    if (byId.PlacementId > 0)
-                        _kgpPlacements.RemoveAll(p => p.ImageId == byId.ImageId && p.PlacementId == byId.PlacementId);
-                    else
-                        _kgpPlacements.RemoveAll(p => p.ImageId == byId.ImageId);
-                    _kgpImageStore.RemoveImage(byId.ImageId);
                 }
                 break;
             case KgpParsedCommand.DeleteSelector.ByNumber byNumber:
@@ -6687,12 +6678,11 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 var hi = range.LastImageId;
                 if (lo > 0 && hi > 0 && lo <= hi)
                 {
-                    _kgpPlacements.RemoveAll(p => p.ImageId >= lo && p.ImageId <= hi);
-                    if (range.FreeData)
-                    {
-                        for (uint id = lo; id <= hi; id++)
-                            _kgpImageStore.RemoveImage(id);
-                    }
+                    var selected = _kgpImageStore.SelectAddressableImagesInRange(
+                        lo,
+                        hi,
+                        range.FreeData);
+                    _kgpPlacements.RemoveAll(p => selected.Contains(p.ImageId));
                 }
                 break;
             }

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -6366,6 +6366,17 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         get { lock (_bufferLock) return _kgpPlacements.ToList(); }
     }
 
+    internal (
+        IReadOnlyList<KgpPlacement> Placements,
+        IReadOnlyDictionary<uint, KgpImageData> Images) CaptureKgpSnapshot()
+    {
+        lock (_bufferLock)
+        {
+            // KGP mutations already acquire locks in buffer -> store order.
+            return _kgpImageStore.CaptureSnapshot(_kgpPlacements);
+        }
+    }
+
     /// <summary>
     /// Processes a KGP (Kitty Graphics Protocol) command.
     /// </summary>
@@ -6427,9 +6438,20 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         KgpParsedCommand.QuietMode quiet,
         string base64Payload)
     {
+        var isContinuation = _kgpImageStore.IsChunkedTransferInProgress;
+        if (!isContinuation &&
+            command.IdentityKind == KgpParsedCommand.ImageIdentityKind.ExplicitId)
+        {
+            var start = _kgpImageStore.BeginExplicitTransmission(command.ImageId);
+            if (start.Relocation is { } relocation)
+                ApplyKgpImageRelocation(relocation);
+            if (start.RemovedAddressableImage)
+                _kgpPlacements.RemoveAll(p => p.ImageId == command.ImageId);
+        }
+
         var decodedData = DecodeKgpPayload(base64Payload);
 
-        if (command.MoreData || _kgpImageStore.IsChunkedTransferInProgress)
+        if (command.MoreData || isContinuation)
         {
             var completed = _kgpImageStore.ProcessChunkAndStore(command, decodedData);
             if (completed is null)
@@ -6496,23 +6518,26 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         KgpParsedCommand.QuietMode quiet)
     {
         if (stored.Relocation is { } relocation)
-        {
-            for (var i = 0; i < _kgpPlacements.Count; i++)
-            {
-                if (_kgpPlacements[i].ImageId == relocation.PreviousId)
-                {
-                    // Replace rather than mutate so existing snapshots keep
-                    // their original placement-to-image identity.
-                    _kgpPlacements[i] = _kgpPlacements[i].WithImageId(relocation.CurrentId);
-                }
-            }
-        }
+            ApplyKgpImageRelocation(relocation);
 
         if (stored.Replaced)
             _kgpPlacements.RemoveAll(p => p.ImageId == stored.Image.ImageId);
 
         SendKgpTransmissionResponse(transmission, stored.Image, "OK", quiet);
         return stored.Image;
+    }
+
+    private void ApplyKgpImageRelocation(KgpImageStore.ImageRelocation relocation)
+    {
+        for (var i = 0; i < _kgpPlacements.Count; i++)
+        {
+            if (_kgpPlacements[i].ImageId == relocation.PreviousId)
+            {
+                // Replace rather than mutate so existing snapshots keep
+                // their original placement-to-image identity.
+                _kgpPlacements[i] = _kgpPlacements[i].WithImageId(relocation.CurrentId);
+            }
+        }
     }
 
     private void SendKgpTransmissionResponse(

--- a/src/Hex1b/Kgp/KgpCommandParser.cs
+++ b/src/Hex1b/Kgp/KgpCommandParser.cs
@@ -19,6 +19,7 @@ internal static class KgpCommandParser
         InvalidImageFormat,
         InvalidSignedInteger,
         InvalidUnsignedInteger,
+        ConflictingImageIdentity,
     }
 
     internal readonly record struct Failure(
@@ -62,6 +63,8 @@ internal static class KgpCommandParser
                     => $"Invalid signed integer '{value.ToString()}' for control key '{Key}'.",
                 ErrorCode.InvalidUnsignedInteger
                     => $"Invalid unsigned integer '{value.ToString()}' for control key '{Key}'.",
+                ErrorCode.ConflictingImageIdentity
+                    => "Must not specify both image id and image number",
                 _ => "Invalid KGP control data.",
             };
         }
@@ -109,6 +112,7 @@ internal static class KgpCommandParser
 
     private struct ControlSlot
     {
+        internal int Position;
         internal int ValueStart;
         internal int ValueLength;
 
@@ -160,6 +164,24 @@ internal static class KgpCommandParser
                 error.Position,
                 error.ValueStart,
                 error.ValueLength,
+                action,
+                imageId,
+                imageNumber,
+                placementId,
+                quiet);
+            return false;
+        }
+
+        if (imageId > 0 && imageNumber > 0)
+        {
+            var slot = slots[GetKeyIndex('I')];
+            command = null;
+            failure = new Failure(
+                ErrorCode.ConflictingImageIdentity,
+                'I',
+                slot.Position,
+                slot.ValueStart,
+                slot.ValueLength,
                 action,
                 imageId,
                 imageNumber,
@@ -345,6 +367,7 @@ internal static class KgpCommandParser
         }
 
         ref var slot = ref slots[GetKeyIndex(key)];
+        slot.Position = pairIndex;
         slot.ValueStart = valueStart;
         slot.ValueLength = valueLength;
     }

--- a/src/Hex1b/Kgp/KgpImageData.cs
+++ b/src/Hex1b/Kgp/KgpImageData.cs
@@ -53,6 +53,25 @@ public sealed class KgpImageData
     /// <param name="height">Image height in pixels.</param>
     /// <param name="format">The pixel format of the stored data.</param>
     public KgpImageData(uint imageId, uint imageNumber, byte[] data, uint width, uint height, KgpFormat format)
+        : this(
+            imageId,
+            imageNumber,
+            data,
+            width,
+            height,
+            format,
+            SHA256.HashData(data))
+    {
+    }
+
+    private KgpImageData(
+        uint imageId,
+        uint imageNumber,
+        byte[] data,
+        uint width,
+        uint height,
+        KgpFormat format,
+        byte[] contentHash)
     {
         ImageId = imageId;
         ImageNumber = imageNumber;
@@ -60,7 +79,7 @@ public sealed class KgpImageData
         Width = width;
         Height = height;
         Format = format;
-        ContentHash = SHA256.HashData(data);
+        ContentHash = contentHash;
     }
 
     /// <summary>
@@ -80,4 +99,14 @@ public sealed class KgpImageData
     /// Whether pixels are 4-byte aligned (RGBA or PNG).
     /// </summary>
     public bool Is4ByteAligned => Format != KgpFormat.Rgb24;
+
+    internal KgpImageData WithImageId(uint imageId)
+        => new(
+            imageId,
+            ImageNumber,
+            Data,
+            Width,
+            Height,
+            Format,
+            ContentHash);
 }

--- a/src/Hex1b/Kgp/KgpImageStore.cs
+++ b/src/Hex1b/Kgp/KgpImageStore.cs
@@ -182,6 +182,57 @@ public sealed class KgpImageStore
         }
     }
 
+    internal bool SelectAddressableImage(uint imageId, bool removeData)
+    {
+        lock (_lock)
+        {
+            if (_unaddressableImageIds.Contains(imageId) ||
+                !_imagesById.ContainsKey(imageId))
+            {
+                return false;
+            }
+
+            if (removeData)
+                RemoveImageUnsafe(imageId);
+            return true;
+        }
+    }
+
+    internal HashSet<uint> SelectAddressableImagesInRange(
+        uint firstImageId,
+        uint lastImageId,
+        bool removeData)
+    {
+        lock (_lock)
+        {
+            var selected = new HashSet<uint>();
+            if (firstImageId == 0 ||
+                lastImageId == 0 ||
+                firstImageId > lastImageId)
+            {
+                return selected;
+            }
+
+            foreach (var imageId in _imagesById.Keys)
+            {
+                if (imageId >= firstImageId &&
+                    imageId <= lastImageId &&
+                    !_unaddressableImageIds.Contains(imageId))
+                {
+                    selected.Add(imageId);
+                }
+            }
+
+            if (removeData)
+            {
+                foreach (var imageId in selected)
+                    RemoveImageUnsafe(imageId);
+            }
+
+            return selected;
+        }
+    }
+
     /// <summary>
     /// Gets the newest image with the specified image number.
     /// </summary>

--- a/src/Hex1b/Kgp/KgpImageStore.cs
+++ b/src/Hex1b/Kgp/KgpImageStore.cs
@@ -18,6 +18,10 @@ public sealed class KgpImageStore
         bool Replaced,
         ImageRelocation? Relocation = null);
 
+    internal readonly record struct TransmissionStartResult(
+        bool RemovedAddressableImage,
+        ImageRelocation? Relocation);
+
     internal readonly record struct CompletedTransmission(
         KgpParsedCommand.TransmissionData Transmission,
         StoreResult Store);
@@ -115,6 +119,47 @@ public sealed class KgpImageStore
         }
     }
 
+    internal TransmissionStartResult BeginExplicitTransmission(uint imageId)
+    {
+        if (imageId == 0)
+            throw new ArgumentOutOfRangeException(nameof(imageId));
+
+        lock (_lock)
+        {
+            ImageRelocation? relocation = null;
+            if (_unaddressableImageIds.Contains(imageId))
+                relocation = RelocateUnaddressableImageUnsafe(imageId);
+
+            return new TransmissionStartResult(
+                RemoveImageUnsafe(imageId),
+                relocation);
+        }
+    }
+
+    internal (
+        IReadOnlyList<KgpPlacement> Placements,
+        IReadOnlyDictionary<uint, KgpImageData> Images) CaptureSnapshot(
+            IReadOnlyList<KgpPlacement> sourcePlacements)
+    {
+        lock (_lock)
+        {
+            var placements = new KgpPlacement[sourcePlacements.Count];
+            var images = new Dictionary<uint, KgpImageData>();
+            for (var i = 0; i < sourcePlacements.Count; i++)
+            {
+                var placement = sourcePlacements[i].Clone();
+                placements[i] = placement;
+                if (!images.ContainsKey(placement.ImageId) &&
+                    _imagesById.TryGetValue(placement.ImageId, out var image))
+                {
+                    images.Add(placement.ImageId, image);
+                }
+            }
+
+            return (placements, images);
+        }
+    }
+
     /// <summary>
     /// Gets an image by its ID.
     /// </summary>
@@ -160,14 +205,7 @@ public sealed class KgpImageStore
     {
         lock (_lock)
         {
-            if (!_imagesById.TryGetValue(imageId, out var image))
-                return false;
-
-            _totalSize -= image.Data.Length;
-            _imagesById.Remove(imageId);
-            _unaddressableImageIds.Remove(imageId);
-            RemoveFromNumberIndex(image);
-            return true;
+            return RemoveImageUnsafe(imageId);
         }
     }
 
@@ -183,10 +221,7 @@ public sealed class KgpImageStore
             if (image is null)
                 return false;
 
-            _totalSize -= image.Data.Length;
-            _imagesById.Remove(image.ImageId);
-            RemoveFromNumberIndex(image);
-            return true;
+            return RemoveImageUnsafe(image.ImageId);
         }
     }
 
@@ -349,6 +384,18 @@ public sealed class KgpImageStore
         }
 
         return new StoreResult(image, replaced);
+    }
+
+    private bool RemoveImageUnsafe(uint imageId)
+    {
+        if (!_imagesById.TryGetValue(imageId, out var image))
+            return false;
+
+        _totalSize -= image.Data.Length;
+        _imagesById.Remove(imageId);
+        _unaddressableImageIds.Remove(imageId);
+        RemoveFromNumberIndex(image);
+        return true;
     }
 
     private ImageRelocation RelocateUnaddressableImageUnsafe(uint previousId)

--- a/src/Hex1b/Kgp/KgpImageStore.cs
+++ b/src/Hex1b/Kgp/KgpImageStore.cs
@@ -9,16 +9,32 @@ namespace Hex1b;
 /// </remarks>
 public sealed class KgpImageStore
 {
+    internal readonly record struct ImageRelocation(
+        uint PreviousId,
+        uint CurrentId);
+
+    internal readonly record struct StoreResult(
+        KgpImageData Image,
+        bool Replaced,
+        ImageRelocation? Relocation = null);
+
+    internal readonly record struct CompletedTransmission(
+        KgpParsedCommand.TransmissionData Transmission,
+        StoreResult Store);
+
+    private readonly record struct AssembledTransmission(
+        KgpParsedCommand.TransmissionData Transmission,
+        byte[] Data);
+
     private readonly object _lock = new();
     private readonly Dictionary<uint, KgpImageData> _imagesById = new();
     private readonly Dictionary<uint, List<uint>> _imagesByNumber = new();
+    private readonly HashSet<uint> _unaddressableImageIds = new();
     private uint _nextId = 1;
     private long _totalSize;
     private readonly long _quotaBytes;
 
     // Chunked transfer state
-    private uint _chunkedImageId;
-    private uint _chunkedImageNumber;
     private KgpParsedCommand.TransmissionData? _chunkedCommand;
     private readonly List<byte> _chunkedData = new();
 
@@ -27,8 +43,14 @@ public sealed class KgpImageStore
     /// </summary>
     /// <param name="quotaBytes">Maximum total image data size in bytes. Default: 320MB (matching kitty).</param>
     public KgpImageStore(long quotaBytes = 320 * 1024 * 1024)
+        : this(quotaBytes, 1)
+    {
+    }
+
+    internal KgpImageStore(long quotaBytes, uint nextId)
     {
         _quotaBytes = quotaBytes;
+        _nextId = nextId == 0 ? 1 : nextId;
     }
 
     /// <summary>
@@ -56,13 +78,18 @@ public sealed class KgpImageStore
     }
 
     /// <summary>
-    /// Allocates a unique image ID.
+    /// Allocates a currently unused, non-zero image ID.
     /// </summary>
+    /// <remarks>
+    /// Allocation skips live image IDs and wraps from <see cref="uint.MaxValue"/> to 1.
+    /// Terminal transmission paths allocate and store under one lock so the selected ID
+    /// cannot be claimed between those operations.
+    /// </remarks>
     public uint AllocateId()
     {
         lock (_lock)
         {
-            return _nextId++;
+            return AllocateIdUnsafe();
         }
     }
 
@@ -74,33 +101,17 @@ public sealed class KgpImageStore
     {
         lock (_lock)
         {
-            // Remove existing image with same ID
-            if (_imagesById.TryGetValue(image.ImageId, out var existing))
-            {
-                _totalSize -= existing.Data.Length;
-                RemoveFromNumberIndex(existing);
-            }
+            return StoreImageUnsafe(image).Image;
+        }
+    }
 
-            // Evict old images if necessary
-            while (_totalSize + image.Data.Length > _quotaBytes && _imagesById.Count > 0)
-            {
-                EvictOldest();
-            }
-
-            _totalSize += image.Data.Length;
-            _imagesById[image.ImageId] = image;
-
-            if (image.ImageNumber > 0)
-            {
-                if (!_imagesByNumber.TryGetValue(image.ImageNumber, out var list))
-                {
-                    list = new List<uint>();
-                    _imagesByNumber[image.ImageNumber] = list;
-                }
-                list.Add(image.ImageId);
-            }
-
-            return image;
+    internal StoreResult StoreImage(
+        KgpParsedCommand.TransmissionData transmission,
+        byte[] data)
+    {
+        lock (_lock)
+        {
+            return StoreTransmissionUnsafe(transmission, data);
         }
     }
 
@@ -111,6 +122,17 @@ public sealed class KgpImageStore
     {
         lock (_lock)
         {
+            return _imagesById.TryGetValue(imageId, out var image) ? image : null;
+        }
+    }
+
+    internal KgpImageData? GetImageByClientId(uint imageId)
+    {
+        lock (_lock)
+        {
+            if (_unaddressableImageIds.Contains(imageId))
+                return null;
+
             return _imagesById.TryGetValue(imageId, out var image) ? image : null;
         }
     }
@@ -143,6 +165,7 @@ public sealed class KgpImageStore
 
             _totalSize -= image.Data.Length;
             _imagesById.Remove(imageId);
+            _unaddressableImageIds.Remove(imageId);
             RemoveFromNumberIndex(image);
             return true;
         }
@@ -176,6 +199,7 @@ public sealed class KgpImageStore
         {
             _imagesById.Clear();
             _imagesByNumber.Clear();
+            _unaddressableImageIds.Clear();
             _totalSize = 0;
             AbortChunkedTransferUnsafe();
         }
@@ -191,43 +215,37 @@ public sealed class KgpImageStore
     /// or null if more chunks are expected.
     /// </returns>
     public KgpImageData? ProcessChunk(KgpCommand command, byte[] decodedData)
-        => ProcessChunk(command.ToTransmissionData(), decodedData);
+    {
+        lock (_lock)
+        {
+            var assembled = ProcessChunkUnsafe(command.ToTransmissionData(), decodedData);
+            if (assembled is null)
+                return null;
 
-    internal KgpImageData? ProcessChunk(
+            var transmission = assembled.Value.Transmission;
+            var imageId = transmission.ImageId > 0
+                ? transmission.ImageId
+                : AllocateIdUnsafe();
+            return CreateImage(imageId, transmission, assembled.Value.Data);
+        }
+    }
+
+    internal CompletedTransmission? ProcessChunkAndStore(
         KgpParsedCommand.TransmissionData transmission,
         byte[] decodedData)
     {
         lock (_lock)
         {
-            if (_chunkedCommand is null)
-            {
-                // First chunk — save the command metadata
-                _chunkedCommand = transmission;
-                _chunkedImageId = transmission.ImageId;
-                _chunkedImageNumber = transmission.ImageNumber;
-            }
+            var assembled = ProcessChunkUnsafe(transmission, decodedData);
+            if (assembled is null)
+                return null;
 
-            _chunkedData.AddRange(decodedData);
-
-            if (!transmission.MoreData)
-            {
-                // Final chunk — assemble the complete image
-                var completeData = _chunkedData.ToArray();
-                var imageId = _chunkedImageId > 0 ? _chunkedImageId : AllocateIdUnsafe();
-                var chunkedCommand = _chunkedCommand.Value;
-                var image = new KgpImageData(
-                    imageId,
-                    _chunkedImageNumber,
-                    completeData,
-                    chunkedCommand.Width,
-                    chunkedCommand.Height,
-                    chunkedCommand.Format);
-
-                AbortChunkedTransferUnsafe();
-                return image;
-            }
-
-            return null;
+            var store = StoreTransmissionUnsafe(
+                assembled.Value.Transmission,
+                assembled.Value.Data);
+            return new CompletedTransmission(
+                assembled.Value.Transmission,
+                store);
         }
     }
 
@@ -245,14 +263,134 @@ public sealed class KgpImageStore
     private void AbortChunkedTransferUnsafe()
     {
         _chunkedCommand = null;
-        _chunkedImageId = 0;
-        _chunkedImageNumber = 0;
         _chunkedData.Clear();
+    }
+
+    private AssembledTransmission? ProcessChunkUnsafe(
+        KgpParsedCommand.TransmissionData transmission,
+        byte[] decodedData)
+    {
+        if (_chunkedCommand is null)
+        {
+            _chunkedCommand = transmission;
+        }
+
+        _chunkedData.AddRange(decodedData);
+
+        if (transmission.MoreData)
+            return null;
+
+        var completeData = _chunkedData.ToArray();
+        var firstTransmission = _chunkedCommand.Value;
+        AbortChunkedTransferUnsafe();
+        return new AssembledTransmission(firstTransmission, completeData);
+    }
+
+    private StoreResult StoreTransmissionUnsafe(
+        KgpParsedCommand.TransmissionData transmission,
+        byte[] data)
+    {
+        if (transmission.ImageId > 0 && transmission.ImageNumber > 0)
+        {
+            throw new InvalidOperationException(
+                "A KGP transmission cannot specify both an image ID and image number.");
+        }
+
+        var imageId = transmission.ImageId > 0
+            ? transmission.ImageId
+            : AllocateIdUnsafe();
+        ImageRelocation? relocation = null;
+        if (transmission.IdentityKind == KgpParsedCommand.ImageIdentityKind.ExplicitId &&
+            _unaddressableImageIds.Contains(imageId))
+        {
+            // Anonymous images have private storage IDs, not client IDs. Move a
+            // private image aside when a client explicitly claims that number.
+            relocation = RelocateUnaddressableImageUnsafe(imageId);
+        }
+
+        var image = CreateImage(imageId, transmission, data);
+        var stored = StoreImageUnsafe(
+            image,
+            transmission.IdentityKind != KgpParsedCommand.ImageIdentityKind.Anonymous);
+        return stored with { Relocation = relocation };
+    }
+
+    private StoreResult StoreImageUnsafe(
+        KgpImageData image,
+        bool addressable = true)
+    {
+        var replaced = _imagesById.TryGetValue(image.ImageId, out var existing);
+        if (existing is not null)
+        {
+            _totalSize -= existing.Data.Length;
+            RemoveFromNumberIndex(existing);
+        }
+
+        while (_totalSize + image.Data.Length > _quotaBytes && _imagesById.Count > 0)
+        {
+            EvictOldest();
+        }
+
+        _totalSize += image.Data.Length;
+        _imagesById[image.ImageId] = image;
+        if (addressable)
+            _unaddressableImageIds.Remove(image.ImageId);
+        else
+            _unaddressableImageIds.Add(image.ImageId);
+
+        if (image.ImageNumber > 0)
+        {
+            if (!_imagesByNumber.TryGetValue(image.ImageNumber, out var list))
+            {
+                list = new List<uint>();
+                _imagesByNumber[image.ImageNumber] = list;
+            }
+            list.Add(image.ImageId);
+        }
+
+        return new StoreResult(image, replaced);
+    }
+
+    private ImageRelocation RelocateUnaddressableImageUnsafe(uint previousId)
+    {
+        var image = _imagesById[previousId];
+        var currentId = AllocateIdUnsafe();
+        var relocatedImage = image.WithImageId(currentId);
+
+        _imagesById.Remove(previousId);
+        _unaddressableImageIds.Remove(previousId);
+        _imagesById[currentId] = relocatedImage;
+        _unaddressableImageIds.Add(currentId);
+
+        return new ImageRelocation(previousId, currentId);
     }
 
     private uint AllocateIdUnsafe()
     {
-        return _nextId++;
+        var attemptsRemaining = (long)_imagesById.Count + 1;
+        while (attemptsRemaining-- > 0)
+        {
+            var candidate = _nextId;
+            _nextId = candidate == uint.MaxValue ? 1 : candidate + 1;
+            if (!_imagesById.ContainsKey(candidate))
+                return candidate;
+        }
+
+        throw new InvalidOperationException("No KGP image IDs are available.");
+    }
+
+    private static KgpImageData CreateImage(
+        uint imageId,
+        KgpParsedCommand.TransmissionData transmission,
+        byte[] data)
+    {
+        return new KgpImageData(
+            imageId,
+            transmission.ImageNumber,
+            data,
+            transmission.Width,
+            transmission.Height,
+            transmission.Format);
     }
 
     private KgpImageData? GetImageByNumberUnsafe(uint imageNumber)

--- a/src/Hex1b/Kgp/KgpParsedCommand.cs
+++ b/src/Hex1b/Kgp/KgpParsedCommand.cs
@@ -9,6 +9,13 @@ internal abstract record KgpParsedCommand(KgpParsedCommand.QuietMode Quiet)
         SuppressAll,
     }
 
+    internal enum ImageIdentityKind
+    {
+        Anonymous,
+        ExplicitId,
+        Number,
+    }
+
     internal enum CompressionMode
     {
         None,
@@ -75,7 +82,15 @@ internal abstract record KgpParsedCommand(KgpParsedCommand.QuietMode Quiet)
         uint PlacementId,
         CompressionMode Compression,
         bool MoreData,
-        uint UsageHints);
+        uint UsageHints)
+    {
+        internal ImageIdentityKind IdentityKind
+            => ImageId > 0
+                ? ImageIdentityKind.ExplicitId
+                : ImageNumber > 0
+                    ? ImageIdentityKind.Number
+                    : ImageIdentityKind.Anonymous;
+    }
 
     internal readonly record struct DisplayData(
         uint ImageId,

--- a/src/Hex1b/Kgp/KgpPlacement.cs
+++ b/src/Hex1b/Kgp/KgpPlacement.cs
@@ -124,4 +124,7 @@ public sealed class KgpPlacement
             ZIndex,
             CellOffsetX,
             CellOffsetY);
+
+    internal KgpPlacement Clone()
+        => WithImageId(ImageId);
 }

--- a/src/Hex1b/Kgp/KgpPlacement.cs
+++ b/src/Hex1b/Kgp/KgpPlacement.cs
@@ -108,4 +108,20 @@ public sealed class KgpPlacement
     /// Whether this placement intersects the given column.
     /// </summary>
     public bool IntersectsColumn(int column) => column >= Column && column < Column + (int)DisplayColumns;
+
+    internal KgpPlacement WithImageId(uint imageId)
+        => new(
+            imageId,
+            PlacementId,
+            Row,
+            Column,
+            DisplayColumns,
+            DisplayRows,
+            SourceX,
+            SourceY,
+            SourceWidth,
+            SourceHeight,
+            ZIndex,
+            CellOffsetX,
+            CellOffsetY);
 }

--- a/tests/Hex1b.Tests/KgpCommandParserTests.cs
+++ b/tests/Hex1b.Tests/KgpCommandParserTests.cs
@@ -43,7 +43,7 @@ public class KgpCommandParserTests
     public void Parse_TransmissionKeys_ReturnsTypedTransmission()
     {
         var parsed = ParseTyped<KgpParsedCommand.Transmit>(
-            "a=t,q=1,f=24,t=s,s=10,v=20,S=30,O=40,i=50,I=60,p=70,o=z,m=1,N=3");
+            "a=t,q=1,f=24,t=s,s=10,v=20,S=30,O=40,i=50,p=70,o=z,m=1,N=3");
 
         Assert.AreEqual(KgpParsedCommand.QuietMode.SuppressSuccess, parsed.Quiet);
         Assert.AreEqual(KgpFormat.Rgb24, parsed.Transmission.Format);
@@ -53,16 +53,25 @@ public class KgpCommandParserTests
         Assert.AreEqual(30u, parsed.Transmission.FileSize);
         Assert.AreEqual(40u, parsed.Transmission.FileOffset);
         Assert.AreEqual(50u, parsed.Transmission.ImageId);
-        Assert.AreEqual(60u, parsed.Transmission.ImageNumber);
+        Assert.AreEqual(0u, parsed.Transmission.ImageNumber);
+        Assert.AreEqual(
+            KgpParsedCommand.ImageIdentityKind.ExplicitId,
+            parsed.Transmission.IdentityKind);
         Assert.AreEqual(70u, parsed.Transmission.PlacementId);
         Assert.AreEqual(KgpParsedCommand.CompressionMode.Zlib, parsed.Transmission.Compression);
         Assert.IsTrue(parsed.Transmission.MoreData);
         Assert.AreEqual(3u, parsed.Transmission.UsageHints);
 
         var compatibility = KgpCommand.Parse(
-            "a=t,q=1,f=24,t=s,s=10,v=20,S=30,O=40,i=50,I=60,p=70,o=z,m=1,N=3");
+            "a=t,q=1,f=24,t=s,s=10,v=20,S=30,O=40,i=50,p=70,o=z,m=1,N=3");
         Assert.AreEqual(3u, compatibility.UsageHints);
         Assert.AreEqual('z', compatibility.Compression);
+
+        var numbered = ParseTyped<KgpParsedCommand.Transmit>("a=t,I=60");
+        Assert.AreEqual(60u, numbered.Transmission.ImageNumber);
+        Assert.AreEqual(
+            KgpParsedCommand.ImageIdentityKind.Number,
+            numbered.Transmission.IdentityKind);
     }
 
     [TestMethod]
@@ -83,14 +92,14 @@ public class KgpCommandParserTests
     public void Parse_TransmitAndDisplayKeys_ReturnsSeparateTypedComponents()
     {
         var parsed = ParseTyped<KgpParsedCommand.TransmitAndDisplay>(
-            "a=T,f=24,t=d,s=100,v=200,S=300,O=400,i=42,I=43,p=7,o=z,m=1,N=1," +
+            "a=T,f=24,t=d,s=100,v=200,S=300,O=400,i=42,p=7,o=z,m=1,N=1," +
             "x=10,y=20,w=30,h=40,X=3,Y=5,c=6,r=8,C=1,U=1,z=-9,P=11,Q=12,H=-13,V=14");
 
         Assert.AreEqual(100u, parsed.Transmission.Width);
         Assert.AreEqual(200u, parsed.Transmission.Height);
         Assert.AreEqual(1u, parsed.Transmission.UsageHints);
         Assert.AreEqual(42u, parsed.Display.ImageId);
-        Assert.AreEqual(43u, parsed.Display.ImageNumber);
+        Assert.AreEqual(0u, parsed.Display.ImageNumber);
         Assert.AreEqual(7u, parsed.Display.PlacementId);
         Assert.AreEqual(10u, parsed.Display.SourceX);
         Assert.AreEqual(20u, parsed.Display.SourceY);
@@ -107,17 +116,21 @@ public class KgpCommandParserTests
         Assert.AreEqual(12u, parsed.Display.ParentPlacementId);
         Assert.AreEqual(-13, parsed.Display.ParentOffsetHorizontal);
         Assert.AreEqual(14, parsed.Display.ParentOffsetVertical);
+
+        var numbered = ParseTyped<KgpParsedCommand.TransmitAndDisplay>("a=T,I=43");
+        Assert.AreEqual(43u, numbered.Transmission.ImageNumber);
+        Assert.AreEqual(43u, numbered.Display.ImageNumber);
     }
 
     [TestMethod]
     public void Parse_PutKeys_ReturnsTypedDisplay()
     {
         var parsed = ParseTyped<KgpParsedCommand.Put>(
-            "a=p,i=1,I=2,p=3,x=4,y=5,w=6,h=7,X=8,Y=9,c=10,r=11,C=2,U=3," +
+            "a=p,i=1,p=3,x=4,y=5,w=6,h=7,X=8,Y=9,c=10,r=11,C=2,U=3," +
             "z=-12,P=13,Q=14,H=-15,V=16");
 
         Assert.AreEqual(1u, parsed.Display.ImageId);
-        Assert.AreEqual(2u, parsed.Display.ImageNumber);
+        Assert.AreEqual(0u, parsed.Display.ImageNumber);
         Assert.AreEqual(3u, parsed.Display.PlacementId);
         Assert.AreEqual(4u, parsed.Display.SourceX);
         Assert.AreEqual(5u, parsed.Display.SourceY);
@@ -134,6 +147,9 @@ public class KgpCommandParserTests
         Assert.AreEqual(14u, parsed.Display.ParentPlacementId);
         Assert.AreEqual(-15, parsed.Display.ParentOffsetHorizontal);
         Assert.AreEqual(16, parsed.Display.ParentOffsetVertical);
+
+        var numbered = ParseTyped<KgpParsedCommand.Put>("a=p,I=2");
+        Assert.AreEqual(2u, numbered.Display.ImageNumber);
     }
 
     [TestMethod]
@@ -211,18 +227,24 @@ public class KgpCommandParserTests
     }
 
     [TestMethod]
-    public void Parse_DeleteFrame_UsesRAsFrameNumberAndPreservesCompatibility()
+    public void Parse_DeleteFrame_UsesRAsFrameNumberAndSingleIdentity()
     {
-        var parsed = ParseTyped<KgpParsedCommand.Delete>("a=d,d=F,i=3,I=4,r=5");
+        var parsed = ParseTyped<KgpParsedCommand.Delete>("a=d,d=F,i=3,r=5");
         var selector = TestSeq.IsType<KgpParsedCommand.DeleteSelector.AnimationFrames>(
             parsed.Selector);
 
         Assert.IsTrue(selector.FreeData);
         Assert.AreEqual(3u, selector.ImageId);
-        Assert.AreEqual(4u, selector.ImageNumber);
+        Assert.AreEqual(0u, selector.ImageNumber);
         Assert.AreEqual(5u, selector.FrameNumber);
 
-        var compatibility = KgpCommand.Parse("a=d,d=F,i=3,I=4,r=5");
+        var byNumber = ParseTyped<KgpParsedCommand.Delete>("a=d,d=F,I=4,r=5");
+        var numberedSelector = TestSeq.IsType<KgpParsedCommand.DeleteSelector.AnimationFrames>(
+            byNumber.Selector);
+        Assert.AreEqual(0u, numberedSelector.ImageId);
+        Assert.AreEqual(4u, numberedSelector.ImageNumber);
+
+        var compatibility = KgpCommand.Parse("a=d,d=F,i=3,r=5");
         Assert.AreEqual(5u, compatibility.DisplayRows);
     }
 
@@ -248,7 +270,7 @@ public class KgpCommandParserTests
     public void Parse_AnimationFrameKeys_ReturnsActionSpecificMeanings()
     {
         var parsed = ParseTyped<KgpParsedCommand.AnimationFrame>(
-            "a=f,f=32,t=d,s=100,v=200,S=300,O=400,i=5,I=6,p=7,o=z,m=1,N=1," +
+            "a=f,f=32,t=d,s=100,v=200,S=300,O=400,i=5,p=7,o=z,m=1,N=1," +
             "x=8,y=9,c=10,r=11,z=-12,X=1,Y=4278190335");
 
         Assert.AreEqual(100u, parsed.Transmission.Width);
@@ -261,6 +283,9 @@ public class KgpCommandParserTests
         Assert.AreEqual(-12, parsed.Frame.Gap);
         Assert.AreEqual(KgpParsedCommand.CompositionMode.Overwrite, parsed.Frame.Composition);
         Assert.AreEqual(4278190335u, parsed.Frame.BackgroundColor);
+
+        var numbered = ParseTyped<KgpParsedCommand.AnimationFrame>("a=f,I=6");
+        Assert.AreEqual(6u, numbered.Transmission.ImageNumber);
 
         var compatibility = KgpCommand.Parse(
             "a=f,s=100,v=200,x=8,y=9,c=10,r=11,z=-12,X=1,Y=4278190335");
@@ -275,16 +300,19 @@ public class KgpCommandParserTests
     public void Parse_AnimationControlKeys_DoNotPopulateImageDimensions()
     {
         var parsed = ParseTyped<KgpParsedCommand.AnimationControl>(
-            "a=a,i=3,I=4,p=5,s=3,v=6,c=7,r=8,z=-9");
+            "a=a,i=3,p=5,s=3,v=6,c=7,r=8,z=-9");
 
         Assert.AreEqual(3u, parsed.Control.ImageId);
-        Assert.AreEqual(4u, parsed.Control.ImageNumber);
+        Assert.AreEqual(0u, parsed.Control.ImageNumber);
         Assert.AreEqual(5u, parsed.Control.PlacementId);
         Assert.AreEqual(KgpParsedCommand.AnimationPlaybackState.Running, parsed.Control.State);
         Assert.AreEqual(6u, parsed.Control.LoopCount);
         Assert.AreEqual(7u, parsed.Control.CurrentFrameNumber);
         Assert.AreEqual(8u, parsed.Control.AffectedFrameNumber);
         Assert.AreEqual(-9, parsed.Control.Gap);
+
+        var numbered = ParseTyped<KgpParsedCommand.AnimationControl>("a=a,I=4");
+        Assert.AreEqual(4u, numbered.Control.ImageNumber);
 
         var compatibility = KgpCommand.Parse("a=a,i=3,s=3,v=6,c=7,r=8,z=-9");
         Assert.AreEqual(3, compatibility.AnimationState);
@@ -309,10 +337,10 @@ public class KgpCommandParserTests
     public void Parse_CompositionKeys_ReturnsActionSpecificMeanings()
     {
         var parsed = ParseTyped<KgpParsedCommand.Compose>(
-            "a=c,i=1,I=2,p=3,c=4,r=5,x=6,y=7,w=8,h=9,X=10,Y=11,C=2");
+            "a=c,i=1,p=3,c=4,r=5,x=6,y=7,w=8,h=9,X=10,Y=11,C=2");
 
         Assert.AreEqual(1u, parsed.Composition.ImageId);
-        Assert.AreEqual(2u, parsed.Composition.ImageNumber);
+        Assert.AreEqual(0u, parsed.Composition.ImageNumber);
         Assert.AreEqual(3u, parsed.Composition.PlacementId);
         Assert.AreEqual(4u, parsed.Composition.DestinationFrameNumber);
         Assert.AreEqual(5u, parsed.Composition.SourceFrameNumber);
@@ -323,6 +351,9 @@ public class KgpCommandParserTests
         Assert.AreEqual(10u, parsed.Composition.SourceX);
         Assert.AreEqual(11u, parsed.Composition.SourceY);
         Assert.AreEqual(KgpParsedCommand.CompositionMode.Overwrite, parsed.Composition.Composition);
+
+        var numbered = ParseTyped<KgpParsedCommand.Compose>("a=c,I=2");
+        Assert.AreEqual(2u, numbered.Composition.ImageNumber);
     }
 
     [TestMethod]
@@ -435,6 +466,39 @@ public class KgpCommandParserTests
     }
 
     [TestMethod]
+    [DataRow("a=t,i=1,I=2")]
+    [DataRow("a=T,i=1,I=2")]
+    [DataRow("a=q,i=1,I=2")]
+    [DataRow("a=p,i=1,I=2")]
+    [DataRow("a=d,d=i,i=1,I=2")]
+    [DataRow("a=f,i=1,I=2")]
+    [DataRow("a=a,i=1,I=2")]
+    [DataRow("a=c,i=1,I=2")]
+    public void Parse_NonZeroImageIdAndNumber_RejectsEveryAction(string controlData)
+    {
+        var failure = ParseFailure(controlData);
+
+        Assert.AreEqual(
+            KgpCommandParser.ErrorCode.ConflictingImageIdentity,
+            failure.Code);
+        Assert.AreEqual('I', failure.Key);
+        Assert.AreEqual(1u, failure.ImageId);
+        Assert.AreEqual(2u, failure.ImageNumber);
+        Assert.AreEqual(
+            "Must not specify both image id and image number",
+            failure.FormatReason(controlData.AsSpan()));
+        Assert.ThrowsExactly<FormatException>(() => KgpCommand.Parse(controlData));
+    }
+
+    [TestMethod]
+    [DataRow("a=t,i=0,I=2")]
+    [DataRow("a=t,i=1,I=0")]
+    public void Parse_OnlyOneNonZeroImageIdentity_AcceptsCommand(string controlData)
+    {
+        ParseSuccess(controlData);
+    }
+
+    [TestMethod]
     public void TryParse_MixedErrors_UsesApprovedDiagnosticPrecedence()
     {
         const string grammarAndValidation = "f=99,broken";
@@ -532,6 +596,9 @@ public class KgpCommandParserTests
         var deleteThenInvalid = ParseFailure("a=d,a=x");
 
         Assert.AreEqual(KgpAction.Transmit, nonDelete.Action);
+        Assert.AreEqual(
+            KgpCommandParser.ErrorCode.InvalidImageFormat,
+            nonDelete.Code);
         Assert.AreEqual(7u, nonDelete.ImageId);
         Assert.AreEqual(8u, nonDelete.ImageNumber);
         Assert.AreEqual(9u, nonDelete.PlacementId);

--- a/tests/Hex1b.Tests/KgpConformanceTests.cs
+++ b/tests/Hex1b.Tests/KgpConformanceTests.cs
@@ -633,16 +633,23 @@ public class KgpImageNumberConformanceTests
         // Transmit two images with same number
         var data1 = KgpTestHelper.CreatePixelData(2, 2, fillByte: 0xAA);
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=t,f=32,s=2,v=2,I=5", data1));
+        var first = terminal.KgpImageStore.GetImageByNumber(5);
+        Assert.IsNotNull(first);
 
         var data2 = KgpTestHelper.CreatePixelData(3, 3, fillByte: 0xBB);
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=t,f=32,s=3,v=3,I=5", data2));
+        var second = terminal.KgpImageStore.GetImageByNumber(5);
+        Assert.IsNotNull(second);
+        Assert.AreNotEqual(first.ImageId, second.ImageId);
 
         // Put by image number - should use the newest image
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[1;1H"));
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=p,I=5,c=2,r=2"));
 
         // Placement should exist
-        TestSeq.Single(terminal.KgpPlacements);
+        var placement = TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(second.ImageId, placement.ImageId);
+        Assert.AreEqual(0xBB, terminal.KgpImageStore.GetImageById(placement.ImageId)!.Data[0]);
     }
 
     [TestMethod]
@@ -671,7 +678,7 @@ public class KgpImageNumberConformanceTests
     }
 
     [TestMethod]
-    public void ImageNumber_ExplicitId_TakesPriority()
+    public void ImageNumber_WithExplicitId_IsRejectedWithoutMutation()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
         using var terminal = CreateTerminal(workload);
@@ -681,10 +688,38 @@ public class KgpImageNumberConformanceTests
         var cmd = KgpTestHelper.BuildCommand("a=t,f=32,s=2,v=2,i=42,I=7", data);
         SendKgp(terminal, cmd);
 
-        // Explicit ID should be used
-        var img = terminal.KgpImageStore.GetImageById(42);
-        Assert.IsNotNull(img);
-        Assert.AreEqual(42u, img.ImageId);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(42));
+        Assert.IsNull(terminal.KgpImageStore.GetImageByNumber(7));
+        Assert.IsEmpty(terminal.KgpPlacements);
+    }
+
+    [TestMethod]
+    public void ImageNumber_RetransmitNewestById_FallsBackToPreviousImage()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+
+        var data1 = KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xAA);
+        SendKgp(terminal, KgpTestHelper.BuildCommand("a=t,f=32,s=1,v=1,I=5", data1));
+        var first = terminal.KgpImageStore.GetImageByNumber(5);
+        Assert.IsNotNull(first);
+
+        var data2 = KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xBB);
+        SendKgp(terminal, KgpTestHelper.BuildCommand("a=t,f=32,s=1,v=1,I=5", data2));
+        var second = terminal.KgpImageStore.GetImageByNumber(5);
+        Assert.IsNotNull(second);
+
+        var replacement = KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xCC);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            $"a=t,f=32,s=1,v=1,i={second.ImageId}",
+            replacement));
+
+        Assert.AreSame(first, terminal.KgpImageStore.GetImageByNumber(5));
+        var replaced = terminal.KgpImageStore.GetImageById(second.ImageId);
+        Assert.IsNotNull(replaced);
+        Assert.AreEqual(0u, replaced.ImageNumber);
+        Assert.AreEqual(0xCC, replaced.Data[0]);
     }
 }
 
@@ -1260,7 +1295,7 @@ public class KgpGhosttyCommandParsingConformanceTests
     }
 
     [TestMethod]
-    public void ResponseEncoding_BothIdAndNumber()
+    public void ResponseEncoding_ConflictingIdAndNumberDoesNotMutateState()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
         using var terminal = CreateTerminal(workload);
@@ -1270,16 +1305,10 @@ public class KgpGhosttyCommandParsingConformanceTests
         var cmd = KgpTestHelper.BuildCommand("a=t,f=32,s=2,v=2,i=10,I=20", data);
         SendKgp(terminal, cmd);
 
-        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
-        var img = terminal.KgpImageStore.GetImageById(10);
-        Assert.IsNotNull(img);
-        Assert.AreEqual(10u, img.ImageId);
-        Assert.AreEqual(20u, img.ImageNumber);
-
-        // Also retrievable by number
-        var imgByNum = terminal.KgpImageStore.GetImageByNumber(20);
-        Assert.IsNotNull(imgByNum);
-        Assert.AreEqual(10u, imgByNum.ImageId);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(10));
+        Assert.IsNull(terminal.KgpImageStore.GetImageByNumber(20));
+        Assert.IsEmpty(terminal.KgpPlacements);
     }
 }
 

--- a/tests/Hex1b.Tests/KgpImageStoreTests.cs
+++ b/tests/Hex1b.Tests/KgpImageStoreTests.cs
@@ -285,6 +285,46 @@ public class KgpImageStoreTests
     }
 
     [TestMethod]
+    public void BeginExplicitTransmission_AddressableImage_RemovesDataAndNumberIndex()
+    {
+        var store = new KgpImageStore();
+        var first = store.StoreImage(
+            CreateTransmission(imageNumber: 42),
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xAA));
+        var newest = store.StoreImage(
+            CreateTransmission(imageNumber: 42),
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xBB));
+
+        var start = store.BeginExplicitTransmission(newest.Image.ImageId);
+
+        Assert.IsTrue(start.RemovedAddressableImage);
+        Assert.IsNull(start.Relocation);
+        Assert.IsNull(store.GetImageById(newest.Image.ImageId));
+        Assert.AreSame(first.Image, store.GetImageByNumber(42));
+        Assert.AreEqual(1, store.ImageCount);
+    }
+
+    [TestMethod]
+    public void BeginExplicitTransmission_AnonymousStorageCollision_RelocatesWithoutRemoving()
+    {
+        var store = new KgpImageStore();
+        var anonymous = store.StoreImage(
+            CreateTransmission(),
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xAA));
+
+        var start = store.BeginExplicitTransmission(anonymous.Image.ImageId);
+
+        Assert.IsFalse(start.RemovedAddressableImage);
+        Assert.IsNotNull(start.Relocation);
+        Assert.AreEqual(1u, start.Relocation.Value.PreviousId);
+        Assert.AreEqual(2u, start.Relocation.Value.CurrentId);
+        Assert.AreEqual(1, store.ImageCount);
+        Assert.IsNull(store.GetImageById(1));
+        Assert.AreEqual(0xAA, store.GetImageById(2)!.Data[0]);
+        Assert.IsNull(store.GetImageByClientId(2));
+    }
+
+    [TestMethod]
     public void StoreImage_ReplacingNewestNumberedImage_RemovesOldNumberIndexEntry()
     {
         var store = new KgpImageStore();

--- a/tests/Hex1b.Tests/KgpImageStoreTests.cs
+++ b/tests/Hex1b.Tests/KgpImageStoreTests.cs
@@ -10,6 +10,20 @@ public class KgpImageStoreTests
         return new KgpImageData(id, number, data, width, height, KgpFormat.Rgba32);
     }
 
+    private static KgpParsedCommand.TransmissionData CreateTransmission(
+        uint imageId = 0,
+        uint imageNumber = 0)
+    {
+        return new KgpCommand
+        {
+            ImageId = imageId,
+            ImageNumber = imageNumber,
+            Width = 1,
+            Height = 1,
+            Format = KgpFormat.Rgba32,
+        }.ToTransmissionData();
+    }
+
     // --- Basic store/retrieve ---
 
     [TestMethod]
@@ -166,6 +180,126 @@ public class KgpImageStoreTests
         Assert.AreNotEqual(id1, id2);
         Assert.AreNotEqual(id2, id3);
         Assert.IsTrue(id1 > 0);
+    }
+
+    [TestMethod]
+    public void AllocateId_LiveExplicitIds_SkipsOccupiedIds()
+    {
+        var store = new KgpImageStore();
+        var explicitImage = CreateImage(1);
+        store.StoreImage(explicitImage);
+
+        var allocated = store.AllocateId();
+
+        Assert.AreEqual(2u, allocated);
+        Assert.AreSame(explicitImage, store.GetImageById(1));
+    }
+
+    [TestMethod]
+    public void AllocateId_AtUInt32Boundary_WrapsToOne()
+    {
+        var store = new KgpImageStore(long.MaxValue, uint.MaxValue);
+
+        var last = store.AllocateId();
+        var wrapped = store.AllocateId();
+
+        Assert.AreEqual(uint.MaxValue, last);
+        Assert.AreEqual(1u, wrapped);
+    }
+
+    [TestMethod]
+    public void StoreGeneratedImage_Wraparound_SkipsZeroAndLiveIds()
+    {
+        var store = new KgpImageStore(long.MaxValue, uint.MaxValue);
+        var maximum = CreateImage(uint.MaxValue);
+        var one = CreateImage(1);
+        store.StoreImage(maximum);
+        store.StoreImage(one);
+
+        var result = store.StoreImage(
+            CreateTransmission(),
+            KgpTestHelper.CreatePixelData(1, 1));
+
+        Assert.AreEqual(2u, result.Image.ImageId);
+        Assert.IsFalse(result.Replaced);
+        Assert.AreSame(maximum, store.GetImageById(uint.MaxValue));
+        Assert.AreSame(one, store.GetImageById(1));
+    }
+
+    [TestMethod]
+    public void StoreGeneratedImage_WithNumber_AlwaysCreatesNewNewestImage()
+    {
+        var store = new KgpImageStore();
+
+        var first = store.StoreImage(
+            CreateTransmission(imageNumber: 42),
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xAA));
+        var second = store.StoreImage(
+            CreateTransmission(imageNumber: 42),
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xBB));
+
+        Assert.AreNotEqual(first.Image.ImageId, second.Image.ImageId);
+        Assert.AreEqual(2, store.ImageCount);
+        Assert.AreSame(second.Image, store.GetImageByNumber(42));
+    }
+
+    [TestMethod]
+    public void StoreAnonymousImage_InternalIdIsNotClientAddressable()
+    {
+        var store = new KgpImageStore();
+
+        var anonymous = store.StoreImage(
+            CreateTransmission(),
+            KgpTestHelper.CreatePixelData(1, 1));
+
+        Assert.AreSame(
+            anonymous.Image,
+            store.GetImageById(anonymous.Image.ImageId));
+        Assert.IsNull(store.GetImageByClientId(anonymous.Image.ImageId));
+    }
+
+    [TestMethod]
+    public void StoreExplicitImage_CollidingWithAnonymousInternalId_RelocatesAnonymousImage()
+    {
+        var store = new KgpImageStore();
+        var anonymous = store.StoreImage(
+            CreateTransmission(),
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xAA));
+        var previousId = anonymous.Image.ImageId;
+
+        var explicitImage = store.StoreImage(
+            CreateTransmission(imageId: previousId),
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xBB));
+
+        Assert.IsFalse(explicitImage.Replaced);
+        Assert.IsNotNull(explicitImage.Relocation);
+        Assert.AreEqual(previousId, explicitImage.Relocation.Value.PreviousId);
+        Assert.AreEqual(2u, explicitImage.Relocation.Value.CurrentId);
+        Assert.AreEqual(previousId, anonymous.Image.ImageId);
+        Assert.AreEqual(2, store.ImageCount);
+        Assert.AreSame(explicitImage.Image, store.GetImageByClientId(previousId));
+        Assert.IsNull(store.GetImageByClientId(explicitImage.Relocation.Value.CurrentId));
+        Assert.AreEqual(
+            0xAA,
+            store.GetImageById(explicitImage.Relocation.Value.CurrentId)!.Data[0]);
+    }
+
+    [TestMethod]
+    public void StoreImage_ReplacingNewestNumberedImage_RemovesOldNumberIndexEntry()
+    {
+        var store = new KgpImageStore();
+        var first = store.StoreImage(
+            CreateTransmission(imageNumber: 42),
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xAA));
+        var second = store.StoreImage(
+            CreateTransmission(imageNumber: 42),
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xBB));
+
+        var replacement = CreateImage(second.Image.ImageId, 1, 1, fill: 0xCC);
+        store.StoreImage(replacement);
+
+        Assert.AreSame(first.Image, store.GetImageByNumber(42));
+        Assert.AreSame(replacement, store.GetImageById(second.Image.ImageId));
     }
 
     // --- TotalSize tracking ---
@@ -386,5 +520,49 @@ public class KgpImageStoreTests
         }
 
         Task.WaitAll(tasks.ToArray());
+    }
+
+    [TestMethod]
+    public void ConcurrentExplicitAndGeneratedStores_PreserveLiveIdsAndUniqueAllocation()
+    {
+        const int explicitCount = 64;
+        const int generatedCount = 128;
+        var store = new KgpImageStore();
+        for (uint id = 1; id <= explicitCount; id++)
+            store.StoreImage(CreateImage(id, 1, 1, fill: 0x11));
+
+        var generatedIds = new uint[generatedCount];
+        var tasks = new List<Task>(explicitCount + generatedCount);
+
+        for (var i = 0; i < explicitCount; i++)
+        {
+            var id = (uint)(i + 1);
+            tasks.Add(Task.Run(() => store.StoreImage(CreateImage(id, 1, 1, fill: 0x22))));
+        }
+
+        for (var i = 0; i < generatedCount; i++)
+        {
+            var index = i;
+            tasks.Add(Task.Run(() =>
+            {
+                var result = store.StoreImage(
+                    CreateTransmission(imageNumber: (uint)(index + 1)),
+                    KgpTestHelper.CreatePixelData(1, 1, fillByte: 0x33));
+                generatedIds[index] = result.Image.ImageId;
+            }));
+        }
+
+        Task.WaitAll(tasks.ToArray());
+
+        Assert.AreEqual(generatedCount, generatedIds.Distinct().Count());
+        TestSeq.All(generatedIds, id => Assert.IsTrue(id > explicitCount));
+        for (uint id = 1; id <= explicitCount; id++)
+        {
+            var explicitImage = store.GetImageById(id);
+            Assert.IsNotNull(explicitImage);
+            Assert.AreEqual(0x22, explicitImage.Data[0]);
+        }
+        Assert.AreEqual(explicitCount + generatedCount, store.ImageCount);
+        Assert.AreEqual((explicitCount + generatedCount) * 4, store.TotalSize);
     }
 }

--- a/tests/Hex1b.Tests/KgpTerminalTests.cs
+++ b/tests/Hex1b.Tests/KgpTerminalTests.cs
@@ -290,6 +290,82 @@ public class KgpTerminalTests
     }
 
     [TestMethod]
+    [DataRow("i")]
+    [DataRow("I")]
+    public void Delete_ByGuessedAnonymousId_DoesNotMatchPrivateImage(string selector)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, 20, 10);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,p=0,c=1,r=1,C=1,q=2",
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xAA)));
+        var privateId = TestSeq.Single(terminal.KgpPlacements).ImageId;
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            $"a=d,d={selector},i={privateId}"));
+
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(privateId, TestSeq.Single(terminal.KgpPlacements).ImageId);
+        Assert.AreEqual(0xAA, terminal.KgpImageStore.GetImageById(privateId)!.Data[0]);
+        Assert.IsNull(terminal.KgpImageStore.GetImageByClientId(privateId));
+    }
+
+    [TestMethod]
+    [DataRow("r", false)]
+    [DataRow("R", true)]
+    public void Delete_ByRange_SelectsAddressableButNotAnonymousImages(
+        string selector,
+        bool freeData)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, 20, 10);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,p=0,c=1,r=1,C=1,q=2",
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xAA)));
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[3;1H"));
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,i=2,p=7,c=1,r=1,C=1,q=2",
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xBB)));
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            $"a=d,d={selector},x=1,y={uint.MaxValue}"));
+
+        var anonymousPlacement = TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(1u, anonymousPlacement.ImageId);
+        Assert.AreEqual(0u, anonymousPlacement.PlacementId);
+        Assert.AreEqual(0xAA, terminal.KgpImageStore.GetImageById(1)!.Data[0]);
+        if (freeData)
+            Assert.IsNull(terminal.KgpImageStore.GetImageById(2));
+        else
+            Assert.AreEqual(0xBB, terminal.KgpImageStore.GetImageById(2)!.Data[0]);
+    }
+
+    [TestMethod]
+    public void Delete_ByClaimedExplicitId_AfterAnonymousRelocation_RemovesOnlyExplicitImage()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, 20, 10);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,p=0,c=1,r=1,C=1,q=2",
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xAA)));
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,i=1,p=7,c=1,r=1,C=1,q=2",
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xBB)));
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand("a=d,d=I,i=1"));
+
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.AreEqual(0xAA, terminal.KgpImageStore.GetImageById(2)!.Data[0]);
+        Assert.IsNull(terminal.KgpImageStore.GetImageByClientId(2));
+        var anonymousPlacement = TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(2u, anonymousPlacement.ImageId);
+        Assert.AreEqual(0u, anonymousPlacement.PlacementId);
+    }
+
+    [TestMethod]
     public void Delete_AbortsChunkedTransfer()
     {
         using var workload = new Hex1bAppWorkloadAdapter();

--- a/tests/Hex1b.Tests/KgpTerminalTests.cs
+++ b/tests/Hex1b.Tests/KgpTerminalTests.cs
@@ -126,32 +126,76 @@ public class KgpTerminalTests
     }
 
     [TestMethod]
-    public void Transmit_InvalidReplacement_PreservesImagePlacementsAndCursor()
+    public void Transmit_InvalidExplicitReplacement_RemovesOldStateBeforeValidation()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, 20, 10);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,I=42,q=2",
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xAA)));
+        var first = terminal.KgpImageStore.GetImageByNumber(42);
+        Assert.IsNotNull(first);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,I=42,q=2",
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xBB)));
+        var newest = terminal.KgpImageStore.GetImageByNumber(42);
+        Assert.IsNotNull(newest);
+
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[3;4H"));
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=p,I=42,p=5,c=2,r=1,C=1,q=2"));
+        using var originalSnapshot = terminal.CreateSnapshot();
+
+        var invalidReplacement = KgpTestHelper.BuildCommand(
+            $"a=t,f=32,s=2,v=2,i={newest.ImageId}",
+            new byte[] { 1, 2, 3, 4 });
+        SendKgp(terminal, invalidReplacement);
+
+        Assert.AreEqual(
+            $"\x1b_Gi={newest.ImageId};ENODATA:Insufficient image data: 4 < 16\x1b\\",
+            workload.ReadResponse());
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(newest.ImageId));
+        Assert.AreSame(first, terminal.KgpImageStore.GetImageByNumber(42));
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+        Assert.IsEmpty(terminal.KgpPlacements);
+        using var snapshot = terminal.CreateSnapshot();
+        Assert.AreEqual(originalSnapshot.CursorX, snapshot.CursorX);
+        Assert.AreEqual(originalSnapshot.CursorY, snapshot.CursorY);
+    }
+
+    [TestMethod]
+    public void Transmit_ChunkedExplicitReplacement_RemovesOldStateOnFirstChunk()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
         using var terminal = CreateTerminal(workload, 20, 10);
 
-        SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 1, 1, fillByte: 0xAA));
-        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[3;4H"));
-        SendKgp(terminal, KgpTestHelper.BuildPutCommand(
-            1,
-            placementId: 5,
-            displayColumns: 2,
-            cursorMovement: 1));
-        var originalImage = terminal.KgpImageStore.GetImageById(1);
-        var originalPlacement = TestSeq.Single(terminal.KgpPlacements);
-        var originalSnapshot = terminal.CreateSnapshot();
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,i=1,p=3,c=1,r=1,C=1,q=2",
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xAA)));
+        SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 4));
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
 
-        var invalidReplacement = KgpTestHelper.BuildCommand(
-            "a=t,f=32,s=2,v=2,i=1,q=2",
-            new byte[] { 1, 2, 3, 4 });
-        SendKgp(terminal, invalidReplacement);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=2,i=1,m=1,q=2",
+            new byte[] { 1, 2, 3, 4 }));
 
-        Assert.AreSame(originalImage, terminal.KgpImageStore.GetImageById(1));
-        Assert.AreSame(originalPlacement, TestSeq.Single(terminal.KgpPlacements));
-        var snapshot = terminal.CreateSnapshot();
-        Assert.AreEqual(originalSnapshot.CursorX, snapshot.CursorX);
-        Assert.AreEqual(originalSnapshot.CursorY, snapshot.CursorY);
+        Assert.IsTrue(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        Assert.IsEmpty(terminal.KgpPlacements);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "m=0,q=2",
+            new byte[] { 5, 6, 7, 8 }));
+
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        var replacement = terminal.KgpImageStore.GetImageById(1);
+        Assert.IsNotNull(replacement);
+        TestSeq.AreEqual(
+            new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 },
+            replacement.Data);
+        Assert.IsEmpty(terminal.KgpPlacements);
     }
 
     [TestMethod]
@@ -792,6 +836,9 @@ public class KgpTerminalTests
         using var snapshotBeforeCollision = terminal.CreateSnapshot();
         Assert.AreEqual(1u, anonymousPlacement.ImageId);
         Assert.AreEqual(0u, anonymousPlacement.PlacementId);
+        Assert.AreNotSame(
+            anonymousPlacement,
+            snapshotBeforeCollision.KgpPlacements[0]);
 
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[3;1H"));
         SendKgp(terminal, KgpTestHelper.BuildCommand(
@@ -818,6 +865,99 @@ public class KgpTerminalTests
             "a=p,i=2,p=9,c=1,r=1,C=1,q=2"));
         Assert.AreEqual(2, terminal.KgpPlacements.Count);
         workload.AssertNoResponse();
+    }
+
+    [TestMethod]
+    public void Transmit_InvalidExplicitClaim_RelocatesAnonymousImageBeforeValidation()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, 20, 10);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,p=0,c=1,r=1,C=1",
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xAA)));
+        Assert.AreEqual(1u, TestSeq.Single(terminal.KgpPlacements).ImageId);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=2,v=2,i=1,q=2",
+            new byte[] { 1, 2, 3, 4 }));
+
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.AreEqual(0xAA, terminal.KgpImageStore.GetImageById(2)!.Data[0]);
+        Assert.IsNull(terminal.KgpImageStore.GetImageByClientId(2));
+        Assert.AreEqual(2u, TestSeq.Single(terminal.KgpPlacements).ImageId);
+        workload.AssertNoResponse();
+    }
+
+    [TestMethod]
+    public void Snapshot_KgpPlacementValuesRemainImmutableAfterScroll()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, 10, 5);
+
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[3;1H"));
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,i=1,p=1,c=1,r=1,C=1,q=2",
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xAA)));
+        var liveBeforeScroll = TestSeq.Single(terminal.KgpPlacements);
+        using var snapshot = terminal.CreateSnapshot();
+        var snapshotPlacement = TestSeq.Single(snapshot.KgpPlacements);
+
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[5;1H\n"));
+
+        var liveAfterScroll = TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(1, liveAfterScroll.Row);
+        Assert.AreEqual(2, snapshotPlacement.Row);
+        Assert.AreNotSame(liveBeforeScroll, snapshotPlacement);
+        Assert.AreEqual(0xAA, snapshot.KgpImages[snapshotPlacement.ImageId].Data[0]);
+    }
+
+    [TestMethod]
+    public async Task Snapshot_ConcurrentKgpReplacement_KeepsPlacementAndImageGenerationPaired()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, 20, 10);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,i=1,p=1,c=1,r=1,C=1,q=2",
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xAA)));
+
+        using var start = new ManualResetEventSlim();
+        var writer = Task.Run(() =>
+        {
+            start.Wait();
+            for (var i = 0; i < 300; i++)
+            {
+                var width = (uint)(i % 2 + 1);
+                var fill = width == 1 ? (byte)0xAA : (byte)0xBB;
+                SendKgp(terminal, KgpTestHelper.BuildCommand(
+                    $"a=T,f=32,s={width},v=1,i=1,p=1,c={width},r=1,C=1,q=2",
+                    KgpTestHelper.CreatePixelData(width, 1, fillByte: fill)));
+                Thread.Yield();
+            }
+        });
+
+        start.Set();
+        try
+        {
+            for (var i = 0; i < 300; i++)
+            {
+                using var snapshot = terminal.CreateSnapshot();
+                var placement = TestSeq.Single(snapshot.KgpPlacements);
+                Assert.IsTrue(snapshot.KgpImages.TryGetValue(placement.ImageId, out var image));
+                Assert.AreEqual(image.Width, placement.DisplayColumns);
+                Assert.AreEqual(
+                    image.Width == 1 ? 0xAA : 0xBB,
+                    image.Data[0]);
+
+                if (i % 16 == 0)
+                    await Task.Yield();
+            }
+        }
+        finally
+        {
+            await writer;
+        }
     }
 
     // =============================================

--- a/tests/Hex1b.Tests/KgpTerminalTests.cs
+++ b/tests/Hex1b.Tests/KgpTerminalTests.cs
@@ -102,18 +102,56 @@ public class KgpTerminalTests
     }
 
     [TestMethod]
-    public void Transmit_ReplaceExistingId_UpdatesImage()
+    public void Transmit_ReplaceExistingId_UpdatesImageAndRemovesItsPlacements()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
-        using var terminal = CreateTerminal(workload);
+        using var terminal = CreateTerminal(workload, 20, 10);
 
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 1, 1, fillByte: 0xAA));
+        SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(2, 1, 1, fillByte: 0xCC));
+        SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 0));
+        SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 7));
+        SendKgp(terminal, KgpTestHelper.BuildPutCommand(2, placementId: 7));
+
         SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 2, 2, fillByte: 0xBB));
 
-        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(2, terminal.KgpImageStore.ImageCount);
         var image = terminal.KgpImageStore.GetImageById(1);
         Assert.IsNotNull(image);
         Assert.AreEqual(2u, image.Width);
+        Assert.AreEqual(0xBB, image.Data[0]);
+        var remainingPlacement = TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(2u, remainingPlacement.ImageId);
+        Assert.AreEqual(7u, remainingPlacement.PlacementId);
+    }
+
+    [TestMethod]
+    public void Transmit_InvalidReplacement_PreservesImagePlacementsAndCursor()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, 20, 10);
+
+        SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 1, 1, fillByte: 0xAA));
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[3;4H"));
+        SendKgp(terminal, KgpTestHelper.BuildPutCommand(
+            1,
+            placementId: 5,
+            displayColumns: 2,
+            cursorMovement: 1));
+        var originalImage = terminal.KgpImageStore.GetImageById(1);
+        var originalPlacement = TestSeq.Single(terminal.KgpPlacements);
+        var originalSnapshot = terminal.CreateSnapshot();
+
+        var invalidReplacement = KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=2,v=2,i=1,q=2",
+            new byte[] { 1, 2, 3, 4 });
+        SendKgp(terminal, invalidReplacement);
+
+        Assert.AreSame(originalImage, terminal.KgpImageStore.GetImageById(1));
+        Assert.AreSame(originalPlacement, TestSeq.Single(terminal.KgpPlacements));
+        var snapshot = terminal.CreateSnapshot();
+        Assert.AreEqual(originalSnapshot.CursorX, snapshot.CursorX);
+        Assert.AreEqual(originalSnapshot.CursorY, snapshot.CursorY);
     }
 
     [TestMethod]
@@ -276,6 +314,98 @@ public class KgpTerminalTests
     }
 
     [TestMethod]
+    [DataRow(0, true)]
+    [DataRow(1, true)]
+    [DataRow(2, false)]
+    public void ConflictingImageIdentity_QuietModes_EmitExactErrorWithoutMutation(
+        int quiet,
+        bool expectsResponse)
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, 20, 10);
+        var pixel = KgpTestHelper.CreatePixelData(1, 1);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,i=1,p=3,C=1,q=2",
+            pixel));
+        var originalImage = terminal.KgpImageStore.GetImageById(1);
+        var originalPlacement = TestSeq.Single(terminal.KgpPlacements);
+        var originalSnapshot = terminal.CreateSnapshot();
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            $"a=T,f=32,s=1,v=1,i=7,I=8,q={quiet}",
+            pixel));
+
+        if (expectsResponse)
+        {
+            Assert.AreEqual(
+                "\x1b_Gi=7,I=8;EINVAL:Must not specify both image id and image number\x1b\\",
+                workload.ReadResponse());
+        }
+        else
+        {
+            workload.AssertNoResponse();
+        }
+
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreSame(originalImage, terminal.KgpImageStore.GetImageById(1));
+        Assert.AreSame(originalPlacement, TestSeq.Single(terminal.KgpPlacements));
+        var snapshot = terminal.CreateSnapshot();
+        Assert.AreEqual(originalSnapshot.CursorX, snapshot.CursorX);
+        Assert.AreEqual(originalSnapshot.CursorY, snapshot.CursorY);
+    }
+
+    [TestMethod]
+    public void Delete_ConflictingImageIdentity_EmitsEinvalWithoutDeleting()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,i=1,p=4,C=1,q=2",
+            KgpTestHelper.CreatePixelData(1, 1)));
+
+        SendKgp(terminal, "\x1b_Ga=d,d=I,i=1,I=8\x1b\\");
+
+        Assert.AreEqual(
+            "\x1b_Gi=1,I=8;EINVAL:Must not specify both image id and image number\x1b\\",
+            workload.ReadResponse());
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpPlacements.Count);
+    }
+
+    [TestMethod]
+    public void ConflictingImageIdentity_DuringChunkedTransfer_DoesNotMutateUpload()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=2,i=5,m=1,q=2",
+            new byte[] { 1, 2, 3, 4 }));
+        Assert.IsTrue(terminal.KgpImageStore.IsChunkedTransferInProgress);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,i=7,I=8,m=0,q=2",
+            new byte[] { 99, 99, 99, 99 }));
+
+        Assert.IsTrue(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "m=0,q=2",
+            new byte[] { 5, 6, 7, 8 }));
+
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        var image = terminal.KgpImageStore.GetImageById(5);
+        Assert.IsNotNull(image);
+        TestSeq.AreEqual(
+            new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 },
+            image.Data);
+    }
+
+    [TestMethod]
     public void InvalidAction_EmitsEinval()
     {
         var workload = new RecordingWorkloadAdapter();
@@ -382,6 +512,138 @@ public class KgpTerminalTests
         Assert.IsNotNull(newest);
     }
 
+    [TestMethod]
+    public void Transmit_WithImageNumber_EmitsGeneratedIdAndPreservesExplicitImage()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(
+            1,
+            1,
+            1,
+            quiet: 2,
+            fillByte: 0xAA));
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,I=93",
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xBB)));
+
+        Assert.AreEqual(
+            "\x1b_Gi=2,I=93;OK\x1b\\",
+            workload.ReadResponse());
+        var numbered = terminal.KgpImageStore.GetImageByNumber(93);
+        Assert.IsNotNull(numbered);
+        Assert.AreEqual(2u, numbered.ImageId);
+        Assert.AreEqual(0xBB, numbered.Data[0]);
+        Assert.AreEqual(0xAA, terminal.KgpImageStore.GetImageById(1)!.Data[0]);
+    }
+
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(2)]
+    public void Transmit_Anonymous_AllQuietModesStoreWithoutResponse(int quiet)
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            $"a=t,f=32,s=1,v=1,q={quiet}",
+            KgpTestHelper.CreatePixelData(1, 1)));
+
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+        workload.AssertNoResponse();
+    }
+
+    [TestMethod]
+    public void Transmit_InvalidImageNumber_DoesNotAllocateIdAndRespondsWithNumberOnly()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=2,v=2,I=93",
+            new byte[] { 1, 2, 3, 4 }));
+
+        Assert.AreEqual(
+            "\x1b_GI=93;ENODATA:Insufficient image data: 4 < 16\x1b\\",
+            workload.ReadResponse());
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,I=94",
+            KgpTestHelper.CreatePixelData(1, 1)));
+
+        Assert.AreEqual(
+            "\x1b_Gi=1,I=94;OK\x1b\\",
+            workload.ReadResponse());
+    }
+
+    [TestMethod]
+    public void Transmit_InvalidAnonymous_DoesNotRespondOrConsumeGeneratedId()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=2,v=2",
+            new byte[] { 1, 2, 3, 4 }));
+
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        workload.AssertNoResponse();
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,I=94",
+            KgpTestHelper.CreatePixelData(1, 1)));
+
+        Assert.AreEqual(
+            "\x1b_Gi=1,I=94;OK\x1b\\",
+            workload.ReadResponse());
+    }
+
+    [TestMethod]
+    public void Transmit_ChunkedImageNumber_RespondsOnlyAfterCommittedGeneratedId()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 1, 1, quiet: 2));
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=2,I=93,m=1",
+            new byte[] { 1, 2, 3, 4 }));
+
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+        workload.AssertNoResponse();
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "m=0",
+            new byte[] { 5, 6, 7, 8 }));
+
+        Assert.AreEqual(
+            "\x1b_Gi=2,I=93;OK\x1b\\",
+            workload.ReadResponse());
+        Assert.AreEqual(2u, terminal.KgpImageStore.GetImageByNumber(93)!.ImageId);
+    }
+
+    [TestMethod]
+    public void Transmit_ChunkedAnonymous_StoresWithoutAnyResponse()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=2,m=1",
+            new byte[] { 1, 2, 3, 4 }));
+        workload.AssertNoResponse();
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "m=0",
+            new byte[] { 5, 6, 7, 8 }));
+
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+        workload.AssertNoResponse();
+    }
+
     // =============================================
     // TransmitAndDisplay tests
     // =============================================
@@ -422,6 +684,140 @@ public class KgpTerminalTests
         var snapshot = terminal.CreateSnapshot();
         Assert.AreEqual(0, snapshot.CursorX);
         Assert.AreEqual(0, snapshot.CursorY);
+    }
+
+    [TestMethod]
+    public void TransmitAndDisplay_WithImageNumber_PlacesNewGeneratedImage()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, 20, 10);
+        SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 1, 1, quiet: 2));
+
+        var command = KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,I=93,p=5,c=1,r=1,C=1,q=2",
+            KgpTestHelper.CreatePixelData(1, 1));
+        SendKgp(terminal, command);
+
+        var image = terminal.KgpImageStore.GetImageByNumber(93);
+        Assert.IsNotNull(image);
+        Assert.AreEqual(2u, image.ImageId);
+        var placement = TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(image.ImageId, placement.ImageId);
+        Assert.AreEqual(5u, placement.PlacementId);
+    }
+
+    [TestMethod]
+    public void TransmitAndDisplay_ReplaceExistingId_RemovesOldPlacementsThenPlacesReplacement()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, 20, 10);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,i=1,p=1,c=1,r=1,C=1,q=2",
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xAA)));
+        SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 2));
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,i=1,p=7,c=1,r=1,C=1,q=2",
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xBB)));
+
+        var placement = TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(1u, placement.ImageId);
+        Assert.AreEqual(7u, placement.PlacementId);
+        Assert.AreEqual(0xBB, terminal.KgpImageStore.GetImageById(1)!.Data[0]);
+    }
+
+    [TestMethod]
+    public void TransmitAndDisplay_AnonymousZeroPlacementId_CreatesDistinctResolvablePlacements()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, 20, 10);
+        var command = KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,p=0,c=1,r=1,C=1",
+            KgpTestHelper.CreatePixelData(1, 1));
+
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[1;1H"));
+        SendKgp(terminal, command);
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[3;4H"));
+        SendKgp(terminal, command);
+
+        Assert.AreEqual(2, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
+        Assert.AreEqual(2, terminal.KgpPlacements.Select(p => p.ImageId).Distinct().Count());
+        TestSeq.All(terminal.KgpPlacements, placement =>
+        {
+            Assert.AreEqual(0u, placement.PlacementId);
+            Assert.IsNotNull(terminal.KgpImageStore.GetImageById(placement.ImageId));
+        });
+
+        var internalId = terminal.KgpPlacements[0].ImageId;
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            $"a=p,i={internalId},p=9,c=1,r=1,C=1,q=2"));
+
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
+        workload.AssertNoResponse();
+    }
+
+    [TestMethod]
+    public void TransmitAndDisplay_AnonymousNonZeroPlacementId_IsIgnored()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, 20, 10);
+        var command = KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,p=7,c=1,r=1,C=1",
+            KgpTestHelper.CreatePixelData(1, 1));
+
+        SendKgp(terminal, command);
+        SendKgp(terminal, command);
+
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
+        TestSeq.All(
+            terminal.KgpPlacements,
+            placement => Assert.AreEqual(0u, placement.PlacementId));
+        Assert.AreEqual(2, terminal.KgpPlacements.Select(p => p.ImageId).Distinct().Count());
+        workload.AssertNoResponse();
+    }
+
+    [TestMethod]
+    public void TransmitAndDisplay_ExplicitIdCollidingWithAnonymousStorage_RelocatesAnonymousPlacement()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, 20, 10);
+
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[1;1H"));
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,p=7,c=1,r=1,C=1",
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xAA)));
+        var anonymousPlacement = TestSeq.Single(terminal.KgpPlacements);
+        using var snapshotBeforeCollision = terminal.CreateSnapshot();
+        Assert.AreEqual(1u, anonymousPlacement.ImageId);
+        Assert.AreEqual(0u, anonymousPlacement.PlacementId);
+
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[3;1H"));
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,i=1,p=7,c=1,r=1,C=1,q=2",
+            KgpTestHelper.CreatePixelData(1, 1, fillByte: 0xBB)));
+
+        Assert.AreEqual(2, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
+        Assert.AreEqual(1u, anonymousPlacement.ImageId);
+        var relocatedAnonymousPlacement = TestSeq.Single(
+            terminal.KgpPlacements.Where(p => p.PlacementId == 0));
+        Assert.AreEqual(2u, relocatedAnonymousPlacement.ImageId);
+        Assert.AreEqual(0xAA, terminal.KgpImageStore.GetImageById(2)!.Data[0]);
+        Assert.IsNull(terminal.KgpImageStore.GetImageByClientId(2));
+        Assert.AreEqual(0xBB, terminal.KgpImageStore.GetImageByClientId(1)!.Data[0]);
+        var explicitPlacement = TestSeq.Single(
+            terminal.KgpPlacements.Where(p => p.ImageId == 1));
+        Assert.AreEqual(7u, explicitPlacement.PlacementId);
+        Assert.AreEqual(2, explicitPlacement.Row);
+        Assert.AreEqual(1u, snapshotBeforeCollision.KgpPlacements[0].ImageId);
+        Assert.AreEqual(0xAA, snapshotBeforeCollision.KgpImages[1].Data[0]);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=p,i=2,p=9,c=1,r=1,C=1,q=2"));
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
+        workload.AssertNoResponse();
     }
 
     // =============================================
@@ -575,6 +971,30 @@ public class KgpTerminalTests
         TestSeq.Single(placements); // Replaced, not duplicated
         Assert.AreEqual(3u, placements[0].DisplayColumns);
         Assert.AreEqual(2, placements[0].Row); // New position
+    }
+
+    [TestMethod]
+    public void Put_SamePlacementIdOnDifferentImages_ReplacesOnlyExactPair()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, 20, 10);
+        SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 1, 1));
+        SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(2, 1, 1));
+
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[1;1H"));
+        SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 5));
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[2;1H"));
+        SendKgp(terminal, KgpTestHelper.BuildPutCommand(2, placementId: 5));
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[3;1H"));
+        SendKgp(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 5));
+
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
+        var imageOne = TestSeq.Single(terminal.KgpPlacements.Where(p => p.ImageId == 1));
+        var imageTwo = TestSeq.Single(terminal.KgpPlacements.Where(p => p.ImageId == 2));
+        Assert.AreEqual(2, imageOne.Row);
+        Assert.AreEqual(1, imageTwo.Row);
+        Assert.AreEqual(5u, imageOne.PlacementId);
+        Assert.AreEqual(5u, imageTwo.PlacementId);
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary
- allocate generated image IDs without colliding with live explicit, numbered, or anonymous storage identities, including zero-skipping `uint` wraparound
- reject simultaneous non-zero `i` and `I` through the typed parser with exact `EINVAL` and no state mutation
- tear down an existing explicit-ID image, number index, and placements when retransmission starts—before payload validation or first-chunk buffering
- relocate anonymous private storage identities when an explicit client ID claims the same number, preserving anonymous images and placements even when the explicit load fails
- keep anonymous images unaddressable through put and identity/range deletion; `d=i/I/r/R` now selects only client-addressable IDs without iterating numeric ranges
- support numbered and anonymous transmit-and-display using the committed image identity, with no unsolicited anonymous-ID response
- capture cloned KGP placements and their referenced image objects atomically under buffer→store lock ordering so snapshots cannot mix generations or observe later row mutation
- preserve exact `(image ID, placement ID)` replacement while keeping anonymous/`p=0` placements distinct

## Validation
- focused KGP suite: 507 passed
- KGP snapshot concurrency regression: passed 5/5 repeated runs
- `Hex1b.Tests`: 8,006 passed, 24 skipped (8,030 total)
- `Hex1b.Analyzers.Tests`: 67 passed
- `Hex1b.McpServer.Tests`: 6 passed
- `Hex1b.Tool.Tests`: 58 passed
- `AgenticPromptDemo.Tests`: 18 passed
- `Hex1b.Tool` build: succeeded with 0 warnings and 0 errors

Closes #396