### PR TITLE
Add incremental Sixel grammar and geometry parser

### DIFF
--- a/docs/sixel-terminal-behavior.md
+++ b/docs/sixel-terminal-behavior.md
@@ -238,6 +238,7 @@ The terminal-first demo sends independently authored raw Sixel bytes through
 
 ```bash
 dotnet run --project samples/SixelTerminalDemo
+dotnet run --project samples/SixelTerminalDemo -- --scene "Declared extent"
 dotnet run --project samples/SixelTerminalDemo -- --headless
 ```
 

--- a/docs/sixel-terminal-behavior.md
+++ b/docs/sixel-terminal-behavior.md
@@ -63,11 +63,10 @@ native terminal.
 | Headless | Internal terminal model | Incremental byte framer | No native display dependency; framing and dispatch still occur before text decoding |
 
 The framer bounds retained DCS content to 1 MiB by default. It continues
-counting and scanning for cancellation or ST after that limit, but reports a
-retention-limit outcome and does not claim Sixel dispatch success. This stage
-only validates the bounded DCS introducer (private marker, parameters,
-intermediates, and final byte). Complete Sixel grammar and geometry remain
-owned by [#447](https://github.com/mitchdenny/hex1b/issues/447).
+counting and scanning for cancellation or ST after that limit. Its incremental
+Sixel observer also continues bounded grammar and geometry parsing, but reports
+a limit-downgraded outcome and stops retaining raster command events. The
+original bytes still flow to native presentations before either parser runs.
 
 ## Grammar and raster model
 
@@ -108,10 +107,10 @@ of the terminal contract.
 
 | Behavior | DEC and reference terminals | Hex1b default | Status or unresolved work |
 |---|---|---|---|
-| `Pan`/`Pad` override | DECGRA aspect overrides the `P1` macro | Last valid DECGRA aspect controls the sequence | [#447](https://github.com/mitchdenny/hex1b/issues/447) |
-| `Ph`/`Pv` orientation | `Ph` is width and `Pv` is height | Horizontal then vertical, without transposition | Current defect captured for #447 |
-| Declared extent | Allocation hint, not a clipping rectangle | Final extent is the maximum of declared and painted extents | [#447](https://github.com/mitchdenny/hex1b/issues/447) |
-| Partial final band | Raster height may end within a six-row band | Preserve the declared or painted pixel extent; round only when converting to cells | [#447](https://github.com/mitchdenny/hex1b/issues/447) and [#449](https://github.com/mitchdenny/hex1b/issues/449) |
+| `Pan`/`Pad` override | DECGRA aspect overrides the `P1` macro | Last valid DECGRA aspect controls the sequence | Active incremental parser tests |
+| `Ph`/`Pv` orientation | `Ph` is width and `Pv` is height | Horizontal then vertical, without transposition | Active incremental parser and terminal tests |
+| Declared extent | Allocation hint, not a clipping rectangle | Final extent is the maximum of declared and data/painted extents | Active incremental parser tests |
+| Partial final band | Raster height may end within a six-row band | Preserve the declared pixel extent separately from band-rounded data geometry | Parser model active; final raster semantics remain in [#449](https://github.com/mitchdenny/hex1b/issues/449) |
 | Pathological ratios/extents | Modern terminals impose implementation bounds | Enforce centralized limits before allocation and report resource rejection | Exact limits remain an implementation decision |
 | Fractional cell metrics | Modern terminals can report non-integral pixel metrics | Retain the best available metric and apply deterministic outward rounding for occupied cells | Harness records fractional width now |
 

--- a/samples/SixelTerminalDemo/Program.cs
+++ b/samples/SixelTerminalDemo/Program.cs
@@ -21,7 +21,16 @@ var capabilities = new TerminalCapabilities
     CellPixelHeight = 20,
 };
 
-var chunks = BuildDemoOutput(fixtures, includeTransportScenes: sceneFilter is null);
+var modelDescriptions = new string[fixtures.Count];
+for (var index = 0; index < fixtures.Count; index++)
+{
+    modelDescriptions[index] = await InspectModelAsync(fixtures[index]);
+}
+
+var chunks = BuildDemoOutput(
+    fixtures,
+    modelDescriptions,
+    includeTransportScenes: sceneFilter is null);
 var workload = new DemoWorkloadAdapter(chunks);
 IHex1bTerminalPresentationAdapter presentation = headless
     ? new HeadlessPresentationAdapter(80, 24, capabilities)
@@ -52,16 +61,16 @@ if (headless)
     Console.WriteLine($"  cell metrics: {snapshot.CellPixelWidth}x{snapshot.CellPixelHeight}px");
     Console.WriteLine();
     Console.WriteLine("Deterministic grammar and geometry scenes:");
-    foreach (var fixture in fixtures)
+    for (var index = 0; index < fixtures.Count; index++)
     {
-        var model = await InspectModelAsync(fixture);
-        Console.WriteLine($"  {fixture.Name}: {model}");
+        Console.WriteLine($"  {fixtures[index].Name}: {modelDescriptions[index]}");
     }
     Console.WriteLine("Run without --headless in a native Sixel terminal to inspect the presentation outcome.");
 }
 
 static IReadOnlyList<byte[]> BuildDemoOutput(
     IReadOnlyList<RawSixelFixture> fixtures,
+    IReadOnlyList<string> modelDescriptions,
     bool includeTransportScenes)
 {
     var chunks = new List<byte[]>
@@ -70,9 +79,11 @@ static IReadOnlyList<byte[]> BuildDemoOutput(
         Encoding.ASCII.GetBytes("Fixtures use standard ESC P ... ESC \\\\ framing; no SixelWidget or encoder.\r\n\r\n"),
     };
 
-    foreach (var fixture in fixtures)
+    for (var index = 0; index < fixtures.Count; index++)
     {
+        var fixture = fixtures[index];
         chunks.Add(Encoding.ASCII.GetBytes($"[{fixture.Name}] Expected: {fixture.Expected}\r\n"));
+        chunks.Add(Encoding.ASCII.GetBytes($"Model: {modelDescriptions[index]}\r\n"));
         chunks.Add(fixture.StandardDcsBytes);
         chunks.Add(Encoding.ASCII.GetBytes("\r\n\r\n"));
     }

--- a/samples/SixelTerminalDemo/Program.cs
+++ b/samples/SixelTerminalDemo/Program.cs
@@ -35,10 +35,17 @@ await terminal.RunAsync();
 if (headless)
 {
     using var snapshot = terminal.CreateSnapshot();
-    Console.WriteLine("Hex1b model inspection (current implementation):");
+    Console.WriteLine("Hex1b authoritative Sixel model inspection:");
     Console.WriteLine($"  tracked Sixel origins: {CountSixelOrigins(snapshot)}");
     Console.WriteLine($"  cursor: ({snapshot.CursorX}, {snapshot.CursorY})");
     Console.WriteLine($"  cell metrics: {snapshot.CellPixelWidth}x{snapshot.CellPixelHeight}px");
+    Console.WriteLine();
+    Console.WriteLine("Deterministic grammar and geometry scenes:");
+    foreach (var fixture in RawSixelFixtures.All)
+    {
+        var model = await InspectModelAsync(fixture);
+        Console.WriteLine($"  {fixture.Name}: {model}");
+    }
     Console.WriteLine("Run without --headless in a native Sixel terminal to inspect the presentation outcome.");
 }
 
@@ -79,8 +86,52 @@ static IReadOnlyList<byte[]> BuildDemoOutput()
     chunks.Add(Encoding.ASCII.GetBytes("\r\n\r\n"));
 
     chunks.Add(Encoding.ASCII.GetBytes(
-        "Stage 2 note: framing is byte-oriented and bounded; Sixel grammar remains owned by #447.\r\n"));
+        "Stage 3: one incremental parser owns Sixel grammar, geometry, palette metadata, and outcomes.\r\n"));
     return chunks;
+}
+
+static async Task<string> InspectModelAsync(RawSixelFixture fixture)
+{
+    var capabilities = new TerminalCapabilities
+    {
+        SupportsSixel = true,
+        SupportsTrueColor = true,
+        Supports256Colors = true,
+        CellPixelWidth = 1,
+        CellPixelHeight = 1,
+    };
+    var workload = new DemoWorkloadAdapter([fixture.StandardDcsBytes]);
+    await using var terminal = Hex1bTerminal.CreateBuilder()
+        .WithWorkload(workload)
+        .WithPresentation(new HeadlessPresentationAdapter(80, 24, capabilities))
+        .WithDimensions(80, 24)
+        .Build();
+    await terminal.RunAsync();
+
+    using var snapshot = terminal.CreateSnapshot();
+    for (var y = 0; y < snapshot.Height; y++)
+    {
+        for (var x = 0; x < snapshot.Width; x++)
+        {
+            var sixel = snapshot.GetCell(x, y).SixelData;
+            if (sixel is null)
+            {
+                continue;
+            }
+
+            var raster = sixel.GetPixels();
+            var rasterDescription = raster is null
+                ? "metadata-only"
+                : $"retained raster {raster.Width}x{raster.Height}";
+            var declaredDescription = sixel.PixelWidth > 0 && sixel.PixelHeight > 0
+                ? $"declared {sixel.PixelWidth}x{sixel.PixelHeight}px"
+                : "no declared extent";
+            return $"{declaredDescription}, logical geometry " +
+                $"{sixel.WidthInCells}x{sixel.HeightInCells}px, {rasterDescription}";
+        }
+    }
+
+    return "no placement";
 }
 
 static void AddChunks(List<byte[]> chunks, byte[] bytes, IReadOnlyList<int> sizes)

--- a/samples/SixelTerminalDemo/Program.cs
+++ b/samples/SixelTerminalDemo/Program.cs
@@ -2,6 +2,16 @@ using System.Text;
 using Hex1b;
 
 var headless = args.Contains("--headless", StringComparer.OrdinalIgnoreCase);
+var sceneFilter = GetOption(args, "--scene");
+var fixtures = sceneFilter is null
+    ? RawSixelFixtures.All
+    : RawSixelFixtures.All
+        .Where(fixture => fixture.Name.Contains(sceneFilter, StringComparison.OrdinalIgnoreCase))
+        .ToArray();
+if (fixtures.Count == 0)
+{
+    throw new ArgumentException($"No Sixel demo scene contains '{sceneFilter}'.", nameof(args));
+}
 var capabilities = new TerminalCapabilities
 {
     SupportsSixel = true,
@@ -11,7 +21,7 @@ var capabilities = new TerminalCapabilities
     CellPixelHeight = 20,
 };
 
-var chunks = BuildDemoOutput();
+var chunks = BuildDemoOutput(fixtures, includeTransportScenes: sceneFilter is null);
 var workload = new DemoWorkloadAdapter(chunks);
 IHex1bTerminalPresentationAdapter presentation = headless
     ? new HeadlessPresentationAdapter(80, 24, capabilities)
@@ -28,6 +38,7 @@ if (!headless)
     Console.Error.WriteLine(
         "SixelTerminalDemo sends standard ESC-framed, independently authored fixtures through Hex1bTerminal.");
     Console.Error.WriteLine("The labels describe the DEC VT340 model outcome expected from a native Sixel terminal.");
+    Console.Error.WriteLine("Use --scene <name> to run one enlarged fixture, for example --scene \"Declared extent\".");
 }
 
 await terminal.RunAsync();
@@ -41,7 +52,7 @@ if (headless)
     Console.WriteLine($"  cell metrics: {snapshot.CellPixelWidth}x{snapshot.CellPixelHeight}px");
     Console.WriteLine();
     Console.WriteLine("Deterministic grammar and geometry scenes:");
-    foreach (var fixture in RawSixelFixtures.All)
+    foreach (var fixture in fixtures)
     {
         var model = await InspectModelAsync(fixture);
         Console.WriteLine($"  {fixture.Name}: {model}");
@@ -49,7 +60,9 @@ if (headless)
     Console.WriteLine("Run without --headless in a native Sixel terminal to inspect the presentation outcome.");
 }
 
-static IReadOnlyList<byte[]> BuildDemoOutput()
+static IReadOnlyList<byte[]> BuildDemoOutput(
+    IReadOnlyList<RawSixelFixture> fixtures,
+    bool includeTransportScenes)
 {
     var chunks = new List<byte[]>
     {
@@ -57,20 +70,27 @@ static IReadOnlyList<byte[]> BuildDemoOutput()
         Encoding.ASCII.GetBytes("Fixtures use standard ESC P ... ESC \\\\ framing; no SixelWidget or encoder.\r\n\r\n"),
     };
 
-    foreach (var fixture in RawSixelFixtures.All)
+    foreach (var fixture in fixtures)
     {
         chunks.Add(Encoding.ASCII.GetBytes($"[{fixture.Name}] Expected: {fixture.Expected}\r\n"));
         chunks.Add(fixture.StandardDcsBytes);
         chunks.Add(Encoding.ASCII.GetBytes("\r\n\r\n"));
     }
 
-    var framingFixture = RawSixelFixtures.All[0].StandardDcsBytes;
+    if (!includeTransportScenes)
+    {
+        chunks.Add(Encoding.ASCII.GetBytes(
+            "Stage 3: one incremental parser owns Sixel grammar, geometry, palette metadata, and outcomes.\r\n"));
+        return chunks;
+    }
+
+    var framingFixture = fixtures[0].StandardDcsBytes;
     chunks.Add(Encoding.ASCII.GetBytes(
         "[Framing] Two consecutive DCS images with no transport boundary between them.\r\n"));
     chunks.Add(
     [
-        .. RawSixelFixtures.All[0].StandardDcsBytes,
-        .. RawSixelFixtures.All[1].StandardDcsBytes,
+        .. fixtures[0].StandardDcsBytes,
+        .. fixtures[1].StandardDcsBytes,
     ]);
     chunks.Add(Encoding.ASCII.GetBytes("\r\n\r\n"));
 
@@ -81,13 +101,26 @@ static IReadOnlyList<byte[]> BuildDemoOutput()
 
     chunks.Add(Encoding.ASCII.GetBytes(
         "[Native passthrough] One-byte workload reads still form the original image upstream.\r\n"));
-    foreach (var value in RawSixelFixtures.All[3].StandardDcsBytes)
+    foreach (var value in fixtures[3].StandardDcsBytes)
         chunks.Add([value]);
     chunks.Add(Encoding.ASCII.GetBytes("\r\n\r\n"));
 
     chunks.Add(Encoding.ASCII.GetBytes(
         "Stage 3: one incremental parser owns Sixel grammar, geometry, palette metadata, and outcomes.\r\n"));
     return chunks;
+}
+
+static string? GetOption(string[] arguments, string option)
+{
+    for (var index = 0; index < arguments.Length - 1; index++)
+    {
+        if (string.Equals(arguments[index], option, StringComparison.OrdinalIgnoreCase))
+        {
+            return arguments[index + 1];
+        }
+    }
+
+    return null;
 }
 
 static async Task<string> InspectModelAsync(RawSixelFixture fixture)

--- a/samples/SixelTerminalDemo/RawSixelFixtures.cs
+++ b/samples/SixelTerminalDemo/RawSixelFixtures.cs
@@ -17,35 +17,39 @@ internal static class RawSixelFixtures
     [
         new(
             "Solid RGB block",
-            "a 24x12 red rectangle",
-            "0;0q\"1;1;24;12#1;2;100;0;0#1!24~-!24~"),
+            "a 240x60 red rectangle (about 24x3 cells with 10x20 metrics)",
+            "0;0q\"1;1;240;60#1;2;100;0;0#1" +
+                RepeatBands("!240~", 10)),
         new(
             "Two-color carriage return",
-            "green top rows and red bottom rows overprinted in the same sixel band",
-            "0;1q\"1;1;24;6#1;2;100;0;0#1!24w$#2;2;0;100;0#2!24B"),
+            "a 240x36 block with obvious green/red stripes overprinted using DECGCR",
+            "0;1q\"1;1;240;36#1;2;100;0;0#2;2;0;100;0" +
+                RepeatBands("#1!240w$#2!240B", 6)),
         new(
             "HLS color",
-            "a 24x6 blue block defined with HLS coordinates",
-            "0;0q\"1;1;24;6#3;1;0;50;100#3!24~"),
+            "a 240x24 block defined with HLS coordinates",
+            "0;0q\"1;1;240;24#3;1;0;50;100#3" +
+                RepeatBands("!240~", 4)),
         new(
             "Transparent background",
-            "red top pixels with untouched background below",
-            "0;1q\"1;1;24;6#1;2;100;0;0#1!24@"),
+            "a 240x24 field with thick red rules and transparent gaps",
+            "0;1q\"1;1;240;24#1;2;100;0;0#1" +
+                RepeatBands("!240N", 4)),
         new(
             "DEC default aspect macro",
-            "omitted P1 selects 2:1 pixels; four complete columns have 4x12 logical geometry",
-            "q#1;2;100;0;0#1!4~"),
+            "omitted P1 selects 2:1 pixels; 120 complete columns have 120x12 logical geometry",
+            "q#1;2;100;0;0#1!120~"),
         new(
             "Declared extent is a hint",
-            "a 2x3 declaration grows to the 4x12 data and painted extent",
-            "7q\"1;1;2;3#2;2;0;100;0#2!4~-!4~"),
+            "a 4x4 declaration grows to the 160x48 data and painted extent",
+            "7q\"1;1;4;4#2;2;0;100;0#2" +
+                RepeatBands("!160~", 8)),
         new(
             "Transparent geometry",
-            "four transparent columns advance data geometry without painted bounds",
-            "7;1q????"),
-        new(
-            "Metadata-only raster",
-            "DECGRA and DECGCI retain a 10x7 logical canvas without raster data",
-            "7;1;42q\"1;1;10;7#9;2;25;50;75"),
+            "240 transparent columns set geometry; DECGCR then paints only the leftmost 80",
+            "7;1q!240?$#1;2;100;0;100#1!80~"),
     ];
+
+    private static string RepeatBands(string band, int count) =>
+        string.Join('-', Enumerable.Repeat(band, count));
 }

--- a/samples/SixelTerminalDemo/RawSixelFixtures.cs
+++ b/samples/SixelTerminalDemo/RawSixelFixtures.cs
@@ -41,9 +41,9 @@ internal static class RawSixelFixtures
             "q#1;2;100;0;0#1!120~"),
         new(
             "Declared extent is a hint",
-            "a 4x4 declaration grows to the 160x48 data and painted extent",
-            "7q\"1;1;4;4#2;2;0;100;0#2" +
-                RepeatBands("!160~", 8)),
+            "an 80x24 green declared region is followed by red overflow; the model grows to 240x60",
+            "7q\"1;1;80;24#1;2;100;0;0#2;2;0;100;0" +
+                RepeatBands("#2!80~#1!160~", 10)),
         new(
             "Transparent geometry",
             "240 transparent columns set geometry; DECGCR then paints only the leftmost 80",

--- a/samples/SixelTerminalDemo/RawSixelFixtures.cs
+++ b/samples/SixelTerminalDemo/RawSixelFixtures.cs
@@ -31,5 +31,21 @@ internal static class RawSixelFixtures
             "Transparent background",
             "red top pixels with untouched background below",
             "0;1q\"1;1;24;6#1;2;100;0;0#1!24@"),
+        new(
+            "DEC default aspect macro",
+            "omitted P1 selects 2:1 pixels; four complete columns have 4x12 logical geometry",
+            "q#1;2;100;0;0#1!4~"),
+        new(
+            "Declared extent is a hint",
+            "a 2x3 declaration grows to the 4x12 data and painted extent",
+            "7q\"1;1;2;3#2;2;0;100;0#2!4~-!4~"),
+        new(
+            "Transparent geometry",
+            "four transparent columns advance data geometry without painted bounds",
+            "7;1q????"),
+        new(
+            "Metadata-only raster",
+            "DECGRA and DECGCI retain a 10x7 logical canvas without raster data",
+            "7;1;42q\"1;1;10;7#9;2;25;50;75"),
     ];
 }

--- a/src/Hex1b/Automation/SixelDecoder.cs
+++ b/src/Hex1b/Automation/SixelDecoder.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+using Hex1b.Sixel;
 
 namespace Hex1b.Automation;
 
@@ -6,222 +6,122 @@ namespace Hex1b.Automation;
 /// Decodes Sixel graphics data to raw pixel arrays for SVG rendering.
 /// </summary>
 /// <remarks>
-/// <para>
-/// Sixel is a graphics format where each "sixel" represents a column of 6 vertical pixels.
-/// The data includes a color palette definition followed by sixel character data.
-/// </para>
-/// <para>
-/// This decoder is used to convert sixel data embedded in terminal snapshots
-/// into images that can be embedded in SVG output for visual testing.
-/// </para>
+/// This compatibility decoder consumes the authoritative incremental Sixel
+/// parser result. It does not independently scan raw payload text.
 /// </remarks>
 public static class SixelDecoder
 {
+    private const int MaximumDecodedPixels = 16 * 1024 * 1024;
+    private const long MaximumRasterOperations = MaximumDecodedPixels * 4L;
+
     /// <summary>
     /// Decodes a Sixel DCS payload to raw RGBA pixel data.
     /// </summary>
     /// <param name="payload">The Sixel payload (including or excluding DCS wrapper).</param>
     /// <param name="cellWidth">The width of a terminal cell in pixels.</param>
     /// <param name="cellHeight">The height of a terminal cell in pixels.</param>
-    /// <returns>Decoded image with RGBA pixel data, or null if decoding fails.</returns>
+    /// <returns>Decoded image with RGBA pixel data, or null if decoding cannot be retained safely.</returns>
     public static SixelImage? Decode(string payload, int cellWidth = 9, int cellHeight = 18)
     {
         if (string.IsNullOrEmpty(payload))
-            return null;
-
-        try
         {
-            // Strip DCS wrapper if present: ESC P ... q <data> ESC \
-            var sixelData = StripDcsWrapper(payload);
-            if (string.IsNullOrEmpty(sixelData))
+            return null;
+        }
+
+        _ = cellWidth;
+        _ = cellHeight;
+        return Decode(SixelParser.ParsePayload(payload));
+    }
+
+    internal static SixelImage? Decode(SixelParseResult result)
+    {
+        if (!result.CommandsComplete ||
+            result.Outcome is SixelParseOutcome.Cancelled or
+                SixelParseOutcome.Malformed or
+                SixelParseOutcome.Rejected)
+        {
+            return null;
+        }
+
+        var width = result.DeclaredExtent.Width;
+        var height = result.DeclaredExtent.Height;
+        var hasData = false;
+        long rasterOperations = 0;
+        foreach (var command in result.Commands)
+        {
+            if (command.Kind != SixelCommandKind.Data)
+            {
+                continue;
+            }
+
+            hasData = true;
+            width = Math.Max(width, SaturatingAdd(command.X, command.RepeatCount));
+            height = Math.Max(height, SaturatingMultiply(SaturatingAdd(command.Band, 1), 6));
+            rasterOperations += (long)command.RepeatCount *
+                System.Numerics.BitOperations.PopCount((uint)command.Value);
+            if (rasterOperations > MaximumRasterOperations)
+            {
                 return null;
-
-            // Parse the sixel data
-            return ParseSixelData(sixelData, cellWidth, cellHeight);
+            }
         }
-        catch
+
+        if (!hasData || width <= 0 || height <= 0)
         {
-            // If parsing fails, return null (graceful degradation)
             return null;
         }
-    }
 
-    private static string StripDcsWrapper(string payload)
-    {
-        // DCS starts with ESC P or 0x90, ends with ESC \ or 0x9C
-        var start = payload.IndexOf('q');
-        if (start < 0)
+        var pixelCount = (long)width * height;
+        if (pixelCount > MaximumDecodedPixels)
         {
-            // No 'q' found - might be raw sixel data without header
-            return payload;
+            return null;
         }
 
-        // Find the end - ESC \ (0x1B 0x5C) or ST (0x9C)
-        var end = payload.IndexOf("\x1b\\", start, StringComparison.Ordinal);
-        if (end < 0)
-        {
-            end = payload.IndexOf('\x9C', start);
-        }
-        if (end < 0)
-        {
-            end = payload.Length;
-        }
-
-        return payload.Substring(start + 1, end - start - 1);
-    }
-
-    private static SixelImage? ParseSixelData(string data, int cellWidth, int cellHeight)
-    {
-        // Parse color palette and sixel data
+        var pixels = new byte[checked((int)pixelCount * 4)];
         var palette = new Dictionary<int, (byte R, byte G, byte B)>();
-        
-        // Default palette (standard 16 colors)
         InitializeDefaultPalette(palette);
+        var selectedColor = 0;
 
-        // Temporary storage for sixel rows
-        // Each sixel represents 6 vertical pixels
-        var rows = new List<List<int>>(); // List of rows, each row is list of color indices
-        var currentRow = new List<int>();
-        var currentX = 0;
-        var maxWidth = 0;
-        var currentColorIndex = 0;
-
-        var i = 0;
-        while (i < data.Length)
+        foreach (var command in result.Commands)
         {
-            var ch = data[i];
-
-            if (ch == '#')
+            if (command.Kind == SixelCommandKind.Palette &&
+                command.Palette is { } paletteCommand)
             {
-                // Color definition or selection: #<colorIndex>[;<type>;<p1>;<p2>;<p3>]
-                i++;
-                var colorData = ParseColorCommand(data, ref i);
-                if (colorData.HasValue)
+                selectedColor = paletteCommand.Register;
+                if (paletteCommand.IsDefinition)
                 {
-                    var (colorIndex, r, g, b, isDefinition) = colorData.Value;
-                    if (isDefinition)
+                    palette[paletteCommand.Register] = ConvertColor(paletteCommand);
+                }
+                continue;
+            }
+
+            if (command.Kind != SixelCommandKind.Data ||
+                command.Value == 0 ||
+                !palette.TryGetValue(selectedColor, out var color))
+            {
+                continue;
+            }
+
+            var endX = Math.Min(width, SaturatingAdd(command.X, command.RepeatCount));
+            for (var x = command.X; x < endX; x++)
+            {
+                for (var bit = 0; bit < 6; bit++)
+                {
+                    if ((command.Value & (1 << bit)) == 0)
                     {
-                        palette[colorIndex] = (r, g, b);
+                        continue;
                     }
-                    currentColorIndex = colorIndex;
-                }
-            }
-            else if (ch == '!')
-            {
-                // Repeat: !<count><sixel>
-                i++;
-                var (count, sixelChar) = ParseRepeat(data, ref i);
-                for (int j = 0; j < count; j++)
-                {
-                    while (rows.Count < 6)
-                        rows.Add([]);
-                    
-                    var sixelValue = sixelChar - '?';
-                    for (int bit = 0; bit < 6; bit++)
+
+                    var y = SaturatingAdd(SaturatingMultiply(command.Band, 6), bit);
+                    if (y >= height)
                     {
-                        // Use same logic as single char: current band (last 6 rows)
-                        var rowIndex = rows.Count - 6 + bit;
-                        if (rowIndex < 0) continue;
-                        
-                        var row = rows[rowIndex];
-                        while (row.Count <= currentX)
-                            row.Add(-1); // Transparent
-                        
-                        if ((sixelValue & (1 << bit)) != 0)
-                        {
-                            row[currentX] = currentColorIndex;
-                        }
+                        continue;
                     }
-                    currentX++;
-                    maxWidth = Math.Max(maxWidth, currentX);
-                }
-            }
-            else if (ch == '$')
-            {
-                // Carriage return - go back to start of current band
-                currentX = 0;
-                i++;
-            }
-            else if (ch == '-')
-            {
-                // Graphics new line - move to next band of 6 rows
-                currentX = 0;
-                // Pad existing rows and start new band
-                for (int j = 0; j < 6; j++)
-                {
-                    rows.Add([]);
-                }
-                i++;
-            }
-            else if (ch == '"')
-            {
-                // Raster attributes: "Pan;Pad;Ph;Pv - skip for now
-                i++;
-                while (i < data.Length && (char.IsDigit(data[i]) || data[i] == ';'))
-                    i++;
-            }
-            else if (ch >= '?' && ch <= '~')
-            {
-                // Sixel character (value = ch - 63)
-                while (rows.Count < 6)
-                    rows.Add([]);
-                
-                var sixelValue = ch - '?';
-                for (int bit = 0; bit < 6; bit++)
-                {
-                    var rowIndex = rows.Count - 6 + bit;
-                    if (rowIndex < 0) continue;
-                    
-                    var row = rows[rowIndex];
-                    while (row.Count <= currentX)
-                        row.Add(-1); // Transparent
-                    
-                    if ((sixelValue & (1 << bit)) != 0)
-                    {
-                        row[currentX] = currentColorIndex;
-                    }
-                }
-                currentX++;
-                maxWidth = Math.Max(maxWidth, currentX);
-                i++;
-            }
-            else
-            {
-                // Unknown character, skip
-                i++;
-            }
-        }
 
-        if (maxWidth == 0 || rows.Count == 0)
-            return null;
-
-        // Convert to RGBA pixels
-        var height = rows.Count;
-        var width = maxWidth;
-        var pixels = new byte[width * height * 4];
-
-        for (int y = 0; y < height; y++)
-        {
-            var row = y < rows.Count ? rows[y] : null;
-            for (int x = 0; x < width; x++)
-            {
-                var pixelIndex = (y * width + x) * 4;
-                var colorIndex = (row != null && x < row.Count) ? row[x] : -1;
-
-                if (colorIndex >= 0 && palette.TryGetValue(colorIndex, out var color))
-                {
+                    var pixelIndex = checked(((y * width) + x) * 4);
                     pixels[pixelIndex] = color.R;
                     pixels[pixelIndex + 1] = color.G;
                     pixels[pixelIndex + 2] = color.B;
-                    pixels[pixelIndex + 3] = 255; // Fully opaque
-                }
-                else
-                {
-                    // Transparent
-                    pixels[pixelIndex] = 0;
-                    pixels[pixelIndex + 1] = 0;
-                    pixels[pixelIndex + 2] = 0;
-                    pixels[pixelIndex + 3] = 0;
+                    pixels[pixelIndex + 3] = 255;
                 }
             }
         }
@@ -229,154 +129,97 @@ public static class SixelDecoder
         return new SixelImage(width, height, pixels);
     }
 
-    private static (int colorIndex, byte r, byte g, byte b, bool isDefinition)? ParseColorCommand(string data, ref int i)
+    private static (byte R, byte G, byte B) ConvertColor(SixelPaletteCommand command)
     {
-        // Parse color index
-        var colorIndexStr = "";
-        while (i < data.Length && char.IsDigit(data[i]))
+        var x = command.X ?? 0;
+        var y = command.Y ?? 0;
+        var z = command.Z ?? 0;
+        return command.ColorSpace switch
         {
-            colorIndexStr += data[i++];
-        }
-
-        if (!int.TryParse(colorIndexStr, out var colorIndex))
-            return null;
-
-        // Check if this is a definition (has semicolons)
-        if (i < data.Length && data[i] == ';')
-        {
-            i++; // Skip first semicolon
-            
-            // Parse color type (1 = HLS, 2 = RGB)
-            var typeStr = "";
-            while (i < data.Length && char.IsDigit(data[i]))
-            {
-                typeStr += data[i++];
-            }
-            
-            if (!int.TryParse(typeStr, out var colorType))
-                return (colorIndex, 0, 0, 0, false); // Just selection
-            
-            if (i < data.Length && data[i] == ';') i++;
-            
-            // Parse color values
-            var values = new List<int>();
-            for (int v = 0; v < 3; v++)
-            {
-                var valStr = "";
-                while (i < data.Length && char.IsDigit(data[i]))
-                {
-                    valStr += data[i++];
-                }
-                if (int.TryParse(valStr, out var val))
-                    values.Add(val);
-                else
-                    values.Add(0);
-                
-                if (i < data.Length && data[i] == ';') i++;
-            }
-
-            if (colorType == 2 && values.Count >= 3)
-            {
-                // RGB: values are 0-100 percentages
-                var r = (byte)(values[0] * 255 / 100);
-                var g = (byte)(values[1] * 255 / 100);
-                var b = (byte)(values[2] * 255 / 100);
-                return (colorIndex, r, g, b, true);
-            }
-            else if (colorType == 1 && values.Count >= 3)
-            {
-                // HLS: convert to RGB
-                var (r, g, b) = HlsToRgb(values[0], values[1], values[2]);
-                return (colorIndex, r, g, b, true);
-            }
-            
-            return (colorIndex, 0, 0, 0, false);
-        }
-
-        return (colorIndex, 0, 0, 0, false); // Just selection, no definition
+            SixelColorSpace.Rgb => (
+                PercentageToByte(x),
+                PercentageToByte(y),
+                PercentageToByte(z)),
+            SixelColorSpace.Hls => HlsToRgb(x, y, z),
+            _ => (0, 0, 0),
+        };
     }
 
-    private static (int count, char sixelChar) ParseRepeat(string data, ref int i)
-    {
-        var countStr = "";
-        while (i < data.Length && char.IsDigit(data[i]))
-        {
-            countStr += data[i++];
-        }
-
-        var count = 1;
-        if (!string.IsNullOrEmpty(countStr))
-        {
-            int.TryParse(countStr, out count);
-        }
-
-        char sixelChar = '?'; // Default to empty sixel
-        if (i < data.Length && data[i] >= '?' && data[i] <= '~')
-        {
-            sixelChar = data[i++];
-        }
-
-        return (count, sixelChar);
-    }
+    private static byte PercentageToByte(int value) =>
+        (byte)(Math.Clamp(value, 0, 100) * 255 / 100);
 
     private static void InitializeDefaultPalette(Dictionary<int, (byte R, byte G, byte B)> palette)
     {
-        // VT340 default 16-color palette (approximate)
-        palette[0] = (0, 0, 0);       // Black
-        palette[1] = (51, 51, 255);   // Blue
-        palette[2] = (255, 51, 51);   // Red
-        palette[3] = (51, 255, 51);   // Green
-        palette[4] = (255, 51, 255);  // Magenta
-        palette[5] = (51, 255, 255);  // Cyan
-        palette[6] = (255, 255, 51);  // Yellow
-        palette[7] = (250, 250, 250); // White
-        palette[8] = (128, 128, 128); // Gray
-        palette[9] = (102, 102, 255); // Light blue
-        palette[10] = (255, 102, 102); // Light red
-        palette[11] = (102, 255, 102); // Light green
-        palette[12] = (255, 102, 255); // Light magenta
-        palette[13] = (102, 255, 255); // Light cyan
-        palette[14] = (255, 255, 102); // Light yellow
-        palette[15] = (255, 255, 255); // Bright white
+        palette[0] = (0, 0, 0);
+        palette[1] = (51, 51, 255);
+        palette[2] = (255, 51, 51);
+        palette[3] = (51, 255, 51);
+        palette[4] = (255, 51, 255);
+        palette[5] = (51, 255, 255);
+        palette[6] = (255, 255, 51);
+        palette[7] = (250, 250, 250);
+        palette[8] = (128, 128, 128);
+        palette[9] = (102, 102, 255);
+        palette[10] = (255, 102, 102);
+        palette[11] = (102, 255, 102);
+        palette[12] = (255, 102, 255);
+        palette[13] = (102, 255, 255);
+        palette[14] = (255, 255, 102);
+        palette[15] = (255, 255, 255);
     }
 
     private static (byte R, byte G, byte B) HlsToRgb(int h, int l, int s)
     {
-        // HLS values are 0-360 for H, 0-100 for L and S
-        var hue = h / 360.0;
-        var lightness = l / 100.0;
-        var saturation = s / 100.0;
-
-        double r, g, b;
+        var hue = Math.Clamp(h, 0, 360) / 360.0;
+        var lightness = Math.Clamp(l, 0, 100) / 100.0;
+        var saturation = Math.Clamp(s, 0, 100) / 100.0;
 
         if (saturation == 0)
         {
-            r = g = b = lightness;
-        }
-        else
-        {
-            var q = lightness < 0.5
-                ? lightness * (1 + saturation)
-                : lightness + saturation - lightness * saturation;
-            var p = 2 * lightness - q;
-
-            r = HueToRgb(p, q, hue + 1.0 / 3);
-            g = HueToRgb(p, q, hue);
-            b = HueToRgb(p, q, hue - 1.0 / 3);
+            var component = (byte)(lightness * 255);
+            return (component, component, component);
         }
 
-        return ((byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
+        var q = lightness < 0.5
+            ? lightness * (1 + saturation)
+            : lightness + saturation - lightness * saturation;
+        var p = 2 * lightness - q;
+        return (
+            (byte)(HueToRgb(p, q, hue + (1.0 / 3)) * 255),
+            (byte)(HueToRgb(p, q, hue) * 255),
+            (byte)(HueToRgb(p, q, hue - (1.0 / 3)) * 255));
     }
 
     private static double HueToRgb(double p, double q, double t)
     {
-        if (t < 0) t += 1;
-        if (t > 1) t -= 1;
-        if (t < 1.0 / 6) return p + (q - p) * 6 * t;
-        if (t < 1.0 / 2) return q;
-        if (t < 2.0 / 3) return p + (q - p) * (2.0 / 3 - t) * 6;
+        if (t < 0)
+        {
+            t += 1;
+        }
+        if (t > 1)
+        {
+            t -= 1;
+        }
+        if (t < 1.0 / 6)
+        {
+            return p + (q - p) * 6 * t;
+        }
+        if (t < 1.0 / 2)
+        {
+            return q;
+        }
+        if (t < 2.0 / 3)
+        {
+            return p + (q - p) * (2.0 / 3 - t) * 6;
+        }
         return p;
     }
+
+    private static int SaturatingAdd(int left, int right) =>
+        right <= int.MaxValue - left ? left + right : int.MaxValue;
+
+    private static int SaturatingMultiply(int left, int right) =>
+        left <= int.MaxValue / right ? left * right : int.MaxValue;
 }
 
 /// <summary>

--- a/src/Hex1b/Automation/TerminalRegionSvgExtensions.cs
+++ b/src/Hex1b/Automation/TerminalRegionSvgExtensions.cs
@@ -400,7 +400,7 @@ public static class TerminalRegionSvgExtensions
                     continue;
                 
                 // Decode sixel to image
-                var image = SixelDecoder.Decode(sixelData.Payload, cellWidth, cellHeight);
+                var image = SixelDecoder.Decode(sixelData.ParseResult);
                 if (image == null || image.Width == 0 || image.Height == 0)
                     continue;
                 

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -6,6 +6,7 @@ using System.Threading.Channels;
 using Hex1b.Automation;
 using Hex1b.Input;
 using Hex1b.Reflow;
+using Hex1b.Sixel;
 using Hex1b.Theming;
 using Hex1b.Tokens;
 
@@ -5798,11 +5799,12 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     {
         if (framedDcs is not null && framedDcs.TryGetValue(token, out var framed))
         {
-            if (framed.Status == DcsSequenceStatus.Complete &&
-                !framed.RetentionLimitExceeded &&
-                framed.Introducer.IsSixel)
+            if (!framed.RetentionLimitExceeded &&
+                framed.SixelResult.Outcome is
+                    SixelParseOutcome.Complete or
+                    SixelParseOutcome.LimitDowngraded)
             {
-                ProcessSixelData(token.Payload, impacts);
+                ProcessSixelData(token.Payload, framed.SixelResult, impacts);
             }
 
             return;
@@ -5810,36 +5812,48 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
 
         // Pre-tokenized output owns its token stream and deliberately bypasses raw-byte
         // framing. Parse only its bounded introducer here for equivalent dispatch semantics.
-        var byteCount = Encoding.UTF8.GetByteCount(token.Payload);
-        var retentionLimitExceeded = byteCount > _dcsByteStreamParser.RetentionLimit;
-        var introducer = DcsByteStreamParser.ParseIntroducer(token.Payload.AsSpan());
-        var status = introducer.IsValid
-            ? DcsSequenceStatus.Complete
-            : DcsSequenceStatus.Malformed;
-        RecordDcsFrame(new DcsFrame(
-            status,
-            introducer,
-            ReadOnlyMemory<byte>.Empty,
-            byteCount,
-            retentionLimitExceeded));
+        var payloadBytes = token.TryGetMatchingRawPayload(out var rawPayload)
+            ? rawPayload.ToArray()
+            : SixelParser.EncodePayload(token.Payload);
+        var frame = DcsByteStreamParser.ParseCompleteContent(
+            payloadBytes,
+            _dcsByteStreamParser.RetentionLimit);
+        RecordDcsFrame(frame);
 
-        if (introducer.IsSixel && !retentionLimitExceeded)
+        if (!frame.RetentionLimitExceeded &&
+            frame.SixelResult.Outcome is
+                SixelParseOutcome.Complete or
+                SixelParseOutcome.LimitDowngraded)
         {
-            ProcessSixelData(token.Payload, impacts);
+            ProcessSixelData(token.Payload, frame.SixelResult, impacts);
         }
     }
 
     /// <summary>
     /// Processes Sixel data by creating a tracked object and marking cells.
     /// </summary>
-    private void ProcessSixelData(string sixelPayload, List<CellImpact>? impacts)
+    private void ProcessSixelData(
+        string sixelPayload,
+        SixelParseResult parseResult,
+        List<CellImpact>? impacts)
     {
-        // Estimate the size in cells based on Sixel data
-        // This is approximate - Sixel images can specify dimensions in the data
-        var (widthInCells, heightInCells) = EstimateSixelDimensions(sixelPayload);
+        var pixelWidth = Math.Max(1, parseResult.LogicalCanvasExtent.Width);
+        var pixelHeight = Math.Max(1, parseResult.LogicalCanvasExtent.Height);
+        var cellWidth = Math.Max(1d, Capabilities.EffectiveCellPixelWidth);
+        var cellHeight = Math.Max(1, Capabilities.CellPixelHeight);
+        var widthInCells = Math.Max(
+            1,
+            (int)Math.Min(int.MaxValue, Math.Ceiling(pixelWidth / cellWidth)));
+        var heightInCells = Math.Max(
+            1,
+            (int)Math.Min(int.MaxValue, ((long)pixelHeight + cellHeight - 1) / cellHeight));
 
         // Create or reuse a tracked Sixel object
-        var sixelData = _trackedObjects.GetOrCreateSixel(sixelPayload, widthInCells, heightInCells);
+        var sixelData = _trackedObjects.GetOrCreateSixel(
+            sixelPayload,
+            widthInCells,
+            heightInCells,
+            parseResult);
 
         // Mark cells covered by this Sixel image
         // The first cell gets the tracked object, others just get the Sixel flag
@@ -5873,59 +5887,6 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 }
             }
         }
-    }
-
-    /// <summary>
-    /// Estimates Sixel image dimensions in terminal cells.
-    /// </summary>
-    private (int Width, int Height) EstimateSixelDimensions(string sixelPayload)
-    {
-        // Default dimensions if we can't parse
-        int width = 1;
-        int height = 1;
-        
-        // Get cell pixel dimensions from capabilities
-        var cellWidth = Capabilities.CellPixelWidth;
-        var cellHeight = Capabilities.CellPixelHeight;
-
-        // Try to find "width;height in the sixel raster attributes
-        // Format: "Pan;Pad;Ph;Pv where Ph = pixel height, Pv = pixel width
-        // This appears after the 'q' and before the first color definition '#'
-        var qIndex = sixelPayload.IndexOf('q');
-        var hashIndex = sixelPayload.IndexOf('#');
-
-        if (qIndex >= 0)
-        {
-            var rasterEnd = hashIndex > qIndex ? hashIndex : sixelPayload.Length;
-            var rasterSection = sixelPayload.Substring(qIndex + 1, Math.Min(50, rasterEnd - qIndex - 1));
-
-            // Look for raster attributes: "Pan;Pad;Ph;Pv
-            var quoteIndex = rasterSection.IndexOf('"');
-            if (quoteIndex >= 0 && quoteIndex + 1 < rasterSection.Length)
-            {
-                var attrStr = rasterSection.Substring(quoteIndex + 1);
-                // Find end of raster attributes - terminated by sixel control chars (not semicolon)
-                var endIndex = attrStr.IndexOfAny(['#', '!', '-', '$', '~', '?']);
-                if (endIndex < 0) endIndex = attrStr.Length;
-                attrStr = attrStr.Substring(0, Math.Min(30, endIndex));
-
-                var parts = attrStr.Split(';');
-                if (parts.Length >= 4)
-                {
-                    // Ph = pixel height, Pv = pixel width
-                    if (int.TryParse(parts[2], out var ph) && int.TryParse(parts[3], out var pv))
-                    {
-                        // Convert pixels to cells using actual cell dimensions
-                        // Round up to ensure the image doesn't get cut off
-                        width = Math.Max(1, (pv + cellWidth - 1) / cellWidth);
-                        height = Math.Max(1, (ph + cellHeight - 1) / cellHeight);
-                    }
-                }
-            }
-        }
-
-        // Clamp to reasonable bounds
-        return (Math.Clamp(width, 1, 200), Math.Clamp(height, 1, 100));
     }
 
     /// <summary>

--- a/src/Hex1b/Sixel/SixelParser.cs
+++ b/src/Hex1b/Sixel/SixelParser.cs
@@ -1,0 +1,824 @@
+using Hex1b.Tokens;
+
+namespace Hex1b.Sixel;
+
+internal enum SixelParseOutcome
+{
+    Complete,
+    Cancelled,
+    Malformed,
+    LimitDowngraded,
+    Rejected,
+}
+
+internal enum SixelBackgroundMode
+{
+    Opaque,
+    Transparent,
+}
+
+internal enum SixelColorSpace
+{
+    Hls = 1,
+    Rgb = 2,
+}
+
+internal enum SixelDiagnosticCode
+{
+    RejectedIntroducer,
+    ExcessiveHeaderParameters,
+    UnsupportedAspectMacro,
+    InvalidByte,
+    IncompleteCommand,
+    ReplacedCommand,
+    ExcessiveCommandParameters,
+    NumericLimitExceeded,
+    GeometrySaturated,
+    InvalidRasterAttributes,
+    InvalidPaletteCommand,
+    MetadataLimitExceeded,
+    CommandRetentionLimitExceeded,
+    UnterminatedSequence,
+}
+
+internal enum SixelCommandKind
+{
+    Data,
+    Palette,
+}
+
+internal readonly record struct SixelPoint(int X, int Y);
+
+internal readonly record struct SixelExtent(int Width, int Height)
+{
+    public static SixelExtent Empty { get; } = new(0, 0);
+}
+
+internal readonly record struct SixelBounds(int X, int Y, int Width, int Height)
+{
+    public static SixelBounds Empty { get; } = new(0, 0, 0, 0);
+
+    public bool IsEmpty => Width == 0 || Height == 0;
+}
+
+internal readonly record struct SixelAspectRatio(int Numerator, int Denominator);
+
+internal readonly record struct SixelHeader(
+    int PixelAspectMacro,
+    int BackgroundSelection,
+    int HorizontalGridSize,
+    SixelAspectRatio AspectRatio,
+    SixelBackgroundMode BackgroundMode);
+
+internal readonly record struct SixelRasterAttributes(
+    int Pan,
+    int Pad,
+    int Ph,
+    int Pv);
+
+internal readonly record struct SixelPaletteCommand(
+    int Register,
+    SixelColorSpace? ColorSpace,
+    int? X,
+    int? Y,
+    int? Z)
+{
+    public bool IsDefinition => ColorSpace is not null;
+}
+
+internal readonly record struct SixelCommand(
+    SixelCommandKind Kind,
+    int X,
+    int Band,
+    int Value,
+    int RepeatCount,
+    SixelPaletteCommand? Palette);
+
+internal readonly record struct SixelDiagnostic(
+    SixelDiagnosticCode Code,
+    long Offset,
+    byte? Command,
+    string Message);
+
+internal sealed record SixelParseResult(
+    SixelHeader Header,
+    SixelRasterAttributes? RasterAttributes,
+    SixelPoint GraphicsCursor,
+    SixelPoint MaximumCommandOrDataPosition,
+    SixelExtent DeclaredExtent,
+    SixelExtent DataExtent,
+    SixelBounds PaintedBounds,
+    SixelExtent LogicalCanvasExtent,
+    int SelectedColorRegister,
+    IReadOnlyList<SixelPaletteCommand> PaletteMutations,
+    IReadOnlyList<SixelCommand> Commands,
+    bool CommandsComplete,
+    SixelParseOutcome Outcome,
+    IReadOnlyList<SixelDiagnostic> Diagnostics)
+{
+    public static SixelParseResult Rejected(
+        DcsIntroducer introducer,
+        DcsSequenceStatus status,
+        bool retentionLimitExceeded)
+    {
+        var outcome = status switch
+        {
+            DcsSequenceStatus.Cancelled => SixelParseOutcome.Cancelled,
+            DcsSequenceStatus.Malformed or DcsSequenceStatus.Unterminated => SixelParseOutcome.Malformed,
+            _ when retentionLimitExceeded => SixelParseOutcome.LimitDowngraded,
+            _ => SixelParseOutcome.Rejected,
+        };
+        var code = status == DcsSequenceStatus.Unterminated
+            ? SixelDiagnosticCode.UnterminatedSequence
+            : SixelDiagnosticCode.RejectedIntroducer;
+        var message = status == DcsSequenceStatus.Unterminated
+            ? "The DCS sequence ended before a string terminator."
+            : "The DCS introducer is not an accepted Sixel form.";
+
+        return new SixelParseResult(
+            CreateHeader(introducer.Parameters),
+            null,
+            new SixelPoint(0, 0),
+            new SixelPoint(0, 0),
+            SixelExtent.Empty,
+            SixelExtent.Empty,
+            SixelBounds.Empty,
+            SixelExtent.Empty,
+            0,
+            Array.Empty<SixelPaletteCommand>(),
+            Array.Empty<SixelCommand>(),
+            false,
+            outcome,
+            [new SixelDiagnostic(code, 0, introducer.FinalByte, message)]);
+    }
+
+    internal static SixelHeader CreateHeader(IReadOnlyList<int?> parameters)
+    {
+        var p1 = GetParameter(parameters, 0);
+        var p2 = GetParameter(parameters, 1);
+        var p3 = GetParameter(parameters, 2);
+        return new SixelHeader(
+            p1,
+            p2,
+            p3,
+            SixelParser.GetAspectRatio(p1),
+            p2 == 1 ? SixelBackgroundMode.Transparent : SixelBackgroundMode.Opaque);
+    }
+
+    private static int GetParameter(IReadOnlyList<int?> parameters, int index) =>
+        index < parameters.Count ? parameters[index] ?? 0 : 0;
+}
+
+internal sealed class SixelParser
+{
+    internal const int MaximumNumericValue = DcsByteStreamParser.DefaultMaximumParameterValue;
+    internal const int MaximumRetainedCommandCount = 65_536;
+    internal const int MaximumPaletteMutationCount = 4_096;
+    internal const int MaximumDiagnosticCount = 64;
+
+    private readonly List<SixelCommand> _commands = [];
+    private readonly List<SixelPaletteCommand> _paletteMutations = [];
+    private readonly List<SixelDiagnostic> _diagnostics = [];
+    private readonly int?[] _parameters = new int?[5];
+    private readonly bool[] _parameterOverflowReported = new bool[5];
+    private readonly SixelHeader _header;
+    private SixelAspectRatio _aspectRatio;
+    private SixelRasterAttributes? _rasterAttributes;
+    private PendingCommand _pendingCommand;
+    private int _parameterCount;
+    private int _graphicsX;
+    private int _graphicsY;
+    private int _band;
+    private int _maximumX;
+    private int _maximumY;
+    private int _dataWidth;
+    private int _dataHeight;
+    private int _selectedColorRegister;
+    private int _paintedMinX = int.MaxValue;
+    private int _paintedMinY = int.MaxValue;
+    private int _paintedMaxX;
+    private int _paintedMaxY;
+    private long _offset;
+    private bool _malformed;
+    private bool _limitDowngraded;
+    private bool _retainCommands = true;
+    private bool _commandsComplete = true;
+    private bool _metadataLimitReported;
+    private bool _commandLimitReported;
+
+    public SixelParser(DcsIntroducer introducer)
+    {
+        _header = SixelParseResult.CreateHeader(introducer.Parameters);
+        _aspectRatio = _header.AspectRatio;
+
+        if (introducer.Parameters.Count > 3)
+        {
+            MarkMalformed(
+                SixelDiagnosticCode.ExcessiveHeaderParameters,
+                null,
+                "Sixel accepts at most three DCS header parameters.");
+        }
+
+        if (_header.PixelAspectMacro is < 0 or > 9)
+        {
+            AddDiagnostic(
+                SixelDiagnosticCode.UnsupportedAspectMacro,
+                null,
+                "The unsupported P1 aspect macro uses the DEC 2:1 default.");
+        }
+    }
+
+    public static SixelParseResult ParsePayload(string payload)
+    {
+        var bytes = EncodePayload(payload);
+        if (bytes.AsSpan().StartsWith("\x1bP"u8) || (bytes.Length > 0 && bytes[0] == 0x90))
+        {
+            var parser = new DcsByteStreamParser();
+            var batch = parser.Process(bytes);
+            if (batch.Frames.Count > 0)
+            {
+                return batch.Frames[0].Frame.SixelResult;
+            }
+
+            var final = parser.Complete();
+            if (final.Frames.Count > 0)
+            {
+                return final.Frames[0].Frame.SixelResult;
+            }
+
+            return SixelParseResult.Rejected(
+                new DcsIntroducer(
+                    null,
+                    Array.Empty<int?>(),
+                    Array.Empty<byte>(),
+                    null,
+                    false),
+                DcsSequenceStatus.Unterminated,
+                retentionLimitExceeded: false);
+        }
+
+        var frame = DcsByteStreamParser.ParseCompleteContent(bytes);
+        if (frame.Introducer.IsSixel)
+        {
+            return frame.SixelResult;
+        }
+
+        var bodyParser = new SixelParser(new DcsIntroducer(
+            null,
+            Array.Empty<int?>(),
+            Array.Empty<byte>(),
+            (byte)'q',
+            true));
+        foreach (var value in bytes)
+        {
+            bodyParser.ProcessByte(value, retainCommand: true);
+        }
+        return bodyParser.Complete(DcsSequenceStatus.Complete, retentionLimitExceeded: false);
+    }
+
+    internal static byte[] EncodePayload(string payload) =>
+        payload.Any(value => value > byte.MaxValue)
+            ? System.Text.Encoding.UTF8.GetBytes(payload)
+            : System.Text.Encoding.Latin1.GetBytes(payload);
+
+    public void ProcessByte(byte value, bool retainCommand)
+    {
+        _retainCommands &= retainCommand;
+        var reprocess = true;
+        while (reprocess)
+        {
+            reprocess = false;
+            if (_pendingCommand == PendingCommand.Repeat)
+            {
+                if (value is >= (byte)'0' and <= (byte)'9')
+                {
+                    AccumulateDigit(value);
+                    break;
+                }
+
+                if (value is >= (byte)'?' and <= (byte)'~')
+                {
+                    var repeatCount = _parameters[0] ?? 1;
+                    if (repeatCount == 0)
+                    {
+                        repeatCount = 1;
+                    }
+                    ApplyData(value - (byte)'?', repeatCount, retainCommand);
+                    ResetPendingCommand();
+                    break;
+                }
+
+                MarkMalformed(
+                    IsCommandIntroducer(value)
+                        ? SixelDiagnosticCode.ReplacedCommand
+                        : SixelDiagnosticCode.IncompleteCommand,
+                    (byte)'!',
+                    "DECGRI was not followed by a Sixel data byte.");
+                ResetPendingCommand();
+                reprocess = true;
+                continue;
+            }
+
+            if (_pendingCommand is PendingCommand.RasterAttributes or PendingCommand.Palette)
+            {
+                if (value is >= (byte)'0' and <= (byte)'9')
+                {
+                    AccumulateDigit(value);
+                    break;
+                }
+
+                if (value == (byte)';')
+                {
+                    AdvanceParameter();
+                    break;
+                }
+
+                CompleteParameterCommand(retainCommand);
+                reprocess = true;
+                continue;
+            }
+
+            switch (value)
+            {
+                case >= (byte)'?' and <= (byte)'~':
+                    ApplyData(value - (byte)'?', 1, retainCommand);
+                    break;
+                case (byte)'!':
+                    BeginCommand(PendingCommand.Repeat);
+                    break;
+                case (byte)'$':
+                    _graphicsX = 0;
+                    ObserveCursor();
+                    break;
+                case (byte)'-':
+                    _graphicsX = 0;
+                    _graphicsY = SaturatingAdd(_graphicsY, ScaleBandHeight(), (byte)'-');
+                    _band = SaturatingAdd(_band, 1, (byte)'-');
+                    ObserveCursor();
+                    break;
+                case (byte)'"':
+                    BeginCommand(PendingCommand.RasterAttributes);
+                    break;
+                case (byte)'#':
+                    BeginCommand(PendingCommand.Palette);
+                    break;
+                default:
+                    MarkMalformed(
+                        SixelDiagnosticCode.InvalidByte,
+                        value,
+                        "The payload contains a byte that is not valid in Sixel data.");
+                    break;
+            }
+        }
+
+        _offset++;
+    }
+
+    public SixelParseResult Complete(
+        DcsSequenceStatus status,
+        bool retentionLimitExceeded)
+    {
+        if (_pendingCommand != PendingCommand.None)
+        {
+            if (_pendingCommand is PendingCommand.RasterAttributes or PendingCommand.Palette)
+            {
+                CompleteParameterCommand(_retainCommands);
+            }
+            else
+            {
+                MarkMalformed(
+                    SixelDiagnosticCode.IncompleteCommand,
+                    PendingCommandByte(_pendingCommand),
+                    "The Sixel sequence ended with an incomplete command.");
+                ResetPendingCommand();
+            }
+        }
+
+        if (status == DcsSequenceStatus.Unterminated)
+        {
+            MarkMalformed(
+                SixelDiagnosticCode.UnterminatedSequence,
+                null,
+                "The DCS sequence ended before a string terminator.");
+        }
+
+        if (retentionLimitExceeded)
+        {
+            _limitDowngraded = true;
+            _commandsComplete = false;
+        }
+
+        var declared = _rasterAttributes is { } raster
+            ? new SixelExtent(raster.Ph, raster.Pv)
+            : SixelExtent.Empty;
+        var painted = _paintedMinX == int.MaxValue
+            ? SixelBounds.Empty
+            : new SixelBounds(
+                _paintedMinX,
+                _paintedMinY,
+                _paintedMaxX - _paintedMinX,
+                _paintedMaxY - _paintedMinY);
+        var logical = new SixelExtent(
+            Math.Max(declared.Width, Math.Max(_dataWidth, _paintedMaxX)),
+            Math.Max(declared.Height, Math.Max(_dataHeight, _paintedMaxY)));
+        var outcome = status switch
+        {
+            DcsSequenceStatus.Cancelled => SixelParseOutcome.Cancelled,
+            DcsSequenceStatus.Malformed or DcsSequenceStatus.Unterminated => SixelParseOutcome.Malformed,
+            _ when _malformed => SixelParseOutcome.Malformed,
+            _ when _limitDowngraded => SixelParseOutcome.LimitDowngraded,
+            _ => SixelParseOutcome.Complete,
+        };
+
+        return new SixelParseResult(
+            _header with { AspectRatio = _aspectRatio },
+            _rasterAttributes,
+            new SixelPoint(_graphicsX, _graphicsY),
+            new SixelPoint(_maximumX, _maximumY),
+            declared,
+            new SixelExtent(_dataWidth, _dataHeight),
+            painted,
+            logical,
+            _selectedColorRegister,
+            _paletteMutations.ToArray(),
+            _commands.ToArray(),
+            _commandsComplete,
+            outcome,
+            _diagnostics.ToArray());
+    }
+
+    internal static SixelAspectRatio GetAspectRatio(int pixelAspectMacro) =>
+        pixelAspectMacro switch
+        {
+            2 => new SixelAspectRatio(5, 1),
+            3 or 4 => new SixelAspectRatio(3, 1),
+            7 or 8 or 9 => new SixelAspectRatio(1, 1),
+            _ => new SixelAspectRatio(2, 1),
+        };
+
+    private void ApplyData(int mask, int repeatCount, bool retainCommand)
+    {
+        var startX = _graphicsX;
+        var endX = SaturatingAdd(startX, repeatCount, null);
+        if (retainCommand)
+        {
+            AddDataCommand(startX, mask, endX - startX);
+        }
+        else
+        {
+            _commandsComplete = false;
+        }
+
+        _graphicsX = endX;
+        _dataWidth = Math.Max(_dataWidth, endX);
+        _dataHeight = Math.Max(
+            _dataHeight,
+            SaturatingAdd(_graphicsY, ScaleBandHeight(), null));
+
+        if (mask != 0 && endX > startX)
+        {
+            var firstBit = 0;
+            while ((mask & (1 << firstBit)) == 0)
+            {
+                firstBit++;
+            }
+
+            var lastBit = 5;
+            while ((mask & (1 << lastBit)) == 0)
+            {
+                lastBit--;
+            }
+
+            var top = SaturatingAdd(_graphicsY, ScaleRowOffsetFloor(firstBit), null);
+            var bottom = SaturatingAdd(_graphicsY, ScaleRowOffsetCeiling(lastBit + 1), null);
+            _paintedMinX = Math.Min(_paintedMinX, startX);
+            _paintedMinY = Math.Min(_paintedMinY, top);
+            _paintedMaxX = Math.Max(_paintedMaxX, endX);
+            _paintedMaxY = Math.Max(_paintedMaxY, bottom);
+        }
+
+        ObserveCursor();
+    }
+
+    private void AddDataCommand(int x, int mask, int repeatCount)
+    {
+        if (repeatCount <= 0)
+        {
+            return;
+        }
+
+        if (_commands.Count > 0)
+        {
+            var last = _commands[^1];
+            if (last.Kind == SixelCommandKind.Data &&
+                last.Band == _band &&
+                last.Value == mask &&
+                last.X + last.RepeatCount == x &&
+                last.RepeatCount <= int.MaxValue - repeatCount)
+            {
+                _commands[^1] = last with { RepeatCount = last.RepeatCount + repeatCount };
+                return;
+            }
+        }
+
+        if (_commands.Count == MaximumRetainedCommandCount)
+        {
+            _commandsComplete = false;
+            _limitDowngraded = true;
+            if (!_commandLimitReported)
+            {
+                _commandLimitReported = true;
+                AddDiagnostic(
+                    SixelDiagnosticCode.CommandRetentionLimitExceeded,
+                    null,
+                    "Parsed command retention was disabled after reaching its bounded limit.");
+            }
+            return;
+        }
+
+        _commands.Add(new SixelCommand(
+            SixelCommandKind.Data,
+            x,
+            _band,
+            mask,
+            repeatCount,
+            null));
+    }
+
+    private void CompleteParameterCommand(bool retainCommand)
+    {
+        switch (_pendingCommand)
+        {
+            case PendingCommand.RasterAttributes:
+                ApplyRasterAttributes();
+                break;
+            case PendingCommand.Palette:
+                ApplyPaletteCommand(retainCommand);
+                break;
+        }
+
+        ResetPendingCommand();
+    }
+
+    private void ApplyRasterAttributes()
+    {
+        if (_parameterCount > 4)
+        {
+            MarkMalformed(
+                SixelDiagnosticCode.InvalidRasterAttributes,
+                (byte)'"',
+                "DECGRA accepts at most Pan, Pad, Ph, and Pv parameters.");
+            return;
+        }
+
+        var pan = _parameters[0] ?? 0;
+        var pad = _parameters[1] ?? 0;
+        var ph = _parameters[2] ?? 0;
+        var pv = _parameters[3] ?? 0;
+        _rasterAttributes = new SixelRasterAttributes(pan, pad, ph, pv);
+        if (pan > 0 && pad > 0)
+        {
+            _aspectRatio = new SixelAspectRatio(pan, pad);
+        }
+        else if (pan != 0 || pad != 0)
+        {
+            MarkMalformed(
+                SixelDiagnosticCode.InvalidRasterAttributes,
+                (byte)'"',
+                "DECGRA Pan and Pad must both be positive to replace the current aspect ratio.");
+        }
+    }
+
+    private void ApplyPaletteCommand(bool retainCommand)
+    {
+        if (_parameters[0] is not { } register)
+        {
+            MarkMalformed(
+                SixelDiagnosticCode.InvalidPaletteCommand,
+                (byte)'#',
+                "DECGCI requires a color register number.");
+            return;
+        }
+
+        SixelPaletteCommand palette;
+        if (_parameterCount == 1)
+        {
+            palette = new SixelPaletteCommand(register, null, null, null, null);
+        }
+        else if (_parameterCount == 5 &&
+                 _parameters[1] is 1 or 2 &&
+                 _parameters[2] is { } x &&
+                 _parameters[3] is { } y &&
+                 _parameters[4] is { } z)
+        {
+            palette = new SixelPaletteCommand(
+                register,
+                (SixelColorSpace)_parameters[1]!.Value,
+                x,
+                y,
+                z);
+        }
+        else
+        {
+            _selectedColorRegister = register;
+            MarkMalformed(
+                SixelDiagnosticCode.InvalidPaletteCommand,
+                (byte)'#',
+                "DECGCI must select Pc or define Pc;Pu;Px;Py;Pz.");
+            return;
+        }
+
+        _selectedColorRegister = register;
+        if (_paletteMutations.Count < MaximumPaletteMutationCount)
+        {
+            _paletteMutations.Add(palette);
+        }
+        else
+        {
+            _limitDowngraded = true;
+            if (!_metadataLimitReported)
+            {
+                _metadataLimitReported = true;
+                AddDiagnostic(
+                    SixelDiagnosticCode.MetadataLimitExceeded,
+                    (byte)'#',
+                    "Palette mutation metadata was truncated at its bounded limit.");
+            }
+        }
+
+        if (!retainCommand)
+        {
+            _commandsComplete = false;
+            return;
+        }
+
+        if (_commands.Count == MaximumRetainedCommandCount)
+        {
+            _commandsComplete = false;
+            _limitDowngraded = true;
+            if (!_commandLimitReported)
+            {
+                _commandLimitReported = true;
+                AddDiagnostic(
+                    SixelDiagnosticCode.CommandRetentionLimitExceeded,
+                    (byte)'#',
+                    "Parsed command retention was disabled after reaching its bounded limit.");
+            }
+            return;
+        }
+
+        _commands.Add(new SixelCommand(
+            SixelCommandKind.Palette,
+            _graphicsX,
+            _band,
+            0,
+            0,
+            palette));
+    }
+
+    private void BeginCommand(PendingCommand command)
+    {
+        _pendingCommand = command;
+        _parameterCount = 1;
+        Array.Clear(_parameters);
+        Array.Clear(_parameterOverflowReported);
+    }
+
+    private void ResetPendingCommand()
+    {
+        _pendingCommand = PendingCommand.None;
+        _parameterCount = 0;
+        Array.Clear(_parameters);
+        Array.Clear(_parameterOverflowReported);
+    }
+
+    private void AccumulateDigit(byte value)
+    {
+        var index = _parameterCount - 1;
+        var digit = value - (byte)'0';
+        var current = _parameters[index] ?? 0;
+        if (current > (MaximumNumericValue - digit) / 10)
+        {
+            _parameters[index] = MaximumNumericValue;
+            _limitDowngraded = true;
+            if (!_parameterOverflowReported[index])
+            {
+                _parameterOverflowReported[index] = true;
+                AddDiagnostic(
+                    SixelDiagnosticCode.NumericLimitExceeded,
+                    PendingCommandByte(_pendingCommand),
+                    "The numeric parameter was saturated at the implementation limit.");
+            }
+            return;
+        }
+
+        _parameters[index] = (current * 10) + digit;
+    }
+
+    private void AdvanceParameter()
+    {
+        if (_parameterCount == _parameters.Length)
+        {
+            _malformed = true;
+            AddDiagnostic(
+                SixelDiagnosticCode.ExcessiveCommandParameters,
+                PendingCommandByte(_pendingCommand),
+                "The Sixel command contains too many parameters.");
+            return;
+        }
+
+        _parameterCount++;
+    }
+
+    private int ScaleBandHeight() => ScaleRowOffsetCeiling(6);
+
+    private int ScaleRowOffsetFloor(int row)
+    {
+        var scaled = (long)row * _aspectRatio.Numerator;
+        return SaturateScaledValue(scaled / _aspectRatio.Denominator);
+    }
+
+    private int ScaleRowOffsetCeiling(int row)
+    {
+        var scaled = ((long)row * _aspectRatio.Numerator) + _aspectRatio.Denominator - 1;
+        return SaturateScaledValue(scaled / _aspectRatio.Denominator);
+    }
+
+    private int SaturateScaledValue(long value)
+    {
+        if (value <= int.MaxValue)
+        {
+            return (int)value;
+        }
+
+        _limitDowngraded = true;
+        AddDiagnostic(
+            SixelDiagnosticCode.GeometrySaturated,
+            (byte)'"',
+            "Sixel aspect-scaled geometry was saturated at the implementation coordinate limit.");
+        return int.MaxValue;
+    }
+
+    private int SaturatingAdd(int left, int right, byte? command)
+    {
+        if (right <= int.MaxValue - left)
+        {
+            return left + right;
+        }
+
+        _limitDowngraded = true;
+        AddDiagnostic(
+            SixelDiagnosticCode.GeometrySaturated,
+            command,
+            "Sixel geometry was saturated at the implementation coordinate limit.");
+        return int.MaxValue;
+    }
+
+    private void ObserveCursor()
+    {
+        _maximumX = Math.Max(_maximumX, _graphicsX);
+        _maximumY = Math.Max(_maximumY, _graphicsY);
+    }
+
+    private void MarkMalformed(
+        SixelDiagnosticCode code,
+        byte? command,
+        string message)
+    {
+        _malformed = true;
+        AddDiagnostic(code, command, message);
+    }
+
+    private void AddDiagnostic(
+        SixelDiagnosticCode code,
+        byte? command,
+        string message)
+    {
+        if (_diagnostics.Count < MaximumDiagnosticCount)
+        {
+            _diagnostics.Add(new SixelDiagnostic(code, _offset, command, message));
+            return;
+        }
+
+    }
+
+    private static bool IsCommandIntroducer(byte value) =>
+        value is (byte)'!' or (byte)'"' or (byte)'#' or (byte)'$' or (byte)'-';
+
+    private static byte? PendingCommandByte(PendingCommand command) =>
+        command switch
+        {
+            PendingCommand.Repeat => (byte)'!',
+            PendingCommand.RasterAttributes => (byte)'"',
+            PendingCommand.Palette => (byte)'#',
+            _ => null,
+        };
+
+    private enum PendingCommand
+    {
+        None,
+        Repeat,
+        RasterAttributes,
+        Palette,
+    }
+}

--- a/src/Hex1b/SixelData.cs
+++ b/src/Hex1b/SixelData.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using Hex1b.Sixel;
 using Hex1b.Surfaces;
 
 namespace Hex1b;
@@ -20,6 +21,8 @@ namespace Hex1b;
 public sealed class SixelData
 {
     private SixelPixelBuffer? _decodedPixels;
+    private bool _decodeAttempted;
+    private readonly object _decodeLock = new();
 
     /// <summary>
     /// Gets the raw Sixel DCS sequence (ESC P ... ESC \).
@@ -51,12 +54,21 @@ public sealed class SixelData
     /// </summary>
     internal byte[] ContentHash { get; }
 
+    internal SixelParseResult ParseResult { get; }
+
     internal SixelData(
         string payload,
         int widthInCells,
         int heightInCells,
         byte[] contentHash)
-        : this(payload, widthInCells, heightInCells, contentHash, 0, 0)
+        : this(
+            payload,
+            widthInCells,
+            heightInCells,
+            contentHash,
+            0,
+            0,
+            SixelParser.ParsePayload(payload))
     {
     }
 
@@ -66,7 +78,8 @@ public sealed class SixelData
         int heightInCells,
         byte[] contentHash,
         int pixelWidth,
-        int pixelHeight)
+        int pixelHeight,
+        SixelParseResult? parseResult = null)
     {
         Payload = payload;
         WidthInCells = widthInCells;
@@ -74,6 +87,7 @@ public sealed class SixelData
         ContentHash = contentHash;
         PixelWidth = pixelWidth;
         PixelHeight = pixelHeight;
+        ParseResult = parseResult ?? SixelParser.ParsePayload(payload);
     }
 
     /// <summary>
@@ -83,6 +97,10 @@ public sealed class SixelData
     /// <returns>The width and height in cells.</returns>
     public (int Width, int Height) GetCellSpan(CellMetrics metrics)
     {
+        if (ParseResult.LogicalCanvasExtent is { Width: > 0, Height: > 0 } logical)
+        {
+            return metrics.PixelToCellSpan(logical.Width, logical.Height);
+        }
         if (PixelWidth > 0 && PixelHeight > 0)
         {
             return metrics.PixelToCellSpan(PixelWidth, PixelHeight);
@@ -98,30 +116,34 @@ public sealed class SixelData
     /// <returns>The decoded pixel buffer, or null if decoding fails.</returns>
     public SixelPixelBuffer? GetPixels()
     {
-        if (_decodedPixels is not null)
-            return _decodedPixels;
-
-        var decoded = Automation.SixelDecoder.Decode(Payload);
-        if (decoded is null)
-            return null;
-
-        // Convert SixelImage to SixelPixelBuffer
-        var buffer = new SixelPixelBuffer(decoded.Width, decoded.Height);
-        for (var y = 0; y < decoded.Height; y++)
+        lock (_decodeLock)
         {
-            for (var x = 0; x < decoded.Width; x++)
-            {
-                var idx = (y * decoded.Width + x) * 4;
-                buffer[x, y] = new Rgba32(
-                    decoded.Pixels[idx],
-                    decoded.Pixels[idx + 1],
-                    decoded.Pixels[idx + 2],
-                    decoded.Pixels[idx + 3]);
-            }
-        }
+            if (_decodeAttempted)
+                return _decodedPixels;
 
-        _decodedPixels = buffer;
-        return buffer;
+            var decoded = Automation.SixelDecoder.Decode(ParseResult);
+            if (decoded is not null)
+            {
+                var buffer = new SixelPixelBuffer(decoded.Width, decoded.Height);
+                for (var y = 0; y < decoded.Height; y++)
+                {
+                    for (var x = 0; x < decoded.Width; x++)
+                    {
+                        var idx = (y * decoded.Width + x) * 4;
+                        buffer[x, y] = new Rgba32(
+                            decoded.Pixels[idx],
+                            decoded.Pixels[idx + 1],
+                            decoded.Pixels[idx + 2],
+                            decoded.Pixels[idx + 3]);
+                    }
+                }
+
+                _decodedPixels = buffer;
+            }
+
+            _decodeAttempted = true;
+            return _decodedPixels;
+        }
     }
 
     /// <summary>

--- a/src/Hex1b/Tokens/DcsByteStreamParser.cs
+++ b/src/Hex1b/Tokens/DcsByteStreamParser.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using Hex1b.Sixel;
 
 namespace Hex1b.Tokens;
 
@@ -29,7 +30,8 @@ internal sealed record DcsFrame(
     DcsIntroducer Introducer,
     ReadOnlyMemory<byte> RetainedContent,
     long ByteCount,
-    bool RetentionLimitExceeded);
+    bool RetentionLimitExceeded,
+    SixelParseResult SixelResult);
 
 internal readonly record struct DcsFrameBoundary(int TextByteOffset, DcsFrame Frame);
 
@@ -68,6 +70,7 @@ internal sealed class DcsByteStreamParser
     private byte[] _intermediates = new byte[MaximumIntermediateCount];
     private int _intermediateCount;
     private byte? _finalByte;
+    private SixelParser? _sixelParser;
 
     public DcsByteStreamParser(
         int retentionLimit = DefaultRetentionLimit,
@@ -163,6 +166,7 @@ internal sealed class DcsByteStreamParser
                         else
                         {
                             AppendContent(0x1b);
+                            ProcessSixelPayloadByte(0x1b);
                             _state = _stateBeforeDcsEscape;
                             reprocess = true;
                         }
@@ -196,6 +200,10 @@ internal sealed class DcsByteStreamParser
                             if (_state == ParserState.Introducer)
                             {
                                 ProcessIntroducerByte(value);
+                            }
+                            else if (_state == ParserState.Payload)
+                            {
+                                ProcessSixelPayloadByte(value);
                             }
                         }
                         break;
@@ -264,6 +272,33 @@ internal sealed class DcsByteStreamParser
         return parser.CreateIntroducer();
     }
 
+    internal static DcsFrame ParseCompleteContent(
+        ReadOnlySpan<byte> content,
+        int retentionLimit = DefaultRetentionLimit,
+        int maximumParameterCount = DefaultMaximumParameterCount,
+        int maximumParameterValue = DefaultMaximumParameterValue)
+    {
+        var parser = new DcsByteStreamParser(
+            retentionLimit,
+            maximumParameterCount,
+            maximumParameterValue);
+        _ = parser.Process("\x1bP"u8);
+        _ = parser.Process(content);
+        var completed = parser.Process("\x1b\\"u8);
+        if (completed.Frames.Count > 0)
+        {
+            return completed.Frames[0].Frame;
+        }
+
+        var final = parser.Complete();
+        if (final.Frames.Count > 0)
+        {
+            return final.Frames[0].Frame;
+        }
+
+        throw new InvalidOperationException("The synthetic DCS frame did not produce a result.");
+    }
+
     internal static DcsIntroducer ParseIntroducer(
         ReadOnlySpan<char> content,
         int maximumParameterCount = DefaultMaximumParameterCount,
@@ -310,6 +345,7 @@ internal sealed class DcsByteStreamParser
         _inIntermediates = false;
         _intermediateCount = 0;
         _finalByte = null;
+        _sixelParser = null;
     }
 
     private void ProcessIntroducerByte(byte value)
@@ -390,6 +426,11 @@ internal sealed class DcsByteStreamParser
             _state = _introducerValid
                 ? ParserState.Payload
                 : ParserState.MalformedIntroducer;
+            var introducer = CreateIntroducer();
+            if (introducer.IsSixel)
+            {
+                _sixelParser = new SixelParser(introducer);
+            }
             return;
         }
 
@@ -436,17 +477,26 @@ internal sealed class DcsByteStreamParser
             status = DcsSequenceStatus.Malformed;
         }
 
+        var introducer = CreateIntroducer();
+        var sixelResult = _sixelParser?.Complete(status, _retentionLimitExceeded)
+            ?? SixelParseResult.Rejected(introducer, status, _retentionLimitExceeded);
         var frame = new DcsFrame(
             status,
-            CreateIntroducer(),
+            introducer,
             _retained.AsMemory(0, _retainedCount),
             _byteCount,
-            _retentionLimitExceeded);
+            _retentionLimitExceeded,
+            sixelResult);
 
         _retained = [];
         _retainedCount = 0;
         _state = ParserState.Ground;
         return frame;
+    }
+
+    private void ProcessSixelPayloadByte(byte value)
+    {
+        _sixelParser?.ProcessByte(value, !_retentionLimitExceeded);
     }
 
     private DcsIntroducer CreateIntroducer()

--- a/src/Hex1b/TrackedObjectStore.cs
+++ b/src/Hex1b/TrackedObjectStore.cs
@@ -1,3 +1,5 @@
+using Hex1b.Sixel;
+
 namespace Hex1b;
 
 /// <summary>
@@ -11,7 +13,7 @@ namespace Hex1b;
 /// </para>
 /// <para>
 /// This is internal infrastructure - not exposed to API consumers.
-/// Type-specific APIs (e.g., <see cref="GetOrCreateSixel"/>) handle deduplication
+/// Type-specific APIs (e.g., <see cref="GetOrCreateSixel(string, int, int)"/>) handle deduplication
 /// by content hash.
 /// </para>
 /// </remarks>
@@ -80,6 +82,17 @@ internal sealed class TrackedObjectStore
     /// <param name="heightInCells">Height of the image in terminal cells.</param>
     /// <returns>A tracked Sixel object (new or existing with added ref).</returns>
     public TrackedObject<SixelData> GetOrCreateSixel(string payload, int widthInCells, int heightInCells)
+        => GetOrCreateSixel(
+            payload,
+            widthInCells,
+            heightInCells,
+            SixelParser.ParsePayload(payload));
+
+    internal TrackedObject<SixelData> GetOrCreateSixel(
+        string payload,
+        int widthInCells,
+        int heightInCells,
+        SixelParseResult parseResult)
     {
         var hash = SixelData.ComputeHash(payload);
 
@@ -92,11 +105,15 @@ internal sealed class TrackedObjectStore
                 return existing;
             }
 
-            // Parse pixel dimensions from the payload raster attributes
-            var (pixelWidth, pixelHeight) = ParseSixelDimensions(payload);
-
             // Create the data
-            var sixelData = new SixelData(payload, widthInCells, heightInCells, hash, pixelWidth, pixelHeight);
+            var sixelData = new SixelData(
+                payload,
+                widthInCells,
+                heightInCells,
+                hash,
+                parseResult.DeclaredExtent.Width,
+                parseResult.DeclaredExtent.Height,
+                parseResult);
             
             // Create new tracked wrapper with removal callback
             var tracked = new TrackedObject<SixelData>(
@@ -106,36 +123,6 @@ internal sealed class TrackedObjectStore
             _sixelByHash[hash] = tracked;
             return tracked;
         }
-    }
-
-    /// <summary>
-    /// Parses pixel dimensions from sixel raster attributes.
-    /// </summary>
-    /// <returns>Tuple of (width, height) in pixels, or (0, 0) if not found.</returns>
-    private static (int Width, int Height) ParseSixelDimensions(string payload)
-    {
-        // Look for raster attributes: "Pan;Pad;Ph;Pv
-        // Pan;Pad = pixel aspect ratio numerator/denominator
-        // Ph = horizontal extent (width), Pv = vertical extent (height)
-        var quoteIdx = payload.IndexOf('"');
-        if (quoteIdx < 0)
-            return (0, 0);
-
-        var endIdx = payload.IndexOfAny(['#', '!', '$', '-', '~'], quoteIdx + 1);
-        if (endIdx < 0)
-            endIdx = Math.Min(quoteIdx + 50, payload.Length);
-
-        var rasterStr = payload.Substring(quoteIdx + 1, endIdx - quoteIdx - 1);
-        var parts = rasterStr.Split(';');
-        
-        if (parts.Length >= 4 && 
-            int.TryParse(parts[2], out var width) && 
-            int.TryParse(parts[3], out var height))
-        {
-            return (width, height);
-        }
-
-        return (0, 0);
     }
 
     /// <summary>

--- a/tests/Hex1b.Tests/Sixel/SixelGrammarParserTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelGrammarParserTests.cs
@@ -1,0 +1,396 @@
+using System.Text;
+using Hex1b.Sixel;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests.Sixel;
+
+[TestClass]
+public class SixelGrammarParserTests
+{
+    [TestMethod]
+    public void Process_AllGrammarCommandsAtEverySplit_ProducesEquivalentResult()
+    {
+        var bytes = Encoding.ASCII.GetBytes(
+            "\x1bP2;1;9q\"1;1;2;3#4;2;100;0;0@?$!2~-#4\x1b\\");
+        var baseline = ParseFramed(bytes).SixelResult;
+
+        for (var split = 0; split <= bytes.Length; split++)
+        {
+            var parser = new DcsByteStreamParser();
+            var frames = new List<DcsFrame>();
+            frames.AddRange(parser.Process(bytes.AsSpan(0, split)).Frames.Select(x => x.Frame));
+            frames.AddRange(parser.Process(bytes.AsSpan(split)).Frames.Select(x => x.Frame));
+            frames.AddRange(parser.Complete().Frames.Select(x => x.Frame));
+
+            var actual = TestSeq.Single(frames).SixelResult;
+            Assert.AreEqual(Fingerprint(baseline), Fingerprint(actual), $"split {split}");
+        }
+
+        Assert.AreEqual(SixelParseOutcome.Complete, baseline.Outcome);
+        Assert.AreEqual(new SixelPoint(0, 6), baseline.GraphicsCursor);
+        Assert.AreEqual(new SixelPoint(2, 6), baseline.MaximumCommandOrDataPosition);
+        Assert.AreEqual(new SixelExtent(2, 3), baseline.DeclaredExtent);
+        Assert.AreEqual(new SixelExtent(2, 6), baseline.DataExtent);
+        Assert.AreEqual(new SixelBounds(0, 0, 2, 6), baseline.PaintedBounds);
+        Assert.AreEqual(new SixelExtent(2, 6), baseline.LogicalCanvasExtent);
+    }
+
+    [TestMethod]
+    public void Framing_StandardAndC1ProduceEquivalentGrammarResult()
+    {
+        var payload = Encoding.ASCII.GetBytes(
+            "2;1;9q\"1;1;2;3#4;2;100;0;0@?$!2~-#4");
+        var standard = ParseFramed([0x1b, (byte)'P', .. payload, 0x1b, (byte)'\\']);
+        var c1 = ParseFramed([0x90, .. payload, 0x9c]);
+
+        Assert.AreEqual(
+            Fingerprint(standard.SixelResult),
+            Fingerprint(c1.SixelResult));
+    }
+
+    [TestMethod]
+    [DataRow("", 2)]
+    [DataRow("0", 2)]
+    [DataRow("1", 2)]
+    [DataRow("2", 5)]
+    [DataRow("3", 3)]
+    [DataRow("4", 3)]
+    [DataRow("5", 2)]
+    [DataRow("6", 2)]
+    [DataRow("7", 1)]
+    [DataRow("8", 1)]
+    [DataRow("9", 1)]
+    [DataRow("99", 2)]
+    public void Header_P1AspectMacro_UsesDecTable(string p1, int verticalScale)
+    {
+        var result = Parse($"{p1}q@").SixelResult;
+
+        Assert.AreEqual(SixelParseOutcome.Complete, result.Outcome);
+        Assert.AreEqual(new SixelAspectRatio(verticalScale, 1), result.Header.AspectRatio);
+        Assert.AreEqual(new SixelExtent(1, 6 * verticalScale), result.DataExtent);
+    }
+
+    [TestMethod]
+    public void Header_EmptyParameters_UseDecDefaultsAndRetainMetadata()
+    {
+        var result = Parse(";;q@").SixelResult;
+
+        Assert.AreEqual(0, result.Header.PixelAspectMacro);
+        Assert.AreEqual(0, result.Header.BackgroundSelection);
+        Assert.AreEqual(0, result.Header.HorizontalGridSize);
+        Assert.AreEqual(SixelBackgroundMode.Opaque, result.Header.BackgroundMode);
+        Assert.AreEqual(new SixelAspectRatio(2, 1), result.Header.AspectRatio);
+    }
+
+    [TestMethod]
+    public void Header_TransparentAndGridParameters_AreRetained()
+    {
+        var result = Parse("7;1;42q@").SixelResult;
+
+        Assert.AreEqual(7, result.Header.PixelAspectMacro);
+        Assert.AreEqual(1, result.Header.BackgroundSelection);
+        Assert.AreEqual(42, result.Header.HorizontalGridSize);
+        Assert.AreEqual(SixelBackgroundMode.Transparent, result.Header.BackgroundMode);
+    }
+
+    [TestMethod]
+    [DataRow("?1q@", (int)SixelParseOutcome.Rejected)]
+    [DataRow("1 q@", (int)SixelParseOutcome.Rejected)]
+    [DataRow("1p@", (int)SixelParseOutcome.Rejected)]
+    [DataRow("1;2;3;4q@", (int)SixelParseOutcome.Malformed)]
+    [DataRow("1000000000q@", (int)SixelParseOutcome.Malformed)]
+    public void Header_InvalidForms_AreNotAcceptedAsSixel(
+        string payload,
+        int expected)
+    {
+        var result = Parse(payload).SixelResult;
+
+        Assert.AreEqual((SixelParseOutcome)expected, result.Outcome);
+        Assert.IsNotEmpty(result.Diagnostics);
+    }
+
+    [TestMethod]
+    public void Data_TransparentColumnsAdvanceWithoutPainting()
+    {
+        var result = Parse("q??").SixelResult;
+
+        Assert.AreEqual(new SixelPoint(2, 0), result.GraphicsCursor);
+        Assert.AreEqual(new SixelPoint(2, 0), result.MaximumCommandOrDataPosition);
+        Assert.AreEqual(new SixelExtent(2, 12), result.DataExtent);
+        Assert.AreEqual(SixelBounds.Empty, result.PaintedBounds);
+        Assert.AreEqual(new SixelExtent(2, 12), result.LogicalCanvasExtent);
+    }
+
+    [TestMethod]
+    public void CursorCommands_MoveCursorWithoutGrowingDataExtent()
+    {
+        var result = Parse("7q@-$").SixelResult;
+
+        Assert.AreEqual(new SixelPoint(0, 6), result.GraphicsCursor);
+        Assert.AreEqual(new SixelPoint(1, 6), result.MaximumCommandOrDataPosition);
+        Assert.AreEqual(new SixelExtent(1, 6), result.DataExtent);
+        Assert.AreEqual(new SixelExtent(1, 6), result.LogicalCanvasExtent);
+    }
+
+    [TestMethod]
+    public void Repeat_ExpandedAndCompressedDataHaveEquivalentGeometryAndEvents()
+    {
+        var expanded = Parse("7q~~~").SixelResult;
+        var repeated = Parse("7q!3~").SixelResult;
+
+        Assert.AreEqual(Fingerprint(expanded), Fingerprint(repeated));
+        Assert.AreEqual(3, TestSeq.Single(repeated.Commands).RepeatCount);
+    }
+
+    [TestMethod]
+    public void Repeat_OmittedAndZeroCountsMeanOne()
+    {
+        var omitted = Parse("7q!~").SixelResult;
+        var zero = Parse("7q!0~").SixelResult;
+
+        Assert.AreEqual(new SixelPoint(1, 0), omitted.GraphicsCursor);
+        Assert.AreEqual(Fingerprint(omitted), Fingerprint(zero));
+    }
+
+    [TestMethod]
+    public void RasterAttributes_OverrideAspectAndDistinguishAllExtents()
+    {
+        var result = Parse("q\"1;1;1;1~~-~~").SixelResult;
+
+        Assert.AreEqual(new SixelRasterAttributes(1, 1, 1, 1), result.RasterAttributes);
+        Assert.AreEqual(new SixelAspectRatio(1, 1), result.Header.AspectRatio);
+        Assert.AreEqual(new SixelExtent(1, 1), result.DeclaredExtent);
+        Assert.AreEqual(new SixelExtent(2, 12), result.DataExtent);
+        Assert.AreEqual(new SixelBounds(0, 0, 2, 12), result.PaintedBounds);
+        Assert.AreEqual(new SixelExtent(2, 12), result.LogicalCanvasExtent);
+    }
+
+    [TestMethod]
+    public void RasterAttributes_DeclaredExtentCanExceedDataAndPaint()
+    {
+        var result = Parse("q\"1;1;40;7@").SixelResult;
+
+        Assert.AreEqual(new SixelExtent(40, 7), result.DeclaredExtent);
+        Assert.AreEqual(new SixelExtent(1, 6), result.DataExtent);
+        Assert.AreEqual(new SixelBounds(0, 0, 1, 1), result.PaintedBounds);
+        Assert.AreEqual(new SixelExtent(40, 7), result.LogicalCanvasExtent);
+    }
+
+    [TestMethod]
+    public void RasterAttributes_FractionalAspectUsesOutwardPaintedBounds()
+    {
+        var result = Parse("q\"1;2;0;0A").SixelResult;
+
+        Assert.AreEqual(new SixelExtent(1, 3), result.DataExtent);
+        Assert.AreEqual(new SixelBounds(0, 0, 1, 1), result.PaintedBounds);
+    }
+
+    [TestMethod]
+    public void RasterAttributes_OmittedTrailingExtentParametersRemainValid()
+    {
+        var result = Parse("q\"1;1@").SixelResult;
+
+        Assert.AreEqual(SixelParseOutcome.Complete, result.Outcome);
+        Assert.AreEqual(new SixelAspectRatio(1, 1), result.Header.AspectRatio);
+        Assert.AreEqual(SixelExtent.Empty, result.DeclaredExtent);
+        Assert.AreEqual(new SixelExtent(1, 6), result.DataExtent);
+    }
+
+    [TestMethod]
+    public void RasterAttributes_HugeAspectSaturatesWithoutWrapping()
+    {
+        var result = Parse("q\"999999999;1;1;1~").SixelResult;
+
+        Assert.AreEqual(SixelParseOutcome.LimitDowngraded, result.Outcome);
+        Assert.AreEqual(int.MaxValue, result.DataExtent.Height);
+        Assert.IsTrue(result.Diagnostics.Any(
+            item => item.Code == SixelDiagnosticCode.GeometrySaturated));
+    }
+
+    [TestMethod]
+    public void TrackedSixel_DeclaredPixelCanvasIsNotInflatedToFinalBand()
+    {
+        var store = new TrackedObjectStore();
+        var tracked = store.GetOrCreateSixel(
+            "\x1bP7q\"1;1;1;20@-@-@-@\x1b\\",
+            widthInCells: 1,
+            heightInCells: 1);
+
+        Assert.AreEqual(1, tracked.Data.PixelWidth);
+        Assert.AreEqual(20, tracked.Data.PixelHeight);
+
+        tracked.Release();
+    }
+
+    [TestMethod]
+    public void TrackedSixel_CellSpanUsesLogicalCanvasBeyondDeclaredHint()
+    {
+        var store = new TrackedObjectStore();
+        var tracked = store.GetOrCreateSixel(
+            "\x1bP7q\"1;1;1;1~~-~~\x1b\\",
+            widthInCells: 1,
+            heightInCells: 1);
+
+        Assert.AreEqual(
+            (2, 12),
+            tracked.Data.GetCellSpan(new Hex1b.Surfaces.CellMetrics(1, 1)));
+
+        tracked.Release();
+    }
+
+    [TestMethod]
+    public void Palette_DefinitionsAndSelectionsAreOrderedAndSelectRegister()
+    {
+        var result = Parse("q#7;1;120;50;100#8;2;100;25;0#7@").SixelResult;
+
+        Assert.AreEqual(SixelParseOutcome.Complete, result.Outcome);
+        Assert.AreEqual(7, result.SelectedColorRegister);
+        Assert.HasCount(3, result.PaletteMutations);
+        Assert.AreEqual(
+            new SixelPaletteCommand(7, SixelColorSpace.Hls, 120, 50, 100),
+            result.PaletteMutations[0]);
+        Assert.AreEqual(
+            new SixelPaletteCommand(8, SixelColorSpace.Rgb, 100, 25, 0),
+            result.PaletteMutations[1]);
+        Assert.AreEqual(
+            new SixelPaletteCommand(7, null, null, null, null),
+            result.PaletteMutations[2]);
+    }
+
+    [TestMethod]
+    public void MetadataOnlySequence_RetainsRasterAndPaletteState()
+    {
+        var result = Parse("q\"1;1;40;7#9;2;1;2;3").SixelResult;
+
+        Assert.AreEqual(SixelParseOutcome.Complete, result.Outcome);
+        Assert.AreEqual(new SixelExtent(40, 7), result.LogicalCanvasExtent);
+        Assert.AreEqual(SixelExtent.Empty, result.DataExtent);
+        Assert.AreEqual(SixelBounds.Empty, result.PaintedBounds);
+        Assert.AreEqual(9, result.SelectedColorRegister);
+        Assert.HasCount(1, result.PaletteMutations);
+    }
+
+    [TestMethod]
+    [DataRow("q!3#1@", (int)SixelDiagnosticCode.ReplacedCommand)]
+    [DataRow("q!", (int)SixelDiagnosticCode.IncompleteCommand)]
+    [DataRow("q#", (int)SixelDiagnosticCode.InvalidPaletteCommand)]
+    [DataRow("q\"1;1;2;3;4", (int)SixelDiagnosticCode.InvalidRasterAttributes)]
+    [DataRow("q\u0001@", (int)SixelDiagnosticCode.InvalidByte)]
+    public void MalformedCommands_ReportDiagnosticsAndBoundedRecovery(
+        string payload,
+        int diagnostic)
+    {
+        var result = Parse(payload).SixelResult;
+
+        Assert.AreEqual(SixelParseOutcome.Malformed, result.Outcome);
+        Assert.IsTrue(result.Diagnostics.Any(item => item.Code == (SixelDiagnosticCode)diagnostic));
+    }
+
+    [TestMethod]
+    public void CancelledSequence_ReportsCancelledOutcome()
+    {
+        var result = ParseFramed(Encoding.ASCII.GetBytes("\x1bPq@\x18")).SixelResult;
+
+        Assert.AreEqual(SixelParseOutcome.Cancelled, result.Outcome);
+    }
+
+    [TestMethod]
+    public void UnterminatedSequence_ReportsMalformedOutcome()
+    {
+        var parser = new DcsByteStreamParser();
+        _ = parser.Process("\x1bPq@"u8);
+
+        var result = TestSeq.Single(parser.Complete().Frames).Frame.SixelResult;
+
+        Assert.AreEqual(SixelParseOutcome.Malformed, result.Outcome);
+        Assert.IsTrue(result.Diagnostics.Any(
+            item => item.Code == SixelDiagnosticCode.UnterminatedSequence));
+    }
+
+    [TestMethod]
+    public void HugeRepeat_SaturatesGeometryWithoutWrapping()
+    {
+        var result = Parse("7q!999999999~!999999999~!999999999~").SixelResult;
+
+        Assert.AreEqual(SixelParseOutcome.LimitDowngraded, result.Outcome);
+        Assert.AreEqual(int.MaxValue, result.GraphicsCursor.X);
+        Assert.AreEqual(int.MaxValue, result.DataExtent.Width);
+        Assert.AreEqual(int.MaxValue, result.PaintedBounds.Width);
+        Assert.IsTrue(result.Diagnostics.Any(
+            item => item.Code == SixelDiagnosticCode.GeometrySaturated));
+    }
+
+    [TestMethod]
+    public void NumericOverflow_IsBoundedAndDiagnostic()
+    {
+        var result = Parse("7q!999999999999999999999999~").SixelResult;
+
+        Assert.AreEqual(SixelParseOutcome.LimitDowngraded, result.Outcome);
+        Assert.AreEqual(SixelParser.MaximumNumericValue, result.GraphicsCursor.X);
+        Assert.IsTrue(result.Diagnostics.Any(
+            item => item.Code == SixelDiagnosticCode.NumericLimitExceeded));
+        Assert.IsLessThanOrEqualTo(SixelParser.MaximumDiagnosticCount, result.Diagnostics.Count);
+    }
+
+    [TestMethod]
+    public void Decoder_RepeatedOverprintsBeyondWorkBudget_DowngradesWithoutLooping()
+    {
+        var payload = "7q" + string.Concat(Enumerable.Repeat("!2000000~$", 6));
+
+        Assert.IsNull(Hex1b.Automation.SixelDecoder.Decode(payload));
+    }
+
+    [TestMethod]
+    public void Decoder_RawCommandBody_RemainsSupported()
+    {
+        var image = Hex1b.Automation.SixelDecoder.Decode("#1;2;100;0;0@");
+
+        Assert.IsNotNull(image);
+        Assert.AreEqual(1, image.Width);
+        Assert.AreEqual(6, image.Height);
+        Assert.AreEqual(255, image.Pixels[0]);
+    }
+
+    [TestMethod]
+    public void RetentionLimitExceeded_ContinuesGeometryWithoutRetainingRasterEvents()
+    {
+        var result = Parse($"7q{new string('~', 100)}", retentionLimit: 8).SixelResult;
+
+        Assert.AreEqual(SixelParseOutcome.LimitDowngraded, result.Outcome);
+        Assert.AreEqual(new SixelPoint(100, 0), result.GraphicsCursor);
+        Assert.AreEqual(new SixelExtent(100, 6), result.DataExtent);
+        Assert.AreEqual(new SixelBounds(0, 0, 100, 6), result.PaintedBounds);
+        Assert.IsFalse(result.CommandsComplete);
+    }
+
+    private static DcsFrame Parse(string payload, int retentionLimit = DcsByteStreamParser.DefaultRetentionLimit) =>
+        DcsByteStreamParser.ParseCompleteContent(
+            Encoding.Latin1.GetBytes(payload),
+            retentionLimit);
+
+    private static DcsFrame ParseFramed(byte[] bytes)
+    {
+        var parser = new DcsByteStreamParser();
+        var frames = new List<DcsFrame>();
+        frames.AddRange(parser.Process(bytes).Frames.Select(x => x.Frame));
+        frames.AddRange(parser.Complete().Frames.Select(x => x.Frame));
+        return TestSeq.Single(frames);
+    }
+
+    private static string Fingerprint(SixelParseResult result) => string.Join(
+        "|",
+        result.Header,
+        result.RasterAttributes,
+        result.GraphicsCursor,
+        result.MaximumCommandOrDataPosition,
+        result.DeclaredExtent,
+        result.DataExtent,
+        result.PaintedBounds,
+        result.LogicalCanvasExtent,
+        result.SelectedColorRegister,
+        string.Join(",", result.PaletteMutations),
+        string.Join(",", result.Commands),
+        result.CommandsComplete,
+        result.Outcome,
+        string.Join(",", result.Diagnostics));
+}

--- a/tests/Hex1b.Tests/Sixel/SixelParserTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelParserTests.cs
@@ -140,7 +140,7 @@ public class SixelParserTests
         Assert.Contains("#0000FFFF", TestSeq.Single(terminal.Observe().Placements).PixelGrid);
     }
 
-    [TestMethod, Ignore("Owned by #447: DCS P1 aspect macros are not represented in terminal Sixel geometry.")]
+    [TestMethod]
     public async Task AspectMacro_Omitted_UsesDecTwoToOneDefault()
     {
         var defaultAspect = new SixelFixture(
@@ -197,7 +197,7 @@ public class SixelParserTests
         Assert.Contains("B=#0000FFFF", grid);
     }
 
-    [TestMethod, Ignore("Owned by #447: DECGRA currently reverses Ph (width) and Pv (height).")]
+    [TestMethod]
     public async Task Decgra_PhAndPv_DefineHorizontalAndVerticalExtents()
     {
         var fixture = SixelFixture.Load("raster-extent", "DECGRA declares a 4x7 raster.");
@@ -216,7 +216,7 @@ public class SixelParserTests
         Assert.AreEqual(7, placement.HeightInCells);
     }
 
-    [TestMethod, Ignore("Owned by #447/#449: declared height and painted height are not yet reconciled by the terminal model.")]
+    [TestMethod]
     public async Task DeclaredHeight_PartialFinalBand_PreservesSevenPixelExtent()
     {
         var fixture = SixelFixture.Load("raster-extent", "DECGRA declares seven rows but paints one band.");
@@ -233,7 +233,7 @@ public class SixelParserTests
         Assert.AreEqual(7, TestSeq.Single(terminal.Observe().Placements).PixelHeight);
     }
 
-    [TestMethod, Ignore("Owned by #447: Ph/Pv are declarations, not clipping bounds.")]
+    [TestMethod]
     public async Task PaintedRaster_BeyondDeclaredExtent_ExpandsToPaintedExtent()
     {
         var payload = new SixelFixture(


### PR DESCRIPTION
Closes #447
Part of #445

## Summary
- add one internal incremental Sixel parser attached to the byte-stream DCS boundary
- model DEC header defaults, all Sixel commands, aspect/background state, raster attributes, palette mutations, cursor/data/painted/declared/logical geometry, structured diagnostics, and explicit outcomes
- use saturating arithmetic and bounded diagnostics/metadata/command retention while continuing geometry parsing after payload retention is disabled
- replace independent dimension/header/palette scans in `Hex1bTerminal`, `TrackedObjectStore`, `SixelData`, and `Automation.SixelDecoder` with the authoritative parse result/events
- preserve immediate byte-exact native passthrough and the existing 1 MiB DCS retention behavior
- unignore the #447 parser contracts and add split-boundary, recovery, overflow, RLE, extent, metadata-only, palette, and outcome coverage
- extend `SixelTerminalDemo` with independently authored grammar/geometry scenes and readable headless model output

## Validation
- focused parser, DCS framing, Sixel, encoder, tokenizer, terminal, automation, and surface tests
- all test projects: 8,739 core tests plus analyzer, MCP server, tool, and AgenticPromptDemo suites
- `dotnet build samples/SixelTerminalDemo/SixelTerminalDemo.csproj`
- `dotnet run --project samples/SixelTerminalDemo/SixelTerminalDemo.csproj -- --headless`

## Deferred by stage boundary
- #449: final raster semantics, DEC HLS conversion, background fill, shared palette persistence, and sparse raster storage
- #450: post-DCS terminal cursor, margin, mode, and protocol-metric semantics
- later placement, scrolling, lifecycle, snapshot, translation, widget, and emitter work