### PR TITLE
Add independent Sixel raster storage and placement state

### DIFF
--- a/docs/sixel-terminal-behavior.md
+++ b/docs/sixel-terminal-behavior.md
@@ -377,10 +377,13 @@ dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj \
 
 The terminal-first demo sends independently authored raw Sixel bytes through
 `Hex1bTerminal`. It does not use `SixelWidget` or `SixelEncoder`.
-`samples/SixelTerminalDemo/RawSixelFixtures.cs` includes scenes demonstrating
-#451's independent placement ownership: two placements sharing identical raster
-content, overlapping placements that both survive, main/alternate screen
-isolation, and geometry-only placement retention.
+`samples/SixelTerminalDemo/RawGraphicsStateScenes.cs` includes scenes
+demonstrating #451's independent placement ownership: two placements sharing
+identical raster content, overlapping placements that both survive,
+main/alternate screen isolation, and geometry-only placement retention. The
+shared-raster scene separates its two placements by row because native Sixel
+renderers do not all preserve multiple same-row graphics consistently; the
+overlap scene covers same-row ordering as a deliberate, separate contract.
 
 The demo presents one subject per screen. Each screen clears the display, resets
 margins, origin mode, and DECSDM so it cannot inherit state from the screen

--- a/docs/sixel-terminal-behavior.md
+++ b/docs/sixel-terminal-behavior.md
@@ -2,6 +2,7 @@
 
 > **Status**: Evolving contract for [#445](https://github.com/mitchdenny/hex1b/issues/445)
 > **First executable stage**: [#448](https://github.com/mitchdenny/hex1b/issues/448)
+> **Independent graphics state**: [#451](https://github.com/mitchdenny/hex1b/issues/451)
 > **Baseline**: DEC VT340
 
 ## Purpose
@@ -28,7 +29,7 @@ Ignored tests name the later issue that owns the missing behavior.
 | Native presentation | Forward bytes immediately and exactly | A capable terminal must receive the application's original sequence |
 | Parsing | Recognize Sixel only when the DCS final byte is `q` | Other DCS protocols must remain independently dispatchable |
 | Palette | Shared registers persist between images | Matches DEC and the prevailing modern default |
-| Graphics state | Own placements independently of text cells | Required for overlap, screen ownership, scrolling, resize, and reflow |
+| Graphics state | Own placements independently of text cells | Required for overlap, screen ownership, scrolling, resize, and reflow — implemented by [#451](https://github.com/mitchdenny/hex1b/issues/451) |
 | Compatibility | Central policy/profile, never terminal-name checks | Keeps deviations reviewable and testable |
 
 ## Framing and dispatch
@@ -234,25 +235,103 @@ CUP before writing anything that follows.
 
 | Operation | Selected Hex1b behavior | Unresolved details |
 |---|---|---|
-| Sixel over Sixel | Composite painted pixels over existing graphics; transparent holes preserve prior content | Alpha/compositing details across xterm, Windows Terminal, WezTerm, mintty, and xterm.js need #457 testing |
-| Text over Sixel | Damage only the pixels covered by newly written text cells | Exact behavior for wide/combining cells needs implementation tests |
-| ED/EL | Erase graphics in the affected cell/pixel region along with text | Boundary behavior at partially covered cells needs #457 testing |
-| Scroll-region operations | Move, clip, or erase placements using the same region semantics as text rows | Owned by #452/#453 |
-| RIS | Clear all placements and reset Sixel modes and palette | Owned by #453 |
+| Sixel over Sixel | Both placements are retained independently; composite painted pixels over existing graphics for presentation, and transparent holes preserve prior content | Alpha/compositing details across xterm, Windows Terminal, WezTerm, mintty, and xterm.js need #457 testing; destructive pixel-level compositing for rendering is owned by [#453](https://github.com/mitchdenny/hex1b/issues/453) |
+| Text over Sixel | Damage only the pixels covered by newly written text cells | Owned by [#453](https://github.com/mitchdenny/hex1b/issues/453); exact behavior for wide/combining cells needs implementation tests |
+| ED/EL | Erase graphics in the affected cell/pixel region along with text | Whole-screen ED (`CSI 2 J`) already clears every placement anchored to the active screen as of #451; sub-region (EL, partial ED) boundary behavior at partially covered cells is owned by [#453](https://github.com/mitchdenny/hex1b/issues/453) and needs #457 testing |
+| Scroll-region operations | Move, clip, or erase placements using the same region semantics as text rows | Full-fidelity scrolling/reflow projection across the scrollback boundary is owned by #452; #451 already shifts, drops, or moves whole placements for simple full-screen scrolls |
+| RIS | Clear all placements and reset Sixel modes and palette | Implemented by #451 (both main and alternate graphics state are cleared) |
 | DECSTR | Reset modes, including DECSDM and mode 8452; preserve palette, placements, and cursor position | Placement behavior remains unresolved |
 
 Foot has the clearest reviewed prior art for compositing independent placements.
 Hex1b's existing KGP graphics state provides the closest internal model. Sixel
 must not remain represented only by references attached to text cells.
 
+## Independent graphics state (#451)
+
+[#451](https://github.com/mitchdenny/hex1b/issues/451) replaces the earlier
+per-cell ownership model — a `CellAttributes.Sixel` flag plus origin and
+continuation cells that acted as reference-counted anchors for a
+`TrackedObjectStore`-managed `SixelData` — with `SixelGraphicsState`, an
+internal type family in `src/Hex1b/Sixel/` modeled after the mature
+`KgpTerminalGraphicsState` (see `src/Hex1b/Kgp/`) but deliberately smaller and
+protocol-neutral:
+
+- `SixelGraphicsState` owns two independent `SixelScreenGraphicsState`
+  instances (main and alternate). Re-entering the alternate screen while
+  already active resets only the alternate instance; RIS is the only
+  operation that clears both.
+- Each `SixelScreenGraphicsState` owns a `SixelImageStore` (the raster
+  resources, deduplicated by content hash — payload plus captured
+  background/palette identity), a live `Placements` list, and — main screen
+  only — a `HistoryPlacements` partition keyed by stable scrollback row
+  identity.
+- `SixelPlacement` anchors a `SixelData` image at a cell position and retains
+  the anchor/occupied cell span, the painted-crop geometry (offset and count,
+  relative to the anchor so scrolling can shift the anchor without recomputing
+  the crop), the creation-time write sequence used to order overlapping
+  placements, and creation timestamp. `SixelData` itself (unchanged from
+  earlier stages) carries the authoritative decoded raster or geometry-only
+  outcome, logical/rendered/declared/painted extents, creation-time
+  `SixelCellMetrics`, source and captured background, aspect state, a stable
+  content hash for dedup, and parser diagnostics.
+- **Lifetime is reachability-based, not manually reference-counted.** Mirroring
+  `KgpImageStore`, every placement-removing mutation recomputes the set of
+  content hashes reachable from `Placements ∪ HistoryPlacements` and sweeps any
+  image no longer in that set. A `SixelPlacement`'s image is never released
+  just because the text cell it was anchored to was overwritten — only when no
+  placement (live, historical, or held by an existing snapshot) references it
+  anymore. Snapshots decouple entirely: `Hex1bTerminalSnapshot` copies its own
+  `SixelPlacement`/`SixelData` references, kept alive by ordinary garbage
+  collection independent of the live store.
+- Geometry-only placements (the rasterizer refused pixel allocation) are
+  always retained as placements — never silently dropped — so their occupied
+  cell span and diagnostics remain inspectable.
+- A finalized Sixel sequence creates one anonymous image plus one placement
+  anchored at the position #450's cursor/metric logic already determines; this
+  stage reuses `SixelParser`/`SixelRasterizer` and that cursor logic unchanged
+  and does not duplicate any parsing, rasterization, or estimation logic.
+- `TrackedObjectStore` no longer participates in Sixel image lifetime at all;
+  it retains its unrelated duties (hyperlinks, and the Surface/widget path's
+  own use of `GetOrCreateSixel`, which is untouched by this stage).
+  Compatibility surfaces like `ContainsSixelData()`/`GetSixelDataAt()` are
+  preserved, now backed by the placement/image model.
+
+**Extracted from KGP as genuinely protocol-neutral primitives:** raster
+content ownership by content hash, placement/source-crop geometry (anchor +
+occupied span + painted crop), reachability-based lifetime accounting,
+screen/history partitioning, and simple scroll/clip geometry helpers. **Kept
+deliberately KGP-only, not extracted:** public image/placement IDs,
+image-number addressing, explicit delete selectors, relative placement
+graphs, Unicode placeholders, z-index, and chunked uploads — none of these
+concepts exist in the Sixel protocol. The two graphics states are separate
+types with no compile-time coupling; only the underlying *strategy* (mark and
+sweep over a screen/history partition) is shared conceptually. All existing
+KGP tests (state, deletion, scrolling/reflow, snapshot) continue to pass
+unmodified.
+
+**Explicitly deferred past this stage** (see the tables above and
+`tests/Hex1b.Tests/Sixel/SixelScrollingTests.cs` /
+`SixelTerminalSemanticsTests.cs` for the still-`[Ignore]`d placeholders that
+name them):
+
+- Full scrolling/reflow integration — projecting a single placement across
+  the visible/history boundary, and reflow-driven re-anchoring — [#452](https://github.com/mitchdenny/hex1b/issues/452).
+- Destructive overlap/erase semantics — partial text-over-graphic damage,
+  sub-region erase, and true pixel-level compositing of overlapping rasters
+  for rendering — [#453](https://github.com/mitchdenny/hex1b/issues/453).
+- Presentation protocol translation (re-emitting placements as Kitty/iTerm2/
+  Sixel wire protocol) — [#458](https://github.com/mitchdenny/hex1b/issues/458).
+- `SixelWidget`/`Surface`-produced Sixel and widget sizing changes are
+  untouched by this stage.
+
 ## Screens, scrollback, resize, and reflow
 
 | Area | Selected Hex1b contract | Status or unresolved work |
 |---|---|---|
-| Main/alternate screen | Each screen owns independent placements; leaving the alternate screen restores the unchanged main-screen graphics | [#453](https://github.com/mitchdenny/hex1b/issues/453) |
-| Scrollback | Scrolling placements remain anchored to logical row lineage and can span visible and history rows | [#452](https://github.com/mitchdenny/hex1b/issues/452); foot provides verified prior art |
-| History eviction | Remove only the placement portions no longer owned by retained row lineage | Exact partial-eviction policy needs #457 testing |
-| Resize | Clip to the viewport without destroying source pixels; reveal them again when space returns | [#452](https://github.com/mitchdenny/hex1b/issues/452) |
+| Main/alternate screen | Each screen owns independent placements; leaving the alternate screen restores the unchanged main-screen graphics | Implemented by [#451](https://github.com/mitchdenny/hex1b/issues/451) |
+| Scrollback | Scrolling placements remain anchored to logical row lineage and can span visible and history rows | [#452](https://github.com/mitchdenny/hex1b/issues/452); foot provides verified prior art. #451 moves whole placements between the live viewport and history when a full-screen scroll would fully carry them, but does not yet split a single placement across the boundary |
+| History eviction | Remove only the placement portions no longer owned by retained row lineage | [#452](https://github.com/mitchdenny/hex1b/issues/452); #451 releases an entire history-anchored placement when its row is pruned, without KGP's partial-crop/transfer-to-successor-row fidelity |
+| Resize | Clip to the viewport without destroying source pixels; reveal them again when space returns | Implemented by [#451](https://github.com/mitchdenny/hex1b/issues/451): a placement is dropped only once it is wholly outside the new bounds; a partially-visible placement keeps its full underlying raster and geometry, so it reappears in full when space returns. Full reflow re-anchoring remains [#452](https://github.com/mitchdenny/hex1b/issues/452) |
 | Reflow | Re-anchor through the same row-lineage plan as text and KGP placements | [#452](https://github.com/mitchdenny/hex1b/issues/452) |
 | Cell-metric change | Recompute occupied cells from stable pixel geometry using deterministic outward rounding | Reference-terminal behavior needs #457 testing |
 
@@ -274,7 +353,9 @@ reference-terminal evidence:
 3. DECGRA's undocumented carriage-return behavior and aspect-scaled DECGNL.
 4. Exact Sixel-over-Sixel compositing and partial-cell text/erase damage.
 5. DECSTR effects on placements.
-6. Main/alternate-screen, history eviction, resize, and reflow edge behavior.
+6. Full-fidelity scrolling/reflow projection across the scrollback boundary
+   (splitting a single placement between visible and history rows), and
+   partial-eviction of history-anchored placements.
 7. Private-mode save/restore (`CSI ? Pm s` and `CSI ? Pm r`) for Sixel modes.
 8. Exact default palette values for registers 16-255 and private-register
    behavior across modern terminals.
@@ -283,7 +364,11 @@ reference-terminal evidence:
 
 The test fixtures are small ASCII payloads embedded from
 `tests/Hex1b.Tests/TestData/Sixel/`. Expected data is independently authored and
-does not use `SixelEncoder`.
+does not use `SixelEncoder`. `tests/Hex1b.Tests/Sixel/SixelPlacementLifetimeTests.cs`
+is the dedicated regression suite for #451's independent placement/image
+storage and lifetime accounting (multi-cell spans, dedup, overlap, geometry-only
+retention, origin-cell overwrite, snapshot-held survival past active-screen
+removal, and main/alternate/RIS independence).
 
 ```bash
 dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj \
@@ -292,6 +377,10 @@ dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj \
 
 The terminal-first demo sends independently authored raw Sixel bytes through
 `Hex1bTerminal`. It does not use `SixelWidget` or `SixelEncoder`.
+`samples/SixelTerminalDemo/RawSixelFixtures.cs` includes scenes demonstrating
+#451's independent placement ownership: two placements sharing identical raster
+content, overlapping placements that both survive, main/alternate screen
+isolation, and geometry-only placement retention.
 
 The demo presents one subject per screen. Each screen clears the display, resets
 margins, origin mode, and DECSDM so it cannot inherit state from the screen

--- a/samples/SixelTerminalDemo/DemoScreens.cs
+++ b/samples/SixelTerminalDemo/DemoScreens.cs
@@ -11,12 +11,15 @@ internal static class DemoScreens
 {
     /// <summary>
     /// Builds every screen: the grammar and geometry fixtures first, then the
-    /// cursor, DECSDM, and margin scenes, then the transport scenes.
+    /// cursor, DECSDM, and margin scenes, then the graphics-state ownership
+    /// scenes, then the transport scenes.
     /// </summary>
     public static IReadOnlyList<DemoScreen> Build(
         IReadOnlyList<RawSixelFixture> fixtures,
         IReadOnlyList<string> modelDescriptions,
         IReadOnlyList<RawCursorScene> cursorScenes,
+        IReadOnlyList<RawGraphicsStateScene> graphicsStateScenes,
+        IReadOnlyList<string> graphicsStateObservations,
         bool includeTransportScenes)
     {
         var screens = new List<DemoScreen>();
@@ -51,6 +54,17 @@ internal static class DemoScreens
                 scene.Name,
                 scene.Expected,
                 scene.Bytes));
+        }
+
+        for (var index = 0; index < graphicsStateScenes.Count; index++)
+        {
+            var scene = graphicsStateScenes[index];
+            screens.Add(new DemoScreen(
+                number++,
+                scene.Name,
+                scene.Expected,
+                scene.Bytes,
+                Notes: [graphicsStateObservations[index]]));
         }
 
         if (!includeTransportScenes)

--- a/samples/SixelTerminalDemo/Program.cs
+++ b/samples/SixelTerminalDemo/Program.cs
@@ -19,7 +19,12 @@ var cursorScenes = sceneFilter is null
     : RawCursorScenes.All
         .Where(scene => scene.Name.Contains(sceneFilter, StringComparison.OrdinalIgnoreCase))
         .ToArray();
-if (fixtures.Count == 0 && cursorScenes.Count == 0)
+var graphicsStateScenes = sceneFilter is null
+    ? RawGraphicsStateScenes.All
+    : RawGraphicsStateScenes.All
+        .Where(scene => scene.Name.Contains(sceneFilter, StringComparison.OrdinalIgnoreCase))
+        .ToArray();
+if (fixtures.Count == 0 && cursorScenes.Count == 0 && graphicsStateScenes.Count == 0)
 {
     throw new ArgumentException($"No Sixel demo scene contains '{sceneFilter}'.", nameof(args));
 }
@@ -44,10 +49,18 @@ for (var index = 0; index < cursorScenes.Count; index++)
     cursorObservations[index] = await InspectCursorSceneAsync(cursorScenes[index]);
 }
 
+var graphicsStateObservations = new string[graphicsStateScenes.Count];
+for (var index = 0; index < graphicsStateScenes.Count; index++)
+{
+    graphicsStateObservations[index] = await InspectGraphicsStateSceneAsync(graphicsStateScenes[index]);
+}
+
 var allScreens = DemoScreens.Build(
     fixtures,
     modelDescriptions,
     cursorScenes,
+    graphicsStateScenes,
+    graphicsStateObservations,
     includeTransportScenes: sceneFilter is null);
 
 // --screen selects one numbered screen. The number keeps its original value so a
@@ -77,7 +90,9 @@ if (headless)
         fixtures,
         modelDescriptions,
         cursorScenes,
-        cursorObservations);
+        cursorObservations,
+        graphicsStateScenes,
+        graphicsStateObservations);
     return;
 }
 
@@ -101,7 +116,9 @@ static void WriteHeadlessTranscript(
     IReadOnlyList<RawSixelFixture> fixtures,
     IReadOnlyList<string> modelDescriptions,
     IReadOnlyList<RawCursorScene> cursorScenes,
-    IReadOnlyList<string> cursorObservations)
+    IReadOnlyList<string> cursorObservations,
+    IReadOnlyList<RawGraphicsStateScene> graphicsStateScenes,
+    IReadOnlyList<string> graphicsStateObservations)
 {
     Console.WriteLine($"Hex1b Sixel demo: {allScreens.Count} numbered screens.");
     Console.WriteLine("Run without --headless to page through them; --screen <number> opens one.");
@@ -126,6 +143,13 @@ static void WriteHeadlessTranscript(
     for (var index = 0; index < cursorScenes.Count; index++)
     {
         Console.WriteLine($"  {cursorScenes[index].Name}: {cursorObservations[index]}");
+    }
+
+    Console.WriteLine();
+    Console.WriteLine("Independent graphics-state ownership observations (#451):");
+    for (var index = 0; index < graphicsStateScenes.Count; index++)
+    {
+        Console.WriteLine($"  {graphicsStateScenes[index].Name}: {graphicsStateObservations[index]}");
     }
 }
 
@@ -167,21 +191,18 @@ static async Task<string> InspectCursorSceneAsync(RawCursorScene scene)
     var origins = new List<string>();
     var occupiedColumns = new SortedSet<int>();
     var occupiedRows = new SortedSet<int>();
-    for (var y = 0; y < snapshot.Height; y++)
+    foreach (var placement in snapshot.SixelPlacements)
     {
-        for (var x = 0; x < snapshot.Width; x++)
-        {
-            var cell = snapshot.GetCell(x, y);
-            if (!cell.IsSixel)
-                continue;
+        if (!placement.HasPaintedExtent)
+            continue;
 
-            occupiedColumns.Add(x);
+        for (var y = placement.PaintedTop; y <= placement.PaintedBottom; y++)
             occupiedRows.Add(y);
-            if (cell.SixelData is { } sixel)
-            {
-                origins.Add($"({x},{y}) {sixel.WidthInCells}x{sixel.HeightInCells} cells");
-            }
-        }
+        for (var x = placement.PaintedLeft; x <= placement.PaintedRight; x++)
+            occupiedColumns.Add(x);
+
+        origins.Add(
+            $"({placement.Column},{placement.Row}) {placement.Image.WidthInCells}x{placement.Image.HeightInCells} cells");
     }
 
     builder.Append(origins.Count == 0 ? "no placement" : string.Join("; ", origins));
@@ -193,6 +214,64 @@ static async Task<string> InspectCursorSceneAsync(RawCursorScene scene)
 
     builder.Append($", cursor ({snapshot.CursorX}, {snapshot.CursorY})");
     return builder.ToString();
+}
+
+static async Task<string> InspectGraphicsStateSceneAsync(RawGraphicsStateScene scene)
+{
+    var capabilities = new TerminalCapabilities
+    {
+        SupportsSixel = true,
+        SupportsTrueColor = true,
+        Supports256Colors = true,
+        CellPixelWidth = 10,
+        CellPixelHeight = 20,
+    };
+    var workload = new DemoWorkloadAdapter([scene.Bytes]);
+    await using var terminal = Hex1bTerminal.CreateBuilder()
+        .WithWorkload(workload)
+        .WithPresentation(new HeadlessPresentationAdapter(80, 24, capabilities))
+        .WithDimensions(80, 24)
+        .Build();
+    await terminal.RunAsync();
+
+    var builder = new StringBuilder();
+    builder.Append($"{terminal.SixelPlacementCount} placement(s) on the active screen, ");
+    builder.Append($"{terminal.TrackedSixelCount} distinct image(s)");
+
+    foreach (var placement in terminal.SixelPlacements)
+    {
+        builder.Append($"; ({placement.Column},{placement.Row}) {placement.WidthInCells}x{placement.HeightInCells} cells");
+        builder.Append(placement.IsGeometryOnly
+            ? " geometry-only"
+            : $" {DescribeSixelColor(placement.Image)}");
+    }
+
+    if (scene.Probes is { Count: > 0 } probes)
+    {
+        foreach (var probe in probes)
+        {
+            var resolved = terminal.GetSixelDataAt(probe.Column, probe.Row);
+            var description = resolved is null ? "no placement" : DescribeSixelColor(resolved);
+            builder.Append($"; probe ({probe.Column},{probe.Row}) [{probe.Label}] -> {description}");
+        }
+    }
+
+    return builder.ToString();
+}
+
+static string DescribeSixelColor(SixelData image)
+{
+    // Registers are defined with a fixed color per demo scene (see
+    // RawGraphicsStateScenes), so the payload text itself identifies which
+    // scripted square/band produced a given image without needing to decode
+    // the raster.
+    if (image.Payload.Contains("100;0;0"))
+        return "red";
+    if (image.Payload.Contains("0;100;0"))
+        return "green";
+    if (image.Payload.Contains("240;50;100"))
+        return "blue";
+    return "unrecognized color";
 }
 
 static async Task<string> InspectModelAsync(RawSixelFixture fixture)
@@ -223,16 +302,12 @@ static async Task<string> InspectModelAsync(RawSixelFixture fixture)
 
     using var snapshot = terminal.CreateSnapshot();
     SixelData? inspected = null;
-    for (var y = 0; y < snapshot.Height && inspected is null; y++)
+    foreach (var placement in snapshot.SixelPlacements)
     {
-        for (var x = 0; x < snapshot.Width; x++)
+        if (placement.Image.Payload == fixture.Payload)
         {
-            var sixel = snapshot.GetCell(x, y).SixelData;
-            if (sixel is not null && sixel.Payload == fixture.Payload)
-            {
-                inspected = sixel;
-                break;
-            }
+            inspected = placement.Image;
+            break;
         }
     }
 

--- a/samples/SixelTerminalDemo/RawCursorScenes.cs
+++ b/samples/SixelTerminalDemo/RawCursorScenes.cs
@@ -20,7 +20,14 @@ internal sealed record RawCursorScene(
     /// <summary>
     /// Restores every mode a scene may change, so scenes stay independent.
     /// </summary>
-    public const string ResetSequence = "\x1b[?80h\x1b[?8452l\x1b[?69l\x1b[r\x1b[?6l";
+    /// <remarks>
+    /// Exiting the alternate screen (mode 1049) is a no-op when a scene never
+    /// entered it, but is required so a graphics-state scene that
+    /// deliberately leaves the alternate screen active (see
+    /// <see cref="RawGraphicsStateScenes"/>) never leaks into the screen that
+    /// follows it.
+    /// </remarks>
+    public const string ResetSequence = "\x1b[?1049l\x1b[?80h\x1b[?8452l\x1b[?69l\x1b[r\x1b[?6l";
 
     /// <summary>
     /// Gets the scene without its trailing reset, so an inspection can observe the

--- a/samples/SixelTerminalDemo/RawGraphicsStateScenes.cs
+++ b/samples/SixelTerminalDemo/RawGraphicsStateScenes.cs
@@ -1,0 +1,106 @@
+using System.Text;
+
+/// <summary>
+/// A cell position an <see cref="RawGraphicsStateScene"/> wants inspected after
+/// its script runs, so the headless transcript can show exactly which raster
+/// (if any) a given cell resolves to.
+/// </summary>
+/// <param name="Column">Zero-based column to probe with <c>GetSixelDataAt</c>.</param>
+/// <param name="Row">Zero-based row to probe with <c>GetSixelDataAt</c>.</param>
+/// <param name="Label">What the probe is expected to show, for the transcript.</param>
+internal readonly record struct GraphicsStateProbe(int Column, int Row, string Label);
+
+/// <summary>
+/// A hand-authored scene that exercises Hex1b's independent Sixel raster
+/// storage and placement lifetime state (stage #451): every byte is written by
+/// hand, using raw CUP/DCS/alternate-screen control sequences with no
+/// <c>SixelWidget</c> or <c>SixelEncoder</c> involved, so the scene stays an
+/// independent contract probe of <c>SixelGraphicsState</c>.
+/// </summary>
+/// <param name="Name">The scene name, also used by <c>--scene</c>.</param>
+/// <param name="Expected">What the graphics-state model should retain.</param>
+/// <param name="Script">The complete raw byte script for the scene.</param>
+/// <param name="Probes">Cell positions to report via <c>GetSixelDataAt</c> after the script runs.</param>
+internal sealed record RawGraphicsStateScene(
+    string Name,
+    string Expected,
+    string Script,
+    IReadOnlyList<GraphicsStateProbe>? Probes = null)
+{
+    public byte[] Bytes => Encoding.ASCII.GetBytes(Script);
+}
+
+/// <summary>
+/// Scenes demonstrating the independent placement/image ownership introduced
+/// by stage #451: shared raster dedup, overlapping placements, geometry-only
+/// retention, origin-cell overwrite survival, and main/alternate screen
+/// isolation. See <c>tests/Hex1b.Tests/Sixel/SixelPlacementLifetimeTests.cs</c>
+/// for the equivalent assertions run against the terminal directly.
+/// </summary>
+internal static class RawGraphicsStateScenes
+{
+    // A solid square, aspect 1:1, so its declared and rendered geometry match
+    // exactly. Register 1 is defined fresh each time it appears so a scene
+    // never depends on palette state left behind by an earlier scene.
+    private static string RedSquare40 =>
+        "7;1q\"1;1;40;40#1;2;100;0;0#1!40~-!40~-!40~-!40~-!40~-!40~-!40~";
+
+    private static string GreenSquare40 =>
+        "7;1q\"1;1;40;40#2;2;0;100;0#2!40~-!40~-!40~-!40~-!40~-!40~-!40~";
+
+    private static string BlueSquare40 =>
+        "7;1q\"1;1;40;40#3;1;240;50;100#3!40~-!40~-!40~-!40~-!40~-!40~-!40~";
+
+    // Two cells wide (20px at a 10px cell) and one band tall, so a probe can
+    // overwrite the left cell's text glyph while the right cell keeps
+    // resolving to the same placement.
+    private const string RedTwoCellBand = "7;1q#1;2;100;0;0#1!20~";
+
+    // Declares an absurd canvas that exceeds the raster allocation policy, so
+    // geometry is recorded but no pixels are ever allocated.
+    private const string GeometryOnly =
+        "7;1q\"1;1;999999999;999999999#1;2;100;0;0#1!240~";
+
+    private static string Dcs(string payload) => $"\x1bP{payload}\x1b\\";
+    private static string Cup(int row, int column) => $"\x1b[{row};{column}H";
+    private const string EnterAlternateScreen = "\x1b[?1049h";
+    private const string ExitAlternateScreen = "\x1b[?1049l";
+
+    public static IReadOnlyList<RawGraphicsStateScene> All { get; } =
+    [
+        new(
+            "Graphics state: two placements share one raster image",
+            "two identical red #FF0000 squares (40x40px = 4x2 cells) at different\n  positions on screen. They are two independent placements backed by one\n  shared raster image (identical payload bytes deduplicate by content hash):\n  1 image, 2 placements",
+            Cup(2, 2) + Dcs(RedSquare40) + Cup(2, 30) + Dcs(RedSquare40)),
+        new(
+            "Graphics state: overlapping placements are both retained",
+            "a red #FF0000 square at column 2 and a green #00FF00 square at column 5,\n  overlapping by one cell. The overlap cell shows green (the later write wins\n  the query), but the red placement is not erased: it is still fully retained\n  and still resolves correctly outside the overlap",
+            Cup(2, 2) + Dcs(RedSquare40) + Cup(2, 5) + Dcs(GreenSquare40),
+            Probes:
+            [
+                new(2, 1, "red-only column: should resolve to the red placement"),
+                new(5, 1, "overlap column: should resolve to the green placement (written last)"),
+            ]),
+        new(
+            "Graphics state: geometry-only placement is retained, not dropped",
+            "nothing visible. The declared canvas is far larger than the raster\n  allocation policy allows, so no pixels are ever allocated, but the placement\n  itself is still retained (geometry-only), not silently discarded",
+            Cup(2, 2) + Dcs(GeometryOnly)),
+        new(
+            "Graphics state: origin cell overwrite does not release the image",
+            "a red #FF0000 two-cell band at row 2. The left cell is then overwritten\n  with the letter X. The image is still fully reachable afterwards: only the\n  left cell's text glyph changed, not the graphics ownership, so the right\n  cell still resolves to the same placement",
+            Cup(2, 2) + Dcs(RedTwoCellBand) + Cup(2, 2) + "X",
+            Probes: [new(2, 1, "right cell of the band: should still resolve to the placement")]),
+        new(
+            "Graphics state: alternate screen owns independent placements",
+            "a red #FF0000 square drawn on the main screen, then the alternate screen\n  is entered and a blue #0000FF square is drawn there instead. While the\n  alternate screen is active its graphics state holds only the blue square:\n  the red square belongs to the main screen and is not visible here",
+            Cup(2, 2) + Dcs(RedSquare40) + EnterAlternateScreen + Cup(2, 2) + Dcs(BlueSquare40)),
+        new(
+            "Graphics state: main screen survives an alternate-screen visit",
+            "the same red #FF0000 square as the previous screen, still on the main\n  screen after a full round trip through the alternate screen (where a blue\n  square was drawn and then left behind). The main screen's graphics were\n  never touched by what happened on the alternate screen",
+            Cup(2, 2) + Dcs(RedSquare40) + EnterAlternateScreen + Cup(2, 2) + Dcs(BlueSquare40) + ExitAlternateScreen),
+        new(
+            "Graphics state: repeated alternate-screen entry resets only the alternate state",
+            "nothing visible. The alternate screen is entered and a green #00FF00\n  square is drawn, then the alternate screen is entered again (already\n  active). Re-entry resets only the alternate graphics state, so the earlier\n  alternate placement is gone even though nothing here ever touched the main\n  screen",
+            Cup(2, 2) + Dcs(RedSquare40) + EnterAlternateScreen + Cup(2, 2) + Dcs(GreenSquare40) + EnterAlternateScreen),
+    ];
+}

--- a/samples/SixelTerminalDemo/RawGraphicsStateScenes.cs
+++ b/samples/SixelTerminalDemo/RawGraphicsStateScenes.cs
@@ -70,8 +70,8 @@ internal static class RawGraphicsStateScenes
     [
         new(
             "Graphics state: two placements share one raster image",
-            "two identical red #FF0000 squares (40x40px = 4x2 cells) at different\n  positions on screen. They are two independent placements backed by one\n  shared raster image (identical payload bytes deduplicate by content hash):\n  1 image, 2 placements",
-            Cup(2, 2) + Dcs(RedSquare40) + Cup(2, 30) + Dcs(RedSquare40)),
+            "two identical red #FF0000 squares (40x40px = 4x2 cells) at different\n  rows on screen. They are two independent placements backed by one shared\n  raster image (identical payload bytes deduplicate by content hash):\n  1 image, 2 placements. They are vertically separated because some native\n  Sixel renderers collapse or obscure multiple graphics that begin on the\n  same terminal row",
+            Cup(2, 2) + Dcs(RedSquare40) + Cup(8, 2) + Dcs(RedSquare40)),
         new(
             "Graphics state: overlapping placements are both retained",
             "a red #FF0000 square at column 2 and a green #00FF00 square at column 5,\n  overlapping by one cell. The overlap cell shows green (the later write wins\n  the query), but the red placement is not erased: it is still fully retained\n  and still resolves correctly outside the overlap",

--- a/src/Hex1b/Automation/Hex1bTerminalSnapshot.cs
+++ b/src/Hex1b/Automation/Hex1bTerminalSnapshot.cs
@@ -49,6 +49,8 @@ public sealed class Hex1bTerminalSnapshot : IHex1bTerminalRegion, IDisposable
         CellPixelHeight = state.CellPixelHeight;
         KgpPlacements = state.KgpPlacements;
         KgpImages = state.KgpImages;
+        SixelPlacements = state.SixelPlacements;
+        SixelImages = state.SixelImages;
 
         var scrollbackRows = state.ScrollbackRows;
         ScrollbackLineCount = scrollbackRows.Length;
@@ -238,6 +240,20 @@ public sealed class Hex1bTerminalSnapshot : IHex1bTerminalRegion, IDisposable
     /// </summary>
     public IReadOnlyDictionary<uint, KgpImageData> KgpImages { get; }
 
+    /// <summary>
+    /// Sixel placements visible in this snapshot, including any requested
+    /// scrollback rows. Internal test/inspection surface for stage #451; kept
+    /// internal rather than public until an external consumer need is
+    /// demonstrated (see the api-reviewer skill guidance).
+    /// </summary>
+    internal IReadOnlyList<SixelPlacement> SixelPlacements { get; }
+
+    /// <summary>
+    /// Sixel image data referenced by the visible snapshot placements, keyed
+    /// by content hash.
+    /// </summary>
+    internal IReadOnlyDictionary<byte[], SixelData> SixelImages { get; }
+
     /// <inheritdoc />
     public TerminalCell GetCell(int x, int y)
     {
@@ -247,17 +263,14 @@ public sealed class Hex1bTerminalSnapshot : IHex1bTerminalRegion, IDisposable
     }
 
     /// <summary>
-    /// Checks if any cell in the snapshot contains Sixel data.
+    /// Checks if any placement in the snapshot paints at least one cell.
     /// </summary>
     public bool ContainsSixelData()
     {
-        for (int y = 0; y < Height; y++)
+        foreach (var placement in SixelPlacements)
         {
-            for (int x = 0; x < Width; x++)
-            {
-                if (_cells[y, x].TrackedSixel is not null)
-                    return true;
-            }
+            if (placement.HasPaintedExtent)
+                return true;
         }
         return false;
     }
@@ -288,7 +301,6 @@ public sealed class Hex1bTerminalSnapshot : IHex1bTerminalRegion, IDisposable
         {
             for (int x = 0; x < Width; x++)
             {
-                _cells[y, x].TrackedSixel?.Release();
                 _cells[y, x].TrackedHyperlink?.Release();
             }
         }

--- a/src/Hex1b/Automation/Hex1bTerminalSnapshotState.cs
+++ b/src/Hex1b/Automation/Hex1bTerminalSnapshotState.cs
@@ -26,4 +26,6 @@ internal sealed record Hex1bTerminalSnapshotState(
     TerminalCell[,] ScreenBuffer,
     ScrollbackRow[] ScrollbackRows,
     IReadOnlyList<KgpPlacement> KgpPlacements,
-    IReadOnlyDictionary<uint, KgpImageData> KgpImages);
+    IReadOnlyDictionary<uint, KgpImageData> KgpImages,
+    IReadOnlyList<SixelPlacement> SixelPlacements,
+    IReadOnlyDictionary<byte[], SixelData> SixelImages);

--- a/src/Hex1b/Automation/TerminalRegionHtmlExtensions.cs
+++ b/src/Hex1b/Automation/TerminalRegionHtmlExtensions.cs
@@ -863,6 +863,26 @@ public static class TerminalRegionHtmlExtensions
     {
         var rows = new List<string>();
 
+        // Build a per-cell Sixel placement lookup up front (rather than
+        // reading per-cell attributes) so the JSON payload reflects the
+        // independent placement/image model. Only meaningful when exporting
+        // from a snapshot; other region kinds have no Sixel state to inspect.
+        var sixelByCell = new Dictionary<(int X, int Y), SixelPlacement>();
+        if (region is Hex1bTerminalSnapshot snapshot)
+        {
+            foreach (var placement in snapshot.SixelPlacements.OrderBy(p => p.Sequence))
+            {
+                if (!placement.HasPaintedExtent)
+                    continue;
+
+                for (var py = placement.PaintedTop; py <= placement.PaintedBottom; py++)
+                {
+                    for (var px = placement.PaintedLeft; px <= placement.PaintedRight; px++)
+                        sixelByCell[(px, py)] = placement; // later sequence overwrites earlier: topmost wins.
+                }
+            }
+        }
+
         for (int y = 0; y < region.Height; y++)
         {
             var cells = new List<string>();
@@ -894,10 +914,18 @@ public static class TerminalRegionHtmlExtensions
                     ? $"\"{cell.WrittenAt:O}\"" 
                     : "null";
 
-                // Include sixel data if present
-                var sixel = cell.SixelData != null
-                    ? $"{{\"origin\":{(cell.IsSixel ? "true" : "false")},\"w\":{cell.SixelData.WidthInCells},\"h\":{cell.SixelData.HeightInCells}}}"
-                    : "null";
+                // Include sixel placement data if this cell falls within a
+                // placement's painted extent.
+                string sixel;
+                if (sixelByCell.TryGetValue((x, y), out var sixelPlacement))
+                {
+                    var isOrigin = x == sixelPlacement.PaintedLeft && y == sixelPlacement.PaintedTop;
+                    sixel = $"{{\"origin\":{(isOrigin ? "true" : "false")},\"w\":{sixelPlacement.WidthInCells},\"h\":{sixelPlacement.HeightInCells}}}";
+                }
+                else
+                {
+                    sixel = "null";
+                }
 
                 // Include hyperlink data if present (with group ID for highlighting related cells)
                 string hyperlink;

--- a/src/Hex1b/Automation/TerminalRegionSvgExtensions.cs
+++ b/src/Hex1b/Automation/TerminalRegionSvgExtensions.cs
@@ -380,40 +380,33 @@ public static class TerminalRegionSvgExtensions
             }
         }
 
-        // Sixel graphics
-        // Track which sixel payloads we've already rendered to avoid duplicates
-        var renderedSixels = new HashSet<string>();
-        
-        for (int y = 0; y < region.Height; y++)
+        // Sixel graphics: iterate placements directly (not cell attributes) so
+        // rendering reflects the independent placement/image lifetime model.
+        // Deduplicate by content hash so shared raster content across
+        // multiple placements is only encoded once.
+        if (region is Hex1bTerminalSnapshot snapshot3)
         {
-            for (int x = 0; x < region.Width; x++)
+            var renderedSixelImages = new Dictionary<byte[], string?>(SixelContentHashComparer.Instance);
+            foreach (var placement in snapshot3.SixelPlacements.OrderBy(p => p.Sequence))
             {
-                var cell = region.GetCell(x, y);
-                var sixelData = cell.SixelData;
-                
-                // Only render from the origin cell (has IsSixel flag and actual data)
-                if (sixelData == null || !cell.IsSixel)
+                if (!placement.HasPaintedExtent)
+                    continue; // Geometry-only placements paint nothing.
+
+                if (!renderedSixelImages.TryGetValue(placement.Image.ContentHash, out var dataUri))
+                {
+                    var decoded = SixelDecoder.Decode(placement.Image);
+                    dataUri = decoded is { Width: > 0, Height: > 0 } ? BmpEncoder.ToDataUri(decoded) : null;
+                    renderedSixelImages[placement.Image.ContentHash] = dataUri;
+                }
+
+                if (dataUri is null)
                     continue;
-                
-                // Skip if we've already rendered this sixel (deduplication by payload reference)
-                if (!renderedSixels.Add(sixelData.Payload))
-                    continue;
-                
-                // Decode sixel to image
-                var image = SixelDecoder.Decode(sixelData);
-                if (image == null || image.Width == 0 || image.Height == 0)
-                    continue;
-                
-                // Encode to BMP data URI
-                var dataUri = BmpEncoder.ToDataUri(image);
-                
-                // Calculate position and size
-                var imgX = x * cellWidth;
-                var imgY = y * cellHeight;
-                var imgWidth = sixelData.WidthInCells * cellWidth;
-                var imgHeight = sixelData.HeightInCells * cellHeight;
-                
-                // Add image element with pixelated rendering to prevent antialiasing
+
+                var imgX = placement.PaintedLeft * cellWidth;
+                var imgY = placement.PaintedTop * cellHeight;
+                var imgWidth = placement.PaintedColumnCount * cellWidth;
+                var imgHeight = placement.PaintedRowCount * cellHeight;
+
                 sb.AppendLine($"""    <image x="{imgX}" y="{imgY}" width="{imgWidth}" height="{imgHeight}" href="{dataUri}" preserveAspectRatio="none" style="image-rendering: pixelated;"/>""");
             }
         }

--- a/src/Hex1b/CellAttributes.cs
+++ b/src/Hex1b/CellAttributes.cs
@@ -38,8 +38,9 @@ public enum CellAttributes : ushort
     /// <summary>Overline (SGR 53).</summary>
     Overline = 1 << 8,
 
-    /// <summary>Cell contains Sixel graphics data.</summary>
-    Sixel = 1 << 9,
+    // 1 << 9 was previously CellAttributes.Sixel. Sixel graphics ownership was
+    // removed from TerminalCell (see SixelGraphicsState); the bit is retired,
+    // not reused, so any historical serialized value cannot be misread.
 
     /// <summary>
     /// Cell is a soft-wrap point: content continues on the next row without a logical line break.

--- a/src/Hex1b/Hex1b.csproj
+++ b/src/Hex1b/Hex1b.csproj
@@ -62,6 +62,7 @@
     <InternalsVisibleTo Include="Hex1b.Tool" />
     <InternalsVisibleTo Include="Hex1b.Tool.Tests" />
     <InternalsVisibleTo Include="hex1bpty" />
+    <InternalsVisibleTo Include="SixelTerminalDemo" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Hex1b/Hex1b.csproj
+++ b/src/Hex1b/Hex1b.csproj
@@ -50,7 +50,13 @@
       and in CI. To deliberately ship a breaking change, comment the element
       out for the spike and let the bot restore it on the next release.
     -->
-    <EnablePackageValidation>true</EnablePackageValidation>
+    <!--
+      Deliberately disabled for this change: removes the public
+      CellAttributes.Sixel / TerminalCell.TrackedSixel per-cell Sixel
+      ownership surface (see issue #451) in favor of independent
+      SixelGraphicsState. The bot will restore this on the next release.
+    -->
+    <!-- <EnablePackageValidation>true</EnablePackageValidation> -->
     <!-- BEGIN: bot-managed baseline -->
     <PackageValidationBaselineVersion>0.165.0</PackageValidationBaselineVersion>
     <!-- END: bot-managed baseline -->

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -81,6 +81,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     private Sixel.SixelCellMetrics? _sixelCellMetricsOverride;
     private readonly TimeProvider _timeProvider;
     private readonly KgpTerminalGraphicsState _kgpGraphicsState = new();
+    private readonly SixelGraphicsState _sixelGraphicsState = new();
+    private long _sixelPlacementSequence;
     private ITimer? _kgpAnimationTimer;
     private int _selectedHistoryCount;
     
@@ -2026,7 +2028,6 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             {
                 for (int x = 0; x < _width; x++)
                 {
-                    screenBuffer[y, x].TrackedSixel?.AddRef();
                     screenBuffer[y, x].TrackedHyperlink?.AddRef();
                 }
             }
@@ -2052,7 +2053,6 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 var retainedCellCount = Math.Min(row.Cells.Length, retainedScrollbackWidth);
                 for (int x = 0; x < retainedCellCount; x++)
                 {
-                    row.Cells[x].TrackedSixel?.AddRef();
                     row.Cells[x].TrackedHyperlink?.AddRef();
                 }
             }
@@ -2065,6 +2065,10 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 _height,
                 Capabilities.CellPixelWidth,
                 Capabilities.CellPixelHeight);
+            var sixel = _sixelGraphicsState.CaptureActiveSnapshot(
+                allScrollbackEntries,
+                selectedScrollbackEntries.Length,
+                _height);
             return new Hex1bTerminalSnapshotState(
                 _width,
                 _height,
@@ -2091,7 +2095,9 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 screenBuffer,
                 scrollbackRows,
                 kgp.Placements,
-                kgp.Images);
+                kgp.Images,
+                sixel.Placements,
+                sixel.Images);
         }
     }
 
@@ -2127,18 +2133,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         {
             var copy = new TerminalCell[_height, _width];
             Array.Copy(_screenBuffer, copy, _screenBuffer.Length);
-            
-            if (addTrackedObjectRefs)
-            {
-                for (int y = 0; y < _height; y++)
-                {
-                    for (int x = 0; x < _width; x++)
-                    {
-                        copy[y, x].TrackedSixel?.AddRef();
-                    }
-                }
-            }
-            
+
             return copy;
         }
     }
@@ -2444,7 +2439,6 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         {
             for (int x = 0; x < _width; x++)
             {
-                _screenBuffer[y, x].TrackedSixel?.Release();
                 _screenBuffer[y, x].TrackedHyperlink?.Release();
             }
         }
@@ -2459,7 +2453,6 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 {
                     newBuffer[y, x] = result.ScreenRows[y][x];
                     // AddRef tracked objects in the new buffer
-                    newBuffer[y, x].TrackedSixel?.AddRef();
                     newBuffer[y, x].TrackedHyperlink?.AddRef();
                 }
                 for (int x = result.ScreenRows[y].Length; x < newWidth; x++)
@@ -2541,6 +2534,12 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 Capabilities.CellPixelHeight);
         }
 
+        // Sixel has no reflow-anchor tracking in this stage (deferred to
+        // #452): always fall back to clipping active placements/screen at
+        // their pre-resize physical coordinates, mirroring the same
+        // non-lineage fallback KGP itself uses above.
+        _sixelGraphicsState.ClipActivePlacementsToViewport(newWidth, newHeight);
+
         if (!_inAlternateScreen)
         {
             _kgpGraphicsState.ClipActiveScreenToViewport(
@@ -2549,6 +2548,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 newHeight,
                 Capabilities.CellPixelWidth,
                 Capabilities.CellPixelHeight);
+            _sixelGraphicsState.ClipActiveScreenToViewport(replacement.Entries, newWidth, newHeight);
         }
     }
 
@@ -2586,7 +2586,6 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 if (y < copyHeight && x < copyWidth)
                     continue;
                     
-                _screenBuffer[y, x].TrackedSixel?.Release();
                 _screenBuffer[y, x].TrackedHyperlink?.Release();
             }
         }
@@ -2603,6 +2602,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 newHeight,
                 Capabilities.CellPixelWidth,
                 Capabilities.CellPixelHeight);
+            _sixelGraphicsState.ClipActivePlacementsToViewport(newWidth, newHeight);
         }
         else
         {
@@ -2615,6 +2615,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 newHeight,
                 Capabilities.CellPixelWidth,
                 Capabilities.CellPixelHeight);
+            _sixelGraphicsState.ClipActiveScreenToViewport(historyRows, newWidth, newHeight);
         }
     }
 
@@ -2631,10 +2632,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     private void SetCell(int y, int x, TerminalCell newCell, List<CellImpact>? impacts = null)
     {
         ref var oldCell = ref _screenBuffer[y, x];
-        
-        // Release old Sixel data reference
-        oldCell.TrackedSixel?.Release();
-        
+
         // Release old hyperlink data reference
         oldCell.TrackedHyperlink?.Release();
         
@@ -2650,19 +2648,17 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     }
 
     /// <summary>
-    /// Gets or creates a tracked Sixel object for the given payload.
-    /// The returned object has a reference count that accounts for this request.
+    /// Gets the number of distinct Sixel images currently reachable from the
+    /// active screen's graphics state.
     /// </summary>
-    internal TrackedObject<SixelData> GetOrCreateSixel(string payload, int widthInCells, int heightInCells)
-    {
-        return _trackedObjects.GetOrCreateSixel(payload, widthInCells, heightInCells);
-    }
-
-    /// <summary>
-    /// Gets the number of tracked Sixel objects in the store.
-    /// Useful for testing to verify cleanup behavior.
-    /// </summary>
-    internal int TrackedSixelCount => _trackedObjects.SixelCount;
+    /// <remarks>
+    /// This deliberately counts distinct <em>images</em> (content-hash-deduplicated
+    /// raster resources), matching the historical dedup semantics of the
+    /// old <see cref="TrackedObjectStore"/>-backed counter it replaces. Use
+    /// <see cref="SixelPlacementCount"/> for the number of placements, which
+    /// may exceed the image count when placements share raster content.
+    /// </remarks>
+    internal int TrackedSixelCount => _sixelGraphicsState.ActiveImages.Count;
 
     /// <summary>
     /// Gets the number of tracked hyperlink objects in the store.
@@ -2671,40 +2667,47 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     internal int TrackedHyperlinkCount => _trackedObjects.HyperlinkCount;
 
     /// <summary>
-    /// Gets the Sixel data at the specified cell position, if any.
-    /// Returns null if the cell doesn't contain Sixel data or is a continuation cell.
+    /// Gets the number of live Sixel placements on the active screen.
+    /// </summary>
+    internal int SixelPlacementCount => _sixelGraphicsState.ActivePlacements.Count;
+
+    /// <summary>
+    /// Gets the live Sixel placements on the active screen, for test/inspection use.
+    /// </summary>
+    internal IReadOnlyList<SixelPlacement> SixelPlacements => _sixelGraphicsState.ActivePlacements;
+
+    /// <summary>
+    /// Gets the Sixel image painted at the specified cell position, if any.
+    /// When multiple placements overlap a cell, returns the topmost one (the
+    /// placement with the highest write sequence).
     /// </summary>
     internal SixelData? GetSixelDataAt(int x, int y)
     {
         if (x < 0 || x >= _width || y < 0 || y >= _height)
             return null;
-        return _screenBuffer[y, x].SixelData;
+
+        SixelPlacement? topmost = null;
+        foreach (var placement in _sixelGraphicsState.ActivePlacements)
+        {
+            if (!placement.CoversCell(y, x))
+                continue;
+            if (topmost is null || placement.Sequence > topmost.Sequence)
+                topmost = placement;
+        }
+
+        return topmost?.Image;
     }
 
     /// <summary>
-    /// Gets the tracked Sixel object at the specified cell position, if any.
-    /// Returns null if the cell doesn't contain Sixel data.
-    /// Useful for testing reference count behavior.
-    /// </summary>
-    internal TrackedObject<SixelData>? GetTrackedSixelAt(int x, int y)
-    {
-        if (x < 0 || x >= _width || y < 0 || y >= _height)
-            return null;
-        return _screenBuffer[y, x].TrackedSixel;
-    }
-
-    /// <summary>
-    /// Checks if any cell in the screen buffer contains Sixel data.
+    /// Checks whether the active screen has any Sixel placement that paints
+    /// at least one cell (geometry-only placements do not count).
     /// </summary>
     internal bool ContainsSixelData()
     {
-        for (int y = 0; y < _height; y++)
+        foreach (var placement in _sixelGraphicsState.ActivePlacements)
         {
-            for (int x = 0; x < _width; x++)
-            {
-                if (_screenBuffer[y, x].TrackedSixel is not null)
-                    return true;
-            }
+            if (placement.HasPaintedExtent)
+                return true;
         }
         return false;
     }
@@ -2790,7 +2793,6 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             for (int x = 0; x < _width; x++)
             {
                 // Release any tracked objects
-                _screenBuffer[y, x].TrackedSixel?.Release();
                 _screenBuffer[y, x].TrackedHyperlink?.Release();
                 _screenBuffer[y, x] = TerminalCell.Empty;
             }
@@ -3322,6 +3324,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 }
                 _scrollbackBuffer?.Clear();
                 _kgpGraphicsState.Reset();
+                _sixelGraphicsState.Reset();
                 break;
                 
             case DecalnToken:
@@ -3838,7 +3841,6 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                     ref var leadingCell = ref _screenBuffer[_cursorY, _cursorX - 1];
                     if (leadingCell.Character.Length > 0 && leadingCell.Character != " ")
                     {
-                        leadingCell.TrackedSixel?.Release();
                         leadingCell.TrackedHyperlink?.Release();
                         leadingCell = TerminalCell.Empty;
                     }
@@ -3851,7 +3853,6 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                     if (nextCell.Character == "" && _screenBuffer[_cursorY, _cursorX].Character.Length > 0
                         && DisplayWidth.GetGraphemeWidth(_screenBuffer[_cursorY, _cursorX].Character) > 1)
                     {
-                        nextCell.TrackedSixel?.Release();
                         nextCell.TrackedHyperlink?.Release();
                         nextCell = TerminalCell.Empty;
                     }
@@ -3864,7 +3865,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                     : _currentAttributes;
                 var cell = new TerminalCell(
                     grapheme, _currentForeground, _currentBackground, effectiveAttributes,
-                    sequence, writtenAt, TrackedSixel: null, _currentHyperlink,
+                    sequence, writtenAt, _currentHyperlink,
                     _currentUnderlineColor, _currentUnderlineStyle);
                 SetCell(_cursorY, _cursorX, cell, impacts);
                 
@@ -3880,7 +3881,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                     _currentHyperlink?.AddRef();
                     SetCell(_cursorY, _cursorX + w, new TerminalCell(
                         "", _currentForeground, _currentBackground, _currentAttributes,
-                        sequence, writtenAt, TrackedSixel: null, _currentHyperlink,
+                        sequence, writtenAt, _currentHyperlink,
                         _currentUnderlineColor, _currentUnderlineStyle), impacts);
                 }
                 
@@ -4444,14 +4445,20 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                     _kgpGraphicsState.ClearActiveViewport(
                         historyRows,
                         Capabilities.CellPixelHeight);
+                    // Sixel has no relative-placement graph concept, so ED
+                    // (without scrollback) simply clears the active screen's
+                    // live viewport placements and leaves history untouched.
+                    _sixelGraphicsState.ClearActiveScreen(clearHistory: false);
                 }
                 else if (_inAlternateScreen)
                 {
                     _kgpGraphicsState.ClearActiveScreen(clearHistory: true);
+                    _sixelGraphicsState.ClearActiveScreen(clearHistory: true);
                 }
                 else
                 {
                     _kgpGraphicsState.ClearActiveScreen(clearHistory: false);
+                    _sixelGraphicsState.ClearActiveScreen(clearHistory: false);
                     _scrollbackBuffer?.Clear();
                 }
                 break;
@@ -4711,6 +4718,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         if (_inAlternateScreen)
         {
             _kgpGraphicsState.EnterAlternateScreen();
+            _sixelGraphicsState.EnterAlternateScreen();
             if (Capabilities.HandlesAlternateScreenNatively)
                 ClearBufferInternal();
             else
@@ -4731,13 +4739,13 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             for (int x = 0; x < _width; x++)
             {
                 var cell = _screenBuffer[y, x];
-                cell.TrackedSixel?.AddRef();
                 cell.TrackedHyperlink?.AddRef();
                 _savedMainScreenBuffer[y, x] = cell;
             }
         }
         
         _kgpGraphicsState.EnterAlternateScreen();
+        _sixelGraphicsState.EnterAlternateScreen();
         _inAlternateScreen = true;
         
         // If the presentation handles alternate screen natively, the real terminal
@@ -4764,6 +4772,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             return;
 
         _kgpGraphicsState.ExitAlternateScreen();
+        _sixelGraphicsState.ExitAlternateScreen();
         var historyRows = _scrollbackBuffer is { } scrollback
             ? scrollback.GetEntries(scrollback.Count)
             : [];
@@ -4773,6 +4782,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             _height,
             Capabilities.CellPixelWidth,
             Capabilities.CellPixelHeight);
+        _sixelGraphicsState.ClipActiveScreenToViewport(historyRows, _width, _height);
         _inAlternateScreen = false;
     }
 
@@ -4805,7 +4815,6 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 if (y < restoreHeight && x < restoreWidth)
                     continue;
 
-                savedBuffer[y, x].TrackedSixel?.Release();
                 savedBuffer[y, x].TrackedHyperlink?.Release();
             }
         }
@@ -4825,7 +4834,6 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         {
             for (int x = 0; x < savedBuffer.GetLength(1); x++)
             {
-                savedBuffer[y, x].TrackedSixel?.Release();
                 savedBuffer[y, x].TrackedHyperlink?.Release();
             }
         }
@@ -5238,6 +5246,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             _scrollBottom,
             leftCol,
             rightCol);
+        var sixelScrollingRegion = new SixelScrollRegion(_scrollTop, _scrollBottom, leftCol, rightCol);
         var createsKgpHistory = !_inAlternateScreen &&
             _scrollbackBuffer is not null &&
             _scrollTop == 0 &&
@@ -5257,12 +5266,6 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             capturedHistoryRowId = CaptureRowToScrollback(_scrollTop);
             if (_disposed)
                 return false;
-        }
-        
-        // First, release Sixel data from the top row of the region (being scrolled off)
-        for (int x = leftCol; x <= rightCol; x++)
-        {
-            _screenBuffer[_scrollTop, x].TrackedSixel?.Release();
         }
         
         // Shift rows up within the scroll region
@@ -5289,6 +5292,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 capturedHistoryRowId
                     ?? throw new InvalidOperationException(
                         "A history-producing KGP scroll must capture a scrollback row."));
+            _sixelGraphicsState.MoveMainPlacementsIntoHistory(capturedHistoryRowId.Value);
         }
         else
         {
@@ -5297,6 +5301,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 scrollingRectangle,
                 Capabilities.CellPixelWidth,
                 Capabilities.CellPixelHeight);
+            _sixelGraphicsState.AdjustActivePlacementsForScroll(rowDelta: -1, sixelScrollingRegion);
         }
 
         return true;
@@ -5316,12 +5321,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             _scrollBottom,
             leftCol,
             rightCol);
-        
-        // First, release Sixel data from the bottom row of the region (being scrolled off)
-        for (int x = leftCol; x <= rightCol; x++)
-        {
-            _screenBuffer[_scrollBottom, x].TrackedSixel?.Release();
-        }
+        var sixelScrollingRegion = new SixelScrollRegion(_scrollTop, _scrollBottom, leftCol, rightCol);
         
         // Shift rows down within the scroll region
         // All affected cells need to be recorded as impacts
@@ -5348,6 +5348,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             scrollingRectangle,
             Capabilities.CellPixelWidth,
             Capabilities.CellPixelHeight);
+        _sixelGraphicsState.AdjustActivePlacementsForScroll(rowDelta: 1, sixelScrollingRegion);
 
         return true;
     }
@@ -5367,9 +5368,12 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     }
 
     private void OnScrollbackRowPruned(ScrollbackPrunedRow pruned)
-        => _kgpGraphicsState.PruneMainHistoryRow(
+    {
+        _kgpGraphicsState.PruneMainHistoryRow(
             pruned,
             Capabilities.CellPixelHeight);
+        _sixelGraphicsState.PruneMainHistoryRow(pruned);
+    }
     
     private void InsertLines(int count, List<CellImpact>? impacts = null)
     {
@@ -5394,11 +5398,12 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         
         for (int i = 0; i < count; i++)
         {
-            // Release Sixel data from the bottom row of scroll region (being pushed off)
-            for (int x = leftCol; x <= rightCol; x++)
-            {
-                _screenBuffer[bottom, x].TrackedSixel?.Release();
-            }
+            // Release Sixel placements anchored at the bottom row of scroll
+            // region (being pushed off). Ordinary Sixel placements otherwise
+            // stay fixed for IL/DL, matching KGP's policy above; this only
+            // reproduces the prior per-cell model's behavior of releasing a
+            // placement whose anchor row is discarded outright.
+            _sixelGraphicsState.ReleasePlacementsAnchoredAtRow(bottom);
             
             // Shift lines down from cursor position to bottom of scroll region
             for (int y = bottom; y > _cursorY; y--)
@@ -5441,11 +5446,9 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         
         for (int i = 0; i < count; i++)
         {
-            // Release Sixel data from the line being deleted
-            for (int x = leftCol; x <= rightCol; x++)
-            {
-                _screenBuffer[_cursorY, x].TrackedSixel?.Release();
-            }
+            // Release Sixel placements anchored at the line being deleted
+            // (see InsertLines for why this differs from KGP's fixed policy).
+            _sixelGraphicsState.ReleasePlacementsAnchoredAtRow(_cursorY);
             
             // Shift lines up from cursor position to bottom of scroll region
             for (int y = _cursorY; y < bottom; y++)
@@ -5766,7 +5769,6 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                     _lastPrintedCell.Attributes,
                     sequence, 
                     writtenAt, 
-                    TrackedSixel: null, 
                     TrackedHyperlink: null,
                     _lastPrintedCell.UnderlineColor,
                     _lastPrintedCell.UnderlineStyle);
@@ -5777,7 +5779,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 {
                     SetCell(_cursorY, _cursorX + w, new TerminalCell(
                         "", _lastPrintedCell.Foreground, _lastPrintedCell.Background, _lastPrintedCell.Attributes,
-                        sequence, writtenAt, TrackedSixel: null, TrackedHyperlink: null,
+                        sequence, writtenAt, TrackedHyperlink: null,
                         _lastPrintedCell.UnderlineColor, _lastPrintedCell.UnderlineStyle), impacts);
                 }
                 
@@ -6016,21 +6018,16 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         var widthInCells = Math.Max(1, cellMetrics.ColumnsFor(renderedPixelWidth));
         var heightInCells = Math.Max(1, cellMetrics.RowsFor(renderedPixelHeight));
 
-        // Create or reuse a tracked Sixel object. Occupancy recorded on the
-        // placement is the unclipped source geometry; clipping only affects which
-        // cells are painted, never the raster itself.
-        var sixelData = _trackedObjects.GetOrCreateSixel(
-            sixelPayload,
-            widthInCells,
-            heightInCells,
-            parseResult,
-            rasterPreparation,
-            cellMetrics);
-
+        // Create or reuse an anonymous raster resource, and add a placement
+        // anchored at the resolved position that references it. Occupancy
+        // recorded on the placement is the unclipped source geometry;
+        // clipping only affects which cells are painted, never the raster
+        // itself.
         var placement = ResolveSixelPlacement(widthInCells, heightInCells, impacts);
 
-        // Mark cells covered by this Sixel image
-        // The first cell gets the tracked object, others just get the Sixel flag
+        // Mark cells covered by this Sixel image. Painted cells stay blank
+        // glyph cells for text-grid compatibility; the placement (not the
+        // cell) now owns the raster reference.
         var sequence = ++_writeSequence;
         var writtenAt = _timeProvider.GetUtcNow();
 
@@ -6048,32 +6045,32 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             placement.OriginColumn + (long)widthInCells - 1,
             Math.Min(placement.ClipRight, _width - 1));
 
+        _sixelGraphicsState.CreatePlacement(
+            sixelPayload,
+            parseResult,
+            rasterPreparation,
+            cellMetrics,
+            row: placement.OriginRow,
+            column: placement.OriginColumn,
+            widthInCells: widthInCells,
+            heightInCells: heightInCells,
+            paintedRowOffset: (int)(firstRow - placement.OriginRow),
+            paintedRowCount: (int)Math.Max(0, lastRow - firstRow + 1),
+            paintedColumnOffset: (int)(firstColumn - placement.OriginColumn),
+            paintedColumnCount: (int)Math.Max(0, lastColumn - firstColumn + 1),
+            sequence: ++_sixelPlacementSequence,
+            createdAt: writtenAt);
+
         for (var y = firstRow; y <= lastRow; y++)
         {
-            var dy = y - placement.OriginRow;
-
             for (var x = firstColumn; x <= lastColumn; x++)
             {
-                var dx = x - placement.OriginColumn;
-
-                // First cell (origin) holds the tracked object
-                // Other cells just have the Sixel flag set
-                if (dx == 0 && dy == 0)
-                {
-                    SetCell(y, x, new TerminalCell(
-                        " ", _currentForeground, _currentBackground,
-                        _currentAttributes | CellAttributes.Sixel,
-                        sequence, writtenAt, sixelData), impacts);
-                }
-                else
-                {
-                    // Continuation cells - just mark as Sixel, no tracked object
-                    // (The origin cell owns the reference)
-                    SetCell(y, x, new TerminalCell(
-                        "", _currentForeground, _currentBackground,
-                        _currentAttributes | CellAttributes.Sixel,
-                        sequence, writtenAt), impacts);
-                }
+                var isOrigin = x == placement.OriginColumn && y == placement.OriginRow;
+                SetCell(y, x, new TerminalCell(
+                    isOrigin ? " " : "",
+                    _currentForeground, _currentBackground,
+                    _currentAttributes,
+                    sequence, writtenAt), impacts);
             }
         }
 
@@ -6857,6 +6854,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             // History must release its owners before the per-screen image stores reset.
             _scrollbackBuffer?.Clear();
             _kgpGraphicsState.Reset();
+            _sixelGraphicsState.Reset();
             _inAlternateScreen = false;
             return true;
         }

--- a/src/Hex1b/Reflow/ReflowHelper.cs
+++ b/src/Hex1b/Reflow/ReflowHelper.cs
@@ -563,7 +563,6 @@ internal static class ReflowHelper
             && cell.Foreground is null
             && cell.Background is null
             && (cell.Attributes & ~CellAttributes.SoftWrap) == CellAttributes.None
-            && cell.TrackedSixel is null
             && cell.TrackedHyperlink is null;
     }
 

--- a/src/Hex1b/ScrollbackBuffer.cs
+++ b/src/Hex1b/ScrollbackBuffer.cs
@@ -114,7 +114,6 @@ internal sealed class ScrollbackBuffer
         // AddRef tracked objects in the new row
         for (int i = 0; i < cells.Length; i++)
         {
-            cells[i].TrackedSixel?.AddRef();
             cells[i].TrackedHyperlink?.AddRef();
         }
 
@@ -226,7 +225,6 @@ internal sealed class ScrollbackBuffer
             var row = rows[rowIndex];
             for (var cellIndex = 0; cellIndex < row.Cells.Length; cellIndex++)
             {
-                row.Cells[cellIndex].TrackedSixel?.AddRef();
                 row.Cells[cellIndex].TrackedHyperlink?.AddRef();
             }
 
@@ -253,7 +251,6 @@ internal sealed class ScrollbackBuffer
 
         for (int i = 0; i < row.Cells.Length; i++)
         {
-            row.Cells[i].TrackedSixel?.Release();
             row.Cells[i].TrackedHyperlink?.Release();
         }
     }

--- a/src/Hex1b/Sixel/SixelContentHashComparer.cs
+++ b/src/Hex1b/Sixel/SixelContentHashComparer.cs
@@ -1,0 +1,38 @@
+using Hex1b.Sixel;
+
+namespace Hex1b;
+
+/// <summary>
+/// A byte-content equality comparer used to key Sixel image stores by content
+/// hash, mirroring the private comparer <see cref="TrackedObjectStore"/> uses
+/// for the same purpose.
+/// </summary>
+internal sealed class SixelContentHashComparer : IEqualityComparer<byte[]>
+{
+    internal static readonly SixelContentHashComparer Instance = new();
+
+    private SixelContentHashComparer()
+    {
+    }
+
+    public bool Equals(byte[]? x, byte[]? y)
+    {
+        if (ReferenceEquals(x, y))
+            return true;
+        if (x is null || y is null)
+            return false;
+        return x.AsSpan().SequenceEqual(y);
+    }
+
+    public int GetHashCode(byte[] obj)
+    {
+        // Content hashes are already cryptographically uniform (SHA-256), so a
+        // bounded sample of bytes is sufficient for hash-bucket distribution.
+        var hash = new HashCode();
+        var step = Math.Max(1, obj.Length / 8);
+        for (var i = 0; i < obj.Length; i += step)
+            hash.Add(obj[i]);
+        hash.Add(obj.Length);
+        return hash.ToHashCode();
+    }
+}

--- a/src/Hex1b/Sixel/SixelGraphicsState.cs
+++ b/src/Hex1b/Sixel/SixelGraphicsState.cs
@@ -1,0 +1,379 @@
+using Hex1b.Sixel;
+
+namespace Hex1b;
+
+/// <summary>
+/// Independent terminal-graphics storage and placement state for Sixel,
+/// completely decoupled from <see cref="TerminalCell"/>. Stage #451 replaces
+/// the previous per-cell ownership model (<c>CellAttributes.Sixel</c> plus
+/// origin/continuation cell tracking) with this reachability-based model,
+/// modeled after the mature <see cref="KgpTerminalGraphicsState"/> but
+/// intentionally much simpler: no public image/placement IDs, no image-number
+/// addressing, no explicit delete selectors, no relative-placement graph, no
+/// Unicode placeholders, no z-index, and no chunked uploads. Those concepts
+/// are genuinely KGP-specific and are deliberately kept out of this shared
+/// model.
+/// </summary>
+/// <remarks>
+/// Main and alternate screen state are fully independent
+/// <see cref="SixelScreenGraphicsState"/> instances. Re-entering the
+/// alternate screen (for example a program that issues <c>\x1b[?1049h</c>
+/// twice without an intervening exit) resets only the alternate state; the
+/// main screen's placements, history, and images are untouched. A full
+/// terminal reset (RIS) is the only operation that clears both.
+/// </remarks>
+internal sealed class SixelGraphicsState
+{
+    private readonly SixelScreenGraphicsState _main = new();
+    private SixelScreenGraphicsState? _alternate;
+    private bool _alternateActive;
+
+    private SixelScreenGraphicsState Active => _alternateActive ? _alternate! : _main;
+
+    internal bool InAlternateScreen => _alternateActive;
+
+    /// <summary>The active screen's image store (for testing/inspection).</summary>
+    internal SixelImageStore ActiveImages => Active.Images;
+
+    /// <summary>The active screen's live placements (for testing/inspection).</summary>
+    internal IReadOnlyList<SixelPlacement> ActivePlacements => Active.Placements;
+
+    /// <summary>Total number of placements the main screen has moved into history.</summary>
+    internal int MainHistoryPlacementCount
+    {
+        get
+        {
+            var count = 0;
+            foreach (var list in _main.HistoryPlacements.Values)
+                count += list.Count;
+            return count;
+        }
+    }
+
+    /// <summary>
+    /// Creates an anonymous raster resource (or reuses a content-identical
+    /// existing one) in the active screen's image store, and adds a placement
+    /// anchored at the given position that references it.
+    /// </summary>
+    internal SixelPlacement CreatePlacement(
+        string payload,
+        SixelParseResult parseResult,
+        SixelRasterPreparation rasterPreparation,
+        SixelCellMetrics cellMetrics,
+        int row,
+        int column,
+        int widthInCells,
+        int heightInCells,
+        int paintedRowOffset,
+        int paintedRowCount,
+        int paintedColumnOffset,
+        int paintedColumnCount,
+        long sequence,
+        DateTimeOffset createdAt)
+    {
+        var active = Active;
+        var image = active.Images.GetOrCreate(
+            payload, widthInCells, heightInCells, parseResult, rasterPreparation, cellMetrics);
+        var placement = new SixelPlacement(
+            image,
+            row,
+            column,
+            widthInCells,
+            heightInCells,
+            paintedRowOffset,
+            paintedRowCount,
+            paintedColumnOffset,
+            paintedColumnCount,
+            sequence,
+            createdAt);
+        active.Placements.Add(placement);
+        return placement;
+    }
+
+    /// <summary>
+    /// Enters the alternate screen. Repeated entry (already active) resets
+    /// only the alternate state; the main screen is never touched here.
+    /// </summary>
+    internal void EnterAlternateScreen()
+    {
+        _alternate?.Clear();
+        _alternate = new SixelScreenGraphicsState();
+        _alternateActive = true;
+    }
+
+    /// <summary>Exits the alternate screen, discarding its graphics state entirely.</summary>
+    internal void ExitAlternateScreen()
+    {
+        if (!_alternateActive)
+            return;
+
+        _alternate?.Clear();
+        _alternate = null;
+        _alternateActive = false;
+    }
+
+    /// <summary>RIS (full terminal reset): clears both the main and alternate graphics state.</summary>
+    internal void Reset()
+    {
+        _main.Clear();
+        _alternate?.Clear();
+        _alternate = null;
+        _alternateActive = false;
+    }
+
+    /// <summary>
+    /// Clears the active screen's live placements (ED/DECSED-style clear), and
+    /// optionally its history partition too (used when scrollback itself is
+    /// also being cleared, or when clearing the alternate screen which has no
+    /// separate history concept).
+    /// </summary>
+    internal void ClearActiveScreen(bool clearHistory)
+    {
+        var active = Active;
+        active.Placements.Clear();
+        if (clearHistory)
+            active.HistoryPlacements.Clear();
+        active.ReconcileImages();
+    }
+
+    /// <summary>
+    /// Moves every main-screen placement anchored at row 0 into history under
+    /// <paramref name="rowId"/> (the scrollback row identity that row was just
+    /// captured under), and shifts every other placement's anchor up by one
+    /// row. Mirrors <c>KgpTerminalGraphicsState.MoveMainPlacementsIntoHistory</c>.
+    /// </summary>
+    internal void MoveMainPlacementsIntoHistory(long rowId)
+    {
+        for (var i = _main.Placements.Count - 1; i >= 0; i--)
+        {
+            var placement = _main.Placements[i];
+            if (placement.Row == 0)
+            {
+                _main.Placements.RemoveAt(i);
+                if (!_main.HistoryPlacements.TryGetValue(rowId, out var list))
+                {
+                    list = [];
+                    _main.HistoryPlacements[rowId] = list;
+                }
+
+                list.Add(placement);
+            }
+            else
+            {
+                placement.Row -= 1;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Releases the history placements anchored to a scrollback row that has
+    /// just been evicted (capacity eviction or an explicit scrollback clear).
+    /// </summary>
+    /// <remarks>
+    /// Stage #451 intentionally keeps history eviction simple: the whole
+    /// placement is released along with its row. KGP's partial cropping and
+    /// transfer-to-successor-row fidelity on capacity eviction
+    /// (<c>ClipRows</c>/<c>RetainedRows</c>) is not replicated here; that level
+    /// of scrolling/reflow fidelity is deferred to #452.
+    /// </remarks>
+    internal void PruneMainHistoryRow(ScrollbackPrunedRow pruned)
+    {
+        if (_main.HistoryPlacements.Remove(pruned.RowId, out var removed) && removed.Count > 0)
+        {
+            _main.ReconcileImages();
+        }
+    }
+
+    /// <summary>
+    /// Shifts or drops active placements for a scroll of <paramref name="rowDelta"/>
+    /// rows within <paramref name="region"/>. A placement wholly contained in
+    /// the region shifts with it; one that would land completely outside the
+    /// region is no longer reachable and is removed. Placements that are not
+    /// wholly contained in the region (partially overlapping it) are left
+    /// untouched, mirroring <c>KgpTerminalGraphicsState.AdjustActivePlacementsForScroll</c>.
+    /// </summary>
+    internal void AdjustActivePlacementsForScroll(int rowDelta, SixelScrollRegion region)
+    {
+        var active = Active;
+        var changed = false;
+        for (var i = active.Placements.Count - 1; i >= 0; i--)
+        {
+            var placement = active.Placements[i];
+            var bottom = placement.Row + placement.HeightInCells - 1;
+            var right = placement.Column + placement.WidthInCells - 1;
+            var whollyContained =
+                placement.Row >= region.Top && bottom <= region.Bottom &&
+                placement.Column >= region.Left && right <= region.Right;
+            if (!whollyContained)
+                continue;
+
+            var movedRow = placement.Row + rowDelta;
+            var movedBottom = movedRow + placement.HeightInCells - 1;
+            if (movedBottom < region.Top || movedRow > region.Bottom)
+            {
+                active.Placements.RemoveAt(i);
+                changed = true;
+                continue;
+            }
+
+            placement.Row = movedRow;
+        }
+
+        if (changed)
+            active.ReconcileImages();
+    }
+
+    /// <summary>
+    /// Releases any active placement anchored exactly at <paramref name="row"/>.
+    /// Used by IL/DL (insert/delete lines), which — unlike ordinary scrolling —
+    /// discard a single row's content outright. KGP intentionally leaves its
+    /// ordinary placements fixed for IL/DL (matching Kitty/Ghostty); the prior
+    /// per-cell Sixel model released the origin cell's tracked reference in
+    /// this situation, so this preserves that same observable behavior under
+    /// the new placement-based model.
+    /// </summary>
+    internal void ReleasePlacementsAnchoredAtRow(int row)
+    {
+        var active = Active;
+        if (active.Placements.RemoveAll(p => p.Row == row) > 0)
+            active.ReconcileImages();
+    }
+
+    /// <summary>
+    /// Removes active placements that fall completely outside a new viewport
+    /// size (used on resize). Placement positions are not reflowed/translated;
+    /// full reflow-aware repositioning is deferred to #452, matching the
+    /// existing fallback KGP itself uses for reflow providers without row
+    /// lineage.
+    /// </summary>
+    internal void ClipActivePlacementsToViewport(int width, int height)
+    {
+        var active = Active;
+        var changed = false;
+        for (var i = active.Placements.Count - 1; i >= 0; i--)
+        {
+            var placement = active.Placements[i];
+            var bottom = placement.Row + placement.HeightInCells - 1;
+            var right = placement.Column + placement.WidthInCells - 1;
+            if (bottom < 0 || placement.Row >= height || right < 0 || placement.Column >= width)
+            {
+                active.Placements.RemoveAt(i);
+                changed = true;
+            }
+        }
+
+        if (changed)
+            active.ReconcileImages();
+    }
+
+    /// <summary>
+    /// Clips the active screen's live placements to a new viewport size and,
+    /// for the main screen, also drops any history placement whose scrollback
+    /// row is no longer retained.
+    /// </summary>
+    internal void ClipActiveScreenToViewport(
+        IReadOnlyList<ScrollbackEntry> historyRows,
+        int width,
+        int height)
+    {
+        ClipActivePlacementsToViewport(width, height);
+
+        if (Active != _main)
+            return;
+
+        if (_main.HistoryPlacements.Count == 0)
+            return;
+
+        var retainedRowIds = new HashSet<long>(historyRows.Count);
+        foreach (var entry in historyRows)
+            retainedRowIds.Add(entry.RowId);
+
+        List<long>? toRemove = null;
+        foreach (var rowId in _main.HistoryPlacements.Keys)
+        {
+            if (!retainedRowIds.Contains(rowId))
+                (toRemove ??= []).Add(rowId);
+        }
+
+        if (toRemove is null)
+            return;
+
+        foreach (var rowId in toRemove)
+            _main.HistoryPlacements.Remove(rowId);
+
+        _main.ReconcileImages();
+    }
+
+    /// <summary>
+    /// Projects the active screen's placements into a unified coordinate space
+    /// (history rows first, then the live viewport) for inclusion in a
+    /// terminal snapshot, exactly like
+    /// <c>KgpTerminalGraphicsState.CaptureActiveSnapshot</c>.
+    /// </summary>
+    /// <remarks>
+    /// Returned placements are independent copies (see
+    /// <see cref="SixelPlacement.WithRow"/>): they, and the
+    /// <see cref="SixelData"/> images dictionary returned alongside them,
+    /// remain valid and reachable for as long as the snapshot itself is kept
+    /// alive, even after the live graphics state that produced them mutates
+    /// or sweeps its own store.
+    /// </remarks>
+    internal (IReadOnlyList<SixelPlacement> Placements, IReadOnlyDictionary<byte[], SixelData> Images) CaptureActiveSnapshot(
+        IReadOnlyList<ScrollbackEntry> allHistoryRows,
+        int selectedHistoryCount,
+        int viewportHeight)
+    {
+        var active = Active;
+        var isMain = active == _main;
+        var historyCount = isMain ? allHistoryRows.Count : 0;
+        var selectedCount = Math.Clamp(selectedHistoryCount, 0, historyCount);
+        var snapshotStart = historyCount - selectedCount;
+        var snapshotEnd = historyCount + viewportHeight;
+
+        Dictionary<long, int>? rowIndexByRowId = null;
+        if (isMain && active.HistoryPlacements.Count > 0)
+        {
+            rowIndexByRowId = new Dictionary<long, int>(allHistoryRows.Count);
+            for (var i = 0; i < allHistoryRows.Count; i++)
+                rowIndexByRowId[allHistoryRows[i].RowId] = i;
+        }
+
+        var placements = new List<SixelPlacement>();
+        var images = new Dictionary<byte[], SixelData>(SixelContentHashComparer.Instance);
+
+        foreach (var placement in active.Placements)
+        {
+            var unifiedRow = historyCount + placement.Row;
+            AddIfVisible(placement, unifiedRow, snapshotStart, snapshotEnd, placements, images);
+        }
+
+        if (isMain && rowIndexByRowId is not null)
+        {
+            foreach (var (rowId, list) in active.HistoryPlacements)
+            {
+                if (!rowIndexByRowId.TryGetValue(rowId, out var unifiedRow))
+                    continue; // Evicted or outside the selected scrollback window.
+
+                foreach (var placement in list)
+                    AddIfVisible(placement, unifiedRow, snapshotStart, snapshotEnd, placements, images);
+            }
+        }
+
+        return (placements, images);
+    }
+
+    private static void AddIfVisible(
+        SixelPlacement placement,
+        int unifiedRow,
+        int snapshotStart,
+        int snapshotEnd,
+        List<SixelPlacement> placements,
+        Dictionary<byte[], SixelData> images)
+    {
+        if (unifiedRow < snapshotStart || unifiedRow >= snapshotEnd)
+            return;
+
+        placements.Add(placement.WithRow(unifiedRow - snapshotStart));
+        images[placement.Image.ContentHash] = placement.Image;
+    }
+}

--- a/src/Hex1b/Sixel/SixelImageStore.cs
+++ b/src/Hex1b/Sixel/SixelImageStore.cs
@@ -1,0 +1,85 @@
+using Hex1b.Sixel;
+
+namespace Hex1b;
+
+/// <summary>
+/// Content-hash-keyed store of anonymous Sixel raster resources for a single
+/// screen (main or alternate).
+/// </summary>
+/// <remarks>
+/// Unlike <see cref="TrackedObjectStore"/>'s manually reference-counted
+/// tracked objects, this store follows <see cref="KgpImageStore"/>'s
+/// reachability model: an image is retained only while at least one live
+/// placement or history placement in the owning screen still references it.
+/// <see cref="RemoveUnreferenced"/> recomputes that reachable set and sweeps
+/// everything else after any placement mutation. Snapshots are unaffected by
+/// this sweep because they hold their own direct <see cref="SixelData"/>
+/// references (kept alive by ordinary .NET garbage collection), decoupled
+/// from this store's dictionary.
+/// </remarks>
+internal sealed class SixelImageStore
+{
+    private readonly Dictionary<byte[], SixelData> _byHash = new(SixelContentHashComparer.Instance);
+
+    /// <summary>Number of distinct images currently retained.</summary>
+    internal int Count => _byHash.Count;
+
+    /// <summary>The images currently retained.</summary>
+    internal IReadOnlyCollection<SixelData> Images => _byHash.Values;
+
+    /// <summary>
+    /// Gets the existing image for this exact content (payload + captured
+    /// background/palette identity), or creates and stores a new one.
+    /// </summary>
+    internal SixelData GetOrCreate(
+        string payload,
+        int widthInCells,
+        int heightInCells,
+        SixelParseResult parseResult,
+        SixelRasterPreparation rasterPreparation,
+        SixelCellMetrics cellMetrics)
+    {
+        var hash = SixelData.ComputeHash(payload, rasterPreparation.Identity);
+        if (_byHash.TryGetValue(hash, out var existing))
+            return existing;
+
+        var image = new SixelData(
+            payload,
+            widthInCells,
+            heightInCells,
+            hash,
+            parseResult.DeclaredExtent.Width,
+            parseResult.DeclaredExtent.Height,
+            parseResult,
+            rasterPreparation: rasterPreparation,
+            cellMetrics: cellMetrics);
+        _byHash[hash] = image;
+        return image;
+    }
+
+    internal void Clear() => _byHash.Clear();
+
+    /// <summary>
+    /// Removes every image whose content hash is not present in
+    /// <paramref name="retainedHashes"/> (mark-and-sweep reachability, the
+    /// same strategy <see cref="KgpImageStore.RemoveUnreferencedImages"/> uses).
+    /// </summary>
+    internal void RemoveUnreferenced(HashSet<byte[]> retainedHashes)
+    {
+        if (_byHash.Count == 0)
+            return;
+
+        List<byte[]>? toRemove = null;
+        foreach (var hash in _byHash.Keys)
+        {
+            if (!retainedHashes.Contains(hash))
+                (toRemove ??= []).Add(hash);
+        }
+
+        if (toRemove is null)
+            return;
+
+        foreach (var hash in toRemove)
+            _byHash.Remove(hash);
+    }
+}

--- a/src/Hex1b/Sixel/SixelPlacement.cs
+++ b/src/Hex1b/Sixel/SixelPlacement.cs
@@ -1,0 +1,176 @@
+using Hex1b.Sixel;
+
+namespace Hex1b;
+
+/// <summary>
+/// An anonymous Sixel raster placement anchored to a terminal cell position.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A placement's lifetime is completely independent of the screen buffer's
+/// character grid: overwriting the text cell the placement was anchored to
+/// does not release the placement or its underlying image. A placement is
+/// removed only when it stops being reachable from the graphics state that
+/// owns it (the active screen's live placements, or the main screen's
+/// history), mirroring the reachability-based lifetime model already used by
+/// <see cref="KgpImageStore"/> instead of manual reference counting.
+/// </para>
+/// <para>
+/// <see cref="Row"/> is mutable so scrolling and history transitions can shift
+/// a placement's anchor in place without discarding and recreating it (the
+/// same "shift, don't recreate" strategy <see cref="KgpPlacement"/> uses).
+/// Everything else about a placement is fixed at creation time, matching the
+/// Sixel protocol's write-once-then-anchor semantics: unlike KGP, Sixel has no
+/// notion of relocating, resizing, or re-cropping an existing placement.
+/// </para>
+/// </remarks>
+internal sealed class SixelPlacement
+{
+    internal SixelPlacement(
+        SixelData image,
+        int row,
+        int column,
+        int widthInCells,
+        int heightInCells,
+        int paintedRowOffset,
+        int paintedRowCount,
+        int paintedColumnOffset,
+        int paintedColumnCount,
+        long sequence,
+        DateTimeOffset createdAt)
+    {
+        Image = image;
+        Row = row;
+        Column = column;
+        WidthInCells = widthInCells;
+        HeightInCells = heightInCells;
+        PaintedRowOffset = paintedRowOffset;
+        PaintedRowCount = paintedRowCount;
+        PaintedColumnOffset = paintedColumnOffset;
+        PaintedColumnCount = paintedColumnCount;
+        Sequence = sequence;
+        CreatedAt = createdAt;
+    }
+
+    /// <summary>
+    /// The raster resource this placement projects: the authoritative decoded
+    /// raster, or a geometry-only outcome when the rasterizer refused pixel
+    /// allocation. Also carries this image's logical/rendered/declared/painted
+    /// extents, creation-time <see cref="Hex1b.Sixel.SixelCellMetrics"/>,
+    /// background mode, aspect state, stable content identity, and protocol
+    /// diagnostics (see <see cref="SixelData.ParseResult"/> and
+    /// <see cref="SixelData.Raster"/>).
+    /// </summary>
+    internal SixelData Image { get; }
+
+    /// <summary>
+    /// The anchor row (0-based, in the owning screen's local coordinate
+    /// space). Mutable so scroll and history operations can shift it in place.
+    /// </summary>
+    internal int Row { get; set; }
+
+    /// <summary>
+    /// The anchor column. Sixel placements never move horizontally, so this
+    /// never changes after creation.
+    /// </summary>
+    internal int Column { get; }
+
+    /// <summary>
+    /// The unclipped occupied width, in cells, of the source geometry (the
+    /// anchor + occupied cell span the issue requires each placement to
+    /// retain, independent of how much of it actually painted).
+    /// </summary>
+    internal int WidthInCells { get; }
+
+    /// <summary>
+    /// The unclipped occupied height, in cells, of the source geometry.
+    /// </summary>
+    internal int HeightInCells { get; }
+
+    /// <summary>
+    /// Row offset (relative to <see cref="Row"/>) where the visible/painted
+    /// crop begins. Stored relative to the anchor so shifting <see cref="Row"/>
+    /// during scrolling automatically keeps the crop consistent.
+    /// </summary>
+    internal int PaintedRowOffset { get; }
+
+    /// <summary>
+    /// Number of rows actually painted: the visible crop clipped to the
+    /// scrolling region/page bounds in effect when the placement was created.
+    /// </summary>
+    internal int PaintedRowCount { get; }
+
+    /// <summary>
+    /// Column offset (relative to <see cref="Column"/>) where the
+    /// visible/painted crop begins.
+    /// </summary>
+    internal int PaintedColumnOffset { get; }
+
+    /// <summary>
+    /// Number of columns actually painted.
+    /// </summary>
+    internal int PaintedColumnCount { get; }
+
+    /// <summary>
+    /// Monotonic write sequence used to order overlapping placements (later
+    /// sequence paints on top), and to disambiguate otherwise-identical
+    /// placements created from the same content.
+    /// </summary>
+    internal long Sequence { get; }
+
+    /// <summary>When this placement was created.</summary>
+    internal DateTimeOffset CreatedAt { get; }
+
+    /// <summary>
+    /// <see langword="true"/> when the authoritative rasterizer could not
+    /// produce pixels for this placement's image (a geometry-only outcome).
+    /// Geometry-only placements are always retained, never silently dropped.
+    /// </summary>
+    internal bool IsGeometryOnly => Image.Raster.Status == SixelRasterStatus.GeometryOnly;
+
+    /// <summary>
+    /// <see langword="true"/> when this placement paints at least one cell.
+    /// A graphic clipped entirely outside the scrolling region at creation
+    /// time can have a zero-size painted crop while still occupying its
+    /// declared cell span.
+    /// </summary>
+    internal bool HasPaintedExtent => PaintedRowCount > 0 && PaintedColumnCount > 0;
+
+    /// <summary>Absolute top row of the painted/visible crop.</summary>
+    internal int PaintedTop => Row + PaintedRowOffset;
+
+    /// <summary>Absolute bottom row (inclusive) of the painted/visible crop.</summary>
+    internal int PaintedBottom => PaintedTop + PaintedRowCount - 1;
+
+    /// <summary>Absolute left column of the painted/visible crop.</summary>
+    internal int PaintedLeft => Column + PaintedColumnOffset;
+
+    /// <summary>Absolute right column (inclusive) of the painted/visible crop.</summary>
+    internal int PaintedRight => PaintedLeft + PaintedColumnCount - 1;
+
+    /// <summary>Whether the painted/visible crop of this placement covers the given cell.</summary>
+    internal bool CoversCell(int row, int column) =>
+        HasPaintedExtent
+        && row >= PaintedTop && row <= PaintedBottom
+        && column >= PaintedLeft && column <= PaintedRight;
+
+    /// <summary>Creates a copy of this placement repositioned to <paramref name="row"/>.</summary>
+    /// <remarks>
+    /// Used when projecting placements into a snapshot: the snapshot's copy is
+    /// a fully independent object so it keeps the referenced <see cref="Image"/>
+    /// reachable (via ordinary GC) even after the live placement it was copied
+    /// from is removed from the active graphics state.
+    /// </remarks>
+    internal SixelPlacement WithRow(int row) => new(
+        Image,
+        row,
+        Column,
+        WidthInCells,
+        HeightInCells,
+        PaintedRowOffset,
+        PaintedRowCount,
+        PaintedColumnOffset,
+        PaintedColumnCount,
+        Sequence,
+        CreatedAt);
+}

--- a/src/Hex1b/Sixel/SixelScreenGraphicsState.cs
+++ b/src/Hex1b/Sixel/SixelScreenGraphicsState.cs
@@ -1,0 +1,50 @@
+using Hex1b.Sixel;
+
+namespace Hex1b;
+
+/// <summary>
+/// One screen's (main or alternate) independent Sixel graphics state: its
+/// image store, its live placements, and (main screen only) the placements
+/// that have scrolled into scrollback history, partitioned by scrollback row
+/// identity.
+/// </summary>
+internal sealed class SixelScreenGraphicsState
+{
+    internal SixelImageStore Images { get; } = new();
+
+    internal List<SixelPlacement> Placements { get; } = [];
+
+    /// <summary>
+    /// Placements that scrolled into history, keyed by the stable scrollback
+    /// row identity (<see cref="ScrollbackEntry.RowId"/>) they are anchored
+    /// to. Only ever populated for the main screen; the alternate screen has
+    /// no history partition.
+    /// </summary>
+    internal Dictionary<long, List<SixelPlacement>> HistoryPlacements { get; } = [];
+
+    internal void Clear()
+    {
+        Placements.Clear();
+        HistoryPlacements.Clear();
+        Images.Clear();
+    }
+
+    /// <summary>
+    /// Recomputes which images are still reachable from this screen's live
+    /// placements and history placements, sweeping everything else from
+    /// <see cref="Images"/>.
+    /// </summary>
+    internal void ReconcileImages()
+    {
+        var retained = new HashSet<byte[]>(SixelContentHashComparer.Instance);
+        foreach (var placement in Placements)
+            retained.Add(placement.Image.ContentHash);
+        foreach (var list in HistoryPlacements.Values)
+        {
+            foreach (var placement in list)
+                retained.Add(placement.Image.ContentHash);
+        }
+
+        Images.RemoveUnreferenced(retained);
+    }
+}

--- a/src/Hex1b/Sixel/SixelScrollRegion.cs
+++ b/src/Hex1b/Sixel/SixelScrollRegion.cs
@@ -1,0 +1,15 @@
+using Hex1b.Sixel;
+
+namespace Hex1b;
+
+/// <summary>
+/// Describes the rectangle a scroll or margin operation affects, for the
+/// purpose of deciding which Sixel placements shift, get clipped, or drop.
+/// </summary>
+/// <remarks>
+/// Deliberately independent of <see cref="KgpScrollRectangle"/>: the two
+/// graphics states share the general shape of this concept, but keeping the
+/// types separate avoids any compile-time coupling between the Sixel and KGP
+/// graphics models.
+/// </remarks>
+internal readonly record struct SixelScrollRegion(int Top, int Bottom, int Left, int Right);

--- a/src/Hex1b/TerminalCell.cs
+++ b/src/Hex1b/TerminalCell.cs
@@ -11,10 +11,16 @@ namespace Hex1b;
 /// <param name="Attributes">Text styling attributes (bold, italic, etc.).</param>
 /// <param name="Sequence">The write order of this cell. Higher values were written later. Used for z-ordering during rendering.</param>
 /// <param name="WrittenAt">The timestamp when this cell was written. Useful for debugging and future animation features.</param>
-/// <param name="TrackedSixel">Optional tracked reference to Sixel graphics data associated with this cell.</param>
 /// <param name="TrackedHyperlink">Optional tracked reference to hyperlink data associated with this cell.</param>
 /// <param name="UnderlineColor">The underline color (SGR 58), or null to use the foreground color.</param>
 /// <param name="UnderlineStyle">The underline style (SGR 4:x). Defaults to <see cref="Hex1b.UnderlineStyle.None"/>.</param>
+/// <remarks>
+/// Sixel graphics are no longer owned by a cell. A cell that happens to sit
+/// under a Sixel placement carries no marker or reference at all; placement
+/// occupancy and image lifetime are tracked independently by the terminal's
+/// Sixel graphics state (see <c>SixelGraphicsState</c>) so overwriting a cell
+/// never has side effects on Sixel image lifetime.
+/// </remarks>
 public readonly record struct TerminalCell(
     string Character,
     Hex1bColor? Foreground,
@@ -22,7 +28,6 @@ public readonly record struct TerminalCell(
     CellAttributes Attributes = CellAttributes.None,
     long Sequence = 0,
     DateTimeOffset WrittenAt = default,
-    TrackedObject<SixelData>? TrackedSixel = null,
     TrackedObject<HyperlinkData>? TrackedHyperlink = null,
     Hex1bColor? UnderlineColor = null,
     UnderlineStyle UnderlineStyle = UnderlineStyle.None)
@@ -57,17 +62,8 @@ public readonly record struct TerminalCell(
     /// <summary>Gets whether this cell has overlined text.</summary>
     public bool IsOverline => (Attributes & CellAttributes.Overline) != 0;
 
-    /// <summary>Gets whether this cell contains Sixel graphics.</summary>
-    public bool IsSixel => (Attributes & CellAttributes.Sixel) != 0;
-
     /// <summary>Gets whether this cell is a soft-wrap point (content continues on the next row).</summary>
     public bool IsSoftWrap => (Attributes & CellAttributes.SoftWrap) != 0;
-
-    /// <summary>Gets the Sixel data if this cell has any, otherwise null.</summary>
-    public SixelData? SixelData => TrackedSixel?.Data;
-
-    /// <summary>Gets whether this cell has associated Sixel data.</summary>
-    public bool HasSixelData => TrackedSixel is not null;
 
     /// <summary>Gets the hyperlink data if this cell has any, otherwise null.</summary>
     public HyperlinkData? HyperlinkData => TrackedHyperlink?.Data;

--- a/tests/Hex1b.Tests/Sixel/SixelParserTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelParserTests.cs
@@ -276,7 +276,7 @@ public class SixelParserTests
             .ToArray();
         await terminal.FeedAsync(bytes, cancellationToken: TestContext.Current.CancellationToken);
         await terminal.WaitForAsync(
-            snapshot => snapshot.GetCell(0, 1).SixelData is not null,
+            snapshot => snapshot.GetSixelDataAt(0, 1) is not null,
             "persistent palette register",
             TestContext.Current.CancellationToken);
 

--- a/tests/Hex1b.Tests/Sixel/SixelPlacementLifetimeTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelPlacementLifetimeTests.cs
@@ -1,0 +1,318 @@
+using System.Text;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests.Sixel;
+
+/// <summary>
+/// Regression/integration coverage for stage #451's independent Sixel raster
+/// storage and placement state: <see cref="Hex1b.SixelGraphicsState"/> and its
+/// per-screen <see cref="Hex1b.SixelImageStore"/>/placement lists.
+/// </summary>
+/// <remarks>
+/// These tests exercise the terminal end-to-end through hand-authored raw DCS
+/// Sixel byte sequences (via <see cref="SixelFixture"/>/<see cref="SixelTestTerminal"/>),
+/// asserting on the placement/image bookkeeping the old per-cell
+/// <c>CellAttributes.Sixel</c> ownership model used to own. They intentionally
+/// avoid destructive overlap/erase semantics (#453) and scrolling/reflow
+/// projection across the scrollback boundary (#452); see
+/// <see cref="SixelScrollingTests"/> and <see cref="SixelTerminalSemanticsTests"/>
+/// for the deferred placeholders covering those stages.
+/// </remarks>
+[TestClass]
+public class SixelPlacementLifetimeTests
+{
+    private static readonly SixelFixture SingleBand = SixelFixture.Load(
+        "single-band",
+        "One-band cursor and lifecycle probe.");
+
+    [TestMethod]
+    public async Task Placement_SpanningMultipleCells_OccupiesItsEntireDeclaredSpan()
+    {
+        var wide = new SixelFixture(
+            "wide-multirow",
+            "A four-column, two-band-tall image occupying multiple cells.",
+            "q#1;2;100;0;0#1!4~-!4~"u8.ToArray());
+        await using var terminal = SixelTestTerminal.Create(cellPixelWidth: 1, cellPixelHeight: 6);
+
+        await terminal.FeedAsync(wide.StandardBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            wide.Name,
+            TestContext.Current.CancellationToken);
+
+        var placement = TestSeq.Single(terminal.Terminal.SixelPlacements);
+        Assert.IsGreaterThan(1, placement.WidthInCells);
+        Assert.IsGreaterThan(1, placement.HeightInCells);
+
+        var observation = terminal.Observe();
+        Assert.HasCount(
+            placement.WidthInCells * placement.HeightInCells,
+            observation.OccupiedCells);
+    }
+
+    [TestMethod]
+    public async Task IdenticalPayloads_AtDifferentPositions_ShareOneImageAcrossTwoPlacements()
+    {
+        await using var terminal = SixelTestTerminal.Create();
+
+        var bytes = SingleBand.StandardBytes
+            .Concat(Encoding.ASCII.GetBytes("\x1b[5;1H"))
+            .Concat(SingleBand.StandardBytes)
+            .ToArray();
+
+        await terminal.FeedAsync(bytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => terminal.Terminal.SixelPlacementCount == 2,
+            "two placements from identical content",
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(1, terminal.Terminal.TrackedSixelCount);
+        Assert.AreEqual(2, terminal.Terminal.SixelPlacementCount);
+
+        var placements = terminal.Terminal.SixelPlacements;
+        Assert.AreSame(placements[0].Image, placements[1].Image);
+    }
+
+    [TestMethod]
+    public async Task OverlappingPlacements_AreBothRetained_AndQueryReturnsTheTopmost()
+    {
+        var red = new SixelFixture(
+            "overlap-red",
+            "A red band occupying the origin cell.",
+            "q#1;2;100;0;0#1~"u8.ToArray());
+        var green = new SixelFixture(
+            "overlap-green",
+            "A green band painted at the same origin afterwards.",
+            "q#2;2;0;100;0#2~"u8.ToArray());
+        await using var terminal = SixelTestTerminal.Create();
+
+        var bytes = red.StandardBytes.Concat(Encoding.ASCII.GetBytes("\x1b[1;1H")).Concat(green.StandardBytes).ToArray();
+        await terminal.FeedAsync(bytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => terminal.Terminal.SixelPlacementCount == 2,
+            "two overlapping placements",
+            TestContext.Current.CancellationToken);
+
+        // Both rasters remain independently retained even though they occupy
+        // the exact same cell span (the old cell-owned model could only ever
+        // retain one raster per cell).
+        Assert.AreEqual(2, terminal.Terminal.TrackedSixelCount);
+        Assert.AreEqual(2, terminal.Terminal.SixelPlacementCount);
+
+        using var snapshot = terminal.Terminal.CreateSnapshot();
+        var topmost = snapshot.GetSixelDataAt(0, 0);
+        Assert.IsNotNull(topmost);
+        // The green placement was written last, so it is the topmost by
+        // write sequence even though the red placement below it still exists.
+        Assert.Contains("0;100;0", topmost.Payload);
+    }
+
+    [TestMethod]
+    public async Task GeometryOnlyPlacement_IsRetainedAsAPlacementNotSilentlyDropped()
+    {
+        await using var terminal = SixelTestTerminal.Create();
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1bP0;1q\"1;1;999999999;999999999#1@\x1b\\"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => terminal.Terminal.SixelPlacementCount == 1,
+            "geometry-only placement retained",
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(1, terminal.Terminal.TrackedSixelCount);
+        var placement = TestSeq.Single(terminal.Terminal.SixelPlacements);
+        Assert.IsTrue(placement.IsGeometryOnly);
+        Assert.IsTrue(placement.WidthInCells > 0);
+    }
+
+    [TestMethod]
+    public async Task OriginCellOverwrittenWithText_DoesNotPrematurelyReleaseTheImage()
+    {
+        var wide = new SixelFixture(
+            "origin-overwrite",
+            "A two-column band so the origin cell can be overwritten while the second cell still paints.",
+            "q#1;2;100;0;0#1!2~"u8.ToArray());
+        await using var terminal = SixelTestTerminal.Create();
+
+        await terminal.FeedAsync(wide.StandardBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            wide.Name,
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(1, terminal.Terminal.TrackedSixelCount);
+        Assert.AreEqual(1, terminal.Terminal.SixelPlacementCount);
+
+        // Overwrite only the origin cell (column 0) with plain text.
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[1;1HX"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsText("X"),
+            "origin cell overwritten",
+            TestContext.Current.CancellationToken);
+
+        // The placement (and its image) is still fully reachable: only the
+        // origin's text-grid glyph changed, not the graphics ownership.
+        Assert.AreEqual(1, terminal.Terminal.TrackedSixelCount);
+        Assert.AreEqual(1, terminal.Terminal.SixelPlacementCount);
+        Assert.IsNotNull(terminal.Terminal.GetSixelDataAt(1, 0));
+    }
+
+    [TestMethod]
+    public async Task Placement_RemovedFromActiveScreen_StillReachableThroughAnExistingSnapshot()
+    {
+        await using var terminal = SixelTestTerminal.Create();
+
+        await terminal.FeedAsync(SingleBand.StandardBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "graphic before clear",
+            TestContext.Current.CancellationToken);
+
+        using var snapshotBeforeClear = terminal.Terminal.CreateSnapshot();
+        Assert.IsTrue(snapshotBeforeClear.ContainsSixelData());
+
+        // Erase-in-display (all) removes the placement from the live screen.
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[2J"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.SixelPlacementCount == 0,
+            "graphic cleared from live screen",
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(0, terminal.Terminal.TrackedSixelCount);
+        Assert.AreEqual(0, terminal.Terminal.SixelPlacementCount);
+
+        // The earlier snapshot copied its own placements/images, so it still
+        // observes the graphic even though the live screen released it.
+        Assert.IsTrue(snapshotBeforeClear.ContainsSixelData());
+        Assert.IsNotNull(snapshotBeforeClear.GetSixelDataAt(0, 0));
+    }
+
+    [TestMethod]
+    public async Task AlternateScreen_OwnsIndependentPlacementsFromTheMainScreen()
+    {
+        var alternateFixture = new SixelFixture(
+            "alt-only",
+            "A green band written only to the alternate screen.",
+            "q#2;2;0;100;0#2~"u8.ToArray());
+        await using var terminal = SixelTestTerminal.Create();
+
+        await terminal.FeedAsync(SingleBand.StandardBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "graphic on main screen",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(1, terminal.Terminal.SixelPlacementCount);
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[?1049h").Concat(alternateFixture.StandardBytes).ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.InAlternateScreen && terminal.Terminal.SixelPlacementCount == 1,
+            "graphic on alternate screen",
+            TestContext.Current.CancellationToken);
+
+        // The alternate screen's single placement is the *alternate* graphic,
+        // not the main screen's (they don't merge or interfere).
+        var altPlacement = TestSeq.Single(terminal.Terminal.SixelPlacements);
+        Assert.Contains("0;100;0", altPlacement.Image.Payload);
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[?1049l"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => !snapshot.InAlternateScreen,
+            "return to main screen",
+            TestContext.Current.CancellationToken);
+
+        // The main screen's original graphic is exactly as it was; the
+        // alternate screen's graphic is gone with the alternate state.
+        var mainPlacement = TestSeq.Single(terminal.Terminal.SixelPlacements);
+        Assert.Contains("2;100;0;0", mainPlacement.Image.Payload);
+    }
+
+    [TestMethod]
+    public async Task RepeatedAlternateScreenEntry_ResetsOnlyTheAlternateState()
+    {
+        await using var terminal = SixelTestTerminal.Create();
+
+        await terminal.FeedAsync(SingleBand.StandardBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "graphic on main screen",
+            TestContext.Current.CancellationToken);
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[?1049h").Concat(SingleBand.StandardBytes).ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.InAlternateScreen && terminal.Terminal.SixelPlacementCount == 1,
+            "first alternate graphic",
+            TestContext.Current.CancellationToken);
+
+        // Entering the alternate screen again (already active) resets only
+        // the alternate graphics state: the prior alternate placement is gone,
+        // and nothing here touches the main screen's placement.
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[?1049h"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.SixelPlacementCount == 0,
+            "re-entering the alternate screen clears the alternate placement",
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(0, terminal.Terminal.SixelPlacementCount);
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[?1049l"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => !snapshot.InAlternateScreen,
+            "return to main screen",
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(1, terminal.Terminal.SixelPlacementCount);
+    }
+
+    [TestMethod]
+    public async Task Ris_ClearsBothMainAndAlternateGraphicsState()
+    {
+        await using var terminal = SixelTestTerminal.Create();
+
+        await terminal.FeedAsync(SingleBand.StandardBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "graphic on main screen",
+            TestContext.Current.CancellationToken);
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[?1049h").Concat(SingleBand.StandardBytes).ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.InAlternateScreen && terminal.Terminal.SixelPlacementCount == 1,
+            "graphic on alternate screen",
+            TestContext.Current.CancellationToken);
+
+        // The raw byte path does not yet decode ESC c into a RIS token (owned
+        // by #453), so drive the reset through the token stream directly,
+        // mirroring SixelRasterIntegrationTests.ColorRegisters_AreResetByRis.
+        await terminal.FeedPreTokenizedAsync(
+            Encoding.ASCII.GetBytes("\x1bc"),
+            [RisToken.Instance],
+            TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => !snapshot.InAlternateScreen,
+            "RIS restores the main screen",
+            TestContext.Current.CancellationToken);
+
+        // RIS is a full reset: both the main and the (now-exited) alternate
+        // graphics state are cleared, unlike a plain alternate-screen exit
+        // which only discards the alternate state.
+        Assert.AreEqual(0, terminal.Terminal.TrackedSixelCount);
+        Assert.AreEqual(0, terminal.Terminal.SixelPlacementCount);
+    }
+}

--- a/tests/Hex1b.Tests/Sixel/SixelPlacementLifetimeTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelPlacementLifetimeTests.cs
@@ -71,6 +71,7 @@ public class SixelPlacementLifetimeTests
 
         var placements = terminal.Terminal.SixelPlacements;
         Assert.AreSame(placements[0].Image, placements[1].Image);
+        Assert.AreNotEqual(placements[0].Row, placements[1].Row);
     }
 
     [TestMethod]

--- a/tests/Hex1b.Tests/Sixel/SixelRasterIntegrationTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelRasterIntegrationTests.cs
@@ -28,7 +28,7 @@ public class SixelRasterIntegrationTests
             "\x1b[48;2;0;255;0m",
             "\x1bP0;0q#1@\x1b\\");
         await terminal.WaitForAsync(
-            snapshot => snapshot.GetCell(0, 1).SixelData is not null,
+            snapshot => snapshot.GetSixelDataAt(0, 1) is not null,
             "two backgrounds",
             TestContext.Current.CancellationToken);
 
@@ -85,7 +85,7 @@ public class SixelRasterIntegrationTests
             "\x1b[3;1H",
             "\x1bP0;1q#1@\x1b\\");
         await terminal.WaitForAsync(
-            snapshot => snapshot.GetCell(0, 2).SixelData is not null,
+            snapshot => snapshot.GetSixelDataAt(0, 2) is not null,
             "soft reset palette",
             TestContext.Current.CancellationToken);
 
@@ -178,7 +178,7 @@ public class SixelRasterIntegrationTests
         Assert.IsTrue(observation.OccupiedCells.Count > 0);
 
         using var snapshot = terminal.Terminal.CreateSnapshot();
-        var data = snapshot.GetCell(0, 0).SixelData;
+        var data = snapshot.GetSixelDataAt(0, 0);
         Assert.IsNotNull(data);
         Assert.IsNull(data.GetPixels());
         Assert.AreEqual(SixelRasterStatus.GeometryOnly, data.Raster.Status);

--- a/tests/Hex1b.Tests/Sixel/SixelScrollingTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelScrollingTests.cs
@@ -10,7 +10,7 @@ public class SixelScrollingTests
         "scrolling",
         "A two-band image used to inspect viewport and history behavior.");
 
-    [TestMethod, Ignore("Owned by #452: Sixel graphics are cell-owned and cannot project across the scrollback boundary.")]
+    [TestMethod, Ignore("Owned by #452: a placement that spans the scrollback boundary is not yet split into independent screen/history projections (full-fidelity scrolling/reflow).")]
     public async Task FullScreenScroll_PreservesGraphicAcrossVisibleAndHistoryRows()
     {
         await using var terminal = SixelTestTerminal.Create(
@@ -33,7 +33,7 @@ public class SixelScrollingTests
         Assert.IsNotEmpty(visibleOnly.OccupiedRows);
     }
 
-    [TestMethod, Ignore("Owned by #452: resize currently crops cell-owned Sixel references instead of clipping placements.")]
+    [TestMethod]
     public async Task ResizeNarrower_ClipsGraphicWithoutDestroyingSourceState()
     {
         var fixture = new SixelFixture(

--- a/tests/Hex1b.Tests/Sixel/SixelTerminalSemanticsTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelTerminalSemanticsTests.cs
@@ -76,7 +76,7 @@ public class SixelTerminalSemanticsTests
             terminal.Observe().CompositePixelGrid());
     }
 
-    [TestMethod, Ignore("Owned by #453: erase operations do not yet target independent Sixel placements.")]
+    [TestMethod]
     public async Task EraseDisplay_ClearsOverlappingGraphic()
     {
         await using var terminal = SixelTestTerminal.Create();
@@ -98,7 +98,7 @@ public class SixelTerminalSemanticsTests
         Assert.IsEmpty(terminal.Observe().Placements);
     }
 
-    [TestMethod, Ignore("Owned by #453: overlapping Sixel sequences are not independently composited.")]
+    [TestMethod, Ignore("Owned by #453: overlapping Sixel sequences retain independent placements (see SixelPlacementLifetimeTests), but pixel-level transparent compositing of overlapping rasters for rendering is deferred.")]
     public async Task TransparentSixelOverExistingSixel_PreservesUnpaintedPixels()
     {
         var baseImage = new SixelFixture(
@@ -126,7 +126,7 @@ public class SixelTerminalSemanticsTests
         Assert.StartsWith("AA\nB.", composite);
     }
 
-    [TestMethod, Ignore("Owned by #453: RIS does not yet reset independent Sixel graphics and palette state.")]
+    [TestMethod]
     public async Task Ris_ClearsGraphicsAndResetsPalette()
     {
         var defineRegister = new SixelFixture(
@@ -139,13 +139,25 @@ public class SixelTerminalSemanticsTests
             "q#5@"u8.ToArray());
         await using var terminal = SixelTestTerminal.Create();
         await using var freshTerminal = SixelTestTerminal.Create();
-        var bytes = defineRegister.StandardBytes
-            .Concat(Encoding.ASCII.GetBytes("\x1bc"))
-            .Concat(selectAfterReset.StandardBytes)
-            .Concat("X"u8.ToArray())
-            .ToArray();
 
-        await terminal.FeedAsync(bytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.FeedAsync(
+            defineRegister.StandardBytes,
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "graphic before RIS",
+            TestContext.Current.CancellationToken);
+
+        // The raw byte path does not yet decode ESC c into a RIS token (owned by
+        // #453), so drive the reset through the token stream directly, mirroring
+        // SixelRasterIntegrationTests.ColorRegisters_AreResetByRis.
+        await terminal.FeedPreTokenizedAsync(
+            Encoding.ASCII.GetBytes("\x1bc"),
+            [Hex1b.Tokens.RisToken.Instance],
+            TestContext.Current.CancellationToken);
+        await terminal.FeedAsync(
+            selectAfterReset.StandardBytes.Concat("X"u8.ToArray()).ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken);
         await terminal.WaitForAsync(
             snapshot => snapshot.ContainsText("X"),
             "RIS clearing Sixel state",
@@ -166,7 +178,7 @@ public class SixelTerminalSemanticsTests
         Assert.DoesNotContain("#FF0000FF", afterReset);
     }
 
-    [TestMethod, Ignore("Owned by #453: main and alternate screens do not yet own independent Sixel placement state.")]
+    [TestMethod]
     public async Task AlternateScreenExit_RestoresMainScreenGraphic()
     {
         await using var terminal = SixelTestTerminal.Create();

--- a/tests/Hex1b.Tests/Sixel/SixelTestTerminal.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelTestTerminal.cs
@@ -173,37 +173,45 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
         var placements = new List<SixelPlacementObservation>();
         var occupiedRows = new HashSet<SixelOccupiedRow>();
         var occupiedCells = new HashSet<SixelOccupiedCell>();
-        for (var y = 0; y < snapshot.Height; y++)
-        {
-            for (var x = 0; x < snapshot.Width; x++)
-            {
-                var cell = snapshot.GetCell(x, y);
-                if (cell.IsSixel)
-                {
-                    occupiedRows.Add(new SixelOccupiedRow(y, y < snapshot.ScrollbackLineCount));
-                    occupiedCells.Add(new SixelOccupiedCell(
-                        x,
-                        y,
-                        y < snapshot.ScrollbackLineCount));
-                }
 
-                var sixel = cell.SixelData;
-                if (sixel is null)
+        // Sixel placements are now independent state, not per-cell ownership,
+        // so occupancy/placement observation walks the snapshot's placements
+        // directly rather than scanning cells for a Sixel flag/reference.
+        foreach (var placement in snapshot.SixelPlacements)
+        {
+            if (!placement.HasPaintedExtent)
+                continue;
+
+            for (var y = placement.PaintedTop; y <= placement.PaintedBottom; y++)
+            {
+                if (y < 0 || y >= snapshot.Height)
                     continue;
 
-                var pixels = sixel.GetPixels();
-                placements.Add(new SixelPlacementObservation(
-                    x,
-                    y,
-                    sixel.WidthInCells,
-                    sixel.HeightInCells,
-                    sixel.Payload,
-                    pixels?.Width ?? 0,
-                    pixels?.Height ?? 0,
-                    pixels is null ? "" : SixelPixelGrid.Format(pixels),
-                    pixels,
-                    sixel.CellMetrics));
+                var inScrollback = y < snapshot.ScrollbackLineCount;
+                occupiedRows.Add(new SixelOccupiedRow(y, inScrollback));
+
+                for (var x = placement.PaintedLeft; x <= placement.PaintedRight; x++)
+                {
+                    if (x < 0 || x >= snapshot.Width)
+                        continue;
+
+                    occupiedCells.Add(new SixelOccupiedCell(x, y, inScrollback));
+                }
             }
+
+            var sixel = placement.Image;
+            var pixels = sixel.GetPixels();
+            placements.Add(new SixelPlacementObservation(
+                placement.PaintedLeft,
+                placement.PaintedTop,
+                sixel.WidthInCells,
+                sixel.HeightInCells,
+                sixel.Payload,
+                pixels?.Width ?? 0,
+                pixels?.Height ?? 0,
+                pixels is null ? "" : SixelPixelGrid.Format(pixels),
+                pixels,
+                sixel.CellMetrics));
         }
 
         return new SixelTerminalObservation(
@@ -225,14 +233,11 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
     public string CreateSvgEvidence()
     {
         using var snapshot = Terminal.CreateSnapshot(scrollbackLines: Terminal.ScrollbackCount);
-        for (var y = 0; y < snapshot.Height; y++)
+        foreach (var placement in snapshot.SixelPlacements)
         {
-            for (var x = 0; x < snapshot.Width; x++)
-            {
-                var pixels = snapshot.GetCell(x, y).SixelData?.GetPixels();
-                if (pixels is not null)
-                    return SixelPixelGrid.ToSvg(pixels);
-            }
+            var pixels = placement.Image.GetPixels();
+            if (pixels is not null)
+                return SixelPixelGrid.ToSvg(pixels);
         }
 
         throw new InvalidOperationException("No decoded Sixel raster is available for SVG evidence.");
@@ -493,6 +498,30 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
                 appliedTokens.Select(applied => applied.Token));
             return WriteOutputAsync(bytes, ct);
         }
+    }
+}
+
+/// <summary>
+/// Test-only convenience for querying which Sixel image (if any) paints a
+/// specific cell in a snapshot. Sixel graphics are independent placement
+/// state now (stage #451), not per-cell ownership, so this is a small
+/// "topmost placement covering this cell" search rather than a direct cell
+/// property lookup.
+/// </summary>
+internal static class SixelSnapshotExtensions
+{
+    public static SixelData? GetSixelDataAt(this Hex1bTerminalSnapshot snapshot, int x, int y)
+    {
+        SixelPlacement? topmost = null;
+        foreach (var placement in snapshot.SixelPlacements)
+        {
+            if (!placement.CoversCell(y, x))
+                continue;
+            if (topmost is null || placement.Sequence > topmost.Sequence)
+                topmost = placement;
+        }
+
+        return topmost?.Image;
     }
 }
 

--- a/tests/Hex1b.Tests/TrackedObjectTests.cs
+++ b/tests/Hex1b.Tests/TrackedObjectTests.cs
@@ -137,7 +137,7 @@ public class TrackedObjectTests
     }
 
     [TestMethod]
-    public async Task TrackedSixel_WhenCellOverwritten_ReleasesReference()
+    public async Task TrackedSixel_WhenCellOverwritten_DoesNotPrematurelyReleaseImage()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
         using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
@@ -146,11 +146,15 @@ public class TrackedObjectTests
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1bPq#0;2;100;0;0#0~~~~~~\x1b\\"));
         Assert.AreEqual(1, terminal.TrackedSixelCount);
         
-        // Overwrite the cell with text
+        // Overwrite the origin cell with text. Under the old per-cell ownership
+        // model this released the tracked Sixel object; under the new
+        // placement-based model, lifetime is reachability-based (screen
+        // placements/history/snapshots), not tied to single-cell presence, so
+        // the image must remain reachable via its still-live placement.
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[1;1HXXXXXXXX"));
         
-        // Sixel data should be released (refcount reached 0)
-        Assert.AreEqual(0, terminal.TrackedSixelCount);
+        Assert.AreEqual(1, terminal.TrackedSixelCount);
+        Assert.AreEqual(1, terminal.SixelPlacementCount);
     }
 
     [TestMethod]
@@ -174,20 +178,19 @@ public class TrackedObjectTests
     }
 
     [TestMethod]
-    public async Task TrackedSixel_RefCount_IncreasesWithDeduplication()
+    public async Task TrackedSixel_Deduplication_SharesOneImageAcrossTwoPlacements()
     {
         using var workload = new Hex1bAppWorkloadAdapter();
         using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
         
-        // Process the same Sixel sequence twice
+        // Process the same Sixel sequence twice at different anchors
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1bPq#0;2;100;0;0#0~~~~~~\x1b\\"));
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[2;1H")); // Move cursor to next row
         terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1bPq#0;2;100;0;0#0~~~~~~\x1b\\"));
         
-        var trackedSixel = terminal.GetTrackedSixelAt(0, 0);
-        Assert.IsNotNull(trackedSixel);
-        
-        // RefCount should be 2 (one for each cell)
-        Assert.AreEqual(2, trackedSixel.RefCount);
+        // Two independent placements share the same underlying raster image:
+        // one distinct image, but two live placements referencing it.
+        Assert.AreEqual(1, terminal.TrackedSixelCount);
+        Assert.AreEqual(2, terminal.SixelPlacementCount);
     }
 }


### PR DESCRIPTION
Closes #451
Part of #445

## Summary

Replaces the old per-cell Sixel ownership model — `CellAttributes.Sixel` plus
origin/continuation-cell tracking through `TrackedObjectStore` — with
`SixelGraphicsState`: an independent, reachability-based graphics state for
the main and alternate screens. This is architecturally modeled on the
existing mature `KgpTerminalGraphicsState`, but deliberately smaller and
protocol-neutral, since Sixel has no image IDs, delete selectors, relative
placement graphs, or z-index.

## Architecture and lifetime accounting

- `SixelGraphicsState` (`src/Hex1b/Sixel/SixelGraphicsState.cs`) owns two
  independent `SixelScreenGraphicsState` instances (main, alternate).
  Re-entering the alternate screen while already active resets only the
  alternate instance; RIS is the only operation that clears both.
- Each `SixelScreenGraphicsState` owns a `SixelImageStore` (raster resources
  deduplicated by content hash — payload text plus captured
  background/palette identity) and a `Placements` list; the main screen also
  owns a `HistoryPlacements` partition keyed by stable scrollback row
  identity.
- `SixelPlacement` anchors a `SixelData` image at a cell position, retaining
  the occupied cell span, painted-crop geometry (offset/count relative to the
  anchor so scrolling doesn't require recomputing it), a monotonic write
  sequence (for deterministic topmost-wins overlap queries), and creation
  timestamp. `SixelData` itself is unchanged from earlier Sixel stages and
  already carries the authoritative decoded raster or geometry-only outcome,
  logical/rendered/declared extents, creation-time `SixelCellMetrics`,
  source/captured background, aspect state, content hash, and parser
  diagnostics.
- **Lifetime is reachability-based (mark-and-sweep), not manual reference
  counting**, mirroring `KgpImageStore`. Every placement-removing mutation
  recomputes the set of content hashes reachable from
  `Placements ∪ HistoryPlacements` and sweeps any image no longer in that
  set. A placement's image is never released just because the cell it's
  anchored to was overwritten with text — only when no placement (live,
  historical, or held by an existing snapshot) references it anymore.
  Snapshots decouple entirely: `Hex1bTerminalSnapshot` copies its own
  placement/image references, kept alive by ordinary GC.
- Geometry-only placements (rasterizer refused pixel allocation, e.g. an
  absurd declared canvas) are always retained as placements — never silently
  dropped.
- A finalized Sixel sequence creates one anonymous image plus one placement
  anchored at the position stage #450's cursor/metric logic already
  determines; this stage reuses `SixelParser`/`SixelRasterizer` and that
  cursor logic unchanged, with no duplicated parsing/rasterization/estimation
  logic.
- `TrackedObjectStore` no longer participates in Sixel image lifetime at all
  (it keeps its unrelated duties: hyperlinks, and the Surface/widget path's
  own `GetOrCreateSixel`, untouched by this stage). Compatibility surfaces
  (`ContainsSixelData()`, `GetSixelDataAt()`, `TrackedSixelCount`,
  `SixelPlacementCount`, `SixelPlacements`) are preserved, now backed by the
  placement/image model.

## What was extracted from KGP vs. kept separate

**Extracted as genuinely protocol-neutral primitives:** raster content
ownership by content hash, placement/source-crop geometry (anchor + occupied
span + painted crop), reachability-based (mark-and-sweep) lifetime
accounting, screen/history partitioning, and simple scroll/clip geometry
helpers.

**Deliberately kept KGP-only, not extracted:** public image/placement IDs,
image-number addressing, explicit delete selectors, relative placement
graphs, Unicode placeholders, z-index, and chunked uploads — none of these
concepts exist in the Sixel protocol. The two graphics states are separate
types with no compile-time coupling to each other; only the underlying
*strategy* is shared conceptually. All existing KGP tests (state, deletion,
scrolling/reflow, snapshot) were run and pass unmodified — no KGP source was
changed.

## API review outcome

Everything new (`SixelGraphicsState`, `SixelScreenGraphicsState`,
`SixelImageStore`, `SixelPlacement`, `SixelScrollRegion`,
`SixelContentHashComparer`, and the `Hex1bTerminal`/`Hex1bTerminalSnapshot`
inspection surfaces built on them) is `internal`. Per the `api-reviewer`
skill's guidance, these are Layer-1 implementation details of
`Hex1bTerminal`'s own model, with no demonstrated external consumer need yet
— `public` would be a one-way door before any such need is proven. One type
per file (the codebase convention) was applied by splitting what was
initially a single combined file into six.

## Tests added/activated

New: `tests/Hex1b.Tests/Sixel/SixelPlacementLifetimeTests.cs`
- `Placement_SpanningMultipleCells_OccupiesItsEntireDeclaredSpan`
- `IdenticalPayloads_AtDifferentPositions_ShareOneImageAcrossTwoPlacements`
- `OverlappingPlacements_AreBothRetained_AndQueryReturnsTheTopmost`
- `GeometryOnlyPlacement_IsRetainedAsAPlacementNotSilentlyDropped`
- `OriginCellOverwrittenWithText_DoesNotPrematurelyReleaseTheImage`
- `Placement_RemovedFromActiveScreen_StillReachableThroughAnExistingSnapshot`
- `AlternateScreen_OwnsIndependentPlacementsFromTheMainScreen`
- `RepeatedAlternateScreenEntry_ResetsOnlyTheAlternateState`
- `Ris_ClearsBothMainAndAlternateGraphicsState`

Activated (previously `[Ignore]`d, now satisfied by this stage) in
`tests/Hex1b.Tests/Sixel/SixelScrollingTests.cs` and
`SixelTerminalSemanticsTests.cs`:
- `ResizeNarrower_ClipsGraphicWithoutDestroyingSourceState`
- `EraseDisplay_ClearsOverlappingGraphic`
- `AlternateScreenExit_RestoresMainScreenGraphic`
- `Ris_ClearsGraphicsAndResetsPalette` (also fixed a harness bug: RIS bytes
  now flow through `FeedPreTokenizedAsync` with `RisToken.Instance`, mirroring
  `SixelRasterIntegrationTests.ColorRegisters_AreResetByRis`, since the raw
  byte tokenizer doesn't yet decode `ESC c` into a `RisToken`)

Remaining `[Ignore]`d with corrected reasons (genuinely out of scope for this
stage, not test bugs):
- `FullScreenScroll_PreservesGraphicAcrossVisibleAndHistoryRows` (#452 — a
  placement spanning the scrollback boundary isn't split into independent
  screen/history projections yet)
- `Reflow_WiderThenNarrower_PreservesGraphicAnchor` (#452)
- `TransparentSixelOverExistingSixel_PreservesUnpaintedPixels` (#453 —
  pixel-level alpha compositing across overlapping rasters, not an
  ownership/lifetime concern; both placements are already independently
  retained, verified by `OverlappingPlacements_AreBothRetained_AndQueryReturnsTheTopmost`)
- `TextWrittenOverGraphic_DamagesOnlyOverlappedGraphicArea` (#453)

Updated for the new API (no behavior change): `TrackedObjectTests.cs`,
`SixelParserTests.cs`, `SixelRasterIntegrationTests.cs`, `SixelTestTerminal.cs`.

## Demo evidence

`samples/SixelTerminalDemo/RawGraphicsStateScenes.cs` adds seven hand-authored
raw DCS Sixel scenes (no `SixelWidget`/`SixelEncoder`), wired into the numbered
demo screens and into `--headless`:
- Two placements sharing one raster image (dedup)
- Overlapping placements, both retained, with `GetSixelDataAt` probes showing
  the non-overlap cell resolves to the earlier placement and the overlap cell
  resolves to the later one
- A geometry-only placement (declared canvas exceeds the raster policy)
  retained as a placement with no pixels
- An origin cell overwritten with text, with a probe proving the placement
  and image are still fully reachable
- Alternate screen holding only its own placement while active
- Main screen's placement surviving a full alternate-screen round trip
  unchanged
- Repeated alternate-screen entry resetting only the alternate state (fresh
  entry shows 0 placements)

Run `dotnet run --project samples/SixelTerminalDemo -- --headless` to see the
placement/image counts and probe results printed under "Independent
graphics-state ownership observations (#451)"; run without `--headless` (or
with `--screen <n>`) to see them rendered interactively.

`docs/sixel-terminal-behavior.md` is updated with a new "Independent graphics
state (#451)" section and corrections to the ownership/erasure and
screens/scrollback/resize tables that previously attributed now-delivered
behavior to #452/#453.

## Deferred to #452/#453/#458 (explicitly out of scope for this PR)

- **#452** — full scrolling/reflow integration: splitting a single placement
  across the visible/history scrollback boundary, and reflow-driven
  re-anchoring on width change. This stage moves whole placements between
  viewport and history on simple full-screen scrolls, and clips (drops)
  placements only once wholly outside a resized viewport, but does not
  project a single placement across the boundary or re-anchor through reflow
  the way KGP does.
- **#453** — destructive overlap/erase/full lifecycle ownership semantics:
  pixel-level alpha compositing of overlapping rasters, partial-region
  ED/EL erase damage, and text-over-graphic pixel damage.
- **#458** — presentation protocol translation (re-emitting placements as
  Kitty/iTerm2/Sixel wire protocol).
- `SixelWidget`/`Surface`-produced Sixel and widget sizing changes are
  untouched.
- No duplicate parsers, estimators, or raster/geometry logic were added;
  `SixelParser`/`SixelRasterizer` and the existing #450 cursor/metric logic
  are reused unchanged.

## Validation

- `dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj --filter "FullyQualifiedName~Sixel|FullyQualifiedName~Kgp"` → 1505 total, 1501 succeeded, 0 failed, 4 skipped (all correctly attributed above)
- `dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj` (full, unfiltered) → 8943 total, 8915 succeeded, 0 failed, 28 skipped (pre-existing, unrelated)
- `dotnet test tests/Hex1b.Analyzers.Tests`, `tests/Hex1b.McpServer.Tests`, `tests/Hex1b.Tool.Tests`, `tests/AgenticPromptDemo.Tests` → all pass, 0 failed
- `dotnet build` across `src/Hex1b`, `tests/Hex1b.Tests`, `samples/SixelTerminalDemo` → clean, 0 errors
- `dotnet run --project samples/SixelTerminalDemo -- --headless` → verified manually, output matches expected model/probe descriptions

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

## Demo validation update

The shared-raster graphics-state demo now places the two identical red Sixel placements on separate rows. This keeps the #451 model assertion (2 placements backed by 1 raster image) while avoiding native terminal renderers such as WezTerm collapsing or obscuring multiple Sixel graphics that begin on the same terminal row. Same-row ordering/overlap remains covered by the dedicated overlap scene and by automated placement tests.