### PR TITLE
Add deterministic bounded Sixel rasterization

### DIFF
--- a/docs/sixel-terminal-behavior.md
+++ b/docs/sixel-terminal-behavior.md
@@ -110,8 +110,10 @@ of the terminal contract.
 | `Pan`/`Pad` override | DECGRA aspect overrides the `P1` macro | Last valid DECGRA aspect controls the sequence | Active incremental parser tests |
 | `Ph`/`Pv` orientation | `Ph` is width and `Pv` is height | Horizontal then vertical, without transposition | Active incremental parser and terminal tests |
 | Declared extent | Allocation hint, not a clipping rectangle | Final extent is the maximum of declared and data/painted extents | Active incremental parser tests |
-| Partial final band | Raster height may end within a six-row band | Preserve the declared pixel extent separately from band-rounded data geometry | Parser model active; final raster semantics remain in [#449](https://github.com/mitchdenny/hex1b/issues/449) |
-| Pathological ratios/extents | Modern terminals impose implementation bounds | Enforce centralized limits before allocation and report resource rejection | Exact limits remain an implementation decision |
+| Partial final band | Raster height may end within a six-row band | Painted bounds record the exact final row while the data extent stays band-rounded; the logical canvas is never resampled by the aspect ratio | Active rasterizer tests |
+| Aspect application | `Pan`/`Pad` scale the displayed image, not its stored rows | Store six logical rows per band unscaled and expose the aspect-scaled result as a separate rendered extent; no eager resampling | Active rasterizer tests |
+| Pathological ratios/extents | Modern terminals impose implementation bounds | Enforce centralized limits before allocation and report resource rejection as an explicit geometry-only result that preserves geometry and diagnostics | Limits centralized in `SixelCompatibilityPolicy`; exact values remain an implementation decision |
+| Large declared canvases | Terminals must survive very large `Ph`/`Pv` hints | Store pixels in lazily allocated tiles so a large declared canvas allocates in proportion to painted area, not declared area; materialize densely only on consumer request and within policy | Active rasterizer tests |
 | Fractional cell metrics | Modern terminals can report non-integral pixel metrics | Retain the best available metric and apply deterministic outward rounding for occupied cells | Harness records fractional width now |
 
 Windows Terminal reports an undocumented VT330 behavior in which DECGRA also
@@ -123,24 +125,40 @@ whether it belongs in an optional profile.
 
 | Behavior | DEC and reference terminals | Hex1b default | Status or unresolved work |
 |---|---|---|---|
-| RGB | Three 0-100% components | Clamp valid components to the DEC domain and convert deterministically to 8-bit RGB | Basic decoding active; parser work in #449 |
-| HLS | Hue 0 is blue, 120 is red, and 240 is green; lightness and saturation are percentages | Use the DEC hue wheel, not the CSS hue wheel | Current automation defect captured for #449 |
-| Register persistence | DEC has a shared palette; xterm, WezTerm, foot, Windows Terminal, and xterm.js persist by default | Share palette state between sequences on the same screen session | [#449](https://github.com/mitchdenny/hex1b/issues/449) |
-| Private registers | xterm mode 1070 and some terminal options provide per-image palettes | Shared by default; any private mode must be an explicit compatibility option | Support and reset details unresolved |
-| RIS | WezTerm resets its shared color map; other reviewed behavior is incomplete | Reset Sixel palette and placements to terminal defaults | [#453](https://github.com/mitchdenny/hex1b/issues/453) |
+| RGB | Three 0-100% components | Clamp valid components to the DEC domain and convert deterministically to 8-bit RGB with nearest rounding (`(percent * 255 + 50) / 100`) | Active rasterizer tests |
+| HLS | Hue 0 is blue, 120 is red, and 240 is green; lightness and saturation are percentages | Use the DEC hue wheel, not the CSS hue wheel; hue wraps modulo 360 and lightness/saturation clamp to 0-100 | Active rasterizer tests |
+| Default palette | DEC VT340 ships 16 hardware colors; modern terminals extend selection beyond them | Registers 0-15 are the VT340 defaults expressed in the DEC 0-100 domain; registers 16-255 extend them with the conventional 6x6x6 cube and grayscale ramp so selection without definition is defined for every register inside policy | Centralized in `SixelDefaultPalette`; exact values remain a [#457](https://github.com/mitchdenny/hex1b/issues/457) target |
+| Register count | DEC VT340 exposes 16; modern terminals commonly expose 256 | 256 terminal-scoped registers; selection or definition outside the policy is rejected explicitly with a diagnostic and never silently wrapped | Centralized in `SixelCompatibilityPolicy` |
+| Register persistence | DEC has a shared palette; xterm, WezTerm, foot, Windows Terminal, and xterm.js persist by default | Share palette state between sequences on the same terminal; definitions apply in command order even when rasterization degrades to geometry only | Active rasterizer and terminal tests |
+| Private registers | xterm mode 1070 and some terminal options provide per-image palettes | Shared by default; any private mode must be an explicit compatibility option expressed through `SixelCompatibilityPolicy.PaletteScope` | Support and reset details unresolved |
+| RIS | WezTerm resets its shared color map; other reviewed behavior is incomplete | Reset the Sixel palette to terminal defaults; placement reset remains later-stage work | Palette reset active; placements in [#453](https://github.com/mitchdenny/hex1b/issues/453) |
+| Alternate screen | Reviewed terminals keep one shared color map across screen buffers | Preserve palette registers across alternate-screen transitions | Active terminal tests |
 | DECSTR | Reference behavior is not sufficiently established | Preserve palette unless differential testing demonstrates a stable DEC-compatible reset rule | Explicitly unresolved for #457 |
 
 ### Background
 
 For `P2=1`, unpainted pixels preserve the underlying graphics or text result.
-For other values, Hex1b fills unpainted pixels with Sixel palette register 0.
-This matches xterm and WezTerm.
 
-Foot and xterm.js instead use the live terminal background. DEC describes the
-"current background color" without resolving this distinction. The selected
-register-0 behavior remains an explicit
+For `P2` 0 or 2, Hex1b fills unpainted pixels across the final logical extent
+with **the terminal background color captured when the graphic was created**.
+The captured value is fixed at creation time, so a later SGR background change
+never retroactively repaints an existing graphic. When the terminal background
+is unset, the fill is a deterministic black (`#000000FF`) so identical byte
+streams always produce identical rasters.
+
+This replaces the earlier provisional choice of Sixel palette register 0, which
+matched xterm and WezTerm. The selected behavior instead matches foot and
+xterm.js, and it keeps the opaque fill independent of a payload that redefines
+register 0 for its own drawing. DEC describes the "current background color"
+without resolving the distinction, so the alternative remains expressible
+through `SixelCompatibilityPolicy.BackgroundSource` rather than as a hidden
+branch, and stays a
 [#457](https://github.com/mitchdenny/hex1b/issues/457) differential-testing
 target.
+
+Because the captured background and the persistent palette both change how an
+identical payload rasterizes, tracked Sixel deduplication keys on the payload
+*and* a raster-state identity rather than on payload content alone.
 
 ## Placement, cursor, and modes
 
@@ -215,12 +233,14 @@ reference-terminal evidence:
 
 1. DECSDM compatibility polarity for an optional xterm profile.
 2. Whether mode 8452 should be implemented beyond its default reset behavior.
-3. Palette register 0 versus live terminal background for opaque `P2`.
+3. Whether an optional palette-register-0 opaque background profile is needed
+   alongside the selected captured-background behavior.
 4. DECGRA's undocumented carriage-return behavior and aspect-scaled DECGNL.
 5. Exact Sixel-over-Sixel compositing and partial-cell text/erase damage.
 6. DECSTR effects on palettes and placements.
 7. Main/alternate-screen, history eviction, resize, and reflow edge behavior.
-8. Default palette values and private-register behavior across modern terminals.
+8. Exact default palette values for registers 16-255 and private-register
+   behavior across modern terminals.
 
 ## Evidence and running the contract
 

--- a/samples/SixelTerminalDemo/Program.cs
+++ b/samples/SixelTerminalDemo/Program.cs
@@ -84,6 +84,14 @@ static IReadOnlyList<byte[]> BuildDemoOutput(
         var fixture = fixtures[index];
         chunks.Add(Encoding.ASCII.GetBytes($"[{fixture.Name}] Expected: {fixture.Expected}\r\n"));
         chunks.Add(Encoding.ASCII.GetBytes($"Model: {modelDescriptions[index]}\r\n"));
+        if (fixture.SetupDcsBytes is { } setup)
+        {
+            chunks.Add(Encoding.ASCII.GetBytes(
+                $"Setup: {fixture.SetupPayload}\r\n"));
+            chunks.Add(setup);
+            chunks.Add(Encoding.ASCII.GetBytes("\r\n"));
+        }
+
         chunks.Add(fixture.StandardDcsBytes);
         chunks.Add(Encoding.ASCII.GetBytes("\r\n\r\n"));
     }
@@ -91,7 +99,7 @@ static IReadOnlyList<byte[]> BuildDemoOutput(
     if (!includeTransportScenes)
     {
         chunks.Add(Encoding.ASCII.GetBytes(
-            "Stage 3: one incremental parser owns Sixel grammar, geometry, palette metadata, and outcomes.\r\n"));
+            "Stage 4: the same parser feeds one deterministic bounded rasterizer for color, background, and aspect.\r\n"));
         return chunks;
     }
 
@@ -117,7 +125,7 @@ static IReadOnlyList<byte[]> BuildDemoOutput(
     chunks.Add(Encoding.ASCII.GetBytes("\r\n\r\n"));
 
     chunks.Add(Encoding.ASCII.GetBytes(
-        "Stage 3: one incremental parser owns Sixel grammar, geometry, palette metadata, and outcomes.\r\n"));
+        "Stage 4: the same parser feeds one deterministic bounded rasterizer for color, background, and aspect.\r\n"));
     return chunks;
 }
 
@@ -144,7 +152,15 @@ static async Task<string> InspectModelAsync(RawSixelFixture fixture)
         CellPixelWidth = 1,
         CellPixelHeight = 1,
     };
-    var workload = new DemoWorkloadAdapter([fixture.StandardDcsBytes]);
+    var chunks = new List<byte[]>();
+    if (fixture.SetupDcsBytes is { } setup)
+    {
+        chunks.Add(setup);
+        chunks.Add(Encoding.ASCII.GetBytes("\r\n"));
+    }
+
+    chunks.Add(fixture.StandardDcsBytes);
+    var workload = new DemoWorkloadAdapter(chunks);
     await using var terminal = Hex1bTerminal.CreateBuilder()
         .WithWorkload(workload)
         .WithPresentation(new HeadlessPresentationAdapter(80, 24, capabilities))
@@ -153,29 +169,72 @@ static async Task<string> InspectModelAsync(RawSixelFixture fixture)
     await terminal.RunAsync();
 
     using var snapshot = terminal.CreateSnapshot();
-    for (var y = 0; y < snapshot.Height; y++)
+    SixelData? inspected = null;
+    for (var y = 0; y < snapshot.Height && inspected is null; y++)
     {
         for (var x = 0; x < snapshot.Width; x++)
         {
             var sixel = snapshot.GetCell(x, y).SixelData;
-            if (sixel is null)
+            if (sixel is not null && sixel.Payload == fixture.Payload)
             {
-                continue;
+                inspected = sixel;
+                break;
             }
-
-            var raster = sixel.GetPixels();
-            var rasterDescription = raster is null
-                ? "metadata-only"
-                : $"retained raster {raster.Width}x{raster.Height}";
-            var declaredDescription = sixel.PixelWidth > 0 && sixel.PixelHeight > 0
-                ? $"declared {sixel.PixelWidth}x{sixel.PixelHeight}px"
-                : "no declared extent";
-            return $"{declaredDescription}, logical geometry " +
-                $"{sixel.WidthInCells}x{sixel.HeightInCells}px, {rasterDescription}";
         }
     }
 
-    return "no placement";
+    if (inspected is null)
+    {
+        return "no placement";
+    }
+
+    return DescribeModel(inspected);
+}
+
+static string DescribeModel(SixelData sixel)
+{
+    var builder = new StringBuilder();
+    builder.Append(sixel.PixelWidth > 0 && sixel.PixelHeight > 0
+        ? $"declared {sixel.PixelWidth}x{sixel.PixelHeight}px"
+        : "no declared extent");
+
+    // The inspection terminal uses 1x1 cell metrics, so the occupied cell span is
+    // the aspect-scaled rendered extent in pixels.
+    builder.Append($", rendered {sixel.WidthInCells}x{sixel.HeightInCells}px");
+
+    var raster = sixel.GetPixels();
+    if (raster is null)
+    {
+        builder.Append(", raster geometry-only (no pixels allocated)");
+        return builder.ToString();
+    }
+
+    builder.Append($", logical raster {raster.Width}x{raster.Height}");
+    builder.Append($", top-left {Describe(raster[0, 0])}");
+    builder.Append($", bottom-right {Describe(raster[raster.Width - 1, raster.Height - 1])}");
+    var distinct = CountDistinctColors(raster);
+    builder.Append($", {distinct} distinct color{(distinct == 1 ? "" : "s")}");
+    return builder.ToString();
+
+    static string Describe(Hex1b.Surfaces.Rgba32 pixel) =>
+        pixel.A == 0
+            ? "transparent"
+            : $"#{pixel.R:X2}{pixel.G:X2}{pixel.B:X2}";
+
+    static int CountDistinctColors(Hex1b.Surfaces.SixelPixelBuffer raster)
+    {
+        var seen = new HashSet<uint>();
+        for (var y = 0; y < raster.Height; y++)
+        {
+            for (var x = 0; x < raster.Width; x++)
+            {
+                var pixel = raster[x, y];
+                seen.Add(((uint)pixel.R << 24) | ((uint)pixel.G << 16) | ((uint)pixel.B << 8) | pixel.A);
+            }
+        }
+
+        return seen.Count;
+    }
 }
 
 static void AddChunks(List<byte[]> chunks, byte[] bytes, IReadOnlyList<int> sizes)

--- a/samples/SixelTerminalDemo/RawSixelFixtures.cs
+++ b/samples/SixelTerminalDemo/RawSixelFixtures.cs
@@ -3,10 +3,18 @@ using System.Text;
 internal sealed record RawSixelFixture(
     string Name,
     string Expected,
-    string Payload)
+    string Payload,
+    string? SetupPayload = null)
 {
     public byte[] StandardDcsBytes =>
         Encoding.ASCII.GetBytes($"\x1bP{Payload}\x1b\\");
+
+    /// <summary>
+    /// An optional sequence sent before <see cref="Payload"/> so a scene can
+    /// depend on terminal-scoped Sixel state such as persistent color registers.
+    /// </summary>
+    public byte[]? SetupDcsBytes =>
+        SetupPayload is null ? null : Encoding.ASCII.GetBytes($"\x1bP{SetupPayload}\x1b\\");
 }
 
 internal static class RawSixelFixtures
@@ -21,33 +29,72 @@ internal static class RawSixelFixtures
             "0;0q\"1;1;240;60#1;2;100;0;0#1" +
                 RepeatBands("!240~", 10)),
         new(
+            "RGB rounding",
+            "three 240x6 bars at 0%, 50%, and 100% red; 50% rounds to 128, not 127",
+            "0;1q\"1;1;240;18#1;2;0;0;0#2;2;50;0;0#3;2;100;0;0" +
+                "#1!240~-#2!240~-#3!240~"),
+        new(
             "Two-color carriage return",
             "a 240x36 block with obvious green/red stripes overprinted using DECGCR",
             "0;1q\"1;1;240;36#1;2;100;0;0#2;2;0;100;0" +
                 RepeatBands("#1!240w$#2!240B", 6)),
+        new(
+            "Overprint wins last",
+            "red paints first and green overprints the same pixels through DECGCR",
+            "0;1q\"1;1;240;6#1;2;100;0;0#2;2;0;100;0#1!240~$#2!240~"),
         new(
             "HLS color",
             "a 240x24 block defined with HLS coordinates",
             "0;0q\"1;1;240;24#3;1;0;50;100#3" +
                 RepeatBands("!240~", 4)),
         new(
+            "DEC HLS hue wheel",
+            "hue 0 is blue, 120 is red, and 240 is green on the DEC wheel",
+            "0;1q\"1;1;240;18#1;1;0;50;100#2;1;120;50;100#3;1;240;50;100" +
+                "#1!240~-#2!240~-#3!240~"),
+        new(
+            "Palette persistence",
+            "the second sequence selects register 5 without defining it and stays red",
+            "0;1q\"1;1;240;6#5!240~",
+            SetupPayload: "0;1q\"1;1;240;6#5;2;100;0;0#5!240~"),
+        new(
             "Transparent background",
             "a 240x24 field with thick red rules and transparent gaps",
             "0;1q\"1;1;240;24#1;2;100;0;0#1" +
                 RepeatBands("!240N", 4)),
         new(
+            "Opaque background",
+            "P2=0 fills every unpainted pixel of the canvas with the captured terminal background",
+            "0;0q\"1;1;240;24#1;2;100;0;0#1!240@"),
+        new(
             "DEC default aspect macro",
             "omitted P1 selects 2:1 pixels; 120 complete columns have 120x12 logical geometry",
             "q#1;2;100;0;0#1!120~"),
+        new(
+            "Square aspect macro",
+            "P1=7 selects 1:1 pixels, so the same six rows render half as tall as the 2:1 default",
+            "7;1q#1;2;100;0;0#1!120~"),
+        new(
+            "DECGRA Pan and Pad",
+            "Pan=3 and Pad=1 override the P1 macro and render six logical rows as eighteen",
+            "7;1q\"3;1;240;6#1;2;100;0;0#1!240~"),
         new(
             "Declared extent is a hint",
             "an 80x24 green declared region is followed by red overflow; the model grows to 240x60",
             "7q\"1;1;80;24#1;2;100;0;0#2;2;0;100;0" +
                 RepeatBands("#2!80~#1!160~", 10)),
         new(
+            "Partial band",
+            "the second band paints only its top two rows, so the painted height is exactly eight",
+            "7;1q\"1;1;240;8#1;2;100;0;0#1!240~-!240B"),
+        new(
             "Transparent geometry",
             "240 transparent columns set geometry; DECGCR then paints only the leftmost 80",
             "7;1q!240?$#1;2;100;0;100#1!80~"),
+        new(
+            "Geometry only",
+            "a declared canvas beyond the raster policy keeps geometry but allocates no pixels",
+            "7;1q\"1;1;999999999;999999999#1;2;100;0;0#1!240~"),
     ];
 
     private static string RepeatBands(string band, int count) =>

--- a/src/Hex1b/Automation/SixelDecoder.cs
+++ b/src/Hex1b/Automation/SixelDecoder.cs
@@ -6,21 +6,30 @@ namespace Hex1b.Automation;
 /// Decodes Sixel graphics data to raw pixel arrays for SVG rendering.
 /// </summary>
 /// <remarks>
-/// This compatibility decoder consumes the authoritative incremental Sixel
-/// parser result. It does not independently scan raw payload text.
+/// <para>
+/// This compatibility shim owns no grammar, color, or raster logic. It consumes
+/// the authoritative incremental Sixel parser and delegates every pixel decision
+/// to the bounded <c>SixelRasterizer</c>.
+/// </para>
+/// <para>
+/// It returns <see langword="null"/> only for the documented failure and
+/// degradation cases: an empty payload, a parse outcome that is not a complete
+/// graphic, or an explicit geometry-only raster produced when resource policy
+/// refuses pixel allocation.
+/// </para>
 /// </remarks>
 public static class SixelDecoder
 {
-    private const int MaximumDecodedPixels = 16 * 1024 * 1024;
-    private const long MaximumRasterOperations = MaximumDecodedPixels * 4L;
-
     /// <summary>
     /// Decodes a Sixel DCS payload to raw RGBA pixel data.
     /// </summary>
     /// <param name="payload">The Sixel payload (including or excluding DCS wrapper).</param>
-    /// <param name="cellWidth">The width of a terminal cell in pixels.</param>
-    /// <param name="cellHeight">The height of a terminal cell in pixels.</param>
-    /// <returns>Decoded image with RGBA pixel data, or null if decoding cannot be retained safely.</returns>
+    /// <param name="cellWidth">The width of a terminal cell in pixels. Unused; retained for source compatibility.</param>
+    /// <param name="cellHeight">The height of a terminal cell in pixels. Unused; retained for source compatibility.</param>
+    /// <returns>
+    /// Decoded image with RGBA pixel data, or <see langword="null"/> when the
+    /// payload is empty or the rasterizer explicitly returned geometry only.
+    /// </returns>
     public static SixelImage? Decode(string payload, int cellWidth = 9, int cellHeight = 18)
     {
         if (string.IsNullOrEmpty(payload))
@@ -33,193 +42,35 @@ public static class SixelDecoder
         return Decode(SixelParser.ParsePayload(payload));
     }
 
-    internal static SixelImage? Decode(SixelParseResult result)
+    internal static SixelImage? Decode(SixelParseResult result) =>
+        Decode(SixelRasterizer.Rasterize(result, SixelRasterEnvironment.CreateDefault()));
+
+    internal static SixelImage? Decode(SixelData data) => Decode(data.Raster);
+
+    internal static SixelImage? Decode(SixelRasterResult raster)
     {
-        if (!result.CommandsComplete ||
-            result.Outcome is SixelParseOutcome.Cancelled or
-                SixelParseOutcome.Malformed or
-                SixelParseOutcome.Rejected)
+        if (raster.Status != SixelRasterStatus.Rasterized || raster.Image is null)
         {
             return null;
         }
 
-        var width = result.DeclaredExtent.Width;
-        var height = result.DeclaredExtent.Height;
-        var hasData = false;
-        long rasterOperations = 0;
-        foreach (var command in result.Commands)
+        var image = raster.Image;
+        var pixels = new byte[checked((int)image.PixelCount * 4)];
+        var index = 0;
+        for (var y = 0; y < image.Height; y++)
         {
-            if (command.Kind != SixelCommandKind.Data)
+            for (var x = 0; x < image.Width; x++)
             {
-                continue;
-            }
-
-            hasData = true;
-            width = Math.Max(width, SaturatingAdd(command.X, command.RepeatCount));
-            height = Math.Max(height, SaturatingMultiply(SaturatingAdd(command.Band, 1), 6));
-            rasterOperations += (long)command.RepeatCount *
-                System.Numerics.BitOperations.PopCount((uint)command.Value);
-            if (rasterOperations > MaximumRasterOperations)
-            {
-                return null;
+                var pixel = image[x, y];
+                pixels[index++] = pixel.R;
+                pixels[index++] = pixel.G;
+                pixels[index++] = pixel.B;
+                pixels[index++] = pixel.A;
             }
         }
 
-        if (!hasData || width <= 0 || height <= 0)
-        {
-            return null;
-        }
-
-        var pixelCount = (long)width * height;
-        if (pixelCount > MaximumDecodedPixels)
-        {
-            return null;
-        }
-
-        var pixels = new byte[checked((int)pixelCount * 4)];
-        var palette = new Dictionary<int, (byte R, byte G, byte B)>();
-        InitializeDefaultPalette(palette);
-        var selectedColor = 0;
-
-        foreach (var command in result.Commands)
-        {
-            if (command.Kind == SixelCommandKind.Palette &&
-                command.Palette is { } paletteCommand)
-            {
-                selectedColor = paletteCommand.Register;
-                if (paletteCommand.IsDefinition)
-                {
-                    palette[paletteCommand.Register] = ConvertColor(paletteCommand);
-                }
-                continue;
-            }
-
-            if (command.Kind != SixelCommandKind.Data ||
-                command.Value == 0 ||
-                !palette.TryGetValue(selectedColor, out var color))
-            {
-                continue;
-            }
-
-            var endX = Math.Min(width, SaturatingAdd(command.X, command.RepeatCount));
-            for (var x = command.X; x < endX; x++)
-            {
-                for (var bit = 0; bit < 6; bit++)
-                {
-                    if ((command.Value & (1 << bit)) == 0)
-                    {
-                        continue;
-                    }
-
-                    var y = SaturatingAdd(SaturatingMultiply(command.Band, 6), bit);
-                    if (y >= height)
-                    {
-                        continue;
-                    }
-
-                    var pixelIndex = checked(((y * width) + x) * 4);
-                    pixels[pixelIndex] = color.R;
-                    pixels[pixelIndex + 1] = color.G;
-                    pixels[pixelIndex + 2] = color.B;
-                    pixels[pixelIndex + 3] = 255;
-                }
-            }
-        }
-
-        return new SixelImage(width, height, pixels);
+        return new SixelImage(image.Width, image.Height, pixels);
     }
-
-    private static (byte R, byte G, byte B) ConvertColor(SixelPaletteCommand command)
-    {
-        var x = command.X ?? 0;
-        var y = command.Y ?? 0;
-        var z = command.Z ?? 0;
-        return command.ColorSpace switch
-        {
-            SixelColorSpace.Rgb => (
-                PercentageToByte(x),
-                PercentageToByte(y),
-                PercentageToByte(z)),
-            SixelColorSpace.Hls => HlsToRgb(x, y, z),
-            _ => (0, 0, 0),
-        };
-    }
-
-    private static byte PercentageToByte(int value) =>
-        (byte)(Math.Clamp(value, 0, 100) * 255 / 100);
-
-    private static void InitializeDefaultPalette(Dictionary<int, (byte R, byte G, byte B)> palette)
-    {
-        palette[0] = (0, 0, 0);
-        palette[1] = (51, 51, 255);
-        palette[2] = (255, 51, 51);
-        palette[3] = (51, 255, 51);
-        palette[4] = (255, 51, 255);
-        palette[5] = (51, 255, 255);
-        palette[6] = (255, 255, 51);
-        palette[7] = (250, 250, 250);
-        palette[8] = (128, 128, 128);
-        palette[9] = (102, 102, 255);
-        palette[10] = (255, 102, 102);
-        palette[11] = (102, 255, 102);
-        palette[12] = (255, 102, 255);
-        palette[13] = (102, 255, 255);
-        palette[14] = (255, 255, 102);
-        palette[15] = (255, 255, 255);
-    }
-
-    private static (byte R, byte G, byte B) HlsToRgb(int h, int l, int s)
-    {
-        var hue = Math.Clamp(h, 0, 360) / 360.0;
-        var lightness = Math.Clamp(l, 0, 100) / 100.0;
-        var saturation = Math.Clamp(s, 0, 100) / 100.0;
-
-        if (saturation == 0)
-        {
-            var component = (byte)(lightness * 255);
-            return (component, component, component);
-        }
-
-        var q = lightness < 0.5
-            ? lightness * (1 + saturation)
-            : lightness + saturation - lightness * saturation;
-        var p = 2 * lightness - q;
-        return (
-            (byte)(HueToRgb(p, q, hue + (1.0 / 3)) * 255),
-            (byte)(HueToRgb(p, q, hue) * 255),
-            (byte)(HueToRgb(p, q, hue - (1.0 / 3)) * 255));
-    }
-
-    private static double HueToRgb(double p, double q, double t)
-    {
-        if (t < 0)
-        {
-            t += 1;
-        }
-        if (t > 1)
-        {
-            t -= 1;
-        }
-        if (t < 1.0 / 6)
-        {
-            return p + (q - p) * 6 * t;
-        }
-        if (t < 1.0 / 2)
-        {
-            return q;
-        }
-        if (t < 2.0 / 3)
-        {
-            return p + (q - p) * (2.0 / 3 - t) * 6;
-        }
-        return p;
-    }
-
-    private static int SaturatingAdd(int left, int right) =>
-        right <= int.MaxValue - left ? left + right : int.MaxValue;
-
-    private static int SaturatingMultiply(int left, int right) =>
-        left <= int.MaxValue / right ? left * right : int.MaxValue;
 }
 
 /// <summary>

--- a/src/Hex1b/Automation/TerminalRegionSvgExtensions.cs
+++ b/src/Hex1b/Automation/TerminalRegionSvgExtensions.cs
@@ -400,7 +400,7 @@ public static class TerminalRegionSvgExtensions
                     continue;
                 
                 // Decode sixel to image
-                var image = SixelDecoder.Decode(sixelData.ParseResult);
+                var image = SixelDecoder.Decode(sixelData);
                 if (image == null || image.Width == 0 || image.Height == 0)
                     continue;
                 

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -61,6 +61,11 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     private readonly CancellationTokenSource _disposeCts = new();
     private readonly DateTimeOffset _sessionStart;
     private readonly TrackedObjectStore _trackedObjects = new();
+
+    // Terminal-scoped Sixel color registers. Palette definitions persist between
+    // Sixel sequences and across alternate-screen transitions; only RIS restores
+    // the default palette.
+    private readonly Sixel.SixelColorRegisters _sixelColorRegisters = new();
     private readonly TimeProvider _timeProvider;
     private readonly KgpTerminalGraphicsState _kgpGraphicsState = new();
     private ITimer? _kgpAnimationTimer;
@@ -3240,6 +3245,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 _charsetG2 = 'B';
                 _charsetG3 = 'B';
                 _activeCharsetSlot = 0;
+                _sixelColorRegisters.Reset();
                 InitializeTabStops();
                 // Clear screen
                 for (int row = 0; row < _height; row++)
@@ -5830,6 +5836,27 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
+    /// Captures the background color used to fill unpainted pixels of an opaque
+    /// (<c>P2</c> 0 or 2) Sixel graphic.
+    /// </summary>
+    /// <remarks>
+    /// The background is captured at graphic creation time. When no background is
+    /// selected, the deterministic policy default is used.
+    /// </remarks>
+    private Surfaces.Rgba32 CaptureSixelBackground()
+    {
+        var policy = _sixelColorRegisters.Policy;
+        if (policy.BackgroundSource != SixelBackgroundSource.CapturedTerminalBackground)
+        {
+            return policy.DefaultBackground;
+        }
+
+        return _currentBackground is { IsDefault: false } background
+            ? new Surfaces.Rgba32(background.R, background.G, background.B, 255)
+            : policy.DefaultBackground;
+    }
+
+    /// <summary>
     /// Processes Sixel data by creating a tracked object and marking cells.
     /// </summary>
     private void ProcessSixelData(
@@ -5837,6 +5864,16 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         SixelParseResult parseResult,
         List<CellImpact>? impacts)
     {
+        // Rasterize against the live terminal graphics state. This applies palette
+        // definitions to the persistent register file in command order and captures
+        // the background in effect when the graphic was created.
+        var raster = SixelRasterizer.Rasterize(
+            parseResult,
+            new SixelRasterEnvironment(
+                CaptureSixelBackground(),
+                _sixelColorRegisters,
+                _sixelColorRegisters.Policy));
+
         var pixelWidth = Math.Max(1, parseResult.LogicalCanvasExtent.Width);
         var pixelHeight = Math.Max(1, parseResult.LogicalCanvasExtent.Height);
         var cellWidth = Math.Max(1d, Capabilities.EffectiveCellPixelWidth);
@@ -5853,7 +5890,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             sixelPayload,
             widthInCells,
             heightInCells,
-            parseResult);
+            parseResult,
+            raster);
 
         // Mark cells covered by this Sixel image
         // The first cell gets the tracked object, others just get the Sixel flag

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -5864,10 +5864,10 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         SixelParseResult parseResult,
         List<CellImpact>? impacts)
     {
-        // Rasterize against the live terminal graphics state. This applies palette
-        // definitions to the persistent register file in command order and captures
-        // the background in effect when the graphic was created.
-        var raster = SixelRasterizer.Rasterize(
+        // Capture immutable raster inputs while applying only palette metadata to
+        // the terminal-scoped state. Pixel painting remains lazy, so the terminal
+        // buffer lock never covers raster work.
+        var rasterPreparation = SixelRasterizer.Prepare(
             parseResult,
             new SixelRasterEnvironment(
                 CaptureSixelBackground(),
@@ -5891,7 +5891,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             widthInCells,
             heightInCells,
             parseResult,
-            raster);
+            rasterPreparation);
 
         // Mark cells covered by this Sixel image
         // The first cell gets the tracked object, others just get the Sixel flag

--- a/src/Hex1b/Sixel/SixelColorConverter.cs
+++ b/src/Hex1b/Sixel/SixelColorConverter.cs
@@ -1,0 +1,116 @@
+using Hex1b.Surfaces;
+
+namespace Hex1b.Sixel;
+
+/// <summary>
+/// Deterministic DEC color conversions for Sixel color registers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// All conversions use integer arithmetic so results are reproducible and
+/// testable. Percentages are clamped to the DEC 0-100 domain and converted to
+/// 8-bit components with nearest rounding (ties away from zero).
+/// </para>
+/// <para>
+/// DEC HLS is not CSS HLS: hue 0 is blue, 120 is red, and 240 is green. Hue
+/// wraps around the wheel rather than clamping.
+/// </para>
+/// </remarks>
+internal static class SixelColorConverter
+{
+    private const int Scale = 10_000;
+
+    /// <summary>
+    /// Converts a DEC 0-100 percentage to an 8-bit component with nearest rounding.
+    /// </summary>
+    public static byte PercentToComponent(int percent)
+    {
+        var clamped = Math.Clamp(percent, 0, 100);
+        return (byte)(((clamped * 255) + 50) / 100);
+    }
+
+    /// <summary>
+    /// Converts DEC RGB percentages to an opaque color.
+    /// </summary>
+    public static Rgba32 FromRgbPercent(int red, int green, int blue) => new(
+        PercentToComponent(red),
+        PercentToComponent(green),
+        PercentToComponent(blue),
+        255);
+
+    /// <summary>
+    /// Converts DEC HLS coordinates to an opaque color using the DEC hue wheel.
+    /// </summary>
+    /// <param name="hue">Hue in degrees; blue at 0, red at 120, green at 240. Wraps.</param>
+    /// <param name="lightness">Lightness percentage, clamped to 0-100.</param>
+    /// <param name="saturation">Saturation percentage, clamped to 0-100.</param>
+    public static Rgba32 FromHls(int hue, int lightness, int saturation)
+    {
+        var lum = Math.Clamp(lightness, 0, 100) * (Scale / 100);
+        var sat = Math.Clamp(saturation, 0, 100) * (Scale / 100);
+        if (sat == 0)
+        {
+            var gray = ScaleToComponent(lum);
+            return new Rgba32(gray, gray, gray, 255);
+        }
+
+        // DEC places blue at hue 0; the interpolation below uses the conventional
+        // wheel where red is at 0, so rotate by 240 degrees.
+        var wheel = Wrap360(hue + 240);
+        var high = lum <= Scale / 2
+            ? (int)DivideRounded((long)lum * (Scale + sat), Scale)
+            : lum + sat - (int)DivideRounded((long)lum * sat, Scale);
+        var low = (2 * lum) - high;
+
+        return new Rgba32(
+            ScaleToComponent(Interpolate(low, high, Wrap360(wheel + 120))),
+            ScaleToComponent(Interpolate(low, high, wheel)),
+            ScaleToComponent(Interpolate(low, high, Wrap360(wheel - 120))),
+            255);
+    }
+
+    /// <summary>
+    /// Converts a parsed DEC color introducer definition to a color.
+    /// </summary>
+    public static Rgba32 FromDefinition(SixelPaletteCommand command) => command.ColorSpace switch
+    {
+        SixelColorSpace.Rgb => FromRgbPercent(command.X ?? 0, command.Y ?? 0, command.Z ?? 0),
+        SixelColorSpace.Hls => FromHls(command.X ?? 0, command.Y ?? 0, command.Z ?? 0),
+        _ => new Rgba32(0, 0, 0, 255),
+    };
+
+    private static int Interpolate(int low, int high, int degrees)
+    {
+        if (degrees < 60)
+        {
+            return low + (int)DivideRounded((long)(high - low) * degrees, 60);
+        }
+
+        if (degrees < 180)
+        {
+            return high;
+        }
+
+        if (degrees < 240)
+        {
+            return low + (int)DivideRounded((long)(high - low) * (240 - degrees), 60);
+        }
+
+        return low;
+    }
+
+    private static byte ScaleToComponent(int scaled)
+    {
+        var clamped = Math.Clamp(scaled, 0, Scale);
+        return (byte)(((clamped * 255) + (Scale / 2)) / Scale);
+    }
+
+    private static long DivideRounded(long value, long divisor) =>
+        (value + (divisor / 2)) / divisor;
+
+    private static int Wrap360(int degrees)
+    {
+        var wrapped = degrees % 360;
+        return wrapped < 0 ? wrapped + 360 : wrapped;
+    }
+}

--- a/src/Hex1b/Sixel/SixelColorRegisters.cs
+++ b/src/Hex1b/Sixel/SixelColorRegisters.cs
@@ -1,0 +1,150 @@
+using Hex1b.Surfaces;
+
+namespace Hex1b.Sixel;
+
+/// <summary>
+/// The selected Hex1b default Sixel palette.
+/// </summary>
+/// <remarks>
+/// Registers 0-15 are the DEC VT340 defaults expressed in the DEC 0-100 domain
+/// and converted with the same deterministic rounding used by DECGCI. Registers
+/// 16-255 extend the VT340 set with the conventional modern 6x6x6 color cube and
+/// grayscale ramp so selection without definition is defined for every register
+/// inside policy.
+/// </remarks>
+internal static class SixelDefaultPalette
+{
+    private static readonly (int R, int G, int B)[] Vt340Percentages =
+    [
+        (0, 0, 0),
+        (20, 20, 80),
+        (80, 13, 13),
+        (20, 80, 20),
+        (80, 20, 80),
+        (20, 80, 80),
+        (80, 80, 20),
+        (53, 53, 53),
+        (26, 26, 26),
+        (33, 33, 60),
+        (60, 26, 26),
+        (33, 60, 33),
+        (60, 33, 60),
+        (33, 60, 60),
+        (60, 60, 33),
+        (80, 80, 80),
+    ];
+
+    private static readonly byte[] CubeLevels = [0, 95, 135, 175, 215, 255];
+
+    /// <summary>
+    /// Gets the number of DEC VT340 registers that use hardware default colors.
+    /// </summary>
+    public const int Vt340RegisterCount = 16;
+
+    /// <summary>
+    /// Writes the default palette into <paramref name="destination"/>.
+    /// </summary>
+    public static void Fill(Span<Rgba32> destination)
+    {
+        for (var register = 0; register < destination.Length; register++)
+        {
+            destination[register] = Get(register);
+        }
+    }
+
+    /// <summary>
+    /// Gets the default color for a register index.
+    /// </summary>
+    public static Rgba32 Get(int register)
+    {
+        if (register < 0)
+        {
+            return new Rgba32(0, 0, 0, 255);
+        }
+
+        if (register < Vt340RegisterCount)
+        {
+            var (r, g, b) = Vt340Percentages[register];
+            return SixelColorConverter.FromRgbPercent(r, g, b);
+        }
+
+        if (register < 232)
+        {
+            var index = register - 16;
+            return new Rgba32(
+                CubeLevels[(index / 36) % 6],
+                CubeLevels[(index / 6) % 6],
+                CubeLevels[index % 6],
+                255);
+        }
+
+        if (register < 256)
+        {
+            var level = (byte)(8 + ((register - 232) * 10));
+            return new Rgba32(level, level, level, 255);
+        }
+
+        return new Rgba32(0, 0, 0, 255);
+    }
+}
+
+/// <summary>
+/// Terminal-scoped, persistent Sixel color registers.
+/// </summary>
+/// <remarks>
+/// Registers survive between Sixel sequences, across alternate-screen
+/// transitions, and across DECSTR. Only RIS restores the default palette.
+/// </remarks>
+internal sealed class SixelColorRegisters
+{
+    private readonly Rgba32[] _registers;
+
+    public SixelColorRegisters(SixelCompatibilityPolicy? policy = null)
+    {
+        Policy = policy ?? SixelCompatibilityPolicy.Default;
+        _registers = new Rgba32[Policy.ColorRegisterCount];
+        SixelDefaultPalette.Fill(_registers);
+    }
+
+    private SixelColorRegisters(SixelCompatibilityPolicy policy, Rgba32[] registers)
+    {
+        Policy = policy;
+        _registers = registers;
+    }
+
+    /// <summary>
+    /// Gets the policy that bounds this register file.
+    /// </summary>
+    public SixelCompatibilityPolicy Policy { get; }
+
+    /// <summary>
+    /// Gets the number of addressable registers.
+    /// </summary>
+    public int Count => _registers.Length;
+
+    /// <summary>
+    /// Determines whether a register number is inside the configured policy.
+    /// </summary>
+    public bool IsWithinPolicy(int register) => register >= 0 && register < _registers.Length;
+
+    /// <summary>
+    /// Gets the current color for an in-policy register.
+    /// </summary>
+    public Rgba32 Get(int register) => _registers[register];
+
+    /// <summary>
+    /// Defines an in-policy register.
+    /// </summary>
+    public void Define(int register, Rgba32 color) => _registers[register] = color;
+
+    /// <summary>
+    /// Restores every register to its default value.
+    /// </summary>
+    public void Reset() => SixelDefaultPalette.Fill(_registers);
+
+    /// <summary>
+    /// Creates an independent copy for private-per-graphic compatibility policies
+    /// and for deterministic test inspection.
+    /// </summary>
+    public SixelColorRegisters Snapshot() => new(Policy, [.. _registers]);
+}

--- a/src/Hex1b/Sixel/SixelCompatibilityPolicy.cs
+++ b/src/Hex1b/Sixel/SixelCompatibilityPolicy.cs
@@ -1,0 +1,85 @@
+using Hex1b.Surfaces;
+
+namespace Hex1b.Sixel;
+
+/// <summary>
+/// Identifies where opaque (<c>P2</c> 0 or 2) Sixel backgrounds come from.
+/// </summary>
+internal enum SixelBackgroundSource
+{
+    /// <summary>
+    /// Use the terminal background captured when the graphic was created.
+    /// </summary>
+    CapturedTerminalBackground,
+
+    /// <summary>
+    /// Use Sixel color register zero, the xterm/WezTerm compatibility behavior.
+    /// </summary>
+    PaletteRegisterZero,
+}
+
+/// <summary>
+/// Identifies whether color registers are shared by the terminal or private per graphic.
+/// </summary>
+internal enum SixelPaletteScope
+{
+    TerminalPersistent,
+    PrivatePerGraphic,
+}
+
+/// <summary>
+/// Centralized, reviewable Sixel compatibility and resource policy.
+/// </summary>
+/// <remarks>
+/// Every deviation from the DEC VT340 baseline and every allocation bound lives
+/// here so it is testable and never expressed as a terminal-name check.
+/// </remarks>
+internal sealed record SixelCompatibilityPolicy
+{
+    /// <summary>
+    /// Gets the selected Hex1b policy described by <c>docs/sixel-terminal-behavior.md</c>.
+    /// </summary>
+    public static SixelCompatibilityPolicy Default { get; } = new();
+
+    /// <summary>
+    /// Gets the number of addressable color registers. Registers outside this
+    /// range are explicitly rejected rather than silently wrapped.
+    /// </summary>
+    public int ColorRegisterCount { get; init; } = 256;
+
+    /// <summary>
+    /// Gets the source used to fill unpainted pixels for opaque backgrounds.
+    /// </summary>
+    public SixelBackgroundSource BackgroundSource { get; init; } =
+        SixelBackgroundSource.CapturedTerminalBackground;
+
+    /// <summary>
+    /// Gets the deterministic background used when the terminal background is unset.
+    /// </summary>
+    public Rgba32 DefaultBackground { get; init; } = new(0, 0, 0, 255);
+
+    /// <summary>
+    /// Gets the palette lifetime scope.
+    /// </summary>
+    public SixelPaletteScope PaletteScope { get; init; } = SixelPaletteScope.TerminalPersistent;
+
+    /// <summary>
+    /// Gets the maximum number of logical pixels a single graphic may materialize.
+    /// </summary>
+    public long MaximumRasterPixels { get; init; } = 16L * 1024 * 1024;
+
+    /// <summary>
+    /// Gets the maximum number of pixel writes performed while rasterizing.
+    /// </summary>
+    public long MaximumRasterOperations { get; init; } = 64L * 1024 * 1024;
+
+    /// <summary>
+    /// Gets the maximum number of sparse tiles retained for a single graphic.
+    /// </summary>
+    public int MaximumRasterTiles { get; init; } = 4 * 1024;
+
+    /// <summary>
+    /// Gets the edge length of a sparse raster tile.
+    /// </summary>
+    public int RasterTileSize { get; init; } = 64;
+}

--- a/src/Hex1b/Sixel/SixelRasterImage.cs
+++ b/src/Hex1b/Sixel/SixelRasterImage.cs
@@ -1,0 +1,151 @@
+using Hex1b.Surfaces;
+
+namespace Hex1b.Sixel;
+
+/// <summary>
+/// Bounded sparse raster storage for a decoded Sixel graphic.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Painted pixels are stored in lazily allocated square tiles so a sequence that
+/// declares a very large transparent or background-filled canvas never allocates
+/// in proportion to its declared extent. Unpainted pixels resolve to
+/// <see cref="UnpaintedPixel"/>, which is the captured background for opaque
+/// graphics and transparent for <c>P2=1</c>.
+/// </para>
+/// <para>
+/// Painted Sixel pixels are always fully opaque, so a zero alpha inside a tile
+/// unambiguously means "not painted".
+/// </para>
+/// </remarks>
+internal sealed class SixelRasterImage
+{
+    private readonly Dictionary<long, Rgba32[]> _tiles = [];
+    private readonly int _tileSize;
+    private readonly int _tileColumns;
+    private readonly int _maximumTiles;
+
+    public SixelRasterImage(int width, int height, Rgba32 unpaintedPixel, SixelCompatibilityPolicy policy)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+
+        Width = width;
+        Height = height;
+        UnpaintedPixel = unpaintedPixel;
+        _tileSize = policy.RasterTileSize;
+        _tileColumns = ((width - 1) / _tileSize) + 1;
+        _maximumTiles = policy.MaximumRasterTiles;
+    }
+
+    /// <summary>
+    /// Gets the logical width in pixels.
+    /// </summary>
+    public int Width { get; }
+
+    /// <summary>
+    /// Gets the logical height in pixels.
+    /// </summary>
+    public int Height { get; }
+
+    /// <summary>
+    /// Gets the color used for pixels that were never painted.
+    /// </summary>
+    public Rgba32 UnpaintedPixel { get; }
+
+    /// <summary>
+    /// Gets the number of tiles currently allocated.
+    /// </summary>
+    public int AllocatedTileCount => _tiles.Count;
+
+    /// <summary>
+    /// Gets the number of pixels that would be materialized densely.
+    /// </summary>
+    public long PixelCount => (long)Width * Height;
+
+    /// <summary>
+    /// Gets the resolved color at a logical coordinate.
+    /// </summary>
+    public Rgba32 this[int x, int y]
+    {
+        get
+        {
+            if ((uint)x >= (uint)Width || (uint)y >= (uint)Height)
+            {
+                throw new ArgumentOutOfRangeException(nameof(x), "The coordinate is outside the raster.");
+            }
+
+            if (!_tiles.TryGetValue(TileKey(x, y), out var tile))
+            {
+                return UnpaintedPixel;
+            }
+
+            var pixel = tile[((y % _tileSize) * _tileSize) + (x % _tileSize)];
+            return pixel.A == 0 ? UnpaintedPixel : pixel;
+        }
+    }
+
+    /// <summary>
+    /// Paints a pixel, allocating its tile on demand.
+    /// </summary>
+    /// <returns><see langword="false"/> when the tile budget refuses the write.</returns>
+    public bool TryPaint(int x, int y, Rgba32 color)
+    {
+        if ((uint)x >= (uint)Width || (uint)y >= (uint)Height)
+        {
+            return true;
+        }
+
+        var key = TileKey(x, y);
+        if (!_tiles.TryGetValue(key, out var tile))
+        {
+            if (_tiles.Count >= _maximumTiles)
+            {
+                return false;
+            }
+
+            tile = new Rgba32[_tileSize * _tileSize];
+            _tiles[key] = tile;
+        }
+
+        tile[((y % _tileSize) * _tileSize) + (x % _tileSize)] = color;
+        return true;
+    }
+
+    /// <summary>
+    /// Materializes a dense RGBA buffer. Repeated calls produce equal content.
+    /// </summary>
+    public SixelPixelBuffer Materialize()
+    {
+        var pixels = new Rgba32[checked((int)PixelCount)];
+        if (UnpaintedPixel.A != 0)
+        {
+            Array.Fill(pixels, UnpaintedPixel);
+        }
+
+        foreach (var (key, tile) in _tiles)
+        {
+            var tileX = (int)(key % _tileColumns) * _tileSize;
+            var tileY = (int)(key / _tileColumns) * _tileSize;
+            var rows = Math.Min(_tileSize, Height - tileY);
+            var columns = Math.Min(_tileSize, Width - tileX);
+            for (var row = 0; row < rows; row++)
+            {
+                var sourceOffset = row * _tileSize;
+                var destinationOffset = ((tileY + row) * Width) + tileX;
+                for (var column = 0; column < columns; column++)
+                {
+                    var pixel = tile[sourceOffset + column];
+                    if (pixel.A != 0)
+                    {
+                        pixels[destinationOffset + column] = pixel;
+                    }
+                }
+            }
+        }
+
+        return new SixelPixelBuffer(Width, Height, pixels);
+    }
+
+    private long TileKey(int x, int y) => ((long)(y / _tileSize) * _tileColumns) + (x / _tileSize);
+}

--- a/src/Hex1b/Sixel/SixelRasterizer.cs
+++ b/src/Hex1b/Sixel/SixelRasterizer.cs
@@ -1,0 +1,521 @@
+using System.Security.Cryptography;
+using Hex1b.Surfaces;
+
+namespace Hex1b.Sixel;
+
+/// <summary>
+/// Describes whether a rasterization produced pixels or only geometry.
+/// </summary>
+internal enum SixelRasterStatus
+{
+    /// <summary>
+    /// Pixels are available through <see cref="SixelRasterResult.Image"/>.
+    /// </summary>
+    Rasterized,
+
+    /// <summary>
+    /// Allocation was explicitly refused or the payload carried no rasterable
+    /// data. Geometry and diagnostics remain available.
+    /// </summary>
+    GeometryOnly,
+}
+
+/// <summary>
+/// Explicit reasons a rasterization degraded or annotated its result.
+/// </summary>
+internal enum SixelRasterDiagnosticCode
+{
+    ParseOutcomeNotRasterable,
+    CommandsIncomplete,
+    NoRasterableExtent,
+    RasterExtentOverflow,
+    RasterPixelLimitExceeded,
+    RasterOperationLimitExceeded,
+    RasterTileLimitExceeded,
+    ColorRegisterOutOfPolicy,
+}
+
+/// <summary>
+/// A single explicit rasterization diagnostic.
+/// </summary>
+internal readonly record struct SixelRasterDiagnostic(
+    SixelRasterDiagnosticCode Code,
+    string Message);
+
+/// <summary>
+/// The separate extents preserved for downstream placement and translation.
+/// </summary>
+/// <param name="Logical">The unscaled canvas; six logical rows per Sixel band.</param>
+/// <param name="Rendered">The logical canvas after applying the pixel aspect ratio.</param>
+/// <param name="Declared">The DECGRA <c>Ph</c>/<c>Pv</c> hint, or empty when absent.</param>
+/// <param name="Data">The unscaled extent reached by data commands.</param>
+/// <param name="Painted">The unscaled bounds of explicitly painted pixels.</param>
+/// <param name="Aspect">The effective pixel aspect ratio.</param>
+internal readonly record struct SixelRasterExtents(
+    SixelExtent Logical,
+    SixelExtent Rendered,
+    SixelExtent Declared,
+    SixelExtent Data,
+    SixelBounds Painted,
+    SixelAspectRatio Aspect)
+{
+    public static SixelRasterExtents Empty { get; } = new(
+        SixelExtent.Empty,
+        SixelExtent.Empty,
+        SixelExtent.Empty,
+        SixelExtent.Empty,
+        SixelBounds.Empty,
+        new SixelAspectRatio(2, 1));
+}
+
+/// <summary>
+/// The environment a Sixel graphic is rasterized against.
+/// </summary>
+/// <param name="Background">The background captured when the graphic was created.</param>
+/// <param name="Registers">The terminal-scoped color registers mutated in command order.</param>
+/// <param name="Policy">The compatibility and resource policy.</param>
+internal sealed record SixelRasterEnvironment(
+    Rgba32 Background,
+    SixelColorRegisters Registers,
+    SixelCompatibilityPolicy Policy)
+{
+    /// <summary>
+    /// Creates an environment with the deterministic default background and a
+    /// fresh default palette. Used when no terminal state is available.
+    /// </summary>
+    public static SixelRasterEnvironment CreateDefault()
+    {
+        var policy = SixelCompatibilityPolicy.Default;
+        return new SixelRasterEnvironment(
+            policy.DefaultBackground,
+            new SixelColorRegisters(policy),
+            policy);
+    }
+}
+
+/// <summary>
+/// The authoritative bounded rasterization of one Sixel sequence.
+/// </summary>
+internal sealed record SixelRasterResult(
+    SixelRasterStatus Status,
+    SixelRasterExtents Extents,
+    SixelRasterImage? Image,
+    SixelBackgroundMode BackgroundMode,
+    Rgba32 UnpaintedPixel,
+    byte[] Identity,
+    IReadOnlyList<SixelRasterDiagnostic> Diagnostics);
+
+/// <summary>
+/// Rasterizes the authoritative structured Sixel parse result.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The rasterizer never rescans raw DCS bytes. It consumes
+/// <see cref="SixelParseResult.Commands"/>, which already carry absolute column
+/// positions and logical band indices, so logical row positions survive even
+/// though the parser's own geometry is aspect-scaled.
+/// </para>
+/// <para>
+/// Color register mutations are applied to the supplied terminal-scoped register
+/// file in command order, which is what makes the palette persist between
+/// sequences.
+/// </para>
+/// </remarks>
+internal static class SixelRasterizer
+{
+    private const int BandRows = 6;
+
+    public static SixelRasterResult Rasterize(
+        SixelParseResult parse,
+        SixelRasterEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(parse);
+        ArgumentNullException.ThrowIfNull(environment);
+
+        var policy = environment.Policy;
+        var diagnostics = new List<SixelRasterDiagnostic>();
+        var aspect = parse.Header.AspectRatio;
+        var declared = parse.DeclaredExtent;
+
+        if (parse.Outcome is SixelParseOutcome.Cancelled or
+            SixelParseOutcome.Malformed or
+            SixelParseOutcome.Rejected)
+        {
+            diagnostics.Add(new SixelRasterDiagnostic(
+                SixelRasterDiagnosticCode.ParseOutcomeNotRasterable,
+                $"The parse outcome '{parse.Outcome}' does not describe a complete graphic."));
+            return GeometryOnly(
+                SixelRasterExtents.Empty with { Declared = declared, Aspect = aspect },
+                parse.Header.BackgroundMode,
+                environment,
+                diagnostics);
+        }
+
+        var measurement = Measure(parse, declared, aspect);
+
+        if (!parse.CommandsComplete)
+        {
+            ApplyPaletteMutations(parse.PaletteMutations, environment, diagnostics);
+            diagnostics.Add(new SixelRasterDiagnostic(
+                SixelRasterDiagnosticCode.CommandsIncomplete,
+                "Raster command retention was bounded, so only geometry and palette state are available."));
+            return GeometryOnly(measurement.Extents, parse.Header.BackgroundMode, environment, diagnostics);
+        }
+
+        if (measurement.Overflowed)
+        {
+            diagnostics.Add(new SixelRasterDiagnostic(
+                SixelRasterDiagnosticCode.RasterExtentOverflow,
+                "The logical raster extent exceeded the implementation coordinate limit."));
+        }
+
+        var unpainted = ResolveUnpaintedPixel(parse.Header.BackgroundMode, environment);
+        var logical = measurement.Extents.Logical;
+        if (logical.Width <= 0 || logical.Height <= 0)
+        {
+            ApplyPaletteOnly(parse, environment, diagnostics);
+            diagnostics.Add(new SixelRasterDiagnostic(
+                SixelRasterDiagnosticCode.NoRasterableExtent,
+                "The sequence produced no logical raster extent."));
+            return GeometryOnly(measurement.Extents, parse.Header.BackgroundMode, environment, diagnostics);
+        }
+
+        var pixelCount = (long)logical.Width * logical.Height;
+        if (measurement.Overflowed || pixelCount > policy.MaximumRasterPixels)
+        {
+            ApplyPaletteOnly(parse, environment, diagnostics);
+            diagnostics.Add(new SixelRasterDiagnostic(
+                SixelRasterDiagnosticCode.RasterPixelLimitExceeded,
+                $"A {logical.Width}x{logical.Height} raster exceeds the {policy.MaximumRasterPixels} pixel limit."));
+            return GeometryOnly(measurement.Extents, parse.Header.BackgroundMode, environment, diagnostics);
+        }
+
+        if (measurement.RasterOperations > policy.MaximumRasterOperations)
+        {
+            ApplyPaletteOnly(parse, environment, diagnostics);
+            diagnostics.Add(new SixelRasterDiagnostic(
+                SixelRasterDiagnosticCode.RasterOperationLimitExceeded,
+                $"The sequence requests {measurement.RasterOperations} pixel writes, above the " +
+                $"{policy.MaximumRasterOperations} limit."));
+            return GeometryOnly(measurement.Extents, parse.Header.BackgroundMode, environment, diagnostics);
+        }
+
+        var image = new SixelRasterImage(logical.Width, logical.Height, unpainted, policy);
+        var identity = new RasterIdentityBuilder(environment.Background, parse.Header.BackgroundMode);
+        var selected = 0;
+        var tileLimitExceeded = false;
+
+        foreach (var command in parse.Commands)
+        {
+            if (command.Kind == SixelCommandKind.Palette)
+            {
+                if (command.Palette is { } palette)
+                {
+                    selected = ApplyPaletteCommand(palette, environment, diagnostics, selected);
+                }
+
+                continue;
+            }
+
+            if (command.Value == 0 || command.RepeatCount <= 0)
+            {
+                continue;
+            }
+
+            if (tileLimitExceeded)
+            {
+                continue;
+            }
+
+            if (!environment.Registers.IsWithinPolicy(selected))
+            {
+                continue;
+            }
+
+            var color = environment.Registers.Get(selected);
+            identity.Observe(selected, color);
+
+            var startX = command.X;
+            var endX = SaturatingAdd(startX, command.RepeatCount);
+            endX = Math.Min(endX, logical.Width);
+            var bandTop = SaturatingMultiply(command.Band, BandRows);
+
+            for (var bit = 0; bit < BandRows; bit++)
+            {
+                if ((command.Value & (1 << bit)) == 0)
+                {
+                    continue;
+                }
+
+                var y = SaturatingAdd(bandTop, bit);
+                if (y >= logical.Height)
+                {
+                    continue;
+                }
+
+                for (var x = startX; x < endX; x++)
+                {
+                    if (image.TryPaint(x, y, color))
+                    {
+                        continue;
+                    }
+
+                    tileLimitExceeded = true;
+                    diagnostics.Add(new SixelRasterDiagnostic(
+                        SixelRasterDiagnosticCode.RasterTileLimitExceeded,
+                        "Sparse raster tile allocation was refused at its bounded limit."));
+                    break;
+                }
+
+                if (tileLimitExceeded)
+                {
+                    break;
+                }
+            }
+        }
+
+        if (tileLimitExceeded)
+        {
+            return GeometryOnly(
+                measurement.Extents,
+                parse.Header.BackgroundMode,
+                environment,
+                diagnostics);
+        }
+
+        return new SixelRasterResult(
+            SixelRasterStatus.Rasterized,
+            measurement.Extents,
+            image,
+            parse.Header.BackgroundMode,
+            unpainted,
+            identity.Build(SixelRasterStatus.Rasterized, measurement.Extents),
+            diagnostics);
+    }
+
+    private static SixelRasterResult GeometryOnly(
+        SixelRasterExtents extents,
+        SixelBackgroundMode backgroundMode,
+        SixelRasterEnvironment environment,
+        List<SixelRasterDiagnostic> diagnostics)
+    {
+        var unpainted = ResolveUnpaintedPixel(backgroundMode, environment);
+        var identity = new RasterIdentityBuilder(environment.Background, backgroundMode);
+        return new SixelRasterResult(
+            SixelRasterStatus.GeometryOnly,
+            extents,
+            null,
+            backgroundMode,
+            unpainted,
+            identity.Build(SixelRasterStatus.GeometryOnly, extents),
+            diagnostics);
+    }
+
+    private static Rgba32 ResolveUnpaintedPixel(
+        SixelBackgroundMode mode,
+        SixelRasterEnvironment environment)
+    {
+        if (mode == SixelBackgroundMode.Transparent)
+        {
+            return Rgba32.Transparent;
+        }
+
+        return environment.Policy.BackgroundSource switch
+        {
+            SixelBackgroundSource.PaletteRegisterZero when environment.Registers.IsWithinPolicy(0) =>
+                environment.Registers.Get(0),
+            _ => environment.Background,
+        };
+    }
+
+    private static void ApplyPaletteOnly(
+        SixelParseResult parse,
+        SixelRasterEnvironment environment,
+        List<SixelRasterDiagnostic> diagnostics)
+    {
+        var selected = 0;
+        foreach (var command in parse.Commands)
+        {
+            if (command.Kind == SixelCommandKind.Palette && command.Palette is { } palette)
+            {
+                selected = ApplyPaletteCommand(palette, environment, diagnostics, selected);
+            }
+        }
+    }
+
+    private static void ApplyPaletteMutations(
+        IReadOnlyList<SixelPaletteCommand> mutations,
+        SixelRasterEnvironment environment,
+        List<SixelRasterDiagnostic> diagnostics)
+    {
+        var selected = 0;
+        foreach (var mutation in mutations)
+        {
+            selected = ApplyPaletteCommand(mutation, environment, diagnostics, selected);
+        }
+    }
+
+    private static int ApplyPaletteCommand(
+        SixelPaletteCommand palette,
+        SixelRasterEnvironment environment,
+        List<SixelRasterDiagnostic> diagnostics,
+        int selected)
+    {
+        if (!environment.Registers.IsWithinPolicy(palette.Register))
+        {
+            if (!diagnostics.Any(item => item.Code == SixelRasterDiagnosticCode.ColorRegisterOutOfPolicy))
+            {
+                diagnostics.Add(new SixelRasterDiagnostic(
+                    SixelRasterDiagnosticCode.ColorRegisterOutOfPolicy,
+                    $"Color register {palette.Register} is outside the configured " +
+                    $"{environment.Registers.Count}-register policy and was rejected."));
+            }
+
+            return selected;
+        }
+
+        if (palette.IsDefinition)
+        {
+            environment.Registers.Define(palette.Register, SixelColorConverter.FromDefinition(palette));
+        }
+
+        return palette.Register;
+    }
+
+    private static Measurement Measure(
+        SixelParseResult parse,
+        SixelExtent declared,
+        SixelAspectRatio aspect)
+    {
+        var dataWidth = 0;
+        var dataHeight = 0;
+        var paintedMinX = int.MaxValue;
+        var paintedMinY = int.MaxValue;
+        var paintedMaxX = 0;
+        var paintedMaxY = 0;
+        long operations = 0;
+        var overflowed = false;
+
+        foreach (var command in parse.Commands)
+        {
+            if (command.Kind != SixelCommandKind.Data || command.RepeatCount <= 0)
+            {
+                continue;
+            }
+
+            var endX = SaturatingAdd(command.X, command.RepeatCount);
+            overflowed |= endX == int.MaxValue;
+            dataWidth = Math.Max(dataWidth, endX);
+
+            var bandTop = SaturatingMultiply(command.Band, BandRows);
+            var bandBottom = SaturatingAdd(bandTop, BandRows);
+            overflowed |= bandBottom == int.MaxValue;
+            dataHeight = Math.Max(dataHeight, bandBottom);
+
+            if (command.Value == 0)
+            {
+                continue;
+            }
+
+            var firstBit = System.Numerics.BitOperations.TrailingZeroCount((uint)command.Value);
+            var lastBit = 31 - System.Numerics.BitOperations.LeadingZeroCount((uint)command.Value);
+            paintedMinX = Math.Min(paintedMinX, command.X);
+            paintedMaxX = Math.Max(paintedMaxX, endX);
+            paintedMinY = Math.Min(paintedMinY, SaturatingAdd(bandTop, firstBit));
+            paintedMaxY = Math.Max(paintedMaxY, SaturatingAdd(bandTop, lastBit + 1));
+
+            operations += (long)command.RepeatCount *
+                System.Numerics.BitOperations.PopCount((uint)command.Value);
+        }
+
+        var painted = paintedMinX == int.MaxValue
+            ? SixelBounds.Empty
+            : new SixelBounds(
+                paintedMinX,
+                paintedMinY,
+                paintedMaxX - paintedMinX,
+                paintedMaxY - paintedMinY);
+
+        var logical = new SixelExtent(
+            Math.Max(declared.Width, Math.Max(dataWidth, paintedMaxX)),
+            Math.Max(declared.Height, Math.Max(dataHeight, paintedMaxY)));
+        var renderedHeight = ScaleHeight(logical.Height, aspect, ref overflowed);
+
+        return new Measurement(
+            new SixelRasterExtents(
+                logical,
+                new SixelExtent(logical.Width, renderedHeight),
+                declared,
+                new SixelExtent(dataWidth, dataHeight),
+                painted,
+                aspect),
+            operations,
+            overflowed);
+    }
+
+    private static int ScaleHeight(int height, SixelAspectRatio aspect, ref bool overflowed)
+    {
+        if (aspect.Numerator <= 0 || aspect.Denominator <= 0)
+        {
+            return height;
+        }
+
+        var scaled = (((long)height * aspect.Numerator) + aspect.Denominator - 1) / aspect.Denominator;
+        if (scaled > int.MaxValue)
+        {
+            overflowed = true;
+            return int.MaxValue;
+        }
+
+        return (int)scaled;
+    }
+
+    private static int SaturatingAdd(int left, int right) =>
+        right <= int.MaxValue - left ? left + right : int.MaxValue;
+
+    private static int SaturatingMultiply(int left, int right) =>
+        right == 0 || left <= int.MaxValue / right ? left * right : int.MaxValue;
+
+    private readonly record struct Measurement(
+        SixelRasterExtents Extents,
+        long RasterOperations,
+        bool Overflowed);
+
+    /// <summary>
+    /// Builds a compact identity for the raster state that produced a graphic.
+    /// </summary>
+    /// <remarks>
+    /// Identical payloads raster differently when the captured background or the
+    /// persistent palette differ, so this identity participates in tracked-object
+    /// deduplication instead of the payload hash alone.
+    /// </remarks>
+    private sealed class RasterIdentityBuilder(Rgba32 background, SixelBackgroundMode mode)
+    {
+        private readonly HashSet<(int Register, uint Color)> _used = [];
+
+        public void Observe(int register, Rgba32 color) =>
+            _used.Add((register, ((uint)color.A << 24) | ((uint)color.R << 16) | ((uint)color.G << 8) | color.B));
+
+        public byte[] Build(SixelRasterStatus status, SixelRasterExtents extents)
+        {
+            var buffer = new List<byte>(32 + (_used.Count * 8))
+            {
+                background.R,
+                background.G,
+                background.B,
+                background.A,
+                (byte)mode,
+                (byte)status,
+            };
+            buffer.AddRange(BitConverter.GetBytes(extents.Logical.Width));
+            buffer.AddRange(BitConverter.GetBytes(extents.Logical.Height));
+            foreach (var (register, color) in _used.OrderBy(item => item.Register).ThenBy(item => item.Color))
+            {
+                buffer.AddRange(BitConverter.GetBytes(register));
+                buffer.AddRange(BitConverter.GetBytes(color));
+            }
+
+            return SHA256.HashData([.. buffer])[..16];
+        }
+    }
+}

--- a/src/Hex1b/Sixel/SixelRasterizer.cs
+++ b/src/Hex1b/Sixel/SixelRasterizer.cs
@@ -94,6 +94,19 @@ internal sealed record SixelRasterEnvironment(
 }
 
 /// <summary>
+/// Captures the immutable inputs needed to rasterize a Sixel graphic lazily.
+/// </summary>
+/// <param name="Environment">
+/// A private register snapshot and the background captured when the graphic was created.
+/// </param>
+/// <param name="Identity">
+/// A deterministic identity for the captured background, palette, and policy.
+/// </param>
+internal sealed record SixelRasterPreparation(
+    SixelRasterEnvironment Environment,
+    byte[] Identity);
+
+/// <summary>
 /// The authoritative bounded rasterization of one Sixel sequence.
 /// </summary>
 internal sealed record SixelRasterResult(
@@ -124,6 +137,30 @@ internal sealed record SixelRasterResult(
 internal static class SixelRasterizer
 {
     private const int BandRows = 6;
+
+    /// <summary>
+    /// Captures the state required for lazy rasterization and applies palette
+    /// definitions immediately to the terminal-scoped register file.
+    /// </summary>
+    public static SixelRasterPreparation Prepare(
+        SixelParseResult parse,
+        SixelRasterEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(parse);
+        ArgumentNullException.ThrowIfNull(environment);
+
+        var capturedEnvironment = environment with
+        {
+            Registers = environment.Registers.Snapshot(),
+        };
+        if (environment.Policy.PaletteScope == SixelPaletteScope.TerminalPersistent)
+        {
+            ApplyPersistentPaletteMutations(parse, environment.Registers);
+        }
+        return new SixelRasterPreparation(
+            capturedEnvironment,
+            BuildPreparationIdentity(parse, capturedEnvironment));
+    }
 
     public static SixelRasterResult Rasterize(
         SixelParseResult parse,
@@ -380,6 +417,108 @@ internal static class SixelRasterizer
         }
 
         return palette.Register;
+    }
+
+    private static void ApplyPersistentPaletteMutations(
+        SixelParseResult parse,
+        SixelColorRegisters registers)
+    {
+        if (!parse.CommandsComplete)
+        {
+            foreach (var mutation in parse.PaletteMutations)
+            {
+                ApplyPersistentPaletteDefinition(mutation, registers);
+            }
+
+            return;
+        }
+
+        foreach (var command in parse.Commands)
+        {
+            if (command.Palette is { } mutation)
+            {
+                ApplyPersistentPaletteDefinition(mutation, registers);
+            }
+        }
+    }
+
+    private static void ApplyPersistentPaletteDefinition(
+        SixelPaletteCommand mutation,
+        SixelColorRegisters registers)
+    {
+        if (mutation.IsDefinition && registers.IsWithinPolicy(mutation.Register))
+        {
+            registers.Define(
+                mutation.Register,
+                SixelColorConverter.FromDefinition(mutation));
+        }
+    }
+
+    private static byte[] BuildPreparationIdentity(
+        SixelParseResult parse,
+        SixelRasterEnvironment environment)
+    {
+        var registers = environment.Registers.Snapshot();
+        var used = new HashSet<(int Register, uint Color)>();
+        var selected = 0;
+
+        foreach (var command in parse.Commands)
+        {
+            if (command.Kind == SixelCommandKind.Palette)
+            {
+                if (command.Palette is { } palette)
+                {
+                    if (registers.IsWithinPolicy(palette.Register))
+                    {
+                        selected = palette.Register;
+                        if (palette.IsDefinition)
+                        {
+                            registers.Define(
+                                palette.Register,
+                                SixelColorConverter.FromDefinition(palette));
+                        }
+                    }
+                }
+
+                continue;
+            }
+
+            if (command.Value == 0 ||
+                command.RepeatCount <= 0 ||
+                !registers.IsWithinPolicy(selected))
+            {
+                continue;
+            }
+
+            var color = registers.Get(selected);
+            used.Add((
+                selected,
+                ((uint)color.A << 24) |
+                ((uint)color.R << 16) |
+                ((uint)color.G << 8) |
+                color.B));
+        }
+
+        var buffer = new List<byte>(32 + (used.Count * 8))
+        {
+            environment.Background.R,
+            environment.Background.G,
+            environment.Background.B,
+            environment.Background.A,
+            (byte)parse.Header.BackgroundMode,
+        };
+        buffer.AddRange(BitConverter.GetBytes(environment.Policy.ColorRegisterCount));
+        buffer.AddRange(BitConverter.GetBytes(environment.Policy.MaximumRasterPixels));
+        buffer.AddRange(BitConverter.GetBytes(environment.Policy.MaximumRasterOperations));
+        buffer.AddRange(BitConverter.GetBytes(environment.Policy.MaximumRasterTiles));
+        buffer.AddRange(BitConverter.GetBytes(environment.Policy.RasterTileSize));
+        foreach (var (register, color) in used.OrderBy(item => item.Register).ThenBy(item => item.Color))
+        {
+            buffer.AddRange(BitConverter.GetBytes(register));
+            buffer.AddRange(BitConverter.GetBytes(color));
+        }
+
+        return SHA256.HashData([.. buffer])[..16];
     }
 
     private static Measurement Measure(

--- a/src/Hex1b/SixelData.cs
+++ b/src/Hex1b/SixelData.cs
@@ -22,6 +22,7 @@ namespace Hex1b;
 public sealed class SixelData
 {
     private readonly object _decodeLock = new();
+    private readonly SixelRasterPreparation? _rasterPreparation;
     private SixelRasterResult? _raster;
     private SixelPixelBuffer? _decodedPixels;
     private bool _decodeAttempted;
@@ -62,10 +63,10 @@ public sealed class SixelData
     /// Gets the authoritative bounded rasterization of <see cref="ParseResult"/>.
     /// </summary>
     /// <remarks>
-    /// When the terminal supplied a raster at creation time, that result is used
-    /// verbatim so the captured background and persistent palette are honored.
-    /// Otherwise the payload is rasterized on first use against the deterministic
-    /// default environment.
+    /// Terminal-created data captures an immutable background and palette
+    /// preparation so rasterization can occur on first use without holding the
+    /// terminal buffer lock. Data created without terminal state uses the
+    /// deterministic default environment.
     /// </remarks>
     internal SixelRasterResult Raster
     {
@@ -75,7 +76,7 @@ public sealed class SixelData
             {
                 return _raster ??= SixelRasterizer.Rasterize(
                     ParseResult,
-                    SixelRasterEnvironment.CreateDefault());
+                    GetRasterEnvironment());
             }
         }
     }
@@ -104,7 +105,8 @@ public sealed class SixelData
         int pixelWidth,
         int pixelHeight,
         SixelParseResult? parseResult = null,
-        SixelRasterResult? raster = null)
+        SixelRasterResult? raster = null,
+        SixelRasterPreparation? rasterPreparation = null)
     {
         Payload = payload;
         WidthInCells = widthInCells;
@@ -114,6 +116,7 @@ public sealed class SixelData
         PixelHeight = pixelHeight;
         ParseResult = parseResult ?? SixelParser.ParsePayload(payload);
         _raster = raster;
+        _rasterPreparation = rasterPreparation;
     }
 
     /// <summary>
@@ -154,7 +157,7 @@ public sealed class SixelData
 
             _raster ??= SixelRasterizer.Rasterize(
                 ParseResult,
-                SixelRasterEnvironment.CreateDefault());
+                GetRasterEnvironment());
             _decodedPixels = _raster.Image?.Materialize();
             _decodeAttempted = true;
             return _decodedPixels;
@@ -175,17 +178,17 @@ public sealed class SixelData
     /// or the persistent palette differ, so the raster identity must participate
     /// in content-addressable reuse.
     /// </remarks>
-    internal static byte[] ComputeHash(string payload, SixelRasterResult? raster)
+    internal static byte[] ComputeHash(string payload, byte[]? rasterIdentity)
     {
         var payloadBytes = System.Text.Encoding.UTF8.GetBytes(payload);
-        if (raster is null)
+        if (rasterIdentity is null)
         {
             return SHA256.HashData(payloadBytes);
         }
 
-        var combined = new byte[payloadBytes.Length + raster.Identity.Length];
+        var combined = new byte[payloadBytes.Length + rasterIdentity.Length];
         payloadBytes.CopyTo(combined, 0);
-        raster.Identity.CopyTo(combined, payloadBytes.Length);
+        rasterIdentity.CopyTo(combined, payloadBytes.Length);
         return SHA256.HashData(combined);
     }
 
@@ -196,4 +199,7 @@ public sealed class SixelData
     {
         return a.AsSpan().SequenceEqual(b.AsSpan());
     }
+
+    private SixelRasterEnvironment GetRasterEnvironment() =>
+        _rasterPreparation?.Environment ?? SixelRasterEnvironment.CreateDefault();
 }

--- a/src/Hex1b/SixelData.cs
+++ b/src/Hex1b/SixelData.cs
@@ -9,20 +9,22 @@ namespace Hex1b;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Sixel data is content-addressable: identical payloads share the same
-/// <see cref="SixelData"/> instance. This deduplicates memory when the same
-/// image appears in multiple cells or is re-rendered.
+/// Sixel data is content-addressable. Identical payloads share the same
+/// <see cref="SixelData"/> instance only when their captured background and
+/// persistent palette inputs also produce the same raster. This deduplicates
+/// equivalent images without conflating terminal graphics state.
 /// </para>
 /// <para>
 /// The raw DCS sequence is stored so it can be re-emitted during rendering.
-/// Pixel dimensions are parsed from the raster attributes in the payload.
+/// Declared pixel dimensions are parsed from the raster attributes in the payload.
 /// </para>
 /// </remarks>
 public sealed class SixelData
 {
+    private readonly object _decodeLock = new();
+    private SixelRasterResult? _raster;
     private SixelPixelBuffer? _decodedPixels;
     private bool _decodeAttempted;
-    private readonly object _decodeLock = new();
 
     /// <summary>
     /// Gets the raw Sixel DCS sequence (ESC P ... ESC \).
@@ -30,12 +32,12 @@ public sealed class SixelData
     public string Payload { get; }
 
     /// <summary>
-    /// Gets the width of the Sixel image in pixels.
+    /// Gets the horizontal extent declared by DECGRA, or zero when none was declared.
     /// </summary>
     public int PixelWidth { get; }
 
     /// <summary>
-    /// Gets the height of the Sixel image in pixels.
+    /// Gets the vertical extent declared by DECGRA, or zero when none was declared.
     /// </summary>
     public int PixelHeight { get; }
 
@@ -55,6 +57,28 @@ public sealed class SixelData
     internal byte[] ContentHash { get; }
 
     internal SixelParseResult ParseResult { get; }
+
+    /// <summary>
+    /// Gets the authoritative bounded rasterization of <see cref="ParseResult"/>.
+    /// </summary>
+    /// <remarks>
+    /// When the terminal supplied a raster at creation time, that result is used
+    /// verbatim so the captured background and persistent palette are honored.
+    /// Otherwise the payload is rasterized on first use against the deterministic
+    /// default environment.
+    /// </remarks>
+    internal SixelRasterResult Raster
+    {
+        get
+        {
+            lock (_decodeLock)
+            {
+                return _raster ??= SixelRasterizer.Rasterize(
+                    ParseResult,
+                    SixelRasterEnvironment.CreateDefault());
+            }
+        }
+    }
 
     internal SixelData(
         string payload,
@@ -79,7 +103,8 @@ public sealed class SixelData
         byte[] contentHash,
         int pixelWidth,
         int pixelHeight,
-        SixelParseResult? parseResult = null)
+        SixelParseResult? parseResult = null,
+        SixelRasterResult? raster = null)
     {
         Payload = payload;
         WidthInCells = widthInCells;
@@ -88,6 +113,7 @@ public sealed class SixelData
         PixelWidth = pixelWidth;
         PixelHeight = pixelHeight;
         ParseResult = parseResult ?? SixelParser.ParsePayload(payload);
+        _raster = raster;
     }
 
     /// <summary>
@@ -110,37 +136,26 @@ public sealed class SixelData
     }
 
     /// <summary>
-    /// Decodes the sixel payload to a pixel buffer.
-    /// The result is cached for subsequent calls.
+    /// Materializes the sixel payload as a dense pixel buffer.
+    /// The result is cached, and repeated calls produce equal content.
     /// </summary>
-    /// <returns>The decoded pixel buffer, or null if decoding fails.</returns>
+    /// <returns>
+    /// The materialized pixel buffer, or <see langword="null"/> when the
+    /// authoritative rasterizer produced a geometry-only result.
+    /// </returns>
     public SixelPixelBuffer? GetPixels()
     {
         lock (_decodeLock)
         {
             if (_decodeAttempted)
-                return _decodedPixels;
-
-            var decoded = Automation.SixelDecoder.Decode(ParseResult);
-            if (decoded is not null)
             {
-                var buffer = new SixelPixelBuffer(decoded.Width, decoded.Height);
-                for (var y = 0; y < decoded.Height; y++)
-                {
-                    for (var x = 0; x < decoded.Width; x++)
-                    {
-                        var idx = (y * decoded.Width + x) * 4;
-                        buffer[x, y] = new Rgba32(
-                            decoded.Pixels[idx],
-                            decoded.Pixels[idx + 1],
-                            decoded.Pixels[idx + 2],
-                            decoded.Pixels[idx + 3]);
-                    }
-                }
-
-                _decodedPixels = buffer;
+                return _decodedPixels;
             }
 
+            _raster ??= SixelRasterizer.Rasterize(
+                ParseResult,
+                SixelRasterEnvironment.CreateDefault());
+            _decodedPixels = _raster.Image?.Materialize();
             _decodeAttempted = true;
             return _decodedPixels;
         }
@@ -149,10 +164,29 @@ public sealed class SixelData
     /// <summary>
     /// Computes a content hash for a Sixel payload.
     /// </summary>
-    internal static byte[] ComputeHash(string payload)
+    internal static byte[] ComputeHash(string payload) => ComputeHash(payload, null);
+
+    /// <summary>
+    /// Computes a deduplication hash that combines the payload with the raster
+    /// state identity.
+    /// </summary>
+    /// <remarks>
+    /// Identical payloads produce different pixels when the captured background
+    /// or the persistent palette differ, so the raster identity must participate
+    /// in content-addressable reuse.
+    /// </remarks>
+    internal static byte[] ComputeHash(string payload, SixelRasterResult? raster)
     {
-        // Use SHA256 for robust deduplication
-        return SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(payload));
+        var payloadBytes = System.Text.Encoding.UTF8.GetBytes(payload);
+        if (raster is null)
+        {
+            return SHA256.HashData(payloadBytes);
+        }
+
+        var combined = new byte[payloadBytes.Length + raster.Identity.Length];
+        payloadBytes.CopyTo(combined, 0);
+        raster.Identity.CopyTo(combined, payloadBytes.Length);
+        return SHA256.HashData(combined);
     }
 
     /// <summary>

--- a/src/Hex1b/TrackedObjectStore.cs
+++ b/src/Hex1b/TrackedObjectStore.cs
@@ -92,9 +92,10 @@ internal sealed class TrackedObjectStore
         string payload,
         int widthInCells,
         int heightInCells,
-        SixelParseResult parseResult)
+        SixelParseResult parseResult,
+        SixelRasterResult? raster = null)
     {
-        var hash = SixelData.ComputeHash(payload);
+        var hash = SixelData.ComputeHash(payload, raster);
 
         lock (_lock)
         {
@@ -113,7 +114,8 @@ internal sealed class TrackedObjectStore
                 hash,
                 parseResult.DeclaredExtent.Width,
                 parseResult.DeclaredExtent.Height,
-                parseResult);
+                parseResult,
+                raster);
             
             // Create new tracked wrapper with removal callback
             var tracked = new TrackedObject<SixelData>(

--- a/src/Hex1b/TrackedObjectStore.cs
+++ b/src/Hex1b/TrackedObjectStore.cs
@@ -93,9 +93,9 @@ internal sealed class TrackedObjectStore
         int widthInCells,
         int heightInCells,
         SixelParseResult parseResult,
-        SixelRasterResult? raster = null)
+        SixelRasterPreparation? rasterPreparation = null)
     {
-        var hash = SixelData.ComputeHash(payload, raster);
+        var hash = SixelData.ComputeHash(payload, rasterPreparation?.Identity);
 
         lock (_lock)
         {
@@ -115,7 +115,7 @@ internal sealed class TrackedObjectStore
                 parseResult.DeclaredExtent.Width,
                 parseResult.DeclaredExtent.Height,
                 parseResult,
-                raster);
+                rasterPreparation: rasterPreparation);
             
             // Create new tracked wrapper with removal callback
             var tracked = new TrackedObject<SixelData>(

--- a/tests/Hex1b.Tests/Sixel/SixelParserTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelParserTests.cs
@@ -1,12 +1,14 @@
+using System.Text;
+
 namespace Hex1b.Tests.Sixel;
 
 [TestClass]
 public class SixelParserTests
 {
     [TestMethod]
-    [DataRow("single-band", 1, 6, "A\n.\n.\n.\n.\n.")]
-    [DataRow("multi-band", 1, 12, "A\n.\n.\n.\n.\n.\nA\nA\n.\n.\n.\n.")]
-    [DataRow("two-color-overprint", 1, 6, "A\nB\n.\n.\n.\n.")]
+    [DataRow("single-band", 1, 6, "A\nB\nB\nB\nB\nB")]
+    [DataRow("multi-band", 1, 12, "A\nB\nB\nB\nB\nB\nA\nA\nB\nB\nB\nB")]
+    [DataRow("two-color-overprint", 1, 6, "A\nB\nC\nC\nC\nC")]
     [DataRow("transparent", 2, 6, "A.\n..\n..\n..\n..\n..")]
     public async Task IndependentFixture_GrammarAndPixels_AreInspectable(
         string fixtureName,
@@ -120,7 +122,7 @@ public class SixelParserTests
         TestSvgHelper.AttachFile("sixel-two-color-evidence.svg", svg);
     }
 
-    [TestMethod, Ignore("Owned by #449: HLS conversion currently uses the conventional hue wheel instead of DEC's blue-at-zero hue wheel.")]
+    [TestMethod]
     public async Task HlsDefinition_HueZeroProducesBlue()
     {
         var fixture = new SixelFixture(
@@ -174,15 +176,19 @@ public class SixelParserTests
         Assert.AreEqual(squarePlacement.HeightInCells * 2, defaultPlacement.HeightInCells);
     }
 
-    [TestMethod, Ignore("Owned by #449: P2 background policy is not represented by the current decoder.")]
-    public async Task OpaqueBackground_UnpaintedPixelsUsePaletteRegisterZero()
+    [TestMethod]
+    public async Task OpaqueBackground_UnpaintedPixelsUseCapturedTerminalBackground()
     {
         var fixture = new SixelFixture(
             "opaque-background",
-            "P2=0 paints register zero into unset pixels.",
-            "0;0q#0;2;0;0;100#1;2;100;0;0#1@"u8.ToArray());
+            "P2=0 fills unset pixels with the background captured at creation time.",
+            "0;0q#1;2;100;0;0#1@"u8.ToArray());
         await using var terminal = SixelTestTerminal.Create();
 
+        // Select a blue SGR background before the graphic is created.
+        await terminal.FeedAsync(
+            "\x1b[48;2;0;0;255m"u8.ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken);
         await terminal.FeedAsync(
             fixture.StandardBytes,
             cancellationToken: TestContext.Current.CancellationToken);
@@ -255,20 +261,22 @@ public class SixelParserTests
         Assert.AreEqual(12, placement.PixelHeight);
     }
 
-    [TestMethod, Ignore("Owned by #449: palette registers are currently reset for each decoded sequence.")]
+    [TestMethod]
     public async Task PaletteDefinition_SubsequentSequence_PersistsRegisterValue()
     {
         var defineRed = new SixelFixture("define-red", "Defines register 5 as red.", "q#5;2;100;0;0@"u8.ToArray());
         var selectRed = new SixelFixture("select-red", "Selects persistent register 5.", "q#5@"u8.ToArray());
         await using var terminal = SixelTestTerminal.Create();
 
+        // Stage 4 does not move the text cursor, so place the second graphic on
+        // its own row explicitly and keep both placements observable.
         var bytes = defineRed.StandardBytes
+            .Concat(Encoding.ASCII.GetBytes("\x1b[2;1H"))
             .Concat(selectRed.StandardBytes)
-            .Concat("X"u8.ToArray())
             .ToArray();
         await terminal.FeedAsync(bytes, cancellationToken: TestContext.Current.CancellationToken);
         await terminal.WaitForAsync(
-            snapshot => snapshot.ContainsText("X"),
+            snapshot => snapshot.GetCell(0, 1).SixelData is not null,
             "persistent palette register",
             TestContext.Current.CancellationToken);
 

--- a/tests/Hex1b.Tests/Sixel/SixelRasterIntegrationTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelRasterIntegrationTests.cs
@@ -1,0 +1,192 @@
+using System.Text;
+using Hex1b.Sixel;
+using Hex1b.Tokens;
+using Hex1b.Surfaces;
+
+namespace Hex1b.Tests.Sixel;
+
+/// <summary>
+/// Terminal-level integration tests for the Sixel raster environment: captured
+/// background, terminal-scoped palette lifetime, and native passthrough.
+/// </summary>
+[TestClass]
+public class SixelRasterIntegrationTests
+{
+    private const string DefineRed = "#1;2;100;0;0";
+
+    [TestMethod]
+    public async Task CapturedBackground_UsesTheBackgroundAtCreationTime()
+    {
+        await using var terminal = SixelTestTerminal.Create();
+
+        // Blue background for the first graphic, green for the second.
+        await FeedAsync(
+            terminal,
+            "\x1b[48;2;0;0;255m",
+            $"\x1bP0;0q{DefineRed}#1@\x1b\\",
+            "\x1b[2;1H",
+            "\x1b[48;2;0;255;0m",
+            "\x1bP0;0q#1@\x1b\\");
+        await terminal.WaitForAsync(
+            snapshot => snapshot.GetCell(0, 1).SixelData is not null,
+            "two backgrounds",
+            TestContext.Current.CancellationToken);
+
+        var placements = terminal.Observe().Placements;
+        Assert.AreEqual(2, placements.Count);
+        Assert.Contains("#0000FFFF", placements[0].PixelGrid);
+        Assert.DoesNotContain("#00FF00FF", placements[0].PixelGrid);
+        Assert.Contains("#00FF00FF", placements[1].PixelGrid);
+    }
+
+    [TestMethod]
+    public async Task CapturedBackground_DefaultsToBlackWhenUnset()
+    {
+        await using var terminal = SixelTestTerminal.Create();
+
+        await FeedAsync(terminal, $"\x1bP0;0q{DefineRed}#1@\x1b\\");
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "default background",
+            TestContext.Current.CancellationToken);
+
+        var grid = TestSeq.Single(terminal.Observe().Placements).PixelGrid;
+        Assert.Contains("#000000FF", grid);
+    }
+
+    [TestMethod]
+    public async Task ColorRegisters_PersistAcrossAlternateScreenTransitions()
+    {
+        await using var terminal = SixelTestTerminal.Create();
+
+        await FeedAsync(
+            terminal,
+            $"\x1bP0;1q{DefineRed}#1@\x1b\\",
+            "\x1b[?1049h",
+            "\x1bP0;1q#1@\x1b\\");
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "alternate screen palette",
+            TestContext.Current.CancellationToken);
+
+        var grid = TestSeq.Single(terminal.Observe().Placements).PixelGrid;
+        Assert.Contains("#FF0000FF", grid);
+    }
+
+    [TestMethod]
+    public async Task ColorRegisters_SurviveASoftReset()
+    {
+        await using var terminal = SixelTestTerminal.Create();
+
+        await FeedAsync(
+            terminal,
+            $"\x1bP0;1q{DefineRed}#1@\x1b\\",
+            "\x1b[!p",
+            "\x1b[3;1H",
+            "\x1bP0;1q#1@\x1b\\");
+        await terminal.WaitForAsync(
+            snapshot => snapshot.GetCell(0, 2).SixelData is not null,
+            "soft reset palette",
+            TestContext.Current.CancellationToken);
+
+        var placements = terminal.Observe().Placements;
+        Assert.Contains("#FF0000FF", placements[^1].PixelGrid);
+    }
+
+    [TestMethod]
+    public async Task ColorRegisters_AreResetByRis()
+    {
+        await using var terminal = SixelTestTerminal.Create();
+
+        await FeedAsync(terminal, $"\x1bP0;1q{DefineRed}#1@\x1b\\");
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "graphic before RIS",
+            TestContext.Current.CancellationToken);
+
+        // The raw byte path does not yet decode ESC c into a RIS token (owned by
+        // #453), so drive the reset through the token stream directly.
+        await terminal.FeedPreTokenizedAsync(
+            Encoding.Latin1.GetBytes("\x1bc"),
+            [RisToken.Instance],
+            TestContext.Current.CancellationToken);
+        await FeedAsync(terminal, "\x1bP0;1q#1@\x1b\\");
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "graphic after RIS",
+            TestContext.Current.CancellationToken);
+
+        var grid = TestSeq.Single(terminal.Observe().Placements).PixelGrid;
+        Assert.DoesNotContain("#FF0000FF", grid);
+        Assert.Contains(FormatColor(SixelDefaultPalette.Get(1)), grid);
+    }
+
+    [TestMethod]
+    public async Task NativePassthrough_IsPreservedForRasterizedGraphics()
+    {
+        var payload = $"\x1bP0;0q\"1;1;2;2{DefineRed}#1@\x1b\\";
+        await using var terminal = SixelTestTerminal.Create();
+
+        await FeedAsync(terminal, payload);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "native passthrough",
+            TestContext.Current.CancellationToken);
+        await terminal.CompleteWorkloadAsync(TestContext.Current.CancellationToken);
+
+        var presented = Encoding.Latin1.GetString(terminal.PresentationBytes);
+        Assert.Contains(payload, presented);
+    }
+
+    [TestMethod]
+    public async Task TerminalRaster_MatchesDirectRasterizationOfTheSamePayload()
+    {
+        var payload = $"\x1bP0;0q\"1;1;4;7{DefineRed}#2;2;0;100;0#1!3~$#2A\x1b\\";
+        await using var terminal = SixelTestTerminal.Create();
+
+        await FeedAsync(terminal, payload);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "parser and raster equivalence",
+            TestContext.Current.CancellationToken);
+
+        var expected = SixelRasterizer.Rasterize(
+            SixelParser.ParsePayload(payload),
+            SixelRasterEnvironment.CreateDefault());
+        var expectedGrid = SixelPixelGrid.Format(expected.Image!.Materialize());
+        var actualGrid = TestSeq.Single(terminal.Observe().Placements).PixelGrid;
+
+        Assert.AreEqual(expectedGrid, actualGrid);
+    }
+
+    [TestMethod]
+    public async Task GeometryOnlyGraphic_StillOccupiesCellsWithoutPixels()
+    {
+        await using var terminal = SixelTestTerminal.Create();
+
+        await FeedAsync(terminal, "\x1bP0;1q\"1;1;999999999;999999999#1@\x1b\\");
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "geometry only",
+            TestContext.Current.CancellationToken);
+
+        var observation = terminal.Observe();
+        var placement = TestSeq.Single(observation.Placements);
+        Assert.AreEqual(0, placement.PixelWidth);
+        Assert.AreEqual("", placement.PixelGrid);
+        Assert.IsTrue(placement.WidthInCells > 0);
+        Assert.IsTrue(observation.OccupiedCells.Count > 0);
+
+        using var snapshot = terminal.Terminal.CreateSnapshot();
+        var data = snapshot.GetCell(0, 0).SixelData;
+        Assert.IsNotNull(data);
+        Assert.IsNull(data.GetPixels());
+        Assert.AreEqual(SixelRasterStatus.GeometryOnly, data.Raster.Status);
+    }
+
+    private static Task FeedAsync(SixelTestTerminal terminal, params string[] chunks) =>
+        terminal.FeedAsync(Encoding.Latin1.GetBytes(string.Concat(chunks)));
+
+    private static string FormatColor(Rgba32 color) =>
+        $"#{color.R:X2}{color.G:X2}{color.B:X2}{color.A:X2}";
+}

--- a/tests/Hex1b.Tests/Sixel/SixelRasterizerTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelRasterizerTests.cs
@@ -1,0 +1,987 @@
+using System.Text;
+using Hex1b.Sixel;
+using Hex1b.Surfaces;
+
+namespace Hex1b.Tests.Sixel;
+
+/// <summary>
+/// Focused tests for the deterministic bounded Sixel rasterizer.
+/// </summary>
+/// <remarks>
+/// Every expected raster in this file is authored by hand from the DEC grammar.
+/// <c>SixelEncoder</c> is never used to produce an expectation.
+/// </remarks>
+[TestClass]
+public class SixelRasterizerTests
+{
+    private const string Red = "#1;2;100;0;0";
+    private const string Green = "#2;2;0;100;0";
+    private const string Blue = "#3;2;0;0;100";
+
+    #region Sixel bit orientation and masks
+
+    [TestMethod]
+    [DataRow('?', "K", "K", "K", "K", "K", "K")]
+    [DataRow('@', "R", "K", "K", "K", "K", "K")]
+    [DataRow('A', "K", "R", "K", "K", "K", "K")]
+    [DataRow('C', "K", "K", "R", "K", "K", "K")]
+    [DataRow('G', "K", "K", "K", "R", "K", "K")]
+    [DataRow('O', "K", "K", "K", "K", "R", "K")]
+    [DataRow('_', "K", "K", "K", "K", "K", "R")]
+    [DataRow('B', "R", "R", "K", "K", "K", "K")]
+    [DataRow('F', "R", "R", "R", "K", "K", "K")]
+    [DataRow('N', "R", "R", "R", "R", "K", "K")]
+    [DataRow('^', "R", "R", "R", "R", "R", "K")]
+    [DataRow('~', "R", "R", "R", "R", "R", "R")]
+    [DataRow('D', "R", "K", "R", "K", "K", "K")]
+    [DataRow('a', "K", "R", "K", "K", "K", "R")]
+    public void DataByte_UsesLeastSignificantBitAsTopPixel(char data, params string[] rows)
+    {
+        var result = Raster($"0;0q{Red}#1{data}");
+
+        AssertPixels(result, rows);
+    }
+
+    [TestMethod]
+    public void EverySixBitMask_PaintsExactlyItsSetBits()
+    {
+        for (var mask = 0; mask < 64; mask++)
+        {
+            var result = Raster($"0;1q{Red}#1{(char)('?' + mask)}");
+            var image = RequireImage(result);
+            Assert.AreEqual(1, image.Width, $"mask {mask}");
+            Assert.AreEqual(6, image.Height, $"mask {mask}");
+
+            for (var bit = 0; bit < 6; bit++)
+            {
+                var expected = (mask & (1 << bit)) != 0
+                    ? new Rgba32(255, 0, 0, 255)
+                    : Rgba32.Transparent;
+                Assert.AreEqual(expected, image[0, bit], $"mask {mask} bit {bit}");
+            }
+        }
+    }
+
+    [TestMethod]
+    public void SingleBitMasks_MapToTheirBandRowInEveryBand()
+    {
+        var result = Raster($"0;1q{Red}#1@-A-C-_");
+        var image = RequireImage(result);
+
+        Assert.AreEqual(24, image.Height);
+        Assert.AreEqual(new Rgba32(255, 0, 0, 255), image[0, 0]);
+        Assert.AreEqual(new Rgba32(255, 0, 0, 255), image[0, 7]);
+        Assert.AreEqual(new Rgba32(255, 0, 0, 255), image[0, 14]);
+        Assert.AreEqual(new Rgba32(255, 0, 0, 255), image[0, 23]);
+        Assert.AreEqual(Rgba32.Transparent, image[0, 1]);
+        Assert.AreEqual(Rgba32.Transparent, image[0, 6]);
+    }
+
+    #endregion
+
+    #region Heights and partial bands
+
+    [TestMethod]
+    [DataRow(1)]
+    [DataRow(2)]
+    [DataRow(3)]
+    [DataRow(4)]
+    [DataRow(5)]
+    [DataRow(6)]
+    [DataRow(7)]
+    [DataRow(8)]
+    [DataRow(9)]
+    [DataRow(10)]
+    [DataRow(11)]
+    [DataRow(12)]
+    [DataRow(13)]
+    public void PartialBands_PaintExactlyTheRequestedHeight(int height)
+    {
+        var bands = ((height - 1) / 6) + 1;
+        var body = new StringBuilder();
+        for (var band = 0; band < bands; band++)
+        {
+            if (band > 0)
+            {
+                body.Append('-');
+            }
+
+            var remaining = height - (band * 6);
+            var mask = remaining >= 6 ? 63 : (1 << remaining) - 1;
+            body.Append((char)('?' + mask));
+        }
+
+        var result = Raster($"0;1q\"1;1;1;{height}{Red}#1{body}");
+        var image = RequireImage(result);
+
+        Assert.AreEqual(new SixelBounds(0, 0, 1, height), result.Extents.Painted);
+        Assert.AreEqual(Math.Max(height, bands * 6), image.Height);
+        for (var y = 0; y < image.Height; y++)
+        {
+            var expected = y < height ? new Rgba32(255, 0, 0, 255) : Rgba32.Transparent;
+            Assert.AreEqual(expected, image[0, y], $"row {y}");
+        }
+    }
+
+    [TestMethod]
+    public void PartialFinalBand_KeepsTheExactPaintedHeight()
+    {
+        var result = Raster($"0;1q\"1;1;1;8{Red}#1~-B");
+        var image = RequireImage(result);
+
+        Assert.AreEqual(12, image.Height);
+        Assert.AreEqual(new Rgba32(255, 0, 0, 255), image[0, 7]);
+        Assert.AreEqual(Rgba32.Transparent, image[0, 8]);
+        Assert.AreEqual(new SixelExtent(1, 12), result.Extents.Data);
+        Assert.AreEqual(new SixelBounds(0, 0, 1, 8), result.Extents.Painted);
+    }
+
+    [TestMethod]
+    public void DataBeyondDeclaredExtent_GrowsTheLogicalCanvas()
+    {
+        var result = Raster($"0;1q\"1;1;1;1{Red}#1~~-~~");
+
+        Assert.AreEqual(new SixelExtent(1, 1), result.Extents.Declared);
+        Assert.AreEqual(new SixelExtent(2, 12), result.Extents.Data);
+        Assert.AreEqual(new SixelExtent(2, 12), result.Extents.Logical);
+        Assert.AreEqual(12, RequireImage(result).Height);
+    }
+
+    [TestMethod]
+    public void DataSmallerThanDeclaredExtent_KeepsTheDeclaredCanvas()
+    {
+        var result = Raster($"0;1q\"1;1;4;7{Red}#1@");
+        var image = RequireImage(result);
+
+        Assert.AreEqual(new SixelExtent(4, 7), result.Extents.Logical);
+        Assert.AreEqual(new SixelExtent(1, 6), result.Extents.Data);
+        Assert.AreEqual(new SixelBounds(0, 0, 1, 1), result.Extents.Painted);
+        Assert.AreEqual(4, image.Width);
+        Assert.AreEqual(7, image.Height);
+    }
+
+    #endregion
+
+    #region Overprint, carriage return, and run length
+
+    [TestMethod]
+    public void Decgcr_OverprintsTheSameBandWithMultipleColors()
+    {
+        var result = Raster($"0;1q{Red}{Green}#1@$#2A");
+
+        AssertPixels(
+            result,
+            "R",
+            "G",
+            ".",
+            ".",
+            ".",
+            ".");
+    }
+
+    [TestMethod]
+    public void Decgcr_LastWriteWinsForOverlappingPixels()
+    {
+        var result = Raster($"0;1q{Red}{Green}#1~$#2@");
+
+        AssertPixels(
+            result,
+            "G",
+            "R",
+            "R",
+            "R",
+            "R",
+            "R");
+    }
+
+    [TestMethod]
+    public void Decgnl_AdvancesOneLogicalBandPerNewline()
+    {
+        var result = Raster($"0;1q{Red}{Green}#1@-#2@");
+
+        AssertPixels(
+            result,
+            "R",
+            ".",
+            ".",
+            ".",
+            ".",
+            ".",
+            "G",
+            ".",
+            ".",
+            ".",
+            ".",
+            ".");
+    }
+
+    [TestMethod]
+    public void RunLength_MatchesTheExpandedFormExactly()
+    {
+        var repeated = Raster($"0;0q{Red}#1!5~");
+        var expanded = Raster($"0;0q{Red}#1~~~~~");
+
+        AssertImagesEqual(RequireImage(expanded), RequireImage(repeated));
+    }
+
+    [TestMethod]
+    public void RunLength_OmittedOrZeroCountPaintsOneColumn()
+    {
+        var omitted = Raster($"0;0q{Red}#1!~");
+        var zero = Raster($"0;0q{Red}#1!0~");
+        var single = Raster($"0;0q{Red}#1~");
+
+        AssertImagesEqual(RequireImage(single), RequireImage(omitted));
+        AssertImagesEqual(RequireImage(single), RequireImage(zero));
+    }
+
+    [TestMethod]
+    public void RunLength_AcrossMixedColorsMatchesTheExpandedForm()
+    {
+        var repeated = Raster($"0;1q{Red}{Green}#1!3~#2!2A");
+        var expanded = Raster($"0;1q{Red}{Green}#1~~~#2AA");
+
+        AssertImagesEqual(RequireImage(expanded), RequireImage(repeated));
+    }
+
+    #endregion
+
+    #region RGB conversion
+
+    [TestMethod]
+    [DataRow(0, 0)]
+    [DataRow(1, 3)]
+    [DataRow(20, 51)]
+    [DataRow(50, 128)]
+    [DataRow(51, 130)]
+    [DataRow(80, 204)]
+    [DataRow(99, 252)]
+    [DataRow(100, 255)]
+    public void RgbPercent_UsesNearestRounding(int percent, int expected)
+    {
+        Assert.AreEqual((byte)expected, SixelColorConverter.PercentToComponent(percent));
+    }
+
+    [TestMethod]
+    [DataRow(-5, 0)]
+    [DataRow(101, 255)]
+    [DataRow(999, 255)]
+    public void RgbPercent_ClampsToTheDecDomain(int percent, int expected)
+    {
+        Assert.AreEqual((byte)expected, SixelColorConverter.PercentToComponent(percent));
+    }
+
+    [TestMethod]
+    public void RgbDefinition_OutOfRangePercentageIsClampedInTheRaster()
+    {
+        var result = Raster("0;1q#1;2;200;50;0#1@");
+
+        Assert.AreEqual(new Rgba32(255, 128, 0, 255), RequireImage(result)[0, 0]);
+    }
+
+    [TestMethod]
+    public void RgbDefinition_MidpointProducesTheRoundedComponent()
+    {
+        var result = Raster("0;1q#1;2;50;50;50#1@");
+
+        Assert.AreEqual(new Rgba32(128, 128, 128, 255), RequireImage(result)[0, 0]);
+    }
+
+    #endregion
+
+    #region DEC HLS conversion
+
+    [TestMethod]
+    [DataRow(0, 0, 0, 255)]
+    [DataRow(120, 255, 0, 0)]
+    [DataRow(240, 0, 255, 0)]
+    [DataRow(60, 255, 0, 255)]
+    [DataRow(180, 255, 255, 0)]
+    [DataRow(300, 0, 255, 255)]
+    public void Hls_UsesTheDecHueWheelWithBlueAtZero(int hue, int r, int g, int b)
+    {
+        Assert.AreEqual(
+            new Rgba32((byte)r, (byte)g, (byte)b, 255),
+            SixelColorConverter.FromHls(hue, 50, 100));
+    }
+
+    [TestMethod]
+    [DataRow(360, 0, 0, 255)]
+    [DataRow(480, 255, 0, 0)]
+    [DataRow(720, 0, 0, 255)]
+    [DataRow(-120, 0, 255, 0)]
+    public void Hls_HueWrapsAroundTheWheel(int hue, int r, int g, int b)
+    {
+        Assert.AreEqual(
+            new Rgba32((byte)r, (byte)g, (byte)b, 255),
+            SixelColorConverter.FromHls(hue, 50, 100));
+    }
+
+    [TestMethod]
+    [DataRow(0, 0, 0, 0)]
+    [DataRow(25, 64, 64, 64)]
+    [DataRow(50, 128, 128, 128)]
+    [DataRow(75, 191, 191, 191)]
+    [DataRow(100, 255, 255, 255)]
+    public void Hls_ZeroSaturationProducesGray(int lightness, int r, int g, int b)
+    {
+        Assert.AreEqual(
+            new Rgba32((byte)r, (byte)g, (byte)b, 255),
+            SixelColorConverter.FromHls(120, lightness, 0));
+    }
+
+    [TestMethod]
+    public void Hls_LightnessExtremesIgnoreHueAndSaturation()
+    {
+        Assert.AreEqual(new Rgba32(0, 0, 0, 255), SixelColorConverter.FromHls(120, 0, 100));
+        Assert.AreEqual(new Rgba32(255, 255, 255, 255), SixelColorConverter.FromHls(120, 100, 100));
+    }
+
+    [TestMethod]
+    public void Hls_ClampsSaturationAndLightnessToTheDecDomain()
+    {
+        Assert.AreEqual(
+            SixelColorConverter.FromHls(120, 100, 100),
+            SixelColorConverter.FromHls(120, 150, 400));
+        Assert.AreEqual(
+            SixelColorConverter.FromHls(120, 0, 0),
+            SixelColorConverter.FromHls(120, -20, -20));
+    }
+
+    [TestMethod]
+    public void Hls_HalfSaturationInterpolatesDeterministically()
+    {
+        Assert.AreEqual(new Rgba32(191, 64, 64, 255), SixelColorConverter.FromHls(120, 50, 50));
+        Assert.AreEqual(new Rgba32(64, 64, 191, 255), SixelColorConverter.FromHls(0, 50, 50));
+    }
+
+    [TestMethod]
+    public void Hls_BoundaryHuesRoundConsistently()
+    {
+        // 60 degrees either side of a primary reaches the secondary exactly.
+        Assert.AreEqual(new Rgba32(255, 0, 255, 255), SixelColorConverter.FromHls(60, 50, 100));
+        // One degree inside the ramp is strictly below the full component.
+        var nearlyMagenta = SixelColorConverter.FromHls(59, 50, 100);
+        Assert.AreEqual((byte)251, nearlyMagenta.R);
+        Assert.AreEqual((byte)0, nearlyMagenta.G);
+        Assert.AreEqual((byte)255, nearlyMagenta.B);
+    }
+
+    [TestMethod]
+    public void HlsDefinition_IsAppliedByTheRasterizer()
+    {
+        var result = Raster("0;1q#3;1;0;50;100#3@");
+
+        Assert.AreEqual(new Rgba32(0, 0, 255, 255), RequireImage(result)[0, 0]);
+    }
+
+    #endregion
+
+    #region Color registers
+
+    [TestMethod]
+    public void SelectionWithoutDefinition_UsesTheDefaultPalette()
+    {
+        var result = Raster("0;1q#2@");
+
+        Assert.AreEqual(SixelDefaultPalette.Get(2), RequireImage(result)[0, 0]);
+        Assert.AreEqual(new Rgba32(204, 33, 33, 255), SixelDefaultPalette.Get(2));
+    }
+
+    [TestMethod]
+    public void DefaultPalette_RegisterZeroIsBlack()
+    {
+        Assert.AreEqual(new Rgba32(0, 0, 0, 255), SixelDefaultPalette.Get(0));
+    }
+
+    [TestMethod]
+    public void DefaultPalette_ExtendsBeyondTheVt340RegistersWithinPolicy()
+    {
+        var registers = new SixelColorRegisters();
+
+        Assert.AreEqual(256, registers.Count);
+        Assert.IsTrue(registers.IsWithinPolicy(255));
+        Assert.IsFalse(registers.IsWithinPolicy(256));
+        Assert.IsFalse(registers.IsWithinPolicy(-1));
+        Assert.AreEqual(new Rgba32(255, 255, 255, 255), registers.Get(231));
+        Assert.AreEqual(new Rgba32(238, 238, 238, 255), registers.Get(255));
+    }
+
+    [TestMethod]
+    public void DecgciDefinition_AlsoSelectsTheRegister()
+    {
+        var result = Raster($"0;1q{Red}@");
+
+        Assert.AreEqual(new Rgba32(255, 0, 0, 255), RequireImage(result)[0, 0]);
+    }
+
+    [TestMethod]
+    public void ColorRegisters_PersistBetweenSequencesOnTheSameEnvironment()
+    {
+        var environment = SixelRasterEnvironment.CreateDefault();
+        _ = SixelRasterizer.Rasterize(SixelParser.ParsePayload($"0;1q{Red}@"), environment);
+
+        var second = SixelRasterizer.Rasterize(SixelParser.ParsePayload("0;1q#1@"), environment);
+
+        Assert.AreEqual(new Rgba32(255, 0, 0, 255), RequireImage(second)[0, 0]);
+    }
+
+    [TestMethod]
+    public void ColorRegisters_ResetRestoresTheDefaultPalette()
+    {
+        var environment = SixelRasterEnvironment.CreateDefault();
+        _ = SixelRasterizer.Rasterize(SixelParser.ParsePayload($"0;1q{Red}@"), environment);
+        environment.Registers.Reset();
+
+        var afterReset = SixelRasterizer.Rasterize(SixelParser.ParsePayload("0;1q#1@"), environment);
+
+        Assert.AreEqual(SixelDefaultPalette.Get(1), RequireImage(afterReset)[0, 0]);
+        Assert.AreNotEqual(new Rgba32(255, 0, 0, 255), RequireImage(afterReset)[0, 0]);
+    }
+
+    [TestMethod]
+    public void ColorRegisters_OutOfPolicyRegisterIsRejectedExplicitly()
+    {
+        var result = Raster("0;1q#999;2;100;0;0#999@");
+
+        Assert.IsTrue(result.Diagnostics.Any(
+            item => item.Code == SixelRasterDiagnosticCode.ColorRegisterOutOfPolicy));
+        // The rejected selection never becomes the paint color; register 0 remains selected.
+        Assert.AreEqual(SixelDefaultPalette.Get(0), RequireImage(result)[0, 0]);
+    }
+
+    [TestMethod]
+    public void ColorRegisters_SnapshotIsIndependent()
+    {
+        var registers = new SixelColorRegisters();
+        var snapshot = registers.Snapshot();
+        registers.Define(1, new Rgba32(1, 2, 3, 255));
+
+        Assert.AreEqual(SixelDefaultPalette.Get(1), snapshot.Get(1));
+        Assert.AreEqual(new Rgba32(1, 2, 3, 255), registers.Get(1));
+    }
+
+    #endregion
+
+    #region Background
+
+    [TestMethod]
+    public void OpaqueBackground_FillsUnpaintedPixelsAcrossTheDeclaredExtent()
+    {
+        var environment = EnvironmentWithBackground(new Rgba32(0, 0, 255, 255));
+        var result = SixelRasterizer.Rasterize(
+            SixelParser.ParsePayload($"0;0q\"1;1;3;6{Red}#1@"),
+            environment);
+
+        AssertPixels(
+            result,
+            "RBB",
+            "BBB",
+            "BBB",
+            "BBB",
+            "BBB",
+            "BBB");
+    }
+
+    [TestMethod]
+    public void OpaqueBackground_FillsUnpaintedPixelsWithoutADeclaredExtent()
+    {
+        var environment = EnvironmentWithBackground(new Rgba32(0, 0, 255, 255));
+        var result = SixelRasterizer.Rasterize(
+            SixelParser.ParsePayload($"0;0q{Red}#1@@"),
+            environment);
+
+        AssertPixels(
+            result,
+            "RR",
+            "BB",
+            "BB",
+            "BB",
+            "BB",
+            "BB");
+    }
+
+    [TestMethod]
+    [DataRow("0")]
+    [DataRow("2")]
+    [DataRow("")]
+    public void OpaqueBackgroundSelectors_AreAllOpaque(string p2)
+    {
+        var environment = EnvironmentWithBackground(new Rgba32(0, 0, 255, 255));
+        var result = SixelRasterizer.Rasterize(
+            SixelParser.ParsePayload($"0;{p2}q{Red}#1@"),
+            environment);
+
+        Assert.AreEqual(SixelBackgroundMode.Opaque, result.BackgroundMode);
+        Assert.AreEqual(new Rgba32(0, 0, 255, 255), RequireImage(result)[0, 1]);
+    }
+
+    [TestMethod]
+    public void TransparentBackground_LeavesUnpaintedPixelsTransparent()
+    {
+        var environment = EnvironmentWithBackground(new Rgba32(0, 0, 255, 255));
+        var result = SixelRasterizer.Rasterize(
+            SixelParser.ParsePayload($"0;1q\"1;1;2;2{Red}#1@"),
+            environment);
+
+        Assert.AreEqual(SixelBackgroundMode.Transparent, result.BackgroundMode);
+        AssertPixels(
+            result,
+            "R.",
+            "..",
+            "..",
+            "..",
+            "..",
+            "..");
+    }
+
+    [TestMethod]
+    public void UnsetTerminalBackground_UsesDeterministicBlack()
+    {
+        var result = Raster($"0;0q{Red}#1@");
+
+        Assert.AreEqual(new Rgba32(0, 0, 0, 255), result.UnpaintedPixel);
+        Assert.AreEqual(new Rgba32(0, 0, 0, 255), RequireImage(result)[0, 1]);
+    }
+
+    [TestMethod]
+    public void CapturedBackground_IsIndependentOfPaletteRegisterZero()
+    {
+        var environment = EnvironmentWithBackground(new Rgba32(0, 0, 255, 255));
+        var result = SixelRasterizer.Rasterize(
+            SixelParser.ParsePayload($"0;0q#0;2;0;100;0{Red}#1@"),
+            environment);
+
+        // Register zero is now green, but the captured background stays blue.
+        Assert.AreEqual(new Rgba32(0, 0, 255, 255), RequireImage(result)[0, 1]);
+    }
+
+    #endregion
+
+    #region Aspect and extents
+
+    [TestMethod]
+    [DataRow("", 2, 1)]
+    [DataRow("0", 2, 1)]
+    [DataRow("1", 2, 1)]
+    [DataRow("2", 5, 1)]
+    [DataRow("3", 3, 1)]
+    [DataRow("4", 3, 1)]
+    [DataRow("5", 2, 1)]
+    [DataRow("6", 2, 1)]
+    [DataRow("7", 1, 1)]
+    [DataRow("8", 1, 1)]
+    [DataRow("9", 1, 1)]
+    public void PixelAspectMacro_FollowsTheDecTable(string p1, int numerator, int denominator)
+    {
+        var result = Raster($"{p1};1q#1~");
+
+        Assert.AreEqual(new SixelAspectRatio(numerator, denominator), result.Extents.Aspect);
+        Assert.AreEqual(6, result.Extents.Logical.Height);
+        Assert.AreEqual(6 * numerator / denominator, result.Extents.Rendered.Height);
+    }
+
+    [TestMethod]
+    [DataRow(1, 1, 6)]
+    [DataRow(2, 1, 12)]
+    [DataRow(3, 1, 18)]
+    [DataRow(1, 2, 3)]
+    [DataRow(5, 2, 15)]
+    [DataRow(7, 3, 14)]
+    public void DecgraPanAndPad_OverrideThePixelAspectMacro(int pan, int pad, int renderedHeight)
+    {
+        var result = Raster($"2;1q\"{pan};{pad};1;6#1~");
+
+        Assert.AreEqual(new SixelAspectRatio(pan, pad), result.Extents.Aspect);
+        Assert.AreEqual(6, result.Extents.Logical.Height);
+        Assert.AreEqual(renderedHeight, result.Extents.Rendered.Height);
+    }
+
+    [TestMethod]
+    public void LogicalStorage_IsNeverResampledByTheAspectRatio()
+    {
+        var square = Raster($"7;1q{Red}#1~");
+        var tall = Raster($"2;1q{Red}#1~");
+
+        AssertImagesEqual(RequireImage(square), RequireImage(tall));
+        Assert.AreEqual(6, RequireImage(tall).Height);
+        Assert.AreEqual(30, tall.Extents.Rendered.Height);
+    }
+
+    [TestMethod]
+    public void DecgraPhAndPv_AreHorizontalThenVertical()
+    {
+        var result = Raster("0;1q\"1;1;9;4#1@");
+
+        Assert.AreEqual(new SixelExtent(9, 4), result.Extents.Declared);
+        Assert.AreEqual(9, RequireImage(result).Width);
+        Assert.AreEqual(6, RequireImage(result).Height);
+        Assert.AreEqual(new SixelExtent(9, 6), result.Extents.Logical);
+    }
+
+    [TestMethod]
+    public void Extents_ArePreservedIndependentlyOfEachOther()
+    {
+        var result = Raster($"2;1q\"1;1;10;3{Red}#1!4A");
+
+        Assert.AreEqual(new SixelExtent(10, 3), result.Extents.Declared);
+        Assert.AreEqual(new SixelExtent(4, 6), result.Extents.Data);
+        Assert.AreEqual(new SixelBounds(0, 1, 4, 1), result.Extents.Painted);
+        Assert.AreEqual(new SixelExtent(10, 6), result.Extents.Logical);
+        Assert.AreEqual(new SixelExtent(10, 6), result.Extents.Rendered);
+    }
+
+    #endregion
+
+    #region Bounded storage and explicit degradation
+
+    [TestMethod]
+    public void HugeTransparentDeclaration_DoesNotAllocateProportionally()
+    {
+        var result = Raster("0;1q\"1;1;4000;4000#1@");
+        var image = RequireImage(result);
+
+        Assert.AreEqual(4000, image.Width);
+        Assert.AreEqual(4000, image.Height);
+        Assert.AreEqual(16_000_000, image.PixelCount);
+        Assert.AreEqual(1, image.AllocatedTileCount);
+    }
+
+    [TestMethod]
+    public void HugeOpaqueDeclaration_DoesNotAllocateProportionally()
+    {
+        var result = Raster("0;0q\"1;1;4000;4000#1@");
+        var image = RequireImage(result);
+
+        Assert.AreEqual(new Rgba32(0, 0, 0, 255), image[3999, 3999]);
+        Assert.AreEqual(1, image.AllocatedTileCount);
+    }
+
+    [TestMethod]
+    public void ExtentBeyondPolicy_ReturnsGeometryOnlyAndPreservesGeometry()
+    {
+        var result = Raster("0;1q\"1;1;999999999;999999999#1@");
+
+        Assert.AreEqual(SixelRasterStatus.GeometryOnly, result.Status);
+        Assert.IsNull(result.Image);
+        Assert.AreEqual(new SixelExtent(999999999, 999999999), result.Extents.Declared);
+        Assert.AreEqual(new SixelExtent(999999999, 999999999), result.Extents.Logical);
+        Assert.IsTrue(result.Diagnostics.Any(
+            item => item.Code == SixelRasterDiagnosticCode.RasterPixelLimitExceeded));
+    }
+
+    [TestMethod]
+    public void ExtentOverflow_IsDetectedWithoutWrapping()
+    {
+        var result = Raster("7;1q" + string.Concat(Enumerable.Repeat("!999999999~", 3)));
+
+        Assert.AreEqual(SixelRasterStatus.GeometryOnly, result.Status);
+        Assert.AreEqual(int.MaxValue, result.Extents.Logical.Width);
+        Assert.IsTrue(result.Extents.Logical.Height > 0);
+        Assert.IsTrue(result.Diagnostics.Any(
+            item => item.Code == SixelRasterDiagnosticCode.RasterExtentOverflow));
+    }
+
+    [TestMethod]
+    public void RasterOperationBudget_ReturnsGeometryOnly()
+    {
+        var result = Raster("7;1q" + string.Concat(Enumerable.Repeat("!2000000~$", 6)));
+
+        Assert.AreEqual(SixelRasterStatus.GeometryOnly, result.Status);
+        Assert.IsTrue(result.Diagnostics.Any(
+            item => item.Code == SixelRasterDiagnosticCode.RasterOperationLimitExceeded));
+        Assert.AreEqual(2_000_000, result.Extents.Logical.Width);
+    }
+
+    [TestMethod]
+    public void SparseTileBudget_ReturnsGeometryOnlyInsteadOfAPartialRaster()
+    {
+        var policy = SixelCompatibilityPolicy.Default with
+        {
+            MaximumRasterTiles = 1,
+        };
+        var result = SixelRasterizer.Rasterize(
+            SixelParser.ParsePayload("7;1q!65~"),
+            new SixelRasterEnvironment(
+                policy.DefaultBackground,
+                new SixelColorRegisters(policy),
+                policy));
+
+        Assert.AreEqual(SixelRasterStatus.GeometryOnly, result.Status);
+        Assert.IsNull(result.Image);
+        Assert.AreEqual(new SixelExtent(65, 6), result.Extents.Logical);
+        Assert.IsTrue(result.Diagnostics.Any(
+            item => item.Code == SixelRasterDiagnosticCode.RasterTileLimitExceeded));
+    }
+
+    [TestMethod]
+    public void GeometryOnly_StillAppliesPaletteDefinitions()
+    {
+        var environment = SixelRasterEnvironment.CreateDefault();
+        var refused = SixelRasterizer.Rasterize(
+            SixelParser.ParsePayload($"0;1q\"1;1;999999999;999999999{Red}#1@"),
+            environment);
+
+        Assert.AreEqual(SixelRasterStatus.GeometryOnly, refused.Status);
+        Assert.AreEqual(new Rgba32(255, 0, 0, 255), environment.Registers.Get(1));
+    }
+
+    [TestMethod]
+    public void MalformedSequence_ReturnsGeometryOnlyWithAnExplicitDiagnostic()
+    {
+        var result = Raster("0;1q#");
+
+        Assert.AreEqual(SixelRasterStatus.GeometryOnly, result.Status);
+        Assert.IsTrue(result.Diagnostics.Any(
+            item => item.Code == SixelRasterDiagnosticCode.ParseOutcomeNotRasterable));
+    }
+
+    [TestMethod]
+    public void SequenceWithoutExtent_ReturnsGeometryOnly()
+    {
+        var result = Raster("0;1q");
+
+        Assert.AreEqual(SixelRasterStatus.GeometryOnly, result.Status);
+        Assert.IsTrue(result.Diagnostics.Any(
+            item => item.Code == SixelRasterDiagnosticCode.NoRasterableExtent));
+    }
+
+    #endregion
+
+    #region Determinism, equivalence, and materialization
+
+    [TestMethod]
+    public void Rasterizing_TheSameParseResultTwice_ProducesEqualPixels()
+    {
+        var parse = SixelParser.ParsePayload($"0;0q\"1;1;5;5{Red}{Green}#1!3~$#2A");
+        var first = SixelRasterizer.Rasterize(parse, SixelRasterEnvironment.CreateDefault());
+        var second = SixelRasterizer.Rasterize(parse, SixelRasterEnvironment.CreateDefault());
+
+        AssertImagesEqual(RequireImage(first), RequireImage(second));
+        TestSeq.AreEqual(first.Identity, second.Identity);
+    }
+
+    [TestMethod]
+    public void Materialize_IsRepeatable()
+    {
+        var image = RequireImage(Raster($"0;0q\"1;1;4;4{Red}#1!2~"));
+
+        var first = image.Materialize();
+        var second = image.Materialize();
+
+        Assert.AreEqual(first.Width, second.Width);
+        Assert.AreEqual(first.Height, second.Height);
+        for (var y = 0; y < first.Height; y++)
+        {
+            for (var x = 0; x < first.Width; x++)
+            {
+                Assert.AreEqual(first[x, y], second[x, y], $"({x},{y})");
+            }
+        }
+    }
+
+    [TestMethod]
+    public void SparseLookupAndDenseMaterialization_Agree()
+    {
+        var image = RequireImage(Raster($"0;0q\"1;1;70;70{Red}{Green}#1!65~-#2!3A"));
+        var dense = image.Materialize();
+
+        for (var y = 0; y < image.Height; y++)
+        {
+            for (var x = 0; x < image.Width; x++)
+            {
+                Assert.AreEqual(image[x, y], dense[x, y], $"({x},{y})");
+            }
+        }
+    }
+
+    [TestMethod]
+    public void SixelData_GetPixels_IsCachedAndRepeatable()
+    {
+        var payload = $"\x1bP0;0q\"1;1;3;3{Red}#1@\x1b\\";
+        var store = new TrackedObjectStore();
+        var tracked = store.GetOrCreateSixel(payload, 1, 1);
+
+        var first = tracked.Data.GetPixels();
+        var second = tracked.Data.GetPixels();
+
+        Assert.IsNotNull(first);
+        Assert.AreSame(first, second);
+        Assert.AreEqual(3, first.Width);
+        Assert.AreEqual(6, first.Height);
+        Assert.AreEqual(new Rgba32(255, 0, 0, 255), first[0, 0]);
+        Assert.AreEqual(new Rgba32(0, 0, 0, 255), first[2, 5]);
+
+        tracked.Release();
+    }
+
+    [TestMethod]
+    public void SixelData_GetPixels_ReturnsNullForGeometryOnlyResults()
+    {
+        var store = new TrackedObjectStore();
+        var tracked = store.GetOrCreateSixel(
+            "\x1bP0;1q\"1;1;999999999;999999999#1@\x1b\\",
+            1,
+            1);
+
+        Assert.IsNull(tracked.Data.GetPixels());
+        Assert.AreEqual(SixelRasterStatus.GeometryOnly, tracked.Data.Raster.Status);
+
+        tracked.Release();
+    }
+
+    [TestMethod]
+    public void TrackedSixel_IdenticalPayloadWithDifferentRasterState_IsNotReused()
+    {
+        var payload = "\x1bP0;0q#1@\x1b\\";
+        var parse = SixelParser.ParsePayload(payload);
+        var store = new TrackedObjectStore();
+
+        var onBlack = store.GetOrCreateSixel(
+            payload,
+            1,
+            1,
+            parse,
+            SixelRasterizer.Rasterize(parse, EnvironmentWithBackground(new Rgba32(0, 0, 0, 255))));
+        var onBlue = store.GetOrCreateSixel(
+            payload,
+            1,
+            1,
+            parse,
+            SixelRasterizer.Rasterize(parse, EnvironmentWithBackground(new Rgba32(0, 0, 255, 255))));
+
+        Assert.AreNotSame(onBlack, onBlue);
+        Assert.AreEqual(new Rgba32(0, 0, 0, 255), onBlack.Data.GetPixels()![0, 1]);
+        Assert.AreEqual(new Rgba32(0, 0, 255, 255), onBlue.Data.GetPixels()![0, 1]);
+
+        onBlack.Release();
+        onBlue.Release();
+    }
+
+    [TestMethod]
+    public void TrackedSixel_IdenticalPayloadAndRasterState_IsReused()
+    {
+        var payload = "\x1bP0;0q#1@\x1b\\";
+        var parse = SixelParser.ParsePayload(payload);
+        var store = new TrackedObjectStore();
+
+        var first = store.GetOrCreateSixel(
+            payload,
+            1,
+            1,
+            parse,
+            SixelRasterizer.Rasterize(parse, EnvironmentWithBackground(new Rgba32(0, 0, 0, 255))));
+        var second = store.GetOrCreateSixel(
+            payload,
+            1,
+            1,
+            parse,
+            SixelRasterizer.Rasterize(parse, EnvironmentWithBackground(new Rgba32(0, 0, 0, 255))));
+
+        Assert.AreSame(first, second);
+
+        first.Release();
+        second.Release();
+    }
+
+    [TestMethod]
+    public void AutomationDecoder_DelegatesToTheAuthoritativeRasterizer()
+    {
+        var payload = $"0;0q\"1;1;2;2{Red}#1@";
+        var image = Hex1b.Automation.SixelDecoder.Decode(payload);
+        var raster = RequireImage(Raster(payload));
+
+        Assert.IsNotNull(image);
+        Assert.AreEqual(raster.Width, image.Width);
+        Assert.AreEqual(raster.Height, image.Height);
+        for (var y = 0; y < raster.Height; y++)
+        {
+            for (var x = 0; x < raster.Width; x++)
+            {
+                var index = ((y * raster.Width) + x) * 4;
+                var expected = raster[x, y];
+                Assert.AreEqual(expected.R, image.Pixels[index], $"({x},{y}).R");
+                Assert.AreEqual(expected.G, image.Pixels[index + 1], $"({x},{y}).G");
+                Assert.AreEqual(expected.B, image.Pixels[index + 2], $"({x},{y}).B");
+                Assert.AreEqual(expected.A, image.Pixels[index + 3], $"({x},{y}).A");
+            }
+        }
+    }
+
+    [TestMethod]
+    public void AutomationDecoder_ReturnsNullOnlyForDocumentedDegradation()
+    {
+        Assert.IsNull(Hex1b.Automation.SixelDecoder.Decode(""));
+        Assert.IsNull(Hex1b.Automation.SixelDecoder.Decode("0;1q#"));
+        Assert.IsNull(Hex1b.Automation.SixelDecoder.Decode("0;1q\"1;1;999999999;999999999#1@"));
+        Assert.IsNotNull(Hex1b.Automation.SixelDecoder.Decode($"0;1q{Red}#1@"));
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private static SixelRasterResult Raster(string payload) =>
+        SixelRasterizer.Rasterize(
+            SixelParser.ParsePayload(payload),
+            SixelRasterEnvironment.CreateDefault());
+
+    private static SixelRasterEnvironment EnvironmentWithBackground(Rgba32 background) =>
+        new(background, new SixelColorRegisters(), SixelCompatibilityPolicy.Default);
+
+    private static SixelRasterImage RequireImage(SixelRasterResult result)
+    {
+        Assert.AreEqual(SixelRasterStatus.Rasterized, result.Status);
+        Assert.IsNotNull(result.Image);
+        return result.Image;
+    }
+
+    private static void AssertPixels(SixelRasterResult result, params string[] rows)
+    {
+        var image = RequireImage(result);
+        Assert.AreEqual(rows.Length, image.Height, "raster height");
+        Assert.AreEqual(rows[0].Length, image.Width, "raster width");
+
+        var actual = new StringBuilder();
+        var expected = new StringBuilder();
+        for (var y = 0; y < image.Height; y++)
+        {
+            for (var x = 0; x < image.Width; x++)
+            {
+                actual.Append(Symbol(image[x, y]));
+                expected.Append(rows[y][x]);
+            }
+
+            actual.Append('\n');
+            expected.Append('\n');
+        }
+
+        Assert.AreEqual(expected.ToString(), actual.ToString());
+    }
+
+    private static char Symbol(Rgba32 pixel) => pixel switch
+    {
+        { A: 0 } => '.',
+        { R: 0, G: 0, B: 0, A: 255 } => 'K',
+        { R: 255, G: 0, B: 0, A: 255 } => 'R',
+        { R: 0, G: 255, B: 0, A: 255 } => 'G',
+        { R: 0, G: 0, B: 255, A: 255 } => 'B',
+        { R: 255, G: 255, B: 255, A: 255 } => 'W',
+        _ => '?',
+    };
+
+    private static void AssertImagesEqual(SixelRasterImage expected, SixelRasterImage actual)
+    {
+        Assert.AreEqual(expected.Width, actual.Width, "width");
+        Assert.AreEqual(expected.Height, actual.Height, "height");
+        for (var y = 0; y < expected.Height; y++)
+        {
+            for (var x = 0; x < expected.Width; x++)
+            {
+                Assert.AreEqual(expected[x, y], actual[x, y], $"({x},{y})");
+            }
+        }
+    }
+
+    #endregion
+}

--- a/tests/Hex1b.Tests/Sixel/SixelRasterizerTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelRasterizerTests.cs
@@ -427,6 +427,50 @@ public class SixelRasterizerTests
     }
 
     [TestMethod]
+    public void Prepare_AppliesPersistentPaletteAndCapturesIndependentRasterState()
+    {
+        var environment = SixelRasterEnvironment.CreateDefault();
+        _ = SixelRasterizer.Prepare(
+            SixelParser.ParsePayload($"0;1q{Red}"),
+            environment);
+        var selectRed = SixelParser.ParsePayload("0;1q#1@");
+        var preparation = SixelRasterizer.Prepare(selectRed, environment);
+
+        Assert.AreEqual(new Rgba32(255, 0, 0, 255), environment.Registers.Get(1));
+
+        environment.Registers.Reset();
+        var raster = SixelRasterizer.Rasterize(selectRed, preparation.Environment);
+        Assert.AreEqual(new Rgba32(255, 0, 0, 255), RequireImage(raster)[0, 0]);
+    }
+
+    [TestMethod]
+    public void Prepare_AppliesDefinitionsBeyondPaletteMutationRetentionLimit()
+    {
+        var environment = SixelRasterEnvironment.CreateDefault();
+        var payload = $"0;1q{string.Concat(Enumerable.Repeat("#1", 4_096))}{Red}";
+        var parse = SixelParser.ParsePayload(payload);
+
+        _ = SixelRasterizer.Prepare(parse, environment);
+
+        Assert.AreEqual(SixelParseOutcome.LimitDowngraded, parse.Outcome);
+        Assert.AreEqual(new Rgba32(255, 0, 0, 255), environment.Registers.Get(1));
+    }
+
+    [TestMethod]
+    public void Prepare_AppliesRetainedPaletteDefinitionsAfterCommandRetentionLimit()
+    {
+        var environment = SixelRasterEnvironment.CreateDefault();
+        var commands = string.Concat(Enumerable.Repeat("@A", 32_768));
+        var parse = SixelParser.ParsePayload($"0;1q{commands}{Red}");
+
+        _ = SixelRasterizer.Prepare(parse, environment);
+
+        Assert.AreEqual(SixelParseOutcome.LimitDowngraded, parse.Outcome);
+        Assert.IsFalse(parse.CommandsComplete);
+        Assert.AreEqual(new Rgba32(255, 0, 0, 255), environment.Registers.Get(1));
+    }
+
+    [TestMethod]
     public void ColorRegisters_ResetRestoresTheDefaultPalette()
     {
         var environment = SixelRasterEnvironment.CreateDefault();
@@ -816,6 +860,35 @@ public class SixelRasterizerTests
     }
 
     [TestMethod]
+    public async Task SixelData_GetPixels_ConcurrentCallersShareOneMaterialization()
+    {
+        var payload = $"\x1bP0;0q\"1;1;70;70{Red}#1!70~\x1b\\";
+        var parse = SixelParser.ParsePayload(payload);
+        var store = new TrackedObjectStore();
+        var tracked = store.GetOrCreateSixel(
+            payload,
+            1,
+            1,
+            parse,
+            SixelRasterizer.Prepare(parse, SixelRasterEnvironment.CreateDefault()));
+        var calls = Enumerable.Range(0, 16)
+            .Select(_ => Task.Run(tracked.Data.GetPixels))
+            .ToArray();
+
+        var results = await Task.WhenAll(calls).WaitAsync(
+            TimeSpan.FromSeconds(2),
+            TestContext.Current.CancellationToken);
+
+        Assert.IsNotNull(results[0]);
+        foreach (var result in results)
+        {
+            Assert.AreSame(results[0], result);
+        }
+
+        tracked.Release();
+    }
+
+    [TestMethod]
     public void SixelData_GetPixels_ReturnsNullForGeometryOnlyResults()
     {
         var store = new TrackedObjectStore();
@@ -842,13 +915,17 @@ public class SixelRasterizerTests
             1,
             1,
             parse,
-            SixelRasterizer.Rasterize(parse, EnvironmentWithBackground(new Rgba32(0, 0, 0, 255))));
+            SixelRasterizer.Prepare(
+                parse,
+                EnvironmentWithBackground(new Rgba32(0, 0, 0, 255))));
         var onBlue = store.GetOrCreateSixel(
             payload,
             1,
             1,
             parse,
-            SixelRasterizer.Rasterize(parse, EnvironmentWithBackground(new Rgba32(0, 0, 255, 255))));
+            SixelRasterizer.Prepare(
+                parse,
+                EnvironmentWithBackground(new Rgba32(0, 0, 255, 255))));
 
         Assert.AreNotSame(onBlack, onBlue);
         Assert.AreEqual(new Rgba32(0, 0, 0, 255), onBlack.Data.GetPixels()![0, 1]);
@@ -864,21 +941,53 @@ public class SixelRasterizerTests
         var payload = "\x1bP0;0q#1@\x1b\\";
         var parse = SixelParser.ParsePayload(payload);
         var store = new TrackedObjectStore();
+        var environment = EnvironmentWithBackground(new Rgba32(0, 0, 0, 255));
 
         var first = store.GetOrCreateSixel(
             payload,
             1,
             1,
             parse,
-            SixelRasterizer.Rasterize(parse, EnvironmentWithBackground(new Rgba32(0, 0, 0, 255))));
+            SixelRasterizer.Prepare(
+                parse,
+                environment));
         var second = store.GetOrCreateSixel(
             payload,
             1,
             1,
             parse,
-            SixelRasterizer.Rasterize(parse, EnvironmentWithBackground(new Rgba32(0, 0, 0, 255))));
+            SixelRasterizer.Prepare(
+                parse,
+                environment));
 
         Assert.AreSame(first, second);
+
+        first.Release();
+        second.Release();
+    }
+
+    [TestMethod]
+    public void TrackedSixel_PreDefinitionPaletteUseProducesDistinctIdentity()
+    {
+        var payload = $"\x1bP0;1q#1@{Red}@\x1b\\";
+        var parse = SixelParser.ParsePayload(payload);
+        var store = new TrackedObjectStore();
+        var environment = SixelRasterEnvironment.CreateDefault();
+
+        var first = store.GetOrCreateSixel(
+            payload,
+            1,
+            1,
+            parse,
+            SixelRasterizer.Prepare(parse, environment));
+        var second = store.GetOrCreateSixel(
+            payload,
+            1,
+            1,
+            parse,
+            SixelRasterizer.Prepare(parse, environment));
+
+        Assert.AreNotSame(first, second);
 
         first.Release();
         second.Release();


### PR DESCRIPTION
Closes #449
Part of #445

## Summary

- add an authoritative rasterizer over structured `SixelParseResult` command events, with separate logical, rendered, declared, data, and painted extents
- add terminal-scoped 256-color palette state, deterministic DEC RGB/HLS conversion, creation-time background capture, and explicit RIS palette reset
- store pixels in bounded sparse tiles and return geometry-only results when extent, operation, or tile limits are exceeded
- route `SixelData`, automation decoding, and SVG export through the shared raster result without reparsing DCS payloads
- extend the raw terminal demo with RGB, HLS, palette persistence, transparent/opaque background, aspect, overprint, partial-band, and geometry-only scenes
- document the captured-background compatibility decision and keep alternative behavior centralized

## Validation

- focused parser/raster/integration tests: 194 passed
- full Sixel suite: 354 passed, 10 deferred-stage tests skipped
- terminal/automation tests: 170 passed, 12 unrelated existing skips
- full `Hex1b.Tests`: 8,838 passed, 34 existing skips
- `samples/SixelTerminalDemo` build and `--headless` scene validation

## Scope

This PR intentionally does not implement #450 cursor/mode/margin semantics, #451 independent placement lifetime, or later scrolling, snapshot, and translation stages.