### PR TITLE
Implement KGP animation frame upload, editing, and deletion

### DIFF
--- a/src/Hex1b/Automation/TerminalRegionSvgExtensions.cs
+++ b/src/Hex1b/Automation/TerminalRegionSvgExtensions.cs
@@ -255,16 +255,16 @@ public static class TerminalRegionSvgExtensions
                 if (placeholderImageDefinitions.ContainsKey(placement.ImageId) ||
                     !snapshot2.KgpImages.TryGetValue(placement.ImageId, out var image) ||
                     (placement.RenderGeometry is null &&
-                     image.Format != KgpFormat.Png))
+                     image.CurrentFrameFormat != KgpFormat.Png))
                 {
                     continue;
                 }
 
                 var dataUri = EncodeKgpImageToDataUri(
-                    image.Data,
+                    image.CurrentFrameData,
                     image.Width,
                     image.Height,
-                    image.Format);
+                    image.CurrentFrameFormat);
                 if (dataUri is not null)
                 {
                     placeholderImageDefinitions.Add(
@@ -316,7 +316,7 @@ public static class TerminalRegionSvgExtensions
                         sb.AppendLine($"""    <clipPath id="{placeholderClipId}"><rect x="{FormatSvgNumber(clipX)}" y="{FormatSvgNumber(clipY)}" width="{FormatSvgNumber(clipWidth)}" height="{FormatSvgNumber(clipHeight)}"/></clipPath>""");
                         sb.AppendLine($"""    <g clip-path="url(#{placeholderClipId})"><use href="#{definition.ElementId}" x="{FormatSvgNumber(imageX)}" y="{FormatSvgNumber(imageY)}" width="{FormatSvgNumber(imageWidth)}" height="{FormatSvgNumber(imageHeight)}" data-image-id="{placement.ImageId}" style="image-rendering: pixelated;"/></g>""");
                     }
-                    else if (imageData.Format == KgpFormat.Png)
+                    else if (imageData.CurrentFrameFormat == KgpFormat.Png)
                     {
                         var destinationX = placement.Column * cellWidth;
                         var destinationY = placement.Row * cellHeight;
@@ -363,10 +363,10 @@ public static class TerminalRegionSvgExtensions
                         var imgWidth = (int)placement.DisplayColumns * cellWidth;
                         var imgHeight = (int)placement.DisplayRows * cellHeight;
                         var dataUri = EncodeKgpImageToDataUri(
-                            imageData.Data,
+                            imageData.CurrentFrameData,
                             imageData.Width,
                             imageData.Height,
-                            imageData.Format,
+                            imageData.CurrentFrameFormat,
                             placement.SourceX,
                             placement.SourceY,
                             placement.SourceWidth,

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -6835,7 +6835,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             var failureQuiet = failure.Quiet == KgpParsedCommand.QuietMode.Normal
                 ? pending.Value.Quiet
                 : failure.Quiet;
-            SendKgpTransmissionResponse(
+            SendKgpUploadResponse(
+                pending.Value.Command,
                 pending.Value.Transmission,
                 storedImage: null,
                 $"EINVAL:{failure.FormatReason(token.ControlData.AsSpan())}",
@@ -6855,14 +6856,15 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             return;
         }
 
-        if (command is KgpParsedCommand.Transmit orphanContinuation &&
-            IsOrphanKgpContinuation(orphanContinuation))
+        if (IsOrphanKgpContinuation(command) &&
+            command.TryGetTransmission(out var orphanTransmission))
         {
-            SendKgpTransmissionResponse(
-                orphanContinuation.Transmission,
+            SendKgpUploadResponse(
+                command,
+                orphanTransmission,
                 storedImage: null,
                 "EILSEQ:No active chunked upload",
-                orphanContinuation.Quiet);
+                command.Quiet);
             return;
         }
 
@@ -6881,7 +6883,9 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             case KgpParsedCommand.Delete delete:
                 ProcessKgpDelete(delete.Selector);
                 break;
-            case KgpParsedCommand.AnimationFrame:
+            case KgpParsedCommand.AnimationFrame animationFrame:
+                ProcessKgpAnimationFrame(animationFrame, token.Payload);
+                break;
             case KgpParsedCommand.AnimationControl:
             case KgpParsedCommand.Compose:
                 break;
@@ -6889,9 +6893,21 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     }
 
     private static bool IsOrphanKgpContinuation(
-        KgpParsedCommand.Transmit command)
-        => command.ControlKeys.Contains('m') &&
-           command.ControlKeys.IsSubsetOf(KgpImageContinuationControls);
+        KgpParsedCommand command)
+    {
+        if (!command.ControlKeys.Contains('m'))
+            return false;
+
+        return command switch
+        {
+            KgpParsedCommand.Transmit transmit
+                => transmit.ControlKeys.IsSubsetOf(KgpImageContinuationControls),
+            KgpParsedCommand.AnimationFrame animationFrame
+                => animationFrame.ControlKeys.Contains('a') &&
+                   animationFrame.ControlKeys.IsSubsetOf(KgpFrameContinuationControls),
+            _ => false,
+        };
+    }
 
     private void ProcessKgpParseFailure(
         KgpCommandParser.Failure failure,
@@ -6951,10 +6967,16 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             case KgpImageStore.ChunkStatus.Incomplete:
                 return;
             case KgpImageStore.ChunkStatus.TooLarge:
-                SendKgpTransmissionResponse(
+                var dataKind =
+                    (result.InitialCommand ?? pending.Command) is
+                        KgpParsedCommand.AnimationFrame
+                            ? "frame"
+                            : "image";
+                SendKgpUploadResponse(
+                    result.InitialCommand ?? pending.Command,
                     result.Transmission,
                     storedImage: null,
-                    $"EFBIG:Too much image data: {result.AttemptedLength} > {result.MaximumLength}",
+                    $"EFBIG:Too much {dataKind} data: {result.AttemptedLength} > {result.MaximumLength}",
                     result.Quiet);
                 return;
             case KgpImageStore.ChunkStatus.Complete:
@@ -6964,7 +6986,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                         "A terminal KGP upload completed without its initial command.");
                 }
 
-                CompleteKgpTransmission(
+                CompleteKgpUpload(
                     result.InitialCommand,
                     result.Quiet,
                     result.Data!);
@@ -7009,11 +7031,74 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         KgpParsedCommand.QuietMode quiet)
     {
         ActiveKgpImageStore.AbortChunkedTransfer();
-        SendKgpTransmissionResponse(
+        SendKgpUploadResponse(
+            pending.Command,
             pending.Transmission,
             storedImage: null,
             message,
             quiet);
+    }
+
+    private void ProcessKgpAnimationFrame(
+        KgpParsedCommand.AnimationFrame command,
+        string base64Payload)
+    {
+        var info = ActiveKgpImageStore.GetAnimationFrameInfo(command);
+        if (info.Status != KgpImageStore.AnimationFrameStatus.Success)
+        {
+            SendKgpFrameResponse(
+                command,
+                info,
+                storedImage: null,
+                FormatKgpAnimationFrameError(info, actualDataLength: null),
+                command.Quiet);
+            return;
+        }
+
+        var maximumEncodedLength = command.Transmission.MoreData
+            ? KgpMaximumEncodedChunkLength
+            : GetMaximumKgpEncodedPayloadLength();
+        if (!TryDecodeKgpPayload(
+                base64Payload,
+                command.Transmission.MoreData,
+                maximumEncodedLength,
+                out var decodedData,
+                out var payloadError))
+        {
+            SendKgpFrameResponse(
+                command,
+                info,
+                storedImage: null,
+                FormatKgpPayloadError(payloadError, maximumEncodedLength),
+                command.Quiet);
+            return;
+        }
+
+        if (command.Transmission.MoreData)
+        {
+            var result = ActiveKgpImageStore.ProcessChunk(
+                command,
+                decodedData,
+                info.ExpectedDataLength);
+            switch (result.Status)
+            {
+                case KgpImageStore.ChunkStatus.Incomplete:
+                    return;
+                case KgpImageStore.ChunkStatus.TooLarge:
+                    SendKgpFrameResponse(
+                        command,
+                        info,
+                        storedImage: null,
+                        $"EFBIG:Too much frame data: {result.AttemptedLength} > {result.MaximumLength}",
+                        result.Quiet);
+                    return;
+                default:
+                    throw new InvalidOperationException(
+                        $"Unexpected initial KGP frame chunk status: {result.Status}.");
+            }
+        }
+
+        CompleteKgpAnimationFrame(command, command.Quiet, decodedData);
     }
 
     private void ProcessKgpTransmission(
@@ -7091,6 +7176,42 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         }
 
         CompleteKgpTransmission(command, command.Quiet, decodedData);
+    }
+
+    private void CompleteKgpUpload(
+        KgpParsedCommand command,
+        KgpParsedCommand.QuietMode quiet,
+        byte[] decodedData)
+    {
+        if (command is KgpParsedCommand.AnimationFrame animationFrame)
+        {
+            CompleteKgpAnimationFrame(animationFrame, quiet, decodedData);
+            return;
+        }
+
+        CompleteKgpTransmission(command, quiet, decodedData);
+    }
+
+    private void CompleteKgpAnimationFrame(
+        KgpParsedCommand.AnimationFrame command,
+        KgpParsedCommand.QuietMode quiet,
+        byte[] decodedData)
+    {
+        var result = ActiveKgpImageStore.StoreAnimationFrame(
+            command,
+            decodedData);
+        var message = result.Info.Status ==
+            KgpImageStore.AnimationFrameStatus.Success
+                ? "OK"
+                : FormatKgpAnimationFrameError(
+                    result.Info,
+                    decodedData.LongLength);
+        SendKgpFrameResponse(
+            command,
+            result.Info,
+            result.Image,
+            message,
+            quiet);
     }
 
     private bool TryGetKgpUploadLimit(
@@ -7267,6 +7388,102 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         }
     }
 
+    private void SendKgpUploadResponse(
+        KgpParsedCommand command,
+        KgpParsedCommand.TransmissionData transmission,
+        KgpImageData? storedImage,
+        string message,
+        KgpParsedCommand.QuietMode quiet)
+    {
+        if (command is KgpParsedCommand.AnimationFrame animationFrame)
+        {
+            var info = ActiveKgpImageStore.GetAnimationFrameInfo(animationFrame);
+            SendKgpFrameResponse(
+                animationFrame,
+                info,
+                storedImage,
+                message,
+                quiet);
+            return;
+        }
+
+        SendKgpTransmissionResponse(
+            transmission,
+            storedImage,
+            message,
+            quiet);
+    }
+
+    private void SendKgpFrameResponse(
+        KgpParsedCommand.AnimationFrame command,
+        KgpImageStore.AnimationFrameInfo info,
+        KgpImageData? storedImage,
+        string message,
+        KgpParsedCommand.QuietMode quiet)
+    {
+        uint imageId;
+        uint imageNumber;
+        switch (command.Transmission.IdentityKind)
+        {
+            case KgpParsedCommand.ImageIdentityKind.ExplicitId:
+                imageId = info.ImageId > 0
+                    ? info.ImageId
+                    : command.Transmission.ImageId;
+                imageNumber = 0;
+                break;
+            case KgpParsedCommand.ImageIdentityKind.Number:
+                imageId = storedImage?.ImageId ?? info.ImageId;
+                imageNumber = command.Transmission.ImageNumber;
+                break;
+            default:
+                return;
+        }
+
+        SendKgpResponse(
+            imageId,
+            imageNumber,
+            message,
+            (int)quiet,
+            info.FrameNumber);
+    }
+
+    private static string FormatKgpAnimationFrameError(
+        KgpImageStore.AnimationFrameInfo info,
+        long? actualDataLength)
+        => info.Status switch
+        {
+            KgpImageStore.AnimationFrameStatus.InvalidIdentity
+                => "EINVAL:Image ID or number required",
+            KgpImageStore.AnimationFrameStatus.ImageNotFound
+                => "ENOENT:Image not found",
+            KgpImageStore.AnimationFrameStatus.UnsupportedMedium
+                => "EINVAL:Animation frame transmission requires direct data",
+            KgpImageStore.AnimationFrameStatus.UnsupportedCompression
+                => "EINVAL:Animation frame compression is not supported",
+            KgpImageStore.AnimationFrameStatus.UnsupportedFormat
+                => "EINVAL:Animation frames require RGB or RGBA data",
+            KgpImageStore.AnimationFrameStatus.UnsupportedBaseFormat
+                => "EINVAL:Animation requires a decoded RGB or RGBA base image",
+            KgpImageStore.AnimationFrameStatus.InvalidBaseData
+                => "EINVAL:Base image data does not match its dimensions",
+            KgpImageStore.AnimationFrameStatus.InvalidDimensions
+                => "EINVAL:Frame dimensions exceed image dimensions",
+            KgpImageStore.AnimationFrameStatus.BaseFrameNotFound
+                => "EINVAL:Base frame not found",
+            KgpImageStore.AnimationFrameStatus.InsufficientData
+                => $"ENODATA:Insufficient frame data: {actualDataLength ?? 0} < {info.ExpectedDataLength}",
+            KgpImageStore.AnimationFrameStatus.TooMuchData
+                => $"EFBIG:Too much frame data: {actualDataLength ?? 0} > {info.ExpectedDataLength}",
+            KgpImageStore.AnimationFrameStatus.NoSpace
+                => "ENOSPC:Animation frame storage full",
+            KgpImageStore.AnimationFrameStatus.OutOfMemory
+                => "ENOMEM:Out of memory",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(info),
+                info.Status,
+                "Expected a KGP animation frame error."),
+        };
+
     private void ProcessKgpQuery(
         KgpParsedCommand.TransmissionData command,
         KgpParsedCommand.QuietMode quiet,
@@ -7421,8 +7638,21 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 RemoveMaterialized(
                     placement => placement.IntersectsCell(_cursorY, _cursorX));
                 break;
-            case KgpParsedCommand.DeleteSelector.AnimationFrames:
+            case KgpParsedCommand.DeleteSelector.AnimationFrames frames:
+            {
+                var result = ActiveKgpImageStore.DeleteAnimationFrame(
+                    frames.ImageId,
+                    frames.ImageNumber,
+                    frames.FrameNumber,
+                    frames.FreeData);
+                if (result.Status ==
+                    KgpImageStore.AnimationFrameDeleteStatus.ImageRemoved)
+                {
+                    _kgpGraphicsState.RemoveActiveImageReferences(
+                        result.ImageId);
+                }
                 break;
+            }
             case KgpParsedCommand.DeleteSelector.AtCell atCell:
                 RemoveMaterialized(
                     placement => placement.IntersectsCell(
@@ -7561,7 +7791,12 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 "Expected a KGP placement error."),
         };
 
-    private void SendKgpResponse(uint imageId, uint imageNumber, string message, int quiet)
+    private void SendKgpResponse(
+        uint imageId,
+        uint imageNumber,
+        string message,
+        int quiet,
+        uint frameNumber = 0)
     {
         // q=1 suppresses OK, q=2 suppresses all responses
         if (quiet >= 2) return;
@@ -7583,6 +7818,12 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             if (imageId > 0)
                 response.Append(',');
             response.Append($"I={imageNumber}");
+        }
+        if (frameNumber > 0)
+        {
+            if (imageId > 0 || imageNumber > 0)
+                response.Append(',');
+            response.Append($"r={frameNumber}");
         }
 
         response.Append(';');

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -7474,6 +7474,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 => $"ENODATA:Insufficient frame data: {actualDataLength ?? 0} < {info.ExpectedDataLength}",
             KgpImageStore.AnimationFrameStatus.TooMuchData
                 => $"EFBIG:Too much frame data: {actualDataLength ?? 0} > {info.ExpectedDataLength}",
+            KgpImageStore.AnimationFrameStatus.FrameLimitReached
+                => $"ENOSPC:Animation frame limit of {KgpAnimationState.MaximumFrameCount} reached",
             KgpImageStore.AnimationFrameStatus.NoSpace
                 => "ENOSPC:Animation frame storage full",
             KgpImageStore.AnimationFrameStatus.OutOfMemory

--- a/src/Hex1b/Kgp/KgpAnimationFrame.cs
+++ b/src/Hex1b/Kgp/KgpAnimationFrame.cs
@@ -1,0 +1,19 @@
+namespace Hex1b;
+
+internal sealed class KgpAnimationFrame
+{
+    internal KgpAnimationFrame(byte[] data, int gapMilliseconds)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        ArgumentOutOfRangeException.ThrowIfNegative(gapMilliseconds);
+
+        Data = data;
+        GapMilliseconds = gapMilliseconds;
+    }
+
+    internal byte[] Data { get; }
+
+    internal int GapMilliseconds { get; }
+
+    internal long StorageSize => Data.LongLength;
+}

--- a/src/Hex1b/Kgp/KgpAnimationFrameComposer.cs
+++ b/src/Hex1b/Kgp/KgpAnimationFrameComposer.cs
@@ -1,0 +1,197 @@
+namespace Hex1b;
+
+internal static class KgpAnimationFrameComposer
+{
+    internal static bool TryGetRgbaBufferLength(
+        uint width,
+        uint height,
+        out int length)
+    {
+        var pixels = (ulong)width * height;
+        if (pixels > (ulong)Array.MaxLength / 4)
+        {
+            length = 0;
+            return false;
+        }
+
+        length = checked((int)(pixels * 4));
+        return true;
+    }
+
+    internal static byte[] CreateRgbaCanvas(
+        uint width,
+        uint height,
+        uint backgroundColor)
+    {
+        if (!TryGetRgbaBufferLength(width, height, out var length))
+            throw new ArgumentOutOfRangeException(nameof(width));
+
+        var canvas = new byte[length];
+        if (backgroundColor == 0)
+            return canvas;
+
+        var red = (byte)(backgroundColor >> 24);
+        var green = (byte)(backgroundColor >> 16);
+        var blue = (byte)(backgroundColor >> 8);
+        var alpha = (byte)backgroundColor;
+        for (var offset = 0; offset < canvas.Length; offset += 4)
+        {
+            canvas[offset] = red;
+            canvas[offset + 1] = green;
+            canvas[offset + 2] = blue;
+            canvas[offset + 3] = alpha;
+        }
+
+        return canvas;
+    }
+
+    internal static byte[] ConvertToRgba(
+        ReadOnlySpan<byte> data,
+        uint width,
+        uint height,
+        KgpFormat format)
+    {
+        if (!TryGetRgbaBufferLength(width, height, out var length))
+            throw new ArgumentOutOfRangeException(nameof(width));
+
+        if (format == KgpFormat.Rgba32)
+        {
+            if (data.Length != length)
+                throw new ArgumentException("RGBA pixel data has an invalid length.", nameof(data));
+            return data.ToArray();
+        }
+
+        if (format != KgpFormat.Rgb24)
+            throw new ArgumentOutOfRangeException(nameof(format));
+
+        var pixelCount = length / 4;
+        if (data.Length != checked(pixelCount * 3))
+            throw new ArgumentException("RGB pixel data has an invalid length.", nameof(data));
+
+        var rgba = new byte[length];
+        var sourceOffset = 0;
+        var destinationOffset = 0;
+        while (sourceOffset < data.Length)
+        {
+            rgba[destinationOffset] = data[sourceOffset];
+            rgba[destinationOffset + 1] = data[sourceOffset + 1];
+            rgba[destinationOffset + 2] = data[sourceOffset + 2];
+            rgba[destinationOffset + 3] = byte.MaxValue;
+            sourceOffset += 3;
+            destinationOffset += 4;
+        }
+
+        return rgba;
+    }
+
+    internal static void Compose(
+        Span<byte> destination,
+        uint destinationWidth,
+        uint destinationHeight,
+        ReadOnlySpan<byte> source,
+        uint sourceWidth,
+        uint sourceHeight,
+        KgpFormat sourceFormat,
+        uint destinationX,
+        uint destinationY,
+        KgpParsedCommand.CompositionMode composition)
+    {
+        if (!TryGetRgbaBufferLength(
+                destinationWidth,
+                destinationHeight,
+                out var destinationLength) ||
+            destination.Length != destinationLength)
+        {
+            throw new ArgumentException(
+                "The destination is not a complete RGBA canvas.",
+                nameof(destination));
+        }
+
+        var sourceBytesPerPixel = sourceFormat switch
+        {
+            KgpFormat.Rgb24 => 3,
+            KgpFormat.Rgba32 => 4,
+            _ => throw new ArgumentOutOfRangeException(nameof(sourceFormat)),
+        };
+        var sourceLength = checked((ulong)sourceWidth * sourceHeight *
+            (uint)sourceBytesPerPixel);
+        if (sourceLength > int.MaxValue || source.Length != (int)sourceLength)
+        {
+            throw new ArgumentException(
+                "The source does not match its dimensions and format.",
+                nameof(source));
+        }
+
+        if (destinationX >= destinationWidth ||
+            destinationY >= destinationHeight ||
+            sourceWidth == 0 ||
+            sourceHeight == 0)
+        {
+            return;
+        }
+
+        var copyWidth = Math.Min(sourceWidth, destinationWidth - destinationX);
+        var copyHeight = Math.Min(sourceHeight, destinationHeight - destinationY);
+        var destinationStride = checked((int)destinationWidth * 4);
+        var sourceStride = checked((int)sourceWidth * sourceBytesPerPixel);
+        var destinationColumnOffset = checked((int)destinationX * 4);
+
+        for (var row = 0; row < copyHeight; row++)
+        {
+            var destinationOffset = checked(
+                ((int)destinationY + (int)row) * destinationStride +
+                destinationColumnOffset);
+            var sourceOffset = checked((int)row * sourceStride);
+            for (var column = 0; column < copyWidth; column++)
+            {
+                var destinationPixel = destination.Slice(destinationOffset, 4);
+                var sourcePixel = source.Slice(sourceOffset, sourceBytesPerPixel);
+                if (composition == KgpParsedCommand.CompositionMode.Overwrite ||
+                    sourceBytesPerPixel == 3)
+                {
+                    destinationPixel[0] = sourcePixel[0];
+                    destinationPixel[1] = sourcePixel[1];
+                    destinationPixel[2] = sourcePixel[2];
+                    destinationPixel[3] = sourceBytesPerPixel == 4
+                        ? sourcePixel[3]
+                        : byte.MaxValue;
+                }
+                else
+                {
+                    AlphaBlend(destinationPixel, sourcePixel);
+                }
+
+                destinationOffset += 4;
+                sourceOffset += sourceBytesPerPixel;
+            }
+        }
+    }
+
+    private static void AlphaBlend(
+        Span<byte> destination,
+        ReadOnlySpan<byte> source)
+    {
+        if (source[3] == 0)
+            return;
+
+        var destinationAlpha = destination[3] / 255f;
+        var sourceAlpha = source[3] / 255f;
+        var alpha = sourceAlpha + destinationAlpha * (1f - sourceAlpha);
+        destination[3] = (byte)(255f * alpha);
+        if (destination[3] == 0)
+        {
+            destination[0] = 0;
+            destination[1] = 0;
+            destination[2] = 0;
+            return;
+        }
+
+        for (var channel = 0; channel < 3; channel++)
+        {
+            destination[channel] = (byte)(
+                (source[channel] * sourceAlpha +
+                 destination[channel] * destinationAlpha * (1f - sourceAlpha)) /
+                alpha);
+        }
+    }
+}

--- a/src/Hex1b/Kgp/KgpAnimationState.cs
+++ b/src/Hex1b/Kgp/KgpAnimationState.cs
@@ -1,16 +1,41 @@
+using System.Collections.Immutable;
+
 namespace Hex1b;
 
 internal sealed class KgpAnimationState
 {
-    private readonly KgpAnimationFrame[] _frames;
+    /// <summary>
+    /// Maximum frames retained by one image, including its root frame.
+    /// This bounds persistent-tree metadata for tiny frames that consume
+    /// negligible pixel quota.
+    /// </summary>
+    internal const int MaximumFrameCount = 4096;
 
-    internal KgpAnimationState(
+    private readonly ImmutableList<KgpAnimationFrame> _frames;
+
+    private KgpAnimationState(
+        ImmutableList<KgpAnimationFrame> frames,
+        int currentFrameIndex,
+        long storageSize)
+    {
+        _frames = frames;
+        CurrentFrameIndex = currentFrameIndex;
+        StorageSize = storageSize;
+    }
+
+    internal static KgpAnimationState Create(
         IReadOnlyList<KgpAnimationFrame> frames,
         int currentFrameIndex)
     {
         ArgumentNullException.ThrowIfNull(frames);
         if (frames.Count == 0)
             throw new ArgumentException("Animation state requires a root frame.", nameof(frames));
+        if (frames.Count > MaximumFrameCount)
+        {
+            throw new ArgumentException(
+                $"Animation state cannot exceed {MaximumFrameCount} frames.",
+                nameof(frames));
+        }
         if (currentFrameIndex < 0 || currentFrameIndex >= frames.Count)
         {
             throw new ArgumentOutOfRangeException(
@@ -19,18 +44,27 @@ internal sealed class KgpAnimationState
                 "The current frame index must identify a stored frame.");
         }
 
-        _frames = [.. frames];
-        CurrentFrameIndex = currentFrameIndex;
-
         long storageSize = 0;
-        foreach (var frame in _frames)
+        foreach (var frame in frames)
             storageSize = checked(storageSize + frame.StorageSize);
-        StorageSize = storageSize;
+        return new KgpAnimationState(
+            ImmutableList.CreateRange(frames),
+            currentFrameIndex,
+            storageSize);
+    }
+
+    internal static KgpAnimationState CreateRoot(KgpAnimationFrame root)
+    {
+        ArgumentNullException.ThrowIfNull(root);
+        return new KgpAnimationState(
+            ImmutableList.Create(root),
+            currentFrameIndex: 0,
+            root.StorageSize);
     }
 
     internal IReadOnlyList<KgpAnimationFrame> Frames => _frames;
 
-    internal int FrameCount => _frames.Length;
+    internal int FrameCount => _frames.Count;
 
     internal int CurrentFrameIndex { get; }
 
@@ -38,4 +72,48 @@ internal sealed class KgpAnimationState
 
     internal KgpAnimationFrame GetFrame(int frameIndex)
         => _frames[frameIndex];
+
+    internal KgpAnimationState AddFrame(KgpAnimationFrame frame)
+    {
+        ArgumentNullException.ThrowIfNull(frame);
+        if (FrameCount >= MaximumFrameCount)
+        {
+            throw new InvalidOperationException(
+                $"Animation state cannot exceed {MaximumFrameCount} frames.");
+        }
+
+        return new KgpAnimationState(
+            _frames.Add(frame),
+            CurrentFrameIndex,
+            checked(StorageSize + frame.StorageSize));
+    }
+
+    internal KgpAnimationState SetFrame(
+        int frameIndex,
+        KgpAnimationFrame frame)
+    {
+        ArgumentNullException.ThrowIfNull(frame);
+        var existing = _frames[frameIndex];
+        return new KgpAnimationState(
+            _frames.SetItem(frameIndex, frame),
+            CurrentFrameIndex,
+            checked(StorageSize - existing.StorageSize + frame.StorageSize));
+    }
+
+    internal KgpAnimationState RemoveFrame(
+        int frameIndex,
+        int currentFrameIndex)
+    {
+        if (FrameCount == 1)
+        {
+            throw new InvalidOperationException(
+                "Animation state cannot remove its only frame.");
+        }
+
+        var removed = _frames[frameIndex];
+        return new KgpAnimationState(
+            _frames.RemoveAt(frameIndex),
+            currentFrameIndex,
+            checked(StorageSize - removed.StorageSize));
+    }
 }

--- a/src/Hex1b/Kgp/KgpAnimationState.cs
+++ b/src/Hex1b/Kgp/KgpAnimationState.cs
@@ -1,0 +1,41 @@
+namespace Hex1b;
+
+internal sealed class KgpAnimationState
+{
+    private readonly KgpAnimationFrame[] _frames;
+
+    internal KgpAnimationState(
+        IReadOnlyList<KgpAnimationFrame> frames,
+        int currentFrameIndex)
+    {
+        ArgumentNullException.ThrowIfNull(frames);
+        if (frames.Count == 0)
+            throw new ArgumentException("Animation state requires a root frame.", nameof(frames));
+        if (currentFrameIndex < 0 || currentFrameIndex >= frames.Count)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(currentFrameIndex),
+                currentFrameIndex,
+                "The current frame index must identify a stored frame.");
+        }
+
+        _frames = [.. frames];
+        CurrentFrameIndex = currentFrameIndex;
+
+        long storageSize = 0;
+        foreach (var frame in _frames)
+            storageSize = checked(storageSize + frame.StorageSize);
+        StorageSize = storageSize;
+    }
+
+    internal IReadOnlyList<KgpAnimationFrame> Frames => _frames;
+
+    internal int FrameCount => _frames.Length;
+
+    internal int CurrentFrameIndex { get; }
+
+    internal long StorageSize { get; }
+
+    internal KgpAnimationFrame GetFrame(int frameIndex)
+        => _frames[frameIndex];
+}

--- a/src/Hex1b/Kgp/KgpImageData.cs
+++ b/src/Hex1b/Kgp/KgpImageData.cs
@@ -8,6 +8,8 @@ namespace Hex1b;
 /// </summary>
 public sealed class KgpImageData
 {
+    private readonly KgpAnimationState? _animation;
+
     /// <summary>
     /// The image ID assigned by the client or allocated by the terminal.
     /// </summary>
@@ -19,8 +21,12 @@ public sealed class KgpImageData
     public uint ImageNumber { get; }
 
     /// <summary>
-    /// The raw decoded pixel data (after base64 decoding, before decompression).
+    /// The decoded pixel data for the root frame.
     /// </summary>
+    /// <remarks>
+    /// When animation frame operations materialize an image, the root frame is
+    /// stored as RGBA data even if the image was originally transmitted as RGB.
+    /// </remarks>
     public byte[] Data { get; }
 
     /// <summary>
@@ -34,12 +40,15 @@ public sealed class KgpImageData
     public uint Height { get; }
 
     /// <summary>
-    /// The pixel format of the stored data.
+    /// The pixel format of the stored root-frame data.
     /// </summary>
+    /// <remarks>
+    /// Animated images are materialized as <see cref="KgpFormat.Rgba32"/>.
+    /// </remarks>
     public KgpFormat Format { get; }
 
     /// <summary>
-    /// SHA256 hash of the data for content-addressable deduplication.
+    /// SHA256 hash of the root-frame data for content-addressable deduplication.
     /// </summary>
     public byte[] ContentHash { get; }
 
@@ -71,7 +80,8 @@ public sealed class KgpImageData
         uint width,
         uint height,
         KgpFormat format,
-        byte[] contentHash)
+        byte[] contentHash,
+        KgpAnimationState? animation = null)
     {
         ImageId = imageId;
         ImageNumber = imageNumber;
@@ -80,6 +90,7 @@ public sealed class KgpImageData
         Height = height;
         Format = format;
         ContentHash = contentHash;
+        _animation = animation;
     }
 
     /// <summary>
@@ -96,9 +107,76 @@ public sealed class KgpImageData
     }
 
     /// <summary>
-    /// Whether pixels are 4-byte aligned (RGBA or PNG).
+    /// Whether root-frame pixels are 4-byte aligned (RGBA or PNG).
     /// </summary>
     public bool Is4ByteAligned => Format != KgpFormat.Rgb24;
+
+    internal int FrameCount => _animation?.FrameCount ?? 1;
+
+    internal int CurrentFrameIndex => _animation?.CurrentFrameIndex ?? 0;
+
+    internal int CurrentFrameNumber => CurrentFrameIndex + 1;
+
+    internal long StorageSize => _animation?.StorageSize ?? Data.LongLength;
+
+    internal IReadOnlyList<KgpAnimationFrame>? AnimationFrames
+        => _animation?.Frames;
+
+    internal byte[] CurrentFrameData
+        => _animation?.GetFrame(CurrentFrameIndex).Data ?? Data;
+
+    internal KgpFormat CurrentFrameFormat
+        => _animation is null && CurrentFrameIndex == 0
+            ? Format
+            : KgpFormat.Rgba32;
+
+    internal bool TryGetFrame(
+        int frameNumber,
+        out byte[] data,
+        out KgpFormat format,
+        out int gapMilliseconds)
+    {
+        if (frameNumber < 1 || frameNumber > FrameCount)
+        {
+            data = [];
+            format = default;
+            gapMilliseconds = 0;
+            return false;
+        }
+
+        if (_animation is null)
+        {
+            data = Data;
+            format = Format;
+            gapMilliseconds = 0;
+            return true;
+        }
+
+        var frame = _animation.GetFrame(frameNumber - 1);
+        data = frame.Data;
+        format = KgpFormat.Rgba32;
+        gapMilliseconds = frame.GapMilliseconds;
+        return true;
+    }
+
+    internal KgpImageData WithAnimation(KgpAnimationState animation)
+    {
+        ArgumentNullException.ThrowIfNull(animation);
+        var root = animation.GetFrame(0);
+        var contentHash = ReferenceEquals(root.Data, Data) &&
+            Format == KgpFormat.Rgba32
+                ? ContentHash
+                : SHA256.HashData(root.Data);
+        return new KgpImageData(
+            ImageId,
+            ImageNumber,
+            root.Data,
+            Width,
+            Height,
+            KgpFormat.Rgba32,
+            contentHash,
+            animation);
+    }
 
     internal KgpImageData WithImageId(uint imageId)
         => new(
@@ -108,5 +186,6 @@ public sealed class KgpImageData
             Width,
             Height,
             Format,
-            ContentHash);
+            ContentHash,
+            _animation);
 }

--- a/src/Hex1b/Kgp/KgpImageData.cs
+++ b/src/Hex1b/Kgp/KgpImageData.cs
@@ -122,6 +122,8 @@ public sealed class KgpImageData
     internal IReadOnlyList<KgpAnimationFrame>? AnimationFrames
         => _animation?.Frames;
 
+    internal KgpAnimationState? AnimationState => _animation;
+
     internal byte[] CurrentFrameData
         => _animation?.GetFrame(CurrentFrameIndex).Data ?? Data;
 

--- a/src/Hex1b/Kgp/KgpImageStore.cs
+++ b/src/Hex1b/Kgp/KgpImageStore.cs
@@ -57,6 +57,7 @@ public sealed class KgpImageStore
         BaseFrameNotFound,
         InsufficientData,
         TooMuchData,
+        FrameLimitReached,
         NoSpace,
         OutOfMemory,
     }
@@ -376,15 +377,16 @@ public sealed class KgpImageStore
             var image = _imagesById[info.ImageId];
             try
             {
-                var frames = CreateNormalizedFrames(image);
+                var animation = CreateNormalizedAnimation(image);
                 var frameIndex = checked((int)info.FrameNumber - 1);
-                var isNewFrame = frameIndex == frames.Length;
+                var isNewFrame = frameIndex == animation.FrameCount;
                 byte[] canvas;
                 int gapMilliseconds;
                 if (isNewFrame)
                 {
                     canvas = command.Frame.BaseFrameNumber > 0
-                        ? frames[checked((int)command.Frame.BaseFrameNumber - 1)]
+                        ? animation.GetFrame(
+                                checked((int)command.Frame.BaseFrameNumber - 1))
                             .Data
                             .ToArray()
                         : KgpAnimationFrameComposer.CreateRgbaCanvas(
@@ -400,7 +402,7 @@ public sealed class KgpImageStore
                 }
                 else
                 {
-                    var existing = frames[frameIndex];
+                    var existing = animation.GetFrame(frameIndex);
                     canvas = existing.Data.ToArray();
                     gapMilliseconds = command.Frame.Gap == 0
                         ? existing.GapMilliseconds
@@ -422,23 +424,10 @@ public sealed class KgpImageStore
                 var updatedFrame = new KgpAnimationFrame(
                     canvas,
                     gapMilliseconds);
-                KgpAnimationFrame[] updatedFrames;
-                if (isNewFrame)
-                {
-                    updatedFrames = new KgpAnimationFrame[frames.Length + 1];
-                    frames.CopyTo(updatedFrames, 0);
-                    updatedFrames[^1] = updatedFrame;
-                }
-                else
-                {
-                    updatedFrames = (KgpAnimationFrame[])frames.Clone();
-                    updatedFrames[frameIndex] = updatedFrame;
-                }
-
-                var animation = new KgpAnimationState(
-                    updatedFrames,
-                    image.CurrentFrameIndex);
-                var updatedImage = image.WithAnimation(animation);
+                var updatedAnimation = isNewFrame
+                    ? animation.AddFrame(updatedFrame)
+                    : animation.SetFrame(frameIndex, updatedFrame);
+                var updatedImage = image.WithAnimation(updatedAnimation);
                 var storageDelta = checked(
                     updatedImage.StorageSize - image.StorageSize);
                 if (storageDelta != info.RequiredStorageBytes)
@@ -503,30 +492,17 @@ public sealed class KgpImageStore
                     CurrentFrameChanged: true);
             }
 
-            var frames = image.AnimationFrames
+            var animation = image.AnimationState
                 ?? throw new InvalidOperationException(
                     "An image with multiple frames has no animation state.");
             var resolvedFrameNumber = frameNumber == 0
                 ? 1u
-                : Math.Min(frameNumber, checked((uint)frames.Count));
+                : Math.Min(frameNumber, checked((uint)animation.FrameCount));
             var removedIndex = checked((int)resolvedFrameNumber - 1);
             try
             {
-                var updatedFrames = new KgpAnimationFrame[frames.Count - 1];
-                for (var sourceIndex = 0;
-                     sourceIndex < frames.Count;
-                     sourceIndex++)
-                {
-                    if (sourceIndex == removedIndex)
-                        continue;
-                    var destinationIndex = sourceIndex < removedIndex
-                        ? sourceIndex
-                        : sourceIndex - 1;
-                    updatedFrames[destinationIndex] = frames[sourceIndex];
-                }
-
                 var currentFrameIndex = image.CurrentFrameIndex;
-                var lastFrameIndex = updatedFrames.Length - 1;
+                var lastFrameIndex = animation.FrameCount - 2;
                 var currentFrameChanged = false;
                 if (currentFrameIndex > lastFrameIndex)
                 {
@@ -542,10 +518,10 @@ public sealed class KgpImageStore
                     currentFrameIndex--;
                 }
 
-                var animation = new KgpAnimationState(
-                    updatedFrames,
+                var updatedAnimation = animation.RemoveFrame(
+                    removedIndex,
                     currentFrameIndex);
-                var updatedImage = image.WithAnimation(animation);
+                var updatedImage = image.WithAnimation(updatedAnimation);
                 _imagesById[image.ImageId] = updatedImage;
                 _totalSize = checked(
                     _totalSize - (image.StorageSize - updatedImage.StorageSize));
@@ -995,7 +971,7 @@ public sealed class KgpImageStore
                 transmission);
         }
 
-        if (image.Format == KgpFormat.Png && image.AnimationFrames is null)
+        if (image.Format == KgpFormat.Png && image.AnimationState is null)
         {
             return CreateAnimationFrameFailure(
                 AnimationFrameStatus.UnsupportedBaseFormat,
@@ -1003,7 +979,7 @@ public sealed class KgpImageStore
                 image);
         }
 
-        if (image.AnimationFrames is null && !image.IsDataSizeValid())
+        if (image.AnimationState is null && !image.IsDataSizeValid())
         {
             return CreateAnimationFrameFailure(
                 AnimationFrameStatus.InvalidBaseData,
@@ -1070,8 +1046,22 @@ public sealed class KgpImageStore
                 RequiredStorageBytes: 0);
         }
 
+        if (isNewFrame &&
+            image.FrameCount >= KgpAnimationState.MaximumFrameCount)
+        {
+            return new AnimationFrameInfo(
+                AnimationFrameStatus.FrameLimitReached,
+                image.ImageId,
+                image.ImageNumber,
+                resolvedFrameNumber,
+                sourceWidth,
+                sourceHeight,
+                checked((int)expectedLength),
+                RequiredStorageBytes: 0);
+        }
+
         var requiredStorageBytes = 0L;
-        if (image.AnimationFrames is null)
+        if (image.AnimationState is null)
             requiredStorageBytes += rgbaFrameLength - image.StorageSize;
         if (isNewFrame)
             requiredStorageBytes += rgbaFrameLength;
@@ -1101,11 +1091,11 @@ public sealed class KgpImageStore
             ExpectedDataLength: 0,
             RequiredStorageBytes: 0);
 
-    private static KgpAnimationFrame[] CreateNormalizedFrames(
+    private static KgpAnimationState CreateNormalizedAnimation(
         KgpImageData image)
     {
-        if (image.AnimationFrames is { } animationFrames)
-            return [.. animationFrames];
+        if (image.AnimationState is { } animation)
+            return animation;
 
         var rootData = image.Format == KgpFormat.Rgba32
             ? image.Data
@@ -1114,7 +1104,8 @@ public sealed class KgpImageStore
                 image.Width,
                 image.Height,
                 image.Format);
-        return [new KgpAnimationFrame(rootData, gapMilliseconds: 0)];
+        return KgpAnimationState.CreateRoot(
+            new KgpAnimationFrame(rootData, gapMilliseconds: 0));
     }
 
     private KgpImageData? ResolveAddressableImageUnsafe(

--- a/src/Hex1b/Kgp/KgpImageStore.cs
+++ b/src/Hex1b/Kgp/KgpImageStore.cs
@@ -43,6 +43,55 @@ public sealed class KgpImageStore
         long AttemptedLength,
         long MaximumLength);
 
+    internal enum AnimationFrameStatus
+    {
+        Success,
+        InvalidIdentity,
+        ImageNotFound,
+        UnsupportedMedium,
+        UnsupportedCompression,
+        UnsupportedFormat,
+        UnsupportedBaseFormat,
+        InvalidBaseData,
+        InvalidDimensions,
+        BaseFrameNotFound,
+        InsufficientData,
+        TooMuchData,
+        NoSpace,
+        OutOfMemory,
+    }
+
+    internal readonly record struct AnimationFrameInfo(
+        AnimationFrameStatus Status,
+        uint ImageId,
+        uint ImageNumber,
+        uint FrameNumber,
+        uint SourceWidth,
+        uint SourceHeight,
+        int ExpectedDataLength,
+        long RequiredStorageBytes);
+
+    internal readonly record struct AnimationFrameResult(
+        AnimationFrameInfo Info,
+        KgpImageData? Image);
+
+    internal enum AnimationFrameDeleteStatus
+    {
+        NotFound,
+        NoOp,
+        Deleted,
+        ImageRemoved,
+        OutOfMemory,
+    }
+
+    internal readonly record struct AnimationFrameDeleteResult(
+        AnimationFrameDeleteStatus Status,
+        uint ImageId,
+        uint ImageNumber,
+        uint FrameNumber,
+        KgpImageData? Image,
+        bool CurrentFrameChanged);
+
     private readonly object _lock = new();
     private readonly Dictionary<uint, KgpImageData> _imagesById = new();
     private readonly Dictionary<uint, List<uint>> _imagesByNumber = new();
@@ -77,7 +126,7 @@ public sealed class KgpImageStore
     }
 
     /// <summary>
-    /// Total size of all stored image data in bytes.
+    /// Total size of all stored root and animation frame data in bytes.
     /// </summary>
     public long TotalSize
     {
@@ -272,6 +321,252 @@ public sealed class KgpImageStore
 
             var newestId = list[^1];
             return _imagesById.TryGetValue(newestId, out var image) ? image : null;
+        }
+    }
+
+    internal AnimationFrameInfo GetAnimationFrameInfo(
+        KgpParsedCommand.AnimationFrame command)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        lock (_lock)
+        {
+            return GetAnimationFrameInfoUnsafe(command);
+        }
+    }
+
+    internal AnimationFrameResult StoreAnimationFrame(
+        KgpParsedCommand.AnimationFrame command,
+        byte[] data)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(data);
+
+        lock (_lock)
+        {
+            var info = GetAnimationFrameInfoUnsafe(command);
+            if (info.Status != AnimationFrameStatus.Success)
+                return new AnimationFrameResult(info, Image: null);
+
+            if (data.Length < info.ExpectedDataLength)
+            {
+                return new AnimationFrameResult(
+                    info with { Status = AnimationFrameStatus.InsufficientData },
+                    Image: null);
+            }
+
+            if (data.Length > info.ExpectedDataLength)
+            {
+                return new AnimationFrameResult(
+                    info with { Status = AnimationFrameStatus.TooMuchData },
+                    Image: null);
+            }
+
+            if (info.RequiredStorageBytes > 0 &&
+                WouldExceedQuota(
+                    _totalSize,
+                    info.RequiredStorageBytes,
+                    _quotaBytes))
+            {
+                return new AnimationFrameResult(
+                    info with { Status = AnimationFrameStatus.NoSpace },
+                    Image: null);
+            }
+
+            var image = _imagesById[info.ImageId];
+            try
+            {
+                var frames = CreateNormalizedFrames(image);
+                var frameIndex = checked((int)info.FrameNumber - 1);
+                var isNewFrame = frameIndex == frames.Length;
+                byte[] canvas;
+                int gapMilliseconds;
+                if (isNewFrame)
+                {
+                    canvas = command.Frame.BaseFrameNumber > 0
+                        ? frames[checked((int)command.Frame.BaseFrameNumber - 1)]
+                            .Data
+                            .ToArray()
+                        : KgpAnimationFrameComposer.CreateRgbaCanvas(
+                            image.Width,
+                            image.Height,
+                            command.Frame.BackgroundColor);
+                    gapMilliseconds = command.Frame.Gap switch
+                    {
+                        > 0 => command.Frame.Gap,
+                        < 0 => 0,
+                        _ => 40,
+                    };
+                }
+                else
+                {
+                    var existing = frames[frameIndex];
+                    canvas = existing.Data.ToArray();
+                    gapMilliseconds = command.Frame.Gap == 0
+                        ? existing.GapMilliseconds
+                        : Math.Max(0, command.Frame.Gap);
+                }
+
+                KgpAnimationFrameComposer.Compose(
+                    canvas,
+                    image.Width,
+                    image.Height,
+                    data,
+                    info.SourceWidth,
+                    info.SourceHeight,
+                    command.Transmission.Format,
+                    command.Frame.X,
+                    command.Frame.Y,
+                    command.Frame.Composition);
+
+                var updatedFrame = new KgpAnimationFrame(
+                    canvas,
+                    gapMilliseconds);
+                KgpAnimationFrame[] updatedFrames;
+                if (isNewFrame)
+                {
+                    updatedFrames = new KgpAnimationFrame[frames.Length + 1];
+                    frames.CopyTo(updatedFrames, 0);
+                    updatedFrames[^1] = updatedFrame;
+                }
+                else
+                {
+                    updatedFrames = (KgpAnimationFrame[])frames.Clone();
+                    updatedFrames[frameIndex] = updatedFrame;
+                }
+
+                var animation = new KgpAnimationState(
+                    updatedFrames,
+                    image.CurrentFrameIndex);
+                var updatedImage = image.WithAnimation(animation);
+                var storageDelta = checked(
+                    updatedImage.StorageSize - image.StorageSize);
+                if (storageDelta != info.RequiredStorageBytes)
+                {
+                    throw new InvalidOperationException(
+                        "KGP animation frame storage accounting changed during a locked transaction.");
+                }
+
+                _imagesById[image.ImageId] = updatedImage;
+                _totalSize = checked(_totalSize + storageDelta);
+                return new AnimationFrameResult(info, updatedImage);
+            }
+            catch (OutOfMemoryException)
+            {
+                return new AnimationFrameResult(
+                    info with { Status = AnimationFrameStatus.OutOfMemory },
+                    Image: null);
+            }
+        }
+    }
+
+    internal AnimationFrameDeleteResult DeleteAnimationFrame(
+        uint imageId,
+        uint imageNumber,
+        uint frameNumber,
+        bool freeData)
+    {
+        lock (_lock)
+        {
+            var image = ResolveAddressableImageUnsafe(imageId, imageNumber);
+            if (image is null)
+            {
+                return new AnimationFrameDeleteResult(
+                    AnimationFrameDeleteStatus.NotFound,
+                    imageId,
+                    imageNumber,
+                    FrameNumber: 0,
+                    Image: null,
+                    CurrentFrameChanged: false);
+            }
+
+            if (image.FrameCount == 1)
+            {
+                if (!freeData)
+                {
+                    return new AnimationFrameDeleteResult(
+                        AnimationFrameDeleteStatus.NoOp,
+                        image.ImageId,
+                        image.ImageNumber,
+                        FrameNumber: 1,
+                        image,
+                        CurrentFrameChanged: false);
+                }
+
+                RemoveImageUnsafe(image.ImageId);
+                return new AnimationFrameDeleteResult(
+                    AnimationFrameDeleteStatus.ImageRemoved,
+                    image.ImageId,
+                    image.ImageNumber,
+                    FrameNumber: 1,
+                    Image: null,
+                    CurrentFrameChanged: true);
+            }
+
+            var frames = image.AnimationFrames
+                ?? throw new InvalidOperationException(
+                    "An image with multiple frames has no animation state.");
+            var resolvedFrameNumber = frameNumber == 0
+                ? 1u
+                : Math.Min(frameNumber, checked((uint)frames.Count));
+            var removedIndex = checked((int)resolvedFrameNumber - 1);
+            try
+            {
+                var updatedFrames = new KgpAnimationFrame[frames.Count - 1];
+                for (var sourceIndex = 0;
+                     sourceIndex < frames.Count;
+                     sourceIndex++)
+                {
+                    if (sourceIndex == removedIndex)
+                        continue;
+                    var destinationIndex = sourceIndex < removedIndex
+                        ? sourceIndex
+                        : sourceIndex - 1;
+                    updatedFrames[destinationIndex] = frames[sourceIndex];
+                }
+
+                var currentFrameIndex = image.CurrentFrameIndex;
+                var lastFrameIndex = updatedFrames.Length - 1;
+                var currentFrameChanged = false;
+                if (currentFrameIndex > lastFrameIndex)
+                {
+                    currentFrameIndex = lastFrameIndex;
+                    currentFrameChanged = true;
+                }
+                else if (removedIndex == currentFrameIndex)
+                {
+                    currentFrameChanged = true;
+                }
+                else if (removedIndex < currentFrameIndex)
+                {
+                    currentFrameIndex--;
+                }
+
+                var animation = new KgpAnimationState(
+                    updatedFrames,
+                    currentFrameIndex);
+                var updatedImage = image.WithAnimation(animation);
+                _imagesById[image.ImageId] = updatedImage;
+                _totalSize = checked(
+                    _totalSize - (image.StorageSize - updatedImage.StorageSize));
+                return new AnimationFrameDeleteResult(
+                    AnimationFrameDeleteStatus.Deleted,
+                    image.ImageId,
+                    image.ImageNumber,
+                    resolvedFrameNumber,
+                    updatedImage,
+                    currentFrameChanged);
+            }
+            catch (OutOfMemoryException)
+            {
+                return new AnimationFrameDeleteResult(
+                    AnimationFrameDeleteStatus.OutOfMemory,
+                    image.ImageId,
+                    image.ImageNumber,
+                    resolvedFrameNumber,
+                    image,
+                    CurrentFrameChanged: false);
+            }
         }
     }
 
@@ -544,16 +839,22 @@ public sealed class KgpImageStore
         var replaced = _imagesById.TryGetValue(image.ImageId, out var existing);
         if (existing is not null)
         {
-            _totalSize -= existing.Data.Length;
+            _totalSize -= existing.StorageSize;
+            _imagesById.Remove(existing.ImageId);
+            _unaddressableImageIds.Remove(existing.ImageId);
             RemoveFromNumberIndex(existing);
         }
 
-        while (_totalSize + image.Data.Length > _quotaBytes && _imagesById.Count > 0)
+        while (WouldExceedQuota(
+                   _totalSize,
+                   image.StorageSize,
+                   _quotaBytes) &&
+               _imagesById.Count > 0)
         {
             EvictOldest();
         }
 
-        _totalSize += image.Data.Length;
+        _totalSize += image.StorageSize;
         _imagesById[image.ImageId] = image;
         if (addressable)
             _unaddressableImageIds.Remove(image.ImageId);
@@ -578,7 +879,7 @@ public sealed class KgpImageStore
         if (!_imagesById.TryGetValue(imageId, out var image))
             return false;
 
-        _totalSize -= image.Data.Length;
+        _totalSize -= image.StorageSize;
         _imagesById.Remove(imageId);
         _unaddressableImageIds.Remove(imageId);
         RemoveFromNumberIndex(image);
@@ -613,6 +914,17 @@ public sealed class KgpImageStore
         throw new InvalidOperationException("No KGP image IDs are available.");
     }
 
+    private static bool WouldExceedQuota(
+        long currentSize,
+        long addedSize,
+        long quotaBytes)
+    {
+        if (currentSize < 0 || addedSize < 0)
+            throw new ArgumentOutOfRangeException(nameof(currentSize));
+        return addedSize > quotaBytes ||
+               currentSize > quotaBytes - addedSize;
+    }
+
     private static KgpImageData CreateImage(
         uint imageId,
         KgpParsedCommand.TransmissionData transmission,
@@ -639,6 +951,188 @@ public sealed class KgpImageStore
             width,
             height,
             transmission.Format);
+    }
+
+    private AnimationFrameInfo GetAnimationFrameInfoUnsafe(
+        KgpParsedCommand.AnimationFrame command)
+    {
+        var transmission = command.Transmission;
+        if (transmission.ImageId == 0 && transmission.ImageNumber == 0)
+        {
+            return CreateAnimationFrameFailure(
+                AnimationFrameStatus.InvalidIdentity,
+                transmission);
+        }
+
+        if (transmission.Medium != KgpTransmissionMedium.Direct)
+        {
+            return CreateAnimationFrameFailure(
+                AnimationFrameStatus.UnsupportedMedium,
+                transmission);
+        }
+
+        if (transmission.Compression != KgpParsedCommand.CompressionMode.None)
+        {
+            return CreateAnimationFrameFailure(
+                AnimationFrameStatus.UnsupportedCompression,
+                transmission);
+        }
+
+        if (transmission.Format is not (KgpFormat.Rgb24 or KgpFormat.Rgba32))
+        {
+            return CreateAnimationFrameFailure(
+                AnimationFrameStatus.UnsupportedFormat,
+                transmission);
+        }
+
+        var image = ResolveAddressableImageUnsafe(
+            transmission.ImageId,
+            transmission.ImageNumber);
+        if (image is null)
+        {
+            return CreateAnimationFrameFailure(
+                AnimationFrameStatus.ImageNotFound,
+                transmission);
+        }
+
+        if (image.Format == KgpFormat.Png && image.AnimationFrames is null)
+        {
+            return CreateAnimationFrameFailure(
+                AnimationFrameStatus.UnsupportedBaseFormat,
+                transmission,
+                image);
+        }
+
+        if (image.AnimationFrames is null && !image.IsDataSizeValid())
+        {
+            return CreateAnimationFrameFailure(
+                AnimationFrameStatus.InvalidBaseData,
+                transmission,
+                image);
+        }
+
+        var sourceWidth = transmission.Width == 0
+            ? image.Width
+            : transmission.Width;
+        var sourceHeight = transmission.Height == 0
+            ? image.Height
+            : transmission.Height;
+        if (sourceWidth == 0 ||
+            sourceHeight == 0 ||
+            sourceWidth > image.Width ||
+            sourceHeight > image.Height)
+        {
+            return CreateAnimationFrameFailure(
+                AnimationFrameStatus.InvalidDimensions,
+                transmission,
+                image);
+        }
+
+        var bytesPerPixel = transmission.Format == KgpFormat.Rgb24 ? 3u : 4u;
+        var expectedLength = (ulong)sourceWidth * sourceHeight * bytesPerPixel;
+        if (expectedLength > (ulong)Array.MaxLength)
+        {
+            return CreateAnimationFrameFailure(
+                AnimationFrameStatus.InvalidDimensions,
+                transmission,
+                image);
+        }
+
+        if (!KgpAnimationFrameComposer.TryGetRgbaBufferLength(
+                image.Width,
+                image.Height,
+                out var rgbaFrameLength))
+        {
+            return CreateAnimationFrameFailure(
+                AnimationFrameStatus.InvalidDimensions,
+                transmission,
+                image);
+        }
+
+        var frameCount = checked((uint)image.FrameCount);
+        var resolvedFrameNumber =
+            command.Frame.EditFrameNumber >= 1 &&
+            command.Frame.EditFrameNumber <= frameCount
+                ? command.Frame.EditFrameNumber
+                : checked(frameCount + 1);
+        var isNewFrame = resolvedFrameNumber == frameCount + 1;
+        if (isNewFrame &&
+            command.Frame.BaseFrameNumber > frameCount)
+        {
+            return new AnimationFrameInfo(
+                AnimationFrameStatus.BaseFrameNotFound,
+                image.ImageId,
+                image.ImageNumber,
+                resolvedFrameNumber,
+                sourceWidth,
+                sourceHeight,
+                checked((int)expectedLength),
+                RequiredStorageBytes: 0);
+        }
+
+        var requiredStorageBytes = 0L;
+        if (image.AnimationFrames is null)
+            requiredStorageBytes += rgbaFrameLength - image.StorageSize;
+        if (isNewFrame)
+            requiredStorageBytes += rgbaFrameLength;
+
+        return new AnimationFrameInfo(
+            AnimationFrameStatus.Success,
+            image.ImageId,
+            image.ImageNumber,
+            resolvedFrameNumber,
+            sourceWidth,
+            sourceHeight,
+            checked((int)expectedLength),
+            requiredStorageBytes);
+    }
+
+    private static AnimationFrameInfo CreateAnimationFrameFailure(
+        AnimationFrameStatus status,
+        KgpParsedCommand.TransmissionData transmission,
+        KgpImageData? image = null)
+        => new(
+            status,
+            image?.ImageId ?? transmission.ImageId,
+            image?.ImageNumber ?? transmission.ImageNumber,
+            FrameNumber: 0,
+            SourceWidth: 0,
+            SourceHeight: 0,
+            ExpectedDataLength: 0,
+            RequiredStorageBytes: 0);
+
+    private static KgpAnimationFrame[] CreateNormalizedFrames(
+        KgpImageData image)
+    {
+        if (image.AnimationFrames is { } animationFrames)
+            return [.. animationFrames];
+
+        var rootData = image.Format == KgpFormat.Rgba32
+            ? image.Data
+            : KgpAnimationFrameComposer.ConvertToRgba(
+                image.Data,
+                image.Width,
+                image.Height,
+                image.Format);
+        return [new KgpAnimationFrame(rootData, gapMilliseconds: 0)];
+    }
+
+    private KgpImageData? ResolveAddressableImageUnsafe(
+        uint imageId,
+        uint imageNumber)
+    {
+        if (imageId > 0)
+        {
+            if (_unaddressableImageIds.Contains(imageId))
+                return null;
+            return _imagesById.TryGetValue(imageId, out var image)
+                ? image
+                : null;
+        }
+
+        return imageNumber > 0
+            ? GetImageByNumberUnsafe(imageNumber)
+            : null;
     }
 
     private KgpImageData? GetImageByNumberUnsafe(uint imageNumber)

--- a/tests/Hex1b.Tests/KgpAnimationFrameStoreTests.cs
+++ b/tests/Hex1b.Tests/KgpAnimationFrameStoreTests.cs
@@ -1,0 +1,405 @@
+namespace Hex1b.Tests;
+
+[TestClass]
+public class KgpAnimationFrameStoreTests
+{
+    [TestMethod]
+    public void StoreAnimationFrame_NewFrameExceedsQuota_ReturnsNoSpaceWithoutMutation()
+    {
+        var store = new KgpImageStore(quotaBytes: 4);
+        var original = CreateImage(1, KgpFormat.Rgba32, [1, 2, 3, 4]);
+        store.StoreImage(original);
+
+        var result = store.StoreAnimationFrame(
+            ParseFrame("a=f,f=32,s=1,v=1,i=1,X=1"),
+            [5, 6, 7, 8]);
+
+        Assert.AreEqual(
+            KgpImageStore.AnimationFrameStatus.NoSpace,
+            result.Info.Status);
+        Assert.AreSame(original, store.GetImageById(1));
+        Assert.AreEqual(1, original.FrameCount);
+        Assert.AreEqual(4L, store.TotalSize);
+    }
+
+    [TestMethod]
+    public void StoreAnimationFrame_RootEditAtQuota_SucceedsWithoutGrowth()
+    {
+        var store = new KgpImageStore(quotaBytes: 4);
+        store.StoreImage(
+            CreateImage(1, KgpFormat.Rgba32, [1, 2, 3, 4]));
+
+        var result = store.StoreAnimationFrame(
+            ParseFrame("a=f,f=32,s=1,v=1,i=1,r=1,X=1"),
+            [5, 6, 7, 8]);
+
+        Assert.AreEqual(
+            KgpImageStore.AnimationFrameStatus.Success,
+            result.Info.Status);
+        Assert.AreEqual(4L, store.TotalSize);
+        AssertFrame(result.Image!, 1, [5, 6, 7, 8], 0);
+    }
+
+    [TestMethod]
+    public void StoreAnimationFrame_RgbNormalizationExceedsQuota_IsAtomic()
+    {
+        var store = new KgpImageStore(quotaBytes: 3);
+        var original = CreateImage(1, KgpFormat.Rgb24, [1, 2, 3]);
+        store.StoreImage(original);
+
+        var result = store.StoreAnimationFrame(
+            ParseFrame("a=f,f=32,s=1,v=1,i=1,r=1,X=1"),
+            [5, 6, 7, 8]);
+
+        Assert.AreEqual(
+            KgpImageStore.AnimationFrameStatus.NoSpace,
+            result.Info.Status);
+        Assert.AreSame(original, store.GetImageById(1));
+        Assert.AreEqual(KgpFormat.Rgb24, original.Format);
+        Assert.AreEqual(3L, store.TotalSize);
+    }
+
+    [TestMethod]
+    public void StoreAnimationFrame_MalformedPublicBaseImage_ReturnsInvalidBaseData()
+    {
+        var store = new KgpImageStore();
+        var malformed = new KgpImageData(
+            1,
+            0,
+            [1, 2, 3],
+            width: 2,
+            height: 1,
+            KgpFormat.Rgba32);
+        store.StoreImage(malformed);
+
+        var result = store.StoreAnimationFrame(
+            ParseFrame("a=f,f=32,s=1,v=1,i=1,r=1,X=1"),
+            [5, 6, 7, 8]);
+
+        Assert.AreEqual(
+            KgpImageStore.AnimationFrameStatus.InvalidBaseData,
+            result.Info.Status);
+        Assert.AreSame(malformed, store.GetImageById(1));
+        Assert.AreEqual(3L, store.TotalSize);
+    }
+
+    [TestMethod]
+    public void StoreAnimationFrame_EditAndAppend_TracksRetainedBytes()
+    {
+        var store = new KgpImageStore();
+        store.StoreImage(
+            CreateImage(1, KgpFormat.Rgba32, [1, 2, 3, 4]));
+
+        var appended = store.StoreAnimationFrame(
+            ParseFrame("a=f,f=32,s=1,v=1,i=1,X=1"),
+            [5, 6, 7, 8]);
+        Assert.AreEqual(
+            KgpImageStore.AnimationFrameStatus.Success,
+            appended.Info.Status);
+        Assert.AreEqual(8L, store.TotalSize);
+
+        var edited = store.StoreAnimationFrame(
+            ParseFrame("a=f,f=32,s=1,v=1,i=1,r=2,X=1"),
+            [9, 10, 11, 12]);
+        Assert.AreEqual(
+            KgpImageStore.AnimationFrameStatus.Success,
+            edited.Info.Status);
+        Assert.AreEqual(8L, store.TotalSize);
+        AssertFrame(edited.Image!, 2, [9, 10, 11, 12], 40);
+    }
+
+    [TestMethod]
+    [DataRow(2, 1, 3, true)]
+    [DataRow(1, 2, 3, true)]
+    [DataRow(2, 3, 2, true)]
+    public void DeleteAnimationFrame_RepairsCurrentFrameIndex(
+        int currentFrameIndex,
+        int deletedFrameNumber,
+        int expectedCurrentValue,
+        bool expectedCurrentFrameChanged)
+    {
+        var store = new KgpImageStore();
+        store.StoreImage(CreateAnimatedImage(1, currentFrameIndex));
+
+        var result = store.DeleteAnimationFrame(
+            imageId: 1,
+            imageNumber: 0,
+            checked((uint)deletedFrameNumber),
+            freeData: false);
+
+        Assert.AreEqual(
+            KgpImageStore.AnimationFrameDeleteStatus.Deleted,
+            result.Status);
+        Assert.AreEqual(
+            expectedCurrentFrameChanged,
+            result.CurrentFrameChanged);
+        Assert.IsNotNull(result.Image);
+        Assert.AreEqual(2, result.Image.FrameCount);
+        Assert.AreEqual(
+            expectedCurrentValue,
+            (int)result.Image.CurrentFrameData[0]);
+        Assert.AreEqual(8L, store.TotalSize);
+    }
+
+    [TestMethod]
+    [DataRow(0u, 1u, 2)]
+    [DataRow(99u, 3u, 2)]
+    public void DeleteAnimationFrame_FrameNumber_ClampsToStoredRange(
+        uint requestedFrameNumber,
+        uint expectedDeletedFrameNumber,
+        int expectedFrameCount)
+    {
+        var store = new KgpImageStore();
+        store.StoreImage(CreateAnimatedImage(1, currentFrameIndex: 0));
+
+        var result = store.DeleteAnimationFrame(
+            imageId: 1,
+            imageNumber: 0,
+            requestedFrameNumber,
+            freeData: false);
+
+        Assert.AreEqual(
+            KgpImageStore.AnimationFrameDeleteStatus.Deleted,
+            result.Status);
+        Assert.AreEqual(expectedDeletedFrameNumber, result.FrameNumber);
+        Assert.AreEqual(expectedFrameCount, result.Image!.FrameCount);
+    }
+
+    [TestMethod]
+    public void DeleteAnimationFrame_ByNumber_UsesNewestImage()
+    {
+        var store = new KgpImageStore();
+        var older = CreateAnimatedImage(1, currentFrameIndex: 0, imageNumber: 42);
+        var newer = CreateAnimatedImage(2, currentFrameIndex: 0, imageNumber: 42);
+        store.StoreImage(older);
+        store.StoreImage(newer);
+
+        var result = store.DeleteAnimationFrame(
+            imageId: 0,
+            imageNumber: 42,
+            frameNumber: 2,
+            freeData: false);
+
+        Assert.AreEqual(2u, result.ImageId);
+        Assert.AreEqual(3, older.FrameCount);
+        Assert.AreEqual(2, store.GetImageById(2)!.FrameCount);
+    }
+
+    [TestMethod]
+    public void DeleteAnimationFrame_SingleFrameHonorsUppercaseBehavior()
+    {
+        var store = new KgpImageStore();
+        var image = CreateImage(1, KgpFormat.Rgba32, [1, 2, 3, 4]);
+        store.StoreImage(image);
+
+        var lowercase = store.DeleteAnimationFrame(
+            imageId: 1,
+            imageNumber: 0,
+            frameNumber: 0,
+            freeData: false);
+        Assert.AreEqual(
+            KgpImageStore.AnimationFrameDeleteStatus.NoOp,
+            lowercase.Status);
+        Assert.AreSame(image, store.GetImageById(1));
+
+        var uppercase = store.DeleteAnimationFrame(
+            imageId: 1,
+            imageNumber: 0,
+            frameNumber: 0,
+            freeData: true);
+        Assert.AreEqual(
+            KgpImageStore.AnimationFrameDeleteStatus.ImageRemoved,
+            uppercase.Status);
+        Assert.IsNull(store.GetImageById(1));
+        Assert.AreEqual(0L, store.TotalSize);
+    }
+
+    [TestMethod]
+    public void StoreAnimationFrame_OutOfBoundsRectangle_CreatesBackgroundOnlyFrame()
+    {
+        var store = new KgpImageStore();
+        store.StoreImage(new KgpImageData(
+            1,
+            0,
+            new byte[8],
+            2,
+            1,
+            KgpFormat.Rgba32));
+
+        var result = store.StoreAnimationFrame(
+            ParseFrame(
+                "a=f,f=32,s=1,v=1,i=1,x=4294967295,y=4294967295," +
+                "X=1,Y=16909060"),
+            [9, 9, 9, 9]);
+
+        Assert.AreEqual(
+            KgpImageStore.AnimationFrameStatus.Success,
+            result.Info.Status);
+        AssertFrame(
+            result.Image!,
+            2,
+            [1, 2, 3, 4, 1, 2, 3, 4],
+            40);
+    }
+
+    [TestMethod]
+    public void Clear_WithAnimationFrames_ReleasesAllRetainedBytes()
+    {
+        var store = new KgpImageStore();
+        store.StoreImage(CreateAnimatedImage(1, currentFrameIndex: 0));
+        Assert.AreEqual(12L, store.TotalSize);
+
+        store.Clear();
+
+        Assert.AreEqual(0, store.ImageCount);
+        Assert.AreEqual(0L, store.TotalSize);
+    }
+
+    [TestMethod]
+    public void StoreImage_QuotaEviction_RemovesAllAnimationFrameBytes()
+    {
+        var store = new KgpImageStore(quotaBytes: 12);
+        store.StoreImage(CreateAnimatedImageWithTwoFrames(1));
+        Assert.AreEqual(8L, store.TotalSize);
+
+        store.StoreImage(new KgpImageData(
+            2,
+            0,
+            new byte[8],
+            width: 2,
+            height: 1,
+            KgpFormat.Rgba32));
+
+        Assert.IsNull(store.GetImageById(1));
+        Assert.IsNotNull(store.GetImageById(2));
+        Assert.AreEqual(8L, store.TotalSize);
+    }
+
+    [TestMethod]
+    public void StoreImage_LargerAnimatedReplacement_DoesNotDoubleSubtractBytes()
+    {
+        var store = new KgpImageStore(quotaBytes: 8);
+        store.StoreImage(CreateAnimatedImageWithTwoFrames(1));
+        Assert.AreEqual(8L, store.TotalSize);
+
+        store.StoreImage(new KgpImageData(
+            1,
+            0,
+            new byte[12],
+            width: 3,
+            height: 1,
+            KgpFormat.Rgba32));
+
+        Assert.AreEqual(1, store.ImageCount);
+        Assert.AreEqual(12L, store.TotalSize);
+        Assert.AreEqual(12, store.GetImageById(1)!.Data.Length);
+    }
+
+    [TestMethod]
+    public void ConcurrentFrameStores_OnIndependentImages_AreDeterministic()
+    {
+        const int imageCount = 32;
+        var store = new KgpImageStore();
+        for (uint imageId = 1; imageId <= imageCount; imageId++)
+        {
+            store.StoreImage(
+                CreateImage(
+                    imageId,
+                    KgpFormat.Rgba32,
+                    [(byte)imageId, 0, 0, 255]));
+        }
+
+        var tasks = Enumerable.Range(1, imageCount)
+            .Select(imageId => Task.Run(() => store.StoreAnimationFrame(
+                ParseFrame($"a=f,f=32,s=1,v=1,i={imageId},X=1"),
+                [(byte)imageId, 1, 2, 255])))
+            .ToArray();
+
+        Task.WaitAll(tasks);
+
+        TestSeq.All(
+            tasks,
+            task => Assert.AreEqual(
+                KgpImageStore.AnimationFrameStatus.Success,
+                task.Result.Info.Status));
+        Assert.AreEqual(imageCount * 8L, store.TotalSize);
+        for (uint imageId = 1; imageId <= imageCount; imageId++)
+            Assert.AreEqual(2, store.GetImageById(imageId)!.FrameCount);
+    }
+
+    private static KgpImageData CreateImage(
+        uint imageId,
+        KgpFormat format,
+        byte[] data,
+        uint imageNumber = 0)
+        => new(
+            imageId,
+            imageNumber,
+            data,
+            1,
+            1,
+            format);
+
+    private static KgpImageData CreateAnimatedImage(
+        uint imageId,
+        int currentFrameIndex,
+        uint imageNumber = 0)
+    {
+        var root = new KgpAnimationFrame([1, 0, 0, 255], 0);
+        var frames = new[]
+        {
+            root,
+            new KgpAnimationFrame([2, 0, 0, 255], 20),
+            new KgpAnimationFrame([3, 0, 0, 255], 30),
+        };
+        var image = CreateImage(
+            imageId,
+            KgpFormat.Rgba32,
+            root.Data,
+            imageNumber);
+        return image.WithAnimation(
+            new KgpAnimationState(frames, currentFrameIndex));
+    }
+
+    private static KgpImageData CreateAnimatedImageWithTwoFrames(uint imageId)
+    {
+        var root = new KgpAnimationFrame([1, 0, 0, 255], 0);
+        var image = CreateImage(
+            imageId,
+            KgpFormat.Rgba32,
+            root.Data);
+        return image.WithAnimation(
+            new KgpAnimationState(
+                [root, new KgpAnimationFrame([2, 0, 0, 255], 40)],
+                currentFrameIndex: 0));
+    }
+
+    private static KgpParsedCommand.AnimationFrame ParseFrame(
+        string controlData)
+    {
+        var success = KgpCommandParser.TryParse(
+            controlData,
+            out var command,
+            out var failure);
+        Assert.IsTrue(
+            success,
+            success ? null : failure.FormatReason(controlData.AsSpan()));
+        return TestSeq.IsType<KgpParsedCommand.AnimationFrame>(command);
+    }
+
+    private static void AssertFrame(
+        KgpImageData image,
+        int frameNumber,
+        byte[] expectedData,
+        int expectedGapMilliseconds)
+    {
+        Assert.IsTrue(image.TryGetFrame(
+            frameNumber,
+            out var data,
+            out var format,
+            out var gapMilliseconds));
+        Assert.AreEqual(KgpFormat.Rgba32, format);
+        Assert.AreEqual(expectedGapMilliseconds, gapMilliseconds);
+        TestSeq.AreEqual(expectedData, data);
+    }
+}

--- a/tests/Hex1b.Tests/KgpAnimationFrameStoreTests.cs
+++ b/tests/Hex1b.Tests/KgpAnimationFrameStoreTests.cs
@@ -3,6 +3,8 @@ namespace Hex1b.Tests;
 [TestClass]
 public class KgpAnimationFrameStoreTests
 {
+    public TestContext TestContext { get; set; } = null!;
+
     [TestMethod]
     public void StoreAnimationFrame_NewFrameExceedsQuota_ReturnsNoSpaceWithoutMutation()
     {
@@ -296,6 +298,113 @@ public class KgpAnimationFrameStoreTests
     }
 
     [TestMethod]
+    public void AnimationState_PersistentMutations_PreserveEarlierVersions()
+    {
+        var root = new KgpAnimationFrame([1, 0, 0, 255], 0);
+        var second = new KgpAnimationFrame([2, 0, 0, 255], 40);
+        var replacement = new KgpAnimationFrame([3, 0, 0, 255], 60);
+        var initial = KgpAnimationState.CreateRoot(root);
+
+        var appended = initial.AddFrame(second);
+        var edited = appended.SetFrame(1, replacement);
+        var removed = edited.RemoveFrame(
+            frameIndex: 0,
+            currentFrameIndex: 0);
+
+        Assert.AreEqual(1, initial.FrameCount);
+        Assert.AreSame(root, initial.GetFrame(0));
+        Assert.AreEqual(4L, initial.StorageSize);
+        Assert.AreEqual(2, appended.FrameCount);
+        Assert.AreSame(second, appended.GetFrame(1));
+        Assert.AreEqual(8L, appended.StorageSize);
+        Assert.AreEqual(2, edited.FrameCount);
+        Assert.AreSame(replacement, edited.GetFrame(1));
+        Assert.AreEqual(8L, edited.StorageSize);
+        Assert.AreEqual(1, removed.FrameCount);
+        Assert.AreSame(replacement, removed.GetFrame(0));
+        Assert.AreEqual(4L, removed.StorageSize);
+    }
+
+    [TestMethod]
+    public void StoreAnimationFrame_PerImageFrameLimit_RejectsAppendAtomically()
+    {
+        var store = new KgpImageStore();
+        store.StoreImage(
+            CreateImage(1, KgpFormat.Rgba32, [1, 2, 3, 255]));
+        var append = ParseFrame("a=f,f=32,s=1,v=1,i=1,X=1");
+        KgpImageStore.AnimationFrameResult result = default;
+        for (var frameNumber = 2;
+             frameNumber <= KgpAnimationState.MaximumFrameCount;
+             frameNumber++)
+        {
+            result = store.StoreAnimationFrame(
+                append,
+                [(byte)(frameNumber & 0xFF), 0, 0, 255]);
+        }
+
+        Assert.AreEqual(
+            KgpImageStore.AnimationFrameStatus.Success,
+            result.Info.Status);
+        var full = store.GetImageById(1);
+        Assert.IsNotNull(full);
+        Assert.AreEqual(
+            KgpAnimationState.MaximumFrameCount,
+            full.FrameCount);
+        Assert.AreEqual(
+            KgpAnimationState.MaximumFrameCount * 4L,
+            full.StorageSize);
+        var totalSize = store.TotalSize;
+
+        var rejected = store.StoreAnimationFrame(
+            append,
+            [9, 9, 9, 255]);
+
+        Assert.AreEqual(
+            KgpImageStore.AnimationFrameStatus.FrameLimitReached,
+            rejected.Info.Status);
+        Assert.AreEqual(
+            (uint)KgpAnimationState.MaximumFrameCount + 1,
+            rejected.Info.FrameNumber);
+        Assert.IsNull(rejected.Image);
+        Assert.AreSame(full, store.GetImageById(1));
+        Assert.AreEqual(totalSize, store.TotalSize);
+
+        var edit = store.StoreAnimationFrame(
+            ParseFrame(
+                $"a=f,f=32,s=1,v=1,i=1,r={KgpAnimationState.MaximumFrameCount},X=1"),
+            [8, 8, 8, 255]);
+        Assert.AreEqual(
+            KgpImageStore.AnimationFrameStatus.Success,
+            edit.Info.Status);
+        Assert.AreEqual(
+            KgpAnimationState.MaximumFrameCount,
+            edit.Image!.FrameCount);
+        Assert.AreEqual(totalSize, store.TotalSize);
+    }
+
+    [TestMethod]
+    [DoNotParallelize]
+    public void StoreAnimationFrame_ManyTinyFrames_AllocationGrowthIsSubquadratic()
+    {
+        _ = MeasureFrameAppendAllocations(32);
+        var small = MeasureFrameAppendAllocations(512);
+        var large = MeasureFrameAppendAllocations(1024);
+
+        TestContext.WriteLine(
+            $"512 appends allocated {small:N0} bytes; " +
+            $"1,024 appends allocated {large:N0} bytes.");
+        Assert.IsGreaterThan(0L, small);
+        Assert.IsLessThan(
+            checked(small * 3),
+            large,
+            "Doubling frame count should remain below quadratic allocation growth.");
+        Assert.IsLessThan(
+            2_000_000L,
+            large,
+            "One thousand tiny-frame appends should have a bounded allocation cost.");
+    }
+
+    [TestMethod]
     public void ConcurrentFrameStores_OnIndependentImages_AreDeterministic()
     {
         const int imageCount = 32;
@@ -358,7 +467,7 @@ public class KgpAnimationFrameStoreTests
             root.Data,
             imageNumber);
         return image.WithAnimation(
-            new KgpAnimationState(frames, currentFrameIndex));
+            KgpAnimationState.Create(frames, currentFrameIndex));
     }
 
     private static KgpImageData CreateAnimatedImageWithTwoFrames(uint imageId)
@@ -369,7 +478,7 @@ public class KgpAnimationFrameStoreTests
             KgpFormat.Rgba32,
             root.Data);
         return image.WithAnimation(
-            new KgpAnimationState(
+            KgpAnimationState.Create(
                 [root, new KgpAnimationFrame([2, 0, 0, 255], 40)],
                 currentFrameIndex: 0));
     }
@@ -385,6 +494,33 @@ public class KgpAnimationFrameStoreTests
             success,
             success ? null : failure.FormatReason(controlData.AsSpan()));
         return TestSeq.IsType<KgpParsedCommand.AnimationFrame>(command);
+    }
+
+    private static long MeasureFrameAppendAllocations(int appendCount)
+    {
+        var store = new KgpImageStore();
+        store.StoreImage(
+            CreateImage(1, KgpFormat.Rgba32, [1, 2, 3, 255]));
+        var command = ParseFrame("a=f,f=32,s=1,v=1,i=1,X=1");
+        var data = new byte[] { 4, 5, 6, 255 };
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        KgpImageStore.AnimationFrameResult result = default;
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var index = 0; index < appendCount; index++)
+            result = store.StoreAnimationFrame(command, data);
+        var allocated = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        Assert.AreEqual(
+            KgpImageStore.AnimationFrameStatus.Success,
+            result.Info.Status);
+        Assert.AreEqual(appendCount + 1, result.Image!.FrameCount);
+        Assert.AreEqual((appendCount + 1) * 4L, store.TotalSize);
+        GC.KeepAlive(store);
+        return allocated;
     }
 
     private static void AssertFrame(

--- a/tests/Hex1b.Tests/KgpAnimationFrameTests.cs
+++ b/tests/Hex1b.Tests/KgpAnimationFrameTests.cs
@@ -675,6 +675,47 @@ public class KgpAnimationFrameTests
     }
 
     [TestMethod]
+    public void AnimationFrame_PerImageFrameLimit_ReturnsEnospcWithoutMutation()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        var frames = new KgpAnimationFrame[
+            KgpAnimationState.MaximumFrameCount];
+        for (var index = 0; index < frames.Length; index++)
+        {
+            frames[index] = new KgpAnimationFrame(
+                [(byte)(index & 0xFF), 0, 0, 255],
+                gapMilliseconds: index == 0 ? 0 : 40);
+        }
+
+        var image = new KgpImageData(
+            1,
+            0,
+            frames[0].Data,
+            1,
+            1,
+            KgpFormat.Rgba32).WithAnimation(
+                KgpAnimationState.Create(
+                    frames,
+                    currentFrameIndex: 0));
+        terminal.KgpImageStore.StoreImage(image);
+        var totalSize = terminal.KgpImageStore.TotalSize;
+
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1,X=1",
+                [9, 9, 9, 255]));
+
+        Assert.AreEqual(
+            $"\x1b_Gi=1,r={KgpAnimationState.MaximumFrameCount + 1};" +
+            $"ENOSPC:Animation frame limit of {KgpAnimationState.MaximumFrameCount} reached\x1b\\",
+            workload.ReadResponse());
+        Assert.AreSame(image, terminal.KgpImageStore.GetImageById(1));
+        Assert.AreEqual(totalSize, terminal.KgpImageStore.TotalSize);
+    }
+
+    [TestMethod]
     public void DeleteAnimationFrame_Root_PromotesSecondFrameAndRepairsAccounting()
     {
         var workload = new RecordingWorkloadAdapter();
@@ -1044,7 +1085,9 @@ public class KgpAnimationFrameTests
             1,
             1,
             KgpFormat.Rgba32).WithAnimation(
-                new KgpAnimationState([root, current], currentFrameIndex: 1));
+                KgpAnimationState.Create(
+                    [root, current],
+                    currentFrameIndex: 1));
         terminal.KgpImageStore.StoreImage(image);
         SendKgp(
             terminal,

--- a/tests/Hex1b.Tests/KgpAnimationFrameTests.cs
+++ b/tests/Hex1b.Tests/KgpAnimationFrameTests.cs
@@ -1,0 +1,1221 @@
+using System.Text;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+/// <summary>
+/// Conformance coverage derived from Kitty graphics.c/graphics.py and Ghostty
+/// graphics_exec.zig at the revisions pinned by issue #403.
+/// </summary>
+[TestClass]
+public class KgpAnimationFrameTests
+{
+    private static readonly TerminalCapabilities KgpCapabilities = new()
+    {
+        SupportsKgp = true,
+        SupportsTrueColor = true,
+        Supports256Colors = true,
+        CellPixelWidth = 10,
+        CellPixelHeight = 20,
+    };
+
+    [TestMethod]
+    public void AnimationFrame_FullRgba_AppendsFrameAndReturnsResolvedNumber()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 2,
+            height: 1,
+            KgpFormat.Rgba32,
+            [10, 20, 30, 255, 40, 50, 60, 255]);
+
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=2,v=1,i=1",
+                [255, 0, 0, 255, 0, 255, 0, 255]));
+
+        var image = GetImage(terminal, 1);
+        Assert.AreEqual(2, image.FrameCount);
+        AssertFrame(
+            image,
+            2,
+            [255, 0, 0, 255, 0, 255, 0, 255],
+            expectedGapMilliseconds: 40);
+        Assert.AreEqual(16L, image.StorageSize);
+        Assert.AreEqual(16L, terminal.KgpImageStore.TotalSize);
+        Assert.AreEqual(
+            "\x1b_Gi=1,r=2;OK\x1b\\",
+            workload.ReadResponse());
+    }
+
+    [TestMethod]
+    public void AnimationFrame_RgbRootAndPayload_NormalizesFramesToRgba()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgb24,
+            [1, 2, 3]);
+
+        SendKgp(
+            terminal,
+            FrameCommand("f=24,s=1,v=1,i=1,q=2", [4, 5, 6]));
+
+        var image = GetImage(terminal, 1);
+        Assert.AreEqual(KgpFormat.Rgba32, image.Format);
+        AssertFrame(image, 1, [1, 2, 3, 255], 0);
+        AssertFrame(image, 2, [4, 5, 6, 255], 40);
+        Assert.AreEqual(8L, image.StorageSize);
+        Assert.AreEqual(8L, terminal.KgpImageStore.TotalSize);
+        workload.AssertNoResponse();
+    }
+
+    [TestMethod]
+    public void AnimationFrame_PartialRectangle_FillsBackgroundInRgbaOrder()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 2,
+            height: 2,
+            KgpFormat.Rgba32,
+            new byte[16]);
+
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1,x=1,y=0,X=1,Y=287454020,q=2",
+                [170, 187, 204, 221]));
+
+        AssertFrame(
+            GetImage(terminal, 1),
+            2,
+            [
+                17, 34, 51, 68,
+                170, 187, 204, 221,
+                17, 34, 51, 68,
+                17, 34, 51, 68,
+            ],
+            40);
+    }
+
+    [TestMethod]
+    public void AnimationFrame_AlphaBlend_UsesSourceOverAndTransparentNoOp()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [0, 0, 0, 0]);
+
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1,Y=1680998655,q=2",
+                [200, 100, 50, 128]));
+        AssertFrame(GetImage(terminal, 1), 2, [150, 75, 25, 255], 40);
+
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1,Y=1680998655,q=2",
+                [255, 255, 255, 0]));
+        AssertFrame(GetImage(terminal, 1), 3, [100, 50, 0, 255], 40);
+
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1,Y=1680998528,q=2",
+                [200, 100, 50, 128]));
+        AssertFrame(GetImage(terminal, 1), 4, [166, 83, 33, 191], 40);
+    }
+
+    [TestMethod]
+    public void AnimationFrame_Overwrite_TransparentSourceReplacesBackground()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [0, 0, 0, 0]);
+
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1,X=1,Y=1680998655,q=2",
+                [255, 255, 255, 0]));
+
+        AssertFrame(GetImage(terminal, 1), 2, [255, 255, 255, 0], 40);
+    }
+
+    [TestMethod]
+    public void AnimationFrame_OmittedDimensions_DefaultToWholeImage()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 2,
+            height: 1,
+            KgpFormat.Rgba32,
+            new byte[8]);
+
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,i=1,X=1,q=2",
+                [1, 2, 3, 4, 5, 6, 7, 8]));
+
+        AssertFrame(
+            GetImage(terminal, 1),
+            2,
+            [1, 2, 3, 4, 5, 6, 7, 8],
+            40);
+    }
+
+    [TestMethod]
+    public void AnimationFrame_BaseFrame_ComposesOntoSelectedFrame()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 2,
+            height: 1,
+            KgpFormat.Rgba32,
+            [0, 0, 255, 255, 0, 0, 255, 255]);
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=2,v=1,i=1,X=1,q=2",
+                [255, 0, 0, 255, 255, 0, 0, 255]));
+
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1,c=2,x=1,X=1,q=2",
+                [0, 255, 0, 255]));
+
+        AssertFrame(
+            GetImage(terminal, 1),
+            3,
+            [255, 0, 0, 255, 0, 255, 0, 255],
+            40);
+    }
+
+    [TestMethod]
+    public void AnimationFrame_EditFrame_ReplacesPixelsAndAppliesGapRules()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 2,
+            height: 1,
+            KgpFormat.Rgba32,
+            new byte[8]);
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=2,v=1,i=1,X=1,z=77,q=2",
+                [1, 2, 3, 4, 5, 6, 7, 8]));
+
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1,r=2,c=999,x=1,X=1,q=2",
+                [9, 10, 11, 12]));
+        AssertFrame(
+            GetImage(terminal, 1),
+            2,
+            [1, 2, 3, 4, 9, 10, 11, 12],
+            77);
+
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1,r=2,X=1,z=-1,q=2",
+                [13, 14, 15, 16]));
+        AssertFrame(
+            GetImage(terminal, 1),
+            2,
+            [13, 14, 15, 16, 9, 10, 11, 12],
+            0);
+    }
+
+    [TestMethod]
+    public void AnimationFrame_EditRoot_UpdatesRootAndKeepsFrameCount()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgb24,
+            [1, 2, 3]);
+
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1,r=1,X=1,z=25",
+                [9, 8, 7, 6]));
+
+        var image = GetImage(terminal, 1);
+        Assert.AreEqual(1, image.FrameCount);
+        AssertFrame(image, 1, [9, 8, 7, 6], 25);
+        Assert.AreEqual(
+            "\x1b_Gi=1,r=1;OK\x1b\\",
+            workload.ReadResponse());
+    }
+
+    [TestMethod]
+    public void AnimationFrame_OutOfRangeEditNumber_AppendsNextFrame()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [0, 0, 0, 0]);
+
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1,r=99,X=1",
+                [1, 2, 3, 4]));
+
+        Assert.AreEqual(2, GetImage(terminal, 1).FrameCount);
+        Assert.AreEqual(
+            "\x1b_Gi=1,r=2;OK\x1b\\",
+            workload.ReadResponse());
+    }
+
+    [TestMethod]
+    public void AnimationFrame_ImageNumber_TargetsNewestAndReturnsBothIdentities()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreNumberedBaseImage(terminal, 42, [1, 1, 1, 255]);
+        var first = terminal.KgpImageStore.GetImageByNumber(42);
+        Assert.IsNotNull(first);
+        StoreNumberedBaseImage(terminal, 42, [2, 2, 2, 255]);
+        var newest = terminal.KgpImageStore.GetImageByNumber(42);
+        Assert.IsNotNull(newest);
+
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,I=42,X=1",
+                [9, 9, 9, 255]));
+
+        Assert.AreEqual(1, first.FrameCount);
+        Assert.AreEqual(2, GetImage(terminal, newest.ImageId).FrameCount);
+        Assert.AreEqual(
+            $"\x1b_Gi={newest.ImageId},I=42,r=2;OK\x1b\\",
+            workload.ReadResponse());
+    }
+
+    [TestMethod]
+    public void AnimationFrame_MissingIdentityAndImage_ReturnProtocolErrors()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+
+        SendKgp(
+            terminal,
+            FrameCommand("f=32,s=1,v=1", [1, 2, 3, 4]));
+        workload.AssertNoResponse();
+
+        SendKgp(
+            terminal,
+            FrameCommand("f=32,s=1,v=1,i=9", [1, 2, 3, 4]));
+        Assert.AreEqual(
+            "\x1b_Gi=9;ENOENT:Image not found\x1b\\",
+            workload.ReadResponse());
+    }
+
+    [TestMethod]
+    public void AnimationFrame_InvalidBaseDimensionsAndPayload_AreAtomic()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [1, 2, 3, 4]);
+        var originalSize = terminal.KgpImageStore.TotalSize;
+
+        SendKgp(
+            terminal,
+            FrameCommand("f=32,s=1,v=1,i=1,c=3", [1, 2, 3, 4]));
+        Assert.AreEqual(
+            "\x1b_Gi=1,r=2;EINVAL:Base frame not found\x1b\\",
+            workload.ReadResponse());
+
+        SendKgp(
+            terminal,
+            FrameCommand("f=32,s=2,v=1,i=1", new byte[8]));
+        Assert.AreEqual(
+            "\x1b_Gi=1;EINVAL:Frame dimensions exceed image dimensions\x1b\\",
+            workload.ReadResponse());
+
+        SendKgp(
+            terminal,
+            FrameCommand("f=32,s=1,v=1,i=1", [1, 2, 3]));
+        Assert.AreEqual(
+            "\x1b_Gi=1,r=2;ENODATA:Insufficient frame data: 3 < 4\x1b\\",
+            workload.ReadResponse());
+
+        SendKgp(
+            terminal,
+            FrameCommand("f=32,s=1,v=1,i=1", [1, 2, 3, 4, 5]));
+        Assert.AreEqual(
+            "\x1b_Gi=1,r=2;EFBIG:Too much frame data: 5 > 4\x1b\\",
+            workload.ReadResponse());
+
+        var image = GetImage(terminal, 1);
+        Assert.AreEqual(1, image.FrameCount);
+        Assert.AreEqual(originalSize, terminal.KgpImageStore.TotalSize);
+        TestSeq.AreEqual(new byte[] { 1, 2, 3, 4 }, image.Data);
+    }
+
+    [TestMethod]
+    public void AnimationFrame_QuietModes_SuppressOnlyConfiguredResponses()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [1, 2, 3, 4]);
+
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1,X=1,q=1",
+                [5, 6, 7, 8]));
+        workload.AssertNoResponse();
+
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1,c=99,q=1",
+                [5, 6, 7, 8]));
+        Assert.AreEqual(
+            "\x1b_Gi=1,r=3;EINVAL:Base frame not found\x1b\\",
+            workload.ReadResponse());
+
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1,c=99,q=2",
+                [5, 6, 7, 8]));
+        workload.AssertNoResponse();
+    }
+
+    [TestMethod]
+    [DataRow("t=f", "EINVAL:Animation frame transmission requires direct data")]
+    [DataRow("o=z", "EINVAL:Animation frame compression is not supported")]
+    [DataRow("f=100", "EINVAL:Animation frames require RGB or RGBA data")]
+    public void AnimationFrame_UnsupportedTransferShape_ReturnsError(
+        string control,
+        string expectedError)
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [1, 2, 3, 4]);
+
+        SendKgp(
+            terminal,
+            FrameCommand($"{control},s=1,v=1,i=1", [1, 2, 3, 4]));
+
+        Assert.AreEqual(
+            $"\x1b_Gi=1;{expectedError}\x1b\\",
+            workload.ReadResponse());
+        Assert.AreEqual(1, GetImage(terminal, 1).FrameCount);
+    }
+
+    [TestMethod]
+    public void AnimationFrame_PngBaseWithoutDecoder_ReturnsError()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=t,f=100,i=1,q=2",
+                [0x89, 0x50, 0x4E, 0x47]));
+
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1",
+                [1, 2, 3, 4]));
+
+        Assert.AreEqual(
+            "\x1b_Gi=1;EINVAL:Animation requires a decoded RGB or RGBA base image\x1b\\",
+            workload.ReadResponse());
+        Assert.AreEqual(1, GetImage(terminal, 1).FrameCount);
+    }
+
+    [TestMethod]
+    public void AnimationFrame_ChunkedUpload_MutatesAndRespondsOnlyAtFinalChunk()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [0, 0, 0, 0]);
+
+        SendKgp(
+            terminal,
+            FrameCommand("f=32,s=1,v=1,i=1,m=1", [1, 2, 3]));
+
+        Assert.AreEqual(1, GetImage(terminal, 1).FrameCount);
+        Assert.IsTrue(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        workload.AssertNoResponse();
+
+        SendKgp(
+            terminal,
+            FrameCommand("m=0", [4]));
+
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        AssertFrame(GetImage(terminal, 1), 2, [1, 2, 3, 4], 40);
+        Assert.AreEqual(
+            "\x1b_Gi=1,r=2;OK\x1b\\",
+            workload.ReadResponse());
+    }
+
+    [TestMethod]
+    public void AnimationFrame_ChunkedUpload_RetainsFirstMetadataAndQuiet()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [0, 0, 0, 0]);
+
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1,X=1,z=91,m=1,q=1",
+                [9, 8, 7]));
+        SendKgp(
+            terminal,
+            FrameCommand("m=0", [6]));
+
+        AssertFrame(GetImage(terminal, 1), 2, [9, 8, 7, 6], 91);
+        workload.AssertNoResponse();
+    }
+
+    [TestMethod]
+    [DataRow("m=0")]
+    [DataRow("a=f,m=0,r=2")]
+    public void AnimationFrame_InvalidContinuation_AbortsWithoutMutation(
+        string continuationControls)
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [0, 0, 0, 0]);
+        SendKgp(
+            terminal,
+            FrameCommand("f=32,s=1,v=1,i=1,m=1", [1, 2, 3]));
+
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand(continuationControls, [4]));
+
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(1, GetImage(terminal, 1).FrameCount);
+        Assert.AreEqual(
+            "\x1b_Gi=1,r=2;EINVAL:Invalid chunk continuation controls\x1b\\",
+            workload.ReadResponse());
+    }
+
+    [TestMethod]
+    public void AnimationFrame_OrphanContinuation_ReturnsSequenceError()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+
+        SendKgp(
+            terminal,
+            FrameCommand("m=0", [1, 2, 3, 4]));
+
+        workload.AssertNoResponse();
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+    }
+
+    [TestMethod]
+    public void AnimationFrame_ChunkedPayloadExceedsExpectedSize_AbortsAtomically()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [0, 0, 0, 0]);
+        SendKgp(
+            terminal,
+            FrameCommand("f=32,s=1,v=1,i=1,m=1", [1, 2, 3]));
+
+        SendKgp(
+            terminal,
+            FrameCommand("m=0", [4, 5]));
+
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(1, GetImage(terminal, 1).FrameCount);
+        Assert.AreEqual(
+            "\x1b_Gi=1,r=2;EFBIG:Too much frame data: 5 > 4\x1b\\",
+            workload.ReadResponse());
+    }
+
+    [TestMethod]
+    public void DeleteAnimationFrame_AbortsPendingFrameUploadBeforeDeletion()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [1, 2, 3, 4]);
+        SendKgp(
+            terminal,
+            FrameCommand("f=32,s=1,v=1,i=1,m=1", [5, 6, 7]));
+        Assert.IsTrue(terminal.KgpImageStore.IsChunkedTransferInProgress);
+
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand("a=d,d=f,i=1"));
+
+        Assert.IsFalse(terminal.KgpImageStore.IsChunkedTransferInProgress);
+        Assert.AreEqual(1, GetImage(terminal, 1).FrameCount);
+        workload.AssertNoResponse();
+    }
+
+    [TestMethod]
+    public void AnimationFrame_InvalidBase64_ReturnsErrorWithoutMutation()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [0, 0, 0, 0]);
+
+        SendKgp(
+            terminal,
+            "\x1b_Ga=f,f=32,s=1,v=1,i=1;%%%\x1b\\");
+
+        Assert.AreEqual(1, GetImage(terminal, 1).FrameCount);
+        Assert.AreEqual(
+            "\x1b_Gi=1,r=2;EINVAL:Invalid Base64 payload\x1b\\",
+            workload.ReadResponse());
+    }
+
+    [TestMethod]
+    public void DeleteAnimationFrame_Root_PromotesSecondFrameAndRepairsAccounting()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [1, 1, 1, 255]);
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1,X=1,z=70,q=2",
+                [2, 2, 2, 255]));
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1,X=1,z=80,q=2",
+                [3, 3, 3, 255]));
+        Assert.AreEqual(12L, terminal.KgpImageStore.TotalSize);
+
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand("a=d,d=f,i=1,r=1"));
+
+        var image = GetImage(terminal, 1);
+        Assert.AreEqual(2, image.FrameCount);
+        AssertFrame(image, 1, [2, 2, 2, 255], 70);
+        AssertFrame(image, 2, [3, 3, 3, 255], 80);
+        Assert.AreEqual(8L, terminal.KgpImageStore.TotalSize);
+        workload.AssertNoResponse();
+    }
+
+    [TestMethod]
+    public void DeleteAnimationFrame_NonRootAndOutOfRange_DeleteSelectedFrames()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [1, 1, 1, 255]);
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1,X=1,q=2",
+                [2, 2, 2, 255]));
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1,X=1,q=2",
+                [3, 3, 3, 255]));
+
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand("a=d,d=F,i=1,r=2"));
+        var image = GetImage(terminal, 1);
+        Assert.AreEqual(2, image.FrameCount);
+        AssertFrame(image, 2, [3, 3, 3, 255], 40);
+
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand("a=d,d=f,i=1,r=99"));
+        image = GetImage(terminal, 1);
+        Assert.AreEqual(1, image.FrameCount);
+        AssertFrame(image, 1, [1, 1, 1, 255], 0);
+        Assert.AreEqual(4L, terminal.KgpImageStore.TotalSize);
+    }
+
+    [TestMethod]
+    public void DeleteAnimationFrame_ImageNumber_AlwaysTargetsNewestImage()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreNumberedBaseImage(terminal, 42, [1, 1, 1, 255]);
+        var older = terminal.KgpImageStore.GetImageByNumber(42);
+        Assert.IsNotNull(older);
+        StoreNumberedBaseImage(terminal, 42, [2, 2, 2, 255]);
+        var newer = terminal.KgpImageStore.GetImageByNumber(42);
+        Assert.IsNotNull(newer);
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,I=42,X=1,q=2",
+                [3, 3, 3, 255]));
+
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand("a=d,d=f,I=42,r=2"));
+
+        Assert.AreEqual(1, GetImage(terminal, older.ImageId).FrameCount);
+        Assert.AreEqual(1, GetImage(terminal, newer.ImageId).FrameCount);
+
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand("a=d,d=F,I=42"));
+
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(newer.ImageId));
+        Assert.AreSame(
+            terminal.KgpImageStore.GetImageById(older.ImageId),
+            terminal.KgpImageStore.GetImageByNumber(42));
+    }
+
+    [TestMethod]
+    public void DeleteAnimationFrame_SingleFrame_LowercaseNoOpUppercaseCascadesGraph()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 10, height: 5);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [1, 1, 1, 255]);
+        StoreBaseImage(
+            terminal,
+            imageId: 2,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [2, 2, 2, 255]);
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=p,i=1,p=10,c=1,r=1,C=1,q=2"));
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=p,i=2,p=20,c=1,r=1,P=1,Q=10,H=1,V=0,C=1,q=2"));
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
+
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand("a=d,d=f,i=1"));
+
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.AreEqual(2, terminal.KgpPlacements.Count);
+
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand("a=d,d=F,i=1"));
+
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(2));
+        Assert.IsEmpty(terminal.KgpPlacements);
+        Assert.AreEqual(0L, terminal.KgpImageStore.TotalSize);
+    }
+
+    [TestMethod]
+    public void DeleteAnimationFrame_UppercaseSingleFrame_RemovesVirtualOwner()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 4, height: 2);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 10,
+            height: 20,
+            KgpFormat.Rgb24,
+            new byte[10 * 20 * 3]);
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=p,U=1,i=1,p=7,c=1,r=1,q=2"));
+        Assert.AreEqual(1, terminal.KgpVirtualPlacementCount);
+
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand("a=d,d=F,i=1"));
+
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.AreEqual(0, terminal.KgpVirtualPlacementCount);
+        Assert.AreEqual(0, terminal.GetKgpVirtualReferenceCount(1));
+    }
+
+    [TestMethod]
+    public void DeleteAnimationFrame_UppercaseSingleFrame_RemovesHistoryOwner()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            width: 4,
+            height: 2,
+            scrollbackCapacity: 2);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 10,
+            height: 20,
+            KgpFormat.Rgb24,
+            new byte[10 * 20 * 3]);
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=p,i=1,p=7,c=1,r=1,C=1,q=2"));
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[S"));
+        Assert.AreEqual(1, terminal.KgpHistoryPlacementCount);
+
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand("a=d,d=F,i=1"));
+
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.AreEqual(0, terminal.KgpHistoryPlacementCount);
+        using var snapshot = terminal.CreateSnapshot(scrollbackLines: 1);
+        Assert.IsEmpty(snapshot.KgpPlacements);
+        Assert.IsEmpty(snapshot.KgpImages);
+    }
+
+    [TestMethod]
+    public void AnimationFrame_ExplicitBaseRetransmission_ResetsAnimationState()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [1, 2, 3, 4]);
+        SendKgp(
+            terminal,
+            FrameCommand("f=32,s=1,v=1,i=1,q=2", [5, 6, 7, 8]));
+        Assert.AreEqual(2, GetImage(terminal, 1).FrameCount);
+
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [9, 10, 11, 12]);
+
+        var image = GetImage(terminal, 1);
+        Assert.AreEqual(1, image.FrameCount);
+        Assert.IsNull(image.AnimationFrames);
+        TestSeq.AreEqual(new byte[] { 9, 10, 11, 12 }, image.Data);
+        Assert.AreEqual(4L, terminal.KgpImageStore.TotalSize);
+    }
+
+    [TestMethod]
+    public void AnimationFrame_InvalidExplicitRetransmission_RemovesAnimationAndPlacements()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 5, height: 3);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [1, 2, 3, 4]);
+        SendKgp(
+            terminal,
+            FrameCommand("f=32,s=1,v=1,i=1,q=2", [5, 6, 7, 8]));
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=p,i=1,p=1,c=1,r=1,C=1,q=2"));
+
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=t,f=32,s=2,v=1,i=1",
+                [9, 10, 11, 12]));
+
+        Assert.AreEqual(
+            "\x1b_Gi=1;ENODATA:Insufficient image data: 4 < 8\x1b\\",
+            workload.ReadResponse());
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.AreEqual(0L, terminal.KgpImageStore.TotalSize);
+        Assert.IsEmpty(terminal.KgpPlacements);
+    }
+
+    [TestMethod]
+    public void AnimationFrame_MainAndAlternateScreens_AreIndependent()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [1, 1, 1, 255]);
+        SendKgp(
+            terminal,
+            FrameCommand("f=32,s=1,v=1,i=1,q=2", [2, 2, 2, 255]));
+        var mainStore = terminal.KgpImageStore;
+
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[?1049h"));
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [3, 3, 3, 255]);
+        var alternateStore = terminal.KgpImageStore;
+        Assert.AreNotSame(mainStore, alternateStore);
+        Assert.AreEqual(1, GetImage(terminal, 1).FrameCount);
+
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[?1049l"));
+
+        Assert.AreSame(mainStore, terminal.KgpImageStore);
+        Assert.AreEqual(2, GetImage(terminal, 1).FrameCount);
+        Assert.AreEqual(0, alternateStore.ImageCount);
+        Assert.AreEqual(0L, alternateStore.TotalSize);
+    }
+
+    [TestMethod]
+    public void AnimationFrame_RootEdit_PreservesEarlierSnapshotAndUpdatesSvg()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 5, height: 3);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [255, 0, 0, 255]);
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=p,i=1,p=1,c=1,r=1,C=1,q=2"));
+        using var before = terminal.CreateSnapshot();
+        var beforeSvg = before.ToSvg();
+
+        SendKgp(
+            terminal,
+            FrameCommand(
+                "f=32,s=1,v=1,i=1,r=1,X=1,q=2",
+                [0, 0, 255, 255]));
+        using var after = terminal.CreateSnapshot();
+        var afterSvg = after.ToSvg();
+
+        TestSeq.AreEqual(
+            new byte[] { 255, 0, 0, 255 },
+            before.KgpImages[1].CurrentFrameData);
+        TestSeq.AreEqual(
+            new byte[] { 0, 0, 255, 255 },
+            after.KgpImages[1].CurrentFrameData);
+        Assert.AreNotEqual(beforeSvg, afterSvg);
+        Assert.Contains("data-image-id=\"1\"", afterSvg);
+    }
+
+    [TestMethod]
+    public void AnimationFrame_SnapshotAndSvg_UseCurrentFramePlaceholder()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = CreateTerminal(workload, width: 5, height: 3);
+        var root = new KgpAnimationFrame([255, 0, 0, 255], 0);
+        var current = new KgpAnimationFrame([0, 0, 255, 255], 40);
+        var image = new KgpImageData(
+            1,
+            0,
+            root.Data,
+            1,
+            1,
+            KgpFormat.Rgba32).WithAnimation(
+                new KgpAnimationState([root, current], currentFrameIndex: 1));
+        terminal.KgpImageStore.StoreImage(image);
+        SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                "a=p,i=1,p=1,c=1,r=1,C=1,q=2"));
+
+        using var snapshot = terminal.CreateSnapshot();
+        var captured = snapshot.KgpImages[1];
+
+        Assert.AreEqual(2, captured.FrameCount);
+        Assert.AreEqual(2, captured.CurrentFrameNumber);
+        TestSeq.AreEqual(
+            new byte[] { 0, 0, 255, 255 },
+            captured.CurrentFrameData);
+        Assert.Contains("data-image-id=\"1\"", snapshot.ToSvg());
+    }
+
+    [TestMethod]
+    public void Dispose_WithAnimationFrames_ReleasesPerScreenStorage()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        var terminal = CreateTerminal(workload);
+        StoreBaseImage(
+            terminal,
+            imageId: 1,
+            width: 1,
+            height: 1,
+            KgpFormat.Rgba32,
+            [1, 2, 3, 4]);
+        SendKgp(
+            terminal,
+            FrameCommand("f=32,s=1,v=1,i=1,q=2", [5, 6, 7, 8]));
+        var store = terminal.KgpImageStore;
+        Assert.AreEqual(8L, store.TotalSize);
+
+        terminal.Dispose();
+
+        Assert.AreEqual(0, store.ImageCount);
+        Assert.AreEqual(0L, store.TotalSize);
+    }
+
+    private static Hex1bTerminal CreateTerminal(
+        IHex1bTerminalWorkloadAdapter workload,
+        int width = 80,
+        int height = 24,
+        int? scrollbackCapacity = null)
+    {
+        var builder = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithHeadless(KgpCapabilities)
+            .WithDimensions(width, height);
+        if (scrollbackCapacity is { } capacity)
+            builder.WithScrollback(capacity);
+        return builder.Build();
+    }
+
+    private static void StoreBaseImage(
+        Hex1bTerminal terminal,
+        uint imageId,
+        uint width,
+        uint height,
+        KgpFormat format,
+        byte[] data)
+        => SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                $"a=t,f={(int)format},s={width},v={height},i={imageId},q=2",
+                data));
+
+    private static void StoreNumberedBaseImage(
+        Hex1bTerminal terminal,
+        uint imageNumber,
+        byte[] data)
+        => SendKgp(
+            terminal,
+            KgpTestHelper.BuildCommand(
+                $"a=t,f=32,s=1,v=1,I={imageNumber},q=2",
+                data));
+
+    private static string FrameCommand(string controls, byte[] data)
+        => KgpTestHelper.BuildCommand($"a=f,{controls}", data);
+
+    private static void SendKgp(
+        Hex1bTerminal terminal,
+        string escapeSequence)
+        => terminal.ApplyTokens(AnsiTokenizer.Tokenize(escapeSequence));
+
+    private static KgpImageData GetImage(
+        Hex1bTerminal terminal,
+        uint imageId)
+    {
+        var image = terminal.KgpImageStore.GetImageById(imageId);
+        Assert.IsNotNull(image);
+        return image;
+    }
+
+    private static void AssertFrame(
+        KgpImageData image,
+        int frameNumber,
+        byte[] expectedData,
+        int expectedGapMilliseconds)
+    {
+        Assert.IsTrue(
+            image.TryGetFrame(
+                frameNumber,
+                out var data,
+                out var format,
+                out var gapMilliseconds));
+        Assert.AreEqual(KgpFormat.Rgba32, format);
+        Assert.AreEqual(expectedGapMilliseconds, gapMilliseconds);
+        TestSeq.AreEqual(expectedData, data);
+    }
+
+    private sealed class RecordingWorkloadAdapter :
+        IHex1bTerminalWorkloadAdapter
+    {
+        private readonly Queue<byte[]> _responses = new();
+        private readonly object _lock = new();
+
+        public event Action? Disconnected
+        {
+            add { }
+            remove { }
+        }
+
+        public ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(
+            CancellationToken ct = default)
+            => ValueTask.FromResult(ReadOnlyMemory<byte>.Empty);
+
+        public ValueTask WriteInputAsync(
+            ReadOnlyMemory<byte> data,
+            CancellationToken ct = default)
+        {
+            lock (_lock)
+                _responses.Enqueue(data.ToArray());
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask ResizeAsync(
+            int width,
+            int height,
+            CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync()
+            => ValueTask.CompletedTask;
+
+        internal string ReadResponse()
+        {
+            byte[]? response = null;
+            var received = SpinWait.SpinUntil(
+                () =>
+                {
+                    lock (_lock)
+                        return _responses.TryDequeue(out response);
+                },
+                TimeSpan.FromSeconds(1));
+            Assert.IsTrue(received, "Expected a KGP protocol response.");
+            return Encoding.UTF8.GetString(response!);
+        }
+
+        internal void AssertNoResponse()
+        {
+            var received = SpinWait.SpinUntil(
+                () =>
+                {
+                    lock (_lock)
+                        return _responses.Count > 0;
+                },
+                TimeSpan.FromMilliseconds(100));
+            Assert.IsFalse(received, "Expected no KGP protocol response.");
+        }
+    }
+}

--- a/tests/Hex1b.Tests/KgpCommandParserTests.cs
+++ b/tests/Hex1b.Tests/KgpCommandParserTests.cs
@@ -652,10 +652,17 @@ public class KgpCommandParserTests
         const string validControlData =
             "a=T,f=24,t=d,s=100,v=200,S=300,O=400,i=42,p=7,m=0,q=1,N=1," +
             "x=10,y=20,w=30,h=40,X=3,Y=5,c=6,r=8,C=1,U=1,z=-9,P=11,Q=12,H=-13,V=14";
+        const string validAnimationFrameControlData =
+            "a=f,f=32,t=d,s=100,v=200,i=42,m=0,q=1," +
+            "x=10,y=20,X=1,Y=4278190335,c=6,r=8,z=-9";
         const string invalidDeleteControlData = "a=d,d=f,i=42,r=bad,q=1";
 
         var validBytes = MeasureParserAllocations(
             validControlData,
+            expectedSuccess: true,
+            iterations);
+        var validAnimationFrameBytes = MeasureParserAllocations(
+            validAnimationFrameControlData,
             expectedSuccess: true,
             iterations);
         var invalidDeleteBytes = MeasureParserAllocations(
@@ -666,10 +673,16 @@ public class KgpCommandParserTests
         TestContext.WriteLine(
             $"Valid parse: {validBytes} bytes total, {(double)validBytes / iterations:F2} bytes/op.");
         TestContext.WriteLine(
+            $"Valid animation frame parse: {validAnimationFrameBytes} bytes total, " +
+            $"{(double)validAnimationFrameBytes / iterations:F2} bytes/op.");
+        TestContext.WriteLine(
             $"Invalid delete parse: {invalidDeleteBytes} bytes total, " +
             $"{(double)invalidDeleteBytes / iterations:F2} bytes/op.");
 
         Assert.IsLessThanOrEqualTo(256L, validBytes / iterations);
+        Assert.IsLessThanOrEqualTo(
+            256L,
+            validAnimationFrameBytes / iterations);
         Assert.AreEqual(0L, invalidDeleteBytes);
     }
 

--- a/tests/Hex1b.Tests/KgpTerminalTests.cs
+++ b/tests/Hex1b.Tests/KgpTerminalTests.cs
@@ -588,10 +588,10 @@ public class KgpTerminalTests
     }
 
     [TestMethod]
-    [DataRow("a=f,i=1,s=1,v=1")]
     [DataRow("a=a,i=1,s=3,v=1")]
     [DataRow("a=c,i=1,c=1,r=1")]
-    public void ValidUnimplementedAnimationAction_IsTypedNoOp(string controlData)
+    public void RemainingUnimplementedAnimationAction_IsTypedNoOp(
+        string controlData)
     {
         var workload = new RecordingWorkloadAdapter();
         using var terminal = CreateTerminal(workload);

--- a/tests/Hex1b.Tests/KgpTokenizerTests.cs
+++ b/tests/Hex1b.Tests/KgpTokenizerTests.cs
@@ -26,6 +26,21 @@ public class KgpTokenizerTests
     }
 
     [TestMethod]
+    public void Tokenize_AnimationFrame_RoundTripsRawControlsAndPayload()
+    {
+        const string sequence =
+            "\x1b_Ga=f,f=32,s=2,v=1,i=7,x=1,Y=287454020,z=-1;AQIDBA==\x1b\\";
+
+        var tokens = AnsiTokenizer.Tokenize(sequence);
+
+        Assert.AreEqual(sequence, AnsiTokenSerializer.Serialize(tokens));
+        Assert.AreEqual(
+            sequence,
+            System.Text.Encoding.UTF8.GetString(
+                AnsiTokenUtf8Serializer.Serialize(tokens).Span));
+    }
+
+    [TestMethod]
     public void Tokenize_KgpWithNoPayload_ProducesKgpTokenWithEmptyPayload()
     {
         var tokens = AnsiTokenizer.Tokenize("\x1b_Ga=d,d=a\x1b\\");


### PR DESCRIPTION
## Summary

- execute direct and bounded chunked `a=f` uploads with full/partial, base-frame, edit-frame, blend/overwrite, background, gap, identity, quiet, and response semantics
- store copy-on-write full-RGBA frame state with atomic quota/accounting updates, root retransmission reset, immutable snapshots, and current-frame SVG rendering
- use a persistent immutable frame tree for O(log n) append/edit/remove/indexed lookup with incremental storage accounting
- cap each image at 4,096 frames and return deterministic `ENOSPC` without mutation when the limit is reached
- implement `d=f/F` frame deletion with root promotion, current-index repair, newest-number targeting, and one-frame uppercase placement-graph cascade
- add Kitty/Ghostty-derived protocol, store, parser, snapshot, SVG, screen-lifetime, allocation-growth, resource-limit, and deterministic concurrency coverage

## Validation

- `dotnet build src/Hex1b/Hex1b.csproj -c Release --no-restore`
- all 59 focused animation-frame tests pass
- all 872 KGP tests pass
- full suite: 8,421 total; 8,397 passed; 24 skipped
- allocation regression: 512 tiny-frame appends allocate 320,160 bytes; 1,024 allocate 688,848 bytes (subquadratic and below the 2 MB bound)

Closes #403