### PR TITLE
Add raw KGP validation sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Hex1b follows a widget/node separation pattern:
 The `samples/` directory contains example applications demonstrating various features:
 
 - **Cancellation** - Master-detail contact editor with save/cancel functionality
+- **KgpValidation** - Raw `Hex1bTerminal` KGP compliance pages without `Hex1bApp` or widgets
 
 ### Running Samples with Aspire
 
@@ -218,4 +219,3 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - [Spectre.Console](https://spectreconsole.net/) - Beautiful console output
 - [Terminal.Gui](https://github.com/gui-cs/Terminal.Gui) - Cross-platform terminal UI toolkit
 - [Aspire](https://aspire.dev/) - Cloud-ready stack for .NET
-

--- a/samples/KgpValidation/AssemblyInfo.cs
+++ b/samples/KgpValidation/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Hex1b.Tests")]

--- a/samples/KgpValidation/KgpImageFactory.cs
+++ b/samples/KgpValidation/KgpImageFactory.cs
@@ -1,0 +1,158 @@
+namespace KgpValidation;
+
+/// <summary>
+/// Generates small deterministic images without native image dependencies.
+/// </summary>
+internal static class KgpImageFactory
+{
+    public static byte[] CreateRgbaGradient(int width, int height)
+    {
+        var data = Allocate(width, height, 4);
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var offset = (y * width + x) * 4;
+                data[offset] = Scale(x, width);
+                data[offset + 1] = Scale(y, height);
+                data[offset + 2] = (byte)(255 - data[offset]);
+                data[offset + 3] = 255;
+            }
+        }
+        return data;
+    }
+
+    public static byte[] CreateRgbBars(int width, int height)
+    {
+        (byte R, byte G, byte B)[] colors =
+        [
+            (255, 64, 64),
+            (255, 192, 32),
+            (64, 220, 96),
+            (64, 180, 255),
+            (96, 96, 255),
+            (220, 80, 255),
+        ];
+        var data = Allocate(width, height, 3);
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var color = colors[Math.Min(
+                    colors.Length - 1,
+                    x * colors.Length / width)];
+                var offset = (y * width + x) * 3;
+                data[offset] = color.R;
+                data[offset + 1] = color.G;
+                data[offset + 2] = color.B;
+            }
+        }
+        return data;
+    }
+
+    public static byte[] CreateRgbaChecker(int width, int height)
+    {
+        var data = Allocate(width, height, 4);
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var first = ((x / 8) + (y / 8)) % 2 == 0;
+                var offset = (y * width + x) * 4;
+                data[offset] = first ? (byte)30 : (byte)240;
+                data[offset + 1] = first ? (byte)190 : (byte)70;
+                data[offset + 2] = first ? (byte)240 : (byte)40;
+                data[offset + 3] = 255;
+            }
+        }
+        return data;
+    }
+
+    public static byte[] CreateRgbaBullseye(int width, int height)
+    {
+        var data = Allocate(width, height, 4);
+        var centerX = (width - 1) / 2.0;
+        var centerY = (height - 1) / 2.0;
+        var radius = Math.Min(width, height) / 2.0;
+
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var distance = Math.Sqrt(
+                    Math.Pow(x - centerX, 2) + Math.Pow(y - centerY, 2));
+                var offset = (y * width + x) * 4;
+                if (distance > radius)
+                {
+                    data[offset + 3] = 0;
+                    continue;
+                }
+
+                var ring = (int)(distance / Math.Max(1, radius / 4));
+                var bright = ring % 2 == 0;
+                data[offset] = bright ? (byte)255 : (byte)25;
+                data[offset + 1] = bright ? (byte)70 : (byte)180;
+                data[offset + 2] = bright ? (byte)60 : (byte)255;
+                data[offset + 3] = 255;
+            }
+        }
+        return data;
+    }
+
+    public static byte[] CreateRgbaQuadrants(int width, int height)
+    {
+        var data = Allocate(width, height, 4);
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var top = y < height / 2;
+                var left = x < width / 2;
+                var color = (top, left) switch
+                {
+                    (true, true) => (R: (byte)240, G: (byte)48, B: (byte)48),
+                    (true, false) => (R: (byte)48, G: (byte)220, B: (byte)80),
+                    (false, true) => (R: (byte)48, G: (byte)96, B: (byte)240),
+                    _ => (R: (byte)250, G: (byte)210, B: (byte)40),
+                };
+                var offset = (y * width + x) * 4;
+                data[offset] = color.R;
+                data[offset + 1] = color.G;
+                data[offset + 2] = color.B;
+                data[offset + 3] = 255;
+            }
+        }
+        return data;
+    }
+
+    public static byte[] CreateRgbaSolid(
+        int width,
+        int height,
+        byte red,
+        byte green,
+        byte blue,
+        byte alpha = 255)
+    {
+        var data = Allocate(width, height, 4);
+        for (var offset = 0; offset < data.Length; offset += 4)
+        {
+            data[offset] = red;
+            data[offset + 1] = green;
+            data[offset + 2] = blue;
+            data[offset + 3] = alpha;
+        }
+        return data;
+    }
+
+    private static byte[] Allocate(int width, int height, int channels)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(width, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(height, 1);
+        return new byte[checked(width * height * channels)];
+    }
+
+    private static byte Scale(int value, int extent)
+        => extent <= 1
+            ? (byte)0
+            : (byte)(value * 255 / (extent - 1));
+}

--- a/samples/KgpValidation/KgpProtocolWriter.cs
+++ b/samples/KgpValidation/KgpProtocolWriter.cs
@@ -1,0 +1,102 @@
+using System.Text;
+using Hex1b;
+
+namespace KgpValidation;
+
+/// <summary>
+/// Builds the raw ANSI and Kitty graphics byte stream consumed by
+/// <see cref="Hex1bTerminal"/>.
+/// </summary>
+/// <remarks>
+/// This deliberately exposes control strings at scenario call sites. The sample
+/// is a protocol debugging aid, so an agent should be able to see the exact KGP
+/// keys involved without stepping through a higher-level graphics abstraction.
+/// </remarks>
+internal sealed class KgpProtocolWriter
+{
+    private readonly StringBuilder _buffer = new();
+
+    public void Raw(string value) => _buffer.Append(value);
+
+    public void MoveTo(int row, int column)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(row, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(column, 1);
+        _buffer.Append("\x1b[")
+            .Append(row)
+            .Append(';')
+            .Append(column)
+            .Append('H');
+    }
+
+    public void TextAt(
+        int row,
+        int column,
+        string value,
+        int maximumLength = int.MaxValue)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        MoveTo(row, column);
+
+        var sanitized = value
+            .Replace('\r', ' ')
+            .Replace('\n', ' ')
+            .Replace('\x1b', '?');
+        _buffer.Append(sanitized.AsSpan(
+            0,
+            Math.Min(sanitized.Length, maximumLength)));
+    }
+
+    public void Kgp(string controlData)
+        => Kgp(controlData, ReadOnlySpan<byte>.Empty);
+
+    public void Kgp(string controlData, ReadOnlySpan<byte> payload)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(controlData);
+        if (controlData.Contains(';') || controlData.Contains('\x1b'))
+        {
+            throw new ArgumentException(
+                "KGP control data cannot contain payload or escape delimiters.",
+                nameof(controlData));
+        }
+
+        _buffer.Append("\x1b_G").Append(controlData);
+        if (!payload.IsEmpty)
+        {
+            _buffer.Append(';');
+            _buffer.Append(Convert.ToBase64String(payload));
+        }
+        _buffer.Append("\x1b\\");
+    }
+
+    public void ChunkedTransmit(
+        uint imageId,
+        int width,
+        int height,
+        KgpFormat format,
+        ReadOnlySpan<byte> payload,
+        int rawChunkSize = 3072)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(rawChunkSize, 3);
+        if (rawChunkSize % 3 != 0)
+        {
+            throw new ArgumentException(
+                "Every non-final Base64 chunk must contain a multiple of three bytes.",
+                nameof(rawChunkSize));
+        }
+
+        var offset = 0;
+        while (offset < payload.Length)
+        {
+            var count = Math.Min(rawChunkSize, payload.Length - offset);
+            var isFinal = offset + count == payload.Length;
+            var controls = offset == 0
+                ? $"a=t,f={(int)format},s={width},v={height},i={imageId},m={(isFinal ? 0 : 1)},q=2"
+                : $"m={(isFinal ? 0 : 1)},q=2";
+            Kgp(controls, payload.Slice(offset, count));
+            offset += count;
+        }
+    }
+
+    public byte[] ToUtf8Bytes() => Encoding.UTF8.GetBytes(_buffer.ToString());
+}

--- a/samples/KgpValidation/KgpScenarioCatalog.cs
+++ b/samples/KgpValidation/KgpScenarioCatalog.cs
@@ -1,0 +1,25 @@
+using System.Collections.ObjectModel;
+using KgpValidation.Scenarios;
+
+namespace KgpValidation;
+
+/// <summary>
+/// Ordered scenario catalog used by both the interactive workload and tests.
+/// </summary>
+internal static class KgpScenarioCatalog
+{
+    public static IReadOnlyList<KgpValidationScenario> All { get; } =
+        new ReadOnlyCollection<KgpValidationScenario>(
+        [
+            new OverviewScenario(),
+            new DirectAndChunkedScenario(),
+            new SharedAndReplacementScenario(),
+            new SourceCropScenario(),
+            new ZOrderScenario(),
+            new ScrollingScenario(),
+            new UnicodePlaceholderScenario(),
+            new RelativePlacementScenario(),
+            new AnimationFrameScenario(),
+            new DeletionReuseScenario(),
+        ]);
+}

--- a/samples/KgpValidation/KgpValidation.csproj
+++ b/samples/KgpValidation/KgpValidation.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <PublishAot>true</PublishAot>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Hex1b/Hex1b.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/KgpValidation/KgpValidationFrameRenderer.cs
+++ b/samples/KgpValidation/KgpValidationFrameRenderer.cs
@@ -1,0 +1,174 @@
+using System.Text;
+
+namespace KgpValidation;
+
+/// <summary>
+/// Renders the common explanatory shell around each raw KGP scenario.
+/// </summary>
+internal static class KgpValidationFrameRenderer
+{
+    public static byte[] Render(
+        KgpValidationScenario scenario,
+        int scenarioIndex,
+        int scenarioCount,
+        int width,
+        int height,
+        bool enterAlternateScreen,
+        int variant = 0)
+    {
+        ArgumentNullException.ThrowIfNull(scenario);
+        ArgumentOutOfRangeException.ThrowIfNegative(scenarioIndex);
+        ArgumentOutOfRangeException.ThrowIfLessThan(scenarioCount, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(width, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(height, 1);
+        if (variant < 0 || variant >= scenario.VariantCount)
+            throw new ArgumentOutOfRangeException(nameof(variant));
+
+        var writer = new KgpProtocolWriter();
+        if (enterAlternateScreen)
+            writer.Raw("\x1b[?1049h");
+
+        // Every page is self-contained. This prevents a failed scenario from
+        // contaminating the visual result of the next one.
+        writer.Kgp("a=d,d=R,x=1,y=4294967295,q=2");
+        writer.Kgp("a=d,d=A,q=2");
+        writer.Raw("\x1b[r\x1b[0m\x1b[?25l\x1b[2J\x1b[H");
+
+        var usableWidth = Math.Max(1, width - 1);
+        WriteBanner(
+            writer,
+            1,
+            $" KGP VALIDATION  {scenarioIndex + 1:00}/{scenarioCount:00}  {scenario.Title}",
+            usableWidth);
+        writer.TextAt(
+            2,
+            2,
+            $"Area: {scenario.Area}",
+            Math.Max(1, usableWidth - 2));
+        WriteWrappedField(
+            writer,
+            3,
+            "Expected",
+            scenario.GetExpected(variant),
+            usableWidth);
+        WriteWrappedField(
+            writer,
+            5,
+            "Protocol",
+            scenario.Protocol,
+            usableWidth);
+        writer.TextAt(7, 2, new string('-', Math.Max(1, usableWidth - 2)));
+
+        var layout = new KgpScenarioLayout(width, height);
+        if (layout.HasGraphicsRoom)
+        {
+            scenario.RenderVariant(writer, layout, variant);
+        }
+        else
+        {
+            writer.TextAt(
+                10,
+                3,
+                $"Resize to at least {KgpScenarioLayout.MinimumWidth}x{KgpScenarioLayout.MinimumHeight} " +
+                "to render this scenario.",
+                Math.Max(1, usableWidth - 3));
+        }
+
+        writer.Raw("\x1b[r\x1b[0m");
+        if (scenario.ActionHint is { } actionHint)
+        {
+            writer.TextAt(
+                Math.Max(1, height - 1),
+                2,
+                actionHint,
+                Math.Max(1, usableWidth - 2));
+        }
+        WriteBanner(
+            writer,
+            height,
+            " N/Space/Right next  P/Left previous  1-9 jump  Q/Esc/Ctrl+C exit ",
+            usableWidth);
+        return writer.ToUtf8Bytes();
+    }
+
+    public static byte[] Cleanup()
+        => Encoding.UTF8.GetBytes(
+            "\x1b_Ga=d,d=R,x=1,y=4294967295,q=2\x1b\\" +
+            "\x1b_Ga=d,d=A,q=2\x1b\\" +
+            "\x1b[r\x1b[0m\x1b[?25h\x1b[2J\x1b[H\x1b[?1049l");
+
+    private static void WriteBanner(
+        KgpProtocolWriter writer,
+        int row,
+        string value,
+        int width)
+    {
+        var content = value.Length >= width
+            ? value[..width]
+            : value.PadRight(width);
+        writer.MoveTo(row, 1);
+        writer.Raw("\x1b[7m");
+        writer.Raw(content);
+        writer.Raw("\x1b[0m");
+    }
+
+    private static void WriteWrappedField(
+        KgpProtocolWriter writer,
+        int firstRow,
+        string label,
+        string value,
+        int width)
+    {
+        var prefix = $"{label}: ";
+        var lineWidth = Math.Max(1, width - 2);
+        var lines = Wrap(prefix + value, lineWidth, maximumLines: 2);
+        writer.TextAt(firstRow, 2, lines[0], lineWidth);
+        if (lines.Count > 1)
+            writer.TextAt(firstRow + 1, 2, lines[1], lineWidth);
+    }
+
+    private static IReadOnlyList<string> Wrap(
+        string value,
+        int width,
+        int maximumLines)
+    {
+        var words = value.Split(
+            ' ',
+            StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var lines = new List<string>(maximumLines);
+        var current = new StringBuilder();
+
+        foreach (var word in words)
+        {
+            if (current.Length > 0 && current.Length + 1 + word.Length > width)
+            {
+                lines.Add(current.ToString());
+                current.Clear();
+                if (lines.Count == maximumLines)
+                    break;
+            }
+
+            if (current.Length > 0)
+                current.Append(' ');
+            current.Append(word);
+        }
+
+        if (lines.Count < maximumLines && current.Length > 0)
+            lines.Add(current.ToString());
+        if (lines.Count == 0)
+            lines.Add(string.Empty);
+
+        var representedLength = lines.Sum(line => line.Length);
+        if (representedLength < value.Length - 1 && lines.Count == maximumLines)
+        {
+            var last = lines[^1];
+            lines[^1] = width <= 3
+                ? new string('.', width)
+                : last.Length <= 3
+                ? "..."
+                : last[..Math.Min(last.Length, width - 3)] + "...";
+        }
+
+        return lines;
+    }
+}

--- a/samples/KgpValidation/KgpValidationScenario.cs
+++ b/samples/KgpValidation/KgpValidationScenario.cs
@@ -1,0 +1,86 @@
+namespace KgpValidation;
+
+/// <summary>
+/// Describes one independently renderable KGP compliance page.
+/// </summary>
+/// <remarks>
+/// A scenario owns the smallest protocol recipe that demonstrates its feature.
+/// Keep scenarios deterministic and visually simple: future debugging should be
+/// able to compare the rendered page with <see cref="Expected"/> without reading
+/// unrelated sample code.
+/// </remarks>
+internal abstract class KgpValidationScenario
+{
+    /// <summary>Stable identifier used in diagnostics and tests.</summary>
+    public abstract string Id { get; }
+
+    /// <summary>Short page title.</summary>
+    public abstract string Title { get; }
+
+    /// <summary>The KGP compliance area exercised by this page.</summary>
+    public abstract string Area { get; }
+
+    /// <summary>Human-verifiable description of the correct final screen.</summary>
+    public abstract string Expected { get; }
+
+    /// <summary>Short summary of the protocol operations used by the page.</summary>
+    public abstract string Protocol { get; }
+
+    /// <summary>Expected Hex1b KGP state after the page has rendered.</summary>
+    public abstract KgpScenarioExpectation ExpectedState { get; }
+
+    /// <summary>Number of user-selectable variants on this page.</summary>
+    public virtual int VariantCount => 1;
+
+    /// <summary>Optional instruction shown above the navigation footer.</summary>
+    public virtual string? ActionHint => null;
+
+    /// <summary>Gets the expected result for a specific page variant.</summary>
+    public virtual string GetExpected(int variant)
+    {
+        if (variant != 0)
+            throw new ArgumentOutOfRangeException(nameof(variant));
+        return Expected;
+    }
+
+    /// <summary>Writes this scenario's text guides and KGP commands.</summary>
+    public abstract void Render(
+        KgpProtocolWriter writer,
+        KgpScenarioLayout layout);
+
+    /// <summary>Writes a selected variant of this scenario.</summary>
+    public virtual void RenderVariant(
+        KgpProtocolWriter writer,
+        KgpScenarioLayout layout,
+        int variant)
+    {
+        if (variant != 0)
+            throw new ArgumentOutOfRangeException(nameof(variant));
+        Render(writer, layout);
+    }
+}
+
+/// <summary>
+/// Machine-checkable state paired with a human-verifiable scenario.
+/// </summary>
+internal sealed record KgpScenarioExpectation(
+    int ImageCount,
+    int PlacementCount,
+    int VirtualPlacementCount = 0,
+    uint? FrameImageId = null,
+    int? FrameCount = null);
+
+/// <summary>
+/// Shared terminal geometry for every validation page.
+/// </summary>
+internal readonly record struct KgpScenarioLayout(int Width, int Height)
+{
+    public const int MinimumWidth = 80;
+    public const int MinimumHeight = 24;
+    public const int GraphicsTop = 9;
+
+    public bool HasGraphicsRoom =>
+        Width >= MinimumWidth && Height >= MinimumHeight;
+
+    public int GraphicsBottom => Height - 2;
+}

--- a/samples/KgpValidation/KgpValidationWorkload.cs
+++ b/samples/KgpValidation/KgpValidationWorkload.cs
@@ -1,0 +1,320 @@
+using System.Threading.Channels;
+using Hex1b;
+
+namespace KgpValidation;
+
+/// <summary>
+/// Raw workload that drives the validation pages without Hex1bApp or widgets.
+/// </summary>
+/// <remarks>
+/// Output is a channel of complete ANSI/KGP frames. Input is intentionally
+/// limited to a few printable navigation keys and common cursor-key sequences,
+/// keeping the harness independent of Hex1b's widget input router.
+/// </remarks>
+internal sealed class KgpValidationWorkload : IHex1bTerminalWorkloadAdapter
+{
+    private readonly object _gate = new();
+    private readonly Channel<ReadOnlyMemory<byte>> _output;
+    private readonly IReadOnlyList<KgpValidationScenario> _scenarios;
+    private int _scenarioIndex;
+    private int _scenarioVariant;
+    private int _width = 80;
+    private int _height = 24;
+    private bool _enteredAlternateScreen;
+    private bool _exitRequested;
+    private bool _disconnected;
+    private bool _disposed;
+
+    public KgpValidationWorkload()
+        : this(KgpScenarioCatalog.All)
+    {
+    }
+
+    public KgpValidationWorkload(
+        IReadOnlyList<KgpValidationScenario> scenarios)
+    {
+        ArgumentNullException.ThrowIfNull(scenarios);
+        if (scenarios.Count == 0)
+            throw new ArgumentException("At least one scenario is required.", nameof(scenarios));
+
+        _scenarios = scenarios;
+        _output = Channel.CreateUnbounded<ReadOnlyMemory<byte>>(
+            new UnboundedChannelOptions
+            {
+                SingleReader = true,
+                SingleWriter = false,
+            });
+    }
+
+    public int CurrentScenarioIndex
+    {
+        get
+        {
+            lock (_gate)
+                return _scenarioIndex;
+        }
+    }
+
+    public int ScenarioCount => _scenarios.Count;
+
+    public int CurrentScenarioVariant
+    {
+        get
+        {
+            lock (_gate)
+                return _scenarioVariant;
+        }
+    }
+
+    public event Action? Disconnected;
+
+    public async ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(
+        CancellationToken ct = default)
+    {
+        try
+        {
+            while (await _output.Reader.WaitToReadAsync(ct))
+            {
+                if (_output.Reader.TryRead(out var data))
+                    return data;
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            return ReadOnlyMemory<byte>.Empty;
+        }
+        catch (ChannelClosedException)
+        {
+            // Completion is handled below.
+        }
+
+        SignalDisconnected();
+        return ReadOnlyMemory<byte>.Empty;
+    }
+
+    public ValueTask WriteInputAsync(
+        ReadOnlyMemory<byte> data,
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        var request = ParseNavigation(data.Span);
+        if (request == NavigationRequest.None)
+            return ValueTask.CompletedTask;
+
+        lock (_gate)
+        {
+            if (_disposed || _exitRequested)
+                return ValueTask.CompletedTask;
+
+            switch (request)
+            {
+                case NavigationRequest.Next:
+                    SelectScenario((_scenarioIndex + 1) % _scenarios.Count);
+                    QueueCurrentFrame();
+                    break;
+                case NavigationRequest.Previous:
+                    SelectScenario(
+                        (_scenarioIndex - 1 + _scenarios.Count) % _scenarios.Count);
+                    QueueCurrentFrame();
+                    break;
+                case NavigationRequest.First:
+                    SelectScenario(0);
+                    QueueCurrentFrame();
+                    break;
+                case NavigationRequest.Last:
+                    SelectScenario(_scenarios.Count - 1);
+                    QueueCurrentFrame();
+                    break;
+                case NavigationRequest.ToggleVariant:
+                    var count = _scenarios[_scenarioIndex].VariantCount;
+                    if (count > 1)
+                    {
+                        _scenarioVariant = (_scenarioVariant + 1) % count;
+                        QueueCurrentFrame();
+                    }
+                    break;
+                case >= NavigationRequest.Jump1 and <= NavigationRequest.Jump9:
+                    var target = request - NavigationRequest.Jump1;
+                    if ((int)target < _scenarios.Count)
+                    {
+                        SelectScenario((int)target);
+                        QueueCurrentFrame();
+                    }
+                    break;
+                case NavigationRequest.Exit:
+                    RequestExitLocked();
+                    break;
+            }
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask ResizeAsync(
+        int width,
+        int height,
+        CancellationToken ct = default)
+    {
+        ct.ThrowIfCancellationRequested();
+        lock (_gate)
+        {
+            if (_disposed || _exitRequested)
+                return ValueTask.CompletedTask;
+
+            _width = Math.Max(1, width);
+            _height = Math.Max(1, height);
+            QueueCurrentFrame();
+        }
+        return ValueTask.CompletedTask;
+    }
+
+    public void RequestExit()
+    {
+        lock (_gate)
+            RequestExitLocked();
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        lock (_gate)
+        {
+            if (_disposed)
+                return ValueTask.CompletedTask;
+
+            _disposed = true;
+            _output.Writer.TryComplete();
+        }
+        SignalDisconnected();
+        return ValueTask.CompletedTask;
+    }
+
+    private void QueueCurrentFrame()
+    {
+        var frame = KgpValidationFrameRenderer.Render(
+            _scenarios[_scenarioIndex],
+            _scenarioIndex,
+            _scenarios.Count,
+            _width,
+            _height,
+            enterAlternateScreen: !_enteredAlternateScreen,
+            variant: _scenarioVariant);
+        _enteredAlternateScreen = true;
+        _output.Writer.TryWrite(frame);
+    }
+
+    private void SelectScenario(int scenarioIndex)
+    {
+        _scenarioIndex = scenarioIndex;
+        _scenarioVariant = 0;
+    }
+
+    private void RequestExitLocked()
+    {
+        if (_exitRequested || _disposed)
+            return;
+
+        _exitRequested = true;
+        _output.Writer.TryWrite(KgpValidationFrameRenderer.Cleanup());
+        _output.Writer.TryComplete();
+    }
+
+    private void SignalDisconnected()
+    {
+        Action? disconnected;
+        lock (_gate)
+        {
+            if (_disconnected)
+                return;
+            _disconnected = true;
+            disconnected = Disconnected;
+        }
+        disconnected?.Invoke();
+    }
+
+    private static NavigationRequest ParseNavigation(ReadOnlySpan<byte> data)
+    {
+        if (data.SequenceEqual("\x1b[C"u8) ||
+            data.SequenceEqual("\x1bOC"u8) ||
+            data.SequenceEqual("\x1b[6~"u8))
+        {
+            return NavigationRequest.Next;
+        }
+
+        if (data.SequenceEqual("\x1b[D"u8) ||
+            data.SequenceEqual("\x1bOD"u8) ||
+            data.SequenceEqual("\x1b[5~"u8))
+        {
+            return NavigationRequest.Previous;
+        }
+
+        if (data.SequenceEqual("\x1b[H"u8) ||
+            data.SequenceEqual("\x1bOH"u8) ||
+            data.SequenceEqual("\x1b[1~"u8) ||
+            data.SequenceEqual("\x1b[7~"u8))
+        {
+            return NavigationRequest.First;
+        }
+
+        if (data.SequenceEqual("\x1b[F"u8) ||
+            data.SequenceEqual("\x1bOF"u8) ||
+            data.SequenceEqual("\x1b[4~"u8) ||
+            data.SequenceEqual("\x1b[8~"u8))
+        {
+            return NavigationRequest.Last;
+        }
+
+        if (!data.IsEmpty && data[0] == 0x1B)
+        {
+            return data.Length == 1
+                ? NavigationRequest.Exit
+                : NavigationRequest.None;
+        }
+
+        foreach (var value in data)
+        {
+            switch (value)
+            {
+                case (byte)'n':
+                case (byte)'N':
+                case (byte)' ':
+                case (byte)'\r':
+                    return NavigationRequest.Next;
+                case (byte)'p':
+                case (byte)'P':
+                case 0x7F:
+                    return NavigationRequest.Previous;
+                case (byte)'r':
+                case (byte)'R':
+                    return NavigationRequest.ToggleVariant;
+                case (byte)'q':
+                case (byte)'Q':
+                case 0x03:
+                    return NavigationRequest.Exit;
+                case >= (byte)'1' and <= (byte)'9':
+                    return NavigationRequest.Jump1 + (value - (byte)'1');
+            }
+        }
+
+        return NavigationRequest.None;
+    }
+
+    private enum NavigationRequest
+    {
+        None,
+        Next,
+        Previous,
+        First,
+        Last,
+        ToggleVariant,
+        Jump1,
+        Jump2,
+        Jump3,
+        Jump4,
+        Jump5,
+        Jump6,
+        Jump7,
+        Jump8,
+        Jump9,
+        Exit,
+    }
+}

--- a/samples/KgpValidation/Program.cs
+++ b/samples/KgpValidation/Program.cs
@@ -1,0 +1,17 @@
+using Hex1b;
+using KgpValidation;
+
+await using var workload = new KgpValidationWorkload();
+await using var terminal = Hex1bTerminal.CreateBuilder()
+    .WithWorkload(workload)
+    .WithDiagnostics("KgpValidation", forceEnable: true)
+    .Build();
+
+try
+{
+    return await terminal.RunAsync();
+}
+catch (OperationCanceledException)
+{
+    return 0;
+}

--- a/samples/KgpValidation/README.md
+++ b/samples/KgpValidation/README.md
@@ -1,0 +1,105 @@
+# KGP validation
+
+`KgpValidation` is a human-verifiable Kitty Graphics Protocol (KGP) compliance
+harness for `Hex1bTerminal`.
+
+It intentionally does **not** use `Hex1bApp`, widgets, nodes, or layout. A custom
+`IHex1bTerminalWorkloadAdapter` writes raw ANSI and KGP byte streams into
+`Hex1bTerminal`, then accepts a small set of navigation keys from the terminal's
+normal input path.
+
+## Run
+
+Use a terminal with KGP support, such as Kitty, Ghostty, or a compatible xterm.js
+addon:
+
+```bash
+dotnet run --project samples/KgpValidation
+```
+
+The text shell remains useful in a terminal without KGP support, but the graphic
+expectations cannot be verified there. Resize the terminal to at least `80x24`.
+
+## Navigation
+
+| Key | Action |
+| --- | --- |
+| `N`, `Space`, `Right`, `PageDown`, `Enter` | Next scenario |
+| `P`, `Left`, `PageUp`, `Backspace` | Previous scenario |
+| `1`-`9` | Jump to one of the first nine scenarios |
+| `Home` / `End` | First / last scenario |
+| `R` | Toggle the current scenario's interactive state, when offered |
+| `Q`, `Esc`, `Ctrl+C` | Exit |
+
+Each page states:
+
+- the compliance area under test;
+- the exact final result that should be visible;
+- the relevant KGP actions and control keys; and
+- a deliberately small graphic recipe.
+
+## Scenarios
+
+| Page | Compliance area | Visual check |
+| --- | --- | --- |
+| Compliance overview | Current scope and known limits | Text-only implementation summary |
+| Direct and chunked transfer | Direct RGB/RGBA and `m=1/0` continuations | Gradient plus complete RGB bars |
+| Shared data and named replacement | Reused image bytes and `(i,p)` replacement | Three targets, one moved cyan block, no red ghost |
+| Source rectangles and display geometry | `x/y/w/h` crop and `c/r` sizing | Full quadrant reference plus four solid crops |
+| Z-order and text occlusion | Negative/positive `z` | Text above blue; orange above dotted cells |
+| Scrolling and placement anchors | Scroll margins and `CSI S` | Press `R` to watch image and marker move together |
+| Unicode placeholder placement | `U=1` and U+10EEEE cells | One continuous image over a 6x3 placeholder grid |
+| Relative placement graph | `P/Q/H/V` and root replacement | Parent and descendants move as one graph |
+| Animation frame storage | Frame append/edit/delete | Cyan edited root with one frame remaining |
+| Deletion and image lifetime | `d=i/I` and reference-aware reclamation | Only the reused right placement remains |
+
+The animation page is intentionally explicit about the current boundary:
+animation frame storage/edit/delete is implemented, while playback control and
+frame composition are still typed no-ops.
+
+## Structure
+
+| File | Responsibility |
+| --- | --- |
+| `KgpValidationWorkload.cs` | Raw workload lifecycle, resize handling, and navigation |
+| `KgpValidationFrameRenderer.cs` | Shared explanatory header/footer and page isolation |
+| `KgpProtocolWriter.cs` | ANSI cursor movement and APC/KGP framing |
+| `KgpImageFactory.cs` | Dependency-free deterministic RGB/RGBA fixtures |
+| `KgpValidationScenario.cs` | Scenario contract and expected machine state |
+| `KgpScenarioCatalog.cs` | Stable scenario ordering |
+| `Scenarios/*.cs` | One documented protocol recipe per compliance area |
+
+Every rendered page starts by deleting active KGP data and clearing the screen.
+This makes each scenario independent: stale state from one page cannot make the
+next page appear to pass.
+
+The same recipes are also parsed by headless tests. Image identity, placement
+geometry, z-order, source rectangles, virtual-placement counts, and frame counts
+are machine-checked; final compositing remains a human visual check.
+
+## Debugging a failure
+
+1. Read the page's **Expected** and **Protocol** lines.
+2. Open the matching class in `Scenarios/`; the exact KGP control strings are at
+   the call site.
+3. Compare the final image IDs and placement counts with that scenario's
+   `ExpectedState`.
+4. Run the focused headless tests:
+
+   ```bash
+   dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj \
+     --filter FullyQualifiedName~KgpValidationSampleTests
+   ```
+
+5. If the headless state passes but the terminal is visually wrong, capture the
+   workload stream with `WithWorkloadLogging` or use the enabled
+   `KgpValidation` diagnostics socket to separate Hex1b state from presentation
+   renderer behavior.
+
+All KGP commands use `q=2`, so terminals intentionally suppress both success and
+error replies. A missing image will not print an inline protocol error; use the
+headless tests, workload logging, or diagnostics socket to inspect that failure.
+
+Keep new scenarios small. Add one class, document one expected final screen, and
+pair it with a `KgpScenarioExpectation` so human and automated checks describe
+the same contract.

--- a/samples/KgpValidation/Scenarios/AnimationFrameScenario.cs
+++ b/samples/KgpValidation/Scenarios/AnimationFrameScenario.cs
@@ -1,0 +1,46 @@
+namespace KgpValidation.Scenarios;
+
+/// <summary>
+/// Exercises implemented animation frame storage without claiming playback or
+/// composition support.
+/// </summary>
+/// <remarks>
+/// The root frame is edited from red to cyan, a yellow second frame is appended,
+/// and frame two is deleted. The final image is therefore cyan with one stored
+/// frame. Playback-control and compose actions remain documented typed no-ops.
+/// </remarks>
+internal sealed class AnimationFrameScenario : KgpValidationScenario
+{
+    private const uint ImageId = 8201;
+
+    public override string Id => "animation-frames";
+    public override string Title => "Animation frame storage";
+    public override string Area => "a=f append/edit and d=f frame deletion";
+    public override string Expected =>
+        "One cyan image. The red root was edited, a yellow frame was appended then deleted, leaving one frame.";
+    public override string Protocol =>
+        "a=T base; a=f,r=1 overwrites root; a=f appends frame 2; d=f,r=2 removes it. Playback is not claimed.";
+    public override KgpScenarioExpectation ExpectedState { get; } =
+        new(1, 1, FrameImageId: ImageId, FrameCount: 1);
+
+    public override void Render(
+        KgpProtocolWriter writer,
+        KgpScenarioLayout layout)
+    {
+        writer.TextAt(
+            9,
+            8,
+            "FINAL ROOT: CYAN    FRAME COUNT (HEADLESS CHECK): 1    PLAYBACK/COMPOSE: NOT IMPLEMENTED");
+        writer.MoveTo(12, 10);
+        writer.Kgp(
+            $"a=T,f=32,s=48,v=48,i={ImageId},p=1,c=16,r=8,C=1,q=2",
+            KgpImageFactory.CreateRgbaSolid(48, 48, 220, 45, 45));
+        writer.Kgp(
+            $"a=f,f=32,s=48,v=48,i={ImageId},r=1,X=1,z=200,q=2",
+            KgpImageFactory.CreateRgbaSolid(48, 48, 20, 205, 220));
+        writer.Kgp(
+            $"a=f,f=32,s=48,v=48,i={ImageId},X=1,z=200,q=2",
+            KgpImageFactory.CreateRgbaSolid(48, 48, 245, 210, 30));
+        writer.Kgp($"a=d,d=f,i={ImageId},r=2,q=2");
+    }
+}

--- a/samples/KgpValidation/Scenarios/DeletionReuseScenario.cs
+++ b/samples/KgpValidation/Scenarios/DeletionReuseScenario.cs
@@ -1,0 +1,53 @@
+namespace KgpValidation.Scenarios;
+
+/// <summary>
+/// Demonstrates placement-targeted deletion and reference-aware image lifetime.
+/// </summary>
+/// <remarks>
+/// Lowercase deletion removes the left placement but retains reusable data. A
+/// new right placement is then created without retransmission. Uppercase
+/// deletion removes the middle placement but cannot reclaim the bytes while the
+/// right placement still references them.
+/// </remarks>
+internal sealed class DeletionReuseScenario : KgpValidationScenario
+{
+    private const uint ImageId = 9201;
+
+    public override string Id => "deletion-reuse";
+    public override string Title => "Deletion and image lifetime";
+    public override string Area => "d=i/I placement selectors and reference-aware reclamation";
+    public override string Expected =>
+        "Only the right bullseye remains. LEFT and MIDDLE are empty, and RIGHT proves the stored data stayed reusable.";
+    public override string Protocol =>
+        "Create p=1/2; delete p=1 lowercase; reuse bytes as p=3; delete p=2 uppercase while p=3 still owns data.";
+    public override KgpScenarioExpectation ExpectedState { get; } = new(1, 1);
+
+    public override void Render(
+        KgpProtocolWriter writer,
+        KgpScenarioLayout layout)
+    {
+        writer.Kgp(
+            $"a=t,f=32,s=48,v=48,i={ImageId},q=2",
+            KgpImageFactory.CreateRgbaBullseye(48, 48));
+
+        Put(writer, placementId: 1, column: 8);
+        Put(writer, placementId: 2, column: 34);
+        writer.Kgp($"a=d,d=i,i={ImageId},p=1,q=2");
+        Put(writer, placementId: 3, column: 60);
+        writer.Kgp($"a=d,d=I,i={ImageId},p=2,q=2");
+
+        writer.TextAt(9, 8, "LEFT: empty");
+        writer.TextAt(9, 34, "MIDDLE: empty");
+        writer.TextAt(9, 60, "RIGHT: reused data");
+    }
+
+    private static void Put(
+        KgpProtocolWriter writer,
+        uint placementId,
+        int column)
+    {
+        writer.MoveTo(12, column);
+        writer.Kgp(
+            $"a=p,i={ImageId},p={placementId},c=12,r=7,C=1,q=2");
+    }
+}

--- a/samples/KgpValidation/Scenarios/DirectAndChunkedScenario.cs
+++ b/samples/KgpValidation/Scenarios/DirectAndChunkedScenario.cs
@@ -1,0 +1,50 @@
+using Hex1b;
+
+namespace KgpValidation.Scenarios;
+
+/// <summary>
+/// Proves direct RGBA and multi-command chunked RGB uploads side by side.
+/// </summary>
+/// <remarks>
+/// The chunk size is divisible by three so every non-final Base64 payload has a
+/// valid boundary. A partial image on the right usually indicates upload-state
+/// or continuation-control regression.
+/// </remarks>
+internal sealed class DirectAndChunkedScenario : KgpValidationScenario
+{
+    private const uint DirectImageId = 1201;
+    private const uint ChunkedImageId = 1202;
+
+    public override string Id => "direct-chunked";
+    public override string Title => "Direct and chunked transfer";
+    public override string Area => "a=T, a=t, f=24/32 and m=1/0 upload state";
+    public override string Expected =>
+        "Two clean images: a smooth RGBA gradient on the left and six sharp RGB color bars on the right.";
+    public override string Protocol =>
+        "Left is one direct transmit+display command; right is a 3072-byte chunk stream followed by a=p.";
+    public override KgpScenarioExpectation ExpectedState { get; } = new(2, 2);
+
+    public override void Render(
+        KgpProtocolWriter writer,
+        KgpScenarioLayout layout)
+    {
+        const int top = KgpScenarioLayout.GraphicsTop + 2;
+
+        writer.TextAt(9, 4, "DIRECT RGBA");
+        writer.MoveTo(top, 4);
+        writer.Kgp(
+            $"a=T,f=32,s=64,v=48,i={DirectImageId},p=1,c=16,r=9,C=1,q=2",
+            KgpImageFactory.CreateRgbaGradient(64, 48));
+
+        writer.TextAt(9, 43, "CHUNKED RGB (multiple m=1, final m=0)");
+        writer.ChunkedTransmit(
+            ChunkedImageId,
+            width: 96,
+            height: 54,
+            KgpFormat.Rgb24,
+            KgpImageFactory.CreateRgbBars(96, 54));
+        writer.MoveTo(top, 43);
+        writer.Kgp(
+            $"a=p,i={ChunkedImageId},p=1,c=24,r=9,C=1,q=2");
+    }
+}

--- a/samples/KgpValidation/Scenarios/OverviewScenario.cs
+++ b/samples/KgpValidation/Scenarios/OverviewScenario.cs
@@ -1,0 +1,44 @@
+namespace KgpValidation.Scenarios;
+
+/// <summary>
+/// Documents the current validation scope before any graphics are emitted.
+/// </summary>
+internal sealed class OverviewScenario : KgpValidationScenario
+{
+    public override string Id => "overview";
+    public override string Title => "Compliance overview";
+    public override string Area => "Harness scope and known limits";
+    public override string Expected =>
+        "This page is text-only. Read the supported areas, then press N or Space to begin the visual checks.";
+    public override string Protocol =>
+        "No KGP payload on this page; subsequent pages emit raw APC graphics commands through Hex1bTerminal.";
+    public override KgpScenarioExpectation ExpectedState { get; } = new(0, 0);
+
+    public override void Render(
+        KgpProtocolWriter writer,
+        KgpScenarioLayout layout)
+    {
+        string[] lines =
+        [
+            "[IMPLEMENTED] Direct RGB/RGBA transmission and chunked uploads",
+            "[IMPLEMENTED] Image identity, replacement, reuse, crop, offsets and z-order",
+            "[IMPLEMENTED] Scrolling/history anchors and per-screen graphics ownership",
+            "[IMPLEMENTED] Unicode placeholders and relative placement graphs",
+            "[IMPLEMENTED] Animation frame upload/edit/delete storage",
+            "[IMPLEMENTED] Placement deletion selectors and reference-aware reclamation",
+            "[PARTIAL]     Animation playback control and frame composition are typed no-ops",
+            "",
+            "Each following page describes one final image that can be checked by eye.",
+            "Headless tests verify identity, geometry, z-order, crops, virtual state and frames.",
+        ];
+
+        for (var index = 0; index < lines.Length; index++)
+        {
+            writer.TextAt(
+                KgpScenarioLayout.GraphicsTop + index,
+                4,
+                lines[index],
+                Math.Max(1, layout.Width - 6));
+        }
+    }
+}

--- a/samples/KgpValidation/Scenarios/RelativePlacementScenario.cs
+++ b/samples/KgpValidation/Scenarios/RelativePlacementScenario.cs
@@ -1,0 +1,63 @@
+namespace KgpValidation.Scenarios;
+
+/// <summary>
+/// Builds a parent/child/grandchild graph, then replaces the root placement at
+/// a new origin.
+/// </summary>
+/// <remarks>
+/// Children use signed H/V offsets and are never independently repositioned.
+/// They must follow the parent replacement as one graph, leaving the original
+/// lower-right origin empty.
+/// </remarks>
+internal sealed class RelativePlacementScenario : KgpValidationScenario
+{
+    private const uint ParentImageId = 7201;
+    private const uint ChildImageId = 7202;
+    private const uint GrandchildImageId = 7203;
+
+    public override string Id => "relative-placement";
+    public override string Title => "Relative placement graph";
+    public override string Area => "P/Q parent identity, signed H/V offsets and graph replacement";
+    public override string Expected =>
+        "A blue parent at FINAL with orange and green descendants offset from it; OLD ORIGIN contains no graphics.";
+    public override string Protocol =>
+        "Three stored images form a two-link relative graph; replacing the root (i,p) moves the graph as one unit.";
+    public override KgpScenarioExpectation ExpectedState { get; } = new(3, 3);
+
+    public override void Render(
+        KgpProtocolWriter writer,
+        KgpScenarioLayout layout)
+    {
+        Transmit(writer, ParentImageId, 35, 100, 220);
+        Transmit(writer, ChildImageId, 245, 135, 25);
+        Transmit(writer, GrandchildImageId, 40, 210, 95);
+
+        writer.MoveTo(16, 52);
+        writer.Kgp(
+            $"a=p,i={ParentImageId},p=1,c=14,r=6,C=1,q=2");
+        writer.Kgp(
+            $"a=p,i={ChildImageId},p=2,c=7,r=3,P={ParentImageId},Q=1,H=10,V=4,C=1,q=2");
+        writer.Kgp(
+            $"a=p,i={GrandchildImageId},p=3,c=4,r=2,P={ChildImageId},Q=2,H=-2,V=-2,C=1,q=2");
+
+        // Replacing only the root is the behavior under test.
+        writer.MoveTo(11, 8);
+        writer.Kgp(
+            $"a=p,i={ParentImageId},p=1,c=14,r=6,C=1,q=2");
+
+        writer.TextAt(9, 8, "FINAL ORIGIN");
+        writer.TextAt(16, 52, "OLD ORIGIN - MUST BE CLEAR");
+    }
+
+    private static void Transmit(
+        KgpProtocolWriter writer,
+        uint imageId,
+        byte red,
+        byte green,
+        byte blue)
+    {
+        writer.Kgp(
+            $"a=t,f=32,s=32,v=32,i={imageId},q=2",
+            KgpImageFactory.CreateRgbaSolid(32, 32, red, green, blue));
+    }
+}

--- a/samples/KgpValidation/Scenarios/ScrollingScenario.cs
+++ b/samples/KgpValidation/Scenarios/ScrollingScenario.cs
@@ -1,0 +1,79 @@
+namespace KgpValidation.Scenarios;
+
+/// <summary>
+/// Scrolls a text marker and ordinary image placement together inside margins.
+/// </summary>
+/// <remarks>
+/// The final page is intentionally static: the protocol first creates the old
+/// position and then scrolls three rows. A ghost at the lower position reveals
+/// a placement-anchor or history-pruning regression.
+/// </remarks>
+internal sealed class ScrollingScenario : KgpValidationScenario
+{
+    private const uint ImageId = 5201;
+
+    public override string Id => "scrolling";
+    public override string Title => "Scrolling and placement anchors";
+    public override string Area => "DECSTBM/CSI S geometry and history-aware placement movement";
+    public override string Expected =>
+        "Press R: the marker and checker move six rows upward together from OLD/BEFORE to EXPECTED AFTER.";
+    public override string Protocol =>
+        "An ordinary placement is created inside a scroll region, then CSI S runs six times before margins reset.";
+    public override KgpScenarioExpectation ExpectedState { get; } = new(1, 1);
+    public override int VariantCount => 2;
+    public override string ActionHint =>
+        "R toggles BEFORE / AFTER. Watch the ANCHOR text and checker move together.";
+
+    public override string GetExpected(int variant)
+        => variant switch
+        {
+            0 => "BEFORE: marker and checker align with OLD/BEFORE. Press R to apply six real scroll operations.",
+            1 => "AFTER: both align with EXPECTED AFTER. If only text moved, the presentation renderer failed.",
+            _ => throw new ArgumentOutOfRangeException(nameof(variant)),
+        };
+
+    public override void Render(
+        KgpProtocolWriter writer,
+        KgpScenarioLayout layout)
+        => RenderVariant(writer, layout, variant: 0);
+
+    public override void RenderVariant(
+        KgpProtocolWriter writer,
+        KgpScenarioLayout layout,
+        int variant)
+    {
+        if (variant is < 0 or > 1)
+            throw new ArgumentOutOfRangeException(nameof(variant));
+
+        var scrollBottom = layout.GraphicsBottom;
+        writer.TextAt(
+            9,
+            4,
+            variant == 0
+                ? "STATE: BEFORE SCROLL - press R"
+                : "STATE: AFTER SIX SCROLLS - press R to reset");
+        writer.Raw($"\x1b[10;{scrollBottom}r");
+        writer.TextAt(18, 9, "ANCHOR: this line moves with the image");
+        writer.MoveTo(19, 9);
+        writer.Kgp(
+            $"a=T,f=32,s=48,v=32,i={ImageId},p=1,c=12,r=4,C=1,q=2",
+            KgpImageFactory.CreateRgbaChecker(48, 32));
+        if (variant == 1)
+            writer.Raw("\x1b[S\x1b[S\x1b[S\x1b[S\x1b[S\x1b[S");
+        writer.Raw("\x1b[r");
+        writer.TextAt(13, 26, "< EXPECTED AFTER image top");
+        writer.TextAt(
+            19,
+            26,
+            variant == 0
+                ? "< OLD/BEFORE image top"
+                : "< OLD/BEFORE must now be empty");
+        if (variant == 1)
+        {
+            writer.TextAt(
+                21,
+                26,
+                "Text moved but image stayed? Presentation renderer: FAIL");
+        }
+    }
+}

--- a/samples/KgpValidation/Scenarios/SharedAndReplacementScenario.cs
+++ b/samples/KgpValidation/Scenarios/SharedAndReplacementScenario.cs
@@ -1,0 +1,66 @@
+namespace KgpValidation.Scenarios;
+
+/// <summary>
+/// Exercises one stored payload with multiple placements and atomic named
+/// replacement of a second image/placement identity.
+/// </summary>
+/// <remarks>
+/// The red replacement seed is intentionally placed at a different location
+/// before the cyan retransmission. Any red image left behind is a stale
+/// placement or renderer-index bug.
+/// </remarks>
+internal sealed class SharedAndReplacementScenario : KgpValidationScenario
+{
+    private const uint SharedImageId = 2201;
+    private const uint ReplacementImageId = 2202;
+
+    public override string Id => "shared-replacement";
+    public override string Title => "Shared data and named replacement";
+    public override string Area => "Stored image reuse, placement IDs and atomic replacement";
+    public override string Expected =>
+        "Three identical bullseyes at different sizes plus one cyan block at NEW; the OLD red slot is empty.";
+    public override string Protocol =>
+        "a=t once plus three a=p placements; same (i,p) is then retransmitted with new bytes and geometry.";
+    public override KgpScenarioExpectation ExpectedState { get; } = new(2, 4);
+
+    public override void Render(
+        KgpProtocolWriter writer,
+        KgpScenarioLayout layout)
+    {
+        writer.TextAt(9, 4, "ONE PAYLOAD -> THREE PLACEMENTS");
+        var target = KgpImageFactory.CreateRgbaBullseye(48, 48);
+        writer.Kgp(
+            $"a=t,f=32,s=48,v=48,i={SharedImageId},q=2",
+            target);
+
+        Put(writer, SharedImageId, placementId: 1, row: 11, column: 4, columns: 10, rows: 6);
+        Put(writer, SharedImageId, placementId: 2, row: 11, column: 20, columns: 8, rows: 5);
+        Put(writer, SharedImageId, placementId: 3, row: 11, column: 34, columns: 12, rows: 7);
+
+        writer.TextAt(9, 58, "OLD (must be empty)");
+        writer.MoveTo(11, 58);
+        writer.Kgp(
+            $"a=T,f=32,s=32,v=32,i={ReplacementImageId},p=7,c=10,r=5,C=1,q=2",
+            KgpImageFactory.CreateRgbaSolid(32, 32, 220, 45, 45));
+
+        writer.TextAt(17, 58, "NEW");
+        writer.MoveTo(18, 58);
+        writer.Kgp(
+            $"a=T,f=32,s=32,v=32,i={ReplacementImageId},p=7,c=10,r=4,C=1,q=2",
+            KgpImageFactory.CreateRgbaSolid(32, 32, 20, 210, 225));
+    }
+
+    private static void Put(
+        KgpProtocolWriter writer,
+        uint imageId,
+        uint placementId,
+        int row,
+        int column,
+        int columns,
+        int rows)
+    {
+        writer.MoveTo(row, column);
+        writer.Kgp(
+            $"a=p,i={imageId},p={placementId},c={columns},r={rows},C=1,q=2");
+    }
+}

--- a/samples/KgpValidation/Scenarios/SourceCropScenario.cs
+++ b/samples/KgpValidation/Scenarios/SourceCropScenario.cs
@@ -1,0 +1,54 @@
+namespace KgpValidation.Scenarios;
+
+/// <summary>
+/// Displays one quadrant source image and four independently cropped views.
+/// </summary>
+internal sealed class SourceCropScenario : KgpValidationScenario
+{
+    private const uint ImageId = 3201;
+
+    public override string Id => "source-crop";
+    public override string Title => "Source rectangles and display geometry";
+    public override string Area => "x/y/w/h source crop with c/r destination sizing";
+    public override string Expected =>
+        "A four-color reference on the left; four solid crops on the right ordered red, green, blue, yellow.";
+    public override string Protocol =>
+        "One a=t payload is reused by five a=p commands with explicit source rectangles and destination cells.";
+    public override KgpScenarioExpectation ExpectedState { get; } = new(1, 5);
+
+    public override void Render(
+        KgpProtocolWriter writer,
+        KgpScenarioLayout layout)
+    {
+        writer.Kgp(
+            $"a=t,f=32,s=80,v=60,i={ImageId},q=2",
+            KgpImageFactory.CreateRgbaQuadrants(80, 60));
+
+        writer.TextAt(9, 3, "FULL REFERENCE");
+        writer.MoveTo(11, 3);
+        writer.Kgp(
+            $"a=p,i={ImageId},p=1,c=16,r=8,C=1,q=2");
+
+        writer.TextAt(9, 28, "CROPS: RED / GREEN, BLUE / YELLOW");
+        Put(writer, 2, 11, 28, 8, 4, sourceX: 0, sourceY: 0);
+        Put(writer, 3, 11, 40, 8, 4, sourceX: 40, sourceY: 0);
+        Put(writer, 4, 17, 28, 8, 4, sourceX: 0, sourceY: 30);
+        Put(writer, 5, 17, 40, 8, 4, sourceX: 40, sourceY: 30);
+    }
+
+    private static void Put(
+        KgpProtocolWriter writer,
+        uint placementId,
+        int row,
+        int column,
+        int columns,
+        int rows,
+        int sourceX = 0,
+        int sourceY = 0)
+    {
+        writer.MoveTo(row, column);
+        writer.Kgp(
+            $"a=p,i={ImageId},p={placementId},x={sourceX},y={sourceY}," +
+            $"w=40,h=30,c={columns},r={rows},C=1,q=2");
+    }
+}

--- a/samples/KgpValidation/Scenarios/UnicodePlaceholderScenario.cs
+++ b/samples/KgpValidation/Scenarios/UnicodePlaceholderScenario.cs
@@ -1,0 +1,70 @@
+using System.Text;
+
+namespace KgpValidation.Scenarios;
+
+/// <summary>
+/// Realizes one virtual placement from a grid of official Unicode placeholder
+/// graphemes.
+/// </summary>
+/// <remarks>
+/// Foreground RGB encodes the image ID, underline RGB encodes the placement ID,
+/// and the first two combining marks encode source row/column. Only the first
+/// six official diacritics are needed for this 6x3 sample.
+/// </remarks>
+internal sealed class UnicodePlaceholderScenario : KgpValidationScenario
+{
+    private const uint ImageId = 6201;
+    private const uint PlacementId = 7;
+    private const int PlaceholderCodePoint = 0x10EEEE;
+
+    private static readonly int[] Diacritics =
+    [
+        0x0305,
+        0x030D,
+        0x030E,
+        0x0310,
+        0x0312,
+        0x033D,
+    ];
+
+    public override string Id => "unicode-placeholder";
+    public override string Title => "Unicode placeholder placement";
+    public override string Area => "U=1 virtual prototypes and U+10EEEE cell realization";
+    public override string Expected =>
+        "One continuous 6x3 gradient exactly covers the placeholder grid; no replacement glyphs or gaps are visible.";
+    public override string Protocol =>
+        "a=T,U=1 creates a prototype; colored U+10EEEE graphemes select image, placement, row and column.";
+    public override KgpScenarioExpectation ExpectedState { get; } =
+        new(1, 3, VirtualPlacementCount: 1);
+
+    public override void Render(
+        KgpProtocolWriter writer,
+        KgpScenarioLayout layout)
+    {
+        writer.TextAt(9, 8, "The image below is positioned by Unicode cells, not an ordinary a=p placement.");
+        writer.Kgp(
+            $"a=T,U=1,f=32,s=60,v=60,i={ImageId},p={PlacementId},c=6,r=3,q=2",
+            KgpImageFactory.CreateRgbaGradient(60, 60));
+
+        var foreground = TrueColorSgr(38, ImageId);
+        var underline = TrueColorSgr(58, PlacementId);
+        for (var row = 0; row < 3; row++)
+        {
+            writer.MoveTo(12 + row, 12);
+            writer.Raw(foreground);
+            writer.Raw(underline);
+            for (var column = 0; column < 6; column++)
+                writer.Raw(Placeholder(row, column));
+            writer.Raw("\x1b[0m");
+        }
+    }
+
+    private static string TrueColorSgr(int selector, uint value)
+        => $"\x1b[{selector};2;{(value >> 16) & 0xFF};" +
+           $"{(value >> 8) & 0xFF};{value & 0xFF}m";
+
+    private static string Placeholder(int row, int column)
+        => new Rune(PlaceholderCodePoint).ToString() +
+           new Rune(Diacritics[row]).ToString() +
+           new Rune(Diacritics[column]).ToString();
+}

--- a/samples/KgpValidation/Scenarios/ZOrderScenario.cs
+++ b/samples/KgpValidation/Scenarios/ZOrderScenario.cs
@@ -1,0 +1,36 @@
+namespace KgpValidation.Scenarios;
+
+/// <summary>
+/// Makes negative and positive z-index behavior visible against ordinary text.
+/// </summary>
+internal sealed class ZOrderScenario : KgpValidationScenario
+{
+    public override string Id => "z-order";
+    public override string Title => "Z-order and text occlusion";
+    public override string Area => "Negative and positive z-index compositing";
+    public override string Expected =>
+        "Text remains readable over the large blue backplate; the smaller orange foreground covers the dotted guide.";
+    public override string Protocol =>
+        "Two a=T placements use z=-2 and z=2 around ordinary terminal cells.";
+    public override KgpScenarioExpectation ExpectedState { get; } = new(2, 2);
+
+    public override void Render(
+        KgpProtocolWriter writer,
+        KgpScenarioLayout layout)
+    {
+        writer.TextAt(9, 5, "NEGATIVE Z BACKPLATE");
+        writer.MoveTo(11, 6);
+        writer.Kgp(
+            "a=T,f=32,s=48,v=32,i=4201,p=1,c=42,r=8,z=-2,C=1,q=2",
+            KgpImageFactory.CreateRgbaSolid(48, 32, 30, 90, 210));
+        writer.TextAt(13, 10, "THIS TEXT MUST STAY ABOVE THE BLUE IMAGE");
+        writer.TextAt(15, 10, "negative z-index -> graphics behind cells");
+
+        writer.TextAt(18, 10, "positive z-index ->");
+        writer.TextAt(19, 10, "........................................");
+        writer.MoveTo(17, 31);
+        writer.Kgp(
+            "a=T,f=32,s=32,v=32,i=4202,p=1,c=14,r=6,z=2,C=1,q=2",
+            KgpImageFactory.CreateRgbaSolid(32, 32, 245, 135, 30));
+    }
+}

--- a/tests/Hex1b.Tests/Hex1b.Tests.csproj
+++ b/tests/Hex1b.Tests/Hex1b.Tests.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Hex1b\Hex1b.csproj" />
+    <ProjectReference Include="..\..\samples\KgpValidation\KgpValidation.csproj" />
   </ItemGroup>
 
   <Target Name="CopyNativeLibraryLinux" AfterTargets="Build" Condition="$([MSBuild]::IsOSPlatform('Linux')) and Exists('../../src/Hex1b/Terminal/runtimes/linux-x64/native/libhex1binterop.so')">

--- a/tests/Hex1b.Tests/KgpValidationSampleTests.cs
+++ b/tests/Hex1b.Tests/KgpValidationSampleTests.cs
@@ -1,0 +1,409 @@
+using System.Text;
+using Hex1b.Tokens;
+using KgpValidation;
+
+namespace Hex1b.Tests;
+
+[TestClass]
+public class KgpValidationSampleTests
+{
+    private static readonly TerminalCapabilities KgpCapabilities = new()
+    {
+        SupportsKgp = true,
+        SupportsTrueColor = true,
+        Supports256Colors = true,
+        CellPixelWidth = 10,
+        CellPixelHeight = 20,
+    };
+
+    [TestMethod]
+    public void ScenarioCatalog_AllScenarios_HaveStableDocumentedMetadata()
+    {
+        var scenarios = KgpScenarioCatalog.All;
+
+        Assert.HasCount(10, scenarios);
+        Assert.HasCount(
+            scenarios.Count,
+            scenarios.Select(scenario => scenario.Id).Distinct().ToList());
+        foreach (var scenario in scenarios)
+        {
+            Assert.IsFalse(string.IsNullOrWhiteSpace(scenario.Id));
+            Assert.IsFalse(string.IsNullOrWhiteSpace(scenario.Title));
+            Assert.IsFalse(string.IsNullOrWhiteSpace(scenario.Area));
+            Assert.IsFalse(string.IsNullOrWhiteSpace(scenario.Expected));
+            Assert.IsFalse(string.IsNullOrWhiteSpace(scenario.Protocol));
+            Assert.IsGreaterThanOrEqualTo(0, scenario.ExpectedState.ImageCount);
+            Assert.IsGreaterThanOrEqualTo(0, scenario.ExpectedState.PlacementCount);
+            Assert.IsGreaterThanOrEqualTo(
+                0,
+                scenario.ExpectedState.VirtualPlacementCount);
+            Assert.IsGreaterThanOrEqualTo(1, scenario.VariantCount);
+            if (scenario.VariantCount > 1)
+                Assert.IsFalse(string.IsNullOrWhiteSpace(scenario.ActionHint));
+        }
+    }
+
+    [TestMethod]
+    public void FrameRenderer_EveryScenario_ProducesExpectedKgpState()
+    {
+        var scenarios = KgpScenarioCatalog.All;
+
+        for (var index = 0; index < scenarios.Count; index++)
+        {
+            var scenario = scenarios[index];
+            using var terminal = CreateTerminal(new PassiveWorkloadAdapter());
+            var frame = KgpValidationFrameRenderer.Render(
+                scenario,
+                index,
+                scenarios.Count,
+                width: 100,
+                height: 32,
+                enterAlternateScreen: true);
+
+            terminal.ApplyTokens(
+                AnsiTokenizer.Tokenize(Encoding.UTF8.GetString(frame)));
+
+            using var snapshot = terminal.CreateSnapshot();
+            Assert.IsTrue(
+                snapshot.ContainsText(scenario.Title),
+                $"{scenario.Id}: title was not rendered.");
+            Assert.AreEqual(
+                scenario.ExpectedState.ImageCount,
+                terminal.KgpImageStore.ImageCount,
+                $"{scenario.Id}: image count");
+            Assert.AreEqual(
+                scenario.ExpectedState.PlacementCount,
+                snapshot.KgpPlacements.Count,
+                $"{scenario.Id}: placement count");
+            Assert.AreEqual(
+                scenario.ExpectedState.VirtualPlacementCount,
+                terminal.KgpVirtualPlacementCount,
+                $"{scenario.Id}: virtual placement count");
+            AssertScenarioGeometry(scenario.Id, snapshot);
+
+            if (scenario.ExpectedState.FrameImageId is { } imageId)
+            {
+                var image = terminal.KgpImageStore.GetImageById(imageId);
+                Assert.IsNotNull(image, $"{scenario.Id}: frame image");
+                Assert.AreEqual(
+                    scenario.ExpectedState.FrameCount,
+                    image.FrameCount,
+                    $"{scenario.Id}: frame count");
+            }
+        }
+    }
+
+    [TestMethod]
+    public void FrameRenderer_ScrollingVariants_MoveMarkerAndImageTogether()
+    {
+        var scenarios = KgpScenarioCatalog.All;
+        using var terminal = CreateTerminal(new PassiveWorkloadAdapter());
+
+        ApplyFrame(
+            terminal,
+            scenarios,
+            scenarioIndex: 5,
+            enterAlternateScreen: true,
+            variant: 0);
+        using (var before = terminal.CreateSnapshot())
+        {
+            AssertPosition(before, 5201, 1, row: 18, column: 8);
+            Assert.Contains("ANCHOR", before.GetLineTrimmed(17));
+        }
+
+        ApplyFrame(
+            terminal,
+            scenarios,
+            scenarioIndex: 5,
+            enterAlternateScreen: false,
+            variant: 1);
+        using var after = terminal.CreateSnapshot();
+        AssertPosition(after, 5201, 1, row: 12, column: 8);
+        Assert.Contains("ANCHOR", after.GetLineTrimmed(11));
+        Assert.DoesNotContain("ANCHOR", after.GetLineTrimmed(17));
+    }
+
+    [TestMethod]
+    public void FrameRenderer_ScenarioChange_ClearsVirtualAndAnimationState()
+    {
+        var scenarios = KgpScenarioCatalog.All;
+        using var terminal = CreateTerminal(new PassiveWorkloadAdapter());
+
+        ApplyFrame(terminal, scenarios, scenarioIndex: 6, enterAlternateScreen: true);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpVirtualPlacementCount);
+
+        ApplyFrame(terminal, scenarios, scenarioIndex: 0, enterAlternateScreen: false);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(0, terminal.KgpVirtualPlacementCount);
+        Assert.IsEmpty(terminal.CreateSnapshot().KgpPlacements);
+
+        ApplyFrame(terminal, scenarios, scenarioIndex: 8, enterAlternateScreen: false);
+        Assert.AreEqual(1, terminal.KgpImageStore.ImageCount);
+        Assert.AreEqual(1, terminal.KgpImageStore.GetImageById(8201)!.FrameCount);
+
+        ApplyFrame(terminal, scenarios, scenarioIndex: 0, enterAlternateScreen: false);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        Assert.IsEmpty(terminal.CreateSnapshot().KgpPlacements);
+    }
+
+    [TestMethod]
+    [DataRow(1, 1)]
+    [DataRow(4, 2)]
+    [DataRow(79, 23)]
+    public void FrameRenderer_UndersizedTerminal_RendersWithoutThrowing(
+        int width,
+        int height)
+    {
+        var frame = KgpValidationFrameRenderer.Render(
+            KgpScenarioCatalog.All[1],
+            scenarioIndex: 1,
+            KgpScenarioCatalog.All.Count,
+            width,
+            height,
+            enterAlternateScreen: true);
+
+        Assert.IsNotEmpty(frame);
+    }
+
+    [TestMethod]
+    public async Task Workload_NavigationAndScenarioAction_RenderThroughRawTerminalStack()
+    {
+        await using var workload = new KgpValidationWorkload();
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithHeadless(KgpCapabilities)
+            .WithDimensions(100, 32)
+            .Build();
+        var runTask = terminal.RunAsync(TestContext.Current.CancellationToken);
+
+        var snapshot = await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(
+                screen =>
+                    screen.ContainsText("Compliance overview") &&
+                    screen.ContainsText("N/Space/Right"),
+                TimeSpan.FromSeconds(3),
+                "overview rendered")
+            .Up()
+            .Down()
+            .Type("n")
+            .WaitUntil(
+                screen =>
+                    screen.ContainsText("Direct and chunked transfer") &&
+                    screen.ContainsText("DIRECT RGBA") &&
+                    screen.ContainsText("CHUNKED RGB"),
+                TimeSpan.FromSeconds(3),
+                "direct and chunked scenario rendered")
+            .Type("6")
+            .WaitUntil(
+                screen =>
+                    screen.ContainsText("Scrolling and placement anchors") &&
+                    screen.ContainsText("STATE: BEFORE SCROLL"),
+                TimeSpan.FromSeconds(3),
+                "scrolling scenario before state rendered")
+            .Type("r")
+            .WaitUntil(
+                screen =>
+                    screen.ContainsText("STATE: AFTER SIX SCROLLS") &&
+                    screen.ContainsText("R toggles BEFORE / AFTER"),
+                TimeSpan.FromSeconds(3),
+                "scrolling scenario after state rendered")
+            .Capture("kgp-validation-scrolling-after")
+            .Type("q")
+            .Build()
+            .ApplyWithCaptureAsync(
+                terminal,
+                TestContext.Current.CancellationToken);
+
+        await runTask.WaitAsync(
+            TimeSpan.FromSeconds(3),
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(5, workload.CurrentScenarioIndex);
+        Assert.AreEqual(1, workload.CurrentScenarioVariant);
+        Assert.AreEqual(1, snapshot.KgpImages.Count);
+        AssertPosition(snapshot, 5201, 1, row: 12, column: 8);
+    }
+
+    [TestMethod]
+    public void SourceTree_DoesNotUseHex1bAppOrWidgets()
+    {
+        var sampleDirectory = Path.Combine(
+            FindRepositoryRoot(),
+            "samples",
+            "KgpValidation");
+
+        foreach (var file in Directory.GetFiles(
+                     sampleDirectory,
+                     "*.cs",
+                     SearchOption.AllDirectories))
+        {
+            var source = File.ReadAllText(file);
+            Assert.DoesNotContain("WithHex1bApp(", source, file);
+            Assert.DoesNotContain("new Hex1bApp", source, file);
+            Assert.DoesNotContain("using Hex1b.Widgets", source, file);
+        }
+    }
+
+    private static Hex1bTerminal CreateTerminal(
+        IHex1bTerminalWorkloadAdapter workload)
+        => Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithHeadless(KgpCapabilities)
+            .WithDimensions(100, 32)
+            .Build();
+
+    private static void ApplyFrame(
+        Hex1bTerminal terminal,
+        IReadOnlyList<KgpValidationScenario> scenarios,
+        int scenarioIndex,
+        bool enterAlternateScreen,
+        int variant = 0)
+    {
+        var frame = KgpValidationFrameRenderer.Render(
+            scenarios[scenarioIndex],
+            scenarioIndex,
+            scenarios.Count,
+            width: 100,
+            height: 32,
+            enterAlternateScreen,
+            variant);
+        terminal.ApplyTokens(
+            AnsiTokenizer.Tokenize(Encoding.UTF8.GetString(frame)));
+    }
+
+    private static void AssertScenarioGeometry(
+        string scenarioId,
+        Hex1bTerminalSnapshot snapshot)
+    {
+        switch (scenarioId)
+        {
+            case "shared-replacement":
+                var replacement = Placement(snapshot, 2202, 7);
+                Assert.AreEqual(17, replacement.Row);
+                Assert.AreEqual(57, replacement.Column);
+                break;
+
+            case "source-crop":
+                var full = Placement(snapshot, 3201, 1);
+                Assert.AreEqual(0u, full.SourceX);
+                Assert.AreEqual(0u, full.SourceY);
+                Assert.AreEqual(80u, full.SourceWidth);
+                Assert.AreEqual(60u, full.SourceHeight);
+                AssertCrop(snapshot, 2, sourceX: 0, sourceY: 0);
+                AssertCrop(snapshot, 3, sourceX: 40, sourceY: 0);
+                AssertCrop(snapshot, 4, sourceX: 0, sourceY: 30);
+                AssertCrop(snapshot, 5, sourceX: 40, sourceY: 30);
+                break;
+
+            case "z-order":
+                Assert.AreEqual(-2, Placement(snapshot, 4201, 1).ZIndex);
+                Assert.AreEqual(2, Placement(snapshot, 4202, 1).ZIndex);
+                break;
+
+            case "scrolling":
+                var scrolled = Placement(snapshot, 5201, 1);
+                Assert.AreEqual(18, scrolled.Row);
+                Assert.AreEqual(8, scrolled.Column);
+                break;
+
+            case "unicode-placeholder":
+                var fragments = snapshot.KgpPlacements
+                    .OrderBy(placement => placement.Row)
+                    .ToList();
+                TestSeq.AreEqual(new[] { 11, 12, 13 }, fragments.Select(p => p.Row));
+                Assert.IsTrue(fragments.All(p => p.Column == 11));
+                Assert.IsTrue(fragments.All(p => p.PlacementId == 7));
+                break;
+
+            case "relative-placement":
+                AssertPosition(snapshot, 7201, 1, row: 10, column: 7);
+                AssertPosition(snapshot, 7202, 2, row: 14, column: 17);
+                AssertPosition(snapshot, 7203, 3, row: 12, column: 15);
+                break;
+
+            case "deletion-reuse":
+                AssertPosition(snapshot, 9201, 3, row: 11, column: 59);
+                break;
+        }
+    }
+
+    private static void AssertCrop(
+        Hex1bTerminalSnapshot snapshot,
+        uint placementId,
+        uint sourceX,
+        uint sourceY)
+    {
+        var placement = Placement(snapshot, 3201, placementId);
+        Assert.AreEqual(sourceX, placement.SourceX);
+        Assert.AreEqual(sourceY, placement.SourceY);
+        Assert.AreEqual(40u, placement.SourceWidth);
+        Assert.AreEqual(30u, placement.SourceHeight);
+    }
+
+    private static void AssertPosition(
+        Hex1bTerminalSnapshot snapshot,
+        uint imageId,
+        uint placementId,
+        int row,
+        int column)
+    {
+        var placement = Placement(snapshot, imageId, placementId);
+        Assert.AreEqual(row, placement.Row);
+        Assert.AreEqual(column, placement.Column);
+    }
+
+    private static KgpPlacement Placement(
+        Hex1bTerminalSnapshot snapshot,
+        uint imageId,
+        uint placementId)
+        => TestSeq.Single(snapshot.KgpPlacements.Where(
+            placement =>
+                placement.ImageId == imageId &&
+                placement.PlacementId == placementId));
+
+    private static string FindRepositoryRoot()
+    {
+        for (var directory = new DirectoryInfo(AppContext.BaseDirectory);
+             directory is not null;
+             directory = directory.Parent)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "global.json")) &&
+                Directory.Exists(Path.Combine(
+                    directory.FullName,
+                    "samples",
+                    "KgpValidation")))
+            {
+                return directory.FullName;
+            }
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not find the Hex1b repository root.");
+    }
+
+    private sealed class PassiveWorkloadAdapter : IHex1bTerminalWorkloadAdapter
+    {
+        public event Action? Disconnected
+        {
+            add { }
+            remove { }
+        }
+
+        public ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(
+            CancellationToken ct = default)
+            => ValueTask.FromResult(ReadOnlyMemory<byte>.Empty);
+
+        public ValueTask WriteInputAsync(
+            ReadOnlyMemory<byte> data,
+            CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask ResizeAsync(
+            int width,
+            int height,
+            CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- add `samples/KgpValidation`, a raw `IHex1bTerminalWorkloadAdapter` harness that runs through `Hex1bTerminal` without `Hex1bApp`, widgets, or nodes
- provide ten self-contained pages covering direct/chunked transfer, identity and replacement, source crops, z-order, scrolling, Unicode placeholders, relative graphs, animation-frame storage, and deletion/lifetime behavior
- show each page's expected visible result and exact protocol area, with keyboard navigation and an `R`-toggle before/after check for scrolling
- make renderer mismatches explicit: scenario 6 separately marks the expected and old image rows when text moves but graphics do not
- document the current compliance boundary, including typed no-op animation playback/composition, project structure, and debugging workflow
- add headless tests for the catalog, raw terminal lifecycle/navigation, page isolation, geometry, crop, z-order, scrolling, relative placement, virtual state, animation frame count, small terminals, and the no-widget constraint

## Validation
- `KgpValidation` Release build: 0 warnings/errors
- focused sample tests: 9 passed
- complete KGP test surface: 1,061 passed
- serialized `Hex1b.Tests`: 8,584 passed, 24 skipped
- interactive `dotnet run --project samples/KgpValidation` navigation and cleanup verified in the console

## Run
```bash
dotnet run --project samples/KgpValidation
```

Fixes: #406