### PR TITLE
Expose terminal graphics resource limits

### DIFF
--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -81,7 +81,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     // capabilities and can be overridden by adapters and tests.
     private Sixel.SixelCellMetrics? _sixelCellMetricsOverride;
     private readonly TimeProvider _timeProvider;
-    private readonly KgpTerminalGraphicsState _kgpGraphicsState = new();
+    private readonly KgpTerminalGraphicsState _kgpGraphicsState;
     private readonly SixelGraphicsState _sixelGraphicsState;
     private long _sixelPlacementSequence;
     private ITimer? _kgpAnimationTimer;
@@ -335,9 +335,12 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         _timeProvider = options.TimeProvider ?? TimeProvider.System;
         _sessionStart = _timeProvider.GetUtcNow();
         _metrics = options.Metrics ?? Diagnostics.Hex1bMetrics.Default;
-        _sixelColorRegisters = new Sixel.SixelColorRegisters(options.SixelPolicy);
+        var sixelPolicy = options.CreateSixelPolicy();
+        _kgpGraphicsState = new KgpTerminalGraphicsState(
+            options.Graphics.MaximumRetainedBytesPerScreen);
+        _sixelColorRegisters = new Sixel.SixelColorRegisters(sixelPolicy);
         _sixelGraphicsState = new SixelGraphicsState(
-            options.SixelPolicy,
+            sixelPolicy,
             RecordSixelStateEvent);
         
         // Notify lifecycle-aware presentation adapters that the terminal is created
@@ -378,7 +381,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             _scrollbackCallback = options.ScrollbackCallback;
         }
         
-        _dcsByteStreamParser = new DcsByteStreamParser(options.SixelPolicy);
+        _dcsByteStreamParser = new DcsByteStreamParser(sixelPolicy);
         _escapeTimeout = options.EscapeSequenceTimeout ?? TimeSpan.FromMilliseconds(50);
         ResetSixelModes();
 

--- a/src/Hex1b/Hex1bTerminalBuilder.cs
+++ b/src/Hex1b/Hex1bTerminalBuilder.cs
@@ -54,6 +54,7 @@ public sealed class Hex1bTerminalBuilder
     private Action<ScrollbackRowEventArgs>? _scrollbackCallback;
     private Reflow.ITerminalReflowProvider? _reflowStrategy;
     private bool _reflowEnabled;
+    private readonly Hex1bTerminalGraphicsOptions _graphicsOptions = new();
 
     /// <summary>
     /// Creates a new terminal builder.
@@ -1351,6 +1352,44 @@ public sealed class Hex1bTerminalBuilder
     }
 
     /// <summary>
+    /// Configures resource limits for terminal graphics.
+    /// </summary>
+    /// <param name="configure">
+    /// A callback that configures the terminal's per-image and per-screen
+    /// graphics limits.
+    /// </param>
+    /// <returns>This builder for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="configure"/> is <see langword="null"/>.
+    /// </exception>
+    /// <remarks>
+    /// Main and alternate screens receive independent retained-resource budgets.
+    /// Invalid values are rejected when <see cref="Build"/> constructs the
+    /// terminal.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// await using var terminal = Hex1bTerminal.CreateBuilder()
+    ///     .WithPtyProcess("bash")
+    ///     .WithGraphics(options =>
+    ///     {
+    ///         options.MaximumRetainedBytesPerScreen = 64L * 1024 * 1024;
+    ///         options.MaximumPlacementsPerScreen = 512;
+    ///     })
+    ///     .Build();
+    ///
+    /// await terminal.RunAsync();
+    /// </code>
+    /// </example>
+    public Hex1bTerminalBuilder WithGraphics(
+        Action<Hex1bTerminalGraphicsOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+        configure(_graphicsOptions);
+        return this;
+    }
+
+    /// <summary>
     /// Enables terminal reflow with automatic strategy detection based on the running
     /// terminal emulator (via <c>TERM_PROGRAM</c>, <c>WT_SESSION</c>, etc.).
     /// </summary>
@@ -1472,7 +1511,8 @@ public sealed class Hex1bTerminalBuilder
             RunCallback = runCallback,
             ScrollbackCapacity = _scrollbackCapacity,
             ScrollbackCallback = _scrollbackCallback,
-            Metrics = ResolveMetrics()
+            Metrics = ResolveMetrics(),
+            Graphics = _graphicsOptions.Clone(),
         };
         
         foreach (var filter in _workloadFilters)

--- a/src/Hex1b/Hex1bTerminalGraphicsOptions.cs
+++ b/src/Hex1b/Hex1bTerminalGraphicsOptions.cs
@@ -1,0 +1,122 @@
+namespace Hex1b;
+
+/// <summary>
+/// Configures resource limits for graphics retained and processed by a
+/// <see cref="Hex1bTerminal"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These limits are protocol-neutral. A graphics protocol uses the limits that
+/// apply to its representation; unsupported concepts are ignored rather than
+/// translated between protocols.
+/// </para>
+/// <para>
+/// Per-image limits bound the work accepted from one graphic. Per-screen limits
+/// bound the live terminal state independently for the main and alternate
+/// screens. Snapshot owners may extend the lifetime of resources after the live
+/// terminal has evicted them.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// await using var terminal = Hex1bTerminal.CreateBuilder()
+///     .WithPtyProcess("bash")
+///     .WithGraphics(options =>
+///     {
+///         options.MaximumRetainedBytesPerScreen = 64L * 1024 * 1024;
+///         options.MaximumImagesPerScreen = 256;
+///     })
+///     .Build();
+///
+/// await terminal.RunAsync();
+/// </code>
+/// </example>
+public sealed class Hex1bTerminalGraphicsOptions
+{
+    /// <summary>
+    /// Gets or sets the maximum number of source input bytes retained for one
+    /// graphic. The default is 1 MiB.
+    /// </summary>
+    /// <remarks>
+    /// Framing may continue after this limit is reached so the terminal can
+    /// recover at the protocol terminator. This limit is separate from decoded
+    /// raster work and aggregate retained-memory budgets.
+    /// </remarks>
+    public int MaximumRetainedInputBytesPerImage { get; set; } = 1024 * 1024;
+
+    /// <summary>
+    /// Gets or sets the maximum logical pixel area rasterized for one graphic.
+    /// The default is 16,777,216 pixels.
+    /// </summary>
+    public long MaximumRasterPixelsPerImage { get; set; } = 16L * 1024 * 1024;
+
+    /// <summary>
+    /// Gets or sets the maximum number of pixel-write operations performed while
+    /// rasterizing one graphic. The default is 67,108,864 operations.
+    /// </summary>
+    public long MaximumRasterOperationsPerImage { get; set; } = 64L * 1024 * 1024;
+
+    /// <summary>
+    /// Gets or sets the maximum number of distinct images retained by one screen.
+    /// The default is 1,024.
+    /// </summary>
+    public int MaximumImagesPerScreen { get; set; } = 1_024;
+
+    /// <summary>
+    /// Gets or sets the maximum number of live image placements retained by one
+    /// screen. The default is 4,096.
+    /// </summary>
+    public int MaximumPlacementsPerScreen { get; set; } = 4_096;
+
+    /// <summary>
+    /// Gets or sets the maximum number of image placement fragments retained in
+    /// scrollback history. The default is 4,096.
+    /// </summary>
+    public int MaximumHistoryPlacements { get; set; } = 4_096;
+
+    /// <summary>
+    /// Gets or sets the maximum aggregate logical pixel area retained by distinct
+    /// images on one screen. The default is 67,108,864 pixels.
+    /// </summary>
+    /// <remarks>
+    /// This bounds potential dense raster materialization independently from the
+    /// actual retained-byte budget.
+    /// </remarks>
+    public long MaximumRetainedLogicalPixelsPerScreen { get; set; } =
+        64L * 1024 * 1024;
+
+    /// <summary>
+    /// Gets or sets the maximum aggregate encoded and decoded image and animation
+    /// frame data retained by one screen. The default is 335,544,320 bytes.
+    /// </summary>
+    /// <remarks>
+    /// The main and alternate screens each receive an independent budget. A value
+    /// of zero disables retained byte-backed image data. Per-image input and raster
+    /// limits remain independent safety bounds.
+    /// </remarks>
+    public long MaximumRetainedBytesPerScreen { get; set; } = 320L * 1024 * 1024;
+
+    internal Hex1bTerminalGraphicsOptions Clone() => new()
+    {
+        MaximumRetainedInputBytesPerImage = MaximumRetainedInputBytesPerImage,
+        MaximumRasterPixelsPerImage = MaximumRasterPixelsPerImage,
+        MaximumRasterOperationsPerImage = MaximumRasterOperationsPerImage,
+        MaximumImagesPerScreen = MaximumImagesPerScreen,
+        MaximumPlacementsPerScreen = MaximumPlacementsPerScreen,
+        MaximumHistoryPlacements = MaximumHistoryPlacements,
+        MaximumRetainedLogicalPixelsPerScreen = MaximumRetainedLogicalPixelsPerScreen,
+        MaximumRetainedBytesPerScreen = MaximumRetainedBytesPerScreen,
+    };
+
+    internal void Validate()
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(MaximumRetainedInputBytesPerImage);
+        ArgumentOutOfRangeException.ThrowIfLessThan(MaximumRasterPixelsPerImage, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(MaximumRasterOperationsPerImage, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(MaximumImagesPerScreen, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(MaximumPlacementsPerScreen, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(MaximumHistoryPlacements, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(MaximumRetainedLogicalPixelsPerScreen, 1);
+        ArgumentOutOfRangeException.ThrowIfNegative(MaximumRetainedBytesPerScreen);
+    }
+}

--- a/src/Hex1b/Hex1bTerminalGraphicsOptions.cs
+++ b/src/Hex1b/Hex1bTerminalGraphicsOptions.cs
@@ -91,8 +91,10 @@ public sealed class Hex1bTerminalGraphicsOptions
     /// </summary>
     /// <remarks>
     /// The main and alternate screens each receive an independent budget. A value
-    /// of zero disables retained byte-backed image data. Per-image input and raster
-    /// limits remain independent safety bounds.
+    /// of zero disables retained byte-backed image data. Protocols that do not yet
+    /// account all retained state in bytes continue to use the other configured
+    /// cardinality and logical-pixel limits. Per-image input and raster limits remain
+    /// independent safety bounds.
     /// </remarks>
     public long MaximumRetainedBytesPerScreen { get; set; } = 320L * 1024 * 1024;
 
@@ -112,6 +114,9 @@ public sealed class Hex1bTerminalGraphicsOptions
     {
         ArgumentOutOfRangeException.ThrowIfNegative(MaximumRetainedInputBytesPerImage);
         ArgumentOutOfRangeException.ThrowIfLessThan(MaximumRasterPixelsPerImage, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(
+            MaximumRasterPixelsPerImage,
+            int.MaxValue);
         ArgumentOutOfRangeException.ThrowIfLessThan(MaximumRasterOperationsPerImage, 1);
         ArgumentOutOfRangeException.ThrowIfLessThan(MaximumImagesPerScreen, 1);
         ArgumentOutOfRangeException.ThrowIfLessThan(MaximumPlacementsPerScreen, 1);

--- a/src/Hex1b/Hex1bTerminalOptions.cs
+++ b/src/Hex1b/Hex1bTerminalOptions.cs
@@ -28,6 +28,16 @@ public sealed class Hex1bTerminalOptions
         Sixel.SixelCompatibilityPolicy.Default;
 
     /// <summary>
+    /// Gets or sets the resource limits used when processing and retaining
+    /// terminal graphics.
+    /// </summary>
+    /// <remarks>
+    /// The default value preserves Hex1b's standard graphics limits. Main and
+    /// alternate screen resources are budgeted independently.
+    /// </remarks>
+    public Hex1bTerminalGraphicsOptions Graphics { get; set; } = new();
+
+    /// <summary>
     /// Terminal width in columns. Used when no presentation adapter is provided.
     /// Default is 80.
     /// </summary>
@@ -148,6 +158,20 @@ public sealed class Hex1bTerminalOptions
             throw new InvalidOperationException("Height must be greater than zero.");
         }
 
-        SixelPolicy.Validate();
+        ArgumentNullException.ThrowIfNull(Graphics);
+        Graphics.Validate();
+        CreateSixelPolicy().Validate();
     }
+
+    internal Sixel.SixelCompatibilityPolicy CreateSixelPolicy() => SixelPolicy with
+    {
+        MaximumRetainedDcsBytes = Graphics.MaximumRetainedInputBytesPerImage,
+        MaximumRasterPixels = Graphics.MaximumRasterPixelsPerImage,
+        MaximumRasterOperations = Graphics.MaximumRasterOperationsPerImage,
+        MaximumPlacementsPerScreen = Graphics.MaximumPlacementsPerScreen,
+        MaximumHistoryPlacements = Graphics.MaximumHistoryPlacements,
+        MaximumImagesPerScreen = Graphics.MaximumImagesPerScreen,
+        MaximumRetainedLogicalPixelsPerScreen =
+            Graphics.MaximumRetainedLogicalPixelsPerScreen,
+    };
 }

--- a/src/Hex1b/Hex1bTerminalOptions.cs
+++ b/src/Hex1b/Hex1bTerminalOptions.cs
@@ -163,15 +163,23 @@ public sealed class Hex1bTerminalOptions
         CreateSixelPolicy().Validate();
     }
 
-    internal Sixel.SixelCompatibilityPolicy CreateSixelPolicy() => SixelPolicy with
+    internal Sixel.SixelCompatibilityPolicy CreateSixelPolicy()
     {
-        MaximumRetainedDcsBytes = Graphics.MaximumRetainedInputBytesPerImage,
-        MaximumRasterPixels = Graphics.MaximumRasterPixelsPerImage,
-        MaximumRasterOperations = Graphics.MaximumRasterOperationsPerImage,
-        MaximumPlacementsPerScreen = Graphics.MaximumPlacementsPerScreen,
-        MaximumHistoryPlacements = Graphics.MaximumHistoryPlacements,
-        MaximumImagesPerScreen = Graphics.MaximumImagesPerScreen,
-        MaximumRetainedLogicalPixelsPerScreen =
-            Graphics.MaximumRetainedLogicalPixelsPerScreen,
-    };
+        var tileArea = checked(
+            (long)SixelPolicy.RasterTileSize * SixelPolicy.RasterTileSize);
+        var maximumRasterTiles = checked((int)(
+            (Graphics.MaximumRasterPixelsPerImage + tileArea - 1) / tileArea));
+        return SixelPolicy with
+        {
+            MaximumRetainedDcsBytes = Graphics.MaximumRetainedInputBytesPerImage,
+            MaximumRasterPixels = Graphics.MaximumRasterPixelsPerImage,
+            MaximumRasterOperations = Graphics.MaximumRasterOperationsPerImage,
+            MaximumRasterTiles = maximumRasterTiles,
+            MaximumPlacementsPerScreen = Graphics.MaximumPlacementsPerScreen,
+            MaximumHistoryPlacements = Graphics.MaximumHistoryPlacements,
+            MaximumImagesPerScreen = Graphics.MaximumImagesPerScreen,
+            MaximumRetainedLogicalPixelsPerScreen =
+                Graphics.MaximumRetainedLogicalPixelsPerScreen,
+        };
+    }
 }

--- a/src/Hex1b/Hex1bTerminalOptions.cs
+++ b/src/Hex1b/Hex1bTerminalOptions.cs
@@ -165,21 +165,82 @@ public sealed class Hex1bTerminalOptions
 
     internal Sixel.SixelCompatibilityPolicy CreateSixelPolicy()
     {
-        var tileArea = checked(
-            (long)SixelPolicy.RasterTileSize * SixelPolicy.RasterTileSize);
-        var maximumRasterTiles = checked((int)(
-            (Graphics.MaximumRasterPixelsPerImage + tileArea - 1) / tileArea));
+        ValidateSixelPolicyResourceLimits();
         return SixelPolicy with
         {
             MaximumRetainedDcsBytes = Graphics.MaximumRetainedInputBytesPerImage,
             MaximumRasterPixels = Graphics.MaximumRasterPixelsPerImage,
             MaximumRasterOperations = Graphics.MaximumRasterOperationsPerImage,
-            MaximumRasterTiles = maximumRasterTiles,
             MaximumPlacementsPerScreen = Graphics.MaximumPlacementsPerScreen,
             MaximumHistoryPlacements = Graphics.MaximumHistoryPlacements,
             MaximumImagesPerScreen = Graphics.MaximumImagesPerScreen,
             MaximumRetainedLogicalPixelsPerScreen =
                 Graphics.MaximumRetainedLogicalPixelsPerScreen,
         };
+    }
+
+    private void ValidateSixelPolicyResourceLimits()
+    {
+        var defaults = Sixel.SixelCompatibilityPolicy.Default;
+        EnsureNoConflict(
+            nameof(Sixel.SixelCompatibilityPolicy.MaximumRetainedDcsBytes),
+            SixelPolicy.MaximumRetainedDcsBytes,
+            defaults.MaximumRetainedDcsBytes,
+            nameof(Hex1bTerminalGraphicsOptions.MaximumRetainedInputBytesPerImage),
+            Graphics.MaximumRetainedInputBytesPerImage);
+        EnsureNoConflict(
+            nameof(Sixel.SixelCompatibilityPolicy.MaximumRasterPixels),
+            SixelPolicy.MaximumRasterPixels,
+            defaults.MaximumRasterPixels,
+            nameof(Hex1bTerminalGraphicsOptions.MaximumRasterPixelsPerImage),
+            Graphics.MaximumRasterPixelsPerImage);
+        EnsureNoConflict(
+            nameof(Sixel.SixelCompatibilityPolicy.MaximumRasterOperations),
+            SixelPolicy.MaximumRasterOperations,
+            defaults.MaximumRasterOperations,
+            nameof(Hex1bTerminalGraphicsOptions.MaximumRasterOperationsPerImage),
+            Graphics.MaximumRasterOperationsPerImage);
+        EnsureNoConflict(
+            nameof(Sixel.SixelCompatibilityPolicy.MaximumPlacementsPerScreen),
+            SixelPolicy.MaximumPlacementsPerScreen,
+            defaults.MaximumPlacementsPerScreen,
+            nameof(Hex1bTerminalGraphicsOptions.MaximumPlacementsPerScreen),
+            Graphics.MaximumPlacementsPerScreen);
+        EnsureNoConflict(
+            nameof(Sixel.SixelCompatibilityPolicy.MaximumHistoryPlacements),
+            SixelPolicy.MaximumHistoryPlacements,
+            defaults.MaximumHistoryPlacements,
+            nameof(Hex1bTerminalGraphicsOptions.MaximumHistoryPlacements),
+            Graphics.MaximumHistoryPlacements);
+        EnsureNoConflict(
+            nameof(Sixel.SixelCompatibilityPolicy.MaximumImagesPerScreen),
+            SixelPolicy.MaximumImagesPerScreen,
+            defaults.MaximumImagesPerScreen,
+            nameof(Hex1bTerminalGraphicsOptions.MaximumImagesPerScreen),
+            Graphics.MaximumImagesPerScreen);
+        EnsureNoConflict(
+            nameof(Sixel.SixelCompatibilityPolicy.MaximumRetainedLogicalPixelsPerScreen),
+            SixelPolicy.MaximumRetainedLogicalPixelsPerScreen,
+            defaults.MaximumRetainedLogicalPixelsPerScreen,
+            nameof(Hex1bTerminalGraphicsOptions.MaximumRetainedLogicalPixelsPerScreen),
+            Graphics.MaximumRetainedLogicalPixelsPerScreen);
+    }
+
+    private static void EnsureNoConflict<T>(
+        string policyName,
+        T policyValue,
+        T defaultPolicyValue,
+        string graphicsName,
+        T graphicsValue)
+        where T : IEquatable<T>
+    {
+        if (!policyValue.Equals(defaultPolicyValue) &&
+            !policyValue.Equals(graphicsValue))
+        {
+            throw new InvalidOperationException(
+                $"Internal Sixel policy limit {policyName} conflicts with " +
+                $"{nameof(Graphics)}.{graphicsName}. Configure the public graphics " +
+                "limit with the same value.");
+        }
     }
 }

--- a/src/Hex1b/Kgp/KgpTerminalGraphicsState.cs
+++ b/src/Hex1b/Kgp/KgpTerminalGraphicsState.cs
@@ -86,7 +86,12 @@ internal sealed class KgpTerminalGraphicsState
 
     private sealed class ScreenState
     {
-        internal KgpImageStore ImageStore { get; } = new();
+        internal ScreenState(long retainedBytes)
+        {
+            ImageStore = new KgpImageStore(retainedBytes);
+        }
+
+        internal KgpImageStore ImageStore { get; }
         internal List<KgpPlacement> Placements { get; } = [];
         internal List<KgpVirtualPlacement> VirtualPlacements { get; } = [];
         internal Dictionary<long, List<HistoryPlacement>> HistoryPlacements { get; } = [];
@@ -106,9 +111,17 @@ internal sealed class KgpTerminalGraphicsState
         }
     }
 
-    private readonly ScreenState _main = new();
+    private readonly long _retainedBytesPerScreen;
+    private readonly ScreenState _main;
     private ScreenState? _alternate;
     private bool _alternateActive;
+
+    internal KgpTerminalGraphicsState(long retainedBytesPerScreen = 320L * 1024 * 1024)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(retainedBytesPerScreen);
+        _retainedBytesPerScreen = retainedBytesPerScreen;
+        _main = new ScreenState(retainedBytesPerScreen);
+    }
 
     private ScreenState Active
         => _alternateActive
@@ -554,11 +567,11 @@ internal sealed class KgpTerminalGraphicsState
         if (_alternateActive)
         {
             _alternate!.Clear();
-            _alternate = new ScreenState();
+            _alternate = new ScreenState(_retainedBytesPerScreen);
             return;
         }
 
-        _alternate = new ScreenState();
+        _alternate = new ScreenState(_retainedBytesPerScreen);
         _alternateActive = true;
     }
 

--- a/src/Hex1b/Sixel/SixelCompatibilityPolicy.cs
+++ b/src/Hex1b/Sixel/SixelCompatibilityPolicy.cs
@@ -313,14 +313,27 @@ internal sealed record SixelCompatibilityPolicy
     public long MaximumRasterOperations { get; init; } = 64L * 1024 * 1024;
 
     /// <summary>
-    /// Gets the maximum number of sparse tiles retained for a single graphic.
-    /// </summary>
-    public int MaximumRasterTiles { get; init; } = 4 * 1024;
-
-    /// <summary>
     /// Gets the edge length of a sparse raster tile.
     /// </summary>
     public int RasterTileSize { get; init; } = 64;
+
+    /// <summary>
+    /// Gets the maximum number of sparse tiles retained for a single graphic.
+    /// </summary>
+    /// <remarks>
+    /// Tiles contain up to <see cref="RasterTileSize"/> squared pixels in
+    /// row-major order. Deriving this value from the raster pixel limit keeps
+    /// the storage bound consistent for every permitted aspect ratio.
+    /// </remarks>
+    public int MaximumRasterTiles
+    {
+        get
+        {
+            var tilePixels = checked((long)RasterTileSize * RasterTileSize);
+            var required = ((MaximumRasterPixels - 1) / tilePixels) + 1;
+            return (int)Math.Min(required, int.MaxValue);
+        }
+    }
 
     /// <summary>Gets the maximum number of live placements retained per screen.</summary>
     public int MaximumPlacementsPerScreen { get; init; } = 4_096;
@@ -357,8 +370,14 @@ internal sealed record SixelCompatibilityPolicy
         }
         ArgumentOutOfRangeException.ThrowIfLessThan(MaximumRasterPixels, 1);
         ArgumentOutOfRangeException.ThrowIfLessThan(MaximumRasterOperations, 1);
-        ArgumentOutOfRangeException.ThrowIfLessThan(MaximumRasterTiles, 1);
         ArgumentOutOfRangeException.ThrowIfLessThan(RasterTileSize, 1);
+        if ((long)RasterTileSize * RasterTileSize > Array.MaxLength)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(RasterTileSize),
+                RasterTileSize,
+                "The raster tile must not exceed the maximum supported array length.");
+        }
         ArgumentOutOfRangeException.ThrowIfLessThan(MaximumPlacementsPerScreen, 1);
         ArgumentOutOfRangeException.ThrowIfLessThan(MaximumHistoryPlacements, 1);
         ArgumentOutOfRangeException.ThrowIfLessThan(MaximumImagesPerScreen, 1);

--- a/src/Hex1b/Sixel/SixelRasterImage.cs
+++ b/src/Hex1b/Sixel/SixelRasterImage.cs
@@ -7,9 +7,11 @@ namespace Hex1b.Sixel;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Painted pixels are stored in lazily allocated square tiles so a sequence that
-/// declares a very large transparent or background-filled canvas never allocates
-/// in proportion to its declared extent. Unpainted pixels resolve to
+/// Painted pixels are stored in lazily allocated row-major tiles so a sequence
+/// that declares a very large transparent or background-filled canvas never
+/// allocates in proportion to its declared extent. Each tile contains at most
+/// the policy's tile edge length squared pixels, including across row boundaries.
+/// Unpainted pixels resolve to
 /// <see cref="UnpaintedPixel"/>, which is the captured background for opaque
 /// graphics and transparent for <c>P2=1</c>.
 /// </para>
@@ -21,8 +23,7 @@ namespace Hex1b.Sixel;
 internal sealed class SixelRasterImage
 {
     private readonly Dictionary<long, Rgba32[]> _tiles = [];
-    private readonly int _tileSize;
-    private readonly int _tileColumns;
+    private readonly int _tilePixelCount;
     private readonly int _maximumTiles;
 
     public SixelRasterImage(int width, int height, Rgba32 unpaintedPixel, SixelCompatibilityPolicy policy)
@@ -33,8 +34,7 @@ internal sealed class SixelRasterImage
         Width = width;
         Height = height;
         UnpaintedPixel = unpaintedPixel;
-        _tileSize = policy.RasterTileSize;
-        _tileColumns = ((width - 1) / _tileSize) + 1;
+        _tilePixelCount = checked(policy.RasterTileSize * policy.RasterTileSize);
         _maximumTiles = policy.MaximumRasterTiles;
     }
 
@@ -80,7 +80,7 @@ internal sealed class SixelRasterImage
                 return UnpaintedPixel;
             }
 
-            var pixel = tile[((y % _tileSize) * _tileSize) + (x % _tileSize)];
+            var pixel = tile[TileOffset(x, y)];
             return pixel.A == 0 ? UnpaintedPixel : pixel;
         }
     }
@@ -104,11 +104,11 @@ internal sealed class SixelRasterImage
                 return false;
             }
 
-            tile = new Rgba32[_tileSize * _tileSize];
+            tile = new Rgba32[_tilePixelCount];
             _tiles[key] = tile;
         }
 
-        tile[((y % _tileSize) * _tileSize) + (x % _tileSize)] = color;
+        tile[TileOffset(x, y)] = color;
         return true;
     }
 
@@ -125,21 +125,14 @@ internal sealed class SixelRasterImage
 
         foreach (var (key, tile) in _tiles)
         {
-            var tileX = (int)(key % _tileColumns) * _tileSize;
-            var tileY = (int)(key / _tileColumns) * _tileSize;
-            var rows = Math.Min(_tileSize, Height - tileY);
-            var columns = Math.Min(_tileSize, Width - tileX);
-            for (var row = 0; row < rows; row++)
+            var destinationOffset = checked((int)(key * _tilePixelCount));
+            var count = Math.Min(tile.Length, pixels.Length - destinationOffset);
+            for (var index = 0; index < count; index++)
             {
-                var sourceOffset = row * _tileSize;
-                var destinationOffset = ((tileY + row) * Width) + tileX;
-                for (var column = 0; column < columns; column++)
+                var pixel = tile[index];
+                if (pixel.A != 0)
                 {
-                    var pixel = tile[sourceOffset + column];
-                    if (pixel.A != 0)
-                    {
-                        pixels[destinationOffset + column] = pixel;
-                    }
+                    pixels[destinationOffset + index] = pixel;
                 }
             }
         }
@@ -147,5 +140,9 @@ internal sealed class SixelRasterImage
         return new SixelPixelBuffer(Width, Height, pixels);
     }
 
-    private long TileKey(int x, int y) => ((long)(y / _tileSize) * _tileColumns) + (x / _tileSize);
+    private long PixelOffset(int x, int y) => ((long)y * Width) + x;
+
+    private long TileKey(int x, int y) => PixelOffset(x, y) / _tilePixelCount;
+
+    private int TileOffset(int x, int y) => (int)(PixelOffset(x, y) % _tilePixelCount);
 }

--- a/tests/Hex1b.Tests/Hex1bTerminalGraphicsOptionsTests.cs
+++ b/tests/Hex1b.Tests/Hex1bTerminalGraphicsOptionsTests.cs
@@ -47,6 +47,9 @@ public class Hex1bTerminalGraphicsOptionsTests
             nameof(Hex1bTerminalGraphicsOptions.MaximumRasterPixelsPerImage),
             options => options.MaximumRasterPixelsPerImage = 0);
         AssertInvalid(
+            nameof(Hex1bTerminalGraphicsOptions.MaximumRasterPixelsPerImage),
+            options => options.MaximumRasterPixelsPerImage = (long)int.MaxValue + 1);
+        AssertInvalid(
             nameof(Hex1bTerminalGraphicsOptions.MaximumRasterOperationsPerImage),
             options => options.MaximumRasterOperationsPerImage = 0);
         AssertInvalid(

--- a/tests/Hex1b.Tests/Hex1bTerminalGraphicsOptionsTests.cs
+++ b/tests/Hex1b.Tests/Hex1bTerminalGraphicsOptionsTests.cs
@@ -18,6 +18,25 @@ public class Hex1bTerminalGraphicsOptionsTests
             64L * 1024 * 1024,
             options.MaximumRetainedLogicalPixelsPerScreen);
         Assert.AreEqual(320L * 1024 * 1024, options.MaximumRetainedBytesPerScreen);
+
+        var policy = new Hex1bTerminalOptions().CreateSixelPolicy();
+        Assert.AreEqual(4_096, policy.MaximumRasterTiles);
+    }
+
+    [TestMethod]
+    public void MaximumRasterPixels_MaximumValue_DerivesTileCountWithoutOverflow()
+    {
+        var options = new Hex1bTerminalOptions
+        {
+            Graphics = new Hex1bTerminalGraphicsOptions
+            {
+                MaximumRasterPixelsPerImage = int.MaxValue,
+            },
+        };
+
+        var policy = options.CreateSixelPolicy();
+
+        Assert.AreEqual(524_288, policy.MaximumRasterTiles);
     }
 
     [TestMethod]
@@ -96,6 +115,48 @@ public class Hex1bTerminalGraphicsOptionsTests
             {
                 MaximumRetainedInputBytesPerImage = 0,
                 MaximumRetainedBytesPerScreen = 0,
+            },
+        });
+    }
+
+    [TestMethod]
+    public void Construction_ConflictingInternalAndPublicLimits_Throws()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        var options = new Hex1bTerminalOptions
+        {
+            WorkloadAdapter = workload,
+            SixelPolicy = global::Hex1b.Sixel.SixelCompatibilityPolicy.Default with
+            {
+                MaximumImagesPerScreen = 1,
+            },
+        };
+
+        var exception = Assert.ThrowsExactly<InvalidOperationException>(
+            () => new Hex1bTerminal(options));
+
+        StringAssert.Contains(
+            exception.Message,
+            nameof(global::Hex1b.Sixel.SixelCompatibilityPolicy.MaximumImagesPerScreen));
+        StringAssert.Contains(
+            exception.Message,
+            nameof(Hex1bTerminalGraphicsOptions.MaximumImagesPerScreen));
+    }
+
+    [TestMethod]
+    public void Construction_MatchingInternalAndPublicLimits_IsAllowed()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = new Hex1bTerminal(new Hex1bTerminalOptions
+        {
+            WorkloadAdapter = workload,
+            SixelPolicy = global::Hex1b.Sixel.SixelCompatibilityPolicy.Default with
+            {
+                MaximumImagesPerScreen = 1,
+            },
+            Graphics = new Hex1bTerminalGraphicsOptions
+            {
+                MaximumImagesPerScreen = 1,
             },
         });
     }

--- a/tests/Hex1b.Tests/Hex1bTerminalGraphicsOptionsTests.cs
+++ b/tests/Hex1b.Tests/Hex1bTerminalGraphicsOptionsTests.cs
@@ -1,0 +1,144 @@
+namespace Hex1b.Tests;
+
+[TestClass]
+public class Hex1bTerminalGraphicsOptionsTests
+{
+    [TestMethod]
+    public void Defaults_PreserveExistingGraphicsLimits()
+    {
+        var options = new Hex1bTerminalGraphicsOptions();
+
+        Assert.AreEqual(1024 * 1024, options.MaximumRetainedInputBytesPerImage);
+        Assert.AreEqual(16L * 1024 * 1024, options.MaximumRasterPixelsPerImage);
+        Assert.AreEqual(64L * 1024 * 1024, options.MaximumRasterOperationsPerImage);
+        Assert.AreEqual(1_024, options.MaximumImagesPerScreen);
+        Assert.AreEqual(4_096, options.MaximumPlacementsPerScreen);
+        Assert.AreEqual(4_096, options.MaximumHistoryPlacements);
+        Assert.AreEqual(
+            64L * 1024 * 1024,
+            options.MaximumRetainedLogicalPixelsPerScreen);
+        Assert.AreEqual(320L * 1024 * 1024, options.MaximumRetainedBytesPerScreen);
+    }
+
+    [TestMethod]
+    public void PublicApi_IsAccessibleFromTerminalOptionsAndBuilder()
+    {
+        Assert.IsTrue(typeof(Hex1bTerminalGraphicsOptions).IsPublic);
+        Assert.IsTrue(
+            typeof(Hex1bTerminalOptions)
+                .GetProperty(nameof(Hex1bTerminalOptions.Graphics))!
+                .GetMethod!
+                .IsPublic);
+        Assert.IsTrue(
+            typeof(Hex1bTerminalBuilder)
+                .GetMethod(
+                    nameof(Hex1bTerminalBuilder.WithGraphics),
+                    [typeof(Action<Hex1bTerminalGraphicsOptions>)])!
+                .IsPublic);
+    }
+
+    [TestMethod]
+    public void Construction_InvalidGraphicsValues_ThrowsPreciseExceptions()
+    {
+        AssertInvalid(
+            nameof(Hex1bTerminalGraphicsOptions.MaximumRetainedInputBytesPerImage),
+            options => options.MaximumRetainedInputBytesPerImage = -1);
+        AssertInvalid(
+            nameof(Hex1bTerminalGraphicsOptions.MaximumRasterPixelsPerImage),
+            options => options.MaximumRasterPixelsPerImage = 0);
+        AssertInvalid(
+            nameof(Hex1bTerminalGraphicsOptions.MaximumRasterOperationsPerImage),
+            options => options.MaximumRasterOperationsPerImage = 0);
+        AssertInvalid(
+            nameof(Hex1bTerminalGraphicsOptions.MaximumImagesPerScreen),
+            options => options.MaximumImagesPerScreen = 0);
+        AssertInvalid(
+            nameof(Hex1bTerminalGraphicsOptions.MaximumPlacementsPerScreen),
+            options => options.MaximumPlacementsPerScreen = 0);
+        AssertInvalid(
+            nameof(Hex1bTerminalGraphicsOptions.MaximumHistoryPlacements),
+            options => options.MaximumHistoryPlacements = 0);
+        AssertInvalid(
+            nameof(Hex1bTerminalGraphicsOptions.MaximumRetainedLogicalPixelsPerScreen),
+            options => options.MaximumRetainedLogicalPixelsPerScreen = 0);
+        AssertInvalid(
+            nameof(Hex1bTerminalGraphicsOptions.MaximumRetainedBytesPerScreen),
+            options => options.MaximumRetainedBytesPerScreen = -1);
+    }
+
+    [TestMethod]
+    public void Construction_NullGraphicsOptions_ThrowsPreciseException()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        var options = new Hex1bTerminalOptions
+        {
+            WorkloadAdapter = workload,
+            Graphics = null!,
+        };
+
+        var exception = Assert.ThrowsExactly<ArgumentNullException>(
+            () => new Hex1bTerminal(options));
+
+        Assert.AreEqual(nameof(Hex1bTerminalOptions.Graphics), exception.ParamName);
+    }
+
+    [TestMethod]
+    public void Construction_ZeroByteBudgets_AreAllowed()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = new Hex1bTerminal(new Hex1bTerminalOptions
+        {
+            WorkloadAdapter = workload,
+            Graphics = new Hex1bTerminalGraphicsOptions
+            {
+                MaximumRetainedInputBytesPerImage = 0,
+                MaximumRetainedBytesPerScreen = 0,
+            },
+        });
+    }
+
+    [TestMethod]
+    public void Builder_NullGraphicsConfiguration_Throws()
+    {
+        var builder = Hex1bTerminal.CreateBuilder();
+
+        Assert.ThrowsExactly<ArgumentNullException>(
+            () => builder.WithGraphics(null!));
+    }
+
+    [TestMethod]
+    public void Builder_InvalidGraphicsConfiguration_ThrowsDuringBuild()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        var builder = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(workload)
+            .WithHeadless()
+            .WithGraphics(options => options.MaximumImagesPerScreen = 0);
+
+        var exception = Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+            () => builder.Build());
+
+        Assert.AreEqual(
+            nameof(Hex1bTerminalGraphicsOptions.MaximumImagesPerScreen),
+            exception.ParamName);
+    }
+
+    private static void AssertInvalid(
+        string expectedParameterName,
+        Action<Hex1bTerminalGraphicsOptions> configure)
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        var graphics = new Hex1bTerminalGraphicsOptions();
+        configure(graphics);
+        var options = new Hex1bTerminalOptions
+        {
+            WorkloadAdapter = workload,
+            Graphics = graphics,
+        };
+
+        var exception = Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+            () => new Hex1bTerminal(options));
+
+        Assert.AreEqual(expectedParameterName, exception.ParamName);
+    }
+}

--- a/tests/Hex1b.Tests/KgpTerminalTests.cs
+++ b/tests/Hex1b.Tests/KgpTerminalTests.cs
@@ -16,13 +16,16 @@ public class KgpTerminalTests
     private static Hex1bTerminal CreateTerminal(
         IHex1bTerminalWorkloadAdapter workload,
         int width = 80,
-        int height = 24)
+        int height = 24,
+        Action<Hex1bTerminalGraphicsOptions>? configureGraphics = null)
     {
-        return Hex1bTerminal.CreateBuilder()
+        var builder = Hex1bTerminal.CreateBuilder()
             .WithWorkload(workload)
             .WithHeadless(KgpCapabilities)
-            .WithDimensions(width, height)
-            .Build();
+            .WithDimensions(width, height);
+        if (configureGraphics is not null)
+            builder.WithGraphics(configureGraphics);
+        return builder.Build();
     }
 
     private static void SendKgp(Hex1bTerminal terminal, string escapeSequence)
@@ -60,6 +63,44 @@ public class KgpTerminalTests
         Assert.AreEqual(2u, image.Width);
         Assert.AreEqual(2u, image.Height);
         Assert.AreEqual(KgpFormat.Rgba32, image.Format);
+    }
+
+    [TestMethod]
+    public void RetainedByteLimit_AppliesToMainAlternateAndRecreatedStores()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(
+            workload,
+            configureGraphics: options =>
+                options.MaximumRetainedBytesPerScreen = 4);
+
+        SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(1, 1, 1, fillByte: 0x11));
+        SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(2, 1, 1, fillByte: 0x22));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(1));
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(2));
+
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[?1049h"));
+        SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(3, 1, 1, fillByte: 0x33));
+        SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(4, 1, 1, fillByte: 0x44));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(3));
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(4));
+
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[?1049l"));
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(2));
+
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[?1049h"));
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(5, 1, 1, fillByte: 0x55));
+        SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(6, 1, 1, fillByte: 0x66));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(5));
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(6));
+
+        terminal.ApplyTokens([RisToken.Instance]);
+        Assert.AreEqual(0, terminal.KgpImageStore.ImageCount);
+        SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(7, 1, 1, fillByte: 0x77));
+        SendKgp(terminal, KgpTestHelper.BuildTransmitCommand(8, 1, 1, fillByte: 0x88));
+        Assert.IsNull(terminal.KgpImageStore.GetImageById(7));
+        Assert.IsNotNull(terminal.KgpImageStore.GetImageById(8));
     }
 
     [TestMethod]

--- a/tests/Hex1b.Tests/Sixel/SixelFramingTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelFramingTests.cs
@@ -378,12 +378,13 @@ public class SixelFramingTests
     [TestMethod]
     public async Task PreTokenizedOutput_OverRetentionLimit_RetainsGeometryOnlyState()
     {
-        var policy = SixelCompatibilityPolicy.Default with
+        var graphics = new Hex1bTerminalGraphicsOptions
         {
-            MaximumRetainedDcsBytes = 16,
+            MaximumRetainedInputBytesPerImage = 16,
         };
-        await using var terminal = SixelTestTerminal.Create(policy: policy);
-        var payload = $"7q{new string('~', policy.MaximumRetainedDcsBytes + 8)}";
+        await using var terminal = SixelTestTerminal.Create(graphics: graphics);
+        var payload =
+            $"7q{new string('~', graphics.MaximumRetainedInputBytesPerImage + 8)}";
         var bytes = Encoding.ASCII.GetBytes($"\x1bP{payload}\x1b\\");
 
         await terminal.FeedPreTokenizedAsync(
@@ -400,7 +401,9 @@ public class SixelFramingTests
         Assert.AreEqual(SixelParseOutcome.LimitDowngraded, placement.Image.Outcome);
         Assert.IsTrue(placement.Image.Diagnostics.Any(
             diagnostic => diagnostic.Code == SixelDiagnosticCode.RetainedContentLimitExceeded));
-        Assert.AreEqual(policy.MaximumRetainedDcsBytes, placement.Image.Payload.Length);
+        Assert.AreEqual(
+            graphics.MaximumRetainedInputBytesPerImage,
+            placement.Image.Payload.Length);
         TestSeq.AreEqual(bytes, terminal.PresentationBytes);
     }
 

--- a/tests/Hex1b.Tests/Sixel/SixelHardeningFuzzTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelHardeningFuzzTests.cs
@@ -57,6 +57,14 @@ public class SixelHardeningFuzzTests
                 6,
                 new TerminalCapabilities { SupportsSixel = true }),
             SixelPolicy = policy,
+            Graphics = new Hex1bTerminalGraphicsOptions
+            {
+                MaximumPlacementsPerScreen = policy.MaximumPlacementsPerScreen,
+                MaximumHistoryPlacements = policy.MaximumHistoryPlacements,
+                MaximumImagesPerScreen = policy.MaximumImagesPerScreen,
+                MaximumRetainedLogicalPixelsPerScreen =
+                    policy.MaximumRetainedLogicalPixelsPerScreen,
+            },
         });
 
         for (var iteration = 0; iteration < 100; iteration++)

--- a/tests/Hex1b.Tests/Sixel/SixelHardeningFuzzTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelHardeningFuzzTests.cs
@@ -46,6 +46,7 @@ public class SixelHardeningFuzzTests
             MaximumImagesPerScreen = 8,
             MaximumRetainedLogicalPixelsPerScreen = 16 * 1024,
         };
+        var graphics = CreateGraphicsOptions(policy);
         using var terminal = new Hex1bTerminal(new Hex1bTerminalOptions
         {
             Width = 12,
@@ -57,14 +58,7 @@ public class SixelHardeningFuzzTests
                 6,
                 new TerminalCapabilities { SupportsSixel = true }),
             SixelPolicy = policy,
-            Graphics = new Hex1bTerminalGraphicsOptions
-            {
-                MaximumPlacementsPerScreen = policy.MaximumPlacementsPerScreen,
-                MaximumHistoryPlacements = policy.MaximumHistoryPlacements,
-                MaximumImagesPerScreen = policy.MaximumImagesPerScreen,
-                MaximumRetainedLogicalPixelsPerScreen =
-                    policy.MaximumRetainedLogicalPixelsPerScreen,
-            },
+            Graphics = graphics,
         });
 
         for (var iteration = 0; iteration < 100; iteration++)
@@ -112,8 +106,20 @@ public class SixelHardeningFuzzTests
                                 terminal.Height,
                                 new TerminalCapabilities { SupportsSixel = true }),
                             SixelPolicy = policy,
+                            Graphics = graphics,
                         });
                         decoded.ReplayInto(viewer);
+                        Assert.IsLessThanOrEqualTo(
+                            graphics.MaximumPlacementsPerScreen,
+                            viewer.SixelPlacementCount);
+                        Assert.IsLessThanOrEqualTo(
+                            graphics.MaximumImagesPerScreen,
+                            viewer.TrackedSixelCount);
+                        using var viewerSnapshot = viewer.CreateSnapshot();
+                        Assert.IsLessThanOrEqualTo(
+                            graphics.MaximumPlacementsPerScreen +
+                                graphics.MaximumHistoryPlacements,
+                            viewerSnapshot.SixelPlacements.Count);
                     }
                     break;
             }
@@ -126,6 +132,19 @@ public class SixelHardeningFuzzTests
                 current.SixelPlacements.Count);
         }
     }
+
+    private static Hex1bTerminalGraphicsOptions CreateGraphicsOptions(
+        SixelCompatibilityPolicy policy) => new()
+    {
+        MaximumRetainedInputBytesPerImage = policy.MaximumRetainedDcsBytes,
+        MaximumRasterPixelsPerImage = policy.MaximumRasterPixels,
+        MaximumRasterOperationsPerImage = policy.MaximumRasterOperations,
+        MaximumImagesPerScreen = policy.MaximumImagesPerScreen,
+        MaximumPlacementsPerScreen = policy.MaximumPlacementsPerScreen,
+        MaximumHistoryPlacements = policy.MaximumHistoryPlacements,
+        MaximumRetainedLogicalPixelsPerScreen =
+            policy.MaximumRetainedLogicalPixelsPerScreen,
+    };
 
     public static TheoryData<int> StableSeeds()
     {

--- a/tests/Hex1b.Tests/Sixel/SixelPlacementLifetimeTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelPlacementLifetimeTests.cs
@@ -221,6 +221,76 @@ public class SixelPlacementLifetimeTests
     }
 
     [TestMethod]
+    public async Task PublicLimits_ApplyAcrossAlternateScreenRecreationAndReset()
+    {
+        var graphics = new Hex1bTerminalGraphicsOptions
+        {
+            MaximumPlacementsPerScreen = 1,
+            MaximumImagesPerScreen = 1,
+        };
+        await using var terminal = SixelTestTerminal.Create(graphics: graphics);
+        var red = Encoding.ASCII.GetBytes("\x1bPq#1;2;100;0;0#1@\x1b\\");
+        var green = Encoding.ASCII.GetBytes("\x1b[2;1H\x1bPq#2;2;0;100;0#2A\x1b\\");
+
+        await terminal.FeedAsync(
+            red.Concat(green).Concat("M"u8.ToArray()).ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsText("M"),
+            "bounded main-screen graphics",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(1, terminal.Terminal.SixelPlacementCount);
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[?1049h")
+                .Concat(red)
+                .Concat(green)
+                .Concat("A"u8.ToArray())
+                .ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.InAlternateScreen && snapshot.ContainsText("A"),
+            "bounded alternate-screen graphics",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(1, terminal.Terminal.SixelPlacementCount);
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[?1049h")
+                .Concat(red)
+                .Concat(green)
+                .Concat("R"u8.ToArray())
+                .ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.InAlternateScreen && snapshot.ContainsText("R"),
+            "bounded recreated alternate-screen graphics",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(1, terminal.Terminal.SixelPlacementCount);
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[?1049l"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => !snapshot.InAlternateScreen,
+            "return to bounded main-screen graphics",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(1, terminal.Terminal.SixelPlacementCount);
+
+        await terminal.FeedPreTokenizedAsync(
+            Encoding.ASCII.GetBytes("\x1b" + "c"),
+            [RisToken.Instance],
+            TestContext.Current.CancellationToken);
+        await terminal.FeedAsync(
+            red.Concat(green).Concat("Z"u8.ToArray()).ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => !snapshot.InAlternateScreen && snapshot.ContainsText("Z"),
+            "bounded graphics after reset",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(1, terminal.Terminal.SixelPlacementCount);
+    }
+
+    [TestMethod]
     public async Task OriginCellOverwrittenWithText_DamagesOnlyTheOverwrittenCell()
     {
         var wide = new SixelFixture(

--- a/tests/Hex1b.Tests/Sixel/SixelPlacementLifetimeTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelPlacementLifetimeTests.cs
@@ -131,12 +131,12 @@ public class SixelPlacementLifetimeTests
     [TestMethod]
     public async Task PlacementLimit_EvictsOldestPlacementAndReleasesItsImage()
     {
-        var policy = SixelCompatibilityPolicy.Default with
+        var graphics = new Hex1bTerminalGraphicsOptions
         {
             MaximumPlacementsPerScreen = 2,
             MaximumImagesPerScreen = 2,
         };
-        await using var terminal = SixelTestTerminal.Create(policy: policy);
+        await using var terminal = SixelTestTerminal.Create(graphics: graphics);
         var red = Encoding.ASCII.GetBytes("\x1bPq#1;2;100;0;0#1@\x1b\\");
         var green = Encoding.ASCII.GetBytes("\x1bPq#2;2;0;100;0#2A\x1b\\");
         var blue = Encoding.ASCII.GetBytes("\x1bPq#3;2;0;0;100#3B\x1b\\");
@@ -165,13 +165,13 @@ public class SixelPlacementLifetimeTests
     [TestMethod]
     public async Task ImageAndAggregateAreaLimits_EvictOldestPlacementDeterministically()
     {
-        var policy = SixelCompatibilityPolicy.Default with
+        var graphics = new Hex1bTerminalGraphicsOptions
         {
             MaximumPlacementsPerScreen = 8,
             MaximumImagesPerScreen = 1,
             MaximumRetainedLogicalPixelsPerScreen = 12,
         };
-        await using var terminal = SixelTestTerminal.Create(policy: policy);
+        await using var terminal = SixelTestTerminal.Create(graphics: graphics);
         var red = Encoding.ASCII.GetBytes("\x1bPq#1;2;100;0;0#1@\x1b\\");
         var green = Encoding.ASCII.GetBytes("\x1b[2;1H\x1bPq#2;2;0;100;0#2A\x1b\\Z");
 
@@ -191,7 +191,7 @@ public class SixelPlacementLifetimeTests
     [TestMethod]
     public async Task HistoryLimit_EvictsOldestHistoryFragment()
     {
-        var policy = SixelCompatibilityPolicy.Default with
+        var graphics = new Hex1bTerminalGraphicsOptions
         {
             MaximumHistoryPlacements = 1,
         };
@@ -199,7 +199,7 @@ public class SixelPlacementLifetimeTests
             width: 4,
             height: 2,
             scrollbackCapacity: 4,
-            policy: policy);
+            graphics: graphics);
         var first = Encoding.ASCII.GetBytes("\x1b[1;1H\x1bPq#1;2;100;0;0#1@\x1b\\");
         var second = Encoding.ASCII.GetBytes("\x1b[2;1H\n\x1b[1;1H\x1bPq#2;2;0;100;0#2A\x1b\\");
         var scrollAgain = Encoding.ASCII.GetBytes("\x1b[2;1H\n");
@@ -212,7 +212,9 @@ public class SixelPlacementLifetimeTests
             "two history scrolls",
             TestContext.Current.CancellationToken);
 
-        Assert.AreEqual(policy.MaximumHistoryPlacements, terminal.Terminal.SixelHistoryPlacementCount);
+        Assert.AreEqual(
+            graphics.MaximumHistoryPlacements,
+            terminal.Terminal.SixelHistoryPlacementCount);
         using var snapshot = terminal.Terminal.CreateSnapshot(scrollbackLines: 4);
         Assert.IsFalse(snapshot.SixelPlacements.Any(
             placement => placement.Image.Payload.Contains("100;0;0", StringComparison.Ordinal)));

--- a/tests/Hex1b.Tests/Sixel/SixelRasterizerTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelRasterizerTests.cs
@@ -791,23 +791,37 @@ public class SixelRasterizerTests
     }
 
     [TestMethod]
-    public void SparseTileBudget_ReturnsGeometryOnlyInsteadOfAPartialRaster()
+    public void PublicPixelLimit_NonAlignedDenseSquare_DoesNotExhaustTileBudget()
     {
-        var policy = SixelCompatibilityPolicy.Default with
+        var options = new Hex1bTerminalOptions
         {
-            MaximumRasterTiles = 1,
+            Graphics = new Hex1bTerminalGraphicsOptions
+            {
+                MaximumRasterPixelsPerImage = 1_000_000,
+                MaximumRasterOperationsPerImage = 1_000_000,
+            },
         };
+        var policy = options.CreateSixelPolicy();
+        var payload = new StringBuilder("0;1q\"1;1;1000;1000");
+        for (var band = 0; band < 166; band++)
+            payload.Append("!1000~-");
+
         var result = SixelRasterizer.Rasterize(
-            SixelParser.ParsePayload("7;1q!65~"),
+            SixelParser.ParsePayload(payload.ToString()),
             new SixelRasterEnvironment(
                 policy.DefaultBackground,
                 new SixelColorRegisters(policy),
                 policy));
 
-        Assert.AreEqual(SixelRasterStatus.GeometryOnly, result.Status);
-        Assert.IsNull(result.Image);
-        Assert.AreEqual(new SixelExtent(65, 6), result.Extents.Logical);
-        Assert.IsTrue(result.Diagnostics.Any(
+        Assert.AreEqual(
+            SixelRasterStatus.Rasterized,
+            result.Status,
+            string.Join(Environment.NewLine, result.Diagnostics.Select(item => item.Message)));
+        Assert.IsNotNull(result.Image);
+        Assert.AreEqual(1_000_000L, result.Image.PixelCount);
+        Assert.AreEqual(244, result.Image.AllocatedTileCount);
+        Assert.AreEqual(245, policy.MaximumRasterTiles);
+        Assert.IsFalse(result.Diagnostics.Any(
             item => item.Code == SixelRasterDiagnosticCode.RasterTileLimitExceeded));
     }
 

--- a/tests/Hex1b.Tests/Sixel/SixelTestTerminal.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelTestTerminal.cs
@@ -30,7 +30,8 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
         IHex1bTerminalPresentationFilter? presentationFilter,
         bool impactAware,
         SixelCellMetrics? cellMetrics,
-        SixelCompatibilityPolicy? policy)
+        SixelCompatibilityPolicy? policy,
+        Hex1bTerminalGraphicsOptions? graphics)
     {
         var capabilities = new TerminalCapabilities
         {
@@ -54,6 +55,7 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
             ScrollbackCapacity = scrollbackCapacity > 0 ? scrollbackCapacity : null,
             Metrics = metrics,
             SixelPolicy = policy ?? SixelCompatibilityPolicy.Default,
+            Graphics = graphics ?? CreateGraphicsOptions(policy),
         };
         if (workloadFilter is not null)
         {
@@ -97,7 +99,8 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
         IHex1bTerminalPresentationFilter? presentationFilter = null,
         bool impactAware = false,
         SixelCellMetrics? cellMetrics = null,
-        SixelCompatibilityPolicy? policy = null)
+        SixelCompatibilityPolicy? policy = null,
+        Hex1bTerminalGraphicsOptions? graphics = null)
         => new(
             width,
             height,
@@ -111,7 +114,25 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
             presentationFilter,
             impactAware,
             cellMetrics,
-            policy);
+            policy,
+            graphics);
+
+    private static Hex1bTerminalGraphicsOptions CreateGraphicsOptions(
+        SixelCompatibilityPolicy? policy)
+    {
+        policy ??= SixelCompatibilityPolicy.Default;
+        return new Hex1bTerminalGraphicsOptions
+        {
+            MaximumRetainedInputBytesPerImage = policy.MaximumRetainedDcsBytes,
+            MaximumRasterPixelsPerImage = policy.MaximumRasterPixels,
+            MaximumRasterOperationsPerImage = policy.MaximumRasterOperations,
+            MaximumImagesPerScreen = policy.MaximumImagesPerScreen,
+            MaximumPlacementsPerScreen = policy.MaximumPlacementsPerScreen,
+            MaximumHistoryPlacements = policy.MaximumHistoryPlacements,
+            MaximumRetainedLogicalPixelsPerScreen =
+                policy.MaximumRetainedLogicalPixelsPerScreen,
+        };
+    }
 
     public async Task FeedAsync(
         ReadOnlyMemory<byte> bytes,


### PR DESCRIPTION
## Summary

- add public, protocol-neutral `Hex1bTerminalGraphicsOptions` on `Hex1bTerminalOptions`
- add `Hex1bTerminalBuilder.WithGraphics(...)` for fluent configuration
- preserve existing Sixel and KGP defaults while validating invalid values during terminal construction
- apply Sixel input, raster, image, placement, history, and logical-pixel limits through the internal compatibility policy
- apply the retained-byte budget to KGP root images and animation frames on independent main/alternate screen stores
- preserve configured limits through alternate-screen recreation, RIS reset, and disposal cleanup
- keep Sixel parser-shape controls and HMP1 recording/replay/wire budgets internal
- expose `MaximumRetainedBytesPerScreen` for the aggregate Sixel accounting follow-up in #478 without implementing that accounting here

## Review repairs

- changed Sixel sparse raster storage to row-major tiles of `RasterTileSize²` pixels, so `MaximumRasterTiles = ceil(MaximumRasterPixels / tilePixels)` is a true invariant for every aspect ratio rather than a square-grid estimate
- preserved the exact default of **4,096** raster tiles and added overflow/maximum-value coverage
- added a regression for a logical **1000×1000** raster at a **1,000,000-pixel** public limit; it rasterizes successfully with no tile-limit diagnostic
- added deterministic conflict validation when a non-default internal `SixelCompatibilityPolicy` resource value disagrees with the corresponding public `Graphics` value; matching bridged values remain supported for internal tests
- wired the tightened graphics limits into both the fuzz corpus terminal and its HMP1 replay viewer, with viewer-side bound assertions

## Public limits

| Limit | Default | Current use |
|---|---:|---|
| `MaximumRetainedInputBytesPerImage` | 1 MiB | retained Sixel input |
| `MaximumRasterPixelsPerImage` | 16,777,216 | Sixel per-image raster area |
| `MaximumRasterOperationsPerImage` | 67,108,864 | Sixel raster work |
| `MaximumImagesPerScreen` | 1,024 | Sixel distinct images |
| `MaximumPlacementsPerScreen` | 4,096 | Sixel live placements |
| `MaximumHistoryPlacements` | 4,096 | Sixel scrollback fragments |
| `MaximumRetainedLogicalPixelsPerScreen` | 67,108,864 | Sixel aggregate logical area |
| `MaximumRetainedBytesPerScreen` | 335,544,320 | KGP image/frame bytes; reserved for #478 Sixel accounting |

Parser parameter counts, numeric grammar bounds, retained diagnostic/command counts, KGP parent depth/frame-count protocol guards, and HMP1 limits remain internal.

## Validation

- focused review regressions: **15 passed**
- Sixel/KGP/HMP1 and graphics options: **1,769 passed**
- `Hex1b.Tests`: **9,174 total; 9,150 passed; 24 skipped; 0 failed**
- `Hex1b.Analyzers.Tests`: **67 passed**
- `Hex1b.McpServer.Tests`: **6 passed**
- `Hex1b.Tool.Tests`: **58 passed**
- `AgenticPromptDemo.Tests`: **18 passed**
- CI-equivalent builds passed for all test projects and `Hex1b.Tool`
- benchmark project Release build passed; two pre-existing nullable warnings remain in `SurfaceBenchmarks.cs`
- API reference generation passed
- `aspire do build-content`: **13/13 steps passed**
- two independent API/correctness reviews of the repairs found no blocking defects

## Benchmarks

BenchmarkDotNet ShortRun on .NET 10.0.9, Apple M5 Max:

| Benchmark | Mean | Allocated |
|---|---:|---:|
| `RawPassthroughWithSixelObservation` | 34.47 us | 22.57 KB |
| `PlacementDamageScrollResizeLifecycle` | 263.72 us | 939.78 KB |

## Fresh GitHub CI

Workflow run `34069070564` completed successfully for head `ded7e0ef9e8ebbc3d85e5745fc940a34f88f7e81`:

- Linux and macOS native builds: **4 passed**
- Windows PTY host builds: **2 passed**
- `test (ubuntu-latest)`: **passed** in 9m9s
- `test (windows-latest)`: **passed** in 7m49s
- `build-pr`: **passed** in 1m8s
- `publish-pr`: **passed** in 23s
- release and production-only jobs: **skipped as expected**

Closes #475