### PR TITLE
Bound Sixel retained memory per screen

### DIFF
--- a/docs/sixel-terminal-behavior.md
+++ b/docs/sixel-terminal-behavior.md
@@ -110,21 +110,21 @@ rasterizer, placement-lifetime, and fuzz tests.
 `Hex1bTerminalGraphicsOptions.MaximumRetainedBytesPerScreen` configures the
 aggregate retained-image budget independently for the main and alternate
 screens. Accounting is deterministic protocol content accounting, not a CLR
-heap-size estimate: UTF-8 payload bytes, content identities, parsed commands,
+heap-size estimate: retained UTF-16 strings, content identities, parsed commands,
 palette and diagnostic metadata, captured palette state, sparse tile pixels
 and keys, raster diagnostics, and a cached dense RGBA buffer are included.
 Placements and history fragments remain governed by their count limits and do
 not cause a shared image to be counted more than once.
 
-When admitting a new distinct image would exceed the byte budget, the terminal
-evicts oldest placements until enough image resources become unreachable. An
-image larger than the entire budget is rejected without evicting existing
-content. Lazy sparse-raster or dense-cache growth protects the image being
-materialized and evicts older unrelated placements first. If the protected
-image still cannot fit, the requested pixels are produced without attaching
-the new cache to live terminal state; accounting and existing placements remain
-unchanged. Clearing, history pruning, alternate-screen exit, RIS, reflow, and
-terminal disposal sweep unreachable images and their accounting together.
+The byte ceiling is shared with KGP rather than duplicated per protocol. Each
+protocol applies its established oldest-first eviction order to its own
+resources. A new Sixel or KGP image that still cannot fit in the capacity left
+by the other protocol is rejected without destroying the other protocol's
+placements. Lazy Sixel sparse-raster or dense-cache growth is observational:
+if it cannot fit, the requested raster or pixels are returned uncached and no
+live placement is evicted. Clearing, history pruning, alternate-screen exit,
+RIS, reflow, and terminal disposal sweep unreachable images and their
+accounting together.
 
 Snapshots copy placements but intentionally share immutable `SixelData`
 resources. A caller-retained snapshot can therefore extend an evicted image's

--- a/docs/sixel-terminal-behavior.md
+++ b/docs/sixel-terminal-behavior.md
@@ -104,7 +104,31 @@ rasterizer, placement-lifetime, and fuzz tests.
 | History placement fragments | 4,096 | Evict oldest history fragments first |
 | Distinct images per screen | 1,024 | Evict oldest reachable placements until the image set is bounded |
 | Aggregate retained raster-capable area | 64 Mi logical pixels | Evict oldest placements; each image contributes at most the per-image raster limit |
+| Aggregate retained image data per screen | 320 MiB | Count each distinct image once; evict oldest reachable placements until payload, parsed metadata, sparse tiles, and cached dense pixels fit |
 | Embedded Sixel data per SVG/HTML export | 64 MiB by default | `TerminalSvgOptions.MaximumEmbeddedSixelBytes` replaces later raster placements with deterministic diagnostic placeholders |
+
+`Hex1bTerminalGraphicsOptions.MaximumRetainedBytesPerScreen` configures the
+aggregate retained-image budget independently for the main and alternate
+screens. Accounting is deterministic protocol content accounting, not a CLR
+heap-size estimate: UTF-8 payload bytes, content identities, parsed commands,
+palette and diagnostic metadata, captured palette state, sparse tile pixels
+and keys, raster diagnostics, and a cached dense RGBA buffer are included.
+Placements and history fragments remain governed by their count limits and do
+not cause a shared image to be counted more than once.
+
+When admitting a new distinct image would exceed the byte budget, the terminal
+evicts oldest placements until enough image resources become unreachable. An
+image larger than the entire budget is rejected without evicting existing
+content. Lazy sparse-raster or dense-cache growth protects the image being
+materialized and evicts older unrelated placements first. If the protected
+image still cannot fit, the requested pixels are produced without attaching
+the new cache to live terminal state; accounting and existing placements remain
+unchanged. Clearing, history pruning, alternate-screen exit, RIS, reflow, and
+terminal disposal sweep unreachable images and their accounting together.
+
+Snapshots copy placements but intentionally share immutable `SixelData`
+resources. A caller-retained snapshot can therefore extend an evicted image's
+payload, raster, or pixel-cache lifetime outside the live terminal budget.
 
 The parser exposes typed outcomes (`Complete`, `LimitDowngraded`, `Cancelled`,
 `Malformed`, and `Rejected`) and bounded diagnostic codes for malformed,
@@ -121,10 +145,11 @@ The `Hex1b` meter exposes constant-cardinality operational measurements:
 - `hex1b.terminal.sixel.resources` (`action`, optional `reason`)
 - `hex1b.terminal.sixel.limit` (`limit`)
 
-Resource actions are allocation, deduplication, release, placement creation,
-damage, and eviction. Eviction reasons distinguish history pruning, scrolling,
-line edits, viewport clipping, reflow, and the `history_limit`,
-`placement_limit`, `image_limit`, and `logical_pixel_limit` policy limits.
+Resource actions are allocation, deduplication, rejection, release, placement
+creation, damage, and eviction. Eviction reasons distinguish history pruning,
+scrolling, line edits, viewport clipping, reflow, and the `history_limit`,
+`placement_limit`, `image_limit`, `logical_pixel_limit`, and
+`retained_byte_limit` policy limits.
 Existing DCS byte, dispatch, cancellation, malformed-recovery, and
 retention-limit instruments remain the framing-level source of truth.
 

--- a/src/Hex1b/Automation/Hex1bTerminalSnapshot.cs
+++ b/src/Hex1b/Automation/Hex1bTerminalSnapshot.cs
@@ -267,6 +267,10 @@ public sealed class Hex1bTerminalSnapshot : IHex1bTerminalRegion, IDisposable
     /// per compatible resource identity, never once per covered cell. Two
     /// placements share a <see cref="SixelData"/> instance only when their
     /// payload, raster state, protocol metrics, and cell span are all equal.
+    /// Snapshot image references are ordinary caller-owned references: keeping a
+    /// snapshot alive can retain payload, sparse raster, or dense pixel data after
+    /// the live terminal has evicted that image, outside the terminal's per-screen
+    /// retained-byte budget.
     /// </remarks>
     public IReadOnlyDictionary<byte[], SixelData> SixelImages { get; }
 

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -341,7 +341,9 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         _sixelColorRegisters = new Sixel.SixelColorRegisters(sixelPolicy);
         _sixelGraphicsState = new SixelGraphicsState(
             sixelPolicy,
-            RecordSixelStateEvent);
+            RecordSixelStateEvent,
+            options.Graphics.MaximumRetainedBytesPerScreen,
+            _bufferLock);
         
         // Notify lifecycle-aware presentation adapters that the terminal is created
         if (presentation is ITerminalLifecycleAwarePresentationAdapter lifecycleAdapter)
@@ -1658,6 +1660,7 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         {
             SixelStateEventKind.ImageAllocated => "image_allocated",
             SixelStateEventKind.ImageDeduplicated => "image_deduplicated",
+            SixelStateEventKind.ImageRejected => "image_rejected",
             SixelStateEventKind.ImageReleased => "image_released",
             SixelStateEventKind.PlacementAdded => "placement_added",
             SixelStateEventKind.PlacementDamaged => "placement_damaged",
@@ -1672,7 +1675,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         if (stateEvent.Reason is "history_limit" or
             "placement_limit" or
             "image_limit" or
-            "logical_pixel_limit")
+            "logical_pixel_limit" or
+            "retained_byte_limit")
         {
             _metrics.TerminalSixelLimitEvents.Add(
                 stateEvent.Count,
@@ -2742,6 +2746,8 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     internal int SixelPlacementCount => _sixelGraphicsState.ActivePlacements.Count;
 
     internal int SixelHistoryPlacementCount => _sixelGraphicsState.MainHistoryPlacementCount;
+
+    internal long SixelRetainedByteCount => _sixelGraphicsState.ActiveRetainedBytes;
 
     internal Diagnostics.Hex1bMetrics DiagnosticsMetrics => _metrics;
 

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -336,13 +336,14 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         _sessionStart = _timeProvider.GetUtcNow();
         _metrics = options.Metrics ?? Diagnostics.Hex1bMetrics.Default;
         var sixelPolicy = options.CreateSixelPolicy();
-        _kgpGraphicsState = new KgpTerminalGraphicsState(
+        var graphicsBudgets = new TerminalGraphicsRetainedBudgetSet(
             options.Graphics.MaximumRetainedBytesPerScreen);
+        _kgpGraphicsState = new KgpTerminalGraphicsState(graphicsBudgets);
         _sixelColorRegisters = new Sixel.SixelColorRegisters(sixelPolicy);
         _sixelGraphicsState = new SixelGraphicsState(
             sixelPolicy,
             RecordSixelStateEvent,
-            options.Graphics.MaximumRetainedBytesPerScreen,
+            graphicsBudgets,
             _bufferLock);
         
         // Notify lifecycle-aware presentation adapters that the terminal is created
@@ -2748,6 +2749,9 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
     internal int SixelHistoryPlacementCount => _sixelGraphicsState.MainHistoryPlacementCount;
 
     internal long SixelRetainedByteCount => _sixelGraphicsState.ActiveRetainedBytes;
+
+    internal long GraphicsRetainedByteCount =>
+        checked(ActiveKgpImageStore.TotalSize + SixelRetainedByteCount);
 
     internal Diagnostics.Hex1bMetrics DiagnosticsMetrics => _metrics;
 
@@ -8052,6 +8056,16 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
         var stored = ActiveKgpImageStore.StoreImage(transmission, decodedData);
         if (stored.Relocation is { } relocation)
             ApplyKgpImageRelocation(relocation);
+        if (!stored.Stored)
+        {
+            _kgpGraphicsState.ReconcileActiveImageReferences();
+            SendKgpTransmissionResponse(
+                transmission,
+                storedImage: null,
+                "ENOSPC:Image storage full",
+                quiet);
+            return;
+        }
 
         if (stored.Replaced)
             _kgpGraphicsState.RemoveActiveImageReferences(stored.Image.ImageId);

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -7903,6 +7903,16 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 nameof(command));
         }
 
+        if (!TryGetKgpUploadLimit(transmission, out _, out var preflightError))
+        {
+            SendKgpTransmissionResponse(
+                transmission,
+                storedImage: null,
+                preflightError,
+                command.Quiet);
+            return;
+        }
+
         if (transmission.IdentityKind == KgpParsedCommand.ImageIdentityKind.ExplicitId)
         {
             var start = ActiveKgpImageStore.BeginExplicitTransmission(transmission.ImageId);

--- a/src/Hex1b/Hex1bTerminal.cs
+++ b/src/Hex1b/Hex1bTerminal.cs
@@ -7913,6 +7913,38 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
             return;
         }
 
+        var maximumEncodedLength = transmission.MoreData
+            ? KgpMaximumEncodedChunkLength
+            : GetMaximumKgpEncodedPayloadLength();
+        byte[]? decodedData = null;
+        if (!transmission.MoreData)
+        {
+            if (!TryDecodeKgpPayload(
+                    base64Payload,
+                    moreData: false,
+                    maximumEncodedLength,
+                    out decodedData,
+                    out var preflightPayloadError))
+            {
+                SendKgpTransmissionResponse(
+                    transmission,
+                    storedImage: null,
+                    FormatKgpPayloadError(preflightPayloadError, maximumEncodedLength),
+                    command.Quiet);
+                return;
+            }
+
+            if (decodedData.LongLength > ActiveKgpImageStore.MaximumPendingUploadBytes)
+            {
+                SendKgpTransmissionResponse(
+                    transmission,
+                    storedImage: null,
+                    "ENOSPC:Image storage full",
+                    command.Quiet);
+                return;
+            }
+        }
+
         if (transmission.IdentityKind == KgpParsedCommand.ImageIdentityKind.ExplicitId)
         {
             var start = ActiveKgpImageStore.BeginExplicitTransmission(transmission.ImageId);
@@ -7922,14 +7954,12 @@ public sealed partial class Hex1bTerminal : IDisposable, IAsyncDisposable
                 _kgpGraphicsState.RemoveActiveImageReferences(transmission.ImageId);
         }
 
-        var maximumEncodedLength = transmission.MoreData
-            ? KgpMaximumEncodedChunkLength
-            : GetMaximumKgpEncodedPayloadLength();
-        if (!TryDecodeKgpPayload(
+        if (decodedData is null &&
+            !TryDecodeKgpPayload(
                 base64Payload,
                 transmission.MoreData,
                 maximumEncodedLength,
-                out var decodedData,
+                out decodedData,
                 out var payloadError))
         {
             SendKgpTransmissionResponse(

--- a/src/Hex1b/Hex1bTerminalGraphicsOptions.cs
+++ b/src/Hex1b/Hex1bTerminalGraphicsOptions.cs
@@ -90,14 +90,16 @@ public sealed class Hex1bTerminalGraphicsOptions
     /// by one screen. The default is 335,544,320 bytes.
     /// </summary>
     /// <remarks>
-    /// The main and alternate screens each receive an independent budget. KGP
-    /// counts encoded image and animation-frame bytes. Sixel counts each distinct
-    /// image once, including retained payload, parsed metadata, sparse raster
-    /// tiles, and a cached dense pixel buffer. Sixel evicts the oldest placements
-    /// whose image is not the resource currently growing; if one image cannot fit,
-    /// the new placement or cache is not retained. A value of zero disables
-    /// retained byte-backed image data. Per-image input and raster limits remain
-    /// independent safety bounds.
+    /// The main and alternate screens each receive one shared budget across all
+    /// graphics protocols. KGP counts encoded image and animation-frame bytes.
+    /// Sixel counts each distinct image once, including retained payload, parsed
+    /// metadata, sparse raster tiles, and a cached dense pixel buffer. Each
+    /// protocol applies its established oldest-first eviction order to its own
+    /// resources; a new resource is rejected when it cannot fit after those
+    /// evictions, without destroying another protocol's placements. Lazy Sixel
+    /// cache growth is non-destructive and remains uncached when it cannot fit.
+    /// A value of zero disables retained byte-backed image data. Per-image input
+    /// and raster limits remain independent safety bounds.
     /// </remarks>
     public long MaximumRetainedBytesPerScreen { get; set; } = 320L * 1024 * 1024;
 

--- a/src/Hex1b/Hex1bTerminalGraphicsOptions.cs
+++ b/src/Hex1b/Hex1bTerminalGraphicsOptions.cs
@@ -86,14 +86,17 @@ public sealed class Hex1bTerminalGraphicsOptions
         64L * 1024 * 1024;
 
     /// <summary>
-    /// Gets or sets the maximum aggregate encoded and decoded image and animation
-    /// frame data retained by one screen. The default is 335,544,320 bytes.
+    /// Gets or sets the maximum aggregate encoded and decoded image data retained
+    /// by one screen. The default is 335,544,320 bytes.
     /// </summary>
     /// <remarks>
-    /// The main and alternate screens each receive an independent budget. A value
-    /// of zero disables retained byte-backed image data. Protocols that do not yet
-    /// account all retained state in bytes continue to use the other configured
-    /// cardinality and logical-pixel limits. Per-image input and raster limits remain
+    /// The main and alternate screens each receive an independent budget. KGP
+    /// counts encoded image and animation-frame bytes. Sixel counts each distinct
+    /// image once, including retained payload, parsed metadata, sparse raster
+    /// tiles, and a cached dense pixel buffer. Sixel evicts the oldest placements
+    /// whose image is not the resource currently growing; if one image cannot fit,
+    /// the new placement or cache is not retained. A value of zero disables
+    /// retained byte-backed image data. Per-image input and raster limits remain
     /// independent safety bounds.
     /// </remarks>
     public long MaximumRetainedBytesPerScreen { get; set; } = 320L * 1024 * 1024;

--- a/src/Hex1b/Kgp/KgpImageStore.cs
+++ b/src/Hex1b/Kgp/KgpImageStore.cs
@@ -21,6 +21,7 @@ public sealed class KgpImageStore
     internal readonly record struct StoreResult(
         KgpImageData Image,
         bool Replaced,
+        bool Stored = true,
         ImageRelocation? Relocation = null);
 
     internal readonly record struct TransmissionStartResult(
@@ -122,6 +123,7 @@ public sealed class KgpImageStore
     private uint _nextId = 1;
     private long _totalSize;
     private readonly long _quotaBytes;
+    private readonly TerminalGraphicsRetainedBudget? _sharedBudget;
 
     private KgpPendingUpload? _pendingUpload;
 
@@ -138,6 +140,13 @@ public sealed class KgpImageStore
     {
         _quotaBytes = quotaBytes;
         _nextId = nextId == 0 ? 1 : nextId;
+    }
+
+    internal KgpImageStore(TerminalGraphicsRetainedBudget sharedBudget)
+    {
+        _sharedBudget = sharedBudget;
+        _quotaBytes = sharedBudget.MaximumBytes;
+        _nextId = 1;
     }
 
     /// <summary>
@@ -191,7 +200,7 @@ public sealed class KgpImageStore
     }
 
     internal long MaximumPendingUploadBytes
-        => Math.Min(Math.Max(0, _quotaBytes), Array.MaxLength);
+        => Math.Min(Math.Max(0, EffectiveQuotaBytes), Array.MaxLength);
 
     /// <summary>
     /// Allocates a currently unused, non-zero image ID.
@@ -217,7 +226,8 @@ public sealed class KgpImageStore
     {
         lock (_lock)
         {
-            return StoreImageUnsafe(image).Image;
+            var result = StoreImageUnsafe(image);
+            return result.Stored ? result.Image : null;
         }
     }
 
@@ -440,7 +450,7 @@ public sealed class KgpImageStore
                 WouldExceedQuota(
                     _totalSize,
                     info.RequiredStorageBytes,
-                    _quotaBytes))
+                    EffectiveQuotaBytes))
             {
                 return new AnimationFrameResult(
                     info with { Status = AnimationFrameStatus.NoSpace },
@@ -516,7 +526,7 @@ public sealed class KgpImageStore
                 }
 
                 _imagesById[image.ImageId] = updatedImage;
-                _totalSize = checked(_totalSize + storageDelta);
+                SetTotalSizeUnsafe(checked(_totalSize + storageDelta));
                 return new AnimationFrameResult(info, updatedImage);
             }
             catch (OutOfMemoryException)
@@ -602,8 +612,8 @@ public sealed class KgpImageStore
                     currentFrameIndex);
                 var updatedImage = image.WithAnimation(updatedAnimation);
                 _imagesById[image.ImageId] = updatedImage;
-                _totalSize = checked(
-                    _totalSize - (image.StorageSize - updatedImage.StorageSize));
+                SetTotalSizeUnsafe(checked(
+                    _totalSize - (image.StorageSize - updatedImage.StorageSize)));
                 return new AnimationFrameDeleteResult(
                     AnimationFrameDeleteStatus.Deleted,
                     image.ImageId,
@@ -775,7 +785,7 @@ public sealed class KgpImageStore
             _imagesById.Clear();
             _imagesByNumber.Clear();
             _unaddressableImageIds.Clear();
-            _totalSize = 0;
+            SetTotalSizeUnsafe(0);
             AbortChunkedTransferUnsafe();
         }
     }
@@ -1028,7 +1038,7 @@ public sealed class KgpImageStore
         var replaced = _imagesById.TryGetValue(image.ImageId, out var existing);
         if (existing is not null)
         {
-            _totalSize -= existing.StorageSize;
+            SetTotalSizeUnsafe(checked(_totalSize - existing.StorageSize));
             _imagesById.Remove(existing.ImageId);
             _unaddressableImageIds.Remove(existing.ImageId);
             RemoveFromNumberIndex(existing);
@@ -1037,13 +1047,17 @@ public sealed class KgpImageStore
         while (WouldExceedQuota(
                    _totalSize,
                    image.StorageSize,
-                   _quotaBytes) &&
+                   EffectiveQuotaBytes) &&
                _imagesById.Count > 0)
         {
             EvictOldest();
         }
 
-        _totalSize += image.StorageSize;
+        if (_sharedBudget is not null &&
+            WouldExceedQuota(_totalSize, image.StorageSize, EffectiveQuotaBytes))
+            return new StoreResult(image, replaced, Stored: false);
+
+        SetTotalSizeUnsafe(checked(_totalSize + image.StorageSize));
         _imagesById[image.ImageId] = image;
         if (addressable)
             _unaddressableImageIds.Remove(image.ImageId);
@@ -1068,7 +1082,7 @@ public sealed class KgpImageStore
         if (!_imagesById.TryGetValue(imageId, out var image))
             return false;
 
-        _totalSize -= image.StorageSize;
+        SetTotalSizeUnsafe(checked(_totalSize - image.StorageSize));
         _imagesById.Remove(imageId);
         _unaddressableImageIds.Remove(imageId);
         RemoveFromNumberIndex(image);
@@ -1120,6 +1134,16 @@ public sealed class KgpImageStore
             throw new ArgumentOutOfRangeException(nameof(currentSize));
         return addedSize > quotaBytes ||
                currentSize > quotaBytes - addedSize;
+    }
+
+    private long EffectiveQuotaBytes =>
+        _sharedBudget?.MaximumKgpBytes ?? _quotaBytes;
+
+    private void SetTotalSizeUnsafe(long totalSize)
+    {
+        if (_sharedBudget is not null)
+            _sharedBudget.SetKgpBytes(totalSize);
+        _totalSize = totalSize;
     }
 
     private static KgpImageData CreateImage(

--- a/src/Hex1b/Kgp/KgpImageStore.cs
+++ b/src/Hex1b/Kgp/KgpImageStore.cs
@@ -1015,6 +1015,10 @@ public sealed class KgpImageStore
         var imageId = transmission.ImageId > 0
             ? transmission.ImageId
             : AllocateIdUnsafe();
+        var image = CreateImage(imageId, transmission, data);
+        if (_sharedBudget is not null && image.StorageSize > EffectiveQuotaBytes)
+            return new StoreResult(image, Replaced: false, Stored: false);
+
         ImageRelocation? relocation = null;
         if (transmission.IdentityKind == KgpParsedCommand.ImageIdentityKind.ExplicitId &&
             _unaddressableImageIds.Contains(imageId))
@@ -1024,7 +1028,6 @@ public sealed class KgpImageStore
             relocation = RelocateUnaddressableImageUnsafe(imageId);
         }
 
-        var image = CreateImage(imageId, transmission, data);
         var stored = StoreImageUnsafe(
             image,
             transmission.IdentityKind != KgpParsedCommand.ImageIdentityKind.Anonymous);
@@ -1035,6 +1038,9 @@ public sealed class KgpImageStore
         KgpImageData image,
         bool addressable = true)
     {
+        if (_sharedBudget is not null && image.StorageSize > EffectiveQuotaBytes)
+            return new StoreResult(image, Replaced: false, Stored: false);
+
         var replaced = _imagesById.TryGetValue(image.ImageId, out var existing);
         if (existing is not null)
         {

--- a/src/Hex1b/Kgp/KgpTerminalGraphicsState.cs
+++ b/src/Hex1b/Kgp/KgpTerminalGraphicsState.cs
@@ -86,9 +86,9 @@ internal sealed class KgpTerminalGraphicsState
 
     private sealed class ScreenState
     {
-        internal ScreenState(long retainedBytes)
+        internal ScreenState(TerminalGraphicsRetainedBudget retainedBudget)
         {
-            ImageStore = new KgpImageStore(retainedBytes);
+            ImageStore = new KgpImageStore(retainedBudget);
         }
 
         internal KgpImageStore ImageStore { get; }
@@ -111,16 +111,21 @@ internal sealed class KgpTerminalGraphicsState
         }
     }
 
-    private readonly long _retainedBytesPerScreen;
+    private readonly TerminalGraphicsRetainedBudgetSet _retainedBudgets;
     private readonly ScreenState _main;
     private ScreenState? _alternate;
     private bool _alternateActive;
 
-    internal KgpTerminalGraphicsState(long retainedBytesPerScreen = 320L * 1024 * 1024)
+    internal KgpTerminalGraphicsState(
+        long retainedBytesPerScreen = 320L * 1024 * 1024)
+        : this(new TerminalGraphicsRetainedBudgetSet(retainedBytesPerScreen))
     {
-        ArgumentOutOfRangeException.ThrowIfNegative(retainedBytesPerScreen);
-        _retainedBytesPerScreen = retainedBytesPerScreen;
-        _main = new ScreenState(retainedBytesPerScreen);
+    }
+
+    internal KgpTerminalGraphicsState(TerminalGraphicsRetainedBudgetSet retainedBudgets)
+    {
+        _retainedBudgets = retainedBudgets;
+        _main = new ScreenState(retainedBudgets.Main);
     }
 
     private ScreenState Active
@@ -567,11 +572,11 @@ internal sealed class KgpTerminalGraphicsState
         if (_alternateActive)
         {
             _alternate!.Clear();
-            _alternate = new ScreenState(_retainedBytesPerScreen);
+            _alternate = new ScreenState(_retainedBudgets.Alternate);
             return;
         }
 
-        _alternate = new ScreenState(_retainedBytesPerScreen);
+        _alternate = new ScreenState(_retainedBudgets.Alternate);
         _alternateActive = true;
     }
 

--- a/src/Hex1b/Sixel/ISixelRetainedResourceOwner.cs
+++ b/src/Hex1b/Sixel/ISixelRetainedResourceOwner.cs
@@ -1,0 +1,10 @@
+using Hex1b.Surfaces;
+
+namespace Hex1b.Sixel;
+
+internal interface ISixelRetainedResourceOwner
+{
+    SixelRasterResult GetRaster(SixelData image);
+
+    SixelPixelBuffer? GetPixels(SixelData image);
+}

--- a/src/Hex1b/Sixel/SixelGraphicsState.cs
+++ b/src/Hex1b/Sixel/SixelGraphicsState.cs
@@ -81,7 +81,7 @@ internal sealed class SixelReflowPlan
 internal sealed class SixelGraphicsState
 {
     private readonly SixelCompatibilityPolicy _policy;
-    private readonly long _maximumRetainedBytesPerScreen;
+    private readonly TerminalGraphicsRetainedBudgetSet _retainedBudgets;
     private readonly object _syncRoot;
     private readonly Action<SixelStateEvent>? _observe;
     private readonly SixelScreenGraphicsState _main;
@@ -93,16 +93,16 @@ internal sealed class SixelGraphicsState
     internal SixelGraphicsState(
         SixelCompatibilityPolicy? policy = null,
         Action<SixelStateEvent>? observe = null,
-        long maximumRetainedBytesPerScreen = 320L * 1024 * 1024,
+        TerminalGraphicsRetainedBudgetSet? retainedBudgets = null,
         object? syncRoot = null)
     {
         _policy = policy ?? SixelCompatibilityPolicy.Default;
         _policy.Validate();
-        ArgumentOutOfRangeException.ThrowIfNegative(maximumRetainedBytesPerScreen);
-        _maximumRetainedBytesPerScreen = maximumRetainedBytesPerScreen;
+        _retainedBudgets = retainedBudgets ??
+            new TerminalGraphicsRetainedBudgetSet(320L * 1024 * 1024);
         _syncRoot = syncRoot ?? new object();
         _observe = observe;
-        _main = CreateScreen();
+        _main = CreateScreen(_retainedBudgets.Main);
     }
 
     internal bool InAlternateScreen => _alternateActive;
@@ -217,7 +217,7 @@ internal sealed class SixelGraphicsState
     {
         if (_alternate is not null)
             ClearScreen(_alternate);
-        _alternate = CreateScreen();
+        _alternate = CreateScreen(_retainedBudgets.Alternate);
         _alternateActive = true;
     }
 
@@ -828,7 +828,7 @@ internal sealed class SixelGraphicsState
         while (screen.Images.Count > _policy.MaximumImagesPerScreen ||
                screen.Images.GetBoundedLogicalPixelCount(_policy.MaximumRasterPixels) >
                    _policy.MaximumRetainedLogicalPixelsPerScreen ||
-               screen.Images.RetainedBytes > _maximumRetainedBytesPerScreen)
+               !screen.RetainedBudget.CanSetSixelBytes(screen.Images.RetainedBytes))
         {
             var reason = screen.Images.Count > _policy.MaximumImagesPerScreen
                 ? "image_limit"
@@ -930,19 +930,12 @@ internal sealed class SixelGraphicsState
     {
         if (addedBytes < 0)
             throw new ArgumentOutOfRangeException(nameof(addedBytes));
-        if (!screen.Images.Contains(image) ||
-            addedBytes > _maximumRetainedBytesPerScreen)
-        {
+        if (!screen.Images.Contains(image))
             return false;
-        }
 
-        while (WouldExceedBudget(screen.Images.RetainedBytes, addedBytes))
-        {
-            if (!TryRemoveOldestPlacement(screen, image))
-                return false;
-            Observe(SixelStateEventKind.PlacementEvicted, reason: "retained_byte_limit");
-            ReconcileImages(screen);
-        }
+        var retainedBytes = SaturatingAdd(screen.Images.RetainedBytes, addedBytes);
+        if (!screen.RetainedBudget.CanSetSixelBytes(retainedBytes))
+            return false;
 
         return screen.Images.TryIncreaseRetainedBytes(image, addedBytes);
     }
@@ -952,10 +945,8 @@ internal sealed class SixelGraphicsState
         long addedBytes,
         SixelData? protectedImage)
     {
-        if (addedBytes > _maximumRetainedBytesPerScreen)
-            return false;
-
-        while (WouldExceedBudget(screen.Images.RetainedBytes, addedBytes))
+        while (!screen.RetainedBudget.CanSetSixelBytes(
+                   SaturatingAdd(screen.Images.RetainedBytes, addedBytes)))
         {
             if (!TryRemoveOldestPlacement(screen, protectedImage))
                 return false;
@@ -966,12 +957,12 @@ internal sealed class SixelGraphicsState
         return true;
     }
 
-    private bool WouldExceedBudget(long currentBytes, long addedBytes) =>
-        addedBytes > _maximumRetainedBytesPerScreen ||
-        currentBytes > _maximumRetainedBytesPerScreen - addedBytes;
+    private SixelScreenGraphicsState CreateScreen(
+        TerminalGraphicsRetainedBudget retainedBudget) =>
+        new(_syncRoot, retainedBudget, TryReserveGrowth);
 
-    private SixelScreenGraphicsState CreateScreen() =>
-        new(_syncRoot, TryReserveGrowth);
+    private static long SaturatingAdd(long left, long right) =>
+        right > long.MaxValue - left ? long.MaxValue : left + right;
 
     private void ClearScreen(SixelScreenGraphicsState screen)
     {

--- a/src/Hex1b/Sixel/SixelGraphicsState.cs
+++ b/src/Hex1b/Sixel/SixelGraphicsState.cs
@@ -945,6 +945,9 @@ internal sealed class SixelGraphicsState
         long addedBytes,
         SixelData? protectedImage)
     {
+        if (addedBytes > screen.RetainedBudget.MaximumSixelBytes)
+            return false;
+
         while (!screen.RetainedBudget.CanSetSixelBytes(
                    SaturatingAdd(screen.Images.RetainedBytes, addedBytes)))
         {

--- a/src/Hex1b/Sixel/SixelGraphicsState.cs
+++ b/src/Hex1b/Sixel/SixelGraphicsState.cs
@@ -7,6 +7,7 @@ internal enum SixelStateEventKind
 {
     ImageAllocated,
     ImageDeduplicated,
+    ImageRejected,
     ImageReleased,
     PlacementAdded,
     PlacementDamaged,
@@ -80,8 +81,10 @@ internal sealed class SixelReflowPlan
 internal sealed class SixelGraphicsState
 {
     private readonly SixelCompatibilityPolicy _policy;
+    private readonly long _maximumRetainedBytesPerScreen;
+    private readonly object _syncRoot;
     private readonly Action<SixelStateEvent>? _observe;
-    private readonly SixelScreenGraphicsState _main = new();
+    private readonly SixelScreenGraphicsState _main;
     private SixelScreenGraphicsState? _alternate;
     private bool _alternateActive;
 
@@ -89,11 +92,17 @@ internal sealed class SixelGraphicsState
 
     internal SixelGraphicsState(
         SixelCompatibilityPolicy? policy = null,
-        Action<SixelStateEvent>? observe = null)
+        Action<SixelStateEvent>? observe = null,
+        long maximumRetainedBytesPerScreen = 320L * 1024 * 1024,
+        object? syncRoot = null)
     {
         _policy = policy ?? SixelCompatibilityPolicy.Default;
         _policy.Validate();
+        ArgumentOutOfRangeException.ThrowIfNegative(maximumRetainedBytesPerScreen);
+        _maximumRetainedBytesPerScreen = maximumRetainedBytesPerScreen;
+        _syncRoot = syncRoot ?? new object();
         _observe = observe;
+        _main = CreateScreen();
     }
 
     internal bool InAlternateScreen => _alternateActive;
@@ -103,6 +112,9 @@ internal sealed class SixelGraphicsState
 
     /// <summary>The active screen's live placements (for testing/inspection).</summary>
     internal IReadOnlyList<SixelPlacement> ActivePlacements => Active.Placements;
+
+    /// <summary>Deterministic retained bytes on the active screen.</summary>
+    internal long ActiveRetainedBytes => Active.Images.RetainedBytes;
 
     /// <summary>Total number of placements the main screen has moved into history.</summary>
     internal int MainHistoryPlacementCount
@@ -140,19 +152,25 @@ internal sealed class SixelGraphicsState
         bool payloadComplete = true)
     {
         var active = Active;
-        var image = active.Images.GetOrCreate(
-            payload,
+        var hash = SixelData.ComputeHash(
             sourceContentHash,
+            rasterPreparation.Identity,
             widthInCells,
             heightInCells,
-            parseResult,
-            rasterPreparation,
-            cellMetrics,
-            payloadComplete,
-            out var imageCreated);
-        Observe(imageCreated
-            ? SixelStateEventKind.ImageAllocated
-            : SixelStateEventKind.ImageDeduplicated);
+            cellMetrics);
+        var imageCreated = !active.Images.TryGet(hash, out var image);
+        if (imageCreated)
+        {
+            image = SixelImageStore.Create(
+                payload,
+                hash,
+                widthInCells,
+                heightInCells,
+                parseResult,
+                rasterPreparation,
+                cellMetrics,
+                payloadComplete);
+        }
         var placement = new SixelPlacement(
             image,
             row,
@@ -165,6 +183,24 @@ internal sealed class SixelGraphicsState
             paintedColumnCount,
             sequence,
             createdAt);
+
+        if (imageCreated)
+        {
+            var retainedBytes = image.RetainedByteCount;
+            if (!EnsureCapacity(active, retainedBytes, protectedImage: null))
+            {
+                Observe(SixelStateEventKind.ImageRejected, reason: "retained_byte_limit");
+                return new SixelPlacementCreationResult(placement, Retained: false);
+            }
+
+            active.Images.Add(image);
+            Observe(SixelStateEventKind.ImageAllocated);
+        }
+        else
+        {
+            Observe(SixelStateEventKind.ImageDeduplicated);
+        }
+
         active.Placements.Add(placement);
         Observe(SixelStateEventKind.PlacementAdded);
         EnforceLimits(active);
@@ -181,7 +217,7 @@ internal sealed class SixelGraphicsState
     {
         if (_alternate is not null)
             ClearScreen(_alternate);
-        _alternate = new SixelScreenGraphicsState();
+        _alternate = CreateScreen();
         _alternateActive = true;
     }
 
@@ -791,11 +827,15 @@ internal sealed class SixelGraphicsState
         ReconcileImages(screen);
         while (screen.Images.Count > _policy.MaximumImagesPerScreen ||
                screen.Images.GetBoundedLogicalPixelCount(_policy.MaximumRasterPixels) >
-                   _policy.MaximumRetainedLogicalPixelsPerScreen)
+                   _policy.MaximumRetainedLogicalPixelsPerScreen ||
+               screen.Images.RetainedBytes > _maximumRetainedBytesPerScreen)
         {
             var reason = screen.Images.Count > _policy.MaximumImagesPerScreen
                 ? "image_limit"
-                : "logical_pixel_limit";
+                : screen.Images.GetBoundedLogicalPixelCount(_policy.MaximumRasterPixels) >
+                    _policy.MaximumRetainedLogicalPixelsPerScreen
+                    ? "logical_pixel_limit"
+                    : "retained_byte_limit";
             if (!TryRemoveOldestPlacement(screen))
                 break;
             Observe(SixelStateEventKind.PlacementEvicted, reason: reason);
@@ -840,14 +880,23 @@ internal sealed class SixelGraphicsState
     }
 
     private static bool TryRemoveOldestPlacement(SixelScreenGraphicsState screen)
+        => TryRemoveOldestPlacement(screen, protectedImage: null);
+
+    private static bool TryRemoveOldestPlacement(
+        SixelScreenGraphicsState screen,
+        SixelData? protectedImage)
     {
         var live = screen.Placements
             .Select((placement, index) => (placement.Sequence, IsHistory: false, RowId: 0L, Index: index))
+            .Where(item => !ReferenceEquals(screen.Placements[item.Index].Image, protectedImage))
             .ToList();
         foreach (var (rowId, placements) in screen.HistoryPlacements)
         {
-            live.AddRange(placements.Select((placement, index) =>
-                (placement.Placement.Sequence, IsHistory: true, RowId: rowId, Index: index)));
+            live.AddRange(placements
+                .Select((placement, index) => (placement, index))
+                .Where(item => !ReferenceEquals(item.placement.Placement.Image, protectedImage))
+                .Select(item =>
+                    (item.placement.Placement.Sequence, IsHistory: true, RowId: rowId, Index: item.index)));
         }
 
         if (live.Count == 0)
@@ -873,6 +922,56 @@ internal sealed class SixelGraphicsState
         if (released > 0)
             Observe(SixelStateEventKind.ImageReleased, released);
     }
+
+    private bool TryReserveGrowth(
+        SixelScreenGraphicsState screen,
+        SixelData image,
+        long addedBytes)
+    {
+        if (addedBytes < 0)
+            throw new ArgumentOutOfRangeException(nameof(addedBytes));
+        if (!screen.Images.Contains(image) ||
+            addedBytes > _maximumRetainedBytesPerScreen)
+        {
+            return false;
+        }
+
+        while (WouldExceedBudget(screen.Images.RetainedBytes, addedBytes))
+        {
+            if (!TryRemoveOldestPlacement(screen, image))
+                return false;
+            Observe(SixelStateEventKind.PlacementEvicted, reason: "retained_byte_limit");
+            ReconcileImages(screen);
+        }
+
+        return screen.Images.TryIncreaseRetainedBytes(image, addedBytes);
+    }
+
+    private bool EnsureCapacity(
+        SixelScreenGraphicsState screen,
+        long addedBytes,
+        SixelData? protectedImage)
+    {
+        if (addedBytes > _maximumRetainedBytesPerScreen)
+            return false;
+
+        while (WouldExceedBudget(screen.Images.RetainedBytes, addedBytes))
+        {
+            if (!TryRemoveOldestPlacement(screen, protectedImage))
+                return false;
+            Observe(SixelStateEventKind.PlacementEvicted, reason: "retained_byte_limit");
+            ReconcileImages(screen);
+        }
+
+        return true;
+    }
+
+    private bool WouldExceedBudget(long currentBytes, long addedBytes) =>
+        addedBytes > _maximumRetainedBytesPerScreen ||
+        currentBytes > _maximumRetainedBytesPerScreen - addedBytes;
+
+    private SixelScreenGraphicsState CreateScreen() =>
+        new(_syncRoot, TryReserveGrowth);
 
     private void ClearScreen(SixelScreenGraphicsState screen)
     {

--- a/src/Hex1b/Sixel/SixelImageStore.cs
+++ b/src/Hex1b/Sixel/SixelImageStore.cs
@@ -23,11 +23,15 @@ internal sealed class SixelImageStore
 
     private readonly Dictionary<byte[], Entry> _byHash = new(SixelContentHashComparer.Instance);
     private readonly ISixelRetainedResourceOwner _owner;
+    private readonly TerminalGraphicsRetainedBudget _retainedBudget;
     private long _retainedBytes;
 
-    internal SixelImageStore(ISixelRetainedResourceOwner owner)
+    internal SixelImageStore(
+        ISixelRetainedResourceOwner owner,
+        TerminalGraphicsRetainedBudget retainedBudget)
     {
         _owner = owner;
+        _retainedBudget = retainedBudget;
     }
 
     /// <summary>Number of distinct images currently retained.</summary>
@@ -79,6 +83,7 @@ internal sealed class SixelImageStore
         image.AttachRetainedResourceOwner(_owner);
         _byHash.Add(image.ContentHash, new Entry(image, retainedBytes));
         _retainedBytes = checked(_retainedBytes + retainedBytes);
+        _retainedBudget.SetSixelBytes(_retainedBytes);
     }
 
     internal bool Contains(SixelData image) =>
@@ -98,6 +103,7 @@ internal sealed class SixelImageStore
         var retainedBytes = checked(entry.RetainedBytes + addedBytes);
         _byHash[image.ContentHash] = entry with { RetainedBytes = retainedBytes };
         _retainedBytes = checked(_retainedBytes + addedBytes);
+        _retainedBudget.SetSixelBytes(_retainedBytes);
         return true;
     }
 
@@ -130,6 +136,7 @@ internal sealed class SixelImageStore
             entry.Image.DetachRetainedResourceOwner(_owner);
         _byHash.Clear();
         _retainedBytes = 0;
+        _retainedBudget.SetSixelBytes(0);
     }
 
     /// <summary>
@@ -159,6 +166,7 @@ internal sealed class SixelImageStore
             _retainedBytes = checked(_retainedBytes - entry.RetainedBytes);
             _byHash.Remove(hash);
         }
+        _retainedBudget.SetSixelBytes(_retainedBytes);
 
         return toRemove.Count;
     }

--- a/src/Hex1b/Sixel/SixelImageStore.cs
+++ b/src/Hex1b/Sixel/SixelImageStore.cs
@@ -19,13 +19,26 @@ namespace Hex1b;
 /// </remarks>
 internal sealed class SixelImageStore
 {
-    private readonly Dictionary<byte[], SixelData> _byHash = new(SixelContentHashComparer.Instance);
+    private sealed record Entry(SixelData Image, long RetainedBytes);
+
+    private readonly Dictionary<byte[], Entry> _byHash = new(SixelContentHashComparer.Instance);
+    private readonly ISixelRetainedResourceOwner _owner;
+    private long _retainedBytes;
+
+    internal SixelImageStore(ISixelRetainedResourceOwner owner)
+    {
+        _owner = owner;
+    }
 
     /// <summary>Number of distinct images currently retained.</summary>
     internal int Count => _byHash.Count;
 
     /// <summary>The images currently retained.</summary>
-    internal IReadOnlyCollection<SixelData> Images => _byHash.Values;
+    internal IReadOnlyCollection<SixelData> Images =>
+        _byHash.Values.Select(entry => entry.Image).ToArray();
+
+    /// <summary>Deterministic retained bytes for all distinct images.</summary>
+    internal long RetainedBytes => _retainedBytes;
 
     /// <summary>
     /// Aggregate logical pixel area of the distinct retained images.
@@ -33,8 +46,9 @@ internal sealed class SixelImageStore
     internal long GetBoundedLogicalPixelCount(long maximumPerImage)
     {
         long total = 0;
-        foreach (var image in _byHash.Values)
+        foreach (var entry in _byHash.Values)
         {
+            var image = entry.Image;
             var extent = image.ParseResult.UnscaledLogicalCanvasExtent;
             var pixels = Math.Min((long)extent.Width * extent.Height, maximumPerImage);
             total = pixels > long.MaxValue - total ? long.MaxValue : total + pixels;
@@ -45,49 +59,78 @@ internal sealed class SixelImageStore
 
     /// <summary>
     /// Gets the existing image for this exact resource identity (payload,
-    /// captured raster state, protocol metrics, and cell span), or creates and
-    /// stores a new one.
+    /// captured raster state, protocol metrics, and cell span).
     /// </summary>
-    internal SixelData GetOrCreate(
+    internal bool TryGet(byte[] hash, out SixelData image)
+    {
+        if (_byHash.TryGetValue(hash, out var entry))
+        {
+            image = entry.Image;
+            return true;
+        }
+
+        image = null!;
+        return false;
+    }
+
+    internal void Add(SixelData image)
+    {
+        var retainedBytes = image.RetainedByteCount;
+        image.AttachRetainedResourceOwner(_owner);
+        _byHash.Add(image.ContentHash, new Entry(image, retainedBytes));
+        _retainedBytes = checked(_retainedBytes + retainedBytes);
+    }
+
+    internal bool Contains(SixelData image) =>
+        _byHash.TryGetValue(image.ContentHash, out var entry) &&
+        ReferenceEquals(entry.Image, image);
+
+    internal bool TryIncreaseRetainedBytes(SixelData image, long addedBytes)
+    {
+        if (addedBytes < 0)
+            throw new ArgumentOutOfRangeException(nameof(addedBytes));
+        if (!_byHash.TryGetValue(image.ContentHash, out var entry) ||
+            !ReferenceEquals(entry.Image, image))
+        {
+            return false;
+        }
+
+        var retainedBytes = checked(entry.RetainedBytes + addedBytes);
+        _byHash[image.ContentHash] = entry with { RetainedBytes = retainedBytes };
+        _retainedBytes = checked(_retainedBytes + addedBytes);
+        return true;
+    }
+
+    internal static SixelData Create(
         string payload,
-        byte[] sourceContentHash,
+        byte[] contentHash,
         int widthInCells,
         int heightInCells,
         SixelParseResult parseResult,
         SixelRasterPreparation rasterPreparation,
         SixelCellMetrics cellMetrics,
-        bool payloadComplete,
-        out bool created)
+        bool payloadComplete)
     {
-        var hash = SixelData.ComputeHash(
-            sourceContentHash,
-            rasterPreparation.Identity,
-            widthInCells,
-            heightInCells,
-            cellMetrics);
-        if (_byHash.TryGetValue(hash, out var existing))
-        {
-            created = false;
-            return existing;
-        }
-
-        var image = new SixelData(
+        return new SixelData(
             payload,
             widthInCells,
             heightInCells,
-            hash,
+            contentHash,
             parseResult.DeclaredExtent.Width,
             parseResult.DeclaredExtent.Height,
             parseResult,
             rasterPreparation: rasterPreparation,
             cellMetrics: cellMetrics,
             payloadComplete: payloadComplete);
-        _byHash[hash] = image;
-        created = true;
-        return image;
     }
 
-    internal void Clear() => _byHash.Clear();
+    internal void Clear()
+    {
+        foreach (var entry in _byHash.Values)
+            entry.Image.DetachRetainedResourceOwner(_owner);
+        _byHash.Clear();
+        _retainedBytes = 0;
+    }
 
     /// <summary>
     /// Removes every image whose content hash is not present in
@@ -110,7 +153,12 @@ internal sealed class SixelImageStore
             return 0;
 
         foreach (var hash in toRemove)
+        {
+            var entry = _byHash[hash];
+            entry.Image.DetachRetainedResourceOwner(_owner);
+            _retainedBytes = checked(_retainedBytes - entry.RetainedBytes);
             _byHash.Remove(hash);
+        }
 
         return toRemove.Count;
     }

--- a/src/Hex1b/Sixel/SixelPlacement.cs
+++ b/src/Hex1b/Sixel/SixelPlacement.cs
@@ -57,7 +57,6 @@ namespace Hex1b;
 public sealed class SixelPlacement
 {
     private readonly HashSet<int> _damagedCells;
-    private SixelPixelBuffer? _visiblePixels;
 
     internal SixelPlacement(
         SixelData image,
@@ -237,7 +236,6 @@ public sealed class SixelPlacement
         if (!CoversCell(row, column))
             return false;
 
-        _visiblePixels = null;
         _damagedCells.Add(CellKey(row, column));
         return true;
     }
@@ -270,8 +268,6 @@ public sealed class SixelPlacement
         PaintedColumnOffset = paintedColumnOffset;
         PaintedColumnCount = paintedColumnCount;
         _damagedCells.Clear();
-        _visiblePixels = null;
-
         foreach (var (row, column) in damagedCells)
         {
             if (row < paintedRowOffset ||
@@ -296,9 +292,6 @@ public sealed class SixelPlacement
         var pixels = Image.GetPixels();
         if (pixels is null || _damagedCells.Count == 0)
             return pixels;
-
-        if (_visiblePixels is not null)
-            return _visiblePixels;
 
         var visible = new SixelPixelBuffer(pixels.Width, pixels.Height);
         for (var y = 0; y < pixels.Height; y++)
@@ -327,7 +320,6 @@ public sealed class SixelPlacement
             }
         }
 
-        _visiblePixels = visible;
         return visible;
     }
 

--- a/src/Hex1b/Sixel/SixelRasterImage.cs
+++ b/src/Hex1b/Sixel/SixelRasterImage.cs
@@ -59,6 +59,21 @@ internal sealed class SixelRasterImage
     public int AllocatedTileCount => _tiles.Count;
 
     /// <summary>
+    /// Gets the deterministic retained bytes for allocated tile pixels and
+    /// their logical keys.
+    /// </summary>
+    internal long RetainedTileBytes
+    {
+        get
+        {
+            var bytesPerTile = checked((long)_tilePixelCount * 4 + sizeof(long));
+            return _tiles.Count > long.MaxValue / bytesPerTile
+                ? long.MaxValue
+                : _tiles.Count * bytesPerTile;
+        }
+    }
+
+    /// <summary>
     /// Gets the number of pixels that would be materialized densely.
     /// </summary>
     public long PixelCount => (long)Width * Height;

--- a/src/Hex1b/Sixel/SixelRasterImage.cs
+++ b/src/Hex1b/Sixel/SixelRasterImage.cs
@@ -1,4 +1,5 @@
 using Hex1b.Surfaces;
+using System.Runtime.CompilerServices;
 
 namespace Hex1b.Sixel;
 
@@ -66,10 +67,18 @@ internal sealed class SixelRasterImage
     {
         get
         {
-            var bytesPerTile = checked((long)_tilePixelCount * 4 + sizeof(long));
-            return _tiles.Count > long.MaxValue / bytesPerTile
-                ? long.MaxValue
-                : _tiles.Count * bytesPerTile;
+            const int arrayHeaderBytes = 24;
+            const int dictionaryEntryStateBytes = 2 * sizeof(int);
+            var capacity = _tiles.EnsureCapacity(0);
+            var buckets = checked((long)capacity * sizeof(int));
+            var entries = checked(
+                (long)capacity *
+                (Unsafe.SizeOf<KeyValuePair<long, Rgba32[]>>() +
+                 dictionaryEntryStateBytes));
+            var tiles = checked(
+                (long)_tiles.Count *
+                (arrayHeaderBytes + ((long)_tilePixelCount * 4)));
+            return checked(buckets + entries + tiles);
         }
     }
 

--- a/src/Hex1b/Sixel/SixelRetainedSize.cs
+++ b/src/Hex1b/Sixel/SixelRetainedSize.cs
@@ -1,0 +1,143 @@
+using System.Text;
+using Hex1b.Surfaces;
+
+namespace Hex1b.Sixel;
+
+/// <summary>
+/// Deterministic retained-byte accounting for one Sixel image resource.
+/// </summary>
+/// <remarks>
+/// This intentionally counts retained protocol and pixel content rather than
+/// runtime object headers or allocator overhead, whose sizes vary by runtime.
+/// </remarks>
+internal static class SixelRetainedSize
+{
+    private const int Int32Bytes = sizeof(int);
+    private const int Int64Bytes = sizeof(long);
+    private const int BooleanBytes = sizeof(byte);
+    private const int NullableMarkerBytes = sizeof(byte);
+    private const int Rgba32Bytes = 4;
+
+    internal static long GetInitialBytes(SixelData image)
+    {
+        var total = 0L;
+        Add(ref total, Encoding.UTF8.GetByteCount(image.Payload));
+        Add(ref total, image.ContentHash.Length);
+        Add(ref total, GetParseResultBytes(image.ParseResult));
+        Add(ref total, GetRasterPreparationBytes(image.RasterPreparation));
+        Add(ref total, 4L * Int32Bytes);
+        Add(ref total, 2L * sizeof(double) + 2L * Int32Bytes);
+        Add(ref total, BooleanBytes);
+        return total;
+    }
+
+    internal static long GetRasterBytes(SixelRasterResult raster)
+    {
+        var total = 0L;
+        Add(ref total, Int32Bytes);
+        Add(ref total, 7L * 2 * Int32Bytes);
+        Add(ref total, 4L * Int32Bytes);
+        Add(ref total, Int32Bytes);
+        Add(ref total, Rgba32Bytes);
+        Add(ref total, raster.Identity.Length);
+        Add(ref total, GetRasterDiagnosticsBytes(raster.Diagnostics));
+        Add(ref total, raster.Image?.RetainedTileBytes ?? 0);
+        return total;
+    }
+
+    internal static long GetDensePixelBytes(SixelPixelBuffer pixels) =>
+        SaturatingMultiply((long)pixels.Width * pixels.Height, Rgba32Bytes);
+
+    private static long GetParseResultBytes(SixelParseResult parse)
+    {
+        var total = 0L;
+        Add(ref total, 6L * Int32Bytes);
+        if (parse.RasterAttributes is not null)
+            Add(ref total, 4L * Int32Bytes);
+        Add(ref total, 4L * Int32Bytes);
+        Add(ref total, 5L * 2 * Int32Bytes);
+        Add(ref total, 2L * 4 * Int32Bytes);
+        Add(ref total, Int32Bytes);
+        Add(ref total, GetPaletteCommandsBytes(parse.PaletteMutations));
+        Add(ref total, GetPaletteCommandsBytes(parse.FinalPaletteDefinitions));
+        foreach (var command in parse.Commands)
+        {
+            Add(ref total, 5L * Int32Bytes + NullableMarkerBytes);
+            if (command.Palette is { } palette)
+                Add(ref total, GetPaletteCommandBytes(palette));
+        }
+        Add(ref total, BooleanBytes + Int32Bytes);
+        Add(ref total, GetDiagnosticsBytes(parse.Diagnostics));
+        return total;
+    }
+
+    private static long GetRasterPreparationBytes(SixelRasterPreparation? preparation)
+    {
+        if (preparation is null)
+            return 0;
+
+        var total = 0L;
+        Add(ref total, preparation.Identity.Length);
+        Add(ref total, Rgba32Bytes);
+        Add(ref total, SaturatingMultiply(preparation.Environment.Registers.Count, Rgba32Bytes));
+        return total;
+    }
+
+    private static long GetPaletteCommandsBytes(IReadOnlyList<SixelPaletteCommand> commands)
+    {
+        var total = 0L;
+        foreach (var command in commands)
+            Add(ref total, GetPaletteCommandBytes(command));
+        return total;
+    }
+
+    private static long GetPaletteCommandBytes(SixelPaletteCommand command)
+    {
+        long total = Int32Bytes;
+        Add(ref total, NullableMarkerBytes + (command.ColorSpace is null ? 0 : Int32Bytes));
+        Add(ref total, GetNullableIntBytes(command.X));
+        Add(ref total, GetNullableIntBytes(command.Y));
+        Add(ref total, GetNullableIntBytes(command.Z));
+        return total;
+    }
+
+    private static long GetNullableIntBytes(int? value) =>
+        NullableMarkerBytes + (value is null ? 0 : Int32Bytes);
+
+    private static long GetDiagnosticsBytes(IReadOnlyList<SixelDiagnostic> diagnostics)
+    {
+        var total = 0L;
+        foreach (var diagnostic in diagnostics)
+        {
+            Add(ref total, Int32Bytes + Int64Bytes + NullableMarkerBytes);
+            if (diagnostic.Command is not null)
+                Add(ref total, sizeof(byte));
+            Add(ref total, Encoding.UTF8.GetByteCount(diagnostic.Message));
+        }
+        return total;
+    }
+
+    private static long GetRasterDiagnosticsBytes(
+        IReadOnlyList<SixelRasterDiagnostic> diagnostics)
+    {
+        var total = 0L;
+        foreach (var diagnostic in diagnostics)
+        {
+            Add(ref total, Int32Bytes);
+            Add(ref total, Encoding.UTF8.GetByteCount(diagnostic.Message));
+        }
+        return total;
+    }
+
+    private static long SaturatingMultiply(long left, long right)
+    {
+        if (left == 0 || right == 0)
+            return 0;
+        return left > long.MaxValue / right ? long.MaxValue : left * right;
+    }
+
+    private static void Add(ref long total, long value)
+    {
+        total = value > long.MaxValue - total ? long.MaxValue : total + value;
+    }
+}

--- a/src/Hex1b/Sixel/SixelRetainedSize.cs
+++ b/src/Hex1b/Sixel/SixelRetainedSize.cs
@@ -1,4 +1,4 @@
-using System.Text;
+using System.Runtime.CompilerServices;
 using Hex1b.Surfaces;
 
 namespace Hex1b.Sixel;
@@ -12,21 +12,20 @@ namespace Hex1b.Sixel;
 /// </remarks>
 internal static class SixelRetainedSize
 {
-    private const int Int32Bytes = sizeof(int);
-    private const int Int64Bytes = sizeof(long);
     private const int BooleanBytes = sizeof(byte);
-    private const int NullableMarkerBytes = sizeof(byte);
     private const int Rgba32Bytes = 4;
+    private const int ArrayHeaderBytes = 24;
+    private const int StringHeaderBytes = 24;
 
     internal static long GetInitialBytes(SixelData image)
     {
         var total = 0L;
-        Add(ref total, Encoding.UTF8.GetByteCount(image.Payload));
-        Add(ref total, image.ContentHash.Length);
+        Add(ref total, GetStringBytes(image.Payload));
+        Add(ref total, GetArrayBytes(image.ContentHash.Length, sizeof(byte)));
         Add(ref total, GetParseResultBytes(image.ParseResult));
         Add(ref total, GetRasterPreparationBytes(image.RasterPreparation));
-        Add(ref total, 4L * Int32Bytes);
-        Add(ref total, 2L * sizeof(double) + 2L * Int32Bytes);
+        Add(ref total, 4L * sizeof(int));
+        Add(ref total, 2L * sizeof(double) + 2L * sizeof(int));
         Add(ref total, BooleanBytes);
         return total;
     }
@@ -34,39 +33,27 @@ internal static class SixelRetainedSize
     internal static long GetRasterBytes(SixelRasterResult raster)
     {
         var total = 0L;
-        Add(ref total, Int32Bytes);
-        Add(ref total, 7L * 2 * Int32Bytes);
-        Add(ref total, 4L * Int32Bytes);
-        Add(ref total, Int32Bytes);
-        Add(ref total, Rgba32Bytes);
-        Add(ref total, raster.Identity.Length);
+        Add(ref total, Unsafe.SizeOf<SixelRasterResultContent>());
+        Add(ref total, GetArrayBytes(raster.Identity.Length, sizeof(byte)));
         Add(ref total, GetRasterDiagnosticsBytes(raster.Diagnostics));
         Add(ref total, raster.Image?.RetainedTileBytes ?? 0);
         return total;
     }
 
     internal static long GetDensePixelBytes(SixelPixelBuffer pixels) =>
-        SaturatingMultiply((long)pixels.Width * pixels.Height, Rgba32Bytes);
+        GetArrayBytes((long)pixels.Width * pixels.Height, Rgba32Bytes);
 
     private static long GetParseResultBytes(SixelParseResult parse)
     {
         var total = 0L;
-        Add(ref total, 6L * Int32Bytes);
-        if (parse.RasterAttributes is not null)
-            Add(ref total, 4L * Int32Bytes);
-        Add(ref total, 4L * Int32Bytes);
-        Add(ref total, 5L * 2 * Int32Bytes);
-        Add(ref total, 2L * 4 * Int32Bytes);
-        Add(ref total, Int32Bytes);
+        Add(ref total, Unsafe.SizeOf<SixelParseResultContent>());
         Add(ref total, GetPaletteCommandsBytes(parse.PaletteMutations));
         Add(ref total, GetPaletteCommandsBytes(parse.FinalPaletteDefinitions));
-        foreach (var command in parse.Commands)
-        {
-            Add(ref total, 5L * Int32Bytes + NullableMarkerBytes);
-            if (command.Palette is { } palette)
-                Add(ref total, GetPaletteCommandBytes(palette));
-        }
-        Add(ref total, BooleanBytes + Int32Bytes);
+        Add(
+            ref total,
+            GetCollectionBytes(
+                parse.Commands,
+                Unsafe.SizeOf<SixelCommand>()));
         Add(ref total, GetDiagnosticsBytes(parse.Diagnostics));
         return total;
     }
@@ -77,56 +64,53 @@ internal static class SixelRetainedSize
             return 0;
 
         var total = 0L;
-        Add(ref total, preparation.Identity.Length);
-        Add(ref total, Rgba32Bytes);
-        Add(ref total, SaturatingMultiply(preparation.Environment.Registers.Count, Rgba32Bytes));
+        Add(ref total, GetArrayBytes(preparation.Identity.Length, sizeof(byte)));
+        Add(ref total, Unsafe.SizeOf<SixelRasterPreparationContent>());
+        Add(
+            ref total,
+            GetArrayBytes(preparation.Environment.Registers.Count, Rgba32Bytes));
         return total;
     }
 
     private static long GetPaletteCommandsBytes(IReadOnlyList<SixelPaletteCommand> commands)
-    {
-        var total = 0L;
-        foreach (var command in commands)
-            Add(ref total, GetPaletteCommandBytes(command));
-        return total;
-    }
-
-    private static long GetPaletteCommandBytes(SixelPaletteCommand command)
-    {
-        long total = Int32Bytes;
-        Add(ref total, NullableMarkerBytes + (command.ColorSpace is null ? 0 : Int32Bytes));
-        Add(ref total, GetNullableIntBytes(command.X));
-        Add(ref total, GetNullableIntBytes(command.Y));
-        Add(ref total, GetNullableIntBytes(command.Z));
-        return total;
-    }
-
-    private static long GetNullableIntBytes(int? value) =>
-        NullableMarkerBytes + (value is null ? 0 : Int32Bytes);
+        => GetCollectionBytes(commands, Unsafe.SizeOf<SixelPaletteCommand>());
 
     private static long GetDiagnosticsBytes(IReadOnlyList<SixelDiagnostic> diagnostics)
     {
-        var total = 0L;
+        var total = GetCollectionBytes(
+            diagnostics,
+            Unsafe.SizeOf<SixelDiagnostic>());
         foreach (var diagnostic in diagnostics)
-        {
-            Add(ref total, Int32Bytes + Int64Bytes + NullableMarkerBytes);
-            if (diagnostic.Command is not null)
-                Add(ref total, sizeof(byte));
-            Add(ref total, Encoding.UTF8.GetByteCount(diagnostic.Message));
-        }
+            Add(ref total, GetStringBytes(diagnostic.Message));
         return total;
     }
 
     private static long GetRasterDiagnosticsBytes(
         IReadOnlyList<SixelRasterDiagnostic> diagnostics)
     {
-        var total = 0L;
+        var total = GetCollectionBytes(
+            diagnostics,
+            Unsafe.SizeOf<SixelRasterDiagnostic>());
         foreach (var diagnostic in diagnostics)
-        {
-            Add(ref total, Int32Bytes);
-            Add(ref total, Encoding.UTF8.GetByteCount(diagnostic.Message));
-        }
+            Add(ref total, GetStringBytes(diagnostic.Message));
         return total;
+    }
+
+    private static long GetStringBytes(string value) =>
+        AlignToEight(SaturatingAdd(
+            StringHeaderBytes,
+            SaturatingMultiply((long)value.Length + 1, sizeof(char))));
+
+    private static long GetArrayBytes(long length, int elementSize) =>
+        AlignToEight(
+            SaturatingAdd(ArrayHeaderBytes, SaturatingMultiply(length, elementSize)));
+
+    private static long GetCollectionBytes<T>(
+        IReadOnlyList<T> values,
+        int elementSize)
+    {
+        var capacity = values is List<T> list ? list.Capacity : values.Count;
+        return GetArrayBytes(capacity, elementSize);
     }
 
     private static long SaturatingMultiply(long left, long right)
@@ -136,8 +120,49 @@ internal static class SixelRetainedSize
         return left > long.MaxValue / right ? long.MaxValue : left * right;
     }
 
+    private static long SaturatingAdd(long left, long right) =>
+        right > long.MaxValue - left ? long.MaxValue : left + right;
+
+    private static long AlignToEight(long value) =>
+        value > long.MaxValue - 7 ? long.MaxValue : (value + 7) & ~7L;
+
     private static void Add(ref long total, long value)
     {
         total = value > long.MaxValue - total ? long.MaxValue : total + value;
     }
+
+    private readonly record struct SixelParseResultContent(
+        SixelHeader Header,
+        SixelRasterAttributes? RasterAttributes,
+        SixelPoint GraphicsCursor,
+        SixelPoint MaximumCommandOrDataPosition,
+        SixelExtent DeclaredExtent,
+        SixelExtent DataExtent,
+        SixelBounds PaintedBounds,
+        SixelExtent LogicalCanvasExtent,
+        SixelExtent UnscaledDataExtent,
+        SixelBounds UnscaledPaintedBounds,
+        SixelExtent UnscaledLogicalCanvasExtent,
+        int SelectedColorRegister,
+        nint PaletteMutations,
+        nint FinalPaletteDefinitions,
+        nint Commands,
+        bool CommandsComplete,
+        SixelParseOutcome Outcome,
+        nint Diagnostics);
+
+    private readonly record struct SixelRasterPreparationContent(
+        Rgba32 Background,
+        nint Registers,
+        nint Policy,
+        nint Identity);
+
+    private readonly record struct SixelRasterResultContent(
+        SixelRasterStatus Status,
+        SixelRasterExtents Extents,
+        nint Image,
+        SixelBackgroundMode BackgroundMode,
+        Rgba32 UnpaintedPixel,
+        nint Identity,
+        nint Diagnostics);
 }

--- a/src/Hex1b/Sixel/SixelScreenGraphicsState.cs
+++ b/src/Hex1b/Sixel/SixelScreenGraphicsState.cs
@@ -1,4 +1,5 @@
 using Hex1b.Sixel;
+using Hex1b.Surfaces;
 
 namespace Hex1b;
 
@@ -10,7 +11,47 @@ namespace Hex1b;
 /// </summary>
 internal sealed class SixelScreenGraphicsState
 {
-    internal SixelImageStore Images { get; } = new();
+    private sealed class RetainedResourceOwner(
+        SixelScreenGraphicsState screen,
+        object syncRoot,
+        Func<SixelScreenGraphicsState, SixelData, long, bool> tryReserve)
+        : ISixelRetainedResourceOwner
+    {
+        public SixelRasterResult GetRaster(SixelData image)
+        {
+            lock (syncRoot)
+            {
+                if (!screen.Images.Contains(image))
+                {
+                    image.DetachRetainedResourceOwner(this);
+                    return image.GetRasterUnowned();
+                }
+                return image.GetRasterOwned(bytes => tryReserve(screen, image, bytes));
+            }
+        }
+
+        public SixelPixelBuffer? GetPixels(SixelData image)
+        {
+            lock (syncRoot)
+            {
+                if (!screen.Images.Contains(image))
+                {
+                    image.DetachRetainedResourceOwner(this);
+                    return image.GetPixelsUnowned();
+                }
+                return image.GetPixelsOwned(bytes => tryReserve(screen, image, bytes));
+            }
+        }
+    }
+
+    internal SixelScreenGraphicsState(
+        object syncRoot,
+        Func<SixelScreenGraphicsState, SixelData, long, bool> tryReserve)
+    {
+        Images = new SixelImageStore(new RetainedResourceOwner(this, syncRoot, tryReserve));
+    }
+
+    internal SixelImageStore Images { get; }
 
     internal List<SixelPlacement> Placements { get; } = [];
 

--- a/src/Hex1b/Sixel/SixelScreenGraphicsState.cs
+++ b/src/Hex1b/Sixel/SixelScreenGraphicsState.cs
@@ -19,39 +19,63 @@ internal sealed class SixelScreenGraphicsState
     {
         public SixelRasterResult GetRaster(SixelData image)
         {
+            if (image.TryGetCachedRaster(out var cached))
+                return cached;
+
+            var candidate = image.ComputeRasterCandidate();
             lock (syncRoot)
             {
                 if (!screen.Images.Contains(image))
                 {
                     image.DetachRetainedResourceOwner(this);
-                    return image.GetRasterUnowned();
+                    return image.PublishRasterUnowned(candidate);
                 }
-                return image.GetRasterOwned(bytes => tryReserve(screen, image, bytes));
+
+                return image.PublishRasterOwned(
+                    candidate,
+                    bytes => tryReserve(screen, image, bytes));
             }
         }
 
         public SixelPixelBuffer? GetPixels(SixelData image)
         {
+            if (image.TryGetCachedPixels(out var cached, out var attempted))
+                return cached;
+            if (attempted)
+                return null;
+
+            var raster = GetRaster(image);
+            var candidate = image.ComputePixelCandidate(raster);
             lock (syncRoot)
             {
                 if (!screen.Images.Contains(image))
                 {
                     image.DetachRetainedResourceOwner(this);
-                    return image.GetPixelsUnowned();
+                    return image.PublishPixelsUnowned(raster, candidate);
                 }
-                return image.GetPixelsOwned(bytes => tryReserve(screen, image, bytes));
+
+                return image.PublishPixelsOwned(
+                    raster,
+                    candidate,
+                    bytes => tryReserve(screen, image, bytes));
             }
         }
     }
 
     internal SixelScreenGraphicsState(
         object syncRoot,
+        TerminalGraphicsRetainedBudget retainedBudget,
         Func<SixelScreenGraphicsState, SixelData, long, bool> tryReserve)
     {
-        Images = new SixelImageStore(new RetainedResourceOwner(this, syncRoot, tryReserve));
+        RetainedBudget = retainedBudget;
+        Images = new SixelImageStore(
+            new RetainedResourceOwner(this, syncRoot, tryReserve),
+            retainedBudget);
     }
 
     internal SixelImageStore Images { get; }
+
+    internal TerminalGraphicsRetainedBudget RetainedBudget { get; }
 
     internal List<SixelPlacement> Placements { get; } = [];
 

--- a/src/Hex1b/SixelData.cs
+++ b/src/Hex1b/SixelData.cs
@@ -278,59 +278,106 @@ public sealed class SixelData
     internal void DetachRetainedResourceOwner(ISixelRetainedResourceOwner owner) =>
         Interlocked.CompareExchange(ref _retainedResourceOwner, null, owner);
 
-    internal SixelRasterResult GetRasterOwned(Func<long, bool> tryReserve)
+    internal bool TryGetCachedRaster(out SixelRasterResult raster)
+    {
+        lock (_decodeLock)
+        {
+            raster = _raster!;
+            return raster is not null;
+        }
+    }
+
+    internal SixelRasterResult ComputeRasterCandidate()
+    {
+        lock (_decodeLock)
+        {
+            return _raster ??
+                SixelRasterizer.Rasterize(ParseResult, GetRasterEnvironment());
+        }
+    }
+
+    internal SixelRasterResult PublishRasterOwned(
+        SixelRasterResult candidate,
+        Func<long, bool> tryReserve)
     {
         lock (_decodeLock)
         {
             if (_raster is not null)
                 return _raster;
 
-            var candidate = SixelRasterizer.Rasterize(ParseResult, GetRasterEnvironment());
-            var retainedBytes = SixelRetainedSize.GetRasterBytes(candidate);
-            if (tryReserve(retainedBytes))
+            if (tryReserve(SixelRetainedSize.GetRasterBytes(candidate)))
                 _raster = candidate;
             return candidate;
         }
     }
 
-    internal SixelPixelBuffer? GetPixelsOwned(Func<long, bool> tryReserve)
+    internal SixelRasterResult PublishRasterUnowned(SixelRasterResult candidate)
+    {
+        lock (_decodeLock)
+            return _raster ??= candidate;
+    }
+
+    internal bool TryGetCachedPixels(
+        out SixelPixelBuffer? pixels,
+        out bool attempted)
+    {
+        lock (_decodeLock)
+        {
+            pixels = _decodedPixels;
+            attempted = _decodeAttempted;
+            return pixels is not null;
+        }
+    }
+
+    internal SixelPixelBuffer? ComputePixelCandidate(SixelRasterResult raster)
     {
         lock (_decodeLock)
         {
             if (_decodeAttempted)
                 return _decodedPixels;
+            return raster.Image?.Materialize();
+        }
+    }
 
-            var raster = _raster;
-            if (raster is null)
+    internal SixelPixelBuffer? PublishPixelsOwned(
+        SixelRasterResult raster,
+        SixelPixelBuffer? candidate,
+        Func<long, bool> tryReserve)
+    {
+        lock (_decodeLock)
+        {
+            if (_decodeAttempted)
+                return _decodedPixels;
+            if (!ReferenceEquals(_raster, raster))
+                return candidate;
+            if (candidate is null)
             {
-                var candidate = SixelRasterizer.Rasterize(ParseResult, GetRasterEnvironment());
-                if (tryReserve(SixelRetainedSize.GetRasterBytes(candidate)))
-                {
-                    _raster = candidate;
-                    raster = candidate;
-                }
-                else
-                {
-                    raster = candidate;
-                }
-            }
-
-            var pixels = raster.Image?.Materialize();
-            if (pixels is null)
-            {
-                if (ReferenceEquals(raster, _raster))
-                    _decodeAttempted = true;
+                _decodeAttempted = true;
                 return null;
             }
 
-            if (ReferenceEquals(raster, _raster) &&
-                tryReserve(SixelRetainedSize.GetDensePixelBytes(pixels)))
+            if (tryReserve(SixelRetainedSize.GetDensePixelBytes(candidate)))
             {
-                _decodedPixels = pixels;
+                _decodedPixels = candidate;
                 _decodeAttempted = true;
             }
 
-            return pixels;
+            return candidate;
+        }
+    }
+
+    internal SixelPixelBuffer? PublishPixelsUnowned(
+        SixelRasterResult raster,
+        SixelPixelBuffer? candidate)
+    {
+        lock (_decodeLock)
+        {
+            _raster ??= raster;
+            if (_decodeAttempted)
+                return _decodedPixels;
+            _decodedPixels = candidate;
+            _decodeAttempted = true;
+            return candidate;
         }
     }
 

--- a/src/Hex1b/SixelData.cs
+++ b/src/Hex1b/SixelData.cs
@@ -25,6 +25,7 @@ public sealed class SixelData
 {
     private readonly object _decodeLock = new();
     private readonly SixelRasterPreparation? _rasterPreparation;
+    private ISixelRetainedResourceOwner? _retainedResourceOwner;
     private SixelRasterResult? _raster;
     private SixelPixelBuffer? _decodedPixels;
     private bool _decodeAttempted;
@@ -66,6 +67,7 @@ public sealed class SixelData
     public byte[] ContentHash { get; }
 
     internal SixelParseResult ParseResult { get; }
+    internal SixelRasterPreparation? RasterPreparation => _rasterPreparation;
     internal bool PayloadComplete { get; }
 
     /// <summary>
@@ -91,19 +93,21 @@ public sealed class SixelData
     /// </summary>
     /// <remarks>
     /// Terminal-created data captures an immutable background and palette
-    /// preparation so rasterization can occur on first use without holding the
-    /// terminal buffer lock. Data created without terminal state uses the
-    /// deterministic default environment.
+    /// preparation. First use reserves retained bytes atomically with the owning
+    /// screen before caching the result. Data created without terminal state uses
+    /// the deterministic default environment.
     /// </remarks>
     internal SixelRasterResult Raster
     {
         get
         {
+            var owner = Volatile.Read(ref _retainedResourceOwner);
+            if (owner is not null)
+                return owner.GetRaster(this);
+
             lock (_decodeLock)
             {
-                return _raster ??= SixelRasterizer.Rasterize(
-                    ParseResult,
-                    GetRasterEnvironment());
+                return GetRasterUnowned();
             }
         }
     }
@@ -217,7 +221,9 @@ public sealed class SixelData
 
     /// <summary>
     /// Materializes the sixel payload as a dense pixel buffer.
-    /// The result is cached, and repeated calls produce equal content.
+    /// The result is cached when the owning live screen's retained-byte budget
+    /// admits it. If that cache cannot fit, the returned buffer is not retained
+    /// by the live terminal and a later call may materialize it again.
     /// </summary>
     /// <returns>
     /// The materialized pixel buffer, or <see langword="null"/> when the
@@ -225,19 +231,13 @@ public sealed class SixelData
     /// </returns>
     public SixelPixelBuffer? GetPixels()
     {
+        var owner = Volatile.Read(ref _retainedResourceOwner);
+        if (owner is not null)
+            return owner.GetPixels(this);
+
         lock (_decodeLock)
         {
-            if (_decodeAttempted)
-            {
-                return _decodedPixels;
-            }
-
-            _raster ??= SixelRasterizer.Rasterize(
-                ParseResult,
-                GetRasterEnvironment());
-            _decodedPixels = _raster.Image?.Materialize();
-            _decodeAttempted = true;
-            return _decodedPixels;
+            return GetPixelsUnowned();
         }
     }
 
@@ -249,6 +249,88 @@ public sealed class SixelData
             {
                 return _decodedPixels is not null;
             }
+        }
+    }
+
+    internal long RetainedByteCount
+    {
+        get
+        {
+            lock (_decodeLock)
+            {
+                var total = SixelRetainedSize.GetInitialBytes(this);
+                if (_raster is not null)
+                    total = SaturatingAdd(total, SixelRetainedSize.GetRasterBytes(_raster));
+                if (_decodedPixels is not null)
+                    total = SaturatingAdd(total, SixelRetainedSize.GetDensePixelBytes(_decodedPixels));
+                return total;
+            }
+        }
+    }
+
+    internal void AttachRetainedResourceOwner(ISixelRetainedResourceOwner owner)
+    {
+        ArgumentNullException.ThrowIfNull(owner);
+        if (Interlocked.CompareExchange(ref _retainedResourceOwner, owner, null) is not null)
+            throw new InvalidOperationException("The Sixel image is already owned by a screen.");
+    }
+
+    internal void DetachRetainedResourceOwner(ISixelRetainedResourceOwner owner) =>
+        Interlocked.CompareExchange(ref _retainedResourceOwner, null, owner);
+
+    internal SixelRasterResult GetRasterOwned(Func<long, bool> tryReserve)
+    {
+        lock (_decodeLock)
+        {
+            if (_raster is not null)
+                return _raster;
+
+            var candidate = SixelRasterizer.Rasterize(ParseResult, GetRasterEnvironment());
+            var retainedBytes = SixelRetainedSize.GetRasterBytes(candidate);
+            if (tryReserve(retainedBytes))
+                _raster = candidate;
+            return candidate;
+        }
+    }
+
+    internal SixelPixelBuffer? GetPixelsOwned(Func<long, bool> tryReserve)
+    {
+        lock (_decodeLock)
+        {
+            if (_decodeAttempted)
+                return _decodedPixels;
+
+            var raster = _raster;
+            if (raster is null)
+            {
+                var candidate = SixelRasterizer.Rasterize(ParseResult, GetRasterEnvironment());
+                if (tryReserve(SixelRetainedSize.GetRasterBytes(candidate)))
+                {
+                    _raster = candidate;
+                    raster = candidate;
+                }
+                else
+                {
+                    raster = candidate;
+                }
+            }
+
+            var pixels = raster.Image?.Materialize();
+            if (pixels is null)
+            {
+                if (ReferenceEquals(raster, _raster))
+                    _decodeAttempted = true;
+                return null;
+            }
+
+            if (ReferenceEquals(raster, _raster) &&
+                tryReserve(SixelRetainedSize.GetDensePixelBytes(pixels)))
+            {
+                _decodedPixels = pixels;
+                _decodeAttempted = true;
+            }
+
+            return pixels;
         }
     }
 
@@ -372,4 +454,33 @@ public sealed class SixelData
 
     private SixelRasterEnvironment GetRasterEnvironment() =>
         _rasterPreparation?.Environment ?? SixelRasterEnvironment.CreateDefault();
+
+    internal SixelRasterResult GetRasterUnowned()
+    {
+        lock (_decodeLock)
+        {
+            return _raster ??= SixelRasterizer.Rasterize(
+                ParseResult,
+                GetRasterEnvironment());
+        }
+    }
+
+    internal SixelPixelBuffer? GetPixelsUnowned()
+    {
+        lock (_decodeLock)
+        {
+            if (_decodeAttempted)
+                return _decodedPixels;
+
+            _raster ??= SixelRasterizer.Rasterize(
+                ParseResult,
+                GetRasterEnvironment());
+            _decodedPixels = _raster.Image?.Materialize();
+            _decodeAttempted = true;
+            return _decodedPixels;
+        }
+    }
+
+    private static long SaturatingAdd(long left, long right) =>
+        right > long.MaxValue - left ? long.MaxValue : left + right;
 }

--- a/src/Hex1b/TerminalGraphicsRetainedBudget.cs
+++ b/src/Hex1b/TerminalGraphicsRetainedBudget.cs
@@ -44,6 +44,15 @@ internal sealed class TerminalGraphicsRetainedBudget
         }
     }
 
+    internal long MaximumSixelBytes
+    {
+        get
+        {
+            lock (_lock)
+                return Math.Max(0, MaximumBytes - _kgpBytes);
+        }
+    }
+
     internal bool CanSetSixelBytes(long bytes)
     {
         ArgumentOutOfRangeException.ThrowIfNegative(bytes);

--- a/src/Hex1b/TerminalGraphicsRetainedBudget.cs
+++ b/src/Hex1b/TerminalGraphicsRetainedBudget.cs
@@ -1,0 +1,88 @@
+namespace Hex1b;
+
+/// <summary>
+/// Shared retained-image byte accounting for one terminal screen.
+/// </summary>
+internal sealed class TerminalGraphicsRetainedBudget
+{
+    private readonly object _lock = new();
+    private long _kgpBytes;
+    private long _sixelBytes;
+
+    internal TerminalGraphicsRetainedBudget(long maximumBytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(maximumBytes);
+        MaximumBytes = maximumBytes;
+    }
+
+    internal long MaximumBytes { get; }
+
+    internal long KgpBytes
+    {
+        get
+        {
+            lock (_lock)
+                return _kgpBytes;
+        }
+    }
+
+    internal long SixelBytes
+    {
+        get
+        {
+            lock (_lock)
+                return _sixelBytes;
+        }
+    }
+
+    internal long MaximumKgpBytes
+    {
+        get
+        {
+            lock (_lock)
+                return Math.Max(0, MaximumBytes - _sixelBytes);
+        }
+    }
+
+    internal bool CanSetSixelBytes(long bytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(bytes);
+        lock (_lock)
+            return bytes <= MaximumBytes - _kgpBytes;
+    }
+
+    internal void SetKgpBytes(long bytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(bytes);
+        lock (_lock)
+        {
+            if (bytes > MaximumBytes - _sixelBytes)
+                throw new InvalidOperationException("KGP retained bytes exceed the shared screen budget.");
+            _kgpBytes = bytes;
+        }
+    }
+
+    internal void SetSixelBytes(long bytes)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(bytes);
+        lock (_lock)
+        {
+            if (bytes > MaximumBytes - _kgpBytes)
+                throw new InvalidOperationException("Sixel retained bytes exceed the shared screen budget.");
+            _sixelBytes = bytes;
+        }
+    }
+}
+
+internal sealed class TerminalGraphicsRetainedBudgetSet
+{
+    internal TerminalGraphicsRetainedBudgetSet(long maximumBytesPerScreen)
+    {
+        Main = new TerminalGraphicsRetainedBudget(maximumBytesPerScreen);
+        Alternate = new TerminalGraphicsRetainedBudget(maximumBytesPerScreen);
+    }
+
+    internal TerminalGraphicsRetainedBudget Main { get; }
+
+    internal TerminalGraphicsRetainedBudget Alternate { get; }
+}

--- a/tests/Hex1b.Tests/Hmp1/Hmp1SixelStateReplayTests.cs
+++ b/tests/Hex1b.Tests/Hmp1/Hmp1SixelStateReplayTests.cs
@@ -243,6 +243,24 @@ public class Hmp1SixelStateReplayTests
     }
 
     [TestMethod]
+    public void BuildPlacementSequence_ReplayedIntoZeroBudgetTerminal_IsRejectedCleanly()
+    {
+        using var producer = CreateHeadlessTerminal();
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1bPq#1;2;100;0;0#1@\x1b\\"));
+        using var producerSnapshot = producer.CreateSnapshot();
+        var placement = TestSeq.Single(producerSnapshot.SixelPlacements);
+        var replay = Hmp1SixelStateReplay.BuildPlacementSequence(placement);
+
+        using var viewer = CreateHeadlessTerminal(maximumRetainedBytesPerScreen: 0);
+        viewer.ApplyTokens(AnsiTokenizer.Tokenize(replay));
+
+        Assert.AreEqual(0, viewer.SixelPlacementCount);
+        Assert.AreEqual(0, viewer.TrackedSixelCount);
+        Assert.AreEqual(0L, viewer.SixelRetainedByteCount);
+    }
+
+    [TestMethod]
     public async Task WriteAsync_PlacementCountExceedsLimit_ReturnsTypedLimitWithoutWriting()
     {
         using var producer = CreateHeadlessTerminal();
@@ -329,11 +347,14 @@ public class Hmp1SixelStateReplayTests
         Assert.AreEqual(0, stream.Length);
     }
 
-    private static Hex1bTerminal CreateHeadlessTerminal() =>
+    private static Hex1bTerminal CreateHeadlessTerminal(
+        long maximumRetainedBytesPerScreen = 320L * 1024 * 1024) =>
         Hex1bTerminal.CreateBuilder()
             .WithDimensions(20, 10)
             .WithWorkload(new NullWorkloadAdapter())
             .WithHeadless(new TerminalCapabilities { SupportsSixel = true })
+            .WithGraphics(options =>
+                options.MaximumRetainedBytesPerScreen = maximumRetainedBytesPerScreen)
             .Build();
 
     private sealed class NullWorkloadAdapter : IHex1bTerminalWorkloadAdapter

--- a/tests/Hex1b.Tests/Sixel/SixelHardeningFuzzTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelHardeningFuzzTests.cs
@@ -115,6 +115,9 @@ public class SixelHardeningFuzzTests
                         Assert.IsLessThanOrEqualTo(
                             graphics.MaximumImagesPerScreen,
                             viewer.TrackedSixelCount);
+                        Assert.IsLessThanOrEqualTo(
+                            graphics.MaximumRetainedBytesPerScreen,
+                            viewer.SixelRetainedByteCount);
                         using var viewerSnapshot = viewer.CreateSnapshot();
                         Assert.IsLessThanOrEqualTo(
                             graphics.MaximumPlacementsPerScreen +
@@ -126,6 +129,9 @@ public class SixelHardeningFuzzTests
 
             Assert.IsLessThanOrEqualTo(policy.MaximumPlacementsPerScreen, terminal.SixelPlacementCount);
             Assert.IsLessThanOrEqualTo(policy.MaximumImagesPerScreen, terminal.TrackedSixelCount);
+            Assert.IsLessThanOrEqualTo(
+                graphics.MaximumRetainedBytesPerScreen,
+                terminal.SixelRetainedByteCount);
             using var current = terminal.CreateSnapshot();
             Assert.IsLessThanOrEqualTo(
                 policy.MaximumPlacementsPerScreen + policy.MaximumHistoryPlacements,

--- a/tests/Hex1b.Tests/Sixel/SixelRetainedMemoryBudgetTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelRetainedMemoryBudgetTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Runtime.CompilerServices;
 using Hex1b.Reflow;
 using Hex1b.Sixel;
 using Hex1b.Tokens;
@@ -133,15 +134,16 @@ public class SixelRetainedMemoryBudgetTests
     }
 
     [TestMethod]
-    public async Task DenseMaterialization_EvictsOlderImageBeforeCachingGrowth()
+    public async Task DenseMaterialization_WhenBudgetIsFull_DoesNotEvictOlderImage()
     {
         var first = Frame("#1;2;100;0;0#1!8~");
         var second = Frame("#2;2;0;100;0#2!8~");
         var firstSizes = await MeasureStagesAsync(first);
         var secondSizes = await MeasureStagesAsync(second);
         var budget = checked(firstSizes.Initial + secondSizes.Rasterized);
-        Assert.IsGreaterThan(secondSizes.Rasterized, secondSizes.Dense);
-        Assert.IsLessThanOrEqualTo(budget, secondSizes.Dense);
+        Assert.IsTrue(secondSizes.Dense > secondSizes.Rasterized);
+        Assert.IsTrue(
+            checked(firstSizes.Initial + secondSizes.Dense) > budget);
 
         await using var terminal = SixelTestTerminal.Create(
             graphics: GraphicsWithBudget(budget));
@@ -158,12 +160,14 @@ public class SixelRetainedMemoryBudgetTests
         var newest = terminal.Terminal.SixelPlacements.MaxBy(placement => placement.Sequence)!;
         Assert.AreEqual(SixelRasterStatus.Rasterized, newest.Image.RasterStatus);
         Assert.AreEqual(2, terminal.Terminal.TrackedSixelCount);
+        var before = terminal.Terminal.SixelRetainedByteCount;
 
         Assert.IsNotNull(newest.Image.GetPixels());
 
-        Assert.IsTrue(newest.Image.HasMaterializedPixels);
-        Assert.AreEqual(1, terminal.Terminal.TrackedSixelCount);
-        Assert.AreSame(newest.Image, TestSeq.Single(terminal.Terminal.SixelPlacements).Image);
+        Assert.IsFalse(newest.Image.HasMaterializedPixels);
+        Assert.AreEqual(2, terminal.Terminal.TrackedSixelCount);
+        Assert.AreEqual(2, terminal.Terminal.SixelPlacementCount);
+        Assert.AreEqual(before, terminal.Terminal.SixelRetainedByteCount);
         Assert.IsLessThanOrEqualTo(budget, terminal.Terminal.SixelRetainedByteCount);
     }
 
@@ -286,6 +290,100 @@ public class SixelRetainedMemoryBudgetTests
         Assert.IsNotNull(image.GetPixels());
         Assert.IsTrue(image.HasMaterializedPixels);
         Assert.AreEqual(0L, terminal.Terminal.SixelRetainedByteCount);
+    }
+
+    [TestMethod]
+    public async Task SnapshotExportsAndHmp1Replay_DoNotEvictLivePlacements()
+    {
+        var first = Frame("#1;2;100;0;0#1!8~");
+        var second = Frame("#2;2;0;100;0#2!8~");
+        var firstSizes = await MeasureStagesAsync(first);
+        var secondSizes = await MeasureStagesAsync(second);
+        var budget = checked(firstSizes.Initial + secondSizes.Initial);
+        await using var terminal = SixelTestTerminal.Create(
+            graphics: GraphicsWithBudget(budget));
+        await terminal.FeedAsync(
+            first.Concat(Encoding.ASCII.GetBytes("\x1b[2;1H"))
+                .Concat(second)
+                .ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.SixelPlacementCount == 2,
+            "two images before read-only materialization",
+            TestContext.Current.CancellationToken);
+        var before = terminal.Terminal.SixelRetainedByteCount;
+
+        using var snapshot = terminal.Terminal.CreateSnapshot();
+        _ = snapshot.ToSvg();
+        _ = snapshot.ToHtml();
+        foreach (var placement in snapshot.SixelPlacements)
+            _ = Hmp1SixelStateReplay.BuildPlacementSequence(placement);
+
+        Assert.AreEqual(2, terminal.Terminal.SixelPlacementCount);
+        Assert.AreEqual(2, terminal.Terminal.TrackedSixelCount);
+        Assert.AreEqual(before, terminal.Terminal.SixelRetainedByteCount);
+    }
+
+    [TestMethod]
+    public async Task MixedProtocols_ShareOneScreenBudgetWithoutCrossProtocolEviction()
+    {
+        var frame = Frame("#1;2;100;0;0#1@");
+        var sixelBytes = await MeasureInitialBytesAsync(frame);
+        var graphics = GraphicsWithBudget(sixelBytes);
+        await using var kgpFirst = SixelTestTerminal.Create(
+            supportsKgp: true,
+            graphics: graphics);
+
+        kgpFirst.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildTransmitCommand(
+                imageId: 1,
+                width: 1,
+                height: 1,
+                quiet: 2)));
+        Assert.AreEqual(4L, kgpFirst.Terminal.KgpImageStore.TotalSize);
+        await FeedAndWaitAsync(kgpFirst, frame, expectedPlacements: 0);
+        Assert.AreEqual(4L, kgpFirst.Terminal.GraphicsRetainedByteCount);
+        Assert.IsNotNull(kgpFirst.Terminal.KgpImageStore.GetImageById(1));
+
+        kgpFirst.Terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[?1049h"));
+        Assert.AreEqual(0L, kgpFirst.Terminal.GraphicsRetainedByteCount);
+        await FeedAndWaitAsync(kgpFirst, frame, expectedPlacements: 1);
+        Assert.AreEqual(sixelBytes, kgpFirst.Terminal.GraphicsRetainedByteCount);
+        kgpFirst.Terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[?1049l"));
+        Assert.AreEqual(4L, kgpFirst.Terminal.GraphicsRetainedByteCount);
+        Assert.IsNotNull(kgpFirst.Terminal.KgpImageStore.GetImageById(1));
+
+        await using var sixelFirst = SixelTestTerminal.Create(
+            supportsKgp: true,
+            graphics: graphics);
+        await FeedAndWaitAsync(sixelFirst, frame, expectedPlacements: 1);
+        sixelFirst.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildTransmitCommand(
+                imageId: 1,
+                width: 1,
+                height: 1,
+                quiet: 2)));
+
+        Assert.IsNull(sixelFirst.Terminal.KgpImageStore.GetImageById(1));
+        Assert.AreEqual(1, sixelFirst.Terminal.SixelPlacementCount);
+        Assert.AreEqual(sixelBytes, sixelFirst.Terminal.GraphicsRetainedByteCount);
+    }
+
+    [TestMethod]
+    public async Task PayloadAndCommandMetadata_AreCountedAsRetainedManagedContent()
+    {
+        var body = "#1;2;100;0;0" + string.Concat(Enumerable.Repeat("#1@", 256));
+        var frame = Frame(body);
+        await using var terminal = SixelTestTerminal.Create();
+        await FeedAndWaitAsync(terminal, frame, expectedPlacements: 1);
+        var image = TestSeq.Single(terminal.Terminal.SixelPlacements).Image;
+        var minimumPayloadAndCommands =
+            ((long)image.Payload.Length * sizeof(char)) +
+            ((long)image.ParseResult.Commands.Count * Unsafe.SizeOf<SixelCommand>());
+
+        Assert.IsGreaterThanOrEqualTo(
+            minimumPayloadAndCommands,
+            terminal.Terminal.SixelRetainedByteCount);
     }
 
     [TestMethod]

--- a/tests/Hex1b.Tests/Sixel/SixelRetainedMemoryBudgetTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelRetainedMemoryBudgetTests.cs
@@ -1,0 +1,405 @@
+using System.Text;
+using Hex1b.Reflow;
+using Hex1b.Sixel;
+using Hex1b.Tokens;
+
+namespace Hex1b.Tests.Sixel;
+
+[TestClass]
+public class SixelRetainedMemoryBudgetTests
+{
+    [TestMethod]
+    public async Task InitialImage_ExactBudgetIsRetained_BoundaryMinusOneIsRejected()
+    {
+        var frame = Frame("#1;2;100;0;0#1@");
+        var requiredBytes = await MeasureInitialBytesAsync(frame);
+
+        await using var exact = SixelTestTerminal.Create(
+            graphics: GraphicsWithBudget(requiredBytes));
+        await FeedAndWaitAsync(exact, frame, expectedPlacements: 1);
+        Assert.AreEqual(requiredBytes, exact.Terminal.SixelRetainedByteCount);
+
+        await using var below = SixelTestTerminal.Create(
+            graphics: GraphicsWithBudget(requiredBytes - 1));
+        await FeedAndWaitAsync(below, frame, expectedPlacements: 0);
+        Assert.AreEqual(0, below.Terminal.TrackedSixelCount);
+        Assert.AreEqual(0L, below.Terminal.SixelRetainedByteCount);
+    }
+
+    [TestMethod]
+    public async Task ZeroBudget_RejectsSixelWithoutDisturbingTerminalProgress()
+    {
+        await using var terminal = SixelTestTerminal.Create(
+            graphics: GraphicsWithBudget(0));
+
+        await terminal.FeedAsync(
+            Frame("#1;2;100;0;0#1@").Concat("Z"u8.ToArray()).ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsText("Z"),
+            "terminal progressed after rejected Sixel",
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(0, terminal.Terminal.SixelPlacementCount);
+        Assert.AreEqual(0, terminal.Terminal.TrackedSixelCount);
+        Assert.AreEqual(0L, terminal.Terminal.SixelRetainedByteCount);
+    }
+
+    [TestMethod]
+    public async Task ManyTinyHighPayloadImages_EvictOldestResourcesDeterministically()
+    {
+        var frames = Enumerable.Range(1, 8)
+            .Select(register => Frame(
+                $"#{register};2;{register};{register};{register}" +
+                string.Concat(Enumerable.Repeat($"#{register}", 1024)) +
+                "@"))
+            .ToArray();
+        var oneImageBytes = await MeasureInitialBytesAsync(frames[0]);
+        var graphics = GraphicsWithBudget(checked(oneImageBytes * 2));
+        graphics.MaximumImagesPerScreen = 16;
+        graphics.MaximumPlacementsPerScreen = 16;
+        await using var terminal = SixelTestTerminal.Create(height: 12, graphics: graphics);
+
+        var stream = new List<byte>();
+        for (var index = 0; index < frames.Length; index++)
+        {
+            stream.AddRange(Encoding.ASCII.GetBytes($"\x1b[{index + 1};1H"));
+            stream.AddRange(frames[index]);
+        }
+        stream.Add((byte)'Z');
+
+        await terminal.FeedAsync(
+            stream.ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsText("Z"),
+            "high-payload image sequence",
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(2, terminal.Terminal.TrackedSixelCount);
+        Assert.IsLessThanOrEqualTo(
+            graphics.MaximumRetainedBytesPerScreen,
+            terminal.Terminal.SixelRetainedByteCount);
+        Assert.IsTrue(terminal.Terminal.SixelPlacements.Any(
+            placement => placement.Image.Payload.Contains("#7;2;7;7;7", StringComparison.Ordinal)));
+        Assert.IsTrue(terminal.Terminal.SixelPlacements.Any(
+            placement => placement.Image.Payload.Contains("#8;2;8;8;8", StringComparison.Ordinal)));
+    }
+
+    [TestMethod]
+    public async Task DeduplicatedPlacements_CountImageBytesOnce()
+    {
+        var frame = Frame("#1;2;100;0;0#1@");
+        await using var terminal = SixelTestTerminal.Create();
+
+        await FeedAndWaitAsync(terminal, frame, expectedPlacements: 1);
+        var retainedBytes = terminal.Terminal.SixelRetainedByteCount;
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[2;1H")
+                .Concat(frame)
+                .ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.SixelPlacementCount == 2,
+            "deduplicated placement",
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(1, terminal.Terminal.TrackedSixelCount);
+        Assert.AreEqual(retainedBytes, terminal.Terminal.SixelRetainedByteCount);
+        Assert.AreSame(
+            terminal.Terminal.SixelPlacements[0].Image,
+            terminal.Terminal.SixelPlacements[1].Image);
+    }
+
+    [TestMethod]
+    public async Task SparseRasterTiles_AreAddedToRetainedByteAccounting()
+    {
+        var frame = Frame(
+            "\"1;1;8193;6#1;2;100;0;0#1@!4095?@!4095?@");
+        await using var terminal = SixelTestTerminal.Create(
+            width: 20,
+            graphics: GraphicsWithBudget(8L * 1024 * 1024));
+        await FeedAndWaitAsync(terminal, frame, expectedPlacements: 1);
+
+        var image = TestSeq.Single(terminal.Terminal.SixelPlacements).Image;
+        var before = terminal.Terminal.SixelRetainedByteCount;
+
+        Assert.AreEqual(SixelRasterStatus.Rasterized, image.RasterStatus);
+
+        var after = terminal.Terminal.SixelRetainedByteCount;
+        Assert.AreEqual(image.RetainedByteCount, after);
+        Assert.IsGreaterThanOrEqualTo(3L * ((64 * 64 * 4) + sizeof(long)), after - before);
+    }
+
+    [TestMethod]
+    public async Task DenseMaterialization_EvictsOlderImageBeforeCachingGrowth()
+    {
+        var first = Frame("#1;2;100;0;0#1!8~");
+        var second = Frame("#2;2;0;100;0#2!8~");
+        var firstSizes = await MeasureStagesAsync(first);
+        var secondSizes = await MeasureStagesAsync(second);
+        var budget = checked(firstSizes.Initial + secondSizes.Rasterized);
+        Assert.IsGreaterThan(secondSizes.Rasterized, secondSizes.Dense);
+        Assert.IsLessThanOrEqualTo(budget, secondSizes.Dense);
+
+        await using var terminal = SixelTestTerminal.Create(
+            graphics: GraphicsWithBudget(budget));
+        await terminal.FeedAsync(
+            first.Concat(Encoding.ASCII.GetBytes("\x1b[2;1H"))
+                .Concat(second)
+                .ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.SixelPlacementCount == 2,
+            "two images before dense materialization",
+            TestContext.Current.CancellationToken);
+
+        var newest = terminal.Terminal.SixelPlacements.MaxBy(placement => placement.Sequence)!;
+        Assert.AreEqual(SixelRasterStatus.Rasterized, newest.Image.RasterStatus);
+        Assert.AreEqual(2, terminal.Terminal.TrackedSixelCount);
+
+        Assert.IsNotNull(newest.Image.GetPixels());
+
+        Assert.IsTrue(newest.Image.HasMaterializedPixels);
+        Assert.AreEqual(1, terminal.Terminal.TrackedSixelCount);
+        Assert.AreSame(newest.Image, TestSeq.Single(terminal.Terminal.SixelPlacements).Image);
+        Assert.IsLessThanOrEqualTo(budget, terminal.Terminal.SixelRetainedByteCount);
+    }
+
+    [TestMethod]
+    public async Task DenseCacheThatCannotFit_IsReturnedUncachedWithoutCorruptingState()
+    {
+        var frame = Frame("#1;2;100;0;0#1!8~");
+        var sizes = await MeasureStagesAsync(frame);
+        await using var terminal = SixelTestTerminal.Create(
+            graphics: GraphicsWithBudget(sizes.Rasterized));
+        await FeedAndWaitAsync(terminal, frame, expectedPlacements: 1);
+
+        var image = TestSeq.Single(terminal.Terminal.SixelPlacements).Image;
+        Assert.AreEqual(SixelRasterStatus.Rasterized, image.RasterStatus);
+        var before = terminal.Terminal.SixelRetainedByteCount;
+
+        Assert.IsNotNull(image.GetPixels());
+
+        Assert.IsFalse(image.HasMaterializedPixels);
+        Assert.AreEqual(before, terminal.Terminal.SixelRetainedByteCount);
+        Assert.AreEqual(1, terminal.Terminal.SixelPlacementCount);
+    }
+
+    [TestMethod]
+    public async Task MainAndAlternateScreens_HaveIndependentBudgetsAndCleanup()
+    {
+        var mainFrame = Frame("#1;2;100;0;0#1@");
+        var alternateFrame = Frame("#2;2;0;100;0#2A");
+        var budget = Math.Max(
+            await MeasureInitialBytesAsync(mainFrame),
+            await MeasureInitialBytesAsync(alternateFrame));
+        await using var terminal = SixelTestTerminal.Create(
+            graphics: GraphicsWithBudget(budget));
+
+        await FeedAndWaitAsync(terminal, mainFrame, expectedPlacements: 1);
+        var mainBytes = terminal.Terminal.SixelRetainedByteCount;
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[?1049h")
+                .Concat(alternateFrame)
+                .ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.InAlternateScreen &&
+                terminal.Terminal.SixelPlacementCount == 1,
+            "alternate image",
+            TestContext.Current.CancellationToken);
+        Assert.IsGreaterThan(0L, terminal.Terminal.SixelRetainedByteCount);
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[?1049l"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => !snapshot.InAlternateScreen,
+            "main image restored",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(mainBytes, terminal.Terminal.SixelRetainedByteCount);
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[?1049h"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.InAlternateScreen,
+            "fresh alternate screen",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(0L, terminal.Terminal.SixelRetainedByteCount);
+    }
+
+    [TestMethod]
+    public async Task ResetAndDisposal_ClearRetainedByteAccounting()
+    {
+        var frame = Frame("#1;2;100;0;0#1@");
+        var terminal = SixelTestTerminal.Create();
+        try
+        {
+            await FeedAndWaitAsync(terminal, frame, expectedPlacements: 1);
+            Assert.IsGreaterThan(0L, terminal.Terminal.SixelRetainedByteCount);
+
+            await terminal.FeedPreTokenizedAsync(
+                Encoding.ASCII.GetBytes("\x1bc"),
+                [RisToken.Instance],
+                TestContext.Current.CancellationToken);
+            await terminal.WaitForAsync(
+                _ => terminal.Terminal.SixelRetainedByteCount == 0,
+                "retained bytes cleared by RIS",
+                TestContext.Current.CancellationToken);
+            Assert.AreEqual(0L, terminal.Terminal.SixelRetainedByteCount);
+
+            await FeedAndWaitAsync(terminal, frame, expectedPlacements: 1);
+        }
+        finally
+        {
+            await terminal.DisposeAsync();
+        }
+
+        Assert.AreEqual(0L, terminal.Terminal.SixelRetainedByteCount);
+    }
+
+    [TestMethod]
+    public async Task SnapshotAfterLiveEviction_CanMaterializeOutsideLiveBudget()
+    {
+        var frame = Frame("#1;2;100;0;0#1!8~");
+        var sizes = await MeasureStagesAsync(frame);
+        await using var terminal = SixelTestTerminal.Create(
+            graphics: GraphicsWithBudget(sizes.Rasterized));
+        await FeedAndWaitAsync(terminal, frame, expectedPlacements: 1);
+
+        using var snapshot = terminal.Terminal.CreateSnapshot();
+        var image = TestSeq.Single(snapshot.SixelImages.Values);
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[2J"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            _ => terminal.Terminal.SixelPlacementCount == 0,
+            "live image evicted",
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(0L, terminal.Terminal.SixelRetainedByteCount);
+        Assert.IsNotNull(image.GetPixels());
+        Assert.IsTrue(image.HasMaterializedPixels);
+        Assert.AreEqual(0L, terminal.Terminal.SixelRetainedByteCount);
+    }
+
+    [TestMethod]
+    public async Task DamageHistoryPruningAndReflow_KeepAccountingReachabilityExact()
+    {
+        var frame = Frame("#1;2;100;0;0#1!2~");
+        await using var damageTerminal = SixelTestTerminal.Create();
+        await FeedAndWaitAsync(damageTerminal, frame, expectedPlacements: 1);
+        var beforeDamage = damageTerminal.Terminal.SixelRetainedByteCount;
+        await damageTerminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[1;1HX"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await damageTerminal.WaitForAsync(
+            snapshot => snapshot.ContainsText("X"),
+            "placement partially damaged",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(beforeDamage, damageTerminal.Terminal.SixelRetainedByteCount);
+        Assert.AreEqual(1, damageTerminal.Terminal.SixelPlacementCount);
+
+        await damageTerminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[2J"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await damageTerminal.WaitForAsync(
+            _ => damageTerminal.Terminal.SixelPlacementCount == 0,
+            "damaged image cleared",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(0L, damageTerminal.Terminal.SixelRetainedByteCount);
+
+        await using var historyTerminal = SixelTestTerminal.Create(
+            width: 4,
+            height: 2,
+            scrollbackCapacity: 4);
+        await FeedAndWaitAsync(historyTerminal, frame, expectedPlacements: 1);
+        await historyTerminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[2;1H\n"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await historyTerminal.WaitForAsync(
+            _ => historyTerminal.Terminal.SixelHistoryPlacementCount > 0,
+            "image moved into history",
+            TestContext.Current.CancellationToken);
+        Assert.IsGreaterThan(0L, historyTerminal.Terminal.SixelRetainedByteCount);
+
+        await historyTerminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[3J"),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await historyTerminal.WaitForAsync(
+            _ => historyTerminal.Terminal.SixelHistoryPlacementCount == 0,
+            "history image cleared",
+            TestContext.Current.CancellationToken);
+        Assert.AreEqual(0L, historyTerminal.Terminal.SixelRetainedByteCount);
+
+        await using var reflowTerminal = SixelTestTerminal.Create(
+            width: 4,
+            height: 3,
+            scrollbackCapacity: 4,
+            reflow: KittyReflowStrategy.Instance);
+        await FeedAndWaitAsync(reflowTerminal, frame, expectedPlacements: 1);
+        var beforeReflow = reflowTerminal.Terminal.SixelRetainedByteCount;
+        using var snapshot = reflowTerminal.Terminal.CreateSnapshot();
+        Assert.AreEqual(beforeReflow, reflowTerminal.Terminal.SixelRetainedByteCount);
+
+        reflowTerminal.Terminal.Resize(8, 3);
+        Assert.AreEqual(beforeReflow, reflowTerminal.Terminal.SixelRetainedByteCount);
+        AssertAccountingMatchesSnapshot(reflowTerminal.Terminal);
+    }
+
+    private static Hex1bTerminalGraphicsOptions GraphicsWithBudget(long budget) => new()
+    {
+        MaximumRetainedBytesPerScreen = budget,
+    };
+
+    private static byte[] Frame(string body) =>
+        Encoding.ASCII.GetBytes($"\x1bPq{body}\x1b\\");
+
+    private static async Task FeedAndWaitAsync(
+        SixelTestTerminal terminal,
+        byte[] frame,
+        int expectedPlacements)
+    {
+        await terminal.FeedAsync(
+            frame.Concat("Z"u8.ToArray()).ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsText("Z") &&
+                terminal.Terminal.SixelPlacementCount == expectedPlacements,
+            $"{expectedPlacements} retained placements",
+            TestContext.Current.CancellationToken);
+    }
+
+    private static async Task<long> MeasureInitialBytesAsync(byte[] frame)
+    {
+        await using var terminal = SixelTestTerminal.Create();
+        await FeedAndWaitAsync(terminal, frame, expectedPlacements: 1);
+        return terminal.Terminal.SixelRetainedByteCount;
+    }
+
+    private static async Task<(long Initial, long Rasterized, long Dense)> MeasureStagesAsync(
+        byte[] frame)
+    {
+        await using var terminal = SixelTestTerminal.Create();
+        await FeedAndWaitAsync(terminal, frame, expectedPlacements: 1);
+        var image = TestSeq.Single(terminal.Terminal.SixelPlacements).Image;
+        var initial = terminal.Terminal.SixelRetainedByteCount;
+        _ = image.RasterStatus;
+        var rasterized = terminal.Terminal.SixelRetainedByteCount;
+        Assert.IsNotNull(image.GetPixels());
+        var dense = terminal.Terminal.SixelRetainedByteCount;
+        return (initial, rasterized, dense);
+    }
+
+    private static void AssertAccountingMatchesSnapshot(Hex1bTerminal terminal)
+    {
+        using var snapshot = terminal.CreateSnapshot(scrollbackLines: terminal.ScrollbackCount);
+        var retainedBytes = snapshot.SixelImages.Values.Sum(image => image.RetainedByteCount);
+        Assert.AreEqual(retainedBytes, terminal.SixelRetainedByteCount);
+    }
+}

--- a/tests/Hex1b.Tests/Sixel/SixelRetainedMemoryBudgetTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelRetainedMemoryBudgetTests.cs
@@ -414,50 +414,77 @@ public class SixelRetainedMemoryBudgetTests
     [TestMethod]
     public async Task UnfitKgpReplacement_WithResidentSixel_PreservesAllKgpState()
     {
-        var frame = Frame("#1;2;100;0;0#1@");
-        var sixelBytes = await MeasureInitialBytesAsync(frame);
-        var budget = checked(sixelBytes + 12);
-        await using var terminal = SixelTestTerminal.Create(
-            supportsKgp: true,
-            graphics: GraphicsWithBudget(budget));
+        await AssertUnfitKgpReplacementPreservesStateAsync(
+            "a=t,f=32,s=4,v=1,i=1",
+            Enumerable.Repeat((byte)0xCC, 16).ToArray(),
+            "EFBIG:Image data size 16 exceeds upload limit 13");
+    }
+
+    [TestMethod]
+    public async Task UnfitPngReplacement_NonMultipleOfThreeQuota_PreservesAllKgpState()
+    {
+        await AssertUnfitKgpReplacementPreservesStateAsync(
+            "a=t,f=100,i=1",
+            Enumerable.Range(0, 14).Select(value => (byte)value).ToArray(),
+            "ENOSPC:Image storage full");
+    }
+
+    [TestMethod]
+    public async Task UnfitCompressedReplacement_NonMultipleOfThreeQuota_PreservesAllKgpState()
+    {
+        await AssertUnfitKgpReplacementPreservesStateAsync(
+            "a=t,f=32,s=1,v=1,i=1,o=z",
+            Enumerable.Range(0, 15).Select(value => (byte)value).ToArray(),
+            "ENOSPC:Image storage full");
+    }
+
+    [TestMethod]
+    public async Task FittingPngReplacement_NonMultipleOfThreeQuota_ReplacesNormally()
+    {
+        var state = await CreateMixedKgpSixelStateAsync();
+        await using var terminal = state.Terminal;
+        var replacement = Enumerable.Range(0, 13).Select(value => (byte)value).ToArray();
+        terminal.ClearWorkloadInput();
 
         terminal.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
-            KgpTestHelper.BuildTransmitCommand(1, 1, 1, quiet: 2)));
+            KgpTestHelper.BuildCommand("a=t,f=100,i=1", replacement)));
+
+        var stored = terminal.Terminal.KgpImageStore.GetImageById(1);
+        Assert.IsNotNull(stored);
+        TestSeq.AreEqual(replacement, stored.Data);
+        Assert.IsNull(terminal.Terminal.KgpImageStore.GetImageById(2));
+        Assert.AreEqual(13L, terminal.Terminal.KgpImageStore.TotalSize);
+        Assert.IsEmpty(terminal.Terminal.KgpPlacements);
+        Assert.AreEqual(
+            state.SixelBytes + 13,
+            terminal.Terminal.GraphicsRetainedByteCount);
+        StringAssert.Contains(terminal.WorkloadInput, ";OK");
+    }
+
+    [TestMethod]
+    public async Task FittingCompressedReplacement_NonMultipleOfThreeQuota_ReplacesNormally()
+    {
+        var state = await CreateMixedKgpSixelStateAsync();
+        await using var terminal = state.Terminal;
+        byte[] replacement = [0x78, 0x9C, 0x03, 0x00];
+        terminal.ClearWorkloadInput();
+
         terminal.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
             KgpTestHelper.BuildCommand(
-                "a=f,f=32,s=1,v=1,i=1,q=2",
-                [0x11, 0x22, 0x33, 0xFF])));
-        terminal.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
-            KgpTestHelper.BuildTransmitCommand(2, 1, 1, quiet: 2)));
-        terminal.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
-            KgpTestHelper.BuildPutCommand(1, placementId: 11)));
-        terminal.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
-            KgpTestHelper.BuildPutCommand(2, placementId: 22)));
-        await FeedAndWaitAsync(terminal, frame, expectedPlacements: 1);
+                "a=t,f=32,s=1,v=1,i=1,o=z",
+                replacement)));
 
-        var originalFirst = terminal.Terminal.KgpImageStore.GetImageById(1);
-        var originalSecond = terminal.Terminal.KgpImageStore.GetImageById(2);
-        Assert.IsNotNull(originalFirst);
-        Assert.IsNotNull(originalSecond);
-        Assert.AreEqual(2, originalFirst.FrameCount);
-        Assert.AreEqual(12L, terminal.Terminal.KgpImageStore.TotalSize);
-        Assert.AreEqual(2, terminal.Terminal.KgpPlacements.Count);
-
-        terminal.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
-            KgpTestHelper.BuildTransmitCommand(
-                imageId: 1,
-                width: 4,
-                height: 1,
-                quiet: 2,
-                fillByte: 0xCC)));
-
-        Assert.AreSame(originalFirst, terminal.Terminal.KgpImageStore.GetImageById(1));
-        Assert.AreSame(originalSecond, terminal.Terminal.KgpImageStore.GetImageById(2));
-        Assert.AreEqual(2, originalFirst.FrameCount);
-        Assert.AreEqual(12L, terminal.Terminal.KgpImageStore.TotalSize);
-        Assert.AreEqual(2, terminal.Terminal.KgpPlacements.Count);
-        Assert.AreEqual(budget, terminal.Terminal.GraphicsRetainedByteCount);
-        Assert.AreEqual(1, terminal.Terminal.SixelPlacementCount);
+        var stored = terminal.Terminal.KgpImageStore.GetImageById(1);
+        Assert.IsNotNull(stored);
+        TestSeq.AreEqual(replacement, stored.Data);
+        Assert.IsNotNull(terminal.Terminal.KgpImageStore.GetImageById(2));
+        Assert.AreEqual(8L, terminal.Terminal.KgpImageStore.TotalSize);
+        Assert.HasCount(1, terminal.Terminal.KgpPlacements);
+        Assert.AreEqual(2u, terminal.Terminal.KgpPlacements[0].ImageId);
+        Assert.AreEqual(
+            state.SixelBytes + 8,
+            terminal.Terminal.GraphicsRetainedByteCount);
+        StringAssert.Contains(terminal.WorkloadInput, ";OK");
     }
 
     [TestMethod]
@@ -583,6 +610,73 @@ public class SixelRetainedMemoryBudgetTests
         Assert.IsNotNull(image.GetPixels());
         var dense = terminal.Terminal.SixelRetainedByteCount;
         return (initial, rasterized, dense);
+    }
+
+    private static async Task AssertUnfitKgpReplacementPreservesStateAsync(
+        string controlData,
+        byte[] replacement,
+        string expectedError)
+    {
+        var state = await CreateMixedKgpSixelStateAsync();
+        await using var terminal = state.Terminal;
+        terminal.ClearWorkloadInput();
+
+        terminal.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildCommand(controlData, replacement)));
+
+        Assert.AreSame(
+            state.FirstImage,
+            terminal.Terminal.KgpImageStore.GetImageById(1));
+        Assert.AreSame(
+            state.SecondImage,
+            terminal.Terminal.KgpImageStore.GetImageById(2));
+        Assert.AreEqual(2, state.FirstImage.FrameCount);
+        Assert.AreEqual(12L, terminal.Terminal.KgpImageStore.TotalSize);
+        Assert.AreEqual(2, terminal.Terminal.KgpPlacements.Count);
+        Assert.AreEqual(
+            state.SixelBytes + 12,
+            terminal.Terminal.GraphicsRetainedByteCount);
+        Assert.AreEqual(1, terminal.Terminal.SixelPlacementCount);
+        StringAssert.Contains(terminal.WorkloadInput, expectedError);
+    }
+
+    private static async Task<(
+        SixelTestTerminal Terminal,
+        KgpImageData FirstImage,
+        KgpImageData SecondImage,
+        long SixelBytes)> CreateMixedKgpSixelStateAsync()
+    {
+        var frame = Frame("#1;2;100;0;0#1@");
+        var sixelBytes = await MeasureInitialBytesAsync(frame);
+        var terminal = SixelTestTerminal.Create(
+            supportsKgp: true,
+            graphics: GraphicsWithBudget(checked(sixelBytes + 13)));
+
+        terminal.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildTransmitCommand(1, 1, 1, quiet: 2)));
+        terminal.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildCommand(
+                "a=f,f=32,s=1,v=1,i=1,q=2",
+                [0x11, 0x22, 0x33, 0xFF])));
+        terminal.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildTransmitCommand(2, 1, 1, quiet: 2)));
+        terminal.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildCommand("a=p,i=1,p=11,q=2")));
+        terminal.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildCommand("a=p,i=2,p=22,q=2")));
+        await FeedAndWaitAsync(terminal, frame, expectedPlacements: 1);
+
+        var first = terminal.Terminal.KgpImageStore.GetImageById(1);
+        var second = terminal.Terminal.KgpImageStore.GetImageById(2);
+        Assert.IsNotNull(first);
+        Assert.IsNotNull(second);
+        Assert.AreEqual(2, first.FrameCount);
+        Assert.AreEqual(12L, terminal.Terminal.KgpImageStore.TotalSize);
+        Assert.AreEqual(2, terminal.Terminal.KgpPlacements.Count);
+        Assert.AreEqual(
+            sixelBytes + 12,
+            terminal.Terminal.GraphicsRetainedByteCount);
+        return (terminal, first, second, sixelBytes);
     }
 
     private static void AssertAccountingMatchesSnapshot(Hex1bTerminal terminal)

--- a/tests/Hex1b.Tests/Sixel/SixelRetainedMemoryBudgetTests.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelRetainedMemoryBudgetTests.cs
@@ -370,6 +370,97 @@ public class SixelRetainedMemoryBudgetTests
     }
 
     [TestMethod]
+    public async Task UnfitSixelAdmission_WithResidentKgp_PreservesExistingSixels()
+    {
+        var existing = Frame("#1;2;100;0;0#1@");
+        var incoming = Frame(
+            "#2;2;0;100;0" +
+            string.Concat(Enumerable.Repeat("#2", 128)) +
+            "@");
+        var existingBytes = await MeasureInitialBytesAsync(existing);
+        var incomingBytes = await MeasureInitialBytesAsync(incoming);
+        var budget = checked(existingBytes + 4);
+        Assert.IsTrue(incomingBytes > existingBytes);
+
+        await using var terminal = SixelTestTerminal.Create(
+            supportsKgp: true,
+            graphics: GraphicsWithBudget(budget));
+        await FeedAndWaitAsync(terminal, existing, expectedPlacements: 1);
+        var originalImage = TestSeq.Single(terminal.Terminal.SixelPlacements).Image;
+        var originalSixelBytes = terminal.Terminal.SixelRetainedByteCount;
+        terminal.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildTransmitCommand(1, 1, 1, quiet: 2)));
+        Assert.AreEqual(budget, terminal.Terminal.GraphicsRetainedByteCount);
+
+        await terminal.FeedAsync(
+            Encoding.ASCII.GetBytes("\x1b[2;1H")
+                .Concat(incoming)
+                .Concat("Z"u8.ToArray())
+                .ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await terminal.WaitForAsync(
+            snapshot => snapshot.ContainsText("Z"),
+            "unfit Sixel rejected",
+            TestContext.Current.CancellationToken);
+
+        Assert.AreEqual(1, terminal.Terminal.SixelPlacementCount);
+        Assert.AreEqual(1, terminal.Terminal.TrackedSixelCount);
+        Assert.AreSame(originalImage, TestSeq.Single(terminal.Terminal.SixelPlacements).Image);
+        Assert.AreEqual(originalSixelBytes, terminal.Terminal.SixelRetainedByteCount);
+        Assert.AreEqual(budget, terminal.Terminal.GraphicsRetainedByteCount);
+        Assert.IsNotNull(terminal.Terminal.KgpImageStore.GetImageById(1));
+    }
+
+    [TestMethod]
+    public async Task UnfitKgpReplacement_WithResidentSixel_PreservesAllKgpState()
+    {
+        var frame = Frame("#1;2;100;0;0#1@");
+        var sixelBytes = await MeasureInitialBytesAsync(frame);
+        var budget = checked(sixelBytes + 12);
+        await using var terminal = SixelTestTerminal.Create(
+            supportsKgp: true,
+            graphics: GraphicsWithBudget(budget));
+
+        terminal.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildTransmitCommand(1, 1, 1, quiet: 2)));
+        terminal.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildCommand(
+                "a=f,f=32,s=1,v=1,i=1,q=2",
+                [0x11, 0x22, 0x33, 0xFF])));
+        terminal.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildTransmitCommand(2, 1, 1, quiet: 2)));
+        terminal.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildPutCommand(1, placementId: 11)));
+        terminal.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildPutCommand(2, placementId: 22)));
+        await FeedAndWaitAsync(terminal, frame, expectedPlacements: 1);
+
+        var originalFirst = terminal.Terminal.KgpImageStore.GetImageById(1);
+        var originalSecond = terminal.Terminal.KgpImageStore.GetImageById(2);
+        Assert.IsNotNull(originalFirst);
+        Assert.IsNotNull(originalSecond);
+        Assert.AreEqual(2, originalFirst.FrameCount);
+        Assert.AreEqual(12L, terminal.Terminal.KgpImageStore.TotalSize);
+        Assert.AreEqual(2, terminal.Terminal.KgpPlacements.Count);
+
+        terminal.Terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            KgpTestHelper.BuildTransmitCommand(
+                imageId: 1,
+                width: 4,
+                height: 1,
+                quiet: 2,
+                fillByte: 0xCC)));
+
+        Assert.AreSame(originalFirst, terminal.Terminal.KgpImageStore.GetImageById(1));
+        Assert.AreSame(originalSecond, terminal.Terminal.KgpImageStore.GetImageById(2));
+        Assert.AreEqual(2, originalFirst.FrameCount);
+        Assert.AreEqual(12L, terminal.Terminal.KgpImageStore.TotalSize);
+        Assert.AreEqual(2, terminal.Terminal.KgpPlacements.Count);
+        Assert.AreEqual(budget, terminal.Terminal.GraphicsRetainedByteCount);
+        Assert.AreEqual(1, terminal.Terminal.SixelPlacementCount);
+    }
+
+    [TestMethod]
     public async Task PayloadAndCommandMetadata_AreCountedAsRetainedManagedContent()
     {
         var body = "#1;2;100;0;0" + string.Concat(Enumerable.Repeat("#1@", 256));

--- a/tests/Hex1b.Tests/Sixel/SixelTestTerminal.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelTestTerminal.cs
@@ -29,6 +29,7 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
         IHex1bTerminalWorkloadFilter? workloadFilter,
         IHex1bTerminalPresentationFilter? presentationFilter,
         bool impactAware,
+        bool supportsKgp,
         SixelCellMetrics? cellMetrics,
         SixelCompatibilityPolicy? policy,
         Hex1bTerminalGraphicsOptions? graphics)
@@ -36,6 +37,7 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
         var capabilities = new TerminalCapabilities
         {
             SupportsSixel = true,
+            SupportsKgp = supportsKgp,
             SupportsTrueColor = true,
             Supports256Colors = true,
             CellPixelWidth = cellPixelWidth,
@@ -98,6 +100,7 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
         IHex1bTerminalWorkloadFilter? workloadFilter = null,
         IHex1bTerminalPresentationFilter? presentationFilter = null,
         bool impactAware = false,
+        bool supportsKgp = false,
         SixelCellMetrics? cellMetrics = null,
         SixelCompatibilityPolicy? policy = null,
         Hex1bTerminalGraphicsOptions? graphics = null)
@@ -113,6 +116,7 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
             workloadFilter,
             presentationFilter,
             impactAware,
+            supportsKgp,
             cellMetrics,
             policy,
             graphics);

--- a/tests/Hex1b.Tests/Sixel/SixelTestTerminal.cs
+++ b/tests/Hex1b.Tests/Sixel/SixelTestTerminal.cs
@@ -84,6 +84,10 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
 
     public byte[] PresentationBytes => _presentation.CapturedBytes;
 
+    public string WorkloadInput => _workload.WrittenInput;
+
+    public void ClearWorkloadInput() => _workload.ClearWrittenInput();
+
     public IReadOnlyList<AppliedToken> AppliedTokens => _presentation is ImpactAwarePresentationAdapter adapter
         ? adapter.AppliedTokens
         : [];
@@ -359,6 +363,7 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
             Channel.CreateUnbounded<WorkloadOutputItem>();
         private readonly object _eventLock = new();
         private Action? _disconnected;
+        private readonly List<byte> _input = [];
         private bool _completed;
 
         public event Action? Disconnected
@@ -409,8 +414,30 @@ internal sealed class SixelTestTerminal : IAsyncDisposable
             return default;
         }
 
+        public string WrittenInput
+        {
+            get
+            {
+                lock (_input)
+                    return Encoding.UTF8.GetString([.. _input]);
+            }
+        }
+
         public ValueTask WriteInputAsync(ReadOnlyMemory<byte> data, CancellationToken ct = default)
-            => ValueTask.CompletedTask;
+        {
+            lock (_input)
+            {
+                foreach (var value in data.Span)
+                    _input.Add(value);
+            }
+            return ValueTask.CompletedTask;
+        }
+
+        public void ClearWrittenInput()
+        {
+            lock (_input)
+                _input.Clear();
+        }
 
         public ValueTask ResizeAsync(int width, int height, CancellationToken ct = default)
             => ValueTask.CompletedTask;


### PR DESCRIPTION
## Summary
- deterministically account each distinct live Sixel image once per screen, including retained UTF-16 payload and diagnostic strings, actual parsed command/palette storage, collection capacity, captured palette state, sparse raster tiles, raster diagnostics, and cached dense RGBA pixels
- enforce one protocol-neutral `Hex1bTerminalGraphicsOptions.MaximumRetainedBytesPerScreen` ceiling shared by KGP and Sixel, independently for main and alternate screens
- keep observational lazy raster/dense materialization non-destructive: expensive work occurs outside the terminal buffer lock, publication is race-safe, and non-fitting results are returned uncached without evicting live placements
- preflight impossible mixed-protocol admissions so rejected Sixel images and KGP replacements preserve all existing images, placements, animation frames, and accounting; satisfiable admissions retain deterministic oldest-first eviction
- decode and preflight actual single-chunk PNG and `o=z` payload sizes before explicit-image teardown, closing base64 rounding (`q+1`/`q+2`) destruction paths while preserving multi-chunk behavior and fitting PNG replacements
- preserve exact cleanup, deduplication, and caller-owned snapshot lifetime semantics

## Stacked dependency
This PR is intentionally based on **#482** (`mitchdenny-terminal-graphics-limits`) and must be reviewed/merged after that PR. The #478 changes are the commits on top of #482 head `ded7e0ef`.

## Validation
- exact PNG/`o=z` non-multiple-of-3 quota regressions passed, including ENOSPC preservation of root image, animation frames, placements, peer images, and accounting; fitting PNG replacement passed
- all Sixel/KGP/HMP1 focused tests passed
- core suite excluding one pre-existing async tree flake: 9,194 total / 9,170 passed / 24 skipped; the excluded test passes in isolation but failed twice only in the full local parallel suite
- analyzer suite passed: 67
- MCP server suite passed: 6
- tool suite passed: 58
- CI-equivalent build matrix: 5 targets, zero warnings/errors
- Sixel hardening BenchmarkDotNet dry run: 9 benchmarks completed
- API docs generation passed; VitePress and Aspire content builds passed after the shared-budget changes
- independent incremental correctness reviews found no remaining significant issues
- final workflow-dispatch validation on `163bf60c`: Ubuntu and Windows tests plus all native and Windows PTY-host builds passed; the workflow conclusion is failure only because the version job intentionally rejects feature branch names

## Known limitation
- KGP `o=z` payload decompression and uncompressed-size validation are pre-existing protocol work outside #478. This PR only ensures quota preflight and state preservation for the currently accepted encoded-data path.

Closes #478