### PR TITLE
Backport KGP state synchronization to 0.166

### DIFF
--- a/docs/muxer-protocol.md
+++ b/docs/muxer-protocol.md
@@ -159,6 +159,11 @@ Sent by the server immediately after the Hello frame. Contains a full snapshot o
 
 The payload may be empty if no screen content is available yet.
 
+If the snapshot contains active Kitty Graphics Protocol images, the server queues
+KGP transmit and placement sequences as `Output` frames immediately after
+`StateSync` and before subsequent live output. Graphics are replayed separately
+because their encoded data may exceed the maximum size of one HMP frame.
+
 ### Output (0x03)
 
 Incremental terminal output from the server's workload (e.g., PTY process). Sent continuously as the workload produces output.
@@ -319,7 +324,8 @@ Client                              Server
 3. Server replies with **Hello** carrying the protocol version, current PTY
    dimensions, the assigned `peerId`, the current `primaryPeerId`, and the
    roster of other attached peers.
-4. Server sends **StateSync** with the full current screen content.
+4. Server sends **StateSync** with the full current text screen content, followed
+   by ordered **Output** frames that restore active KGP images and placements.
 5. Normal operation: **Output** flows server → client; **Input** flows client → server.
 6. To take control of the PTY size, a peer sends **RequestPrimary**. The
    server applies the resize, broadcasts **RoleChange** to all peers, and

--- a/src/Hex1b/Hmp1/Hmp1KgpStateReplay.cs
+++ b/src/Hex1b/Hmp1/Hmp1KgpStateReplay.cs
@@ -1,0 +1,161 @@
+using System.Globalization;
+using System.Text;
+
+namespace Hex1b;
+
+internal static class Hmp1KgpStateReplay
+{
+    private const int MaximumBase64ChunkLength = 4096;
+    private const int MaximumRawChunkLength = MaximumBase64ChunkLength / 4 * 3;
+    private const int TargetFrameSize = 1024 * 1024;
+
+    internal static async Task WriteAsync(
+        Stream stream,
+        IReadOnlyList<KgpPlacement> placements,
+        IReadOnlyDictionary<uint, KgpImageData> images,
+        int cursorX,
+        int cursorY,
+        CancellationToken ct)
+    {
+        if (placements.Count == 0 || images.Count == 0)
+            return;
+
+        var frame = new StringBuilder(TargetFrameSize);
+
+        foreach (var image in images.Values.OrderBy(image => image.ImageId))
+        {
+            await AppendImageAsync(image).ConfigureAwait(false);
+        }
+
+        var placementIdentityCounts = placements
+            .Where(placement => placement.PlacementId > 0)
+            .GroupBy(placement => (placement.ImageId, placement.PlacementId))
+            .ToDictionary(group => group.Key, group => group.Count());
+
+        foreach (var placement in placements)
+        {
+            if (!images.TryGetValue(placement.ImageId, out var image))
+                continue;
+
+            var preservePlacementId =
+                placement.PlacementId > 0 &&
+                placementIdentityCounts[(placement.ImageId, placement.PlacementId)] == 1;
+            await AppendAsync(BuildPlacementSequence(
+                placement,
+                image,
+                preservePlacementId)).ConfigureAwait(false);
+        }
+
+        await AppendAsync(FormattableString.Invariant(
+            $"\x1b[{cursorY + 1};{cursorX + 1}H")).ConfigureAwait(false);
+        await FlushAsync().ConfigureAwait(false);
+
+        async ValueTask AppendImageAsync(KgpImageData image)
+        {
+            var data = image.CurrentFrameData;
+            var offset = 0;
+            var first = true;
+            do
+            {
+                var count = Math.Min(MaximumRawChunkLength, data.Length - offset);
+                var isLast = offset + count >= data.Length;
+                var payload = count == 0
+                    ? string.Empty
+                    : Convert.ToBase64String(data, offset, count);
+                string controls;
+                if (first)
+                {
+                    controls = FormattableString.Invariant(
+                        $"a=t,f={(int)image.CurrentFrameFormat},s={image.Width},v={image.Height},{BuildImageIdentity(image)},t=d,q=2");
+                    if (!isLast)
+                        controls += ",m=1";
+                }
+                else
+                {
+                    controls = isLast ? "m=0,q=2" : "m=1,q=2";
+                }
+
+                await AppendAsync(BuildKgpSequence(controls, payload)).ConfigureAwait(false);
+                offset += count;
+                first = false;
+            }
+            while (offset < data.Length);
+        }
+
+        async ValueTask AppendAsync(string sequence)
+        {
+            if (frame.Length > 0 && frame.Length + sequence.Length > TargetFrameSize)
+                await FlushAsync().ConfigureAwait(false);
+            frame.Append(sequence);
+        }
+
+        async ValueTask FlushAsync()
+        {
+            if (frame.Length == 0)
+                return;
+
+            var payload = Encoding.UTF8.GetBytes(frame.ToString());
+            frame.Clear();
+            await Hmp1Protocol.WriteFrameAsync(
+                stream,
+                Hmp1FrameType.Output,
+                payload,
+                ct).ConfigureAwait(false);
+        }
+    }
+
+    private static string BuildPlacementSequence(
+        KgpPlacement placement,
+        KgpImageData image,
+        bool preservePlacementId)
+    {
+        var controls = new StringBuilder();
+        controls.Append("a=p,");
+        controls.Append(BuildImageIdentity(image));
+        if (preservePlacementId)
+        {
+            controls.Append(",p=");
+            controls.Append(placement.PlacementId.ToString(CultureInfo.InvariantCulture));
+        }
+
+        AppendNonZero(controls, 'x', placement.SourceX);
+        AppendNonZero(controls, 'y', placement.SourceY);
+        AppendNonZero(controls, 'w', placement.SourceWidth);
+        AppendNonZero(controls, 'h', placement.SourceHeight);
+        AppendNonZero(controls, 'X', placement.CellOffsetX);
+        AppendNonZero(controls, 'Y', placement.CellOffsetY);
+        AppendNonZero(controls, 'c', placement.DisplayColumns);
+        AppendNonZero(controls, 'r', placement.DisplayRows);
+        if (placement.ZIndex != 0)
+        {
+            controls.Append(",z=");
+            controls.Append(placement.ZIndex.ToString(CultureInfo.InvariantCulture));
+        }
+        controls.Append(",C=1,q=2");
+
+        return FormattableString.Invariant(
+            $"\x1b[{placement.Row + 1};{placement.Column + 1}H") +
+            BuildKgpSequence(controls.ToString(), string.Empty);
+    }
+
+    private static string BuildImageIdentity(KgpImageData image)
+        => image.ImageNumber > 0
+            ? FormattableString.Invariant($"I={image.ImageNumber}")
+            : FormattableString.Invariant($"i={image.ImageId}");
+
+    private static string BuildKgpSequence(string controls, string payload)
+        => payload.Length == 0
+            ? $"\x1b_G{controls}\x1b\\"
+            : $"\x1b_G{controls};{payload}\x1b\\";
+
+    private static void AppendNonZero(StringBuilder builder, char key, uint value)
+    {
+        if (value == 0)
+            return;
+
+        builder.Append(',');
+        builder.Append(key);
+        builder.Append('=');
+        builder.Append(value.ToString(CultureInfo.InvariantCulture));
+    }
+}

--- a/src/Hex1b/Hmp1/Hmp1PresentationAdapter.cs
+++ b/src/Hex1b/Hmp1/Hmp1PresentationAdapter.cs
@@ -88,7 +88,8 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
         SupportsTrueColor = true,
         Supports256Colors = true,
         SupportsAlternateScreen = true,
-        SupportsBracketedPaste = true
+        SupportsBracketedPaste = true,
+        SupportsKgp = true
     };
 
     /// <inheritdoc />
@@ -231,6 +232,10 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
 
         Hmp1ClientSession[] existingPeers;
         byte[] syncBytes;
+        IReadOnlyList<KgpPlacement> kgpPlacements;
+        IReadOnlyDictionary<uint, KgpImageData> kgpImages;
+        int cursorX;
+        int cursorY;
         string? primarySnapshot;
         int widthSnapshot;
         int heightSnapshot;
@@ -260,15 +265,35 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
                 });
                 var suffix = BuildStateReplaySuffix(snap);
                 syncBytes = Encoding.UTF8.GetBytes(prefix + ansi + suffix);
+                kgpPlacements = snap.KgpPlacements;
+                kgpImages = snap.KgpImages;
+                cursorX = snap.CursorX;
+                cursorY = snap.CursorY;
             }
             else
             {
                 syncBytes = [];
+                kgpPlacements = [];
+                kgpImages = new Dictionary<uint, KgpImageData>();
+                cursorX = 0;
+                cursorY = 0;
             }
 
             primarySnapshot = _primaryPeerId;
             widthSnapshot = _width;
             heightSnapshot = _height;
+
+            if (kgpPlacements.Count > 0)
+            {
+                EnqueueControlFrameAsync(session, stream =>
+                    Hmp1KgpStateReplay.WriteAsync(
+                        stream,
+                        kgpPlacements,
+                        kgpImages,
+                        cursorX,
+                        cursorY,
+                        session.Cts.Token));
+            }
 
             _sessions.Add(session);
 

--- a/tests/Hex1b.Tests/Hmp1/Hmp1StateReplayCursorRegressionTests.cs
+++ b/tests/Hex1b.Tests/Hmp1/Hmp1StateReplayCursorRegressionTests.cs
@@ -117,6 +117,82 @@ public class Hmp1StateReplayCursorRegressionTests
         Assert.AreEqual((byte)'G', lastByte);
     }
 
+    [TestMethod]
+    public async Task StateSync_WithActiveKgpPlacement_ReplaysImageToLateJoiningPeer()
+    {
+        await using var server = new Hmp1PresentationAdapter(20, 10);
+        await using var producer = Hex1bTerminal.CreateBuilder()
+            .WithDimensions(20, 10)
+            .WithWorkload(new NullWorkloadAdapter())
+            .WithPresentation(server)
+            .Build();
+
+        var pixels = new byte[]
+        {
+            255, 0, 0, 255,
+            0, 255, 0, 255,
+            0, 0, 255, 255,
+            255, 255, 255, 255,
+        };
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b[3;5H" +
+            KgpTestHelper.BuildCommand(
+                "a=T,f=32,s=2,v=2,i=7,p=11,c=2,r=2,C=1,q=2",
+                pixels)));
+        using (var producerState = producer.CreateSnapshot())
+        {
+            Assert.HasCount(1, producerState.KgpPlacements);
+            Assert.HasCount(1, producerState.KgpImages);
+        }
+
+        var (serverStream, clientStream) = CreateFullDuplexPair();
+        using var cts = new CancellationTokenSource(TestTimeout);
+        var addClientTask = server.AddClient(serverStream, cts.Token);
+        await Hmp1Protocol.WriteClientHelloAsync(
+            clientStream,
+            displayName: "late-viewer",
+            defaultRole: null,
+            cts.Token);
+
+        var hello = await Hmp1Protocol.ReadFrameAsync(clientStream, cts.Token)
+            ?? throw new AssertFailedException("Server closed the stream before sending Hello.");
+        var stateSync = await Hmp1Protocol.ReadFrameAsync(clientStream, cts.Token)
+            ?? throw new AssertFailedException("Server closed the stream before sending StateSync.");
+        var kgpReplay = await Hmp1Protocol.ReadFrameAsync(clientStream, cts.Token)
+            ?? throw new AssertFailedException("Server closed the stream before sending KGP replay.");
+
+        Assert.AreEqual(Hmp1FrameType.Hello, hello.Type);
+        Assert.AreEqual(Hmp1FrameType.StateSync, stateSync.Type);
+        Assert.AreEqual(Hmp1FrameType.Output, kgpReplay.Type);
+
+        var handle = await addClientTask;
+        await using var handleDispose = handle;
+        await using var viewer = Hex1bTerminal.CreateBuilder()
+            .WithDimensions(20, 10)
+            .WithWorkload(new NullWorkloadAdapter())
+            .WithHeadless(new TerminalCapabilities { SupportsKgp = true })
+            .Build();
+
+        viewer.ApplyTokens(AnsiTokenizer.Tokenize(
+            Encoding.UTF8.GetString(stateSync.Payload.Span)));
+        viewer.ApplyTokens(AnsiTokenizer.Tokenize(
+            Encoding.UTF8.GetString(kgpReplay.Payload.Span)));
+
+        using var producerSnapshot = producer.CreateSnapshot();
+        using var snapshot = viewer.CreateSnapshot();
+        var placement = TestSeq.Single(snapshot.KgpPlacements);
+        Assert.AreEqual((uint)7, placement.ImageId);
+        Assert.AreEqual((uint)11, placement.PlacementId);
+        Assert.AreEqual(2, placement.Row);
+        Assert.AreEqual(4, placement.Column);
+        Assert.AreEqual((uint)2, placement.DisplayColumns);
+        Assert.AreEqual((uint)2, placement.DisplayRows);
+        Assert.IsTrue(snapshot.KgpImages.TryGetValue(7, out var image));
+        TestSeq.AreEqual(pixels, image.Data);
+        Assert.AreEqual(producerSnapshot.CursorX, snapshot.CursorX);
+        Assert.AreEqual(producerSnapshot.CursorY, snapshot.CursorY);
+    }
+
     private sealed class NullWorkloadAdapter : IHex1bTerminalWorkloadAdapter
     {
         public event Action? Disconnected


### PR DESCRIPTION
## Summary
- cherry-picks the HMP1 KGP state synchronization fix from #424
- restores active KGP images and placements for late-joining WebMuxer peers
- targets release/0.166 so the release workflow publishes a new beta

## Validation
- Hex1b library build
- complete Hex1b.Tests suite