### PR TITLE
Add Sixel snapshots, exports, recording, and replay (#456)

### DIFF
--- a/docs/sixel-terminal-behavior.md
+++ b/docs/sixel-terminal-behavior.md
@@ -3,6 +3,7 @@
 > **Status**: Evolving contract for [#445](https://github.com/mitchdenny/hex1b/issues/445)
 > **First executable stage**: [#448](https://github.com/mitchdenny/hex1b/issues/448)
 > **Independent graphics state**: [#451](https://github.com/mitchdenny/hex1b/issues/451)
+> **Snapshots, exports, recording, and replay**: [#456](https://github.com/mitchdenny/hex1b/issues/456)
 > **Baseline**: DEC VT340
 
 ## Purpose
@@ -441,6 +442,160 @@ untouched; every behavior below is implemented purely in `SixelGraphicsState`,
   KGP-only concepts with no Sixel equivalent. All existing KGP scrolling,
   history, reflow, and snapshot tests continue to pass unmodified.
 
+## Immutable snapshots, export, recording, and replay (#456)
+
+[#456](https://github.com/mitchdenny/hex1b/issues/456) makes Sixel graphics
+first-class in `Hex1bTerminalSnapshot`, SVG/HTML export, and HMP1 state
+synchronization/recording/replay, analogous in capability to KGP's existing
+snapshot/export/replay support but exposing no KGP-only protocol concept (no
+image IDs, no delete selectors, no z-index — see "Independent graphics state
+(#451)" above for the full extracted/kept-KGP-only split, which this stage
+does not revisit). No parser, rasterizer, cursor, graphics-state, damage,
+history, or reflow behavior from #448-#453 changes; this stage only adds
+read paths over that authoritative state.
+
+- **Snapshot model.** `Hex1bTerminalSnapshot.SixelPlacements` (an
+  `IReadOnlyList<SixelPlacement>`) and `SixelImages` (an
+  `IReadOnlyDictionary<byte[], SixelData>` keyed by content hash) are now
+  public, mirroring the shape of the existing `KgpPlacements`/KGP image
+  surfaces. `SixelPlacement` and the `SixelData` properties it exposes
+  (`Image`, `Row`, `Column`, `WidthInCells`/`HeightInCells`,
+  `PaintedRowOffset`/`PaintedRowCount`/`PaintedColumnOffset`/`PaintedColumnCount`
+  and their derived `PaintedTop`/`PaintedBottom`/`PaintedLeft`/`PaintedRight`,
+  `Sequence`, `CreatedAt`, `IsGeometryOnly`, `HasPaintedExtent`,
+  `HasVisiblePaintedCells`, `CoversCell`, `IsCellDamaged`, `GetVisiblePixels`,
+  and the new `GetPaintedPixels`) were promoted from `internal` to `public`
+  for this stage; everything else on both types remains internal. `SixelData`
+  itself gained public `ContentHash`, `Outcome`, `Diagnostics`,
+  `BackgroundMode`, `RasterStatus`, `RasterDiagnostics`, `Extents`, and
+  `CellMetrics` so a consumer can inspect a placement's authoritative parser
+  outcome and geometry without reaching into internals. Whether a placement
+  is a viewport or history placement is derived, not stored: a placement's
+  `Row` is unified with the text scrollback buffer's own numbering (a `Row`
+  at or above `ScrollbackLineCount` is history, below it is viewport),
+  exactly the coordinate space `CaptureActiveSnapshot` already established
+  for #452. `CreateSnapshot(scrollbackLines:)` therefore continues to select
+  viewport-only (`0`), history-inclusive (`>0`), and
+  `ScrollbackWidth.CurrentTerminal`/`ScrollbackWidth.Original` projections
+  with no Sixel-specific parameter — the same call already used for text and
+  KGP.
+- **Retention and disposal.** `SixelData` has no reference-counting
+  mechanism of its own (unlike `TrackedHyperlink`, which the snapshot does
+  release in `Dispose()`) — it is a plain garbage-collected object, and its
+  raster is retained once per referenced image, never per covered cell,
+  exactly as the live `SixelImageStore` already guarantees (see "Independent
+  graphics state (#451)" above). A snapshot's placements reference the same
+  `SixelData` instance as the live placements they were captured from, and
+  two independently captured snapshots that both reference the same content
+  hash share that same instance; disposing one snapshot has no effect on
+  another snapshot's (or the live terminal's) access to that instance, and
+  `Hex1bTerminalSnapshot.Dispose()` is idempotent, so it can never
+  double-release Sixel state because there is nothing Sixel-specific to
+  release. `tests/Hex1b.Tests/Sixel/SixelSnapshotSharingTests.cs` is the
+  dedicated regression suite for this contract.
+- **Automation API.** `ContainsSixelData()` and the other existing
+  compatibility surfaces remain, now backed entirely by the placement/image
+  model above rather than any separate bookkeeping — there is exactly one
+  authoritative source for "does this cell show Sixel graphics." Deterministic
+  assertions over image/placement counts, dimensions, RGBA pixels
+  (`GetVisiblePixels`/`GetPaintedPixels`), anchor/occupied cells, source crop,
+  history-vs-viewport (via unified `Row`), parser outcome/geometry-only
+  downgrade (`IsGeometryOnly`, `Image.Outcome`, `Image.Diagnostics`,
+  `Image.RasterStatus`, `Image.RasterDiagnostics`), and cursor/graphics-state
+  correspondence are all available directly from the public surface above; no
+  new bespoke assertion type was introduced.
+- **SVG/HTML export.** `TerminalRegionSvgExtensions`/
+  `TerminalRegionHtmlExtensions` render Sixel using
+  `SixelPlacement.GetPaintedPixels()` — the exact snapshot pixels within the
+  placement's current painted/visible crop rectangle (never the full
+  declared image, so scrolling, margin clipping, and history eviction that
+  cropped the placement are reflected exactly), mapped through the image's
+  own `SixelCellMetrics` so cell geometry matches the snapshot precisely. A
+  geometry-only placement (the rasterizer could not produce pixels) renders
+  an explicit dashed-outline placeholder with a `<title>` diagnostic built
+  from `Image.Outcome`/`Image.RasterDiagnostics`/`Image.Diagnostics` —
+  `#456` forbids silently omitting it — occupying the same painted cell
+  rectangle a rasterized placement would, so overall export geometry never
+  depends on whether an image happened to rasterize. HTML export's
+  interaction payload reports the same `geometryOnly`/`outcome` metadata per
+  cell. Both exporters reuse the snapshot's already-decoded `SixelData`
+  directly; neither reparses, redecodes, or rehashes the payload. Repeated
+  export of the same snapshot is byte-identical
+  (`SvgExport_RepeatedExportOfSameSnapshot_IsByteIdentical`,
+  `HtmlExport_RepeatedExportOfSameSnapshot_IsByteIdentical`). KGP's own
+  export output, layering, and z-order behavior are unmodified by this
+  stage — the two placement kinds are painted through the same z-ordered
+  loop they already shared, keyed by each placement's own `Sequence`.
+- **Recording, state sync, and replay.** Two independent mechanisms exist,
+  matching the pre-existing KGP split:
+  - `Hmp1SixelStateReplay` (internal) extends the live HMP1 state-sync path
+    exactly as `Hmp1KgpStateReplay` already does for KGP: it writes plain
+    cursor-position + Sixel DCS escape sequences that a freshly joining
+    peer's own terminal parses through the ordinary live path, so replay
+    reconstructs state through the same authoritative parser/rasterizer used
+    for live processing rather than a separate code path. Because Sixel
+    placements (unlike KGP's) own the character cells they occupy, replay
+    also emits a trailing "damage patch" that restores exactly the damaged
+    cells' original content after placement recreation would otherwise
+    re-blank them. Rasterized placements are replayed via a fresh,
+    self-contained re-encode of their already-decoded pixels
+    (`SixelExactEncoder`, not `Hex1b.Surfaces.SixelEncoder`, which is
+    lossy/quantizing and reserved for widget authoring) rather than the
+    placement's original payload, because that payload may depend on
+    persistent color-register state the joining peer's terminal never saw;
+    a geometry-only placement has no decoded pixels and is safe to replay
+    verbatim, since its outcome is a deterministic function of the payload's
+    own declared extents. Only the viewport is replayed here, matching
+    `Hex1bTerminal.CreateSnapshot()`'s existing zero-scrollback state-sync
+    scope.
+  - `Hmp1SixelRecording` (internal) is a new, versioned binary format for
+    the explicit record/serialize/replay/compare scenarios the plain-bytes
+    wire replay above cannot express (truncation, unsupported version,
+    missing references, invalid geometry, resource limits). It serializes
+    an `IReadOnlyList<SixelPlacement>` — the same type the live snapshot and
+    live wire replay use — into a `SXRC`-tagged, versioned
+    (`Hmp1SixelRecording.CurrentVersion = 1`) stream: an image table
+    deduplicated by `SixelData.ContentHash` (content-addressed, so a raster
+    shared by multiple placements is never repeated in the stream), followed
+    by placements referencing that table by index, each carrying its
+    geometry, painted crop, sequence, creation time, and anchor-relative
+    damaged-cell offsets. Rasterized images are re-encoded byte-exact via
+    `SixelExactEncoder`; geometry-only images retain their original payload
+    verbatim, for the same reason `Hmp1SixelStateReplay` does. Deserializing
+    validates every field explicitly and throws
+    `Hmp1SixelRecordingException` (never returns a success-shaped partial
+    result, never a broad catch) tagged with a specific
+    `Hmp1SixelRecordingFailureReason`: `Malformed` (bad magic marker,
+    negative counts, unrecognized raster status), `UnsupportedVersion`,
+    `Truncated` (stream ends before declared data), `MissingImageReference`
+    (a placement's image index is out of range), `InvalidGeometry`
+    (non-positive cell dimensions or negative painted extents), or
+    `ResourceLimitExceeded` (`MaxPlacementCount`/`MaxImageCount` = 4096,
+    `MaxPayloadLength` = 64 MiB, `MaxDamagedCellCount` = 2^20). Recorded
+    placements/images (`Hmp1SixelRecordedPlacement`/`Hmp1SixelRecordedImage`)
+    are plain immutable data carriers, not `SixelPlacement`/`SixelData`
+    themselves, keeping the recording format decoupled from the live
+    graphics-state types' internal invariants.
+- **Coverage.** In addition to the export/sharing/recording suites named
+  above: `tests/Hex1b.Tests/Hmp1/Hmp1SixelRecordingTests.cs` round-trips
+  single and multi-placement recordings (including image-table
+  deduplication, anchor-relative damage offsets, geometry-only payload
+  preservation, main/alternate-screen isolation, and distinct
+  history-vs-viewport unified row offsets across a scroll), replays a
+  recording's escape-sequence reconstruction into a fresh terminal and
+  compares resulting pixels, and exercises every `Hmp1SixelRecordingException`
+  failure mode named above. `tests/Hex1b.Tests/Hmp1/Hmp1SixelStateReplayTests.cs`
+  covers the existing live wire replay path, including the damage-patch
+  restoration. All pre-existing KGP snapshot/export/replay and terminal
+  automation tests continue to pass unmodified, confirming this stage adds
+  a parallel Sixel path without touching KGP's.
+- **Explicitly out of scope for this stage** (see the exclusions in
+  [#456](https://github.com/mitchdenny/hex1b/issues/456)): capability probing
+  ([#455](https://github.com/mitchdenny/hex1b/issues/455)), native
+  presentation protocol translation
+  ([#458](https://github.com/mitchdenny/hex1b/issues/458)), and any
+  `SixelWidget`/`Surface`-side preview generation.
+
 ## Screens, scrollback, resize, and reflow
 
 | Area | Selected Hex1b contract | Status or unresolved work |
@@ -493,10 +648,19 @@ alternate-screen isolation, current/original-width scrollback projection,
 #453 damage persistence across scroll/history/snapshot, and final-reference
 release) — including the partial-vertical-margin history transfer fixed by
 this stage.
+`tests/Hex1b.Tests/Sixel/SixelSnapshotSharingTests.cs`,
+`tests/Hex1b.Tests/Sixel/SixelSvgExportTests.cs`, and
+`tests/Hex1b.Tests/Sixel/SixelHtmlExportTests.cs`, together with
+`tests/Hex1b.Tests/Hmp1/Hmp1SixelRecordingTests.cs` and
+`tests/Hex1b.Tests/Hmp1/Hmp1SixelStateReplayTests.cs`, are #456's dedicated
+regression suites for the snapshot/export/recording/replay contract described
+above.
 
 ```bash
 dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj \
   --filter "FullyQualifiedName~Hex1b.Tests.Sixel."
+dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj \
+  --filter "FullyQualifiedName~Hex1b.Tests.Hmp1.Hmp1Sixel"
 ```
 
 The terminal-first demo sends independently authored raw Sixel bytes through
@@ -523,6 +687,22 @@ above is authoritative for history/crop/reflow geometry that has already
 scrolled out of view or been reflowed, and the differences between what an
 interactive terminal can show live versus what the headless evidence reports
 are called out explicitly in each scene's description.
+`samples/SixelTerminalDemo/RawSnapshotExportReplayScenes.cs` adds #456's
+snapshot/export/recording/replay scenes, again using the same raw-DCS
+convention with no `SixelWidget`/`SixelEncoder` involvement. Its headless
+inspector (`InspectSnapshotExportReplaySceneAsync` in `Program.cs`) goes
+beyond replaying the script: it also creates multiple snapshots to prove
+raster sharing and safe double-disposal, compares the four projection modes
+against each other, exports SVG/HTML to confirm the geometry-only diagnostic
+placeholder and byte-identical repeated export, and drives
+`Hmp1SixelRecording.Serialize`/`Deserialize`/`BuildReplayEscapeSequence` to
+record a snapshot, replay it into a brand-new terminal with no live upstream
+connection, and compare the resulting pixels and painted (damage) extent —
+including across a main/alternate screen transition — plus feeds
+deliberately corrupted recordings (wrong magic marker, truncation, a bumped
+version number) through `Deserialize` to show each fails with its own
+explicit `Hmp1SixelRecordingFailureReason`, never a silent or success-shaped
+fallback.
 
 The demo presents one subject per screen. Each screen clears the display, resets
 margins, origin mode, and DECSDM so it cannot inherit state from the screen

--- a/samples/SixelTerminalDemo/DemoScreens.cs
+++ b/samples/SixelTerminalDemo/DemoScreens.cs
@@ -13,7 +13,8 @@ internal static class DemoScreens
     /// Builds every screen: the grammar and geometry fixtures first, then the
     /// cursor, DECSDM, and margin scenes, then the graphics-state ownership
     /// scenes (#451), then the scrolling/history/resize scenes (#452), then
-    /// the transport scenes.
+    /// the snapshot/export/recording/replay scenes (#456), then the
+    /// transport scenes.
     /// </summary>
     public static IReadOnlyList<DemoScreen> Build(
         IReadOnlyList<RawSixelFixture> fixtures,
@@ -23,6 +24,8 @@ internal static class DemoScreens
         IReadOnlyList<string> graphicsStateObservations,
         IReadOnlyList<RawScrollHistoryReflowScene> scrollHistoryReflowScenes,
         IReadOnlyList<string> scrollHistoryReflowObservations,
+        IReadOnlyList<RawSnapshotExportReplayScene> snapshotExportReplayScenes,
+        IReadOnlyList<string> snapshotExportReplayObservations,
         bool includeTransportScenes)
     {
         var screens = new List<DemoScreen>();
@@ -79,6 +82,17 @@ internal static class DemoScreens
                 scene.Expected,
                 scene.Bytes,
                 Notes: [scrollHistoryReflowObservations[index]]));
+        }
+
+        for (var index = 0; index < snapshotExportReplayScenes.Count; index++)
+        {
+            var scene = snapshotExportReplayScenes[index];
+            screens.Add(new DemoScreen(
+                number++,
+                scene.Name,
+                scene.Expected,
+                scene.Bytes,
+                Notes: [snapshotExportReplayObservations[index]]));
         }
 
         if (!includeTransportScenes)

--- a/samples/SixelTerminalDemo/Program.cs
+++ b/samples/SixelTerminalDemo/Program.cs
@@ -1,5 +1,7 @@
+using System.Security.Cryptography;
 using System.Text;
 using Hex1b;
+using Hex1b.Automation;
 
 var headless = args.Contains("--headless", StringComparer.OrdinalIgnoreCase);
 var sceneFilter = GetOption(args, "--scene");
@@ -29,7 +31,13 @@ var scrollHistoryReflowScenes = sceneFilter is null
     : RawScrollHistoryReflowScenes.All
         .Where(scene => scene.Name.Contains(sceneFilter, StringComparison.OrdinalIgnoreCase))
         .ToArray();
-if (fixtures.Count == 0 && cursorScenes.Count == 0 && graphicsStateScenes.Count == 0 && scrollHistoryReflowScenes.Count == 0)
+var snapshotExportReplayScenes = sceneFilter is null
+    ? RawSnapshotExportReplayScenes.All
+    : RawSnapshotExportReplayScenes.All
+        .Where(scene => scene.Name.Contains(sceneFilter, StringComparison.OrdinalIgnoreCase))
+        .ToArray();
+if (fixtures.Count == 0 && cursorScenes.Count == 0 && graphicsStateScenes.Count == 0
+    && scrollHistoryReflowScenes.Count == 0 && snapshotExportReplayScenes.Count == 0)
 {
     throw new ArgumentException($"No Sixel demo scene contains '{sceneFilter}'.", nameof(args));
 }
@@ -66,6 +74,12 @@ for (var index = 0; index < scrollHistoryReflowScenes.Count; index++)
     scrollHistoryReflowObservations[index] = await InspectScrollHistoryReflowSceneAsync(scrollHistoryReflowScenes[index]);
 }
 
+var snapshotExportReplayObservations = new string[snapshotExportReplayScenes.Count];
+for (var index = 0; index < snapshotExportReplayScenes.Count; index++)
+{
+    snapshotExportReplayObservations[index] = await InspectSnapshotExportReplaySceneAsync(snapshotExportReplayScenes[index]);
+}
+
 var allScreens = DemoScreens.Build(
     fixtures,
     modelDescriptions,
@@ -74,6 +88,8 @@ var allScreens = DemoScreens.Build(
     graphicsStateObservations,
     scrollHistoryReflowScenes,
     scrollHistoryReflowObservations,
+    snapshotExportReplayScenes,
+    snapshotExportReplayObservations,
     includeTransportScenes: sceneFilter is null);
 
 // --screen selects one numbered screen. The number keeps its original value so a
@@ -107,7 +123,9 @@ if (headless)
         graphicsStateScenes,
         graphicsStateObservations,
         scrollHistoryReflowScenes,
-        scrollHistoryReflowObservations);
+        scrollHistoryReflowObservations,
+        snapshotExportReplayScenes,
+        snapshotExportReplayObservations);
     return;
 }
 
@@ -135,7 +153,9 @@ static void WriteHeadlessTranscript(
     IReadOnlyList<RawGraphicsStateScene> graphicsStateScenes,
     IReadOnlyList<string> graphicsStateObservations,
     IReadOnlyList<RawScrollHistoryReflowScene> scrollHistoryReflowScenes,
-    IReadOnlyList<string> scrollHistoryReflowObservations)
+    IReadOnlyList<string> scrollHistoryReflowObservations,
+    IReadOnlyList<RawSnapshotExportReplayScene> snapshotExportReplayScenes,
+    IReadOnlyList<string> snapshotExportReplayObservations)
 {
     Console.WriteLine($"Hex1b Sixel demo: {allScreens.Count} numbered screens.");
     Console.WriteLine("Run without --headless to page through them; --screen <number> opens one.");
@@ -174,6 +194,13 @@ static void WriteHeadlessTranscript(
     for (var index = 0; index < scrollHistoryReflowScenes.Count; index++)
     {
         Console.WriteLine($"  {scrollHistoryReflowScenes[index].Name}: {scrollHistoryReflowObservations[index]}");
+    }
+
+    Console.WriteLine();
+    Console.WriteLine("Snapshot, export, and recording/replay observations (#456):");
+    for (var index = 0; index < snapshotExportReplayScenes.Count; index++)
+    {
+        Console.WriteLine($"  {snapshotExportReplayScenes[index].Name}: {snapshotExportReplayObservations[index]}");
     }
 }
 
@@ -496,3 +523,273 @@ static string DescribeModel(SixelData sixel)
         return seen.Count;
     }
 }
+
+// #456: snapshot model, SVG/HTML export, and HMP1 recording/replay evidence.
+// Each RawSnapshotExportReplayScene.Kind needs materially different
+// follow-up work beyond just replaying the script, so this dispatches to one
+// focused inspector per kind rather than one function trying to do all of it.
+static async Task<string> InspectSnapshotExportReplaySceneAsync(RawSnapshotExportReplayScene scene) =>
+    scene.Kind switch
+    {
+        SnapshotExportReplayScenarioKind.SnapshotSharing => await InspectSnapshotSharingAsync(scene),
+        SnapshotExportReplayScenarioKind.Projections => await InspectProjectionsAsync(scene),
+        SnapshotExportReplayScenarioKind.GeometryOnlyExport => await InspectGeometryOnlyExportAsync(scene),
+        SnapshotExportReplayScenarioKind.DeterministicExport => await InspectDeterministicExportAsync(scene),
+        SnapshotExportReplayScenarioKind.RecordReplayWithDamage => await InspectRecordReplayWithDamageAsync(scene),
+        SnapshotExportReplayScenarioKind.MainAlternateIndependence => await InspectMainAlternateIndependenceAsync(scene),
+        SnapshotExportReplayScenarioKind.MalformedFailures => await InspectMalformedFailuresAsync(scene),
+        _ => throw new ArgumentOutOfRangeException(nameof(scene)),
+    };
+
+static Hex1bTerminalBuilder CreateSnapshotExportReplayTerminalBuilder(byte[] script, int scrollbackCapacity)
+{
+    var capabilities = new TerminalCapabilities
+    {
+        SupportsSixel = true,
+        SupportsTrueColor = true,
+        Supports256Colors = true,
+        CellPixelWidth = 10,
+        CellPixelHeight = 20,
+    };
+    var builder = Hex1bTerminal.CreateBuilder()
+        .WithWorkload(new DemoWorkloadAdapter([script]))
+        .WithPresentation(new HeadlessPresentationAdapter(80, 24, capabilities))
+        .WithDimensions(80, 24);
+    return scrollbackCapacity > 0 ? builder.WithScrollback(scrollbackCapacity) : builder;
+}
+
+static async Task<string> InspectSnapshotSharingAsync(RawSnapshotExportReplayScene scene)
+{
+    await using var terminal = CreateSnapshotExportReplayTerminalBuilder(scene.Bytes, scene.ScrollbackCapacity).Build();
+    await terminal.RunAsync();
+
+    // Not `using`, since the double-Dispose() below is the point of this
+    // scene: it must be safe and must not affect snapshotB's independent
+    // lifetime, matching SixelSnapshotSharingTests' disposal contract.
+    var snapshotA = terminal.CreateSnapshot();
+    using var snapshotB = terminal.CreateSnapshot();
+
+    var placementsA = snapshotA.SixelPlacements;
+    var placementsB = snapshotB.SixelPlacements;
+    var sharedWithinSnapshot = placementsA.Count >= 2 && ReferenceEquals(placementsA[0].Image, placementsA[1].Image);
+    var sharedAcrossSnapshots = placementsA.Count > 0 && placementsB.Count > 0
+        && ReferenceEquals(placementsA[0].Image, placementsB[0].Image);
+
+    snapshotA.Dispose();
+    snapshotA.Dispose();
+
+    var builder = new StringBuilder();
+    builder.Append($"{placementsA.Count} placement(s); both anchors reference the same image instance: {sharedWithinSnapshot}");
+    builder.Append($"; a second independent snapshot observes that identical shared instance: {sharedAcrossSnapshots}");
+    builder.Append($"; snapshot B still resolves pixels after snapshot A was disposed twice: {snapshotB.ContainsSixelData()}");
+    return builder.ToString();
+}
+
+static async Task<string> InspectProjectionsAsync(RawSnapshotExportReplayScene scene)
+{
+    await using var terminal = CreateSnapshotExportReplayTerminalBuilder(scene.Bytes, scene.ScrollbackCapacity).Build();
+    await terminal.RunAsync();
+
+    using var viewportOnly = terminal.CreateSnapshot(scrollbackLines: 0);
+    using var historyInclusive = terminal.CreateSnapshot(scrollbackLines: terminal.ScrollbackCount);
+    using var currentWidth = terminal.CreateSnapshot(scrollbackLines: terminal.ScrollbackCount, scrollbackWidth: ScrollbackWidth.CurrentTerminal);
+    using var originalWidth = terminal.CreateSnapshot(scrollbackLines: terminal.ScrollbackCount, scrollbackWidth: ScrollbackWidth.Original);
+
+    var builder = new StringBuilder();
+    builder.Append($"viewport-only: {viewportOnly.SixelPlacements.Count} placement(s), scrollbackLineCount={viewportOnly.ScrollbackLineCount}");
+    builder.Append($"; history-inclusive: {historyInclusive.SixelPlacements.Count} placement(s), scrollbackLineCount={historyInclusive.ScrollbackLineCount}");
+    builder.Append($"; current-width projection: {currentWidth.SixelPlacements.Count} placement(s)");
+    builder.Append($"; original-width projection: {originalWidth.SixelPlacements.Count} placement(s)");
+    return builder.ToString();
+}
+
+static async Task<string> InspectGeometryOnlyExportAsync(RawSnapshotExportReplayScene scene)
+{
+    await using var terminal = CreateSnapshotExportReplayTerminalBuilder(scene.Bytes, scene.ScrollbackCapacity).Build();
+    await terminal.RunAsync();
+
+    using var snapshot = terminal.CreateSnapshot();
+    var placement = snapshot.SixelPlacements.Count > 0 ? snapshot.SixelPlacements[0] : null;
+    var svg = snapshot.ToSvg();
+    var html = snapshot.ToHtml();
+
+    var builder = new StringBuilder();
+    builder.Append($"placement geometry-only: {placement?.IsGeometryOnly ?? false}");
+    builder.Append($"; SVG diagnostic placeholder present ('sixel-geometry-only'): {svg.Contains("sixel-geometry-only", StringComparison.Ordinal)}");
+    builder.Append($"; HTML geometry-only metadata present ('\"geometryOnly\":true'): {html.Contains("\"geometryOnly\":true", StringComparison.Ordinal)}");
+    return builder.ToString();
+}
+
+static async Task<string> InspectDeterministicExportAsync(RawSnapshotExportReplayScene scene)
+{
+    await using var terminal = CreateSnapshotExportReplayTerminalBuilder(scene.Bytes, scene.ScrollbackCapacity).Build();
+    await terminal.RunAsync();
+
+    using var snapshot = terminal.CreateSnapshot();
+    var svgFirst = snapshot.ToSvg();
+    var svgSecond = snapshot.ToSvg();
+    var htmlFirst = snapshot.ToHtml();
+    var htmlSecond = snapshot.ToHtml();
+
+    var builder = new StringBuilder();
+    builder.Append($"SVG export byte-identical across repeats: {string.Equals(svgFirst, svgSecond, StringComparison.Ordinal)}");
+    builder.Append($"; HTML export byte-identical across repeats: {string.Equals(htmlFirst, htmlSecond, StringComparison.Ordinal)}");
+    builder.Append($"; SVG SHA-256 (first 16 hex chars): {Sha256Hex(svgFirst)}");
+    return builder.ToString();
+}
+
+static async Task<string> InspectRecordReplayWithDamageAsync(RawSnapshotExportReplayScene scene)
+{
+    await using var terminal = CreateSnapshotExportReplayTerminalBuilder(scene.Bytes, scene.ScrollbackCapacity).Build();
+    await terminal.RunAsync();
+
+    using var snapshot = terminal.CreateSnapshot(scrollbackLines: terminal.ScrollbackCount);
+    var recorded = Hmp1SixelRecording.Serialize(snapshot.SixelPlacements);
+    var deserialized = Hmp1SixelRecording.Deserialize(recorded);
+    var replayScript = deserialized.BuildReplayEscapeSequence();
+
+    await using var viewer = CreateSnapshotExportReplayTerminalBuilder(
+        Encoding.ASCII.GetBytes(replayScript), scene.ScrollbackCapacity).Build();
+    await viewer.RunAsync();
+
+    using var replayed = viewer.CreateSnapshot(scrollbackLines: viewer.ScrollbackCount);
+
+    var builder = new StringBuilder();
+    builder.Append($"original: {snapshot.SixelPlacements.Count} placement(s), {recorded.Length} recorded byte(s)");
+    builder.Append($"; replayed: {replayed.SixelPlacements.Count} placement(s)");
+
+    var pixelsMatch = snapshot.SixelPlacements.Count == replayed.SixelPlacements.Count;
+    var damageMatches = pixelsMatch;
+    for (var index = 0; pixelsMatch && index < snapshot.SixelPlacements.Count; index++)
+    {
+        var original = snapshot.SixelPlacements[index];
+        var replayedPlacement = replayed.SixelPlacements[index];
+        if (!PixelsEqual(original.Image.GetPixels(), replayedPlacement.Image.GetPixels()))
+        {
+            pixelsMatch = false;
+        }
+
+        if (original.PaintedRowCount != replayedPlacement.PaintedRowCount
+            || original.PaintedColumnCount != replayedPlacement.PaintedColumnCount)
+        {
+            damageMatches = false;
+        }
+    }
+
+    builder.Append($"; surviving pixels match after record/replay: {pixelsMatch}");
+    builder.Append($"; painted (post-damage) extent matches after record/replay: {damageMatches}");
+    return builder.ToString();
+}
+
+static async Task<string> InspectMainAlternateIndependenceAsync(RawSnapshotExportReplayScene scene)
+{
+    if (scene.Checkpoints is not { Count: > 0 } checkpoints)
+    {
+        throw new InvalidOperationException($"'{scene.Name}' requires at least one checkpoint.");
+    }
+
+    var labels = new[] { "main only", "alternate active", "back to main" };
+    var builder = new StringBuilder();
+    for (var index = 0; index < checkpoints.Count; index++)
+    {
+        var script = Encoding.ASCII.GetBytes(checkpoints[index]);
+        await using var terminal = CreateSnapshotExportReplayTerminalBuilder(script, 0).Build();
+        await terminal.RunAsync();
+
+        using var snapshot = terminal.CreateSnapshot();
+        var recorded = Hmp1SixelRecording.Serialize(snapshot.SixelPlacements);
+        var deserialized = Hmp1SixelRecording.Deserialize(recorded);
+        var replayScript = deserialized.BuildReplayEscapeSequence();
+
+        await using var viewer = CreateSnapshotExportReplayTerminalBuilder(
+            Encoding.ASCII.GetBytes(replayScript), 0).Build();
+        await viewer.RunAsync();
+        using var replayed = viewer.CreateSnapshot();
+
+        var pixelsMatch = snapshot.SixelPlacements.Count == replayed.SixelPlacements.Count
+            && snapshot.SixelPlacements.Count > 0
+            && PixelsEqual(snapshot.SixelPlacements[0].Image.GetPixels(), replayed.SixelPlacements[0].Image.GetPixels());
+
+        if (index > 0)
+        {
+            builder.Append("; ");
+        }
+
+        var label = index < labels.Length ? labels[index] : $"checkpoint {index}";
+        builder.Append(
+            $"{label}: in alternate screen={snapshot.InAlternateScreen}, {snapshot.SixelPlacements.Count} placement(s) recorded, replay pixel match={pixelsMatch}");
+    }
+
+    return builder.ToString();
+}
+
+static async Task<string> InspectMalformedFailuresAsync(RawSnapshotExportReplayScene scene)
+{
+    await using var terminal = CreateSnapshotExportReplayTerminalBuilder(scene.Bytes, scene.ScrollbackCapacity).Build();
+    await terminal.RunAsync();
+
+    using var snapshot = terminal.CreateSnapshot();
+    var baseline = Hmp1SixelRecording.Serialize(snapshot.SixelPlacements);
+
+    var wrongMagic = new byte[16];
+    Encoding.ASCII.GetBytes("XXXX").CopyTo(wrongMagic, 0);
+
+    var truncated = baseline[..^8];
+
+    using var versionStream = new MemoryStream();
+    using (var writer = new BinaryWriter(versionStream, Encoding.UTF8, leaveOpen: true))
+    {
+        writer.Write("SXRC"u8.ToArray());
+        writer.Write(Hmp1SixelRecording.CurrentVersion + 1);
+        writer.Write(0); // placementCount
+        writer.Write(0); // imageCount
+    }
+
+    var builder = new StringBuilder();
+    builder.Append($"baseline recording: {baseline.Length} byte(s)");
+    builder.Append($"; wrong magic marker -> {DescribeRecordingFailure(wrongMagic)}");
+    builder.Append($"; truncated mid-record -> {DescribeRecordingFailure(truncated)}");
+    builder.Append($"; unsupported version -> {DescribeRecordingFailure(versionStream.ToArray())}");
+    return builder.ToString();
+}
+
+static string DescribeRecordingFailure(byte[] data)
+{
+    try
+    {
+        Hmp1SixelRecording.Deserialize(data);
+        return "unexpectedly succeeded";
+    }
+    catch (Hmp1SixelRecordingException ex)
+    {
+        return ex.Reason.ToString();
+    }
+}
+
+static bool PixelsEqual(Hex1b.Surfaces.SixelPixelBuffer? a, Hex1b.Surfaces.SixelPixelBuffer? b)
+{
+    if (a is null || b is null)
+    {
+        return a is null && b is null;
+    }
+
+    if (a.Width != b.Width || a.Height != b.Height)
+    {
+        return false;
+    }
+
+    for (var y = 0; y < a.Height; y++)
+    {
+        for (var x = 0; x < a.Width; x++)
+        {
+            if (!a[x, y].Equals(b[x, y]))
+            {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+static string Sha256Hex(string text) => Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(text)))[..16];

--- a/samples/SixelTerminalDemo/RawSnapshotExportReplayScenes.cs
+++ b/samples/SixelTerminalDemo/RawSnapshotExportReplayScenes.cs
@@ -1,0 +1,165 @@
+using System.Text;
+
+/// <summary>
+/// Which additional headless evidence a <see cref="RawSnapshotExportReplayScene"/>
+/// wants gathered, since issue #456's snapshot/export/recording/replay
+/// requirements each need materially different follow-up work beyond just
+/// replaying the script (see <c>Program.cs</c>'s
+/// <c>InspectSnapshotExportReplaySceneAsync</c>).
+/// </summary>
+internal enum SnapshotExportReplayScenarioKind
+{
+    /// <summary>Multiple snapshots safely sharing one raster, with independent, idempotent disposal.</summary>
+    SnapshotSharing,
+
+    /// <summary>Viewport-only vs history-inclusive vs current-width vs original-width projections.</summary>
+    Projections,
+
+    /// <summary>SVG/HTML export of a geometry-only placement produces an explicit diagnostic placeholder.</summary>
+    GeometryOnlyExport,
+
+    /// <summary>Repeated SVG/HTML export of the same snapshot is deterministic.</summary>
+    DeterministicExport,
+
+    /// <summary>Record/serialize/replay reconstructs damaged, scrolled-into-history state.</summary>
+    RecordReplayWithDamage,
+
+    /// <summary>Recording captures only the active screen, independently across main/alternate transitions.</summary>
+    MainAlternateIndependence,
+
+    /// <summary>Deserializing malformed/truncated/mismatched-version data fails explicitly.</summary>
+    MalformedFailures,
+}
+
+/// <summary>
+/// A hand-authored scene that exercises issue #456's snapshot, SVG/HTML
+/// export, and HMP1 recording/replay contract: every byte is written by
+/// hand, using raw CUP/DCS/alternate-screen control sequences with no
+/// <c>SixelWidget</c> or <c>SixelEncoder</c> involved, so the scene stays an
+/// independent contract probe of the snapshot/export/recording model,
+/// mirroring <c>SixelSnapshotSharingTests.cs</c>, <c>SixelSvgExportTests.cs</c>,
+/// <c>SixelHtmlExportTests.cs</c>, and <c>Hmp1SixelRecordingTests.cs</c>.
+/// </summary>
+/// <param name="Name">The scene name, also used by <c>--scene</c>.</param>
+/// <param name="Expected">What the terminal model should retain after the script runs.</param>
+/// <param name="Script">The complete raw byte script for the scene.</param>
+/// <param name="Kind">Which additional headless evidence this scene wants gathered.</param>
+/// <param name="ScrollbackCapacity">Rows of main-screen scrollback the demo terminal is built with.</param>
+/// <param name="Checkpoints">
+/// Ordered, cumulative script prefixes to snapshot independently, each a
+/// complete valid script starting from the beginning. Used only by
+/// <see cref="SnapshotExportReplayScenarioKind.MainAlternateIndependence"/>,
+/// which needs to inspect state at several points across a screen
+/// transition; every other scenario inspects only the full <see cref="Script"/>.
+/// </param>
+internal sealed record RawSnapshotExportReplayScene(
+    string Name,
+    string Expected,
+    string Script,
+    SnapshotExportReplayScenarioKind Kind,
+    int ScrollbackCapacity = 0,
+    IReadOnlyList<string>? Checkpoints = null)
+{
+    public byte[] Bytes => Encoding.ASCII.GetBytes(Script);
+}
+
+/// <summary>
+/// Scenes demonstrating issue #456's snapshot model, SVG/HTML export, and
+/// HMP1 recording/replay: raster sharing and disposal safety, the four
+/// projection modes, the geometry-only export placeholder, deterministic
+/// repeated export, damage/history surviving a record-serialize-replay round
+/// trip, main/alternate screen independence under recording, and the
+/// recording format's explicit (never success-shaped) failure modes. See
+/// <c>docs/sixel-terminal-behavior.md</c>'s "#456" section for the full
+/// contract this scene set mirrors.
+/// </summary>
+internal static class RawSnapshotExportReplayScenes
+{
+    // One raster band is 6 pixels tall by protocol. At this demo's 10x20px
+    // cell metrics (see Program.cs's TerminalCapabilities), a band count is
+    // chosen so the declared pixel height lands just past a cell boundary,
+    // matching the convention established by RawScrollHistoryReflowScenes:
+    // 4 bands = 24px -> ceil(24/20) = 2 rows; 1 band = 6px -> 1 row.
+    private static string SolidBand(int pixelWidth, int bandCount, int register, string colorDefinition) =>
+        $"7;1q\"1;1;{pixelWidth};{bandCount * 6}#{register};{colorDefinition}#{register}{string.Join("-", Enumerable.Repeat("!" + pixelWidth + "~", bandCount))}";
+
+    // 1 cell wide, 1 row tall. Small and cheap to duplicate at two anchors so
+    // a scene can demonstrate two placements sharing one raster.
+    private static string RedOneColOneRow => SolidBand(10, 1, 1, "2;100;0;0");
+
+    // 1 cell wide, 2 rows tall. Used for the projection scene, so scrolling
+    // one row into history leaves exactly one row still in the viewport.
+    private static string RedOneColTwoRow => SolidBand(10, 4, 1, "2;100;0;0");
+
+    // 2 cells wide, 1 row tall, so a damage probe can overwrite one column
+    // and leave the other intact.
+    private static string BlueTwoColOneRow => SolidBand(20, 1, 1, "1;240;50;100");
+
+    // Declares an absurd canvas that exceeds the raster allocation policy, so
+    // geometry is recorded but no pixels are ever allocated (reused verbatim
+    // from RawGraphicsStateScenes' GeometryOnly probe).
+    private const string GeometryOnly =
+        "7;1q\"1;1;999999999;999999999#1;2;100;0;0#1!240~";
+
+    // A solid square declared at 40x40px, aspect 1:1, matching
+    // RawGraphicsStateScenes' RedSquare40/GreenSquare40 exactly so this
+    // scene set's exported pixels are directly comparable to that one's.
+    private static string RedSquare40 =>
+        "7;1q\"1;1;40;40#1;2;100;0;0#1!40~-!40~-!40~-!40~-!40~-!40~-!40~";
+
+    private static string GreenSquare40 =>
+        "7;1q\"1;1;40;40#2;2;0;100;0#2!40~-!40~-!40~-!40~-!40~-!40~-!40~";
+
+    private static string Dcs(string payload) => $"\x1bP{payload}\x1b\\";
+    private static string Cup(int row, int column) => $"\x1b[{row};{column}H";
+    private static string Margins(int top, int bottom) => $"\x1b[{top};{bottom}r";
+    private const string EnterAlternateScreen = "\x1b[?1049h";
+    private const string ExitAlternateScreen = "\x1b[?1049l";
+
+    public static IReadOnlyList<RawSnapshotExportReplayScene> All { get; } =
+    [
+        new(
+            "Snapshot: two placements sharing one raster resolve to the same image instance",
+            "the same red band painted at two anchors. Both placements reference\n  the identical decoded raster - the image is retained once per referenced\n  raster, never once per covered cell, and multiple snapshots of this state\n  observe the very same shared instance",
+            Cup(1, 1) + Dcs(RedOneColOneRow) + Cup(3, 1) + Dcs(RedOneColOneRow),
+            SnapshotExportReplayScenarioKind.SnapshotSharing),
+        new(
+            "Snapshot: viewport-only, history-inclusive, and width projections all agree on content",
+            "a one-row-tall remainder of a two-row-tall red band, its top row\n  scrolled into main-screen history. A viewport-only snapshot omits the\n  scrolled row entirely; a history-inclusive snapshot restores it; current-\n  width and original-width projections describe the identical placement\n  geometry either way, since this scene never changes width",
+            Margins(1, 3) + Cup(1, 1) + Dcs(RedOneColTwoRow) + Cup(3, 1) + "\n",
+            SnapshotExportReplayScenarioKind.Projections,
+            ScrollbackCapacity: 3),
+        new(
+            "Export: a geometry-only placement gets an explicit diagnostic placeholder, never silent omission",
+            "nothing visible: the declared canvas exceeds the raster allocation\n  policy, so no pixels are ever allocated. Both the SVG and HTML exports\n  still describe this placement explicitly - a dashed diagnostic placeholder\n  in the SVG, and geometry-only metadata in the HTML - rather than silently\n  dropping it",
+            Cup(2, 2) + Dcs(GeometryOnly),
+            SnapshotExportReplayScenarioKind.GeometryOnlyExport),
+        new(
+            "Export: repeated SVG/HTML export of the same snapshot is byte-identical",
+            "a solid red #FF0000 square. Exporting the very same snapshot to SVG\n  and to HTML twice each produces byte-identical output both times: export\n  reads only the authoritative snapshot state, never re-decoding or\n  re-hashing the payload independently per call",
+            Cup(2, 2) + Dcs(RedSquare40),
+            SnapshotExportReplayScenarioKind.DeterministicExport),
+        new(
+            "Recording: record/serialize/replay reconstructs damaged, history-bound state without a live terminal",
+            "nothing on the main screen: the entire one-row-tall blue band scrolled\n  fully into history, with its left column destructively overwritten by X\n  before the scroll. Serializing that snapshot, deserializing it, and\n  replaying the reconstructed escape sequence into a brand-new terminal\n  reproduces the identical surviving right-column pixels and damage, through\n  the very same parser/raster path a live terminal would use",
+            Margins(1, 3) + Cup(1, 1) + Dcs(BlueTwoColOneRow) + Cup(1, 1) + "X" + Cup(3, 1) + "\n",
+            SnapshotExportReplayScenarioKind.RecordReplayWithDamage,
+            ScrollbackCapacity: 3),
+        new(
+            "Recording: main and alternate screens record and replay independently across transitions",
+            "a red square on the main screen. A recording taken while the\n  alternate screen is active (showing a different green square) reconstructs\n  only the alternate screen's own graphic; switching back to the main screen\n  and recording again reconstructs the original red square, completely\n  unaffected by whatever happened on the alternate screen in between",
+            Cup(1, 1) + Dcs(RedSquare40) + EnterAlternateScreen + Cup(1, 1) + Dcs(GreenSquare40) + ExitAlternateScreen,
+            SnapshotExportReplayScenarioKind.MainAlternateIndependence,
+            Checkpoints:
+            [
+                Cup(1, 1) + Dcs(RedSquare40),
+                Cup(1, 1) + Dcs(RedSquare40) + EnterAlternateScreen + Cup(1, 1) + Dcs(GreenSquare40),
+                Cup(1, 1) + Dcs(RedSquare40) + EnterAlternateScreen + Cup(1, 1) + Dcs(GreenSquare40) + ExitAlternateScreen,
+            ]),
+        new(
+            "Recording: malformed, truncated, and version-mismatched data fail explicitly, never silently",
+            "a solid red #FF0000 square, recorded successfully once as a baseline.\n  Corrupting the recording's magic marker, truncating it mid-record, and\n  bumping its version number each produce a distinct, explicitly named\n  failure reason - never a broad catch or a success-shaped empty result",
+            Cup(2, 2) + Dcs(RedSquare40),
+            SnapshotExportReplayScenarioKind.MalformedFailures),
+    ];
+}

--- a/samples/WebMuxerDemo/wwwroot/js/app.js
+++ b/samples/WebMuxerDemo/wwwroot/js/app.js
@@ -204,7 +204,7 @@ function ensureTerminal() {
     pixelLimit: 4 * 1024 * 1024,
     storageLimit: 64,
     showPlaceholder: true,
-    sixelSupport: false,
+    sixelSupport: true,
     iipSupport: false,
     kittySupport: true,
     kittySizeLimit: 8 * 1024 * 1024,

--- a/src/Hex1b/Automation/Hex1bTerminalSnapshot.cs
+++ b/src/Hex1b/Automation/Hex1bTerminalSnapshot.cs
@@ -242,17 +242,33 @@ public sealed class Hex1bTerminalSnapshot : IHex1bTerminalRegion, IDisposable
 
     /// <summary>
     /// Sixel placements visible in this snapshot, including any requested
-    /// scrollback rows. Internal test/inspection surface for stage #451; kept
-    /// internal rather than public until an external consumer need is
-    /// demonstrated (see the api-reviewer skill guidance).
+    /// scrollback rows.
     /// </summary>
-    internal IReadOnlyList<SixelPlacement> SixelPlacements { get; }
+    /// <remarks>
+    /// Analogous to <see cref="KgpPlacements"/> but sized and shaped for the
+    /// Sixel protocol: there is no image ID (Sixel has no protocol concept
+    /// of one), so placements reference their <see cref="SixelPlacement.Image"/>
+    /// directly and <see cref="SixelImages"/> is keyed by content hash instead.
+    /// Each placement captures its own creation-time
+    /// <see cref="Sixel.SixelCellMetrics"/>, painted/declared extents, and
+    /// per-cell damage independently of any other placement, and remains
+    /// valid for the lifetime of this snapshot even after the live terminal
+    /// erases, prunes, or resets the placement that produced it.
+    /// </remarks>
+    public IReadOnlyList<SixelPlacement> SixelPlacements { get; }
 
     /// <summary>
     /// Sixel image data referenced by the visible snapshot placements, keyed
     /// by content hash.
     /// </summary>
-    internal IReadOnlyDictionary<byte[], SixelData> SixelImages { get; }
+    /// <remarks>
+    /// An image's decoded raster (or geometry-only outcome) is retained once
+    /// per referenced image, never once per covered cell: two placements —
+    /// in this snapshot or across independently captured snapshots — that
+    /// reference the same content hash share the same <see cref="SixelData"/>
+    /// instance and its underlying raster.
+    /// </remarks>
+    public IReadOnlyDictionary<byte[], SixelData> SixelImages { get; }
 
     /// <inheritdoc />
     public TerminalCell GetCell(int x, int y)

--- a/src/Hex1b/Automation/TerminalRegionHtmlExtensions.cs
+++ b/src/Hex1b/Automation/TerminalRegionHtmlExtensions.cs
@@ -587,8 +587,10 @@ public static class TerminalRegionHtmlExtensions
         sb.AppendLine("          <div class=\"tooltip-label\">Sixel Graphics</div>");
         sb.AppendLine("          <div class=\"tooltip-value\">");
         sb.AppendLine("            ${cell.sixel.origin ? '<span class=\"attr-badge\" style=\"background:#4e9a06\">Origin</span>' : '<span class=\"attr-badge\">Continuation</span>'}");
+        sb.AppendLine("            ${cell.sixel.geometryOnly ? '<span class=\"attr-badge\" style=\"background:#a06e4e\">Geometry-only</span>' : ''}");
         sb.AppendLine("            ${cell.sixel.w}×${cell.sixel.h} cells");
-        sb.AppendLine("          </div>");
+        sb.AppendLine("            <br><span style=\"color:#888;font-size:11px\">Outcome: ${cell.sixel.outcome}</span>");
+        sb.AppendLine("        </div>");
         sb.AppendLine("        </div>` : ''}");
         sb.AppendLine("        ${hasLink ? `");
         sb.AppendLine("        <div class=\"tooltip-section\">");
@@ -878,7 +880,14 @@ public static class TerminalRegionHtmlExtensions
                 for (var py = placement.PaintedTop; py <= placement.PaintedBottom; py++)
                 {
                     for (var px = placement.PaintedLeft; px <= placement.PaintedRight; px++)
-                        sixelByCell[(px, py)] = placement; // later sequence overwrites earlier: topmost wins.
+                    {
+                        // CoversCell excludes cells a later text write has
+                        // damaged, so damaged cells correctly stop reporting
+                        // Sixel metadata even while still inside the painted
+                        // rectangle. CoversCell takes (row, column) — py, px.
+                        if (placement.CoversCell(py, px))
+                            sixelByCell[(px, py)] = placement; // later sequence overwrites earlier: topmost wins.
+                    }
                 }
             }
         }
@@ -920,7 +929,9 @@ public static class TerminalRegionHtmlExtensions
                 if (sixelByCell.TryGetValue((x, y), out var sixelPlacement))
                 {
                     var isOrigin = x == sixelPlacement.PaintedLeft && y == sixelPlacement.PaintedTop;
-                    sixel = $"{{\"origin\":{(isOrigin ? "true" : "false")},\"w\":{sixelPlacement.WidthInCells},\"h\":{sixelPlacement.HeightInCells}}}";
+                    var geometryOnly = sixelPlacement.IsGeometryOnly ? "true" : "false";
+                    var outcome = EscapeJsonString(sixelPlacement.Image.RasterStatus.ToString());
+                    sixel = $"{{\"origin\":{(isOrigin ? "true" : "false")},\"w\":{sixelPlacement.WidthInCells},\"h\":{sixelPlacement.HeightInCells},\"geometryOnly\":{geometryOnly},\"outcome\":\"{outcome}\"}}";
                 }
                 else
                 {

--- a/src/Hex1b/Automation/TerminalRegionSvgExtensions.cs
+++ b/src/Hex1b/Automation/TerminalRegionSvgExtensions.cs
@@ -387,11 +387,17 @@ public static class TerminalRegionSvgExtensions
             foreach (var placement in snapshot3.SixelPlacements.OrderBy(p => p.Sequence))
             {
                 if (!placement.HasPaintedExtent)
-                    continue; // Geometry-only placements paint nothing.
+                    continue; // Nothing occupies visible area (e.g. scrolled fully off-screen).
 
-                var visiblePixels = placement.GetVisiblePixels();
-                if (visiblePixels is not { Width: > 0, Height: > 0 })
+                if (placement.IsGeometryOnly)
+                {
+                    AppendSixelGeometryOnlyPlaceholder(sb, placement, cellWidth, cellHeight);
                     continue;
+                }
+
+                var visiblePixels = placement.GetPaintedPixels();
+                if (visiblePixels is not { Width: > 0, Height: > 0 })
+                    continue; // Fully damaged: nothing left to paint.
 
                 var rgba = new byte[visiblePixels.Width * visiblePixels.Height * 4];
                 var offset = 0;
@@ -658,6 +664,54 @@ public static class TerminalRegionSvgExtensions
         sb.AppendLine("</svg>");
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Renders an explicit, deterministic diagnostic placeholder for a
+    /// geometry-only Sixel placement: the authoritative rasterizer could not
+    /// produce pixels for it, but the issue's contract forbids silently
+    /// omitting the placement from the export. The placeholder occupies the
+    /// same painted cell rectangle a rasterized placement would, so overall
+    /// export geometry never depends on whether an image rasterized.
+    /// </summary>
+    private static void AppendSixelGeometryOnlyPlaceholder(
+        StringBuilder sb, SixelPlacement placement, int cellWidth, int cellHeight)
+    {
+        var imgX = placement.PaintedLeft * cellWidth;
+        var imgY = placement.PaintedTop * cellHeight;
+        var imgWidth = placement.PaintedColumnCount * cellWidth;
+        var imgHeight = placement.PaintedRowCount * cellHeight;
+        var diagnosticText = DescribeSixelGeometryOnlyOutcome(placement);
+
+        sb.AppendLine($"""    <g class="sixel-geometry-only" data-sixel-outcome="{placement.Image.RasterStatus}">""");
+        sb.AppendLine($"""      <title>{HttpUtility.HtmlEncode(diagnosticText)}</title>""");
+        sb.AppendLine($"""      <rect x="{imgX}" y="{imgY}" width="{imgWidth}" height="{imgHeight}" fill="none" stroke="currentColor" stroke-width="1" stroke-dasharray="4,2"/>""");
+        sb.AppendLine($"""      <line x1="{imgX}" y1="{imgY}" x2="{imgX + imgWidth}" y2="{imgY + imgHeight}" stroke="currentColor" stroke-width="1" stroke-dasharray="4,2"/>""");
+        sb.AppendLine($"""      <line x1="{imgX + imgWidth}" y1="{imgY}" x2="{imgX}" y2="{imgY + imgHeight}" stroke="currentColor" stroke-width="1" stroke-dasharray="4,2"/>""");
+        sb.AppendLine("    </g>");
+    }
+
+    /// <summary>
+    /// Builds a stable, human-readable description of why a placement's
+    /// image is geometry-only, from its captured parser/raster diagnostics.
+    /// Deterministic for a given <see cref="SixelData"/>: diagnostics are
+    /// captured once at parse/raster time and never mutate afterward.
+    /// </summary>
+    private static string DescribeSixelGeometryOnlyOutcome(SixelPlacement placement)
+    {
+        var image = placement.Image;
+        var parts = new List<string>
+        {
+            $"Sixel geometry-only ({image.RasterStatus}): outcome={image.Outcome}",
+        };
+
+        foreach (var diagnostic in image.RasterDiagnostics)
+            parts.Add($"raster:{diagnostic.Code}: {diagnostic.Message}");
+
+        foreach (var diagnostic in image.Diagnostics)
+            parts.Add($"parse:{diagnostic.Code}: {diagnostic.Message}");
+
+        return string.Join(" | ", parts);
     }
 
     private static string? EncodeKgpImageToDataUri(

--- a/src/Hex1b/Hmp1/Hmp1PresentationAdapter.cs
+++ b/src/Hex1b/Hmp1/Hmp1PresentationAdapter.cs
@@ -234,6 +234,8 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
         byte[] syncBytes;
         IReadOnlyList<KgpPlacement> kgpPlacements;
         IReadOnlyDictionary<uint, KgpImageData> kgpImages;
+        IReadOnlyList<SixelPlacement> sixelPlacements;
+        IReadOnlyList<(int Row, int Column, TerminalCell Cell)> sixelDamagedCells;
         int cursorX;
         int cursorY;
         string? primarySnapshot;
@@ -267,6 +269,8 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
                 syncBytes = Encoding.UTF8.GetBytes(prefix + ansi + suffix);
                 kgpPlacements = snap.KgpPlacements;
                 kgpImages = snap.KgpImages;
+                sixelPlacements = snap.SixelPlacements;
+                sixelDamagedCells = CaptureSixelDamagedCells(snap, sixelPlacements);
                 cursorX = snap.CursorX;
                 cursorY = snap.CursorY;
             }
@@ -275,6 +279,8 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
                 syncBytes = [];
                 kgpPlacements = [];
                 kgpImages = new Dictionary<uint, KgpImageData>();
+                sixelPlacements = [];
+                sixelDamagedCells = [];
                 cursorX = 0;
                 cursorY = 0;
             }
@@ -292,6 +298,22 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
                         kgpImages,
                         cursorX,
                         cursorY,
+                        session.Cts.Token));
+            }
+
+            // Sixel placements own the character cells they occupy (unlike KGP), but
+            // StateSync's CSI-2J clear unconditionally erases every Sixel placement
+            // regardless of ordering. So — exactly like KGP — this must be queued
+            // after StateSync on the per-client write pump, not written directly
+            // before it. See Hmp1SixelStateReplay for the full rationale, including
+            // why a trailing damage patch is required.
+            if (sixelPlacements.Count > 0)
+            {
+                EnqueueControlFrameAsync(session, stream =>
+                    Hmp1SixelStateReplay.WriteAsync(
+                        stream,
+                        sixelPlacements,
+                        sixelDamagedCells,
                         session.Cts.Token));
             }
 
@@ -322,6 +344,7 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
         // hasn't yet received a handle.
         await Hmp1Protocol.WriteHelloAsync(
             stream, widthSnapshot, heightSnapshot, peerId, primarySnapshot, roster, ct).ConfigureAwait(false);
+
         await Hmp1Protocol.WriteFrameAsync(stream, Hmp1FrameType.StateSync, syncBytes, ct).ConfigureAwait(false);
 
         // Start per-client write pump and read pump
@@ -419,6 +442,43 @@ public sealed class Hmp1PresentationAdapter : ITerminalLifecycleAwarePresentatio
         }
 
         return sb.ToString();
+    }
+
+    /// <summary>
+    /// Captures the exact content of every cell any of <paramref name="placements"/>
+    /// reports as damaged, while <paramref name="snapshot"/> is still valid.
+    /// </summary>
+    /// <remarks>
+    /// Sixel replay must run after StateSync's unconditional erase-display, which
+    /// re-blanks these cells when the placement is recreated. The captured cells
+    /// let <see cref="Hmp1SixelStateReplay"/> patch them back afterward. Capturing
+    /// (rather than deferring the read) is required because the snapshot is
+    /// disposed at the end of the caller's <c>using</c> block, well before the
+    /// queued replay writer runs.
+    /// </remarks>
+    private static List<(int Row, int Column, TerminalCell Cell)> CaptureSixelDamagedCells(
+        Hex1bTerminalSnapshot snapshot,
+        IReadOnlyList<SixelPlacement> placements)
+    {
+        if (placements.Count == 0)
+            return [];
+
+        var damaged = new List<(int Row, int Column, TerminalCell Cell)>();
+        foreach (var placement in placements)
+        {
+            for (var row = placement.PaintedTop; row <= placement.PaintedBottom; row++)
+            {
+                for (var column = placement.PaintedLeft; column <= placement.PaintedRight; column++)
+                {
+                    if (placement.IsCellDamaged(row, column))
+                    {
+                        damaged.Add((row, column, snapshot.GetCell(column, row)));
+                    }
+                }
+            }
+        }
+
+        return damaged;
     }
 
     /// <inheritdoc />

--- a/src/Hex1b/Hmp1/Hmp1SixelRecordedImage.cs
+++ b/src/Hex1b/Hmp1/Hmp1SixelRecordedImage.cs
@@ -1,0 +1,45 @@
+using Hex1b.Sixel;
+
+namespace Hex1b;
+
+/// <summary>
+/// A decoded Sixel image record from a <see cref="Hmp1SixelRecording"/>.
+/// </summary>
+internal sealed class Hmp1SixelRecordedImage(
+    byte[] contentHash,
+    bool isGeometryOnly,
+    int declaredPixelWidth,
+    int declaredPixelHeight,
+    int widthInCells,
+    int heightInCells,
+    SixelRasterStatus rasterStatus,
+    string payload)
+{
+    /// <summary>The image's content hash, as captured from <see cref="SixelData.ContentHash"/>.</summary>
+    public byte[] ContentHash { get; } = contentHash;
+
+    /// <summary>Whether this image carries no decoded pixels.</summary>
+    public bool IsGeometryOnly { get; } = isGeometryOnly;
+
+    /// <summary>The declared pixel width, or zero when none was declared.</summary>
+    public int DeclaredPixelWidth { get; } = declaredPixelWidth;
+
+    /// <summary>The declared pixel height, or zero when none was declared.</summary>
+    public int DeclaredPixelHeight { get; } = declaredPixelHeight;
+
+    /// <summary>The image width in cells.</summary>
+    public int WidthInCells { get; } = widthInCells;
+
+    /// <summary>The image height in cells.</summary>
+    public int HeightInCells { get; } = heightInCells;
+
+    /// <summary>The raster outcome captured at recording time.</summary>
+    public SixelRasterStatus RasterStatus { get; } = rasterStatus;
+
+    /// <summary>
+    /// The self-contained Sixel DCS payload for this image: a fresh
+    /// <see cref="Sixel.SixelExactEncoder"/> re-encoding of the decoded pixels for
+    /// rasterized images, or the original payload verbatim for geometry-only images.
+    /// </summary>
+    public string Payload { get; } = payload;
+}

--- a/src/Hex1b/Hmp1/Hmp1SixelRecordedPlacement.cs
+++ b/src/Hex1b/Hmp1/Hmp1SixelRecordedPlacement.cs
@@ -1,0 +1,55 @@
+namespace Hex1b;
+
+/// <summary>
+/// A decoded Sixel placement record from a <see cref="Hmp1SixelRecording"/>.
+/// </summary>
+internal sealed class Hmp1SixelRecordedPlacement(
+    int imageIndex,
+    int row,
+    int column,
+    int widthInCells,
+    int heightInCells,
+    int paintedRowOffset,
+    int paintedRowCount,
+    int paintedColumnOffset,
+    int paintedColumnCount,
+    long sequence,
+    DateTimeOffset createdAt,
+    IReadOnlyList<(int Row, int Column)> damagedCells)
+{
+    /// <summary>The index of this placement's image within the recording's image table.</summary>
+    public int ImageIndex { get; } = imageIndex;
+
+    /// <summary>The anchor row.</summary>
+    public int Row { get; } = row;
+
+    /// <summary>The anchor column.</summary>
+    public int Column { get; } = column;
+
+    /// <summary>The occupied width in cells.</summary>
+    public int WidthInCells { get; } = widthInCells;
+
+    /// <summary>The occupied height in cells.</summary>
+    public int HeightInCells { get; } = heightInCells;
+
+    /// <summary>The painted-extent row offset from the anchor.</summary>
+    public int PaintedRowOffset { get; } = paintedRowOffset;
+
+    /// <summary>The painted-extent row count.</summary>
+    public int PaintedRowCount { get; } = paintedRowCount;
+
+    /// <summary>The painted-extent column offset from the anchor.</summary>
+    public int PaintedColumnOffset { get; } = paintedColumnOffset;
+
+    /// <summary>The painted-extent column count.</summary>
+    public int PaintedColumnCount { get; } = paintedColumnCount;
+
+    /// <summary>The creation sequence number, used to order overlapping placements.</summary>
+    public long Sequence { get; } = sequence;
+
+    /// <summary>The placement's creation timestamp.</summary>
+    public DateTimeOffset CreatedAt { get; } = createdAt;
+
+    /// <summary>Anchor-relative (row, column) pairs for cells that have been damaged.</summary>
+    public IReadOnlyList<(int Row, int Column)> DamagedCells { get; } = damagedCells;
+}

--- a/src/Hex1b/Hmp1/Hmp1SixelRecording.cs
+++ b/src/Hex1b/Hmp1/Hmp1SixelRecording.cs
@@ -1,0 +1,381 @@
+using System.Text;
+using Hex1b.Sixel;
+
+namespace Hex1b;
+
+/// <summary>
+/// Serializes and deserializes a versioned, explicit binary representation of
+/// viewport Sixel placements — independent of the plain-bytes escape sequences
+/// <see cref="Hmp1SixelStateReplay"/> writes directly to a live HMP1 peer's stream.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This format exists to satisfy record/serialize/replay/compare scenarios that
+/// need explicit, testable failure modes (unsupported version, truncation,
+/// missing image references, invalid geometry, resource-limit violations) —
+/// none of which apply to <see cref="Hmp1SixelStateReplay"/>, which only ever
+/// emits plain terminal bytes interpreted by the existing, already-robust live
+/// Sixel parser.
+/// </para>
+/// <para>
+/// Images are content-addressed and deduplicated by <see cref="SixelData.ContentHash"/>:
+/// multiple placements sharing a raster reference the same image table entry, so
+/// pixel payloads are never repeated within a single recording (unlike the live
+/// wire replay, where the Sixel protocol has no "reuse an existing image at a new
+/// position" primitive).
+/// </para>
+/// </remarks>
+internal static class Hmp1SixelRecording
+{
+    private static readonly byte[] Magic = "SXRC"u8.ToArray();
+
+    internal const int CurrentVersion = 1;
+    internal const int MaxPlacementCount = 4096;
+    internal const int MaxImageCount = 4096;
+    internal const int MaxPayloadLength = 64 * 1024 * 1024;
+    internal const int MaxDamagedCellCount = 1 << 20;
+
+    /// <summary>
+    /// Serializes the given viewport placements into a versioned recording.
+    /// </summary>
+    internal static byte[] Serialize(IReadOnlyList<SixelPlacement> placements)
+    {
+        ArgumentNullException.ThrowIfNull(placements);
+
+        if (placements.Count > MaxPlacementCount)
+        {
+            throw new Hmp1SixelRecordingException(
+                Hmp1SixelRecordingFailureReason.ResourceLimitExceeded,
+                $"Placement count {placements.Count} exceeds the limit of {MaxPlacementCount}.");
+        }
+
+        var imageIndexByHash = new Dictionary<byte[], int>(SixelContentHashComparer.Instance);
+        var images = new List<SixelData>();
+        foreach (var placement in placements)
+        {
+            if (!imageIndexByHash.ContainsKey(placement.Image.ContentHash))
+            {
+                imageIndexByHash[placement.Image.ContentHash] = images.Count;
+                images.Add(placement.Image);
+            }
+        }
+
+        if (images.Count > MaxImageCount)
+        {
+            throw new Hmp1SixelRecordingException(
+                Hmp1SixelRecordingFailureReason.ResourceLimitExceeded,
+                $"Image count {images.Count} exceeds the limit of {MaxImageCount}.");
+        }
+
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true))
+        {
+            writer.Write(Magic);
+            writer.Write(CurrentVersion);
+            writer.Write(placements.Count);
+            writer.Write(images.Count);
+
+            foreach (var image in images)
+            {
+                WriteImage(writer, image);
+            }
+
+            foreach (var placement in placements)
+            {
+                WritePlacement(writer, placement, imageIndexByHash[placement.Image.ContentHash]);
+            }
+        }
+
+        return stream.ToArray();
+    }
+
+    /// <summary>
+    /// Deserializes and strictly validates a recording produced by
+    /// <see cref="Serialize"/>. Throws <see cref="Hmp1SixelRecordingException"/> for
+    /// every failure mode rather than returning a success-shaped partial result.
+    /// </summary>
+    internal static Hmp1SixelRecordingSnapshot Deserialize(ReadOnlyMemory<byte> data)
+    {
+        using var stream = new MemoryStream(data.ToArray(), writable: false);
+        using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+
+        var magic = ReadExact(reader, Magic.Length);
+        if (!magic.AsSpan().SequenceEqual(Magic))
+        {
+            throw new Hmp1SixelRecordingException(
+                Hmp1SixelRecordingFailureReason.Malformed,
+                "Recording is missing the expected format marker.");
+        }
+
+        var version = ReadInt32(reader);
+        if (version != CurrentVersion)
+        {
+            throw new Hmp1SixelRecordingException(
+                Hmp1SixelRecordingFailureReason.UnsupportedVersion,
+                $"Recording version {version} is not supported. Supported version: {CurrentVersion}.");
+        }
+
+        var placementCount = ReadInt32(reader);
+        var imageCount = ReadInt32(reader);
+        ValidateCount(placementCount, MaxPlacementCount, "placement");
+        ValidateCount(imageCount, MaxImageCount, "image");
+
+        var images = new List<Hmp1SixelRecordedImage>(imageCount);
+        for (var i = 0; i < imageCount; i++)
+        {
+            images.Add(ReadImage(reader));
+        }
+
+        var placements = new List<Hmp1SixelRecordedPlacement>(placementCount);
+        for (var i = 0; i < placementCount; i++)
+        {
+            placements.Add(ReadPlacement(reader, imageCount));
+        }
+
+        return new Hmp1SixelRecordingSnapshot(version, images, placements);
+    }
+
+    private static void WriteImage(BinaryWriter writer, SixelData image)
+    {
+        var payload = image.RasterStatus == SixelRasterStatus.GeometryOnly
+            ? image.Payload
+            : EncodeRasterizedPayload(image);
+
+        var payloadBytes = Encoding.UTF8.GetBytes(payload);
+        if (payloadBytes.Length > MaxPayloadLength)
+        {
+            throw new Hmp1SixelRecordingException(
+                Hmp1SixelRecordingFailureReason.ResourceLimitExceeded,
+                $"Image payload length {payloadBytes.Length} exceeds the limit of {MaxPayloadLength}.");
+        }
+
+        writer.Write(image.ContentHash);
+        writer.Write(image.RasterStatus == SixelRasterStatus.GeometryOnly);
+        writer.Write(image.PixelWidth);
+        writer.Write(image.PixelHeight);
+        writer.Write(image.WidthInCells);
+        writer.Write(image.HeightInCells);
+        writer.Write((byte)image.RasterStatus);
+        writer.Write(payloadBytes.Length);
+        writer.Write(payloadBytes);
+    }
+
+    private static string EncodeRasterizedPayload(SixelData image)
+    {
+        var pixels = image.GetPixels();
+
+        // A non-geometry-only image should always have decoded pixels. Fall back to
+        // the original payload defensively rather than dropping the image.
+        return pixels is null
+            ? image.Payload
+            : SixelExactEncoder.Encode(pixels) ?? image.Payload;
+    }
+
+    private static void WritePlacement(BinaryWriter writer, SixelPlacement placement, int imageIndex)
+    {
+        writer.Write(imageIndex);
+        writer.Write(placement.Row);
+        writer.Write(placement.Column);
+        writer.Write(placement.WidthInCells);
+        writer.Write(placement.HeightInCells);
+        writer.Write(placement.PaintedRowOffset);
+        writer.Write(placement.PaintedRowCount);
+        writer.Write(placement.PaintedColumnOffset);
+        writer.Write(placement.PaintedColumnCount);
+        writer.Write(placement.Sequence);
+        writer.Write(placement.CreatedAt.ToUnixTimeMilliseconds());
+
+        var damagedCells = new List<(int Row, int Column)>();
+        for (var row = 0; row < placement.PaintedRowCount; row++)
+        {
+            for (var col = 0; col < placement.PaintedColumnCount; col++)
+            {
+                var absoluteRow = placement.PaintedTop + row;
+                var absoluteColumn = placement.PaintedLeft + col;
+                if (placement.IsCellDamaged(absoluteRow, absoluteColumn))
+                {
+                    // Store anchor-relative offsets, matching SixelPlacement's own
+                    // damaged-cell key convention, so damage stays consistent if the
+                    // placement is later shifted (e.g. replayed at a different anchor).
+                    damagedCells.Add((absoluteRow - placement.Row, absoluteColumn - placement.Column));
+                }
+            }
+        }
+
+        if (damagedCells.Count > MaxDamagedCellCount)
+        {
+            throw new Hmp1SixelRecordingException(
+                Hmp1SixelRecordingFailureReason.ResourceLimitExceeded,
+                $"Damaged cell count {damagedCells.Count} exceeds the limit of {MaxDamagedCellCount}.");
+        }
+
+        writer.Write(damagedCells.Count);
+        foreach (var (row, col) in damagedCells)
+        {
+            writer.Write(row);
+            writer.Write(col);
+        }
+    }
+
+    private static Hmp1SixelRecordedImage ReadImage(BinaryReader reader)
+    {
+        var contentHash = ReadExact(reader, 32);
+        var isGeometryOnly = ReadBool(reader);
+        var declaredPixelWidth = ReadInt32(reader);
+        var declaredPixelHeight = ReadInt32(reader);
+        var widthInCells = ReadInt32(reader);
+        var heightInCells = ReadInt32(reader);
+        var rasterStatusByte = ReadByte(reader);
+        var payloadLength = ReadInt32(reader);
+
+        if (payloadLength < 0 || payloadLength > MaxPayloadLength)
+        {
+            throw new Hmp1SixelRecordingException(
+                Hmp1SixelRecordingFailureReason.ResourceLimitExceeded,
+                $"Image payload length {payloadLength} is invalid or exceeds the limit of {MaxPayloadLength}.");
+        }
+
+        var payloadBytes = ReadExact(reader, payloadLength);
+
+        if (declaredPixelWidth < 0 || declaredPixelHeight < 0 || widthInCells <= 0 || heightInCells <= 0)
+        {
+            throw new Hmp1SixelRecordingException(
+                Hmp1SixelRecordingFailureReason.InvalidGeometry,
+                $"Image declares invalid geometry (pixels {declaredPixelWidth}x{declaredPixelHeight}, cells {widthInCells}x{heightInCells}).");
+        }
+
+        if (!Enum.IsDefined(typeof(SixelRasterStatus), (int)rasterStatusByte))
+        {
+            throw new Hmp1SixelRecordingException(
+                Hmp1SixelRecordingFailureReason.Malformed,
+                $"Image declares an unrecognized raster status value {rasterStatusByte}.");
+        }
+
+        return new Hmp1SixelRecordedImage(
+            contentHash,
+            isGeometryOnly,
+            declaredPixelWidth,
+            declaredPixelHeight,
+            widthInCells,
+            heightInCells,
+            (SixelRasterStatus)rasterStatusByte,
+            Encoding.UTF8.GetString(payloadBytes));
+    }
+
+    private static Hmp1SixelRecordedPlacement ReadPlacement(BinaryReader reader, int imageCount)
+    {
+        var imageIndex = ReadInt32(reader);
+        var row = ReadInt32(reader);
+        var column = ReadInt32(reader);
+        var widthInCells = ReadInt32(reader);
+        var heightInCells = ReadInt32(reader);
+        var paintedRowOffset = ReadInt32(reader);
+        var paintedRowCount = ReadInt32(reader);
+        var paintedColumnOffset = ReadInt32(reader);
+        var paintedColumnCount = ReadInt32(reader);
+        var sequence = ReadInt64(reader);
+        var createdAtUnixMs = ReadInt64(reader);
+        var damagedCellCount = ReadInt32(reader);
+
+        if (imageIndex < 0 || imageIndex >= imageCount)
+        {
+            throw new Hmp1SixelRecordingException(
+                Hmp1SixelRecordingFailureReason.MissingImageReference,
+                $"Placement references image index {imageIndex}, but the recording only has {imageCount} image(s).");
+        }
+
+        if (widthInCells <= 0 || heightInCells <= 0 || paintedRowCount < 0 || paintedColumnCount < 0)
+        {
+            throw new Hmp1SixelRecordingException(
+                Hmp1SixelRecordingFailureReason.InvalidGeometry,
+                $"Placement declares invalid geometry (cells {widthInCells}x{heightInCells}, painted {paintedRowCount}x{paintedColumnCount}).");
+        }
+
+        if (damagedCellCount < 0 || damagedCellCount > MaxDamagedCellCount)
+        {
+            throw new Hmp1SixelRecordingException(
+                Hmp1SixelRecordingFailureReason.ResourceLimitExceeded,
+                $"Damaged cell count {damagedCellCount} is invalid or exceeds the limit of {MaxDamagedCellCount}.");
+        }
+
+        var damagedCells = new List<(int Row, int Column)>(damagedCellCount);
+        for (var i = 0; i < damagedCellCount; i++)
+        {
+            var damagedRow = ReadInt32(reader);
+            var damagedCol = ReadInt32(reader);
+            damagedCells.Add((damagedRow, damagedCol));
+        }
+
+        return new Hmp1SixelRecordedPlacement(
+            imageIndex,
+            row,
+            column,
+            widthInCells,
+            heightInCells,
+            paintedRowOffset,
+            paintedRowCount,
+            paintedColumnOffset,
+            paintedColumnCount,
+            sequence,
+            DateTimeOffset.FromUnixTimeMilliseconds(createdAtUnixMs),
+            damagedCells);
+    }
+
+    private static void ValidateCount(int count, int max, string what)
+    {
+        if (count < 0)
+        {
+            throw new Hmp1SixelRecordingException(
+                Hmp1SixelRecordingFailureReason.Malformed,
+                $"Recording declares a negative {what} count ({count}).");
+        }
+
+        if (count > max)
+        {
+            throw new Hmp1SixelRecordingException(
+                Hmp1SixelRecordingFailureReason.ResourceLimitExceeded,
+                $"Recording declares {count} {what}(s), exceeding the limit of {max}.");
+        }
+    }
+
+    private static byte[] ReadExact(BinaryReader reader, int count)
+    {
+        try
+        {
+            var bytes = reader.ReadBytes(count);
+            if (bytes.Length != count)
+            {
+                throw new Hmp1SixelRecordingException(
+                    Hmp1SixelRecordingFailureReason.Truncated,
+                    $"Expected {count} byte(s) but only {bytes.Length} remained.");
+            }
+
+            return bytes;
+        }
+        catch (EndOfStreamException)
+        {
+            throw new Hmp1SixelRecordingException(
+                Hmp1SixelRecordingFailureReason.Truncated,
+                "Recording ended before all declared data could be read.");
+        }
+    }
+
+    private static int ReadInt32(BinaryReader reader) => ReadPrimitive(reader, r => r.ReadInt32());
+    private static long ReadInt64(BinaryReader reader) => ReadPrimitive(reader, r => r.ReadInt64());
+    private static byte ReadByte(BinaryReader reader) => ReadPrimitive(reader, r => r.ReadByte());
+    private static bool ReadBool(BinaryReader reader) => ReadPrimitive(reader, r => r.ReadBoolean());
+
+    private static T ReadPrimitive<T>(BinaryReader reader, Func<BinaryReader, T> read)
+    {
+        try
+        {
+            return read(reader);
+        }
+        catch (EndOfStreamException)
+        {
+            throw new Hmp1SixelRecordingException(
+                Hmp1SixelRecordingFailureReason.Truncated,
+                "Recording ended before all declared data could be read.");
+        }
+    }
+}

--- a/src/Hex1b/Hmp1/Hmp1SixelRecordingException.cs
+++ b/src/Hex1b/Hmp1/Hmp1SixelRecordingException.cs
@@ -1,0 +1,13 @@
+namespace Hex1b;
+
+/// <summary>
+/// Thrown when a Sixel state recording cannot be serialized or deserialized. Never
+/// thrown as a success-shaped fallback: every throw site corresponds to a specific,
+/// named <see cref="Hmp1SixelRecordingFailureReason"/>.
+/// </summary>
+internal sealed class Hmp1SixelRecordingException(Hmp1SixelRecordingFailureReason reason, string message)
+    : Exception(message)
+{
+    /// <summary>The specific reason the recording operation failed.</summary>
+    public Hmp1SixelRecordingFailureReason Reason { get; } = reason;
+}

--- a/src/Hex1b/Hmp1/Hmp1SixelRecordingFailureReason.cs
+++ b/src/Hex1b/Hmp1/Hmp1SixelRecordingFailureReason.cs
@@ -1,0 +1,26 @@
+namespace Hex1b;
+
+/// <summary>
+/// Explicit failure reasons for <see cref="Hmp1SixelRecording"/> serialization and
+/// deserialization.
+/// </summary>
+internal enum Hmp1SixelRecordingFailureReason
+{
+    /// <summary>The recording's format marker was not recognized.</summary>
+    Malformed,
+
+    /// <summary>The recording ended before all declared data could be read.</summary>
+    Truncated,
+
+    /// <summary>The recording's version is not supported by this build.</summary>
+    UnsupportedVersion,
+
+    /// <summary>A placement referenced an image table index that does not exist.</summary>
+    MissingImageReference,
+
+    /// <summary>A declared extent or cell dimension was not positive.</summary>
+    InvalidGeometry,
+
+    /// <summary>A placement, image, or payload count/size exceeded a bounded limit.</summary>
+    ResourceLimitExceeded,
+}

--- a/src/Hex1b/Hmp1/Hmp1SixelRecordingSnapshot.cs
+++ b/src/Hex1b/Hmp1/Hmp1SixelRecordingSnapshot.cs
@@ -1,0 +1,45 @@
+using System.Text;
+
+namespace Hex1b;
+
+/// <summary>
+/// A decoded, versioned Sixel state recording: sufficient to reconstruct image
+/// definitions, placements, damage, source crops, geometry-only outcomes, and
+/// metrics without a live upstream terminal.
+/// </summary>
+internal sealed class Hmp1SixelRecordingSnapshot(
+    int version,
+    IReadOnlyList<Hmp1SixelRecordedImage> images,
+    IReadOnlyList<Hmp1SixelRecordedPlacement> placements)
+{
+    /// <summary>The format version this recording was written with.</summary>
+    public int Version { get; } = version;
+
+    /// <summary>The recording's distinct image table, ordered by first appearance.</summary>
+    public IReadOnlyList<Hmp1SixelRecordedImage> Images { get; } = images;
+
+    /// <summary>The recording's placements, in their original creation order.</summary>
+    public IReadOnlyList<Hmp1SixelRecordedPlacement> Placements { get; } = placements;
+
+    /// <summary>
+    /// Builds the cursor-position + Sixel DCS escape sequence text needed to
+    /// reconstruct every placement in this recording on a fresh terminal, in
+    /// <see cref="Hmp1SixelRecordedPlacement.Sequence"/> order. Feeding the result
+    /// through the same tokenizer/apply path a live terminal uses for incoming
+    /// output (rather than a bespoke reconstruction) is what lets replay be
+    /// verified against the same authoritative parser/raster invariants used by
+    /// live terminal processing.
+    /// </summary>
+    public string BuildReplayEscapeSequence()
+    {
+        var sb = new StringBuilder();
+        foreach (var placement in Placements.OrderBy(p => p.Sequence))
+        {
+            var image = Images[placement.ImageIndex];
+            sb.Append(FormattableString.Invariant($"\x1b[{placement.Row + 1};{placement.Column + 1}H"));
+            sb.Append(image.Payload);
+        }
+
+        return sb.ToString();
+    }
+}

--- a/src/Hex1b/Hmp1/Hmp1SixelStateReplay.cs
+++ b/src/Hex1b/Hmp1/Hmp1SixelStateReplay.cs
@@ -1,0 +1,192 @@
+using System.Globalization;
+using System.Text;
+using Hex1b.Sixel;
+using Hex1b.Surfaces;
+using Hex1b.Theming;
+
+namespace Hex1b;
+
+/// <summary>
+/// Reconstructs Sixel graphics state for a freshly joining HMP1 peer by replaying
+/// synthetic cursor-position and Sixel DCS escape sequences.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Erase-display (<c>CSI 2 J</c>) unconditionally clears every Sixel placement on
+/// the active screen (see <c>Hex1bTerminal.ApplyClearScreen</c>), and the
+/// <see cref="Hmp1FrameType.StateSync"/> payload always begins with exactly that
+/// sequence. This means Sixel replay must be queued <em>after</em> StateSync on the
+/// wire — like <see cref="Hmp1KgpStateReplay"/> — or StateSync's own clear would
+/// immediately erase it.
+/// </para>
+/// <para>
+/// Unlike Kitty Graphics Protocol (KGP) placements, Sixel placements own the
+/// character cells they occupy: creating a placement blanks its occupied cell
+/// rectangle (see <c>Hex1bTerminal</c>'s cell-reservation behavior). Replaying
+/// placement creation after StateSync therefore re-blanks any cell inside the
+/// placement's rectangle that StateSync had just painted with real content —
+/// including damaged (overwritten) cells. To compensate, this replay writes a
+/// trailing "damage patch": for every cell the producer's placement recorded as
+/// damaged, it re-emits that cell's exact character, colors, and attributes
+/// (captured from the same snapshot the placements came from) immediately after
+/// the placement-creation sequences, so the joining peer ends up with the same
+/// end state as the producer: placement geometry intact, damaged cells showing
+/// their overwritten content.
+/// </para>
+/// <para>
+/// Rasterized placements are replayed by re-encoding their already-decoded
+/// pixels (<see cref="SixelData.GetPixels"/>) into a fresh, self-contained
+/// Sixel DCS sequence via <see cref="SixelExactEncoder"/>, rather than by
+/// replaying the placement's original payload. This avoids a correctness gap:
+/// the original payload may depend on persistent color registers set by
+/// earlier, unreplayed images on the source terminal (<c>Hex1bTerminal</c>
+/// keeps one <c>SixelColorRegisters</c> table for its whole lifetime), which a
+/// freshly joining peer's terminal does not have. <see cref="SixelExactEncoder"/>
+/// keeps the re-encode byte-exact, unlike <see cref="Hex1b.Surfaces.SixelEncoder"/>
+/// (used for widget authoring), which intentionally quantizes to a reduced
+/// palette and is not suitable here. Geometry-only placements have no decoded
+/// pixels, so their original payload is replayed verbatim — safe because a
+/// geometry-only outcome is a deterministic function of parser/raster policy
+/// limits applied to the payload's own declared extents, not of any
+/// persistent register state.
+/// </para>
+/// <para>
+/// Only the viewport (not scrollback history) is replayed, matching the scope
+/// of the existing KGP replay and the fact that <c>Hex1bTerminal.CreateSnapshot()</c>
+/// (used for HMP1 state sync) captures zero scrollback lines by design.
+/// </para>
+/// </remarks>
+internal static class Hmp1SixelStateReplay
+{
+    private const int TargetFrameSize = 1024 * 1024;
+
+    /// <summary>
+    /// Writes the escape sequences needed to recreate the given viewport Sixel
+    /// placements — and repair any cells they damaged — on a fresh terminal,
+    /// chunked into HMP1 <see cref="Hmp1FrameType.Output"/> frames.
+    /// </summary>
+    /// <param name="stream">The stream to write frames to.</param>
+    /// <param name="placements">The producer's current viewport Sixel placements, captured from the same snapshot as <paramref name="damagedCells"/>.</param>
+    /// <param name="damagedCells">Absolute (row, column, cell) triples for every cell any of <paramref name="placements"/> reports as damaged, captured from the same snapshot.</param>
+    /// <param name="ct">Cancellation token.</param>
+    internal static async Task WriteAsync(
+        Stream stream,
+        IReadOnlyList<SixelPlacement> placements,
+        IReadOnlyList<(int Row, int Column, TerminalCell Cell)> damagedCells,
+        CancellationToken ct)
+    {
+        if (placements.Count == 0)
+            return;
+
+        var frame = new StringBuilder(TargetFrameSize);
+
+        foreach (var placement in placements.OrderBy(p => p.Sequence))
+        {
+            await AppendAsync(BuildPlacementSequence(placement)).ConfigureAwait(false);
+        }
+
+        foreach (var (row, column, cell) in damagedCells)
+        {
+            await AppendAsync(BuildDamagePatchSequence(row, column, cell)).ConfigureAwait(false);
+        }
+
+        await FlushAsync().ConfigureAwait(false);
+
+        async ValueTask AppendAsync(string sequence)
+        {
+            if (frame.Length > 0 && frame.Length + sequence.Length > TargetFrameSize)
+                await FlushAsync().ConfigureAwait(false);
+            frame.Append(sequence);
+        }
+
+        async ValueTask FlushAsync()
+        {
+            if (frame.Length == 0)
+                return;
+
+            var payload = Encoding.UTF8.GetBytes(frame.ToString());
+            frame.Clear();
+            await Hmp1Protocol.WriteFrameAsync(
+                stream,
+                Hmp1FrameType.Output,
+                payload,
+                ct).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Builds the cursor-position + Sixel DCS escape sequence needed to recreate a
+    /// single placement on a fresh terminal.
+    /// </summary>
+    internal static string BuildPlacementSequence(SixelPlacement placement)
+    {
+        var payload = placement.IsGeometryOnly
+            ? placement.Image.Payload
+            : EncodeRasterizedPayload(placement.Image);
+
+        return FormattableString.Invariant(
+            $"\x1b[{placement.Row + 1};{placement.Column + 1}H") + payload;
+    }
+
+    /// <summary>
+    /// Builds the cursor-position + SGR + character sequence needed to restore a
+    /// single damaged cell's exact content after its owning placement has
+    /// re-blanked it.
+    /// </summary>
+    private static string BuildDamagePatchSequence(int row, int column, TerminalCell cell)
+    {
+        var sb = new StringBuilder();
+        sb.Append(FormattableString.Invariant($"\x1b[{row + 1};{column + 1}H"));
+        sb.Append("\x1b[0m");
+
+        var attrs = cell.Attributes;
+        var isReverse = (attrs & CellAttributes.Reverse) != 0;
+        var fg = isReverse ? cell.Background : cell.Foreground;
+        var bg = isReverse ? cell.Foreground : cell.Background;
+
+        var sgrParts = new List<string>();
+        if ((attrs & CellAttributes.Bold) != 0) sgrParts.Add("1");
+        if ((attrs & CellAttributes.Dim) != 0) sgrParts.Add("2");
+        if ((attrs & CellAttributes.Italic) != 0) sgrParts.Add("3");
+        if ((attrs & CellAttributes.Underline) != 0) sgrParts.Add("4");
+        if ((attrs & CellAttributes.Blink) != 0) sgrParts.Add("5");
+        if ((attrs & CellAttributes.Hidden) != 0) sgrParts.Add("8");
+        if ((attrs & CellAttributes.Strikethrough) != 0) sgrParts.Add("9");
+        if ((attrs & CellAttributes.Overline) != 0) sgrParts.Add("53");
+        if (fg.HasValue) sgrParts.Add(FormatColorSgr(fg.Value, isForeground: true));
+        if (bg.HasValue) sgrParts.Add(FormatColorSgr(bg.Value, isForeground: false));
+
+        if (sgrParts.Count > 0)
+            sb.Append(FormattableString.Invariant($"\x1b[{string.Join(";", sgrParts)}m"));
+
+        var ch = cell.Character;
+        if (!string.IsNullOrEmpty(ch) && ch != "\0" && ch != "\uE000")
+        {
+            sb.Append((attrs & CellAttributes.Hidden) != 0
+                ? new string(' ', DisplayWidth.GetGraphemeWidth(ch))
+                : ch);
+        }
+
+        return sb.ToString();
+    }
+
+    private static string FormatColorSgr(Hex1bColor color, bool isForeground) => color.Kind switch
+    {
+        Hex1bColorKind.Standard => (isForeground ? 30 + color.AnsiIndex : 40 + color.AnsiIndex).ToString(CultureInfo.InvariantCulture),
+        Hex1bColorKind.Bright => (isForeground ? 90 + color.AnsiIndex : 100 + color.AnsiIndex).ToString(CultureInfo.InvariantCulture),
+        Hex1bColorKind.Indexed => FormattableString.Invariant($"{(isForeground ? "38;5" : "48;5")};{color.AnsiIndex}"),
+        _ => FormattableString.Invariant($"{(isForeground ? "38;2" : "48;2")};{color.R};{color.G};{color.B}"),
+    };
+
+
+    private static string EncodeRasterizedPayload(SixelData image)
+    {
+        var pixels = image.GetPixels();
+
+        // A non-geometry-only image should always have decoded pixels. Fall back to
+        // the original payload defensively rather than dropping the placement.
+        return pixels is null
+            ? image.Payload
+            : SixelExactEncoder.Encode(pixels) ?? image.Payload;
+    }
+}

--- a/src/Hex1b/Sixel/SixelCellMetrics.cs
+++ b/src/Hex1b/Sixel/SixelCellMetrics.cs
@@ -9,7 +9,7 @@ namespace Hex1b.Sixel;
 /// (commonly 9x20 or 10x20) instead of its physical glyph box, so the source must
 /// travel with the value.
 /// </remarks>
-internal enum SixelCellMetricsSource
+public enum SixelCellMetricsSource
 {
     /// <summary>
     /// The presentation reported protocol cell metrics directly.
@@ -41,7 +41,7 @@ internal enum SixelCellMetricsSource
 /// <summary>
 /// Describes how much a <see cref="SixelCellMetrics"/> value can be trusted.
 /// </summary>
-internal enum SixelCellMetricsReliability
+public enum SixelCellMetricsReliability
 {
     /// <summary>
     /// The upstream presentation reported the value for the Sixel protocol grid.
@@ -80,7 +80,7 @@ internal enum SixelCellMetricsReliability
 /// next cell.
 /// </para>
 /// </remarks>
-internal readonly record struct SixelCellMetrics(
+public readonly record struct SixelCellMetrics(
     double Width,
     double Height,
     SixelCellMetricsSource Source,

--- a/src/Hex1b/Sixel/SixelExactEncoder.cs
+++ b/src/Hex1b/Sixel/SixelExactEncoder.cs
@@ -1,0 +1,187 @@
+using System.Text;
+using Hex1b.Surfaces;
+
+namespace Hex1b.Sixel;
+
+/// <summary>
+/// Re-encodes an already-decoded Sixel pixel buffer back into a self-contained
+/// Sixel DCS sequence using an exact (unquantized) color register table, so
+/// that re-parsing the result reproduces byte-identical pixels.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike <see cref="Hex1b.Surfaces.SixelEncoder"/> — built for authoring a Sixel
+/// payload from an arbitrary RGBA source such as a screenshot, where reducing to a
+/// bounded palette is an acceptable, even necessary, lossy step — this encoder
+/// exists for the narrower case of round-tripping a buffer that itself came from
+/// decoding a valid Sixel raster (a live terminal's placement, on its way to
+/// being replayed or recorded). Every color value in such a buffer was produced by
+/// <see cref="SixelColorConverter.PercentToComponent"/> (directly, or via
+/// <see cref="SixelColorConverter.FromRgbPercent"/>/<see cref="SixelColorConverter.FromHls"/>,
+/// or the built-in default palette, all of which route through the same
+/// conversion), so inverting that conversion always finds an exact match — no
+/// quantization is needed or performed.
+/// </para>
+/// </remarks>
+internal static class SixelExactEncoder
+{
+    /// <summary>
+    /// Encodes <paramref name="buffer"/> into a complete Sixel DCS sequence
+    /// (ESC P ... ESC \), matching the shape of <see cref="SixelData.Payload"/>.
+    /// </summary>
+    /// <returns>
+    /// The encoded sequence, or <see langword="null"/> if the buffer's distinct
+    /// (exact, unquantized) color count exceeds the number of registers a single
+    /// Sixel raster can address (<see cref="SixelEncoder.MaxPaletteColors"/>) —
+    /// callers should fall back to the original payload in that case.
+    /// </returns>
+    internal static string? Encode(SixelPixelBuffer buffer)
+    {
+        ArgumentNullException.ThrowIfNull(buffer);
+
+        var width = buffer.Width;
+        var height = buffer.Height;
+
+        var palette = new Dictionary<Rgba32, int>();
+        var indexedPixels = new int[width, height];
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var pixel = buffer[x, y];
+                if (pixel.A == 0)
+                {
+                    indexedPixels[x, y] = -1;
+                    continue;
+                }
+
+                if (!palette.TryGetValue(pixel, out var index))
+                {
+                    if (palette.Count >= SixelEncoder.MaxPaletteColors)
+                        return null;
+
+                    index = palette.Count;
+                    palette[pixel] = index;
+                }
+
+                indexedPixels[x, y] = index;
+            }
+        }
+
+        if (palette.Count == 0)
+            return "\x1bP0;1;0q\x1b\\";
+
+        var sb = new StringBuilder();
+        sb.Append("\x1bP0;1;0q");
+        sb.Append(FormattableString.Invariant($"\"1;1;{width};{height}"));
+
+        foreach (var (color, index) in palette)
+        {
+            var r = ComponentToPercent(color.R);
+            var g = ComponentToPercent(color.G);
+            var b = ComponentToPercent(color.B);
+            sb.Append(FormattableString.Invariant($"#{index};2;{r};{g};{b}"));
+        }
+
+        var numBands = (height + 5) / 6;
+        for (var band = 0; band < numBands; band++)
+        {
+            var bandStartY = band * 6;
+            var bandHeight = Math.Min(6, height - bandStartY);
+
+            foreach (var index in Enumerable.Range(0, palette.Count))
+            {
+                var run = BuildColorRunForBand(indexedPixels, width, bandStartY, bandHeight, index);
+                if (run.Length == 0)
+                    continue;
+
+                sb.Append('#');
+                sb.Append(index);
+                sb.Append(run);
+                sb.Append('$');
+            }
+
+            if (band < numBands - 1)
+                sb.Append('-');
+        }
+
+        sb.Append("\x1b\\");
+        return sb.ToString();
+    }
+
+    private static string BuildColorRunForBand(int[,] indexedPixels, int width, int bandStartY, int bandHeight, int colorIndex)
+    {
+        var chars = new char[width];
+        var lastNonBlank = -1;
+        for (var x = 0; x < width; x++)
+        {
+            byte bits = 0;
+            for (var row = 0; row < bandHeight; row++)
+            {
+                if (indexedPixels[x, bandStartY + row] == colorIndex)
+                    bits |= (byte)(1 << row);
+            }
+
+            chars[x] = (char)('?' + bits);
+            if (bits != 0)
+                lastNonBlank = x;
+        }
+
+        // This color doesn't appear anywhere in this band — omit its line entirely.
+        if (lastNonBlank < 0)
+            return string.Empty;
+
+        // Trailing all-blank columns need no representation: nothing follows them
+        // on this color's line. Interior blank runs (between two occurrences of
+        // this color) MUST be kept — they are what keeps this color's pixels
+        // aligned to the correct column when its line is drawn independently of
+        // every other color's line.
+        var length = lastNonBlank + 1;
+
+        var sb = new StringBuilder();
+        var i = 0;
+        while (i < length)
+        {
+            var run = 1;
+            while (i + run < length && chars[i + run] == chars[i])
+                run++;
+
+            if (run > 3)
+            {
+                sb.Append('!');
+                sb.Append(run);
+                sb.Append(chars[i]);
+            }
+            else
+            {
+                sb.Append(chars[i], run);
+            }
+
+            i += run;
+        }
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Finds the DEC 0-100 percentage that <see cref="SixelColorConverter.PercentToComponent"/>
+    /// converts back to the exact given byte.
+    /// </summary>
+    /// <remarks>
+    /// The scan is at most 101 iterations and runs once per distinct register
+    /// color, not per pixel.
+    /// </remarks>
+    private static int ComponentToPercent(byte component)
+    {
+        for (var percent = 0; percent <= 100; percent++)
+        {
+            if (SixelColorConverter.PercentToComponent(percent) == component)
+                return percent;
+        }
+
+        // Defensive fallback: should be unreachable for genuinely decoded Sixel
+        // pixel data. Produces the nearest percentage rather than throwing, since
+        // a slightly-off color is preferable to failing the whole re-encode.
+        return Math.Clamp(((component * 100) + 127) / 255, 0, 100);
+    }
+}

--- a/src/Hex1b/Sixel/SixelParser.cs
+++ b/src/Hex1b/Sixel/SixelParser.cs
@@ -2,18 +2,43 @@ using Hex1b.Tokens;
 
 namespace Hex1b.Sixel;
 
-internal enum SixelParseOutcome
+/// <summary>
+/// The authoritative outcome of parsing a Sixel DCS sequence.
+/// </summary>
+/// <remarks>
+/// Automation code can use this to assert whether a graphic parsed cleanly or
+/// degraded, without inspecting raw diagnostics. See
+/// <see cref="Hex1b.SixelData.Outcome"/> and <see cref="Hex1b.SixelData.Diagnostics"/>
+/// for the explanatory detail behind a non-<see cref="Complete"/> outcome.
+/// </remarks>
+public enum SixelParseOutcome
 {
+    /// <summary>The sequence parsed to completion with no downgrades.</summary>
     Complete,
+
+    /// <summary>The upstream stream cancelled the sequence before it terminated.</summary>
     Cancelled,
+
+    /// <summary>The sequence was structurally invalid.</summary>
     Malformed,
+
+    /// <summary>The sequence parsed, but bounded retention limits downgraded it.</summary>
     LimitDowngraded,
+
+    /// <summary>The DCS introducer was not an accepted Sixel form.</summary>
     Rejected,
 }
 
-internal enum SixelBackgroundMode
+/// <summary>
+/// Whether unpainted Sixel pixels resolve to the captured background color or
+/// remain transparent.
+/// </summary>
+public enum SixelBackgroundMode
 {
+    /// <summary>Unpainted pixels resolve to the captured background color.</summary>
     Opaque,
+
+    /// <summary>Unpainted pixels remain transparent.</summary>
     Transparent,
 }
 
@@ -23,21 +48,52 @@ internal enum SixelColorSpace
     Rgb = 2,
 }
 
-internal enum SixelDiagnosticCode
+/// <summary>
+/// Explicit reasons a Sixel parse degraded or was annotated, surfaced via
+/// <see cref="SixelDiagnostic"/> on <see cref="Hex1b.SixelData.Diagnostics"/>.
+/// </summary>
+public enum SixelDiagnosticCode
 {
+    /// <summary>The DCS introducer is not an accepted Sixel form.</summary>
     RejectedIntroducer,
+
+    /// <summary>The header carried more parameters than the policy allows.</summary>
     ExcessiveHeaderParameters,
+
+    /// <summary>The pixel-aspect-ratio macro is not one this parser supports.</summary>
     UnsupportedAspectMacro,
+
+    /// <summary>A byte outside the accepted Sixel alphabet was encountered.</summary>
     InvalidByte,
+
+    /// <summary>A command ended before it was fully specified.</summary>
     IncompleteCommand,
+
+    /// <summary>A later command replaced an earlier, conflicting one.</summary>
     ReplacedCommand,
+
+    /// <summary>A command carried more parameters than the policy allows.</summary>
     ExcessiveCommandParameters,
+
+    /// <summary>A numeric parameter exceeded the implementation's coordinate limit.</summary>
     NumericLimitExceeded,
+
+    /// <summary>Geometry accumulation saturated at the coordinate limit.</summary>
     GeometrySaturated,
+
+    /// <summary>The raster attributes (DECGRA) command was invalid.</summary>
     InvalidRasterAttributes,
+
+    /// <summary>A palette definition or selection command was invalid.</summary>
     InvalidPaletteCommand,
+
+    /// <summary>A bounded metadata limit (e.g. palette entries) was exceeded.</summary>
     MetadataLimitExceeded,
+
+    /// <summary>Bounded command retention truncated the remaining sequence.</summary>
     CommandRetentionLimitExceeded,
+
+    /// <summary>The DCS sequence ended before a string terminator.</summary>
     UnterminatedSequence,
 }
 
@@ -49,19 +105,39 @@ internal enum SixelCommandKind
 
 internal readonly record struct SixelPoint(int X, int Y);
 
-internal readonly record struct SixelExtent(int Width, int Height)
+/// <summary>
+/// A width/height pixel extent.
+/// </summary>
+/// <param name="Width">The width, in pixels.</param>
+/// <param name="Height">The height, in pixels.</param>
+public readonly record struct SixelExtent(int Width, int Height)
 {
+    /// <summary>An empty (zero-size) extent.</summary>
     public static SixelExtent Empty { get; } = new(0, 0);
 }
 
-internal readonly record struct SixelBounds(int X, int Y, int Width, int Height)
+/// <summary>
+/// A pixel-space rectangle.
+/// </summary>
+/// <param name="X">The left offset, in pixels.</param>
+/// <param name="Y">The top offset, in pixels.</param>
+/// <param name="Width">The width, in pixels.</param>
+/// <param name="Height">The height, in pixels.</param>
+public readonly record struct SixelBounds(int X, int Y, int Width, int Height)
 {
+    /// <summary>An empty (zero-size) bounds.</summary>
     public static SixelBounds Empty { get; } = new(0, 0, 0, 0);
 
+    /// <summary>Gets whether this bounds has zero width or height.</summary>
     public bool IsEmpty => Width == 0 || Height == 0;
 }
 
-internal readonly record struct SixelAspectRatio(int Numerator, int Denominator);
+/// <summary>
+/// A pixel aspect ratio expressed as a numerator/denominator pair (DECGRA/DECSIXEL macro).
+/// </summary>
+/// <param name="Numerator">The vertical scale numerator.</param>
+/// <param name="Denominator">The vertical scale denominator.</param>
+public readonly record struct SixelAspectRatio(int Numerator, int Denominator);
 
 internal readonly record struct SixelHeader(
     int PixelAspectMacro,
@@ -94,7 +170,14 @@ internal readonly record struct SixelCommand(
     int RepeatCount,
     SixelPaletteCommand? Palette);
 
-internal readonly record struct SixelDiagnostic(
+/// <summary>
+/// A single explicit Sixel parse diagnostic explaining a degraded or annotated outcome.
+/// </summary>
+/// <param name="Code">The specific reason this diagnostic was raised.</param>
+/// <param name="Offset">The byte offset into the payload where the condition was observed.</param>
+/// <param name="Command">The offending command byte, when applicable.</param>
+/// <param name="Message">A human-readable explanation.</param>
+public readonly record struct SixelDiagnostic(
     SixelDiagnosticCode Code,
     long Offset,
     byte? Command,

--- a/src/Hex1b/Sixel/SixelPlacement.cs
+++ b/src/Hex1b/Sixel/SixelPlacement.cs
@@ -26,17 +26,33 @@ namespace Hex1b;
 /// existing placement's declared geometry. The painted crop window
 /// (<see cref="PaintedRowOffset"/>/<see cref="PaintedRowCount"/>/
 /// <see cref="PaintedColumnOffset"/>/<see cref="PaintedColumnCount"/>) may
-/// still shrink after creation via <see cref="ClipToCellRectangle"/> — always
+/// still shrink after creation via <c>ClipToCellRectangle</c> — always
 /// by intersecting the *current* painted rectangle with a new clip bound, so
 /// a row or column already cropped away can never resurface later regardless
 /// of operation order (scroll, resize, and history pruning all funnel through
 /// this same monotonic intersection). <see cref="Column"/> is likewise
-/// repositioned only via <see cref="WithPosition"/>, used by reflow when an
-/// anchor's wrapped-line position genuinely moves horizontally; ordinary
-/// scrolling and margin operations never touch it.
+/// repositioned only via internal reflow machinery, used when an anchor's
+/// wrapped-line position genuinely moves horizontally; ordinary scrolling and
+/// margin operations never touch it.
+/// </para>
+/// <para>
+/// This type deliberately omits KGP-only protocol concepts: no public
+/// image/placement IDs, no image-number addressing, no explicit delete
+/// selectors, no relative-placement graph, no Unicode placeholders, no
+/// z-index, and no chunked uploads. A placement's identity for automation
+/// purposes is its anchor position plus <see cref="Sequence"/> (for
+/// disambiguating overlapping placements created from identical content).
+/// </para>
+/// <para>
+/// Whether a placement was captured from the live viewport or from
+/// scrollback history is derived, not stored: a placement whose
+/// <see cref="Row"/> falls below <see cref="Hex1b.Automation.Hex1bTerminalSnapshot.ScrollbackLineCount"/>
+/// is a viewport placement, and one at or above it is a history placement —
+/// the same row-space unification <see cref="Hex1b.Automation.Hex1bTerminalSnapshot"/> uses for
+/// its text cell buffer.
 /// </para>
 /// </remarks>
-internal sealed class SixelPlacement
+public sealed class SixelPlacement
 {
     private readonly HashSet<int> _damagedCells;
     private SixelPixelBuffer? _visiblePixels;
@@ -103,77 +119,78 @@ internal sealed class SixelPlacement
     /// allocation. Also carries this image's logical/rendered/declared/painted
     /// extents, creation-time <see cref="Hex1b.Sixel.SixelCellMetrics"/>,
     /// background mode, aspect state, stable content identity, and protocol
-    /// diagnostics (see <see cref="SixelData.ParseResult"/> and
-    /// <see cref="SixelData.Raster"/>).
+    /// diagnostics (see <see cref="SixelData.Outcome"/>,
+    /// <see cref="SixelData.Diagnostics"/>, <see cref="SixelData.RasterStatus"/>,
+    /// and <see cref="SixelData.RasterDiagnostics"/>).
     /// </summary>
-    internal SixelData Image { get; }
+    public SixelData Image { get; }
 
     /// <summary>
     /// The anchor row (0-based, in the owning screen's local coordinate
     /// space). Mutable so scroll and history operations can shift it in place.
     /// </summary>
-    internal int Row { get; set; }
+    public int Row { get; internal set; }
 
     /// <summary>
     /// The anchor column. Ordinary scrolling and margin operations never
-    /// change this; only reflow (<see cref="WithPosition"/>) repositions it,
+    /// change this; only internal reflow machinery repositions it,
     /// when a wrapped line's anchor genuinely lands in a different column
     /// under the new width.
     /// </summary>
-    internal int Column { get; }
+    public int Column { get; }
 
     /// <summary>
     /// The unclipped occupied width, in cells, of the source geometry (the
     /// anchor + occupied cell span the issue requires each placement to
     /// retain, independent of how much of it actually painted).
     /// </summary>
-    internal int WidthInCells { get; }
+    public int WidthInCells { get; }
 
     /// <summary>
     /// The unclipped occupied height, in cells, of the source geometry.
     /// </summary>
-    internal int HeightInCells { get; }
+    public int HeightInCells { get; }
 
     /// <summary>
     /// Row offset (relative to <see cref="Row"/>) where the visible/painted
     /// crop begins. Stored relative to the anchor so shifting <see cref="Row"/>
     /// during scrolling automatically keeps the crop consistent.
     /// </summary>
-    internal int PaintedRowOffset { get; }
+    public int PaintedRowOffset { get; }
 
     /// <summary>
     /// Number of rows actually painted: the visible crop clipped to the
     /// scrolling region/page bounds in effect when the placement was created.
     /// </summary>
-    internal int PaintedRowCount { get; }
+    public int PaintedRowCount { get; }
 
     /// <summary>
     /// Column offset (relative to <see cref="Column"/>) where the
     /// visible/painted crop begins.
     /// </summary>
-    internal int PaintedColumnOffset { get; }
+    public int PaintedColumnOffset { get; }
 
     /// <summary>
     /// Number of columns actually painted.
     /// </summary>
-    internal int PaintedColumnCount { get; }
+    public int PaintedColumnCount { get; }
 
     /// <summary>
     /// Monotonic write sequence used to order overlapping placements (later
     /// sequence paints on top), and to disambiguate otherwise-identical
     /// placements created from the same content.
     /// </summary>
-    internal long Sequence { get; }
+    public long Sequence { get; }
 
     /// <summary>When this placement was created.</summary>
-    internal DateTimeOffset CreatedAt { get; }
+    public DateTimeOffset CreatedAt { get; }
 
     /// <summary>
     /// <see langword="true"/> when the authoritative rasterizer could not
     /// produce pixels for this placement's image (a geometry-only outcome).
     /// Geometry-only placements are always retained, never silently dropped.
     /// </summary>
-    internal bool IsGeometryOnly => Image.Raster.Status == SixelRasterStatus.GeometryOnly;
+    public bool IsGeometryOnly => Image.RasterStatus == SixelRasterStatus.GeometryOnly;
 
     /// <summary>
     /// <see langword="true"/> when this placement paints at least one cell.
@@ -181,22 +198,22 @@ internal sealed class SixelPlacement
     /// time can have a zero-size painted crop while still occupying its
     /// declared cell span.
     /// </summary>
-    internal bool HasPaintedExtent => PaintedRowCount > 0 && PaintedColumnCount > 0;
+    public bool HasPaintedExtent => PaintedRowCount > 0 && PaintedColumnCount > 0;
 
     /// <summary>Absolute top row of the painted/visible crop.</summary>
-    internal int PaintedTop => Row + PaintedRowOffset;
+    public int PaintedTop => Row + PaintedRowOffset;
 
     /// <summary>Absolute bottom row (inclusive) of the painted/visible crop.</summary>
-    internal int PaintedBottom => PaintedTop + PaintedRowCount - 1;
+    public int PaintedBottom => PaintedTop + PaintedRowCount - 1;
 
     /// <summary>Absolute left column of the painted/visible crop.</summary>
-    internal int PaintedLeft => Column + PaintedColumnOffset;
+    public int PaintedLeft => Column + PaintedColumnOffset;
 
     /// <summary>Absolute right column (inclusive) of the painted/visible crop.</summary>
-    internal int PaintedRight => PaintedLeft + PaintedColumnCount - 1;
+    public int PaintedRight => PaintedLeft + PaintedColumnCount - 1;
 
     /// <summary>Whether the painted/visible crop of this placement covers the given cell.</summary>
-    internal bool CoversCell(int row, int column) =>
+    public bool CoversCell(int row, int column) =>
         HasPaintedExtent
         && row >= PaintedTop && row <= PaintedBottom
         && column >= PaintedLeft && column <= PaintedRight
@@ -206,7 +223,7 @@ internal sealed class SixelPlacement
     /// Gets whether this placement still has at least one painted cell that has
     /// not been destructively damaged.
     /// </summary>
-    internal bool HasVisiblePaintedCells =>
+    public bool HasVisiblePaintedCells =>
         HasPaintedExtent && _damagedCells.Count < PaintedRowCount * PaintedColumnCount;
 
     /// <summary>
@@ -226,7 +243,7 @@ internal sealed class SixelPlacement
     /// <summary>
     /// Materializes this placement's pixels with damaged cells made transparent.
     /// </summary>
-    internal SixelPixelBuffer? GetVisiblePixels()
+    public SixelPixelBuffer? GetVisiblePixels()
     {
         var pixels = Image.GetPixels();
         if (pixels is null || _damagedCells.Count == 0)
@@ -265,6 +282,62 @@ internal sealed class SixelPlacement
         _visiblePixels = visible;
         return visible;
     }
+
+    /// <summary>
+    /// Materializes exactly the pixels within this placement's painted/visible
+    /// crop rectangle (<see cref="PaintedRowOffset"/>/<see cref="PaintedRowCount"/>/
+    /// <see cref="PaintedColumnOffset"/>/<see cref="PaintedColumnCount"/>), with
+    /// damaged cells made transparent.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="GetVisiblePixels"/> — which always returns the full
+    /// declared image, damage-masked but uncropped — this maps the placement's
+    /// cell-space crop window into the underlying pixel buffer using the same
+    /// <see cref="Hex1b.Sixel.SixelCellMetrics"/>-based rounding
+    /// <see cref="GetVisiblePixels"/> uses for damage, so exporters render
+    /// exactly what the terminal shows even when scrolling, margin operations,
+    /// or history eviction have cropped away part of the originally declared
+    /// image. Consumers that need the exact source-crop pixels (SVG/HTML
+    /// export, automation assertions) should use this method rather than
+    /// re-deriving the crop themselves.
+    /// </remarks>
+    /// <returns>
+    /// The cropped pixel buffer, or <see langword="null"/> when the image has
+    /// no decoded raster (geometry-only) or the painted crop is empty.
+    /// </returns>
+    public SixelPixelBuffer? GetPaintedPixels()
+    {
+        var full = GetVisiblePixels();
+        if (full is null || !HasPaintedExtent)
+            return null;
+
+        if (PaintedRowOffset == 0 && PaintedColumnOffset == 0 &&
+            PaintedRowCount == HeightInCells && PaintedColumnCount == WidthInCells)
+        {
+            // Nothing cropped away: avoid an unnecessary copy.
+            return full;
+        }
+
+        var pixelLeft = Math.Clamp((int)Math.Floor(PaintedColumnOffset * Image.CellMetrics.SafeWidth), 0, full.Width);
+        var pixelRight = Math.Clamp((int)Math.Ceiling((PaintedColumnOffset + PaintedColumnCount) * Image.CellMetrics.SafeWidth), 0, full.Width);
+        var pixelTop = Math.Clamp((int)Math.Floor(PaintedRowOffset * Image.CellMetrics.SafeHeight), 0, full.Height);
+        var pixelBottom = Math.Clamp((int)Math.Ceiling((PaintedRowOffset + PaintedRowCount) * Image.CellMetrics.SafeHeight), 0, full.Height);
+
+        var width = Math.Max(0, pixelRight - pixelLeft);
+        var height = Math.Max(0, pixelBottom - pixelTop);
+        if (width == 0 || height == 0)
+            return null;
+
+        var cropped = new SixelPixelBuffer(width, height);
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+                cropped[x, y] = full[pixelLeft + x, pixelTop + y];
+        }
+
+        return cropped;
+    }
+
 
     /// <summary>Creates a copy of this placement repositioned to <paramref name="row"/>.</summary>
     /// <remarks>
@@ -422,7 +495,13 @@ internal sealed class SixelPlacement
         return filtered ?? _damagedCells;
     }
 
-    private bool IsCellDamaged(int row, int column) => _damagedCells.Contains(CellKey(row, column));
+    /// <summary>
+    /// Gets whether text has destructively overwritten this cell's pixels
+    /// since the placement was created.
+    /// </summary>
+    /// <param name="row">The absolute row to check.</param>
+    /// <param name="column">The absolute column to check.</param>
+    public bool IsCellDamaged(int row, int column) => _damagedCells.Contains(CellKey(row, column));
 
     private int CellKey(int row, int column) => ((row - Row) * WidthInCells) + (column - Column);
 }

--- a/src/Hex1b/Sixel/SixelRasterizer.cs
+++ b/src/Hex1b/Sixel/SixelRasterizer.cs
@@ -6,11 +6,16 @@ namespace Hex1b.Sixel;
 /// <summary>
 /// Describes whether a rasterization produced pixels or only geometry.
 /// </summary>
-internal enum SixelRasterStatus
+/// <remarks>
+/// A <see cref="GeometryOnly"/> outcome means the authoritative rasterizer
+/// explicitly refused pixel allocation (a bounded resource limit, or a parse
+/// outcome that carried no rasterable data), not a bug: the placement is
+/// still retained with its declared geometry and explanatory
+/// <see cref="Hex1b.SixelData.RasterDiagnostics"/>, never silently dropped.
+/// </remarks>
+public enum SixelRasterStatus
 {
-    /// <summary>
-    /// Pixels are available through <see cref="SixelRasterResult.Image"/>.
-    /// </summary>
+    /// <summary>Pixels are available through <see cref="Hex1b.SixelData.GetPixels"/>.</summary>
     Rasterized,
 
     /// <summary>
@@ -21,24 +26,44 @@ internal enum SixelRasterStatus
 }
 
 /// <summary>
-/// Explicit reasons a rasterization degraded or annotated its result.
+/// Explicit reasons a rasterization degraded or annotated its result,
+/// surfaced via <see cref="SixelRasterDiagnostic"/> on
+/// <see cref="Hex1b.SixelData.RasterDiagnostics"/>.
 /// </summary>
-internal enum SixelRasterDiagnosticCode
+public enum SixelRasterDiagnosticCode
 {
+    /// <summary>The parse outcome (cancelled/malformed/rejected) carried no complete graphic to rasterize.</summary>
     ParseOutcomeNotRasterable,
+
+    /// <summary>Bounded command retention truncated the sequence, leaving only geometry and palette state.</summary>
     CommandsIncomplete,
+
+    /// <summary>The sequence produced no logical raster extent.</summary>
     NoRasterableExtent,
+
+    /// <summary>The logical raster extent exceeded the implementation coordinate limit.</summary>
     RasterExtentOverflow,
+
+    /// <summary>The logical pixel count exceeded the configured raster pixel limit.</summary>
     RasterPixelLimitExceeded,
+
+    /// <summary>The number of requested pixel writes exceeded the configured raster operation limit.</summary>
     RasterOperationLimitExceeded,
+
+    /// <summary>A tiled-raster resource limit was exceeded.</summary>
     RasterTileLimitExceeded,
+
+    /// <summary>A referenced color register fell outside the compatibility policy's accepted range.</summary>
     ColorRegisterOutOfPolicy,
 }
 
 /// <summary>
-/// A single explicit rasterization diagnostic.
+/// A single explicit rasterization diagnostic explaining a geometry-only
+/// downgrade or other annotated raster outcome.
 /// </summary>
-internal readonly record struct SixelRasterDiagnostic(
+/// <param name="Code">The specific reason this diagnostic was raised.</param>
+/// <param name="Message">A human-readable explanation.</param>
+public readonly record struct SixelRasterDiagnostic(
     SixelRasterDiagnosticCode Code,
     string Message);
 
@@ -51,7 +76,7 @@ internal readonly record struct SixelRasterDiagnostic(
 /// <param name="Data">The unscaled extent reached by data commands.</param>
 /// <param name="Painted">The unscaled bounds of explicitly painted pixels.</param>
 /// <param name="Aspect">The effective pixel aspect ratio.</param>
-internal readonly record struct SixelRasterExtents(
+public readonly record struct SixelRasterExtents(
     SixelExtent Logical,
     SixelExtent Rendered,
     SixelExtent Declared,
@@ -59,6 +84,7 @@ internal readonly record struct SixelRasterExtents(
     SixelBounds Painted,
     SixelAspectRatio Aspect)
 {
+    /// <summary>An empty set of extents, using the default 2:1 aspect ratio.</summary>
     public static SixelRasterExtents Empty { get; } = new(
         SixelExtent.Empty,
         SixelExtent.Empty,

--- a/src/Hex1b/SixelData.cs
+++ b/src/Hex1b/SixelData.cs
@@ -55,9 +55,33 @@ public sealed class SixelData
     /// <summary>
     /// Gets the content hash used for deduplication.
     /// </summary>
-    internal byte[] ContentHash { get; }
+    /// <remarks>
+    /// Identical payloads that also capture the same background and palette
+    /// state produce the same hash, which content-addressed replay and
+    /// serialization can use to reference this image without repeating its
+    /// pixel payload.
+    /// </remarks>
+    public byte[] ContentHash { get; }
 
     internal SixelParseResult ParseResult { get; }
+
+    /// <summary>
+    /// Gets the authoritative parser outcome for this image's payload.
+    /// </summary>
+    public SixelParseOutcome Outcome => ParseResult.Outcome;
+
+    /// <summary>
+    /// Gets the explicit parser diagnostics explaining any downgraded or
+    /// annotated outcome. Empty when <see cref="Outcome"/> is
+    /// <see cref="SixelParseOutcome.Complete"/> with nothing to report.
+    /// </summary>
+    public IReadOnlyList<SixelDiagnostic> Diagnostics => ParseResult.Diagnostics;
+
+    /// <summary>
+    /// Gets whether unpainted pixels resolve to the captured background color
+    /// or remain transparent.
+    /// </summary>
+    public SixelBackgroundMode BackgroundMode => ParseResult.Header.BackgroundMode;
 
     /// <summary>
     /// Gets the authoritative bounded rasterization of <see cref="ParseResult"/>.
@@ -80,6 +104,31 @@ public sealed class SixelData
             }
         }
     }
+
+    /// <summary>
+    /// Gets whether the authoritative rasterizer produced pixels for this
+    /// image, or explicitly refused allocation (a geometry-only outcome).
+    /// </summary>
+    /// <remarks>
+    /// A geometry-only image still carries its declared/logical extents and
+    /// <see cref="RasterDiagnostics"/> explaining the downgrade; it is never
+    /// silently indistinguishable from a fully rasterized one.
+    /// </remarks>
+    public SixelRasterStatus RasterStatus => Raster.Status;
+
+    /// <summary>
+    /// Gets the explicit rasterizer diagnostics explaining a geometry-only
+    /// outcome or other annotated raster result. Empty when
+    /// <see cref="RasterStatus"/> is <see cref="SixelRasterStatus.Rasterized"/>
+    /// with nothing to report.
+    /// </summary>
+    public IReadOnlyList<SixelRasterDiagnostic> RasterDiagnostics => Raster.Diagnostics;
+
+    /// <summary>
+    /// Gets this image's logical/rendered/declared/data/painted extents and
+    /// effective pixel aspect ratio.
+    /// </summary>
+    public SixelRasterExtents Extents => Raster.Extents;
 
     internal SixelData(
         string payload,
@@ -122,13 +171,13 @@ public sealed class SixelData
     }
 
     /// <summary>
-    /// Gets the protocol cell metrics captured when this placement was created.
+    /// Gets the protocol cell metrics captured when this image was created.
     /// </summary>
     /// <remarks>
     /// Metrics are captured once so a later metric change cannot retroactively
-    /// alter the occupancy already recorded for this placement.
+    /// alter the occupancy already recorded for a placement of this image.
     /// </remarks>
-    internal SixelCellMetrics CellMetrics { get; }
+    public SixelCellMetrics CellMetrics { get; }
 
     /// <summary>
     /// Gets the cell span for this sixel using the specified cell metrics.

--- a/tests/Hex1b.Tests/Hmp1/Hmp1SixelRecordingTests.cs
+++ b/tests/Hex1b.Tests/Hmp1/Hmp1SixelRecordingTests.cs
@@ -1,0 +1,479 @@
+// Copyright (c) Hex1b contributors. Licensed under the MIT license.
+
+using System.Text;
+using Hex1b.Sixel;
+using Hex1b.Tests.Sixel;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests.Hmp1;
+
+/// <summary>
+/// Coverage for <see cref="Hmp1SixelRecording"/>: the versioned, explicit
+/// binary Sixel state representation used to record/serialize/replay/compare
+/// complete Sixel state without a live upstream terminal. Every documented
+/// <see cref="Hmp1SixelRecordingFailureReason"/> gets its own explicit,
+/// deliberately triggered test -- this format must fail loudly (no broad
+/// catches, no success-shaped fallback) for unsupported versions,
+/// malformed/truncated records, missing image references, invalid geometry,
+/// and resource-limit violations.
+/// </summary>
+[TestClass]
+public class Hmp1SixelRecordingTests
+{
+    [TestMethod]
+    public void RoundTrip_WithSinglePlacement_ReconstructsAllRecordedFields()
+    {
+        using var producer = CreateHeadlessTerminal();
+        var fixture = new SixelFixture(
+            "recording-single-band",
+            "One-band red probe for recording round-trip coverage.",
+            "q#1;2;100;0;0#1!11~"u8.ToArray());
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b[3;5H" + Encoding.ASCII.GetString(fixture.StandardBytes)));
+
+        using var producerSnapshot = producer.CreateSnapshot();
+        var placement = TestSeq.Single(producerSnapshot.SixelPlacements);
+
+        var recorded = Hmp1SixelRecording.Serialize(producerSnapshot.SixelPlacements);
+        var decoded = Hmp1SixelRecording.Deserialize(recorded);
+
+        Assert.AreEqual(Hmp1SixelRecording.CurrentVersion, decoded.Version);
+        var image = TestSeq.Single(decoded.Images);
+        var recordedPlacement = TestSeq.Single(decoded.Placements);
+
+        Assert.IsFalse(image.IsGeometryOnly);
+        Assert.AreEqual(placement.Image.WidthInCells, image.WidthInCells);
+        Assert.AreEqual(placement.Image.HeightInCells, image.HeightInCells);
+        Assert.AreEqual(SixelRasterStatus.Rasterized, image.RasterStatus);
+        CollectionAssert.AreEqual(placement.Image.ContentHash, image.ContentHash);
+
+        Assert.AreEqual(0, recordedPlacement.ImageIndex);
+        Assert.AreEqual(placement.Row, recordedPlacement.Row);
+        Assert.AreEqual(placement.Column, recordedPlacement.Column);
+        Assert.AreEqual(placement.WidthInCells, recordedPlacement.WidthInCells);
+        Assert.AreEqual(placement.HeightInCells, recordedPlacement.HeightInCells);
+        Assert.AreEqual(placement.PaintedRowOffset, recordedPlacement.PaintedRowOffset);
+        Assert.AreEqual(placement.PaintedRowCount, recordedPlacement.PaintedRowCount);
+        Assert.AreEqual(placement.PaintedColumnOffset, recordedPlacement.PaintedColumnOffset);
+        Assert.AreEqual(placement.PaintedColumnCount, recordedPlacement.PaintedColumnCount);
+        Assert.AreEqual(placement.Sequence, recordedPlacement.Sequence);
+        Assert.IsEmpty(recordedPlacement.DamagedCells);
+    }
+
+    [TestMethod]
+    public void RoundTrip_WithMultiplePlacementsSharingOneImage_DeduplicatesImageTable()
+    {
+        using var producer = CreateHeadlessTerminal();
+        var fixture = new SixelFixture(
+            "recording-shared-image",
+            "Small band replayed at two anchors so both placements reference the same image.",
+            "q#1;2;100;0;0#1!2~"u8.ToArray());
+
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b[1;1H" + Encoding.ASCII.GetString(fixture.StandardBytes)));
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b[3;1H" + Encoding.ASCII.GetString(fixture.StandardBytes)));
+
+        using var producerSnapshot = producer.CreateSnapshot();
+        Assert.HasCount(2, producerSnapshot.SixelPlacements);
+
+        var recorded = Hmp1SixelRecording.Serialize(producerSnapshot.SixelPlacements);
+        var decoded = Hmp1SixelRecording.Deserialize(recorded);
+
+        // Identical pixel content -> a single deduplicated image table entry,
+        // even though two independent placements reference it.
+        Assert.HasCount(1, decoded.Images);
+        Assert.HasCount(2, decoded.Placements);
+        Assert.IsTrue(decoded.Placements.All(p => p.ImageIndex == 0));
+    }
+
+    [TestMethod]
+    public void RoundTrip_WithDamagedCell_PreservesAnchorRelativeDamageOffsets()
+    {
+        using var producer = CreateHeadlessTerminal();
+        var fixture = new SixelFixture(
+            "recording-damage-band",
+            "A two-cell-wide band whose origin cell is later overwritten with text.",
+            "q#1;2;100;0;0#1!11~"u8.ToArray());
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b[2;3H" + Encoding.ASCII.GetString(fixture.StandardBytes)));
+        // Overwrite only the origin cell with plain text, damaging it.
+        producer.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[2;3HX"));
+
+        using var producerSnapshot = producer.CreateSnapshot();
+        var placement = TestSeq.Single(producerSnapshot.SixelPlacements);
+        Assert.IsTrue(placement.IsCellDamaged(placement.Row, placement.Column));
+
+        var recorded = Hmp1SixelRecording.Serialize(producerSnapshot.SixelPlacements);
+        var decoded = Hmp1SixelRecording.Deserialize(recorded);
+        var recordedPlacement = TestSeq.Single(decoded.Placements);
+
+        var damaged = TestSeq.Single(recordedPlacement.DamagedCells);
+        Assert.AreEqual((0, 0), damaged);
+    }
+
+    [TestMethod]
+    public void RoundTrip_WithGeometryOnlyPlacement_PreservesOutcomeAndOriginalPayload()
+    {
+        using var producer = CreateHeadlessTerminal();
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1bP0;1q\"1;1;999999999;999999999#1@\x1b\\"));
+
+        using var producerSnapshot = producer.CreateSnapshot();
+        var placement = TestSeq.Single(producerSnapshot.SixelPlacements);
+        Assert.IsTrue(placement.IsGeometryOnly);
+
+        var recorded = Hmp1SixelRecording.Serialize(producerSnapshot.SixelPlacements);
+        var decoded = Hmp1SixelRecording.Deserialize(recorded);
+        var image = TestSeq.Single(decoded.Images);
+
+        Assert.IsTrue(image.IsGeometryOnly);
+        Assert.AreEqual(SixelRasterStatus.GeometryOnly, image.RasterStatus);
+        Assert.AreEqual(placement.Image.Payload, image.Payload);
+    }
+
+    [TestMethod]
+    public void BuildReplayEscapeSequence_FedToFreshTerminal_ReconstructsEquivalentGeometryAndPixels()
+    {
+        using var producer = CreateHeadlessTerminal();
+        var fixture = new SixelFixture(
+            "recording-replay-band",
+            "One-band red probe fed through the recorded replay escape sequence.",
+            "q#1;2;100;0;0#1!11~"u8.ToArray());
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b[3;5H" + Encoding.ASCII.GetString(fixture.StandardBytes)));
+
+        using var producerSnapshot = producer.CreateSnapshot();
+        var recorded = Hmp1SixelRecording.Serialize(producerSnapshot.SixelPlacements);
+        var decoded = Hmp1SixelRecording.Deserialize(recorded);
+        var replaySequence = decoded.BuildReplayEscapeSequence();
+
+        using var viewer = CreateHeadlessTerminal();
+        // Fed through the same tokenizer/apply path a live terminal uses for
+        // incoming output, so replay is verified against the same
+        // authoritative parser/raster invariants live processing uses.
+        viewer.ApplyTokens(AnsiTokenizer.Tokenize(replaySequence));
+
+        using var viewerSnapshot = viewer.CreateSnapshot();
+        var producerPlacement = TestSeq.Single(producerSnapshot.SixelPlacements);
+        var viewerPlacement = TestSeq.Single(viewerSnapshot.SixelPlacements);
+
+        Assert.AreEqual(producerPlacement.Row, viewerPlacement.Row);
+        Assert.AreEqual(producerPlacement.Column, viewerPlacement.Column);
+        Assert.AreEqual(producerPlacement.WidthInCells, viewerPlacement.WidthInCells);
+        Assert.AreEqual(producerPlacement.HeightInCells, viewerPlacement.HeightInCells);
+
+        AssertPixelsEqual(producerPlacement.Image, viewerPlacement.Image);
+    }
+
+    [TestMethod]
+    public void RoundTrip_WithHistoryAndViewportPlacements_PreservesTheirDistinctUnifiedRowOffsets()
+    {
+        using var producer = Hex1bTerminal.CreateBuilder()
+            .WithDimensions(8, 3)
+            .WithWorkload(new NullWorkloadAdapter())
+            .WithScrollback(3)
+            .WithHeadless(new TerminalCapabilities { SupportsSixel = true, SupportsTrueColor = true })
+            .Build();
+
+        var historyFixture = new SixelFixture(
+            "recording-history-band",
+            "A red band painted at row 0, later scrolled into history.",
+            "q#1;2;100;0;0#1~"u8.ToArray());
+        var viewportFixture = new SixelFixture(
+            "recording-viewport-band",
+            "A green band painted on the live viewport after the scroll.",
+            "q#2;2;0;100;0#2~"u8.ToArray());
+
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b[1;1H" + Encoding.ASCII.GetString(historyFixture.StandardBytes)));
+        // Cursor on the bottom row: a plain LF scrolls the whole screen up by
+        // one, pushing the row-0 placement into scrollback.
+        producer.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[3;1H\n"));
+        // Paint on the *middle* row (not the new bottom row): painting a
+        // 1-row-tall placement on the physical last row would itself trigger
+        // an additional proactive pre-scroll-for-cursor-room scroll, pushing
+        // a second (empty) row into history and shifting this test's
+        // intended single-history-row setup out from under it.
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b[2;1H" + Encoding.ASCII.GetString(viewportFixture.StandardBytes)));
+
+        using var producerSnapshot = producer.CreateSnapshot(scrollbackLines: 1);
+        Assert.HasCount(2, producerSnapshot.SixelPlacements);
+
+        var recorded = Hmp1SixelRecording.Serialize(producerSnapshot.SixelPlacements);
+        var decoded = Hmp1SixelRecording.Deserialize(recorded);
+        Assert.HasCount(2, decoded.Placements);
+        Assert.HasCount(2, decoded.Images);
+
+        var producerByRow = producerSnapshot.SixelPlacements.OrderBy(p => p.Row).ToList();
+        var decodedByRow = decoded.Placements.OrderBy(p => p.Row).ToList();
+
+        // The history placement's unified row (0) and the viewport
+        // placement's unified row (historyCount + its live row) must both
+        // survive the round trip distinctly -- recording never collapses
+        // scrollback and live-viewport placements into the same offset.
+        Assert.AreEqual(producerByRow[0].Row, decodedByRow[0].Row);
+        Assert.AreEqual(producerByRow[1].Row, decodedByRow[1].Row);
+        Assert.IsTrue(decodedByRow[0].Row < decodedByRow[1].Row);
+    }
+
+    [TestMethod]
+    public void RoundTrip_CapturedWhileOnAlternateScreen_RecordsOnlyTheActiveScreensPlacement_AndMainScreenIndependently()
+    {
+        using var producer = CreateHeadlessTerminal();
+        var mainFixture = new SixelFixture(
+            "recording-main-screen-band",
+            "A red band painted on the main screen.",
+            "q#1;2;100;0;0#1~"u8.ToArray());
+        var alternateFixture = new SixelFixture(
+            "recording-alternate-screen-band",
+            "A green band painted only on the alternate screen.",
+            "q#2;2;0;100;0#2~"u8.ToArray());
+
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b[1;1H" + Encoding.ASCII.GetString(mainFixture.StandardBytes)));
+
+        producer.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[?1049h"));
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b[1;1H" + Encoding.ASCII.GetString(alternateFixture.StandardBytes)));
+
+        using var alternateSnapshot = producer.CreateSnapshot();
+        Assert.IsTrue(alternateSnapshot.InAlternateScreen);
+        var alternatePlacement = TestSeq.Single(alternateSnapshot.SixelPlacements);
+        Assert.Contains("0;100;0", alternatePlacement.Image.Payload);
+
+        var alternateRecorded = Hmp1SixelRecording.Serialize(alternateSnapshot.SixelPlacements);
+        var alternateDecoded = Hmp1SixelRecording.Deserialize(alternateRecorded);
+        Assert.Contains("0;100;0", TestSeq.Single(alternateDecoded.Images).Payload);
+
+        using var alternateViewer = CreateHeadlessTerminal();
+        alternateViewer.ApplyTokens(AnsiTokenizer.Tokenize(alternateDecoded.BuildReplayEscapeSequence()));
+        using var alternateViewerSnapshot = alternateViewer.CreateSnapshot();
+        var alternateViewerPlacement = TestSeq.Single(alternateViewerSnapshot.SixelPlacements);
+        Assert.AreEqual(alternatePlacement.Row, alternateViewerPlacement.Row);
+        Assert.AreEqual(alternatePlacement.Column, alternateViewerPlacement.Column);
+        AssertPixelsEqual(alternatePlacement.Image, alternateViewerPlacement.Image);
+
+        // Switching back to the main screen and recording+replaying *that*
+        // snapshot independently reconstructs the main screen's own,
+        // different graphic -- screen switching never leaks or conflates the
+        // two screens' placement state through the recording format.
+        producer.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[?1049l"));
+        using var mainSnapshot = producer.CreateSnapshot();
+        Assert.IsFalse(mainSnapshot.InAlternateScreen);
+        var mainPlacement = TestSeq.Single(mainSnapshot.SixelPlacements);
+        Assert.Contains("100;0;0", mainPlacement.Image.Payload);
+
+        var mainRecorded = Hmp1SixelRecording.Serialize(mainSnapshot.SixelPlacements);
+        var mainDecoded = Hmp1SixelRecording.Deserialize(mainRecorded);
+        Assert.Contains("100;0;0", TestSeq.Single(mainDecoded.Images).Payload);
+
+        using var mainViewer = CreateHeadlessTerminal();
+        mainViewer.ApplyTokens(AnsiTokenizer.Tokenize(mainDecoded.BuildReplayEscapeSequence()));
+        using var mainViewerSnapshot = mainViewer.CreateSnapshot();
+        AssertPixelsEqual(mainPlacement.Image, TestSeq.Single(mainViewerSnapshot.SixelPlacements).Image);
+    }
+
+    [TestMethod]
+    public void Deserialize_WithWrongMagicMarker_ThrowsMalformed()
+    {
+        var bytes = new byte[16];
+        Encoding.ASCII.GetBytes("XXXX").CopyTo(bytes, 0);
+
+        var ex = Assert.ThrowsExactly<Hmp1SixelRecordingException>(
+            () => Hmp1SixelRecording.Deserialize(bytes));
+        Assert.AreEqual(Hmp1SixelRecordingFailureReason.Malformed, ex.Reason);
+    }
+
+    [TestMethod]
+    public void Deserialize_WithTruncatedData_ThrowsTruncated()
+    {
+        using var producer = CreateHeadlessTerminal();
+        var fixture = new SixelFixture(
+            "recording-truncation-probe",
+            "One-band probe whose serialized recording gets truncated for this test.",
+            "q#1;2;100;0;0#1!11~"u8.ToArray());
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b[1;1H" + Encoding.ASCII.GetString(fixture.StandardBytes)));
+
+        using var producerSnapshot = producer.CreateSnapshot();
+        var recorded = Hmp1SixelRecording.Serialize(producerSnapshot.SixelPlacements);
+        var truncated = recorded[..^8];
+
+        var ex = Assert.ThrowsExactly<Hmp1SixelRecordingException>(
+            () => Hmp1SixelRecording.Deserialize(truncated));
+        Assert.AreEqual(Hmp1SixelRecordingFailureReason.Truncated, ex.Reason);
+    }
+
+    [TestMethod]
+    public void Deserialize_WithUnsupportedVersion_ThrowsUnsupportedVersion()
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true))
+        {
+            writer.Write("SXRC"u8.ToArray());
+            writer.Write(Hmp1SixelRecording.CurrentVersion + 1);
+            writer.Write(0); // placementCount
+            writer.Write(0); // imageCount
+        }
+
+        var ex = Assert.ThrowsExactly<Hmp1SixelRecordingException>(
+            () => Hmp1SixelRecording.Deserialize(stream.ToArray()));
+        Assert.AreEqual(Hmp1SixelRecordingFailureReason.UnsupportedVersion, ex.Reason);
+    }
+
+    [TestMethod]
+    public void Deserialize_WithPlacementReferencingMissingImageIndex_ThrowsMissingImageReference()
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true))
+        {
+            writer.Write("SXRC"u8.ToArray());
+            writer.Write(Hmp1SixelRecording.CurrentVersion);
+            writer.Write(1); // placementCount
+            writer.Write(0); // imageCount -- no images at all.
+
+            // One placement referencing image index 0, which does not exist.
+            writer.Write(0); // imageIndex
+            writer.Write(0); // row
+            writer.Write(0); // column
+            writer.Write(1); // widthInCells
+            writer.Write(1); // heightInCells
+            writer.Write(0); // paintedRowOffset
+            writer.Write(1); // paintedRowCount
+            writer.Write(0); // paintedColumnOffset
+            writer.Write(1); // paintedColumnCount
+            writer.Write(0L); // sequence
+            writer.Write(0L); // createdAtUnixMs
+            writer.Write(0); // damagedCellCount
+        }
+
+        var ex = Assert.ThrowsExactly<Hmp1SixelRecordingException>(
+            () => Hmp1SixelRecording.Deserialize(stream.ToArray()));
+        Assert.AreEqual(Hmp1SixelRecordingFailureReason.MissingImageReference, ex.Reason);
+    }
+
+    [TestMethod]
+    public void Deserialize_WithNonPositiveImageCellDimension_ThrowsInvalidGeometry()
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true))
+        {
+            writer.Write("SXRC"u8.ToArray());
+            writer.Write(Hmp1SixelRecording.CurrentVersion);
+            writer.Write(0); // placementCount
+            writer.Write(1); // imageCount
+
+            // One image declaring a non-positive width in cells.
+            writer.Write(new byte[32]); // contentHash
+            writer.Write(false); // isGeometryOnly
+            writer.Write(1); // declaredPixelWidth
+            writer.Write(1); // declaredPixelHeight
+            writer.Write(0); // widthInCells -- invalid: must be positive.
+            writer.Write(1); // heightInCells
+            writer.Write((byte)SixelRasterStatus.Rasterized);
+            writer.Write(0); // payloadLength
+        }
+
+        var ex = Assert.ThrowsExactly<Hmp1SixelRecordingException>(
+            () => Hmp1SixelRecording.Deserialize(stream.ToArray()));
+        Assert.AreEqual(Hmp1SixelRecordingFailureReason.InvalidGeometry, ex.Reason);
+    }
+
+    [TestMethod]
+    public void Deserialize_WithPayloadLengthExceedingLimit_ThrowsResourceLimitExceeded()
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true))
+        {
+            writer.Write("SXRC"u8.ToArray());
+            writer.Write(Hmp1SixelRecording.CurrentVersion);
+            writer.Write(0); // placementCount
+            writer.Write(1); // imageCount
+
+            writer.Write(new byte[32]); // contentHash
+            writer.Write(false); // isGeometryOnly
+            writer.Write(1); // declaredPixelWidth
+            writer.Write(1); // declaredPixelHeight
+            writer.Write(1); // widthInCells
+            writer.Write(1); // heightInCells
+            writer.Write((byte)SixelRasterStatus.Rasterized);
+            writer.Write(int.MaxValue); // payloadLength -- declared far beyond the limit.
+            // No payload bytes follow: the length check must fail before any
+            // attempt to read that much data.
+        }
+
+        var ex = Assert.ThrowsExactly<Hmp1SixelRecordingException>(
+            () => Hmp1SixelRecording.Deserialize(stream.ToArray()));
+        Assert.AreEqual(Hmp1SixelRecordingFailureReason.ResourceLimitExceeded, ex.Reason);
+    }
+
+    [TestMethod]
+    public void Serialize_WithPlacementCountExceedingLimit_ThrowsResourceLimitExceeded()
+    {
+        using var producer = CreateHeadlessTerminal();
+        var fixture = new SixelFixture(
+            "recording-limit-probe",
+            "One-band probe reused to synthesize an over-limit placement list.",
+            "q#1;2;100;0;0#1!11~"u8.ToArray());
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b[1;1H" + Encoding.ASCII.GetString(fixture.StandardBytes)));
+
+        using var producerSnapshot = producer.CreateSnapshot();
+        var placement = TestSeq.Single(producerSnapshot.SixelPlacements);
+
+        // The same placement reference repeated past the limit is sufficient
+        // to exercise the count check -- content identity is irrelevant to
+        // this specific validation.
+        var oversized = Enumerable.Repeat(placement, Hmp1SixelRecording.MaxPlacementCount + 1).ToList();
+
+        var ex = Assert.ThrowsExactly<Hmp1SixelRecordingException>(
+            () => Hmp1SixelRecording.Serialize(oversized));
+        Assert.AreEqual(Hmp1SixelRecordingFailureReason.ResourceLimitExceeded, ex.Reason);
+    }
+
+    private static void AssertPixelsEqual(SixelData expected, SixelData actual)
+    {
+        var expectedPixels = expected.GetPixels();
+        var actualPixels = actual.GetPixels();
+        Assert.IsNotNull(expectedPixels);
+        Assert.IsNotNull(actualPixels);
+        Assert.AreEqual(expectedPixels.Width, actualPixels.Width);
+        Assert.AreEqual(expectedPixels.Height, actualPixels.Height);
+        for (var y = 0; y < expectedPixels.Height; y++)
+        {
+            for (var x = 0; x < expectedPixels.Width; x++)
+            {
+                Assert.AreEqual(expectedPixels[x, y], actualPixels[x, y]);
+            }
+        }
+    }
+
+    private static Hex1bTerminal CreateHeadlessTerminal()
+        => Hex1bTerminal.CreateBuilder()
+            .WithDimensions(20, 10)
+            .WithWorkload(new NullWorkloadAdapter())
+            .WithHeadless(new TerminalCapabilities { SupportsSixel = true, SupportsTrueColor = true })
+            .Build();
+
+    private sealed class NullWorkloadAdapter : IHex1bTerminalWorkloadAdapter
+    {
+        public event Action? Disconnected
+        {
+            add { }
+            remove { }
+        }
+
+        public ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(CancellationToken ct = default)
+            => ValueTask.FromResult(ReadOnlyMemory<byte>.Empty);
+
+        public ValueTask WriteInputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask ResizeAsync(int width, int height, CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+}

--- a/tests/Hex1b.Tests/Hmp1/Hmp1SixelStateReplayTests.cs
+++ b/tests/Hex1b.Tests/Hmp1/Hmp1SixelStateReplayTests.cs
@@ -1,0 +1,244 @@
+using System.IO.Pipelines;
+using System.Text;
+using Hex1b.Tests.Sixel;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests.Hmp1;
+
+/// <summary>
+/// Integration coverage for <see cref="Hmp1SixelStateReplay"/>: the plain
+/// cursor+DCS bytes a late-joining HMP1 peer receives so its Sixel placements
+/// match the producer's, without requiring a live upstream terminal.
+/// </summary>
+[TestClass]
+public class Hmp1SixelStateReplayTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(5);
+
+    [TestMethod]
+    public async Task StateSync_WithActiveSixelPlacement_ReplaysImageToLateJoiningPeer()
+    {
+        await using var server = new Hmp1PresentationAdapter(20, 10);
+        await using var producer = Hex1bTerminal.CreateBuilder()
+            .WithDimensions(20, 10)
+            .WithWorkload(new NullWorkloadAdapter())
+            .WithPresentation(server)
+            .Build();
+
+        // server.Capabilities (10x20 cell pixels) drives the producer's Sixel
+        // raster geometry, so the fixture must span more than one cell pixel
+        // width (10) to produce a multi-cell placement: 11 pixels wide, one
+        // band (6 pixel rows) tall.
+        var fixture = new SixelFixture(
+            "hmp1-single-band",
+            "One-band red probe for HMP1 replay coverage.",
+            "q#1;2;100;0;0#1!11~"u8.ToArray());
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b[3;5H" + Encoding.ASCII.GetString(fixture.StandardBytes)));
+
+        using (var producerState = producer.CreateSnapshot())
+        {
+            Assert.HasCount(1, producerState.SixelPlacements);
+            Assert.IsTrue(producerState.ContainsSixelData());
+        }
+
+        var (serverStream, clientStream) = CreateFullDuplexPair();
+        using var cts = new CancellationTokenSource(TestTimeout);
+        var addClientTask = server.AddClient(serverStream, cts.Token);
+        await Hmp1Protocol.WriteClientHelloAsync(
+            clientStream,
+            displayName: "late-viewer",
+            defaultRole: null,
+            cts.Token);
+
+        var hello = await Hmp1Protocol.ReadFrameAsync(clientStream, cts.Token)
+            ?? throw new AssertFailedException("Server closed the stream before sending Hello.");
+        var stateSync = await Hmp1Protocol.ReadFrameAsync(clientStream, cts.Token)
+            ?? throw new AssertFailedException("Server closed the stream before sending StateSync.");
+        var sixelReplay = await Hmp1Protocol.ReadFrameAsync(clientStream, cts.Token)
+            ?? throw new AssertFailedException("Server closed the stream before sending Sixel replay.");
+
+        Assert.AreEqual(Hmp1FrameType.Hello, hello.Type);
+        Assert.AreEqual(Hmp1FrameType.StateSync, stateSync.Type);
+        Assert.AreEqual(Hmp1FrameType.Output, sixelReplay.Type);
+
+        var handle = await addClientTask;
+        await using var handleDispose = handle;
+        await using var viewer = Hex1bTerminal.CreateBuilder()
+            .WithDimensions(20, 10)
+            .WithWorkload(new NullWorkloadAdapter())
+            .WithHeadless(new TerminalCapabilities { SupportsSixel = true })
+            .Build();
+
+        // Apply in the exact wire order Hmp1PresentationAdapter emits them:
+        // StateSync (with its unconditional CSI-2J) first, then the Sixel
+        // placement-creation + damage-patch replay.
+        viewer.ApplyTokens(AnsiTokenizer.Tokenize(
+            Encoding.UTF8.GetString(stateSync.Payload.Span)));
+        viewer.ApplyTokens(AnsiTokenizer.Tokenize(
+            Encoding.UTF8.GetString(sixelReplay.Payload.Span)));
+
+        using var producerSnapshot = producer.CreateSnapshot();
+        using var snapshot = viewer.CreateSnapshot();
+        var placement = TestSeq.Single(snapshot.SixelPlacements);
+        Assert.AreEqual(2, placement.Row);
+        Assert.AreEqual(4, placement.Column);
+        Assert.AreEqual(2, placement.WidthInCells);
+        Assert.AreEqual(1, placement.HeightInCells);
+        Assert.IsFalse(placement.IsGeometryOnly);
+
+        var producerPlacement = TestSeq.Single(producerSnapshot.SixelPlacements);
+        var producerPixels = producerPlacement.Image.GetPixels();
+        var replayedPixels = placement.Image.GetPixels();
+        Assert.IsNotNull(producerPixels);
+        Assert.IsNotNull(replayedPixels);
+        Assert.AreEqual(producerPixels.Width, replayedPixels.Width);
+        Assert.AreEqual(producerPixels.Height, replayedPixels.Height);
+        for (var y = 0; y < producerPixels.Height; y++)
+        {
+            for (var x = 0; x < producerPixels.Width; x++)
+            {
+                Assert.AreEqual(producerPixels[x, y], replayedPixels[x, y]);
+            }
+        }
+
+        Assert.AreEqual(producerSnapshot.CursorX, snapshot.CursorX);
+        Assert.AreEqual(producerSnapshot.CursorY, snapshot.CursorY);
+    }
+
+    [TestMethod]
+    public async Task StateSync_WithDamagedSixelCell_PreservesOverwrittenTextAfterReplay()
+    {
+        // Regression coverage for the ordering fix: Sixel placement creation
+        // blanks its occupied cells (unlike KGP), so the placement-creation
+        // replay must land *after* StateSync's own unconditional CSI-2J, and
+        // any cell the placement had damaged must be patched back afterward
+        // so its overwritten text survives.
+        await using var server = new Hmp1PresentationAdapter(20, 10);
+        await using var producer = Hex1bTerminal.CreateBuilder()
+            .WithDimensions(20, 10)
+            .WithWorkload(new NullWorkloadAdapter())
+            .WithPresentation(server)
+            .Build();
+
+        var fixture = new SixelFixture(
+            "hmp1-damage-band",
+            "A two-cell-wide band whose origin cell is later overwritten with text.",
+            "q#1;2;100;0;0#1!11~"u8.ToArray());
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b[1;1H" + Encoding.ASCII.GetString(fixture.StandardBytes)));
+        // Overwrite only the origin cell with plain text, damaging it.
+        producer.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[1;1HX"));
+
+        using (var producerState = producer.CreateSnapshot())
+        {
+            var producerPlacement = TestSeq.Single(producerState.SixelPlacements);
+            Assert.IsTrue(producerPlacement.IsCellDamaged(0, 0));
+            Assert.AreEqual("X", producerState.GetCell(0, 0).Character);
+        }
+
+        var (serverStream, clientStream) = CreateFullDuplexPair();
+        using var cts = new CancellationTokenSource(TestTimeout);
+        var addClientTask = server.AddClient(serverStream, cts.Token);
+        await Hmp1Protocol.WriteClientHelloAsync(
+            clientStream,
+            displayName: "late-viewer",
+            defaultRole: null,
+            cts.Token);
+
+        var hello = await Hmp1Protocol.ReadFrameAsync(clientStream, cts.Token)
+            ?? throw new AssertFailedException("Server closed the stream before sending Hello.");
+        var stateSync = await Hmp1Protocol.ReadFrameAsync(clientStream, cts.Token)
+            ?? throw new AssertFailedException("Server closed the stream before sending StateSync.");
+        var sixelReplay = await Hmp1Protocol.ReadFrameAsync(clientStream, cts.Token)
+            ?? throw new AssertFailedException("Server closed the stream before sending Sixel replay.");
+
+        Assert.AreEqual(Hmp1FrameType.Hello, hello.Type);
+        Assert.AreEqual(Hmp1FrameType.StateSync, stateSync.Type);
+        Assert.AreEqual(Hmp1FrameType.Output, sixelReplay.Type);
+
+        var handle = await addClientTask;
+        await using var handleDispose = handle;
+        await using var viewer = Hex1bTerminal.CreateBuilder()
+            .WithDimensions(20, 10)
+            .WithWorkload(new NullWorkloadAdapter())
+            .WithHeadless(new TerminalCapabilities { SupportsSixel = true })
+            .Build();
+
+        // Apply in the exact wire order Hmp1PresentationAdapter emits them:
+        // StateSync first, then the Sixel placement-creation + damage-patch
+        // replay.
+        viewer.ApplyTokens(AnsiTokenizer.Tokenize(
+            Encoding.UTF8.GetString(stateSync.Payload.Span)));
+        viewer.ApplyTokens(AnsiTokenizer.Tokenize(
+            Encoding.UTF8.GetString(sixelReplay.Payload.Span)));
+
+        using var snapshot = viewer.CreateSnapshot();
+
+        // The damaged cell's text must survive: the trailing damage-patch
+        // step re-applies it after the placement-creation replay re-blanks
+        // it.
+        Assert.AreEqual("X", snapshot.GetCell(0, 0).Character);
+
+        // The placement itself is still present and still occupies its
+        // second cell (never damaged).
+        var placement = TestSeq.Single(snapshot.SixelPlacements);
+        Assert.AreEqual(0, placement.Row);
+        Assert.AreEqual(0, placement.Column);
+    }
+
+    private sealed class NullWorkloadAdapter : IHex1bTerminalWorkloadAdapter
+    {
+        public event Action? Disconnected
+        {
+            add { }
+            remove { }
+        }
+
+        public ValueTask<ReadOnlyMemory<byte>> ReadOutputAsync(CancellationToken ct = default)
+            => ValueTask.FromResult(ReadOnlyMemory<byte>.Empty);
+
+        public ValueTask WriteInputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask ResizeAsync(int width, int height, CancellationToken ct = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private static (Stream S1, Stream S2) CreateFullDuplexPair()
+    {
+        var p12 = new Pipe();
+        var p21 = new Pipe();
+        return (
+            new DuplexPipeStream(p21.Reader.AsStream(), p12.Writer.AsStream()),
+            new DuplexPipeStream(p12.Reader.AsStream(), p21.Writer.AsStream()));
+    }
+
+    private sealed class DuplexPipeStream(Stream readStream, Stream writeStream) : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanWrite => true;
+        public override bool CanSeek => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+        public override void Flush() => writeStream.Flush();
+        public override Task FlushAsync(CancellationToken ct) => writeStream.FlushAsync(ct);
+        public override int Read(byte[] buffer, int offset, int count) => readStream.Read(buffer, offset, count);
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken ct = default) => readStream.ReadAsync(buffer, ct);
+        public override void Write(byte[] buffer, int offset, int count) => writeStream.Write(buffer, offset, count);
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken ct = default) => writeStream.WriteAsync(buffer, ct);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                try { readStream.Dispose(); } catch { }
+                try { writeStream.Dispose(); } catch { }
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/tests/Hex1b.Tests/Sixel/SixelHtmlExportTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelHtmlExportTests.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Hex1b contributors. Licensed under the MIT license.
+
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Hex1b.Automation;
+
+namespace Hex1b.Tests.Sixel;
+
+/// <summary>
+/// Integration coverage for issue #456's HTML export requirements: the
+/// per-cell Sixel metadata payload embedded in HTML export must reflect the
+/// exact <see cref="Hex1b.Sixel.SixelPlacement"/> geometry the snapshot
+/// reports -- including for non-square placements where a row/column
+/// parameter-order mistake would only surface off the diagonal -- and
+/// repeated export must be deterministic. HTML export embeds Sixel raster
+/// pixels by delegating to the SVG exporter, so pixel-level crop/fidelity
+/// coverage lives in <see cref="SixelSvgExportTests"/>; these tests focus on
+/// the HTML-specific per-cell JSON metadata contract.
+/// </summary>
+[TestClass]
+public class SixelHtmlExportTests
+{
+    private static readonly SixelFixture SingleBand = SixelFixture.Load(
+        "single-band",
+        "One-band cursor and lifecycle probe.");
+
+    [TestMethod]
+    public async Task HtmlExport_WithSixelPlacement_EmbedsSvgViaToSvg()
+    {
+        await using var terminal = SixelTestTerminal.Create(width: 20, height: 10);
+
+        await terminal.FeedAsync(SingleBand.StandardBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            SingleBand.Name,
+            TestContext.Current.CancellationToken);
+
+        using var snapshot = terminal.Terminal.CreateSnapshot();
+        var svg = snapshot.ToSvg();
+        var html = snapshot.ToHtml();
+        TestCaptureHelper.AttachFile("sixel-html-embeds-svg.html", html);
+
+        // HTML export must reuse the authoritative SVG exporter rather than
+        // re-deriving/re-decoding Sixel raster pixels independently.
+        Assert.Contains("data:image/bmp;base64,", html);
+        Assert.Contains("<image", html);
+    }
+
+    [TestMethod]
+    public async Task HtmlExport_WithAsymmetricPlacement_ReportsCorrectPerCellMetadataAtEachCoordinate()
+    {
+        // Regression coverage for the CoversCell(row, column) parameter-order
+        // fix: use a placement whose painted footprint is wider than it is
+        // tall (3 columns x 1 row) so that transposing row/column would only
+        // manifest off the [0,0] origin -- exactly the kind of bug a square
+        // fixture cannot catch.
+        // Explicit 1:1 aspect + 3x6 declared extent (mirrors
+        // SixelScrollHistoryReflowTests.OneRowThreeCol) so this occupies
+        // exactly one row, three columns -- the default 2:1 aspect used by
+        // the shared SingleBand fixture would occupy two rows instead.
+        var wide = new SixelFixture(
+            "html-asymmetric-probe",
+            "Three-column, one-row band to catch row/column transposition bugs.",
+            "q\"1;1;3;6#1;2;100;0;0!3~"u8.ToArray());
+        await using var terminal = SixelTestTerminal.Create(width: 20, height: 10);
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[4;2H").Concat(wide.StandardBytes).ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            wide.Name,
+            TestContext.Current.CancellationToken);
+
+        using var snapshot = terminal.Terminal.CreateSnapshot();
+        var placement = TestSeq.Single(snapshot.SixelPlacements);
+        Assert.AreEqual(3, placement.WidthInCells);
+        Assert.AreEqual(1, placement.HeightInCells);
+
+        var html = snapshot.ToHtml();
+        TestCaptureHelper.AttachFile("sixel-html-asymmetric.html", html);
+        var cellData = ExtractCellData(html);
+
+        // Row index (placement.Row == y == 3), three columns starting at
+        // placement.Column == x == 1.
+        var originCell = cellData.RootElement[placement.Row][placement.Column];
+        var sixelAtOrigin = originCell.GetProperty("sixel");
+        Assert.AreNotEqual(JsonValueKind.Null, sixelAtOrigin.ValueKind);
+        Assert.IsTrue(sixelAtOrigin.GetProperty("origin").GetBoolean());
+        Assert.AreEqual(3, sixelAtOrigin.GetProperty("w").GetInt32());
+        Assert.AreEqual(1, sixelAtOrigin.GetProperty("h").GetInt32());
+
+        // The two subsequent columns on the SAME row must also report the
+        // placement (non-origin), while the row above/below must not.
+        for (var dx = 1; dx <= 2; dx++)
+        {
+            var cell = cellData.RootElement[placement.Row][placement.Column + dx];
+            var sixel = cell.GetProperty("sixel");
+            Assert.AreNotEqual(JsonValueKind.Null, sixel.ValueKind);
+            Assert.IsFalse(sixel.GetProperty("origin").GetBoolean());
+        }
+
+        var aboveRow = cellData.RootElement[placement.Row - 1][placement.Column];
+        Assert.AreEqual(JsonValueKind.Null, aboveRow.GetProperty("sixel").ValueKind);
+
+        var belowRow = cellData.RootElement[placement.Row + 1][placement.Column];
+        Assert.AreEqual(JsonValueKind.Null, belowRow.GetProperty("sixel").ValueKind);
+    }
+
+    [TestMethod]
+    public async Task HtmlExport_WithGeometryOnlyPlacement_ReportsGeometryOnlyMetadata()
+    {
+        await using var terminal = SixelTestTerminal.Create();
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1bP0;1q\"1;1;999999999;999999999#1@\x1b\\"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => terminal.Terminal.SixelPlacementCount == 1,
+            "geometry-only placement retained",
+            TestContext.Current.CancellationToken);
+
+        using var snapshot = terminal.Terminal.CreateSnapshot();
+        var placement = TestSeq.Single(snapshot.SixelPlacements);
+        Assert.IsTrue(placement.IsGeometryOnly);
+
+        var html = snapshot.ToHtml();
+        TestCaptureHelper.AttachFile("sixel-html-geometry-only.html", html);
+        var cellData = ExtractCellData(html);
+
+        var originCell = cellData.RootElement[placement.Row][placement.Column].GetProperty("sixel");
+        Assert.IsTrue(originCell.GetProperty("geometryOnly").GetBoolean());
+        Assert.AreEqual(
+            placement.Image.RasterStatus.ToString(),
+            originCell.GetProperty("outcome").GetString());
+    }
+
+    [TestMethod]
+    public async Task HtmlExport_RepeatedExportOfSameSnapshot_IsByteIdentical()
+    {
+        await using var terminal = SixelTestTerminal.Create(width: 20, height: 10);
+
+        await terminal.FeedAsync(SingleBand.StandardBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            SingleBand.Name,
+            TestContext.Current.CancellationToken);
+
+        using var snapshot = terminal.Terminal.CreateSnapshot();
+        var first = snapshot.ToHtml();
+        var second = snapshot.ToHtml();
+
+        Assert.AreEqual(first, second);
+    }
+
+    private static JsonDocument ExtractCellData(string html)
+    {
+        var match = Regex.Match(html, @"const cellData = (\[.*?\]);", RegexOptions.Singleline);
+        Assert.IsTrue(match.Success, "Expected an embedded 'const cellData = [...]' payload in the exported HTML.");
+        return JsonDocument.Parse(match.Groups[1].Value);
+    }
+}

--- a/tests/Hex1b.Tests/Sixel/SixelSnapshotSharingTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelSnapshotSharingTests.cs
@@ -1,0 +1,143 @@
+using System.Text;
+
+namespace Hex1b.Tests.Sixel;
+
+/// <summary>
+/// Regression coverage for stage #456's snapshot raster-retention contract:
+/// a decoded (or geometry-only) <see cref="Hex1b.SixelData"/> instance is
+/// retained once per referenced image, never once per covered cell, and
+/// multiple independently captured <see cref="Hex1bTerminalSnapshot"/>
+/// instances taken from the same live terminal state safely share that same
+/// instance rather than each cloning their own copy. Disposing one snapshot
+/// must not corrupt, invalidate, or double-release data still reachable
+/// through another live snapshot.
+/// </summary>
+/// <remarks>
+/// <see cref="Hex1bTerminalSnapshot"/>'s <c>Dispose()</c> only releases
+/// tracked hyperlink references; <see cref="Hex1b.SixelData"/> itself is a
+/// plain garbage-collected value with no reference-counted lifetime of its
+/// own, so "safe sharing" here means reference identity is preserved across
+/// snapshots and disposal of one snapshot has zero observable effect on
+/// another snapshot's placements, images, or decoded pixels. See
+/// <see cref="SixelPlacementLifetimeTests.IdenticalPayloads_AtDifferentPositions_ShareOneImageAcrossTwoPlacements"/>
+/// for the analogous same-snapshot (two placements, one live screen) sharing
+/// contract this test extends across independently captured snapshots.
+/// </remarks>
+[TestClass]
+public class SixelSnapshotSharingTests
+{
+    private static readonly SixelFixture SingleBand = SixelFixture.Load(
+        "single-band",
+        "One-band cursor and lifecycle probe.");
+
+    [TestMethod]
+    public async Task TwoSnapshots_CapturedFromSameLiveState_ShareTheSameImageInstance()
+    {
+        await using var terminal = SixelTestTerminal.Create();
+
+        await terminal.FeedAsync(SingleBand.StandardBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "graphic present",
+            TestContext.Current.CancellationToken);
+
+        using var first = terminal.Terminal.CreateSnapshot();
+        using var second = terminal.Terminal.CreateSnapshot();
+
+        var firstPlacement = TestSeq.Single(first.SixelPlacements);
+        var secondPlacement = TestSeq.Single(second.SixelPlacements);
+
+        // Independently captured snapshots must not clone the underlying
+        // raster: the same content hash resolves to the exact same SixelData
+        // instance whether reached through the first or second snapshot.
+        Assert.AreSame(firstPlacement.Image, secondPlacement.Image);
+
+        var firstImageEntry = TestSeq.Single(first.SixelImages.Values);
+        var secondImageEntry = TestSeq.Single(second.SixelImages.Values);
+        Assert.AreSame(firstImageEntry, secondImageEntry);
+        Assert.AreSame(firstPlacement.Image, firstImageEntry);
+    }
+
+    [TestMethod]
+    public async Task DisposingOneSnapshot_LeavesAnotherSnapshotsSixelDataFullyIntact()
+    {
+        await using var terminal = SixelTestTerminal.Create();
+
+        await terminal.FeedAsync(SingleBand.StandardBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "graphic present",
+            TestContext.Current.CancellationToken);
+
+        var first = terminal.Terminal.CreateSnapshot();
+        using var second = terminal.Terminal.CreateSnapshot();
+
+        var expectedPixels = TestSeq.Single(second.SixelPlacements).Image.GetPixels()!.AsSpan().ToArray();
+
+        // Dispose the first snapshot; the second must remain fully usable —
+        // same placement count, same image reference, same pixel content —
+        // proving Sixel resources aren't shared-then-released underneath a
+        // still-live snapshot.
+        first.Dispose();
+
+        Assert.IsTrue(second.ContainsSixelData());
+        var survivingPlacement = TestSeq.Single(second.SixelPlacements);
+        Assert.IsNotNull(survivingPlacement.Image);
+        TestSeq.AreEqual(expectedPixels, survivingPlacement.Image.GetPixels()!.AsSpan().ToArray());
+    }
+
+    [TestMethod]
+    public async Task DisposingSnapshot_MultipleTimes_IsIdempotentAndDoesNotThrow()
+    {
+        await using var terminal = SixelTestTerminal.Create();
+
+        await terminal.FeedAsync(SingleBand.StandardBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "graphic present",
+            TestContext.Current.CancellationToken);
+
+        var snapshot = terminal.Terminal.CreateSnapshot();
+
+        snapshot.Dispose();
+        snapshot.Dispose();
+        snapshot.Dispose();
+    }
+
+    [TestMethod]
+    public async Task SnapshotTakenBeforeErase_KeepsItsOwnImageInstance_IndependentOfALaterEmptySnapshot()
+    {
+        await using var terminal = SixelTestTerminal.Create();
+
+        await terminal.FeedAsync(SingleBand.StandardBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "graphic before erase",
+            TestContext.Current.CancellationToken);
+
+        using var beforeErase = terminal.Terminal.CreateSnapshot();
+        var originalImage = TestSeq.Single(beforeErase.SixelPlacements).Image;
+
+        // Erase-in-display (all) removes the placement from the live screen.
+        await terminal.FeedAsync(Encoding.ASCII.GetBytes("\x1b[2J"), cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.SixelPlacementCount == 0,
+            "graphic cleared from live screen",
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(0, terminal.Terminal.TrackedSixelCount);
+        Assert.AreEqual(0, terminal.Terminal.SixelPlacementCount);
+
+        // A snapshot captured *after* the erase correctly reflects the now
+        // empty live state...
+        using var afterErase = terminal.Terminal.CreateSnapshot();
+        Assert.IsFalse(afterErase.ContainsSixelData());
+        Assert.IsEmpty(afterErase.SixelPlacements);
+
+        // ...while the earlier snapshot's placement/image reference is wholly
+        // unaffected by both the live erase and the newer empty snapshot's
+        // existence: it keeps observing its own graphic.
+        Assert.IsTrue(beforeErase.ContainsSixelData());
+        Assert.AreSame(originalImage, TestSeq.Single(beforeErase.SixelPlacements).Image);
+    }
+}

--- a/tests/Hex1b.Tests/Sixel/SixelSvgExportTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelSvgExportTests.cs
@@ -1,0 +1,234 @@
+// Copyright (c) Hex1b contributors. Licensed under the MIT license.
+
+using System.Text;
+using System.Text.RegularExpressions;
+using Hex1b.Automation;
+
+namespace Hex1b.Tests.Sixel;
+
+/// <summary>
+/// Integration coverage for issue #456's SVG export requirements: Sixel
+/// placements must render using the exact snapshot pixels/cell geometry and
+/// source crop the authoritative <see cref="Hex1b.Sixel.SixelPlacement"/>
+/// model reports — not a re-derived or re-decoded approximation — and must
+/// produce an explicit diagnostic placeholder for geometry-only placements
+/// rather than silently omitting them. These tests exercise raw DCS byte
+/// sequences only (never <c>SixelWidget</c>/<c>SixelEncoder</c>), mirroring
+/// the conventions established by <see cref="SixelScrollHistoryReflowTests"/>
+/// and <see cref="SixelPlacementLifetimeTests"/>.
+/// </summary>
+[TestClass]
+public class SixelSvgExportTests
+{
+    private static readonly SixelFixture SingleBand = SixelFixture.Load(
+        "single-band",
+        "One-band cursor and lifecycle probe.");
+
+    // 1x18 px, 1:1 aspect, three full six-pixel bands -> three occupied rows
+    // at the default 1x6 cell metrics harness. Reused verbatim from
+    // SixelScrollHistoryReflowTests' progressive-crop probe so this test
+    // exercises the exact same crop scenario against the SVG exporter.
+    private static readonly SixelFixture ThreeRowBar = new(
+        "three-row-bar",
+        "Three-band bar used as a three-row-tall progressive-crop probe.",
+        Encoding.ASCII.GetBytes("q\"1;1;1;18#1;2;100;0;0~-~-~"));
+
+    [TestMethod]
+    public async Task SvgExport_WithSixelPlacement_ContainsImageElementAtCorrectCellPosition()
+    {
+        await using var terminal = SixelTestTerminal.Create(width: 20, height: 10);
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[3;5H").Concat(SingleBand.StandardBytes).ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            SingleBand.Name,
+            TestContext.Current.CancellationToken);
+
+        using var snapshot = terminal.Terminal.CreateSnapshot();
+        var placement = TestSeq.Single(snapshot.SixelPlacements);
+        var svg = snapshot.ToSvg();
+        TestCaptureHelper.AttachSvg("sixel-basic-position.svg", svg);
+
+        Assert.Contains("<image", svg);
+        Assert.Contains("data:image/bmp;base64,", svg);
+        Assert.Contains("preserveAspectRatio=\"none\"", svg);
+
+        // Default SixelTestTerminal cell metrics: 1x6 pixels per cell.
+        var expectedX = placement.PaintedLeft * 1;
+        var expectedY = placement.PaintedTop * 6;
+        Assert.Contains($"x=\"{expectedX}\"", svg);
+        Assert.Contains($"y=\"{expectedY}\"", svg);
+    }
+
+    [TestMethod]
+    public async Task SvgExport_WithPartiallyCroppedPlacement_EmbedsExactCroppedPixelsNotSquishedFullImage()
+    {
+        // Regression coverage: the SVG exporter must size *and* fill its
+        // embedded raster from the placement's exact painted/visible crop
+        // (Hex1b.Sixel.SixelPlacement.GetPaintedPixels), not the full
+        // originally-declared image scaled down to the cropped cell box.
+        await using var terminal = SixelTestTerminal.Create(width: 8, height: 5);
+        var prefix = Encoding.ASCII.GetBytes("\x1b[2;4r\x1b[2;1H");
+        var scrollOnce = Encoding.ASCII.GetBytes("\x1b[S");
+        var bytes = prefix.Concat(ThreeRowBar.StandardBytes).Concat(scrollOnce).ToArray();
+
+        await terminal.FeedAsync(bytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            "first partial-margin scroll",
+            TestContext.Current.CancellationToken);
+
+        await terminal.FeedAsync(scrollOnce, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.SixelPlacements is [{ } p] && p.PaintedRowCount == 1,
+            "second partial-margin scroll crops to a single row",
+            TestContext.Current.CancellationToken);
+
+        using var snapshot = terminal.Terminal.CreateSnapshot();
+        var placement = TestSeq.Single(snapshot.SixelPlacements);
+        Assert.AreEqual(1, placement.PaintedRowCount);
+        Assert.AreEqual(1, placement.WidthInCells);
+
+        // Sanity: the full declared image is still 3 rows tall (18px) even
+        // though only 1 row (6px) survives the crop — this is exactly the
+        // gap between "full declared image" and "painted/visible crop" that
+        // the exporter must respect.
+        var fullPixels = placement.Image.GetPixels();
+        Assert.IsNotNull(fullPixels);
+        Assert.AreEqual(18, fullPixels.Height);
+
+        var svg = snapshot.ToSvg();
+        TestCaptureHelper.AttachSvg("sixel-partial-crop.svg", svg);
+
+        var (bmpWidth, bmpHeight) = ExtractEmbeddedBmpDimensions(svg);
+
+        // The embedded raster must match the cropped cell footprint (1 col x
+        // 1 row -> 1x6 px), never the full declared image (1x18 px).
+        Assert.AreEqual(1, bmpWidth);
+        Assert.AreEqual(6, bmpHeight);
+    }
+
+    [TestMethod]
+    public async Task SvgExport_WithDamagedCell_RendersTransparentBackgroundUnderText()
+    {
+        var wide = new SixelFixture(
+            "svg-damage-probe",
+            "A two-column band so the origin cell can be overwritten while the second cell still paints.",
+            "q#1;2;100;0;0#1!2~"u8.ToArray());
+        await using var terminal = SixelTestTerminal.Create();
+
+        await terminal.FeedAsync(wide.StandardBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            wide.Name,
+            TestContext.Current.CancellationToken);
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[1;1HX"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsText("X"),
+            "origin cell overwritten",
+            TestContext.Current.CancellationToken);
+
+        using var snapshot = terminal.Terminal.CreateSnapshot();
+        var svg = snapshot.ToSvg();
+        TestCaptureHelper.AttachSvg("sixel-damage-layering.svg", svg);
+
+        var placement = TestSeq.Single(snapshot.SixelPlacements);
+        var (bmpWidth, _) = ExtractEmbeddedBmpDimensions(svg);
+
+        // Both cells are still within the painted rectangle (the placement
+        // survives because its second cell still paints), so the embedded
+        // raster still spans both columns...
+        Assert.AreEqual(2, bmpWidth);
+
+        // ...but the damaged (overwritten) origin column must decode as the
+        // BMP encoder's transparent background fill (0x1e,0x1e,0x1e), not the
+        // placement's opaque red, and the "X" text must be drawn on top in
+        // the separate terminal-text layer.
+        var pixel = ExtractEmbeddedBmpPixel(svg, x: 0, y: 0);
+        Assert.AreEqual((0x1e, 0x1e, 0x1e), pixel);
+        Assert.Contains(">X<", svg);
+        Assert.IsTrue(placement.IsCellDamaged(placement.Row, placement.Column));
+    }
+
+    [TestMethod]
+    public async Task SvgExport_WithGeometryOnlyPlacement_RendersExplicitDiagnosticPlaceholder()
+    {
+        await using var terminal = SixelTestTerminal.Create();
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1bP0;1q\"1;1;999999999;999999999#1@\x1b\\"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => terminal.Terminal.SixelPlacementCount == 1,
+            "geometry-only placement retained",
+            TestContext.Current.CancellationToken);
+
+        using var snapshot = terminal.Terminal.CreateSnapshot();
+        var placement = TestSeq.Single(snapshot.SixelPlacements);
+        Assert.IsTrue(placement.IsGeometryOnly);
+
+        var svg = snapshot.ToSvg();
+        TestCaptureHelper.AttachSvg("sixel-geometry-only-placeholder.svg", svg);
+
+        // A deterministic, discoverable placeholder must be present -- never
+        // a silent omission of the placement from the export.
+        Assert.Contains("sixel-geometry-only", svg);
+        Assert.Contains($"data-sixel-outcome=\"{placement.Image.RasterStatus}\"", svg);
+        Assert.Contains("<title>", svg);
+        Assert.DoesNotContain("data:image/bmp;base64,", svg);
+    }
+
+    [TestMethod]
+    public async Task SvgExport_RepeatedExportOfSameSnapshot_IsByteIdentical()
+    {
+        await using var terminal = SixelTestTerminal.Create(width: 20, height: 10);
+
+        await terminal.FeedAsync(SingleBand.StandardBytes, cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsSixelData(),
+            SingleBand.Name,
+            TestContext.Current.CancellationToken);
+
+        using var snapshot = terminal.Terminal.CreateSnapshot();
+        var first = snapshot.ToSvg();
+        var second = snapshot.ToSvg();
+
+        Assert.AreEqual(first, second);
+    }
+
+    private static (int Width, int Height) ExtractEmbeddedBmpDimensions(string svg)
+    {
+        var bmp = DecodeFirstBmp(svg);
+        var width = BitConverter.ToInt32(bmp, 18);
+        var height = BitConverter.ToInt32(bmp, 22);
+        return (width, height);
+    }
+
+    private static (byte R, byte G, byte B) ExtractEmbeddedBmpPixel(string svg, int x, int y)
+    {
+        var bmp = DecodeFirstBmp(svg);
+        var width = BitConverter.ToInt32(bmp, 18);
+        var height = BitConverter.ToInt32(bmp, 22);
+        var rowStride = (width * 3 + 3) & ~3;
+
+        // BMP rows are stored bottom-up.
+        var rowOffset = 54 + (height - 1 - y) * rowStride;
+        var pixelOffset = rowOffset + x * 3;
+        var b = bmp[pixelOffset];
+        var g = bmp[pixelOffset + 1];
+        var r = bmp[pixelOffset + 2];
+        return (r, g, b);
+    }
+
+    private static byte[] DecodeFirstBmp(string svg)
+    {
+        var match = Regex.Match(svg, "data:image/bmp;base64,([A-Za-z0-9+/=]+)");
+        Assert.IsTrue(match.Success, "Expected at least one embedded BMP data URI in the SVG output.");
+        return Convert.FromBase64String(match.Groups[1].Value);
+    }
+}


### PR DESCRIPTION
## Summary

Implements #456: makes authoritative Sixel graphics first-class in immutable terminal snapshots, automation assertions, SVG/HTML export, and HMP1 state recording/replay, while preserving all parser/raster/cursor/graphics-state/damage/history/reflow semantics from #451/#452 (merged as `d8af16a7` via #468). Existing KGP snapshot/export/replay behavior is unchanged.

Closes #456
Related to #445

## Snapshot model

- `SixelPlacement` is now `public`, exposing declared/rendered/painted/visible extents, exact source crops, creation-time `SixelCellMetrics`, and a new `GetPaintedPixels()` accessor.
- `SixelData` exposes `ContentHash`, `Outcome`, `Diagnostics`, `BackgroundMode`, `RasterStatus`/`RasterDiagnostics`, `Extents`, and `CellMetrics`.
- `Hex1bTerminalSnapshot.SixelPlacements`/`SixelImages` are `public`. Resources are retained once per referenced image/placement, never per covered cell; multiple snapshots safely share raster instances, and disposal is idempotent and independent across snapshots (never leaks, never over-releases).
- `CreateSnapshot(scrollbackLines, scrollbackWidth, voidCell)` supports viewport-only, history-inclusive, current-terminal-width, and original-width projections, consistent with #452.

## Automation API

Deterministic access to image/placement counts, dimensions, RGBA pixels, anchor/occupied cells, source crops, history vs. viewport, parser outcome/geometry-only downgrade, diagnostics, and cursor/graphics-state correspondence. `ContainsSixelData()` is retained as a convenience method but now reads through snapshot graphics state.

## SVG/HTML export

`TerminalRegionSvgExtensions`/`TerminalRegionHtmlExtensions` render exact snapshot pixels/geometry/crops/transparency/background and #453 text damage. Geometry-only placements get an explicit `sixel-geometry-only` SVG diagnostic placeholder and HTML `geometryOnly` metadata instead of silent omission. Export reads only the authoritative cached snapshot state — no independent reparsing/redecoding/hashing per exporter — so repeated exports are byte-identical. KGP export output and layering are unchanged.

## Recording/replay

New `Hmp1SixelRecording` (`src/Hex1b/Hmp1/Hmp1SixelRecording.cs`) with a versioned (`"SXRC"`, `CurrentVersion`) binary format sufficient to reconstruct image/raster definitions, placements, damage, source crops, scrolling/history transitions, screen switching, resource release, geometry-only outcomes, metrics, and diagnostics without a live upstream terminal. Content-addressed image references avoid repeating pixel payloads across placements. `Hmp1SixelRecordingSnapshot.BuildReplayEscapeSequence()` reconstructs state through the same parser/raster path a live terminal uses, verified equivalently across main/alternate transitions and scrolling.

`Deserialize` throws `Hmp1SixelRecordingException` with an explicit `Hmp1SixelRecordingFailureReason` (`Malformed`, `Truncated`, `UnsupportedVersion`, `MissingImageReference`, `InvalidGeometry`, `ResourceLimitExceeded`) — never a broad catch or success-shaped fallback. Bounded by `MaxPlacementCount`/`MaxImageCount`/`MaxPayloadLength`/`MaxDamagedCellCount`.

## Tests

- `tests/Hex1b.Tests/Sixel/SixelSnapshotSharingTests.cs`, `SixelSvgExportTests.cs`, `SixelHtmlExportTests.cs`
- `tests/Hex1b.Tests/Hmp1/Hmp1SixelRecordingTests.cs`, `Hmp1SixelStateReplayTests.cs`

Cover: live-vs-snapshot geometry/pixels/damage/history; snapshots held while live placements are erased/pruned/reset; multiple snapshots sharing raster safely with deterministic disposal; all four projections; SVG/HTML geometry-only placeholder and deterministic export; record/serialize/replay across main/alternate screens, scrolling/history, and damage; explicit version-mismatch/malformed/missing-reference/limit failures. Existing KGP snapshot/export/replay and terminal automation tests are unchanged and green.

## Docs/demo

- `docs/sixel-terminal-behavior.md`: new `#456` section covering the snapshot/export/replay contract, retention/lifetime rules, serialization versioning, diagnostic behavior, and stage boundaries.
- `samples/SixelTerminalDemo/RawSnapshotExportReplayScenes.cs`: raw-DCS-only scenes (no `SixelWidget`/`SixelEncoder`) demonstrating raster sharing, all four projections, the geometry-only export placeholder, deterministic export, damage-surviving record/replay, main/alternate independence, and explicit recording failure modes, with a matching headless inspector in `Program.cs`.

## Exclusions (per stage boundary)

No capability probing (#455), terminal protocol translation (#458), or widget preview generation.

## Validation

- `dotnet test tests/Hex1b.Tests/Hex1b.Tests.csproj` (full suite): **9003 total, 0 failed, 8979 succeeded, 24 skipped**.
- Focused filter `FullyQualifiedName~Hex1b.Tests.Sixel.` and `~Hex1b.Tests.Hmp1.Hmp1Sixel`: all green.
- `samples/SixelTerminalDemo` builds cleanly; `dotnet run --project samples/SixelTerminalDemo -- --headless` runs all 50 scenes and produces deterministic, byte-identical output across repeated runs.
- No changes under `src/Hex1b/Surfaces/`, so Surface benchmarks were not required for this stage.

**Not merging / no auto-merge** — this PR is intended for review.