### PR TITLE
Complete KGP chunked upload semantics

### DIFF
--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -6030,6 +6030,10 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         _escapeFlushTimer?.Dispose();
 
         _disposeCts.Cancel();
+        lock (_bufferLock)
+        {
+            _kgpImageStore.AbortChunkedTransfer();
+        }
         _disposeCts.Dispose();
     }
 
@@ -6079,6 +6083,10 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         _escapeFlushTimer?.Dispose();
 
         _disposeCts.Cancel();
+        lock (_bufferLock)
+        {
+            _kgpImageStore.AbortChunkedTransfer();
+        }
         _disposeCts.Dispose();
     }
 
@@ -6377,27 +6385,67 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         }
     }
 
+    private const int KgpMaximumEncodedChunkLength = 4096;
+
+    private static readonly KgpControlKeySet KgpImageContinuationControls =
+        KgpControlKeySet.From('m').Add('q');
+
+    private static readonly KgpControlKeySet KgpFrameContinuationControls =
+        KgpImageContinuationControls.Add('a');
+
     /// <summary>
     /// Processes a KGP (Kitty Graphics Protocol) command.
     /// </summary>
     private void ProcessKgpCommand(KgpToken token)
     {
-        if (!Capabilities.SupportsKgp)
+        if (_disposed || !Capabilities.SupportsKgp)
             return;
 
         if (!KgpCommandParser.TryParse(token.ControlData, out var command, out var failure))
         {
-            ProcessKgpParseFailure(failure, token.ControlData);
+            var pending = _kgpImageStore.GetPendingTransmission();
+            if (pending is null)
+            {
+                ProcessKgpParseFailure(failure, token.ControlData);
+                return;
+            }
+
+            if (failure.Action == KgpAction.Delete)
+            {
+                _kgpImageStore.AbortChunkedTransfer();
+                ProcessKgpParseFailure(failure, token.ControlData);
+                return;
+            }
+
+            _kgpImageStore.AbortChunkedTransfer();
+            var failureQuiet = failure.Quiet == KgpParsedCommand.QuietMode.Normal
+                ? pending.Value.Quiet
+                : failure.Quiet;
+            SendKgpTransmissionResponse(
+                pending.Value.Transmission,
+                storedImage: null,
+                $"EINVAL:{failure.FormatReason(token.ControlData.AsSpan())}",
+                failureQuiet);
+            return;
+        }
+
+        if (_kgpImageStore.GetPendingTransmission() is { } pendingTransmission)
+        {
+            if (command is KgpParsedCommand.Delete delete)
+            {
+                ProcessKgpDelete(delete.Selector);
+                return;
+            }
+
+            ProcessKgpContinuation(command, token.Payload, pendingTransmission);
             return;
         }
 
         switch (command)
         {
-            case KgpParsedCommand.Transmit transmit:
-                ProcessKgpTransmit(transmit.Transmission, transmit.Quiet, token.Payload);
-                break;
-            case KgpParsedCommand.TransmitAndDisplay transmitAndDisplay:
-                ProcessKgpTransmitAndDisplay(transmitAndDisplay, token.Payload);
+            case KgpParsedCommand.Transmit:
+            case KgpParsedCommand.TransmitAndDisplay:
+                ProcessKgpTransmission(command, token.Payload);
                 break;
             case KgpParsedCommand.Query query:
                 ProcessKgpQuery(query.Transmission, query.Quiet, token.Payload);
@@ -6433,60 +6481,257 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             (int)failure.Quiet);
     }
 
-    private KgpImageData? ProcessKgpTransmit(
-        KgpParsedCommand.TransmissionData command,
-        KgpParsedCommand.QuietMode quiet,
+    private void ProcessKgpContinuation(
+        KgpParsedCommand command,
+        string base64Payload,
+        KgpImageStore.PendingTransmission pending)
+    {
+        var effectiveQuiet = GetKgpContinuationQuiet(command, pending.Quiet);
+        if (!IsValidKgpContinuation(command, pending.Command) ||
+            !command.TryGetTransmission(out var transmission))
+        {
+            FailPendingKgpUpload(
+                pending,
+                "EINVAL:Invalid chunk continuation controls",
+                effectiveQuiet);
+            return;
+        }
+
+        const int maximumEncodedLength = KgpMaximumEncodedChunkLength;
+        if (!TryDecodeKgpPayload(
+                base64Payload,
+                transmission.MoreData,
+                maximumEncodedLength,
+                out var decodedData,
+                out var payloadError))
+        {
+            FailPendingKgpUpload(
+                pending,
+                FormatKgpPayloadError(payloadError, maximumEncodedLength),
+                effectiveQuiet);
+            return;
+        }
+
+        var result = _kgpImageStore.ProcessChunk(
+            command,
+            decodedData,
+            _kgpImageStore.MaximumPendingUploadBytes);
+        switch (result.Status)
+        {
+            case KgpImageStore.ChunkStatus.Incomplete:
+                return;
+            case KgpImageStore.ChunkStatus.TooLarge:
+                SendKgpTransmissionResponse(
+                    result.Transmission,
+                    storedImage: null,
+                    $"EFBIG:Too much image data: {result.AttemptedLength} > {result.MaximumLength}",
+                    result.Quiet);
+                return;
+            case KgpImageStore.ChunkStatus.Complete:
+                if (result.InitialCommand is null)
+                {
+                    throw new InvalidOperationException(
+                        "A terminal KGP upload completed without its initial command.");
+                }
+
+                CompleteKgpTransmission(
+                    result.InitialCommand,
+                    result.Quiet,
+                    result.Data!);
+                return;
+            default:
+                throw new InvalidOperationException(
+                    $"Unsupported KGP chunk status: {result.Status}.");
+        }
+    }
+
+    private static bool IsValidKgpContinuation(
+        KgpParsedCommand command,
+        KgpParsedCommand initialCommand)
+    {
+        if (!command.ControlKeys.Contains('m'))
+            return false;
+
+        return initialCommand switch
+        {
+            KgpParsedCommand.Transmit or KgpParsedCommand.TransmitAndDisplay
+                => command is KgpParsedCommand.Transmit &&
+                   command.ControlKeys.IsSubsetOf(KgpImageContinuationControls),
+            KgpParsedCommand.AnimationFrame
+                => command is KgpParsedCommand.AnimationFrame &&
+                   command.ControlKeys.Contains('a') &&
+                   command.ControlKeys.IsSubsetOf(KgpFrameContinuationControls),
+            _ => false,
+        };
+    }
+
+    private static KgpParsedCommand.QuietMode GetKgpContinuationQuiet(
+        KgpParsedCommand command,
+        KgpParsedCommand.QuietMode inheritedQuiet)
+        => command.ControlKeys.Contains('q') &&
+           command.Quiet != KgpParsedCommand.QuietMode.Normal
+            ? command.Quiet
+            : inheritedQuiet;
+
+    private void FailPendingKgpUpload(
+        KgpImageStore.PendingTransmission pending,
+        string message,
+        KgpParsedCommand.QuietMode quiet)
+    {
+        _kgpImageStore.AbortChunkedTransfer();
+        SendKgpTransmissionResponse(
+            pending.Transmission,
+            storedImage: null,
+            message,
+            quiet);
+    }
+
+    private void ProcessKgpTransmission(
+        KgpParsedCommand command,
         string base64Payload)
     {
-        var isContinuation = _kgpImageStore.IsChunkedTransferInProgress;
-        if (!isContinuation &&
-            command.IdentityKind == KgpParsedCommand.ImageIdentityKind.ExplicitId)
+        if (!command.TryGetTransmission(out var transmission))
         {
-            var start = _kgpImageStore.BeginExplicitTransmission(command.ImageId);
+            throw new ArgumentException(
+                "The command does not carry transmission data.",
+                nameof(command));
+        }
+
+        if (transmission.IdentityKind == KgpParsedCommand.ImageIdentityKind.ExplicitId)
+        {
+            var start = _kgpImageStore.BeginExplicitTransmission(transmission.ImageId);
             if (start.Relocation is { } relocation)
                 ApplyKgpImageRelocation(relocation);
             if (start.RemovedAddressableImage)
-                _kgpPlacements.RemoveAll(p => p.ImageId == command.ImageId);
+                _kgpPlacements.RemoveAll(p => p.ImageId == transmission.ImageId);
         }
 
-        var decodedData = DecodeKgpPayload(base64Payload);
-
-        if (command.MoreData || isContinuation)
+        var maximumEncodedLength = transmission.MoreData
+            ? KgpMaximumEncodedChunkLength
+            : GetMaximumKgpEncodedPayloadLength();
+        if (!TryDecodeKgpPayload(
+                base64Payload,
+                transmission.MoreData,
+                maximumEncodedLength,
+                out var decodedData,
+                out var payloadError))
         {
-            var completed = _kgpImageStore.ProcessChunkAndStore(command, decodedData);
-            if (completed is null)
-                return null;
-
-            return CompleteKgpTransmit(
-                completed.Value.Transmission,
-                completed.Value.Store,
-                quiet);
+            SendKgpTransmissionResponse(
+                transmission,
+                storedImage: null,
+                FormatKgpPayloadError(payloadError, maximumEncodedLength),
+                command.Quiet);
+            return;
         }
 
-        var expectedSize = GetExpectedKgpDataSize(command);
-        if (expectedSize > 0 && decodedData.Length < expectedSize)
+        if (transmission.MoreData)
         {
-            SendKgpTransmissionResponse(command, null,
-                $"ENODATA:Insufficient image data: {decodedData.Length} < {expectedSize}",
-                quiet);
-            return null;
+            if (!TryGetKgpUploadLimit(
+                    transmission,
+                    out var maximumBytes,
+                    out var limitError))
+            {
+                SendKgpTransmissionResponse(
+                    transmission,
+                    storedImage: null,
+                    limitError,
+                    command.Quiet);
+                return;
+            }
+
+            var result = _kgpImageStore.ProcessChunk(
+                command,
+                decodedData,
+                maximumBytes);
+            switch (result.Status)
+            {
+                case KgpImageStore.ChunkStatus.Incomplete:
+                    return;
+                case KgpImageStore.ChunkStatus.TooLarge:
+                    SendKgpTransmissionResponse(
+                        result.Transmission,
+                        storedImage: null,
+                        $"EFBIG:Too much image data: {result.AttemptedLength} > {result.MaximumLength}",
+                        result.Quiet);
+                    return;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unexpected initial KGP chunk status: {result.Status}.");
+            }
         }
 
-        var stored = _kgpImageStore.StoreImage(command, decodedData);
-        return CompleteKgpTransmit(command, stored, quiet);
+        CompleteKgpTransmission(command, command.Quiet, decodedData);
     }
 
-    private void ProcessKgpTransmitAndDisplay(
-        KgpParsedCommand.TransmitAndDisplay command,
-        string base64Payload)
+    private bool TryGetKgpUploadLimit(
+        KgpParsedCommand.TransmissionData transmission,
+        out long maximumBytes,
+        out string error)
     {
-        var image = ProcessKgpTransmit(
-            command.Transmission,
-            command.Quiet,
-            base64Payload);
-        if (image is null)
-            return;
+        maximumBytes = _kgpImageStore.MaximumPendingUploadBytes;
+        if (transmission.Compression != KgpParsedCommand.CompressionMode.None ||
+            !TryGetExpectedKgpDataSize(transmission, out var expectedSize) ||
+            expectedSize == 0)
+        {
+            error = "";
+            return true;
+        }
 
+        if (expectedSize > maximumBytes)
+        {
+            error =
+                $"EFBIG:Image data size {expectedSize} exceeds upload limit {maximumBytes}";
+            return false;
+        }
+
+        maximumBytes = expectedSize;
+        error = "";
+        return true;
+    }
+
+    private void CompleteKgpTransmission(
+        KgpParsedCommand command,
+        KgpParsedCommand.QuietMode quiet,
+        byte[] decodedData)
+    {
+        if (!command.TryGetTransmission(out var transmission))
+        {
+            throw new ArgumentException(
+                "The command does not carry transmission data.",
+                nameof(command));
+        }
+
+        if (!TryValidateKgpData(transmission, decodedData, out var validationError))
+        {
+            SendKgpTransmissionResponse(
+                transmission,
+                storedImage: null,
+                validationError,
+                quiet);
+            return;
+        }
+
+        var stored = _kgpImageStore.StoreImage(transmission, decodedData);
+        if (stored.Relocation is { } relocation)
+            ApplyKgpImageRelocation(relocation);
+
+        if (stored.Replaced)
+            _kgpPlacements.RemoveAll(p => p.ImageId == stored.Image.ImageId);
+
+        if (command is KgpParsedCommand.TransmitAndDisplay transmitAndDisplay)
+            DisplayTransmittedKgpImage(stored.Image, transmitAndDisplay);
+
+        SendKgpTransmissionResponse(
+            transmission,
+            stored.Image,
+            "OK",
+            quiet);
+    }
+
+    private void DisplayTransmittedKgpImage(
+        KgpImageData image,
+        KgpParsedCommand.TransmitAndDisplay command)
+    {
         var cols = command.Display.Columns > 0 ? (int)command.Display.Columns : 1;
         var rows = command.Display.Rows > 0 ? (int)command.Display.Rows : 1;
         var placementId = command.Transmission.IdentityKind ==
@@ -6512,19 +6757,34 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         }
     }
 
-    private KgpImageData CompleteKgpTransmit(
+    private static bool TryValidateKgpData(
         KgpParsedCommand.TransmissionData transmission,
-        KgpImageStore.StoreResult stored,
-        KgpParsedCommand.QuietMode quiet)
+        byte[] data,
+        out string error)
     {
-        if (stored.Relocation is { } relocation)
-            ApplyKgpImageRelocation(relocation);
+        if (!TryGetExpectedKgpDataSize(transmission, out var expectedSize) ||
+            expectedSize == 0)
+        {
+            error = "";
+            return true;
+        }
 
-        if (stored.Replaced)
-            _kgpPlacements.RemoveAll(p => p.ImageId == stored.Image.ImageId);
+        if (data.LongLength < expectedSize)
+        {
+            error =
+                $"ENODATA:Insufficient image data: {data.LongLength} < {expectedSize}";
+            return false;
+        }
 
-        SendKgpTransmissionResponse(transmission, stored.Image, "OK", quiet);
-        return stored.Image;
+        if (data.LongLength > expectedSize)
+        {
+            error =
+                $"EFBIG:Too much image data: {data.LongLength} > {expectedSize}";
+            return false;
+        }
+
+        error = "";
+        return true;
     }
 
     private void ApplyKgpImageRelocation(KgpImageStore.ImageRelocation relocation)
@@ -6573,9 +6833,10 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         string base64Payload)
     {
         var decodedData = DecodeKgpPayload(base64Payload);
-        var expectedSize = GetExpectedKgpDataSize(command);
 
-        if (expectedSize > 0 && decodedData.Length < expectedSize)
+        if (TryGetExpectedKgpDataSize(command, out var expectedSize) &&
+            expectedSize > 0 &&
+            decodedData.Length < expectedSize)
         {
             SendKgpResponse(command.ImageId, command.ImageNumber,
                 $"ENODATA:Insufficient image data: {decodedData.Length} < {expectedSize}",
@@ -6627,6 +6888,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
 
     private void ProcessKgpDelete(KgpParsedCommand.DeleteSelector selector)
     {
+        _kgpImageStore.AbortChunkedTransfer();
+
         switch (selector)
         {
             case KgpParsedCommand.DeleteSelector.All { FreeData: false }:
@@ -6696,8 +6959,6 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             }
         }
 
-        // Delete aborts any in-progress chunked transfer
-        _kgpImageStore.AbortChunkedTransfer();
     }
 
     private void CreateKgpPlacement(
@@ -6776,15 +7037,153 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         }
     }
 
-    private static long GetExpectedKgpDataSize(KgpParsedCommand.TransmissionData command)
+    private enum KgpPayloadError
     {
-        if (command.Format == KgpFormat.Png)
-            return 0; // PNG size is variable
+        None,
+        TooLong,
+        InvalidNonFinalLength,
+        NonFinalPadding,
+        InvalidEncoding,
+    }
 
-        if (command.Width == 0 || command.Height == 0)
-            return 0;
+    private static bool TryDecodeKgpPayload(
+        string base64Payload,
+        bool moreData,
+        int maximumEncodedLength,
+        out byte[] data,
+        out KgpPayloadError error)
+    {
+        data = [];
+        if (base64Payload.Length > maximumEncodedLength)
+        {
+            error = KgpPayloadError.TooLong;
+            return false;
+        }
+
+        if (moreData && base64Payload.Length % 4 != 0)
+        {
+            error = KgpPayloadError.InvalidNonFinalLength;
+            return false;
+        }
+
+        var paddingIndex = base64Payload.IndexOf('=');
+        if (moreData && paddingIndex >= 0)
+        {
+            error = KgpPayloadError.NonFinalPadding;
+            return false;
+        }
+
+        foreach (var character in base64Payload)
+        {
+            if (IsKgpBase64Character(character) ||
+                (!moreData && character == '='))
+            {
+                continue;
+            }
+
+            error = KgpPayloadError.InvalidEncoding;
+            return false;
+        }
+
+        if (base64Payload.Length == 0)
+        {
+            error = KgpPayloadError.None;
+            return true;
+        }
+
+        var remainder = base64Payload.Length % 4;
+        if (remainder == 1 || (paddingIndex >= 0 && remainder != 0))
+        {
+            error = KgpPayloadError.InvalidEncoding;
+            return false;
+        }
+
+        var addedPadding = paddingIndex >= 0 || remainder == 0
+            ? 0
+            : 4 - remainder;
+        ReadOnlySpan<char> normalized;
+        char[]? normalizedBuffer = null;
+        if (addedPadding == 0)
+        {
+            normalized = base64Payload.AsSpan();
+        }
+        else
+        {
+            var normalizedLength = checked(base64Payload.Length + addedPadding);
+            if (normalizedLength > maximumEncodedLength)
+            {
+                error = KgpPayloadError.TooLong;
+                return false;
+            }
+
+            normalizedBuffer = new char[normalizedLength];
+            base64Payload.AsSpan().CopyTo(normalizedBuffer);
+            normalizedBuffer.AsSpan(base64Payload.Length).Fill('=');
+            normalized = normalizedBuffer;
+        }
+
+        var maximumDecodedLength = checked((int)((long)normalized.Length / 4 * 3));
+        var decoded = new byte[maximumDecodedLength];
+        if (!Convert.TryFromBase64Chars(normalized, decoded, out var bytesWritten))
+        {
+            error = KgpPayloadError.InvalidEncoding;
+            return false;
+        }
+
+        if (bytesWritten != decoded.Length)
+            Array.Resize(ref decoded, bytesWritten);
+
+        data = decoded;
+        error = KgpPayloadError.None;
+        return true;
+    }
+
+    private int GetMaximumKgpEncodedPayloadLength()
+    {
+        var maximumDecodedLength = _kgpImageStore.MaximumPendingUploadBytes;
+        var maximumEncodedLength = (maximumDecodedLength + 2) / 3 * 4;
+        return checked((int)Math.Min(maximumEncodedLength, int.MaxValue));
+    }
+
+    private static string FormatKgpPayloadError(
+        KgpPayloadError error,
+        int maximumEncodedLength)
+        => error switch
+        {
+            KgpPayloadError.TooLong
+                => $"EFBIG:Encoded payload exceeds {maximumEncodedLength} bytes",
+            KgpPayloadError.InvalidNonFinalLength
+                => "EINVAL:Non-final Base64 chunk length must be a multiple of 4",
+            KgpPayloadError.NonFinalPadding
+                => "EINVAL:Non-final Base64 chunk must not contain padding",
+            KgpPayloadError.InvalidEncoding
+                => "EINVAL:Invalid Base64 payload",
+            _ => throw new ArgumentOutOfRangeException(nameof(error)),
+        };
+
+    private static bool IsKgpBase64Character(char character)
+        => character is >= 'A' and <= 'Z' or
+            >= 'a' and <= 'z' or
+            >= '0' and <= '9' or
+            '+' or '/';
+
+    private static bool TryGetExpectedKgpDataSize(
+        KgpParsedCommand.TransmissionData command,
+        out long expectedSize)
+    {
+        if (command.Format == KgpFormat.Png ||
+            command.Width == 0 ||
+            command.Height == 0)
+        {
+            expectedSize = 0;
+            return false;
+        }
 
         var bytesPerPixel = command.Format == KgpFormat.Rgb24 ? 3 : 4;
-        return (long)command.Width * command.Height * bytesPerPixel;
+        var pixels = (ulong)command.Width * command.Height;
+        expectedSize = pixels > (ulong)long.MaxValue / (uint)bytesPerPixel
+            ? long.MaxValue
+            : (long)(pixels * (uint)bytesPerPixel);
+        return true;
     }
 }

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -6443,6 +6443,17 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             return;
         }
 
+        if (command is KgpParsedCommand.Transmit orphanContinuation &&
+            IsOrphanKgpContinuation(orphanContinuation))
+        {
+            SendKgpTransmissionResponse(
+                orphanContinuation.Transmission,
+                storedImage: null,
+                "EILSEQ:No active chunked upload",
+                orphanContinuation.Quiet);
+            return;
+        }
+
         switch (command)
         {
             case KgpParsedCommand.Transmit:
@@ -6464,6 +6475,11 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 break;
         }
     }
+
+    private static bool IsOrphanKgpContinuation(
+        KgpParsedCommand.Transmit command)
+        => command.ControlKeys.Contains('m') &&
+           command.ControlKeys.IsSubsetOf(KgpImageContinuationControls);
 
     private void ProcessKgpParseFailure(
         KgpCommandParser.Failure failure,

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -5992,6 +5992,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     {
         if (_disposed) return;
         _disposed = true;
+        AbortPendingKgpUploadForDisposal();
 
         // Complete any active paste context
         if (_activePasteContext != null)
@@ -6030,10 +6031,6 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         _escapeFlushTimer?.Dispose();
 
         _disposeCts.Cancel();
-        lock (_bufferLock)
-        {
-            _kgpImageStore.AbortChunkedTransfer();
-        }
         _disposeCts.Dispose();
     }
 
@@ -6042,6 +6039,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     {
         if (_disposed) return;
         _disposed = true;
+        AbortPendingKgpUploadForDisposal();
 
         // Complete any active paste context
         if (_activePasteContext != null)
@@ -6083,11 +6081,15 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         _escapeFlushTimer?.Dispose();
 
         _disposeCts.Cancel();
+        _disposeCts.Dispose();
+    }
+
+    private void AbortPendingKgpUploadForDisposal()
+    {
         lock (_bufferLock)
         {
             _kgpImageStore.AbortChunkedTransfer();
         }
-        _disposeCts.Dispose();
     }
 
     // === Filter Notification Helpers ===

--- a/src/Hex1b/Kgp/KgpCommandParser.cs
+++ b/src/Hex1b/Kgp/KgpCommandParser.cs
@@ -16,6 +16,7 @@ internal static class KgpCommandParser
         InvalidDeleteTarget,
         InvalidTransmissionMedium,
         InvalidCompression,
+        InvalidMoreData,
         InvalidImageFormat,
         InvalidSignedInteger,
         InvalidUnsignedInteger,
@@ -57,6 +58,8 @@ internal static class KgpCommandParser
                     => $"Invalid transmission medium '{value.ToString()}'.",
                 ErrorCode.InvalidCompression
                     => $"Invalid compression value '{value.ToString()}'.",
+                ErrorCode.InvalidMoreData
+                    => $"Invalid more-data value '{value.ToString()}'.",
                 ErrorCode.InvalidImageFormat
                     => $"Invalid image format '{value.ToString()}'.",
                 ErrorCode.InvalidSignedInteger
@@ -135,13 +138,15 @@ internal static class KgpCommandParser
 
         var errors = default(ErrorCandidates);
         var hasActionControl = false;
+        var controlKeys = default(KgpControlKeySet);
         if (!controlData.IsEmpty)
         {
             ScanControlData(
                 controlData,
                 slots,
                 ref errors,
-                ref hasActionControl);
+                ref hasActionControl,
+                ref controlKeys);
         }
 
         var action = HasValue(slots, 'a')
@@ -194,30 +199,38 @@ internal static class KgpCommandParser
         {
             KgpAction.Transmit => new KgpParsedCommand.Transmit(
                 ParseTransmission(controlData, slots),
-                quiet),
+                quiet,
+                controlKeys),
             KgpAction.TransmitAndDisplay => new KgpParsedCommand.TransmitAndDisplay(
                 ParseTransmission(controlData, slots),
                 ParseDisplay(controlData, slots),
-                quiet),
+                quiet,
+                controlKeys),
             KgpAction.Query => new KgpParsedCommand.Query(
                 ParseTransmission(controlData, slots),
-                quiet),
+                quiet,
+                controlKeys),
             KgpAction.Put => new KgpParsedCommand.Put(
                 ParseDisplay(controlData, slots),
-                quiet),
+                quiet,
+                controlKeys),
             KgpAction.Delete => new KgpParsedCommand.Delete(
                 ParseDelete(controlData, slots),
-                quiet),
+                quiet,
+                controlKeys),
             KgpAction.AnimationFrame => new KgpParsedCommand.AnimationFrame(
                 ParseTransmission(controlData, slots),
                 ParseAnimationFrame(controlData, slots),
-                quiet),
+                quiet,
+                controlKeys),
             KgpAction.AnimationControl => new KgpParsedCommand.AnimationControl(
                 ParseAnimationControl(controlData, slots),
-                quiet),
+                quiet,
+                controlKeys),
             KgpAction.Compose => new KgpParsedCommand.Compose(
                 ParseComposition(controlData, slots),
-                quiet),
+                quiet,
+                controlKeys),
             _ => throw new InvalidOperationException(
                 $"Unsupported KGP action: {action.Value}."),
         };
@@ -229,7 +242,8 @@ internal static class KgpCommandParser
         ReadOnlySpan<char> controlData,
         Span<ControlSlot> slots,
         ref ErrorCandidates errors,
-        ref bool hasActionControl)
+        ref bool hasActionControl,
+        ref KgpControlKeySet controlKeys)
     {
         var pairStart = 0;
         var pairIndex = 0;
@@ -249,7 +263,8 @@ internal static class KgpCommandParser
                 pairIndex,
                 slots,
                 ref errors,
-                ref hasActionControl);
+                ref hasActionControl,
+                ref controlKeys);
 
             if (commaIndex < 0)
                 break;
@@ -266,7 +281,8 @@ internal static class KgpCommandParser
         int pairIndex,
         Span<ControlSlot> slots,
         ref ErrorCandidates errors,
-        ref bool hasActionControl)
+        ref bool hasActionControl,
+        ref KgpControlKeySet controlKeys)
     {
         if (pairLength == 0)
         {
@@ -336,6 +352,8 @@ internal static class KgpCommandParser
                 valueLength);
             return;
         }
+
+        controlKeys = controlKeys.Add(key);
 
         var validation = ValidateKnownValue(key, value, out var errorCode);
         if (validation == ValidationResult.Unknown)
@@ -426,6 +444,13 @@ internal static class KgpCommandParser
                     return ValidationResult.Invalid;
                 }
                 break;
+            case 'm':
+                if (value.Length != 1 || value[0] is not ('0' or '1'))
+                {
+                    errorCode = ErrorCode.InvalidMoreData;
+                    return ValidationResult.Invalid;
+                }
+                break;
             case 'f':
                 if (!TryParseFormat(value, out _))
                 {
@@ -450,7 +475,6 @@ internal static class KgpCommandParser
             case 'i':
             case 'I':
             case 'p':
-            case 'm':
             case 'N':
             case 'x':
             case 'y':

--- a/src/Hex1b/Kgp/KgpControlKeySet.cs
+++ b/src/Hex1b/Kgp/KgpControlKeySet.cs
@@ -1,0 +1,28 @@
+namespace Hex1b;
+
+internal readonly record struct KgpControlKeySet(ulong Bits)
+{
+    internal bool Contains(char key)
+        => (Bits & GetBit(key)) != 0;
+
+    internal bool IsSubsetOf(KgpControlKeySet other)
+        => (Bits & ~other.Bits) == 0;
+
+    internal KgpControlKeySet Add(char key)
+        => new(Bits | GetBit(key));
+
+    internal static KgpControlKeySet From(char key)
+        => new(GetBit(key));
+
+    private static ulong GetBit(char key)
+    {
+        var index = key switch
+        {
+            >= 'a' and <= 'z' => key - 'a',
+            >= 'A' and <= 'Z' => 26 + key - 'A',
+            _ => throw new ArgumentOutOfRangeException(nameof(key)),
+        };
+
+        return 1UL << index;
+    }
+}

--- a/src/Hex1b/Kgp/KgpImageStore.cs
+++ b/src/Hex1b/Kgp/KgpImageStore.cs
@@ -22,13 +22,26 @@ public sealed class KgpImageStore
         bool RemovedAddressableImage,
         ImageRelocation? Relocation);
 
-    internal readonly record struct CompletedTransmission(
-        KgpParsedCommand.TransmissionData Transmission,
-        StoreResult Store);
+    internal enum ChunkStatus
+    {
+        Incomplete,
+        Complete,
+        TooLarge,
+    }
 
-    private readonly record struct AssembledTransmission(
+    internal readonly record struct PendingTransmission(
+        KgpParsedCommand Command,
         KgpParsedCommand.TransmissionData Transmission,
-        byte[] Data);
+        KgpParsedCommand.QuietMode Quiet);
+
+    internal readonly record struct ChunkResult(
+        ChunkStatus Status,
+        KgpParsedCommand? InitialCommand,
+        KgpParsedCommand.TransmissionData Transmission,
+        KgpParsedCommand.QuietMode Quiet,
+        byte[]? Data,
+        long AttemptedLength,
+        long MaximumLength);
 
     private readonly object _lock = new();
     private readonly Dictionary<uint, KgpImageData> _imagesById = new();
@@ -38,9 +51,7 @@ public sealed class KgpImageStore
     private long _totalSize;
     private readonly long _quotaBytes;
 
-    // Chunked transfer state
-    private KgpParsedCommand.TransmissionData? _chunkedCommand;
-    private readonly List<byte> _chunkedData = new();
+    private KgpPendingUpload? _pendingUpload;
 
     /// <summary>
     /// Creates a new image store with the specified storage quota.
@@ -78,8 +89,11 @@ public sealed class KgpImageStore
     /// </summary>
     public bool IsChunkedTransferInProgress
     {
-        get { lock (_lock) return _chunkedCommand is not null; }
+        get { lock (_lock) return _pendingUpload is not null; }
     }
+
+    internal long MaximumPendingUploadBytes
+        => Math.Min(Math.Max(0, _quotaBytes), Array.MaxLength);
 
     /// <summary>
     /// Allocates a currently unused, non-zero image ID.
@@ -302,36 +316,66 @@ public sealed class KgpImageStore
     /// </returns>
     public KgpImageData? ProcessChunk(KgpCommand command, byte[] decodedData)
     {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(decodedData);
+
         lock (_lock)
         {
-            var assembled = ProcessChunkUnsafe(command.ToTransmissionData(), decodedData);
-            if (assembled is null)
+            var transmission = command.ToTransmissionData();
+            var result = ProcessChunkUnsafe(
+                initialCommand: null,
+                transmission,
+                ToQuietMode(command.Quiet),
+                quietWasSpecified: command.Quiet != 0,
+                decodedData,
+                Array.MaxLength);
+            if (result.Status != ChunkStatus.Complete)
                 return null;
 
-            var transmission = assembled.Value.Transmission;
-            var imageId = transmission.ImageId > 0
-                ? transmission.ImageId
+            var imageId = result.Transmission.ImageId > 0
+                ? result.Transmission.ImageId
                 : AllocateIdUnsafe();
-            return CreateImage(imageId, transmission, assembled.Value.Data);
+            return CreateImage(imageId, result.Transmission, result.Data!);
         }
     }
 
-    internal CompletedTransmission? ProcessChunkAndStore(
-        KgpParsedCommand.TransmissionData transmission,
-        byte[] decodedData)
+    internal ChunkResult ProcessChunk(
+        KgpParsedCommand command,
+        byte[] decodedData,
+        long maximumBytes)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(decodedData);
+        if (!command.TryGetTransmission(out var transmission))
+            throw new ArgumentException("The command does not carry transmission data.", nameof(command));
+
+        lock (_lock)
+        {
+            return ProcessChunkUnsafe(
+                command,
+                transmission,
+                command.Quiet,
+                command.ControlKeys.Contains('q'),
+                decodedData,
+                maximumBytes);
+        }
+    }
+
+    internal PendingTransmission? GetPendingTransmission()
     {
         lock (_lock)
         {
-            var assembled = ProcessChunkUnsafe(transmission, decodedData);
-            if (assembled is null)
-                return null;
+            return GetPendingTransmissionUnsafe();
+        }
+    }
 
-            var store = StoreTransmissionUnsafe(
-                assembled.Value.Transmission,
-                assembled.Value.Data);
-            return new CompletedTransmission(
-                assembled.Value.Transmission,
-                store);
+    internal PendingTransmission? AbortPendingTransmission()
+    {
+        lock (_lock)
+        {
+            var pending = GetPendingTransmissionUnsafe();
+            AbortChunkedTransferUnsafe();
+            return pending;
         }
     }
 
@@ -348,29 +392,92 @@ public sealed class KgpImageStore
 
     private void AbortChunkedTransferUnsafe()
     {
-        _chunkedCommand = null;
-        _chunkedData.Clear();
+        var pending = _pendingUpload;
+        _pendingUpload = null;
+        pending?.Dispose();
     }
 
-    private AssembledTransmission? ProcessChunkUnsafe(
+    private ChunkResult ProcessChunkUnsafe(
+        KgpParsedCommand? initialCommand,
         KgpParsedCommand.TransmissionData transmission,
-        byte[] decodedData)
+        KgpParsedCommand.QuietMode quiet,
+        bool quietWasSpecified,
+        byte[] decodedData,
+        long maximumBytes)
     {
-        if (_chunkedCommand is null)
+        if (_pendingUpload is null)
         {
-            _chunkedCommand = transmission;
+            _pendingUpload = new KgpPendingUpload(
+                initialCommand,
+                transmission,
+                quiet,
+                maximumBytes);
+        }
+        else if (quietWasSpecified)
+        {
+            _pendingUpload.ApplyQuiet(quiet);
         }
 
-        _chunkedData.AddRange(decodedData);
+        var pending = _pendingUpload;
+        if (!pending.TryAppend(decodedData, out var attemptedLength))
+        {
+            var tooLarge = new ChunkResult(
+                ChunkStatus.TooLarge,
+                pending.InitialCommand,
+                pending.Transmission,
+                pending.EffectiveQuiet,
+                Data: null,
+                attemptedLength,
+                pending.MaximumBytes);
+            AbortChunkedTransferUnsafe();
+            return tooLarge;
+        }
 
         if (transmission.MoreData)
+        {
+            return new ChunkResult(
+                ChunkStatus.Incomplete,
+                pending.InitialCommand,
+                pending.Transmission,
+                pending.EffectiveQuiet,
+                Data: null,
+                attemptedLength,
+                pending.MaximumBytes);
+        }
+
+        var initial = pending.InitialCommand;
+        var initialTransmission = pending.Transmission;
+        var effectiveQuiet = pending.EffectiveQuiet;
+        var completeData = pending.Complete();
+        _pendingUpload = null;
+        return new ChunkResult(
+            ChunkStatus.Complete,
+            initial,
+            initialTransmission,
+            effectiveQuiet,
+            completeData,
+            attemptedLength,
+            pending.MaximumBytes);
+    }
+
+    private PendingTransmission? GetPendingTransmissionUnsafe()
+    {
+        if (_pendingUpload?.InitialCommand is not { } command)
             return null;
 
-        var completeData = _chunkedData.ToArray();
-        var firstTransmission = _chunkedCommand.Value;
-        AbortChunkedTransferUnsafe();
-        return new AssembledTransmission(firstTransmission, completeData);
+        return new PendingTransmission(
+            command,
+            _pendingUpload.Transmission,
+            _pendingUpload.EffectiveQuiet);
     }
+
+    private static KgpParsedCommand.QuietMode ToQuietMode(int quiet)
+        => quiet switch
+        {
+            <= 0 => KgpParsedCommand.QuietMode.Normal,
+            1 => KgpParsedCommand.QuietMode.SuppressSuccess,
+            _ => KgpParsedCommand.QuietMode.SuppressAll,
+        };
 
     private StoreResult StoreTransmissionUnsafe(
         KgpParsedCommand.TransmissionData transmission,

--- a/src/Hex1b/Kgp/KgpParsedCommand.cs
+++ b/src/Hex1b/Kgp/KgpParsedCommand.cs
@@ -1,7 +1,31 @@
 namespace Hex1b;
 
-internal abstract record KgpParsedCommand(KgpParsedCommand.QuietMode Quiet)
+internal abstract record KgpParsedCommand(
+    KgpParsedCommand.QuietMode Quiet,
+    KgpControlKeySet ControlKeys)
 {
+    internal bool TryGetTransmission(out TransmissionData transmission)
+    {
+        switch (this)
+        {
+            case Transmit transmit:
+                transmission = transmit.Transmission;
+                return true;
+            case TransmitAndDisplay transmitAndDisplay:
+                transmission = transmitAndDisplay.Transmission;
+                return true;
+            case Query query:
+                transmission = query.Transmission;
+                return true;
+            case AnimationFrame animationFrame:
+                transmission = animationFrame.Transmission;
+                return true;
+            default:
+                transmission = default;
+                return false;
+        }
+    }
+
     internal enum QuietMode
     {
         Normal,
@@ -38,37 +62,45 @@ internal abstract record KgpParsedCommand(KgpParsedCommand.QuietMode Quiet)
 
     internal sealed record Transmit(
         TransmissionData Transmission,
-        QuietMode Quiet) : KgpParsedCommand(Quiet);
+        QuietMode Quiet,
+        KgpControlKeySet ControlKeys) : KgpParsedCommand(Quiet, ControlKeys);
 
     internal sealed record TransmitAndDisplay(
         TransmissionData Transmission,
         DisplayData Display,
-        QuietMode Quiet) : KgpParsedCommand(Quiet);
+        QuietMode Quiet,
+        KgpControlKeySet ControlKeys) : KgpParsedCommand(Quiet, ControlKeys);
 
     internal sealed record Query(
         TransmissionData Transmission,
-        QuietMode Quiet) : KgpParsedCommand(Quiet);
+        QuietMode Quiet,
+        KgpControlKeySet ControlKeys) : KgpParsedCommand(Quiet, ControlKeys);
 
     internal sealed record Put(
         DisplayData Display,
-        QuietMode Quiet) : KgpParsedCommand(Quiet);
+        QuietMode Quiet,
+        KgpControlKeySet ControlKeys) : KgpParsedCommand(Quiet, ControlKeys);
 
     internal sealed record Delete(
         DeleteSelector Selector,
-        QuietMode Quiet) : KgpParsedCommand(Quiet);
+        QuietMode Quiet,
+        KgpControlKeySet ControlKeys) : KgpParsedCommand(Quiet, ControlKeys);
 
     internal sealed record AnimationFrame(
         TransmissionData Transmission,
         AnimationFrameData Frame,
-        QuietMode Quiet) : KgpParsedCommand(Quiet);
+        QuietMode Quiet,
+        KgpControlKeySet ControlKeys) : KgpParsedCommand(Quiet, ControlKeys);
 
     internal sealed record AnimationControl(
         AnimationControlData Control,
-        QuietMode Quiet) : KgpParsedCommand(Quiet);
+        QuietMode Quiet,
+        KgpControlKeySet ControlKeys) : KgpParsedCommand(Quiet, ControlKeys);
 
     internal sealed record Compose(
         CompositionData Composition,
-        QuietMode Quiet) : KgpParsedCommand(Quiet);
+        QuietMode Quiet,
+        KgpControlKeySet ControlKeys) : KgpParsedCommand(Quiet, ControlKeys);
 
     internal readonly record struct TransmissionData(
         KgpFormat Format,

--- a/src/Hex1b/Kgp/KgpPendingUpload.cs
+++ b/src/Hex1b/Kgp/KgpPendingUpload.cs
@@ -1,0 +1,84 @@
+namespace Hex1b;
+
+internal sealed class KgpPendingUpload : IDisposable
+{
+    private byte[]? _buffer = [];
+    private int _length;
+
+    internal KgpPendingUpload(
+        KgpParsedCommand? initialCommand,
+        KgpParsedCommand.TransmissionData transmission,
+        KgpParsedCommand.QuietMode quiet,
+        long maximumBytes)
+    {
+        InitialCommand = initialCommand;
+        Transmission = transmission;
+        EffectiveQuiet = quiet;
+        MaximumBytes = Math.Max(0, maximumBytes);
+    }
+
+    internal KgpParsedCommand? InitialCommand { get; }
+
+    internal KgpParsedCommand.TransmissionData Transmission { get; }
+
+    internal KgpParsedCommand.QuietMode EffectiveQuiet { get; private set; }
+
+    internal long MaximumBytes { get; }
+
+    internal long Length => _length;
+
+    internal void ApplyQuiet(KgpParsedCommand.QuietMode quiet)
+    {
+        if (quiet != KgpParsedCommand.QuietMode.Normal)
+            EffectiveQuiet = quiet;
+    }
+
+    internal bool TryAppend(ReadOnlySpan<byte> data, out long attemptedLength)
+    {
+        var buffer = _buffer
+            ?? throw new ObjectDisposedException(nameof(KgpPendingUpload));
+
+        attemptedLength = (long)_length + data.Length;
+        if (attemptedLength > MaximumBytes)
+            return false;
+
+        if (attemptedLength > buffer.Length)
+        {
+            var doubledLength = Math.Max((long)buffer.Length * 2, attemptedLength);
+            var newLength = checked((int)Math.Min(MaximumBytes, doubledLength));
+            var expanded = new byte[newLength];
+            buffer.AsSpan(0, _length).CopyTo(expanded);
+            _buffer = buffer = expanded;
+        }
+
+        data.CopyTo(buffer.AsSpan(_length));
+        _length += data.Length;
+        return true;
+    }
+
+    internal byte[] Complete()
+    {
+        var buffer = _buffer
+            ?? throw new ObjectDisposedException(nameof(KgpPendingUpload));
+        byte[] data;
+        if (_length == buffer.Length)
+        {
+            data = buffer;
+        }
+        else
+        {
+            data = new byte[_length];
+            buffer.AsSpan(0, _length).CopyTo(data);
+        }
+
+        _buffer = null;
+        _length = 0;
+        return data;
+    }
+
+    public void Dispose()
+    {
+        _buffer = null;
+        _length = 0;
+    }
+}

--- a/src/Hex1b/Kgp/KgpTestHelper.cs
+++ b/src/Hex1b/Kgp/KgpTestHelper.cs
@@ -151,17 +151,31 @@ public static class KgpTestHelper
         KgpFormat format = KgpFormat.Rgba32,
         byte fillByte = 0xFF)
     {
+        ArgumentOutOfRangeException.ThrowIfLessThan(chunkSize, 1);
+
         var bytesPerPixel = format == KgpFormat.Rgb24 ? 3 : 4;
         var totalData = new byte[width * height * bytesPerPixel];
         Array.Fill(totalData, fillByte);
 
         var commands = new List<string>();
         var offset = 0;
+        var maximumRawChunkSize = Math.Min(chunkSize, 3 * 4096 / 4);
 
         while (offset < totalData.Length)
         {
             var remaining = totalData.Length - offset;
-            var thisChunk = Math.Min(chunkSize, remaining);
+            var thisChunk = Math.Min(maximumRawChunkSize, remaining);
+            if (thisChunk < remaining)
+            {
+                thisChunk -= thisChunk % 3;
+                if (thisChunk == 0)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(chunkSize),
+                        "A multi-chunk Base64 transfer requires at least three raw bytes per non-final chunk.");
+                }
+            }
+
             var chunk = new byte[thisChunk];
             Array.Copy(totalData, offset, chunk, 0, thisChunk);
 

--- a/tests/Hex1b.Tests/KgpCommandParserTests.cs
+++ b/tests/Hex1b.Tests/KgpCommandParserTests.cs
@@ -387,7 +387,7 @@ public class KgpCommandParserTests
     [TestMethod]
     public void Parse_QuietAndBooleanLikeControls_UseKittyCompatiblePolicies()
     {
-        var quiet = ParseTyped<KgpParsedCommand.Transmit>("q=4294967295,m=2");
+        var quiet = ParseTyped<KgpParsedCommand.Transmit>("q=4294967295,m=1");
         var display = ParseTyped<KgpParsedCommand.Put>("a=p,C=2,U=2");
         var frame = ParseTyped<KgpParsedCommand.AnimationFrame>("a=f,X=2");
         var composition = ParseTyped<KgpParsedCommand.Compose>("a=c,C=2");
@@ -529,6 +529,37 @@ public class KgpCommandParserTests
             ParseSuccess($"{prefix},{key}=0");
             ParseSuccess($"{prefix},{key}=4294967295");
         }
+    }
+
+    [TestMethod]
+    public void Parse_MoreData_AcceptsOnlyZeroOrOne()
+    {
+        ParseSuccess("a=t,m=0");
+        ParseSuccess("a=t,m=1");
+
+        foreach (var invalidValue in new[] { "2", "00", "01", "4294967295" })
+        {
+            var failure = ParseFailure($"a=t,i=7,m={invalidValue}");
+            Assert.AreEqual(KgpCommandParser.ErrorCode.InvalidMoreData, failure.Code);
+            Assert.AreEqual(KgpAction.Transmit, failure.Action);
+            Assert.AreEqual(7u, failure.ImageId);
+            Assert.AreEqual(
+                $"Invalid more-data value '{invalidValue}'.",
+                failure.FormatReason($"a=t,i=7,m={invalidValue}".AsSpan()));
+        }
+    }
+
+    [TestMethod]
+    public void TryParse_ControlKeys_PreservesKnownAndUnknownControls()
+    {
+        var command = ParseTyped<KgpParsedCommand.Transmit>(
+            "a=t,m=1,q=0,k=opaque");
+
+        Assert.IsTrue(command.ControlKeys.Contains('a'));
+        Assert.IsTrue(command.ControlKeys.Contains('m'));
+        Assert.IsTrue(command.ControlKeys.Contains('q'));
+        Assert.IsTrue(command.ControlKeys.Contains('k'));
+        Assert.IsFalse(command.ControlKeys.Contains('i'));
     }
 
     [TestMethod]
@@ -742,7 +773,6 @@ public class KgpCommandParserTests
             ("a=t", "i"),
             ("a=t", "I"),
             ("a=t", "p"),
-            ("a=t", "m"),
             ("a=t", "N"),
             ("a=p", "i"),
             ("a=p", "I"),

--- a/tests/Hex1b.Tests/KgpConformanceTests.cs
+++ b/tests/Hex1b.Tests/KgpConformanceTests.cs
@@ -82,14 +82,14 @@ public class KgpLoadConformanceTests
     }
 
     [TestMethod]
-    public void ChunkedLoad_FourChunks_AssemblesCorrectly()
+    public void ChunkedLoad_MultipleChunks_AssemblesCorrectly()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
         using var terminal = CreateTerminal(workload);
 
         // 10x10 RGBA = 400 bytes, chunk at 100 bytes → 4 chunks
         var chunks = KgpTestHelper.BuildChunkedTransmitCommands(1, 10, 10, chunkSize: 100);
-        Assert.AreEqual(4, chunks.Count);
+        Assert.IsGreaterThan(1, chunks.Count);
 
         foreach (var chunk in chunks)
         {
@@ -299,8 +299,8 @@ public class KgpResponseConformanceTests
 
         // Chunked transfer with q=1
         var data = KgpTestHelper.CreatePixelData(10, 10);
-        var chunk1 = data[..(data.Length / 2)];
-        var chunk2 = data[(data.Length / 2)..];
+        var chunk1 = data[..198];
+        var chunk2 = data[198..];
 
         var cmd1 = KgpTestHelper.BuildCommand($"a=t,f=32,s=10,v=10,i=1,m=1,q=1", chunk1);
         var cmd2 = KgpTestHelper.BuildCommand("m=0", chunk2);
@@ -1543,9 +1543,8 @@ public class KgpGhosttyExecConformanceTests
 
         // 4x4 RGBA = 64 bytes, split into 2 chunks
         var data = KgpTestHelper.CreatePixelData(4, 4);
-        var half = data.Length / 2;
-        var chunk1 = data[..half];
-        var chunk2 = data[half..];
+        var chunk1 = data[..30];
+        var chunk2 = data[30..];
 
         // First chunk: q=0 (send responses), m=1 (more coming)
         var cmd1 = KgpTestHelper.BuildCommand("a=t,f=32,s=4,v=4,i=1,m=1,q=0", chunk1);
@@ -1568,11 +1567,11 @@ public class KgpGhosttyExecConformanceTests
         using var workload = new Hex1bAppWorkloadAdapter();
         using var terminal = CreateTerminal(workload);
 
-        // 6x1 RGBA = 24 bytes, split into 3 chunks of 8 bytes each
+        // 6x1 RGBA = 24 bytes, split on Base64-safe 3-byte boundaries
         var data = KgpTestHelper.CreatePixelData(6, 1);
-        var chunk1 = data[..8];
-        var chunk2 = data[8..16];
-        var chunk3 = data[16..];
+        var chunk1 = data[..6];
+        var chunk2 = data[6..12];
+        var chunk3 = data[12..];
 
         // Increasing quiet: 0 → 1 → 2
         SendKgp(terminal, KgpTestHelper.BuildCommand("a=t,f=32,s=6,v=1,i=1,m=1,q=0", chunk1));

--- a/tests/Hex1b.Tests/KgpImageStoreTests.cs
+++ b/tests/Hex1b.Tests/KgpImageStoreTests.cs
@@ -24,6 +24,18 @@ public class KgpImageStoreTests
         }.ToTransmissionData();
     }
 
+    private static KgpParsedCommand ParseCommand(string controlData)
+    {
+        var success = KgpCommandParser.TryParse(
+            controlData,
+            out var command,
+            out var failure);
+        Assert.IsTrue(
+            success,
+            success ? null : failure.FormatReason(controlData.AsSpan()));
+        return command!;
+    }
+
     // --- Basic store/retrieve ---
 
     [TestMethod]
@@ -408,7 +420,7 @@ public class KgpImageStoreTests
     {
         var store = new KgpImageStore();
 
-        var cmd1 = new KgpCommand { Width = 2, Height = 2, Format = KgpFormat.Rgba32, ImageId = 1, MoreData = 1 };
+        var cmd1 = new KgpCommand { Width = 2, Height = 2, Format = KgpFormat.Rgba32, ImageId = 5, MoreData = 1 };
         var result1 = store.ProcessChunk(cmd1, new byte[] { 1, 2, 3, 4 });
         Assert.IsNull(result1);
         Assert.IsTrue(store.IsChunkedTransferInProgress);
@@ -422,7 +434,7 @@ public class KgpImageStoreTests
         Assert.IsNotNull(result3);
 
         TestSeq.AreEqual(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 }, result3.Data);
-        Assert.AreEqual(1u, result3.ImageId);
+        Assert.AreEqual(5u, result3.ImageId);
         Assert.AreEqual(2u, result3.Width);
         Assert.AreEqual(2u, result3.Height);
         Assert.IsFalse(store.IsChunkedTransferInProgress);
@@ -473,6 +485,82 @@ public class KgpImageStoreTests
 
         store.Clear();
         Assert.IsFalse(store.IsChunkedTransferInProgress);
+    }
+
+    [TestMethod]
+    public void ProcessChunk_TypedCommands_RetainsFirstMetadataAndEffectiveQuiet()
+    {
+        var store = new KgpImageStore();
+        var first = ParseCommand(
+            "a=T,f=32,s=1,v=2,i=7,p=9,c=2,r=1,m=1,q=0");
+
+        var initial = store.ProcessChunk(
+            first,
+            new byte[] { 1, 2, 3 },
+            maximumBytes: 8);
+
+        Assert.AreEqual(KgpImageStore.ChunkStatus.Incomplete, initial.Status);
+        var pending = store.GetPendingTransmission();
+        Assert.IsNotNull(pending);
+        Assert.AreSame(first, pending.Value.Command);
+        Assert.AreEqual(7u, pending.Value.Transmission.ImageId);
+        Assert.AreEqual(KgpParsedCommand.QuietMode.Normal, pending.Value.Quiet);
+
+        var final = store.ProcessChunk(
+            ParseCommand("m=0,q=1"),
+            new byte[] { 4, 5, 6, 7, 8 },
+            maximumBytes: long.MaxValue);
+
+        Assert.AreEqual(KgpImageStore.ChunkStatus.Complete, final.Status);
+        Assert.AreSame(first, final.InitialCommand);
+        Assert.AreEqual(7u, final.Transmission.ImageId);
+        Assert.AreEqual(
+            KgpParsedCommand.QuietMode.SuppressSuccess,
+            final.Quiet);
+        TestSeq.AreEqual(
+            new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 },
+            final.Data!);
+        Assert.IsFalse(store.IsChunkedTransferInProgress);
+    }
+
+    [TestMethod]
+    public void ProcessChunk_ExceedsBound_AbortsAndReportsAttempt()
+    {
+        var store = new KgpImageStore();
+        store.ProcessChunk(
+            ParseCommand("a=t,f=32,s=1,v=1,i=7,m=1"),
+            new byte[] { 1, 2, 3 },
+            maximumBytes: 4);
+
+        var result = store.ProcessChunk(
+            ParseCommand("m=0"),
+            new byte[] { 4, 5 },
+            maximumBytes: long.MaxValue);
+
+        Assert.AreEqual(KgpImageStore.ChunkStatus.TooLarge, result.Status);
+        Assert.AreEqual(5L, result.AttemptedLength);
+        Assert.AreEqual(4L, result.MaximumLength);
+        Assert.IsNull(result.Data);
+        Assert.IsFalse(store.IsChunkedTransferInProgress);
+    }
+
+    [TestMethod]
+    public void AbortPendingTransmission_ReturnsFirstMetadataAndClearsState()
+    {
+        var store = new KgpImageStore();
+        var first = ParseCommand("a=t,f=32,s=1,v=1,I=42,m=1,q=2");
+        store.ProcessChunk(first, new byte[] { 1, 2, 3 }, maximumBytes: 4);
+
+        var aborted = store.AbortPendingTransmission();
+
+        Assert.IsNotNull(aborted);
+        Assert.AreSame(first, aborted.Value.Command);
+        Assert.AreEqual(42u, aborted.Value.Transmission.ImageNumber);
+        Assert.AreEqual(
+            KgpParsedCommand.QuietMode.SuppressAll,
+            aborted.Value.Quiet);
+        Assert.IsFalse(store.IsChunkedTransferInProgress);
+        Assert.IsNull(store.AbortPendingTransmission());
     }
 
     // --- KgpImageData validation ---

--- a/tests/Hex1b.Tests/KgpPerlinNoiseTests.cs
+++ b/tests/Hex1b.Tests/KgpPerlinNoiseTests.cs
@@ -438,7 +438,7 @@ public class KgpPerlinNoiseTests
     /// </summary>
     private static void TransmitImage(Hex1bTerminal terminal, uint imageId, uint width, uint height, byte[] rgbData)
     {
-        const int chunkSize = 4096;
+        const int chunkSize = 3 * 4096 / 4;
         int offset = 0;
 
         while (offset < rgbData.Length)

--- a/tests/Hex1b.Tests/KgpTerminalTests.cs
+++ b/tests/Hex1b.Tests/KgpTerminalTests.cs
@@ -1455,6 +1455,65 @@ public class KgpTerminalTests
     // =============================================
 
     [TestMethod]
+    [DataRow("m=0")]
+    [DataRow("m=0,q=0")]
+    [DataRow("m=0,q=1")]
+    [DataRow("m=0,q=2")]
+    [DataRow("m=1")]
+    [DataRow("m=1,q=0")]
+    [DataRow("m=1,q=1")]
+    [DataRow("m=1,q=2")]
+    public void Transmit_OrphanContinuation_IsSilentNoOpWithoutIdConsumption(
+        string controlData)
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(controlData));
+
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(0L, terminal.KgpImageStore.TotalSize);
+        Assert.IsEmpty(terminal.KgpPlacements);
+        workload.AssertNoResponse();
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,I=94",
+            KgpTestHelper.CreatePixelData(1, 1)));
+
+        Assert.AreEqual(
+            "\x1b_Gi=1,I=94;OK\x1b\\",
+            workload.ReadResponse());
+        Assert.AreEqual(1u, terminal.KgpImageStore.GetImageByNumber(94)!.ImageId);
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.IsEmpty(terminal.KgpPlacements);
+    }
+
+    [TestMethod]
+    [DataRow(3)]
+    [DataRow(6)]
+    [DataRow(9)]
+    public void Transmit_ChunkedTransfer_ValidThreeByteSplitBoundaries(
+        int chunkSize)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        var chunks = KgpTestHelper.BuildChunkedTransmitCommands(
+            imageId: 20,
+            width: 4,
+            height: 1,
+            chunkSize: chunkSize);
+
+        foreach (var chunk in chunks)
+            SendKgp(terminal, chunk);
+
+        var image = terminal.KgpImageStore.GetImageById(20);
+        Assert.IsNotNull(image);
+        Assert.AreEqual(16, image.Data.Length);
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+    }
+
+    [TestMethod]
     public void Transmit_ChunkedTransfer_HasNoEffectsBeforeFinalChunk()
     {
         var workload = new RecordingWorkloadAdapter();

--- a/tests/Hex1b.Tests/KgpTerminalTests.cs
+++ b/tests/Hex1b.Tests/KgpTerminalTests.cs
@@ -178,7 +178,7 @@ public class KgpTerminalTests
 
         SendKgp(terminal, KgpTestHelper.BuildCommand(
             "a=t,f=32,s=1,v=2,i=1,m=1,q=2",
-            new byte[] { 1, 2, 3, 4 }));
+            new byte[] { 1, 2, 3 }));
 
         Assert.IsTrue(terminal.KgpImageStore.IsChunkedTransferInProgress);
         Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
@@ -187,7 +187,7 @@ public class KgpTerminalTests
 
         SendKgp(terminal, KgpTestHelper.BuildCommand(
             "m=0,q=2",
-            new byte[] { 5, 6, 7, 8 }));
+            new byte[] { 4, 5, 6, 7, 8 }));
 
         Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
         var replacement = terminal.KgpImageStore.GetImageById(1);
@@ -373,7 +373,9 @@ public class KgpTerminalTests
 
         // Start a chunked transfer
         var data = new byte[] { 1, 2, 3, 4 };
-        var cmd = KgpTestHelper.BuildCommand("a=t,f=32,s=2,v=2,i=1,m=1", data);
+        var cmd = KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=2,v=2,i=1,m=1",
+            data[..3]);
         SendKgp(terminal, cmd);
 
         Assert.IsTrue(terminal.KgpImageStore.IsChunkedTransferInProgress);
@@ -496,33 +498,29 @@ public class KgpTerminalTests
     }
 
     [TestMethod]
-    public void ConflictingImageIdentity_DuringChunkedTransfer_DoesNotMutateUpload()
+    public void ConflictingImageIdentity_DuringChunkedTransfer_AbortsUsingInitialIdentity()
     {
-        using var workload = new Hex1bAppWorkloadAdapter();
+        var workload = new RecordingWorkloadAdapter();
         using var terminal = CreateTerminal(workload);
 
         SendKgp(terminal, KgpTestHelper.BuildCommand(
-            "a=t,f=32,s=1,v=2,i=5,m=1,q=2",
-            new byte[] { 1, 2, 3, 4 }));
+            "a=t,f=32,s=1,v=2,i=5,m=1",
+            new byte[] { 1, 2, 3 }));
         Assert.IsTrue(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        workload.AssertNoResponse();
 
         SendKgp(terminal, KgpTestHelper.BuildCommand(
-            "a=t,i=7,I=8,m=0,q=2",
+            "a=t,i=7,I=8,m=0",
             new byte[] { 99, 99, 99, 99 }));
 
-        Assert.IsTrue(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(
+            "\x1b_Gi=5;EINVAL:Must not specify both image id and image number\x1b\\",
+            workload.ReadResponse());
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
         Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
 
-        SendKgp(terminal, KgpTestHelper.BuildCommand(
-            "m=0,q=2",
-            new byte[] { 5, 6, 7, 8 }));
-
-        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
-        var image = terminal.KgpImageStore.GetImageById(5);
-        Assert.IsNotNull(image);
-        TestSeq.AreEqual(
-            new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 },
-            image.Data);
+        SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(6, 1, 1));
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(6));
     }
 
     [TestMethod]
@@ -730,14 +728,14 @@ public class KgpTerminalTests
 
         SendKgp(terminal, KgpTestHelper.BuildCommand(
             "a=t,f=32,s=1,v=2,I=93,m=1",
-            new byte[] { 1, 2, 3, 4 }));
+            new byte[] { 1, 2, 3 }));
 
         Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
         workload.AssertNoResponse();
 
         SendKgp(terminal, KgpTestHelper.BuildCommand(
             "m=0",
-            new byte[] { 5, 6, 7, 8 }));
+            new byte[] { 4, 5, 6, 7, 8 }));
 
         Assert.AreEqual(
             "\x1b_Gi=2,I=93;OK\x1b\\",
@@ -753,12 +751,12 @@ public class KgpTerminalTests
 
         SendKgp(terminal, KgpTestHelper.BuildCommand(
             "a=t,f=32,s=1,v=2,m=1",
-            new byte[] { 1, 2, 3, 4 }));
+            new byte[] { 1, 2, 3 }));
         workload.AssertNoResponse();
 
         SendKgp(terminal, KgpTestHelper.BuildCommand(
             "m=0",
-            new byte[] { 5, 6, 7, 8 }));
+            new byte[] { 4, 5, 6, 7, 8 }));
 
         Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
         workload.AssertNoResponse();
@@ -1451,6 +1449,598 @@ public class KgpTerminalTests
         // Note: This test documents the expected behavior - implementation
         // may need to handle placement scrolling in the scroll logic
     }
+
+    // =============================================
+    // Chunked upload state machine tests
+    // =============================================
+
+    [TestMethod]
+    public void Transmit_ChunkedTransfer_HasNoEffectsBeforeFinalChunk()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=2,i=21,m=1",
+            new byte[] { 1, 2, 3 }));
+
+        Assert.IsTrue(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(0L, terminal.KgpImageStore.TotalSize);
+        Assert.IsEmpty(terminal.KgpPlacements);
+        workload.AssertNoResponse();
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "m=1",
+            new byte[] { 4, 5, 6 }));
+
+        Assert.IsTrue(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        Assert.IsEmpty(terminal.KgpPlacements);
+        workload.AssertNoResponse();
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "m=0",
+            new byte[] { 7, 8 }));
+
+        Assert.AreEqual("\x1b_Gi=21;OK\x1b\\", workload.ReadResponse());
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+        TestSeq.AreEqual(
+            new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 },
+            terminal.KgpImageStore.GetImageById(21)!.Data);
+        Assert.IsEmpty(terminal.KgpPlacements);
+    }
+
+    [TestMethod]
+    public void TransmitAndDisplay_ChunkedTransfer_PlacesOnceAtFinalCursor()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, 20, 10);
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[2;3H"));
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=2,i=22,p=9,c=2,r=2,m=1",
+            new byte[] { 1, 2, 3 }));
+
+        Assert.IsEmpty(terminal.KgpPlacements);
+        using (var preFinalSnapshot = terminal.CreateSnapshot())
+        {
+            Assert.AreEqual(2, preFinalSnapshot.CursorX);
+            Assert.AreEqual(1, preFinalSnapshot.CursorY);
+        }
+        workload.AssertNoResponse();
+
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[5;7H"));
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "m=0",
+            new byte[] { 4, 5, 6, 7, 8 }));
+
+        Assert.AreEqual("\x1b_Gi=22;OK\x1b\\", workload.ReadResponse());
+        var placement = TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(22u, placement.ImageId);
+        Assert.AreEqual(9u, placement.PlacementId);
+        Assert.AreEqual(4, placement.Row);
+        Assert.AreEqual(6, placement.Column);
+        Assert.AreEqual(2u, placement.DisplayColumns);
+        Assert.AreEqual(2u, placement.DisplayRows);
+        using var snapshot = terminal.CreateSnapshot();
+        Assert.AreEqual(8, snapshot.CursorX);
+        Assert.AreEqual(5, snapshot.CursorY);
+    }
+
+    [TestMethod]
+    [DataRow("f=32,m=0")]
+    [DataRow("s=1,m=0")]
+    [DataRow("i=99,m=0")]
+    [DataRow("k=opaque,m=0")]
+    [DataRow("a=t,m=0")]
+    [DataRow("a=f,m=0")]
+    public void Continuation_ForbiddenControl_AbortsUsingInitialIdentity(
+        string controlData)
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=2,i=31,m=1",
+            new byte[] { 1, 2, 3 }));
+        workload.AssertNoResponse();
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            controlData,
+            new byte[] { 4, 5, 6, 7, 8 }));
+
+        Assert.AreEqual(
+            "\x1b_Gi=31;EINVAL:Invalid chunk continuation controls\x1b\\",
+            workload.ReadResponse());
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        Assert.IsEmpty(terminal.KgpPlacements);
+    }
+
+    [TestMethod]
+    public void Continuation_MissingMoreDataControl_Aborts()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,i=32,m=1",
+            new byte[] { 1, 2, 3 }));
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "q=0",
+            new byte[] { 4 }));
+
+        Assert.AreEqual(
+            "\x1b_Gi=32;EINVAL:Invalid chunk continuation controls\x1b\\",
+            workload.ReadResponse());
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+    }
+
+    [TestMethod]
+    public void Continuation_InvalidMoreDataValue_AbortsWithParseError()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,i=33,m=1",
+            new byte[] { 1, 2, 3 }));
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "m=2",
+            new byte[] { 4 }));
+
+        Assert.AreEqual(
+            "\x1b_Gi=33;EINVAL:Invalid more-data value '2'.\x1b\\",
+            workload.ReadResponse());
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+    }
+
+    [TestMethod]
+    public void Continuation_ParseFailureQTwo_SuppressesFailure()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,i=58,m=1,q=0",
+            new byte[] { 1, 2, 3 }));
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand("m=2,q=2"));
+
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        workload.AssertNoResponse();
+    }
+
+    [TestMethod]
+    public void Continuation_ParseFailureQOne_ReplacesSuppressAllForFailure()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,i=59,m=1,q=2",
+            new byte[] { 1, 2, 3 }));
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand("m=2,q=1"));
+
+        Assert.AreEqual(
+            "\x1b_Gi=59;EINVAL:Invalid more-data value '2'.\x1b\\",
+            workload.ReadResponse());
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+    }
+
+    [TestMethod]
+    [DataRow("a=p,i=90")]
+    [DataRow("a=q,f=32,s=1,v=1,i=90")]
+    [DataRow("a=t,f=32,s=1,v=1,i=90")]
+    [DataRow("a=a,i=90,s=3")]
+    public void Upload_NonDeleteGraphicsCommand_AbortsWithoutProcessing(
+        string controlData)
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,i=34,m=1",
+            new byte[] { 1, 2, 3 }));
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(controlData));
+
+        Assert.AreEqual(
+            "\x1b_Gi=34;EINVAL:Invalid chunk continuation controls\x1b\\",
+            workload.ReadResponse());
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        Assert.IsEmpty(terminal.KgpPlacements);
+
+        SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(35, 1, 1));
+        Assert.AreEqual("\x1b_Gi=35;OK\x1b\\", workload.ReadResponse());
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(35));
+    }
+
+    [TestMethod]
+    public void Transmit_NonFinal4096CharacterPayload_AcceptsEmptyFinalMarker()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        var data = new byte[3072];
+        Array.Fill(data, (byte)0x5A);
+        var first = KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=768,v=1,i=36,m=1",
+            data);
+        Assert.AreEqual(4096, Convert.ToBase64String(data).Length);
+
+        SendKgp(terminal, first);
+        Assert.IsTrue(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        workload.AssertNoResponse();
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand("m=0"));
+
+        Assert.AreEqual("\x1b_Gi=36;OK\x1b\\", workload.ReadResponse());
+        var image = terminal.KgpImageStore.GetImageById(36);
+        Assert.IsNotNull(image);
+        Assert.AreEqual(3072, image.Data.Length);
+        Assert.AreEqual(0x5A, image.Data[0]);
+    }
+
+    [TestMethod]
+    public void Transmit_EncodedPayloadLongerThan4096_RejectsWithoutBuffering()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+
+        SendKgp(terminal, BuildEncodedKgpCommand(
+            "a=t,f=32,s=1,v=1,i=37,m=1",
+            new string('A', 4097)));
+
+        Assert.AreEqual(
+            "\x1b_Gi=37;EFBIG:Encoded payload exceeds 4096 bytes\x1b\\",
+            workload.ReadResponse());
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+    }
+
+    [TestMethod]
+    [DataRow(
+        "AAA",
+        "EINVAL:Non-final Base64 chunk length must be a multiple of 4")]
+    [DataRow(
+        "AAAA====",
+        "EINVAL:Non-final Base64 chunk must not contain padding")]
+    [DataRow(
+        "AAA*",
+        "EINVAL:Invalid Base64 payload")]
+    public void Transmit_InvalidNonFinalBase64_RejectsExactError(
+        string payload,
+        string expectedError)
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+
+        SendKgp(terminal, BuildEncodedKgpCommand(
+            "a=t,f=32,s=1,v=1,i=38,m=1",
+            payload));
+
+        Assert.AreEqual(
+            $"\x1b_Gi=38;{expectedError}\x1b\\",
+            workload.ReadResponse());
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+    }
+
+    [TestMethod]
+    public void Continuation_UnpaddedFinalBase64_DecodesSuccessfully()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,i=39,m=1",
+            new byte[] { 1, 2, 3 }));
+
+        SendKgp(terminal, BuildEncodedKgpCommand("m=0", "BA"));
+
+        Assert.AreEqual("\x1b_Gi=39;OK\x1b\\", workload.ReadResponse());
+        TestSeq.AreEqual(
+            new byte[] { 1, 2, 3, 4 },
+            terminal.KgpImageStore.GetImageById(39)!.Data);
+    }
+
+    [TestMethod]
+    public void Continuation_MalformedFinalPadding_AbortsWithoutStorage()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,i=40,m=1",
+            new byte[] { 1, 2, 3 }));
+
+        SendKgp(terminal, BuildEncodedKgpCommand("m=0", "BA="));
+
+        Assert.AreEqual(
+            "\x1b_Gi=40;EINVAL:Invalid Base64 payload\x1b\\",
+            workload.ReadResponse());
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+    }
+
+    [TestMethod]
+    public void Continuation_ShortFinalData_RejectsWithoutOkOrStorage()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,i=41,p=7,c=2,r=2,m=1",
+            new byte[] { 1, 2, 3 }));
+        workload.AssertNoResponse();
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand("m=0"));
+
+        Assert.AreEqual(
+            "\x1b_Gi=41;ENODATA:Insufficient image data: 3 < 4\x1b\\",
+            workload.ReadResponse());
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        Assert.IsEmpty(terminal.KgpPlacements);
+    }
+
+    [TestMethod]
+    public void Transmit_SingleOversizedPayload_UsesSameFinalValidation()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,i=52",
+            new byte[] { 1, 2, 3, 4, 5 }));
+
+        Assert.AreEqual(
+            "\x1b_Gi=52;EFBIG:Too much image data: 5 > 4\x1b\\",
+            workload.ReadResponse());
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+    }
+
+    [TestMethod]
+    public void Continuation_OversizedFinalData_RejectsWithoutOkOrStorage()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,i=42,m=1",
+            new byte[] { 1, 2, 3 }));
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "m=0",
+            new byte[] { 4, 5 }));
+
+        Assert.AreEqual(
+            "\x1b_Gi=42;EFBIG:Too much image data: 5 > 4\x1b\\",
+            workload.ReadResponse());
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        Assert.IsEmpty(terminal.KgpPlacements);
+    }
+
+    [TestMethod]
+    public void ChunkedQuiet_OmittedFinalQuiet_InheritsSuppressSuccess()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=2,i=43,m=1,q=1",
+            new byte[] { 1, 2, 3 }));
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "m=0",
+            new byte[] { 4, 5, 6, 7, 8 }));
+
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(43));
+        workload.AssertNoResponse();
+    }
+
+    [TestMethod]
+    public void ChunkedQuiet_QZero_InheritsLastExplicitSuppression()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=2,i=44,m=1,q=0",
+            new byte[] { 1, 2, 3 }));
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "m=1,q=2",
+            new byte[] { 4, 5, 6 }));
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "m=0,q=0",
+            new byte[] { 7, 8 }));
+
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(44));
+        workload.AssertNoResponse();
+    }
+
+    [TestMethod]
+    public void ChunkedQuiet_FinalQOne_ReplacesSuppressAllForFailure()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,i=45,m=1,q=2",
+            new byte[] { 1, 2, 3 }));
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand("m=0,q=1"));
+
+        Assert.AreEqual(
+            "\x1b_Gi=45;ENODATA:Insufficient image data: 3 < 4\x1b\\",
+            workload.ReadResponse());
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+    }
+
+    [TestMethod]
+    public void Continuation_InvalidPayloadQTwo_SuppressesFailure()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,i=56,m=1,q=0",
+            new byte[] { 1, 2, 3 }));
+
+        SendKgp(terminal, BuildEncodedKgpCommand("m=0,q=2", "*"));
+
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        workload.AssertNoResponse();
+    }
+
+    [TestMethod]
+    public void Continuation_InvalidPayloadQOne_ReplacesSuppressAllForFailure()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,i=57,m=1,q=2",
+            new byte[] { 1, 2, 3 }));
+
+        SendKgp(terminal, BuildEncodedKgpCommand("m=0,q=1", "BA="));
+
+        Assert.AreEqual(
+            "\x1b_Gi=57;EINVAL:Invalid Base64 payload\x1b\\",
+            workload.ReadResponse());
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+    }
+
+    [TestMethod]
+    public void Delete_MalformedRecognizedCommand_AbortsWithoutDeletingOrResponding()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(46, 1, 1, quiet: 2));
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,i=47,m=1",
+            new byte[] { 1, 2, 3 }));
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand("a=d,d=?"));
+
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(46));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(47));
+        workload.AssertNoResponse();
+    }
+
+    [TestMethod]
+    public void Transmit_CompletedChunkedUploads_CanRunBackToBack()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,i=48,m=1",
+            new byte[] { 1, 2, 3 }));
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "m=0",
+            new byte[] { 4 }));
+        Assert.AreEqual("\x1b_Gi=48;OK\x1b\\", workload.ReadResponse());
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,i=49,m=1",
+            new byte[] { 5, 6, 7 }));
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "m=0",
+            new byte[] { 8 }));
+        Assert.AreEqual("\x1b_Gi=49;OK\x1b\\", workload.ReadResponse());
+
+        Assert.AreEqual(2, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.GetImageById(48)!.Data[0]);
+        Assert.AreEqual(5, terminal.KgpImageStore.GetImageById(49)!.Data[0]);
+    }
+
+    [TestMethod]
+    public void Upload_SecondExplicitTransmission_DoesNotTearDownItsImage()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(53, 1, 1, quiet: 2));
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,i=54,m=1",
+            new byte[] { 1, 2, 3 }));
+
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,i=53",
+            new byte[] { 9, 9, 9, 9 }));
+
+        Assert.AreEqual(
+            "\x1b_Gi=54;EINVAL:Invalid chunk continuation controls\x1b\\",
+            workload.ReadResponse());
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(53));
+        Assert.AreEqual(0xFF, terminal.KgpImageStore.GetImageById(53)!.Data[0]);
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(54));
+    }
+
+    [TestMethod]
+    public void Transmit_ChunkedExplicitReplacement_InvalidFirstPayloadKeepsTeardown()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, 20, 10);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=T,f=32,s=1,v=1,i=50,p=7,C=1,q=2",
+            KgpTestHelper.CreatePixelData(1, 1)));
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(50));
+        Assert.AreEqual(1, terminal.KgpPlacements.Count);
+
+        SendKgp(terminal, BuildEncodedKgpCommand(
+            "a=t,f=32,s=1,v=1,i=50,m=1",
+            "AAA"));
+
+        Assert.AreEqual(
+            "\x1b_Gi=50;EINVAL:Non-final Base64 chunk length must be a multiple of 4\x1b\\",
+            workload.ReadResponse());
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(50));
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+    }
+
+    [TestMethod]
+    public void Dispose_WithPendingUpload_AbortsState()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        var terminal = CreateTerminal(workload);
+        try
+        {
+            SendKgp(terminal, KgpTestHelper.BuildCommand(
+                "a=t,f=32,s=1,v=1,i=51,m=1,q=2",
+                new byte[] { 1, 2, 3 }));
+            Assert.IsTrue(terminal.KgpImageStore.IsChunkedTransferInProgress);
+
+            terminal.Dispose();
+
+            Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        }
+        finally
+        {
+            terminal.Dispose();
+        }
+    }
+
+    [TestMethod]
+    public async Task DisposeAsync_WithPendingUpload_AbortsState()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,i=55,m=1,q=2",
+            new byte[] { 1, 2, 3 }));
+        Assert.IsTrue(terminal.KgpImageStore.IsChunkedTransferInProgress);
+
+        await terminal.DisposeAsync();
+
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+    }
+
+    private static string BuildEncodedKgpCommand(
+        string controlData,
+        string encodedPayload)
+        => $"\x1b_G{controlData};{encodedPayload}\x1b\\";
 
     private sealed class RecordingWorkloadAdapter : IHex1bTerminalWorkloadAdapter
     {

--- a/tests/Hex1b.Tests/KgpTerminalTests.cs
+++ b/tests/Hex1b.Tests/KgpTerminalTests.cs
@@ -2037,6 +2037,48 @@ public class KgpTerminalTests
         Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
     }
 
+    [TestMethod]
+    public void Dispose_ThrowingAdapter_AbortsPendingUploadBeforeRethrowing()
+    {
+        var workload = new ThrowingDisposeWorkloadAdapter();
+        var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,i=60,m=1,q=2",
+            new byte[] { 1, 2, 3 }));
+        Assert.IsTrue(terminal.KgpImageStore.IsChunkedTransferInProgress);
+
+        var exception = Assert.ThrowsExactly<InvalidOperationException>(
+            terminal.Dispose);
+
+        Assert.AreSame(workload.DisposalException, exception);
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(1, workload.DisposeCallCount);
+
+        terminal.Dispose();
+        Assert.AreEqual(1, workload.DisposeCallCount);
+    }
+
+    [TestMethod]
+    public async Task DisposeAsync_ThrowingAdapter_AbortsPendingUploadBeforeRethrowing()
+    {
+        var workload = new ThrowingDisposeWorkloadAdapter();
+        var terminal = CreateTerminal(workload);
+        SendKgp(terminal, KgpTestHelper.BuildCommand(
+            "a=t,f=32,s=1,v=1,i=61,m=1,q=2",
+            new byte[] { 1, 2, 3 }));
+        Assert.IsTrue(terminal.KgpImageStore.IsChunkedTransferInProgress);
+
+        var exception = await Assert.ThrowsExactlyAsync<InvalidOperationException>(
+            async () => await terminal.DisposeAsync());
+
+        Assert.AreSame(workload.DisposalException, exception);
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(1, workload.DisposeCallCount);
+
+        await terminal.DisposeAsync();
+        Assert.AreEqual(1, workload.DisposeCallCount);
+    }
+
     private static string BuildEncodedKgpCommand(
         string controlData,
         string encodedPayload)
@@ -2107,6 +2149,48 @@ public class KgpTerminalTests
                 TimeSpan.FromMilliseconds(100));
 
             Assert.IsFalse(received, "Expected no KGP protocol response.");
+        }
+    }
+
+    private sealed class ThrowingDisposeWorkloadAdapter : IHex1bTerminalWorkloadAdapter
+    {
+        private bool _stopping;
+
+        internal InvalidOperationException DisposalException { get; } =
+            new("Workload disposal failed.");
+
+        internal int DisposeCallCount { get; private set; }
+
+        public event Action? Disconnected
+        {
+            add { }
+            remove { }
+        }
+
+        public ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(
+            CancellationToken ct = default)
+            => _stopping
+                ? new ValueTask<ReadOnlyMemory<byte>>(
+                    Task.FromCanceled<ReadOnlyMemory<byte>>(
+                        new CancellationToken(canceled: true)))
+                : ValueTask.FromResult(ReadOnlyMemory<byte>.Empty);
+
+        public ValueTask WriteInputAsync(
+            ReadOnlyMemory<byte> data,
+            CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask ResizeAsync(
+            int width,
+            int height,
+            CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCallCount++;
+            _stopping = true;
+            return new ValueTask(Task.FromException(DisposalException));
         }
     }
 }


### PR DESCRIPTION
## Summary
- retain the first typed KGP command across chunks, including identity, display metadata, and effective quiet behavior
- enforce continuation controls and Base64 chunk boundaries with bounded, disposable partial-upload state
- reject orphan `m`/`m,q` continuations while idle without consuming image IDs or creating upload state
- validate and commit only after final `m=0`, with exact size/error handling and no pre-final image, placement, ID allocation, or success response
- defer chunked `a=T` placement and cursor movement until the final chunk, using the cursor position at final arrival
- abort partial uploads on recognized deletes, malformed continuations, interleaved graphics commands, and terminal disposal while preserving explicit-ID retransmission teardown
- clear pending uploads before fallible adapter cleanup while preserving disposal exceptions and idempotent retries

## Validation
- focused KGP suite: 562 passed
- `Hex1b.Tests`: 8,063 passed, 24 skipped (8,087 total)
- `Hex1b.Analyzers.Tests`: 67 passed
- `Hex1b.McpServer.Tests`: 6 passed
- `Hex1b.Tool.Tests`: 58 passed
- `AgenticPromptDemo.Tests`: 18 passed
- `Hex1b.Tool` build: succeeded with 0 warnings and 0 errors

Closes #392