### PR TITLE
Implement Sixel cursor, DECSDM, margin, and metric semantics

### DIFF
--- a/docs/sixel-terminal-behavior.md
+++ b/docs/sixel-terminal-behavior.md
@@ -293,11 +293,22 @@ dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj \
 The terminal-first demo sends independently authored raw Sixel bytes through
 `Hex1bTerminal`. It does not use `SixelWidget` or `SixelEncoder`.
 
+The demo presents one subject per screen. Each screen clears the display, resets
+margins, origin mode, and DECSDM so it cannot inherit state from the screen
+before it, then draws its subject and waits. Enter or Space advances, `p` goes
+back, and `q` quits. Screens are numbered so a specific one can be named in
+review and reopened directly.
+
 ```bash
 dotnet run --project samples/SixelTerminalDemo
+dotnet run --project samples/SixelTerminalDemo -- --screen 17
 dotnet run --project samples/SixelTerminalDemo -- --scene "Declared extent"
 dotnet run --project samples/SixelTerminalDemo -- --headless
 ```
+
+`--headless` prints the numbered screen list together with the parsed model and
+the observed cursor, mode, and margin results, so the same screen numbers can be
+checked without a Sixel-capable terminal.
 
 ## Primary references
 

--- a/docs/sixel-terminal-behavior.md
+++ b/docs/sixel-terminal-behavior.md
@@ -299,6 +299,12 @@ before it, then draws its subject and waits. Enter or Space advances, `p` goes
 back, and `q` quits. Screens are numbered so a specific one can be named in
 review and reopened directly.
 
+The description is drawn below the image, after the graphic has been placed. A
+Sixel graphic is painted at the cursor, and some screens deliberately anchor it
+at the page origin, so a description above the image would be overpainted.
+Each description states the expected colour and the size in both pixels and
+cells, so a screen can be checked against what is actually on the terminal.
+
 ```bash
 dotnet run --project samples/SixelTerminalDemo
 dotnet run --project samples/SixelTerminalDemo -- --screen 17

--- a/docs/sixel-terminal-behavior.md
+++ b/docs/sixel-terminal-behavior.md
@@ -172,12 +172,13 @@ identical payload rasterizes, tracked Sixel deduplication keys on the payload
 | `CSI ? 8452 l` | In scrolling mode, leave the cursor at its original column below the graphic | xterm extension reset/default behavior |
 | `CSI ? 8452 h` | Compatibility option to leave the cursor to the right | Confirmed only in xterm/RLogin; do not enable by default |
 
-DECSDM polarity is the most significant unresolved compatibility issue. Current
-xterm documentation and implementation interpret set/reset in the opposite
-direction from the VT340 manual and hardware tests. Foot changed its polarity
-after testing real VT340 hardware. Hex1b selects the DEC interpretation and
-must keep an xterm-compatible inversion, if later required, in centralized
-policy rather than terminal detection.
+DECSDM polarity is the most significant compatibility issue. Current xterm
+documentation and implementation interpret set/reset in the opposite direction
+from the VT340 manual and hardware tests. Foot changed its polarity after
+testing real VT340 hardware. Hex1b selects the DEC interpretation, and the
+xterm-compatible inversion lives in `SixelCompatibilityPolicy.DecsdmPolarity`
+rather than in terminal detection. Which reference profile a terminal should
+select stays a [#457](https://github.com/mitchdenny/hex1b/issues/457) target.
 
 ### Cursor, margins, and origin
 
@@ -192,7 +193,42 @@ the text cursor exactly. Windows Terminal explicitly uses the full page instead
 of text margins in this mode. Exact margin clipping across references remains a
 [#457](https://github.com/mitchdenny/hex1b/issues/457) test target.
 
-Implementation belongs to [#450](https://github.com/mitchdenny/hex1b/issues/450).
+Three cursor concepts stay distinct. The *Sixel graphics cursor* lives inside the
+raster and never escapes the parser. The *anchor* is the text cursor position the
+placement is pinned to when the DCS sequence starts. The *final text cursor* is
+where the terminal leaves the cursor once the sequence completes.
+
+| Situation | Implemented behavior |
+|---|---|
+| Ordinary completion, scrolling mode | Anchor at the active text position; final cursor is one row below the occupied rows, at the anchor column |
+| One-row image | Final cursor is on the row immediately below the anchor row |
+| Multi-row image | Final cursor is `anchor row + occupied rows` |
+| Partial final band | The partial band rounds up to a whole cell row before the cursor moves |
+| Declared extent, no painted pixels | The declared extent still occupies cells; occupancy never collapses below one cell |
+| Image exceeds the viewport | Occupancy keeps the full source geometry; only painted cells are clipped |
+| Completion at or below the bottom margin | The region scrolls just enough to fit the image and the cursor row; a taller-than-region image keeps its bottom edge on the last region row |
+| Followed by text, CR, LF, CUP, or another Sixel | Each applies from the final cursor, so a second Sixel stacks below the first |
+| Non-scrolling mode | Anchor is the graphics-page origin, the full page is used instead of text margins, nothing scrolls, and the text cursor is unchanged |
+
+A completed sequence also clears any deferred wrap, exactly like a line feed.
+Occupancy is `ceil(renderedPixelExtent / cellMetric)` per axis, computed from
+protocol cell metrics rather than from font metrics. Those metrics are captured
+once, when the placement is created, and are recorded on the placement together
+with their source and reliability, so a later metric change cannot retroactively
+rewrite an existing placement. Discovering real metrics from an upstream
+presentation is owned by
+[#455](https://github.com/mitchdenny/hex1b/issues/455); until then metrics are
+derived from terminal capabilities, reported as estimated, and injectable.
+
+`CSI ? 80` and `CSI ? 8452` are reset to their defaults by both RIS and DECSTR.
+Save/restore of these private modes (`CSI ? Pm s` and `CSI ? Pm r`) is not
+implemented, because Hex1b has no private-mode save/restore machinery to extend.
+
+This is the terminal-model direction of the data flow: how `Hex1bTerminal`
+interprets an incoming Sixel sequence. In the opposite direction, when Hex1b
+emits its own managed output, it never relies on where an upstream terminal
+leaves the cursor after a Sixel image; it always repositions explicitly with
+CUP before writing anything that follows.
 
 ## Ownership, overlap, and erasure
 
@@ -203,7 +239,7 @@ Implementation belongs to [#450](https://github.com/mitchdenny/hex1b/issues/450)
 | ED/EL | Erase graphics in the affected cell/pixel region along with text | Boundary behavior at partially covered cells needs #457 testing |
 | Scroll-region operations | Move, clip, or erase placements using the same region semantics as text rows | Owned by #452/#453 |
 | RIS | Clear all placements and reset Sixel modes and palette | Owned by #453 |
-| DECSTR | Reset modes; preserve palette and placements provisionally | Palette and placement behavior remains unresolved |
+| DECSTR | Reset modes, including DECSDM and mode 8452; preserve palette, placements, and cursor position | Placement behavior remains unresolved |
 
 Foot has the clearest reviewed prior art for compositing independent placements.
 Hex1b's existing KGP graphics state provides the closest internal model. Sixel
@@ -231,14 +267,15 @@ The following decisions must remain visible until
 [#457](https://github.com/mitchdenny/hex1b/issues/457) provides executable
 reference-terminal evidence:
 
-1. DECSDM compatibility polarity for an optional xterm profile.
-2. Whether mode 8452 should be implemented beyond its default reset behavior.
-3. Whether an optional palette-register-0 opaque background profile is needed
+1. Which DECSDM polarity profile a given reference terminal should select. The
+   inversion knob exists; the per-terminal selection does not.
+2. Whether an optional palette-register-0 opaque background profile is needed
    alongside the selected captured-background behavior.
-4. DECGRA's undocumented carriage-return behavior and aspect-scaled DECGNL.
-5. Exact Sixel-over-Sixel compositing and partial-cell text/erase damage.
-6. DECSTR effects on palettes and placements.
-7. Main/alternate-screen, history eviction, resize, and reflow edge behavior.
+3. DECGRA's undocumented carriage-return behavior and aspect-scaled DECGNL.
+4. Exact Sixel-over-Sixel compositing and partial-cell text/erase damage.
+5. DECSTR effects on placements.
+6. Main/alternate-screen, history eviction, resize, and reflow edge behavior.
+7. Private-mode save/restore (`CSI ? Pm s` and `CSI ? Pm r`) for Sixel modes.
 8. Exact default palette values for registers 16-255 and private-register
    behavior across modern terminals.
 

--- a/samples/SixelTerminalDemo/DemoScreen.cs
+++ b/samples/SixelTerminalDemo/DemoScreen.cs
@@ -32,12 +32,18 @@ internal sealed record DemoScreen(
 internal static class DemoScreenRenderer
 {
     /// <summary>
-    /// The row the screen body starts on, leaving the header above it.
+    /// The first row of the description block, counting from 1.
     /// </summary>
-    public const int BodyRow = 5;
+    /// <remarks>
+    /// The description sits below the image rather than above it. A Sixel graphic
+    /// is placed at the cursor, and some scenes deliberately place it at the page
+    /// origin, so any text above the image would be painted over. Keeping the
+    /// description low also leaves the top of the screen free for the graphic.
+    /// </remarks>
+    public const int DescriptionRow = 22;
 
     /// <summary>
-    /// Builds the header, positions the cursor at the body row, and appends the
+    /// Builds the screen: resets modes, clears, homes the cursor, and appends the
     /// screen body.
     /// </summary>
     /// <remarks>
@@ -46,37 +52,62 @@ internal static class DemoScreenRenderer
     /// </remarks>
     public static byte[] Render(DemoScreen screen, int total)
     {
-        var header = new StringBuilder();
-        header.Append(RawCursorScene.ResetSequence);
-        header.Append("\x1b[2J\x1b[H");
-        header.Append($"\x1b[1m{screen.Label}\x1b[0m  ({screen.Number}/{total})\r\n");
-        header.Append($"Expected: {screen.Expected}\r\n");
-        if (screen.Notes is { Count: > 0 })
-        {
-            foreach (var note in screen.Notes)
-            {
-                header.Append($"{note}\r\n");
-            }
-        }
-
-        header.Append($"\x1b[{BodyRow};1H");
+        var prologue = $"{RawCursorScene.ResetSequence}\x1b[2J\x1b[H";
 
         return
         [
-            .. Encoding.ASCII.GetBytes(header.ToString()),
+            .. Encoding.ASCII.GetBytes(prologue),
             .. screen.Body,
         ];
     }
 
     /// <summary>
-    /// Builds the footer prompt shown while a screen waits for input.
+    /// Builds the description and the footer prompt shown while a screen waits.
     /// </summary>
-    public static byte[] RenderPrompt(DemoScreen screen, int total, int promptRow)
+    /// <remarks>
+    /// This is emitted after the body so the description is never overpainted by
+    /// the graphic, whatever geometry or anchor the screen used.
+    /// </remarks>
+    public static byte[] RenderPrompt(DemoScreen screen, int total, int promptRow, bool isLast)
     {
-        var last = screen.Number == total;
-        var action = last ? "quit" : "continue";
-        return Encoding.ASCII.GetBytes(
-            $"\x1b[{promptRow};1H\x1b[2K\x1b[7m Screen {screen.Number}/{total} \x1b[0m " +
+        var text = new StringBuilder();
+
+        // Margins and origin mode are reset again here: a scene may have set a
+        // scrolling region, which would otherwise capture the description.
+        text.Append(RawCursorScene.ResetSequence);
+        text.Append($"\x1b[{DescriptionRow};1H\x1b[0m");
+        text.Append($"\x1b[1mScreen {screen.Number}/{total}: {screen.Title}\x1b[0m\r\n");
+        foreach (var line in Lines(screen.Expected))
+        {
+            text.Append($"\x1b[2K{line}\r\n");
+        }
+
+        if (screen.Notes is { Count: > 0 })
+        {
+            foreach (var note in screen.Notes)
+            {
+                foreach (var line in Lines(note))
+                {
+                    text.Append($"\x1b[2K{line}\r\n");
+                }
+            }
+        }
+
+        var action = isLast ? "quit" : "next";
+        text.Append($"\x1b[{promptRow};1H\x1b[2K\x1b[7m {screen.Number}/{total} \x1b[0m " +
             $"Enter/Space {action}  \u2022  p previous  \u2022  q quit");
+
+        return Encoding.ASCII.GetBytes(text.ToString());
     }
+
+    /// <summary>
+    /// Splits a description into display lines.
+    /// </summary>
+    /// <remarks>
+    /// Descriptions are authored with plain newlines, but a terminal in raw mode
+    /// needs an explicit carriage return to return to column 1.
+    /// </remarks>
+    private static IEnumerable<string> Lines(string text) =>
+        text.Replace("\r\n", "\n").Split('\n');
 }
+

--- a/samples/SixelTerminalDemo/DemoScreen.cs
+++ b/samples/SixelTerminalDemo/DemoScreen.cs
@@ -93,6 +93,10 @@ internal static class DemoScreenRenderer
             }
         }
 
+        // Pixel sizes are exact, but cell counts depend on the host's cell box,
+        // which cannot be probed yet, so say which grid the counts assume.
+        text.Append("\x1b[2K\x1b[2mPixel sizes are exact; cell counts assume a 10x20px cell.\x1b[0m\r\n");
+
         var action = isLast ? "quit" : "next";
         text.Append($"\x1b[{promptRow};1H\x1b[2K\x1b[7m {screen.Number}/{total} \x1b[0m " +
             $"Enter/Space {action}  \u2022  p previous  \u2022  q quit");

--- a/samples/SixelTerminalDemo/DemoScreen.cs
+++ b/samples/SixelTerminalDemo/DemoScreen.cs
@@ -1,0 +1,82 @@
+using System.Text;
+
+/// <summary>
+/// One numbered demo screen. Every screen owns the whole terminal: it clears the
+/// display, draws a single subject, and then waits before the next screen runs.
+/// </summary>
+/// <remarks>
+/// Screens are numbered so a specific one can be named in review and reproduced
+/// directly with <c>--screen &lt;number&gt;</c>.
+/// </remarks>
+/// <param name="Number">The 1-based screen number, stable across a run.</param>
+/// <param name="Title">The screen title shown in the header.</param>
+/// <param name="Expected">What a DEC-compatible terminal should display.</param>
+/// <param name="Body">The bytes that draw the screen, sent after the header.</param>
+/// <param name="Notes">Optional extra lines shown under the header.</param>
+internal sealed record DemoScreen(
+    int Number,
+    string Title,
+    string Expected,
+    byte[] Body,
+    IReadOnlyList<string>? Notes = null)
+{
+    /// <summary>
+    /// Gets the label used in the header and in the headless transcript.
+    /// </summary>
+    public string Label => $"Screen {Number}: {Title}";
+}
+
+/// <summary>
+/// Renders a <see cref="DemoScreen"/> as terminal bytes.
+/// </summary>
+internal static class DemoScreenRenderer
+{
+    /// <summary>
+    /// The row the screen body starts on, leaving the header above it.
+    /// </summary>
+    public const int BodyRow = 5;
+
+    /// <summary>
+    /// Builds the header, positions the cursor at the body row, and appends the
+    /// screen body.
+    /// </summary>
+    /// <remarks>
+    /// The mode reset runs before the clear so a screen can never inherit margins,
+    /// origin mode, or DECSDM state from the screen before it.
+    /// </remarks>
+    public static byte[] Render(DemoScreen screen, int total)
+    {
+        var header = new StringBuilder();
+        header.Append(RawCursorScene.ResetSequence);
+        header.Append("\x1b[2J\x1b[H");
+        header.Append($"\x1b[1m{screen.Label}\x1b[0m  ({screen.Number}/{total})\r\n");
+        header.Append($"Expected: {screen.Expected}\r\n");
+        if (screen.Notes is { Count: > 0 })
+        {
+            foreach (var note in screen.Notes)
+            {
+                header.Append($"{note}\r\n");
+            }
+        }
+
+        header.Append($"\x1b[{BodyRow};1H");
+
+        return
+        [
+            .. Encoding.ASCII.GetBytes(header.ToString()),
+            .. screen.Body,
+        ];
+    }
+
+    /// <summary>
+    /// Builds the footer prompt shown while a screen waits for input.
+    /// </summary>
+    public static byte[] RenderPrompt(DemoScreen screen, int total, int promptRow)
+    {
+        var last = screen.Number == total;
+        var action = last ? "quit" : "continue";
+        return Encoding.ASCII.GetBytes(
+            $"\x1b[{promptRow};1H\x1b[2K\x1b[7m Screen {screen.Number}/{total} \x1b[0m " +
+            $"Enter/Space {action}  \u2022  p previous  \u2022  q quit");
+    }
+}

--- a/samples/SixelTerminalDemo/DemoScreens.cs
+++ b/samples/SixelTerminalDemo/DemoScreens.cs
@@ -61,7 +61,7 @@ internal static class DemoScreens
         screens.Add(new DemoScreen(
             number++,
             "Framing: two images, one write",
-            "two red #FF0000 blocks stacked vertically, the first 240x60px (24x3 cells) and\n  the second 240x18px, both delivered in a single write with no transport boundary\n  between them. Both should appear complete and correctly separated",
+            "two red #FF0000 blocks stacked vertically, the first 240x60px (24 cells wide) and\n  the second 240x18px, both delivered in a single write with no transport boundary\n  between them. Both should appear complete and correctly separated",
             [
                 .. fixtures[0].StandardDcsBytes,
                 .. fixtures[1].StandardDcsBytes,
@@ -72,7 +72,7 @@ internal static class DemoScreens
         screens.Add(new DemoScreen(
             number++,
             "Framing: split writes",
-            "the same solid red #FF0000 240x60px (24 cells wide, 3 cells tall) rectangle as\n  screen 1, but its DCS introducer, payload, and ESC-backslash terminator arrive in\n  six separate reads. It should look identical to screen 1: framing is transport-independent",
+            "the same solid red #FF0000 240x60px (24 cells wide) rectangle as\n  screen 1, but its DCS introducer, payload, and ESC-backslash terminator arrive in\n  six separate reads. It should look identical to screen 1: framing is transport-independent",
             [.. split]));
 
         screens.Add(new DemoScreen(

--- a/samples/SixelTerminalDemo/DemoScreens.cs
+++ b/samples/SixelTerminalDemo/DemoScreens.cs
@@ -61,7 +61,7 @@ internal static class DemoScreens
         screens.Add(new DemoScreen(
             number++,
             "Framing: two images, one write",
-            "two consecutive DCS images arrive with no transport boundary between them",
+            "two red #FF0000 blocks stacked vertically, the first 240x60px (24x3 cells) and\n  the second 240x18px, both delivered in a single write with no transport boundary\n  between them. Both should appear complete and correctly separated",
             [
                 .. fixtures[0].StandardDcsBytes,
                 .. fixtures[1].StandardDcsBytes,
@@ -72,13 +72,13 @@ internal static class DemoScreens
         screens.Add(new DemoScreen(
             number++,
             "Framing: split writes",
-            "the introducer, payload, and ESC-backslash terminator arrive in separate reads",
+            "the same solid red #FF0000 240x60px (24 cells wide, 3 cells tall) rectangle as\n  screen 1, but its DCS introducer, payload, and ESC-backslash terminator arrive in\n  six separate reads. It should look identical to screen 1: framing is transport-independent",
             [.. split]));
 
         screens.Add(new DemoScreen(
             number,
             "Framing: one byte at a time",
-            "single-byte workload reads still form the original image upstream",
+            "the same 240x6px (24 cells wide) all-green #00FF00 band as screen 4, delivered\n  one byte at a time. It should render identically: the parser reassembles the\n  image regardless of how the bytes are chunked",
             fixtures[3].StandardDcsBytes));
 
         return screens;

--- a/samples/SixelTerminalDemo/DemoScreens.cs
+++ b/samples/SixelTerminalDemo/DemoScreens.cs
@@ -1,0 +1,101 @@
+using System.Text;
+
+/// <summary>
+/// Builds the numbered screen list the demo pages through.
+/// </summary>
+/// <remarks>
+/// Numbering is positional and stable for a given build, so "screen 14" means the
+/// same subject in a terminal, in the headless transcript, and in review.
+/// </remarks>
+internal static class DemoScreens
+{
+    /// <summary>
+    /// Builds every screen: the grammar and geometry fixtures first, then the
+    /// cursor, DECSDM, and margin scenes, then the transport scenes.
+    /// </summary>
+    public static IReadOnlyList<DemoScreen> Build(
+        IReadOnlyList<RawSixelFixture> fixtures,
+        IReadOnlyList<string> modelDescriptions,
+        IReadOnlyList<RawCursorScene> cursorScenes,
+        bool includeTransportScenes)
+    {
+        var screens = new List<DemoScreen>();
+        var number = 1;
+
+        for (var index = 0; index < fixtures.Count; index++)
+        {
+            var fixture = fixtures[index];
+            var body = new List<byte>();
+            if (fixture.SetupDcsBytes is { } setup)
+            {
+                body.AddRange(setup);
+                body.AddRange(Encoding.ASCII.GetBytes("\r\n"));
+            }
+
+            body.AddRange(fixture.StandardDcsBytes);
+
+            screens.Add(new DemoScreen(
+                number++,
+                fixture.Name,
+                fixture.Expected,
+                [.. body],
+                Notes: [$"Model: {modelDescriptions[index]}"]));
+        }
+
+        foreach (var scene in cursorScenes)
+        {
+            // The scene owns its own cursor position, so it is emitted without the
+            // renderer's body-row positioning already applied to it.
+            screens.Add(new DemoScreen(
+                number++,
+                scene.Name,
+                scene.Expected,
+                scene.Bytes));
+        }
+
+        if (!includeTransportScenes)
+        {
+            return screens;
+        }
+
+        screens.Add(new DemoScreen(
+            number++,
+            "Framing: two images, one write",
+            "two consecutive DCS images arrive with no transport boundary between them",
+            [
+                .. fixtures[0].StandardDcsBytes,
+                .. fixtures[1].StandardDcsBytes,
+            ]));
+
+        var split = new List<byte>();
+        AddChunks(split, fixtures[0].StandardDcsBytes, [1, 1, 5, fixtures[0].StandardDcsBytes.Length - 9, 1, 1]);
+        screens.Add(new DemoScreen(
+            number++,
+            "Framing: split writes",
+            "the introducer, payload, and ESC-backslash terminator arrive in separate reads",
+            [.. split]));
+
+        screens.Add(new DemoScreen(
+            number,
+            "Framing: one byte at a time",
+            "single-byte workload reads still form the original image upstream",
+            fixtures[3].StandardDcsBytes));
+
+        return screens;
+    }
+
+    private static void AddChunks(List<byte> destination, byte[] bytes, IReadOnlyList<int> sizes)
+    {
+        var offset = 0;
+        foreach (var size in sizes)
+        {
+            destination.AddRange(bytes.AsSpan(offset, size));
+            offset += size;
+        }
+
+        if (offset != bytes.Length)
+        {
+            throw new InvalidOperationException("Demo split sizes must consume the complete DCS.");
+        }
+    }
+}

--- a/samples/SixelTerminalDemo/DemoWorkloadAdapter.cs
+++ b/samples/SixelTerminalDemo/DemoWorkloadAdapter.cs
@@ -1,0 +1,61 @@
+using Hex1b;
+
+/// <summary>
+/// Replays a fixed list of byte chunks and then disconnects.
+/// </summary>
+/// <remarks>
+/// Used by the headless inspection helpers, which feed one fixture into a
+/// short-lived terminal to read back the resulting model. Interactive runs use
+/// <see cref="PagedScreenWorkloadAdapter"/> instead, because they must wait for
+/// input between screens.
+/// </remarks>
+internal sealed class DemoWorkloadAdapter(IReadOnlyList<byte[]> chunks) : IHex1bTerminalWorkloadAdapter
+{
+    private readonly object _eventLock = new();
+    private Action? _disconnected;
+    private bool _completed;
+    private int _nextChunk;
+
+    public event Action? Disconnected
+    {
+        add
+        {
+            var invokeNow = false;
+            lock (_eventLock)
+            {
+                _disconnected += value;
+                invokeNow = _completed;
+            }
+            if (invokeNow)
+                value?.Invoke();
+        }
+        remove
+        {
+            lock (_eventLock)
+                _disconnected -= value;
+        }
+    }
+
+    public ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(CancellationToken ct = default)
+    {
+        if (_nextChunk < chunks.Count)
+            return ValueTask.FromResult<ReadOnlyMemory<byte>>(chunks[_nextChunk++]);
+
+        Action? disconnected;
+        lock (_eventLock)
+        {
+            _completed = true;
+            disconnected = _disconnected;
+        }
+        disconnected?.Invoke();
+        return ValueTask.FromResult(ReadOnlyMemory<byte>.Empty);
+    }
+
+    public ValueTask WriteInputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+        => ValueTask.CompletedTask;
+
+    public ValueTask ResizeAsync(int width, int height, CancellationToken ct = default)
+        => ValueTask.CompletedTask;
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}

--- a/samples/SixelTerminalDemo/PagedScreenWorkloadAdapter.cs
+++ b/samples/SixelTerminalDemo/PagedScreenWorkloadAdapter.cs
@@ -35,6 +35,7 @@ internal sealed class PagedScreenWorkloadAdapter : IHex1bTerminalWorkloadAdapter
 
     private int _index;
     private bool _promptPending;
+    private bool _awaitingInput;
     private bool _quit;
 
     /// <param name="screens">The screens to page through, which may be a filtered subset.</param>
@@ -75,6 +76,39 @@ internal sealed class PagedScreenWorkloadAdapter : IHex1bTerminalWorkloadAdapter
 
     public async ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(CancellationToken ct = default)
     {
+        // A screen is delivered as two reads: the graphic, then the description and
+        // prompt. The wait for input happens at the START of the read that follows,
+        // so the description and prompt are already flushed to the terminal before
+        // anything blocks. Awaiting before returning them would hold them back until
+        // the key had already been pressed, leaving the screen with no visible prompt.
+        if (_awaitingInput)
+        {
+            _awaitingInput = false;
+
+            DemoNavigation navigation;
+            try
+            {
+                navigation = await _input.Reader.ReadAsync(ct).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return Finish();
+            }
+
+            switch (navigation)
+            {
+                case DemoNavigation.Quit:
+                    _quit = true;
+                    break;
+                case DemoNavigation.Previous:
+                    _index = Math.Max(0, _index - 1);
+                    break;
+                default:
+                    _index++;
+                    break;
+            }
+        }
+
         if (_quit || _index >= _screens.Count)
         {
             return Finish();
@@ -82,46 +116,20 @@ internal sealed class PagedScreenWorkloadAdapter : IHex1bTerminalWorkloadAdapter
 
         var screen = _screens[_index];
 
-        // A screen is emitted in two reads: the screen itself, then the prompt.
-        // Splitting them keeps the prompt on screen while the wait happens, so the
-        // viewer always sees why the demo has paused.
         if (!_promptPending)
         {
             _promptPending = true;
             return DemoScreenRenderer.Render(screen, _catalogueTotal);
         }
 
-        var prompt = DemoScreenRenderer.RenderPrompt(
+        _promptPending = false;
+        _awaitingInput = true;
+
+        return DemoScreenRenderer.RenderPrompt(
             screen,
             _catalogueTotal,
             _promptRow,
             isLast: _index == _screens.Count - 1);
-        _promptPending = false;
-
-        DemoNavigation navigation;
-        try
-        {
-            navigation = await _input.Reader.ReadAsync(ct).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException)
-        {
-            return Finish();
-        }
-
-        switch (navigation)
-        {
-            case DemoNavigation.Quit:
-                _quit = true;
-                break;
-            case DemoNavigation.Previous:
-                _index = Math.Max(0, _index - 1);
-                break;
-            default:
-                _index++;
-                break;
-        }
-
-        return prompt;
     }
 
     public ValueTask WriteInputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)

--- a/samples/SixelTerminalDemo/PagedScreenWorkloadAdapter.cs
+++ b/samples/SixelTerminalDemo/PagedScreenWorkloadAdapter.cs
@@ -1,0 +1,162 @@
+using System.Threading.Channels;
+using Hex1b;
+
+/// <summary>
+/// Drives the demo one screen at a time, advancing only when the viewer presses a
+/// key.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The terminal pulls bytes through <see cref="ReadOutputAsync"/> and pushes
+/// keystrokes back through <see cref="WriteInputAsync"/>, so paging is expressed
+/// as a workload that simply refuses to produce the next screen until a key
+/// arrives. That keeps the demo an ordinary workload rather than something that
+/// reaches around the terminal.
+/// </para>
+/// <para>
+/// Navigation is deliberately small: Enter or Space moves forward, <c>p</c> moves
+/// back, and <c>q</c> or Ctrl+C quits.
+/// </para>
+/// </remarks>
+internal sealed class PagedScreenWorkloadAdapter : IHex1bTerminalWorkloadAdapter
+{
+    private readonly IReadOnlyList<DemoScreen> _screens;
+    private readonly int _promptRow;
+    private readonly Channel<DemoNavigation> _input =
+        Channel.CreateUnbounded<DemoNavigation>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+        });
+
+    private readonly object _eventLock = new();
+    private Action? _disconnected;
+    private bool _completed;
+
+    private int _index;
+    private bool _promptPending;
+    private bool _quit;
+
+    public PagedScreenWorkloadAdapter(IReadOnlyList<DemoScreen> screens, int promptRow)
+    {
+        _screens = screens;
+        _promptRow = promptRow;
+    }
+
+    public event Action? Disconnected
+    {
+        add
+        {
+            var invokeNow = false;
+            lock (_eventLock)
+            {
+                _disconnected += value;
+                invokeNow = _completed;
+            }
+            if (invokeNow)
+                value?.Invoke();
+        }
+        remove
+        {
+            lock (_eventLock)
+                _disconnected -= value;
+        }
+    }
+
+    public async ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(CancellationToken ct = default)
+    {
+        if (_quit || _index >= _screens.Count)
+        {
+            return Finish();
+        }
+
+        var screen = _screens[_index];
+
+        // A screen is emitted in two reads: the screen itself, then the prompt.
+        // Splitting them keeps the prompt on screen while the wait happens, so the
+        // viewer always sees why the demo has paused.
+        if (!_promptPending)
+        {
+            _promptPending = true;
+            return DemoScreenRenderer.Render(screen, _screens.Count);
+        }
+
+        var prompt = DemoScreenRenderer.RenderPrompt(screen, _screens.Count, _promptRow);
+        _promptPending = false;
+
+        DemoNavigation navigation;
+        try
+        {
+            navigation = await _input.Reader.ReadAsync(ct).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return Finish();
+        }
+
+        switch (navigation)
+        {
+            case DemoNavigation.Quit:
+                _quit = true;
+                break;
+            case DemoNavigation.Previous:
+                _index = Math.Max(0, _index - 1);
+                break;
+            default:
+                _index++;
+                break;
+        }
+
+        return prompt;
+    }
+
+    public ValueTask WriteInputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+    {
+        foreach (var value in data.Span)
+        {
+            var navigation = value switch
+            {
+                // CR and LF both appear depending on the upstream terminal's mode.
+                (byte)'\r' or (byte)'\n' or (byte)' ' => DemoNavigation.Next,
+                (byte)'p' or (byte)'P' => DemoNavigation.Previous,
+                // q, Ctrl+C, and Escape all leave.
+                (byte)'q' or (byte)'Q' or 0x03 or 0x1b => DemoNavigation.Quit,
+                _ => (DemoNavigation?)null,
+            };
+
+            if (navigation is { } resolved)
+            {
+                _input.Writer.TryWrite(resolved);
+            }
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask ResizeAsync(int width, int height, CancellationToken ct = default)
+        => ValueTask.CompletedTask;
+
+    public ValueTask DisposeAsync()
+    {
+        _input.Writer.TryComplete();
+        return ValueTask.CompletedTask;
+    }
+
+    private ReadOnlyMemory<byte> Finish()
+    {
+        Action? disconnected;
+        lock (_eventLock)
+        {
+            _completed = true;
+            disconnected = _disconnected;
+        }
+        disconnected?.Invoke();
+        return ReadOnlyMemory<byte>.Empty;
+    }
+}
+
+internal enum DemoNavigation
+{
+    Next,
+    Previous,
+    Quit,
+}

--- a/samples/SixelTerminalDemo/PagedScreenWorkloadAdapter.cs
+++ b/samples/SixelTerminalDemo/PagedScreenWorkloadAdapter.cs
@@ -21,6 +21,7 @@ using Hex1b;
 internal sealed class PagedScreenWorkloadAdapter : IHex1bTerminalWorkloadAdapter
 {
     private readonly IReadOnlyList<DemoScreen> _screens;
+    private readonly int _catalogueTotal;
     private readonly int _promptRow;
     private readonly Channel<DemoNavigation> _input =
         Channel.CreateUnbounded<DemoNavigation>(new UnboundedChannelOptions
@@ -36,9 +37,19 @@ internal sealed class PagedScreenWorkloadAdapter : IHex1bTerminalWorkloadAdapter
     private bool _promptPending;
     private bool _quit;
 
-    public PagedScreenWorkloadAdapter(IReadOnlyList<DemoScreen> screens, int promptRow)
+    /// <param name="screens">The screens to page through, which may be a filtered subset.</param>
+    /// <param name="catalogueTotal">
+    /// The total number of screens in the full demo. Reported alongside each screen
+    /// number so a filtered run still shows a screen's real catalogue position.
+    /// </param>
+    /// <param name="promptRow">The row the footer prompt is drawn on.</param>
+    public PagedScreenWorkloadAdapter(
+        IReadOnlyList<DemoScreen> screens,
+        int catalogueTotal,
+        int promptRow)
     {
         _screens = screens;
+        _catalogueTotal = catalogueTotal;
         _promptRow = promptRow;
     }
 
@@ -77,10 +88,14 @@ internal sealed class PagedScreenWorkloadAdapter : IHex1bTerminalWorkloadAdapter
         if (!_promptPending)
         {
             _promptPending = true;
-            return DemoScreenRenderer.Render(screen, _screens.Count);
+            return DemoScreenRenderer.Render(screen, _catalogueTotal);
         }
 
-        var prompt = DemoScreenRenderer.RenderPrompt(screen, _screens.Count, _promptRow);
+        var prompt = DemoScreenRenderer.RenderPrompt(
+            screen,
+            _catalogueTotal,
+            _promptRow,
+            isLast: _index == _screens.Count - 1);
         _promptPending = false;
 
         DemoNavigation navigation;

--- a/samples/SixelTerminalDemo/Program.cs
+++ b/samples/SixelTerminalDemo/Program.cs
@@ -8,7 +8,12 @@ var fixtures = sceneFilter is null
     : RawSixelFixtures.All
         .Where(fixture => fixture.Name.Contains(sceneFilter, StringComparison.OrdinalIgnoreCase))
         .ToArray();
-if (fixtures.Count == 0)
+var cursorScenes = sceneFilter is null
+    ? RawCursorScenes.All
+    : RawCursorScenes.All
+        .Where(scene => scene.Name.Contains(sceneFilter, StringComparison.OrdinalIgnoreCase))
+        .ToArray();
+if (fixtures.Count == 0 && cursorScenes.Count == 0)
 {
     throw new ArgumentException($"No Sixel demo scene contains '{sceneFilter}'.", nameof(args));
 }
@@ -27,9 +32,16 @@ for (var index = 0; index < fixtures.Count; index++)
     modelDescriptions[index] = await InspectModelAsync(fixtures[index]);
 }
 
+var cursorObservations = new string[cursorScenes.Count];
+for (var index = 0; index < cursorScenes.Count; index++)
+{
+    cursorObservations[index] = await InspectCursorSceneAsync(cursorScenes[index]);
+}
+
 var chunks = BuildDemoOutput(
     fixtures,
     modelDescriptions,
+    cursorScenes,
     includeTransportScenes: sceneFilter is null);
 var workload = new DemoWorkloadAdapter(chunks);
 IHex1bTerminalPresentationAdapter presentation = headless
@@ -65,12 +77,19 @@ if (headless)
     {
         Console.WriteLine($"  {fixtures[index].Name}: {modelDescriptions[index]}");
     }
+    Console.WriteLine();
+    Console.WriteLine("Cursor, DECSDM, and margin scenes:");
+    for (var index = 0; index < cursorScenes.Count; index++)
+    {
+        Console.WriteLine($"  {cursorScenes[index].Name}: {cursorObservations[index]}");
+    }
     Console.WriteLine("Run without --headless in a native Sixel terminal to inspect the presentation outcome.");
 }
 
 static IReadOnlyList<byte[]> BuildDemoOutput(
     IReadOnlyList<RawSixelFixture> fixtures,
     IReadOnlyList<string> modelDescriptions,
+    IReadOnlyList<RawCursorScene> cursorScenes,
     bool includeTransportScenes)
 {
     var chunks = new List<byte[]>
@@ -96,10 +115,12 @@ static IReadOnlyList<byte[]> BuildDemoOutput(
         chunks.Add(Encoding.ASCII.GetBytes("\r\n\r\n"));
     }
 
+    AddCursorScenes(chunks, cursorScenes);
+
     if (!includeTransportScenes)
     {
         chunks.Add(Encoding.ASCII.GetBytes(
-            "Stage 4: the same parser feeds one deterministic bounded rasterizer for color, background, and aspect.\r\n"));
+            "Stage 5: the same parser and rasterizer drive cursor, DECSDM, margin, and metric semantics.\r\n"));
         return chunks;
     }
 
@@ -125,8 +146,74 @@ static IReadOnlyList<byte[]> BuildDemoOutput(
     chunks.Add(Encoding.ASCII.GetBytes("\r\n\r\n"));
 
     chunks.Add(Encoding.ASCII.GetBytes(
-        "Stage 4: the same parser feeds one deterministic bounded rasterizer for color, background, and aspect.\r\n"));
+        "Stage 5: the same parser and rasterizer drive cursor, DECSDM, margin, and metric semantics.\r\n"));
     return chunks;
+}
+
+static void AddCursorScenes(List<byte[]> chunks, IReadOnlyList<RawCursorScene> scenes)
+{
+    foreach (var scene in scenes)
+    {
+        // Each scene owns a clean screen so margins and the scrolling region can
+        // be observed without the previous scene's output interfering.
+        chunks.Add(Encoding.ASCII.GetBytes(
+            $"{RawCursorScene.ResetSequence}\x1b[2J\x1b[H[{scene.Name}] Expected: {scene.Expected}\r\n"));
+        chunks.Add(scene.Bytes);
+        chunks.Add(Encoding.ASCII.GetBytes("\x1b[24;1H"));
+    }
+}
+
+static async Task<string> InspectCursorSceneAsync(RawCursorScene scene)
+{
+    var capabilities = new TerminalCapabilities
+    {
+        SupportsSixel = true,
+        SupportsTrueColor = true,
+        Supports256Colors = true,
+        CellPixelWidth = 10,
+        CellPixelHeight = 20,
+    };
+    // The reset sequence is omitted here: DECSTBM homes the cursor, which would
+    // hide the very position this scene exists to demonstrate.
+    var workload = new DemoWorkloadAdapter([scene.SceneBytes]);
+    await using var terminal = Hex1bTerminal.CreateBuilder()
+        .WithWorkload(workload)
+        .WithPresentation(new HeadlessPresentationAdapter(80, 24, capabilities))
+        .WithDimensions(80, 24)
+        .Build();
+    await terminal.RunAsync();
+
+    using var snapshot = terminal.CreateSnapshot();
+    var builder = new StringBuilder();
+    var origins = new List<string>();
+    var occupiedColumns = new SortedSet<int>();
+    var occupiedRows = new SortedSet<int>();
+    for (var y = 0; y < snapshot.Height; y++)
+    {
+        for (var x = 0; x < snapshot.Width; x++)
+        {
+            var cell = snapshot.GetCell(x, y);
+            if (!cell.IsSixel)
+                continue;
+
+            occupiedColumns.Add(x);
+            occupiedRows.Add(y);
+            if (cell.SixelData is { } sixel)
+            {
+                origins.Add($"({x},{y}) {sixel.WidthInCells}x{sixel.HeightInCells} cells");
+            }
+        }
+    }
+
+    builder.Append(origins.Count == 0 ? "no placement" : string.Join("; ", origins));
+    if (occupiedColumns.Count > 0)
+    {
+        builder.Append($", painted columns {occupiedColumns.Min}-{occupiedColumns.Max}");
+        builder.Append($", painted rows {occupiedRows.Min}-{occupiedRows.Max}");
+    }
+
+    builder.Append($", cursor ({snapshot.CursorX}, {snapshot.CursorY})");
+    return builder.ToString();
 }
 
 static string? GetOption(string[] arguments, string option)

--- a/samples/SixelTerminalDemo/Program.cs
+++ b/samples/SixelTerminalDemo/Program.cs
@@ -3,6 +3,10 @@ using Hex1b;
 
 var headless = args.Contains("--headless", StringComparer.OrdinalIgnoreCase);
 var sceneFilter = GetOption(args, "--scene");
+var screenOption = GetOption(args, "--screen");
+const int Width = 80;
+const int Height = 24;
+
 var fixtures = sceneFilter is null
     ? RawSixelFixtures.All
     : RawSixelFixtures.All
@@ -38,129 +42,102 @@ for (var index = 0; index < cursorScenes.Count; index++)
     cursorObservations[index] = await InspectCursorSceneAsync(cursorScenes[index]);
 }
 
-var chunks = BuildDemoOutput(
+var allScreens = DemoScreens.Build(
     fixtures,
     modelDescriptions,
     cursorScenes,
     includeTransportScenes: sceneFilter is null);
-var workload = new DemoWorkloadAdapter(chunks);
-IHex1bTerminalPresentationAdapter presentation = headless
-    ? new HeadlessPresentationAdapter(80, 24, capabilities)
-    : new ConsolePresentationAdapter(enableMouse: false);
 
-await using var terminal = Hex1bTerminal.CreateBuilder()
-    .WithWorkload(workload)
-    .WithPresentation(presentation)
-    .WithDimensions(80, 24)
-    .Build();
-
-if (!headless)
+// --screen selects one numbered screen. The number keeps its original value so a
+// screen referenced in review still identifies the same subject when run alone.
+var screens = allScreens;
+if (screenOption is not null)
 {
-    Console.Error.WriteLine(
-        "SixelTerminalDemo sends standard ESC-framed, independently authored fixtures through Hex1bTerminal.");
-    Console.Error.WriteLine("The labels describe the DEC VT340 model outcome expected from a native Sixel terminal.");
-    Console.Error.WriteLine("Use --scene <name> to run one enlarged fixture, for example --scene \"Declared extent\".");
-}
+    if (!int.TryParse(screenOption, out var requested))
+    {
+        throw new ArgumentException($"--screen expects a number, not '{screenOption}'.", nameof(args));
+    }
 
-await terminal.RunAsync();
+    screens = allScreens.Where(screen => screen.Number == requested).ToArray();
+    if (screens.Count == 0)
+    {
+        throw new ArgumentException(
+            $"No screen numbered {requested}; the demo has {allScreens.Count}.",
+            nameof(args));
+    }
+}
 
 if (headless)
 {
-    using var snapshot = terminal.CreateSnapshot();
-    Console.WriteLine("Hex1b authoritative Sixel model inspection:");
-    Console.WriteLine($"  tracked Sixel origins: {CountSixelOrigins(snapshot)}");
-    Console.WriteLine($"  cursor: ({snapshot.CursorX}, {snapshot.CursorY})");
-    Console.WriteLine($"  cell metrics: {snapshot.CellPixelWidth}x{snapshot.CellPixelHeight}px");
+    WriteHeadlessTranscript(
+        allScreens,
+        screens,
+        fixtures,
+        modelDescriptions,
+        cursorScenes,
+        cursorObservations);
+    return;
+}
+
+var workload = new PagedScreenWorkloadAdapter(screens, promptRow: Height);
+await using var terminal = Hex1bTerminal.CreateBuilder()
+    .WithWorkload(workload)
+    .WithPresentation(new ConsolePresentationAdapter(enableMouse: false))
+    .WithDimensions(Width, Height)
+    .Build();
+
+Console.Error.WriteLine(
+    "SixelTerminalDemo pages through numbered screens of independently authored, ESC-framed fixtures.");
+Console.Error.WriteLine("Enter or Space advances, p goes back, and q quits.");
+Console.Error.WriteLine($"Use --screen <number> to open one screen directly (1-{allScreens.Count}).");
+
+await terminal.RunAsync();
+
+static void WriteHeadlessTranscript(
+    IReadOnlyList<DemoScreen> allScreens,
+    IReadOnlyList<DemoScreen> selected,
+    IReadOnlyList<RawSixelFixture> fixtures,
+    IReadOnlyList<string> modelDescriptions,
+    IReadOnlyList<RawCursorScene> cursorScenes,
+    IReadOnlyList<string> cursorObservations)
+{
+    Console.WriteLine($"Hex1b Sixel demo: {allScreens.Count} numbered screens.");
+    Console.WriteLine("Run without --headless to page through them; --screen <number> opens one.");
     Console.WriteLine();
-    Console.WriteLine("Deterministic grammar and geometry scenes:");
+
+    Console.WriteLine("Screens:");
+    foreach (var screen in selected)
+    {
+        Console.WriteLine($"  {screen.Number,3}. {screen.Title}");
+        Console.WriteLine($"       expected: {screen.Expected}");
+    }
+
+    Console.WriteLine();
+    Console.WriteLine("Deterministic grammar and geometry model:");
     for (var index = 0; index < fixtures.Count; index++)
     {
         Console.WriteLine($"  {fixtures[index].Name}: {modelDescriptions[index]}");
     }
+
     Console.WriteLine();
-    Console.WriteLine("Cursor, DECSDM, and margin scenes:");
+    Console.WriteLine("Cursor, DECSDM, and margin observations:");
     for (var index = 0; index < cursorScenes.Count; index++)
     {
         Console.WriteLine($"  {cursorScenes[index].Name}: {cursorObservations[index]}");
     }
-    Console.WriteLine("Run without --headless in a native Sixel terminal to inspect the presentation outcome.");
 }
 
-static IReadOnlyList<byte[]> BuildDemoOutput(
-    IReadOnlyList<RawSixelFixture> fixtures,
-    IReadOnlyList<string> modelDescriptions,
-    IReadOnlyList<RawCursorScene> cursorScenes,
-    bool includeTransportScenes)
+static string? GetOption(string[] arguments, string option)
 {
-    var chunks = new List<byte[]>
+    for (var index = 0; index < arguments.Length - 1; index++)
     {
-        Encoding.ASCII.GetBytes("\x1b[2J\x1b[HHex1b terminal-first Sixel behavior demo\r\n"),
-        Encoding.ASCII.GetBytes("Fixtures use standard ESC P ... ESC \\\\ framing; no SixelWidget or encoder.\r\n\r\n"),
-    };
-
-    for (var index = 0; index < fixtures.Count; index++)
-    {
-        var fixture = fixtures[index];
-        chunks.Add(Encoding.ASCII.GetBytes($"[{fixture.Name}] Expected: {fixture.Expected}\r\n"));
-        chunks.Add(Encoding.ASCII.GetBytes($"Model: {modelDescriptions[index]}\r\n"));
-        if (fixture.SetupDcsBytes is { } setup)
+        if (string.Equals(arguments[index], option, StringComparison.OrdinalIgnoreCase))
         {
-            chunks.Add(Encoding.ASCII.GetBytes(
-                $"Setup: {fixture.SetupPayload}\r\n"));
-            chunks.Add(setup);
-            chunks.Add(Encoding.ASCII.GetBytes("\r\n"));
+            return arguments[index + 1];
         }
-
-        chunks.Add(fixture.StandardDcsBytes);
-        chunks.Add(Encoding.ASCII.GetBytes("\r\n\r\n"));
     }
 
-    AddCursorScenes(chunks, cursorScenes);
-
-    if (!includeTransportScenes)
-    {
-        chunks.Add(Encoding.ASCII.GetBytes(
-            "Stage 5: the same parser and rasterizer drive cursor, DECSDM, margin, and metric semantics.\r\n"));
-        return chunks;
-    }
-
-    var framingFixture = fixtures[0].StandardDcsBytes;
-    chunks.Add(Encoding.ASCII.GetBytes(
-        "[Framing] Two consecutive DCS images with no transport boundary between them.\r\n"));
-    chunks.Add(
-    [
-        .. fixtures[0].StandardDcsBytes,
-        .. fixtures[1].StandardDcsBytes,
-    ]);
-    chunks.Add(Encoding.ASCII.GetBytes("\r\n\r\n"));
-
-    chunks.Add(Encoding.ASCII.GetBytes(
-        "[Split write] The introducer, payload, and ESC-backslash terminator arrive in separate reads.\r\n"));
-    AddChunks(chunks, framingFixture, [1, 1, 5, framingFixture.Length - 9, 1, 1]);
-    chunks.Add(Encoding.ASCII.GetBytes("\r\n\r\n"));
-
-    chunks.Add(Encoding.ASCII.GetBytes(
-        "[Native passthrough] One-byte workload reads still form the original image upstream.\r\n"));
-    foreach (var value in fixtures[3].StandardDcsBytes)
-        chunks.Add([value]);
-    chunks.Add(Encoding.ASCII.GetBytes("\r\n\r\n"));
-
-    chunks.Add(Encoding.ASCII.GetBytes(
-        "Stage 5: the same parser and rasterizer drive cursor, DECSDM, margin, and metric semantics.\r\n"));
-    return chunks;
-}
-
-static void AddCursorScenes(List<byte[]> chunks, IReadOnlyList<RawCursorScene> scenes)
-{
-    foreach (var scene in scenes)
-    {
-        // Each scene owns a clean screen so margins and the scrolling region can
-        // be observed without the previous scene's output interfering.
-        chunks.Add(Encoding.ASCII.GetBytes(
-            $"{RawCursorScene.ResetSequence}\x1b[2J\x1b[H[{scene.Name}] Expected: {scene.Expected}\r\n"));
-        chunks.Add(scene.Bytes);
-        chunks.Add(Encoding.ASCII.GetBytes("\x1b[24;1H"));
-    }
+    return null;
 }
 
 static async Task<string> InspectCursorSceneAsync(RawCursorScene scene)
@@ -214,19 +191,6 @@ static async Task<string> InspectCursorSceneAsync(RawCursorScene scene)
 
     builder.Append($", cursor ({snapshot.CursorX}, {snapshot.CursorY})");
     return builder.ToString();
-}
-
-static string? GetOption(string[] arguments, string option)
-{
-    for (var index = 0; index < arguments.Length - 1; index++)
-    {
-        if (string.Equals(arguments[index], option, StringComparison.OrdinalIgnoreCase))
-        {
-            return arguments[index + 1];
-        }
-    }
-
-    return null;
 }
 
 static async Task<string> InspectModelAsync(RawSixelFixture fixture)
@@ -322,84 +286,4 @@ static string DescribeModel(SixelData sixel)
 
         return seen.Count;
     }
-}
-
-static void AddChunks(List<byte[]> chunks, byte[] bytes, IReadOnlyList<int> sizes)
-{
-    var offset = 0;
-    foreach (var size in sizes)
-    {
-        chunks.Add(bytes.AsSpan(offset, size).ToArray());
-        offset += size;
-    }
-
-    if (offset != bytes.Length)
-    {
-        throw new InvalidOperationException("Demo split sizes must consume the complete DCS.");
-    }
-}
-
-static int CountSixelOrigins(Hex1b.Automation.Hex1bTerminalSnapshot snapshot)
-{
-    var count = 0;
-    for (var y = 0; y < snapshot.Height; y++)
-    {
-        for (var x = 0; x < snapshot.Width; x++)
-        {
-            if (snapshot.GetCell(x, y).SixelData is not null)
-                count++;
-        }
-    }
-    return count;
-}
-
-internal sealed class DemoWorkloadAdapter(IReadOnlyList<byte[]> chunks) : IHex1bTerminalWorkloadAdapter
-{
-    private readonly object _eventLock = new();
-    private Action? _disconnected;
-    private int _nextChunk;
-    private bool _completed;
-
-    public event Action? Disconnected
-    {
-        add
-        {
-            var invokeNow = false;
-            lock (_eventLock)
-            {
-                _disconnected += value;
-                invokeNow = _completed;
-            }
-            if (invokeNow)
-                value?.Invoke();
-        }
-        remove
-        {
-            lock (_eventLock)
-                _disconnected -= value;
-        }
-    }
-
-    public ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(CancellationToken ct = default)
-    {
-        if (_nextChunk < chunks.Count)
-            return ValueTask.FromResult<ReadOnlyMemory<byte>>(chunks[_nextChunk++]);
-
-        Action? disconnected;
-        lock (_eventLock)
-        {
-            _completed = true;
-            disconnected = _disconnected;
-        }
-        disconnected?.Invoke();
-        return ValueTask.FromResult(ReadOnlyMemory<byte>.Empty);
-    }
-
-    public ValueTask WriteInputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
-        => ValueTask.CompletedTask;
-
-    public ValueTask ResizeAsync(int width, int height, CancellationToken ct = default)
-        => ValueTask.CompletedTask;
-
-    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
 }

--- a/samples/SixelTerminalDemo/Program.cs
+++ b/samples/SixelTerminalDemo/Program.cs
@@ -4,8 +4,10 @@ using Hex1b;
 var headless = args.Contains("--headless", StringComparer.OrdinalIgnoreCase);
 var sceneFilter = GetOption(args, "--scene");
 var screenOption = GetOption(args, "--screen");
-const int Width = 80;
-const int Height = 24;
+// Wide enough for the longest description line, and tall enough that the cursor
+// scenes (which paint as low as row 20) never reach the description block.
+const int Width = 100;
+const int Height = 32;
 
 var fixtures = sceneFilter is null
     ? RawSixelFixtures.All
@@ -79,7 +81,7 @@ if (headless)
     return;
 }
 
-var workload = new PagedScreenWorkloadAdapter(screens, promptRow: Height);
+var workload = new PagedScreenWorkloadAdapter(screens, allScreens.Count, promptRow: Height);
 await using var terminal = Hex1bTerminal.CreateBuilder()
     .WithWorkload(workload)
     .WithPresentation(new ConsolePresentationAdapter(enableMouse: false))

--- a/samples/SixelTerminalDemo/RawCursorScenes.cs
+++ b/samples/SixelTerminalDemo/RawCursorScenes.cs
@@ -51,37 +51,37 @@ internal static class RawCursorScenes
     [
         new(
             "Cursor scrolling mode",
-            "the graphic is anchored at row 3 column 5 and the probe text starts on the row below it, in the same column",
+            "a red #FF0000 square, 40x40px = 4 cells wide by 3 cells tall, anchored at row 3\n  column 5. The probe text starts on the row directly below the square, back at\n  column 5: in scrolling mode the cursor returns to the column it started in",
             "\x1b[?80h\x1b[3;5H",
             Square40,
             "<- cursor returned to the original column"),
         new(
             "Cursor non-scrolling mode",
-            "the graphic is drawn at the page origin and the probe text stays exactly where the cursor already was",
+            "the same 4x3 cell red #FF0000 square, but drawn at the top-left page origin\n  even though the cursor was at row 6 column 20. The probe text appears at row 6\n  column 20, untouched: DECSDM off anchors the graphic to the page, not the cursor",
             "\x1b[?80l\x1b[6;20H",
             Square40,
             "<- cursor never moved"),
         new(
             "Cursor mode 8452",
-            "mode 8452 leaves the cursor to the right of the graphic instead of at the original column",
+            "the same 4x3 cell red #FF0000 square at row 3 column 5, but the probe text now\n  starts immediately to the RIGHT of the square rather than below-left of it.\n  Mode 8452 leaves the cursor beside the graphic",
             "\x1b[?80h\x1b[?8452h\x1b[3;5H",
             Square40,
             "<- cursor left to the right of the graphic"),
         new(
             "Margin clipping",
-            "left/right margins clip the 200px graphic to columns 10-24 without changing its source raster",
+            "a green #00FF00 bar that is 200px (20 cells) wide in its source raster but is\n  visibly cut off at column 25 by the left/right margins, so only columns 10-24\n  are painted. The raster is unchanged; only the painting is clipped",
             "\x1b[?80h\x1b[?69h\x1b[10;25s\x1b[2;12r\x1b[4;10H",
             Wide200,
             "clipped"),
         new(
             "Bottom margin completion",
-            "the graphic starts on the last row of a small scrolling region, so the region scrolls and the cursor stays inside it",
+            "a 4x3 cell red #FF0000 square placed on the last row of a 5-row scrolling region\n  (rows 10-14). The region scrolls up to make room, so the square finishes inside\n  the region and the probe text stays within rows 10-14, never below it",
             "\x1b[?80h\x1b[10;14r\x1b[14;3H",
             Square40,
             "<- cursor stayed inside the region"),
         new(
             "Explicit repositioning",
-            "Hex1b never assumes where an upstream terminal leaves the cursor: managed output re-positions with CUP first",
+            "a 4x3 cell red #FF0000 square at row 18 column 5, with the probe text at row 20\n  column 40, far from where the graphic ended. Hex1b never assumes where an\n  upstream terminal leaves the cursor, so managed output issues an explicit CUP first",
             "\x1b[?80h\x1b[18;5H",
             Square40,
             "\x1b[20;40Hexplicitly positioned"),

--- a/samples/SixelTerminalDemo/RawCursorScenes.cs
+++ b/samples/SixelTerminalDemo/RawCursorScenes.cs
@@ -1,0 +1,89 @@
+using System.Text;
+
+/// <summary>
+/// A hand-authored scene that exercises Hex1b's Sixel cursor, DECSDM, and margin
+/// semantics. Every byte is written by hand; no <c>SixelWidget</c> or encoder is
+/// involved, so the scene stays an independent contract probe.
+/// </summary>
+/// <param name="Name">The scene name, also used by <c>--scene</c>.</param>
+/// <param name="Expected">What a DEC-compatible terminal should show.</param>
+/// <param name="Setup">Control sequences applied before the graphic.</param>
+/// <param name="Payload">The Sixel payload, without DCS framing.</param>
+/// <param name="Probe">Text written immediately after the graphic completes, so the final cursor position is visible.</param>
+internal sealed record RawCursorScene(
+    string Name,
+    string Expected,
+    string Setup,
+    string Payload,
+    string Probe)
+{
+    /// <summary>
+    /// Restores every mode a scene may change, so scenes stay independent.
+    /// </summary>
+    public const string ResetSequence = "\x1b[?80h\x1b[?8452l\x1b[?69l\x1b[r\x1b[?6l";
+
+    /// <summary>
+    /// Gets the scene without its trailing reset, so an inspection can observe the
+    /// final cursor position the Sixel sequence itself produced.
+    /// </summary>
+    public byte[] SceneBytes =>
+        Encoding.ASCII.GetBytes($"{Setup}\x1bP{Payload}\x1b\\{Probe}");
+
+    /// <summary>
+    /// Gets the complete scene, including setup, graphic, probe text, and reset.
+    /// </summary>
+    public byte[] Bytes =>
+        Encoding.ASCII.GetBytes($"{Setup}\x1bP{Payload}\x1b\\{Probe}{ResetSequence}");
+}
+
+internal static class RawCursorScenes
+{
+    // A 40x40 red square: four columns of complete bands, seven bands tall, with a
+    // square aspect so the rendered extent matches the declared extent exactly.
+    private const string Square40 = "7;1q\"1;1;40;40#1;2;100;0;0#1" +
+        "!40~-!40~-!40~-!40~-!40~-!40~-!40~";
+
+    // A deliberately wide graphic used to show horizontal margin clipping.
+    private const string Wide200 = "7;1q\"1;1;200;20#1;2;0;100;0#1" +
+        "!200~-!200~-!200~-!200~";
+
+    public static IReadOnlyList<RawCursorScene> All { get; } =
+    [
+        new(
+            "Cursor scrolling mode",
+            "the graphic is anchored at row 3 column 5 and the probe text starts on the row below it, in the same column",
+            "\x1b[?80h\x1b[3;5H",
+            Square40,
+            "<- cursor returned to the original column"),
+        new(
+            "Cursor non-scrolling mode",
+            "the graphic is drawn at the page origin and the probe text stays exactly where the cursor already was",
+            "\x1b[?80l\x1b[6;20H",
+            Square40,
+            "<- cursor never moved"),
+        new(
+            "Cursor mode 8452",
+            "mode 8452 leaves the cursor to the right of the graphic instead of at the original column",
+            "\x1b[?80h\x1b[?8452h\x1b[3;5H",
+            Square40,
+            "<- cursor left to the right of the graphic"),
+        new(
+            "Margin clipping",
+            "left/right margins clip the 200px graphic to columns 10-24 without changing its source raster",
+            "\x1b[?80h\x1b[?69h\x1b[10;25s\x1b[2;12r\x1b[4;10H",
+            Wide200,
+            "clipped"),
+        new(
+            "Bottom margin completion",
+            "the graphic starts on the last row of a small scrolling region, so the region scrolls and the cursor stays inside it",
+            "\x1b[?80h\x1b[10;14r\x1b[14;3H",
+            Square40,
+            "<- cursor stayed inside the region"),
+        new(
+            "Explicit repositioning",
+            "Hex1b never assumes where an upstream terminal leaves the cursor: managed output re-positions with CUP first",
+            "\x1b[?80h\x1b[18;5H",
+            Square40,
+            "\x1b[20;40Hexplicitly positioned"),
+    ];
+}

--- a/samples/SixelTerminalDemo/RawSixelFixtures.cs
+++ b/samples/SixelTerminalDemo/RawSixelFixtures.cs
@@ -25,26 +25,26 @@ internal static class RawSixelFixtures
     [
         new(
             "Solid RGB block",
-            "a solid pure-red (#FF0000) rectangle, 240x60px = 24 cells wide by 3 cells tall",
+            "a solid pure-red (#FF0000) rectangle, 240x60px, which is 24x3 cells on a 10x20px cell grid",
             "0;0q\"1;1;240;60#1;2;100;0;0#1" +
                 RepeatBands("!240~", 10)),
         new(
             "RGB rounding",
-            "three stacked full-width bars, each 240x6px (24 cells wide, 1 cell tall):\n  black #000000 on top, mid-red #800000 in the middle, pure red #FF0000 at the bottom.\n  The middle bar is 128, not 127: 50% rounds up",
+            "three stacked full-width bars, each 240x6px (24 cells wide, well under one row tall):\n  black #000000 on top, mid-red #800000 in the middle, pure red #FF0000 at the bottom.\n  The middle bar is 128, not 127: 50% rounds up",
             "0;1q\"1;1;240;18#1;2;0;0;0#2;2;50;0;0#3;2;100;0;0" +
                 "#1!240~-#2!240~-#3!240~"),
         new(
             "Two-color carriage return",
-            "a 240x36px block (24 cells wide, ~2 cells tall) of six horizontal stripe pairs.\n  DECGCR returns to the left margin so green #00FF00 overprints red #FF0000:\n  the top edge reads green, the bottom edge red",
+            "a 240x36px block (240px = 24 cells wide) of six horizontal stripe pairs.\n  DECGCR returns to the left margin so green #00FF00 overprints red #FF0000:\n  the top edge reads green, the bottom edge red",
             "0;1q\"1;1;240;36#1;2;100;0;0#2;2;0;100;0" +
                 RepeatBands("#1!240w$#2!240B", 6)),
         new(
             "Overprint wins last",
-            "a single thin 240x6px band (24 cells wide, well under one cell tall).\n  Red paints first, then DECGCR rewinds and green paints the same pixels,\n  so the band appears entirely green #00FF00: the last write wins",
+            "a single thin 240x6px band (24 cells wide, well under one row tall).\n  Red paints first, then DECGCR rewinds and green paints the same pixels,\n  so the band appears entirely green #00FF00: the last write wins",
             "0;1q\"1;1;240;6#1;2;100;0;0#2;2;0;100;0#1!240~$#2!240~"),
         new(
             "HLS color",
-            "a solid 240x24px block (24 cells wide, ~1 cell tall) in pure blue #0000FF,\n  specified in HLS rather than RGB: hue 0 on the DEC wheel is blue, not red",
+            "a solid 240x24px block (24 cells wide, about one 20px row tall) in pure blue #0000FF,\n  specified in HLS rather than RGB: hue 0 on the DEC wheel is blue, not red",
             "0;0q\"1;1;240;24#3;1;0;50;100#3" +
                 RepeatBands("!240~", 4)),
         new(
@@ -59,12 +59,12 @@ internal static class RawSixelFixtures
             SetupPayload: "0;1q\"1;1;240;6#5;2;100;0;0#5!240~"),
         new(
             "Transparent background",
-            "four red #FF0000 horizontal rules across 240x24px (24 cells wide, ~1 cell tall).\n  The gaps between them are transparent, so whatever is behind shows through",
+            "four red #FF0000 horizontal rules across 240x24px (24 cells wide).\n  The gaps between them are transparent, so whatever is behind shows through",
             "0;1q\"1;1;240;24#1;2;100;0;0#1" +
                 RepeatBands("!240N", 4)),
         new(
             "Opaque background",
-            "a 240x24px block (24 cells wide, ~1 cell tall) with a red #FF0000 top rule.\n  Unlike the transparent screen, P2=0 fills every unpainted pixel with the\n  terminal background, so the rest of the block is solid, not see-through",
+            "a 240x24px block (24 cells wide) with a red #FF0000 top rule.\n  Unlike the transparent screen, P2=0 fills every unpainted pixel with the\n  terminal background, so the rest of the block is solid, not see-through",
             "0;0q\"1;1;240;24#1;2;100;0;0#1!240@"),
         new(
             "DEC default aspect macro",
@@ -80,7 +80,7 @@ internal static class RawSixelFixtures
             "7;1q\"3;1;240;6#1;2;100;0;0#1!240~"),
         new(
             "Declared extent is a hint",
-            "a two-color block: a green #00FF00 stripe down the left 80px (8 cells) and\n  red #FF0000 filling the remaining 160px, 240x60px overall (24 cells wide, 3 tall).\n  The sequence declared only 80x24px, so the image is far larger than declared:\n  the declared extent is a hint, not a limit",
+            "a two-color block: a green #00FF00 stripe down the left 80px (8 cells) and\n  red #FF0000 filling the remaining 160px, 240x60px overall (24 cells wide).\n  The sequence declared only 80x24px, so the image is far larger than declared:\n  the declared extent is a hint, not a limit",
             "7q\"1;1;80;24#1;2;100;0;0#2;2;0;100;0" +
                 RepeatBands("#2!80~#1!160~", 10)),
         new(

--- a/samples/SixelTerminalDemo/RawSixelFixtures.cs
+++ b/samples/SixelTerminalDemo/RawSixelFixtures.cs
@@ -25,75 +25,75 @@ internal static class RawSixelFixtures
     [
         new(
             "Solid RGB block",
-            "a 240x60 red rectangle (about 24x3 cells with 10x20 metrics)",
+            "a solid pure-red (#FF0000) rectangle, 240x60px = 24 cells wide by 3 cells tall",
             "0;0q\"1;1;240;60#1;2;100;0;0#1" +
                 RepeatBands("!240~", 10)),
         new(
             "RGB rounding",
-            "three 240x6 bars at 0%, 50%, and 100% red; 50% rounds to 128, not 127",
+            "three stacked full-width bars, each 240x6px (24 cells wide, 1 cell tall):\n  black #000000 on top, mid-red #800000 in the middle, pure red #FF0000 at the bottom.\n  The middle bar is 128, not 127: 50% rounds up",
             "0;1q\"1;1;240;18#1;2;0;0;0#2;2;50;0;0#3;2;100;0;0" +
                 "#1!240~-#2!240~-#3!240~"),
         new(
             "Two-color carriage return",
-            "a 240x36 block with obvious green/red stripes overprinted using DECGCR",
+            "a 240x36px block (24 cells wide, ~2 cells tall) of six horizontal stripe pairs.\n  DECGCR returns to the left margin so green #00FF00 overprints red #FF0000:\n  the top edge reads green, the bottom edge red",
             "0;1q\"1;1;240;36#1;2;100;0;0#2;2;0;100;0" +
                 RepeatBands("#1!240w$#2!240B", 6)),
         new(
             "Overprint wins last",
-            "red paints first and green overprints the same pixels through DECGCR",
+            "a single thin 240x6px band (24 cells wide, well under one cell tall).\n  Red paints first, then DECGCR rewinds and green paints the same pixels,\n  so the band appears entirely green #00FF00: the last write wins",
             "0;1q\"1;1;240;6#1;2;100;0;0#2;2;0;100;0#1!240~$#2!240~"),
         new(
             "HLS color",
-            "a 240x24 block defined with HLS coordinates",
+            "a solid 240x24px block (24 cells wide, ~1 cell tall) in pure blue #0000FF,\n  specified in HLS rather than RGB: hue 0 on the DEC wheel is blue, not red",
             "0;0q\"1;1;240;24#3;1;0;50;100#3" +
                 RepeatBands("!240~", 4)),
         new(
             "DEC HLS hue wheel",
-            "hue 0 is blue, 120 is red, and 240 is green on the DEC wheel",
+            "three stacked full-width bars, each 240x6px (24 cells wide), showing the DEC HLS wheel:\n  hue 0 = blue #0000FF on top, hue 120 = red #FF0000 in the middle,\n  hue 240 = green #00FF00 at the bottom",
             "0;1q\"1;1;240;18#1;1;0;50;100#2;1;120;50;100#3;1;240;50;100" +
                 "#1!240~-#2!240~-#3!240~"),
         new(
             "Palette persistence",
-            "the second sequence selects register 5 without defining it and stays red",
+            "one thin 240x6px band (24 cells wide) in pure red #FF0000.\n  An earlier sequence defined register 5 as red; this sequence only selects it.\n  The band is red because color registers persist across DCS sequences",
             "0;1q\"1;1;240;6#5!240~",
             SetupPayload: "0;1q\"1;1;240;6#5;2;100;0;0#5!240~"),
         new(
             "Transparent background",
-            "a 240x24 field with thick red rules and transparent gaps",
+            "four red #FF0000 horizontal rules across 240x24px (24 cells wide, ~1 cell tall).\n  The gaps between them are transparent, so whatever is behind shows through",
             "0;1q\"1;1;240;24#1;2;100;0;0#1" +
                 RepeatBands("!240N", 4)),
         new(
             "Opaque background",
-            "P2=0 fills every unpainted pixel of the canvas with the captured terminal background",
+            "a 240x24px block (24 cells wide, ~1 cell tall) with a red #FF0000 top rule.\n  Unlike the transparent screen, P2=0 fills every unpainted pixel with the\n  terminal background, so the rest of the block is solid, not see-through",
             "0;0q\"1;1;240;24#1;2;100;0;0#1!240@"),
         new(
             "DEC default aspect macro",
-            "omitted P1 selects 2:1 pixels; 120 complete columns have 120x12 logical geometry",
+            "a red #FF0000 bar 120px wide (12 cells) that renders 12px tall from only 6 raster rows:\n  omitting P1 selects the DEC 2:1 default, so each pixel is twice as tall as it is wide.\n  Compare directly with the next screen",
             "q#1;2;100;0;0#1!120~"),
         new(
             "Square aspect macro",
-            "P1=7 selects 1:1 pixels, so the same six rows render half as tall as the 2:1 default",
+            "the same 120px-wide (12 cells) red #FF0000 bar and the same 6 raster rows as the\n  previous screen, but only 6px tall instead of 12px: P1=7 selects square 1:1 pixels.\n  This bar should look half the height of the one before it",
             "7;1q#1;2;100;0;0#1!120~"),
         new(
             "DECGRA Pan and Pad",
-            "Pan=3 and Pad=1 override the P1 macro and render six logical rows as eighteen",
+            "a red #FF0000 bar 240px wide (24 cells) rendered 18px tall from 6 raster rows.\n  DECGRA Pan=3/Pad=1 overrides the P1 macro, stretching each pixel 3x vertically,\n  so this is three times taller than the square-aspect screen",
             "7;1q\"3;1;240;6#1;2;100;0;0#1!240~"),
         new(
             "Declared extent is a hint",
-            "an 80x24 green declared region is followed by red overflow; the model grows to 240x60",
+            "a two-color block: a green #00FF00 stripe down the left 80px (8 cells) and\n  red #FF0000 filling the remaining 160px, 240x60px overall (24 cells wide, 3 tall).\n  The sequence declared only 80x24px, so the image is far larger than declared:\n  the declared extent is a hint, not a limit",
             "7q\"1;1;80;24#1;2;100;0;0#2;2;0;100;0" +
                 RepeatBands("#2!80~#1!160~", 10)),
         new(
             "Partial band",
-            "the second band paints only its top two rows, so the painted height is exactly eight",
+            "a red #FF0000 block 240px wide (24 cells). The first band is a full 6px tall;\n  the second paints only its top 2 rows, so the red stops at 8px even though the\n  band occupies 12px. The bottom 4px are transparent",
             "7;1q\"1;1;240;8#1;2;100;0;0#1!240~-!240B"),
         new(
             "Transparent geometry",
-            "240 transparent columns set geometry; DECGCR then paints only the leftmost 80",
+            "a magenta #FF00FF bar covering only the leftmost 80px (8 cells) of a 240px-wide\n  (24 cell) canvas. 240 transparent columns established the full width first,\n  so the image is 3x wider than the visible magenta",
             "7;1q!240?$#1;2;100;0;100#1!80~"),
         new(
             "Geometry only",
-            "a declared canvas beyond the raster policy keeps geometry but allocates no pixels",
+            "nothing visible. The sequence declares an absurd 999999999x999999999px canvas,\n  which exceeds the raster policy, so geometry is recorded but no pixels are\n  allocated and nothing is painted. The screen should stay blank",
             "7;1q\"1;1;999999999;999999999#1;2;100;0;0#1!240~"),
     ];
 

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -66,6 +66,19 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     // Sixel sequences and across alternate-screen transitions; only RIS restores
     // the default palette.
     private readonly Sixel.SixelColorRegisters _sixelColorRegisters = new();
+
+    // DECSDM (private mode 80). Sixel scrolling is the default; see
+    // docs/sixel-terminal-behavior.md for the polarity decision.
+    private bool _sixelScrollingMode;
+
+    // xterm private mode 8452. Reset (the default) returns the cursor to the
+    // column the sequence started in; set leaves it right of the graphic.
+    private bool _sixelCursorToRightMode;
+
+    // Protocol cell metrics used to size Sixel placements. Real negotiation with an
+    // upstream presentation is owned by #455; until then this is derived from
+    // capabilities and can be overridden by adapters and tests.
+    private Sixel.SixelCellMetrics? _sixelCellMetricsOverride;
     private readonly TimeProvider _timeProvider;
     private readonly KgpTerminalGraphicsState _kgpGraphicsState = new();
     private ITimer? _kgpAnimationTimer;
@@ -357,6 +370,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         _metrics = options.Metrics ?? Diagnostics.Hex1bMetrics.Default;
         _dcsByteStreamParser = new DcsByteStreamParser();
         _escapeTimeout = options.EscapeSequenceTimeout ?? TimeSpan.FromMilliseconds(50);
+        ResetSixelModes();
 
         // Subscribe to presentation events
         _presentation.Resized += OnPresentationResized;
@@ -2982,6 +2996,19 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                     // but wraps across hard line boundaries and wraps from top to bottom
                     _reverseWrapExtendedMode = privateModeToken.Enable;
                 }
+                else if (privateModeToken.Mode == 80)
+                {
+                    // DECSDM - Sixel Display Mode. Hex1b follows the DEC polarity
+                    // (set enables Sixel scrolling); the xterm inversion lives in
+                    // the compatibility policy rather than in a terminal-name check.
+                    _sixelScrollingMode = _sixelColorRegisters.Policy.ResolveSixelScrolling(privateModeToken.Enable);
+                }
+                else if (privateModeToken.Mode == 8452)
+                {
+                    // xterm private mode 8452 - place the cursor to the right of a
+                    // Sixel graphic instead of returning it to the original column.
+                    _sixelCursorToRightMode = privateModeToken.Enable;
+                }
                 else if (privateModeToken.Mode == 2027)
                 {
                     // Grapheme cluster mode — when enabled, multi-codepoint graphemes
@@ -3199,6 +3226,43 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 DeleteLines(deleteLinesToken.Count, impacts);
                 break;
                 
+            case SoftResetToken:
+                // DECSTR (CSI ! p): mode-only reset. The screen, the scrollback, the
+                // Sixel color registers and the cursor position all survive; palette
+                // and placement lifetime on reset is owned by #453.
+                _scrollTop = 0;
+                _scrollBottom = _height - 1;
+                _marginLeft = 0;
+                _marginRight = _width - 1;
+                _declrmm = false;
+                _originMode = false;
+                _insertMode = false;
+                _newlineMode = false;
+                _pendingWrap = false;
+                _wraparoundMode = true;
+                _reverseWrapMode = false;
+                _reverseWrapExtendedMode = false;
+                _cursorVisible = true;
+                _protectedMode = ProtectedMode.Off;
+                _cursorProtected = false;
+                _currentForeground = null;
+                _currentBackground = null;
+                _currentAttributes = CellAttributes.None;
+                _currentUnderlineColor = null;
+                _currentUnderlineStyle = UnderlineStyle.None;
+                _savedCursorX = 0;
+                _savedCursorY = 0;
+                _savedPendingWrap = false;
+                _savedCursorProtected = false;
+                _cursorSaved = false;
+                _charsetG0 = 'B';
+                _charsetG1 = 'B';
+                _charsetG2 = 'B';
+                _charsetG3 = 'B';
+                _activeCharsetSlot = 0;
+                ResetSixelModes();
+                break;
+
             case RisToken:
                 // RIS (ESC c): Full terminal reset — clear screen, reset all state
                 ReleaseSavedMainScreenBuffer();
@@ -3246,6 +3310,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 _charsetG3 = 'B';
                 _activeCharsetSlot = 0;
                 _sixelColorRegisters.Reset();
+                ResetSixelModes();
                 InitializeTabStops();
                 // Clear screen
                 for (int row = 0; row < _height; row++)
@@ -5843,8 +5908,55 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     /// The background is captured at graphic creation time. When no background is
     /// selected, the deterministic policy default is used.
     /// </remarks>
-    private Surfaces.Rgba32 CaptureSixelBackground()
+    /// <summary>
+    /// Gets the protocol cell metrics Sixel placements are measured against.
+    /// </summary>
+    /// <remarks>
+    /// Sixel cell metrics are protocol metrics rather than physical font metrics, so
+    /// they are modelled separately from <see cref="TerminalCapabilities"/>. Until
+    /// real presentation probing lands, the value is derived from capabilities and
+    /// reported as estimated. Adapters and tests can inject a value through
+    /// <see cref="SetSixelCellMetrics"/>.
+    /// </remarks>
+    internal Sixel.SixelCellMetrics SixelCellMetrics =>
+        _sixelCellMetricsOverride ?? Sixel.SixelCellMetrics.FromCapabilities(Capabilities);
+
+    /// <summary>
+    /// Overrides the protocol cell metrics used for new Sixel placements.
+    /// </summary>
+    /// <param name="metrics">The metrics to use, or <see langword="null"/> to derive them from capabilities.</param>
+    /// <remarks>
+    /// Metrics are captured when a placement is created, so this never changes the
+    /// occupancy already recorded for existing placements.
+    /// </remarks>
+    internal void SetSixelCellMetrics(Sixel.SixelCellMetrics? metrics) =>
+        _sixelCellMetricsOverride = metrics;
+
+    /// <summary>
+    /// Gets a value indicating whether Sixel scrolling (DECSDM) is enabled.
+    /// </summary>
+    internal bool SixelScrollingModeEnabled => _sixelScrollingMode;
+
+    /// <summary>
+    /// Gets a value indicating whether xterm private mode 8452 is enabled.
+    /// </summary>
+    internal bool SixelCursorToRightModeEnabled => _sixelCursorToRightMode;
+
+    /// <summary>
+    /// Restores the Sixel presentation modes to their documented defaults.
+    /// </summary>
+    /// <remarks>
+    /// This resets mode state only. Palette and placement lifetime on reset is
+    /// owned by <see href="https://github.com/mitchdenny/hex1b/issues/453">#453</see>.
+    /// </remarks>
+    private void ResetSixelModes()
     {
+        var policy = _sixelColorRegisters.Policy;
+        _sixelScrollingMode = policy.DefaultSixelScrolling;
+        _sixelCursorToRightMode = policy.DefaultSixelCursorToRight;
+    }
+
+    private Surfaces.Rgba32 CaptureSixelBackground()    {
         var policy = _sixelColorRegisters.Policy;
         if (policy.BackgroundSource != SixelBackgroundSource.CapturedTerminalBackground)
         {
@@ -5857,8 +5969,24 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// Processes Sixel data by creating a tracked object and marking cells.
+    /// Processes Sixel data by creating a tracked object, marking the cells it
+    /// occupies, and applying DECSDM cursor, scrolling, and margin semantics.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the terminal-model direction of the data flow: Hex1b is interpreting
+    /// an incoming Sixel sequence produced by a hosted program. It is deliberately
+    /// separate from the emitter direction, where Hex1b writes Sixel output to an
+    /// upstream terminal and always repositions the cursor explicitly afterwards
+    /// instead of relying on the upstream terminal's own post-Sixel quirks.
+    /// </para>
+    /// <para>
+    /// Three cursor concepts stay distinct here. The Sixel graphics cursor lives in
+    /// <see cref="SixelParseResult"/> and never escapes the raster. The anchor is
+    /// the text cursor position the placement is pinned to. The final text cursor
+    /// is what this method leaves behind for the next token.
+    /// </para>
+    /// </remarks>
     private void ProcessSixelData(
         string sixelPayload,
         SixelParseResult parseResult,
@@ -5874,36 +6002,53 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 _sixelColorRegisters,
                 _sixelColorRegisters.Policy));
 
-        var pixelWidth = Math.Max(1, parseResult.LogicalCanvasExtent.Width);
-        var pixelHeight = Math.Max(1, parseResult.LogicalCanvasExtent.Height);
-        var cellWidth = Math.Max(1d, Capabilities.EffectiveCellPixelWidth);
-        var cellHeight = Math.Max(1, Capabilities.CellPixelHeight);
-        var widthInCells = Math.Max(
-            1,
-            (int)Math.Min(int.MaxValue, Math.Ceiling(pixelWidth / cellWidth)));
-        var heightInCells = Math.Max(
-            1,
-            (int)Math.Min(int.MaxValue, ((long)pixelHeight + cellHeight - 1) / cellHeight));
+        // The parser's canvas extent is already aspect-scaled, so it is the rendered
+        // pixel extent the placement occupies on screen.
+        var renderedPixelWidth = Math.Max(1, parseResult.LogicalCanvasExtent.Width);
+        var renderedPixelHeight = Math.Max(1, parseResult.LogicalCanvasExtent.Height);
 
-        // Create or reuse a tracked Sixel object
+        // Metrics are captured once, at placement creation time, so later metric
+        // changes cannot retroactively alter this placement's recorded occupancy.
+        var cellMetrics = SixelCellMetrics;
+
+        // A graphic that declares an extent but paints nothing still occupies the
+        // cell it was anchored to, so occupancy never collapses to zero.
+        var widthInCells = Math.Max(1, cellMetrics.ColumnsFor(renderedPixelWidth));
+        var heightInCells = Math.Max(1, cellMetrics.RowsFor(renderedPixelHeight));
+
+        // Create or reuse a tracked Sixel object. Occupancy recorded on the
+        // placement is the unclipped source geometry; clipping only affects which
+        // cells are painted, never the raster itself.
         var sixelData = _trackedObjects.GetOrCreateSixel(
             sixelPayload,
             widthInCells,
             heightInCells,
             parseResult,
-            rasterPreparation);
+            rasterPreparation,
+            cellMetrics);
+
+        var placement = ResolveSixelPlacement(widthInCells, heightInCells, impacts);
 
         // Mark cells covered by this Sixel image
         // The first cell gets the tracked object, others just get the Sixel flag
         var sequence = ++_writeSequence;
         var writtenAt = _timeProvider.GetUtcNow();
 
-        for (int dy = 0; dy < heightInCells && _cursorY + dy < _height; dy++)
+        for (int dy = 0; dy < heightInCells; dy++)
         {
-            for (int dx = 0; dx < widthInCells && _cursorX + dx < _width; dx++)
+            var y = placement.OriginRow + dy;
+            if (y < placement.ClipTop || y > placement.ClipBottom || y >= _height)
             {
-                var y = _cursorY + dy;
-                var x = _cursorX + dx;
+                continue;
+            }
+
+            for (int dx = 0; dx < widthInCells; dx++)
+            {
+                var x = placement.OriginColumn + dx;
+                if (x < placement.ClipLeft || x > placement.ClipRight || x >= _width)
+                {
+                    continue;
+                }
 
                 // First cell (origin) holds the tracked object
                 // Other cells just have the Sixel flag set
@@ -5925,6 +6070,119 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 }
             }
         }
+
+        ApplyPostSixelCursor(placement, widthInCells, heightInCells);
+    }
+
+    /// <summary>
+    /// Describes where a Sixel placement is anchored and which cells it may paint.
+    /// </summary>
+    private readonly record struct SixelPlacementGeometry(
+        int OriginColumn,
+        int OriginRow,
+        int ClipLeft,
+        int ClipRight,
+        int ClipTop,
+        int ClipBottom,
+        bool Scrolling);
+
+    /// <summary>
+    /// Chooses the placement anchor and clipping rectangle, scrolling the active
+    /// region first when the graphic would overflow it in Sixel scrolling mode.
+    /// </summary>
+    private SixelPlacementGeometry ResolveSixelPlacement(
+        int widthInCells,
+        int heightInCells,
+        List<CellImpact>? impacts)
+    {
+        if (!_sixelScrollingMode)
+        {
+            // Non-scrolling mode uses the graphics page origin and the full page
+            // instead of the text margins, matching DEC display mode. Nothing
+            // scrolls and the text cursor is left untouched.
+            return new SixelPlacementGeometry(
+                OriginColumn: 0,
+                OriginRow: 0,
+                ClipLeft: 0,
+                ClipRight: _width - 1,
+                ClipTop: 0,
+                ClipBottom: _height - 1,
+                Scrolling: false);
+        }
+
+        // Scrolling mode starts at the active text position. Margins clip the
+        // graphic; they never rewrite the raster.
+        var clipLeft = _declrmm ? _marginLeft : 0;
+        var clipRight = _declrmm ? _marginRight : _width - 1;
+
+        // A cursor parked outside the scrolling region (only reachable with origin
+        // mode off) uses the full page, mirroring how LF treats the same case.
+        var insideRegion = _cursorY >= _scrollTop && _cursorY <= _scrollBottom;
+        var clipTop = insideRegion ? _scrollTop : 0;
+        var clipBottom = insideRegion ? _scrollBottom : _height - 1;
+
+        var originColumn = _cursorX;
+        var originRow = _cursorY;
+
+        // The cursor lands one row below the graphic, so the rows the graphic needs
+        // and the row the cursor needs are scrolled in a single step.
+        var regionHeight = clipBottom - clipTop + 1;
+        var overflow = originRow + heightInCells - clipBottom;
+        if (overflow > 0)
+        {
+            var scrollCount = Math.Min(overflow, regionHeight);
+            for (int i = 0; i < scrollCount; i++)
+            {
+                if (!ScrollUp(impacts))
+                {
+                    break;
+                }
+            }
+
+            // A graphic taller than the region keeps its bottom edge on the last
+            // region row; the top is clipped rather than corrupted.
+            originRow = Math.Max(clipTop, originRow - scrollCount);
+        }
+
+        return new SixelPlacementGeometry(
+            originColumn,
+            originRow,
+            clipLeft,
+            clipRight,
+            clipTop,
+            clipBottom,
+            Scrolling: true);
+    }
+
+    /// <summary>
+    /// Applies the final text cursor position after a Sixel sequence completes.
+    /// </summary>
+    private void ApplyPostSixelCursor(
+        SixelPlacementGeometry placement,
+        int widthInCells,
+        int heightInCells)
+    {
+        if (!placement.Scrolling)
+        {
+            // DECSDM display mode leaves the text cursor exactly where it was.
+            return;
+        }
+
+        // Any pending wrap is consumed by the graphic, exactly like a line feed.
+        _pendingWrap = false;
+
+        // Mode 8452 reset (the default) returns the cursor to the column the
+        // sequence started in; set leaves it to the right of the graphic.
+        _cursorX = _sixelCursorToRightMode
+            ? Math.Min(placement.OriginColumn + widthInCells, placement.ClipRight)
+            : placement.OriginColumn;
+
+        // The cursor lands on the row below the last row the graphic occupies and
+        // never escapes the region the graphic was clipped to.
+        _cursorY = Math.Clamp(
+            placement.OriginRow + heightInCells,
+            placement.ClipTop,
+            placement.ClipBottom);
     }
 
     /// <summary>

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -6034,21 +6034,27 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         var sequence = ++_writeSequence;
         var writtenAt = _timeProvider.GetUtcNow();
 
-        for (int dy = 0; dy < heightInCells; dy++)
-        {
-            var y = placement.OriginRow + dy;
-            if (y < placement.ClipTop || y > placement.ClipBottom || y >= _height)
-            {
-                continue;
-            }
+        // Only the visible intersection is walked. A placement may declare an
+        // enormous extent (a geometry-only frame can declare hundreds of millions of
+        // cells), so iterating the declared extent and skipping out-of-range cells
+        // would stall the terminal. Clipping is a bound on the loop, not a filter
+        // inside it; the placement still records its unclipped source geometry.
+        var firstRow = Math.Max(placement.OriginRow, Math.Max(placement.ClipTop, 0));
+        var lastRow = Math.Min(
+            placement.OriginRow + (long)heightInCells - 1,
+            Math.Min(placement.ClipBottom, _height - 1));
+        var firstColumn = Math.Max(placement.OriginColumn, Math.Max(placement.ClipLeft, 0));
+        var lastColumn = Math.Min(
+            placement.OriginColumn + (long)widthInCells - 1,
+            Math.Min(placement.ClipRight, _width - 1));
 
-            for (int dx = 0; dx < widthInCells; dx++)
+        for (var y = firstRow; y <= lastRow; y++)
+        {
+            var dy = y - placement.OriginRow;
+
+            for (var x = firstColumn; x <= lastColumn; x++)
             {
-                var x = placement.OriginColumn + dx;
-                if (x < placement.ClipLeft || x > placement.ClipRight || x >= _width)
-                {
-                    continue;
-                }
+                var dx = x - placement.OriginColumn;
 
                 // First cell (origin) holds the tracked object
                 // Other cells just have the Sixel flag set
@@ -6125,12 +6131,14 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         var originRow = _cursorY;
 
         // The cursor lands one row below the graphic, so the rows the graphic needs
-        // and the row the cursor needs are scrolled in a single step.
+        // and the row the cursor needs are scrolled in a single step. The arithmetic
+        // is widened because a geometry-only frame can declare an extent that
+        // saturates the cell count.
         var regionHeight = clipBottom - clipTop + 1;
-        var overflow = originRow + heightInCells - clipBottom;
+        var overflow = originRow + (long)heightInCells - clipBottom;
         if (overflow > 0)
         {
-            var scrollCount = Math.Min(overflow, regionHeight);
+            var scrollCount = (int)Math.Min(overflow, regionHeight);
             for (int i = 0; i < scrollCount; i++)
             {
                 if (!ScrollUp(impacts))
@@ -6172,15 +6180,17 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         _pendingWrap = false;
 
         // Mode 8452 reset (the default) returns the cursor to the column the
-        // sequence started in; set leaves it to the right of the graphic.
+        // sequence started in; set leaves it to the right of the graphic. The widened
+        // arithmetic keeps a saturating declared extent from wrapping to a negative
+        // column or row.
         _cursorX = _sixelCursorToRightMode
-            ? Math.Min(placement.OriginColumn + widthInCells, placement.ClipRight)
+            ? (int)Math.Min(placement.OriginColumn + (long)widthInCells, placement.ClipRight)
             : placement.OriginColumn;
 
         // The cursor lands on the row below the last row the graphic occupies and
         // never escapes the region the graphic was clipped to.
-        _cursorY = Math.Clamp(
-            placement.OriginRow + heightInCells,
+        _cursorY = (int)Math.Clamp(
+            placement.OriginRow + (long)heightInCells,
             placement.ClipTop,
             placement.ClipBottom);
     }

--- a/src/Hex1b/Sixel/SixelCellMetrics.cs
+++ b/src/Hex1b/Sixel/SixelCellMetrics.cs
@@ -1,0 +1,166 @@
+namespace Hex1b.Sixel;
+
+/// <summary>
+/// Identifies where a <see cref="SixelCellMetrics"/> value came from.
+/// </summary>
+/// <remarks>
+/// Sixel cell metrics are protocol metrics, not physical font metrics. Windows
+/// Terminal, for example, deliberately exposes a VT-compatible virtual Sixel grid
+/// (commonly 9x20 or 10x20) instead of its physical glyph box, so the source must
+/// travel with the value.
+/// </remarks>
+internal enum SixelCellMetricsSource
+{
+    /// <summary>
+    /// The presentation reported protocol cell metrics directly.
+    /// </summary>
+    Direct,
+
+    /// <summary>
+    /// The metrics came from an XTWINOPS <c>CSI 16 t</c> report.
+    /// </summary>
+    Csi16,
+
+    /// <summary>
+    /// The metrics came from an OSC 1337 report.
+    /// </summary>
+    Osc1337,
+
+    /// <summary>
+    /// The metrics were computed from other reported geometry, such as a window
+    /// pixel size divided by the character grid.
+    /// </summary>
+    Derived,
+
+    /// <summary>
+    /// No report was available and a documented default was assumed.
+    /// </summary>
+    Assumed,
+}
+
+/// <summary>
+/// Describes how much a <see cref="SixelCellMetrics"/> value can be trusted.
+/// </summary>
+internal enum SixelCellMetricsReliability
+{
+    /// <summary>
+    /// The upstream presentation reported the value for the Sixel protocol grid.
+    /// </summary>
+    Authoritative,
+
+    /// <summary>
+    /// The value was computed from an authoritative report of different geometry.
+    /// </summary>
+    Derived,
+
+    /// <summary>
+    /// The value is a guess and may not match the upstream presentation.
+    /// </summary>
+    Estimated,
+}
+
+/// <summary>
+/// The protocol cell metrics a Sixel placement is measured against.
+/// </summary>
+/// <param name="Width">The protocol cell width in pixels. May be fractional.</param>
+/// <param name="Height">The protocol cell height in pixels. May be fractional.</param>
+/// <param name="Source">Where the metrics came from.</param>
+/// <param name="Reliability">How much the metrics can be trusted.</param>
+/// <remarks>
+/// <para>
+/// Metrics are captured once, when a completed Sixel sequence creates a placement,
+/// so a later metric change cannot retroactively alter an existing placement's
+/// recorded occupancy. Discovering real upstream metrics is owned by
+/// <see href="https://github.com/mitchdenny/hex1b/issues/455">#455</see>; this type
+/// only models the value and lets tests and adapters inject one.
+/// </para>
+/// <para>
+/// Occupancy always uses ceiling division of the <em>rendered</em> (aspect-scaled)
+/// pixel extent, so a graphic one pixel past a cell boundary occupies the whole
+/// next cell.
+/// </para>
+/// </remarks>
+internal readonly record struct SixelCellMetrics(
+    double Width,
+    double Height,
+    SixelCellMetricsSource Source,
+    SixelCellMetricsReliability Reliability)
+{
+    /// <summary>
+    /// The documented fallback used when nothing is known about the presentation.
+    /// </summary>
+    public static SixelCellMetrics Unknown { get; } = new(
+        10,
+        20,
+        SixelCellMetricsSource.Assumed,
+        SixelCellMetricsReliability.Estimated);
+
+    /// <summary>
+    /// Gets a value indicating whether the metrics were reported by the upstream
+    /// presentation for the Sixel protocol grid.
+    /// </summary>
+    public bool IsAuthoritative => Reliability == SixelCellMetricsReliability.Authoritative;
+
+    /// <summary>
+    /// Gets the sanitized cell width. Non-positive or non-finite widths fall back
+    /// to <see cref="Unknown"/> so occupancy math stays deterministic.
+    /// </summary>
+    public double SafeWidth => Sanitize(Width, Unknown.Width);
+
+    /// <summary>
+    /// Gets the sanitized cell height.
+    /// </summary>
+    public double SafeHeight => Sanitize(Height, Unknown.Height);
+
+    /// <summary>
+    /// Creates metrics derived from <see cref="TerminalCapabilities"/>.
+    /// </summary>
+    /// <remarks>
+    /// Capability metrics describe the presentation's text cell, not a negotiated
+    /// Sixel protocol grid, so the result is never authoritative.
+    /// </remarks>
+    public static SixelCellMetrics FromCapabilities(TerminalCapabilities capabilities)
+    {
+        ArgumentNullException.ThrowIfNull(capabilities);
+        return new SixelCellMetrics(
+            capabilities.EffectiveCellPixelWidth,
+            capabilities.CellPixelHeight,
+            SixelCellMetricsSource.Derived,
+            SixelCellMetricsReliability.Estimated);
+    }
+
+    /// <summary>
+    /// Computes the number of columns a rendered pixel width occupies.
+    /// </summary>
+    /// <param name="renderedPixelWidth">The aspect-scaled horizontal extent.</param>
+    public int ColumnsFor(int renderedPixelWidth) => Occupancy(renderedPixelWidth, SafeWidth);
+
+    /// <summary>
+    /// Computes the number of rows a rendered pixel height occupies.
+    /// </summary>
+    /// <param name="renderedPixelHeight">The aspect-scaled vertical extent.</param>
+    public int RowsFor(int renderedPixelHeight) => Occupancy(renderedPixelHeight, SafeHeight);
+
+    /// <summary>
+    /// Formats the metrics for diagnostics, keeping estimated values visibly
+    /// distinct from authoritative ones.
+    /// </summary>
+    public override string ToString() =>
+        string.Create(
+            System.Globalization.CultureInfo.InvariantCulture,
+            $"{Width:0.###}x{Height:0.###}px ({Source}/{Reliability})");
+
+    private static int Occupancy(int renderedPixels, double cellPixels)
+    {
+        if (renderedPixels <= 0)
+        {
+            return 0;
+        }
+
+        var cells = Math.Ceiling(renderedPixels / cellPixels);
+        return cells >= int.MaxValue ? int.MaxValue : (int)cells;
+    }
+
+    private static double Sanitize(double value, double fallback) =>
+        double.IsFinite(value) && value > 0 ? value : fallback;
+}

--- a/src/Hex1b/Sixel/SixelCompatibilityPolicy.cs
+++ b/src/Hex1b/Sixel/SixelCompatibilityPolicy.cs
@@ -28,6 +28,28 @@ internal enum SixelPaletteScope
 }
 
 /// <summary>
+/// Identifies how DECSDM (private mode 80) set/reset maps onto Sixel scrolling.
+/// </summary>
+/// <remarks>
+/// The VT340 manual and hardware tests make <c>CSI ? 80 h</c> enable Sixel
+/// scrolling. Current xterm documentation and implementation interpret the same
+/// mode in the opposite direction. Hex1b selects the DEC interpretation and keeps
+/// the inversion here rather than in a terminal-name check.
+/// </remarks>
+internal enum SixelDecsdmPolarity
+{
+    /// <summary>
+    /// <c>CSI ? 80 h</c> enables Sixel scrolling; <c>CSI ? 80 l</c> disables it.
+    /// </summary>
+    Dec,
+
+    /// <summary>
+    /// <c>CSI ? 80 h</c> disables Sixel scrolling; <c>CSI ? 80 l</c> enables it.
+    /// </summary>
+    Xterm,
+}
+
+/// <summary>
 /// Centralized, reviewable Sixel compatibility and resource policy.
 /// </summary>
 /// <remarks>
@@ -62,6 +84,38 @@ internal sealed record SixelCompatibilityPolicy
     /// Gets the palette lifetime scope.
     /// </summary>
     public SixelPaletteScope PaletteScope { get; init; } = SixelPaletteScope.TerminalPersistent;
+
+    /// <summary>
+    /// Gets the DECSDM (private mode 80) polarity.
+    /// </summary>
+    public SixelDecsdmPolarity DecsdmPolarity { get; init; } = SixelDecsdmPolarity.Dec;
+
+    /// <summary>
+    /// Gets the Sixel scrolling state a reset restores.
+    /// </summary>
+    /// <remarks>
+    /// DEC VT340 hardware reports and the manual identify scrolling as the normal
+    /// behavior, so RIS and DECSTR restore it.
+    /// </remarks>
+    public bool DefaultSixelScrolling { get; init; } = true;
+
+    /// <summary>
+    /// Gets the xterm private mode 8452 state a reset restores.
+    /// </summary>
+    /// <remarks>
+    /// The reset (default) behavior leaves the text cursor at its original column
+    /// below the graphic. Setting the mode leaves it to the right of the graphic,
+    /// which is confirmed only in xterm and RLogin.
+    /// </remarks>
+    public bool DefaultSixelCursorToRight { get; init; }
+
+    /// <summary>
+    /// Maps a DECSDM set/reset request onto the Sixel scrolling state.
+    /// </summary>
+    /// <param name="decsdmEnabled"><see langword="true"/> for <c>CSI ? 80 h</c>.</param>
+    /// <returns><see langword="true"/> when Sixel scrolling should be enabled.</returns>
+    public bool ResolveSixelScrolling(bool decsdmEnabled) =>
+        DecsdmPolarity == SixelDecsdmPolarity.Xterm ? !decsdmEnabled : decsdmEnabled;
 
     /// <summary>
     /// Gets the maximum number of logical pixels a single graphic may materialize.

--- a/src/Hex1b/SixelData.cs
+++ b/src/Hex1b/SixelData.cs
@@ -106,7 +106,8 @@ public sealed class SixelData
         int pixelHeight,
         SixelParseResult? parseResult = null,
         SixelRasterResult? raster = null,
-        SixelRasterPreparation? rasterPreparation = null)
+        SixelRasterPreparation? rasterPreparation = null,
+        SixelCellMetrics? cellMetrics = null)
     {
         Payload = payload;
         WidthInCells = widthInCells;
@@ -117,7 +118,17 @@ public sealed class SixelData
         ParseResult = parseResult ?? SixelParser.ParsePayload(payload);
         _raster = raster;
         _rasterPreparation = rasterPreparation;
+        CellMetrics = cellMetrics ?? SixelCellMetrics.Unknown;
     }
+
+    /// <summary>
+    /// Gets the protocol cell metrics captured when this placement was created.
+    /// </summary>
+    /// <remarks>
+    /// Metrics are captured once so a later metric change cannot retroactively
+    /// alter the occupancy already recorded for this placement.
+    /// </remarks>
+    internal SixelCellMetrics CellMetrics { get; }
 
     /// <summary>
     /// Gets the cell span for this sixel using the specified cell metrics.

--- a/src/Hex1b/Surfaces/SurfaceComparer.cs
+++ b/src/Hex1b/Surfaces/SurfaceComparer.cs
@@ -615,7 +615,10 @@ public static class SurfaceComparer
                     // Emit the sixel DCS sequence as raw - the payload already contains ESC P ... ESC \
                     tokens.Add(new UnrecognizedSequenceToken(change.Cell.Sixel.Data.Payload));
                     
-                    // Sixel rendering moves cursor, mark position as unknown
+                    // Hex1b-as-emitter never relies on where the upstream terminal
+                    // leaves the cursor after a Sixel sequence: DECSDM, mode 8452
+                    // and margin state all vary between terminals. Invalidating the
+                    // tracked position forces an explicit CUP before the next cell.
                     cursorX = -1;
                     cursorY = -1;
                 }

--- a/src/Hex1b/Tokens/AnsiTokenSerializer.cs
+++ b/src/Hex1b/Tokens/AnsiTokenSerializer.cs
@@ -51,6 +51,7 @@ public static class AnsiTokenSerializer
             EraseCharacterToken ech => ech.Count == 1 ? "\x1b[X" : $"\x1b[{ech.Count}X",
             RepeatCharacterToken rep => rep.Count == 1 ? "\x1b[b" : $"\x1b[{rep.Count}b",
             IndexToken => "\x1bD",
+            SoftResetToken => "\x1b[!p",
             ReverseIndexToken => "\x1bM",
             CharacterSetToken cs => $"\x1b{(cs.Target == 0 ? '(' : ')')}{cs.Charset}",
             KeypadModeToken kp => kp.Application ? "\x1b=" : "\x1b>",

--- a/src/Hex1b/Tokens/AnsiTokenUtf8Serializer.cs
+++ b/src/Hex1b/Tokens/AnsiTokenUtf8Serializer.cs
@@ -238,6 +238,12 @@ public static class AnsiTokenUtf8Serializer
                 WriteByte(writer, (byte)'M');
                 return;
 
+            case SoftResetToken:
+                WriteEscLeftBracket(writer);
+                WriteByte(writer, (byte)'!');
+                WriteByte(writer, (byte)'p');
+                return;
+
             case CharacterSetToken cs:
                 WriteByte(writer, 0x1b);
                 WriteByte(writer, (byte)(cs.Target == 0 ? '(' : ')'));

--- a/src/Hex1b/Tokens/AnsiTokenizer.cs
+++ b/src/Hex1b/Tokens/AnsiTokenizer.cs
@@ -488,6 +488,20 @@ public static class AnsiTokenizer
                 tokens.Add(new DeleteLinesToken(ParseMoveCount(parameters)));
                 break;
                 
+            case 'p':
+                // CSI ! p = DECSTR (Soft Terminal Reset). Other 'p' finals (DECSCL,
+                // DECRQM, xterm pointer modes) stay unrecognized so raw passthrough
+                // keeps forwarding them unchanged.
+                if (!isPrivateMode && parameters == "!")
+                {
+                    tokens.Add(SoftResetToken.Instance);
+                }
+                else
+                {
+                    tokens.Add(new UnrecognizedSequenceToken(text[start..(end + 1)]));
+                }
+                break;
+
             case 'P':
                 // CSI 1;m P = F1 with modifiers (xterm); otherwise CSI Ps P = Delete Character (DCH)
                 if (TryParseFunctionKeyWithModifier(parameters, out var pMod))

--- a/src/Hex1b/Tokens/SoftResetToken.cs
+++ b/src/Hex1b/Tokens/SoftResetToken.cs
@@ -1,0 +1,18 @@
+namespace Hex1b.Tokens;
+
+/// <summary>
+/// Token for DECSTR (Soft Terminal Reset, CSI ! p).
+/// </summary>
+/// <remarks>
+/// A soft reset restores mode state without clearing the screen, the scrollback,
+/// or the Sixel color registers, and without moving the cursor.
+/// </remarks>
+public sealed record SoftResetToken : AnsiToken
+{
+    /// <summary>
+    /// The shared instance. The sequence carries no parameters.
+    /// </summary>
+    public static readonly SoftResetToken Instance = new();
+
+    private SoftResetToken() { }
+}

--- a/src/Hex1b/TrackedObjectStore.cs
+++ b/src/Hex1b/TrackedObjectStore.cs
@@ -93,7 +93,8 @@ internal sealed class TrackedObjectStore
         int widthInCells,
         int heightInCells,
         SixelParseResult parseResult,
-        SixelRasterPreparation? rasterPreparation = null)
+        SixelRasterPreparation? rasterPreparation = null,
+        SixelCellMetrics? cellMetrics = null)
     {
         var hash = SixelData.ComputeHash(payload, rasterPreparation?.Identity);
 
@@ -115,7 +116,8 @@ internal sealed class TrackedObjectStore
                 parseResult.DeclaredExtent.Width,
                 parseResult.DeclaredExtent.Height,
                 parseResult,
-                rasterPreparation: rasterPreparation);
+                rasterPreparation: rasterPreparation,
+                cellMetrics: cellMetrics);
             
             // Create new tracked wrapper with removal callback
             var tracked = new TrackedObject<SixelData>(

--- a/tests/Hex1b.Tests/Sixel/SixelCursorSemanticsTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelCursorSemanticsTests.cs
@@ -526,4 +526,37 @@ public class SixelCursorSemanticsTests
         Assert.IsFalse(policy.ResolveSixelScrolling(decsdmEnabled: true));
         Assert.IsTrue(policy.ResolveSixelScrolling(decsdmEnabled: false));
     }
+
+    [TestMethod]
+    [DataRow(999999999, 999999999)]
+    [DataRow(int.MaxValue, int.MaxValue)]
+    public async Task ProcessSixelData_DeclaredExtentFarBeyondViewport_PaintsOnlyTheVisibleIntersection(
+        int pixelWidth,
+        int pixelHeight)
+    {
+        // A geometry-only frame can declare hundreds of millions of cells. Painting
+        // must be bounded by the viewport rather than walking the declared extent,
+        // otherwise the terminal stalls before any output reaches the presentation.
+        await using var terminal = SixelTestTerminal.Create(
+            width: 40,
+            height: 20,
+            cellMetrics: Metrics(10, 20));
+
+        var observation = await RunAsync(
+            terminal,
+            Graphic(pixelWidth, pixelHeight),
+            TestContext.Current.CancellationToken)
+            .WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+
+        // The placement still records its unclipped source geometry.
+        var placement = TestSeq.Single(observation.Placements);
+        Assert.AreEqual(0, placement.OriginColumn);
+        Assert.AreEqual(0, placement.OriginRow);
+
+        // The cursor is clamped into the region instead of overflowing.
+        Assert.IsGreaterThanOrEqualTo(0, observation.CursorY);
+        Assert.IsLessThan(20, observation.CursorY);
+        Assert.IsGreaterThanOrEqualTo(0, observation.CursorX);
+        Assert.IsLessThan(40, observation.CursorX);
+    }
 }

--- a/tests/Hex1b.Tests/Sixel/SixelCursorSemanticsTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelCursorSemanticsTests.cs
@@ -1,0 +1,529 @@
+using System.Text;
+using Hex1b.Sixel;
+
+namespace Hex1b.Tests.Sixel;
+
+/// <summary>
+/// Covers how <c>Hex1bTerminal</c> interprets an incoming Sixel sequence: where the
+/// placement is anchored, how it is clipped, and where the text cursor ends up.
+/// </summary>
+/// <remarks>
+/// These tests exercise the terminal-model direction of the data flow. Hex1b's own
+/// emitter behavior is covered by <c>SixelEmitterCursorTests</c>.
+/// </remarks>
+[TestClass]
+public class SixelCursorSemanticsTests
+{
+    private const string SquareBand = "7q#1;2;100;0;0";
+
+    /// <summary>
+    /// Builds a square-aspect graphic that declares an exact pixel extent, so the
+    /// rendered extent used for occupancy is fully deterministic.
+    /// </summary>
+    private static byte[] Graphic(int pixelWidth, int pixelHeight, string prefix = "")
+    {
+        var payload = new StringBuilder();
+        payload.Append(prefix);
+        payload.Append("\x1bP");
+        payload.Append(SquareBand);
+
+        // DECGRA declares the raster; a single painted sixel keeps the graphic
+        // valid without changing the declared extent.
+        payload.Append($"\"1;1;{pixelWidth};{pixelHeight}");
+        payload.Append("#1@");
+        payload.Append("\x1b\\");
+        return Encoding.ASCII.GetBytes(payload.ToString());
+    }
+
+    private static SixelCellMetrics Metrics(double width, double height) => new(
+        width,
+        height,
+        SixelCellMetricsSource.Direct,
+        SixelCellMetricsReliability.Authoritative);
+
+    private static async Task<SixelTerminalObservation> RunAsync(
+        SixelTestTerminal terminal,
+        byte[] bytes,
+        CancellationToken cancellationToken)
+    {
+        await terminal.FeedAsync(bytes, cancellationToken: cancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "Sixel placement",
+            cancellationToken);
+        return terminal.Observe();
+    }
+
+    [TestMethod]
+    // One pixel below, exactly on, and one pixel above a cell boundary for each
+    // metric, so ceiling division is pinned at every edge.
+    [DataRow(9d, 20d, 17, 39, 2, 2)]
+    [DataRow(9d, 20d, 18, 40, 2, 2)]
+    [DataRow(9d, 20d, 19, 41, 3, 3)]
+    [DataRow(10d, 20d, 19, 39, 2, 2)]
+    [DataRow(10d, 20d, 20, 40, 2, 2)]
+    [DataRow(10d, 20d, 21, 41, 3, 3)]
+    [DataRow(8d, 16d, 15, 31, 2, 2)]
+    [DataRow(8d, 16d, 16, 32, 2, 2)]
+    [DataRow(8d, 16d, 17, 33, 3, 3)]
+    [DataRow(12d, 24d, 23, 47, 2, 2)]
+    [DataRow(12d, 24d, 24, 48, 2, 2)]
+    [DataRow(12d, 24d, 25, 49, 3, 3)]
+    // Fractional metrics must not be truncated to integers before dividing.
+    [DataRow(7.5d, 16.5d, 15, 33, 2, 2)]
+    [DataRow(7.5d, 16.5d, 16, 34, 3, 3)]
+    [DataRow(9.6d, 20.4d, 20, 41, 3, 3)]
+    public async Task ProcessSixelData_RenderedExtentAndMetrics_UsesCeilingDivision(
+        double cellWidth,
+        double cellHeight,
+        int pixelWidth,
+        int pixelHeight,
+        int expectedColumns,
+        int expectedRows)
+    {
+        await using var terminal = SixelTestTerminal.Create(
+            width: 40,
+            height: 20,
+            cellMetrics: Metrics(cellWidth, cellHeight));
+
+        var observation = await RunAsync(
+            terminal,
+            Graphic(pixelWidth, pixelHeight),
+            TestContext.Current.CancellationToken);
+
+        var placement = TestSeq.Single(observation.Placements);
+        Assert.AreEqual(expectedColumns, placement.WidthInCells);
+        Assert.AreEqual(expectedRows, placement.HeightInCells);
+    }
+
+    [TestMethod]
+    public async Task ProcessSixelData_InjectedMetrics_AreCapturedOnThePlacement()
+    {
+        await using var terminal = SixelTestTerminal.Create(cellMetrics: Metrics(9, 20));
+
+        var observation = await RunAsync(
+            terminal,
+            Graphic(18, 20),
+            TestContext.Current.CancellationToken);
+
+        var placement = TestSeq.Single(observation.Placements);
+        Assert.AreEqual(9d, placement.CellMetrics.Width);
+        Assert.AreEqual(20d, placement.CellMetrics.Height);
+        Assert.AreEqual(SixelCellMetricsSource.Direct, placement.CellMetrics.Source);
+        Assert.AreEqual(SixelCellMetricsReliability.Authoritative, placement.CellMetrics.Reliability);
+        Assert.IsTrue(placement.CellMetrics.IsAuthoritative);
+    }
+
+    [TestMethod]
+    public void SixelCellMetrics_DerivedFromCapabilities_IsReportedAsEstimated()
+    {
+        var capabilities = new TerminalCapabilities
+        {
+            CellPixelWidth = 10,
+            CellPixelHeight = 20,
+            ActualCellPixelWidth = 9.5,
+        };
+
+        var metrics = SixelCellMetrics.FromCapabilities(capabilities);
+
+        Assert.AreEqual(9.5d, metrics.Width);
+        Assert.AreEqual(20d, metrics.Height);
+        Assert.AreEqual(SixelCellMetricsSource.Derived, metrics.Source);
+        Assert.AreEqual(SixelCellMetricsReliability.Estimated, metrics.Reliability);
+        Assert.IsFalse(metrics.IsAuthoritative);
+    }
+
+    [TestMethod]
+    [DataRow(0d)]
+    [DataRow(-4d)]
+    [DataRow(double.NaN)]
+    [DataRow(double.PositiveInfinity)]
+    public void SixelCellMetrics_NonPositiveOrNonFinite_FallsBackToTheAssumedGrid(double invalid)
+    {
+        var metrics = new SixelCellMetrics(
+            invalid,
+            invalid,
+            SixelCellMetricsSource.Assumed,
+            SixelCellMetricsReliability.Estimated);
+
+        Assert.AreEqual(SixelCellMetrics.Unknown.Width, metrics.SafeWidth);
+        Assert.AreEqual(SixelCellMetrics.Unknown.Height, metrics.SafeHeight);
+        Assert.AreEqual(1, metrics.ColumnsFor(1));
+        Assert.AreEqual(0, metrics.RowsFor(0));
+    }
+
+    [TestMethod]
+    public async Task ProcessSixelData_MultiRowGraphic_LeavesCursorBelowAtOriginalColumn()
+    {
+        await using var terminal = SixelTestTerminal.Create(
+            width: 20,
+            height: 12,
+            cellMetrics: Metrics(10, 20));
+
+        var observation = await RunAsync(
+            terminal,
+            Graphic(30, 60, "\x1b[4;6H"),
+            TestContext.Current.CancellationToken);
+
+        var placement = TestSeq.Single(observation.Placements);
+        Assert.AreEqual(5, placement.OriginColumn);
+        Assert.AreEqual(3, placement.OriginRow);
+        Assert.AreEqual(3, placement.WidthInCells);
+        Assert.AreEqual(3, placement.HeightInCells);
+        Assert.AreEqual(5, observation.CursorX);
+        Assert.AreEqual(6, observation.CursorY);
+    }
+
+    [TestMethod]
+    public async Task ProcessSixelData_OneRowGraphic_LeavesCursorOnTheNextRow()
+    {
+        await using var terminal = SixelTestTerminal.Create(cellMetrics: Metrics(10, 20));
+
+        var observation = await RunAsync(
+            terminal,
+            Graphic(10, 20, "\x1b[2;3H"),
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(1, TestSeq.Single(observation.Placements).HeightInCells);
+        Assert.AreEqual(2, observation.CursorX);
+        Assert.AreEqual(2, observation.CursorY);
+    }
+
+    [TestMethod]
+    public async Task ProcessSixelData_PartialFinalBand_RoundsUpToAWholeRow()
+    {
+        await using var terminal = SixelTestTerminal.Create(cellMetrics: Metrics(10, 20));
+
+        var observation = await RunAsync(
+            terminal,
+            Graphic(10, 21, "\x1b[2;3H"),
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(2, TestSeq.Single(observation.Placements).HeightInCells);
+        Assert.AreEqual(3, observation.CursorY);
+    }
+
+    [TestMethod]
+    public async Task ProcessSixelData_DeclaredExtentWithoutPaintedPixels_StillOccupiesCells()
+    {
+        await using var terminal = SixelTestTerminal.Create(cellMetrics: Metrics(10, 20));
+
+        // A raster attribute with no sixel data at all: the declared extent is the
+        // only geometry available and must still occupy cells.
+        var bytes = Encoding.ASCII.GetBytes("\x1b[2;2H\x1bP7q\"1;1;30;40\x1b\\");
+        var observation = await RunAsync(terminal, bytes, TestContext.Current.CancellationToken);
+
+        var placement = TestSeq.Single(observation.Placements);
+        Assert.AreEqual(3, placement.WidthInCells);
+        Assert.AreEqual(2, placement.HeightInCells);
+        Assert.AreEqual(1, observation.CursorX);
+        Assert.AreEqual(3, observation.CursorY);
+    }
+
+    [TestMethod]
+    public async Task ProcessSixelData_NonScrollingMode_UsesPageOriginAndLeavesTheCursorAlone()
+    {
+        await using var terminal = SixelTestTerminal.Create(cellMetrics: Metrics(10, 20));
+
+        var observation = await RunAsync(
+            terminal,
+            Graphic(20, 40, "\x1b[?80l\x1b[5;7H"),
+            TestContext.Current.CancellationToken);
+
+        var placement = TestSeq.Single(observation.Placements);
+        Assert.AreEqual(0, placement.OriginColumn);
+        Assert.AreEqual(0, placement.OriginRow);
+        Assert.AreEqual(6, observation.CursorX);
+        Assert.AreEqual(4, observation.CursorY);
+    }
+
+    [TestMethod]
+    public async Task ProcessSixelData_NonScrollingModeWithMargins_IgnoresTextMargins()
+    {
+        await using var terminal = SixelTestTerminal.Create(
+            width: 20,
+            height: 12,
+            cellMetrics: Metrics(10, 20));
+
+        // Margins constrain text, but DECSDM display mode paints the whole page.
+        var observation = await RunAsync(
+            terminal,
+            Graphic(60, 80, "\x1b[?69h\x1b[4;10s\x1b[3;8r\x1b[?80l"),
+            TestContext.Current.CancellationToken);
+
+        Assert.IsTrue(observation.OccupiedCells.Any(cell => cell.Column == 0 && cell.Row == 0));
+        Assert.IsTrue(observation.OccupiedCells.Any(cell => cell.Row == 3));
+    }
+
+    [TestMethod]
+    public async Task ProcessSixelData_Mode8452Set_LeavesCursorRightOfTheGraphic()
+    {
+        await using var terminal = SixelTestTerminal.Create(cellMetrics: Metrics(10, 20));
+
+        var observation = await RunAsync(
+            terminal,
+            Graphic(30, 40, "\x1b[?8452h\x1b[2;3H"),
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(5, observation.CursorX);
+        Assert.AreEqual(3, observation.CursorY);
+    }
+
+    [TestMethod]
+    public async Task ProcessSixelData_AtBottomMargin_ScrollsTheRegionAndKeepsTheCursorInside()
+    {
+        await using var terminal = SixelTestTerminal.Create(
+            width: 20,
+            height: 10,
+            cellMetrics: Metrics(10, 20));
+
+        // Rows 2..6 (1-based 3..7) form the region; the cursor starts on its last
+        // row, so a two-row graphic has to scroll the region twice.
+        var observation = await RunAsync(
+            terminal,
+            Graphic(10, 40, "\x1b[3;7r\x1b[7;1H"),
+            TestContext.Current.CancellationToken);
+
+        var placement = TestSeq.Single(observation.Placements);
+        Assert.AreEqual(2, placement.HeightInCells);
+        Assert.AreEqual(4, placement.OriginRow);
+        Assert.AreEqual(0, observation.CursorX);
+        Assert.AreEqual(6, observation.CursorY);
+        Assert.IsTrue(observation.OccupiedRows.All(row => row.Row is >= 2 and <= 6));
+    }
+
+    [TestMethod]
+    public async Task ProcessSixelData_TallerThanTheRegion_ClipsInsteadOfEscapingTheMargins()
+    {
+        await using var terminal = SixelTestTerminal.Create(
+            width: 20,
+            height: 10,
+            cellMetrics: Metrics(10, 20));
+
+        var observation = await RunAsync(
+            terminal,
+            Graphic(10, 200, "\x1b[3;6r\x1b[4;1H"),
+            TestContext.Current.CancellationToken);
+
+        var placement = TestSeq.Single(observation.Placements);
+
+        // The placement keeps the full source geometry; only the painted cells are
+        // clipped, so the raster is never corrupted by the margins.
+        Assert.AreEqual(10, placement.HeightInCells);
+        Assert.IsTrue(observation.OccupiedRows.All(row => row.Row is >= 2 and <= 5));
+        Assert.AreEqual(5, observation.CursorY);
+    }
+
+    [TestMethod]
+    public async Task ProcessSixelData_WithLeftRightMargins_ClipsHorizontally()
+    {
+        await using var terminal = SixelTestTerminal.Create(
+            width: 20,
+            height: 10,
+            cellMetrics: Metrics(10, 20));
+
+        var observation = await RunAsync(
+            terminal,
+            Graphic(120, 20, "\x1b[?69h\x1b[3;8s\x1b[1;3H"),
+            TestContext.Current.CancellationToken);
+
+        var placement = TestSeq.Single(observation.Placements);
+        Assert.AreEqual(12, placement.WidthInCells);
+        Assert.IsTrue(observation.OccupiedCells.All(cell => cell.Column is >= 2 and <= 7));
+    }
+
+    [TestMethod]
+    public async Task ProcessSixelData_ExceedingTheViewport_ClipsToTheVisibleCells()
+    {
+        await using var terminal = SixelTestTerminal.Create(
+            width: 8,
+            height: 6,
+            cellMetrics: Metrics(10, 20));
+
+        var observation = await RunAsync(
+            terminal,
+            Graphic(200, 200, "\x1b[1;1H"),
+            TestContext.Current.CancellationToken);
+
+        var placement = TestSeq.Single(observation.Placements);
+        Assert.AreEqual(20, placement.WidthInCells);
+        Assert.AreEqual(10, placement.HeightInCells);
+        Assert.IsTrue(observation.OccupiedCells.All(cell => cell.Column < 8 && cell.Row < 6));
+        Assert.AreEqual(5, observation.CursorY);
+    }
+
+    [TestMethod]
+    public async Task ProcessSixelData_OriginModeWithMargins_AnchorsRelativeToTheRegion()
+    {
+        await using var terminal = SixelTestTerminal.Create(
+            width: 20,
+            height: 12,
+            cellMetrics: Metrics(10, 20));
+
+        var observation = await RunAsync(
+            terminal,
+            Graphic(10, 20, "\x1b[?69h\x1b[4;12s\x1b[3;9r\x1b[?6h\x1b[1;1H"),
+            TestContext.Current.CancellationToken);
+
+        var placement = TestSeq.Single(observation.Placements);
+        Assert.AreEqual(3, placement.OriginColumn);
+        Assert.AreEqual(2, placement.OriginRow);
+        Assert.AreEqual(3, observation.CursorY);
+    }
+
+    [TestMethod]
+    public async Task ProcessSixelData_FollowedByText_WritesAtTheReportedCursor()
+    {
+        await using var terminal = SixelTestTerminal.Create(cellMetrics: Metrics(10, 20));
+
+        await terminal.FeedAsync(
+            Graphic(20, 40, "\x1b[2;3H"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "graphic",
+            TestContext.Current.CancellationToken);
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("ok"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.GetLine(3).Contains("ok", StringComparison.Ordinal),
+            "text after graphic",
+            TestContext.Current.CancellationToken);
+
+        var observation = terminal.Observe();
+        Assert.StartsWith("  ok", observation.Lines[3]);
+        Assert.AreEqual(4, observation.CursorX);
+        Assert.AreEqual(3, observation.CursorY);
+    }
+
+    [TestMethod]
+    [DataRow("\r", 0, 3)]
+    [DataRow("\n", 2, 4)]
+    [DataRow("\x1b[1;1H", 0, 0)]
+    public async Task ProcessSixelData_FollowedByCursorControl_AppliesFromTheFinalPosition(
+        string suffix,
+        int expectedCursorX,
+        int expectedCursorY)
+    {
+        await using var terminal = SixelTestTerminal.Create(cellMetrics: Metrics(10, 20));
+
+        var bytes = Graphic(20, 40, "\x1b[2;3H")
+            .Concat(Encoding.ASCII.GetBytes(suffix))
+            .ToArray();
+        var observation = await RunAsync(terminal, bytes, TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(expectedCursorX, observation.CursorX);
+        Assert.AreEqual(expectedCursorY, observation.CursorY);
+    }
+
+    [TestMethod]
+    public async Task ProcessSixelData_FollowedByAnotherSixel_StacksBelowTheFirst()
+    {
+        await using var terminal = SixelTestTerminal.Create(cellMetrics: Metrics(10, 20));
+
+        var bytes = Graphic(20, 40, "\x1b[2;3H")
+            .Concat(Graphic(30, 20))
+            .ToArray();
+        var observation = await RunAsync(terminal, bytes, TestContext.Current.CancellationToken);
+
+        Assert.HasCount(2, observation.Placements);
+        var first = observation.Placements.First(p => p.OriginRow == 1);
+        var second = observation.Placements.First(p => p.OriginRow == 3);
+        Assert.AreEqual(2, first.OriginColumn);
+        Assert.AreEqual(2, second.OriginColumn);
+        Assert.AreEqual(4, observation.CursorY);
+    }
+
+    [TestMethod]
+    public async Task ProcessSixelData_AfterAPendingWrap_ClearsTheDeferredWrap()
+    {
+        await using var terminal = SixelTestTerminal.Create(
+            width: 4,
+            height: 6,
+            cellMetrics: Metrics(10, 20));
+
+        // Fill the row so the cursor is parked in the deferred-wrap state.
+        var bytes = Encoding.ASCII.GetBytes("\x1b[1;1Habcd")
+            .Concat(Graphic(10, 20))
+            .ToArray();
+        var observation = await RunAsync(terminal, bytes, TestContext.Current.CancellationToken);
+
+        var placement = TestSeq.Single(observation.Placements);
+        Assert.AreEqual(3, placement.OriginColumn);
+        Assert.AreEqual(3, observation.CursorX);
+        Assert.AreEqual(1, observation.CursorY);
+    }
+
+    [TestMethod]
+    [DataRow("\x1b[?80l", "\x1b[!p")]
+    [DataRow("\x1b[?8452h", "\x1b[!p")]
+    public async Task SoftReset_AfterChangingSixelModes_RestoresTheDefaults(
+        string modeChange,
+        string reset)
+    {
+        await using var terminal = SixelTestTerminal.Create(cellMetrics: Metrics(10, 20));
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes(modeChange + reset),
+            cancellationToken: TestContext.Current.CancellationToken);
+        var observation = await RunAsync(
+            terminal,
+            Graphic(20, 40, "\x1b[2;3H"),
+            TestContext.Current.CancellationToken);
+
+        Assert.IsTrue(terminal.Terminal.SixelScrollingModeEnabled);
+        Assert.IsFalse(terminal.Terminal.SixelCursorToRightModeEnabled);
+        Assert.AreEqual(2, TestSeq.Single(observation.Placements).OriginColumn);
+        Assert.AreEqual(2, observation.CursorX);
+        Assert.AreEqual(3, observation.CursorY);
+    }
+
+    [TestMethod]
+    public async Task Ris_AfterChangingSixelModes_RestoresTheDefaults()
+    {
+        await using var terminal = SixelTestTerminal.Create(cellMetrics: Metrics(10, 20));
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[?80l\x1b[?8452h"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.FeedPreTokenizedAsync(
+            Encoding.ASCII.GetBytes("\x1bc"),
+            [Hex1b.Tokens.RisToken.Instance],
+            TestContext.Current.CancellationToken);
+
+        // Feeding a graphic afterwards proves the reset reached the model before
+        // the next sequence was interpreted.
+        var observation = await RunAsync(
+            terminal,
+            Graphic(20, 40, "\x1b[2;3H"),
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(2, TestSeq.Single(observation.Placements).OriginColumn);
+        Assert.AreEqual(2, observation.CursorX);
+        Assert.IsTrue(terminal.Terminal.SixelScrollingModeEnabled);
+        Assert.IsFalse(terminal.Terminal.SixelCursorToRightModeEnabled);
+    }
+
+    [TestMethod]
+    public void ResolveSixelScrolling_DecPolarity_SetEnablesScrolling()
+    {
+        var policy = SixelCompatibilityPolicy.Default;
+
+        Assert.AreEqual(SixelDecsdmPolarity.Dec, policy.DecsdmPolarity);
+        Assert.IsTrue(policy.ResolveSixelScrolling(decsdmEnabled: true));
+        Assert.IsFalse(policy.ResolveSixelScrolling(decsdmEnabled: false));
+    }
+
+    [TestMethod]
+    public void ResolveSixelScrolling_XtermPolarity_InvertsSetAndReset()
+    {
+        var policy = SixelCompatibilityPolicy.Default with
+        {
+            DecsdmPolarity = SixelDecsdmPolarity.Xterm,
+        };
+
+        Assert.IsFalse(policy.ResolveSixelScrolling(decsdmEnabled: true));
+        Assert.IsTrue(policy.ResolveSixelScrolling(decsdmEnabled: false));
+    }
+}

--- a/tests/Hex1b.Tests/Sixel/SixelEmitterCursorTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelEmitterCursorTests.cs
@@ -1,0 +1,106 @@
+using Hex1b.Surfaces;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests.Sixel;
+
+/// <summary>
+/// Covers Hex1b's emitter direction: when Hex1b writes managed output that follows
+/// a Sixel image, it must reposition the cursor explicitly instead of relying on
+/// the upstream terminal's post-Sixel cursor behavior.
+/// </summary>
+/// <remarks>
+/// This is the mirror image of <c>SixelCursorSemanticsTests</c>, which covers how
+/// <c>Hex1bTerminal</c> interprets an incoming Sixel sequence.
+/// </remarks>
+[TestClass]
+public class SixelEmitterCursorTests
+{
+    private const string Payload = "\x1bP7q#1;2;100;0;0#1~\x1b\\";
+
+    private static SurfaceCell SixelCell(int widthInCells, int heightInCells) =>
+        new(
+            " ",
+            null,
+            null,
+            Sixel: new TrackedObject<SixelData>(
+                new SixelData(Payload, widthInCells, heightInCells, [1, 2, 3]),
+                _ => { }));
+
+    [TestMethod]
+    public void ToTokens_TextAfterSixel_EmitsAnExplicitCursorPosition()
+    {
+        var previous = new Surface(10, 3);
+        var current = new Surface(10, 3);
+        current[0, 0] = SixelCell(2, 1);
+        current[4, 0] = new SurfaceCell("X", null, null);
+
+        var diff = SurfaceComparer.Compare(previous, current);
+        var tokens = SurfaceComparer.ToTokens(diff, current).ToList();
+
+        var sixelIndex = IndexOfSixel(tokens);
+        var textIndex = IndexOf(tokens, token => token is TextToken text && text.Text.Contains('X'));
+        Assert.IsGreaterThanOrEqualTo(0, sixelIndex);
+        Assert.IsGreaterThan(sixelIndex, textIndex);
+        Assert.IsTrue(
+            tokens.Skip(sixelIndex + 1).Take(textIndex - sixelIndex - 1).OfType<CursorPositionToken>().Any(),
+            "Managed output after a Sixel image must reposition the cursor explicitly.");
+    }
+
+    [TestMethod]
+    public void ToTokens_SixelPlacement_IsPrecededByAnExplicitCursorPosition()
+    {
+        var previous = new Surface(10, 3);
+        var current = new Surface(10, 3);
+        current[3, 1] = SixelCell(2, 1);
+
+        var diff = SurfaceComparer.Compare(previous, current);
+        var tokens = SurfaceComparer.ToTokens(diff, current).ToList();
+
+        var sixelIndex = IndexOfSixel(tokens);
+        Assert.IsGreaterThanOrEqualTo(0, sixelIndex);
+
+        var position = tokens.Take(sixelIndex).OfType<CursorPositionToken>().LastOrDefault();
+        Assert.IsNotNull(position);
+        Assert.AreEqual(2, position.Row);
+        Assert.AreEqual(4, position.Column);
+    }
+
+    [TestMethod]
+    public void SixelFragmentsToTokens_EveryFragment_IsPrecededByAnExplicitCursorPosition()
+    {
+        var surface = new Surface(10, 4);
+        surface[1, 1] = SixelCell(2, 2);
+        var composite = new CompositeSurface(10, 4);
+        composite.AddLayer(surface, 0, 0);
+
+        var tokens = SurfaceComparer.SixelFragmentsToTokens(composite);
+
+        for (var i = 0; i < tokens.Count; i++)
+        {
+            if (tokens[i] is UnrecognizedSequenceToken raw && raw.Sequence.StartsWith("\x1bP", StringComparison.Ordinal))
+            {
+                Assert.IsGreaterThan(0, i);
+                TestSeq.IsType<CursorPositionToken>(tokens[i - 1]);
+            }
+        }
+    }
+
+    private static int IndexOfSixel(IReadOnlyList<AnsiToken> tokens) => IndexOf(tokens, IsSixel);
+
+    private static bool IsSixel(AnsiToken token) =>
+        token is UnrecognizedSequenceToken raw &&
+        raw.Sequence.StartsWith("\x1bP", StringComparison.Ordinal);
+
+    private static int IndexOf(IReadOnlyList<AnsiToken> tokens, Func<AnsiToken, bool> predicate)
+    {
+        for (var i = 0; i < tokens.Count; i++)
+        {
+            if (predicate(tokens[i]))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+}

--- a/tests/Hex1b.Tests/Sixel/SixelTerminalSemanticsTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelTerminalSemanticsTests.cs
@@ -9,7 +9,7 @@ public class SixelTerminalSemanticsTests
         "single-band",
         "One-band cursor and lifecycle probe.");
 
-    [TestMethod, Ignore("Owned by #450: DECSDM and xterm mode 8452 are not modeled yet.")]
+    [TestMethod]
     public async Task DecsdmEnabled_SequenceEndsWithCursorBelowGraphic()
     {
         await using var terminal = SixelTestTerminal.Create();
@@ -24,11 +24,20 @@ public class SixelTerminalSemanticsTests
             TestContext.Current.CancellationToken);
 
         var observation = terminal.Observe();
+        var placement = TestSeq.Single(observation.Placements);
+
+        // The fixture omits P1, so the default 2:1 aspect renders one six-pixel
+        // band as twelve device pixels — two rows at the harness's six-pixel cells.
+        Assert.AreEqual(2, placement.OriginRow);
+        Assert.AreEqual(2, placement.HeightInCells);
+
+        // Mode 8452 is reset, so the cursor returns to the column the sequence
+        // started in, one row below the last row the graphic occupies.
         Assert.AreEqual(3, observation.CursorX);
-        Assert.AreEqual(3, observation.CursorY);
+        Assert.AreEqual(placement.OriginRow + placement.HeightInCells, observation.CursorY);
     }
 
-    [TestMethod, Ignore("Owned by #450: Sixel placement does not yet honor horizontal margins and origin mode.")]
+    [TestMethod]
     public async Task OriginMode_WithMargins_AnchorsGraphicAtMarginRelativeCursor()
     {
         await using var terminal = SixelTestTerminal.Create(width: 12, height: 8);

--- a/tests/Hex1b.Tests/Sixel/SixelTestTerminal.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelTestTerminal.cs
@@ -4,6 +4,7 @@ using System.Threading.Channels;
 using Hex1b.Automation;
 using Hex1b.Diagnostics;
 using Hex1b.Reflow;
+using Hex1b.Sixel;
 using Hex1b.Surfaces;
 using Hex1b.Tokens;
 
@@ -27,7 +28,8 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
         Hex1bMetrics? metrics,
         IHex1bTerminalWorkloadFilter? workloadFilter,
         IHex1bTerminalPresentationFilter? presentationFilter,
-        bool impactAware)
+        bool impactAware,
+        SixelCellMetrics? cellMetrics)
     {
         var capabilities = new TerminalCapabilities
         {
@@ -61,6 +63,14 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
         }
 
         Terminal = new Hex1bTerminal(options);
+
+        // Real presentation probing is owned by #455; tests inject protocol cell
+        // metrics directly through the same seam an adapter would use.
+        if (cellMetrics is { } injected)
+        {
+            Terminal.SetSixelCellMetrics(injected);
+        }
+
         _runTask = Terminal.RunAsync(_runCancellation.Token);
     }
 
@@ -79,7 +89,8 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
         Hex1bMetrics? metrics = null,
         IHex1bTerminalWorkloadFilter? workloadFilter = null,
         IHex1bTerminalPresentationFilter? presentationFilter = null,
-        bool impactAware = false)
+        bool impactAware = false,
+        SixelCellMetrics? cellMetrics = null)
         => new(
             width,
             height,
@@ -91,7 +102,8 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
             metrics,
             workloadFilter,
             presentationFilter,
-            impactAware);
+            impactAware,
+            cellMetrics);
 
     public async Task FeedAsync(
         ReadOnlyMemory<byte> bytes,
@@ -189,7 +201,8 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
                     pixels?.Width ?? 0,
                     pixels?.Height ?? 0,
                     pixels is null ? "" : SixelPixelGrid.Format(pixels),
-                    pixels));
+                    pixels,
+                    sixel.CellMetrics));
             }
         }
 
@@ -568,7 +581,8 @@ internal sealed record SixelPlacementObservation(
     int PixelWidth,
     int PixelHeight,
     string PixelGrid,
-    SixelPixelBuffer? Pixels);
+    SixelPixelBuffer? Pixels,
+    SixelCellMetrics CellMetrics);
 
 internal sealed record SixelOccupiedRow(int Row, bool InScrollback);
 


### PR DESCRIPTION
Closes #450. Stage 5 of the terminal-first Sixel roadmap in #445, following #459 (behavior contract), #461 (grammar parser), and #462 (rasterizer).

## What this implements

**Cursor semantics.** Three cursor concepts stay distinct: the Sixel graphics cursor (inside `SixelParser`/`SixelRasterizer`, never escapes), the anchor (the text cursor when the DCS started), and the final text cursor. A completed sequence now resolves against the terminal model in `ProcessSixelData` → `ResolveSixelPlacement` → `ApplyPostSixelCursor`, covering ordinary completion, one-row, multi-row, and partial-final-band images, declared-extent-but-unpainted graphics, graphics larger than the viewport, completion at or below the bottom margin, and follow-up text, CR, LF, CUP, or another Sixel. Completion also clears any deferred wrap, like a line feed.

**Modes.** DECSDM private mode 80 and xterm private mode 8452, both reset to defaults by RIS and by a new DECSTR (`CSI ! p`) token. DECSTR is deliberately mode-only here: it preserves the palette, placements, screen, and cursor position, so it does not intrude on #453.

**Margins and origin.** DECSTBM drives the anchor, the scroll amount, and top/bottom clipping. DECSLRM under DECLRMM drives left/right clipping. DECOM is honoured through the existing cursor plumbing. Clipping never mutates raster data: the placement always records its *unclipped* cell geometry and only the paint loop is clipped.

**Metrics.** New `SixelCellMetrics(double Width, double Height, SixelCellMetricsSource Source, SixelCellMetricsReliability Reliability)` with `Direct`/`Csi16`/`Osc1337`/`Derived`/`Assumed` sources and `Authoritative`/`Derived`/`Estimated` reliability. Fractional by construction, captured once at placement creation, recorded on `SixelData`, and converted to occupancy with `ceil(renderedPixelWidth / cellWidth)` and `ceil(renderedPixelHeight / cellHeight)`. All `internal`; the test project already has `InternalsVisibleTo`. `EstimateSixelDimensions` was already gone and stays gone.

**Emitter independence.** Hex1b-as-emitter already emitted CUP around inline Sixel in `SurfaceComparer`; the rationale is now documented there and locked down by regression tests, so the behavior cannot silently regress into trusting an upstream terminal's post-Sixel cursor. This direction of data flow is kept conceptually separate from the terminal-model side above.

## Design decisions

**DECSDM polarity — the task brief and the doc disagreed; the doc wins.** The brief stated `?80h` = display/non-scrolling. `docs/sixel-terminal-behavior.md` states the opposite (`?80h` = scrolling enabled, `?80l` = non-scrolling/graphics-page origin), citing the VT340 manual and foot's post-hardware-testing change. Per the brief's own instruction to implement exactly what the doc specifies, this PR implements the doc's DEC polarity. The xterm inversion lives in `SixelCompatibilityPolicy.DecsdmPolarity` / `ResolveSixelScrolling`, not in terminal detection — profile *selection* stays a #457 target.

**`LogicalCanvasExtent` is already aspect-scaled.** `SixelParser` scales row geometry by the aspect ratio, so the parser's logical canvas extent *is* the rendered extent. No `MeasureExtents` wrapper on the rasterizer was needed, and no raster logic is re-implemented.

**Corrected a stale expectation.** `DecsdmEnabled_SequenceEndsWithCursorBelowGraphic` (previously `[Ignore]`d) expected a one-row graphic. Its shared fixture omits P1, so the DEC 2:1 default aspect renders one band as 12 device pixels = 2 rows at the harness's 6px cells. The test now asserts `HeightInCells == 2` and `CursorY == OriginRow + HeightInCells`. This is a pre-#461/#462 expectation being corrected, not a behavior change.

**Scroll amount includes the cursor row.** `overflow = originRow + rows - clipBottom` deliberately counts the cursor's landing row, so the graphic and the cursor scroll in one step rather than the cursor landing on the graphic's last row.

**Mode save/restore is not implemented.** `CSI ? Pm s` / `CSI ? Pm r` do not exist anywhere in Hex1b today, so there is no machinery to extend, and the brief forbids inventing a new mode subsystem. Recorded as unresolved in the doc.

## Test evidence

```
$ dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj -v q -- --filter "FullyQualifiedName~Hex1b.Tests.Sixel."
total: 291   succeeded: 283   failed: 0   skipped: 8

$ dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj -v q
Test run summary: Passed!
total: 8932   succeeded: 8900   failed: 0   skipped: 32   duration: 1m 16s
```

New coverage: `SixelCursorSemanticsTests` (44 cases — metrics parameterized over 9x20, 10x20, 8x16, 12x24, 7.5x16.5, and 9.6x20.4 with extents one below / exactly at / one above a cell boundary; plus placement, scrolling, clipping, origin mode, follow-up sequences, and reset behavior) and `SixelEmitterCursorTests` (3 cases). The two `[Ignore("Owned by #450")]` tests in `SixelTerminalSemanticsTests` are now live; the remaining `[Ignore]`s there are #453-owned and untouched.

`dotnet build` is clean with `TreatWarningsAsErrors=true` for `src/Hex1b`, `src/Hex1b.Analyzers`, `tests/Hex1b.Analyzers.Tests`, and every sample except `BlazorDemo`, `BlazorPerfStressDemo`, and `WasmDemo`, which fail on this machine with `NETSDK1147: workloads must be installed: wasm-tools` — a pre-existing environment gap unrelated to this change.

## Demo evidence

Six hand-authored raw DCS scenes in `samples/SixelTerminalDemo/RawCursorScenes.cs` (no `SixelWidget`, no encoder), wired into the existing scene list so `--scene` and `--headless` both work.

```
$ dotnet run --project samples/SixelTerminalDemo -- --headless
Cursor, DECSDM, and margin scenes:
  Cursor scrolling mode: (4,2) 4x3 cells, painted columns 4-7, painted rows 2-4, cursor (45, 5)
  Cursor non-scrolling mode: (0,0) 4x3 cells, painted columns 0-3, painted rows 0-2, cursor (40, 5)
  Cursor mode 8452: (4,2) 4x3 cells, painted columns 4-7, painted rows 2-4, cursor (50, 5)
  Margin clipping: (9,3) 20x2 cells, painted columns 9-24, painted rows 3-4, cursor (16, 5)
  Bottom margin completion: (2,10) 4x3 cells, painted columns 2-5, painted rows 10-12, cursor (36, 13)
  Explicit repositioning: (4,17) 4x3 cells, painted columns 4-7, painted rows 17-19, cursor (60, 19)
```

Reading those: scrolling mode anchors at (4,2) and returns the cursor to column 4 one row below the 3-row graphic, where the 41-character probe ends at column 45. Non-scrolling mode paints at the page origin and leaves the cursor exactly where it was at (19,5), where its 21-character probe ends at column 40. Mode 8452 puts the cursor to the right of the graphic instead. Margin clipping keeps the placement's full 20-cell width while painting only columns 9-24. Bottom-margin completion scrolls the 10-14 region so the graphic and cursor both stay inside it. The last scene shows managed output positioning explicitly with CUP after a graphic. Interactive mode was not run here because this environment has no Sixel-capable TTY.

## Deferred

- Persistent scrollback placement ownership, reflow, history eviction, and row-lineage anchoring — #451 / #452 / #453
- RIS palette and placement destruction — #453
- Real presentation capability probing (DA2, XTGETTCAP, OSC 1337) — #455. Metrics are injectable for tests only.
- Reference-terminal profile selection and validation, including which DECSDM polarity a given terminal picks — #457
- Widget layout and requested image sizing — unchanged
- Private-mode save/restore for modes 80 and 8452 — no existing machinery; recorded as unresolved in the doc

## Open questions

1. Is adding DECSTR in this stage acceptable? It was needed to reset mode state, and it is scoped to modes only.
2. Is the corrected `DecsdmEnabled_SequenceEndsWithCursorBelowGraphic` expectation (2 rows, not 1) agreed?
3. `SixelCompatibilityPolicy` is not reachable from `Hex1bTerminalOptions` today, so the xterm polarity knob is unit-tested on the policy object rather than end-to-end. Wiring policy through the builder feels like it belongs to #457 — confirm?
