### PR TITLE
Stabilize Sixel widget and Surface rendering

### DIFF
--- a/docs/experimental/sixel.md
+++ b/docs/experimental/sixel.md
@@ -1,0 +1,13 @@
+# Experimental Sixel API
+
+The Sixel widget and render-context APIs remain experimental under diagnostic
+`HEX1B_SIXEL`.
+
+Use `SixelPixelBuffer` with `SixelWidget` for structured application-generated
+pixels. Use the pre-encoded string overload only as a compatibility path for
+existing Sixel payloads; Hex1b validates and normalizes its DCS framing.
+
+See the [SixelWidget guide](../../src/content/guide/widgets/sixel.md) for a
+complete example, sizing and fallback behavior, and the native-terminal demo
+command. The lower-level terminal behavior contract is documented in
+[Sixel terminal behavior](../sixel-terminal-behavior.md).

--- a/docs/experimental/sixel.md
+++ b/docs/experimental/sixel.md
@@ -6,6 +6,9 @@ The Sixel widget and render-context APIs remain experimental under diagnostic
 Use `SixelPixelBuffer` with `SixelWidget` for structured application-generated
 pixels. Use the pre-encoded string overload only as a compatibility path for
 existing Sixel payloads; Hex1b validates and normalizes its DCS framing.
+Structured pixels are resampled when layout requests an explicit cell span.
+Pre-encoded payloads remain lossless and throw if their natural protocol-cell
+span does not match the arranged widget size.
 
 See the [SixelWidget guide](../../src/content/guide/widgets/sixel.md) for a
 complete example, sizing and fallback behavior, and the native-terminal demo

--- a/docs/sixel-terminal-behavior.md
+++ b/docs/sixel-terminal-behavior.md
@@ -6,6 +6,7 @@
 > **Snapshots, exports, recording, and replay**: [#456](https://github.com/mitchdenny/hex1b/issues/456)
 > **Capability discovery and protocol cell metrics**: [#455](https://github.com/mitchdenny/hex1b/issues/455)
 > **Differential conformance corpus**: [#457](https://github.com/mitchdenny/hex1b/issues/457)
+> **Widget and Surface integration**: [#480](https://github.com/mitchdenny/hex1b/issues/480)
 > **Baseline**: DEC VT340
 
 ## Purpose
@@ -23,6 +24,12 @@ contract. The finite differential corpus in
 `tests/Hex1b.Tests/TestData/Sixel/Conformance/terminal-reference-matrix.json`
 records the primary reference matrix, normalized expected outcomes, provenance,
 and the dedicated regression suites covering the rest of the terminal contract.
+
+The application-facing `SixelWidget` contract is documented separately in
+[`src/content/guide/widgets/sixel.md`](../src/content/guide/widgets/sixel.md).
+Direct render contexts emit normalized native Sixel, while Surface-backed
+contexts retain structured Sixel content for deterministic diffing, clipping,
+overlap, caching, movement, replacement, removal, and resize behavior.
 
 ## Governing decisions
 

--- a/docs/sixel-terminal-behavior.md
+++ b/docs/sixel-terminal-behavior.md
@@ -627,10 +627,14 @@ read paths over that authoritative state.
     missing references, invalid geometry, resource limits). It serializes
     an `IReadOnlyList<SixelPlacement>` — the same type the live snapshot and
     live wire replay use — into a `SXRC`-tagged, versioned
-    (`Hmp1SixelRecording.CurrentVersion = 1`) stream: an image table
+    (`Hmp1SixelRecording.CurrentVersion = 2`) stream: an image table
     deduplicated by `SixelData.ContentHash`. Placements share an entry only
     when payload, raster state, protocol metrics, and cell span all match, so
-    incompatible clipping/damage contexts are not conflated. The table is
+    incompatible clipping/damage contexts are not conflated. Version 2 stores
+    each image's exact raw metric width/height bits plus
+    `SixelCellMetricsSource` and `SixelCellMetricsReliability`; version 1
+    remains readable and retains its historical target-metric replay behavior
+    because it did not carry per-image metric context. The image table is
     followed by placements referencing it by index, each carrying its
     geometry, painted crop, sequence, creation time, and anchor-relative
     damaged-cell offsets. Rasterized images are re-encoded byte-exact via
@@ -649,10 +653,13 @@ read paths over that authoritative state.
     `MaxRecordingLength` = 72 MiB, and aggregate
     `MaxDamagedCellCount` = 2^20). Exact raster re-encoding is constrained by
     the remaining per-image and aggregate payload budget before allocating
-    its output. Expanding a deduplicated recording back into cursor-position
-    plus Sixel sequences performs a checked, cancellable preflight and rejects
-    output above the same 64 MiB aggregate limit before allocating the replay
-    string. Retention-limited images are rejected before
+    its output. `Hmp1SixelRecordingSnapshot.ReplayInto` performs a checked,
+    cancellable preflight and rejects expanded output above the same 64 MiB
+    aggregate limit before changing the target. It then applies each version
+    2 image's recorded metrics, feeds cursor-position plus Sixel DCS through
+    the ordinary terminal parser, restores the recorded painted crop and
+    damage mask, and finally restores the target's prior metric override.
+    Retention-limited images are rejected before
     serialization because their complete payload is unavailable; deserialization
     rejects an oversized input before copying it and rejects trailing bytes.
     Recorded
@@ -666,8 +673,9 @@ read paths over that authoritative state.
   deduplication, anchor-relative damage offsets, geometry-only payload
   preservation, main/alternate-screen isolation, and distinct
   history-vs-viewport unified row offsets across a scroll), replays a
-  recording's escape-sequence reconstruction into a fresh terminal and
-  compares resulting pixels, and exercises every `Hmp1SixelRecordingException`
+  a recording into a fresh terminal and compares resulting pixels, captured
+  metrics, spans, resource identity, painted crops, and damage boundaries,
+  and exercises every `Hmp1SixelRecordingException`
   failure mode named above. `tests/Hex1b.Tests/Hmp1/Hmp1SixelStateReplayTests.cs`
   covers the existing live wire replay path, including the damage-patch
   restoration. All pre-existing KGP snapshot/export/replay and terminal
@@ -1279,9 +1287,9 @@ beyond replaying the script: it also creates multiple snapshots to prove
 raster sharing and safe double-disposal, compares the four projection modes
 against each other, exports SVG/HTML to confirm the geometry-only diagnostic
 placeholder and byte-identical repeated export, and drives
-`Hmp1SixelRecording.Serialize`/`Deserialize`/`BuildReplayEscapeSequence` to
+`Hmp1SixelRecording.Serialize`/`Deserialize`/`ReplayInto` to
 record a snapshot, replay it into a brand-new terminal with no live upstream
-connection, and compare the resulting pixels and painted (damage) extent —
+connection, and compare the resulting pixels, painted crop, and damage mask —
 including across a main/alternate screen transition — plus feeds
 deliberately corrupted recordings (wrong magic marker, truncation, a bumped
 version number) through `Deserialize` to show each fails with its own

--- a/docs/sixel-terminal-behavior.md
+++ b/docs/sixel-terminal-behavior.md
@@ -216,9 +216,10 @@ through `SixelCompatibilityPolicy.BackgroundSource` rather than as a hidden
 branch. The #457 corpus exercises both the DEC/Hex1b captured-background
 profile and the source-derived xterm/WezTerm register-zero profile.
 
-Because the captured background and the persistent palette both change how an
-identical payload rasterizes, tracked Sixel deduplication keys on the payload
-*and* a raster-state identity rather than on payload content alone.
+Because captured background and persistent palette state change how an identical
+payload rasterizes, while protocol cell metrics and the declared cell span
+change how that raster is clipped and damaged, tracked Sixel deduplication keys
+on all of those immutable resource inputs rather than payload content alone.
 
 ## Placement, cursor, and modes
 
@@ -321,11 +322,11 @@ protocol-neutral:
   instances (main and alternate). Re-entering the alternate screen while
   already active resets only the alternate instance; RIS is the only
   operation that clears both.
-- Each `SixelScreenGraphicsState` owns a `SixelImageStore` (the raster
-  resources, deduplicated by content hash — payload plus captured
-  background/palette identity), a live `Placements` list, and — main screen
-  only — a `HistoryPlacements` partition keyed by stable scrollback row
-  identity.
+- Each `SixelScreenGraphicsState` owns a `SixelImageStore` (the image
+  resources, deduplicated by resource identity — payload, captured
+  background/palette state, protocol cell metrics, and declared cell span), a
+  live `Placements` list, and — main screen only — a `HistoryPlacements`
+  partition keyed by stable scrollback row identity.
 - `SixelPlacement` anchors a `SixelData` image at a cell position and retains
   the anchor/occupied cell span, the painted-crop geometry (offset and count,
   relative to the anchor so scrolling can shift the anchor without recomputing
@@ -337,12 +338,12 @@ protocol-neutral:
   earlier stages) carries the authoritative decoded raster or geometry-only
   outcome, logical/rendered/declared/painted extents, creation-time
   `SixelCellMetrics`, source and captured background, aspect state, a stable
-  content hash for dedup, and parser diagnostics.
+  resource identity hash exposed as `ContentHash`, and parser diagnostics.
 - **Lifetime is reachability-based, not manually reference-counted.** Mirroring
   `KgpImageStore`, every placement-removing mutation recomputes the set of
-  content hashes reachable from `Placements ∪ HistoryPlacements` and sweeps any
-  image no longer in that set. A `SixelPlacement`'s image is never released
-  just because one text cell it covered was overwritten — only when no
+  resource identity hashes reachable from `Placements ∪ HistoryPlacements` and
+  sweeps any image no longer in that set. A `SixelPlacement`'s image is never
+  released just because one text cell it covered was overwritten — only when no
   visible cell remains in any placement (live, historical, or held by an
   existing snapshot). Snapshots decouple entirely:
   `Hex1bTerminalSnapshot` copies its own `SixelPlacement`/`SixelData`
@@ -369,9 +370,9 @@ on `SixelDamaged`. A graphics-only delta is still a render-invalidating change
 even when no text cell value changed.
 
 **Extracted from KGP as genuinely protocol-neutral primitives:** raster
-content ownership by content hash, placement/source-crop geometry (anchor +
-occupied span + painted crop), reachability-based lifetime accounting,
-screen/history partitioning, and simple scroll/clip geometry helpers. **Kept
+resource ownership by immutable identity, placement/source-crop geometry
+(anchor + occupied span + painted crop), reachability-based lifetime
+accounting, screen/history partitioning, and simple scroll/clip geometry helpers. **Kept
 deliberately KGP-only, not extracted:** public image/placement IDs,
 image-number addressing, explicit delete selectors, relative placement
 graphs, Unicode placeholders, z-index, and chunked uploads — none of these
@@ -516,9 +517,10 @@ read paths over that authoritative state.
 
 - **Snapshot model.** `Hex1bTerminalSnapshot.SixelPlacements` (an
   `IReadOnlyList<SixelPlacement>`) and `SixelImages` (an
-  `IReadOnlyDictionary<byte[], SixelData>` keyed by content hash) are now
-  public, mirroring the shape of the existing `KgpPlacements`/KGP image
-  surfaces. `SixelPlacement` and the `SixelData` properties it exposes
+  `IReadOnlyDictionary<byte[], SixelData>` keyed by immutable resource identity
+  hash) are now public, mirroring the shape of the existing
+  `KgpPlacements`/KGP image surfaces. `SixelPlacement` and the `SixelData`
+  properties it exposes
   (`Image`, `Row`, `Column`, `WidthInCells`/`HeightInCells`,
   `PaintedRowOffset`/`PaintedRowCount`/`PaintedColumnOffset`/`PaintedColumnCount`
   and their derived `PaintedTop`/`PaintedBottom`/`PaintedLeft`/`PaintedRight`,
@@ -626,9 +628,10 @@ read paths over that authoritative state.
     an `IReadOnlyList<SixelPlacement>` — the same type the live snapshot and
     live wire replay use — into a `SXRC`-tagged, versioned
     (`Hmp1SixelRecording.CurrentVersion = 1`) stream: an image table
-    deduplicated by `SixelData.ContentHash` (content-addressed, so a raster
-    shared by multiple placements is never repeated in the stream), followed
-    by placements referencing that table by index, each carrying its
+    deduplicated by `SixelData.ContentHash`. Placements share an entry only
+    when payload, raster state, protocol metrics, and cell span all match, so
+    incompatible clipping/damage contexts are not conflated. The table is
+    followed by placements referencing it by index, each carrying its
     geometry, painted crop, sequence, creation time, and anchor-relative
     damaged-cell offsets. Rasterized images are re-encoded byte-exact via
     `SixelExactEncoder`; geometry-only images retain their original payload
@@ -967,8 +970,9 @@ Sixel presentation uses the existing terminal contracts:
   Sixel-specific event hierarchy.
 - **Snapshots provide full authoritative graphics state.**
   `Hex1bTerminal.CreateSnapshot()` exposes `SixelPlacements` and the
-  content-addressed `SixelImages` table, including decoded pixels or an explicit
-  geometry-only outcome, placement geometry, crop, ordering, and damage state.
+  identity-addressed `SixelImages` table, including decoded pixels or an explicit
+  geometry-only outcome, captured protocol metrics, placement geometry, crop,
+  ordering, and damage state.
   Consumers that need complete state use snapshots rather than reconstructing it
   from incremental impacts alone.
 - **HMP1 replay is private same-protocol restoration.**
@@ -1304,9 +1308,9 @@ disagreement surfaced in diagnostics; a fractional cell size derived from
 rejected with an explicit diagnostic detail; a resize invalidating only
 `Derived`-sourced metrics while leaving `SixelSupport` itself untouched; a
 later `SetSixelCellMetrics` change leaving an already-created placement's
-recorded metrics unchanged while a subsequent placement (with distinct
-payload content, since identical content is deduplicated by
-`TrackedObjectStore.GetOrCreateSixel`) picks up the new value; and, run
+recorded metrics unchanged while a subsequent placement of the same payload
+picks up the new value and retains a distinct metric-specific image resource;
+and, run
 against `Hex1bTerminal` directly, native-presentation silence versus
 default-headless (`SixelSupport.Unknown`, "no parameter 4") versus an
 explicitly declared confirmed-unsupported headless (`SixelSupport.None`,

--- a/samples/SixelTerminalDemo/Program.cs
+++ b/samples/SixelTerminalDemo/Program.cs
@@ -661,11 +661,9 @@ static async Task<string> InspectRecordReplayWithDamageAsync(RawSnapshotExportRe
     using var snapshot = terminal.CreateSnapshot(scrollbackLines: terminal.ScrollbackCount);
     var recorded = Hmp1SixelRecording.Serialize(snapshot.SixelPlacements);
     var deserialized = Hmp1SixelRecording.Deserialize(recorded);
-    var replayScript = deserialized.BuildReplayEscapeSequence();
-
-    await using var viewer = CreateSnapshotExportReplayTerminalBuilder(
-        Encoding.ASCII.GetBytes(replayScript), scene.ScrollbackCapacity).Build();
-    await viewer.RunAsync();
+    using var viewer = CreateSnapshotExportReplayTerminalBuilder(
+        [], scene.ScrollbackCapacity).Build();
+    deserialized.ReplayInto(viewer);
 
     using var replayed = viewer.CreateSnapshot(scrollbackLines: viewer.ScrollbackCount);
 
@@ -689,10 +687,26 @@ static async Task<string> InspectRecordReplayWithDamageAsync(RawSnapshotExportRe
         {
             damageMatches = false;
         }
+        for (var row = 0; damageMatches && row < original.PaintedRowCount; row++)
+        {
+            for (var column = 0; column < original.PaintedColumnCount; column++)
+            {
+                var originalRow = original.PaintedTop + row;
+                var originalColumn = original.PaintedLeft + column;
+                var replayedRow = replayedPlacement.PaintedTop + row;
+                var replayedColumn = replayedPlacement.PaintedLeft + column;
+                if (original.IsCellDamaged(originalRow, originalColumn) !=
+                    replayedPlacement.IsCellDamaged(replayedRow, replayedColumn))
+                {
+                    damageMatches = false;
+                    break;
+                }
+            }
+        }
     }
 
     builder.Append($"; surviving pixels match after record/replay: {pixelsMatch}");
-    builder.Append($"; painted (post-damage) extent matches after record/replay: {damageMatches}");
+    builder.Append($"; painted crop and damage mask match after record/replay: {damageMatches}");
     return builder.ToString();
 }
 
@@ -714,11 +728,8 @@ static async Task<string> InspectMainAlternateIndependenceAsync(RawSnapshotExpor
         using var snapshot = terminal.CreateSnapshot();
         var recorded = Hmp1SixelRecording.Serialize(snapshot.SixelPlacements);
         var deserialized = Hmp1SixelRecording.Deserialize(recorded);
-        var replayScript = deserialized.BuildReplayEscapeSequence();
-
-        await using var viewer = CreateSnapshotExportReplayTerminalBuilder(
-            Encoding.ASCII.GetBytes(replayScript), 0).Build();
-        await viewer.RunAsync();
+        using var viewer = CreateSnapshotExportReplayTerminalBuilder([], 0).Build();
+        deserialized.ReplayInto(viewer);
         using var replayed = viewer.CreateSnapshot();
 
         var pixelsMatch = snapshot.SixelPlacements.Count == replayed.SixelPlacements.Count

--- a/samples/SixelWidgetDemo/Program.cs
+++ b/samples/SixelWidgetDemo/Program.cs
@@ -1,0 +1,151 @@
+#pragma warning disable HEX1B_SIXEL // This sample demonstrates the experimental Sixel widget API.
+
+using Hex1b;
+using Hex1b.Layout;
+using Hex1b.Sixel;
+using Hex1b.Surfaces;
+using Hex1b.Widgets;
+
+var images = new[]
+{
+    CreateGradient(240, 120, Rgba32.FromRgb(20, 90, 220), Rgba32.FromRgb(255, 80, 70)),
+    CreateCheckerboard(240, 120, 20),
+    CreateRings(240, 120)
+};
+
+var selectedImage = 0;
+var horizontalOffset = 0;
+var showMovingImage = true;
+
+await using var terminal = Hex1bTerminal.CreateBuilder()
+    .WithHex1bApp(ctx => ctx.VStack(root =>
+    [
+        root.Text("SixelWidget: structured pixels, native output, Surface composition"),
+        root.Text("Use Tab/Shift+Tab and Enter to replace, move, or remove the lower image."),
+        root.HStack(row =>
+        [
+            row.Border(
+                    row.Sixel(
+                        images[0],
+                        fallback => fallback.Text("[Sixel unavailable: natural-size image]")))
+                .Title("Natural pixel-to-cell size"),
+            row.Border(
+                    row.Sixel(
+                            images[1],
+                            fallback => fallback.Text("[Sixel unavailable: explicit-size image]"))
+                        .Width(24)
+                        .Height(8))
+                .Title("Explicit 24x8 cells")
+        ]).ContentHeight(),
+        root.Border(
+                root.HScrollPanel(
+                    root.Sixel(
+                            images[2],
+                            fallback => fallback.Text("[Sixel unavailable: clipped image]"))
+                        .Width(42)
+                        .Height(9),
+                    showScrollbar: false))
+            .Title("Clipped to a 28x8 viewport")
+            .FixedWidth(30)
+            .FixedHeight(10),
+        root.Border(
+                root.ZStack(stack =>
+                [
+                    stack.Sixel(
+                            images[selectedImage],
+                            fallback => fallback.Text("[Sixel unavailable: replacement image]"))
+                        .Width(32)
+                        .Height(9),
+                    stack.Center(center => center.Border(
+                        center.Text(" text over Sixel ")))
+                ]))
+            .Title("Deterministic text overlap")
+            .FixedWidth(34)
+            .FixedHeight(11),
+        root.HStack(row =>
+        [
+            row.Button("Replace").OnClick(_ => selectedImage = (selectedImage + 1) % images.Length),
+            row.Button("Move").OnClick(_ => horizontalOffset = (horizontalOffset + 4) % 17),
+            row.Button(showMovingImage ? "Remove" : "Restore").OnClick(_ => showMovingImage = !showMovingImage)
+        ]).ContentHeight(),
+        root.Border(
+                root.HStack(row =>
+                [
+                    row.Text(new string(' ', horizontalOffset)),
+                    showMovingImage
+                        ? row.Sixel(
+                                images[selectedImage],
+                                fallback => fallback.Text("[Sixel unavailable: moving image]"))
+                            .Width(24)
+                            .Height(7)
+                        : row.Text("[image removed; prior pixels should be cleared]")
+                ]))
+            .Title($"Replacement / movement / removal (offset {horizontalOffset})")
+            .FixedHeight(9)
+    ]))
+    .Build();
+
+await terminal.RunAsync();
+
+static SixelPixelBuffer CreateGradient(int width, int height, Rgba32 start, Rgba32 end)
+{
+    var pixels = new SixelPixelBuffer(width, height);
+    for (var y = 0; y < height; y++)
+    {
+        for (var x = 0; x < width; x++)
+        {
+            var amount = (double)(x + y) / (width + height - 2);
+            pixels[x, y] = new Rgba32(
+                Lerp(start.R, end.R, amount),
+                Lerp(start.G, end.G, amount),
+                Lerp(start.B, end.B, amount),
+                255);
+        }
+    }
+
+    return pixels;
+}
+
+static SixelPixelBuffer CreateCheckerboard(int width, int height, int squareSize)
+{
+    var pixels = new SixelPixelBuffer(width, height);
+    for (var y = 0; y < height; y++)
+    {
+        for (var x = 0; x < width; x++)
+        {
+            var bright = ((x / squareSize) + (y / squareSize)) % 2 == 0;
+            pixels[x, y] = bright
+                ? Rgba32.FromRgb(255, 200, 40)
+                : Rgba32.FromRgb(70, 20, 130);
+        }
+    }
+
+    return pixels;
+}
+
+static SixelPixelBuffer CreateRings(int width, int height)
+{
+    var pixels = new SixelPixelBuffer(width, height);
+    var centerX = (width - 1) / 2d;
+    var centerY = (height - 1) / 2d;
+    for (var y = 0; y < height; y++)
+    {
+        for (var x = 0; x < width; x++)
+        {
+            var distance = Math.Sqrt(
+                Math.Pow((x - centerX) / width, 2) +
+                Math.Pow((y - centerY) / height, 2));
+            var wave = (Math.Sin(distance * 90) + 1) / 2;
+            pixels[x, y] = new Rgba32(
+                (byte)(20 + wave * 40),
+                (byte)(90 + wave * 150),
+                (byte)(120 + wave * 135),
+                255);
+        }
+    }
+
+    return pixels;
+}
+
+static byte Lerp(byte start, byte end, double amount)
+    => (byte)Math.Round(start + ((end - start) * amount));

--- a/samples/SixelWidgetDemo/SixelWidgetDemo.csproj
+++ b/samples/SixelWidgetDemo/SixelWidgetDemo.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Hex1b\Hex1b.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Hex1b.Website/Examples/SixelExample.cs
+++ b/src/Hex1b.Website/Examples/SixelExample.cs
@@ -1,200 +1,122 @@
+#pragma warning disable HEX1B_SIXEL // The gallery demonstrates the experimental Sixel API.
+
 using Hex1b;
-using Hex1b.Layout;
+using Hex1b.Surfaces;
 using Hex1b.Widgets;
 using Microsoft.Extensions.Logging;
 
 namespace Hex1b.Website.Examples;
 
 /// <summary>
-/// An example demonstrating Sixel graphics support with fallback for terminals
-/// that don't support Sixel.
+/// Demonstrates structured Sixel pixels, explicit sizing, fallback content,
+/// and image replacement through the normal widget pipeline.
 /// </summary>
-public class SixelExample : Hex1bExample
+public class SixelExample(ILogger<SixelExample> logger) : Hex1bExample
 {
-    private readonly ILogger<SixelExample> _logger;
-    private readonly IWebHostEnvironment _environment;
-
-    public SixelExample(ILogger<SixelExample> logger, IWebHostEnvironment environment)
-    {
-        _logger = logger;
-        _environment = environment;
-    }
+    private readonly ILogger<SixelExample> _logger = logger;
 
     public override string Id => "sixel";
     public override string Title => "Sixel Graphics";
-    public override string Description => "Sixel image rendering with automatic fallback for unsupported terminals.";
-
-    /// <summary>
-    /// Represents a sample image for the gallery.
-    /// </summary>
-    private class SampleImage
-    {
-        public required string Id { get; init; }
-        public required string Name { get; init; }
-        public required string Description { get; init; }
-        public required string FilePath { get; init; }
-        public string? CachedSixelData { get; set; }
-        public int CachedWidth { get; set; }
-        public int CachedHeight { get; set; }
-    }
-
-    /// <summary>
-    /// State for the Sixel exhibit.
-    /// </summary>
-    private class SixelState
-    {
-        public int SelectedImageIndex { get; set; }
-        public List<SampleImage> Images { get; } = [];
-        public IReadOnlyList<string> ImageItems { get; set; } = [];
-        
-        public SampleImage? SelectedImage => 
-            SelectedImageIndex >= 0 && SelectedImageIndex < Images.Count 
-                ? Images[SelectedImageIndex] 
-                : null;
-    }
+    public override string Description => "Structured Sixel rendering with terminal-aware sizing and fallback content.";
 
     public override Func<Hex1bWidget> CreateWidgetBuilder()
     {
-        _logger.LogInformation("Creating widget builder for Sixel example");
+        _logger.LogInformation("Creating Sixel widget example");
 
-        var state = new SixelState();
-        var imagesPath = Path.Combine(_environment.WebRootPath, "images");
-        
-        // Add real images from wwwroot/images
-        if (Directory.Exists(imagesPath))
+        var images = new[]
         {
-            var imageFiles = Directory.GetFiles(imagesPath, "*.*")
-                .Where(f => f.EndsWith(".svg", StringComparison.OrdinalIgnoreCase) ||
-                           f.EndsWith(".jpg", StringComparison.OrdinalIgnoreCase) ||
-                           f.EndsWith(".jpeg", StringComparison.OrdinalIgnoreCase) ||
-                           f.EndsWith(".png", StringComparison.OrdinalIgnoreCase) ||
-                           f.EndsWith(".gif", StringComparison.OrdinalIgnoreCase) ||
-                           f.EndsWith(".bmp", StringComparison.OrdinalIgnoreCase))
-                .ToList();
-
-            foreach (var filePath in imageFiles)
-            {
-                var fileName = Path.GetFileNameWithoutExtension(filePath);
-                state.Images.Add(new SampleImage
-                {
-                    Id = fileName.ToLowerInvariant(),
-                    Name = char.ToUpper(fileName[0]) + fileName[1..],
-                    Description = $"Image: {Path.GetFileName(filePath)}",
-                    FilePath = filePath
-                });
-            }
-        }
-
-        // If no images found, add a placeholder
-        if (state.Images.Count == 0)
-        {
-            _logger.LogWarning("No images found in {Path}", imagesPath);
-        }
-
-        state.ImageItems = state.Images
-            .Select(img => img.Name)
-            .ToList();
+            CreateGradient(240, 120, Rgba32.FromRgb(20, 90, 220), Rgba32.FromRgb(255, 80, 70)),
+            CreateCheckerboard(240, 120, 20),
+            CreateRings(240, 120)
+        };
+        var selectedImage = 0;
 
         return () =>
         {
-            var ctx = new RootContext();
-            var selectedImage = state.SelectedImage;
-
-            // Calculate available space for the image
-            // Right panel gets about 60% of 80 cols = ~48 cols, minus borders = ~44 cols
-            // Height is typically 24 rows minus headers = ~18 rows
-            const int imageWidthCells = 44;
-            const int imageHeightCells = 16;
-
-            // Get or generate sixel data for the selected image
-            string sixelData = "";
-            if (selectedImage != null)
-            {
-                // Check if we need to regenerate (size changed or first time)
-                if (selectedImage.CachedSixelData == null ||
-                    selectedImage.CachedWidth != imageWidthCells ||
-                    selectedImage.CachedHeight != imageHeightCells)
-                {
-                    try
-                    {
-                        _logger.LogInformation("Encoding {Image} at {W}x{H} cells", 
-                            selectedImage.Name, imageWidthCells, imageHeightCells);
-                        
-                        sixelData = SixelEncoder.EncodeFromFile(
-                            selectedImage.FilePath,
-                            imageWidthCells,
-                            imageHeightCells);
-                        
-                        // Cache the result
-                        selectedImage.CachedSixelData = sixelData;
-                        selectedImage.CachedWidth = imageWidthCells;
-                        selectedImage.CachedHeight = imageHeightCells;
-                        
-                        _logger.LogInformation("Encoded {Image}: {Len} bytes", 
-                            selectedImage.Name, sixelData.Length);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.LogError(ex, "Failed to encode {Image}", selectedImage.Name);
-                        sixelData = "";
-                    }
-                }
-                else
-                {
-                    sixelData = selectedImage.CachedSixelData;
-                }
-            }
-
-            var widget = ctx.HSplitter(
-                // Left panel: Image list
-                ctx.Layout(leftPanel => [
-                    leftPanel.Text("═══ Images ═══"),
-                    leftPanel.Text(""),
-                    leftPanel.List(state.ImageItems).OnSelectionChanged(e => state.SelectedImageIndex = e.SelectedIndex),
-                    leftPanel.Text(""),
-                    leftPanel.Text("Use ↑↓ to select"),
-                    leftPanel.Text("Tab to switch panels")
-                ]),
-                // Right panel: Image viewer
-                ctx.Layout(rightPanel => selectedImage != null
-                    ? [
-                        rightPanel.Text($"═══ {selectedImage.Name} ═══"),
-                        rightPanel.Text(""),
-                        rightPanel.Text(selectedImage.Description),
-                        rightPanel.Text(""),
-                        string.IsNullOrEmpty(sixelData)
-                            ? rightPanel.Text("[Failed to load image]")
-                            : rightPanel.Sixel(
-                                sixelData,
-                                rightPanel.VStack(fallback => [
-                                    fallback.Text("┌─────────────────────────────────┐"),
-                                    fallback.Text("│  Sixel graphics not supported   │"),
-                                    fallback.Text("│  in this terminal.              │"),
-                                    fallback.Text("│                                 │"),
-                                    fallback.Text("│  Try using a Sixel-capable      │"),
-                                    fallback.Text("│  terminal like:                 │"),
-                                    fallback.Text("│  • xterm -ti vt340              │"),
-                                    fallback.Text("│  • mlterm                       │"),
-                                    fallback.Text("│  • foot                         │"),
-                                    fallback.Text("│  • WezTerm                      │"),
-                                    fallback.Text("└─────────────────────────────────┘"),
-                                ]),
-                                width: imageWidthCells,
-                                height: imageHeightCells)
-                      ]
-                    : [
-                        rightPanel.Text("═══ No Image Selected ═══"),
-                        rightPanel.Text(""),
-                        rightPanel.Text("Select an image from the list"),
-                        rightPanel.Text(""),
-                        state.Images.Count == 0
-                            ? rightPanel.Text("No images found in wwwroot/images/")
-                            : rightPanel.Text($"Found {state.Images.Count} image(s)")
-                      ]),
-                leftWidth: 25
-            );
-
-            return widget;
+            var context = new RootContext();
+            return context.VStack(root =>
+            [
+                root.Text("SixelWidget uses structured RGBA pixels."),
+                root.Text("Select an image to exercise replacement without ghost pixels."),
+                root.Picker(["Gradient", "Checkerboard", "Rings"], selectedImage)
+                    .OnSelectionChanged(e => selectedImage = e.SelectedIndex)
+                    .ContentHeight(),
+                root.Border(
+                        root.Sixel(
+                                images[selectedImage],
+                                fallback => fallback.VStack(column =>
+                                [
+                                    column.Text("Sixel graphics are unavailable."),
+                                    column.Text("The fallback participates in normal layout and focus.")
+                                ]))
+                            .Width(36)
+                            .Height(12))
+                    .Title("Structured pixels - 36x12 cells")
+                    .FixedWidth(38)
+                    .FixedHeight(14)
+            ]);
         };
     }
+
+    private static SixelPixelBuffer CreateGradient(int width, int height, Rgba32 start, Rgba32 end)
+    {
+        var pixels = new SixelPixelBuffer(width, height);
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var amount = (double)(x + y) / (width + height - 2);
+                pixels[x, y] = new Rgba32(
+                    Lerp(start.R, end.R, amount),
+                    Lerp(start.G, end.G, amount),
+                    Lerp(start.B, end.B, amount),
+                    255);
+            }
+        }
+
+        return pixels;
+    }
+
+    private static SixelPixelBuffer CreateCheckerboard(int width, int height, int squareSize)
+    {
+        var pixels = new SixelPixelBuffer(width, height);
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                pixels[x, y] = ((x / squareSize) + (y / squareSize)) % 2 == 0
+                    ? Rgba32.FromRgb(255, 200, 40)
+                    : Rgba32.FromRgb(70, 20, 130);
+            }
+        }
+
+        return pixels;
+    }
+
+    private static SixelPixelBuffer CreateRings(int width, int height)
+    {
+        var pixels = new SixelPixelBuffer(width, height);
+        var centerX = (width - 1) / 2d;
+        var centerY = (height - 1) / 2d;
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var distance = Math.Sqrt(
+                    Math.Pow((x - centerX) / width, 2) +
+                    Math.Pow((y - centerY) / height, 2));
+                var wave = (Math.Sin(distance * 90) + 1) / 2;
+                pixels[x, y] = new Rgba32(
+                    (byte)(20 + wave * 40),
+                    (byte)(90 + wave * 150),
+                    (byte)(120 + wave * 135),
+                    255);
+            }
+        }
+
+        return pixels;
+    }
+
+    private static byte Lerp(byte start, byte end, double amount)
+        => (byte)Math.Round(start + ((end - start) * amount));
 }

--- a/src/Hex1b/Automation/Hex1bTerminalSnapshot.cs
+++ b/src/Hex1b/Automation/Hex1bTerminalSnapshot.cs
@@ -248,25 +248,25 @@ public sealed class Hex1bTerminalSnapshot : IHex1bTerminalRegion, IDisposable
     /// Analogous to <see cref="KgpPlacements"/> but sized and shaped for the
     /// Sixel protocol: there is no image ID (Sixel has no protocol concept
     /// of one), so placements reference their <see cref="SixelPlacement.Image"/>
-    /// directly and <see cref="SixelImages"/> is keyed by content hash instead.
-    /// Each placement captures its own creation-time
-    /// <see cref="Sixel.SixelCellMetrics"/>, painted/declared extents, and
-    /// per-cell damage independently of any other placement, and remains
-    /// valid for the lifetime of this snapshot even after the live terminal
-    /// erases, prunes, or resets the placement that produced it.
+    /// directly and <see cref="SixelImages"/> is keyed by resource identity
+    /// hash instead.
+    /// Each placement references an image resource whose identity includes its
+    /// creation-time <see cref="Sixel.SixelCellMetrics"/> and declared cell
+    /// span. Painted extents and per-cell damage remain placement-specific, and
+    /// the complete placement remains valid for the lifetime of this snapshot
+    /// even after the live terminal erases, prunes, or resets its source.
     /// </remarks>
     public IReadOnlyList<SixelPlacement> SixelPlacements { get; }
 
     /// <summary>
     /// Sixel image data referenced by the visible snapshot placements, keyed
-    /// by content hash.
+    /// by immutable resource identity hash.
     /// </summary>
     /// <remarks>
     /// An image's decoded raster (or geometry-only outcome) is retained once
-    /// per referenced image, never once per covered cell: two placements —
-    /// in this snapshot or across independently captured snapshots — that
-    /// reference the same content hash share the same <see cref="SixelData"/>
-    /// instance and its underlying raster.
+    /// per compatible resource identity, never once per covered cell. Two
+    /// placements share a <see cref="SixelData"/> instance only when their
+    /// payload, raster state, protocol metrics, and cell span are all equal.
     /// </remarks>
     public IReadOnlyDictionary<byte[], SixelData> SixelImages { get; }
 

--- a/src/Hex1b/Flow/Hex1bFlowRunner.cs
+++ b/src/Hex1b/Flow/Hex1bFlowRunner.cs
@@ -1097,6 +1097,7 @@ internal sealed class Hex1bFlowRunner
         // misbehaving widget can't allocate an unbounded surface.
         var measureMax = Math.Max(maxHeight * 10, maxHeight);
         var constraints = new Constraints(0, width, 0, measureMax);
+        node.SetTerminalCapabilities(_parentAdapter.Capabilities);
         var measured = node.Measure(constraints);
         var height = Math.Max(1, Math.Min(measured.Height, measureMax));
 

--- a/src/Hex1b/Hex1bApp.cs
+++ b/src/Hex1b/Hex1bApp.cs
@@ -1026,6 +1026,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         var frameCapabilities = _adapter.Capabilities;
         if (_rootNode != null)
         {
+            _rootNode.SetTerminalCapabilities(frameCapabilities);
             var terminalSize = new Size(frameWidth, frameHeight);
             var constraints = Constraints.Tight(terminalSize);
             _rootNode.Measure(constraints);
@@ -1213,6 +1214,8 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
 
             _adapter.Write("\x1b[0m\x1b[2J");
 
+            _currentSurface?.ClearAndReleaseTrackedObjects();
+            _previousSurface?.ClearAndReleaseTrackedObjects();
             _currentSurface = new Surface(width, height, cellMetrics);
             _previousSurface = new Surface(width, height, cellMetrics);
             _isFirstFrame = true;
@@ -1221,7 +1224,7 @@ public class Hex1bApp : IDisposable, IAsyncDisposable, IDiagnosticTreeProvider
         // Swap buffers (reuse previous surface as current for double-buffering)
         // After the needNewSurfaces block, both surfaces are guaranteed non-null
         (_previousSurface, _currentSurface) = (_currentSurface!, _previousSurface!);
-        _currentSurface.Clear();
+        _currentSurface.ClearAndReleaseTrackedObjects();
 
         if (_kgpRetransmitPendingAfterResize && !needNewSurfaces)
         {

--- a/src/Hex1b/Hex1bRenderContext.cs
+++ b/src/Hex1b/Hex1bRenderContext.cs
@@ -70,6 +70,7 @@ public class Hex1bRenderContext
 
     /// <summary>
     /// Writes structured pixels as a native Sixel sequence at the current cursor position.
+    /// The pixels are resampled to the requested cell span using the active Sixel protocol metrics.
     /// Surface-backed contexts override this operation to retain structured Sixel content.
     /// </summary>
     /// <param name="pixels">The pixels to encode.</param>
@@ -85,11 +86,20 @@ public class Hex1bRenderContext
     public virtual void WriteSixel(SixelPixelBuffer pixels, int cellWidth, int cellHeight)
     {
         ArgumentNullException.ThrowIfNull(pixels);
-        WriteSixel(SixelEncoder.Encode(pixels), cellWidth, cellHeight);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(cellWidth);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(cellHeight);
+
+        var metrics = Capabilities.SixelCellMetrics ?? SixelCellMetrics.FromCapabilities(Capabilities);
+        var resized = pixels.Resize(
+            metrics.GetPixelWidthForColumns(cellWidth),
+            metrics.GetPixelHeightForRows(cellHeight));
+        Write(SixelEncoder.Encode(resized));
     }
 
     /// <summary>
     /// Writes validated pre-encoded Sixel data at the current cursor position.
+    /// Pre-encoded content is not resampled and must naturally occupy the requested
+    /// cell span under the active Sixel protocol metrics.
     /// Surface-backed contexts override this operation to retain structured Sixel content.
     /// </summary>
     /// <param name="imageData">
@@ -98,7 +108,8 @@ public class Hex1bRenderContext
     /// <param name="cellWidth">The occupied width in terminal cells.</param>
     /// <param name="cellHeight">The occupied height in terminal cells.</param>
     /// <exception cref="ArgumentException">
-    /// Thrown when <paramref name="imageData"/> is malformed or incomplete.
+    /// Thrown when <paramref name="imageData"/> is malformed, incomplete, or
+    /// does not naturally occupy the requested cell span.
     /// </exception>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="imageData"/> is <see langword="null"/>.
@@ -111,7 +122,11 @@ public class Hex1bRenderContext
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(cellWidth);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(cellHeight);
-        Write(SixelPayload.NormalizeAndValidate(imageData, nameof(imageData)));
+        var payload = SixelPayload.NormalizeAndValidate(imageData, nameof(imageData));
+        var parseResult = SixelParser.ParsePayload(payload);
+        var metrics = Capabilities.SixelCellMetrics ?? SixelCellMetrics.FromCapabilities(Capabilities);
+        SixelPayload.ValidateCellSpan(parseResult, metrics, cellWidth, cellHeight, nameof(imageData));
+        Write(payload);
     }
     
     /// <summary>

--- a/src/Hex1b/Hex1bRenderContext.cs
+++ b/src/Hex1b/Hex1bRenderContext.cs
@@ -2,6 +2,8 @@ using System.Security.Cryptography;
 using System.Buffers.Binary;
 using Hex1b.Layout;
 using Hex1b.Nodes;
+using Hex1b.Sixel;
+using Hex1b.Surfaces;
 using Hex1b.Theming;
 
 namespace Hex1b;
@@ -65,6 +67,52 @@ public class Hex1bRenderContext
     public virtual void Write(string text) => _adapter?.Write(text);
     public virtual void Clear() => _adapter?.Clear();
     public virtual void SetCursorPosition(int left, int top) => _adapter?.SetCursorPosition(left, top);
+
+    /// <summary>
+    /// Writes structured pixels as a native Sixel sequence at the current cursor position.
+    /// Surface-backed contexts override this operation to retain structured Sixel content.
+    /// </summary>
+    /// <param name="pixels">The pixels to encode.</param>
+    /// <param name="cellWidth">The occupied width in terminal cells.</param>
+    /// <param name="cellHeight">The occupied height in terminal cells.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="pixels"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="cellWidth"/> or <paramref name="cellHeight"/> is not positive.
+    /// </exception>
+    [System.Diagnostics.CodeAnalysis.Experimental("HEX1B_SIXEL", UrlFormat = "https://github.com/hex1b/hex1b/blob/main/docs/experimental/sixel.md")]
+    public virtual void WriteSixel(SixelPixelBuffer pixels, int cellWidth, int cellHeight)
+    {
+        ArgumentNullException.ThrowIfNull(pixels);
+        WriteSixel(SixelEncoder.Encode(pixels), cellWidth, cellHeight);
+    }
+
+    /// <summary>
+    /// Writes validated pre-encoded Sixel data at the current cursor position.
+    /// Surface-backed contexts override this operation to retain structured Sixel content.
+    /// </summary>
+    /// <param name="imageData">
+    /// A complete Sixel DCS sequence, or the Sixel body without its DCS framing.
+    /// </param>
+    /// <param name="cellWidth">The occupied width in terminal cells.</param>
+    /// <param name="cellHeight">The occupied height in terminal cells.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="imageData"/> is malformed or incomplete.
+    /// </exception>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="imageData"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="cellWidth"/> or <paramref name="cellHeight"/> is not positive.
+    /// </exception>
+    [System.Diagnostics.CodeAnalysis.Experimental("HEX1B_SIXEL", UrlFormat = "https://github.com/hex1b/hex1b/blob/main/docs/experimental/sixel.md")]
+    public virtual void WriteSixel(string imageData, int cellWidth, int cellHeight)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(cellWidth);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(cellHeight);
+        Write(SixelPayload.NormalizeAndValidate(imageData, nameof(imageData)));
+    }
     
     /// <summary>
     /// Writes a KGP image at the current cursor position.

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -6244,6 +6244,12 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             ?? Sixel.SixelCellMetrics.FromCapabilities(Capabilities);
 
     /// <summary>
+    /// Gets the explicit protocol-metric override, preserving whether metrics
+    /// currently come from capabilities rather than an override.
+    /// </summary>
+    internal Sixel.SixelCellMetrics? SixelCellMetricsOverride => _sixelCellMetricsOverride;
+
+    /// <summary>
     /// Overrides the protocol cell metrics used for new Sixel placements.
     /// </summary>
     /// <param name="metrics">The metrics to use, or <see langword="null"/> to derive them from capabilities.</param>

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -2718,11 +2718,12 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     /// active screen's graphics state.
     /// </summary>
     /// <remarks>
-    /// This deliberately counts distinct <em>images</em> (content-hash-deduplicated
-    /// raster resources), matching the historical dedup semantics of the
-    /// old <see cref="TrackedObjectStore"/>-backed counter it replaces. Use
+    /// This deliberately counts distinct <em>images</em> (identity-deduplicated
+    /// raster resources), matching the historical dedup semantics of the old
+    /// <see cref="TrackedObjectStore"/>-backed counter it replaces. Use
     /// <see cref="SixelPlacementCount"/> for the number of placements, which
-    /// may exceed the image count when placements share raster content.
+    /// may exceed the image count when placements share raster content,
+    /// protocol metrics, and cell span.
     /// </remarks>
     internal int TrackedSixelCount => _sixelGraphicsState.ActiveImages.Count;
 

--- a/src/Hex1b/Hmp1/Hmp1SixelRecordedImage.cs
+++ b/src/Hex1b/Hmp1/Hmp1SixelRecordedImage.cs
@@ -12,6 +12,7 @@ internal sealed class Hmp1SixelRecordedImage(
     int declaredPixelHeight,
     int widthInCells,
     int heightInCells,
+    SixelCellMetrics? cellMetrics,
     SixelRasterStatus rasterStatus,
     string payload)
 {
@@ -35,6 +36,12 @@ internal sealed class Hmp1SixelRecordedImage(
 
     /// <summary>The image height in cells.</summary>
     public int HeightInCells { get; } = heightInCells;
+
+    /// <summary>
+    /// The exact protocol metrics captured with this image, or
+    /// <see langword="null"/> for a version 1 recording that did not persist them.
+    /// </summary>
+    public SixelCellMetrics? CellMetrics { get; } = cellMetrics;
 
     /// <summary>The raster outcome captured at recording time.</summary>
     public SixelRasterStatus RasterStatus { get; } = rasterStatus;

--- a/src/Hex1b/Hmp1/Hmp1SixelRecordedImage.cs
+++ b/src/Hex1b/Hmp1/Hmp1SixelRecordedImage.cs
@@ -15,7 +15,10 @@ internal sealed class Hmp1SixelRecordedImage(
     SixelRasterStatus rasterStatus,
     string payload)
 {
-    /// <summary>The image's content hash, as captured from <see cref="SixelData.ContentHash"/>.</summary>
+    /// <summary>
+    /// The image's resource identity hash, as captured from
+    /// <see cref="SixelData.ContentHash"/>.
+    /// </summary>
     public byte[] ContentHash { get; } = contentHash;
 
     /// <summary>Whether this image carries no decoded pixels.</summary>

--- a/src/Hex1b/Hmp1/Hmp1SixelRecording.cs
+++ b/src/Hex1b/Hmp1/Hmp1SixelRecording.cs
@@ -18,11 +18,11 @@ namespace Hex1b;
 /// Sixel parser.
 /// </para>
 /// <para>
-/// Images are content-addressed and deduplicated by <see cref="SixelData.ContentHash"/>:
-/// multiple placements sharing a raster reference the same image table entry, so
-/// pixel payloads are never repeated within a single recording (unlike the live
-/// wire replay, where the Sixel protocol has no "reuse an existing image at a new
-/// position" primitive).
+/// Images are identity-addressed and deduplicated by
+/// <see cref="SixelData.ContentHash"/>. Multiple placements share an image table
+/// entry only when their raster state, protocol metrics, and cell span are all
+/// compatible, so a recording never conflates placements whose pixels must be
+/// clipped or damaged on different protocol grids.
 /// </para>
 /// </remarks>
 internal static class Hmp1SixelRecording

--- a/src/Hex1b/Hmp1/Hmp1SixelRecording.cs
+++ b/src/Hex1b/Hmp1/Hmp1SixelRecording.cs
@@ -24,12 +24,19 @@ namespace Hex1b;
 /// compatible, so a recording never conflates placements whose pixels must be
 /// clipped or damaged on different protocol grids.
 /// </para>
+/// <para>
+/// Version 2 persists each image's exact protocol-metric bit patterns, source,
+/// and reliability. Version 1 remains readable for compatibility, but replays
+/// with the target terminal's current metrics because that version did not
+/// record per-image metric context.
+/// </para>
 /// </remarks>
 internal static class Hmp1SixelRecording
 {
     private static readonly byte[] Magic = "SXRC"u8.ToArray();
 
-    internal const int CurrentVersion = 1;
+    internal const int CurrentVersion = 2;
+    internal const int MinimumSupportedVersion = 1;
     internal const int MaxPlacementCount = Hmp1SixelLimits.MaximumPlacementCount;
     internal const int MaxImageCount = Hmp1SixelLimits.MaximumImageCount;
     internal const int MaxPayloadLength = Hmp1SixelLimits.MaximumSequenceBytes;
@@ -162,11 +169,11 @@ internal static class Hmp1SixelRecording
         }
 
         var version = ReadInt32(reader);
-        if (version != CurrentVersion)
+        if (version < MinimumSupportedVersion || version > CurrentVersion)
         {
             throw new Hmp1SixelRecordingException(
                 Hmp1SixelRecordingFailureReason.UnsupportedVersion,
-                $"Recording version {version} is not supported. Supported version: {CurrentVersion}.");
+                $"Recording version {version} is not supported. Supported versions: {MinimumSupportedVersion}-{CurrentVersion}.");
         }
 
         var placementCount = ReadInt32(reader);
@@ -178,7 +185,7 @@ internal static class Hmp1SixelRecording
         long totalPayloadLength = 0;
         for (var i = 0; i < imageCount; i++)
         {
-            var image = ReadImage(reader, ref totalPayloadLength);
+            var image = ReadImage(reader, version, ref totalPayloadLength);
             images.Add(image);
         }
 
@@ -186,7 +193,7 @@ internal static class Hmp1SixelRecording
         var totalDamagedCells = 0;
         for (var i = 0; i < placementCount; i++)
         {
-            placements.Add(ReadPlacement(reader, imageCount, ref totalDamagedCells));
+            placements.Add(ReadPlacement(reader, images, ref totalDamagedCells));
         }
 
         if (stream.Position != stream.Length)
@@ -207,6 +214,10 @@ internal static class Hmp1SixelRecording
         writer.Write(image.PixelHeight);
         writer.Write(image.WidthInCells);
         writer.Write(image.HeightInCells);
+        writer.Write(BitConverter.DoubleToInt64Bits(image.CellMetrics.Width));
+        writer.Write(BitConverter.DoubleToInt64Bits(image.CellMetrics.Height));
+        writer.Write((byte)image.CellMetrics.Source);
+        writer.Write((byte)image.CellMetrics.Reliability);
         writer.Write((byte)image.RasterStatus);
         writer.Write(payloadBytes.Length);
         writer.Write(payloadBytes);
@@ -301,7 +312,10 @@ internal static class Hmp1SixelRecording
         return totalDamagedCells + damagedCells.Count;
     }
 
-    private static Hmp1SixelRecordedImage ReadImage(BinaryReader reader, ref long totalPayloadLength)
+    private static Hmp1SixelRecordedImage ReadImage(
+        BinaryReader reader,
+        int version,
+        ref long totalPayloadLength)
     {
         var contentHash = ReadExact(reader, 32);
         var isGeometryOnly = ReadBool(reader);
@@ -309,6 +323,27 @@ internal static class Hmp1SixelRecording
         var declaredPixelHeight = ReadInt32(reader);
         var widthInCells = ReadInt32(reader);
         var heightInCells = ReadInt32(reader);
+        SixelCellMetrics? cellMetrics = null;
+        if (version >= 2)
+        {
+            var widthBits = ReadInt64(reader);
+            var heightBits = ReadInt64(reader);
+            var sourceByte = ReadByte(reader);
+            var reliabilityByte = ReadByte(reader);
+            if (!Enum.IsDefined(typeof(SixelCellMetricsSource), (int)sourceByte) ||
+                !Enum.IsDefined(typeof(SixelCellMetricsReliability), (int)reliabilityByte))
+            {
+                throw new Hmp1SixelRecordingException(
+                    Hmp1SixelRecordingFailureReason.Malformed,
+                    $"Image declares unrecognized Sixel metric metadata ({sourceByte}/{reliabilityByte}).");
+            }
+
+            cellMetrics = new SixelCellMetrics(
+                BitConverter.Int64BitsToDouble(widthBits),
+                BitConverter.Int64BitsToDouble(heightBits),
+                (SixelCellMetricsSource)sourceByte,
+                (SixelCellMetricsReliability)reliabilityByte);
+        }
         var rasterStatusByte = ReadByte(reader);
         var payloadLength = ReadInt32(reader);
 
@@ -349,13 +384,14 @@ internal static class Hmp1SixelRecording
             declaredPixelHeight,
             widthInCells,
             heightInCells,
+            cellMetrics,
             (SixelRasterStatus)rasterStatusByte,
             Encoding.UTF8.GetString(payloadBytes));
     }
 
     private static Hmp1SixelRecordedPlacement ReadPlacement(
         BinaryReader reader,
-        int imageCount,
+        IReadOnlyList<Hmp1SixelRecordedImage> images,
         ref int totalDamagedCells)
     {
         var imageIndex = ReadInt32(reader);
@@ -371,18 +407,28 @@ internal static class Hmp1SixelRecording
         var createdAtUnixMs = ReadInt64(reader);
         var damagedCellCount = ReadInt32(reader);
 
-        if (imageIndex < 0 || imageIndex >= imageCount)
+        if (imageIndex < 0 || imageIndex >= images.Count)
         {
             throw new Hmp1SixelRecordingException(
                 Hmp1SixelRecordingFailureReason.MissingImageReference,
-                $"Placement references image index {imageIndex}, but the recording only has {imageCount} image(s).");
+                $"Placement references image index {imageIndex}, but the recording only has {images.Count} image(s).");
         }
 
-        if (widthInCells <= 0 || heightInCells <= 0 || paintedRowCount < 0 || paintedColumnCount < 0)
+        var image = images[imageIndex];
+        if (widthInCells <= 0 ||
+            heightInCells <= 0 ||
+            widthInCells != image.WidthInCells ||
+            heightInCells != image.HeightInCells ||
+            paintedRowOffset < 0 ||
+            paintedRowCount < 0 ||
+            paintedColumnOffset < 0 ||
+            paintedColumnCount < 0 ||
+            paintedRowOffset > heightInCells - paintedRowCount ||
+            paintedColumnOffset > widthInCells - paintedColumnCount)
         {
             throw new Hmp1SixelRecordingException(
                 Hmp1SixelRecordingFailureReason.InvalidGeometry,
-                $"Placement declares invalid geometry (cells {widthInCells}x{heightInCells}, painted {paintedRowCount}x{paintedColumnCount}).");
+                $"Placement declares invalid geometry (cells {widthInCells}x{heightInCells}, painted rows {paintedRowOffset}+{paintedRowCount}, painted columns {paintedColumnOffset}+{paintedColumnCount}).");
         }
 
         if (damagedCellCount < 0 || damagedCellCount > MaxDamagedCellCount)
@@ -403,6 +449,15 @@ internal static class Hmp1SixelRecording
         {
             var damagedRow = ReadInt32(reader);
             var damagedCol = ReadInt32(reader);
+            if (damagedRow < paintedRowOffset ||
+                damagedRow >= paintedRowOffset + paintedRowCount ||
+                damagedCol < paintedColumnOffset ||
+                damagedCol >= paintedColumnOffset + paintedColumnCount)
+            {
+                throw new Hmp1SixelRecordingException(
+                    Hmp1SixelRecordingFailureReason.InvalidGeometry,
+                    $"Damage cell ({damagedRow},{damagedCol}) lies outside the placement's painted crop.");
+            }
             damagedCells.Add((damagedRow, damagedCol));
         }
         totalDamagedCells += damagedCellCount;

--- a/src/Hex1b/Hmp1/Hmp1SixelRecordingSnapshot.cs
+++ b/src/Hex1b/Hmp1/Hmp1SixelRecordingSnapshot.cs
@@ -1,4 +1,6 @@
 using System.Text;
+using Hex1b.Sixel;
+using Hex1b.Tokens;
 
 namespace Hex1b;
 
@@ -22,23 +24,29 @@ internal sealed class Hmp1SixelRecordingSnapshot(
     public IReadOnlyList<Hmp1SixelRecordedPlacement> Placements { get; } = placements;
 
     /// <summary>
-    /// Builds the cursor-position + Sixel DCS escape sequence text needed to
-    /// reconstruct every placement in this recording on a fresh terminal, in
-    /// <see cref="Hmp1SixelRecordedPlacement.Sequence"/> order. Feeding the result
-    /// through the same tokenizer/apply path a live terminal uses for incoming
-    /// output (rather than a bespoke reconstruction) is what lets replay be
-    /// verified against the same authoritative parser/raster invariants used by
-    /// live terminal processing.
+    /// Replays every placement into a fresh terminal in
+    /// <see cref="Hmp1SixelRecordedPlacement.Sequence"/> order. Version 2
+    /// recordings apply each image's captured protocol metrics before feeding
+    /// its cursor-position and Sixel DCS through the ordinary tokenizer/apply
+    /// path. Version 1 recordings retain their legacy behavior and use the
+    /// target terminal's current metrics because that format did not persist
+    /// per-image metric context.
     /// </summary>
+    /// <param name="terminal">The fresh terminal that receives the recording.</param>
     /// <param name="cancellationToken">Stops validation or construction before completion.</param>
     /// <exception cref="Hmp1SixelRecordingException">
-    /// The expanded replay would exceed the internal aggregate replay limit.
+    /// The expanded replay would exceed the internal aggregate replay limit,
+    /// or the target cannot reproduce the recorded placement geometry.
     /// </exception>
     /// <exception cref="OperationCanceledException">
     /// <paramref name="cancellationToken"/> was cancelled.
     /// </exception>
-    public string BuildReplayEscapeSequence(CancellationToken cancellationToken = default)
+    public void ReplayInto(
+        Hex1bTerminal terminal,
+        CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(terminal);
+
         var orderedPlacements = Placements.OrderBy(p => p.Sequence).ToArray();
         long totalBytes = 0;
         foreach (var placement in orderedPlacements)
@@ -60,18 +68,82 @@ internal sealed class Hmp1SixelRecordingSnapshot(
             }
         }
 
-        var sb = new StringBuilder((int)totalBytes);
-        foreach (var placement in orderedPlacements)
+        var originalMetricsOverride = terminal.SixelCellMetricsOverride;
+        try
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            var image = Images[placement.ImageIndex];
-            sb.Append(FormattableString.Invariant(
-                $"\x1b[{placement.Row + 1};{placement.Column + 1}H"));
-            sb.Append(image.IsGeometryOnly
-                ? Hmp1SixelStateReplay.FramePayload(image.Payload)
-                : image.Payload);
+            foreach (var placement in orderedPlacements)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var image = Images[placement.ImageIndex];
+                terminal.SetSixelCellMetrics(image.CellMetrics ?? originalMetricsOverride);
+
+                var placementCountBefore = terminal.SixelPlacementCount;
+                var sequence = FormattableString.Invariant(
+                    $"\x1b[{placement.Row + 1};{placement.Column + 1}H") +
+                    (image.IsGeometryOnly
+                        ? Hmp1SixelStateReplay.FramePayload(image.Payload)
+                        : image.Payload);
+                terminal.ApplyTokens(AnsiTokenizer.Tokenize(sequence));
+
+                if (terminal.SixelPlacementCount != placementCountBefore + 1)
+                {
+                    throw new Hmp1SixelRecordingException(
+                        Hmp1SixelRecordingFailureReason.InvalidGeometry,
+                        "Replay did not create exactly one active Sixel placement. The target must be a fresh terminal large enough for the recorded viewport geometry.");
+                }
+
+                var replayed = terminal.SixelPlacements[^1];
+                ValidateReplayedPlacement(image, placement, replayed);
+                try
+                {
+                    replayed.RestoreVisibleState(
+                        placement.PaintedRowOffset,
+                        placement.PaintedRowCount,
+                        placement.PaintedColumnOffset,
+                        placement.PaintedColumnCount,
+                        placement.DamagedCells);
+                }
+                catch (ArgumentOutOfRangeException ex)
+                {
+                    throw new Hmp1SixelRecordingException(
+                        Hmp1SixelRecordingFailureReason.InvalidGeometry,
+                        ex.Message);
+                }
+            }
+        }
+        finally
+        {
+            terminal.SetSixelCellMetrics(originalMetricsOverride);
+        }
+    }
+
+    private static void ValidateReplayedPlacement(
+        Hmp1SixelRecordedImage image,
+        Hmp1SixelRecordedPlacement placement,
+        SixelPlacement replayed)
+    {
+        if (replayed.Row != placement.Row ||
+            replayed.Column != placement.Column ||
+            replayed.WidthInCells != placement.WidthInCells ||
+            replayed.HeightInCells != placement.HeightInCells)
+        {
+            throw new Hmp1SixelRecordingException(
+                Hmp1SixelRecordingFailureReason.InvalidGeometry,
+                "The target terminal could not reproduce the recorded placement geometry.");
         }
 
-        return sb.ToString();
+        if (image.CellMetrics is { } recordedMetrics &&
+            !MetricsEqual(recordedMetrics, replayed.Image.CellMetrics))
+        {
+            throw new Hmp1SixelRecordingException(
+                Hmp1SixelRecordingFailureReason.InvalidGeometry,
+                "The target terminal did not preserve the recording's protocol cell metrics.");
+        }
     }
+
+    private static bool MetricsEqual(SixelCellMetrics left, SixelCellMetrics right) =>
+        BitConverter.DoubleToInt64Bits(left.Width) == BitConverter.DoubleToInt64Bits(right.Width) &&
+        BitConverter.DoubleToInt64Bits(left.Height) == BitConverter.DoubleToInt64Bits(right.Height) &&
+        left.Source == right.Source &&
+        left.Reliability == right.Reliability;
 }

--- a/src/Hex1b/Nodes/Hex1bNode.cs
+++ b/src/Hex1b/Nodes/Hex1bNode.cs
@@ -57,6 +57,35 @@ public abstract class Hex1bNode
     internal int MetricChildIndex { get; set; }
 
     private string? _cachedMetricPath;
+    private TerminalCapabilities _terminalCapabilities = TerminalCapabilities.Minimal;
+
+    /// <summary>
+    /// Gets the terminal capabilities used for layout and input-tree decisions.
+    /// </summary>
+    protected TerminalCapabilities TerminalCapabilities => _terminalCapabilities;
+
+    internal void SetTerminalCapabilities(TerminalCapabilities capabilities)
+    {
+        ArgumentNullException.ThrowIfNull(capabilities);
+
+        if (_terminalCapabilities != capabilities)
+        {
+            _terminalCapabilities = capabilities;
+            OnTerminalCapabilitiesChanged();
+        }
+
+        foreach (var child in GetChildren())
+        {
+            child.SetTerminalCapabilities(capabilities);
+        }
+    }
+
+    /// <summary>
+    /// Called when terminal capabilities change.
+    /// </summary>
+    protected virtual void OnTerminalCapabilitiesChanged()
+    {
+    }
 
     /// <summary>
     /// Gets the hierarchical metric path for this node, composed from ancestor MetricName values.

--- a/src/Hex1b/Nodes/SixelNode.cs
+++ b/src/Hex1b/Nodes/SixelNode.cs
@@ -1,52 +1,43 @@
 using System.Diagnostics.CodeAnalysis;
 using Hex1b.Layout;
-using Hex1b.Widgets;
+using Hex1b.Sixel;
+using Hex1b.Surfaces;
 
 namespace Hex1b.Nodes;
 
 /// <summary>
-/// A node that renders Sixel graphics if the terminal supports it,
-/// otherwise falls back to rendering a fallback node.
-/// 
-/// Sixel support detection is done by querying the terminal with DA1 (Primary Device Attributes)
-/// escape sequence. If the response includes ";4" (graphics capability), Sixel is supported.
-/// The query is sent on first render and times out after 1 second.
+/// Renders Sixel graphics when the effective presentation supports them,
+/// otherwise renders a fallback node.
 /// </summary>
 [Experimental("HEX1B_SIXEL", UrlFormat = "https://github.com/hex1b/hex1b/blob/main/docs/experimental/sixel.md")]
 public sealed class SixelNode : Hex1bNode
 {
+    private string? _imageData;
+    private SixelPixelBuffer? _pixels;
+    private SixelExtent _pixelExtent;
+    private int? _requestedWidth;
+    private int? _requestedHeight;
+
     /// <summary>
-    /// The Sixel-encoded image data to render.
+    /// Gets or sets validated pre-encoded Sixel data.
     /// </summary>
-    private string _imageData = "";
-    public string ImageData 
-    { 
-        get => _imageData; 
-        set
-        {
-            if (_imageData != value)
-            {
-                _imageData = value;
-                // Mark parent dirty to force full re-render of the container
-                // This is a sledgehammer fix for Sixel ghost pixels when switching images
-                Parent?.MarkDirty();
-                MarkDirty();
-            }
-        }
+    public string ImageData
+    {
+        get => _imageData ?? string.Empty;
+        set => SetEncodedImage(value);
     }
 
     /// <summary>
-    /// The fallback node to render if Sixel is not supported.
+    /// Gets or sets the fallback node rendered when Sixel is unavailable.
     /// </summary>
     public Hex1bNode? Fallback { get; set; }
 
     /// <summary>
-    /// Requested width in character cells. If null, uses natural image width.
+    /// Gets or sets the requested width in terminal cells.
     /// </summary>
-    private int? _requestedWidth;
-    public int? RequestedWidth 
-    { 
-        get => _requestedWidth; 
+    public int? RequestedWidth
+    {
+        get => _requestedWidth;
         set
         {
             if (_requestedWidth != value)
@@ -58,12 +49,11 @@ public sealed class SixelNode : Hex1bNode
     }
 
     /// <summary>
-    /// Requested height in character cells. If null, uses natural image height.
+    /// Gets or sets the requested height in terminal cells.
     /// </summary>
-    private int? _requestedHeight;
-    public int? RequestedHeight 
-    { 
-        get => _requestedHeight; 
+    public int? RequestedHeight
+    {
+        get => _requestedHeight;
         set
         {
             if (_requestedHeight != value)
@@ -74,45 +64,64 @@ public sealed class SixelNode : Hex1bNode
         }
     }
 
-    /// <summary>
-    /// Start of Sixel data (DCS - Device Control String).
-    /// Format: DCS q [sixel data] ST
-    /// Using minimal DCS header (parameters default to 0 anyway).
-    /// </summary>
-    private const string SixelStart = "\x1bPq";
-
-    /// <summary>
-    /// End of Sixel data (ST - String Terminator).
-    /// </summary>
-    private const string SixelEnd = "\x1b\\";
-
-    protected override Size MeasureCore(Constraints constraints)
+    internal void SetPixels(SixelPixelBuffer pixels)
     {
-        // During measure, we don't know if Sixel is supported yet
-        // Measure both and take the larger to ensure we have enough space
-        var fallbackSize = Fallback?.Measure(constraints) ?? Size.Zero;
-        
-        var sixelWidth = RequestedWidth ?? 40;
-        var sixelHeight = RequestedHeight ?? 20;
-        var sixelSize = constraints.Constrain(new Size(sixelWidth, sixelHeight));
-        
-        // Return the larger of the two to accommodate either rendering mode
-        return new Size(
-            Math.Max(fallbackSize.Width, sixelSize.Width),
-            Math.Max(fallbackSize.Height, sixelSize.Height));
+        ArgumentNullException.ThrowIfNull(pixels);
+        if (ReferenceEquals(_pixels, pixels) && _imageData is null)
+        {
+            return;
+        }
+
+        _pixels = pixels;
+        _imageData = null;
+        _pixelExtent = new SixelExtent(pixels.Width, pixels.Height);
+        MarkDirty();
     }
 
+    internal void SetEncodedImage(string imageData)
+    {
+        var normalized = SixelPayload.NormalizeAndValidate(imageData, nameof(imageData));
+        if (_imageData == normalized && _pixels is null)
+        {
+            return;
+        }
+
+        var parsed = SixelParser.ParsePayload(normalized);
+        _pixels = null;
+        _imageData = normalized;
+        _pixelExtent = parsed.LogicalCanvasExtent;
+        MarkDirty();
+    }
+
+    /// <inheritdoc />
+    protected override Size MeasureCore(Constraints constraints)
+    {
+        if (!IsSixelSupported(TerminalCapabilities))
+        {
+            return Fallback?.Measure(constraints) ?? Size.Zero;
+        }
+
+        var metrics = TerminalCapabilities.SixelCellMetrics
+            ?? SixelCellMetrics.FromCapabilities(TerminalCapabilities);
+        var width = RequestedWidth ?? metrics.ColumnsFor(_pixelExtent.Width);
+        var height = RequestedHeight ?? metrics.RowsFor(_pixelExtent.Height);
+        return constraints.Constrain(new Size(width, height));
+    }
+
+    /// <inheritdoc />
     protected override void ArrangeCore(Rect bounds)
     {
         base.ArrangeCore(bounds);
-        Fallback?.Arrange(bounds);
+        if (!IsSixelSupported(TerminalCapabilities))
+        {
+            Fallback?.Arrange(bounds);
+        }
     }
 
+    /// <inheritdoc />
     public override IEnumerable<Hex1bNode> GetFocusableNodes()
     {
-        // SixelNode itself isn't focusable, but fallback might be
-        // We return fallback focusables always since we don't know capabilities at this point
-        if (Fallback != null)
+        if (!IsSixelSupported(TerminalCapabilities) && Fallback is not null)
         {
             foreach (var focusable in Fallback.GetFocusableNodes())
             {
@@ -121,12 +130,10 @@ public sealed class SixelNode : Hex1bNode
         }
     }
 
+    /// <inheritdoc />
     public override void Render(Hex1bRenderContext context)
     {
-        // Use capabilities from the render context (flows from presentation → terminal → workload → app)
-        var sixelSupported = context.Capabilities.SupportsSixel;
-
-        if (sixelSupported)
+        if (IsSixelSupported(context.Capabilities))
         {
             RenderSixel(context);
         }
@@ -138,55 +145,57 @@ public sealed class SixelNode : Hex1bNode
 
     private void RenderSixel(Hex1bRenderContext context)
     {
-        if (string.IsNullOrEmpty(ImageData))
+        if (_pixels is null && _imageData is null)
         {
             context.SetCursorPosition(Bounds.X, Bounds.Y);
             context.Write("[No image data]");
             return;
         }
 
-        // Position cursor at the image location
-        context.SetCursorPosition(Bounds.X, Bounds.Y);
-
-        // Check if data already has a DCS header
-        // Use explicit character comparison instead of StartsWith to avoid escape char issues
-        var startsWithEscP = ImageData.Length >= 2 && ImageData[0] == '\x1b' && ImageData[1] == 'P';
-        var startsWithDCS = ImageData.Length >= 1 && ImageData[0] == '\x90';
-        var hasHeader = startsWithEscP || startsWithDCS;
-        
-        if (hasHeader)
+        if (Bounds.Width <= 0 || Bounds.Height <= 0)
         {
-            // Already has DCS header
-            context.Write(ImageData);
+            return;
+        }
+
+        context.SetCursorPosition(Bounds.X, Bounds.Y);
+        if (_pixels is not null)
+        {
+            context.WriteSixel(_pixels, Bounds.Width, Bounds.Height);
         }
         else
         {
-            // Wrap in Sixel sequence - write as a single string so parser can detect it
-            context.Write($"{SixelStart}{ImageData}{SixelEnd}");
+            context.WriteSixel(_imageData!, Bounds.Width, Bounds.Height);
         }
     }
 
     private void RenderFallback(Hex1bRenderContext context)
     {
-        if (Fallback != null)
+        if (Fallback is not null)
         {
-            // Use RenderChild for automatic caching support
             context.RenderChild(Fallback);
+            return;
         }
-        else
+
+        context.SetCursorPosition(Bounds.X, Bounds.Y);
+        context.Write("[Sixel not supported]");
+    }
+
+    /// <inheritdoc />
+    public override IEnumerable<Hex1bNode> GetChildren()
+    {
+        if (Fallback is not null)
         {
-            // No fallback provided - show a placeholder
-            context.SetCursorPosition(Bounds.X, Bounds.Y);
-            context.Write("[Sixel not supported]");
+            yield return Fallback;
         }
     }
 
-    /// <summary>
-    /// Gets the direct children of this container for input routing.
-    /// Always returns fallback as a potential child - actual rendering depends on capabilities.
-    /// </summary>
-    public override IEnumerable<Hex1bNode> GetChildren()
-    {
-        if (Fallback != null) yield return Fallback;
-    }
+    internal override IEnumerable<Hex1bNode> GetInputChildren()
+        => IsSixelSupported(TerminalCapabilities) || Fallback is null ? [] : [Fallback];
+
+    /// <inheritdoc />
+    protected override void OnTerminalCapabilitiesChanged() => MarkDirty();
+
+    internal static bool IsSixelSupported(TerminalCapabilities capabilities)
+        => capabilities.SixelSupport is SixelPresentationSupport.Native or SixelPresentationSupport.Headless
+            || capabilities.SixelSupport == SixelPresentationSupport.Unknown && capabilities.SupportsSixel;
 }

--- a/src/Hex1b/Sixel/SixelCellMetrics.cs
+++ b/src/Hex1b/Sixel/SixelCellMetrics.cs
@@ -141,6 +141,24 @@ public readonly record struct SixelCellMetrics(
     /// <param name="renderedPixelHeight">The aspect-scaled vertical extent.</param>
     public int RowsFor(int renderedPixelHeight) => Occupancy(renderedPixelHeight, SafeHeight);
 
+    internal int GetPixelForColumnBoundary(int column)
+        => GetPixelForCellBoundary(column, SafeWidth);
+
+    internal int GetPixelForRowBoundary(int row)
+        => GetPixelForCellBoundary(row, SafeHeight);
+
+    internal int GetPixelWidthForColumns(int columns)
+        => GetPixelSpanForCells(columns, SafeWidth);
+
+    internal int GetPixelHeightForRows(int rows)
+        => GetPixelSpanForCells(rows, SafeHeight);
+
+    internal int GetColumnOffsetForPixel(int pixelX)
+        => GetCellOffsetForPixel(pixelX, SafeWidth);
+
+    internal int GetRowOffsetForPixel(int pixelY)
+        => GetCellOffsetForPixel(pixelY, SafeHeight);
+
     /// <summary>
     /// Formats the metrics for diagnostics, keeping estimated values visibly
     /// distinct from authoritative ones.
@@ -159,6 +177,49 @@ public readonly record struct SixelCellMetrics(
 
         var cells = Math.Ceiling(renderedPixels / cellPixels);
         return cells >= int.MaxValue ? int.MaxValue : (int)cells;
+    }
+
+    private static int GetPixelForCellBoundary(int cell, double cellPixels)
+    {
+        if (cell <= 0)
+        {
+            return 0;
+        }
+
+        var pixels = Math.Floor(cell * cellPixels);
+        return pixels >= int.MaxValue ? int.MaxValue : Math.Max(1, (int)pixels);
+    }
+
+    private static int GetPixelSpanForCells(int cells, double cellPixels)
+    {
+        if (cells <= 0)
+        {
+            return 0;
+        }
+
+        // Use the largest whole-pixel span that cannot cross into the next cell.
+        var pixels = Math.Floor(cells * cellPixels);
+        return pixels >= int.MaxValue ? int.MaxValue : Math.Max(1, (int)pixels);
+    }
+
+    private static int GetCellOffsetForPixel(int pixel, double cellPixels)
+    {
+        if (pixel <= 0)
+        {
+            return 0;
+        }
+
+        var cell = Math.Min(int.MaxValue - 1, (int)Math.Floor(pixel / cellPixels));
+        while (cell < int.MaxValue - 1 && GetPixelForCellBoundary(cell + 1, cellPixels) <= pixel)
+        {
+            cell++;
+        }
+        while (cell > 0 && GetPixelForCellBoundary(cell, cellPixels) > pixel)
+        {
+            cell--;
+        }
+
+        return cell;
     }
 
     private static double Sanitize(double value, double fallback) =>

--- a/src/Hex1b/Sixel/SixelImageStore.cs
+++ b/src/Hex1b/Sixel/SixelImageStore.cs
@@ -3,8 +3,8 @@ using Hex1b.Sixel;
 namespace Hex1b;
 
 /// <summary>
-/// Content-hash-keyed store of anonymous Sixel raster resources for a single
-/// screen (main or alternate).
+/// Identity-keyed store of anonymous Sixel image resources for a single screen
+/// (main or alternate).
 /// </summary>
 /// <remarks>
 /// Unlike <see cref="TrackedObjectStore"/>'s manually reference-counted
@@ -44,8 +44,9 @@ internal sealed class SixelImageStore
     }
 
     /// <summary>
-    /// Gets the existing image for this exact content (payload + captured
-    /// background/palette identity), or creates and stores a new one.
+    /// Gets the existing image for this exact resource identity (payload,
+    /// captured raster state, protocol metrics, and cell span), or creates and
+    /// stores a new one.
     /// </summary>
     internal SixelData GetOrCreate(
         string payload,
@@ -58,7 +59,12 @@ internal sealed class SixelImageStore
         bool payloadComplete,
         out bool created)
     {
-        var hash = SixelData.ComputeHash(sourceContentHash, rasterPreparation.Identity);
+        var hash = SixelData.ComputeHash(
+            sourceContentHash,
+            rasterPreparation.Identity,
+            widthInCells,
+            heightInCells,
+            cellMetrics);
         if (_byHash.TryGetValue(hash, out var existing))
         {
             created = false;

--- a/src/Hex1b/Sixel/SixelPayload.cs
+++ b/src/Hex1b/Sixel/SixelPayload.cs
@@ -1,0 +1,54 @@
+namespace Hex1b.Sixel;
+
+internal static class SixelPayload
+{
+    private const string SevenBitIntroducer = "\x1bP";
+    private const string SevenBitTerminator = "\x1b\\";
+    private const char EightBitIntroducer = '\x90';
+    private const char EightBitTerminator = '\x9c';
+
+    public static string NormalizeAndValidate(string imageData, string? parameterName = null)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(imageData, parameterName);
+
+        string framed;
+        if (imageData.StartsWith(SevenBitIntroducer, StringComparison.Ordinal))
+        {
+            if (!imageData.EndsWith(SevenBitTerminator, StringComparison.Ordinal))
+            {
+                throw new ArgumentException(
+                    "A framed Sixel sequence must end with the ESC \\ string terminator.",
+                    parameterName);
+            }
+
+            framed = imageData;
+        }
+        else if (imageData[0] == EightBitIntroducer)
+        {
+            if (imageData[^1] != EightBitTerminator)
+            {
+                throw new ArgumentException(
+                    "An 8-bit framed Sixel sequence must end with the 8-bit string terminator.",
+                    parameterName);
+            }
+
+            framed = imageData;
+        }
+        else
+        {
+            framed = $"{SevenBitIntroducer}q{imageData}{SevenBitTerminator}";
+        }
+
+        var parseResult = SixelParser.ParsePayload(framed);
+        if (parseResult.Outcome != SixelParseOutcome.Complete)
+        {
+            var diagnostic = parseResult.Diagnostics.FirstOrDefault();
+            var detail = string.IsNullOrEmpty(diagnostic.Message)
+                ? parseResult.Outcome.ToString()
+                : diagnostic.Message;
+            throw new ArgumentException($"The value is not a complete valid Sixel sequence: {detail}", parameterName);
+        }
+
+        return framed;
+    }
+}

--- a/src/Hex1b/Sixel/SixelPayload.cs
+++ b/src/Hex1b/Sixel/SixelPayload.cs
@@ -32,7 +32,10 @@ internal static class SixelPayload
                     parameterName);
             }
 
-            framed = imageData;
+            framed = string.Concat(
+                SevenBitIntroducer,
+                imageData.AsSpan(1, imageData.Length - 2),
+                SevenBitTerminator);
         }
         else
         {
@@ -50,5 +53,24 @@ internal static class SixelPayload
         }
 
         return framed;
+    }
+
+    internal static void ValidateCellSpan(
+        SixelParseResult parseResult,
+        SixelCellMetrics metrics,
+        int cellWidth,
+        int cellHeight,
+        string parameterName)
+    {
+        var naturalWidth = metrics.ColumnsFor(parseResult.LogicalCanvasExtent.Width);
+        var naturalHeight = metrics.RowsFor(parseResult.LogicalCanvasExtent.Height);
+        if (naturalWidth != cellWidth || naturalHeight != cellHeight)
+        {
+            throw new ArgumentException(
+                $"Pre-encoded Sixel data occupies {naturalWidth}x{naturalHeight} cells with the active " +
+                $"Sixel metrics and cannot be resized to {cellWidth}x{cellHeight}. Use structured pixels " +
+                "when resizing is required.",
+                parameterName);
+        }
     }
 }

--- a/src/Hex1b/Sixel/SixelPlacement.cs
+++ b/src/Hex1b/Sixel/SixelPlacement.cs
@@ -30,7 +30,9 @@ namespace Hex1b;
 /// by intersecting the *current* painted rectangle with a new clip bound, so
 /// a row or column already cropped away can never resurface later regardless
 /// of operation order (scroll, resize, and history pruning all funnel through
-/// this same monotonic intersection). <see cref="Column"/> is likewise
+/// this same monotonic intersection). Internal recording replay may restore an
+/// already-captured crop and damage mask after recreating the raster through
+/// the normal parser. <see cref="Column"/> is likewise
 /// repositioned only via internal reflow machinery, used when an anchor's
 /// wrapped-line position genuinely moves horizontally; ordinary scrolling and
 /// margin operations never touch it.
@@ -156,24 +158,24 @@ public sealed class SixelPlacement
     /// crop begins. Stored relative to the anchor so shifting <see cref="Row"/>
     /// during scrolling automatically keeps the crop consistent.
     /// </summary>
-    public int PaintedRowOffset { get; }
+    public int PaintedRowOffset { get; private set; }
 
     /// <summary>
     /// Number of rows actually painted: the visible crop clipped to the
     /// scrolling region/page bounds in effect when the placement was created.
     /// </summary>
-    public int PaintedRowCount { get; }
+    public int PaintedRowCount { get; private set; }
 
     /// <summary>
     /// Column offset (relative to <see cref="Column"/>) where the
     /// visible/painted crop begins.
     /// </summary>
-    public int PaintedColumnOffset { get; }
+    public int PaintedColumnOffset { get; private set; }
 
     /// <summary>
     /// Number of columns actually painted.
     /// </summary>
-    public int PaintedColumnCount { get; }
+    public int PaintedColumnCount { get; private set; }
 
     /// <summary>
     /// Monotonic write sequence used to order overlapping placements (later
@@ -238,6 +240,52 @@ public sealed class SixelPlacement
         _visiblePixels = null;
         _damagedCells.Add(CellKey(row, column));
         return true;
+    }
+
+    /// <summary>
+    /// Restores a previously recorded painted crop and damage mask after the
+    /// raster has been recreated through the normal terminal parser.
+    /// </summary>
+    internal void RestoreVisibleState(
+        int paintedRowOffset,
+        int paintedRowCount,
+        int paintedColumnOffset,
+        int paintedColumnCount,
+        IReadOnlyList<(int Row, int Column)> damagedCells)
+    {
+        if (paintedRowOffset < 0 ||
+            paintedRowCount < 0 ||
+            paintedColumnOffset < 0 ||
+            paintedColumnCount < 0 ||
+            paintedRowOffset > HeightInCells - paintedRowCount ||
+            paintedColumnOffset > WidthInCells - paintedColumnCount)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(paintedRowOffset),
+                "The painted crop must lie within the placement's declared cell span.");
+        }
+
+        PaintedRowOffset = paintedRowOffset;
+        PaintedRowCount = paintedRowCount;
+        PaintedColumnOffset = paintedColumnOffset;
+        PaintedColumnCount = paintedColumnCount;
+        _damagedCells.Clear();
+        _visiblePixels = null;
+
+        foreach (var (row, column) in damagedCells)
+        {
+            if (row < paintedRowOffset ||
+                row >= paintedRowOffset + paintedRowCount ||
+                column < paintedColumnOffset ||
+                column >= paintedColumnOffset + paintedColumnCount)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(damagedCells),
+                    $"Damage cell ({row},{column}) lies outside the painted crop.");
+            }
+
+            _damagedCells.Add(row * WidthInCells + column);
+        }
     }
 
     /// <summary>

--- a/src/Hex1b/SixelData.cs
+++ b/src/Hex1b/SixelData.cs
@@ -28,7 +28,7 @@ public sealed class SixelData
     private bool _decodeAttempted;
 
     /// <summary>
-    /// Gets the retained DCS content between the introducer and string terminator.
+    /// Gets the complete framed DCS sequence used for rendering.
     /// </summary>
     public string Payload { get; }
 
@@ -252,6 +252,23 @@ public sealed class SixelData
         width = image.Width;
         height = image.Height;
         return width > 0 && height > 0;
+    }
+
+    internal SixelExtent GetRenderedPixelExtent()
+    {
+        if (ParseResult.LogicalCanvasExtent is { Width: > 0, Height: > 0 } logical)
+        {
+            return logical;
+        }
+
+        if (TryGetRasterDimensions(out var width, out var height))
+        {
+            return new SixelExtent(width, height);
+        }
+
+        return new SixelExtent(
+            (int)Math.Ceiling(WidthInCells * CellMetrics.SafeWidth),
+            (int)Math.Ceiling(HeightInCells * CellMetrics.SafeHeight));
     }
 
     /// <summary>

--- a/src/Hex1b/SixelData.cs
+++ b/src/Hex1b/SixelData.cs
@@ -184,23 +184,34 @@ public sealed class SixelData
     public SixelCellMetrics CellMetrics { get; }
 
     /// <summary>
-    /// Gets the cell span for this sixel using the specified cell metrics.
+    /// Gets the cell span for this Sixel image using the protocol cell metrics
+    /// captured when the image was created.
     /// </summary>
-    /// <param name="metrics">The cell metrics to use for conversion.</param>
     /// <returns>The width and height in cells.</returns>
-    public (int Width, int Height) GetCellSpan(CellMetrics metrics)
+    public (int Width, int Height) GetCellSpan()
     {
         if (ParseResult.LogicalCanvasExtent is { Width: > 0, Height: > 0 } logical)
         {
-            return metrics.PixelToCellSpan(logical.Width, logical.Height);
+            return (CellMetrics.ColumnsFor(logical.Width), CellMetrics.RowsFor(logical.Height));
         }
         if (PixelWidth > 0 && PixelHeight > 0)
         {
-            return metrics.PixelToCellSpan(PixelWidth, PixelHeight);
+            return (CellMetrics.ColumnsFor(PixelWidth), CellMetrics.RowsFor(PixelHeight));
         }
         // Fall back to stored cell dimensions
         return (WidthInCells, HeightInCells);
     }
+
+    /// <summary>
+    /// Gets the cell span for this Sixel image using the protocol cell metrics
+    /// captured when the image was created.
+    /// </summary>
+    /// <param name="metrics">
+    /// Ignored. Sixel placement metrics are captured when the image is created.
+    /// </param>
+    /// <returns>The width and height in cells.</returns>
+    [Obsolete("Cell metrics are captured by SixelData. Use GetCellSpan().")]
+    public (int Width, int Height) GetCellSpan(CellMetrics metrics) => GetCellSpan();
 
     /// <summary>
     /// Materializes the sixel payload as a dense pixel buffer.

--- a/src/Hex1b/SixelData.cs
+++ b/src/Hex1b/SixelData.cs
@@ -1,3 +1,4 @@
+using System.Buffers.Binary;
 using System.Security.Cryptography;
 using Hex1b.Sixel;
 using Hex1b.Surfaces;
@@ -10,9 +11,10 @@ namespace Hex1b;
 /// <remarks>
 /// <para>
 /// Sixel data is content-addressable. Identical payloads share the same
-/// <see cref="SixelData"/> instance only when their captured background and
-/// persistent palette inputs also produce the same raster. This deduplicates
-/// equivalent images without conflating terminal graphics state.
+/// <see cref="SixelData"/> instance only when their captured background,
+/// persistent palette, protocol cell metrics, and cell span are also equal.
+/// This deduplicates equivalent image resources without conflating placement
+/// contexts that would crop or damage the raster differently.
 /// </para>
 /// <para>
 /// The raw DCS sequence is stored so it can be re-emitted during rendering.
@@ -53,13 +55,13 @@ public sealed class SixelData
     public int HeightInCells { get; }
 
     /// <summary>
-    /// Gets the content hash used for deduplication.
+    /// Gets the immutable image-resource identity used for deduplication.
     /// </summary>
     /// <remarks>
-    /// Identical payloads that also capture the same background and palette
-    /// state produce the same hash, which content-addressed replay and
-    /// serialization can use to reference this image without repeating its
-    /// pixel payload.
+    /// Identical payloads that also capture the same background, palette,
+    /// protocol cell metrics, and cell span produce the same hash. Replay and
+    /// serialization use this identity to share only resources whose placement
+    /// geometry has identical pixel-to-cell behavior.
     /// </remarks>
     public byte[] ContentHash { get; }
 
@@ -283,34 +285,45 @@ public sealed class SixelData
     }
 
     /// <summary>
-    /// Computes a content hash for a Sixel payload.
-    /// </summary>
-    internal static byte[] ComputeHash(string payload) => ComputeHash(payload, null);
-
-    /// <summary>
-    /// Computes a deduplication hash that combines the payload with the raster
-    /// state identity.
+    /// Computes a deduplication identity that combines the payload, raster
+    /// state, cell span, and captured protocol cell metrics.
     /// </summary>
     /// <remarks>
     /// Identical payloads produce different pixels when the captured background
-    /// or the persistent palette differ, so the raster identity must participate
-    /// in content-addressable reuse.
+    /// or persistent palette differ. Even when the pixels are identical,
+    /// different protocol metrics or cell spans change clipping and damage
+    /// behavior, so the complete immutable placement context participates in
+    /// resource reuse.
     /// </remarks>
-    internal static byte[] ComputeHash(string payload, byte[]? rasterIdentity)
+    internal static byte[] ComputeHash(
+        string payload,
+        byte[]? rasterIdentity,
+        int widthInCells,
+        int heightInCells,
+        SixelCellMetrics cellMetrics)
     {
         var payloadBytes = System.Text.Encoding.UTF8.GetBytes(payload);
-        if (rasterIdentity is null)
-        {
-            return SHA256.HashData(payloadBytes);
-        }
-
-        var combined = new byte[payloadBytes.Length + rasterIdentity.Length];
-        payloadBytes.CopyTo(combined, 0);
-        rasterIdentity.CopyTo(combined, payloadBytes.Length);
-        return SHA256.HashData(combined);
+        var payloadHash = SHA256.HashData(payloadBytes);
+        return ComputeHash(
+            payloadHash,
+            rasterIdentity,
+            widthInCells,
+            heightInCells,
+            cellMetrics);
     }
 
-    internal static byte[] ComputeHash(ReadOnlySpan<byte> payloadHash, byte[]? rasterIdentity)
+    internal static byte[] ComputeHash(
+        ReadOnlySpan<byte> payloadHash,
+        byte[]? rasterIdentity,
+        int widthInCells,
+        int heightInCells,
+        SixelCellMetrics cellMetrics)
+    {
+        var rasterHash = ComputeRasterHash(payloadHash, rasterIdentity);
+        return AddPlacementContext(rasterHash, widthInCells, heightInCells, cellMetrics);
+    }
+
+    private static byte[] ComputeRasterHash(ReadOnlySpan<byte> payloadHash, byte[]? rasterIdentity)
     {
         if (rasterIdentity is null)
         {
@@ -320,6 +333,32 @@ public sealed class SixelData
         var combined = new byte[payloadHash.Length + rasterIdentity.Length];
         payloadHash.CopyTo(combined);
         rasterIdentity.CopyTo(combined, payloadHash.Length);
+        return SHA256.HashData(combined);
+    }
+
+    private static byte[] AddPlacementContext(
+        ReadOnlySpan<byte> rasterHash,
+        int widthInCells,
+        int heightInCells,
+        SixelCellMetrics cellMetrics)
+    {
+        const int contextLength = 33;
+        Span<byte> context = stackalloc byte[contextLength];
+        context[0] = 1; // Identity format version.
+        BinaryPrimitives.WriteInt32LittleEndian(context[1..5], widthInCells);
+        BinaryPrimitives.WriteInt32LittleEndian(context[5..9], heightInCells);
+        BinaryPrimitives.WriteInt64LittleEndian(
+            context[9..17],
+            BitConverter.DoubleToInt64Bits(cellMetrics.Width));
+        BinaryPrimitives.WriteInt64LittleEndian(
+            context[17..25],
+            BitConverter.DoubleToInt64Bits(cellMetrics.Height));
+        BinaryPrimitives.WriteInt32LittleEndian(context[25..29], (int)cellMetrics.Source);
+        BinaryPrimitives.WriteInt32LittleEndian(context[29..33], (int)cellMetrics.Reliability);
+
+        var combined = new byte[rasterHash.Length + contextLength];
+        rasterHash.CopyTo(combined);
+        context.CopyTo(combined.AsSpan(rasterHash.Length));
         return SHA256.HashData(combined);
     }
 

--- a/src/Hex1b/SixelExtensions.cs
+++ b/src/Hex1b/SixelExtensions.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Hex1b.Surfaces;
 
 namespace Hex1b;
 
@@ -10,6 +11,38 @@ using Hex1b.Widgets;
 [Experimental("HEX1B_SIXEL", UrlFormat = "https://github.com/hex1b/hex1b/blob/main/docs/experimental/sixel.md")]
 public static class SixelExtensions
 {
+    /// <summary>
+    /// Creates a Sixel widget from structured RGBA pixels.
+    /// </summary>
+    /// <param name="context">The widget context.</param>
+    /// <param name="pixels">The pixels to encode and display.</param>
+    /// <param name="fallback">The widget displayed when Sixel is unavailable.</param>
+    /// <returns>A new Sixel widget at its natural pixel-to-cell size.</returns>
+    public static SixelWidget Sixel<TParent>(
+        this WidgetContext<TParent> context,
+        SixelPixelBuffer pixels,
+        Hex1bWidget fallback)
+        where TParent : Hex1bWidget
+        => new(pixels, fallback);
+
+    /// <summary>
+    /// Creates a Sixel widget from structured RGBA pixels.
+    /// </summary>
+    /// <param name="context">The widget context.</param>
+    /// <param name="pixels">The pixels to encode and display.</param>
+    /// <param name="builder">Builds the widget displayed when Sixel is unavailable.</param>
+    /// <returns>A new Sixel widget at its natural pixel-to-cell size.</returns>
+    public static SixelWidget Sixel<TParent>(
+        this WidgetContext<TParent> context,
+        SixelPixelBuffer pixels,
+        Func<WidgetContext<SixelWidget>, Hex1bWidget> builder)
+        where TParent : Hex1bWidget
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        var fallbackContext = new WidgetContext<SixelWidget>();
+        return new SixelWidget(pixels, builder(fallbackContext));
+    }
+
     /// <summary>
     /// Creates a SixelWidget with the specified image data and fallback widget.
     /// </summary>
@@ -90,5 +123,35 @@ public static class SixelExtensions
             new VStackWidget(builder(fallbackCtx)),
             width,
             height);
+    }
+
+    /// <summary>
+    /// Sets the display width in terminal cells.
+    /// </summary>
+    /// <param name="widget">The Sixel widget to configure.</param>
+    /// <param name="width">The display width in terminal cells.</param>
+    /// <returns>A new widget with the requested width.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="width"/> is not positive.
+    /// </exception>
+    public static SixelWidget Width(this SixelWidget widget, int width)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        return widget with { Width = width };
+    }
+
+    /// <summary>
+    /// Sets the display height in terminal cells.
+    /// </summary>
+    /// <param name="widget">The Sixel widget to configure.</param>
+    /// <param name="height">The display height in terminal cells.</param>
+    /// <returns>A new widget with the requested height.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="height"/> is not positive.
+    /// </exception>
+    public static SixelWidget Height(this SixelWidget widget, int height)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+        return widget with { Height = height };
     }
 }

--- a/src/Hex1b/SixelExtensions.cs
+++ b/src/Hex1b/SixelExtensions.cs
@@ -128,6 +128,10 @@ public static class SixelExtensions
     /// <summary>
     /// Sets the display width in terminal cells.
     /// </summary>
+    /// <remarks>
+    /// Structured pixels are resampled to this width. Pre-encoded content must
+    /// already have this natural width under the active Sixel protocol metrics.
+    /// </remarks>
     /// <param name="widget">The Sixel widget to configure.</param>
     /// <param name="width">The display width in terminal cells.</param>
     /// <returns>A new widget with the requested width.</returns>
@@ -143,6 +147,10 @@ public static class SixelExtensions
     /// <summary>
     /// Sets the display height in terminal cells.
     /// </summary>
+    /// <remarks>
+    /// Structured pixels are resampled to this height. Pre-encoded content must
+    /// already have this natural height under the active Sixel protocol metrics.
+    /// </remarks>
     /// <param name="widget">The Sixel widget to configure.</param>
     /// <param name="height">The display height in terminal cells.</param>
     /// <returns>A new widget with the requested height.</returns>

--- a/src/Hex1b/Surfaces/CompositeSurface.cs
+++ b/src/Hex1b/Surfaces/CompositeSurface.cs
@@ -403,7 +403,7 @@ public sealed class CompositeSurface : ISurfaceSource
         {
             if (!sixelVis.IsFullyOccluded)
             {
-                fragments.AddRange(sixelVis.GenerateFragments(sixelVis.Sixel.Data.CellMetrics));
+                fragments.AddRange(sixelVis.GenerateFragments());
             }
         }
 
@@ -477,7 +477,7 @@ public sealed class CompositeSurface : ISurfaceSource
             var sixelOcclusions = CollectSixelRegions(layer, layerRect, sixelRect);
             foreach (var occ in sixelOcclusions)
             {
-                sixelVis.ApplyOcclusion(occ, sixelData.CellMetrics);
+                sixelVis.ApplyOcclusion(occ);
             }
 
             // Then scan the overlapping region for opaque text/background cells
@@ -503,7 +503,7 @@ public sealed class CompositeSurface : ISurfaceSource
                     {
                         // Apply single-cell occlusion
                         var occlusionRect = new Layout.Rect(x, y, 1, 1);
-                        sixelVis.ApplyOcclusion(occlusionRect, sixelData.CellMetrics);
+                        sixelVis.ApplyOcclusion(occlusionRect);
                     }
                 }
             }
@@ -523,26 +523,22 @@ public sealed class CompositeSurface : ISurfaceSource
             if (sixelRect.X < 0)
             {
                 sixelVis.ApplyOcclusion(
-                    new Layout.Rect(sixelRect.X, sixelRect.Y, -sixelRect.X, sixelRect.Height),
-                    sixelData.CellMetrics);
+                    new Layout.Rect(sixelRect.X, sixelRect.Y, -sixelRect.X, sixelRect.Height));
             }
             if (sixelRect.Y < 0)
             {
                 sixelVis.ApplyOcclusion(
-                    new Layout.Rect(sixelRect.X, sixelRect.Y, sixelRect.Width, -sixelRect.Y),
-                    sixelData.CellMetrics);
+                    new Layout.Rect(sixelRect.X, sixelRect.Y, sixelRect.Width, -sixelRect.Y));
             }
             if (sixelRect.Right > Width)
             {
                 sixelVis.ApplyOcclusion(
-                    new Layout.Rect(Width, sixelRect.Y, sixelRect.Right - Width, sixelRect.Height),
-                    sixelData.CellMetrics);
+                    new Layout.Rect(Width, sixelRect.Y, sixelRect.Right - Width, sixelRect.Height));
             }
             if (sixelRect.Bottom > Height)
             {
                 sixelVis.ApplyOcclusion(
-                    new Layout.Rect(sixelRect.X, Height, sixelRect.Width, sixelRect.Bottom - Height),
-                    sixelData.CellMetrics);
+                    new Layout.Rect(sixelRect.X, Height, sixelRect.Width, sixelRect.Bottom - Height));
             }
         }
     }

--- a/src/Hex1b/Surfaces/CompositeSurface.cs
+++ b/src/Hex1b/Surfaces/CompositeSurface.cs
@@ -245,6 +245,8 @@ public sealed class CompositeSurface : ISurfaceSource
     /// </summary>
     private static SurfaceCell CompositeCellFast(SurfaceCell below, SurfaceCell above)
     {
+        above = PreserveSixelUnderlay(below, above);
+
         // Handle transparency
         if (above.HasTransparentBackground)
             above = above with { Background = below.Background };
@@ -278,6 +280,31 @@ public sealed class CompositeSurface : ISurfaceSource
             Kgp = below.Kgp      // Preserve KGP from below if any
         };
     }
+
+    private static SurfaceCell PreserveSixelUnderlay(SurfaceCell below, SurfaceCell above)
+    {
+        if ((!below.IsSixelUnderlay && !below.HasSixel) || above.IsSixelUnderlay)
+        {
+            return above;
+        }
+
+        var occludesSixel = IsSixelOccluder(above);
+        if (!occludesSixel && above.HasTransparentBackground)
+        {
+            occludesSixel = below.OccludesSixel;
+        }
+
+        return above with
+        {
+            Sixel = below.HasSixel && !above.HasSixel ? below.Sixel : above.Sixel,
+            IsSixelUnderlay = true,
+            OccludesSixel = occludesSixel
+        };
+    }
+
+    private static bool IsSixelOccluder(in SurfaceCell cell)
+        => cell.Character != SurfaceCells.UnwrittenMarker
+            && (cell.Character != " " || cell.Background is not null);
 
     /// <inheritdoc />
     public bool IsInBounds(int x, int y)
@@ -376,7 +403,7 @@ public sealed class CompositeSurface : ISurfaceSource
         {
             if (!sixelVis.IsFullyOccluded)
             {
-                fragments.AddRange(sixelVis.GenerateFragments(CellMetrics));
+                fragments.AddRange(sixelVis.GenerateFragments(sixelVis.Sixel.Data.CellMetrics));
             }
         }
 
@@ -450,7 +477,7 @@ public sealed class CompositeSurface : ISurfaceSource
             var sixelOcclusions = CollectSixelRegions(layer, layerRect, sixelRect);
             foreach (var occ in sixelOcclusions)
             {
-                sixelVis.ApplyOcclusion(occ, CellMetrics);
+                sixelVis.ApplyOcclusion(occ, sixelData.CellMetrics);
             }
 
             // Then scan the overlapping region for opaque text/background cells
@@ -476,7 +503,7 @@ public sealed class CompositeSurface : ISurfaceSource
                     {
                         // Apply single-cell occlusion
                         var occlusionRect = new Layout.Rect(x, y, 1, 1);
-                        sixelVis.ApplyOcclusion(occlusionRect, CellMetrics);
+                        sixelVis.ApplyOcclusion(occlusionRect, sixelData.CellMetrics);
                     }
                 }
             }
@@ -497,25 +524,25 @@ public sealed class CompositeSurface : ISurfaceSource
             {
                 sixelVis.ApplyOcclusion(
                     new Layout.Rect(sixelRect.X, sixelRect.Y, -sixelRect.X, sixelRect.Height),
-                    CellMetrics);
+                    sixelData.CellMetrics);
             }
             if (sixelRect.Y < 0)
             {
                 sixelVis.ApplyOcclusion(
                     new Layout.Rect(sixelRect.X, sixelRect.Y, sixelRect.Width, -sixelRect.Y),
-                    CellMetrics);
+                    sixelData.CellMetrics);
             }
             if (sixelRect.Right > Width)
             {
                 sixelVis.ApplyOcclusion(
                     new Layout.Rect(Width, sixelRect.Y, sixelRect.Right - Width, sixelRect.Height),
-                    CellMetrics);
+                    sixelData.CellMetrics);
             }
             if (sixelRect.Bottom > Height)
             {
                 sixelVis.ApplyOcclusion(
                     new Layout.Rect(sixelRect.X, Height, sixelRect.Width, sixelRect.Bottom - Height),
-                    CellMetrics);
+                    sixelData.CellMetrics);
             }
         }
     }
@@ -873,6 +900,8 @@ public sealed class CompositeSurface : ISurfaceSource
 
         private static SurfaceCell CompositeCell(SurfaceCell below, SurfaceCell above)
         {
+            above = CompositeSurface.PreserveSixelUnderlay(below, above);
+
             // Handle transparency
             if (above.HasTransparentBackground)
             {

--- a/src/Hex1b/Surfaces/ComputeContext.cs
+++ b/src/Hex1b/Surfaces/ComputeContext.cs
@@ -151,13 +151,7 @@ public readonly ref struct ComputeContext
         if (pixels is null)
             return default;
 
-        // Calculate pixel offset for this cell within the sixel
-        var cellOffsetX = X - anchorX;
-        var cellOffsetY = Y - anchorY;
-        var pixelOffsetX = cellOffsetX * CellMetrics.PixelWidth;
-        var pixelOffsetY = cellOffsetY * CellMetrics.PixelHeight;
-
-        return new SixelPixelAccess(pixels, pixelOffsetX, pixelOffsetY, CellMetrics);
+        return CreateSixelPixelAccess(pixels, sixelData, X - anchorX, Y - anchorY);
     }
 
     /// <summary>
@@ -180,12 +174,26 @@ public readonly ref struct ComputeContext
         if (pixels is null)
             return default;
 
-        var cellOffsetX = x - anchorX;
-        var cellOffsetY = y - anchorY;
-        var pixelOffsetX = cellOffsetX * CellMetrics.PixelWidth;
-        var pixelOffsetY = cellOffsetY * CellMetrics.PixelHeight;
+        return CreateSixelPixelAccess(pixels, sixelData, x - anchorX, y - anchorY);
+    }
 
-        return new SixelPixelAccess(pixels, pixelOffsetX, pixelOffsetY, CellMetrics);
+    private static SixelPixelAccess CreateSixelPixelAccess(
+        SixelPixelBuffer pixels,
+        SixelData sixelData,
+        int cellOffsetX,
+        int cellOffsetY)
+    {
+        var metrics = sixelData.CellMetrics;
+        var pixelLeft = Math.Min(pixels.Width, metrics.GetPixelForColumnBoundary(cellOffsetX));
+        var pixelTop = Math.Min(pixels.Height, metrics.GetPixelForRowBoundary(cellOffsetY));
+        var pixelRight = Math.Min(pixels.Width, metrics.GetPixelForColumnBoundary(cellOffsetX + 1));
+        var pixelBottom = Math.Min(pixels.Height, metrics.GetPixelForRowBoundary(cellOffsetY + 1));
+        return new SixelPixelAccess(
+            pixels,
+            pixelLeft,
+            pixelTop,
+            Math.Max(0, pixelRight - pixelLeft),
+            Math.Max(0, pixelBottom - pixelTop));
     }
 
     /// <summary>

--- a/src/Hex1b/Surfaces/SixelEncoder.cs
+++ b/src/Hex1b/Surfaces/SixelEncoder.cs
@@ -274,6 +274,30 @@ public sealed class SixelPixelBuffer
     /// <returns>A new buffer containing the cropped region.</returns>
     public SixelPixelBuffer Crop(PixelRect rect) => Crop(rect.X, rect.Y, rect.Width, rect.Height);
 
+    internal SixelPixelBuffer Resize(int width, int height)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+
+        if (width == Width && height == Height)
+        {
+            return this;
+        }
+
+        var resized = new SixelPixelBuffer(width, height);
+        for (var y = 0; y < height; y++)
+        {
+            var sourceY = (int)((long)y * Height / height);
+            for (var x = 0; x < width; x++)
+            {
+                var sourceX = (int)((long)x * Width / width);
+                resized[x, y] = this[sourceX, sourceY];
+            }
+        }
+
+        return resized;
+    }
+
     /// <summary>
     /// Fragments this buffer into multiple cropped buffers based on the specified regions.
     /// </summary>

--- a/src/Hex1b/Surfaces/SixelFragment.cs
+++ b/src/Hex1b/Surfaces/SixelFragment.cs
@@ -30,11 +30,17 @@ public sealed class SixelFragment
     /// <summary>
     /// Gets whether this fragment represents the complete original sixel (no clipping).
     /// </summary>
-    public bool IsComplete => 
-        PixelRegion.X == 0 && 
-        PixelRegion.Y == 0 &&
-        PixelRegion.Width == OriginalSixel.PixelWidth &&
-        PixelRegion.Height == OriginalSixel.PixelHeight;
+    public bool IsComplete
+    {
+        get
+        {
+            var extent = OriginalSixel.GetRenderedPixelExtent();
+            return PixelRegion.X == 0
+                && PixelRegion.Y == 0
+                && PixelRegion.Width == extent.Width
+                && PixelRegion.Height == extent.Height;
+        }
+    }
 
     private string? _encodedPayload;
     private SixelPixelBuffer? _croppedPixels;
@@ -158,7 +164,15 @@ public sealed class SixelVisibility
     /// <summary>
     /// Gets whether this sixel is fully occluded (not visible at all).
     /// </summary>
-    public bool IsFullyOccluded => VisibleRegions.Count == 0;
+    public bool IsFullyOccluded
+    {
+        get
+        {
+            var contentBounds = GetVisibleContentBounds();
+            return contentBounds.IsEmpty ||
+                !VisibleRegions.Any(region => !region.Intersect(contentBounds).IsEmpty);
+        }
+    }
 
     /// <summary>
     /// Gets whether this sixel is fragmented (partially occluded, multiple visible regions).
@@ -177,11 +191,9 @@ public sealed class SixelVisibility
         // Initially fully visible
         var data = sixel.Data;
         
-        // Use pixel dimensions if available, otherwise estimate from cell dimensions
-        var pixelWidth = data.PixelWidth > 0 ? data.PixelWidth : data.WidthInCells * 10;
-        var pixelHeight = data.PixelHeight > 0 ? data.PixelHeight : data.HeightInCells * 20;
+        var extent = data.GetRenderedPixelExtent();
         
-        VisibleRegions = [new PixelRect(0, 0, pixelWidth, pixelHeight)];
+        VisibleRegions = [new PixelRect(0, 0, extent.Width, extent.Height)];
         IsFullyVisible = true;
     }
 
@@ -237,24 +249,55 @@ public sealed class SixelVisibility
         if (IsFullyOccluded)
             return [];
 
-        var fragments = new List<SixelFragment>();
         var data = Sixel.Data;
+        var extent = data.GetRenderedPixelExtent();
+        if (IsFullyVisible)
+        {
+            return
+            [
+                new SixelFragment(
+                    data,
+                    AnchorPosition.X,
+                    AnchorPosition.Y,
+                    new PixelRect(0, 0, extent.Width, extent.Height))
+            ];
+        }
+
+        var fragments = new List<SixelFragment>();
+        var contentBounds = GetVisibleContentBounds();
 
         foreach (var region in VisibleRegions)
         {
+            var visibleRegion = region.Intersect(contentBounds);
+            if (visibleRegion.IsEmpty)
+                continue;
+
             // Calculate cell position for this fragment using actual cell width
             // The pixel region is in the original sixel's coordinate space
-            var cellOffsetX = metrics.GetCellOffsetForPixel(region.X);
-            var cellOffsetY = region.Y / metrics.PixelHeight;
+            var cellOffsetX = metrics.GetCellOffsetForPixel(visibleRegion.X);
+            var cellOffsetY = visibleRegion.Y / metrics.PixelHeight;
             
             fragments.Add(new SixelFragment(
                 data,
                 AnchorPosition.X + cellOffsetX,
                 AnchorPosition.Y + cellOffsetY,
-                region));
+                visibleRegion));
         }
 
         return fragments;
+    }
+
+    private PixelRect GetVisibleContentBounds()
+    {
+        var data = Sixel.Data;
+        if (data.BackgroundMode == Hex1b.Sixel.SixelBackgroundMode.Transparent)
+        {
+            var painted = data.ParseResult.PaintedBounds;
+            return new PixelRect(painted.X, painted.Y, painted.Width, painted.Height);
+        }
+
+        var extent = data.GetRenderedPixelExtent();
+        return new PixelRect(0, 0, extent.Width, extent.Height);
     }
 
     private static Rect IntersectRects(Rect a, Rect b)

--- a/src/Hex1b/Surfaces/SixelFragment.cs
+++ b/src/Hex1b/Surfaces/SixelFragment.cs
@@ -123,12 +123,26 @@ public sealed class SixelFragment
     }
 
     /// <summary>
-    /// Gets the cell span for this fragment using the specified metrics.
+    /// Gets the cell span for this fragment using the protocol cell metrics
+    /// captured by the original Sixel image.
     /// </summary>
-    public (int Width, int Height) GetCellSpan(CellMetrics metrics)
+    /// <returns>The width and height in protocol cells.</returns>
+    public (int Width, int Height) GetCellSpan()
     {
-        return metrics.PixelToCellSpan(PixelRegion.Width, PixelRegion.Height);
+        var metrics = OriginalSixel.CellMetrics;
+        return (metrics.ColumnsFor(PixelRegion.Width), metrics.RowsFor(PixelRegion.Height));
     }
+
+    /// <summary>
+    /// Gets the cell span for this fragment using the protocol cell metrics
+    /// captured by the original Sixel image.
+    /// </summary>
+    /// <param name="metrics">
+    /// Ignored. Sixel placement metrics are captured by <see cref="SixelData"/>.
+    /// </param>
+    /// <returns>The width and height in protocol cells.</returns>
+    [Obsolete("Cell metrics are captured by SixelData. Use GetCellSpan().")]
+    public (int Width, int Height) GetCellSpan(CellMetrics metrics) => GetCellSpan();
 }
 
 /// <summary>
@@ -199,22 +213,14 @@ public sealed class SixelVisibility
     }
 
     /// <summary>
-    /// Applies an occlusion rectangle (in cell coordinates) to this sixel.
+    /// Applies an occlusion rectangle in cell coordinates to this Sixel image,
+    /// using the protocol cell metrics captured when the image was created.
     /// </summary>
     /// <param name="occlusionCellRect">The occluding rectangle in cell coordinates.</param>
-    /// <param name="metrics">Cell metrics for coordinate conversion.</param>
-    public void ApplyOcclusion(Rect occlusionCellRect, CellMetrics metrics)
-        => ApplyOcclusion(
-            occlusionCellRect,
-            new SixelCellMetrics(
-                metrics.ActualPixelWidth,
-                metrics.PixelHeight,
-                SixelCellMetricsSource.Derived,
-                SixelCellMetricsReliability.Derived));
-
-    internal void ApplyOcclusion(Rect occlusionCellRect, SixelCellMetrics metrics)
+    public void ApplyOcclusion(Rect occlusionCellRect)
     {
         var data = Sixel.Data;
+        var metrics = data.CellMetrics;
         
         // Convert sixel bounds to cell rect
         var sixelCellRect = new Rect(
@@ -252,24 +258,29 @@ public sealed class SixelVisibility
     }
 
     /// <summary>
-    /// Generates fragments for the visible regions of this sixel.
+    /// Applies an occlusion rectangle in cell coordinates to this Sixel image,
+    /// using the protocol cell metrics captured when the image was created.
     /// </summary>
-    /// <param name="metrics">Cell metrics for position calculation.</param>
-    /// <returns>List of fragments to render.</returns>
-    public IReadOnlyList<SixelFragment> GenerateFragments(CellMetrics metrics)
-        => GenerateFragments(
-            new SixelCellMetrics(
-                metrics.ActualPixelWidth,
-                metrics.PixelHeight,
-                SixelCellMetricsSource.Derived,
-                SixelCellMetricsReliability.Derived));
+    /// <param name="occlusionCellRect">The occluding rectangle in cell coordinates.</param>
+    /// <param name="metrics">
+    /// Ignored. Sixel placement metrics are captured by <see cref="SixelData"/>.
+    /// </param>
+    [Obsolete("Cell metrics are captured by SixelData. Use ApplyOcclusion(Rect).")]
+    public void ApplyOcclusion(Rect occlusionCellRect, CellMetrics metrics)
+        => ApplyOcclusion(occlusionCellRect);
 
-    internal IReadOnlyList<SixelFragment> GenerateFragments(SixelCellMetrics metrics)
+    /// <summary>
+    /// Generates fragments for the visible regions of this Sixel image using
+    /// the protocol cell metrics captured when the image was created.
+    /// </summary>
+    /// <returns>List of fragments to render.</returns>
+    public IReadOnlyList<SixelFragment> GenerateFragments()
     {
         if (IsFullyOccluded)
             return [];
 
         var data = Sixel.Data;
+        var metrics = data.CellMetrics;
         var extent = data.GetRenderedPixelExtent();
         if (IsFullyVisible)
         {
@@ -306,6 +317,18 @@ public sealed class SixelVisibility
 
         return fragments;
     }
+
+    /// <summary>
+    /// Generates fragments for the visible regions of this Sixel image using
+    /// the protocol cell metrics captured when the image was created.
+    /// </summary>
+    /// <param name="metrics">
+    /// Ignored. Sixel placement metrics are captured by <see cref="SixelData"/>.
+    /// </param>
+    /// <returns>List of fragments to render.</returns>
+    [Obsolete("Cell metrics are captured by SixelData. Use GenerateFragments().")]
+    public IReadOnlyList<SixelFragment> GenerateFragments(CellMetrics metrics)
+        => GenerateFragments();
 
     private PixelRect GetVisibleContentBounds()
     {

--- a/src/Hex1b/Surfaces/SixelFragment.cs
+++ b/src/Hex1b/Surfaces/SixelFragment.cs
@@ -1,4 +1,5 @@
 using Hex1b.Layout;
+using Hex1b.Sixel;
 
 namespace Hex1b.Surfaces;
 
@@ -203,6 +204,15 @@ public sealed class SixelVisibility
     /// <param name="occlusionCellRect">The occluding rectangle in cell coordinates.</param>
     /// <param name="metrics">Cell metrics for coordinate conversion.</param>
     public void ApplyOcclusion(Rect occlusionCellRect, CellMetrics metrics)
+        => ApplyOcclusion(
+            occlusionCellRect,
+            new SixelCellMetrics(
+                metrics.ActualPixelWidth,
+                metrics.PixelHeight,
+                SixelCellMetricsSource.Derived,
+                SixelCellMetricsReliability.Derived));
+
+    internal void ApplyOcclusion(Rect occlusionCellRect, SixelCellMetrics metrics)
     {
         var data = Sixel.Data;
         
@@ -222,11 +232,13 @@ public sealed class SixelVisibility
         // Use actual (floating-point) cell width for precise alignment
         var relX = intersection.X - AnchorPosition.X;
         var relY = intersection.Y - AnchorPosition.Y;
+        var pixelLeft = metrics.GetPixelForColumnBoundary(relX);
+        var pixelTop = metrics.GetPixelForRowBoundary(relY);
         var pixelOcclusion = new PixelRect(
-            metrics.GetPixelForCellBoundary(relX),
-            relY * metrics.PixelHeight,
-            metrics.GetPixelWidthForCells(intersection.Width),
-            intersection.Height * metrics.PixelHeight);
+            pixelLeft,
+            pixelTop,
+            metrics.GetPixelForColumnBoundary(relX + intersection.Width) - pixelLeft,
+            metrics.GetPixelForRowBoundary(relY + intersection.Height) - pixelTop);
 
         // Apply occlusion to all visible regions
         var newRegions = new List<PixelRect>();
@@ -245,6 +257,14 @@ public sealed class SixelVisibility
     /// <param name="metrics">Cell metrics for position calculation.</param>
     /// <returns>List of fragments to render.</returns>
     public IReadOnlyList<SixelFragment> GenerateFragments(CellMetrics metrics)
+        => GenerateFragments(
+            new SixelCellMetrics(
+                metrics.ActualPixelWidth,
+                metrics.PixelHeight,
+                SixelCellMetricsSource.Derived,
+                SixelCellMetricsReliability.Derived));
+
+    internal IReadOnlyList<SixelFragment> GenerateFragments(SixelCellMetrics metrics)
     {
         if (IsFullyOccluded)
             return [];
@@ -274,8 +294,8 @@ public sealed class SixelVisibility
 
             // Calculate cell position for this fragment using actual cell width
             // The pixel region is in the original sixel's coordinate space
-            var cellOffsetX = metrics.GetCellOffsetForPixel(visibleRegion.X);
-            var cellOffsetY = visibleRegion.Y / metrics.PixelHeight;
+            var cellOffsetX = metrics.GetColumnOffsetForPixel(visibleRegion.X);
+            var cellOffsetY = metrics.GetRowOffsetForPixel(visibleRegion.Y);
             
             fragments.Add(new SixelFragment(
                 data,

--- a/src/Hex1b/Surfaces/SixelPixelAccess.cs
+++ b/src/Hex1b/Surfaces/SixelPixelAccess.cs
@@ -18,17 +18,18 @@ public readonly struct SixelPixelAccess
     private readonly SixelPixelBuffer _buffer;
     private readonly int _offsetX;
     private readonly int _offsetY;
-    private readonly CellMetrics _metrics;
+    private readonly int _pixelWidth;
+    private readonly int _pixelHeight;
 
     /// <summary>
     /// Gets the width of this cell's pixel region.
     /// </summary>
-    public int PixelWidth => _metrics.PixelWidth;
+    public int PixelWidth => _pixelWidth;
 
     /// <summary>
     /// Gets the height of this cell's pixel region.
     /// </summary>
-    public int PixelHeight => _metrics.PixelHeight;
+    public int PixelHeight => _pixelHeight;
 
     /// <summary>
     /// Gets whether this accessor has valid pixel data.
@@ -36,11 +37,22 @@ public readonly struct SixelPixelAccess
     public bool IsValid => _buffer is not null;
 
     internal SixelPixelAccess(SixelPixelBuffer buffer, int offsetX, int offsetY, CellMetrics metrics)
+        : this(buffer, offsetX, offsetY, metrics.PixelWidth, metrics.PixelHeight)
+    {
+    }
+
+    internal SixelPixelAccess(
+        SixelPixelBuffer buffer,
+        int offsetX,
+        int offsetY,
+        int pixelWidth,
+        int pixelHeight)
     {
         _buffer = buffer;
         _offsetX = offsetX;
         _offsetY = offsetY;
-        _metrics = metrics;
+        _pixelWidth = pixelWidth;
+        _pixelHeight = pixelHeight;
     }
 
     /// <summary>

--- a/src/Hex1b/Surfaces/Surface.cs
+++ b/src/Hex1b/Surfaces/Surface.cs
@@ -629,12 +629,25 @@ public sealed class Surface : ISurfaceSource
                 var index = destRowStart + destX;
                 var oldCell = _cells[index];
 
-                // Keep the Sixel anchor reachable when later text or an explicit
-                // background overlays its top-left cell. Visibility is resolved by
-                // SurfaceComparer, which can fragment around the overlaid cell.
-                if (oldCell.HasSixel && !srcCell.HasSixel && IsSixelOccluder(srcCell))
+                if ((oldCell.IsSixelUnderlay || oldCell.HasSixel) && !srcCell.IsSixelUnderlay)
                 {
-                    srcCell = srcCell with { Sixel = oldCell.Sixel };
+                    var occludesSixel = IsSixelOccluder(srcCell);
+                    if (!occludesSixel && srcCell.HasTransparentBackground)
+                    {
+                        occludesSixel = oldCell.OccludesSixel;
+                    }
+
+                    srcCell = srcCell with
+                    {
+                        IsSixelUnderlay = true,
+                        OccludesSixel = occludesSixel
+                    };
+
+                    // Keep the anchor reachable while higher-layer content covers it.
+                    if (oldCell.HasSixel && !srcCell.HasSixel)
+                    {
+                        srcCell = srcCell with { Sixel = oldCell.Sixel };
+                    }
                 }
 
                 // Handle partial transparency (has content but transparent background)
@@ -717,14 +730,15 @@ public sealed class Surface : ISurfaceSource
                 }
 
                 var extent = sixelData.GetRenderedPixelExtent();
+                var metrics = sixelData.CellMetrics;
                 var leftCells = visibleLeft - destAnchorX;
                 var topCells = visibleTop - destAnchorY;
                 var rightCells = visibleRight - destAnchorX;
                 var bottomCells = visibleBottom - destAnchorY;
-                var pixelLeft = Math.Min(extent.Width, CellMetrics.GetPixelForCellBoundary(leftCells));
-                var pixelTop = Math.Min(extent.Height, topCells * CellMetrics.PixelHeight);
-                var pixelRight = Math.Min(extent.Width, CellMetrics.GetPixelForCellBoundary(rightCells));
-                var pixelBottom = Math.Min(extent.Height, bottomCells * CellMetrics.PixelHeight);
+                var pixelLeft = Math.Min(extent.Width, metrics.GetPixelForColumnBoundary(leftCells));
+                var pixelTop = Math.Min(extent.Height, metrics.GetPixelForRowBoundary(topCells));
+                var pixelRight = Math.Min(extent.Width, metrics.GetPixelForColumnBoundary(rightCells));
+                var pixelBottom = Math.Min(extent.Height, metrics.GetPixelForRowBoundary(bottomCells));
                 var pixelRegion = new PixelRect(
                     pixelLeft,
                     pixelTop,
@@ -750,9 +764,10 @@ public sealed class Surface : ISurfaceSource
                     cellMetrics: sixelData.CellMetrics);
                 var tracked = new TrackedObject<SixelData>(clippedData, _ => { });
                 var visibleSourceCell = source.GetCell(visibleLeft - offsetX, visibleTop - offsetY);
-                overrides[(visibleLeft, visibleTop)] = visibleSourceCell == SurfaceCells.Empty
+                var overrideCell = visibleSourceCell == SurfaceCells.Empty
                     ? new SurfaceCell(" ", null, null, Sixel: tracked)
                     : visibleSourceCell with { Sixel = tracked };
+                overrides[(visibleLeft, visibleTop)] = overrideCell with { IsSixelUnderlay = true };
             }
         }
 
@@ -934,6 +949,7 @@ public sealed class Surface : ISurfaceSource
     private static bool IsCellComplex(in SurfaceCell cell)
     {
         if (cell.DisplayWidth != 1) return true;
+        if (cell.IsSixelUnderlay || cell.OccludesSixel) return true;
         if (cell.UnderlineStyle != UnderlineStyle.None) return true;
         if (cell.UnderlineColor.HasValue) return true;
         if (cell.Sixel is not null) return true;

--- a/src/Hex1b/Surfaces/Surface.cs
+++ b/src/Hex1b/Surfaces/Surface.cs
@@ -757,7 +757,12 @@ public sealed class Surface : ISurfaceSource
                     payload,
                     visibleRight - visibleLeft,
                     visibleBottom - visibleTop,
-                    SixelData.ComputeHash(payload),
+                    SixelData.ComputeHash(
+                        payload,
+                        rasterIdentity: null,
+                        visibleRight - visibleLeft,
+                        visibleBottom - visibleTop,
+                        sixelData.CellMetrics),
                     pixelRegion.Width,
                     pixelRegion.Height,
                     parseResult,

--- a/src/Hex1b/Surfaces/Surface.cs
+++ b/src/Hex1b/Surfaces/Surface.cs
@@ -589,6 +589,12 @@ public sealed class Surface : ISurfaceSource
             kgpOverrides = BuildKgpCompositeOverrides(source, offsetX, offsetY, clipRect);
         }
 
+        Dictionary<(int X, int Y), SurfaceCell>? sixelOverrides = null;
+        if (source.HasSixels)
+        {
+            sixelOverrides = BuildSixelCompositeOverrides(source, offsetX, offsetY, clipRect);
+        }
+
         for (var destY = destStartY; destY < destEndY; destY++)
         {
             var srcY = destY - offsetY;
@@ -597,9 +603,18 @@ public sealed class Surface : ISurfaceSource
             for (var destX = destStartX; destX < destEndX; destX++)
             {
                 var srcX = destX - offsetX;
-                var srcCell = kgpOverrides != null && kgpOverrides.TryGetValue((destX, destY), out var overrideCell)
-                    ? overrideCell
-                    : source.GetCell(srcX, srcY);
+                var srcCell = source.GetCell(srcX, srcY);
+                if (kgpOverrides != null && kgpOverrides.TryGetValue((destX, destY), out var kgpOverride))
+                {
+                    srcCell = kgpOverride;
+                }
+                var transfersSixelOverride = false;
+                if (sixelOverrides != null &&
+                    sixelOverrides.TryGetValue((destX, destY), out var sixelOverride))
+                {
+                    srcCell = sixelOverride;
+                    transfersSixelOverride = true;
+                }
                 
                 // Skip cells that are exactly the initial empty state - these are unwritten cells
                 // that should not overwrite anything. We compare the full cell struct, not just
@@ -611,18 +626,22 @@ public sealed class Surface : ISurfaceSource
                     continue;
                 }
                 
+                var index = destRowStart + destX;
+                var oldCell = _cells[index];
+
+                // Keep the Sixel anchor reachable when later text or an explicit
+                // background overlays its top-left cell. Visibility is resolved by
+                // SurfaceComparer, which can fragment around the overlaid cell.
+                if (oldCell.HasSixel && !srcCell.HasSixel && IsSixelOccluder(srcCell))
+                {
+                    srcCell = srcCell with { Sixel = oldCell.Sixel };
+                }
+
                 // Handle partial transparency (has content but transparent background)
                 if (srcCell.HasTransparentBackground)
                 {
                     // Blend with existing cell's background
-                    var destCell = _cells[destRowStart + destX];
-                    srcCell = srcCell with { Background = destCell.Background };
-                }
-                
-                // Clip sixels that would extend beyond destination bounds
-                if (srcCell.HasSixel && srcCell.Sixel?.Data is not null)
-                {
-                    srcCell = ClipSixelCell(srcCell, destX, destY);
+                    srcCell = srcCell with { Background = oldCell.Background };
                 }
                 
                 // Clip KGP images that would extend beyond destination bounds
@@ -631,10 +650,7 @@ public sealed class Surface : ISurfaceSource
                     srcCell = ClipKgpCell(srcCell, destX, destY);
                 }
 
-                var index = destRowStart + destX;
-                
                 // Track sixel count changes
-                var oldCell = _cells[index];
                 if (oldCell.HasSixel && !srcCell.HasSixel)
                     _sixelCount--;
                 else if (!oldCell.HasSixel && srcCell.HasSixel)
@@ -646,10 +662,101 @@ public sealed class Surface : ISurfaceSource
                 else if (!oldCell.HasKgp && srcCell.HasKgp)
                     _kgpCount++;
 
+                if (!ReferenceEquals(oldCell.Sixel, srcCell.Sixel))
+                {
+                    // Normal composites retain the source reference for the
+                    // destination surface. A clipped override is created solely
+                    // for this destination, so its initial reference transfers.
+                    if (!transfersSixelOverride)
+                        srcCell.Sixel?.AddRef();
+                    oldCell.Sixel?.Release();
+                }
+
                 SetCellInternal(index, srcCell);
                 ExpandContentBounds(destX, destY);
             }
         }
+    }
+
+    private Dictionary<(int X, int Y), SurfaceCell> BuildSixelCompositeOverrides(
+        ISurfaceSource source,
+        int offsetX,
+        int offsetY,
+        Rect clipRect)
+    {
+        var overrides = new Dictionary<(int X, int Y), SurfaceCell>();
+
+        for (var srcY = 0; srcY < source.Height; srcY++)
+        {
+            for (var srcX = 0; srcX < source.Width; srcX++)
+            {
+                var anchorCell = source.GetCell(srcX, srcY);
+                if (!anchorCell.HasSixel || anchorCell.Sixel?.Data is not SixelData sixelData)
+                {
+                    continue;
+                }
+
+                var destAnchorX = offsetX + srcX;
+                var destAnchorY = offsetY + srcY;
+                var visibleLeft = Math.Max(0, Math.Max(destAnchorX, clipRect.X));
+                var visibleTop = Math.Max(0, Math.Max(destAnchorY, clipRect.Y));
+                var visibleRight = Math.Min(Width, Math.Min(destAnchorX + sixelData.WidthInCells, clipRect.Right));
+                var visibleBottom = Math.Min(Height, Math.Min(destAnchorY + sixelData.HeightInCells, clipRect.Bottom));
+
+                if (visibleLeft >= visibleRight || visibleTop >= visibleBottom)
+                {
+                    continue;
+                }
+
+                if (visibleLeft == destAnchorX &&
+                    visibleTop == destAnchorY &&
+                    visibleRight == destAnchorX + sixelData.WidthInCells &&
+                    visibleBottom == destAnchorY + sixelData.HeightInCells)
+                {
+                    continue;
+                }
+
+                var extent = sixelData.GetRenderedPixelExtent();
+                var leftCells = visibleLeft - destAnchorX;
+                var topCells = visibleTop - destAnchorY;
+                var rightCells = visibleRight - destAnchorX;
+                var bottomCells = visibleBottom - destAnchorY;
+                var pixelLeft = Math.Min(extent.Width, CellMetrics.GetPixelForCellBoundary(leftCells));
+                var pixelTop = Math.Min(extent.Height, topCells * CellMetrics.PixelHeight);
+                var pixelRight = Math.Min(extent.Width, CellMetrics.GetPixelForCellBoundary(rightCells));
+                var pixelBottom = Math.Min(extent.Height, bottomCells * CellMetrics.PixelHeight);
+                var pixelRegion = new PixelRect(
+                    pixelLeft,
+                    pixelTop,
+                    Math.Max(0, pixelRight - pixelLeft),
+                    Math.Max(0, pixelBottom - pixelTop));
+
+                var fragment = new SixelFragment(sixelData, visibleLeft, visibleTop, pixelRegion);
+                var payload = fragment.GetPayload();
+                if (payload is null)
+                {
+                    continue;
+                }
+
+                var parseResult = Hex1b.Sixel.SixelParser.ParsePayload(payload);
+                var clippedData = new SixelData(
+                    payload,
+                    visibleRight - visibleLeft,
+                    visibleBottom - visibleTop,
+                    SixelData.ComputeHash(payload),
+                    pixelRegion.Width,
+                    pixelRegion.Height,
+                    parseResult,
+                    cellMetrics: sixelData.CellMetrics);
+                var tracked = new TrackedObject<SixelData>(clippedData, _ => { });
+                var visibleSourceCell = source.GetCell(visibleLeft - offsetX, visibleTop - offsetY);
+                overrides[(visibleLeft, visibleTop)] = visibleSourceCell == SurfaceCells.Empty
+                    ? new SurfaceCell(" ", null, null, Sixel: tracked)
+                    : visibleSourceCell with { Sixel = tracked };
+            }
+        }
+
+        return overrides;
     }
 
     private Dictionary<(int X, int Y), SurfaceCell> BuildKgpCompositeOverrides(
@@ -717,74 +824,6 @@ public sealed class Surface : ISurfaceSource
     }
 
     /// <summary>
-    /// Clips a sixel cell so it doesn't extend beyond the surface bounds.
-    /// </summary>
-    private SurfaceCell ClipSixelCell(SurfaceCell cell, int destX, int destY)
-    {
-        var sixelData = cell.Sixel!.Data;
-        var sixelWidth = sixelData.WidthInCells;
-        var sixelHeight = sixelData.HeightInCells;
-        
-        // Check if sixel extends beyond bounds
-        var extendsRight = destX + sixelWidth > Width;
-        var extendsDown = destY + sixelHeight > Height;
-        
-        if (!extendsRight && !extendsDown)
-        {
-            // Sixel fits entirely, no clipping needed
-            return cell;
-        }
-        
-        // Calculate the visible portion in cells
-        var visibleCellWidth = Math.Min(sixelWidth, Width - destX);
-        var visibleCellHeight = Math.Min(sixelHeight, Height - destY);
-        
-        if (visibleCellWidth <= 0 || visibleCellHeight <= 0)
-        {
-            // Completely outside, return cell without sixel
-            return cell with { Sixel = null };
-        }
-        
-        // Calculate visible portion in pixels
-        var visiblePixelWidth = visibleCellWidth * CellMetrics.PixelWidth;
-        var visiblePixelHeight = visibleCellHeight * CellMetrics.PixelHeight;
-        
-        // Clamp to actual sixel pixel dimensions
-        visiblePixelWidth = Math.Min(visiblePixelWidth, sixelData.PixelWidth);
-        visiblePixelHeight = Math.Min(visiblePixelHeight, sixelData.PixelHeight);
-        
-        // Create a fragment for the visible portion
-        var fragment = new SixelFragment(
-            sixelData,
-            destX, destY,
-            new PixelRect(0, 0, visiblePixelWidth, visiblePixelHeight));
-        
-        // Get the clipped payload
-        var clippedPayload = fragment.GetPayload();
-        if (clippedPayload is null)
-        {
-            // Decoding/re-encoding failed, return without sixel
-            return cell with { Sixel = null };
-        }
-        
-        // Create new SixelData with the clipped payload
-        var clippedSixelData = new SixelData(
-            clippedPayload,
-            visibleCellWidth,
-            visibleCellHeight,
-            sixelData.ContentHash, // Reuse hash for now (not strictly correct but avoids re-hashing)
-            visiblePixelWidth,
-            visiblePixelHeight);
-        
-        // Create a new TrackedObject for the clipped sixel
-        // Note: This doesn't go through the store for deduplication since it's a derived clip.
-        // Use no-op callback since clipped sixels aren't tracked in the store.
-        var clippedTracked = new TrackedObject<SixelData>(clippedSixelData, _ => { });
-        
-        return cell with { Sixel = clippedTracked };
-    }
-
-    /// <summary>
     /// Clips a KGP cell so it doesn't extend beyond the surface bounds.
     /// Unlike sixel clipping (which re-encodes pixels), KGP clipping adjusts
     /// the source rectangle placement parameters — a pure metadata operation.
@@ -826,6 +865,10 @@ public sealed class Surface : ISurfaceSource
         var clippedTracked = new TrackedObject<KgpCellData>(clippedData, _ => { });
         return cell with { Kgp = clippedTracked };
     }
+
+    private static bool IsSixelOccluder(SurfaceCell cell)
+        => cell.Character != SurfaceCells.UnwrittenMarker
+            && (cell.Character != " " || cell.Background is not null);
 
     /// <summary>
     /// Gets a read-only span over all cells in row-major order.

--- a/src/Hex1b/Surfaces/SurfaceCell.cs
+++ b/src/Hex1b/Surfaces/SurfaceCell.cs
@@ -40,6 +40,16 @@ public readonly record struct SurfaceCell(
     Hex1bColor? UnderlineColor = null)
 {
     /// <summary>
+    /// Marks cells occupied by a Sixel placement, including non-anchor cells.
+    /// </summary>
+    internal bool IsSixelUnderlay { get; init; }
+
+    /// <summary>
+    /// Marks content composited above a Sixel placement that must occlude it.
+    /// </summary>
+    internal bool OccludesSixel { get; init; }
+
+    /// <summary>
     /// Gets whether this cell is a continuation of a previous wide character.
     /// Continuation cells should not be rendered directly - the wide character in the previous cell covers this position.
     /// </summary>

--- a/src/Hex1b/Surfaces/SurfaceComparer.cs
+++ b/src/Hex1b/Surfaces/SurfaceComparer.cs
@@ -397,7 +397,6 @@ public static class SurfaceComparer
             foreach (var (sx, sy, sw, sh, cell) in sixelRegions)
             {
                 var visibility = new SixelVisibility(cell.Sixel!, sx, sy, 0);
-                var metrics = cell.Sixel!.Data.CellMetrics;
 
                 for (var y = sy; y < sy + sh && y < currentSurface.Height; y++)
                 {
@@ -406,14 +405,14 @@ public static class SurfaceComparer
                         var checkCell = currentSurface[x, y];
                         if (IsSixelOccluder(checkCell))
                         {
-                            visibility.ApplyOcclusion(new Rect(x, y, 1, 1), metrics);
+                            visibility.ApplyOcclusion(new Rect(x, y, 1, 1));
                         }
                     }
                 }
 
                 if (!visibility.IsFullyOccluded)
                 {
-                    foreach (var fragment in visibility.GenerateFragments(metrics))
+                    foreach (var fragment in visibility.GenerateFragments())
                     {
                         fragmentsToEmit.Add(fragment);
                     }

--- a/src/Hex1b/Surfaces/SurfaceComparer.cs
+++ b/src/Hex1b/Surfaces/SurfaceComparer.cs
@@ -1,3 +1,4 @@
+using Hex1b.Layout;
 using Hex1b.Theming;
 using Hex1b.Tokens;
 using System.Text;
@@ -261,6 +262,17 @@ public static class SurfaceComparer
         if (diff.IsEmpty) return;
 
         var tokens = output;
+        IReadOnlyList<ChangedCell> changes = diff.ChangedCells;
+        List<Rect>? sixelDamage = null;
+
+        if (currentSurface is not null && previousSurface is not null && previousSurface.HasSixels)
+        {
+            sixelDamage = GetReplacedSixelRegions(previousSurface, currentSurface);
+            if (sixelDamage.Count > 0)
+            {
+                changes = IncludeDamageCells(diff.ChangedCells, currentSurface, sixelDamage);
+            }
+        }
         
         // Emit KGP delete commands for images that were in the previous surface but have
         // moved or been removed. KGP placements persist in the terminal until explicitly
@@ -298,6 +310,7 @@ public static class SurfaceComparer
                                 currentKgpAnchors.TryAdd(cell.Kgp.Data.ImageId, (x, y));
                             }
                         }
+
                     }
                 }
 
@@ -311,6 +324,11 @@ public static class SurfaceComparer
                     }
                 }
             }
+        }
+
+        if (sixelDamage is { Count: > 0 })
+        {
+            EmitSixelDamageClears(tokens, sixelDamage, currentSurface!.Width, currentSurface.Height);
         }
 
         // Track regions covered by sixels (we need to skip cells under sixels)
@@ -332,7 +350,7 @@ public static class SurfaceComparer
         {
             // Build a set of dirty cell positions for fast lookup
             var dirtyCells = new HashSet<(int, int)>();
-            foreach (var change in diff.ChangedCells)
+            foreach (var change in changes)
             {
                 dirtyCells.Add((change.X, change.Y));
             }
@@ -371,78 +389,48 @@ public static class SurfaceComparer
                 }
             }
             
-            // TEMPORARY: Skip fragmentation - just emit full sixels
-            // This tests whether the alignment issue is in fragmentation logic
-            // Use environment variable to toggle: HEX1B_SIXEL_FRAGMENTATION=1 to enable
-            var useFragmentation = Environment.GetEnvironmentVariable("HEX1B_SIXEL_FRAGMENTATION") == "1";
-            
-            if (useFragmentation)
+            // Deterministically fragment around text occluders. Cell backgrounds are
+            // the image's underlay, including backgrounds inherited during compositing,
+            // and must not suppress the image itself.
+            var fragmentsToEmit = new List<SixelFragment>();
+
+            foreach (var (sx, sy, sw, sh, cell) in sixelRegions)
             {
-                // For each sixel, compute occlusions from overlapping text and fragment accordingly
-                var fragmentsToEmit = new List<SixelFragment>();
-                
-                foreach (var (sx, sy, sw, sh, cell) in sixelRegions)
+                var visibility = new SixelVisibility(cell.Sixel!, sx, sy, 0);
+                var metrics = currentSurface.CellMetrics;
+
+                for (var y = sy; y < sy + sh && y < currentSurface.Height; y++)
                 {
-                    // Create a SixelVisibility tracker for this sixel
-                    var visibility = new SixelVisibility(cell.Sixel!, sx, sy, 0);
-                    var metrics = currentSurface.CellMetrics;
-                    
-                    // Scan for overlapping text cells and apply as occlusions
-                    for (var y = sy; y < sy + sh && y < currentSurface.Height; y++)
+                    for (var x = sx; x < sx + sw && x < currentSurface.Width; x++)
                     {
-                        for (var x = sx; x < sx + sw && x < currentSurface.Width; x++)
+                        var checkCell = currentSurface[x, y];
+                        if (IsSixelOccluder(checkCell))
                         {
-                            var checkCell = currentSurface[x, y];
-                            // If there's a non-space, non-unwritten cell in the sixel region, it occludes
-                            if (checkCell.Character != " " && checkCell.Character != SurfaceCells.UnwrittenMarker)
-                            {
-                                // This single cell is an occlusion
-                                visibility.ApplyOcclusion(new Layout.Rect(x, y, 1, 1), metrics);
-                            }
+                            visibility.ApplyOcclusion(new Rect(x, y, 1, 1), metrics);
                         }
                     }
-                    
-                    // Generate fragments for the visible portions
-                    var fragments = visibility.GenerateFragments(metrics);
-                    
-                    if (visibility.IsFullyOccluded)
-                    {
-                        continue;
-                    }
-                    
-                    foreach (var fragment in fragments)
+                }
+
+                if (!visibility.IsFullyOccluded)
+                {
+                    foreach (var fragment in visibility.GenerateFragments(metrics))
                     {
                         fragmentsToEmit.Add(fragment);
                     }
                 }
-                
-                // Emit ALL sixel fragments first (before any text cells)
-                foreach (var fragment in fragmentsToEmit)
-                {
-                    var payload = fragment.GetPayload();
-                    if (payload is null)
-                    {
-                        continue;
-                    }
-
-                    var (fx, fy) = fragment.CellPosition;
-                    
-                    // Position cursor at fragment position
-                    tokens.Add(new CursorPositionToken(fy + 1, fx + 1));
-                    // Emit the fragment
-                    tokens.Add(new UnrecognizedSequenceToken(payload));
-                }
             }
-            else
+
+            foreach (var fragment in fragmentsToEmit)
             {
-                // No fragmentation - emit full sixels, rely on text to overwrite
-                foreach (var (sx, sy, _, _, cell) in sixelRegions)
+                var payload = fragment.GetPayload();
+                if (payload is null)
                 {
-                    // Position cursor at sixel anchor
-                    tokens.Add(new CursorPositionToken(sy + 1, sx + 1));
-                    // Emit the full sixel
-                    tokens.Add(new UnrecognizedSequenceToken(cell.Sixel!.Data.Payload));
+                    continue;
                 }
+
+                var (fx, fy) = fragment.CellPosition;
+                tokens.Add(new CursorPositionToken(fy + 1, fx + 1));
+                tokens.Add(new UnrecognizedSequenceToken(payload));
             }
         }
 
@@ -450,7 +438,7 @@ public static class SurfaceComparer
         if (currentSurface != null && currentSurface.HasKgp)
         {
             var dirtyCells = new HashSet<(int, int)>();
-            foreach (var change in diff.ChangedCells)
+            foreach (var change in changes)
             {
                 dirtyCells.Add((change.X, change.Y));
             }
@@ -520,7 +508,7 @@ public static class SurfaceComparer
         // foreground+RGB background+RGB underline colour, e.g. "0;1;3;38;2;255;255;255;48;2;255;255;255;58;2;255;255;255" is 56 bytes.
         Span<byte> sgrBuf = stackalloc byte[96];
 
-        foreach (var change in diff.ChangedCells)
+        foreach (var change in changes)
         {
             // Skip continuation cells - they're handled by the wide character before them
             if (change.Cell.IsContinuation)
@@ -622,7 +610,11 @@ public static class SurfaceComparer
                     cursorX = -1;
                     cursorY = -1;
                 }
-                continue;
+
+                if (!IsSixelOccluder(change.Cell))
+                {
+                    continue;
+                }
             }
 
             // Check if this cell has KGP data
@@ -863,9 +855,144 @@ public static class SurfaceComparer
         if (a is null && b is null) return true;
         if (a is null || b is null) return false;
         
-        // Compare by content hash
-        return SixelData.HashEquals(a.Data.ContentHash, b.Data.ContentHash);
+        return SixelData.HashEquals(a.Data.ContentHash, b.Data.ContentHash)
+            && a.Data.WidthInCells == b.Data.WidthInCells
+            && a.Data.HeightInCells == b.Data.HeightInCells
+            && a.Data.CellMetrics == b.Data.CellMetrics;
     }
+
+    private static List<Rect> GetReplacedSixelRegions(Surface previous, Surface current)
+    {
+        var currentAnchors = new Dictionary<(int X, int Y), SixelData>();
+        for (var y = 0; y < current.Height; y++)
+        {
+            for (var x = 0; x < current.Width; x++)
+            {
+                if (current[x, y].Sixel?.Data is { } currentData)
+                {
+                    currentAnchors[(x, y)] = currentData;
+                }
+            }
+        }
+
+        var damage = new List<Rect>();
+        for (var y = 0; y < previous.Height; y++)
+        {
+            for (var x = 0; x < previous.Width; x++)
+            {
+                if (previous[x, y].Sixel?.Data is not { } previousData)
+                {
+                    continue;
+                }
+
+                if (currentAnchors.TryGetValue((x, y), out var currentData) &&
+                    SixelData.HashEquals(previousData.ContentHash, currentData.ContentHash) &&
+                    previousData.WidthInCells == currentData.WidthInCells &&
+                    previousData.HeightInCells == currentData.HeightInCells &&
+                    previousData.CellMetrics == currentData.CellMetrics)
+                {
+                    continue;
+                }
+
+                damage.Add(new Rect(x, y, previousData.WidthInCells, previousData.HeightInCells));
+            }
+        }
+
+        return damage;
+    }
+
+    private static IReadOnlyList<ChangedCell> IncludeDamageCells(
+        IReadOnlyList<ChangedCell> changes,
+        Surface current,
+        IReadOnlyList<Rect> damage)
+    {
+        var byPosition = new Dictionary<(int X, int Y), ChangedCell>(changes.Count);
+        foreach (var change in changes)
+        {
+            byPosition[(change.X, change.Y)] = change;
+        }
+
+        foreach (var rect in damage)
+        {
+            var left = Math.Max(0, rect.X);
+            var top = Math.Max(0, rect.Y);
+            var right = Math.Min(current.Width, rect.Right);
+            var bottom = Math.Min(current.Height, rect.Bottom);
+            for (var y = top; y < bottom; y++)
+            {
+                for (var x = left; x < right; x++)
+                {
+                    byPosition[(x, y)] = new ChangedCell(x, y, current[x, y]);
+                }
+            }
+        }
+
+        return byPosition.Values
+            .OrderBy(static change => change.Y)
+            .ThenBy(static change => change.X)
+            .ToArray();
+    }
+
+    private static void EmitSixelDamageClears(
+        List<AnsiToken> tokens,
+        IReadOnlyList<Rect> damage,
+        int surfaceWidth,
+        int surfaceHeight)
+    {
+        var rows = new Dictionary<int, HashSet<int>>();
+        foreach (var rect in damage)
+        {
+            var left = Math.Max(0, rect.X);
+            var top = Math.Max(0, rect.Y);
+            var right = Math.Min(surfaceWidth, rect.Right);
+            var bottom = Math.Min(surfaceHeight, rect.Bottom);
+            for (var y = top; y < bottom; y++)
+            {
+                if (!rows.TryGetValue(y, out var columns))
+                {
+                    columns = [];
+                    rows[y] = columns;
+                }
+
+                for (var x = left; x < right; x++)
+                {
+                    columns.Add(x);
+                }
+            }
+        }
+
+        if (rows.Count == 0)
+        {
+            return;
+        }
+
+        tokens.Add(SgrToken.Reset);
+        foreach (var (y, columns) in rows.OrderBy(static pair => pair.Key))
+        {
+            var ordered = columns.Order().ToArray();
+            var start = ordered[0];
+            var previous = start;
+            for (var i = 1; i <= ordered.Length; i++)
+            {
+                if (i < ordered.Length && ordered[i] == previous + 1)
+                {
+                    previous = ordered[i];
+                    continue;
+                }
+
+                tokens.Add(new CursorPositionToken(y + 1, start + 1));
+                tokens.Add(new TextToken(new string(' ', previous - start + 1)));
+                if (i < ordered.Length)
+                {
+                    start = previous = ordered[i];
+                }
+            }
+        }
+    }
+
+    private static bool IsSixelOccluder(SurfaceCell cell)
+        => cell.Character != SurfaceCells.UnwrittenMarker
+            && cell.Character != " ";
     
     private static bool KgpEqual(TrackedObject<KgpCellData>? a, TrackedObject<KgpCellData>? b)
     {

--- a/src/Hex1b/Surfaces/SurfaceComparer.cs
+++ b/src/Hex1b/Surfaces/SurfaceComparer.cs
@@ -397,7 +397,7 @@ public static class SurfaceComparer
             foreach (var (sx, sy, sw, sh, cell) in sixelRegions)
             {
                 var visibility = new SixelVisibility(cell.Sixel!, sx, sy, 0);
-                var metrics = currentSurface.CellMetrics;
+                var metrics = cell.Sixel!.Data.CellMetrics;
 
                 for (var y = sy; y < sy + sh && y < currentSurface.Height; y++)
                 {
@@ -716,7 +716,7 @@ public static class SurfaceComparer
     private static bool IsCoveredBySixelRegion(int x, int y, SurfaceCell cell, List<(int X, int Y, int Width, int Height, SurfaceCell Cell)> regions)
     {
         // If the cell has actual content, it should be rendered over the sixel
-        if (cell.Character != " " && cell.Character != string.Empty && cell.Character != SurfaceCells.UnwrittenMarker)
+        if (IsSixelOccluder(cell))
             return false;
         
         foreach (var (sx, sy, sw, sh, _) in regions)
@@ -832,6 +832,8 @@ public static class SurfaceComparer
             !ColorsEqual(a.Background, b.Background) ||
             a.Attributes != b.Attributes ||
             a.DisplayWidth != b.DisplayWidth ||
+            a.IsSixelUnderlay != b.IsSixelUnderlay ||
+            a.OccludesSixel != b.OccludesSixel ||
             a.UnderlineStyle != b.UnderlineStyle ||
             !ColorsEqual(a.UnderlineColor, b.UnderlineColor))
         {
@@ -991,8 +993,21 @@ public static class SurfaceComparer
     }
 
     private static bool IsSixelOccluder(SurfaceCell cell)
-        => cell.Character != SurfaceCells.UnwrittenMarker
-            && cell.Character != " ";
+    {
+        if (cell.OccludesSixel)
+        {
+            return true;
+        }
+
+        if (cell.HasSixel)
+        {
+            return cell.Character != SurfaceCells.UnwrittenMarker && cell.Character != " ";
+        }
+
+        return !cell.IsSixelUnderlay &&
+            cell.Character != SurfaceCells.UnwrittenMarker &&
+            (cell.Character != " " || cell.Background is not null);
+    }
     
     private static bool KgpEqual(TrackedObject<KgpCellData>? a, TrackedObject<KgpCellData>? b)
     {

--- a/src/Hex1b/Surfaces/SurfaceRenderContext.cs
+++ b/src/Hex1b/Surfaces/SurfaceRenderContext.cs
@@ -282,37 +282,109 @@ public class SurfaceRenderContext : Hex1bRenderContext
     public override void WriteSixel(SixelPixelBuffer pixels, int cellWidth, int cellHeight)
     {
         ArgumentNullException.ThrowIfNull(pixels);
-        WriteSixelCore(SixelEncoder.Encode(pixels), cellWidth, cellHeight);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(cellWidth);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(cellHeight);
+
+        if (!TryGetVisibleSixelSpan(cellWidth, cellHeight, out var visibleWidth, out var visibleHeight))
+        {
+            return;
+        }
+
+        var metrics = Capabilities.SixelCellMetrics ?? SixelCellMetrics.FromCapabilities(Capabilities);
+        var resized = pixels.Resize(
+            metrics.GetPixelWidthForColumns(cellWidth),
+            metrics.GetPixelHeightForRows(cellHeight));
+        if (visibleWidth != cellWidth || visibleHeight != cellHeight)
+        {
+            resized = resized.Crop(
+                0,
+                0,
+                metrics.GetPixelForColumnBoundary(visibleWidth),
+                metrics.GetPixelForRowBoundary(visibleHeight));
+        }
+
+        var payload = SixelEncoder.Encode(resized);
+        WriteSixelCore(
+            payload,
+            visibleWidth,
+            visibleHeight,
+            SixelParser.ParsePayload(payload),
+            metrics);
     }
 
     /// <inheritdoc />
     public override void WriteSixel(string imageData, int cellWidth, int cellHeight)
-        => WriteSixelCore(
-            SixelPayload.NormalizeAndValidate(imageData, nameof(imageData)),
-            cellWidth,
-            cellHeight);
-
-    private void WriteSixelCore(string payload, int cellWidth, int cellHeight)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(cellWidth);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(cellHeight);
 
+        var payload = SixelPayload.NormalizeAndValidate(imageData, nameof(imageData));
+        var parseResult = SixelParser.ParsePayload(payload);
+        var metrics = Capabilities.SixelCellMetrics ?? SixelCellMetrics.FromCapabilities(Capabilities);
+        SixelPayload.ValidateCellSpan(parseResult, metrics, cellWidth, cellHeight, nameof(imageData));
+
+        if (!TryGetVisibleSixelSpan(cellWidth, cellHeight, out var visibleWidth, out var visibleHeight))
+        {
+            return;
+        }
+
+        if (visibleWidth != cellWidth || visibleHeight != cellHeight)
+        {
+            var data = new SixelData(
+                payload,
+                cellWidth,
+                cellHeight,
+                SixelData.ComputeHash(payload),
+                parseResult.DeclaredExtent.Width,
+                parseResult.DeclaredExtent.Height,
+                parseResult,
+                cellMetrics: metrics);
+            var fragment = new SixelFragment(
+                data,
+                0,
+                0,
+                new PixelRect(
+                    0,
+                    0,
+                    Math.Min(data.GetRenderedPixelExtent().Width, metrics.GetPixelForColumnBoundary(visibleWidth)),
+                    Math.Min(data.GetRenderedPixelExtent().Height, metrics.GetPixelForRowBoundary(visibleHeight))));
+            payload = fragment.GetPayload()
+                ?? throw new InvalidOperationException("The pre-encoded Sixel payload could not be clipped.");
+            parseResult = SixelParser.ParsePayload(payload);
+        }
+
+        WriteSixelCore(payload, visibleWidth, visibleHeight, parseResult, metrics);
+    }
+
+    private bool TryGetVisibleSixelSpan(
+        int cellWidth,
+        int cellHeight,
+        out int visibleWidth,
+        out int visibleHeight)
+    {
         var writeX = _cursorX - _offsetX;
         var writeY = _cursorY - _offsetY;
         if (writeX < 0 || writeY < 0 || writeX >= _surface.Width || writeY >= _surface.Height)
         {
-            return;
+            visibleWidth = 0;
+            visibleHeight = 0;
+            return false;
         }
 
-        var visibleWidth = Math.Min(cellWidth, _surface.Width - writeX);
-        var visibleHeight = Math.Min(cellHeight, _surface.Height - writeY);
-        if (visibleWidth <= 0 || visibleHeight <= 0)
-        {
-            return;
-        }
+        visibleWidth = Math.Min(cellWidth, _surface.Width - writeX);
+        visibleHeight = Math.Min(cellHeight, _surface.Height - writeY);
+        return visibleWidth > 0 && visibleHeight > 0;
+    }
 
-        var parseResult = SixelParser.ParsePayload(payload);
-        var metrics = Capabilities.SixelCellMetrics ?? SixelCellMetrics.FromCapabilities(Capabilities);
+    private void WriteSixelCore(
+        string payload,
+        int visibleWidth,
+        int visibleHeight,
+        SixelParseResult parseResult,
+        SixelCellMetrics metrics)
+    {
+        var writeX = _cursorX - _offsetX;
+        var writeY = _cursorY - _offsetY;
         var tracked = _trackedObjects.GetOrCreateSixel(
             payload,
             visibleWidth,
@@ -346,7 +418,10 @@ public class SurfaceRenderContext : Hex1bRenderContext
                         _currentAttributes,
                         Sixel: tracked,
                         UnderlineStyle: _currentUnderlineStyle,
-                        UnderlineColor: _currentUnderlineColor);
+                        UnderlineColor: _currentUnderlineColor)
+                    {
+                        IsSixelUnderlay = true
+                    };
                 }
                 else
                 {
@@ -357,7 +432,10 @@ public class SurfaceRenderContext : Hex1bRenderContext
                         _currentBackground,
                         _currentAttributes,
                         UnderlineStyle: _currentUnderlineStyle,
-                        UnderlineColor: _currentUnderlineColor);
+                        UnderlineColor: _currentUnderlineColor)
+                    {
+                        IsSixelUnderlay = true
+                    };
                 }
             }
         }
@@ -1166,24 +1244,36 @@ public class SurfaceRenderContext : Hex1bRenderContext
                 if (displayWidth == 2)
                 {
                     // Write main cell
-                    var existingSixel = _surface[writeX, writeY].Sixel;
-                    _surface[writeX, writeY] = new SurfaceCell(
+                    var existingCell = _surface[writeX, writeY];
+                    var cell = new SurfaceCell(
                         grapheme,
                         _currentForeground,
                         _currentBackground,
                         _currentAttributes,
                         displayWidth,
-                        Sixel: existingSixel,
+                        Sixel: existingCell.Sixel,
                         Hyperlink: _currentHyperlink,
                         UnderlineStyle: _currentUnderlineStyle,
                         UnderlineColor: _currentUnderlineColor);
+                    if (existingCell.IsSixelUnderlay)
+                    {
+                        cell = cell with
+                        {
+                            IsSixelUnderlay = true,
+                            OccludesSixel = IsSixelOccluder(cell)
+                        };
+                    }
+                    _surface[writeX, writeY] = cell;
 
                     // Write continuation cell if space allows
                     if (writeX + 1 < _surface.Width)
                     {
+                        var existingContinuation = _surface[writeX + 1, writeY];
                         var continuation = SurfaceCell.CreateContinuation(_currentBackground) with
                         {
-                            Sixel = _surface[writeX + 1, writeY].Sixel
+                            Sixel = existingContinuation.Sixel,
+                            IsSixelUnderlay = existingContinuation.IsSixelUnderlay,
+                            OccludesSixel = existingContinuation.IsSixelUnderlay
                         };
                         _surface[writeX + 1, writeY] = continuation;
                     }
@@ -1192,17 +1282,26 @@ public class SurfaceRenderContext : Hex1bRenderContext
                 }
                 else if (displayWidth == 1)
                 {
-                    var existingSixel = _surface[writeX, writeY].Sixel;
-                    _surface[writeX, writeY] = new SurfaceCell(
+                    var existingCell = _surface[writeX, writeY];
+                    var cell = new SurfaceCell(
                         grapheme,
                         _currentForeground,
                         _currentBackground,
                         _currentAttributes,
                         displayWidth,
-                        Sixel: existingSixel,
+                        Sixel: existingCell.Sixel,
                         Hyperlink: _currentHyperlink,
                         UnderlineStyle: _currentUnderlineStyle,
                         UnderlineColor: _currentUnderlineColor);
+                    if (existingCell.IsSixelUnderlay)
+                    {
+                        cell = cell with
+                        {
+                            IsSixelUnderlay = true,
+                            OccludesSixel = IsSixelOccluder(cell)
+                        };
+                    }
+                    _surface[writeX, writeY] = cell;
                     writeX++;
                 }
                 else
@@ -1229,6 +1328,10 @@ public class SurfaceRenderContext : Hex1bRenderContext
             _cursorY = writeY + _offsetY;
         }
     }
+
+    private static bool IsSixelOccluder(in SurfaceCell cell)
+        => cell.Character != SurfaceCells.UnwrittenMarker
+            && (cell.Character != " " || cell.Background is not null);
     
     /// <summary>
     /// Gets the next grapheme cluster from the string starting at the given index.

--- a/src/Hex1b/Surfaces/SurfaceRenderContext.cs
+++ b/src/Hex1b/Surfaces/SurfaceRenderContext.cs
@@ -1,5 +1,6 @@
 using Hex1b.Layout;
 using Hex1b.Nodes;
+using Hex1b.Sixel;
 using Hex1b.Theming;
 
 namespace Hex1b.Surfaces;
@@ -275,6 +276,91 @@ public class SurfaceRenderContext : Hex1bRenderContext
             return;
 
         WriteToSurface(_cursorX, _cursorY, text, updateCursor: true);
+    }
+
+    /// <inheritdoc />
+    public override void WriteSixel(SixelPixelBuffer pixels, int cellWidth, int cellHeight)
+    {
+        ArgumentNullException.ThrowIfNull(pixels);
+        WriteSixelCore(SixelEncoder.Encode(pixels), cellWidth, cellHeight);
+    }
+
+    /// <inheritdoc />
+    public override void WriteSixel(string imageData, int cellWidth, int cellHeight)
+        => WriteSixelCore(
+            SixelPayload.NormalizeAndValidate(imageData, nameof(imageData)),
+            cellWidth,
+            cellHeight);
+
+    private void WriteSixelCore(string payload, int cellWidth, int cellHeight)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(cellWidth);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(cellHeight);
+
+        var writeX = _cursorX - _offsetX;
+        var writeY = _cursorY - _offsetY;
+        if (writeX < 0 || writeY < 0 || writeX >= _surface.Width || writeY >= _surface.Height)
+        {
+            return;
+        }
+
+        var visibleWidth = Math.Min(cellWidth, _surface.Width - writeX);
+        var visibleHeight = Math.Min(cellHeight, _surface.Height - writeY);
+        if (visibleWidth <= 0 || visibleHeight <= 0)
+        {
+            return;
+        }
+
+        var parseResult = SixelParser.ParsePayload(payload);
+        var metrics = Capabilities.SixelCellMetrics ?? SixelCellMetrics.FromCapabilities(Capabilities);
+        var tracked = _trackedObjects.GetOrCreateSixel(
+            payload,
+            visibleWidth,
+            visibleHeight,
+            parseResult,
+            cellMetrics: metrics);
+
+        for (var y = 0; y < visibleHeight; y++)
+        {
+            for (var x = 0; x < visibleWidth; x++)
+            {
+                var targetX = writeX + x;
+                var targetY = writeY + y;
+                var oldSixel = _surface[targetX, targetY].Sixel;
+
+                if (x == 0 && y == 0)
+                {
+                    if (ReferenceEquals(oldSixel, tracked))
+                    {
+                        tracked.Release();
+                    }
+                    else
+                    {
+                        oldSixel?.Release();
+                    }
+
+                    _surface[targetX, targetY] = new SurfaceCell(
+                        " ",
+                        _currentForeground,
+                        _currentBackground,
+                        _currentAttributes,
+                        Sixel: tracked,
+                        UnderlineStyle: _currentUnderlineStyle,
+                        UnderlineColor: _currentUnderlineColor);
+                }
+                else
+                {
+                    oldSixel?.Release();
+                    _surface[targetX, targetY] = new SurfaceCell(
+                        " ",
+                        _currentForeground,
+                        _currentBackground,
+                        _currentAttributes,
+                        UnderlineStyle: _currentUnderlineStyle,
+                        UnderlineColor: _currentUnderlineColor);
+                }
+            }
+        }
     }
     
     /// <summary>
@@ -942,10 +1028,16 @@ public class SurfaceRenderContext : Hex1bRenderContext
             else
             {
                 var pool = SurfacePool;
-                // The retained buffer no longer fits — surrender it to the pool
-                // (or let GC collect it) before allocating a new one.
-                if (pool != null && child.RenderBuffer is { } retired)
-                    pool.Return(retired);
+                // The retained buffer no longer fits. Return it to the pool, or
+                // explicitly release tracked references before letting GC collect it.
+                if (existingBuffer is { } retired)
+                {
+                    if (pool != null)
+                        pool.Return(retired);
+                    else
+                        retired.ClearAndReleaseTrackedObjects();
+                }
+                child.CachedSurface = null;
                 child.RenderBuffer = null;
                 childSurface = pool != null
                     ? pool.Rent(clampedWidth, clampedHeight, CellMetrics)
@@ -1074,12 +1166,14 @@ public class SurfaceRenderContext : Hex1bRenderContext
                 if (displayWidth == 2)
                 {
                     // Write main cell
+                    var existingSixel = _surface[writeX, writeY].Sixel;
                     _surface[writeX, writeY] = new SurfaceCell(
                         grapheme,
                         _currentForeground,
                         _currentBackground,
                         _currentAttributes,
                         displayWidth,
+                        Sixel: existingSixel,
                         Hyperlink: _currentHyperlink,
                         UnderlineStyle: _currentUnderlineStyle,
                         UnderlineColor: _currentUnderlineColor);
@@ -1087,19 +1181,25 @@ public class SurfaceRenderContext : Hex1bRenderContext
                     // Write continuation cell if space allows
                     if (writeX + 1 < _surface.Width)
                     {
-                        _surface[writeX + 1, writeY] = SurfaceCell.CreateContinuation(_currentBackground);
+                        var continuation = SurfaceCell.CreateContinuation(_currentBackground) with
+                        {
+                            Sixel = _surface[writeX + 1, writeY].Sixel
+                        };
+                        _surface[writeX + 1, writeY] = continuation;
                     }
 
                     writeX += 2;
                 }
                 else if (displayWidth == 1)
                 {
+                    var existingSixel = _surface[writeX, writeY].Sixel;
                     _surface[writeX, writeY] = new SurfaceCell(
                         grapheme,
                         _currentForeground,
                         _currentBackground,
                         _currentAttributes,
                         displayWidth,
+                        Sixel: existingSixel,
                         Hyperlink: _currentHyperlink,
                         UnderlineStyle: _currentUnderlineStyle,
                         UnderlineColor: _currentUnderlineColor);

--- a/src/Hex1b/Surfaces/SurfaceRenderContext.cs
+++ b/src/Hex1b/Surfaces/SurfaceRenderContext.cs
@@ -334,7 +334,12 @@ public class SurfaceRenderContext : Hex1bRenderContext
                 payload,
                 cellWidth,
                 cellHeight,
-                SixelData.ComputeHash(payload),
+                SixelData.ComputeHash(
+                    payload,
+                    rasterIdentity: null,
+                    cellWidth,
+                    cellHeight,
+                    metrics),
                 parseResult.DeclaredExtent.Width,
                 parseResult.DeclaredExtent.Height,
                 parseResult,

--- a/src/Hex1b/TrackedObjectStore.cs
+++ b/src/Hex1b/TrackedObjectStore.cs
@@ -19,8 +19,15 @@ namespace Hex1b;
 /// </remarks>
 internal sealed class TrackedObjectStore
 {
-    // Content-addressable storage for Sixel data, keyed by content hash
-    private readonly Dictionary<byte[], TrackedObject<SixelData>> _sixelByHash = new(ByteArrayComparer.Instance);
+    private readonly record struct SixelStoreKey(
+        string ContentHash,
+        int WidthInCells,
+        int HeightInCells,
+        SixelCellMetrics CellMetrics);
+
+    // A Sixel image's retained raster content is content-addressed, but its
+    // placement span and captured protocol metrics are also immutable state.
+    private readonly Dictionary<SixelStoreKey, TrackedObject<SixelData>> _sixelByKey = [];
     
     // Content-addressable storage for hyperlink data, keyed by content hash
     private readonly Dictionary<byte[], TrackedObject<HyperlinkData>> _hyperlinkByHash = new(ByteArrayComparer.Instance);
@@ -39,7 +46,7 @@ internal sealed class TrackedObjectStore
         {
             lock (_lock)
             {
-                return _sixelByHash.Count;
+                return _sixelByKey.Count;
             }
         }
     }
@@ -97,10 +104,16 @@ internal sealed class TrackedObjectStore
         SixelCellMetrics? cellMetrics = null)
     {
         var hash = SixelData.ComputeHash(payload, rasterPreparation?.Identity);
+        var capturedMetrics = cellMetrics ?? SixelCellMetrics.Unknown;
+        var key = new SixelStoreKey(
+            Convert.ToHexString(hash),
+            widthInCells,
+            heightInCells,
+            capturedMetrics);
 
         lock (_lock)
         {
-            if (_sixelByHash.TryGetValue(hash, out var existing))
+            if (_sixelByKey.TryGetValue(key, out var existing))
             {
                 // Found existing - add a reference and return it
                 existing.AddRef();
@@ -117,14 +130,14 @@ internal sealed class TrackedObjectStore
                 parseResult.DeclaredExtent.Height,
                 parseResult,
                 rasterPreparation: rasterPreparation,
-                cellMetrics: cellMetrics);
+                cellMetrics: capturedMetrics);
             
             // Create new tracked wrapper with removal callback
             var tracked = new TrackedObject<SixelData>(
                 sixelData,
-                onZeroRefs: obj => RemoveSixel(obj.Data));
+                onZeroRefs: obj => RemoveSixel(key, obj));
 
-            _sixelByHash[hash] = tracked;
+            _sixelByKey[key] = tracked;
             return tracked;
         }
     }
@@ -202,17 +215,21 @@ internal sealed class TrackedObjectStore
     {
         lock (_lock)
         {
-            _sixelByHash.Clear();
+            _sixelByKey.Clear();
             _hyperlinkByHash.Clear();
             _kgpByHash.Clear();
         }
     }
 
-    private void RemoveSixel(SixelData sixel)
+    private void RemoveSixel(SixelStoreKey key, TrackedObject<SixelData> tracked)
     {
         lock (_lock)
         {
-            _sixelByHash.Remove(sixel.ContentHash);
+            if (_sixelByKey.TryGetValue(key, out var current) &&
+                ReferenceEquals(current, tracked))
+            {
+                _sixelByKey.Remove(key);
+            }
         }
     }
 

--- a/src/Hex1b/TrackedObjectStore.cs
+++ b/src/Hex1b/TrackedObjectStore.cs
@@ -14,20 +14,14 @@ namespace Hex1b;
 /// <para>
 /// This is internal infrastructure - not exposed to API consumers.
 /// Type-specific APIs (e.g., <see cref="GetOrCreateSixel(string, int, int)"/>) handle deduplication
-/// by content hash.
+/// by complete immutable resource identity.
 /// </para>
 /// </remarks>
 internal sealed class TrackedObjectStore
 {
-    private readonly record struct SixelStoreKey(
-        string ContentHash,
-        int WidthInCells,
-        int HeightInCells,
-        SixelCellMetrics CellMetrics);
-
-    // A Sixel image's retained raster content is content-addressed, but its
-    // placement span and captured protocol metrics are also immutable state.
-    private readonly Dictionary<SixelStoreKey, TrackedObject<SixelData>> _sixelByKey = [];
+    // Sixel resource identity includes raster content/state, placement span,
+    // and captured protocol metrics.
+    private readonly Dictionary<string, TrackedObject<SixelData>> _sixelByIdentity = [];
     
     // Content-addressable storage for hyperlink data, keyed by content hash
     private readonly Dictionary<byte[], TrackedObject<HyperlinkData>> _hyperlinkByHash = new(ByteArrayComparer.Instance);
@@ -46,7 +40,7 @@ internal sealed class TrackedObjectStore
         {
             lock (_lock)
             {
-                return _sixelByKey.Count;
+                return _sixelByIdentity.Count;
             }
         }
     }
@@ -80,9 +74,9 @@ internal sealed class TrackedObjectStore
     }
 
     /// <summary>
-    /// Gets or creates a tracked Sixel object for the given payload.
-    /// If an identical payload already exists, adds a reference and returns it.
-    /// Otherwise, creates a new tracked object with refcount 1.
+    /// Gets or creates a tracked Sixel object for the given payload and cell span.
+    /// If an identical compatible resource already exists, adds a reference and
+    /// returns it. Otherwise, creates a new tracked object with refcount 1.
     /// </summary>
     /// <param name="payload">The raw Sixel DCS sequence.</param>
     /// <param name="widthInCells">Width of the image in terminal cells.</param>
@@ -103,17 +97,18 @@ internal sealed class TrackedObjectStore
         SixelRasterPreparation? rasterPreparation = null,
         SixelCellMetrics? cellMetrics = null)
     {
-        var hash = SixelData.ComputeHash(payload, rasterPreparation?.Identity);
         var capturedMetrics = cellMetrics ?? SixelCellMetrics.Unknown;
-        var key = new SixelStoreKey(
-            Convert.ToHexString(hash),
+        var hash = SixelData.ComputeHash(
+            payload,
+            rasterPreparation?.Identity,
             widthInCells,
             heightInCells,
             capturedMetrics);
+        var identity = Convert.ToHexString(hash);
 
         lock (_lock)
         {
-            if (_sixelByKey.TryGetValue(key, out var existing))
+            if (_sixelByIdentity.TryGetValue(identity, out var existing))
             {
                 // Found existing - add a reference and return it
                 existing.AddRef();
@@ -135,9 +130,9 @@ internal sealed class TrackedObjectStore
             // Create new tracked wrapper with removal callback
             var tracked = new TrackedObject<SixelData>(
                 sixelData,
-                onZeroRefs: obj => RemoveSixel(key, obj));
+                onZeroRefs: obj => RemoveSixel(identity, obj));
 
-            _sixelByKey[key] = tracked;
+            _sixelByIdentity[identity] = tracked;
             return tracked;
         }
     }
@@ -215,20 +210,20 @@ internal sealed class TrackedObjectStore
     {
         lock (_lock)
         {
-            _sixelByKey.Clear();
+            _sixelByIdentity.Clear();
             _hyperlinkByHash.Clear();
             _kgpByHash.Clear();
         }
     }
 
-    private void RemoveSixel(SixelStoreKey key, TrackedObject<SixelData> tracked)
+    private void RemoveSixel(string identity, TrackedObject<SixelData> tracked)
     {
         lock (_lock)
         {
-            if (_sixelByKey.TryGetValue(key, out var current) &&
+            if (_sixelByIdentity.TryGetValue(identity, out var current) &&
                 ReferenceEquals(current, tracked))
             {
-                _sixelByKey.Remove(key);
+                _sixelByIdentity.Remove(identity);
             }
         }
     }

--- a/src/Hex1b/Widgets/SixelWidget.cs
+++ b/src/Hex1b/Widgets/SixelWidget.cs
@@ -1,27 +1,132 @@
 using System.Diagnostics.CodeAnalysis;
 using Hex1b.Nodes;
+using Hex1b.Sixel;
+using Hex1b.Surfaces;
 
 namespace Hex1b.Widgets;
 
 /// <summary>
-/// A widget that displays a Sixel image if the terminal supports it,
-/// otherwise falls back to rendering the fallback widget.
+/// Displays a Sixel image when the effective presentation supports Sixel,
+/// otherwise displays a fallback widget.
 /// </summary>
-/// <param name="ImageData">The raw Sixel-encoded image data (as a string in Sixel format).</param>
-/// <param name="Fallback">A widget to display if Sixel is not supported.</param>
-/// <param name="Width">The width in character cells for the image. If null, uses the image's natural width.</param>
-/// <param name="Height">The height in character cells for the image. If null, uses the image's natural height.</param>
+/// <remarks>
+/// Structured <see cref="SixelPixelBuffer"/> input is the preferred path.
+/// Pre-encoded input is retained for compatibility and is validated and
+/// normalized to a complete 7-bit DCS sequence.
+/// </remarks>
+/// <example>
+/// <code>
+/// #pragma warning disable HEX1B_SIXEL
+/// using Hex1b;
+/// using Hex1b.Surfaces;
+///
+/// var pixels = new SixelPixelBuffer(80, 40);
+/// for (var y = 0; y &lt; pixels.Height; y++)
+/// {
+///     for (var x = 0; x &lt; pixels.Width; x++)
+///         pixels[x, y] = Rgba32.FromRgb((byte)(x * 3), (byte)(y * 6), 180);
+/// }
+///
+/// await using var terminal = Hex1bTerminal.CreateBuilder()
+///     .WithHex1bApp(ctx =&gt;
+///         ctx.Sixel(pixels, fallback =&gt; fallback.Text("Sixel unavailable"))
+///             .Width(16)
+///             .Height(4))
+///     .Build();
+///
+/// await terminal.RunAsync();
+/// </code>
+/// </example>
 [Experimental("HEX1B_SIXEL", UrlFormat = "https://github.com/hex1b/hex1b/blob/main/docs/experimental/sixel.md")]
-public sealed record SixelWidget(
-    string ImageData, 
-    Hex1bWidget Fallback,
-    int? Width = null,
-    int? Height = null) : Hex1bWidget
+public sealed record SixelWidget : Hex1bWidget
 {
+    /// <summary>
+    /// Creates a widget from structured RGBA pixels.
+    /// </summary>
+    /// <param name="pixels">The pixels to encode and display.</param>
+    /// <param name="fallback">The widget displayed when Sixel is unavailable.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="pixels"/> or <paramref name="fallback"/> is <see langword="null"/>.
+    /// </exception>
+    public SixelWidget(SixelPixelBuffer pixels, Hex1bWidget fallback)
+    {
+        ArgumentNullException.ThrowIfNull(pixels);
+        ArgumentNullException.ThrowIfNull(fallback);
+        Pixels = pixels;
+        Fallback = fallback;
+    }
+
+    /// <summary>
+    /// Creates a widget from validated pre-encoded Sixel data.
+    /// </summary>
+    /// <param name="imageData">
+    /// A complete Sixel DCS sequence, or the Sixel body without its DCS framing.
+    /// </param>
+    /// <param name="fallback">The widget displayed when Sixel is unavailable.</param>
+    /// <param name="width">Optional display width in terminal cells.</param>
+    /// <param name="height">Optional display height in terminal cells.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="imageData"/> is malformed or incomplete.
+    /// </exception>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="imageData"/> or <paramref name="fallback"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="width"/> or <paramref name="height"/> is not positive.
+    /// </exception>
+    public SixelWidget(string imageData, Hex1bWidget fallback, int? width = null, int? height = null)
+    {
+        ArgumentNullException.ThrowIfNull(fallback);
+        ImageData = SixelPayload.NormalizeAndValidate(imageData, nameof(imageData));
+        Fallback = fallback;
+        Width = ValidateDimension(width, nameof(width));
+        Height = ValidateDimension(height, nameof(height));
+    }
+
+    /// <summary>
+    /// Gets the validated, fully framed Sixel sequence for pre-encoded content.
+    /// </summary>
+    /// <remarks>
+    /// This is <see langword="null"/> when the widget was created from
+    /// <see cref="SixelPixelBuffer"/>.
+    /// </remarks>
+    public string? ImageData { get; }
+
+    /// <summary>
+    /// Gets the structured pixels supplied to the widget.
+    /// </summary>
+    /// <remarks>
+    /// This is <see langword="null"/> when the widget was created from pre-encoded content.
+    /// Do not mutate the buffer while the widget is in use.
+    /// </remarks>
+    public SixelPixelBuffer? Pixels { get; }
+
+    /// <summary>
+    /// Gets the widget displayed when Sixel is unavailable.
+    /// </summary>
+    public Hex1bWidget Fallback { get; init; }
+
+    /// <summary>
+    /// Gets the optional display width in terminal cells.
+    /// </summary>
+    public int? Width { get; init; }
+
+    /// <summary>
+    /// Gets the optional display height in terminal cells.
+    /// </summary>
+    public int? Height { get; init; }
+
     internal override async Task<Hex1bNode> ReconcileAsync(Hex1bNode? existingNode, ReconcileContext context)
     {
         var node = existingNode as SixelNode ?? new SixelNode();
-        node.ImageData = ImageData;
+        if (Pixels is not null)
+        {
+            node.SetPixels(Pixels);
+        }
+        else
+        {
+            node.SetEncodedImage(ImageData!);
+        }
         node.RequestedWidth = Width;
         node.RequestedHeight = Height;
         node.Fallback = await context.ReconcileChildAsync(node.Fallback, Fallback, node);
@@ -29,4 +134,14 @@ public sealed record SixelWidget(
     }
 
     internal override Type GetExpectedNodeType() => typeof(SixelNode);
+
+    private static int? ValidateDimension(int? value, string parameterName)
+    {
+        if (value <= 0)
+        {
+            throw new ArgumentOutOfRangeException(parameterName, "Sixel dimensions must be greater than zero.");
+        }
+
+        return value;
+    }
 }

--- a/src/Hex1b/Widgets/SixelWidget.cs
+++ b/src/Hex1b/Widgets/SixelWidget.cs
@@ -11,8 +11,10 @@ namespace Hex1b.Widgets;
 /// </summary>
 /// <remarks>
 /// Structured <see cref="SixelPixelBuffer"/> input is the preferred path.
+/// Explicit cell dimensions resample structured pixels to the corresponding
+/// Sixel protocol raster.
 /// Pre-encoded input is retained for compatibility and is validated and
-/// normalized to a complete 7-bit DCS sequence.
+/// normalized to a complete 7-bit DCS sequence, but cannot be resampled.
 /// </remarks>
 /// <example>
 /// <code>
@@ -63,10 +65,17 @@ public sealed record SixelWidget : Hex1bWidget
     /// A complete Sixel DCS sequence, or the Sixel body without its DCS framing.
     /// </param>
     /// <param name="fallback">The widget displayed when Sixel is unavailable.</param>
-    /// <param name="width">Optional display width in terminal cells.</param>
-    /// <param name="height">Optional display height in terminal cells.</param>
+    /// <param name="width">
+    /// Optional display width in terminal cells. When specified, it must match
+    /// the payload's natural width under the active Sixel protocol metrics.
+    /// </param>
+    /// <param name="height">
+    /// Optional display height in terminal cells. When specified, it must match
+    /// the payload's natural height under the active Sixel protocol metrics.
+    /// </param>
     /// <exception cref="ArgumentException">
     /// Thrown when <paramref name="imageData"/> is malformed or incomplete.
+    /// A dimension mismatch is reported when the widget renders.
     /// </exception>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="imageData"/> or <paramref name="fallback"/> is <see langword="null"/>.
@@ -109,11 +118,19 @@ public sealed record SixelWidget : Hex1bWidget
     /// <summary>
     /// Gets the optional display width in terminal cells.
     /// </summary>
+    /// <remarks>
+    /// Structured pixels are resampled to this width. Pre-encoded content must
+    /// already have this natural width under the active Sixel protocol metrics.
+    /// </remarks>
     public int? Width { get; init; }
 
     /// <summary>
     /// Gets the optional display height in terminal cells.
     /// </summary>
+    /// <remarks>
+    /// Structured pixels are resampled to this height. Pre-encoded content must
+    /// already have this natural height under the active Sixel protocol metrics.
+    /// </remarks>
     public int? Height { get; init; }
 
     internal override async Task<Hex1bNode> ReconcileAsync(Hex1bNode? existingNode, ReconcileContext context)

--- a/src/Hex1b/Widgets/SurfaceContext.cs
+++ b/src/Hex1b/Widgets/SurfaceContext.cs
@@ -1,4 +1,5 @@
 using System.Security.Cryptography;
+using Hex1b.Sixel;
 using Hex1b.Surfaces;
 using Hex1b.Theming;
 
@@ -162,12 +163,21 @@ public class SurfaceLayerContext
     /// <returns>A tracked sixel object, or null if sixel creation is not available.</returns>
     public TrackedObject<SixelData>? CreateSixel(SixelPixelBuffer buffer)
     {
+        ArgumentNullException.ThrowIfNull(buffer);
         if (_store is null)
             return null;
-            
+
+        var metrics = Capabilities.SixelCellMetrics ?? SixelCellMetrics.FromCapabilities(Capabilities);
         var payload = SixelEncoder.Encode(buffer);
-        var (cellWidth, cellHeight) = CellMetrics.PixelToCellSpan(buffer.Width, buffer.Height);
-        return _store.GetOrCreateSixel(payload, cellWidth, cellHeight);
+        var parseResult = SixelParser.ParsePayload(payload);
+        var cellWidth = metrics.ColumnsFor(buffer.Width);
+        var cellHeight = metrics.RowsFor(buffer.Height);
+        return _store.GetOrCreateSixel(
+            payload,
+            cellWidth,
+            cellHeight,
+            parseResult,
+            cellMetrics: metrics);
     }
     
     /// <summary>
@@ -177,12 +187,30 @@ public class SurfaceLayerContext
     /// <param name="widthInCells">Width in terminal cells.</param>
     /// <param name="heightInCells">Height in terminal cells.</param>
     /// <returns>A tracked sixel object, or null if sixel creation is not available.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="payload"/> is malformed, incomplete, or
+    /// does not naturally occupy the requested cell span.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="widthInCells"/> or <paramref name="heightInCells"/> is not positive.
+    /// </exception>
     public TrackedObject<SixelData>? CreateSixel(string payload, int widthInCells, int heightInCells)
     {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(widthInCells);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(heightInCells);
         if (_store is null)
             return null;
-            
-        return _store.GetOrCreateSixel(payload, widthInCells, heightInCells);
+
+        var normalized = SixelPayload.NormalizeAndValidate(payload, nameof(payload));
+        var parseResult = SixelParser.ParsePayload(normalized);
+        var metrics = Capabilities.SixelCellMetrics ?? SixelCellMetrics.FromCapabilities(Capabilities);
+        SixelPayload.ValidateCellSpan(parseResult, metrics, widthInCells, heightInCells, nameof(payload));
+        return _store.GetOrCreateSixel(
+            normalized,
+            widthInCells,
+            heightInCells,
+            parseResult,
+            cellMetrics: metrics);
     }
 
     /// <summary>

--- a/src/content/guide/widgets/index.md
+++ b/src/content/guide/widgets/index.md
@@ -54,6 +54,7 @@ Widgets for presenting information.
 - **[Hyperlink](/guide/widgets/hyperlink)** — Clickable terminal hyperlinks (OSC 8)
 - **[QrCode](/guide/widgets/qrcode)** — Render QR codes in the terminal
 - **[KgpImage](/guide/widgets/kgpimage)** — Display pixel images via the Kitty Graphics Protocol
+- **[Sixel](/guide/widgets/sixel)** — Display structured pixels in Sixel-capable terminals with fallback content
 
 ## Utility Widgets
 

--- a/src/content/guide/widgets/sixel.md
+++ b/src/content/guide/widgets/sixel.md
@@ -1,0 +1,96 @@
+<!--
+  MIRROR WARNING: The code sample below mirrors:
+  - src/Hex1b.Website/Examples/SixelExample.cs
+  - samples/SixelWidgetDemo/Program.cs
+  Keep the public API usage in sync when making changes.
+-->
+<script setup>
+const basicCode = `#pragma warning disable HEX1B_SIXEL
+
+using Hex1b;
+using Hex1b.Surfaces;
+
+var pixels = new SixelPixelBuffer(160, 80);
+for (var y = 0; y < pixels.Height; y++)
+{
+    for (var x = 0; x < pixels.Width; x++)
+    {
+        pixels[x, y] = Rgba32.FromRgb(
+            (byte)(x * 255 / pixels.Width),
+            (byte)(y * 255 / pixels.Height),
+            180);
+    }
+}
+
+await using var terminal = Hex1bTerminal.CreateBuilder()
+    .WithHex1bApp(ctx =>
+        ctx.Sixel(
+                pixels,
+                fallback => fallback.Text("Sixel graphics are unavailable."))
+            .Width(24)
+            .Height(8))
+    .Build();
+
+await terminal.RunAsync();`
+</script>
+
+# SixelWidget
+
+`SixelWidget` displays pixel graphics in terminals with affirmative Sixel
+support and composes a normal fallback widget everywhere else. The API is
+experimental and emits warning `HEX1B_SIXEL`.
+
+## Structured pixels
+
+Use `SixelPixelBuffer` for application-generated images. Hex1b encodes the
+buffer, measures its natural size using the terminal's authoritative Sixel cell
+metrics, and stores structured graphics when rendering through a `Surface`.
+
+<CodeBlock lang="csharp" :code="basicCode" command="dotnet run" example="sixel" exampleTitle="Sixel Widget" />
+
+Omit `Width(...)` and `Height(...)` to use the natural pixel-to-cell size. Set
+either dimension fluently when the layout needs an explicit cell span.
+
+## Pre-encoded compatibility
+
+Use the string overload only when you already have Sixel data:
+
+```csharp
+var image = ctx.Sixel(
+        encodedSixel,
+        fallback => fallback.Text("Sixel graphics are unavailable."))
+    .Width(24)
+    .Height(8);
+```
+
+The input may be a complete 7-bit or 8-bit DCS sequence, or an unframed Sixel
+body. Hex1b validates it and normalizes output to one complete 7-bit
+`ESC P ... ESC \` sequence. Malformed or incomplete data throws
+`ArgumentException`.
+
+## Capability and fallback behavior
+
+Native and headless Sixel presentations render the image. Unsupported and
+unknown presentations render the fallback, which supplies measurement, focus,
+input, and rendering behavior like any other widget subtree. The legacy
+`SupportsSixel` capability remains compatible when typed Sixel support is
+unknown.
+
+## Surface behavior
+
+Surface-backed applications retain Sixel as structured content instead of
+parsing raw DCS written through the generic text path. This enables
+deterministic replacement, movement, removal, clipping, resize, caching, and
+text overlap. Overlapping text is emitted with visible image fragments around
+the occluded cells.
+
+For a larger native-terminal exercise, run:
+
+```bash
+dotnet run --project samples/SixelWidgetDemo
+```
+
+## Related widgets
+
+- [KgpImageWidget](/guide/widgets/kgpimage) - Pixel images using the Kitty Graphics Protocol
+- [SurfaceWidget](/guide/widgets/surface) - Low-level layered cell rendering

--- a/src/content/guide/widgets/sixel.md
+++ b/src/content/guide/widgets/sixel.md
@@ -48,8 +48,9 @@ metrics, and stores structured graphics when rendering through a `Surface`.
 
 <CodeBlock lang="csharp" :code="basicCode" command="dotnet run" example="sixel" exampleTitle="Sixel Widget" />
 
-Omit `Width(...)` and `Height(...)` to use the natural pixel-to-cell size. Set
-either dimension fluently when the layout needs an explicit cell span.
+Omit `Width(...)` and `Height(...)` to use the natural pixel-to-cell size. For
+structured pixels, setting either dimension resamples the emitted raster to the
+widget's arranged cell span using the active Sixel protocol metrics.
 
 ## Pre-encoded compatibility
 
@@ -57,16 +58,20 @@ Use the string overload only when you already have Sixel data:
 
 ```csharp
 var image = ctx.Sixel(
-        encodedSixel,
-        fallback => fallback.Text("Sixel graphics are unavailable."))
-    .Width(24)
-    .Height(8);
+    encodedSixel,
+    fallback => fallback.Text("Sixel graphics are unavailable."));
 ```
 
 The input may be a complete 7-bit or 8-bit DCS sequence, or an unframed Sixel
 body. Hex1b validates it and normalizes output to one complete 7-bit
 `ESC P ... ESC \` sequence. Malformed or incomplete data throws
 `ArgumentException`.
+
+Pre-encoded payloads remain lossless and are not resampled. Their arranged cell
+span must match their natural span under the active Sixel protocol metrics. If
+you apply `Width(...)` or `Height(...)`, use the payload's exact natural
+dimension; an incompatible span throws `ArgumentException` when rendered. Use
+`SixelPixelBuffer` when the image needs to resize with layout.
 
 ## Capability and fallback behavior
 

--- a/tests/Hex1b.Tests/Hex1bRenderContextTests.cs
+++ b/tests/Hex1b.Tests/Hex1bRenderContextTests.cs
@@ -1,4 +1,9 @@
+#pragma warning disable HEX1B_SIXEL // Testing experimental Sixel API
+
+using System.Text;
 using Hex1b.Layout;
+using Hex1b.Sixel;
+using Hex1b.Surfaces;
 
 namespace Hex1b.Tests;
 
@@ -8,6 +13,75 @@ namespace Hex1b.Tests;
 [TestClass]
 public class Hex1bRenderContextTests
 {
+    [TestMethod]
+    public void WriteSixel_StructuredPixels_ResamplesToRequestedProtocolSpan()
+    {
+        var context = new CapturingRenderContext(CreateSixelCapabilities(10, 20));
+        var pixels = new SixelPixelBuffer(240, 120);
+        pixels[0, 0] = Rgba32.FromRgb(255, 0, 0);
+
+        context.WriteSixel(pixels, 32, 9);
+
+        var payload = TestSeq.Single(context.Writes);
+        var parsed = SixelParser.ParsePayload(payload);
+        Assert.AreEqual(320, parsed.DeclaredExtent.Width);
+        Assert.AreEqual(180, parsed.DeclaredExtent.Height);
+        Assert.AreEqual(32, context.Capabilities.SixelCellMetrics!.Value.ColumnsFor(parsed.LogicalCanvasExtent.Width));
+        Assert.AreEqual(9, context.Capabilities.SixelCellMetrics!.Value.RowsFor(parsed.LogicalCanvasExtent.Height));
+    }
+
+    [TestMethod]
+    public void WriteSixel_PreEncodedPayloadWithDifferentSpan_Throws()
+    {
+        var context = new CapturingRenderContext(CreateSixelCapabilities(10, 20));
+        var pixels = new SixelPixelBuffer(20, 20);
+        pixels[0, 0] = Rgba32.FromRgb(255, 0, 0);
+        var payload = SixelEncoder.Encode(pixels);
+
+        var exception = Assert.Throws<ArgumentException>(() => context.WriteSixel(payload, 3, 1));
+
+        Assert.Contains("cannot be resized", exception.Message);
+        Assert.IsEmpty(context.Writes);
+    }
+
+    [TestMethod]
+    public void WriteSixel_FractionalProtocolMetrics_PreservesRequestedCellSpan()
+    {
+        var context = new CapturingRenderContext(CreateSixelCapabilities(9.6, 19.6));
+        var pixels = new SixelPixelBuffer(20, 20);
+        pixels[0, 0] = Rgba32.FromRgb(255, 0, 0);
+
+        context.WriteSixel(pixels, 1, 1);
+
+        var parsed = SixelParser.ParsePayload(TestSeq.Single(context.Writes));
+        Assert.AreEqual(9, parsed.DeclaredExtent.Width);
+        Assert.AreEqual(19, parsed.DeclaredExtent.Height);
+        Assert.AreEqual(1, context.Capabilities.SixelCellMetrics!.Value.ColumnsFor(parsed.LogicalCanvasExtent.Width));
+        Assert.AreEqual(1, context.Capabilities.SixelCellMetrics!.Value.RowsFor(parsed.LogicalCanvasExtent.Height));
+    }
+
+    [TestMethod]
+    public void WriteSixel_EightBitFraming_EmitsCanonicalSevenBitBytes()
+    {
+        var context = new CapturingRenderContext(CreateSixelCapabilities(10, 20));
+        var pixels = new SixelPixelBuffer(10, 20);
+        pixels[0, 0] = Rgba32.FromRgb(255, 0, 0);
+        var sevenBit = SixelEncoder.Encode(pixels);
+        var eightBit = $"\x90{sevenBit[2..^2]}\x9c";
+
+        context.WriteSixel(eightBit, 1, 1);
+
+        var emitted = TestSeq.Single(context.Writes);
+        var bytes = Encoding.UTF8.GetBytes(emitted);
+        Assert.StartsWith("\x1bP", emitted);
+        Assert.EndsWith("\x1b\\", emitted);
+        Assert.AreEqual(0x1b, bytes[0]);
+        Assert.AreEqual((byte)'P', bytes[1]);
+        Assert.AreEqual(0x1b, bytes[^2]);
+        Assert.AreEqual((byte)'\\', bytes[^1]);
+        Assert.IsFalse(bytes.Contains((byte)0xc2));
+    }
+
     #region ClearRegion Tests
 
     [TestMethod]
@@ -171,4 +245,25 @@ public class Hex1bRenderContextTests
     }
 
     #endregion
+
+    private static TerminalCapabilities CreateSixelCapabilities(double width, double height)
+        => new()
+        {
+            SixelSupport = SixelPresentationSupport.Native,
+            SixelCellMetrics = new SixelCellMetrics(
+                width,
+                height,
+                SixelCellMetricsSource.Direct,
+                SixelCellMetricsReliability.Authoritative)
+        };
+
+    private sealed class CapturingRenderContext(TerminalCapabilities capabilities)
+        : Hex1bRenderContext(theme: null)
+    {
+        public override TerminalCapabilities Capabilities => capabilities;
+
+        internal List<string> Writes { get; } = [];
+
+        public override void Write(string text) => Writes.Add(text);
+    }
 }

--- a/tests/Hex1b.Tests/Hmp1/Hmp1SixelRecordingTests.cs
+++ b/tests/Hex1b.Tests/Hmp1/Hmp1SixelRecordingTests.cs
@@ -88,6 +88,45 @@ public class Hmp1SixelRecordingTests
     }
 
     [TestMethod]
+    public void RoundTrip_IdenticalPayloadAcrossProtocolMetrics_PreservesDistinctImageResources()
+    {
+        using var producer = CreateHeadlessTerminal();
+        var fixture = new SixelFixture(
+            "recording-metric-specific-images",
+            "The same raster captured against two different protocol cell grids.",
+            "q\"1;1;2;6#1;2;100;0;0#1!2~"u8.ToArray());
+        producer.SetSixelCellMetrics(new SixelCellMetrics(
+            1,
+            6,
+            SixelCellMetricsSource.Direct,
+            SixelCellMetricsReliability.Authoritative));
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b[1;1H" + Encoding.ASCII.GetString(fixture.StandardBytes)));
+
+        producer.SetSixelCellMetrics(new SixelCellMetrics(
+            1,
+            3,
+            SixelCellMetricsSource.Direct,
+            SixelCellMetricsReliability.Authoritative));
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b[4;1H" + Encoding.ASCII.GetString(fixture.StandardBytes)));
+
+        using var snapshot = producer.CreateSnapshot();
+        Assert.HasCount(2, snapshot.SixelImages);
+        Assert.HasCount(2, snapshot.SixelPlacements);
+        Assert.AreEqual((2, 1), snapshot.SixelPlacements[0].Image.GetCellSpan());
+        Assert.AreEqual((2, 2), snapshot.SixelPlacements[1].Image.GetCellSpan());
+
+        var recorded = Hmp1SixelRecording.Serialize(snapshot.SixelPlacements);
+        var decoded = Hmp1SixelRecording.Deserialize(recorded);
+
+        Assert.HasCount(2, decoded.Images);
+        Assert.HasCount(2, decoded.Placements);
+        Assert.AreNotEqual(decoded.Placements[0].ImageIndex, decoded.Placements[1].ImageIndex);
+        Assert.IsFalse(decoded.Images[0].ContentHash.SequenceEqual(decoded.Images[1].ContentHash));
+    }
+
+    [TestMethod]
     public void RoundTrip_WithDamagedCell_PreservesAnchorRelativeDamageOffsets()
     {
         using var producer = CreateHeadlessTerminal();

--- a/tests/Hex1b.Tests/Hmp1/Hmp1SixelRecordingTests.cs
+++ b/tests/Hex1b.Tests/Hmp1/Hmp1SixelRecordingTests.cs
@@ -2,6 +2,7 @@
 
 using System.Text;
 using Hex1b.Sixel;
+using Hex1b.Surfaces;
 using Hex1b.Tests.Sixel;
 using Hex1b.Tokens;
 
@@ -28,6 +29,11 @@ public class Hmp1SixelRecordingTests
             "recording-single-band",
             "One-band red probe for recording round-trip coverage.",
             "q#1;2;100;0;0#1!11~"u8.ToArray());
+        producer.SetSixelCellMetrics(new SixelCellMetrics(
+            9.4,
+            19.4,
+            SixelCellMetricsSource.Osc1337,
+            SixelCellMetricsReliability.Derived));
         producer.ApplyTokens(AnsiTokenizer.Tokenize(
             "\x1b[3;5H" + Encoding.ASCII.GetString(fixture.StandardBytes)));
 
@@ -44,6 +50,7 @@ public class Hmp1SixelRecordingTests
         Assert.IsFalse(image.IsGeometryOnly);
         Assert.AreEqual(placement.Image.WidthInCells, image.WidthInCells);
         Assert.AreEqual(placement.Image.HeightInCells, image.HeightInCells);
+        Assert.AreEqual(placement.Image.CellMetrics, image.CellMetrics);
         Assert.AreEqual(SixelRasterStatus.Rasterized, image.RasterStatus);
         CollectionAssert.AreEqual(placement.Image.ContentHash, image.ContentHash);
 
@@ -88,7 +95,7 @@ public class Hmp1SixelRecordingTests
     }
 
     [TestMethod]
-    public void RoundTrip_IdenticalPayloadAcrossProtocolMetrics_PreservesDistinctImageResources()
+    public void ReplayInto_IdenticalPayloadAcrossProtocolMetrics_RestoresSpansIdentityAndDamageBoundaries()
     {
         using var producer = CreateHeadlessTerminal();
         var fixture = new SixelFixture(
@@ -110,6 +117,7 @@ public class Hmp1SixelRecordingTests
             SixelCellMetricsReliability.Authoritative));
         producer.ApplyTokens(AnsiTokenizer.Tokenize(
             "\x1b[4;1H" + Encoding.ASCII.GetString(fixture.StandardBytes)));
+        producer.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[1;1HX\x1b[4;1HY"));
 
         using var snapshot = producer.CreateSnapshot();
         Assert.HasCount(2, snapshot.SixelImages);
@@ -124,6 +132,40 @@ public class Hmp1SixelRecordingTests
         Assert.HasCount(2, decoded.Placements);
         Assert.AreNotEqual(decoded.Placements[0].ImageIndex, decoded.Placements[1].ImageIndex);
         Assert.IsFalse(decoded.Images[0].ContentHash.SequenceEqual(decoded.Images[1].ContentHash));
+        Assert.AreEqual(snapshot.SixelPlacements[0].Image.CellMetrics, decoded.Images[0].CellMetrics);
+        Assert.AreEqual(snapshot.SixelPlacements[1].Image.CellMetrics, decoded.Images[1].CellMetrics);
+
+        using var viewer = CreateHeadlessTerminal();
+        var viewerMetrics = new SixelCellMetrics(
+            7,
+            11,
+            SixelCellMetricsSource.Derived,
+            SixelCellMetricsReliability.Estimated);
+        viewer.SetSixelCellMetrics(viewerMetrics);
+        decoded.ReplayInto(viewer);
+        Assert.AreEqual(viewerMetrics, viewer.SixelCellMetrics);
+
+        using var replayedSnapshot = viewer.CreateSnapshot();
+        Assert.HasCount(2, replayedSnapshot.SixelImages);
+        Assert.HasCount(2, replayedSnapshot.SixelPlacements);
+        var replayedFirst = replayedSnapshot.SixelPlacements[0];
+        var replayedSecond = replayedSnapshot.SixelPlacements[1];
+        Assert.AreEqual((2, 1), replayedFirst.Image.GetCellSpan());
+        Assert.AreEqual((2, 2), replayedSecond.Image.GetCellSpan());
+        Assert.AreEqual(decoded.Images[0].CellMetrics, replayedFirst.Image.CellMetrics);
+        Assert.AreEqual(decoded.Images[1].CellMetrics, replayedSecond.Image.CellMetrics);
+        Assert.IsFalse(SixelData.HashEquals(
+            replayedFirst.Image.ContentHash,
+            replayedSecond.Image.ContentHash));
+
+        var firstPixels = replayedFirst.GetVisiblePixels()!;
+        Assert.AreEqual(Rgba32.Transparent, firstPixels[0, 0]);
+        Assert.AreNotEqual(Rgba32.Transparent, firstPixels[1, 0]);
+
+        var secondPixels = replayedSecond.GetVisiblePixels()!;
+        Assert.AreEqual(Rgba32.Transparent, secondPixels[0, 2]);
+        Assert.AreNotEqual(Rgba32.Transparent, secondPixels[0, 3]);
+        Assert.AreNotEqual(Rgba32.Transparent, secondPixels[1, 0]);
     }
 
     [TestMethod]
@@ -171,7 +213,7 @@ public class Hmp1SixelRecordingTests
         Assert.AreEqual(placement.Image.Payload, image.Payload);
 
         using var viewer = CreateHeadlessTerminal();
-        viewer.ApplyTokens(AnsiTokenizer.Tokenize(decoded.BuildReplayEscapeSequence()));
+        decoded.ReplayInto(viewer);
         using var viewerSnapshot = viewer.CreateSnapshot();
         var replayed = TestSeq.Single(viewerSnapshot.SixelPlacements);
         Assert.IsTrue(replayed.IsGeometryOnly);
@@ -206,7 +248,7 @@ public class Hmp1SixelRecordingTests
     }
 
     [TestMethod]
-    public void BuildReplayEscapeSequence_FedToFreshTerminal_ReconstructsEquivalentGeometryAndPixels()
+    public void ReplayInto_FreshTerminal_ReconstructsEquivalentGeometryAndPixels()
     {
         using var producer = CreateHeadlessTerminal();
         var fixture = new SixelFixture(
@@ -219,13 +261,8 @@ public class Hmp1SixelRecordingTests
         using var producerSnapshot = producer.CreateSnapshot();
         var recorded = Hmp1SixelRecording.Serialize(producerSnapshot.SixelPlacements);
         var decoded = Hmp1SixelRecording.Deserialize(recorded);
-        var replaySequence = decoded.BuildReplayEscapeSequence();
-
         using var viewer = CreateHeadlessTerminal();
-        // Fed through the same tokenizer/apply path a live terminal uses for
-        // incoming output, so replay is verified against the same
-        // authoritative parser/raster invariants live processing uses.
-        viewer.ApplyTokens(AnsiTokenizer.Tokenize(replaySequence));
+        decoded.ReplayInto(viewer);
 
         using var viewerSnapshot = viewer.CreateSnapshot();
         var producerPlacement = TestSeq.Single(producerSnapshot.SixelPlacements);
@@ -237,6 +274,44 @@ public class Hmp1SixelRecordingTests
         Assert.AreEqual(producerPlacement.HeightInCells, viewerPlacement.HeightInCells);
 
         AssertPixelsEqual(producerPlacement.Image, viewerPlacement.Image);
+    }
+
+    [TestMethod]
+    public void ReplayInto_LargerTerminal_RestoresRecordedPaintedCrop()
+    {
+        using var producer = Hex1bTerminal.CreateBuilder()
+            .WithDimensions(1, 4)
+            .WithWorkload(new NullWorkloadAdapter())
+            .WithHeadless(new TerminalCapabilities { SupportsSixel = true, SupportsTrueColor = true })
+            .Build();
+        producer.SetSixelCellMetrics(new SixelCellMetrics(
+            10,
+            20,
+            SixelCellMetricsSource.Direct,
+            SixelCellMetricsReliability.Authoritative));
+        var pixels = new SixelPixelBuffer(20, 20);
+        for (var y = 0; y < pixels.Height; y++)
+        {
+            for (var x = 0; x < pixels.Width; x++)
+                pixels[x, y] = Rgba32.FromRgb(180, 60, 30);
+        }
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(SixelEncoder.Encode(pixels)));
+
+        using var producerSnapshot = producer.CreateSnapshot();
+        var original = TestSeq.Single(producerSnapshot.SixelPlacements);
+        Assert.AreEqual(2, original.WidthInCells);
+        Assert.AreEqual(1, original.PaintedColumnCount);
+
+        var decoded = Hmp1SixelRecording.Deserialize(
+            Hmp1SixelRecording.Serialize(producerSnapshot.SixelPlacements));
+        using var viewer = CreateHeadlessTerminal();
+        decoded.ReplayInto(viewer);
+
+        var replayed = TestSeq.Single(viewer.SixelPlacements);
+        Assert.AreEqual(original.WidthInCells, replayed.WidthInCells);
+        Assert.AreEqual(original.PaintedColumnOffset, replayed.PaintedColumnOffset);
+        Assert.AreEqual(original.PaintedColumnCount, replayed.PaintedColumnCount);
+        Assert.AreEqual(10, replayed.GetPaintedPixels()!.Width);
     }
 
     [TestMethod]
@@ -321,7 +396,7 @@ public class Hmp1SixelRecordingTests
         Assert.Contains("0;100;0", TestSeq.Single(alternateDecoded.Images).Payload);
 
         using var alternateViewer = CreateHeadlessTerminal();
-        alternateViewer.ApplyTokens(AnsiTokenizer.Tokenize(alternateDecoded.BuildReplayEscapeSequence()));
+        alternateDecoded.ReplayInto(alternateViewer);
         using var alternateViewerSnapshot = alternateViewer.CreateSnapshot();
         var alternateViewerPlacement = TestSeq.Single(alternateViewerSnapshot.SixelPlacements);
         Assert.AreEqual(alternatePlacement.Row, alternateViewerPlacement.Row);
@@ -343,7 +418,7 @@ public class Hmp1SixelRecordingTests
         Assert.Contains("100;0;0", TestSeq.Single(mainDecoded.Images).Payload);
 
         using var mainViewer = CreateHeadlessTerminal();
-        mainViewer.ApplyTokens(AnsiTokenizer.Tokenize(mainDecoded.BuildReplayEscapeSequence()));
+        mainDecoded.ReplayInto(mainViewer);
         using var mainViewerSnapshot = mainViewer.CreateSnapshot();
         AssertPixelsEqual(mainPlacement.Image, TestSeq.Single(mainViewerSnapshot.SixelPlacements).Image);
     }
@@ -397,6 +472,45 @@ public class Hmp1SixelRecordingTests
     }
 
     [TestMethod]
+    public void Deserialize_Version1Recording_PreservesLegacyTargetMetricReplay()
+    {
+        const string payload = "\x1bPq\"1;1;2;6#1;2;100;0;0#1!2~\x1b\\";
+        var payloadBytes = Encoding.ASCII.GetBytes(payload);
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true))
+        {
+            writer.Write("SXRC"u8.ToArray());
+            writer.Write(1); // legacy version
+            writer.Write(1); // placementCount
+            writer.Write(1); // imageCount
+            writer.Write(new byte[32]); // contentHash
+            writer.Write(false); // isGeometryOnly
+            writer.Write(2); // declaredPixelWidth
+            writer.Write(6); // declaredPixelHeight
+            writer.Write(2); // widthInCells
+            writer.Write(1); // heightInCells
+            writer.Write((byte)SixelRasterStatus.Rasterized);
+            writer.Write(payloadBytes.Length);
+            writer.Write(payloadBytes);
+            WritePlacement(writer, imageIndex: 0, widthInCells: 2, heightInCells: 1);
+        }
+
+        var decoded = Hmp1SixelRecording.Deserialize(stream.ToArray());
+        Assert.AreEqual(1, decoded.Version);
+        Assert.IsNull(TestSeq.Single(decoded.Images).CellMetrics);
+
+        using var viewer = CreateHeadlessTerminal();
+        viewer.SetSixelCellMetrics(new SixelCellMetrics(
+            1,
+            6,
+            SixelCellMetricsSource.Direct,
+            SixelCellMetricsReliability.Authoritative));
+        decoded.ReplayInto(viewer);
+
+        Assert.AreEqual((2, 1), TestSeq.Single(viewer.SixelPlacements).Image.GetCellSpan());
+    }
+
+    [TestMethod]
     public void Deserialize_WithPlacementReferencingMissingImageIndex_ThrowsMissingImageReference()
     {
         using var stream = new MemoryStream();
@@ -445,6 +559,7 @@ public class Hmp1SixelRecordingTests
             writer.Write(1); // declaredPixelHeight
             writer.Write(0); // widthInCells -- invalid: must be positive.
             writer.Write(1); // heightInCells
+            WriteMetrics(writer, SixelCellMetrics.Unknown);
             writer.Write((byte)SixelRasterStatus.Rasterized);
             writer.Write(0); // payloadLength
         }
@@ -471,6 +586,7 @@ public class Hmp1SixelRecordingTests
             writer.Write(1); // declaredPixelHeight
             writer.Write(1); // widthInCells
             writer.Write(1); // heightInCells
+            WriteMetrics(writer, SixelCellMetrics.Unknown);
             writer.Write((byte)SixelRasterStatus.Rasterized);
             writer.Write(int.MaxValue); // payloadLength -- declared far beyond the limit.
             // No payload bytes follow: the length check must fail before any
@@ -480,6 +596,33 @@ public class Hmp1SixelRecordingTests
         var ex = Assert.ThrowsExactly<Hmp1SixelRecordingException>(
             () => Hmp1SixelRecording.Deserialize(stream.ToArray()));
         Assert.AreEqual(Hmp1SixelRecordingFailureReason.ResourceLimitExceeded, ex.Reason);
+    }
+
+    [TestMethod]
+    public void Deserialize_WithUnrecognizedMetricMetadata_ThrowsMalformed()
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true))
+        {
+            writer.Write("SXRC"u8.ToArray());
+            writer.Write(Hmp1SixelRecording.CurrentVersion);
+            writer.Write(0); // placementCount
+            writer.Write(1); // imageCount
+            writer.Write(new byte[32]); // contentHash
+            writer.Write(false); // isGeometryOnly
+            writer.Write(1); // declaredPixelWidth
+            writer.Write(1); // declaredPixelHeight
+            writer.Write(1); // widthInCells
+            writer.Write(1); // heightInCells
+            writer.Write(BitConverter.DoubleToInt64Bits(10d));
+            writer.Write(BitConverter.DoubleToInt64Bits(20d));
+            writer.Write(byte.MaxValue); // invalid source
+            writer.Write((byte)SixelCellMetricsReliability.Authoritative);
+        }
+
+        var ex = Assert.ThrowsExactly<Hmp1SixelRecordingException>(
+            () => Hmp1SixelRecording.Deserialize(stream.ToArray()));
+        Assert.AreEqual(Hmp1SixelRecordingFailureReason.Malformed, ex.Reason);
     }
 
     [TestMethod]
@@ -507,7 +650,7 @@ public class Hmp1SixelRecordingTests
     }
 
     [TestMethod]
-    public async Task BuildReplayEscapeSequence_WhenDeduplicationExpandsBeyondLimit_ThrowsResourceLimitExceeded()
+    public async Task ReplayInto_WhenDeduplicationExpandsBeyondLimit_ThrowsResourceLimitExceeded()
     {
         var policy = SixelCompatibilityPolicy.Default with
         {
@@ -534,11 +677,40 @@ public class Hmp1SixelRecordingTests
         var recording = Hmp1SixelRecording.Serialize(placements);
         Assert.IsLessThan(1024 * 1024, recording.Length);
         var decoded = Hmp1SixelRecording.Deserialize(recording);
+        using var viewer = CreateHeadlessTerminal();
 
         var ex = Assert.ThrowsExactly<Hmp1SixelRecordingException>(
-            () => decoded.BuildReplayEscapeSequence());
+            () => decoded.ReplayInto(viewer));
 
         Assert.AreEqual(Hmp1SixelRecordingFailureReason.ResourceLimitExceeded, ex.Reason);
+    }
+
+    private static void WriteMetrics(BinaryWriter writer, SixelCellMetrics metrics)
+    {
+        writer.Write(BitConverter.DoubleToInt64Bits(metrics.Width));
+        writer.Write(BitConverter.DoubleToInt64Bits(metrics.Height));
+        writer.Write((byte)metrics.Source);
+        writer.Write((byte)metrics.Reliability);
+    }
+
+    private static void WritePlacement(
+        BinaryWriter writer,
+        int imageIndex,
+        int widthInCells,
+        int heightInCells)
+    {
+        writer.Write(imageIndex);
+        writer.Write(0); // row
+        writer.Write(0); // column
+        writer.Write(widthInCells);
+        writer.Write(heightInCells);
+        writer.Write(0); // paintedRowOffset
+        writer.Write(heightInCells); // paintedRowCount
+        writer.Write(0); // paintedColumnOffset
+        writer.Write(widthInCells); // paintedColumnCount
+        writer.Write(0L); // sequence
+        writer.Write(0L); // createdAtUnixMs
+        writer.Write(0); // damagedCellCount
     }
 
     private static void AssertPixelsEqual(SixelData expected, SixelData actual)

--- a/tests/Hex1b.Tests/Sixel/SixelGrammarParserTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelGrammarParserTests.cs
@@ -226,14 +226,27 @@ public class SixelGrammarParserTests
     public void TrackedSixel_CellSpanUsesLogicalCanvasBeyondDeclaredHint()
     {
         var store = new TrackedObjectStore();
+        const string payload = "\x1bP7q\"1;1;1;1~~-~~\x1b\\";
         var tracked = store.GetOrCreateSixel(
-            "\x1bP7q\"1;1;1;1~~-~~\x1b\\",
+            payload,
             widthInCells: 1,
-            heightInCells: 1);
+            heightInCells: 1,
+            parseResult: SixelParser.ParsePayload(payload),
+            cellMetrics: new SixelCellMetrics(
+                1,
+                1,
+                SixelCellMetricsSource.Direct,
+                SixelCellMetricsReliability.Authoritative));
 
         Assert.AreEqual(
             (2, 12),
-            tracked.Data.GetCellSpan(new Hex1b.Surfaces.CellMetrics(1, 1)));
+            tracked.Data.GetCellSpan());
+
+#pragma warning disable CS0618 // Verifies source-compatible overloads ignore legacy text metrics.
+        Assert.AreEqual(
+            (2, 12),
+            tracked.Data.GetCellSpan(new Hex1b.Surfaces.CellMetrics(8, 16)));
+#pragma warning restore CS0618
 
         tracked.Release();
     }

--- a/tests/Hex1b.Tests/Sixel/SixelHardeningFuzzTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelHardeningFuzzTests.cs
@@ -94,7 +94,18 @@ public class SixelHardeningFuzzTests
                     {
                         var recording = Hmp1SixelRecording.Serialize(snapshot.SixelPlacements);
                         var decoded = Hmp1SixelRecording.Deserialize(recording);
-                        _ = decoded.BuildReplayEscapeSequence();
+                        using var viewer = new Hex1bTerminal(new Hex1bTerminalOptions
+                        {
+                            Width = terminal.Width,
+                            Height = terminal.Height,
+                            WorkloadAdapter = new NullWorkloadAdapter(),
+                            PresentationAdapter = new HeadlessPresentationAdapter(
+                                terminal.Width,
+                                terminal.Height,
+                                new TerminalCapabilities { SupportsSixel = true }),
+                            SixelPolicy = policy,
+                        });
+                        decoded.ReplayInto(viewer);
                     }
                     break;
             }

--- a/tests/Hex1b.Tests/Sixel/SixelScrollHistoryReflowTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelScrollHistoryReflowTests.cs
@@ -547,13 +547,16 @@ public class SixelScrollHistoryReflowTests
             snapshot => snapshot.ContainsSixelData(),
             "placement created under the original cell metrics",
             TestContext.Current.CancellationToken);
-        Assert.AreEqual(2, TestSeq.Single(terminal.Terminal.SixelPlacements).HeightInCells);
+        var firstPlacement = TestSeq.Single(terminal.Terminal.SixelPlacements);
+        Assert.AreEqual(2, firstPlacement.HeightInCells);
+        Assert.AreEqual((1, 2), firstPlacement.Image.GetCellSpan());
 
-        terminal.Terminal.SetSixelCellMetrics(new SixelCellMetrics(
+        var changedMetrics = new SixelCellMetrics(
             1,
             3,
             SixelCellMetricsSource.Direct,
-            SixelCellMetricsReliability.Authoritative));
+            SixelCellMetricsReliability.Authoritative);
+        terminal.Terminal.SetSixelCellMetrics(changedMetrics);
 
         await terminal.FeedAsync(
             Encoding.ASCII.GetBytes("\x1b[4;1H").Concat(TwoRowBar.StandardBytes).ToArray(),
@@ -566,6 +569,31 @@ public class SixelScrollHistoryReflowTests
         var placements = terminal.Terminal.SixelPlacements;
         Assert.AreEqual(2, placements[0].HeightInCells, "the metric change does not retroactively affect an existing placement");
         Assert.AreEqual(4, placements[1].HeightInCells, "the same 12px payload now spans four 3px-tall cells");
+        Assert.AreNotSame(placements[0].Image, placements[1].Image);
+        Assert.IsFalse(placements[0].Image.ContentHash.SequenceEqual(placements[1].Image.ContentHash));
+        Assert.AreEqual(changedMetrics, placements[1].Image.CellMetrics);
+        Assert.AreEqual((1, 4), placements[1].Image.GetCellSpan());
+        Assert.AreEqual(2, terminal.Terminal.TrackedSixelCount);
+
+        using (var snapshot = terminal.Terminal.CreateSnapshot())
+        {
+            Assert.HasCount(2, snapshot.SixelImages);
+        }
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[4;1HX"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.SixelPlacements[1].IsCellDamaged(3, 0),
+            "first cell of the second placement damaged",
+            TestContext.Current.CancellationToken);
+
+        var damagedPixels = placements[1].GetVisiblePixels();
+        Assert.IsNotNull(damagedPixels);
+        Assert.AreEqual(0, damagedPixels[0, 0].A);
+        Assert.AreEqual(0, damagedPixels[0, 2].A);
+        Assert.IsGreaterThan(0, damagedPixels[0, 3].A,
+            "damage must stop at the changed 3px protocol-cell boundary");
     }
 
     [TestMethod]

--- a/tests/Hex1b.Tests/SixelEncoderTests.cs
+++ b/tests/Hex1b.Tests/SixelEncoderTests.cs
@@ -1,5 +1,6 @@
 using Hex1b;
 using Hex1b.Automation;
+using Hex1b.Sixel;
 using Hex1b.Surfaces;
 using Hex1b.Theming;
 using Hex1b.Tokens;
@@ -1637,11 +1638,19 @@ public class SixelVisibilityTests
                 buffer[x, y] = Rgba32.FromRgb((byte)(x % 256), (byte)(y % 256), 128);
         
         var payload = SixelEncoder.Encode(buffer);
+        var parseResult = SixelParser.ParsePayload(payload);
         
         // Use the store to create a tracked object
-        return _store.GetOrCreateSixel(payload, 
+        return _store.GetOrCreateSixel(
+            payload,
             (pixelWidth + 9) / 10,   // Approximate cell width
-            (pixelHeight + 19) / 20); // Approximate cell height
+            (pixelHeight + 19) / 20, // Approximate cell height
+            parseResult,
+            cellMetrics: new SixelCellMetrics(
+                10,
+                20,
+                SixelCellMetricsSource.Direct,
+                SixelCellMetricsReliability.Authoritative));
     }
 
     #endregion

--- a/tests/Hex1b.Tests/SixelEncoderTests.cs
+++ b/tests/Hex1b.Tests/SixelEncoderTests.cs
@@ -1031,6 +1031,71 @@ public class SixelVisibilityTests
         Assert.AreEqual((1, 1), span);
     }
 
+    [TestMethod]
+    public void TrackedStore_IdenticalPixelsWithDifferentProtocolMetrics_KeepDistinctFragmentGeometry()
+    {
+        var buffer = new SixelPixelBuffer(20, 18);
+        for (var y = 0; y < buffer.Height; y++)
+        {
+            for (var x = 0; x < buffer.Width; x++)
+                buffer[x, y] = Rgba32.FromRgb(255, 0, 0);
+        }
+        var payload = SixelEncoder.Encode(buffer);
+        var parseResult = SixelParser.ParsePayload(payload);
+        var tenByEighteen = new SixelCellMetrics(
+            10,
+            18,
+            SixelCellMetricsSource.Direct,
+            SixelCellMetricsReliability.Authoritative);
+        var eightByNine = new SixelCellMetrics(
+            8,
+            9,
+            SixelCellMetricsSource.Direct,
+            SixelCellMetricsReliability.Authoritative);
+
+        var first = _store.GetOrCreateSixel(
+            payload,
+            2,
+            1,
+            parseResult,
+            cellMetrics: tenByEighteen);
+        var second = _store.GetOrCreateSixel(
+            payload,
+            3,
+            2,
+            parseResult,
+            cellMetrics: eightByNine);
+        var repeatedSecond = _store.GetOrCreateSixel(
+            payload,
+            3,
+            2,
+            parseResult,
+            cellMetrics: eightByNine);
+        var differentSpan = _store.GetOrCreateSixel(
+            payload,
+            2,
+            2,
+            parseResult,
+            cellMetrics: eightByNine);
+
+        Assert.AreNotSame(first, second);
+        Assert.AreSame(second, repeatedSecond);
+        Assert.AreNotSame(second, differentSpan);
+        Assert.IsFalse(first.Data.ContentHash.SequenceEqual(second.Data.ContentHash));
+        Assert.IsFalse(second.Data.ContentHash.SequenceEqual(differentSpan.Data.ContentHash));
+        Assert.AreEqual((2, 1), first.Data.GetCellSpan());
+        Assert.AreEqual((3, 2), second.Data.GetCellSpan());
+        Assert.AreEqual(3, _store.SixelCount);
+
+        var visibility = new SixelVisibility(second, 0, 0, 0);
+        visibility.ApplyOcclusion(new Hex1b.Layout.Rect(0, 0, 1, 2));
+        var fragment = TestSeq.Single(visibility.GenerateFragments());
+
+        Assert.AreEqual(new PixelRect(8, 0, 12, 18), fragment.PixelRegion);
+        Assert.AreEqual((1, 0), fragment.CellPosition);
+        Assert.AreEqual((2, 2), fragment.GetCellSpan());
+    }
+
     #endregion
 
     #region T5: Computed Cell Sixel Access Tests

--- a/tests/Hex1b.Tests/SixelEncoderTests.cs
+++ b/tests/Hex1b.Tests/SixelEncoderTests.cs
@@ -806,11 +806,9 @@ public class SixelVisibilityTests
     {
         var sixelRef = CreateTestSixel(100, 60);
         var visibility = new SixelVisibility(sixelRef, 0, 0, 0);
-        var metrics = new CellMetrics(10, 20);
-        
         // Occlude center 2x1 cells (cells 4-5, row 1)
         var occlusion = new Hex1b.Layout.Rect(4, 1, 2, 1);
-        visibility.ApplyOcclusion(occlusion, metrics);
+        visibility.ApplyOcclusion(occlusion);
         
         Assert.IsFalse(visibility.IsFullyVisible);
         Assert.IsFalse(visibility.IsFullyOccluded);
@@ -823,11 +821,9 @@ public class SixelVisibilityTests
     {
         var sixelRef = CreateTestSixel(100, 60);
         var visibility = new SixelVisibility(sixelRef, 0, 0, 0);
-        var metrics = new CellMetrics(10, 20);
-        
         // Occlude entire sixel (10x3 cells)
         var occlusion = new Hex1b.Layout.Rect(0, 0, 10, 3);
-        visibility.ApplyOcclusion(occlusion, metrics);
+        visibility.ApplyOcclusion(occlusion);
         
         Assert.IsTrue(visibility.IsFullyOccluded);
         Assert.IsEmpty(visibility.VisibleRegions);
@@ -838,11 +834,9 @@ public class SixelVisibilityTests
     {
         var sixelRef = CreateTestSixel(100, 60);
         var visibility = new SixelVisibility(sixelRef, 0, 0, 0);
-        var metrics = new CellMetrics(10, 20);
-        
         // Occlude area outside sixel
         var occlusion = new Hex1b.Layout.Rect(20, 20, 5, 5);
-        visibility.ApplyOcclusion(occlusion, metrics);
+        visibility.ApplyOcclusion(occlusion);
         
         Assert.IsTrue(visibility.IsFullyVisible);
         TestSeq.Single(visibility.VisibleRegions);
@@ -853,9 +847,7 @@ public class SixelVisibilityTests
     {
         var sixelRef = CreateTestSixel(100, 60);
         var visibility = new SixelVisibility(sixelRef, 5, 3, 0);
-        var metrics = new CellMetrics(10, 20);
-        
-        var fragments = visibility.GenerateFragments(metrics);
+        var fragments = visibility.GenerateFragments();
         
         TestSeq.Single(fragments);
         Assert.AreEqual((5, 3), fragments[0].CellPosition);
@@ -867,13 +859,11 @@ public class SixelVisibilityTests
     {
         var sixelRef = CreateTestSixel(100, 60);
         var visibility = new SixelVisibility(sixelRef, 0, 0, 0);
-        var metrics = new CellMetrics(10, 20);
-        
         // Occlude center
         var occlusion = new Hex1b.Layout.Rect(4, 1, 2, 1);
-        visibility.ApplyOcclusion(occlusion, metrics);
+        visibility.ApplyOcclusion(occlusion);
         
-        var fragments = visibility.GenerateFragments(metrics);
+        var fragments = visibility.GenerateFragments();
         
         Assert.IsTrue(fragments.Count >= 2);
         TestSeq.All(fragments, f => Assert.IsFalse(f.IsComplete));
@@ -1013,16 +1003,32 @@ public class SixelVisibilityTests
     }
 
     [TestMethod]
-    public void SixelFragment_GetCellSpan_CalculatesCorrectly()
+    public void SixelFragment_GetCellSpan_UsesCapturedProtocolMetrics()
     {
-        var sixelRef = CreateTestSixel(100, 60);
-        var fragment = new SixelFragment(sixelRef.Data, 0, 0, new PixelRect(0, 0, 55, 35));
-        var metrics = new CellMetrics(10, 20);
+        var sixelRef = CreateTestSixel(20, 20);
+        var fragment = new SixelFragment(sixelRef.Data, 0, 0, new PixelRect(0, 0, 20, 20));
         
-        var (width, height) = fragment.GetCellSpan(metrics);
-        
-        Assert.AreEqual(6, width);  // ceil(55/10)
-        Assert.AreEqual(2, height); // ceil(35/20)
+        var span = fragment.GetCellSpan();
+
+        Assert.AreEqual((2, 1), span);
+    }
+
+    [TestMethod]
+    public void PublicFragmentationApis_MismatchedLegacyMetrics_UseCapturedProtocolMetrics()
+    {
+        var sixelRef = CreateTestSixel(20, 20);
+        var visibility = new SixelVisibility(sixelRef, 0, 0, 0);
+        var mismatchedTextMetrics = new CellMetrics(8, 16);
+
+#pragma warning disable CS0618 // Verifies source-compatible overloads ignore legacy text metrics.
+        visibility.ApplyOcclusion(new Hex1b.Layout.Rect(0, 0, 1, 1), mismatchedTextMetrics);
+        var fragment = TestSeq.Single(visibility.GenerateFragments(mismatchedTextMetrics));
+        var span = fragment.GetCellSpan(mismatchedTextMetrics);
+#pragma warning restore CS0618
+
+        Assert.AreEqual(new PixelRect(10, 0, 10, 20), fragment.PixelRegion);
+        Assert.AreEqual((1, 0), fragment.CellPosition);
+        Assert.AreEqual((1, 1), span);
     }
 
     #endregion

--- a/tests/Hex1b.Tests/SixelNodeTests.cs
+++ b/tests/Hex1b.Tests/SixelNodeTests.cs
@@ -41,6 +41,22 @@ public class SixelNodeTests
             Supports256Colors = true
         });
 
+    private static SixelPixelBuffer CreatePixelBuffer(byte[] rgba, int width, int height)
+    {
+        var pixels = new Rgba32[width * height];
+        for (var i = 0; i < pixels.Length; i++)
+        {
+            var offset = i * 4;
+            pixels[i] = new Rgba32(
+                rgba[offset],
+                rgba[offset + 1],
+                rgba[offset + 2],
+                rgba[offset + 3]);
+        }
+
+        return new SixelPixelBuffer(width, height, pixels);
+    }
+
     [TestMethod]
     public void Measure_WithRequestedDimensions_ReturnsRequestedSize()
     {
@@ -263,7 +279,7 @@ public class SixelNodeTests
         using var workload = CreateSixelEnabledWorkload();
         using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
         var context = new Hex1bRenderContext(workload);
-        node.Arrange(new Rect(0, 0, 40, 20));
+        node.Arrange(new Rect(0, 0, 1, 1));
         node.Render(context);
         await new Hex1bTerminalInputSequenceBuilder()
             .Wait(TimeSpan.FromMilliseconds(100))
@@ -292,7 +308,7 @@ public class SixelNodeTests
         using var workload = CreateSixelEnabledWorkload();
         using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
         var context = new Hex1bRenderContext(workload);
-        node.Arrange(new Rect(0, 0, 40, 20));
+        node.Arrange(new Rect(0, 0, 1, 1));
         node.Render(context);
         await new Hex1bTerminalInputSequenceBuilder()
             .Wait(TimeSpan.FromMilliseconds(100))
@@ -323,14 +339,12 @@ public class SixelNodeTests
         const int height = 30; // 30 pixels tall
         
         var pixels = TestPatternGenerator.GenerateSmpteColorBars(width, height);
-        var sixelPayload = TestPatternGenerator.ConvertToSixel(pixels, width, height);
-        
         var node = new SixelNode
         {
-            ImageData = sixelPayload,
             RequestedWidth = 10,
             RequestedHeight = 5
         };
+        node.SetPixels(CreatePixelBuffer(pixels, width, height));
         
         using var workload = CreateSixelEnabledWorkload();
         using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
@@ -385,14 +399,12 @@ public class SixelNodeTests
         const int height = 60; // 3 rows * 20 pixels
         
         var pixels = TestPatternGenerator.GenerateColorGrid(width, height);
-        var sixelPayload = TestPatternGenerator.ConvertToSixel(pixels, width, height);
-        
         var node = new SixelNode
         {
-            ImageData = sixelPayload,
             RequestedWidth = 10,
             RequestedHeight = 5
         };
+        node.SetPixels(CreatePixelBuffer(pixels, width, height));
         
         using var workload = CreateSixelEnabledWorkload();
         using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
@@ -442,14 +454,12 @@ public class SixelNodeTests
         const int height = 24;
         
         var pixels = TestPatternGenerator.GenerateGrayscaleGradient(width, height);
-        var sixelPayload = TestPatternGenerator.ConvertToSixel(pixels, width, height);
-        
         var node = new SixelNode
         {
-            ImageData = sixelPayload,
             RequestedWidth = 10,
             RequestedHeight = 3
         };
+        node.SetPixels(CreatePixelBuffer(pixels, width, height));
         
         using var workload = CreateSixelEnabledWorkload();
         using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
@@ -499,14 +509,12 @@ public class SixelNodeTests
         const int height = 36; // 3 bands of 12 pixels each
         
         var pixels = TestPatternGenerator.GenerateRgbGradients(width, height);
-        var sixelPayload = TestPatternGenerator.ConvertToSixel(pixels, width, height);
-        
         var node = new SixelNode
         {
-            ImageData = sixelPayload,
             RequestedWidth = 10,
             RequestedHeight = 4
         };
+        node.SetPixels(CreatePixelBuffer(pixels, width, height));
         
         using var workload = CreateSixelEnabledWorkload();
         using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
@@ -556,14 +564,12 @@ public class SixelNodeTests
         const int squareSize = 8;
         
         var pixels = TestPatternGenerator.GenerateCheckerboard(width, height, squareSize);
-        var sixelPayload = TestPatternGenerator.ConvertToSixel(pixels, width, height);
-        
         var node = new SixelNode
         {
-            ImageData = sixelPayload,
             RequestedWidth = 10,
             RequestedHeight = 5
         };
+        node.SetPixels(CreatePixelBuffer(pixels, width, height));
         
         using var workload = CreateSixelEnabledWorkload();
         using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();
@@ -613,14 +619,12 @@ public class SixelNodeTests
         const int height = 60;
         
         var pixels = TestPatternGenerator.GenerateRegistrationMarks(width, height);
-        var sixelPayload = TestPatternGenerator.ConvertToSixel(pixels, width, height);
-        
         var node = new SixelNode
         {
-            ImageData = sixelPayload,
             RequestedWidth = 12,
             RequestedHeight = 6
         };
+        node.SetPixels(CreatePixelBuffer(pixels, width, height));
         
         using var workload = CreateSixelEnabledWorkload();
         using var terminal = Hex1bTerminal.CreateBuilder().WithWorkload(workload).WithHeadless().WithDimensions(80, 24).Build();

--- a/tests/Hex1b.Tests/SixelNodeTests.cs
+++ b/tests/Hex1b.Tests/SixelNodeTests.cs
@@ -4,6 +4,8 @@ using Hex1b;
 using Hex1b.Input;
 using Hex1b.Layout;
 using Hex1b.Nodes;
+using Hex1b.Sixel;
+using Hex1b.Surfaces;
 using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
@@ -40,13 +42,15 @@ public class SixelNodeTests
         });
 
     [TestMethod]
-    public async Task Measure_WithRequestedDimensions_ReturnsRequestedSize()
+    public void Measure_WithRequestedDimensions_ReturnsRequestedSize()
     {
         var node = new SixelNode
         {
             RequestedWidth = 50,
             RequestedHeight = 25
         };
+        node.SetPixels(new SixelPixelBuffer(80, 40));
+        node.SetTerminalCapabilities(CreateSixelEnabledWorkload().Capabilities);
 
         var size = node.Measure(Constraints.Unbounded);
 
@@ -55,30 +59,40 @@ public class SixelNodeTests
     }
 
     [TestMethod]
-    public async Task Measure_WithoutRequestedDimensions_ReturnsDefaultSize()
+    public void Measure_WithoutRequestedDimensions_UsesSixelCellMetrics()
     {
         var node = new SixelNode();
+        node.SetPixels(new SixelPixelBuffer(81, 41));
+        node.SetTerminalCapabilities(new TerminalCapabilities
+        {
+            SixelSupport = SixelPresentationSupport.Native,
+            SixelCellMetrics = new SixelCellMetrics(
+                10,
+                20,
+                SixelCellMetricsSource.Direct,
+                SixelCellMetricsReliability.Authoritative)
+        });
 
         var size = node.Measure(Constraints.Unbounded);
 
-        // Default size is 40x20
-        Assert.AreEqual(40, size.Width);
-        Assert.AreEqual(20, size.Height);
+        Assert.AreEqual(9, size.Width);
+        Assert.AreEqual(3, size.Height);
     }
 
     [TestMethod]
-    public async Task Measure_WithFallback_ReturnsFallbackSize()
+    public void Measure_WithUnknownSupport_ReturnsFallbackSize()
     {
         var fallbackNode = new TextBlockNode { Text = "Fallback text" };
         var node = new SixelNode
         {
             Fallback = fallbackNode
         };
+        node.SetPixels(new SixelPixelBuffer(400, 400));
 
         var size = node.Measure(Constraints.Unbounded);
 
-        // Should return the larger of sixel or fallback size
-        Assert.IsTrue(size.Width > 0);
+        Assert.AreEqual("Fallback text".Length, size.Width);
+        Assert.AreEqual(1, size.Height);
     }
 
     [TestMethod]
@@ -163,9 +177,53 @@ public class SixelNodeTests
         
         var focusables = node.GetFocusableNodes().ToList();
         
-        // Fallback focusables are always returned since we don't know at this point
-        // whether sixel will be rendered or not
         Assert.Contains(buttonNode, focusables);
+    }
+
+    [TestMethod]
+    public void GetFocusableNodes_WithNativeSupport_ExcludesFallbackFocusables()
+    {
+        var buttonNode = new ButtonNode { Label = "Test" };
+        var node = new SixelNode { Fallback = buttonNode };
+        node.SetTerminalCapabilities(new TerminalCapabilities
+        {
+            SixelSupport = SixelPresentationSupport.Native
+        });
+
+        Assert.IsEmpty(node.GetFocusableNodes());
+    }
+
+    [TestMethod]
+    public void IsSixelSupported_TypedSupportTakesPrecedenceOverLegacyFlag()
+    {
+        Assert.IsFalse(SixelNode.IsSixelSupported(new TerminalCapabilities
+        {
+            SupportsSixel = true,
+            SixelSupport = SixelPresentationSupport.None
+        }));
+        Assert.IsTrue(SixelNode.IsSixelSupported(new TerminalCapabilities
+        {
+            SupportsSixel = false,
+            SixelSupport = SixelPresentationSupport.Headless
+        }));
+        Assert.IsTrue(SixelNode.IsSixelSupported(new TerminalCapabilities
+        {
+            SupportsSixel = true,
+            SixelSupport = SixelPresentationSupport.Unknown
+        }));
+    }
+
+    [TestMethod]
+    public void SixelWidget_PreEncodedData_ValidatesAndFramesOnce()
+    {
+        var body = "#0;2;100;0;0#0~~~~~~";
+        var fromBody = new SixelWidget(body, new TextBlockWidget("fallback"));
+        var framed = new SixelWidget($"\x1bPq{body}\x1b\\", new TextBlockWidget("fallback"));
+
+        Assert.AreEqual($"\x1bPq{body}\x1b\\", fromBody.ImageData);
+        Assert.AreEqual(fromBody.ImageData, framed.ImageData);
+        Assert.Throws<ArgumentException>(() =>
+            new SixelWidget("\x1bPqmissing-terminator", new TextBlockWidget("fallback")));
     }
 
     [TestMethod]

--- a/tests/Hex1b.Tests/SixelScalingIntegrationTests.cs
+++ b/tests/Hex1b.Tests/SixelScalingIntegrationTests.cs
@@ -2,6 +2,8 @@
 
 using System.Text;
 using Hex1b.Input;
+using Hex1b.Sixel;
+using Hex1b.Surfaces;
 using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
@@ -26,6 +28,12 @@ public class SixelScalingIntegrationTests
             SupportsAlternateScreen = true,
             SupportsBracketedPaste = true,
             SupportsSixel = true,
+            SixelSupport = SixelPresentationSupport.Headless,
+            SixelCellMetrics = new SixelCellMetrics(
+                cellPixelWidth,
+                cellPixelHeight,
+                SixelCellMetricsSource.Direct,
+                SixelCellMetricsReliability.Authoritative),
             CellPixelWidth = cellPixelWidth,
             CellPixelHeight = cellPixelHeight
         };
@@ -40,7 +48,7 @@ public class SixelScalingIntegrationTests
         { 12, 24, "large" }     // Large font
     };
 
-    [TestMethod, Ignore("Widget/emitter Surface integration is outside terminal-side issue #457.")]
+    [TestMethod]
     [DynamicData(nameof(CellDimensions))]
     public async Task SmpteColorBars_RendersCorrectlyAtScale(int cellWidth, int cellHeight, string scaleName)
     {
@@ -48,7 +56,7 @@ public class SixelScalingIntegrationTests
         const int imageWidth = 70;
         const int imageHeight = 30;
         var pixels = TestPatternGenerator.GenerateSmpteColorBars(imageWidth, imageHeight);
-        var sixelPayload = TestPatternGenerator.ConvertToSixel(pixels, imageWidth, imageHeight);
+        var pixelBuffer = CreatePixelBuffer(pixels, imageWidth, imageHeight);
         
         // Calculate expected cell dimensions for the image
         var expectedCellsWide = (imageWidth + cellWidth - 1) / cellWidth;
@@ -84,10 +92,8 @@ public class SixelScalingIntegrationTests
                         ),
                         // The sixel image with fallback
                         new SixelWidget(
-                            sixelPayload,
-                            new TextBlockWidget($"[{expectedCellsWide}x{expectedCellsTall}]"),
-                            expectedCellsWide,
-                            expectedCellsTall)
+                            pixelBuffer,
+                            new TextBlockWidget($"[{expectedCellsWide}x{expectedCellsTall}]"))
                     ])
                 ])
             ),
@@ -117,7 +123,7 @@ public class SixelScalingIntegrationTests
         TestCaptureHelper.AttachSvg($"sixel-smpte-{scaleName}-reference.svg", refSvg);
     }
 
-    [TestMethod, Ignore("Widget/emitter Surface integration is outside terminal-side issue #457.")]
+    [TestMethod]
     [DynamicData(nameof(CellDimensions))]
     public async Task Checkerboard_RendersCorrectlyAtScale(int cellWidth, int cellHeight, string scaleName)
     {
@@ -126,7 +132,7 @@ public class SixelScalingIntegrationTests
         const int imageHeight = 48;
         const int squareSize = 8;
         var pixels = TestPatternGenerator.GenerateCheckerboard(imageWidth, imageHeight, squareSize);
-        var sixelPayload = TestPatternGenerator.ConvertToSixel(pixels, imageWidth, imageHeight);
+        var pixelBuffer = CreatePixelBuffer(pixels, imageWidth, imageHeight);
         
         // Calculate expected cell dimensions
         var expectedCellsWide = (imageWidth + cellWidth - 1) / cellWidth;
@@ -157,10 +163,8 @@ public class SixelScalingIntegrationTests
                                 .ToArray<Hex1bWidget>()
                         ),
                         new SixelWidget(
-                            sixelPayload,
-                            new TextBlockWidget($"[{expectedCellsWide}x{expectedCellsTall}]"),
-                            expectedCellsWide,
-                            expectedCellsTall)
+                            pixelBuffer,
+                            new TextBlockWidget($"[{expectedCellsWide}x{expectedCellsTall}]"))
                     ])
                 ])
             ),
@@ -198,6 +202,22 @@ public class SixelScalingIntegrationTests
             sb.Append((col % 10).ToString());
         }
         return sb.ToString();
+    }
+
+    private static SixelPixelBuffer CreatePixelBuffer(byte[] rgba, int width, int height)
+    {
+        var pixels = new Rgba32[width * height];
+        for (var i = 0; i < pixels.Length; i++)
+        {
+            var offset = i * 4;
+            pixels[i] = new Rgba32(
+                rgba[offset],
+                rgba[offset + 1],
+                rgba[offset + 2],
+                rgba[offset + 3]);
+        }
+
+        return new SixelPixelBuffer(width, height, pixels);
     }
 
     /// <summary>

--- a/tests/Hex1b.Tests/SixelSurfaceComparerTests.cs
+++ b/tests/Hex1b.Tests/SixelSurfaceComparerTests.cs
@@ -427,6 +427,101 @@ public class SixelSurfaceComparerTests
     }
 
     [TestMethod]
+    public void TrackedStore_SamePayloadUnderDifferentMetrics_PreservesEachFragmentGeometry()
+    {
+        var store = new TrackedObjectStore();
+        var pixels = CreateSolidPixels(18, 18, Rgba32.FromRgb(200, 80, 40));
+        var payload = SixelEncoder.Encode(pixels);
+        var parseResult = SixelParser.ParsePayload(payload);
+        var integerMetrics = new SixelCellMetrics(
+            10,
+            20,
+            SixelCellMetricsSource.Direct,
+            SixelCellMetricsReliability.Authoritative);
+        var fractionalMetrics = new SixelCellMetrics(
+            9.4,
+            19.4,
+            SixelCellMetricsSource.Direct,
+            SixelCellMetricsReliability.Authoritative);
+
+        var integer = store.GetOrCreateSixel(payload, 2, 1, parseResult, cellMetrics: integerMetrics);
+        var duplicate = store.GetOrCreateSixel(payload, 2, 1, parseResult, cellMetrics: integerMetrics);
+        var fractional = store.GetOrCreateSixel(payload, 2, 1, parseResult, cellMetrics: fractionalMetrics);
+
+        try
+        {
+            Assert.AreSame(integer, duplicate);
+            Assert.AreNotSame(integer, fractional);
+            Assert.AreEqual(2, store.SixelCount);
+            Assert.IsFalse(SixelData.HashEquals(integer.Data.ContentHash, fractional.Data.ContentHash));
+
+            var integerVisibility = new SixelVisibility(integer, 0, 0, 0);
+            integerVisibility.ApplyOcclusion(new Rect(0, 0, 1, 1));
+            var integerFragment = TestSeq.Single(integerVisibility.GenerateFragments());
+
+            var fractionalVisibility = new SixelVisibility(fractional, 0, 0, 0);
+            fractionalVisibility.ApplyOcclusion(new Rect(0, 0, 1, 1));
+            var fractionalFragment = TestSeq.Single(fractionalVisibility.GenerateFragments());
+
+            Assert.AreEqual((1, 0), integerFragment.CellPosition);
+            Assert.AreEqual((1, 0), fractionalFragment.CellPosition);
+            Assert.AreEqual(new PixelRect(10, 0, 8, 18), integerFragment.PixelRegion);
+            Assert.AreEqual(new PixelRect(9, 0, 9, 18), fractionalFragment.PixelRegion);
+        }
+        finally
+        {
+            integer.Release();
+            duplicate.Release();
+            fractional.Release();
+        }
+
+        Assert.AreEqual(0, store.SixelCount);
+    }
+
+    [TestMethod]
+    public void Compare_SamePayloadAndSpanWithDifferentMetrics_IsDifferent()
+    {
+        var store = new TrackedObjectStore();
+        var pixels = CreateSolidPixels(18, 18, Rgba32.FromRgb(80, 160, 240));
+        var payload = SixelEncoder.Encode(pixels);
+        var parseResult = SixelParser.ParsePayload(payload);
+        var previousSixel = store.GetOrCreateSixel(
+            payload,
+            2,
+            1,
+            parseResult,
+            cellMetrics: new SixelCellMetrics(
+                10,
+                20,
+                SixelCellMetricsSource.Direct,
+                SixelCellMetricsReliability.Authoritative));
+        var currentSixel = store.GetOrCreateSixel(
+            payload,
+            2,
+            1,
+            parseResult,
+            cellMetrics: new SixelCellMetrics(
+                9.4,
+                19.4,
+                SixelCellMetricsSource.Direct,
+                SixelCellMetricsReliability.Authoritative));
+        var previous = new Surface(4, 2, CellMetrics.Default);
+        var current = new Surface(4, 2, CellMetrics.Default);
+        previous[0, 0] = new SurfaceCell(" ", null, null, Sixel: previousSixel);
+        current[0, 0] = new SurfaceCell(" ", null, null, Sixel: currentSixel);
+
+        try
+        {
+            Assert.IsFalse(SurfaceComparer.Compare(previous, current).IsEmpty);
+        }
+        finally
+        {
+            previous.ClearAndReleaseTrackedObjects();
+            current.ClearAndReleaseTrackedObjects();
+        }
+    }
+
+    [TestMethod]
     public void SurfaceLayerContext_CreateSixel_CapturesProtocolMetrics()
     {
         var store = new TrackedObjectStore();

--- a/tests/Hex1b.Tests/SixelSurfaceComparerTests.cs
+++ b/tests/Hex1b.Tests/SixelSurfaceComparerTests.cs
@@ -1,0 +1,216 @@
+#pragma warning disable HEX1B_SIXEL // Testing experimental Sixel API
+
+using Hex1b.Surfaces;
+using Hex1b.Theming;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests;
+
+[TestClass]
+public class SixelSurfaceComparerTests
+{
+    [TestMethod]
+    public void ToTokens_ReplacedSixel_ClearsOldPixelsBeforeEmittingReplacement()
+    {
+        var previous = CreateSixelSurface(
+            CreateSolidPixels(20, 20, Rgba32.FromRgb(255, 0, 0)),
+            0,
+            0,
+            2,
+            1);
+        var current = CreateSixelSurface(
+            CreateSolidPixels(19, 20, Rgba32.FromRgb(0, 0, 255)),
+            0,
+            0,
+            2,
+            1);
+
+        var tokens = SurfaceComparer.ToTokens(
+            SurfaceComparer.Compare(previous, current),
+            current,
+            previous);
+        var clearIndex = FindSpaceToken(tokens);
+        var sixelIndex = tokens
+            .Select((token, index) => (token, index))
+            .First(item => item.token is UnrecognizedSequenceToken sequence &&
+                           sequence.Sequence.StartsWith("\x1bP", StringComparison.Ordinal))
+            .index;
+
+        Assert.IsTrue(clearIndex >= 0 && clearIndex < sixelIndex, Describe(tokens));
+    }
+
+    [TestMethod]
+    public void ToTokens_RemovedSixel_ClearsEntirePreviousRegion()
+    {
+        var previous = CreateSixelSurface(Rgba32.FromRgb(255, 0, 0), 1, 1, 3, 2);
+        var current = new Surface(8, 4, CellMetrics.Default);
+
+        var tokens = SurfaceComparer.ToTokens(
+            SurfaceComparer.Compare(previous, current),
+            current,
+            previous);
+        Assert.IsTrue(tokens.OfType<TextToken>().Sum(token => token.Text.Length) >= 6);
+        Assert.IsFalse(tokens.OfType<UnrecognizedSequenceToken>().Any(
+            token => token.Sequence.StartsWith("\x1bP", StringComparison.Ordinal)));
+    }
+
+    [TestMethod]
+    public void ToTokens_MovedSixel_ClearsOldRegionThenEmitsNewAnchor()
+    {
+        var previous = CreateSixelSurface(Rgba32.FromRgb(0, 200, 120), 0, 0, 2, 1);
+        var current = CreateSixelSurface(Rgba32.FromRgb(0, 200, 120), 4, 2, 2, 1);
+
+        var tokens = SurfaceComparer.ToTokens(
+            SurfaceComparer.Compare(previous, current),
+            current,
+            previous);
+        var clearIndex = FindSpaceToken(tokens);
+        var newPositionIndex = tokens
+            .Select((token, index) => (token, index))
+            .First(item => item.token is CursorPositionToken { Row: 3, Column: 5 })
+            .index;
+
+        Assert.IsTrue(clearIndex >= 0 && clearIndex < newPositionIndex, Describe(tokens));
+    }
+
+    [TestMethod]
+    public void ToTokens_TextOverAnchor_FragmentsImageAndRendersTextAfterward()
+    {
+        var previous = new Surface(6, 2, CellMetrics.Default);
+        var current = new Surface(6, 2, CellMetrics.Default);
+        var context = new SurfaceRenderContext(current);
+        context.WriteSixel(CreateSolidPixels(20, 20, Rgba32.FromRgb(200, 80, 40)), 2, 1);
+        context.SetCursorPosition(0, 0);
+        context.Write("X");
+
+        var tokens = SurfaceComparer.ToTokens(
+            SurfaceComparer.Compare(previous, current),
+            current,
+            previous);
+
+        var sixelIndex = tokens
+            .Select((token, index) => (token, index))
+            .First(item => item.token is UnrecognizedSequenceToken sequence &&
+                           sequence.Sequence.StartsWith("\x1bP", StringComparison.Ordinal))
+            .index;
+        var textIndex = tokens
+            .Select((token, index) => (token, index))
+            .First(item => item.token is TextToken { Text: "X" })
+            .index;
+
+        Assert.IsTrue(sixelIndex < textIndex);
+    }
+
+    [TestMethod]
+    public void ToTokens_SixelWrittenWithActiveBackground_EmitsImage()
+    {
+        var previous = new Surface(6, 2, CellMetrics.Default);
+        var current = new Surface(6, 2, CellMetrics.Default);
+        var context = new SurfaceRenderContext(current);
+        context.Write("\x1b[44m");
+        context.WriteSixel(CreateSolidPixels(20, 20, Rgba32.FromRgb(200, 80, 40)), 2, 1);
+
+        var tokens = SurfaceComparer.ToTokens(
+            SurfaceComparer.Compare(previous, current),
+            current,
+            previous);
+
+        Assert.IsTrue(tokens.OfType<UnrecognizedSequenceToken>().Any(
+            token => token.Sequence.StartsWith("\x1bP", StringComparison.Ordinal)));
+    }
+
+    [TestMethod]
+    public void ToTokens_SixelCompositedOverBackground_EmitsImage()
+    {
+        var previous = new Surface(6, 2, CellMetrics.Default);
+        var current = new Surface(6, 2, CellMetrics.Default);
+        current.Clear(new SurfaceCell(" ", null, Hex1bColor.Blue));
+
+        var child = CreateSixelSurface(
+            CreateSolidPixels(20, 20, Rgba32.FromRgb(200, 80, 40)),
+            0,
+            0,
+            2,
+            1);
+        current.Composite(child, 0, 0);
+
+        var tokens = SurfaceComparer.ToTokens(
+            SurfaceComparer.Compare(previous, current),
+            current,
+            previous);
+
+        Assert.IsTrue(tokens.OfType<UnrecognizedSequenceToken>().Any(
+            token => token.Sequence.StartsWith("\x1bP", StringComparison.Ordinal)));
+    }
+
+    [TestMethod]
+    public void Compare_SamePayloadWithDifferentCellSpan_IsDifferent()
+    {
+        var pixels = CreateSolidPixels(20, 20, Rgba32.FromRgb(80, 160, 240));
+        var previous = CreateSixelSurface(pixels, 0, 0, 2, 1);
+        var current = CreateSixelSurface(pixels, 0, 0, 3, 2);
+
+        var diff = SurfaceComparer.Compare(previous, current);
+
+        Assert.IsFalse(diff.IsEmpty);
+    }
+
+    [TestMethod]
+    public void Compare_RepeatedIdenticalSixelRender_HasNoChanges()
+    {
+        var pixels = CreateSolidPixels(20, 20, Rgba32.FromRgb(80, 160, 240));
+        var previous = CreateSixelSurface(pixels, 0, 0, 2, 1);
+        var current = CreateSixelSurface(pixels, 0, 0, 2, 1);
+
+        Assert.IsTrue(SurfaceComparer.Compare(previous, current).IsEmpty);
+    }
+
+    private static Surface CreateSixelSurface(
+        Rgba32 color,
+        int x,
+        int y,
+        int width,
+        int height)
+        => CreateSixelSurface(CreateSolidPixels(width * 10, height * 20, color), x, y, width, height);
+
+    private static Surface CreateSixelSurface(
+        SixelPixelBuffer pixels,
+        int x,
+        int y,
+        int width,
+        int height)
+    {
+        var surface = new Surface(8, 4, CellMetrics.Default);
+        var context = new SurfaceRenderContext(surface);
+        context.SetCursorPosition(x, y);
+        context.WriteSixel(pixels, width, height);
+        return surface;
+    }
+
+    private static SixelPixelBuffer CreateSolidPixels(int width, int height, Rgba32 color)
+    {
+        var pixels = new SixelPixelBuffer(width, height);
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                pixels[x, y] = color;
+            }
+        }
+
+        return pixels;
+    }
+
+    private static int FindSpaceToken(IReadOnlyList<AnsiToken> tokens)
+        => tokens
+            .Select((token, index) => (token, index))
+            .Where(item => item.token is TextToken text &&
+                           text.Text.Length > 0 &&
+                           text.Text.All(static character => character == ' '))
+            .Select(static item => item.index)
+            .DefaultIfEmpty(-1)
+            .First();
+
+    private static string Describe(IReadOnlyList<AnsiToken> tokens)
+        => string.Join(Environment.NewLine, tokens.Select((token, index) => $"{index}: {token}"));
+}

--- a/tests/Hex1b.Tests/SixelSurfaceComparerTests.cs
+++ b/tests/Hex1b.Tests/SixelSurfaceComparerTests.cs
@@ -3,6 +3,9 @@
 using Hex1b.Surfaces;
 using Hex1b.Theming;
 using Hex1b.Tokens;
+using Hex1b.Layout;
+using Hex1b.Sixel;
+using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
 
@@ -144,6 +147,324 @@ public class SixelSurfaceComparerTests
     }
 
     [TestMethod]
+    public void ToTokens_NonAnchorOpaqueBackground_ClipsSixel()
+    {
+        var current = CreateLayeredSixelSurface(
+            new Rect(1, 0, 1, 1),
+            new SurfaceCell(" ", null, Hex1bColor.Blue));
+        var previous = new Surface(current.Width, current.Height, current.CellMetrics);
+
+        var tokens = SurfaceComparer.ToTokens(
+            SurfaceComparer.Compare(previous, current),
+            current,
+            previous);
+        var sixelIndex = tokens
+            .Select((token, index) => (token, index))
+            .First(item => item.token is UnrecognizedSequenceToken)
+            .index;
+        var backgroundIndex = tokens
+            .Select((token, index) => (token, index))
+            .First(item => item.index > sixelIndex &&
+                           item.token is TextToken { Text: " " })
+            .index;
+        var payload = ((UnrecognizedSequenceToken)tokens[sixelIndex]).Sequence;
+
+        Assert.AreEqual(10, SixelParser.ParsePayload(payload).DeclaredExtent.Width);
+        Assert.IsTrue(sixelIndex < backgroundIndex, Describe(tokens));
+    }
+
+    [TestMethod]
+    public void ToTokens_AnchorOpaqueBackground_ClipsAndReanchorsSixel()
+    {
+        var current = CreateLayeredSixelSurface(
+            new Rect(0, 0, 1, 1),
+            new SurfaceCell(" ", null, Hex1bColor.Blue));
+        var previous = new Surface(current.Width, current.Height, current.CellMetrics);
+
+        var tokens = SurfaceComparer.ToTokens(
+            SurfaceComparer.Compare(previous, current),
+            current,
+            previous);
+        var sixelIndex = tokens
+            .Select((token, index) => (token, index))
+            .First(item => item.token is UnrecognizedSequenceToken)
+            .index;
+        var backgroundIndex = tokens
+            .Select((token, index) => (token, index))
+            .First(item => item.index > sixelIndex &&
+                           item.token is TextToken { Text: " " })
+            .index;
+
+        Assert.IsTrue(tokens.Take(sixelIndex).OfType<CursorPositionToken>().Any(
+            token => token.Row == 1 && token.Column == 2));
+        Assert.IsTrue(sixelIndex < backgroundIndex, Describe(tokens));
+    }
+
+    [TestMethod]
+    public void ToTokens_FullyOpaqueBackground_SuppressesSixel()
+    {
+        var current = CreateLayeredSixelSurface(
+            new Rect(0, 0, 2, 1),
+            new SurfaceCell(" ", null, Hex1bColor.Blue));
+        var previous = new Surface(current.Width, current.Height, current.CellMetrics);
+
+        var tokens = SurfaceComparer.ToTokens(
+            SurfaceComparer.Compare(previous, current),
+            current,
+            previous);
+
+        Assert.IsFalse(tokens.OfType<UnrecognizedSequenceToken>().Any(
+            token => token.Sequence.StartsWith("\x1bP", StringComparison.Ordinal)));
+        Assert.IsTrue(tokens.OfType<TextToken>().Sum(token => token.Text.Length) >= 2);
+    }
+
+    [TestMethod]
+    public void ToTokens_TransparentSpace_DoesNotOccludeSixel()
+    {
+        var current = CreateLayeredSixelSurface(
+            new Rect(0, 0, 2, 1),
+            new SurfaceCell(" ", null, null));
+        var previous = new Surface(current.Width, current.Height, current.CellMetrics);
+
+        var tokens = SurfaceComparer.ToTokens(
+            SurfaceComparer.Compare(previous, current),
+            current,
+            previous);
+        var payload = TestSeq.Single(tokens.OfType<UnrecognizedSequenceToken>()).Sequence;
+
+        Assert.AreEqual(20, SixelParser.ParsePayload(payload).DeclaredExtent.Width);
+    }
+
+    [TestMethod]
+    public void ToTokens_OcclusionUsesCapturedSixelMetrics()
+    {
+        var textMetrics = new CellMetrics(8, 16);
+        var previous = new Surface(4, 2, textMetrics);
+        var current = new Surface(4, 2, textMetrics);
+        var context = CreateSixelContext(current, 10, 20);
+        context.WriteSixel(CreateSolidPixels(20, 20, Rgba32.FromRgb(200, 80, 40)), 2, 1);
+        context.SetCursorPosition(0, 0);
+        context.Write("X");
+
+        var tokens = SurfaceComparer.ToTokens(
+            SurfaceComparer.Compare(previous, current),
+            current,
+            previous);
+        var payload = TestSeq.Single(tokens.OfType<UnrecognizedSequenceToken>()).Sequence;
+
+        Assert.AreEqual(10, SixelParser.ParsePayload(payload).DeclaredExtent.Width);
+    }
+
+    [TestMethod]
+    public void Composite_LeftClipUsesCapturedSixelMetrics()
+    {
+        var textMetrics = new CellMetrics(8, 16);
+        var source = new Surface(3, 2, textMetrics);
+        var context = CreateSixelContext(source, 10, 20);
+        context.WriteSixel(CreateSolidPixels(20, 20, Rgba32.FromRgb(200, 80, 40)), 2, 1);
+        var target = new Surface(3, 2, textMetrics);
+
+        target.Composite(source, -1, 0);
+
+        var clipped = target[0, 0].Sixel!.Data;
+        Assert.AreEqual(10, clipped.PixelWidth);
+        Assert.AreEqual(10, SixelParser.ParsePayload(clipped.Payload).DeclaredExtent.Width);
+    }
+
+    [TestMethod]
+    public void ComputedCellPixelAccess_UsesCapturedSixelMetrics()
+    {
+        var textMetrics = new CellMetrics(8, 16);
+        var source = new Surface(4, 2, textMetrics);
+        var context = CreateSixelContext(source, 10, 20);
+        var pixels = new SixelPixelBuffer(20, 20);
+        for (var y = 0; y < pixels.Height; y++)
+        {
+            for (var x = 0; x < pixels.Width; x++)
+            {
+                pixels[x, y] = x < 10
+                    ? Rgba32.FromRgb(255, 0, 0)
+                    : Rgba32.FromRgb(0, 0, 255);
+            }
+        }
+        context.WriteSixel(pixels, 2, 1);
+
+        var composite = new CompositeSurface(4, 2, textMetrics);
+        composite.AddLayer(source, 0, 0);
+        SixelPixelAccess access = default;
+        composite.AddComputedLayer(4, 2, compute =>
+        {
+            if (compute.X == 1 && compute.Y == 0)
+            {
+                access = compute.GetSixelBelow();
+            }
+            return SurfaceCells.Empty;
+        }, 0, 0);
+
+        _ = composite.GetCell(1, 0);
+
+        Assert.IsTrue(access.IsValid);
+        Assert.AreEqual(10, access.PixelWidth);
+        var pixel = access.GetPixel(0, 0);
+        Assert.IsTrue(pixel.B > 200 && pixel.R < 10, $"Expected blue pixel, got {pixel}.");
+    }
+
+    [TestMethod]
+    public void CompositeSurface_AnchorOpaqueBackground_ClipsAndReanchorsSixel()
+    {
+        var source = CreateSixelSurface(
+            CreateSolidPixels(20, 20, Rgba32.FromRgb(200, 80, 40)),
+            0,
+            0,
+            2,
+            1);
+        var overlay = new Surface(source.Width, source.Height, source.CellMetrics);
+        overlay.Fill(new Rect(0, 0, 1, 1), new SurfaceCell(" ", null, Hex1bColor.Blue));
+        var composite = new CompositeSurface(source.Width, source.Height, source.CellMetrics);
+        composite.AddLayer(source, 0, 0);
+        composite.AddLayer(overlay, 0, 0);
+        var current = composite.Flatten();
+        var previous = new Surface(current.Width, current.Height, current.CellMetrics);
+
+        var tokens = SurfaceComparer.ToTokens(
+            SurfaceComparer.Compare(previous, current),
+            current,
+            previous);
+        var payload = TestSeq.Single(tokens.OfType<UnrecognizedSequenceToken>()).Sequence;
+
+        Assert.AreEqual(10, SixelParser.ParsePayload(payload).DeclaredExtent.Width);
+        Assert.IsTrue(tokens.OfType<CursorPositionToken>().Any(
+            token => token.Row == 1 && token.Column == 2));
+    }
+
+    [TestMethod]
+    public void CompositeSurface_ManualAnchorOpaqueBackground_PreservesSixel()
+    {
+        var metrics = new CellMetrics(10, 20);
+        var store = new TrackedObjectStore();
+        var pixels = CreateSolidPixels(20, 20, Rgba32.FromRgb(200, 80, 40));
+        var payload = SixelEncoder.Encode(pixels);
+        var tracked = store.GetOrCreateSixel(
+            payload,
+            2,
+            1,
+            SixelParser.ParsePayload(payload),
+            cellMetrics: new SixelCellMetrics(
+                10,
+                20,
+                SixelCellMetricsSource.Direct,
+                SixelCellMetricsReliability.Authoritative));
+        var source = new Surface(4, 2, metrics);
+        source[0, 0] = new SurfaceCell(" ", null, null, Sixel: tracked);
+        var overlay = new Surface(4, 2, metrics);
+        overlay[0, 0] = new SurfaceCell(" ", null, Hex1bColor.Blue);
+        var composite = new CompositeSurface(4, 2, metrics);
+        composite.AddLayer(source, 0, 0);
+        composite.AddLayer(overlay, 0, 0);
+
+        var current = composite.Flatten();
+        var previous = new Surface(4, 2, metrics);
+        var tokens = SurfaceComparer.ToTokens(
+            SurfaceComparer.Compare(previous, current),
+            current,
+            previous);
+
+        Assert.IsTrue(tokens.OfType<UnrecognizedSequenceToken>().Any(
+            token => token.Sequence.StartsWith("\x1bP", StringComparison.Ordinal)));
+        Assert.IsTrue(tokens.OfType<CursorPositionToken>().Any(
+            token => token.Row == 1 && token.Column == 2));
+    }
+
+    [TestMethod]
+    public void ToTokens_ManualAnchorBackground_DoesNotOccludeItsOwnSixel()
+    {
+        var metrics = new CellMetrics(10, 20);
+        var store = new TrackedObjectStore();
+        var pixels = CreateSolidPixels(10, 18, Rgba32.FromRgb(200, 80, 40));
+        var payload = SixelEncoder.Encode(pixels);
+        var tracked = store.GetOrCreateSixel(
+            payload,
+            1,
+            1,
+            SixelParser.ParsePayload(payload),
+            cellMetrics: new SixelCellMetrics(
+                10,
+                20,
+                SixelCellMetricsSource.Direct,
+                SixelCellMetricsReliability.Authoritative));
+        var current = new Surface(2, 1, metrics);
+        current[0, 0] = new SurfaceCell(" ", null, Hex1bColor.Red, Sixel: tracked);
+        var previous = new Surface(2, 1, metrics);
+
+        var tokens = SurfaceComparer.ToTokens(
+            SurfaceComparer.Compare(previous, current),
+            current,
+            previous);
+
+        Assert.IsTrue(tokens.OfType<UnrecognizedSequenceToken>().Any(
+            token => token.Sequence.StartsWith("\x1bP", StringComparison.Ordinal)));
+    }
+
+    [TestMethod]
+    public void FragmentPosition_UsesFractionalProtocolBoundaries()
+    {
+        var surface = new Surface(4, 4, new CellMetrics(8, 16));
+        var context = CreateSixelContext(surface, 9.4, 19.4);
+        context.WriteSixel(CreateSolidPixels(20, 40, Rgba32.FromRgb(200, 80, 40)), 2, 2);
+        var tracked = surface[0, 0].Sixel!;
+        var metrics = tracked.Data.CellMetrics;
+
+        var horizontal = new SixelVisibility(tracked, 0, 0, 0);
+        horizontal.ApplyOcclusion(new Rect(0, 0, 1, 2), metrics);
+        var horizontalFragment = TestSeq.Single(horizontal.GenerateFragments(metrics));
+
+        var vertical = new SixelVisibility(tracked, 0, 0, 0);
+        vertical.ApplyOcclusion(new Rect(0, 0, 2, 1), metrics);
+        var verticalFragment = TestSeq.Single(vertical.GenerateFragments(metrics));
+
+        Assert.AreEqual((1, 0), horizontalFragment.CellPosition);
+        Assert.AreEqual((0, 1), verticalFragment.CellPosition);
+        Assert.AreEqual(1, metrics.ColumnsFor(horizontalFragment.PixelRegion.Width));
+        Assert.AreEqual(1, metrics.RowsFor(verticalFragment.PixelRegion.Height));
+    }
+
+    [TestMethod]
+    public void SurfaceLayerContext_CreateSixel_CapturesProtocolMetrics()
+    {
+        var store = new TrackedObjectStore();
+        var capabilities = new TerminalCapabilities
+        {
+            SixelSupport = SixelPresentationSupport.Headless,
+            SixelCellMetrics = new SixelCellMetrics(
+                10,
+                20,
+                SixelCellMetricsSource.Direct,
+                SixelCellMetricsReliability.Authoritative)
+        };
+        var context = new SurfaceLayerContext(
+            4,
+            2,
+            -1,
+            -1,
+            new Hex1bTheme("Test"),
+            store,
+            new CellMetrics(8, 16),
+            capabilities);
+        var pixels = CreateSolidPixels(20, 18, Rgba32.FromRgb(200, 80, 40));
+
+        var structured = context.CreateSixel(pixels)!;
+        var encoded = context.CreateSixel(SixelEncoder.Encode(pixels), 2, 1)!;
+
+        Assert.AreEqual(2, structured.Data.WidthInCells);
+        Assert.AreEqual(1, structured.Data.HeightInCells);
+        Assert.AreEqual(capabilities.SixelCellMetrics, structured.Data.CellMetrics);
+        Assert.AreEqual(capabilities.SixelCellMetrics, encoded.Data.CellMetrics);
+
+        structured.Release();
+        encoded.Release();
+    }
+
+    [TestMethod]
     public void Compare_SamePayloadWithDifferentCellSpan_IsDifferent()
     {
         var pixels = CreateSolidPixels(20, 20, Rgba32.FromRgb(80, 160, 240));
@@ -185,6 +506,38 @@ public class SixelSurfaceComparerTests
         context.SetCursorPosition(x, y);
         context.WriteSixel(pixels, width, height);
         return surface;
+    }
+
+    private static Surface CreateLayeredSixelSurface(Rect overlayRect, SurfaceCell overlayCell)
+    {
+        var current = CreateSixelSurface(
+            CreateSolidPixels(20, 20, Rgba32.FromRgb(200, 80, 40)),
+            0,
+            0,
+            2,
+            1);
+        var overlay = new Surface(current.Width, current.Height, current.CellMetrics);
+        overlay.Fill(overlayRect, overlayCell);
+        current.Composite(overlay, 0, 0);
+        return current;
+    }
+
+    private static SurfaceRenderContext CreateSixelContext(
+        Surface surface,
+        double sixelCellWidth,
+        double sixelCellHeight)
+    {
+        var context = new SurfaceRenderContext(surface);
+        context.SetCapabilities(new TerminalCapabilities
+        {
+            SixelSupport = SixelPresentationSupport.Headless,
+            SixelCellMetrics = new SixelCellMetrics(
+                sixelCellWidth,
+                sixelCellHeight,
+                SixelCellMetricsSource.Direct,
+                SixelCellMetricsReliability.Authoritative)
+        });
+        return context;
     }
 
     private static SixelPixelBuffer CreateSolidPixels(int width, int height, Rgba32 color)

--- a/tests/Hex1b.Tests/SixelSurfaceComparerTests.cs
+++ b/tests/Hex1b.Tests/SixelSurfaceComparerTests.cs
@@ -412,20 +412,18 @@ public class SixelSurfaceComparerTests
         var context = CreateSixelContext(surface, 9.4, 19.4);
         context.WriteSixel(CreateSolidPixels(20, 40, Rgba32.FromRgb(200, 80, 40)), 2, 2);
         var tracked = surface[0, 0].Sixel!;
-        var metrics = tracked.Data.CellMetrics;
-
         var horizontal = new SixelVisibility(tracked, 0, 0, 0);
-        horizontal.ApplyOcclusion(new Rect(0, 0, 1, 2), metrics);
-        var horizontalFragment = TestSeq.Single(horizontal.GenerateFragments(metrics));
+        horizontal.ApplyOcclusion(new Rect(0, 0, 1, 2));
+        var horizontalFragment = TestSeq.Single(horizontal.GenerateFragments());
 
         var vertical = new SixelVisibility(tracked, 0, 0, 0);
-        vertical.ApplyOcclusion(new Rect(0, 0, 2, 1), metrics);
-        var verticalFragment = TestSeq.Single(vertical.GenerateFragments(metrics));
+        vertical.ApplyOcclusion(new Rect(0, 0, 2, 1));
+        var verticalFragment = TestSeq.Single(vertical.GenerateFragments());
 
         Assert.AreEqual((1, 0), horizontalFragment.CellPosition);
         Assert.AreEqual((0, 1), verticalFragment.CellPosition);
-        Assert.AreEqual(1, metrics.ColumnsFor(horizontalFragment.PixelRegion.Width));
-        Assert.AreEqual(1, metrics.RowsFor(verticalFragment.PixelRegion.Height));
+        Assert.AreEqual(1, tracked.Data.CellMetrics.ColumnsFor(horizontalFragment.PixelRegion.Width));
+        Assert.AreEqual(1, tracked.Data.CellMetrics.RowsFor(verticalFragment.PixelRegion.Height));
     }
 
     [TestMethod]

--- a/tests/Hex1b.Tests/SixelWidgetIntegrationTests.cs
+++ b/tests/Hex1b.Tests/SixelWidgetIntegrationTests.cs
@@ -1,0 +1,144 @@
+#pragma warning disable HEX1B_SIXEL // Testing experimental Sixel API
+
+using Hex1b.Automation;
+using Hex1b.Input;
+using Hex1b.Sixel;
+using Hex1b.Surfaces;
+using Hex1b.Widgets;
+
+namespace Hex1b.Tests;
+
+[TestClass]
+public class SixelWidgetIntegrationTests
+{
+    [TestMethod]
+    public async Task SurfacePipeline_ReplacementMovementAndRemoval_LeavesOnlyCurrentPixels()
+    {
+        var red = CreateSolidPixels(30, 40, Rgba32.FromRgb(255, 0, 0));
+        var blue = CreateSolidPixels(30, 40, Rgba32.FromRgb(0, 80, 255));
+        var phase = 0;
+        var capabilities = new TerminalCapabilities
+        {
+            SupportsSixel = true,
+            SixelSupport = SixelPresentationSupport.Headless,
+            SixelCellMetrics = new SixelCellMetrics(
+                10,
+                20,
+                SixelCellMetricsSource.Direct,
+                SixelCellMetricsReliability.Authoritative),
+            CellPixelWidth = 10,
+            CellPixelHeight = 20
+        };
+        using var workload = new Hex1bAppWorkloadAdapter(capabilities);
+        using var terminal = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithHeadless(capabilities)
+            .WithDimensions(20, 6)
+            .Build();
+        using var app = new Hex1bApp(
+            context => Task.FromResult<Hex1bWidget>(
+                context.VStack(column =>
+                [
+                    column.Button($"Advance phase {phase}")
+                        .OnClick(_ => phase = Math.Min(2, phase + 1)),
+                    column.HStack(row =>
+                    [
+                        row.Text(new string(' ', phase == 1 ? 4 : 0)),
+                        phase == 2
+                            ? row.Text("image removed")
+                            : row.Sixel(
+                                    phase == 0 ? red : blue,
+                                    fallback => fallback.Text("Sixel unavailable"))
+                                .Width(3)
+                                .Height(2)
+                    ])
+                ])),
+            new Hex1bAppOptions { WorkloadAdapter = workload });
+
+        var sequence = new Hex1bTerminalInputSequenceBuilder()
+            .WaitUntil(
+                snapshot => snapshot.ContainsText("Advance phase 0") && snapshot.ContainsSixelData(),
+                TimeSpan.FromSeconds(5),
+                "initial Sixel image")
+            .Capture("sixel-widget-initial")
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(
+                snapshot => snapshot.ContainsText("Advance phase 1"),
+                TimeSpan.FromSeconds(5),
+                "replacement image moved")
+            .Capture("sixel-widget-replaced-moved")
+            .Key(Hex1bKey.Enter)
+            .WaitUntil(
+                snapshot => snapshot.ContainsText("image removed"),
+                TimeSpan.FromSeconds(5),
+                "Sixel image removed")
+            .Capture("sixel-widget-removed")
+            .Ctrl().Key(Hex1bKey.C)
+            .Build();
+
+        var runTask = app.RunAsync(TestContext.Current.CancellationToken);
+        await sequence.ApplyWithCaptureAsync(terminal, TestContext.Current.CancellationToken);
+        await runTask;
+
+        var captures = sequence.Steps.OfType<CaptureStep>().ToArray();
+        var initial = TestSeq.Single(GetVisiblePlacements(captures[0].CapturedSnapshot!));
+        Assert.AreEqual(0, initial.Column);
+        AssertDominantColor(initial.GetPaintedPixels()![0, 0], red: true);
+
+        var moved = TestSeq.Single(GetVisiblePlacements(captures[1].CapturedSnapshot!));
+        Assert.AreEqual(4, moved.Column);
+        AssertDominantColor(moved.GetPaintedPixels()![0, 0], red: false);
+
+        Assert.IsEmpty(GetVisiblePlacements(captures[2].CapturedSnapshot!));
+    }
+
+    private static IReadOnlyList<SixelPlacement> GetVisiblePlacements(Hex1bTerminalSnapshot snapshot)
+        => snapshot.SixelPlacements
+            .Where(static placement => ContainsOpaquePixel(placement.GetPaintedPixels()))
+            .ToArray();
+
+    private static bool ContainsOpaquePixel(SixelPixelBuffer? pixels)
+    {
+        if (pixels is null)
+        {
+            return false;
+        }
+
+        foreach (var pixel in pixels.AsSpan())
+        {
+            if (pixel.A != 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void AssertDominantColor(Rgba32 pixel, bool red)
+    {
+        Assert.AreEqual((byte)255, pixel.A);
+        if (red)
+        {
+            Assert.IsTrue(pixel.R > 200 && pixel.G < 20 && pixel.B < 20);
+        }
+        else
+        {
+            Assert.IsTrue(pixel.B > 200 && pixel.B > pixel.G && pixel.G > pixel.R);
+        }
+    }
+
+    private static SixelPixelBuffer CreateSolidPixels(int width, int height, Rgba32 color)
+    {
+        var pixels = new SixelPixelBuffer(width, height);
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                pixels[x, y] = color;
+            }
+        }
+
+        return pixels;
+    }
+}

--- a/tests/Hex1b.Tests/SurfaceRenderContextTests.cs
+++ b/tests/Hex1b.Tests/SurfaceRenderContextTests.cs
@@ -1,5 +1,8 @@
+#pragma warning disable HEX1B_SIXEL // Testing experimental Sixel API
+
 using Hex1b.Layout;
 using Hex1b.Nodes;
+using Hex1b.Sixel;
 using Hex1b.Surfaces;
 using Hex1b.Theming;
 using Hex1b.Widgets;
@@ -57,6 +60,187 @@ public class SurfaceRenderContextTests
         Assert.AreEqual("r", surface[12, 5].Character);
         Assert.AreEqual("l", surface[13, 5].Character);
         Assert.AreEqual("d", surface[14, 5].Character);
+    }
+
+    #endregion
+
+    #region Sixel Writing
+
+    [TestMethod]
+    public void WriteSixel_StructuredPixels_StoresTrackedContentAndMetrics()
+    {
+        var surface = new Surface(10, 5, new CellMetrics(8, 16));
+        var context = new SurfaceRenderContext(surface)
+        {
+            CellMetrics = new CellMetrics(8, 16)
+        };
+        context.SetCapabilities(new TerminalCapabilities
+        {
+            SixelSupport = SixelPresentationSupport.Native,
+            SixelCellMetrics = new SixelCellMetrics(
+                8,
+                16,
+                SixelCellMetricsSource.Direct,
+                SixelCellMetricsReliability.Authoritative)
+        });
+        var pixels = CreateSolidPixels(17, 17);
+
+        context.SetCursorPosition(2, 1);
+        context.WriteSixel(pixels, 3, 2);
+
+        var sixel = surface[2, 1].Sixel;
+        Assert.IsNotNull(sixel);
+        Assert.StartsWith("\x1bP", sixel.Data.Payload);
+        Assert.EndsWith("\x1b\\", sixel.Data.Payload);
+        Assert.AreEqual(3, sixel.Data.WidthInCells);
+        Assert.AreEqual(2, sixel.Data.HeightInCells);
+        Assert.AreEqual(8d, sixel.Data.CellMetrics.Width);
+        Assert.AreEqual(1, context.TrackedObjectStore.SixelCount);
+    }
+
+    [TestMethod]
+    public void WriteSixel_PreEncodedBody_IsFramedExactlyOnce()
+    {
+        var surface = new Surface(10, 5);
+        var context = new SurfaceRenderContext(surface);
+        const string body = "#0;2;100;0;0#0~~~~~~";
+
+        context.WriteSixel(body, 2, 1);
+
+        Assert.AreEqual($"\x1bPq{body}\x1b\\", surface[0, 0].Sixel!.Data.Payload);
+    }
+
+    [TestMethod]
+    public void WriteSixel_ReplacingImage_ReleasesPreviousTrackedReference()
+    {
+        var surface = new Surface(10, 5);
+        var context = new SurfaceRenderContext(surface);
+
+        context.WriteSixel(CreateSolidPixels(10, 20, Rgba32.FromRgb(255, 0, 0)), 1, 1);
+        context.SetCursorPosition(0, 0);
+        context.WriteSixel(CreateSolidPixels(10, 20, Rgba32.FromRgb(0, 0, 255)), 1, 1);
+
+        Assert.AreEqual(1, context.TrackedObjectStore.SixelCount);
+    }
+
+    [TestMethod]
+    public void Write_AfterSixel_PreservesAnchorForOcclusion()
+    {
+        var surface = new Surface(10, 5);
+        var context = new SurfaceRenderContext(surface);
+
+        context.WriteSixel(CreateSolidPixels(20, 20), 2, 1);
+        context.SetCursorPosition(0, 0);
+        context.Write("X");
+
+        Assert.AreEqual("X", surface[0, 0].Character);
+        Assert.IsNotNull(surface[0, 0].Sixel);
+    }
+
+    [TestMethod]
+    public void RenderChild_SixelCacheHit_RetainsOneReferencePerSurface()
+    {
+        var surface = new Surface(10, 5);
+        var context = CreateSixelContext(surface);
+        var node = CreateSixelNode(new Rect(0, 0, 2, 1));
+
+        context.RenderChild(node);
+
+        var tracked = node.CachedSurface![0, 0].Sixel!;
+        Assert.AreEqual(2, tracked.RefCount);
+        Assert.AreEqual(1, context.TrackedObjectStore.SixelCount);
+
+        surface.ClearAndReleaseTrackedObjects();
+        node.ClearDirty();
+        context.ResetCacheStats();
+        context.RenderChild(node);
+
+        Assert.AreEqual(1, context.CacheHits);
+        Assert.AreEqual(2, tracked.RefCount);
+        surface.ClearAndReleaseTrackedObjects();
+        Assert.AreEqual(1, tracked.RefCount);
+    }
+
+    [TestMethod]
+    public void RenderChild_SixelResizeWithoutPool_ReleasesRetiredCacheReference()
+    {
+        var surface = new Surface(10, 5);
+        var context = CreateSixelContext(surface);
+        var node = CreateSixelNode(new Rect(0, 0, 2, 1));
+
+        context.RenderChild(node);
+        var retired = node.CachedSurface![0, 0].Sixel!;
+        surface.ClearAndReleaseTrackedObjects();
+        Assert.AreEqual(1, retired.RefCount);
+
+        node.Arrange(new Rect(0, 0, 3, 1));
+        context.RenderChild(node);
+
+        Assert.AreEqual(0, retired.RefCount);
+        Assert.AreEqual(1, context.TrackedObjectStore.SixelCount);
+        Assert.AreNotSame(retired, node.CachedSurface![0, 0].Sixel);
+    }
+
+    [TestMethod]
+    public void RenderChild_SixelWithoutCaching_ReleasesWithOwningSurface()
+    {
+        var surface = new Surface(10, 5);
+        var context = CreateSixelContext(surface);
+        context.CachingEnabled = false;
+        var node = CreateSixelNode(new Rect(0, 0, 2, 1));
+
+        context.RenderChild(node);
+        var tracked = surface[0, 0].Sixel!;
+        Assert.AreEqual(1, tracked.RefCount);
+
+        surface.ClearAndReleaseTrackedObjects();
+
+        Assert.AreEqual(0, tracked.RefCount);
+        Assert.AreEqual(0, context.TrackedObjectStore.SixelCount);
+    }
+
+    private static SixelPixelBuffer CreateSolidPixels(
+        int width,
+        int height,
+        Rgba32? color = null)
+    {
+        var buffer = new SixelPixelBuffer(width, height);
+        var fill = color ?? Rgba32.FromRgb(0, 180, 255);
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                buffer[x, y] = fill;
+            }
+        }
+
+        return buffer;
+    }
+
+    private static SurfaceRenderContext CreateSixelContext(Surface surface)
+    {
+        var capabilities = new TerminalCapabilities
+        {
+            SupportsSixel = true,
+            SixelSupport = SixelPresentationSupport.Headless
+        };
+        var context = new SurfaceRenderContext(surface);
+        context.SetCapabilities(capabilities);
+        return context;
+    }
+
+    private static SixelNode CreateSixelNode(Rect bounds)
+    {
+        var capabilities = new TerminalCapabilities
+        {
+            SupportsSixel = true,
+            SixelSupport = SixelPresentationSupport.Headless
+        };
+        var node = new SixelNode();
+        node.SetPixels(CreateSolidPixels(20, 20));
+        node.SetTerminalCapabilities(capabilities);
+        node.Arrange(bounds);
+        return node;
     }
 
     #endregion

--- a/tests/Hex1b.Tests/SurfaceRenderContextTests.cs
+++ b/tests/Hex1b.Tests/SurfaceRenderContextTests.cs
@@ -5,6 +5,7 @@ using Hex1b.Nodes;
 using Hex1b.Sixel;
 using Hex1b.Surfaces;
 using Hex1b.Theming;
+using Hex1b.Tokens;
 using Hex1b.Widgets;
 
 namespace Hex1b.Tests;
@@ -94,6 +95,8 @@ public class SurfaceRenderContextTests
         Assert.EndsWith("\x1b\\", sixel.Data.Payload);
         Assert.AreEqual(3, sixel.Data.WidthInCells);
         Assert.AreEqual(2, sixel.Data.HeightInCells);
+        Assert.AreEqual(24, sixel.Data.PixelWidth);
+        Assert.AreEqual(32, sixel.Data.PixelHeight);
         Assert.AreEqual(8d, sixel.Data.CellMetrics.Width);
         Assert.AreEqual(1, context.TrackedObjectStore.SixelCount);
     }
@@ -105,9 +108,42 @@ public class SurfaceRenderContextTests
         var context = new SurfaceRenderContext(surface);
         const string body = "#0;2;100;0;0#0~~~~~~";
 
-        context.WriteSixel(body, 2, 1);
+        context.WriteSixel(body, 1, 1);
 
         Assert.AreEqual($"\x1bPq{body}\x1b\\", surface[0, 0].Sixel!.Data.Payload);
+    }
+
+    [TestMethod]
+    public void WriteSixel_EightBitFraming_SerializesCanonicalSevenBitBytes()
+    {
+        var surface = new Surface(10, 5, new CellMetrics(10, 20));
+        var context = CreateSixelContext(surface, 10, 20);
+        var pixels = new SixelPixelBuffer(10, 20);
+        pixels[0, 0] = Rgba32.FromRgb(255, 0, 0);
+        var sevenBit = SixelEncoder.Encode(pixels);
+        var eightBit = $"\x90{sevenBit[2..^2]}\x9c";
+
+        context.WriteSixel(eightBit, 1, 1);
+
+        var tokens = SurfaceComparer.ToTokens(SurfaceComparer.CreateFullDiff(surface), surface);
+        var bytes = System.Text.Encoding.UTF8.GetBytes(AnsiTokenSerializer.Serialize(tokens));
+        Assert.AreEqual(0x1b, bytes.First(value => value == 0x1b));
+        Assert.IsTrue(bytes.AsSpan().IndexOf([(byte)0x1b, (byte)'P']) >= 0);
+        Assert.IsTrue(bytes.AsSpan().IndexOf([(byte)0x1b, (byte)'\\']) >= 0);
+        Assert.IsFalse(bytes.Contains((byte)0xc2));
+    }
+
+    [TestMethod]
+    public void WriteSixel_PreEncodedPayloadWithDifferentSpan_Throws()
+    {
+        var surface = new Surface(10, 5, new CellMetrics(10, 20));
+        var context = CreateSixelContext(surface, 10, 20);
+        var pixels = new SixelPixelBuffer(20, 20);
+        pixels[0, 0] = Rgba32.FromRgb(255, 0, 0);
+        var payload = SixelEncoder.Encode(pixels);
+
+        Assert.Throws<ArgumentException>(() => context.WriteSixel(payload, 3, 1));
+        Assert.IsFalse(surface.HasSixels);
     }
 
     [TestMethod]
@@ -218,11 +254,22 @@ public class SurfaceRenderContextTests
     }
 
     private static SurfaceRenderContext CreateSixelContext(Surface surface)
+        => CreateSixelContext(surface, 10, 20);
+
+    private static SurfaceRenderContext CreateSixelContext(
+        Surface surface,
+        double sixelCellWidth,
+        double sixelCellHeight)
     {
         var capabilities = new TerminalCapabilities
         {
             SupportsSixel = true,
-            SixelSupport = SixelPresentationSupport.Headless
+            SixelSupport = SixelPresentationSupport.Headless,
+            SixelCellMetrics = new SixelCellMetrics(
+                sixelCellWidth,
+                sixelCellHeight,
+                SixelCellMetricsSource.Direct,
+                SixelCellMetricsReliability.Authoritative)
         };
         var context = new SurfaceRenderContext(surface);
         context.SetCapabilities(capabilities);

--- a/tests/Hex1b.Tests/TestData/Sixel/Conformance/terminal-reference-matrix.json
+++ b/tests/Hex1b.Tests/TestData/Sixel/Conformance/terminal-reference-matrix.json
@@ -409,16 +409,5 @@
       ]
     }
   ],
-  "ignoredTests": [
-    {
-      "test": "Hex1b.Tests.SixelScalingIntegrationTests.SmpteColorBars_RendersCorrectlyAtScale",
-      "scope": "widget-emitter",
-      "reason": "Exercises SixelWidget and Surface emission, which is explicitly outside terminal-side issue #457."
-    },
-    {
-      "test": "Hex1b.Tests.SixelScalingIntegrationTests.Checkerboard_RendersCorrectlyAtScale",
-      "scope": "widget-emitter",
-      "reason": "Exercises SixelWidget and Surface emission, which is explicitly outside terminal-side issue #457."
-    }
-  ]
+  "ignoredTests": []
 }


### PR DESCRIPTION
Closes #480

## Summary

- rehabilitates the existing experimental `SixelWidget` with structured `SixelPixelBuffer` input, validated pre-encoded compatibility input, fluent explicit sizing, and capability-aware fallback behavior
- adds experimental structured `Hex1bRenderContext.WriteSixel` operations; direct contexts emit native Sixel while `SurfaceRenderContext` stores tracked structured graphics
- derives natural layout from authoritative `TerminalCapabilities.SixelCellMetrics` and preserves legacy `SupportsSixel` compatibility only when typed support is `Unknown`
- makes Surface clipping, text overlap, replacement, movement, removal, resize, repeated rendering, caching, and tracked-reference lifetime deterministic without parent invalidation
- removes the environment-controlled fragmentation path and keeps all implementation terminal-first without cross-protocol translation or public HMP1 coupling

## Independent review fixes

- explicit structured sizing now nearest-neighbor resamples the emitted raster to the requested protocol-cell span; lossless pre-encoded input rejects incompatible requested spans instead of misreporting occupancy
- accepted 8-bit C1 DCS/ST framing is canonicalized to 7-bit `ESC P ... ESC \\` before string/UTF-8 output
- clipping, fragment placement, occlusion, composites, and computed pixel access use each image's captured `SixelData.CellMetrics`, including fractional protocol metrics that differ from text metrics
- Surface cells preserve Sixel-underlay versus higher-layer occlusion metadata, so opaque background-only overlays hide images while transparent spaces remain non-occluding, including anchor and non-anchor cases
- `SixelData.ContentHash` is a complete immutable resource identity including payload/raster state, cell span, exact metric bits, metric source, and reliability, preventing incompatible metric contexts from deduplicating

## HMP1 replay repair

- advances the internal Sixel recording format to v2, persisting exact metric width/height bits, source, reliability, cell span, raster metadata, payload, and content hash per image
- retains v1 read compatibility; v1 recordings intentionally use the target terminal's metrics because the original format did not store per-image metrics
- replaces the lossy replay escape-string path with internal `ReplayInto(Hex1bTerminal)`, which preflights limits, applies each image's metrics through the normal tokenizer/parser, restores recorded crop/damage, and restores the target's prior metric override
- rejects invalid metric enums, incompatible spans, invalid crop/damage state, truncation, unsupported versions, and existing count/payload/recording limit violations explicitly
- keeps all replay/versioning mechanics internal to HMP1; no public HMP1 API or cross-protocol translation was introduced

## Public API

```csharp
new SixelWidget(SixelPixelBuffer pixels, Hex1bWidget fallback)
context.Sixel(SixelPixelBuffer pixels, Hex1bWidget fallback)
context.Sixel(SixelPixelBuffer pixels, Func<WidgetContext<SixelWidget>, Hex1bWidget> builder)
widget.Width(int width)
widget.Height(int height)
renderContext.WriteSixel(SixelPixelBuffer pixels, int cellWidth, int cellHeight)
renderContext.WriteSixel(string imageData, int cellWidth, int cellHeight)
```

The existing encoded-string widget and extension overloads remain as validated compatibility paths. All user-facing Sixel APIs remain marked experimental.

## Tests and evidence

- activated both previously ignored `SixelScalingIntegrationTests` across 8x16, 10x20, and 12x24 cell metrics
- added focused coverage for emitted raster dimensions, encoded mismatch rejection, byte-level C1 canonicalization, captured/fractional protocol metrics, opaque and transparent overlays, composite flattening, replacement/movement/removal, clipping, caching, resize, repeated renders, and reference cleanup
- added full-app Surface pipeline evidence for initial, replaced/moved, and removed states in SVG, HTML, and ANSI formats
- added `samples/SixelWidgetDemo` with large visible images and interactive sizing, fallback, clipping, overlap, replacement, movement, and removal scenarios
- added true serialize → deserialize → fresh-terminal HMP1 replay coverage for identical payloads captured at 1x6 and 1x3 metrics, asserting 2x1 versus 2x2 spans, exact metric metadata, distinct identities, target metric restoration, and different damage boundaries
- added larger-target crop restoration, v1 compatibility, exact fractional metric round-trip, invalid metric metadata, replay-limit, and fuzz coverage
- added 18x18 fractional same-span Surface coverage for 10x20 versus 9.4x19.4 metrics: distinct identity, same-context deduplication, different crop boundaries, metric-only comparer differences, and complete reference release
- updated the website example and Sixel widget documentation

### Surface lifecycle evidence

| Initial | Replaced and moved | Removed |
|---|---|---|
| ![Initial Sixel widget surface](https://github.com/user-attachments/assets/68d9b988-fff1-4c1d-8983-cf0bf7e92ab0) | ![Replaced and moved Sixel widget surface](https://github.com/user-attachments/assets/307dc36a-d0b7-4fb7-bbf2-04fcb3e089a9) | ![Removed Sixel widget surface](https://github.com/user-attachments/assets/a2d12857-e98c-4a01-951b-6115f2d8414e) |

The same integration test emits matching HTML and ANSI artifacts for all three states.

## Validation

- focused HMP1/Surface/fuzz: 50/50 passed
- broad HMP1/Sixel/Surface: 955/955 passed
- full test matrix: 9,311 total; 9,287 passed, 24 pre-existing skipped, 0 failed
- six project builds completed with zero warnings/errors
- both Sixel demos built successfully
- Aspire documentation pipeline: 13/13 passed
- independent incremental code review found no correctness, compatibility, resource-limit, or lifecycle defects
- fresh GitHub CI passed Ubuntu/Windows tests, four native builds, two Windows PTY-host builds, versioning, PR build, and PR publishing

## Surface benchmarks

All 39 Surface dry benchmarks were compared against the saved `07edf538` baseline. The immediate repeat showed no timing regression above 20%. A first-sample unrelated `WriteText_Medium` outlier disappeared on repeat. Allocations were unchanged except `CreateSurface_Medium`, which increased 672 bytes (0.14%); no production `src/Hex1b/Surfaces` code changed in the HMP1 repair.

## Limitations and deferred work

- v1 recordings cannot recover per-image metrics that were never stored, so they retain legacy target-terminal-metric replay
- `ReplayInto` requires a fresh/inactive target whose dimensions can address the recorded placement anchors
- public graphics limits (#475) and aggregate retained-memory budgeting (#478) remain intentionally deferred; #475 is the next stage and supplies the configuration surface required by #478