### PR TITLE
Integrate independent Sixel placements with terminal scrolling, history, and reflow (#452)

### DIFF
--- a/docs/sixel-terminal-behavior.md
+++ b/docs/sixel-terminal-behavior.md
@@ -237,9 +237,9 @@ CUP before writing anything that follows.
 |---|---|---|
 | Sixel over Sixel | Both placements are retained independently; presentation composites in placement sequence order. Painted pixels from a later placement cover earlier pixels; unpainted/transparent pixels leave earlier placements visible. | Protocol translation into native downstream graphics remains #458; broader cross-terminal visual comparison remains #457. |
 | Text over Sixel | Any text-cell write destructively damages the Sixel pixels projected into the overwritten cell. A space, styled background write, combining-cluster update, wide-character leading cell, or wide-character continuation cleanup is still a text write for graphics damage. Destroyed Sixel pixels do not reappear if the text is later erased. | Damage is modeled at bounded cell granularity rather than sub-cell glyph-shape granularity. |
-| ED/EL/ECH/DECERA/DECSERA | Erase graphics in the same clipped cell region that text erasure affects. Selective erase preserves graphics only where the underlying terminal cell is protected. Full ED/RIS remove active placements; partial erases damage only intersecting placement cells. | Full scrolling/reflow projection across the scrollback boundary remains #452. |
-| Insert/delete characters, columns, and lines | Character/column/line edits damage every overwritten destination or blank-fill cell in their clipped edit region, while Sixel placements themselves do not shift with ordinary text edits unless the existing scroll integration explicitly moves/drops them. | Full history/reflow projection remains #452. |
-| Scroll-region operations | Move, clip, or erase placements using the same region semantics as text rows | Full-fidelity scrolling/reflow projection across the scrollback boundary is owned by #452; #451 already shifts, drops, or moves whole placements for simple full-screen scrolls |
+| ED/EL/ECH/DECERA/DECSERA | Erase graphics in the same clipped cell region that text erasure affects. Selective erase preserves graphics only where the underlying terminal cell is protected. Full ED/RIS remove active placements; partial erases damage only intersecting placement cells. | Implemented; scrolling/reflow projection across the scrollback boundary is implemented by [#452](https://github.com/mitchdenny/hex1b/issues/452) (see below). |
+| Insert/delete characters, columns, and lines | Character/column/line edits damage every overwritten destination or blank-fill cell in their clipped edit region, while Sixel placements themselves do not shift with ordinary text edits unless the existing scroll integration explicitly moves/drops them. | History/reflow projection is implemented by [#452](https://github.com/mitchdenny/hex1b/issues/452). |
+| Scroll-region operations | Move, clip, split into history, or erase placements using the same region semantics as text rows, including partial vertical/horizontal margins under DECSTBM/DECLRMM | Full-fidelity scrolling/reflow projection across the scrollback boundary is implemented by [#452](https://github.com/mitchdenny/hex1b/issues/452); see "Independent Sixel scrolling, history, and reflow (#452)" below |
 | RIS | Clear main and alternate placements, reset Sixel modes, reset the palette, clear saved screen state, and leave previously captured snapshots valid. | Implemented for lifecycle; native downstream redraw protocol remains #458. |
 | DECSTR | Reset modes, including DECSDM and mode 8452; preserve palette, placements, cursor position, and snapshots. | Broader terminal comparison remains #457, but Hex1b's compatibility choice is centralized and deterministic. |
 
@@ -326,23 +326,131 @@ unmodified.
 placeholders that name them):
 
 - Full scrolling/reflow integration — projecting a single placement across
-  the visible/history boundary, and reflow-driven re-anchoring — [#452](https://github.com/mitchdenny/hex1b/issues/452).
+  the visible/history boundary, and reflow-driven re-anchoring — is
+  implemented by [#452](https://github.com/mitchdenny/hex1b/issues/452); see
+  "Independent Sixel scrolling, history, and reflow (#452)" below.
 - Native presentation protocol translation (removing/replacing damaged
   downstream rasters in terminals that are not using Hex1b's managed
   presentation model) — [#458](https://github.com/mitchdenny/hex1b/issues/458).
 - `SixelWidget`/`Surface`-produced Sixel and widget sizing changes are
   untouched by this stage.
 
+## Independent Sixel scrolling, history, and reflow (#452)
+
+[#452](https://github.com/mitchdenny/hex1b/issues/452) layers scrolling,
+main-screen scrollback history, viewport clipping/pruning, resize, and
+anchor-based reflow onto #451's placement/image model, mirroring
+`KgpTerminalGraphicsState`'s scrolling/history/reflow fidelity with the same
+deliberate protocol-neutral simplifications — no public placement IDs, no
+delete selectors, no z-index. KGP's own scroll/history/reflow code paths are
+untouched; every behavior below is implemented purely in `SixelGraphicsState`,
+`SixelScreenGraphicsState`, `SixelPlacement`, and the new
+`SixelHistoryPlacement`.
+
+- **Scrolling.** LF and IND at the bottom margin, RI and SD (scroll down) at
+  the top margin, and the explicit `CSI Ps S`/`CSI Ps T` sequences all drive
+  the same `SixelGraphicsState.AdjustActivePlacementsForScroll`/
+  `MoveMainPlacementsIntoHistory` pair `Hex1bTerminal.ScrollUp`/`ScrollDown`
+  already use for KGP. Full, partial, and horizontal (DECLRMM) margins are all
+  supported: a placement is only shifted, cropped, or moved into history when
+  it is wholly contained in the current scroll region (`IsWhollyContained`);
+  a placement that straddles the region's boundary, or lies wholly outside
+  it, is left completely untouched, matching real hardware's row-local
+  scrolling semantics. Repeated scroll-up progressively and irreversibly
+  crops a departing placement one row at a time until nothing remains
+  ("progressive crop"); reverse scrolling (RI/SD) only ever shifts what is
+  still active and can never resurrect a row that has already departed into
+  history on an earlier forward scroll ("no resurrection"). DECSDM changes
+  where a finalized Sixel graphic is initially anchored, not whether later
+  ordinary scrolling moves it — the two behaviors are independent.
+- **Main-screen history.** `SixelScreenGraphicsState.HistoryPlacements`
+  partitions history entries by the same stable scrollback row identity
+  (`rowId`) the terminal's own text scrollback buffer assigns, so a placement
+  spanning the visible/history boundary keeps an independently-clippable copy
+  on each side (`SixelPlacement.SliceHistoryRows`), cut from the placement's
+  *current* painted window, never its original declared geometry — the
+  invariant that makes "no resurrection" possible. `PruneMainHistoryRow`
+  evicts exactly the placement portions no longer owned by a retained row
+  (partial-crop/transfer-to-successor-row fidelity, mirroring KGP).
+  `CaptureActiveSnapshot` projects history and viewport placements into one
+  unified coordinate space and supports both `ScrollbackWidth.CurrentTerminal`
+  (the live terminal's current width) and `ScrollbackWidth.Original` (each row's
+  width at capture time) projections, matching the text scrollback buffer's
+  own dual-width contract. Entering the alternate screen creates a fully
+  independent `SixelScreenGraphicsState` with no `HistoryPlacements`
+  partition at all — alternate-screen scrolling can never create or observe
+  main-screen history, and leaving the alternate screen restores the
+  untouched main-screen state exactly as #451 already guarantees.
+- **Resize and reflow.** `ClipActivePlacementsToViewport`/
+  `ClipActiveScreenToViewport` implement plain viewport-only resize: a
+  placement's own painted window and creation-time `SixelCellMetrics` are
+  never mutated by a smaller viewport, so widening the viewport back out
+  reveals previously off-screen rows/columns unchanged; a placement is
+  dropped only once its bounding box no longer intersects the viewport at
+  all. `PrepareActiveReflow`/`ApplyActiveReflow` implement optional
+  line-oriented reflow using the same `TerminalReflowAnchor`/
+  `ReflowHelper.PerformReflowWithAnchors` machinery as KGP and text (Sixel's
+  anchors use negative ids so they can be merged into one combined reflow
+  call without colliding with KGP's positive ids): each placement moves
+  atomically to wherever its single anchor point was mapped — reflow itself
+  never splits a placement across rows — and is then re-partitioned into
+  history vs. live viewport, and (when its anchor lands inside a
+  history/discarded window) split via the same non-destructive
+  `SliceHistoryRows` projection used by ordinary scrolling ("projection-only
+  splitting"). A placement whose anchor could not be represented in the
+  reflowed layout at all (its row was consumed elsewhere, or falls in a
+  discarded/unrepresentable window) is dropped outright rather than left in
+  an inconsistent state — the explicit safe behavior the issue requires.
+  Sixel protocol metric changes (a `CSI Ps ; Ps ; Ps ; Ps ; Ps S` geometry
+  query response, for example) never resize the terminal on their own and
+  leave every existing placement's occupied footprint untouched; only an
+  actual `Hex1bTerminal.Resize`/reflow call changes what is on-screen.
+- **Damage persistence (#453).** Destructive text-damage state recorded on a
+  `SixelPlacement` (its bounded sparse damaged-cell set) travels unchanged
+  through every operation above: scroll shift, history split/crop,
+  eviction, resize clip, reflow, and snapshot projection all copy or slice
+  the placement without ever clearing or reinitializing its damage set, so a
+  cell damaged before a scroll stays damaged after the scroll, after a
+  scrollback round trip, and in a captured snapshot.
+- **Partial-vertical-margin history fix.** KGP's own history-transfer gate
+  (`createsKgpHistory` in `Hex1bTerminal.ScrollUp`) intentionally requires the
+  scroll region to span the *entire* physical screen height before treating a
+  departing row as history-worthy — a deliberate, unchanged KGP behavior.
+  Sixel cannot reuse that same gate: DECSTBM lets a program declare a
+  vertical margin strictly smaller than the physical terminal (a "partial
+  vertical margin"), and the terminal's own text scrollback buffer already
+  captures the departing row in that case. Before this stage, a Sixel
+  placement that fully departed such a region in a single scroll step (for
+  example, a one-row-tall placement anchored at the region's top row) was
+  simply deleted with no history transfer and no cropped remainder — a
+  silent, permanent data loss the existing full-height-only test fixtures
+  never exercised. The fix introduces a separate, less-restrictive
+  `createsSixelHistory` condition (the scrollback-capture guard, without the
+  full-height requirement) and makes `SixelGraphicsState.MoveMainPlacementsIntoHistory`
+  accept the active `SixelScrollRegion` and gate each placement on
+  `IsWhollyContained` before shifting it — exactly the same containment test
+  `AdjustActivePlacementsForScroll` already used, so a placement outside a
+  partial region is still left untouched. KGP's `createsKgpHistory` gate and
+  `KgpTerminalGraphicsState.MoveMainPlacementsIntoHistory` call are completely
+  unchanged by this fix.
+- **Extracted vs. kept KGP-only:** the same split #451 established still
+  holds. Scroll/clip/history-partition/reflow-anchor *mechanics* are shared
+  conceptually with KGP (mirrored, not inherited — the two graphics states
+  remain separate types with no compile-time coupling); public IDs, delete
+  selectors, relative placement graphs, and z-index remain genuinely
+  KGP-only concepts with no Sixel equivalent. All existing KGP scrolling,
+  history, reflow, and snapshot tests continue to pass unmodified.
+
 ## Screens, scrollback, resize, and reflow
 
 | Area | Selected Hex1b contract | Status or unresolved work |
 |---|---|---|
 | Main/alternate screen | Each screen owns independent placements; leaving the alternate screen restores the unchanged main-screen graphics | Implemented by [#451](https://github.com/mitchdenny/hex1b/issues/451) |
-| Scrollback | Scrolling placements remain anchored to logical row lineage and can span visible and history rows | [#452](https://github.com/mitchdenny/hex1b/issues/452); foot provides verified prior art. #451 moves whole placements between the live viewport and history when a full-screen scroll would fully carry them, but does not yet split a single placement across the boundary |
-| History eviction | Remove only the placement portions no longer owned by retained row lineage | [#452](https://github.com/mitchdenny/hex1b/issues/452); #451 releases an entire history-anchored placement when its row is pruned, without KGP's partial-crop/transfer-to-successor-row fidelity |
-| Resize | Clip to the viewport without destroying source pixels; reveal them again when space returns | Implemented by [#451](https://github.com/mitchdenny/hex1b/issues/451): a placement is dropped only once it is wholly outside the new bounds; a partially-visible placement keeps its full underlying raster and geometry, so it reappears in full when space returns. Full reflow re-anchoring remains [#452](https://github.com/mitchdenny/hex1b/issues/452) |
-| Reflow | Re-anchor through the same row-lineage plan as text and KGP placements | [#452](https://github.com/mitchdenny/hex1b/issues/452) |
-| Cell-metric change | Recompute occupied cells from stable pixel geometry using deterministic outward rounding | Reference-terminal behavior needs #457 testing |
+| Scrollback | Scrolling placements remain anchored to logical row lineage and can span visible and history rows; a placement is split across the visible/history boundary via a non-destructive crop of its *current* painted window | Implemented by [#452](https://github.com/mitchdenny/hex1b/issues/452); foot provides verified prior art |
+| History eviction | Remove only the placement portions no longer owned by retained row lineage | Implemented by [#452](https://github.com/mitchdenny/hex1b/issues/452), with KGP's partial-crop/transfer-to-successor-row fidelity |
+| Resize | Clip to the viewport without destroying source pixels; reveal them again when space returns | Implemented by [#451](https://github.com/mitchdenny/hex1b/issues/451)/[#452](https://github.com/mitchdenny/hex1b/issues/452): a placement is dropped only once it is wholly outside the new bounds; a partially-visible placement keeps its full underlying raster and geometry, so it reappears in full when space returns |
+| Reflow | Re-anchor through the same row-lineage plan as text and KGP placements; atomic per-anchor movement, with projection-only splitting when an anchor lands in a history/discarded window | Implemented by [#452](https://github.com/mitchdenny/hex1b/issues/452) |
+| Cell-metric change | Recompute occupied cells from stable pixel geometry using deterministic outward rounding; a protocol metric-query response never resizes the terminal or its placements on its own | Implemented by [#452](https://github.com/mitchdenny/hex1b/issues/452); reference-terminal behavior needs #457 testing |
 
 No reviewed reference provided a complete answer for resize/reflow or
 main/alternate-screen ownership. These decisions intentionally align Sixel with
@@ -362,11 +470,8 @@ reference-terminal evidence:
 3. DECGRA's undocumented carriage-return behavior and aspect-scaled DECGNL.
 4. Exact Sixel-over-Sixel compositing and partial-cell text/erase damage.
 5. DECSTR effects on placements.
-6. Full-fidelity scrolling/reflow projection across the scrollback boundary
-   (splitting a single placement between visible and history rows), and
-   partial-eviction of history-anchored placements.
-7. Private-mode save/restore (`CSI ? Pm s` and `CSI ? Pm r`) for Sixel modes.
-8. Exact default palette values for registers 16-255 and private-register
+6. Private-mode save/restore (`CSI ? Pm s` and `CSI ? Pm r`) for Sixel modes.
+7. Exact default palette values for registers 16-255 and private-register
    behavior across modern terminals.
 
 ## Evidence and running the contract
@@ -378,6 +483,16 @@ is the dedicated regression suite for #451's independent placement/image
 storage and lifetime accounting (multi-cell spans, dedup, overlap, geometry-only
 retention, origin-cell overwrite, snapshot-held survival past active-screen
 removal, and main/alternate/RIS independence).
+`tests/Hex1b.Tests/Sixel/SixelScrollHistoryReflowTests.cs` is the dedicated
+regression suite for #452's scrolling, main-screen history, resize, and reflow
+integration (LF/IND/RI/SU/SD equivalence, full/partial vertical margins,
+DECLRMM horizontal margins, progressive crop, no-resurrection reverse
+scrolling, DECSDM independence, capacity-one/two history pruning, both resize
+directions, fractional-pixel crops, protocol metric-change independence,
+alternate-screen isolation, current/original-width scrollback projection,
+#453 damage persistence across scroll/history/snapshot, and final-reference
+release) — including the partial-vertical-margin history transfer fixed by
+this stage.
 
 ```bash
 dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj \
@@ -393,6 +508,21 @@ main/alternate screen isolation, and geometry-only placement retention. The
 shared-raster scene separates its two placements by row because native Sixel
 renderers do not all preserve multiple same-row graphics consistently; the
 overlap scene covers same-row ordering as a deliberate, separate contract.
+`samples/SixelTerminalDemo/RawScrollHistoryReflowScenes.cs` adds #452's
+scrolling/history/crop/prune/margin/resize/reflow/alternate/damage scenes
+using the same raw-DCS convention. Its headless output is the authoritative
+evidence for these scenes: it reports scrollback-line, active-placement, and
+tracked-image counts, each active placement's declared vs. painted geometry,
+the current viewport's observed rows/columns after clipping, and — for
+placements that live purely in history — their own origin-cell coverage, so
+#453 damage persisting into a scrolled-past row is directly inspectable
+without an interactive terminal. Because interactive terminals render Sixel
+graphics as an overlay independent of the text grid, an interactive session of
+these scenes can only show the *current* screen's pixels; the headless model
+above is authoritative for history/crop/reflow geometry that has already
+scrolled out of view or been reflowed, and the differences between what an
+interactive terminal can show live versus what the headless evidence reports
+are called out explicitly in each scene's description.
 
 The demo presents one subject per screen. Each screen clears the display, resets
 margins, origin mode, and DECSDM so it cannot inherit state from the screen
@@ -410,6 +540,7 @@ cells, so a screen can be checked against what is actually on the terminal.
 dotnet run --project samples/SixelTerminalDemo
 dotnet run --project samples/SixelTerminalDemo -- --screen 17
 dotnet run --project samples/SixelTerminalDemo -- --scene "Declared extent"
+dotnet run --project samples/SixelTerminalDemo -- --scene "Scrolling"
 dotnet run --project samples/SixelTerminalDemo -- --headless
 ```
 

--- a/samples/SixelTerminalDemo/DemoScreens.cs
+++ b/samples/SixelTerminalDemo/DemoScreens.cs
@@ -12,7 +12,8 @@ internal static class DemoScreens
     /// <summary>
     /// Builds every screen: the grammar and geometry fixtures first, then the
     /// cursor, DECSDM, and margin scenes, then the graphics-state ownership
-    /// scenes, then the transport scenes.
+    /// scenes (#451), then the scrolling/history/resize scenes (#452), then
+    /// the transport scenes.
     /// </summary>
     public static IReadOnlyList<DemoScreen> Build(
         IReadOnlyList<RawSixelFixture> fixtures,
@@ -20,6 +21,8 @@ internal static class DemoScreens
         IReadOnlyList<RawCursorScene> cursorScenes,
         IReadOnlyList<RawGraphicsStateScene> graphicsStateScenes,
         IReadOnlyList<string> graphicsStateObservations,
+        IReadOnlyList<RawScrollHistoryReflowScene> scrollHistoryReflowScenes,
+        IReadOnlyList<string> scrollHistoryReflowObservations,
         bool includeTransportScenes)
     {
         var screens = new List<DemoScreen>();
@@ -65,6 +68,17 @@ internal static class DemoScreens
                 scene.Expected,
                 scene.Bytes,
                 Notes: [graphicsStateObservations[index]]));
+        }
+
+        for (var index = 0; index < scrollHistoryReflowScenes.Count; index++)
+        {
+            var scene = scrollHistoryReflowScenes[index];
+            screens.Add(new DemoScreen(
+                number++,
+                scene.Name,
+                scene.Expected,
+                scene.Bytes,
+                Notes: [scrollHistoryReflowObservations[index]]));
         }
 
         if (!includeTransportScenes)

--- a/samples/SixelTerminalDemo/Program.cs
+++ b/samples/SixelTerminalDemo/Program.cs
@@ -24,7 +24,12 @@ var graphicsStateScenes = sceneFilter is null
     : RawGraphicsStateScenes.All
         .Where(scene => scene.Name.Contains(sceneFilter, StringComparison.OrdinalIgnoreCase))
         .ToArray();
-if (fixtures.Count == 0 && cursorScenes.Count == 0 && graphicsStateScenes.Count == 0)
+var scrollHistoryReflowScenes = sceneFilter is null
+    ? RawScrollHistoryReflowScenes.All
+    : RawScrollHistoryReflowScenes.All
+        .Where(scene => scene.Name.Contains(sceneFilter, StringComparison.OrdinalIgnoreCase))
+        .ToArray();
+if (fixtures.Count == 0 && cursorScenes.Count == 0 && graphicsStateScenes.Count == 0 && scrollHistoryReflowScenes.Count == 0)
 {
     throw new ArgumentException($"No Sixel demo scene contains '{sceneFilter}'.", nameof(args));
 }
@@ -55,12 +60,20 @@ for (var index = 0; index < graphicsStateScenes.Count; index++)
     graphicsStateObservations[index] = await InspectGraphicsStateSceneAsync(graphicsStateScenes[index]);
 }
 
+var scrollHistoryReflowObservations = new string[scrollHistoryReflowScenes.Count];
+for (var index = 0; index < scrollHistoryReflowScenes.Count; index++)
+{
+    scrollHistoryReflowObservations[index] = await InspectScrollHistoryReflowSceneAsync(scrollHistoryReflowScenes[index]);
+}
+
 var allScreens = DemoScreens.Build(
     fixtures,
     modelDescriptions,
     cursorScenes,
     graphicsStateScenes,
     graphicsStateObservations,
+    scrollHistoryReflowScenes,
+    scrollHistoryReflowObservations,
     includeTransportScenes: sceneFilter is null);
 
 // --screen selects one numbered screen. The number keeps its original value so a
@@ -92,7 +105,9 @@ if (headless)
         cursorScenes,
         cursorObservations,
         graphicsStateScenes,
-        graphicsStateObservations);
+        graphicsStateObservations,
+        scrollHistoryReflowScenes,
+        scrollHistoryReflowObservations);
     return;
 }
 
@@ -118,7 +133,9 @@ static void WriteHeadlessTranscript(
     IReadOnlyList<RawCursorScene> cursorScenes,
     IReadOnlyList<string> cursorObservations,
     IReadOnlyList<RawGraphicsStateScene> graphicsStateScenes,
-    IReadOnlyList<string> graphicsStateObservations)
+    IReadOnlyList<string> graphicsStateObservations,
+    IReadOnlyList<RawScrollHistoryReflowScene> scrollHistoryReflowScenes,
+    IReadOnlyList<string> scrollHistoryReflowObservations)
 {
     Console.WriteLine($"Hex1b Sixel demo: {allScreens.Count} numbered screens.");
     Console.WriteLine("Run without --headless to page through them; --screen <number> opens one.");
@@ -150,6 +167,13 @@ static void WriteHeadlessTranscript(
     for (var index = 0; index < graphicsStateScenes.Count; index++)
     {
         Console.WriteLine($"  {graphicsStateScenes[index].Name}: {graphicsStateObservations[index]}");
+    }
+
+    Console.WriteLine();
+    Console.WriteLine("Scrolling, history, and resize observations (#452):");
+    for (var index = 0; index < scrollHistoryReflowScenes.Count; index++)
+    {
+        Console.WriteLine($"  {scrollHistoryReflowScenes[index].Name}: {scrollHistoryReflowObservations[index]}");
     }
 }
 
@@ -272,6 +296,114 @@ static string DescribeSixelColor(SixelData image)
     if (image.Payload.Contains("240;50;100"))
         return "blue";
     return "unrecognized color";
+}
+
+static async Task<string> InspectScrollHistoryReflowSceneAsync(RawScrollHistoryReflowScene scene)
+{
+    var capabilities = new TerminalCapabilities
+    {
+        SupportsSixel = true,
+        SupportsTrueColor = true,
+        Supports256Colors = true,
+        CellPixelWidth = 10,
+        CellPixelHeight = 20,
+    };
+    var workload = new DemoWorkloadAdapter([scene.Bytes]);
+    var terminalBuilder = Hex1bTerminal.CreateBuilder()
+        .WithWorkload(workload)
+        .WithPresentation(new HeadlessPresentationAdapter(80, 24, capabilities))
+        .WithDimensions(80, 24);
+    if (scene.ScrollbackCapacity > 0)
+    {
+        terminalBuilder = terminalBuilder.WithScrollback(scene.ScrollbackCapacity);
+    }
+
+    await using var terminal = terminalBuilder.Build();
+    await terminal.RunAsync();
+
+    var builder = new StringBuilder();
+    builder.Append(DescribeScrollHistoryReflowState(terminal, "after script"));
+
+    if (scene.ResizeSteps is { Count: > 0 } steps)
+    {
+        foreach (var (width, height) in steps)
+        {
+            terminal.Resize(width, height);
+            builder.Append("; ");
+            builder.Append(DescribeScrollHistoryReflowState(terminal, $"after resize to {width}x{height}"));
+        }
+    }
+
+    return builder.ToString();
+}
+
+static string DescribeScrollHistoryReflowState(Hex1bTerminal terminal, string label)
+{
+    var builder = new StringBuilder();
+    builder.Append(label);
+    builder.Append(": ");
+    builder.Append($"{terminal.ScrollbackCount} scrollback line(s), {terminal.SixelPlacementCount} active placement(s), {terminal.TrackedSixelCount} tracked image(s)");
+
+    foreach (var placement in terminal.SixelPlacements)
+    {
+        builder.Append(
+            $"; ({placement.Column},{placement.Row}) declared {placement.WidthInCells}x{placement.HeightInCells} cells, painted {placement.PaintedColumnCount}x{placement.PaintedRowCount}");
+    }
+
+    // The declared/painted geometry above never changes just because the
+    // viewport got smaller (see SixelGraphicsState.ClipActivePlacementsToViewport):
+    // only what the *current* viewport can actually observe narrows. Walking a
+    // fresh snapshot's placements the same way SixelTestTerminal.Observe does in
+    // the test suite makes that distinction visible here too.
+    using var snapshot = terminal.CreateSnapshot(scrollbackLines: terminal.ScrollbackCount);
+    builder.Append($" [snapshot: {snapshot.SixelPlacements.Count} placement(s), scrollbackLineCount={snapshot.ScrollbackLineCount}]");
+    var mainScreenRows = new SortedSet<int>();
+    var mainScreenColumns = new SortedSet<int>();
+    foreach (var placement in snapshot.SixelPlacements)
+    {
+        if (!placement.HasPaintedExtent)
+            continue;
+
+        var top = Math.Max(placement.PaintedTop, snapshot.ScrollbackLineCount);
+        var bottom = Math.Min(placement.PaintedBottom, snapshot.Height - 1);
+        var left = Math.Max(placement.PaintedLeft, 0);
+        var right = Math.Min(placement.PaintedRight, snapshot.Width - 1);
+        for (var row = top; row <= bottom; row++)
+        {
+            for (var column = left; column <= right; column++)
+            {
+                if (!placement.CoversCell(row, column))
+                    continue;
+
+                mainScreenRows.Add(row - snapshot.ScrollbackLineCount);
+                mainScreenColumns.Add(column);
+            }
+        }
+    }
+
+    if (mainScreenRows.Count > 0)
+        builder.Append($"; viewport rows observed: {string.Join(",", mainScreenRows)}");
+    if (mainScreenColumns.Count > 0)
+        builder.Append($"; viewport columns observed: {string.Join(",", mainScreenColumns)}");
+
+    // Placements that live purely in history (their painted top already
+    // scrolled past the visible viewport) are not walked above, since the
+    // live-viewport loop only reports what a real presentation adapter could
+    // draw. Reporting their own origin-cell coverage here is the direct,
+    // authoritative evidence that #453 destructive damage survives the
+    // history/snapshot projection (SixelPlacement.SliceHistoryRows), not just
+    // that the row count matches.
+    foreach (var placement in snapshot.SixelPlacements)
+    {
+        if (!placement.HasPaintedExtent || placement.PaintedTop >= snapshot.ScrollbackLineCount)
+            continue;
+
+        var originCovered = placement.CoversCell(placement.PaintedTop, placement.PaintedLeft);
+        builder.Append(
+            $"; history placement ({placement.PaintedLeft},{placement.PaintedTop}) painted {placement.PaintedColumnCount}x{placement.PaintedRowCount}, origin cell covered: {originCovered}");
+    }
+
+    return builder.ToString();
 }
 
 static async Task<string> InspectModelAsync(RawSixelFixture fixture)

--- a/samples/SixelTerminalDemo/RawScrollHistoryReflowScenes.cs
+++ b/samples/SixelTerminalDemo/RawScrollHistoryReflowScenes.cs
@@ -1,0 +1,137 @@
+using System.Text;
+
+/// <summary>
+/// A hand-authored scene that exercises Hex1b's independent Sixel placements
+/// interacting with terminal scrolling, main-screen scrollback history,
+/// viewport clipping, and resize (issue #452): every byte is written by hand,
+/// using raw CUP/DCS/DECSTBM/DECLRMM/DECSDM/alternate-screen control
+/// sequences with no <c>SixelWidget</c> or <c>SixelEncoder</c> involved, so
+/// the scene stays an independent contract probe of the placement/scrolling
+/// integration, mirroring <c>tests/Hex1b.Tests/Sixel/SixelScrollHistoryReflowTests.cs</c>.
+/// </summary>
+/// <param name="Name">The scene name, also used by <c>--scene</c>.</param>
+/// <param name="Expected">What the terminal model should retain after the script (and any resize steps) run.</param>
+/// <param name="Script">The complete raw byte script for the scene, run before any <see cref="ResizeSteps"/>.</param>
+/// <param name="ScrollbackCapacity">
+/// Rows of main-screen scrollback the demo terminal is built with. Zero
+/// means the scene never expects a placement to survive being scrolled off
+/// (scrolled-off content is simply discarded, matching a terminal with no
+/// history buffer configured at all).
+/// </param>
+/// <param name="ResizeSteps">
+/// Width/height pairs applied via <c>Hex1bTerminal.Resize</c>, in order,
+/// after <see cref="Script"/> runs. Each step's resulting placement/viewport
+/// state is folded into the headless observation note. Resize can only be
+/// demonstrated headlessly here: the interactive demo pages through screens
+/// on one fixed-size terminal, so an interactive run shows the scene's
+/// pre-resize state only, with the headless note carrying the authoritative
+/// evidence for what the resize itself does (see
+/// <c>docs/sixel-terminal-behavior.md</c>'s "#452" section).
+/// </param>
+internal sealed record RawScrollHistoryReflowScene(
+    string Name,
+    string Expected,
+    string Script,
+    int ScrollbackCapacity = 0,
+    IReadOnlyList<(int Width, int Height)>? ResizeSteps = null)
+{
+    public byte[] Bytes => Encoding.ASCII.GetBytes(Script);
+}
+
+/// <summary>
+/// Scenes demonstrating independent Sixel placements moving through
+/// scrolling, main-screen scrollback history, viewport clipping, and resize
+/// (#452): LF/IND/RI/SU/SD, partial vertical and DECLRMM horizontal margins,
+/// DECSDM, alternate-screen isolation, damage persisting across scroll, and
+/// resize's deliberately non-destructive clip-without-reflow behavior. See
+/// <c>tests/Hex1b.Tests/Sixel/SixelScrollHistoryReflowTests.cs</c> for the
+/// equivalent integration assertions this scene set mirrors.
+/// </summary>
+internal static class RawScrollHistoryReflowScenes
+{
+    // One raster band is 6 pixels tall by protocol. At this demo's 10x20px
+    // cell metrics (see Program.cs's TerminalCapabilities), a band count is
+    // chosen so the declared pixel height lands just past a cell boundary:
+    // 4 bands = 24px -> ceil(24/20) = 2 rows; 8 bands = 48px -> 3 rows; 1
+    // band = 6px -> 1 row. Declaring an explicit raster header ("1;1;W;H)
+    // keeps the geometry exact instead of depending on the default 2:1
+    // aspect doubling a bare payload would get.
+    private static string SolidBand(int pixelWidth, int bandCount, int register, string colorDefinition) =>
+        $"7;1q\"1;1;{pixelWidth};{bandCount * 6}#{register};{colorDefinition}#{register}{string.Join("-", Enumerable.Repeat("!" + pixelWidth + "~", bandCount))}";
+
+    // 1 cell wide, 2 cells tall (10x24px). Used for LF/IND/RI/SD scroll probes.
+    private static string RedOneColTwoRow => SolidBand(10, 4, 1, "2;100;0;0");
+
+    // 1 cell wide, 3 cells tall (10x48px). Used for the progressive-crop probe.
+    private static string RedOneColThreeRow => SolidBand(10, 8, 1, "2;100;0;0");
+
+    // 3 cells wide, 1 cell tall (30x6px). Used for the DECLRMM horizontal-margin probe.
+    private static string GreenThreeColOneRow => SolidBand(30, 1, 2, "2;0;100;0");
+
+    // 2 cells wide, 1 cell tall (20x6px). Used for the damage-persistence probe, so only
+    // one of the two columns is overwritten with text.
+    private static string BlueTwoColOneRow => SolidBand(20, 1, 3, "1;240;50;100");
+
+    private static string Dcs(string payload) => $"\x1bP{payload}\x1b\\";
+    private static string Cup(int row, int column) => $"\x1b[{row};{column}H";
+    private static string Margins(int top, int bottom) => $"\x1b[{top};{bottom}r";
+    private const string EnableDeclrmm = "\x1b[?69h";
+    private static string HorizontalMargins(int left, int right) => $"\x1b[{left};{right}s";
+    private const string EnableDecsdm = "\x1b[?80h";
+    private const string EnterAlternateScreen = "\x1b[?1049h";
+    private const string ExitAlternateScreen = "\x1b[?1049l";
+    private const string ReverseIndex = "\x1bM";
+    private const string ScrollDown = "\x1b[T";
+    private const string ScrollUp = "\x1b[S";
+
+    public static IReadOnlyList<RawScrollHistoryReflowScene> All { get; } =
+    [
+        new(
+            "Scrolling/history: LF at the bottom margin moves a departing row into history",
+            "a one-row-tall remainder of what was a two-row-tall red band: the top row\n  scrolled off into main-screen history (1 scrollback line), while the bottom\n  row is still an active, independently retained placement. IND (ESC D)\n  produces the identical result - both are ordinary bottom-margin scroll-ups",
+            Margins(1, 3) + Cup(1, 1) + Dcs(RedOneColTwoRow) + Cup(3, 1) + "\n",
+            ScrollbackCapacity: 3),
+        new(
+            "Scrolling: RI at the top margin shifts a placement down, never resurrecting departed rows",
+            "the same red band shifted down by one row within its region after a\n  reverse-index (ESC M) at the region's top margin. Reverse scrolling only\n  ever shifts what is still active - it can never resurrect a row that has\n  already departed into history on an earlier forward scroll",
+            Margins(2, 4) + Cup(4, 1) + Dcs(RedOneColTwoRow) + Cup(2, 1) + ReverseIndex),
+        new(
+            "Scrolling: SD (CSI T) shifts a placement down within an explicit vertical margin",
+            "the same red band shifted down by one row, this time via the explicit\n  CSI Ps T \"scroll down\" sequence rather than reverse-index - both reverse\n  scroll into the region's headroom identically",
+            Margins(2, 4) + Cup(4, 1) + Dcs(RedOneColTwoRow) + Cup(2, 1) + ScrollDown),
+        new(
+            "Scrolling/history: repeated scroll-up progressively crops a placement before removing it",
+            "nothing: a three-row-tall red band inside a partial vertical margin is\n  cropped by one row on each of two successive scroll-ups (3 painted rows,\n  then 2, then 1), and a third scroll-up removes the fully cropped remainder\n  entirely. Progressive crop never restores a row once it has scrolled past\n  the margin - each step is a permanent, one-way reduction",
+            Margins(2, 4) + Cup(2, 1) + Dcs(RedOneColThreeRow) + ScrollUp + ScrollUp + ScrollUp),
+        new(
+            "Scrolling: DECLRMM horizontal margins clip painting, and SU shifts a wholly-contained placement",
+            "a green band, three cells wide, shifted up by one row after scroll-up.\n  DECLRMM (CSI ?69h) plus a CSI Ps;Ps s horizontal-margin declaration clips\n  Sixel painting unconditionally to the declared columns; a placement whose\n  declared footprint is wholly inside those columns is shifted by ordinary\n  vertical scrolling exactly like one with no horizontal margins at all",
+            EnableDeclrmm + HorizontalMargins(4, 8) + Cup(2, 5) + Dcs(GreenThreeColOneRow) + ScrollUp),
+        new(
+            "Scrolling: DECSDM (Sixel Display Mode) does not gate ordinary scrolling",
+            "a one-row-tall remainder in main-screen history exactly as in the plain\n  LF scene: enabling DECSDM (CSI ?80h) changes where a Sixel graphic is\n  positioned on write, not whether later ordinary line-feed/index scrolling\n  moves it into history - the two behaviors are independent",
+            EnableDecsdm + Margins(1, 3) + Cup(1, 1) + Dcs(RedOneColTwoRow) + Cup(3, 1) + "\n",
+            ScrollbackCapacity: 3),
+        new(
+            "Scrolling: alternate-screen scrolling never creates or affects main-screen history",
+            "the same red band's one-row-tall main-screen remainder as the plain LF\n  scene, unaffected by four line feeds sent after entering, then a fourth\n  line feed and exiting, the alternate screen. Alternate-screen scrolling is\n  fully isolated from main-screen history: it never adds scrollback lines\n  and never touches the main screen's placements",
+            Margins(1, 3) + Cup(1, 1) + Dcs(RedOneColTwoRow) + Cup(3, 1) + "\n"
+                + EnterAlternateScreen + "\n\n\n\n" + ExitAlternateScreen,
+            ScrollbackCapacity: 4),
+        new(
+            "Damage (#453): destructive text damage applied before a scroll survives the scroll and any snapshot",
+            "nothing on the main screen: the entire one-row-tall blue band scrolled\n  fully into history. Its left column was overwritten with X before the\n  scroll, so that cell's pixels are permanently gone (destructive damage);\n  the untouched right column is still visible. Both survive the scroll and a\n  history/snapshot round trip unchanged - see the headless note for the\n  per-cell damage evidence",
+            Margins(1, 3) + Cup(1, 1) + Dcs(BlueTwoColOneRow) + Cup(1, 1) + "X" + Cup(3, 1) + "\n",
+            ScrollbackCapacity: 3),
+        new(
+            "Resize: shrinking the viewport clips visibility without destroying the placement's own painted state",
+            "the same three-row-tall red band as the progressive-crop scene, still\n  declaring all three painted rows internally after a resize down to one row\n  tall - only the *observed* viewport narrows. Resizing back to the original\n  height reveals the untouched rows again: unlike scroll-margin cropping,\n  viewport-only resize never permanently mutates a placement's painted\n  window (see the headless note for the row-by-row evidence)",
+            Cup(1, 1) + Dcs(RedOneColThreeRow),
+            ResizeSteps: [(20, 1), (20, 3)]),
+        new(
+            "Resize: narrowing the viewport clips visibility without destroying the placement's own painted state",
+            "the same three-cell-wide green band as the DECLRMM scene, still declaring\n  all three painted columns internally after a resize down to one column\n  wide - only the *observed* viewport narrows. Resizing back to the original\n  width reveals the untouched columns again, for the same reason a shorter\n  viewport never destroys painted rows",
+            Cup(1, 1) + Dcs(GreenThreeColOneRow),
+            ResizeSteps: [(1, 5), (20, 5)]),
+    ];
+}

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -2069,7 +2069,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             var sixel = _sixelGraphicsState.CaptureActiveSnapshot(
                 allScrollbackEntries,
                 selectedScrollbackEntries.Length,
-                _height);
+                _height,
+                retainedScrollbackWidth);
             return new Hex1bTerminalSnapshotState(
                 _width,
                 _height,
@@ -2421,13 +2422,18 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             _cursorSaved ? _savedCursorY : null);
 
         var kgpReflow = _kgpGraphicsState.PrepareActiveReflow(scrollbackEntries);
+        var sixelReflow = _sixelGraphicsState.PrepareActiveReflow(scrollbackEntries);
         var internalResult = default(InternalReflowResult);
         var hasKgpLineage = false;
         if (reflowProvider is IInternalTerminalReflowProvider internalReflow)
         {
+            var mergedAnchors = new List<TerminalReflowAnchor>(
+                kgpReflow.Anchors.Count + sixelReflow.Anchors.Count);
+            mergedAnchors.AddRange(kgpReflow.Anchors);
+            mergedAnchors.AddRange(sixelReflow.Anchors);
             hasKgpLineage = internalReflow.TryReflowWithAnchors(
                 context,
-                kgpReflow.Anchors,
+                mergedAnchors,
                 out internalResult);
         }
 
@@ -2522,6 +2528,13 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 newHeight,
                 Capabilities.CellPixelWidth,
                 Capabilities.CellPixelHeight);
+            _sixelGraphicsState.ApplyActiveReflow(
+                sixelReflow,
+                internalResult.Anchors,
+                result.ScrollbackRows.Length,
+                replacement,
+                newWidth,
+                newHeight);
         }
         else
         {
@@ -2533,13 +2546,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 newHeight,
                 Capabilities.CellPixelWidth,
                 Capabilities.CellPixelHeight);
+            _sixelGraphicsState.ClipActivePlacementsToViewport(newWidth, newHeight);
         }
-
-        // Sixel has no reflow-anchor tracking in this stage (deferred to
-        // #452): always fall back to clipping active placements/screen at
-        // their pre-resize physical coordinates, mirroring the same
-        // non-lineage fallback KGP itself uses above.
-        _sixelGraphicsState.ClipActivePlacementsToViewport(newWidth, newHeight);
 
         if (!_inAlternateScreen)
         {
@@ -5294,6 +5302,21 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             _scrollBottom == _height - 1 &&
             leftCol == 0 &&
             rightCol == _width - 1;
+
+        // Unlike KGP's history transfer (which is intentionally restricted to
+        // a full-height scroll region), Sixel history must also fire under a
+        // partial vertical margin: DECSTBM's bottom smaller than the physical
+        // screen still genuinely scrolls row 0 off the visible screen and
+        // into the same scrollback row captured below, so a placement wholly
+        // inside that margin must not silently lose its departing row's
+        // pixels just because the region doesn't span every physical row.
+        // KGP behavior is preserved exactly as-is via the separate, unchanged
+        // createsKgpHistory condition above.
+        var createsSixelHistory = !_inAlternateScreen &&
+            _scrollbackBuffer is not null &&
+            _scrollTop == 0 &&
+            leftCol == 0 &&
+            rightCol == _width - 1;
         long? capturedHistoryRowId = null;
         
         // Capture the top row into the scrollback buffer before it's overwritten.
@@ -5310,13 +5333,21 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         }
         
         // Shift rows up within the scroll region
-        // All affected cells need to be recorded as impacts
+        // All affected cells need to be recorded as impacts. Sixel damage is
+        // suppressed here: this is a coordinated region shift, not an
+        // overwrite of unrelated content, and MoveMainPlacementsIntoHistory /
+        // AdjustActivePlacementsForScroll (below) already recompute each
+        // placement's post-scroll geometry — including any cropping a
+        // partial scroll region requires. Letting per-cell damage tracking
+        // run here as well would see a still-in-place placement's rows
+        // overwritten one by one and destroy it before the real geometry
+        // update ever runs.
         for (int y = _scrollTop; y < _scrollBottom; y++)
         {
             for (int x = leftCol; x <= rightCol; x++)
             {
                 var cellFromBelow = _screenBuffer[y + 1, x];
-                SetCell(y, x, cellFromBelow, impacts);
+                SetCell(y, x, cellFromBelow, impacts, damageSixel: false);
             }
         }
         
@@ -5324,7 +5355,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         var eraseCell = CreateEraseCell();
         for (int x = leftCol; x <= rightCol; x++)
         {
-            SetCell(_scrollBottom, x, eraseCell, impacts);
+            SetCell(_scrollBottom, x, eraseCell, impacts, damageSixel: false);
         }
 
         if (createsKgpHistory)
@@ -5333,7 +5364,6 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 capturedHistoryRowId
                     ?? throw new InvalidOperationException(
                         "A history-producing KGP scroll must capture a scrollback row."));
-            _sixelGraphicsState.MoveMainPlacementsIntoHistory(capturedHistoryRowId.Value);
         }
         else
         {
@@ -5342,6 +5372,18 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 scrollingRectangle,
                 Capabilities.CellPixelWidth,
                 Capabilities.CellPixelHeight);
+        }
+
+        if (createsSixelHistory)
+        {
+            _sixelGraphicsState.MoveMainPlacementsIntoHistory(
+                capturedHistoryRowId
+                    ?? throw new InvalidOperationException(
+                        "A history-producing Sixel scroll must capture a scrollback row."),
+                sixelScrollingRegion);
+        }
+        else
+        {
             _sixelGraphicsState.AdjustActivePlacementsForScroll(rowDelta: -1, sixelScrollingRegion);
         }
 
@@ -5365,13 +5407,15 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         var sixelScrollingRegion = new SixelScrollRegion(_scrollTop, _scrollBottom, leftCol, rightCol);
         
         // Shift rows down within the scroll region
-        // All affected cells need to be recorded as impacts
+        // All affected cells need to be recorded as impacts. Sixel damage is
+        // suppressed here for the same reason as ScrollUp: AdjustActivePlacementsForScroll
+        // (below) recomputes each placement's post-scroll geometry directly.
         for (int y = _scrollBottom; y > _scrollTop; y--)
         {
             for (int x = leftCol; x <= rightCol; x++)
             {
                 var cellFromAbove = _screenBuffer[y - 1, x];
-                SetCell(y, x, cellFromAbove, impacts);
+                SetCell(y, x, cellFromAbove, impacts, damageSixel: false);
             }
         }
         
@@ -5379,7 +5423,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         var eraseCell = CreateEraseCell();
         for (int x = leftCol; x <= rightCol; x++)
         {
-            SetCell(_scrollTop, x, eraseCell, impacts);
+            SetCell(_scrollTop, x, eraseCell, impacts, damageSixel: false);
         }
 
         // Reverse scrolling does not pull rows from history. Placements whose

--- a/src/Hex1b/Sixel/SixelGraphicsState.cs
+++ b/src/Hex1b/Sixel/SixelGraphicsState.cs
@@ -1,6 +1,39 @@
+using Hex1b.Reflow;
 using Hex1b.Sixel;
 
 namespace Hex1b;
+
+/// <summary>
+/// A single tracked placement participating in a Sixel reflow pass: its
+/// reflow anchor id, the placement geometry to re-derive from, and (when it
+/// originated from history) the retained-window descriptor to slice before
+/// re-deriving. Mirrors <c>KgpTerminalGraphicsState.ReflowPlacement</c>.
+/// </summary>
+internal readonly record struct SixelReflowPlacement(
+    int Id,
+    SixelPlacement Placement,
+    SixelHistoryPlacement? History);
+
+/// <summary>
+/// The anchors and tracked placements built by <see cref="SixelGraphicsState.PrepareActiveReflow"/>,
+/// ready to be merged with another subsystem's anchors for a single combined
+/// <c>ReflowHelper.PerformReflowWithAnchors</c> call. Mirrors
+/// <c>KgpTerminalGraphicsState.KgpReflowPlan</c>.
+/// </summary>
+internal sealed class SixelReflowPlan
+{
+    internal SixelReflowPlan(
+        IReadOnlyList<TerminalReflowAnchor> anchors,
+        IReadOnlyList<SixelReflowPlacement> placements)
+    {
+        Anchors = anchors;
+        Placements = placements;
+    }
+
+    internal IReadOnlyList<TerminalReflowAnchor> Anchors { get; }
+
+    internal IReadOnlyList<SixelReflowPlacement> Placements { get; }
+}
 
 /// <summary>
 /// Independent terminal-graphics storage and placement state for Sixel,
@@ -12,7 +45,10 @@ namespace Hex1b;
 /// addressing, no explicit delete selectors, no relative-placement graph, no
 /// Unicode placeholders, no z-index, and no chunked uploads. Those concepts
 /// are genuinely KGP-specific and are deliberately kept out of this shared
-/// model.
+/// model. Stage #452 layers scrolling, main-screen scrollback history,
+/// viewport clipping/pruning, resize, and anchor-based reflow onto this
+/// model, mirroring KGP's scrolling/history/reflow fidelity with the same
+/// deliberate simplifications.
 /// </summary>
 /// <remarks>
 /// Main and alternate screen state are fully independent
@@ -161,60 +197,151 @@ internal sealed class SixelGraphicsState
     }
 
     /// <summary>
-    /// Moves every main-screen placement anchored at row 0 into history under
-    /// <paramref name="rowId"/> (the scrollback row identity that row was just
-    /// captured under), and shifts every other placement's anchor up by one
-    /// row. Mirrors <c>KgpTerminalGraphicsState.MoveMainPlacementsIntoHistory</c>.
+    /// Shifts every main-screen placement's anchor up by one row (the row
+    /// that just scrolled off the top of the screen and was captured into
+    /// scrollback under <paramref name="rowId"/>), and, for any placement
+    /// whose painted window still touches that departing row afterwards,
+    /// splits it: exactly the departing painted row moves into history, while
+    /// any painted rows beneath it stay active, re-anchored so the new
+    /// topmost row lands at absolute row 0.
     /// </summary>
-    internal void MoveMainPlacementsIntoHistory(long rowId)
+    /// <remarks>
+    /// Unlike a single-row placement (the common case, where the whole thing
+    /// simply transfers), a placement whose declared footprint spans more
+    /// than one row can have only its first painted row depart while the
+    /// rest remains visible on the newly-shifted screen — this is the
+    /// "history/viewport split" the issue requires (a graphic straddling the
+    /// scrollback boundary keeps a live, independently-clippable copy on each
+    /// side). Both the departing slice and the remaining slice are cut from
+    /// the placement's *current* painted window via
+    /// <see cref="SixelPlacement.SliceHistoryRows"/>, never from its original
+    /// declared geometry, preserving the "no resurrection" invariant across
+    /// repeated scrolling. Geometry-only placements (nothing ever painted)
+    /// have no window to split, so the entire placement transfers as soon as
+    /// its anchor departs, purely to preserve reachability — mirroring
+    /// <c>KgpTerminalGraphicsState.MoveMainPlacementsIntoHistory</c> for that
+    /// case.
+    /// <para>
+    /// Only placements wholly contained in <paramref name="region"/> (the
+    /// same gate <see cref="AdjustActivePlacementsForScroll"/> uses) shift at
+    /// all: a full-height scroll region contains everything on the main
+    /// screen, but under a partial vertical margin (DECSTBM's bottom smaller
+    /// than the physical screen height) only rows inside the margin actually
+    /// move — a placement anchored below the margin, or straddling its
+    /// bottom edge, is untouched by this scroll and must not be shifted or
+    /// have any of its rows transferred, exactly like the ordinary
+    /// non-history scroll path.
+    /// </para>
+    /// </remarks>
+    internal void MoveMainPlacementsIntoHistory(long rowId, SixelScrollRegion region)
     {
         for (var i = _main.Placements.Count - 1; i >= 0; i--)
         {
             var placement = _main.Placements[i];
-            if (placement.Row == 0)
-            {
-                _main.Placements.RemoveAt(i);
-                if (!_main.HistoryPlacements.TryGetValue(rowId, out var list))
-                {
-                    list = [];
-                    _main.HistoryPlacements[rowId] = list;
-                }
+            if (!IsWhollyContained(placement, region))
+                continue;
 
-                list.Add(placement);
-            }
-            else
+            placement.Row -= 1;
+
+            if (!placement.HasPaintedExtent)
             {
-                placement.Row -= 1;
+                if (placement.PaintedTop > -1)
+                    continue;
+
+                _main.Placements.RemoveAt(i);
+                AddHistoryPlacement(
+                    _main,
+                    rowId,
+                    new SixelHistoryPlacement(placement, FirstRow: 0, RetainedRows: 0));
+                continue;
+            }
+
+            if (placement.PaintedTop > -1)
+                continue;
+
+            var departing = placement.SliceHistoryRows(firstRow: 0, retainedRows: 1, resultRow: 0);
+            var remainingRows = placement.PaintedRowCount - 1;
+            var remainder = remainingRows > 0
+                ? placement.SliceHistoryRows(firstRow: 1, retainedRows: remainingRows, resultRow: 0)
+                : null;
+
+            _main.Placements.RemoveAt(i);
+            if (remainder is not null)
+                _main.Placements.Insert(i, remainder);
+
+            if (departing is not null)
+            {
+                AddHistoryPlacement(
+                    _main,
+                    rowId,
+                    new SixelHistoryPlacement(departing, FirstRow: 0, RetainedRows: departing.PaintedRowCount));
             }
         }
     }
 
     /// <summary>
-    /// Releases the history placements anchored to a scrollback row that has
-    /// just been evicted (capacity eviction or an explicit scrollback clear).
+    /// Releases or transfers the history placements anchored to a scrollback
+    /// row that has just been evicted (capacity eviction or an explicit
+    /// scrollback clear).
     /// </summary>
     /// <remarks>
-    /// Stage #451 intentionally keeps history eviction simple: the whole
-    /// placement is released along with its row. KGP's partial cropping and
-    /// transfer-to-successor-row fidelity on capacity eviction
-    /// (<c>ClipRows</c>/<c>RetainedRows</c>) is not replicated here; that level
-    /// of scrolling/reflow fidelity is deferred to #452.
+    /// On capacity eviction with a successor row, a placement whose retained
+    /// window still spans more than one row transfers its remaining window to
+    /// the successor — cropped from the same original geometry every time
+    /// (never from an already-cropped copy), so repeated capacity eviction
+    /// cannot accumulate error. Mirrors
+    /// <c>KgpTerminalGraphicsState.PruneMainHistoryRow</c>'s transfer-to-successor
+    /// behavior, minus KGP's pixel-precise <c>cellPixelHeight</c> rounding
+    /// (Sixel's window arithmetic is exact cell-integer math, so the
+    /// transferred window is always representable when the source invariant
+    /// holds).
     /// </remarks>
     internal void PruneMainHistoryRow(ScrollbackPrunedRow pruned)
     {
-        if (_main.HistoryPlacements.Remove(pruned.RowId, out var removed) && removed.Count > 0)
+        if (!_main.HistoryPlacements.TryGetValue(pruned.RowId, out var placements))
+            return;
+
+        var transfers = new List<(long RowId, SixelHistoryPlacement Placement)>();
+        var anyDropped = false;
+
+        foreach (var historyPlacement in placements)
         {
-            _main.ReconcileImages();
+            if (pruned.Reason == ScrollbackPruneReason.Capacity &&
+                pruned.SuccessorRowId is { } successorRowId &&
+                historyPlacement.RetainedRows > 1)
+            {
+                var transferred = historyPlacement with
+                {
+                    FirstRow = historyPlacement.FirstRow + 1,
+                    RetainedRows = historyPlacement.RetainedRows - 1,
+                };
+                if (transferred.Placement.SliceHistoryRows(
+                        transferred.FirstRow, transferred.RetainedRows, resultRow: 0) is not null)
+                {
+                    transfers.Add((successorRowId, transferred));
+                    continue;
+                }
+            }
+
+            anyDropped = true;
         }
+
+        _main.HistoryPlacements.Remove(pruned.RowId);
+        foreach (var (rowId, historyPlacement) in transfers)
+            AddHistoryPlacement(_main, rowId, historyPlacement);
+
+        if (anyDropped || transfers.Count > 0)
+            _main.ReconcileImages();
     }
 
     /// <summary>
-    /// Shifts or drops active placements for a scroll of <paramref name="rowDelta"/>
-    /// rows within <paramref name="region"/>. A placement wholly contained in
-    /// the region shifts with it; one that would land completely outside the
-    /// region is no longer reachable and is removed. Placements that are not
-    /// wholly contained in the region (partially overlapping it) are left
-    /// untouched, mirroring <c>KgpTerminalGraphicsState.AdjustActivePlacementsForScroll</c>.
+    /// Shifts or crops active placements for a scroll of <paramref name="rowDelta"/>
+    /// rows within <paramref name="region"/>. A placement whose painted
+    /// rectangle is wholly contained in the region shifts with it and is
+    /// re-cropped to the region's bounds; one that would land completely
+    /// outside is no longer reachable and is removed. Placements not wholly
+    /// contained in the region (partially overlapping it) are left untouched.
+    /// Mirrors <c>KgpTerminalGraphicsState.AdjustActivePlacementsForScroll</c>.
     /// </summary>
     internal void AdjustActivePlacementsForScroll(int rowDelta, SixelScrollRegion region)
     {
@@ -223,24 +350,22 @@ internal sealed class SixelGraphicsState
         for (var i = active.Placements.Count - 1; i >= 0; i--)
         {
             var placement = active.Placements[i];
-            var bottom = placement.Row + placement.HeightInCells - 1;
-            var right = placement.Column + placement.WidthInCells - 1;
-            var whollyContained =
-                placement.Row >= region.Top && bottom <= region.Bottom &&
-                placement.Column >= region.Left && right <= region.Right;
-            if (!whollyContained)
+            if (!IsWhollyContained(placement, region))
                 continue;
 
-            var movedRow = placement.Row + rowDelta;
-            var movedBottom = movedRow + placement.HeightInCells - 1;
-            if (movedBottom < region.Top || movedRow > region.Bottom)
+            placement.Row += rowDelta;
+            var clipped = placement.ClipToCellRectangle(
+                region.Top, region.Bottom + 1, region.Left, region.Right + 1);
+            if (clipped is null)
             {
                 active.Placements.RemoveAt(i);
                 changed = true;
-                continue;
             }
-
-            placement.Row = movedRow;
+            else if (!ReferenceEquals(clipped, placement))
+            {
+                active.Placements[i] = clipped;
+                changed = true;
+            }
         }
 
         if (changed)
@@ -265,10 +390,16 @@ internal sealed class SixelGraphicsState
 
     /// <summary>
     /// Removes active placements that fall completely outside a new viewport
-    /// size (used on resize). Placement positions are not reflowed/translated;
-    /// full reflow-aware repositioning is deferred to #452, matching the
-    /// existing fallback KGP itself uses for reflow providers without row
-    /// lineage.
+    /// size (used on resize without reflow). Unlike scroll-margin cropping or
+    /// history/snapshot slicing, a viewport-only resize never permanently
+    /// narrows a placement's painted window: on a real terminal, columns or
+    /// rows that are merely off-screen because the current window is smaller
+    /// than the placement's true extent are not "destroyed" content, and
+    /// widening the viewport back out must be able to reveal them again. Only
+    /// placements whose bounding box no longer intersects the new viewport at
+    /// all are dropped (their content genuinely can no longer be observed by
+    /// any resize back to a larger size, since their row/column anchor itself
+    /// is untouched by a plain crop resize).
     /// </summary>
     internal void ClipActivePlacementsToViewport(int width, int height)
     {
@@ -295,6 +426,14 @@ internal sealed class SixelGraphicsState
     /// for the main screen, also drops any history placement whose scrollback
     /// row is no longer retained.
     /// </summary>
+    /// <remarks>
+    /// Unlike KGP, no eager per-row retained-window shrink is needed here:
+    /// Sixel's history slicing is always non-destructive (the stored
+    /// <see cref="SixelHistoryPlacement.Placement"/> is never mutated), so
+    /// <see cref="CaptureActiveSnapshot"/>'s own spillover intersection
+    /// against the current selected scrollback window is sufficient to keep
+    /// materialized geometry correct without any eager re-bound here.
+    /// </remarks>
     internal void ClipActiveScreenToViewport(
         IReadOnlyList<ScrollbackEntry> historyRows,
         int width,
@@ -329,10 +468,146 @@ internal sealed class SixelGraphicsState
     }
 
     /// <summary>
+    /// Builds the reflow anchors and tracked placements for the active
+    /// screen, for merging into a single combined
+    /// <c>ReflowHelper.PerformReflowWithAnchors</c> call alongside KGP's own
+    /// anchors. Mirrors <c>KgpTerminalGraphicsState.PrepareActiveReflow</c>.
+    /// </summary>
+    /// <remarks>
+    /// Anchor ids are negative (starting at -1, decrementing), guaranteeing no
+    /// collision with KGP's positive ids (which start at 1) when both
+    /// subsystems' anchors are merged into one list — required because the
+    /// reflow strategy needs a single, global view of every anchor to
+    /// redistribute logical lines consistently.
+    /// </remarks>
+    internal SixelReflowPlan PrepareActiveReflow(IReadOnlyList<ScrollbackEntry> historyRows)
+    {
+        var active = Active;
+        var isMain = active == _main;
+        var historyCount = isMain ? historyRows.Count : 0;
+        var anchors = new List<TerminalReflowAnchor>(
+            active.Placements.Count + active.HistoryPlacements.Count);
+        var placements = new List<SixelReflowPlacement>(anchors.Capacity);
+        var nextId = -1;
+
+        foreach (var placement in active.Placements)
+        {
+            var id = nextId--;
+            anchors.Add(new TerminalReflowAnchor(id, historyCount + placement.Row, placement.Column));
+            placements.Add(new SixelReflowPlacement(id, placement, History: null));
+        }
+
+        if (isMain && active.HistoryPlacements.Count > 0)
+        {
+            var rowIndices = new Dictionary<long, int>(historyRows.Count);
+            for (var i = 0; i < historyRows.Count; i++)
+                rowIndices[historyRows[i].RowId] = i;
+
+            foreach (var (rowId, rowPlacements) in active.HistoryPlacements)
+            {
+                if (!rowIndices.TryGetValue(rowId, out var rowIndex))
+                    continue; // Evicted or outside the selected scrollback window.
+
+                foreach (var historyPlacement in rowPlacements)
+                {
+                    var id = nextId--;
+                    anchors.Add(new TerminalReflowAnchor(id, rowIndex, historyPlacement.Placement.Column));
+                    placements.Add(new SixelReflowPlacement(id, historyPlacement.Placement, historyPlacement));
+                }
+            }
+        }
+
+        return new SixelReflowPlan(anchors, placements);
+    }
+
+    /// <summary>
+    /// Applies a completed reflow: each tracked placement moves atomically to
+    /// wherever its single anchor point was mapped (no per-row splitting
+    /// during reflow itself), then is re-partitioned into history vs. live
+    /// viewport based on the mapped row. A placement whose anchor could not
+    /// be represented in the reflowed layout (row consumed elsewhere, or a
+    /// history window that no longer fits) is dropped — the explicit safe
+    /// behavior the issue requires for genuinely unrepresentable placements.
+    /// Mirrors <c>KgpTerminalGraphicsState.ApplyActiveReflow</c>.
+    /// </summary>
+    internal void ApplyActiveReflow(
+        SixelReflowPlan plan,
+        IReadOnlyList<TerminalReflowAnchor> mappedAnchors,
+        int resultHistoryCount,
+        ScrollbackReplacementResult replacement,
+        int width,
+        int height)
+    {
+        var active = Active;
+        var mappedById = new Dictionary<int, TerminalReflowAnchor>(mappedAnchors.Count);
+        foreach (var anchor in mappedAnchors)
+            mappedById[anchor.Id] = anchor;
+
+        active.Placements.Clear();
+        active.HistoryPlacements.Clear();
+
+        foreach (var tracked in plan.Placements)
+        {
+            var placement = tracked.Placement;
+            if (tracked.History is { } history)
+            {
+                var sliced = placement.SliceHistoryRows(history.FirstRow, history.RetainedRows, resultRow: 0);
+                if (sliced is null)
+                    continue;
+
+                placement = sliced;
+            }
+
+            if (!mappedById.TryGetValue(tracked.Id, out var mapped))
+                continue;
+
+            if (mapped.Row < replacement.DiscardedRowCount)
+            {
+                var discardedRows = replacement.DiscardedRowCount - mapped.Row;
+                if (discardedRows >= placement.PaintedRowCount)
+                    continue;
+
+                var clipped = placement.SliceHistoryRows(
+                    discardedRows, placement.PaintedRowCount - discardedRows, resultRow: 0);
+                if (clipped is null)
+                    continue;
+
+                placement = clipped;
+                mapped = mapped with { Row = replacement.DiscardedRowCount };
+            }
+
+            if (mapped.Row < resultHistoryCount)
+            {
+                var retainedIndex = mapped.Row - replacement.DiscardedRowCount;
+                if (retainedIndex < 0 || retainedIndex >= replacement.Entries.Length)
+                    continue;
+
+                var repositioned = placement.WithPosition(0, mapped.Column);
+                AddHistoryPlacement(
+                    active,
+                    replacement.Entries[retainedIndex].RowId,
+                    new SixelHistoryPlacement(repositioned, FirstRow: 0, repositioned.PaintedRowCount));
+                continue;
+            }
+
+            var screenRow = mapped.Row - resultHistoryCount;
+            var activePlacement = placement
+                .WithPosition(screenRow, mapped.Column)
+                .ClipToCellRectangle(0, height, 0, width);
+            if (activePlacement is not null)
+                active.Placements.Add(activePlacement);
+        }
+
+        active.ReconcileImages();
+    }
+
+    /// <summary>
     /// Projects the active screen's placements into a unified coordinate space
     /// (history rows first, then the live viewport) for inclusion in a
     /// terminal snapshot, exactly like
-    /// <c>KgpTerminalGraphicsState.CaptureActiveSnapshot</c>.
+    /// <c>KgpTerminalGraphicsState.CaptureActiveSnapshot</c>. A placement that
+    /// spans the scrollback/viewport boundary is split into independent
+    /// projections on each side (never duplicated whole).
     /// </summary>
     /// <remarks>
     /// Returned placements are independent copies (see
@@ -340,12 +615,16 @@ internal sealed class SixelGraphicsState
     /// <see cref="SixelData"/> images dictionary returned alongside them,
     /// remain valid and reachable for as long as the snapshot itself is kept
     /// alive, even after the live graphics state that produced them mutates
-    /// or sweeps its own store.
+    /// or sweeps its own store. <paramref name="width"/> bounds both the live
+    /// viewport and history rows uniformly, matching the snapshot's single
+    /// unified width (which may exceed the terminal's current width when
+    /// projecting scrollback under <c>ScrollbackWidth.Original</c>).
     /// </remarks>
     internal (IReadOnlyList<SixelPlacement> Placements, IReadOnlyDictionary<byte[], SixelData> Images) CaptureActiveSnapshot(
         IReadOnlyList<ScrollbackEntry> allHistoryRows,
         int selectedHistoryCount,
-        int viewportHeight)
+        int viewportHeight,
+        int width)
     {
         var active = Active;
         var isMain = active == _main;
@@ -368,36 +647,103 @@ internal sealed class SixelGraphicsState
         foreach (var placement in active.Placements)
         {
             var unifiedRow = historyCount + placement.Row;
-            AddIfVisible(placement, unifiedRow, snapshotStart, snapshotEnd, placements, images);
+            AddMaterializedPlacement(
+                placement.WithRow(unifiedRow), snapshotStart, snapshotEnd, width, placements, images);
         }
 
         if (isMain && rowIndexByRowId is not null)
         {
             foreach (var (rowId, list) in active.HistoryPlacements)
             {
-                if (!rowIndexByRowId.TryGetValue(rowId, out var unifiedRow))
+                if (!rowIndexByRowId.TryGetValue(rowId, out var anchorRow))
                     continue; // Evicted or outside the selected scrollback window.
 
-                foreach (var placement in list)
-                    AddIfVisible(placement, unifiedRow, snapshotStart, snapshotEnd, placements, images);
+                foreach (var historyPlacement in list)
+                {
+                    AddMaterializedHistoryPlacement(
+                        historyPlacement, anchorRow, snapshotStart, snapshotEnd, width, placements, images);
+                }
             }
         }
 
         return (placements, images);
     }
 
-    private static void AddIfVisible(
-        SixelPlacement placement,
-        int unifiedRow,
+    private static void AddHistoryPlacement(
+        SixelScreenGraphicsState screen,
+        long rowId,
+        SixelHistoryPlacement historyPlacement)
+    {
+        if (!screen.HistoryPlacements.TryGetValue(rowId, out var list))
+        {
+            list = [];
+            screen.HistoryPlacements[rowId] = list;
+        }
+
+        list.Add(historyPlacement);
+    }
+
+    /// <summary>
+    /// A placement's painted rectangle (or, for a geometry-only placement, its
+    /// declared footprint) is wholly contained in <paramref name="region"/>.
+    /// Gating on the painted rectangle — not the raw declared footprint —
+    /// means an oversized/cross-margin placement that was already
+    /// creation-time-clipped into the scroll region (see
+    /// <c>Hex1bTerminal.ResolveSixelPlacement</c>) is correctly eligible to
+    /// keep scrolling/cropping with the region, rather than being permanently
+    /// excluded because its full declared footprint extends outside it.
+    /// </summary>
+    private static bool IsWhollyContained(SixelPlacement placement, SixelScrollRegion region)
+    {
+        if (placement.HasPaintedExtent)
+        {
+            return placement.PaintedTop >= region.Top && placement.PaintedBottom <= region.Bottom &&
+                placement.PaintedLeft >= region.Left && placement.PaintedRight <= region.Right;
+        }
+
+        var bottom = placement.Row + placement.HeightInCells - 1;
+        var right = placement.Column + placement.WidthInCells - 1;
+        return placement.Row >= region.Top && bottom <= region.Bottom &&
+            placement.Column >= region.Left && right <= region.Right;
+    }
+
+    private static void AddMaterializedHistoryPlacement(
+        SixelHistoryPlacement historyPlacement,
+        int anchorRow,
         int snapshotStart,
         int snapshotEnd,
-        List<SixelPlacement> placements,
+        int width,
+        List<SixelPlacement> destination,
         Dictionary<byte[], SixelData> images)
     {
-        if (unifiedRow < snapshotStart || unifiedRow >= snapshotEnd)
+        var placementEnd = anchorRow + historyPlacement.RetainedRows;
+        var retainedStart = Math.Max(anchorRow, snapshotStart);
+        var retainedEnd = Math.Min(placementEnd, snapshotEnd);
+        if (retainedStart >= retainedEnd)
             return;
 
-        placements.Add(placement.WithRow(unifiedRow - snapshotStart));
-        images[placement.Image.ContentHash] = placement.Image;
+        var firstRow = historyPlacement.FirstRow + (retainedStart - anchorRow);
+        var retainedRows = retainedEnd - retainedStart;
+        var sliced = historyPlacement.Placement.SliceHistoryRows(firstRow, retainedRows, resultRow: retainedStart);
+        if (sliced is null)
+            return;
+
+        AddMaterializedPlacement(sliced, snapshotStart, snapshotEnd, width, destination, images);
+    }
+
+    private static void AddMaterializedPlacement(
+        SixelPlacement placement,
+        int snapshotStart,
+        int snapshotEnd,
+        int width,
+        List<SixelPlacement> destination,
+        Dictionary<byte[], SixelData> images)
+    {
+        var clipped = placement.ClipToCellRectangle(snapshotStart, snapshotEnd, 0, width);
+        if (clipped is null)
+            return;
+
+        destination.Add(clipped.WithRow(clipped.Row - snapshotStart));
+        images[clipped.Image.ContentHash] = clipped.Image;
     }
 }

--- a/src/Hex1b/Sixel/SixelHistoryPlacement.cs
+++ b/src/Hex1b/Sixel/SixelHistoryPlacement.cs
@@ -1,0 +1,47 @@
+namespace Hex1b.Sixel;
+
+/// <summary>
+/// A Sixel placement that has scrolled into main-screen scrollback history,
+/// tracking how much of its painted window is still retained by the
+/// scrollback row identity it is currently anchored to.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Mirrors <c>KgpTerminalGraphicsState.HistoryPlacement</c>: <see cref="Placement"/>
+/// keeps describing the geometry it had at the moment it (or its predecessor
+/// transfer) last entered history, and never has its own painted window
+/// mutated in place. <see cref="FirstRow"/>/<see cref="RetainedRows"/> instead
+/// describe, non-destructively, which sub-window of
+/// <see cref="Placement"/>'s own <c>PaintedRowOffset</c>/<c>PaintedRowCount</c>
+/// range is still owned by this row identity — both are 0-based offsets
+/// within that painted window, not within the placement's declared footprint
+/// and not absolute terminal rows.
+/// </para>
+/// <para>
+/// This indirection is what lets a multi-row placement "spill over" from
+/// history back into the still-visible viewport (its <see cref="RetainedRows"/>
+/// can extend past the true scrollback row count into unified snapshot space)
+/// and lets capacity eviction transfer a shrinking remainder to the successor
+/// row (<see cref="FirstRow"/> creeps forward, <see cref="RetainedRows"/>
+/// shrinks) without ever re-deriving cropped geometry from the full,
+/// original footprint — the same "never resurrect a previously discarded
+/// row" invariant <see cref="SixelPlacement.ClipToCellRectangle"/> relies on.
+/// </para>
+/// </remarks>
+/// <param name="Placement">
+/// The placement as it was recorded when it (or its predecessor transfer)
+/// entered history. Never mutated in place; slicing always happens on demand
+/// via <see cref="SixelPlacement.SliceHistoryRows"/>.
+/// </param>
+/// <param name="FirstRow">
+/// Offset, relative to <see cref="Placement"/>'s own painted-row window, of
+/// the first still-retained painted row.
+/// </param>
+/// <param name="RetainedRows">
+/// How many painted rows starting at <paramref name="FirstRow"/> are still
+/// retained by this row identity's chain.
+/// </param>
+internal readonly record struct SixelHistoryPlacement(
+    SixelPlacement Placement,
+    int FirstRow,
+    int RetainedRows);

--- a/src/Hex1b/Sixel/SixelPlacement.cs
+++ b/src/Hex1b/Sixel/SixelPlacement.cs
@@ -20,9 +20,20 @@ namespace Hex1b;
 /// <see cref="Row"/> is mutable so scrolling and history transitions can shift
 /// a placement's anchor in place without discarding and recreating it (the
 /// same "shift, don't recreate" strategy <see cref="KgpPlacement"/> uses).
-/// Everything else about a placement is fixed at creation time, matching the
-/// Sixel protocol's write-once-then-anchor semantics: unlike KGP, Sixel has no
-/// notion of relocating, resizing, or re-cropping an existing placement.
+/// The declared footprint (<see cref="WidthInCells"/>/<see cref="HeightInCells"/>)
+/// is fixed at creation time, matching the Sixel protocol's
+/// write-once-then-anchor semantics: unlike KGP, Sixel never resizes an
+/// existing placement's declared geometry. The painted crop window
+/// (<see cref="PaintedRowOffset"/>/<see cref="PaintedRowCount"/>/
+/// <see cref="PaintedColumnOffset"/>/<see cref="PaintedColumnCount"/>) may
+/// still shrink after creation via <see cref="ClipToCellRectangle"/> — always
+/// by intersecting the *current* painted rectangle with a new clip bound, so
+/// a row or column already cropped away can never resurface later regardless
+/// of operation order (scroll, resize, and history pruning all funnel through
+/// this same monotonic intersection). <see cref="Column"/> is likewise
+/// repositioned only via <see cref="WithPosition"/>, used by reflow when an
+/// anchor's wrapped-line position genuinely moves horizontally; ordinary
+/// scrolling and margin operations never touch it.
 /// </para>
 /// </remarks>
 internal sealed class SixelPlacement
@@ -104,8 +115,10 @@ internal sealed class SixelPlacement
     internal int Row { get; set; }
 
     /// <summary>
-    /// The anchor column. Sixel placements never move horizontally, so this
-    /// never changes after creation.
+    /// The anchor column. Ordinary scrolling and margin operations never
+    /// change this; only reflow (<see cref="WithPosition"/>) repositions it,
+    /// when a wrapped line's anchor genuinely lands in a different column
+    /// under the new width.
     /// </summary>
     internal int Column { get; }
 
@@ -260,10 +273,25 @@ internal sealed class SixelPlacement
     /// reachable (via ordinary GC) even after the live placement it was copied
     /// from is removed from the active graphics state.
     /// </remarks>
-    internal SixelPlacement WithRow(int row) => new(
+    internal SixelPlacement WithRow(int row) => WithPosition(row, Column);
+
+    /// <summary>
+    /// Creates a copy of this placement repositioned to
+    /// <paramref name="row"/>/<paramref name="column"/>, used by reflow when
+    /// an anchor's wrapped-line position moves both vertically and
+    /// horizontally.
+    /// </summary>
+    /// <remarks>
+    /// Damaged-cell keys are anchor-relative (see <see cref="CellKey"/>), so
+    /// repositioning the anchor never needs to remap them: the same
+    /// image-local (row, column) pair they encode stays correct regardless of
+    /// which absolute anchor position <see cref="Row"/>/<see cref="Column"/>
+    /// currently hold.
+    /// </remarks>
+    internal SixelPlacement WithPosition(int row, int column) => new(
         Image,
         row,
-        Column,
+        column,
         WidthInCells,
         HeightInCells,
         PaintedRowOffset,
@@ -273,6 +301,126 @@ internal sealed class SixelPlacement
         Sequence,
         CreatedAt,
         _damagedCells);
+
+    /// <summary>
+    /// Intersects the current painted rectangle with
+    /// <paramref name="top"/>/<paramref name="bottomExclusive"/>/<paramref name="left"/>/<paramref name="rightExclusive"/>,
+    /// returning a narrower copy, this same instance when nothing changed, or
+    /// <see langword="null"/> when the placement is no longer reachable.
+    /// </summary>
+    /// <remarks>
+    /// This is the single choke point every scroll/resize/history operation
+    /// funnels through to shrink a placement's visible window. Because it
+    /// always intersects the *current* painted rectangle — never re-derives
+    /// from the full declared footprint — a row or column already cropped
+    /// away by an earlier operation can never resurface later, regardless of
+    /// how many further scrolls or resizes are applied (the "no resurrection"
+    /// invariant the issue requires). A geometry-only placement (the
+    /// rasterizer refused pixel allocation) is always retained, even with a
+    /// zero-size painted window, since its reachability must not depend on
+    /// paint status.
+    /// </remarks>
+    internal SixelPlacement? ClipToCellRectangle(int top, int bottomExclusive, int left, int rightExclusive)
+    {
+        if (!HasPaintedExtent || top >= bottomExclusive || left >= rightExclusive)
+            return IsGeometryOnly ? this : null;
+
+        var clippedTop = Math.Max(PaintedTop, top);
+        var clippedBottom = Math.Min(PaintedBottom + 1, bottomExclusive);
+        var clippedLeft = Math.Max(PaintedLeft, left);
+        var clippedRight = Math.Min(PaintedRight + 1, rightExclusive);
+
+        if (clippedTop >= clippedBottom || clippedLeft >= clippedRight)
+        {
+            return IsGeometryOnly
+                ? new SixelPlacement(
+                    Image, Row, Column, WidthInCells, HeightInCells,
+                    PaintedRowOffset, 0, PaintedColumnOffset, 0,
+                    Sequence, CreatedAt, [])
+                : null;
+        }
+
+        var newRowOffset = PaintedRowOffset + (clippedTop - PaintedTop);
+        var newRowCount = clippedBottom - clippedTop;
+        var newColumnOffset = PaintedColumnOffset + (clippedLeft - PaintedLeft);
+        var newColumnCount = clippedRight - clippedLeft;
+
+        if (newRowOffset == PaintedRowOffset && newRowCount == PaintedRowCount &&
+            newColumnOffset == PaintedColumnOffset && newColumnCount == PaintedColumnCount)
+        {
+            return this;
+        }
+
+        return new SixelPlacement(
+            Image, Row, Column, WidthInCells, HeightInCells,
+            newRowOffset, newRowCount, newColumnOffset, newColumnCount,
+            Sequence, CreatedAt,
+            FilterDamagedCells(newRowOffset, newRowCount, newColumnOffset, newColumnCount));
+    }
+
+    /// <summary>
+    /// Slices a sub-window of the *current* painted rows — <paramref name="retainedRows"/>
+    /// rows starting <paramref name="firstRow"/> rows into the current
+    /// <see cref="PaintedRowOffset"/> — into a copy whose <see cref="PaintedTop"/>
+    /// lands exactly at <paramref name="resultRow"/>. Used both to validate
+    /// and to materialize a <see cref="SixelHistoryPlacement"/>'s retained
+    /// window.
+    /// </summary>
+    /// <remarks>
+    /// Returns <see langword="null"/> when the requested window is empty or
+    /// out of range. Unlike <see cref="ClipToCellRectangle"/>, this never
+    /// falls back to retaining a geometry-only placement at zero extent: it
+    /// is only ever called with an already-validated, non-empty
+    /// <c>FirstRow</c>/<c>RetainedRows</c> pair, so an out-of-range request
+    /// here always indicates a genuinely unrepresentable slice.
+    /// </remarks>
+    internal SixelPlacement? SliceHistoryRows(int firstRow, int retainedRows, int resultRow)
+    {
+        if (retainedRows <= 0 || firstRow < 0 || firstRow + retainedRows > PaintedRowCount)
+            return null;
+
+        // PaintedRowOffset keeps indexing into the image's own rows (damaged-cell
+        // keys are image-local), so Row must absorb resultRow's shift on top of
+        // that offset — Row + newRowOffset always has to equal resultRow, never
+        // resultRow itself, or PaintedTop drifts by whatever the slice skipped.
+        var newRowOffset = PaintedRowOffset + firstRow;
+        var newRow = resultRow - newRowOffset;
+        return new SixelPlacement(
+            Image, newRow, Column, WidthInCells, HeightInCells,
+            newRowOffset, retainedRows, PaintedColumnOffset, PaintedColumnCount,
+            Sequence, CreatedAt,
+            FilterDamagedCells(newRowOffset, retainedRows, PaintedColumnOffset, PaintedColumnCount));
+    }
+
+    /// <summary>
+    /// Filters stale damaged-cell keys that fall outside a narrowed painted
+    /// window. Damaged-cell keys are already image-local (anchor-relative),
+    /// so no coordinate remapping is needed here — only a range filter, so a
+    /// shrinking window never over-counts damage against
+    /// <see cref="HasVisiblePaintedCells"/>'s narrower total.
+    /// </summary>
+    private HashSet<int> FilterDamagedCells(int newRowOffset, int newRowCount, int newColumnOffset, int newColumnCount)
+    {
+        if (_damagedCells.Count == 0)
+            return _damagedCells;
+
+        HashSet<int>? filtered = null;
+        foreach (var key in _damagedCells)
+        {
+            var relativeRow = key / WidthInCells;
+            var relativeColumn = key % WidthInCells;
+            var stillInWindow =
+                relativeRow >= newRowOffset && relativeRow < newRowOffset + newRowCount &&
+                relativeColumn >= newColumnOffset && relativeColumn < newColumnOffset + newColumnCount;
+            if (stillInWindow)
+                continue;
+
+            filtered ??= new HashSet<int>(_damagedCells);
+            filtered.Remove(key);
+        }
+
+        return filtered ?? _damagedCells;
+    }
 
     private bool IsCellDamaged(int row, int column) => _damagedCells.Contains(CellKey(row, column));
 

--- a/src/Hex1b/Sixel/SixelScreenGraphicsState.cs
+++ b/src/Hex1b/Sixel/SixelScreenGraphicsState.cs
@@ -20,7 +20,7 @@ internal sealed class SixelScreenGraphicsState
     /// to. Only ever populated for the main screen; the alternate screen has
     /// no history partition.
     /// </summary>
-    internal Dictionary<long, List<SixelPlacement>> HistoryPlacements { get; } = [];
+    internal Dictionary<long, List<SixelHistoryPlacement>> HistoryPlacements { get; } = [];
 
     internal void Clear()
     {
@@ -41,8 +41,8 @@ internal sealed class SixelScreenGraphicsState
             retained.Add(placement.Image.ContentHash);
         foreach (var list in HistoryPlacements.Values)
         {
-            foreach (var placement in list)
-                retained.Add(placement.Image.ContentHash);
+            foreach (var historyPlacement in list)
+                retained.Add(historyPlacement.Placement.Image.ContentHash);
         }
 
         Images.RemoveUnreferenced(retained);

--- a/tests/Hex1b.Tests/Hex1bTerminalScrollbackTests.cs
+++ b/tests/Hex1b.Tests/Hex1bTerminalScrollbackTests.cs
@@ -342,4 +342,55 @@ public class Hex1bTerminalScrollbackTests
         // Should not capture to scrollback since scroll region doesn't start at row 0
         Assert.AreEqual(0, terminal.Scrollback!.Count);
     }
+
+    /// <summary>
+    /// Plain-text (no Sixel state involved) regression coverage for the
+    /// #452 history-transfer fix: a DECSTBM region that starts at row 0 but
+    /// is *smaller* than the physical screen ("partial vertical margin")
+    /// must still capture the departing row into scrollback, and rows
+    /// outside the margin must be completely unaffected by the scroll.
+    /// </summary>
+    /// <remarks>
+    /// This complements <see cref="PartialScrollRegion_DoesNotCaptureScrollback"/>
+    /// (region not starting at row 0 -&gt; no capture) by covering the other
+    /// partial-margin shape (region starting at row 0, ending above the
+    /// bottom of the screen -&gt; capture still happens). It exists to prove,
+    /// independently of any Sixel test, that the <c>Hex1bTerminal.ScrollUp</c>
+    /// changes made to support the new Sixel-only <c>createsSixelHistory</c>
+    /// gate (see <c>SixelScrollHistoryReflowTests</c>) left plain scrollback
+    /// capture and row-shift behavior for a top-anchored partial margin
+    /// exactly as it was before.
+    /// </remarks>
+    [TestMethod]
+    public void PartialVerticalMargin_FromTop_CapturesScrollbackAndLeavesRowsBelowUntouched()
+    {
+        using var terminal = CreateTerminal(width: 10, height: 5);
+
+        // Set scroll region to rows 1-3 (starts at row 0, ends above the
+        // physical bottom row 4) - a "partial vertical margin from the top".
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[1;3r")); // DECSTBM: rows 1-3 (1-based)
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[1;1H")); // Move cursor to row 1
+
+        // Fill the 3-row margin and force exactly one scroll within it.
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("A\r\nB\r\nC\r\nD"));
+
+        // The departing row ("A") must still be captured into scrollback,
+        // even though the margin doesn't span the full physical screen.
+        Assert.IsNotNull(terminal.Scrollback);
+        Assert.AreEqual(1, terminal.Scrollback.Count);
+        var lines = terminal.Scrollback.GetLines(1);
+        Assert.AreEqual("A", lines[0].Cells[0].Character);
+
+        // Rows inside the margin shifted up by one and the new row was
+        // written at the margin's bottom.
+        using var snapshot = terminal.CreateSnapshot();
+        Assert.AreEqual("B", snapshot.GetCell(0, 0).Character);
+        Assert.AreEqual("C", snapshot.GetCell(0, 1).Character);
+        Assert.AreEqual("D", snapshot.GetCell(0, 2).Character);
+
+        // Rows 4-5 (outside the margin, physical rows 3-4) were never part
+        // of the scroll region and must remain completely blank/untouched.
+        Assert.AreEqual(" ", snapshot.GetCell(0, 3).Character);
+        Assert.AreEqual(" ", snapshot.GetCell(0, 4).Character);
+    }
 }

--- a/tests/Hex1b.Tests/Sixel/SixelScrollHistoryReflowTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelScrollHistoryReflowTests.cs
@@ -1,0 +1,693 @@
+// Copyright (c) Hex1b contributors. Licensed under the MIT license.
+
+using System.Text;
+using Hex1b.Automation;
+using Hex1b.Reflow;
+using Hex1b.Sixel;
+using Hex1b.Testing;
+
+namespace Hex1b.Tests.Sixel;
+
+/// <summary>
+/// Integration coverage for issue #452: independent Sixel placements moving
+/// through terminal scrolling, main-screen scrollback history, viewport
+/// clipping, resize, and reflow. These tests exercise raw DCS byte sequences
+/// only (never <c>SixelWidget</c>/<c>SixelEncoder</c>) and assert against the
+/// production <see cref="Hex1bTerminal"/> Sixel accessors, mirroring the
+/// conventions established by <see cref="KgpScrollingTests"/> for the KGP
+/// protocol but adapted to Sixel's simpler anonymous-placement model (no IDs,
+/// no relative graph, no z-index).
+/// </summary>
+[TestClass]
+public class SixelScrollHistoryReflowTests
+{
+    // 1x12 px, 1:1 aspect, two full six-pixel bands -> two occupied rows at
+    // the harness's default 1x6 cell metrics. Reused from SixelScrollingTests'
+    // "scrolling" fixture convention (explicit raster header avoids the
+    // default 2:1 vertical aspect doubling that a bare "q...@" payload gets).
+    private static readonly SixelFixture TwoRowBar = SixelFixture.Load(
+        "scrolling",
+        "Two-band bar used as a two-row-tall scroll/history probe.");
+
+    // 1x18 px, 1:1 aspect, three full six-pixel bands -> three occupied rows.
+    private static readonly SixelFixture ThreeRowBar = new(
+        "three-row-bar",
+        "Three-band bar used as a three-row-tall progressive-crop probe.",
+        Encoding.ASCII.GetBytes("q\"1;1;1;18#1;2;100;0;0~-~-~"));
+
+    // 3x6 px, 1:1 aspect, one band, three columns -> one row, three columns.
+    private static readonly SixelFixture OneRowThreeCol = new(
+        "one-row-three-col",
+        "Single-row, three-column bar used for horizontal-margin probes.",
+        Encoding.ASCII.GetBytes("q\"1;1;3;6#1;2;100;0;0~~~"));
+
+    // 1x6 px, 1:1 aspect, one band -> exactly one occupied row (unlike the
+    // "single-band" shared fixture, which relies on the default 2:1 aspect
+    // and therefore occupies two rows).
+    private static readonly SixelFixture OneRowBar = new(
+        "one-row-bar",
+        "Single-row bar used for capacity-one pruning probes.",
+        Encoding.ASCII.GetBytes("q\"1;1;1;6#1;2;100;0;0@"));
+
+    // 2x6 px, 1:1 aspect, one band, two columns -> one row, two columns. Used
+    // for the damage-persistence probe so only one of the two columns is
+    // overwritten with text.
+    private static readonly SixelFixture TwoColBar = new(
+        "two-col-bar",
+        "Single-row, two-column bar used for the damage-persistence probe.",
+        Encoding.ASCII.GetBytes("q\"1;1;2;6#1;2;100;0;0~~"));
+
+    [TestMethod]
+    [DataRow("\n", DisplayName = "LF")]
+    [DataRow("\u001bD", DisplayName = "IND")]
+    public async Task ScrollUpEquivalents_LineFeedAndIndex_BothMoveDepartingRowIntoHistory(string terminator)
+    {
+        await using var terminal = SixelTestTerminal.Create(width: 8, height: 3, scrollbackCapacity: 3);
+        var bytes = TwoRowBar.StandardBytes
+            .Concat(Encoding.ASCII.GetBytes("\x1b[3;1H" + terminator))
+            .ToArray();
+
+        await terminal.FeedAsync(bytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ScrollbackLineCount > 0,
+            "scroll into history",
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(1, terminal.Terminal.ScrollbackCount);
+        Assert.HasCount(1, terminal.Terminal.SixelPlacements);
+        Assert.AreEqual(1, terminal.Terminal.SixelPlacements[0].PaintedRowCount);
+    }
+
+    [TestMethod]
+    [DataRow("\u001bM", DisplayName = "RI")]
+    [DataRow("\u001b[T", DisplayName = "SD")]
+    public async Task ScrollDownEquivalents_ReverseIndexAndScrollDown_ShiftPlacementDownWithinMargin(string sequence)
+    {
+        await using var terminal = SixelTestTerminal.Create(width: 8, height: 5);
+
+        // Cursor is parked one row above the region bottom so painting the
+        // two-row graphic needs a row for the cursor to land on below it;
+        // ResolveSixelPlacement pre-scrolls the region up once to make room,
+        // landing the placement at Row=1 (0-based) instead of Row=3.
+        var prefix = Encoding.ASCII.GetBytes("\x1b[2;4r\x1b[4;1H");
+        var bytes = prefix.Concat(TwoRowBar.StandardBytes)
+            .Concat(Encoding.ASCII.GetBytes("\x1b[2;1H" + sequence))
+            .ToArray();
+
+        await terminal.FeedAsync(bytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "shift within vertical margin",
+            TestContext.Current.CancellationToken);
+
+        // Placement lands at Row=1 (Top=1,Bottom=2) after the pre-scroll, then
+        // RI/SD (issued with the cursor at the region's top margin) shifts it
+        // down by one row within the [1,3] region: Top=2, Bottom=3.
+        var placement = TestSeq.Single(terminal.Terminal.SixelPlacements);
+        Assert.AreEqual(2, placement.PaintedTop);
+    }
+
+    [TestMethod]
+    public async Task HorizontalMargins_ScrollUp_LeavesPlacementsNotWhollyContainedUntouched()
+    {
+        await using var terminal = SixelTestTerminal.Create(width: 12, height: 3);
+
+        // DECLRMM clips painting unconditionally to the horizontal margin
+        // (cols 4-8, 1-based), so a placement anchored entirely outside it
+        // paints nothing (HasPaintedExtent is false). Containment then falls
+        // back to the declared footprint, which is outside the margin on
+        // both sides here (cols 1-3 and cols 9-11, 1-based) - so SU must
+        // leave both untouched (Row stays 0) rather than shifting them.
+        var prefix = Encoding.ASCII.GetBytes("\x1b[?69h\x1b[4;8s\x1b[1;1H");
+        var second = Encoding.ASCII.GetBytes("\x1b[1;9H");
+        var bytes = prefix
+            .Concat(OneRowThreeCol.StandardBytes)
+            .Concat(second)
+            .Concat(OneRowThreeCol.StandardBytes)
+            .Concat(Encoding.ASCII.GetBytes("\x1b[S"))
+            .ToArray();
+
+        await terminal.FeedAsync(bytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.SixelPlacements.Count == 2,
+            "both placements created (neither paints visibly, so ContainsSixelData never becomes true)",
+            TestContext.Current.CancellationToken);
+
+        Assert.HasCount(2, terminal.Terminal.SixelPlacements);
+        foreach (var placement in terminal.Terminal.SixelPlacements)
+        {
+            Assert.AreEqual(0, placement.Row);
+        }
+    }
+
+    [TestMethod]
+    public async Task HorizontalMargins_ScrollUp_ShiftsWhollyContainedPlacementUpByOne()
+    {
+        await using var terminal = SixelTestTerminal.Create(width: 12, height: 3);
+
+        // A one-row placement leaves a row of headroom above it in the
+        // full-height region, so the shift is clean (no cropping needed) -
+        // unlike a two-row placement here, which would fill the region
+        // exactly and trigger ResolveSixelPlacement's pre-scroll-for-cursor
+        // room, or get cropped by the very shift being tested.
+        var prefix = Encoding.ASCII.GetBytes("\x1b[?69h\x1b[4;8s\x1b[2;5H");
+        var bytes = prefix
+            .Concat(OneRowThreeCol.StandardBytes)
+            .Concat(Encoding.ASCII.GetBytes("\x1b[S"))
+            .ToArray();
+
+        await terminal.FeedAsync(bytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "horizontal-margin shift",
+            TestContext.Current.CancellationToken);
+
+        var placement = TestSeq.Single(terminal.Terminal.SixelPlacements);
+        Assert.AreEqual(0, placement.Row);
+        Assert.AreEqual(1, placement.PaintedRowCount);
+    }
+
+    [TestMethod]
+    public async Task PartialVerticalMargins_ScrollUp_CropsThenRemovesContainedPlacement()
+    {
+        await using var terminal = SixelTestTerminal.Create(width: 8, height: 5);
+        var prefix = Encoding.ASCII.GetBytes("\x1b[2;4r\x1b[2;1H");
+        var scrollOnce = Encoding.ASCII.GetBytes("\x1b[S");
+        var bytes = prefix.Concat(ThreeRowBar.StandardBytes).Concat(scrollOnce).ToArray();
+
+        await terminal.FeedAsync(bytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "first partial-margin scroll",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(2, TestSeq.Single(terminal.Terminal.SixelPlacements).PaintedRowCount);
+
+        await terminal.FeedAsync(scrollOnce, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.SixelPlacements is [{ } p] && p.PaintedRowCount == 1,
+            "second partial-margin scroll crops to a single row",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(1, TestSeq.Single(terminal.Terminal.SixelPlacements).PaintedRowCount);
+
+        await terminal.FeedAsync(scrollOnce, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.SixelPlacements.Count == 0,
+            "third partial-margin scroll removes remainder",
+            TestContext.Current.CancellationToken);
+        Assert.IsEmpty(terminal.Terminal.SixelPlacements);
+        Assert.AreEqual(0, terminal.Terminal.ScrollbackCount);
+    }
+
+    [TestMethod]
+    public async Task PartialVerticalMargins_ScrollDown_CropsBottomThenRemovesContainedPlacement()
+    {
+        await using var terminal = SixelTestTerminal.Create(width: 8, height: 5);
+        var prefix = Encoding.ASCII.GetBytes("\x1b[2;5r\x1b[4;1H");
+        var scrollOnce = Encoding.ASCII.GetBytes("\x1b[T");
+        var bytes = prefix.Concat(TwoRowBar.StandardBytes).ToArray();
+
+        await terminal.FeedAsync(bytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "placement created inside vertical margin",
+            TestContext.Current.CancellationToken);
+        // The cursor (row 3, 0-based) plus the graphic's height overflows the
+        // region bottom (row 4) by exactly the one row the cursor itself needs
+        // to land on below the graphic, so ResolveSixelPlacement's proactive
+        // pre-scroll-for-cursor-room mechanism fires once before the placement
+        // is even created, landing it at row 2 (rows 2-3) instead of row 3.
+        Assert.AreEqual(2, TestSeq.Single(terminal.Terminal.SixelPlacements).Row);
+        Assert.AreEqual(2, TestSeq.Single(terminal.Terminal.SixelPlacements).PaintedRowCount);
+
+        // First reverse-margin scroll shifts rows 2-3 down to rows 3-4: still
+        // fully inside the region (bottom row 4 == region bottom), so nothing
+        // is cropped yet.
+        await terminal.FeedAsync(scrollOnce, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.SixelPlacements is [{ } p] && p.Row == 3,
+            "first reverse-margin scroll shifts the placement flush to the region bottom",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(2, TestSeq.Single(terminal.Terminal.SixelPlacements).PaintedRowCount);
+
+        // Second reverse-margin scroll shifts rows 3-4 down to rows 4-5: row 5
+        // falls outside the region bottom (row 4) and is cropped away.
+        await terminal.FeedAsync(scrollOnce, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.SixelPlacements is [{ } p] && p.PaintedRowCount == 1,
+            "second reverse-margin scroll crops the bottom row",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(1, TestSeq.Single(terminal.Terminal.SixelPlacements).PaintedRowCount);
+
+        // Third reverse-margin scroll pushes the remaining row entirely past
+        // the region bottom, removing the placement.
+        await terminal.FeedAsync(scrollOnce, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.SixelPlacements.Count == 0,
+            "third reverse-margin scroll removes remainder",
+            TestContext.Current.CancellationToken);
+        Assert.IsEmpty(terminal.Terminal.SixelPlacements);
+    }
+
+    [TestMethod]
+    public async Task PartialVerticalMargins_FullyDepartingSingleRowPlacement_MovesIntoHistory()
+    {
+        // The physical terminal (5 rows) is taller than the DECSTBM region
+        // (rows 1-3, i.e. 0-based rows 0-2): unlike every other history test
+        // in this suite, the scroll region here does not span the whole
+        // screen. A scroll within that partial region still departs row 0
+        // into the terminal's own text scrollback, and a placement that
+        // fully occupies the departing row (this fixture is exactly one row
+        // tall, anchored at the region's top) must transfer into Sixel
+        // history the same way it would under a full-height region -- it
+        // must not be silently dropped just because the region is partial.
+        await using var terminal = SixelTestTerminal.Create(width: 8, height: 5, scrollbackCapacity: 3);
+        var prefix = Encoding.ASCII.GetBytes("\x1b[1;3r\x1b[1;1H");
+        var bytes = prefix.Concat(OneRowBar.StandardBytes)
+            .Concat(Encoding.ASCII.GetBytes("\x1b[3;1H\n"))
+            .ToArray();
+
+        await terminal.FeedAsync(bytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ScrollbackLineCount > 0,
+            "partial-margin scroll captures the departing row",
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(1, terminal.Terminal.ScrollbackCount);
+        Assert.AreEqual(1, terminal.Terminal.TrackedSixelCount);
+        Assert.IsEmpty(terminal.Terminal.SixelPlacements);
+    }
+
+    [TestMethod]
+    public async Task ScrollDown_AfterScrollUpIntoHistory_DoesNotResurrectTheDepartedRow()
+    {
+        await using var terminal = SixelTestTerminal.Create(width: 8, height: 3, scrollbackCapacity: 3);
+        var bytes = TwoRowBar.StandardBytes
+            .Concat(Encoding.ASCII.GetBytes("\x1b[3;1H\n"))
+            .ToArray();
+
+        await terminal.FeedAsync(bytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ScrollbackLineCount > 0,
+            "scroll into history",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(1, terminal.Terminal.ScrollbackCount);
+        Assert.AreEqual(1, TestSeq.Single(terminal.Terminal.SixelPlacements).PaintedRowCount);
+
+        await terminal.FeedAsync(Encoding.ASCII.GetBytes("\x1b[T"), cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "reverse scroll after history capture",
+            TestContext.Current.CancellationToken);
+
+        // The departed row lives only in history now; scrolling back down must
+        // not resurrect it into the live remainder (it must stay a single row).
+        Assert.AreEqual(1, terminal.Terminal.ScrollbackCount);
+        Assert.AreEqual(1, TestSeq.Single(terminal.Terminal.SixelPlacements).PaintedRowCount);
+    }
+
+    [TestMethod]
+    public async Task DecsdmEnabled_ExplicitLineFeed_StillMovesPlacementIntoHistory()
+    {
+        await using var terminal = SixelTestTerminal.Create(width: 8, height: 3, scrollbackCapacity: 3);
+        var bytes = Encoding.ASCII.GetBytes("\x1b[?80h")
+            .Concat(TwoRowBar.StandardBytes)
+            .Concat(Encoding.ASCII.GetBytes("\x1b[3;1H\n"))
+            .ToArray();
+
+        await terminal.FeedAsync(bytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ScrollbackLineCount > 0,
+            "DECSDM does not gate ordinary scrolling",
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(1, terminal.Terminal.ScrollbackCount);
+    }
+
+    [TestMethod]
+    public async Task CapacityOnePruning_OrdinaryScrollEntry_DropsHistoryPlacementOnNextEviction()
+    {
+        await using var terminal = SixelTestTerminal.Create(width: 8, height: 3, scrollbackCapacity: 1);
+        var bytes = OneRowBar.StandardBytes
+            .Concat(Encoding.ASCII.GetBytes("\x1b[3;1H\n"))
+            .ToArray();
+
+        await terminal.FeedAsync(bytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ScrollbackLineCount > 0,
+            "first scroll moves placement to the sole history slot",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(1, terminal.Terminal.TrackedSixelCount);
+        Assert.IsEmpty(terminal.Terminal.SixelPlacements);
+
+        await terminal.FeedAsync(Encoding.ASCII.GetBytes("\n"), cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.TrackedSixelCount == 0,
+            "second scroll evicts the capacity-one buffer and drops the image",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(0, terminal.Terminal.TrackedSixelCount);
+    }
+
+    [TestMethod]
+    public async Task CapacityTwoPruning_ReflowCreatedMultiRowEntry_TransfersRemainderAcrossEvictions()
+    {
+        await using var terminal = SixelTestTerminal.Create(
+            width: 4,
+            height: 3,
+            scrollbackCapacity: 2,
+            reflow: KittyReflowStrategy.Instance);
+
+        await terminal.FeedAsync(TwoRowBar.StandardBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "placement created at row 0",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(0, TestSeq.Single(terminal.Terminal.SixelPlacements).Row);
+
+        // Shrinking height alone is sufficient to trigger reflow. With no
+        // history yet and the placement anchored at row 0, its single reflow
+        // anchor maps to unified row 0 -- the oldest eventual history slot --
+        // so the whole two-row placement is attributed to one history entry.
+        terminal.Terminal.Resize(4, 1);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ScrollbackLineCount == 2,
+            "reflow moves the whole placement into one history entry",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(0, terminal.Terminal.SixelPlacementCount);
+        Assert.AreEqual(1, terminal.Terminal.TrackedSixelCount);
+
+        // First ordinary scroll evicts the oldest history slot: the reflow
+        // entry has RetainedRows > 1, so it transfers its remainder to the
+        // successor slot instead of being dropped.
+        await terminal.FeedAsync(Encoding.ASCII.GetBytes("\n"), cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.ScrollbackCount == 2,
+            "first scroll transfers the remainder to the successor slot",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(1, terminal.Terminal.TrackedSixelCount);
+
+        // Second ordinary scroll evicts the (now single-row) transferred
+        // entry outright; there is no remainder left to transfer.
+        await terminal.FeedAsync(Encoding.ASCII.GetBytes("\n"), cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.TrackedSixelCount == 0,
+            "second scroll drops the transferred remainder",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(0, terminal.Terminal.TrackedSixelCount);
+    }
+
+    [TestMethod]
+    public async Task ProgressiveCrop_EveryScrollStepShrinksPaintedExtentByOneRow()
+    {
+        await using var terminal = SixelTestTerminal.Create(width: 8, height: 5);
+        var prefix = Encoding.ASCII.GetBytes("\x1b[2;4r\x1b[2;1H");
+        var scrollOnce = Encoding.ASCII.GetBytes("\x1b[S");
+        var bytes = prefix.Concat(ThreeRowBar.StandardBytes).ToArray();
+
+        await terminal.FeedAsync(bytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "placement created wholly inside margins",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(3, TestSeq.Single(terminal.Terminal.SixelPlacements).PaintedRowCount);
+
+        for (var expected = 2; expected >= 1; expected--)
+        {
+            await terminal.FeedAsync(scrollOnce, cancellationToken: TestContext.Current.CancellationToken);
+            var target = expected;
+            await terminal.WaitForAsync(
+                _ => terminal.Terminal.SixelPlacements is [{ } p] && p.PaintedRowCount == target,
+                $"crop step to {expected} painted rows",
+                TestContext.Current.CancellationToken);
+        }
+
+        await terminal.FeedAsync(scrollOnce, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => !snapshot.ContainsSixelData(),
+            "final scroll removes the fully cropped placement",
+            TestContext.Current.CancellationToken);
+        Assert.IsEmpty(terminal.Terminal.SixelPlacements);
+    }
+
+    [TestMethod]
+    public async Task ResizeTallerThenShorter_ClipsGraphicWithoutDestroyingSourceState()
+    {
+        await using var terminal = SixelTestTerminal.Create(width: 8, height: 6);
+        await terminal.FeedAsync(ThreeRowBar.StandardBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "placement created",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(3, TestSeq.Single(terminal.Terminal.SixelPlacements).HeightInCells);
+
+        terminal.Terminal.Resize(8, 8);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "resize taller keeps the declared footprint",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(3, TestSeq.Single(terminal.Terminal.SixelPlacements).HeightInCells);
+        Assert.AreEqual(3, TestSeq.Single(terminal.Terminal.SixelPlacements).PaintedRowCount);
+
+        // Resize/clip-without-reflow never mutates the placement's own painted
+        // window (only scroll-margin cropping and history/snapshot slicing do
+        // that) - only viewport observation narrows, and only for rows the new,
+        // shorter viewport can no longer show. The declared footprint and the
+        // placement's own PaintedRowCount both stay at 3.
+        terminal.Terminal.Resize(8, 2);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "resize shorter clips the viewport without destroying source state",
+            TestContext.Current.CancellationToken);
+        var clipped = TestSeq.Single(terminal.Terminal.SixelPlacements);
+        Assert.AreEqual(3, clipped.HeightInCells, "declared footprint is never mutated by resize/clip");
+        Assert.AreEqual(3, clipped.PaintedRowCount, "the placement's own painted window is never mutated by a viewport-only resize");
+
+        var observedShort = terminal.Observe(includeScrollback: false);
+        Assert.IsTrue(observedShort.OccupiedCells.All(cell => cell.Row < 2), "the shorter viewport can only observe rows within its own bounds");
+
+        terminal.Terminal.Resize(8, 8);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "resize back taller reveals the previously off-screen rows",
+            TestContext.Current.CancellationToken);
+        var observedRestored = terminal.Observe(includeScrollback: false);
+        Assert.IsTrue(observedRestored.OccupiedCells.Any(cell => cell.Row == 2), "resizing back taller must reveal rows never actually destroyed by the shorter viewport");
+    }
+
+    [TestMethod]
+    public async Task ResizeWider_RevealsColumnsPreviouslyClippedByANarrowerViewport()
+    {
+        // Paint fully unclipped at the initial wide terminal (all three columns
+        // painted) so that the later narrowing is a viewport-only clip - not
+        // the separate, permanent paint-time clip against the active width
+        // that ResolveSixelPlacement applies (which a later resize can never
+        // retroactively undo, unlike a plain viewport resize).
+        await using var terminal = SixelTestTerminal.Create(width: 6, height: 3);
+        await terminal.FeedAsync(OneRowThreeCol.StandardBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "placement created unclipped at the wide terminal",
+            TestContext.Current.CancellationToken);
+        var full = TestSeq.Single(terminal.Terminal.SixelPlacements);
+        Assert.AreEqual(3, full.WidthInCells);
+        Assert.AreEqual(3, full.PaintedColumnCount, "nothing to clip at paint time when the viewport is already wide enough");
+
+        terminal.Terminal.Resize(2, 3);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "resize narrower clips the observed viewport without destroying source state",
+            TestContext.Current.CancellationToken);
+        var narrowed = TestSeq.Single(terminal.Terminal.SixelPlacements);
+        Assert.AreEqual(3, narrowed.WidthInCells, "declared footprint is never mutated by a viewport-only resize");
+        Assert.AreEqual(3, narrowed.PaintedColumnCount, "the placement's own painted window is never mutated by a viewport-only resize");
+        var observedNarrow = terminal.Observe(includeScrollback: false);
+        Assert.IsTrue(observedNarrow.OccupiedCells.All(cell => cell.Column < 2), "the narrower viewport can only observe columns within its own bounds");
+
+        terminal.Terminal.Resize(6, 3);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "resize wider reveals the previously clipped columns",
+            TestContext.Current.CancellationToken);
+
+        // The placement's own painted window was never mutated by the narrower
+        // viewport (only the observed viewport was narrower) - it's the
+        // Observe() projection, bounded by the *current* viewport, that
+        // reveals the full three columns without any reflow.
+        var wide = TestSeq.Single(terminal.Terminal.SixelPlacements);
+        Assert.AreEqual(3, wide.WidthInCells, "declared footprint is unaffected by viewport resize");
+        var observedWide = terminal.Observe(includeScrollback: false);
+        Assert.IsTrue(observedWide.OccupiedCells.Any(cell => cell.Column == 2), "resizing wider must reveal columns never actually destroyed by the narrower viewport");
+    }
+
+    [TestMethod]
+    public async Task FractionalPixelWidth_CeilsToAWholeOccupiedCellIncludingItsPartialRemainder()
+    {
+        await using var terminal = SixelTestTerminal.Create(width: 8, height: 3);
+        var fractional = new SixelFixture(
+            "fractional-width",
+            "Five-pixel-wide raster over one-pixel-wide cells.",
+            Encoding.ASCII.GetBytes("q\"1;1;5;6#1;2;100;0;0!5@"));
+
+        await terminal.FeedAsync(fractional.StandardBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "fractional-width placement created",
+            TestContext.Current.CancellationToken);
+
+        var observation = TestSeq.Single(terminal.Observe().Placements);
+        Assert.AreEqual(5, observation.PixelWidth);
+        Assert.AreEqual(5, observation.WidthInCells, "1px-wide cells: no partial-remainder rounding needed here");
+    }
+
+    [TestMethod]
+    public async Task ProtocolMetricChange_WithoutResize_LeavesExistingPlacementUnaffected()
+    {
+        await using var terminal = SixelTestTerminal.Create(width: 8, height: 8);
+        await terminal.FeedAsync(TwoRowBar.StandardBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "placement created under the original cell metrics",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(2, TestSeq.Single(terminal.Terminal.SixelPlacements).HeightInCells);
+
+        terminal.Terminal.SetSixelCellMetrics(new SixelCellMetrics(
+            1,
+            3,
+            SixelCellMetricsSource.Direct,
+            SixelCellMetricsReliability.Authoritative));
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[4;1H").Concat(TwoRowBar.StandardBytes).ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.SixelPlacements.Count == 2,
+            "second placement created under the changed cell metrics",
+            TestContext.Current.CancellationToken);
+
+        var placements = terminal.Terminal.SixelPlacements;
+        Assert.AreEqual(2, placements[0].HeightInCells, "the metric change does not retroactively affect an existing placement");
+        Assert.AreEqual(4, placements[1].HeightInCells, "the same 12px payload now spans four 3px-tall cells");
+    }
+
+    [TestMethod]
+    public async Task AlternateScreenScrolling_NeverCreatesOrAffectsMainScreenHistory()
+    {
+        await using var terminal = SixelTestTerminal.Create(width: 8, height: 3, scrollbackCapacity: 4);
+        var mainBytes = TwoRowBar.StandardBytes
+            .Concat(Encoding.ASCII.GetBytes("\x1b[3;1H\n"))
+            .ToArray();
+        await terminal.FeedAsync(mainBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ScrollbackLineCount > 0,
+            "main-screen history captured",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(1, terminal.Terminal.ScrollbackCount);
+
+        var altBytes = Encoding.ASCII.GetBytes("\x1b[?1049h")
+            .Concat(Encoding.ASCII.GetBytes("\n\n\n\n"))
+            .Concat(Encoding.ASCII.GetBytes("\x1b[?1049l"))
+            .ToArray();
+        await terminal.FeedAsync(altBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "alternate screen scrolling settles back on the main screen",
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(1, terminal.Terminal.ScrollbackCount, "alternate-screen scrolling must never touch main history");
+    }
+
+    [TestMethod]
+    public async Task ScrollbackWidthProjection_OriginalPreservesContentClippedUnderCurrentWidth()
+    {
+        await using var terminal = SixelTestTerminal.Create(width: 8, height: 3, scrollbackCapacity: 2);
+        var bytes = Encoding.ASCII.GetBytes("\x1b[1;5H")
+            .Concat(OneRowThreeCol.StandardBytes)
+            .Concat(Encoding.ASCII.GetBytes("\x1b[3;1H\n"))
+            .ToArray();
+
+        await terminal.FeedAsync(bytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ScrollbackLineCount > 0,
+            "placement captured into history at the original width",
+            TestContext.Current.CancellationToken);
+
+        terminal.Terminal.Resize(6, 3);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "narrower terminal",
+            TestContext.Current.CancellationToken);
+
+        var current = terminal.Observe(includeScrollback: true, scrollbackWidth: ScrollbackWidth.CurrentTerminal);
+        var original = terminal.Observe(includeScrollback: true, scrollbackWidth: ScrollbackWidth.Original);
+
+        var currentOccupied = current.OccupiedCells.Count(c => c.Row == 0);
+        var originalOccupied = original.OccupiedCells.Count(c => c.Row == 0);
+        Assert.IsGreaterThan(currentOccupied, originalOccupied, "the original-width projection preserves columns clipped away under the current width");
+    }
+
+    [TestMethod]
+    public async Task DamageAppliedBeforeScroll_PersistsAcrossScrollAndSnapshot()
+    {
+        // Painting a 1-row-tall placement at row 0 (0-based) leaves no overflow
+        // against the bottom margin (row0 + height1 <= clipBottom2), so it does
+        // NOT trigger ResolveSixelPlacement's proactive pre-scroll-for-cursor-room
+        // mechanism - unlike painting at the screen's last row, which would move
+        // the placement one row higher than expected before we ever damage it.
+        await using var terminal = SixelTestTerminal.Create(width: 8, height: 3, scrollbackCapacity: 3);
+        var bytes = Encoding.ASCII.GetBytes("\x1b[1;1H")
+            .Concat(TwoColBar.StandardBytes)
+            .Concat(Encoding.ASCII.GetBytes("\x1b[1;1HX"))
+            .ToArray();
+
+        await terminal.FeedAsync(bytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.SixelPlacements is [{ } p] && p.CoversCell(p.PaintedTop, 0) == false,
+            "damage applied to the placement's origin cell",
+            TestContext.Current.CancellationToken);
+
+        // Now scroll the damaged placement (still at row 0) into history: the
+        // cursor is on the bottom row, so a plain LF scrolls the whole screen
+        // up by one, pushing row 0 - the placement's row - into scrollback.
+        var scroll = Encoding.ASCII.GetBytes("\x1b[3;1H\n");
+        await terminal.FeedAsync(scroll, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ScrollbackLineCount > 0,
+            "damaged placement scrolled into history",
+            TestContext.Current.CancellationToken);
+
+        var snapshot = terminal.Terminal.CreateSnapshot(scrollbackLines: 1);
+        var historyPlacement = TestSeq.Single(snapshot.SixelPlacements);
+        var row = historyPlacement.PaintedTop;
+
+        Assert.IsFalse(historyPlacement.CoversCell(row, 0), "the overwritten origin cell must remain damaged after the scroll+snapshot round trip");
+        Assert.IsTrue(historyPlacement.CoversCell(row, 1), "the sibling cell was never overwritten and must remain covered");
+    }
+
+    [TestMethod]
+    public async Task FinalHistoryReferenceRelease_ReleasesTrackedImageOnceAllReferencesAreGone()
+    {
+        await using var terminal = SixelTestTerminal.Create(width: 8, height: 1, scrollbackCapacity: 1);
+        await terminal.FeedAsync(OneRowBar.StandardBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "placement created",
+            TestContext.Current.CancellationToken);
+
+        var snapshotWhileLive = terminal.Terminal.CreateSnapshot();
+        Assert.IsTrue(snapshotWhileLive.ContainsSixelData());
+
+        await terminal.FeedAsync(Encoding.ASCII.GetBytes("\n"), cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.TrackedSixelCount == 1,
+            "the single-row placement moves entirely into the sole history slot",
+            TestContext.Current.CancellationToken);
+
+        await terminal.FeedAsync(Encoding.ASCII.GetBytes("\n"), cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.TrackedSixelCount == 0,
+            "the next eviction drops the last live reference",
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(0, terminal.Terminal.TrackedSixelCount);
+        Assert.IsTrue(snapshotWhileLive.ContainsSixelData(), "a previously captured snapshot keeps its own independent reference");
+    }
+}

--- a/tests/Hex1b.Tests/Sixel/SixelScrollingTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelScrollingTests.cs
@@ -10,7 +10,7 @@ public class SixelScrollingTests
         "scrolling",
         "A two-band image used to inspect viewport and history behavior.");
 
-    [TestMethod, Ignore("Owned by #452: a placement that spans the scrollback boundary is not yet split into independent screen/history projections (full-fidelity scrolling/reflow).")]
+    [TestMethod]
     public async Task FullScreenScroll_PreservesGraphicAcrossVisibleAndHistoryRows()
     {
         await using var terminal = SixelTestTerminal.Create(
@@ -64,7 +64,7 @@ public class SixelScrollingTests
         Assert.IsTrue(restored.OccupiedCells.Any(cell => cell.Column == 3));
     }
 
-    [TestMethod, Ignore("Owned by #452: Sixel placements do not yet participate in row-lineage reflow.")]
+    [TestMethod]
     public async Task Reflow_WiderThenNarrower_PreservesGraphicAnchor()
     {
         await using var terminal = SixelTestTerminal.Create(

--- a/tests/Hex1b.Tests/Sixel/SixelTestTerminal.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelTestTerminal.cs
@@ -170,10 +170,13 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
         throw new TimeoutException($"Timed out waiting for Sixel test terminal state: {expectation}.");
     }
 
-    public SixelTerminalObservation Observe(bool includeScrollback = true)
+    public SixelTerminalObservation Observe(
+        bool includeScrollback = true,
+        ScrollbackWidth scrollbackWidth = ScrollbackWidth.CurrentTerminal)
     {
         using var snapshot = Terminal.CreateSnapshot(
-            scrollbackLines: includeScrollback ? Terminal.ScrollbackCount : 0);
+            scrollbackLines: includeScrollback ? Terminal.ScrollbackCount : 0,
+            scrollbackWidth: scrollbackWidth);
         var placements = new List<SixelPlacementObservation>();
         var occupiedRows = new HashSet<SixelOccupiedRow>();
         var occupiedCells = new HashSet<SixelOccupiedCell>();
@@ -396,7 +399,8 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
         TerminalCapabilities capabilities,
         ITerminalReflowProvider? reflow) :
         IHex1bTerminalPresentationAdapter,
-        ITerminalReflowProvider
+        ITerminalReflowProvider,
+        IInternalTerminalReflowProvider
     {
         private readonly List<byte> _bytes = [];
         private TaskCompletionSource _changed =
@@ -485,6 +489,18 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
         public (int Row, int Column) GetCursorPosition() => (0, 0);
         public ReflowResult Reflow(ReflowContext context) =>
             (reflow ?? throw new InvalidOperationException("Reflow is not enabled.")).Reflow(context);
+
+        bool IInternalTerminalReflowProvider.TryReflowWithAnchors(
+            ReflowContext context,
+            IReadOnlyList<TerminalReflowAnchor> anchors,
+            out InternalReflowResult result)
+        {
+            if (reflow is null)
+                throw new InvalidOperationException("Reflow is not enabled.");
+
+            return InternalTerminalReflow.TryReflow(reflow, context, anchors, out result);
+        }
+
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 


### PR DESCRIPTION
## Summary

Stage 8 of the terminal-first Sixel roadmap. Integrates independent Sixel graphic placements (introduced in #451, damage semantics in #453) with terminal scrolling, main-screen scrollback history, viewport clipping, resize, and reflow — while leaving KGP's own scrolling/history/reflow code paths completely untouched.

Closes #452
Relates to #445

## What changed

### Scrolling (LF/IND/RI/SU/SD)
- `SixelGraphicsState.AdjustActivePlacementsForScroll` handles full and partial vertical margins (DECSTBM), horizontal margins under DECLRMM, and DECSDM, independently of KGP.
- Placements are progressively cropped as they cross scroll boundaries; once a placement has fully scrolled out of a region it is removed rather than resurrected by a later reverse scroll (SD).
- Oversized and cross-margin placements are clipped against the active scroll region on every scroll step.

### Main-screen history
- New `SixelHistoryPlacement` gives history rows stable row identities, so placements resolve to exact original-geometry source crops from either the live viewport or history.
- `SixelGraphicsState.MoveMainPlacementsIntoHistory(rowId, region)` is now region-aware: each placement is gated on `IsWhollyContained(...)` before transferring into history, mirroring the containment check `AdjustActivePlacementsForScroll` already used.
- `PruneMainHistoryRow` releases resources once a row leaves capacity; `CaptureActiveSnapshot` supports both `ScrollbackWidth.CurrentTerminal` and `ScrollbackWidth.Original` projections. Alternate-screen state stays fully isolated from main-screen history.

### Resize and reflow
- `ClipActivePlacementsToViewport` deterministically clips placements to a new viewport without restoring pixels discarded by prior destructive damage (#453).
- `PrepareActiveReflow`/`ApplyActiveReflow` move whole placements atomically when a row-anchor is representable after reflow, falling back to projection-only splitting otherwise; a placement that can't be represented under a reflow strategy is explicitly and safely dropped rather than corrupted.
- `SixelCellMetrics` established at creation time is preserved independently of terminal-dimension changes — only the placement's occupied footprint changes on resize.

## A real bug found and fixed along the way

`Hex1bTerminal.ScrollUp()` previously gated *both* KGP's and Sixel's `MoveMainPlacementsIntoHistory` behind `createsKgpHistory`, which requires the scroll region to span the **full physical screen height** — an intentional KGP-only restriction. Under a partial DECSTBM region smaller than the physical terminal, the terminal's own text scrollback still captures departing rows, but Sixel placements were silently deleted instead of transferring into history.

Fix: Sixel now uses its own `createsSixelHistory` condition (mirrors the terminal's scrollback-capture guard, without the full-height requirement) and calls the region-aware `MoveMainPlacementsIntoHistory` overload. KGP's gate and method are completely unchanged. A permanent regression test (`PartialVerticalMargins_FullyDepartingSingleRowPlacement_MovesIntoHistory`) covers this exact scenario.

This was invisible to the originally-"complete" test suite because no existing test combined an explicit DECSTBM region smaller than the physical terminal with `scrollbackCapacity > 0` — exactly the combination that triggers it.

## API review

No new public API surface. Every new/changed member (`SixelHistoryPlacement`, `MoveMainPlacementsIntoHistory` overload, `IsWhollyContained`, `createsSixelHistory`, etc.) is `internal`, matching KGP's non-exposure of image/placement IDs, delete semantics, and z-index. KGP scrolling/history/reflow code paths are untouched. Verified via diff against merge-base — zero `public`/`protected` additions in any changed file.

## Tests

- `tests/Hex1b.Tests/Sixel/SixelScrollHistoryReflowTests.cs` (new, 22 tests): full scroll into history, history/viewport split, capacity-one/two pruning, crop after every scroll, partial vertical/horizontal margins (including the fixed bug as a permanent regression test), scroll down (SD), all resize directions, reflow anchors and source geometry, fractional/aspect crops, metric-change independence, alternate-screen isolation, LF/IND/RI/SU/SD, DECSDM, current- and original-width snapshots, #453 damage persistence across all movement, and final-reference release.
- De-ignored two previously-deferred #452 contract tests in `SixelScrollingTests.cs` (`FullScreenScroll_PreservesGraphicAcrossVisibleAndHistoryRows`, `Reflow_WiderThenNarrower_PreservesGraphicAnchor`) now that full-fidelity scrolling/reflow splitting is implemented.
- Broad filter (`Kgp|Sixel|Scroll|Reflow|Snapshot`): **2072 tests, 0 failed, 1 skipped**.
- Full repo suite: **8973 tests, 0 failed, 24 skipped**.
- Existing KGP scrolling/reflow/snapshot/lifecycle tests remain green (unchanged, unaffected).

## Demo

`samples/SixelTerminalDemo/RawScrollHistoryReflowScenes.cs` adds raw DCS fixtures (never `SixelWidget`/`SixelEncoder`) covering scrolling, history, crop, pruning, margins, resize, reflow, alternate-screen isolation, and damage persistence. Verified headlessly at the 80x24 baseline (`--scene "Scrolling"`, `"Damage"`, `"Resize"`, and full unfiltered pass) — all correct, exit code 0, no exceptions.

## Docs

`docs/sixel-terminal-behavior.md`:
- New **"Independent Sixel scrolling, history, and reflow (#452)"** section.
- Updated ownership/erasure and screens/scrollback/resize tables (marked implemented, not deferred).
- Documents the partial-margin history bug and its fix as an architectural note.
- Expanded evidence section explaining both the automated test suite and the headless demo model as authoritative evidence for geometry (declared vs. painted, viewport-observed rows/columns, history-only origin-cell coverage) that an interactive terminal cannot show live — satisfying the "interactive-native differences explicit" requirement.
- Removed the now-resolved "explicitly unresolved" full-fidelity scrolling/reflow item.

## Explicit deferrals (unchanged, per issue scope)

- #455 (capability probing)
- #458 (translation)
- Widget-level sizing integration
- #456 (full replay serialization)

## Benchmarks

No changes under `src/Hex1b/Surfaces/` — `surface-benchmarker` skill correctly not invoked.

## Roadmap impact

Stage 8 of the Sixel roadmap is now complete. Prior stages through #453 (PR #466, merge commit `a965dc103a9e024e4a04c931ba62ca8d379432ba`) remain merged and untouched by this change.

## Post-review addition

While assessing regression risk to non-Sixel scroll behavior, identified and closed a coverage gap: added `PartialVerticalMargin_FromTop_CapturesScrollbackAndLeavesRowsBelowUntouched` in `Hex1bTerminalScrollbackTests.cs` — a plain-text (zero Sixel state) regression test isolating scrollback capture and row-shift correctness for a DECSTBM region that starts at row 0 but ends above the physical bottom row. This directly evidences that the `ScrollUp` changes supporting the new Sixel-only `createsSixelHistory` gate left plain scrollback capture/row-shift for a top-anchored partial margin unchanged. Full repo suite re-verified: 8974 total, 0 failed, 24 skipped (one confirmed unrelated flake in `Tree_BorderRendering_Investigation` re-ran clean). CI green at head `33424bec`.
