### PR TITLE
Implement KGP relative image placements

### DIFF
--- a/src/Hex1b/Automation/TerminalRegionSvgExtensions.cs
+++ b/src/Hex1b/Automation/TerminalRegionSvgExtensions.cs
@@ -244,6 +244,9 @@ public static class TerminalRegionSvgExtensions
             var sortedPlacements = snapshot2.KgpPlacements
                 .OrderBy(placement => placement.ZIndex)
                 .ThenBy(placement => placement.ImageId)
+                .ThenBy(placement => placement.GraphId)
+                .ThenBy(placement => placement.Row)
+                .ThenBy(placement => placement.Column)
                 .ToList();
             var placeholderImageDefinitions =
                 new Dictionary<uint, (string ElementId, string DataUri)>();

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -4255,9 +4255,18 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 break;
             case ClearMode.All:
             case ClearMode.AllAndScrollback:
+                var visibleRelativeKgpGraphIds = mode == ClearMode.All
+                    ? CaptureActiveKgpPlacementsForMutation()
+                        .Where(placement => placement.RenderGeometry is null)
+                        .Select(placement => placement.GraphId)
+                        .Distinct()
+                        .ToArray()
+                    : [];
                 ClearBuffer(respectProtection, impacts);
                 if (mode == ClearMode.All)
                 {
+                    _kgpGraphicsState.RemoveActiveRelativePlacementsByGraphId(
+                        visibleRelativeKgpGraphIds);
                     var historyRows = _inAlternateScreen || _scrollbackBuffer is null
                         ? []
                         : _scrollbackBuffer.GetEntries(_scrollbackBuffer.Count);
@@ -6720,8 +6729,6 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
 
     private KgpImageStore ActiveKgpImageStore => _kgpGraphicsState.ActiveImageStore;
 
-    private List<KgpPlacement> ActiveKgpPlacements => _kgpGraphicsState.ActivePlacements;
-
     /// <summary>
     /// Gets the KGP image store for testing and inspection.
     /// </summary>
@@ -6738,6 +6745,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             {
                 _kgpGraphicsState.ReconcileActiveImageReferences();
                 if (_kgpGraphicsState.ActiveVirtualPlacementCount == 0 &&
+                    _kgpGraphicsState.ActivePlacements.All(
+                        placement => !placement.IsRelative) &&
                     (_inAlternateScreen ||
                      _scrollbackBuffer is null ||
                      _kgpGraphicsState.MainHistoryPlacementCount == 0))
@@ -7179,22 +7188,18 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 ? 0
                 : command.Display.PlacementId;
 
-        CreateKgpPlacement(
+        var placementError = CreateKgpPlacement(
             image.ImageId,
             placementId,
             (uint)cols,
             (uint)rows,
             command.Display);
+        if (placementError != KgpTerminalGraphicsState.PlacementError.None)
+            return FormatKgpPlacementError(placementError);
 
-        if (!command.Display.SuppressCursorMovement)
-        {
-            _cursorX = Math.Min(_cursorX + cols, _width - 1);
-            for (int r = 1; r < rows; r++)
-            {
-                if (_cursorY < _height - 1)
-                    _cursorY++;
-            }
-        }
+        if (command.Display.ParentImageId == 0 &&
+            !command.Display.SuppressCursorMovement)
+            MoveCursorAfterKgpPlacement(cols, rows);
         return "OK";
     }
 
@@ -7326,18 +7331,20 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         var cols = command.Columns > 0 ? (int)command.Columns : 1;
         var rows = command.Rows > 0 ? (int)command.Rows : 1;
 
-        CreateKgpPlacement(image.ImageId, command.PlacementId,
+        var placementError = CreateKgpPlacement(image.ImageId, command.PlacementId,
             (uint)cols, (uint)rows, command);
-
-        if (!command.SuppressCursorMovement)
+        if (placementError != KgpTerminalGraphicsState.PlacementError.None)
         {
-            _cursorX = Math.Min(_cursorX + cols, _width - 1);
-            for (int r = 1; r < rows; r++)
-            {
-                if (_cursorY < _height - 1)
-                    _cursorY++;
-            }
+            SendKgpResponse(
+                image.ImageId,
+                image.ImageNumber,
+                FormatKgpPlacementError(placementError),
+                (int)quiet);
+            return;
         }
+
+        if (command.ParentImageId == 0 && !command.SuppressCursorMovement)
+            MoveCursorAfterKgpPlacement(cols, rows);
 
         SendKgpResponse(image.ImageId, image.ImageNumber, "OK", (int)quiet);
     }
@@ -7345,52 +7352,50 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     private void ProcessKgpDelete(KgpParsedCommand.DeleteSelector selector)
     {
         ActiveKgpImageStore.AbortChunkedTransfer();
+        IReadOnlyList<KgpPlacement>? materialized = null;
+
+        void RemoveMaterialized(Func<KgpPlacement, bool> predicate)
+        {
+            materialized ??= CaptureActiveKgpPlacementsForMutation();
+            _kgpGraphicsState.RemoveActivePlacementsByGraphId(
+                materialized
+                    .Where(placement => placement.RenderGeometry is null)
+                    .Where(predicate)
+                    .Select(placement => placement.GraphId)
+                    .Distinct()
+                    .ToArray());
+        }
 
         switch (selector)
         {
             case KgpParsedCommand.DeleteSelector.All { FreeData: false }:
-                _kgpGraphicsState.DeleteAllActiveOrdinaryPlacements(
-                    freeData: false);
+                RemoveMaterialized(_ => true);
                 break;
             case KgpParsedCommand.DeleteSelector.All { FreeData: true }:
+                RemoveMaterialized(_ => true);
                 _kgpGraphicsState.DeleteAllActiveOrdinaryPlacements(
                     freeData: true);
                 break;
             case KgpParsedCommand.DeleteSelector.ById byId:
                 if (byId.ImageId > 0)
                 {
-                    _kgpGraphicsState.RemoveActiveVirtualPlacements(
-                        byId.ImageId,
-                        byId.PlacementId);
-                    var hasVirtualOwner =
-                        _kgpGraphicsState.ActiveVirtualReferenceCount(
-                            byId.ImageId) > 0;
-                    if (ActiveKgpImageStore.SelectAddressableImage(
+                    var hasVirtualPlacement =
+                        _kgpGraphicsState.HasActiveVirtualPlacement(
                             byId.ImageId,
-                            removeData: false))
+                            byId.PlacementId);
+                    var hasAddressableImage =
+                        ActiveKgpImageStore.SelectAddressableImage(
+                            byId.ImageId,
+                            removeData: false);
+                    if (hasAddressableImage || hasVirtualPlacement)
                     {
-                        if (hasVirtualOwner)
-                        {
-                            _kgpGraphicsState.RemoveActiveOrdinaryPlacements(
-                                byId.ImageId,
-                                byId.PlacementId);
-                        }
-                        else if (byId.PlacementId > 0)
-                        {
-                            ActiveKgpPlacements.RemoveAll(
-                                placement => placement.ImageId == byId.ImageId &&
-                                    placement.PlacementId == byId.PlacementId);
-                        }
-                        else
-                        {
-                            ActiveKgpPlacements.RemoveAll(
-                                placement => placement.ImageId == byId.ImageId);
-                        }
-
-                        if (byId.FreeData && !hasVirtualOwner)
-                        {
+                        _kgpGraphicsState.RemoveActivePlacements(
+                            byId.ImageId,
+                            byId.PlacementId);
+                        if (byId.FreeData &&
+                            !_kgpGraphicsState.HasActivePlacementOwner(
+                                byId.ImageId))
                             ActiveKgpImageStore.RemoveImage(byId.ImageId);
-                        }
                     }
                 }
                 break;
@@ -7400,20 +7405,12 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                     var img = ActiveKgpImageStore.GetImageByNumber(byNumber.ImageNumber);
                     if (img is not null)
                     {
-                        _kgpGraphicsState.RemoveActiveVirtualPlacements(
+                        _kgpGraphicsState.RemoveActivePlacements(
                             img.ImageId,
                             byNumber.PlacementId);
-                        if (_kgpGraphicsState.ActiveVirtualReferenceCount(
-                                img.ImageId) > 0)
+                        if (!_kgpGraphicsState.HasActivePlacementOwner(
+                                img.ImageId))
                         {
-                            _kgpGraphicsState.RemoveActiveOrdinaryPlacements(
-                                img.ImageId,
-                                byNumber.PlacementId);
-                        }
-                        else
-                        {
-                            ActiveKgpPlacements.RemoveAll(
-                                placement => placement.ImageId == img.ImageId);
                             ActiveKgpImageStore.RemoveImageByNumber(
                                 byNumber.ImageNumber);
                         }
@@ -7421,21 +7418,29 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 }
                 break;
             case KgpParsedCommand.DeleteSelector.AtCursor:
-                ActiveKgpPlacements.RemoveAll(p => p.IntersectsCell(_cursorY, _cursorX));
+                RemoveMaterialized(
+                    placement => placement.IntersectsCell(_cursorY, _cursorX));
                 break;
             case KgpParsedCommand.DeleteSelector.AnimationFrames:
                 break;
             case KgpParsedCommand.DeleteSelector.AtCell atCell:
-                ActiveKgpPlacements.RemoveAll(p => p.IntersectsCell((int)atCell.Y - 1, (int)atCell.X - 1));
+                RemoveMaterialized(
+                    placement => placement.IntersectsCell(
+                        (int)atCell.Y - 1,
+                        (int)atCell.X - 1));
                 break;
             case KgpParsedCommand.DeleteSelector.ByColumn column:
-                ActiveKgpPlacements.RemoveAll(p => p.IntersectsColumn((int)column.Column - 1));
+                RemoveMaterialized(
+                    placement => placement.IntersectsColumn(
+                        (int)column.Column - 1));
                 break;
             case KgpParsedCommand.DeleteSelector.ByRow row:
-                ActiveKgpPlacements.RemoveAll(p => p.IntersectsRow((int)row.Row - 1));
+                RemoveMaterialized(
+                    placement => placement.IntersectsRow((int)row.Row - 1));
                 break;
             case KgpParsedCommand.DeleteSelector.ByZIndex zIndex:
-                ActiveKgpPlacements.RemoveAll(p => p.ZIndex == zIndex.ZIndex);
+                _kgpGraphicsState.RemoveActivePlacementsByZIndex(
+                    zIndex.ZIndex);
                 break;
             case KgpParsedCommand.DeleteSelector.ByRange range:
             {
@@ -7448,7 +7453,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                         lo,
                         hi,
                         range.FreeData);
-                    ActiveKgpPlacements.RemoveAll(p => selected.Contains(p.ImageId));
+                    _kgpGraphicsState.RemoveActivePlacementsInImageSet(selected);
                 }
                 break;
             }
@@ -7457,7 +7462,9 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 var cellRow = (int)atCellWithZ.Y - 1;
                 var cellCol = (int)atCellWithZ.X - 1;
                 var targetZ = atCellWithZ.ZIndex;
-                ActiveKgpPlacements.RemoveAll(p => p.IntersectsCell(cellRow, cellCol) && p.ZIndex == targetZ);
+                RemoveMaterialized(
+                    placement => placement.IntersectsCell(cellRow, cellCol) &&
+                        placement.ZIndex == targetZ);
                 break;
             }
         }
@@ -7465,16 +7472,33 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         _kgpGraphicsState.ReconcileActiveImageReferences();
     }
 
-    private void CreateKgpPlacement(
+    private IReadOnlyList<KgpPlacement> CaptureActiveKgpPlacementsForMutation()
+    {
+        var historyRows = _inAlternateScreen || _scrollbackBuffer is null
+            ? []
+            : _scrollbackBuffer.GetEntries(_scrollbackBuffer.Count);
+        return _kgpGraphicsState.CaptureActiveSnapshot(
+            historyRows,
+            selectedHistoryCount: 0,
+            _screenBuffer,
+            _width,
+            _height,
+            Capabilities.CellPixelWidth,
+            Capabilities.CellPixelHeight).Placements;
+    }
+
+    private KgpTerminalGraphicsState.PlacementError CreateKgpPlacement(
         uint imageId,
         uint placementId,
         uint cols,
         uint rows,
         KgpParsedCommand.DisplayData command)
     {
+        var isRelative = command.ParentImageId > 0;
         var placement = new KgpPlacement(
             imageId, placementId,
-            _cursorY, _cursorX,
+            isRelative ? 0 : _cursorY,
+            isRelative ? 0 : _cursorX,
             cols, rows,
             command.SourceX,
             command.SourceY,
@@ -7487,19 +7511,55 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         var image = ActiveKgpImageStore.GetImageById(imageId)
             ?? throw new InvalidOperationException(
                 $"Cannot create a KGP placement for missing image {imageId}.");
-        var clipped = placement.ClipToCellRectangle(
-            image,
-            0,
-            _height,
-            0,
-            _width,
-            Capabilities.CellPixelWidth,
-            Capabilities.CellPixelHeight);
-        _kgpGraphicsState.ReplaceActivePlacement(
+        var stored = isRelative
+            ? placement
+            : placement.ClipToCellRectangle(
+                image,
+                0,
+                _height,
+                0,
+                _width,
+                Capabilities.CellPixelWidth,
+                Capabilities.CellPixelHeight);
+        return _kgpGraphicsState.TryReplaceActivePlacement(
             imageId,
             placementId,
-            clipped);
+            stored,
+            command.ParentImageId,
+            command.ParentPlacementId,
+            command.ParentOffsetHorizontal,
+            command.ParentOffsetVertical);
     }
+
+    private void MoveCursorAfterKgpPlacement(int columns, int rows)
+    {
+        _cursorX = Math.Min(_cursorX + columns, _width - 1);
+        for (var row = 1; row < rows; row++)
+        {
+            if (_cursorY < _height - 1)
+                _cursorY++;
+        }
+    }
+
+    private static string FormatKgpPlacementError(
+        KgpTerminalGraphicsState.PlacementError error)
+        => error switch
+        {
+            KgpTerminalGraphicsState.PlacementError.ParentImageNotFound
+                => "ENOPARENT:Parent image not found",
+            KgpTerminalGraphicsState.PlacementError.ParentPlacementNotFound
+                => "ENOPARENT:Parent placement not found",
+            KgpTerminalGraphicsState.PlacementError.SelfParent
+                => "EINVAL:Placement cannot be its own parent",
+            KgpTerminalGraphicsState.PlacementError.Cycle
+                => "ECYCLE:Parent chain creates a cycle",
+            KgpTerminalGraphicsState.PlacementError.TooDeep
+                => "ETOODEEP:Parent chain too deep",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(error),
+                error,
+                "Expected a KGP placement error."),
+        };
 
     private void SendKgpResponse(uint imageId, uint imageNumber, string message, int quiet)
     {

--- a/src/Hex1b/Kgp/KgpPlacement.cs
+++ b/src/Hex1b/Kgp/KgpPlacement.cs
@@ -56,6 +56,16 @@ public sealed class KgpPlacement
     /// </remarks>
     public KgpPlacementRenderGeometry? RenderGeometry { get; }
 
+    internal long GraphId { get; }
+
+    internal long? ParentGraphId { get; }
+
+    internal int ParentOffsetHorizontal { get; }
+
+    internal int ParentOffsetVertical { get; }
+
+    internal bool IsRelative => ParentGraphId.HasValue;
+
     /// <summary>
     /// Creates a new KGP placement anchored at the specified cell position.
     /// </summary>
@@ -100,7 +110,11 @@ public sealed class KgpPlacement
             zIndex,
             cellOffsetX,
             cellOffsetY,
-            renderGeometry: null)
+            renderGeometry: null,
+            graphId: 0,
+            parentGraphId: null,
+            parentOffsetHorizontal: 0,
+            parentOffsetVertical: 0)
     {
     }
 
@@ -118,7 +132,8 @@ public sealed class KgpPlacement
         int zIndex,
         uint cellOffsetX,
         uint cellOffsetY,
-        KgpPlacementRenderGeometry renderGeometry)
+        KgpPlacementRenderGeometry renderGeometry,
+        long graphId = 0)
         : this(
             imageId,
             placementId,
@@ -133,7 +148,11 @@ public sealed class KgpPlacement
             zIndex,
             cellOffsetX,
             cellOffsetY,
-            (KgpPlacementRenderGeometry?)renderGeometry)
+            (KgpPlacementRenderGeometry?)renderGeometry,
+            graphId,
+            parentGraphId: null,
+            parentOffsetHorizontal: 0,
+            parentOffsetVertical: 0)
     {
     }
 
@@ -151,7 +170,11 @@ public sealed class KgpPlacement
         int zIndex,
         uint cellOffsetX,
         uint cellOffsetY,
-        KgpPlacementRenderGeometry? renderGeometry)
+        KgpPlacementRenderGeometry? renderGeometry,
+        long graphId,
+        long? parentGraphId,
+        int parentOffsetHorizontal,
+        int parentOffsetVertical)
     {
         ImageId = imageId;
         PlacementId = placementId;
@@ -167,6 +190,10 @@ public sealed class KgpPlacement
         CellOffsetX = cellOffsetX;
         CellOffsetY = cellOffsetY;
         RenderGeometry = renderGeometry;
+        GraphId = graphId;
+        ParentGraphId = parentGraphId;
+        ParentOffsetHorizontal = parentOffsetHorizontal;
+        ParentOffsetVertical = parentOffsetVertical;
     }
 
     /// <summary>
@@ -174,19 +201,21 @@ public sealed class KgpPlacement
     /// </summary>
     public bool IntersectsCell(int row, int column)
     {
-        return row >= Row && row < Row + (int)DisplayRows &&
-               column >= Column && column < Column + (int)DisplayColumns;
+        return row >= Row && (long)row < (long)Row + DisplayRows &&
+               column >= Column && (long)column < (long)Column + DisplayColumns;
     }
 
     /// <summary>
     /// Whether this placement intersects the given row.
     /// </summary>
-    public bool IntersectsRow(int row) => row >= Row && row < Row + (int)DisplayRows;
+    public bool IntersectsRow(int row)
+        => row >= Row && (long)row < (long)Row + DisplayRows;
 
     /// <summary>
     /// Whether this placement intersects the given column.
     /// </summary>
-    public bool IntersectsColumn(int column) => column >= Column && column < Column + (int)DisplayColumns;
+    public bool IntersectsColumn(int column)
+        => column >= Column && (long)column < (long)Column + DisplayColumns;
 
     internal KgpPlacement WithImageId(uint imageId)
         => new(
@@ -203,7 +232,11 @@ public sealed class KgpPlacement
             ZIndex,
             CellOffsetX,
             CellOffsetY,
-            RenderGeometry);
+            RenderGeometry,
+            GraphId,
+            ParentGraphId,
+            ParentOffsetHorizontal,
+            ParentOffsetVertical);
 
     internal KgpPlacement WithPosition(int row, int column)
         => new(
@@ -220,7 +253,36 @@ public sealed class KgpPlacement
             ZIndex,
             CellOffsetX,
             CellOffsetY,
-            RenderGeometry);
+            RenderGeometry,
+            GraphId,
+            ParentGraphId,
+            ParentOffsetHorizontal,
+            ParentOffsetVertical);
+
+    internal KgpPlacement WithGraphIdentity(
+        long graphId,
+        long? parentGraphId,
+        int parentOffsetHorizontal,
+        int parentOffsetVertical)
+        => new(
+            ImageId,
+            PlacementId,
+            Row,
+            Column,
+            DisplayColumns,
+            DisplayRows,
+            SourceX,
+            SourceY,
+            SourceWidth,
+            SourceHeight,
+            ZIndex,
+            CellOffsetX,
+            CellOffsetY,
+            RenderGeometry,
+            graphId,
+            parentGraphId,
+            parentOffsetHorizontal,
+            parentOffsetVertical);
 
     internal KgpPlacement? ClipToCellRectangle(
         KgpImageData image,
@@ -288,7 +350,12 @@ public sealed class KgpPlacement
             clippedSourceHeight,
             ZIndex,
             firstColumn == 0 ? CellOffsetX : 0,
-            firstRow == 0 ? CellOffsetY : 0);
+            firstRow == 0 ? CellOffsetY : 0,
+            RenderGeometry,
+            GraphId,
+            ParentGraphId,
+            ParentOffsetHorizontal,
+            ParentOffsetVertical);
     }
 
     internal KgpPlacement? ClipRows(
@@ -339,7 +406,12 @@ public sealed class KgpPlacement
             clippedSourceHeight,
             ZIndex,
             CellOffsetX,
-            firstRow == 0 ? CellOffsetY : 0);
+            firstRow == 0 ? CellOffsetY : 0,
+            RenderGeometry,
+            GraphId,
+            ParentGraphId,
+            ParentOffsetHorizontal,
+            ParentOffsetVertical);
     }
 
     internal KgpPlacement Clone()

--- a/src/Hex1b/Kgp/KgpTerminalGraphicsState.cs
+++ b/src/Hex1b/Kgp/KgpTerminalGraphicsState.cs
@@ -10,6 +10,18 @@ internal readonly record struct KgpScrollRectangle(
 
 internal sealed class KgpTerminalGraphicsState
 {
+    internal enum PlacementError
+    {
+        None,
+        ParentImageNotFound,
+        ParentPlacementNotFound,
+        SelfParent,
+        Cycle,
+        TooDeep,
+    }
+
+    private const int MaximumParentDepth = 8;
+
     internal readonly record struct HistoryPlacement(
         KgpPlacement Placement,
         uint FirstRow,
@@ -19,6 +31,13 @@ internal sealed class KgpTerminalGraphicsState
         int Id,
         KgpPlacement Placement,
         HistoryPlacement? History);
+
+    private readonly record struct EffectiveOrigin(int Row, int Column);
+
+    private readonly record struct PlacementIdentity(
+        long GraphId,
+        uint ImageId,
+        uint PlacementId);
 
     internal sealed class KgpReflowPlan
     {
@@ -43,7 +62,7 @@ internal sealed class KgpTerminalGraphicsState
         internal Dictionary<long, List<HistoryPlacement>> HistoryPlacements { get; } = [];
         internal Dictionary<uint, int> HistoryReferences { get; } = [];
         internal Dictionary<uint, int> VirtualReferences { get; } = [];
-        internal long NextVirtualPlacementOrdinal { get; set; } = 1;
+        internal long NextPlacementGraphId { get; set; } = 1;
 
         internal void Clear()
         {
@@ -52,7 +71,7 @@ internal sealed class KgpTerminalGraphicsState
             HistoryPlacements.Clear();
             HistoryReferences.Clear();
             VirtualReferences.Clear();
-            NextVirtualPlacementOrdinal = 1;
+            NextPlacementGraphId = 1;
             ImageStore.Clear();
         }
     }
@@ -75,6 +94,16 @@ internal sealed class KgpTerminalGraphicsState
     internal int ActiveVirtualReferenceCount(uint imageId)
         => Active.VirtualReferences.TryGetValue(imageId, out var count) ? count : 0;
 
+    internal bool HasActiveVirtualPlacement(
+        uint imageId,
+        uint placementId = 0)
+        => Active.VirtualPlacements.Any(
+            placement => placement.ImageId == imageId &&
+                (placementId == 0 || placement.PlacementId == placementId));
+
+    internal bool HasActivePlacementOwner(uint imageId)
+        => HasPlacementReference(Active, imageId);
+
     internal void ReconcileActiveImageReferences()
         => ReconcileImageReferences(Active);
 
@@ -88,50 +117,20 @@ internal sealed class KgpTerminalGraphicsState
             throw new ArgumentOutOfRangeException(nameof(imageId));
 
         var active = Active;
-        if (placementId > 0)
-        {
-            for (var i = 0; i < active.VirtualPlacements.Count; i++)
-            {
-                var existing = active.VirtualPlacements[i];
-                if (existing.ImageId == imageId &&
-                    existing.PlacementId == placementId)
-                {
-                    active.VirtualPlacements[i] = existing with
-                    {
-                        Columns = columns,
-                        Rows = rows,
-                    };
-                    active.Placements.RemoveAll(
-                        placement => placement.ImageId == imageId &&
-                            placement.PlacementId == placementId);
-                    RemoveHistoryPlacementsByIdentity(
-                        active,
-                        imageId,
-                        placementId);
-                    return;
-                }
-            }
-        }
-
+        ReconcileImageReferences(active);
+        var graphId = placementId > 0 &&
+            TryFindGraphId(active, imageId, placementId, out var existingGraphId)
+                ? existingGraphId
+                : AllocateGraphId(active);
+        DetachPlacement(active, graphId);
         active.VirtualPlacements.Add(new KgpVirtualPlacement(
+            graphId,
             imageId,
             placementId,
             columns,
-            rows,
-            active.NextVirtualPlacementOrdinal++));
-        active.VirtualReferences.TryGetValue(imageId, out var count);
-        active.VirtualReferences[imageId] = checked(count + 1);
-
-        if (placementId > 0)
-        {
-            active.Placements.RemoveAll(
-                placement => placement.ImageId == imageId &&
-                    placement.PlacementId == placementId);
-            RemoveHistoryPlacementsByIdentity(
-                active,
-                imageId,
-                placementId);
-        }
+            rows));
+        RebuildHistoryReferences(active);
+        RebuildVirtualReferences(active);
     }
 
     internal int RemoveActiveVirtualPlacements(
@@ -142,12 +141,13 @@ internal sealed class KgpTerminalGraphicsState
             return 0;
 
         var active = Active;
-        var removed = active.VirtualPlacements.RemoveAll(
-            placement => placement.ImageId == imageId &&
-                (placementId == 0 || placement.PlacementId == placementId));
-        if (removed > 0)
-            RebuildVirtualReferences(active);
-        return removed;
+        var selected = active.VirtualPlacements
+            .Where(placement => placement.ImageId == imageId &&
+                (placementId == 0 || placement.PlacementId == placementId))
+            .Select(placement => placement.GraphId)
+            .ToArray();
+        RemovePlacementSubtrees(active, selected);
+        return selected.Length;
     }
 
     internal int RemoveActiveVirtualPlacementsInRange(
@@ -162,25 +162,32 @@ internal sealed class KgpTerminalGraphicsState
         }
 
         var active = Active;
-        var removed = active.VirtualPlacements.RemoveAll(
-            placement => placement.ImageId >= firstImageId &&
-                placement.ImageId <= lastImageId);
-        if (removed > 0)
-            RebuildVirtualReferences(active);
-        return removed;
+        var selected = active.VirtualPlacements
+            .Where(placement => placement.ImageId >= firstImageId &&
+                placement.ImageId <= lastImageId)
+            .Select(placement => placement.GraphId)
+            .ToArray();
+        RemovePlacementSubtrees(active, selected);
+        return selected.Length;
     }
 
     internal void DeleteAllActiveOrdinaryPlacements(bool freeData)
     {
         var active = Active;
-        active.Placements.Clear();
-        if (!freeData)
-            return;
+        var selected = active.Placements
+            .Where(placement => !placement.IsRelative)
+            .Select(placement => placement.GraphId)
+            .ToList();
+        if (freeData)
+        {
+            selected.AddRange(active.HistoryPlacements.Values
+                .SelectMany(placements => placements)
+                .Select(placement => placement.Placement.GraphId));
+        }
 
-        active.HistoryPlacements.Clear();
-        active.HistoryReferences.Clear();
-        active.ImageStore.RemoveUnreferencedImages(active.VirtualReferences.Keys);
-        ReconcileImageReferences(active);
+        RemovePlacementSubtrees(active, selected);
+        if (freeData)
+            active.ImageStore.RemoveUnreferencedImages(GetRetainedImageIds(active));
     }
 
     internal void RemoveActiveOrdinaryPlacements(
@@ -191,21 +198,133 @@ internal sealed class KgpTerminalGraphicsState
             return;
 
         var active = Active;
-        active.Placements.RemoveAll(
-            placement => placement.ImageId == imageId &&
-                (placementId == 0 || placement.PlacementId == placementId));
-        foreach (var rowId in active.HistoryPlacements.Keys.ToArray())
-        {
-            var placements = active.HistoryPlacements[rowId];
-            placements.RemoveAll(
-                placement => placement.Placement.ImageId == imageId &&
+        var selected = active.Placements
+            .Where(placement => placement.ImageId == imageId &&
+                (placementId == 0 || placement.PlacementId == placementId))
+            .Select(placement => placement.GraphId)
+            .Concat(active.HistoryPlacements.Values
+                .SelectMany(placements => placements)
+                .Where(placement => placement.Placement.ImageId == imageId &&
                     (placementId == 0 ||
-                     placement.Placement.PlacementId == placementId));
-            if (placements.Count == 0)
-                active.HistoryPlacements.Remove(rowId);
+                     placement.Placement.PlacementId == placementId))
+                .Select(placement => placement.Placement.GraphId))
+            .ToArray();
+        RemovePlacementSubtrees(active, selected);
+    }
+
+    internal void RemoveActivePlacements(
+        uint imageId,
+        uint placementId = 0)
+    {
+        if (imageId == 0)
+            return;
+
+        var active = Active;
+        var selected = EnumeratePlacementIdentities(active)
+            .Where(placement => placement.ImageId == imageId &&
+                (placementId == 0 || placement.PlacementId == placementId))
+            .Select(placement => placement.GraphId)
+            .ToArray();
+        RemovePlacementSubtrees(active, selected);
+    }
+
+    internal void RemoveActivePlacementsByGraphId(
+        IEnumerable<long> graphIds)
+        => RemovePlacementSubtrees(Active, graphIds);
+
+    internal void RemoveActiveRelativePlacementsByGraphId(
+        IEnumerable<long> graphIds)
+    {
+        var selected = graphIds.ToHashSet();
+        RemovePlacementSubtrees(
+            Active,
+            Active.Placements
+                .Where(placement => placement.IsRelative &&
+                    selected.Contains(placement.GraphId))
+                .Select(placement => placement.GraphId)
+                .ToArray());
+    }
+
+    internal void RemoveActivePlacementsInImageSet(
+        IReadOnlySet<uint> imageIds)
+    {
+        ArgumentNullException.ThrowIfNull(imageIds);
+        var active = Active;
+        var selected = EnumeratePlacementIdentities(active)
+            .Where(placement => imageIds.Contains(placement.ImageId))
+            .Select(placement => placement.GraphId)
+            .ToArray();
+        RemovePlacementSubtrees(active, selected);
+    }
+
+    internal void RemoveActivePlacementsByZIndex(int zIndex)
+    {
+        var active = Active;
+        var selected = active.Placements
+            .Where(placement => placement.ZIndex == zIndex)
+            .Select(placement => placement.GraphId)
+            .Concat(active.HistoryPlacements.Values
+                .SelectMany(placements => placements)
+                .Where(placement => placement.Placement.ZIndex == zIndex)
+                .Select(placement => placement.Placement.GraphId))
+            .ToArray();
+        RemovePlacementSubtrees(active, selected);
+    }
+
+    internal PlacementError TryReplaceActivePlacement(
+        uint imageId,
+        uint placementId,
+        KgpPlacement? replacement,
+        uint parentImageId,
+        uint parentPlacementId,
+        int parentOffsetHorizontal,
+        int parentOffsetVertical)
+    {
+        var active = Active;
+        ReconcileImageReferences(active);
+
+        var existingGraphId = 0L;
+        var hasExisting = placementId > 0 &&
+            TryFindGraphId(active, imageId, placementId, out existingGraphId);
+        long? parentGraphId = null;
+        if (parentImageId > 0)
+        {
+            var parentError = TryResolveParent(
+                active,
+                hasExisting ? existingGraphId : null,
+                parentImageId,
+                parentPlacementId,
+                out var resolvedParentGraphId);
+            if (parentError != PlacementError.None)
+                return parentError;
+
+            parentGraphId = resolvedParentGraphId;
         }
 
-        ReconcileImageReferences(active);
+        var graphId = hasExisting
+            ? existingGraphId
+            : AllocateGraphId(active);
+        if (replacement is null)
+        {
+            if (hasExisting)
+                RemovePlacementSubtrees(active, [graphId]);
+            return PlacementError.None;
+        }
+
+        if (hasExisting)
+            DetachPlacement(active, graphId);
+        var stored = replacement
+            .WithPosition(parentGraphId.HasValue ? 0 : replacement.Row,
+                parentGraphId.HasValue ? 0 : replacement.Column)
+            .WithGraphIdentity(
+                graphId,
+                parentGraphId,
+                parentOffsetHorizontal,
+                parentOffsetVertical);
+        active.Placements.Add(stored);
+        RebuildHistoryReferences(active);
+        RebuildVirtualReferences(active);
+        return PlacementError.None;
     }
 
     internal void EnterAlternateScreen()
@@ -242,13 +361,20 @@ internal sealed class KgpTerminalGraphicsState
     internal void ClearActiveScreen(bool clearHistory)
     {
         var active = Active;
-        active.Placements.Clear();
+        var selected = active.Placements
+            .Where(placement => !placement.IsRelative)
+            .Select(placement => placement.GraphId)
+            .ToList();
         if (clearHistory)
         {
-            active.HistoryPlacements.Clear();
-            active.HistoryReferences.Clear();
+            selected.AddRange(active.HistoryPlacements.Values
+                .SelectMany(placements => placements)
+                .Select(placement => placement.Placement.GraphId));
         }
 
+        RemovePlacementSubtrees(active, selected);
+        if (clearHistory)
+            active.HistoryReferences.Clear();
         active.ImageStore.RemoveUnreferencedImages(GetRetainedImageIds(active));
     }
 
@@ -283,19 +409,11 @@ internal sealed class KgpTerminalGraphicsState
     internal void RemoveActiveImageReferences(uint imageId)
     {
         var active = Active;
-        active.Placements.RemoveAll(placement => placement.ImageId == imageId);
-        active.VirtualPlacements.RemoveAll(
-            placement => placement.ImageId == imageId);
-        RebuildVirtualReferences(active);
-        foreach (var rowId in active.HistoryPlacements.Keys.ToArray())
-        {
-            var placements = active.HistoryPlacements[rowId];
-            placements.RemoveAll(placement => placement.Placement.ImageId == imageId);
-            if (placements.Count == 0)
-                active.HistoryPlacements.Remove(rowId);
-        }
-
-        active.HistoryReferences.Remove(imageId);
+        var selected = EnumeratePlacementIdentities(active)
+            .Where(placement => placement.ImageId == imageId)
+            .Select(placement => placement.GraphId)
+            .ToArray();
+        RemovePlacementSubtrees(active, selected);
     }
 
     internal void ReplaceActivePlacement(
@@ -303,30 +421,14 @@ internal sealed class KgpTerminalGraphicsState
         uint placementId,
         KgpPlacement? replacement)
     {
-        var active = Active;
-        if (placementId == 0)
-        {
-            if (replacement is not null)
-                active.Placements.Add(replacement);
-            return;
-        }
-
-        active.Placements.RemoveAll(
-            placement => placement.ImageId == imageId &&
-                placement.PlacementId == placementId);
-
-        // Add first so releasing the last history owner cannot remove image
-        // data needed by the replacement placement.
-        if (replacement is not null)
-            active.Placements.Add(replacement);
-
-        if (active.VirtualPlacements.RemoveAll(
-                placement => placement.ImageId == imageId &&
-                    placement.PlacementId == placementId) > 0)
-        {
-            RebuildVirtualReferences(active);
-        }
-        RemoveHistoryPlacementsByIdentity(active, imageId, placementId);
+        _ = TryReplaceActivePlacement(
+            imageId,
+            placementId,
+            replacement,
+            parentImageId: 0,
+            parentPlacementId: 0,
+            parentOffsetHorizontal: 0,
+            parentOffsetVertical: 0);
     }
 
     internal void RelocateActiveImage(KgpImageStore.ImageRelocation relocation)
@@ -371,6 +473,7 @@ internal sealed class KgpTerminalGraphicsState
             }
         }
         RebuildVirtualReferences(Active);
+        RebuildHistoryReferences(Active);
     }
 
     internal void MoveMainPlacementsIntoHistory(long rowId)
@@ -382,6 +485,9 @@ internal sealed class KgpTerminalGraphicsState
         for (var i = _main.Placements.Count - 1; i >= 0; i--)
         {
             var placement = _main.Placements[i];
+            if (placement.IsRelative)
+                continue;
+
             if (placement.Row == 0)
             {
                 _main.Placements.RemoveAt(i);
@@ -409,10 +515,13 @@ internal sealed class KgpTerminalGraphicsState
     {
         if (pruned.Reason == ScrollbackPruneReason.Capacity)
             ReconcileImageReferences(_main);
-        if (!_main.HistoryPlacements.Remove(pruned.RowId, out var placements))
+        if (!_main.HistoryPlacements.TryGetValue(pruned.RowId, out var placements))
             return;
 
-        foreach (var historyPlacement in placements)
+        var transfers = new List<(long RowId, HistoryPlacement Placement)>();
+        var removedGraphIds = new List<long>();
+        var removedImageIds = new HashSet<uint>();
+        foreach (var historyPlacement in placements.ToArray())
         {
             if (pruned.Reason == ScrollbackPruneReason.Capacity &&
                 pruned.SuccessorRowId is { } successorRowId &&
@@ -438,16 +547,31 @@ internal sealed class KgpTerminalGraphicsState
                     cellPixelHeight);
                 if (clipped is not null)
                 {
-                    AddHistoryPlacement(
-                        _main,
-                        successorRowId,
-                        transferred,
-                        retainImage: false);
+                    transfers.Add((successorRowId, transferred));
                     continue;
                 }
             }
 
-            ReleaseHistoryImage(_main, historyPlacement.Placement.ImageId);
+            removedGraphIds.Add(historyPlacement.Placement.GraphId);
+            removedImageIds.Add(historyPlacement.Placement.ImageId);
+        }
+
+        RemovePlacementSubtrees(_main, removedGraphIds);
+        _main.HistoryPlacements.Remove(pruned.RowId);
+        foreach (var transfer in transfers)
+        {
+            AddHistoryPlacement(
+                _main,
+                transfer.RowId,
+                transfer.Placement,
+                retainImage: false);
+        }
+
+        RebuildHistoryReferences(_main);
+        foreach (var imageId in removedImageIds)
+        {
+            if (!HasPlacementReference(_main, imageId))
+                _main.ImageStore.RemoveImage(imageId);
         }
     }
 
@@ -459,9 +583,13 @@ internal sealed class KgpTerminalGraphicsState
     {
         var active = Active;
         ReconcileImageReferences(active);
+        List<long>? removedGraphIds = null;
         for (var i = active.Placements.Count - 1; i >= 0; i--)
         {
             var placement = active.Placements[i];
+            if (placement.IsRelative)
+                continue;
+
             if (!IsWhollyContained(placement, rectangle))
                 continue;
 
@@ -480,10 +608,16 @@ internal sealed class KgpTerminalGraphicsState
                 cellPixelWidth,
                 cellPixelHeight);
             if (clipped is null)
-                active.Placements.RemoveAt(i);
+            {
+                removedGraphIds ??= [];
+                removedGraphIds.Add(placement.GraphId);
+            }
             else
                 active.Placements[i] = clipped;
         }
+
+        if (removedGraphIds is not null)
+            RemovePlacementSubtrees(active, removedGraphIds);
     }
 
     internal void ClipActivePlacementsToViewport(
@@ -494,9 +628,13 @@ internal sealed class KgpTerminalGraphicsState
     {
         var active = Active;
         ReconcileImageReferences(active);
+        List<long>? removedGraphIds = null;
         for (var i = active.Placements.Count - 1; i >= 0; i--)
         {
             var placement = active.Placements[i];
+            if (placement.IsRelative)
+                continue;
+
             var image = active.ImageStore.GetImageById(placement.ImageId)
                 ?? throw new InvalidOperationException(
                     $"Active placement {placement.PlacementId} references missing KGP image {placement.ImageId}.");
@@ -509,10 +647,16 @@ internal sealed class KgpTerminalGraphicsState
                 cellPixelWidth,
                 cellPixelHeight);
             if (clipped is null)
-                active.Placements.RemoveAt(i);
+            {
+                removedGraphIds ??= [];
+                removedGraphIds.Add(placement.GraphId);
+            }
             else
                 active.Placements[i] = clipped;
         }
+
+        if (removedGraphIds is not null)
+            RemovePlacementSubtrees(active, removedGraphIds);
     }
 
     internal void ClearActiveViewport(
@@ -521,7 +665,11 @@ internal sealed class KgpTerminalGraphicsState
     {
         var active = Active;
         ReconcileImageReferences(active);
-        active.Placements.Clear();
+        var selected = active.Placements
+            .Where(placement => !placement.IsRelative)
+            .Select(placement => placement.GraphId)
+            .ToArray();
+        RemovePlacementSubtrees(active, selected);
         if (!_alternateActive)
             ClipMainHistoryToRetainedRows(
                 historyRows,
@@ -566,6 +714,9 @@ internal sealed class KgpTerminalGraphicsState
 
         foreach (var placement in active.Placements)
         {
+            if (placement.IsRelative)
+                continue;
+
             var id = nextId++;
             anchors.Add(new TerminalReflowAnchor(
                 id,
@@ -619,8 +770,17 @@ internal sealed class KgpTerminalGraphicsState
         var active = Active;
         ReconcileImageReferences(active);
         var mappedById = mappedAnchors.ToDictionary(anchor => anchor.Id);
-        active.Placements.Clear();
+        active.Placements.RemoveAll(placement => !placement.IsRelative);
         active.HistoryPlacements.Clear();
+        var removedGraphIds = new HashSet<long>();
+        var removedHistoryImageIds = new HashSet<uint>();
+
+        void MarkRemoved(KgpPlacement placement, bool wasHistory)
+        {
+            removedGraphIds.Add(placement.GraphId);
+            if (wasHistory)
+                removedHistoryImageIds.Add(placement.ImageId);
+        }
 
         foreach (var tracked in plan.Placements)
         {
@@ -639,7 +799,7 @@ internal sealed class KgpTerminalGraphicsState
                     cellPixelHeight);
                 if (clippedHistoryPlacement is null)
                 {
-                    ReleaseHistoryImage(active, tracked.Placement.ImageId);
+                    MarkRemoved(tracked.Placement, wasHistory);
                     continue;
                 }
 
@@ -648,8 +808,7 @@ internal sealed class KgpTerminalGraphicsState
 
             if (!mappedById.TryGetValue(tracked.Id, out var mapped))
             {
-                if (wasHistory)
-                    ReleaseHistoryImage(active, placement.ImageId);
+                MarkRemoved(placement, wasHistory);
                 continue;
             }
 
@@ -658,8 +817,7 @@ internal sealed class KgpTerminalGraphicsState
                 var discardedRows = replacement.DiscardedRowCount - mapped.Row;
                 if ((uint)discardedRows >= placement.DisplayRows)
                 {
-                    if (wasHistory)
-                        ReleaseHistoryImage(active, placement.ImageId);
+                    MarkRemoved(placement, wasHistory);
                     continue;
                 }
 
@@ -674,8 +832,7 @@ internal sealed class KgpTerminalGraphicsState
                     cellPixelHeight);
                 if (clipped is null)
                 {
-                    if (wasHistory)
-                        ReleaseHistoryImage(active, placement.ImageId);
+                    MarkRemoved(placement, wasHistory);
                     continue;
                 }
 
@@ -688,8 +845,7 @@ internal sealed class KgpTerminalGraphicsState
                 var retainedIndex = mapped.Row - replacement.DiscardedRowCount;
                 if (retainedIndex < 0 || retainedIndex >= replacement.Entries.Length)
                 {
-                    if (wasHistory)
-                        ReleaseHistoryImage(active, placement.ImageId);
+                    MarkRemoved(placement, wasHistory);
                     continue;
                 }
 
@@ -701,7 +857,7 @@ internal sealed class KgpTerminalGraphicsState
                     active,
                     replacement.Entries[retainedIndex].RowId,
                     historyPlacement,
-                    retainImage: !wasHistory);
+                    retainImage: false);
                 continue;
             }
 
@@ -721,8 +877,16 @@ internal sealed class KgpTerminalGraphicsState
                     cellPixelHeight);
             if (activePlacement is not null)
                 active.Placements.Add(activePlacement);
-            if (wasHistory)
-                ReleaseHistoryImage(active, placement.ImageId);
+            else
+                MarkRemoved(placement, wasHistory);
+        }
+
+        RemovePlacementSubtrees(active, removedGraphIds);
+        RebuildHistoryReferences(active);
+        foreach (var imageId in removedHistoryImageIds)
+        {
+            if (!HasPlacementReference(active, imageId))
+                active.ImageStore.RemoveImage(imageId);
         }
     }
 
@@ -732,7 +896,10 @@ internal sealed class KgpTerminalGraphicsState
     {
         var active = Active;
         ReconcileImageReferences(active);
-        return active.ImageStore.CaptureSnapshot(active.Placements);
+        return active.ImageStore.CaptureSnapshot(
+            active.Placements
+                .Where(placement => !placement.IsRelative)
+                .ToArray());
     }
 
     internal (
@@ -752,16 +919,102 @@ internal sealed class KgpTerminalGraphicsState
         var selectedCount = Math.Clamp(selectedHistoryCount, 0, historyCount);
         var snapshotStart = historyCount - selectedCount;
         var snapshotEnd = checked(historyCount + height);
+        var captured = active.ImageStore.CaptureSnapshot(
+            [],
+            GetRetainedImageIds(active));
+        var rowIndices = new Dictionary<long, int>(historyRows.Count);
+        for (var i = 0; i < historyRows.Count; i++)
+            rowIndices.Add(historyRows[i].RowId, i);
+        var virtualOrigins = new Dictionary<long, (int Row, int Column)>();
+        foreach (var (rowId, _) in active.HistoryPlacements)
+        {
+            if (!rowIndices.ContainsKey(rowId))
+            {
+                throw new InvalidOperationException(
+                    $"KGP history placement anchor {rowId} is not present in scrollback.");
+            }
+        }
+
+        var screenWidth = Math.Min(width, screenBuffer.GetLength(1));
+        var screenHeight = Math.Min(height, screenBuffer.GetLength(0));
+        var screenRow = new TerminalCell[screenWidth];
+        if (active.VirtualPlacements.Count > 0)
+        {
+            for (var historyIndex = 0;
+                 historyIndex < historyCount;
+                 historyIndex++)
+            {
+                var cells = historyRows[historyIndex].Row.Cells;
+                KgpUnicodePlaceholder.CollectOrigins(
+                    cells,
+                    historyIndex,
+                    active.VirtualPlacements,
+                    captured.Images,
+                    cellPixelWidth,
+                    cellPixelHeight,
+                    virtualOrigins);
+            }
+
+            for (var row = 0; row < screenHeight; row++)
+            {
+                for (var column = 0; column < screenWidth; column++)
+                    screenRow[column] = screenBuffer[row, column];
+                KgpUnicodePlaceholder.CollectOrigins(
+                    screenRow,
+                    SaturatingAdd(historyCount, row),
+                    active.VirtualPlacements,
+                    captured.Images,
+                    cellPixelWidth,
+                    cellPixelHeight,
+                    virtualOrigins);
+            }
+        }
+
+        var rootOrigins = new Dictionary<long, EffectiveOrigin>();
+        foreach (var placement in active.Placements)
+        {
+            if (!placement.IsRelative)
+            {
+                rootOrigins[placement.GraphId] = new EffectiveOrigin(
+                    SaturatingAdd(historyCount, placement.Row),
+                    placement.Column);
+            }
+        }
+
+        foreach (var (rowId, placements) in active.HistoryPlacements)
+        {
+            var rowIndex = rowIndices[rowId];
+            foreach (var placement in placements)
+            {
+                rootOrigins[placement.Placement.GraphId] =
+                    new EffectiveOrigin(
+                        SaturatingSubtract(rowIndex, placement.FirstRow),
+                        placement.Placement.Column);
+            }
+        }
+
+        foreach (var (graphId, origin) in virtualOrigins)
+        {
+            rootOrigins[graphId] = new EffectiveOrigin(
+                origin.Row,
+                origin.Column);
+        }
+
         var materialized = new List<KgpPlacement>(
-            active.Placements.Count + active.HistoryPlacements.Count);
+            active.Placements.Count +
+            active.HistoryPlacements.Values.Sum(placements => placements.Count) +
+            active.VirtualPlacements.Count);
 
         foreach (var placement in active.Placements)
         {
+            if (placement.IsRelative)
+                continue;
+
             AddMaterializedPlacement(
-                active,
+                captured.Images,
                 materialized,
                 placement.WithPosition(
-                    checked(historyCount + placement.Row),
+                    SaturatingAdd(historyCount, placement.Row),
                     placement.Column),
                 snapshotStart,
                 snapshotEnd,
@@ -770,24 +1023,16 @@ internal sealed class KgpTerminalGraphicsState
                 cellPixelHeight);
         }
 
-        if (!_alternateActive && _main.HistoryPlacements.Count > 0)
+        if (!_alternateActive && active.HistoryPlacements.Count > 0)
         {
-            var rowIndices = new Dictionary<long, int>(historyRows.Count);
-            for (var i = 0; i < historyRows.Count; i++)
-                rowIndices.Add(historyRows[i].RowId, i);
-
-            foreach (var (rowId, placements) in _main.HistoryPlacements)
+            foreach (var (rowId, placements) in active.HistoryPlacements)
             {
-                if (!rowIndices.TryGetValue(rowId, out var rowIndex))
-                {
-                    throw new InvalidOperationException(
-                        $"KGP history placement anchor {rowId} is not present in scrollback.");
-                }
+                var rowIndex = rowIndices[rowId];
 
                 foreach (var placement in placements)
                 {
                     AddMaterializedHistoryPlacement(
-                        _main,
+                        captured.Images,
                         materialized,
                         placement,
                         rowIndex,
@@ -800,43 +1045,82 @@ internal sealed class KgpTerminalGraphicsState
             }
         }
 
-        var captured = active.ImageStore.CaptureSnapshot(
-            materialized,
-            active.VirtualPlacements.Select(placement => placement.ImageId));
-        var snapshotPlacements = captured.Placements.ToList();
-
-        for (var historyIndex = snapshotStart;
-             historyIndex < historyCount;
-             historyIndex++)
+        var resolvedOrigins = new Dictionary<long, EffectiveOrigin?>();
+        foreach (var placement in active.Placements
+            .Where(placement => placement.IsRelative)
+            .OrderBy(placement => placement.GraphId))
         {
-            var cells = historyRows[historyIndex].Row.Cells;
-            KgpUnicodePlaceholder.MaterializeRow(
-                cells.AsSpan(0, Math.Min(cells.Length, width)),
-                historyIndex - snapshotStart,
-                active.VirtualPlacements,
+            if (!TryResolveEffectiveOrigin(
+                    active,
+                    placement.GraphId,
+                    rootOrigins,
+                    resolvedOrigins,
+                    out var origin))
+            {
+                continue;
+            }
+
+            AddMaterializedPlacement(
                 captured.Images,
+                materialized,
+                placement.WithPosition(origin.Row, origin.Column),
+                snapshotStart,
+                snapshotEnd,
+                width,
                 cellPixelWidth,
-                cellPixelHeight,
-                snapshotPlacements);
+                cellPixelHeight);
         }
 
-        var screenWidth = Math.Min(width, screenBuffer.GetLength(1));
-        var screenHeight = Math.Min(height, screenBuffer.GetLength(0));
-        var screenRow = new TerminalCell[screenWidth];
-        for (var row = 0; row < screenHeight; row++)
+        var snapshotPlacements = materialized;
+        if (active.VirtualPlacements.Count > 0)
         {
-            for (var column = 0; column < screenWidth; column++)
-                screenRow[column] = screenBuffer[row, column];
+            for (var historyIndex = snapshotStart;
+                 historyIndex < historyCount;
+                 historyIndex++)
+            {
+                var cells = historyRows[historyIndex].Row.Cells;
+                KgpUnicodePlaceholder.MaterializeRow(
+                    cells.AsSpan(0, Math.Min(cells.Length, width)),
+                    historyIndex - snapshotStart,
+                    active.VirtualPlacements,
+                    captured.Images,
+                    cellPixelWidth,
+                    cellPixelHeight,
+                    snapshotPlacements);
+            }
 
-            KgpUnicodePlaceholder.MaterializeRow(
-                screenRow,
-                checked(selectedCount + row),
-                active.VirtualPlacements,
-                captured.Images,
-                cellPixelWidth,
-                cellPixelHeight,
-                snapshotPlacements);
+            for (var row = 0; row < screenHeight; row++)
+            {
+                for (var column = 0; column < screenWidth; column++)
+                    screenRow[column] = screenBuffer[row, column];
+
+                KgpUnicodePlaceholder.MaterializeRow(
+                    screenRow,
+                    checked(selectedCount + row),
+                    active.VirtualPlacements,
+                    captured.Images,
+                    cellPixelWidth,
+                    cellPixelHeight,
+                    snapshotPlacements);
+            }
         }
+
+        snapshotPlacements.Sort(static (left, right) =>
+        {
+            var result = left.GraphId.CompareTo(right.GraphId);
+            if (result != 0)
+                return result;
+            result = left.Row.CompareTo(right.Row);
+            if (result != 0)
+                return result;
+            result = left.Column.CompareTo(right.Column);
+            if (result != 0)
+                return result;
+            result = left.SourceY.CompareTo(right.SourceY);
+            return result != 0
+                ? result
+                : left.SourceX.CompareTo(right.SourceX);
+        });
 
         var snapshotImages = new Dictionary<uint, KgpImageData>();
         foreach (var placement in snapshotPlacements)
@@ -872,46 +1156,59 @@ internal sealed class KgpTerminalGraphicsState
     private static void ReconcileImageReferences(ScreenState screen)
     {
         // Deletion and quota policy live in the image store. If either removes
-        // data, discard only the now-invalid placement ownership here.
+        // data, discard the now-invalid placement ownership and its descendants.
         // Virtual prototypes intentionally survive missing data so a later
         // transmission with the same client ID can realize existing text cells.
-        screen.Placements.RemoveAll(
-            placement => screen.ImageStore.GetImageById(placement.ImageId) is null);
+        var missingImagePlacements = screen.Placements
+           .Where(placement => screen.ImageStore.GetImageById(
+               placement.ImageId) is null)
+           .Select(placement => placement.GraphId)
+           .Concat(screen.HistoryPlacements.Values
+               .SelectMany(placements => placements)
+               .Where(placement => screen.ImageStore.GetImageById(
+                   placement.Placement.ImageId) is null)
+               .Select(placement => placement.Placement.GraphId))
+           .ToArray();
+        RemovePlacementSubtrees(screen, missingImagePlacements);
 
-        var historyReferences = new Dictionary<uint, int>();
-        foreach (var rowId in screen.HistoryPlacements.Keys.ToArray())
-        {
-            var placements = screen.HistoryPlacements[rowId];
-            placements.RemoveAll(
-                placement => screen.ImageStore.GetImageById(
-                    placement.Placement.ImageId) is null);
-            foreach (var placement in placements)
-            {
-                var imageId = placement.Placement.ImageId;
-                historyReferences.TryGetValue(imageId, out var count);
-                historyReferences[imageId] = checked(count + 1);
-            }
-
-            if (placements.Count == 0)
-                screen.HistoryPlacements.Remove(rowId);
-        }
-
-        screen.HistoryReferences.Clear();
-        foreach (var (imageId, count) in historyReferences)
-            screen.HistoryReferences.Add(imageId, count);
+        var orphaned = screen.Placements
+           .Where(placement => placement.ParentGraphId is { } parentGraphId &&
+               !ContainsGraphId(screen, parentGraphId))
+           .Select(placement => placement.GraphId)
+           .ToArray();
+        RemovePlacementSubtrees(
+           screen,
+           orphaned,
+           reclaimSelectedImages: true);
+        RebuildHistoryReferences(screen);
         RebuildVirtualReferences(screen);
     }
 
     private static HashSet<uint> GetRetainedImageIds(ScreenState screen)
     {
-        var retained = new HashSet<uint>(screen.HistoryReferences.Keys);
+        var retained = EnumeratePlacementIdentities(screen)
+           .Select(placement => placement.ImageId)
+           .ToHashSet();
+        retained.UnionWith(screen.HistoryReferences.Keys);
         retained.UnionWith(screen.VirtualReferences.Keys);
         return retained;
     }
 
     private static bool HasPlacementReference(ScreenState screen, uint imageId)
-        => screen.Placements.Any(placement => placement.ImageId == imageId) ||
-           screen.VirtualReferences.ContainsKey(imageId);
+        => EnumeratePlacementIdentities(screen)
+           .Any(placement => placement.ImageId == imageId);
+
+    private static void RebuildHistoryReferences(ScreenState screen)
+    {
+        screen.HistoryReferences.Clear();
+        foreach (var placement in screen.HistoryPlacements.Values
+           .SelectMany(placements => placements))
+        {
+           var imageId = placement.Placement.ImageId;
+           screen.HistoryReferences.TryGetValue(imageId, out var count);
+           screen.HistoryReferences[imageId] = checked(count + 1);
+        }
+    }
 
     private static void RebuildVirtualReferences(ScreenState screen)
     {
@@ -923,31 +1220,333 @@ internal sealed class KgpTerminalGraphicsState
         }
     }
 
-    private static void RemoveHistoryPlacementsByIdentity(
+    private static long AllocateGraphId(ScreenState screen)
+    {
+        if (screen.NextPlacementGraphId == long.MaxValue)
+            throw new InvalidOperationException("No KGP placement graph IDs are available.");
+
+        return screen.NextPlacementGraphId++;
+    }
+
+    private static IEnumerable<PlacementIdentity> EnumeratePlacementIdentities(
+        ScreenState screen)
+    {
+        foreach (var placement in screen.Placements)
+        {
+            yield return new PlacementIdentity(
+                placement.GraphId,
+                placement.ImageId,
+                placement.PlacementId);
+        }
+
+        foreach (var placement in screen.VirtualPlacements)
+        {
+            yield return new PlacementIdentity(
+                placement.GraphId,
+                placement.ImageId,
+                placement.PlacementId);
+        }
+
+        foreach (var placement in screen.HistoryPlacements.Values
+            .SelectMany(placements => placements))
+        {
+            yield return new PlacementIdentity(
+                placement.Placement.GraphId,
+                placement.Placement.ImageId,
+                placement.Placement.PlacementId);
+        }
+    }
+
+    private static bool TryFindGraphId(
         ScreenState screen,
         uint imageId,
-        uint placementId)
+        uint placementId,
+        out long graphId)
     {
+        graphId = 0;
+        if (placementId == 0)
+            return false;
+
+        foreach (var placement in EnumeratePlacementIdentities(screen))
+        {
+            if (placement.ImageId == imageId &&
+                placement.PlacementId == placementId)
+            {
+                graphId = placement.GraphId;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryFindIdentity(
+        ScreenState screen,
+        long graphId,
+        out PlacementIdentity identity)
+    {
+        foreach (var placement in EnumeratePlacementIdentities(screen))
+        {
+            if (placement.GraphId == graphId)
+            {
+                identity = placement;
+                return true;
+            }
+        }
+
+        identity = default;
+        return false;
+    }
+
+    private static bool ContainsGraphId(ScreenState screen, long graphId)
+        => TryFindIdentity(screen, graphId, out _);
+
+    private static bool TryGetRelativePlacement(
+        ScreenState screen,
+        long graphId,
+        out KgpPlacement placement)
+    {
+        foreach (var candidate in screen.Placements)
+        {
+            if (candidate.GraphId == graphId && candidate.IsRelative)
+            {
+                placement = candidate;
+                return true;
+            }
+        }
+
+        placement = null!;
+        return false;
+    }
+
+    private static void DetachPlacement(ScreenState screen, long graphId)
+    {
+        screen.Placements.RemoveAll(placement => placement.GraphId == graphId);
+        screen.VirtualPlacements.RemoveAll(
+            placement => placement.GraphId == graphId);
         foreach (var rowId in screen.HistoryPlacements.Keys.ToArray())
         {
             var placements = screen.HistoryPlacements[rowId];
-            for (var i = placements.Count - 1; i >= 0; i--)
-            {
-                var placement = placements[i].Placement;
-                if (placement.ImageId != imageId ||
-                    placement.PlacementId != placementId)
-                {
-                    continue;
-                }
-
-                placements.RemoveAt(i);
-                ReleaseHistoryImage(screen, imageId);
-            }
-
+            placements.RemoveAll(
+                placement => placement.Placement.GraphId == graphId);
             if (placements.Count == 0)
                 screen.HistoryPlacements.Remove(rowId);
         }
     }
+
+    private static void RemovePlacementSubtrees(
+        ScreenState screen,
+        IEnumerable<long> selectedGraphIds,
+        bool reclaimSelectedImages = false)
+    {
+        var selected = selectedGraphIds
+            .Where(graphId => graphId >= 0)
+            .ToHashSet();
+        if (selected.Count == 0)
+            return;
+
+        var removal = new HashSet<long>(selected);
+        var descendants = new HashSet<long>();
+        var queue = new Queue<long>(selected);
+        while (queue.TryDequeue(out var parentGraphId))
+        {
+            foreach (var child in screen.Placements)
+            {
+                if (child.ParentGraphId != parentGraphId)
+                    continue;
+
+                descendants.Add(child.GraphId);
+                if (removal.Add(child.GraphId))
+                    queue.Enqueue(child.GraphId);
+            }
+        }
+
+        var reclaimedImageIds = new HashSet<uint>();
+        foreach (var graphId in descendants)
+        {
+            if (TryFindIdentity(screen, graphId, out var identity))
+                reclaimedImageIds.Add(identity.ImageId);
+        }
+        if (reclaimSelectedImages)
+        {
+            foreach (var graphId in selected)
+            {
+                if (TryFindIdentity(screen, graphId, out var identity))
+                    reclaimedImageIds.Add(identity.ImageId);
+            }
+        }
+
+        screen.Placements.RemoveAll(
+            placement => removal.Contains(placement.GraphId));
+        var removedVirtual = screen.VirtualPlacements.RemoveAll(
+            placement => removal.Contains(placement.GraphId));
+        var removedHistory = false;
+        foreach (var rowId in screen.HistoryPlacements.Keys.ToArray())
+        {
+            var placements = screen.HistoryPlacements[rowId];
+            removedHistory |= placements.RemoveAll(
+                placement => removal.Contains(placement.Placement.GraphId)) > 0;
+            if (placements.Count == 0)
+                screen.HistoryPlacements.Remove(rowId);
+        }
+
+        if (removedHistory)
+            RebuildHistoryReferences(screen);
+        if (removedVirtual > 0)
+            RebuildVirtualReferences(screen);
+        foreach (var imageId in reclaimedImageIds)
+        {
+            if (!HasPlacementReference(screen, imageId))
+                screen.ImageStore.RemoveImage(imageId);
+        }
+    }
+
+    private static PlacementError TryResolveParent(
+        ScreenState screen,
+        long? childGraphId,
+        uint parentImageId,
+        uint parentPlacementId,
+        out long parentGraphId)
+    {
+        parentGraphId = 0;
+        var parentImage = screen.ImageStore.GetImageByClientId(parentImageId);
+        if (parentImage is null)
+            return PlacementError.ParentImageNotFound;
+
+        var candidates = EnumeratePlacementIdentities(screen)
+            .Where(placement => placement.ImageId == parentImage.ImageId);
+        PlacementIdentity? parent = parentPlacementId > 0
+            ? candidates.FirstOrDefault(
+                placement => placement.PlacementId == parentPlacementId)
+            : candidates.OrderBy(placement => placement.GraphId).FirstOrDefault();
+        if (parent is null || parent.Value.GraphId == 0)
+            return PlacementError.ParentPlacementNotFound;
+
+        parentGraphId = parent.Value.GraphId;
+        if (childGraphId == parentGraphId)
+            return PlacementError.SelfParent;
+
+        var depth = 1;
+        var ancestorGraphId = parentGraphId;
+        var visited = new HashSet<long>();
+        while (true)
+        {
+            if (childGraphId == ancestorGraphId)
+                return PlacementError.Cycle;
+            if (!visited.Add(ancestorGraphId))
+                return PlacementError.Cycle;
+            if (!TryGetRelativePlacement(
+                    screen,
+                    ancestorGraphId,
+                    out var ancestor))
+            {
+                if (!ContainsGraphId(screen, ancestorGraphId))
+                    return PlacementError.ParentPlacementNotFound;
+                break;
+            }
+
+            depth++;
+            ancestorGraphId = ancestor.ParentGraphId!.Value;
+        }
+
+        if (depth > MaximumParentDepth)
+            return PlacementError.TooDeep;
+        if (childGraphId is { } existingChildGraphId &&
+            depth + GetMaximumDescendantDepth(screen, existingChildGraphId) >
+                MaximumParentDepth)
+        {
+            return PlacementError.TooDeep;
+        }
+
+        return PlacementError.None;
+    }
+
+    private static int GetMaximumDescendantDepth(
+        ScreenState screen,
+        long graphId)
+    {
+        var maximum = 0;
+        var queue = new Queue<(long GraphId, int Depth)>();
+        queue.Enqueue((graphId, 0));
+        while (queue.TryDequeue(out var current))
+        {
+            foreach (var child in screen.Placements)
+            {
+                if (child.ParentGraphId != current.GraphId)
+                    continue;
+
+                var depth = current.Depth + 1;
+                maximum = Math.Max(maximum, depth);
+                queue.Enqueue((child.GraphId, depth));
+            }
+        }
+
+        return maximum;
+    }
+
+    private static bool TryResolveEffectiveOrigin(
+        ScreenState screen,
+        long graphId,
+        IReadOnlyDictionary<long, EffectiveOrigin> rootOrigins,
+        Dictionary<long, EffectiveOrigin?> resolvedOrigins,
+        out EffectiveOrigin origin)
+    {
+        return TryResolveEffectiveOrigin(
+            screen,
+            graphId,
+            rootOrigins,
+            resolvedOrigins,
+            new HashSet<long>(),
+            out origin);
+    }
+
+    private static bool TryResolveEffectiveOrigin(
+        ScreenState screen,
+        long graphId,
+        IReadOnlyDictionary<long, EffectiveOrigin> rootOrigins,
+        Dictionary<long, EffectiveOrigin?> resolvedOrigins,
+        HashSet<long> visiting,
+        out EffectiveOrigin origin)
+    {
+        if (resolvedOrigins.TryGetValue(graphId, out var cached))
+        {
+            origin = cached.GetValueOrDefault();
+            return cached.HasValue;
+        }
+        if (rootOrigins.TryGetValue(graphId, out origin))
+        {
+            resolvedOrigins[graphId] = origin;
+            return true;
+        }
+        if (!visiting.Add(graphId) ||
+            !TryGetRelativePlacement(screen, graphId, out var placement) ||
+            !TryResolveEffectiveOrigin(
+                screen,
+                placement.ParentGraphId!.Value,
+                rootOrigins,
+                resolvedOrigins,
+                visiting,
+                out var parentOrigin))
+        {
+            resolvedOrigins[graphId] = null;
+            origin = default;
+            visiting.Remove(graphId);
+            return false;
+        }
+
+        origin = new EffectiveOrigin(
+            SaturatingAdd(parentOrigin.Row, placement.ParentOffsetVertical),
+            SaturatingAdd(parentOrigin.Column, placement.ParentOffsetHorizontal));
+        visiting.Remove(graphId);
+        resolvedOrigins[graphId] = origin;
+        return true;
+    }
+
+    private static int SaturatingAdd(int left, int right)
+        => (int)Math.Clamp((long)left + right, int.MinValue, int.MaxValue);
+
+    private static int SaturatingSubtract(int value, uint offset)
+        => (int)Math.Clamp((long)value - offset, int.MinValue, int.MaxValue);
 
     private static void AddHistoryPlacement(
         ScreenState screen,
@@ -977,23 +1576,6 @@ internal sealed class KgpTerminalGraphicsState
         screen.HistoryReferences[imageId] = checked(count + 1);
     }
 
-    private static void ReleaseHistoryImage(ScreenState screen, uint imageId)
-    {
-        if (!screen.HistoryReferences.TryGetValue(imageId, out var count))
-            throw new InvalidOperationException($"KGP image {imageId} has no history reference.");
-
-        if (count == 1)
-        {
-            screen.HistoryReferences.Remove(imageId);
-            if (!HasPlacementReference(screen, imageId))
-                screen.ImageStore.RemoveImage(imageId);
-        }
-        else
-        {
-            screen.HistoryReferences[imageId] = count - 1;
-        }
-    }
-
     private void ClipMainHistoryToRetainedRows(
         IReadOnlyList<ScrollbackEntry> historyRows,
         int additionalRows,
@@ -1005,6 +1587,8 @@ internal sealed class KgpTerminalGraphicsState
         var rowIndices = new Dictionary<long, int>(historyRows.Count);
         for (var i = 0; i < historyRows.Count; i++)
             rowIndices.Add(historyRows[i].RowId, i);
+        var removedGraphIds = new List<long>();
+        var removedImageIds = new HashSet<uint>();
 
         foreach (var rowId in _main.HistoryPlacements.Keys.ToArray())
         {
@@ -1013,7 +1597,10 @@ internal sealed class KgpTerminalGraphicsState
                 var orphaned = _main.HistoryPlacements[rowId];
                 _main.HistoryPlacements.Remove(rowId);
                 foreach (var historyPlacement in orphaned)
-                    ReleaseHistoryImage(_main, historyPlacement.Placement.ImageId);
+                {
+                    removedGraphIds.Add(historyPlacement.Placement.GraphId);
+                    removedImageIds.Add(historyPlacement.Placement.ImageId);
+                }
                 continue;
             }
 
@@ -1040,7 +1627,8 @@ internal sealed class KgpTerminalGraphicsState
                 if (clipped is null)
                 {
                     placements.RemoveAt(i);
-                    ReleaseHistoryImage(_main, placement.ImageId);
+                    removedGraphIds.Add(placement.GraphId);
+                    removedImageIds.Add(placement.ImageId);
                 }
                 else
                 {
@@ -1051,10 +1639,18 @@ internal sealed class KgpTerminalGraphicsState
             if (placements.Count == 0)
                 _main.HistoryPlacements.Remove(rowId);
         }
+
+        RemovePlacementSubtrees(_main, removedGraphIds);
+        RebuildHistoryReferences(_main);
+        foreach (var imageId in removedImageIds)
+        {
+            if (!HasPlacementReference(_main, imageId))
+                _main.ImageStore.RemoveImage(imageId);
+        }
     }
 
     private static void AddMaterializedHistoryPlacement(
-        ScreenState screen,
+        IReadOnlyDictionary<uint, KgpImageData> images,
         List<KgpPlacement> destination,
         HistoryPlacement historyPlacement,
         int anchorRow,
@@ -1071,9 +1667,8 @@ internal sealed class KgpTerminalGraphicsState
         if (retainedStart >= retainedEnd)
             return;
 
-        var image = screen.ImageStore.GetImageById(placement.ImageId)
-            ?? throw new InvalidOperationException(
-                $"History placement {placement.PlacementId} references missing KGP image {placement.ImageId}.");
+        if (!images.TryGetValue(placement.ImageId, out var image))
+            return;
         var firstRow = checked(
             historyPlacement.FirstRow + (uint)(retainedStart - anchorRow));
         var retainedRows = checked((uint)(retainedEnd - retainedStart));
@@ -1087,7 +1682,7 @@ internal sealed class KgpTerminalGraphicsState
             return;
 
         AddMaterializedPlacement(
-            screen,
+            images,
             destination,
             sliced,
             snapshotStart,
@@ -1098,7 +1693,7 @@ internal sealed class KgpTerminalGraphicsState
     }
 
     private static void AddMaterializedPlacement(
-        ScreenState screen,
+        IReadOnlyDictionary<uint, KgpImageData> images,
         List<KgpPlacement> destination,
         KgpPlacement placement,
         int snapshotStart,
@@ -1107,9 +1702,8 @@ internal sealed class KgpTerminalGraphicsState
         int cellPixelWidth,
         int cellPixelHeight)
     {
-        var image = screen.ImageStore.GetImageById(placement.ImageId)
-            ?? throw new InvalidOperationException(
-                $"Placement {placement.PlacementId} references missing KGP image {placement.ImageId}.");
+        if (!images.TryGetValue(placement.ImageId, out var image))
+            return;
         var clipped = placement.ClipToCellRectangle(
             image,
             snapshotStart,

--- a/src/Hex1b/Kgp/KgpUnicodePlaceholder.cs
+++ b/src/Hex1b/Kgp/KgpUnicodePlaceholder.cs
@@ -101,6 +101,69 @@ internal static class KgpUnicodePlaceholder
             destination);
     }
 
+    internal static void CollectOrigins(
+        ReadOnlySpan<TerminalCell> cells,
+        int absoluteRow,
+        IReadOnlyList<KgpVirtualPlacement> prototypes,
+        IReadOnlyDictionary<uint, KgpImageData> images,
+        int cellPixelWidth,
+        int cellPixelHeight,
+        Dictionary<long, (int Row, int Column)> origins)
+    {
+        PlacementRun? current = null;
+        for (var column = 0; column < cells.Length; column++)
+        {
+            if (!TryDecode(cells[column], out var decoded))
+            {
+                FinalizeOrigin(
+                    current,
+                    absoluteRow,
+                    prototypes,
+                    images,
+                    cellPixelWidth,
+                    cellPixelHeight,
+                    origins);
+                current = null;
+                continue;
+            }
+
+            if (current is { } run && CanAppend(run, decoded))
+            {
+                run.Width++;
+                current = run;
+                continue;
+            }
+
+            FinalizeOrigin(
+                current,
+                absoluteRow,
+                prototypes,
+                images,
+                cellPixelWidth,
+                cellPixelHeight,
+                origins);
+            current = new PlacementRun
+            {
+                ImageIdLow = decoded.ImageIdLow,
+                PlacementId = decoded.PlacementId,
+                Row = decoded.Row ?? 0,
+                Column = decoded.Column ?? 0,
+                ImageIdHigh = decoded.ImageIdHigh ?? 0,
+                ScreenColumn = column,
+                Width = 1,
+            };
+        }
+
+        FinalizeOrigin(
+            current,
+            absoluteRow,
+            prototypes,
+            images,
+            cellPixelWidth,
+            cellPixelHeight,
+            origins);
+    }
+
     private static bool TryDecode(
         TerminalCell cell,
         out IncompletePlacement placement)
@@ -184,23 +247,83 @@ internal static class KgpUnicodePlaceholder
         if (run is not { } value)
             return;
 
-        var imageId = value.ImageIdLow | ((uint)value.ImageIdHigh << 24);
-        if (imageId == 0 ||
-            !images.TryGetValue(imageId, out var image) ||
-            FindPrototype(prototypes, imageId, value.PlacementId) is not { } prototype)
-        {
+        if (!TryResolveRun(
+                value,
+                prototypes,
+                images,
+                cellPixelWidth,
+                cellPixelHeight,
+                out var prototype,
+                out var image,
+                out var columns,
+                out var rows,
+                out var visibleRunWidth))
             return;
-        }
 
         var placement = CreateFragment(
             value,
             snapshotRow,
             prototype,
             image,
+            columns,
+            rows,
+            visibleRunWidth,
             cellPixelWidth,
             cellPixelHeight);
         if (placement is not null)
             destination.Add(placement);
+    }
+
+    private static void FinalizeOrigin(
+        PlacementRun? run,
+        int absoluteRow,
+        IReadOnlyList<KgpVirtualPlacement> prototypes,
+        IReadOnlyDictionary<uint, KgpImageData> images,
+        int cellPixelWidth,
+        int cellPixelHeight,
+        Dictionary<long, (int Row, int Column)> origins)
+    {
+        if (run is not { } value ||
+            !TryResolveRun(
+                value,
+                prototypes,
+                images,
+                cellPixelWidth,
+                cellPixelHeight,
+                out var prototype,
+                out var image,
+                out var columns,
+                out var rows,
+                out var visibleRunWidth) ||
+            CreateFragment(
+                value,
+                absoluteRow,
+                prototype,
+                image,
+                columns,
+                rows,
+                visibleRunWidth,
+                cellPixelWidth,
+                cellPixelHeight) is not { } fragment)
+        {
+            return;
+        }
+
+        var geometry = fragment.RenderGeometry!.Value;
+        var realizedRow = checked(
+            fragment.Row + (int)Math.Floor(geometry.ClipOffsetYInCells));
+        var realizedColumn = checked(
+            fragment.Column + (int)Math.Floor(geometry.ClipOffsetXInCells));
+        if (origins.TryGetValue(prototype.GraphId, out var origin))
+        {
+            origins[prototype.GraphId] = (
+                Math.Min(origin.Row, realizedRow),
+                Math.Min(origin.Column, realizedColumn));
+        }
+        else
+        {
+            origins.Add(prototype.GraphId, (realizedRow, realizedColumn));
+        }
     }
 
     private static KgpVirtualPlacement? FindPrototype(
@@ -232,38 +355,12 @@ internal static class KgpUnicodePlaceholder
         int snapshotRow,
         KgpVirtualPlacement prototype,
         KgpImageData image,
+        uint columns,
+        uint rows,
+        int visibleRunWidth,
         int cellPixelWidth,
         int cellPixelHeight)
     {
-        if (image.Width == 0 ||
-            image.Height == 0 ||
-            cellPixelWidth <= 0 ||
-            cellPixelHeight <= 0)
-        {
-            return null;
-        }
-
-        var columns = prototype.Columns > 0
-            ? prototype.Columns
-            : DivideCeiling(image.Width, checked((uint)cellPixelWidth));
-        var rows = prototype.Rows > 0
-            ? prototype.Rows
-            : DivideCeiling(image.Height, checked((uint)cellPixelHeight));
-        if (columns == 0 ||
-            rows == 0 ||
-            run.Row < 0 ||
-            run.Column < 0 ||
-            (uint)run.Row >= rows ||
-            (uint)run.Column >= columns)
-        {
-            return null;
-        }
-
-        var availableColumns = (ulong)columns - (uint)run.Column;
-        var visibleRunWidth = checked((int)Math.Min((ulong)run.Width, availableColumns));
-        if (visibleRunWidth <= 0)
-            return null;
-
         var boxWidth = (double)columns * cellPixelWidth;
         var boxHeight = (double)rows * cellPixelHeight;
         var scale = Math.Min(boxWidth / image.Width, boxHeight / image.Height);
@@ -326,7 +423,61 @@ internal static class KgpUnicodePlaceholder
             zIndex: -1,
             cellOffsetX: 0,
             cellOffsetY: 0,
-            geometry);
+            geometry,
+            graphId: prototype.GraphId);
+    }
+
+    private static bool TryResolveRun(
+        PlacementRun run,
+        IReadOnlyList<KgpVirtualPlacement> prototypes,
+        IReadOnlyDictionary<uint, KgpImageData> images,
+        int cellPixelWidth,
+        int cellPixelHeight,
+        out KgpVirtualPlacement prototype,
+        out KgpImageData image,
+        out uint columns,
+        out uint rows,
+        out int visibleRunWidth)
+    {
+        prototype = null!;
+        image = null!;
+        columns = 0;
+        rows = 0;
+        visibleRunWidth = 0;
+
+        var imageId = run.ImageIdLow | ((uint)run.ImageIdHigh << 24);
+        if (imageId == 0 ||
+            !images.TryGetValue(imageId, out var foundImage) ||
+            FindPrototype(prototypes, imageId, run.PlacementId) is not { } found ||
+            foundImage.Width == 0 ||
+            foundImage.Height == 0 ||
+            cellPixelWidth <= 0 ||
+            cellPixelHeight <= 0)
+        {
+            return false;
+        }
+
+        prototype = found;
+        image = foundImage;
+        columns = prototype.Columns > 0
+            ? prototype.Columns
+            : DivideCeiling(image.Width, checked((uint)cellPixelWidth));
+        rows = prototype.Rows > 0
+            ? prototype.Rows
+            : DivideCeiling(image.Height, checked((uint)cellPixelHeight));
+        if (columns == 0 ||
+            rows == 0 ||
+            run.Row < 0 ||
+            run.Column < 0 ||
+            (uint)run.Row >= rows ||
+            (uint)run.Column >= columns)
+        {
+            return false;
+        }
+
+        var availableColumns = (ulong)columns - (uint)run.Column;
+        visibleRunWidth = checked((int)Math.Min((ulong)run.Width, availableColumns));
+        return visibleRunWidth > 0;
     }
 
     private static uint ClampToUInt(double value, uint maximum)

--- a/src/Hex1b/Kgp/KgpVirtualPlacement.cs
+++ b/src/Hex1b/Kgp/KgpVirtualPlacement.cs
@@ -1,8 +1,11 @@
 namespace Hex1b;
 
 internal sealed record KgpVirtualPlacement(
+    long GraphId,
     uint ImageId,
     uint PlacementId,
     uint Columns,
-    uint Rows,
-    long CreationOrdinal);
+    uint Rows)
+{
+    internal long CreationOrdinal => GraphId;
+}

--- a/tests/Hex1b.Tests/Hex1bTerminalTests.cs
+++ b/tests/Hex1b.Tests/Hex1bTerminalTests.cs
@@ -894,6 +894,40 @@ public class Hex1bTerminalTests
                 TestContext.Current.CancellationToken);
         Assert.AreEqual(42u, TestSeq.Single(snapshot.KgpPlacements).ImageId);
 
+        await WriteAndAssertForwardedAsync(Encoding.UTF8.GetBytes(
+            KgpTestHelper.BuildCommand(
+                "a=t,f=24,s=1,v=1,i=43,q=2",
+                [0x44, 0x55, 0x66])));
+        var relativeCommand = Encoding.UTF8.GetBytes(
+            KgpTestHelper.BuildCommand(
+                "a=p,i=43,p=8,c=1,r=1,P=42,H=1,V=1,C=0,q=2"));
+        var relativeSplitIndex = split switch
+        {
+            "esc" => 1,
+            "apc-prefix" => 2,
+            "terminator" => relativeCommand.Length - 1,
+            _ => throw new InvalidOperationException(split),
+        };
+        await WriteAndAssertForwardedAsync(
+            relativeCommand.AsMemory(0, relativeSplitIndex));
+        await WriteAndAssertForwardedAsync(
+            relativeCommand.AsMemory(relativeSplitIndex));
+
+        using var relativeSnapshot = await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(
+                value => value.KgpPlacements.Any(
+                    placement => placement.ImageId == 43),
+                TimeSpan.FromSeconds(2),
+                "split relative KGP APC applied")
+            .Build()
+            .ApplyWithCaptureAsync(
+                terminal,
+                TestContext.Current.CancellationToken);
+        var relative = TestSeq.Single(relativeSnapshot.KgpPlacements.Where(
+            placement => placement.ImageId == 43));
+        Assert.AreEqual(1, relative.Row);
+        Assert.AreEqual(1, relative.Column);
+
         cts.Cancel();
         await Assert.ThrowsAsync<OperationCanceledException>(
             async () => await runTask);

--- a/tests/Hex1b.Tests/KgpRelativePlacementTests.cs
+++ b/tests/Hex1b.Tests/KgpRelativePlacementTests.cs
@@ -1,0 +1,1297 @@
+using System.Text;
+using Hex1b.Reflow;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Relative-placement conformance derived from the Kitty and Ghostty revisions
+/// pinned by issue #399.
+/// </summary>
+[TestClass]
+public class KgpRelativePlacementTests
+{
+    private static readonly TerminalCapabilities KgpCapabilities = new()
+    {
+        SupportsKgp = true,
+        SupportsTrueColor = true,
+        Supports256Colors = true,
+        CellPixelWidth = 10,
+        CellPixelHeight = 20,
+    };
+
+    [TestMethod]
+    public void Put_RelativeChildAndGrandchild_AccumulateSignedOffsetsWithoutMovingCursor()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 12, height: 8);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Transmit(terminal, 3);
+        Apply(terminal, "\x1b[3;4H");
+        Put(terminal, "i=1,p=1,c=2,r=2,C=1");
+        Apply(terminal, "\x1b[8;12H");
+        using var before = terminal.CreateSnapshot();
+
+        Put(terminal, "i=2,p=2,c=2,r=1,P=1,Q=1,H=-2,V=3,C=0");
+        Put(terminal, "i=3,p=3,c=1,r=1,P=2,Q=2,H=4,V=-1,C=1");
+
+        using var snapshot = terminal.CreateSnapshot();
+        Assert.AreEqual(before.CursorX, snapshot.CursorX);
+        Assert.AreEqual(before.CursorY, snapshot.CursorY);
+        AssertPlacement(snapshot, imageId: 1, placementId: 1, row: 2, column: 3);
+        AssertPlacement(snapshot, imageId: 2, placementId: 2, row: 5, column: 1);
+        AssertPlacement(snapshot, imageId: 3, placementId: 3, row: 4, column: 5);
+    }
+
+    [TestMethod]
+    public void Put_ExactAndWildcardParentSelection_UseConcreteDeterministicPlacements()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 12, height: 6);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Transmit(terminal, 3);
+        Apply(terminal, "\x1b[1;2H");
+        Put(terminal, "i=1,c=1,r=1,C=1");
+        Apply(terminal, "\x1b[1;10H");
+        Put(terminal, "i=1,c=1,r=1,C=1");
+        Apply(terminal, "\x1b[1;7H");
+        Put(terminal, "i=1,p=7,c=1,r=1,C=1");
+
+        Put(terminal, "i=2,p=2,c=1,r=1,P=1,H=2,V=1,C=1");
+        Put(terminal, "i=3,p=3,c=1,r=1,P=1,Q=7,H=-1,V=2,C=1");
+
+        using var snapshot = terminal.CreateSnapshot();
+        AssertPlacement(snapshot, imageId: 2, placementId: 2, row: 1, column: 3);
+        AssertPlacement(snapshot, imageId: 3, placementId: 3, row: 2, column: 5);
+    }
+
+    [TestMethod]
+    public void Put_MissingParentsAndSelfParent_EmitExactErrorsWithoutMutation()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 10, height: 6);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Apply(terminal, "\x1b[2;3H");
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        using var expected = terminal.CreateSnapshot();
+
+        Apply(terminal, KgpTestHelper.BuildCommand(
+            "a=p,i=999,p=9,P=1,Q=1,C=1"));
+        Assert.AreEqual(
+            "\x1b_Gi=999;ENOENT:Image not found\x1b\\",
+            workload.ReadResponse());
+
+        Apply(terminal, KgpTestHelper.BuildCommand(
+            "a=p,i=2,p=2,P=99,Q=1,C=1"));
+        Assert.AreEqual(
+            "\x1b_Gi=2;ENOPARENT:Parent image not found\x1b\\",
+            workload.ReadResponse());
+
+        Apply(terminal, KgpTestHelper.BuildCommand(
+            "a=p,i=2,p=2,P=2,Q=77,C=1"));
+        Assert.AreEqual(
+            "\x1b_Gi=2;ENOPARENT:Parent placement not found\x1b\\",
+            workload.ReadResponse());
+
+        Apply(terminal, KgpTestHelper.BuildCommand(
+            "a=p,i=2,p=2,P=2,C=1"));
+        Assert.AreEqual(
+            "\x1b_Gi=2;ENOPARENT:Parent placement not found\x1b\\",
+            workload.ReadResponse());
+
+        Apply(terminal, KgpTestHelper.BuildCommand(
+            "a=p,i=1,p=1,P=1,Q=1,H=4,V=4,C=1"));
+        Assert.AreEqual(
+            "\x1b_Gi=1;EINVAL:Placement cannot be its own parent\x1b\\",
+            workload.ReadResponse());
+
+        using var actual = terminal.CreateSnapshot();
+        Assert.AreEqual(expected.CursorX, actual.CursorX);
+        Assert.AreEqual(expected.CursorY, actual.CursorY);
+        Assert.AreEqual(1, actual.KgpPlacements.Count);
+        AssertPlacement(actual, imageId: 1, placementId: 1, row: 1, column: 2);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(2));
+    }
+
+    [TestMethod]
+    [DataRow(1, true)]
+    [DataRow(2, false)]
+    public void Put_MissingParent_QuietModePreservesErrorSuppression(
+        int quiet,
+        bool expectsResponse)
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        Transmit(terminal, 1);
+
+        Apply(terminal, KgpTestHelper.BuildCommand(
+            $"a=p,i=1,p=1,P=99,Q=1,q={quiet}"));
+
+        if (expectsResponse)
+        {
+            Assert.AreEqual(
+                "\x1b_Gi=1;ENOPARENT:Parent image not found\x1b\\",
+                workload.ReadResponse());
+        }
+        else
+        {
+            workload.AssertNoResponse();
+        }
+        Assert.IsEmpty(terminal.KgpPlacements);
+    }
+
+    [TestMethod]
+    public void Put_CycleReplacement_EmitsExactErrorAndPreservesOriginalGraph()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 10, height: 6);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Apply(terminal, "\x1b[2;2H");
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        Put(terminal, "i=2,p=2,c=1,r=1,P=1,Q=1,H=2,V=1,C=1");
+
+        Apply(terminal, KgpTestHelper.BuildCommand(
+            "a=p,i=1,p=1,P=2,Q=2,H=5,V=5,C=1"));
+
+        Assert.AreEqual(
+            "\x1b_Gi=1;ECYCLE:Parent chain creates a cycle\x1b\\",
+            workload.ReadResponse());
+        using var snapshot = terminal.CreateSnapshot();
+        AssertPlacement(snapshot, imageId: 1, placementId: 1, row: 1, column: 1);
+        AssertPlacement(snapshot, imageId: 2, placementId: 2, row: 2, column: 3);
+    }
+
+    [TestMethod]
+    public void Put_EightParentLinksSucceed_NinthEmitsTooDeep()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 12, height: 4);
+        Transmit(terminal, 1);
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        for (var placementId = 2; placementId <= 9; placementId++)
+        {
+            Put(
+                terminal,
+                $"i=1,p={placementId},c=1,r=1,P=1,Q={placementId - 1},C=1");
+        }
+
+        Apply(terminal, KgpTestHelper.BuildCommand(
+            "a=p,i=1,p=10,c=1,r=1,P=1,Q=9,C=1"));
+
+        Assert.AreEqual(
+            "\x1b_Gi=1;ETOODEEP:Parent chain too deep\x1b\\",
+            workload.ReadResponse());
+        using var snapshot = terminal.CreateSnapshot();
+        Assert.AreEqual(9, snapshot.KgpPlacements.Count);
+        Assert.IsFalse(snapshot.KgpPlacements.Any(
+            placement => placement.PlacementId == 10));
+    }
+
+    [TestMethod]
+    public void Put_ReparentingAncestorThatWouldDeepenDescendantPastLimit_IsRejected()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 12, height: 4);
+        Transmit(terminal, 1);
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        for (var placementId = 2; placementId <= 8; placementId++)
+        {
+            Put(
+                terminal,
+                $"i=1,p={placementId},c=1,r=1,P=1,Q={placementId - 1},C=1");
+        }
+        Put(terminal, "i=1,p=20,c=1,r=1,C=1");
+        Put(terminal, "i=1,p=21,c=1,r=1,P=1,Q=20,C=1");
+
+        Apply(terminal, KgpTestHelper.BuildCommand(
+            "a=p,i=1,p=1,c=1,r=1,P=1,Q=21,C=1"));
+
+        Assert.AreEqual(
+            "\x1b_Gi=1;ETOODEEP:Parent chain too deep\x1b\\",
+            workload.ReadResponse());
+        using var snapshot = terminal.CreateSnapshot();
+        Assert.AreEqual(10, snapshot.KgpPlacements.Count);
+        Assert.IsTrue(snapshot.KgpPlacements.Any(
+            placement => placement.PlacementId == 8));
+    }
+
+    [TestMethod]
+    public void Put_ZeroPlacementIdRelativeChildren_AreDistinctOwners()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 8, height: 4);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+
+        Put(terminal, "i=2,c=1,r=1,P=1,Q=1,H=1,C=1");
+        Put(terminal, "i=2,c=1,r=1,P=1,Q=1,H=2,C=1");
+
+        using var snapshot = terminal.CreateSnapshot();
+        var children = snapshot.KgpPlacements
+            .Where(placement => placement.ImageId == 2)
+            .OrderBy(placement => placement.Column)
+            .ToArray();
+        Assert.AreEqual(2, children.Length);
+        Assert.AreEqual(0u, children[0].PlacementId);
+        Assert.AreEqual(1, children[0].Column);
+        Assert.AreEqual(2, children[1].Column);
+        Assert.AreEqual(2, snapshot.KgpImages.Count);
+    }
+
+    [TestMethod]
+    public void Put_WildcardVirtualParentAndPlaceholderChooseSameOldestPrototype()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 8, height: 4);
+        Transmit(terminal, 42);
+        Transmit(terminal, 2);
+        Put(terminal, "i=42,U=1,c=1,r=1,C=1");
+        Put(terminal, "i=42,U=1,c=2,r=1,C=1");
+        Put(terminal, "i=2,p=2,c=1,r=1,P=42,H=1,C=1");
+        Apply(
+            terminal,
+            Foreground(42) +
+            Placeholder(row: 0, column: 0) +
+            "\x1b[0m");
+
+        using var snapshot = terminal.CreateSnapshot();
+        Assert.AreEqual(2, terminal.KgpVirtualPlacementCount);
+        AssertPlacement(snapshot, imageId: 2, placementId: 2, row: 0, column: 1);
+    }
+
+    [TestMethod]
+    public void TransmitAndDisplay_MissingRelativeParentStoresImageAndDoesNotMoveCursor()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 8, height: 4);
+        Apply(terminal, "\x1b[3;4H");
+        using var before = terminal.CreateSnapshot();
+
+        Apply(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=T,f=32,s=1,v=1,i=2,p=2,c=1,r=1,P=99,Q=1,C=0",
+                KgpTestHelper.CreatePixelData(1, 1)));
+
+        Assert.AreEqual(
+            "\x1b_Gi=2;ENOPARENT:Parent image not found\x1b\\",
+            workload.ReadResponse());
+        using var after = terminal.CreateSnapshot();
+        Assert.AreEqual(before.CursorX, after.CursorX);
+        Assert.AreEqual(before.CursorY, after.CursorY);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(2));
+        Assert.IsEmpty(after.KgpPlacements);
+    }
+
+    [TestMethod]
+    public void Put_VirtualParentWithoutCellsDefersChild_ThenUsesIndependentMinimumOrigin()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 10, height: 7);
+        AddVirtualImage(terminal, imageId: 42, placementId: 7);
+        Transmit(terminal, 2);
+        Transmit(terminal, 3);
+        Put(terminal, "i=2,p=2,c=1,r=1,P=42,Q=7,H=1,V=2,C=1");
+        Put(terminal, "i=3,p=3,c=1,r=1,P=2,Q=2,H=2,V=-1,C=1");
+
+        using (var unresolved = terminal.CreateSnapshot())
+        {
+            Assert.IsEmpty(unresolved.KgpPlacements);
+            Assert.IsNotNull(terminal.KgpImageStore.GetImageById(2));
+        }
+
+        Apply(
+            terminal,
+            "\x1b[2;6H" +
+            Foreground(42) +
+            UnderlineColor(7) +
+            Placeholder(row: 0, column: 0) +
+            "\x1b[5;2H" +
+            Placeholder(row: 0, column: 0) +
+            "\x1b[0m");
+
+        using (var realized = terminal.CreateSnapshot())
+        {
+            Assert.AreEqual(
+                2,
+                realized.KgpPlacements.Count(
+                    placement => placement.ImageId == 42));
+            AssertPlacement(
+                realized,
+                imageId: 2,
+                placementId: 2,
+                row: 3,
+                column: 2);
+            AssertPlacement(
+                realized,
+                imageId: 3,
+                placementId: 3,
+                row: 2,
+                column: 4);
+        }
+
+        Apply(terminal, "\x1b[2J");
+        using var erased = terminal.CreateSnapshot();
+        Assert.IsEmpty(erased.KgpPlacements);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(42));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(2));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(3));
+    }
+
+    [TestMethod]
+    public void VirtualParent_LetterboxedPlaceholderWithoutRenderedFragment_DoesNotSetOrigin()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 8, height: 5);
+        Apply(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=T,U=1,f=24,s=10,v=10,i=42,p=7,c=1,r=4,q=2",
+                KgpTestHelper.CreatePixelData(10, 10, KgpFormat.Rgb24)));
+        Transmit(terminal, 2);
+        Put(terminal, "i=2,p=2,c=1,r=1,P=42,Q=7,C=1");
+        Apply(
+            terminal,
+            Foreground(42) +
+            UnderlineColor(7) +
+            Placeholder(row: 0, column: 0) +
+            "\x1b[3;4H" +
+            Placeholder(row: 2, column: 0) +
+            "\x1b[0m");
+
+        using var snapshot = terminal.CreateSnapshot();
+        AssertPlacement(snapshot, imageId: 2, placementId: 2, row: 2, column: 3);
+    }
+
+    [TestMethod]
+    public void VirtualParent_LeadingLetterboxCellsDoNotOffsetRenderedOrigin()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 6, height: 3);
+        Apply(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=T,U=1,f=24,s=10,v=10,i=42,p=7,c=4,r=1,q=2",
+                KgpTestHelper.CreatePixelData(10, 10, KgpFormat.Rgb24)));
+        Transmit(terminal, 2);
+        Put(terminal, "i=2,p=2,c=1,r=1,P=42,Q=7,C=1");
+        Apply(
+            terminal,
+            Foreground(42) +
+            UnderlineColor(7) +
+            Placeholder(row: 0, column: 0) +
+            Placeholder() +
+            Placeholder() +
+            Placeholder() +
+            "\x1b[0m");
+
+        using var snapshot = terminal.CreateSnapshot();
+        AssertPlacement(snapshot, imageId: 2, placementId: 2, row: 0, column: 1);
+    }
+
+    [TestMethod]
+    public void VirtualParent_ReflowedPlaceholderMovesRelativeChild()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 4,
+            height: 3,
+            scrollbackCapacity: 4,
+            reflow: KittyReflowStrategy.Instance);
+        AddVirtualImage(terminal, imageId: 42, placementId: 7);
+        Transmit(terminal, 2);
+        Put(terminal, "i=2,p=2,c=1,r=1,P=42,Q=7,H=-1,V=1,C=1");
+        Apply(
+            terminal,
+            "A" +
+            Foreground(42) +
+            UnderlineColor(7) +
+            Placeholder(row: 0, column: 0) +
+            "\x1b[0mBCDE");
+
+        terminal.Resize(2, 3);
+
+        using var snapshot = terminal.CreateSnapshot();
+        AssertPlacement(snapshot, imageId: 42, placementId: 7, row: 0, column: 1);
+        AssertPlacement(snapshot, imageId: 2, placementId: 2, row: 1, column: 0);
+    }
+
+    [TestMethod]
+    public void Put_ExplicitParentReplacementAndCrossKindReplacement_MoveDescendant()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 10, height: 7);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Apply(terminal, "\x1b[1;1H");
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        Put(terminal, "i=2,p=2,c=1,r=1,P=1,Q=1,H=1,V=1,C=1");
+        Apply(terminal, "\x1b[4;5H");
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+
+        using (var moved = terminal.CreateSnapshot())
+            AssertPlacement(moved, imageId: 2, placementId: 2, row: 4, column: 5);
+
+        Put(terminal, "i=1,p=1,U=1,c=1,r=1,C=1");
+        Apply(
+            terminal,
+            "\x1b[2;3H" +
+            Foreground(1) +
+            UnderlineColor(1) +
+            Placeholder(row: 0, column: 0) +
+            "\x1b[0m");
+
+        using var virtualParent = terminal.CreateSnapshot();
+        AssertPlacement(
+            virtualParent,
+            imageId: 2,
+            placementId: 2,
+            row: 2,
+            column: 3);
+
+        Apply(terminal, "\x1b[5;2H");
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        using var ordinaryParent = terminal.CreateSnapshot();
+        AssertPlacement(
+            ordinaryParent,
+            imageId: 2,
+            placementId: 2,
+            row: 5,
+            column: 2);
+    }
+
+    [TestMethod]
+    public void Delete_ParentCascadesAndReclaimsOnlyUnownedDescendantImages()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 10, height: 7);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Transmit(terminal, 3);
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        Put(terminal, "i=2,p=2,c=1,r=1,P=1,Q=1,H=1,C=1");
+        Put(terminal, "i=3,p=3,c=1,r=1,P=2,Q=2,H=1,C=1");
+        Apply(terminal, "\x1b[4;4H");
+        Put(terminal, "i=2,p=9,c=1,r=1,C=1");
+
+        Apply(terminal, KgpTestHelper.BuildCommand(
+            "a=d,d=i,i=1,p=1"));
+
+        using var snapshot = terminal.CreateSnapshot();
+        var survivor = TestSeq.Single(snapshot.KgpPlacements);
+        Assert.AreEqual(2u, survivor.ImageId);
+        Assert.AreEqual(9u, survivor.PlacementId);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(2));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(3));
+        Assert.IsFalse(snapshot.KgpImages.ContainsKey(3));
+    }
+
+    [TestMethod]
+    public void Delete_ParentAndSameImageDescendant_ReclaimsNowUnownedImage()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        Transmit(terminal, 1);
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        Put(terminal, "i=1,p=2,c=1,r=1,P=1,Q=1,H=1,C=1");
+
+        Apply(terminal, KgpTestHelper.BuildCommand(
+            "a=d,d=i,i=1,p=1"));
+
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+    }
+
+    [TestMethod]
+    public void Scrollback_ParentAnchorMovesChildAndPruningRemovesSubtree()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 8,
+            height: 4,
+            scrollbackCapacity: 2);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        Put(terminal, "i=2,p=2,c=1,r=1,P=1,Q=1,V=1,C=1");
+
+        Apply(terminal, "\x1b[S");
+
+        using (var active = terminal.CreateSnapshot())
+            AssertPlacement(active, imageId: 2, placementId: 2, row: 0, column: 0);
+        using (var history = terminal.CreateSnapshot(scrollbackLines: 1))
+        {
+            AssertPlacement(history, imageId: 1, placementId: 1, row: 0, column: 0);
+            AssertPlacement(history, imageId: 2, placementId: 2, row: 1, column: 0);
+        }
+
+        Apply(terminal, "\x1b[S\x1b[S");
+
+        Assert.AreEqual(0, terminal.KgpHistoryPlacementCount);
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(2));
+        using var pruned = terminal.CreateSnapshot(scrollbackLines: 2);
+        Assert.IsEmpty(pruned.KgpPlacements);
+        Assert.IsEmpty(pruned.KgpImages);
+    }
+
+    [TestMethod]
+    public void Scrollback_CapacityReanchorPreservesParentsLogicalOriginForChild()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 8,
+            height: 3,
+            scrollbackCapacity: 1);
+        Apply(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=t,f=32,s=10,v=60,i=1,q=2",
+                KgpTestHelper.CreatePixelData(10, 60)));
+        Transmit(terminal, 2);
+        Put(terminal, "i=1,p=1,c=1,r=3,C=1");
+        Put(terminal, "i=2,p=2,c=1,r=1,P=1,Q=1,V=2,C=1");
+
+        Apply(terminal, "\x1b[S\x1b[S");
+
+        using var active = terminal.CreateSnapshot();
+        AssertPlacement(active, imageId: 2, placementId: 2, row: 0, column: 0);
+        Assert.AreEqual(1, terminal.KgpHistoryPlacementCount);
+    }
+
+    [TestMethod]
+    public void Put_HistoryParentResolvesAndSameIdentityReplacementReturnsItToActiveScreen()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 8,
+            height: 4,
+            scrollbackCapacity: 2);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        Apply(terminal, "\x1b[S");
+
+        Put(terminal, "i=2,p=2,c=1,r=1,P=1,Q=1,V=1,C=1");
+        using (var active = terminal.CreateSnapshot())
+            AssertPlacement(active, imageId: 2, placementId: 2, row: 0, column: 0);
+
+        Apply(terminal, "\x1b[3;4H");
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+
+        Assert.AreEqual(0, terminal.KgpHistoryPlacementCount);
+        Assert.AreEqual(0, terminal.GetKgpHistoryReferenceCount(1));
+        using var moved = terminal.CreateSnapshot(scrollbackLines: 1);
+        AssertPlacement(moved, imageId: 1, placementId: 1, row: 3, column: 3);
+        AssertPlacement(moved, imageId: 2, placementId: 2, row: 4, column: 3);
+    }
+
+    [TestMethod]
+    public void VirtualParent_ScrollbackAndPruningUpdateThenUnresolveChild()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 8,
+            height: 3,
+            scrollbackCapacity: 1);
+        AddVirtualImage(terminal, imageId: 42, placementId: 7);
+        Transmit(terminal, 2);
+        Put(terminal, "i=2,p=2,c=1,r=1,P=42,Q=7,V=1,C=1");
+        Apply(
+            terminal,
+            Foreground(42) +
+            UnderlineColor(7) +
+            Placeholder(row: 0, column: 0) +
+            "\x1b[0m");
+
+        Apply(terminal, "\x1b[S");
+
+        using (var active = terminal.CreateSnapshot())
+            AssertPlacement(active, imageId: 2, placementId: 2, row: 0, column: 0);
+        using (var history = terminal.CreateSnapshot(scrollbackLines: 1))
+        {
+            AssertPlacement(history, imageId: 42, placementId: 7, row: 0, column: 0);
+            AssertPlacement(history, imageId: 2, placementId: 2, row: 1, column: 0);
+        }
+
+        Apply(terminal, "\x1b[S");
+
+        Assert.AreEqual(1, terminal.KgpVirtualPlacementCount);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(2));
+        using var unresolved = terminal.CreateSnapshot(scrollbackLines: 1);
+        Assert.IsEmpty(unresolved.KgpPlacements);
+    }
+
+    [TestMethod]
+    public void VirtualParent_OffWidthHistoryCellCanAnchorVisibleNegativeOffsetChild()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 8,
+            height: 3,
+            scrollbackCapacity: 2,
+            reflow: NoReflowStrategy.Instance);
+        AddVirtualImage(terminal, imageId: 42, placementId: 7);
+        Transmit(terminal, 2);
+        Put(terminal, "i=2,p=2,c=1,r=1,P=42,Q=7,H=-7,V=1,C=1");
+        Apply(
+            terminal,
+            "\x1b[1;8H" +
+            Foreground(42) +
+            UnderlineColor(7) +
+            Placeholder(row: 0, column: 0) +
+            "\x1b[0m\x1b[S");
+
+        terminal.Resize(4, 3);
+
+        using var snapshot = terminal.CreateSnapshot();
+        AssertPlacement(snapshot, imageId: 2, placementId: 2, row: 0, column: 0);
+    }
+
+    [TestMethod]
+    public void Reflow_ParentAnchorMovesRelativeChildWithMappedText()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 6,
+            height: 3,
+            reflow: KittyReflowStrategy.Instance);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Apply(terminal, "ABCDEF\x1b[1;5H");
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        Put(terminal, "i=2,p=2,c=1,r=1,P=1,Q=1,H=1,C=1");
+
+        terminal.Resize(3, 3);
+
+        using var snapshot = terminal.CreateSnapshot();
+        AssertPlacement(snapshot, imageId: 1, placementId: 1, row: 1, column: 1);
+        AssertPlacement(snapshot, imageId: 2, placementId: 2, row: 1, column: 2);
+    }
+
+    [TestMethod]
+    public void MarginScroll_MovesRootAndRelativeChildTogether()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 6, height: 5);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Apply(terminal, "\x1b[3;2H");
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        Put(terminal, "i=2,p=2,c=1,r=1,P=1,Q=1,V=1,C=1");
+
+        Apply(terminal, "\x1b[2;4r\x1b[S");
+
+        using var snapshot = terminal.CreateSnapshot();
+        AssertPlacement(snapshot, imageId: 1, placementId: 1, row: 1, column: 1);
+        AssertPlacement(snapshot, imageId: 2, placementId: 2, row: 2, column: 1);
+    }
+
+    [TestMethod]
+    public void Resize_ClippedParentCascadesChildWithoutFreeingParentData()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 6, height: 3);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Apply(terminal, "\x1b[1;5H");
+        Put(terminal, "i=1,p=1,c=2,r=1,C=1");
+        Put(terminal, "i=2,p=2,c=1,r=1,P=1,Q=1,C=1");
+
+        terminal.Resize(3, 3);
+
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(2));
+    }
+
+    [TestMethod]
+    public void Screens_ResolveParentsOnlyWithinActiveScreenAndRestoreMainGraph()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 10, height: 6);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Apply(terminal, "\x1b[2;2H");
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        Put(terminal, "i=2,p=2,c=1,r=1,P=1,Q=1,H=1,C=1");
+
+        Apply(terminal, "\x1b[?1049h");
+        Transmit(terminal, 2);
+        Apply(terminal, KgpTestHelper.BuildCommand(
+            "a=p,i=2,p=2,P=1,Q=1,C=1"));
+        Assert.AreEqual(
+            "\x1b_Gi=2;ENOPARENT:Parent image not found\x1b\\",
+            workload.ReadResponse());
+
+        Transmit(terminal, 1);
+        Apply(terminal, "\x1b[4;5H");
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        Put(terminal, "i=2,p=2,c=1,r=1,P=1,Q=1,H=1,C=1");
+        using (var alternate = terminal.CreateSnapshot())
+        {
+            Assert.IsTrue(alternate.InAlternateScreen);
+            AssertPlacement(
+                alternate,
+                imageId: 2,
+                placementId: 2,
+                row: 3,
+                column: 5);
+        }
+
+        Apply(terminal, "\x1b[?1049l");
+        using var main = terminal.CreateSnapshot();
+        Assert.IsFalse(main.InAlternateScreen);
+        AssertPlacement(main, imageId: 2, placementId: 2, row: 1, column: 2);
+    }
+
+    [TestMethod]
+    public void RelativePlacement_ClipsDestinationAndSourceAtViewportEdges()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 5, height: 4);
+        Transmit(terminal, 1);
+        Apply(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=t,f=32,s=20,v=20,i=2,q=2",
+                KgpTestHelper.CreatePixelData(20, 20)));
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        Put(terminal, "i=2,p=2,c=2,r=2,P=1,Q=1,H=-1,V=-1,C=1");
+
+        using var snapshot = terminal.CreateSnapshot();
+        var child = TestSeq.Single(snapshot.KgpPlacements.Where(
+            placement => placement.ImageId == 2));
+        Assert.AreEqual(0, child.Row);
+        Assert.AreEqual(0, child.Column);
+        Assert.AreEqual(1u, child.DisplayColumns);
+        Assert.AreEqual(1u, child.DisplayRows);
+        Assert.AreEqual(10u, child.SourceX);
+        Assert.AreEqual(10u, child.SourceY);
+        Assert.AreEqual(10u, child.SourceWidth);
+        Assert.AreEqual(10u, child.SourceHeight);
+    }
+
+    [TestMethod]
+    public void Delete_PositionalParentMatch_CascadesDescendant()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 8, height: 4);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Apply(terminal, "\x1b[2;3H");
+        Put(terminal, "i=1,p=1,c=2,r=1,C=1");
+        Put(terminal, "i=2,p=2,c=1,r=1,P=1,Q=1,H=2,C=1");
+        Apply(terminal, "\x1b[2;3H");
+
+        Apply(terminal, KgpTestHelper.BuildCommand("a=d,d=c"));
+
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(2));
+    }
+
+    [TestMethod]
+    public void DeleteAll_VisibleChildOfHistoryParent_RemovesChildPlacement()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 8,
+            height: 4,
+            scrollbackCapacity: 2);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        Put(terminal, "i=2,p=2,c=1,r=1,P=1,Q=1,V=1,C=1");
+        Apply(terminal, "\x1b[S");
+        AssertPlacement(
+            terminal.CreateSnapshot(),
+            imageId: 2,
+            placementId: 2,
+            row: 0,
+            column: 0);
+
+        Apply(terminal, KgpTestHelper.BuildCommand("a=d,d=a"));
+
+        Assert.IsEmpty(terminal.CreateSnapshot().KgpPlacements);
+        Assert.AreEqual(1, terminal.KgpHistoryPlacementCount);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(2));
+    }
+
+    [TestMethod]
+    public void Ed2_VisibleChildOfHistoryParent_RemovesChildAndItsUnownedData()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 8,
+            height: 4,
+            scrollbackCapacity: 2);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        Put(terminal, "i=2,p=2,c=1,r=1,P=1,Q=1,V=1,C=1");
+        Apply(terminal, "\x1b[S");
+        AssertPlacement(
+            terminal.CreateSnapshot(),
+            imageId: 2,
+            placementId: 2,
+            row: 0,
+            column: 0);
+
+        Apply(terminal, "\x1b[2J");
+
+        Assert.IsEmpty(terminal.CreateSnapshot().KgpPlacements);
+        Assert.AreEqual(1, terminal.KgpHistoryPlacementCount);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(2));
+    }
+
+    [TestMethod]
+    public void DeleteByZ_UnresolvedRelativePlacement_DoesNotReappear()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 8, height: 4);
+        AddVirtualImage(terminal, imageId: 42, placementId: 7);
+        Transmit(terminal, 2);
+        Put(terminal, "i=2,p=2,c=1,r=1,z=5,P=42,Q=7,C=1");
+
+        Apply(terminal, KgpTestHelper.BuildCommand("a=d,d=z,z=5"));
+        Apply(
+            terminal,
+            Foreground(42) +
+            UnderlineColor(7) +
+            Placeholder(row: 0, column: 0) +
+            "\x1b[0m");
+
+        using var snapshot = terminal.CreateSnapshot();
+        Assert.IsFalse(snapshot.KgpPlacements.Any(
+            placement => placement.ImageId == 2));
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(2));
+    }
+
+    [TestMethod]
+    [DataRow("a=d,d=z,z=5")]
+    [DataRow("a=d,d=r,x=5,y=5")]
+    public void Delete_ZAndRangeParentMatches_CascadeDescendant(string controls)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 8, height: 4);
+        Transmit(terminal, 5);
+        Transmit(terminal, 6);
+        Put(terminal, "i=5,p=1,c=1,r=1,z=5,C=1");
+        Put(terminal, "i=6,p=2,c=1,r=1,P=5,Q=1,H=1,C=1");
+
+        Apply(terminal, KgpTestHelper.BuildCommand(controls));
+
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(5));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(6));
+    }
+
+    [TestMethod]
+    public void DeleteByRange_HistoryParent_CascadesActiveRelativeChild()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 8,
+            height: 4,
+            scrollbackCapacity: 2);
+        Transmit(terminal, 5);
+        Transmit(terminal, 6);
+        Put(terminal, "i=5,p=1,c=1,r=1,C=1");
+        Put(terminal, "i=6,p=2,c=1,r=1,P=5,Q=1,V=1,C=1");
+        Apply(terminal, "\x1b[S");
+
+        Apply(terminal, KgpTestHelper.BuildCommand(
+            "a=d,d=r,x=5,y=5"));
+
+        Assert.AreEqual(0, terminal.KgpHistoryPlacementCount);
+        Assert.IsEmpty(terminal.CreateSnapshot(scrollbackLines: 1).KgpPlacements);
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(5));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(6));
+    }
+
+    [TestMethod]
+    public void Delete_UnrealizedVirtualParent_CascadesStoredChild()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        AddVirtualImage(terminal, imageId: 42, placementId: 7);
+        Transmit(terminal, 2);
+        Put(terminal, "i=2,p=2,c=1,r=1,P=42,Q=7,C=1");
+
+        Apply(terminal, KgpTestHelper.BuildCommand(
+            "a=d,d=i,i=42,p=7"));
+
+        Assert.AreEqual(0, terminal.KgpVirtualPlacementCount);
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(2));
+        Assert.IsEmpty(terminal.CreateSnapshot().KgpPlacements);
+    }
+
+    [TestMethod]
+    public void DeleteById_DataLessVirtualParentStillCascadesStoredChild()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        AddVirtualImage(terminal, imageId: 42, placementId: 7);
+        Transmit(terminal, 2);
+        Put(terminal, "i=2,p=2,c=1,r=1,P=42,Q=7,C=1");
+        Assert.IsTrue(terminal.KgpImageStore.RemoveImage(42));
+
+        Apply(terminal, KgpTestHelper.BuildCommand(
+            "a=d,d=i,i=42,p=7"));
+
+        Assert.AreEqual(0, terminal.KgpVirtualPlacementCount);
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(2));
+        Assert.IsEmpty(terminal.CreateSnapshot().KgpPlacements);
+    }
+
+    [TestMethod]
+    public void Retransmit_ParentImage_RemovesSubtreeBeforeReplacement()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        Put(terminal, "i=2,p=2,c=1,r=1,P=1,Q=1,C=1");
+
+        Apply(
+            terminal,
+            KgpTestHelper.BuildTransmitCommand(
+                1,
+                width: 2,
+                height: 1,
+                quiet: 2,
+                fillByte: 0x44));
+
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.AreEqual(2u, terminal.KgpImageStore.GetImageById(1)!.Width);
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(2));
+    }
+
+    [TestMethod]
+    public void AnonymousImageRelocation_PreservesRelativePlacementAndParentEdge()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 8, height: 4);
+        Transmit(terminal, 10);
+        Put(terminal, "i=10,p=1,c=1,r=1,C=1");
+        Apply(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=T,f=32,s=1,v=1,c=1,r=1,P=10,Q=1,H=1,C=1,q=2",
+                KgpTestHelper.CreatePixelData(1, 1, fillByte: 0x33)));
+        var anonymous = TestSeq.Single(terminal.KgpPlacements.Where(
+            placement => placement.ImageId != 10));
+        Assert.AreEqual(1u, anonymous.ImageId);
+
+        Apply(
+            terminal,
+            KgpTestHelper.BuildTransmitCommand(
+                1,
+                width: 1,
+                height: 1,
+                quiet: 2,
+                fillByte: 0x44));
+
+        using var snapshot = terminal.CreateSnapshot();
+        var relocated = TestSeq.Single(snapshot.KgpPlacements.Where(
+            placement => placement.ImageId != 10));
+        Assert.AreEqual(2u, relocated.ImageId);
+        Assert.AreEqual(1, relocated.Column);
+        Assert.AreEqual(0x33, snapshot.KgpImages[2].Data[0]);
+        Assert.AreEqual(0x44, terminal.KgpImageStore.GetImageById(1)!.Data[0]);
+    }
+
+    [TestMethod]
+    [DataRow("\x1b[2J")]
+    [DataRow("\u001bc")]
+    public void TerminalClear_ParentRemovalCascadesAllDescendants(string operation)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        Put(terminal, "i=2,p=2,c=1,r=1,P=1,Q=1,C=1");
+
+        Apply(terminal, operation);
+
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+    }
+
+    [TestMethod]
+    public void Dispose_ParentGraphReleasesBothPlacementAndImageOwners()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        var terminal = CreateTerminal(workload);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        Put(terminal, "i=2,p=2,c=1,r=1,P=1,Q=1,C=1");
+
+        terminal.Dispose();
+
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        Assert.IsEmpty(terminal.KgpPlacements);
+    }
+
+    [TestMethod]
+    public void Snapshot_ParentReplacementDoesNotMutateCapturedDescendant()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 10, height: 6);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        Put(terminal, "i=2,p=2,c=1,r=1,P=1,Q=1,H=1,V=1,C=1");
+        using var before = terminal.CreateSnapshot();
+
+        Apply(terminal, "\x1b[4;5H");
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+
+        AssertPlacement(before, imageId: 2, placementId: 2, row: 1, column: 1);
+        using var after = terminal.CreateSnapshot();
+        AssertPlacement(after, imageId: 2, placementId: 2, row: 4, column: 5);
+    }
+
+    [TestMethod]
+    public async Task Snapshot_ConcurrentParentReplacement_ContainsOneAtomicGraphGeneration()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 10, height: 6);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Put(terminal, "i=1,p=1,c=1,r=1,C=1");
+        Put(terminal, "i=2,p=2,c=1,r=1,P=1,Q=1,H=1,V=1,C=1");
+        var replacement = AnsiTokenizer.Tokenize(
+            "\x1b[4;5H" +
+            KgpTestHelper.BuildCommand(
+                "a=p,i=1,p=1,c=1,r=1,C=1,q=2"));
+        using var barrier = new Barrier(2);
+        var writer = Task.Run(() =>
+        {
+            barrier.SignalAndWait();
+            terminal.ApplyTokens(replacement);
+        });
+
+        barrier.SignalAndWait();
+        using var snapshot = terminal.CreateSnapshot();
+        await writer;
+
+        var parent = TestSeq.Single(snapshot.KgpPlacements.Where(
+            placement => placement.PlacementId == 1));
+        var child = TestSeq.Single(snapshot.KgpPlacements.Where(
+            placement => placement.PlacementId == 2));
+        Assert.AreEqual(parent.Row + 1, child.Row);
+        Assert.AreEqual(parent.Column + 1, child.Column);
+        Assert.IsTrue(
+            (parent.Row == 0 && parent.Column == 0) ||
+            (parent.Row == 3 && parent.Column == 4));
+    }
+
+    [TestMethod]
+    public void Svg_RelativePlacementsUseEffectiveCoordinatesAndOwnZOrder()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 10, height: 6);
+        Transmit(terminal, 1);
+        Transmit(terminal, 2);
+        Apply(terminal, "\x1b[2;3H");
+        Put(terminal, "i=1,p=1,c=1,r=1,z=5,C=1");
+        Put(terminal, "i=2,p=2,c=1,r=1,z=-2,P=1,Q=1,H=2,V=1,C=1");
+
+        var svg = terminal.CreateSnapshot().ToSvg();
+        var parent = GetSvgImageElement(svg, imageId: 1);
+        var child = GetSvgImageElement(svg, imageId: 2);
+        Assert.Contains("x=\"20\"", parent);
+        Assert.Contains("y=\"20\"", parent);
+        Assert.Contains("x=\"40\"", child);
+        Assert.Contains("y=\"40\"", child);
+        Assert.IsTrue(
+            svg.IndexOf(child, StringComparison.Ordinal) <
+            svg.IndexOf(parent, StringComparison.Ordinal));
+    }
+
+    private static Hex1bTerminal CreateTerminal(
+        IHex1bTerminalWorkloadAdapter workload,
+        int width = 20,
+        int height = 10,
+        int? scrollbackCapacity = null,
+        ITerminalReflowProvider? reflow = null)
+    {
+        var builder = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithHeadless(KgpCapabilities)
+            .WithDimensions(width, height);
+        if (scrollbackCapacity.HasValue)
+            builder.WithScrollback(scrollbackCapacity.Value);
+        if (reflow is not null)
+            builder.WithReflow(reflow);
+        return builder.Build();
+    }
+
+    private static void Transmit(Hex1bTerminal terminal, uint imageId)
+        => Apply(
+            terminal,
+            KgpTestHelper.BuildTransmitCommand(
+                imageId,
+                width: 1,
+                height: 1,
+                quiet: 2));
+
+    private static void Put(Hex1bTerminal terminal, string controls)
+        => Apply(
+            terminal,
+            KgpTestHelper.BuildCommand($"a=p,{controls},q=2"));
+
+    private static void AddVirtualImage(
+        Hex1bTerminal terminal,
+        uint imageId,
+        uint placementId)
+        => Apply(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                $"a=T,U=1,f=24,s=10,v=20,i={imageId},p={placementId},c=1,r=1,q=2",
+                KgpTestHelper.CreatePixelData(
+                    10,
+                    20,
+                    KgpFormat.Rgb24)));
+
+    private static void Apply(Hex1bTerminal terminal, string value)
+        => terminal.ApplyTokens(AnsiTokenizer.Tokenize(value));
+
+    private static void AssertPlacement(
+        Hex1bTerminalSnapshot snapshot,
+        uint imageId,
+        uint placementId,
+        int row,
+        int column)
+    {
+        var placement = TestSeq.Single(snapshot.KgpPlacements.Where(
+            placement => placement.ImageId == imageId &&
+                placement.PlacementId == placementId));
+        Assert.AreEqual(row, placement.Row);
+        Assert.AreEqual(column, placement.Column);
+        Assert.IsTrue(snapshot.KgpImages.ContainsKey(imageId));
+    }
+
+    private static string GetSvgImageElement(string svg, uint imageId)
+    {
+        var marker = $"data-image-id=\"{imageId}\"";
+        var markerIndex = svg.IndexOf(marker, StringComparison.Ordinal);
+        Assert.IsGreaterThanOrEqualTo(0, markerIndex);
+        var start = svg.LastIndexOf("<image ", markerIndex, StringComparison.Ordinal);
+        Assert.IsGreaterThanOrEqualTo(0, start);
+        var end = svg.IndexOf("/>", markerIndex, StringComparison.Ordinal);
+        Assert.IsGreaterThanOrEqualTo(0, end);
+        return svg[start..(end + 2)];
+    }
+
+    private static string Foreground(uint imageId)
+        => $"\x1b[38;2;{(imageId >> 16) & 0xFF};{(imageId >> 8) & 0xFF};{imageId & 0xFF}m";
+
+    private static string UnderlineColor(uint placementId)
+        => $"\x1b[58;2;{(placementId >> 16) & 0xFF};{(placementId >> 8) & 0xFF};{placementId & 0xFF}m";
+
+    private static string Placeholder(
+        int? row = null,
+        int? column = null)
+    {
+        var builder = new StringBuilder(
+            new Rune(KgpUnicodePlaceholder.CodePoint).ToString());
+        if (row.HasValue)
+            builder.Append(Diacritic(row.Value));
+        if (column.HasValue)
+            builder.Append(Diacritic(column.Value));
+        return builder.ToString();
+    }
+
+    private static string Diacritic(int index)
+        => new Rune(KgpUnicodePlaceholderDiacritics.CodePoints[index]).ToString();
+
+    private sealed class RecordingWorkloadAdapter : IHex1bTerminalWorkloadAdapter
+    {
+        private readonly Queue<byte[]> _responses = new();
+        private readonly object _lock = new();
+
+        public event Action? Disconnected
+        {
+            add { }
+            remove { }
+        }
+
+        public ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(
+            CancellationToken ct = default)
+            => ValueTask.FromResult(ReadOnlyMemory<byte>.Empty);
+
+        public ValueTask WriteInputAsync(
+            ReadOnlyMemory<byte> data,
+            CancellationToken ct = default)
+        {
+            lock (_lock)
+            {
+                _responses.Enqueue(data.ToArray());
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask ResizeAsync(
+            int width,
+            int height,
+            CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync()
+            => ValueTask.CompletedTask;
+
+        internal string ReadResponse()
+        {
+            byte[]? response = null;
+            var received = SpinWait.SpinUntil(
+                () =>
+                {
+                    lock (_lock)
+                    {
+                        return _responses.TryDequeue(out response);
+                    }
+                },
+                TimeSpan.FromSeconds(1));
+            Assert.IsTrue(received, "Expected a KGP protocol response.");
+            return Encoding.UTF8.GetString(response!);
+        }
+
+        internal void AssertNoResponse()
+        {
+            var received = SpinWait.SpinUntil(
+                () =>
+                {
+                    lock (_lock)
+                    {
+                        return _responses.Count > 0;
+                    }
+                },
+                TimeSpan.FromMilliseconds(100));
+            Assert.IsFalse(received, "Expected no KGP protocol response.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add stable per-screen placement graph identities and concrete parent edges for `P`/`Q`
- resolve signed relative geometry through ordinary, history, and Unicode-placeholder roots without moving the cursor
- cascade parent removal across selectors, scrolling, pruning, retransmission, ED/RIS, screen teardown, and disposal while reclaiming unowned descendant image data
- preserve atomic snapshots and deterministic SVG ordering without expanding the public API
- add Kitty/Ghostty-derived relative-placement, lifecycle, history/reflow, virtual-origin, concurrency, response, and passthrough coverage

## Validation
- focused KGP matrix: 418 passed
- Hex1b.Tests: 8,362 total (8,338 passed, 24 skipped)
- Hex1b.Analyzers.Tests: 67 passed
- Hex1b.McpServer.Tests: 6 passed
- Hex1b.Tool.Tests: 58 passed
- complete CI build matrix: 5 projects, 0 warnings/errors

Closes #399
