### PR TITLE
[release/0.166] Backport nested KGP translation for TerminalWidget

### DIFF
--- a/src/Hex1b/Hex1bRenderContext.cs
+++ b/src/Hex1b/Hex1bRenderContext.cs
@@ -130,6 +130,67 @@ public class Hex1bRenderContext
         Write(sb.ToString());
     }
 
+    internal virtual void RegisterKgp(KgpImageData image, KgpPlacement placement)
+    {
+        if (!Capabilities.SupportsKgp)
+            return;
+
+        var data = CreateKgpCellData(image, placement);
+        SetCursorPosition(placement.Column, placement.Row);
+        foreach (var chunk in data.BuildTransmitChunks())
+        {
+            Write(chunk);
+        }
+        Write(data.BuildPlacementPayload());
+    }
+
+    protected KgpCellData CreateKgpCellData(KgpImageData image, KgpPlacement placement)
+    {
+        var frameData = image.CurrentFrameData;
+        var frameFormat = image.CurrentFrameFormat;
+        var contentHash = ComputeKgpContentHash(
+            frameData,
+            frameFormat,
+            image.Width,
+            image.Height);
+        var imageId = ComputeKgpImageId(contentHash);
+        var base64 = Convert.ToBase64String(frameData);
+        var transmitPayload =
+            $"\x1b_Ga=t,f={(int)frameFormat},s={image.Width},v={image.Height},i={imageId},t=d,q=2;{base64}\x1b\\";
+
+        return new KgpCellData(
+            transmitPayload,
+            imageId,
+            checked((int)placement.DisplayColumns),
+            checked((int)placement.DisplayRows),
+            image.Width,
+            image.Height,
+            contentHash,
+            clipX: checked((int)placement.SourceX),
+            clipY: checked((int)placement.SourceY),
+            clipW: checked((int)placement.SourceWidth),
+            clipH: checked((int)placement.SourceHeight),
+            zIndex: placement.ZIndex,
+            cellOffsetX: placement.CellOffsetX,
+            cellOffsetY: placement.CellOffsetY);
+    }
+
+    private static byte[] ComputeKgpContentHash(
+        byte[] imageData,
+        KgpFormat format,
+        uint pixelWidth,
+        uint pixelHeight)
+    {
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        Span<byte> metadata = stackalloc byte[9];
+        metadata[0] = checked((byte)format);
+        BinaryPrimitives.WriteUInt32BigEndian(metadata[1..5], pixelWidth);
+        BinaryPrimitives.WriteUInt32BigEndian(metadata[5..9], pixelHeight);
+        hash.AppendData(metadata);
+        hash.AppendData(imageData);
+        return hash.GetHashAndReset();
+    }
+
     /// <summary>
     /// Maps image content to a Kitty image ID, salted by <see cref="KgpImageEpoch"/>
     /// so the same bytes can be reintroduced under a fresh ID after a terminal resize.

--- a/src/Hex1b/Kgp/KgpCellData.cs
+++ b/src/Hex1b/Kgp/KgpCellData.cs
@@ -79,6 +79,16 @@ public sealed class KgpCellData
     public int ZIndex { get; }
 
     /// <summary>
+    /// Gets the horizontal pixel offset within the destination cell.
+    /// </summary>
+    public uint CellOffsetX { get; }
+
+    /// <summary>
+    /// Gets the vertical pixel offset within the destination cell.
+    /// </summary>
+    public uint CellOffsetY { get; }
+
+    /// <summary>
     /// Creates a new KGP cell data instance with structured placement data.
     /// </summary>
     internal KgpCellData(
@@ -93,7 +103,9 @@ public sealed class KgpCellData
         int clipY = 0,
         int clipW = 0,
         int clipH = 0,
-        int zIndex = -1)
+        int zIndex = -1,
+        uint cellOffsetX = 0,
+        uint cellOffsetY = 0)
     {
         TransmitPayload = transmitPayload;
         ImageId = imageId;
@@ -107,6 +119,8 @@ public sealed class KgpCellData
         ClipW = clipW;
         ClipH = clipH;
         ZIndex = zIndex;
+        CellOffsetX = cellOffsetX;
+        CellOffsetY = cellOffsetY;
     }
 
     /// <summary>
@@ -122,6 +136,8 @@ public sealed class KgpCellData
         if (ClipY > 0) sb.Append($",y={ClipY}");
         if (ClipW > 0) sb.Append($",w={ClipW}");
         if (ClipH > 0) sb.Append($",h={ClipH}");
+        if (CellOffsetX > 0) sb.Append($",X={CellOffsetX}");
+        if (CellOffsetY > 0) sb.Append($",Y={CellOffsetY}");
         sb.Append($",q=2,z={ZIndex}");
         sb.Append("\x1b\\");
         return sb.ToString();
@@ -145,7 +161,9 @@ public sealed class KgpCellData
             clipY,
             clipW,
             clipH,
-            ZIndex);
+            ZIndex,
+            clipX == ClipX ? CellOffsetX : 0,
+            clipY == ClipY ? CellOffsetY : 0);
     }
 
     /// <summary>

--- a/src/Hex1b/Nodes/TerminalNode.cs
+++ b/src/Hex1b/Nodes/TerminalNode.cs
@@ -589,6 +589,8 @@ public sealed class TerminalNode : Hex1bNode
     public override void Render(Hex1bRenderContext context)
     {
         if (_handle == null) return;
+
+        _handle.UpdateHostCapabilities(context.Capabilities);
         
         // If terminal is not running and we have a fallback child, render the fallback instead
         if (_handle.State != TerminalState.Running && FallbackChild != null)
@@ -641,6 +643,44 @@ public sealed class TerminalNode : Hex1bNode
         else
         {
             RenderLive(context, buffer, handleWidth, handleHeight);
+        }
+
+        RenderKgp(context, handleWidth, handleHeight);
+    }
+
+    private void RenderKgp(Hex1bRenderContext context, int handleWidth, int handleHeight)
+    {
+        if (_handle is null || !context.Capabilities.SupportsKgp)
+            return;
+
+        var effectiveOffset = Math.Min(_scrollbackOffset, _handle.ScrollbackCount);
+        using var snapshot = _handle.CreateSnapshot(effectiveOffset);
+        if (snapshot is null)
+            return;
+
+        var visibleWidth = Math.Min(Bounds.Width, handleWidth);
+        var visibleHeight = Math.Min(Bounds.Height, handleHeight);
+        foreach (var placement in snapshot.KgpPlacements)
+        {
+            if (!snapshot.KgpImages.TryGetValue(placement.ImageId, out var image))
+                continue;
+
+            var clipped = placement.ClipToCellRectangle(
+                image,
+                top: 0,
+                bottomExclusive: visibleHeight,
+                left: 0,
+                rightExclusive: visibleWidth,
+                snapshot.CellPixelWidth,
+                snapshot.CellPixelHeight);
+            if (clipped is null)
+                continue;
+
+            context.RegisterKgp(
+                image,
+                clipped.WithPosition(
+                    Bounds.Y + clipped.Row,
+                    Bounds.X + clipped.Column));
         }
     }
     

--- a/src/Hex1b/Surfaces/SurfaceRenderContext.cs
+++ b/src/Hex1b/Surfaces/SurfaceRenderContext.cs
@@ -459,6 +459,45 @@ public class SurfaceRenderContext : Hex1bRenderContext
         }
     }
 
+    internal override void RegisterKgp(KgpImageData image, KgpPlacement placement)
+    {
+        if (!Capabilities.SupportsKgp)
+            return;
+
+        var surfaceBounds = new Rect(_offsetX, _offsetY, _surface.Width, _surface.Height);
+        var visibleBounds = _kgpClipRect is { } clip
+            ? IntersectRects(surfaceBounds, clip)
+            : surfaceBounds;
+        if (visibleBounds is null)
+            return;
+
+        var clipped = placement.ClipToCellRectangle(
+            image,
+            visibleBounds.Value.Y,
+            visibleBounds.Value.Bottom,
+            visibleBounds.Value.X,
+            visibleBounds.Value.Right,
+            CellMetrics.PixelWidth,
+            CellMetrics.PixelHeight);
+        if (clipped is null)
+            return;
+
+        var kgpData = CreateKgpCellData(image, clipped);
+        _kgpRegistry?.RegisterImage(kgpData, clipped.Column, clipped.Row);
+
+        if (_kgpRegistry is not null)
+            return;
+
+        var writeX = clipped.Column - _offsetX;
+        var writeY = clipped.Row - _offsetY;
+        if (writeX < 0 || writeX >= _surface.Width || writeY < 0 || writeY >= _surface.Height)
+            return;
+
+        var tracked = _trackedObjects.GetOrCreateKgp(kgpData);
+        tracked.AddRef();
+        _surface[writeX, writeY] = _surface[writeX, writeY] with { Kgp = tracked };
+    }
+
     /// <summary>
     /// Writes text at the specified position, respecting the current layout provider's clipping.
     /// </summary>

--- a/src/Hex1b/TerminalWidgetHandle.cs
+++ b/src/Hex1b/TerminalWidgetHandle.cs
@@ -1,5 +1,6 @@
 using Hex1b.Input;
 using Hex1b.Tokens;
+using Hex1b.Automation;
 
 namespace Hex1b;
 
@@ -62,6 +63,12 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
     private int _cursorY;
     private bool _cursorVisible = true;
     private bool _disposed;
+    private TerminalCapabilities _capabilities = new()
+    {
+        SupportsMouse = true,
+        Supports256Colors = true,
+        SupportsTrueColor = true,
+    };
     
     // Mouse tracking state - tracks whether the child process has enabled mouse
     // These are set when we receive PrivateModeToken from the child's output
@@ -510,13 +517,33 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
             _cursorY = cursorY;
             return (buffer, width, height);
         }
-        
+
         lock (_bufferLock)
         {
             var copy = new TerminalCell[_height, _width];
             Array.Copy(_screenBuffer, copy, _screenBuffer.Length);
             return (copy, _width, _height);
         }
+    }
+
+    internal Hex1bTerminalSnapshot? CreateSnapshot(
+        int scrollbackLines,
+        ScrollbackWidth scrollbackWidth = ScrollbackWidth.CurrentTerminal)
+        => _terminal?.CreateSnapshot(scrollbackLines, scrollbackWidth);
+
+    internal void UpdateHostCapabilities(TerminalCapabilities hostCapabilities)
+    {
+        ArgumentNullException.ThrowIfNull(hostCapabilities);
+
+        var current = Volatile.Read(ref _capabilities);
+        var updated = current with
+        {
+            SupportsKgp = hostCapabilities.SupportsKgp,
+            CellPixelWidth = hostCapabilities.CellPixelWidth,
+            ActualCellPixelWidth = hostCapabilities.ActualCellPixelWidth,
+            CellPixelHeight = hostCapabilities.CellPixelHeight,
+        };
+        Volatile.Write(ref _capabilities, updated);
     }
     
     /// <summary>
@@ -566,12 +593,7 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
     int IHex1bTerminalPresentationAdapter.Height => _height;
     
     /// <inheritdoc />
-    public TerminalCapabilities Capabilities { get; } = new()
-    {
-        SupportsMouse = true,
-        Supports256Colors = true,
-        SupportsTrueColor = true,
-    };
+    public TerminalCapabilities Capabilities => Volatile.Read(ref _capabilities);
     
     /// <inheritdoc />
     public event Action<int, int>? Resized;
@@ -636,10 +658,16 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
     private void ApplyTokensToBuffer(IReadOnlyList<AppliedToken> appliedTokens)
     {
         int maxY = -1;
+        var hasKgpChanges = false;
         lock (_bufferLock)
         {
             foreach (var applied in appliedTokens)
             {
+                if (applied.Token is KgpToken)
+                {
+                    hasKgpChanges = true;
+                }
+
                 // Check for mode changes from the child process
                 if (applied.Token is PrivateModeToken pm)
                 {
@@ -674,8 +702,9 @@ public sealed class TerminalWidgetHandle : ICellImpactAwarePresentationAdapter, 
             }
         }
         
-        // Only notify bound nodes when there are actual cell changes
-        if (maxY >= 0)
+        // KGP state lives in the owning terminal rather than this cell buffer,
+        // but changes still require the bound TerminalNode to render a new frame.
+        if (maxY >= 0 || hasKgpChanges)
         {
             OutputReceived?.Invoke();
         }

--- a/tests/Hex1b.Tests/TerminalWidgetKgpTests.cs
+++ b/tests/Hex1b.Tests/TerminalWidgetKgpTests.cs
@@ -1,0 +1,526 @@
+using System.Text;
+using Hex1b.Kgp;
+using Hex1b.Layout;
+using Hex1b.Nodes;
+using Hex1b.Surfaces;
+using Hex1b.Tokens;
+using Hex1b.Widgets;
+
+namespace Hex1b.Tests;
+
+[TestClass]
+public class TerminalWidgetKgpTests
+{
+    private static readonly TerminalCapabilities KgpCapabilities = new()
+    {
+        SupportsKgp = true,
+        SupportsTrueColor = true,
+        Supports256Colors = true,
+        CellPixelWidth = 10,
+        CellPixelHeight = 20,
+    };
+
+    [TestMethod]
+    public void Render_KgpCapableParent_PropagatesCapabilitiesAndCellMetrics()
+    {
+        var handle = new TerminalWidgetHandle(8, 4);
+        var node = CreateNode(handle, new Rect(2, 1, 8, 4));
+        var context = CreateContext(12, 8, out _);
+
+        node.Render(context);
+
+        Assert.IsTrue(handle.Capabilities.SupportsKgp);
+        Assert.AreEqual(10, handle.Capabilities.CellPixelWidth);
+        Assert.AreEqual(20, handle.Capabilities.CellPixelHeight);
+    }
+
+    [TestMethod]
+    public async Task WriteOutputWithImpacts_KgpOnlyToken_RaisesOutputReceived()
+    {
+        var handle = new TerminalWidgetHandle(8, 4);
+        var token = TestSeq.Single(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildTransmitCommand(1, 1, 1, quiet: 2)));
+        var received = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        handle.OutputReceived += () => received.TrySetResult();
+
+        await handle.WriteOutputWithImpactsAsync(
+            [AppliedToken.WithNoCellImpacts(token, 0, 0, 0, 0)]);
+
+        await received.Task.WaitAsync(
+            TimeSpan.FromSeconds(1),
+            TestContext.Current.CancellationToken);
+    }
+
+    [TestMethod]
+    public void Render_KgpCapableParent_ChildQueryReceivesOkResponse()
+    {
+        var workload = new RecordingWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithDimensions(8, 4)
+            .WithTerminalWidget(out var handle)
+            .Build();
+        var node = CreateNode(handle, new Rect(0, 0, 8, 4));
+        var context = CreateContext(8, 4, out _);
+
+        node.Render(context);
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildQueryCommand(imageId: 31)));
+
+        Assert.AreEqual("\x1b_Gi=31;OK\x1b\\", workload.ReadResponse());
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+    }
+
+    [TestMethod]
+    public async Task Render_ChildPlacementExceedsBounds_TranslatesAndClipsSource()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithDimensions(6, 4)
+            .WithTerminalWidget(out var handle)
+            .Build();
+        var node = CreateNode(handle, new Rect(3, 2, 4, 3));
+        var context = CreateContext(12, 8, out var registry);
+
+        node.Render(context);
+
+        var command =
+            "\x1b[2;3H" +
+            KgpTestHelper.BuildTransmitAndDisplayCommand(
+                imageId: 77,
+                width: 40,
+                height: 60,
+                displayColumns: 4,
+                displayRows: 3,
+                quiet: 2);
+        var applied = terminal.ApplyTokensWithImpacts(AnsiTokenizer.Tokenize(command));
+        await handle.WriteOutputWithImpactsAsync(applied);
+
+        node.Render(context);
+
+        var entry = TestSeq.Single(registry.Images);
+        Assert.AreEqual(5, entry.AbsoluteX);
+        Assert.AreEqual(3, entry.AbsoluteY);
+        Assert.AreEqual(2, entry.Data.WidthInCells);
+        Assert.AreEqual(2, entry.Data.HeightInCells);
+        Assert.AreEqual(20, entry.Data.ClipW);
+        Assert.AreEqual(40, entry.Data.ClipH);
+    }
+
+    [TestMethod]
+    [DataRow(KgpFormat.Rgb24)]
+    [DataRow(KgpFormat.Rgba32)]
+    [DataRow(KgpFormat.Png)]
+    public void RegisterKgp_PreservesFormatPayloadPlacementAndText(KgpFormat format)
+    {
+        var imageBytes = new byte[] { 1, 2, 3, 4, 5, 6 };
+        var image = new KgpImageData(91, 0, imageBytes, 20, 20, format);
+        var placement = new KgpPlacement(
+            imageId: 91,
+            placementId: 4,
+            row: 1,
+            column: 2,
+            displayColumns: 2,
+            displayRows: 1,
+            sourceX: 3,
+            sourceY: 4,
+            sourceWidth: 10,
+            sourceHeight: 12,
+            zIndex: 7,
+            cellOffsetX: 2,
+            cellOffsetY: 3);
+        var surface = new Surface(10, 5, new CellMetrics(10, 20));
+        surface[2, 1] = new SurfaceCell("T", null, null);
+        var registry = new KgpImageRegistry();
+        var context = new SurfaceRenderContext(surface)
+        {
+            CellMetrics = new CellMetrics(10, 20),
+            KgpRegistry = registry,
+        };
+        context.SetCapabilities(KgpCapabilities);
+
+        context.RegisterKgp(image, placement);
+
+        var entry = TestSeq.Single(registry.Images);
+        Assert.AreEqual("T", surface[2, 1].Character);
+        Assert.Contains($"f={(int)format}", entry.Data.TransmitPayload!);
+        Assert.Contains(Convert.ToBase64String(imageBytes), entry.Data.TransmitPayload!);
+        Assert.AreEqual(3, entry.Data.ClipX);
+        Assert.AreEqual(4, entry.Data.ClipY);
+        Assert.AreEqual(10, entry.Data.ClipW);
+        Assert.AreEqual(12, entry.Data.ClipH);
+        Assert.AreEqual(7, entry.Data.ZIndex);
+        Assert.AreEqual(2u, entry.Data.CellOffsetX);
+        Assert.AreEqual(3u, entry.Data.CellOffsetY);
+        Assert.Contains("X=2", entry.Data.BuildPlacementPayload());
+        Assert.Contains("Y=3", entry.Data.BuildPlacementPayload());
+    }
+
+    [TestMethod]
+    public async Task NestedHex1bApp_KgpImage_RendersInOuterTerminal()
+    {
+        var imageBytes = KgpTestHelper.CreatePixelData(4, 4, fillByte: 0x5A);
+        Hex1bApp? innerApp = null;
+        await using var innerTerminal = Hex1bTerminal.CreateBuilder()
+            .WithHex1bApp(
+                _ => { },
+                app =>
+                {
+                    innerApp = app;
+                    return _ => new KgpImageWidget(
+                            imageBytes,
+                            4,
+                            4,
+                            new TextBlockWidget("[inner fallback]"))
+                        .Width(4)
+                        .Height(2);
+                })
+            .WithDimensions(8, 4)
+            .WithTerminalWidget(out var handle)
+            .Build();
+
+        Hex1bApp? outerApp = null;
+        await using var outerTerminal = Hex1bTerminal.CreateBuilder()
+            .WithHex1bApp(
+                _ => { },
+                app =>
+                {
+                    outerApp = app;
+                    return _ => new VStackWidget([
+                        new TextBlockWidget("Host"),
+                        new TerminalWidget(handle)
+                            .Width(SizeHint.Fixed(8))
+                            .Height(SizeHint.Fixed(4)),
+                    ]);
+                })
+            .WithHeadless(KgpCapabilities)
+            .WithDimensions(12, 8)
+            .Build();
+
+        var outerRunTask = outerTerminal.RunAsync(TestContext.Current.CancellationToken);
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(
+                snapshot => snapshot.ContainsText("Host") && handle.Capabilities.SupportsKgp,
+                TimeSpan.FromSeconds(5),
+                "outer terminal mounted the KGP-capable child")
+            .Build()
+            .ApplyAsync(outerTerminal, TestContext.Current.CancellationToken);
+
+        var innerRunTask = innerTerminal.RunAsync(TestContext.Current.CancellationToken);
+        using var snapshot = await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(
+                current => current.KgpPlacements.Count > 0,
+                TimeSpan.FromSeconds(5),
+                "nested KGP placement reached the outer terminal")
+            .Capture("nested-terminal-widget-kgp")
+            .Build()
+            .ApplyWithCaptureAsync(outerTerminal, TestContext.Current.CancellationToken);
+
+        Assert.DoesNotContain("[inner fallback]", snapshot.GetScreenText());
+        var placement = TestSeq.Single(snapshot.KgpPlacements);
+        var image = snapshot.KgpImages[placement.ImageId];
+        CollectionAssert.AreEqual(imageBytes, image.Data);
+        Assert.AreEqual(1, placement.Row);
+        Assert.AreEqual(0, placement.Column);
+
+        innerApp!.RequestStop();
+        outerApp!.RequestStop();
+        await Task.WhenAll(innerRunTask, outerRunTask);
+    }
+
+    [TestMethod]
+    public async Task NestedHex1bApp_KgpPlacementMovesAndDeletesWithoutGhosts()
+    {
+        var state = new NestedKgpState();
+        var imageBytes = KgpTestHelper.CreatePixelData(4, 4, fillByte: 0x6B);
+        Hex1bApp? innerApp = null;
+        await using var innerTerminal = Hex1bTerminal.CreateBuilder()
+            .WithHex1bApp(
+                _ => { },
+                (Func<Hex1bApp, Func<RootContext, Hex1bWidget>>)(app =>
+                {
+                    innerApp = app;
+                    return _ =>
+                    {
+                        if (!state.ShowImage)
+                            return (Hex1bWidget)new TextBlockWidget("gone");
+
+                        var image = new KgpImageWidget(
+                                imageBytes,
+                                4,
+                                4,
+                                new TextBlockWidget("image fallback"))
+                            .Width(4)
+                            .Height(2);
+                        return state.MoveDown
+                            ? new VStackWidget([new TextBlockWidget("moved"), image])
+                            : (Hex1bWidget)image;
+                    };
+                }))
+            .WithDimensions(8, 4)
+            .WithTerminalWidget(out var handle)
+            .Build();
+
+        Hex1bApp? outerApp = null;
+        await using var outerTerminal = Hex1bTerminal.CreateBuilder()
+            .WithHex1bApp(
+                _ => { },
+                app =>
+                {
+                    outerApp = app;
+                    return _ => new TerminalWidget(handle)
+                        .Width(SizeHint.Fixed(8))
+                        .Height(SizeHint.Fixed(4));
+                })
+            .WithHeadless(KgpCapabilities)
+            .WithDimensions(8, 4)
+            .Build();
+
+        var outerRunTask = outerTerminal.RunAsync(TestContext.Current.CancellationToken);
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(
+                _ => handle.Capabilities.SupportsKgp,
+                TimeSpan.FromSeconds(5),
+                "outer terminal propagated KGP support")
+            .Build()
+            .ApplyAsync(outerTerminal, TestContext.Current.CancellationToken);
+
+        var innerRunTask = innerTerminal.RunAsync(TestContext.Current.CancellationToken);
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(
+                snapshot => snapshot.KgpPlacements.Count == 1 &&
+                    snapshot.KgpPlacements[0].Row == 0,
+                TimeSpan.FromSeconds(5),
+                "initial nested KGP placement reached the outer terminal")
+            .Build()
+            .ApplyAsync(outerTerminal, TestContext.Current.CancellationToken);
+
+        state.MoveDown = true;
+        innerApp!.Invalidate();
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(
+                snapshot => snapshot.KgpPlacements.Count == 1 &&
+                    snapshot.KgpPlacements[0].Row == 1,
+                TimeSpan.FromSeconds(5),
+                "nested KGP placement moved without leaving its old placement")
+            .Build()
+            .ApplyAsync(outerTerminal, TestContext.Current.CancellationToken);
+
+        state.ShowImage = false;
+        innerApp.Invalidate();
+        await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(
+                snapshot => snapshot.KgpPlacements.Count == 0 &&
+                    snapshot.ContainsText("gone"),
+                TimeSpan.FromSeconds(5),
+                "nested KGP placement was deleted without leaving a ghost")
+            .Build()
+            .ApplyAsync(outerTerminal, TestContext.Current.CancellationToken);
+
+        innerApp.RequestStop();
+        outerApp!.RequestStop();
+        await Task.WhenAll(innerRunTask, outerRunTask);
+    }
+
+    [TestMethod]
+    public async Task Render_TwoChildrenReuseImageId_HostImagesRemainDistinct()
+    {
+        using var firstWorkload = new Hex1bAppWorkloadAdapter();
+        using var firstTerminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(firstWorkload)
+            .WithDimensions(4, 2)
+            .WithTerminalWidget(out var firstHandle)
+            .Build();
+        using var secondWorkload = new Hex1bAppWorkloadAdapter();
+        using var secondTerminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(secondWorkload)
+            .WithDimensions(4, 2)
+            .WithTerminalWidget(out var secondHandle)
+            .Build();
+        var firstNode = CreateNode(firstHandle, new Rect(0, 0, 4, 2));
+        var secondNode = CreateNode(secondHandle, new Rect(4, 0, 4, 2));
+        var context = CreateContext(8, 2, out var registry);
+
+        firstNode.Render(context);
+        secondNode.Render(context);
+        var firstApplied = firstTerminal.ApplyTokensWithImpacts(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildTransmitAndDisplayCommand(
+                imageId: 1,
+                width: 2,
+                height: 2,
+                displayColumns: 1,
+                displayRows: 1,
+                quiet: 2,
+                fillByte: 0x11)));
+        var secondApplied = secondTerminal.ApplyTokensWithImpacts(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildTransmitAndDisplayCommand(
+                imageId: 1,
+                width: 2,
+                height: 2,
+                displayColumns: 1,
+                displayRows: 1,
+                quiet: 2,
+                fillByte: 0x22)));
+        await firstHandle.WriteOutputWithImpactsAsync(firstApplied);
+        await secondHandle.WriteOutputWithImpactsAsync(secondApplied);
+
+        firstNode.Render(context);
+        secondNode.Render(context);
+
+        Assert.HasCount(2, registry.Images);
+        Assert.AreEqual(0, registry.Images[0].AbsoluteX);
+        Assert.AreEqual(4, registry.Images[1].AbsoluteX);
+        Assert.AreNotEqual(registry.Images[0].Data.ImageId, registry.Images[1].Data.ImageId);
+    }
+
+    [TestMethod]
+    public async Task NestedHex1bApp_NonKgpParent_RendersFallback()
+    {
+        Hex1bApp? innerApp = null;
+        await using var innerTerminal = Hex1bTerminal.CreateBuilder()
+            .WithHex1bApp(
+                _ => { },
+                app =>
+                {
+                    innerApp = app;
+                    return _ => new KgpImageWidget(
+                        KgpTestHelper.CreatePixelData(2, 2),
+                        2,
+                        2,
+                        new TextBlockWidget("fallback"));
+                })
+            .WithDimensions(8, 3)
+            .WithTerminalWidget(out var handle)
+            .Build();
+
+        Hex1bApp? outerApp = null;
+        await using var outerTerminal = Hex1bTerminal.CreateBuilder()
+            .WithHex1bApp(
+                _ => { },
+                app =>
+                {
+                    outerApp = app;
+                    return _ => new TerminalWidget(handle)
+                        .Width(SizeHint.Fixed(8))
+                        .Height(SizeHint.Fixed(3));
+                })
+            .WithHeadless(new TerminalCapabilities { SupportsKgp = false })
+            .WithDimensions(8, 3)
+            .Build();
+
+        var outerRunTask = outerTerminal.RunAsync(TestContext.Current.CancellationToken);
+        var innerRunTask = innerTerminal.RunAsync(TestContext.Current.CancellationToken);
+        using var snapshot = await new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(
+                current => current.ContainsText("fallback"),
+                TimeSpan.FromSeconds(5),
+                "nested app rendered its non-KGP fallback")
+            .Build()
+            .ApplyWithCaptureAsync(outerTerminal, TestContext.Current.CancellationToken);
+
+        Assert.IsFalse(handle.Capabilities.SupportsKgp);
+        Assert.IsEmpty(snapshot.KgpPlacements);
+
+        innerApp!.RequestStop();
+        outerApp!.RequestStop();
+        await Task.WhenAll(innerRunTask, outerRunTask);
+    }
+
+    private static TerminalNode CreateNode(TerminalWidgetHandle handle, Rect bounds)
+    {
+        var node = new TerminalNode { Handle = handle };
+        node.SetInvalidateCallback(() => { });
+        node.Bind();
+        node.Arrange(bounds);
+        return node;
+    }
+
+    private static SurfaceRenderContext CreateContext(
+        int width,
+        int height,
+        out KgpImageRegistry registry)
+    {
+        registry = new KgpImageRegistry();
+        var context = new SurfaceRenderContext(
+            new Surface(width, height, new CellMetrics(10, 20)))
+        {
+            CellMetrics = new CellMetrics(10, 20),
+            KgpRegistry = registry,
+            CachingEnabled = false,
+        };
+        context.SetCapabilities(KgpCapabilities);
+        return context;
+    }
+
+    private sealed class NestedKgpState
+    {
+        private int _showImage = 1;
+        private int _moveDown;
+
+        public bool ShowImage
+        {
+            get => Volatile.Read(ref _showImage) != 0;
+            set => Volatile.Write(ref _showImage, value ? 1 : 0);
+        }
+
+        public bool MoveDown
+        {
+            get => Volatile.Read(ref _moveDown) != 0;
+            set => Volatile.Write(ref _moveDown, value ? 1 : 0);
+        }
+    }
+
+    private sealed class RecordingWorkloadAdapter : IHex1bTerminalWorkloadAdapter
+    {
+        private readonly Queue<byte[]> _responses = new();
+        private readonly object _lock = new();
+
+        public event Action? Disconnected
+        {
+            add { }
+            remove { }
+        }
+
+        public ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(CancellationToken ct = default)
+            => ValueTask.FromResult(ReadOnlyMemory<byte>.Empty);
+
+        public ValueTask WriteInputAsync(
+            ReadOnlyMemory<byte> data,
+            CancellationToken ct = default)
+        {
+            lock (_lock)
+            {
+                _responses.Enqueue(data.ToArray());
+            }
+
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask ResizeAsync(
+            int width,
+            int height,
+            CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync()
+            => ValueTask.CompletedTask;
+
+        public string ReadResponse()
+        {
+            byte[]? response = null;
+            var received = SpinWait.SpinUntil(
+                () =>
+                {
+                    lock (_lock)
+                    {
+                        return _responses.TryDequeue(out response);
+                    }
+                },
+                TimeSpan.FromSeconds(1));
+
+            Assert.IsTrue(received, "Expected a KGP protocol response.");
+            return Encoding.UTF8.GetString(response!);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- backport #426 onto `release/0.166`
- propagate host Kitty Graphics Protocol capabilities and cell metrics into embedded terminals
- translate and clip nested KGP placements through `TerminalWidget` bounds
- preserve nested placement lifecycle, format, crop, z-index, and pixel-offset behavior

## Backport
Cherry-picked squash merge commit `3f2fe24ca4bd03e9312431473451b95d212ff17a` without conflicts.

## Validation
- `dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj --filter "FullyQualifiedName~TerminalWidgetKgpTests"` — 11 passed