### PR TITLE
Correct KGP graphics scrolling, margins, and history

### DIFF
--- a/src/Hex1b/Automation/Hex1bTerminalSnapshot.cs
+++ b/src/Hex1b/Automation/Hex1bTerminalSnapshot.cs
@@ -228,12 +228,13 @@ public sealed class Hex1bTerminalSnapshot : IHex1bTerminalRegion, IDisposable
     public int CellPixelHeight { get; }
 
     /// <summary>
-    /// KGP image placements active at snapshot time.
+    /// KGP image placement fragments visible in this snapshot, including any
+    /// requested scrollback rows.
     /// </summary>
     public IReadOnlyList<KgpPlacement> KgpPlacements { get; }
 
     /// <summary>
-    /// KGP image data referenced by placements, keyed by image ID.
+    /// KGP image data referenced by the visible snapshot placements, keyed by image ID.
     /// </summary>
     public IReadOnlyDictionary<uint, KgpImageData> KgpImages { get; }
 

--- a/src/Hex1b/ConsolePresentationAdapter.cs
+++ b/src/Hex1b/ConsolePresentationAdapter.cs
@@ -12,7 +12,10 @@ namespace Hex1b;
 /// This adapter uses raw terminal mode (termios on Unix, SetConsoleMode on Windows)
 /// to properly capture mouse events, escape sequences, and control characters.
 /// </remarks>
-public sealed class ConsolePresentationAdapter : IHex1bTerminalPresentationAdapter, ITerminalReflowProvider
+public sealed class ConsolePresentationAdapter :
+    IHex1bTerminalPresentationAdapter,
+    ITerminalReflowProvider,
+    IInternalTerminalReflowProvider
 {
     private const uint KgpProbeImageId = 2147483647u;
     private static readonly byte[] KgpProbeQuery = Encoding.ASCII.GetBytes(
@@ -108,6 +111,16 @@ public sealed class ConsolePresentationAdapter : IHex1bTerminalPresentationAdapt
 
     /// <inheritdoc/>
     public ReflowResult Reflow(ReflowContext context) => _reflowStrategy.Reflow(context);
+
+    bool IInternalTerminalReflowProvider.TryReflowWithAnchors(
+        ReflowContext context,
+        IReadOnlyList<TerminalReflowAnchor> anchors,
+        out InternalReflowResult result)
+        => InternalTerminalReflow.TryReflow(
+            _reflowStrategy,
+            context,
+            anchors,
+            out result);
 
     /// <summary>
     /// Detects the current terminal emulator and returns the appropriate reflow strategy.

--- a/src/Hex1b/HeadlessPresentationAdapter.cs
+++ b/src/Hex1b/HeadlessPresentationAdapter.cs
@@ -39,7 +39,12 @@ namespace Hex1b;
 ///     .RunAsync();
 /// </code>
 /// </example>
-public sealed class HeadlessPresentationAdapter : IHex1bTerminalPresentationAdapter, ITerminalReflowProvider, IAsyncDisposable, IDisposable
+public sealed class HeadlessPresentationAdapter :
+    IHex1bTerminalPresentationAdapter,
+    ITerminalReflowProvider,
+    IInternalTerminalReflowProvider,
+    IAsyncDisposable,
+    IDisposable
 {
     private readonly int _width;
     private readonly int _height;
@@ -141,6 +146,16 @@ public sealed class HeadlessPresentationAdapter : IHex1bTerminalPresentationAdap
 
     /// <inheritdoc/>
     public ReflowResult Reflow(ReflowContext context) => _reflowStrategy.Reflow(context);
+
+    bool IInternalTerminalReflowProvider.TryReflowWithAnchors(
+        ReflowContext context,
+        IReadOnlyList<TerminalReflowAnchor> anchors,
+        out InternalReflowResult result)
+        => InternalTerminalReflow.TryReflow(
+            _reflowStrategy,
+            context,
+            anchors,
+            out result);
 
     /// <summary>
     /// Triggers a resize event for testing purposes.

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -339,7 +339,9 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         // Initialize scrollback buffer if configured
         if (options.ScrollbackCapacity is int scrollbackCapacity)
         {
-            _scrollbackBuffer = new ScrollbackBuffer(scrollbackCapacity);
+            _scrollbackBuffer = new ScrollbackBuffer(
+                scrollbackCapacity,
+                OnScrollbackRowPruned);
             _scrollbackCallback = options.ScrollbackCallback;
         }
         
@@ -1921,9 +1923,15 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 }
             }
 
-            var scrollbackRows = scrollbackLines > 0
-                ? _scrollbackBuffer?.GetLines(scrollbackLines) ?? []
+            var allScrollbackEntries = !_inAlternateScreen && _scrollbackBuffer is { } scrollback
+                ? scrollback.GetEntries(scrollback.Count)
                 : [];
+            var selectedScrollbackEntries = !_inAlternateScreen && scrollbackLines > 0
+                ? _scrollbackBuffer?.GetEntries(scrollbackLines) ?? []
+                : [];
+            var scrollbackRows = new ScrollbackRow[selectedScrollbackEntries.Length];
+            for (var i = 0; i < selectedScrollbackEntries.Length; i++)
+                scrollbackRows[i] = selectedScrollbackEntries[i].Row;
             var retainedScrollbackWidth = _width;
             if (scrollbackWidth == ScrollbackWidth.Original)
             {
@@ -1941,7 +1949,13 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 }
             }
 
-            var kgp = _kgpGraphicsState.CaptureActiveSnapshot();
+            var kgp = _kgpGraphicsState.CaptureActiveSnapshot(
+                allScrollbackEntries,
+                selectedScrollbackEntries.Length,
+                retainedScrollbackWidth,
+                _height,
+                Capabilities.CellPixelWidth,
+                Capabilities.CellPixelHeight);
             return new Hex1bTerminalSnapshotState(
                 _width,
                 _height,
@@ -2284,11 +2298,14 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         }
 
         // Get scrollback rows
-        var scrollbackData = _scrollbackBuffer?.GetLines(_scrollbackBuffer.Count) ?? [];
-        var scrollbackRows = new ReflowScrollbackRow[scrollbackData.Length];
-        for (int i = 0; i < scrollbackData.Length; i++)
+        var scrollbackEntries = !_inAlternateScreen && _scrollbackBuffer is { } scrollback
+            ? scrollback.GetEntries(scrollback.Count)
+            : [];
+        var scrollbackRows = new ReflowScrollbackRow[scrollbackEntries.Length];
+        for (int i = 0; i < scrollbackEntries.Length; i++)
         {
-            scrollbackRows[i] = new ReflowScrollbackRow(scrollbackData[i].Cells, scrollbackData[i].OriginalWidth);
+            var row = scrollbackEntries[i].Row;
+            scrollbackRows[i] = new ReflowScrollbackRow(row.Cells, row.OriginalWidth);
         }
 
         var context = new ReflowContext(
@@ -2298,8 +2315,20 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             _cursorSaved ? _savedCursorX : null,
             _cursorSaved ? _savedCursorY : null);
 
-        // Call the adapter's reflow implementation
-        var result = reflowProvider.Reflow(context);
+        var kgpReflow = _kgpGraphicsState.PrepareActiveReflow(scrollbackEntries);
+        var internalResult = default(InternalReflowResult);
+        var hasKgpLineage = false;
+        if (reflowProvider is IInternalTerminalReflowProvider internalReflow)
+        {
+            hasKgpLineage = internalReflow.TryReflowWithAnchors(
+                context,
+                kgpReflow.Anchors,
+                out internalResult);
+        }
+
+        var result = hasKgpLineage
+            ? internalResult.Reflow
+            : reflowProvider.Reflow(context);
 
         // Release tracked objects from old screen buffer (all cells)
         for (int y = 0; y < _height; y++)
@@ -2334,14 +2363,36 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             }
         }
 
-        // Apply reflowed scrollback if scrollback is enabled
-        if (_scrollbackBuffer is not null)
+        ScrollbackReplacementResult replacement;
+        if (_inAlternateScreen)
+        {
+            replacement = new ScrollbackReplacementResult(
+                Entries: [],
+                DiscardedRowCount: result.ScrollbackRows.Length);
+        }
+        else if (_scrollbackBuffer is not null && hasKgpLineage)
+        {
+            replacement = _scrollbackBuffer.ReplaceRows(
+                result.ScrollbackRows,
+                _timeProvider.GetUtcNow());
+        }
+        else if (_scrollbackBuffer is not null)
         {
             _scrollbackBuffer.Clear();
             foreach (var sbRow in result.ScrollbackRows)
             {
                 _scrollbackBuffer.Push(sbRow.Cells, sbRow.OriginalWidth, _timeProvider.GetUtcNow());
             }
+
+            replacement = new ScrollbackReplacementResult(
+                _scrollbackBuffer.GetEntries(_scrollbackBuffer.Count),
+                Math.Max(0, result.ScrollbackRows.Length - _scrollbackBuffer.Capacity));
+        }
+        else
+        {
+            replacement = new ScrollbackReplacementResult(
+                Entries: [],
+                DiscardedRowCount: result.ScrollbackRows.Length);
         }
 
         _screenBuffer = newBuffer;
@@ -2355,6 +2406,30 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         {
             _savedCursorX = Math.Clamp(result.NewSavedCursorX.Value, 0, newWidth - 1);
             _savedCursorY = Math.Clamp(result.NewSavedCursorY.Value, 0, newHeight - 1);
+        }
+
+        if (hasKgpLineage)
+        {
+            _kgpGraphicsState.ApplyActiveReflow(
+                kgpReflow,
+                internalResult.Anchors,
+                result.ScrollbackRows.Length,
+                replacement,
+                newWidth,
+                newHeight,
+                Capabilities.CellPixelWidth,
+                Capabilities.CellPixelHeight);
+        }
+        else
+        {
+            // Public third-party reflow providers do not expose row lineage.
+            // Keep active placements at physical coordinates and clip them;
+            // clearing the old main scrollback released unprovable history.
+            _kgpGraphicsState.ClipActivePlacementsToViewport(
+                newWidth,
+                newHeight,
+                Capabilities.CellPixelWidth,
+                Capabilities.CellPixelHeight);
         }
     }
 
@@ -2402,6 +2477,11 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         _height = newHeight;
         _cursorX = Math.Min(_cursorX, newWidth - 1);
         _cursorY = Math.Min(_cursorY, newHeight - 1);
+        _kgpGraphicsState.ClipActivePlacementsToViewport(
+            newWidth,
+            newHeight,
+            Capabilities.CellPixelWidth,
+            Capabilities.CellPixelHeight);
     }
 
     // === Screen Buffer Parsing ===
@@ -4148,11 +4228,23 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             case ClearMode.All:
             case ClearMode.AllAndScrollback:
                 ClearBuffer(respectProtection, impacts);
-                _kgpGraphicsState.ClearActiveScreen(mode == ClearMode.AllAndScrollback);
-                if (mode == ClearMode.AllAndScrollback)
+                if (mode == ClearMode.All)
                 {
-                    if (!_inAlternateScreen)
-                        _scrollbackBuffer?.Clear();
+                    var historyRows = _inAlternateScreen || _scrollbackBuffer is null
+                        ? []
+                        : _scrollbackBuffer.GetEntries(_scrollbackBuffer.Count);
+                    _kgpGraphicsState.ClearActiveViewport(
+                        historyRows,
+                        Capabilities.CellPixelHeight);
+                }
+                else if (_inAlternateScreen)
+                {
+                    _kgpGraphicsState.ClearActiveScreen(clearHistory: true);
+                }
+                else
+                {
+                    _kgpGraphicsState.ClearActiveScreen(clearHistory: false);
+                    _scrollbackBuffer?.Clear();
                 }
                 break;
         }
@@ -4924,6 +5016,18 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         // When DECLRMM is enabled, only scroll within left/right margins
         int leftCol = _declrmm ? _marginLeft : 0;
         int rightCol = _declrmm ? _marginRight : _width - 1;
+        var scrollingRectangle = new KgpScrollRectangle(
+            _scrollTop,
+            _scrollBottom,
+            leftCol,
+            rightCol);
+        var createsKgpHistory = !_inAlternateScreen &&
+            _scrollbackBuffer is not null &&
+            _scrollTop == 0 &&
+            _scrollBottom == _height - 1 &&
+            leftCol == 0 &&
+            rightCol == _width - 1;
+        long? capturedHistoryRowId = null;
         
         // Capture the top row into the scrollback buffer before it's overwritten.
         // Only capture when: scrollback is enabled, not in alternate screen, scroll region
@@ -4933,7 +5037,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             && _scrollTop == 0
             && leftCol == 0 && rightCol == _width - 1)
         {
-            CaptureRowToScrollback(_scrollTop);
+            capturedHistoryRowId = CaptureRowToScrollback(_scrollTop);
             if (_disposed)
                 return false;
         }
@@ -4962,22 +5066,20 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             SetCell(_scrollBottom, x, eraseCell, impacts);
         }
 
-        // Scroll KGP placements up within the scroll region
-        var kgpPlacements = _kgpGraphicsState.ActivePlacements;
-        if (kgpPlacements.Count > 0)
+        if (createsKgpHistory)
         {
-            for (int i = kgpPlacements.Count - 1; i >= 0; i--)
-            {
-                var p = kgpPlacements[i];
-                if (p.Row >= _scrollTop && p.Row <= _scrollBottom)
-                {
-                    p.Row--;
-                    if (p.Row < _scrollTop)
-                    {
-                        kgpPlacements.RemoveAt(i);
-                    }
-                }
-            }
+            _kgpGraphicsState.MoveMainPlacementsIntoHistory(
+                capturedHistoryRowId
+                    ?? throw new InvalidOperationException(
+                        "A history-producing KGP scroll must capture a scrollback row."));
+        }
+        else
+        {
+            _kgpGraphicsState.AdjustActivePlacementsForScroll(
+                rowDelta: -1,
+                scrollingRectangle,
+                Capabilities.CellPixelWidth,
+                Capabilities.CellPixelHeight);
         }
 
         return true;
@@ -4992,6 +5094,11 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         // When DECLRMM is enabled, only scroll within left/right margins
         int leftCol = _declrmm ? _marginLeft : 0;
         int rightCol = _declrmm ? _marginRight : _width - 1;
+        var scrollingRectangle = new KgpScrollRectangle(
+            _scrollTop,
+            _scrollBottom,
+            leftCol,
+            rightCol);
         
         // First, release Sixel data from the bottom row of the region (being scrolled off)
         for (int x = leftCol; x <= rightCol; x++)
@@ -5017,28 +5124,18 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             SetCell(_scrollTop, x, eraseCell, impacts);
         }
 
-        // Scroll KGP placements down within the scroll region
-        var kgpPlacements = _kgpGraphicsState.ActivePlacements;
-        if (kgpPlacements.Count > 0)
-        {
-            for (int i = kgpPlacements.Count - 1; i >= 0; i--)
-            {
-                var p = kgpPlacements[i];
-                if (p.Row >= _scrollTop && p.Row <= _scrollBottom)
-                {
-                    p.Row++;
-                    if (p.Row > _scrollBottom)
-                    {
-                        kgpPlacements.RemoveAt(i);
-                    }
-                }
-            }
-        }
+        // Reverse scrolling does not pull rows from history. Placements whose
+        // anchors are already in scrollback stay pinned to those unchanged rows.
+        _kgpGraphicsState.AdjustActivePlacementsForScroll(
+            rowDelta: 1,
+            scrollingRectangle,
+            Capabilities.CellPixelWidth,
+            Capabilities.CellPixelHeight);
 
         return true;
     }
     
-    private void CaptureRowToScrollback(int row)
+    private long CaptureRowToScrollback(int row)
     {
         var cells = new TerminalCell[_width];
         for (int x = 0; x < _width; x++)
@@ -5047,15 +5144,23 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         }
 
         var timestamp = _timeProvider.GetUtcNow();
-        _scrollbackBuffer!.Push(cells, _width, timestamp);
+        var push = _scrollbackBuffer!.PushWithIdentity(cells, _width, timestamp);
         _scrollbackCallback?.Invoke(new ScrollbackRowEventArgs(this, cells, _width, timestamp));
+        return push.RowId;
     }
+
+    private void OnScrollbackRowPruned(ScrollbackPrunedRow pruned)
+        => _kgpGraphicsState.PruneMainHistoryRow(
+            pruned,
+            Capabilities.CellPixelHeight);
     
     private void InsertLines(int count, List<CellImpact>? impacts = null)
     {
         // Insert blank lines at cursor position within scroll region
         // Lines pushed off the bottom of the scroll region are lost
         // When DECLRMM is enabled, only affect columns within left/right margins
+        // Ordinary KGP placements intentionally stay fixed for IL/DL. KGP does
+        // not define these commands, and both pinned Kitty and Ghostty do this.
         
         // IL resets pending wrap and moves cursor to left margin
         _pendingWrap = false;
@@ -5102,6 +5207,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         // Delete lines at cursor position within scroll region
         // Blank lines are inserted at the bottom of the scroll region
         // When DECLRMM is enabled, only affect columns within left/right margins
+        // See InsertLines for the Kitty/Ghostty ordinary-placement policy.
         
         // DL resets pending wrap and moves cursor to left margin
         _pendingWrap = false;
@@ -6589,7 +6695,45 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     /// </summary>
     internal IReadOnlyList<KgpPlacement> KgpPlacements
     {
-        get { lock (_bufferLock) return _kgpGraphicsState.ActivePlacements.ToList(); }
+        get
+        {
+            lock (_bufferLock)
+            {
+                _kgpGraphicsState.ReconcileActiveImageReferences();
+                if (_inAlternateScreen ||
+                    _scrollbackBuffer is null ||
+                    _kgpGraphicsState.MainHistoryPlacementCount == 0)
+                {
+                    return _kgpGraphicsState.ActivePlacements.ToList();
+                }
+
+                var historyRows = _inAlternateScreen || _scrollbackBuffer is null
+                    ? []
+                    : _scrollbackBuffer.GetEntries(_scrollbackBuffer.Count);
+                return _kgpGraphicsState.CaptureActiveSnapshot(
+                    historyRows,
+                    selectedHistoryCount: 0,
+                    _width,
+                    _height,
+                    Capabilities.CellPixelWidth,
+                    Capabilities.CellPixelHeight).Placements;
+            }
+        }
+    }
+
+    internal int KgpHistoryPlacementCount
+    {
+        get
+        {
+            lock (_bufferLock)
+                return _kgpGraphicsState.MainHistoryPlacementCount;
+        }
+    }
+
+    internal int GetKgpHistoryReferenceCount(uint imageId)
+    {
+        lock (_bufferLock)
+            return _kgpGraphicsState.ActiveHistoryReferenceCount(imageId);
     }
 
     private const int KgpMaximumEncodedChunkLength = 4096;
@@ -6940,6 +7084,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
 
         if (stored.Replaced)
             _kgpGraphicsState.RemoveActiveImageReferences(stored.Image.ImageId);
+        _kgpGraphicsState.ReconcileActiveImageReferences();
 
         if (command is KgpParsedCommand.TransmitAndDisplay transmitAndDisplay)
             DisplayTransmittedKgpImage(stored.Image, transmitAndDisplay);
@@ -7176,6 +7321,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             }
         }
 
+        _kgpGraphicsState.ReconcileActiveImageReferences();
     }
 
     private void CreateKgpPlacement(
@@ -7203,7 +7349,19 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             command.CellOffsetX,
             command.CellOffsetY);
 
-        ActiveKgpPlacements.Add(placement);
+        var image = ActiveKgpImageStore.GetImageById(imageId)
+            ?? throw new InvalidOperationException(
+                $"Cannot create a KGP placement for missing image {imageId}.");
+        var clipped = placement.ClipToCellRectangle(
+            image,
+            0,
+            _height,
+            0,
+            _width,
+            Capabilities.CellPixelWidth,
+            Capabilities.CellPixelHeight);
+        if (clipped is not null)
+            ActiveKgpPlacements.Add(clipped);
     }
 
     private void SendKgpResponse(uint imageId, uint imageNumber, string message, int quiet)

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -4556,6 +4556,15 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             return;
 
         _kgpGraphicsState.ExitAlternateScreen();
+        var historyRows = _scrollbackBuffer is { } scrollback
+            ? scrollback.GetEntries(scrollback.Count)
+            : [];
+        _kgpGraphicsState.ClipActiveScreenToViewport(
+            historyRows,
+            _width,
+            _height,
+            Capabilities.CellPixelWidth,
+            Capabilities.CellPixelHeight);
         _inAlternateScreen = false;
     }
 
@@ -7331,12 +7340,6 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         uint rows,
         KgpParsedCommand.DisplayData command)
     {
-        // If same image+placement combo exists, replace it
-        if (placementId > 0)
-        {
-            ActiveKgpPlacements.RemoveAll(p => p.ImageId == imageId && p.PlacementId == placementId);
-        }
-
         var placement = new KgpPlacement(
             imageId, placementId,
             _cursorY, _cursorX,
@@ -7360,8 +7363,10 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             _width,
             Capabilities.CellPixelWidth,
             Capabilities.CellPixelHeight);
-        if (clipped is not null)
-            ActiveKgpPlacements.Add(clipped);
+        _kgpGraphicsState.ReplaceActivePlacement(
+            imageId,
+            placementId,
+            clipped);
     }
 
     private void SendKgpResponse(uint imageId, uint imageNumber, string message, int quiet)

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -2431,6 +2431,16 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 Capabilities.CellPixelWidth,
                 Capabilities.CellPixelHeight);
         }
+
+        if (!_inAlternateScreen)
+        {
+            _kgpGraphicsState.ClipActiveScreenToViewport(
+                replacement.Entries,
+                newWidth,
+                newHeight,
+                Capabilities.CellPixelWidth,
+                Capabilities.CellPixelHeight);
+        }
     }
 
     private void ResizeWithCrop(int newWidth, int newHeight)
@@ -2477,11 +2487,26 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         _height = newHeight;
         _cursorX = Math.Min(_cursorX, newWidth - 1);
         _cursorY = Math.Min(_cursorY, newHeight - 1);
-        _kgpGraphicsState.ClipActivePlacementsToViewport(
-            newWidth,
-            newHeight,
-            Capabilities.CellPixelWidth,
-            Capabilities.CellPixelHeight);
+        if (_inAlternateScreen)
+        {
+            _kgpGraphicsState.ClipActivePlacementsToViewport(
+                newWidth,
+                newHeight,
+                Capabilities.CellPixelWidth,
+                Capabilities.CellPixelHeight);
+        }
+        else
+        {
+            var historyRows = _scrollbackBuffer is { } scrollback
+                ? scrollback.GetEntries(scrollback.Count)
+                : [];
+            _kgpGraphicsState.ClipActiveScreenToViewport(
+                historyRows,
+                newWidth,
+                newHeight,
+                Capabilities.CellPixelWidth,
+                Capabilities.CellPixelHeight);
+        }
     }
 
     // === Screen Buffer Parsing ===

--- a/src/Hex1b/Kgp/KgpPlacement.cs
+++ b/src/Hex1b/Kgp/KgpPlacement.cs
@@ -125,6 +125,241 @@ public sealed class KgpPlacement
             CellOffsetX,
             CellOffsetY);
 
+    internal KgpPlacement WithPosition(int row, int column)
+        => new(
+            ImageId,
+            PlacementId,
+            row,
+            column,
+            DisplayColumns,
+            DisplayRows,
+            SourceX,
+            SourceY,
+            SourceWidth,
+            SourceHeight,
+            ZIndex,
+            CellOffsetX,
+            CellOffsetY);
+
+    internal KgpPlacement? ClipToCellRectangle(
+        KgpImageData image,
+        int top,
+        int bottomExclusive,
+        int left,
+        int rightExclusive,
+        int cellPixelWidth,
+        int cellPixelHeight)
+    {
+        if (top >= bottomExclusive || left >= rightExclusive)
+            return null;
+
+        var placementTop = (long)Row;
+        var placementBottom = placementTop + DisplayRows;
+        var placementLeft = (long)Column;
+        var placementRight = placementLeft + DisplayColumns;
+        var clippedTop = Math.Max(placementTop, top);
+        var clippedBottom = Math.Min(placementBottom, bottomExclusive);
+        var clippedLeft = Math.Max(placementLeft, left);
+        var clippedRight = Math.Min(placementRight, rightExclusive);
+        if (clippedTop >= clippedBottom || clippedLeft >= clippedRight)
+            return null;
+
+        if (!TryNormalizeSourceAxis(image.Width, SourceX, SourceWidth, out var sourceX, out var sourceWidth) ||
+            !TryNormalizeSourceAxis(image.Height, SourceY, SourceHeight, out var sourceY, out var sourceHeight))
+        {
+            return null;
+        }
+
+        var firstColumn = checked((uint)(clippedLeft - placementLeft));
+        var retainedColumns = checked((uint)(clippedRight - clippedLeft));
+        var firstRow = checked((uint)(clippedTop - placementTop));
+        var retainedRows = checked((uint)(clippedBottom - clippedTop));
+        if (!TryProjectSourceAxis(
+                sourceWidth,
+                firstColumn,
+                retainedColumns,
+                DisplayColumns,
+                cellPixelWidth,
+                CellOffsetX,
+                out var projectedX,
+                out var projectedWidth) ||
+            !TryProjectSourceAxis(
+                sourceHeight,
+                firstRow,
+                retainedRows,
+                DisplayRows,
+                cellPixelHeight,
+                CellOffsetY,
+                out var projectedY,
+                out var projectedHeight))
+        {
+            return null;
+        }
+
+        return new KgpPlacement(
+            ImageId,
+            PlacementId,
+            checked((int)clippedTop),
+            checked((int)clippedLeft),
+            retainedColumns,
+            retainedRows,
+            checked(sourceX + projectedX),
+            checked(sourceY + projectedY),
+            projectedWidth,
+            projectedHeight,
+            ZIndex,
+            firstColumn == 0 ? CellOffsetX : 0,
+            firstRow == 0 ? CellOffsetY : 0);
+    }
+
+    internal KgpPlacement? ClipRows(
+        KgpImageData image,
+        uint firstRow,
+        uint retainedRows,
+        int resultRow,
+        int cellPixelHeight)
+    {
+        if (retainedRows == 0 ||
+            firstRow >= DisplayRows ||
+            retainedRows > DisplayRows - firstRow)
+        {
+            return null;
+        }
+
+        if (!TryNormalizeSourceAxis(image.Width, SourceX, SourceWidth, out var sourceX, out var sourceWidth) ||
+            !TryNormalizeSourceAxis(image.Height, SourceY, SourceHeight, out var sourceY, out var sourceHeight) ||
+            !TryProjectSourceAxis(
+                sourceHeight,
+                firstRow,
+                retainedRows,
+                DisplayRows,
+                cellPixelHeight,
+                CellOffsetY,
+                out var projectedY,
+                out var projectedHeight))
+        {
+            return null;
+        }
+
+        return new KgpPlacement(
+            ImageId,
+            PlacementId,
+            resultRow,
+            Column,
+            DisplayColumns,
+            retainedRows,
+            sourceX,
+            checked(sourceY + projectedY),
+            sourceWidth,
+            projectedHeight,
+            ZIndex,
+            CellOffsetX,
+            firstRow == 0 ? CellOffsetY : 0);
+    }
+
     internal KgpPlacement Clone()
         => WithImageId(ImageId);
+
+    private static bool TryNormalizeSourceAxis(
+        uint imageSize,
+        uint sourceOffset,
+        uint requestedSize,
+        out uint normalizedOffset,
+        out uint normalizedSize)
+    {
+        normalizedOffset = sourceOffset;
+        normalizedSize = 0;
+        if (imageSize == 0 || sourceOffset >= imageSize)
+            return false;
+
+        var available = imageSize - sourceOffset;
+        normalizedSize = requestedSize == 0
+            ? available
+            : Math.Min(requestedSize, available);
+        return normalizedSize > 0;
+    }
+
+    private static bool TryProjectSourceAxis(
+        uint sourceSize,
+        uint firstCell,
+        uint retainedCells,
+        uint totalCells,
+        int cellPixelSize,
+        uint cellOffset,
+        out uint sourceOffset,
+        out uint projectedSize)
+    {
+        sourceOffset = 0;
+        projectedSize = 0;
+        if (sourceSize == 0 ||
+            totalCells == 0 ||
+            retainedCells == 0 ||
+            firstCell >= totalCells ||
+            retainedCells > totalCells - firstCell)
+        {
+            return false;
+        }
+
+        ulong destinationSize;
+        ulong destinationStart;
+        ulong destinationEnd;
+        if (cellPixelSize > 0)
+        {
+            var cellSize = (ulong)cellPixelSize;
+            var fullSize = checked((ulong)totalCells * cellSize);
+            if (cellOffset >= fullSize)
+                return false;
+
+            destinationSize = fullSize - cellOffset;
+            destinationStart = ProjectCellBoundary(firstCell, cellSize, cellOffset, destinationSize);
+            destinationEnd = ProjectCellBoundary(
+                checked(firstCell + retainedCells),
+                cellSize,
+                cellOffset,
+                destinationSize);
+        }
+        else
+        {
+            // Unknown cell metrics: each destination cell is one proportional
+            // unit. Pixel offsets cannot be interpreted without a cell size.
+            destinationSize = totalCells;
+            destinationStart = firstCell;
+            destinationEnd = checked(firstCell + retainedCells);
+        }
+
+        if (destinationSize == 0 || destinationStart >= destinationEnd)
+            return false;
+
+        var startProduct = checked((ulong)sourceSize * destinationStart);
+        var endProduct = checked((ulong)sourceSize * destinationEnd);
+        var start = startProduct / destinationSize;
+        var end = DivideCeiling(endProduct, destinationSize);
+        start = Math.Min(start, sourceSize);
+        end = Math.Min(end, sourceSize);
+        if (start >= end)
+            return false;
+
+        sourceOffset = checked((uint)start);
+        projectedSize = checked((uint)(end - start));
+        return true;
+    }
+
+    private static ulong ProjectCellBoundary(
+        uint cell,
+        ulong cellPixelSize,
+        uint cellOffset,
+        ulong destinationSize)
+    {
+        if (cell == 0)
+            return 0;
+
+        var rawBoundary = checked((ulong)cell * cellPixelSize);
+        var adjusted = rawBoundary > cellOffset
+            ? rawBoundary - cellOffset
+            : 0;
+        return Math.Min(adjusted, destinationSize);
+    }
+
+    private static ulong DivideCeiling(ulong numerator, ulong denominator)
+        => numerator / denominator + (numerator % denominator == 0 ? 0UL : 1UL);
 }

--- a/src/Hex1b/Kgp/KgpPlacement.cs
+++ b/src/Hex1b/Kgp/KgpPlacement.cs
@@ -164,34 +164,32 @@ public sealed class KgpPlacement
         if (clippedTop >= clippedBottom || clippedLeft >= clippedRight)
             return null;
 
-        if (!TryNormalizeSourceAxis(image.Width, SourceX, SourceWidth, out var sourceX, out var sourceWidth) ||
-            !TryNormalizeSourceAxis(image.Height, SourceY, SourceHeight, out var sourceY, out var sourceHeight))
-        {
-            return null;
-        }
-
         var firstColumn = checked((uint)(clippedLeft - placementLeft));
         var retainedColumns = checked((uint)(clippedRight - clippedLeft));
         var firstRow = checked((uint)(clippedTop - placementTop));
         var retainedRows = checked((uint)(clippedBottom - clippedTop));
-        if (!TryProjectSourceAxis(
-                sourceWidth,
+        if (!TryClipSourceAxis(
+                image.Width,
+                SourceX,
+                SourceWidth,
                 firstColumn,
                 retainedColumns,
                 DisplayColumns,
                 cellPixelWidth,
                 CellOffsetX,
-                out var projectedX,
-                out var projectedWidth) ||
-            !TryProjectSourceAxis(
-                sourceHeight,
+                out var clippedSourceX,
+                out var clippedSourceWidth) ||
+            !TryClipSourceAxis(
+                image.Height,
+                SourceY,
+                SourceHeight,
                 firstRow,
                 retainedRows,
                 DisplayRows,
                 cellPixelHeight,
                 CellOffsetY,
-                out var projectedY,
-                out var projectedHeight))
+                out var clippedSourceY,
+                out var clippedSourceHeight))
         {
             return null;
         }
@@ -203,10 +201,10 @@ public sealed class KgpPlacement
             checked((int)clippedLeft),
             retainedColumns,
             retainedRows,
-            checked(sourceX + projectedX),
-            checked(sourceY + projectedY),
-            projectedWidth,
-            projectedHeight,
+            clippedSourceX,
+            clippedSourceY,
+            clippedSourceWidth,
+            clippedSourceHeight,
             ZIndex,
             firstColumn == 0 ? CellOffsetX : 0,
             firstRow == 0 ? CellOffsetY : 0);
@@ -226,17 +224,23 @@ public sealed class KgpPlacement
             return null;
         }
 
-        if (!TryNormalizeSourceAxis(image.Width, SourceX, SourceWidth, out var sourceX, out var sourceWidth) ||
-            !TryNormalizeSourceAxis(image.Height, SourceY, SourceHeight, out var sourceY, out var sourceHeight) ||
-            !TryProjectSourceAxis(
-                sourceHeight,
+        if (!TryNormalizeOrPreserveUnknownSourceAxis(
+                image.Width,
+                SourceX,
+                SourceWidth,
+                out var sourceX,
+                out var sourceWidth) ||
+            !TryClipSourceAxis(
+                image.Height,
+                SourceY,
+                SourceHeight,
                 firstRow,
                 retainedRows,
                 DisplayRows,
                 cellPixelHeight,
                 CellOffsetY,
-                out var projectedY,
-                out var projectedHeight))
+                out var clippedSourceY,
+                out var clippedSourceHeight))
         {
             return null;
         }
@@ -249,9 +253,9 @@ public sealed class KgpPlacement
             DisplayColumns,
             retainedRows,
             sourceX,
-            checked(sourceY + projectedY),
+            clippedSourceY,
             sourceWidth,
-            projectedHeight,
+            clippedSourceHeight,
             ZIndex,
             CellOffsetX,
             firstRow == 0 ? CellOffsetY : 0);
@@ -277,6 +281,76 @@ public sealed class KgpPlacement
             ? available
             : Math.Min(requestedSize, available);
         return normalizedSize > 0;
+    }
+
+    private static bool TryNormalizeOrPreserveUnknownSourceAxis(
+        uint imageSize,
+        uint sourceOffset,
+        uint requestedSize,
+        out uint normalizedOffset,
+        out uint normalizedSize)
+    {
+        if (imageSize == 0)
+        {
+            normalizedOffset = sourceOffset;
+            normalizedSize = requestedSize;
+            return true;
+        }
+
+        return TryNormalizeSourceAxis(
+            imageSize,
+            sourceOffset,
+            requestedSize,
+            out normalizedOffset,
+            out normalizedSize);
+    }
+
+    private static bool TryClipSourceAxis(
+        uint imageSize,
+        uint sourceOffset,
+        uint requestedSize,
+        uint firstCell,
+        uint retainedCells,
+        uint totalCells,
+        int cellPixelSize,
+        uint cellOffset,
+        out uint clippedOffset,
+        out uint clippedSize)
+    {
+        if (imageSize == 0)
+        {
+            // PNG dimensions are populated by a future decoding path. Until
+            // then source zeroes retain their "unknown/full source" meaning,
+            // and clipping affects destination geometry only.
+            clippedOffset = sourceOffset;
+            clippedSize = requestedSize;
+            return true;
+        }
+
+        if (!TryNormalizeSourceAxis(
+                imageSize,
+                sourceOffset,
+                requestedSize,
+                out var normalizedOffset,
+                out var normalizedSize) ||
+            !TryProjectSourceAxis(
+                normalizedSize,
+                firstCell,
+                retainedCells,
+                totalCells,
+                cellPixelSize,
+                cellOffset,
+                out var projectedOffset,
+                out var projectedSize))
+        {
+            clippedOffset = 0;
+            clippedSize = 0;
+            return false;
+        }
+
+        clippedOffset = checked(normalizedOffset + projectedOffset);
+        clippedSize = projectedSize;
+        return true;
     }
 
     private static bool TryProjectSourceAxis(

--- a/src/Hex1b/Kgp/KgpTerminalGraphicsState.cs
+++ b/src/Hex1b/Kgp/KgpTerminalGraphicsState.cs
@@ -154,6 +154,49 @@ internal sealed class KgpTerminalGraphicsState
         active.HistoryReferences.Remove(imageId);
     }
 
+    internal void ReplaceActivePlacement(
+        uint imageId,
+        uint placementId,
+        KgpPlacement? replacement)
+    {
+        var active = Active;
+        if (placementId == 0)
+        {
+            if (replacement is not null)
+                active.Placements.Add(replacement);
+            return;
+        }
+
+        active.Placements.RemoveAll(
+            placement => placement.ImageId == imageId &&
+                placement.PlacementId == placementId);
+
+        // Add first so releasing the last history owner cannot remove image
+        // data needed by the replacement placement.
+        if (replacement is not null)
+            active.Placements.Add(replacement);
+
+        foreach (var rowId in active.HistoryPlacements.Keys.ToArray())
+        {
+            var placements = active.HistoryPlacements[rowId];
+            for (var i = placements.Count - 1; i >= 0; i--)
+            {
+                var placement = placements[i].Placement;
+                if (placement.ImageId != imageId ||
+                    placement.PlacementId != placementId)
+                {
+                    continue;
+                }
+
+                placements.RemoveAt(i);
+                ReleaseHistoryImage(active, imageId);
+            }
+
+            if (placements.Count == 0)
+                active.HistoryPlacements.Remove(rowId);
+        }
+    }
+
     internal void RelocateActiveImage(KgpImageStore.ImageRelocation relocation)
     {
         var placements = Active.Placements;
@@ -335,8 +378,34 @@ internal sealed class KgpTerminalGraphicsState
         ReconcileImageReferences(active);
         active.Placements.Clear();
         if (!_alternateActive)
-            ClipMainHistoryToHistoryRows(historyRows, cellPixelHeight);
+            ClipMainHistoryToRetainedRows(
+                historyRows,
+                additionalRows: 0,
+                cellPixelHeight);
         active.ImageStore.RemoveUnreferencedImages(active.HistoryReferences.Keys);
+    }
+
+    internal void ClipActiveScreenToViewport(
+        IReadOnlyList<ScrollbackEntry> historyRows,
+        int width,
+        int height,
+        int cellPixelWidth,
+        int cellPixelHeight)
+    {
+        // This first step reconciles both active and history references before
+        // the history geometry below reads image data.
+        ClipActivePlacementsToViewport(
+            width,
+            height,
+            cellPixelWidth,
+            cellPixelHeight);
+        if (!_alternateActive)
+        {
+            ClipMainHistoryToRetainedRows(
+                historyRows,
+                height,
+                cellPixelHeight);
+        }
     }
 
     internal KgpReflowPlan PrepareActiveReflow(
@@ -681,8 +750,9 @@ internal sealed class KgpTerminalGraphicsState
         }
     }
 
-    private void ClipMainHistoryToHistoryRows(
+    private void ClipMainHistoryToRetainedRows(
         IReadOnlyList<ScrollbackEntry> historyRows,
+        int additionalRows,
         int cellPixelHeight)
     {
         if (_main.HistoryPlacements.Count == 0)
@@ -703,7 +773,8 @@ internal sealed class KgpTerminalGraphicsState
                 continue;
             }
 
-            var retainedRowCount = checked((uint)(historyRows.Count - rowIndex));
+            var retainedRowCount = checked(
+                (uint)(historyRows.Count - rowIndex + additionalRows));
             var placements = _main.HistoryPlacements[rowId];
             for (var i = placements.Count - 1; i >= 0; i--)
             {

--- a/src/Hex1b/Kgp/KgpTerminalGraphicsState.cs
+++ b/src/Hex1b/Kgp/KgpTerminalGraphicsState.cs
@@ -1,16 +1,51 @@
+using Hex1b.Reflow;
+
 namespace Hex1b;
+
+internal readonly record struct KgpScrollRectangle(
+    int Top,
+    int Bottom,
+    int Left,
+    int Right);
 
 internal sealed class KgpTerminalGraphicsState
 {
+    internal readonly record struct HistoryPlacement(
+        KgpPlacement Placement,
+        uint FirstRow,
+        uint RetainedRows);
+
+    internal readonly record struct ReflowPlacement(
+        int Id,
+        KgpPlacement Placement,
+        HistoryPlacement? History);
+
+    internal sealed class KgpReflowPlan
+    {
+        internal readonly IReadOnlyList<ReflowPlacement> Placements;
+
+        internal KgpReflowPlan(
+            IReadOnlyList<TerminalReflowAnchor> anchors,
+            IReadOnlyList<ReflowPlacement> placements)
+        {
+            Anchors = anchors;
+            Placements = placements;
+        }
+
+        internal IReadOnlyList<TerminalReflowAnchor> Anchors { get; }
+    }
+
     private sealed class ScreenState
     {
         internal KgpImageStore ImageStore { get; } = new();
         internal List<KgpPlacement> Placements { get; } = [];
+        internal Dictionary<long, List<HistoryPlacement>> HistoryPlacements { get; } = [];
         internal Dictionary<uint, int> HistoryReferences { get; } = [];
 
         internal void Clear()
         {
             Placements.Clear();
+            HistoryPlacements.Clear();
             HistoryReferences.Clear();
             ImageStore.Clear();
         }
@@ -28,6 +63,9 @@ internal sealed class KgpTerminalGraphicsState
     internal KgpImageStore ActiveImageStore => Active.ImageStore;
 
     internal List<KgpPlacement> ActivePlacements => Active.Placements;
+
+    internal void ReconcileActiveImageReferences()
+        => ReconcileImageReferences(Active);
 
     internal void EnterAlternateScreen()
     {
@@ -65,7 +103,10 @@ internal sealed class KgpTerminalGraphicsState
         var active = Active;
         active.Placements.Clear();
         if (clearHistory)
+        {
+            active.HistoryPlacements.Clear();
             active.HistoryReferences.Clear();
+        }
 
         active.ImageStore.RemoveUnreferencedImages(active.HistoryReferences.Keys);
     }
@@ -100,8 +141,17 @@ internal sealed class KgpTerminalGraphicsState
 
     internal void RemoveActiveImageReferences(uint imageId)
     {
-        Active.Placements.RemoveAll(placement => placement.ImageId == imageId);
-        Active.HistoryReferences.Remove(imageId);
+        var active = Active;
+        active.Placements.RemoveAll(placement => placement.ImageId == imageId);
+        foreach (var rowId in active.HistoryPlacements.Keys.ToArray())
+        {
+            var placements = active.HistoryPlacements[rowId];
+            placements.RemoveAll(placement => placement.Placement.ImageId == imageId);
+            if (placements.Count == 0)
+                active.HistoryPlacements.Remove(rowId);
+        }
+
+        active.HistoryReferences.Remove(imageId);
     }
 
     internal void RelocateActiveImage(KgpImageStore.ImageRelocation relocation)
@@ -113,6 +163,21 @@ internal sealed class KgpTerminalGraphicsState
                 placements[i] = placements[i].WithImageId(relocation.CurrentId);
         }
 
+        foreach (var historyPlacements in Active.HistoryPlacements.Values)
+        {
+            for (var i = 0; i < historyPlacements.Count; i++)
+            {
+                var historyPlacement = historyPlacements[i];
+                if (historyPlacement.Placement.ImageId == relocation.PreviousId)
+                {
+                    historyPlacements[i] = historyPlacement with
+                    {
+                        Placement = historyPlacement.Placement.WithImageId(relocation.CurrentId)
+                    };
+                }
+            }
+        }
+
         if (Active.HistoryReferences.Remove(relocation.PreviousId, out var count))
         {
             Active.HistoryReferences.TryGetValue(relocation.CurrentId, out var existing);
@@ -120,8 +185,629 @@ internal sealed class KgpTerminalGraphicsState
         }
     }
 
+    internal void MoveMainPlacementsIntoHistory(long rowId)
+    {
+        if (_alternateActive)
+            throw new InvalidOperationException("Alternate-screen placements cannot enter main-screen history.");
+
+        ReconcileImageReferences(_main);
+        for (var i = _main.Placements.Count - 1; i >= 0; i--)
+        {
+            var placement = _main.Placements[i];
+            if (placement.Row == 0)
+            {
+                _main.Placements.RemoveAt(i);
+                AddHistoryPlacement(
+                    _main,
+                    rowId,
+                    new HistoryPlacement(
+                        placement.WithPosition(0, placement.Column),
+                        FirstRow: 0,
+                        placement.DisplayRows),
+                    retainImage: true);
+            }
+            else
+            {
+                _main.Placements[i] = placement.WithPosition(
+                    checked(placement.Row - 1),
+                    placement.Column);
+            }
+        }
+    }
+
+    internal void PruneMainHistoryRow(
+        ScrollbackPrunedRow pruned,
+        int cellPixelHeight)
+    {
+        if (pruned.Reason == ScrollbackPruneReason.Capacity)
+            ReconcileImageReferences(_main);
+        if (!_main.HistoryPlacements.Remove(pruned.RowId, out var placements))
+            return;
+
+        foreach (var historyPlacement in placements)
+        {
+            if (pruned.Reason == ScrollbackPruneReason.Capacity &&
+                pruned.SuccessorRowId is { } successorRowId &&
+                historyPlacement.RetainedRows > 1)
+            {
+                // The anchor row is only the first retained destination row.
+                // Transfer ownership to its successor and crop from the original
+                // geometry so repeated capacity eviction cannot accumulate error.
+                var placement = historyPlacement.Placement;
+                var image = _main.ImageStore.GetImageById(placement.ImageId)
+                    ?? throw new InvalidOperationException(
+                        $"History placement {placement.PlacementId} references missing KGP image {placement.ImageId}.");
+                var transferred = historyPlacement with
+                {
+                    FirstRow = checked(historyPlacement.FirstRow + 1),
+                    RetainedRows = historyPlacement.RetainedRows - 1,
+                };
+                var clipped = transferred.Placement.ClipRows(
+                    image,
+                    transferred.FirstRow,
+                    transferred.RetainedRows,
+                    resultRow: 0,
+                    cellPixelHeight);
+                if (clipped is not null)
+                {
+                    AddHistoryPlacement(
+                        _main,
+                        successorRowId,
+                        transferred,
+                        retainImage: false);
+                    continue;
+                }
+            }
+
+            ReleaseHistoryImage(_main, historyPlacement.Placement.ImageId);
+        }
+    }
+
+    internal void AdjustActivePlacementsForScroll(
+        int rowDelta,
+        KgpScrollRectangle rectangle,
+        int cellPixelWidth,
+        int cellPixelHeight)
+    {
+        var active = Active;
+        ReconcileImageReferences(active);
+        for (var i = active.Placements.Count - 1; i >= 0; i--)
+        {
+            var placement = active.Placements[i];
+            if (!IsWhollyContained(placement, rectangle))
+                continue;
+
+            var image = active.ImageStore.GetImageById(placement.ImageId)
+                ?? throw new InvalidOperationException(
+                    $"Active placement {placement.PlacementId} references missing KGP image {placement.ImageId}.");
+            var moved = placement.WithPosition(
+                checked(placement.Row + rowDelta),
+                placement.Column);
+            var clipped = moved.ClipToCellRectangle(
+                image,
+                rectangle.Top,
+                checked(rectangle.Bottom + 1),
+                rectangle.Left,
+                checked(rectangle.Right + 1),
+                cellPixelWidth,
+                cellPixelHeight);
+            if (clipped is null)
+                active.Placements.RemoveAt(i);
+            else
+                active.Placements[i] = clipped;
+        }
+    }
+
+    internal void ClipActivePlacementsToViewport(
+        int width,
+        int height,
+        int cellPixelWidth,
+        int cellPixelHeight)
+    {
+        var active = Active;
+        ReconcileImageReferences(active);
+        for (var i = active.Placements.Count - 1; i >= 0; i--)
+        {
+            var placement = active.Placements[i];
+            var image = active.ImageStore.GetImageById(placement.ImageId)
+                ?? throw new InvalidOperationException(
+                    $"Active placement {placement.PlacementId} references missing KGP image {placement.ImageId}.");
+            var clipped = placement.ClipToCellRectangle(
+                image,
+                0,
+                height,
+                0,
+                width,
+                cellPixelWidth,
+                cellPixelHeight);
+            if (clipped is null)
+                active.Placements.RemoveAt(i);
+            else
+                active.Placements[i] = clipped;
+        }
+    }
+
+    internal void ClearActiveViewport(
+        IReadOnlyList<ScrollbackEntry> historyRows,
+        int cellPixelHeight)
+    {
+        var active = Active;
+        ReconcileImageReferences(active);
+        active.Placements.Clear();
+        if (!_alternateActive)
+            ClipMainHistoryToHistoryRows(historyRows, cellPixelHeight);
+        active.ImageStore.RemoveUnreferencedImages(active.HistoryReferences.Keys);
+    }
+
+    internal KgpReflowPlan PrepareActiveReflow(
+        IReadOnlyList<ScrollbackEntry> historyRows)
+    {
+        var active = Active;
+        ReconcileImageReferences(active);
+        var historyCount = _alternateActive ? 0 : historyRows.Count;
+        var anchors = new List<TerminalReflowAnchor>(
+            active.Placements.Count + active.HistoryPlacements.Count);
+        var placements = new List<ReflowPlacement>(anchors.Capacity);
+        var nextId = 1;
+
+        foreach (var placement in active.Placements)
+        {
+            var id = nextId++;
+            anchors.Add(new TerminalReflowAnchor(
+                id,
+                checked(historyCount + placement.Row),
+                placement.Column));
+            placements.Add(new ReflowPlacement(id, placement, History: null));
+        }
+
+        if (!_alternateActive && _main.HistoryPlacements.Count > 0)
+        {
+            var rowIndices = new Dictionary<long, int>(historyRows.Count);
+            for (var i = 0; i < historyRows.Count; i++)
+                rowIndices.Add(historyRows[i].RowId, i);
+
+            foreach (var (rowId, rowPlacements) in _main.HistoryPlacements)
+            {
+                if (!rowIndices.TryGetValue(rowId, out var rowIndex))
+                {
+                    throw new InvalidOperationException(
+                        $"KGP history placement anchor {rowId} is not present in scrollback.");
+                }
+
+                foreach (var historyPlacement in rowPlacements)
+                {
+                    var id = nextId++;
+                    anchors.Add(new TerminalReflowAnchor(
+                        id,
+                        rowIndex,
+                        historyPlacement.Placement.Column));
+                    placements.Add(new ReflowPlacement(
+                        id,
+                        historyPlacement.Placement,
+                        historyPlacement));
+                }
+            }
+        }
+
+        return new KgpReflowPlan(anchors, placements);
+    }
+
+    internal void ApplyActiveReflow(
+        KgpReflowPlan plan,
+        IReadOnlyList<TerminalReflowAnchor> mappedAnchors,
+        int resultHistoryCount,
+        ScrollbackReplacementResult replacement,
+        int width,
+        int height,
+        int cellPixelWidth,
+        int cellPixelHeight)
+    {
+        var active = Active;
+        ReconcileImageReferences(active);
+        var mappedById = mappedAnchors.ToDictionary(anchor => anchor.Id);
+        active.Placements.Clear();
+        active.HistoryPlacements.Clear();
+
+        foreach (var tracked in plan.Placements)
+        {
+            var wasHistory = tracked.History.HasValue;
+            var placement = tracked.Placement;
+            if (tracked.History is { } history)
+            {
+                var image = active.ImageStore.GetImageById(placement.ImageId)
+                    ?? throw new InvalidOperationException(
+                        $"History placement {placement.PlacementId} references missing KGP image {placement.ImageId}.");
+                var clippedHistoryPlacement = placement.ClipRows(
+                    image,
+                    history.FirstRow,
+                    history.RetainedRows,
+                    resultRow: 0,
+                    cellPixelHeight);
+                if (clippedHistoryPlacement is null)
+                {
+                    ReleaseHistoryImage(active, tracked.Placement.ImageId);
+                    continue;
+                }
+
+                placement = clippedHistoryPlacement;
+            }
+
+            if (!mappedById.TryGetValue(tracked.Id, out var mapped))
+            {
+                if (wasHistory)
+                    ReleaseHistoryImage(active, placement.ImageId);
+                continue;
+            }
+
+            if (mapped.Row < replacement.DiscardedRowCount)
+            {
+                var discardedRows = replacement.DiscardedRowCount - mapped.Row;
+                if ((uint)discardedRows >= placement.DisplayRows)
+                {
+                    if (wasHistory)
+                        ReleaseHistoryImage(active, placement.ImageId);
+                    continue;
+                }
+
+                var image = active.ImageStore.GetImageById(placement.ImageId)
+                    ?? throw new InvalidOperationException(
+                        $"Placement {placement.PlacementId} references missing KGP image {placement.ImageId}.");
+                var clipped = placement.ClipRows(
+                    image,
+                    checked((uint)discardedRows),
+                    placement.DisplayRows - checked((uint)discardedRows),
+                    resultRow: 0,
+                    cellPixelHeight);
+                if (clipped is null)
+                {
+                    if (wasHistory)
+                        ReleaseHistoryImage(active, placement.ImageId);
+                    continue;
+                }
+
+                placement = clipped;
+                mapped = mapped with { Row = replacement.DiscardedRowCount };
+            }
+
+            if (mapped.Row < resultHistoryCount)
+            {
+                var retainedIndex = mapped.Row - replacement.DiscardedRowCount;
+                if (retainedIndex < 0 || retainedIndex >= replacement.Entries.Length)
+                {
+                    if (wasHistory)
+                        ReleaseHistoryImage(active, placement.ImageId);
+                    continue;
+                }
+
+                var historyPlacement = new HistoryPlacement(
+                    placement.WithPosition(0, mapped.Column),
+                    FirstRow: 0,
+                    placement.DisplayRows);
+                AddHistoryPlacement(
+                    active,
+                    replacement.Entries[retainedIndex].RowId,
+                    historyPlacement,
+                    retainImage: !wasHistory);
+                continue;
+            }
+
+            var screenRow = mapped.Row - resultHistoryCount;
+            var imageData = active.ImageStore.GetImageById(placement.ImageId)
+                ?? throw new InvalidOperationException(
+                    $"Placement {placement.PlacementId} references missing KGP image {placement.ImageId}.");
+            var activePlacement = placement
+                .WithPosition(screenRow, mapped.Column)
+                .ClipToCellRectangle(
+                    imageData,
+                    0,
+                    height,
+                    0,
+                    width,
+                    cellPixelWidth,
+                    cellPixelHeight);
+            if (activePlacement is not null)
+                active.Placements.Add(activePlacement);
+            if (wasHistory)
+                ReleaseHistoryImage(active, placement.ImageId);
+        }
+    }
+
     internal (
         IReadOnlyList<KgpPlacement> Placements,
         IReadOnlyDictionary<uint, KgpImageData> Images) CaptureActiveSnapshot()
-        => Active.ImageStore.CaptureSnapshot(Active.Placements);
+    {
+        var active = Active;
+        ReconcileImageReferences(active);
+        return active.ImageStore.CaptureSnapshot(active.Placements);
+    }
+
+    internal (
+        IReadOnlyList<KgpPlacement> Placements,
+        IReadOnlyDictionary<uint, KgpImageData> Images) CaptureActiveSnapshot(
+            IReadOnlyList<ScrollbackEntry> historyRows,
+            int selectedHistoryCount,
+            int width,
+            int height,
+            int cellPixelWidth,
+            int cellPixelHeight)
+    {
+        var active = Active;
+        ReconcileImageReferences(active);
+        var historyCount = _alternateActive ? 0 : historyRows.Count;
+        var selectedCount = Math.Clamp(selectedHistoryCount, 0, historyCount);
+        var snapshotStart = historyCount - selectedCount;
+        var snapshotEnd = checked(historyCount + height);
+        var materialized = new List<KgpPlacement>(
+            active.Placements.Count + active.HistoryPlacements.Count);
+
+        foreach (var placement in active.Placements)
+        {
+            AddMaterializedPlacement(
+                active,
+                materialized,
+                placement.WithPosition(
+                    checked(historyCount + placement.Row),
+                    placement.Column),
+                snapshotStart,
+                snapshotEnd,
+                width,
+                cellPixelWidth,
+                cellPixelHeight);
+        }
+
+        if (!_alternateActive && _main.HistoryPlacements.Count > 0)
+        {
+            var rowIndices = new Dictionary<long, int>(historyRows.Count);
+            for (var i = 0; i < historyRows.Count; i++)
+                rowIndices.Add(historyRows[i].RowId, i);
+
+            foreach (var (rowId, placements) in _main.HistoryPlacements)
+            {
+                if (!rowIndices.TryGetValue(rowId, out var rowIndex))
+                {
+                    throw new InvalidOperationException(
+                        $"KGP history placement anchor {rowId} is not present in scrollback.");
+                }
+
+                foreach (var placement in placements)
+                {
+                    AddMaterializedHistoryPlacement(
+                        _main,
+                        materialized,
+                        placement,
+                        rowIndex,
+                        snapshotStart,
+                        snapshotEnd,
+                        width,
+                        cellPixelWidth,
+                        cellPixelHeight);
+                }
+            }
+        }
+
+        return active.ImageStore.CaptureSnapshot(materialized);
+    }
+
+    internal int ActiveHistoryReferenceCount(uint imageId)
+        => Active.HistoryReferences.TryGetValue(imageId, out var count) ? count : 0;
+
+    internal int MainHistoryPlacementCount
+        => _main.HistoryPlacements.Values.Sum(placements => placements.Count);
+
+    private static bool IsWhollyContained(
+        KgpPlacement placement,
+        KgpScrollRectangle rectangle)
+    {
+        var bottom = (long)placement.Row + placement.DisplayRows - 1;
+        var right = (long)placement.Column + placement.DisplayColumns - 1;
+        return placement.Row >= rectangle.Top &&
+            bottom <= rectangle.Bottom &&
+            placement.Column >= rectangle.Left &&
+            right <= rectangle.Right;
+    }
+
+    private static void ReconcileImageReferences(ScreenState screen)
+    {
+        // Deletion and quota policy live in the image store. If either removes
+        // data, discard only the now-invalid placement ownership here.
+        screen.Placements.RemoveAll(
+            placement => screen.ImageStore.GetImageById(placement.ImageId) is null);
+
+        var historyReferences = new Dictionary<uint, int>();
+        foreach (var rowId in screen.HistoryPlacements.Keys.ToArray())
+        {
+            var placements = screen.HistoryPlacements[rowId];
+            placements.RemoveAll(
+                placement => screen.ImageStore.GetImageById(
+                    placement.Placement.ImageId) is null);
+            foreach (var placement in placements)
+            {
+                var imageId = placement.Placement.ImageId;
+                historyReferences.TryGetValue(imageId, out var count);
+                historyReferences[imageId] = checked(count + 1);
+            }
+
+            if (placements.Count == 0)
+                screen.HistoryPlacements.Remove(rowId);
+        }
+
+        screen.HistoryReferences.Clear();
+        foreach (var (imageId, count) in historyReferences)
+            screen.HistoryReferences.Add(imageId, count);
+    }
+
+    private static void AddHistoryPlacement(
+        ScreenState screen,
+        long rowId,
+        HistoryPlacement placement,
+        bool retainImage)
+    {
+        if (!screen.HistoryPlacements.TryGetValue(rowId, out var placements))
+        {
+            placements = [];
+            screen.HistoryPlacements.Add(rowId, placements);
+        }
+
+        placements.Add(placement);
+        if (retainImage)
+            RetainHistoryImage(screen, placement.Placement.ImageId);
+    }
+
+    private static void RetainHistoryImage(ScreenState screen, uint imageId)
+    {
+        if (imageId == 0)
+            throw new ArgumentOutOfRangeException(nameof(imageId));
+        if (screen.ImageStore.GetImageById(imageId) is null)
+            throw new InvalidOperationException($"Cannot retain missing KGP image {imageId}.");
+
+        screen.HistoryReferences.TryGetValue(imageId, out var count);
+        screen.HistoryReferences[imageId] = checked(count + 1);
+    }
+
+    private static void ReleaseHistoryImage(ScreenState screen, uint imageId)
+    {
+        if (!screen.HistoryReferences.TryGetValue(imageId, out var count))
+            throw new InvalidOperationException($"KGP image {imageId} has no history reference.");
+
+        if (count == 1)
+        {
+            screen.HistoryReferences.Remove(imageId);
+            if (!screen.Placements.Any(placement => placement.ImageId == imageId))
+                screen.ImageStore.RemoveImage(imageId);
+        }
+        else
+        {
+            screen.HistoryReferences[imageId] = count - 1;
+        }
+    }
+
+    private void ClipMainHistoryToHistoryRows(
+        IReadOnlyList<ScrollbackEntry> historyRows,
+        int cellPixelHeight)
+    {
+        if (_main.HistoryPlacements.Count == 0)
+            return;
+
+        var rowIndices = new Dictionary<long, int>(historyRows.Count);
+        for (var i = 0; i < historyRows.Count; i++)
+            rowIndices.Add(historyRows[i].RowId, i);
+
+        foreach (var rowId in _main.HistoryPlacements.Keys.ToArray())
+        {
+            if (!rowIndices.TryGetValue(rowId, out var rowIndex))
+            {
+                var orphaned = _main.HistoryPlacements[rowId];
+                _main.HistoryPlacements.Remove(rowId);
+                foreach (var historyPlacement in orphaned)
+                    ReleaseHistoryImage(_main, historyPlacement.Placement.ImageId);
+                continue;
+            }
+
+            var retainedRowCount = checked((uint)(historyRows.Count - rowIndex));
+            var placements = _main.HistoryPlacements[rowId];
+            for (var i = placements.Count - 1; i >= 0; i--)
+            {
+                var historyPlacement = placements[i];
+                if (historyPlacement.RetainedRows <= retainedRowCount)
+                    continue;
+
+                var placement = historyPlacement.Placement;
+                var retained = historyPlacement with { RetainedRows = retainedRowCount };
+                var image = _main.ImageStore.GetImageById(placement.ImageId)
+                    ?? throw new InvalidOperationException(
+                        $"History placement {placement.PlacementId} references missing KGP image {placement.ImageId}.");
+                var clipped = placement.ClipRows(
+                    image,
+                    retained.FirstRow,
+                    retained.RetainedRows,
+                    resultRow: 0,
+                    cellPixelHeight);
+                if (clipped is null)
+                {
+                    placements.RemoveAt(i);
+                    ReleaseHistoryImage(_main, placement.ImageId);
+                }
+                else
+                {
+                    placements[i] = retained;
+                }
+            }
+
+            if (placements.Count == 0)
+                _main.HistoryPlacements.Remove(rowId);
+        }
+    }
+
+    private static void AddMaterializedHistoryPlacement(
+        ScreenState screen,
+        List<KgpPlacement> destination,
+        HistoryPlacement historyPlacement,
+        int anchorRow,
+        int snapshotStart,
+        int snapshotEnd,
+        int width,
+        int cellPixelWidth,
+        int cellPixelHeight)
+    {
+        var placement = historyPlacement.Placement;
+        var placementEnd = checked(anchorRow + (int)historyPlacement.RetainedRows);
+        var retainedStart = Math.Max(anchorRow, snapshotStart);
+        var retainedEnd = Math.Min(placementEnd, snapshotEnd);
+        if (retainedStart >= retainedEnd)
+            return;
+
+        var image = screen.ImageStore.GetImageById(placement.ImageId)
+            ?? throw new InvalidOperationException(
+                $"History placement {placement.PlacementId} references missing KGP image {placement.ImageId}.");
+        var firstRow = checked(
+            historyPlacement.FirstRow + (uint)(retainedStart - anchorRow));
+        var retainedRows = checked((uint)(retainedEnd - retainedStart));
+        var sliced = placement.ClipRows(
+            image,
+            firstRow,
+            retainedRows,
+            retainedStart,
+            cellPixelHeight);
+        if (sliced is null)
+            return;
+
+        AddMaterializedPlacement(
+            screen,
+            destination,
+            sliced,
+            snapshotStart,
+            snapshotEnd,
+            width,
+            cellPixelWidth,
+            cellPixelHeight);
+    }
+
+    private static void AddMaterializedPlacement(
+        ScreenState screen,
+        List<KgpPlacement> destination,
+        KgpPlacement placement,
+        int snapshotStart,
+        int snapshotEnd,
+        int width,
+        int cellPixelWidth,
+        int cellPixelHeight)
+    {
+        var image = screen.ImageStore.GetImageById(placement.ImageId)
+            ?? throw new InvalidOperationException(
+                $"Placement {placement.PlacementId} references missing KGP image {placement.ImageId}.");
+        var clipped = placement.ClipToCellRectangle(
+            image,
+            snapshotStart,
+            snapshotEnd,
+            0,
+            width,
+            cellPixelWidth,
+            cellPixelHeight);
+        if (clipped is not null)
+        {
+            destination.Add(clipped.WithPosition(
+                checked(clipped.Row - snapshotStart),
+                clipped.Column));
+        }
+    }
 }

--- a/src/Hex1b/Reflow/IInternalTerminalReflowProvider.cs
+++ b/src/Hex1b/Reflow/IInternalTerminalReflowProvider.cs
@@ -1,0 +1,9 @@
+namespace Hex1b.Reflow;
+
+internal interface IInternalTerminalReflowProvider
+{
+    bool TryReflowWithAnchors(
+        ReflowContext context,
+        IReadOnlyList<TerminalReflowAnchor> anchors,
+        out InternalReflowResult result);
+}

--- a/src/Hex1b/Reflow/InternalReflowResult.cs
+++ b/src/Hex1b/Reflow/InternalReflowResult.cs
@@ -1,0 +1,5 @@
+namespace Hex1b.Reflow;
+
+internal readonly record struct InternalReflowResult(
+    ReflowResult Reflow,
+    IReadOnlyList<TerminalReflowAnchor> Anchors);

--- a/src/Hex1b/Reflow/InternalTerminalReflow.cs
+++ b/src/Hex1b/Reflow/InternalTerminalReflow.cs
@@ -67,12 +67,7 @@ internal static class InternalTerminalReflow
             if (anchor.Row < oldHistoryCount)
             {
                 if (anchor.Row < newHistoryCount)
-                {
-                    mapped.Add(anchor with
-                    {
-                        Column = Math.Clamp(anchor.Column, 0, context.NewWidth - 1)
-                    });
-                }
+                    mapped.Add(anchor);
 
                 continue;
             }
@@ -82,8 +77,7 @@ internal static class InternalTerminalReflow
             {
                 mapped.Add(anchor with
                 {
-                    Row = checked(newHistoryCount + screenRow),
-                    Column = Math.Clamp(anchor.Column, 0, context.NewWidth - 1)
+                    Row = checked(newHistoryCount + screenRow)
                 });
             }
         }

--- a/src/Hex1b/Reflow/InternalTerminalReflow.cs
+++ b/src/Hex1b/Reflow/InternalTerminalReflow.cs
@@ -1,0 +1,93 @@
+namespace Hex1b.Reflow;
+
+internal static class InternalTerminalReflow
+{
+    internal static bool TryReflow(
+        ITerminalReflowProvider provider,
+        ReflowContext context,
+        IReadOnlyList<TerminalReflowAnchor> anchors,
+        out InternalReflowResult result)
+    {
+        if (provider is AutoReflowStrategy auto)
+        {
+            return TryReflow(
+                auto.DetectedStrategy,
+                context,
+                anchors,
+                out result);
+        }
+
+        if (context.InAlternateScreen ||
+            provider is NoReflowStrategy or XtermReflowStrategy or ITerm2ReflowStrategy)
+        {
+            result = PerformNoReflow(provider, context, anchors);
+            return true;
+        }
+
+        switch (provider)
+        {
+            case KittyReflowStrategy or WezTermReflowStrategy:
+                result = ReflowHelper.PerformReflowWithAnchors(
+                    context,
+                    preserveCursorRow: true,
+                    reflowSavedCursor: false,
+                    anchors);
+                return true;
+            case GhosttyReflowStrategy or FootReflowStrategy or VteReflowStrategy:
+                result = ReflowHelper.PerformReflowWithAnchors(
+                    context,
+                    preserveCursorRow: true,
+                    reflowSavedCursor: true,
+                    anchors);
+                return true;
+            case AlacrittyReflowStrategy or WindowsTerminalReflowStrategy:
+                result = ReflowHelper.PerformReflowWithAnchors(
+                    context,
+                    preserveCursorRow: false,
+                    reflowSavedCursor: false,
+                    anchors);
+                return true;
+            default:
+                result = default;
+                return false;
+        }
+    }
+
+    private static InternalReflowResult PerformNoReflow(
+        ITerminalReflowProvider provider,
+        ReflowContext context,
+        IReadOnlyList<TerminalReflowAnchor> anchors)
+    {
+        var reflow = provider.Reflow(context);
+        var oldHistoryCount = context.ScrollbackRows.Length;
+        var newHistoryCount = reflow.ScrollbackRows.Length;
+        var mapped = new List<TerminalReflowAnchor>(anchors.Count);
+        foreach (var anchor in anchors)
+        {
+            if (anchor.Row < oldHistoryCount)
+            {
+                if (anchor.Row < newHistoryCount)
+                {
+                    mapped.Add(anchor with
+                    {
+                        Column = Math.Clamp(anchor.Column, 0, context.NewWidth - 1)
+                    });
+                }
+
+                continue;
+            }
+
+            var screenRow = anchor.Row - oldHistoryCount;
+            if (screenRow >= 0 && screenRow < context.NewHeight)
+            {
+                mapped.Add(anchor with
+                {
+                    Row = checked(newHistoryCount + screenRow),
+                    Column = Math.Clamp(anchor.Column, 0, context.NewWidth - 1)
+                });
+            }
+        }
+
+        return new InternalReflowResult(reflow, mapped);
+    }
+}

--- a/src/Hex1b/Reflow/ReflowHelper.cs
+++ b/src/Hex1b/Reflow/ReflowHelper.cs
@@ -130,7 +130,7 @@ internal static class ReflowHelper
             {
                 foreach (var (anchor, rowInLine) in lineAnchors)
                 {
-                    var (row, column) = ComputeCursorInWrappedLine(
+                    var (row, column) = ComputeAnchorInWrappedLine(
                         logicalLine,
                         wrappedRows,
                         rowsSoFar,
@@ -192,6 +192,28 @@ internal static class ReflowHelper
         }
 
         return (row, col);
+    }
+
+    private static (int row, int col) ComputeAnchorInWrappedLine(
+        List<TerminalCell> logicalLine,
+        List<TerminalCell[]> wrappedRows,
+        int rowsSoFar,
+        int rowInLogicalLine,
+        int column,
+        int oldWidth,
+        int newWidth)
+    {
+        if (logicalLine.Count == 0)
+            return (rowsSoFar, Math.Clamp(column, 0, newWidth - 1));
+
+        return ComputeCursorInWrappedLine(
+            logicalLine,
+            wrappedRows,
+            rowsSoFar,
+            rowInLogicalLine,
+            column,
+            oldWidth,
+            newWidth);
     }
 
     /// <summary>

--- a/src/Hex1b/Reflow/ReflowHelper.cs
+++ b/src/Hex1b/Reflow/ReflowHelper.cs
@@ -34,14 +34,31 @@ internal static class ReflowHelper
     /// <returns>The reflowed terminal state.</returns>
     public static ReflowResult PerformReflow(ReflowContext context, bool preserveCursorRow,
         bool reflowSavedCursor = false)
+        => PerformReflowWithAnchors(
+            context,
+            preserveCursorRow,
+            reflowSavedCursor,
+            []).Reflow;
+
+    internal static InternalReflowResult PerformReflowWithAnchors(
+        ReflowContext context,
+        bool preserveCursorRow,
+        bool reflowSavedCursor,
+        IReadOnlyList<TerminalReflowAnchor> anchors)
     {
         bool hasSavedCursor = reflowSavedCursor && context.SavedCursorX.HasValue && context.SavedCursorY.HasValue;
 
         if (context.NewWidth == context.OldWidth && context.NewHeight == context.OldHeight)
         {
-            return new ReflowResult(context.ScreenRows, context.ScrollbackRows, context.CursorX, context.CursorY,
-                hasSavedCursor ? context.SavedCursorX : null,
-                hasSavedCursor ? context.SavedCursorY : null);
+            return new InternalReflowResult(
+                new ReflowResult(
+                    context.ScreenRows,
+                    context.ScrollbackRows,
+                    context.CursorX,
+                    context.CursorY,
+                    hasSavedCursor ? context.SavedCursorX : null,
+                    hasSavedCursor ? context.SavedCursorY : null),
+                anchors.ToArray());
         }
 
         // Step 1: Collect all rows into a unified sequence (scrollback + screen)
@@ -57,6 +74,23 @@ internal static class ReflowHelper
              savedCursorLogicalLine, savedCursorRowInLogicalLine) =
             GroupLogicalLinesWithCursors(allRows, cursorAbsoluteRow,
                 hasSavedCursor ? savedCursorAbsoluteRow : null);
+        var rowLocations = BuildLogicalRowLocations(allRows);
+        var anchorsByLogicalLine =
+            new Dictionary<int, List<(TerminalReflowAnchor Anchor, int RowInLine)>>();
+        foreach (var anchor in anchors)
+        {
+            if (anchor.Row < 0 || anchor.Row >= rowLocations.Length)
+                continue;
+
+            var location = rowLocations[anchor.Row];
+            if (!anchorsByLogicalLine.TryGetValue(location.LogicalLine, out var lineAnchors))
+            {
+                lineAnchors = [];
+                anchorsByLogicalLine.Add(location.LogicalLine, lineAnchors);
+            }
+
+            lineAnchors.Add((anchor, location.RowInLine));
+        }
 
         // Step 3: Re-wrap all logical lines to the new width
         var rewrappedRows = new List<TerminalCell[]>();
@@ -67,6 +101,7 @@ internal static class ReflowHelper
         int rowsSoFar = 0;
         bool cursorFound = false;
         bool savedCursorFound = false;
+        var mappedAnchors = new List<TerminalReflowAnchor>(anchors.Count);
 
         for (int lineIdx = 0; lineIdx < logicalLines.Count; lineIdx++)
         {
@@ -91,6 +126,22 @@ internal static class ReflowHelper
                 savedCursorFound = true;
             }
 
+            if (anchorsByLogicalLine.TryGetValue(lineIdx, out var lineAnchors))
+            {
+                foreach (var (anchor, rowInLine) in lineAnchors)
+                {
+                    var (row, column) = ComputeCursorInWrappedLine(
+                        logicalLine,
+                        wrappedRows,
+                        rowsSoFar,
+                        rowInLine,
+                        anchor.Column,
+                        context.OldWidth,
+                        context.NewWidth);
+                    mappedAnchors.Add(anchor with { Row = row, Column = column });
+                }
+            }
+
             rewrappedRows.AddRange(wrappedRows);
             rowsSoFar += wrappedRows.Count;
         }
@@ -108,9 +159,12 @@ internal static class ReflowHelper
         }
 
         // Step 4: Distribute rows into scrollback and screen
-        return DistributeRows(rewrappedRows, context, newCursorRow, newCursorCol, preserveCursorRow,
+        var reflow = DistributeRows(rewrappedRows, context, newCursorRow, newCursorCol, preserveCursorRow,
             hasSavedCursor ? newSavedCursorRow : null,
             hasSavedCursor ? newSavedCursorCol : null);
+        var retainedRowCount = reflow.ScrollbackRows.Length + reflow.ScreenRows.Length;
+        mappedAnchors.RemoveAll(anchor => anchor.Row < 0 || anchor.Row >= retainedRowCount);
+        return new InternalReflowResult(reflow, mappedAnchors);
     }
 
     /// <summary>
@@ -173,6 +227,32 @@ internal static class ReflowHelper
         }
 
         return allRows;
+    }
+
+    private static (int LogicalLine, int RowInLine)[] BuildLogicalRowLocations(
+        List<TerminalCell[]> allRows)
+    {
+        var locations = new (int LogicalLine, int RowInLine)[allRows.Count];
+        var logicalLine = 0;
+        var rowInLine = 0;
+        for (var rowIndex = 0; rowIndex < allRows.Count; rowIndex++)
+        {
+            locations[rowIndex] = (logicalLine, rowInLine);
+            var row = allRows[rowIndex];
+            var hasSoftWrap = row.Length > 0 &&
+                (row[^1].Attributes & CellAttributes.SoftWrap) != 0;
+            if (hasSoftWrap)
+            {
+                rowInLine++;
+            }
+            else
+            {
+                logicalLine++;
+                rowInLine = 0;
+            }
+        }
+
+        return locations;
     }
 
     /// <summary>

--- a/src/Hex1b/Reflow/TerminalReflowAnchor.cs
+++ b/src/Hex1b/Reflow/TerminalReflowAnchor.cs
@@ -1,0 +1,6 @@
+namespace Hex1b.Reflow;
+
+internal readonly record struct TerminalReflowAnchor(
+    int Id,
+    int Row,
+    int Column);

--- a/src/Hex1b/ScrollbackBuffer.cs
+++ b/src/Hex1b/ScrollbackBuffer.cs
@@ -1,4 +1,31 @@
+using Hex1b.Reflow;
+
 namespace Hex1b;
+
+internal enum ScrollbackPruneReason
+{
+    Capacity,
+    Clear,
+}
+
+internal readonly record struct ScrollbackPrunedRow(
+    long RowId,
+    long? SuccessorRowId,
+    ScrollbackPruneReason Reason);
+
+internal readonly record struct ScrollbackEntry(
+    long RowId,
+    ScrollbackRow Row);
+
+internal readonly record struct ScrollbackPushResult(
+    long RowId,
+    ScrollbackRow? EvictedRow,
+    long? EvictedRowId,
+    long? SuccessorRowId);
+
+internal readonly record struct ScrollbackReplacementResult(
+    ScrollbackEntry[] Entries,
+    int DiscardedRowCount);
 
 /// <summary>
 /// A fixed-capacity circular buffer that stores terminal rows scrolled off screen.
@@ -15,19 +42,31 @@ namespace Hex1b;
 internal sealed class ScrollbackBuffer
 {
     private readonly ScrollbackRow[] _rows;
+    private readonly long[] _rowIds;
+    private readonly Action<ScrollbackPrunedRow>? _rowPruned;
     private int _head; // Next write position
     private int _count;
+    private long _nextRowId = 1;
 
     /// <summary>
     /// Creates a scrollback buffer with the specified maximum line capacity.
     /// </summary>
     /// <param name="capacity">Maximum number of rows to retain.</param>
     public ScrollbackBuffer(int capacity)
+        : this(capacity, rowPruned: null)
+    {
+    }
+
+    internal ScrollbackBuffer(
+        int capacity,
+        Action<ScrollbackPrunedRow>? rowPruned)
     {
         if (capacity <= 0)
             throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be positive.");
 
         _rows = new ScrollbackRow[capacity];
+        _rowIds = new long[capacity];
+        _rowPruned = rowPruned;
         Capacity = capacity;
     }
 
@@ -50,13 +89,21 @@ internal sealed class ScrollbackBuffer
     /// <param name="timestamp">When the row was scrolled off screen.</param>
     /// <returns>The evicted row if the buffer was full; otherwise <c>null</c>.</returns>
     public ScrollbackRow? Push(TerminalCell[] cells, int originalWidth, DateTimeOffset timestamp)
+        => PushWithIdentity(cells, originalWidth, timestamp).EvictedRow;
+
+    internal ScrollbackPushResult PushWithIdentity(
+        TerminalCell[] cells,
+        int originalWidth,
+        DateTimeOffset timestamp)
     {
         ScrollbackRow? evicted = null;
+        long? evictedRowId = null;
 
         // Evict oldest row if full
         if (_count == Capacity)
         {
             evicted = _rows[_head];
+            evictedRowId = _rowIds[_head];
             ReleaseTrackedObjects(evicted.Value);
         }
         else
@@ -71,10 +118,27 @@ internal sealed class ScrollbackBuffer
             cells[i].TrackedHyperlink?.AddRef();
         }
 
+        var rowId = _nextRowId;
+        _nextRowId = checked(_nextRowId + 1);
         _rows[_head] = new ScrollbackRow(cells, originalWidth, timestamp);
+        _rowIds[_head] = rowId;
         _head = (_head + 1) % Capacity;
 
-        return evicted;
+        long? successorRowId = null;
+        if (evictedRowId.HasValue)
+        {
+            successorRowId = _rowIds[_head];
+            _rowPruned?.Invoke(new ScrollbackPrunedRow(
+                evictedRowId.Value,
+                successorRowId,
+                ScrollbackPruneReason.Capacity));
+        }
+
+        return new ScrollbackPushResult(
+            rowId,
+            evicted,
+            evictedRowId,
+            successorRowId);
     }
 
     /// <summary>
@@ -82,22 +146,32 @@ internal sealed class ScrollbackBuffer
     /// </summary>
     public ScrollbackRow[] GetLines(int count)
     {
+        var entries = GetEntries(count);
+        var result = new ScrollbackRow[entries.Length];
+        for (var i = 0; i < entries.Length; i++)
+            result[i] = entries[i].Row;
+        return result;
+    }
+
+    internal ScrollbackEntry[] GetEntries(int count)
+    {
         if (count <= 0)
             return [];
 
-        int actual = Math.Min(count, _count);
-        var result = new ScrollbackRow[actual];
+        var actual = Math.Min(count, _count);
+        var result = new ScrollbackEntry[actual];
 
         // Start index: oldest of the requested lines
         // _head points to the next write slot. The newest row is at (_head - 1).
         // The oldest row in the buffer is at (_head) when full, or at index 0 when not full.
-        int startIndex = _count == Capacity
+        var startIndex = _count == Capacity
             ? (_head - actual + Capacity) % Capacity
             : _count - actual;
 
-        for (int i = 0; i < actual; i++)
+        for (var i = 0; i < actual; i++)
         {
-            result[i] = _rows[(startIndex + i) % Capacity];
+            var index = (startIndex + i) % Capacity;
+            result[i] = new ScrollbackEntry(_rowIds[index], _rows[index]);
         }
 
         return result;
@@ -117,11 +191,59 @@ internal sealed class ScrollbackBuffer
         {
             int idx = (startIndex + i) % Capacity;
             ReleaseTrackedObjects(_rows[idx]);
+            var rowId = _rowIds[idx];
             _rows[idx] = default;
+            _rowIds[idx] = 0;
+            _rowPruned?.Invoke(new ScrollbackPrunedRow(
+                rowId,
+                SuccessorRowId: null,
+                ScrollbackPruneReason.Clear));
         }
 
         _head = 0;
         _count = 0;
+    }
+
+    internal ScrollbackReplacementResult ReplaceRows(
+        IReadOnlyList<ReflowScrollbackRow> rows,
+        DateTimeOffset timestamp)
+    {
+        var startIndex = _count == Capacity ? _head : 0;
+        for (var i = 0; i < _count; i++)
+        {
+            var index = (startIndex + i) % Capacity;
+            ReleaseTrackedObjects(_rows[index]);
+            _rows[index] = default;
+            _rowIds[index] = 0;
+        }
+
+        _head = 0;
+        _count = 0;
+
+        var discarded = Math.Max(0, rows.Count - Capacity);
+        for (var rowIndex = discarded; rowIndex < rows.Count; rowIndex++)
+        {
+            var row = rows[rowIndex];
+            for (var cellIndex = 0; cellIndex < row.Cells.Length; cellIndex++)
+            {
+                row.Cells[cellIndex].TrackedSixel?.AddRef();
+                row.Cells[cellIndex].TrackedHyperlink?.AddRef();
+            }
+
+            var id = _nextRowId;
+            _nextRowId = checked(_nextRowId + 1);
+            _rows[_head] = new ScrollbackRow(
+                row.Cells,
+                row.OriginalWidth,
+                timestamp);
+            _rowIds[_head] = id;
+            _head = (_head + 1) % Capacity;
+            _count++;
+        }
+
+        return new ScrollbackReplacementResult(
+            GetEntries(_count),
+            discarded);
     }
 
     private static void ReleaseTrackedObjects(ScrollbackRow row)

--- a/tests/Hex1b.Tests/Hex1bTerminalTests.cs
+++ b/tests/Hex1b.Tests/Hex1bTerminalTests.cs
@@ -660,6 +660,15 @@ public class Hex1bTerminalTests
             Assert.AreEqual(0x22, restoredSnapshot.KgpImages[2].Data[0]);
         }
 
+        const string scrollingAndHistoryClear =
+            "\x1b[?69h\x1b[2;10s\x1b[2;7r\x1b[S\x1b[T\x1b[3J";
+        await WriteAndAssertForwardedAsync(scrollingAndHistoryClear);
+        using (var clearedSnapshot = terminal.CreateSnapshot())
+        {
+            Assert.IsEmpty(clearedSnapshot.KgpPlacements);
+            Assert.IsEmpty(clearedSnapshot.KgpImages);
+        }
+
         cts.Cancel();
         await Assert.ThrowsAsync<OperationCanceledException>(
             async () => await runTask);

--- a/tests/Hex1b.Tests/KgpConformanceTests.cs
+++ b/tests/Hex1b.Tests/KgpConformanceTests.cs
@@ -1005,11 +1005,11 @@ public class KgpScrollConformanceTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\n"));
 
         // After scroll, placement should have moved up by 1
-        var placements = terminal.KgpPlacements;
-        if (placements.Count > 0)
-        {
-            Assert.AreEqual(1, placements[0].Row);
-        }
+        var placement = TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(1, placement.Row);
+        Assert.AreEqual(1u, placement.DisplayRows);
+        Assert.AreEqual(0u, placement.SourceY);
+        Assert.AreEqual(4u, placement.SourceHeight);
     }
 
     [TestMethod]
@@ -1029,10 +1029,8 @@ public class KgpScrollConformanceTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[5;1H"));
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\n\n"));
 
-        // After scrolling off, placement should be removed
-        var placements = terminal.KgpPlacements;
-        // Either removed or row < 0
-        Assert.IsTrue(placements.Count == 0 || placements[0].Row < 0);
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
     }
 }
 

--- a/tests/Hex1b.Tests/KgpScrollingTests.cs
+++ b/tests/Hex1b.Tests/KgpScrollingTests.cs
@@ -1,0 +1,1068 @@
+using Hex1b.Tokens;
+using Hex1b.Reflow;
+
+namespace Hex1b.Tests;
+
+[TestClass]
+public class KgpScrollingTests
+{
+    private static Hex1bTerminal CreateTerminal(
+        IHex1bTerminalWorkloadAdapter workload,
+        int width = 10,
+        int height = 6,
+        int? scrollbackCapacity = null,
+        int cellPixelWidth = 10,
+        int cellPixelHeight = 10,
+        ITerminalReflowProvider? reflow = null)
+    {
+        var capabilities = new TerminalCapabilities
+        {
+            SupportsKgp = true,
+            SupportsTrueColor = true,
+            Supports256Colors = true,
+            CellPixelWidth = cellPixelWidth,
+            CellPixelHeight = cellPixelHeight,
+        };
+        var builder = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithHeadless(capabilities)
+            .WithDimensions(width, height);
+        if (scrollbackCapacity is { } capacity)
+            builder.WithScrollback(capacity);
+        if (reflow is not null)
+            builder.WithReflow(reflow);
+        return builder.Build();
+    }
+
+    private static void Apply(Hex1bTerminal terminal, string value)
+        => terminal.ApplyTokens(AnsiTokenizer.Tokenize(value));
+
+    private static void PlaceImage(
+        Hex1bTerminal terminal,
+        uint imageId,
+        uint imageWidth,
+        uint imageHeight,
+        uint displayColumns,
+        uint displayRows,
+        int row = 0,
+        int column = 0)
+    {
+        Apply(terminal, $"\x1b[{row + 1};{column + 1}H");
+        Apply(
+            terminal,
+            KgpTestHelper.BuildTransmitAndDisplayCommand(
+                imageId,
+                imageWidth,
+                imageHeight,
+                displayColumns: displayColumns,
+                displayRows: displayRows,
+                cursorMovement: 1,
+                quiet: 2));
+    }
+
+    private static KgpPlacement SinglePlacement(Hex1bTerminalSnapshot snapshot)
+        => TestSeq.Single(snapshot.KgpPlacements);
+
+    [TestMethod]
+    public void FullScreenScroll_WithScrollback_ProjectsPlacementAcrossHistoryBoundary()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 10,
+            height: 4,
+            scrollbackCapacity: 3);
+        PlaceImage(terminal, 1, 10, 20, displayColumns: 1, displayRows: 2);
+
+        Apply(terminal, "\x1b[S");
+
+        using var active = terminal.CreateSnapshot();
+        var activePlacement = SinglePlacement(active);
+        Assert.AreEqual(0, activePlacement.Row);
+        Assert.AreEqual(1u, activePlacement.DisplayRows);
+        Assert.AreEqual(10u, activePlacement.SourceY);
+        Assert.AreEqual(10u, activePlacement.SourceHeight);
+
+        using var withHistory = terminal.CreateSnapshot(scrollbackLines: 1);
+        var historyPlacement = SinglePlacement(withHistory);
+        Assert.AreEqual(0, historyPlacement.Row);
+        Assert.AreEqual(2u, historyPlacement.DisplayRows);
+        Assert.AreEqual(0u, historyPlacement.SourceY);
+        Assert.AreEqual(20u, historyPlacement.SourceHeight);
+        Assert.AreEqual(1, terminal.KgpHistoryPlacementCount);
+        Assert.AreEqual(1, terminal.GetKgpHistoryReferenceCount(1));
+        Assert.IsTrue(withHistory.KgpImages.ContainsKey(1));
+    }
+
+    [TestMethod]
+    public void LineFeedAtBottom_FullScreenMovesPlacementIntoHistory()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 10,
+            height: 4,
+            scrollbackCapacity: 2);
+        PlaceImage(terminal, 1, 10, 10, displayColumns: 1, displayRows: 1);
+
+        Apply(terminal, "\x1b[4;1H\n");
+
+        Assert.AreEqual(1, terminal.ScrollbackCount);
+        AssertHistoryOwner(terminal, expectedPlacements: 1, expectedReferences: 1);
+        AssertPlacement(
+            terminal.CreateSnapshot(scrollbackLines: 1),
+            row: 0,
+            rows: 1,
+            sourceY: 0,
+            sourceHeight: 10);
+    }
+
+    [TestMethod]
+    public void FullScreenScrollDown_HistoryAnchoredVisibleTailRemainsPinned()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            height: 4,
+            scrollbackCapacity: 2);
+        PlaceImage(terminal, 1, 10, 20, displayColumns: 1, displayRows: 2);
+        Apply(terminal, "\x1b[S");
+
+        Apply(terminal, "\x1b[T");
+
+        AssertPlacement(
+            terminal.CreateSnapshot(),
+            row: 0,
+            rows: 1,
+            sourceY: 10,
+            sourceHeight: 10);
+        AssertHistoryOwner(terminal, expectedPlacements: 1, expectedReferences: 1);
+    }
+
+    [TestMethod]
+    public void FullScreenScroll_CapacityOne_ReanchorsScaledCropUntilFullyPruned()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 10,
+            height: 4,
+            scrollbackCapacity: 1);
+        var data = KgpTestHelper.CreatePixelData(10, 80);
+        Apply(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=T,f=32,s=10,v=80,i=1,p=1,x=0,y=10,w=10,h=60,c=1,r=3,C=1,q=2",
+                data));
+
+        Apply(terminal, "\x1b[S");
+        AssertPlacement(
+            terminal.CreateSnapshot(scrollbackLines: 1),
+            row: 0,
+            rows: 3,
+            sourceY: 10,
+            sourceHeight: 60);
+        AssertPlacement(
+            terminal.CreateSnapshot(),
+            row: 0,
+            rows: 2,
+            sourceY: 30,
+            sourceHeight: 40);
+        AssertHistoryOwner(terminal, expectedPlacements: 1, expectedReferences: 1);
+
+        Apply(terminal, "\x1b[S");
+        AssertPlacement(
+            terminal.CreateSnapshot(scrollbackLines: 1),
+            row: 0,
+            rows: 2,
+            sourceY: 30,
+            sourceHeight: 40);
+        AssertPlacement(
+            terminal.CreateSnapshot(),
+            row: 0,
+            rows: 1,
+            sourceY: 50,
+            sourceHeight: 20);
+        AssertHistoryOwner(terminal, expectedPlacements: 1, expectedReferences: 1);
+
+        Apply(terminal, "\x1b[S");
+        AssertPlacement(
+            terminal.CreateSnapshot(scrollbackLines: 1),
+            row: 0,
+            rows: 1,
+            sourceY: 50,
+            sourceHeight: 20);
+        using (var active = terminal.CreateSnapshot())
+            Assert.IsEmpty(active.KgpPlacements);
+        AssertHistoryOwner(terminal, expectedPlacements: 1, expectedReferences: 1);
+
+        Apply(terminal, "\x1b[S");
+
+        using var pruned = terminal.CreateSnapshot(scrollbackLines: 1);
+        Assert.IsEmpty(pruned.KgpPlacements);
+        Assert.AreEqual(0, terminal.KgpHistoryPlacementCount);
+        Assert.AreEqual(0, terminal.GetKgpHistoryReferenceCount(1));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+    }
+
+    [TestMethod]
+    public void FullScreenScroll_CapacityTwo_UsesOriginalScaleAcrossRepeatedReanchors()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 10,
+            height: 5,
+            scrollbackCapacity: 2);
+        var data = KgpTestHelper.CreatePixelData(10, 100);
+        Apply(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=T,f=32,s=10,v=100,i=1,p=1,x=0,y=10,w=10,h=70,c=1,r=4,C=1,q=2",
+                data));
+
+        Apply(terminal, "\x1b[S\x1b[S\x1b[S");
+
+        AssertPlacement(
+            terminal.CreateSnapshot(scrollbackLines: 2),
+            row: 0,
+            rows: 3,
+            sourceY: 27,
+            sourceHeight: 53);
+        AssertPlacement(
+            terminal.CreateSnapshot(),
+            row: 0,
+            rows: 1,
+            sourceY: 62,
+            sourceHeight: 18);
+        AssertHistoryOwner(terminal, expectedPlacements: 1, expectedReferences: 1);
+
+        Apply(terminal, "\x1b[S");
+        AssertPlacement(
+            terminal.CreateSnapshot(scrollbackLines: 2),
+            row: 0,
+            rows: 2,
+            sourceY: 45,
+            sourceHeight: 35);
+        AssertHistoryOwner(terminal, expectedPlacements: 1, expectedReferences: 1);
+
+        Apply(terminal, "\x1b[S");
+        AssertPlacement(
+            terminal.CreateSnapshot(scrollbackLines: 2),
+            row: 0,
+            rows: 1,
+            sourceY: 62,
+            sourceHeight: 18);
+        AssertHistoryOwner(terminal, expectedPlacements: 1, expectedReferences: 1);
+
+        Apply(terminal, "\x1b[S");
+        Assert.AreEqual(0, terminal.KgpHistoryPlacementCount);
+        Assert.AreEqual(0, terminal.GetKgpHistoryReferenceCount(1));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+    }
+
+    [TestMethod]
+    [DataRow("\x1b[S")]
+    [DataRow("\u001bD")]
+    public void PartialMargins_ScrollUp_MovesClipsThenDeletesContainedPlacement(
+        string scrollSequence)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        Apply(terminal, "\x1b[2;5r");
+        PlaceImage(
+            terminal,
+            1,
+            imageWidth: 10,
+            imageHeight: 20,
+            displayColumns: 1,
+            displayRows: 2,
+            row: 2);
+        Apply(terminal, "\x1b[5;1H");
+
+        Apply(terminal, scrollSequence);
+        AssertPlacement(
+            terminal.CreateSnapshot(),
+            row: 1,
+            rows: 2,
+            sourceY: 0,
+            sourceHeight: 20);
+
+        Apply(terminal, scrollSequence);
+        AssertPlacement(
+            terminal.CreateSnapshot(),
+            row: 1,
+            rows: 1,
+            sourceY: 10,
+            sourceHeight: 10);
+
+        Apply(terminal, scrollSequence);
+        using var snapshot = terminal.CreateSnapshot();
+        Assert.IsEmpty(snapshot.KgpPlacements);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
+    }
+
+    [TestMethod]
+    [DataRow("\x1bM")]
+    [DataRow("\x1b[T")]
+    public void PartialMargins_ScrollDown_ClipsBottomThenDeletesContainedPlacement(
+        string scrollSequence)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        Apply(terminal, "\x1b[2;5r");
+        PlaceImage(
+            terminal,
+            1,
+            imageWidth: 10,
+            imageHeight: 20,
+            displayColumns: 1,
+            displayRows: 2,
+            row: 3);
+        Apply(terminal, "\x1b[2;1H");
+
+        Apply(terminal, scrollSequence);
+        AssertPlacement(
+            terminal.CreateSnapshot(),
+            row: 4,
+            rows: 1,
+            sourceY: 0,
+            sourceHeight: 10);
+
+        Apply(terminal, scrollSequence);
+        using var snapshot = terminal.CreateSnapshot();
+        Assert.IsEmpty(snapshot.KgpPlacements);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
+    }
+
+    [TestMethod]
+    public void PartialMargins_ScrollDown_ClipsScaledPreCroppedSourceProportionally()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        Apply(terminal, "\x1b[2;3r\x1b[2;1H");
+        var data = KgpTestHelper.CreatePixelData(10, 80);
+        Apply(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=T,f=32,s=10,v=80,i=1,p=1,x=0,y=10,w=10,h=60,c=1,r=2,C=1,q=2",
+                data));
+
+        Apply(terminal, "\x1b[T");
+
+        AssertPlacement(
+            terminal.CreateSnapshot(),
+            row: 2,
+            rows: 1,
+            sourceY: 10,
+            sourceHeight: 30);
+    }
+
+    [TestMethod]
+    public void PartialMargins_StraddlingOutsideAndStatusPlacementsRemainFixed()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        Apply(terminal, KgpTestHelper.BuildTransmitCommand(1, 10, 30, quiet: 2));
+        Apply(terminal, "\x1b[1;1H");
+        Apply(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 1, displayColumns: 1, displayRows: 2, cursorMovement: 1));
+        Apply(terminal, "\x1b[3;1H");
+        Apply(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 2, displayColumns: 1, displayRows: 1, cursorMovement: 1));
+        Apply(terminal, "\x1b[6;1H");
+        Apply(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 3, displayColumns: 1, displayRows: 1, cursorMovement: 1));
+        Apply(terminal, "\x1b[2;5r\x1b[S");
+
+        var placements = terminal.KgpPlacements.OrderBy(placement => placement.PlacementId).ToArray();
+        Assert.AreEqual(3, placements.Length);
+        Assert.AreEqual(0, placements[0].Row);
+        Assert.AreEqual(1, placements[1].Row);
+        Assert.AreEqual(5, placements[2].Row);
+    }
+
+    [TestMethod]
+    public void HorizontalMargins_MoveOnlyWhollyContainedPlacement()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        Apply(terminal, KgpTestHelper.BuildTransmitCommand(1, 10, 10, quiet: 2));
+        Apply(terminal, "\x1b[3;1H");
+        Apply(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 1, displayColumns: 1, displayRows: 1, cursorMovement: 1));
+        Apply(terminal, "\x1b[3;4H");
+        Apply(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 2, displayColumns: 2, displayRows: 1, cursorMovement: 1));
+        Apply(terminal, "\x1b[3;8H");
+        Apply(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 3, displayColumns: 2, displayRows: 1, cursorMovement: 1));
+
+        Apply(terminal, "\x1b[?69h\x1b[3;8s\x1b[S");
+
+        var placements = terminal.KgpPlacements.OrderBy(placement => placement.PlacementId).ToArray();
+        Assert.AreEqual(3, placements.Length);
+        Assert.AreEqual(2, placements[0].Row);
+        Assert.AreEqual(0, placements[0].Column);
+        Assert.AreEqual(1, placements[1].Row);
+        Assert.AreEqual(3, placements[1].Column);
+        Assert.AreEqual(2, placements[2].Row);
+        Assert.AreEqual(7, placements[2].Column);
+    }
+
+    [TestMethod]
+    public void InsertDeleteLines_OrdinaryPlacementsRemainFixed()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        Apply(terminal, "\x1b[2;5r");
+        PlaceImage(
+            terminal,
+            1,
+            imageWidth: 10,
+            imageHeight: 10,
+            displayColumns: 1,
+            displayRows: 1,
+            row: 2,
+            column: 3);
+        Apply(terminal, "\x1b[?69h\x1b[3;8s\x1b[3;4H");
+
+        Apply(terminal, "\x1b[L");
+        var afterInsert = TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(2, afterInsert.Row);
+        Assert.AreEqual(3, afterInsert.Column);
+
+        Apply(terminal, "\x1b[M");
+        var afterDelete = TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(2, afterDelete.Row);
+        Assert.AreEqual(3, afterDelete.Column);
+    }
+
+    [TestMethod]
+    public void PartialMargins_MultiCountScroll_AppliesEachStepConsistently()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        Apply(terminal, "\x1b[2;5r");
+        PlaceImage(
+            terminal,
+            1,
+            imageWidth: 10,
+            imageHeight: 10,
+            displayColumns: 1,
+            displayRows: 1,
+            row: 3);
+
+        Apply(terminal, "\x1b[2S");
+
+        var placement = TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(1, placement.Row);
+        Assert.AreEqual(1u, placement.DisplayRows);
+        Assert.AreEqual(0u, placement.SourceY);
+        Assert.AreEqual(10u, placement.SourceHeight);
+    }
+
+    [TestMethod]
+    public void ClipRows_WithoutCellMetrics_UsesDeterministicCellProportions()
+    {
+        var image = new KgpImageData(
+            imageId: 1,
+            imageNumber: 0,
+            KgpTestHelper.CreatePixelData(10, 20),
+            width: 10,
+            height: 20,
+            KgpFormat.Rgba32);
+        var placement = new KgpPlacement(
+            imageId: 1,
+            placementId: 1,
+            row: 0,
+            column: 0,
+            displayColumns: 1,
+            displayRows: 3,
+            sourceX: 0,
+            sourceY: 10,
+            sourceWidth: 10,
+            sourceHeight: 5,
+            cellOffsetY: 19);
+
+        var middle = placement.ClipRows(
+            image,
+            firstRow: 1,
+            retainedRows: 1,
+            resultRow: 0,
+            cellPixelHeight: 0);
+
+        Assert.IsNotNull(middle);
+        Assert.AreEqual(11u, middle.SourceY);
+        Assert.AreEqual(3u, middle.SourceHeight);
+        Assert.AreEqual(0u, middle.CellOffsetY);
+    }
+
+    [TestMethod]
+    public void ClipRectangle_WithoutCellMetrics_UsesFloorStartAndCeilingEndOnBothAxes()
+    {
+        var image = new KgpImageData(
+            imageId: 1,
+            imageNumber: 0,
+            KgpTestHelper.CreatePixelData(5, 5),
+            width: 5,
+            height: 5,
+            KgpFormat.Rgba32);
+        var placement = new KgpPlacement(
+            imageId: 1,
+            placementId: 1,
+            row: 0,
+            column: 0,
+            displayColumns: 3,
+            displayRows: 3,
+            cellOffsetX: 9,
+            cellOffsetY: 19);
+
+        var clipped = placement.ClipToCellRectangle(
+            image,
+            top: 1,
+            bottomExclusive: 2,
+            left: 1,
+            rightExclusive: 2,
+            cellPixelWidth: 0,
+            cellPixelHeight: 0);
+
+        Assert.IsNotNull(clipped);
+        Assert.AreEqual(1, clipped.Row);
+        Assert.AreEqual(1, clipped.Column);
+        Assert.AreEqual(1u, clipped.DisplayColumns);
+        Assert.AreEqual(1u, clipped.DisplayRows);
+        Assert.AreEqual(1u, clipped.SourceX);
+        Assert.AreEqual(1u, clipped.SourceY);
+        Assert.AreEqual(3u, clipped.SourceWidth);
+        Assert.AreEqual(3u, clipped.SourceHeight);
+        Assert.AreEqual(0u, clipped.CellOffsetX);
+        Assert.AreEqual(0u, clipped.CellOffsetY);
+    }
+
+    [TestMethod]
+    public void ClipRows_WithCellOffset_UsesDestinationPixelFraction()
+    {
+        var image = new KgpImageData(
+            imageId: 1,
+            imageNumber: 0,
+            KgpTestHelper.CreatePixelData(10, 30),
+            width: 10,
+            height: 30,
+            KgpFormat.Rgba32);
+        var placement = new KgpPlacement(
+            imageId: 1,
+            placementId: 1,
+            row: 0,
+            column: 0,
+            displayColumns: 1,
+            displayRows: 2,
+            cellOffsetY: 5);
+
+        var topClipped = placement.ClipRows(
+            image,
+            firstRow: 1,
+            retainedRows: 1,
+            resultRow: 0,
+            cellPixelHeight: 10);
+        var bottomClipped = placement.ClipRows(
+            image,
+            firstRow: 0,
+            retainedRows: 1,
+            resultRow: 0,
+            cellPixelHeight: 10);
+
+        Assert.IsNotNull(topClipped);
+        Assert.AreEqual(10u, topClipped.SourceY);
+        Assert.AreEqual(20u, topClipped.SourceHeight);
+        Assert.AreEqual(0u, topClipped.CellOffsetY);
+        Assert.IsNotNull(bottomClipped);
+        Assert.AreEqual(0u, bottomClipped.SourceY);
+        Assert.AreEqual(10u, bottomClipped.SourceHeight);
+        Assert.AreEqual(5u, bottomClipped.CellOffsetY);
+    }
+
+    [TestMethod]
+    public void FullScreenScroll_WithoutScrollback_ClipsMultirowPlacementAtViewport()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, height: 4);
+        PlaceImage(terminal, 1, 10, 30, displayColumns: 1, displayRows: 3);
+
+        Apply(terminal, "\x1b[S");
+        AssertPlacement(
+            terminal.CreateSnapshot(),
+            row: 0,
+            rows: 2,
+            sourceY: 10,
+            sourceHeight: 20);
+
+        Apply(terminal, "\x1b[S");
+        AssertPlacement(
+            terminal.CreateSnapshot(),
+            row: 0,
+            rows: 1,
+            sourceY: 20,
+            sourceHeight: 10);
+
+        Apply(terminal, "\x1b[S");
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
+    }
+
+    [TestMethod]
+    public void MainHistory_Ed2ClipsVisibleTailAndEd3ReleasesHistory()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            height: 4,
+            scrollbackCapacity: 3);
+        PlaceImage(terminal, 1, 10, 30, displayColumns: 1, displayRows: 3);
+        Apply(terminal, "\x1b[S");
+
+        Apply(terminal, "\x1b[2J");
+
+        using (var active = terminal.CreateSnapshot())
+            Assert.IsEmpty(active.KgpPlacements);
+        AssertPlacement(
+            terminal.CreateSnapshot(scrollbackLines: 1),
+            row: 0,
+            rows: 1,
+            sourceY: 0,
+            sourceHeight: 10);
+        AssertHistoryOwner(terminal, expectedPlacements: 1, expectedReferences: 1);
+
+        Apply(terminal, "\x1b[3J");
+
+        Assert.AreEqual(0, terminal.ScrollbackCount);
+        Assert.AreEqual(0, terminal.KgpHistoryPlacementCount);
+        Assert.AreEqual(0, terminal.GetKgpHistoryReferenceCount(1));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+    }
+
+    [TestMethod]
+    public void AlternateScreen_ScrollAndEd3_PreserveMainHistory()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            height: 4,
+            scrollbackCapacity: 3);
+        PlaceImage(terminal, 1, 10, 20, displayColumns: 1, displayRows: 2);
+        Apply(terminal, "\x1b[S");
+
+        Apply(terminal, "\x1b[?1049h");
+        PlaceImage(terminal, 2, 10, 10, displayColumns: 1, displayRows: 1);
+        Apply(terminal, "\x1b[S\x1b[3J");
+        using (var alternate = terminal.CreateSnapshot(scrollbackLines: 3))
+        {
+            Assert.IsTrue(alternate.InAlternateScreen);
+            Assert.IsEmpty(alternate.KgpPlacements);
+            Assert.AreEqual(0, alternate.ScrollbackLineCount);
+        }
+
+        Apply(terminal, "\x1b[?1049l");
+
+        using var restored = terminal.CreateSnapshot(scrollbackLines: 1);
+        Assert.IsFalse(restored.InAlternateScreen);
+        var placement = SinglePlacement(restored);
+        Assert.AreEqual(1u, placement.ImageId);
+        Assert.AreEqual(2u, placement.DisplayRows);
+        Assert.IsTrue(restored.KgpImages.ContainsKey(1));
+        Assert.AreEqual(1, terminal.ScrollbackCount);
+        AssertHistoryOwner(terminal, expectedPlacements: 1, expectedReferences: 1);
+    }
+
+    [TestMethod]
+    public void Ris_ClearsHistoryPlacementsReferencesAndData()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            height: 4,
+            scrollbackCapacity: 3);
+        PlaceImage(terminal, 1, 10, 20, displayColumns: 1, displayRows: 2);
+        Apply(terminal, "\x1b[S");
+
+        Apply(terminal, "\x1b" + "c");
+
+        Assert.AreEqual(0, terminal.ScrollbackCount);
+        Assert.AreEqual(0, terminal.KgpHistoryPlacementCount);
+        Assert.AreEqual(0, terminal.GetKgpHistoryReferenceCount(1));
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        using var snapshot = terminal.CreateSnapshot(scrollbackLines: 3);
+        Assert.IsEmpty(snapshot.KgpPlacements);
+        Assert.IsEmpty(snapshot.KgpImages);
+    }
+
+    [TestMethod]
+    public void Snapshot_SubsetOfHistory_MaterializesTailWhoseAnchorIsNotSelected()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            height: 4,
+            scrollbackCapacity: 4);
+        PlaceImage(terminal, 1, 10, 30, displayColumns: 1, displayRows: 3);
+        Apply(terminal, "\x1b[S\x1b[S\x1b[S");
+
+        using var snapshot = terminal.CreateSnapshot(scrollbackLines: 1);
+        Assert.AreEqual(1, snapshot.ScrollbackLineCount);
+        var placement = SinglePlacement(snapshot);
+        Assert.AreEqual(0, placement.Row);
+        Assert.AreEqual(1u, placement.DisplayRows);
+        Assert.AreEqual(20u, placement.SourceY);
+        Assert.AreEqual(10u, placement.SourceHeight);
+        Assert.IsTrue(snapshot.KgpImages.ContainsKey(1));
+    }
+
+    [TestMethod]
+    public void Snapshot_HistoryPlacementRemainsImmutableAfterLivePruning()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            height: 4,
+            scrollbackCapacity: 1);
+        PlaceImage(terminal, 1, 10, 20, displayColumns: 1, displayRows: 2);
+        Apply(terminal, "\x1b[S");
+        using var snapshot = terminal.CreateSnapshot(scrollbackLines: 1);
+        var captured = SinglePlacement(snapshot);
+
+        Apply(terminal, "\x1b[S\x1b[S");
+
+        Assert.AreEqual(0, terminal.KgpHistoryPlacementCount);
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.AreEqual(0, captured.Row);
+        Assert.AreEqual(2u, captured.DisplayRows);
+        Assert.AreEqual(0u, captured.SourceY);
+        Assert.AreEqual(20u, captured.SourceHeight);
+        Assert.AreEqual(0xFF, snapshot.KgpImages[1].Data[0]);
+    }
+
+    [TestMethod]
+    public void SharedImage_MultipleHistoryPlacementsRetainIndependentReferences()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            height: 4,
+            scrollbackCapacity: 4);
+        Apply(terminal, KgpTestHelper.BuildTransmitCommand(1, 10, 10, quiet: 2));
+        Apply(terminal, "\x1b[1;1H");
+        Apply(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 1, displayColumns: 1, displayRows: 1, cursorMovement: 1));
+        Apply(terminal, "\x1b[2;1H");
+        Apply(terminal, KgpTestHelper.BuildPutCommand(1, placementId: 2, displayColumns: 1, displayRows: 1, cursorMovement: 1));
+
+        Apply(terminal, "\x1b[S\x1b[S");
+
+        Assert.AreEqual(2, terminal.KgpHistoryPlacementCount);
+        Assert.AreEqual(2, terminal.GetKgpHistoryReferenceCount(1));
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
+        using var snapshot = terminal.CreateSnapshot(scrollbackLines: 2);
+        Assert.AreEqual(2, snapshot.KgpPlacements.Count);
+        TestSeq.All(
+            snapshot.KgpPlacements,
+            placement => Assert.IsTrue(snapshot.KgpImages.ContainsKey(placement.ImageId)));
+    }
+
+    [TestMethod]
+    public void RetransmitImageId_RemovesHistoryPlacementBeforeReplacingData()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            height: 4,
+            scrollbackCapacity: 3);
+        PlaceImage(terminal, 1, 10, 10, displayColumns: 1, displayRows: 1);
+        Apply(terminal, "\x1b[S");
+        AssertHistoryOwner(terminal, expectedPlacements: 1, expectedReferences: 1);
+
+        Apply(
+            terminal,
+            KgpTestHelper.BuildTransmitCommand(
+                1,
+                20,
+                10,
+                quiet: 2,
+                fillByte: 0x44));
+
+        Assert.AreEqual(0, terminal.KgpHistoryPlacementCount);
+        Assert.AreEqual(0, terminal.GetKgpHistoryReferenceCount(1));
+        var replacement = terminal.KgpImageStore.GetImageById(1);
+        Assert.IsNotNull(replacement);
+        Assert.AreEqual(20u, replacement.Width);
+        Assert.AreEqual(0x44, replacement.Data[0]);
+        using var snapshot = terminal.CreateSnapshot(scrollbackLines: 1);
+        Assert.IsEmpty(snapshot.KgpPlacements);
+        Assert.IsEmpty(snapshot.KgpImages);
+    }
+
+    [TestMethod]
+    public void FreeImageData_AfterHistoryScroll_ReconcilesHistoryWithoutDanglingPlacement()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            height: 4,
+            scrollbackCapacity: 2);
+        PlaceImage(terminal, 1, 10, 10, displayColumns: 1, displayRows: 1);
+        Apply(terminal, "\x1b[S");
+
+        Apply(terminal, KgpTestHelper.BuildDeleteCommand('A'));
+
+        Assert.AreEqual(0, terminal.KgpHistoryPlacementCount);
+        Assert.AreEqual(0, terminal.GetKgpHistoryReferenceCount(1));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+        using var snapshot = terminal.CreateSnapshot(scrollbackLines: 1);
+        Assert.IsEmpty(snapshot.KgpPlacements);
+        Assert.IsEmpty(snapshot.KgpImages);
+    }
+
+    [TestMethod]
+    public void ExternalImageRemoval_AfterHistoryScroll_IsReconciledBeforeSnapshot()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            height: 4,
+            scrollbackCapacity: 2);
+        PlaceImage(terminal, 1, 10, 10, displayColumns: 1, displayRows: 1);
+        Apply(terminal, "\x1b[S");
+
+        Assert.IsTrue(terminal.KgpImageStore.RemoveImage(1));
+
+        using var snapshot = terminal.CreateSnapshot(scrollbackLines: 1);
+        Assert.IsEmpty(snapshot.KgpPlacements);
+        Assert.IsEmpty(snapshot.KgpImages);
+        Assert.AreEqual(0, terminal.KgpHistoryPlacementCount);
+        Assert.AreEqual(0, terminal.GetKgpHistoryReferenceCount(1));
+    }
+
+    [TestMethod]
+    public void Dispose_ReleasesHistoryPlacementsAndImageData()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        var terminal = CreateTerminal(
+            workload,
+            height: 4,
+            scrollbackCapacity: 2);
+        PlaceImage(terminal, 1, 10, 20, displayColumns: 1, displayRows: 2);
+        Apply(terminal, "\x1b[S");
+
+        terminal.Dispose();
+
+        Assert.AreEqual(0, terminal.ScrollbackCount);
+        Assert.AreEqual(0, terminal.KgpHistoryPlacementCount);
+        Assert.AreEqual(0, terminal.GetKgpHistoryReferenceCount(1));
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+    }
+
+    [TestMethod]
+    public void ResizeWithBuiltInReflow_PromotesHistoryAnchorWithoutLosingImage()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 4,
+            height: 3,
+            scrollbackCapacity: 4,
+            reflow: KittyReflowStrategy.Instance);
+        Apply(terminal, "ABCD");
+        Apply(terminal, "\x1b[1;1H");
+        Apply(
+            terminal,
+            KgpTestHelper.BuildTransmitAndDisplayCommand(
+                1,
+                10,
+                10,
+                displayColumns: 1,
+                displayRows: 1,
+                cursorMovement: 1,
+                quiet: 2));
+        Apply(terminal, "\x1b[S");
+
+        terminal.Resize(2, 3);
+
+        Assert.AreEqual(0, terminal.ScrollbackCount);
+        Assert.AreEqual(0, terminal.KgpHistoryPlacementCount);
+        Assert.AreEqual(0, terminal.GetKgpHistoryReferenceCount(1));
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
+        using var snapshot = terminal.CreateSnapshot();
+        var placement = SinglePlacement(snapshot);
+        Assert.AreEqual(0, placement.Row);
+        Assert.AreEqual(1u, placement.DisplayRows);
+        Assert.IsTrue(snapshot.KgpImages.ContainsKey(1));
+    }
+
+    [TestMethod]
+    public void ResizeWithBuiltInReflow_CapacityDiscardClipsAndReanchorsHistoryTail()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 4,
+            height: 2,
+            scrollbackCapacity: 1,
+            reflow: KittyReflowStrategy.Instance);
+        Apply(terminal, "\x1b[1;1HABCD\x1b[2;1HEFGH\x1b[1;1H");
+        Apply(
+            terminal,
+            KgpTestHelper.BuildTransmitAndDisplayCommand(
+                1,
+                10,
+                20,
+                displayColumns: 1,
+                displayRows: 2,
+                cursorMovement: 1,
+                quiet: 2));
+        Apply(terminal, "\x1b[S\x1b[2;1HIJKL\x1b[1;1H");
+
+        terminal.Resize(2, 2);
+
+        Assert.AreEqual(1, terminal.ScrollbackCount);
+        AssertHistoryOwner(terminal, expectedPlacements: 1, expectedReferences: 1);
+        AssertPlacement(
+            terminal.CreateSnapshot(scrollbackLines: 1),
+            row: 0,
+            rows: 1,
+            sourceY: 10,
+            sourceHeight: 10);
+        using var active = terminal.CreateSnapshot();
+        Assert.IsEmpty(active.KgpPlacements);
+    }
+
+    [TestMethod]
+    public void ResizeWithThirdPartyReflow_ReleasesUnprovableHistorySafely()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 4,
+            height: 3,
+            scrollbackCapacity: 4,
+            reflow: new ThirdPartyNoReflowProvider());
+        Apply(terminal, "ABCD");
+        Apply(terminal, "\x1b[1;1H");
+        Apply(
+            terminal,
+            KgpTestHelper.BuildTransmitAndDisplayCommand(
+                1,
+                10,
+                10,
+                displayColumns: 1,
+                displayRows: 1,
+                cursorMovement: 1,
+                quiet: 2));
+        Apply(terminal, "\x1b[S");
+
+        terminal.Resize(2, 3);
+
+        Assert.AreEqual(0, terminal.KgpHistoryPlacementCount);
+        Assert.AreEqual(0, terminal.GetKgpHistoryReferenceCount(1));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+        using var snapshot = terminal.CreateSnapshot(scrollbackLines: terminal.ScrollbackCount);
+        Assert.IsEmpty(snapshot.KgpPlacements);
+        Assert.IsEmpty(snapshot.KgpImages);
+    }
+
+    [TestMethod]
+    public void ResizeWithCrop_ClipsActiveDestinationAndSource()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 6, height: 5);
+        PlaceImage(
+            terminal,
+            1,
+            imageWidth: 20,
+            imageHeight: 20,
+            displayColumns: 2,
+            displayRows: 2,
+            row: 2,
+            column: 3);
+
+        terminal.Resize(4, 3);
+
+        using var snapshot = terminal.CreateSnapshot();
+        var placement = SinglePlacement(snapshot);
+        Assert.AreEqual(2, placement.Row);
+        Assert.AreEqual(3, placement.Column);
+        Assert.AreEqual(1u, placement.DisplayRows);
+        Assert.AreEqual(1u, placement.DisplayColumns);
+        Assert.AreEqual(10u, placement.SourceWidth);
+        Assert.AreEqual(10u, placement.SourceHeight);
+        Assert.AreEqual(0u, placement.SourceX);
+        Assert.AreEqual(0u, placement.SourceY);
+    }
+
+    [TestMethod]
+    public void Snapshot_OriginalScrollbackWidth_PreservesHistoricalPlacementColumns()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 6,
+            height: 3,
+            scrollbackCapacity: 2);
+        PlaceImage(
+            terminal,
+            1,
+            imageWidth: 20,
+            imageHeight: 10,
+            displayColumns: 2,
+            displayRows: 1,
+            row: 0,
+            column: 4);
+        Apply(terminal, "\x1b[S");
+        terminal.Resize(3, 3);
+
+        using (var currentWidth = terminal.CreateSnapshot(
+            scrollbackLines: 1,
+            scrollbackWidth: ScrollbackWidth.CurrentTerminal))
+        {
+            Assert.IsEmpty(currentWidth.KgpPlacements);
+            Assert.IsEmpty(currentWidth.KgpImages);
+        }
+
+        using var originalWidth = terminal.CreateSnapshot(
+            scrollbackLines: 1,
+            scrollbackWidth: ScrollbackWidth.Original);
+        Assert.AreEqual(6, originalWidth.Width);
+        var placement = SinglePlacement(originalWidth);
+        Assert.AreEqual(0, placement.Row);
+        Assert.AreEqual(4, placement.Column);
+        Assert.AreEqual(2u, placement.DisplayColumns);
+        Assert.IsTrue(originalWidth.KgpImages.ContainsKey(1));
+    }
+
+    private static void AssertPlacement(
+        Hex1bTerminalSnapshot snapshot,
+        int row,
+        uint rows,
+        uint sourceY,
+        uint sourceHeight)
+    {
+        using (snapshot)
+        {
+            var placement = SinglePlacement(snapshot);
+            Assert.AreEqual(row, placement.Row);
+            Assert.AreEqual(rows, placement.DisplayRows);
+            Assert.AreEqual(sourceY, placement.SourceY);
+            Assert.AreEqual(sourceHeight, placement.SourceHeight);
+            Assert.IsTrue(snapshot.KgpImages.ContainsKey(placement.ImageId));
+        }
+    }
+
+    private static void AssertHistoryOwner(
+        Hex1bTerminal terminal,
+        int expectedPlacements,
+        int expectedReferences)
+    {
+        Assert.AreEqual(expectedPlacements, terminal.KgpHistoryPlacementCount);
+        Assert.AreEqual(expectedReferences, terminal.GetKgpHistoryReferenceCount(1));
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
+    }
+
+    private sealed class ThirdPartyNoReflowProvider : ITerminalReflowProvider
+    {
+        public bool ShouldClearSoftWrapOnAbsolutePosition => false;
+
+        public ReflowResult Reflow(ReflowContext context)
+            => NoReflowStrategy.Instance.Reflow(context);
+    }
+}

--- a/tests/Hex1b.Tests/KgpScrollingTests.cs
+++ b/tests/Hex1b.Tests/KgpScrollingTests.cs
@@ -1038,6 +1038,59 @@ public class KgpScrollingTests
     }
 
     [TestMethod]
+    [DataRow(false)]
+    [DataRow(true)]
+    public void MainNoReflowResize_TrimmedHistoryTailDoesNotResurrect(
+        bool explicitNoReflow)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 6,
+            height: 4,
+            scrollbackCapacity: 2,
+            reflow: explicitNoReflow ? NoReflowStrategy.Instance : null);
+        Apply(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=T,f=32,s=10,v=80,i=1,p=1,x=0,y=10,w=10,h=60,c=1,r=3,C=1,q=2",
+                KgpTestHelper.CreatePixelData(10, 80)));
+        Apply(terminal, "\x1b[S");
+
+        terminal.Resize(6, 1);
+
+        AssertHistoryOwner(terminal, expectedPlacements: 1, expectedReferences: 1);
+        AssertPlacement(
+            terminal.CreateSnapshot(scrollbackLines: 1),
+            row: 0,
+            rows: 2,
+            sourceY: 10,
+            sourceHeight: 40);
+        AssertPlacement(
+            terminal.CreateSnapshot(),
+            row: 0,
+            rows: 1,
+            sourceY: 30,
+            sourceHeight: 20);
+
+        terminal.Resize(6, 4);
+
+        AssertHistoryOwner(terminal, expectedPlacements: 1, expectedReferences: 1);
+        AssertPlacement(
+            terminal.CreateSnapshot(scrollbackLines: 1),
+            row: 0,
+            rows: 2,
+            sourceY: 10,
+            sourceHeight: 40);
+        AssertPlacement(
+            terminal.CreateSnapshot(),
+            row: 0,
+            rows: 1,
+            sourceY: 30,
+            sourceHeight: 20);
+    }
+
+    [TestMethod]
     public void PngUnknownDimensions_PlacementUsesDestinationOnlyScrollClipping()
     {
         using var workload = new Hex1bAppWorkloadAdapter();

--- a/tests/Hex1b.Tests/KgpScrollingTests.cs
+++ b/tests/Hex1b.Tests/KgpScrollingTests.cs
@@ -998,7 +998,8 @@ public class KgpScrollingTests
             workload,
             width: 6,
             height: 3,
-            scrollbackCapacity: 2);
+            scrollbackCapacity: 2,
+            reflow: NoReflowStrategy.Instance);
         PlaceImage(
             terminal,
             1,
@@ -1028,6 +1029,400 @@ public class KgpScrollingTests
         Assert.AreEqual(4, placement.Column);
         Assert.AreEqual(2u, placement.DisplayColumns);
         Assert.IsTrue(originalWidth.KgpImages.ContainsKey(1));
+
+        terminal.Resize(6, 3);
+        using var enlarged = terminal.CreateSnapshot(scrollbackLines: 1);
+        var enlargedPlacement = SinglePlacement(enlarged);
+        Assert.AreEqual(4, enlargedPlacement.Column);
+        Assert.AreEqual(2u, enlargedPlacement.DisplayColumns);
+    }
+
+    [TestMethod]
+    public void PngUnknownDimensions_PlacementUsesDestinationOnlyScrollClipping()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, height: 4);
+        Apply(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=T,f=100,i=1,p=1,c=1,r=2,C=1,q=2",
+                [0x89, 0x50, 0x4E, 0x47]));
+
+        var initial = TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(2u, initial.DisplayRows);
+        Assert.AreEqual(0u, initial.SourceX);
+        Assert.AreEqual(0u, initial.SourceY);
+        Assert.AreEqual(0u, initial.SourceWidth);
+        Assert.AreEqual(0u, initial.SourceHeight);
+        Assert.AreEqual(0u, terminal.KgpImageStore.GetImageById(1)!.Width);
+        Assert.AreEqual(0u, terminal.KgpImageStore.GetImageById(1)!.Height);
+
+        Apply(terminal, "\x1b[S");
+
+        var clipped = TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(0, clipped.Row);
+        Assert.AreEqual(1u, clipped.DisplayRows);
+        Assert.AreEqual(0u, clipped.SourceX);
+        Assert.AreEqual(0u, clipped.SourceY);
+        Assert.AreEqual(0u, clipped.SourceWidth);
+        Assert.AreEqual(0u, clipped.SourceHeight);
+
+        Apply(terminal, "\x1b[S");
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
+    }
+
+    [TestMethod]
+    public void PngUnknownDimensions_HistoryReanchorsUntilDestinationIsPruned()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            height: 4,
+            scrollbackCapacity: 1);
+        Apply(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=T,f=100,i=1,p=1,c=1,r=2,C=1,q=2",
+                [0x89, 0x50, 0x4E, 0x47]));
+
+        Apply(terminal, "\x1b[S");
+        using (var first = terminal.CreateSnapshot(scrollbackLines: 1))
+        {
+            var placement = SinglePlacement(first);
+            Assert.AreEqual(2u, placement.DisplayRows);
+            Assert.AreEqual(0u, placement.SourceWidth);
+            Assert.AreEqual(0u, placement.SourceHeight);
+        }
+        AssertHistoryOwner(terminal, expectedPlacements: 1, expectedReferences: 1);
+
+        Apply(terminal, "\x1b[S");
+        using (var second = terminal.CreateSnapshot(scrollbackLines: 1))
+        {
+            var placement = SinglePlacement(second);
+            Assert.AreEqual(1u, placement.DisplayRows);
+            Assert.AreEqual(0u, placement.SourceWidth);
+            Assert.AreEqual(0u, placement.SourceHeight);
+        }
+        AssertHistoryOwner(terminal, expectedPlacements: 1, expectedReferences: 1);
+
+        Apply(terminal, "\x1b[S");
+        Assert.AreEqual(0, terminal.KgpHistoryPlacementCount);
+        Assert.AreEqual(0, terminal.GetKgpHistoryReferenceCount(1));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+    }
+
+    [TestMethod]
+    public void Put_NonzeroPair_ReplacesExactActiveAndHistoryPlacement()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            height: 4,
+            scrollbackCapacity: 3);
+        Apply(terminal, KgpTestHelper.BuildTransmitCommand(1, 10, 10, quiet: 2));
+        Apply(terminal, "\x1b[1;1H");
+        Apply(terminal, KgpTestHelper.BuildPutCommand(
+            1,
+            placementId: 7,
+            displayColumns: 1,
+            displayRows: 1,
+            cursorMovement: 1));
+        Apply(terminal, KgpTestHelper.BuildPutCommand(
+            1,
+            placementId: 8,
+            displayColumns: 1,
+            displayRows: 1,
+            cursorMovement: 1));
+        Apply(terminal, "\x1b[S");
+        Assert.AreEqual(2, terminal.KgpHistoryPlacementCount);
+        Assert.AreEqual(2, terminal.GetKgpHistoryReferenceCount(1));
+
+        Apply(terminal, "\x1b[3;2H");
+        Apply(terminal, KgpTestHelper.BuildPutCommand(
+            1,
+            placementId: 7,
+            displayColumns: 2,
+            displayRows: 1,
+            cursorMovement: 1));
+
+        Assert.AreEqual(1, terminal.KgpHistoryPlacementCount);
+        Assert.AreEqual(1, terminal.GetKgpHistoryReferenceCount(1));
+        var active = TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(7u, active.PlacementId);
+        Assert.AreEqual(2, active.Row);
+        Assert.AreEqual(1, active.Column);
+        Assert.AreEqual(2u, active.DisplayColumns);
+        using var withHistory = terminal.CreateSnapshot(scrollbackLines: 1);
+        var placements = withHistory.KgpPlacements
+            .OrderBy(placement => placement.PlacementId)
+            .ToArray();
+        Assert.AreEqual(2, placements.Length);
+        Assert.AreEqual(7u, placements[0].PlacementId);
+        Assert.AreEqual(8u, placements[1].PlacementId);
+    }
+
+    [TestMethod]
+    public void Put_ZeroPlacementId_RemainsAppendOnlyAcrossHistory()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            height: 4,
+            scrollbackCapacity: 2);
+        Apply(terminal, KgpTestHelper.BuildTransmitCommand(1, 10, 10, quiet: 2));
+        Apply(terminal, "\x1b[1;1H");
+        Apply(terminal, KgpTestHelper.BuildPutCommand(
+            1,
+            displayColumns: 1,
+            displayRows: 1,
+            cursorMovement: 1));
+        Apply(terminal, "\x1b[S\x1b[2;1H");
+        Apply(terminal, KgpTestHelper.BuildPutCommand(
+            1,
+            displayColumns: 1,
+            displayRows: 1,
+            cursorMovement: 1));
+
+        Assert.AreEqual(1, terminal.KgpHistoryPlacementCount);
+        Assert.AreEqual(1, terminal.GetKgpHistoryReferenceCount(1));
+        using var snapshot = terminal.CreateSnapshot(scrollbackLines: 1);
+        Assert.AreEqual(2, snapshot.KgpPlacements.Count);
+        TestSeq.All(
+            snapshot.KgpPlacements,
+            placement => Assert.AreEqual(0u, placement.PlacementId));
+    }
+
+    [TestMethod]
+    public void Put_NonzeroPair_InAlternateScreen_DoesNotReplaceMainHistory()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            height: 4,
+            scrollbackCapacity: 2);
+        Apply(terminal, KgpTestHelper.BuildTransmitCommand(1, 10, 10, quiet: 2));
+        Apply(terminal, "\x1b[1;1H");
+        Apply(terminal, KgpTestHelper.BuildPutCommand(
+            1,
+            placementId: 7,
+            displayColumns: 1,
+            displayRows: 1,
+            cursorMovement: 1));
+        Apply(terminal, "\x1b[S\x1b[?1049h");
+        Apply(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=T,f=32,s=10,v=10,i=1,p=7,c=1,r=1,C=1,q=2",
+                KgpTestHelper.CreatePixelData(10, 10, fillByte: 0x44)));
+        Apply(terminal, "\x1b[?1049l");
+
+        AssertHistoryOwner(terminal, expectedPlacements: 1, expectedReferences: 1);
+        using var snapshot = terminal.CreateSnapshot(scrollbackLines: 1);
+        var placement = SinglePlacement(snapshot);
+        Assert.AreEqual(7u, placement.PlacementId);
+        Assert.AreEqual(0xFF, snapshot.KgpImages[1].Data[0]);
+    }
+
+    [TestMethod]
+    public void NoReflow_ActiveAnchorOutsideShrinkViewport_DoesNotClampOrResurrect()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 6,
+            height: 3,
+            reflow: NoReflowStrategy.Instance);
+        PlaceImage(
+            terminal,
+            1,
+            imageWidth: 20,
+            imageHeight: 10,
+            displayColumns: 2,
+            displayRows: 1,
+            column: 4);
+
+        terminal.Resize(3, 3);
+        Assert.IsEmpty(terminal.KgpPlacements);
+
+        terminal.Resize(6, 3);
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
+    }
+
+    [TestMethod]
+    public void BuiltInReflow_BlankRowHeightChange_PreservesAnchorColumn()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 6,
+            height: 4,
+            reflow: KittyReflowStrategy.Instance);
+        PlaceImage(
+            terminal,
+            1,
+            imageWidth: 10,
+            imageHeight: 10,
+            displayColumns: 1,
+            displayRows: 1,
+            column: 4);
+
+        terminal.Resize(6, 3);
+
+        var placement = TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(4, placement.Column);
+    }
+
+    [TestMethod]
+    public void BuiltInReflow_BlankRowWidthChange_ClampsAnchorColumnInsteadOfCollapsingToZero()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 6,
+            height: 3,
+            reflow: KittyReflowStrategy.Instance);
+        PlaceImage(
+            terminal,
+            1,
+            imageWidth: 10,
+            imageHeight: 10,
+            displayColumns: 1,
+            displayRows: 1,
+            column: 4);
+
+        terminal.Resize(3, 3);
+
+        var placement = TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(2, placement.Column);
+    }
+
+    [TestMethod]
+    public void BuiltInReflow_PopulatedWrappedRow_MapsAnchorColumnWithText()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 6,
+            height: 3,
+            reflow: KittyReflowStrategy.Instance);
+        Apply(terminal, "ABCDEF\x1b[1;5H");
+        Apply(
+            terminal,
+            KgpTestHelper.BuildTransmitAndDisplayCommand(
+                1,
+                10,
+                10,
+                displayColumns: 1,
+                displayRows: 1,
+                cursorMovement: 1,
+                quiet: 2));
+
+        terminal.Resize(3, 3);
+
+        var placement = TestSeq.Single(terminal.KgpPlacements);
+        Assert.AreEqual(1, placement.Column);
+    }
+
+    [TestMethod]
+    public void AlternateResize_ExitCropsHiddenMainPlacementAndPreventsResurrection()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 6, height: 4);
+        PlaceImage(
+            terminal,
+            1,
+            imageWidth: 20,
+            imageHeight: 20,
+            displayColumns: 2,
+            displayRows: 2,
+            row: 2,
+            column: 4);
+        Apply(terminal, "\x1b[?1049h");
+
+        terminal.Resize(3, 2);
+        Apply(terminal, "\x1b[?1049l");
+
+        Assert.IsEmpty(terminal.KgpPlacements);
+        terminal.Resize(6, 4);
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
+    }
+
+    [TestMethod]
+    public void AlternateResize_ExitPermanentlyClipsPartiallyVisibleMainPlacement()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 6, height: 4);
+        PlaceImage(
+            terminal,
+            1,
+            imageWidth: 20,
+            imageHeight: 20,
+            displayColumns: 2,
+            displayRows: 2,
+            row: 1,
+            column: 2);
+        Apply(terminal, "\x1b[?1049h");
+
+        terminal.Resize(3, 2);
+        Apply(terminal, "\x1b[?1049l");
+
+        using (var cropped = terminal.CreateSnapshot())
+        {
+            var placement = SinglePlacement(cropped);
+            Assert.AreEqual(1, placement.Row);
+            Assert.AreEqual(2, placement.Column);
+            Assert.AreEqual(1u, placement.DisplayRows);
+            Assert.AreEqual(1u, placement.DisplayColumns);
+            Assert.AreEqual(10u, placement.SourceWidth);
+            Assert.AreEqual(10u, placement.SourceHeight);
+        }
+
+        terminal.Resize(6, 4);
+        using var enlarged = terminal.CreateSnapshot();
+        var enlargedPlacement = SinglePlacement(enlarged);
+        Assert.AreEqual(1u, enlargedPlacement.DisplayRows);
+        Assert.AreEqual(1u, enlargedPlacement.DisplayColumns);
+        Assert.AreEqual(10u, enlargedPlacement.SourceWidth);
+        Assert.AreEqual(10u, enlargedPlacement.SourceHeight);
+    }
+
+    [TestMethod]
+    public void AlternateResize_ExitTrimsMainHistoryTailToCurrentHeight()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 6,
+            height: 4,
+            scrollbackCapacity: 2);
+        PlaceImage(
+            terminal,
+            1,
+            imageWidth: 10,
+            imageHeight: 30,
+            displayColumns: 1,
+            displayRows: 3);
+        Apply(terminal, "\x1b[S\x1b[?1049h");
+
+        terminal.Resize(6, 1);
+        Apply(terminal, "\x1b[?1049l");
+
+        AssertPlacement(
+            terminal.CreateSnapshot(scrollbackLines: 1),
+            row: 0,
+            rows: 2,
+            sourceY: 0,
+            sourceHeight: 20);
+        terminal.Resize(6, 4);
+        AssertPlacement(
+            terminal.CreateSnapshot(scrollbackLines: 1),
+            row: 0,
+            rows: 2,
+            sourceY: 0,
+            sourceHeight: 20);
     }
 
     private static void AssertPlacement(

--- a/tests/Hex1b.Tests/KgpTerminalTests.cs
+++ b/tests/Hex1b.Tests/KgpTerminalTests.cs
@@ -1742,9 +1742,8 @@ public class KgpTerminalTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[5;1H")); // Go to last row
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\n")); // This triggers scroll
 
-        // After scroll, placement row should decrease by 1 (scrolled up)
-        // Note: This test documents the expected behavior - implementation
-        // may need to handle placement scrolling in the scroll logic
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
     }
 
     // =============================================

--- a/tests/Hex1b.Tests/ScrollbackBufferTests.cs
+++ b/tests/Hex1b.Tests/ScrollbackBufferTests.cs
@@ -222,4 +222,55 @@ public class ScrollbackBufferTests
         var buffer = CreateBuffer(42);
         Assert.AreEqual(42, buffer.Capacity);
     }
+
+    [TestMethod]
+    public void PushWithIdentity_AtCapacity_ReportsRetainedSuccessor()
+    {
+        var pruned = new List<ScrollbackPrunedRow>();
+        var buffer = new ScrollbackBuffer(1, pruned.Add);
+
+        var first = buffer.PushWithIdentity(
+            MakeRow("A"),
+            10,
+            DateTimeOffset.UtcNow);
+        var second = buffer.PushWithIdentity(
+            MakeRow("B"),
+            10,
+            DateTimeOffset.UtcNow);
+
+        var notification = TestSeq.Single(pruned);
+        Assert.AreEqual(first.RowId, notification.RowId);
+        Assert.AreEqual(second.RowId, notification.SuccessorRowId);
+        Assert.AreEqual(ScrollbackPruneReason.Capacity, notification.Reason);
+        Assert.AreEqual(first.RowId, second.EvictedRowId);
+    }
+
+    [TestMethod]
+    public void Clear_ReportsAllRowsWithoutSuccessors()
+    {
+        var pruned = new List<ScrollbackPrunedRow>();
+        var buffer = new ScrollbackBuffer(2, pruned.Add);
+        var first = buffer.PushWithIdentity(
+            MakeRow("A"),
+            10,
+            DateTimeOffset.UtcNow);
+        var second = buffer.PushWithIdentity(
+            MakeRow("B"),
+            10,
+            DateTimeOffset.UtcNow);
+
+        buffer.Clear();
+
+        Assert.AreEqual(2, pruned.Count);
+        TestSeq.AreEqual(
+            new[] { first.RowId, second.RowId },
+            pruned.Select(notification => notification.RowId));
+        TestSeq.All(
+            pruned,
+            notification =>
+            {
+                Assert.IsNull(notification.SuccessorRowId);
+                Assert.AreEqual(ScrollbackPruneReason.Clear, notification.Reason);
+            });
+    }
 }


### PR DESCRIPTION
## Summary
- move ordinary KGP placements with full-screen text scrolling into stable main-screen history, retaining image data until the last visible/retained destination slice is pruned
- clip scaled and cropped source/destination geometry exactly across top and bottom boundaries, including capacity-1/capacity-2 re-anchoring and zero-cell-metric fallbacks
- preserve valid PNG/unknown-dimension placements with destination-only clipping until future PNG decoding supplies source dimensions
- replace exact nonzero image/placement pairs across active and current-screen history while preserving `p=0` append semantics and screen isolation
- apply Kitty/Ghostty-compatible bounded-margin behavior: move only wholly contained placements, respect horizontal margins, keep straddling/outside/status/history placements pinned, and leave ordinary placements fixed for IL/DL
- preserve literal no-reflow columns, blank-row anchor columns during built-in reflow, and permanently trim history tails on main/alternate no-reflow height shrink so later enlargement cannot resurrect rows or pixels
- preserve ED2/ED3/RIS/disposal cleanup, optional-history snapshots, third-party reflow safety, and byte-for-byte presentation passthrough

## Compatibility and ownership
- extends the per-screen `KgpTerminalGraphicsState` and `HistoryReferences` contract from #413 rather than adding another image owner
- assigns internal identities to circular scrollback rows; anchor eviction clips and transfers a placement to the next retained row without duplicating or prematurely releasing its single history reference
- keeps public `ITerminalReflowProvider`, `ReflowContext`, and `ReflowResult` shapes unchanged; built-ins use a separate internal anchor pipeline
- reconciles placements after store-side data removal so quota/deletion policy cannot leave a dangling active or history placement, without changing #405 or #406 policy
- leaves PNG payload dimension decoding to #391 and preserves zero source extents as unknown/full-source state

## #402 acceptance completed
This completes #402's scrollback ownership/pruning, history-aware clear/reset/disposal, and history snapshot coordinate/data acceptance. #402 remains open until #401 supplies Unicode-placeholder cell ownership; this PR does not close #402.

## Validation
- focused KGP/scrollback/reflow/passthrough suite: 800 passed
- serialized full `Hex1b.Tests`: 8,145 passed, 24 skipped (8,169 total)
- final default/explicit no-reflow history-trim regressions: 6 passed
- shipped `Hex1b` build: succeeded with 0 warnings and 0 errors
- independent follow-up review: no remaining high-confidence correctness issues

## Deferred scope
PNG payload decoding (#391), Unicode placeholders (#401), relative placement graphs (#399), animation frames (#403), quota policy (#405), general deletion selector semantics (#406), and widget/surface clipping remain unchanged.

Closes #400