### PR TITLE
Add Azure Sandbox terminal demo

### DIFF
--- a/samples/AzureSandboxDemo/AcaCli.cs
+++ b/samples/AzureSandboxDemo/AcaCli.cs
@@ -1,0 +1,314 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace AzureSandboxDemo;
+
+internal sealed class AcaCli
+{
+    private static readonly TimeSpan DataPlaneAccessTimeout = TimeSpan.FromMinutes(2);
+    private static readonly TimeSpan DataPlaneAccessRetryDelay = TimeSpan.FromSeconds(5);
+
+    internal async Task<string> GetActiveSubscriptionIdAsync(CancellationToken cancellationToken)
+    {
+        var result = await RunAsync(
+            "az",
+            ["account", "show", "--query", "id", "--output", "tsv"],
+            cancellationToken);
+        return RequireValue(result.StandardOutput, "Azure CLI returned no active subscription.");
+    }
+
+    internal async Task<string> GetVersionAsync(CancellationToken cancellationToken)
+    {
+        var result = await RunAsync("aca", ["--version"], cancellationToken);
+        return RequireValue(result.StandardOutput, "ACA CLI returned no version.");
+    }
+
+    internal async Task CreateSandboxGroupAsync(
+        AzureSandboxSettings settings,
+        Action<string> reportStatus,
+        CancellationToken cancellationToken)
+    {
+        reportStatus("Creating or updating the Azure resource group...");
+        await RunAsync(
+            "az",
+            [
+                "group", "create",
+                "--name", settings.ResourceGroup,
+                "--location", settings.Region,
+                "--subscription", settings.SubscriptionId,
+                "--output", "none"
+            ],
+            cancellationToken);
+
+        reportStatus("Creating the sandbox group and assigning Data Owner access...");
+        await RunAsync(
+            "aca",
+            [
+                "sandboxgroup", "create",
+                "--name", settings.SandboxGroup,
+                "--location", settings.Region,
+                "--subscription", settings.SubscriptionId,
+                "--resource-group", settings.ResourceGroup,
+                "--output", "json"
+            ],
+            cancellationToken);
+
+        await WaitForDataPlaneAccessAsync(settings, reportStatus, cancellationToken);
+    }
+
+    internal async Task WaitForDataPlaneAccessAsync(
+        AzureSandboxSettings settings,
+        Action<string> reportStatus,
+        CancellationToken cancellationToken)
+    {
+        reportStatus("Checking ACA data-plane access...");
+        var deadline = DateTimeOffset.UtcNow + DataPlaneAccessTimeout;
+
+        while (true)
+        {
+            try
+            {
+                await RunAsync(
+                    "aca",
+                    [
+                        "sandbox", "list",
+                        "--group", settings.SandboxGroup,
+                        "--subscription", settings.SubscriptionId,
+                        "--resource-group", settings.ResourceGroup,
+                        "--region", settings.Region,
+                        "--output", "json"
+                    ],
+                    cancellationToken);
+                return;
+            }
+            catch (AcaCliCommandException ex) when (ex.IsForbidden)
+            {
+                if (DateTimeOffset.UtcNow >= deadline)
+                {
+                    throw new InvalidOperationException(
+                        "ACA data-plane access is still forbidden after waiting for role propagation. " +
+                        "Verify that the signed-in user has the Container Apps SandboxGroup Data Owner " +
+                        "role on the sandbox group.",
+                        ex);
+                }
+
+                reportStatus("Waiting for Container Apps SandboxGroup Data Owner role propagation...");
+                await Task.Delay(DataPlaneAccessRetryDelay, cancellationToken);
+            }
+        }
+    }
+
+    internal async Task<string> CreateSandboxAsync(
+        AzureSandboxSettings settings,
+        CancellationToken cancellationToken)
+    {
+        var result = await RunAsync(
+            "aca",
+            [
+                "sandbox", "create",
+                "--group", settings.SandboxGroup,
+                "--disk", settings.DiskImage,
+                "--subscription", settings.SubscriptionId,
+                "--resource-group", settings.ResourceGroup,
+                "--region", settings.Region,
+                "--output", "json"
+            ],
+            cancellationToken);
+
+        if (TryGetSandboxId(result.StandardOutput, out var id))
+        {
+            return id;
+        }
+
+        throw new InvalidOperationException(
+            $"ACA CLI sandbox creation response did not contain an id: {Normalize(result.StandardOutput)}");
+    }
+
+    internal Task DeleteSandboxAsync(
+        AzureSandboxSettings settings,
+        CancellationToken cancellationToken)
+        => RunAsync(
+            "aca",
+            [
+                "sandbox", "delete",
+                "--group", settings.SandboxGroup,
+                "--id", settings.SandboxId,
+                "--yes",
+                "--subscription", settings.SubscriptionId,
+                "--resource-group", settings.ResourceGroup,
+                "--region", settings.Region,
+                "--output", "json"
+            ],
+            cancellationToken);
+
+    internal Task DeleteSandboxGroupAsync(
+        AzureSandboxSettings settings,
+        CancellationToken cancellationToken)
+        => RunAsync(
+            "aca",
+            [
+                "sandboxgroup", "delete",
+                "--name", settings.SandboxGroup,
+                "--yes",
+                "--subscription", settings.SubscriptionId,
+                "--resource-group", settings.ResourceGroup,
+                "--output", "json"
+            ],
+            cancellationToken);
+
+    internal async Task<string> GetDataPlaneTokenAsync(
+        string subscriptionId,
+        CancellationToken cancellationToken)
+    {
+        var result = await RunAsync(
+            "az",
+            [
+                "account", "get-access-token",
+                "--subscription", subscriptionId,
+                "--scope", AzureSandboxWorkloadAdapter.DefaultTokenScope,
+                "--query", "accessToken",
+                "--output", "tsv"
+            ],
+            cancellationToken);
+        return RequireValue(result.StandardOutput, "Azure CLI returned no data-plane access token.");
+    }
+
+    private static async Task<ProcessResult> RunAsync(
+        string fileName,
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken)
+    {
+        var startInfo = new ProcessStartInfo(fileName)
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        Process process;
+        try
+        {
+            process = Process.Start(startInfo)
+                ?? throw new InvalidOperationException($"Failed to start '{fileName}'.");
+        }
+        catch (Win32Exception ex)
+        {
+            throw new InvalidOperationException(
+                $"'{fileName}' was not found. Install it and ensure it is available on PATH.",
+                ex);
+        }
+
+        using (process)
+        {
+            var standardOutput = process.StandardOutput.ReadToEndAsync();
+            var standardError = process.StandardError.ReadToEndAsync();
+
+            try
+            {
+                await process.WaitForExitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                    await process.WaitForExitAsync(CancellationToken.None);
+                }
+
+                throw;
+            }
+
+            var output = await standardOutput;
+            var error = await standardError;
+            if (process.ExitCode != 0)
+            {
+                var detail = string.IsNullOrWhiteSpace(error) ? output : error;
+                throw new AcaCliCommandException(fileName, process.ExitCode, detail);
+            }
+
+            return new ProcessResult(output.Trim(), error.Trim());
+        }
+    }
+
+    private static bool TryGetString(JsonElement element, string propertyName, out string value)
+    {
+        if (element.ValueKind == JsonValueKind.Object &&
+            element.TryGetProperty(propertyName, out var property) &&
+            property.ValueKind == JsonValueKind.String &&
+            property.GetString() is { Length: > 0 } text)
+        {
+            value = text;
+            return true;
+        }
+
+        value = "";
+        return false;
+    }
+
+    private static bool TryGetSandboxId(string output, out string id)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(output);
+            if (TryGetString(document.RootElement, "id", out id) ||
+                TryGetString(document.RootElement, "sandboxId", out id))
+            {
+                return true;
+            }
+        }
+        catch (JsonException)
+        {
+        }
+
+        foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            const string prefix = "Created sandbox:";
+            var trimmed = line.Trim();
+            if (trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                var candidate = trimmed[prefix.Length..].Trim();
+                if (Guid.TryParse(candidate, out var sandboxId))
+                {
+                    id = sandboxId.ToString();
+                    return true;
+                }
+            }
+        }
+
+        id = "";
+        return false;
+    }
+
+    private static string RequireValue(string value, string error)
+        => string.IsNullOrWhiteSpace(value)
+            ? throw new InvalidOperationException(error)
+            : value.Trim();
+
+    private static string Normalize(string value)
+    {
+        var normalized = value.Replace('\r', ' ').Replace('\n', ' ').Trim();
+        return normalized.Length <= 500 ? normalized : $"{normalized[..500]}...";
+    }
+
+    private sealed record ProcessResult(string StandardOutput, string StandardError);
+
+    private sealed class AcaCliCommandException : InvalidOperationException
+    {
+        internal AcaCliCommandException(string command, int exitCode, string detail)
+            : base($"{command} exited with code {exitCode}: {Normalize(detail)}")
+        {
+            IsForbidden =
+                detail.Contains("403", StringComparison.OrdinalIgnoreCase) ||
+                detail.Contains("forbidden", StringComparison.OrdinalIgnoreCase);
+        }
+
+        internal bool IsForbidden { get; }
+    }
+}

--- a/samples/AzureSandboxDemo/AzureSandboxDemo.csproj
+++ b/samples/AzureSandboxDemo/AzureSandboxDemo.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <PublishAot>true</PublishAot>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Hex1b/Hex1b.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/AzureSandboxDemo/AzureSandboxDemoApp.cs
+++ b/samples/AzureSandboxDemo/AzureSandboxDemoApp.cs
@@ -1,0 +1,383 @@
+using Hex1b;
+using Hex1b.Input;
+using Hex1b.Nodes;
+using Hex1b.Widgets;
+
+namespace AzureSandboxDemo;
+
+internal sealed class AzureSandboxDemoApp
+{
+    private const int InitialTerminalWidth = 100;
+    private const int InitialTerminalHeight = 30;
+
+    private readonly AcaCli _cli = new();
+    private readonly AzureSandboxSettings _settings = new();
+    private readonly CancellationTokenSource _lifetime = new();
+    private Hex1bApp? _app;
+    private Hex1bTerminal? _sandboxTerminal;
+    private TerminalWidgetHandle? _sandboxHandle;
+    private CancellationTokenSource? _sandboxTerminalCts;
+    private Task? _sandboxTerminalTask;
+    private bool _busy;
+    private string _status = "Checking Azure and ACA CLI prerequisites...";
+
+    internal async Task RunAsync()
+    {
+        await InitializeDefaultsAsync();
+
+        await using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithMouse()
+            .WithHex1bApp(
+                _ => { },
+                app =>
+                {
+                    _app = app;
+                    return context => Build(context);
+                })
+            .Build();
+
+        try
+        {
+            await terminal.RunAsync(_lifetime.Token);
+        }
+        catch (OperationCanceledException) when (_lifetime.IsCancellationRequested)
+        {
+        }
+        finally
+        {
+            await DisconnectTerminalAsync();
+            _lifetime.Dispose();
+        }
+    }
+
+    private Hex1bWidget Build(RootContext context)
+        => context.HSplitter(
+            setup => BuildSetupPane(setup),
+            terminal => BuildTerminalPane(terminal),
+            leftWidth: 48)
+        .InputBindings(bindings =>
+        {
+            bindings.Ctrl().Key(Hex1bKey.B).Then().Key(Hex1bKey.D)
+                .OverridesCapture()
+                .Action(async _ => await DisconnectTerminalAsync(), "Disconnect shell");
+            bindings.Ctrl().Key(Hex1bKey.B).Then().Key(Hex1bKey.Q)
+                .OverridesCapture()
+                .Action(_ => _lifetime.Cancel(), "Quit");
+        });
+
+    private Hex1bWidget[] BuildSetupPane<TParent>(WidgetContext<TParent> context)
+        where TParent : Hex1bWidget
+        =>
+        [
+            context.Text(" Azure Sandbox Demo"),
+            context.Text(" Provision with aca; connect with the sample protocol adapter."),
+            context.Separator(),
+            Field(context, "Subscription", _settings.SubscriptionId, value => _settings.SubscriptionId = value),
+            Field(context, "Resource group", _settings.ResourceGroup, value => _settings.ResourceGroup = value),
+            Field(context, "Region", _settings.Region, value => _settings.Region = value),
+            Field(context, "Sandbox group", _settings.SandboxGroup, value => _settings.SandboxGroup = value),
+            Field(context, "Disk image", _settings.DiskImage, value => _settings.DiskImage = value),
+            Field(context, "Shell command", _settings.Command, value => _settings.Command = value),
+            Field(context, "Sandbox ID", _settings.SandboxId, value => _settings.SandboxId = value),
+            context.Text(""),
+            context.HStack(row =>
+            [
+                row.Button("Create group")
+                    .OnClick(_ => StartOperation(CreateGroupAsync)),
+                row.Text(" "),
+                row.Button("Create sandbox + connect")
+                    .OnClick(_ => StartOperation(CreateSandboxAndConnectAsync))
+            ]).ContentHeight(),
+            context.HStack(row =>
+            [
+                row.Button("Connect ID")
+                    .OnClick(_ => StartOperation(ConnectExistingSandboxAsync)),
+                row.Text(" "),
+                row.Button("Disconnect")
+                    .OnClick(async _ => await DisconnectTerminalAsync())
+            ]).ContentHeight(),
+            context.HStack(row =>
+            [
+                row.Button("Delete sandbox")
+                    .OnClick(_ => StartOperation(DeleteSandboxAsync)),
+                row.Text(" "),
+                row.Button("Delete group")
+                    .OnClick(_ => StartOperation(DeleteGroupAsync))
+            ]).ContentHeight(),
+            context.Text(""),
+            context.Separator(),
+            context.Text(_busy ? $" Working: {_status}" : $" Status: {_status}"),
+            context.Text(" Resources remain in Azure until explicitly deleted.")
+        ];
+
+    private Hex1bWidget[] BuildTerminalPane<TParent>(WidgetContext<TParent> context)
+        where TParent : Hex1bWidget
+    {
+        Hex1bWidget content = _sandboxHandle is null
+            ? context.Center(
+                context.VStack(message =>
+                [
+                    message.Text("No sandbox shell connected."),
+                    message.Text(""),
+                    message.Text("Create a sandbox or enter an existing sandbox ID.")
+                ]))
+            : context.Terminal(_sandboxHandle)
+                .CopyModeBindings()
+                .WhenNotRunning(args =>
+                {
+                    var detail = args.ExitCode is { } exitCode
+                        ? $"Sandbox shell exited with code {exitCode}."
+                        : "Sandbox shell disconnected.";
+                    return context.Center(context.Text(detail));
+                });
+
+        return
+        [
+            context.Border(content.Fill())
+                .Title(string.IsNullOrWhiteSpace(_settings.SandboxId)
+                    ? "ACA sandbox shell"
+                    : $"ACA sandbox {_settings.SandboxId}")
+                .Fill(),
+            context.InfoBar(
+            [
+                "Mouse", "Change pane",
+                "Ctrl+B D", "Disconnect",
+                "Ctrl+B Q", "Quit"
+            ])
+        ];
+    }
+
+    private static Hex1bWidget Field<TParent>(
+        WidgetContext<TParent> context,
+        string label,
+        string value,
+        Action<string> update)
+        where TParent : Hex1bWidget
+        => context.VStack(column =>
+        [
+            column.Text($" {label}:"),
+            column.TextBox(value)
+                .OnTextChanged(args => update(args.NewText))
+                .FillWidth()
+        ]).ContentHeight();
+
+    private async Task InitializeDefaultsAsync()
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(_settings.SubscriptionId))
+            {
+                _settings.SubscriptionId =
+                    await _cli.GetActiveSubscriptionIdAsync(_lifetime.Token);
+            }
+
+            var version = await _cli.GetVersionAsync(_lifetime.Token);
+            _status = $"Ready ({version}).";
+        }
+        catch (Exception ex)
+        {
+            _status = $"Prerequisite check failed: {OneLine(ex.Message)}";
+        }
+    }
+
+    private void StartOperation(Func<CancellationToken, Task> operation)
+    {
+        if (_busy)
+        {
+            return;
+        }
+
+        _ = RunOperationAsync(operation);
+    }
+
+    private async Task RunOperationAsync(Func<CancellationToken, Task> operation)
+    {
+        _busy = true;
+        Invalidate();
+        try
+        {
+            await operation(_lifetime.Token);
+        }
+        catch (OperationCanceledException) when (_lifetime.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            _status = $"Error: {OneLine(ex.Message)}";
+        }
+        finally
+        {
+            _busy = false;
+            Invalidate();
+        }
+    }
+
+    private async Task CreateGroupAsync(CancellationToken cancellationToken)
+    {
+        var settings = _settings.Snapshot();
+        await _cli.CreateSandboxGroupAsync(settings, UpdateStatus, cancellationToken);
+        _status = $"Sandbox group '{settings.SandboxGroup}' is ready.";
+    }
+
+    private async Task CreateSandboxAndConnectAsync(CancellationToken cancellationToken)
+    {
+        var settings = _settings.Snapshot();
+        await _cli.WaitForDataPlaneAccessAsync(settings, UpdateStatus, cancellationToken);
+        _status = $"Creating a '{settings.DiskImage}' sandbox...";
+        Invalidate();
+
+        _settings.SandboxId = await _cli.CreateSandboxAsync(settings, cancellationToken);
+        _status = $"Sandbox {_settings.SandboxId} is running; opening PTY...";
+        Invalidate();
+
+        await ConnectAsync(_settings.SnapshotWithSandbox(), cancellationToken);
+    }
+
+    private Task ConnectExistingSandboxAsync(CancellationToken cancellationToken)
+        => ConnectAsync(_settings.SnapshotWithSandbox(), cancellationToken);
+
+    private async Task ConnectAsync(
+        AzureSandboxSettings settings,
+        CancellationToken cancellationToken)
+    {
+        await DisconnectTerminalAsync();
+        await _cli.WaitForDataPlaneAccessAsync(settings, UpdateStatus, cancellationToken);
+        _status = "Acquiring an ACA data-plane token...";
+        Invalidate();
+
+        var token = await _cli.GetDataPlaneTokenAsync(
+            settings.SubscriptionId,
+            cancellationToken);
+        var adapter = new AzureSandboxWorkloadAdapter(settings, token);
+        try
+        {
+            await adapter.ConnectAsync(
+                InitialTerminalWidth,
+                InitialTerminalHeight,
+                cancellationToken);
+
+            var terminalCts =
+                CancellationTokenSource.CreateLinkedTokenSource(_lifetime.Token);
+            var terminal = Hex1bTerminal.CreateBuilder()
+                .WithDimensions(InitialTerminalWidth, InitialTerminalHeight)
+                .WithWorkload(adapter)
+                .WithScrollback()
+                .WithTerminalWidget(out var handle)
+                .Build();
+
+            _sandboxTerminalCts = terminalCts;
+            _sandboxTerminal = terminal;
+            _sandboxHandle = handle;
+            _sandboxTerminalTask =
+                ObserveTerminalAsync(terminal, adapter, terminalCts.Token);
+            _status = $"Connected to shell session {adapter.SessionId}.";
+            _app?.RequestFocus(node => node is TerminalNode);
+        }
+        catch
+        {
+            await adapter.DisposeAsync();
+            throw;
+        }
+    }
+
+    private async Task ObserveTerminalAsync(
+        Hex1bTerminal terminal,
+        AzureSandboxWorkloadAdapter adapter,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var exitCode = await terminal.RunAsync(cancellationToken);
+            if (ReferenceEquals(_sandboxTerminal, terminal))
+            {
+                _status = adapter.ErrorMessage is { Length: > 0 } error
+                    ? $"Shell failed: {OneLine(error)}"
+                    : $"Shell exited with code {adapter.ExitCode ?? exitCode}.";
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception ex)
+        {
+            if (ReferenceEquals(_sandboxTerminal, terminal))
+            {
+                _status = $"Terminal failed: {OneLine(ex.Message)}";
+            }
+        }
+        finally
+        {
+            Invalidate();
+        }
+    }
+
+    private async Task DisconnectTerminalAsync()
+    {
+        var terminal = _sandboxTerminal;
+        var terminalCts = _sandboxTerminalCts;
+        var terminalTask = _sandboxTerminalTask;
+
+        _sandboxTerminal = null;
+        _sandboxHandle = null;
+        _sandboxTerminalCts = null;
+        _sandboxTerminalTask = null;
+
+        if (terminalCts is not null)
+        {
+            await terminalCts.CancelAsync();
+        }
+
+        if (terminalTask is not null)
+        {
+            try
+            {
+                await terminalTask;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        if (terminal is not null)
+        {
+            await terminal.DisposeAsync();
+            _status = "Sandbox shell disconnected.";
+        }
+
+        terminalCts?.Dispose();
+        Invalidate();
+    }
+
+    private async Task DeleteSandboxAsync(CancellationToken cancellationToken)
+    {
+        var settings = _settings.SnapshotWithSandbox();
+        await DisconnectTerminalAsync();
+        _status = $"Deleting sandbox {settings.SandboxId}...";
+        Invalidate();
+        await _cli.DeleteSandboxAsync(settings, cancellationToken);
+        _settings.SandboxId = "";
+        _status = $"Deleted sandbox {settings.SandboxId}.";
+    }
+
+    private async Task DeleteGroupAsync(CancellationToken cancellationToken)
+    {
+        var settings = _settings.Snapshot();
+        await DisconnectTerminalAsync();
+        _status = $"Deleting sandbox group '{settings.SandboxGroup}'...";
+        Invalidate();
+        await _cli.DeleteSandboxGroupAsync(settings, cancellationToken);
+        _settings.SandboxId = "";
+        _status = $"Deleted sandbox group '{settings.SandboxGroup}'.";
+    }
+
+    private void UpdateStatus(string status)
+    {
+        _status = status;
+        Invalidate();
+    }
+
+    private void Invalidate() => _app?.Invalidate();
+
+    private static string OneLine(string value)
+        => value.Replace('\r', ' ').Replace('\n', ' ').Trim();
+}

--- a/samples/AzureSandboxDemo/AzureSandboxSettings.cs
+++ b/samples/AzureSandboxDemo/AzureSandboxSettings.cs
@@ -1,0 +1,46 @@
+namespace AzureSandboxDemo;
+
+internal sealed class AzureSandboxSettings
+{
+    internal string SubscriptionId { get; set; } =
+        Environment.GetEnvironmentVariable("ACA_SUBSCRIPTION") ?? "";
+
+    internal string ResourceGroup { get; set; } =
+        Environment.GetEnvironmentVariable("ACA_RESOURCE_GROUP") ?? "hex1b-sandbox-demo-rg";
+
+    internal string Region { get; set; } =
+        Environment.GetEnvironmentVariable("ACA_REGION") ?? "eastus2";
+
+    internal string SandboxGroup { get; set; } =
+        Environment.GetEnvironmentVariable("ACA_SANDBOX_GROUP") ?? "hex1b-sandbox-demo";
+
+    internal string DiskImage { get; set; } = "ubuntu";
+
+    internal string Command { get; set; } = "/bin/bash";
+
+    internal string SandboxId { get; set; } = "";
+
+    internal AzureSandboxSettings Snapshot()
+        => new()
+        {
+            SubscriptionId = Require(nameof(SubscriptionId), SubscriptionId),
+            ResourceGroup = Require(nameof(ResourceGroup), ResourceGroup),
+            Region = Require(nameof(Region), Region),
+            SandboxGroup = Require(nameof(SandboxGroup), SandboxGroup),
+            DiskImage = Require(nameof(DiskImage), DiskImage),
+            Command = Require(nameof(Command), Command),
+            SandboxId = SandboxId.Trim()
+        };
+
+    internal AzureSandboxSettings SnapshotWithSandbox()
+    {
+        var snapshot = Snapshot();
+        snapshot.SandboxId = Require(nameof(SandboxId), SandboxId);
+        return snapshot;
+    }
+
+    private static string Require(string name, string value)
+        => string.IsNullOrWhiteSpace(value)
+            ? throw new InvalidOperationException($"{name} is required.")
+            : value.Trim();
+}

--- a/samples/AzureSandboxDemo/AzureSandboxWorkloadAdapter.cs
+++ b/samples/AzureSandboxDemo/AzureSandboxWorkloadAdapter.cs
@@ -1,0 +1,426 @@
+using System.Buffers;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Channels;
+using Hex1b;
+
+namespace AzureSandboxDemo;
+
+internal sealed class AzureSandboxWorkloadAdapter : IHex1bTerminalWorkloadAdapter
+{
+    internal const string DefaultApiVersion = "2026-02-01-preview";
+    internal const string DefaultTokenScope = "https://dynamicsessions.io/.default";
+
+    private readonly ClientWebSocket _webSocket = new();
+    private readonly Channel<ReadOnlyMemory<byte>> _output =
+        Channel.CreateUnbounded<ReadOnlyMemory<byte>>(
+            new UnboundedChannelOptions
+            {
+                SingleReader = true,
+                SingleWriter = true
+            });
+    private readonly SemaphoreSlim _sendLock = new(1, 1);
+    private readonly object _disconnectLock = new();
+    private readonly Uri _uri;
+    private readonly string _accessToken;
+    private readonly string _command;
+    private CancellationTokenSource? _receiveCts;
+    private Task? _receiveTask;
+    private Action? _disconnected;
+    private bool _disconnectSignaled;
+    private bool _disposed;
+
+    internal AzureSandboxWorkloadAdapter(
+        AzureSandboxSettings settings,
+        string accessToken)
+    {
+        _uri = BuildUri(settings);
+        _accessToken = string.IsNullOrWhiteSpace(accessToken)
+            ? throw new ArgumentException("An access token is required.", nameof(accessToken))
+            : accessToken;
+        _command = settings.Command;
+    }
+
+    internal string? SessionId { get; private set; }
+
+    internal int? ExitCode { get; private set; }
+
+    internal string? ErrorMessage { get; private set; }
+
+    public event Action? Disconnected
+    {
+        add
+        {
+            var invokeImmediately = false;
+            lock (_disconnectLock)
+            {
+                if (_disconnectSignaled)
+                {
+                    invokeImmediately = true;
+                }
+                else
+                {
+                    _disconnected += value;
+                }
+            }
+
+            if (invokeImmediately)
+            {
+                value?.Invoke();
+            }
+        }
+        remove
+        {
+            lock (_disconnectLock)
+            {
+                _disconnected -= value;
+            }
+        }
+    }
+
+    internal async Task ConnectAsync(
+        int width,
+        int height,
+        CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+
+        _webSocket.Options.SetRequestHeader("Authorization", $"Bearer {_accessToken}");
+        await _webSocket.ConnectAsync(_uri, cancellationToken);
+
+        await SendAsync(
+            new SandboxClientMessage
+            {
+                Type = "start",
+                Start = new SandboxStartMessage
+                {
+                    Command = _command,
+                    Args = [],
+                    Environment = new Dictionary<string, string>(),
+                    WorkingDirectory = "",
+                    Tty = true,
+                    Stdin = true,
+                    Height = height,
+                    Width = width
+                }
+            },
+            cancellationToken);
+
+        var handshake = await ReceiveMessageAsync(cancellationToken)
+            ?? throw new InvalidOperationException("ACA closed the WebSocket before the shell handshake.");
+        if (handshake.Type != "session_id" || string.IsNullOrWhiteSpace(handshake.Data))
+        {
+            throw new InvalidOperationException(
+                $"Expected an ACA session_id message, received '{handshake.Type ?? "<missing>"}'.");
+        }
+
+        SessionId = handshake.Data;
+        _receiveCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _receiveTask = ReceivePumpAsync(_receiveCts.Token);
+    }
+
+    public async ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(
+        CancellationToken cancellationToken = default)
+    {
+        while (await _output.Reader.WaitToReadAsync(cancellationToken))
+        {
+            if (_output.Reader.TryRead(out var data))
+            {
+                return data;
+            }
+        }
+
+        return ReadOnlyMemory<byte>.Empty;
+    }
+
+    public ValueTask WriteInputAsync(
+        ReadOnlyMemory<byte> data,
+        CancellationToken cancellationToken = default)
+        => SendAsync(
+            new SandboxClientMessage
+            {
+                Type = "stdin",
+                Data = Convert.ToBase64String(data.Span)
+            },
+            cancellationToken);
+
+    public ValueTask ResizeAsync(
+        int width,
+        int height,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+
+        return SendAsync(
+            new SandboxClientMessage
+            {
+                Type = "resize",
+                Resize = new SandboxResizeMessage
+                {
+                    Height = height,
+                    Width = width
+                }
+            },
+            cancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        if (_receiveCts is not null)
+        {
+            await _receiveCts.CancelAsync();
+        }
+
+        if (_webSocket.State is WebSocketState.Open or WebSocketState.CloseReceived)
+        {
+            try
+            {
+                await _webSocket.CloseOutputAsync(
+                    WebSocketCloseStatus.NormalClosure,
+                    null,
+                    CancellationToken.None);
+            }
+            catch (WebSocketException)
+            {
+            }
+        }
+
+        if (_receiveTask is not null)
+        {
+            try
+            {
+                await _receiveTask;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+        }
+
+        _receiveCts?.Dispose();
+        _sendLock.Dispose();
+        _webSocket.Dispose();
+        Complete();
+    }
+
+    private async Task ReceivePumpAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var message = await ReceiveMessageAsync(cancellationToken);
+                if (message is null)
+                {
+                    break;
+                }
+
+                switch (message.Type)
+                {
+                    case "stdout":
+                    case "stderr":
+                        if (!string.IsNullOrEmpty(message.Data))
+                        {
+                            await _output.Writer.WriteAsync(
+                                Convert.FromBase64String(message.Data),
+                                cancellationToken);
+                        }
+                        break;
+
+                    case "exit_code":
+                        ExitCode = message.ExitCode;
+                        return;
+
+                    case "error":
+                        ErrorMessage = message.Error ?? "Unknown ACA exec-stream error.";
+                        await WriteDiagnosticAsync(ErrorMessage, cancellationToken);
+                        return;
+                }
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (WebSocketException ex)
+        {
+            ErrorMessage = ex.Message;
+        }
+        catch (JsonException ex)
+        {
+            ErrorMessage = $"Invalid ACA protocol message: {ex.Message}";
+        }
+        catch (FormatException ex)
+        {
+            ErrorMessage = $"Invalid ACA Base64 payload: {ex.Message}";
+        }
+        catch (InvalidOperationException ex)
+        {
+            ErrorMessage = ex.Message;
+        }
+        finally
+        {
+            Complete();
+        }
+    }
+
+    private async ValueTask SendAsync(
+        SandboxClientMessage message,
+        CancellationToken cancellationToken)
+    {
+        if (_disposed || _webSocket.State != WebSocketState.Open)
+        {
+            return;
+        }
+
+        var payload = JsonSerializer.SerializeToUtf8Bytes(
+            message,
+            SandboxProtocolJsonContext.Default.SandboxClientMessage);
+
+        await _sendLock.WaitAsync(cancellationToken);
+        try
+        {
+            await _webSocket.SendAsync(
+                payload,
+                WebSocketMessageType.Text,
+                endOfMessage: true,
+                cancellationToken);
+        }
+        finally
+        {
+            _sendLock.Release();
+        }
+    }
+
+    private async Task<SandboxServerMessage?> ReceiveMessageAsync(
+        CancellationToken cancellationToken)
+    {
+        var rented = ArrayPool<byte>.Shared.Rent(8192);
+        try
+        {
+            using var buffer = new MemoryStream();
+            ValueWebSocketReceiveResult result;
+            do
+            {
+                result = await _webSocket.ReceiveAsync(
+                    rented.AsMemory(),
+                    cancellationToken);
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    return null;
+                }
+                if (result.MessageType != WebSocketMessageType.Text)
+                {
+                    throw new InvalidOperationException(
+                        $"ACA sent an unexpected {result.MessageType} WebSocket frame.");
+                }
+
+                buffer.Write(rented, 0, result.Count);
+            }
+            while (!result.EndOfMessage);
+
+            return JsonSerializer.Deserialize(
+                buffer.GetBuffer().AsSpan(0, checked((int)buffer.Length)),
+                SandboxProtocolJsonContext.Default.SandboxServerMessage)
+                ?? throw new JsonException("ACA protocol message was null.");
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(rented);
+        }
+    }
+
+    private async Task WriteDiagnosticAsync(
+        string message,
+        CancellationToken cancellationToken)
+    {
+        var bytes = Encoding.UTF8.GetBytes($"\r\nACA sandbox error: {message}\r\n");
+        await _output.Writer.WriteAsync(bytes, cancellationToken);
+    }
+
+    private void Complete()
+    {
+        _output.Writer.TryComplete();
+        Action? disconnected;
+        lock (_disconnectLock)
+        {
+            if (_disconnectSignaled)
+            {
+                return;
+            }
+
+            _disconnectSignaled = true;
+            disconnected = _disconnected;
+        }
+
+        disconnected?.Invoke();
+    }
+
+    private static Uri BuildUri(AzureSandboxSettings settings)
+    {
+        var host = $"management.{settings.Region}.azuredevcompute.io";
+        var path =
+            $"/subscriptions/{Escape(settings.SubscriptionId)}" +
+            $"/resourceGroups/{Escape(settings.ResourceGroup)}" +
+            $"/sandboxGroups/{Escape(settings.SandboxGroup)}" +
+            $"/sandboxes/{Escape(settings.SandboxId)}" +
+            "/exec/stream";
+        return new UriBuilder(Uri.UriSchemeWss, host)
+        {
+            Path = path,
+            Query = $"api-version={DefaultApiVersion}"
+        }.Uri;
+    }
+
+    private static string Escape(string value) => Uri.EscapeDataString(value);
+}
+
+internal sealed class SandboxClientMessage
+{
+    public required string Type { get; init; }
+    public SandboxStartMessage? Start { get; init; }
+    public string? Data { get; init; }
+    public SandboxResizeMessage? Resize { get; init; }
+}
+
+internal sealed class SandboxStartMessage
+{
+    public required string Command { get; init; }
+    public required string[] Args { get; init; }
+    public required Dictionary<string, string> Environment { get; init; }
+    public required string WorkingDirectory { get; init; }
+    public bool Tty { get; init; }
+    public bool Stdin { get; init; }
+    public int Height { get; init; }
+    public int Width { get; init; }
+}
+
+internal sealed class SandboxResizeMessage
+{
+    public int Height { get; init; }
+    public int Width { get; init; }
+}
+
+internal sealed class SandboxServerMessage
+{
+    public string? Type { get; init; }
+    public string? Data { get; init; }
+    public int? ExitCode { get; init; }
+    public string? Error { get; init; }
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(SandboxClientMessage))]
+[JsonSerializable(typeof(SandboxServerMessage))]
+internal sealed partial class SandboxProtocolJsonContext : JsonSerializerContext;

--- a/samples/AzureSandboxDemo/Program.cs
+++ b/samples/AzureSandboxDemo/Program.cs
@@ -1,0 +1,4 @@
+using AzureSandboxDemo;
+
+var app = new AzureSandboxDemoApp();
+await app.RunAsync();

--- a/samples/AzureSandboxDemo/README.md
+++ b/samples/AzureSandboxDemo/README.md
@@ -1,0 +1,30 @@
+# Azure Sandbox Demo
+
+This sample provisions Azure Container Apps sandboxes with the official `aca`
+CLI and connects a Hex1b `TerminalWidget` directly to the sandbox PTY WebSocket.
+The sample-local `AzureSandboxWorkloadAdapter` implements the ACA exec-stream
+framing rather than launching `aca sandbox shell`.
+
+## Prerequisites
+
+1. Install the Azure CLI and sign in with `az login`.
+2. Install the preview `aca` CLI:
+
+   ```bash
+   curl -fsSL https://aka.ms/aca-cli-install | sh
+   ```
+
+3. Run the sample:
+
+   ```bash
+   dotnet run --project samples/AzureSandboxDemo
+   ```
+
+The **Create group** action creates the resource group when necessary, creates
+the sandbox group, and lets `aca` assign the signed-in user the Container Apps
+SandboxGroup Data Owner role. **Create sandbox + connect** creates an Ubuntu
+sandbox and opens `/bin/bash` through the WebSocket protocol.
+
+Sandboxes and sandbox groups are Azure resources that may incur charges. Closing
+the demo only disconnects the shell; use the delete actions in the UI when the
+resources are no longer needed.


### PR DESCRIPTION
## Summary

- add an interactive sample for provisioning and cleaning up Azure Container Apps sandboxes
- implement the ACA JSON-over-WebSocket PTY framing in a sample-local workload adapter
- embed live sandbox shells in a Hex1b `TerminalWidget`
- wait for data-plane RBAC propagation before sandbox operations

## Validation

- `dotnet build samples/AzureSandboxDemo/AzureSandboxDemo.csproj --no-restore`
- live sandbox create, connect, interactive shell, disconnect, and delete
- Release Native AOT publish