### PR TITLE
Add Ctrl/Cmd-click hyperlink activation to the web terminal

### DIFF
--- a/docs/web-terminal-protocol.md
+++ b/docs/web-terminal-protocol.md
@@ -162,6 +162,7 @@ delta.
 | `mouseTracking` | integer | Effective mouse tracking mode: `0`, `9`, `1000`, `1002`, or `1003`; see §7. |
 | `peer` | object | Required complete HMP1 peer/primary state, or standalone defaults, defined below. |
 | `history` | object or null | Complete per-view text viewport, selection, and copy state, defined below. Null denotes a projection without history interaction metadata. |
+| `hyperlinks` | array of objects | Complete OSC 8 destination ranges for the presented viewport, including on cell-delta frames. |
 | `defaultBackground`, `defaultForeground` | integers | Resolved packed colors, using §3.3; producer emits opaque colors. |
 | `cursor` | object | Complete cursor state, defined below. |
 | `images` | array of objects | New/replacement resource descriptors, each with one corresponding binary payload. |
@@ -183,6 +184,22 @@ The reference renderer treats Default as a blinking block. It uses a local
 color. Its block has 0.55 alpha; underline and bar are two logical pixels thick.
 These raster details and blink phase are not transmitted. The numeric shape
 values follow [`CursorShape`](../src/Hex1b/CursorShape.cs).
+
+Each `hyperlinks` entry contains `row`, `startColumn`, `endColumn`, and `uri`.
+Coordinates are zero-based viewport cells, with an exclusive `endColumn`.
+Ranges are nonempty, sorted by row then column, nonoverlapping, and bounded by
+the current grid. The array is bounded by the total cell count. Contiguous cells
+with the same destination are combined within each row, including wide-cell
+continuations. Wrapped links have one range per row. Hidden cells are excluded.
+OSC 8 parameters are not transmitted.
+
+These ranges replace the previous frame's entire hyperlink map. An empty array
+clears all links; changing only a destination need not resend any binary cells.
+Historical ranges come from the same authoritative snapshot as displayed text.
+URI strings are untrusted terminal output. The browser permits activation only
+of absolute HTTP, HTTPS, or mailto URLs without raw ASCII whitespace/control
+characters; it does not resolve page-relative paths or detect URLs in plain text.
+Hyperlinks share the 8 MiB serialized metadata bound, which the producer enforces.
 
 `peer` contains:
 
@@ -332,8 +349,9 @@ request to perform Unicode width calculation in the browser:
 
 The projection substitutes a space for a null character value, a NUL character,
 or the internal U+E000 placeholder. Empty strings remain continuation cells.
-The wire has no hyperlink, font, original palette index, terminal sequence
-number, or original Sixel-ownership field.
+The binary cell record has no hyperlink, font, original palette index, terminal
+sequence number, or original Sixel-ownership field. Hyperlinks are carried in
+the complete viewport metadata instead.
 
 ### 3.3. Colors and attributes
 
@@ -911,7 +929,13 @@ This policy is not additional wire syntax:
   page-mode deltas use canvas height; one cell height is one report on either
   axis. Each emitted direction is capped at 32 reports. Ctrl+wheel/pinch and
   Meta+wheel remain browser gestures. X10 sends no wheel.
-* Meta-modified pointer-down/motion is filtered. Geometry changes cancel capture.
+* Ctrl/Cmd+left-click on an allowed OSC 8 destination opens a new tab on release
+  with `noopener,noreferrer`, without sending a mouse report or starting a selection.
+  Explicit input routes/actions take precedence, and Shift/Alt retain selection
+  behavior. Dragging, cancellation, or a changed destination cancels activation.
+  Hovering shows the destination and modifier hint. This works in historical and
+  read-only views too; pending viewport transitions cannot activate stale links.
+* Other Meta-modified pointer-down/motion is filtered. Geometry changes cancel capture.
   Changing a tracking mode does not transfer a locally owned gesture to the
   application.
 

--- a/samples/WebTerminalDemo/README.md
+++ b/samples/WebTerminalDemo/README.md
@@ -86,6 +86,7 @@ origin:
 | `sizing.browser.js` | Auto font-size controls, fixed-grid presets, keyboard selection, resize authority, and retained sizing policy across primary handoff. |
 | `floating.browser.js` | Real workers/WebSockets/HMP1, dragging, primary-only resize, takeover, detach/reattach, and independent instances. |
 | `input.browser.js` | Real POSIX shell input, Backspace, history, paste, MouseTest, thumbnail coordinates, and window-chrome focus. Build `samples/MouseTest` in Release first. |
+| `hyperlinks.browser.js` | Real OSC 8 output through HWT1 and the worker, Ctrl/Cmd activation, safe new tabs, selection/capture isolation, read-only thumbnails, destination updates, and scrollback. |
 | `history.browser.js` | Shared producer history, independent viewports, character/word/logical-line/block selection, held/released wheel scrolling, clipboard intent, capture override, read-only inspection, and eviction. Clipboard writes are intercepted rather than changing the user's clipboard. |
 | `bindings.browser.js` | Per-view input overrides, named actions, Windows-style right-click copy/paste, clipboard failures/races, capture ownership, and native text/paste/IME paths. Clipboard access is mocked. |
 | `selection-ui.browser.js` | Default, augmented, and replaced selection controls; host CSS, highlight parts, canvas alignment, focus/input isolation, action reuse, UI errors, and disposal. |

--- a/samples/WebTerminalDemo/tests/bindings.browser.js
+++ b/samples/WebTerminalDemo/tests/bindings.browser.js
@@ -144,7 +144,7 @@ async page => {
           const history = structuredClone(this.history);
           validateHistory(history, 40, 12);
           const message = {
-            type: "geometry", columns: 40, rows: 12, cellWidth: 10, cellHeight: 20,
+            type: "geometry", columns: 40, rows: 12, cellWidth: 10, cellHeight: 20, hyperlinks: [],
             mouseTracking: this.tracking, peer: { id: this.name, primaryId: "native", isPrimary: false },
             revision: ++this.revision, history, text: history.rowIds.map(rowId => this.line(rowId)).join("\n")
           };

--- a/samples/WebTerminalDemo/tests/hyperlinks.browser.js
+++ b/samples/WebTerminalDemo/tests/hyperlinks.browser.js
@@ -1,0 +1,154 @@
+async page => {
+  const origin = page.url().match(/^https?:\/\/[^/]+/)?.[0] || "http://localhost:5290";
+  const context = await page.context().browser().newContext({
+    viewport: { width: 1440, height: 1000 }, deviceScaleFactor: 2
+  });
+  const test = await context.newPage();
+  const errors = [];
+  let instanceId;
+  let stage = "mounting real shell and worker";
+  test.on("pageerror", error => errors.push(error.message));
+  const check = (value, message) => { if (!value) throw new Error(message); };
+  const shell = async (command, marker) => {
+    await test.evaluate(() => primary.focus());
+    await test.keyboard.press("Control+u");
+    await test.evaluate(command => primary.paste(command), command);
+    await test.keyboard.press("Enter");
+    await test.waitForFunction(marker => primary.screenText.split("\n").some(line => line.trim() === marker) &&
+      /[\u276f$#%>]$/.test(primary.screenText.trimEnd()), marker, { timeout: 30000 });
+  };
+  const cell = (name, x, y) => test.evaluate(({ name, x, y }) => {
+    const terminal = window[name];
+    const box = terminal.element.shadowRoot.querySelector("canvas").getBoundingClientRect();
+    return { x: box.x + (x + .5) * box.width / terminal.geometry.columns,
+      y: box.y + (y + .5) * box.height / terminal.geometry.rows };
+  }, { name, x, y });
+  const click = async (name, x, y, modifier = "Control") => {
+    const position = await cell(name, x, y);
+    await test.mouse.move(position.x, position.y);
+    if (modifier) await test.keyboard.down(modifier);
+    await test.mouse.click(position.x, position.y);
+    if (modifier) await test.keyboard.up(modifier);
+  };
+  try {
+    await test.goto(`${origin}/health`);
+    const created = await test.request.post(`${origin}/api/terminals`, {
+      headers: { Origin: origin }, data: { scene: "shell", columns: 80, rows: 24 }
+    });
+    check(created.status() === 201, `Shell creation failed: ${created.status()}`);
+    instanceId = (await created.json()).id;
+    await test.evaluate(async id => {
+      const { WebTerminal } = await import("/web-terminal/index.js");
+      document.body.innerHTML = '<div id="a" style="width:800px;height:480px"></div><div id="b" style="width:400px;height:240px"></div>';
+      window.commands = [];
+      const RealWorker = window.Worker;
+      window.Worker = class extends RealWorker {
+        postMessage(message, ...args) {
+          if (message.type === "command") commands.push(message.command);
+          super.postMessage(message, ...args);
+        }
+      };
+      window.primary = await WebTerminal.mount(document.getElementById("a"), {
+        url: `/ws?instance=${id}`, sizing: { mode: "fixed", columns: 80, rows: 24 }
+      });
+      primary.requestPrimary();
+      window.secondary = await WebTerminal.mount(document.getElementById("b"), {
+        url: `/ws?instance=${id}`, readOnly: true
+      });
+    }, instanceId);
+    await test.waitForFunction(() => primary.peer.isPrimary && primary.geometry.columns === 80 &&
+      /[\u276f$#%>]$/.test(primary.screenText.trimEnd()), null, { timeout: 30000 });
+    const target = `${origin}/health?hyperlink=first`;
+    const osc = (uri, text) => `\\033]8;;${uri}\\033\\\\${text}\\033]8;;\\033\\\\`;
+    await shell(`printf '\\033[2J\\033[H${osc(target, "LINK")}\\r\\n${osc("javascript:alert(1)", "BLOCKED")}\\r\\n__LINKS_READY__\\r\\n'`,
+      "__LINKS_READY__");
+
+    stage = "real Cmd-click navigation";
+    const position = await cell("primary", 1, 0);
+    await test.mouse.move(position.x, position.y);
+    const canvas = test.locator("#a canvas");
+    check((await canvas.getAttribute("title")).includes(target), "Presented OSC 8 destination was lost");
+    await test.keyboard.down("Meta");
+    check(await canvas.evaluate(element => element.style.cursor === "pointer"), "Link affordance missing");
+    const nextPage = context.waitForEvent("page");
+    const request = context.waitForEvent("request", request => request.url() === target);
+    await test.mouse.click(position.x, position.y);
+    await test.keyboard.up("Meta");
+    const popup = await nextPage;
+    await popup.waitForURL(target);
+    await popup.waitForLoadState("domcontentloaded");
+    check(await popup.evaluate(() => window.opener === null), "Opened link retained an opener");
+    check((await request).headers().referer === undefined, "Opened link leaked a referrer");
+    await popup.close();
+
+    await test.evaluate(() => {
+      window.opened = [];
+      window.open = (...args) => { opened.push(args); return null; };
+    });
+    stage = "selection, unsafe URLs, and read-only thumbnails";
+    await click("primary", 1, 1);
+    check(await test.evaluate(() => opened.length === 0), "Script URI activated");
+    await click("primary", 1, 0, null);
+    await test.waitForFunction(() => primary.selection.active && !primary.selection.pending);
+    const selected = await test.evaluate(() => primary.selection.text);
+    await click("primary", 1, 0);
+    check(await test.evaluate(text => opened.length === 1 && primary.selection.text === text, selected),
+      "Ctrl-click changed the retained selection");
+    await click("secondary", 1, 0);
+    check(await test.evaluate(() => opened.length === 2 && opened.every(args =>
+      args[1] === "_blank" && args[2] === "noopener,noreferrer")), "Read-only thumbnail link did not activate safely");
+
+    stage = "application capture and drag cancellation";
+    await shell("printf '\\033[?1003;1006h__CAPTURE_READY__\\r\\n'", "__CAPTURE_READY__");
+    await test.waitForFunction(() => primary.geometry.mouseTracking === 1003);
+    const captured = await cell("primary", 1, 0);
+    await test.mouse.move(captured.x, captured.y);
+    await test.evaluate(() => new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+    await test.evaluate(() => { commands.length = 0; opened.length = 0; });
+    await test.keyboard.down("Control");
+    await test.mouse.down();
+    await test.mouse.up();
+    await test.keyboard.up("Control");
+    check(await test.evaluate(() => opened.length === 1 && !commands.some(command =>
+      command.type === "mouse" || command.type === "selection")), "Link gesture leaked into terminal input");
+    await test.keyboard.down("Control");
+    await test.mouse.down();
+    await test.mouse.move(captured.x + 20, captured.y);
+    await test.mouse.move(captured.x, captured.y);
+    await test.mouse.up();
+    await test.keyboard.up("Control");
+    check(await test.evaluate(() => opened.length === 1), "Dragged link activated");
+
+    stage = "destination-only updates";
+    const replacement = `${origin}/health?hyperlink=replaced`;
+    await shell(`printf '\\033[?1003l\\033[s\\033[H${osc(replacement, "LINK")}\\033[u__REPLACED__\\r\\n'`, "__REPLACED__");
+    await click("primary", 1, 0);
+    check(await test.evaluate(uri => opened.at(-1)[0] === uri, replacement), "Destination-only change left stale hit testing");
+
+    stage = "scrollback destinations";
+    await shell("i=0; while [ \"$i\" -lt 40 ]; do printf 'history row\\r\\n'; i=$((i+1)); done; printf '__SCROLLED__\\r\\n'", "__SCROLLED__");
+    await test.evaluate(() => secondary.scrollLines(-10000));
+    await test.waitForFunction(() => !secondary.viewport.pending && secondary.screenText.split("\n").some(line => line === "LINK"));
+    const row = await test.evaluate(() => secondary.screenText.split("\n").findIndex(line => line === "LINK"));
+    await click("secondary", 1, row);
+    check(await test.evaluate(uri => opened.at(-1)[0] === uri, replacement), "Historical link used live viewport coordinates");
+    await test.evaluate(() => secondary.scrollToLive());
+    await test.waitForFunction(() => secondary.viewport.following && !secondary.viewport.pending);
+    const before = await test.evaluate(() => opened.length);
+    await click("secondary", 1, 0);
+    check(await test.evaluate(before => opened.length === before, before), "Return to live retained old links");
+    check(errors.length === 0, `Browser errors: ${errors.join("; ")}`);
+    return { passed: true, covered: ["real OSC 8/worker delivery", "Cmd/Ctrl activation", "noopener/noreferrer",
+      "unsafe schemes", "selection preservation", "read-only thumbnail", "mouse capture", "drag cancellation",
+      "destination-only updates", "scrollback and return to live"] };
+  } catch (error) {
+    const text = await test.evaluate(() => window.primary?.screenText);
+    throw new Error(`${stage}: ${error.message}; ${text}`);
+  } finally {
+    try {
+      if (instanceId) await test.request.delete(`${origin}/api/terminals/${instanceId}`, { headers: { Origin: origin } });
+    } finally {
+      await context.close();
+    }
+  }
+}

--- a/samples/WebTerminalDemo/tests/mount.browser.js
+++ b/samples/WebTerminalDemo/tests/mount.browser.js
@@ -17,7 +17,7 @@ async page => {
         for (const worker of workers) {
           if (worker.stopped) continue;
           worker.dispatchEvent(new MessageEvent("message", { data: {
-            type: "geometry", ...grid, cellWidth: 10, cellHeight: 20, mouseTracking: 1003,
+            type: "geometry", ...grid, cellWidth: 10, cellHeight: 20, mouseTracking: 1003, hyperlinks: [],
             peer: { id: worker.id, primaryId, isPrimary: worker.id === primaryId }
           } }));
           worker.dispatchEvent(new MessageEvent("message", { data: {
@@ -33,7 +33,7 @@ async page => {
               queueMicrotask(() => {
                 this.dispatchEvent(new MessageEvent("message", { data: { type: "connected" } }));
                 this.dispatchEvent(new MessageEvent("message", { data: {
-                  type: "geometry", ...grid, cellWidth: 10, cellHeight: 20, mouseTracking: 0,
+                  type: "geometry", ...grid, cellWidth: 10, cellHeight: 20, mouseTracking: 0, hyperlinks: [],
                   peer: { id: null, primaryId: null, isPrimary: false }
                 } }));
                 this.dispatchEvent(new MessageEvent("message", { data: { type: "stats", stats: { revision: 1 } } }));

--- a/samples/WebTerminalDemo/tests/selection-ui.browser.js
+++ b/samples/WebTerminalDemo/tests/selection-ui.browser.js
@@ -48,7 +48,7 @@ async page => {
           if (this.stopped) return;
           const revision = ++uiFixture.revision;
           this.dispatchEvent(new MessageEvent("message", { data: {
-            type: "geometry", columns: 40, rows: 10, cellWidth: 10, cellHeight: 20, mouseTracking: 1003,
+            type: "geometry", columns: 40, rows: 10, cellWidth: 10, cellHeight: 20, mouseTracking: 1003, hyperlinks: [],
             peer: { id: this.id, primaryId: "native", isPrimary: false }, revision, text: "HELLO",
             history: { generation: "1", buffer: "main", totalRows: 30, top: this.top, liveTop: 20,
               following: this.top === 20, requestId: this.viewportRequest,

--- a/src/Hex1b/Hwt1/Hwt1FrameMetadata.cs
+++ b/src/Hex1b/Hwt1/Hwt1FrameMetadata.cs
@@ -5,4 +5,5 @@ internal sealed record Hwt1FrameMetadata(
     int Columns, int Rows, int CellWidth, int CellHeight, int MouseTracking,
     uint DefaultBackground, uint DefaultForeground, Hwt1Cursor Cursor,
     List<Hwt1RenderImage> Images, string[] RetainedImages, List<Hwt1RenderPlacement> Placements,
-    Hwt1FrameStatistics Stats, List<string> Warnings, Hwt1Peer Peer, Hwt1History? History);
+    Hwt1FrameStatistics Stats, List<string> Warnings, Hwt1Peer Peer, Hwt1History? History,
+    List<Hwt1Hyperlink> Hyperlinks);

--- a/src/Hex1b/Hwt1/Hwt1Hyperlink.cs
+++ b/src/Hex1b/Hwt1/Hwt1Hyperlink.cs
@@ -1,0 +1,3 @@
+namespace Hex1b;
+
+internal sealed record Hwt1Hyperlink(int Row, int StartColumn, int EndColumn, string Uri);

--- a/src/Hex1b/Hwt1/Hwt1RenderProjection.cs
+++ b/src/Hex1b/Hwt1/Hwt1RenderProjection.cs
@@ -41,15 +41,29 @@ internal sealed class Hwt1RenderProjection
         _rows = snapshot.Height;
         var cells = new Hwt1RenderCell[checked(_columns * _rows)];
         var changed = new List<int>();
+        var hyperlinks = new List<Hwt1Hyperlink>();
         for (var y = 0; y < _rows; y++)
         {
+            string? linkUri = null;
+            var linkStart = 0;
             for (var x = 0; x < _columns; x++)
             {
                 var index = y * _columns + x;
                 cells[index] = ProjectCell(snapshot, x, y, capabilities);
                 if (full || cells[index] != _previous[index])
                     changed.Add(index);
+                var source = snapshot.GetCell(x, y);
+                var uri = source.IsHidden ? null : source.HyperlinkData?.Uri;
+                if (linkUri != uri)
+                {
+                    if (!string.IsNullOrEmpty(linkUri))
+                        hyperlinks.Add(new(y, linkStart, x, linkUri));
+                    linkUri = uri;
+                    linkStart = x;
+                }
             }
+            if (!string.IsNullOrEmpty(linkUri))
+                hyperlinks.Add(new(y, linkStart, _columns, linkUri));
         }
         _previous = cells;
 
@@ -157,7 +171,9 @@ internal sealed class Hwt1RenderProjection
             newImages, _images.Keys.ToArray(), placements,
             new(workloadBytes, outputBatches, elapsedMs,
                 snapshotMs + Stopwatch.GetElapsedTime(started).TotalMilliseconds),
-            warnings, peer ?? Hwt1Peer.Standalone, history), Hwt1JsonSerializerContext.Default.Hwt1FrameMetadata);
+            warnings, peer ?? Hwt1Peer.Standalone, history, hyperlinks), Hwt1JsonSerializerContext.Default.Hwt1FrameMetadata);
+        if (metadata.Length > 8 * 1024 * 1024)
+            throw new InvalidDataException("Frame metadata exceeds the HWT1 8 MiB limit.");
 
         using var stream = new MemoryStream();
         using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);

--- a/src/web-terminal/README.md
+++ b/src/web-terminal/README.md
@@ -172,6 +172,20 @@ actions reject if selection/input/focus changes before their asynchronous work
 can be applied safely. Errors are surfaced rather than silently reported as
 successful copies or pastes.
 
+### Hyperlinks
+
+Hold Ctrl or Cmd and click an OSC 8 hyperlink to open its destination in a new
+tab. Hovering shows the destination and activation hint; holding the modifier
+also shows a pointer cursor. Links work in live output, scrollback, and read-only
+views. Plain clicks and drags retain their existing selection/application
+behavior, and explicit input-policy routes or actions take precedence.
+Shift and Alt/Option continue to reserve selection gestures.
+
+Only absolute `http:`, `https:`, and `mailto:` destinations are activated
+(`mailto:` handling depends on the browser). New tabs use `noopener,noreferrer`.
+Script, data, file, relative, and custom-scheme URLs are not activated.
+Plain URL text is not automatically detected; the workload must emit OSC 8.
+
 ## Selection UI hooks
 
 `onSelectionUI` receives a typed `SelectionUIEvent`, also dispatched as the

--- a/src/web-terminal/src/hyperlinks.ts
+++ b/src/web-terminal/src/hyperlinks.ts
@@ -1,0 +1,31 @@
+import type { TerminalPoint } from "./types.js";
+import type { HyperlinkRange } from "./wire-types.js";
+
+/** OSC 8 destinations are untrusted output, not page-relative navigation. */
+export function hyperlinkUri(uri: string): string | null {
+  if (/[\u0000-\u0020\u007f]/u.test(uri) || !URL.canParse(uri)) return null;
+  const url = new URL(uri);
+  return ["https:", "http:", "mailto:"].includes(url.protocol) ? url.href : null;
+}
+
+export class Hyperlinks {
+  #rows = new Map<number, HyperlinkRange[]>();
+
+  update(ranges: readonly HyperlinkRange[]): void {
+    this.#rows.clear();
+    const destinations = new Map<string, string | null>();
+    for (const range of ranges) {
+      if (!destinations.has(range.uri)) destinations.set(range.uri, hyperlinkUri(range.uri));
+      const uri = destinations.get(range.uri);
+      if (!uri) continue;
+      const row = this.#rows.get(range.row) ?? [];
+      row.push({ ...range, uri });
+      this.#rows.set(range.row, row);
+    }
+  }
+
+  at(point: TerminalPoint): string | null {
+    return this.#rows.get(point.y)?.find(range =>
+      point.x >= range.startColumn && point.x < range.endColumn)?.uri ?? null;
+  }
+}

--- a/src/web-terminal/src/mouse-input.ts
+++ b/src/web-terminal/src/mouse-input.ts
@@ -8,6 +8,7 @@ import type { CellPosition, MouseButton, MouseCommand } from "./wire-types.js";
 const buttons: readonly (readonly [PointerButton, number])[] = [["left", 1], ["middle", 4], ["right", 2]];
 const pointerButtons: readonly PointerButton[] = ["left", "middle", "right"];
 interface SelectionClick { point: TerminalPoint; mode: SelectionMode; extend: boolean; dragged: boolean }
+interface HyperlinkClick { uri: string; x: number; y: number; dragged: boolean }
 interface MouseInspection {
   state?: () => Omit<GestureState, "tracking">;
   begin?: (point: TerminalPoint, selection: { mode: SelectionMode; extend: boolean }) => void;
@@ -16,9 +17,12 @@ interface MouseInspection {
   end?: (cancelled: boolean) => void;
   resolve?: (input: TerminalInput) => InputDecision;
   execute?: (decision: Extract<InputDecision, { action: unknown }>, input: TerminalInput) => void;
+  hyperlink?: (point: TerminalPoint) => string | null;
+  openHyperlink?: (uri: string) => void;
 }
 export interface MouseCapture {
   update(columns: number, rows: number, tracking: MouseTrackingMode): void;
+  refresh(): void;
   cancel(): void;
   dispose(): void;
 }
@@ -46,10 +50,26 @@ export function captureMouse(canvas: HTMLCanvasElement, send: (command: MouseCom
   let completedClick: SelectionClick | undefined;
   let routedGesture: InputRouteValue | undefined;
   let contextMenuRoute: InputRouteValue | undefined;
+  let hyperlinkClick: HyperlinkClick | undefined;
+  let hoverEvent: PointerEvent | undefined;
+  let hoverModifiers: Pick<MouseEvent, "ctrlKey" | "metaKey" | "altKey" | "shiftKey"> | undefined;
+  const originalTitle = canvas.title;
+  const originalCursor = canvas.style.cursor;
   const state = () => ({ tracking, ...inspection.state?.() });
 
   function point(event: MouseEvent, clamp = false): CellPosition | null {
     return cellPoint(event, canvas.getBoundingClientRect(), columns, rows, clamp);
+  }
+
+  function refreshHover(modifiers = hoverModifiers) {
+    if (!inspection.hyperlink) return;
+    hoverModifiers = modifiers;
+    const position = hoverEvent && point(hoverEvent);
+    const uri = position ? inspection.hyperlink(position) : null;
+    canvas.title = uri ? `${uri}\nCtrl/Cmd+click to open link` : originalTitle;
+    canvas.style.cursor = uri && modifiers && (modifiers.ctrlKey || modifiers.metaKey) &&
+      !modifiers.altKey && !modifiers.shiftKey ? "pointer" : originalCursor;
+    if (hyperlinkClick && hyperlinkClick.uri !== uri) hyperlinkClick.dragged = true;
   }
 
   function updateAutoScroll() {
@@ -101,6 +121,7 @@ export function captureMouse(canvas: HTMLCanvasElement, send: (command: MouseCom
     pointerEvent = undefined;
     selectionClick = undefined;
     completedClick = undefined;
+    hyperlinkClick = undefined;
     gesture.end();
     routedGesture = undefined;
     if (report) flushMove();
@@ -129,6 +150,7 @@ export function captureMouse(canvas: HTMLCanvasElement, send: (command: MouseCom
     const position = point(event);
     if (!position) return;
     if (pointerId !== null) {
+      if (hyperlinkClick) hyperlinkClick.dragged = true;
       if (routedGesture !== InputRoute.Browser) event.preventDefault();
       if ((gesture.owner === "app" || routedGesture === InputRoute.Application) && pointerId === event.pointerId)
         changeButtons(event, position);
@@ -138,8 +160,19 @@ export function captureMouse(canvas: HTMLCanvasElement, send: (command: MouseCom
     const input: TerminalInput = { type: "pointer", button: pointerButtons[event.button],
       point: Object.freeze({ ...position }), ...inputModifiers(event) };
     const decision = inspection.resolve?.(input) ?? { route: InputRoute.Continue };
-    const route = decision.action !== undefined ? InputRoute.Consume : decision.route;
+    let route = decision.action !== undefined ? InputRoute.Consume : decision.route;
+    if (route === InputRoute.Continue && event.button === 0 && (event.ctrlKey || event.metaKey) &&
+        !event.altKey && !event.shiftKey) {
+      const uri = inspection.hyperlink?.(position);
+      if (uri) {
+        hyperlinkClick = { uri, x: event.clientX, y: event.clientY, dragged: false };
+        route = InputRoute.Consume;
+      }
+    }
     contextMenuRoute = event.button === 2 ? route : undefined;
+    if (hyperlinkClick) contextMenuRoute = InputRoute.Consume;
+    hoverEvent = event;
+    refreshHover(event);
     if (route !== InputRoute.Continue) {
       completedClick = selectionClick = undefined;
       click.count = 0;
@@ -188,6 +221,10 @@ export function captureMouse(canvas: HTMLCanvasElement, send: (command: MouseCom
     if (event.pointerType !== "mouse") return;
     if (pointerId === null && event.buttons) return;
     if (pointerId !== null && pointerId !== event.pointerId) return;
+    hoverEvent = event;
+    refreshHover(event);
+    if (hyperlinkClick && Math.hypot(event.clientX - hyperlinkClick.x, event.clientY - hyperlinkClick.y) >= 4)
+      hyperlinkClick.dragged = true;
     const position = point(event, pointerId !== null);
     if (!position) return;
     lastPoint = position;
@@ -218,6 +255,18 @@ export function captureMouse(canvas: HTMLCanvasElement, send: (command: MouseCom
 
   canvas.addEventListener("pointerup", event => {
     if (pointerId !== event.pointerId) return;
+    if (hyperlinkClick) {
+      event.preventDefault();
+      const link = hyperlinkClick;
+      const position = point(event);
+      const activate = event.button === 0 && event.buttons === 0 && !link.dragged &&
+        Math.hypot(event.clientX - link.x, event.clientY - link.y) < 4 &&
+        position && inspection.hyperlink?.(position) === link.uri;
+      if (event.buttons === 0) cancel(false, false);
+      else link.dragged = true;
+      if (activate) inspection.openHyperlink?.(link.uri);
+      return;
+    }
     const position = point(event, true) ?? lastPoint;
     if (routedGesture) {
       if (routedGesture === InputRoute.Application && position) changeButtons(event, position);
@@ -249,10 +298,20 @@ export function captureMouse(canvas: HTMLCanvasElement, send: (command: MouseCom
       inspection.begin?.(completed.point, { mode, extend: false });
   }, options);
   canvas.addEventListener("pointercancel", () => cancel(), options);
+  canvas.addEventListener("pointerleave", () => {
+    hoverEvent = undefined;
+    refreshHover();
+  }, options);
   canvas.addEventListener("lostpointercapture", () => {
     if (pointerId !== null) cancel();
   }, options);
-  window.addEventListener("blur", () => cancel(), options);
+  window.addEventListener("blur", () => {
+    cancel();
+    hoverEvent = undefined;
+    refreshHover();
+  }, options);
+  window.addEventListener("keydown", event => refreshHover(event), { ...options, capture: true });
+  window.addEventListener("keyup", event => refreshHover(event), { ...options, capture: true });
   canvas.addEventListener("contextmenu", event => {
     if (contextMenuRoute !== undefined && contextMenuRoute !== InputRoute.Continue) {
       const route = contextMenuRoute;
@@ -263,6 +322,7 @@ export function captureMouse(canvas: HTMLCanvasElement, send: (command: MouseCom
     if (tracking || gesture.owner === "local") event.preventDefault();
   }, options);
   canvas.addEventListener("wheel", event => {
+    if (hyperlinkClick) hyperlinkClick.dragged = true;
     const input: TerminalInput = { type: "wheel", deltaX: event.deltaX, deltaY: event.deltaY,
       deltaMode: event.deltaMode, point: point(event), ...inputModifiers(event) };
     const decision: InputDecision = pointerId === null
@@ -321,11 +381,15 @@ export function captureMouse(canvas: HTMLCanvasElement, send: (command: MouseCom
         rows = nextRows;
         tracking = nextTracking;
       }
+      refreshHover();
     },
+    refresh() { refreshHover(); },
     cancel() { cancel(); },
     dispose() {
       cancel(false);
       listeners.abort();
+      canvas.title = originalTitle;
+      canvas.style.cursor = originalCursor;
     }
   };
 }

--- a/src/web-terminal/src/protocol.ts
+++ b/src/web-terminal/src/protocol.ts
@@ -114,6 +114,18 @@ function validateMetadata(metadata: unknown): asserts metadata is FrameMetadata 
   }
   integer(columns * rows, "cell count", 1, LIMITS.cells);
   validateHistory(metadata.history, columns, rows);
+  array(metadata.hyperlinks, "hyperlinks", columns * rows);
+  let previousLinkEnd = 0;
+  for (const link of metadata.hyperlinks) {
+    if (!isRecord(link)) throw new Error("Invalid hyperlink");
+    const row = integer(link.row, "hyperlink row", 0, rows - 1);
+    const start = integer(link.startColumn, "hyperlink start column", 0, columns - 1);
+    const end = integer(link.endColumn, "hyperlink end column", start + 1, columns);
+    if (row * columns + start < previousLinkEnd) throw new Error("Unordered or overlapping hyperlinks");
+    previousLinkEnd = row * columns + end;
+    if (typeof link.uri !== "string" || !link.uri.length || link.uri.length > LIMITS.metadataBytes)
+      throw new Error("Invalid hyperlink URI");
+  }
   if (metadata.cellWidth !== 10 || metadata.cellHeight !== 20) {
     throw new Error("This spike requires server geometry of 10 × 20 logical pixels");
   }

--- a/src/web-terminal/src/terminal-worker.ts
+++ b/src/web-terminal/src/terminal-worker.ts
@@ -136,7 +136,7 @@ async function drawFrame() {
         type: "geometry", columns: metadata.columns, rows: metadata.rows,
         cellWidth: metadata.cellWidth, cellHeight: metadata.cellHeight,
         mouseTracking: metadata.mouseTracking, peer: metadata.peer,
-        history: metadata.history, revision: frame.revision, text
+        history: metadata.history, revision: frame.revision, text, hyperlinks: metadata.hyperlinks
       });
       send({ type: "ack", revision: frame.revision });
       emitStats(text);

--- a/src/web-terminal/src/web-terminal.ts
+++ b/src/web-terminal/src/web-terminal.ts
@@ -6,6 +6,7 @@ import { terminalThemeCss } from "./terminal-theme.js";
 import { InputPolicy, InputRoute, TerminalAction, inputModifiers } from "./input-policy.js";
 import { assertCommandSize } from "./protocol.js";
 import { SelectionUI } from "./selection-ui.js";
+import { Hyperlinks } from "./hyperlinks.js";
 import type { MouseCapture } from "./mouse-input.js";
 import type { CopySelectionOptions, InputActionHandler, InputDecision, InputBinding,
   TerminalActionName, TerminalGeometry, TerminalInput, TerminalInputContext, TerminalPeer,
@@ -64,6 +65,7 @@ export class WebTerminal implements WebTerminalHandle {
   #selectionOverlay!: HTMLDivElement;
   #selectionUIError = "";
   #canvasSize = { width: 0, height: 0 };
+  #hyperlinks = new Hyperlinks();
 
   /** Resolves after a connected terminal frame is presented. Supply signal to cancel mounting. */
   static async mount(container: HTMLElement, options: WebTerminalOptions): Promise<WebTerminal> {
@@ -203,7 +205,12 @@ export class WebTerminal implements WebTerminalHandle {
       scroll: (delta, endpoint) => inspect(() => this.#history.scroll(delta, endpoint)),
       end: cancelled => this.#history.endGesture(cancelled),
       resolve: input => this.#resolveInput(input),
-      execute: (decision, input) => this.#executeInputAction(decision, input)
+      execute: (decision, input) => this.#executeInputAction(decision, input),
+      hyperlink: point => this.#connected && !this.viewport.pending ? this.#hyperlinks.at(point) : null,
+      openHyperlink: uri => {
+        try { window.open(uri, "_blank", "noopener,noreferrer"); }
+        catch (error) { this.#actionFailed(error); }
+      }
     });
     this.#bindKeyboard();
     requiredElement(this.#inspection, ".return-live", HTMLButtonElement).addEventListener("click", () => {
@@ -270,7 +277,7 @@ export class WebTerminal implements WebTerminalHandle {
       this.#peer = message.peer;
       this.#input.disabled = !this.#canInput();
       if (this.#canInput() && document.activeElement === this.element && !this.element.shadowRoot?.activeElement) this.focus();
-      this.#mouse?.update(message.columns, message.rows, message.mouseTracking);
+      this.#hyperlinks.update(message.hyperlinks);
       if (geometryChanged || oldPeer.isPrimary !== this.#peer.isPrimary) this.#fit();
       if (!this.#peer.isPrimary) {
         clearTimeout(this.#resizeTimer);
@@ -283,6 +290,7 @@ export class WebTerminal implements WebTerminalHandle {
         this.#screenText = message.text;
         this.#history.accept(message.history, message.revision);
       }
+      this.#mouse?.update(message.columns, message.rows, message.mouseTracking);
       if (geometryChanged) this.#options.onGeometry?.(this.geometry);
       if (first) this.#options.onSizingChange?.(this.sizing);
       if (oldPeer.id !== this.#peer.id || oldPeer.primaryId !== this.#peer.primaryId || oldPeer.isPrimary !== this.#peer.isPrimary) {
@@ -358,6 +366,7 @@ export class WebTerminal implements WebTerminalHandle {
   #inspectionChanged() {
     const viewport = this.viewport;
     const selection = this.selection;
+    this.#mouse?.refresh();
     if (selection.status === "invalidated") this.#mouse?.cancel();
     if (this.#highlights) {
       this.#highlights.replaceChildren(...selection.ranges.map(range => {
@@ -650,6 +659,7 @@ export class WebTerminal implements WebTerminalHandle {
   #disconnect() {
     this.#inputSerial++;
     this.#connected = false;
+    this.#hyperlinks.update([]);
     if (this.#input) this.#input.disabled = true;
     this.#mouse?.update(1, 1, 0);
     this.#history.disconnect();

--- a/src/web-terminal/src/wire-types.ts
+++ b/src/web-terminal/src/wire-types.ts
@@ -18,6 +18,9 @@ export interface TerminalCell {
   index: number; foreground: number; background: number; underlineColor: number;
   attributes: number; width: number; underlineStyle: number; text: string;
 }
+export interface HyperlinkRange {
+  row: number; startColumn: number; endColumn: number; uri: string;
+}
 export interface ImageMetadata {
   key: string; width: number; height: number; byteLength: number; format: "rgba" | "png";
 }
@@ -34,6 +37,7 @@ export interface FrameMetadata extends TerminalGeometry {
   defaultBackground?: number; defaultForeground?: number;
   cursor: { visible: boolean; x: number; y: number; shape: number };
   images: ImageMetadata[]; retainedImages: string[]; placements: ImagePlacement[]; warnings: string[];
+  hyperlinks: HyperlinkRange[];
   stats: { workloadBytes: number; outputBatches: number; captureMs: number; elapsedMs: number };
 }
 export interface TerminalFrame { metadata: FrameMetadata; cells: TerminalCell[]; images: FrameImage[] }
@@ -76,6 +80,6 @@ export type WorkerOutputMessage =
   | { type: "connected" | "disconnected" }
   | { type: "status"; message: string; level: TerminalStatusLevel }
   | ({ type: "geometry"; peer: TerminalPeer; history: HistoryMetadata | null;
-       revision: number; text: string } & TerminalGeometry)
+       revision: number; text: string; hyperlinks: HyperlinkRange[] } & TerminalGeometry)
   | { type: "history"; history: HistoryMetadata | null; revision: number; text: string }
   | { type: "stats"; stats: WorkerStats; text?: string };

--- a/src/web-terminal/tests/hyperlinks.test.mjs
+++ b/src/web-terminal/tests/hyperlinks.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Hyperlinks, hyperlinkUri } from "../dist/hyperlinks.js";
+
+test("OSC 8 links allow only absolute web and mail destinations", () => {
+  for (const uri of ["https://example.com/docs?a=b#section", "http://localhost:5290/", "mailto:hello@example.com"])
+    assert.equal(hyperlinkUri(uri), uri);
+  assert.equal(hyperlinkUri("HTTPS://EXAMPLE.COM"), "https://example.com/");
+  for (const uri of ["javascript:alert(1)", "JaVaScRiPt:alert(1)", "data:text/html,test",
+    "file:///etc/passwd", "vbscript:msgbox(1)", "blob:https://example.com/id", "about:blank",
+    "/relative", "//example.com", "", "https://", "https://example.com/\npath",
+    "java\tscript:alert(1)", " https://example.com", "https://example.com/a b", "custom:action"])
+    assert.equal(hyperlinkUri(uri), null, uri);
+});
+
+test("Hyperlink hit testing uses authoritative exclusive ranges, including wide and wrapped cells", () => {
+  const links = new Hyperlinks();
+  links.update([
+    { row: 0, startColumn: 38, endColumn: 40, uri: "https://example.com/docs" },
+    { row: 1, startColumn: 0, endColumn: 2, uri: "https://example.com/docs" },
+    { row: 1, startColumn: 2, endColumn: 4, uri: "mailto:hello@example.com" },
+    { row: 2, startColumn: 0, endColumn: 5, uri: "javascript:alert(1)" }
+  ]);
+  for (const point of [{ x: 38, y: 0 }, { x: 39, y: 0 }, { x: 0, y: 1 }, { x: 1, y: 1 }])
+    assert.equal(links.at(point), "https://example.com/docs");
+  assert.equal(links.at({ x: 2, y: 1 }), "mailto:hello@example.com");
+  for (const point of [{ x: 37, y: 0 }, { x: 40, y: 0 }, { x: 4, y: 1 }, { x: 0, y: 2 }, { x: 0, y: 3 }])
+    assert.equal(links.at(point), null);
+});
+
+test("Every presented frame replaces link state, even with no text delta", () => {
+  const links = new Hyperlinks();
+  const range = { row: 0, startColumn: 0, endColumn: 4, uri: "https://example.com/old" };
+  links.update([range]);
+  range.uri = "https://example.com/mutated";
+  assert.equal(links.at({ x: 0, y: 0 }), "https://example.com/old");
+  links.update([range]);
+  assert.equal(links.at({ x: 0, y: 0 }), range.uri);
+  links.update([]);
+  assert.equal(links.at({ x: 0, y: 0 }), null);
+});

--- a/src/web-terminal/tests/protocol-validation.test.mjs
+++ b/src/web-terminal/tests/protocol-validation.test.mjs
@@ -8,7 +8,7 @@ function metadata() {
     columns: 1, rows: 1, cellWidth: 10, cellHeight: 20, mouseTracking: 0,
     peer: { id: null, primaryId: null, isPrimary: true },
     cursor: { x: 0, y: 0, visible: false, shape: "SteadyBlock" }, history: null,
-    images: [], retainedImages: [], placements: [], warnings: [],
+    images: [], retainedImages: [], placements: [], warnings: [], hyperlinks: [],
     stats: { workloadBytes: 0, outputBatches: 0, captureMs: 0, elapsedMs: 0 }
   };
 }
@@ -59,4 +59,16 @@ test("Typed protocol boundary rejects every truncated frame and trailing payload
   const trailing = new Uint8Array(buffer.byteLength + 1);
   trailing.set(new Uint8Array(buffer));
   assert.throws(() => decodeFrame(trailing.buffer), /Image payload length mismatch/u);
+});
+
+test("Hyperlink metadata preserves URI data and rejects malformed or overlapping ranges", () => {
+  const link = { row: 0, startColumn: 0, endColumn: 1, uri: "https://example.com" };
+  assert.deepEqual(decodeFrame(frame({ ...metadata(), hyperlinks: [link] })).metadata.hyperlinks, [link]);
+  for (const hyperlinks of [undefined, null, {}, [null], [link, link],
+    [{ ...link, row: 1 }], [{ ...link, row: -1 }], [{ ...link, row: .5 }],
+    [{ ...link, startColumn: -1 }], [{ ...link, startColumn: "0" }],
+    [{ ...link, endColumn: 0 }], [{ ...link, endColumn: 2 }],
+    [{ ...link, uri: "" }], [{ ...link, uri: null }], [{ ...link, uri: 42 }]]) {
+    assert.throws(() => decodeFrame(frame({ ...metadata(), hyperlinks })));
+  }
 });

--- a/src/web-terminal/tests/selection-input.test.mjs
+++ b/src/web-terminal/tests/selection-input.test.mjs
@@ -98,7 +98,7 @@ test("Trackpad fractions accumulate while line and page wheel units remain bound
   assert.deepEqual(wheel.take({ deltaX: 0, deltaY: 10000, deltaMode: 0 }, bounds, 10), { x: 0, y: 32 });
 });
 
-function mouseHarness(run, tracking = 1002, resolve) {
+function mouseHarness(run, tracking = 1002, resolve, inspection = {}) {
   const originals = Object.fromEntries(["window", "requestAnimationFrame", "cancelAnimationFrame", "setTimeout", "clearTimeout"]
     .map(key => [key, globalThis[key]]));
   const timers = new Map();
@@ -109,6 +109,8 @@ function mouseHarness(run, tracking = 1002, resolve) {
   globalThis.requestAnimationFrame = globalThis.setTimeout;
   globalThis.cancelAnimationFrame = globalThis.clearTimeout;
   const canvas = new EventTarget();
+  canvas.title = "";
+  canvas.style = { cursor: "" };
   canvas.getBoundingClientRect = () => ({ left: 0, top: 0, width: 200, height: 100, bottom: 100 });
   let capturedPointer;
   canvas.setPointerCapture = id => { capturedPointer = id; };
@@ -123,7 +125,8 @@ function mouseHarness(run, tracking = 1002, resolve) {
     scroll: (delta, point) => commands.push({ type: "scroll", delta, point }),
     end: cancelled => endings.push(cancelled),
     resolve,
-    execute: (decision, input) => commands.push({ type: "action", decision, input })
+    execute: (decision, input) => commands.push({ type: "action", decision, input }),
+    ...inspection
   });
   mouse.update(20, 10, tracking);
   endings.length = 0;
@@ -156,6 +159,100 @@ test("A routed clipboard gesture suppresses context menu and never leaks mouse r
     emit("pointerup", { button: 2, buttons: 0 });
     assert.deepEqual(commands.map(command => command.type), ["action"]);
   }, 1003, () => ({ action: "copyOrPaste" }));
+});
+
+test("Ctrl/Cmd hyperlink clicks open on release without application or selection commands", () => {
+  for (const tracking of [0, 9, 1000, 1002, 1003]) {
+    for (const modifiers of [{ ctrlKey: true }, { metaKey: true }]) {
+      const opened = [];
+      mouseHarness(({ commands, emit }) => {
+        assert.equal(emit("pointerdown", modifiers).defaultPrevented, true);
+        assert.deepEqual(opened, []);
+        assert.equal(emit("contextmenu", modifiers).defaultPrevented, true);
+        emit("pointerup", { buttons: 0 });
+        emit("click", { buttons: 0, detail: 1 });
+        assert.deepEqual(opened, ["https://example.com/"]);
+        assert.deepEqual(commands, []);
+      }, tracking, undefined, {
+        hyperlink: () => "https://example.com/", openHyperlink: uri => opened.push(uri)
+      });
+    }
+  }
+});
+
+test("Plain clicks, shift selection, and explicit routing retain ownership over hyperlinks", () => {
+  for (const [tracking, modifiers, resolve, expected] of [
+    [0, {}, undefined, ["begin"]],
+    [1003, {}, undefined, ["mouse", "mouse"]],
+    [1003, { ctrlKey: true, shiftKey: true }, undefined, ["begin"]],
+    [0, { ctrlKey: true, altKey: true }, undefined, ["begin"]],
+    [1003, { ctrlKey: true }, () => ({ route: "application" }), ["mouse", "mouse"]],
+    [1003, { ctrlKey: true }, () => ({ route: "consume" }), []],
+    [1003, { ctrlKey: true }, () => ({ route: "browser" }), []],
+    [1003, { ctrlKey: true }, () => ({ action: "custom" }), ["action"]]
+  ]) {
+    mouseHarness(({ commands, emit }) => {
+      emit("pointerdown", modifiers);
+      emit("pointerup", { buttons: 0 });
+      assert.deepEqual(commands.map(command => command.type), expected);
+    }, tracking, resolve, {
+      hyperlink: () => "https://example.com/", openHyperlink: () => assert.fail("Unexpected hyperlink activation")
+    });
+  }
+});
+
+test("Dragging, cancellation, scrolling, stale targets, and disposal never activate hyperlinks", () => {
+  for (const cancel of [
+    ({ emit }) => { emit("pointermove", { clientX: 35 }); emit("pointermove", { clientX: 25 }); },
+    ({ emit }) => emit("pointercancel"),
+    ({ emit }) => emit("blur", {}, window),
+    ({ emit }) => emit("pointerleave"),
+    ({ emit }) => emit("wheel"),
+    ({ emit }) => emit("pointerdown", { button: 2, buttons: 3 }),
+    ({ mouse }) => mouse.update(40, 10, 1003),
+    ({ mouse }) => mouse.cancel(),
+    ({ mouse }) => mouse.dispose()
+  ]) {
+    mouseHarness(harness => {
+      harness.emit("pointerdown", { ctrlKey: true });
+      cancel(harness);
+      harness.emit("pointerup", { buttons: 0 });
+    }, 1003, undefined, {
+      hyperlink: () => "https://example.com/", openHyperlink: () => assert.fail("Canceled hyperlink activated")
+    });
+  }
+  let uri = "https://example.com/old";
+  mouseHarness(({ emit, mouse }) => {
+    emit("pointerdown", { ctrlKey: true });
+    uri = "https://example.com/new";
+    mouse.update(20, 10, 1003);
+    uri = "https://example.com/old";
+    emit("pointerup", { buttons: 0 });
+  }, 1003, undefined, {
+    hyperlink: () => uri, openHyperlink: () => assert.fail("Changed hyperlink activated")
+  });
+});
+
+test("Hyperlink hover hints track modifiers, frame changes, and pointer departure", () => {
+  let uri = "https://example.com/";
+  mouseHarness(({ emit, canvas, mouse }) => {
+    emit("pointermove", { buttons: 0 });
+    assert.match(canvas.title, /https:\/\/example.com\/\nCtrl\/Cmd\+click/);
+    assert.equal(canvas.style.cursor, "");
+    emit("keydown", { ctrlKey: true }, window);
+    assert.equal(canvas.style.cursor, "pointer");
+    mouse.update(20, 10, 0);
+    assert.equal(canvas.style.cursor, "pointer");
+    emit("keyup", { ctrlKey: false }, window);
+    mouse.refresh();
+    assert.equal(canvas.style.cursor, "");
+    uri = "https://example.com/new";
+    mouse.update(20, 10, 0);
+    assert.match(canvas.title, /example.com\/new/);
+    emit("pointerleave");
+    assert.equal(canvas.title, "");
+    assert.equal(canvas.style.cursor, "");
+  }, 0, undefined, { hyperlink: () => uri });
 });
 
 test("Browser-routed pointer gestures preserve the native context menu even under capture", () => {

--- a/src/web-terminal/tests/web-terminal.test.mjs
+++ b/src/web-terminal/tests/web-terminal.test.mjs
@@ -118,7 +118,7 @@ function frame(peer) {
     version: 1, revision: 1, baseRevision: 0, full: true,
     columns: 1, rows: 1, cellWidth: 10, cellHeight: 20, mouseTracking: 0, peer,
     cursor: { x: 0, y: 0, visible: false, shape: 0 }, history: null,
-    images: [], retainedImages: [], placements: [], warnings: [],
+    images: [], retainedImages: [], placements: [], warnings: [], hyperlinks: [],
     stats: { workloadBytes: 0, outputBatches: 0, captureMs: 0, elapsedMs: 0 }
   };
   const json = new TextEncoder().encode(JSON.stringify(metadata));

--- a/tests/Hex1b.Tests/Hwt1HistoryTests.cs
+++ b/tests/Hex1b.Tests/Hwt1HistoryTests.cs
@@ -10,6 +10,33 @@ namespace Hex1b.Tests;
 public class Hwt1HistoryTests
 {
     [TestMethod]
+    public async Task Hyperlinks_HistoricalView_UsesProducerViewportAndClearsOnReturnToLive()
+    {
+        await using var muxer = new Hmp1PresentationAdapter(20, 10);
+        await using var producer = Hex1bTerminal.CreateBuilder()
+            .WithWorkload(new Hex1bAppWorkloadAdapter()).WithPresentation(muxer)
+            .WithDimensions(20, 10).WithScrollback(100).Build();
+        producer.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b]8;;https://example.com/history\x1b\\old link\x1b]8;;\x1b\\\r\n" + Lines(0, 30)));
+        await using var view = await muxer.CreateBrowserViewAsync();
+        var live = await FrameAsync(view);
+        Assert.AreEqual(0, live.GetProperty("hyperlinks").GetArrayLength());
+
+        await MessageAsync(view, new { type = "viewport", requestId = 1, delta = -100 });
+        var historical = await FrameAsync(view);
+        var links = historical.GetProperty("hyperlinks");
+        Assert.AreEqual(1, links.GetArrayLength());
+        Assert.AreEqual("https://example.com/history", links[0].GetProperty("uri").GetString());
+        Assert.AreEqual(0, links[0].GetProperty("row").GetInt32());
+        Assert.AreEqual(0, links[0].GetProperty("startColumn").GetInt32());
+        Assert.AreEqual(8, links[0].GetProperty("endColumn").GetInt32());
+
+        await MessageAsync(view, new { type = "viewport", requestId = 2, live = true });
+        var returned = await FrameAsync(view);
+        Assert.AreEqual(0, returned.GetProperty("hyperlinks").GetArrayLength());
+    }
+
+    [TestMethod]
     [DataRow("character", false)]
     [DataRow("character", true)]
     [DataRow("word", false)]

--- a/tests/Hex1b.Tests/WebTerminalProjectionTests.cs
+++ b/tests/Hex1b.Tests/WebTerminalProjectionTests.cs
@@ -14,6 +14,74 @@ public class WebTerminalProjectionTests
     };
 
     [TestMethod]
+    public void Encode_Hyperlinks_PreservesWideCellsAndWrappedViewportRanges()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b[1;39H\x1b]8;id=docs;https://example.com/docs\x1b\\\u754cAB\x1b]8;;\x1b\\plain"));
+        using var snapshot = terminal.CreateSnapshot();
+        using var frame = Decode(new Hwt1RenderProjection().Encode(snapshot, Capabilities, 0, 1, 1));
+        var links = frame.Metadata.RootElement.GetProperty("hyperlinks");
+        Assert.AreEqual(2, links.GetArrayLength());
+        Assert.AreEqual(0, links[0].GetProperty("row").GetInt32());
+        Assert.AreEqual(38, links[0].GetProperty("startColumn").GetInt32());
+        Assert.AreEqual(40, links[0].GetProperty("endColumn").GetInt32());
+        Assert.AreEqual(1, links[1].GetProperty("row").GetInt32());
+        Assert.AreEqual(0, links[1].GetProperty("startColumn").GetInt32());
+        Assert.AreEqual(2, links[1].GetProperty("endColumn").GetInt32());
+        foreach (var link in links.EnumerateArray())
+            Assert.AreEqual("https://example.com/docs", link.GetProperty("uri").GetString());
+    }
+
+    [TestMethod]
+    public void Encode_HyperlinkOnlyChanges_ReplaceDestinationsWithoutResendingText()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        var projection = new Hwt1RenderProjection();
+        foreach (var uri in new[] { "https://example.com/first", "https://example.com/second", "" })
+        {
+            terminal.ApplyTokens(AnsiTokenizer.Tokenize($"\r\x1b]8;;{uri}\x1b\\link\x1b]8;;\x1b\\"));
+            using var snapshot = terminal.CreateSnapshot();
+            using var frame = Decode(projection.Encode(snapshot, Capabilities, 0, 1, 1));
+            var links = frame.Metadata.RootElement.GetProperty("hyperlinks");
+            Assert.AreEqual(uri.Length == 0 ? 0 : 1, links.GetArrayLength());
+            if (uri.Length != 0)
+            {
+                Assert.AreEqual(uri, links[0].GetProperty("uri").GetString());
+                Assert.AreEqual(4, links[0].GetProperty("endColumn").GetInt32());
+            }
+            if (projection.Revision > 1)
+                Assert.AreEqual(0, frame.Cells.Count);
+        }
+    }
+
+    [TestMethod]
+    public void Encode_HiddenAndErasedHyperlinks_DoNotLeaveClickableRanges()
+    {
+        using var workload = new Hex1bAppWorkloadAdapter();
+        using var terminal = CreateTerminal(workload);
+        var projection = new Hwt1RenderProjection();
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize(
+            "\x1b]8;;https://example.com\x1b\\A\x1b[8mB\x1b[28mC\x1b]8;;\x1b\\"));
+        using (var snapshot = terminal.CreateSnapshot())
+        using (var frame = Decode(projection.Encode(snapshot, Capabilities, 0, 1, 1)))
+        {
+            var links = frame.Metadata.RootElement.GetProperty("hyperlinks");
+            Assert.AreEqual(2, links.GetArrayLength());
+            Assert.AreEqual(1, links[0].GetProperty("endColumn").GetInt32());
+            Assert.AreEqual(2, links[1].GetProperty("startColumn").GetInt32());
+        }
+        terminal.ApplyTokens(AnsiTokenizer.Tokenize("\x1b[2J"));
+        using var erased = terminal.CreateSnapshot();
+        using var cleared = Decode(projection.Encode(erased, Capabilities, 0, 2, 2));
+        Assert.AreEqual(0, cleared.Metadata.RootElement.GetProperty("hyperlinks").GetArrayLength());
+        using var resync = Decode(projection.Encode(erased, Capabilities, 0, 2, 3, forceFull: true));
+        Assert.AreEqual(0, resync.Metadata.RootElement.GetProperty("hyperlinks").GetArrayLength());
+    }
+
+    [TestMethod]
     public void Encode_MouseModeOnlyChange_AdvertisesTrackingWithoutCellChanges()
     {
         using var workload = new Hex1bAppWorkloadAdapter();


### PR DESCRIPTION
The web terminal rendered OSC 8 hyperlink text but could not activate it because HWT1 omitted the destination metadata. This adds Ctrl/Cmd+click activation without taking ordinary clicks away from terminal applications or text selection.

## Approach

- Carry complete, authoritative hyperlink ranges with each presented HWT1 frame, including destination-only changes, wrapped/wide cells, and scrollback.
- Show destination hover hints and open links in a new tab on Ctrl/Cmd+click. Preserve existing selections, application mouse capture, read-only inspection, and explicit input-policy overrides; cancel activation on drags or stale targets.
- Allow only absolute HTTP, HTTPS, and mailto destinations, with `noopener,noreferrer`. Plain-text URL detection and custom URL schemes are intentionally out of scope.

The internal HWT1 metadata now requires a `hyperlinks` array, so the server and browser client must be upgraded together. Binary cell records are unchanged. Includes protocol/usage documentation and server, Node, and real-browser regression coverage.